### PR TITLE
Fix servers-com breezy board config

### DIFF
--- a/apps/crawler/data/boards.csv
+++ b/apps/crawler/data/boards.csv
@@ -3335,7 +3335,7 @@ sequra,sequra-pinpoint,https://sequra.pinpointhq.com,pinpoint,"{""slug"": ""sequ
 serhant,serhant-greenhouse,https://job-boards.greenhouse.io/serhant,greenhouse,"{""token"": ""serhant""}",skip,
 sertis,sertis-greenhouse,https://job-boards.greenhouse.io/sertis,greenhouse,"{""token"": ""sertis""}",skip,
 sertrading,sertrading-greenhouse,https://job-boards.greenhouse.io/sertradingsa,greenhouse,"{""token"": ""sertradingsa""}",skip,
-servers-com,servers-com-careers-apply,https://servers-com.breezy.hr/,breezy,,,
+servers-com,servers-com-careers-apply,https://servers-com.breezy.hr/,breezy,"{""portal_url"": ""https://servers-com.breezy.hr"", ""slug"": ""servers-com""}",json-ld,
 servimo,servimo-join,https://join.com/companies/servimofr,join,"{""slug"": ""servimofr""}",nextdata,"{""path"": ""props.pageProps.initialState.job"", ""fields"": {""title"": ""title"", ""description"": ""description"", ""locations"": ""city.cityName"", ""employment_type"": ""employmentType.googleType"", ""job_location_type"": ""workplaceType"", ""date_posted"": ""createdAt""}}"
 sesame,sesame-ashby,https://jobs.ashbyhq.com/sesame,ashby,"{""token"": ""sesame""}",skip,
 sesame,sesame-lever,https://jobs.lever.co/sesame,lever,"{""token"": ""sesame""}",skip,


### PR DESCRIPTION
## Summary
- `servers-com` breezy board had empty `monitor_config` and `scraper_type` fields
- Added `portal_url`/`slug` monitor config and `json-ld` scraper type
- Fixes "Unknown scraper type: breezy" errors in workers

## Test plan
- [ ] Verify servers-com board scrapes successfully after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)