### PR TITLE
Convert app pages from SSR to client-side fetching + anon truncation

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
@@ -1,13 +1,14 @@
-import { Suspense, cache } from "react";
+import { cache } from "react";
 import type { Metadata } from "next";
-import { isLocale, defaultLocale, loadCatalog, initI18nForPage } from "@/lib/i18n";
+import { isLocale, defaultLocale, loadCatalog } from "@/lib/i18n";
 import {
   getWatchlistByUserAndSlug as _getWatchlistByUserAndSlug,
 } from "@/lib/actions/watchlists";
 import { siteConfig } from "@/content/config";
 import { buildAlternates } from "@/lib/seo";
-import { WatchlistSkeleton } from "@/components/search/watchlist-skeleton";
 import { WatchlistContent } from "./watchlist-content";
+
+export const revalidate = 600; // ISR: cache metadata for 10 minutes
 
 // Deduplicate across generateMetadata + page component within a single render
 const getWatchlistByUserAndSlug = cache(_getWatchlistByUserAndSlug);
@@ -30,7 +31,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   let description = detail.description;
   if (!description) {
-    // Auto-generate from companies/filters
     const parts: string[] = [];
     if (detail.companies.length > 0) {
       const names = detail.companies.slice(0, 3).map((c) => c.name);
@@ -90,11 +90,6 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function WatchlistRoute({ params }: Props) {
   const { lang, userSlug, watchlistSlug } = await params;
-  await initI18nForPage(Promise.resolve({ lang }));
 
-  return (
-    <Suspense fallback={<WatchlistSkeleton />}>
-      <WatchlistContent lang={lang} userSlug={userSlug} watchlistSlug={watchlistSlug} />
-    </Suspense>
-  );
+  return <WatchlistContent lang={lang} userSlug={userSlug} watchlistSlug={watchlistSlug} />;
 }

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-content.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-content.tsx
@@ -1,15 +1,8 @@
-import { notFound } from "next/navigation";
-import { getI18n } from "@lingui/react/server";
-import {
-  getWatchlistByUserAndSlug,
-  getWatchlistPostings,
-} from "@/lib/actions/watchlists";
-import { getSession } from "@/lib/sessionCache";
-import { getUserPlan, PLAN_LIMITS, canCreateWatchlist } from "@/lib/plans";
-import { resolveLocationSlugs } from "@/lib/actions/locations";
-import { resolveOccupationSlugs, resolveSenioritySlugs, resolveTechnologySlugs } from "@/lib/actions/taxonomy";
-import { siteConfig } from "@/content/config";
-import { JsonLd } from "@/lib/seo";
+"use client";
+
+import { useEffect, useState } from "react";
+import { fetchWatchlistPageData, type WatchlistPageData } from "@/lib/actions/watchlist-page-data";
+import { WatchlistSkeleton } from "@/components/search/watchlist-skeleton";
 import { WatchlistViewPage } from "./watchlist-view-page";
 
 type WatchlistContentProps = {
@@ -18,99 +11,40 @@ type WatchlistContentProps = {
   watchlistSlug: string;
 };
 
-export async function WatchlistContent({ lang, userSlug, watchlistSlug }: WatchlistContentProps) {
-  const detail = await getWatchlistByUserAndSlug(userSlug, watchlistSlug);
-  if (!detail) notFound();
+function WatchlistNotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center py-24 text-center">
+      <h1 className="text-2xl font-bold">Watchlist not found</h1>
+      <p className="mt-2 text-muted">This watchlist does not exist or is not public.</p>
+    </div>
+  );
+}
 
-  const session = await getSession();
-  const isOwner = session?.user?.id === detail.owner.id;
+export function WatchlistContent({ lang, userSlug, watchlistSlug }: WatchlistContentProps) {
+  const [data, setData] = useState<WatchlistPageData | null | "not-found">(null);
 
-  const [plan, limit] = await Promise.all([
-    session ? getUserPlan(session.user.id) : ("free" as const),
-    session ? canCreateWatchlist(session.user.id) : { allowed: false, current: 0, max: 0 },
-  ]);
-  const isPaidPlan = PLAN_LIMITS[plan].canReceiveAlerts;
-  const limitReached = !limit.allowed;
+  useEffect(() => {
+    fetchWatchlistPageData({ userSlug, watchlistSlug, locale: lang }).then((result) => {
+      setData(result ?? "not-found");
+    });
+  }, [lang, userSlug, watchlistSlug]);
 
-  const filters = detail.filters;
-
-  // Resolve filter slugs to display objects
-  const [locMap, occMap, senMap, techMap] = await Promise.all([
-    filters.locationSlugs?.length
-      ? resolveLocationSlugs(filters.locationSlugs, lang)
-      : Promise.resolve(new Map()),
-    filters.occupationSlugs?.length
-      ? resolveOccupationSlugs(filters.occupationSlugs, lang)
-      : Promise.resolve(new Map()),
-    filters.senioritySlugs?.length
-      ? resolveSenioritySlugs(filters.senioritySlugs, lang)
-      : Promise.resolve(new Map()),
-    filters.technologySlugs?.length
-      ? resolveTechnologySlugs(filters.technologySlugs)
-      : Promise.resolve(new Map()),
-  ]);
-
-  const resolvedLocations = (filters.locationSlugs ?? [])
-    .map((slug) => locMap.get(slug))
-    .filter((l): l is NonNullable<typeof l> => l != null)
-    .map((l) => ({ id: l.id, slug: l.slug, name: l.name, type: l.type as "macro" | "country" | "region" | "city", parentName: l.parentName }));
-
-  const resolvedOccupations = (filters.occupationSlugs ?? [])
-    .map((slug) => occMap.get(slug))
-    .filter((o): o is NonNullable<typeof o> => o != null);
-
-  const resolvedSeniorities = (filters.senioritySlugs ?? [])
-    .map((slug) => senMap.get(slug))
-    .filter((s): s is NonNullable<typeof s> => s != null);
-
-  const resolvedTechnologies = (filters.technologySlugs ?? [])
-    .map((slug) => techMap.get(slug))
-    .filter((t): t is NonNullable<typeof t> => t != null);
-
-  const { postings, total } = await getWatchlistPostings({
-    companyIds: filters.anyCompany ? [] : detail.companies.map((c) => c.id),
-    anyCompany: filters.anyCompany,
-    offset: 0,
-    limit: 20,
-    keywords: filters.keywords,
-    locationIds: resolvedLocations.map((l) => l.id),
-    occupationIds: resolvedOccupations.map((o) => o.id),
-    seniorityIds: resolvedSeniorities.map((s) => s.id),
-    technologyIds: resolvedTechnologies.map((t) => t.id),
-    salaryMin: filters.salaryMin,
-    salaryMax: filters.salaryMax,
-    experienceMin: filters.experienceMin,
-    experienceMax: filters.experienceMax,
-  });
-
-  const i18n = getI18n()!;
-  const ownerLabel = detail.owner.displayUsername ?? detail.owner.username ?? detail.owner.name;
-  const breadcrumbJsonLd: Record<string, unknown> = {
-    "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: [
-      { "@type": "ListItem", position: 1, name: i18n._({ id: "breadcrumb.home", message: "Home" }), item: `${siteConfig.url}/${lang}` },
-      { "@type": "ListItem", position: 2, name: `@${ownerLabel}` },
-      { "@type": "ListItem", position: 3, name: detail.title },
-    ],
-  };
+  if (data === null) return <WatchlistSkeleton />;
+  if (data === "not-found") return <WatchlistNotFound />;
 
   return (
-    <>
-      <JsonLd data={breadcrumbJsonLd} />
-      <WatchlistViewPage
-        detail={detail}
-        isOwner={isOwner}
-        isPaidPlan={isPaidPlan}
-        limitReached={limitReached}
-        initialPostings={postings}
-        initialTotal={total}
-        locale={lang}
-        resolvedLocations={resolvedLocations}
-        resolvedOccupations={resolvedOccupations}
-        resolvedSeniorities={resolvedSeniorities}
-        resolvedTechnologies={resolvedTechnologies}
-      />
-    </>
+    <WatchlistViewPage
+      detail={data.detail}
+      isOwner={data.isOwner}
+      isPaidPlan={data.isPaidPlan}
+      limitReached={data.limitReached}
+      initialPostings={data.postings}
+      initialTotal={data.total}
+      locale={lang}
+      resolvedLocations={data.resolvedLocations}
+      resolvedOccupations={data.resolvedOccupations}
+      resolvedSeniorities={data.resolvedSeniorities}
+      resolvedTechnologies={data.resolvedTechnologies}
+    />
   );
 }

--- a/apps/web/app/[lang]/(app)/company/[slug]/company-content.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-content.tsx
@@ -1,130 +1,76 @@
-import { notFound } from "next/navigation";
-import { getI18n } from "@lingui/react/server";
-import { getCompanyBySlug, getCompanyPostings } from "@/lib/actions/company";
-import { getPreferences } from "@/lib/actions/preferences";
-import { parseSearchFilters } from "@/lib/actions/search-input";
-import { resolveJobLanguages } from "@/lib/job-languages";
-import { siteConfig } from "@/content/config";
-import { JsonLd, formatEmployeeCount } from "@/lib/seo";
-import { firstOf, idsOrUndefined, parseRangeParam, getGeoFromHeaders } from "@/lib/search/params";
-import type { Locale } from "@/lib/i18n";
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { fetchCompanyPageData, type CompanyPageData } from "@/lib/actions/company-page-data";
+import { CompanySkeleton } from "@/components/search/company-skeleton";
 import { CompanyPage } from "./company-page";
 
-const PAGE_SIZE = 20;
-
 type CompanyContentProps = {
-  locale: Locale;
+  locale: string;
   slug: string;
-  searchParams: Record<string, string | string[] | undefined>;
 };
 
-export async function CompanyContent({ locale, slug, searchParams }: CompanyContentProps) {
-  const q = firstOf(searchParams.q);
-  const loc = firstOf(searchParams.loc);
-  const occ = firstOf(searchParams.occ);
-  const sen = firstOf(searchParams.sen);
-  const tech = firstOf(searchParams.tech);
-  const show = firstOf(searchParams.show);
-  const sal = firstOf(searchParams.sal);
-  const salcur = firstOf(searchParams.salcur);
-  const exp = firstOf(searchParams.exp);
+function CompanyNotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center py-24 text-center">
+      <h1 className="text-2xl font-bold">Company not found</h1>
+      <p className="mt-2 text-muted">The company you are looking for does not exist or has been removed.</p>
+    </div>
+  );
+}
 
