### PR TITLE
Fix Hetzner deploy: build for amd64

### DIFF
--- a/.github/workflows/deploy-crawler-browser.yml
+++ b/.github/workflows/deploy-crawler-browser.yml
@@ -22,9 +22,6 @@ jobs:
         id: version
         run: echo "version=$(cat apps/crawler/VERSION | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
 
-      - name: Set up QEMU (for ARM64 cross-build)
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -39,7 +36,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: apps/crawler
-          platforms: linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/jobseek-crawler:latest


### PR DESCRIPTION
CPX22 is x86, not ARM. Removes QEMU step (no cross-build needed) and targets linux/amd64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)