### PR TITLE
Add description field to watchlists for SEO

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import type { Metadata } from "next";
 import { initI18nForPage } from "@/lib/i18n";
 import {
   getWatchlistByUserAndSlug,
@@ -13,6 +14,37 @@ import { WatchlistViewPage } from "./watchlist-view-page";
 type Props = {
   params: Promise<{ lang: string; userSlug: string; watchlistSlug: string }>;
 };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { userSlug, watchlistSlug } = await params;
+  const detail = await getWatchlistByUserAndSlug(userSlug, watchlistSlug);
+  if (!detail) return {};
+
+  const ownerLabel = detail.owner.displayUsername ?? detail.owner.username ?? detail.owner.name;
+  const title = `${detail.title} — @${ownerLabel}`;
+
+  let description = detail.description;
+  if (!description) {
+    // Auto-generate from companies/filters
+    const parts: string[] = [];
+    if (detail.companies.length > 0) {
+      const names = detail.companies.slice(0, 3).map((c) => c.name);
+      if (detail.companies.length > 3) {
+        names.push(`${detail.companies.length - 3} more`);
+      }
+      parts.push(`Jobs at ${names.join(", ")}`);
+    }
+    if (detail.filters.occupationSlugs?.length) {
+      parts.push(detail.filters.occupationSlugs.map((s) => s.replace(/-/g, " ")).join(", "));
+    }
+    if (detail.filters.locationSlugs?.length) {
+      parts.push(`in ${detail.filters.locationSlugs.slice(0, 2).map((s) => s.replace(/-/g, " ")).join(", ")}`);
+    }
+    description = parts.length > 0 ? parts.join(" · ") : `Job watchlist by @${ownerLabel}`;
+  }
+
+  return { title, description };
+}
 
 export default async function WatchlistRoute({ params }: Props) {
   const { lang, userSlug, watchlistSlug } = await params;

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
@@ -365,18 +365,20 @@ export function WatchlistViewPage({
             </div>
           ) : description ? (
             <p
-              className="line-clamp-2 cursor-pointer rounded px-2 py-1 -mx-2 -my-1 text-sm text-muted transition-colors hover:bg-border-soft"
+              className="group/desc line-clamp-2 cursor-pointer rounded px-2 py-1 -mx-2 -my-1 text-sm text-muted transition-colors hover:bg-border-soft flex items-start gap-2"
               onClick={() => setEditingDescription(true)}
               title={t({ id: "watchlists.view.editDescription", comment: "Tooltip for clicking to edit watchlist description", message: "Click to edit description" })}
             >
-              {description}
+              <span className="line-clamp-2">{description}</span>
+              <Pencil size={12} className="mt-0.5 shrink-0 text-muted opacity-0 transition-opacity group-hover/desc:opacity-100" />
             </p>
           ) : (
             <button
               type="button"
               onClick={() => setEditingDescription(true)}
-              className="cursor-pointer text-sm text-muted/60 transition-colors hover:text-muted"
+              className="flex items-center gap-1.5 cursor-pointer text-sm text-muted/60 transition-colors hover:text-muted"
             >
+              <Pencil size={12} />
               {t({ id: "watchlists.view.addDescription", comment: "Link to add a description to the watchlist", message: "Add description" })}
             </button>
           )
@@ -385,7 +387,7 @@ export function WatchlistViewPage({
         ) : null}
 
         {/* Companies */}
-        <div className="space-y-2">
+        <div className="space-y-2 !mt-6">
           {isOwner && (
             <div className="flex items-center gap-2">
               <button

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
@@ -85,6 +85,37 @@ export function WatchlistViewPage({
     }
   }, [title, detail.title, detail.id, user?.username, router, lp]);
 
+  // ── Editable description ──
+  const [description, setDescription] = useState(detail.description ?? "");
+  const [editingDescription, setEditingDescription] = useState(false);
+  const [savingDescription, setSavingDescription] = useState(false);
+  const descriptionRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    if (editingDescription) {
+      const el = descriptionRef.current;
+      if (el) {
+        el.focus();
+        el.selectionStart = el.value.length;
+      }
+    }
+  }, [editingDescription]);
+
+  const saveDescription = useCallback(async () => {
+    const trimmed = description.trim();
+    if (trimmed === (detail.description ?? "")) {
+      setEditingDescription(false);
+      return;
+    }
+    setSavingDescription(true);
+    await updateWatchlist({
+      watchlistId: detail.id,
+      description: trimmed || null,
+    });
+    setSavingDescription(false);
+    setEditingDescription(false);
+  }, [description, detail.description, detail.id]);
+
   // ── Editable companies ──
   const [companies, setCompanies] = useState<Company[]>(detail.companies);
   const [anyCompany, setAnyCompany] = useState(detail.filters.anyCompany ?? false);
@@ -305,6 +336,53 @@ export function WatchlistViewPage({
             limitReached={limitReached}
           />
         </div>
+
+        {/* Description */}
+        {isOwner ? (
+          editingDescription ? (
+            <div className="flex items-start gap-2">
+              <textarea
+                ref={descriptionRef}
+                value={description}
+                onChange={(e) => setDescription(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !e.shiftKey) {
+                    e.preventDefault();
+                    saveDescription();
+                  }
+                  if (e.key === "Escape") {
+                    setDescription(detail.description ?? "");
+                    setEditingDescription(false);
+                  }
+                }}
+                onBlur={saveDescription}
+                maxLength={200}
+                rows={2}
+                className="w-full resize-none rounded-md border border-border-soft bg-transparent px-2 py-1 text-sm text-muted outline-none focus:border-primary"
+                placeholder={t({ id: "watchlists.view.descriptionPlaceholder", comment: "Placeholder for watchlist description textarea", message: "Describe this watchlist..." })}
+              />
+              {savingDescription && <Loader2 size={14} className="mt-1.5 animate-spin text-muted" />}
+            </div>
+          ) : description ? (
+            <p
+              className="line-clamp-2 cursor-pointer rounded px-2 py-1 -mx-2 -my-1 text-sm text-muted transition-colors hover:bg-border-soft"
+              onClick={() => setEditingDescription(true)}
+              title={t({ id: "watchlists.view.editDescription", comment: "Tooltip for clicking to edit watchlist description", message: "Click to edit description" })}
+            >
+              {description}
+            </p>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setEditingDescription(true)}
+              className="cursor-pointer text-sm text-muted/60 transition-colors hover:text-muted"
+            >
+              {t({ id: "watchlists.view.addDescription", comment: "Link to add a description to the watchlist", message: "Add description" })}
+            </button>
+          )
+        ) : description ? (
+          <p className="text-sm text-muted">{description}</p>
+        ) : null}
 
         {/* Companies */}
         <div className="space-y-2">

--- a/apps/web/drizzle/0070_add_watchlist_description.sql
+++ b/apps/web/drizzle/0070_add_watchlist_description.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "watchlist" ADD COLUMN "description" text;

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -456,6 +456,13 @@
       "when": 1775337600000,
       "tag": "0067_add_dismissed_banners",
       "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1774934400000,
+      "tag": "0070_add_watchlist_description",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -98,20 +98,20 @@ msgstr "{0} Mitarbeitende"
 #. Count of additional watchlists not shown
 #. js-lingui-explicit-id
 #. placeholder {0}: total - results.length
-#: src/components/watchlist/public-watchlist-search.tsx:127
+#: src/components/watchlist/public-watchlist-search.tsx:130
 msgid "watchlists.explore.moreCount"
 msgstr "{0} weitere"
 
 #. Button to show remaining collapsed locations
 #. js-lingui-explicit-id
 #. placeholder {0}: locations.length - LOCATIONS_COLLAPSED
-#: src/components/search/job-detail-dialog.tsx:350
+#: src/components/search/job-detail-dialog.tsx:348
 msgid "search.detail.showMoreLocations"
 msgstr "{0} weitere"
 
 #. Heatmap tooltip for multiple applications
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:81
+#: src/components/my-jobs/activity-heatmap.tsx:80
 msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} Bewerbungen am {date}"
 
@@ -129,7 +129,7 @@ msgstr "10 $ / Monat"
 
 #. Heatmap tooltip for 1 application
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:80
+#: src/components/my-jobs/activity-heatmap.tsx:79
 msgid "myJobs.heatmap.tooltipOne"
 msgstr "1 Bewerbung am {date}"
 
@@ -169,15 +169,21 @@ msgstr "aktiv"
 msgid "watchlists.companyModal.title"
 msgstr "Unternehmen hinzufügen"
 
+#. Link to add a description to the watchlist
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:379
+msgid "watchlists.view.addDescription"
+msgstr "Beschreibung hinzufügen"
+
 #. Quick action tooltip: add interview round
 #. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:20
+#: src/components/my-jobs/quick-actions.tsx:19
 msgid "myJobs.action.addInterview"
 msgstr "Interview hinzufügen"
 
 #. Button to add an interview round
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:78
+#: src/components/my-jobs/interview-list.tsx:76
 msgid "myJobs.detail.addInterview"
 msgstr "Interview hinzufügen"
 
@@ -261,7 +267,7 @@ msgstr "Beliebig"
 
 #. Toggle to show jobs from all companies
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:329
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:407
 msgid "watchlists.view.anyCompany"
 msgstr "Alle Unternehmen"
 
@@ -282,7 +288,7 @@ msgstr "Anwendungscode (MIT)"
 
 #. Link to application stats page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:265
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:263
 msgid "myJobs.viewStats"
 msgstr "Bewerbungsstatistik"
 
@@ -312,7 +318,7 @@ msgstr "Bewerbungstracker"
 
 #. Application tracker section heading in job detail
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:246
+#: src/components/search/job-detail-dialog.tsx:244
 msgid "search.detail.applicationTracker"
 msgstr "Bewerbungstracker"
 
@@ -324,31 +330,31 @@ msgstr "Bewerbungen im letzten Jahr"
 
 #. Status group heading: applied jobs
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:31
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:29
 msgid "myJobs.group.applied"
-msgstr "Beworben"
-
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:440
-msgid "search.tracker.applied"
 msgstr "Beworben"
 
 #. Applied status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:21
+#: src/components/my-jobs/status-badge.tsx:20
 msgid "myJobs.status.applied"
 msgstr "Beworben"
 
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:43
+#: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
+msgstr "Beworben"
+
+#. Application tracker status: applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:438
+msgid "search.tracker.applied"
 msgstr "Beworben"
 
 #. Status option in dropdown: applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:35
+#: src/components/my-jobs/my-job-detail-panel.tsx:33
 msgid "myJobs.statusOption.applied"
 msgstr "Beworben"
 
@@ -366,13 +372,13 @@ msgstr "Anwenden"
 
 #. Apply button linking to original job posting
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:295
+#: src/components/my-jobs/my-job-detail-panel.tsx:293
 msgid "search.detail.apply"
 msgstr "Bewerben"
 
 #. Short April label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:61
+#: src/components/my-jobs/activity-heatmap.tsx:60
 msgid "myJobs.heatmap.month.apr"
 msgstr "Apr"
 
@@ -396,7 +402,7 @@ msgstr "Maximal 30 Zeichen"
 
 #. Short August label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:65
+#: src/components/my-jobs/activity-heatmap.tsx:64
 msgid "myJobs.heatmap.month.aug"
 msgstr "Aug"
 
@@ -406,16 +412,16 @@ msgstr "Aug"
 msgid "settings.account.username.available"
 msgstr "Verfügbar"
 
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Zurück zur Anmeldung"
-
 #. Link back to sign-in after failed verification
 #. js-lingui-explicit-id
 #: app/[lang]/verify-email/page.tsx:68
 msgid "auth.verify.error.backToSignIn"
+msgstr "Zurück zur Anmeldung"
+
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
 msgstr "Zurück zur Anmeldung"
 
 #. Link back to sign-in from forgot password
@@ -432,7 +438,7 @@ msgstr "Zurück zur Anmeldung"
 
 #. Interview type label: behavioral interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:23
+#: src/components/my-jobs/interview-list.tsx:21
 msgid "myJobs.interviewType.behavioral"
 msgstr "Verhalten"
 
@@ -498,21 +504,21 @@ msgstr "Ändere dein Passwort über einen sicheren E-Mail-Link."
 
 #. Placeholder in status change dropdown
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:63
+#: src/components/my-jobs/my-job-detail-panel.tsx:61
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Ändern…"
-
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "E-Mail prüfen"
 
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
 msgstr "E-Mail überprüfen"
+
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
+msgstr "E-Mail prüfen"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -566,14 +572,14 @@ msgstr "Zurücksetzen"
 
 #. Button to remove all companies from watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:347
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:425
 msgid "watchlists.view.clearAllCompanies"
 msgstr "Alle entfernen"
 
 #. Button to clear all active search filters
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:455
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:533
 #: src/components/search/search-toolbar.tsx:282
 msgid "search.filters.clearAll"
 msgstr "Alle löschen"
@@ -584,9 +590,15 @@ msgstr "Alle löschen"
 msgid "watchlists.companyModal.clearAll"
 msgstr "Alle entfernen"
 
+#. Tooltip for clicking to edit watchlist description
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:369
+msgid "watchlists.view.editDescription"
+msgstr "Klicken, um Beschreibung zu bearbeiten"
+
 #. Tooltip for clicking to edit watchlist title
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:289
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:320
 msgid "watchlists.view.editTitle"
 msgstr "Klicken zum Umbenennen"
 
@@ -616,7 +628,7 @@ msgstr "Geschlossen"
 
 #. Interview type label: coding challenge
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:21
+#: src/components/my-jobs/interview-list.tsx:19
 msgid "myJobs.interviewType.coding"
 msgstr "Coding"
 
@@ -652,19 +664,19 @@ msgstr "Beobachtete Unternehmen"
 
 #. Button to open company search modal
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:318
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:396
 msgid "watchlists.view.addCompany"
 msgstr "Unternehmen"
 
 #. Sort option: company name
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:17
+#: src/components/my-jobs/sort-filter-bar.tsx:16
 msgid "myJobs.sort.company"
 msgstr "Unternehmen"
 
 #. Group by company option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:24
+#: src/components/my-jobs/sort-filter-bar.tsx:23
 msgid "myJobs.group.company"
 msgstr "Unternehmen"
 
@@ -718,14 +730,14 @@ msgstr "Kontakt"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
+#: src/components/LicenseContent.tsx:18
+msgid "license.toc.title"
 msgstr "Inhalt"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
-msgid "license.toc.title"
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Inhalt"
 
 #. Button to continue to app after verification
@@ -754,7 +766,7 @@ msgstr "Weiter mit LinkedIn"
 
 #. Employment type: contract
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:15
+#: src/components/search/employment-type-modal.tsx:13
 msgid "search.employmentType.contract"
 msgstr "Freiberuflich"
 
@@ -834,7 +846,7 @@ msgstr "Währung"
 
 #. Currency label in salary override
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:108
+#: src/components/my-jobs/salary-override.tsx:106
 msgid "myJobs.detail.salary.currency"
 msgstr "Währung"
 
@@ -858,13 +870,13 @@ msgstr "Dunkel"
 
 #. Sort option: date saved
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:15
+#: src/components/my-jobs/sort-filter-bar.tsx:14
 msgid "myJobs.sort.dateSaved"
 msgstr "Speicherdatum"
 
 #. Short December label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:69
