### PR TITLE
Add SEO metadata, structured data, and dynamic sitemap

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
@@ -10,7 +10,7 @@ import { getUserPlan, PLAN_LIMITS, canCreateWatchlist } from "@/lib/plans";
 import { resolveLocationSlugs } from "@/lib/actions/locations";
 import { resolveOccupationSlugs, resolveSenioritySlugs, resolveTechnologySlugs } from "@/lib/actions/taxonomy";
 import { siteConfig } from "@/content/config";
-import { buildAlternates } from "@/lib/seo";
+import { buildAlternates, JsonLd } from "@/lib/seo";
 import { WatchlistViewPage } from "./watchlist-view-page";
 
 type Props = {
@@ -128,7 +128,20 @@ export default async function WatchlistRoute({ params }: Props) {
     experienceMax: filters.experienceMax,
   });
 
+  const ownerLabel = detail.owner.displayUsername ?? detail.owner.username ?? detail.owner.name;
+  const breadcrumbJsonLd: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: `${siteConfig.url}/${lang}` },
+      { "@type": "ListItem", position: 2, name: `@${ownerLabel}` },
+      { "@type": "ListItem", position: 3, name: detail.title },
+    ],
+  };
+
   return (
+    <>
+    <JsonLd data={breadcrumbJsonLd} />
     <WatchlistViewPage
       detail={detail}
       isOwner={isOwner}
@@ -142,5 +155,6 @@ export default async function WatchlistRoute({ params }: Props) {
       resolvedSeniorities={resolvedSeniorities}
       resolvedTechnologies={resolvedTechnologies}
     />
+    </>
   );
 }

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
-import { isLocale, defaultLocale, initI18nForPage } from "@/lib/i18n";
+import { getI18n } from "@lingui/react/server";
+import { isLocale, defaultLocale, loadCatalog, initI18nForPage } from "@/lib/i18n";
 import {
   getWatchlistByUserAndSlug,
   getWatchlistPostings,
@@ -20,7 +21,10 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { userSlug, watchlistSlug, lang } = await params;
   const locale = isLocale(lang) ? lang : defaultLocale;
-  const detail = await getWatchlistByUserAndSlug(userSlug, watchlistSlug);
+  const [detail, { i18n }] = await Promise.all([
+    getWatchlistByUserAndSlug(userSlug, watchlistSlug),
+    loadCatalog(locale),
+  ]);
   if (!detail) return {};
 
   const ownerLabel = detail.owner.displayUsername ?? detail.owner.username ?? detail.owner.name;
@@ -33,21 +37,43 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (detail.companies.length > 0) {
       const names = detail.companies.slice(0, 3).map((c) => c.name);
       if (detail.companies.length > 3) {
-        names.push(`${detail.companies.length - 3} more`);
+        names.push(i18n.t({
+          id: "watchlist.meta.moreCompanies",
+          message: "{count} more",
+          values: { count: detail.companies.length - 3 },
+        }));
       }
-      parts.push(`Jobs at ${names.join(", ")}`);
+      parts.push(i18n.t({
+        id: "watchlist.meta.jobsAt",
+        message: "Jobs at {names}",
+        values: { names: names.join(", ") },
+      }));
     }
     if (detail.filters.occupationSlugs?.length) {
       parts.push(detail.filters.occupationSlugs.map((s) => s.replace(/-/g, " ")).join(", "));
     }
     if (detail.filters.locationSlugs?.length) {
-      parts.push(`in ${detail.filters.locationSlugs.slice(0, 2).map((s) => s.replace(/-/g, " ")).join(", ")}`);
+      parts.push(i18n.t({
+        id: "watchlist.meta.inLocations",
+        message: "in {locations}",
+        values: { locations: detail.filters.locationSlugs.slice(0, 2).map((s) => s.replace(/-/g, " ")).join(", ") },
+      }));
     }
-    description = parts.length > 0 ? parts.join(" · ") : `Job watchlist by @${ownerLabel}`;
+    description = parts.length > 0
+      ? parts.join(" · ")
+      : i18n.t({
+          id: "watchlist.meta.fallback",
+          message: "Job watchlist by @{owner}",
+          values: { owner: ownerLabel },
+        });
   }
   const companyCount = detail.companies.length;
   if (companyCount > 0) {
-    description = `Tracking ${companyCount} ${companyCount === 1 ? "company" : "companies"}. ${description}`;
+    description = i18n.t({
+      id: "watchlist.meta.tracking",
+      message: "{count, plural, one {Tracking # company} other {Tracking # companies}}. {description}",
+      values: { count: companyCount, description },
+    });
   }
 
   const path = `/${userSlug}/${watchlistSlug}`;
@@ -132,12 +158,13 @@ export default async function WatchlistRoute({ params }: Props) {
     experienceMax: filters.experienceMax,
   });
 
+  const i18n = getI18n()!;
   const ownerLabel = detail.owner.displayUsername ?? detail.owner.username ?? detail.owner.name;
   const breadcrumbJsonLd: Record<string, unknown> = {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     itemListElement: [
-      { "@type": "ListItem", position: 1, name: "Home", item: `${siteConfig.url}/${lang}` },
+      { "@type": "ListItem", position: 1, name: i18n.t({ id: "breadcrumb.home", message: "Home" }), item: `${siteConfig.url}/${lang}` },
       { "@type": "ListItem", position: 2, name: `@${ownerLabel}` },
       { "@type": "ListItem", position: 3, name: detail.title },
     ],

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
@@ -45,6 +45,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     }
     description = parts.length > 0 ? parts.join(" · ") : `Job watchlist by @${ownerLabel}`;
   }
+  const companyCount = detail.companies.length;
+  if (companyCount > 0) {
+    description = `Tracking ${companyCount} ${companyCount === 1 ? "company" : "companies"}. ${description}`;
+  }
 
   const path = `/${userSlug}/${watchlistSlug}`;
   return {

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
-import { initI18nForPage } from "@/lib/i18n";
+import { isLocale, defaultLocale, initI18nForPage } from "@/lib/i18n";
 import {
   getWatchlistByUserAndSlug,
   getWatchlistPostings,
@@ -9,6 +9,8 @@ import { getSession } from "@/lib/sessionCache";
 import { getUserPlan, PLAN_LIMITS, canCreateWatchlist } from "@/lib/plans";
 import { resolveLocationSlugs } from "@/lib/actions/locations";
 import { resolveOccupationSlugs, resolveSenioritySlugs, resolveTechnologySlugs } from "@/lib/actions/taxonomy";
+import { siteConfig } from "@/content/config";
+import { buildAlternates } from "@/lib/seo";
 import { WatchlistViewPage } from "./watchlist-view-page";
 
 type Props = {
@@ -16,7 +18,8 @@ type Props = {
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
-  const { userSlug, watchlistSlug } = await params;
+  const { userSlug, watchlistSlug, lang } = await params;
+  const locale = isLocale(lang) ? lang : defaultLocale;
   const detail = await getWatchlistByUserAndSlug(userSlug, watchlistSlug);
   if (!detail) return {};
 
@@ -43,7 +46,18 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     description = parts.length > 0 ? parts.join(" · ") : `Job watchlist by @${ownerLabel}`;
   }
 
-  return { title, description };
+  const path = `/${userSlug}/${watchlistSlug}`;
+  return {
+    title,
+    description,
+    alternates: buildAlternates(path, locale),
+    openGraph: {
+      title,
+      description,
+      url: `${siteConfig.url}/${locale}${path}`,
+      type: "website",
+    },
+  };
 }
 
 export default async function WatchlistRoute({ params }: Props) {

--- a/apps/web/app/[lang]/(app)/company/[slug]/opengraph-image.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/opengraph-image.tsx
@@ -1,0 +1,132 @@
+import { ImageResponse } from "next/og";
+import { getCompanyBySlug } from "@/lib/actions/company";
+
+export const alt = "Company jobs";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+// Cache the font load across invocations
+const fontPromise = fetch(
+  new URL("../../../../../../public/fonts/JetBrainsMono-Bold.woff2", import.meta.url),
+).then((res) => res.arrayBuffer());
+
+export default async function OgImage({
+  params,
+}: {
+  params: Promise<{ lang: string; slug: string }>;
+}) {
+  const { slug, lang } = await params;
+  const company = await getCompanyBySlug(slug, lang);
+  if (!company) {
+    return new ImageResponse(
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor: "#0a0a0a",
+          color: "#fafafa",
+          fontSize: 48,
+          fontFamily: "JetBrains Mono",
+        }}
+      >
+        Not Found
+      </div>,
+      { ...size },
+    );
+  }
+
+  const fontData = await fontPromise;
+  const hasIcon = company.icon && company.icon.startsWith("http");
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        backgroundColor: "#0a0a0a",
+        color: "#fafafa",
+        fontFamily: "JetBrains Mono",
+        padding: "60px 80px",
+      }}
+    >
+      {/* Top: company icon + name */}
+      <div style={{ display: "flex", alignItems: "center", gap: "24px" }}>
+        {hasIcon && (
+          <img
+            src={company.icon!}
+            width={72}
+            height={72}
+            style={{ borderRadius: 12 }}
+          />
+        )}
+        <span style={{ fontSize: 52, fontWeight: 700 }}>{company.name}</span>
+      </div>
+
+      {/* Middle: description */}
+      {company.description && (
+        <div
+          style={{
+            fontSize: 28,
+            color: "#a1a1aa",
+            marginTop: 32,
+            lineHeight: 1.4,
+            overflow: "hidden",
+            display: "flex",
+            maxHeight: "160px",
+          }}
+        >
+          {company.description.length > 200
+            ? company.description.slice(0, 200) + "…"
+            : company.description}
+        </div>
+      )}
+
+      {/* Bottom: meta chips */}
+      <div
+        style={{
+          display: "flex",
+          gap: "16px",
+          marginTop: "auto",
+          fontSize: 22,
+          color: "#71717a",
+        }}
+      >
+        {company.industryName && <span>{company.industryName}</span>}
+        {company.industryName && company.website && <span>·</span>}
+        {company.website && (
+          <span>{company.website.replace(/^https?:\/\//, "").replace(/\/$/, "")}</span>
+        )}
+      </div>
+
+      {/* Branding */}
+      <div
+        style={{
+          position: "absolute",
+          bottom: 40,
+          right: 80,
+          fontSize: 20,
+          color: "#52525b",
+          display: "flex",
+        }}
+      >
+        jobseek.com
+      </div>
+    </div>,
+    {
+      ...size,
+      fonts: [
+        {
+          name: "JetBrains Mono",
+          data: fontData,
+          weight: 700,
+          style: "normal",
+        },
+      ],
+    },
+  );
+}

--- a/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
@@ -1,11 +1,13 @@
 import { notFound } from "next/navigation";
 import { headers } from "next/headers";
 import type { Metadata } from "next";
-import { initI18nForPage } from "@/lib/i18n";
+import { isLocale, defaultLocale, initI18nForPage } from "@/lib/i18n";
 import { getCompanyBySlug, getCompanyPostings } from "@/lib/actions/company";
 import { getPreferences } from "@/lib/actions/preferences";
 import { parseSearchFilters } from "@/lib/actions/search-input";
 import { resolveJobLanguages } from "@/lib/job-languages";
+import { siteConfig } from "@/content/config";
+import { buildAlternates, JsonLd, formatEmployeeCount } from "@/lib/seo";
 import { CompanyPage } from "./company-page";
 
 const PAGE_SIZE = 20;
@@ -17,11 +19,24 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug, lang } = await params;
-  const company = await getCompanyBySlug(slug, lang);
+  const locale = isLocale(lang) ? lang : defaultLocale;
+  const company = await getCompanyBySlug(slug, locale);
   if (!company) return {};
+
+  const title = `Jobs at ${company.name}`;
+  const description = company.description ?? `Browse open positions at ${company.name}`;
+  const path = `/company/${slug}`;
+
   return {
-    title: `Jobs at ${company.name}`,
-    description: company.description ?? `Browse open positions at ${company.name}`,
+    title,
+    description,
+    alternates: buildAlternates(path, locale),
+    openGraph: {
+      title,
+      description,
+      url: `${siteConfig.url}/${locale}${path}`,
+      type: "website",
+    },
   };
 }
 
@@ -93,7 +108,26 @@ export default async function CompanyPageRoute({ params, searchParams }: Props) 
     limit: PAGE_SIZE,
   });
 
+  const orgJsonLd: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: company.name,
+    ...(company.website && { url: company.website }),
+    ...(company.description && { description: company.description }),
+    ...(company.icon && { logo: company.icon }),
+    ...(company.foundedYear && { foundingDate: String(company.foundedYear) }),
+    ...(company.industryName && { industry: company.industryName }),
+    ...(formatEmployeeCount(company.employeeCountRange) && {
+      numberOfEmployees: {
+        "@type": "QuantitativeValue",
+        value: formatEmployeeCount(company.employeeCountRange),
+      },
+    }),
+  };
+
   return (
+    <>
+    <JsonLd data={orgJsonLd} />
     <CompanyPage
       company={company}
       initialPostings={postingsResult.postings}
@@ -117,5 +151,6 @@ export default async function CompanyPageRoute({ params, searchParams }: Props) 
       userLat={parsedUserLat}
       userLng={parsedUserLng}
     />
+    </>
   );
 }

--- a/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
@@ -24,7 +24,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (!company) return {};
 
   const title = `Jobs at ${company.name}`;
-  const description = company.description ?? `Browse open positions at ${company.name}`;
+  const count = company.activeJobCount;
+  const countText = count > 0 ? `${count} open position${count !== 1 ? "s" : ""}` : "Open positions";
+  const description = company.description
+    ? `${countText} at ${company.name}. ${company.description}`
+    : `${countText} at ${company.name}`;
   const path = `/company/${slug}`;
 
   return {

--- a/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
@@ -1,7 +1,8 @@
 import { notFound } from "next/navigation";
 import { headers } from "next/headers";
 import type { Metadata } from "next";
-import { isLocale, defaultLocale, initI18nForPage } from "@/lib/i18n";
+import { getI18n } from "@lingui/react/server";
+import { isLocale, defaultLocale, loadCatalog, initI18nForPage } from "@/lib/i18n";
 import { getCompanyBySlug, getCompanyPostings } from "@/lib/actions/company";
 import { getPreferences } from "@/lib/actions/preferences";
 import { parseSearchFilters } from "@/lib/actions/search-input";
@@ -20,15 +21,36 @@ type Props = {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug, lang } = await params;
   const locale = isLocale(lang) ? lang : defaultLocale;
-  const company = await getCompanyBySlug(slug, locale);
+  const [company, { i18n }] = await Promise.all([
+    getCompanyBySlug(slug, locale),
+    loadCatalog(locale),
+  ]);
   if (!company) return {};
 
-  const title = `Jobs at ${company.name}`;
+  const title = i18n.t({
+    id: "company.meta.title",
+    message: "Jobs at {name}",
+    values: { name: company.name },
+  });
   const count = company.activeJobCount;
-  const countText = count > 0 ? `${count} open position${count !== 1 ? "s" : ""}` : "Open positions";
+  const countText = count > 0
+    ? i18n.t({
+        id: "company.meta.positionCount",
+        message: "{count, plural, one {# open position} other {# open positions}}",
+        values: { count },
+      })
+    : i18n.t({ id: "company.meta.openPositions", message: "Open positions" });
   const description = company.description
-    ? `${countText} at ${company.name}. ${company.description}`
-    : `${countText} at ${company.name}`;
+    ? i18n.t({
+        id: "company.meta.descriptionWithInfo",
+        message: "{countText} at {name}. {description}",
+        values: { countText, name: company.name, description: company.description },
+      })
+    : i18n.t({
+        id: "company.meta.descriptionBasic",
+        message: "{countText} at {name}",
+        values: { countText, name: company.name },
+      });
   const path = `/company/${slug}`;
 
   return {
@@ -129,12 +151,13 @@ export default async function CompanyPageRoute({ params, searchParams }: Props) 
     }),
   };
 
+  const i18n = getI18n()!;
   const breadcrumbJsonLd: Record<string, unknown> = {
     "@context": "https://schema.org",
     "@type": "BreadcrumbList",
     itemListElement: [
-      { "@type": "ListItem", position: 1, name: "Home", item: `${siteConfig.url}/${locale}` },
-      { "@type": "ListItem", position: 2, name: "Explore", item: `${siteConfig.url}/${locale}/explore` },
+      { "@type": "ListItem", position: 1, name: i18n.t({ id: "breadcrumb.home", message: "Home" }), item: `${siteConfig.url}/${locale}` },
+      { "@type": "ListItem", position: 2, name: i18n.t({ id: "breadcrumb.explore", message: "Explore" }), item: `${siteConfig.url}/${locale}/explore` },
       { "@type": "ListItem", position: 3, name: company.name },
     ],
   };

--- a/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
@@ -125,9 +125,20 @@ export default async function CompanyPageRoute({ params, searchParams }: Props) 
     }),
   };
 
+  const breadcrumbJsonLd: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Home", item: `${siteConfig.url}/${locale}` },
+      { "@type": "ListItem", position: 2, name: "Explore", item: `${siteConfig.url}/${locale}/explore` },
+      { "@type": "ListItem", position: 3, name: company.name },
+    ],
+  };
+
   return (
     <>
     <JsonLd data={orgJsonLd} />
+    <JsonLd data={breadcrumbJsonLd} />
     <CompanyPage
       company={company}
       initialPostings={postingsResult.postings}

--- a/apps/web/app/[lang]/(app)/explore/page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const title = i18n.t({ id: "explore.meta.title", message: "Explore Jobs" });
   const description = i18n.t({
     id: "explore.meta.description",
-    message: "Search and filter job openings across hundreds of companies.",
+    message: "Search jobs across hundreds of companies. Create watchlists to track new openings and get alerts.",
   });
 
   return {

--- a/apps/web/app/[lang]/(app)/explore/page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/page.tsx
@@ -1,10 +1,13 @@
 import { Suspense } from "react";
 import { headers } from "next/headers";
-import { initI18nForPage } from "@/lib/i18n";
+import type { Metadata } from "next";
+import { isLocale, defaultLocale, loadCatalog, initI18nForPage } from "@/lib/i18n";
 import { searchJobs, listTopCompanies } from "@/lib/actions/search";
 import { parseSearchFilters } from "@/lib/actions/search-input";
 import { getPreferences } from "@/lib/actions/preferences";
 import { resolveJobLanguages } from "@/lib/job-languages";
+import { siteConfig } from "@/content/config";
+import { buildAlternates } from "@/lib/seo";
 import { SearchPage } from "./search-page";
 
 const PAGE_SIZE = 10;
@@ -13,6 +16,30 @@ type Props = {
   params: Promise<{ lang: string }>;
   searchParams: Promise<{ q?: string; loc?: string; occ?: string; sen?: string; tech?: string; show?: string; sal?: string; salcur?: string; exp?: string }>;
 };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { lang } = await params;
+  const locale = isLocale(lang) ? lang : defaultLocale;
+  const { i18n } = await loadCatalog(locale);
+
+  const title = i18n.t({ id: "explore.meta.title", message: "Explore Jobs" });
+  const description = i18n.t({
+    id: "explore.meta.description",
+    message: "Search and filter job openings across hundreds of companies.",
+  });
+
+  return {
+    title,
+    description,
+    alternates: buildAlternates("/explore", locale),
+    openGraph: {
+      title,
+      description,
+      url: `${siteConfig.url}/${locale}/explore`,
+      type: "website",
+    },
+  };
+}
 
 export default async function AppPage({ params, searchParams }: Props) {
   const locale = await initI18nForPage(params);

--- a/apps/web/app/[lang]/(public)/how-we-index/page.tsx
+++ b/apps/web/app/[lang]/(public)/how-we-index/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { initI18nForPage, isLocale, defaultLocale, loadCatalog } from "@/lib/i18n";
+import { siteConfig } from "@/content/config";
+import { buildAlternates } from "@/lib/seo";
 import { HowWeIndexContent } from "@/components/HowWeIndexContent";
 
 type Props = {
@@ -20,7 +22,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title,
     description,
-    openGraph: { title, description, url: `/${locale}/how-we-index` },
+    alternates: buildAlternates("/how-we-index", locale),
+    openGraph: { title, description, url: `${siteConfig.url}/${locale}/how-we-index` },
   };
 }
 

--- a/apps/web/app/[lang]/(public)/license/page.tsx
+++ b/apps/web/app/[lang]/(public)/license/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { initI18nForPage, isLocale, defaultLocale, loadCatalog } from "@/lib/i18n";
+import { siteConfig } from "@/content/config";
+import { buildAlternates } from "@/lib/seo";
 import { LicenseContent } from "@/components/LicenseContent";
 
 type Props = {
@@ -20,7 +22,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title,
     description,
-    openGraph: { title, description, url: `/${locale}/license` },
+    alternates: buildAlternates("/license", locale),
+    openGraph: { title, description, url: `${siteConfig.url}/${locale}/license` },
   };
 }
 

--- a/apps/web/app/[lang]/(public)/page.tsx
+++ b/apps/web/app/[lang]/(public)/page.tsx
@@ -5,6 +5,7 @@ import { Features } from "@/components/Features";
 import { Pricing } from "@/components/Pricing";
 import { PublicDomainArt } from "@/components/PublicDomainArt";
 import { siteConfig, publicDomainAssets } from "@/content/config";
+import { buildAlternates } from "@/lib/seo";
 
 type Props = {
   params: Promise<{ lang: string }>;
@@ -24,7 +25,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title,
     description,
-    openGraph: { title, description, url: `/${locale}` },
+    alternates: buildAlternates("", locale),
+    openGraph: { title, description, url: `${siteConfig.url}/${locale}` },
   };
 }
 

