### PR TITLE
Link Apify badge to company-discovery-actor OpenAPI page

### DIFF
--- a/apps/web/app/agentic/page.tsx
+++ b/apps/web/app/agentic/page.tsx
@@ -169,7 +169,7 @@ export default function Page() {
 
         <div className="flex items-center gap-3 pt-2">
           <a
-            href="https://apify.com"
+            href="https://apify.com/golanger/company-discovery-actor/api/openapi"
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-1.5 text-xs text-muted border border-divider rounded-full px-3 py-1 hover:border-foreground/30 transition-colors"


### PR DESCRIPTION
## Summary
- Updates the "Powered by Apify" badge link on the agentic API page to point to the specific actor's OpenAPI page instead of the generic apify.com homepage