### PR TITLE
Add missing search bar keyword translation

### DIFF
--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -94,6 +94,111 @@ msgstr ""
 #~ msgid "breadcrumb.home"
 #~ msgstr "Startseite"
 
+#. Count of additional watchlists not shown
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:130
+#~ msgid "watchlists.explore.moreCount"
+#~ msgstr "{0} weitere"
+
+#. Agentic features section heading
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:104
+#: src/components/AgenticFeatures.tsx:44
+#~ msgid "home.agentic.title"
+#~ msgstr "Agentische Workflows auf dem Job-Index"
+
+#. Agentic feature card title: ghosting
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:108
+#: src/components/AgenticFeatures.tsx:66
+#~ msgid "home.agentic.cards.ghosting.title"
+#~ msgstr "Wahrscheinliche Geisterstellen erkennen"
+
+#. Agentic feature card title: discovery
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:109
+#: src/components/AgenticFeatures.tsx:71
+#~ msgid "home.agentic.cards.discovery.title"
+#~ msgstr "Entdecken, wer jetzt einstellt"
+
+#. Agentic features section eyebrow
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:103
+#: src/components/AgenticFeatures.tsx:41
+#~ msgid "home.agentic.eyebrow"
+#~ msgstr "Für KI-Agenten"
+
+#. Agentic features section description
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:105
+#: src/components/AgenticFeatures.tsx:47
+#~ msgid "home.agentic.description"
+#~ msgstr "Job Seek ist nicht nur eine Suchoberfläche für Menschen. Es bietet auch strukturierte Workflows für Agenten, die Jobs suchen, Geisterstellen erkennen und analysieren müssen, wo die Einstellungsaktivität zunimmt."
+
+#. Agentic features CTA title
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:117
+#~ msgid "home.agentic.cta.title"
+#~ msgstr "Brauchen Sie die Endpoint-Dokumentation?"
+
+#. Agentic feature card metadata: ghosting
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:100
+#~ msgid "home.agentic.cards.ghosting.meta"
+#~ msgstr "Offene Stufe"
+
+#. Agentic feature card metadata: discovery
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:105
+#~ msgid "home.agentic.cards.discovery.meta"
+#~ msgstr "Offene Stufe"
+
+#. Agentic feature card description: discovery
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:109
+#: src/components/AgenticFeatures.tsx:88
+#~ msgid "home.agentic.cards.discovery.description"
+#~ msgstr "Trendsignale von 39+ Jobbörsen abrufen, um expandierende Unternehmen, sinkende Aktivität und neue Einstellungswellen zu erkennen, bevor sie anderswo offensichtlich werden."
+
+#. Agentic feature card description: search
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:107
+#: src/components/AgenticFeatures.tsx:78
+#~ msgid "home.agentic.cards.search.description"
+#~ msgstr "Abfragen von Jobs, Unternehmen und Filtertaxonomien über JSON, damit Copiloten und interne Tools gegen dasselbe strukturierte Inventar wie das Produkt arbeiten können."
+
+#. Agentic feature card description: ghosting
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:108
+#: src/components/AgenticFeatures.tsx:83
+#~ msgid "home.agentic.cards.ghosting.description"
+#~ msgstr "Rekonstruiere den Posting-Verlauf aus archivierten Snapshots, um Stellen zu markieren, die scheinbar offen bleiben ohne echte Einstellungsabsicht, und erhalte einen Bericht, über den dein Agent Reasoning betreiben kann."
+
+#. Agentic features CTA description
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:122
+#~ msgid "home.agentic.cta.description"
+#~ msgstr "Überprüfe die agentische API-Referenz, das Auth-Modell und Beispielanfragen für Suche, Geisterstellen-Analyse und Unternehmensidentifizierung."
+
+#. Agentic feature card title: search
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:107
+#: src/components/AgenticFeatures.tsx:61
+#~ msgid "home.agentic.cards.search.title"
+#~ msgstr "Den Index direkt durchsuchen"
+
+#. Agentic feature card metadata: search
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:95
+#~ msgid "home.agentic.cards.search.meta"
+#~ msgstr "Abonnement erforderlich"
+
+#. Agentic features CTA button label
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:137
+#~ msgid "home.agentic.cta.button"
+#~ msgstr "API-Dokumentation ansehen"
+
 #. CC right 1
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:80
@@ -127,17 +232,10 @@ msgstr "(öffnet in neuem Tab)"
 msgid "company.page.employees"
 msgstr "{0} Mitarbeitende"
 
-#. Count of additional watchlists not shown
-#. js-lingui-explicit-id
-#. placeholder {0}: total - results.length
-#: src/components/watchlist/public-watchlist-search.tsx:130
-msgid "watchlists.explore.moreCount"
-msgstr "{0} weitere"
-
 #. Button to show remaining collapsed locations
 #. js-lingui-explicit-id
 #. placeholder {0}: locations.length - LOCATIONS_COLLAPSED
-#: src/components/search/job-detail-dialog.tsx:351
+#: src/components/search/job-detail-dialog.tsx:371
 msgid "search.detail.showMoreLocations"
 msgstr "{0} weitere"
 
@@ -253,7 +351,7 @@ msgstr "aktiv"
 
 #. Title for add companies modal
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:179
+#: src/components/watchlist/company-search-modal.tsx:182
 msgid "watchlists.companyModal.title"
 msgstr "Unternehmen hinzufügen"
 
@@ -263,16 +361,16 @@ msgstr "Unternehmen hinzufügen"
 msgid "watchlists.view.addDescription"
 msgstr "Beschreibung hinzufügen"
 
-#. Button to add an interview round
-#. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:76
-msgid "myJobs.detail.addInterview"
-msgstr "Interview hinzufügen"
-
 #. Quick action tooltip: add interview round
 #. js-lingui-explicit-id
 #: src/components/my-jobs/quick-actions.tsx:19
 msgid "myJobs.action.addInterview"
+msgstr "Interview hinzufügen"
+
+#. Button to add an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx:76
+msgid "myJobs.detail.addInterview"
 msgstr "Interview hinzufügen"
 
 #. Placeholder in the add keyword input
@@ -293,13 +391,6 @@ msgstr "Standort- oder Stichwortfilter hinzufügen…"
 msgid "search.locations.addPlaceholder"
 msgstr "Standort hinzufügen..."
 
-#. Agentic features section heading
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:104
-#: src/components/AgenticFeatures.tsx:44
-msgid "home.agentic.title"
-msgstr "Agentische Workflows auf dem Job-Index"
-
 #. Encryption
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/privacy-policy/page.tsx:57
@@ -309,7 +400,7 @@ msgstr "Alle Daten werden bei Übertragung und Speicherung verschlüsselt."
 
 #. Option to show all industries
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:255
+#: src/components/watchlist/company-search-modal.tsx:258
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Alle Branchen"
 
@@ -384,8 +475,8 @@ msgstr "Anwendungscode (MIT)"
 
 #. Feature: application stats title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:91
-#: src/components/Features.tsx:216
+#: app/[lang]/(public)/page.tsx:89
+#: src/components/Features.tsx:251
 msgid "home.features.s2.p3.title"
 msgstr "Benachrichtigungen, die du steuerst"
 
@@ -403,7 +494,7 @@ msgstr "Bewerbungsstatistik"
 
 #. Application tracker section heading in job detail
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:247
+#: src/components/search/job-detail-dialog.tsx:259
 msgid "search.detail.applicationTracker"
 msgstr "Bewerbungstracker"
 
@@ -425,16 +516,16 @@ msgstr "Bewerbungen im letzten Jahr"
 msgid "myJobs.group.applied"
 msgstr "Beworben"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:441
-msgid "search.tracker.applied"
-msgstr "Beworben"
-
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
 msgid "myJobs.status.applied"
+msgstr "Beworben"
+
+#. Status option in dropdown: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:36
+msgid "myJobs.statusOption.applied"
 msgstr "Beworben"
 
 #. Sankey funnel node: applied
@@ -443,10 +534,10 @@ msgstr "Beworben"
 msgid "myJobs.funnel.applied"
 msgstr "Beworben"
 
-#. Status option in dropdown: applied
+#. Application tracker status: applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:36
-msgid "myJobs.statusOption.applied"
+#: src/components/search/job-detail-dialog.tsx:461
+msgid "search.tracker.applied"
 msgstr "Beworben"
 
 #. Apply salary filter
@@ -463,7 +554,7 @@ msgstr "Anwenden"
 
 #. Apply button linking to original job posting
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:296
+#: src/components/my-jobs/my-job-detail-panel.tsx:304
 msgid "search.detail.apply"
 msgstr "Bewerben"
 
@@ -565,16 +656,16 @@ msgstr "Mit der Nutzung von Job Seek stimmst du diesen Bedingungen zu. Hier eine
 msgid "faq.q.optOut"
 msgstr "Kann ich die Indexierung meines Unternehmens durch Jobseek ablehnen?"
 
-#. Cancel button in create watchlist dialog
-#. js-lingui-explicit-id
-#: src/components/watchlist/create-watchlist-dialog.tsx:164
-msgid "watchlists.create.cancel"
-msgstr "Abbrechen"
-
 #. Cancel delete watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-action-bar.tsx:233
 msgid "watchlists.delete.cancel"
+msgstr "Abbrechen"
+
+#. Cancel button in create watchlist dialog
+#. js-lingui-explicit-id
+#: src/components/watchlist/create-watchlist-dialog.tsx:164
+msgid "watchlists.create.cancel"
 msgstr "Abbrechen"
 
 #. Cancel delete button
@@ -613,17 +704,17 @@ msgstr "Ändere dein Passwort über einen sicheren E-Mail-Link."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Ändern…"
 
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "E-Mail prüfen"
-
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
 msgstr "E-Mail überprüfen"
+
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
+msgstr "E-Mail prüfen"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -651,7 +742,7 @@ msgstr "Wählen Sie den Plan, der zu Ihnen passt."
 
 #. Pricing section heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:113
+#: app/[lang]/(public)/page.tsx:102
 #: src/components/Pricing.tsx:103
 msgid "home.pricing.title"
 msgstr "Wähle den passenden Plan"
@@ -685,14 +776,14 @@ msgstr "Alle entfernen"
 #. Button to clear all active search filters
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:536
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:542
 #: src/components/search/search-toolbar.tsx:283
 msgid "search.filters.clearAll"
 msgstr "Alle löschen"
 
 #. Clear all selected companies button
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:191
+#: src/components/watchlist/company-search-modal.tsx:194
 msgid "watchlists.companyModal.clearAll"
 msgstr "Alle entfernen"
 
@@ -748,15 +839,15 @@ msgstr "Sammlung von Stellenanzeigen (CC BY-NC 4.0)"
 
 #. Feature: multi-dimensional filters description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:81
-#: src/components/Features.tsx:152
+#: app/[lang]/(public)/page.tsx:79
+#: src/components/Features.tsx:186
 msgid "home.features.s1.p2.description"
 msgstr "Erfasse, wo du dich beworben hast, Status, Kontakte und nächste Schritte."
 
 #. Feature: focused search description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:98
-#: src/components/Features.tsx:267
+#: app/[lang]/(public)/page.tsx:96
+#: src/components/Features.tsx:303
 msgid "home.features.s3.p1.description"
 msgstr "Kombiniere bestimmte Unternehmen mit Rollenfiltern, um genau die Positionen zu finden, die du suchst."
 
@@ -774,7 +865,7 @@ msgstr "Unternehmen"
 
 #. Section header for company suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:446
+#: src/components/search/search-bar.tsx:632
 msgid "search.bar.companies"
 msgstr "Unternehmen"
 
@@ -833,28 +924,28 @@ msgstr "Verknüpfte Konten"
 msgid "license.contact.title"
 msgstr "Kontakt"
 
-#. TOC: Contact
-#. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:25
-msgid "license.toc.contact"
-msgstr "Kontakt"
-
 #. Footer link to contact email
 #. js-lingui-explicit-id
 #: src/components/Footer.tsx:41
 msgid "common.footer.contact"
 msgstr "Kontakt"
 
-#. Table of contents heading
+#. TOC: Contact
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
-msgstr "Inhalt"
+#: src/components/LicenseContent.tsx:25
+msgid "license.toc.contact"
+msgstr "Kontakt"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
+msgstr "Inhalt"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Inhalt"
 
 #. Button to continue to app after verification
@@ -977,8 +1068,8 @@ msgstr "Konto wird erstellt…"
 
 #. Feature section 3 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:95
-#: src/components/Features.tsx:257
+#: app/[lang]/(public)/page.tsx:93
+#: src/components/Features.tsx:293
 msgid "home.features.s3.title"
 msgstr "Erstelle eine Watchlist für jede Nische"
 
@@ -1080,16 +1171,9 @@ msgstr "Details"
 
 #. Collapsible section heading for extracted job details
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:379
+#: src/components/search/job-detail-dialog.tsx:399
 msgid "search.detail.details"
 msgstr "Details"
-
-#. Agentic feature card title: ghosting
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:108
-#: src/components/AgenticFeatures.tsx:66
-msgid "home.agentic.cards.ghosting.title"
-msgstr "Wahrscheinliche Geisterstellen erkennen"
 
 #. Subtext encouraging user to request a company when no results found
 #. js-lingui-explicit-id
@@ -1099,8 +1183,8 @@ msgstr "Haben Sie das gesuchte Unternehmen nicht gefunden?"
 
 #. Feature: direct from source title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:80
-#: src/components/Features.tsx:146
+#: app/[lang]/(public)/page.tsx:78
+#: src/components/Features.tsx:180
 msgid "home.features.s1.p1.title"
 msgstr "Unternehmens-Benachrichtigungen"
 
@@ -1118,16 +1202,9 @@ msgstr "Trennen"
 
 #. Section title for discovering public watchlists
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:73
+#: src/components/watchlist/public-watchlist-search.tsx:81
 msgid "watchlists.explore.publicTitle"
 msgstr "Öffentliche Watchlists entdecken"
-
-#. Agentic feature card title: discovery
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:109
-#: src/components/AgenticFeatures.tsx:71
-msgid "home.agentic.cards.discovery.title"
-msgstr "Entdecken, wer jetzt einstellt"
 
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/faq/page.tsx:78
@@ -1234,8 +1311,8 @@ msgstr "Auch nach der Entdeckung rufen wir Stellendetailseiten mit einem strikte
 
 #. Feature section 1 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:77
-#: src/components/Features.tsx:137
+#: app/[lang]/(public)/page.tsx:75
+#: src/components/Features.tsx:171
 msgid "home.features.s1.title"
 msgstr "Entwickelt für aktive Jobsuchende"
 
@@ -1381,21 +1458,21 @@ msgstr "Filter"
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:104
-#: src/components/search/job-detail-dialog.tsx:292
-#: src/components/search/job-detail-dialog.tsx:370
+#: src/components/search/job-detail-dialog.tsx:116
+#: src/components/search/job-detail-dialog.tsx:312
+#: src/components/search/job-detail-dialog.tsx:390
 msgid "search.detail.filterByPrefix"
 msgstr "Filtern nach"
 
 #. Tooltip for salary filter pill
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:226
+#: src/components/search/job-detail-dialog.tsx:238
 msgid "search.detail.filterBySalary"
 msgstr "Nach Gehaltsbereich filtern"
 
 #. Placeholder for industry filter search
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:243
+#: src/components/watchlist/company-search-modal.tsx:246
 msgid "watchlists.companyModal.industrySearch"
 msgstr "Branchen filtern..."
 
@@ -1424,22 +1501,22 @@ msgid "settings.general.jobLanguages.findMore"
 msgstr "Weitere finden"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:22
-#: app/[lang]/(public)/page.tsx:47
+#: app/[lang]/(public)/page.tsx:21
+#: app/[lang]/(public)/page.tsx:46
 msgid "home.meta.title"
 msgstr "Relevante Stellen schneller finden"
 
 #. Main heading on the landing page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:73
+#: app/[lang]/(public)/page.tsx:71
 #: src/components/Hero.tsx:28
 msgid "home.hero.title"
 msgstr "Relevante Stellen schneller finden."
 
 #. Feature: focused search title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:98
-#: src/components/Features.tsx:266
+#: app/[lang]/(public)/page.tsx:96
+#: src/components/Features.tsx:302
 msgid "home.features.s3.p1.title"
 msgstr "Fokussierte Suche"
 
@@ -1454,13 +1531,6 @@ msgstr "Folge uns auf LinkedIn"
 #: src/components/Footer.tsx:31
 msgid "common.footer.ariaLabel"
 msgstr "Fußzeile"
-
-#. Agentic features section eyebrow
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:103
-#: src/components/AgenticFeatures.tsx:41
-msgid "home.agentic.eyebrow"
-msgstr "Für KI-Agenten"
 
 #. Free tier period
 #. js-lingui-explicit-id
@@ -1489,7 +1559,7 @@ msgstr "Gegründet {0}"
 
 #. Free tier name
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:115
+#: app/[lang]/(public)/page.tsx:104
 #: src/components/Pricing.tsx:32
 msgid "home.pricing.free.name"
 msgstr "Kostenlos"
@@ -1520,8 +1590,8 @@ msgstr "Fr"
 
 #. Feature section 2 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:86
-#: src/components/Features.tsx:197
+#: app/[lang]/(public)/page.tsx:84
+#: src/components/Features.tsx:232
 msgid "home.features.s2.title"
 msgstr "Der erste Job-Aggregator, der dich ans Steuer lässt"
 
@@ -1538,7 +1608,7 @@ msgstr "Vollständige Suche, 1 Watchlist, Bewerbungstracker"
 
 #. Free tier description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:115
+#: app/[lang]/(public)/page.tsx:104
 #: src/components/Pricing.tsx:41
 msgid "home.pricing.free.description"
 msgstr "Teste Job Seek mit genug Spielraum, um bei deinen Traumunternehmen auf dem Laufenden zu bleiben."
@@ -1730,7 +1800,7 @@ msgstr "Indexierungsrichtlinie"
 
 #. Industry filter label
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:231
+#: src/components/watchlist/company-search-modal.tsx:234
 msgid "watchlists.companyModal.industry"
 msgstr "Branche"
 
@@ -1775,8 +1845,8 @@ msgstr "Interview"
 
 #. Feature: interview log title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:90
-#: src/components/Features.tsx:211
+#: app/[lang]/(public)/page.tsx:88
+#: src/components/Features.tsx:246
 msgid "home.features.s2.p2.title"
 msgstr "Schluss mit der 50-Tab-Routine"
 
@@ -1784,12 +1854,6 @@ msgstr "Schluss mit der 50-Tab-Routine"
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:30
 msgid "myJobs.group.interviewing"
-msgstr "Im Interview"
-
-#. Application tracker status: interviewing
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:442
-msgid "search.tracker.interviewing"
 msgstr "Im Interview"
 
 #. Interviewing status badge label
@@ -1802,6 +1866,12 @@ msgstr "Im Interview"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:37
 msgid "myJobs.statusOption.interviewing"
+msgstr "Im Interview"
+
+#. Application tracker status: interviewing
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:462
+msgid "search.tracker.interviewing"
 msgstr "Im Interview"
 
 #. Interviews section heading
@@ -1846,7 +1916,7 @@ msgstr "Job"
 
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:110
+#: src/components/watchlist/public-watchlist-search.tsx:118
 msgid "watchlists.explore.jobSingular"
 msgstr "Job"
 
@@ -1861,17 +1931,17 @@ msgstr "Job-Aggregator, der Karriereseiten von Unternehmen überwacht. Abonniere
 msgid "license.toc.data"
 msgstr "Stellendaten (CC BY-NC 4.0)"
 
-#. Job detail panel title
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:74
-msgid "search.detail.title"
-msgstr "Stellendetails"
-
 #. Job detail panel title in My Jobs
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:161
+#: src/components/my-jobs/my-job-detail-panel.tsx:163
 msgid "myJobs.detail.title"
 msgstr "Jobdetails"
+
+#. Job detail panel title
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:86
+msgid "search.detail.title"
+msgstr "Stellendetails"
 
 #. Nav link: Job indexing
 #. Nav link: Job indexing
@@ -1912,7 +1982,7 @@ msgstr "Den Puls des Arbeitsmarkts im Blick behalten."
 
 #. Alt text for feature section 2 screenshot
 #. js-lingui-explicit-id
-#: src/components/Features.tsx:224
+#: src/components/Features.tsx:259
 msgid "home.features.s2.screenshot.alt"
 msgstr "Job Seek Oberfläche zum Einreichen von Unternehmenslinks und Konfigurieren benutzerdefinierter Benachrichtigungen"
 
@@ -1941,13 +2011,6 @@ msgstr "Job Seek wird aktiv entwickelt. Bleib dran für Updates!"
 msgid "about.p1"
 msgstr "Job Seek wird von der Colophon Group entwickelt, einem kleinen Entwicklerteam in der Schweiz. Wir haben es gestartet, weil wir das gleiche Problem satt hatten, das jeder Jobsuchende kennt: Dutzende Browser-Tabs jonglieren, neue Stellen verpassen, weil ein Aggregator zu langsam war, und in algorithmischem Rauschen untergehen, das auf Klicks statt auf Relevanz optimiert."
 
-#. Agentic features section description
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:105
-#: src/components/AgenticFeatures.tsx:47
-msgid "home.agentic.description"
-msgstr "Job Seek ist nicht nur eine Suchoberfläche für Menschen. Es bietet auch strukturierte Workflows für Agenten, die Jobs suchen, Geisterstellen erkennen und analysieren müssen, wo die Einstellungsaktivität zunimmt."
-
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/privacy-policy/page.tsx:19
 #: app/[lang]/(public)/privacy-policy/page.tsx:41
@@ -1956,13 +2019,13 @@ msgstr "Datenschutzrichtlinie von Job Seek — welche personenbezogenen Daten wi
 
 #. Alt text for feature section 1 screenshot
 #. js-lingui-explicit-id
-#: src/components/Features.tsx:164
+#: src/components/Features.tsx:198
 msgid "home.features.s1.screenshot.alt"
 msgstr "Job Seek Dashboard mit verfolgten Bewerbungen und Unternehmensbenachrichtigungen"
 
 #. Alt text for feature section 3 screenshot
 #. js-lingui-explicit-id
-#: src/components/Features.tsx:284
+#: src/components/Features.tsx:320
 msgid "home.features.s3.screenshot.alt"
 msgstr "Job Seek Watchlist mit kuratierten Robotik-Ingenieurstellen in Zürich"
 
@@ -1986,13 +2049,13 @@ msgstr "Jobs"
 
 #. Job count label in watchlist view
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:215
+#: src/components/watchlist/watchlist-job-list.tsx:226
 msgid "watchlists.jobList.jobCount"
 msgstr "Jobs"
 
 #. Plural job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:111
+#: src/components/watchlist/public-watchlist-search.tsx:119
 msgid "watchlists.explore.jobPlural"
 msgstr "Jobs"
 
@@ -2078,16 +2141,16 @@ msgstr "Erfahre, wie Job Seek Karriereseiten von Workday, Greenhouse, Lever und 
 msgid "home.hero.secondaryCta"
 msgstr "Mehr erfahren"
 
+#. Section header for seniority suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:522
+msgid "search.bar.level"
+msgstr "Stufe"
+
 #. Label for seniority/level filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:154
 msgid "search.advanced.level"
-msgstr "Stufe"
-
-#. Section header for seniority suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:567
-msgid "search.bar.level"
 msgstr "Stufe"
 
 #. js-lingui-explicit-id
@@ -2104,7 +2167,7 @@ msgstr "Lizenz"
 
 #. Footer link to license page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
+#: src/components/Footer.tsx:47
 msgid "common.footer.licenseLink"
 msgstr "Lizenz"
 
@@ -2157,16 +2220,16 @@ msgstr "Standort"
 msgid "search.advanced.location"
 msgstr "Standort"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:304