+#: src/components/my-jobs/activity-heatmap.tsx:68
 msgid "myJobs.heatmap.month.dec"
 msgstr "Dez"
 
@@ -882,7 +894,7 @@ msgstr "Löschen"
 
 #. Delete interview button
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:165
+#: src/components/my-jobs/interview-list.tsx:163
 msgid "myJobs.interview.delete"
 msgstr "Löschen"
 
@@ -910,6 +922,12 @@ msgstr "Watchlist löschen?"
 msgid "settings.account.delete.deleting"
 msgstr "Löschen…"
 
+#. Placeholder for watchlist description textarea
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:361
+msgid "watchlists.view.descriptionPlaceholder"
+msgstr "Diese Watchlist beschreiben …"
+
 #. Cookie banner details button
 #. js-lingui-explicit-id
 #: src/components/CookieBanner.tsx:60
@@ -918,7 +936,7 @@ msgstr "Details"
 
 #. Collapsible section heading for extracted job details
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:378
+#: src/components/search/job-detail-dialog.tsx:376
 msgid "search.detail.details"
 msgstr "Details"
 
@@ -1020,7 +1038,7 @@ msgstr "E-Mail bestätigt"
 
 #. Title for the employment type selection modal
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:49
+#: src/components/search/employment-type-modal.tsx:47
 msgid "search.employmentTypeModal.title"
 msgstr "Beschäftigungsart"
 
@@ -1150,7 +1168,7 @@ msgstr "Funktionen"
 
 #. Short February label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:59
+#: src/components/my-jobs/activity-heatmap.tsx:58
 msgid "myJobs.heatmap.month.feb"
 msgstr "Feb"
 
@@ -1164,15 +1182,15 @@ msgstr "Filter"
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:103
-#: src/components/search/job-detail-dialog.tsx:291
-#: src/components/search/job-detail-dialog.tsx:369
+#: src/components/search/job-detail-dialog.tsx:101
+#: src/components/search/job-detail-dialog.tsx:289
+#: src/components/search/job-detail-dialog.tsx:367
 msgid "search.detail.filterByPrefix"
 msgstr "Filtern nach"
 
 #. Tooltip for salary filter pill
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:225
+#: src/components/search/job-detail-dialog.tsx:223
 msgid "search.detail.filterBySalary"
 msgstr "Nach Gehaltsbereich filtern"
 
@@ -1280,7 +1298,7 @@ msgstr "Kostenlos"
 
 #. Short Friday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:50
+#: src/components/my-jobs/activity-heatmap.tsx:49
 msgid "myJobs.heatmap.day.fri"
 msgstr "Fr"
 
@@ -1292,7 +1310,7 @@ msgstr "Vollständige Jobsuche"
 
 #. Employment type: full-time
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:13
+#: src/components/search/employment-type-modal.tsx:11
 msgid "search.employmentType.fullTime"
 msgstr "Vollzeit"
 
@@ -1356,7 +1374,7 @@ msgstr "Passwort verbergen"
 
 #. Interview type label: hiring manager round
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:26
+#: src/components/my-jobs/interview-list.tsx:24
 msgid "myJobs.interviewType.hiringManager"
 msgstr "Hiring Manager"
 
@@ -1368,7 +1386,7 @@ msgstr "Stündlich"
 
 #. Hourly salary period option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:48
+#: src/components/my-jobs/salary-override.tsx:46
 msgid "myJobs.salary.hourly"
 msgstr "Stündlich"
 
@@ -1483,43 +1501,43 @@ msgstr "Eingabe ist zu kurz."
 
 #. Employment type: internship
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:16
+#: src/components/search/employment-type-modal.tsx:14
 msgid "search.employmentType.internship"
 msgstr "Praktikum"
 
 #. Interview type label: general interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:17
+#: src/components/my-jobs/interview-list.tsx:15
 msgid "myJobs.interviewType.interview"
 msgstr "Interview"
 
 #. Status group heading: interviewing
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:32
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:30
 msgid "myJobs.group.interviewing"
-msgstr "Im Interview"
-
-#. Application tracker status: interviewing
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:441
-msgid "search.tracker.interviewing"
 msgstr "Im Interview"
 
 #. Interviewing status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:22
+#: src/components/my-jobs/status-badge.tsx:21
 msgid "myJobs.status.interviewing"
+msgstr "Im Interview"
+
+#. Application tracker status: interviewing
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:439
+msgid "search.tracker.interviewing"
 msgstr "Im Interview"
 
 #. Status option in dropdown: interviewing
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:36
+#: src/components/my-jobs/my-job-detail-panel.tsx:34
 msgid "myJobs.statusOption.interviewing"
 msgstr "Im Interview"
 
 #. Interviews section heading
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:51
+#: src/components/my-jobs/interview-list.tsx:49
 msgid "myJobs.detail.interviews"
 msgstr "Interviews"
 
@@ -1537,7 +1555,7 @@ msgstr "Ungültiger Bestätigungslink"
 
 #. Short January label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:58
+#: src/components/my-jobs/activity-heatmap.tsx:57
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
@@ -1549,7 +1567,7 @@ msgstr "Job"
 
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:107
+#: src/components/watchlist/public-watchlist-search.tsx:110
 msgid "watchlists.explore.jobSingular"
 msgstr "Job"
 
@@ -1561,13 +1579,13 @@ msgstr "Stellendaten (CC BY-NC 4.0)"
 
 #. Job detail panel title
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:73
+#: src/components/search/job-detail-dialog.tsx:71
 msgid "search.detail.title"
 msgstr "Stellendetails"
 
 #. Job detail panel title in My Jobs
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:160
+#: src/components/my-jobs/my-job-detail-panel.tsx:158
 msgid "myJobs.detail.title"
 msgstr "Jobdetails"
 
@@ -1613,33 +1631,33 @@ msgstr "Job Seek wird aktiv entwickelt. Bleib dran für Updates!"
 msgid "license.hero.description"
 msgstr "Die Codebasis von Job Seek ist Open Source unter MIT. Die von uns gesammelten und aufbereiteten Stellendaten stehen unter Creative Commons BY-NC 4.0. Nachfolgend eine verständliche Zusammenfassung — bitte lies die vollständigen Lizenzen für die genauen Bedingungen."
 
-#. Job count label in watchlist view
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:210
-msgid "watchlists.jobList.jobCount"
-msgstr "Jobs"
-
 #. Plural job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:32
 msgid "watchlists.card.jobPlural"
 msgstr "Jobs"
 
+#. Job count label in watchlist view
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-job-list.tsx:210
+msgid "watchlists.jobList.jobCount"
+msgstr "Jobs"
+
 #. Plural job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:108
+#: src/components/watchlist/public-watchlist-search.tsx:111
 msgid "watchlists.explore.jobPlural"
 msgstr "Jobs"
 
 #. Short July label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:64
+#: src/components/my-jobs/activity-heatmap.tsx:63
 msgid "myJobs.heatmap.month.jul"
 msgstr "Jul"
 
 #. Short June label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:63
+#: src/components/my-jobs/activity-heatmap.tsx:62
 msgid "myJobs.heatmap.month.jun"
 msgstr "Jun"
 
@@ -1779,16 +1797,16 @@ msgstr "Standort"
 msgid "search.advanced.location"
 msgstr "Standort"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:303
-msgid "search.detail.locations"
-msgstr "Standorte"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:531
 msgid "search.bar.locations"
+msgstr "Standorte"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:301
+msgid "search.detail.locations"
 msgstr "Standorte"
 
 #. Login button label
@@ -1837,49 +1855,49 @@ msgstr "Verwalte deine verknüpften Social-Media-Konten."
 
 #. Short March label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:60
+#: src/components/my-jobs/activity-heatmap.tsx:59
 msgid "myJobs.heatmap.month.mar"
 msgstr "Mär"
 
 #. Quick action tooltip: mark job as applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:19
+#: src/components/my-jobs/quick-actions.tsx:18
 msgid "myJobs.action.markApplied"
 msgstr "Als beworben markieren"
 
 #. Quick action tooltip: mark job as offered
 #. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:22
+#: src/components/my-jobs/quick-actions.tsx:21
 msgid "myJobs.action.markOffer"
 msgstr "Als Angebot markieren"
 
 #. Quick action tooltip: mark job as rejected
 #. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:21
+#: src/components/my-jobs/quick-actions.tsx:20
 msgid "myJobs.action.markRejected"
 msgstr "Als abgelehnt markieren"
 
 #. Maximum salary label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:45
+#: src/components/my-jobs/salary-override.tsx:43
 msgid "myJobs.salary.max"
 msgstr "Max"
 
 #. Short May label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:62
+#: src/components/my-jobs/activity-heatmap.tsx:61
 msgid "myJobs.heatmap.month.may"
 msgstr "Mai"
 
 #. Minimum salary label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:44
+#: src/components/my-jobs/salary-override.tsx:42
 msgid "myJobs.salary.min"
 msgstr "Min"
 
 #. Singular mirror count
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:115
+#: src/components/watchlist/public-watchlist-search.tsx:118
 msgid "watchlists.explore.mirrorSingular"
 msgstr "Kopie"
 
@@ -1899,13 +1917,13 @@ msgstr "Spiegle jede öffentliche Watchlist, um sie zu deiner eigenen zu machen 
 
 #. Plural mirror count
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:116
+#: src/components/watchlist/public-watchlist-search.tsx:119
 msgid "watchlists.explore.mirrorPlural"
 msgstr "Kopien"
 
 #. Short Monday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:46
+#: src/components/my-jobs/activity-heatmap.tsx:45
 msgid "myJobs.heatmap.day.mon"
 msgstr "Mo"
 
@@ -1917,7 +1935,7 @@ msgstr "Monatlich"
 
 #. Monthly salary period option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:47
+#: src/components/my-jobs/salary-override.tsx:45
 msgid "myJobs.salary.monthly"
 msgstr "Monatlich"
 
@@ -1947,7 +1965,7 @@ msgstr "Meine Jobs"
 
 #. Title of the My Jobs page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:254
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:252
 msgid "myJobs.title"
 msgstr "Meine Jobs"
 
@@ -2007,7 +2025,7 @@ msgstr "Neues Passwort"
 
 #. Heatmap tooltip when no applications on a date
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:79
+#: src/components/my-jobs/activity-heatmap.tsx:78
 msgid "myJobs.heatmap.tooltipNone"
 msgstr "Keine Bewerbungen am {date}"
 
@@ -2041,17 +2059,17 @@ msgstr "Keine Jobs gefunden."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Keine Sprachen entsprechen deiner Suche."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:170
-msgid "search.locationModal.noResults"
-msgstr "Keine Standorte gefunden."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:185
 msgid "company.locationModal.noResults"
 msgstr "Keine Standorte entsprechen Ihrer Suche."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:170
+msgid "search.locationModal.noResults"
+msgstr "Keine Standorte gefunden."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2061,7 +2079,7 @@ msgstr "Keine passenden Stellenanzeigen gefunden."
 
 #. Sankey funnel node label prefix: no response
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:47
+#: src/components/my-jobs/sankey-funnel.tsx:46
 msgid "myJobs.funnel.noResponse"
 msgstr "Keine Antwort"
 
@@ -2091,7 +2109,7 @@ msgstr "Keine Technologien gefunden."
 
 #. Empty state message when no tracked jobs
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:237
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:235
 msgid "myJobs.empty"
 msgstr "Noch keine verfolgten Jobs. Speichern Sie Jobs aus den Suchergebnissen, um Ihre Bewerbungen zu verfolgen."
 
@@ -2103,7 +2121,7 @@ msgstr "Keine Gewährleistung — Nutzung auf eigenes Risiko."
 
 #. No results message when searching public watchlists
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:137
+#: src/components/watchlist/public-watchlist-search.tsx:140
 msgid "watchlists.explore.noResults"
 msgstr "Keine Watchlists gefunden."
 
@@ -2113,16 +2131,16 @@ msgstr "Keine Watchlists gefunden."
 msgid "watchlists.page.empty"
 msgstr "Noch keine Watchlists. Erstelle eine, um Jobs von deinen Lieblingsunternehmen zu verfolgen."
 
-#. Application tracker status: not applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:439
-msgid "search.tracker.notApplied"
-msgstr "Nicht beworben"
-
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:45
+#: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
+msgstr "Nicht beworben"
+
+#. Application tracker status: not applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:437
+msgid "search.tracker.notApplied"
 msgstr "Nicht beworben"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2137,7 +2155,7 @@ msgstr "Hinweis: Wir konnten kein Tracking-Issue erstellen, aber Ihre Anfrage wu
 
 #. Short November label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:68
+#: src/components/my-jobs/activity-heatmap.tsx:67
 msgid "myJobs.heatmap.month.nov"
 msgstr "Nov"
 
@@ -2149,37 +2167,37 @@ msgstr "Berufsfeld"
 
 #. Short October label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:67
+#: src/components/my-jobs/activity-heatmap.tsx:66
 msgid "myJobs.heatmap.month.oct"
 msgstr "Okt"
 
-#. Application tracker status: offer
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:442
-msgid "search.tracker.offer"
-msgstr "Angebot"
-
 #. Offered status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:23
+#: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
+msgstr "Angebot"
+
+#. Application tracker status: offer
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:440
+msgid "search.tracker.offer"
 msgstr "Angebot"
 
 #. Status group heading: offered
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:33
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:31
 msgid "myJobs.group.offered"
 msgstr "Angebot"
 
 #. Sankey funnel node: offered
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:44
+#: src/components/my-jobs/sankey-funnel.tsx:43
 msgid "myJobs.funnel.offered"
 msgstr "Angebot"
 
 #. Status option in dropdown: offered
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:37
+#: src/components/my-jobs/my-job-detail-panel.tsx:35
 msgid "myJobs.statusOption.offered"
 msgstr "Angebot"
 
@@ -2209,7 +2227,7 @@ msgstr "Nur Kleinbuchstaben, Zahlen und Bindestriche (nicht am Anfang/Ende)"
 
 #. Interview type label: onsite interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:24
+#: src/components/my-jobs/interview-list.tsx:22
 msgid "myJobs.interviewType.onsite"
 msgstr "Vor Ort"
 
@@ -2257,7 +2275,7 @@ msgstr "Original"
 
 #. Interview type label: other/unspecified
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:27
+#: src/components/my-jobs/interview-list.tsx:25
 msgid "myJobs.interviewType.other"
 msgstr "Sonstige"
 
@@ -2281,26 +2299,26 @@ msgstr "Unsere Haltung zur Automatisierung"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Überblick"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Überblick"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Seiteninhalt"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Überblick"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Seiteninhalt"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Seiteninhalt"
 
 #. Heading shown on the 404 page
@@ -2311,7 +2329,7 @@ msgstr "Seite nicht gefunden"
 
 #. Interview type label: panel interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:25
+#: src/components/my-jobs/interview-list.tsx:23
 msgid "myJobs.interviewType.panel"
 msgstr "Panel"
 
@@ -2323,7 +2341,7 @@ msgstr "Sammle alle interessanten Startups in einem Dashboard, statt mit Chrome-
 
 #. Employment type: part-time
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:14
+#: src/components/search/employment-type-modal.tsx:12
 msgid "search.employmentType.partTime"
 msgstr "Teilzeit"
 
