### PR TITLE
Fix domain to jseek.co, add WebApplication schema and AI plugin manifest

### DIFF
--- a/apps/web/app/[lang]/layout.tsx
+++ b/apps/web/app/[lang]/layout.tsx
@@ -40,10 +40,34 @@ export default async function LocaleLayout({ children, params }: Props) {
           "@type": "SearchAction",
           target: {
             "@type": "EntryPoint",
-            urlTemplate: `${siteConfig.url}/en/explore?q={search_term_string}`,
+            urlTemplate: `${siteConfig.url}/${locale}/explore?q={search_term_string}`,
           },
           "query-input": "required name=search_term_string",
         },
+      }} />
+      <JsonLd data={{
+        "@context": "https://schema.org",
+        "@type": "WebApplication",
+        name: "Job Seek",
+        url: siteConfig.url,
+        applicationCategory: "BusinessApplication",
+        operatingSystem: "Any",
+        inLanguage: locale,
+        description: i18n._({
+          id: "app.schema.description",
+          message: "Job aggregator that monitors company career pages. Subscribe to company updates, track applications, and get alerts on new openings.",
+        }),
+        offers: {
+          "@type": "Offer",
+          price: "0",
+          priceCurrency: "USD",
+        },
+        featureList: [
+          i18n._({ id: "app.schema.feature.monitor", message: "Monitor company career pages" }),
+          i18n._({ id: "app.schema.feature.alerts", message: "Real-time job posting alerts" }),
+          i18n._({ id: "app.schema.feature.languages", message: "Multi-language support" }),
+          i18n._({ id: "app.schema.feature.watchlists", message: "Watchlists and application tracking" }),
+        ],
       }} />
       {children}
     </LinguiClientProvider>

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -359,12 +359,6 @@ msgstr "Bewerbungen im letzten Jahr"
 msgid "myJobs.group.applied"
 msgstr "Beworben"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:438
-msgid "search.tracker.applied"
-msgstr "Beworben"
-
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
@@ -383,16 +377,22 @@ msgstr "Beworben"
 msgid "myJobs.statusOption.applied"
 msgstr "Beworben"
 
-#. Apply experience filter
+#. Application tracker status: applied
 #. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:246
-msgid "search.experienceModal.apply"
-msgstr "Anwenden"
+#: src/components/search/job-detail-dialog.tsx:438
+msgid "search.tracker.applied"
+msgstr "Beworben"
 
 #. Apply salary filter
 #. js-lingui-explicit-id
 #: src/components/search/salary-modal.tsx:320
 msgid "search.salaryModal.apply"
+msgstr "Anwenden"
+
+#. Apply experience filter
+#. js-lingui-explicit-id
+#: src/components/search/experience-modal.tsx:246
+msgid "search.experienceModal.apply"
 msgstr "Anwenden"
 
 #. Apply button linking to original job posting
@@ -443,6 +443,12 @@ msgstr "Verfügbar"
 msgid "auth.verify.error.backToSignIn"
 msgstr "Zurück zur Anmeldung"
 
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
+msgstr "Zurück zur Anmeldung"
+
 #. Link back to sign-in from forgot password
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:68
@@ -453,12 +459,6 @@ msgstr "Zurück zur Anmeldung"
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:110
 msgid "auth.forgotPassword.backLink"
-msgstr "Zurück zur Anmeldung"
-
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
 msgstr "Zurück zur Anmeldung"
 
 #. Interview type label: behavioral interview
@@ -485,16 +485,16 @@ msgstr "Entwickelt für aktive Jobsuchende"
 msgid "terms.hero.description"
 msgstr "Mit der Nutzung von Job Seek stimmst du diesen Bedingungen zu. Hier eine verständliche Zusammenfassung."
 
-#. Cancel button in create watchlist dialog
-#. js-lingui-explicit-id
-#: src/components/watchlist/create-watchlist-dialog.tsx:162
-msgid "watchlists.create.cancel"
-msgstr "Abbrechen"
-
 #. Cancel delete watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-action-bar.tsx:233
 msgid "watchlists.delete.cancel"
+msgstr "Abbrechen"
+
+#. Cancel button in create watchlist dialog
+#. js-lingui-explicit-id
+#: src/components/watchlist/create-watchlist-dialog.tsx:162
+msgid "watchlists.create.cancel"
 msgstr "Abbrechen"
 
 #. Cancel delete button
@@ -533,17 +533,17 @@ msgstr "Ändere dein Passwort über einen sicheren E-Mail-Link."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Ändern…"
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "E-Mail überprüfen"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
 msgstr "E-Mail prüfen"
+
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
+msgstr "E-Mail überprüfen"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -735,12 +735,6 @@ msgstr "Verbinden"
 msgid "settings.account.socials.title"
 msgstr "Verknüpfte Konten"
 
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:41
-msgid "common.footer.contact"
-msgstr "Kontakt"
-
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:25
@@ -753,16 +747,22 @@ msgstr "Kontakt"
 msgid "license.contact.title"
 msgstr "Kontakt"
 
-#. Table of contents heading
+#. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
-msgstr "Inhalt"
+#: src/components/Footer.tsx:41
+msgid "common.footer.contact"
+msgstr "Kontakt"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
+msgstr "Inhalt"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Inhalt"
 
 #. Button to continue to app after verification
@@ -1563,12 +1563,6 @@ msgstr "Interview"
 msgid "myJobs.group.interviewing"
 msgstr "Im Interview"
 
-#. Application tracker status: interviewing
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:439
-msgid "search.tracker.interviewing"
-msgstr "Im Interview"
-
 #. Interviewing status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:21
@@ -1579,6 +1573,12 @@ msgstr "Im Interview"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:34
 msgid "myJobs.statusOption.interviewing"
+msgstr "Im Interview"
+
+#. Application tracker status: interviewing
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:439
+msgid "search.tracker.interviewing"
 msgstr "Im Interview"
 
 #. Interviews section heading
@@ -1617,23 +1617,28 @@ msgstr "Job"
 msgid "watchlists.explore.jobSingular"
 msgstr "Job"
 
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:56
+msgid "app.schema.description"
+msgstr ""
+
 #. TOC: Job data (CC BY-NC 4.0)
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:24
 msgid "license.toc.data"
 msgstr "Stellendaten (CC BY-NC 4.0)"
 
-#. Job detail panel title
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:71
-msgid "search.detail.title"
-msgstr "Stellendetails"
-
 #. Job detail panel title in My Jobs
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:158
 msgid "myJobs.detail.title"
 msgstr "Jobdetails"
+
+#. Job detail panel title
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:71
+msgid "search.detail.title"
+msgstr "Stellendetails"
 
 #. Job languages settings section heading
 #. js-lingui-explicit-id
