### PR TITLE
Add career-vs-linkedin Apify research actor

### DIFF
--- a/apify/actors/career-vs-linkedin/.actor/actor.json
+++ b/apify/actors/career-vs-linkedin/.actor/actor.json
@@ -1,0 +1,88 @@
+{
+  "actorSpecification": 1,
+  "name": "career-vs-linkedin",
+  "title": "Career Page vs LinkedIn — First-Posting Proof",
+  "description": "Uses the Wayback Machine to compare when jobs first appeared on a company's career page versus LinkedIn, providing historical evidence that career pages are the primary source of job postings — often days or weeks before LinkedIn indexes them.",
+  "version": "1.0",
+  "environmentVariables": {
+    "GOOGLE_AI_API_KEY": "@GOOGLE_AI_API_KEY"
+  },
+  "input": {
+    "title": "Input",
+    "type": "object",
+    "schemaVersion": 1,
+    "properties": {
+      "companyName": {
+        "title": "Company name",
+        "type": "string",
+        "description": "Human-readable company name (e.g. 'Stripe'). Auto-detected from careerPageUrl if omitted.",
+        "editor": "textfield"
+      },
+      "careerPageUrl": {
+        "title": "Career page URL",
+        "type": "string",
+        "description": "The company's career portal URL. Examples: https://boards.greenhouse.io/stripe, https://jobs.lever.co/openai, https://jobs.ashbyhq.com/linear",
+        "editor": "textfield"
+      },
+      "linkedinSlug": {
+        "title": "LinkedIn company slug",
+        "type": "string",
+        "description": "The company slug from their LinkedIn URL (e.g. 'stripe' from linkedin.com/company/stripe). Used to find LinkedIn job page archives.",
+        "editor": "textfield"
+      },
+      "linkedinCompanyId": {
+        "title": "LinkedIn company ID (numeric)",
+        "type": "string",
+        "description": "Numeric LinkedIn company ID for jobs/search?f_C= URLs. Optional — use linkedinSlug instead if possible.",
+        "editor": "textfield"
+      },
+      "batchMode": {
+        "title": "Batch mode",
+        "type": "boolean",
+        "description": "Run on multiple companies at once. Uses built-in seed list (Stripe, Coinbase, Anthropic, OpenAI…) unless you supply a custom companies list.",
+        "default": false,
+        "editor": "checkbox"
+      },
+      "companies": {
+        "title": "Companies list (batch mode)",
+        "type": "array",
+        "description": "Override the seed list. Each item: { name, careerPageUrl, linkedinSlug?, linkedinCompanyId? }",
+        "editor": "json"
+      },
+      "startDate": {
+        "title": "Start date (YYYY-MM-DD)",
+        "type": "string",
+        "description": "Earliest Wayback snapshot date to analyze. Defaults to 1 year ago.",
+        "editor": "textfield"
+      },
+      "endDate": {
+        "title": "End date (YYYY-MM-DD)",
+        "type": "string",
+        "description": "Latest Wayback snapshot date to analyze. Defaults to today.",
+        "editor": "textfield"
+      },
+      "maxSnapshots": {
+        "title": "Max snapshots per source",
+        "type": "integer",
+        "description": "Maximum number of CDX snapshots to fetch per platform (career page and LinkedIn separately). Higher = more evidence but slower.",
+        "editor": "number",
+        "default": 60
+      },
+      "delayMs": {
+        "title": "Delay between requests (ms)",
+        "type": "integer",
+        "description": "Milliseconds to wait between Wayback Machine requests to avoid rate limits.",
+        "editor": "number",
+        "default": 1500
+      },
+      "googleAiApiKey": {
+        "title": "Google AI API key (Gemini)",
+        "type": "string",
+        "description": "Gemini key for research narrative generation. Leave blank to use the GOOGLE_AI_API_KEY secret, or omit for stats-only output.",
+        "editor": "textfield",
+        "isSecret": true
+      }
+    },
+    "required": []
+  }
+}

--- a/apify/actors/career-vs-linkedin/package.json
+++ b/apify/actors/career-vs-linkedin/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "career-vs-linkedin",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/main.js",
+  "scripts": {
+    "start": "node dist/main.js",
+    "build": "npx esbuild src/main.ts --bundle --outfile=dist/main.js --platform=node --target=node20 --format=esm --packages=external",
+    "dev": "ts-node src/main.ts"
+  },
+  "dependencies": {
+    "apify": "^3.0.0",
+    "cheerio": "^1.0.0",
+    "@google/generative-ai": "^0.21.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "@types/node": "^20.0.0",
+    "ts-node": "^10.9.0",
+    "esbuild": "^0.25.0"
+  }
+}