@@ -2397,7 +2415,7 @@ msgstr "Zeitraum"
 
 #. Period label in salary override
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:128
+#: src/components/my-jobs/salary-override.tsx:126
 msgid "myJobs.detail.salary.period"
 msgstr "Zeitraum"
 
@@ -2409,7 +2427,7 @@ msgstr "Lösche dein Konto und alle zugehörigen Daten dauerhaft. Diese Aktion k
 
 #. Interview type label: phone screen
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:18
+#: src/components/my-jobs/interview-list.tsx:16
 msgid "myJobs.interviewType.phoneScreen"
 msgstr "Telefoninterview"
 
@@ -2501,21 +2519,15 @@ msgstr "Verweise uns auf eine beliebige Karriereseite oder ein Notion-Jobboard u
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:88
+#: src/components/search/job-detail-dialog.tsx:86
 msgid "search.detail.notFound"
 msgstr "Stelle nicht gefunden."
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:180
+#: src/components/my-jobs/my-job-detail-panel.tsx:178
 msgid "myJobs.detail.notFound"
 msgstr "Stellenanzeige nicht gefunden."
-
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: src/components/Pricing.tsx:101
-msgid "home.pricing.eyebrow"
-msgstr "Preise"
 
 #. Nav link: Pricing
 #. Nav link: Pricing
@@ -2523,6 +2535,12 @@ msgstr "Preise"
 #: src/components/Header.tsx:61
 #: src/components/MobileMenu.tsx:86
 msgid "common.nav.pricing"
+msgstr "Preise"
+
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:101
+msgid "home.pricing.eyebrow"
 msgstr "Preise"
 
 #. Privacy policy page eyebrow
@@ -2630,7 +2648,7 @@ msgstr "Vollständige Nutzungsbedingungen lesen"
 
 #. Sort option: recently updated
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:14
+#: src/components/my-jobs/sort-filter-bar.tsx:13
 msgid "myJobs.sort.recentlyUpdated"
 msgstr "Kürzlich aktualisiert"
 
@@ -2654,31 +2672,31 @@ msgstr "Region"
 
 #. Status group heading: rejected
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:34
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:32
 msgid "myJobs.group.rejected"
-msgstr "Abgelehnt"
-
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:443
-msgid "search.tracker.rejected"
 msgstr "Abgelehnt"
 
 #. Rejected status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:24
+#: src/components/my-jobs/status-badge.tsx:23
 msgid "myJobs.status.rejected"
 msgstr "Abgelehnt"
 
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:46
+#: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
+msgstr "Abgelehnt"
+
+#. Application tracker status: rejected
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:441
+msgid "search.tracker.rejected"
 msgstr "Abgelehnt"
 
 #. Status option in dropdown: rejected
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:38
+#: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.rejected"
 msgstr "Abgelehnt"
 
@@ -2788,20 +2806,20 @@ msgstr "Berufe"
 
 #. Sankey funnel node: interview round prefix
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:48
+#: src/components/my-jobs/sankey-funnel.tsx:47
 msgid "myJobs.funnel.round"
 msgstr "Runde"
+
+#. Salary override section heading
+#. js-lingui-explicit-id
+#: src/components/my-jobs/salary-override.tsx:76
+msgid "myJobs.detail.salary"
+msgstr "Gehalt"
 
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:171
 msgid "search.advanced.salary"
-msgstr "Gehalt"
-
-#. Salary override section heading
-#. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:78
-msgid "myJobs.detail.salary"
 msgstr "Gehalt"
 
 #. Salary display settings section heading
@@ -2848,25 +2866,25 @@ msgstr "Speichere deine Filter für schnelle Überprüfungen, ohne alles neu ein
 
 #. Status group heading: saved jobs
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:30
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:28
 msgid "myJobs.group.saved"
 msgstr "Gespeichert"
 
 #. Saved status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:20
+#: src/components/my-jobs/status-badge.tsx:19
 msgid "myJobs.status.saved"
 msgstr "Gespeichert"
 
 #. Sankey funnel node: saved jobs
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:42
+#: src/components/my-jobs/sankey-funnel.tsx:41
 msgid "myJobs.funnel.saved"
 msgstr "Gespeichert"
 
 #. Status option in dropdown: saved
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:34
+#: src/components/my-jobs/my-job-detail-panel.tsx:32
 msgid "myJobs.statusOption.saved"
 msgstr "Gespeichert"
 
@@ -2907,16 +2925,16 @@ msgstr "Speichern…"
 msgid "company.page.searchPlaceholder"
 msgstr "Suchen bei {0}..."
 
-#. Placeholder for company search in watchlist creation
-#. js-lingui-explicit-id
-#: src/components/watchlist/company-selector.tsx:91
-msgid "watchlists.companySelector.placeholder"
-msgstr "Unternehmen suchen..."
-
 #. Placeholder for company search in modal
 #. js-lingui-explicit-id
 #: src/components/watchlist/company-search-modal.tsx:212
 msgid "watchlists.companyModal.searchPlaceholder"
+msgstr "Unternehmen suchen..."
+
+#. Placeholder for company search in watchlist creation
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-selector.tsx:91
+msgid "watchlists.companySelector.placeholder"
 msgstr "Unternehmen suchen..."
 
 #. Placeholder for search input in all-languages modal
@@ -2925,17 +2943,17 @@ msgstr "Unternehmen suchen..."
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Sprachen suchen…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:149
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Standorte suchen..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:164
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Standorte suchen…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:149
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Standorte suchen..."
 
 #. Back to search results link on company page
 #. js-lingui-explicit-id
@@ -3015,17 +3033,17 @@ msgstr "Link senden"
 msgid "settings.account.password.send"
 msgstr "Link senden"
 
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Wird gesendet..."
-
 #. Resend button while sending
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:96
 msgid "auth.verify.resending"
 msgstr "Wird gesendet…"
+
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
+msgstr "Wird gesendet..."
 
 #. Reset password button while loading
 #. js-lingui-explicit-id
@@ -3041,7 +3059,7 @@ msgstr "Erfahrungsstufe"
 
 #. Short September label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:66
+#: src/components/my-jobs/activity-heatmap.tsx:65
 msgid "myJobs.heatmap.month.sep"
 msgstr "Sep"
 
@@ -3099,16 +3117,16 @@ msgstr "Einstellungen"
 #~ msgid "settings.billing.usage.unlimited"
 #~ msgstr "Unbegrenzt"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:346
-msgid "search.detail.showLessLocations"
-msgstr "Weniger anzeigen"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:350
 msgid "company.page.showLess"
+msgstr "Weniger anzeigen"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:344
+msgid "search.detail.showLessLocations"
 msgstr "Weniger anzeigen"
 
 #. Aria label to show password
@@ -3219,12 +3237,6 @@ msgstr "Zum Inhalt springen"
 msgid "error.title"
 msgstr "Etwas ist schiefgelaufen"
 
-#. Generic forgot password error
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:43
-msgid "auth.forgotPassword.error.generic"
-msgstr "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
-
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
@@ -3234,6 +3246,12 @@ msgstr "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
 #: src/components/search/request-company.tsx:19
 msgid "app.home.request.error.unknown"
 msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
+
+#. Generic forgot password error
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:43
+msgid "auth.forgotPassword.error.generic"
+msgstr "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
 
 #. Generic error creating watchlist
 #. js-lingui-explicit-id
@@ -3267,19 +3285,19 @@ msgstr "Kostenlos starten"
 
 #. Sort option: status
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:16
+#: src/components/my-jobs/sort-filter-bar.tsx:15
 msgid "myJobs.sort.status"
 msgstr "Status"
 
 #. Group by status option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:25
+#: src/components/my-jobs/sort-filter-bar.tsx:24
 msgid "myJobs.group.status"
 msgstr "Status"
 
 #. Status section heading
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:197
+#: src/components/my-jobs/my-job-detail-panel.tsx:195
 msgid "myJobs.detail.status"
 msgstr "Status"
 
@@ -3346,26 +3364,26 @@ msgstr "Zum hellen Modus wechseln"
 
 #. Interview type label: system design
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:22
+#: src/components/my-jobs/interview-list.tsx:20
 msgid "myJobs.interviewType.systemDesign"
 msgstr "System Design"
 
 #. Interview type label: technical interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:20
+#: src/components/my-jobs/interview-list.tsx:18
 msgid "myJobs.interviewType.technical"
 msgstr "Technisch"
-
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:388
-msgid "search.detail.technologies"
-msgstr "Technologien"
 
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:496
 msgid "search.bar.technologies"
+msgstr "Technologien"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:386
+msgid "search.detail.technologies"
 msgstr "Technologien"
 
 #. Add technology filter
@@ -3382,7 +3400,7 @@ msgstr "Technologie"
 
 #. Employment type: temporary
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:17
+#: src/components/search/employment-type-modal.tsx:15
 msgid "search.employmentType.temporary"
 msgstr "Befristet"
 
@@ -3590,7 +3608,7 @@ msgstr "Upgrade l\\u00e4uft\\u2026"
 
 #. Fallback username for watchlist owner
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:106
+#: src/components/watchlist/public-watchlist-search.tsx:109
 msgid "watchlists.explore.unknownUser"
 msgstr "Nutzer"
 
@@ -3638,19 +3656,19 @@ msgstr "E-Mail wird bestätigt…"
 
 #. Interview type label: video call
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:19
+#: src/components/my-jobs/interview-list.tsx:17
 msgid "myJobs.interviewType.videoCall"
 msgstr "Videoanruf"
 
 #. Link to the original job posting
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:185
+#: src/components/search/job-detail-dialog.tsx:183
 msgid "search.detail.viewPosting"
 msgstr "Stellenanzeige ansehen"
 
 #. Employment type: volunteer
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:18
+#: src/components/search/employment-type-modal.tsx:16
 msgid "search.employmentType.volunteer"
 msgstr "Ehrenamtlich"
 
@@ -3668,7 +3686,7 @@ msgstr "Watchlists"
 
 #. Back to watchlists link
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:257
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:288
 msgid "watchlists.view.back"
 msgstr "Watchlists"
 
@@ -3752,7 +3770,7 @@ msgstr "Wir nutzen eine Handvoll Drittanbieter für Anmeldung, Hosting und Speic
 
 #. Short Wednesday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:48
+#: src/components/my-jobs/activity-heatmap.tsx:47
 msgid "myJobs.heatmap.day.wed"
 msgstr "Mi"
 
@@ -3776,7 +3794,7 @@ msgstr "Jährlich"
 
 #. Yearly salary period option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:46
+#: src/components/my-jobs/salary-override.tsx:44
 msgid "myJobs.salary.yearly"
 msgstr "Jährlich"
 

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -98,20 +98,20 @@ msgstr "{0} employés"
 #. Count of additional watchlists not shown
 #. js-lingui-explicit-id
 #. placeholder {0}: total - results.length
-#: src/components/watchlist/public-watchlist-search.tsx:127
+#: src/components/watchlist/public-watchlist-search.tsx:130
 msgid "watchlists.explore.moreCount"
 msgstr "{0} de plus"
 
 #. Button to show remaining collapsed locations
 #. js-lingui-explicit-id
 #. placeholder {0}: locations.length - LOCATIONS_COLLAPSED
-#: src/components/search/job-detail-dialog.tsx:350
+#: src/components/search/job-detail-dialog.tsx:348
 msgid "search.detail.showMoreLocations"
 msgstr "{0} de plus"
 
 #. Heatmap tooltip for multiple applications
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:81
+#: src/components/my-jobs/activity-heatmap.tsx:80
 msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} candidatures le {date}"
 
@@ -129,7 +129,7 @@ msgstr "10 $ / mois"
 
 #. Heatmap tooltip for 1 application
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:80
+#: src/components/my-jobs/activity-heatmap.tsx:79
 msgid "myJobs.heatmap.tooltipOne"
 msgstr "1 candidature le {date}"
 
@@ -169,15 +169,21 @@ msgstr "actif"
 msgid "watchlists.companyModal.title"
 msgstr "Ajouter des entreprises"
 
+#. Link to add a description to the watchlist
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:379
+msgid "watchlists.view.addDescription"
+msgstr "Ajouter une description"
+
 #. Quick action tooltip: add interview round
 #. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:20
+#: src/components/my-jobs/quick-actions.tsx:19
 msgid "myJobs.action.addInterview"
 msgstr "Ajouter un entretien"
 
 #. Button to add an interview round
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:78
+#: src/components/my-jobs/interview-list.tsx:76
 msgid "myJobs.detail.addInterview"
 msgstr "Ajouter un entretien"
 
@@ -261,7 +267,7 @@ msgstr "Tous"
 
 #. Toggle to show jobs from all companies
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:329
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:407
 msgid "watchlists.view.anyCompany"
 msgstr "Toute entreprise"
 
@@ -282,7 +288,7 @@ msgstr "Code applicatif (MIT)"
 
 #. Link to application stats page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:265
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:263
 msgid "myJobs.viewStats"
 msgstr "Statistiques des candidatures"
 
@@ -312,7 +318,7 @@ msgstr "Suivi des candidatures"
 
 #. Application tracker section heading in job detail
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:246
+#: src/components/search/job-detail-dialog.tsx:244
 msgid "search.detail.applicationTracker"
 msgstr "Suivi de candidature"
 
@@ -324,31 +330,31 @@ msgstr "candidatures durant l'année écoulée"
 
 #. Status group heading: applied jobs
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:31
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:29
 msgid "myJobs.group.applied"
-msgstr "Postulé"
-
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:440
-msgid "search.tracker.applied"
 msgstr "Postulé"
 
 #. Applied status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:21
+#: src/components/my-jobs/status-badge.tsx:20
 msgid "myJobs.status.applied"
 msgstr "Postulé"
 
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:43
+#: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
+msgstr "Postulé"
+
+#. Application tracker status: applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:438
+msgid "search.tracker.applied"
 msgstr "Postulé"
 
 #. Status option in dropdown: applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:35
+#: src/components/my-jobs/my-job-detail-panel.tsx:33
 msgid "myJobs.statusOption.applied"
 msgstr "Postulé"
 
@@ -366,13 +372,13 @@ msgstr "Appliquer"
 
 #. Apply button linking to original job posting
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:295
+#: src/components/my-jobs/my-job-detail-panel.tsx:293
 msgid "search.detail.apply"
 msgstr "Postuler"
 
 #. Short April label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:61
+#: src/components/my-jobs/activity-heatmap.tsx:60
 msgid "myJobs.heatmap.month.apr"
 msgstr "Avr"
 
@@ -396,7 +402,7 @@ msgstr "30 caractères maximum"
 
 #. Short August label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:65
+#: src/components/my-jobs/activity-heatmap.tsx:64
 msgid "myJobs.heatmap.month.aug"
 msgstr "Aoû"
 
@@ -406,16 +412,16 @@ msgstr "Aoû"
 msgid "settings.account.username.available"
 msgstr "Disponible"
 
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Retour à la connexion"
-
 #. Link back to sign-in after failed verification
 #. js-lingui-explicit-id
 #: app/[lang]/verify-email/page.tsx:68
 msgid "auth.verify.error.backToSignIn"
+msgstr "Retour à la connexion"
+
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
 msgstr "Retour à la connexion"
 
 #. Link back to sign-in from forgot password