@@ -1682,16 +1687,16 @@ msgstr "Die Codebasis von Job Seek ist Open Source unter MIT. Die von uns gesamm
 msgid "watchlist.meta.fallback"
 msgstr "Job-Watchlist von @{owner}"
 
-#. Job count label in watchlist view
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:210
-msgid "watchlists.jobList.jobCount"
-msgstr "Jobs"
-
 #. Plural job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:32
 msgid "watchlists.card.jobPlural"
+msgstr "Jobs"
+
+#. Job count label in watchlist view
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-job-list.tsx:210
+msgid "watchlists.jobList.jobCount"
 msgstr "Jobs"
 
 #. Plural job count in public watchlist
@@ -1988,6 +1993,11 @@ msgstr "Kopien"
 msgid "myJobs.heatmap.day.mon"
 msgstr "Mo"
 
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:66
+msgid "app.schema.feature.monitor"
+msgstr ""
+
 #. Monthly pay period option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:350
@@ -2005,6 +2015,11 @@ msgstr "Monatlich"
 #: src/components/search/filter-bar.tsx:355
 msgid "company.page.showMore"
 msgstr "mehr"
+
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:68
+msgid "app.schema.feature.languages"
+msgstr ""
 
 #. Warning when Enter is pressed but multiple items match
 #. Warning when Enter is pressed but multiple items match
@@ -2120,17 +2135,17 @@ msgstr "Keine Jobs gefunden."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Keine Sprachen entsprechen deiner Suche."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:170
-msgid "search.locationModal.noResults"
-msgstr "Keine Standorte gefunden."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:185
 msgid "company.locationModal.noResults"
 msgstr "Keine Standorte entsprechen Ihrer Suche."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:170
+msgid "search.locationModal.noResults"
+msgstr "Keine Standorte gefunden."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2192,16 +2207,16 @@ msgstr "Keine Watchlists gefunden."
 msgid "watchlists.page.empty"
 msgstr "Noch keine Watchlists. Erstelle eine, um Jobs von deinen Lieblingsunternehmen zu verfolgen."
 
-#. Application tracker status: not applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:437
-msgid "search.tracker.notApplied"
-msgstr "Nicht beworben"
-
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
+msgstr "Nicht beworben"
+
+#. Application tracker status: not applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:437
+msgid "search.tracker.notApplied"
 msgstr "Nicht beworben"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2232,16 +2247,16 @@ msgstr "Berufsfeld"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Okt"
 
-#. Application tracker status: offer
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:440
-msgid "search.tracker.offer"
-msgstr "Angebot"
-
 #. Offered status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
+msgstr "Angebot"
+
+#. Application tracker status: offer
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:440
+msgid "search.tracker.offer"
 msgstr "Angebot"
 
 #. Status group heading: offered
@@ -2365,26 +2380,26 @@ msgstr "Unsere Haltung zur Automatisierung"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Überblick"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Überblick"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Seiteninhalt"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Überblick"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Seiteninhalt"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Seiteninhalt"
 
 #. Heading shown on the 404 page
@@ -2585,15 +2600,15 @@ msgstr "Verweise uns auf eine beliebige Karriereseite oder ein Notion-Jobboard u
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:86
-msgid "search.detail.notFound"
-msgstr "Stelle nicht gefunden."
-
-#. Posting not found message
-#. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:178
 msgid "myJobs.detail.notFound"
 msgstr "Stellenanzeige nicht gefunden."
+
+#. Posting not found message
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:86
+msgid "search.detail.notFound"
+msgstr "Stelle nicht gefunden."
 
 #. Pricing section eyebrow
 #. js-lingui-explicit-id
@@ -2712,6 +2727,11 @@ msgstr "Vollständige Datenschutzrichtlinie lesen"
 msgid "terms.fullTermsLink"
 msgstr "Vollständige Nutzungsbedingungen lesen"
 
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:67
+msgid "app.schema.feature.alerts"
+msgstr ""
+
 #. Sort option: recently updated
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sort-filter-bar.tsx:13
@@ -2742,12 +2762,6 @@ msgstr "Region"
 msgid "myJobs.group.rejected"
 msgstr "Abgelehnt"
 
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:441
-msgid "search.tracker.rejected"
-msgstr "Abgelehnt"
-
 #. Rejected status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:23
@@ -2764,6 +2778,12 @@ msgstr "Abgelehnt"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.rejected"
+msgstr "Abgelehnt"
+
+#. Application tracker status: rejected
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:441
+msgid "search.tracker.rejected"
 msgstr "Abgelehnt"
 
 #. Footer license summary text
@@ -2822,16 +2842,16 @@ msgstr "Erneut senden in {cooldown}s"
 msgid "auth.verify.resend"
 msgstr "Bestätigungs-E-Mail erneut senden"
 
-#. Reset experience filter
-#. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:240
-msgid "search.experienceModal.reset"
-msgstr "Zurücksetzen"
-
 #. Reset salary filter
 #. js-lingui-explicit-id
 #: src/components/search/salary-modal.tsx:314
 msgid "search.salaryModal.reset"
+msgstr "Zurücksetzen"
+
+#. Reset experience filter
+#. js-lingui-explicit-id
+#: src/components/search/experience-modal.tsx:240
+msgid "search.experienceModal.reset"
 msgstr "Zurücksetzen"
 
 #. Reset password submit button
@@ -3014,17 +3034,17 @@ msgstr "Jobs bei Hunderten von Unternehmen durchsuchen. Erstellen Sie Watchlists
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Sprachen suchen…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:149
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Standorte suchen..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:164
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Standorte suchen…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:149
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Standorte suchen..."
 
 #. Back to search results link on company page
 #. js-lingui-explicit-id
@@ -3104,17 +3124,17 @@ msgstr "Link senden"
 msgid "settings.account.password.send"
 msgstr "Link senden"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Wird gesendet…"
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
 msgstr "Wird gesendet..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
+msgstr "Wird gesendet…"
 
 #. Reset password button while loading
 #. js-lingui-explicit-id
@@ -3188,16 +3208,16 @@ msgstr "Einstellungen"
 #~ msgid "settings.billing.usage.unlimited"
 #~ msgstr "Unbegrenzt"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:344
-msgid "search.detail.showLessLocations"
-msgstr "Weniger anzeigen"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:350
 msgid "company.page.showLess"
+msgstr "Weniger anzeigen"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:344
+msgid "search.detail.showLessLocations"
 msgstr "Weniger anzeigen"
 
 #. Aria label to show password
@@ -3308,6 +3328,12 @@ msgstr "Zum Inhalt springen"
 msgid "error.title"
 msgstr "Etwas ist schiefgelaufen"
 