--- a/apify/actors/career-vs-linkedin/src/career.ts
+++ b/apify/actors/career-vs-linkedin/src/career.ts
@@ -1,0 +1,320 @@
+import { log } from 'apify';
+import { load } from 'cheerio';
+import { fetchCdxSnapshots } from './cdx.js';
+import { fetchArchivedPage, fetchArchivedJson } from './fetch.js';
+import { normalizeTitle } from './match.js';
+import type { CdxSnapshot, JobSighting } from './types.js';
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+/**
+ * Collect all unique jobs seen on a company career portal over a date range,
+ * using Wayback Machine CDX snapshots.
+ *
+ * For known ATS platforms (Greenhouse, Lever, Ashby, SmartRecruiters, Workable)
+ * the actor CDXes their API endpoints directly — those are well-archived and include
+ * structured datePosted data. For unknown portals it falls back to HTML snapshots.
+ *
+ * Returns a map of normalizedTitle → JobSighting (first sighting only).
+ */
+export async function collectCareerJobs(
+  portalUrl: string,
+  startDate: string,
+  endDate: string,
+  maxSnapshots: number,
+  delayMs: number,
+): Promise<Map<string, JobSighting>> {
+  const jobs = new Map<string, JobSighting>();
+
+  // Detect ATS type and pick the best CDX target URL
+  const atsInfo = detectAts(portalUrl);
+  if (atsInfo) {
+    log.info(`Career portal: detected ${atsInfo.type}, using API CDX URL`, { apiUrl: atsInfo.apiUrl });
+    await collectFromAtsApi(jobs, atsInfo, startDate, endDate, maxSnapshots, delayMs);
+  }
+
+  // Also try the portal HTML page for extra coverage (or as fallback)
+  if (jobs.size === 0) {
+    log.info('Career portal: falling back to HTML snapshot extraction', { url: portalUrl });
+    const snapshots = await fetchCdxSnapshots({ url: portalUrl, startDate, endDate, maxSnapshots });
+    log.info(`Career portal: ${snapshots.length} HTML snapshots found`, { url: portalUrl });
+    for (let i = 0; i < snapshots.length; i++) {
+      const snap = snapshots[i];
+      const date = snapshotToDate(snap.timestamp);
+      log.info(`[career-html ${i + 1}/${snapshots.length}] ${date}`);
+      const html = await fetchArchivedPage(snap.timestamp, snap.original);
+      if (html) mergeJobs(jobs, extractFromHtml(html, snap), snap);
+      if (i < snapshots.length - 1) await sleep(delayMs);
+    }
+  }
+
+  log.info(`Career portal: ${jobs.size} unique jobs collected`);
+  return jobs;
+}
+
+interface AtsInfo {
+  type: string;
+  apiUrl: string;
+  /** Extract jobs from an archived API response body. */
+  extract: (body: unknown) => Partial<JobSighting>[];
+}
+
+/** Detect the ATS platform from a portal URL and return CDX target + extractor. */
+function detectAts(portalUrl: string): AtsInfo | null {
+  let url: URL;
+  try { url = new URL(portalUrl); } catch { return null; }
+
+  // Greenhouse: boards.greenhouse.io/{token}
+  if (/^boards\.greenhouse\.io$/i.test(url.hostname)) {
+    const token = url.pathname.split('/').filter(Boolean)[0];
+    if (!token) return null;
+    return {
+      type: 'greenhouse',
+      apiUrl: `https://boards-api.greenhouse.io/v1/boards/${token}/jobs?content=false`,
+      extract: (body) => {
+        const data = body as { jobs?: GhJob[] };
+        return (data.jobs ?? []).map(j => ({
+          title: j.title,
+          location: j.location?.name,
+          department: j.departments?.[0]?.name,
+          id: String(j.id),
+          datePosted: j.updated_at?.slice(0, 10),
+          extractionMethod: 'greenhouse-api',
+        }));
+      },
+    };
+  }
+
+  // Lever: jobs.lever.co/{company}
+  if (/^jobs\.lever\.co$/i.test(url.hostname)) {
+    const company = url.pathname.split('/').filter(Boolean)[0];
+    if (!company) return null;
+    return {
+      type: 'lever',
+      apiUrl: `https://api.lever.co/v0/postings/${company}?mode=json&limit=500`,
+      extract: (body) => {
+        const postings = body as LeverPosting[];
+        if (!Array.isArray(postings)) return [];
+        return postings.map(p => ({
+          title: p.text,
+          location: p.categories?.location,
+          department: p.categories?.department,
+          id: p.id,
+          datePosted: p.createdAt ? new Date(p.createdAt).toISOString().slice(0, 10) : undefined,
+          extractionMethod: 'lever-api',
+        }));
+      },
+    };
+  }
+
+  // SmartRecruiters: jobs.smartrecruiters.com/{company}
+  if (/^jobs\.smartrecruiters\.com$/i.test(url.hostname)) {
+    const company = url.pathname.split('/').filter(Boolean)[0];
+    if (!company) return null;
+    return {
+      type: 'smartrecruiters',
+      apiUrl: `https://api.smartrecruiters.com/v1/companies/${company}/postings?limit=100&status=PUBLIC`,
+      extract: (body) => {
+        const data = body as SRResponse;
+        return (data.content ?? []).map(j => ({
+          title: j.name,
+          location: [j.location?.city, j.location?.country].filter(Boolean).join(', '),
+          department: j.department?.label,
+          id: j.id,
+          datePosted: j.releasedDate?.slice(0, 10),
+          extractionMethod: 'smartrecruiters-api',
+        }));
+      },
+    };
+  }
+
+  // Workable: {company}.workable.com
+  const workableMatch = url.hostname.match(/^([^.]+)\.workable\.com$/i);
+  if (workableMatch) {
+    const company = workableMatch[1];
+    return {
+      type: 'workable',
+      apiUrl: `https://apply.workable.com/api/v1/widget/accounts/${company}/jobs`,
+      extract: (body) => {
+        const data = body as WorkableResponse;
+        return (data.jobs ?? []).map(j => ({
+          title: j.title,
+          location: j.location?.location_str,
+          department: j.department,
+          id: j.id,
+          datePosted: j.created_at?.slice(0, 10),
+          extractionMethod: 'workable-api',
+        }));
+      },
+    };
+  }
+
+  return null;
+}
+
+/** Fetch CDX snapshots for an ATS API endpoint and extract jobs from each snapshot. */
+async function collectFromAtsApi(
+  jobs: Map<string, JobSighting>,
+  ats: AtsInfo,
+  startDate: string,
+  endDate: string,
+  maxSnapshots: number,
+  delayMs: number,
+): Promise<void> {
+  const snapshots = await fetchCdxSnapshots({ url: ats.apiUrl, startDate, endDate, maxSnapshots });
+  log.info(`Career ATS API: ${snapshots.length} snapshots`, { url: ats.apiUrl, type: ats.type });
+  for (let i = 0; i < snapshots.length; i++) {
+    const snap = snapshots[i];
+    const date = snapshotToDate(snap.timestamp);
+    log.info(`[career-api ${i + 1}/${snapshots.length}] ${date} (${ats.type})`);
+    const data = await fetchArchivedJson<unknown>(snap.timestamp, snap.original);
+    if (data) mergeJobs(jobs, ats.extract(data), snap);
+    if (i < snapshots.length - 1) await sleep(delayMs);
+  }
+}
+
+/** Merge extracted jobs into the registry, keeping the earliest sighting per title. */
+function mergeJobs(
+  registry: Map<string, JobSighting>,
+  extracted: Partial<JobSighting>[],
+  snap: CdxSnapshot,
+): void {
+  const date = snapshotToDate(snap.timestamp);
+  const snapshotUrl = `https://web.archive.org/web/${snap.timestamp}/${snap.original}`;
+
+  for (const raw of extracted) {
+    if (!raw.title?.trim()) continue;
+    const normTitle = normalizeTitle(raw.title);
+    if (!normTitle) continue;
+
+    const existing = registry.get(normTitle);
+    // For career page: use datePosted if available, else snapshot date
+    const effectiveDate = raw.datePosted ?? date;
+
+    if (!existing || effectiveDate < existing.firstSeen) {
+      registry.set(normTitle, {
+        title: raw.title,
+        normalizedTitle: normTitle,
+        firstSeen: effectiveDate,
+        datePosted: raw.datePosted,
+        snapshotUrl,
+        location: raw.location,
+        department: raw.department,
+        id: raw.id,
+        platform: 'career_page',
+        extractionMethod: raw.extractionMethod ?? 'unknown',
+      });
+    }
+  }
+}
+
+/** Convert CDX timestamp (YYYYMMDDHHmmss) to YYYY-MM-DD. */
+function snapshotToDate(ts: string): string {
+  return `${ts.slice(0, 4)}-${ts.slice(4, 6)}-${ts.slice(6, 8)}`;
+}
+
+// ── ATS response type interfaces ─────────────────────────────────────────────
+
+interface GhJob { id: number; title: string; location: { name: string }; departments: { name: string }[]; updated_at: string }
+interface LeverPosting { id: string; text: string; categories: { location?: string; department?: string }; createdAt: number }
+interface SRJob { id: string; name: string; location: { city?: string; country?: string }; department: { label?: string }; releasedDate?: string }
+interface SRResponse { content: SRJob[] }
+interface WorkableJob { id: string; title: string; location?: { location_str?: string }; department?: string; created_at?: string }
+interface WorkableResponse { jobs: WorkableJob[] }
+
+// ── HTML-based extractors ─────────────────────────────────────────────────────
+
+function extractFromHtml(html: string, snap: CdxSnapshot): Partial<JobSighting>[] {
+  const $ = load(html);
+  const results: Partial<JobSighting>[] = [];
+
+  // 1. JSON-LD JobPosting
+  $('script[type="application/ld+json"]').each((_, el) => {
+    try {
+      const raw = $(el).html() ?? '';
+      const data: unknown = JSON.parse(raw);
+      const items = Array.isArray(data) ? data : [data];
+      for (const item of items) {
+        if (!item || typeof item !== 'object') continue;
+        const obj = item as Record<string, unknown>;
+        if (obj['@type'] === 'JobPosting' || (Array.isArray(obj['@type']) && (obj['@type'] as string[]).includes('JobPosting'))) {
+          const title = String(obj['title'] ?? obj['name'] ?? '').trim();
+          if (!title) continue;
+          results.push({
+            title,
+            datePosted: obj['datePosted'] ? String(obj['datePosted']).slice(0, 10) : undefined,
+            location: extractLocationFromJsonLd(obj),
+            department: obj['occupationalCategory'] ? String(obj['occupationalCategory']) : undefined,
+            extractionMethod: 'jsonld',
+          });
+        }
+      }
+    } catch { /* skip */ }
+  });
+  if (results.length > 0) return results;
+
+  // 2. __NEXT_DATA__
+  return extractJobsFromNextData(html, 'html');
+}
+
+function extractLocationFromJsonLd(obj: Record<string, unknown>): string | undefined {
+  const loc = obj['jobLocation'];
+  if (!loc) return undefined;
+  const items = Array.isArray(loc) ? loc : [loc];
+  const parts: string[] = [];
+  for (const l of items) {
+    if (typeof l === 'string') { if (l) parts.push(l); }
+    else if (l && typeof l === 'object') {
+      const lo = l as Record<string, unknown>;
+      const addr = lo['address'] as Record<string, unknown> | undefined;
+      const part = String(lo['name'] ?? addr?.['addressLocality'] ?? addr?.['addressRegion'] ?? '').trim();
+      if (part) parts.push(part);
+    }
+  }
+  return parts.length > 0 ? parts.join(', ') : undefined;
+}
+
+function extractJobsFromNextData(html: string, method: string): Partial<JobSighting>[] {
+  const $ = load(html);
+  const script = $('script#__NEXT_DATA__').html() ?? '';
+  if (!script) return [];
+  try {
+    const data = JSON.parse(script) as Record<string, unknown>;
+    return findJobsInObject(data, method);
+  } catch { return []; }
+}
+
+function findJobsInObject(obj: unknown, method: string, depth = 0): Partial<JobSighting>[] {
+  if (depth > 10 || !obj || typeof obj !== 'object') return [];
+  if (Array.isArray(obj)) {
+    // Check if this looks like a job array
+    const sample = obj[0];
+    if (sample && typeof sample === 'object') {
+      const s = sample as Record<string, unknown>;
+      if ('title' in s || 'jobTitle' in s || 'name' in s) {
+        return (obj as Record<string, unknown>[])
+          .map(item => {
+            const title = String(item['title'] ?? item['jobTitle'] ?? item['name'] ?? '').trim();
+            if (!title) return null;
+            return {
+              title,
+              datePosted: item['datePosted'] ? String(item['datePosted']).slice(0, 10) : (item['created_at'] ? String(item['created_at']).slice(0, 10) : undefined),
+              location: item['location'] ? String(typeof item['location'] === 'object' ? (item['location'] as Record<string, unknown>)['name'] ?? '' : item['location']) : undefined,
+              department: item['department'] ? String(typeof item['department'] === 'object' ? (item['department'] as Record<string, unknown>)['name'] ?? '' : item['department']) : undefined,
+              extractionMethod: method,
+            } as Partial<JobSighting>;
+          })
+          .filter((j): j is Partial<JobSighting> => j !== null);
+      }
+    }
+    const collected: Partial<JobSighting>[] = [];
+    for (const item of obj) collected.push(...findJobsInObject(item, method, depth + 1));
+    return collected;
+  }
+  const record = obj as Record<string, unknown>;
+  const collected: Partial<JobSighting>[] = [];
+  for (const val of Object.values(record)) {
+    if (val && typeof val === 'object') collected.push(...findJobsInObject(val, method, depth + 1));
+  }
+  return collected;
+}

--- a/apify/actors/career-vs-linkedin/src/career.ts
+++ b/apify/actors/career-vs-linkedin/src/career.ts
@@ -254,7 +254,11 @@ function extractFromHtml(html: string, snap: CdxSnapshot): Partial<JobSighting>[
   if (results.length > 0) return results;
 
   // 2. __NEXT_DATA__
-  return extractJobsFromNextData(html, 'html');
+  const nextData = extractJobsFromNextData(html, 'html');
+  if (nextData.length > 0) return nextData;
+
+  // 3. Greenhouse boards HTML: <div class="opening"><a href="/slug/jobs/ID">Title</a><span class="location">…</span></div>
+  return extractFromGreenhouseBoards($);
 }
 
 function extractLocationFromJsonLd(obj: Record<string, unknown>): string | undefined {
@@ -272,6 +276,29 @@ function extractLocationFromJsonLd(obj: Record<string, unknown>): string | undef
     }
   }
   return parts.length > 0 ? parts.join(', ') : undefined;
