### PR TITLE
Fix Alloy command in docker-compose.yml

### DIFF
--- a/apps/crawler/docker-compose.yml
+++ b/apps/crawler/docker-compose.yml
@@ -130,7 +130,7 @@ services:
       LOKI_URL: ${GRAFANA_LOKI_URL}
       LOKI_USERNAME: ${GRAFANA_LOKI_USERNAME}
       LOKI_PASSWORD: ${GRAFANA_LOKI_PASSWORD}
-    command: run --config.file=/etc/alloy/config.river
+    command: run --server.http.listen-addr=0.0.0.0:12346 /etc/alloy/config.river
     deploy:
       resources:
         limits:


### PR DESCRIPTION
Positional arg, not --config.file flag. Alloy v1.14+ changed the syntax.

🤖 Generated with [Claude Code](https://claude.com/claude-code)