### PR TITLE
Never cache degraded search responses

### DIFF
--- a/apps/web/src/lib/actions/search.ts
+++ b/apps/web/src/lib/actions/search.ts
@@ -271,13 +271,16 @@ export async function listTopCompanies(params: {
   // Cache the default homepage (no user-specified filters). Include languages
   // in the key since different locales produce different language filters.
   const langKey = [...(params.languages ?? [])].sort().join(",");
-  const result = hasNoExplicitFilters
-    ? await cached(
-        `top-companies:${params.locale}:${langKey}:${params.offset}:${params.limit}`,
-        fetch,
-        { ttl: 60 },
-      )
-    : await fetch();
+  let result: SearchResponse;
+  if (hasNoExplicitFilters) {
+    result = await cached(
+      `top-companies:${params.locale}:${langKey}:${params.offset}:${params.limit}`,
+      fetch,
+      { ttl: 60, skipIf: (r: SearchResponse) => !!r.degraded },
+    );
+  } else {
+    result = await fetch();
+  }
 
   if (!userId && params.offset + result.companies.length >= ANON_MAX_COMPANIES) {
     return { ...result, truncated: true };

--- a/apps/web/src/lib/cache.ts
+++ b/apps/web/src/lib/cache.ts
@@ -1,9 +1,11 @@
 import "server-only";
 import { redis } from "@/lib/redis";
 
-interface CacheOptions {
+interface CacheOptions<T = unknown> {
   /** TTL in seconds. */
   ttl: number;
+  /** Skip caching the result if this predicate returns true. */
+  skipIf?: (data: T) => boolean;
 }
 
 /**
@@ -15,7 +17,7 @@ interface CacheOptions {
 export async function cached<T>(
   key: string,
   fetcher: () => Promise<T>,
-  options: CacheOptions,
+  options: CacheOptions<T>,
 ): Promise<T> {
   const fullKey = `cache:${key}`;
 
@@ -28,10 +30,12 @@ export async function cached<T>(
 
   const data = await fetcher();
 
-  try {
-    await redis.set(fullKey, JSON.stringify(data), { ex: options.ttl });
-  } catch {
-    // Redis unavailable — data still returned from fetcher
+  if (!options.skipIf?.(data)) {
+    try {
+      await redis.set(fullKey, JSON.stringify(data), { ex: options.ttl });
+    } catch {
+      // Redis unavailable — data still returned from fetcher
+    }
   }
 
   return data;


### PR DESCRIPTION
## Summary
- Adds `skipIf` option to the Redis `cached()` wrapper
- Uses it to skip caching when Typesense returns a degraded (error/empty) response
- Prevents 403 errors from being cached for 60s, leaving the homepage blank

## Context
When Typesense is unreachable (e.g. Cloudflare blocking), the search provider returns `{ companies: [], totalCompanies: 0, degraded: true }`. This was being cached in Redis for 60s, so even after fixing the underlying issue, the homepage stayed empty until the cache expired.

## Test plan
- [ ] Verify homepage loads normally after deploy
- [ ] Confirm degraded responses are not cached (check Redis key `cache:top-companies:*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)