### PR TITLE
Fix infinite loading on app pages

### DIFF
--- a/apps/web/src/db/index.ts
+++ b/apps/web/src/db/index.ts
@@ -14,7 +14,7 @@ export const db = new Proxy({} as PostgresJsDatabase<typeof schema>, {
         throw new Error("DATABASE_URL is not set");
       }
       globalForDb._db = drizzle(
-        postgres(process.env.DATABASE_URL, { max: 1, idle_timeout: 20, max_lifetime: 300, prepare: false }),
+        postgres(process.env.DATABASE_URL, { max: 10, idle_timeout: 20, max_lifetime: 300, prepare: false }),
         { schema },
       );
     }

--- a/apps/web/src/lib/sessionCache.ts
+++ b/apps/web/src/lib/sessionCache.ts
@@ -36,7 +36,13 @@ async function fetchSession(): Promise<SessionResult> {
   }
 
   // Cache miss — fetch from DB via Better Auth
-  const result = await auth.api.getSession({ headers: headersList });
+  let result: SessionResult;
+  try {
+    result = await auth.api.getSession({ headers: headersList });
+  } catch {
+    // DB unavailable (e.g. statement timeout) — treat as unauthenticated
+    return null;
+  }
   if (!result) return null;
 
   // Store in Redis for subsequent requests


### PR DESCRIPTION
## Summary
- **Root cause**: DB connection pool was `max: 1` — the `(app)` layout runs 4 parallel queries (`getSession`, `getPreferences`, `getSavedJobStatuses`, `getStarredCompanyIds`) and the explore page adds heavy search queries. With a single connection, everything queues and the page hangs.
- Increased pool to `max: 10` so parallel queries can run concurrently
- Wrapped `auth.api.getSession()` in try/catch so a transient DB timeout returns `null` (treat as logged out) instead of crashing the Node process with an unhandled rejection

## Test plan
- [ ] Visit /progress then navigate to /explore — should load without hanging
- [ ] Rapid navigation between app pages should not cause timeouts
- [ ] Pages still render correctly when authenticated

🤖 Generated with [Claude Code](https://claude.com/claude-code)