-msgid "search.detail.locations"
-msgstr "Standorte"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:492
+#: src/components/search/search-bar.tsx:592
 msgid "search.bar.locations"
+msgstr "Standorte"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:324
+msgid "search.detail.locations"
 msgstr "Standorte"
 
 #. Login button label
@@ -2191,8 +2254,8 @@ msgstr "Melde dich an, um diese Suche als Watchlist zu speichern"
 
 #. Feature: share watchlists description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:100
-#: src/components/Features.tsx:277
+#: app/[lang]/(public)/page.tsx:98
+#: src/components/Features.tsx:313
 msgid "home.features.s3.p3.description"
 msgstr "Mach eine Watchlist öffentlich und teile den Link mit Freunden, Communities oder deinem Netzwerk."
 
@@ -2264,7 +2327,7 @@ msgstr "Min"
 
 #. Singular mirror count
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:118
+#: src/components/watchlist/public-watchlist-search.tsx:126
 msgid "watchlists.explore.mirrorSingular"
 msgstr "Kopie"
 
@@ -2284,14 +2347,14 @@ msgstr "Spiegle jede öffentliche Watchlist, um sie zu deiner eigenen zu machen 
 
 #. Plural mirror count
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:119
+#: src/components/watchlist/public-watchlist-search.tsx:127
 msgid "watchlists.explore.mirrorPlural"
 msgstr "Kopien"
 
 #. Feature: request companies description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:99
-#: src/components/Features.tsx:272
+#: app/[lang]/(public)/page.tsx:97
+#: src/components/Features.tsx:308
 msgid "home.features.s3.p2.description"
 msgstr "Ein Unternehmen fehlt? Füge die Karriereseiten-URL ein und wir beginnen, es für dich zu indexieren."
 
@@ -2326,15 +2389,15 @@ msgstr "mehr"
 
 #. Feature: status tracking description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:89
-#: src/components/Features.tsx:207
+#: app/[lang]/(public)/page.tsx:87
+#: src/components/Features.tsx:242
 msgid "home.features.s2.p1.description"
 msgstr "Verweise uns auf eine beliebige Karriereseite oder ein Notion-Jobboard und Job Seek spiegelt sie innerhalb von Minuten in deinem Workspace."
 
 #. Feature: multi-dimensional filters title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:81
-#: src/components/Features.tsx:151
+#: app/[lang]/(public)/page.tsx:79
+#: src/components/Features.tsx:185
 msgid "home.features.s1.p2.title"
 msgstr "Bewerbungstracker"
 
@@ -2391,12 +2454,6 @@ msgstr "Name"
 msgid "watchlists.create.nameLabel"
 msgstr "Name"
 
-#. Agentic features CTA title
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:117
-msgid "home.agentic.cta.title"
-msgstr "Brauchen Sie die Endpoint-Dokumentation?"
-
 #. TOC: Need to reach us?
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:33
@@ -2447,13 +2504,13 @@ msgstr "Keine Filter gesetzt. Füge Filter hinzu, um die Ergebnisse einzugrenzen
 
 #. No industries match search
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:273
+#: src/components/watchlist/company-search-modal.tsx:276
 msgid "watchlists.companyModal.noIndustries"
 msgstr "Keine Branchen gefunden."
 
 #. Empty state when no jobs match the time range
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:226
+#: src/components/watchlist/watchlist-job-list.tsx:237
 msgid "watchlists.jobList.empty"
 msgstr "Keine Jobs gefunden."
 
@@ -2463,17 +2520,17 @@ msgstr "Keine Jobs gefunden."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Keine Sprachen entsprechen deiner Suche."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:186
-msgid "company.locationModal.noResults"
-msgstr "Keine Standorte entsprechen Ihrer Suche."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:171
 msgid "search.locationModal.noResults"
 msgstr "Keine Standorte gefunden."
+
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:186
+msgid "company.locationModal.noResults"
+msgstr "Keine Standorte entsprechen Ihrer Suche."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2525,7 +2582,7 @@ msgstr "Keine Gewährleistung — Nutzung auf eigenes Risiko."
 
 #. No results message when searching public watchlists
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:140
+#: src/components/watchlist/public-watchlist-search.tsx:142
 msgid "watchlists.explore.noResults"
 msgstr "Keine Watchlists gefunden."
 
@@ -2545,16 +2602,16 @@ msgstr "Nein. Der Bewerbungstracker hat kein festes Limit — speichere so viele
 msgid "faq.a.dataPrivacy"
 msgstr "Nein. Wir verkaufen, vermieten oder teilen deine Daten nicht zu Marketingzwecken. Cookies sind nur sitzungsbasiert, ohne Werbung oder Tracking. Du kannst dein Konto löschen und alle Daten werden innerhalb von 30 Tagen entfernt."
 
-#. Application tracker status: not applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:440
-msgid "search.tracker.notApplied"
-msgstr "Nicht beworben"
-
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
+msgstr "Nicht beworben"
+
+#. Application tracker status: not applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:460
+msgid "search.tracker.notApplied"
 msgstr "Nicht beworben"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2585,16 +2642,16 @@ msgstr "Berufsfeld"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Okt"
 
-#. Application tracker status: offer
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:443
-msgid "search.tracker.offer"
-msgstr "Angebot"
-
 #. Offered status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
+msgstr "Angebot"
+
+#. Application tracker status: offer
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:463
+msgid "search.tracker.offer"
 msgstr "Angebot"
 
 #. Status group heading: offered
@@ -2603,16 +2660,16 @@ msgstr "Angebot"
 msgid "myJobs.group.offered"
 msgstr "Angebot"
 
-#. Sankey funnel node: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:43
-msgid "myJobs.funnel.offered"
-msgstr "Angebot"
-
 #. Status option in dropdown: offered
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:38
 msgid "myJobs.statusOption.offered"
+msgstr "Angebot"
+
+#. Sankey funnel node: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:43
+msgid "myJobs.funnel.offered"
 msgstr "Angebot"
 
 #. Cookie banner accept button
@@ -2649,7 +2706,7 @@ msgstr "Vor Ort"
 
 #. Aria label for mobile menu button
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:86
+#: src/components/Header.tsx:83
 msgid "common.header.openMenu"
 msgstr "Hauptmenü öffnen"
 
@@ -2657,18 +2714,6 @@ msgstr "Hauptmenü öffnen"
 #: app/[lang]/(app)/company/[slug]/page.tsx:36
 msgid "company.meta.openPositions"
 msgstr "Offene Stellen"
-
-#. Agentic feature card metadata: ghosting
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:100
-msgid "home.agentic.cards.ghosting.meta"
-msgstr "Offene Stufe"
-
-#. Agentic feature card metadata: discovery
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:105
-msgid "home.agentic.cards.discovery.meta"
-msgstr "Offene Stufe"
 
 #. Open-source section title
 #. js-lingui-explicit-id
@@ -2736,26 +2781,26 @@ msgstr "Unsere Haltung zur Automatisierung"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Überblick"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Überblick"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Seiteninhalt"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Überblick"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Seiteninhalt"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Seiteninhalt"
 
 #. Heading shown on the 404 page
@@ -2828,7 +2873,7 @@ msgstr "Zeitraum"
 
 #. Pro tier period
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:116
+#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:73
 msgid "home.pricing.pro.period"
 msgstr "pro Monat"
@@ -2859,8 +2904,8 @@ msgstr "Telefoninterview"
 
 #. Feature section 3 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:96
-#: src/components/Features.tsx:260
+#: app/[lang]/(public)/page.tsx:94
+#: src/components/Features.tsx:296
 msgid "home.features.s3.description"
 msgstr "Wähle die Unternehmen, die dich interessieren, setze deine Filter und erhalte einen Live-Feed passender Stellen. Teile ihn öffentlich oder behalte ihn für dich."
 
@@ -2946,19 +2991,19 @@ msgstr "Bitte melden Sie sich an, um Ihre Abrechnungseinstellungen zu verwalten.
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:89
-msgid "search.detail.notFound"
-msgstr "Stelle nicht gefunden."
-
-#. Posting not found message
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:181
+#: src/components/my-jobs/my-job-detail-panel.tsx:183
 msgid "myJobs.detail.notFound"
 msgstr "Stellenanzeige nicht gefunden."
 
+#. Posting not found message
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:101
+msgid "search.detail.notFound"
+msgstr "Stelle nicht gefunden."
+
 #. Pricing section eyebrow
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:112
+#: app/[lang]/(public)/page.tsx:101
 #: src/components/Pricing.tsx:100
 msgid "home.pricing.eyebrow"
 msgstr "Preise"
@@ -2979,7 +3024,7 @@ msgstr "Datenschutz"
 
 #. Footer link to privacy policy page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:57
+#: src/components/Footer.tsx:52
 msgid "common.footer.privacyLink"
 msgstr "Datenschutz"
 
@@ -3004,7 +3049,7 @@ msgstr "Private Watchlists sind eine kostenpflichtige Funktion. Upgrade, um dein
 
 #. Pro tier name
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:116
+#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:68
 msgid "home.pricing.pro.name"
 msgstr "Pro"
@@ -3026,20 +3071,6 @@ msgstr "Öffentlich (für andere sichtbar)"
 #: src/components/PublicDomainArt.tsx:62
 msgid "common.art.publicDomain"
 msgstr "Gemeinfrei"
-
-#. Agentic feature card description: discovery
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:109
-#: src/components/AgenticFeatures.tsx:88
-msgid "home.agentic.cards.discovery.description"
-msgstr "Trendsignale von 39+ Jobbörsen abrufen, um expandierende Unternehmen, sinkende Aktivität und neue Einstellungswellen zu erkennen, bevor sie anderswo offensichtlich werden."
-
-#. Agentic feature card description: search
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:107
-#: src/components/AgenticFeatures.tsx:78
-msgid "home.agentic.cards.search.description"
-msgstr "Abfragen von Jobs, Unternehmen und Filtertaxonomien über JSON, damit Copiloten und interne Tools gegen dasselbe strukturierte Inventar wie das Produkt arbeiten können."
 
 #. Contact call to action
 #. js-lingui-explicit-id
@@ -3097,17 +3128,10 @@ msgstr "Echtzeit-Benachrichtigungen über neue Stellen"
 msgid "myJobs.sort.recentlyUpdated"
 msgstr "Kürzlich aktualisiert"
 
-#. Agentic feature card description: ghosting
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:108
-#: src/components/AgenticFeatures.tsx:83
-msgid "home.agentic.cards.ghosting.description"
-msgstr "Rekonstruiere den Posting-Verlauf aus archivierten Snapshots, um Stellen zu markieren, die scheinbar offen bleiben ohne echte Einstellungsabsicht, und erhalte einen Bericht, über den dein Agent Reasoning betreiben kann."
-
 #. Feature: interview log description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:90
-#: src/components/Features.tsx:212
+#: app/[lang]/(public)/page.tsx:88
+#: src/components/Features.tsx:247
 msgid "home.features.s2.p2.description"
 msgstr "Sammle alle interessanten Startups in einem Dashboard, statt mit Chrome-Fenstern und Lesezeichen zu jonglieren."
 
@@ -3135,16 +3159,16 @@ msgstr "Region"
 msgid "myJobs.group.rejected"
 msgstr "Abgelehnt"
 
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:444
-msgid "search.tracker.rejected"
-msgstr "Abgelehnt"
-
 #. Rejected status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:23
 msgid "myJobs.status.rejected"
+msgstr "Abgelehnt"
+
+#. Status option in dropdown: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:39
+msgid "myJobs.statusOption.rejected"
 msgstr "Abgelehnt"
 
 #. Sankey funnel node label prefix: rejected
@@ -3153,10 +3177,10 @@ msgstr "Abgelehnt"
 msgid "myJobs.funnel.rejected"
 msgstr "Abgelehnt"
 
-#. Status option in dropdown: rejected
+#. Application tracker status: rejected
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:39
-msgid "myJobs.statusOption.rejected"
+#: src/components/search/job-detail-dialog.tsx:464
+msgid "search.tracker.rejected"
 msgstr "Abgelehnt"
 
 #. Footer license summary text
@@ -3179,8 +3203,8 @@ msgstr "Standort entfernen"
 
 #. Feature: request companies title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:99
-#: src/components/Features.tsx:271
+#: app/[lang]/(public)/page.tsx:97
+#: src/components/Features.tsx:307
 msgid "home.features.s3.p2.title"
 msgstr "Beliebiges Unternehmen anfragen"
 
@@ -3253,12 +3277,6 @@ msgstr "Wird zurückgesetzt…"
 msgid "indexing.assurances.i1.title"
 msgstr "Respektvolles Tempo."
 
-#. Agentic features CTA description
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:122
-msgid "home.agentic.cta.description"
-msgstr "Überprüfe die agentische API-Referenz, das Auth-Modell und Beispielanfragen für Suche, Geisterstellen-Analyse und Unternehmensidentifizierung."
-
 #. Assurance 2 title
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/how-we-index/page.tsx:54
@@ -3274,7 +3292,7 @@ msgstr "Beruf"
 
 #. Section header for occupation suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:532
+#: src/components/search/search-bar.tsx:487
 msgid "search.bar.roles"
 msgstr "Berufe"
 
@@ -3284,16 +3302,16 @@ msgstr "Berufe"
 msgid "myJobs.funnel.round"
 msgstr "Runde"
 
-#. Salary override section heading
-#. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:76
-msgid "myJobs.detail.salary"
-msgstr "Gehalt"
-
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:171
 msgid "search.advanced.salary"
+msgstr "Gehalt"
+
+#. Salary override section heading
+#. js-lingui-explicit-id
+#: src/components/my-jobs/salary-override.tsx:76
+msgid "myJobs.detail.salary"
 msgstr "Gehalt"
 
 #. Salary display settings section heading
@@ -3310,21 +3328,21 @@ msgstr "Gehaltsspanne"
 
 #. Feature section 2 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:87
-#: src/components/Features.tsx:200
+#: app/[lang]/(public)/page.tsx:85
+#: src/components/Features.tsx:235
 msgid "home.features.s2.description"
 msgstr "Dein Lieblingsunternehmen fehlt im Feed? Füge den Karriereseiten-Link ein und wir beginnen, ihn für dich zu scrapen — keine Skripte, keine Tabellen, kein Warten in Support-Warteschlangen."
 
 #. Feature: watchlists and alerts description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:82
-#: src/components/Features.tsx:157
+#: app/[lang]/(public)/page.tsx:80
+#: src/components/Features.tsx:191
 msgid "home.features.s1.p3.description"
 msgstr "Speichere deine Filter für schnelle Überprüfungen, ohne alles neu eintippen zu müssen."
 
 #. Save job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:191
+#: src/components/watchlist/watchlist-job-list.tsx:202
 msgid "watchlists.jobList.save"
 msgstr "Job speichern"
 
@@ -3364,16 +3382,16 @@ msgstr "Gespeichert"
 msgid "myJobs.status.saved"
 msgstr "Gespeichert"
 
-#. Sankey funnel node: saved jobs
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:41
-msgid "myJobs.funnel.saved"
-msgstr "Gespeichert"
-
 #. Status option in dropdown: saved
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:35
 msgid "myJobs.statusOption.saved"
+msgstr "Gespeichert"
+
+#. Sankey funnel node: saved jobs
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:41
+msgid "myJobs.funnel.saved"
 msgstr "Gespeichert"
 
 #. Username save button while loading
@@ -3396,8 +3414,8 @@ msgstr "Bis zu 5 Unternehmen abonnieren"
 
 #. Feature section 1 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:78
-#: src/components/Features.tsx:140
+#: app/[lang]/(public)/page.tsx:76
+#: src/components/Features.tsx:174
 msgid "home.features.s1.description"
 msgstr "Verfolge Stellen, werde benachrichtigt, wenn Unternehmen etwas Neues veröffentlichen, und halte deine Pipeline sauber."
 
@@ -3416,9 +3434,15 @@ msgstr "Unternehmen suchen..."
 
 #. Placeholder for company search in modal
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:213
+#: src/components/watchlist/company-search-modal.tsx:216
 msgid "watchlists.companyModal.searchPlaceholder"
 msgstr "Unternehmen suchen..."
+
+#. Option to search by title keyword in dropdown
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:475
+msgid "search.bar.keyword"
+msgstr "Nach \"{trimmedInput}\" in Jobtiteln suchen"
 
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/explore/page.tsx:18
@@ -3431,21 +3455,21 @@ msgstr "Durchsuche Jobs bei Tausenden von Unternehmen, direkt von Karriereseiten
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Sprachen suchen…"
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:165
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Standorte suchen…"
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:150
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Standorte suchen..."
 
+#. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:23
-#: app/[lang]/(public)/page.tsx:48
+#: src/components/search/location-modal.tsx:165
+msgid "company.locationModal.searchPlaceholder"
+msgstr "Standorte suchen…"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:22
+#: app/[lang]/(public)/page.tsx:47
 msgid "home.meta.description"
 msgstr "Durchsuche Millionen von Jobs, direkt von Tausenden von Karriereseiten gecrawlt. Filtere nach Erfahrungsstufe, Tech-Stack, Gehalt und Standort und verfolge jede Bewerbung."
 
@@ -3461,29 +3485,22 @@ msgstr "Suchergebnisse"
 msgid "search.occupationModal.searchPlaceholder"
 msgstr "Berufe suchen..."
 
-#. Agentic feature card title: search
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:107
-#: src/components/AgenticFeatures.tsx:61
-msgid "home.agentic.cards.search.title"
-msgstr "Den Index direkt durchsuchen"
-
 #. Placeholder for public watchlist search input
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:84
+#: src/components/watchlist/public-watchlist-search.tsx:92
 msgid "watchlists.explore.searchPlaceholder"
 msgstr "Watchlists suchen..."
 
 #. Feature section 1 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:76
-#: src/components/Features.tsx:134
+#: app/[lang]/(public)/page.tsx:74
+#: src/components/Features.tsx:168
 msgid "home.features.s1.eyebrow"
 msgstr "Alles, was du brauchst, um vorne zu bleiben"
 
 #. Placeholder for the main search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:391
+#: src/components/search/search-bar.tsx:404
 msgid "search.bar.placeholder"
 msgstr "Suchen…"
 
@@ -3495,8 +3512,8 @@ msgstr "Suchen…"
 
 #. Feature: application stats description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:91
-#: src/components/Features.tsx:217
+#: app/[lang]/(public)/page.tsx:89
+#: src/components/Features.tsx:252
 msgid "home.features.s2.p3.description"
 msgstr "Lege die Frequenz pro Unternehmen fest, damit du von neuen Stellen erfährst, ohne den ganzen Tag durch Jobportale zu scrollen."
 
@@ -3549,17 +3566,17 @@ msgstr "Link senden"
 msgid "settings.account.password.send"
 msgstr "Link senden"
 
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Wird gesendet..."
-
 #. Resend button while sending
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:96
 msgid "auth.verify.resending"
 msgstr "Wird gesendet…"
+
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
+msgstr "Wird gesendet..."
 
 #. Reset password button while loading
 #. js-lingui-explicit-id
@@ -3629,8 +3646,8 @@ msgstr "Einstellungen"
 
 #. Feature: share watchlists title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:100
-#: src/components/Features.tsx:276
+#: app/[lang]/(public)/page.tsx:98
+#: src/components/Features.tsx:312
 msgid "home.features.s3.p3.title"
 msgstr "Mit jedem teilen"
 
@@ -3642,7 +3659,7 @@ msgstr "Weniger anzeigen"
 
 #. Button to collapse location list
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:347
+#: src/components/search/job-detail-dialog.tsx:367
 msgid "search.detail.showLessLocations"
 msgstr "Weniger anzeigen"
 
@@ -3744,7 +3761,7 @@ msgstr "Anmeldung läuft…"
 
 #. Pricing section description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:114
+#: app/[lang]/(public)/page.tsx:103
 #: src/components/Pricing.tsx:106
 msgid "home.pricing.description"
 msgstr "Einfache, transparente Preise. Starte kostenlos und upgrade, wenn du deine Jobsuche ernst meinst."
@@ -3828,14 +3845,14 @@ msgstr "Status"
 
 #. Status section heading
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:198
+#: src/components/my-jobs/my-job-detail-panel.tsx:200
 msgid "myJobs.detail.status"
 msgstr "Status"
 
 #. Feature: status tracking title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:89
-#: src/components/Features.tsx:206
+#: app/[lang]/(public)/page.tsx:87
+#: src/components/Features.tsx:241
 msgid "home.features.s2.p1.title"
 msgstr "Link einfügen, Crawl starten"
 
@@ -3864,12 +3881,6 @@ msgstr "Wird gesendet..."
 #: src/components/settings/SettingsNav.tsx:31
 msgid "settings.nav.billing"
 msgstr "Abonnement"
-
-#. Agentic feature card metadata: search
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:95
-msgid "home.agentic.cards.search.meta"
-msgstr "Abonnement erforderlich"
 
 #. FAQ page eyebrow
 #. js-lingui-explicit-id
@@ -3901,16 +3912,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technisch"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:389
-msgid "search.detail.technologies"
-msgstr "Technologien"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:602
+#: src/components/search/search-bar.tsx:557
 msgid "search.bar.technologies"
+msgstr "Technologien"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:409
+msgid "search.detail.technologies"
 msgstr "Technologien"
 
 #. Add technology filter
@@ -3939,7 +3950,7 @@ msgstr "Nutzungsbedingungen"
 
 #. Footer link to terms of service page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:62
+#: src/components/Footer.tsx:57
 msgid "common.footer.termsLink"
 msgstr "AGB"
 
@@ -4038,14 +4049,14 @@ msgstr "Diese Watchlist und alle zugehörigen Einstellungen werden dauerhaft gel
 
 #. Date divider label for today
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:79
+#: src/components/watchlist/watchlist-job-list.tsx:81
 msgid "watchlists.jobList.today"
 msgstr "Heute"
 
 #. Feature section 2 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:85
-#: src/components/Features.tsx:194
+#: app/[lang]/(public)/page.tsx:83
+#: src/components/Features.tsx:229
 msgid "home.features.s2.eyebrow"
 msgstr "Behalte die Kontrolle"
 
@@ -4102,7 +4113,7 @@ msgstr "Unbegrenzte Unternehmensabonnements"
 
 #. Pro tier description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:116
+#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:77
 msgid "home.pricing.pro.description"
 msgstr "Für aktive Jobsuchende, die unbegrenzte Reichweite und schnellere Einblicke brauchen."
@@ -4114,7 +4125,7 @@ msgstr "Unbegrenzte Watchlists, E-Mail-Benachrichtigungen bei neuen Treffern"
 
 #. Unsave job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:190
+#: src/components/watchlist/watchlist-job-list.tsx:201
 msgid "watchlists.jobList.unsave"
 msgstr "Job entfernen"
 
@@ -4173,7 +4184,7 @@ msgstr "Nutze das Anfrageformular auf der Entdecken-Seite — füge eine Karrier
 
 #. Fallback username for watchlist owner
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:109
+#: src/components/watchlist/public-watchlist-search.tsx:117
 msgid "watchlists.explore.unknownUser"
 msgstr "Nutzer"
 
@@ -4225,15 +4236,9 @@ msgstr "E-Mail wird bestätigt…"
 msgid "myJobs.interviewType.videoCall"
 msgstr "Videoanruf"
 
-#. Agentic features CTA button label
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:137
-msgid "home.agentic.cta.button"
-msgstr "API-Dokumentation ansehen"
-
 #. Link to the original job posting
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:186
+#: src/components/search/job-detail-dialog.tsx:198
 msgid "search.detail.viewPosting"
 msgstr "Stellenanzeige ansehen"
 