--- a/apps/web/app/[lang]/(public)/privacy-policy/page.tsx
+++ b/apps/web/app/[lang]/(public)/privacy-policy/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { initI18nForPage, isLocale, defaultLocale, loadCatalog } from "@/lib/i18n";
+import { siteConfig } from "@/content/config";
+import { buildAlternates } from "@/lib/seo";
 import { PrivacyPolicyContent } from "@/components/PrivacyPolicyContent";
 
 type Props = {
@@ -20,7 +22,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title,
     description,
-    openGraph: { title, description, url: `/${locale}/privacy-policy` },
+    alternates: buildAlternates("/privacy-policy", locale),
+    openGraph: { title, description, url: `${siteConfig.url}/${locale}/privacy-policy` },
   };
 }
 

--- a/apps/web/app/[lang]/(public)/terms/page.tsx
+++ b/apps/web/app/[lang]/(public)/terms/page.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { initI18nForPage, isLocale, defaultLocale, loadCatalog } from "@/lib/i18n";
+import { siteConfig } from "@/content/config";
+import { buildAlternates } from "@/lib/seo";
 import { TermsContent } from "@/components/TermsContent";
 
 type Props = {
@@ -20,7 +22,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   return {
     title,
     description,
-    openGraph: { title, description, url: `/${locale}/terms` },
+    alternates: buildAlternates("/terms", locale),
+    openGraph: { title, description, url: `${siteConfig.url}/${locale}/terms` },
   };
 }
 

--- a/apps/web/app/[lang]/layout.tsx
+++ b/apps/web/app/[lang]/layout.tsx
@@ -2,6 +2,8 @@ import { setI18n } from "@lingui/react/server";
 import type { ReactNode } from "react";
 import { LinguiClientProvider } from "@/components/LinguiProvider";
 import { type Locale, isLocale, defaultLocale, locales, loadCatalog } from "@/lib/i18n";
+import { siteConfig } from "@/content/config";
+import { JsonLd } from "@/lib/seo";
 
 type Props = {
   children: ReactNode;
@@ -21,6 +23,28 @@ export default async function LocaleLayout({ children, params }: Props) {
 
   return (
     <LinguiClientProvider locale={locale} messages={messages}>
+      <JsonLd data={{
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        name: "Job Seek",
+        url: siteConfig.url,
+        logo: `${siteConfig.url}${siteConfig.logo.src}`,
+        sameAs: [siteConfig.social.linkedin.href],
+      }} />
+      <JsonLd data={{
+        "@context": "https://schema.org",
+        "@type": "WebSite",
+        name: "Job Seek",
+        url: siteConfig.url,
+        potentialAction: {
+          "@type": "SearchAction",
+          target: {
+            "@type": "EntryPoint",
+            urlTemplate: `${siteConfig.url}/en/explore?q={search_term_string}`,
+          },
+          "query-input": "required name=search_term_string",
+        },
+      }} />
       {children}
     </LinguiClientProvider>
   );

--- a/apps/web/app/[lang]/layout.tsx
+++ b/apps/web/app/[lang]/layout.tsx
@@ -29,7 +29,7 @@ export default async function LocaleLayout({ children, params }: Props) {
         name: "Job Seek",
         url: siteConfig.url,
         logo: `${siteConfig.url}${siteConfig.logo.src}`,
-        sameAs: [siteConfig.social.linkedin.href],
+        sameAs: [siteConfig.social.linkedin.href, siteConfig.repoUrl],
       }} />
       <JsonLd data={{
         "@context": "https://schema.org",

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
     siteName: "Job Seek",
     locale: "en",
   },
-  twitter: { card: "summary" },
+  twitter: { card: "summary_large_image" },
 };
 
 /**

--- a/apps/web/app/opengraph-image.tsx
+++ b/apps/web/app/opengraph-image.tsx
@@ -1,0 +1,53 @@
+import { ImageResponse } from "next/og";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+export const alt = "Job Seek";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+const fontPromise = fetch(
+  new URL("../public/fonts/JetBrainsMono-Bold.woff2", import.meta.url),
+).then((res) => res.arrayBuffer());
+
+const logoPromise = readFile(
+  join(process.cwd(), "public", "android-chrome-512x512.png"),
+).then((buf) => `data:image/png;base64,${buf.toString("base64")}`);
+
+export default async function OgImage() {
+  const [fontData, logoSrc] = await Promise.all([fontPromise, logoPromise]);
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        backgroundColor: "#0a0a0a",
+        color: "#fafafa",
+        fontFamily: "JetBrains Mono",
+        gap: "24px",
+      }}
+    >
+      <img src={logoSrc} width={120} height={120} />
+      <span style={{ fontSize: 56, fontWeight: 700 }}>Job Seek</span>
+      <span style={{ fontSize: 26, color: "#a1a1aa" }}>
+        Find relevant roles faster
+      </span>
+    </div>,
+    {
+      ...size,
+      fonts: [
+        {
+          name: "JetBrains Mono",
+          data: fontData,
+          weight: 700,
+          style: "normal",
+        },
+      ],
+    },
+  );
+}

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -73,5 +73,36 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }
   }
 
+  // ── Public watchlists ─────────────────────────────────────────────
+  const watchlists = await db.execute<{
+    user_slug: string;
+    watchlist_slug: string;
+    updated_at: Date;
+  }>(sql`
+    SELECT
+      COALESCE(u.display_username, u.username) AS user_slug,
+      w.slug AS watchlist_slug,
+      w.updated_at
+    FROM watchlist w
+    JOIN "user" u ON u.id = w.user_id
+    WHERE w.is_public = true
+      AND u.username IS NOT NULL
+    ORDER BY w.updated_at DESC
+  `);
+
+  for (const row of watchlists) {
+    const path = `/${row.user_slug}/${row.watchlist_slug}`;
+    const languages = langAlternates(path);
+    for (const locale of locales) {
+      entries.push({
+        url: `${siteConfig.url}/${locale}${path}`,
+        lastModified: row.updated_at,
+        changeFrequency: "weekly",
+        priority: 0.6,
+        alternates: { languages },
+      });
+    }
+  }
+
   return entries;
 }

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -45,29 +45,36 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // ── Company pages ──────────────────────────────────────────────────
   // Only include companies that have at least one active job posting.
+  // Ordered by active posting count so high-content pages are crawled first.
   // If company count exceeds ~500, consider splitting with generateSitemaps().
   const companies = await db.execute<{
     slug: string;
     updated_at: Date;
+    active_count: number;
   }>(sql`
-    SELECT c.slug, c.updated_at
+    SELECT c.slug, c.updated_at,
+      (SELECT count(*) FROM job_posting jp
+       WHERE jp.company_id = c.id AND jp.is_active = true
+      )::int AS active_count
     FROM company c
     WHERE EXISTS (
       SELECT 1 FROM job_posting jp
       WHERE jp.company_id = c.id AND jp.is_active = true
     )
-    ORDER BY c.slug
+    ORDER BY active_count DESC, c.slug
   `);
 
   for (const row of companies) {
     const path = `/company/${row.slug}`;
     const languages = langAlternates(path);
+    // Scale priority: 0.9 for 20+ postings, 0.8 for 5+, 0.7 otherwise
+    const priority = row.active_count >= 20 ? 0.9 : row.active_count >= 5 ? 0.8 : 0.7;
     for (const locale of locales) {
       entries.push({
         url: `${siteConfig.url}/${locale}${path}`,
         lastModified: row.updated_at,
         changeFrequency: "daily",
-        priority: 0.8,
+        priority,
         alternates: { languages },
       });
     }

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,18 +1,74 @@
 import type { MetadataRoute } from "next";
+import { sql } from "drizzle-orm";
+import { db } from "@/db";
 import { siteConfig } from "@/content/config";
 import { locales } from "@/lib/i18n";
 
-export default function sitemap(): MetadataRoute.Sitemap {
+/** Build hreflang alternates map for a given path (without locale prefix). */
+function langAlternates(path: string): Record<string, string> {
+  const languages: Record<string, string> = {};
+  for (const locale of locales) {
+    languages[locale] = `${siteConfig.url}/${locale}${path}`;
+  }
+  return languages;
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const entries: MetadataRoute.Sitemap = [];
 
+  // ── Static pages ───────────────────────────────────────────────────
   for (const item of siteConfig.seo.sitemap) {
+    const suffix = item.path === "/" ? "" : item.path;
+    const languages = langAlternates(suffix);
     for (const locale of locales) {
-      const suffix = item.path === "/" ? "" : item.path;
       entries.push({
         url: `${siteConfig.url}/${locale}${suffix}`,
         lastModified: new Date(),
         changeFrequency: item.changeFrequency as "weekly" | "monthly",
         priority: item.priority,
+        alternates: { languages },
+      });
+    }
+  }
+
+  // ── Explore page ───────────────────────────────────────────────────
+  const exploreLanguages = langAlternates("/explore");
+  for (const locale of locales) {
+    entries.push({
+      url: `${siteConfig.url}/${locale}/explore`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.9,
+      alternates: { languages: exploreLanguages },
+    });
+  }
+
+  // ── Company pages ──────────────────────────────────────────────────
+  // Only include companies that have at least one active job posting.
+  // If company count exceeds ~500, consider splitting with generateSitemaps().
+  const companies = await db.execute<{
+    slug: string;
+    updated_at: Date;
+  }>(sql`
+    SELECT c.slug, c.updated_at
+    FROM company c
+    WHERE EXISTS (
+      SELECT 1 FROM job_posting jp
+      WHERE jp.company_id = c.id AND jp.is_active = true
+    )
+    ORDER BY c.slug
+  `);
+
+  for (const row of companies) {
+    const path = `/company/${row.slug}`;
+    const languages = langAlternates(path);
+    for (const locale of locales) {
+      entries.push({
+        url: `${siteConfig.url}/${locale}${path}`,
+        lastModified: row.updated_at,
+        changeFrequency: "daily",
+        priority: 0.8,
+        alternates: { languages },
       });
     }
   }

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -74,20 +74,24 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   }
 
   // ── Public watchlists ─────────────────────────────────────────────
+  // Curated (colophongroup) watchlists get higher priority than user-created ones.
+  const CURATED_USERNAME = "colophongroup";
   const watchlists = await db.execute<{
     user_slug: string;
     watchlist_slug: string;
     updated_at: Date;
+    is_curated: boolean;
   }>(sql`
     SELECT
       COALESCE(u.display_username, u.username) AS user_slug,
       w.slug AS watchlist_slug,
-      w.updated_at
+      w.updated_at,
+      (u.username = ${CURATED_USERNAME}) AS is_curated
     FROM watchlist w
     JOIN "user" u ON u.id = w.user_id
     WHERE w.is_public = true
       AND u.username IS NOT NULL
-    ORDER BY w.updated_at DESC
+    ORDER BY is_curated DESC, w.updated_at DESC
   `);
 
   for (const row of watchlists) {
@@ -97,8 +101,8 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       entries.push({
         url: `${siteConfig.url}/${locale}${path}`,
         lastModified: row.updated_at,
-        changeFrequency: "weekly",
-        priority: 0.6,
+        changeFrequency: row.is_curated ? "daily" : "weekly",
+        priority: row.is_curated ? 0.8 : 0.6,
         alternates: { languages },
       });
     }

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -371,28 +371,28 @@ msgstr "Beworben"
 msgid "myJobs.status.applied"
 msgstr "Beworben"
 
-#. Status option in dropdown: applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:33
-msgid "myJobs.statusOption.applied"
-msgstr "Beworben"
-
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
 msgstr "Beworben"
 
-#. Apply salary filter
+#. Status option in dropdown: applied
 #. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:320
-msgid "search.salaryModal.apply"
-msgstr "Anwenden"
+#: src/components/my-jobs/my-job-detail-panel.tsx:33
+msgid "myJobs.statusOption.applied"
+msgstr "Beworben"
 
 #. Apply experience filter
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:246
 msgid "search.experienceModal.apply"
+msgstr "Anwenden"
+
+#. Apply salary filter
+#. js-lingui-explicit-id
+#: src/components/search/salary-modal.tsx:320
+msgid "search.salaryModal.apply"
 msgstr "Anwenden"
 
 #. Apply button linking to original job posting
@@ -437,12 +437,6 @@ msgstr "Aug"
 msgid "settings.account.username.available"
 msgstr "Verfügbar"
 
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Zurück zur Anmeldung"
-
 #. Link back to sign-in after failed verification
 #. js-lingui-explicit-id
 #: app/[lang]/verify-email/page.tsx:68
@@ -459,6 +453,12 @@ msgstr "Zurück zur Anmeldung"
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:110
 msgid "auth.forgotPassword.backLink"
+msgstr "Zurück zur Anmeldung"
+
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
 msgstr "Zurück zur Anmeldung"
 
 #. Interview type label: behavioral interview
@@ -755,14 +755,14 @@ msgstr "Kontakt"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
-msgid "license.toc.title"
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Inhalt"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
+#: src/components/LicenseContent.tsx:18
+msgid "license.toc.title"
 msgstr "Inhalt"
 
 #. Button to continue to app after verification
@@ -1109,16 +1109,16 @@ msgstr "E-Mail-Benachrichtigungen bei neuen Stellen"
 msgid "home.features.s1.eyebrow"
 msgstr "Alles, was du brauchst, um vorne zu bleiben"
 
-#. Label for experience filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:177
-msgid "search.advanced.experience"
-msgstr "Erfahrung"
-
 #. Title for experience filter modal
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:186
 msgid "search.experienceModal.title"
+msgstr "Erfahrung"
+
+#. Label for experience filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:177
+msgid "search.advanced.experience"
 msgstr "Erfahrung"
 
 #. js-lingui-explicit-id
@@ -1605,16 +1605,16 @@ msgstr "Ungültiger Bestätigungslink"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:110
-msgid "watchlists.explore.jobSingular"
-msgstr "Job"
-
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31
 msgid "watchlists.card.jobSingular"
+msgstr "Job"
+
+#. Singular job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:110
+msgid "watchlists.explore.jobSingular"
 msgstr "Job"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -1682,10 +1682,10 @@ msgstr "Die Codebasis von Job Seek ist Open Source unter MIT. Die von uns gesamm
 msgid "watchlist.meta.fallback"
 msgstr "Job-Watchlist von @{owner}"
 
-#. Plural job count in public watchlist
+#. Job count label in watchlist view
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:111
-msgid "watchlists.explore.jobPlural"
+#: src/components/watchlist/watchlist-job-list.tsx:210
+msgid "watchlists.jobList.jobCount"
 msgstr "Jobs"
 
 #. Plural job count on watchlist card
@@ -1694,10 +1694,10 @@ msgstr "Jobs"
 msgid "watchlists.card.jobPlural"
 msgstr "Jobs"
 
-#. Job count label in watchlist view
+#. Plural job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:210
-msgid "watchlists.jobList.jobCount"
+#: src/components/watchlist/public-watchlist-search.tsx:111
+msgid "watchlists.explore.jobPlural"
 msgstr "Jobs"
 
 #. js-lingui-explicit-id
@@ -1788,16 +1788,16 @@ msgstr "Letzte Woche"
 msgid "home.hero.secondaryCta"
 msgstr "Mehr erfahren"
 
-#. Label for seniority/level filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:154
-msgid "search.advanced.level"
-msgstr "Stufe"
-
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:461
 msgid "search.bar.level"
+msgstr "Stufe"
+
+#. Label for seniority/level filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:154
+msgid "search.advanced.level"
 msgstr "Stufe"
 
 #. js-lingui-explicit-id
@@ -1858,16 +1858,16 @@ msgstr "Standort"
 msgid "search.advanced.location"
 msgstr "Standort"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:301
-msgid "search.detail.locations"
-msgstr "Standorte"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:531
 msgid "search.bar.locations"
+msgstr "Standorte"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:301
+msgid "search.detail.locations"
 msgstr "Standorte"
 
 #. Login button label
@@ -2120,17 +2120,17 @@ msgstr "Keine Jobs gefunden."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Keine Sprachen entsprechen deiner Suche."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:185
-msgid "company.locationModal.noResults"
-msgstr "Keine Standorte entsprechen Ihrer Suche."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:170
 msgid "search.locationModal.noResults"
 msgstr "Keine Standorte gefunden."
+
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:185
+msgid "company.locationModal.noResults"
+msgstr "Keine Standorte entsprechen Ihrer Suche."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2250,16 +2250,16 @@ msgstr "Angebot"
 msgid "myJobs.group.offered"
 msgstr "Angebot"
 
-#. Status option in dropdown: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:35
-msgid "myJobs.statusOption.offered"
-msgstr "Angebot"
-
 #. Sankey funnel node: offered
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:43
 msgid "myJobs.funnel.offered"
+msgstr "Angebot"
+
+#. Status option in dropdown: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:35
+msgid "myJobs.statusOption.offered"
 msgstr "Angebot"
 
 #. Cookie banner accept button
@@ -2365,26 +2365,26 @@ msgstr "Unsere Haltung zur Automatisierung"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:22
-msgid "license.toc.overview"
-msgstr "Überblick"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:27
 msgid "indexing.toc.overview"
 msgstr "Überblick"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:19
-msgid "license.toc.ariaLabel"
-msgstr "Seiteninhalt"
+#: src/components/LicenseContent.tsx:22
+msgid "license.toc.overview"
+msgstr "Überblick"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:24
 msgid "indexing.toc.ariaLabel"
+msgstr "Seiteninhalt"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:19
+msgid "license.toc.ariaLabel"
 msgstr "Seiteninhalt"
 
 #. Heading shown on the 404 page
@@ -2754,16 +2754,16 @@ msgstr "Abgelehnt"
 msgid "myJobs.status.rejected"
 msgstr "Abgelehnt"
 
-#. Status option in dropdown: rejected
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:36
-msgid "myJobs.statusOption.rejected"
-msgstr "Abgelehnt"
-
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
+msgstr "Abgelehnt"
+
+#. Status option in dropdown: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:36
+msgid "myJobs.statusOption.rejected"
 msgstr "Abgelehnt"
 
 #. Footer license summary text
@@ -2822,16 +2822,16 @@ msgstr "Erneut senden in {cooldown}s"
 msgid "auth.verify.resend"
 msgstr "Bestätigungs-E-Mail erneut senden"
 
-#. Reset salary filter
-#. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:314
-msgid "search.salaryModal.reset"
-msgstr "Zurücksetzen"
-
 #. Reset experience filter
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:240
 msgid "search.experienceModal.reset"
+msgstr "Zurücksetzen"
+
+#. Reset salary filter
+#. js-lingui-explicit-id
+#: src/components/search/salary-modal.tsx:314
+msgid "search.salaryModal.reset"
 msgstr "Zurücksetzen"
 
 #. Reset password submit button
@@ -2942,16 +2942,16 @@ msgstr "Gespeichert"
 msgid "myJobs.status.saved"
 msgstr "Gespeichert"
 
-#. Status option in dropdown: saved
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:32
-msgid "myJobs.statusOption.saved"
-msgstr "Gespeichert"
-
 #. Sankey funnel node: saved jobs
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:41
 msgid "myJobs.funnel.saved"
+msgstr "Gespeichert"
+
+#. Status option in dropdown: saved
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:32
+msgid "myJobs.statusOption.saved"
 msgstr "Gespeichert"
 
 #. Free feature: saved searches
@@ -2984,11 +2984,6 @@ msgstr "Speichern..."
 msgid "settings.account.email.saving"
 msgstr "Speichern…"
 
-#. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:26
-msgid "explore.meta.description"
-msgstr "Stellenangebote bei Hunderten von Unternehmen suchen und filtern."
-
 #. Placeholder for search bar when on company page
 #. js-lingui-explicit-id
 #. placeholder {0}: company.name
@@ -3008,23 +3003,28 @@ msgstr "Unternehmen suchen..."
 msgid "watchlists.companyModal.searchPlaceholder"
 msgstr "Unternehmen suchen..."
 
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/explore/page.tsx:26
+msgid "explore.meta.description"
+msgstr "Jobs bei Hunderten von Unternehmen durchsuchen. Erstellen Sie Watchlists, um neue Stellen zu verfolgen und Benachrichtigungen zu erhalten."
+
 #. Placeholder for search input in all-languages modal
 #. js-lingui-explicit-id
 #: src/components/settings/JobLanguageModal.tsx:77
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Sprachen suchen…"
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:164
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Standorte suchen…"
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:149
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Standorte suchen..."
+
+#. Placeholder for search input in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:164
+msgid "company.locationModal.searchPlaceholder"
+msgstr "Standorte suchen…"
 
 #. Back to search results link on company page
 #. js-lingui-explicit-id
@@ -3188,16 +3188,16 @@ msgstr "Einstellungen"
 #~ msgid "settings.billing.usage.unlimited"
 #~ msgstr "Unbegrenzt"
 
-#. Collapse location pill list
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:350
-msgid "company.page.showLess"
-msgstr "Weniger anzeigen"
-
 #. Button to collapse location list
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:344
 msgid "search.detail.showLessLocations"
+msgstr "Weniger anzeigen"
+
+#. Collapse location pill list
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:350
+msgid "company.page.showLess"
 msgstr "Weniger anzeigen"
 
 #. Aria label to show password
@@ -3308,12 +3308,6 @@ msgstr "Zum Inhalt springen"
 msgid "error.title"
 msgstr "Etwas ist schiefgelaufen"
 
-#. Generic forgot password error
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:43
-msgid "auth.forgotPassword.error.generic"
-msgstr "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
-
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
@@ -3323,6 +3317,12 @@ msgstr "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
 #: src/components/search/request-company.tsx:19
 msgid "app.home.request.error.unknown"
 msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
+
+#. Generic forgot password error
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:43
+msgid "auth.forgotPassword.error.generic"
+msgstr "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
 
 #. Generic error creating watchlist
 #. js-lingui-explicit-id
@@ -3445,16 +3445,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technisch"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:386
-msgid "search.detail.technologies"
-msgstr "Technologien"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:496
 msgid "search.bar.technologies"
+msgstr "Technologien"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:386
+msgid "search.detail.technologies"
 msgstr "Technologien"
 
 #. Add technology filter

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -109,11 +109,36 @@ msgstr "{0} weitere"
 msgid "search.detail.showMoreLocations"
 msgstr "{0} weitere"
 
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:37
+msgid "company.meta.positionCount"
+msgstr "{count, plural, one {# offene Stelle} other {# offene Stellen}}"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:72
+msgid "watchlist.meta.tracking"
+msgstr "{count, plural, one {# Unternehmen beobachtet} other {# Unternehmen beobachtet}}. {description}"
+
 #. Heatmap tooltip for multiple applications
 #. js-lingui-explicit-id
 #: src/components/my-jobs/activity-heatmap.tsx:80
 msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} Bewerbungen am {date}"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:40
