### PR TITLE
Fix ws submit gate

### DIFF
--- a/apps/crawler/src/workspace/workflow.py
+++ b/apps/crawler/src/workspace/workflow.py
@@ -196,7 +196,7 @@ GLOBAL_GATES: dict[str, Any] = {
         and ws.industry is not None
     ),
     "all_boards_added": lambda ws, boards: len(boards) > 0,
-    "submitted": lambda ws, boards: ws.submit_state.get("pr_ready", False),
+    "submitted": lambda ws, boards: ws.submitted,
 }
 
 PER_BOARD_GATES: dict[str, Any] = {

--- a/apps/crawler/tests/test_workflow.py
+++ b/apps/crawler/tests/test_workflow.py
@@ -258,6 +258,26 @@ class TestGates:
         passed, _ = check_gate(step, ws, [board_careers], board_careers)
         assert passed
 
+    def test_submitted_gate_uses_submit_checkpoints(self, workspace, board_careers):
+        slug, ws, ws_root = workspace
+        ws.submit_state = {
+            "csv_written": True,
+            "validated": True,
+            "committed": True,
+            "pushed": True,
+        }
+        save_workspace(ws)
+        step = StepDef(
+            id="submit",
+            title="",
+            instructions="",
+            gate_type="state",
+            gate_check="submitted",
+            phase="final",
+        )
+        passed, _ = check_gate(step, ws, [board_careers])
+        assert passed
+
     def test_manual_gate_never_auto_passes(self, workspace, board_careers):
         slug, ws, ws_root = workspace
         step = StepDef(id="reflect", title="", instructions="", gate_type="manual", phase="final")


### PR DESCRIPTION
## Summary
- make the submit workflow gate rely on the existing Workspace.submitted checkpoint state
- stop blocking task advancement on pr_ready, which is only set later during ws task complete
- add regression coverage for the final submit gate

## Testing
- uv run python -m pytest tests/test_workflow.py
- uv run ruff check src/workspace/workflow.py tests/test_workflow.py