### PR TITLE
Upgrade company-discovery-actor: Puppeteer + apify/ai-web-scraper

### DIFF
--- a/apify/actors/company-discovery-actor/.actor/actor.json
+++ b/apify/actors/company-discovery-actor/.actor/actor.json
@@ -2,9 +2,11 @@
   "actorSpecification": 1,
   "name": "company-discovery-actor",
   "title": "Company Discovery — AI-Powered Self-Evolving",
-  "description": "Discovers companies with open positions. Uses Gemini to reason about coverage gaps and suggest+validate new job portals each run. Registry persists across runs in KV store.",
-  "version": "1.0",
-  "environmentVariables": { "GOOGLE_AI_API_KEY": "@GOOGLE_AI_API_KEY" },
+  "description": "Discovers companies with open positions. Uses Gemini to reason about coverage gaps and suggest+validate new job portals each run. Scrapes JS-heavy sites (Glassdoor, Indeed) with Puppeteer. Calls apify/ai-web-scraper to extract companies from dynamic directories (Built In, etc.). Registry persists across runs in KV store.",
+  "version": "1.1",
+  "environmentVariables": {
+    "GOOGLE_AI_API_KEY": "@GOOGLE_AI_API_KEY"
+  },
   "input": {
     "title": "Input",
     "type": "object",
@@ -20,9 +22,9 @@
       "sources": {
         "type": "array",
         "title": "Static sources",
-        "description": "Which hardcoded sources to query.",
+        "description": "Which hardcoded sources to query. Include 'ai-web-scraper' to call apify/ai-web-scraper for dynamic directories.",
         "editor": "json",
-        "default": ["greenhouse", "themuse", "megaemployers", "arbeitnow", "remotive"]
+        "default": ["greenhouse", "themuse", "megaemployers", "arbeitnow", "remotive", "ai-web-scraper"]
       },
       "enableAiDiscovery": {
         "type": "boolean",

--- a/apify/actors/company-discovery-actor/Dockerfile
+++ b/apify/actors/company-discovery-actor/Dockerfile
@@ -1,4 +1,4 @@
-FROM apify/actor-node:20
+FROM apify/actor-node-puppeteer-chrome:20
 COPY package*.json ./
 RUN npm --quiet set progress=false && npm install --include=dev
 COPY . .

--- a/apify/actors/company-discovery-actor/package.json
+++ b/apify/actors/company-discovery-actor/package.json
@@ -8,16 +8,15 @@
     "dev": "ts-node src/main.ts"
   },
   "dependencies": {
-    "@crawlee/playwright": "^3.0.0",
+    "@crawlee/puppeteer": "^3.0.0",
     "@google/generative-ai": "^0.21.0",
     "apify": "^3.0.0",
+    "apify-client": "^2.9.0",
     "crawlee": "^3.0.0",
     "cheerio": "^1.0.0",
     "got-scraping": "^4.0.0",
     "node-tls-client": "^2.1.0",
-    "playwright": "^1.40.0",
-    "playwright-extra": "^4.3.6",
-    "puppeteer-extra-plugin-stealth": "^2.11.2"
+    "puppeteer": "^22.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.0.0",

--- a/apify/actors/company-discovery-actor/src/browser.ts
+++ b/apify/actors/company-discovery-actor/src/browser.ts
@@ -1,0 +1,57 @@
+/**
+ * Puppeteer-based browser fetcher using @crawlee/puppeteer PuppeteerCrawler.
+ *
+ * Use this for JS-heavy sites where got-scraping returns empty/blocked content.
+ * The Apify actor-node-puppeteer-chrome Docker image provides Chromium pre-installed.
+ */
+import { PuppeteerCrawler } from '@crawlee/puppeteer';
+
+export interface BrowserFetchOptions {
+  /** Milliseconds to wait after page load for dynamic content to render (default 2000). */
+  waitMs?: number;
+  /** Extra HTTP headers to send (e.g. Accept-Language). */
+  extraHeaders?: Record<string, string>;
+}
+
+/**
+ * Fetch a URL using a headless Chromium browser (Puppeteer).
+ * Returns the page's full HTML after JS has rendered, or null on failure.
+ */
+export async function fetchPageWithPuppeteer(
+  url: string,
+  opts: BrowserFetchOptions = {},
+): Promise<string | null> {
+  const { waitMs = 2000, extraHeaders = {} } = opts;
+  let html: string | null = null;
+
+  const crawler = new PuppeteerCrawler({
+    maxRequestRetries: 1,
+    requestHandlerTimeoutSecs: 45,
+    launchContext: {
+      launchOptions: {
+        headless: true,
+        args: [
+          '--no-sandbox',
+          '--disable-setuid-sandbox',
+          '--disable-dev-shm-usage',
+          '--disable-gpu',
+        ],
+      },
+    },
+    async requestHandler({ page }) {
+      if (Object.keys(extraHeaders).length > 0) {
+        await page.setExtraHTTPHeaders(extraHeaders);
+      }
+      // Wait for the network to be mostly idle, then a bit more for late renders.
+      await page.waitForNetworkIdle({ idleTime: 500 }).catch(() => null);
+      await new Promise<void>(r => setTimeout(r, waitMs));
+      html = await page.content();
+    },
+    failedRequestHandler({ request, log: crawlerLog }) {
+      crawlerLog.warning(`Puppeteer fetch failed: ${request.url}`);
+    },
+  });
+
+  await crawler.run([{ url }]);
+  return html;
+}

--- a/apify/actors/company-discovery-actor/src/main.ts
+++ b/apify/actors/company-discovery-actor/src/main.ts
@@ -103,6 +103,7 @@ import { discoverFromFactorial, discoverFromKenjo, discoverFromWorkstream, disco
 import { suggestNewPortals } from './sources/ai-discovery.js';
 import { probePortal, validatePortal } from './sources/generic-portal.js';
 import { loadRegistry, saveRegistry, getActivePortals, upsertPortal } from './registry.js';
+import { discoverFromAiWebScraper } from './sources/ai-web-scraper-source.js';
 
 interface Input {
   sources?: string[];
@@ -115,7 +116,7 @@ await Actor.init();
 
 const input = (await Actor.getInput<Input>()) ?? {};
 const {
-  sources = ['greenhouse', 'themuse', 'megaemployers', 'arbeitnow', 'remotive', 'remoteok', 'hiring-cafe', 'himalayas', 'ycombinator', 'bamboohr', 'recruitee', 'workable', 'ashby', 'lever', 'greenhouse-cdx', 'jazzhr', 'breezyhr', 'homerun', 'hibob', 'eightfold', 'cornerstone', 'pageup', 'avature', 'hireology', 'zohorecruit', 'talentlyft', 'occupop', 'easycruit', 'varbi', 'paycor', 'clearcompany', 'dayforce', 'darwinbox', 'keka', 'teamtailor', 'personio', 'icims', 'taleo', 'jobvite', 'successfactors', 'smartrecruiters', 'pinpoint', 'comeet', 'fountain', 'rippling', 'ashby-boards', 'factorial', 'kenjo', 'workstream', 'dover', 'jobteaser', 'wttj', 'freshteam', 'linkedin', 'indeed', 'glassdoor', 'stepstone', 'xing', 'workday-cdx', 'wellfound', 'weworkremotely', 'softgarden', 'join'],
+  sources = ['greenhouse', 'themuse', 'megaemployers', 'arbeitnow', 'remotive', 'remoteok', 'hiring-cafe', 'himalayas', 'ycombinator', 'bamboohr', 'recruitee', 'workable', 'ashby', 'lever', 'greenhouse-cdx', 'jazzhr', 'breezyhr', 'homerun', 'hibob', 'eightfold', 'cornerstone', 'pageup', 'avature', 'hireology', 'zohorecruit', 'talentlyft', 'occupop', 'easycruit', 'varbi', 'paycor', 'clearcompany', 'dayforce', 'darwinbox', 'keka', 'teamtailor', 'personio', 'icims', 'taleo', 'jobvite', 'successfactors', 'smartrecruiters', 'pinpoint', 'comeet', 'fountain', 'rippling', 'ashby-boards', 'factorial', 'kenjo', 'workstream', 'dover', 'jobteaser', 'wttj', 'freshteam', 'linkedin', 'indeed', 'glassdoor', 'stepstone', 'xing', 'workday-cdx', 'wellfound', 'weworkremotely', 'softgarden', 'join', 'ai-web-scraper'],
   maxCompaniesPerSource = 1000,
   enableAiDiscovery = true,
   maxAiSuggestionsPerRun = 4,
@@ -226,6 +227,7 @@ const staticSourceMap: Record<string, SourceFn> = {
   dayforce:        () => discoverFromDayforce(),
   easycruit:       () => discoverFromEasyCruit(),
   varbi:           () => discoverFromVarbi(),
+  'ai-web-scraper': () => discoverFromAiWebScraper(maxCompaniesPerSource),
 };
 
 /** Fetch a single source; returns raw results without mutating shared state. */

--- a/apify/actors/company-discovery-actor/src/sources/ai-web-scraper-source.ts
+++ b/apify/actors/company-discovery-actor/src/sources/ai-web-scraper-source.ts
@@ -1,0 +1,144 @@
+/**
+ * Company discovery via the Apify `apify/ai-web-scraper` actor.
+ *
+ * Calls the public Apify store actor which uses AI (Claude/GPT) to extract structured
+ * data from any web page — ideal for JS-heavy job directories we can't parse with
+ * plain selectors. The actor runs inside the same Apify account, so APIFY_TOKEN is
+ * automatically available when running on the platform.
+ *
+ * Targeted pages: job/startup directories with dynamic content not covered by our
+ * static scrapers (Built In, Wellfound new-format pages, etc.).
+ */
+import { Actor, log } from 'apify';
+import type { CompanyDiscovery } from '../types.js';
+
+interface TargetPage {
+  url: string;
+  instructions: string;
+}
+
+// Pages where AI extraction shines — JS-rendered directories with unstructured layouts.
+const TARGET_PAGES: TargetPage[] = [
+  {
+    url: 'https://builtin.com/companies',
+    instructions:
+      'Find every company card on this page. For each company extract: company_name (string) and job_board_url (string, the URL to their careers/jobs page or their Builtin profile). Return a JSON array.',
+  },
+  {
+    url: 'https://www.builtinnyc.com/companies',
+    instructions:
+      'Find every company card on this page. For each company extract: company_name (string) and job_board_url (string, their jobs/careers page). Return a JSON array.',
+  },
+  {
+    url: 'https://www.builtinla.com/companies',
+    instructions:
+      'Find every company card on this page. For each company extract: company_name (string) and job_board_url (string). Return a JSON array.',
+  },
+  {
+    url: 'https://www.builtinchicago.org/companies',
+    instructions:
+      'Find every company card on this page. For each company extract: company_name (string) and job_board_url (string). Return a JSON array.',
+  },
+  {
+    url: 'https://www.builtinaustin.com/companies',
+    instructions:
+      'Find every company card on this page. For each company extract: company_name (string) and job_board_url (string). Return a JSON array.',
+  },
+  {
+    url: 'https://www.builtinseattle.com/companies',
+    instructions:
+      'Find every company card on this page. For each company extract: company_name (string) and job_board_url (string). Return a JSON array.',
+  },
+  {
+    url: 'https://www.builtinboston.com/companies',
+    instructions:
+      'Find every company card on this page. For each company extract: company_name (string) and job_board_url (string). Return a JSON array.',
+  },
+  {
+    url: 'https://www.builtincolorado.com/companies',
+    instructions:
+      'Find every company card on this page. For each company extract: company_name (string) and job_board_url (string). Return a JSON array.',
+  },
+];
+
+interface ExtractedItem {
+  company_name?: string;
+  name?: string;
+  job_board_url?: string;
+  careers_url?: string;
+  url?: string;
+  website?: string;
+}
+
+/**
+ * Discover companies by calling the `apify/ai-web-scraper` actor on each target page.
+ * Requires APIFY_TOKEN to be available (auto-injected on the Apify platform).
+ */
+export async function discoverFromAiWebScraper(maxCompanies = 500): Promise<CompanyDiscovery[]> {
+  const results: CompanyDiscovery[] = [];
+  const seen = new Set<string>();
+  const now = new Date().toISOString();
+
+  for (const target of TARGET_PAGES) {
+    if (results.length >= maxCompanies) break;
+    log.info(`AI Web Scraper: processing ${target.url}`);
+
+    try {
+      const run = await Actor.call('apify/ai-web-scraper', {
+        startUrls: [{ url: target.url }],
+        // The actor accepts either `instructions` or `pageInstructions` depending on version.
+        instructions: target.instructions,
+        pageInstructions: target.instructions,
+        outputSchema: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              company_name: { type: 'string', description: 'Company or organisation name' },
+              job_board_url: { type: 'string', description: 'URL to the company job listings or careers page' },
+            },
+            required: ['company_name'],
+          },
+        },
+        // Keep the sub-run cheap: one page, short timeout.
+        maxPagesPerCrawl: 1,
+        maxCrawlingDepth: 0,
+      });
+
+      if (!run?.defaultDatasetId) {
+        log.warning(`AI Web Scraper: run for ${target.url} returned no dataset`);
+        continue;
+      }
+
+      const dataset = await Actor.openDataset(run.defaultDatasetId);
+      const { items } = await dataset.getData({ limit: maxCompanies - results.length });
+
+      let pageFound = 0;
+      for (const raw of items as ExtractedItem[]) {
+        const name = (raw.company_name || raw.name || '').trim();
+        const boardUrl = (raw.job_board_url || raw.careers_url || raw.url || raw.website || '').trim();
+        if (!name || name.length < 2 || name.length > 120) continue;
+
+        const key = name.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+
+        results.push({
+          company_name: name,
+          job_board_url: boardUrl || `https://www.google.com/search?q=${encodeURIComponent(name + ' careers')}`,
+          estimated_jobs: 1,
+          source: 'ai-web-scraper',
+          discovered_at: now,
+        });
+        pageFound++;
+      }
+
+      log.info(`AI Web Scraper: ${pageFound} companies from ${target.url} (total=${results.length})`);
+    } catch (err) {
+      log.error(`AI Web Scraper: failed for ${target.url}: ${err}`);
+    }
+  }
+
+  log.info(`AI Web Scraper: finished with ${results.length} total companies`);
+  return results;
+}

--- a/apify/actors/company-discovery-actor/src/sources/glassdoor.ts
+++ b/apify/actors/company-discovery-actor/src/sources/glassdoor.ts
@@ -1,5 +1,6 @@
 import * as cheerio from 'cheerio';
 import { fetchPage, sleep } from '../http.js';
+import { fetchPageWithPuppeteer } from '../browser.js';
 import type { CompanyDiscovery } from '../types.js';
 
 export async function discoverFromGlassdoor(
@@ -17,20 +18,27 @@ export async function discoverFromGlassdoor(
     if (results.length >= maxCompanies) break;
 
     const url = `https://www.glassdoor.com/Explore/browse-companies.htm?overall_rating_low=0&page=${page}`;
-    const html = await fetchPage({
+
+    // Glassdoor renders content via JavaScript — try HTTP first (faster), fall back to Puppeteer.
+    let html = await fetchPage({
       url,
       proxyUrl,
       headers: { 'Accept-Language': 'en-US,en;q=0.9' },
     });
 
-    if (!html) {
-      // Try alternative URL pattern
-      const altUrl = `https://www.glassdoor.com/Reviews/company-reviews.htm?page=${page}`;
-      const altHtml = await fetchPage({ url: altUrl, proxyUrl });
-      if (!altHtml) break;
-      parseGlassdoorPage(cheerio.load(altHtml), results, seen, now);
-      await sleep(1500 + Math.random() * 2000);
-      continue;
+    // If HTTP returned no employer content, render with a real browser.
+    if (!html || !hasEmployerContent(html)) {
+      console.log(`Glassdoor: page=${page} HTTP gave no content, retrying with Puppeteer…`);
+      html = await fetchPageWithPuppeteer(url, {
+        waitMs: 2500,
+        extraHeaders: { 'Accept-Language': 'en-US,en;q=0.9' },
+      });
+      if (!html) {
+        // Try alternative URL pattern before giving up on this page
+        const altUrl = `https://www.glassdoor.com/Reviews/company-reviews.htm?page=${page}`;
+        html = await fetchPageWithPuppeteer(altUrl, { waitMs: 2500 });
+        if (!html) break;
+      }
     }
 
     const found = parseGlassdoorPage(cheerio.load(html), results, seen, now);
@@ -42,6 +50,11 @@ export async function discoverFromGlassdoor(
 
   console.log(`Glassdoor: finished with ${results.length} companies`);
   return results;
+}
+
+/** Quick check: does the HTML look like a rendered employer listing? */
+function hasEmployerContent(html: string): boolean {
+  return /Overview|employer|company/i.test(html) && html.length > 5000;
 }
 
 function parseGlassdoorPage(

--- a/apify/actors/company-discovery-actor/src/sources/indeed.ts
+++ b/apify/actors/company-discovery-actor/src/sources/indeed.ts
@@ -1,5 +1,6 @@
 import * as cheerio from 'cheerio';
 import { fetchPage, sleep } from '../http.js';
+import { fetchPageWithPuppeteer } from '../browser.js';
 import type { CompanyDiscovery } from '../types.js';
 
 const DEFAULT_QUERIES = [
@@ -29,8 +30,15 @@ export async function discoverFromIndeed(
       if (results.length >= maxCompanies) break;
 
       const url = `https://www.indeed.com/companies?q=${encodeURIComponent(query)}&l=&start=${start}`;
-      const html = await fetchPage({ url, proxyUrl });
-      if (!html) break;
+
+      // Try plain HTTP first; Indeed renders its company directory in JavaScript, so fall back to Puppeteer.
+      let html = await fetchPage({ url, proxyUrl });
+
+      if (!html || !hasCompanyContent(html)) {
+        console.log(`Indeed: q="${query}" start=${start} HTTP gave no content, retrying with Puppeteer…`);
+        html = await fetchPageWithPuppeteer(url, { waitMs: 2500 });
+        if (!html) break;
+      }
 
       const $ = cheerio.load(html);
       let found = 0;
@@ -100,4 +108,9 @@ export async function discoverFromIndeed(
 
   console.log(`Indeed: finished with ${results.length} companies`);
   return results;
+}
+
+/** Heuristic: does the fetched HTML look like a rendered company directory? */
+function hasCompanyContent(html: string): boolean {
+  return /\/cmp\//i.test(html) && html.length > 3000;
 }


### PR DESCRIPTION
## Summary

- **Replace Playwright with Puppeteer** (`@crawlee/playwright` → `@crawlee/puppeteer`, `playwright` → `puppeteer`). The old Playwright deps were installed but never used — all HTTP went through `got-scraping`. Now `PuppeteerCrawler` is wired up properly.
- **Dockerfile** base image updated to `apify/actor-node-puppeteer-chrome:20` (includes Chromium).
- **New `src/browser.ts`** — reusable `fetchPageWithPuppeteer()` using `PuppeteerCrawler`; waits for network-idle then an extra configurable delay so dynamic content renders.
- **Glassdoor & Indeed**: both sites render their company directories via JavaScript. Each source now tries `got-scraping` first (fast, no browser) and falls back to `fetchPageWithPuppeteer` when the HTTP response has no meaningful content. This gives us real results instead of blank pages.
- **New `src/sources/ai-web-scraper-source.ts`** — calls the Apify store actor `apify/ai-web-scraper` (via `Actor.call`) on 8 Built In city pages (`builtin.com`, `builtinnyc.com`, `builtinla.com`, etc.). The AI actor extracts company names + job URLs from JS-heavy card layouts we can't reliably parse with CSS selectors. Results are merged into the main dataset under source `ai-web-scraper`.
- **`main.ts`**: imports and wires `discoverFromAiWebScraper` into `staticSourceMap` under the `ai-web-scraper` key; added to default sources list.
- **`actor.json`**: version bumped to `1.1`, description updated, `ai-web-scraper` added to default sources example.

## Test plan

- [ ] `npm run build` succeeds (esbuild bundles without import errors)
- [ ] On Apify platform: run actor with sources `["glassdoor"]` — verify companies returned (previously often empty due to JS rendering)
- [ ] Run with sources `["indeed"]` — verify companies returned
- [ ] Run with sources `["ai-web-scraper"]` — verify Built In companies extracted via AI actor
- [ ] Full run: confirm total company count is >= previous baseline