+msgid "watchlist.meta.moreCompanies"
+msgstr "{count} weitere"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:49
+msgid "company.meta.descriptionBasic"
+msgstr "{countText} bei {name}"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:44
+msgid "company.meta.descriptionWithInfo"
+msgstr "{countText} bei {name}. {description}"
 
 #. Free plan price display
 #. js-lingui-explicit-id
@@ -171,7 +196,7 @@ msgstr "Unternehmen hinzufügen"
 
 #. Link to add a description to the watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:379
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:382
 msgid "watchlists.view.addDescription"
 msgstr "Beschreibung hinzufügen"
 
@@ -267,7 +292,7 @@ msgstr "Beliebig"
 
 #. Toggle to show jobs from all companies
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:407
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:410
 msgid "watchlists.view.anyCompany"
 msgstr "Alle Unternehmen"
 
@@ -334,28 +359,28 @@ msgstr "Bewerbungen im letzten Jahr"
 msgid "myJobs.group.applied"
 msgstr "Beworben"
 
-#. Applied status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:20
-msgid "myJobs.status.applied"
-msgstr "Beworben"
-
-#. Sankey funnel node: applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:42
-msgid "myJobs.funnel.applied"
-msgstr "Beworben"
-
 #. Application tracker status: applied
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:438
 msgid "search.tracker.applied"
 msgstr "Beworben"
 
+#. Applied status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:20
+msgid "myJobs.status.applied"
+msgstr "Beworben"
+
 #. Status option in dropdown: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:33
 msgid "myJobs.statusOption.applied"
+msgstr "Beworben"
+
+#. Sankey funnel node: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:42
+msgid "myJobs.funnel.applied"
 msgstr "Beworben"
 
 #. Apply salary filter
@@ -412,16 +437,16 @@ msgstr "Aug"
 msgid "settings.account.username.available"
 msgstr "Verfügbar"
 
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Zurück zur Anmeldung"
-
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Zurück zur Anmeldung"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Zurück zur Anmeldung"
 
 #. Link back to sign-in from forgot password
@@ -572,14 +597,14 @@ msgstr "Zurücksetzen"
 
 #. Button to remove all companies from watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:425
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:428
 msgid "watchlists.view.clearAllCompanies"
 msgstr "Alle entfernen"
 
 #. Button to clear all active search filters
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:533
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:536
 #: src/components/search/search-toolbar.tsx:282
 msgid "search.filters.clearAll"
 msgstr "Alle löschen"
@@ -592,7 +617,7 @@ msgstr "Alle entfernen"
 
 #. Tooltip for clicking to edit watchlist description
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:369
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:370
 msgid "watchlists.view.editDescription"
 msgstr "Klicken, um Beschreibung zu bearbeiten"
 
@@ -664,7 +689,7 @@ msgstr "Beobachtete Unternehmen"
 
 #. Button to open company search modal
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:396
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:399
 msgid "watchlists.view.addCompany"
 msgstr "Unternehmen"
 
@@ -924,7 +949,7 @@ msgstr "Löschen…"
 
 #. Placeholder for watchlist description textarea
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:361
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:362
 msgid "watchlists.view.descriptionPlaceholder"
 msgstr "Diese Watchlist beschreiben …"
 
@@ -1084,23 +1109,33 @@ msgstr "E-Mail-Benachrichtigungen bei neuen Stellen"
 msgid "home.features.s1.eyebrow"
 msgstr "Alles, was du brauchst, um vorne zu bleiben"
 
-#. Title for experience filter modal
-#. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:186
-msgid "search.experienceModal.title"
-msgstr "Erfahrung"
-
 #. Label for experience filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:177
 msgid "search.advanced.experience"
 msgstr "Erfahrung"
 
+#. Title for experience filter modal
+#. js-lingui-explicit-id
+#: src/components/search/experience-modal.tsx:186
+msgid "search.experienceModal.title"
+msgstr "Erfahrung"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:160
+msgid "breadcrumb.explore"
+msgstr "Entdecken"
+
 #. Explore nav icon tooltip
 #. js-lingui-explicit-id
 #: src/components/AppHeader.tsx:54
 msgid "app.header.nav.explore"
 msgstr "Entdecken"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/explore/page.tsx:25
+msgid "explore.meta.title"
+msgstr "Jobs entdecken"
 
 #. Generic email change error
 #. js-lingui-explicit-id
@@ -1225,7 +1260,7 @@ msgid "settings.general.jobLanguages.findMore"
 msgstr "Weitere finden"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:18
+#: app/[lang]/(public)/page.tsx:19
 msgid "home.meta.title"
 msgstr "Relevante Stellen schneller finden"
 
@@ -1378,6 +1413,12 @@ msgstr "Passwort verbergen"
 msgid "myJobs.interviewType.hiringManager"
 msgstr "Hiring Manager"
 
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:167
+#: app/[lang]/(app)/company/[slug]/page.tsx:159
+msgid "breadcrumb.home"
+msgstr "Startseite"
+
 #. Hourly pay period option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:356
@@ -1399,12 +1440,12 @@ msgid "common.nav.company"
 msgstr "Wie indexieren wir Stellen?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:15
+#: app/[lang]/(public)/privacy-policy/page.tsx:17
 msgid "privacy.meta.description"
 msgstr "Wie Job Seek deine persönlichen Daten erhebt, nutzt und schützt."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:15
+#: app/[lang]/(public)/how-we-index/page.tsx:17
 msgid "indexing.meta.description"
 msgstr "Wie Job Seek Stellenanzeigen entdeckt, crawlt und indexiert — und welche Schutzmaßnahmen wir einhalten."
 
@@ -1427,7 +1468,7 @@ msgid "indexing.hero.title"
 msgstr "Wie wir Stellenanzeigen finden und verarbeiten"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:14
+#: app/[lang]/(public)/how-we-index/page.tsx:16
 msgid "indexing.meta.title"
 msgstr "So indexieren wir"
 
@@ -1454,6 +1495,11 @@ msgstr "Wenn du unerwartete Aktivitäten unseres Crawlers bemerkst oder es vorzi
 #: src/components/HowWeIndexContent.tsx:206
 msgid "indexing.outreach.body"
 msgstr "Wenn du ungewöhnliches Crawler-Verhalten bemerkst, es vorziehst, dass wir deine Inhalte nicht indexieren, oder Vorschläge zur Verbesserung unserer Schutzmaßnahmen hast, kontaktiere uns bitte."
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:56
+msgid "watchlist.meta.inLocations"
+msgstr "in {locations}"
 
 #. Year postings count on company page
 #. js-lingui-explicit-id
@@ -1517,16 +1563,16 @@ msgstr "Interview"
 msgid "myJobs.group.interviewing"
 msgstr "Im Interview"
 
-#. Interviewing status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:21
-msgid "myJobs.status.interviewing"
-msgstr "Im Interview"
-
 #. Application tracker status: interviewing
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:439
 msgid "search.tracker.interviewing"
+msgstr "Im Interview"
+
+#. Interviewing status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:21
+msgid "myJobs.status.interviewing"
 msgstr "Im Interview"
 
 #. Status option in dropdown: interviewing
@@ -1559,16 +1605,16 @@ msgstr "Ungültiger Bestätigungslink"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:31
-msgid "watchlists.card.jobSingular"
-msgstr "Job"
-
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:110
 msgid "watchlists.explore.jobSingular"
+msgstr "Job"
+
+#. Singular job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:31
+msgid "watchlists.card.jobSingular"
 msgstr "Job"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -1631,6 +1677,17 @@ msgstr "Job Seek wird aktiv entwickelt. Bleib dran für Updates!"
 msgid "license.hero.description"
 msgstr "Die Codebasis von Job Seek ist Open Source unter MIT. Die von uns gesammelten und aufbereiteten Stellendaten stehen unter Creative Commons BY-NC 4.0. Nachfolgend eine verständliche Zusammenfassung — bitte lies die vollständigen Lizenzen für die genauen Bedingungen."
 
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:64
+msgid "watchlist.meta.fallback"
+msgstr "Job-Watchlist von @{owner}"
+
+#. Plural job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:111
+msgid "watchlists.explore.jobPlural"
+msgstr "Jobs"
+
 #. Plural job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:32
@@ -1643,11 +1700,15 @@ msgstr "Jobs"
 msgid "watchlists.jobList.jobCount"
 msgstr "Jobs"
 
-#. Plural job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:111
-msgid "watchlists.explore.jobPlural"
-msgstr "Jobs"
+#: app/[lang]/(app)/company/[slug]/page.tsx:30
+msgid "company.meta.title"
+msgstr "Jobs bei {name}"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:46
+msgid "watchlist.meta.jobsAt"
+msgstr "Jobs bei {names}"
 
 #. Short July label
 #. js-lingui-explicit-id
@@ -1727,20 +1788,20 @@ msgstr "Letzte Woche"
 msgid "home.hero.secondaryCta"
 msgstr "Mehr erfahren"
 
-#. Section header for seniority suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:461
-msgid "search.bar.level"
-msgstr "Stufe"
-
 #. Label for seniority/level filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:154
 msgid "search.advanced.level"
 msgstr "Stufe"
 
+#. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:14
+#: src/components/search/search-bar.tsx:461
+msgid "search.bar.level"
+msgstr "Stufe"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/license/page.tsx:16
 msgid "license.meta.title"
 msgstr "Lizenz"
 
@@ -1763,7 +1824,7 @@ msgid "license.hero.eyebrow"
 msgstr "Lizenzierung"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:15
+#: app/[lang]/(public)/license/page.tsx:17
 msgid "license.meta.description"
 msgstr "Lizenzbedingungen für den Job-Seek-Anwendungscode (MIT) und die Stellendaten (CC BY-NC 4.0)."
 
@@ -1797,16 +1858,16 @@ msgstr "Standort"
 msgid "search.advanced.location"
 msgstr "Standort"
 
-#. Section header for location suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:531
-msgid "search.bar.locations"
-msgstr "Standorte"
-
 #. Locations heading in job detail
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:301
 msgid "search.detail.locations"
+msgstr "Standorte"
+
+#. Section header for location suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:531
+msgid "search.bar.locations"
 msgstr "Standorte"
 
 #. Login button label
@@ -2131,16 +2192,16 @@ msgstr "Keine Watchlists gefunden."
 msgid "watchlists.page.empty"
 msgstr "Noch keine Watchlists. Erstelle eine, um Jobs von deinen Lieblingsunternehmen zu verfolgen."
 
-#. Sankey funnel node: not applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:44
-msgid "myJobs.funnel.notApplied"
-msgstr "Nicht beworben"
-
 #. Application tracker status: not applied
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:437
 msgid "search.tracker.notApplied"
+msgstr "Nicht beworben"
+
+#. Sankey funnel node: not applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:44
+msgid "myJobs.funnel.notApplied"
 msgstr "Nicht beworben"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2171,16 +2232,16 @@ msgstr "Berufsfeld"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Okt"
 
-#. Offered status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:22
-msgid "myJobs.status.offered"
-msgstr "Angebot"
-
 #. Application tracker status: offer
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:440
 msgid "search.tracker.offer"
+msgstr "Angebot"
+
+#. Offered status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:22
+msgid "myJobs.status.offered"
 msgstr "Angebot"
 
 #. Status group heading: offered
@@ -2189,16 +2250,16 @@ msgstr "Angebot"
 msgid "myJobs.group.offered"
 msgstr "Angebot"
 
-#. Sankey funnel node: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:43
-msgid "myJobs.funnel.offered"
-msgstr "Angebot"
-
 #. Status option in dropdown: offered
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:35
 msgid "myJobs.statusOption.offered"
+msgstr "Angebot"
+
+#. Sankey funnel node: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:43
+msgid "myJobs.funnel.offered"
 msgstr "Angebot"
 
 #. Cookie banner accept button
@@ -2236,6 +2297,11 @@ msgstr "Vor Ort"
 #: src/components/Header.tsx:79
 msgid "common.header.openMenu"
 msgstr "Hauptmenü öffnen"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:42
+msgid "company.meta.openPositions"
+msgstr "Offene Stellen"
 
 #. TOC: Open-source crawlers
 #. js-lingui-explicit-id
@@ -2529,18 +2595,18 @@ msgstr "Stelle nicht gefunden."
 msgid "myJobs.detail.notFound"
 msgstr "Stellenanzeige nicht gefunden."
 
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:101
+msgid "home.pricing.eyebrow"
+msgstr "Preise"
+
 #. Nav link: Pricing
 #. Nav link: Pricing
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:61
 #: src/components/MobileMenu.tsx:86
 msgid "common.nav.pricing"
-msgstr "Preise"
-
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: src/components/Pricing.tsx:101
-msgid "home.pricing.eyebrow"
 msgstr "Preise"
 
 #. Privacy policy page eyebrow
@@ -2562,7 +2628,7 @@ msgid "privacy.hero.title"
 msgstr "Datenschutz bei Job Seek"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:14
+#: app/[lang]/(public)/privacy-policy/page.tsx:16
 msgid "privacy.meta.title"
 msgstr "Datenschutzrichtlinie"
 
@@ -2676,28 +2742,28 @@ msgstr "Region"
 msgid "myJobs.group.rejected"
 msgstr "Abgelehnt"
 
-#. Rejected status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:23
-msgid "myJobs.status.rejected"
-msgstr "Abgelehnt"
-
-#. Sankey funnel node label prefix: rejected
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:45
-msgid "myJobs.funnel.rejected"
-msgstr "Abgelehnt"
-
 #. Application tracker status: rejected
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:441
 msgid "search.tracker.rejected"
 msgstr "Abgelehnt"
 
+#. Rejected status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:23
+msgid "myJobs.status.rejected"
+msgstr "Abgelehnt"
+
 #. Status option in dropdown: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.rejected"
+msgstr "Abgelehnt"
+
+#. Sankey funnel node label prefix: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:45
+msgid "myJobs.funnel.rejected"
 msgstr "Abgelehnt"
 
 #. Footer license summary text
@@ -2810,16 +2876,16 @@ msgstr "Berufe"
 msgid "myJobs.funnel.round"
 msgstr "Runde"
 
-#. Salary override section heading
-#. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:76
-msgid "myJobs.detail.salary"
-msgstr "Gehalt"
-
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:171
 msgid "search.advanced.salary"
+msgstr "Gehalt"
+
+#. Salary override section heading
+#. js-lingui-explicit-id
+#: src/components/my-jobs/salary-override.tsx:76
+msgid "myJobs.detail.salary"
 msgstr "Gehalt"
 
 #. Salary display settings section heading
@@ -2876,16 +2942,16 @@ msgstr "Gespeichert"
 msgid "myJobs.status.saved"
 msgstr "Gespeichert"
 
-#. Sankey funnel node: saved jobs
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:41
-msgid "myJobs.funnel.saved"
-msgstr "Gespeichert"
-
 #. Status option in dropdown: saved
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:32
 msgid "myJobs.statusOption.saved"
+msgstr "Gespeichert"
+
+#. Sankey funnel node: saved jobs
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:41
+msgid "myJobs.funnel.saved"
 msgstr "Gespeichert"
 
 #. Free feature: saved searches
@@ -2918,6 +2984,11 @@ msgstr "Speichern..."
 msgid "settings.account.email.saving"
 msgstr "Speichern…"
 
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/explore/page.tsx:26
+msgid "explore.meta.description"
+msgstr "Stellenangebote bei Hunderten von Unternehmen suchen und filtern."
+
 #. Placeholder for search bar when on company page
 #. js-lingui-explicit-id
 #. placeholder {0}: company.name
@@ -2925,16 +2996,16 @@ msgstr "Speichern…"
 msgid "company.page.searchPlaceholder"
 msgstr "Suchen bei {0}..."
 
-#. Placeholder for company search in modal
-#. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:212
-msgid "watchlists.companyModal.searchPlaceholder"
-msgstr "Unternehmen suchen..."
-
 #. Placeholder for company search in watchlist creation
 #. js-lingui-explicit-id
 #: src/components/watchlist/company-selector.tsx:91
 msgid "watchlists.companySelector.placeholder"
+msgstr "Unternehmen suchen..."
+
+#. Placeholder for company search in modal
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-search-modal.tsx:212
+msgid "watchlists.companyModal.searchPlaceholder"
 msgstr "Unternehmen suchen..."
 
 #. Placeholder for search input in all-languages modal
@@ -3237,6 +3308,12 @@ msgstr "Zum Inhalt springen"
 msgid "error.title"
 msgstr "Etwas ist schiefgelaufen"
 
+#. Generic forgot password error
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:43
+msgid "auth.forgotPassword.error.generic"
+msgstr "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
+
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
@@ -3246,12 +3323,6 @@ msgstr "Etwas ist schiefgelaufen"
 #: src/components/search/request-company.tsx:19
 msgid "app.home.request.error.unknown"
 msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
-
-#. Generic forgot password error
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:43
-msgid "auth.forgotPassword.error.generic"
-msgstr "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
 
 #. Generic error creating watchlist
 #. js-lingui-explicit-id
@@ -3334,7 +3405,7 @@ msgid "home.pricing.free.f1"
 msgstr "Bis zu 5 Unternehmen abonnieren"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:19
+#: app/[lang]/(public)/page.tsx:20
 msgid "home.meta.description"
 msgstr "Abonniere Updates von Unternehmen, verfolge Bewerbungen und verpasse keine neuen Stellen."
 
@@ -3374,16 +3445,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technisch"
 
-#. Section header for technology suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:496
-msgid "search.bar.technologies"
-msgstr "Technologien"
-
 #. Technologies sub-heading in details section
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:386
 msgid "search.detail.technologies"
+msgstr "Technologien"
+
+#. Section header for technology suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:496
+msgid "search.bar.technologies"
 msgstr "Technologien"
 
 #. Add technology filter
@@ -3417,7 +3488,7 @@ msgid "common.footer.termsLink"
 msgstr "AGB"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:14
+#: app/[lang]/(public)/terms/page.tsx:16
 msgid "terms.meta.title"
 msgstr "Nutzungsbedingungen"
 
@@ -3428,7 +3499,7 @@ msgid "terms.hero.title"
 msgstr "Nutzungsbedingungen"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:15
+#: app/[lang]/(public)/terms/page.tsx:17
 msgid "terms.meta.description"
 msgstr "Nutzungsbedingungen der Job-Seek-Anwendung."
 

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -98,22 +98,47 @@ msgstr "{0} employees"
 #. Count of additional watchlists not shown
 #. js-lingui-explicit-id
 #. placeholder {0}: total - results.length
-#: src/components/watchlist/public-watchlist-search.tsx:127
+#: src/components/watchlist/public-watchlist-search.tsx:130
 msgid "watchlists.explore.moreCount"
 msgstr "{0} more"
 
 #. Button to show remaining collapsed locations
 #. js-lingui-explicit-id
 #. placeholder {0}: locations.length - LOCATIONS_COLLAPSED
-#: src/components/search/job-detail-dialog.tsx:350
+#: src/components/search/job-detail-dialog.tsx:348
 msgid "search.detail.showMoreLocations"
 msgstr "{0} more"
 
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:37
+msgid "company.meta.positionCount"
+msgstr "{count, plural, one {# open position} other {# open positions}}"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:72
+msgid "watchlist.meta.tracking"
+msgstr "{count, plural, one {Tracking # company} other {Tracking # companies}}. {description}"
+
 #. Heatmap tooltip for multiple applications
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:81
+#: src/components/my-jobs/activity-heatmap.tsx:80
 msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} applications on {date}"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:40
+msgid "watchlist.meta.moreCompanies"
+msgstr "{count} more"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:49
+msgid "company.meta.descriptionBasic"
+msgstr "{countText} at {name}"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:44
+msgid "company.meta.descriptionWithInfo"
+msgstr "{countText} at {name}. {description}"
 
 #. Free plan price display
 #. js-lingui-explicit-id
@@ -129,7 +154,7 @@ msgstr "$10 / month"
 
 #. Heatmap tooltip for 1 application
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:80
+#: src/components/my-jobs/activity-heatmap.tsx:79
 msgid "myJobs.heatmap.tooltipOne"
 msgstr "1 application on {date}"
 
@@ -169,15 +194,21 @@ msgstr "active"
 msgid "watchlists.companyModal.title"
 msgstr "Add companies"
 
+#. Link to add a description to the watchlist
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:382
+msgid "watchlists.view.addDescription"
+msgstr "Add description"
+
 #. Quick action tooltip: add interview round
 #. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:20
+#: src/components/my-jobs/quick-actions.tsx:19
 msgid "myJobs.action.addInterview"
 msgstr "Add interview"
 
 #. Button to add an interview round
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:78
+#: src/components/my-jobs/interview-list.tsx:76
 msgid "myJobs.detail.addInterview"
 msgstr "Add interview"
 
