### PR TITLE
Add Typesense env vars to turbo.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -18,7 +18,12 @@
         "DATABASE_URL_UNPOOLED",
         "UPSTASH_REDIS_REST_URL",
         "UPSTASH_REDIS_REST_TOKEN",
-        "R2_DOMAIN_URL"
+        "R2_DOMAIN_URL",
+        "TYPESENSE_HOST",
+        "TYPESENSE_PORT",
+        "TYPESENSE_PROTOCOL",
+        "TYPESENSE_SEARCH_KEY",
+        "TYPESENSE_WRITE_KEY"
       ]
     },
     "dev": {


### PR DESCRIPTION
## Summary
- Adds `TYPESENSE_HOST`, `TYPESENSE_PORT`, `TYPESENSE_PROTOCOL`, `TYPESENSE_SEARCH_KEY`, and `TYPESENSE_WRITE_KEY` to turbo.json build env filter
- Without these, Turbo excluded Typesense env vars from the web app build, causing search to fail with empty results after #1513 was merged

## Context
After merging #1513 (Typesense search integration), production search returned empty results because the Typesense client couldn't initialize — `TYPESENSE_SEARCH_KEY` was undefined at runtime despite being set in Vercel.

Turbo's `env` array in `turbo.json` acts as an allowlist: env vars not listed are excluded from the build environment. The Typesense vars were never added to this list.

## Test plan
- [ ] Merge and verify Vercel redeploy picks up Typesense env vars
- [ ] Confirm search results appear on https://jseek.co/en/explore

🤖 Generated with [Claude Code](https://claude.com/claude-code)