+}
+
+function extractFromGreenhouseBoards($: ReturnType<typeof load>): Partial<JobSighting>[] {
+  const results: Partial<JobSighting>[] = [];
+  $('div.opening').each((_, el) => {
+    const a = $(el).find('a').first();
+    const title = a.text().trim();
+    if (!title) return;
+    const location = $(el).find('span.location').first().text().trim() || undefined;
+    // department: nearest preceding <h3> within parent section
+    const section = $(el).closest('section');
+    const department = section.find('h3').first().text().trim() || undefined;
+    const href = a.attr('href') ?? '';
+    const idMatch = href.match(/\/(\d+)$/);
+    results.push({
+      title,
+      location,
+      department,
+      id: idMatch ? idMatch[1] : undefined,
+      extractionMethod: 'greenhouse-html',
+    });
+  });
+  return results;
 }
 
 function extractJobsFromNextData(html: string, method: string): Partial<JobSighting>[] {

--- a/apify/actors/career-vs-linkedin/src/cdx.ts
+++ b/apify/actors/career-vs-linkedin/src/cdx.ts
@@ -1,0 +1,146 @@
+import { log } from 'apify';
+import type { CdxSnapshot } from './types.js';
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+interface CdxOptions {
+  url: string;
+  startDate?: string;   // YYYY-MM-DD
+  endDate?: string;     // YYYY-MM-DD
+  maxSnapshots?: number;
+  /** If true, uses matchType=prefix to enumerate all archived sub-URLs. */
+  prefix?: boolean;
+  /** Additional CDX filter strings (e.g. "statuscode:200"). */
+  filters?: string[];
+  /** collapse parameter (e.g. "timestamp:8" = one per day). */
+  collapse?: string;
+}
+
+/**
+ * Query the Wayback CDX Search API.
+ * Falls back to http:// and trailing-slash variants if the primary URL has no results.
+ */
+export async function fetchCdxSnapshots(opts: CdxOptions): Promise<CdxSnapshot[]> {
+  const { url, startDate, endDate, maxSnapshots = 100, prefix = false, filters = ['statuscode:200'], collapse = 'timestamp:8' } = opts;
+
+  const urlVariants: string[] = [url];
+  try {
+    const u = new URL(url);
+    const altProtocol = u.protocol === 'https:' ? 'http' : 'https';
+    urlVariants.push(url.replace(u.protocol, `${altProtocol}:`));
+    if (u.pathname.endsWith('/') && u.pathname.length > 1) {
+      urlVariants.push(url.replace(/\/$/, ''));
+    } else {
+      urlVariants.push(url + '/');
+    }
+  } catch { /* malformed URL */ }
+
+  for (const variant of urlVariants) {
+    const snapshots = await queryCdx(variant, { startDate, endDate, maxSnapshots, prefix, filters, collapse });
+    if (snapshots.length > 0) {
+      if (variant !== url) log.info(`CDX found results using alternative URL: ${variant}`);
+      return snapshots;
+    }
+  }
+  return [];
+}
+
+/**
+ * CDX prefix enumeration — returns all unique archived URLs under a path prefix.
+ * Used to discover individual LinkedIn job pages archived under a company's URL space.
+ */
+export async function fetchCdxUrlInventory(
+  urlPrefix: string,
+  startDate?: string,
+  endDate?: string,
+  limit = 500,
+): Promise<string[]> {
+  const params = new URLSearchParams({
+    url: urlPrefix,
+    matchType: 'prefix',
+    output: 'json',
+    fl: 'original',
+    filter: 'statuscode:200',
+    collapse: 'urlkey',
+    limit: String(limit),
+  });
+  if (startDate) params.set('from', startDate.replace(/-/g, ''));
+  if (endDate)   params.set('to',   endDate.replace(/-/g, ''));
+
+  const apiUrl = `http://web.archive.org/cdx/search/cdx?${params}`;
+  log.info('CDX URL inventory', { urlPrefix, limit });
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await fetch(apiUrl, { signal: AbortSignal.timeout(40_000), headers: { Accept: 'application/json' } });
+      if (res.status === 429) { await sleep(20_000); continue; }
+      if (!res.ok) { await sleep(5_000 * (attempt + 1)); continue; }
+      const rows: string[][] = await res.json();
+      if (!Array.isArray(rows) || rows.length < 2) return [];
+      return rows.slice(1).map(r => r[0]).filter(Boolean);
+    } catch (err) {
+      log.warning(`CDX inventory error (attempt ${attempt + 1}): ${err}`);
+      await sleep(5_000 * (attempt + 1));
+    }
+  }
+  return [];
+}
+
+/**
+ * Get the best (most recent) snapshot timestamp for a specific URL.
+ */
+export async function getLatestSnapshotTimestamp(url: string, beforeDate?: string): Promise<string | null> {
+  const params = new URLSearchParams({
+    url,
+    output: 'json',
+    fl: 'timestamp',
+    filter: 'statuscode:200',
+    limit: '1',
+  });
+  if (beforeDate) params.set('to', beforeDate.replace(/-/g, ''));
+  const apiUrl = `http://web.archive.org/cdx/search/cdx?${params}`;
+  try {
+    const res = await fetch(apiUrl, { signal: AbortSignal.timeout(15_000) });
+    if (!res.ok) return null;
+    const rows: string[][] = await res.json();
+    if (!Array.isArray(rows) || rows.length < 2) return null;
+    return rows[1][0] ?? null;
+  } catch { return null; }
+}
+
+async function queryCdx(
+  url: string,
+  opts: { startDate?: string; endDate?: string; maxSnapshots: number; prefix: boolean; filters: string[]; collapse: string },
+): Promise<CdxSnapshot[]> {
+  const params = new URLSearchParams({
+    url,
+    output: 'json',
+    fl: 'timestamp,original,statuscode',
+    limit: String(opts.maxSnapshots),
+    collapse: opts.collapse,
+  });
+  if (opts.prefix) params.set('matchType', 'prefix');
+  for (const f of opts.filters) params.append('filter', f);
+  if (opts.startDate) params.set('from', opts.startDate.replace(/-/g, ''));
+  if (opts.endDate)   params.set('to',   opts.endDate.replace(/-/g, ''));
+
+  const apiUrl = `http://web.archive.org/cdx/search/cdx?${params}`;
+  log.info('Querying Wayback CDX', { url, maxSnapshots: opts.maxSnapshots });
+
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const res = await fetch(apiUrl, { signal: AbortSignal.timeout(30_000), headers: { Accept: 'application/json' } });
+      if (res.status === 429) { log.warning('CDX rate limited, waiting 20s'); await sleep(20_000); continue; }
+      if (!res.ok) { await sleep(5_000 * (attempt + 1)); continue; }
+      const rows: string[][] = await res.json();
+      if (!Array.isArray(rows) || rows.length < 2) return [];
+      const snapshots: CdxSnapshot[] = rows.slice(1).map(([timestamp, original]) => ({ timestamp, original }));
+      log.info(`CDX returned ${snapshots.length} snapshots for ${url}`);
+      return snapshots;
+    } catch (err) {
+      log.warning(`CDX query error (attempt ${attempt + 1}): ${err}`);
+      await sleep(5_000 * (attempt + 1));
+    }
+  }
+  return [];
+}