+#. Generic forgot password error
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:43
+msgid "auth.forgotPassword.error.generic"
+msgstr "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
+
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
@@ -3317,12 +3343,6 @@ msgstr "Etwas ist schiefgelaufen"
 #: src/components/search/request-company.tsx:19
 msgid "app.home.request.error.unknown"
 msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
-
-#. Generic forgot password error
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:43
-msgid "auth.forgotPassword.error.generic"
-msgstr "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
 
 #. Generic error creating watchlist
 #. js-lingui-explicit-id
@@ -3766,6 +3786,11 @@ msgstr "Watchlists"
 #: src/components/AppHeader.tsx:55
 msgid "app.header.nav.watchlists"
 msgstr "Watchlists"
+
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:69
+msgid "app.schema.feature.watchlists"
+msgstr ""
 
 #. What the service does
 #. js-lingui-explicit-id

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -359,12 +359,6 @@ msgstr "applications in the past year"
 msgid "myJobs.group.applied"
 msgstr "Applied"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:438
-msgid "search.tracker.applied"
-msgstr "Applied"
-
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
@@ -383,16 +377,22 @@ msgstr "Applied"
 msgid "myJobs.statusOption.applied"
 msgstr "Applied"
 
-#. Apply experience filter
+#. Application tracker status: applied
 #. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:246
-msgid "search.experienceModal.apply"
-msgstr "Apply"
+#: src/components/search/job-detail-dialog.tsx:438
+msgid "search.tracker.applied"
+msgstr "Applied"
 
 #. Apply salary filter
 #. js-lingui-explicit-id
 #: src/components/search/salary-modal.tsx:320
 msgid "search.salaryModal.apply"
+msgstr "Apply"
+
+#. Apply experience filter
+#. js-lingui-explicit-id
+#: src/components/search/experience-modal.tsx:246
+msgid "search.experienceModal.apply"
 msgstr "Apply"
 
 #. Apply button linking to original job posting
@@ -443,6 +443,12 @@ msgstr "Available"
 msgid "auth.verify.error.backToSignIn"
 msgstr "Back to sign in"
 
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
+msgstr "Back to sign in"
+
 #. Link back to sign-in from forgot password
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:68
@@ -453,12 +459,6 @@ msgstr "Back to sign in"
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:110
 msgid "auth.forgotPassword.backLink"
-msgstr "Back to sign in"
-
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
 msgstr "Back to sign in"
 
 #. Interview type label: behavioral interview
@@ -485,16 +485,16 @@ msgstr "Built for active job seekers"
 msgid "terms.hero.description"
 msgstr "By using Job Seek you agree to these terms. Here’s a plain-language overview."
 
-#. Cancel button in create watchlist dialog
-#. js-lingui-explicit-id
-#: src/components/watchlist/create-watchlist-dialog.tsx:162
-msgid "watchlists.create.cancel"
-msgstr "Cancel"
-
 #. Cancel delete watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-action-bar.tsx:233
 msgid "watchlists.delete.cancel"
+msgstr "Cancel"
+
+#. Cancel button in create watchlist dialog
+#. js-lingui-explicit-id
+#: src/components/watchlist/create-watchlist-dialog.tsx:162
+msgid "watchlists.create.cancel"
 msgstr "Cancel"
 
 #. Cancel delete button
@@ -533,16 +533,16 @@ msgstr "Change your password via a secure email link."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Change..."
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "Check your email"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
+msgstr "Check your email"
+
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
 msgstr "Check your email"
 
 #. Checking username availability
@@ -735,12 +735,6 @@ msgstr "Connect"
 msgid "settings.account.socials.title"
 msgstr "Connected accounts"
 
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:41
-msgid "common.footer.contact"
-msgstr "Contact"
-
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:25
@@ -753,16 +747,22 @@ msgstr "Contact"
 msgid "license.contact.title"
 msgstr "Contact"
 
-#. Table of contents heading
+#. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
-msgstr "Contents"
+#: src/components/Footer.tsx:41
+msgid "common.footer.contact"
+msgstr "Contact"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
+msgstr "Contents"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Contents"
 
 #. Button to continue to app after verification
@@ -1563,12 +1563,6 @@ msgstr "Interview"
 msgid "myJobs.group.interviewing"
 msgstr "Interviewing"
 
-#. Application tracker status: interviewing
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:439
-msgid "search.tracker.interviewing"
-msgstr "Interviewing"
-
 #. Interviewing status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:21
@@ -1579,6 +1573,12 @@ msgstr "Interviewing"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:34
 msgid "myJobs.statusOption.interviewing"
+msgstr "Interviewing"
+
+#. Application tracker status: interviewing
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:439
+msgid "search.tracker.interviewing"
 msgstr "Interviewing"
 
 #. Interviews section heading
@@ -1617,22 +1617,27 @@ msgstr "job"
 msgid "watchlists.explore.jobSingular"
 msgstr "job"
 
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:56
+msgid "app.schema.description"
+msgstr "Job aggregator that monitors company career pages. Subscribe to company updates, track applications, and get alerts on new openings."
+
 #. TOC: Job data (CC BY-NC 4.0)
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:24
 msgid "license.toc.data"
 msgstr "Job data (CC BY-NC 4.0)"
 
-#. Job detail panel title
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:71
-msgid "search.detail.title"
-msgstr "Job Details"
-
 #. Job detail panel title in My Jobs
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:158
 msgid "myJobs.detail.title"
+msgstr "Job Details"
+
+#. Job detail panel title
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:71
+msgid "search.detail.title"
 msgstr "Job Details"
 
 #. Job languages settings section heading
@@ -1682,16 +1687,16 @@ msgstr "Job Seek's codebase is open source under MIT. The job data we collect an
 msgid "watchlist.meta.fallback"
 msgstr "Job watchlist by @{owner}"
 
-#. Job count label in watchlist view
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:210
-msgid "watchlists.jobList.jobCount"
-msgstr "jobs"
-
 #. Plural job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:32
 msgid "watchlists.card.jobPlural"
+msgstr "jobs"
+
+#. Job count label in watchlist view
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-job-list.tsx:210
+msgid "watchlists.jobList.jobCount"
 msgstr "jobs"
 
 #. Plural job count in public watchlist
@@ -1988,6 +1993,11 @@ msgstr "mirrors"
 msgid "myJobs.heatmap.day.mon"
 msgstr "Mon"
 
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:66
+msgid "app.schema.feature.monitor"
+msgstr "Monitor company career pages"
+
 #. Monthly pay period option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:350
