### PR TITLE
Fix json-ld scraper for PascalCase keys (CSOD)

### DIFF
--- a/apps/crawler/src/core/scrapers/jsonld.py
+++ b/apps/crawler/src/core/scrapers/jsonld.py
@@ -82,6 +82,28 @@ class _JsonLdExtractor(HTMLParser):
                         pass
 
 
+def _normalize_keys(data):
+    """Lowercase the first character of JSON-LD keys for case-insensitive matching.
+
+    Some ATS providers (e.g. Cornerstone OnDemand) emit PascalCase property names
+    like ``Title`` instead of the schema.org-standard ``title``.  Normalising to
+    camelCase (first char lower) lets the rest of the parser use canonical names.
+    Keys starting with ``@`` are left unchanged.
+    """
+    if isinstance(data, dict):
+        out = {}
+        for key, value in data.items():
+            if key.startswith("@"):
+                nk = key
+            else:
+                nk = key[0].lower() + key[1:] if key else key
+            out[nk] = _normalize_keys(value)
+        return out
+    if isinstance(data, list):
+        return [_normalize_keys(item) for item in data]
+    return data
+
+
 def _find_job_posting(data: dict | list) -> dict | None:
     """Recursively find a JobPosting object in JSON-LD data."""
     if isinstance(data, list):
@@ -94,9 +116,9 @@ def _find_job_posting(data: dict | list) -> dict | None:
     if isinstance(data, dict):
         type_val = data.get("@type", "")
         if isinstance(type_val, str) and "JobPosting" in type_val:
-            return data
+            return _normalize_keys(data)
         if isinstance(type_val, list) and any("JobPosting" in t for t in type_val):
-            return data
+            return _normalize_keys(data)
 
         # Check @graph
         graph = data.get("@graph")

--- a/apps/crawler/tests/test_jsonld_scraper.py
+++ b/apps/crawler/tests/test_jsonld_scraper.py
@@ -63,7 +63,8 @@ class TestJsonLdExtractor:
 class TestFindJobPosting:
     def test_direct_match(self):
         data = {"@type": "JobPosting", "title": "Engineer"}
-        assert _find_job_posting(data) == data
+        result = _find_job_posting(data)
+        assert result["title"] == "Engineer"
 
     def test_in_list(self):
         data = [{"@type": "Organization"}, {"@type": "JobPosting", "title": "X"}]
@@ -77,7 +78,8 @@ class TestFindJobPosting:
 
     def test_type_as_list(self):
         data = {"@type": ["JobPosting", "Thing"], "title": "Z"}
-        assert _find_job_posting(data) == data
+        result = _find_job_posting(data)
+        assert result["title"] == "Z"
 
     def test_not_found_dict(self):
         assert _find_job_posting({"@type": "Organization"}) is None
@@ -98,6 +100,24 @@ class TestFindJobPosting:
         }
         result = _find_job_posting(data)
         assert result["title"] == "Nested"
+
+    def test_pascalcase_keys_normalized(self):
+        """CSOD-style PascalCase keys are normalized to camelCase."""
+        data = {
+            "@type": "JobPosting",
+            "Title": "Manager",
+            "Description": "A role",
+            "DatePosted": "2026-01-01",
+            "ValidThrough": "2026-06-01",
+            "jobLocation": [{"@type": "Place", "Address": {"@type": "PostalAddress", "addressLocality": "Geneva"}}],
+        }
+        result = _find_job_posting(data)
+        assert result["title"] == "Manager"
+        assert result["description"] == "A role"
+        assert result["datePosted"] == "2026-01-01"
+        assert result["validThrough"] == "2026-06-01"
+        # Nested keys are also normalized
+        assert result["jobLocation"][0]["address"]["addressLocality"] == "Geneva"
 
 
 class TestExtractLocations:
@@ -376,6 +396,29 @@ class TestScrape:
         async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
             result = await scrape("https://example.com/job", {"render": False}, client)
             assert result.title == "Static"
+
+    async def test_pascalcase_csod_style(self):
+        """CSOD-style PascalCase JSON-LD is extracted correctly."""
+        page_html = """<html><head>
+        <script type="application/ld+json">
+        {"@context":"http://schema.org","@type":"JobPosting",
+         "Title":"Senior Engineer","Description":"<p>Build things</p>",
+         "DatePosted":"2026-01-01","ValidThrough":"2026-06-01",
+         "jobLocation":[{"@type":"Place","Address":{"@type":"PostalAddress",
+         "addressLocality":"Geneva","addressCountry":"CH"}}],
+         "HiringOrganization":{"@type":"Organization","Name":"IATA"}}
+        </script>
+        </head></html>"""
+
+        def handler(request):
+            return httpx.Response(200, text=page_html)
+
+        async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+            result = await scrape("https://example.com/job", {}, client)
+            assert result.title == "Senior Engineer"
+            assert result.description == "<p>Build things</p>"
+            assert result.locations == ["Geneva, CH"]
+            assert result.date_posted == "2026-01-01"
 
 
 class TestProbe:


### PR DESCRIPTION
## Summary
- CSOD (Cornerstone OnDemand) ATS emits JSON-LD with PascalCase property names (`Title`, `Description`, `DatePosted`) instead of standard schema.org camelCase
- The json-ld scraper reported `jsonld.not_found` despite valid `@type: JobPosting` data being present in the HTML
- Added `_normalize_keys()` to lowercase the first character of all property keys (except `@`-prefixed) when a JobPosting is found

## What was tried during the guided workflow
- `json-ld` scraper with `render: false` and `render: true` — both returned 0/10 on all fields
- `api_sniffer` scraper — found titles but no descriptions
- Inspected raw HTML and confirmed JSON-LD exists with PascalCase keys

## Why it failed
The `_parse_posting()` function uses `posting.get("title")` (lowercase) but CSOD emits `"Title"` (PascalCase). Same for `description`, `datePosted`, `validThrough`, and nested `address` keys.

## What the code change does
- Adds `_normalize_keys()` that recursively lowercases the first character of all dict keys (preserving `@`-prefixed keys like `@type`, `@context`)
- Called in `_find_job_posting()` when a JobPosting match is found, so all downstream field lookups work regardless of casing
- Added tests for PascalCase normalization and end-to-end CSOD-style extraction
- All 51 tests pass

## Test plan
- [x] Existing tests pass (51/51)
- [x] New test: PascalCase keys are normalized to camelCase
- [x] New test: Full CSOD-style JSON-LD extraction works end-to-end
- [x] Verified against live IATA CSOD page: 10/10 titles, descriptions, locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)