### PR TITLE
Fix Playwright cleanup calling stop() on wrong object

### DIFF
--- a/apps/crawler/src/batch.py
+++ b/apps/crawler/src/batch.py
@@ -1833,8 +1833,8 @@ async def _process_one_board(
         try:
             result = await monitor_one(board_url, crawler_type, metadata, http, pw=pw)
         finally:
-            if pw_ctx:
-                await pw_ctx.stop()
+            if pw:
+                await pw.stop()
 
         enrich_fields = _board_has_enrich(metadata)
 


### PR DESCRIPTION
## Summary
- `_process_one_board` was calling `pw_ctx.stop()` on the `PlaywrightContextManager`, which doesn't have a `stop()` method
- Fixed to call `pw.stop()` on the `Playwright` instance returned by `pw_ctx.start()`
- This caused an `AttributeError` crash after every DOM-based monitor run (e.g. JPMC Oracle board)

## Test plan
- [ ] Verify JPMC Oracle board (`728abb9c`) completes without `AttributeError`
- [ ] Confirm Playwright browser is properly cleaned up after monitor runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)