@@ -2005,6 +2015,11 @@ msgstr "Monthly"
 #: src/components/search/filter-bar.tsx:355
 msgid "company.page.showMore"
 msgstr "more"
+
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:68
+msgid "app.schema.feature.languages"
+msgstr "Multi-language support"
 
 #. Warning when Enter is pressed but multiple items match
 #. Warning when Enter is pressed but multiple items match
@@ -2120,16 +2135,16 @@ msgstr "No jobs found."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "No languages match your search."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:170
-msgid "search.locationModal.noResults"
-msgstr "No locations match your search."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:185
 msgid "company.locationModal.noResults"
+msgstr "No locations match your search."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:170
+msgid "search.locationModal.noResults"
 msgstr "No locations match your search."
 
 #. No postings found message on company page
@@ -2192,16 +2207,16 @@ msgstr "No watchlists found."
 msgid "watchlists.page.empty"
 msgstr "No watchlists yet. Create one to track jobs from your favorite companies."
 
-#. Application tracker status: not applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:437
-msgid "search.tracker.notApplied"
-msgstr "Not applied"
-
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
+msgstr "Not applied"
+
+#. Application tracker status: not applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:437
+msgid "search.tracker.notApplied"
 msgstr "Not applied"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2232,16 +2247,16 @@ msgstr "Occupation"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Oct"
 
-#. Application tracker status: offer
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:440
-msgid "search.tracker.offer"
-msgstr "Offer"
-
 #. Offered status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
+msgstr "Offer"
+
+#. Application tracker status: offer
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:440
+msgid "search.tracker.offer"
 msgstr "Offer"
 
 #. Status group heading: offered
@@ -2365,26 +2380,26 @@ msgstr "Our stance on automation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Overview"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Overview"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Page contents"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Overview"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Page contents"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Page contents"
 
 #. Heading shown on the 404 page
@@ -2585,14 +2600,14 @@ msgstr "Point us at any careers page or Notion job board and Job Seek mirrors it
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:86
-msgid "search.detail.notFound"
+#: src/components/my-jobs/my-job-detail-panel.tsx:178
+msgid "myJobs.detail.notFound"
 msgstr "Posting not found."
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:178
-msgid "myJobs.detail.notFound"
+#: src/components/search/job-detail-dialog.tsx:86
+msgid "search.detail.notFound"
 msgstr "Posting not found."
 
 #. Pricing section eyebrow
@@ -2712,6 +2727,11 @@ msgstr "Read the full Privacy Policy"
 msgid "terms.fullTermsLink"
 msgstr "Read the full Terms of Service"
 
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:67
+msgid "app.schema.feature.alerts"
+msgstr "Real-time job posting alerts"
+
 #. Sort option: recently updated
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sort-filter-bar.tsx:13
@@ -2742,12 +2762,6 @@ msgstr "Region"
 msgid "myJobs.group.rejected"
 msgstr "Rejected"
 
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:441
-msgid "search.tracker.rejected"
-msgstr "Rejected"
-
 #. Rejected status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:23
@@ -2764,6 +2778,12 @@ msgstr "Rejected"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.rejected"
+msgstr "Rejected"
+
+#. Application tracker status: rejected
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:441
+msgid "search.tracker.rejected"
 msgstr "Rejected"
 
 #. Footer license summary text
@@ -2822,16 +2842,16 @@ msgstr "Resend in {cooldown}s"
 msgid "auth.verify.resend"
 msgstr "Resend verification email"
 
-#. Reset experience filter
-#. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:240
-msgid "search.experienceModal.reset"
-msgstr "Reset"
-
 #. Reset salary filter
 #. js-lingui-explicit-id
 #: src/components/search/salary-modal.tsx:314
 msgid "search.salaryModal.reset"
+msgstr "Reset"
+
+#. Reset experience filter
+#. js-lingui-explicit-id
+#: src/components/search/experience-modal.tsx:240
+msgid "search.experienceModal.reset"
 msgstr "Reset"
 
 #. Reset password submit button
@@ -3014,16 +3034,16 @@ msgstr "Search and filter job openings across hundreds of companies."
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Search languages..."
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:149
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Search locations..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:164
 msgid "company.locationModal.searchPlaceholder"
+msgstr "Search locations..."
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:149
+msgid "search.locationModal.searchPlaceholder"
 msgstr "Search locations..."
 
 #. Back to search results link on company page
@@ -3104,16 +3124,16 @@ msgstr "Send reset link"
 msgid "settings.account.password.send"
 msgstr "Send reset link"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Sending..."
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
+msgstr "Sending..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
 msgstr "Sending..."
 
 #. Reset password button while loading
@@ -3188,16 +3208,16 @@ msgstr "Settings"
 #~ msgid "settings.billing.usage.unlimited"
 #~ msgstr "Unlimited"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:344
-msgid "search.detail.showLessLocations"
-msgstr "Show less"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:350
 msgid "company.page.showLess"
+msgstr "Show less"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:344
+msgid "search.detail.showLessLocations"
 msgstr "Show less"
 
 #. Aria label to show password
@@ -3308,6 +3328,12 @@ msgstr "Skip to content"
 msgid "error.title"
 msgstr "Something went wrong"
 
+#. Generic forgot password error
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:43
+msgid "auth.forgotPassword.error.generic"
+msgstr "Something went wrong. Please try again."
+
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
@@ -3316,12 +3342,6 @@ msgstr "Something went wrong"
 #: app/[lang]/(app)/progress/company-request-form.tsx:18
 #: src/components/search/request-company.tsx:19
 msgid "app.home.request.error.unknown"
-msgstr "Something went wrong. Please try again."
-
-#. Generic forgot password error
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:43
-msgid "auth.forgotPassword.error.generic"
 msgstr "Something went wrong. Please try again."
 
 #. Generic error creating watchlist
@@ -3766,6 +3786,11 @@ msgstr "Watchlists"
 #: src/components/AppHeader.tsx:55
 msgid "app.header.nav.watchlists"
 msgstr "Watchlists"
+
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:69
+msgid "app.schema.feature.watchlists"
+msgstr "Watchlists and application tracking"
 
 #. What the service does
 #. js-lingui-explicit-id

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -359,12 +359,6 @@ msgstr "candidatures durant l'année écoulée"
 msgid "myJobs.group.applied"
 msgstr "Postulé"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:438
-msgid "search.tracker.applied"
-msgstr "Postulé"
-
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
@@ -383,16 +377,22 @@ msgstr "Postulé"
 msgid "myJobs.statusOption.applied"
 msgstr "Postulé"
 
-#. Apply experience filter
+#. Application tracker status: applied
 #. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:246
