### PR TITLE
Fix deploy: SCP compose files, Dockerfile targets

### DIFF
--- a/.github/workflows/deploy-crawler-browser.yml
+++ b/.github/workflows/deploy-crawler-browser.yml
@@ -58,13 +58,13 @@ jobs:
           cache-from: type=gha,scope=crawler-browser
           cache-to: type=gha,mode=max,scope=crawler-browser
 
-      - name: Copy deploy script
+      - name: Copy deploy files
         uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.HETZNER_HOST }}
           username: deploy
           key: ${{ secrets.HETZNER_SSH_KEY }}
-          source: apps/crawler/deploy.sh
+          source: apps/crawler/deploy.sh,apps/crawler/docker-compose.yml,apps/crawler/alloy.river
           target: /home/deploy/
           strip_components: 2
 


### PR DESCRIPTION
Fixes the two remaining deploy failures after #1153:

1. **Dockerfile targets** — main still has `http`/`r2-drain`/`browser` but workflow builds `slim`/`full`
2. **Missing compose files** — only `deploy.sh` was SCP'd to Hetzner, but it runs `docker compose` which needs `docker-compose.yml` and `alloy.river`

🤖 Generated with [Claude Code](https://claude.com/claude-code)