### PR TITLE
Add Google DeepMind

### DIFF
--- a/apps/crawler/data/boards.csv
+++ b/apps/crawler/data/boards.csv
@@ -1,2 +1,3 @@
 company_slug,board_url,monitor_type,monitor_config,scraper_type,scraper_config
 stripe,https://stripe.com/jobs/search,greenhouse,,,
+deepmind,https://deepmind.google/about/careers/,greenhouse,"{""token"": ""deepmind""}","",""

--- a/apps/crawler/data/companies.csv
+++ b/apps/crawler/data/companies.csv
@@ -1,2 +1,3 @@
 slug,name,website,logo_url,icon_url
 stripe,Stripe,https://stripe.com,https://images.stripeassets.com/fzn2n1nzq965/1hgcBNd12BfT9VLgbId7By/01d91920114b124fb4cf6d448f9f06eb/favicon.svg,https://images.stripeassets.com/fzn2n1nzq965/1hgcBNd12BfT9VLgbId7By/01d91920114b124fb4cf6d448f9f06eb/favicon.svg
+deepmind,Google DeepMind,https://deepmind.google,https://lh3.googleusercontent.com/KUdUtUTMEl1MnTidSobfNoculOnfEywWYldyCXHMbt8NHcRkXw_lSQ7f9c-SdChVhhuroYkWgnaC9Kv-byzYWNtwAwSqBRfeLMTBPlhetF34jlVS=s0,https://www.google.com/s2/favicons?domain=deepmind.google&sz=128


### PR DESCRIPTION
Closes #5

## Summary

- **Monitor type**: greenhouse (token: `deepmind`)
- **Scraper type**: none (Greenhouse API returns rich data: titles, descriptions, locations)
- **Estimated job count**: 119 jobs (verified against https://job-boards.greenhouse.io/deepmind)
- **Crawl time**: ~0.7s

## Notes

The board URL is `https://deepmind.google/about/careers/` which embeds the Greenhouse board token `deepmind` in its page source. Since `slugs_from_url` for `deepmind.google` would extract `google` (not `deepmind`), the token is explicitly set in `monitor_config`.

## Label

`auto-merge` (< 500 jobs, config-only)