### PR TITLE
Randomize clone path in fail-mode instructions

### DIFF
--- a/apps/crawler/src/workspace/steps/fail-mode.md
+++ b/apps/crawler/src/workspace/steps/fail-mode.md
@@ -14,11 +14,14 @@ Before writing code, confirm configuration exploration is exhausted:
 ## Steps
 
 1. Clean up the failed workspace: `ws del`
-2. Clone the repo into a separate working copy (do NOT use `~/.jobseek/repo/` — that belongs to `ws`):
+2. Clone the repo into a **private, randomized** working copy (do NOT use `~/.jobseek/repo/` — that belongs to `ws`):
    ```bash
-   git clone https://github.com/colophon-group/jobseek.git /tmp/jobseek-fix
-   cd /tmp/jobseek-fix/apps/crawler
+   WORKDIR="/tmp/jobseek-fix-$(openssl rand -hex 4)"
+   git clone https://github.com/colophon-group/jobseek.git "$WORKDIR"
+   cd "$WORKDIR/apps/crawler"
    ```
+   **Important:** Always randomize the clone path. Multiple agents may run concurrently —
+   a fixed path like `/tmp/jobseek-fix` will cause agents to overwrite each other's work.
 3. Identify the root cause in the source code (`src/core/monitors/`, `src/core/scrapers/`, `src/workspace/`)
 4. Create a `fix-crawler/<description>` branch
 5. Make the minimal code change that fixes the issue


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `/tmp/jobseek-fix` clone path in fail-mode instructions with a randomized path using `openssl rand -hex 4`
- Adds a warning that multiple agents may run concurrently and a fixed path causes them to overwrite each other's work

## Context

When multiple agents hit `ws task fail` concurrently, they all clone to the same `/tmp/jobseek-fix` directory. This causes one agent's committed work to be silently destroyed when another agent re-clones over it.

## Test plan

- [x] Verified the rendered fail-mode output includes the randomized path instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)