@@ -4269,8 +4274,8 @@ msgstr "Watchlists"
 
 #. Feature: watchlists and alerts title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:82
-#: src/components/Features.tsx:156
+#: app/[lang]/(public)/page.tsx:80
+#: src/components/Features.tsx:190
 msgid "home.features.s1.p3.title"
 msgstr "Gespeicherte Suchen"
 
@@ -4351,15 +4356,15 @@ msgstr "Wir respektieren robots.txt und TDM-Reservation-Header, beschränken Anf
 
 #. Hero description paragraph
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:74
+#: app/[lang]/(public)/page.tsx:72
 #: src/components/Hero.tsx:31
 msgid "home.hero.description"
 msgstr "Wir durchsuchen Karriereseiten direkt, damit du Stellen sofort siehst. Durchsuche Millionen von Stellenangeboten bei Tausenden von Unternehmen — filtere nach Erfahrungsstufe, Tech-Stack, Gehalt und Standort und verfolge jede Bewerbung an einem Ort."
 
 #. Feature: direct from source description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:80
-#: src/components/Features.tsx:147
+#: app/[lang]/(public)/page.tsx:78
+#: src/components/Features.tsx:181
 msgid "home.features.s1.p1.description"
 msgstr "Folge Wunscharbeitgebern und werde benachrichtigt, wenn neue Stellen erscheinen."
 
@@ -4466,7 +4471,7 @@ msgstr "Ja. Der Crawler und die Extraktions-Pipeline sind vollständig Open Sour
 
 #. Date divider label for yesterday
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:80
+#: src/components/watchlist/watchlist-job-list.tsx:82
 msgid "watchlists.jobList.yesterday"
 msgstr "Gestern"
 
@@ -4530,8 +4535,8 @@ msgstr "Du hast dein Watchlist-Limit erreicht. Upgrade deinen Plan, um weitere W
 
 #. Feature section 3 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:94
-#: src/components/Features.tsx:254
+#: app/[lang]/(public)/page.tsx:92
+#: src/components/Features.tsx:290
 msgid "home.features.s3.eyebrow"
 msgstr "Deine Unternehmen, deine Regeln"
 

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -14,6 +14,111 @@ msgstr ""
 "Plural-Forms: \n"
 "X-Generator: @lingui/cli\n"
 
+#. Count of additional watchlists not shown
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:130
+#~ msgid "watchlists.explore.moreCount"
+#~ msgstr "{0} more"
+
+#. Agentic features section heading
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:104
+#: src/components/AgenticFeatures.tsx:44
+#~ msgid "home.agentic.title"
+#~ msgstr "Agentic workflows on top of the job index"
+
+#. Agentic feature card title: ghosting
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:108
+#: src/components/AgenticFeatures.tsx:66
+#~ msgid "home.agentic.cards.ghosting.title"
+#~ msgstr "Detect likely ghost jobs"
+
+#. Agentic feature card title: discovery
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:109
+#: src/components/AgenticFeatures.tsx:71
+#~ msgid "home.agentic.cards.discovery.title"
+#~ msgstr "Discover who is hiring now"
+
+#. Agentic features section eyebrow
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:103
+#: src/components/AgenticFeatures.tsx:41
+#~ msgid "home.agentic.eyebrow"
+#~ msgstr "For AI agents"
+
+#. Agentic features section description
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:105
+#: src/components/AgenticFeatures.tsx:47
+#~ msgid "home.agentic.description"
+#~ msgstr "Job Seek is not only a search interface for people. It also exposes structured workflows for agents that need to search jobs, detect ghost listings, and map where hiring is accelerating."
+
+#. Agentic features CTA title
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:117
+#~ msgid "home.agentic.cta.title"
+#~ msgstr "Need the endpoint-level docs?"
+
+#. Agentic feature card metadata: ghosting
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:100
+#~ msgid "home.agentic.cards.ghosting.meta"
+#~ msgstr "Open tier"
+
+#. Agentic feature card metadata: discovery
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:105
+#~ msgid "home.agentic.cards.discovery.meta"
+#~ msgstr "Open tier"
+
+#. Agentic feature card description: discovery
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:109
+#: src/components/AgenticFeatures.tsx:88
+#~ msgid "home.agentic.cards.discovery.description"
+#~ msgstr "Pull trend signals across 39+ job boards to spot expanding companies, shrinking activity, and fresh hiring bursts before they become obvious elsewhere."
+
+#. Agentic feature card description: search
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:107
+#: src/components/AgenticFeatures.tsx:78
+#~ msgid "home.agentic.cards.search.description"
+#~ msgstr "Query jobs, companies, and filter taxonomies over JSON so copilots and internal tools can work against the same structured inventory as the product."
+
+#. Agentic feature card description: ghosting
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:108
+#: src/components/AgenticFeatures.tsx:83
+#~ msgid "home.agentic.cards.ghosting.description"
+#~ msgstr "Reconstruct posting history from archived snapshots to flag roles that appear to stay open without real hiring intent and return a report your agent can reason over."
+
+#. Agentic features CTA description
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:122
+#~ msgid "home.agentic.cta.description"
+#~ msgstr "Review the agentic API reference, auth model, and example requests for search, ghost-job analysis, and company discovery."
+
+#. Agentic feature card title: search
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:107
+#: src/components/AgenticFeatures.tsx:61
+#~ msgid "home.agentic.cards.search.title"
+#~ msgstr "Search the index directly"
+
+#. Agentic feature card metadata: search
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:95
+#~ msgid "home.agentic.cards.search.meta"
+#~ msgstr "Subscription required"
+
+#. Agentic features CTA button label
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:137
+#~ msgid "home.agentic.cta.button"
+#~ msgstr "View API docs"
+
 #. CC right 1
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:80
@@ -47,17 +152,10 @@ msgstr "(opens in new tab)"
 msgid "company.page.employees"
 msgstr "{0} employees"
 
-#. Count of additional watchlists not shown
-#. js-lingui-explicit-id
-#. placeholder {0}: total - results.length
-#: src/components/watchlist/public-watchlist-search.tsx:130
-msgid "watchlists.explore.moreCount"
-msgstr "{0} more"
-
 #. Button to show remaining collapsed locations
 #. js-lingui-explicit-id
 #. placeholder {0}: locations.length - LOCATIONS_COLLAPSED
-#: src/components/search/job-detail-dialog.tsx:351
+#: src/components/search/job-detail-dialog.tsx:371
 msgid "search.detail.showMoreLocations"
 msgstr "{0} more"
 
@@ -173,7 +271,7 @@ msgstr "active"
 
 #. Title for add companies modal
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:179
+#: src/components/watchlist/company-search-modal.tsx:182
 msgid "watchlists.companyModal.title"
 msgstr "Add companies"
 
@@ -183,16 +281,16 @@ msgstr "Add companies"
 msgid "watchlists.view.addDescription"
 msgstr "Add description"
 
-#. Button to add an interview round
-#. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:76
-msgid "myJobs.detail.addInterview"
-msgstr "Add interview"
-
 #. Quick action tooltip: add interview round
 #. js-lingui-explicit-id
 #: src/components/my-jobs/quick-actions.tsx:19
 msgid "myJobs.action.addInterview"
+msgstr "Add interview"
+
+#. Button to add an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx:76
+msgid "myJobs.detail.addInterview"
 msgstr "Add interview"
 
 #. Placeholder in the add keyword input
@@ -213,13 +311,6 @@ msgstr "Add location or keyword filter..."
 msgid "search.locations.addPlaceholder"
 msgstr "Add location..."
 
-#. Agentic features section heading
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:104
-#: src/components/AgenticFeatures.tsx:44
-msgid "home.agentic.title"
-msgstr "Agentic workflows on top of the job index"
-
 #. Encryption
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/privacy-policy/page.tsx:57
@@ -229,7 +320,7 @@ msgstr "All data is encrypted in transit and at rest."
 
 #. Option to show all industries
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:255
+#: src/components/watchlist/company-search-modal.tsx:258
 msgid "watchlists.companyModal.allIndustries"
 msgstr "All industries"
 
@@ -301,8 +392,8 @@ msgstr "Application code (MIT)"
 
 #. Feature: application stats title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:91
-#: src/components/Features.tsx:216
+#: app/[lang]/(public)/page.tsx:89
+#: src/components/Features.tsx:251
 msgid "home.features.s2.p3.title"
 msgstr "Application stats"
 
@@ -320,7 +411,7 @@ msgstr "Application Stats"
 
 #. Application tracker section heading in job detail
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:247
+#: src/components/search/job-detail-dialog.tsx:259
 msgid "search.detail.applicationTracker"
 msgstr "Application tracker"
 
@@ -342,16 +433,16 @@ msgstr "applications in the past year"
 msgid "myJobs.group.applied"
 msgstr "Applied"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:441
-msgid "search.tracker.applied"
-msgstr "Applied"
-
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
 msgid "myJobs.status.applied"
+msgstr "Applied"
+
+#. Status option in dropdown: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:36
+msgid "myJobs.statusOption.applied"
 msgstr "Applied"
 
 #. Sankey funnel node: applied
@@ -360,10 +451,10 @@ msgstr "Applied"
 msgid "myJobs.funnel.applied"
 msgstr "Applied"
 
-#. Status option in dropdown: applied
+#. Application tracker status: applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:36
-msgid "myJobs.statusOption.applied"
+#: src/components/search/job-detail-dialog.tsx:461
+msgid "search.tracker.applied"
 msgstr "Applied"
 
 #. Apply salary filter
@@ -380,7 +471,7 @@ msgstr "Apply"
 
 #. Apply button linking to original job posting
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:296
+#: src/components/my-jobs/my-job-detail-panel.tsx:304
 msgid "search.detail.apply"
 msgstr "Apply"
 
@@ -482,16 +573,16 @@ msgstr "By using Job Seek you agree to these terms. Here’s a plain-language ov
 msgid "faq.q.optOut"
 msgstr "Can I opt out of Jobseek indexing my company?"
 
-#. Cancel button in create watchlist dialog
-#. js-lingui-explicit-id
-#: src/components/watchlist/create-watchlist-dialog.tsx:164
-msgid "watchlists.create.cancel"
-msgstr "Cancel"
-
 #. Cancel delete watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-action-bar.tsx:233
 msgid "watchlists.delete.cancel"
+msgstr "Cancel"
+
+#. Cancel button in create watchlist dialog
+#. js-lingui-explicit-id
+#: src/components/watchlist/create-watchlist-dialog.tsx:164
+msgid "watchlists.create.cancel"
 msgstr "Cancel"
 
 #. Cancel delete button
@@ -530,16 +621,16 @@ msgstr "Change your password via a secure email link."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Change..."
 
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "Check your email"
-
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
+msgstr "Check your email"
+
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
 msgstr "Check your email"
 
 #. Checking username availability
@@ -568,7 +659,7 @@ msgstr "Choose the plan that works for you."
 
 #. Pricing section heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:113
+#: app/[lang]/(public)/page.tsx:102
 #: src/components/Pricing.tsx:103
 msgid "home.pricing.title"
 msgstr "Choose the right plan for you"
@@ -602,14 +693,14 @@ msgstr "Clear all"
 #. Button to clear all active search filters
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:536
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:542
 #: src/components/search/search-toolbar.tsx:283
 msgid "search.filters.clearAll"
 msgstr "Clear all"
 
 #. Clear all selected companies button
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:191
+#: src/components/watchlist/company-search-modal.tsx:194
 msgid "watchlists.companyModal.clearAll"
 msgstr "Clear all"
 
@@ -665,15 +756,15 @@ msgstr "Collection of job postings (CC BY-NC 4.0)"
 
 #. Feature: multi-dimensional filters description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:81
-#: src/components/Features.tsx:152
+#: app/[lang]/(public)/page.tsx:79
+#: src/components/Features.tsx:186
 msgid "home.features.s1.p2.description"
 msgstr "Combine seniority, technologies, salary, location, and job language in a single query. No more sifting through noise."
 
 #. Feature: focused search description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:98
-#: src/components/Features.tsx:267
+#: app/[lang]/(public)/page.tsx:96
+#: src/components/Features.tsx:303
 msgid "home.features.s3.p1.description"
 msgstr "Combine specific companies with role filters to zero in on exactly the positions you want."
 
@@ -691,7 +782,7 @@ msgstr "Companies"
 
 #. Section header for company suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:446
+#: src/components/search/search-bar.tsx:632
 msgid "search.bar.companies"
 msgstr "Companies"
 
@@ -750,28 +841,28 @@ msgstr "Connected accounts"
 msgid "license.contact.title"
 msgstr "Contact"
 
-#. TOC: Contact
-#. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:25
-msgid "license.toc.contact"
-msgstr "Contact"
-
 #. Footer link to contact email
 #. js-lingui-explicit-id
 #: src/components/Footer.tsx:41
 msgid "common.footer.contact"
 msgstr "Contact"
 
-#. Table of contents heading
+#. TOC: Contact
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
-msgstr "Contents"
+#: src/components/LicenseContent.tsx:25
+msgid "license.toc.contact"
+msgstr "Contact"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
+msgstr "Contents"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Contents"
 
 #. Button to continue to app after verification
@@ -894,8 +985,8 @@ msgstr "Creating account..."
 
 #. Feature section 3 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:95
-#: src/components/Features.tsx:257
+#: app/[lang]/(public)/page.tsx:93
+#: src/components/Features.tsx:293
 msgid "home.features.s3.title"
 msgstr "Curate a watchlist for any niche"
 
@@ -997,16 +1088,9 @@ msgstr "Details"
 
 #. Collapsible section heading for extracted job details
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:379
+#: src/components/search/job-detail-dialog.tsx:399
 msgid "search.detail.details"
 msgstr "Details"
-
-#. Agentic feature card title: ghosting
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:108
-#: src/components/AgenticFeatures.tsx:66
-msgid "home.agentic.cards.ghosting.title"
-msgstr "Detect likely ghost jobs"
 
 #. Subtext encouraging user to request a company when no results found
 #. js-lingui-explicit-id
@@ -1016,8 +1100,8 @@ msgstr "Did not find the company you were looking for?"
 
 #. Feature: direct from source title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:80
-#: src/components/Features.tsx:146
+#: app/[lang]/(public)/page.tsx:78
+#: src/components/Features.tsx:180
 msgid "home.features.s1.p1.title"
 msgstr "Direct from the source"
 
@@ -1035,16 +1119,9 @@ msgstr "Disconnect"
 
 #. Section title for discovering public watchlists
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:73
+#: src/components/watchlist/public-watchlist-search.tsx:81
 msgid "watchlists.explore.publicTitle"
 msgstr "Discover public watchlists"
-
-#. Agentic feature card title: discovery
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:109
-#: src/components/AgenticFeatures.tsx:71
-msgid "home.agentic.cards.discovery.title"
-msgstr "Discover who is hiring now"
 
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/faq/page.tsx:78
@@ -1151,8 +1228,8 @@ msgstr "Even after discovery we retrieve job detail pages at a strict limit of o
 
 #. Feature section 1 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:77
-#: src/components/Features.tsx:137
+#: app/[lang]/(public)/page.tsx:75
+#: src/components/Features.tsx:171
 msgid "home.features.s1.title"
 msgstr "Every filter a job seeker actually needs"
 
@@ -1298,21 +1375,21 @@ msgstr "Filter"
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:104
-#: src/components/search/job-detail-dialog.tsx:292
-#: src/components/search/job-detail-dialog.tsx:370
+#: src/components/search/job-detail-dialog.tsx:116
+#: src/components/search/job-detail-dialog.tsx:312
+#: src/components/search/job-detail-dialog.tsx:390
 msgid "search.detail.filterByPrefix"
 msgstr "Filter by"
 
 #. Tooltip for salary filter pill
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:226
+#: src/components/search/job-detail-dialog.tsx:238
 msgid "search.detail.filterBySalary"
 msgstr "Filter by this salary range"
 
 #. Placeholder for industry filter search
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:243
+#: src/components/watchlist/company-search-modal.tsx:246
 msgid "watchlists.companyModal.industrySearch"
 msgstr "Filter industries..."
 
@@ -1341,22 +1418,22 @@ msgid "settings.general.jobLanguages.findMore"
 msgstr "Find more"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:22
-#: app/[lang]/(public)/page.tsx:47
+#: app/[lang]/(public)/page.tsx:21
+#: app/[lang]/(public)/page.tsx:46
 msgid "home.meta.title"
 msgstr "Find Roles Before They Hit the Big Boards"
 
 #. Main heading on the landing page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:73
+#: app/[lang]/(public)/page.tsx:71
 #: src/components/Hero.tsx:28
 msgid "home.hero.title"
 msgstr "Find roles before they hit the big boards."
 
 #. Feature: focused search title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:98
-#: src/components/Features.tsx:266
+#: app/[lang]/(public)/page.tsx:96
+#: src/components/Features.tsx:302
 msgid "home.features.s3.p1.title"
 msgstr "Focused search"
 
@@ -1371,13 +1448,6 @@ msgstr "Follow us on LinkedIn"
 #: src/components/Footer.tsx:31
 msgid "common.footer.ariaLabel"
 msgstr "Footer"
-
-#. Agentic features section eyebrow
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:103
-#: src/components/AgenticFeatures.tsx:41
-msgid "home.agentic.eyebrow"
-msgstr "For AI agents"
 
 #. Free tier period
 #. js-lingui-explicit-id
@@ -1406,7 +1476,7 @@ msgstr "Founded {0}"
 
 #. Free tier name
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:115
+#: app/[lang]/(public)/page.tsx:104
 #: src/components/Pricing.tsx:32
 msgid "home.pricing.free.name"
 msgstr "Free"
@@ -1437,8 +1507,8 @@ msgstr "Fri"
 
 #. Feature section 2 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:86
-#: src/components/Features.tsx:197
+#: app/[lang]/(public)/page.tsx:84
+#: src/components/Features.tsx:232
 msgid "home.features.s2.title"
 msgstr "From saved role to signed offer, all in one place"
 
@@ -1455,7 +1525,7 @@ msgstr "Full search, 1 watchlist, application tracker"
 
 #. Free tier description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:115
+#: app/[lang]/(public)/page.tsx:104
 #: src/components/Pricing.tsx:41
 msgid "home.pricing.free.description"
 msgstr "Full search, one watchlist, and a built-in application tracker to manage your pipeline."
@@ -1647,7 +1717,7 @@ msgstr "Indexing policy"
 
 #. Industry filter label
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:231
+#: src/components/watchlist/company-search-modal.tsx:234
 msgid "watchlists.companyModal.industry"
 msgstr "Industry"
 
@@ -1692,8 +1762,8 @@ msgstr "Interview"
 
 #. Feature: interview log title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:90
-#: src/components/Features.tsx:211
+#: app/[lang]/(public)/page.tsx:88
+#: src/components/Features.tsx:246
 msgid "home.features.s2.p2.title"
 msgstr "Interview log"
 
@@ -1701,12 +1771,6 @@ msgstr "Interview log"
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:30
 msgid "myJobs.group.interviewing"
-msgstr "Interviewing"
-
-#. Application tracker status: interviewing
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:442
-msgid "search.tracker.interviewing"
 msgstr "Interviewing"
 
 #. Interviewing status badge label
@@ -1719,6 +1783,12 @@ msgstr "Interviewing"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:37
 msgid "myJobs.statusOption.interviewing"
+msgstr "Interviewing"
+
+#. Application tracker status: interviewing
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:462
+msgid "search.tracker.interviewing"
 msgstr "Interviewing"
 
 #. Interviews section heading
@@ -1763,7 +1833,7 @@ msgstr "job"
 
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:110
+#: src/components/watchlist/public-watchlist-search.tsx:118
 msgid "watchlists.explore.jobSingular"
 msgstr "job"
 
@@ -1778,16 +1848,16 @@ msgstr "Job aggregator that monitors company career pages. Subscribe to company 
 msgid "license.toc.data"
 msgstr "Job data (CC BY-NC 4.0)"
 
-#. Job detail panel title
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:74
-msgid "search.detail.title"
-msgstr "Job Details"
-
 #. Job detail panel title in My Jobs
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:161
+#: src/components/my-jobs/my-job-detail-panel.tsx:163
 msgid "myJobs.detail.title"
+msgstr "Job Details"
+
+#. Job detail panel title
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:86
+msgid "search.detail.title"
 msgstr "Job Details"
 
 #. Nav link: Job indexing
@@ -1829,7 +1899,7 @@ msgstr "Job search on your terms."
 
 #. Alt text for feature section 2 screenshot
 #. js-lingui-explicit-id
-#: src/components/Features.tsx:224
+#: src/components/Features.tsx:259
 msgid "home.features.s2.screenshot.alt"
 msgstr "Job Seek application tracker showing saved jobs and interview details"
 
@@ -1858,13 +1928,6 @@ msgstr "Job Seek is being actively built. Stay tuned for updates!"
 msgid "about.p1"
 msgstr "Job Seek is built by Colophon Group, a small team of developers based in Switzerland. We started it because we were tired of the same problem every job seeker faces: juggling dozens of browser tabs, missing new postings because an aggregator was slow to pick them up, and drowning in algorithmic noise that optimizes for clicks rather than relevance."
 
-#. Agentic features section description
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:105
-#: src/components/AgenticFeatures.tsx:47
-msgid "home.agentic.description"
-msgstr "Job Seek is not only a search interface for people. It also exposes structured workflows for agents that need to search jobs, detect ghost listings, and map where hiring is accelerating."
-
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/privacy-policy/page.tsx:19
 #: app/[lang]/(public)/privacy-policy/page.tsx:41
@@ -1873,13 +1936,13 @@ msgstr "Job Seek privacy policy — what personal data we collect, how we use it
 
 #. Alt text for feature section 1 screenshot
 #. js-lingui-explicit-id
-#: src/components/Features.tsx:164
+#: src/components/Features.tsx:198
 msgid "home.features.s1.screenshot.alt"
 msgstr "Job Seek search results filtered by role and location"
 
 #. Alt text for feature section 3 screenshot
 #. js-lingui-explicit-id
-#: src/components/Features.tsx:284
+#: src/components/Features.tsx:320
 msgid "home.features.s3.screenshot.alt"
 msgstr "Job Seek watchlist showing curated robotics engineering roles in Zurich"
 
@@ -1903,13 +1966,13 @@ msgstr "jobs"
 
 #. Job count label in watchlist view
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:215
+#: src/components/watchlist/watchlist-job-list.tsx:226
 msgid "watchlists.jobList.jobCount"
 msgstr "jobs"
 
 #. Plural job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:111
+#: src/components/watchlist/public-watchlist-search.tsx:119
 msgid "watchlists.explore.jobPlural"
 msgstr "jobs"
 
@@ -1995,16 +2058,16 @@ msgstr "Learn how Job Seek scrapes career pages from Workday, Greenhouse, Lever,
 msgid "home.hero.secondaryCta"
 msgstr "Learn more"
 
+#. Section header for seniority suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:522
+msgid "search.bar.level"
+msgstr "Level"
+
 #. Label for seniority/level filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:154
 msgid "search.advanced.level"
-msgstr "Level"
-
-#. Section header for seniority suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:567
-msgid "search.bar.level"
 msgstr "Level"
 
 #. js-lingui-explicit-id
@@ -2021,7 +2084,7 @@ msgstr "License"
 
 #. Footer link to license page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
+#: src/components/Footer.tsx:47
 msgid "common.footer.licenseLink"
 msgstr "License"
 
@@ -2074,16 +2137,16 @@ msgstr "Location"
 msgid "search.advanced.location"
 msgstr "Location"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:304
-msgid "search.detail.locations"
-msgstr "Locations"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:492
+#: src/components/search/search-bar.tsx:592
 msgid "search.bar.locations"
+msgstr "Locations"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:324
+msgid "search.detail.locations"
 msgstr "Locations"
 
 #. Login button label
