### PR TITLE
Fix lenovo scraper: dom with extraction steps

### DIFF
--- a/apps/crawler/data/boards.csv
+++ b/apps/crawler/data/boards.csv
@@ -83,7 +83,7 @@ kpmg,kpmg-us,https://www.kpmguscareers.com/job-search/,api_sniffer,"{""api_url""
 kraken,kraken-careers,https://jobs.ashbyhq.com/kraken.com,ashby,"{""token"": ""kraken.com""}",,
 lakera,lakera-careers,https://jobs.ashbyhq.com/lakera.ai,ashby,"{""token"": ""lakera.ai""}",,
 latticeflow,latticeflow-workable,https://apply.workable.com/latticeflow/,workable,"{""token"": ""latticeflow""}",workable,
-lenovo,lenovo-careers,https://jobs.lenovo.com/en_US/careers/SearchJobs,dom,"{""render"": true, ""wait"": ""networkidle"", ""url_filter"": ""/careers/JobDetail/"", ""pagination"": {""param_name"": ""jobOffset"", ""start"": 0, ""increment"": 10, ""max_pages"": 100, ""browser"": true}}",json-ld,
+lenovo,lenovo-careers,https://jobs.lenovo.com/en_US/careers/SearchJobs,dom,"{""render"": true, ""wait"": ""networkidle"", ""url_filter"": ""/careers/JobDetail/"", ""pagination"": {""param_name"": ""jobOffset"", ""start"": 0, ""increment"": 10, ""max_pages"": 100, ""browser"": true}}",dom,"{""render"": true, ""wait"": ""networkidle"", ""steps"": [{""tag"": ""h2"", ""attr"": ""class=banner__text__title"", ""field"": ""title""}, {""text"": ""City:"", ""offset"": 1, ""field"": ""locations""}, {""text"": ""Description and Requirements"", ""offset"": 1, ""field"": ""description"", ""html"": true, ""stop"": ""Additional Locations""}]}"
 lightpanda,lightpanda-careers,https://lightpanda.io/jobs,dom,"{""url_filter"": ""/jobs/.+""}",json-ld,
 lightricks,lightricks-careers,https://boards.greenhouse.io/lightricks,greenhouse,"{""token"": ""lightricks""}",skip,
 logitech,logitech-careers,https://logitech.wd5.myworkdayjobs.com/Logitech,workday,,workday,


### PR DESCRIPTION
## Summary
- Lenovo job pages are a JS-rendered SPA (HTTP 202 empty body, no JSON-LD markup)
- Previous config had `json-ld` scraper which extracted 0/10 on all fields
- Switched to `dom` scraper with `render: true` and proper extraction steps

## Extraction steps
- **Title**: `h2.banner__text__title`
- **Location**: text after "City:" label
- **Description**: HTML content from "Description and Requirements" to "Additional Locations"

## Verification
- Scraper: 10/10 titles, 10/10 descriptions, 10/10 locations
- Monitor: 919 jobs across 92 paginated pages (matches website total)

## Test plan
- [x] CSV validation passes
- [x] DOM scraper extracts all required fields on sample URLs
- [x] Monitor pagination discovers all 919 jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)