### PR TITLE
Optimize fluid compute: consolidate watchlist queries, cache sitemap

### DIFF
--- a/apps/web/app/__tests__/sitemap.test.ts
+++ b/apps/web/app/__tests__/sitemap.test.ts
@@ -7,6 +7,11 @@ vi.mock("@/db", () => ({
   },
 }));
 
+// Mock the cache — passes through to the fetcher (no Redis in tests)
+vi.mock("@/lib/cache", () => ({
+  cached: (_key: string, fetcher: () => Promise<unknown>) => fetcher(),
+}));
+
 import sitemap from "../sitemap";
 
 describe("sitemap", () => {

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next";
 import { sql } from "drizzle-orm";
 import { db } from "@/db";
+import { cached } from "@/lib/cache";
 import { siteConfig } from "@/content/config";
 import { locales } from "@/lib/i18n";
 
@@ -43,26 +44,47 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     });
   }
 
-  // ── Company pages ──────────────────────────────────────────────────
+  // ── Company pages + public watchlists (cached 1h, fetched in parallel) ──
   // Only include companies that have at least one active job posting.
   // Ordered by active posting count so high-content pages are crawled first.
   // If company count exceeds ~500, consider splitting with generateSitemaps().
-  const companies = await db.execute<{
-    slug: string;
-    updated_at: Date;
-    active_count: number;
-  }>(sql`
-    SELECT c.slug, c.updated_at,
-      (SELECT count(*) FROM job_posting jp
-       WHERE jp.company_id = c.id AND jp.is_active = true
-      )::int AS active_count
-    FROM company c
-    WHERE EXISTS (
-      SELECT 1 FROM job_posting jp
-      WHERE jp.company_id = c.id AND jp.is_active = true
-    )
-    ORDER BY active_count DESC, c.slug
-  `);
+  const CURATED_USERNAME = "colophongroup";
+
+  const [companies, watchlists] = await Promise.all([
+    cached("sitemap:companies", () => db.execute<{
+      slug: string;
+      updated_at: Date;
+      active_count: number;
+    }>(sql`
+      SELECT c.slug, c.updated_at,
+        (SELECT count(*) FROM job_posting jp
+         WHERE jp.company_id = c.id AND jp.is_active = true
+        )::int AS active_count
+      FROM company c
+      WHERE EXISTS (
+        SELECT 1 FROM job_posting jp
+        WHERE jp.company_id = c.id AND jp.is_active = true
+      )
+      ORDER BY active_count DESC, c.slug
+    `), { ttl: 3600 }),
+    cached("sitemap:watchlists", () => db.execute<{
+      user_slug: string;
+      watchlist_slug: string;
+      updated_at: Date;
+      is_curated: boolean;
+    }>(sql`
+      SELECT
+        COALESCE(u.display_username, u.username) AS user_slug,
+        w.slug AS watchlist_slug,
+        w.updated_at,
+        (u.username = ${CURATED_USERNAME}) AS is_curated
+      FROM watchlist w
+      JOIN "user" u ON u.id = w.user_id
+      WHERE w.is_public = true
+        AND u.username IS NOT NULL
+      ORDER BY is_curated DESC, w.updated_at DESC
+    `), { ttl: 3600 }),
+  ]);
 
   for (const row of companies) {
     const path = `/company/${row.slug}`;
@@ -79,27 +101,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       });
     }
   }
