### PR TITLE
Fix Dockerfile: rename targets to slim/full

### DIFF
--- a/apps/crawler/Dockerfile
+++ b/apps/crawler/Dockerfile
@@ -16,17 +16,13 @@ COPY data/ data/
 # Install the project itself
 RUN uv sync --frozen --no-dev
 
-# ── Target: http (slim, no Playwright) ───────────────────────────────
-FROM base AS http
-CMD ["uv", "run", "--no-sync", "scheduler", "--http-only"]
+# ── Target: slim (worker, exporter, drain — no Playwright) ───────────
+FROM base AS slim
+# Default: worker instance. Override via docker-compose command.
+CMD ["uv", "run", "--no-sync", "crawler", "run"]
 
-# ── Target: r2-drain (slim, no Playwright, no data/) ─────────────────
-FROM base AS r2-drain
-RUN rm -rf data/
-CMD ["uv", "run", "--no-sync", "scheduler", "--r2-drain-only"]
-
-# ── Target: browser (full, with Playwright + Chromium) ────────────────
-FROM base AS browser
+# ── Target: full (browser worker — with Playwright + Chromium) ───────
+FROM base AS full
 
 # OS deps for headless Chromium
 RUN apt-get update \
@@ -41,4 +37,4 @@ RUN apt-get update \
 # Download Chromium binary
 RUN uv run --no-sync playwright install --only-shell chromium
 
-CMD ["uv", "run", "--no-sync", "scheduler", "--browser-only"]
+CMD ["uv", "run", "--no-sync", "crawler", "run-browser"]


### PR DESCRIPTION
The deploy workflow builds targets `slim` and `full` but the Dockerfile on main still has the old `http`/`r2-drain`/`browser` targets. This caused the deploy to fail with:

```
target stage "slim" could not be found
```

Also updates CMD from old `scheduler` entry point to `crawler` CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)