### PR TITLE
Add guidelines for parent company centralized portals

### DIFF
--- a/apps/crawler/src/workspace/commands/lifecycle.py
+++ b/apps/crawler/src/workspace/commands/lifecycle.py
@@ -467,15 +467,15 @@ def reject(slug: str | None, issue: int | None, reason: str, message: str):
     if local:
         out.warn("github", "Local mode — skipping issue comment and close")
         out.plain("github", f"Would comment on issue #{issue}: {reason}")
-        if reason == "duplicate":
-            out.plain("github", f"Would add 'duplicate' label to issue #{issue}")
+        if reason in ("duplicate", "subsidiary"):
+            out.plain("github", f"Would add {reason!r} label to issue #{issue}")
         out.plain("github", f"Would close issue #{issue}")
     else:
         from src.workspace import git
 
         git.comment_on_issue(issue, body)
-        if reason == "duplicate":
-            git.add_label_to_issue(issue, "duplicate")
+        if reason in ("duplicate", "subsidiary"):
+            git.add_label_to_issue(issue, reason)
         git.unclaim_issue(issue)
         git.close_issue(issue)
         out.info("github", f"Commented on issue #{issue} (validation-failed: {reason})")

--- a/apps/crawler/src/workspace/kb/subsidiary-jobs-listed-on-parent-company-centralized-portal.md
+++ b/apps/crawler/src/workspace/kb/subsidiary-jobs-listed-on-parent-company-centralized-portal.md
@@ -27,7 +27,7 @@ the actual data source and covers all subsidiaries in one place.
 
 1. Reject the subsidiary issue explaining the situation:
    ```bash
-   ws reject --issue <N> --reason duplicate --message "<Subsidiary> does not have its own careers page. All jobs are listed on the <Parent> Group careers portal at <URL>. Configuring <Parent> Group instead, which covers all subsidiaries."
+   ws reject --issue <N> --reason subsidiary --message "<Subsidiary> does not have its own careers page. All jobs are listed on the <Parent> Group careers portal at <URL>. Configuring <Parent> Group instead, which covers all subsidiaries."
    ```
 2. Create a new workspace for the parent company:
    ```bash

--- a/apps/crawler/src/workspace/kb/subsidiary-jobs-listed-on-parent-company-centralized-portal.md
+++ b/apps/crawler/src/workspace/kb/subsidiary-jobs-listed-on-parent-company-centralized-portal.md
@@ -1,0 +1,47 @@
+---
+step: pre_verify
+symptom: Issue requests a subsidiary company whose jobs are listed on a centralized parent company careers portal (e.g. SWISS jobs on Lufthansa Group portal, Fiat jobs on Stellantis portal).
+tags: ['subsidiary', 'parent-org', 'centralized-portal', 'group', 'division']
+---
+# Subsidiary jobs listed on parent company centralized careers portal
+
+## Problem
+The requested company is a subsidiary or brand within a larger group. It does
+not operate its own careers page — all job listings are hosted on the parent
+company's centralized careers portal, often filterable by division or brand.
+
+Examples:
+- **Swiss International Air Lines** → jobs at `apply.lufthansagroup.careers` (Lufthansa Group portal, filtered by SWISS division)
+- **Fiat** → jobs at Stellantis careers portal
+- **Instagram** → jobs at Meta careers portal
+
+## How to detect
+1. The subsidiary's own website has no `/careers` or `/jobs` page, or it redirects to a parent domain.
+2. Web search for `"<subsidiary> careers"` leads to the parent company's portal.
+3. The careers portal URL contains the parent company's name (e.g. `lufthansagroup.careers`), not the subsidiary's.
+4. The portal shows jobs for multiple brands/divisions with a division filter.
+
+## Solution
+**Configure the parent company, not the subsidiary.** The parent's portal is
+the actual data source and covers all subsidiaries in one place.
+
+1. Reject the subsidiary issue explaining the situation:
+   ```bash
+   ws reject --issue <N> --reason duplicate --message "<Subsidiary> does not have its own careers page. All jobs are listed on the <Parent> Group careers portal at <URL>. Configuring <Parent> Group instead, which covers all subsidiaries."
+   ```
+2. Create a new workspace for the parent company:
+   ```bash
+   ws new <parent-slug> --issue <N>
+   ```
+3. Configure the parent's centralized portal as the board. If the portal
+   supports division filters, consider:
+   - **One board for everything** if all divisions share the same listing page and API
+   - **Separate boards per division** only if divisions have distinct URLs or ATS platforms (like Glencore)
+
+## When to configure the subsidiary instead
+If the subsidiary has its own independent careers page with its own job
+listings (not just a redirect to the parent), configure the subsidiary
+directly. This is common when:
+- The subsidiary was recently acquired and still runs its own ATS
+- The subsidiary operates in a different industry from the parent
+- The parent company is a holding/investment company with no unified portal

--- a/apps/crawler/src/workspace/steps/00-pre-verify.md
+++ b/apps/crawler/src/workspace/steps/00-pre-verify.md
@@ -47,7 +47,7 @@ If there's no public careers page and the user cannot provide a URL, reject with
 **Subsidiary check:** If the company's careers page redirects to a parent
 company's centralized portal (e.g. SWISS → Lufthansa Group, Fiat → Stellantis),
 configure the **parent company** instead — its portal is the actual data source
-and covers all subsidiaries. Reject the issue with `duplicate` explaining the
+and covers all subsidiaries. Reject the issue with `subsidiary` explaining the
 situation, then `ws new <parent-slug> --issue {issue}` for the parent.
 
 ```bash