-msgid "search.experienceModal.apply"
-msgstr "Appliquer"
+#: src/components/search/job-detail-dialog.tsx:438
+msgid "search.tracker.applied"
+msgstr "Postulé"
 
 #. Apply salary filter
 #. js-lingui-explicit-id
 #: src/components/search/salary-modal.tsx:320
 msgid "search.salaryModal.apply"
+msgstr "Appliquer"
+
+#. Apply experience filter
+#. js-lingui-explicit-id
+#: src/components/search/experience-modal.tsx:246
+msgid "search.experienceModal.apply"
 msgstr "Appliquer"
 
 #. Apply button linking to original job posting
@@ -443,6 +443,12 @@ msgstr "Disponible"
 msgid "auth.verify.error.backToSignIn"
 msgstr "Retour à la connexion"
 
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
+msgstr "Retour à la connexion"
+
 #. Link back to sign-in from forgot password
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:68
@@ -453,12 +459,6 @@ msgstr "Retour à la connexion"
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:110
 msgid "auth.forgotPassword.backLink"
-msgstr "Retour à la connexion"
-
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
 msgstr "Retour à la connexion"
 
 #. Interview type label: behavioral interview
@@ -485,16 +485,16 @@ msgstr "Conçu pour les chercheurs d'emploi actifs"
 msgid "terms.hero.description"
 msgstr "En utilisant Job Seek, tu acceptes ces conditions. Voici un résumé en langage clair."
 
-#. Cancel button in create watchlist dialog
-#. js-lingui-explicit-id
-#: src/components/watchlist/create-watchlist-dialog.tsx:162
-msgid "watchlists.create.cancel"
-msgstr "Annuler"
-
 #. Cancel delete watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-action-bar.tsx:233
 msgid "watchlists.delete.cancel"
+msgstr "Annuler"
+
+#. Cancel button in create watchlist dialog
+#. js-lingui-explicit-id
+#: src/components/watchlist/create-watchlist-dialog.tsx:162
+msgid "watchlists.create.cancel"
 msgstr "Annuler"
 
 #. Cancel delete button
@@ -533,17 +533,17 @@ msgstr "Modifie ton mot de passe via un lien e-mail sécurisé."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Changer…"
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "Vérifie ton e-mail"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
 msgstr "Vérifiez votre e-mail"
+
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
+msgstr "Vérifie ton e-mail"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -735,12 +735,6 @@ msgstr "Connecter"
 msgid "settings.account.socials.title"
 msgstr "Comptes connectés"
 
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:41
-msgid "common.footer.contact"
-msgstr "Contact"
-
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:25
@@ -753,16 +747,22 @@ msgstr "Contact"
 msgid "license.contact.title"
 msgstr "Contact"
 
-#. Table of contents heading
+#. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
-msgstr "Sommaire"
+#: src/components/Footer.tsx:41
+msgid "common.footer.contact"
+msgstr "Contact"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
+msgstr "Sommaire"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Sommaire"
 
 #. Button to continue to app after verification
@@ -1563,12 +1563,6 @@ msgstr "Entretien"
 msgid "myJobs.group.interviewing"
 msgstr "En entretien"
 
-#. Application tracker status: interviewing
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:439
-msgid "search.tracker.interviewing"
-msgstr "En entretien"
-
 #. Interviewing status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:21
@@ -1579,6 +1573,12 @@ msgstr "En entretien"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:34
 msgid "myJobs.statusOption.interviewing"
+msgstr "En entretien"
+
+#. Application tracker status: interviewing
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:439
+msgid "search.tracker.interviewing"
 msgstr "En entretien"
 
 #. Interviews section heading
@@ -1617,23 +1617,28 @@ msgstr "offre"
 msgid "watchlists.explore.jobSingular"
 msgstr "offre"
 
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:56
+msgid "app.schema.description"
+msgstr ""
+
 #. TOC: Job data (CC BY-NC 4.0)
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:24
 msgid "license.toc.data"
 msgstr "Données d'emploi (CC BY-NC 4.0)"
 
-#. Job detail panel title
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:71
-msgid "search.detail.title"
-msgstr "Détails de l'offre"
-
 #. Job detail panel title in My Jobs
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:158
 msgid "myJobs.detail.title"
 msgstr "Détails du poste"
+
+#. Job detail panel title
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:71
+msgid "search.detail.title"
+msgstr "Détails de l'offre"
 
 #. Job languages settings section heading
 #. js-lingui-explicit-id
@@ -1682,16 +1687,16 @@ msgstr "Le code source de Job Seek est ouvert sous licence MIT. Les données d'e
 msgid "watchlist.meta.fallback"
 msgstr "Liste d'emplois de @{owner}"
 
-#. Job count label in watchlist view
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:210
-msgid "watchlists.jobList.jobCount"
-msgstr "offres"
-
 #. Plural job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:32
 msgid "watchlists.card.jobPlural"
+msgstr "offres"
+
+#. Job count label in watchlist view
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-job-list.tsx:210
+msgid "watchlists.jobList.jobCount"
 msgstr "offres"
 
 #. Plural job count in public watchlist
@@ -1988,6 +1993,11 @@ msgstr "copies"
 msgid "myJobs.heatmap.day.mon"
 msgstr "Lun"
 
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:66
+msgid "app.schema.feature.monitor"
+msgstr ""
+
 #. Monthly pay period option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:350
@@ -2005,6 +2015,11 @@ msgstr "Mensuel"
 #: src/components/search/filter-bar.tsx:355
 msgid "company.page.showMore"
 msgstr "plus"
+
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:68
+msgid "app.schema.feature.languages"
+msgstr ""
 
 #. Warning when Enter is pressed but multiple items match
 #. Warning when Enter is pressed but multiple items match
@@ -2120,16 +2135,16 @@ msgstr "Aucune offre trouvée."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Aucune langue ne correspond à votre recherche."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:170
-msgid "search.locationModal.noResults"
-msgstr "Aucun lieu ne correspond à votre recherche."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:185
 msgid "company.locationModal.noResults"
+msgstr "Aucun lieu ne correspond à votre recherche."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:170
+msgid "search.locationModal.noResults"
 msgstr "Aucun lieu ne correspond à votre recherche."
 
 #. No postings found message on company page
@@ -2192,16 +2207,16 @@ msgstr "Aucune liste de suivi trouvée."
 msgid "watchlists.page.empty"
 msgstr "Aucune liste de suivi pour l'instant. Créez-en une pour suivre les offres de vos entreprises préférées."
 
-#. Application tracker status: not applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:437
-msgid "search.tracker.notApplied"
-msgstr "Non postulé"
-
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
+msgstr "Non postulé"
+
+#. Application tracker status: not applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:437
+msgid "search.tracker.notApplied"
 msgstr "Non postulé"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2232,16 +2247,16 @@ msgstr "Métier"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Oct"
 