@@ -261,7 +292,7 @@ msgstr "Any"
 
 #. Toggle to show jobs from all companies
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:329
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:410
 msgid "watchlists.view.anyCompany"
 msgstr "Any company"
 
@@ -282,7 +313,7 @@ msgstr "Application code (MIT)"
 
 #. Link to application stats page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:265
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:263
 msgid "myJobs.viewStats"
 msgstr "Application stats"
 
@@ -312,7 +343,7 @@ msgstr "Application tracker"
 
 #. Application tracker section heading in job detail
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:246
+#: src/components/search/job-detail-dialog.tsx:244
 msgid "search.detail.applicationTracker"
 msgstr "Application tracker"
 
@@ -324,32 +355,32 @@ msgstr "applications in the past year"
 
 #. Status group heading: applied jobs
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:31
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:29
 msgid "myJobs.group.applied"
 msgstr "Applied"
 
 #. Application tracker status: applied
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:440
+#: src/components/search/job-detail-dialog.tsx:438
 msgid "search.tracker.applied"
 msgstr "Applied"
 
 #. Applied status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:21
+#: src/components/my-jobs/status-badge.tsx:20
 msgid "myJobs.status.applied"
-msgstr "Applied"
-
-#. Sankey funnel node: applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:43
-msgid "myJobs.funnel.applied"
 msgstr "Applied"
 
 #. Status option in dropdown: applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:35
+#: src/components/my-jobs/my-job-detail-panel.tsx:33
 msgid "myJobs.statusOption.applied"
+msgstr "Applied"
+
+#. Sankey funnel node: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:42
+msgid "myJobs.funnel.applied"
 msgstr "Applied"
 
 #. Apply salary filter
@@ -366,13 +397,13 @@ msgstr "Apply"
 
 #. Apply button linking to original job posting
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:295
+#: src/components/my-jobs/my-job-detail-panel.tsx:293
 msgid "search.detail.apply"
 msgstr "Apply"
 
 #. Short April label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:61
+#: src/components/my-jobs/activity-heatmap.tsx:60
 msgid "myJobs.heatmap.month.apr"
 msgstr "Apr"
 
@@ -396,7 +427,7 @@ msgstr "At most 30 characters"
 
 #. Short August label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:65
+#: src/components/my-jobs/activity-heatmap.tsx:64
 msgid "myJobs.heatmap.month.aug"
 msgstr "Aug"
 
@@ -432,7 +463,7 @@ msgstr "Back to sign in"
 
 #. Interview type label: behavioral interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:23
+#: src/components/my-jobs/interview-list.tsx:21
 msgid "myJobs.interviewType.behavioral"
 msgstr "Behavioral"
 
@@ -498,20 +529,20 @@ msgstr "Change your password via a secure email link."
 
 #. Placeholder in status change dropdown
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:63
+#: src/components/my-jobs/my-job-detail-panel.tsx:61
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Change..."
-
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "Check your email"
 
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
+msgstr "Check your email"
+
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
 msgstr "Check your email"
 
 #. Checking username availability
@@ -566,14 +597,14 @@ msgstr "Clear"
 
 #. Button to remove all companies from watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:347
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:428
 msgid "watchlists.view.clearAllCompanies"
 msgstr "Clear all"
 
 #. Button to clear all active search filters
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:455
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:536
 #: src/components/search/search-toolbar.tsx:282
 msgid "search.filters.clearAll"
 msgstr "Clear all"
@@ -584,9 +615,15 @@ msgstr "Clear all"
 msgid "watchlists.companyModal.clearAll"
 msgstr "Clear all"
 
+#. Tooltip for clicking to edit watchlist description
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:370
+msgid "watchlists.view.editDescription"
+msgstr "Click to edit description"
+
 #. Tooltip for clicking to edit watchlist title
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:289
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:320
 msgid "watchlists.view.editTitle"
 msgstr "Click to rename"
 
@@ -616,7 +653,7 @@ msgstr "Closed"
 
 #. Interview type label: coding challenge
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:21
+#: src/components/my-jobs/interview-list.tsx:19
 msgid "myJobs.interviewType.coding"
 msgstr "Coding"
 
@@ -652,19 +689,19 @@ msgstr "Companies Tracked"
 
 #. Button to open company search modal
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:318
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:399
 msgid "watchlists.view.addCompany"
 msgstr "Company"
 
 #. Sort option: company name
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:17
+#: src/components/my-jobs/sort-filter-bar.tsx:16
 msgid "myJobs.sort.company"
 msgstr "Company"
 
 #. Group by company option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:24
+#: src/components/my-jobs/sort-filter-bar.tsx:23
 msgid "myJobs.group.company"
 msgstr "Company"
 
@@ -718,14 +755,14 @@ msgstr "Contact"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
+#: src/components/LicenseContent.tsx:18
+msgid "license.toc.title"
 msgstr "Contents"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
-msgid "license.toc.title"
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Contents"
 
 #. Button to continue to app after verification
@@ -754,7 +791,7 @@ msgstr "Continue with LinkedIn"
 
 #. Employment type: contract
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:15
+#: src/components/search/employment-type-modal.tsx:13
 msgid "search.employmentType.contract"
 msgstr "Contract"
 
@@ -834,7 +871,7 @@ msgstr "Currency"
 
 #. Currency label in salary override
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:108
+#: src/components/my-jobs/salary-override.tsx:106
 msgid "myJobs.detail.salary.currency"
 msgstr "Currency"
 
@@ -858,13 +895,13 @@ msgstr "Dark"
 
 #. Sort option: date saved
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:15
+#: src/components/my-jobs/sort-filter-bar.tsx:14
 msgid "myJobs.sort.dateSaved"
 msgstr "Date saved"
 
 #. Short December label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:69
+#: src/components/my-jobs/activity-heatmap.tsx:68
 msgid "myJobs.heatmap.month.dec"
 msgstr "Dec"
 
@@ -882,7 +919,7 @@ msgstr "Delete"
 
 #. Delete interview button
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:165
+#: src/components/my-jobs/interview-list.tsx:163
 msgid "myJobs.interview.delete"
 msgstr "Delete"
 
@@ -910,6 +947,12 @@ msgstr "Delete watchlist?"
 msgid "settings.account.delete.deleting"
 msgstr "Deleting..."
 
+#. Placeholder for watchlist description textarea
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:362
+msgid "watchlists.view.descriptionPlaceholder"
+msgstr "Describe this watchlist..."
+
 #. Cookie banner details button
 #. js-lingui-explicit-id
 #: src/components/CookieBanner.tsx:60
@@ -918,7 +961,7 @@ msgstr "Details"
 
 #. Collapsible section heading for extracted job details
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:378
+#: src/components/search/job-detail-dialog.tsx:376
 msgid "search.detail.details"
 msgstr "Details"
 
@@ -1020,7 +1063,7 @@ msgstr "Email verified"
 
 #. Title for the employment type selection modal
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:49
+#: src/components/search/employment-type-modal.tsx:47
 msgid "search.employmentTypeModal.title"
 msgstr "Employment type"
 
@@ -1066,23 +1109,33 @@ msgstr "Email alerts for new postings"
 msgid "home.features.s1.eyebrow"
 msgstr "Everything you need to stay ahead"
 
-#. Title for experience filter modal
-#. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:186
-msgid "search.experienceModal.title"
-msgstr "Experience"
-
 #. Label for experience filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:177
 msgid "search.advanced.experience"
 msgstr "Experience"
 
+#. Title for experience filter modal
+#. js-lingui-explicit-id
+#: src/components/search/experience-modal.tsx:186
+msgid "search.experienceModal.title"
+msgstr "Experience"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:160
+msgid "breadcrumb.explore"
+msgstr "Explore"
+
 #. Explore nav icon tooltip
 #. js-lingui-explicit-id
 #: src/components/AppHeader.tsx:54
 msgid "app.header.nav.explore"
 msgstr "Explore"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/explore/page.tsx:25
+msgid "explore.meta.title"
+msgstr "Explore Jobs"
 
 #. Generic email change error
 #. js-lingui-explicit-id
@@ -1150,7 +1203,7 @@ msgstr "Features"
 
 #. Short February label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:59
+#: src/components/my-jobs/activity-heatmap.tsx:58
 msgid "myJobs.heatmap.month.feb"
 msgstr "Feb"
 
@@ -1164,15 +1217,15 @@ msgstr "Filter"
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:103
-#: src/components/search/job-detail-dialog.tsx:291
-#: src/components/search/job-detail-dialog.tsx:369
+#: src/components/search/job-detail-dialog.tsx:101
+#: src/components/search/job-detail-dialog.tsx:289
+#: src/components/search/job-detail-dialog.tsx:367
 msgid "search.detail.filterByPrefix"
 msgstr "Filter by"
 
 #. Tooltip for salary filter pill
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:225
+#: src/components/search/job-detail-dialog.tsx:223
 msgid "search.detail.filterBySalary"
 msgstr "Filter by this salary range"
 
@@ -1207,7 +1260,7 @@ msgid "settings.general.jobLanguages.findMore"
 msgstr "Find more"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:18
+#: app/[lang]/(public)/page.tsx:19
 msgid "home.meta.title"
 msgstr "Find Relevant Roles Faster"
 
@@ -1280,7 +1333,7 @@ msgstr "Free"
 
 #. Short Friday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:50
+#: src/components/my-jobs/activity-heatmap.tsx:49
 msgid "myJobs.heatmap.day.fri"
 msgstr "Fri"
 
@@ -1292,7 +1345,7 @@ msgstr "Full job search"
 
 #. Employment type: full-time
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:13
+#: src/components/search/employment-type-modal.tsx:11
 msgid "search.employmentType.fullTime"
 msgstr "Full-time"
 
@@ -1356,9 +1409,15 @@ msgstr "Hide password"
 
 #. Interview type label: hiring manager round
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:26
+#: src/components/my-jobs/interview-list.tsx:24
 msgid "myJobs.interviewType.hiringManager"
 msgstr "Hiring Manager"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:167
+#: app/[lang]/(app)/company/[slug]/page.tsx:159
+msgid "breadcrumb.home"
+msgstr "Home"
 
 #. Hourly pay period option
 #. js-lingui-explicit-id
@@ -1368,7 +1427,7 @@ msgstr "Hourly"
 
 #. Hourly salary period option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:48
+#: src/components/my-jobs/salary-override.tsx:46
 msgid "myJobs.salary.hourly"
 msgstr "Hourly"
 
@@ -1381,12 +1440,12 @@ msgid "common.nav.company"
 msgstr "How do we index jobs?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:15
+#: app/[lang]/(public)/privacy-policy/page.tsx:17
 msgid "privacy.meta.description"
 msgstr "How Job Seek collects, uses, and protects your personal data."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:15
+#: app/[lang]/(public)/how-we-index/page.tsx:17
 msgid "indexing.meta.description"
 msgstr "How Job Seek discovers, crawls, and indexes job postings — and the safeguards we follow."
 
@@ -1409,7 +1468,7 @@ msgid "indexing.hero.title"
 msgstr "How we find and process job postings"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:14
+#: app/[lang]/(public)/how-we-index/page.tsx:16
 msgid "indexing.meta.title"
 msgstr "How We Index"
 
@@ -1436,6 +1495,11 @@ msgstr "If you notice unexpected activity from our crawler or prefer that your c
 #: src/components/HowWeIndexContent.tsx:206
 msgid "indexing.outreach.body"
 msgstr "If you notice unusual crawler behaviour, prefer that we do not index your content, or have suggestions on how to improve our safeguards, please reach out."
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:56
+msgid "watchlist.meta.inLocations"
+msgstr "in {locations}"
 
 #. Year postings count on company page
 #. js-lingui-explicit-id
@@ -1483,43 +1547,43 @@ msgstr "Input is too short."
 
 #. Employment type: internship
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:16
+#: src/components/search/employment-type-modal.tsx:14
 msgid "search.employmentType.internship"
 msgstr "Internship"
 
 #. Interview type label: general interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:17
+#: src/components/my-jobs/interview-list.tsx:15
 msgid "myJobs.interviewType.interview"
 msgstr "Interview"
 
 #. Status group heading: interviewing
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:32
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:30
 msgid "myJobs.group.interviewing"
 msgstr "Interviewing"
 
 #. Application tracker status: interviewing
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:441
+#: src/components/search/job-detail-dialog.tsx:439
 msgid "search.tracker.interviewing"
 msgstr "Interviewing"
 
 #. Interviewing status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:22
+#: src/components/my-jobs/status-badge.tsx:21
 msgid "myJobs.status.interviewing"
 msgstr "Interviewing"
 
 #. Status option in dropdown: interviewing
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:36
+#: src/components/my-jobs/my-job-detail-panel.tsx:34
 msgid "myJobs.statusOption.interviewing"
 msgstr "Interviewing"
 
 #. Interviews section heading
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:51
+#: src/components/my-jobs/interview-list.tsx:49
 msgid "myJobs.detail.interviews"
 msgstr "Interviews"
 
@@ -1537,20 +1601,20 @@ msgstr "Invalid verification link"
 
 #. Short January label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:58
+#: src/components/my-jobs/activity-heatmap.tsx:57
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
+
+#. Singular job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:110
+msgid "watchlists.explore.jobSingular"
+msgstr "job"
 
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31
 msgid "watchlists.card.jobSingular"
-msgstr "job"
-
-#. Singular job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:107
-msgid "watchlists.explore.jobSingular"
 msgstr "job"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -1561,13 +1625,13 @@ msgstr "Job data (CC BY-NC 4.0)"
 
 #. Job detail panel title
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:73
+#: src/components/search/job-detail-dialog.tsx:71
 msgid "search.detail.title"
 msgstr "Job Details"
 
 #. Job detail panel title in My Jobs
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:160
+#: src/components/my-jobs/my-job-detail-panel.tsx:158
 msgid "myJobs.detail.title"
 msgstr "Job Details"
 
@@ -1613,10 +1677,15 @@ msgstr "Job Seek is being actively built. Stay tuned for updates!"
 msgid "license.hero.description"
 msgstr "Job Seek's codebase is open source under MIT. The job data we collect and enrich is Creative Commons BY-NC 4.0. Below is the plain-language summary — please read the full licenses for exact terms."
 
-#. Job count label in watchlist view
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:210
-msgid "watchlists.jobList.jobCount"
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:64
+msgid "watchlist.meta.fallback"
+msgstr "Job watchlist by @{owner}"
+
+#. Plural job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:111
+msgid "watchlists.explore.jobPlural"
 msgstr "jobs"
 
 #. Plural job count on watchlist card
@@ -1625,21 +1694,31 @@ msgstr "jobs"
 msgid "watchlists.card.jobPlural"
 msgstr "jobs"
 
-#. Plural job count in public watchlist
+#. Job count label in watchlist view
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:108
-msgid "watchlists.explore.jobPlural"
+#: src/components/watchlist/watchlist-job-list.tsx:210
+msgid "watchlists.jobList.jobCount"
 msgstr "jobs"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:30
+msgid "company.meta.title"
+msgstr "Jobs at {name}"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:46
+msgid "watchlist.meta.jobsAt"
+msgstr "Jobs at {names}"
 
 #. Short July label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:64
+#: src/components/my-jobs/activity-heatmap.tsx:63
 msgid "myJobs.heatmap.month.jul"
 msgstr "Jul"
 
 #. Short June label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:63
+#: src/components/my-jobs/activity-heatmap.tsx:62
 msgid "myJobs.heatmap.month.jun"
 msgstr "Jun"
 
@@ -1709,20 +1788,20 @@ msgstr "Last week"
 msgid "home.hero.secondaryCta"
 msgstr "Learn more"
 
-#. Section header for seniority suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:461
-msgid "search.bar.level"
-msgstr "Level"
-
 #. Label for seniority/level filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:154
 msgid "search.advanced.level"
 msgstr "Level"
 
+#. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:14
+#: src/components/search/search-bar.tsx:461
+msgid "search.bar.level"
+msgstr "Level"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/license/page.tsx:16
 msgid "license.meta.title"
 msgstr "License"
 
@@ -1745,7 +1824,7 @@ msgid "license.hero.eyebrow"
 msgstr "Licensing"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:15
+#: app/[lang]/(public)/license/page.tsx:17
 msgid "license.meta.description"
 msgstr "Licensing terms for Job Seek application code (MIT) and job data (CC BY-NC 4.0)."
 
@@ -1781,7 +1860,7 @@ msgstr "Location"
 
 #. Locations heading in job detail
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:303
+#: src/components/search/job-detail-dialog.tsx:301
 msgid "search.detail.locations"
 msgstr "Locations"
 
@@ -1837,49 +1916,49 @@ msgstr "Manage your linked social accounts."
 
 #. Short March label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:60
+#: src/components/my-jobs/activity-heatmap.tsx:59
 msgid "myJobs.heatmap.month.mar"
 msgstr "Mar"
 
 #. Quick action tooltip: mark job as applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:19
+#: src/components/my-jobs/quick-actions.tsx:18
 msgid "myJobs.action.markApplied"
 msgstr "Mark applied"
 
 #. Quick action tooltip: mark job as offered
 #. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:22
+#: src/components/my-jobs/quick-actions.tsx:21
 msgid "myJobs.action.markOffer"
 msgstr "Mark offer"
 
 #. Quick action tooltip: mark job as rejected
 #. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:21
+#: src/components/my-jobs/quick-actions.tsx:20
 msgid "myJobs.action.markRejected"
 msgstr "Mark rejected"
 
 #. Maximum salary label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:45
+#: src/components/my-jobs/salary-override.tsx:43
 msgid "myJobs.salary.max"
 msgstr "Max"
 
 #. Short May label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:62
+#: src/components/my-jobs/activity-heatmap.tsx:61
 msgid "myJobs.heatmap.month.may"
 msgstr "May"
 
 #. Minimum salary label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:44
+#: src/components/my-jobs/salary-override.tsx:42
 msgid "myJobs.salary.min"
 msgstr "Min"
 
 #. Singular mirror count
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:115
+#: src/components/watchlist/public-watchlist-search.tsx:118
 msgid "watchlists.explore.mirrorSingular"
 msgstr "mirror"
 
@@ -1899,13 +1978,13 @@ msgstr "Mirror any public watchlist to make it your own — tweak companies, adj
 
 #. Plural mirror count
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:116
+#: src/components/watchlist/public-watchlist-search.tsx:119
 msgid "watchlists.explore.mirrorPlural"
 msgstr "mirrors"
 
 #. Short Monday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:46
+#: src/components/my-jobs/activity-heatmap.tsx:45
 msgid "myJobs.heatmap.day.mon"
 msgstr "Mon"
 
@@ -1917,7 +1996,7 @@ msgstr "Monthly"
 
 #. Monthly salary period option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:47
+#: src/components/my-jobs/salary-override.tsx:45
 msgid "myJobs.salary.monthly"
 msgstr "Monthly"
 
@@ -1947,7 +2026,7 @@ msgstr "My Jobs"
 
 #. Title of the My Jobs page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:254
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:252
 msgid "myJobs.title"
 msgstr "My Jobs"
 
@@ -2007,7 +2086,7 @@ msgstr "New password"
 
 #. Heatmap tooltip when no applications on a date
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:79
+#: src/components/my-jobs/activity-heatmap.tsx:78
 msgid "myJobs.heatmap.tooltipNone"
 msgstr "No applications on {date}"
 
@@ -2041,16 +2120,16 @@ msgstr "No jobs found."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "No languages match your search."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:170
-msgid "search.locationModal.noResults"
-msgstr "No locations match your search."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:185
 msgid "company.locationModal.noResults"
+msgstr "No locations match your search."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:170
+msgid "search.locationModal.noResults"
 msgstr "No locations match your search."
 
 #. No postings found message on company page
@@ -2061,7 +2140,7 @@ msgstr "No matching postings found."
 
 #. Sankey funnel node label prefix: no response
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:47
+#: src/components/my-jobs/sankey-funnel.tsx:46
 msgid "myJobs.funnel.noResponse"
 msgstr "No response"
 
@@ -2091,7 +2170,7 @@ msgstr "No technologies found."
 
 #. Empty state message when no tracked jobs
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:237
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:235
 msgid "myJobs.empty"
 msgstr "No tracked jobs yet. Save jobs from search results to start tracking your applications."
 
@@ -2103,7 +2182,7 @@ msgstr "No warranty — use at your own risk."
 
 #. No results message when searching public watchlists
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:137
+#: src/components/watchlist/public-watchlist-search.tsx:140
 msgid "watchlists.explore.noResults"
 msgstr "No watchlists found."
 
@@ -2115,13 +2194,13 @@ msgstr "No watchlists yet. Create one to track jobs from your favorite companies
 
 #. Application tracker status: not applied
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:439
+#: src/components/search/job-detail-dialog.tsx:437
 msgid "search.tracker.notApplied"
 msgstr "Not applied"
 
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:45
+#: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
 msgstr "Not applied"
 
@@ -2137,7 +2216,7 @@ msgstr "Note: We couldn't create a tracking issue, but your request was saved."
 
 #. Short November label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:68
+#: src/components/my-jobs/activity-heatmap.tsx:67
 msgid "myJobs.heatmap.month.nov"
 msgstr "Nov"
 
@@ -2149,38 +2228,38 @@ msgstr "Occupation"
 
 #. Short October label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:67
+#: src/components/my-jobs/activity-heatmap.tsx:66
 msgid "myJobs.heatmap.month.oct"
 msgstr "Oct"
 
 #. Application tracker status: offer
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:442
+#: src/components/search/job-detail-dialog.tsx:440
 msgid "search.tracker.offer"
 msgstr "Offer"
 
 #. Offered status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:23
