### PR TITLE
Cache company OG images for 1 day

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/opengraph-image.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/opengraph-image.tsx
@@ -4,6 +4,7 @@ import { getCompanyBySlug } from "@/lib/actions/company";
 export const alt = "Company jobs";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
+export const revalidate = 86400; // Cache generated image for 1 day
 
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";


### PR DESCRIPTION
## Summary

- Add `export const revalidate = 86400` to company `opengraph-image.tsx`
- Company logos and descriptions rarely change — no need to regenerate the PNG on every social crawler hit
- Eliminates Satori + font rendering compute for repeat OG image requests

## Test plan

- [ ] Share a company page link on Slack/Twitter — OG image renders correctly
- [ ] Re-share after a few minutes — response should be instant (ISR cached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)