@@ -2108,8 +2171,8 @@ msgstr "Log in to save this search as a watchlist"
 
 #. Feature: share watchlists description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:100
-#: src/components/Features.tsx:277
+#: app/[lang]/(public)/page.tsx:98
+#: src/components/Features.tsx:313
 msgid "home.features.s3.p3.description"
 msgstr "Make a watchlist public and share the link with friends, communities, or your network."
 
@@ -2181,7 +2244,7 @@ msgstr "Min"
 
 #. Singular mirror count
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:118
+#: src/components/watchlist/public-watchlist-search.tsx:126
 msgid "watchlists.explore.mirrorSingular"
 msgstr "mirror"
 
@@ -2201,14 +2264,14 @@ msgstr "Mirror any public watchlist to make it your own — tweak companies, adj
 
 #. Plural mirror count
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:119
+#: src/components/watchlist/public-watchlist-search.tsx:127
 msgid "watchlists.explore.mirrorPlural"
 msgstr "mirrors"
 
 #. Feature: request companies description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:99
-#: src/components/Features.tsx:272
+#: app/[lang]/(public)/page.tsx:97
+#: src/components/Features.tsx:308
 msgid "home.features.s3.p2.description"
 msgstr "Missing a company? Paste its careers page URL and we start indexing it for you."
 
@@ -2243,15 +2306,15 @@ msgstr "more"
 
 #. Feature: status tracking description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:89
-#: src/components/Features.tsx:207
+#: app/[lang]/(public)/page.tsx:87
+#: src/components/Features.tsx:242
 msgid "home.features.s2.p1.description"
 msgstr "Move each role from saved to applied, interviewing, offered, or rejected. Always know where you stand."
 
 #. Feature: multi-dimensional filters title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:81
-#: src/components/Features.tsx:151
+#: app/[lang]/(public)/page.tsx:79
+#: src/components/Features.tsx:185
 msgid "home.features.s1.p2.title"
 msgstr "Multi-dimensional filters"
 
@@ -2308,12 +2371,6 @@ msgstr "Name"
 msgid "watchlists.create.nameLabel"
 msgstr "Name"
 
-#. Agentic features CTA title
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:117
-msgid "home.agentic.cta.title"
-msgstr "Need the endpoint-level docs?"
-
 #. TOC: Need to reach us?
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:33
@@ -2364,13 +2421,13 @@ msgstr "No filters set. Add filters to narrow job results."
 
 #. No industries match search
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:273
+#: src/components/watchlist/company-search-modal.tsx:276
 msgid "watchlists.companyModal.noIndustries"
 msgstr "No industries found."
 
 #. Empty state when no jobs match the time range
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:226
+#: src/components/watchlist/watchlist-job-list.tsx:237
 msgid "watchlists.jobList.empty"
 msgstr "No jobs found."
 
@@ -2380,16 +2437,16 @@ msgstr "No jobs found."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "No languages match your search."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:186
-msgid "company.locationModal.noResults"
-msgstr "No locations match your search."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:171
 msgid "search.locationModal.noResults"
+msgstr "No locations match your search."
+
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:186
+msgid "company.locationModal.noResults"
 msgstr "No locations match your search."
 
 #. No postings found message on company page
@@ -2442,7 +2499,7 @@ msgstr "No warranty — use at your own risk."
 
 #. No results message when searching public watchlists
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:140
+#: src/components/watchlist/public-watchlist-search.tsx:142
 msgid "watchlists.explore.noResults"
 msgstr "No watchlists found."
 
@@ -2462,16 +2519,16 @@ msgstr "No. The application tracker has no hard limit — save as many jobs as y
 msgid "faq.a.dataPrivacy"
 msgstr "No. We don't sell, rent, or share your data for marketing. Cookies are session-only with no ads or tracking. You can delete your account and all data is wiped within 30 days."
 
-#. Application tracker status: not applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:440
-msgid "search.tracker.notApplied"
-msgstr "Not applied"
-
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
+msgstr "Not applied"
+
+#. Application tracker status: not applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:460
+msgid "search.tracker.notApplied"
 msgstr "Not applied"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2502,16 +2559,16 @@ msgstr "Occupation"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Oct"
 
-#. Application tracker status: offer
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:443
-msgid "search.tracker.offer"
-msgstr "Offer"
-
 #. Offered status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
+msgstr "Offer"
+
+#. Application tracker status: offer
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:463
+msgid "search.tracker.offer"
 msgstr "Offer"
 
 #. Status group heading: offered
@@ -2520,16 +2577,16 @@ msgstr "Offer"
 msgid "myJobs.group.offered"
 msgstr "Offered"
 
-#. Sankey funnel node: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:43
-msgid "myJobs.funnel.offered"
-msgstr "Offered"
-
 #. Status option in dropdown: offered
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:38
 msgid "myJobs.statusOption.offered"
+msgstr "Offered"
+
+#. Sankey funnel node: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:43
+msgid "myJobs.funnel.offered"
 msgstr "Offered"
 
 #. Cookie banner accept button
@@ -2566,7 +2623,7 @@ msgstr "Onsite"
 
 #. Aria label for mobile menu button
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:86
+#: src/components/Header.tsx:83
 msgid "common.header.openMenu"
 msgstr "Open main menu"
 
@@ -2574,18 +2631,6 @@ msgstr "Open main menu"
 #: app/[lang]/(app)/company/[slug]/page.tsx:36
 msgid "company.meta.openPositions"
 msgstr "Open positions"
-
-#. Agentic feature card metadata: ghosting
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:100
-msgid "home.agentic.cards.ghosting.meta"
-msgstr "Open tier"
-
-#. Agentic feature card metadata: discovery
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:105
-msgid "home.agentic.cards.discovery.meta"
-msgstr "Open tier"
 
 #. Open-source section title
 #. js-lingui-explicit-id
@@ -2653,26 +2698,26 @@ msgstr "Our stance on automation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Overview"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Overview"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Page contents"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Overview"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Page contents"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Page contents"
 
 #. Heading shown on the 404 page
@@ -2745,7 +2790,7 @@ msgstr "Pay period"
 
 #. Pro tier period
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:116
+#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:73
 msgid "home.pricing.pro.period"
 msgstr "per month"
@@ -2776,8 +2821,8 @@ msgstr "Phone Screen"
 
 #. Feature section 3 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:96
-#: src/components/Features.tsx:260
+#: app/[lang]/(public)/page.tsx:94
+#: src/components/Features.tsx:296
 msgid "home.features.s3.description"
 msgstr "Pick the companies you care about, set your filters, and get a live feed of matching roles. Share it publicly or keep it private."
 
@@ -2851,19 +2896,19 @@ msgstr "Please log in to manage your billing settings."
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:89
-msgid "search.detail.notFound"
+#: src/components/my-jobs/my-job-detail-panel.tsx:183
+msgid "myJobs.detail.notFound"
 msgstr "Posting not found."
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:181
-msgid "myJobs.detail.notFound"
+#: src/components/search/job-detail-dialog.tsx:101
+msgid "search.detail.notFound"
 msgstr "Posting not found."
 
 #. Pricing section eyebrow
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:112
+#: app/[lang]/(public)/page.tsx:101
 #: src/components/Pricing.tsx:100
 msgid "home.pricing.eyebrow"
 msgstr "Pricing"
@@ -2884,7 +2929,7 @@ msgstr "Privacy"
 
 #. Footer link to privacy policy page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:57
+#: src/components/Footer.tsx:52
 msgid "common.footer.privacyLink"
 msgstr "Privacy"
 
@@ -2909,7 +2954,7 @@ msgstr "Private watchlists are a paid feature. Upgrade to hide your watchlists f
 
 #. Pro tier name
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:116
+#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:68
 msgid "home.pricing.pro.name"
 msgstr "Pro"
@@ -2931,20 +2976,6 @@ msgstr "Public (discoverable by others)"
 #: src/components/PublicDomainArt.tsx:62
 msgid "common.art.publicDomain"
 msgstr "Public Domain"
-
-#. Agentic feature card description: discovery
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:109
-#: src/components/AgenticFeatures.tsx:88
-msgid "home.agentic.cards.discovery.description"
-msgstr "Pull trend signals across 39+ job boards to spot expanding companies, shrinking activity, and fresh hiring bursts before they become obvious elsewhere."
-
-#. Agentic feature card description: search
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:107
-#: src/components/AgenticFeatures.tsx:78
-msgid "home.agentic.cards.search.description"
-msgstr "Query jobs, companies, and filter taxonomies over JSON so copilots and internal tools can work against the same structured inventory as the product."
 
 #. Contact call to action
 #. js-lingui-explicit-id
@@ -3002,17 +3033,10 @@ msgstr "Real-time job posting alerts"
 msgid "myJobs.sort.recentlyUpdated"
 msgstr "Recently updated"
 
-#. Agentic feature card description: ghosting
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:108
-#: src/components/AgenticFeatures.tsx:83
-msgid "home.agentic.cards.ghosting.description"
-msgstr "Reconstruct posting history from archived snapshots to flag roles that appear to stay open without real hiring intent and return a report your agent can reason over."
-
 #. Feature: interview log description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:90
-#: src/components/Features.tsx:212
+#: app/[lang]/(public)/page.tsx:88
+#: src/components/Features.tsx:247
 msgid "home.features.s2.p2.description"
 msgstr "Record each interview round with date, type, and notes so nothing slips through the cracks."
 
@@ -3040,16 +3064,16 @@ msgstr "Region"
 msgid "myJobs.group.rejected"
 msgstr "Rejected"
 
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:444
-msgid "search.tracker.rejected"
-msgstr "Rejected"
-
 #. Rejected status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:23
 msgid "myJobs.status.rejected"
+msgstr "Rejected"
+
+#. Status option in dropdown: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:39
+msgid "myJobs.statusOption.rejected"
 msgstr "Rejected"
 
 #. Sankey funnel node label prefix: rejected
@@ -3058,10 +3082,10 @@ msgstr "Rejected"
 msgid "myJobs.funnel.rejected"
 msgstr "Rejected"
 
-#. Status option in dropdown: rejected
+#. Application tracker status: rejected
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:39
-msgid "myJobs.statusOption.rejected"
+#: src/components/search/job-detail-dialog.tsx:464
+msgid "search.tracker.rejected"
 msgstr "Rejected"
 
 #. Footer license summary text
@@ -3084,8 +3108,8 @@ msgstr "Remove location"
 
 #. Feature: request companies title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:99
-#: src/components/Features.tsx:271
+#: app/[lang]/(public)/page.tsx:97
+#: src/components/Features.tsx:307
 msgid "home.features.s3.p2.title"
 msgstr "Request any company"
 
@@ -3158,12 +3182,6 @@ msgstr "Resetting..."
 msgid "indexing.assurances.i1.title"
 msgstr "Respectful pacing."
 
-#. Agentic features CTA description
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:122
-msgid "home.agentic.cta.description"
-msgstr "Review the agentic API reference, auth model, and example requests for search, ghost-job analysis, and company discovery."
-
 #. Assurance 2 title
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/how-we-index/page.tsx:54
@@ -3179,7 +3197,7 @@ msgstr "Role"
 
 #. Section header for occupation suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:532
+#: src/components/search/search-bar.tsx:487
 msgid "search.bar.roles"
 msgstr "Roles"
 
@@ -3189,16 +3207,16 @@ msgstr "Roles"
 msgid "myJobs.funnel.round"
 msgstr "Round"
 
-#. Salary override section heading
-#. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:76
-msgid "myJobs.detail.salary"
-msgstr "Salary"
-
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:171
 msgid "search.advanced.salary"
+msgstr "Salary"
+
+#. Salary override section heading
+#. js-lingui-explicit-id
+#: src/components/my-jobs/salary-override.tsx:76
+msgid "myJobs.detail.salary"
 msgstr "Salary"
 
 #. Salary display settings section heading
@@ -3215,21 +3233,21 @@ msgstr "Salary range"
 
 #. Feature section 2 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:87
-#: src/components/Features.tsx:200
+#: app/[lang]/(public)/page.tsx:85
+#: src/components/Features.tsx:235
 msgid "home.features.s2.description"
 msgstr "Save any role you find, move it through your pipeline as you apply and interview, and see where every application stands at a glance."
 
 #. Feature: watchlists and alerts description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:82
-#: src/components/Features.tsx:157
+#: app/[lang]/(public)/page.tsx:80
+#: src/components/Features.tsx:191
 msgid "home.features.s1.p3.description"
 msgstr "Save any search as a watchlist and get email alerts when new roles match your criteria."
 
 #. Save job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:191
+#: src/components/watchlist/watchlist-job-list.tsx:202
 msgid "watchlists.jobList.save"
 msgstr "Save job"
 
@@ -3269,16 +3287,16 @@ msgstr "Saved"
 msgid "myJobs.status.saved"
 msgstr "Saved"
 
-#. Sankey funnel node: saved jobs
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:41
-msgid "myJobs.funnel.saved"
-msgstr "Saved"
-
 #. Status option in dropdown: saved
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:35
 msgid "myJobs.statusOption.saved"
+msgstr "Saved"
+
+#. Sankey funnel node: saved jobs
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:41
+msgid "myJobs.funnel.saved"
 msgstr "Saved"
 
 #. Username save button while loading
@@ -3301,8 +3319,8 @@ msgstr "Search across all companies and filters"
 
 #. Feature section 1 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:78
-#: src/components/Features.tsx:140
+#: app/[lang]/(public)/page.tsx:76
+#: src/components/Features.tsx:174
 msgid "home.features.s1.description"
 msgstr "Search across thousands of companies scraped directly from their career pages. Filter by seniority, tech stack, salary range, location, and language — all at once."
 
@@ -3321,9 +3339,15 @@ msgstr "Search companies..."
 
 #. Placeholder for company search in modal
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:213
+#: src/components/watchlist/company-search-modal.tsx:216
 msgid "watchlists.companyModal.searchPlaceholder"
 msgstr "Search companies..."
+
+#. Option to search by title keyword in dropdown
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:475
+msgid "search.bar.keyword"
+msgstr "Search for \"{trimmedInput}\" in job titles"
 
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/explore/page.tsx:18
@@ -3336,21 +3360,21 @@ msgstr "Search jobs across thousands of companies scraped directly from career p
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Search languages..."
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:165
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Search locations..."
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:150
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Search locations..."
 
+#. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:23
-#: app/[lang]/(public)/page.tsx:48
+#: src/components/search/location-modal.tsx:165
+msgid "company.locationModal.searchPlaceholder"
+msgstr "Search locations..."
+
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:22
+#: app/[lang]/(public)/page.tsx:47
 msgid "home.meta.description"
 msgstr "Search millions of jobs scraped directly from thousands of company career pages. Filter by seniority, tech stack, salary, and location, then track every application."
 
@@ -3366,36 +3390,29 @@ msgstr "Search results"
 msgid "search.occupationModal.searchPlaceholder"
 msgstr "Search roles..."
 
-#. Agentic feature card title: search
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:107
-#: src/components/AgenticFeatures.tsx:61
-msgid "home.agentic.cards.search.title"
-msgstr "Search the index directly"
-
 #. Placeholder for public watchlist search input
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:84
+#: src/components/watchlist/public-watchlist-search.tsx:92
 msgid "watchlists.explore.searchPlaceholder"
 msgstr "Search watchlists..."
 
 #. Feature section 1 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:76
-#: src/components/Features.tsx:134
+#: app/[lang]/(public)/page.tsx:74
+#: src/components/Features.tsx:168
 msgid "home.features.s1.eyebrow"
 msgstr "Search with precision"
 
 #. Placeholder for the main search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:391
+#: src/components/search/search-bar.tsx:404
 msgid "search.bar.placeholder"
 msgstr "Search..."
 
 #. Feature: application stats description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:91
-#: src/components/Features.tsx:217
+#: app/[lang]/(public)/page.tsx:89
+#: src/components/Features.tsx:252
 msgid "home.features.s2.p3.description"
 msgstr "See your funnel, conversion rates, and activity heatmap to understand what is working."
 
@@ -3448,16 +3465,16 @@ msgstr "Send reset link"
 msgid "settings.account.password.send"
 msgstr "Send reset link"
 
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Sending..."
-
 #. Resend button while sending
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:96
 msgid "auth.verify.resending"
+msgstr "Sending..."
+
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
 msgstr "Sending..."
 
 #. Reset password button while loading
@@ -3510,8 +3527,8 @@ msgstr "Settings"
 
 #. Feature: share watchlists title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:100
-#: src/components/Features.tsx:276
+#: app/[lang]/(public)/page.tsx:98
+#: src/components/Features.tsx:312
 msgid "home.features.s3.p3.title"
 msgstr "Share with anyone"
 
@@ -3523,7 +3540,7 @@ msgstr "Show less"
 
 #. Button to collapse location list
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:347
+#: src/components/search/job-detail-dialog.tsx:367
 msgid "search.detail.showLessLocations"
 msgstr "Show less"
 
@@ -3625,7 +3642,7 @@ msgstr "Signing in..."
 
 #. Pricing section description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:114
+#: app/[lang]/(public)/page.tsx:103
 #: src/components/Pricing.tsx:106
 msgid "home.pricing.description"
 msgstr "Simple, transparent pricing. Start for free and upgrade when you get serious about your job search."
@@ -3709,14 +3726,14 @@ msgstr "Status"
 
 #. Status section heading
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:198
+#: src/components/my-jobs/my-job-detail-panel.tsx:200
 msgid "myJobs.detail.status"
 msgstr "Status"
 
 #. Feature: status tracking title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:89
-#: src/components/Features.tsx:206
+#: app/[lang]/(public)/page.tsx:87
+#: src/components/Features.tsx:241
 msgid "home.features.s2.p1.title"
 msgstr "Status tracking"
 
@@ -3745,12 +3762,6 @@ msgstr "Submitting..."
 #: src/components/settings/SettingsNav.tsx:31
 msgid "settings.nav.billing"
 msgstr "Subscription"
-
-#. Agentic feature card metadata: search
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:95
-msgid "home.agentic.cards.search.meta"
-msgstr "Subscription required"
 
 #. FAQ page eyebrow
 #. js-lingui-explicit-id
@@ -3782,16 +3793,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technical"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:389
-msgid "search.detail.technologies"
-msgstr "Technologies"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:602
+#: src/components/search/search-bar.tsx:557
 msgid "search.bar.technologies"
+msgstr "Technologies"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:409
+msgid "search.detail.technologies"
 msgstr "Technologies"
 
 #. Add technology filter
@@ -3820,7 +3831,7 @@ msgstr "Terms"
 
 #. Footer link to terms of service page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:62
+#: src/components/Footer.tsx:57
 msgid "common.footer.termsLink"
 msgstr "Terms"
 
@@ -3919,14 +3930,14 @@ msgstr "This will permanently delete this watchlist and all its settings. This a
 
 #. Date divider label for today
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:79
+#: src/components/watchlist/watchlist-job-list.tsx:81
 msgid "watchlists.jobList.today"
 msgstr "Today"
 
 #. Feature section 2 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:85
-#: src/components/Features.tsx:194
+#: app/[lang]/(public)/page.tsx:83
+#: src/components/Features.tsx:229
 msgid "home.features.s2.eyebrow"
 msgstr "Track your pipeline"
 
@@ -3983,7 +3994,7 @@ msgstr "Unlimited watchlists"
 
 #. Pro tier description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:116
+#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:77
 msgid "home.pricing.pro.description"
 msgstr "Unlimited watchlists with email alerts so you never miss an opening."
@@ -3995,7 +4006,7 @@ msgstr "Unlimited watchlists, email alerts on new matches"
 
 #. Unsave job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:190
+#: src/components/watchlist/watchlist-job-list.tsx:201
 msgid "watchlists.jobList.unsave"
 msgstr "Unsave job"
 
@@ -4054,7 +4065,7 @@ msgstr "Use the request form on the explore page — paste a careers page URL or
 
 #. Fallback username for watchlist owner
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:109
+#: src/components/watchlist/public-watchlist-search.tsx:117
 msgid "watchlists.explore.unknownUser"
 msgstr "user"
 
@@ -4106,15 +4117,9 @@ msgstr "Verifying your email..."
 msgid "myJobs.interviewType.videoCall"
 msgstr "Video Call"
 
-#. Agentic features CTA button label
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:137
-msgid "home.agentic.cta.button"
-msgstr "View API docs"
-
 #. Link to the original job posting
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:186
+#: src/components/search/job-detail-dialog.tsx:198
 msgid "search.detail.viewPosting"
 msgstr "View posting"
 
@@ -4150,8 +4155,8 @@ msgstr "Watchlists"
 
 #. Feature: watchlists and alerts title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:82
-#: src/components/Features.tsx:156
+#: app/[lang]/(public)/page.tsx:80
+#: src/components/Features.tsx:190
 msgid "home.features.s1.p3.title"
 msgstr "Watchlists and alerts"
 
@@ -4232,15 +4237,15 @@ msgstr "We respect robots.txt and TDM-Reservation headers, limit requests to one
 
 #. Hero description paragraph
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:74
+#: app/[lang]/(public)/page.tsx:72
 #: src/components/Hero.tsx:31
 msgid "home.hero.description"
 msgstr "We scrape career pages directly so you see openings the moment they go live. Search millions of job postings across thousands of companies — filter by seniority, tech stack, salary, and location, then track every application in one place."
 
 #. Feature: direct from source description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:80
-#: src/components/Features.tsx:147
+#: app/[lang]/(public)/page.tsx:78
+#: src/components/Features.tsx:181
 msgid "home.features.s1.p1.description"
 msgstr "We scrape career pages from Workday, Greenhouse, Lever, and more — roles show up here before they hit the big aggregators."
 
@@ -4347,7 +4352,7 @@ msgstr "Yes. The crawler and extraction pipeline are fully open source on GitHub
 
 #. Date divider label for yesterday
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:80
+#: src/components/watchlist/watchlist-job-list.tsx:82
 msgid "watchlists.jobList.yesterday"
 msgstr "Yesterday"
 
@@ -4411,8 +4416,8 @@ msgstr "You've reached your watchlist limit. Upgrade your plan to mirror more wa
 
 #. Feature section 3 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:94
-#: src/components/Features.tsx:254
+#: app/[lang]/(public)/page.tsx:92
+#: src/components/Features.tsx:290
 msgid "home.features.s3.eyebrow"
 msgstr "Your companies, your rules"
 

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -94,6 +94,111 @@ msgstr ""
 #~ msgid "breadcrumb.home"
 #~ msgstr "Accueil"
 