+#: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
 msgstr "Offer"
 
 #. Status group heading: offered
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:33
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:31
 msgid "myJobs.group.offered"
-msgstr "Offered"
-
-#. Sankey funnel node: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:44
-msgid "myJobs.funnel.offered"
 msgstr "Offered"
 
 #. Status option in dropdown: offered
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:37
+#: src/components/my-jobs/my-job-detail-panel.tsx:35
 msgid "myJobs.statusOption.offered"
+msgstr "Offered"
+
+#. Sankey funnel node: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:43
+msgid "myJobs.funnel.offered"
 msgstr "Offered"
 
 #. Cookie banner accept button
@@ -2209,7 +2288,7 @@ msgstr "Only lowercase letters, numbers, and hyphens (cannot start/end with hyph
 
 #. Interview type label: onsite interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:24
+#: src/components/my-jobs/interview-list.tsx:22
 msgid "myJobs.interviewType.onsite"
 msgstr "Onsite"
 
@@ -2218,6 +2297,11 @@ msgstr "Onsite"
 #: src/components/Header.tsx:79
 msgid "common.header.openMenu"
 msgstr "Open main menu"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:42
+msgid "company.meta.openPositions"
+msgstr "Open positions"
 
 #. TOC: Open-source crawlers
 #. js-lingui-explicit-id
@@ -2257,7 +2341,7 @@ msgstr "Original"
 
 #. Interview type label: other/unspecified
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:27
+#: src/components/my-jobs/interview-list.tsx:25
 msgid "myJobs.interviewType.other"
 msgstr "Other"
 
@@ -2281,26 +2365,26 @@ msgstr "Our stance on automation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Overview"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Overview"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Page contents"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Overview"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Page contents"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Page contents"
 
 #. Heading shown on the 404 page
@@ -2311,7 +2395,7 @@ msgstr "Page not found"
 
 #. Interview type label: panel interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:25
+#: src/components/my-jobs/interview-list.tsx:23
 msgid "myJobs.interviewType.panel"
 msgstr "Panel"
 
@@ -2323,7 +2407,7 @@ msgstr "Park every interesting startup in one dashboard instead of juggling Chro
 
 #. Employment type: part-time
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:14
+#: src/components/search/employment-type-modal.tsx:12
 msgid "search.employmentType.partTime"
 msgstr "Part-time"
 
@@ -2397,7 +2481,7 @@ msgstr "Period"
 
 #. Period label in salary override
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:128
+#: src/components/my-jobs/salary-override.tsx:126
 msgid "myJobs.detail.salary.period"
 msgstr "Period"
 
@@ -2409,7 +2493,7 @@ msgstr "Permanently delete your account and all associated data. This action can
 
 #. Interview type label: phone screen
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:18
+#: src/components/my-jobs/interview-list.tsx:16
 msgid "myJobs.interviewType.phoneScreen"
 msgstr "Phone Screen"
 
@@ -2501,13 +2585,13 @@ msgstr "Point us at any careers page or Notion job board and Job Seek mirrors it
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:88
+#: src/components/search/job-detail-dialog.tsx:86
 msgid "search.detail.notFound"
 msgstr "Posting not found."
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:180
+#: src/components/my-jobs/my-job-detail-panel.tsx:178
 msgid "myJobs.detail.notFound"
 msgstr "Posting not found."
 
@@ -2544,7 +2628,7 @@ msgid "privacy.hero.title"
 msgstr "Privacy at Job Seek"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:14
+#: app/[lang]/(public)/privacy-policy/page.tsx:16
 msgid "privacy.meta.title"
 msgstr "Privacy Policy"
 
@@ -2630,7 +2714,7 @@ msgstr "Read the full Terms of Service"
 
 #. Sort option: recently updated
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:14
+#: src/components/my-jobs/sort-filter-bar.tsx:13
 msgid "myJobs.sort.recentlyUpdated"
 msgstr "Recently updated"
 
@@ -2654,32 +2738,32 @@ msgstr "Region"
 
 #. Status group heading: rejected
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:34
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:32
 msgid "myJobs.group.rejected"
 msgstr "Rejected"
 
 #. Application tracker status: rejected
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:443
+#: src/components/search/job-detail-dialog.tsx:441
 msgid "search.tracker.rejected"
 msgstr "Rejected"
 
 #. Rejected status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:24
+#: src/components/my-jobs/status-badge.tsx:23
 msgid "myJobs.status.rejected"
-msgstr "Rejected"
-
-#. Sankey funnel node label prefix: rejected
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:46
-msgid "myJobs.funnel.rejected"
 msgstr "Rejected"
 
 #. Status option in dropdown: rejected
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:38
+#: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.rejected"
+msgstr "Rejected"
+
+#. Sankey funnel node label prefix: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:45
+msgid "myJobs.funnel.rejected"
 msgstr "Rejected"
 
 #. Footer license summary text
@@ -2788,7 +2872,7 @@ msgstr "Roles"
 
 #. Sankey funnel node: interview round prefix
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:48
+#: src/components/my-jobs/sankey-funnel.tsx:47
 msgid "myJobs.funnel.round"
 msgstr "Round"
 
@@ -2800,7 +2884,7 @@ msgstr "Salary"
 
 #. Salary override section heading
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:78
+#: src/components/my-jobs/salary-override.tsx:76
 msgid "myJobs.detail.salary"
 msgstr "Salary"
 
@@ -2848,26 +2932,26 @@ msgstr "Save your filters for quick scans without retyping everything."
 
 #. Status group heading: saved jobs
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:30
+#: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:28
 msgid "myJobs.group.saved"
 msgstr "Saved"
 
 #. Saved status badge label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:20
+#: src/components/my-jobs/status-badge.tsx:19
 msgid "myJobs.status.saved"
-msgstr "Saved"
-
-#. Sankey funnel node: saved jobs
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:42
-msgid "myJobs.funnel.saved"
 msgstr "Saved"
 
 #. Status option in dropdown: saved
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:34
+#: src/components/my-jobs/my-job-detail-panel.tsx:32
 msgid "myJobs.statusOption.saved"
+msgstr "Saved"
+
+#. Sankey funnel node: saved jobs
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:41
+msgid "myJobs.funnel.saved"
 msgstr "Saved"
 
 #. Free feature: saved searches
@@ -2900,6 +2984,11 @@ msgstr "Saving..."
 msgid "settings.account.email.saving"
 msgstr "Saving..."
 
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/explore/page.tsx:26
+msgid "explore.meta.description"
+msgstr "Search and filter job openings across hundreds of companies."
+
 #. Placeholder for search bar when on company page
 #. js-lingui-explicit-id
 #. placeholder {0}: company.name
@@ -2925,16 +3014,16 @@ msgstr "Search companies..."
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Search languages..."
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:149
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Search locations..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:164
 msgid "company.locationModal.searchPlaceholder"
+msgstr "Search locations..."
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:149
+msgid "search.locationModal.searchPlaceholder"
 msgstr "Search locations..."
 
 #. Back to search results link on company page
@@ -3015,16 +3104,16 @@ msgstr "Send reset link"
 msgid "settings.account.password.send"
 msgstr "Send reset link"
 
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Sending..."
-
 #. Resend button while sending
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:96
 msgid "auth.verify.resending"
+msgstr "Sending..."
+
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
 msgstr "Sending..."
 
 #. Reset password button while loading
@@ -3041,7 +3130,7 @@ msgstr "Seniority"
 
 #. Short September label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:66
+#: src/components/my-jobs/activity-heatmap.tsx:65
 msgid "myJobs.heatmap.month.sep"
 msgstr "Sep"
 
@@ -3099,16 +3188,16 @@ msgstr "Settings"
 #~ msgid "settings.billing.usage.unlimited"
 #~ msgstr "Unlimited"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:346
-msgid "search.detail.showLessLocations"
-msgstr "Show less"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:350
 msgid "company.page.showLess"
+msgstr "Show less"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:344
+msgid "search.detail.showLessLocations"
 msgstr "Show less"
 
 #. Aria label to show password
@@ -3267,19 +3356,19 @@ msgstr "Start for free"
 
 #. Sort option: status
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:16
+#: src/components/my-jobs/sort-filter-bar.tsx:15
 msgid "myJobs.sort.status"
 msgstr "Status"
 
 #. Group by status option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sort-filter-bar.tsx:25
+#: src/components/my-jobs/sort-filter-bar.tsx:24
 msgid "myJobs.group.status"
 msgstr "Status"
 
 #. Status section heading
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:197
+#: src/components/my-jobs/my-job-detail-panel.tsx:195
 msgid "myJobs.detail.status"
 msgstr "Status"
 
@@ -3316,7 +3405,7 @@ msgid "home.pricing.free.f1"
 msgstr "Subscribe to up to 5 companies"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:19
+#: app/[lang]/(public)/page.tsx:20
 msgid "home.meta.description"
 msgstr "Subscribe to updates from companies, track applications, and never miss new openings."
 
@@ -3346,19 +3435,19 @@ msgstr "Switch to light mode"
 
 #. Interview type label: system design
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:22
+#: src/components/my-jobs/interview-list.tsx:20
 msgid "myJobs.interviewType.systemDesign"
 msgstr "System Design"
 
 #. Interview type label: technical interview
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:20
+#: src/components/my-jobs/interview-list.tsx:18
 msgid "myJobs.interviewType.technical"
 msgstr "Technical"
 
 #. Technologies sub-heading in details section
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:388
+#: src/components/search/job-detail-dialog.tsx:386
 msgid "search.detail.technologies"
 msgstr "Technologies"
 
@@ -3382,7 +3471,7 @@ msgstr "Technology"
 
 #. Employment type: temporary
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:17
+#: src/components/search/employment-type-modal.tsx:15
 msgid "search.employmentType.temporary"
 msgstr "Temporary"
 
@@ -3399,7 +3488,7 @@ msgid "common.footer.termsLink"
 msgstr "Terms"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:14
+#: app/[lang]/(public)/terms/page.tsx:16
 msgid "terms.meta.title"
 msgstr "Terms of Service"
 
@@ -3410,7 +3499,7 @@ msgid "terms.hero.title"
 msgstr "Terms of Service"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:15
+#: app/[lang]/(public)/terms/page.tsx:17
 msgid "terms.meta.description"
 msgstr "Terms of Service for the Job Seek application."
 
@@ -3590,7 +3679,7 @@ msgstr "Upgrading…"
 
 #. Fallback username for watchlist owner
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:106
+#: src/components/watchlist/public-watchlist-search.tsx:109
 msgid "watchlists.explore.unknownUser"
 msgstr "user"
 
@@ -3638,19 +3727,19 @@ msgstr "Verifying your email..."
 
 #. Interview type label: video call
 #. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:19
+#: src/components/my-jobs/interview-list.tsx:17
 msgid "myJobs.interviewType.videoCall"
 msgstr "Video Call"
 
 #. Link to the original job posting
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:185
+#: src/components/search/job-detail-dialog.tsx:183
 msgid "search.detail.viewPosting"
 msgstr "View posting"
 
 #. Employment type: volunteer
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:18
+#: src/components/search/employment-type-modal.tsx:16
 msgid "search.employmentType.volunteer"
 msgstr "Volunteer"
 
@@ -3668,7 +3757,7 @@ msgstr "Watchlists"
 
 #. Back to watchlists link
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:257
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:288
 msgid "watchlists.view.back"
 msgstr "Watchlists"
 
@@ -3752,7 +3841,7 @@ msgstr "We use a handful of third-party services for sign-in, hosting, and stora
 
 #. Short Wednesday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:48
+#: src/components/my-jobs/activity-heatmap.tsx:47
 msgid "myJobs.heatmap.day.wed"
 msgstr "Wed"
 
@@ -3776,7 +3865,7 @@ msgstr "Yearly"
 
 #. Yearly salary period option
 #. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:46
+#: src/components/my-jobs/salary-override.tsx:44
 msgid "myJobs.salary.yearly"
 msgstr "Yearly"
 

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -371,28 +371,28 @@ msgstr "Applied"
 msgid "myJobs.status.applied"
 msgstr "Applied"
 
-#. Status option in dropdown: applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:33
-msgid "myJobs.statusOption.applied"
-msgstr "Applied"
-
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
 msgstr "Applied"
 
-#. Apply salary filter
+#. Status option in dropdown: applied
 #. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:320
-msgid "search.salaryModal.apply"
-msgstr "Apply"
+#: src/components/my-jobs/my-job-detail-panel.tsx:33
+msgid "myJobs.statusOption.applied"
+msgstr "Applied"
 
 #. Apply experience filter
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:246
 msgid "search.experienceModal.apply"
+msgstr "Apply"
+
+#. Apply salary filter
+#. js-lingui-explicit-id
+#: src/components/search/salary-modal.tsx:320
+msgid "search.salaryModal.apply"
 msgstr "Apply"
 
 #. Apply button linking to original job posting
@@ -437,12 +437,6 @@ msgstr "Aug"
 msgid "settings.account.username.available"
 msgstr "Available"
 
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Back to sign in"
-
 #. Link back to sign-in after failed verification
 #. js-lingui-explicit-id
 #: app/[lang]/verify-email/page.tsx:68
@@ -459,6 +453,12 @@ msgstr "Back to sign in"
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:110
 msgid "auth.forgotPassword.backLink"
+msgstr "Back to sign in"
+
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
 msgstr "Back to sign in"
 
 #. Interview type label: behavioral interview
@@ -755,14 +755,14 @@ msgstr "Contact"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
-msgid "license.toc.title"
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Contents"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
+#: src/components/LicenseContent.tsx:18
+msgid "license.toc.title"
 msgstr "Contents"
 
 #. Button to continue to app after verification
@@ -1109,16 +1109,16 @@ msgstr "Email alerts for new postings"
 msgid "home.features.s1.eyebrow"
 msgstr "Everything you need to stay ahead"
 
-#. Label for experience filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:177
-msgid "search.advanced.experience"
-msgstr "Experience"
-
 #. Title for experience filter modal
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:186
 msgid "search.experienceModal.title"
+msgstr "Experience"
+
+#. Label for experience filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:177
+msgid "search.advanced.experience"
 msgstr "Experience"
 
 #. js-lingui-explicit-id
@@ -1605,16 +1605,16 @@ msgstr "Invalid verification link"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:110
-msgid "watchlists.explore.jobSingular"
-msgstr "job"
-
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31
 msgid "watchlists.card.jobSingular"
+msgstr "job"
+
+#. Singular job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:110
+msgid "watchlists.explore.jobSingular"
 msgstr "job"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -1682,10 +1682,10 @@ msgstr "Job Seek's codebase is open source under MIT. The job data we collect an
 msgid "watchlist.meta.fallback"
 msgstr "Job watchlist by @{owner}"
 
-#. Plural job count in public watchlist
+#. Job count label in watchlist view
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:111
-msgid "watchlists.explore.jobPlural"
+#: src/components/watchlist/watchlist-job-list.tsx:210
+msgid "watchlists.jobList.jobCount"
 msgstr "jobs"
 
 #. Plural job count on watchlist card
@@ -1694,10 +1694,10 @@ msgstr "jobs"
 msgid "watchlists.card.jobPlural"
 msgstr "jobs"
 
-#. Job count label in watchlist view
+#. Plural job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:210
-msgid "watchlists.jobList.jobCount"
+#: src/components/watchlist/public-watchlist-search.tsx:111
+msgid "watchlists.explore.jobPlural"
 msgstr "jobs"
 
 #. js-lingui-explicit-id
@@ -1788,16 +1788,16 @@ msgstr "Last week"
 msgid "home.hero.secondaryCta"
 msgstr "Learn more"
 
-#. Label for seniority/level filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:154
-msgid "search.advanced.level"
-msgstr "Level"
-
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:461
 msgid "search.bar.level"
+msgstr "Level"
+
+#. Label for seniority/level filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:154
+msgid "search.advanced.level"
 msgstr "Level"
 
 #. js-lingui-explicit-id
@@ -1858,16 +1858,16 @@ msgstr "Location"
 msgid "search.advanced.location"
 msgstr "Location"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:301
-msgid "search.detail.locations"
-msgstr "Locations"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:531
 msgid "search.bar.locations"
+msgstr "Locations"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:301
+msgid "search.detail.locations"
 msgstr "Locations"
 
 #. Login button label
@@ -2120,16 +2120,16 @@ msgstr "No jobs found."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "No languages match your search."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:185
-msgid "company.locationModal.noResults"
-msgstr "No locations match your search."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:170
 msgid "search.locationModal.noResults"
+msgstr "No locations match your search."
+
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:185
+msgid "company.locationModal.noResults"
 msgstr "No locations match your search."
 
 #. No postings found message on company page
@@ -2250,16 +2250,16 @@ msgstr "Offer"
 msgid "myJobs.group.offered"
 msgstr "Offered"
 
-#. Status option in dropdown: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:35
-msgid "myJobs.statusOption.offered"
-msgstr "Offered"
-
 #. Sankey funnel node: offered
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:43
 msgid "myJobs.funnel.offered"
+msgstr "Offered"
+
+#. Status option in dropdown: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:35
+msgid "myJobs.statusOption.offered"
 msgstr "Offered"
 
 #. Cookie banner accept button
@@ -2365,26 +2365,26 @@ msgstr "Our stance on automation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:22
-msgid "license.toc.overview"
-msgstr "Overview"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:27
 msgid "indexing.toc.overview"
 msgstr "Overview"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:19
-msgid "license.toc.ariaLabel"
-msgstr "Page contents"
+#: src/components/LicenseContent.tsx:22
+msgid "license.toc.overview"
+msgstr "Overview"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:24
 msgid "indexing.toc.ariaLabel"
+msgstr "Page contents"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:19
+msgid "license.toc.ariaLabel"
 msgstr "Page contents"
 
 #. Heading shown on the 404 page
@@ -2754,16 +2754,16 @@ msgstr "Rejected"
 msgid "myJobs.status.rejected"
 msgstr "Rejected"
 
-#. Status option in dropdown: rejected
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:36
-msgid "myJobs.statusOption.rejected"
-msgstr "Rejected"
-
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
+msgstr "Rejected"
+
+#. Status option in dropdown: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:36
+msgid "myJobs.statusOption.rejected"
 msgstr "Rejected"
 
 #. Footer license summary text
@@ -2822,16 +2822,16 @@ msgstr "Resend in {cooldown}s"
 msgid "auth.verify.resend"
 msgstr "Resend verification email"
 
-#. Reset salary filter
-#. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:314
-msgid "search.salaryModal.reset"
-msgstr "Reset"
-
 #. Reset experience filter
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:240
 msgid "search.experienceModal.reset"
+msgstr "Reset"
+
+#. Reset salary filter
+#. js-lingui-explicit-id
+#: src/components/search/salary-modal.tsx:314
+msgid "search.salaryModal.reset"
 msgstr "Reset"
 
 #. Reset password submit button
@@ -2942,16 +2942,16 @@ msgstr "Saved"
 msgid "myJobs.status.saved"
 msgstr "Saved"
 
-#. Status option in dropdown: saved
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:32
-msgid "myJobs.statusOption.saved"
-msgstr "Saved"
-
 #. Sankey funnel node: saved jobs
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:41
 msgid "myJobs.funnel.saved"
+msgstr "Saved"
+
+#. Status option in dropdown: saved
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:32
+msgid "myJobs.statusOption.saved"
 msgstr "Saved"
 
 #. Free feature: saved searches
@@ -2984,11 +2984,6 @@ msgstr "Saving..."
 msgid "settings.account.email.saving"
 msgstr "Saving..."
 
-#. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:26
-msgid "explore.meta.description"
-msgstr "Search and filter job openings across hundreds of companies."
-
 #. Placeholder for search bar when on company page
 #. js-lingui-explicit-id
 #. placeholder {0}: company.name
@@ -3008,22 +3003,27 @@ msgstr "Search companies..."
 msgid "watchlists.companyModal.searchPlaceholder"
 msgstr "Search companies..."
 
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/explore/page.tsx:26
+msgid "explore.meta.description"
+msgstr "Search and filter job openings across hundreds of companies."
+
 #. Placeholder for search input in all-languages modal
 #. js-lingui-explicit-id
 #: src/components/settings/JobLanguageModal.tsx:77
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Search languages..."
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:164
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Search locations..."
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:149
 msgid "search.locationModal.searchPlaceholder"
+msgstr "Search locations..."
+
+#. Placeholder for search input in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:164
+msgid "company.locationModal.searchPlaceholder"
 msgstr "Search locations..."
 
 #. Back to search results link on company page
@@ -3188,16 +3188,16 @@ msgstr "Settings"
 #~ msgid "settings.billing.usage.unlimited"
 #~ msgstr "Unlimited"
 
-#. Collapse location pill list
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:350
-msgid "company.page.showLess"
-msgstr "Show less"
-
 #. Button to collapse location list
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:344
 msgid "search.detail.showLessLocations"
+msgstr "Show less"
+
+#. Collapse location pill list
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:350
+msgid "company.page.showLess"
 msgstr "Show less"
 
 #. Aria label to show password
@@ -3308,12 +3308,6 @@ msgstr "Skip to content"
 msgid "error.title"
 msgstr "Something went wrong"
 
-#. Generic forgot password error
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:43
-msgid "auth.forgotPassword.error.generic"
-msgstr "Something went wrong. Please try again."
-
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
@@ -3322,6 +3316,12 @@ msgstr "Something went wrong. Please try again."
 #: app/[lang]/(app)/progress/company-request-form.tsx:18
 #: src/components/search/request-company.tsx:19
 msgid "app.home.request.error.unknown"
+msgstr "Something went wrong. Please try again."
+
+#. Generic forgot password error
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:43
+msgid "auth.forgotPassword.error.generic"
 msgstr "Something went wrong. Please try again."
 
 #. Generic error creating watchlist
