### PR TITLE
Fix explicit scraper_type=skip not classified as rich board

### DIFF
--- a/apps/crawler/src/batch.py
+++ b/apps/crawler/src/batch.py
@@ -1043,6 +1043,9 @@ async def _load_board_scrapers(
                 continue
             scraper_type = auto[0] if auto else "json-ld"
             auto_config = auto[1] if auto else None
+        elif explicit_scraper == "skip":
+            rich_board_ids.add(board_id)
+            continue
         else:
             scraper_type = explicit_scraper
             auto_config = None


### PR DESCRIPTION
## Summary
- Boards with explicit `scraper_type=skip` in CSV (e.g. Klarna/deel) were not classified as rich in `_load_board_scrapers`, because the `skip` check only ran in the auto-configured path
- This caused the `skip` scraper to be invoked (which throws), recording a failure that set `next_scrape_at` — creating an endless retry loop
- Cleaned up 71 affected Klarna postings in the DB

## Test plan
- [x] `uv run pytest tests/test_batch.py` — 71 passed
- [x] Verified Klarna postings no longer have `next_scrape_at` set
- [x] Ruff lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)