### PR TITLE
Fix select monitor overwriting scraper settings

### DIFF
--- a/apps/crawler/src/workspace/commands/crawl.py
+++ b/apps/crawler/src/workspace/commands/crawl.py
@@ -1068,6 +1068,12 @@ def select_monitor(
     # Auto-configure scraper when the monitor determines it
     if auto:
         cfg_entry["scraper_type"] = auto[0]
+    # Preserve scraper settings when re-selecting a monitor with the same name
+    if name in board.configs:
+        prev = board.configs[name]
+        for key in ("scraper_type", "scraper_config"):
+            if key in prev and key not in cfg_entry:
+                cfg_entry[key] = prev[key]
     board.configs[name] = cfg_entry
     board.active_config = name
 

--- a/apps/crawler/src/workspace/commands/lifecycle.py
+++ b/apps/crawler/src/workspace/commands/lifecycle.py
@@ -1145,8 +1145,15 @@ def submit(slug: str | None, summary: str | None, force: bool):
             for b in blockers:
                 out.warn("submit", f"(forced) {b}")
 
-    # Stale submit detection: if config selections changed since last submit, restart
-    current_configs = {b.alias: b.active_config for b in boards}
+    # Stale submit detection: if config selections or content changed since last submit, restart
+    current_configs = {}
+    for b in boards:
+        cfg = b._active_cfg()
+        current_configs[b.alias] = {
+            "active": b.active_config,
+            "monitor_type": cfg.get("monitor_type"),
+            "scraper_type": cfg.get("scraper_type"),
+        }
     prev_configs = ws.submit_state.get("_active_configs")
     if prev_configs and prev_configs != current_configs:
         out.warn("submit", "Board config changed since last submit — restarting")

--- a/apps/crawler/tests/test_ws_commands.py
+++ b/apps/crawler/tests/test_ws_commands.py
@@ -2374,7 +2374,13 @@ class TestSubmitIdempotency:
 
         # Mark some steps as done
         ws_obj.submit_state = {
-            "_active_configs": {"careers": "greenhouse"},
+            "_active_configs": {
+                "careers": {
+                    "active": "greenhouse",
+                    "monitor_type": "greenhouse",
+                    "scraper_type": None,
+                }
+            },
             "csv_written": True,
             "validated": True,
         }


### PR DESCRIPTION
## Summary
- **Bug 1**: `ws select monitor --as <name>` replaces the entire config dict, silently dropping any previously set `scraper_type`/`scraper_config`. Now preserves scraper settings when re-selecting a monitor with the same config name.
- **Bug 2**: Submit's stale-detection only compared `active_config` pointer names, not config contents. After fixing a missing scraper and retrying submit, the `csv_written` step was skipped (checkpointed from the failed attempt), so the CSV was never re-written and validation kept failing. Now includes `monitor_type` and `scraper_type` in the fingerprint so content changes trigger a restart.

## Test plan
- [x] Existing `TestSubmitIdempotency` tests updated and passing
- [x] Full test suite passes (2762 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)