### PR TITLE
Fix "Tracking N companies" in watchlist social preview

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { isLocale, defaultLocale, loadCatalog } from "@/lib/i18n";
 import {
   getWatchlistByUserAndSlug as _getWatchlistByUserAndSlug,
+  getWatchlistMatchingCompanyCount,
 } from "@/lib/actions/watchlists";
 import { siteConfig } from "@/content/config";
 import { buildAlternates } from "@/lib/seo";
@@ -65,7 +66,13 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
           values: { owner: ownerLabel },
         });
   }
-  const companyCount = detail.companies.length;
+  // For `anyCompany` watchlists, `detail.companies` is unrelated to what the
+  // watchlist actually tracks (it holds leftover rows from source copies).
+  // Ask Typesense how many distinct companies currently have postings matching
+  // the filter so the social preview reflects reality.
+  const companyCount = detail.filters.anyCompany
+    ? await getWatchlistMatchingCompanyCount(detail.filters)
+    : detail.companies.length;
   if (companyCount > 0) {
     description = i18n._({
       id: "watchlist.meta.tracking",

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -562,6 +562,59 @@ function buildFilterCacheKey(f: WatchlistFilters, companyIds: string[]): string 
   return parts.join("|");
 }
 
+/**
+ * Count distinct companies with currently-active postings matching the given
+ * watchlist filters. Used to render an accurate "Tracking N companies" string
+ * in metadata for `anyCompany` watchlists, where `watchlist_company` rows are
+ * unrelated to what the watchlist actually tracks.
+ */
+export async function getWatchlistMatchingCompanyCount(
+  f: WatchlistFilters,
+): Promise<number> {
+  const key = `wl-match-companies:${buildFilterCacheKey(f, [])}`;
+  return cached(key, async () => {
+    const locale = "en";
+    const [locMap, occMap, senMap, techMap] = await Promise.all([
+      f.locationSlugs?.length ? resolveLocationSlugs(f.locationSlugs, locale) : Promise.resolve(new Map()),
+      f.occupationSlugs?.length ? resolveOccupationSlugs(f.occupationSlugs, locale) : Promise.resolve(new Map()),
+      f.senioritySlugs?.length ? resolveSenioritySlugs(f.senioritySlugs, locale) : Promise.resolve(new Map()),
+      f.technologySlugs?.length ? resolveTechnologySlugs(f.technologySlugs) : Promise.resolve(new Map()),
+    ]);
+
+    const filterStr = buildFilterString({
+      locationIds: locMap.size > 0 ? [...locMap.values()].map((l) => l.id) : undefined,
+      occupationIds: occMap.size > 0 ? [...occMap.values()].map((o) => o.id) : undefined,
+      seniorityIds: senMap.size > 0 ? [...senMap.values()].map((s) => s.id) : undefined,
+      technologyIds: techMap.size > 0 ? [...techMap.values()].map((t) => t.id) : undefined,
+      salaryMinEur: f.salaryMin,
+      salaryMaxEur: f.salaryMax,
+      experienceMin: f.experienceMin,
+      experienceMax: f.experienceMax,
+    });
+
+    const fullFilter = `is_active:true${filterStr ? " && " + filterStr : ""}`;
+    const hasKeywords = f.keywords && f.keywords.length > 0;
+    const q = hasKeywords ? f.keywords!.join(" ") : "*";
+
+    try {
+      const client = getSearchClient();
+      const result = await client.collections("job_posting").documents().search({
+        q,
+        query_by: "title",
+        filter_by: fullFilter,
+        facet_by: "company_id",
+        facet_strategy: "exhaustive",
+        max_facet_values: 1,
+        per_page: 0,
+      });
+      return result.facet_counts?.[0]?.stats?.total_values ?? 0;
+    } catch (err) {
+      console.error("[getWatchlistMatchingCompanyCount] Typesense failed", err);
+      return 0;
+    }
+  }, { ttl: 600 });
+}
+
 async function resolveFilteredJobCount(
   watchlistId: string,
   f: WatchlistFilters,


### PR DESCRIPTION
## Summary

- `generateMetadata` for `/[user]/[watchlist]` unconditionally used `detail.companies.length` to render the "Tracking N companies" line in the OG/meta description. For `anyCompany` watchlists, that column holds leftover rows copied from the source watchlist, not the companies the watchlist actually tracks.
- Example: `https://jseek.co/en/colophongroup/swe-zurich` was showing **"Tracking 5 companies"** even though it tracks every company with SWE postings in Zürich.
- For `anyCompany` watchlists, query Typesense with the watchlist filters and facet on `company_id` (`max_facet_values: 1`, `facet_strategy: exhaustive`) to read `facet_counts[0].stats.total_values` — the distinct count of companies with currently active matching postings. Non-`anyCompany` watchlists are untouched.
- Cached in Redis via `cached(...)` with a 600s TTL keyed on the watchlist filter hash (same helper + key shape as `resolveFilteredJobCount`).

## Notes

- Count semantics: companies with **currently active** matching postings (matches the filter used by `_getWatchlistPostingsTypesense`, the main search, and everything else the user sees on the page). If an expired-job-inclusive count is ever wanted, drop the `is_active:true` clause in `getWatchlistMatchingCompanyCount`.
- No UI or i18n string changes — the existing `watchlist.meta.tracking` ICU message is reused.

## Test plan

- [ ] After deploy, re-check `https://jseek.co/en/colophongroup/swe-zurich` — meta description should read "Tracking <real number> companies. All software engineering roles in Zürich."
- [ ] Check a non-`anyCompany` public watchlist — meta description should still use `watchlist_company` count and read the same as before.
- [ ] Check an `anyCompany` watchlist with no matching active postings — should gracefully omit the "Tracking …" prefix (count is 0, branch skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)