### PR TITLE
Fix empty locations: populate GeoNames + currency_rate in local Postgres

### DIFF
--- a/apps/crawler/src/backfill.py
+++ b/apps/crawler/src/backfill.py
@@ -1,0 +1,85 @@
+"""Backfill location_ids for jobs scraped while GeoNames tables were empty.
+
+Enqueues re-scrape tasks into Redis at low priority (tier 2).  The existing
+scrape pipeline handles location resolution.  R2 uploads are avoided because
+``description_r2_hash`` is passed through, so ``_stage_r2_pending`` skips
+unchanged descriptions.
+
+Usage::
+
+    uv run crawler backfill-locations
+"""
+
+from __future__ import annotations
+
+import time
+from urllib.parse import urlparse
+
+import asyncpg
+import structlog
+
+from src.redis_queue import enqueue_scrape, get_redis
+
+log = structlog.get_logger()
+
+_FETCH_MISSING_LOCATIONS = """
+SELECT jp.id::text, jp.source_url, jp.board_id::text, jp.description_r2_hash
+FROM job_posting jp
+WHERE jp.is_active = true
+  AND jp.location_ids IS NULL
+  AND jp.description_r2_hash IS NOT NULL
+"""
+
+
+async def backfill_locations(pool: asyncpg.Pool) -> int:
+    """Enqueue re-scrapes for active jobs missing location_ids.
+
+    Returns the number of tasks enqueued.
+    """
+    rows = await pool.fetch(_FETCH_MISSING_LOCATIONS)
+    if not rows:
+        log.info("backfill.locations.none_needed")
+        return 0
+
+    log.info("backfill.locations.found", count=len(rows))
+
+    r = get_redis()
+
+    # Cache board configs to avoid repeated Redis lookups
+    board_cache: dict[str, bool] = {}  # board_id -> needs_browser
+    enqueued = 0
+    now = time.time()
+
+    for row in rows:
+        posting_id = row["id"]
+        url = row["source_url"]
+        board_id = row["board_id"] or ""
+        r2_hash = row["description_r2_hash"]
+        domain = urlparse(url).hostname or ""
+
+        # Determine if scraper needs browser from cached board config
+        if board_id and board_id not in board_cache:
+            board_config = await r.hgetall(f"board:{board_id}")
+            board_cache[board_id] = (
+                board_config.get("scraper_needs_browser", "0") == "1" if board_config else False
+            )
+        needs_browser = board_cache.get(board_id, False)
+
+        added = await enqueue_scrape(
+            domain,
+            posting_id,
+            now,  # due immediately
+            {
+                "source_url": url,
+                "board_id": board_id,
+                "description_r2_hash": str(r2_hash) if r2_hash is not None else "",
+                "scrape_step": "0",
+            },
+            browser=needs_browser,
+            first_time=False,  # tier 2 = lowest priority
+        )
+        if added:
+            enqueued += 1
+
+    log.info("backfill.locations.enqueued", enqueued=enqueued, skipped=len(rows) - enqueued)
+    return enqueued

--- a/apps/crawler/src/cli.py
+++ b/apps/crawler/src/cli.py
@@ -61,6 +61,8 @@ def parse_args() -> argparse.Namespace:
     recon_g.add_argument("--full", action="store_true", help="Touch all rows")
     recon_g.add_argument("--bootstrap", action="store_true", help="Bootstrap local from Supabase")
 
+    sub.add_parser("backfill-locations", help="Enqueue re-scrapes for jobs missing locations")
+
     board_p = sub.add_parser("board", help="Dev testing for a single board")
     board_p.add_argument("slug", help="Board slug to process")
     board_p.add_argument("--dry-run", action="store_true", help="No DB writes")
@@ -125,6 +127,12 @@ async def run() -> None:
             from src.sync import run_sync
 
             await run_sync()
+
+        elif args.command == "backfill-locations":
+            local_pool = await create_local_pool()
+            from src.backfill import backfill_locations
+
+            await backfill_locations(local_pool)
 
         elif args.command == "reconcile":
             local_pool = await create_local_pool()

--- a/apps/crawler/src/sync.py
+++ b/apps/crawler/src/sync.py
@@ -1018,6 +1018,82 @@ async def _mirror_table(
     )
 
 