-  const company = await getCompanyBySlug(slug, locale);
-  if (!company) notFound();
+export function CompanyContent({ locale, slug }: CompanyContentProps) {
+  const searchParams = useSearchParams();
+  const [data, setData] = useState<CompanyPageData | null | "not-found">(null);
 
-  const { userLat, userLng } = await getGeoFromHeaders();
-  const [parsed, prefs] = await Promise.all([
-    parseSearchFilters({ q, loc, occ, sen, tech, locale, userLat, userLng }),
-    getPreferences(),
-  ]);
+  // Exclude UI-only params like "show" so opening a posting doesn't re-fetch
+  const searchKey = useMemo(() => {
+    const filtered = new URLSearchParams();
+    searchParams.forEach((value, key) => {
+      if (key !== "show") filtered.set(key, value);
+    });
+    return filtered.toString();
+  }, [searchParams]);
 
-  const jobLanguages = prefs?.jobLanguages ?? [];
-  const languages = resolveJobLanguages(jobLanguages, locale);
-  const displayCurrency = prefs?.displayCurrency ?? "EUR";
+  useEffect(() => {
+    setData(null);
+    const sp: Record<string, string | undefined> = {};
+    searchParams.forEach((value, key) => {
+      sp[key] = value;
+    });
+    fetchCompanyPageData({ slug, searchParams: sp, locale }).then((result) => {
+      setData(result ?? "not-found");
+    });
+  }, [slug, searchKey, locale]);
 
-  const locationIds = idsOrUndefined(parsed.locations);
-  const occupationIds = idsOrUndefined(parsed.occupations);
-  const seniorityIds = idsOrUndefined(parsed.seniorities);
-  const technologyIds = idsOrUndefined(parsed.technologies);
-
-  const salaryCurrencyParam = salcur ?? displayCurrency;
-  const { min: salaryMinDisplay, max: salaryMaxDisplay } = parseRangeParam(sal);
-  const salaryMinEur = salaryMinDisplay;
-  const salaryMaxEur = salaryMaxDisplay;
-  const { min: experienceMin, max: experienceMax } = parseRangeParam(exp);
-
-  const postingsResult = await getCompanyPostings({
-    companyId: company.id,
-    keywords: parsed.keywords,
-    locationIds,
-    occupationIds,
-    seniorityIds,
-    technologyIds,
-    salaryMinEur,
-    salaryMaxEur,
-    experienceMin,
-    experienceMax,
-    languages,
-    locale,
-    offset: 0,
-    limit: PAGE_SIZE,
-  });
-
-  const orgJsonLd: Record<string, unknown> = {
-    "@context": "https://schema.org",
-    "@type": "Organization",
-    name: company.name,
-    ...(company.website && { url: company.website }),
-    ...(company.description && { description: company.description }),
-    ...(company.icon && { logo: company.icon }),
-    ...(company.foundedYear && { foundingDate: String(company.foundedYear) }),
-    ...(company.industryName && { industry: company.industryName }),
-    ...(formatEmployeeCount(company.employeeCountRange) && {
-      numberOfEmployees: {
-        "@type": "QuantitativeValue",
-        value: formatEmployeeCount(company.employeeCountRange),
-      },
-    }),
-  };
-
-  const i18n = getI18n()!;
-  const breadcrumbJsonLd: Record<string, unknown> = {
-    "@context": "https://schema.org",
-    "@type": "BreadcrumbList",
-    itemListElement: [
-      { "@type": "ListItem", position: 1, name: i18n._({ id: "breadcrumb.home", message: "Home" }), item: `${siteConfig.url}/${locale}` },
-      { "@type": "ListItem", position: 2, name: i18n._({ id: "breadcrumb.explore", message: "Explore" }), item: `${siteConfig.url}/${locale}/explore` },
-      { "@type": "ListItem", position: 3, name: company.name },
-    ],
-  };
+  if (data === null) return <CompanySkeleton />;
+  if (data === "not-found") return <CompanyNotFound />;
 
   return (
-    <>
-      <JsonLd data={orgJsonLd} />
-      <JsonLd data={breadcrumbJsonLd} />
-      <CompanyPage
-        company={company}
-        initialPostings={postingsResult.postings}
-        initialActiveCount={postingsResult.activeCount}
-        initialYearCount={postingsResult.yearCount}
-        initialKeywords={parsed.keywords}
-        initialLocations={parsed.locations}
-        initialOccupations={parsed.occupations}
-        initialSeniorities={parsed.seniorities}
-        initialTechnologies={parsed.technologies}
-        initialSalaryCurrency={salaryCurrencyParam !== displayCurrency ? salaryCurrencyParam : undefined}
-        initialSalaryMin={salaryMinDisplay}
-        initialSalaryMax={salaryMaxDisplay}
-        initialExperienceMin={experienceMin}
-        initialExperienceMax={experienceMax}
-        initialShowPostingId={show ?? null}
-        displayCurrency={displayCurrency}
-        locale={locale}
-        jobLanguages={jobLanguages}
-        languages={languages}
-        userLat={userLat}
-        userLng={userLng}
-      />
-    </>
+    <CompanyPage
+      company={data.company}
+      initialPostings={data.postings}
+      initialActiveCount={data.activeCount}
+      initialYearCount={data.yearCount}
+      initialTruncated={data.truncated}
+      initialKeywords={data.parsed.keywords}
+      initialLocations={data.parsed.locations}
+      initialOccupations={data.parsed.occupations}
+      initialSeniorities={data.parsed.seniorities}
+      initialTechnologies={data.parsed.technologies}
+      initialSalaryCurrency={data.salaryCurrencyParam !== data.displayCurrency ? data.salaryCurrencyParam : undefined}
+      initialSalaryMin={data.salaryMinDisplay}
+      initialSalaryMax={data.salaryMaxDisplay}
+      initialExperienceMin={data.experienceMin}
+      initialExperienceMax={data.experienceMax}
+      initialShowPostingId={data.showPostingId}
+      displayCurrency={data.displayCurrency}
+      locale={locale}
+      jobLanguages={data.jobLanguages}
+      languages={data.languages}
+      userLat={data.userLat}
+      userLng={data.userLng}
+    />
   );
 }

--- a/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
@@ -14,6 +14,7 @@ import { SearchToolbar } from "@/components/search/search-toolbar";
 import { getCompanyPostings } from "@/lib/actions/company";
 import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
 import { InfiniteScrollSentinel } from "@/components/InfiniteScrollSentinel";
+import { TruncationPrompt } from "@/components/TruncationPrompt";
 import { TrackingDot } from "@/components/TrackingDot";
 import { PendingJobIcon } from "@/components/PendingJobWarning";
 import { getCurrencyRates, type CurrencyRate } from "@/lib/actions/search";
