### PR TITLE
Add inline monitor for single-page job boards

### DIFF
--- a/apps/crawler/AGENTS.md
+++ b/apps/crawler/AGENTS.md
@@ -34,7 +34,8 @@ src/
 │   │   ├── workday.py     # Workday Job Board API
 │   │   ├── sitemap.py     # XML sitemap parser
 │   │   ├── nextdata.py    # Next.js __NEXT_DATA__ discovery
-│   │   └── dom.py         # Playwright DOM-based discovery
+│   │   ├── dom.py         # Playwright DOM-based discovery
+│   │   └── inline.py      # Single-page inline job extraction (rich)
 │   ├── scrapers/          # Scraper implementations
 │   │   ├── __init__.py    # Registry + JobContent dataclass
 │   │   ├── api_sniffer.py # XHR/fetch API capture for single pages

--- a/apps/crawler/src/core/monitors/__init__.py
+++ b/apps/crawler/src/core/monitors/__init__.py
@@ -180,7 +180,7 @@ def monitor_needs_browser(name: str, config: dict | None = None) -> bool:
         if not cfg.get("api_url"):
             return True
         return bool(cfg.get("browser"))
-    if name == "dom":
+    if name in ("dom", "inline"):
         return bool((config or {}).get("render"))
     if name == "nextdata":
         cfg = config or {}
