### PR TITLE
Use host networking for Hetzner crawler container

### DIFF
--- a/.github/workflows/deploy-crawler-browser.yml
+++ b/.github/workflows/deploy-crawler-browser.yml
@@ -58,7 +58,7 @@ jobs:
               --name jobseek-crawler \
               --restart unless-stopped \
               --env-file /home/deploy/crawler.env \
-              -p 127.0.0.1:9091:9091 \
+              --network host \
               --memory=3g \
               --shm-size=1g \
               ghcr.io/${{ github.repository_owner }}/jobseek-crawler:latest \


### PR DESCRIPTION
Docker containers default to IPv6 DNS resolution, but Supabase Postgres only accepts IPv4. Using --network host lets the container use the host's IPv4 stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)