### PR TITLE
Add Stripe

### DIFF
--- a/apps/crawler/data/boards.csv
+++ b/apps/crawler/data/boards.csv
@@ -1,1 +1,2 @@
 company_slug,board_url,monitor_type,monitor_config,scraper_type,scraper_config
+stripe,https://stripe.com/jobs/search,greenhouse,,,

--- a/apps/crawler/data/companies.csv
+++ b/apps/crawler/data/companies.csv
@@ -1,1 +1,2 @@
 slug,name,website,logo_url,icon_url
+stripe,Stripe,https://stripe.com,https://images.stripeassets.com/fzn2n1nzq965/1hgcBNd12BfT9VLgbId7By/01d91920114b124fb4cf6d448f9f06eb/favicon.svg,https://images.stripeassets.com/fzn2n1nzq965/1hgcBNd12BfT9VLgbId7By/01d91920114b124fb4cf6d448f9f06eb/favicon.svg


### PR DESCRIPTION
Closes #6

## Summary
- Adds Stripe to the company registry and board configuration
- Monitor type: `greenhouse` (auto-detected, token: `stripe`)
- Scraper type: `greenhouse_api` (rich data from API, no scraper config needed)

## Crawl results
- **Job count:** 591 jobs
- **Crawl time:** 0.5s
- **Rich data:** yes (titles, descriptions, locations)

## Test plan
- [x] Auto-detected monitor type (`greenhouse`)
- [x] Test crawl successful (591 jobs in 0.5s)
- [x] CSV validation passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)