@@ -3445,16 +3445,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technical"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:386
-msgid "search.detail.technologies"
-msgstr "Technologies"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:496
 msgid "search.bar.technologies"
+msgstr "Technologies"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:386
+msgid "search.detail.technologies"
 msgstr "Technologies"
 
 #. Add technology filter

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -109,11 +109,36 @@ msgstr "{0} de plus"
 msgid "search.detail.showMoreLocations"
 msgstr "{0} de plus"
 
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:37
+msgid "company.meta.positionCount"
+msgstr "{count, plural, one {# poste ouvert} other {# postes ouverts}}"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:72
+msgid "watchlist.meta.tracking"
+msgstr "{count, plural, one {# entreprise suivie} other {# entreprises suivies}}. {description}"
+
 #. Heatmap tooltip for multiple applications
 #. js-lingui-explicit-id
 #: src/components/my-jobs/activity-heatmap.tsx:80
 msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} candidatures le {date}"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:40
+msgid "watchlist.meta.moreCompanies"
+msgstr "{count} de plus"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:49
+msgid "company.meta.descriptionBasic"
+msgstr "{countText} chez {name}"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:44
+msgid "company.meta.descriptionWithInfo"
+msgstr "{countText} chez {name}. {description}"
 
 #. Free plan price display
 #. js-lingui-explicit-id
@@ -171,7 +196,7 @@ msgstr "Ajouter des entreprises"
 
 #. Link to add a description to the watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:379
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:382
 msgid "watchlists.view.addDescription"
 msgstr "Ajouter une description"
 
@@ -267,7 +292,7 @@ msgstr "Tous"
 
 #. Toggle to show jobs from all companies
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:407
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:410
 msgid "watchlists.view.anyCompany"
 msgstr "Toute entreprise"
 
@@ -334,28 +359,28 @@ msgstr "candidatures durant l'année écoulée"
 msgid "myJobs.group.applied"
 msgstr "Postulé"
 
-#. Applied status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:20
-msgid "myJobs.status.applied"
-msgstr "Postulé"
-
-#. Sankey funnel node: applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:42
-msgid "myJobs.funnel.applied"
-msgstr "Postulé"
-
 #. Application tracker status: applied
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:438
 msgid "search.tracker.applied"
 msgstr "Postulé"
 
+#. Applied status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:20
+msgid "myJobs.status.applied"
+msgstr "Postulé"
+
 #. Status option in dropdown: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:33
 msgid "myJobs.statusOption.applied"
+msgstr "Postulé"
+
+#. Sankey funnel node: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:42
+msgid "myJobs.funnel.applied"
 msgstr "Postulé"
 
 #. Apply salary filter
@@ -412,16 +437,16 @@ msgstr "Aoû"
 msgid "settings.account.username.available"
 msgstr "Disponible"
 
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Retour à la connexion"
-
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Retour à la connexion"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Retour à la connexion"
 
 #. Link back to sign-in from forgot password
@@ -572,14 +597,14 @@ msgstr "Réinitialiser"
 
 #. Button to remove all companies from watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:425
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:428
 msgid "watchlists.view.clearAllCompanies"
 msgstr "Tout effacer"
 
 #. Button to clear all active search filters
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:533
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:536
 #: src/components/search/search-toolbar.tsx:282
 msgid "search.filters.clearAll"
 msgstr "Tout effacer"
@@ -592,7 +617,7 @@ msgstr "Tout effacer"
 
 #. Tooltip for clicking to edit watchlist description
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:369
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:370
 msgid "watchlists.view.editDescription"
 msgstr "Cliquer pour modifier la description"
 
@@ -664,7 +689,7 @@ msgstr "Entreprises suivies"
 
 #. Button to open company search modal
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:396
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:399
 msgid "watchlists.view.addCompany"
 msgstr "Entreprise"
 
@@ -924,7 +949,7 @@ msgstr "Suppression…"
 
 #. Placeholder for watchlist description textarea
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:361
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:362
 msgid "watchlists.view.descriptionPlaceholder"
 msgstr "Décrire cette watchlist …"
 
@@ -1084,23 +1109,33 @@ msgstr "Alertes e-mail pour les nouvelles offres"
 msgid "home.features.s1.eyebrow"
 msgstr "Tout ce qu'il te faut pour garder une longueur d'avance"
 
-#. Title for experience filter modal
-#. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:186
-msgid "search.experienceModal.title"
-msgstr "Expérience"
-
 #. Label for experience filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:177
 msgid "search.advanced.experience"
 msgstr "Expérience"
 
+#. Title for experience filter modal
+#. js-lingui-explicit-id
+#: src/components/search/experience-modal.tsx:186
+msgid "search.experienceModal.title"
+msgstr "Expérience"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:160
+msgid "breadcrumb.explore"
+msgstr "Explorer"
+
 #. Explore nav icon tooltip
 #. js-lingui-explicit-id
 #: src/components/AppHeader.tsx:54
 msgid "app.header.nav.explore"
 msgstr "Explorer"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/explore/page.tsx:25
+msgid "explore.meta.title"
+msgstr "Explorer les emplois"
 
 #. Generic email change error
 #. js-lingui-explicit-id
@@ -1225,7 +1260,7 @@ msgid "settings.general.jobLanguages.findMore"
 msgstr "Rechercher"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:18
+#: app/[lang]/(public)/page.tsx:19
 msgid "home.meta.title"
 msgstr "Trouve les postes pertinents plus vite"
 
@@ -1378,6 +1413,12 @@ msgstr "Masquer le mot de passe"
 msgid "myJobs.interviewType.hiringManager"
 msgstr "Responsable RH"
 
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:167
+#: app/[lang]/(app)/company/[slug]/page.tsx:159
+msgid "breadcrumb.home"
+msgstr "Accueil"
+
 #. Hourly pay period option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:356
@@ -1399,12 +1440,12 @@ msgid "common.nav.company"
 msgstr "Comment indexons-nous les offres ?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:15
+#: app/[lang]/(public)/privacy-policy/page.tsx:17
 msgid "privacy.meta.description"
 msgstr "Comment Job Seek collecte, utilise et protège tes données personnelles."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:15
+#: app/[lang]/(public)/how-we-index/page.tsx:17
 msgid "indexing.meta.description"
 msgstr "Comment Job Seek découvre, explore et indexe les offres d'emploi — et les garanties que nous appliquons."
 
@@ -1427,7 +1468,7 @@ msgid "indexing.hero.title"
 msgstr "Comment nous trouvons et traitons les offres d'emploi"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:14
+#: app/[lang]/(public)/how-we-index/page.tsx:16
 msgid "indexing.meta.title"
 msgstr "Comment nous indexons"
 
@@ -1454,6 +1495,11 @@ msgstr "Si tu constates une activité inattendue de notre robot d'indexation ou 
 #: src/components/HowWeIndexContent.tsx:206
 msgid "indexing.outreach.body"
 msgstr "Si tu remarques un comportement inhabituel de notre robot, préfères que nous n'indexions pas ton contenu, ou as des suggestions pour améliorer nos mesures de protection, n'hésite pas à nous contacter."
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:56
+msgid "watchlist.meta.inLocations"
+msgstr "à {locations}"
 
 #. Year postings count on company page
 #. js-lingui-explicit-id
@@ -1517,16 +1563,16 @@ msgstr "Entretien"
 msgid "myJobs.group.interviewing"
 msgstr "En entretien"
 
-#. Interviewing status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:21
-msgid "myJobs.status.interviewing"
-msgstr "En entretien"
-
 #. Application tracker status: interviewing
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:439
 msgid "search.tracker.interviewing"
+msgstr "En entretien"
+
+#. Interviewing status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:21
+msgid "myJobs.status.interviewing"
 msgstr "En entretien"
 
 #. Status option in dropdown: interviewing
@@ -1559,16 +1605,16 @@ msgstr "Lien de vérification invalide"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:31
-msgid "watchlists.card.jobSingular"
-msgstr "offre"
-
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:110
 msgid "watchlists.explore.jobSingular"
+msgstr "offre"
+
+#. Singular job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:31
+msgid "watchlists.card.jobSingular"
 msgstr "offre"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -1631,6 +1677,17 @@ msgstr "Job Seek est en cours de développement. Restez à l'écoute pour les mi
 msgid "license.hero.description"
 msgstr "Le code source de Job Seek est ouvert sous licence MIT. Les données d'emploi que nous collectons et enrichissons sont sous Creative Commons BY-NC 4.0. Tu trouveras ci-dessous un résumé en langage clair — consulte les licences complètes pour les termes exacts."
 
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:64
+msgid "watchlist.meta.fallback"
+msgstr "Liste d'emplois de @{owner}"
+
+#. Plural job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:111
+msgid "watchlists.explore.jobPlural"
+msgstr "offres"
+
 #. Plural job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:32
@@ -1643,11 +1700,15 @@ msgstr "offres"
 msgid "watchlists.jobList.jobCount"
 msgstr "offres"
 
-#. Plural job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:111
-msgid "watchlists.explore.jobPlural"
-msgstr "offres"
+#: app/[lang]/(app)/company/[slug]/page.tsx:30
+msgid "company.meta.title"
+msgstr "Emplois chez {name}"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:46
+msgid "watchlist.meta.jobsAt"
+msgstr "Emplois chez {names}"
 
 #. Short July label
 #. js-lingui-explicit-id
@@ -1727,20 +1788,20 @@ msgstr "Dernière semaine"
 msgid "home.hero.secondaryCta"
 msgstr "En savoir plus"
 
-#. Section header for seniority suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:461
-msgid "search.bar.level"
-msgstr "Niveau"
-
 #. Label for seniority/level filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:154
 msgid "search.advanced.level"
 msgstr "Niveau"
 
+#. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:14
+#: src/components/search/search-bar.tsx:461
+msgid "search.bar.level"
+msgstr "Niveau"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/license/page.tsx:16
 msgid "license.meta.title"
 msgstr "Licence"
 
@@ -1763,7 +1824,7 @@ msgid "license.hero.eyebrow"
 msgstr "Licences"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:15
+#: app/[lang]/(public)/license/page.tsx:17
 msgid "license.meta.description"
 msgstr "Conditions de licence du code applicatif de Job Seek (MIT) et des données d'emploi (CC BY-NC 4.0)."
 
@@ -1797,16 +1858,16 @@ msgstr "Lieu"
 msgid "search.advanced.location"
 msgstr "Lieu"
 
-#. Section header for location suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:531
-msgid "search.bar.locations"
-msgstr "Lieux"
-
 #. Locations heading in job detail
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:301
 msgid "search.detail.locations"
+msgstr "Lieux"
+
+#. Section header for location suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:531
+msgid "search.bar.locations"
 msgstr "Lieux"
 
 #. Login button label
@@ -2131,16 +2192,16 @@ msgstr "Aucune liste de suivi trouvée."
 msgid "watchlists.page.empty"
 msgstr "Aucune liste de suivi pour l'instant. Créez-en une pour suivre les offres de vos entreprises préférées."
 
-#. Sankey funnel node: not applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:44
-msgid "myJobs.funnel.notApplied"
-msgstr "Non postulé"
-
 #. Application tracker status: not applied
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:437
 msgid "search.tracker.notApplied"
+msgstr "Non postulé"
+
+#. Sankey funnel node: not applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:44
+msgid "myJobs.funnel.notApplied"
 msgstr "Non postulé"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2171,16 +2232,16 @@ msgstr "Métier"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Oct"
 
-#. Offered status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:22
-msgid "myJobs.status.offered"
-msgstr "Offre"
-
 #. Application tracker status: offer
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:440
 msgid "search.tracker.offer"
+msgstr "Offre"
+
+#. Offered status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:22
+msgid "myJobs.status.offered"
 msgstr "Offre"
 
 #. Status group heading: offered
@@ -2189,16 +2250,16 @@ msgstr "Offre"
 msgid "myJobs.group.offered"
 msgstr "Offre"
 
-#. Sankey funnel node: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:43
-msgid "myJobs.funnel.offered"
-msgstr "Offre"
-
 #. Status option in dropdown: offered
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:35
 msgid "myJobs.statusOption.offered"
+msgstr "Offre"
+
+#. Sankey funnel node: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:43
+msgid "myJobs.funnel.offered"
 msgstr "Offre"
 
 #. Cookie banner accept button
@@ -2236,6 +2297,11 @@ msgstr "Sur site"
 #: src/components/Header.tsx:79
 msgid "common.header.openMenu"
 msgstr "Ouvrir le menu principal"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:42
+msgid "company.meta.openPositions"
+msgstr "Postes ouverts"
 
 #. TOC: Open-source crawlers
 #. js-lingui-explicit-id
@@ -2529,18 +2595,18 @@ msgstr "Offre non trouvée."
 msgid "myJobs.detail.notFound"
 msgstr "Offre introuvable."
 
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:101
+msgid "home.pricing.eyebrow"
+msgstr "Tarifs"
+
 #. Nav link: Pricing
 #. Nav link: Pricing
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:61
 #: src/components/MobileMenu.tsx:86
 msgid "common.nav.pricing"
-msgstr "Tarifs"
-
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: src/components/Pricing.tsx:101
-msgid "home.pricing.eyebrow"
 msgstr "Tarifs"
 
 #. Privacy policy page eyebrow
@@ -2562,7 +2628,7 @@ msgid "privacy.hero.title"
 msgstr "Confidentialité chez Job Seek"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:14
+#: app/[lang]/(public)/privacy-policy/page.tsx:16
 msgid "privacy.meta.title"
 msgstr "Politique de confidentialité"
 
@@ -2676,28 +2742,28 @@ msgstr "Région"
 msgid "myJobs.group.rejected"
 msgstr "Refusé"
 
-#. Rejected status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:23
-msgid "myJobs.status.rejected"
-msgstr "Refusé"
-
-#. Sankey funnel node label prefix: rejected
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:45
-msgid "myJobs.funnel.rejected"
-msgstr "Refusé"
-
 #. Application tracker status: rejected
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:441
 msgid "search.tracker.rejected"
 msgstr "Refusé"
 
+#. Rejected status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:23
+msgid "myJobs.status.rejected"
+msgstr "Refusé"
+
 #. Status option in dropdown: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.rejected"
+msgstr "Refusé"
+
+#. Sankey funnel node label prefix: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:45
+msgid "myJobs.funnel.rejected"
 msgstr "Refusé"
 
 #. Footer license summary text
@@ -2810,16 +2876,16 @@ msgstr "Rôles"
 msgid "myJobs.funnel.round"
 msgstr "Tour"
 
-#. Salary override section heading
-#. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:76
-msgid "myJobs.detail.salary"
-msgstr "Salaire"
-
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:171
 msgid "search.advanced.salary"
+msgstr "Salaire"
+
+#. Salary override section heading
+#. js-lingui-explicit-id
+#: src/components/my-jobs/salary-override.tsx:76
+msgid "myJobs.detail.salary"
 msgstr "Salaire"
 
 #. Salary display settings section heading
@@ -2876,16 +2942,16 @@ msgstr "Enregistré"
 msgid "myJobs.status.saved"
 msgstr "Enregistré"
 
-#. Sankey funnel node: saved jobs
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:41
-msgid "myJobs.funnel.saved"
-msgstr "Enregistré"
-
 #. Status option in dropdown: saved
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:32
 msgid "myJobs.statusOption.saved"
+msgstr "Enregistré"
+
+#. Sankey funnel node: saved jobs
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:41
+msgid "myJobs.funnel.saved"
 msgstr "Enregistré"
 
 #. Free feature: saved searches
@@ -2918,6 +2984,11 @@ msgstr "Enregistrement..."
 msgid "settings.account.email.saving"
 msgstr "Enregistrement…"
 
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/explore/page.tsx:26
+msgid "explore.meta.description"
+msgstr "Recherchez et filtrez les offres d'emploi de centaines d'entreprises."
+
 #. Placeholder for search bar when on company page
 #. js-lingui-explicit-id
 #. placeholder {0}: company.name
@@ -2925,16 +2996,16 @@ msgstr "Enregistrement…"
 msgid "company.page.searchPlaceholder"
 msgstr "Rechercher chez {0}..."
 
-#. Placeholder for company search in modal
-#. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:212
-msgid "watchlists.companyModal.searchPlaceholder"
-msgstr "Rechercher des entreprises..."
-
 #. Placeholder for company search in watchlist creation
 #. js-lingui-explicit-id
 #: src/components/watchlist/company-selector.tsx:91
 msgid "watchlists.companySelector.placeholder"
+msgstr "Rechercher des entreprises..."
+
+#. Placeholder for company search in modal
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-search-modal.tsx:212
+msgid "watchlists.companyModal.searchPlaceholder"
 msgstr "Rechercher des entreprises..."
 
 #. Placeholder for search input in all-languages modal
@@ -3237,6 +3308,12 @@ msgstr "Aller au contenu"
 msgid "error.title"
 msgstr "Une erreur est survenue"
 
+#. Generic forgot password error
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:43
+msgid "auth.forgotPassword.error.generic"
+msgstr "Une erreur est survenue. Veuillez réessayer."
+
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
@@ -3246,12 +3323,6 @@ msgstr "Une erreur est survenue"
 #: src/components/search/request-company.tsx:19
 msgid "app.home.request.error.unknown"
 msgstr "Une erreur s'est produite. Veuillez réessayer."
-
-#. Generic forgot password error
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:43
-msgid "auth.forgotPassword.error.generic"
-msgstr "Une erreur est survenue. Veuillez réessayer."
 
 #. Generic error creating watchlist
 #. js-lingui-explicit-id
@@ -3334,7 +3405,7 @@ msgid "home.pricing.free.f1"
 msgstr "Suivi de 5 entreprises maximum"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:19
+#: app/[lang]/(public)/page.tsx:20
 msgid "home.meta.description"
 msgstr "Abonne-toi aux mises à jour d'entreprises, suis tes candidatures et ne rate aucune nouvelle offre."
 
@@ -3374,16 +3445,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technique"
 
-#. Section header for technology suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:496
-msgid "search.bar.technologies"
-msgstr "Technologies"
-
 #. Technologies sub-heading in details section
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:386
 msgid "search.detail.technologies"
+msgstr "Technologies"
+
+#. Section header for technology suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:496
+msgid "search.bar.technologies"
 msgstr "Technologies"
 
 #. Add technology filter
@@ -3417,7 +3488,7 @@ msgid "common.footer.termsLink"
 msgstr "CGU"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:14
+#: app/[lang]/(public)/terms/page.tsx:16
 msgid "terms.meta.title"
 msgstr "Conditions d'utilisation"
 
@@ -3428,7 +3499,7 @@ msgid "terms.hero.title"
 msgstr "Conditions d'utilisation"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:15
+#: app/[lang]/(public)/terms/page.tsx:17
 msgid "terms.meta.description"
 msgstr "Conditions d'utilisation de l'application Job Seek."
 

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -371,28 +371,28 @@ msgstr "Postulé"
 msgid "myJobs.status.applied"
 msgstr "Postulé"
 
-#. Status option in dropdown: applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:33
-msgid "myJobs.statusOption.applied"
-msgstr "Postulé"
-
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
 msgstr "Postulé"
 
-#. Apply salary filter
+#. Status option in dropdown: applied
 #. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:320
-msgid "search.salaryModal.apply"
-msgstr "Appliquer"
+#: src/components/my-jobs/my-job-detail-panel.tsx:33
+msgid "myJobs.statusOption.applied"
+msgstr "Postulé"
 
 #. Apply experience filter
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:246
 msgid "search.experienceModal.apply"
+msgstr "Appliquer"
+
+#. Apply salary filter
+#. js-lingui-explicit-id
+#: src/components/search/salary-modal.tsx:320
+msgid "search.salaryModal.apply"
 msgstr "Appliquer"
 
 #. Apply button linking to original job posting
@@ -437,12 +437,6 @@ msgstr "Aoû"
 msgid "settings.account.username.available"
 msgstr "Disponible"
 
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Retour à la connexion"
-
 #. Link back to sign-in after failed verification
 #. js-lingui-explicit-id
 #: app/[lang]/verify-email/page.tsx:68
@@ -459,6 +453,12 @@ msgstr "Retour à la connexion"
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:110
 msgid "auth.forgotPassword.backLink"
+msgstr "Retour à la connexion"
+
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
 msgstr "Retour à la connexion"
 
 #. Interview type label: behavioral interview
@@ -755,14 +755,14 @@ msgstr "Contact"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
-msgid "license.toc.title"
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Sommaire"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
+#: src/components/LicenseContent.tsx:18
+msgid "license.toc.title"
 msgstr "Sommaire"
 
 #. Button to continue to app after verification
@@ -1109,16 +1109,16 @@ msgstr "Alertes e-mail pour les nouvelles offres"
 msgid "home.features.s1.eyebrow"
 msgstr "Tout ce qu'il te faut pour garder une longueur d'avance"
 
-#. Label for experience filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:177
-msgid "search.advanced.experience"
-msgstr "Expérience"
-
 #. Title for experience filter modal
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:186
 msgid "search.experienceModal.title"
+msgstr "Expérience"
+
+#. Label for experience filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:177
+msgid "search.advanced.experience"
 msgstr "Expérience"
 
 #. js-lingui-explicit-id
@@ -1605,16 +1605,16 @@ msgstr "Lien de vérification invalide"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:110
-msgid "watchlists.explore.jobSingular"
-msgstr "offre"
-
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31
 msgid "watchlists.card.jobSingular"
+msgstr "offre"
+
+#. Singular job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:110
+msgid "watchlists.explore.jobSingular"
 msgstr "offre"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -1682,10 +1682,10 @@ msgstr "Le code source de Job Seek est ouvert sous licence MIT. Les données d'e
 msgid "watchlist.meta.fallback"
 msgstr "Liste d'emplois de @{owner}"
 
