### PR TITLE
Fix infinite scroll with shared useInfiniteScroll hook

### DIFF
--- a/apps/web/app/[lang]/(app)/explore/search-page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/search-page.tsx
@@ -513,22 +513,25 @@ export function SearchPage({
     runSearch();
   }, [displayCurrency]);
 
-  const handleLoadMore = useCallback(() => {
+  function handleLoadMore() {
     if (loadingRef.current) return;
     loadingRef.current = true;
     setIsLoadingMore(true);
 
-    const offset = companies.length;
-    const locationIds = locations.map((l) => l.id);
-    const occupationIds = occupations.length > 0 ? occupations.map((o) => o.id) : undefined;
-    const seniorityIds = seniorities.length > 0 ? seniorities.map((s) => s.id) : undefined;
-    const technologyIds = technologies.length > 0 ? technologies.map((t) => t.id) : undefined;
-    const salMinEur = toEur(salaryMin);
-    const salMaxEur = toEur(salaryMax);
+    const offset = companiesRef.current.length;
+    const kws = keywordsRef.current;
+    const locationIds = locationsRef.current.map((l) => l.id);
+    const occupationIds = occupationsRef.current.length > 0 ? occupationsRef.current.map((o) => o.id) : undefined;
+    const seniorityIds = senioritiesRef.current.length > 0 ? senioritiesRef.current.map((s) => s.id) : undefined;
+    const technologyIds = technologiesRef.current.length > 0 ? technologiesRef.current.map((t) => t.id) : undefined;
+    const salMinEur = toEur(salaryMinRef.current);
+    const salMaxEur = toEur(salaryMaxRef.current);
+    const expMin = experienceMinRef.current;
+    const expMax = experienceMaxRef.current;
     const fetcher =
-      keywords.length > 0
-        ? searchJobs({ keywords, locationIds, occupationIds, seniorityIds, technologyIds, salaryMinEur: salMinEur, salaryMaxEur: salMaxEur, experienceMin, experienceMax, languages, locale, offset, limit: PAGE_SIZE })
-        : listTopCompanies({ locationIds, occupationIds, seniorityIds, technologyIds, salaryMinEur: salMinEur, salaryMaxEur: salMaxEur, experienceMin, experienceMax, languages, locale, offset, limit: PAGE_SIZE });
+      kws.length > 0
+        ? searchJobs({ keywords: kws, locationIds, occupationIds, seniorityIds, technologyIds, salaryMinEur: salMinEur, salaryMaxEur: salMaxEur, experienceMin: expMin, experienceMax: expMax, languages, locale, offset, limit: PAGE_SIZE })
+        : listTopCompanies({ locationIds, occupationIds, seniorityIds, technologyIds, salaryMinEur: salMinEur, salaryMaxEur: salMaxEur, experienceMin: expMin, experienceMax: expMax, languages, locale, offset, limit: PAGE_SIZE });
 
     fetcher
       .then((result) => {
@@ -545,7 +548,7 @@ export function SearchPage({
         loadingRef.current = false;
         setIsLoadingMore(false);
       });
-  }, [companies.length, keywords, locations, occupations, seniorities, technologies, languages, locale, salaryMin, salaryMax, experienceMin, experienceMax]);
+  }
 
   const histogramFilters: HistogramFilters = useMemo(() => ({
     keywords: keywords.length > 0 ? keywords : undefined,

--- a/apps/web/src/components/search/company-card.tsx
+++ b/apps/web/src/components/search/company-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useMemo, useCallback } from "react";
+import { useState, useRef, useMemo } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { Building2, Loader2 } from "lucide-react";
@@ -8,6 +8,7 @@ import { Trans } from "@lingui/react/macro";
 import { useParams } from "next/navigation";
 import { timeAgoShort } from "@/lib/time";
 import { loadMorePostings } from "@/lib/actions/search";
+import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
 import { SaveButton } from "@/components/search/save-button";
 import { StarButton } from "@/components/search/star-button";
 import { buildFilteredPath } from "@/lib/search/query-params";
@@ -64,7 +65,7 @@ export function CompanyCard({ result, keywords, locationIds, locations, occupati
   const hasMoreRef = useRef(hasMore);
   hasMoreRef.current = hasMore;
 
-  const handleLoadMore = useCallback(() => {
+  function handleLoadMore() {
     if (loadingRef.current || !hasMoreRef.current) return;
     loadingRef.current = true;
     setIsLoading(true);
@@ -91,21 +92,9 @@ export function CompanyCard({ result, keywords, locationIds, locations, occupati
         setIsLoading(false);
         loadingRef.current = false;
       });
-  }, [company.id, keywords, locationIds, languages, locale]);
+  }
 
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-
-    const onScroll = () => {
-      if (!hasMoreRef.current || loadingRef.current) return;
-      const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 50;
-      if (nearBottom) handleLoadMore();
-    };
-
-    el.addEventListener("scroll", onScroll, { passive: true });
-    return () => el.removeEventListener("scroll", onScroll);
-  }, [handleLoadMore]);
+  const sentinelRef = useInfiniteScroll({ hasMore, isLoading, onLoadMore: handleLoadMore, root: scrollRef, rootMargin: "50px" });
 
   return (
     <div className="rounded-md border border-divider bg-surface p-4">
@@ -171,9 +160,10 @@ export function CompanyCard({ result, keywords, locationIds, locations, occupati
             </span>
           </div>
         ))}
-        {hasMore && (
+        {hasMore && <div ref={sentinelRef} className="h-1" />}
+        {isLoading && (
           <div className="flex h-6 items-center justify-center">
-            {isLoading && <Loader2 size={12} className="animate-spin text-muted" />}
+            <Loader2 size={12} className="animate-spin text-muted" />
           </div>
         )}
       </div>

--- a/apps/web/src/components/search/search-results.tsx
+++ b/apps/web/src/components/search/search-results.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useRef } from "react";
 import { CompanyCard } from "./company-card";
 import { RequestCompanyPrompt } from "./request-company";
 import type { SearchResultCompany } from "@/lib/search";
 import type { SerializableLocation, SerializableOccupation, SerializableSeniority, SerializableTechnology } from "@/lib/search/query-params";
+import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
 
 interface SearchResultsProps {
   companies: SearchResultCompany[];
@@ -37,25 +37,7 @@ export function SearchResults({
   onShowPosting,
   selectedPostingId,
 }: SearchResultsProps) {
-  const sentinelRef = useRef<HTMLDivElement>(null);
-
-  // Infinite scroll sentinel
-  useEffect(() => {
-    const sentinel = sentinelRef.current;
-    if (!sentinel || !hasMore) return;
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          onLoadMore();
-        }
-      },
-      { rootMargin: "200px" },
-    );
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [hasMore, onLoadMore]);
+  const sentinelRef = useInfiniteScroll({ hasMore, isLoading: isLoadingMore, onLoadMore });
 
   return (
     <div className="space-y-3">

--- a/apps/web/src/components/watchlist/company-search-modal.tsx
+++ b/apps/web/src/components/watchlist/company-search-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import Image from "next/image";
 import * as Dialog from "@radix-ui/react-dialog";
 import { X, Search, Building2, Loader2, Check, ChevronDown } from "lucide-react";
@@ -11,6 +11,7 @@ import {
   type CompanyListEntry,
   type IndustrySuggestion,
 } from "@/lib/actions/company";
+import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
 import { RequestCompanyPrompt } from "@/components/search/request-company";
 import { useStarredCompanies } from "@/components/StarredCompaniesProvider";
 
@@ -57,7 +58,6 @@ export function CompanySearchModal({
   const [exhausted, setExhausted] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const inputRef = useRef<HTMLInputElement>(null);
-  const sentinelRef = useRef<HTMLDivElement>(null);
   const loadingRef = useRef(false);
 
   // Industry selector state
@@ -148,7 +148,7 @@ export function CompanySearchModal({
   }, [query, selectedIndustry, open]);
 
   // Load more
-  const handleLoadMore = useCallback(() => {
+  function handleLoadMore() {
     if (loadingRef.current || exhausted) return;
     loadingRef.current = true;
     setLoadingMore(true);
@@ -176,23 +176,9 @@ export function CompanySearchModal({
         setLoadingMore(false);
         loadingRef.current = false;
       });
-  }, [companies.length, exhausted, query, selectedIndustry, locale, watchlistFilters]);
+  }
 
-  // IntersectionObserver sentinel
-  useEffect(() => {
-    const sentinel = sentinelRef.current;
-    if (!sentinel || exhausted) return;
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) handleLoadMore();
-      },
-      { rootMargin: "200px" },
-    );
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [handleLoadMore, exhausted]);
+  const sentinelRef = useInfiniteScroll({ hasMore: !exhausted, isLoading: loadingMore, onLoadMore: handleLoadMore });
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>

--- a/apps/web/src/components/watchlist/watchlist-job-list.tsx
+++ b/apps/web/src/components/watchlist/watchlist-job-list.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef } from "react";
 import Image from "next/image";
 import { Building2, Bookmark, Loader2 } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
@@ -11,6 +11,7 @@ import {
 } from "@/lib/actions/watchlists";
 import { useSavedJobs } from "@/components/SavedJobsProvider";
 import { JobDetailPanel } from "@/components/search/job-detail-dialog";
+import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
 
 const BATCH = 20;
 
@@ -67,7 +68,6 @@ export function WatchlistJobList({
   const [isLoading, setIsLoading] = useState(false);
   const [exhausted, setExhausted] = useState(initialPostings.length >= initialTotal);
   const [showPostingId, setShowPostingId] = useState<string | null>(null);
-  const sentinelRef = useRef<HTMLDivElement>(null);
   const loadingRef = useRef(false);
   const filtersRef = useRef(filters);
   filtersRef.current = filters;
@@ -99,7 +99,7 @@ export function WatchlistJobList({
       });
   }, [filtersKey]);
 
-  const handleLoadMore = useCallback(() => {
+  function handleLoadMore() {
     if (loadingRef.current || exhausted) return;
     loadingRef.current = true;
     setIsLoading(true);
@@ -123,23 +123,9 @@ export function WatchlistJobList({
         setIsLoading(false);
         loadingRef.current = false;
       });
-  }, [postings.length, exhausted]);
+  }
 
-  // IntersectionObserver sentinel for infinite scroll
-  useEffect(() => {
-    const sentinel = sentinelRef.current;
-    if (!sentinel || exhausted) return;
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) handleLoadMore();
-      },
-      { rootMargin: "200px" },
-    );
-
-    observer.observe(sentinel);
-    return () => observer.disconnect();
-  }, [handleLoadMore, exhausted]);
+  const sentinelRef = useInfiniteScroll({ hasMore: !exhausted, isLoading, onLoadMore: handleLoadMore });
 
   function handleOpenPosting(postingId: string) {
     setShowPostingId(postingId);

--- a/apps/web/src/lib/use-infinite-scroll.ts
+++ b/apps/web/src/lib/use-infinite-scroll.ts
@@ -1,0 +1,40 @@
+import { useRef, useEffect } from "react";
+
+interface UseInfiniteScrollOptions {
+  hasMore: boolean;
+  isLoading: boolean;
+  onLoadMore: () => void;
+  root?: React.RefObject<Element | null>;
+  rootMargin?: string;
+}
+
+export function useInfiniteScroll({
+  hasMore,
+  isLoading,
+  onLoadMore,
+  root,
+  rootMargin = "200px",
+}: UseInfiniteScrollOptions) {
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const onLoadMoreRef = useRef(onLoadMore);
+  onLoadMoreRef.current = onLoadMore;
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel || !hasMore || isLoading) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          onLoadMoreRef.current();
+        }
+      },
+      { root: root?.current ?? null, rootMargin },
+    );
+
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [hasMore, isLoading, root, rootMargin]);
+
+  return sentinelRef;
+}


### PR DESCRIPTION
## Summary
- Created `useInfiniteScroll` hook (~40 lines) that uses `isLoading` as the observer lifecycle signal instead of callback identity — observer is destroyed while loading and recreated after, so it catches cases where the sentinel is still visible
- Fixed the watchlist job list infinite scroll bug (primary issue)
- Migrated all 5 scroll views (`watchlist-job-list`, `search-results`, `search-page`, `company-card`, `company-search-modal`) to the shared hook to prevent recurrence
- Simplified `handleLoadMore` in `search-page.tsx` to read from refs instead of a 13-dep `useCallback`
- Replaced `company-card.tsx` scroll event listener with IntersectionObserver via the hook

## Test plan
- [ ] Watchlist: scroll to bottom, verify continuous loading without stopping
- [ ] Throttle network: verify no double-triggers during slow loads
- [ ] Search results page: verify infinite scroll still works
- [ ] Company card (expanded postings): verify scroll-to-load in the card's scrollable area
- [ ] Company search modal: verify infinite scroll still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)