### PR TITLE
Add automatic board overlap detection

### DIFF
--- a/apps/crawler/AGENTS.md
+++ b/apps/crawler/AGENTS.md
@@ -75,7 +75,7 @@ src/
 │   ├── commands/          # Command implementations
 │   │   ├── lifecycle.py   # new, reject, del, submit, status, validate, resume
 │   │   ├── config.py      # set, add board, del board
-│   │   ├── crawl.py       # probe, select/run monitor/scraper, feedback
+│   │   ├── crawl.py       # probe, select/run monitor/scraper, feedback, compare-boards
 │   │   ├── task.py        # Workflow: task, troubleshoot, learn, casestudy
 │   │   └── help.py        # Reference docs for monitors, scrapers, config
 │   ├── state.py           # YAML workspace state (v2: named configs)
@@ -127,6 +127,7 @@ ws run scraper [--url URL ...] [--config <name>]  # Test scrape
 ws feedback [<config>] --verdict good  # Record extraction quality (mandatory)
 ws select config <name>                # Re-activate a previously tested config
 ws reject-config <name> --reason "..." # Mark a config as rejected
+ws compare-boards                      # Detect mirror/subset/overlapping boards
 ws submit [--summary "..."] [--force]  # Validate, commit, push, post stats
 
 # Search + discovery

