### PR TITLE
Fix location backfill OOM on large boards

### DIFF
--- a/apps/crawler/src/core/location_resolve.py
+++ b/apps/crawler/src/core/location_resolve.py
@@ -739,6 +739,10 @@ class LocationResolver:
 
         Inserts results into SQLite so subsequent ``resolve()`` calls hit.
         Returns True if new names were added.
+
+        Queries are chunked to avoid shared-memory exhaustion on Postgres
+        when thousands of location names need backfilling (e.g. Amazon
+        with 17k+ jobs per crawl).
         """
         if not self._pool or not self._misses or self._db is None:
             return False
@@ -746,23 +750,26 @@ class LocationResolver:
         missed = list(self._misses)
         self._misses.clear()
 
-        async with self._pool.acquire() as conn:
-            rows = await conn.fetch(
-                "SELECT location_id, lower(name) AS name "
-                "FROM location_name WHERE lower(name) = ANY($1::text[])",
-                missed,
-            )
-
-        if not rows:
-            self._negative.update(missed)
-            return False
-
+        _CHUNK = 500
         matched_keys: set[str] = set()
         name_pairs: list[tuple[str, int]] = []
-        for row in rows:
-            matched_keys.add(row["name"])
-            for variant in self._name_variants(row["name"]):
-                name_pairs.append((variant, row["location_id"]))
+
+        for i in range(0, len(missed), _CHUNK):
+            chunk = missed[i : i + _CHUNK]
+            async with self._pool.acquire() as conn:
+                rows = await conn.fetch(
+                    "SELECT location_id, lower(name) AS name "
+                    "FROM location_name WHERE lower(name) = ANY($1::text[])",
+                    chunk,
+                )
+            for row in rows:
+                matched_keys.add(row["name"])
+                for variant in self._name_variants(row["name"]):
+                    name_pairs.append((variant, row["location_id"]))
+
+        if not name_pairs:
+            self._negative.update(missed)
+            return False
 
         self._db.executemany(
             "INSERT OR IGNORE INTO name_index (name, location_id) VALUES (?, ?)",


### PR DESCRIPTION
## Summary

Amazon's monitor (~17k jobs per crawl) was crashing the Postgres container during location resolution. The `backfill_misses()` method sent all accumulated location name misses in a single `ANY($1::text[])` query, exhausting shared memory.

**Code fix:** Chunk the backfill query into batches of 500 names, keeping individual query memory bounded.

**Infra fix** (already applied to Hetzner):
| Setting | Before | After | Why |
|---------|--------|-------|-----|
| Container memory | 512MB | 2GB | Machine has 7.6GB RAM, 4.8GB free |
| `shared_buffers` | 128MB | 512MB | Standard recommendation: 25% of container RAM |
| `work_mem` | 4MB | 16MB | Allows larger sorts/hashes for batch queries |
| `shm-size` | 64MB | 256MB | Prevents `/dev/shm` exhaustion |

**Root cause trace:** Amazon monitor partitions by country, discovers ~17k jobs, passes them through location resolution. The resolver accumulates misses during `resolve()`, then `backfill_misses()` queries Postgres for all of them at once. With thousands of names in a single `ANY()` clause, the query exceeded shared memory → `DiskFullError` → monitor crash → 13,829 jobs left with NULL `location_ids`.

## Test plan
- [x] 456 location-related tests pass
- [x] Postgres container restarted with new settings, verified `shared_buffers=512MB`, `work_mem=16MB`
- [ ] Requeue Amazon board and verify location resolution completes without OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)