-#. Plural job count in public watchlist
+#. Job count label in watchlist view
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:111
-msgid "watchlists.explore.jobPlural"
+#: src/components/watchlist/watchlist-job-list.tsx:210
+msgid "watchlists.jobList.jobCount"
 msgstr "offres"
 
 #. Plural job count on watchlist card
@@ -1694,10 +1694,10 @@ msgstr "offres"
 msgid "watchlists.card.jobPlural"
 msgstr "offres"
 
-#. Job count label in watchlist view
+#. Plural job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:210
-msgid "watchlists.jobList.jobCount"
+#: src/components/watchlist/public-watchlist-search.tsx:111
+msgid "watchlists.explore.jobPlural"
 msgstr "offres"
 
 #. js-lingui-explicit-id
@@ -1788,16 +1788,16 @@ msgstr "Dernière semaine"
 msgid "home.hero.secondaryCta"
 msgstr "En savoir plus"
 
-#. Label for seniority/level filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:154
-msgid "search.advanced.level"
-msgstr "Niveau"
-
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:461
 msgid "search.bar.level"
+msgstr "Niveau"
+
+#. Label for seniority/level filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:154
+msgid "search.advanced.level"
 msgstr "Niveau"
 
 #. js-lingui-explicit-id
@@ -1858,16 +1858,16 @@ msgstr "Lieu"
 msgid "search.advanced.location"
 msgstr "Lieu"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:301
-msgid "search.detail.locations"
-msgstr "Lieux"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:531
 msgid "search.bar.locations"
+msgstr "Lieux"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:301
+msgid "search.detail.locations"
 msgstr "Lieux"
 
 #. Login button label
@@ -2120,16 +2120,16 @@ msgstr "Aucune offre trouvée."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Aucune langue ne correspond à votre recherche."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:185
-msgid "company.locationModal.noResults"
-msgstr "Aucun lieu ne correspond à votre recherche."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:170
 msgid "search.locationModal.noResults"
+msgstr "Aucun lieu ne correspond à votre recherche."
+
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:185
+msgid "company.locationModal.noResults"
 msgstr "Aucun lieu ne correspond à votre recherche."
 
 #. No postings found message on company page
@@ -2250,16 +2250,16 @@ msgstr "Offre"
 msgid "myJobs.group.offered"
 msgstr "Offre"
 
-#. Status option in dropdown: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:35
-msgid "myJobs.statusOption.offered"
-msgstr "Offre"
-
 #. Sankey funnel node: offered
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:43
 msgid "myJobs.funnel.offered"
+msgstr "Offre"
+
+#. Status option in dropdown: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:35
+msgid "myJobs.statusOption.offered"
 msgstr "Offre"
 
 #. Cookie banner accept button
@@ -2365,26 +2365,26 @@ msgstr "Notre position sur l'automatisation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:22
-msgid "license.toc.overview"
-msgstr "Aperçu"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:27
 msgid "indexing.toc.overview"
 msgstr "Aperçu"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:19
-msgid "license.toc.ariaLabel"
-msgstr "Sommaire de la page"
+#: src/components/LicenseContent.tsx:22
+msgid "license.toc.overview"
+msgstr "Aperçu"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:24
 msgid "indexing.toc.ariaLabel"
+msgstr "Sommaire de la page"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:19
+msgid "license.toc.ariaLabel"
 msgstr "Sommaire de la page"
 
 #. Heading shown on the 404 page
@@ -2754,16 +2754,16 @@ msgstr "Refusé"
 msgid "myJobs.status.rejected"
 msgstr "Refusé"
 
-#. Status option in dropdown: rejected
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:36
-msgid "myJobs.statusOption.rejected"
-msgstr "Refusé"
-
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
+msgstr "Refusé"
+
+#. Status option in dropdown: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:36
+msgid "myJobs.statusOption.rejected"
 msgstr "Refusé"
 
 #. Footer license summary text
@@ -2822,16 +2822,16 @@ msgstr "Renvoyer dans {cooldown}s"
 msgid "auth.verify.resend"
 msgstr "Renvoyer l'e-mail de vérification"
 
-#. Reset salary filter
-#. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:314
-msgid "search.salaryModal.reset"
-msgstr "Réinitialiser"
-
 #. Reset experience filter
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:240
 msgid "search.experienceModal.reset"
+msgstr "Réinitialiser"
+
+#. Reset salary filter
+#. js-lingui-explicit-id
+#: src/components/search/salary-modal.tsx:314
+msgid "search.salaryModal.reset"
 msgstr "Réinitialiser"
 
 #. Reset password submit button
@@ -2942,16 +2942,16 @@ msgstr "Enregistré"
 msgid "myJobs.status.saved"
 msgstr "Enregistré"
 
-#. Status option in dropdown: saved
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:32
-msgid "myJobs.statusOption.saved"
-msgstr "Enregistré"
-
 #. Sankey funnel node: saved jobs
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:41
 msgid "myJobs.funnel.saved"
+msgstr "Enregistré"
+
+#. Status option in dropdown: saved
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:32
+msgid "myJobs.statusOption.saved"
 msgstr "Enregistré"
 
 #. Free feature: saved searches
@@ -2984,11 +2984,6 @@ msgstr "Enregistrement..."
 msgid "settings.account.email.saving"
 msgstr "Enregistrement…"
 
-#. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:26
-msgid "explore.meta.description"
-msgstr "Recherchez et filtrez les offres d'emploi de centaines d'entreprises."
-
 #. Placeholder for search bar when on company page
 #. js-lingui-explicit-id
 #. placeholder {0}: company.name
@@ -3008,23 +3003,28 @@ msgstr "Rechercher des entreprises..."
 msgid "watchlists.companyModal.searchPlaceholder"
 msgstr "Rechercher des entreprises..."
 
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/explore/page.tsx:26
+msgid "explore.meta.description"
+msgstr "Recherchez des emplois dans des centaines d'entreprises. Créez des listes de suivi pour suivre les nouvelles offres et recevoir des alertes."
+
 #. Placeholder for search input in all-languages modal
 #. js-lingui-explicit-id
 #: src/components/settings/JobLanguageModal.tsx:77
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Rechercher des langues…"
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:164
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Rechercher des lieux…"
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:149
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Rechercher des lieux..."
+
+#. Placeholder for search input in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:164
+msgid "company.locationModal.searchPlaceholder"
+msgstr "Rechercher des lieux…"
 
 #. Back to search results link on company page
 #. js-lingui-explicit-id
@@ -3188,16 +3188,16 @@ msgstr "Paramètres"
 #~ msgid "settings.billing.usage.unlimited"
 #~ msgstr "Illimité"
 
-#. Collapse location pill list
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:350
-msgid "company.page.showLess"
-msgstr "Afficher moins"
-
 #. Button to collapse location list
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:344
 msgid "search.detail.showLessLocations"
+msgstr "Afficher moins"
+
+#. Collapse location pill list
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:350
+msgid "company.page.showLess"
 msgstr "Afficher moins"
 
 #. Aria label to show password
@@ -3308,12 +3308,6 @@ msgstr "Aller au contenu"
 msgid "error.title"
 msgstr "Une erreur est survenue"
 
-#. Generic forgot password error
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:43
-msgid "auth.forgotPassword.error.generic"
-msgstr "Une erreur est survenue. Veuillez réessayer."
-
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
@@ -3323,6 +3317,12 @@ msgstr "Une erreur est survenue. Veuillez réessayer."
 #: src/components/search/request-company.tsx:19
 msgid "app.home.request.error.unknown"
 msgstr "Une erreur s'est produite. Veuillez réessayer."
+
+#. Generic forgot password error
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:43
+msgid "auth.forgotPassword.error.generic"
+msgstr "Une erreur est survenue. Veuillez réessayer."
 
 #. Generic error creating watchlist
 #. js-lingui-explicit-id
@@ -3445,16 +3445,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technique"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:386
-msgid "search.detail.technologies"
-msgstr "Technologies"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:496
 msgid "search.bar.technologies"
+msgstr "Technologies"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:386
+msgid "search.detail.technologies"
 msgstr "Technologies"
 
 #. Add technology filter

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -371,28 +371,28 @@ msgstr "Candidato"
 msgid "myJobs.status.applied"
 msgstr "Candidato"
 
-#. Status option in dropdown: applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:33
-msgid "myJobs.statusOption.applied"
-msgstr "Candidato"
-
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
 msgstr "Candidato"
 
-#. Apply salary filter
+#. Status option in dropdown: applied
 #. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:320
-msgid "search.salaryModal.apply"
-msgstr "Applica"
+#: src/components/my-jobs/my-job-detail-panel.tsx:33
+msgid "myJobs.statusOption.applied"
+msgstr "Candidato"
 
 #. Apply experience filter
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:246
 msgid "search.experienceModal.apply"
+msgstr "Applica"
+
+#. Apply salary filter
+#. js-lingui-explicit-id
+#: src/components/search/salary-modal.tsx:320
+msgid "search.salaryModal.apply"
 msgstr "Applica"
 
 #. Apply button linking to original job posting
@@ -437,12 +437,6 @@ msgstr "Ago"
 msgid "settings.account.username.available"
 msgstr "Disponibile"
 
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Torna all'accesso"
-
 #. Link back to sign-in after failed verification
 #. js-lingui-explicit-id
 #: app/[lang]/verify-email/page.tsx:68
@@ -460,6 +454,12 @@ msgstr "Torna al login"
 #: app/[lang]/(auth)/forgot-password/page.tsx:110
 msgid "auth.forgotPassword.backLink"
 msgstr "Torna al login"
+
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
+msgstr "Torna all'accesso"
 
 #. Interview type label: behavioral interview
 #. js-lingui-explicit-id
@@ -755,14 +755,14 @@ msgstr "Contatti"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
-msgid "license.toc.title"
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Sommario"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
+#: src/components/LicenseContent.tsx:18
+msgid "license.toc.title"
 msgstr "Sommario"
 
 #. Button to continue to app after verification
@@ -1109,16 +1109,16 @@ msgstr "Avvisi e-mail per nuove offerte"
 msgid "home.features.s1.eyebrow"
 msgstr "Tutto ciò che ti serve per restare al passo"
 
-#. Label for experience filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:177
-msgid "search.advanced.experience"
-msgstr "Esperienza"
-
 #. Title for experience filter modal
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:186
 msgid "search.experienceModal.title"
+msgstr "Esperienza"
+
+#. Label for experience filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:177
+msgid "search.advanced.experience"
 msgstr "Esperienza"
 
 #. js-lingui-explicit-id
@@ -1605,16 +1605,16 @@ msgstr "Link di verifica non valido"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Gen"
 
-#. Singular job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:110
-msgid "watchlists.explore.jobSingular"
-msgstr "offerta"
-
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31
 msgid "watchlists.card.jobSingular"
+msgstr "offerta"
+
+#. Singular job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:110
+msgid "watchlists.explore.jobSingular"
 msgstr "offerta"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -1682,10 +1682,10 @@ msgstr "Il codice sorgente di Job Seek è open source sotto licenza MIT. I dati 
 msgid "watchlist.meta.fallback"
 msgstr "Lista lavori di @{owner}"
 
-#. Plural job count in public watchlist
+#. Job count label in watchlist view
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:111
-msgid "watchlists.explore.jobPlural"
+#: src/components/watchlist/watchlist-job-list.tsx:210
+msgid "watchlists.jobList.jobCount"
 msgstr "offerte"
 
 #. Plural job count on watchlist card
@@ -1694,10 +1694,10 @@ msgstr "offerte"
 msgid "watchlists.card.jobPlural"
 msgstr "offerte"
 
-#. Job count label in watchlist view
+#. Plural job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:210
-msgid "watchlists.jobList.jobCount"
+#: src/components/watchlist/public-watchlist-search.tsx:111
+msgid "watchlists.explore.jobPlural"
 msgstr "offerte"
 
 #. js-lingui-explicit-id
@@ -1788,16 +1788,16 @@ msgstr "Ultima settimana"
 msgid "home.hero.secondaryCta"
 msgstr "Scopri di più"
 
-#. Label for seniority/level filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:154
-msgid "search.advanced.level"
-msgstr "Livello"
-
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:461
 msgid "search.bar.level"
+msgstr "Livello"
+
+#. Label for seniority/level filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:154
+msgid "search.advanced.level"
 msgstr "Livello"
 
 #. js-lingui-explicit-id
@@ -1858,17 +1858,17 @@ msgstr "Luogo"
 msgid "search.advanced.location"
 msgstr "Luogo"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:301
-msgid "search.detail.locations"
-msgstr "Località"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:531
 msgid "search.bar.locations"
 msgstr "Sedi"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:301
+msgid "search.detail.locations"
+msgstr "Località"
 
 #. Login button label
 #. Login button label
@@ -2120,17 +2120,17 @@ msgstr "Nessuna offerta trovata."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Nessuna lingua corrisponde alla ricerca."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:185
-msgid "company.locationModal.noResults"
-msgstr "Nessuna sede corrisponde alla tua ricerca."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:170
 msgid "search.locationModal.noResults"
 msgstr "Nessun luogo corrisponde alla tua ricerca."
+
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:185
+msgid "company.locationModal.noResults"
+msgstr "Nessuna sede corrisponde alla tua ricerca."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2250,16 +2250,16 @@ msgstr "Offerta"
 msgid "myJobs.group.offered"
 msgstr "Offerta"
 
-#. Status option in dropdown: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:35
-msgid "myJobs.statusOption.offered"
-msgstr "Offerta"
-
 #. Sankey funnel node: offered
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:43
 msgid "myJobs.funnel.offered"
+msgstr "Offerta"
+
+#. Status option in dropdown: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:35
+msgid "myJobs.statusOption.offered"
 msgstr "Offerta"
 
 #. Cookie banner accept button
@@ -2365,26 +2365,26 @@ msgstr "La nostra posizione sull'automazione"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:22
-msgid "license.toc.overview"
-msgstr "Panoramica"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:27
 msgid "indexing.toc.overview"
 msgstr "Panoramica"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:19
-msgid "license.toc.ariaLabel"
-msgstr "Contenuti della pagina"
+#: src/components/LicenseContent.tsx:22
+msgid "license.toc.overview"
+msgstr "Panoramica"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:24
 msgid "indexing.toc.ariaLabel"
+msgstr "Contenuti della pagina"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:19
+msgid "license.toc.ariaLabel"
 msgstr "Contenuti della pagina"
 
 #. Heading shown on the 404 page
@@ -2754,16 +2754,16 @@ msgstr "Rifiutato"
 msgid "myJobs.status.rejected"
 msgstr "Rifiutato"
 
-#. Status option in dropdown: rejected
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:36
-msgid "myJobs.statusOption.rejected"
-msgstr "Rifiutato"
-
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
+msgstr "Rifiutato"
+
+#. Status option in dropdown: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:36
+msgid "myJobs.statusOption.rejected"
 msgstr "Rifiutato"
 
 #. Footer license summary text
@@ -2822,16 +2822,16 @@ msgstr "Reinvia tra {cooldown}s"
 msgid "auth.verify.resend"
 msgstr "Reinvia email di verifica"
 
-#. Reset salary filter
-#. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:314
-msgid "search.salaryModal.reset"
-msgstr "Reimposta"
-
 #. Reset experience filter
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:240
 msgid "search.experienceModal.reset"
+msgstr "Reimposta"
+
+#. Reset salary filter
+#. js-lingui-explicit-id
+#: src/components/search/salary-modal.tsx:314
+msgid "search.salaryModal.reset"
 msgstr "Reimposta"
 
 #. Reset password submit button
@@ -2942,16 +2942,16 @@ msgstr "Salvato"
 msgid "myJobs.status.saved"
 msgstr "Salvato"
 
-#. Status option in dropdown: saved
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:32
-msgid "myJobs.statusOption.saved"
-msgstr "Salvato"
-
 #. Sankey funnel node: saved jobs
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:41
 msgid "myJobs.funnel.saved"
+msgstr "Salvato"
+
+#. Status option in dropdown: saved
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:32
+msgid "myJobs.statusOption.saved"
 msgstr "Salvato"
 
 #. Free feature: saved searches
@@ -2984,11 +2984,6 @@ msgstr "Salvataggio..."
 msgid "settings.account.email.saving"
 msgstr "Salvataggio…"
 
-#. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:26
-msgid "explore.meta.description"
-msgstr "Cerca e filtra le offerte di lavoro di centinaia di aziende."
-
 #. Placeholder for search bar when on company page
 #. js-lingui-explicit-id
 #. placeholder {0}: company.name
@@ -3008,23 +3003,28 @@ msgstr "Cerca aziende..."
 msgid "watchlists.companyModal.searchPlaceholder"
 msgstr "Cerca aziende..."
 
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/explore/page.tsx:26
+msgid "explore.meta.description"
+msgstr "Cerca lavori in centinaia di aziende. Crea watchlist per seguire le nuove posizioni e ricevere notifiche."
+
 #. Placeholder for search input in all-languages modal
 #. js-lingui-explicit-id
 #: src/components/settings/JobLanguageModal.tsx:77
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Cerca lingue…"
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:164
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Cerca sedi…"
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:149
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Cerca luoghi..."
+
+#. Placeholder for search input in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:164
+msgid "company.locationModal.searchPlaceholder"
+msgstr "Cerca sedi…"
 
 #. Back to search results link on company page
 #. js-lingui-explicit-id
@@ -3188,16 +3188,16 @@ msgstr "Impostazioni"
 #~ msgid "settings.billing.usage.unlimited"
 #~ msgstr "Illimitato"
 
-#. Collapse location pill list
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:350
-msgid "company.page.showLess"
-msgstr "Mostra meno"
-
 #. Button to collapse location list
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:344
 msgid "search.detail.showLessLocations"
+msgstr "Mostra meno"
+
+#. Collapse location pill list
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:350
+msgid "company.page.showLess"
 msgstr "Mostra meno"
 
 #. Aria label to show password
@@ -3308,12 +3308,6 @@ msgstr "Vai al contenuto"
 msgid "error.title"
 msgstr "Qualcosa è andato storto"
 
-#. Generic forgot password error
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:43
-msgid "auth.forgotPassword.error.generic"
-msgstr "Qualcosa è andato storto. Riprova."
-
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
@@ -3322,6 +3316,12 @@ msgstr "Qualcosa è andato storto. Riprova."
 #: app/[lang]/(app)/progress/company-request-form.tsx:18
 #: src/components/search/request-company.tsx:19
 msgid "app.home.request.error.unknown"
+msgstr "Qualcosa è andato storto. Riprova."
+
+#. Generic forgot password error
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:43
+msgid "auth.forgotPassword.error.generic"
 msgstr "Qualcosa è andato storto. Riprova."
 
 #. Generic error creating watchlist
@@ -3445,16 +3445,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Tecnico"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:386
-msgid "search.detail.technologies"
-msgstr "Tecnologie"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:496
 msgid "search.bar.technologies"
+msgstr "Tecnologie"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:386
+msgid "search.detail.technologies"
 msgstr "Tecnologie"
 
 #. Add technology filter

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -109,11 +109,36 @@ msgstr "{0} in più"
 msgid "search.detail.showMoreLocations"
 msgstr "{0} in più"
 
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:37
+msgid "company.meta.positionCount"
+msgstr "{count, plural, one {# posizione aperta} other {# posizioni aperte}}"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:72
+msgid "watchlist.meta.tracking"
+msgstr "{count, plural, one {# azienda monitorata} other {# aziende monitorate}}. {description}"
+
 #. Heatmap tooltip for multiple applications
 #. js-lingui-explicit-id
 #: src/components/my-jobs/activity-heatmap.tsx:80
 msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} candidature il {date}"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:40
+msgid "watchlist.meta.moreCompanies"
+msgstr "altre {count}"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:49
+msgid "company.meta.descriptionBasic"
+msgstr "{countText} presso {name}"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:44
+msgid "company.meta.descriptionWithInfo"
+msgstr "{countText} presso {name}. {description}"
 
 #. Free plan price display
 #. js-lingui-explicit-id
@@ -171,7 +196,7 @@ msgstr "Aggiungi aziende"
 
 #. Link to add a description to the watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:379
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:382
 msgid "watchlists.view.addDescription"
 msgstr "Aggiungi descrizione"
 
@@ -267,7 +292,7 @@ msgstr "Qualsiasi"
 
 #. Toggle to show jobs from all companies
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:407
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:410
 msgid "watchlists.view.anyCompany"
 msgstr "Qualsiasi azienda"
 
@@ -334,28 +359,28 @@ msgstr "candidature nell'ultimo anno"
 msgid "myJobs.group.applied"
 msgstr "Candidato"
 
-#. Applied status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:20
-msgid "myJobs.status.applied"
-msgstr "Candidato"
-
-#. Sankey funnel node: applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:42
-msgid "myJobs.funnel.applied"
-msgstr "Candidato"
-
 #. Application tracker status: applied
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:438
 msgid "search.tracker.applied"
 msgstr "Candidato"
 
+#. Applied status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:20
+msgid "myJobs.status.applied"
+msgstr "Candidato"
+
 #. Status option in dropdown: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:33
 msgid "myJobs.statusOption.applied"
+msgstr "Candidato"
+
+#. Sankey funnel node: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:42
+msgid "myJobs.funnel.applied"
 msgstr "Candidato"
 
 #. Apply salary filter
@@ -412,16 +437,16 @@ msgstr "Ago"
 msgid "settings.account.username.available"
 msgstr "Disponibile"
 
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Torna all'accesso"
-
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Torna all'accesso"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Torna all'accesso"
 
 #. Link back to sign-in from forgot password