--- a/apps/crawler/src/workspace/steps/00-pre-verify.md
+++ b/apps/crawler/src/workspace/steps/00-pre-verify.md
@@ -44,6 +44,12 @@ Research tips:
 If the company doesn't exist or can't be identified, reject with `not-a-company` or `company-not-found`.
 If there's no public careers page and the user cannot provide a URL, reject with `no-job-board`.
 
+**Subsidiary check:** If the company's careers page redirects to a parent
+company's centralized portal (e.g. SWISS → Lufthansa Group, Fiat → Stellantis),
+configure the **parent company** instead — its portal is the actual data source
+and covers all subsidiaries. Reject the issue with `duplicate` explaining the
+situation, then `ws new <parent-slug> --issue {issue}` for the parent.
+
 ```bash
 ws reject --issue {issue} --reason <key> --message "..."
 ```

--- a/apps/crawler/src/workspace/steps/02-add-boards.md
+++ b/apps/crawler/src/workspace/steps/02-add-boards.md
@@ -88,6 +88,13 @@ careers page, and Workday site lists for the full set.
 Prefer directly referenced board URLs over unreferenced slug guesses unless
 the latter has stronger corroborating evidence.
 
+**Centralized parent portals:** If the company's careers page redirects to a
+parent company's portal (e.g. SWISS → Lufthansa Group, Fiat → Stellantis),
+the parent company should be configured instead — reject this issue and create
+a workspace for the parent. Use `ws task fail --reason "Jobs are hosted on
+<Parent> Group's centralized portal at <URL>. Configure the parent company
+instead."` to abort.
+
 ## Add each board
 
 ```bash

--- a/apps/crawler/src/workspace/steps/parallel/track-c-boards.md
+++ b/apps/crawler/src/workspace/steps/parallel/track-c-boards.md
@@ -78,6 +78,13 @@ Search the company name + "jobs" + common ATS domains.
   board — e.g., WTTJ often mirrors Ashby listings)
 - Do NOT read source code files — use `ws help` and `ws task troubleshoot` instead
 
+**Centralized parent portals:** If the company's careers page redirects to or
+is hosted on a parent company's centralized portal (e.g. SWISS jobs on the
+Lufthansa Group portal, Fiat jobs on Stellantis portal), **stop and report this
+to the main agent.** The parent company should be configured instead — its
+portal covers all subsidiaries and is the actual data source. Do not add boards
+from a parent portal when working on a subsidiary workspace.
+
 {% if monitor_table %}
 ### Auto-detected ATS types
 


### PR DESCRIPTION
## Summary
- Adds agent guidance for when a subsidiary's jobs are hosted on a parent company's centralized careers portal (e.g. SWISS → Lufthansa Group, Fiat → Stellantis, Instagram → Meta)
- **Pre-verification step** (`00-pre-verify.md`): subsidiary check — detect the redirect early and configure the parent instead
- **Board discovery steps** (`02-add-boards.md`, `track-c-boards.md`): stop and report if the careers page is a parent portal, don't add boards from it under the subsidiary workspace
- **New KB article**: documents the pattern, detection signals, and when to configure subsidiary vs parent

Motivated by the SWISS/Lufthansa Group case — agent configured SWISS but all jobs were on `apply.lufthansagroup.careers` filtered by division.

## Test plan
- [ ] Review KB article content and examples
- [ ] Verify guidance is clear for agents encountering this pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)