+#. Count of additional watchlists not shown
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:130
+#~ msgid "watchlists.explore.moreCount"
+#~ msgstr "{0} de plus"
+
+#. Agentic features section heading
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:104
+#: src/components/AgenticFeatures.tsx:44
+#~ msgid "home.agentic.title"
+#~ msgstr "Workflows agentiques sur l'index d'emplois"
+
+#. Agentic feature card title: ghosting
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:108
+#: src/components/AgenticFeatures.tsx:66
+#~ msgid "home.agentic.cards.ghosting.title"
+#~ msgstr "Détecter les offres fantômes probables"
+
+#. Agentic feature card title: discovery
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:109
+#: src/components/AgenticFeatures.tsx:71
+#~ msgid "home.agentic.cards.discovery.title"
+#~ msgstr "Découvrir qui recrute maintenant"
+
+#. Agentic features section eyebrow
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:103
+#: src/components/AgenticFeatures.tsx:41
+#~ msgid "home.agentic.eyebrow"
+#~ msgstr "Pour les agents IA"
+
+#. Agentic features section description
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:105
+#: src/components/AgenticFeatures.tsx:47
+#~ msgid "home.agentic.description"
+#~ msgstr "Job Seek n'est pas seulement une interface de recherche pour les personnes. Il expose également des workflows structurés pour les agents qui doivent chercher des emplois, détecter les offres fantômes et cartographier où le recrutement s'accélère."
+
+#. Agentic features CTA title
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:117
+#~ msgid "home.agentic.cta.title"
+#~ msgstr "Besoin de la documentation au niveau des endpoints ?"
+
+#. Agentic feature card metadata: ghosting
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:100
+#~ msgid "home.agentic.cards.ghosting.meta"
+#~ msgstr "Niveau ouvert"
+
+#. Agentic feature card metadata: discovery
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:105
+#~ msgid "home.agentic.cards.discovery.meta"
+#~ msgstr "Niveau ouvert"
+
+#. Agentic feature card description: discovery
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:109
+#: src/components/AgenticFeatures.tsx:88
+#~ msgid "home.agentic.cards.discovery.description"
+#~ msgstr "Extrayez des signaux de tendance sur 39+ job boards pour repérer les entreprises en expansion, les activités en déclin et les nouvelles vagues de recrutement avant qu'elles ne deviennent évidentes ailleurs."
+
+#. Agentic feature card description: search
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:107
+#: src/components/AgenticFeatures.tsx:78
+#~ msgid "home.agentic.cards.search.description"
+#~ msgstr "Requêtez des emplois, des entreprises et des taxonomies de filtres via JSON afin que les copilotes et les outils internes puissent travailler avec le même inventaire structuré que le produit."
+
+#. Agentic feature card description: ghosting
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:108
+#: src/components/AgenticFeatures.tsx:83
+#~ msgid "home.agentic.cards.ghosting.description"
+#~ msgstr "Reconstruisez l'historique des publications à partir de captures archivées pour signaler les postes qui semblent rester ouverts sans intention réelle de recrutement et retournez un rapport sur lequel votre agent peut raisonner."
+
+#. Agentic features CTA description
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:122
+#~ msgid "home.agentic.cta.description"
+#~ msgstr "Consultez la référence API agentique, le modèle d'authentification et les exemples de requêtes pour la recherche, l'analyse des offres fantômes et la découverte d'entreprises."
+
+#. Agentic feature card title: search
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:107
+#: src/components/AgenticFeatures.tsx:61
+#~ msgid "home.agentic.cards.search.title"
+#~ msgstr "Interroger l'index directement"
+
+#. Agentic feature card metadata: search
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:95
+#~ msgid "home.agentic.cards.search.meta"
+#~ msgstr "Abonnement requis"
+
+#. Agentic features CTA button label
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:137
+#~ msgid "home.agentic.cta.button"
+#~ msgstr "Voir la documentation API"
+
 #. CC right 1
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:80
@@ -127,17 +232,10 @@ msgstr "(ouvre dans un nouvel onglet)"
 msgid "company.page.employees"
 msgstr "{0} employés"
 
-#. Count of additional watchlists not shown
-#. js-lingui-explicit-id
-#. placeholder {0}: total - results.length
-#: src/components/watchlist/public-watchlist-search.tsx:130
-msgid "watchlists.explore.moreCount"
-msgstr "{0} de plus"
-
 #. Button to show remaining collapsed locations
 #. js-lingui-explicit-id
 #. placeholder {0}: locations.length - LOCATIONS_COLLAPSED
-#: src/components/search/job-detail-dialog.tsx:351
+#: src/components/search/job-detail-dialog.tsx:371
 msgid "search.detail.showMoreLocations"
 msgstr "{0} de plus"
 
@@ -253,7 +351,7 @@ msgstr "actif"
 
 #. Title for add companies modal
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:179
+#: src/components/watchlist/company-search-modal.tsx:182
 msgid "watchlists.companyModal.title"
 msgstr "Ajouter des entreprises"
 
@@ -263,16 +361,16 @@ msgstr "Ajouter des entreprises"
 msgid "watchlists.view.addDescription"
 msgstr "Ajouter une description"
 
-#. Button to add an interview round
-#. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:76
-msgid "myJobs.detail.addInterview"
-msgstr "Ajouter un entretien"
-
 #. Quick action tooltip: add interview round
 #. js-lingui-explicit-id
 #: src/components/my-jobs/quick-actions.tsx:19
 msgid "myJobs.action.addInterview"
+msgstr "Ajouter un entretien"
+
+#. Button to add an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx:76
+msgid "myJobs.detail.addInterview"
 msgstr "Ajouter un entretien"
 
 #. Placeholder in the add keyword input
@@ -293,13 +391,6 @@ msgstr "Ajouter un filtre de lieu ou mot-clé…"
 msgid "search.locations.addPlaceholder"
 msgstr "Ajouter un lieu..."
 
-#. Agentic features section heading
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:104
-#: src/components/AgenticFeatures.tsx:44
-msgid "home.agentic.title"
-msgstr "Workflows agentiques sur l'index d'emplois"
-
 #. Encryption
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/privacy-policy/page.tsx:57
@@ -309,7 +400,7 @@ msgstr "Toutes les données sont chiffrées en transit et au repos."
 
 #. Option to show all industries
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:255
+#: src/components/watchlist/company-search-modal.tsx:258
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Tous les secteurs"
 
@@ -384,8 +475,8 @@ msgstr "Code applicatif (MIT)"
 
 #. Feature: application stats title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:91
-#: src/components/Features.tsx:216
+#: app/[lang]/(public)/page.tsx:89
+#: src/components/Features.tsx:251
 msgid "home.features.s2.p3.title"
 msgstr "Des alertes que tu contrôles vraiment"
 
@@ -403,7 +494,7 @@ msgstr "Statistiques des candidatures"
 
 #. Application tracker section heading in job detail
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:247
+#: src/components/search/job-detail-dialog.tsx:259
 msgid "search.detail.applicationTracker"
 msgstr "Suivi de candidature"
 
@@ -425,16 +516,16 @@ msgstr "candidatures durant l'année écoulée"
 msgid "myJobs.group.applied"
 msgstr "Postulé"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:441
-msgid "search.tracker.applied"
-msgstr "Postulé"
-
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
 msgid "myJobs.status.applied"
+msgstr "Postulé"
+
+#. Status option in dropdown: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:36
+msgid "myJobs.statusOption.applied"
 msgstr "Postulé"
 
 #. Sankey funnel node: applied
@@ -443,10 +534,10 @@ msgstr "Postulé"
 msgid "myJobs.funnel.applied"
 msgstr "Postulé"
 
-#. Status option in dropdown: applied
+#. Application tracker status: applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:36
-msgid "myJobs.statusOption.applied"
+#: src/components/search/job-detail-dialog.tsx:461
+msgid "search.tracker.applied"
 msgstr "Postulé"
 
 #. Apply salary filter
@@ -463,7 +554,7 @@ msgstr "Appliquer"
 
 #. Apply button linking to original job posting
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:296
+#: src/components/my-jobs/my-job-detail-panel.tsx:304
 msgid "search.detail.apply"
 msgstr "Postuler"
 
@@ -565,16 +656,16 @@ msgstr "En utilisant Job Seek, tu acceptes ces conditions. Voici un résumé en 
 msgid "faq.q.optOut"
 msgstr "Puis-je refuser l'indexation de mon entreprise par Jobseek ?"
 
-#. Cancel button in create watchlist dialog
-#. js-lingui-explicit-id
-#: src/components/watchlist/create-watchlist-dialog.tsx:164
-msgid "watchlists.create.cancel"
-msgstr "Annuler"
-
 #. Cancel delete watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-action-bar.tsx:233
 msgid "watchlists.delete.cancel"
+msgstr "Annuler"
+
+#. Cancel button in create watchlist dialog
+#. js-lingui-explicit-id
+#: src/components/watchlist/create-watchlist-dialog.tsx:164
+msgid "watchlists.create.cancel"
 msgstr "Annuler"
 
 #. Cancel delete button
@@ -613,17 +704,17 @@ msgstr "Modifie ton mot de passe via un lien e-mail sécurisé."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Changer…"
 
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "Vérifiez votre e-mail"
-
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
 msgstr "Vérifie ton e-mail"
+
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
+msgstr "Vérifiez votre e-mail"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -651,7 +742,7 @@ msgstr "Choisissez le plan qui vous convient."
 
 #. Pricing section heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:113
+#: app/[lang]/(public)/page.tsx:102
 #: src/components/Pricing.tsx:103
 msgid "home.pricing.title"
 msgstr "Choisis l'offre qui te convient"
@@ -685,14 +776,14 @@ msgstr "Tout effacer"
 #. Button to clear all active search filters
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:536
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:542
 #: src/components/search/search-toolbar.tsx:283
 msgid "search.filters.clearAll"
 msgstr "Tout effacer"
 
 #. Clear all selected companies button
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:191
+#: src/components/watchlist/company-search-modal.tsx:194
 msgid "watchlists.companyModal.clearAll"
 msgstr "Tout effacer"
 
@@ -748,15 +839,15 @@ msgstr "Collection d'offres d'emploi (CC BY-NC 4.0)"
 
 #. Feature: multi-dimensional filters description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:81
-#: src/components/Features.tsx:152
+#: app/[lang]/(public)/page.tsx:79
+#: src/components/Features.tsx:186
 msgid "home.features.s1.p2.description"
 msgstr "Note où tu as postulé, le statut, les contacts et les prochaines étapes."
 
 #. Feature: focused search description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:98
-#: src/components/Features.tsx:267
+#: app/[lang]/(public)/page.tsx:96
+#: src/components/Features.tsx:303
 msgid "home.features.s3.p1.description"
 msgstr "Combinez des entreprises spécifiques avec des filtres de rôle pour cibler exactement les postes que vous recherchez."
 
@@ -774,7 +865,7 @@ msgstr "Entreprises"
 
 #. Section header for company suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:446
+#: src/components/search/search-bar.tsx:632
 msgid "search.bar.companies"
 msgstr "Entreprises"
 
@@ -833,28 +924,28 @@ msgstr "Comptes connectés"
 msgid "license.contact.title"
 msgstr "Contact"
 
-#. TOC: Contact
-#. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:25
-msgid "license.toc.contact"
-msgstr "Contact"
-
 #. Footer link to contact email
 #. js-lingui-explicit-id
 #: src/components/Footer.tsx:41
 msgid "common.footer.contact"
 msgstr "Contact"
 
-#. Table of contents heading
+#. TOC: Contact
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
-msgstr "Sommaire"
+#: src/components/LicenseContent.tsx:25
+msgid "license.toc.contact"
+msgstr "Contact"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
+msgstr "Sommaire"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Sommaire"
 
 #. Button to continue to app after verification
@@ -977,8 +1068,8 @@ msgstr "Création du compte..."
 
 #. Feature section 3 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:95
-#: src/components/Features.tsx:257
+#: app/[lang]/(public)/page.tsx:93
+#: src/components/Features.tsx:293
 msgid "home.features.s3.title"
 msgstr "Créez une liste de suivi pour chaque niche"
 
@@ -1080,16 +1171,9 @@ msgstr "Détails"
 
 #. Collapsible section heading for extracted job details
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:379
+#: src/components/search/job-detail-dialog.tsx:399
 msgid "search.detail.details"
 msgstr "Détails"
-
-#. Agentic feature card title: ghosting
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:108
-#: src/components/AgenticFeatures.tsx:66
-msgid "home.agentic.cards.ghosting.title"
-msgstr "Détecter les offres fantômes probables"
 
 #. Subtext encouraging user to request a company when no results found
 #. js-lingui-explicit-id
@@ -1099,8 +1183,8 @@ msgstr "Vous n'avez pas trouvé l'entreprise recherchée ?"
 
 #. Feature: direct from source title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:80
-#: src/components/Features.tsx:146
+#: app/[lang]/(public)/page.tsx:78
+#: src/components/Features.tsx:180
 msgid "home.features.s1.p1.title"
 msgstr "Alertes entreprises"
 
@@ -1118,16 +1202,9 @@ msgstr "Déconnecter"
 
 #. Section title for discovering public watchlists
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:73
+#: src/components/watchlist/public-watchlist-search.tsx:81
 msgid "watchlists.explore.publicTitle"
 msgstr "Découvrir des listes publiques"
-
-#. Agentic feature card title: discovery
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:109
-#: src/components/AgenticFeatures.tsx:71
-msgid "home.agentic.cards.discovery.title"
-msgstr "Découvrir qui recrute maintenant"
 
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/faq/page.tsx:78
@@ -1234,8 +1311,8 @@ msgstr "Même après la découverte, nous récupérons les pages de détail des 
 
 #. Feature section 1 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:77
-#: src/components/Features.tsx:137
+#: app/[lang]/(public)/page.tsx:75
+#: src/components/Features.tsx:171
 msgid "home.features.s1.title"
 msgstr "Conçu pour les chercheurs d'emploi actifs"
 
@@ -1381,21 +1458,21 @@ msgstr "Filtre"
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:104
-#: src/components/search/job-detail-dialog.tsx:292
-#: src/components/search/job-detail-dialog.tsx:370
+#: src/components/search/job-detail-dialog.tsx:116
+#: src/components/search/job-detail-dialog.tsx:312
+#: src/components/search/job-detail-dialog.tsx:390
 msgid "search.detail.filterByPrefix"
 msgstr "Filtrer par"
 
 #. Tooltip for salary filter pill
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:226
+#: src/components/search/job-detail-dialog.tsx:238
 msgid "search.detail.filterBySalary"
 msgstr "Filtrer par cette fourchette salariale"
 
 #. Placeholder for industry filter search
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:243
+#: src/components/watchlist/company-search-modal.tsx:246
 msgid "watchlists.companyModal.industrySearch"
 msgstr "Filtrer les secteurs..."
 
@@ -1424,22 +1501,22 @@ msgid "settings.general.jobLanguages.findMore"
 msgstr "Rechercher"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:22
-#: app/[lang]/(public)/page.tsx:47
+#: app/[lang]/(public)/page.tsx:21
+#: app/[lang]/(public)/page.tsx:46
 msgid "home.meta.title"
 msgstr "Trouve les postes pertinents plus vite"
 
 #. Main heading on the landing page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:73
+#: app/[lang]/(public)/page.tsx:71
 #: src/components/Hero.tsx:28
 msgid "home.hero.title"
 msgstr "Trouve les bons postes plus vite."
 
 #. Feature: focused search title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:98
-#: src/components/Features.tsx:266
+#: app/[lang]/(public)/page.tsx:96
+#: src/components/Features.tsx:302
 msgid "home.features.s3.p1.title"
 msgstr "Recherche ciblée"
 
@@ -1454,13 +1531,6 @@ msgstr "Suivez-nous sur LinkedIn"
 #: src/components/Footer.tsx:31
 msgid "common.footer.ariaLabel"
 msgstr "Pied de page"
-
-#. Agentic features section eyebrow
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:103
-#: src/components/AgenticFeatures.tsx:41
-msgid "home.agentic.eyebrow"
-msgstr "Pour les agents IA"
 
 #. Free tier period
 #. js-lingui-explicit-id
@@ -1489,7 +1559,7 @@ msgstr "Fondée en {0}"
 
 #. Free tier name
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:115
+#: app/[lang]/(public)/page.tsx:104
 #: src/components/Pricing.tsx:32
 msgid "home.pricing.free.name"
 msgstr "Gratuit"
@@ -1520,8 +1590,8 @@ msgstr "Ven"
 
 #. Feature section 2 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:86
-#: src/components/Features.tsx:197
+#: app/[lang]/(public)/page.tsx:84
+#: src/components/Features.tsx:232
 msgid "home.features.s2.title"
 msgstr "Le premier agrégateur d'emploi qui te met aux commandes"
 
@@ -1538,7 +1608,7 @@ msgstr "Recherche complète, 1 liste de suivi, suivi des candidatures"
 
 #. Free tier description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:115
+#: app/[lang]/(public)/page.tsx:104
 #: src/components/Pricing.tsx:41
 msgid "home.pricing.free.description"
 msgstr "Teste Job Seek avec assez de marge pour rester à jour avec les entreprises de tes rêves."
@@ -1730,7 +1800,7 @@ msgstr "Politique d'indexation"
 
 #. Industry filter label
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:231
+#: src/components/watchlist/company-search-modal.tsx:234
 msgid "watchlists.companyModal.industry"
 msgstr "Secteur"
 
@@ -1775,8 +1845,8 @@ msgstr "Entretien"
 
 #. Feature: interview log title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:90
-#: src/components/Features.tsx:211
+#: app/[lang]/(public)/page.tsx:88
+#: src/components/Features.tsx:246
 msgid "home.features.s2.p2.title"
 msgstr "Fini la routine des 50 onglets"
 
@@ -1784,12 +1854,6 @@ msgstr "Fini la routine des 50 onglets"
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:30
 msgid "myJobs.group.interviewing"
-msgstr "En entretien"
-
-#. Application tracker status: interviewing
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:442
-msgid "search.tracker.interviewing"
 msgstr "En entretien"
 
 #. Interviewing status badge label
@@ -1802,6 +1866,12 @@ msgstr "En entretien"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:37
 msgid "myJobs.statusOption.interviewing"
+msgstr "En entretien"
+
+#. Application tracker status: interviewing
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:462
+msgid "search.tracker.interviewing"
 msgstr "En entretien"
 
 #. Interviews section heading
@@ -1846,7 +1916,7 @@ msgstr "offre"
 
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:110
+#: src/components/watchlist/public-watchlist-search.tsx:118
 msgid "watchlists.explore.jobSingular"
 msgstr "offre"
 
@@ -1861,17 +1931,17 @@ msgstr "Agrégateur d'offres d'emploi qui surveille les pages carrières des ent
 msgid "license.toc.data"
 msgstr "Données d'emploi (CC BY-NC 4.0)"
 
-#. Job detail panel title
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:74
-msgid "search.detail.title"
-msgstr "Détails de l'offre"
-
 #. Job detail panel title in My Jobs
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:161
+#: src/components/my-jobs/my-job-detail-panel.tsx:163
 msgid "myJobs.detail.title"
 msgstr "Détails du poste"
+
+#. Job detail panel title
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:86
+msgid "search.detail.title"
+msgstr "Détails de l'offre"
 
 #. Nav link: Job indexing
 #. Nav link: Job indexing
@@ -1912,7 +1982,7 @@ msgstr "Garde le pouls du marché de l'emploi."
 
 #. Alt text for feature section 2 screenshot
 #. js-lingui-explicit-id
-#: src/components/Features.tsx:224
+#: src/components/Features.tsx:259
 msgid "home.features.s2.screenshot.alt"
 msgstr "Interface Job Seek pour soumettre des liens d'entreprises et configurer des alertes personnalisées"
 
@@ -1941,13 +2011,6 @@ msgstr "Job Seek est en cours de développement. Restez à l'écoute pour les mi
 msgid "about.p1"
 msgstr "Job Seek est développé par Colophon Group, une petite équipe de développeurs basée en Suisse. Nous l'avons créé parce que nous en avions assez du même problème que rencontre chaque chercheur d'emploi : jongler entre des dizaines d'onglets, rater des offres parce qu'un agrégateur était trop lent, et se noyer dans du bruit algorithmique optimisé pour les clics plutôt que pour la pertinence."
 
-#. Agentic features section description
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:105
-#: src/components/AgenticFeatures.tsx:47
-msgid "home.agentic.description"
-msgstr "Job Seek n'est pas seulement une interface de recherche pour les personnes. Il expose également des workflows structurés pour les agents qui doivent chercher des emplois, détecter les offres fantômes et cartographier où le recrutement s'accélère."
-
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/privacy-policy/page.tsx:19
 #: app/[lang]/(public)/privacy-policy/page.tsx:41
@@ -1956,13 +2019,13 @@ msgstr "Politique de confidentialité de Job Seek — données collectées, util
 
 #. Alt text for feature section 1 screenshot
 #. js-lingui-explicit-id
-#: src/components/Features.tsx:164
+#: src/components/Features.tsx:198
 msgid "home.features.s1.screenshot.alt"
 msgstr "Tableau de bord Job Seek affichant les candidatures suivies et les alertes entreprises"
 
 #. Alt text for feature section 3 screenshot
 #. js-lingui-explicit-id
-#: src/components/Features.tsx:284
+#: src/components/Features.tsx:320
 msgid "home.features.s3.screenshot.alt"
 msgstr "Liste de suivi Job Seek montrant des postes sélectionnés en ingénierie robotique à Zurich"
 
@@ -1986,13 +2049,13 @@ msgstr "offres"
 
 #. Job count label in watchlist view
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:215
+#: src/components/watchlist/watchlist-job-list.tsx:226
 msgid "watchlists.jobList.jobCount"
 msgstr "offres"
 
 #. Plural job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:111
+#: src/components/watchlist/public-watchlist-search.tsx:119
 msgid "watchlists.explore.jobPlural"
 msgstr "offres"
 
@@ -2078,16 +2141,16 @@ msgstr "Découvrez comment Job Seek scrape les pages carrières de Workday, Gree
 msgid "home.hero.secondaryCta"
 msgstr "En savoir plus"
 
+#. Section header for seniority suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:522
+msgid "search.bar.level"
+msgstr "Niveau"
+
 #. Label for seniority/level filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:154
 msgid "search.advanced.level"
-msgstr "Niveau"
-
-#. Section header for seniority suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:567
-msgid "search.bar.level"
 msgstr "Niveau"
 
 #. js-lingui-explicit-id
@@ -2104,7 +2167,7 @@ msgstr "Licence"
 
 #. Footer link to license page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
+#: src/components/Footer.tsx:47
 msgid "common.footer.licenseLink"
 msgstr "Licence"
 
@@ -2157,16 +2220,16 @@ msgstr "Lieu"
 msgid "search.advanced.location"
 msgstr "Lieu"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:304
-msgid "search.detail.locations"
-msgstr "Lieux"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:492
+#: src/components/search/search-bar.tsx:592
 msgid "search.bar.locations"
+msgstr "Lieux"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:324
+msgid "search.detail.locations"
 msgstr "Lieux"
 
 #. Login button label
@@ -2191,8 +2254,8 @@ msgstr "Connectez-vous pour enregistrer cette recherche comme liste de suivi"
 
 #. Feature: share watchlists description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:100
-#: src/components/Features.tsx:277
+#: app/[lang]/(public)/page.tsx:98
+#: src/components/Features.tsx:313
 msgid "home.features.s3.p3.description"
 msgstr "Rendez une liste de suivi publique et partagez le lien avec vos amis, communautés ou votre réseau."
 
@@ -2264,7 +2327,7 @@ msgstr "Min"
 
 #. Singular mirror count
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:118
+#: src/components/watchlist/public-watchlist-search.tsx:126
 msgid "watchlists.explore.mirrorSingular"
 msgstr "copie"
 
@@ -2284,14 +2347,14 @@ msgstr "Copiez n'importe quelle liste publique pour la personnaliser — modifie
 
 #. Plural mirror count
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:119
+#: src/components/watchlist/public-watchlist-search.tsx:127
 msgid "watchlists.explore.mirrorPlural"
 msgstr "copies"
 
 #. Feature: request companies description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:99
-#: src/components/Features.tsx:272
+#: app/[lang]/(public)/page.tsx:97
+#: src/components/Features.tsx:308
 msgid "home.features.s3.p2.description"
 msgstr "Une entreprise manque ? Collez l'URL de sa page carrières et nous commençons à l'indexer pour vous."
 
@@ -2326,15 +2389,15 @@ msgstr "plus"
 
 #. Feature: status tracking description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:89
-#: src/components/Features.tsx:207
+#: app/[lang]/(public)/page.tsx:87
+#: src/components/Features.tsx:242
 msgid "home.features.s2.p1.description"
 msgstr "Indique-nous n'importe quelle page carrières ou tableau d'offres Notion et Job Seek le reproduit dans ton espace de travail en quelques minutes."
 
 #. Feature: multi-dimensional filters title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:81