@@ -432,7 +438,7 @@ msgstr "Retour à la connexion"
 
 #. Interview type label: behavioral interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:23
+#: src/components/my-jobs/interview-list.tsx:21
 msgid "myJobs.interviewType.behavioral"
 msgstr "Comportemental"
 
@@ -498,21 +504,21 @@ msgstr "Modifie ton mot de passe via un lien e-mail sécurisé."
 
 #. Placeholder in status change dropdown
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:63
+#: src/components/my-jobs/my-job-detail-panel.tsx:61
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Changer…"
-
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "Vérifiez votre e-mail"
 
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
 msgstr "Vérifie ton e-mail"
+
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
+msgstr "Vérifiez votre e-mail"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -566,14 +572,14 @@ msgstr "Réinitialiser"
 
 #. Button to remove all companies from watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:347
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:425
 msgid "watchlists.view.clearAllCompanies"
 msgstr "Tout effacer"
 
 #. Button to clear all active search filters
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:455
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:533
 #: src/components/search/search-toolbar.tsx:282
 msgid "search.filters.clearAll"
 msgstr "Tout effacer"
@@ -584,9 +590,15 @@ msgstr "Tout effacer"
 msgid "watchlists.companyModal.clearAll"
 msgstr "Tout effacer"
 
+#. Tooltip for clicking to edit watchlist description
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:369
+msgid "watchlists.view.editDescription"
+msgstr "Cliquer pour modifier la description"
+
 #. Tooltip for clicking to edit watchlist title
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:289
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:320
 msgid "watchlists.view.editTitle"
 msgstr "Cliquer pour renommer"
 
@@ -616,7 +628,7 @@ msgstr "Fermé"
 
 #. Interview type label: coding challenge
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:21
+#: src/components/my-jobs/interview-list.tsx:19
 msgid "myJobs.interviewType.coding"
 msgstr "Coding"
 
@@ -652,19 +664,19 @@ msgstr "Entreprises suivies"
 
 #. Button to open company search modal
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:318
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:396
 msgid "watchlists.view.addCompany"
 msgstr "Entreprise"
 
 #. Sort option: company name
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:17
+#: src/components/my-jobs/sort-filter-bar.tsx:16
 msgid "myJobs.sort.company"
 msgstr "Entreprise"
 
 #. Group by company option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:24
+#: src/components/my-jobs/sort-filter-bar.tsx:23
 msgid "myJobs.group.company"
 msgstr "Entreprise"
 
@@ -718,14 +730,14 @@ msgstr "Contact"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
+#: src/components/LicenseContent.tsx:18
+msgid "license.toc.title"
 msgstr "Sommaire"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
-msgid "license.toc.title"
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Sommaire"
 
 #. Button to continue to app after verification
@@ -754,7 +766,7 @@ msgstr "Continuer avec LinkedIn"
 
 #. Employment type: contract
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:15
+#: src/components/search/employment-type-modal.tsx:13
 msgid "search.employmentType.contract"
 msgstr "Freelance"
 
@@ -834,7 +846,7 @@ msgstr "Devise"
 
 #. Currency label in salary override
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:108
+#: src/components/my-jobs/salary-override.tsx:106
 msgid "myJobs.detail.salary.currency"
 msgstr "Devise"
 
@@ -858,13 +870,13 @@ msgstr "Sombre"
 
 #. Sort option: date saved
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:15
+#: src/components/my-jobs/sort-filter-bar.tsx:14
 msgid "myJobs.sort.dateSaved"
 msgstr "Date d'enregistrement"
 
 #. Short December label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:69
+#: src/components/my-jobs/activity-heatmap.tsx:68
 msgid "myJobs.heatmap.month.dec"
 msgstr "Déc"
 
@@ -882,7 +894,7 @@ msgstr "Supprimer"
 
 #. Delete interview button
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:165
+#: src/components/my-jobs/interview-list.tsx:163
 msgid "myJobs.interview.delete"
 msgstr "Supprimer"
 
@@ -910,6 +922,12 @@ msgstr "Supprimer la liste de suivi ?"
 msgid "settings.account.delete.deleting"
 msgstr "Suppression…"
 
+#. Placeholder for watchlist description textarea
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:361
+msgid "watchlists.view.descriptionPlaceholder"
+msgstr "Décrire cette watchlist …"
+
 #. Cookie banner details button
 #. js-lingui-explicit-id
 #: src/components/CookieBanner.tsx:60
@@ -918,7 +936,7 @@ msgstr "Détails"
 
 #. Collapsible section heading for extracted job details
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:378
+#: src/components/search/job-detail-dialog.tsx:376
 msgid "search.detail.details"
 msgstr "Détails"
 
@@ -1020,7 +1038,7 @@ msgstr "E-mail vérifié"
 
 #. Title for the employment type selection modal
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:49
+#: src/components/search/employment-type-modal.tsx:47
 msgid "search.employmentTypeModal.title"
 msgstr "Type d'emploi"
 
@@ -1150,7 +1168,7 @@ msgstr "Fonctionnalités"
 
 #. Short February label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:59
+#: src/components/my-jobs/activity-heatmap.tsx:58
 msgid "myJobs.heatmap.month.feb"
 msgstr "Fév"
 
@@ -1164,15 +1182,15 @@ msgstr "Filtre"
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:103
-#: src/components/search/job-detail-dialog.tsx:291
-#: src/components/search/job-detail-dialog.tsx:369
+#: src/components/search/job-detail-dialog.tsx:101
+#: src/components/search/job-detail-dialog.tsx:289
+#: src/components/search/job-detail-dialog.tsx:367
 msgid "search.detail.filterByPrefix"
 msgstr "Filtrer par"
 
 #. Tooltip for salary filter pill
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:225
+#: src/components/search/job-detail-dialog.tsx:223
 msgid "search.detail.filterBySalary"
 msgstr "Filtrer par cette fourchette salariale"
 
@@ -1280,7 +1298,7 @@ msgstr "Gratuit"
 
 #. Short Friday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:50
+#: src/components/my-jobs/activity-heatmap.tsx:49
 msgid "myJobs.heatmap.day.fri"
 msgstr "Ven"
 
@@ -1292,7 +1310,7 @@ msgstr "Recherche d'emploi complète"
 
 #. Employment type: full-time
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:13
+#: src/components/search/employment-type-modal.tsx:11
 msgid "search.employmentType.fullTime"
 msgstr "Temps plein"
 
@@ -1356,7 +1374,7 @@ msgstr "Masquer le mot de passe"
 
 #. Interview type label: hiring manager round
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:26
+#: src/components/my-jobs/interview-list.tsx:24
 msgid "myJobs.interviewType.hiringManager"
 msgstr "Responsable RH"
 
@@ -1368,7 +1386,7 @@ msgstr "Horaire"
 
 #. Hourly salary period option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:48
+#: src/components/my-jobs/salary-override.tsx:46
 msgid "myJobs.salary.hourly"
 msgstr "Horaire"
 
@@ -1483,43 +1501,43 @@ msgstr "L'entrée est trop courte."
 
 #. Employment type: internship
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:16
+#: src/components/search/employment-type-modal.tsx:14
 msgid "search.employmentType.internship"
 msgstr "Stage"
 
 #. Interview type label: general interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:17
+#: src/components/my-jobs/interview-list.tsx:15
 msgid "myJobs.interviewType.interview"
 msgstr "Entretien"
 
 #. Status group heading: interviewing
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:32
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:30
 msgid "myJobs.group.interviewing"
-msgstr "En entretien"
-
-#. Application tracker status: interviewing
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:441
-msgid "search.tracker.interviewing"
 msgstr "En entretien"
 
 #. Interviewing status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:22
+#: src/components/my-jobs/status-badge.tsx:21
 msgid "myJobs.status.interviewing"
+msgstr "En entretien"
+
+#. Application tracker status: interviewing
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:439
+msgid "search.tracker.interviewing"
 msgstr "En entretien"
 
 #. Status option in dropdown: interviewing
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:36
+#: src/components/my-jobs/my-job-detail-panel.tsx:34
 msgid "myJobs.statusOption.interviewing"
 msgstr "En entretien"
 
 #. Interviews section heading
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:51
+#: src/components/my-jobs/interview-list.tsx:49
 msgid "myJobs.detail.interviews"
 msgstr "Entretiens"
 
@@ -1537,7 +1555,7 @@ msgstr "Lien de vérification invalide"
 
 #. Short January label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:58
+#: src/components/my-jobs/activity-heatmap.tsx:57
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
@@ -1549,7 +1567,7 @@ msgstr "offre"
 
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:107
+#: src/components/watchlist/public-watchlist-search.tsx:110
 msgid "watchlists.explore.jobSingular"
 msgstr "offre"
 
@@ -1561,13 +1579,13 @@ msgstr "Données d'emploi (CC BY-NC 4.0)"
 
 #. Job detail panel title
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:73
+#: src/components/search/job-detail-dialog.tsx:71
 msgid "search.detail.title"
 msgstr "Détails de l'offre"
 
 #. Job detail panel title in My Jobs
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:160
+#: src/components/my-jobs/my-job-detail-panel.tsx:158
 msgid "myJobs.detail.title"
 msgstr "Détails du poste"
 
@@ -1613,33 +1631,33 @@ msgstr "Job Seek est en cours de développement. Restez à l'écoute pour les mi
 msgid "license.hero.description"
 msgstr "Le code source de Job Seek est ouvert sous licence MIT. Les données d'emploi que nous collectons et enrichissons sont sous Creative Commons BY-NC 4.0. Tu trouveras ci-dessous un résumé en langage clair — consulte les licences complètes pour les termes exacts."
 
-#. Job count label in watchlist view
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:210
-msgid "watchlists.jobList.jobCount"
-msgstr "offres"
-
 #. Plural job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:32
 msgid "watchlists.card.jobPlural"
 msgstr "offres"
 
+#. Job count label in watchlist view
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-job-list.tsx:210
+msgid "watchlists.jobList.jobCount"
+msgstr "offres"
+
 #. Plural job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:108
+#: src/components/watchlist/public-watchlist-search.tsx:111
 msgid "watchlists.explore.jobPlural"
 msgstr "offres"
 
 #. Short July label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:64
+#: src/components/my-jobs/activity-heatmap.tsx:63
 msgid "myJobs.heatmap.month.jul"
 msgstr "Jul"
 
 #. Short June label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:63
+#: src/components/my-jobs/activity-heatmap.tsx:62
 msgid "myJobs.heatmap.month.jun"
 msgstr "Jun"
 
@@ -1779,16 +1797,16 @@ msgstr "Lieu"
 msgid "search.advanced.location"
 msgstr "Lieu"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:303
-msgid "search.detail.locations"
-msgstr "Lieux"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:531
 msgid "search.bar.locations"
+msgstr "Lieux"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:301
+msgid "search.detail.locations"
 msgstr "Lieux"
 
 #. Login button label
@@ -1837,49 +1855,49 @@ msgstr "Gère tes comptes sociaux liés."
 
 #. Short March label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:60
+#: src/components/my-jobs/activity-heatmap.tsx:59
 msgid "myJobs.heatmap.month.mar"
 msgstr "Mar"
 
 #. Quick action tooltip: mark job as applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:19
+#: src/components/my-jobs/quick-actions.tsx:18
 msgid "myJobs.action.markApplied"
 msgstr "Marquer comme postulé"
 
 #. Quick action tooltip: mark job as offered
 #. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:22
+#: src/components/my-jobs/quick-actions.tsx:21
 msgid "myJobs.action.markOffer"
 msgstr "Marquer comme offre"
 
 #. Quick action tooltip: mark job as rejected
 #. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:21
+#: src/components/my-jobs/quick-actions.tsx:20
 msgid "myJobs.action.markRejected"
 msgstr "Marquer comme refusé"
 
 #. Maximum salary label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:45
+#: src/components/my-jobs/salary-override.tsx:43
 msgid "myJobs.salary.max"
 msgstr "Max"
 
 #. Short May label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:62
+#: src/components/my-jobs/activity-heatmap.tsx:61
 msgid "myJobs.heatmap.month.may"
 msgstr "Mai"
 
 #. Minimum salary label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:44
+#: src/components/my-jobs/salary-override.tsx:42
 msgid "myJobs.salary.min"
 msgstr "Min"
 
 #. Singular mirror count
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:115
+#: src/components/watchlist/public-watchlist-search.tsx:118
 msgid "watchlists.explore.mirrorSingular"
 msgstr "copie"
 
@@ -1899,13 +1917,13 @@ msgstr "Copiez n'importe quelle liste publique pour la personnaliser — modifie
 
 #. Plural mirror count
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:116
+#: src/components/watchlist/public-watchlist-search.tsx:119
 msgid "watchlists.explore.mirrorPlural"
 msgstr "copies"
 
 #. Short Monday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:46
+#: src/components/my-jobs/activity-heatmap.tsx:45
 msgid "myJobs.heatmap.day.mon"
 msgstr "Lun"
 
@@ -1917,7 +1935,7 @@ msgstr "Mensuel"
 
 #. Monthly salary period option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:47
+#: src/components/my-jobs/salary-override.tsx:45
 msgid "myJobs.salary.monthly"
 msgstr "Mensuel"
 
@@ -1947,7 +1965,7 @@ msgstr "Mes emplois"
 
 #. Title of the My Jobs page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:254
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:252
 msgid "myJobs.title"
 msgstr "Mes emplois"
 
@@ -2007,7 +2025,7 @@ msgstr "Nouveau mot de passe"
 
 #. Heatmap tooltip when no applications on a date
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:79
+#: src/components/my-jobs/activity-heatmap.tsx:78
 msgid "myJobs.heatmap.tooltipNone"
 msgstr "Aucune candidature le {date}"
 
@@ -2041,16 +2059,16 @@ msgstr "Aucune offre trouvée."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Aucune langue ne correspond à votre recherche."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:170
-msgid "search.locationModal.noResults"
-msgstr "Aucun lieu ne correspond à votre recherche."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:185
 msgid "company.locationModal.noResults"
+msgstr "Aucun lieu ne correspond à votre recherche."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:170
+msgid "search.locationModal.noResults"
 msgstr "Aucun lieu ne correspond à votre recherche."
 
 #. No postings found message on company page
@@ -2061,7 +2079,7 @@ msgstr "Aucune offre correspondante trouvée."
 
 #. Sankey funnel node label prefix: no response
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:47
+#: src/components/my-jobs/sankey-funnel.tsx:46
 msgid "myJobs.funnel.noResponse"
 msgstr "Sans réponse"
 
@@ -2091,7 +2109,7 @@ msgstr "Aucune technologie trouvée."
 
 #. Empty state message when no tracked jobs
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:237
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:235
 msgid "myJobs.empty"
 msgstr "Aucun emploi suivi pour le moment. Enregistrez des offres depuis les résultats de recherche pour commencer à suivre vos candidatures."
 
@@ -2103,7 +2121,7 @@ msgstr "Aucune garantie — utilisation à tes risques et périls."
 
 #. No results message when searching public watchlists
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:137
+#: src/components/watchlist/public-watchlist-search.tsx:140
 msgid "watchlists.explore.noResults"
 msgstr "Aucune liste de suivi trouvée."
 