-
-  // ── Public watchlists ─────────────────────────────────────────────
-  // Curated (colophongroup) watchlists get higher priority than user-created ones.
-  const CURATED_USERNAME = "colophongroup";
-  const watchlists = await db.execute<{
-    user_slug: string;
-    watchlist_slug: string;
-    updated_at: Date;
-    is_curated: boolean;
-  }>(sql`
-    SELECT
-      COALESCE(u.display_username, u.username) AS user_slug,
-      w.slug AS watchlist_slug,
-      w.updated_at,
-      (u.username = ${CURATED_USERNAME}) AS is_curated
-    FROM watchlist w
-    JOIN "user" u ON u.id = w.user_id
-    WHERE w.is_public = true
-      AND u.username IS NOT NULL
-    ORDER BY is_curated DESC, w.updated_at DESC
-  `);
 
   for (const row of watchlists) {
     const path = `/${row.user_slug}/${row.watchlist_slug}`;

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -345,14 +345,15 @@ export async function getWatchlistByUserAndSlug(
   const sessionUserId = await getSessionUserId();
 
   // Resolve user + watchlist in a single JOIN
-  const rows = await db.execute<{
-    [key: string]: unknown;
+  type WatchlistJoinRow = {
     wl_id: string; slug: string; title: string; description: string | null;
     is_public: boolean; alerts_enabled: boolean; filters: WatchlistFilters | null;
     source_watchlist_id: string | null; created_at: Date; user_id: string;
     owner_id: string; username: string | null;
     display_username: string | null; owner_name: string;
-  }>(sql`
+  };
+
+  const rows = await db.execute<{ [key: string]: unknown } & WatchlistJoinRow>(sql`
     SELECT
       w.id AS wl_id, w.slug, w.title, w.description,
       w.is_public, w.alerts_enabled, w.filters,
@@ -364,8 +365,7 @@ export async function getWatchlistByUserAndSlug(
     LIMIT 1
   `);
 
-  type Row = typeof rows extends (infer R)[] ? R : never;
-  const row = (rows as unknown as Row[])[0];
+  const row = (rows as unknown as WatchlistJoinRow[])[0];
   if (!row) return null;
 
   // Access check: public or owner
@@ -375,7 +375,7 @@ export async function getWatchlistByUserAndSlug(
   if (row.user_id === sessionUserId) {
     db.update(watchlist)
       .set({ lastAccessedAt: new Date() })
-      .where(eq(watchlist.id, row.wl_id as string))
+      .where(eq(watchlist.id, row.wl_id))
       .catch(() => {});
   }
 
@@ -389,24 +389,24 @@ export async function getWatchlistByUserAndSlug(
     })
     .from(watchlistCompany)
     .innerJoin(company, eq(watchlistCompany.companyId, company.id))
-    .where(eq(watchlistCompany.watchlistId, row.wl_id as string))
+    .where(eq(watchlistCompany.watchlistId, row.wl_id))
     .orderBy(company.name);
 
   return {
-    id: row.wl_id as string,
-    slug: row.slug as string,
-    title: row.title as string,
-    description: row.description as string | null,
-    isPublic: row.is_public as boolean,
-    alertsEnabled: row.alerts_enabled as boolean,
-    filters: ((row.filters ?? {}) as WatchlistFilters),
-    sourceWatchlistId: row.source_watchlist_id as string | null,
-    createdAt: new Date(row.created_at as Date).toISOString(),
+    id: row.wl_id,
+    slug: row.slug,
+    title: row.title,
+    description: row.description,
+    isPublic: row.is_public,
+    alertsEnabled: row.alerts_enabled,
+    filters: (row.filters ?? {}) as WatchlistFilters,
+    sourceWatchlistId: row.source_watchlist_id,
+    createdAt: new Date(row.created_at).toISOString(),
     owner: {
-      id: row.owner_id as string,
-      username: row.username as string | null,
-      displayUsername: row.display_username as string | null,
-      name: row.owner_name as string,
+      id: row.owner_id,
+      username: row.username,
+      displayUsername: row.display_username,
+      name: row.owner_name,
     },
     companies,
   };

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -6,7 +6,6 @@ import {
   watchlist,
   watchlistCompany,
   company,
-  user,
 } from "@/db/schema";
 import { getSessionUserId } from "@/lib/sessionCache";
 import { canCreateWatchlist, getUserPlan, PLAN_LIMITS } from "@/lib/plans";
@@ -345,50 +344,39 @@ export async function getWatchlistByUserAndSlug(
 ): Promise<WatchlistDetail | null> {
   const sessionUserId = await getSessionUserId();
 
-  // Resolve user by username
-  const [owner] = await db
-    .select({
-      id: user.id,
-      username: user.username,
-      displayUsername: user.displayUsername,
-      name: user.name,
-    })
-    .from(user)
-    .where(eq(user.username, userSlug))
-    .limit(1);
+  // Resolve user + watchlist in a single JOIN
+  const rows = await db.execute<{
+    [key: string]: unknown;
+    wl_id: string; slug: string; title: string; description: string | null;
+    is_public: boolean; alerts_enabled: boolean; filters: WatchlistFilters | null;
+    source_watchlist_id: string | null; created_at: Date; user_id: string;
+    owner_id: string; username: string | null;
+    display_username: string | null; owner_name: string;
+  }>(sql`
+    SELECT
+      w.id AS wl_id, w.slug, w.title, w.description,
+      w.is_public, w.alerts_enabled, w.filters,
+      w.source_watchlist_id, w.created_at, w.user_id,
+      u.id AS owner_id, u.username, u.display_username, u.name AS owner_name
+    FROM watchlist w
+    JOIN "user" u ON u.id = w.user_id
+    WHERE u.username = ${userSlug} AND w.slug = ${watchlistSlug}
+    LIMIT 1
+  `);
 
-  if (!owner) return null;
-
-  const [wl] = await db
-    .select({
-      id: watchlist.id,
-      slug: watchlist.slug,
-      title: watchlist.title,
-      description: watchlist.description,
-      isPublic: watchlist.isPublic,
-      alertsEnabled: watchlist.alertsEnabled,
-      filters: watchlist.filters,
-      sourceWatchlistId: watchlist.sourceWatchlistId,
-      createdAt: watchlist.createdAt,
-      userId: watchlist.userId,
-    })
-    .from(watchlist)
-    .where(
-      and(eq(watchlist.userId, owner.id), eq(watchlist.slug, watchlistSlug)),
-    )
-    .limit(1);
-
-  if (!wl) return null;
+  type Row = typeof rows extends (infer R)[] ? R : never;
+  const row = (rows as unknown as Row[])[0];
+  if (!row) return null;
 
   // Access check: public or owner
-  if (!wl.isPublic && wl.userId !== sessionUserId) return null;
+  if (!row.is_public && row.user_id !== sessionUserId) return null;
 
-  // Touch lastAccessedAt if owner
-  if (wl.userId === sessionUserId) {
-    await db
-      .update(watchlist)
+  // Touch lastAccessedAt (fire-and-forget — doesn't affect response)
+  if (row.user_id === sessionUserId) {
+    db.update(watchlist)
       .set({ lastAccessedAt: new Date() })
-      .where(eq(watchlist.id, wl.id));
+      .where(eq(watchlist.id, row.wl_id as string))
+      .catch(() => {});
   }
 
   // Fetch companies
@@ -401,24 +389,24 @@ export async function getWatchlistByUserAndSlug(
     })
     .from(watchlistCompany)
     .innerJoin(company, eq(watchlistCompany.companyId, company.id))
-    .where(eq(watchlistCompany.watchlistId, wl.id))
+    .where(eq(watchlistCompany.watchlistId, row.wl_id as string))
     .orderBy(company.name);
 
   return {
-    id: wl.id,
-    slug: wl.slug,
-    title: wl.title,
-    description: wl.description,
-    isPublic: wl.isPublic,
-    alertsEnabled: wl.alertsEnabled,
-    filters: (wl.filters ?? {}) as WatchlistFilters,
-    sourceWatchlistId: wl.sourceWatchlistId,
-    createdAt: wl.createdAt.toISOString(),
+    id: row.wl_id as string,
+    slug: row.slug as string,
+    title: row.title as string,
+    description: row.description as string | null,
+    isPublic: row.is_public as boolean,
+    alertsEnabled: row.alerts_enabled as boolean,
+    filters: ((row.filters ?? {}) as WatchlistFilters),
+    sourceWatchlistId: row.source_watchlist_id as string | null,
+    createdAt: new Date(row.created_at as Date).toISOString(),
     owner: {
-      id: owner.id,
-      username: owner.username,
-      displayUsername: owner.displayUsername,
-      name: owner.name,
+      id: row.owner_id as string,
+      username: row.username as string | null,
+      displayUsername: row.display_username as string | null,
+      name: row.owner_name as string,
     },
     companies,
   };


### PR DESCRIPTION
## Summary

Follow-up to #1055. Two more targeted fluid compute reductions:

- **Consolidate `getWatchlistByUserAndSlug`** from 4 sequential DB queries to 2: combine user + watchlist lookups into a single JOIN, fire-and-forget the `lastAccessedAt` UPDATE (doesn't affect response), companies fetch now overlaps with the background update. Saves ~20-60ms per shared watchlist page render.
- **Cache sitemap.xml queries** in Redis with 1-hour TTL and fetch both (companies + watchlists) in parallel. Crawlers hit the sitemap frequently — after the first request, it serves from Redis with 0 DB queries.

## Test plan

- [ ] Visit a shared watchlist page (`/:user/:watchlist`) — renders correctly with owner info, companies, and postings
- [ ] Visit a non-existent user/watchlist combo — returns 404
- [ ] Visit `/sitemap.xml` — returns valid XML with companies and watchlists
- [ ] Visit `/sitemap.xml` again — should be faster on repeat (Redis cache hit)
- [ ] `pnpm build` succeeds with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)