-#: src/components/Features.tsx:151
+#: app/[lang]/(public)/page.tsx:79
+#: src/components/Features.tsx:185
 msgid "home.features.s1.p2.title"
 msgstr "Suivi des candidatures"
 
@@ -2391,12 +2454,6 @@ msgstr "Nom"
 msgid "watchlists.create.nameLabel"
 msgstr "Nom"
 
-#. Agentic features CTA title
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:117
-msgid "home.agentic.cta.title"
-msgstr "Besoin de la documentation au niveau des endpoints ?"
-
 #. TOC: Need to reach us?
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:33
@@ -2447,13 +2504,13 @@ msgstr "Aucun filtre défini. Ajoutez des filtres pour affiner les résultats."
 
 #. No industries match search
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:273
+#: src/components/watchlist/company-search-modal.tsx:276
 msgid "watchlists.companyModal.noIndustries"
 msgstr "Aucun secteur trouvé."
 
 #. Empty state when no jobs match the time range
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:226
+#: src/components/watchlist/watchlist-job-list.tsx:237
 msgid "watchlists.jobList.empty"
 msgstr "Aucune offre trouvée."
 
@@ -2463,16 +2520,16 @@ msgstr "Aucune offre trouvée."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Aucune langue ne correspond à votre recherche."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:186
-msgid "company.locationModal.noResults"
-msgstr "Aucun lieu ne correspond à votre recherche."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:171
 msgid "search.locationModal.noResults"
+msgstr "Aucun lieu ne correspond à votre recherche."
+
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:186
+msgid "company.locationModal.noResults"
 msgstr "Aucun lieu ne correspond à votre recherche."
 
 #. No postings found message on company page
@@ -2525,7 +2582,7 @@ msgstr "Aucune garantie — utilisation à tes risques et périls."
 
 #. No results message when searching public watchlists
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:140
+#: src/components/watchlist/public-watchlist-search.tsx:142
 msgid "watchlists.explore.noResults"
 msgstr "Aucune liste de suivi trouvée."
 
@@ -2545,16 +2602,16 @@ msgstr "Non. Le suivi des candidatures n'a pas de limite — enregistrez autant 
 msgid "faq.a.dataPrivacy"
 msgstr "Non. Nous ne vendons, ne louons ni ne partageons vos données à des fins marketing. Les cookies sont uniquement de session, sans publicité ni tracking. Vous pouvez supprimer votre compte et toutes les données seront effacées sous 30 jours."
 
-#. Application tracker status: not applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:440
-msgid "search.tracker.notApplied"
-msgstr "Non postulé"
-
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
+msgstr "Non postulé"
+
+#. Application tracker status: not applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:460
+msgid "search.tracker.notApplied"
 msgstr "Non postulé"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2585,16 +2642,16 @@ msgstr "Métier"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Oct"
 
-#. Application tracker status: offer
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:443
-msgid "search.tracker.offer"
-msgstr "Offre"
-
 #. Offered status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
+msgstr "Offre"
+
+#. Application tracker status: offer
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:463
+msgid "search.tracker.offer"
 msgstr "Offre"
 
 #. Status group heading: offered
@@ -2603,16 +2660,16 @@ msgstr "Offre"
 msgid "myJobs.group.offered"
 msgstr "Offre"
 
-#. Sankey funnel node: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:43
-msgid "myJobs.funnel.offered"
-msgstr "Offre"
-
 #. Status option in dropdown: offered
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:38
 msgid "myJobs.statusOption.offered"
+msgstr "Offre"
+
+#. Sankey funnel node: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:43
+msgid "myJobs.funnel.offered"
 msgstr "Offre"
 
 #. Cookie banner accept button
@@ -2649,7 +2706,7 @@ msgstr "Sur site"
 
 #. Aria label for mobile menu button
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:86
+#: src/components/Header.tsx:83
 msgid "common.header.openMenu"
 msgstr "Ouvrir le menu principal"
 
@@ -2657,18 +2714,6 @@ msgstr "Ouvrir le menu principal"
 #: app/[lang]/(app)/company/[slug]/page.tsx:36
 msgid "company.meta.openPositions"
 msgstr "Postes ouverts"
-
-#. Agentic feature card metadata: ghosting
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:100
-msgid "home.agentic.cards.ghosting.meta"
-msgstr "Niveau ouvert"
-
-#. Agentic feature card metadata: discovery
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:105
-msgid "home.agentic.cards.discovery.meta"
-msgstr "Niveau ouvert"
 
 #. Open-source section title
 #. js-lingui-explicit-id
@@ -2736,26 +2781,26 @@ msgstr "Notre position sur l'automatisation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Aperçu"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Aperçu"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Sommaire de la page"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Aperçu"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Sommaire de la page"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Sommaire de la page"
 
 #. Heading shown on the 404 page
@@ -2828,7 +2873,7 @@ msgstr "Période"
 
 #. Pro tier period
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:116
+#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:73
 msgid "home.pricing.pro.period"
 msgstr "par mois"
@@ -2859,8 +2904,8 @@ msgstr "Entretien téléphonique"
 
 #. Feature section 3 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:96
-#: src/components/Features.tsx:260
+#: app/[lang]/(public)/page.tsx:94
+#: src/components/Features.tsx:296
 msgid "home.features.s3.description"
 msgstr "Choisissez les entreprises qui vous intéressent, définissez vos filtres et obtenez un flux en direct des postes correspondants. Partagez-le publiquement ou gardez-le privé."
 
@@ -2946,19 +2991,19 @@ msgstr "Veuillez vous connecter pour gérer vos paramètres de facturation."
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:89
-msgid "search.detail.notFound"
-msgstr "Offre non trouvée."
-
-#. Posting not found message
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:181
+#: src/components/my-jobs/my-job-detail-panel.tsx:183
 msgid "myJobs.detail.notFound"
 msgstr "Offre introuvable."
 
+#. Posting not found message
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:101
+msgid "search.detail.notFound"
+msgstr "Offre non trouvée."
+
 #. Pricing section eyebrow
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:112
+#: app/[lang]/(public)/page.tsx:101
 #: src/components/Pricing.tsx:100
 msgid "home.pricing.eyebrow"
 msgstr "Tarifs"
@@ -2979,7 +3024,7 @@ msgstr "Confidentialité"
 
 #. Footer link to privacy policy page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:57
+#: src/components/Footer.tsx:52
 msgid "common.footer.privacyLink"
 msgstr "Confidentialité"
 
@@ -3004,7 +3049,7 @@ msgstr "Les listes de suivi privées sont une fonctionnalité payante. Passez à
 
 #. Pro tier name
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:116
+#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:68
 msgid "home.pricing.pro.name"
 msgstr "Pro"
@@ -3026,20 +3071,6 @@ msgstr "Publique (visible par les autres)"
 #: src/components/PublicDomainArt.tsx:62
 msgid "common.art.publicDomain"
 msgstr "Domaine public"
-
-#. Agentic feature card description: discovery
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:109
-#: src/components/AgenticFeatures.tsx:88
-msgid "home.agentic.cards.discovery.description"
-msgstr "Extrayez des signaux de tendance sur 39+ job boards pour repérer les entreprises en expansion, les activités en déclin et les nouvelles vagues de recrutement avant qu'elles ne deviennent évidentes ailleurs."
-
-#. Agentic feature card description: search
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:107
-#: src/components/AgenticFeatures.tsx:78
-msgid "home.agentic.cards.search.description"
-msgstr "Requêtez des emplois, des entreprises et des taxonomies de filtres via JSON afin que les copilotes et les outils internes puissent travailler avec le même inventaire structuré que le produit."
 
 #. Contact call to action
 #. js-lingui-explicit-id
@@ -3097,17 +3128,10 @@ msgstr "Alertes en temps réel sur les nouvelles offres"
 msgid "myJobs.sort.recentlyUpdated"
 msgstr "Récemment mis à jour"
 
-#. Agentic feature card description: ghosting
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:108
-#: src/components/AgenticFeatures.tsx:83
-msgid "home.agentic.cards.ghosting.description"
-msgstr "Reconstruisez l'historique des publications à partir de captures archivées pour signaler les postes qui semblent rester ouverts sans intention réelle de recrutement et retournez un rapport sur lequel votre agent peut raisonner."
-
 #. Feature: interview log description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:90
-#: src/components/Features.tsx:212
+#: app/[lang]/(public)/page.tsx:88
+#: src/components/Features.tsx:247
 msgid "home.features.s2.p2.description"
 msgstr "Regroupe toutes les startups intéressantes dans un seul tableau de bord au lieu de jongler entre les fenêtres Chrome et les favoris."
 
@@ -3135,16 +3159,16 @@ msgstr "Région"
 msgid "myJobs.group.rejected"
 msgstr "Refusé"
 
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:444
-msgid "search.tracker.rejected"
-msgstr "Refusé"
-
 #. Rejected status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:23
 msgid "myJobs.status.rejected"
+msgstr "Refusé"
+
+#. Status option in dropdown: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:39
+msgid "myJobs.statusOption.rejected"
 msgstr "Refusé"
 
 #. Sankey funnel node label prefix: rejected
@@ -3153,10 +3177,10 @@ msgstr "Refusé"
 msgid "myJobs.funnel.rejected"
 msgstr "Refusé"
 
-#. Status option in dropdown: rejected
+#. Application tracker status: rejected
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:39
-msgid "myJobs.statusOption.rejected"
+#: src/components/search/job-detail-dialog.tsx:464
+msgid "search.tracker.rejected"
 msgstr "Refusé"
 
 #. Footer license summary text
@@ -3179,8 +3203,8 @@ msgstr "Supprimer le lieu"
 
 #. Feature: request companies title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:99
-#: src/components/Features.tsx:271
+#: app/[lang]/(public)/page.tsx:97
+#: src/components/Features.tsx:307
 msgid "home.features.s3.p2.title"
 msgstr "Demander n'importe quelle entreprise"
 
@@ -3253,12 +3277,6 @@ msgstr "Réinitialisation…"
 msgid "indexing.assurances.i1.title"
 msgstr "Rythme respectueux."
 
-#. Agentic features CTA description
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:122
-msgid "home.agentic.cta.description"
-msgstr "Consultez la référence API agentique, le modèle d'authentification et les exemples de requêtes pour la recherche, l'analyse des offres fantômes et la découverte d'entreprises."
-
 #. Assurance 2 title
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/how-we-index/page.tsx:54
@@ -3274,7 +3292,7 @@ msgstr "Rôle"
 
 #. Section header for occupation suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:532
+#: src/components/search/search-bar.tsx:487
 msgid "search.bar.roles"
 msgstr "Rôles"
 
@@ -3284,16 +3302,16 @@ msgstr "Rôles"
 msgid "myJobs.funnel.round"
 msgstr "Tour"
 
-#. Salary override section heading
-#. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:76
-msgid "myJobs.detail.salary"
-msgstr "Salaire"
-
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:171
 msgid "search.advanced.salary"
+msgstr "Salaire"
+
+#. Salary override section heading
+#. js-lingui-explicit-id
+#: src/components/my-jobs/salary-override.tsx:76
+msgid "myJobs.detail.salary"
 msgstr "Salaire"
 
 #. Salary display settings section heading
@@ -3310,21 +3328,21 @@ msgstr "Fourchette salariale"
 
 #. Feature section 2 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:87
-#: src/components/Features.tsx:200
+#: app/[lang]/(public)/page.tsx:85
+#: src/components/Features.tsx:235
 msgid "home.features.s2.description"
 msgstr "Tu ne trouves pas ton entreprise préférée dans le flux ? Colle le lien de sa page carrières et on commence à la scraper pour toi — pas de scripts, pas de tableurs, pas d'attente au support."
 
 #. Feature: watchlists and alerts description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:82
-#: src/components/Features.tsx:157
+#: app/[lang]/(public)/page.tsx:80
+#: src/components/Features.tsx:191
 msgid "home.features.s1.p3.description"
 msgstr "Enregistre tes filtres pour des recherches rapides sans tout retaper à chaque fois."
 
 #. Save job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:191
+#: src/components/watchlist/watchlist-job-list.tsx:202
 msgid "watchlists.jobList.save"
 msgstr "Sauvegarder l'offre"
 
@@ -3364,16 +3382,16 @@ msgstr "Enregistré"
 msgid "myJobs.status.saved"
 msgstr "Enregistré"
 
-#. Sankey funnel node: saved jobs
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:41
-msgid "myJobs.funnel.saved"
-msgstr "Enregistré"
-
 #. Status option in dropdown: saved
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:35
 msgid "myJobs.statusOption.saved"
+msgstr "Enregistré"
+
+#. Sankey funnel node: saved jobs
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:41
+msgid "myJobs.funnel.saved"
 msgstr "Enregistré"
 
 #. Username save button while loading
@@ -3396,8 +3414,8 @@ msgstr "Suivi de 5 entreprises maximum"
 
 #. Feature section 1 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:78
-#: src/components/Features.tsx:140
+#: app/[lang]/(public)/page.tsx:76
+#: src/components/Features.tsx:174
 msgid "home.features.s1.description"
 msgstr "Suis les postes, reçois des notifications quand les entreprises publient quelque chose de nouveau, et garde ton pipeline propre."
 
@@ -3416,9 +3434,15 @@ msgstr "Rechercher des entreprises..."
 
 #. Placeholder for company search in modal
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:213
+#: src/components/watchlist/company-search-modal.tsx:216
 msgid "watchlists.companyModal.searchPlaceholder"
 msgstr "Rechercher des entreprises..."
+
+#. Option to search by title keyword in dropdown
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:475
+msgid "search.bar.keyword"
+msgstr "Rechercher \"{trimmedInput}\" dans les titres de postes"
 
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/explore/page.tsx:18
@@ -3431,21 +3455,21 @@ msgstr "Recherchez des emplois dans des milliers d'entreprises, scrapés directe
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Rechercher des langues…"
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:165
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Rechercher des lieux…"
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:150
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Rechercher des lieux..."
 
+#. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:23
-#: app/[lang]/(public)/page.tsx:48
+#: src/components/search/location-modal.tsx:165
+msgid "company.locationModal.searchPlaceholder"
+msgstr "Rechercher des lieux…"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:22
+#: app/[lang]/(public)/page.tsx:47
 msgid "home.meta.description"
 msgstr "Recherchez des millions d'offres scrapées directement depuis des milliers de pages carrières. Filtrez par niveau, stack technique, salaire et localisation, puis suivez chaque candidature."
 
@@ -3461,29 +3485,22 @@ msgstr "Résultats de recherche"
 msgid "search.occupationModal.searchPlaceholder"
 msgstr "Rechercher des rôles..."
 
-#. Agentic feature card title: search
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:107
-#: src/components/AgenticFeatures.tsx:61
-msgid "home.agentic.cards.search.title"
-msgstr "Interroger l'index directement"
-
 #. Placeholder for public watchlist search input
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:84
+#: src/components/watchlist/public-watchlist-search.tsx:92
 msgid "watchlists.explore.searchPlaceholder"
 msgstr "Rechercher des listes..."
 
 #. Feature section 1 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:76
-#: src/components/Features.tsx:134
+#: app/[lang]/(public)/page.tsx:74
+#: src/components/Features.tsx:168
 msgid "home.features.s1.eyebrow"
 msgstr "Tout ce qu'il te faut pour garder une longueur d'avance"
 
 #. Placeholder for the main search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:391
+#: src/components/search/search-bar.tsx:404
 msgid "search.bar.placeholder"
 msgstr "Rechercher…"
 
@@ -3495,8 +3512,8 @@ msgstr "Rechercher…"
 
 #. Feature: application stats description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:91
-#: src/components/Features.tsx:217
+#: app/[lang]/(public)/page.tsx:89
+#: src/components/Features.tsx:252
 msgid "home.features.s2.p3.description"
 msgstr "Définis la fréquence par entreprise pour être informé des nouvelles offres sans scroller les sites d'emploi toute la journée."
 
@@ -3549,16 +3566,16 @@ msgstr "Envoyer le lien"
 msgid "settings.account.password.send"
 msgstr "Envoyer le lien"
 
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Envoi en cours..."
-
 #. Resend button while sending
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:96
 msgid "auth.verify.resending"
+msgstr "Envoi en cours..."
+
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
 msgstr "Envoi en cours..."
 
 #. Reset password button while loading
@@ -3629,8 +3646,8 @@ msgstr "Paramètres"
 
 #. Feature: share watchlists title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:100
-#: src/components/Features.tsx:276
+#: app/[lang]/(public)/page.tsx:98
+#: src/components/Features.tsx:312
 msgid "home.features.s3.p3.title"
 msgstr "Partager avec tout le monde"
 
@@ -3642,7 +3659,7 @@ msgstr "Afficher moins"
 
 #. Button to collapse location list
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:347
+#: src/components/search/job-detail-dialog.tsx:367
 msgid "search.detail.showLessLocations"
 msgstr "Afficher moins"
 
@@ -3744,7 +3761,7 @@ msgstr "Connexion en cours..."
 
 #. Pricing section description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:114
+#: app/[lang]/(public)/page.tsx:103
 #: src/components/Pricing.tsx:106
 msgid "home.pricing.description"
 msgstr "Des tarifs simples et transparents. Commence gratuitement et passe à la vitesse supérieure quand ta recherche d'emploi devient sérieuse."
@@ -3828,14 +3845,14 @@ msgstr "Statut"
 
 #. Status section heading
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:198
+#: src/components/my-jobs/my-job-detail-panel.tsx:200
 msgid "myJobs.detail.status"
 msgstr "Statut"
 
 #. Feature: status tracking title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:89
-#: src/components/Features.tsx:206
+#: app/[lang]/(public)/page.tsx:87
+#: src/components/Features.tsx:241
 msgid "home.features.s2.p1.title"
 msgstr "Colle un lien, lance un crawl"
 
@@ -3864,12 +3881,6 @@ msgstr "Envoi en cours..."
 #: src/components/settings/SettingsNav.tsx:31
 msgid "settings.nav.billing"
 msgstr "Abonnement"
-
-#. Agentic feature card metadata: search
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:95
-msgid "home.agentic.cards.search.meta"
-msgstr "Abonnement requis"
 
 #. FAQ page eyebrow
 #. js-lingui-explicit-id
@@ -3901,16 +3912,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technique"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:389
-msgid "search.detail.technologies"
-msgstr "Technologies"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:602
+#: src/components/search/search-bar.tsx:557
 msgid "search.bar.technologies"
+msgstr "Technologies"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:409
+msgid "search.detail.technologies"
 msgstr "Technologies"
 
 #. Add technology filter
@@ -3939,7 +3950,7 @@ msgstr "Conditions d'utilisation"
 
 #. Footer link to terms of service page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:62
+#: src/components/Footer.tsx:57
 msgid "common.footer.termsLink"
 msgstr "CGU"
 
@@ -4038,14 +4049,14 @@ msgstr "Cette liste de suivi et tous ses paramètres seront définitivement supp
 
 #. Date divider label for today
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:79
+#: src/components/watchlist/watchlist-job-list.tsx:81
 msgid "watchlists.jobList.today"
 msgstr "Aujourd'hui"
 
 #. Feature section 2 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:85
-#: src/components/Features.tsx:194
+#: app/[lang]/(public)/page.tsx:83
+#: src/components/Features.tsx:229
 msgid "home.features.s2.eyebrow"
 msgstr "Garde le contrôle"
 
@@ -4102,7 +4113,7 @@ msgstr "Abonnements entreprises illimités"
 
 #. Pro tier description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:116
+#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:77
 msgid "home.pricing.pro.description"
 msgstr "Pour les chercheurs d'emploi actifs qui veulent une portée illimitée et des informations plus rapides."
@@ -4114,7 +4125,7 @@ msgstr "Listes de suivi illimitées, alertes email sur les nouveaux résultats"
 
 #. Unsave job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:190
+#: src/components/watchlist/watchlist-job-list.tsx:201
 msgid "watchlists.jobList.unsave"
 msgstr "Retirer l'offre"
 
@@ -4173,7 +4184,7 @@ msgstr "Utilisez le formulaire de demande sur la page Explorer — collez l'URL 
 
 #. Fallback username for watchlist owner
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:109
+#: src/components/watchlist/public-watchlist-search.tsx:117
 msgid "watchlists.explore.unknownUser"
 msgstr "utilisateur"
 
@@ -4225,15 +4236,9 @@ msgstr "Vérification de ton e-mail…"
 msgid "myJobs.interviewType.videoCall"
 msgstr "Appel vidéo"
 
-#. Agentic features CTA button label
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:137
-msgid "home.agentic.cta.button"
-msgstr "Voir la documentation API"
-
 #. Link to the original job posting
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:186
+#: src/components/search/job-detail-dialog.tsx:198
 msgid "search.detail.viewPosting"
 msgstr "Voir l'offre"
 
@@ -4269,8 +4274,8 @@ msgstr "Listes de suivi"
 
 #. Feature: watchlists and alerts title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:82
-#: src/components/Features.tsx:156
+#: app/[lang]/(public)/page.tsx:80
+#: src/components/Features.tsx:190
 msgid "home.features.s1.p3.title"
 msgstr "Recherches enregistrées"
 
@@ -4351,15 +4356,15 @@ msgstr "Nous respectons robots.txt et les en-têtes TDM-Reservation, limitons le
 
 #. Hero description paragraph
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:74
+#: app/[lang]/(public)/page.tsx:72
 #: src/components/Hero.tsx:31
 msgid "home.hero.description"
 msgstr "Nous scrapons les pages carrières directement pour que tu voies les offres dès leur publication. Parcours des millions d'offres d'emploi dans des milliers d'entreprises — filtre par niveau, stack technique, salaire et localisation, et suis chaque candidature en un seul endroit."
 
 #. Feature: direct from source description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:80
-#: src/components/Features.tsx:147
+#: app/[lang]/(public)/page.tsx:78
+#: src/components/Features.tsx:181
 msgid "home.features.s1.p1.description"
 msgstr "Suis les employeurs qui t'intéressent et reçois une notification dès qu'ils publient de nouveaux postes."
 
@@ -4466,7 +4471,7 @@ msgstr "Oui. Le crawler et le pipeline d'extraction sont entièrement open sourc
 
 #. Date divider label for yesterday
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:80
+#: src/components/watchlist/watchlist-job-list.tsx:82
 msgid "watchlists.jobList.yesterday"
 msgstr "Hier"
 
@@ -4530,8 +4535,8 @@ msgstr "Vous avez atteint la limite de vos listes de suivi. Passez à un plan su
 
 #. Feature section 3 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:94
-#: src/components/Features.tsx:254
+#: app/[lang]/(public)/page.tsx:92
+#: src/components/Features.tsx:290
 msgid "home.features.s3.eyebrow"
 msgstr "Vos entreprises, vos règles"
 

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -94,6 +94,111 @@ msgstr ""
 #~ msgid "breadcrumb.home"
 #~ msgstr "Home"
 