--- a/apify/actors/career-vs-linkedin/src/compare.ts
+++ b/apify/actors/career-vs-linkedin/src/compare.ts
@@ -1,0 +1,205 @@
+import { findBestMatch, daysBetween } from './match.js';
+import type { JobSighting, JobComparison, ResearchSummary, LagBucket, Verdict } from './types.js';
+
+/**
+ * Cross-reference career page jobs against LinkedIn jobs.
+ * Returns one JobComparison per unique career-page job title,
+ * plus any LinkedIn-only jobs not found on the career page.
+ */
+export function compareJobs(
+  careerJobs: Map<string, JobSighting>,
+  linkedinJobs: Map<string, JobSighting>,
+  companyName: string,
+  careerPageUrl: string,
+  linkedinUrl: string,
+  periodStart: string,
+  periodEnd: string,
+  careerSnapshotsProcessed: number,
+  linkedinSnapshotsProcessed: number,
+): { comparisons: JobComparison[]; summary: Omit<ResearchSummary, 'geminiSummary' | 'geminiAvailable'> } {
+  const comparisons: JobComparison[] = [];
+  const matchedLinkedInTitles = new Set<string>();
+
+  const linkedinNormTitles = Array.from(linkedinJobs.keys());
+
+  // ── Match career-page jobs → LinkedIn ─────────────────────────────────────
+  for (const [normTitle, careerJob] of careerJobs.entries()) {
+    const liMatch = findBestMatch(normTitle, linkedinNormTitles);
+    const liJob = liMatch ? linkedinJobs.get(liMatch.match) ?? null : null;
+
+    if (liJob) matchedLinkedInTitles.add(liJob.normalizedTitle);
+
+    const effectiveCareerDate = careerJob.datePosted ?? careerJob.firstSeen;
+    const effectiveLinkedInDate = liJob ? (liJob.datePosted ?? liJob.firstSeen) : undefined;
+
+    let verdict: Verdict;
+    let lagDays: number | undefined;
+
+    if (!liJob) {
+      verdict = 'career_only';
+    } else {
+      lagDays = daysBetween(effectiveCareerDate, effectiveLinkedInDate!);
+      if (lagDays > 0) {
+        verdict = 'career_first';
+      } else if (lagDays < 0) {
+        verdict = 'linkedin_first';
+      } else {
+        verdict = 'same_day';
+      }
+    }
+
+    comparisons.push({
+      _type: 'job-comparison',
+      company: companyName,
+      normalizedTitle: normTitle,
+      careerTitle: careerJob.title,
+      linkedinTitle: liJob?.title,
+      careerPageFirstSeen: careerJob.firstSeen,
+      careerPageDatePosted: careerJob.datePosted,
+      linkedinFirstSeen: liJob?.firstSeen,
+      linkedinDatePosted: liJob?.datePosted,
+      effectiveCareerDate,
+      effectiveLinkedInDate,
+      lagDays,
+      verdict,
+      location: careerJob.location ?? liJob?.location,
+      department: careerJob.department ?? liJob?.department,
+      careerSnapshotUrl: careerJob.snapshotUrl,
+      linkedinSnapshotUrl: liJob?.snapshotUrl,
+    });
+  }
+
+  // ── LinkedIn-only jobs (seen on LinkedIn but not career page) ─────────────
+  for (const [normTitle, liJob] of linkedinJobs.entries()) {
+    if (matchedLinkedInTitles.has(normTitle)) continue;
+    comparisons.push({
+      _type: 'job-comparison',
+      company: companyName,
+      normalizedTitle: normTitle,
+      careerTitle: '',
+      linkedinTitle: liJob.title,
+      careerPageFirstSeen: '',
+      linkedinFirstSeen: liJob.firstSeen,
+      linkedinDatePosted: liJob.datePosted,
+      effectiveCareerDate: '',
+      effectiveLinkedInDate: liJob.datePosted ?? liJob.firstSeen,
+      verdict: 'linkedin_only',
+      location: liJob.location,
+      department: liJob.department,
+      careerSnapshotUrl: '',
+      linkedinSnapshotUrl: liJob.snapshotUrl,
+    });
+  }
+
+  // ── Compute aggregate statistics ──────────────────────────────────────────
+  const matched = comparisons.filter(c => c.verdict !== 'career_only' && c.verdict !== 'linkedin_only');
+  const careerFirst = comparisons.filter(c => c.verdict === 'career_first');
+  const linkedinFirst = comparisons.filter(c => c.verdict === 'linkedin_first');
+  const sameDay = comparisons.filter(c => c.verdict === 'same_day');
+  const careerOnly = comparisons.filter(c => c.verdict === 'career_only');
+  const linkedinOnly = comparisons.filter(c => c.verdict === 'linkedin_only');
+
+  const lagValues = careerFirst.map(c => c.lagDays!).filter(n => n > 0);
+  const avgLagDays = lagValues.length > 0 ? Math.round(lagValues.reduce((a, b) => a + b, 0) / lagValues.length) : 0;
+  const medianLagDays = lagValues.length > 0 ? computeMedian(lagValues) : 0;
+  const pctCareerFirst = matched.length > 0 ? Math.round((careerFirst.length / matched.length) * 100) : 0;
+
+  const lagDistribution = buildLagDistribution(lagValues);
+
+  // Top evidence: career-first jobs sorted by largest lag, with both snapshot links available
+  const topEvidenceJobs = [...careerFirst]
+    .filter(c => c.linkedinSnapshotUrl)
+    .sort((a, b) => (b.lagDays ?? 0) - (a.lagDays ?? 0))
+    .slice(0, 10);
+
+  const conclusion = buildConclusion(
+    companyName,
+    careerFirst.length,
+    matched.length,
+    avgLagDays,
+    medianLagDays,
+    careerOnly.length,
+    careerJobs.size,
+    linkedinJobs.size,
+  );
+
+  const summary: Omit<ResearchSummary, 'geminiSummary' | 'geminiAvailable'> = {
+    _type: 'research-summary',
+    company: companyName,
+    careerPageUrl,
+    linkedinUrl,
+    periodStart,
+    periodEnd,
+    careerSnapshotsProcessed,
+    linkedinSnapshotsProcessed,
+    totalCareerJobs: careerJobs.size,
+    totalLinkedInJobs: linkedinJobs.size,
+    matchedJobs: matched.length,
+    careerOnlyJobs: careerOnly.length,
+    linkedinOnlyJobs: linkedinOnly.length,
+    careerFirstCount: careerFirst.length,
+    linkedinFirstCount: linkedinFirst.length,
+    sameDayCount: sameDay.length,
+    avgLagDays,
+    medianLagDays,
+    pctCareerFirst,
+    lagDistribution,
+    topEvidenceJobs,
+    conclusion,
+  };
+
+  return { comparisons, summary };
+}
+
+function computeMedian(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? Math.round((sorted[mid - 1] + sorted[mid]) / 2)
+    : sorted[mid];
+}
+
+function buildLagDistribution(lagValues: number[]): LagBucket[] {
+  const buckets: { label: string; min: number; max: number }[] = [
+    { label: 'Same day (0)', min: 0, max: 0 },
+    { label: '1–3 days', min: 1, max: 3 },
+    { label: '4–7 days', min: 4, max: 7 },
+    { label: '8–14 days', min: 8, max: 14 },
+    { label: '15–30 days', min: 15, max: 30 },
+    { label: '31–60 days', min: 31, max: 60 },
+    { label: '61–90 days', min: 61, max: 90 },
+    { label: '90+ days', min: 91, max: Infinity },
+  ];
+  return buckets.map(b => ({
+    range: b.label,
+    count: lagValues.filter(v => v >= b.min && v <= b.max).length,
+  })).filter(b => b.count > 0);
+}
+
+function buildConclusion(
+  company: string,
+  careerFirstCount: number,
+  matchedCount: number,
+  avgLag: number,
+  medianLag: number,
+  careerOnlyCount: number,
+  totalCareer: number,
+  totalLinkedIn: number,
+): string {
+  if (matchedCount === 0) {
+    return `Insufficient matching data for ${company}. Career page has ${totalCareer} jobs; LinkedIn has ${totalLinkedIn} jobs. No cross-platform matches found — titles may differ significantly or LinkedIn snapshots are sparse.`;
+  }
+
+  const pct = Math.round((careerFirstCount / matchedCount) * 100);
+  const strength = pct >= 80 ? 'strongly' : pct >= 60 ? 'clearly' : pct >= 40 ? 'generally' : 'partially';
+
+  return (
+    `For ${company}, the career page ${strength} precedes LinkedIn: ` +
+    `${pct}% of matched jobs (${careerFirstCount}/${matchedCount}) appeared on the career page first, ` +
+    `with an average lead of ${avgLag} days (median: ${medianLag} days). ` +
+    (careerOnlyCount > 0
+      ? `An additional ${careerOnlyCount} jobs (${Math.round((careerOnlyCount / totalCareer) * 100)}% of career-page listings) were never indexed by LinkedIn at all. `
+      : '') +
+    `This confirms that the career page is the primary source of truth for job postings.`
+  );
+}

--- a/apify/actors/career-vs-linkedin/src/fetch.ts
+++ b/apify/actors/career-vs-linkedin/src/fetch.ts
@@ -1,0 +1,52 @@
+const WB = 'https://web.archive.org/web';
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+/**
+ * Fetch the raw HTML of an archived page from the Wayback Machine.
+ * Uses the `id_` flag to get the original, unmodified response (no Wayback toolbar injection).
+ */
+export async function fetchArchivedPage(timestamp: string, url: string): Promise<string | null> {
+  for (let i = 0; i < 3; i++) {
+    try {
+      const res = await fetch(`${WB}/${timestamp}id_/${url}`, {
+        signal: AbortSignal.timeout(30_000),
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
+          'Accept': 'text/html,application/xhtml+xml,*/*',
+          'Accept-Language': 'en-US,en;q=0.9',
+        },
+        redirect: 'follow',
+      });
+      if (res.status === 429) { await sleep(15_000 * (i + 1)); continue; }
+      if (res.status === 404) return null;
+      if (!res.ok) { await sleep(3_000 * (i + 1)); continue; }
+      return await res.text();
+    } catch { await sleep(3_000 * (i + 1)); }
+  }
+  return null;
+}
+
+/**
+ * Fetch an archived JSON endpoint from the Wayback Machine.
+ * Returns null if the response starts with HTML (Wayback error page).
+ */
+export async function fetchArchivedJson<T>(timestamp: string, url: string): Promise<T | null> {
+  for (let i = 0; i < 3; i++) {
+    try {
+      const res = await fetch(`${WB}/${timestamp}id_/${url}`, {
+        signal: AbortSignal.timeout(20_000),
+        headers: {
+          'Accept': 'application/json',
+          'User-Agent': 'Mozilla/5.0 (compatible; CareerVsLinkedIn/1.0)',
+        },
+      });
+      if (res.status === 429) { await sleep(12_000 * (i + 1)); continue; }
+      if (res.status === 404) return null;
+      if (!res.ok) { await sleep(2_000 * (i + 1)); continue; }
+      const text = await res.text();
+      if (text.trimStart().startsWith('<')) return null;
+      return JSON.parse(text) as T;
+    } catch { await sleep(2_000 * (i + 1)); }
+  }
+  return null;
+}

--- a/apify/actors/career-vs-linkedin/src/gemini.ts
+++ b/apify/actors/career-vs-linkedin/src/gemini.ts
@@ -1,0 +1,55 @@
+import { log } from 'apify';
+import type { ResearchSummary, JobComparison } from './types.js';
+
+/**
+ * Use Gemini to generate a research-quality narrative summary of the career-page-vs-LinkedIn
+ * timing analysis. Returns the geminiSummary string to embed in the ResearchSummary record.
+ */
+export async function analyzeWithGemini(
+  apiKey: string,
+  summary: Omit<ResearchSummary, 'geminiSummary' | 'geminiAvailable'>,
+  topEvidence: JobComparison[],
+): Promise<string> {
+  const { GoogleGenerativeAI } = await import('@google/generative-ai');
+  const genAI = new GoogleGenerativeAI(apiKey);
+  const model = genAI.getGenerativeModel({ model: 'gemini-2.5-flash' });
+
+  const evidenceLines = topEvidence.slice(0, 8).map(j =>
+    `  • "${j.careerTitle}" — career page: ${j.effectiveCareerDate}, LinkedIn: ${j.effectiveLinkedInDate ?? 'not found'}, lag: ${j.lagDays != null ? `+${j.lagDays} days` : 'career only'}`
+  ).join('\n');
+
+  const prompt = `You are a labor market researcher analyzing whether company career pages publish job postings before LinkedIn.
+
+## Data for ${summary.company}
+- Analysis period: ${summary.periodStart} to ${summary.periodEnd}
+- Career page snapshots processed: ${summary.careerSnapshotsProcessed}
+- LinkedIn snapshots processed: ${summary.linkedinSnapshotsProcessed}
+- Career page unique jobs: ${summary.totalCareerJobs}
+- LinkedIn unique jobs: ${summary.totalLinkedInJobs}
+- Jobs matched across both platforms: ${summary.matchedJobs}
+- Career page first: ${summary.careerFirstCount} (${summary.pctCareerFirst}%)
+- LinkedIn first: ${summary.linkedinFirstCount}
+- Same day: ${summary.sameDayCount}
+- Career page only (never on LinkedIn): ${summary.careerOnlyJobs}
+- Average lag (career ahead of LinkedIn): ${summary.avgLagDays} days
+- Median lag: ${summary.medianLagDays} days
+
+## Top evidence jobs (career page appeared first)
+${evidenceLines || '  (no matched jobs with LinkedIn snapshots available)'}
+
+## Lag distribution
+${summary.lagDistribution.map(b => `  ${b.range}: ${b.count} jobs`).join('\n')}
+
+Write a concise, research-quality narrative (3–5 paragraphs) that:
+1. States the key finding clearly (does career page precede LinkedIn, and by how much?)
+2. Interprets the lag distribution — what does it mean for job seekers?
+3. Notes any caveats (data limitations, LinkedIn crawl coverage, CDX snapshot frequency)
+4. Gives a practical recommendation for job seekers (e.g. "Monitor career pages directly to see jobs 5–14 days before they reach LinkedIn")
+
+Be specific with numbers. Do NOT use bullet points — write flowing prose.`;
+
+  const result = await model.generateContent(prompt);
+  const text = result.response.text().trim();
+  log.info(`Gemini analysis complete for ${summary.company}`, { chars: text.length });
+  return text;
+}

