### PR TITLE
Fix CI/auto-merge: use paginated files API for large PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,8 @@ jobs:
           if [ "${{ github.event_name }}" = "push" ]; then
             FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "force")
           else
-            FILES=$(gh pr diff "${{ github.event.pull_request.number }}" --name-only 2>/dev/null || echo "force")
+            # Use paginated files API — gh pr diff fails on large diffs (>20k lines)
+            FILES=$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --jq '.[].filename' 2>/dev/null || echo "force")
           fi
           CODE=false
           CRAWLER_CODE=false

--- a/.github/workflows/maybe-auto-merge.yml
+++ b/.github/workflows/maybe-auto-merge.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Check for pending images
         id: images
         run: |
-          FILES=$(gh pr diff "$PR" --repo "$REPO" --name-only)
+          # Use paginated files API — gh pr diff fails on large diffs (>20k lines)
+          FILES=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename')
           if echo "$FILES" | grep -q '^apps/crawler/data/images/'; then
             echo "pending=true" >> "$GITHUB_OUTPUT"
             echo "Images pending — upload-company-images workflow will handle labeling"


### PR DESCRIPTION
## Summary
- `gh pr diff` fails with HTTP 406 when a PR exceeds 20,000 diff lines
- Both `ci.yml` (Detect changes) and `maybe-auto-merge.yml` (Check for pending images) use `gh pr diff --name-only` which hard-fails on large PRs, causing false positives (triggering version bump check) and pipeline failures
- Replace with `gh api --paginate .../pulls/{n}/files` which handles any size PR

## Test plan
- [ ] Merge this first, then re-run checks on PR #1117