+#. Count of additional watchlists not shown
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:130
+#~ msgid "watchlists.explore.moreCount"
+#~ msgstr "{0} in più"
+
+#. Agentic features section heading
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:104
+#: src/components/AgenticFeatures.tsx:44
+#~ msgid "home.agentic.title"
+#~ msgstr "Workflow agentici sull'indice dei lavori"
+
+#. Agentic feature card title: ghosting
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:108
+#: src/components/AgenticFeatures.tsx:66
+#~ msgid "home.agentic.cards.ghosting.title"
+#~ msgstr "Rileva probabili annunci fantasma"
+
+#. Agentic feature card title: discovery
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:109
+#: src/components/AgenticFeatures.tsx:71
+#~ msgid "home.agentic.cards.discovery.title"
+#~ msgstr "Scopri chi sta assumendo ora"
+
+#. Agentic features section eyebrow
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:103
+#: src/components/AgenticFeatures.tsx:41
+#~ msgid "home.agentic.eyebrow"
+#~ msgstr "Per agenti IA"
+
+#. Agentic features section description
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:105
+#: src/components/AgenticFeatures.tsx:47
+#~ msgid "home.agentic.description"
+#~ msgstr "Job Seek non è solo un'interfaccia di ricerca per le persone. Espone anche workflow strutturati per gli agenti che devono cercare lavoro, rilevare annunci fantasma e mappare dove il recruiting si sta accelerando."
+
+#. Agentic features CTA title
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:117
+#~ msgid "home.agentic.cta.title"
+#~ msgstr "Hai bisogno della documentazione a livello di endpoint?"
+
+#. Agentic feature card metadata: ghosting
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:100
+#~ msgid "home.agentic.cards.ghosting.meta"
+#~ msgstr "Livello aperto"
+
+#. Agentic feature card metadata: discovery
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:105
+#~ msgid "home.agentic.cards.discovery.meta"
+#~ msgstr "Livello aperto"
+
+#. Agentic feature card description: discovery
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:109
+#: src/components/AgenticFeatures.tsx:88
+#~ msgid "home.agentic.cards.discovery.description"
+#~ msgstr "Estrai segnali di tendenza da 39+ job board per individuare aziende in espansione, attività in calo e nuove ondate di assunzione prima che diventino ovvie altrove."
+
+#. Agentic feature card description: search
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:107
+#: src/components/AgenticFeatures.tsx:78
+#~ msgid "home.agentic.cards.search.description"
+#~ msgstr "Interroga lavori, aziende e tassonomie di filtri via JSON in modo che copiloti e strumenti interni possano lavorare con lo stesso inventario strutturato del prodotto."
+
+#. Agentic feature card description: ghosting
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:108
+#: src/components/AgenticFeatures.tsx:83
+#~ msgid "home.agentic.cards.ghosting.description"
+#~ msgstr "Ricostruisci la cronologia delle pubblicazioni da snapshot archiviati per segnalare i ruoli che sembrano rimanere aperti senza reale intenzione di assunzione e restituisci un rapporto su cui il tuo agente può ragionare."
+
+#. Agentic features CTA description
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:122
+#~ msgid "home.agentic.cta.description"
+#~ msgstr "Consulta il riferimento API agentico, il modello di autenticazione e le richieste di esempio per ricerca, analisi degli annunci fantasma e scoperta di aziende."
+
+#. Agentic feature card title: search
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:107
+#: src/components/AgenticFeatures.tsx:61
+#~ msgid "home.agentic.cards.search.title"
+#~ msgstr "Cerca direttamente nell'indice"
+
+#. Agentic feature card metadata: search
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:95
+#~ msgid "home.agentic.cards.search.meta"
+#~ msgstr "Abbonamento richiesto"
+
+#. Agentic features CTA button label
+#. js-lingui-explicit-id
+#: src/components/AgenticFeatures.tsx:137
+#~ msgid "home.agentic.cta.button"
+#~ msgstr "Visualizza la documentazione API"
+
 #. CC right 1
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:80
@@ -127,17 +232,10 @@ msgstr "(apre in una nuova scheda)"
 msgid "company.page.employees"
 msgstr "{0} dipendenti"
 
-#. Count of additional watchlists not shown
-#. js-lingui-explicit-id
-#. placeholder {0}: total - results.length
-#: src/components/watchlist/public-watchlist-search.tsx:130
-msgid "watchlists.explore.moreCount"
-msgstr "{0} in più"
-
 #. Button to show remaining collapsed locations
 #. js-lingui-explicit-id
 #. placeholder {0}: locations.length - LOCATIONS_COLLAPSED
-#: src/components/search/job-detail-dialog.tsx:351
+#: src/components/search/job-detail-dialog.tsx:371
 msgid "search.detail.showMoreLocations"
 msgstr "{0} in più"
 
@@ -253,7 +351,7 @@ msgstr "attivo"
 
 #. Title for add companies modal
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:179
+#: src/components/watchlist/company-search-modal.tsx:182
 msgid "watchlists.companyModal.title"
 msgstr "Aggiungi aziende"
 
@@ -263,16 +361,16 @@ msgstr "Aggiungi aziende"
 msgid "watchlists.view.addDescription"
 msgstr "Aggiungi descrizione"
 
-#. Button to add an interview round
-#. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:76
-msgid "myJobs.detail.addInterview"
-msgstr "Aggiungi colloquio"
-
 #. Quick action tooltip: add interview round
 #. js-lingui-explicit-id
 #: src/components/my-jobs/quick-actions.tsx:19
 msgid "myJobs.action.addInterview"
+msgstr "Aggiungi colloquio"
+
+#. Button to add an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx:76
+msgid "myJobs.detail.addInterview"
 msgstr "Aggiungi colloquio"
 
 #. Placeholder in the add keyword input
@@ -293,13 +391,6 @@ msgstr "Aggiungi filtro per luogo o parola chiave…"
 msgid "search.locations.addPlaceholder"
 msgstr "Aggiungi località..."
 
-#. Agentic features section heading
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:104
-#: src/components/AgenticFeatures.tsx:44
-msgid "home.agentic.title"
-msgstr "Workflow agentici sull'indice dei lavori"
-
 #. Encryption
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/privacy-policy/page.tsx:57
@@ -309,7 +400,7 @@ msgstr "Tutti i dati sono crittografati in transito e a riposo."
 
 #. Option to show all industries
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:255
+#: src/components/watchlist/company-search-modal.tsx:258
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Tutti i settori"
 
@@ -384,8 +475,8 @@ msgstr "Codice dell'applicazione (MIT)"
 
 #. Feature: application stats title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:91
-#: src/components/Features.tsx:216
+#: app/[lang]/(public)/page.tsx:89
+#: src/components/Features.tsx:251
 msgid "home.features.s2.p3.title"
 msgstr "Avvisi che controlli davvero"
 
@@ -403,7 +494,7 @@ msgstr "Statistiche candidature"
 
 #. Application tracker section heading in job detail
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:247
+#: src/components/search/job-detail-dialog.tsx:259
 msgid "search.detail.applicationTracker"
 msgstr "Monitoraggio candidatura"
 
@@ -425,16 +516,16 @@ msgstr "candidature nell'ultimo anno"
 msgid "myJobs.group.applied"
 msgstr "Candidato"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:441
-msgid "search.tracker.applied"
-msgstr "Candidato"
-
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
 msgid "myJobs.status.applied"
+msgstr "Candidato"
+
+#. Status option in dropdown: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:36
+msgid "myJobs.statusOption.applied"
 msgstr "Candidato"
 
 #. Sankey funnel node: applied
@@ -443,10 +534,10 @@ msgstr "Candidato"
 msgid "myJobs.funnel.applied"
 msgstr "Candidato"
 
-#. Status option in dropdown: applied
+#. Application tracker status: applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:36
-msgid "myJobs.statusOption.applied"
+#: src/components/search/job-detail-dialog.tsx:461
+msgid "search.tracker.applied"
 msgstr "Candidato"
 
 #. Apply salary filter
@@ -463,7 +554,7 @@ msgstr "Applica"
 
 #. Apply button linking to original job posting
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:296
+#: src/components/my-jobs/my-job-detail-panel.tsx:304
 msgid "search.detail.apply"
 msgstr "Candidati"
 
@@ -565,16 +656,16 @@ msgstr "Utilizzando Job Seek accetti questi termini. Ecco un riassunto in parole
 msgid "faq.q.optOut"
 msgstr "Posso rifiutare l'indicizzazione della mia azienda da parte di Jobseek?"
 
-#. Cancel button in create watchlist dialog
-#. js-lingui-explicit-id
-#: src/components/watchlist/create-watchlist-dialog.tsx:164
-msgid "watchlists.create.cancel"
-msgstr "Annulla"
-
 #. Cancel delete watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-action-bar.tsx:233
 msgid "watchlists.delete.cancel"
+msgstr "Annulla"
+
+#. Cancel button in create watchlist dialog
+#. js-lingui-explicit-id
+#: src/components/watchlist/create-watchlist-dialog.tsx:164
+msgid "watchlists.create.cancel"
 msgstr "Annulla"
 
 #. Cancel delete button
@@ -613,17 +704,17 @@ msgstr "Cambia la tua password tramite un link email sicuro."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Cambia…"
 
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "Controlla la tua e-mail"
-
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
 msgstr "Controlla la tua email"
+
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
+msgstr "Controlla la tua e-mail"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -651,7 +742,7 @@ msgstr "Scegli il piano più adatto a te."
 
 #. Pricing section heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:113
+#: app/[lang]/(public)/page.tsx:102
 #: src/components/Pricing.tsx:103
 msgid "home.pricing.title"
 msgstr "Scegli il piano giusto per te"
@@ -685,14 +776,14 @@ msgstr "Rimuovi tutti"
 #. Button to clear all active search filters
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:536
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:542
 #: src/components/search/search-toolbar.tsx:283
 msgid "search.filters.clearAll"
 msgstr "Cancella tutto"
 
 #. Clear all selected companies button
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:191
+#: src/components/watchlist/company-search-modal.tsx:194
 msgid "watchlists.companyModal.clearAll"
 msgstr "Rimuovi tutti"
 
@@ -748,15 +839,15 @@ msgstr "Raccolta di annunci di lavoro (CC BY-NC 4.0)"
 
 #. Feature: multi-dimensional filters description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:81
-#: src/components/Features.tsx:152
+#: app/[lang]/(public)/page.tsx:79
+#: src/components/Features.tsx:186
 msgid "home.features.s1.p2.description"
 msgstr "Annota dove ti sei candidato, lo stato, i contatti e i prossimi passi."
 
 #. Feature: focused search description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:98
-#: src/components/Features.tsx:267
+#: app/[lang]/(public)/page.tsx:96
+#: src/components/Features.tsx:303
 msgid "home.features.s3.p1.description"
 msgstr "Combina aziende specifiche con filtri per ruolo per individuare esattamente le posizioni che cerchi."
 
@@ -774,7 +865,7 @@ msgstr "Aziende"
 
 #. Section header for company suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:446
+#: src/components/search/search-bar.tsx:632
 msgid "search.bar.companies"
 msgstr "Aziende"
 
@@ -833,28 +924,28 @@ msgstr "Account collegati"
 msgid "license.contact.title"
 msgstr "Contatti"
 
-#. TOC: Contact
-#. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:25
-msgid "license.toc.contact"
-msgstr "Contatti"
-
 #. Footer link to contact email
 #. js-lingui-explicit-id
 #: src/components/Footer.tsx:41
 msgid "common.footer.contact"
 msgstr "Contatti"
 
-#. Table of contents heading
+#. TOC: Contact
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
-msgstr "Sommario"
+#: src/components/LicenseContent.tsx:25
+msgid "license.toc.contact"
+msgstr "Contatti"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
+msgstr "Sommario"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Sommario"
 
 #. Button to continue to app after verification
@@ -977,8 +1068,8 @@ msgstr "Creazione account..."
 
 #. Feature section 3 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:95
-#: src/components/Features.tsx:257
+#: app/[lang]/(public)/page.tsx:93
+#: src/components/Features.tsx:293
 msgid "home.features.s3.title"
 msgstr "Crea una watchlist per ogni nicchia"
 
@@ -1080,16 +1171,9 @@ msgstr "Dettagli"
 
 #. Collapsible section heading for extracted job details
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:379
+#: src/components/search/job-detail-dialog.tsx:399
 msgid "search.detail.details"
 msgstr "Dettagli"
-
-#. Agentic feature card title: ghosting
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:108
-#: src/components/AgenticFeatures.tsx:66
-msgid "home.agentic.cards.ghosting.title"
-msgstr "Rileva probabili annunci fantasma"
 
 #. Subtext encouraging user to request a company when no results found
 #. js-lingui-explicit-id
@@ -1099,8 +1183,8 @@ msgstr "Non hai trovato l'azienda che cercavi?"
 
 #. Feature: direct from source title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:80
-#: src/components/Features.tsx:146
+#: app/[lang]/(public)/page.tsx:78
+#: src/components/Features.tsx:180
 msgid "home.features.s1.p1.title"
 msgstr "Avvisi aziendali"
 
@@ -1118,16 +1202,9 @@ msgstr "Scollega"
 
 #. Section title for discovering public watchlists
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:73
+#: src/components/watchlist/public-watchlist-search.tsx:81
 msgid "watchlists.explore.publicTitle"
 msgstr "Scopri liste pubbliche"
-
-#. Agentic feature card title: discovery
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:109
-#: src/components/AgenticFeatures.tsx:71
-msgid "home.agentic.cards.discovery.title"
-msgstr "Scopri chi sta assumendo ora"
 
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/faq/page.tsx:78
@@ -1234,8 +1311,8 @@ msgstr "Anche dopo la scoperta, recuperiamo le pagine di dettaglio degli annunci
 
 #. Feature section 1 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:77
-#: src/components/Features.tsx:137
+#: app/[lang]/(public)/page.tsx:75
+#: src/components/Features.tsx:171
 msgid "home.features.s1.title"
 msgstr "Pensato per chi cerca lavoro attivamente"
 
@@ -1381,21 +1458,21 @@ msgstr "Filtro"
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:104
-#: src/components/search/job-detail-dialog.tsx:292
-#: src/components/search/job-detail-dialog.tsx:370
+#: src/components/search/job-detail-dialog.tsx:116
+#: src/components/search/job-detail-dialog.tsx:312
+#: src/components/search/job-detail-dialog.tsx:390
 msgid "search.detail.filterByPrefix"
 msgstr "Filtra per"
 
 #. Tooltip for salary filter pill
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:226
+#: src/components/search/job-detail-dialog.tsx:238
 msgid "search.detail.filterBySalary"
 msgstr "Filtra per questa fascia salariale"
 
 #. Placeholder for industry filter search
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:243
+#: src/components/watchlist/company-search-modal.tsx:246
 msgid "watchlists.companyModal.industrySearch"
 msgstr "Filtra settori..."
 
@@ -1424,22 +1501,22 @@ msgid "settings.general.jobLanguages.findMore"
 msgstr "Cerca altre"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:22
-#: app/[lang]/(public)/page.tsx:47
+#: app/[lang]/(public)/page.tsx:21
+#: app/[lang]/(public)/page.tsx:46
 msgid "home.meta.title"
 msgstr "Trova i ruoli giusti più velocemente"
 
 #. Main heading on the landing page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:73
+#: app/[lang]/(public)/page.tsx:71
 #: src/components/Hero.tsx:28
 msgid "home.hero.title"
 msgstr "Trova le posizioni giuste, più velocemente."
 
 #. Feature: focused search title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:98
-#: src/components/Features.tsx:266
+#: app/[lang]/(public)/page.tsx:96
+#: src/components/Features.tsx:302
 msgid "home.features.s3.p1.title"
 msgstr "Ricerca mirata"
 
@@ -1454,13 +1531,6 @@ msgstr "Seguici su LinkedIn"
 #: src/components/Footer.tsx:31
 msgid "common.footer.ariaLabel"
 msgstr "Piè di pagina"
-
-#. Agentic features section eyebrow
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:103
-#: src/components/AgenticFeatures.tsx:41
-msgid "home.agentic.eyebrow"
-msgstr "Per agenti IA"
 
 #. Free tier period
 #. js-lingui-explicit-id
@@ -1489,7 +1559,7 @@ msgstr "Fondata nel {0}"
 
 #. Free tier name
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:115
+#: app/[lang]/(public)/page.tsx:104
 #: src/components/Pricing.tsx:32
 msgid "home.pricing.free.name"
 msgstr "Gratis"
@@ -1520,8 +1590,8 @@ msgstr "Ven"
 
 #. Feature section 2 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:86
-#: src/components/Features.tsx:197
+#: app/[lang]/(public)/page.tsx:84
+#: src/components/Features.tsx:232
 msgid "home.features.s2.title"
 msgstr "Il primo aggregatore di lavoro che ti mette al volante"
 
@@ -1538,7 +1608,7 @@ msgstr "Ricerca completa, 1 watchlist, tracker delle candidature"
 
 #. Free tier description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:115
+#: app/[lang]/(public)/page.tsx:104
 #: src/components/Pricing.tsx:41
 msgid "home.pricing.free.description"
 msgstr "Prova Job Seek con abbastanza spazio per restare aggiornato sulle aziende dei tuoi sogni."
@@ -1730,7 +1800,7 @@ msgstr "Politica di indicizzazione"
 
 #. Industry filter label
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:231
+#: src/components/watchlist/company-search-modal.tsx:234
 msgid "watchlists.companyModal.industry"
 msgstr "Settore"
 
@@ -1775,8 +1845,8 @@ msgstr "Colloquio"
 
 #. Feature: interview log title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:90
-#: src/components/Features.tsx:211
+#: app/[lang]/(public)/page.tsx:88
+#: src/components/Features.tsx:246
 msgid "home.features.s2.p2.title"
 msgstr "Basta con le 50 schede aperte"
 
@@ -1784,12 +1854,6 @@ msgstr "Basta con le 50 schede aperte"
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:30
 msgid "myJobs.group.interviewing"
-msgstr "In colloquio"
-
-#. Application tracker status: interviewing
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:442
-msgid "search.tracker.interviewing"
 msgstr "In colloquio"
 
 #. Interviewing status badge label
@@ -1802,6 +1866,12 @@ msgstr "In colloquio"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:37
 msgid "myJobs.statusOption.interviewing"
+msgstr "In colloquio"
+
+#. Application tracker status: interviewing
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:462
+msgid "search.tracker.interviewing"
 msgstr "In colloquio"
 
 #. Interviews section heading
@@ -1846,7 +1916,7 @@ msgstr "offerta"
 
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:110
+#: src/components/watchlist/public-watchlist-search.tsx:118
 msgid "watchlists.explore.jobSingular"
 msgstr "offerta"
 
@@ -1861,17 +1931,17 @@ msgstr "Aggregatore di offerte di lavoro che monitora le pagine carriere azienda
 msgid "license.toc.data"
 msgstr "Dati sugli annunci (CC BY-NC 4.0)"
 
-#. Job detail panel title
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:74
-msgid "search.detail.title"
-msgstr "Dettagli dell'offerta"
-
 #. Job detail panel title in My Jobs
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:161
+#: src/components/my-jobs/my-job-detail-panel.tsx:163
 msgid "myJobs.detail.title"
 msgstr "Dettagli lavoro"
+
+#. Job detail panel title
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:86
+msgid "search.detail.title"
+msgstr "Dettagli dell'offerta"
 
 #. Nav link: Job indexing
 #. Nav link: Job indexing
@@ -1912,7 +1982,7 @@ msgstr "Tieni il polso del mercato del lavoro."
 
 #. Alt text for feature section 2 screenshot
 #. js-lingui-explicit-id
-#: src/components/Features.tsx:224
+#: src/components/Features.tsx:259
 msgid "home.features.s2.screenshot.alt"
 msgstr "Interfaccia Job Seek per inviare link aziendali e configurare avvisi personalizzati"
 
@@ -1941,13 +2011,6 @@ msgstr "Job Seek è in fase di sviluppo attivo. Resta aggiornato per le novità!
 msgid "about.p1"
 msgstr "Job Seek è sviluppato da Colophon Group, un piccolo team di sviluppatori con sede in Svizzera. L'abbiamo creato perché eravamo stanchi dello stesso problema che ogni persona in cerca di lavoro conosce: destreggiarsi tra decine di schede del browser, perdere nuove offerte perché un aggregatore era troppo lento, e annegare nel rumore algoritmico ottimizzato per i clic anziché per la rilevanza."
 
-#. Agentic features section description
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:105
-#: src/components/AgenticFeatures.tsx:47
-msgid "home.agentic.description"
-msgstr "Job Seek non è solo un'interfaccia di ricerca per le persone. Espone anche workflow strutturati per gli agenti che devono cercare lavoro, rilevare annunci fantasma e mappare dove il recruiting si sta accelerando."
-
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/privacy-policy/page.tsx:19
 #: app/[lang]/(public)/privacy-policy/page.tsx:41
@@ -1956,13 +2019,13 @@ msgstr "Informativa sulla privacy di Job Seek — dati personali raccolti, utili
 
 #. Alt text for feature section 1 screenshot
 #. js-lingui-explicit-id
-#: src/components/Features.tsx:164
+#: src/components/Features.tsx:198
 msgid "home.features.s1.screenshot.alt"
 msgstr "Dashboard di Job Seek con candidature monitorate e avvisi aziendali"
 
 #. Alt text for feature section 3 screenshot
 #. js-lingui-explicit-id
-#: src/components/Features.tsx:284
+#: src/components/Features.tsx:320
 msgid "home.features.s3.screenshot.alt"
 msgstr "Watchlist di Job Seek con posizioni selezionate in ingegneria robotica a Zurigo"
 
@@ -1986,13 +2049,13 @@ msgstr "offerte"
 
 #. Job count label in watchlist view
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:215
+#: src/components/watchlist/watchlist-job-list.tsx:226
 msgid "watchlists.jobList.jobCount"
 msgstr "offerte"
 
 #. Plural job count in public watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:111
+#: src/components/watchlist/public-watchlist-search.tsx:119
 msgid "watchlists.explore.jobPlural"
 msgstr "offerte"
 
@@ -2078,16 +2141,16 @@ msgstr "Scopri come Job Seek scansiona le pagine carriere di Workday, Greenhouse
 msgid "home.hero.secondaryCta"
 msgstr "Scopri di più"
 
+#. Section header for seniority suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:522
+msgid "search.bar.level"
+msgstr "Livello"
+
 #. Label for seniority/level filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:154
 msgid "search.advanced.level"
-msgstr "Livello"
-
-#. Section header for seniority suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:567
-msgid "search.bar.level"
 msgstr "Livello"
 
 #. js-lingui-explicit-id
@@ -2104,7 +2167,7 @@ msgstr "Licenza"
 
 #. Footer link to license page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
+#: src/components/Footer.tsx:47
 msgid "common.footer.licenseLink"
 msgstr "Licenza"
 
@@ -2157,17 +2220,17 @@ msgstr "Luogo"
 msgid "search.advanced.location"
 msgstr "Luogo"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:304
-msgid "search.detail.locations"
-msgstr "Località"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:492
+#: src/components/search/search-bar.tsx:592
 msgid "search.bar.locations"
 msgstr "Sedi"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:324
+msgid "search.detail.locations"
+msgstr "Località"
 
 #. Login button label
 #. Login button label
@@ -2191,8 +2254,8 @@ msgstr "Accedi per salvare questa ricerca come watchlist"
 
 #. Feature: share watchlists description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:100
-#: src/components/Features.tsx:277
+#: app/[lang]/(public)/page.tsx:98
+#: src/components/Features.tsx:313
 msgid "home.features.s3.p3.description"
 msgstr "Rendi una watchlist pubblica e condividi il link con amici, community o il tuo network."
 
@@ -2264,7 +2327,7 @@ msgstr "Min"
 
 #. Singular mirror count
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:118
+#: src/components/watchlist/public-watchlist-search.tsx:126
 msgid "watchlists.explore.mirrorSingular"
 msgstr "copia"
 
@@ -2284,14 +2347,14 @@ msgstr "Copia qualsiasi lista pubblica per personalizzarla — modifica le azien
 
 #. Plural mirror count
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:119
+#: src/components/watchlist/public-watchlist-search.tsx:127
 msgid "watchlists.explore.mirrorPlural"
 msgstr "copie"
 
 #. Feature: request companies description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:99
-#: src/components/Features.tsx:272
+#: app/[lang]/(public)/page.tsx:97
+#: src/components/Features.tsx:308
 msgid "home.features.s3.p2.description"
 msgstr "Manca un'azienda? Incolla l'URL della sua pagina carriere e iniziamo a indicizzarla per te."
 
