### PR TITLE
Fix ws taxonomy data lookup

### DIFF
--- a/apps/crawler/src/workspace/commands/help.py
+++ b/apps/crawler/src/workspace/commands/help.py
@@ -1578,9 +1578,9 @@ def _show_occupations() -> None:
     """Display occupation taxonomy from data/occupations.csv."""
     import polars as pl
 
-    from src.shared.constants import DATA_DIR
+    from src.shared.constants import get_data_dir
 
-    path = DATA_DIR / "occupations.csv"
+    path = get_data_dir() / "occupations.csv"
     if not path.exists():
         print("No occupations found in data/occupations.csv")
         return
@@ -1607,9 +1607,9 @@ def _show_seniority() -> None:
     """Display seniority taxonomy from data/seniority.csv."""
     import polars as pl
 
-    from src.shared.constants import DATA_DIR
+    from src.shared.constants import get_data_dir
 
-    path = DATA_DIR / "seniority.csv"
+    path = get_data_dir() / "seniority.csv"
     if not path.exists():
         print("No seniority levels found in data/seniority.csv")
         return
@@ -1636,24 +1636,27 @@ def _show_industries() -> None:
     """Display industry taxonomy from data/industries.csv."""
     import polars as pl
 
-    from src.shared.constants import DATA_DIR
+    from src.shared.constants import get_data_dir
 
-    path = DATA_DIR / "industries.csv"
+    path = get_data_dir() / "industries.csv"
     if not path.exists():
         print("No industries found in data/industries.csv")
         return
 
     df = pl.read_csv(path, infer_schema_length=0)
+    name_header = "EN" if "en" in df.columns else "Name"
+    name_col = "en" if "en" in df.columns else "name"
+    de_col = "de" if "de" in df.columns else None
     print("Industry Taxonomy")
     print("Managed in data/industries.csv — set per company with: ws set --industry <id>\n")
-    print(f"  {'ID':>3}  {'EN':<30} {'DE':<30}")
+    print(f"  {'ID':>3}  {name_header:<30} {'DE':<30}")
     print(f"  {'──':>3}  {'─' * 30} {'─' * 30}")
 
     for row in df.iter_rows(named=True):
         ind_id = row["id"]
-        en = row.get("en", "")
-        de = row.get("de", "")
-        print(f"  {ind_id:>3}  {en:<30} {de:<30}")
+        name = row.get(name_col, "")
+        de = row.get(de_col, "") if de_col else ""
+        print(f"  {ind_id:>3}  {name:<30} {de:<30}")
 
     print(f"\n  {len(df)} industries total")
     print("\n  CLI: ws taxonomy search industries <query>")

--- a/apps/crawler/src/workspace/commands/taxonomy.py
+++ b/apps/crawler/src/workspace/commands/taxonomy.py
@@ -7,7 +7,7 @@ import re
 import click
 import polars as pl
 
-from src.shared.constants import DATA_DIR
+from src.shared.constants import get_data_dir
 
 
 def _detect_format(df: pl.DataFrame) -> str:
@@ -24,7 +24,7 @@ def _detect_format(df: pl.DataFrame) -> str:
 
 def _load_taxonomy(name: str) -> tuple[pl.DataFrame, str]:
     """Load a taxonomy CSV by name and detect its format."""
-    path = DATA_DIR / f"{name}.csv"
+    path = get_data_dir() / f"{name}.csv"
     if not path.exists():
         raise click.ClickException(f"Taxonomy file not found: {path}")
     df = pl.read_csv(path, infer_schema_length=0)

--- a/apps/crawler/tests/test_ws_commands.py
+++ b/apps/crawler/tests/test_ws_commands.py
@@ -52,6 +52,7 @@ def _patch_all(monkeypatch, tmp_path):
     monkeypatch.setattr("src.csvtool.get_data_dir", _data)
     monkeypatch.setattr("src.inspect.get_data_dir", _data)
     monkeypatch.setattr("src.workspace.commands.lifecycle.get_data_dir", _data)
+    monkeypatch.setattr("src.workspace.commands.taxonomy.get_data_dir", _data)
     monkeypatch.setattr("src.workspace.state.get_workspace_dir", _ws)
 
     # Keep CLI tests deterministic/offline: board link analysis is exercised
@@ -158,6 +159,22 @@ class TestHelp:
         legacy_result = runner.invoke(ws, ["help", "monitor", "successfactors"])
         assert legacy_result.exit_code != 0
         assert "Unknown monitor type" in legacy_result.output
+
+    def test_help_industries_uses_repo_data_and_supports_legacy_schema(
+        self, tmp_path, monkeypatch
+    ):
+        _patch_all(monkeypatch, tmp_path)
+        (tmp_path / "industries.csv").write_text(
+            "id,name,keywords\n1,Technology,\"software,AI\"\n", encoding="utf-8"
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(ws, ["help", "industries"])
+
+        assert result.exit_code == 0
+        assert "Industry Taxonomy" in result.output
+        assert "Technology" in result.output
+        assert "No industries found" not in result.output
 
     def test_with_workspace(self, tmp_path, monkeypatch):
         _patch_all(monkeypatch, tmp_path)
@@ -449,6 +466,20 @@ class TestAddBoard:
         assert result.exit_code == 0
         board = load_board("test", "careers")
         assert board.job_link_pattern == r"^https?://test\.com/jobs/"
+
+
+class TestTaxonomy:
+    def test_taxonomy_search_uses_repo_data(self, tmp_path, monkeypatch):
+        _patch_all(monkeypatch, tmp_path)
+        (tmp_path / "industries.csv").write_text(
+            "id,name,keywords\n1,Technology,\"software,AI\"\n", encoding="utf-8"
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(ws, ["taxonomy", "search", "industries", "AI"])
+
+        assert result.exit_code == 0
+        assert "Technology" in result.output
 
 
 class TestDelBoard:


### PR DESCRIPTION
## Summary
- use repo-root-aware taxonomy paths in ws help and ws taxonomy
- render legacy industries.csv rows that still use name instead of localized columns
- add CLI regression tests for ws help industries and ws taxonomy search industries

## Testing
- uv run python -m pytest tests/test_ws_commands.py
- uv run ruff check src/workspace/commands/help.py src/workspace/commands/taxonomy.py tests/test_ws_commands.py
- uv run ws help industries
- uv run ws taxonomy search industries AI