### PR TITLE
Add Google

### DIFF
--- a/apps/crawler/data/boards.csv
+++ b/apps/crawler/data/boards.csv
@@ -1,3 +1,4 @@
 company_slug,board_url,monitor_type,monitor_config,scraper_type,scraper_config
 stripe,https://stripe.com/jobs/search,greenhouse,,,
 deepmind,https://deepmind.google/about/careers/,greenhouse,"{""token"": ""deepmind""}","",""
+google,https://www.google.com/about/careers/applications/jobs/results/,sitemap,"{""sitemap_url"": ""https://www.google.com/about/careers/applications/jobs/sitemap.xml""}",browser,"{""title"": ""h2.p1N2lc"", ""location"": "".op1BBf .r0wTof"", ""description"": "".aG5W3"", ""wait"": ""networkidle""}"

--- a/apps/crawler/data/companies.csv
+++ b/apps/crawler/data/companies.csv
@@ -1,3 +1,4 @@
 slug,name,website,logo_url,icon_url
 stripe,Stripe,https://stripe.com,https://images.stripeassets.com/fzn2n1nzq965/1hgcBNd12BfT9VLgbId7By/01d91920114b124fb4cf6d448f9f06eb/favicon.svg,https://images.stripeassets.com/fzn2n1nzq965/1hgcBNd12BfT9VLgbId7By/01d91920114b124fb4cf6d448f9f06eb/favicon.svg
 deepmind,Google DeepMind,https://deepmind.google,https://lh3.googleusercontent.com/KUdUtUTMEl1MnTidSobfNoculOnfEywWYldyCXHMbt8NHcRkXw_lSQ7f9c-SdChVhhuroYkWgnaC9Kv-byzYWNtwAwSqBRfeLMTBPlhetF34jlVS=s0,https://www.google.com/s2/favicons?domain=deepmind.google&sz=128
+google,Google,https://www.google.com,https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png,https://www.google.com/favicon.ico


### PR DESCRIPTION
## Summary

- Adds Google (`google`) to companies.csv and boards.csv
- Monitor: **sitemap** — discovers ~3,959 jobs from the XML sitemap at `google.com/about/careers/applications/jobs/sitemap.xml`
- Scraper: **browser** (Playwright) — extracts title (`h2.p1N2lc`), location (`.op1BBf .r0wTof`), and description (`.aG5W3`) after JS rendering

Closes #4

## Details

| Field | Value |
|-------|-------|
| Monitor type | `sitemap` |
| Scraper type | `browser` |
| Estimated jobs | ~3,959 |
| Crawl time | 0.1s (monitor) + per-page browser rendering |
| Label | `review-size` (500–5000 jobs) |

## Test plan

- [x] Auto-detected monitor type (`sitemap`)
- [x] Test crawl found 3,959 jobs
- [x] Probed JSON-LD — not available, confirmed `browser` scraper needed
- [x] Verified CSS selectors on 4 sample job pages (title, location, description all extract correctly)
- [x] CSV validation passed