--- a/apps/crawler/src/workspace/cli.py
+++ b/apps/crawler/src/workspace/cli.py
@@ -22,6 +22,7 @@ from src.workspace.commands.config import (
     set_,
 )
 from src.workspace.commands.crawl import (
+    compare_boards,
     feedback_cmd,
     probe_api,
     probe_deep,
@@ -97,6 +98,7 @@ ws.add_command(help_cmd, name="help")
 ws.add_command(logos)
 ws.add_command(discover)
 ws.add_command(discover_bg, name="discover-bg")
+ws.add_command(compare_boards, name="compare-boards")
 ws.add_command(feedback_cmd, name="feedback")
 ws.add_command(reject_config, name="reject-config")
 ws.add_command(task, name="task")

--- a/apps/crawler/src/workspace/commands/crawl.py
+++ b/apps/crawler/src/workspace/commands/crawl.py
@@ -1487,6 +1487,66 @@ def run_monitor(slug: str | None, board_alias: str | None, config_name: str | No
     )
     save_board(slug, board)
 
+    # Auto-compare against other boards with monitor runs
+    if job_count > 0:
+        _auto_compare_boards(slug, board.alias)
+
+
+def _auto_compare_boards(slug: str, current_alias: str) -> None:
+    """Compare the current board against all other boards that have monitor runs."""
+    from src.workspace.state import list_boards as _list_boards
+
+    boards = _list_boards(slug)
+    other_aliases = []
+    for b in boards:
+        if b.alias == current_alias:
+            continue
+        for cfg in b.configs.values():
+            run = cfg.get("run")
+            if run and run.get("jobs", 0) > 0:
+                other_aliases.append(b.alias)
+                break
+
+    if not other_aliases:
+        return
+
+    for other in other_aliases:
+        cmp = _compare_two_boards(slug, current_alias, other)
+        if "error" in cmp:
+            continue
+        rel = cmp["relationship"]
+        if rel == "mirror":
+            print()
+            out.warn(
+                "overlap",
+                f"MIRROR: {current_alias} ({cmp['count_a']} jobs) and "
+                f"{other} ({cmp['count_b']} jobs) share "
+                f"{cmp['shared_urls']} URLs "
+                f"({cmp['url_overlap_pct_a']}%/{cmp['url_overlap_pct_b']}%). "
+                f"These boards are nearly identical — keep only the one with "
+                f"better data or lower cost.",
+            )
+        elif rel == "subset":
+            smaller = current_alias if cmp["count_a"] <= cmp["count_b"] else other
+            larger = other if smaller == current_alias else current_alias
+            print()
+            out.warn(
+                "overlap",
+                f"SUBSET: {smaller} appears to be a subset of {larger} "
+                f"({cmp['shared_urls']} shared URLs). "
+                f"Consider dropping {smaller} unless it has unique data.",
+            )
+        elif rel == "overlap":
+            print()
+            out.warn(
+                "overlap",
+                f"OVERLAP: {current_alias} and {other} share "
+                f"{cmp['shared_urls']} URLs "
+                f"({cmp['url_overlap_pct_a']}% of {current_alias}, "
+                f"{cmp['url_overlap_pct_b']}% of {other}). "
+                f"Run: ws compare-boards",
+            )
+
 
 @click.command(name="scraper")
 @click.argument("slug_or_type")
@@ -2221,4 +2281,242 @@ def run_quality_gates(
         if not has_icon and not icon_is_remote:
             warnings.append("No minified square logo image artifact found (icon_url)")
 
+    # Check for board overlap (only when 2+ boards have monitor runs)
+    aliases_with_runs = [
+        b.alias
+        for b in boards
+        if any((cfg.get("run") or {}).get("jobs", 0) > 0 for cfg in b.configs.values())
+    ]
+    if len(aliases_with_runs) >= 2:
+        for i, alias_a in enumerate(aliases_with_runs):
+            for alias_b in aliases_with_runs[i + 1 :]:
+                cmp = _compare_two_boards(ws.slug, alias_a, alias_b)
+                if "error" in cmp:
+                    continue
+                rel = cmp["relationship"]
+                if rel == "mirror":
+                    warnings.append(
+                        f"Boards {alias_a} and {alias_b} are mirrors "
+                        f"({cmp['shared_urls']}/{cmp['count_a']} shared URLs). "
+                        f"Run: ws compare-boards"
+                    )
+                elif rel == "subset":
+                    smaller = alias_a if cmp["count_a"] <= cmp["count_b"] else alias_b
+                    larger = alias_b if smaller == alias_a else alias_a
+                    warnings.append(
+                        f"Board {smaller} is a subset of {larger} "
+                        f"({cmp['shared_urls']} shared URLs). "
+                        f"Run: ws compare-boards"
+                    )
+                elif rel == "overlap":
+                    warnings.append(
+                        f"Boards {alias_a} and {alias_b} have significant overlap "
+                        f"({cmp['shared_urls']} shared URLs). "
+                        f"Run: ws compare-boards"
+                    )
+
     return blockers, warnings
+
+
+# ── Compare boards ─────────────────────────────────────────────────────
+
+
+def _latest_jobs_json(slug: str, alias: str) -> list[dict] | None:
+    """Load jobs.json from the most recent monitor run for a board."""
+    from src.workspace.state import artifacts_dir
+
+    monitor_dir = artifacts_dir(slug, alias) / "monitor"
+    if not monitor_dir.exists():
+        return None
+    runs = sorted(monitor_dir.glob("run-*"), reverse=True)
+    if not runs:
+        return None
+    jobs_file = runs[0] / "jobs.json"
+    if not jobs_file.exists():
+        return None
+    return json.loads(jobs_file.read_text())
+
+
+def _normalize_compare_url(url: str) -> str:
+    """Normalize URL for comparison — strip trailing slash, lowercase host."""
+    from urllib.parse import urlparse, urlunparse
+
+    p = urlparse(url)
+    path = p.path.rstrip("/") or "/"
+    return urlunparse((p.scheme.lower(), p.netloc.lower(), path, p.params, p.query, ""))
+
+
+def _compare_two_boards(
+    slug: str,
+    alias_a: str,
+    alias_b: str,
+) -> dict:
+    """Compare two boards by URL overlap and title similarity."""
+    jobs_a = _latest_jobs_json(slug, alias_a)
+    jobs_b = _latest_jobs_json(slug, alias_b)
+
+    if jobs_a is None:
+        return {"error": f"No monitor run artifacts for board '{alias_a}'"}
+    if jobs_b is None:
+        return {"error": f"No monitor run artifacts for board '{alias_b}'"}
+
+    # URL comparison
+    urls_a = {_normalize_compare_url(j["url"]) for j in jobs_a if j.get("url")}
+    urls_b = {_normalize_compare_url(j["url"]) for j in jobs_b if j.get("url")}
+
+    shared_urls = urls_a & urls_b
+    only_a = urls_a - urls_b
+    only_b = urls_b - urls_a
+
+    # Title comparison (for rich data)
+    titles_a = {j.get("title", "").strip().lower() for j in jobs_a if j.get("title")}
+    titles_b = {j.get("title", "").strip().lower() for j in jobs_b if j.get("title")}
+
+    shared_titles = titles_a & titles_b if titles_a and titles_b else set()
+
+    # Classify relationship
+    url_overlap_pct_a = round(len(shared_urls) / len(urls_a) * 100) if urls_a else 0
+    url_overlap_pct_b = round(len(shared_urls) / len(urls_b) * 100) if urls_b else 0
+
+    if url_overlap_pct_a >= 90 and url_overlap_pct_b >= 90:
+        relationship = "mirror"
+    elif url_overlap_pct_a >= 90:
+        relationship = "subset"  # A is subset of B
+    elif url_overlap_pct_b >= 90:
+        relationship = "subset"  # B is subset of A
+    elif url_overlap_pct_a >= 30 or url_overlap_pct_b >= 30:
+        relationship = "overlap"
+    else:
+        relationship = "independent"
+
+    return {
+        "board_a": alias_a,
+        "board_b": alias_b,
+        "count_a": len(urls_a),
+        "count_b": len(urls_b),
+        "shared_urls": len(shared_urls),
+        "only_a": len(only_a),
+        "only_b": len(only_b),
+        "url_overlap_pct_a": url_overlap_pct_a,
+        "url_overlap_pct_b": url_overlap_pct_b,
+        "titles_a": len(titles_a),
+        "titles_b": len(titles_b),
+        "shared_titles": len(shared_titles),
+        "relationship": relationship,
+    }
+
+
+@click.command("compare-boards")
+@click.argument("slug", required=False)
+def compare_boards(slug: str | None):
+    """Compare job URL overlap between all boards in a workspace.
+
+    Detects mirror boards, subsets, and partial overlaps to help decide
+    which boards to keep.
+    """
+    from src.workspace.state import list_boards
+
+    slug = resolve_slug(slug)
+    boards = list_boards(slug)
+
+    if len(boards) < 2:
+        out.info("compare", "Need at least 2 boards to compare")
+        return
+
+    # Collect all board aliases that have monitor runs
+    board_aliases = []
+    for b in boards:
+        has_run = False
+        for cfg in b.configs.values():
+            run = cfg.get("run")
+            if run and run.get("jobs", 0) > 0:
+                has_run = True
+                break
+        if has_run:
+            board_aliases.append(b.alias)
+
+    if len(board_aliases) < 2:
+        out.info("compare", "Need at least 2 boards with monitor runs to compare")
+        return
+
+    # Compare all pairs
+    comparisons = []
+    for i, alias_a in enumerate(board_aliases):
+        for alias_b in board_aliases[i + 1 :]:
+            result = _compare_two_boards(slug, alias_a, alias_b)
+            comparisons.append(result)
+
+    # Print results
+    print()
+    for c in comparisons:
+        if "error" in c:
+            out.warn("compare", c["error"])
+            continue
+
+        rel = c["relationship"]
+        if rel == "mirror":
+            icon = "!!"
+        elif rel == "subset":
+            icon = "! "
+        elif rel == "overlap":
+            icon = "? "
+        else:
+            icon = "ok"
+
+        out.plain(
+            "compare",
+            f"[{icon}] {c['board_a']} ({c['count_a']} jobs) vs "
+            f"{c['board_b']} ({c['count_b']} jobs)",
+        )
+        out.plain(
+            "compare",
+            f"     URLs: {c['shared_urls']} shared, "
+            f"{c['only_a']} only-{c['board_a']}, "
+            f"{c['only_b']} only-{c['board_b']} "
+            f"({c['url_overlap_pct_a']}% of {c['board_a']}, "
+            f"{c['url_overlap_pct_b']}% of {c['board_b']})",
+        )
+        if c["titles_a"] or c["titles_b"]:
+            out.plain(
+                "compare",
+                f"     Titles: {c['shared_titles']} shared "
+                f"(of {c['titles_a']} in {c['board_a']}, "
+                f"{c['titles_b']} in {c['board_b']})",
+            )
+
+        if rel == "mirror":
+            out.warn(
+                "compare",
+                "     -> MIRROR: these boards are nearly identical. "
+                "Keep the one with better data quality or lower cost.",
+            )
+        elif rel == "subset":
+            smaller = c["board_a"] if c["count_a"] <= c["count_b"] else c["board_b"]
+            larger = c["board_b"] if smaller == c["board_a"] else c["board_a"]
+            out.warn(
+                "compare",
+                f"     -> SUBSET: {smaller} appears to be a subset of {larger}. "
+                f"Consider dropping {smaller} unless it has unique data.",
+            )
+        elif rel == "overlap":
+            out.warn(
+                "compare",
+                "     -> OVERLAP: significant job overlap detected. "
+                "Investigate whether both boards are needed.",
+            )
+
+    # Summary
+    mirrors = sum(1 for c in comparisons if c.get("relationship") == "mirror")
+    subsets = sum(1 for c in comparisons if c.get("relationship") == "subset")
+    overlaps = sum(1 for c in comparisons if c.get("relationship") == "overlap")
+
+    print()
+    if mirrors or subsets or overlaps:
+        out.warn(
+            "compare",
+            f"Found {mirrors} mirror(s), {subsets} subset(s), "
+            f"{overlaps} partial overlap(s). "
+            f"Review and drop redundant boards before submitting.",
+        )
+    else:
+        out.info("compare", "All boards are independent — no overlaps detected.")

--- a/apps/crawler/src/workspace/steps/02-add-boards.md
+++ b/apps/crawler/src/workspace/steps/02-add-boards.md
@@ -126,8 +126,10 @@ ws add board careers-us --url "https://company.com/us/careers"
 ws add board careers-de --url "https://company.com/de/careers"
 ```
 
-If one board's listings are a strict superset of another's (verified by comparing job counts
-and sampling titles), the subset board can be skipped — document this in feedback `--verdict-notes` later.
+After configuring monitors for all boards, run `ws compare-boards` to detect
+overlapping boards (mirrors, subsets, partial overlap). Drop redundant boards —
+keep the one with better data quality, or lower cost if equal. Document skipped
+boards in feedback `--verdict-notes`.
 
 ## When done
 

--- a/apps/crawler/src/workspace/steps/parallel/orchestrator.md
+++ b/apps/crawler/src/workspace/steps/parallel/orchestrator.md
@@ -121,8 +121,14 @@ Before submitting, verify:
   multiple countries but only 1 board was configured, discovery is likely
   incomplete. Investigate the careers page for regional or ATS-specific
   boards before submitting.
+- **Board overlap check (2+ boards):** Run `ws compare-boards {{ slug }}`
+  to detect mirrors, subsets, and partial overlaps. If boards are mirrors or
+  subsets, drop the redundant one (keep the board with better data quality,
+  or lower cost if equal). For partial overlaps, investigate whether both
+  boards serve distinct audiences before keeping both.
 
 ```bash
+ws compare-boards {{ slug }}   # check for overlap between boards
 ws submit {{ slug }} [--summary "..."]
 ```
 


### PR DESCRIPTION
## Summary
- **Automatic overlap detection** after every `ws run monitor`: if the current board shares 90%+ URLs with another board, warns immediately with relationship type (mirror/subset/overlap)
- **`ws compare-boards` command**: compares all board pairs in a workspace, showing URL overlap counts, percentages, and title matches — agents can re-run manually for details
- **Submit quality gates**: warns about mirror/subset/overlapping boards before submit
- **Agent guidelines**: orchestrator pre-submit checklist, board discovery step, and AGENTS.md command reference updated

Motivated by the Renault/Alpine Racing case where two Workday boards on the same tenant returned nearly identical job sets (692 vs 696 jobs).

### How it works
After `ws run monitor`, the command automatically loads `jobs.json` from the latest monitor run of every other board and compares URLs:
- **Mirror** (90%+ overlap both ways): boards are nearly identical
- **Subset** (90%+ of one board appears in the other): smaller board is redundant
- **Overlap** (30%+ shared): warrants investigation
- **Independent** (<30%): no action needed

## Test plan
- [x] All 2762 existing tests pass
- [ ] `ws run monitor` on a second board with overlapping URLs shows overlap warning
- [ ] `ws compare-boards` prints pairwise comparison table
- [ ] `ws submit` warns about overlapping boards in quality gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)