### PR TITLE
Fix Workable monitor 429 rate-limit failures

### DIFF
--- a/apps/crawler/src/core/monitors/workable.py
+++ b/apps/crawler/src/core/monitors/workable.py
@@ -11,6 +11,7 @@ scrape schedule.
 
 from __future__ import annotations
 
+import asyncio
 import re
 
 import httpx
@@ -26,6 +27,8 @@ from src.core.monitors import (
 log = structlog.get_logger()
 
 MAX_JOBS = 10_000
+_RETRY_ATTEMPTS = 4
+_RETRY_BACKOFF = (5.0, 15.0, 30.0, 60.0)
 
 _PAGE_PATTERNS = [
     re.compile(r"apply\.workable\.com/([\w-]+)"),
@@ -59,9 +62,21 @@ async def _api_list(slug: str, client: httpx.AsyncClient) -> set[str]:
     body: dict = {"query": "", "location": [], "department": [], "worktype": []}
 
     while True:
-        resp = await client.post(_api_list_url(slug), json=body)
-        resp.raise_for_status()
-        data = resp.json()
+        data = None
+        for attempt in range(_RETRY_ATTEMPTS):
+            resp = await client.post(_api_list_url(slug), json=body)
+            if resp.status_code == 429:
+                backoff = _RETRY_BACKOFF[min(attempt, len(_RETRY_BACKOFF) - 1)]
+                log.warning("workable.rate_limited", slug=slug, backoff_s=backoff)
+                await asyncio.sleep(backoff)
+                continue
+            resp.raise_for_status()
+            data = resp.json()
+            break
+
+        if data is None:
+            log.warning("workable.retries_exhausted", slug=slug, collected=len(urls))
+            break
 
         results = data.get("results", [])
         for item in results:

--- a/apps/crawler/src/shared/throttle.py
+++ b/apps/crawler/src/shared/throttle.py
@@ -18,6 +18,7 @@ _API_DELAY = 0.5  # Known ATS APIs with higher rate limits
 
 _KNOWN_ATS_HOSTS = frozenset(
     {
+        "apply.workable.com",
         "boards-api.greenhouse.io",
         "api.lever.co",
         "api.ashbyhq.com",

--- a/apps/crawler/tests/test_workable.py
+++ b/apps/crawler/tests/test_workable.py
@@ -140,6 +140,51 @@ class TestDiscover:
             assert len(urls) == 2
             assert call_count == 2
 
+    async def test_retries_on_429(self, monkeypatch):
+        import src.core.monitors.workable as wmod
+
+        monkeypatch.setattr(wmod, "_RETRY_BACKOFF", (0.0, 0.0, 0.0, 0.0))
+
+        call_count = 0
+
+        def handler(request):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 2:
+                return httpx.Response(429)
+            return httpx.Response(
+                200,
+                json={
+                    "results": [{"shortcode": "SC1"}],
+                    "nextPage": None,
+                },
+            )
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            board = {
+                "board_url": "https://apply.workable.com/testco",
+                "metadata": {"token": "testco"},
+            }
+            urls = await discover(board, client)
+            assert len(urls) == 1
+            assert call_count == 3
+
+    async def test_exhausted_retries_returns_empty(self, monkeypatch):
+        import src.core.monitors.workable as wmod
+
+        monkeypatch.setattr(wmod, "_RETRY_BACKOFF", (0.0, 0.0, 0.0, 0.0))
+
+        def handler(request):
+            return httpx.Response(429)
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            board = {
+                "board_url": "https://apply.workable.com/testco",
+                "metadata": {"token": "testco"},
+            }
+            urls = await discover(board, client)
+            assert len(urls) == 0
+
 
 class TestCanHandle:
     async def test_workable_url_match(self):


### PR DESCRIPTION
## Summary

- Add retry-with-backoff (4 attempts, 5s/15s/30s/60s) for 429 responses in the Workable monitor's `_api_list()` pagination loop
- Add `apply.workable.com` to `_KNOWN_ATS_HOSTS` in the throttle module (0.5s delay instead of 2.0s)
- Add two tests covering retry success and retry exhaustion

## What was tried during the guided workflow

Onboarding **Limula** (issue #103, Workable board at `apply.workable.com/limula`):
1. `ws probe monitor -n 3` — detected Workable with token `limula` via v1 API ✓
2. `ws select monitor workable` — selected successfully ✓
3. `ws run monitor` — failed with `429 Too Many Requests` on the v3 list endpoint
4. Retried 5+ times over ~3 minutes with increasing delays — all returned 429
5. No alternative monitor types detected for this board

## Why it failed

The Workable v3 jobs list API (`/api/v3/accounts/{slug}/jobs`) aggressively rate-limits.
The `discover()` → `_api_list()` call path had no retry logic — a single 429 response
caused `raise_for_status()` to throw immediately. The workspace CLI's probe phase
succeeded because `can_handle()` / `_fetch_job_count()` silently returned `None` on
non-200 status codes, so the probe only needed one successful request. But the monitor
run always hit the rate limit.

## What the code change does

Follows the retry pattern already established in `workday.py` (lines 102-118):
a retry loop around the HTTP call that catches 429 status codes and backs off
before retrying. After exhausting retries, it logs a warning and returns whatever
URLs were collected so far (graceful degradation).

The throttle host addition ensures that when Redis-based domain throttling is active,
Workable requests use the 0.5s ATS delay rather than the 2.0s default, reducing the
chance of triggering rate limits in the first place.

## Test plan

- [x] All 53 existing + new tests pass (`pytest tests/test_workable.py`)
- [ ] Re-run `ws` workflow for Limula after merging to confirm end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)