-#. Application tracker status: offer
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:440
-msgid "search.tracker.offer"
-msgstr "Offre"
-
 #. Offered status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
+msgstr "Offre"
+
+#. Application tracker status: offer
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:440
+msgid "search.tracker.offer"
 msgstr "Offre"
 
 #. Status group heading: offered
@@ -2365,26 +2380,26 @@ msgstr "Notre position sur l'automatisation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Aperçu"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Aperçu"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Sommaire de la page"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Aperçu"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Sommaire de la page"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Sommaire de la page"
 
 #. Heading shown on the 404 page
@@ -2585,15 +2600,15 @@ msgstr "Indique-nous n'importe quelle page carrières ou tableau d'offres Notion
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:86
-msgid "search.detail.notFound"
-msgstr "Offre non trouvée."
-
-#. Posting not found message
-#. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:178
 msgid "myJobs.detail.notFound"
 msgstr "Offre introuvable."
+
+#. Posting not found message
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:86
+msgid "search.detail.notFound"
+msgstr "Offre non trouvée."
 
 #. Pricing section eyebrow
 #. js-lingui-explicit-id
@@ -2712,6 +2727,11 @@ msgstr "Lire la politique de confidentialité complète"
 msgid "terms.fullTermsLink"
 msgstr "Lire les conditions d'utilisation complètes"
 
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:67
+msgid "app.schema.feature.alerts"
+msgstr ""
+
 #. Sort option: recently updated
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sort-filter-bar.tsx:13
@@ -2742,12 +2762,6 @@ msgstr "Région"
 msgid "myJobs.group.rejected"
 msgstr "Refusé"
 
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:441
-msgid "search.tracker.rejected"
-msgstr "Refusé"
-
 #. Rejected status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:23
@@ -2764,6 +2778,12 @@ msgstr "Refusé"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.rejected"
+msgstr "Refusé"
+
+#. Application tracker status: rejected
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:441
+msgid "search.tracker.rejected"
 msgstr "Refusé"
 
 #. Footer license summary text
@@ -2822,16 +2842,16 @@ msgstr "Renvoyer dans {cooldown}s"
 msgid "auth.verify.resend"
 msgstr "Renvoyer l'e-mail de vérification"
 
-#. Reset experience filter
-#. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:240
-msgid "search.experienceModal.reset"
-msgstr "Réinitialiser"
-
 #. Reset salary filter
 #. js-lingui-explicit-id
 #: src/components/search/salary-modal.tsx:314
 msgid "search.salaryModal.reset"
+msgstr "Réinitialiser"
+
+#. Reset experience filter
+#. js-lingui-explicit-id
+#: src/components/search/experience-modal.tsx:240
+msgid "search.experienceModal.reset"
 msgstr "Réinitialiser"
 
 #. Reset password submit button
@@ -3014,17 +3034,17 @@ msgstr "Recherchez des emplois dans des centaines d'entreprises. Créez des list
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Rechercher des langues…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:149
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Rechercher des lieux..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:164
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Rechercher des lieux…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:149
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Rechercher des lieux..."
 
 #. Back to search results link on company page
 #. js-lingui-explicit-id
@@ -3104,16 +3124,16 @@ msgstr "Envoyer le lien"
 msgid "settings.account.password.send"
 msgstr "Envoyer le lien"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Envoi en cours..."
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
+msgstr "Envoi en cours..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
 msgstr "Envoi en cours..."
 
 #. Reset password button while loading
@@ -3188,16 +3208,16 @@ msgstr "Paramètres"
 #~ msgid "settings.billing.usage.unlimited"
 #~ msgstr "Illimité"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:344
-msgid "search.detail.showLessLocations"
-msgstr "Afficher moins"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:350
 msgid "company.page.showLess"
+msgstr "Afficher moins"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:344
+msgid "search.detail.showLessLocations"
 msgstr "Afficher moins"
 
 #. Aria label to show password
@@ -3308,6 +3328,12 @@ msgstr "Aller au contenu"
 msgid "error.title"
 msgstr "Une erreur est survenue"
 
+#. Generic forgot password error
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:43
+msgid "auth.forgotPassword.error.generic"
+msgstr "Une erreur est survenue. Veuillez réessayer."
+
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
@@ -3317,12 +3343,6 @@ msgstr "Une erreur est survenue"
 #: src/components/search/request-company.tsx:19
 msgid "app.home.request.error.unknown"
 msgstr "Une erreur s'est produite. Veuillez réessayer."
-
-#. Generic forgot password error
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:43
-msgid "auth.forgotPassword.error.generic"
-msgstr "Une erreur est survenue. Veuillez réessayer."
 
 #. Generic error creating watchlist
 #. js-lingui-explicit-id
@@ -3766,6 +3786,11 @@ msgstr "Listes de suivi"
 #: src/components/AppHeader.tsx:55
 msgid "app.header.nav.watchlists"
 msgstr "Listes de suivi"
+
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:69
+msgid "app.schema.feature.watchlists"
+msgstr ""
 
 #. What the service does
 #. js-lingui-explicit-id

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -359,12 +359,6 @@ msgstr "candidature nell'ultimo anno"
 msgid "myJobs.group.applied"
 msgstr "Candidato"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:438
-msgid "search.tracker.applied"
-msgstr "Candidato"
-
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
@@ -383,16 +377,22 @@ msgstr "Candidato"
 msgid "myJobs.statusOption.applied"
 msgstr "Candidato"
 
-#. Apply experience filter
+#. Application tracker status: applied
 #. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:246
-msgid "search.experienceModal.apply"
-msgstr "Applica"
+#: src/components/search/job-detail-dialog.tsx:438
+msgid "search.tracker.applied"
+msgstr "Candidato"
 
 #. Apply salary filter
 #. js-lingui-explicit-id
 #: src/components/search/salary-modal.tsx:320
 msgid "search.salaryModal.apply"
+msgstr "Applica"
+
+#. Apply experience filter
+#. js-lingui-explicit-id
+#: src/components/search/experience-modal.tsx:246
+msgid "search.experienceModal.apply"
 msgstr "Applica"
 
 #. Apply button linking to original job posting
@@ -443,6 +443,12 @@ msgstr "Disponibile"
 msgid "auth.verify.error.backToSignIn"
 msgstr "Torna all'accesso"
 
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
+msgstr "Torna all'accesso"
+
 #. Link back to sign-in from forgot password
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:68
@@ -454,12 +460,6 @@ msgstr "Torna al login"
 #: app/[lang]/(auth)/forgot-password/page.tsx:110
 msgid "auth.forgotPassword.backLink"
 msgstr "Torna al login"