@@ -2326,15 +2389,15 @@ msgstr "altro"
 
 #. Feature: status tracking description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:89
-#: src/components/Features.tsx:207
+#: app/[lang]/(public)/page.tsx:87
+#: src/components/Features.tsx:242
 msgid "home.features.s2.p1.description"
 msgstr "Indicaci qualsiasi pagina carriere o job board su Notion e Job Seek la replica nel tuo spazio di lavoro in pochi minuti."
 
 #. Feature: multi-dimensional filters title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:81
-#: src/components/Features.tsx:151
+#: app/[lang]/(public)/page.tsx:79
+#: src/components/Features.tsx:185
 msgid "home.features.s1.p2.title"
 msgstr "Tracker delle candidature"
 
@@ -2391,12 +2454,6 @@ msgstr "Nome"
 msgid "watchlists.create.nameLabel"
 msgstr "Nome"
 
-#. Agentic features CTA title
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:117
-msgid "home.agentic.cta.title"
-msgstr "Hai bisogno della documentazione a livello di endpoint?"
-
 #. TOC: Need to reach us?
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:33
@@ -2447,13 +2504,13 @@ msgstr "Nessun filtro impostato. Aggiungi filtri per restringere i risultati."
 
 #. No industries match search
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:273
+#: src/components/watchlist/company-search-modal.tsx:276
 msgid "watchlists.companyModal.noIndustries"
 msgstr "Nessun settore trovato."
 
 #. Empty state when no jobs match the time range
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:226
+#: src/components/watchlist/watchlist-job-list.tsx:237
 msgid "watchlists.jobList.empty"
 msgstr "Nessuna offerta trovata."
 
@@ -2463,17 +2520,17 @@ msgstr "Nessuna offerta trovata."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Nessuna lingua corrisponde alla ricerca."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:186
-msgid "company.locationModal.noResults"
-msgstr "Nessuna sede corrisponde alla tua ricerca."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:171
 msgid "search.locationModal.noResults"
 msgstr "Nessun luogo corrisponde alla tua ricerca."
+
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:186
+msgid "company.locationModal.noResults"
+msgstr "Nessuna sede corrisponde alla tua ricerca."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2525,7 +2582,7 @@ msgstr "Nessuna garanzia — l'uso è a proprio rischio e pericolo."
 
 #. No results message when searching public watchlists
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:140
+#: src/components/watchlist/public-watchlist-search.tsx:142
 msgid "watchlists.explore.noResults"
 msgstr "Nessuna lista trovata."
 
@@ -2545,16 +2602,16 @@ msgstr "No. Il tracker delle candidature non ha limiti — salva quante offerte 
 msgid "faq.a.dataPrivacy"
 msgstr "No. Non vendiamo, affittiamo né condividiamo i tuoi dati a fini di marketing. I cookie sono solo di sessione, senza pubblicità né tracciamento. Puoi eliminare il tuo account e tutti i dati verranno cancellati entro 30 giorni."
 
-#. Application tracker status: not applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:440
-msgid "search.tracker.notApplied"
-msgstr "Non candidato"
-
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
+msgstr "Non candidato"
+
+#. Application tracker status: not applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:460
+msgid "search.tracker.notApplied"
 msgstr "Non candidato"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2585,16 +2642,16 @@ msgstr "Professione"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Ott"
 
-#. Application tracker status: offer
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:443
-msgid "search.tracker.offer"
-msgstr "Offerta"
-
 #. Offered status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
+msgstr "Offerta"
+
+#. Application tracker status: offer
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:463
+msgid "search.tracker.offer"
 msgstr "Offerta"
 
 #. Status group heading: offered
@@ -2603,16 +2660,16 @@ msgstr "Offerta"
 msgid "myJobs.group.offered"
 msgstr "Offerta"
 
-#. Sankey funnel node: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:43
-msgid "myJobs.funnel.offered"
-msgstr "Offerta"
-
 #. Status option in dropdown: offered
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:38
 msgid "myJobs.statusOption.offered"
+msgstr "Offerta"
+
+#. Sankey funnel node: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:43
+msgid "myJobs.funnel.offered"
 msgstr "Offerta"
 
 #. Cookie banner accept button
@@ -2649,7 +2706,7 @@ msgstr "In sede"
 
 #. Aria label for mobile menu button
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:86
+#: src/components/Header.tsx:83
 msgid "common.header.openMenu"
 msgstr "Apri menu principale"
 
@@ -2657,18 +2714,6 @@ msgstr "Apri menu principale"
 #: app/[lang]/(app)/company/[slug]/page.tsx:36
 msgid "company.meta.openPositions"
 msgstr "Posizioni aperte"
-
-#. Agentic feature card metadata: ghosting
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:100
-msgid "home.agentic.cards.ghosting.meta"
-msgstr "Livello aperto"
-
-#. Agentic feature card metadata: discovery
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:105
-msgid "home.agentic.cards.discovery.meta"
-msgstr "Livello aperto"
 
 #. Open-source section title
 #. js-lingui-explicit-id
@@ -2736,26 +2781,26 @@ msgstr "La nostra posizione sull'automazione"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Panoramica"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Panoramica"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Contenuti della pagina"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Panoramica"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Contenuti della pagina"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Contenuti della pagina"
 
 #. Heading shown on the 404 page
@@ -2828,7 +2873,7 @@ msgstr "Periodo"
 
 #. Pro tier period
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:116
+#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:73
 msgid "home.pricing.pro.period"
 msgstr "al mese"
@@ -2859,8 +2904,8 @@ msgstr "Colloquio telefonico"
 
 #. Feature section 3 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:96
-#: src/components/Features.tsx:260
+#: app/[lang]/(public)/page.tsx:94
+#: src/components/Features.tsx:296
 msgid "home.features.s3.description"
 msgstr "Scegli le aziende che ti interessano, imposta i filtri e ottieni un feed in tempo reale delle offerte corrispondenti. Condividilo pubblicamente o tienilo privato."
 
@@ -2946,19 +2991,19 @@ msgstr "Accedi per gestire le impostazioni di fatturazione."
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:89
-msgid "search.detail.notFound"
+#: src/components/my-jobs/my-job-detail-panel.tsx:183
+msgid "myJobs.detail.notFound"
 msgstr "Offerta non trovata."
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:181
-msgid "myJobs.detail.notFound"
+#: src/components/search/job-detail-dialog.tsx:101
+msgid "search.detail.notFound"
 msgstr "Offerta non trovata."
 
 #. Pricing section eyebrow
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:112
+#: app/[lang]/(public)/page.tsx:101
 #: src/components/Pricing.tsx:100
 msgid "home.pricing.eyebrow"
 msgstr "Prezzi"
@@ -2979,7 +3024,7 @@ msgstr "Privacy"
 
 #. Footer link to privacy policy page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:57
+#: src/components/Footer.tsx:52
 msgid "common.footer.privacyLink"
 msgstr "Privacy"
 
@@ -3004,7 +3049,7 @@ msgstr "Le liste private sono una funzionalità a pagamento. Effettua l'upgrade 
 
 #. Pro tier name
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:116
+#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:68
 msgid "home.pricing.pro.name"
 msgstr "Pro"
@@ -3026,20 +3071,6 @@ msgstr "Pubblica (visibile ad altri)"
 #: src/components/PublicDomainArt.tsx:62
 msgid "common.art.publicDomain"
 msgstr "Pubblico dominio"
-
-#. Agentic feature card description: discovery
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:109
-#: src/components/AgenticFeatures.tsx:88
-msgid "home.agentic.cards.discovery.description"
-msgstr "Estrai segnali di tendenza da 39+ job board per individuare aziende in espansione, attività in calo e nuove ondate di assunzione prima che diventino ovvie altrove."
-
-#. Agentic feature card description: search
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:107
-#: src/components/AgenticFeatures.tsx:78
-msgid "home.agentic.cards.search.description"
-msgstr "Interroga lavori, aziende e tassonomie di filtri via JSON in modo che copiloti e strumenti interni possano lavorare con lo stesso inventario strutturato del prodotto."
 
 #. Contact call to action
 #. js-lingui-explicit-id
@@ -3097,17 +3128,10 @@ msgstr "Avvisi in tempo reale sulle nuove offerte"
 msgid "myJobs.sort.recentlyUpdated"
 msgstr "Aggiornati di recente"
 
-#. Agentic feature card description: ghosting
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:108
-#: src/components/AgenticFeatures.tsx:83
-msgid "home.agentic.cards.ghosting.description"
-msgstr "Ricostruisci la cronologia delle pubblicazioni da snapshot archiviati per segnalare i ruoli che sembrano rimanere aperti senza reale intenzione di assunzione e restituisci un rapporto su cui il tuo agente può ragionare."
-
 #. Feature: interview log description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:90
-#: src/components/Features.tsx:212
+#: app/[lang]/(public)/page.tsx:88
+#: src/components/Features.tsx:247
 msgid "home.features.s2.p2.description"
 msgstr "Raccogli tutte le startup interessanti in un'unica dashboard invece di destreggiarti tra finestre di Chrome e segnalibri."
 
@@ -3135,16 +3159,16 @@ msgstr "Regione"
 msgid "myJobs.group.rejected"
 msgstr "Rifiutato"
 
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:444
-msgid "search.tracker.rejected"
-msgstr "Rifiutato"
-
 #. Rejected status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:23
 msgid "myJobs.status.rejected"
+msgstr "Rifiutato"
+
+#. Status option in dropdown: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:39
+msgid "myJobs.statusOption.rejected"
 msgstr "Rifiutato"
 
 #. Sankey funnel node label prefix: rejected
@@ -3153,10 +3177,10 @@ msgstr "Rifiutato"
 msgid "myJobs.funnel.rejected"
 msgstr "Rifiutato"
 
-#. Status option in dropdown: rejected
+#. Application tracker status: rejected
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:39
-msgid "myJobs.statusOption.rejected"
+#: src/components/search/job-detail-dialog.tsx:464
+msgid "search.tracker.rejected"
 msgstr "Rifiutato"
 
 #. Footer license summary text
@@ -3179,8 +3203,8 @@ msgstr "Rimuovi località"
 
 #. Feature: request companies title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:99
-#: src/components/Features.tsx:271
+#: app/[lang]/(public)/page.tsx:97
+#: src/components/Features.tsx:307
 msgid "home.features.s3.p2.title"
 msgstr "Richiedi qualsiasi azienda"
 
@@ -3253,12 +3277,6 @@ msgstr "Reimpostazione…"
 msgid "indexing.assurances.i1.title"
 msgstr "Ritmo rispettoso."
 
-#. Agentic features CTA description
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:122
-msgid "home.agentic.cta.description"
-msgstr "Consulta il riferimento API agentico, il modello di autenticazione e le richieste di esempio per ricerca, analisi degli annunci fantasma e scoperta di aziende."
-
 #. Assurance 2 title
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/how-we-index/page.tsx:54
@@ -3274,7 +3292,7 @@ msgstr "Ruolo"
 
 #. Section header for occupation suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:532
+#: src/components/search/search-bar.tsx:487
 msgid "search.bar.roles"
 msgstr "Ruoli"
 
@@ -3284,16 +3302,16 @@ msgstr "Ruoli"
 msgid "myJobs.funnel.round"
 msgstr "Turno"
 
-#. Salary override section heading
-#. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:76
-msgid "myJobs.detail.salary"
-msgstr "Stipendio"
-
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:171
 msgid "search.advanced.salary"
+msgstr "Stipendio"
+
+#. Salary override section heading
+#. js-lingui-explicit-id
+#: src/components/my-jobs/salary-override.tsx:76
+msgid "myJobs.detail.salary"
 msgstr "Stipendio"
 
 #. Salary display settings section heading
@@ -3310,21 +3328,21 @@ msgstr "Fascia salariale"
 
 #. Feature section 2 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:87
-#: src/components/Features.tsx:200
+#: app/[lang]/(public)/page.tsx:85
+#: src/components/Features.tsx:235
 msgid "home.features.s2.description"
 msgstr "Non trovi la tua azienda preferita nel feed? Incolla il link alla pagina carriere e inizieremo a monitorarla per te — niente script, niente fogli di calcolo, niente attese."
 
 #. Feature: watchlists and alerts description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:82
-#: src/components/Features.tsx:157
+#: app/[lang]/(public)/page.tsx:80
+#: src/components/Features.tsx:191
 msgid "home.features.s1.p3.description"
 msgstr "Salva i tuoi filtri per scansioni rapide senza dover riscrivere tutto ogni volta."
 
 #. Save job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:191
+#: src/components/watchlist/watchlist-job-list.tsx:202
 msgid "watchlists.jobList.save"
 msgstr "Salva offerta"
 
@@ -3364,16 +3382,16 @@ msgstr "Salvato"
 msgid "myJobs.status.saved"
 msgstr "Salvato"
 
-#. Sankey funnel node: saved jobs
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:41
-msgid "myJobs.funnel.saved"
-msgstr "Salvato"
-
 #. Status option in dropdown: saved
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:35
 msgid "myJobs.statusOption.saved"
+msgstr "Salvato"
+
+#. Sankey funnel node: saved jobs
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:41
+msgid "myJobs.funnel.saved"
 msgstr "Salvato"
 
 #. Username save button while loading
@@ -3396,8 +3414,8 @@ msgstr "Segui fino a 5 aziende"
 
 #. Feature section 1 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:78
-#: src/components/Features.tsx:140
+#: app/[lang]/(public)/page.tsx:76
+#: src/components/Features.tsx:174
 msgid "home.features.s1.description"
 msgstr "Monitora le posizioni, ricevi notifiche quando le aziende pubblicano qualcosa di nuovo e tieni in ordine la tua pipeline."
 
@@ -3416,9 +3434,15 @@ msgstr "Cerca aziende..."
 
 #. Placeholder for company search in modal
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:213
+#: src/components/watchlist/company-search-modal.tsx:216
 msgid "watchlists.companyModal.searchPlaceholder"
 msgstr "Cerca aziende..."
+
+#. Option to search by title keyword in dropdown
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:475
+msgid "search.bar.keyword"
+msgstr "Cerca \"{trimmedInput}\" nei titoli di lavoro"
 
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/explore/page.tsx:18
@@ -3431,21 +3455,21 @@ msgstr "Cerca lavori in migliaia di aziende, scansionati direttamente dalle pagi
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Cerca lingue…"
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:165
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Cerca sedi…"
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:150
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Cerca luoghi..."
 
+#. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:23
-#: app/[lang]/(public)/page.tsx:48
+#: src/components/search/location-modal.tsx:165
+msgid "company.locationModal.searchPlaceholder"
+msgstr "Cerca sedi…"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/page.tsx:22
+#: app/[lang]/(public)/page.tsx:47
 msgid "home.meta.description"
 msgstr "Cerca milioni di offerte scansionate direttamente da migliaia di pagine carriere. Filtra per livello, stack tecnologico, stipendio e località, e monitora ogni candidatura."
 
@@ -3461,29 +3485,22 @@ msgstr "Risultati di ricerca"
 msgid "search.occupationModal.searchPlaceholder"
 msgstr "Cerca ruoli..."
 
-#. Agentic feature card title: search
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:107
-#: src/components/AgenticFeatures.tsx:61
-msgid "home.agentic.cards.search.title"
-msgstr "Cerca direttamente nell'indice"
-
 #. Placeholder for public watchlist search input
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:84
+#: src/components/watchlist/public-watchlist-search.tsx:92
 msgid "watchlists.explore.searchPlaceholder"
 msgstr "Cerca liste..."
 
 #. Feature section 1 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:76
-#: src/components/Features.tsx:134
+#: app/[lang]/(public)/page.tsx:74
+#: src/components/Features.tsx:168
 msgid "home.features.s1.eyebrow"
 msgstr "Tutto ciò che ti serve per restare al passo"
 
 #. Placeholder for the main search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:391
+#: src/components/search/search-bar.tsx:404
 msgid "search.bar.placeholder"
 msgstr "Cerca…"
 
@@ -3495,8 +3512,8 @@ msgstr "Cerca…"
 
 #. Feature: application stats description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:91
-#: src/components/Features.tsx:217
+#: app/[lang]/(public)/page.tsx:89
+#: src/components/Features.tsx:252
 msgid "home.features.s2.p3.description"
 msgstr "Imposta la frequenza per ogni azienda così ricevi aggiornamenti sulle nuove posizioni senza passare la giornata a scorrere siti di lavoro."
 
@@ -3549,16 +3566,16 @@ msgstr "Invia link"
 msgid "settings.account.password.send"
 msgstr "Invia il link"
 
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Invio in corso..."
-
 #. Resend button while sending
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:96
 msgid "auth.verify.resending"
+msgstr "Invio in corso..."
+
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
 msgstr "Invio in corso..."
 
 #. Reset password button while loading
@@ -3629,8 +3646,8 @@ msgstr "Impostazioni"
 
 #. Feature: share watchlists title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:100
-#: src/components/Features.tsx:276
+#: app/[lang]/(public)/page.tsx:98
+#: src/components/Features.tsx:312
 msgid "home.features.s3.p3.title"
 msgstr "Condividi con chiunque"
 
@@ -3642,7 +3659,7 @@ msgstr "Mostra meno"
 
 #. Button to collapse location list
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:347
+#: src/components/search/job-detail-dialog.tsx:367
 msgid "search.detail.showLessLocations"
 msgstr "Mostra meno"
 
@@ -3744,7 +3761,7 @@ msgstr "Accesso in corso..."
 
 #. Pricing section description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:114
+#: app/[lang]/(public)/page.tsx:103
 #: src/components/Pricing.tsx:106
 msgid "home.pricing.description"
 msgstr "Prezzi semplici e trasparenti. Inizia gratis e passa al piano superiore quando fai sul serio con la tua ricerca di lavoro."
@@ -3828,14 +3845,14 @@ msgstr "Stato"
 
 #. Status section heading
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:198
+#: src/components/my-jobs/my-job-detail-panel.tsx:200
 msgid "myJobs.detail.status"
 msgstr "Stato"
 
 #. Feature: status tracking title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:89
-#: src/components/Features.tsx:206
+#: app/[lang]/(public)/page.tsx:87
+#: src/components/Features.tsx:241
 msgid "home.features.s2.p1.title"
 msgstr "Incolla un link, avvia il crawling"
 
@@ -3864,12 +3881,6 @@ msgstr "Invio in corso..."
 #: src/components/settings/SettingsNav.tsx:31
 msgid "settings.nav.billing"
 msgstr "Abbonamento"
-
-#. Agentic feature card metadata: search
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:95
-msgid "home.agentic.cards.search.meta"
-msgstr "Abbonamento richiesto"
 
 #. FAQ page eyebrow
 #. js-lingui-explicit-id
@@ -3901,16 +3912,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Tecnico"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:389
-msgid "search.detail.technologies"
-msgstr "Tecnologie"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:602
+#: src/components/search/search-bar.tsx:557
 msgid "search.bar.technologies"
+msgstr "Tecnologie"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:409
+msgid "search.detail.technologies"
 msgstr "Tecnologie"
 
 #. Add technology filter
@@ -3939,7 +3950,7 @@ msgstr "Termini di servizio"
 
 #. Footer link to terms of service page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:62
+#: src/components/Footer.tsx:57
 msgid "common.footer.termsLink"
 msgstr "Termini"
 
@@ -4038,14 +4049,14 @@ msgstr "Questa lista di osservazione e tutte le sue impostazioni verranno elimin
 
 #. Date divider label for today
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:79
+#: src/components/watchlist/watchlist-job-list.tsx:81
 msgid "watchlists.jobList.today"
 msgstr "Oggi"
 
 #. Feature section 2 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:85
-#: src/components/Features.tsx:194
+#: app/[lang]/(public)/page.tsx:83
+#: src/components/Features.tsx:229
 msgid "home.features.s2.eyebrow"
 msgstr "Mantieni il controllo"
 
@@ -4102,7 +4113,7 @@ msgstr "Abbonamenti aziendali illimitati"
 
 #. Pro tier description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:116
+#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:77
 msgid "home.pricing.pro.description"
 msgstr "Per chi cerca lavoro attivamente e vuole una copertura illimitata e risultati più rapidi."
@@ -4114,7 +4125,7 @@ msgstr "Watchlist illimitate, avvisi email sui nuovi risultati"
 
 #. Unsave job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:190
+#: src/components/watchlist/watchlist-job-list.tsx:201
 msgid "watchlists.jobList.unsave"
 msgstr "Rimuovi offerta"
 
@@ -4173,7 +4184,7 @@ msgstr "Usa il modulo di richiesta nella pagina Esplora — incolla l'URL di una
 
 #. Fallback username for watchlist owner
 #. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:109
+#: src/components/watchlist/public-watchlist-search.tsx:117
 msgid "watchlists.explore.unknownUser"
 msgstr "utente"
 
@@ -4225,15 +4236,9 @@ msgstr "Verifica dell'email in corso..."
 msgid "myJobs.interviewType.videoCall"
 msgstr "Videochiamata"
 
-#. Agentic features CTA button label
-#. js-lingui-explicit-id
-#: src/components/AgenticFeatures.tsx:137
-msgid "home.agentic.cta.button"
-msgstr "Visualizza la documentazione API"
-
 #. Link to the original job posting
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:186
+#: src/components/search/job-detail-dialog.tsx:198
 msgid "search.detail.viewPosting"
 msgstr "Vedi offerta"
 
@@ -4269,8 +4274,8 @@ msgstr "Liste di osservazione"
 
 #. Feature: watchlists and alerts title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:82
-#: src/components/Features.tsx:156
+#: app/[lang]/(public)/page.tsx:80
+#: src/components/Features.tsx:190
 msgid "home.features.s1.p3.title"
 msgstr "Ricerche salvate"
 
@@ -4351,15 +4356,15 @@ msgstr "Rispettiamo robots.txt e gli header TDM-Reservation, limitiamo le richie
 
 #. Hero description paragraph
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:74
+#: app/[lang]/(public)/page.tsx:72
 #: src/components/Hero.tsx:31
 msgid "home.hero.description"
 msgstr "Scansioniamo le pagine carriere direttamente così vedi le posizioni appena pubblicate. Cerca milioni di offerte in migliaia di aziende — filtra per livello, stack tecnologico, stipendio e località, e monitora ogni candidatura in un unico posto."
 
 #. Feature: direct from source description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:80
-#: src/components/Features.tsx:147
+#: app/[lang]/(public)/page.tsx:78
+#: src/components/Features.tsx:181
 msgid "home.features.s1.p1.description"
 msgstr "Segui le aziende che ti interessano e ricevi una notifica quando pubblicano nuove posizioni."
 
@@ -4466,7 +4471,7 @@ msgstr "Sì. Il crawler e la pipeline di estrazione sono completamente open sour
 
 #. Date divider label for yesterday
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:80
+#: src/components/watchlist/watchlist-job-list.tsx:82
 msgid "watchlists.jobList.yesterday"
 msgstr "Ieri"
 
@@ -4530,8 +4535,8 @@ msgstr "Hai raggiunto il limite delle tue liste di osservazione. Effettua l'upgr
 
 #. Feature section 3 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:94
-#: src/components/Features.tsx:254
+#: app/[lang]/(public)/page.tsx:92
+#: src/components/Features.tsx:290
 msgid "home.features.s3.eyebrow"
 msgstr "Le tue aziende, le tue regole"
 


### PR DESCRIPTION
## Summary

The "Search for X in job titles" option in the search bar dropdown was showing the raw message ID (`search.bar.keyword`) instead of translated text in German, French, and Italian locales.

- Ran `pnpm extract` to sync the catalog
- Added translations for `search.bar.keyword` in de/fr/it
- This was the only missing translation across all 709 message IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)