### PR TITLE
Fix ws new failing when slug already exists in CSV

### DIFF
--- a/apps/crawler/src/workspace/commands/lifecycle.py
+++ b/apps/crawler/src/workspace/commands/lifecycle.py
@@ -181,6 +181,7 @@ def new(slug: str, issue: int | None, pr_opt: int | None, reconfig: bool, reset:
         set_repo_root(worktree_path)
         out.plain("git", f"Created worktree at {worktree_path} (branch {branch})")
 
+    csv_changed = False
     if not reconfig:
         # Add stub CSV row for new companies
         from src.csvtool import company_add
@@ -188,6 +189,7 @@ def new(slug: str, issue: int | None, pr_opt: int | None, reconfig: bool, reset:
 
         try:
             company_add(slug)
+            csv_changed = True
             out.plain("csv", "Added stub row to companies.csv")
         except NothingToUpdateError:
             # Slug already present in worktree CSV from a previous attempt
@@ -204,10 +206,11 @@ def new(slug: str, issue: int | None, pr_opt: int | None, reconfig: bool, reset:
         from src.workspace import git
 
         if not reconfig:
-            # Commit and push stub row
-            git.add_files(["apps/crawler/data/companies.csv"])
-            git.commit(f"Add {slug}")
-            out.plain("git", f'Committed: "Add {slug}"')
+            if csv_changed:
+                # Commit and push stub row
+                git.add_files(["apps/crawler/data/companies.csv"])
+                git.commit(f"Add {slug}")
+                out.plain("git", f'Committed: "Add {slug}"')
 
             # Push branch (needed before creating PR)
             git.push(branch, set_upstream=True)

--- a/apps/crawler/tests/test_ws_commands.py
+++ b/apps/crawler/tests/test_ws_commands.py
@@ -3309,3 +3309,87 @@ class TestProbeAllBoards:
         board_de = load_board("test", "careers-de")
         assert "greenhouse" in board_de.detections
         assert board_de.detections["greenhouse"]["jobs"] == 42
+
+
+class TestNewIdempotent:
+    """ws new should not fail when slug already exists in CSV from a prior attempt."""
+
+    def _git_mocks(self, stack, tmp_path, *, pr_opt=False):
+        """Set up common git mocks for new() tests. Returns (add_files, commit, push)."""
+        stack.enter_context(
+            patch(
+                "src.workspace.commands.lifecycle.is_local_mode",
+                return_value=False,
+            )
+        )
+        stack.enter_context(patch("src.workspace.git.check_gh_auth", return_value=True))
+        stack.enter_context(patch("src.workspace.git.fetch"))
+        stack.enter_context(
+            patch("src.workspace.git.worktrees_dir", return_value=tmp_path / "worktrees")
+        )
+        stack.enter_context(patch("src.workspace.git.get_main_branch", return_value="main"))
+        stack.enter_context(patch("src.workspace.git.delete_remote_branch"))
+        stack.enter_context(patch("src.workspace.git.create_worktree"))
+        stack.enter_context(patch("src.shared.constants.set_repo_root"))
+        stack.enter_context(patch("src.shared.constants.get_repo_root", return_value=tmp_path))
+        stack.enter_context(patch("src.workspace.git.check_existing_prs", return_value=[]))
+        if pr_opt:
+            stack.enter_context(
+                patch("src.workspace.git.get_pr_branch", return_value="add-company/acme")
+            )
+
+        add_files = stack.enter_context(patch("src.workspace.git.add_files"))
+        commit = stack.enter_context(patch("src.workspace.git.commit"))
+        push = stack.enter_context(patch("src.workspace.git.push"))
+        stack.enter_context(patch("src.workspace.git.create_draft_pr", return_value=99))
+        return add_files, commit, push
+
+    def test_new_skips_commit_when_slug_already_in_csv(self, tmp_path, monkeypatch):
+        """When company_add raises NothingToUpdateError (e.g. --pr reattach to
+        a branch that already has the slug), git.commit must be skipped but
+        git.push should still be called."""
+        _patch_all(monkeypatch, tmp_path)
+        # Empty CSV in the "original" repo — slug only exists in the worktree
+        # CSV (simulated by mocking company_add to raise NothingToUpdateError).
+        _setup_csvs(tmp_path)
+
+        from src.workspace.errors import NothingToUpdateError
+
+        with ExitStack() as stack:
+            add_files, commit, push = self._git_mocks(stack, tmp_path, pr_opt=True)
+            # Simulate the worktree CSV already containing the slug
+            stack.enter_context(
+                patch(
+                    "src.csvtool.company_add",
+                    side_effect=NothingToUpdateError("already exists"),
+                )
+            )
+
+            runner = CliRunner()
+            result = runner.invoke(ws, ["new", "acme", "--issue", "1", "--pr", "42"])
+
+        assert result.exit_code == 0, result.output
+        # company_add raised NothingToUpdateError, so commit must NOT be called
+        add_files.assert_not_called()
+        commit.assert_not_called()
+        # push must still be called (branch needs to exist on remote for PR)
+        push.assert_called_once()
+        # Workspace should be registered
+        assert workspace_exists("acme")
+
+    def test_new_commits_when_csv_actually_changed(self, tmp_path, monkeypatch):
+        """Normal case: slug not in CSV, so commit + push both happen."""
+        _patch_all(monkeypatch, tmp_path)
+        _setup_csvs(tmp_path)  # empty CSV — slug not present
+
+        with ExitStack() as stack:
+            add_files, commit, push = self._git_mocks(stack, tmp_path)
+
+            runner = CliRunner()
+            result = runner.invoke(ws, ["new", "acme", "--issue", "1"])
+
+        assert result.exit_code == 0, result.output
+        # CSV was changed, so commit + push both called
+        add_files.assert_called_once()
+        commit.assert_called_once()
+        push.assert_called_once()


### PR DESCRIPTION
## Summary

- **Bug**: `ws new` crashed with a git "nothing to commit" error when retrying after a previous partial attempt that already added the slug to `companies.csv`. This left the workspace unregistered, causing `ws task` to report "No active workspace" and agents to loop indefinitely.
- **Fix**: Track whether `company_add()` actually modified the CSV. Skip `git add` + `git commit` when the row already existed; still push the branch so PR creation succeeds.
- **Tests**: Two new tests in `TestNewIdempotent` covering both the idempotent retry path and the normal (CSV changed) path.

## Test plan

- [x] All 149 existing tests in `test_ws_commands.py` pass
- [x] New test: `test_new_skips_commit_when_slug_already_in_csv` — verifies commit is skipped but push still happens
- [x] New test: `test_new_commits_when_csv_actually_changed` — verifies normal path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)