-
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Torna all'accesso"
 
 #. Interview type label: behavioral interview
 #. js-lingui-explicit-id
@@ -485,16 +485,16 @@ msgstr "Pensato per chi cerca lavoro attivamente"
 msgid "terms.hero.description"
 msgstr "Utilizzando Job Seek accetti questi termini. Ecco un riassunto in parole semplici."
 
-#. Cancel button in create watchlist dialog
-#. js-lingui-explicit-id
-#: src/components/watchlist/create-watchlist-dialog.tsx:162
-msgid "watchlists.create.cancel"
-msgstr "Annulla"
-
 #. Cancel delete watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-action-bar.tsx:233
 msgid "watchlists.delete.cancel"
+msgstr "Annulla"
+
+#. Cancel button in create watchlist dialog
+#. js-lingui-explicit-id
+#: src/components/watchlist/create-watchlist-dialog.tsx:162
+msgid "watchlists.create.cancel"
 msgstr "Annulla"
 
 #. Cancel delete button
@@ -533,17 +533,17 @@ msgstr "Cambia la tua password tramite un link email sicuro."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Cambia…"
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "Controlla la tua email"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
 msgstr "Controlla la tua e-mail"
+
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
+msgstr "Controlla la tua email"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -735,12 +735,6 @@ msgstr "Collega"
 msgid "settings.account.socials.title"
 msgstr "Account collegati"
 
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:41
-msgid "common.footer.contact"
-msgstr "Contatti"
-
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:25
@@ -753,16 +747,22 @@ msgstr "Contatti"
 msgid "license.contact.title"
 msgstr "Contatti"
 
-#. Table of contents heading
+#. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
-msgstr "Sommario"
+#: src/components/Footer.tsx:41
+msgid "common.footer.contact"
+msgstr "Contatti"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
+msgstr "Sommario"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Sommario"
 
 #. Button to continue to app after verification
@@ -1563,12 +1563,6 @@ msgstr "Colloquio"
 msgid "myJobs.group.interviewing"
 msgstr "In colloquio"
 
-#. Application tracker status: interviewing
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:439
-msgid "search.tracker.interviewing"
-msgstr "In colloquio"
-
 #. Interviewing status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:21
@@ -1579,6 +1573,12 @@ msgstr "In colloquio"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:34
 msgid "myJobs.statusOption.interviewing"
+msgstr "In colloquio"
+
+#. Application tracker status: interviewing
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:439
+msgid "search.tracker.interviewing"
 msgstr "In colloquio"
 
 #. Interviews section heading
@@ -1617,23 +1617,28 @@ msgstr "offerta"
 msgid "watchlists.explore.jobSingular"
 msgstr "offerta"
 
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:56
+msgid "app.schema.description"
+msgstr ""
+
 #. TOC: Job data (CC BY-NC 4.0)
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:24
 msgid "license.toc.data"
 msgstr "Dati sugli annunci (CC BY-NC 4.0)"
 
-#. Job detail panel title
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:71
-msgid "search.detail.title"
-msgstr "Dettagli dell'offerta"
-
 #. Job detail panel title in My Jobs
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:158
 msgid "myJobs.detail.title"
 msgstr "Dettagli lavoro"
+
+#. Job detail panel title
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:71
+msgid "search.detail.title"
+msgstr "Dettagli dell'offerta"
 
 #. Job languages settings section heading
 #. js-lingui-explicit-id
@@ -1682,16 +1687,16 @@ msgstr "Il codice sorgente di Job Seek è open source sotto licenza MIT. I dati 
 msgid "watchlist.meta.fallback"
 msgstr "Lista lavori di @{owner}"
 
-#. Job count label in watchlist view
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:210
-msgid "watchlists.jobList.jobCount"
-msgstr "offerte"
-
 #. Plural job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:32
 msgid "watchlists.card.jobPlural"
+msgstr "offerte"
+
+#. Job count label in watchlist view
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-job-list.tsx:210
+msgid "watchlists.jobList.jobCount"
 msgstr "offerte"
 
 #. Plural job count in public watchlist
@@ -1988,6 +1993,11 @@ msgstr "copie"
 msgid "myJobs.heatmap.day.mon"
 msgstr "Lun"
 
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:66
+msgid "app.schema.feature.monitor"
+msgstr ""
+
 #. Monthly pay period option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:350
@@ -2005,6 +2015,11 @@ msgstr "Mensile"
 #: src/components/search/filter-bar.tsx:355
 msgid "company.page.showMore"
 msgstr "altro"
+
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:68
+msgid "app.schema.feature.languages"
+msgstr ""
 
 #. Warning when Enter is pressed but multiple items match
 #. Warning when Enter is pressed but multiple items match
@@ -2120,17 +2135,17 @@ msgstr "Nessuna offerta trovata."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Nessuna lingua corrisponde alla ricerca."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:170
-msgid "search.locationModal.noResults"
-msgstr "Nessun luogo corrisponde alla tua ricerca."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:185
 msgid "company.locationModal.noResults"
 msgstr "Nessuna sede corrisponde alla tua ricerca."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:170
+msgid "search.locationModal.noResults"
+msgstr "Nessun luogo corrisponde alla tua ricerca."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2192,16 +2207,16 @@ msgstr "Nessuna lista trovata."
 msgid "watchlists.page.empty"
 msgstr "Nessuna lista di osservazione. Creane una per seguire le offerte delle tue aziende preferite."
 
-#. Application tracker status: not applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:437
-msgid "search.tracker.notApplied"
-msgstr "Non candidato"
-
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
+msgstr "Non candidato"
+
+#. Application tracker status: not applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:437
+msgid "search.tracker.notApplied"
 msgstr "Non candidato"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2232,16 +2247,16 @@ msgstr "Professione"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Ott"
 
-#. Application tracker status: offer
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:440
-msgid "search.tracker.offer"
-msgstr "Offerta"
-
 #. Offered status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
+msgstr "Offerta"
+
+#. Application tracker status: offer
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:440
+msgid "search.tracker.offer"
 msgstr "Offerta"
 
 #. Status group heading: offered
@@ -2365,26 +2380,26 @@ msgstr "La nostra posizione sull'automazione"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Panoramica"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Panoramica"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Contenuti della pagina"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Panoramica"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Contenuti della pagina"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Contenuti della pagina"
 
 #. Heading shown on the 404 page
