### PR TITLE
Fix app pages broken by missing setI18n() call

### DIFF
--- a/apps/web/app/[lang]/(app)/layout.tsx
+++ b/apps/web/app/[lang]/(app)/layout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 
 export const dynamic = "force-dynamic";
 
+import { setI18n } from "@lingui/react/server";
 import { getSession } from "@/lib/sessionCache";
 import { isLocale, defaultLocale, loadCatalog, type Locale } from "@/lib/i18n";
 import { LinguiClientProvider } from "@/components/LinguiProvider";
@@ -28,7 +29,8 @@ type Props = {
 export default async function AppLayout({ params, children }: Props) {
   const { lang } = await params;
   const locale: Locale = isLocale(lang) ? lang : defaultLocale;
-  const { messages } = await loadCatalog(locale);
+  const { i18n, messages } = await loadCatalog(locale);
+  setI18n(i18n);
   const session = await getSession();
 
   const [prefs, savedStatuses, starredIds] = await Promise.all([


### PR DESCRIPTION
## Summary
- The `(app)` layout called `loadCatalog()` but only destructured `messages` for the client provider — it never called `setI18n(i18n)`, leaving server-side i18n uninitialized
- All protected pages broke while public/marketing pages continued to work (their layouts call `setI18n()` correctly)
- Added the missing `setI18n(i18n)` call, matching the pattern in the root and `(public)` layouts

## Test plan
- [ ] Verify protected app pages load correctly
- [ ] Verify public/marketing pages still work
- [ ] Check that server-rendered i18n strings appear correctly on app pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)