### PR TITLE
Add MCP tool annotations for registry submissions

### DIFF
--- a/apps/web/app/mcp/route.ts
+++ b/apps/web/app/mcp/route.ts
@@ -1,13 +1,32 @@
 import { handleMcpRequest } from "@jseek/mcp-server/handler";
 
+const CORS_HEADERS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, POST, DELETE, OPTIONS",
+  "Access-Control-Allow-Headers":
+    "Content-Type, Accept, Mcp-Session-Id, Last-Event-ID, Mcp-Protocol-Version",
+  "Access-Control-Expose-Headers": "Mcp-Session-Id",
+};
+
+function withCors(response: Response): Response {
+  for (const [key, value] of Object.entries(CORS_HEADERS)) {
+    response.headers.set(key, value);
+  }
+  return response;
+}
+
+export async function OPTIONS() {
+  return new Response(null, { status: 204, headers: CORS_HEADERS });
+}
+
 export async function POST(req: Request) {
-  return handleMcpRequest(req);
+  return withCors(await handleMcpRequest(req));
 }
 
 export async function GET(req: Request) {
-  return handleMcpRequest(req);
+  return withCors(await handleMcpRequest(req));
 }
 
 export async function DELETE(req: Request) {
-  return handleMcpRequest(req);
+  return withCors(await handleMcpRequest(req));
 }

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -1,8 +1,18 @@
 # @jseek/mcp-server
 