--- a/apify/actors/career-vs-linkedin/src/linkedin.ts
+++ b/apify/actors/career-vs-linkedin/src/linkedin.ts
@@ -1,0 +1,336 @@
+import { log } from 'apify';
+import { load } from 'cheerio';
+import { fetchCdxSnapshots } from './cdx.js';
+import { fetchArchivedPage } from './fetch.js';
+import { normalizeTitle } from './match.js';
+import type { JobSighting } from './types.js';
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+/**
+ * Build the LinkedIn URL(s) to use for CDX searches.
+ *
+ * Priority:
+ * 1. linkedin.com/company/{slug}/jobs/ — most direct, no login needed for crawlers
+ * 2. linkedin.com/jobs/search/?f_C={companyId} — numeric ID based search
+ */
+export function buildLinkedInUrls(slug?: string, companyId?: string): string[] {
+  const urls: string[] = [];
+  if (slug) {
+    urls.push(`https://www.linkedin.com/company/${slug}/jobs/`);
+    urls.push(`https://www.linkedin.com/jobs/search/?f_C=&keywords=&location=&geoId=&f_C=${slug}`);
+  }
+  if (companyId) {
+    urls.push(`https://www.linkedin.com/jobs/search/?f_C=${companyId}`);
+    urls.push(`https://www.linkedin.com/jobs/search/?f_C=${companyId}&keywords=&location=`);
+  }
+  return urls;
+}
+
+/**
+ * Collect all unique jobs seen on LinkedIn for a company over a date range.
+ *
+ * Strategy:
+ * 1. Fetch CDX snapshots of the company's LinkedIn jobs page and extract job listings.
+ * 2. Collect unique individual LinkedIn job page URLs (/jobs/view/{id}/) via CDX inventory.
+ * 3. Fetch each individual job page to extract title, datePosted, and hiringOrganization.
+ *
+ * Returns a map of normalizedTitle → JobSighting (first sighting only).
+ */
+export async function collectLinkedInJobs(
+  companyName: string,
+  linkedinSlug: string | undefined,
+  linkedinCompanyId: string | undefined,
+  startDate: string,
+  endDate: string,
+  maxSnapshots: number,
+  delayMs: number,
+): Promise<{ jobs: Map<string, JobSighting>; snapshotsProcessed: number; linkedinUrl: string }> {
+  const jobs = new Map<string, JobSighting>();
+  let snapshotsProcessed = 0;
+  const linkedinUrls = buildLinkedInUrls(linkedinSlug, linkedinCompanyId);
+  const primaryLinkedInUrl = linkedinUrls[0] ?? `https://www.linkedin.com/company/${companyName.toLowerCase().replace(/\s+/g, '-')}/jobs/`;
+
+  // ── Step 1: Company jobs page snapshots ────────────────────────────────────
+  let companyPageSnapshots: import('./types.js').CdxSnapshot[] = [];
+  for (const url of linkedinUrls) {
+    const snaps = await fetchCdxSnapshots({ url, startDate, endDate, maxSnapshots: Math.min(maxSnapshots, 50) });
+    if (snaps.length > 0) { companyPageSnapshots = snaps; break; }
+  }
+  log.info(`LinkedIn company page: ${companyPageSnapshots.length} snapshots`, { url: primaryLinkedInUrl });
+
+  const jobViewUrls = new Set<string>();
+
+  for (let i = 0; i < companyPageSnapshots.length; i++) {
+    const snap = companyPageSnapshots[i];
+    const date = tsToDate(snap.timestamp);
+    log.info(`[linkedin-page ${i + 1}/${companyPageSnapshots.length}] ${date}`);
+    const html = await fetchArchivedPage(snap.timestamp, snap.original);
+    if (html) {
+      const extracted = extractFromLinkedInHtml(html, snap, companyName);
+      snapshotsProcessed++;
+      for (const job of extracted.jobs) mergeJob(jobs, job);
+      for (const url of extracted.jobViewUrls) jobViewUrls.add(url);
+    }
+    if (i < companyPageSnapshots.length - 1) await sleep(delayMs);
+  }
+
+  // ── Step 2: Additional LinkedIn URL variants ───────────────────────────────
+  // Try alternate company URL forms if the first didn't yield many job view links.
+  if (jobViewUrls.size < 5 && linkedinUrls.length > 1) {
+    for (const altUrl of linkedinUrls.slice(1)) {
+      const altSnaps = await fetchCdxSnapshots({ url: altUrl, startDate, endDate, maxSnapshots: Math.min(maxSnapshots, 20) });
+      for (const snap of altSnaps) {
+        const html = await fetchArchivedPage(snap.timestamp, snap.original);
+        if (html) {
+          const result = extractFromLinkedInHtml(html, snap, companyName);
+          for (const job of result.jobs) mergeJob(jobs, job);
+          for (const u of result.jobViewUrls) jobViewUrls.add(u);
+          snapshotsProcessed++;
+        }
+      }
+      if (jobViewUrls.size >= 5) break;
+    }
+  }
+  log.info(`LinkedIn: ${jobViewUrls.size} individual job view URLs to fetch`);
+
+  // ── Step 3: Fetch individual job pages ────────────────────────────────────
+  const jobViewArray = Array.from(jobViewUrls).slice(0, maxSnapshots * 2);
+  log.info(`LinkedIn: fetching ${jobViewArray.length} individual job pages`);
+
+  for (let i = 0; i < jobViewArray.length; i++) {
+    const jobUrl = jobViewArray[i];
+    // Get the most relevant snapshot for this URL within our date range
+    const snaps = await fetchCdxSnapshots({
+      url: jobUrl,
+      startDate,
+      endDate,
+      maxSnapshots: 1,
+      collapse: 'timestamp:8',
+    });
+    if (snaps.length === 0) { await sleep(delayMs / 2); continue; }
+
+    const snap = snaps[0];
+    const html = await fetchArchivedPage(snap.timestamp, snap.original);
+    if (html) {
+      snapshotsProcessed++;
+      const job = extractFromLinkedInJobPage(html, snap, companyName);
+      if (job) mergeJob(jobs, job);
+    }
+    if (i < jobViewArray.length - 1) await sleep(delayMs);
+  }
+
+  log.info(`LinkedIn: ${jobs.size} unique jobs collected`, { company: companyName });
+  return { jobs, snapshotsProcessed, linkedinUrl: primaryLinkedInUrl };
+}
+
+function mergeJob(registry: Map<string, JobSighting>, job: JobSighting): void {
+  const existing = registry.get(job.normalizedTitle);
+  const effectiveDate = job.datePosted ?? job.firstSeen;
+  const existingDate = existing ? (existing.datePosted ?? existing.firstSeen) : null;
+  if (!existing || effectiveDate < (existingDate ?? '9999')) {
+    registry.set(job.normalizedTitle, job);
+  }
+}
+
+function tsToDate(ts: string): string {
+  return `${ts.slice(0, 4)}-${ts.slice(4, 6)}-${ts.slice(6, 8)}`;
+}
+
+// ── LinkedIn company jobs page HTML extractor ─────────────────────────────────
+
+interface CompanyPageResult {
+  jobs: JobSighting[];
+  jobViewUrls: string[];
+}
+
+function extractFromLinkedInHtml(html: string, snap: { timestamp: string; original: string }, companyName: string): CompanyPageResult {
+  const $ = load(html);
+  const jobs: JobSighting[] = [];
+  const jobViewUrls: string[] = [];
+  const date = tsToDate(snap.timestamp);
+  const snapshotUrl = `https://web.archive.org/web/${snap.timestamp}/${snap.original}`;
+
+  // Collect all /jobs/view/ hrefs found on the page
+  $('a[href*="/jobs/view/"]').each((_, el) => {
+    const href = $(el).attr('href') ?? '';
+    const match = href.match(/\/jobs\/view\/(\d+)/);
+    if (match) {
+      const cleanUrl = `https://www.linkedin.com/jobs/view/${match[1]}/`;
+      jobViewUrls.push(cleanUrl);
+    }
+  });
+
+  // Extract job titles from listing elements (multiple LinkedIn HTML eras)
+  const titleSelectors = [
+    'h3.job-card-list__title',
+    'h3.base-search-card__title',
+    '.job-result-card__title',
+    'h3[class*="job-card"]',
+    '.jobs-unified-top-card__job-title',
+    '[class*="job-title"]',
+    '.result-card__title',
+  ];
+
+  const seenTitles = new Set<string>();
+  for (const sel of titleSelectors) {
+    $(sel).each((_, el) => {
+      const title = $(el).text().trim();
+      if (!title || seenTitles.has(title)) return;
+      seenTitles.add(title);
+      const normTitle = normalizeTitle(title);
+      if (!normTitle) return;
+      jobs.push({
+        title,
+        normalizedTitle: normTitle,
+        firstSeen: date,
+        snapshotUrl,
+        platform: 'linkedin',
+        extractionMethod: 'linkedin-company-page-html',
+      });
+    });
+  }
+
+  // Try JSON-LD on listing page
+  $('script[type="application/ld+json"]').each((_, el) => {
+    try {
+      const raw = $(el).html() ?? '';
+      const data: unknown = JSON.parse(raw);
+      const items = Array.isArray(data) ? data : [data];
+      for (const item of items) {
+        if (!item || typeof item !== 'object') continue;
+        const obj = item as Record<string, unknown>;
+        if (obj['@type'] === 'JobPosting' || (Array.isArray(obj['@type']) && (obj['@type'] as string[]).includes('JobPosting'))) {
+          const title = String(obj['title'] ?? obj['name'] ?? '').trim();
+          if (!title || seenTitles.has(title)) continue;
+          // Verify this job belongs to our target company
+          const org = getHiringOrganization(obj);
+          if (org && !orgMatchesCompany(org, companyName)) continue;
+          seenTitles.add(title);
+          const normTitle = normalizeTitle(title);
+          if (!normTitle) continue;
+          jobs.push({
+            title,
+            normalizedTitle: normTitle,
+            firstSeen: date,
+            datePosted: obj['datePosted'] ? String(obj['datePosted']).slice(0, 10) : undefined,
+            snapshotUrl,
+            location: extractLocationStr(obj),
+            platform: 'linkedin',
+            extractionMethod: 'linkedin-jsonld',
+          });
+        }
+      }
+    } catch { /* skip */ }
+  });
+
+  return { jobs, jobViewUrls };
+}
+
+// ── LinkedIn individual job page extractor ────────────────────────────────────
+
+function extractFromLinkedInJobPage(
+  html: string,
+  snap: { timestamp: string; original: string },
+  companyName: string,
+): JobSighting | null {
+  const $ = load(html);
+  const date = tsToDate(snap.timestamp);
+  const snapshotUrl = `https://web.archive.org/web/${snap.timestamp}/${snap.original}`;
+
+  // 1. JSON-LD is most reliable — LinkedIn populates it for crawlers
+  let extracted: JobSighting | null = null;
+  $('script[type="application/ld+json"]').each((_, el) => {
+    if (extracted) return; // already found one
+    try {
+      const raw = $(el).html() ?? '';
+      const data: unknown = JSON.parse(raw);
+      const items = Array.isArray(data) ? data : [data];
+      for (const item of items) {
+        if (!item || typeof item !== 'object') continue;
+        const obj = item as Record<string, unknown>;
+        const type = obj['@type'];
+        if (type !== 'JobPosting' && !(Array.isArray(type) && (type as string[]).includes('JobPosting'))) continue;
+
+        const title = String(obj['title'] ?? obj['name'] ?? '').trim();
+        if (!title) continue;
+
+        // Verify the job belongs to our target company
+        const org = getHiringOrganization(obj);
+        if (org && !orgMatchesCompany(org, companyName)) continue;
+
+        const normTitle = normalizeTitle(title);
+        if (!normTitle) continue;
+
+        extracted = {
+          title,
+          normalizedTitle: normTitle,
+          firstSeen: date,
+          datePosted: obj['datePosted'] ? String(obj['datePosted']).slice(0, 10) : undefined,
+          snapshotUrl,
+          location: extractLocationStr(obj),
+          platform: 'linkedin',
+          extractionMethod: 'linkedin-job-page-jsonld',
+        };
+      }
+    } catch { /* skip */ }
+  });
+  if (extracted) return extracted;
+
+  // 2. HTML selectors — LinkedIn job page structure varies by era
+  const titleEl = $(
+    'h1.top-card-layout__title, h1[class*="job-title"], h1[class*="topcard__title"], .jobs-unified-top-card__job-title h1, h1.t-24'
+  ).first();
+  const companyEl = $(
+    '.topcard__org-name-link, .top-card-layout__second-subline, [class*="company-name"], .job-details-jobs-unified-top-card__company-name'
+  ).first();
+
+  const title = titleEl.text().trim();
+  const company = companyEl.text().trim();
+
+  if (!title) return null;
+  if (company && !orgMatchesCompany(company, companyName)) return null;
+
+  const normTitle = normalizeTitle(title);
+  if (!normTitle) return null;
+
+  return {
+    title,
+    normalizedTitle: normTitle,
+    firstSeen: date,
+    snapshotUrl,
+    platform: 'linkedin',
+    extractionMethod: 'linkedin-job-page-html',
+  };
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function getHiringOrganization(obj: Record<string, unknown>): string | null {
+  const ho = obj['hiringOrganization'];
+  if (!ho || typeof ho !== 'object') return null;
+  return String((ho as Record<string, unknown>)['name'] ?? '').trim() || null;
+}
+
+function orgMatchesCompany(org: string, company: string): boolean {
+  const normalizeOrg = (s: string) => s.toLowerCase().replace(/[^a-z0-9]/g, '');
+  return normalizeOrg(org).includes(normalizeOrg(company)) ||
+         normalizeOrg(company).includes(normalizeOrg(org));
+}
+
+function extractLocationStr(obj: Record<string, unknown>): string | undefined {
+  const loc = obj['jobLocation'];
+  if (!loc) return undefined;
+  const items = Array.isArray(loc) ? loc : [loc];
+  const parts: string[] = [];
+  for (const l of items) {
+    if (typeof l === 'string') { if (l) parts.push(l); }
+    else if (l && typeof l === 'object') {
+      const lo = l as Record<string, unknown>;
+      const addr = lo['address'] as Record<string, unknown> | undefined;
+      const part = String(lo['name'] ?? addr?.['addressLocality'] ?? addr?.['addressRegion'] ?? '').trim();
+      if (part) parts.push(part);
+    }
+  }
+  return parts.length > 0 ? parts.join(', ') : undefined;
+}

--- a/apify/actors/career-vs-linkedin/src/linkedin.ts
+++ b/apify/actors/career-vs-linkedin/src/linkedin.ts
@@ -152,9 +152,10 @@ function extractFromLinkedInHtml(html: string, snap: { timestamp: string; origin
   const snapshotUrl = `https://web.archive.org/web/${snap.timestamp}/${snap.original}`;
 
   // Collect all /jobs/view/ hrefs found on the page
+  // LinkedIn URL formats: /jobs/view/12345/ (old) or /jobs/view/title-at-co-12345?tracking (new)
   $('a[href*="/jobs/view/"]').each((_, el) => {
     const href = $(el).attr('href') ?? '';
-    const match = href.match(/\/jobs\/view\/(\d+)/);
+    const match = href.match(/\/jobs\/view\/(?:[^/?]*?-)?(\d{7,})/);
     if (match) {
       const cleanUrl = `https://www.linkedin.com/jobs/view/${match[1]}/`;
       jobViewUrls.push(cleanUrl);
@@ -165,8 +166,10 @@ function extractFromLinkedInHtml(html: string, snap: { timestamp: string; origin
   const titleSelectors = [
     'h3.job-card-list__title',
     'h3.base-search-card__title',
+    'h3.base-main-card__title',
     '.job-result-card__title',
     'h3[class*="job-card"]',
+    'h3[class*="base-main-card"]',
     '.jobs-unified-top-card__job-title',
     '[class*="job-title"]',
     '.result-card__title',

--- a/apify/actors/career-vs-linkedin/src/main.ts
+++ b/apify/actors/career-vs-linkedin/src/main.ts
@@ -1,0 +1,179 @@
+import { Actor, log } from 'apify';
+import { collectCareerJobs } from './career.js';
+import { collectLinkedInJobs } from './linkedin.js';
+import { compareJobs } from './compare.js';
+import { analyzeWithGemini } from './gemini.js';
+import type { Input, CompanyPair, ResearchSummary, BatchSummary } from './types.js';
+
+/**
+ * Seed companies for batch mode — a diverse mix of ATS platforms.
+ * Each pair has a well-archived career page and a LinkedIn company slug.
+ */
+const SEED_COMPANIES: CompanyPair[] = [
+  { name: 'Stripe',       careerPageUrl: 'https://boards.greenhouse.io/stripe',         linkedinSlug: 'stripe' },
+  { name: 'Coinbase',     careerPageUrl: 'https://boards.greenhouse.io/coinbase',        linkedinSlug: 'coinbase' },
+  { name: 'Anthropic',    careerPageUrl: 'https://boards.greenhouse.io/anthropic',       linkedinSlug: 'anthropic' },
+  { name: 'OpenAI',       careerPageUrl: 'https://boards.greenhouse.io/openai',          linkedinSlug: 'openai' },
+  { name: 'Figma',        careerPageUrl: 'https://boards.greenhouse.io/figma',           linkedinSlug: 'figma' },
+  { name: 'Notion',       careerPageUrl: 'https://boards.greenhouse.io/notion',          linkedinSlug: 'notion' },
+  { name: 'Scale AI',     careerPageUrl: 'https://jobs.lever.co/scaleai',                linkedinSlug: 'scaleai' },
+  { name: 'Brex',         careerPageUrl: 'https://jobs.lever.co/brex',                   linkedinSlug: 'brex-inc-' },
+  { name: 'Rippling',     careerPageUrl: 'https://jobs.lever.co/rippling',               linkedinSlug: 'rippling' },
+  { name: 'Linear',       careerPageUrl: 'https://jobs.ashbyhq.com/linear',              linkedinSlug: 'linear-app' },
+  { name: 'Vercel',       careerPageUrl: 'https://jobs.ashbyhq.com/vercel',              linkedinSlug: 'vercel' },
+  { name: 'Retool',       careerPageUrl: 'https://jobs.ashbyhq.com/retool',              linkedinSlug: 'tryretool' },
+  { name: 'Klarna',       careerPageUrl: 'https://boards.greenhouse.io/klarna',          linkedinSlug: 'klarna' },
+  { name: 'Spotify',      careerPageUrl: 'https://boards.greenhouse.io/spotify',         linkedinSlug: 'spotify' },
+  { name: 'Robinhood',    careerPageUrl: 'https://boards.greenhouse.io/robinhood',       linkedinSlug: 'robinhood' },
+  { name: 'Miro',         careerPageUrl: 'https://miro.recruitee.com',                   linkedinSlug: 'mirohq' },
+  { name: 'Typeform',     careerPageUrl: 'https://typeform.recruitee.com',               linkedinSlug: 'typeform' },
+  { name: 'Novartis',     careerPageUrl: 'https://jobs.smartrecruiters.com/Novartis',    linkedinSlug: 'novartis' },
+  { name: 'SAP',          careerPageUrl: 'https://jobs.smartrecruiters.com/SAP',         linkedinSlug: 'sap' },
+  { name: 'Bosch',        careerPageUrl: 'https://jobs.smartrecruiters.com/BoschGroup',  linkedinSlug: 'bosch' },
+];
+
+await Actor.init();
+const input = (await Actor.getInput<Input>()) ?? ({} as Input);
+
+const {
+  batchMode = false,
+  companies,
+  careerPageUrl,
+  companyName,
+  linkedinSlug,
+  linkedinCompanyId,
+  startDate,
+  endDate,
+  maxSnapshots = 60,
+  delayMs = 1500,
+} = input;
+const googleAiApiKey = input.googleAiApiKey ?? process.env.GOOGLE_AI_API_KEY ?? '';
+
+const today = new Date().toISOString().slice(0, 10);
+const oneYearAgo = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+const effectiveStart = startDate ?? oneYearAgo;
+const effectiveEnd = endDate ?? today;
+
+if (batchMode) {
+  await runBatch();
+} else {
+  if (!careerPageUrl) throw new Error('Input field "careerPageUrl" is required (or set batchMode: true).');
+  if (!linkedinSlug && !linkedinCompanyId) {
+    throw new Error('Either "linkedinSlug" or "linkedinCompanyId" is required (or set batchMode: true).');
+  }
+  const name = companyName ?? new URL(careerPageUrl).hostname;
+  log.info('Career vs LinkedIn', { company: name, careerPageUrl, linkedinSlug, linkedinCompanyId, start: effectiveStart, end: effectiveEnd });
+  await analyzeCompany({ name, careerPageUrl, linkedinSlug, linkedinCompanyId });
+}
+
+await Actor.exit();
+
+// ── Batch mode ──────────────────────────────────────────────────────────────
+
+async function runBatch(): Promise<void> {
+  const companyList: CompanyPair[] = companies?.length ? companies : SEED_COMPANIES;
+  log.info(`Batch mode: ${companyList.length} companies`, { start: effectiveStart, end: effectiveEnd, gemini: !!googleAiApiKey });
+
+  const batchResults: ResearchSummary[] = [];
+
+  for (let i = 0; i < companyList.length; i++) {
+    const co = companyList[i];
+    log.info(`=== [${i + 1}/${companyList.length}] ${co.name} ===`);
+    try {
+      const summary = await analyzeCompany(co);
+      if (summary) batchResults.push(summary);
+    } catch (err) {
+      log.warning(`Failed to analyze ${co.name}: ${err}`);
+    }
+  }
+
+  if (batchResults.length === 0) { log.warning('No results produced in batch mode.'); return; }
+
+  const avgPct = Math.round(batchResults.reduce((s, r) => s + r.pctCareerFirst, 0) / batchResults.length);
+  const avgLag = Math.round(batchResults.reduce((s, r) => s + r.avgLagDays, 0) / batchResults.length);
+
+  const batchSummary: BatchSummary = {
+    _type: 'batch-summary',
+    companiesAnalyzed: batchResults.length,
+    avgPctCareerFirst: avgPct,
+    avgLagDays: avgLag,
+    overallConclusion:
+      `Across ${batchResults.length} companies, ${avgPct}% of matched jobs appeared on the career page before LinkedIn, ` +
+      `with an average career-page lead of ${avgLag} days. ` +
+      `Career pages are consistently the primary source of truth for job postings.`,
+    companyResults: batchResults.map(r => ({
+      company: r.company,
+      pctCareerFirst: r.pctCareerFirst,
+      avgLagDays: r.avgLagDays,
+      matchedJobs: r.matchedJobs,
+      conclusion: r.conclusion,
+    })),
+  };
+
+  await Actor.pushData(batchSummary);
+  log.info('Batch complete', { companies: batchResults.length, avgPctCareerFirst: avgPct, avgLagDays: avgLag });
+}
+
+// ── Single-company analysis ──────────────────────────────────────────────────
+
+async function analyzeCompany(co: CompanyPair): Promise<ResearchSummary | null> {
+  log.info(`Collecting career page jobs…`, { url: co.careerPageUrl });
+  const careerJobs = await collectCareerJobs(
+    co.careerPageUrl, effectiveStart, effectiveEnd, maxSnapshots, delayMs,
+  );
+
+  log.info(`Collecting LinkedIn jobs…`, { slug: co.linkedinSlug, id: co.linkedinCompanyId });
+  const { jobs: linkedinJobs, snapshotsProcessed: liSnaps, linkedinUrl } = await collectLinkedInJobs(
+    co.name, co.linkedinSlug, co.linkedinCompanyId,
+    effectiveStart, effectiveEnd, maxSnapshots, delayMs,
+  );
+
+  if (careerJobs.size === 0 && linkedinJobs.size === 0) {
+    log.warning(`${co.name}: no jobs found on either platform. Skipping.`);
+    return null;
+  }
+
+  log.info(`${co.name}: ${careerJobs.size} career jobs, ${linkedinJobs.size} LinkedIn jobs — comparing…`);
+
+  const { comparisons, summary: partialSummary } = compareJobs(
+    careerJobs, linkedinJobs, co.name, co.careerPageUrl, linkedinUrl,
+    effectiveStart, effectiveEnd,
+    maxSnapshots, // careerSnapshotsProcessed approximation
+    liSnaps,
+  );
+
+  // Push individual job comparison records
+  for (const cmp of comparisons) {
+    await Actor.pushData(cmp);
+  }
+
+  // Gemini narrative analysis
+  let geminiSummary: string | undefined;
+  let geminiAvailable = false;
+  if (googleAiApiKey && comparisons.length > 0) {
+    try {
+      log.info(`${co.name}: running Gemini analysis…`);
+      geminiSummary = await analyzeWithGemini(googleAiApiKey, partialSummary, partialSummary.topEvidenceJobs);
+      geminiAvailable = true;
+    } catch (err) {
+      log.warning(`${co.name}: Gemini analysis failed: ${err}`);
+    }
+  }
+
+  const summary: ResearchSummary = {
+    ...partialSummary,
+    geminiSummary,
+    geminiAvailable,
+  };
+
+  await Actor.pushData(summary);
+  log.info(`${co.name}: done`, {
+    careerJobs: summary.totalCareerJobs,
+    linkedinJobs: summary.totalLinkedInJobs,
+    matched: summary.matchedJobs,
+    pctCareerFirst: `${summary.pctCareerFirst}%`,
+    avgLag: `${summary.avgLagDays}d`,
+  });
+
+  return summary;
+}

--- a/apify/actors/career-vs-linkedin/src/match.ts
+++ b/apify/actors/career-vs-linkedin/src/match.ts
@@ -1,0 +1,69 @@
+/**
+ * Job title normalization and matching utilities.
+ *
+ * The goal is to find the same job posting across two platforms (career page and LinkedIn)
+ * even when titles differ slightly (e.g. "Sr. Software Engineer" vs "Senior Software Engineer").
+ */
+
+const SENIORITY = /\b(sr\.?|jr\.?|senior|junior|lead|principal|staff|associate|mid[-\s]?level|entry[-\s]?level|l[0-9]|i{1,3}|iv|v)\b/gi;
+const NOISE_WORDS = /\b(the|a|an|and|or|of|to|in|for|with|on|at|by|from)\b/gi;
+const PUNCTUATION = /[^\w\s]/g;
+const MULTI_SPACE = /\s+/g;
+
+/** Normalize a job title for fuzzy comparison. */
+export function normalizeTitle(title: string): string {
+  return title
+    .toLowerCase()
+    .replace(PUNCTUATION, ' ')
+    .replace(SENIORITY, '')
+    .replace(NOISE_WORDS, ' ')
+    .replace(MULTI_SPACE, ' ')
+    .trim();
+}
+
+/**
+ * Compute Jaccard similarity between two normalized titles (word-set overlap).
+ * Returns a value in [0, 1]; 1 = identical word sets.
+ */
+export function jaccardSimilarity(a: string, b: string): number {
+  const setA = new Set(a.split(' ').filter(Boolean));
+  const setB = new Set(b.split(' ').filter(Boolean));
+  if (setA.size === 0 && setB.size === 0) return 1;
+  if (setA.size === 0 || setB.size === 0) return 0;
+  let intersection = 0;
+  for (const w of setA) { if (setB.has(w)) intersection++; }
+  const union = setA.size + setB.size - intersection;
+  return intersection / union;
+}
+
+/** Returns true if two normalized titles are considered a match (threshold: 0.6). */
+export function titlesMatch(normA: string, normB: string, threshold = 0.6): boolean {
+  if (normA === normB) return true;
+  return jaccardSimilarity(normA, normB) >= threshold;
+}
+
+/**
+ * Find the best matching title from a candidate list.
+ * Returns the candidate and its similarity score, or null if no match exceeds the threshold.
+ */
+export function findBestMatch(
+  query: string,
+  candidates: string[],
+  threshold = 0.6,
+): { match: string; score: number } | null {
+  let best: { match: string; score: number } | null = null;
+  for (const candidate of candidates) {
+    const score = jaccardSimilarity(query, candidate);
+    if (score >= threshold && (!best || score > best.score)) {
+      best = { match: candidate, score };
+    }
+  }
+  return best;
+}
+
+/** Days between two YYYY-MM-DD date strings (positive if dateB > dateA). */
+export function daysBetween(dateA: string, dateB: string): number {
+  const a = new Date(dateA).getTime();
+  const b = new Date(dateB).getTime();
+  return Math.round((b - a) / 86_400_000);
+}

--- a/apify/actors/career-vs-linkedin/src/types.ts
+++ b/apify/actors/career-vs-linkedin/src/types.ts
@@ -1,0 +1,125 @@
+export interface CompanyPair {
+  name: string;
+  careerPageUrl: string;
+  linkedinSlug?: string;       // e.g. "stripe" → linkedin.com/company/stripe/jobs/
+  linkedinCompanyId?: string;  // numeric LinkedIn company ID for jobs/search?f_C= URLs
+}
+
+export interface Input {
+  // ── Single-company mode ────────────────────────────────────────────────────
+  companyName?: string;
+  careerPageUrl?: string;
+  linkedinSlug?: string;
+  linkedinCompanyId?: string;
+  // ── Batch mode ─────────────────────────────────────────────────────────────
+  batchMode?: boolean;
+  companies?: CompanyPair[];
+  // ── Shared options ─────────────────────────────────────────────────────────
+  startDate?: string;      // YYYY-MM-DD, defaults to 1 year ago
+  endDate?: string;        // YYYY-MM-DD, defaults to today
+  maxSnapshots?: number;   // per-source CDX snapshot limit (default 60)
+  delayMs?: number;        // ms between Wayback requests (default 1500)
+  googleAiApiKey?: string; // Gemini key (falls back to GOOGLE_AI_API_KEY env var)
+}
+
+export interface CdxSnapshot {
+  timestamp: string;  // 14-digit YYYYMMDDHHmmss
+  original: string;   // original archived URL
+}
+
+/** A job posting observed on one specific snapshot date for one platform. */
+export interface JobSighting {
+  title: string;
+  normalizedTitle: string;
+  firstSeen: string;         // YYYY-MM-DD of earliest Wayback snapshot where job appears
+  datePosted?: string;       // YYYY-MM-DD from JSON-LD datePosted (more accurate than firstSeen)
+  snapshotUrl: string;       // Wayback snapshot URL for evidence link
+  location?: string;
+  department?: string;
+  id?: string;               // ATS job ID if available
+  platform: 'career_page' | 'linkedin';
+  extractionMethod: string;
+}
+
+export type Verdict =
+  | 'career_first'    // career page appeared N days before LinkedIn
+  | 'linkedin_first'  // LinkedIn appeared N days before career page (anomaly)
+  | 'same_day'        // appeared on same day on both platforms
+  | 'career_only'     // seen on career page but never indexed by LinkedIn
+  | 'linkedin_only';  // seen on LinkedIn but not found on career page (syndicated/old)
+
+export interface JobComparison {
+  _type: 'job-comparison';
+  company: string;
+  normalizedTitle: string;
+  careerTitle: string;
+  linkedinTitle?: string;
+  /** Earliest Wayback snapshot date for this job on the career page. */
+  careerPageFirstSeen: string;
+  /** datePosted from career page JSON-LD if available (more accurate than firstSeen). */
+  careerPageDatePosted?: string;
+  /** Earliest Wayback snapshot date for this job on LinkedIn. */
+  linkedinFirstSeen?: string;
+  /** datePosted from LinkedIn JSON-LD if available. */
+  linkedinDatePosted?: string;
+  /** Best available date for career page (datePosted > firstSeen). */
+  effectiveCareerDate: string;
+  /** Best available date for LinkedIn (datePosted > firstSeen). */
+  effectiveLinkedInDate?: string;
+  /** Days career page is ahead of LinkedIn (positive = career page first). */
+  lagDays?: number;
+  verdict: Verdict;
+  location?: string;
+  department?: string;
+  careerSnapshotUrl: string;
+  linkedinSnapshotUrl?: string;
+}
+
+export interface LagBucket {
+  range: string;   // e.g. "1-3 days", "4-7 days"
+  count: number;
+}
+
+export interface ResearchSummary {
+  _type: 'research-summary';
+  company: string;
+  careerPageUrl: string;
+  linkedinUrl: string;
+  periodStart: string;
+  periodEnd: string;
+  careerSnapshotsProcessed: number;
+  linkedinSnapshotsProcessed: number;
+  totalCareerJobs: number;
+  totalLinkedInJobs: number;
+  matchedJobs: number;
+  careerOnlyJobs: number;
+  linkedinOnlyJobs: number;
+  careerFirstCount: number;
+  linkedinFirstCount: number;
+  sameDayCount: number;
+  avgLagDays: number;
+  medianLagDays: number;
+  /** % of matched jobs where career page was indexed first. */
+  pctCareerFirst: number;
+  lagDistribution: LagBucket[];
+  /** Top 10 jobs with the largest career-page lead as concrete evidence. */
+  topEvidenceJobs: JobComparison[];
+  conclusion: string;
+  geminiSummary?: string;
+  geminiAvailable: boolean;
+}
+
+export interface BatchSummary {
+  _type: 'batch-summary';
+  companiesAnalyzed: number;
+  avgPctCareerFirst: number;
+  avgLagDays: number;
+  overallConclusion: string;
+  companyResults: {
+    company: string;
+    pctCareerFirst: number;
+    avgLagDays: number;
+    matchedJobs: number;
+    conclusion: string;
+  }[];
+}

--- a/apify/actors/career-vs-linkedin/storage/key_value_stores/default/INPUT.json
+++ b/apify/actors/career-vs-linkedin/storage/key_value_stores/default/INPUT.json
@@ -1,0 +1,1 @@
+{"companyName":"Stripe","careerPageUrl":"https://boards.greenhouse.io/stripe","linkedinSlug":"stripe","startDate":"2024-06-01","endDate":"2024-09-30","maxSnapshots":8,"delayMs":1000}

--- a/apify/actors/career-vs-linkedin/storage/key_value_stores/default/INPUT.json
+++ b/apify/actors/career-vs-linkedin/storage/key_value_stores/default/INPUT.json
@@ -1,1 +1,1 @@
-{"companyName":"Stripe","careerPageUrl":"https://boards.greenhouse.io/stripe","linkedinSlug":"stripe","startDate":"2024-06-01","endDate":"2024-09-30","maxSnapshots":8,"delayMs":1000}
+{"companyName":"OpenAI","careerPageUrl":"https://boards.greenhouse.io/openai","linkedinSlug":"openai","startDate":"2023-01-01","endDate":"2024-12-31","maxSnapshots":60,"delayMs":1000}

--- a/apify/actors/career-vs-linkedin/tsconfig.json
+++ b/apify/actors/career-vs-linkedin/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"]
+}

--- a/apify/package-lock.json
+++ b/apify/package-lock.json
@@ -15,6 +15,76 @@
         "typescript": "^5.4.5"
       }
     },
+    "actors/career-vs-linkedin": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@google/generative-ai": "^0.21.0",
+        "apify": "^3.0.0",
+        "cheerio": "^1.0.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.0.0",
+        "esbuild": "^0.25.0",
+        "ts-node": "^10.9.0",
+        "typescript": "^5.4.5"
+      }
+    },
+    "actors/career-vs-linkedin/node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "actors/career-vs-linkedin/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "actors/career-vs-linkedin/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
     "actors/company-discovery-actor": {
       "version": "1.0.0",
       "dependencies": {
@@ -1419,7 +1489,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1442,7 +1511,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2432,7 +2500,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.37.tgz",
       "integrity": "sha512-8kzdPJ3FsNsVIurqBs7oodNnCEVbni9yUEkaHbgptDACOPW04jimGagZ51E6+lXUwJjgnBw+hyko/lkFWCldqw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2763,7 +2830,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2882,6 +2948,10 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/career-vs-linkedin": {
+      "resolved": "actors/career-vs-linkedin",
+      "link": true
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4402,8 +4472,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/idcac-playwright/-/idcac-playwright-0.2.0.tgz",
       "integrity": "sha512-qJH7vQgq3TKnhea/3Z3jlEJL7NC9vK9BkLClAzQHVRepBtq1fWfSI4fSuMKcPq7nDUTTlIEIS+vU+GRwwR1BXw==",
-      "license": "GPL-3.0-only",
-      "peer": true
+      "license": "GPL-3.0-only"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -5423,7 +5492,6 @@
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright-core": "1.58.2"
       },
@@ -5442,7 +5510,6 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -6246,7 +6313,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
## Summary

- New Apify actor at `apify/actors/career-vs-linkedin/` that uses the Wayback Machine to prove jobs appear on career pages before LinkedIn
- Fetches CDX snapshots of ATS API endpoints (Greenhouse, Lever, SmartRecruiters, Workable) and LinkedIn company jobs pages
- Matches jobs by normalized title (Jaccard similarity), computes per-job lag days, outputs `job-comparison` records with dual Wayback snapshot URLs as evidence
- Produces a `research-summary` with lag distribution, % career-first stat, and written conclusion
- Optional Gemini analysis generates a research-quality narrative
- Batch mode with 20 seed companies (Stripe, Coinbase, Anthropic, OpenAI, Figma, etc.)

## Test plan

- [ ] Single-company run: `careerPageUrl=https://boards.greenhouse.io/stripe`, `linkedinSlug=stripe`, `maxSnapshots=8`
- [ ] Verify `job-comparison` records are pushed with both `careerSnapshotUrl` and `linkedinSnapshotUrl`
- [ ] Verify `research-summary` `pctCareerFirst` and `avgLagDays` fields are populated
- [ ] Batch mode run with default seed list
- [ ] Gemini narrative with `GOOGLE_AI_API_KEY` set