@@ -44,6 +45,7 @@ interface CompanyPageProps {
   initialPostings: SearchResultPosting[];
   initialActiveCount: number;
   initialYearCount: number;
+  initialTruncated?: boolean;
   initialKeywords: string[];
   initialLocations: SelectedLocation[];
   initialOccupations: TaxonomyItem[];
@@ -70,6 +72,7 @@ export function CompanyPage({
   initialPostings,
   initialActiveCount,
   initialYearCount,
+  initialTruncated,
   initialKeywords,
   initialLocations,
   initialOccupations,
@@ -114,6 +117,7 @@ export function CompanyPage({
   );
   const [isSearching, startSearch] = useTransition();
   const [exhausted, setExhausted] = useState(initialPostings.length < PAGE_SIZE);
+  const [isTruncated, setIsTruncated] = useState(initialTruncated ?? false);
 
   // Currency rates for EUR conversion (fetched lazily)
   const [currencyRates, setCurrencyRates] = useState<CurrencyRate[]>([]);
@@ -145,7 +149,7 @@ export function CompanyPage({
   experienceMinRef.current = experienceMin;
   experienceMaxRef.current = experienceMax;
 
-  const hasMore = !exhausted && postings.length < yearCount;
+  const hasMore = !exhausted && !isTruncated && postings.length < yearCount;
   const hasFilters = keywords.length > 0 || locations.length > 0 || occupations.length > 0 || seniorities.length > 0 || technologies.length > 0 || salaryMin != null || salaryMax != null || experienceMin != null || experienceMax != null;
 
   /** Convert a salary amount from the user's display currency to EUR. */
@@ -221,6 +225,7 @@ export function CompanyPage({
       setActiveCount(result.activeCount);
       setYearCount(result.yearCount);
       setExhausted(result.postings.length < PAGE_SIZE);
+      setIsTruncated(result.truncated ?? false);
     });
   }
 
@@ -483,6 +488,7 @@ export function CompanyPage({
       offset: postings.length,
       limit: PAGE_SIZE,
     });
+    if (result.truncated) setIsTruncated(true);
     if (result.postings.length > 0) {
       setPostings((prev) => {
         const seen = new Set(prev.map((p) => p.id));
@@ -683,6 +689,7 @@ export function CompanyPage({
             </div>
           ))}
           {hasMore && <InfiniteScrollSentinel sentinelRef={sentinelRef} isLoading={isLoadingMore} />}
+          {!hasMore && isTruncated && <TruncationPrompt type="postings" />}
         </div>
       )}
     </div>

--- a/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
@@ -1,11 +1,11 @@
-import { Suspense } from "react";
 import type { Metadata } from "next";
-import { isLocale, defaultLocale, loadCatalog, initI18nForPage } from "@/lib/i18n";
+import { isLocale, defaultLocale, loadCatalog } from "@/lib/i18n";
 import { getCompanyBySlug } from "@/lib/actions/company";
 import { siteConfig } from "@/content/config";
 import { buildAlternates } from "@/lib/seo";
-import { CompanySkeleton } from "@/components/search/company-skeleton";
 import { CompanyContent } from "./company-content";
+
+export const revalidate = 600; // ISR: cache metadata for 10 minutes
 
 type Props = {
   params: Promise<{ lang: string; slug: string }>;
@@ -60,14 +60,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export default async function CompanyPageRoute({ params, searchParams }: Props) {
-  const locale = await initI18nForPage(params);
-  const { slug } = await params;
-  const sp = await searchParams;
+export default async function CompanyPageRoute({ params }: Props) {
+  const { lang, slug } = await params;
+  const locale = isLocale(lang) ? lang : defaultLocale;
 
-  return (
-    <Suspense fallback={<CompanySkeleton />}>
-      <CompanyContent locale={locale} slug={slug} searchParams={sp} />
-    </Suspense>
-  );
+  return <CompanyContent locale={locale} slug={slug} />;
 }

--- a/apps/web/app/[lang]/(app)/explore/explore-content.tsx
+++ b/apps/web/app/[lang]/(app)/explore/explore-content.tsx
@@ -1,87 +1,48 @@
-import { searchJobs, listTopCompanies } from "@/lib/actions/search";
-import { parseSearchFilters } from "@/lib/actions/search-input";
-import { getPreferences } from "@/lib/actions/preferences";
-import { resolveJobLanguages } from "@/lib/job-languages";
-import { firstOf, idsOrUndefined, parseRangeParam, getGeoFromHeaders } from "@/lib/search/params";
-import type { Locale } from "@/lib/i18n";
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { fetchExploreData, type ExploreData } from "@/lib/actions/explore-data";
+import { ExploreSkeleton } from "@/components/search/explore-skeleton";
 import { SearchPage } from "./search-page";
 
-const PAGE_SIZE = 10;
-
 type ExploreContentProps = {
-  locale: Locale;
-  searchParams: Record<string, string | string[] | undefined>;
+  locale: string;
 };
 
-export async function ExploreContent({ locale, searchParams }: ExploreContentProps) {
-  const q = firstOf(searchParams.q);
-  const loc = firstOf(searchParams.loc);
-  const occ = firstOf(searchParams.occ);
-  const sen = firstOf(searchParams.sen);
-  const tech = firstOf(searchParams.tech);
-  const sal = firstOf(searchParams.sal);
-  const salcur = firstOf(searchParams.salcur);
-  const exp = firstOf(searchParams.exp);
+export function ExploreContent({ locale }: ExploreContentProps) {
+  const searchParams = useSearchParams();
+  const [data, setData] = useState<ExploreData | null>(null);
 
-  const { userLat, userLng } = await getGeoFromHeaders();
+  // Build a stable key from search params, excluding UI-only params like "show"
+  // so that opening a posting detail panel doesn't trigger a re-fetch.
+  const searchKey = useMemo(() => {
+    const filtered = new URLSearchParams();
+    searchParams.forEach((value, key) => {
+      if (key !== "show") filtered.set(key, value);
+    });
+    return filtered.toString();
+  }, [searchParams]);
 
-  const [parsed, prefs] = await Promise.all([
-    parseSearchFilters({ q, loc, occ, sen, tech, locale, userLat, userLng }),
-    getPreferences(),
-  ]);
+  useEffect(() => {
+    setData(null);
+    const sp: Record<string, string | undefined> = {};
+    searchParams.forEach((value, key) => {
+      sp[key] = value;
+    });
+    fetchExploreData({ searchParams: sp, locale }).then(setData);
+  }, [searchKey, locale]);
 
-  const jobLanguages = prefs?.jobLanguages ?? [];
-  const languages = resolveJobLanguages(jobLanguages, locale);
-  const displayCurrency = prefs?.displayCurrency ?? "EUR";
+  if (!data) return <ExploreSkeleton />;
 
-  const locationIds = idsOrUndefined(parsed.locations);
-  const occupationIds = idsOrUndefined(parsed.occupations);
-  const seniorityIds = idsOrUndefined(parsed.seniorities);
-  const technologyIds = idsOrUndefined(parsed.technologies);
-
-  const salaryCurrencyParam = salcur ?? displayCurrency;
-  const { min: salaryMinDisplay, max: salaryMaxDisplay } = parseRangeParam(sal);
-  const salaryMinEur = salaryMinDisplay;
-  const salaryMaxEur = salaryMaxDisplay;
-  const { min: experienceMin, max: experienceMax } = parseRangeParam(exp);
-
-  const result =
-    parsed.keywords.length > 0
-      ? await searchJobs({
-          keywords: parsed.keywords,
-          locationIds,
-          occupationIds,
-          seniorityIds,
-          technologyIds,
-          salaryMinEur,
-          salaryMaxEur,
-          experienceMin,
-          experienceMax,
-          languages,
-          locale,
-          offset: 0,
-          limit: PAGE_SIZE,
-        })
-      : await listTopCompanies({
-          locationIds,
-          occupationIds,
-          seniorityIds,
-          technologyIds,
-          salaryMinEur,
-          salaryMaxEur,
-          experienceMin,
-          experienceMax,
-          languages,
-          locale,
-          offset: 0,
-          limit: PAGE_SIZE,
-        });
+  const { result, parsed, displayCurrency, jobLanguages, languages, userLat, userLng, salaryCurrencyParam, salaryMinDisplay, salaryMaxDisplay, experienceMin, experienceMax } = data;
 
   return (
     <SearchPage
       key={`${parsed.keywords.join(",")}-${parsed.locations.map((l) => l.id).join(",")}-${parsed.occupations.map((o) => o.id).join(",")}-${parsed.seniorities.map((s) => s.id).join(",")}-${parsed.technologies.map((t) => t.id).join(",")}`}
       initialCompanies={result.companies}
       initialTotalCompanies={result.totalCompanies}
+      initialTruncated={result.truncated}
       initialKeywords={parsed.keywords}
       initialLocations={parsed.locations}
       initialOccupations={parsed.occupations}

--- a/apps/web/app/[lang]/(app)/explore/page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/page.tsx
@@ -1,9 +1,7 @@
-import { Suspense } from "react";
 import type { Metadata } from "next";
-import { isLocale, defaultLocale, loadCatalog, initI18nForPage } from "@/lib/i18n";
+import { isLocale, defaultLocale, loadCatalog } from "@/lib/i18n";
 import { siteConfig } from "@/content/config";
 import { buildAlternates } from "@/lib/seo";
-import { ExploreSkeleton } from "@/components/search/explore-skeleton";
 import { ExploreContent } from "./explore-content";
 
 type Props = {
@@ -35,13 +33,9 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export default async function AppPage({ params, searchParams }: Props) {
-  const locale = await initI18nForPage(params);
-  const sp = await searchParams;
+export default async function AppPage({ params }: Props) {
+  const { lang } = await params;
+  const locale = isLocale(lang) ? lang : defaultLocale;
 
-  return (
-    <Suspense fallback={<ExploreSkeleton />}>
-      <ExploreContent locale={locale} searchParams={sp} />
-    </Suspense>
-  );
+  return <ExploreContent locale={locale} />;
 }

--- a/apps/web/app/[lang]/(app)/explore/search-page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/search-page.tsx
@@ -24,6 +24,7 @@ type TaxonomyItem = { id: number; slug: string; name: string };
 interface SearchPageProps {
   initialCompanies: SearchResultCompany[];
   initialTotalCompanies: number;
+  initialTruncated?: boolean;
   initialKeywords: string[];
   initialLocations: SelectedLocation[];
   initialOccupations: TaxonomyItem[];
@@ -47,6 +48,7 @@ interface SearchPageProps {
 export function SearchPage({
   initialCompanies,
   initialTotalCompanies,
+  initialTruncated,
   initialKeywords,
   initialLocations,
   initialOccupations,
@@ -130,6 +132,7 @@ export function SearchPage({
     shouldRestore ? cached.totalCompanies : initialTotalCompanies,
   );
   const [isSearching, startSearch] = useTransition();
+  const [isTruncated, setIsTruncated] = useState(initialTruncated ?? false);
 
   // Refs for all filter state — single source of truth for updateUrl/runSearch
   const keywordsRef = useRef(keywords);
@@ -291,7 +294,7 @@ export function SearchPage({
     }
   }, []);
 
-  const hasMore = companies.length < totalCompanies;
+  const hasMore = companies.length < totalCompanies && !isTruncated;
   const hasFilters = keywords.length > 0 || locations.length > 0 || occupations.length > 0 || seniorities.length > 0 || technologies.length > 0 || employmentTypes.length > 0 || salaryMin != null || salaryMax != null || experienceMin != null || experienceMax != null;
 
   /** Sync URL to current ref state. */
@@ -378,6 +381,7 @@ export function SearchPage({
               });
         setCompanies(result.companies);
         setTotalCompanies(result.totalCompanies);
+        setIsTruncated(result.truncated ?? false);
       } catch {
         // Ensure transition ends even on error — keeps existing results visible
       }
@@ -556,6 +560,8 @@ export function SearchPage({
       ? await searchJobs({ keywords: kws, locationIds, occupationIds, seniorityIds, technologyIds, employmentTypes: etypes, salaryMinEur: salMinEur, salaryMaxEur: salMaxEur, experienceMin: expMin, experienceMax: expMax, languages, locale, offset, limit: PAGE_SIZE })
       : await listTopCompanies({ locationIds, occupationIds, seniorityIds, technologyIds, employmentTypes: etypes, salaryMinEur: salMinEur, salaryMaxEur: salMaxEur, experienceMin: expMin, experienceMax: expMax, languages, locale, offset, limit: PAGE_SIZE });
 
+    if (result.truncated) setIsTruncated(true);
+
     setCompanies((prev) => {
       const seen = new Set(prev.map((c) => c.company.id));
       return [...prev, ...result.companies.filter((c) => !seen.has(c.company.id))];
@@ -634,6 +640,7 @@ export function SearchPage({
           experienceMax={experienceMax}
           languages={languages}
           hasMore={hasMore}
+          truncated={isTruncated}
           load={handleLoadMore}
           onShowPosting={handleOpenPosting}
           selectedPostingId={showPostingId}

--- a/apps/web/app/[lang]/(app)/layout.tsx
+++ b/apps/web/app/[lang]/(app)/layout.tsx
@@ -1,25 +1,14 @@
 import type { ReactNode } from "react";
 
-export const dynamic = "force-dynamic";
-
 import { setI18n } from "@lingui/react/server";
-import { getSession } from "@/lib/sessionCache";
 import { isLocale, defaultLocale, loadCatalog, type Locale } from "@/lib/i18n";
 import { LinguiClientProvider } from "@/components/LinguiProvider";
-import { getPreferences } from "@/lib/actions/preferences";
-import { getSavedJobStatuses } from "@/lib/actions/saved-jobs";
-import { getStarredCompanyIds } from "@/lib/actions/starred-companies";
-import { SessionProvider } from "@/components/SessionProvider";
-import { SavedJobsProvider } from "@/components/SavedJobsProvider";
-import { StarredCompaniesProvider } from "@/components/StarredCompaniesProvider";
-import { BannerProvider } from "@/components/BannerProvider";
+import { AppBootstrapProvider } from "@/components/AppBootstrapProvider";
 import { AppHeader } from "@/components/AppHeader";
 import { CookieBanner } from "@/components/CookieBanner";
-import { PreferencesInitializer } from "@/components/PreferencesInitializer";
 import { SearchStateProvider } from "@/components/SearchStateProvider";
 import { UpgradeBanner } from "@/components/UpgradeBanner";
 import { WatchlistTipBanner } from "@/components/watchlist/watchlist-tip-banner";
-import { SalaryDisplayProvider } from "@/components/SalaryDisplayProvider";
 
 type Props = {
   params: Promise<{ lang: string }>;
@@ -31,35 +20,15 @@ export default async function AppLayout({ params, children }: Props) {
   const locale: Locale = isLocale(lang) ? lang : defaultLocale;
   const { i18n, messages } = await loadCatalog(locale);
   setI18n(i18n);
-  const session = await getSession();
-
-  const [prefs, savedStatuses, starredIds] = await Promise.all([
-    session ? getPreferences() : null,
-    session ? getSavedJobStatuses() : [],
-    session ? getStarredCompanyIds() : [],
-  ]);
 
   return (
     <LinguiClientProvider locale={locale} messages={messages}>
-    <SessionProvider user={session?.user ?? null}>
-      <SavedJobsProvider initialStatuses={savedStatuses ?? []}>
-      <StarredCompaniesProvider initialIds={starredIds ?? []}>
+    <AppBootstrapProvider>
       <SearchStateProvider>
-      <SalaryDisplayProvider displayCurrency={prefs?.displayCurrency ?? null} salaryPeriod={prefs?.salaryPeriod ?? null}>
-      <BannerProvider serverDismissed={prefs?.dismissedBanners ?? []}>
         <div className="flex min-h-dvh flex-col">
-          {prefs && (
-            <PreferencesInitializer
-              theme={prefs.theme}
-              themeUpdatedAt={prefs.themeUpdatedAt?.toISOString() ?? null}
-              locale={prefs.locale}
-              localeUpdatedAt={prefs.localeUpdatedAt?.toISOString() ?? null}
-              cookieConsent={prefs.cookieConsent}
-            />
-          )}
           <AppHeader />
           <div className="flex min-h-0 flex-1 flex-col md:pt-12">
-            <CookieBanner aboveBottomBar serverConsent={prefs?.cookieConsent} />
+            <CookieBanner aboveBottomBar />
             <UpgradeBanner aboveBottomBar />
             <WatchlistTipBanner aboveBottomBar />
             <main className="mx-auto w-full max-w-[1200px] px-4 py-8 pb-20 md:pb-8">
@@ -67,12 +36,8 @@ export default async function AppLayout({ params, children }: Props) {
             </main>
           </div>
         </div>
-      </BannerProvider>
-      </SalaryDisplayProvider>
       </SearchStateProvider>
-      </StarredCompaniesProvider>
-      </SavedJobsProvider>
-    </SessionProvider>
+    </AppBootstrapProvider>
     </LinguiClientProvider>
   );
 }

--- a/apps/web/app/[lang]/(app)/my-jobs/my-jobs-loader.tsx
+++ b/apps/web/app/[lang]/(app)/my-jobs/my-jobs-loader.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getMyJobs } from "@/lib/actions/my-jobs";
+import { MyJobsPage } from "./my-jobs-page";
+
+type MyJobsData = Awaited<ReturnType<typeof getMyJobs>>;
+
+export function MyJobsLoader({ locale: _locale }: { locale: string }) {
+  const [data, setData] = useState<MyJobsData | null>(null);
+
+  useEffect(() => {
+    getMyJobs({ offset: 0, limit: 20 }).then(setData);
+  }, []);
+
+  if (!data) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary" />
+      </div>
+    );
+  }
+
+  return <MyJobsPage initialJobs={data.jobs} initialTotal={data.total} />;
+}

--- a/apps/web/app/[lang]/(app)/my-jobs/page.tsx
+++ b/apps/web/app/[lang]/(app)/my-jobs/page.tsx
@@ -1,13 +1,12 @@
-import { initI18nForPage } from "@/lib/i18n";
-import { getMyJobs } from "@/lib/actions/my-jobs";
-import { MyJobsPage } from "./my-jobs-page";
+import { isLocale, defaultLocale } from "@/lib/i18n";
+import { MyJobsLoader } from "./my-jobs-loader";
 
 type Props = {
   params: Promise<{ lang: string }>;
 };
 
 export default async function MyJobsRoute({ params }: Props) {
-  await initI18nForPage(params);
-  const { jobs, total } = await getMyJobs({ offset: 0, limit: 20 });
-  return <MyJobsPage initialJobs={jobs} initialTotal={total} />;
+  const { lang } = await params;
+  const locale = isLocale(lang) ? lang : defaultLocale;
+  return <MyJobsLoader locale={locale} />;
 }

--- a/apps/web/app/[lang]/(app)/my-jobs/stats/page.tsx
+++ b/apps/web/app/[lang]/(app)/my-jobs/stats/page.tsx
@@ -1,13 +1,12 @@
-import { initI18nForPage } from "@/lib/i18n";
-import { getStats } from "@/lib/actions/my-jobs-stats";
-import { StatsPage } from "./stats-page";
+import { isLocale, defaultLocale } from "@/lib/i18n";
+import { StatsLoader } from "./stats-loader";
 
 type Props = {
   params: Promise<{ lang: string }>;
 };
 
 export default async function MyJobsStatsRoute({ params }: Props) {
-  await initI18nForPage(params);
-  const initial = await getStats();
-  return <StatsPage initial={initial} />;
+  const { lang } = await params;
+  const locale = isLocale(lang) ? lang : defaultLocale;
+  return <StatsLoader locale={locale} />;
 }

--- a/apps/web/app/[lang]/(app)/my-jobs/stats/stats-loader.tsx
+++ b/apps/web/app/[lang]/(app)/my-jobs/stats/stats-loader.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getStats, type StatsData } from "@/lib/actions/my-jobs-stats";
+import { StatsPage } from "./stats-page";
+
+export function StatsLoader({ locale: _locale }: { locale: string }) {
+  const [data, setData] = useState<StatsData | null>(null);
+
+  useEffect(() => {
+    getStats().then(setData);
+  }, []);
+
+  if (!data) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary" />
+      </div>
+    );
+  }
+
+  return <StatsPage initial={data} />;
+}

--- a/apps/web/app/[lang]/(app)/progress/page.tsx
+++ b/apps/web/app/[lang]/(app)/progress/page.tsx
@@ -1,9 +1,5 @@
-import { Trans } from "@lingui/react/macro";
-import { Construction, Building2, Briefcase } from "lucide-react";
-import { siteConfig } from "@/content/config";
-import { initI18nForPage } from "@/lib/i18n";
-import { getStats } from "@/lib/actions/stats";
-import { CompanyRequestForm } from "./company-request-form";
+import { isLocale, defaultLocale } from "@/lib/i18n";
+import { ProgressLoader } from "./progress-loader";
 
 type Props = {
   params: Promise<{ lang: string }>;
@@ -11,69 +7,6 @@ type Props = {
 
 export default async function AppPage({ params }: Props) {
   const { lang } = await params;
-  await initI18nForPage(params);
-  const { companyCount, jobPostingCount } = await getStats();
-
-  return (
-    <div className="flex flex-col items-center justify-center py-24 text-center">
-      <Construction className="mb-6 h-16 w-16 text-muted" />
-      <h1 className="text-3xl font-bold">
-        <Trans id="app.home.title" comment="Main app page heading">
-          Under Active Development
-        </Trans>
-      </h1>
-      <p className="mt-4 max-w-md text-muted">
-        <Trans id="app.home.subtitle" comment="Main app page subtitle explaining the app is being built">
-          Job Seek is being actively built. Stay tuned for updates!
-        </Trans>
-      </p>
-
-      <div className="mt-10 flex gap-6">
-        <div className="flex flex-col items-center rounded-md border border-divider bg-surface px-8 py-6">
-          <Building2 className="mb-2 h-6 w-6 text-muted" />
-          <span className="text-3xl font-bold">{companyCount.toLocaleString()}</span>
-          <span className="mt-1 text-sm text-muted">
-            <Trans id="app.home.stats.companies" comment="Label for the company counter on the app home page">
-              Companies Tracked
-            </Trans>
-          </span>
-        </div>
-        <div className="flex flex-col items-center rounded-md border border-divider bg-surface px-8 py-6">
-          <Briefcase className="mb-2 h-6 w-6 text-muted" />
-          <span className="text-3xl font-bold">{jobPostingCount.toLocaleString()}</span>
-          <span className="mt-1 text-sm text-muted">
-            <Trans id="app.home.stats.jobPostings" comment="Label for the job postings counter on the app home page">
-              Job Postings
-            </Trans>
-          </span>
-        </div>
-      </div>
-
-      <div className="mt-10">
-        <h2 className="text-xl font-semibold">
-          <Trans id="app.home.request.heading" comment="Heading above the company request input on the app home page">
-            Which company should we track?
-          </Trans>
-        </h2>
-        <p className="mt-2 max-w-md text-sm text-muted">
-          <Trans id="app.home.request.description" comment="Description below the heading explaining users can request a company">
-            Paste a careers page URL for best results, or just type a company name.
-          </Trans>
-        </p>
-
-        <CompanyRequestForm locale={lang} />
-      </div>
-
-      <a
-        href={siteConfig.social.linkedin.href}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="mt-10 inline-flex items-center justify-center whitespace-nowrap rounded-full font-semibold border border-primary bg-primary text-primary-contrast transition-opacity hover:opacity-90 px-5 py-2"
-      >
-        <Trans id="app.home.followLinkedIn" comment="Link to follow Job Seek on LinkedIn">
-          Follow us on LinkedIn
-        </Trans>
-      </a>
-    </div>
-  );
+  const locale = isLocale(lang) ? lang : defaultLocale;
+  return <ProgressLoader locale={locale} lang={lang} />;
 }

--- a/apps/web/app/[lang]/(app)/progress/progress-loader.tsx
+++ b/apps/web/app/[lang]/(app)/progress/progress-loader.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Trans } from "@lingui/react/macro";
+import { Construction, Building2, Briefcase } from "lucide-react";
+import { siteConfig } from "@/content/config";
+import { getStats } from "@/lib/actions/stats";
+import { CompanyRequestForm } from "./company-request-form";
+
+type StatsData = { companyCount: number; jobPostingCount: number };
+
+export function ProgressLoader({ locale: _locale, lang }: { locale: string; lang: string }) {
+  const [stats, setStats] = useState<StatsData | null>(null);
+
+  useEffect(() => {
+    getStats().then(setStats);
+  }, []);
+
+  return (
+    <div className="flex flex-col items-center justify-center py-24 text-center">
+      <Construction className="mb-6 h-16 w-16 text-muted" />
+      <h1 className="text-3xl font-bold">
+        <Trans id="app.home.title" comment="Main app page heading">
+          Under Active Development
+        </Trans>
+      </h1>
+      <p className="mt-4 max-w-md text-muted">
+        <Trans id="app.home.subtitle" comment="Main app page subtitle explaining the app is being built">
+          Job Seek is being actively built. Stay tuned for updates!
+        </Trans>
+      </p>
+
+      <div className="mt-10 flex gap-6">
+        <div className="flex flex-col items-center rounded-md border border-divider bg-surface px-8 py-6">
+          <Building2 className="mb-2 h-6 w-6 text-muted" />
+          <span className="text-3xl font-bold">{stats ? stats.companyCount.toLocaleString() : "—"}</span>
+          <span className="mt-1 text-sm text-muted">
+            <Trans id="app.home.stats.companies" comment="Label for the company counter on the app home page">
+              Companies Tracked
+            </Trans>
+          </span>
+        </div>
+        <div className="flex flex-col items-center rounded-md border border-divider bg-surface px-8 py-6">
+          <Briefcase className="mb-2 h-6 w-6 text-muted" />
+          <span className="text-3xl font-bold">{stats ? stats.jobPostingCount.toLocaleString() : "—"}</span>
+          <span className="mt-1 text-sm text-muted">
+            <Trans id="app.home.stats.jobPostings" comment="Label for the job postings counter on the app home page">
+              Job Postings
+            </Trans>
+          </span>
+        </div>
+      </div>
+
+      <div className="mt-10">
+        <h2 className="text-xl font-semibold">
+          <Trans id="app.home.request.heading" comment="Heading above the company request input on the app home page">
+            Which company should we track?
+          </Trans>
+        </h2>
+        <p className="mt-2 max-w-md text-sm text-muted">
+          <Trans id="app.home.request.description" comment="Description below the heading explaining users can request a company">
+            Paste a careers page URL for best results, or just type a company name.
+          </Trans>
+        </p>
+
+        <CompanyRequestForm locale={lang} />
+      </div>
+
+      <a
+        href={siteConfig.social.linkedin.href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mt-10 inline-flex items-center justify-center whitespace-nowrap rounded-full font-semibold border border-primary bg-primary text-primary-contrast transition-opacity hover:opacity-90 px-5 py-2"
+      >
+        <Trans id="app.home.followLinkedIn" comment="Link to follow Job Seek on LinkedIn">
+          Follow us on LinkedIn
+        </Trans>
+      </a>
+    </div>
+  );
+}

--- a/apps/web/app/[lang]/(app)/settings/account/account-loader.tsx
+++ b/apps/web/app/[lang]/(app)/settings/account/account-loader.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getAccountPageData } from "@/lib/actions/preferences";
+import { AccountSettings } from "@/components/settings/AccountSettings";
+
+export function AccountLoader({ locale: _locale }: { locale: string }) {
+  const [data, setData] = useState<Awaited<ReturnType<typeof getAccountPageData>> | undefined>(undefined);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    getAccountPageData().then((result) => {
+      setData(result);
+      setLoaded(true);
+    });
+  }, []);
+
+  if (!loaded) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary" />
+      </div>
+    );
+  }
+
+  return <AccountSettings initialData={data} />;
+}

--- a/apps/web/app/[lang]/(app)/settings/account/page.tsx
+++ b/apps/web/app/[lang]/(app)/settings/account/page.tsx
@@ -1,14 +1,12 @@
-import { initI18nForPage } from "@/lib/i18n";
-import { getAccountPageData } from "@/lib/actions/preferences";
-import { AccountSettings } from "@/components/settings/AccountSettings";
+import { isLocale, defaultLocale } from "@/lib/i18n";
+import { AccountLoader } from "./account-loader";
 
 type Props = {
   params: Promise<{ lang: string }>;
 };
 
 export default async function AccountSettingsPage({ params }: Props) {
-  await initI18nForPage(params);
-  const data = await getAccountPageData();
-
-  return <AccountSettings initialData={data} />;
+  const { lang } = await params;
+  const locale = isLocale(lang) ? lang : defaultLocale;
+  return <AccountLoader locale={locale} />;
 }

--- a/apps/web/app/[lang]/(app)/settings/billing/billing-loader.tsx
+++ b/apps/web/app/[lang]/(app)/settings/billing/billing-loader.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getPlanInfo } from "@/lib/actions/billing";
+import { BillingSettings } from "@/components/settings/BillingSettings";
+
+type PlanInfo = Awaited<ReturnType<typeof getPlanInfo>>;
+
+export function BillingLoader({ locale: _locale }: { locale: string }) {
+  const [data, setData] = useState<PlanInfo | null>(null);
+
+  useEffect(() => {
+    getPlanInfo().then(setData);
+  }, []);
+
+  if (!data) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary" />
+      </div>
+    );
+  }
+
+  return <BillingSettings planInfo={data} />;
+}

--- a/apps/web/app/[lang]/(app)/settings/billing/page.tsx
+++ b/apps/web/app/[lang]/(app)/settings/billing/page.tsx
@@ -1,14 +1,12 @@
-import { initI18nForPage } from "@/lib/i18n";
-import { getPlanInfo } from "@/lib/actions/billing";
-import { BillingSettings } from "@/components/settings/BillingSettings";
+import { isLocale, defaultLocale } from "@/lib/i18n";
+import { BillingLoader } from "./billing-loader";
 
 type Props = {
   params: Promise<{ lang: string }>;
 };
 
 export default async function BillingSettingsPage({ params }: Props) {
-  await initI18nForPage(params);
-  const planInfo = await getPlanInfo();
-
-  return <BillingSettings planInfo={planInfo} />;
+  const { lang } = await params;
+  const locale = isLocale(lang) ? lang : defaultLocale;
+  return <BillingLoader locale={locale} />;
 }

--- a/apps/web/app/[lang]/(app)/settings/page.tsx
+++ b/apps/web/app/[lang]/(app)/settings/page.tsx
@@ -1,29 +1,12 @@
-import { initI18nForPage } from "@/lib/i18n";
-import { GeneralSettings } from "@/components/settings/GeneralSettings";
-import { getPreferences, getAvailableJobLanguages } from "@/lib/actions/preferences";
-import { getCurrencyRates } from "@/lib/actions/search";
+import { isLocale, defaultLocale } from "@/lib/i18n";
+import { SettingsLoader } from "./settings-loader";
 
 type Props = {
   params: Promise<{ lang: string }>;
 };
 
 export default async function SettingsPage({ params }: Props) {
-  const locale = await initI18nForPage(params);
-
-  const [prefs, availableLanguages, currencyRates] = await Promise.all([
-    getPreferences(),
-    getAvailableJobLanguages(),
-    getCurrencyRates(),
-  ]);
-
-  return (
-    <GeneralSettings
-      savedJobLanguages={prefs?.jobLanguages ?? []}
-      savedDisplayCurrency={prefs?.displayCurrency ?? "EUR"}
-      savedSalaryPeriod={prefs?.salaryPeriod ?? null}
-      availableCurrencies={currencyRates.map((r) => r.currency)}
-      availableLanguages={availableLanguages}
-      locale={locale}
-    />
-  );
+  const { lang } = await params;
+  const locale = isLocale(lang) ? lang : defaultLocale;
+  return <SettingsLoader locale={locale} />;
 }

--- a/apps/web/app/[lang]/(app)/settings/settings-loader.tsx
+++ b/apps/web/app/[lang]/(app)/settings/settings-loader.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { GeneralSettings } from "@/components/settings/GeneralSettings";
+import { getPreferences, getAvailableJobLanguages, type AvailableLanguage } from "@/lib/actions/preferences";
+import { getCurrencyRates } from "@/lib/actions/search";
+
+type SettingsData = {
+  jobLanguages: string[];
+  displayCurrency: string;
+  salaryPeriod: string | null;
+  availableCurrencies: string[];
+  availableLanguages: AvailableLanguage[];
+};
+
+export function SettingsLoader({ locale }: { locale: string }) {
+  const [data, setData] = useState<SettingsData | null>(null);
+
+  useEffect(() => {
+    Promise.all([getPreferences(), getAvailableJobLanguages(), getCurrencyRates()]).then(
+      ([prefs, availableLanguages, currencyRates]) => {
+        setData({
+          jobLanguages: prefs?.jobLanguages ?? [],
+          displayCurrency: prefs?.displayCurrency ?? "EUR",
+          salaryPeriod: prefs?.salaryPeriod ?? null,
+          availableCurrencies: currencyRates.map((r) => r.currency),
+          availableLanguages,
+        });
+      },
+    );
+  }, []);
+
+  if (!data) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <GeneralSettings
+      savedJobLanguages={data.jobLanguages}
+      savedDisplayCurrency={data.displayCurrency}
+      savedSalaryPeriod={data.salaryPeriod}
+      availableCurrencies={data.availableCurrencies}
+      availableLanguages={data.availableLanguages}
+      locale={locale}
+    />
+  );
+}

--- a/apps/web/app/[lang]/(app)/watchlists/page.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/page.tsx
@@ -1,31 +1,12 @@
-import { initI18nForPage } from "@/lib/i18n";
-import { getUserWatchlists, type WatchlistSummary } from "@/lib/actions/watchlists";
-import { getSession } from "@/lib/sessionCache";
-import { canCreateWatchlist } from "@/lib/plans";
-import { WatchlistsPage } from "./watchlists-page";
+import { isLocale, defaultLocale } from "@/lib/i18n";
+import { WatchlistsLoader } from "./watchlists-loader";
 
 type Props = {
   params: Promise<{ lang: string }>;
 };
 
 export default async function WatchlistsRoute({ params }: Props) {
-  await initI18nForPage(params);
-  const session = await getSession();
-
-  const [watchlists, limit] = session
-    ? await Promise.all([
-        getUserWatchlists(),
-        canCreateWatchlist(session.user.id),
-      ])
-    : [[] as WatchlistSummary[], { allowed: false, current: 0, max: 0 }];
-
-  const username = session?.user?.username ?? null;
-
-  return (
-    <WatchlistsPage
-      initialWatchlists={watchlists}
-      username={username}
-      limitReached={!limit.allowed}
-    />
-  );
+  const { lang } = await params;
+  const locale = isLocale(lang) ? lang : defaultLocale;
+  return <WatchlistsLoader locale={locale} />;
 }

--- a/apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getUserWatchlists, type WatchlistSummary } from "@/lib/actions/watchlists";
+import { useSession } from "@/components/SessionProvider";
+import { WatchlistsPage } from "./watchlists-page";
+
+type WatchlistsData = {
+  watchlists: WatchlistSummary[];
+  username: string | null;
+  limitReached: boolean;
+};
+
+export function WatchlistsLoader({ locale: _locale }: { locale: string }) {
+  const { user, isPending } = useSession();
+  const [data, setData] = useState<WatchlistsData | null>(null);
+
+  useEffect(() => {
+    if (isPending) return;
+    if (!user) {
+      setData({ watchlists: [], username: null, limitReached: true });
+      return;
+    }
+    getUserWatchlists().then((watchlists) => {
+      setData({
+        watchlists,
+        username: user.username ?? null,
+        limitReached: false,
+      });
+    });
+  }, [user, isPending]);
+
+  if (!data) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary" />
+      </div>
+    );
+  }
+
+  return (
+    <WatchlistsPage
+      initialWatchlists={data.watchlists}
+      username={data.username}
+      limitReached={data.limitReached}
+    />
+  );
+}

--- a/apps/web/docs/data-fetching.md
+++ b/apps/web/docs/data-fetching.md
@@ -1,0 +1,144 @@
+# Data Fetching & Anonymous Truncation
+
+## Architecture
+
+The `(app)` route group serves **static page shells from CDN**. All data
+fetching happens client-side via Next.js server actions called on mount.
+
+```
+Browser loads static HTML (CDN)
+  → AppBootstrapProvider calls fetchAppBootstrap() once
+  → Each page's loader component calls its data server action
+  → Server actions execute DB queries, return JSON
+  → Client renders with fetched data
+```
+
+### Why not SSR?
+
+The layout previously used `export const dynamic = "force-dynamic"`, causing
+every page navigation to trigger a full server-side render — 4+ DB queries in
+the layout alone (session, preferences, saved jobs, starred companies), plus
+7-12 per page. This drove high Vercel fluid compute costs.
+
+With client-side fetching:
+- The layout renders once as static HTML, served from CDN (zero compute)
+- `AppBootstrapProvider` fetches user data once on mount via a single
+  server action, and the data persists across navigations (React doesn't
+  unmount layouts)
+- Each page shows a skeleton, then loads data — the server action invocation
+  is much cheaper than a full SSR render (JSON response vs. full React tree)
+
+### Why server actions, not the `/api/v1/*` routes?
+
+The app has two data paths:
+
+| Path | Consumers | Auth | Data shape |
+|------|-----------|------|------------|
+| **Server actions** | UI (client components) | Cookie-based, automatic | Rich (filter state, preferences, geo) |
+| **`/api/v1/*` routes** | External (AI agents, integrations) | None (rate-limited by IP) | Stripped-down (5 companies max, simplified schema) |
+
+Server actions were chosen for the UI because:
+
+1. **Already the data layer** — all business logic (filter parsing, location
+   expansion, preference resolution, caching) lives in server actions. The
+   API routes are thin wrappers that call these same actions.
+2. **Auth for free** — server actions receive request cookies automatically
+   when called from client components. No auth middleware needed.
+3. **Type safety** — end-to-end TypeScript types without manual
+   request/response schemas.
+4. **Richer data** — the UI needs geo sorting, salary conversion, job
+   language preferences, parsed filter state. The API routes intentionally
+   omit this.
+
+Server actions called from client components are POST requests under the
+hood — functionally equivalent to API calls, but with better DX.
+
+## Anonymous Truncation
+
+Unauthenticated users see limited results to prevent data scraping while
+keeping the product usable.
+
+### Limits
+
+| Context | Limit | Constant |
+|---------|-------|----------|
+| Search results (companies) | 15 | `ANON_MAX_COMPANIES` |
+| Company card postings (search page) | 20 | `ANON_MAX_CARD_POSTINGS` |
+| Company detail page postings | 40 | `ANON_MAX_POSTINGS` |
+| Watchlist postings | 20 | `ANON_MAX_WATCHLIST_POSTINGS` |
+
+Constants are in `src/lib/search/constants.ts`.
+
+### Enforcement
+
+Truncation is **enforced server-side** in each server action
+(`searchJobs`, `listTopCompanies`, `loadMorePostings`,
+`getCompanyPostings`, `getWatchlistPostings`). Each checks
+`getSessionUserId()` — if null, caps results at the limit and sets
+`truncated: true` in the response.
+
+The client reads the `truncated` flag and replaces the infinite scroll
+sentinel with a `TruncationPrompt` ("Sign in to see more"). The client-side
+`hasMore` check is a UX optimization — even if bypassed, the server action
+returns empty results.
+
+### Why not restrict filters?
+
+All filters remain available to anonymous users. The protection comes from
+truncation, not filter restriction. With broad results and no fine-grained
+enumeration, each query returns overlapping data. Combined with the existing
+IP rate limiter (30 req/60s), comprehensive scraping is uneconomical.
+
+## Bootstrap Flow
+
+`AppBootstrapProvider` (client component in the layout) calls a single
+`fetchAppBootstrap()` server action on mount:
+
+```
+fetchAppBootstrap()
+  → getSession()          // Redis → DB fallback
+  → if authenticated:
+      Promise.all([
+        getPreferences(),
+        getSavedJobStatuses(),
+        getStarredCompanyIds(),
+      ])
+  → returns { user, prefs, savedStatuses, starredIds }
+```
+
+This replaces the 4 separate SSR fetches that ran on every navigation.
+The data is passed to nested providers (`SessionProvider`,
+`SavedJobsProvider`, `StarredCompaniesProvider`, etc.) and persists
+across page navigations.
+
+### `isPending` state
+
+While the bootstrap fetch is in flight, `SessionProvider` exposes
+`isPending: true`. Auth-dependent components (header avatar, save/star
+buttons, truncation prompt) check this to avoid flashing incorrect UI.
+
+## ISR for SEO
+
+Company and watchlist detail pages use `export const revalidate = 600`
+for `generateMetadata()`. This caches OG tags and page titles for 10
+minutes via ISR, preserving SEO without per-request compute. The page
+body itself is a client component that fetches its own data.
+
+## Page Conversion Pattern
+
+Each page follows this structure:
+
+```
+page.tsx (server component, sync)
+  → resolves locale from params
+  → renders <PageLoader locale={locale} />
+
+page-loader.tsx (client component)
+  → calls server action on mount
+  → shows skeleton while loading
+  → renders existing page component with data
+```
+
+The existing client components (SearchPage, CompanyPage, etc.) are
+unchanged — they still receive initial data as props. The loader is a
+thin bridge that replaces the former SSR data fetch.

--- a/apps/web/src/components/AppBootstrapProvider.tsx
+++ b/apps/web/src/components/AppBootstrapProvider.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import { fetchAppBootstrap, type AppBootstrapData } from "@/lib/actions/bootstrap";
+import { SessionProvider } from "@/components/SessionProvider";
+import { SavedJobsProvider } from "@/components/SavedJobsProvider";
+import { StarredCompaniesProvider } from "@/components/StarredCompaniesProvider";
+import { SalaryDisplayProvider } from "@/components/SalaryDisplayProvider";
+import { BannerProvider } from "@/components/BannerProvider";
+import { PreferencesInitializer } from "@/components/PreferencesInitializer";
+
+export function AppBootstrapProvider({ children }: { children: ReactNode }) {
+  const [data, setData] = useState<AppBootstrapData | null>(null);
+
+  useEffect(() => {
+    fetchAppBootstrap().then(setData);
+  }, []);
+
+  const isPending = data === null;
+  const user = data?.user ?? null;
+  const prefs = data?.prefs;
+
+  return (
+    <SessionProvider user={user} isPending={isPending}>
+      <SavedJobsProvider initialStatuses={data?.savedStatuses}>
+        <StarredCompaniesProvider initialIds={data?.starredIds}>
+          <SalaryDisplayProvider
+            displayCurrency={prefs?.displayCurrency ?? null}
+            salaryPeriod={prefs?.salaryPeriod ?? null}
+          >
+            <BannerProvider serverDismissed={prefs?.dismissedBanners}>
+              {prefs && (
+                <PreferencesInitializer
+                  theme={prefs.theme}
+                  themeUpdatedAt={prefs.themeUpdatedAt ? String(prefs.themeUpdatedAt) : null}
+                  locale={prefs.locale}
+                  localeUpdatedAt={prefs.localeUpdatedAt ? String(prefs.localeUpdatedAt) : null}
+                  cookieConsent={prefs.cookieConsent}
+                />
+              )}
+              {children}
+            </BannerProvider>
+          </SalaryDisplayProvider>
+        </StarredCompaniesProvider>
+      </SavedJobsProvider>
+    </SessionProvider>
+  );
+}

--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -47,7 +47,7 @@ function BottomBarLink({ href, label, children }: { href: string; label: string;
 export function AppHeader() {
   const { t } = useLingui();
   const lp = useLocalePath();
-  const { isLoggedIn, user } = useAuth();
+  const { isLoggedIn, user, isPending } = useAuth();
 
   const appHref = lp(siteConfig.nav.app.href);
 
@@ -68,6 +68,13 @@ export function AppHeader() {
 
   async function handleSignOut() {
     await authClient.signOut();
+    // Manually clear session cookies — better-auth's nextCookies() plugin
+    // uses cookies().set(name, "", {maxAge:0}) which can silently fail in
+    // route handlers, leaving the browser cookie intact.
+    document.cookie = "better-auth.session_token=; Max-Age=0; Path=/";
+    document.cookie = "__Secure-better-auth.session_token=; Max-Age=0; Path=/; Secure";
+    document.cookie = "better-auth.session_data=; Max-Age=0; Path=/";
+    document.cookie = "__Secure-better-auth.session_data=; Max-Age=0; Path=/; Secure";
     window.location.href = lp("/explore");
   }
 
@@ -153,7 +160,9 @@ export function AppHeader() {
 
           {/* Auth area (desktop only) */}
           <div className="hidden items-center md:flex">
-            {isLoggedIn && user ? (
+            {isPending ? (
+              <div className="h-8 w-8 rounded-full bg-muted/30 animate-pulse" />
+            ) : isLoggedIn && user ? (
               <DropdownMenu.Root>
                 <DropdownMenu.Trigger asChild>
                   {avatarButton}
@@ -187,7 +196,12 @@ export function AppHeader() {
           <Settings size={20} />
         </BottomBarLink>
         <span className="flex flex-1">
-          {isLoggedIn && user ? (
+          {isPending ? (
+            <span className="flex flex-1 flex-col items-center gap-0.5 py-1.5">
+              <span className="size-6 rounded-full bg-muted/30 animate-pulse" />
+              <span className="h-3 w-10 rounded bg-muted/30 animate-pulse" />
+            </span>
+          ) : isLoggedIn && user ? (
             <DropdownMenu.Root>
               <DropdownMenu.Trigger asChild>
                 <button className="flex flex-1 flex-col items-center gap-0.5 py-1.5 transition-colors cursor-pointer">

--- a/apps/web/src/components/BannerProvider.tsx
+++ b/apps/web/src/components/BannerProvider.tsx
@@ -17,10 +17,10 @@ const BannerContext = createContext<BannerContextValue>({
 });
 
 export function BannerProvider({
-  serverDismissed,
+  serverDismissed = [],
   children,
 }: {
-  serverDismissed: string[];
+  serverDismissed?: string[];
   children: ReactNode;
 }) {
   const [dismissedBanners] = useState(() => {

--- a/apps/web/src/components/SalaryDisplayProvider.tsx
+++ b/apps/web/src/components/SalaryDisplayProvider.tsx
@@ -22,12 +22,12 @@ const SalaryDisplayContext = createContext<SalaryDisplayContextValue>({
 });
 
 export function SalaryDisplayProvider({
-  displayCurrency: initialCurrency,
-  salaryPeriod: initialPeriod,
+  displayCurrency: initialCurrency = null,
+  salaryPeriod: initialPeriod = null,
   children,
 }: {
-  displayCurrency: string | null;
-  salaryPeriod: string | null;
+  displayCurrency?: string | null;
+  salaryPeriod?: string | null;
   children: ReactNode;
 }) {
   const [rates, setRates] = useState<CurrencyRate[]>([]);

--- a/apps/web/src/components/SavedJobsProvider.tsx
+++ b/apps/web/src/components/SavedJobsProvider.tsx
@@ -36,10 +36,10 @@ const SavedJobsContext = createContext<SavedJobsContextValue>({
 });
 
 export function SavedJobsProvider({
-  initialStatuses,
+  initialStatuses = [],
   children,
 }: {
-  initialStatuses: SavedJobStatus[];
+  initialStatuses?: SavedJobStatus[];
   children: ReactNode;
 }) {
   const [infoMap, setInfoMap] = useState(

--- a/apps/web/src/components/SessionProvider.tsx
+++ b/apps/web/src/components/SessionProvider.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, type ReactNode } from "react";
 
-type SessionUser = {
+export type SessionUser = {
   id: string;
   email: string;
   name: string;
@@ -15,22 +15,26 @@ type SessionUser = {
 type SessionContextValue = {
   user: SessionUser | null;
   isLoggedIn: boolean;
+  isPending: boolean;
 };
 
 const SessionContext = createContext<SessionContextValue>({
   user: null,
   isLoggedIn: false,
+  isPending: true,
 });
 
 export function SessionProvider({
   user,
+  isPending = false,
   children,
 }: {
   user: SessionUser | null;
+  isPending?: boolean;
   children: ReactNode;
 }) {
   return (
-    <SessionContext.Provider value={{ user, isLoggedIn: Boolean(user) }}>
+    <SessionContext.Provider value={{ user, isLoggedIn: Boolean(user), isPending }}>
       {children}
     </SessionContext.Provider>
   );

--- a/apps/web/src/components/StarredCompaniesProvider.tsx
+++ b/apps/web/src/components/StarredCompaniesProvider.tsx
@@ -26,10 +26,10 @@ const StarredCompaniesContext = createContext<StarredCompaniesContextValue>({
 });
 
 export function StarredCompaniesProvider({
-  initialIds,
+  initialIds = [],
   children,
 }: {
-  initialIds: string[];
+  initialIds?: string[];
   children: ReactNode;
 }) {
   const [starredIdSet, setStarredIdSet] = useState(() => new Set(initialIds));

--- a/apps/web/src/components/TruncationPrompt.tsx
+++ b/apps/web/src/components/TruncationPrompt.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Trans } from "@lingui/react/macro";
+import { useParams } from "next/navigation";
+import { useSession } from "@/components/SessionProvider";
+
+export function TruncationPrompt({ type }: { type: "companies" | "postings" }) {
+  const { isPending } = useSession();
+  const params = useParams();
+  const lang = (params.lang as string) ?? "en";
+
+  if (isPending) return null;
+
+  return (
+    <div className="py-4">
+      <div className="flex items-center gap-3">
+        <div className="h-px flex-1 bg-divider" />
+        <a
+          href={`/${lang}/sign-in`}
+          className="whitespace-nowrap rounded-full border border-primary bg-primary px-4 py-1.5 text-xs font-semibold text-primary-contrast transition-opacity hover:opacity-90"
+        >
+          {type === "companies" ? (
+            <Trans
+              id="truncation.companies.title"
+              comment="Prompt shown when anonymous user hits the company pagination limit"
+            >
+              Sign in to see more companies
+            </Trans>
+          ) : (
+            <Trans
+              id="truncation.postings.title"
+              comment="Prompt shown when anonymous user hits the posting pagination limit"
+            >
+              Sign in to see more job postings
+            </Trans>
+          )}
+        </a>
+        <div className="h-px flex-1 bg-divider" />
+      </div>
+      <p className="mt-3 text-center text-xs text-muted">
+        <Trans
+          id="truncation.benefits"
+          comment="Description of benefits shown below the sign-in prompt for anonymous users"
+        >
+          Create a free account to browse all results, save jobs, track applications, build watchlists, and get alerts for new openings.
+        </Trans>
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/search/company-card.tsx
+++ b/apps/web/src/components/search/company-card.tsx
@@ -10,6 +10,7 @@ import { timeAgoShort } from "@/lib/time";
 import { loadMorePostings } from "@/lib/actions/search";
 import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
 import { InfiniteScrollSentinel } from "@/components/InfiniteScrollSentinel";
+import { TruncationPrompt } from "@/components/TruncationPrompt";
 import { TrackingDot } from "@/components/TrackingDot";
 import { PendingJobIcon } from "@/components/PendingJobWarning";
 import { SaveButton } from "@/components/search/save-button";
@@ -55,6 +56,7 @@ export function CompanyCard({ result, keywords, locationIds, locations, occupati
 
   const [extraPostings, setExtraPostings] = useState<SearchResultPosting[]>([]);
   const [exhausted, setExhausted] = useState(false);
+  const [isTruncated, setIsTruncated] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   const allPostings = useMemo(() => {
@@ -66,11 +68,11 @@ export function CompanyCard({ result, keywords, locationIds, locations, occupati
     });
   }, [result.postings, extraPostings]);
 
-  const hasMore = !exhausted && allPostings.length < yearMatches;
+  const hasMore = !exhausted && !isTruncated && allPostings.length < yearMatches;
   const offsetRef = useRef(result.postings.length);
 
   async function handleLoadMore() {
-    const more = await loadMorePostings({
+    const result = await loadMorePostings({
       companyId: company.id,
       keywords,
       locationIds,
@@ -87,11 +89,12 @@ export function CompanyCard({ result, keywords, locationIds, locations, occupati
       offset: offsetRef.current,
       limit: POSTINGS_BATCH,
     });
-    offsetRef.current += more.length;
-    if (more.length > 0) {
-      setExtraPostings((prev) => [...prev, ...more]);
+    if (result.truncated) setIsTruncated(true);
+    offsetRef.current += result.postings.length;
+    if (result.postings.length > 0) {
+      setExtraPostings((prev) => [...prev, ...result.postings]);
     }
-    if (more.length < POSTINGS_BATCH) {
+    if (result.postings.length < POSTINGS_BATCH) {
       setExhausted(true);
     }
   }
@@ -165,6 +168,7 @@ export function CompanyCard({ result, keywords, locationIds, locations, occupati
           </div>
         ))}
         {hasMore && <InfiniteScrollSentinel sentinelRef={sentinelRef} isLoading={isLoading} size="sm" />}
+        {!hasMore && isTruncated && <TruncationPrompt type="postings" />}
       </div>
     </div>
   );

--- a/apps/web/src/components/search/save-button.tsx
+++ b/apps/web/src/components/search/save-button.tsx
@@ -10,7 +10,7 @@ import { tooltipClass } from "@/components/ui/tooltip-styles";
 
 export function SaveButton({ postingId }: { postingId: string }) {
   const { t } = useLingui();
-  const { isLoggedIn } = useAuth();
+  const { isLoggedIn, isPending } = useAuth();
   const lp = useLocalePath();
   const { isSaved, toggle, isToggling } = useSavedJobs();
 
@@ -23,6 +23,7 @@ export function SaveButton({ postingId }: { postingId: string }) {
 
   function handleClick(e: React.MouseEvent) {
     e.stopPropagation();
+    if (isPending) return;
     if (!isLoggedIn) {
       window.location.href = lp("/sign-in");
       return;

--- a/apps/web/src/components/search/search-results.tsx
+++ b/apps/web/src/components/search/search-results.tsx
@@ -3,6 +3,7 @@
 import { CompanyCard } from "./company-card";
 import { RequestCompanyPrompt } from "./request-company";
 import { InfiniteScrollSentinel } from "@/components/InfiniteScrollSentinel";
+import { TruncationPrompt } from "@/components/TruncationPrompt";
 import type { SearchResultCompany } from "@/lib/search";
 import type { SerializableLocation, SerializableOccupation, SerializableSeniority, SerializableTechnology } from "@/lib/search/query-params";
 import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
@@ -22,6 +23,7 @@ interface SearchResultsProps {
   experienceMax?: number;
   languages?: string[];
   hasMore: boolean;
+  truncated?: boolean;
   load: () => Promise<void>;
   onShowPosting?: (postingId: string) => void;
   selectedPostingId?: string | null;
@@ -42,6 +44,7 @@ export function SearchResults({
   experienceMax,
   languages,
   hasMore,
+  truncated,
   load,
   onShowPosting,
   selectedPostingId,
@@ -56,7 +59,8 @@ export function SearchResults({
         </div>
       ))}
       {hasMore && <InfiniteScrollSentinel sentinelRef={sentinelRef} isLoading={isLoading} />}
-      {!hasMore && <RequestCompanyPrompt />}
+      {!hasMore && truncated && <TruncationPrompt type="companies" />}
+      {!hasMore && !truncated && <RequestCompanyPrompt />}
     </div>
   );
 }

--- a/apps/web/src/components/search/star-button.tsx
+++ b/apps/web/src/components/search/star-button.tsx
@@ -8,7 +8,7 @@ import { useStarredCompanies } from "@/components/StarredCompaniesProvider";
 
 export function StarButton({ companyId }: { companyId: string }) {
   const { t } = useLingui();
-  const { isLoggedIn } = useAuth();
+  const { isLoggedIn, isPending } = useAuth();
   const lp = useLocalePath();
   const { isStarred, toggle, isToggling } = useStarredCompanies();
 
@@ -22,6 +22,7 @@ export function StarButton({ companyId }: { companyId: string }) {
   function handleClick(e: React.MouseEvent) {
     e.stopPropagation();
     e.preventDefault();
+    if (isPending) return;
     if (!isLoggedIn) {
       window.location.href = lp("/sign-in");
       return;

--- a/apps/web/src/components/watchlist/watchlist-job-list.tsx
+++ b/apps/web/src/components/watchlist/watchlist-job-list.tsx
@@ -13,6 +13,7 @@ import { useSavedJobs } from "@/components/SavedJobsProvider";
 import { JobDetailPanel } from "@/components/search/job-detail-dialog";
 import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
 import { InfiniteScrollSentinel } from "@/components/InfiniteScrollSentinel";
+import { TruncationPrompt } from "@/components/TruncationPrompt";
 import { TrackingDot } from "@/components/TrackingDot";
 import { PendingJobIcon } from "@/components/PendingJobWarning";
 
@@ -69,6 +70,7 @@ export function WatchlistJobList({
   const [postings, setPostings] = useState(initialPostings);
   const [total, setTotal] = useState(initialTotal);
   const [exhausted, setExhausted] = useState(initialPostings.length >= initialTotal);
+  const [isTruncated, setIsTruncated] = useState(false);
   const [showPostingId, setShowPostingId] = useState<string | null>(null);
   const filtersRef = useRef(filters);
   filtersRef.current = filters;
@@ -82,30 +84,33 @@ export function WatchlistJobList({
   // Re-fetch when filters change
   useEffect(() => {
     getWatchlistPostings({ ...filters, offset: 0, limit: BATCH })
-      .then(({ postings: p, total: t }) => {
+      .then(({ postings: p, total: t, truncated }) => {
         setPostings(p);
         setTotal(t);
         setExhausted(p.length >= t);
+        setIsTruncated(truncated ?? false);
       });
   }, [filtersKey]);
 
   async function handleLoadMore() {
-    const { postings: more, total: newTotal } = await getWatchlistPostings({
+    const result = await getWatchlistPostings({
       ...filtersRef.current,
       offset: postings.length,
       limit: BATCH,
     });
-    setTotal(newTotal);
-    if (more.length > 0) {
+    if (result.truncated) setIsTruncated(true);
+    setTotal(result.total);
+    if (result.postings.length > 0) {
       setPostings((prev) => {
         const seen = new Set(prev.map((p) => p.id));
-        return [...prev, ...more.filter((p) => !seen.has(p.id))];
+        return [...prev, ...result.postings.filter((p) => !seen.has(p.id))];
       });
     }
-    if (more.length < BATCH) setExhausted(true);
+    if (result.postings.length < BATCH) setExhausted(true);
   }
 
-  const { sentinelRef, isLoading } = useInfiniteScroll({ hasMore: !exhausted, load: handleLoadMore });
+  const hasMore = !exhausted && !isTruncated;
+  const { sentinelRef, isLoading } = useInfiniteScroll({ hasMore, load: handleLoadMore });
 
   function handleOpenPosting(postingId: string) {
     setShowPostingId(postingId);
@@ -224,7 +229,8 @@ export function WatchlistJobList({
           </div>
         )}
 
-        {!exhausted && <InfiniteScrollSentinel sentinelRef={sentinelRef} isLoading={isLoading} />}
+        {hasMore && <InfiniteScrollSentinel sentinelRef={sentinelRef} isLoading={isLoading} />}
+        {!hasMore && isTruncated && <TruncationPrompt type="postings" />}
       </div>
     </div>
   );

--- a/apps/web/src/lib/__tests__/useAuth.test.ts
+++ b/apps/web/src/lib/__tests__/useAuth.test.ts
@@ -12,7 +12,7 @@ import { useAuth } from "../useAuth";
 describe("useAuth", () => {
   it("returns logged in state when user exists", () => {
     const user = { id: "1", email: "a@b.com", name: "A", emailVerified: true };
-    mockUseSession.mockReturnValue({ user, isLoggedIn: true });
+    mockUseSession.mockReturnValue({ user, isLoggedIn: true, isPending: false });
 
     const { result } = renderHook(() => useAuth());
     expect(result.current.isLoggedIn).toBe(true);
@@ -21,7 +21,7 @@ describe("useAuth", () => {
   });
 
   it("returns logged out state when no user", () => {
-    mockUseSession.mockReturnValue({ user: null, isLoggedIn: false });
+    mockUseSession.mockReturnValue({ user: null, isLoggedIn: false, isPending: false });
 
     const { result } = renderHook(() => useAuth());
     expect(result.current.isLoggedIn).toBe(false);

--- a/apps/web/src/lib/actions/bootstrap.ts
+++ b/apps/web/src/lib/actions/bootstrap.ts
@@ -1,0 +1,55 @@
+"use server";
+
+import { getSession } from "@/lib/sessionCache";
+import { getPreferences } from "@/lib/actions/preferences";
+import { getSavedJobStatuses, type SavedJobStatus } from "@/lib/actions/saved-jobs";
+import { getStarredCompanyIds } from "@/lib/actions/starred-companies";
+
+export type SessionUser = {
+  id: string;
+  email: string;
+  name: string;
+  image?: string | null;
+  emailVerified: boolean;
+  username?: string | null;
+  displayUsername?: string | null;
+};
+
+export type AppPreferences = {
+  theme?: "light" | "dark";
+  themeUpdatedAt?: Date | null;
+  locale?: string;
+  localeUpdatedAt?: Date | null;
+  cookieConsent?: boolean;
+  displayCurrency?: string;
+  salaryPeriod?: string | null;
+  dismissedBanners?: string[];
+  jobLanguages?: string[];
+};
+
+export type AppBootstrapData = {
+  user: SessionUser | null;
+  prefs: AppPreferences | null;
+  savedStatuses: SavedJobStatus[];
+  starredIds: string[];
+};
+
+export async function fetchAppBootstrap(): Promise<AppBootstrapData> {
+  const session = await getSession();
+  if (!session) {
+    return { user: null, prefs: null, savedStatuses: [], starredIds: [] };
+  }
+
+  const [prefs, savedStatuses, starredIds] = await Promise.all([
+    getPreferences(),
+    getSavedJobStatuses(),
+    getStarredCompanyIds(),
+  ]);
+
+  return {
+    user: session.user as SessionUser,
+    prefs: prefs as AppPreferences | null,
+    savedStatuses,
+    starredIds,
+  };
+}

--- a/apps/web/src/lib/actions/company-page-data.ts
+++ b/apps/web/src/lib/actions/company-page-data.ts
@@ -1,0 +1,110 @@
+"use server";
+
+import { getCompanyBySlug, getCompanyPostings, type CompanyDetail } from "@/lib/actions/company";
+import { parseSearchFilters, type ParsedSearchFilters } from "@/lib/actions/search-input";
+import { getPreferences } from "@/lib/actions/preferences";
+import { resolveJobLanguages } from "@/lib/job-languages";
+import { firstOf, idsOrUndefined, parseRangeParam, getGeoFromHeaders } from "@/lib/search/params";
+import type { SearchResultPosting } from "@/lib/search";
+
+const PAGE_SIZE = 20;
+
+export interface CompanyPageData {
+  company: CompanyDetail;
+  postings: SearchResultPosting[];
+  activeCount: number;
+  yearCount: number;
+  truncated?: boolean;
+  parsed: ParsedSearchFilters;
+  displayCurrency: string;
+  jobLanguages: string[];
+  languages: string[];
+  userLat: number | undefined;
+  userLng: number | undefined;
+  salaryCurrencyParam: string;
+  salaryMinDisplay: number | undefined;
+  salaryMaxDisplay: number | undefined;
+  experienceMin: number | undefined;
+  experienceMax: number | undefined;
+  showPostingId: string | null;
+}
+
+export async function fetchCompanyPageData(params: {
+  slug: string;
+  searchParams: Record<string, string | string[] | undefined>;
+  locale: string;
+}): Promise<CompanyPageData | null> {
+  const { slug, searchParams, locale } = params;
+
+  const company = await getCompanyBySlug(slug, locale);
+  if (!company) return null;
+
+  const q = firstOf(searchParams.q);
+  const loc = firstOf(searchParams.loc);
+  const occ = firstOf(searchParams.occ);
+  const sen = firstOf(searchParams.sen);
+  const tech = firstOf(searchParams.tech);
+  const show = firstOf(searchParams.show);
+  const sal = firstOf(searchParams.sal);
+  const salcur = firstOf(searchParams.salcur);
+  const exp = firstOf(searchParams.exp);
+
+  const { userLat, userLng } = await getGeoFromHeaders();
+
+  const [parsed, prefs] = await Promise.all([
+    parseSearchFilters({ q, loc, occ, sen, tech, locale, userLat, userLng }),
+    getPreferences(),
+  ]);
+
+  const jobLanguages = prefs?.jobLanguages ?? [];
+  const languages = resolveJobLanguages(jobLanguages, locale);
+  const displayCurrency = prefs?.displayCurrency ?? "EUR";
+
+  const locationIds = idsOrUndefined(parsed.locations);
+  const occupationIds = idsOrUndefined(parsed.occupations);
+  const seniorityIds = idsOrUndefined(parsed.seniorities);
+  const technologyIds = idsOrUndefined(parsed.technologies);
+
+  const salaryCurrencyParam = salcur ?? displayCurrency;
+  const { min: salaryMinDisplay, max: salaryMaxDisplay } = parseRangeParam(sal);
+  const salaryMinEur = salaryMinDisplay;
+  const salaryMaxEur = salaryMaxDisplay;
+  const { min: experienceMin, max: experienceMax } = parseRangeParam(exp);
+
+  const postingsResult = await getCompanyPostings({
+    companyId: company.id,
+    keywords: parsed.keywords,
+    locationIds,
+    occupationIds,
+    seniorityIds,
+    technologyIds,
+    salaryMinEur,
+    salaryMaxEur,
+    experienceMin,
+    experienceMax,
+    languages,
+    locale,
+    offset: 0,
+    limit: PAGE_SIZE,
+  });
+
+  return {
+    company,
+    postings: postingsResult.postings,
+    activeCount: postingsResult.activeCount,
+    yearCount: postingsResult.yearCount,
+    truncated: postingsResult.truncated,
+    parsed,
+    displayCurrency,
+    jobLanguages,
+    languages,
+    userLat,
+    userLng,
+    salaryCurrencyParam,
+    salaryMinDisplay,
+    salaryMaxDisplay,
+    experienceMin,
+    experienceMax,
+    showPostingId: show ?? null,
+  };
+}

--- a/apps/web/src/lib/actions/company.ts
+++ b/apps/web/src/lib/actions/company.ts
@@ -5,8 +5,10 @@ import { db } from "@/db";
 import { getSearchProvider } from "@/lib/search";
 import type { SearchResultPosting } from "@/lib/search";
 import { cached } from "@/lib/cache";
+import { getSessionUserId } from "@/lib/sessionCache";
 import { expandLocationIds } from "@/lib/actions/locations";
 import { expandOccupationIds } from "@/lib/actions/taxonomy";
+import { ANON_MAX_POSTINGS } from "@/lib/search/constants";
 
 // ── Company suggestions (search bar autocomplete) ───────────────────
 
@@ -362,7 +364,13 @@ export async function getCompanyPostings(params: {
   locale: string;
   offset: number;
   limit: number;
-}): Promise<{ postings: SearchResultPosting[]; activeCount: number; yearCount: number }> {
+}): Promise<{ postings: SearchResultPosting[]; activeCount: number; yearCount: number; truncated?: boolean }> {
+  const userId = await getSessionUserId();
+
+  if (!userId && params.offset >= ANON_MAX_POSTINGS) {
+    return { postings: [], activeCount: 0, yearCount: 0, truncated: true };
+  }
+
   const sortedKw = [...params.keywords].sort();
   const sortedLoc = [...(params.locationIds ?? [])].sort();
   const sortedOcc = [...(params.occupationIds ?? [])].sort();
@@ -371,7 +379,7 @@ export async function getCompanyPostings(params: {
   const sortedEtype = [...(params.employmentTypes ?? [])].sort();
   const sortedLangs = [...params.languages].sort();
   const key = `company-postings:${params.companyId}:${sortedKw.join(",")}:${sortedLoc.join(",")}:${sortedOcc.join(",")}:${sortedSen.join(",")}:${sortedTech.join(",")}:${sortedEtype.join(",")}:${sortedLangs.join(",")}:${params.salaryMinEur ?? ""}:${params.salaryMaxEur ?? ""}:${params.experienceMin ?? ""}:${params.experienceMax ?? ""}:${params.locale}:${params.offset}:${params.limit}`;
-  return cached(
+  const result = await cached(
     key,
     async () => {
       const [expandedLocs, expandedOccs] = await Promise.all([
@@ -382,6 +390,12 @@ export async function getCompanyPostings(params: {
     },
     { ttl: 300 },
   );
+
+  if (!userId && params.offset + result.postings.length >= ANON_MAX_POSTINGS) {
+    return { ...result, truncated: true };
+  }
+
+  return result;
 }
 
 // ── Top locations for a company ─────────────────────────────────────

--- a/apps/web/src/lib/actions/explore-data.ts
+++ b/apps/web/src/lib/actions/explore-data.ts
@@ -1,0 +1,110 @@
+"use server";
+
+import { searchJobs, listTopCompanies } from "@/lib/actions/search";
+import { parseSearchFilters, type ParsedSearchFilters } from "@/lib/actions/search-input";
+import { getPreferences } from "@/lib/actions/preferences";
+import { resolveJobLanguages } from "@/lib/job-languages";
+import { firstOf, idsOrUndefined, parseRangeParam, getGeoFromHeaders } from "@/lib/search/params";
+import type { SearchResponse } from "@/lib/search";
+
+const PAGE_SIZE = 10;
+
+export interface ExploreData {
+  result: SearchResponse;
+  parsed: ParsedSearchFilters;
+  displayCurrency: string;
+  jobLanguages: string[];
+  languages: string[];
+  userLat: number | undefined;
+  userLng: number | undefined;
+  salaryCurrencyParam: string;
+  salaryMinDisplay: number | undefined;
+  salaryMaxDisplay: number | undefined;
+  experienceMin: number | undefined;
+  experienceMax: number | undefined;
+}
+
+export async function fetchExploreData(params: {
+  searchParams: Record<string, string | string[] | undefined>;
+  locale: string;
+}): Promise<ExploreData> {
+  const { searchParams, locale } = params;
+
+  const q = firstOf(searchParams.q);
+  const loc = firstOf(searchParams.loc);
+  const occ = firstOf(searchParams.occ);
+  const sen = firstOf(searchParams.sen);
+  const tech = firstOf(searchParams.tech);
+  const sal = firstOf(searchParams.sal);
+  const salcur = firstOf(searchParams.salcur);
+  const exp = firstOf(searchParams.exp);
+
+  const { userLat, userLng } = await getGeoFromHeaders();
+
+  const [parsed, prefs] = await Promise.all([
+    parseSearchFilters({ q, loc, occ, sen, tech, locale, userLat, userLng }),
+    getPreferences(),
+  ]);
+
+  const jobLanguages = prefs?.jobLanguages ?? [];
+  const languages = resolveJobLanguages(jobLanguages, locale);
+  const displayCurrency = prefs?.displayCurrency ?? "EUR";
+
+  const locationIds = idsOrUndefined(parsed.locations);
+  const occupationIds = idsOrUndefined(parsed.occupations);
+  const seniorityIds = idsOrUndefined(parsed.seniorities);
+  const technologyIds = idsOrUndefined(parsed.technologies);
+
+  const salaryCurrencyParam = salcur ?? displayCurrency;
+  const { min: salaryMinDisplay, max: salaryMaxDisplay } = parseRangeParam(sal);
+  const salaryMinEur = salaryMinDisplay;
+  const salaryMaxEur = salaryMaxDisplay;
+  const { min: experienceMin, max: experienceMax } = parseRangeParam(exp);
+
+  const result =
+    parsed.keywords.length > 0
+      ? await searchJobs({
+          keywords: parsed.keywords,
+          locationIds,
+          occupationIds,
+          seniorityIds,
+          technologyIds,
+          salaryMinEur,
+          salaryMaxEur,
+          experienceMin,
+          experienceMax,
+          languages,
+          locale,
+          offset: 0,
+          limit: PAGE_SIZE,
+        })
+      : await listTopCompanies({
+          locationIds,
+          occupationIds,
+          seniorityIds,
+          technologyIds,
+          salaryMinEur,
+          salaryMaxEur,
+          experienceMin,
+          experienceMax,
+          languages,
+          locale,
+          offset: 0,
+          limit: PAGE_SIZE,
+        });
+
+  return {
+    result,
+    parsed,
+    displayCurrency,
+    jobLanguages,
+    languages,
+    userLat,
+    userLng,
+    salaryCurrencyParam,
+    salaryMinDisplay,
+    salaryMaxDisplay,
+    experienceMin,
+    experienceMax,
+  };
+}

--- a/apps/web/src/lib/actions/search.ts
+++ b/apps/web/src/lib/actions/search.ts
@@ -5,8 +5,10 @@ import { db } from "@/db";
 import { getSearchProvider } from "@/lib/search";
 import type { SearchResponse, SearchResultPosting, HistogramFilters } from "@/lib/search";
 import { cached } from "@/lib/cache";
+import { getSessionUserId } from "@/lib/sessionCache";
 import { expandLocationIds } from "@/lib/actions/locations";
 import { expandOccupationIds } from "@/lib/actions/taxonomy";
+import { ANON_MAX_COMPANIES, ANON_MAX_CARD_POSTINGS } from "@/lib/search/constants";
 
 // ── Posting detail ──────────────────────────────────────────────────
 
@@ -229,6 +231,13 @@ export async function searchJobs(params: {
   offset: number;
   limit: number;
 }): Promise<SearchResponse> {
+  const userId = await getSessionUserId();
+
+  // Enforce truncation for unauthenticated users
+  if (!userId && params.offset >= ANON_MAX_COMPANIES) {
+    return { companies: [], totalCompanies: 0, truncated: true };
+  }
+
   const sortedKw = [...params.keywords].sort();
   const sortedLoc = [...(params.locationIds ?? [])].sort();
   const sortedOcc = [...(params.occupationIds ?? [])].sort();
@@ -239,7 +248,7 @@ export async function searchJobs(params: {
   const salKey = `${params.salaryMinEur ?? ""}:${params.salaryMaxEur ?? ""}`;
   const expKey = `${params.experienceMax ?? ""}`;
   const key = `search:${sortedKw.join(",")}:${sortedLoc.join(",")}:${sortedOcc.join(",")}:${sortedSen.join(",")}:${sortedTech}:${sortedEtype}:${sortedLangs.join(",")}:${salKey}:${expKey}:${params.locale}:${params.offset}:${params.limit}`;
-  return cached(
+  const result = await cached(
     key,
     async () => {
       const [expandedLocs, expandedOccs] = await Promise.all([
@@ -250,6 +259,13 @@ export async function searchJobs(params: {
     },
     { ttl: 300 },
   );
+
+  // Mark as truncated if this is the last allowed page for anon
+  if (!userId && params.offset + result.companies.length >= ANON_MAX_COMPANIES) {
+    return { ...result, truncated: true };
+  }
+
+  return result;
 }
 
 export async function listTopCompanies(params: {
@@ -267,6 +283,12 @@ export async function listTopCompanies(params: {
   offset: number;
   limit: number;
 }): Promise<SearchResponse> {
+  const userId = await getSessionUserId();
+
+  if (!userId && params.offset >= ANON_MAX_COMPANIES) {
+    return { companies: [], totalCompanies: 0, truncated: true };
+  }
+
   const sortedLoc = [...(params.locationIds ?? [])].sort();
   const sortedOcc = [...(params.occupationIds ?? [])].sort();
   const sortedSen = [...(params.seniorityIds ?? [])].sort();
@@ -276,7 +298,7 @@ export async function listTopCompanies(params: {
   const salKey = `${params.salaryMinEur ?? ""}:${params.salaryMaxEur ?? ""}`;
   const expKey = `${params.experienceMax ?? ""}`;
   const key = `top-companies:${sortedLoc.join(",")}:${sortedOcc.join(",")}:${sortedSen.join(",")}:${sortedTech}:${sortedEtype}:${sortedLangs.join(",")}:${salKey}:${expKey}:${params.locale}:${params.offset}:${params.limit}`;
-  return cached(
+  const result = await cached(
     key,
     async () => {
       const [expandedLocs, expandedOccs] = await Promise.all([
@@ -287,6 +309,12 @@ export async function listTopCompanies(params: {
     },
     { ttl: 600 },
   );
+
+  if (!userId && params.offset + result.companies.length >= ANON_MAX_COMPANIES) {
+    return { ...result, truncated: true };
+  }
+
+  return result;
 }
 
 // ── Currency rates for salary filter ────────────────────────────────
@@ -414,7 +442,13 @@ export async function loadMorePostings(params: {
   locale: string;
   offset: number;
   limit: number;
-}): Promise<SearchResultPosting[]> {
+}): Promise<{ postings: SearchResultPosting[]; truncated?: boolean }> {
+  const userId = await getSessionUserId();
+
+  if (!userId && params.offset >= ANON_MAX_CARD_POSTINGS) {
+    return { postings: [], truncated: true };
+  }
+
   const sortedKw = [...params.keywords].sort();
   const sortedLoc = [...(params.locationIds ?? [])].sort();
   const sortedOcc = [...(params.occupationIds ?? [])].sort();
@@ -424,7 +458,7 @@ export async function loadMorePostings(params: {
   const salKey = `${params.salaryMinEur ?? ""}:${params.salaryMaxEur ?? ""}`;
   const expKey = `${params.experienceMin ?? ""}:${params.experienceMax ?? ""}`;
   const key = `postings:${params.companyId}:${sortedKw.join(",")}:${sortedLoc.join(",")}:${sortedOcc.join(",")}:${sortedSen.join(",")}:${sortedTech}:${sortedLangs.join(",")}:${salKey}:${expKey}:${params.locale}:${params.offset}:${params.limit}`;
-  return cached(
+  const postings = await cached(
     key,
     async () => {
       const [expandedLocs, expandedOccs] = await Promise.all([
@@ -435,4 +469,10 @@ export async function loadMorePostings(params: {
     },
     { ttl: 300 },
   );
+
+  if (!userId && params.offset + postings.length >= ANON_MAX_CARD_POSTINGS) {
+    return { postings, truncated: true };
+  }
+
+  return { postings };
 }

--- a/apps/web/src/lib/actions/watchlist-page-data.ts
+++ b/apps/web/src/lib/actions/watchlist-page-data.ts
@@ -1,0 +1,108 @@
+"use server";
+
+import {
+  getWatchlistByUserAndSlug,
+  getWatchlistPostings,
+} from "@/lib/actions/watchlists";
+import { getSession } from "@/lib/sessionCache";
+import { getUserPlan, PLAN_LIMITS, canCreateWatchlist } from "@/lib/plans";
+import { resolveLocationSlugs } from "@/lib/actions/locations";
+import { resolveOccupationSlugs, resolveSenioritySlugs, resolveTechnologySlugs } from "@/lib/actions/taxonomy";
+import type { WatchlistPostingEntry } from "@/lib/actions/watchlists";
+
+export interface WatchlistPageData {
+  detail: NonNullable<Awaited<ReturnType<typeof getWatchlistByUserAndSlug>>>;
+  isOwner: boolean;
+  isPaidPlan: boolean;
+  limitReached: boolean;
+  postings: WatchlistPostingEntry[];
+  total: number;
+  resolvedLocations: { id: number; slug: string; name: string; type: "macro" | "country" | "region" | "city"; parentName: string | null }[];
+  resolvedOccupations: { id: number; slug: string; name: string }[];
+  resolvedSeniorities: { id: number; slug: string; name: string }[];
+  resolvedTechnologies: { id: number; slug: string; name: string }[];
+}
+
+export async function fetchWatchlistPageData(params: {
+  userSlug: string;
+  watchlistSlug: string;
+  locale: string;
+}): Promise<WatchlistPageData | null> {
+  const { userSlug, watchlistSlug, locale } = params;
+
+  const detail = await getWatchlistByUserAndSlug(userSlug, watchlistSlug);
+  if (!detail) return null;
+
+  const session = await getSession();
+  const isOwner = session?.user?.id === detail.owner.id;
+
+  const [plan, limit] = await Promise.all([
+    session ? getUserPlan(session.user.id) : ("free" as const),
+    session ? canCreateWatchlist(session.user.id) : { allowed: false, current: 0, max: 0 },
+  ]);
+  const isPaidPlan = PLAN_LIMITS[plan].canReceiveAlerts;
+  const limitReached = !limit.allowed;
+
+  const filters = detail.filters;
+
+  const [locMap, occMap, senMap, techMap] = await Promise.all([
+    filters.locationSlugs?.length
+      ? resolveLocationSlugs(filters.locationSlugs, locale)
+      : Promise.resolve(new Map()),
+    filters.occupationSlugs?.length
+      ? resolveOccupationSlugs(filters.occupationSlugs, locale)
+      : Promise.resolve(new Map()),
+    filters.senioritySlugs?.length
+      ? resolveSenioritySlugs(filters.senioritySlugs, locale)
+      : Promise.resolve(new Map()),
+    filters.technologySlugs?.length
+      ? resolveTechnologySlugs(filters.technologySlugs)
+      : Promise.resolve(new Map()),
+  ]);
+
+  const resolvedLocations = (filters.locationSlugs ?? [])
+    .map((slug) => locMap.get(slug))
+    .filter((l): l is NonNullable<typeof l> => l != null)
+    .map((l) => ({ id: l.id, slug: l.slug, name: l.name, type: l.type as "macro" | "country" | "region" | "city", parentName: l.parentName ?? null }));
+
+  const resolvedOccupations = (filters.occupationSlugs ?? [])
+    .map((slug) => occMap.get(slug))
+    .filter((o): o is NonNullable<typeof o> => o != null);
+
+  const resolvedSeniorities = (filters.senioritySlugs ?? [])
+    .map((slug) => senMap.get(slug))
+    .filter((s): s is NonNullable<typeof s> => s != null);
+
+  const resolvedTechnologies = (filters.technologySlugs ?? [])
+    .map((slug) => techMap.get(slug))
+    .filter((t): t is NonNullable<typeof t> => t != null);
+
+  const { postings, total } = await getWatchlistPostings({
+    companyIds: filters.anyCompany ? [] : detail.companies.map((c) => c.id),
+    anyCompany: filters.anyCompany,
+    offset: 0,
+    limit: 20,
+    keywords: filters.keywords,
+    locationIds: resolvedLocations.map((l) => l.id),
+    occupationIds: resolvedOccupations.map((o) => o.id),
+    seniorityIds: resolvedSeniorities.map((s) => s.id),
+    technologyIds: resolvedTechnologies.map((t) => t.id),
+    salaryMin: filters.salaryMin,
+    salaryMax: filters.salaryMax,
+    experienceMin: filters.experienceMin,
+    experienceMax: filters.experienceMax,
+  });
+
+  return {
+    detail,
+    isOwner,
+    isPaidPlan,
+    limitReached,
+    postings,
+    total,
+    resolvedLocations,
+    resolvedOccupations,
+    resolvedSeniorities,
+    resolvedTechnologies,
+  };
+}

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -11,6 +11,7 @@ import { getSessionUserId } from "@/lib/sessionCache";
 import { cached } from "@/lib/cache";
 import { canCreateWatchlist, getUserPlan, PLAN_LIMITS } from "@/lib/plans";
 import { generateUniqueSlug } from "@/lib/watchlist-slug";
+import { ANON_MAX_WATCHLIST_POSTINGS } from "@/lib/search/constants";
 import { expandLocationIds, resolveLocationSlugs } from "@/lib/actions/locations";
 import { expandOccupationIds, resolveOccupationSlugs, resolveSenioritySlugs, resolveTechnologySlugs } from "@/lib/actions/taxonomy";
 
@@ -585,10 +586,16 @@ export async function getWatchlistPostings(params: {
   salaryMax?: number;
   experienceMin?: number;
   experienceMax?: number;
-}): Promise<{ postings: WatchlistPostingEntry[]; total: number }> {
+}): Promise<{ postings: WatchlistPostingEntry[]; total: number; truncated?: boolean }> {
   // No companies selected and not "any company" mode → empty
   if (!params.anyCompany && params.companyIds.length === 0) {
     return { postings: [], total: 0 };
+  }
+
+  // Enforce truncation for unauthenticated users
+  const userId = await getSessionUserId();
+  if (!userId && params.offset >= ANON_MAX_WATCHLIST_POSTINGS) {
+    return { postings: [], total: 0, truncated: true };
   }
 
   // Expand parent locations/occupations to include children (e.g. Switzerland → Zurich)
@@ -700,6 +707,7 @@ export async function getWatchlistPostings(params: {
       },
     })),
     total,
+    ...(!userId && params.offset + params.limit >= ANON_MAX_WATCHLIST_POSTINGS ? { truncated: true } : {}),
   };
 }
 

--- a/apps/web/src/lib/search/constants.ts
+++ b/apps/web/src/lib/search/constants.ts
@@ -1,0 +1,5 @@
+/** Pagination limits for unauthenticated users. */
+export const ANON_MAX_COMPANIES = 15; // 1.5 pages of PAGE_SIZE=10
+export const ANON_MAX_POSTINGS = 40; // 2 pages of PAGE_SIZE=20 (company detail page)
+export const ANON_MAX_CARD_POSTINGS = 20; // 10 initial + 1 batch (company card in search)
+export const ANON_MAX_WATCHLIST_POSTINGS = 20; // 1 page of 20 (watchlist detail page)

--- a/apps/web/src/lib/search/types.ts
+++ b/apps/web/src/lib/search/types.ts
@@ -23,6 +23,7 @@ export interface SearchResultCompany {
 export interface SearchResponse {
   companies: SearchResultCompany[];
   totalCompanies: number;
+  truncated?: boolean;
 }
 
 export interface SearchFilters {

--- a/apps/web/src/lib/useAuth.ts
+++ b/apps/web/src/lib/useAuth.ts
@@ -3,13 +3,13 @@
 import { useSession } from "@/components/SessionProvider";
 
 /**
- * Returns the current session from the server-provided SessionProvider.
+ * Returns the current session from the SessionProvider context.
  *
- * Unlike the previous implementation (which called `authClient.useSession()`
- * triggering `GET /api/auth/get-session` on mount and on window focus),
- * this reads from React context populated during SSR — zero network requests.
+ * `isPending` is true while the initial bootstrap fetch is in progress.
+ * Components should show neutral/skeleton UI while isPending to avoid
+ * flashing auth-dependent content.
  */
 export function useAuth() {
-  const { user, isLoggedIn } = useSession();
-  return { isLoggedIn, user, isPending: false };
+  const { user, isLoggedIn, isPending } = useSession();
+  return { isLoggedIn, user, isPending };
 }


### PR DESCRIPTION
## Summary

- **Remove `force-dynamic` from `(app)` layout** — pages now serve static shells from CDN instead of SSR on every navigation
- **Client-side data fetching** — layout bootstrap + page data loaded via server actions on mount, cutting serverless invocations dramatically
- **Anon truncation** — unauthenticated users see limited results (15 companies, 20-40 postings) with "Sign in to see more" prompt
- **Sign-out fix** — manual cookie clearing to work around better-auth `nextCookies()` silent failure
- **ISR metadata** — company and watchlist detail pages cache SEO metadata for 10 minutes

## Test plan

- [ ] Incognito: load `/explore`, scroll through results — truncation prompt appears after ~15 companies
- [ ] Incognito: expand a company card — truncation prompt appears after 1 load-more
- [ ] Incognito: visit `/company/<slug>` — truncation after 2 pages of postings
- [ ] Incognito: visit a shared watchlist — truncation after initial page
- [ ] Sign in — all truncation disappears, full pagination works
- [ ] Sign out — session clears, redirects to explore as anonymous
- [ ] Navigate between pages — no full reload, provider state persists
- [ ] Click a posting in search results — detail panel opens without page reload
- [ ] Company page has correct OG tags in page source (ISR metadata)
- [ ] Verify Vercel function invocation count drops vs baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)