### PR TITLE
Fix sync failing in CI when local Postgres is unreachable

### DIFF
--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -50,3 +50,4 @@ jobs:
         env:
           DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED || secrets.DATABASE_URL }}
           DATABASE_URL: ${{ secrets.DATABASE_URL_UNPOOLED || secrets.DATABASE_URL }}
+          LOCAL_DATABASE_URL: ${{ secrets.LOCAL_DATABASE_URL }}

--- a/apps/crawler/src/sync.py
+++ b/apps/crawler/src/sync.py
@@ -1224,7 +1224,12 @@ async def run_sync(dry_run: bool = False) -> None:
         return
 
     supa_pool = await create_pool()
-    local_pool = None if dry_run else await create_local_pool()
+    local_pool = None
+    if not dry_run:
+        try:
+            local_pool = await create_local_pool()
+        except OSError:
+            log.warning("sync.local_pool_unavailable", msg="Cannot reach local Postgres, skipping")
     try:
         async with supa_pool.acquire() as supa_conn, supa_conn.transaction():
             await supa_conn.execute("SET lock_timeout = '30s'")


### PR DESCRIPTION
## Summary
- `sync.py` unconditionally calls `create_local_pool()` which tries to connect to `postgres:5432` (Docker hostname)
- In CI (GitHub Actions), this hostname doesn't resolve → `socket.gaierror: Temporary failure in name resolution`
- Fix: catch `OSError` and skip local Postgres sync gracefully — Supabase sync continues normally

Introduced by #1194 which added local Postgres lookup table mirroring to the sync path.

## Test plan
- [x] All 2774 tests pass
- [ ] CI sync-data workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)