### PR TITLE
Add discovery actor OpenAPI link to agentic page

### DIFF
--- a/apps/web/app/agentic/page.tsx
+++ b/apps/web/app/agentic/page.tsx
@@ -177,6 +177,15 @@ export default function Page() {
             <ApifyIcon className="w-3.5 h-3.5" />
             Powered by Apify
           </a>
+          <a
+            href="https://apify.com/golanger/company-discovery-actor/api/openapi"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-xs text-muted border border-divider rounded-full px-3 py-1 hover:border-foreground/30 transition-colors"
+          >
+            <ApifyIcon className="w-3.5 h-3.5" />
+            Get to know our Apify discovery actor
+          </a>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Adds a "Get to know our Apify discovery actor" link badge to the agentic page header, linking to the company-discovery-actor OpenAPI spec on Apify

## Test plan
- [ ] Visit `/agentic` and confirm the new pill badge appears next to "Powered by Apify"
- [ ] Click the link and confirm it opens the Apify OpenAPI page in a new tab