@@ -2113,16 +2131,16 @@ msgstr "Aucune liste de suivi trouvée."
 msgid "watchlists.page.empty"
 msgstr "Aucune liste de suivi pour l'instant. Créez-en une pour suivre les offres de vos entreprises préférées."
 
-#. Application tracker status: not applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:439
-msgid "search.tracker.notApplied"
-msgstr "Non postulé"
-
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:45
+#: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
+msgstr "Non postulé"
+
+#. Application tracker status: not applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:437
+msgid "search.tracker.notApplied"
 msgstr "Non postulé"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2137,7 +2155,7 @@ msgstr "Remarque : Nous n'avons pas pu créer un ticket de suivi, mais votre dem
 
 #. Short November label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:68
+#: src/components/my-jobs/activity-heatmap.tsx:67
 msgid "myJobs.heatmap.month.nov"
 msgstr "Nov"
 
@@ -2149,37 +2167,37 @@ msgstr "Métier"
 
 #. Short October label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:67
+#: src/components/my-jobs/activity-heatmap.tsx:66
 msgid "myJobs.heatmap.month.oct"
 msgstr "Oct"
 
-#. Application tracker status: offer
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:442
-msgid "search.tracker.offer"
-msgstr "Offre"
-
 #. Offered status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:23
+#: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
+msgstr "Offre"
+
+#. Application tracker status: offer
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:440
+msgid "search.tracker.offer"
 msgstr "Offre"
 
 #. Status group heading: offered
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:33
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:31
 msgid "myJobs.group.offered"
 msgstr "Offre"
 
 #. Sankey funnel node: offered
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:44
+#: src/components/my-jobs/sankey-funnel.tsx:43
 msgid "myJobs.funnel.offered"
 msgstr "Offre"
 
 #. Status option in dropdown: offered
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:37
+#: src/components/my-jobs/my-job-detail-panel.tsx:35
 msgid "myJobs.statusOption.offered"
 msgstr "Offre"
 
@@ -2209,7 +2227,7 @@ msgstr "Uniquement des lettres minuscules, des chiffres et des tirets (pas au d�
 
 #. Interview type label: onsite interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:24
+#: src/components/my-jobs/interview-list.tsx:22
 msgid "myJobs.interviewType.onsite"
 msgstr "Sur site"
 
@@ -2257,7 +2275,7 @@ msgstr "Original"
 
 #. Interview type label: other/unspecified
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:27
+#: src/components/my-jobs/interview-list.tsx:25
 msgid "myJobs.interviewType.other"
 msgstr "Autre"
 
@@ -2281,26 +2299,26 @@ msgstr "Notre position sur l'automatisation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Aperçu"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Aperçu"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Sommaire de la page"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Aperçu"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Sommaire de la page"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Sommaire de la page"
 
 #. Heading shown on the 404 page
@@ -2311,7 +2329,7 @@ msgstr "Page introuvable"
 
 #. Interview type label: panel interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:25
+#: src/components/my-jobs/interview-list.tsx:23
 msgid "myJobs.interviewType.panel"
 msgstr "Panel"
 
@@ -2323,7 +2341,7 @@ msgstr "Regroupe toutes les startups intéressantes dans un seul tableau de bord
 
 #. Employment type: part-time
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:14
+#: src/components/search/employment-type-modal.tsx:12
 msgid "search.employmentType.partTime"
 msgstr "Temps partiel"
 
@@ -2397,7 +2415,7 @@ msgstr "Période"
 
 #. Period label in salary override
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:128
+#: src/components/my-jobs/salary-override.tsx:126
 msgid "myJobs.detail.salary.period"
 msgstr "Période"
 
@@ -2409,7 +2427,7 @@ msgstr "Supprime définitivement ton compte et toutes les données associées. C
 
 #. Interview type label: phone screen
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:18
+#: src/components/my-jobs/interview-list.tsx:16
 msgid "myJobs.interviewType.phoneScreen"
 msgstr "Entretien téléphonique"
 
@@ -2501,21 +2519,15 @@ msgstr "Indique-nous n'importe quelle page carrières ou tableau d'offres Notion
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:88
+#: src/components/search/job-detail-dialog.tsx:86
 msgid "search.detail.notFound"
 msgstr "Offre non trouvée."
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:180
+#: src/components/my-jobs/my-job-detail-panel.tsx:178
 msgid "myJobs.detail.notFound"
 msgstr "Offre introuvable."
-
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: src/components/Pricing.tsx:101
-msgid "home.pricing.eyebrow"
-msgstr "Tarifs"
 
 #. Nav link: Pricing
 #. Nav link: Pricing
@@ -2523,6 +2535,12 @@ msgstr "Tarifs"
 #: src/components/Header.tsx:61
 #: src/components/MobileMenu.tsx:86
 msgid "common.nav.pricing"
+msgstr "Tarifs"
+
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:101
+msgid "home.pricing.eyebrow"
 msgstr "Tarifs"
 
 #. Privacy policy page eyebrow
@@ -2630,7 +2648,7 @@ msgstr "Lire les conditions d'utilisation complètes"
 
 #. Sort option: recently updated
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:14
+#: src/components/my-jobs/sort-filter-bar.tsx:13
 msgid "myJobs.sort.recentlyUpdated"
 msgstr "Récemment mis à jour"
 
@@ -2654,31 +2672,31 @@ msgstr "Région"
 
 #. Status group heading: rejected
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:34
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:32
 msgid "myJobs.group.rejected"
-msgstr "Refusé"
-
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:443
-msgid "search.tracker.rejected"
 msgstr "Refusé"
 
 #. Rejected status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:24
+#: src/components/my-jobs/status-badge.tsx:23
 msgid "myJobs.status.rejected"
 msgstr "Refusé"
 
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:46
+#: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
+msgstr "Refusé"
+
+#. Application tracker status: rejected
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:441
+msgid "search.tracker.rejected"
 msgstr "Refusé"
 
 #. Status option in dropdown: rejected
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:38
+#: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.rejected"
 msgstr "Refusé"
 
@@ -2788,20 +2806,20 @@ msgstr "Rôles"
 
 #. Sankey funnel node: interview round prefix
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:48
+#: src/components/my-jobs/sankey-funnel.tsx:47
 msgid "myJobs.funnel.round"
 msgstr "Tour"
+
+#. Salary override section heading
+#. js-lingui-explicit-id
+#: src/components/my-jobs/salary-override.tsx:76
+msgid "myJobs.detail.salary"
+msgstr "Salaire"
 
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:171
 msgid "search.advanced.salary"
-msgstr "Salaire"
-
-#. Salary override section heading
-#. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:78
-msgid "myJobs.detail.salary"
 msgstr "Salaire"
 
 #. Salary display settings section heading
@@ -2848,25 +2866,25 @@ msgstr "Enregistre tes filtres pour des recherches rapides sans tout retaper à 
 
 #. Status group heading: saved jobs
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:30
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:28
 msgid "myJobs.group.saved"
 msgstr "Enregistré"
 
 #. Saved status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:20
+#: src/components/my-jobs/status-badge.tsx:19
 msgid "myJobs.status.saved"
 msgstr "Enregistré"
 
 #. Sankey funnel node: saved jobs
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:42
+#: src/components/my-jobs/sankey-funnel.tsx:41
 msgid "myJobs.funnel.saved"
 msgstr "Enregistré"
 
 #. Status option in dropdown: saved
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:34
+#: src/components/my-jobs/my-job-detail-panel.tsx:32
 msgid "myJobs.statusOption.saved"
 msgstr "Enregistré"
 
@@ -2907,16 +2925,16 @@ msgstr "Enregistrement…"
 msgid "company.page.searchPlaceholder"
 msgstr "Rechercher chez {0}..."
 
-#. Placeholder for company search in watchlist creation
-#. js-lingui-explicit-id
-#: src/components/watchlist/company-selector.tsx:91
-msgid "watchlists.companySelector.placeholder"
-msgstr "Rechercher des entreprises..."
-
 #. Placeholder for company search in modal
 #. js-lingui-explicit-id
 #: src/components/watchlist/company-search-modal.tsx:212
 msgid "watchlists.companyModal.searchPlaceholder"
+msgstr "Rechercher des entreprises..."
+
+#. Placeholder for company search in watchlist creation
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-selector.tsx:91
+msgid "watchlists.companySelector.placeholder"
 msgstr "Rechercher des entreprises..."
 
 #. Placeholder for search input in all-languages modal
@@ -2925,17 +2943,17 @@ msgstr "Rechercher des entreprises..."
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Rechercher des langues…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:149
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Rechercher des lieux..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:164
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Rechercher des lieux…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:149
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Rechercher des lieux..."
 
 #. Back to search results link on company page
 #. js-lingui-explicit-id
@@ -3015,16 +3033,16 @@ msgstr "Envoyer le lien"
 msgid "settings.account.password.send"
 msgstr "Envoyer le lien"
 
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Envoi en cours..."
-
 #. Resend button while sending
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:96
 msgid "auth.verify.resending"
+msgstr "Envoi en cours..."
+
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
 msgstr "Envoi en cours..."
 
 #. Reset password button while loading
@@ -3041,7 +3059,7 @@ msgstr "Niveau d'expérience"
 
 #. Short September label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:66
+#: src/components/my-jobs/activity-heatmap.tsx:65
 msgid "myJobs.heatmap.month.sep"
 msgstr "Sep"
 
@@ -3099,16 +3117,16 @@ msgstr "Paramètres"
 #~ msgid "settings.billing.usage.unlimited"
 #~ msgstr "Illimité"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:346
-msgid "search.detail.showLessLocations"
-msgstr "Afficher moins"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:350
 msgid "company.page.showLess"
+msgstr "Afficher moins"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:344
+msgid "search.detail.showLessLocations"
 msgstr "Afficher moins"
 
 #. Aria label to show password
@@ -3219,12 +3237,6 @@ msgstr "Aller au contenu"
 msgid "error.title"
 msgstr "Une erreur est survenue"
 
-#. Generic forgot password error
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:43
-msgid "auth.forgotPassword.error.generic"
-msgstr "Une erreur est survenue. Veuillez réessayer."
-
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
@@ -3234,6 +3246,12 @@ msgstr "Une erreur est survenue. Veuillez réessayer."
 #: src/components/search/request-company.tsx:19
 msgid "app.home.request.error.unknown"
 msgstr "Une erreur s'est produite. Veuillez réessayer."
+
+#. Generic forgot password error
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:43
+msgid "auth.forgotPassword.error.generic"
+msgstr "Une erreur est survenue. Veuillez réessayer."
 
 #. Generic error creating watchlist
 #. js-lingui-explicit-id
@@ -3267,19 +3285,19 @@ msgstr "Commencer gratuitement"
 
 #. Sort option: status
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:16
+#: src/components/my-jobs/sort-filter-bar.tsx:15
 msgid "myJobs.sort.status"
 msgstr "Statut"
 
 #. Group by status option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:25
+#: src/components/my-jobs/sort-filter-bar.tsx:24
 msgid "myJobs.group.status"
 msgstr "Statut"
 
 #. Status section heading
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:197
+#: src/components/my-jobs/my-job-detail-panel.tsx:195
 msgid "myJobs.detail.status"
 msgstr "Statut"
 
@@ -3346,26 +3364,26 @@ msgstr "Passer au mode clair"
 
 #. Interview type label: system design
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:22
+#: src/components/my-jobs/interview-list.tsx:20
 msgid "myJobs.interviewType.systemDesign"
 msgstr "System Design"
 
 #. Interview type label: technical interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:20
+#: src/components/my-jobs/interview-list.tsx:18
 msgid "myJobs.interviewType.technical"
 msgstr "Technique"
-
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:388
-msgid "search.detail.technologies"
-msgstr "Technologies"
 
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:496
 msgid "search.bar.technologies"
+msgstr "Technologies"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:386
+msgid "search.detail.technologies"
 msgstr "Technologies"
 
 #. Add technology filter
@@ -3382,7 +3400,7 @@ msgstr "Technologie"
 
 #. Employment type: temporary
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:17
+#: src/components/search/employment-type-modal.tsx:15
 msgid "search.employmentType.temporary"
 msgstr "Temporaire"
 
@@ -3590,7 +3608,7 @@ msgstr "Mise à jour…"
 
 #. Fallback username for watchlist owner
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:106
+#: src/components/watchlist/public-watchlist-search.tsx:109
 msgid "watchlists.explore.unknownUser"
 msgstr "utilisateur"
 
@@ -3638,19 +3656,19 @@ msgstr "Vérification de ton e-mail…"
 
 #. Interview type label: video call
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:19
+#: src/components/my-jobs/interview-list.tsx:17
 msgid "myJobs.interviewType.videoCall"
 msgstr "Appel vidéo"
 
 #. Link to the original job posting
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:185
+#: src/components/search/job-detail-dialog.tsx:183
 msgid "search.detail.viewPosting"
 msgstr "Voir l'offre"
 
 #. Employment type: volunteer
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:18
+#: src/components/search/employment-type-modal.tsx:16
 msgid "search.employmentType.volunteer"
 msgstr "Bénévolat"
 
@@ -3668,7 +3686,7 @@ msgstr "Listes de suivi"
 
 #. Back to watchlists link
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:257
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:288
 msgid "watchlists.view.back"
 msgstr "Listes de suivi"
 
@@ -3752,7 +3770,7 @@ msgstr "Nous utilisons quelques services tiers pour la connexion, l’hébergeme
 
 #. Short Wednesday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:48
+#: src/components/my-jobs/activity-heatmap.tsx:47
 msgid "myJobs.heatmap.day.wed"
 msgstr "Mer"
 
@@ -3776,7 +3794,7 @@ msgstr "Annuel"
 
 #. Yearly salary period option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:46
+#: src/components/my-jobs/salary-override.tsx:44
 msgid "myJobs.salary.yearly"
 msgstr "Annuel"
 

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -98,20 +98,20 @@ msgstr "{0} dipendenti"
 #. Count of additional watchlists not shown
 #. js-lingui-explicit-id
 #. placeholder {0}: total - results.length
-#: src/components/watchlist/public-watchlist-search.tsx:127
+#: src/components/watchlist/public-watchlist-search.tsx:130
 msgid "watchlists.explore.moreCount"
 msgstr "{0} in più"
 
 #. Button to show remaining collapsed locations
 #. js-lingui-explicit-id
 #. placeholder {0}: locations.length - LOCATIONS_COLLAPSED
-#: src/components/search/job-detail-dialog.tsx:350
+#: src/components/search/job-detail-dialog.tsx:348
 msgid "search.detail.showMoreLocations"
 msgstr "{0} in più"
 
 #. Heatmap tooltip for multiple applications
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:81
+#: src/components/my-jobs/activity-heatmap.tsx:80
 msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} candidature il {date}"
 
@@ -129,7 +129,7 @@ msgstr "10 $ / mese"
 
 #. Heatmap tooltip for 1 application
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:80
+#: src/components/my-jobs/activity-heatmap.tsx:79
 msgid "myJobs.heatmap.tooltipOne"
 msgstr "1 candidatura il {date}"
 
@@ -169,15 +169,21 @@ msgstr "attivo"
 msgid "watchlists.companyModal.title"
 msgstr "Aggiungi aziende"
 
+#. Link to add a description to the watchlist
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:379
+msgid "watchlists.view.addDescription"
+msgstr "Aggiungi descrizione"
+
 #. Quick action tooltip: add interview round
 #. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:20
