### PR TITLE
Fix prod build: move isTrivialWatchlist out of "use server" module

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
@@ -4,8 +4,8 @@ import { isLocale, defaultLocale, loadCatalog } from "@/lib/i18n";
 import {
   getWatchlistByUserAndSlug as _getWatchlistByUserAndSlug,
   getWatchlistMatchingCompanyCount,
-  isTrivialWatchlist,
 } from "@/lib/actions/watchlists";
+import { isTrivialWatchlist } from "@/lib/watchlist-utils";
 import { siteConfig } from "@/content/config";
 import { buildAlternates } from "@/lib/seo";
 import { WatchlistContent } from "./watchlist-content";

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -21,6 +21,7 @@ import {
   deleteWatchlist as tsDeleteWatchlist,
   updateWatchlistField as tsUpdateWatchlistField,
 } from "@/lib/search/typesense-watchlist";
+import { isTrivialWatchlist } from "@/lib/watchlist-utils";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -88,29 +89,6 @@ export type WatchlistPostingEntry = {
     icon: string | null;
   };
 };
-
-// A watchlist is "trivial" when it carries no meaningful filters and tracks
-// no companies — effectively a blank shell. We exclude these from public
-// listings and search engines so they don't dilute the index.
-// `anyCompany` and `salaryCurrency` alone don't count (they're defaults/prefs).
-export function isTrivialWatchlist(
-  filters: WatchlistFilters | null | undefined,
-  companyCount: number,
-): boolean {
-  if (companyCount > 0) return false;
-  const f = filters ?? {};
-  return !(
-    f.keywords?.length ||
-    f.locationSlugs?.length ||
-    f.occupationSlugs?.length ||
-    f.senioritySlugs?.length ||
-    f.technologySlugs?.length ||
-    f.salaryMin != null ||
-    f.salaryMax != null ||
-    f.experienceMin != null ||
-    f.experienceMax != null
-  );
-}
 
 // ── Actions ─────────────────────────────────────────────────────────
 

--- a/apps/web/src/lib/watchlist-utils.ts
+++ b/apps/web/src/lib/watchlist-utils.ts
@@ -1,0 +1,25 @@
+import type { WatchlistFilters } from "@/lib/actions/watchlists";
+
+
+// A watchlist is "trivial" when it carries no meaningful filters and tracks
+// no companies — effectively a blank shell. We exclude these from public
+// listings and search engines so they don't dilute the index.
+// `anyCompany` and `salaryCurrency` alone don't count (they're defaults/prefs).
+export function isTrivialWatchlist(
+  filters: WatchlistFilters | null | undefined,
+  companyCount: number,
+): boolean {
+  if (companyCount > 0) return false;
+  const f = filters ?? {};
+  return !(
+    f.keywords?.length ||
+    f.locationSlugs?.length ||
+    f.occupationSlugs?.length ||
+    f.senioritySlugs?.length ||
+    f.technologySlugs?.length ||
+    f.salaryMin != null ||
+    f.salaryMax != null ||
+    f.experienceMin != null ||
+    f.experienceMax != null
+  );
+}


### PR DESCRIPTION
## Summary
- Production build broke after #2177: `isTrivialWatchlist` is a sync helper exported from `apps/web/src/lib/actions/watchlists.ts`, which has `"use server"` at the top — Server Action files require all exports to be async functions.
- Move `isTrivialWatchlist` to a new plain module `apps/web/src/lib/watchlist-utils.ts` and update the two importers (`watchlists.ts` itself and the watchlist detail page).

## Test plan
- [ ] Vercel preview build succeeds
- [ ] Watchlist create/update still indexes correctly (exercises `isTrivialWatchlist` path)
- [ ] Watchlist detail page renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)