### PR TITLE
Fix company search modal: correct total count, filter zero-match in SQL

### DIFF
--- a/apps/web/src/components/watchlist/company-search-modal.tsx
+++ b/apps/web/src/components/watchlist/company-search-modal.tsx
@@ -165,11 +165,8 @@ export function CompanySearchModal({
 
   const { sentinelRef, isLoading: isLoadingMore } = useInfiniteScroll({ hasMore: !exhausted, load: handleLoadMore, root: scrollRef });
 
-  // Hide companies with zero matches for the current filters
-  const visibleCompanies = useMemo(
-    () => companies.filter((c) => c.activeMatches > 0 || c.yearMatches > 0),
-    [companies],
-  );
+  // Server already filters out zero-match companies
+  const visibleCompanies = companies;
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>

--- a/apps/web/src/lib/actions/company.ts
+++ b/apps/web/src/lib/actions/company.ts
@@ -170,12 +170,6 @@ export async function searchCompaniesForWatchlist(params: {
   }
   const jobWhere = sql.join(jobClauses, sql` AND `);
 
-  const [totalRow] = await db.execute<{ [key: string]: unknown; cnt: number }>(sql`
-    SELECT count(*)::int AS cnt FROM company c WHERE ${companyWhere}
-  `);
-  const total = (totalRow as unknown as { cnt: number })?.cnt ?? 0;
-  if (total === 0) return { companies: [], total: 0 };
-
   // When no text query and starred IDs are provided, boost starred companies to top
   const starredIds = params.starredCompanyIds;
   const boostStarred = !hasQuery && starredIds && starredIds.length > 0;
@@ -185,6 +179,8 @@ export async function searchCompaniesForWatchlist(params: {
     ? sql`CASE WHEN c.id = ANY(${starredArray}::uuid[]) THEN 0 ELSE 1 END, active_matches DESC, c.name`
     : sql`active_matches DESC, c.name`;
 
+  // Single query: compute match counts, filter out zero-match companies,
+  // and get total in one pass using a window function.
   const rows = await db.execute<{
     [key: string]: unknown;
     id: string;
@@ -194,18 +190,22 @@ export async function searchCompaniesForWatchlist(params: {
     description: string | null;
     active_matches: number;
     year_matches: number;
+    filtered_total: number;
   }>(sql`
-    SELECT c.id, c.name, c.slug, c.icon,
-           COALESCE(cd.description, c.description) AS description,
-           (SELECT count(*)::int FROM job_posting jp
-            WHERE jp.company_id = c.id AND ${jobWhere}) AS active_matches,
-           (SELECT count(*)::int FROM job_posting jp
-            WHERE jp.company_id = c.id
-              AND jp.first_seen_at >= now() - interval '1 year'
-              AND ${jobWhere}) AS year_matches
-    FROM company c
-    LEFT JOIN company_description cd ON cd.company_id = c.id AND cd.locale = ${params.locale}
-    WHERE ${companyWhere}
+    SELECT *, count(*) OVER () AS filtered_total FROM (
+      SELECT c.id, c.name, c.slug, c.icon,
+             COALESCE(cd.description, c.description) AS description,
+             (SELECT count(*)::int FROM job_posting jp
+              WHERE jp.company_id = c.id AND ${jobWhere}) AS active_matches,
+             (SELECT count(*)::int FROM job_posting jp
+              WHERE jp.company_id = c.id
+                AND jp.first_seen_at >= now() - interval '1 year'
+                AND ${jobWhere}) AS year_matches
+      FROM company c
+      LEFT JOIN company_description cd ON cd.company_id = c.id AND cd.locale = ${params.locale}
+      WHERE ${companyWhere}
+    ) sub
+    WHERE active_matches > 0 OR year_matches > 0
     ORDER BY ${orderClause}
     OFFSET ${params.offset}
     LIMIT ${params.limit}
@@ -214,9 +214,12 @@ export async function searchCompaniesForWatchlist(params: {
   type Row = {
     id: string; name: string; slug: string; icon: string | null;
     description: string | null; active_matches: number; year_matches: number;
+    filtered_total: number;
   };
+  const typed = rows as unknown as Row[];
+  const total = typed.length > 0 ? typed[0].filtered_total : 0;
   return {
-    companies: (rows as unknown as Row[]).map((r) => ({
+    companies: typed.map((r) => ({
       id: r.id,
       name: r.name,
       slug: r.slug,

--- a/apps/web/src/lib/actions/company.ts
+++ b/apps/web/src/lib/actions/company.ts
@@ -176,8 +176,8 @@ export async function searchCompaniesForWatchlist(params: {
   const starredArray = boostStarred ? `{${starredIds.join(",")}}` : null;
 
   const orderClause = boostStarred
-    ? sql`CASE WHEN c.id = ANY(${starredArray}::uuid[]) THEN 0 ELSE 1 END, active_matches DESC, c.name`
-    : sql`active_matches DESC, c.name`;
+    ? sql`CASE WHEN sub.id = ANY(${starredArray}::uuid[]) THEN 0 ELSE 1 END, active_matches DESC, sub.name`
+    : sql`active_matches DESC, sub.name`;
 
   // Single query: compute match counts, filter out zero-match companies,
   // and get total in one pass using a window function.


### PR DESCRIPTION
## Summary
- **Total count**: Header now shows count of companies with matching postings, not all companies. Uses `count(*) OVER()` window function on the filtered subquery.
- **Zero-match filter moved to SQL**: Companies with 0 active and 0 yearly matches are excluded in the query (`WHERE active_matches > 0 OR year_matches > 0`), not client-side. Reduces result set size.
- **One fewer query**: Removed the separate `SELECT count(*)` total query — the window function computes it alongside the main query.

## Test plan
- [ ] Company modal header shows correct count (matches visible list)
- [ ] No companies with "0 active · 0 in the last year" shown
- [ ] Infinite scroll still works (scroll to bottom → loads more)
- [ ] Search by name filters correctly, count updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)