+#: src/components/my-jobs/quick-actions.tsx:19
 msgid "myJobs.action.addInterview"
 msgstr "Aggiungi colloquio"
 
 #. Button to add an interview round
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:78
+#: src/components/my-jobs/interview-list.tsx:76
 msgid "myJobs.detail.addInterview"
 msgstr "Aggiungi colloquio"
 
@@ -261,7 +267,7 @@ msgstr "Qualsiasi"
 
 #. Toggle to show jobs from all companies
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:329
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:407
 msgid "watchlists.view.anyCompany"
 msgstr "Qualsiasi azienda"
 
@@ -282,7 +288,7 @@ msgstr "Codice dell'applicazione (MIT)"
 
 #. Link to application stats page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:265
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:263
 msgid "myJobs.viewStats"
 msgstr "Statistiche candidature"
 
@@ -312,7 +318,7 @@ msgstr "Tracker delle candidature"
 
 #. Application tracker section heading in job detail
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:246
+#: src/components/search/job-detail-dialog.tsx:244
 msgid "search.detail.applicationTracker"
 msgstr "Monitoraggio candidatura"
 
@@ -324,31 +330,31 @@ msgstr "candidature nell'ultimo anno"
 
 #. Status group heading: applied jobs
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:31
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:29
 msgid "myJobs.group.applied"
-msgstr "Candidato"
-
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:440
-msgid "search.tracker.applied"
 msgstr "Candidato"
 
 #. Applied status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:21
+#: src/components/my-jobs/status-badge.tsx:20
 msgid "myJobs.status.applied"
 msgstr "Candidato"
 
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:43
+#: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
+msgstr "Candidato"
+
+#. Application tracker status: applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:438
+msgid "search.tracker.applied"
 msgstr "Candidato"
 
 #. Status option in dropdown: applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:35
+#: src/components/my-jobs/my-job-detail-panel.tsx:33
 msgid "myJobs.statusOption.applied"
 msgstr "Candidato"
 
@@ -366,13 +372,13 @@ msgstr "Applica"
 
 #. Apply button linking to original job posting
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:295
+#: src/components/my-jobs/my-job-detail-panel.tsx:293
 msgid "search.detail.apply"
 msgstr "Candidati"
 
 #. Short April label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:61
+#: src/components/my-jobs/activity-heatmap.tsx:60
 msgid "myJobs.heatmap.month.apr"
 msgstr "Apr"
 
@@ -396,7 +402,7 @@ msgstr "Massimo 30 caratteri"
 
 #. Short August label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:65
+#: src/components/my-jobs/activity-heatmap.tsx:64
 msgid "myJobs.heatmap.month.aug"
 msgstr "Ago"
 
@@ -406,16 +412,16 @@ msgstr "Ago"
 msgid "settings.account.username.available"
 msgstr "Disponibile"
 
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Torna all'accesso"
-
 #. Link back to sign-in after failed verification
 #. js-lingui-explicit-id
 #: app/[lang]/verify-email/page.tsx:68
 msgid "auth.verify.error.backToSignIn"
+msgstr "Torna all'accesso"
+
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
 msgstr "Torna all'accesso"
 
 #. Link back to sign-in from forgot password
@@ -432,7 +438,7 @@ msgstr "Torna al login"
 
 #. Interview type label: behavioral interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:23
+#: src/components/my-jobs/interview-list.tsx:21
 msgid "myJobs.interviewType.behavioral"
 msgstr "Comportamentale"
 
@@ -498,21 +504,21 @@ msgstr "Cambia la tua password tramite un link email sicuro."
 
 #. Placeholder in status change dropdown
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:63
+#: src/components/my-jobs/my-job-detail-panel.tsx:61
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Cambia…"
-
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "Controlla la tua e-mail"
 
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
 msgstr "Controlla la tua email"
+
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
+msgstr "Controlla la tua e-mail"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -566,14 +572,14 @@ msgstr "Reimposta"
 
 #. Button to remove all companies from watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:347
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:425
 msgid "watchlists.view.clearAllCompanies"
 msgstr "Rimuovi tutti"
 
 #. Button to clear all active search filters
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:455
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:533
 #: src/components/search/search-toolbar.tsx:282
 msgid "search.filters.clearAll"
 msgstr "Cancella tutto"
@@ -584,9 +590,15 @@ msgstr "Cancella tutto"
 msgid "watchlists.companyModal.clearAll"
 msgstr "Rimuovi tutti"
 
+#. Tooltip for clicking to edit watchlist description
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:369
+msgid "watchlists.view.editDescription"
+msgstr "Clicca per modificare la descrizione"
+
 #. Tooltip for clicking to edit watchlist title
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:289
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:320
 msgid "watchlists.view.editTitle"
 msgstr "Clicca per rinominare"
 
@@ -616,7 +628,7 @@ msgstr "Chiuso"
 
 #. Interview type label: coding challenge
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:21
+#: src/components/my-jobs/interview-list.tsx:19
 msgid "myJobs.interviewType.coding"
 msgstr "Coding"
 
@@ -652,19 +664,19 @@ msgstr "Aziende monitorate"
 
 #. Button to open company search modal
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:318
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:396
 msgid "watchlists.view.addCompany"
 msgstr "Azienda"
 
 #. Sort option: company name
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:17
+#: src/components/my-jobs/sort-filter-bar.tsx:16
 msgid "myJobs.sort.company"
 msgstr "Azienda"
 
 #. Group by company option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:24
+#: src/components/my-jobs/sort-filter-bar.tsx:23
 msgid "myJobs.group.company"
 msgstr "Azienda"
 
@@ -718,14 +730,14 @@ msgstr "Contatti"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
+#: src/components/LicenseContent.tsx:18
+msgid "license.toc.title"
 msgstr "Sommario"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
-msgid "license.toc.title"
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Sommario"
 
 #. Button to continue to app after verification
@@ -754,7 +766,7 @@ msgstr "Continua con LinkedIn"
 
 #. Employment type: contract
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:15
+#: src/components/search/employment-type-modal.tsx:13
 msgid "search.employmentType.contract"
 msgstr "Freelance"
 
@@ -834,7 +846,7 @@ msgstr "Valuta"
 
 #. Currency label in salary override
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:108
+#: src/components/my-jobs/salary-override.tsx:106
 msgid "myJobs.detail.salary.currency"
 msgstr "Valuta"
 
@@ -858,13 +870,13 @@ msgstr "Scuro"
 
 #. Sort option: date saved
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:15
+#: src/components/my-jobs/sort-filter-bar.tsx:14
 msgid "myJobs.sort.dateSaved"
 msgstr "Data di salvataggio"
 
 #. Short December label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:69
+#: src/components/my-jobs/activity-heatmap.tsx:68
 msgid "myJobs.heatmap.month.dec"
 msgstr "Dic"
 
@@ -882,7 +894,7 @@ msgstr "Elimina"
 
 #. Delete interview button
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:165
+#: src/components/my-jobs/interview-list.tsx:163
 msgid "myJobs.interview.delete"
 msgstr "Elimina"
 
@@ -910,6 +922,12 @@ msgstr "Eliminare la lista di osservazione?"
 msgid "settings.account.delete.deleting"
 msgstr "Eliminazione…"
 
+#. Placeholder for watchlist description textarea
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:361
+msgid "watchlists.view.descriptionPlaceholder"
+msgstr "Descrivi questa watchlist …"
+
 #. Cookie banner details button
 #. js-lingui-explicit-id
 #: src/components/CookieBanner.tsx:60
@@ -918,7 +936,7 @@ msgstr "Dettagli"
 
 #. Collapsible section heading for extracted job details
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:378
+#: src/components/search/job-detail-dialog.tsx:376
 msgid "search.detail.details"
 msgstr "Dettagli"
 
@@ -1020,7 +1038,7 @@ msgstr "Email verificata"
 
 #. Title for the employment type selection modal
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:49
+#: src/components/search/employment-type-modal.tsx:47
 msgid "search.employmentTypeModal.title"
 msgstr "Tipo di impiego"
 
@@ -1150,7 +1168,7 @@ msgstr "Funzionalità"
 
 #. Short February label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:59
+#: src/components/my-jobs/activity-heatmap.tsx:58
 msgid "myJobs.heatmap.month.feb"
 msgstr "Feb"
 
@@ -1164,15 +1182,15 @@ msgstr "Filtro"
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:103
-#: src/components/search/job-detail-dialog.tsx:291
-#: src/components/search/job-detail-dialog.tsx:369
+#: src/components/search/job-detail-dialog.tsx:101
+#: src/components/search/job-detail-dialog.tsx:289
+#: src/components/search/job-detail-dialog.tsx:367
 msgid "search.detail.filterByPrefix"
 msgstr "Filtra per"
 
 #. Tooltip for salary filter pill
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:225
+#: src/components/search/job-detail-dialog.tsx:223
 msgid "search.detail.filterBySalary"
 msgstr "Filtra per questa fascia salariale"
 
@@ -1280,7 +1298,7 @@ msgstr "Gratuito"
 
 #. Short Friday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:50
+#: src/components/my-jobs/activity-heatmap.tsx:49
 msgid "myJobs.heatmap.day.fri"
 msgstr "Ven"
 
@@ -1292,7 +1310,7 @@ msgstr "Ricerca lavoro completa"
 
 #. Employment type: full-time
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:13
+#: src/components/search/employment-type-modal.tsx:11
 msgid "search.employmentType.fullTime"
 msgstr "Tempo pieno"
 
@@ -1356,7 +1374,7 @@ msgstr "Nascondi password"
 
 #. Interview type label: hiring manager round
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:26
+#: src/components/my-jobs/interview-list.tsx:24
 msgid "myJobs.interviewType.hiringManager"
 msgstr "Hiring Manager"
 
@@ -1368,7 +1386,7 @@ msgstr "Orario"
 
 #. Hourly salary period option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:48
+#: src/components/my-jobs/salary-override.tsx:46
 msgid "myJobs.salary.hourly"
 msgstr "Orario"
 
@@ -1483,43 +1501,43 @@ msgstr "L'input è troppo corto."
 
 #. Employment type: internship
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:16
+#: src/components/search/employment-type-modal.tsx:14
 msgid "search.employmentType.internship"
 msgstr "Stage"
 
 #. Interview type label: general interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:17
+#: src/components/my-jobs/interview-list.tsx:15
 msgid "myJobs.interviewType.interview"
 msgstr "Colloquio"
 
 #. Status group heading: interviewing
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:32
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:30
 msgid "myJobs.group.interviewing"
-msgstr "In colloquio"
-
-#. Application tracker status: interviewing
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:441
-msgid "search.tracker.interviewing"
 msgstr "In colloquio"
 
 #. Interviewing status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:22
+#: src/components/my-jobs/status-badge.tsx:21
 msgid "myJobs.status.interviewing"
+msgstr "In colloquio"
+
+#. Application tracker status: interviewing
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:439
+msgid "search.tracker.interviewing"
 msgstr "In colloquio"
 
 #. Status option in dropdown: interviewing
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:36
+#: src/components/my-jobs/my-job-detail-panel.tsx:34
 msgid "myJobs.statusOption.interviewing"
 msgstr "In colloquio"
 
 #. Interviews section heading
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:51
+#: src/components/my-jobs/interview-list.tsx:49
 msgid "myJobs.detail.interviews"
 msgstr "Colloqui"
 
@@ -1537,7 +1555,7 @@ msgstr "Link di verifica non valido"
 
 #. Short January label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:58
+#: src/components/my-jobs/activity-heatmap.tsx:57
 msgid "myJobs.heatmap.month.jan"
 msgstr "Gen"
 
@@ -1549,7 +1567,7 @@ msgstr "offerta"
 
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:107
+#: src/components/watchlist/public-watchlist-search.tsx:110
 msgid "watchlists.explore.jobSingular"
 msgstr "offerta"
 
@@ -1561,13 +1579,13 @@ msgstr "Dati sugli annunci (CC BY-NC 4.0)"
 
 #. Job detail panel title
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:73
+#: src/components/search/job-detail-dialog.tsx:71
 msgid "search.detail.title"
 msgstr "Dettagli dell'offerta"
 
 #. Job detail panel title in My Jobs
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:160
+#: src/components/my-jobs/my-job-detail-panel.tsx:158
 msgid "myJobs.detail.title"
 msgstr "Dettagli lavoro"
 
@@ -1613,33 +1631,33 @@ msgstr "Job Seek è in fase di sviluppo attivo. Resta aggiornato per le novità!
 msgid "license.hero.description"
 msgstr "Il codice sorgente di Job Seek è open source sotto licenza MIT. I dati sugli annunci che raccogliamo e arricchiamo sono Creative Commons BY-NC 4.0. Di seguito il riepilogo in linguaggio semplice — si prega di leggere le licenze complete per i termini esatti."
 
-#. Job count label in watchlist view
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:210
-msgid "watchlists.jobList.jobCount"
-msgstr "offerte"
-
 #. Plural job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:32
 msgid "watchlists.card.jobPlural"
 msgstr "offerte"
 
+#. Job count label in watchlist view
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-job-list.tsx:210
+msgid "watchlists.jobList.jobCount"
+msgstr "offerte"
+
 #. Plural job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:108
+#: src/components/watchlist/public-watchlist-search.tsx:111
 msgid "watchlists.explore.jobPlural"
 msgstr "offerte"
 
 #. Short July label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:64
+#: src/components/my-jobs/activity-heatmap.tsx:63
 msgid "myJobs.heatmap.month.jul"
 msgstr "Lug"
 
 #. Short June label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:63
+#: src/components/my-jobs/activity-heatmap.tsx:62
 msgid "myJobs.heatmap.month.jun"
 msgstr "Giu"
 
@@ -1779,17 +1797,17 @@ msgstr "Luogo"
 msgid "search.advanced.location"
 msgstr "Luogo"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:303
-msgid "search.detail.locations"
-msgstr "Località"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:531
 msgid "search.bar.locations"
 msgstr "Sedi"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:301
+msgid "search.detail.locations"
+msgstr "Località"
 
 #. Login button label
 #. Login button label
@@ -1837,49 +1855,49 @@ msgstr "Gestisci i tuoi account social collegati."
 
 #. Short March label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:60
+#: src/components/my-jobs/activity-heatmap.tsx:59
 msgid "myJobs.heatmap.month.mar"
 msgstr "Mar"
 
 #. Quick action tooltip: mark job as applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:19
+#: src/components/my-jobs/quick-actions.tsx:18
 msgid "myJobs.action.markApplied"
 msgstr "Segna come candidato"
 
 #. Quick action tooltip: mark job as offered
 #. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:22
+#: src/components/my-jobs/quick-actions.tsx:21
 msgid "myJobs.action.markOffer"
 msgstr "Segna come offerta"
 
 #. Quick action tooltip: mark job as rejected
 #. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:21
+#: src/components/my-jobs/quick-actions.tsx:20
 msgid "myJobs.action.markRejected"
 msgstr "Segna come rifiutato"
 
 #. Maximum salary label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:45
+#: src/components/my-jobs/salary-override.tsx:43
 msgid "myJobs.salary.max"
 msgstr "Max"
 
 #. Short May label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:62
+#: src/components/my-jobs/activity-heatmap.tsx:61
 msgid "myJobs.heatmap.month.may"
 msgstr "Mag"
 
 #. Minimum salary label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:44