@@ -2585,14 +2600,14 @@ msgstr "Indicaci qualsiasi pagina carriere o job board su Notion e Job Seek la r
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:86
-msgid "search.detail.notFound"
+#: src/components/my-jobs/my-job-detail-panel.tsx:178
+msgid "myJobs.detail.notFound"
 msgstr "Offerta non trovata."
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:178
-msgid "myJobs.detail.notFound"
+#: src/components/search/job-detail-dialog.tsx:86
+msgid "search.detail.notFound"
 msgstr "Offerta non trovata."
 
 #. Pricing section eyebrow
@@ -2712,6 +2727,11 @@ msgstr "Leggi l'informativa sulla privacy completa"
 msgid "terms.fullTermsLink"
 msgstr "Leggi i termini di servizio completi"
 
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:67
+msgid "app.schema.feature.alerts"
+msgstr ""
+
 #. Sort option: recently updated
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sort-filter-bar.tsx:13
@@ -2742,12 +2762,6 @@ msgstr "Regione"
 msgid "myJobs.group.rejected"
 msgstr "Rifiutato"
 
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:441
-msgid "search.tracker.rejected"
-msgstr "Rifiutato"
-
 #. Rejected status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:23
@@ -2764,6 +2778,12 @@ msgstr "Rifiutato"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.rejected"
+msgstr "Rifiutato"
+
+#. Application tracker status: rejected
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:441
+msgid "search.tracker.rejected"
 msgstr "Rifiutato"
 
 #. Footer license summary text
@@ -2822,16 +2842,16 @@ msgstr "Reinvia tra {cooldown}s"
 msgid "auth.verify.resend"
 msgstr "Reinvia email di verifica"
 
-#. Reset experience filter
-#. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:240
-msgid "search.experienceModal.reset"
-msgstr "Reimposta"
-
 #. Reset salary filter
 #. js-lingui-explicit-id
 #: src/components/search/salary-modal.tsx:314
 msgid "search.salaryModal.reset"
+msgstr "Reimposta"
+
+#. Reset experience filter
+#. js-lingui-explicit-id
+#: src/components/search/experience-modal.tsx:240
+msgid "search.experienceModal.reset"
 msgstr "Reimposta"
 
 #. Reset password submit button
@@ -3014,17 +3034,17 @@ msgstr "Cerca lavori in centinaia di aziende. Crea watchlist per seguire le nuov
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Cerca lingue…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:149
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Cerca luoghi..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:164
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Cerca sedi…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:149
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Cerca luoghi..."
 
 #. Back to search results link on company page
 #. js-lingui-explicit-id
@@ -3104,16 +3124,16 @@ msgstr "Invia link"
 msgid "settings.account.password.send"
 msgstr "Invia il link"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Invio in corso..."
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
+msgstr "Invio in corso..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
 msgstr "Invio in corso..."
 
 #. Reset password button while loading
@@ -3188,16 +3208,16 @@ msgstr "Impostazioni"
 #~ msgid "settings.billing.usage.unlimited"
 #~ msgstr "Illimitato"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:344
-msgid "search.detail.showLessLocations"
-msgstr "Mostra meno"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:350
 msgid "company.page.showLess"
+msgstr "Mostra meno"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:344
+msgid "search.detail.showLessLocations"
 msgstr "Mostra meno"
 
 #. Aria label to show password
@@ -3308,6 +3328,12 @@ msgstr "Vai al contenuto"
 msgid "error.title"
 msgstr "Qualcosa è andato storto"
 
+#. Generic forgot password error
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:43
+msgid "auth.forgotPassword.error.generic"
+msgstr "Qualcosa è andato storto. Riprova."
+
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
@@ -3316,12 +3342,6 @@ msgstr "Qualcosa è andato storto"
 #: app/[lang]/(app)/progress/company-request-form.tsx:18
 #: src/components/search/request-company.tsx:19
 msgid "app.home.request.error.unknown"
-msgstr "Qualcosa è andato storto. Riprova."
-
-#. Generic forgot password error
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:43
-msgid "auth.forgotPassword.error.generic"
 msgstr "Qualcosa è andato storto. Riprova."
 
 #. Generic error creating watchlist
@@ -3766,6 +3786,11 @@ msgstr "Liste di osservazione"
 #: src/components/AppHeader.tsx:55
 msgid "app.header.nav.watchlists"
 msgstr "Liste di osservazione"
+
+#. js-lingui-explicit-id
+#: app/[lang]/layout.tsx:69
+msgid "app.schema.feature.watchlists"
+msgstr ""
 
 #. What the service does
 #. js-lingui-explicit-id

--- a/apps/web/public/.well-known/ai-plugin.json
+++ b/apps/web/public/.well-known/ai-plugin.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "v1",
+  "name_for_human": "Job Seek",
+  "name_for_model": "jobseek",
+  "description_for_human": "Monitor company career pages, get alerts on new job postings, and track applications.",
+  "description_for_model": "Job Seek is a job aggregator that monitors company career pages. Users can browse jobs by company, create watchlists, filter by location/occupation/seniority, and get alerts when new positions are posted. The explore page at /explore allows searching all indexed jobs. Company pages at /company/{slug} show all open positions for a specific company. The site is free to use with optional paid plans for advanced features.",
+  "auth": { "type": "none" },
+  "api": {
+    "type": "openapi",
+    "url": "https://jseek.co/api/openapi.json",
+    "is_user_authenticated": false
+  },
+  "logo_url": "https://jseek.co/js_logo_black_circle.svg",
+  "contact_email": "business@colophon-group.org",
+  "legal_info_url": "https://jseek.co/en/terms"
+}

--- a/apps/web/src/content/config.ts
+++ b/apps/web/src/content/config.ts
@@ -30,8 +30,8 @@ export type PublicDomainAsset = {
 };
 
 export const siteConfig = {
-  url: "https://jobseek.com",
-  domain: "jobseek.com",
+  url: "https://jseek.co",
+  domain: "jseek.co",
   repoUrl: "https://github.com/colophon-group/jobseek",
   creator: "Viktor Shcherbakov",
 


### PR DESCRIPTION
## Summary
- **Domain fix**: All canonical URLs, hreflang, og:url, structured data, robots.txt sitemap reference now point to `jseek.co` instead of `jobseek.com`. Single change in `config.ts`.
- **WebApplication schema**: Added JSON-LD `WebApplication` type with translatable description/features for AI agent and search engine discoverability.
- **AI plugin manifest**: Added `/.well-known/ai-plugin.json` describing the app's capabilities for AI agents.
- **i18n**: Extracted new translatable strings for schema descriptions (5 messages).
- No hardcoded company counts or locale lists in schema data.

## Test plan
- [ ] Verify canonical URLs show `jseek.co` in page source
- [ ] Check JSON-LD in page source for WebApplication type
- [ ] Fetch `https://jseek.co/.well-known/ai-plugin.json`
- [ ] Verify Vercel build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)