### PR TITLE
Fix ws run scraper not applying config defaults

### DIFF
--- a/apps/crawler/src/workspace/commands/crawl.py
+++ b/apps/crawler/src/workspace/commands/crawl.py
@@ -1601,6 +1601,7 @@ def run_scraper(
         from playwright.async_api import async_playwright
 
         from src.core.scrape import scrape_one
+        from src.processing.scrape import _apply_defaults
         from src.shared.http import create_logging_http_client
 
         ssl_verify = (board.monitor_config or {}).get("ssl_verify", True)
@@ -1625,6 +1626,7 @@ def run_scraper(
                     except HTTPStatusError as exc:
                         skipped.append((url, str(exc.response.status_code)))
                         continue
+                    content = _apply_defaults(content, scr_config or {})
                     elapsed = time.monotonic() - start
                     results.append((url, content, elapsed))
             return results, http_log, skipped


### PR DESCRIPTION
## Summary
- `ws run scraper` called `scrape_one()` but never applied `_apply_defaults()` to the result
- Scraper config `defaults` (e.g. `{"locations": ["Helsinki, FI"], "employment_type": "full_time"}`) were silently ignored during workspace test runs
- The production code paths in `board.py` and `processing/scrape.py` all apply defaults correctly — only the workspace CLI command was missing it

## Test plan
- [x] All 2762 existing tests pass
- [ ] `ws run scraper` with a config containing `defaults` now shows the default values in output and quality stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)