+async def _populate_locations_if_empty(
+    supa_conn: asyncpg.Connection,
+    local_conn: asyncpg.Connection,
+) -> None:
+    """One-time population of GeoNames data from Supabase into local Postgres.
+
+    Local DB is the source of truth.  This only runs when the local tables
+    are empty (fresh deploy).  After that, GeoNames data lives in local
+    Postgres and is never overwritten from Supabase.
+    """
+    local_count = await local_conn.fetchval("SELECT count(*) FROM location")
+    if local_count > 0:
+        log.info("sync.locations.already_populated", count=local_count)
+        return
+
+    loc_rows = await supa_conn.fetch(
+        "SELECT id, parent_id, type, population, languages FROM location"
+    )
+    if not loc_rows:
+        log.warning("sync.locations.supabase_empty")
+        return
+
+    name_rows = await supa_conn.fetch(
+        "SELECT location_id, locale, name, is_display FROM location_name"
+    )
+
+    await local_conn.copy_records_to_table(
+        "location",
+        records=[
+            (r["id"], r["parent_id"], r["type"], r["population"], r["languages"]) for r in loc_rows
+        ],
+        columns=["id", "parent_id", "type", "population", "languages"],
+    )
+
+    if name_rows:
+        await local_conn.copy_records_to_table(
+            "location_name",
+            records=[
+                (r["location_id"], r["locale"], r["name"], r["is_display"]) for r in name_rows
+            ],
+            columns=["location_id", "locale", "name", "is_display"],
+        )
+
+    log.info(
+        "sync.locations.populated_from_supabase",
+        locations=len(loc_rows),
+        names=len(name_rows),
+    )
+
+
+async def _populate_currency_rates_if_empty(
+    supa_conn: asyncpg.Connection,
+    local_conn: asyncpg.Connection,
+) -> None:
+    """One-time population of currency rates from Supabase into local Postgres.
+
+    Local DB is the source of truth.  After initial population, rates
+    should be refreshed by a local script (e.g. ECB daily feed).
+    """
+    local_count = await local_conn.fetchval("SELECT count(*) FROM currency_rate")
+    if local_count > 0:
+        log.info("sync.currency_rates.already_populated", count=local_count)
+        return
+
+    rows = await supa_conn.fetch("SELECT currency, to_eur, updated_at FROM currency_rate")
+    if not rows:
+        return
+
+    await local_conn.copy_records_to_table(
+        "currency_rate",
+        records=[(r["currency"], r["to_eur"], r["updated_at"]) for r in rows],
+        columns=["currency", "to_eur", "updated_at"],
+    )
+    log.info("sync.currency_rates.populated_from_supabase", count=len(rows))
+
+
 async def sync_lookup_tables_local(
     supa_conn: asyncpg.Connection,
     local_conn: asyncpg.Connection,
@@ -1113,6 +1189,10 @@ async def sync_lookup_tables_local(
     # Sync them normally.
     await sync_technologies(local_conn, technologies, dry_run)
     await sync_industries(local_conn, industries, dry_run)
+
+    # --- GeoNames + currency: one-time population from Supabase if empty ---
+    await _populate_locations_if_empty(supa_conn, local_conn)
+    await _populate_currency_rates_if_empty(supa_conn, local_conn)
 
     # --- Re-add FK constraints (dropped above) ---
     await local_conn.execute(

--- a/apps/crawler/tests/test_sync.py
+++ b/apps/crawler/tests/test_sync.py
@@ -519,6 +519,7 @@ class TestRunSync:
         # Set up Supabase pool + connection mock with proper async context managers
         mock_conn = MagicMock()
         mock_conn.execute = AsyncMock()
+        mock_conn.fetch = AsyncMock(return_value=[])
         mock_txn_cm = AsyncMock()
         mock_conn.transaction.return_value = mock_txn_cm
 
@@ -537,6 +538,8 @@ class TestRunSync:
         # supports both modes. We simulate this with a helper class.
         mock_local_conn = MagicMock()
         mock_local_conn.execute = AsyncMock()
+        mock_local_conn.copy_records_to_table = AsyncMock()
+        mock_local_conn.fetchval = AsyncMock(return_value=0)
 
         class _FakeAcquireCtx:
             """Simulates asyncpg PoolAcquireContext: awaitable + async CM."""


### PR DESCRIPTION
## Summary
- The pipeline rewrite moved all processing to local Hetzner Postgres, but `sync_lookup_tables_local` never populated `location`, `location_name`, and `currency_rate` tables
- `LocationResolver` loaded 0 entries → all 18,589 recent active jobs had NULL `location_ids`
- Added `_populate_locations_if_empty` and `_populate_currency_rates_if_empty` — one-time copy from Supabase when local tables are empty (local DB is source of truth after initial population)

## Already deployed
- Sync ran: 37,526 locations, 572,486 names, 31 currency rates populated
- Workers restarted, LocationResolver loaded with 37,526 entries
- New scrapes are already resolving locations correctly

## Test plan
- [x] `uv run pytest tests/test_sync.py` — 22 passed
- [x] `uv run pytest tests/` — 2762 passed
- [x] Deployed and verified on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)