@@ -517,6 +517,7 @@ from src.core.monitors import (  # noqa: E402
     gem,  # noqa: F401
     greenhouse,  # noqa: F401
     hireology,  # noqa: F401
+    inline,  # noqa: F401
     join,  # noqa: F401
     lever,  # noqa: F401
     mokahr,  # noqa: F401

--- a/apps/crawler/src/core/monitors/inline.py
+++ b/apps/crawler/src/core/monitors/inline.py
@@ -1,0 +1,154 @@
+"""Inline single-page job extraction monitor.
+
+Extracts multiple jobs from a single career page where all postings are
+listed inline (no individual job URLs).  Uses step-based extraction
+(same as the DOM scraper) in a loop — the cursor advances through the
+page, extracting one job per iteration.
+
+Each job gets a synthetic URL with a ``_jid`` query parameter for
+pipeline compatibility::
+
+    https://example.com/open-positions?_jid=senior-engineer-a1b2c3
+
+Registered as a **rich** monitor — the scraper step is skipped.
+
+Requires playwright when ``render`` is true:
+``uv run playwright install chromium``
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+import structlog
+
+from src.core.monitors import DiscoveredJob, register
+from src.shared.browser import BROWSER_KEYS, navigate, open_page
+from src.shared.extract import flatten, walk_steps
+from src.shared.slug import slugify
+
+if TYPE_CHECKING:
+    import httpx
+
+log = structlog.get_logger()
+
+_MAX_JOBS = 500  # safety cap
+
+
+def _generate_url(board_url: str, title: str, seen: dict[str, int]) -> str:
+    """Generate a stable synthetic URL for an inline job.
+
+    Format: ``{board_url}?_jid={slug}-{hash[:6]}``
+    Appends a counter suffix on collision (identical titles).
+    """
+    slug = slugify(title)[:50]
+    title_hash = hashlib.sha256(title.strip().lower().encode()).hexdigest()[:6]
+    jid = f"{slug}-{title_hash}" if slug else title_hash
+
+    # Handle collisions (identical titles on same page)
+    count = seen.get(jid, 0)
+    seen[jid] = count + 1
+    if count > 0:
+        jid = f"{jid}-{count + 1}"
+
+    # Append _jid to the board URL, preserving existing query params
+    parsed = urlparse(board_url)
+    params = parse_qs(parsed.query, keep_blank_values=True)
+    params["_jid"] = [jid]
+    new_query = urlencode(params, doseq=True)
+    return urlunparse(parsed._replace(query=new_query))
+
+
+async def _fetch_html(
+    board_url: str,
+    metadata: dict,
+    http: httpx.AsyncClient,
+    pw=None,
+) -> str:
+    """Fetch page HTML, using Playwright when render is configured."""
+    if metadata.get("render") and pw:
+        browser_cfg = {k: v for k, v in metadata.items() if k in BROWSER_KEYS}
+        async with open_page(pw, browser_cfg, target_url=board_url) as page:
+            await navigate(page, board_url, browser_cfg)
+            return await page.content()
+
+    resp = await http.get(board_url, follow_redirects=True)
+    resp.raise_for_status()
+    return resp.text
+
+
+async def discover(
+    board: dict,
+    client: httpx.AsyncClient = None,
+    pw=None,
+) -> list[DiscoveredJob]:
+    """Extract inline jobs from a single page.
+
+    Config keys:
+        steps      — extraction steps (same format as DOM scraper)
+        render     — if true, use Playwright (default: false)
+        defaults   — default field values applied to all jobs
+        + browser keys (wait, timeout, actions, etc.)
+    """
+    board_url = board["board_url"]
+    metadata = board.get("metadata") or {}
+
+    steps = metadata.get("steps")
+    if not steps:
+        log.warning("inline.no_steps", url=board_url)
+        return []
+
+    defaults = metadata.get("defaults") or {}
+
+    html = await _fetch_html(board_url, metadata, client, pw)
+    elements = flatten(html)
+
+    if not elements:
+        log.info("inline.empty_page", url=board_url)
+        return []
+
+    # Extract jobs by running steps repeatedly
+    jobs: list[DiscoveredJob] = []
+    seen_jids: dict[str, int] = {}
+    cursor = 0
+
+    while cursor < len(elements) and len(jobs) < _MAX_JOBS:
+        result, new_cursor = walk_steps(elements, steps, start=cursor)
+
+        # Stop if no title found or cursor didn't advance
+        title = result.get("title")
+        if not title or new_cursor <= cursor:
+            break
+
+        cursor = new_cursor
+
+        url = _generate_url(board_url, title, seen_jids)
+
+        # Build DiscoveredJob with extracted + default fields
+        description = result.get("description")
+        location = result.get("location")
+        locations = None
+        if location:
+            if isinstance(location, list):
+                locations = location
+            else:
+                locations = [loc.strip() for loc in location.split(",") if loc.strip()]
+
+        job = DiscoveredJob(
+            url=url,
+            title=title,
+            description=description,
+            locations=locations or (defaults.get("locations") if not locations else None),
+            employment_type=result.get("employment_type") or defaults.get("employment_type"),
+            job_location_type=result.get("job_location_type") or defaults.get("job_location_type"),
+            date_posted=result.get("date_posted") or defaults.get("date_posted"),
+        )
+        jobs.append(job)
+
+    log.info("inline.discovered", url=board_url, jobs=len(jobs))
+    return jobs
+
+
+register("inline", discover, cost=60, rich=True)

--- a/apps/crawler/src/core/scrapers/dom.py
+++ b/apps/crawler/src/core/scrapers/dom.py
@@ -147,7 +147,7 @@ def parse_html(html: str, config: dict) -> JobContent:
     if not steps:
         return JobContent()
     elements = flatten(html)
-    raw = walk_steps(elements, steps)
+    raw, _ = walk_steps(elements, steps)
     return _map_to_job_content(raw)
 
 
@@ -264,7 +264,7 @@ async def scrape(
             )
 
     start = _fragment_start(url, elements)
-    raw = walk_steps(elements, steps, start=start)
+    raw, _ = walk_steps(elements, steps, start=start)
     content = _map_to_job_content(raw)
 
     log.debug("dom.extracted", url=url, fields=[k for k, v in raw.items() if v is not None])

--- a/apps/crawler/src/shared/extract.py
+++ b/apps/crawler/src/shared/extract.py
@@ -297,7 +297,7 @@ def walk_steps(
     steps: list[dict],
     *,
     start: int = 0,
-) -> dict[str, str | list[str] | None]:
+) -> tuple[dict[str, str | list[str] | None], int]:
     """Walk flat elements according to extraction steps, returning extracted fields.
 
     Every step with a ``field`` key is guaranteed present in the result: the
@@ -435,9 +435,9 @@ def walk_steps(
             # Anchor step — just advance cursor
             cursor = match_idx + 1
 
-    return result
+    return result, cursor
 
 
 def extract_sections(html: str, steps: list[dict]) -> dict[str, str | list[str] | None]:
     """Flatten HTML and walk extraction steps in one call."""
-    return walk_steps(flatten(html), steps)
+    return walk_steps(flatten(html), steps)[0]

--- a/apps/crawler/src/workspace/_compat.py
+++ b/apps/crawler/src/workspace/_compat.py
@@ -22,6 +22,7 @@ _RICH_MONITORS: frozenset[str] = frozenset(
         "gem",
         "greenhouse",
         "hireology",
+        "inline",
         "lever",
         "mokahr",
         "oracle_hcm",

--- a/apps/crawler/src/workspace/commands/help.py
+++ b/apps/crawler/src/workspace/commands/help.py
@@ -634,6 +634,52 @@ notion — Notion Site Job Pages
   Pair with:   notion scraper (extracts title, description, locations,
                employment_type from page blocks and collection properties)"""
 
+MONITOR_INLINE = """\
+inline — Single-Page Extraction (rich)
+
+  Returns:  Full job data (title, description, locations, etc.)
+  Scraper:  Not needed (skipped)
+  Cost:     60
+  Browser:  Only when render: true
+
+  For career pages that list all jobs inline on a single URL with no
+  individual job links (e.g., Squarespace, Webflow sites).  Extracts
+  multiple jobs by running step-based extraction repeatedly — the cursor
+  advances through the page, pulling one job per iteration.
+
+  Each job gets a synthetic URL: {board_url}?_jid={title-slug}-{hash}
+
+  Config:
+    {
+      "render": true,
+      "steps": [
+        {"tag": "h3", "field": "title"},
+        {"text": "Location", "offset": 1, "field": "location", "optional": true},
+        {"tag": "p", "field": "description", "html": true, "stop_tag": "h3"}
+      ],
+      "defaults": {"employment_type": "full_time"}
+    }
+
+    render       true = Playwright, false = static HTTP (default: false)
+    steps        Extraction steps run once per job (see: ws help steps).
+                 The first step with a field (usually title) is the stop
+                 condition — when it can't find a match, extraction ends.
+    defaults     Default field values applied when extracted value is absent.
+                 Supports: locations (list), employment_type, job_location_type,
+                 date_posted.
+    + browser keys (wait, timeout, user_agent, etc.)
+
+  Step design tips:
+    - Steps run in a loop: after extracting one job, the cursor is where
+      the next job starts.  Design steps so the last step's cursor ends
+      just before the next job's title.
+    - Use stop_tag to limit description collection: {"stop_tag": "h3"}
+      stops before the next job's heading.
+    - Use optional: true for fields that may not appear on every job.
+
+  Detection:   Not auto-detected. Select manually after inspecting the page.
+               Best for small boards (< 50 jobs) with consistent HTML structure."""
+
 MONITOR_DOM = """\
 dom — Link Extraction (fallback)
 
@@ -1788,6 +1834,7 @@ oracle_hcm — Oracle Cloud HCM REST API monitor
   Pair with oracle_hcm scraper + enrich: ["description"] for descriptions.
   Handles pagination automatically via finder param offset suffix.""",
     "dom": MONITOR_DOM,
+    "inline": MONITOR_INLINE,
     "api_sniffer": MONITOR_API_SNIFFER,
     "mokahr": MONITOR_MOKAHR,
     "signals": MONITOR_SIGNALS,

--- a/apps/crawler/tests/test_extract.py
+++ b/apps/crawler/tests/test_extract.py
@@ -138,7 +138,7 @@ class TestFlatten:
         )
         els = flatten(html)
         steps = [{"tag": "title", "field": "title"}, {"tag": "p", "field": "desc"}]
-        result = walk_steps(els, steps)
+        result, _ = walk_steps(els, steps)
         assert result["title"] == "Software Engineer"
         assert result["desc"] == "Description"
 
@@ -207,13 +207,13 @@ class TestWalkSteps:
     def test_basic_single_match(self):
         els = self._els(("h1", "Title"), ("p", "Description"))
         steps = [{"tag": "h1", "field": "title"}]
-        result = walk_steps(els, steps)
+        result, _ = walk_steps(els, steps)
         assert result["title"] == "Title"
 
     def test_text_match(self):
         els = self._els(("p", "Location: Berlin"), ("p", "Other"))
         steps = [{"text": "Location", "field": "loc"}]
-        result = walk_steps(els, steps)
+        result, _ = walk_steps(els, steps)
         assert result["loc"] == "Location: Berlin"
 
     def test_range_with_stop(self):
@@ -225,7 +225,7 @@ class TestWalkSteps:
             ("p", "Req 1"),
         )
         steps = [{"tag": "h2", "text": "Description", "field": "desc", "stop": "Requirements"}]
-        result = walk_steps(els, steps)
+        result, _ = walk_steps(els, steps)
         assert "Description" in result["desc"]
         assert "Line 1" in result["desc"]
         assert "Line 2" in result["desc"]
@@ -238,7 +238,7 @@ class TestWalkSteps:
             ("h2", "Next Section"),
         )
         steps = [{"tag": "p", "text": "Start", "field": "section", "stop_tag": "h2"}]
-        result = walk_steps(els, steps)
+        result, _ = walk_steps(els, steps)
         assert "Start" in result["section"]
         assert "Middle" in result["section"]
         assert "Next Section" not in result["section"]
@@ -251,7 +251,7 @@ class TestWalkSteps:
             ("p", "Four"),
         )
         steps = [{"tag": "p", "field": "first_two", "stop_count": 2}]
-        result = walk_steps(els, steps)
+        result, _ = walk_steps(els, steps)
         assert "One" in result["first_two"]
         assert "Two" in result["first_two"]
         assert "Three" not in result["first_two"]
@@ -261,7 +261,7 @@ class TestWalkSteps:
         steps = [{"tag": "h1", "field": "missing", "optional": True}]
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            result = walk_steps(els, steps)
+            result, _ = walk_steps(els, steps)
             assert result["missing"] is None
             assert len(w) == 0
 
@@ -270,7 +270,7 @@ class TestWalkSteps:
         steps = [{"tag": "h1", "field": "missing"}]
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            result = walk_steps(els, steps)
+            result, _ = walk_steps(els, steps)
             assert result["missing"] is None
             assert len(w) == 1
             assert "not found" in str(w[0].message)
@@ -281,7 +281,7 @@ class TestWalkSteps:
             {"tag": "div", "attrs": {"class": "job-loc"}, "text": "Berlin"},
         ]
         steps = [{"attr": "class=job-loc", "field": "location"}]
-        result = walk_steps(els, steps)
+        result, _ = walk_steps(els, steps)
         assert result["location"] == "Berlin"
 
     def test_attr_key_exists_match(self):
@@ -290,37 +290,37 @@ class TestWalkSteps:
             {"tag": "div", "attrs": {"data-role": "title"}, "text": "With attr"},
         ]
         steps = [{"attr": "data-role", "field": "val"}]
-        result = walk_steps(els, steps)
+        result, _ = walk_steps(els, steps)
         assert result["val"] == "With attr"
 
     def test_regex_capture(self):
         els = self._els(("p", "Location: Berlin, Germany"))
         steps = [{"tag": "p", "field": "city", "regex": r"Location:\s*(.+)"}]
-        result = walk_steps(els, steps)
+        result, _ = walk_steps(els, steps)
         assert result["city"] == "Berlin, Germany"
 
     def test_regex_no_match_keeps_original(self):
         els = self._els(("p", "Hello World"))
         steps = [{"tag": "p", "field": "val", "regex": r"Missing:\s*(.+)"}]
-        result = walk_steps(els, steps)
+        result, _ = walk_steps(els, steps)
         assert result["val"] == "Hello World"
 
     def test_split_produces_list(self):
         els = self._els(("p", "Python,Java,Go"))
         steps = [{"tag": "p", "field": "skills", "split": ","}]
-        result = walk_steps(els, steps)
+        result, _ = walk_steps(els, steps)
         assert result["skills"] == ["Python", "Java", "Go"]
 
     def test_split_filters_empties(self):
         els = self._els(("p", "A,,B, ,C"))
         steps = [{"tag": "p", "field": "items", "split": ","}]
-        result = walk_steps(els, steps)
+        result, _ = walk_steps(els, steps)
         assert result["items"] == ["A", "B", "C"]
 
     def test_offset_skips_elements(self):
         els = self._els(("h2", "Title"), ("p", "Subtitle"), ("p", "Content"))
         steps = [{"tag": "h2", "field": "val", "offset": 1}]
-        result = walk_steps(els, steps)
+        result, _ = walk_steps(els, steps)
         assert result["val"] == "Subtitle"
 
     def test_from_seeks_from_index(self):
@@ -330,7 +330,7 @@ class TestWalkSteps:
             {"tag": "p", "field": "a"},
             {"tag": "p", "field": "b", "from": 0},
         ]
-        result = walk_steps(els, steps)
+        result, _ = walk_steps(els, steps)
         assert result["a"] == "First"
         assert result["b"] == "First"  # "from": 0 overrides cursor
 
@@ -342,7 +342,7 @@ class TestWalkSteps:
             {"tag": "h2", "attrs": {}, "text": "Next"},
         ]
         steps = [{"tag": "p", "text": "Intro", "field": "content", "stop": "Next", "html": True}]
-        result = walk_steps(els, steps)
+        result, _ = walk_steps(els, steps)
         assert "<p>Intro</p>" in result["content"]
         assert "<ul>" in result["content"]
         assert "<li>Item 1</li>" in result["content"]
@@ -358,7 +358,7 @@ class TestWalkSteps:
         ]
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
-            result = walk_steps(els, steps)
+            result, _ = walk_steps(els, steps)
         assert "found" in result
         assert "missing" in result
         assert "also_missing" in result
@@ -372,20 +372,20 @@ class TestWalkSteps:
             {"tag": "h1"},  # anchor — no field
             {"tag": "p", "field": "val"},
         ]
-        result = walk_steps(els, steps)
+        result, _ = walk_steps(els, steps)
         assert "val" in result
         assert result["val"] == "Para 1"
 
     def test_unicode_text_matching(self):
         els = self._els(("p", "What\u2019s New"))
         steps = [{"text": "What's New", "field": "title"}]
-        result = walk_steps(els, steps)
+        result, _ = walk_steps(els, steps)
         assert result["title"] == "What\u2019s New"
 
     def test_case_insensitive_matching(self):
         els = self._els(("h2", "JOB DESCRIPTION"), ("p", "Details here"))
         steps = [{"text": "job description", "field": "heading"}]
-        result = walk_steps(els, steps)
+        result, _ = walk_steps(els, steps)
         assert result["heading"] == "JOB DESCRIPTION"
 
     def test_case_insensitive_stop(self):
@@ -394,7 +394,7 @@ class TestWalkSteps:
             ("h2", "REQUIREMENTS"),
         )
         steps = [{"tag": "p", "field": "section", "stop": "requirements"}]
-        result = walk_steps(els, steps)
+        result, _ = walk_steps(els, steps)
         assert result["section"] == "Content"
 
 
@@ -406,7 +406,7 @@ class TestExtractSections:
             {"tag": "p", "field": "body"},
         ]
         result = extract_sections(html, steps)
-        expected = walk_steps(flatten(html), steps)
+        expected, _ = walk_steps(flatten(html), steps)
         assert result == expected
 
     def test_end_to_end(self):

--- a/apps/crawler/tests/test_inline_monitor.py
+++ b/apps/crawler/tests/test_inline_monitor.py
@@ -1,0 +1,227 @@
+"""Tests for the inline single-page monitor."""
+
+from __future__ import annotations
+
+import pytest
+
+from src.core.monitors.inline import _generate_url, discover
+from src.shared.extract import flatten, walk_steps
+
+# ── walk_steps returns cursor ──────────────────────────────────────────
+
+
+def test_walk_steps_returns_cursor():
+    elements = [
+        {"tag": "h1", "attrs": {}, "text": "Title"},
+        {"tag": "p", "attrs": {}, "text": "Description"},
+    ]
+    result, cursor = walk_steps(elements, [{"tag": "h1", "field": "title"}])
+    assert result["title"] == "Title"
+    assert cursor == 1
+
+
+def test_walk_steps_cursor_advances_through_range():
+    elements = [
+        {"tag": "h3", "attrs": {}, "text": "Job A"},
+        {"tag": "p", "attrs": {}, "text": "Desc A line 1"},
+        {"tag": "p", "attrs": {}, "text": "Desc A line 2"},
+        {"tag": "h3", "attrs": {}, "text": "Job B"},
+        {"tag": "p", "attrs": {}, "text": "Desc B"},
+    ]
+    steps = [
+        {"tag": "h3", "field": "title"},
+        {"tag": "p", "field": "description", "stop_tag": "h3"},
+    ]
+
+    result_a, cursor_a = walk_steps(elements, steps, start=0)
+    assert result_a["title"] == "Job A"
+    assert "Desc A line 1" in result_a["description"]
+    assert cursor_a == 3  # at "Job B"
+
+    result_b, cursor_b = walk_steps(elements, steps, start=cursor_a)
+    assert result_b["title"] == "Job B"
+    assert "Desc B" in result_b["description"]
+    assert cursor_b > cursor_a
+
+
+# ── Repeated extraction ────────────────────────────────────────────────
+
+
+SAMPLE_HTML = """
+<html><body>
+<h3>Software Engineer</h3>
+<p>Location: Zurich, Switzerland</p>
+<p>We are looking for a talented engineer to join our team.</p>
+
+<h3>Product Manager</h3>
+<p>Location: Berlin, Germany</p>
+<p>Lead our product strategy and roadmap.</p>
+
+<h3>Data Scientist</h3>
+<p>Location: London, UK</p>
+<p>Apply ML to solve real problems.</p>
+</body></html>
+"""
+
+
+def test_repeated_extraction():
+    elements = flatten(SAMPLE_HTML)
+    steps = [
+        {"tag": "h3", "field": "title"},
+        {"text": "Location", "field": "location"},
+        {"tag": "p", "field": "description", "stop_tag": "h3"},
+    ]
+
+    jobs = []
+    cursor = 0
+    while cursor < len(elements):
+        result, new_cursor = walk_steps(elements, steps, start=cursor)
+        if not result.get("title") or new_cursor <= cursor:
+            break
+        jobs.append(result)
+        cursor = new_cursor
+
+    assert len(jobs) == 3
+    assert jobs[0]["title"] == "Software Engineer"
+    assert jobs[1]["title"] == "Product Manager"
+    assert jobs[2]["title"] == "Data Scientist"
+    assert "Zurich" in jobs[0]["location"]
+    assert "Berlin" in jobs[1]["location"]
+
+
+# ── URL generation ─────────────────────────────────────────────────────
+
+
+def test_generate_url_stable():
+    seen: dict[str, int] = {}
+    url1 = _generate_url("https://example.com/careers", "Software Engineer", seen)
+    seen2: dict[str, int] = {}
+    url2 = _generate_url("https://example.com/careers", "Software Engineer", seen2)
+    assert url1 == url2
+    assert "_jid=software-engineer-" in url1
+
+
+def test_generate_url_different_titles():
+    seen: dict[str, int] = {}
+    url1 = _generate_url("https://example.com/careers", "Software Engineer", seen)
+    url2 = _generate_url("https://example.com/careers", "Product Manager", seen)
+    assert url1 != url2
+
+
+def test_generate_url_collision():
+    seen: dict[str, int] = {}
+    url1 = _generate_url("https://example.com/careers", "Engineer", seen)
+    url2 = _generate_url("https://example.com/careers", "Engineer", seen)
+    assert url1 != url2
+    assert "-2" in url2
+
+
+def test_generate_url_with_existing_params():
+    seen: dict[str, int] = {}
+    url = _generate_url("https://example.com/jobs?lang=en", "Engineer", seen)
+    assert "lang=en" in url
+    assert "_jid=" in url
+
+
+def test_generate_url_slug_caps_length():
+    seen: dict[str, int] = {}
+    long_title = "A" * 200
+    url = _generate_url("https://example.com/careers", long_title, seen)
+    # The slug portion (before the hash) should be capped
+    assert len(url) < 300
+
+
+# ── discover() end-to-end ──────────────────────────────────────────────
+
+
+class _FakeResponse:
+    def __init__(self, text: str):
+        self.text = text
+        self.status_code = 200
+
+    def raise_for_status(self):
+        pass
+
+
+class _FakeClient:
+    def __init__(self, html: str):
+        self._html = html
+
+    async def get(self, url, **kwargs):
+        return _FakeResponse(self._html)
+
+
+@pytest.mark.asyncio
+async def test_discover_static():
+    client = _FakeClient(SAMPLE_HTML)
+    board = {
+        "board_url": "https://example.com/open-positions",
+        "metadata": {
+            "steps": [
+                {"tag": "h3", "field": "title"},
+                {"text": "Location", "field": "location", "regex": "Location:\\s*(.+)"},
+                {"tag": "p", "field": "description", "stop_tag": "h3"},
+            ],
+        },
+    }
+    jobs = await discover(board, client)
+
+    assert len(jobs) == 3
+    assert jobs[0].title == "Software Engineer"
+    assert jobs[0].locations == ["Zurich", "Switzerland"]
+    assert jobs[1].title == "Product Manager"
+    assert "_jid=" in jobs[0].url
+    assert jobs[0].url != jobs[1].url
+
+
+@pytest.mark.asyncio
+async def test_discover_with_defaults():
+    html = """
+    <html><body>
+    <h3>Engineer</h3>
+    <p>Build things.</p>
+    </body></html>
+    """
+    client = _FakeClient(html)
+    board = {
+        "board_url": "https://example.com/jobs",
+        "metadata": {
+            "steps": [
+                {"tag": "h3", "field": "title"},
+                {"tag": "p", "field": "description", "stop_tag": "h3"},
+            ],
+            "defaults": {
+                "employment_type": "full_time",
+                "job_location_type": "onsite",
+            },
+        },
+    }
+    jobs = await discover(board, client)
+
+    assert len(jobs) == 1
+    assert jobs[0].employment_type == "full_time"
+    assert jobs[0].job_location_type == "onsite"
+
+
+@pytest.mark.asyncio
+async def test_discover_empty_page():
+    client = _FakeClient("<html><body></body></html>")
+    board = {
+        "board_url": "https://example.com/jobs",
+        "metadata": {
+            "steps": [{"tag": "h3", "field": "title"}],
+        },
+    }
+    jobs = await discover(board, client)
+    assert jobs == []
+
+
+@pytest.mark.asyncio
+async def test_discover_no_steps():
+    client = _FakeClient("")
+    board = {
+        "board_url": "https://example.com/jobs",
+        "metadata": {},
+    }
+    jobs = await discover(board, client)
+    assert jobs == []


### PR DESCRIPTION
## Summary
- New `inline` rich monitor type for career pages that list all jobs on a single page with no individual URLs (Squarespace, Webflow, etc.)
- Extracts multiple jobs by running `walk_steps()` repeatedly — the cursor advances through the page, pulling one job per iteration until no more titles are found
- Each job gets a synthetic URL: `{board_url}?_jid={title-slug}-{hash}` — stable across runs for dedup, preserves existing UNIQUE constraint, no schema changes needed
- `walk_steps()` now returns `(result_dict, cursor_position)` tuple to support chained calls

### How it works
```json
{
  "render": true,
  "steps": [
    {"tag": "h3", "field": "title"},
    {"text": "Location", "offset": 1, "field": "location", "regex": "Location:\\s*(.+)"},
    {"tag": "p", "field": "description", "html": true, "stop_tag": "h3"}
  ],
  "defaults": {"employment_type": "full_time"}
}
```

The steps define a repeating pattern. After extracting one job (h3 → location → description), the cursor is at the next h3. Run the steps again → next job. No `job_marker` needed.

### Files changed
- `src/shared/extract.py` — `walk_steps` returns `(dict, int)` tuple
- `src/core/scrapers/dom.py` — unpack tuple at 2 call sites
- `src/core/monitors/inline.py` — **new** monitor module
- `src/core/monitors/__init__.py` — import + `monitor_needs_browser`
- `src/workspace/_compat.py` — add to `_RICH_MONITORS`
- `src/workspace/commands/help.py` — `ws help monitor inline` docs
- `AGENTS.md` — listing
- `tests/test_extract.py` — update for tuple return
- `tests/test_inline_monitor.py` — **new** 12 tests

## Test plan
- [x] All 2774 tests pass (2762 existing + 12 new)
- [ ] `ws select monitor <slug> inline --config '...'` → `ws run monitor` on a real single-page board

🤖 Generated with [Claude Code](https://claude.com/claude-code)