### PR TITLE
Add Bing site verification XML

### DIFF
--- a/apps/web/public/BingSiteAuth.xml
+++ b/apps/web/public/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>F05CA7ACBCC1933457C54891BFBE28E6</user>
+</users>


### PR DESCRIPTION
## Summary
- Add `BingSiteAuth.xml` to `apps/web/public/` so it's served at the site root for Bing Webmaster Tools domain verification

## Test plan
- [ ] Verify `https://jseek.co/BingSiteAuth.xml` returns the XML after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)