### PR TITLE
Rebase PR before handing off to image upload workflow

### DIFF
--- a/.github/workflows/maybe-auto-merge.yml
+++ b/.github/workflows/maybe-auto-merge.yml
@@ -43,7 +43,9 @@ jobs:
 
       - name: Rebase and resolve CSV conflicts
         id: rebase
-        if: steps.images.outputs.pending == 'false' && contains(steps.label.outputs.labels, 'auto-merge')
+        if: >-
+          steps.images.outputs.pending == 'true'
+          || contains(steps.label.outputs.labels, 'auto-merge')
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
@@ -100,7 +102,7 @@ jobs:
           echo "rebased=true" >> "$GITHUB_OUTPUT"
 
       - name: Merge
-        if: steps.rebase.outputs.rebased == 'true'
+        if: steps.rebase.outputs.rebased == 'true' && steps.images.outputs.pending == 'false'
         run: |
           gh pr merge "$PR" --repo "$REPO" --rebase
         env:
@@ -109,7 +111,7 @@ jobs:
           REPO: ${{ github.repository }}
 
       - name: Close linked company-request issues
-        if: steps.rebase.outputs.rebased == 'true'
+        if: steps.rebase.outputs.rebased == 'true' && steps.images.outputs.pending == 'false'
         run: .github/scripts/close-linked-company-request-issues.sh
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- The `maybe-auto-merge` workflow skipped the rebase step when images were pending, leaving the `upload-company-images` workflow unable to merge due to CSV conflicts
- Now the rebase step runs for **both** auto-merge and image-pending PRs
- Merge and issue-close steps remain gated on `images.pending == 'false'`

## Changes
- Rebase condition: `pending == 'true' || labels contain 'auto-merge'` (was `pending == 'false' && auto-merge`)
- Merge condition: added `&& pending == 'false'` guard
- Close issues condition: added `&& pending == 'false'` guard

## Test plan
- [ ] Submit a company PR with images — verify rebase runs, then image upload workflow merges
- [ ] Submit a company PR without images — verify normal auto-merge still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)