-MCP server for [Job Seek](https://jseek.co) — search jobs, companies, and watchlists directly from Claude, Cursor, or any MCP-compatible client.
+MCP server for [Job Seek](https://jseek.co) — search jobs, companies, and watchlists directly from Claude, ChatGPT, Cursor, or any MCP-compatible client.
 
-## Installation
+## Remote Endpoint
+
+A hosted Streamable HTTP endpoint is available at:
+
+```
+https://jseek.co/mcp
+```
+
+No authentication required. Add it as a custom connector in Claude.ai or ChatGPT.
+
+## Local Installation
 
 ### Claude Desktop
 
@@ -52,16 +62,33 @@ Add to `.cursor/mcp.json`:
 | `search_watchlists` | Search public watchlists |
 | `create_watchlist_link` | Generate a prefilled watchlist creation link |
 
-## Usage
+All tools are annotated as read-only and non-destructive.
 
-Ask Claude things like:
+## Usage Examples
 
-- "Find senior backend engineer jobs in Zurich"
-- "What companies are hiring for machine learning roles?"
-- "Show me React jobs paying over 100k EUR"
-- "Create a watchlist for Go developer positions in Switzerland"
+### Example 1: Find backend jobs in Zurich
 
-The server will guide Claude through the correct workflow: resolving freetext to slugs, searching with those slugs, and drilling into individual postings.
+**User:** "Find senior backend engineer jobs in Zurich"
+
+The server resolves "Zurich" to the slug `zurich` via `resolve_slugs`, then searches with `search_jobs(q: "backend engineer", loc: "zurich", sen: "senior")`. Returns matching companies with their top postings, each linking to the full listing on jseek.co.
+
+### Example 2: Explore a specific company
+
+**User:** "What jobs does Google have open?"
+
+The server calls `search_companies(q: "Google")` to find the company, then `search_jobs` filtered to that company's postings. For any interesting result, `get_job_detail` returns salary, technologies, seniority, experience requirements, and locations.
+
+### Example 3: Create a watchlist for email alerts
+
+**User:** "Create a watchlist for React jobs in Switzerland paying over 100k EUR"
+
+The server resolves "Switzerland" and "React" to slugs, then calls `create_watchlist_link(title: "React Jobs Switzerland 100k+", loc: "switzerland", tech: "react", sal: "100000-")`. Returns a prefilled link the user can open to save the watchlist and receive email alerts for new matching jobs.
+
+### Example 4: Discover filter options
+
+**User:** "What seniority levels can I filter by?"
+
+The server calls `list_taxonomies(type: "seniority")` and returns all available levels: Intern, Entry Level, Senior, Lead, Staff, Principal, Director, Executive.
 
 ## Options
 
@@ -72,6 +99,10 @@ The server will guide Claude through the correct workflow: resolving freetext to
 ## Rate Limits
 
 The Job Seek API is rate-limited to 30 requests per minute per IP.
+
+## Privacy Policy
+
+https://jseek.co/en/privacy-policy
 
 ## License
 

--- a/packages/mcp-server/src/tools/companies.ts
+++ b/packages/mcp-server/src/tools/companies.ts
@@ -13,6 +13,7 @@ export function register(server: McpServer, client: JobseekClient) {
         .default("en")
         .describe("Response language"),
     },
+    { title: "Search Companies", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async (params) => {
       const data = await client.get("/api/v1/companies", {
         q: params.q,

--- a/packages/mcp-server/src/tools/create-watchlist.ts
+++ b/packages/mcp-server/src/tools/create-watchlist.ts
@@ -38,6 +38,7 @@ export function register(server: McpServer, client: JobseekClient) {
         .default("en")
         .describe("Response language"),
     },
+    { title: "Create Watchlist Link", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async (params) => {
       const data = await client.get("/api/v1/watchlist/create", {
         title: params.title,

--- a/packages/mcp-server/src/tools/job-detail.ts
+++ b/packages/mcp-server/src/tools/job-detail.ts
@@ -13,6 +13,7 @@ export function register(server: McpServer, client: JobseekClient) {
         .default("en")
         .describe("Response language"),
     },
+    { title: "Get Job Detail", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async (params) => {
       const data = await client.get("/api/v1/job", {
         id: params.id,

--- a/packages/mcp-server/src/tools/resolve.ts
+++ b/packages/mcp-server/src/tools/resolve.ts
@@ -16,6 +16,7 @@ export function register(server: McpServer, client: JobseekClient) {
         .default("en")
         .describe("Response language"),
     },
+    { title: "Resolve Slugs", readOnlyHint: true, destructiveHint: false, openWorldHint: true, idempotentHint: true },
     async (params) => {
       const data = await client.get("/api/v1/resolve", {
         type: params.type,

--- a/packages/mcp-server/src/tools/search.ts
+++ b/packages/mcp-server/src/tools/search.ts
@@ -39,6 +39,7 @@ export function register(server: McpServer, client: JobseekClient) {
         .describe("Experience range in years, format: min-max (e.g. 3-10)"),
       locale: LOCALE,
     },
+    { title: "Search Jobs", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async (params) => {
       const data = await client.get("/api/v1/search", {
         q: params.q,

--- a/packages/mcp-server/src/tools/taxonomies.ts
+++ b/packages/mcp-server/src/tools/taxonomies.ts
@@ -15,6 +15,7 @@ export function register(server: McpServer, client: JobseekClient) {
         .default("en")
         .describe("Response language"),
     },
+    { title: "List Taxonomies", readOnlyHint: true, destructiveHint: false, openWorldHint: true, idempotentHint: true },
     async (params) => {
       const data = await client.get("/api/v1/taxonomies", {
         type: params.type,

--- a/packages/mcp-server/src/tools/watchlists.ts
+++ b/packages/mcp-server/src/tools/watchlists.ts
@@ -16,6 +16,7 @@ export function register(server: McpServer, client: JobseekClient) {
         .default("en")
         .describe("Response language"),
     },
+    { title: "Search Watchlists", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async (params) => {
       const data = await client.get("/api/v1/watchlists", {
         q: params.q,


### PR DESCRIPTION
## Summary
- Add tool annotations (`title`, `readOnlyHint`, `destructiveHint`, `openWorldHint`, `idempotentHint`) to all 7 MCP tools
- Required for ChatGPT App Directory and Claude.ai connector submissions

## Submission links
- **ChatGPT App Directory**: https://platform.openai.com/apps-manage
- **Claude.ai custom connector**: Settings → Connectors → `https://jseek.co/mcp`

## Test plan
- [x] All tools return annotations in `tools/list` response
- [x] Full endpoint tested locally (initialize, all 7 tools, DELETE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)