### PR TITLE
Fix ws scraper validation

### DIFF
--- a/apps/crawler/src/inspect.py
+++ b/apps/crawler/src/inspect.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import time
 
+from src.core.scrapers import _REGISTRY as SCRAPER_REGISTRY
 from src.shared.constants import LOGO_TYPES, SLUG_RE, URL_RE, get_data_dir
 from src.shared.csv_io import read_csv
 from src.workspace._compat import all_monitor_types
@@ -104,12 +105,7 @@ def validate_csvs() -> list[ValidationError]:
         return errors
 
     valid_monitor_types = all_monitor_types()
-    valid_scraper_types = {
-        "json-ld",
-        "dom",
-        "nextdata",
-        "embedded",
-        "api_sniffer",
+    valid_scraper_types = set(SCRAPER_REGISTRY) | {
         "",  # API monitors don't need a scraper
     }
     url_only_monitors = {"sitemap", "dom"}

--- a/apps/crawler/tests/test_inspect.py
+++ b/apps/crawler/tests/test_inspect.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from src.inspect import ValidationError, validate_csvs
 
 
@@ -181,6 +183,19 @@ class TestValidateCsvs:
         monkeypatch.setattr("src.inspect.get_data_dir", lambda: tmp_path)
         errors = validate_csvs()
         assert any("Invalid scraper_type" in str(e) for e in errors)
+
+    @pytest.mark.parametrize("scraper_type", ["skip", "workday"])
+    def test_registered_scraper_types_are_valid(self, tmp_path, monkeypatch, scraper_type):
+        self._write_csvs(
+            tmp_path,
+            "slug,name,website,logo_url,icon_url,logo_type\ntest,Test,https://test.com,,\n",
+            "company_slug,board_slug,board_url,monitor_type,monitor_config,scraper_type,scraper_config\n"
+            f"test,test-careers,https://example.com,greenhouse,,{scraper_type},\n",
+        )
+        monkeypatch.setattr("src.shared.constants.get_data_dir", lambda: tmp_path)
+        monkeypatch.setattr("src.inspect.get_data_dir", lambda: tmp_path)
+        errors = validate_csvs()
+        assert not any("Invalid scraper_type" in str(e) for e in errors)
 
     def test_invalid_monitor_config_json(self, tmp_path, monkeypatch):
         self._write_csvs(


### PR DESCRIPTION
## Summary
- validate scraper types against the actual scraper registry instead of a stale hard-coded allowlist
- allow documented auto-configured scraper types like skip and registered API scrapers during CSV validation
- add regression coverage for skip and workday scraper validation

## Testing
- uv run python -m pytest tests/test_inspect.py
- uv run ruff check src/inspect.py tests/test_inspect.py