+#: src/components/my-jobs/salary-override.tsx:42
 msgid "myJobs.salary.min"
 msgstr "Min"
 
 #. Singular mirror count
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:115
+#: src/components/watchlist/public-watchlist-search.tsx:118
 msgid "watchlists.explore.mirrorSingular"
 msgstr "copia"
 
@@ -1899,13 +1917,13 @@ msgstr "Copia qualsiasi lista pubblica per personalizzarla — modifica le azien
 
 #. Plural mirror count
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:116
+#: src/components/watchlist/public-watchlist-search.tsx:119
 msgid "watchlists.explore.mirrorPlural"
 msgstr "copie"
 
 #. Short Monday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:46
+#: src/components/my-jobs/activity-heatmap.tsx:45
 msgid "myJobs.heatmap.day.mon"
 msgstr "Lun"
 
@@ -1917,7 +1935,7 @@ msgstr "Mensile"
 
 #. Monthly salary period option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:47
+#: src/components/my-jobs/salary-override.tsx:45
 msgid "myJobs.salary.monthly"
 msgstr "Mensile"
 
@@ -1947,7 +1965,7 @@ msgstr "I miei lavori"
 
 #. Title of the My Jobs page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:254
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:252
 msgid "myJobs.title"
 msgstr "I miei lavori"
 
@@ -2007,7 +2025,7 @@ msgstr "Nuova password"
 
 #. Heatmap tooltip when no applications on a date
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:79
+#: src/components/my-jobs/activity-heatmap.tsx:78
 msgid "myJobs.heatmap.tooltipNone"
 msgstr "Nessuna candidatura il {date}"
 
@@ -2041,17 +2059,17 @@ msgstr "Nessuna offerta trovata."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Nessuna lingua corrisponde alla ricerca."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:170
-msgid "search.locationModal.noResults"
-msgstr "Nessun luogo corrisponde alla tua ricerca."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:185
 msgid "company.locationModal.noResults"
 msgstr "Nessuna sede corrisponde alla tua ricerca."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:170
+msgid "search.locationModal.noResults"
+msgstr "Nessun luogo corrisponde alla tua ricerca."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2061,7 +2079,7 @@ msgstr "Nessun annuncio corrispondente trovato."
 
 #. Sankey funnel node label prefix: no response
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:47
+#: src/components/my-jobs/sankey-funnel.tsx:46
 msgid "myJobs.funnel.noResponse"
 msgstr "Nessuna risposta"
 
@@ -2091,7 +2109,7 @@ msgstr "Nessuna tecnologia trovata."
 
 #. Empty state message when no tracked jobs
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:237
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:235
 msgid "myJobs.empty"
 msgstr "Nessun lavoro monitorato. Salva offerte dai risultati di ricerca per iniziare a monitorare le tue candidature."
 
@@ -2103,7 +2121,7 @@ msgstr "Nessuna garanzia — l'uso è a proprio rischio e pericolo."
 
 #. No results message when searching public watchlists
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:137
+#: src/components/watchlist/public-watchlist-search.tsx:140
 msgid "watchlists.explore.noResults"
 msgstr "Nessuna lista trovata."
 
@@ -2113,16 +2131,16 @@ msgstr "Nessuna lista trovata."
 msgid "watchlists.page.empty"
 msgstr "Nessuna lista di osservazione. Creane una per seguire le offerte delle tue aziende preferite."
 
-#. Application tracker status: not applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:439
-msgid "search.tracker.notApplied"
-msgstr "Non candidato"
-
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:45
+#: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
+msgstr "Non candidato"
+
+#. Application tracker status: not applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:437
+msgid "search.tracker.notApplied"
 msgstr "Non candidato"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2137,7 +2155,7 @@ msgstr "Nota: Non siamo riusciti a creare un ticket di monitoraggio, ma la tua r
 
 #. Short November label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:68
+#: src/components/my-jobs/activity-heatmap.tsx:67
 msgid "myJobs.heatmap.month.nov"
 msgstr "Nov"
 
@@ -2149,37 +2167,37 @@ msgstr "Professione"
 
 #. Short October label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:67
+#: src/components/my-jobs/activity-heatmap.tsx:66
 msgid "myJobs.heatmap.month.oct"
 msgstr "Ott"
 
-#. Application tracker status: offer
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:442
-msgid "search.tracker.offer"
-msgstr "Offerta"
-
 #. Offered status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:23
+#: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
+msgstr "Offerta"
+
+#. Application tracker status: offer
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:440
+msgid "search.tracker.offer"
 msgstr "Offerta"
 
 #. Status group heading: offered
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:33
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:31
 msgid "myJobs.group.offered"
 msgstr "Offerta"
 
 #. Sankey funnel node: offered
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:44
+#: src/components/my-jobs/sankey-funnel.tsx:43
 msgid "myJobs.funnel.offered"
 msgstr "Offerta"
 
 #. Status option in dropdown: offered
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:37
+#: src/components/my-jobs/my-job-detail-panel.tsx:35
 msgid "myJobs.statusOption.offered"
 msgstr "Offerta"
 
@@ -2209,7 +2227,7 @@ msgstr "Solo lettere minuscole, numeri e trattini (non all'inizio/fine)"
 
 #. Interview type label: onsite interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:24
+#: src/components/my-jobs/interview-list.tsx:22
 msgid "myJobs.interviewType.onsite"
 msgstr "In sede"
 
@@ -2257,7 +2275,7 @@ msgstr "Originale"
 
 #. Interview type label: other/unspecified
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:27
+#: src/components/my-jobs/interview-list.tsx:25
 msgid "myJobs.interviewType.other"
 msgstr "Altro"
 
@@ -2281,26 +2299,26 @@ msgstr "La nostra posizione sull'automazione"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Panoramica"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Panoramica"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Contenuti della pagina"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Panoramica"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Contenuti della pagina"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Contenuti della pagina"
 
 #. Heading shown on the 404 page
@@ -2311,7 +2329,7 @@ msgstr "Pagina non trovata"
 
 #. Interview type label: panel interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:25
+#: src/components/my-jobs/interview-list.tsx:23
 msgid "myJobs.interviewType.panel"
 msgstr "Panel"
 
@@ -2323,7 +2341,7 @@ msgstr "Raccogli tutte le startup interessanti in un'unica dashboard invece di d
 
 #. Employment type: part-time
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:14
+#: src/components/search/employment-type-modal.tsx:12
 msgid "search.employmentType.partTime"
 msgstr "Part-time"
 
@@ -2397,7 +2415,7 @@ msgstr "Periodo"
 
 #. Period label in salary override
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:128
+#: src/components/my-jobs/salary-override.tsx:126
 msgid "myJobs.detail.salary.period"
 msgstr "Periodo"
 
@@ -2409,7 +2427,7 @@ msgstr "Elimina definitivamente il tuo account e tutti i dati associati. Questa 
 
 #. Interview type label: phone screen
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:18
+#: src/components/my-jobs/interview-list.tsx:16
 msgid "myJobs.interviewType.phoneScreen"
 msgstr "Colloquio telefonico"
 
@@ -2501,21 +2519,15 @@ msgstr "Indicaci qualsiasi pagina carriere o job board su Notion e Job Seek la r
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:88
+#: src/components/search/job-detail-dialog.tsx:86
 msgid "search.detail.notFound"
 msgstr "Offerta non trovata."
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:180
+#: src/components/my-jobs/my-job-detail-panel.tsx:178
 msgid "myJobs.detail.notFound"
 msgstr "Offerta non trovata."
-
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: src/components/Pricing.tsx:101
-msgid "home.pricing.eyebrow"
-msgstr "Prezzi"
 
 #. Nav link: Pricing
 #. Nav link: Pricing
@@ -2523,6 +2535,12 @@ msgstr "Prezzi"
 #: src/components/Header.tsx:61
 #: src/components/MobileMenu.tsx:86
 msgid "common.nav.pricing"
+msgstr "Prezzi"
+
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:101
+msgid "home.pricing.eyebrow"
 msgstr "Prezzi"
 
 #. Privacy policy page eyebrow
@@ -2630,7 +2648,7 @@ msgstr "Leggi i termini di servizio completi"
 
 #. Sort option: recently updated
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:14
+#: src/components/my-jobs/sort-filter-bar.tsx:13
 msgid "myJobs.sort.recentlyUpdated"
 msgstr "Aggiornati di recente"
 
@@ -2654,31 +2672,31 @@ msgstr "Regione"
 
 #. Status group heading: rejected
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:34
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:32
 msgid "myJobs.group.rejected"
-msgstr "Rifiutato"
-
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:443
-msgid "search.tracker.rejected"
 msgstr "Rifiutato"
 
 #. Rejected status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:24
+#: src/components/my-jobs/status-badge.tsx:23
 msgid "myJobs.status.rejected"
 msgstr "Rifiutato"
 
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:46
+#: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
+msgstr "Rifiutato"
+
+#. Application tracker status: rejected
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:441
+msgid "search.tracker.rejected"
 msgstr "Rifiutato"
 
 #. Status option in dropdown: rejected
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:38
+#: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.rejected"
 msgstr "Rifiutato"
 
@@ -2788,20 +2806,20 @@ msgstr "Ruoli"
 
 #. Sankey funnel node: interview round prefix
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:48
+#: src/components/my-jobs/sankey-funnel.tsx:47
 msgid "myJobs.funnel.round"
 msgstr "Turno"
+
+#. Salary override section heading
+#. js-lingui-explicit-id
+#: src/components/my-jobs/salary-override.tsx:76
+msgid "myJobs.detail.salary"
+msgstr "Stipendio"
 
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:171
 msgid "search.advanced.salary"
-msgstr "Stipendio"
-
-#. Salary override section heading
-#. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:78
-msgid "myJobs.detail.salary"
 msgstr "Stipendio"
 
 #. Salary display settings section heading
@@ -2848,25 +2866,25 @@ msgstr "Salva i tuoi filtri per scansioni rapide senza dover riscrivere tutto og
 
 #. Status group heading: saved jobs
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:30
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:28
 msgid "myJobs.group.saved"
 msgstr "Salvato"
 
 #. Saved status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:20
+#: src/components/my-jobs/status-badge.tsx:19
 msgid "myJobs.status.saved"
 msgstr "Salvato"
 
 #. Sankey funnel node: saved jobs
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:42
+#: src/components/my-jobs/sankey-funnel.tsx:41
 msgid "myJobs.funnel.saved"
 msgstr "Salvato"
 
 #. Status option in dropdown: saved
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:34
+#: src/components/my-jobs/my-job-detail-panel.tsx:32
 msgid "myJobs.statusOption.saved"
 msgstr "Salvato"
 
@@ -2907,16 +2925,16 @@ msgstr "Salvataggio…"
 msgid "company.page.searchPlaceholder"
 msgstr "Cerca in {0}..."
 
-#. Placeholder for company search in watchlist creation
-#. js-lingui-explicit-id
-#: src/components/watchlist/company-selector.tsx:91
-msgid "watchlists.companySelector.placeholder"
-msgstr "Cerca aziende..."
-
 #. Placeholder for company search in modal
 #. js-lingui-explicit-id
 #: src/components/watchlist/company-search-modal.tsx:212
 msgid "watchlists.companyModal.searchPlaceholder"
+msgstr "Cerca aziende..."
+
+#. Placeholder for company search in watchlist creation
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-selector.tsx:91
+msgid "watchlists.companySelector.placeholder"
 msgstr "Cerca aziende..."
 
 #. Placeholder for search input in all-languages modal
@@ -2925,17 +2943,17 @@ msgstr "Cerca aziende..."
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Cerca lingue…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:149
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Cerca luoghi..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:164
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Cerca sedi…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:149
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Cerca luoghi..."
 
 #. Back to search results link on company page
 #. js-lingui-explicit-id
@@ -3015,16 +3033,16 @@ msgstr "Invia link"
 msgid "settings.account.password.send"
 msgstr "Invia il link"
 
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Invio in corso..."
-
 #. Resend button while sending
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:96
 msgid "auth.verify.resending"
+msgstr "Invio in corso..."
+
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
 msgstr "Invio in corso..."
 
 #. Reset password button while loading
@@ -3041,7 +3059,7 @@ msgstr "Livello di esperienza"
 
 #. Short September label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:66
+#: src/components/my-jobs/activity-heatmap.tsx:65
 msgid "myJobs.heatmap.month.sep"
 msgstr "Set"
 
@@ -3099,16 +3117,16 @@ msgstr "Impostazioni"
 #~ msgid "settings.billing.usage.unlimited"
 #~ msgstr "Illimitato"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:346
-msgid "search.detail.showLessLocations"
-msgstr "Mostra meno"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:350
 msgid "company.page.showLess"
+msgstr "Mostra meno"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:344
+msgid "search.detail.showLessLocations"
 msgstr "Mostra meno"
 
 #. Aria label to show password
@@ -3219,12 +3237,6 @@ msgstr "Vai al contenuto"
 msgid "error.title"
 msgstr "Qualcosa è andato storto"
 
-#. Generic forgot password error
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:43
-msgid "auth.forgotPassword.error.generic"
-msgstr "Qualcosa è andato storto. Riprova."
-
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
@@ -3233,6 +3245,12 @@ msgstr "Qualcosa è andato storto. Riprova."
 #: app/[lang]/(app)/progress/company-request-form.tsx:18
 #: src/components/search/request-company.tsx:19
 msgid "app.home.request.error.unknown"
+msgstr "Qualcosa è andato storto. Riprova."
+
+#. Generic forgot password error
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:43
+msgid "auth.forgotPassword.error.generic"
 msgstr "Qualcosa è andato storto. Riprova."
 
 #. Generic error creating watchlist
@@ -3267,19 +3285,19 @@ msgstr "Inizia gratis"
 
 #. Sort option: status
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:16
+#: src/components/my-jobs/sort-filter-bar.tsx:15
 msgid "myJobs.sort.status"
 msgstr "Stato"
 
 #. Group by status option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:25
+#: src/components/my-jobs/sort-filter-bar.tsx:24
 msgid "myJobs.group.status"
 msgstr "Stato"
 
 #. Status section heading
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:197
+#: src/components/my-jobs/my-job-detail-panel.tsx:195
 msgid "myJobs.detail.status"
 msgstr "Stato"
 
@@ -3346,26 +3364,26 @@ msgstr "Passa alla modalità chiara"
 
 #. Interview type label: system design
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:22
+#: src/components/my-jobs/interview-list.tsx:20
 msgid "myJobs.interviewType.systemDesign"
 msgstr "System Design"
 
 #. Interview type label: technical interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:20
+#: src/components/my-jobs/interview-list.tsx:18
 msgid "myJobs.interviewType.technical"
 msgstr "Tecnico"
-
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:388
-msgid "search.detail.technologies"
-msgstr "Tecnologie"
 
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:496
 msgid "search.bar.technologies"
+msgstr "Tecnologie"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:386
+msgid "search.detail.technologies"
 msgstr "Tecnologie"
 
 #. Add technology filter
@@ -3382,7 +3400,7 @@ msgstr "Tecnologia"
 
 #. Employment type: temporary
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:17
+#: src/components/search/employment-type-modal.tsx:15
 msgid "search.employmentType.temporary"
 msgstr "Temporaneo"
 
