### PR TITLE
Fix watchlist filter modals showing empty results

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
@@ -477,6 +477,12 @@ export function WatchlistViewPage({
               onRemoveTechnology={onRemoveTechnology}
               onSalaryChange={onSalaryChange}
               onExperienceChange={onExperienceChange}
+              histogramFilters={{
+                locationIds: locations.length > 0 ? locations.map((l) => l.id) : undefined,
+                occupationIds: occupations.length > 0 ? occupations.map((o) => o.id) : undefined,
+                seniorityIds: seniorities.length > 0 ? seniorities.map((s) => s.id) : undefined,
+                technologyIds: technologies.length > 0 ? technologies.map((t) => t.id) : undefined,
+              }}
             />
             {hasFilters && (
               <div className="flex flex-wrap items-center gap-2">

--- a/apps/web/src/lib/search/typesense-filters.ts
+++ b/apps/web/src/lib/search/typesense-filters.ts
@@ -10,6 +10,7 @@ export function buildFilterString(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   filters: any,
 ): string {
+  if (!filters) return "";
   const parts: string[] = [];
 
   if (filters.locationIds?.length) {


### PR DESCRIPTION
## Summary

- **Root cause**: `buildFilterString()` in `typesense-filters.ts` crashed on `undefined` input (`filters.locationIds` throws TypeError when filters is undefined). All calling functions have `try/catch` blocks that silently swallow the error and return `[]`, causing taxonomy modals to show "No locations/roles/levels/technologies match."
- **Fix**: Added early return `if (!filters) return ""` in `buildFilterString()`
- **Bonus**: Watchlist view page now passes `histogramFilters` to `AdvancedSearchPanel`, so salary/experience histogram modals reflect the current filter selections instead of showing global unfiltered data

## Test plan

- [ ] Create a new watchlist, click Filters, open Location modal — should show all locations with counts
- [ ] Open Occupation/Seniority/Technology modals — all should populate correctly
- [ ] Select a location filter, then open Salary modal — histogram should reflect location-scoped data
- [ ] Select a location filter, then open Experience modal — histogram should reflect location-scoped data
- [ ] Verify main search page filters still work correctly (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)