### PR TITLE
Raise sitemap MAX_URLS from 10k to 50k

### DIFF
--- a/apps/crawler/src/core/monitors/sitemap.py
+++ b/apps/crawler/src/core/monitors/sitemap.py
@@ -12,7 +12,7 @@ from src.core.monitors import register
 
 log = structlog.get_logger()
 
-MAX_URLS = 10_000
+MAX_URLS = 50_000
 NS = "{http://www.sitemaps.org/schemas/sitemap/0.9}"
 
 _JOB_KEYWORDS = ("job", "career", "posting", "position", "vacancy", "opening")


### PR DESCRIPTION
## Summary
- Three sitemap-monitored boards were hitting the 10k URL cap and silently dropping jobs:
  - **Salesforce**: 20,665 total → 10,665 lost (52%)
  - **Caterpillar**: 12,085 total → 2,085 lost (17%)
  - **IBM**: 10,461 total → 461 lost (4%)
- Raised `MAX_URLS` from 10,000 to 50,000 in `sitemap.py`
- Memory impact is negligible (~170 bytes/URL, ~7 MB worst case at 50k)

## Test plan
- [x] Verified all 34 sitemap boards' URL counts — only 3 exceeded 10k, none exceed 50k
- [x] Confirmed other monitor types (API-based) keep their 10k caps since they only return actual jobs
- [x] Verified IBM's 10.4k URLs are all real unique job postings (not junk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)