### PR TITLE
Fix Hetzner deploy Redis OOM during sync

### DIFF
--- a/apps/crawler/deploy.sh
+++ b/apps/crawler/deploy.sh
@@ -74,7 +74,12 @@ EOF
 # ── Pull images and restart ──────────────────────────────────────────
 cd "$DEPLOY_DIR"
 docker compose pull
-docker compose up -d --remove-orphans
+
+# Keep Redis up for migrations + sync, but quiesce the rest of the
+# crawler so deploy-time `crawler sync` does not race with live workers
+# claiming work out of Redis while we are reseeding board monitors.
+docker compose stop worker-1 worker-2 worker-3 browser-1 exporter drain alloy 2>/dev/null || true
+docker compose up -d redis
 
 # ── Run Alembic migrations on local Postgres ─────────────────────────
 docker run --rm --env-file "$DEPLOY_DIR/.env" --network host \
@@ -85,6 +90,9 @@ docker run --rm --env-file "$DEPLOY_DIR/.env" --network host \
 docker run --rm --env-file "$DEPLOY_DIR/.env" --network host \
   "ghcr.io/${OWNER}/jobseek-crawler:latest" \
   uv run --no-sync crawler sync
+
+# ── Start the full stack on the freshly seeded Redis state ───────────
+docker compose up -d --remove-orphans
 
 # ── Cleanup ──────────────────────────────────────────────────────────
 docker image prune -f

--- a/apps/crawler/docker-compose.yml
+++ b/apps/crawler/docker-compose.yml
@@ -32,10 +32,14 @@ services:
     image: redis:7-alpine
     restart: unless-stopped
     network_mode: host
-    command: redis-server --maxmemory 256mb --maxmemory-policy noeviction --bind 127.0.0.1
+    # Deploy-time sync reseeds ~4.7k board monitors into Redis. 256 MB
+    # leaves too little headroom once steady-state scrape backlog is
+    # already present, so deploys can fail with OOM before sync
+    # completes.
+    command: redis-server --maxmemory 512mb --maxmemory-policy noeviction --bind 127.0.0.1
     volumes:
       - redis-data:/data
-    mem_limit: 320m
+    mem_limit: 768m
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s


### PR DESCRIPTION
## Summary
- stop crawler services before deploy-time `crawler sync` so Redis is reseeded while the queue is quiescent
- start only Redis for migrations and sync, then bring the full stack back up
- raise the Redis memory limits on the Hetzner worker to give the existing queue backlog enough headroom during deploys

## Root cause
The April 15, 2026 `Deploy Crawler (Hetzner)` run failed in `Deploy via SSH` when `crawler sync` hit Redis `OutOfMemoryError` while enqueueing board monitors.

## Verification
- `bash -n apps/crawler/deploy.sh`
- `docker compose -f apps/crawler/docker-compose.yml config --no-interpolate`