@@ -3590,7 +3608,7 @@ msgstr "Aggiornamento…"
 
 #. Fallback username for watchlist owner
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:106
+#: src/components/watchlist/public-watchlist-search.tsx:109
 msgid "watchlists.explore.unknownUser"
 msgstr "utente"
 
@@ -3638,19 +3656,19 @@ msgstr "Verifica dell'email in corso..."
 
 #. Interview type label: video call
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:19
+#: src/components/my-jobs/interview-list.tsx:17
 msgid "myJobs.interviewType.videoCall"
 msgstr "Videochiamata"
 
 #. Link to the original job posting
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:185
+#: src/components/search/job-detail-dialog.tsx:183
 msgid "search.detail.viewPosting"
 msgstr "Vedi offerta"
 
 #. Employment type: volunteer
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:18
+#: src/components/search/employment-type-modal.tsx:16
 msgid "search.employmentType.volunteer"
 msgstr "Volontariato"
 
@@ -3668,7 +3686,7 @@ msgstr "Liste di osservazione"
 
 #. Back to watchlists link
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:257
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:288
 msgid "watchlists.view.back"
 msgstr "Liste di osservazione"
 
@@ -3752,7 +3770,7 @@ msgstr "Utilizziamo pochi servizi terzi per accesso, hosting e archiviazione —
 
 #. Short Wednesday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:48
+#: src/components/my-jobs/activity-heatmap.tsx:47
 msgid "myJobs.heatmap.day.wed"
 msgstr "Mer"
 
@@ -3776,7 +3794,7 @@ msgstr "Annuale"
 
 #. Yearly salary period option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:46
+#: src/components/my-jobs/salary-override.tsx:44
 msgid "myJobs.salary.yearly"
 msgstr "Annuale"
 

--- a/apps/web/scripts/backfill-watchlist-descriptions.ts
+++ b/apps/web/scripts/backfill-watchlist-descriptions.ts
@@ -1,0 +1,167 @@
+import dotenv from "dotenv";
+dotenv.config({ path: ".env.local" });
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+import { eq } from "drizzle-orm";
+import { user, watchlist, watchlistCompany, company } from "../src/db/schema";
+
+const url = process.env.DATABASE_URL_UNPOOLED ?? process.env.DATABASE_URL;
+if (!url) {
+  throw new Error("DATABASE_URL_UNPOOLED or DATABASE_URL must be set");
+}
+
+const sql = postgres(url);
+const db = drizzle(sql);
+
+const ADMIN_EMAIL = "colophongroup@gmail.com";
+
+type WatchlistFilters = {
+  keywords?: string[];
+  locationSlugs?: string[];
+  occupationSlugs?: string[];
+  senioritySlugs?: string[];
+  technologySlugs?: string[];
+  salaryMin?: number;
+  salaryMax?: number;
+  salaryCurrency?: string;
+  experienceMin?: number;
+  experienceMax?: number;
+  anyCompany?: boolean;
+};
+
+function slugToLabel(slug: string): string {
+  return slug
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function generateDescription(
+  title: string,
+  companyNames: string[],
+  filters: WatchlistFilters,
+): string {
+  const parts: string[] = [];
+
+  // Companies
+  if (companyNames.length > 0) {
+    const shown = companyNames.slice(0, 4);
+    const rest = companyNames.length - shown.length;
+    const companyList =
+      rest > 0
+        ? `${shown.join(", ")} and ${rest} more`
+        : shown.length > 1
+          ? `${shown.slice(0, -1).join(", ")} and ${shown[shown.length - 1]}`
+          : shown[0];
+    parts.push(`Track open positions at ${companyList}`);
+  }
+
+  // Filters
+  const filterFragments: string[] = [];
+
+  if (filters.occupationSlugs?.length) {
+    const labels = filters.occupationSlugs.slice(0, 3).map(slugToLabel);
+    filterFragments.push(labels.join(", "));
+  }
+
+  if (filters.senioritySlugs?.length) {
+    const labels = filters.senioritySlugs.slice(0, 2).map(slugToLabel);
+    filterFragments.push(labels.join(", "));
+  }
+
+  if (filters.locationSlugs?.length) {
+    const labels = filters.locationSlugs.slice(0, 3).map(slugToLabel);
+    filterFragments.push(`in ${labels.join(", ")}`);
+  }
+
+  if (filters.technologySlugs?.length) {
+    const labels = filters.technologySlugs.slice(0, 3).map(slugToLabel);
+    filterFragments.push(`using ${labels.join(", ")}`);
+  }
+
+  if (filterFragments.length > 0) {
+    if (parts.length > 0) {
+      parts.push(`Filtered by ${filterFragments.join(" · ")}.`);
+    } else {
+      parts.push(`${filterFragments.join(" · ")} jobs.`);
+    }
+  }
+
+  if (parts.length === 0) {
+    // Fallback: derive from title
+    return `Curated job watchlist: ${title}.`;
+  }
+
+  // Join and ensure it fits in ~200 chars
+  let result = parts.join(". ");
+  if (!result.endsWith(".")) result += ".";
+  if (result.length > 200) {
+    result = result.slice(0, 197) + "...";
+  }
+  return result;
+}
+
+async function main() {
+  // 1. Find admin user
+  const [found] = await db
+    .select({ id: user.id, name: user.name })
+    .from(user)
+    .where(eq(user.email, ADMIN_EMAIL))
+    .limit(1);
+
+  if (!found) {
+    console.error(`No user found with email: ${ADMIN_EMAIL}`);
+    process.exit(1);
+  }
+
+  console.log(`Found user: ${found.name} (${found.id})`);
+
+  // 2. Fetch all their watchlists
+  const watchlists = await db
+    .select({
+      id: watchlist.id,
+      title: watchlist.title,
+      description: watchlist.description,
+      filters: watchlist.filters,
+    })
+    .from(watchlist)
+    .where(eq(watchlist.userId, found.id));
+
+  console.log(`Found ${watchlists.length} watchlists`);
+
+  let updated = 0;
+  for (const wl of watchlists) {
+    if (wl.description) {
+      console.log(`  SKIP "${wl.title}" — already has description`);
+      continue;
+    }
+
+    // Fetch company names for this watchlist
+    const companies = await db
+      .select({ name: company.name })
+      .from(watchlistCompany)
+      .innerJoin(company, eq(watchlistCompany.companyId, company.id))
+      .where(eq(watchlistCompany.watchlistId, wl.id))
+      .orderBy(company.name);
+
+    const companyNames = companies.map((c) => c.name);
+    const filters = (wl.filters ?? {}) as WatchlistFilters;
+
+    const description = generateDescription(wl.title, companyNames, filters);
+
+    await db
+      .update(watchlist)
+      .set({ description })
+      .where(eq(watchlist.id, wl.id));
+
+    console.log(`  SET "${wl.title}" → ${description}`);
+    updated++;
+  }
+
+  console.log(`\nDone. Updated ${updated} of ${watchlists.length} watchlists.`);
+  await sql.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/apps/web/src/components/watchlist/public-watchlist-search.tsx
+++ b/apps/web/src/components/watchlist/public-watchlist-search.tsx
@@ -102,6 +102,9 @@ export function PublicWatchlistSearch() {
             >
               <div className="min-w-0 flex-1">
                 <p className="truncate text-sm font-medium">{wl.title}</p>
+                {wl.description && (
+                  <p className="line-clamp-1 text-xs text-muted">{wl.description}</p>
+                )}
                 <p className="text-xs text-muted">
                   @{wl.ownerUsername ?? t({ id: "watchlists.explore.unknownUser", comment: "Fallback username for watchlist owner", message: "user" })} · {wl.activeJobCount} {wl.activeJobCount === 1
                     ? t({ id: "watchlists.explore.jobSingular", comment: "Singular job count in public watchlist", message: "job" })

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -751,6 +751,7 @@ export const watchlist = pgTable(
       .references(() => user.id, { onDelete: "cascade" }),
     slug: text("slug").notNull(),
     title: text("title").notNull(),
+    description: text("description"),
     isPublic: boolean("is_public").default(true).notNull(),
     alertsEnabled: boolean("alerts_enabled").default(false).notNull(),
     filters: jsonb("filters").default({}).notNull(),

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -34,6 +34,7 @@ export type WatchlistSummary = {
   id: string;
   slug: string;
   title: string;
+  description: string | null;
   isPublic: boolean;
   alertsEnabled: boolean;
   companyCount: number;
@@ -46,6 +47,7 @@ export type WatchlistDetail = {
   id: string;
   slug: string;
   title: string;
+  description: string | null;
   isPublic: boolean;
   alertsEnabled: boolean;
   filters: WatchlistFilters;
@@ -83,6 +85,7 @@ export type WatchlistPostingEntry = {
 
 export async function createWatchlist(params: {
   title: string;
+  description?: string;
   companyIds: string[];
   filters?: WatchlistFilters;
   isPublic?: boolean;
@@ -101,6 +104,7 @@ export async function createWatchlist(params: {
       userId,
       slug,
       title: params.title,
+      description: params.description ?? null,
       isPublic: params.isPublic ?? true,
       filters: params.filters ?? {},
     })
@@ -121,6 +125,7 @@ export async function createWatchlist(params: {
 export async function updateWatchlist(params: {
   watchlistId: string;
   title?: string;
+  description?: string | null;
   companyIds?: string[];
   filters?: WatchlistFilters;
   isPublic?: boolean;
@@ -144,6 +149,7 @@ export async function updateWatchlist(params: {
     newSlug = await generateUniqueSlug(userId, params.title);
     updates.slug = newSlug;
   }
+  if (params.description !== undefined) updates.description = params.description;
   if (params.filters !== undefined) updates.filters = params.filters;
   if (params.isPublic !== undefined) updates.isPublic = params.isPublic;
 
@@ -202,6 +208,7 @@ export async function copyWatchlist(
   const [source] = await db
     .select({
       title: watchlist.title,
+      description: watchlist.description,
       filters: watchlist.filters,
       isPublic: watchlist.isPublic,
       userId: watchlist.userId,
@@ -225,6 +232,7 @@ export async function copyWatchlist(
       userId,
       slug,
       title: source.title,
+      description: source.description,
       isPublic: true,
       filters: sourceFilters,
       sourceWatchlistId: watchlistId,
@@ -295,7 +303,7 @@ export async function getUserWatchlists(): Promise<WatchlistSummary[]> {
     company_count: number;
     company_ids: string[];
   }>(sql`
-    SELECT w.id, w.slug, w.title, w.is_public, w.alerts_enabled, w.filters,
+    SELECT w.id, w.slug, w.title, w.description, w.is_public, w.alerts_enabled, w.filters,
            w.last_accessed_at, w.created_at,
            (SELECT count(*)::int FROM watchlist_company wc WHERE wc.watchlist_id = w.id) AS company_count,
            (SELECT coalesce(array_agg(wc.company_id), '{}') FROM watchlist_company wc WHERE wc.watchlist_id = w.id) AS company_ids
@@ -305,7 +313,7 @@ export async function getUserWatchlists(): Promise<WatchlistSummary[]> {
   `);
 
   type Row = {
-    id: string; slug: string; title: string; is_public: boolean;
+    id: string; slug: string; title: string; description: string | null; is_public: boolean;
     alerts_enabled: boolean; filters: WatchlistFilters; last_accessed_at: Date; created_at: Date;
     company_count: number; company_ids: string[];
   };
@@ -321,6 +329,7 @@ export async function getUserWatchlists(): Promise<WatchlistSummary[]> {
     id: r.id,
     slug: r.slug,
     title: r.title,
+    description: r.description,
     isPublic: r.is_public,
     alertsEnabled: r.alerts_enabled,
     companyCount: r.company_count,
@@ -355,6 +364,7 @@ export async function getWatchlistByUserAndSlug(
       id: watchlist.id,
       slug: watchlist.slug,
       title: watchlist.title,
+      description: watchlist.description,
       isPublic: watchlist.isPublic,
       alertsEnabled: watchlist.alertsEnabled,
       filters: watchlist.filters,
@@ -398,6 +408,7 @@ export async function getWatchlistByUserAndSlug(
     id: wl.id,
     slug: wl.slug,
     title: wl.title,
+    description: wl.description,
     isPublic: wl.isPublic,
     alertsEnabled: wl.alertsEnabled,
     filters: (wl.filters ?? {}) as WatchlistFilters,
@@ -473,7 +484,7 @@ async function queryPublicWatchlists(params: {
     company_count: number; company_ids: string[];
     mirror_count: number;
   }>(sql`
-    SELECT w.id, w.slug, w.title, w.is_public, w.alerts_enabled, w.filters,
+    SELECT w.id, w.slug, w.title, w.description, w.is_public, w.alerts_enabled, w.filters,
            w.last_accessed_at, w.created_at,
            u.name AS owner_name, u.username AS owner_username,
            (SELECT count(*)::int FROM watchlist_company wc WHERE wc.watchlist_id = w.id) AS company_count,
@@ -488,7 +499,7 @@ async function queryPublicWatchlists(params: {
   `);
 
   type Row = {
-    id: string; slug: string; title: string; is_public: boolean;
+    id: string; slug: string; title: string; description: string | null; is_public: boolean;
     alerts_enabled: boolean; filters: WatchlistFilters;
     last_accessed_at: Date; created_at: Date;
     owner_name: string; owner_username: string | null;
@@ -508,6 +519,7 @@ async function queryPublicWatchlists(params: {
       id: r.id,
       slug: r.slug,
       title: r.title,
+      description: r.description,
       isPublic: r.is_public,
       alertsEnabled: r.alerts_enabled,
       companyCount: r.company_count,
@@ -531,7 +543,7 @@ export async function searchPublicWatchlists(params: {
   if (!q) return { watchlists: [], total: 0 };
 
   return queryPublicWatchlists({
-    whereClause: sql`w.is_public = true AND w.title ILIKE ${"%" + q + "%"}`,
+    whereClause: sql`w.is_public = true AND (w.title ILIKE ${"%" + q + "%"} OR w.description ILIKE ${"%" + q + "%"})`,
     orderClause: sql`w.created_at DESC`,
     offset: params.offset,
     limit: params.limit,


### PR DESCRIPTION
## Summary
- Adds a nullable `description` column to the `watchlist` table with migration `0070`
- Adds `generateMetadata()` to the watchlist detail page — uses stored description, or auto-generates from companies/filters/locations
- Adds inline click-to-edit description in the watchlist detail UI (between `@username` and companies section); visitors see static text, owners click to edit
- Shows descriptions in public watchlist search results and searches against them
- Includes a backfill script (`scripts/backfill-watchlist-descriptions.ts`) to populate descriptions for colophongroup watchlists

## Test plan
- [ ] Run migration `0070_add_watchlist_description.sql` against dev DB
- [ ] Verify watchlist detail page renders description for owner (click-to-edit) and visitor (static)
- [ ] Verify "Add description" link appears for owner on watchlists without description
- [ ] Verify `<meta>` tags are set correctly (view source or inspect head) on public watchlist pages
- [ ] Verify public watchlist search shows descriptions and matches search queries against them
- [ ] Run `pnpm tsx scripts/backfill-watchlist-descriptions.ts` to backfill colophongroup watchlists

🤖 Generated with [Claude Code](https://claude.com/claude-code)