@@ -572,14 +597,14 @@ msgstr "Reimposta"
 
 #. Button to remove all companies from watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:425
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:428
 msgid "watchlists.view.clearAllCompanies"
 msgstr "Rimuovi tutti"
 
 #. Button to clear all active search filters
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:533
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:536
 #: src/components/search/search-toolbar.tsx:282
 msgid "search.filters.clearAll"
 msgstr "Cancella tutto"
@@ -592,7 +617,7 @@ msgstr "Rimuovi tutti"
 
 #. Tooltip for clicking to edit watchlist description
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:369
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:370
 msgid "watchlists.view.editDescription"
 msgstr "Clicca per modificare la descrizione"
 
@@ -664,7 +689,7 @@ msgstr "Aziende monitorate"
 
 #. Button to open company search modal
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:396
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:399
 msgid "watchlists.view.addCompany"
 msgstr "Azienda"
 
@@ -924,7 +949,7 @@ msgstr "Eliminazione…"
 
 #. Placeholder for watchlist description textarea
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:361
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:362
 msgid "watchlists.view.descriptionPlaceholder"
 msgstr "Descrivi questa watchlist …"
 
@@ -1084,23 +1109,33 @@ msgstr "Avvisi e-mail per nuove offerte"
 msgid "home.features.s1.eyebrow"
 msgstr "Tutto ciò che ti serve per restare al passo"
 
-#. Title for experience filter modal
-#. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:186
-msgid "search.experienceModal.title"
-msgstr "Esperienza"
-
 #. Label for experience filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:177
 msgid "search.advanced.experience"
 msgstr "Esperienza"
 
+#. Title for experience filter modal
+#. js-lingui-explicit-id
+#: src/components/search/experience-modal.tsx:186
+msgid "search.experienceModal.title"
+msgstr "Esperienza"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:160
+msgid "breadcrumb.explore"
+msgstr "Esplora"
+
 #. Explore nav icon tooltip
 #. js-lingui-explicit-id
 #: src/components/AppHeader.tsx:54
 msgid "app.header.nav.explore"
 msgstr "Esplora"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/explore/page.tsx:25
+msgid "explore.meta.title"
+msgstr "Esplora lavori"
 
 #. Generic email change error
 #. js-lingui-explicit-id
@@ -1225,7 +1260,7 @@ msgid "settings.general.jobLanguages.findMore"
 msgstr "Cerca altre"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:18
+#: app/[lang]/(public)/page.tsx:19
 msgid "home.meta.title"
 msgstr "Trova i ruoli giusti più velocemente"
 
@@ -1378,6 +1413,12 @@ msgstr "Nascondi password"
 msgid "myJobs.interviewType.hiringManager"
 msgstr "Hiring Manager"
 
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:167
+#: app/[lang]/(app)/company/[slug]/page.tsx:159
+msgid "breadcrumb.home"
+msgstr "Home"
+
 #. Hourly pay period option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:356
@@ -1399,12 +1440,12 @@ msgid "common.nav.company"
 msgstr "Come indicizziamo gli annunci?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:15
+#: app/[lang]/(public)/privacy-policy/page.tsx:17
 msgid "privacy.meta.description"
 msgstr "Come Job Seek raccoglie, utilizza e protegge i tuoi dati personali."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:15
+#: app/[lang]/(public)/how-we-index/page.tsx:17
 msgid "indexing.meta.description"
 msgstr "Come Job Seek scopre, analizza e indicizza le offerte di lavoro — e le garanzie che rispettiamo."
 
@@ -1427,7 +1468,7 @@ msgid "indexing.hero.title"
 msgstr "Come troviamo e processiamo gli annunci di lavoro"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:14
+#: app/[lang]/(public)/how-we-index/page.tsx:16
 msgid "indexing.meta.title"
 msgstr "Come indicizziamo"
 
@@ -1454,6 +1495,11 @@ msgstr "Se noti attività impreviste del nostro crawler o preferisci che il tuo 
 #: src/components/HowWeIndexContent.tsx:206
 msgid "indexing.outreach.body"
 msgstr "Se noti un comportamento anomalo del crawler, preferisci che non indicizziamo i tuoi contenuti o hai suggerimenti su come migliorare le nostre misure di sicurezza, contattaci."
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:56
+msgid "watchlist.meta.inLocations"
+msgstr "a {locations}"
 
 #. Year postings count on company page
 #. js-lingui-explicit-id
@@ -1517,16 +1563,16 @@ msgstr "Colloquio"
 msgid "myJobs.group.interviewing"
 msgstr "In colloquio"
 
-#. Interviewing status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:21
-msgid "myJobs.status.interviewing"
-msgstr "In colloquio"
-
 #. Application tracker status: interviewing
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:439
 msgid "search.tracker.interviewing"
+msgstr "In colloquio"
+
+#. Interviewing status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:21
+msgid "myJobs.status.interviewing"
 msgstr "In colloquio"
 
 #. Status option in dropdown: interviewing
@@ -1559,16 +1605,16 @@ msgstr "Link di verifica non valido"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Gen"
 
-#. Singular job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:31
-msgid "watchlists.card.jobSingular"
-msgstr "offerta"
-
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:110
 msgid "watchlists.explore.jobSingular"
+msgstr "offerta"
+
+#. Singular job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:31
+msgid "watchlists.card.jobSingular"
 msgstr "offerta"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -1631,6 +1677,17 @@ msgstr "Job Seek è in fase di sviluppo attivo. Resta aggiornato per le novità!
 msgid "license.hero.description"
 msgstr "Il codice sorgente di Job Seek è open source sotto licenza MIT. I dati sugli annunci che raccogliamo e arricchiamo sono Creative Commons BY-NC 4.0. Di seguito il riepilogo in linguaggio semplice — si prega di leggere le licenze complete per i termini esatti."
 
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:64
+msgid "watchlist.meta.fallback"
+msgstr "Lista lavori di @{owner}"
+
+#. Plural job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:111
+msgid "watchlists.explore.jobPlural"
+msgstr "offerte"
+
 #. Plural job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:32
@@ -1643,11 +1700,15 @@ msgstr "offerte"
 msgid "watchlists.jobList.jobCount"
 msgstr "offerte"
 
-#. Plural job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:111
-msgid "watchlists.explore.jobPlural"
-msgstr "offerte"
+#: app/[lang]/(app)/company/[slug]/page.tsx:30
+msgid "company.meta.title"
+msgstr "Lavori presso {name}"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:46
+msgid "watchlist.meta.jobsAt"
+msgstr "Lavori presso {names}"
 
 #. Short July label
 #. js-lingui-explicit-id
@@ -1727,20 +1788,20 @@ msgstr "Ultima settimana"
 msgid "home.hero.secondaryCta"
 msgstr "Scopri di più"
 
-#. Section header for seniority suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:461
-msgid "search.bar.level"
-msgstr "Livello"
-
 #. Label for seniority/level filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:154
 msgid "search.advanced.level"
 msgstr "Livello"
 
+#. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:14
+#: src/components/search/search-bar.tsx:461
+msgid "search.bar.level"
+msgstr "Livello"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/license/page.tsx:16
 msgid "license.meta.title"
 msgstr "Licenza"
 
@@ -1763,7 +1824,7 @@ msgid "license.hero.eyebrow"
 msgstr "Licenze"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:15
+#: app/[lang]/(public)/license/page.tsx:17
 msgid "license.meta.description"
 msgstr "Termini di licenza per il codice dell'applicazione Job Seek (MIT) e i dati sulle offerte di lavoro (CC BY-NC 4.0)."
 
@@ -1797,17 +1858,17 @@ msgstr "Luogo"
 msgid "search.advanced.location"
 msgstr "Luogo"
 
-#. Section header for location suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:531
-msgid "search.bar.locations"
-msgstr "Sedi"
-
 #. Locations heading in job detail
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:301
 msgid "search.detail.locations"
 msgstr "Località"
+
+#. Section header for location suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:531
+msgid "search.bar.locations"
+msgstr "Sedi"
 
 #. Login button label
 #. Login button label
@@ -2131,16 +2192,16 @@ msgstr "Nessuna lista trovata."
 msgid "watchlists.page.empty"
 msgstr "Nessuna lista di osservazione. Creane una per seguire le offerte delle tue aziende preferite."
 
-#. Sankey funnel node: not applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:44
-msgid "myJobs.funnel.notApplied"
-msgstr "Non candidato"
-
 #. Application tracker status: not applied
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:437
 msgid "search.tracker.notApplied"
+msgstr "Non candidato"
+
+#. Sankey funnel node: not applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:44
+msgid "myJobs.funnel.notApplied"
 msgstr "Non candidato"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2171,16 +2232,16 @@ msgstr "Professione"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Ott"
 
-#. Offered status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:22
-msgid "myJobs.status.offered"
-msgstr "Offerta"
-
 #. Application tracker status: offer
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:440
 msgid "search.tracker.offer"
+msgstr "Offerta"
+
+#. Offered status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:22
+msgid "myJobs.status.offered"
 msgstr "Offerta"
 
 #. Status group heading: offered
@@ -2189,16 +2250,16 @@ msgstr "Offerta"
 msgid "myJobs.group.offered"
 msgstr "Offerta"
 
-#. Sankey funnel node: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:43
-msgid "myJobs.funnel.offered"
-msgstr "Offerta"
-
 #. Status option in dropdown: offered
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:35
 msgid "myJobs.statusOption.offered"
+msgstr "Offerta"
+
+#. Sankey funnel node: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:43
+msgid "myJobs.funnel.offered"
 msgstr "Offerta"
 
 #. Cookie banner accept button
@@ -2236,6 +2297,11 @@ msgstr "In sede"
 #: src/components/Header.tsx:79
 msgid "common.header.openMenu"
 msgstr "Apri menu principale"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/page.tsx:42
+msgid "company.meta.openPositions"
+msgstr "Posizioni aperte"
 
 #. TOC: Open-source crawlers
 #. js-lingui-explicit-id
@@ -2529,18 +2595,18 @@ msgstr "Offerta non trovata."
 msgid "myJobs.detail.notFound"
 msgstr "Offerta non trovata."
 
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:101
+msgid "home.pricing.eyebrow"
+msgstr "Prezzi"
+
 #. Nav link: Pricing
 #. Nav link: Pricing
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:61
 #: src/components/MobileMenu.tsx:86
 msgid "common.nav.pricing"
-msgstr "Prezzi"
-
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: src/components/Pricing.tsx:101
-msgid "home.pricing.eyebrow"
 msgstr "Prezzi"
 
 #. Privacy policy page eyebrow
@@ -2562,7 +2628,7 @@ msgid "privacy.hero.title"
 msgstr "Privacy su Job Seek"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:14
+#: app/[lang]/(public)/privacy-policy/page.tsx:16
 msgid "privacy.meta.title"
 msgstr "Informativa sulla privacy"
 
@@ -2676,28 +2742,28 @@ msgstr "Regione"
 msgid "myJobs.group.rejected"
 msgstr "Rifiutato"
 
-#. Rejected status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:23
-msgid "myJobs.status.rejected"
-msgstr "Rifiutato"
-
-#. Sankey funnel node label prefix: rejected
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:45
-msgid "myJobs.funnel.rejected"
-msgstr "Rifiutato"
-
 #. Application tracker status: rejected
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:441
 msgid "search.tracker.rejected"
 msgstr "Rifiutato"
 
+#. Rejected status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:23
+msgid "myJobs.status.rejected"
+msgstr "Rifiutato"
+
 #. Status option in dropdown: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.rejected"
+msgstr "Rifiutato"
+
+#. Sankey funnel node label prefix: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:45
+msgid "myJobs.funnel.rejected"
 msgstr "Rifiutato"
 
 #. Footer license summary text
@@ -2810,16 +2876,16 @@ msgstr "Ruoli"
 msgid "myJobs.funnel.round"
 msgstr "Turno"
 
-#. Salary override section heading
-#. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:76
-msgid "myJobs.detail.salary"
-msgstr "Stipendio"
-
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:171
 msgid "search.advanced.salary"
+msgstr "Stipendio"
+
+#. Salary override section heading
+#. js-lingui-explicit-id
+#: src/components/my-jobs/salary-override.tsx:76
+msgid "myJobs.detail.salary"
 msgstr "Stipendio"
 
 #. Salary display settings section heading
@@ -2876,16 +2942,16 @@ msgstr "Salvato"
 msgid "myJobs.status.saved"
 msgstr "Salvato"
 
-#. Sankey funnel node: saved jobs
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:41
-msgid "myJobs.funnel.saved"
-msgstr "Salvato"
-
 #. Status option in dropdown: saved
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:32
 msgid "myJobs.statusOption.saved"
+msgstr "Salvato"
+
+#. Sankey funnel node: saved jobs
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:41
+msgid "myJobs.funnel.saved"
 msgstr "Salvato"
 
 #. Free feature: saved searches
@@ -2918,6 +2984,11 @@ msgstr "Salvataggio..."
 msgid "settings.account.email.saving"
 msgstr "Salvataggio…"
 
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/explore/page.tsx:26
+msgid "explore.meta.description"
+msgstr "Cerca e filtra le offerte di lavoro di centinaia di aziende."
+
 #. Placeholder for search bar when on company page
 #. js-lingui-explicit-id
 #. placeholder {0}: company.name
@@ -2925,16 +2996,16 @@ msgstr "Salvataggio…"
 msgid "company.page.searchPlaceholder"
 msgstr "Cerca in {0}..."
 
-#. Placeholder for company search in modal
-#. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:212
-msgid "watchlists.companyModal.searchPlaceholder"
-msgstr "Cerca aziende..."
-
 #. Placeholder for company search in watchlist creation
 #. js-lingui-explicit-id
 #: src/components/watchlist/company-selector.tsx:91
 msgid "watchlists.companySelector.placeholder"
+msgstr "Cerca aziende..."
+
+#. Placeholder for company search in modal
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-search-modal.tsx:212
+msgid "watchlists.companyModal.searchPlaceholder"
 msgstr "Cerca aziende..."
 
 #. Placeholder for search input in all-languages modal
@@ -3237,6 +3308,12 @@ msgstr "Vai al contenuto"
 msgid "error.title"
 msgstr "Qualcosa è andato storto"
 
+#. Generic forgot password error
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:43
+msgid "auth.forgotPassword.error.generic"
+msgstr "Qualcosa è andato storto. Riprova."
+
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
@@ -3245,12 +3322,6 @@ msgstr "Qualcosa è andato storto"
 #: app/[lang]/(app)/progress/company-request-form.tsx:18
 #: src/components/search/request-company.tsx:19
 msgid "app.home.request.error.unknown"
-msgstr "Qualcosa è andato storto. Riprova."
-
-#. Generic forgot password error
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:43
-msgid "auth.forgotPassword.error.generic"
 msgstr "Qualcosa è andato storto. Riprova."
 
 #. Generic error creating watchlist
@@ -3334,7 +3405,7 @@ msgid "home.pricing.free.f1"
 msgstr "Segui fino a 5 aziende"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:19
+#: app/[lang]/(public)/page.tsx:20
 msgid "home.meta.description"
 msgstr "Iscriviti agli aggiornamenti delle aziende, monitora le candidature e non perdere mai nuove offerte."
 
@@ -3374,16 +3445,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Tecnico"
 
-#. Section header for technology suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:496
-msgid "search.bar.technologies"
-msgstr "Tecnologie"
-
 #. Technologies sub-heading in details section
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:386
 msgid "search.detail.technologies"
+msgstr "Tecnologie"
+
+#. Section header for technology suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:496
+msgid "search.bar.technologies"
 msgstr "Tecnologie"
 
 #. Add technology filter
@@ -3417,7 +3488,7 @@ msgid "common.footer.termsLink"
 msgstr "Termini"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:14
+#: app/[lang]/(public)/terms/page.tsx:16
 msgid "terms.meta.title"
 msgstr "Termini di servizio"
 
@@ -3428,7 +3499,7 @@ msgid "terms.hero.title"
 msgstr "Termini di servizio"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:15
+#: app/[lang]/(public)/terms/page.tsx:17
 msgid "terms.meta.description"
 msgstr "Termini di servizio dell'applicazione Job Seek."
 

--- a/apps/web/src/content/config.ts
+++ b/apps/web/src/content/config.ts
@@ -156,7 +156,19 @@ export const siteConfig = {
   },
 
   seo: {
-    disallow: ["/dashboard", "/sign-in", "/sign-up"],
+    disallow: [
+      "/dashboard",
+      "/sign-in",
+      "/sign-up",
+      "/api/",
+      "/settings",
+      "/my-jobs",
+      "/progress",
+      "/check-email",
+      "/forgot-password",
+      "/reset-password",
+      "/verify-email",
+    ],
     sitemap: [
       { path: "/", changeFrequency: "weekly", priority: 1 },
       { path: "/how-we-index", changeFrequency: "monthly", priority: 0.6 },

--- a/apps/web/src/lib/actions/company.ts
+++ b/apps/web/src/lib/actions/company.ts
@@ -277,6 +277,7 @@ export interface CompanyDetail {
   industryName: string | null;
   employeeCountRange: number | null;
   foundedYear: number | null;
+  activeJobCount: number;
 }
 
 export async function getCompanyBySlug(
@@ -299,12 +300,15 @@ async function _fetchCompanyBySlug(slug: string, locale: string): Promise<Compan
     industry_name: string | null;
     employee_count_range: number | null;
     founded_year: number | null;
+    active_job_count: number;
   }>(sql`
     SELECT c.id, c.name, c.slug, c.icon, c.website,
       COALESCE(cd.description, c.description) AS description,
       COALESCE(ind_name.name, i.name) AS industry_name,
       c.employee_count_range,
-      c.founded_year
+      c.founded_year,
+      (SELECT count(*) FROM job_posting jp
+       WHERE jp.company_id = c.id AND jp.is_active = true)::int AS active_job_count
     FROM company c
     LEFT JOIN industry i ON i.id = c.industry
     LEFT JOIN company_description cd
@@ -321,7 +325,7 @@ async function _fetchCompanyBySlug(slug: string, locale: string): Promise<Compan
     id: string; name: string; slug: string; icon: string | null;
     website: string | null; description: string | null;
     industry_name: string | null; employee_count_range: number | null;
-    founded_year: number | null;
+    founded_year: number | null; active_job_count: number;
   };
   const row = (rows as unknown as Row[])[0];
   if (!row) return null;
@@ -336,6 +340,7 @@ async function _fetchCompanyBySlug(slug: string, locale: string): Promise<Compan
     industryName: row.industry_name,
     employeeCountRange: row.employee_count_range,
     foundedYear: row.founded_year,
+    activeJobCount: row.active_job_count,
   };
 }
 

--- a/apps/web/src/lib/seo.tsx
+++ b/apps/web/src/lib/seo.tsx
@@ -1,0 +1,51 @@
+import { siteConfig } from "@/content/config";
+import { locales, type Locale } from "@/lib/i18n";
+
+/**
+ * Build hreflang alternates for Next.js Metadata API.
+ * Returns canonical URL (without query params) and language alternates including x-default.
+ */
+export function buildAlternates(path: string, currentLocale: Locale) {
+  const languages: Record<string, string> = {};
+  for (const locale of locales) {
+    languages[locale] = `${siteConfig.url}/${locale}${path}`;
+  }
+  languages["x-default"] = `${siteConfig.url}/en${path}`;
+  return {
+    canonical: `${siteConfig.url}/${currentLocale}${path}`,
+    languages,
+  };
+}
+
+/**
+ * Render JSON-LD structured data as a sanitized <script> tag.
+ * Replaces `<` with `\u003c` to prevent XSS in embedded JSON.
+ */
+export function JsonLd({ data }: { data: Record<string, unknown> }) {
+  const json = JSON.stringify(data).replace(/</g, "\\u003c");
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: json }}
+    />
+  );
+}
+
+const EMPLOYEE_RANGES: Record<number, string> = {
+  1: "1-10",
+  2: "11-50",
+  3: "51-200",
+  4: "201-500",
+  5: "501-1000",
+  6: "1001-5000",
+  7: "5001-10000",
+  8: "10001+",
+};
+
+/**
+ * Map numeric employee_count_range code to a display string for JSON-LD.
+ */
+export function formatEmployeeCount(range: number | null): string | null {
+  if (range === null) return null;
+  return EMPLOYEE_RANGES[range] ?? null;
+}


### PR DESCRIPTION
## Summary

- Add canonical URLs, hreflang alternates, and OpenGraph metadata to all pages (company, explore, watchlists, and 5 public pages)
- Add Organization JSON-LD on company pages with founding date, employee count, industry
- Add root-level Organization + WebSite JSON-LD with SearchAction for sitelinks search box
- Add `generateMetadata` to explore page (was completely missing)
- Rewrite `sitemap.ts` to dynamically include company pages with active postings, with hreflang alternates on all entries
- Expand `robots.txt` disallow list for auth/private routes (`/api/`, `/settings`, `/my-jobs`, etc.)
- Create shared `seo.tsx` utilities (`buildAlternates`, `JsonLd`, `formatEmployeeCount`)

## Test plan

- [ ] Verify `<link rel="canonical">` and `<link rel="alternate" hreflang>` in page source on company, explore, watchlist pages
- [ ] Verify `<script type="application/ld+json">` on company pages (Organization) and all pages (root Organization + WebSite)
- [ ] Verify `<meta property="og:*">` tags on company and explore pages
- [ ] Fetch `/sitemap.xml` and confirm company entries with hreflang alternates
- [ ] Fetch `/robots.txt` and confirm expanded disallow list
- [ ] Validate JSON-LD with Google Rich Results Test
- [ ] Run `pnpm extract` to update Lingui .po files with new explore page strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)