### PR TITLE
Use overflow-clip in ScrollFade for IntersectionObserver compatibility

### DIFF
--- a/apps/web/src/components/ui/scroll-fade.tsx
+++ b/apps/web/src/components/ui/scroll-fade.tsx
@@ -34,7 +34,7 @@ export function ScrollFade({ className = "", wrapperClassName = "", children, fa
   }, [...deps, update]);
 
   return (
-    <div className={`relative flex flex-col overflow-hidden rounded-[inherit] ${wrapperClassName}`}>
+    <div className={`relative flex flex-col overflow-clip rounded-[inherit] ${wrapperClassName}`}>
       {canScrollUp && (
         <div className={`pointer-events-none absolute inset-x-0 top-0 z-10 ${fadeHeight} bg-gradient-to-b from-surface via-surface/40 to-transparent`} />
       )}


### PR DESCRIPTION
## Summary
`overflow-hidden` on ScrollFade's wrapper creates a new scroll context that breaks `IntersectionObserver` — sentinels inside never become visible even with the correct `root` ref.

`overflow-clip` clips visual overflow identically (gradient overlays stay contained within rounded corners) but does NOT create a scroll context, so `IntersectionObserver` works normally.

Re-adds ScrollFade to the company search modal now that they're compatible.

## Test plan
- [ ] Company search modal: scroll to bottom → "Request a company" prompt appears
- [ ] Company search modal: fade gradients clip to rounded corners (no overflow)
- [ ] Company cards on explore page: fade indicators still work
- [ ] Search bar dropdown: fade indicators + rounded corners still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)