### PR TITLE
Fix search not updating when filter pills removed quickly

### DIFF
--- a/apps/web/app/[lang]/(app)/explore/search-page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/search-page.tsx
@@ -407,46 +407,46 @@ export function SearchPage({
 
   const handleRemoveKeyword = useCallback(
     (keyword: string) => {
-      const updated = keywords.filter((k) => k !== keyword);
+      const updated = keywordsRef.current.filter((k) => k !== keyword);
       setKeywords(updated);
       keywordsRef.current = updated;
       updateUrl();
       runSearch();
     },
-    [keywords],
+    [],
   );
 
   const handleAddLocation = useCallback(
     (location: SelectedLocation) => {
-      const updated = [...locations, location];
+      const updated = [...locationsRef.current, location];
       setLocations(updated);
       locationsRef.current = updated;
       updateUrl();
       runSearch();
     },
-    [locations],
+    [],
   );
 
   const handleAddOccupation = useCallback(
     (occ: TaxonomyItem) => {
-      const updated = [...occupations, occ];
+      const updated = [...occupationsRef.current, occ];
       setOccupations(updated);
       occupationsRef.current = updated;
       updateUrl();
       runSearch();
     },
-    [occupations],
+    [],
   );
 
   const handleAddSeniority = useCallback(
     (sen: TaxonomyItem) => {
-      const updated = [...seniorities, sen];
+      const updated = [...senioritiesRef.current, sen];
       setSeniorities(updated);
       senioritiesRef.current = updated;
       updateUrl();
       runSearch();
     },
-    [seniorities],
+    [],
   );
 
   const handleSubmitSearch = useCallback(
@@ -465,57 +465,57 @@ export function SearchPage({
 
   const handleRemoveLocation = useCallback(
     (locationId: number) => {
-      const updated = locations.filter((l) => l.id !== locationId);
+      const updated = locationsRef.current.filter((l) => l.id !== locationId);
       setLocations(updated);
       locationsRef.current = updated;
       updateUrl();
       runSearch();
     },
-    [locations],
+    [],
   );
 
   const handleRemoveOccupation = useCallback(
     (occId: number) => {
-      const updated = occupations.filter((o) => o.id !== occId);
+      const updated = occupationsRef.current.filter((o) => o.id !== occId);
       setOccupations(updated);
       occupationsRef.current = updated;
       updateUrl();
       runSearch();
     },
-    [occupations],
+    [],
   );
 
   const handleRemoveSeniority = useCallback(
     (senId: number) => {
-      const updated = seniorities.filter((s) => s.id !== senId);
+      const updated = senioritiesRef.current.filter((s) => s.id !== senId);
       setSeniorities(updated);
       senioritiesRef.current = updated;
       updateUrl();
       runSearch();
     },
-    [seniorities],
+    [],
   );
 
   const handleAddTechnology = useCallback(
     (tech: TaxonomyItem) => {
-      const updated = [...technologies, tech];
+      const updated = [...technologiesRef.current, tech];
       setTechnologies(updated);
       technologiesRef.current = updated;
       updateUrl();
       runSearch();
     },
-    [technologies],
+    [],
   );
 
   const handleRemoveTechnology = useCallback(
     (techId: number) => {
-      const updated = technologies.filter((t) => t.id !== techId);
+      const updated = technologiesRef.current.filter((t) => t.id !== techId);
       setTechnologies(updated);
       technologiesRef.current = updated;
       updateUrl();
       runSearch();
     },
-    [technologies],
+    [],
   );
 
   const handleSalaryChange = useCallback(


### PR DESCRIPTION
## Summary
- Filter pill add/remove handlers used `useState` values captured in `useCallback` closures
- When two pills are changed quickly (before React re-renders), the second handler's closure has the pre-first-change array — so it computes its update from stale state, undoing the first change
- Fix: all handlers now read from refs (`keywordsRef.current`, `locationsRef.current`, etc.) which are always current, instead of closure-captured state
- Dependency arrays changed from `[keywords]`/`[locations]`/etc. to `[]` since refs don't need to be dependencies

## Test plan
- [ ] Add 3+ keyword filters, then rapidly remove two — both removals should stick
- [ ] Same test with location, occupation, seniority, and technology pills
- [ ] Verify URL stays in sync after rapid filter changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)