### PR TITLE
Scope search counts to user filters and language

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
@@ -5,6 +5,7 @@ import {
   getWatchlistByUserAndSlug as _getWatchlistByUserAndSlug,
   getWatchlistMatchingCompanyCount,
 } from "@/lib/actions/watchlists";
+import { getViewerLanguages } from "@/lib/viewer";
 import { isTrivialWatchlist } from "@/lib/watchlist-utils";
 import { siteConfig } from "@/content/config";
 import { buildAlternates } from "@/lib/seo";
@@ -70,9 +71,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   // For `anyCompany` watchlists, `detail.companies` is unrelated to what the
   // watchlist actually tracks (it holds leftover rows from source copies).
   // Ask Typesense how many distinct companies currently have postings matching
-  // the filter so the social preview reflects reality.
+  // the filter. Scope by the viewer's language preference so the social
+  // preview / page header match what the user actually sees below.
+  const languages = await getViewerLanguages(locale);
   const companyCount = detail.filters.anyCompany
-    ? await getWatchlistMatchingCompanyCount(detail.filters)
+    ? await getWatchlistMatchingCompanyCount(detail.filters, languages)
     : detail.companies.length;
   if (companyCount > 0) {
     description = i18n._({

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-content.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-content.tsx
@@ -47,6 +47,7 @@ export function WatchlistContent({ lang, userSlug, watchlistSlug }: WatchlistCon
       resolvedOccupations={data.resolvedOccupations}
       resolvedSeniorities={data.resolvedSeniorities}
       resolvedTechnologies={data.resolvedTechnologies}
+      jobLanguages={data.jobLanguages}
       languages={data.languages}
     />
   );

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-content.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-content.tsx
@@ -47,6 +47,7 @@ export function WatchlistContent({ lang, userSlug, watchlistSlug }: WatchlistCon
       resolvedOccupations={data.resolvedOccupations}
       resolvedSeniorities={data.resolvedSeniorities}
       resolvedTechnologies={data.resolvedTechnologies}
+      languages={data.languages}
     />
   );
 }

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
@@ -566,10 +566,9 @@ export function WatchlistViewPage({
       </div>
 
       {/* Language-scope disclosure — watchlist postings are filtered by
-          the viewer's jobLanguages pref, so surface the active scope. */}
-      <div className="flex justify-end">
-        <LanguageNote jobLanguages={jobLanguages} locale={locale} />
-      </div>
+          the viewer's jobLanguages pref, so surface the active scope
+          (left-aligned to match the toolbar convention on explore/company). */}
+      <LanguageNote jobLanguages={jobLanguages} locale={locale} />
 
       {/* Job results */}
       <WatchlistJobList

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
@@ -24,6 +24,7 @@ import { WatchlistActionBar } from "@/components/watchlist/watchlist-action-bar"
 import { WatchlistJobList } from "@/components/watchlist/watchlist-job-list";
 import { FilterPillsReadOnly } from "@/components/search/filter-pills-readonly";
 import { AdvancedSearchPanel } from "@/components/search/advanced-search-panel";
+import { LanguageNote } from "@/components/search/language-note";
 import type { SelectedLocation } from "@/components/search/location-pills";
 import type { HistogramFilters } from "@/lib/search";
 
@@ -42,6 +43,7 @@ export function WatchlistViewPage({
   resolvedOccupations,
   resolvedSeniorities,
   resolvedTechnologies,
+  jobLanguages,
   languages,
 }: {
   detail: WatchlistDetail;
@@ -55,6 +57,7 @@ export function WatchlistViewPage({
   resolvedOccupations: TaxonomyItem[];
   resolvedSeniorities: TaxonomyItem[];
   resolvedTechnologies: TaxonomyItem[];
+  jobLanguages: string[];
   languages: string[];
 }) {
   const { t } = useLingui();
@@ -560,6 +563,12 @@ export function WatchlistViewPage({
             technologies={resolvedTechnologies}
           />
         )}
+      </div>
+
+      {/* Language-scope disclosure — watchlist postings are filtered by
+          the viewer's jobLanguages pref, so surface the active scope. */}
+      <div className="flex justify-end">
+        <LanguageNote jobLanguages={jobLanguages} locale={locale} />
       </div>
 
       {/* Job results */}

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { X, Loader2, MapPin, Briefcase, BarChart3, Code2, DollarSign, Clock, Building2, Pencil } from "lucide-react";
 import { BackLink } from "@/components/BackLink";
@@ -25,6 +25,7 @@ import { WatchlistJobList } from "@/components/watchlist/watchlist-job-list";
 import { FilterPillsReadOnly } from "@/components/search/filter-pills-readonly";
 import { AdvancedSearchPanel } from "@/components/search/advanced-search-panel";
 import type { SelectedLocation } from "@/components/search/location-pills";
+import type { HistogramFilters } from "@/lib/search";
 
 type Company = { id: string; name: string; slug: string; icon: string | null };
 type TaxonomyItem = { id: number; slug: string; name: string };
@@ -41,6 +42,7 @@ export function WatchlistViewPage({
   resolvedOccupations,
   resolvedSeniorities,
   resolvedTechnologies,
+  languages,
 }: {
   detail: WatchlistDetail;
   isOwner: boolean;
@@ -53,6 +55,7 @@ export function WatchlistViewPage({
   resolvedOccupations: TaxonomyItem[];
   resolvedSeniorities: TaxonomyItem[];
   resolvedTechnologies: TaxonomyItem[];
+  languages: string[];
 }) {
   const { t } = useLingui();
   const router = useRouter();
@@ -153,6 +156,14 @@ export function WatchlistViewPage({
   const [salaryMax, setSalaryMax] = useState<number | undefined>(detail.filters.salaryMax);
   const [experienceMin, setExperienceMin] = useState<number | undefined>(detail.filters.experienceMin);
   const [experienceMax, setExperienceMax] = useState<number | undefined>(detail.filters.experienceMax);
+
+  const histogramFilters: HistogramFilters = useMemo(() => ({
+    locationIds: locations.length > 0 ? locations.map((l) => l.id) : undefined,
+    occupationIds: occupations.length > 0 ? occupations.map((o) => o.id) : undefined,
+    seniorityIds: seniorities.length > 0 ? seniorities.map((s) => s.id) : undefined,
+    technologyIds: technologies.length > 0 ? technologies.map((t) => t.id) : undefined,
+    languages: languages.length > 0 ? languages : undefined,
+  }), [locations, occupations, seniorities, technologies, languages]);
 
   // Persist filters to DB (debounced, cleaned up on unmount)
   const saveFiltersTimeout = useRef<ReturnType<typeof setTimeout>>(undefined);
@@ -448,6 +459,7 @@ export function WatchlistViewPage({
                 salaryMax,
                 experienceMin,
                 experienceMax,
+                languages: languages.length > 0 ? languages : undefined,
               }}
             />
           )}
@@ -477,12 +489,7 @@ export function WatchlistViewPage({
               onRemoveTechnology={onRemoveTechnology}
               onSalaryChange={onSalaryChange}
               onExperienceChange={onExperienceChange}
-              histogramFilters={{
-                locationIds: locations.length > 0 ? locations.map((l) => l.id) : undefined,
-                occupationIds: occupations.length > 0 ? occupations.map((o) => o.id) : undefined,
-                seniorityIds: seniorities.length > 0 ? seniorities.map((s) => s.id) : undefined,
-                technologyIds: technologies.length > 0 ? technologies.map((t) => t.id) : undefined,
-              }}
+              histogramFilters={histogramFilters}
             />
             {hasFilters && (
               <div className="flex flex-wrap items-center gap-2">
@@ -569,6 +576,7 @@ export function WatchlistViewPage({
           salaryMax,
           experienceMin,
           experienceMax,
+          languages: languages.length > 0 ? languages : undefined,
         }}
         initialPostings={initialPostings}
         initialTotal={initialTotal}

--- a/apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx
@@ -11,7 +11,7 @@ type WatchlistsData = {
   limitReached: boolean;
 };
 
-export function WatchlistsLoader({ locale: _locale }: { locale: string }) {
+export function WatchlistsLoader({ locale }: { locale: string }) {
   const { user, isPending } = useSession();
   const [data, setData] = useState<WatchlistsData | null>(null);
 
@@ -21,14 +21,14 @@ export function WatchlistsLoader({ locale: _locale }: { locale: string }) {
       setData({ watchlists: [], username: null, limitReached: true });
       return;
     }
-    getUserWatchlists().then((watchlists) => {
+    getUserWatchlists(locale).then((watchlists) => {
       setData({
         watchlists,
         username: user.username ?? null,
         limitReached: false,
       });
     });
-  }, [user, isPending]);
+  }, [user, isPending, locale]);
 
   if (!data) {
     return (

--- a/apps/web/app/api/v1/watchlists/route.ts
+++ b/apps/web/app/api/v1/watchlists/route.ts
@@ -20,8 +20,9 @@ export async function GET(request: NextRequest) {
         query: q,
         offset: 0,
         limit: MAX_RESULTS,
+        locale,
       })
-    : await getPopularWatchlists({ offset: 0, limit: MAX_RESULTS });
+    : await getPopularWatchlists({ offset: 0, limit: MAX_RESULTS, locale });
 
   const watchlists = result.watchlists.map((w) => ({
     title: w.title,

--- a/apps/web/src/components/search/language-note.tsx
+++ b/apps/web/src/components/search/language-note.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { Trans } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { getLanguage } from "@/lib/job-languages";
 
 interface LanguageNoteProps {
@@ -12,6 +12,7 @@ interface LanguageNoteProps {
 }
 
 export function LanguageNote({ jobLanguages, locale }: LanguageNoteProps) {
+  const { t } = useLingui();
   const params = useParams();
   const lang = (params.lang as string) ?? locale;
   const settingsHref = `/${lang}/settings`;
@@ -28,8 +29,19 @@ export function LanguageNote({ jobLanguages, locale }: LanguageNoteProps) {
   const shownNames = allNames.slice(0, MAX_INLINE).join(", ");
   const remaining = displayCodes.length - MAX_INLINE;
 
+  const changeLabel = t({
+    id: "search.languageNote.changeAria",
+    comment: "Aria label for the change link in the language note",
+    message: "Change job language preference",
+  });
+
   const changeLink = (
-    <Link href={settingsHref} prefetch={false} className="text-primary hover:underline">
+    <Link
+      href={settingsHref}
+      prefetch={false}
+      className="text-primary hover:underline"
+      aria-label={changeLabel}
+    >
       <Trans id="search.languageNote.change" comment="Link to change language settings">
         change
       </Trans>
@@ -38,7 +50,7 @@ export function LanguageNote({ jobLanguages, locale }: LanguageNoteProps) {
 
   if (isAll) {
     return (
-      <p className="shrink-0 text-xs text-muted">
+      <p role="status" className="shrink-0 text-xs text-muted">
         <Trans id="search.languageNote.all" comment="Note showing jobs in all languages">
           Showing jobs in all languages
         </Trans>
@@ -49,7 +61,7 @@ export function LanguageNote({ jobLanguages, locale }: LanguageNoteProps) {
   }
 
   return (
-    <p className="shrink-0 text-xs text-muted">
+    <p role="status" className="shrink-0 text-xs text-muted">
       {remaining > 0 ? (
         <Trans
           id="search.languageNote.withMore"

--- a/apps/web/src/components/search/search-bar.tsx
+++ b/apps/web/src/components/search/search-bar.tsx
@@ -45,6 +45,8 @@ interface SearchBarProps {
   occupations?: { id: number; slug: string; name: string }[];
   seniorities?: { id: number; slug: string; name: string }[];
   technologies?: { id: number; slug: string; name: string }[];
+  languages?: string[];
+  companyId?: string;
   userLat?: number;
   userLng?: number;
   className?: string;
@@ -63,6 +65,8 @@ export function SearchBar({
   occupations: occupationsProp,
   seniorities: senioritiesProp,
   technologies: technologiesProp,
+  languages: languagesProp,
+  companyId,
   userLat: serverLat,
   userLng: serverLng,
   className,
@@ -130,6 +134,16 @@ export function SearchBar({
   const selectedSeniorityIds = new Set((senioritiesProp ?? []).map((s) => s.id));
   const selectedTechnologyIds = new Set((technologiesProp ?? []).map((t) => t.id));
 
+  // Filter context shared across typeahead boost queries. Each suggest*
+  // call omits the dimension it's suggesting (same convention as the
+  // browse-all modals) so users see counts under their *other* filters.
+  const baseLocationIds = locationsProp?.length ? locationsProp.map((l) => l.id) : undefined;
+  const baseOccupationIds = occupationsProp?.length ? occupationsProp.map((o) => o.id) : undefined;
+  const baseSeniorityIds = senioritiesProp?.length ? senioritiesProp.map((s) => s.id) : undefined;
+  const baseTechnologyIds = technologiesProp?.length ? technologiesProp.map((t) => t.id) : undefined;
+  const baseLanguages = languagesProp?.length ? languagesProp : undefined;
+  const baseKeywords = currentKeywords.length > 0 ? currentKeywords : undefined;
+
   // Build flat list for keyboard navigation
   // "keyword" option first so user can search by title, then structured suggestions
   const trimmedInput = inputValue.trim();
@@ -163,31 +177,77 @@ export function SearchBar({
           setCompanyResults(companies);
           if (companies.length > 0) setIsOpen(true);
         });
-        suggestLocations({ query, locale: lang, userLat, userLng }).then((locs) => {
+        suggestLocations({
+          query,
+          locale: lang,
+          userLat,
+          userLng,
+          filters: {
+            companyId,
+            keywords: baseKeywords,
+            occupationIds: baseOccupationIds,
+            seniorityIds: baseSeniorityIds,
+            technologyIds: baseTechnologyIds,
+            languages: baseLanguages,
+          },
+        }).then((locs) => {
           const filtered = selectedLocationIds
             ? locs.filter((r) => !selectedLocationIds.has(r.id))
             : locs.filter((r) => !selectedLocationSlugs.has(r.slug));
           setLocationResults(filtered);
           if (filtered.length > 0) setIsOpen(true);
         });
-        suggestOccupations({ query, locale: lang }).then((occs) => {
+        suggestOccupations({
+          query,
+          locale: lang,
+          filters: {
+            companyId,
+            keywords: baseKeywords,
+            locationIds: baseLocationIds,
+            seniorityIds: baseSeniorityIds,
+            technologyIds: baseTechnologyIds,
+            languages: baseLanguages,
+          },
+        }).then((occs) => {
           const filtered = occs.filter((r) => !selectedOccupationIds.has(r.id));
           setOccupationResults(filtered);
           if (filtered.length > 0) setIsOpen(true);
         });
-        suggestSeniorities({ query, locale: lang }).then((sens) => {
+        suggestSeniorities({
+          query,
+          locale: lang,
+          filters: {
+            companyId,
+            keywords: baseKeywords,
+            locationIds: baseLocationIds,
+            occupationIds: baseOccupationIds,
+            technologyIds: baseTechnologyIds,
+            languages: baseLanguages,
+          },
+        }).then((sens) => {
           const filtered = sens.filter((r) => !selectedSeniorityIds.has(r.id));
           setSeniorityResults(filtered);
           if (filtered.length > 0) setIsOpen(true);
         });
-        suggestTechnologies({ query, locale: lang }).then((techs) => {
+        suggestTechnologies({
+          query,
+          locale: lang,
+          filters: {
+            companyId,
+            keywords: baseKeywords,
+            locationIds: baseLocationIds,
+            occupationIds: baseOccupationIds,
+            seniorityIds: baseSeniorityIds,
+            languages: baseLanguages,
+          },
+        }).then((techs) => {
           const filtered = techs.filter((r) => !selectedTechnologyIds.has(r.id));
           setTechnologyResults(filtered);
           if (filtered.length > 0) setIsOpen(true);
         });
       }, 200);
     },
-    [lang, userLat, userLng, selectedLocationIds, selectedLocationSlugs, selectedOccupationIds, selectedSeniorityIds, selectedTechnologyIds],
+    [lang, userLat, userLng, companyId, selectedLocationIds, selectedLocationSlugs, selectedOccupationIds, selectedSeniorityIds, selectedTechnologyIds, baseKeywords, baseLanguages, baseLocationIds, baseOccupationIds, baseSeniorityIds, baseTechnologyIds],
   );
 
   const selectItem = useCallback(

--- a/apps/web/src/components/search/search-bar.tsx
+++ b/apps/web/src/components/search/search-bar.tsx
@@ -170,6 +170,26 @@ export function SearchBar({
         setIsOpen(false);
         return;
       }
+      // Build the shared filter context for typeahead boost once; each
+      // suggest* call omits its own dimension so the boost query re-ranks
+      // candidates against the viewer's *other* filters (matches the
+      // browse-all-modal convention and prevents sticky self-matches).
+      const baseFilters = {
+        companyId,
+        keywords: baseKeywords,
+        locationIds: baseLocationIds,
+        occupationIds: baseOccupationIds,
+        seniorityIds: baseSeniorityIds,
+        technologyIds: baseTechnologyIds,
+        languages: baseLanguages,
+      };
+      const filtersExcluding = (
+        omit: "locationIds" | "occupationIds" | "seniorityIds" | "technologyIds",
+      ) => {
+        const { [omit]: _omitted, ...rest } = baseFilters;
+        return rest;
+      };
+
       debounceRef.current = setTimeout(() => {
         // Fire all requests independently so results appear as they arrive
         setActiveIndex(-1);
@@ -182,14 +202,7 @@ export function SearchBar({
           locale: lang,
           userLat,
           userLng,
-          filters: {
-            companyId,
-            keywords: baseKeywords,
-            occupationIds: baseOccupationIds,
-            seniorityIds: baseSeniorityIds,
-            technologyIds: baseTechnologyIds,
-            languages: baseLanguages,
-          },
+          filters: filtersExcluding("locationIds"),
         }).then((locs) => {
           const filtered = selectedLocationIds
             ? locs.filter((r) => !selectedLocationIds.has(r.id))
@@ -200,14 +213,7 @@ export function SearchBar({
         suggestOccupations({
           query,
           locale: lang,
-          filters: {
-            companyId,
-            keywords: baseKeywords,
-            locationIds: baseLocationIds,
-            seniorityIds: baseSeniorityIds,
-            technologyIds: baseTechnologyIds,
-            languages: baseLanguages,
-          },
+          filters: filtersExcluding("occupationIds"),
         }).then((occs) => {
           const filtered = occs.filter((r) => !selectedOccupationIds.has(r.id));
           setOccupationResults(filtered);
@@ -216,14 +222,7 @@ export function SearchBar({
         suggestSeniorities({
           query,
           locale: lang,
-          filters: {
-            companyId,
-            keywords: baseKeywords,
-            locationIds: baseLocationIds,
-            occupationIds: baseOccupationIds,
-            technologyIds: baseTechnologyIds,
-            languages: baseLanguages,
-          },
+          filters: filtersExcluding("seniorityIds"),
         }).then((sens) => {
           const filtered = sens.filter((r) => !selectedSeniorityIds.has(r.id));
           setSeniorityResults(filtered);
@@ -232,14 +231,7 @@ export function SearchBar({
         suggestTechnologies({
           query,
           locale: lang,
-          filters: {
-            companyId,
-            keywords: baseKeywords,
-            locationIds: baseLocationIds,
-            occupationIds: baseOccupationIds,
-            seniorityIds: baseSeniorityIds,
-            languages: baseLanguages,
-          },
+          filters: filtersExcluding("technologyIds"),
         }).then((techs) => {
           const filtered = techs.filter((r) => !selectedTechnologyIds.has(r.id));
           setTechnologyResults(filtered);

--- a/apps/web/src/components/search/search-toolbar.tsx
+++ b/apps/web/src/components/search/search-toolbar.tsx
@@ -117,6 +117,8 @@ export function SearchToolbar({
           occupations={occupations}
           seniorities={seniorities}
           technologies={technologies}
+          languages={histogramFilters?.languages}
+          companyId={histogramFilters?.companyId}
           userLat={userLat}
           userLng={userLng}
           placeholder={searchPlaceholder}

--- a/apps/web/src/components/watchlist/company-search-modal.tsx
+++ b/apps/web/src/components/watchlist/company-search-modal.tsx
@@ -30,6 +30,7 @@ export interface CompanySearchFilters {
   salaryMax?: number;
   experienceMin?: number;
   experienceMax?: number;
+  languages?: string[];
 }
 
 export function CompanySearchModal({

--- a/apps/web/src/components/watchlist/public-watchlist-search.tsx
+++ b/apps/web/src/components/watchlist/public-watchlist-search.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect, useCallback } from "react";
+import { useParams } from "next/navigation";
 import Link from "next/link";
 import { Search, Loader2, Copy } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
@@ -16,6 +17,8 @@ import {
 const PAGE_SIZE = 10;
 
 export function PublicWatchlistSearch() {
+  const params = useParams();
+  const locale = (params.lang as string) ?? "en";
   const { t } = useLingui();
   const lp = useLocalePath();
   const [query, setQuery] = useState("");
@@ -30,8 +33,8 @@ export function PublicWatchlistSearch() {
 
   const fetchPage = useCallback(async (q: string, offset: number, append: boolean) => {
     const fetcher = q.length >= 2
-      ? () => searchPublicWatchlists({ query: q, offset, limit: PAGE_SIZE })
-      : () => getPopularWatchlists({ offset, limit: PAGE_SIZE });
+      ? () => searchPublicWatchlists({ query: q, offset, limit: PAGE_SIZE, locale })
+      : () => getPopularWatchlists({ offset, limit: PAGE_SIZE, locale });
 
     const newMode = q.length >= 2 ? "search" : "popular";
 
@@ -51,7 +54,7 @@ export function PublicWatchlistSearch() {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [locale]);
 
   // Initial load + search on query change
   useEffect(() => {

--- a/apps/web/src/components/watchlist/watchlist-job-list.tsx
+++ b/apps/web/src/components/watchlist/watchlist-job-list.tsx
@@ -32,6 +32,7 @@ export interface WatchlistJobListFilters {
   salaryMax?: number;
   experienceMin?: number;
   experienceMax?: number;
+  languages?: string[];
 }
 
 function formatDateDivider(dateStr: string, todayLabel: string, yesterdayLabel: string): string {

--- a/apps/web/src/lib/actions/company-page-data.ts
+++ b/apps/web/src/lib/actions/company-page-data.ts
@@ -3,7 +3,7 @@
 import { getCompanyBySlug, getCompanyPostings, type CompanyDetail } from "@/lib/actions/company";
 import { parseSearchFilters, type ParsedSearchFilters } from "@/lib/actions/search-input";
 import { getPreferences } from "@/lib/actions/preferences";
-import { resolveJobLanguages } from "@/lib/job-languages";
+import { getViewerLanguages } from "@/lib/viewer";
 import { firstOf, idsOrUndefined, parseRangeParam, getGeoFromHeaders } from "@/lib/search/params";
 import type { SearchResultPosting } from "@/lib/search";
 
@@ -51,13 +51,13 @@ export async function fetchCompanyPageData(params: {
 
   const { userLat, userLng } = await getGeoFromHeaders();
 
-  const [parsed, prefs] = await Promise.all([
+  const [parsed, prefs, languages] = await Promise.all([
     parseSearchFilters({ q, loc, occ, sen, tech, locale, userLat, userLng }),
     getPreferences(),
+    getViewerLanguages(locale),
   ]);
 
   const jobLanguages = prefs?.jobLanguages ?? [];
-  const languages = resolveJobLanguages(jobLanguages, locale);
   const displayCurrency = prefs?.displayCurrency ?? "EUR";
 
   const locationIds = idsOrUndefined(parsed.locations);

--- a/apps/web/src/lib/actions/company.ts
+++ b/apps/web/src/lib/actions/company.ts
@@ -100,6 +100,7 @@ export async function searchCompaniesForWatchlist(params: {
   salaryMax?: number;
   experienceMin?: number;
   experienceMax?: number;
+  languages?: string[];
   starredCompanyIds?: string[];
 }): Promise<{ companies: CompanyListEntry[]; total: number }> {
   try {
@@ -125,6 +126,7 @@ async function _searchCompaniesForWatchlistTypesense(params: {
   salaryMax?: number;
   experienceMin?: number;
   experienceMax?: number;
+  languages?: string[];
   starredCompanyIds?: string[];
 }): Promise<{ companies: CompanyListEntry[]; total: number }> {
   const client = getSearchClient();
@@ -143,6 +145,7 @@ async function _searchCompaniesForWatchlistTypesense(params: {
     salaryMaxEur: params.salaryMax,
     experienceMin: params.experienceMin,
     experienceMax: params.experienceMax,
+    languages: params.languages,
   });
 
   const hasWatchlistFilters = watchlistFilterStr.length > 0 || (params.keywords && params.keywords.length > 0);
@@ -358,6 +361,7 @@ async function _searchCompaniesForWatchlistPostgres(params: {
   salaryMax?: number;
   experienceMin?: number;
   experienceMax?: number;
+  languages?: string[];
   starredCompanyIds?: string[];
 }): Promise<{ companies: CompanyListEntry[]; total: number }> {
   const q = params.query?.trim().toLowerCase();
@@ -424,6 +428,11 @@ async function _searchCompaniesForWatchlistPostgres(params: {
     } else {
       jobClauses.push(sql`(jp.experience_min IS NULL OR jp.experience_min <= ${params.experienceMax!})`);
     }
+  }
+  // Match Typesense semantics: include postings with no detected language.
+  if (params.languages && params.languages.length > 0) {
+    const a = `{${params.languages.join(",")}}`;
+    jobClauses.push(sql`(jp.locales && ${a}::text[] OR cardinality(jp.locales) = 0)`);
   }
   const jobWhere = sql.join(jobClauses, sql` AND `);
 

--- a/apps/web/src/lib/actions/company.ts
+++ b/apps/web/src/lib/actions/company.ts
@@ -11,6 +11,7 @@ import { expandOccupationIds } from "@/lib/actions/taxonomy";
 import { ANON_MAX_POSTINGS } from "@/lib/search/constants";
 import { getSearchClient } from "@/lib/search/typesense-client";
 import { buildFilterString } from "@/lib/search/typesense-filters";
+import { localesOrNoneClause } from "@/lib/search/pg-filters";
 
 // ── Company suggestions (search bar autocomplete) ───────────────────
 
@@ -429,11 +430,8 @@ async function _searchCompaniesForWatchlistPostgres(params: {
       jobClauses.push(sql`(jp.experience_min IS NULL OR jp.experience_min <= ${params.experienceMax!})`);
     }
   }
-  // Match Typesense semantics: include postings with no detected language.
-  if (params.languages && params.languages.length > 0) {
-    const a = `{${params.languages.join(",")}}`;
-    jobClauses.push(sql`(jp.locales && ${a}::text[] OR cardinality(jp.locales) = 0)`);
-  }
+  const localesClause = localesOrNoneClause(params.languages);
+  if (localesClause) jobClauses.push(localesClause);
   const jobWhere = sql.join(jobClauses, sql` AND `);
 
   const [totalRow] = await db.execute<{ [key: string]: unknown; cnt: number }>(sql`

--- a/apps/web/src/lib/actions/explore-data.ts
+++ b/apps/web/src/lib/actions/explore-data.ts
@@ -3,7 +3,7 @@
 import { searchJobs, listTopCompanies } from "@/lib/actions/search";
 import { parseSearchFilters, type ParsedSearchFilters } from "@/lib/actions/search-input";
 import { getPreferences } from "@/lib/actions/preferences";
-import { resolveJobLanguages } from "@/lib/job-languages";
+import { getViewerLanguages } from "@/lib/viewer";
 import { firstOf, idsOrUndefined, parseRangeParam, getGeoFromHeaders } from "@/lib/search/params";
 import type { SearchResponse } from "@/lib/search";
 
@@ -41,13 +41,13 @@ export async function fetchExploreData(params: {
 
   const { userLat, userLng } = await getGeoFromHeaders();
 
-  const [parsed, prefs] = await Promise.all([
+  const [parsed, prefs, languages] = await Promise.all([
     parseSearchFilters({ q, loc, occ, sen, tech, locale, userLat, userLng }),
     getPreferences(),
+    getViewerLanguages(locale),
   ]);
 
   const jobLanguages = prefs?.jobLanguages ?? [];
-  const languages = resolveJobLanguages(jobLanguages, locale);
   const displayCurrency = prefs?.displayCurrency ?? "EUR";
 
   const locationIds = idsOrUndefined(parsed.locations);

--- a/apps/web/src/lib/actions/locations.ts
+++ b/apps/web/src/lib/actions/locations.ts
@@ -5,6 +5,7 @@ import { db } from "@/db";
 import { cached } from "@/lib/cache";
 import { getTypesenseClient, type TypesenseHit } from "@/lib/search/typesense-client";
 import { buildFilterString } from "@/lib/search/typesense-filters";
+import { boostByFilterMatches, type TypeaheadBoostFilters } from "@/lib/search/typeahead-boost";
 
 export interface LocationSuggestion {
   id: number;
@@ -19,6 +20,7 @@ export async function suggestLocations(params: {
   locale: string;
   userLat?: number;
   userLng?: number;
+  filters?: TypeaheadBoostFilters;
 }): Promise<LocationSuggestion[]> {
   const q = params.query.trim();
   if (q.length < 2) return [];
@@ -52,7 +54,17 @@ export async function suggestLocations(params: {
 
     if (!result.hits || result.hits.length === 0) return [];
 
-    return result.hits.map((hit) => _mapLocationHit(hit as unknown as TypesenseHit, locale));
+    const suggestions = result.hits.map((hit) =>
+      _mapLocationHit(hit as unknown as TypesenseHit, locale),
+    );
+
+    if (!params.filters) return suggestions;
+    return boostByFilterMatches(
+      suggestions,
+      "location_ids",
+      (s) => s.id,
+      params.filters,
+    );
   } catch {
     // Typesense unavailable — return empty (graceful degradation)
     return [];

--- a/apps/web/src/lib/actions/preferences.ts
+++ b/apps/web/src/lib/actions/preferences.ts
@@ -7,8 +7,19 @@ import { account, userPreferences } from "@/db/schema";
 import { auth } from "@/lib/auth";
 import { getSession, getSessionUserId } from "@/lib/sessionCache";
 import { cached } from "@/lib/cache";
+import { getLanguage } from "@/lib/job-languages";
 
 const PASSWORD_RESET_COOLDOWN_SECONDS = 60;
+
+/**
+ * jobLanguages flows into Typesense `filter_by` strings and Postgres array
+ * literals via raw interpolation, so we whitelist at the write boundary.
+ * Anything not a known language code (or the "*" all-languages sentinel)
+ * is silently dropped to keep the array shape predictable.
+ */
+function sanitizeJobLanguages(input: string[]): string[] {
+  return input.filter((c) => c === "*" || getLanguage(c) != null);
+}
 
 export async function getPreferences() {
   const session = await getSession();
@@ -63,7 +74,7 @@ export async function updatePreferences(
     }
 
     if (data.jobLanguages !== undefined) {
-      set.jobLanguages = data.jobLanguages;
+      set.jobLanguages = sanitizeJobLanguages(data.jobLanguages);
     }
 
     if (data.displayCurrency !== undefined) {
@@ -110,7 +121,7 @@ export async function updatePreferences(
       userId,
       theme: data.theme ?? "light",
       locale: data.locale ?? "en",
-      jobLanguages: data.jobLanguages ?? [],
+      jobLanguages: data.jobLanguages ? sanitizeJobLanguages(data.jobLanguages) : [],
       displayCurrency: data.displayCurrency ?? "EUR",
       cookieConsent: data.cookieConsent ?? false,
       themeUpdatedAt: data.themeUpdatedAt ? new Date(data.themeUpdatedAt) : new Date(),

--- a/apps/web/src/lib/actions/taxonomy.ts
+++ b/apps/web/src/lib/actions/taxonomy.ts
@@ -5,6 +5,7 @@ import { db } from "@/db";
 import { cached } from "@/lib/cache";
 import { getTypesenseClient, type TypesenseHit } from "@/lib/search/typesense-client";
 import { buildFilterString } from "@/lib/search/typesense-filters";
+import { boostByFilterMatches, type TypeaheadBoostFilters } from "@/lib/search/typeahead-boost";
 
 export interface TaxonomySuggestion {
   id: number;
@@ -19,6 +20,7 @@ export interface TaxonomySuggestion {
 export async function suggestOccupations(params: {
   query: string;
   locale: string;
+  filters?: TypeaheadBoostFilters;
 }): Promise<TaxonomySuggestion[]> {
   const q = params.query.trim();
   if (q.length < 2) return [];
@@ -53,7 +55,17 @@ export async function suggestOccupations(params: {
 
     if (!result.hits || result.hits.length === 0) return [];
 
-    return result.hits.map((hit) => _mapOccupationHit(hit as unknown as TypesenseHit));
+    const suggestions = result.hits.map((hit) =>
+      _mapOccupationHit(hit as unknown as TypesenseHit),
+    );
+
+    if (!params.filters) return suggestions;
+    return boostByFilterMatches(
+      suggestions,
+      "occupation_id",
+      (s) => s.id,
+      params.filters,
+    );
   } catch {
     return [];
   }
@@ -77,6 +89,7 @@ function _mapOccupationHit(hit: TypesenseHit): TaxonomySuggestion {
 export async function suggestSeniorities(params: {
   query: string;
   locale: string;
+  filters?: TypeaheadBoostFilters;
 }): Promise<TaxonomySuggestion[]> {
   const q = params.query.trim();
   if (q.length < 2) return [];
@@ -110,7 +123,17 @@ export async function suggestSeniorities(params: {
 
     if (!result.hits || result.hits.length === 0) return [];
 
-    return result.hits.map((hit) => _mapSeniorityHit(hit as unknown as TypesenseHit));
+    const suggestions = result.hits.map((hit) =>
+      _mapSeniorityHit(hit as unknown as TypesenseHit),
+    );
+
+    if (!params.filters) return suggestions;
+    return boostByFilterMatches(
+      suggestions,
+      "seniority_id",
+      (s) => s.id,
+      params.filters,
+    );
   } catch {
     return [];
   }
@@ -134,6 +157,7 @@ function _mapSeniorityHit(hit: TypesenseHit): TaxonomySuggestion {
 export async function suggestTechnologies(params: {
   query: string;
   locale: string;
+  filters?: TypeaheadBoostFilters;
 }): Promise<TaxonomySuggestion[]> {
   const q = params.query.trim();
   if (q.length < 2) return [];
@@ -153,7 +177,7 @@ export async function suggestTechnologies(params: {
 
     if (!result.hits || result.hits.length === 0) return [];
 
-    return result.hits.map((hit) => {
+    const suggestions = result.hits.map((hit) => {
       const doc = (hit as unknown as TypesenseHit).document;
       return {
         id: doc.technology_id as number,
@@ -161,6 +185,14 @@ export async function suggestTechnologies(params: {
         name: (doc.name ?? doc.slug) as string,
       };
     });
+
+    if (!params.filters) return suggestions;
+    return boostByFilterMatches(
+      suggestions,
+      "technology_ids",
+      (s) => s.id,
+      params.filters,
+    );
   } catch {
     return [];
   }

--- a/apps/web/src/lib/actions/watchlist-page-data.ts
+++ b/apps/web/src/lib/actions/watchlist-page-data.ts
@@ -8,6 +8,8 @@ import { getSession } from "@/lib/sessionCache";
 import { getUserPlan, PLAN_LIMITS, canCreateWatchlist } from "@/lib/plans";
 import { resolveLocationSlugs } from "@/lib/actions/locations";
 import { resolveOccupationSlugs, resolveSenioritySlugs, resolveTechnologySlugs } from "@/lib/actions/taxonomy";
+import { getPreferences } from "@/lib/actions/preferences";
+import { resolveJobLanguages } from "@/lib/job-languages";
 import type { WatchlistPostingEntry } from "@/lib/actions/watchlists";
 
 export interface WatchlistPageData {
@@ -21,6 +23,8 @@ export interface WatchlistPageData {
   resolvedOccupations: { id: number; slug: string; name: string }[];
   resolvedSeniorities: { id: number; slug: string; name: string }[];
   resolvedTechnologies: { id: number; slug: string; name: string }[];
+  jobLanguages: string[];
+  languages: string[];
 }
 
 export async function fetchWatchlistPageData(params: {
@@ -36,12 +40,16 @@ export async function fetchWatchlistPageData(params: {
   const session = await getSession();
   const isOwner = session?.user?.id === detail.owner.id;
 
-  const [plan, limit] = await Promise.all([
+  const [plan, limit, prefs] = await Promise.all([
     session ? getUserPlan(session.user.id) : ("free" as const),
     session ? canCreateWatchlist(session.user.id) : { allowed: false, current: 0, max: 0 },
+    session ? getPreferences() : Promise.resolve(null),
   ]);
   const isPaidPlan = PLAN_LIMITS[plan].canReceiveAlerts;
   const limitReached = !limit.allowed;
+
+  const jobLanguages = prefs?.jobLanguages ?? [];
+  const languages = resolveJobLanguages(jobLanguages, locale);
 
   const filters = detail.filters;
 
@@ -91,6 +99,7 @@ export async function fetchWatchlistPageData(params: {
     salaryMax: filters.salaryMax,
     experienceMin: filters.experienceMin,
     experienceMax: filters.experienceMax,
+    languages,
   });
 
   return {
@@ -104,5 +113,7 @@ export async function fetchWatchlistPageData(params: {
     resolvedOccupations,
     resolvedSeniorities,
     resolvedTechnologies,
+    jobLanguages,
+    languages,
   };
 }

--- a/apps/web/src/lib/actions/watchlist-page-data.ts
+++ b/apps/web/src/lib/actions/watchlist-page-data.ts
@@ -9,7 +9,7 @@ import { getUserPlan, PLAN_LIMITS, canCreateWatchlist } from "@/lib/plans";
 import { resolveLocationSlugs } from "@/lib/actions/locations";
 import { resolveOccupationSlugs, resolveSenioritySlugs, resolveTechnologySlugs } from "@/lib/actions/taxonomy";
 import { getPreferences } from "@/lib/actions/preferences";
-import { resolveJobLanguages } from "@/lib/job-languages";
+import { getViewerLanguages } from "@/lib/viewer";
 import type { WatchlistPostingEntry } from "@/lib/actions/watchlists";
 
 export interface WatchlistPageData {
@@ -40,16 +40,16 @@ export async function fetchWatchlistPageData(params: {
   const session = await getSession();
   const isOwner = session?.user?.id === detail.owner.id;
 
-  const [plan, limit, prefs] = await Promise.all([
+  const [plan, limit, prefs, languages] = await Promise.all([
     session ? getUserPlan(session.user.id) : ("free" as const),
     session ? canCreateWatchlist(session.user.id) : { allowed: false, current: 0, max: 0 },
     session ? getPreferences() : Promise.resolve(null),
+    getViewerLanguages(locale),
   ]);
   const isPaidPlan = PLAN_LIMITS[plan].canReceiveAlerts;
   const limitReached = !limit.allowed;
 
   const jobLanguages = prefs?.jobLanguages ?? [];
-  const languages = resolveJobLanguages(jobLanguages, locale);
 
   const filters = detail.filters;
 

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -7,9 +7,8 @@ import {
   watchlistCompany,
   company,
 } from "@/db/schema";
-import { getSession, getSessionUserId } from "@/lib/sessionCache";
-import { getPreferences } from "@/lib/actions/preferences";
-import { resolveJobLanguages } from "@/lib/job-languages";
+import { getSessionUserId } from "@/lib/sessionCache";
+import { getViewerLanguages } from "@/lib/viewer";
 import { cached } from "@/lib/cache";
 import { canCreateWatchlist, getUserPlan, PLAN_LIMITS } from "@/lib/plans";
 import { generateUniqueSlug } from "@/lib/watchlist-slug";
@@ -18,6 +17,7 @@ import { expandLocationIds, resolveLocationSlugs } from "@/lib/actions/locations
 import { expandOccupationIds, resolveOccupationSlugs, resolveSenioritySlugs, resolveTechnologySlugs } from "@/lib/actions/taxonomy";
 import { getSearchClient } from "@/lib/search/typesense-client";
 import { buildFilterString } from "@/lib/search/typesense-filters";
+import { localesOrNoneClause } from "@/lib/search/pg-filters";
 import {
   upsertWatchlist as tsUpsertWatchlist,
   deleteWatchlist as tsDeleteWatchlist,
@@ -416,7 +416,7 @@ export async function getUserWatchlists(locale: string): Promise<WatchlistSummar
   const userId = await getSessionUserId();
   if (!userId) return [];
 
-  const languages = await resolveViewerLanguages(locale);
+  const languages = await getViewerLanguages(locale);
 
   const rows = await db.execute<{
     [key: string]: unknown;
@@ -548,17 +548,6 @@ export type PublicWatchlistEntry = WatchlistSummary & {
   mirrorCount: number;
 };
 
-/**
- * Resolve the current viewer's effective job-language filter.
- * Anonymous viewers fall through to `[locale]` (UI locale only), matching
- * the behavior of explore and company pages.
- */
-async function resolveViewerLanguages(locale: string): Promise<string[]> {
-  const session = await getSession();
-  const prefs = session ? await getPreferences() : null;
-  return resolveJobLanguages(prefs?.jobLanguages ?? [], locale);
-}
-
 /** Stable cache-key fragment for a viewer's language filter. */
 function languagesCacheKey(languages: string[] | undefined): string {
   if (!languages || languages.length === 0) return "all";
@@ -589,8 +578,9 @@ function buildFilterCacheKey(f: WatchlistFilters, companyIds: string[]): string 
  */
 export async function getWatchlistMatchingCompanyCount(
   f: WatchlistFilters,
+  languages?: string[],
 ): Promise<number> {
-  const key = `wl-match-companies:${buildFilterCacheKey(f, [])}`;
+  const key = `wl-match-companies:${buildFilterCacheKey(f, [])}:${languagesCacheKey(languages)}`;
   return cached(key, async () => {
     const locale = "en";
     const [locMap, occMap, senMap, techMap] = await Promise.all([
@@ -609,6 +599,7 @@ export async function getWatchlistMatchingCompanyCount(
       salaryMaxEur: f.salaryMax,
       experienceMin: f.experienceMin,
       experienceMax: f.experienceMax,
+      languages,
     });
 
     const fullFilter = `is_active:true${filterStr ? " && " + filterStr : ""}`;
@@ -754,7 +745,7 @@ export async function searchPublicWatchlists(params: {
   const q = params.query.trim();
   if (!q) return { watchlists: [], total: 0 };
 
-  const languages = await resolveViewerLanguages(params.locale);
+  const languages = await getViewerLanguages(params.locale);
   const langKey = languagesCacheKey(languages);
 
   return cached(
@@ -789,7 +780,7 @@ export async function getPopularWatchlists(params: {
   limit: number;
   locale: string;
 }): Promise<{ watchlists: PublicWatchlistEntry[]; total: number }> {
-  const languages = await resolveViewerLanguages(params.locale);
+  const languages = await getViewerLanguages(params.locale);
   const langKey = languagesCacheKey(languages);
 
   return cached(
@@ -1349,12 +1340,8 @@ async function _getWatchlistPostingsPostgres(
       clauses.push(sql`(jp.experience_min IS NULL OR jp.experience_min <= ${params.experienceMax!})`);
     }
   }
-  // Match Typesense semantics: include postings with no detected language
-  // (empty `locales` array — the `_none` sentinel on the Typesense side).
-  if (params.languages && params.languages.length > 0) {
-    const pgArr = `{${params.languages.join(",")}}`;
-    clauses.push(sql`(jp.locales && ${pgArr}::text[] OR cardinality(jp.locales) = 0)`);
-  }
+  const localesClause = localesOrNoneClause(params.languages);
+  if (localesClause) clauses.push(localesClause);
 
   const whereClause = sql.join(clauses, sql` AND `);
 

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -7,7 +7,9 @@ import {
   watchlistCompany,
   company,
 } from "@/db/schema";
-import { getSessionUserId } from "@/lib/sessionCache";
+import { getSession, getSessionUserId } from "@/lib/sessionCache";
+import { getPreferences } from "@/lib/actions/preferences";
+import { resolveJobLanguages } from "@/lib/job-languages";
 import { cached } from "@/lib/cache";
 import { canCreateWatchlist, getUserPlan, PLAN_LIMITS } from "@/lib/plans";
 import { generateUniqueSlug } from "@/lib/watchlist-slug";
@@ -410,9 +412,11 @@ export async function toggleWatchlistAlerts(
   return { enabled: newVal };
 }
 
-export async function getUserWatchlists(): Promise<WatchlistSummary[]> {
+export async function getUserWatchlists(locale: string): Promise<WatchlistSummary[]> {
   const userId = await getSessionUserId();
   if (!userId) return [];
+
+  const languages = await resolveViewerLanguages(locale);
 
   const rows = await db.execute<{
     [key: string]: unknown;
@@ -444,9 +448,10 @@ export async function getUserWatchlists(): Promise<WatchlistSummary[]> {
 
   const typed = rows as unknown as Row[];
 
-  // Compute active job counts respecting each watchlist's filters (cached 5min)
+  // Compute active job counts respecting each watchlist's filters and the
+  // viewer's language preference (cached 5min per (watchlist, filters, languages)).
   const counts = await Promise.all(
-    typed.map((r) => resolveFilteredJobCount(r.id, r.filters ?? {}, r.company_ids ?? [])),
+    typed.map((r) => resolveFilteredJobCount(r.id, r.filters ?? {}, r.company_ids ?? [], languages)),
   );
 
   return typed.map((r, i) => ({
@@ -543,6 +548,23 @@ export type PublicWatchlistEntry = WatchlistSummary & {
   mirrorCount: number;
 };
 
+/**
+ * Resolve the current viewer's effective job-language filter.
+ * Anonymous viewers fall through to `[locale]` (UI locale only), matching
+ * the behavior of explore and company pages.
+ */
+async function resolveViewerLanguages(locale: string): Promise<string[]> {
+  const session = await getSession();
+  const prefs = session ? await getPreferences() : null;
+  return resolveJobLanguages(prefs?.jobLanguages ?? [], locale);
+}
+
+/** Stable cache-key fragment for a viewer's language filter. */
+function languagesCacheKey(languages: string[] | undefined): string {
+  if (!languages || languages.length === 0) return "all";
+  return languages.join(",");
+}
+
 function buildFilterCacheKey(f: WatchlistFilters, companyIds: string[]): string {
   const parts: string[] = [];
   if (f.anyCompany) parts.push("any");
@@ -616,11 +638,12 @@ async function resolveFilteredJobCount(
   watchlistId: string,
   f: WatchlistFilters,
   companyIds: string[],
+  languages?: string[],
 ): Promise<number> {
   const isAny = f.anyCompany;
   if (!isAny && companyIds.length === 0) return 0;
 
-  const key = `wl-count:${watchlistId}:${buildFilterCacheKey(f, companyIds)}`;
+  const key = `wl-count:${watchlistId}:${buildFilterCacheKey(f, companyIds)}:${languagesCacheKey(languages)}`;
   return cached(key, async () => {
     const locale = "en";
     const [locMap, occMap, senMap, techMap] = await Promise.all([
@@ -644,6 +667,7 @@ async function resolveFilteredJobCount(
       salaryMax: f.salaryMax,
       experienceMin: f.experienceMin,
       experienceMax: f.experienceMax,
+      languages,
     });
     return total;
   }, { ttl: 300 });
@@ -654,6 +678,7 @@ async function queryPublicWatchlists(params: {
   orderClause: ReturnType<typeof sql>;
   offset: number;
   limit: number;
+  languages?: string[];
 }): Promise<{ watchlists: PublicWatchlistEntry[]; total: number }> {
   const [totalRow] = await db.execute<{ [key: string]: unknown; cnt: number }>(sql`
     SELECT count(*)::int AS cnt FROM watchlist w WHERE ${params.whereClause}
@@ -695,9 +720,9 @@ async function queryPublicWatchlists(params: {
 
   const typed = rows as unknown as Row[];
 
-  // Compute filtered job counts in parallel (cached 5min)
+  // Compute filtered job counts in parallel (cached 5min per viewer-languages)
   const counts = await Promise.all(
-    typed.map((r) => resolveFilteredJobCount(r.id, r.filters ?? {}, r.company_ids ?? [])),
+    typed.map((r) => resolveFilteredJobCount(r.id, r.filters ?? {}, r.company_ids ?? [], params.languages)),
   );
 
   return {
@@ -724,18 +749,22 @@ export async function searchPublicWatchlists(params: {
   query: string;
   offset: number;
   limit: number;
+  locale: string;
 }): Promise<{ watchlists: PublicWatchlistEntry[]; total: number }> {
   const q = params.query.trim();
   if (!q) return { watchlists: [], total: 0 };
 
+  const languages = await resolveViewerLanguages(params.locale);
+  const langKey = languagesCacheKey(languages);
+
   return cached(
-    `public-watchlist-search:${q}:${params.offset}:${params.limit}`,
+    `public-watchlist-search:${q}:${params.offset}:${params.limit}:${langKey}`,
     async () => {
       try {
         const tsResult = await _searchPublicWatchlistsTypesense(q, params.offset, params.limit);
         if (tsResult.watchlists.length > 0) {
           return {
-            watchlists: await _enrichWatchlistsWithRealCounts(tsResult.watchlists),
+            watchlists: await _enrichWatchlistsWithRealCounts(tsResult.watchlists, languages),
             total: tsResult.total,
           };
         }
@@ -748,6 +777,7 @@ export async function searchPublicWatchlists(params: {
         orderClause: sql`w.created_at DESC`,
         offset: params.offset,
         limit: params.limit,
+        languages,
       });
     },
     { ttl: 60 },
@@ -757,15 +787,19 @@ export async function searchPublicWatchlists(params: {
 export async function getPopularWatchlists(params: {
   offset: number;
   limit: number;
+  locale: string;
 }): Promise<{ watchlists: PublicWatchlistEntry[]; total: number }> {
+  const languages = await resolveViewerLanguages(params.locale);
+  const langKey = languagesCacheKey(languages);
+
   return cached(
-    `popular-watchlists:${params.offset}:${params.limit}`,
+    `popular-watchlists:${params.offset}:${params.limit}:${langKey}`,
     async () => {
       try {
         const tsResult = await _getPopularWatchlistsTypesense(params.offset, params.limit);
         if (tsResult.watchlists.length > 0) {
           return {
-            watchlists: await _enrichWatchlistsWithRealCounts(tsResult.watchlists),
+            watchlists: await _enrichWatchlistsWithRealCounts(tsResult.watchlists, languages),
             total: tsResult.total,
           };
         }
@@ -778,6 +812,7 @@ export async function getPopularWatchlists(params: {
         orderClause: sql`(u.username = 'colophongroup')::int DESC, (SELECT count(*)::int FROM watchlist w2 WHERE w2.source_watchlist_id = w.id) DESC, (w.description IS NOT NULL AND w.description != '')::int DESC, w.created_at DESC`,
         offset: params.offset,
         limit: params.limit,
+        languages,
       });
     },
     { ttl: 120 },
@@ -991,6 +1026,7 @@ function _mapWatchlistDoc(doc: Record<string, unknown>): PublicWatchlistEntry {
  */
 async function _enrichWatchlistsWithRealCounts(
   watchlists: PublicWatchlistEntry[],
+  languages?: string[],
 ): Promise<PublicWatchlistEntry[]> {
   const ids = watchlists.map((w) => w.id);
   if (ids.length === 0) return watchlists;
@@ -1018,7 +1054,7 @@ async function _enrichWatchlistsWithRealCounts(
     watchlists.map((w) => {
       const pgRow = rowMap.get(w.id);
       if (!pgRow) return Promise.resolve(0);
-      return resolveFilteredJobCount(w.id, pgRow.filters ?? {}, pgRow.company_ids ?? []);
+      return resolveFilteredJobCount(w.id, pgRow.filters ?? {}, pgRow.company_ids ?? [], languages);
     }),
   );
 

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -798,6 +798,7 @@ export async function getWatchlistPostings(params: {
   salaryMax?: number;
   experienceMin?: number;
   experienceMax?: number;
+  languages?: string[];
 }): Promise<{ postings: WatchlistPostingEntry[]; total: number; truncated?: boolean }> {
   // No companies selected and not "any company" mode → empty
   if (!params.anyCompany && params.companyIds.length === 0) {
@@ -1045,6 +1046,7 @@ async function _getWatchlistPostingsTypesense(
     salaryMax?: number;
     experienceMin?: number;
     experienceMax?: number;
+    languages?: string[];
   },
   userId: string | null,
 ): Promise<{ postings: WatchlistPostingEntry[]; total: number; truncated?: boolean }> {
@@ -1062,6 +1064,7 @@ async function _getWatchlistPostingsTypesense(
     salaryMaxEur: params.salaryMax,
     experienceMin: params.experienceMin,
     experienceMax: params.experienceMax,
+    languages: params.languages,
   });
 
   const hasKeywords = params.keywords && params.keywords.length > 0;
@@ -1135,6 +1138,7 @@ async function _getWatchlistPostingsBatched(
     salaryMax?: number;
     experienceMin?: number;
     experienceMax?: number;
+    languages?: string[];
   },
   userId: string | null,
 ): Promise<{ postings: WatchlistPostingEntry[]; total: number; truncated?: boolean }> {
@@ -1150,6 +1154,7 @@ async function _getWatchlistPostingsBatched(
     salaryMaxEur: params.salaryMax,
     experienceMin: params.experienceMin,
     experienceMax: params.experienceMax,
+    languages: params.languages,
   });
 
   const hasKeywords = params.keywords && params.keywords.length > 0;
@@ -1246,6 +1251,7 @@ async function _getWatchlistPostingsPostgres(
     salaryMax?: number;
     experienceMin?: number;
     experienceMax?: number;
+    languages?: string[];
   },
   userId: string | null,
 ): Promise<{ postings: WatchlistPostingEntry[]; total: number; truncated?: boolean }> {
@@ -1306,6 +1312,12 @@ async function _getWatchlistPostingsPostgres(
     } else {
       clauses.push(sql`(jp.experience_min IS NULL OR jp.experience_min <= ${params.experienceMax!})`);
     }
+  }
+  // Match Typesense semantics: include postings with no detected language
+  // (empty `locales` array — the `_none` sentinel on the Typesense side).
+  if (params.languages && params.languages.length > 0) {
+    const pgArr = `{${params.languages.join(",")}}`;
+    clauses.push(sql`(jp.locales && ${pgArr}::text[] OR cardinality(jp.locales) = 0)`);
   }
 
   const whereClause = sql.join(clauses, sql` AND `);

--- a/apps/web/src/lib/job-languages.ts
+++ b/apps/web/src/lib/job-languages.ts
@@ -3208,7 +3208,11 @@ export function getLanguage(code: string): JobLanguage | undefined {
  *
  * - `[]`        → default: filter by UI locale only
  * - `["*"]`     → all languages: no filter (returns `[]`)
- * - `["en","de"]` → specific selection
+ * - `["en","de"]` → specific selection (silently filtered to known codes)
+ *
+ * Unknown / malformed codes are dropped — these strings flow into Typesense
+ * `filter_by` and Postgres array literals, so we must not trust the DB's
+ * `user_preferences.jobLanguages` value blindly.
  */
 export function resolveJobLanguages(
   jobLanguages: string[],
@@ -3216,5 +3220,10 @@ export function resolveJobLanguages(
 ): string[] {
   if (jobLanguages.length === 0) return [locale];
   if (jobLanguages.includes("*")) return [];
-  return jobLanguages;
+  const safe = jobLanguages.filter((c) => _langMap.has(c));
+  if (safe.length === 0) return [locale];
+  // Sort + dedupe so downstream JSON.stringify cache keys (taxonomy.ts,
+  // locations.ts) collapse equivalent prefs across users (["en","de"] and
+  // ["de","en"] would otherwise produce distinct Redis entries).
+  return Array.from(new Set(safe)).sort();
 }

--- a/apps/web/src/lib/search/pg-filters.ts
+++ b/apps/web/src/lib/search/pg-filters.ts
@@ -1,0 +1,17 @@
+import { sql } from "drizzle-orm";
+
+/**
+ * Postgres clause that filters `job_posting` (aliased `jp`) to postings
+ * whose `locales` array overlaps the given languages — including postings
+ * with no detected language (`cardinality = 0`). Mirrors the Typesense
+ * `_none` sentinel semantics so Typesense and Postgres paths produce the
+ * same result set.
+ *
+ * Returns `null` when no language filter is active; callers should skip
+ * appending a clause rather than emitting a trivially-true predicate.
+ */
+export function localesOrNoneClause(languages: string[] | undefined) {
+  if (!languages || languages.length === 0) return null;
+  const arr = `{${languages.join(",")}}`;
+  return sql`(jp.locales && ${arr}::text[] OR cardinality(jp.locales) = 0)`;
+}

--- a/apps/web/src/lib/search/typeahead-boost.ts
+++ b/apps/web/src/lib/search/typeahead-boost.ts
@@ -27,22 +27,21 @@ export async function boostByFilterMatches<T>(
 ): Promise<T[]> {
   if (candidates.length === 0) return candidates;
 
-  // No active filter dimensions → boost would be a no-op (every taxonomy
-  // candidate already has has_active_postings:true). Skip the round-trip.
+  // No active filter dimensions AND no keyword query → boost would be a
+  // no-op (every taxonomy candidate already has has_active_postings:true).
+  // Skip the round-trip. Keywords aren't emitted by buildFilterString (they
+  // go into `q`), so check them separately.
   const filterStr = buildFilterString(filters);
-  if (!filterStr) return candidates;
+  const hasKeywords = filters.keywords && filters.keywords.length > 0;
+  if (!filterStr && !hasKeywords) return candidates;
 
   try {
     const client = getSearchClient();
     const ids = candidates.map(idOf);
 
-    const filterParts = [
-      "is_active:true",
-      `${facetField}:[${ids.join(",")}]`,
-      filterStr,
-    ];
+    const filterParts = ["is_active:true", `${facetField}:[${ids.join(",")}]`];
+    if (filterStr) filterParts.push(filterStr);
 
-    const hasKeywords = filters.keywords && filters.keywords.length > 0;
     const q = hasKeywords ? filters.keywords!.join(" ") : "*";
 
     const result = await client

--- a/apps/web/src/lib/search/typeahead-boost.ts
+++ b/apps/web/src/lib/search/typeahead-boost.ts
@@ -27,6 +27,11 @@ export async function boostByFilterMatches<T>(
 ): Promise<T[]> {
   if (candidates.length === 0) return candidates;
 
+  // No active filter dimensions → boost would be a no-op (every taxonomy
+  // candidate already has has_active_postings:true). Skip the round-trip.
+  const filterStr = buildFilterString(filters);
+  if (!filterStr) return candidates;
+
   try {
     const client = getSearchClient();
     const ids = candidates.map(idOf);
@@ -34,9 +39,8 @@ export async function boostByFilterMatches<T>(
     const filterParts = [
       "is_active:true",
       `${facetField}:[${ids.join(",")}]`,
+      filterStr,
     ];
-    const filterStr = buildFilterString(filters);
-    if (filterStr) filterParts.push(filterStr);
 
     const hasKeywords = filters.keywords && filters.keywords.length > 0;
     const q = hasKeywords ? filters.keywords!.join(" ") : "*";

--- a/apps/web/src/lib/search/typeahead-boost.ts
+++ b/apps/web/src/lib/search/typeahead-boost.ts
@@ -1,0 +1,78 @@
+import { getSearchClient } from "./typesense-client";
+import { buildFilterString } from "./typesense-filters";
+
+export interface TypeaheadBoostFilters {
+  companyId?: string;
+  keywords?: string[];
+  locationIds?: number[];
+  occupationIds?: number[];
+  seniorityIds?: number[];
+  technologyIds?: number[];
+  languages?: string[];
+}
+
+/**
+ * Re-rank typeahead candidates so that those with ≥1 matching posting
+ * under `filters` rank above those with zero matches. Original order is
+ * preserved within each group.
+ *
+ * Falls back to the input order on any Typesense error — typeahead must
+ * never break.
+ */
+export async function boostByFilterMatches<T>(
+  candidates: T[],
+  facetField: string,
+  idOf: (c: T) => number | string,
+  filters: TypeaheadBoostFilters,
+): Promise<T[]> {
+  if (candidates.length === 0) return candidates;
+
+  try {
+    const client = getSearchClient();
+    const ids = candidates.map(idOf);
+
+    const filterParts = [
+      "is_active:true",
+      `${facetField}:[${ids.join(",")}]`,
+    ];
+    const filterStr = buildFilterString(filters);
+    if (filterStr) filterParts.push(filterStr);
+
+    const hasKeywords = filters.keywords && filters.keywords.length > 0;
+    const q = hasKeywords ? filters.keywords!.join(" ") : "*";
+
+    const result = await client
+      .collections("job_posting")
+      .documents()
+      .search({
+        q,
+        query_by: "title",
+        filter_by: filterParts.join(" && "),
+        facet_by: facetField,
+        facet_strategy: "exhaustive",
+        max_facet_values: ids.length,
+        per_page: 0,
+      });
+
+    const facet = result.facet_counts?.find(
+      (f) => (f as { field_name: string }).field_name === facetField,
+    ) as { counts: Array<{ value: string; count: number }> } | undefined;
+
+    if (!facet) return candidates;
+
+    const matched = new Set<string>();
+    for (const fc of facet.counts) {
+      if ((fc.count as number) > 0) matched.add(String(fc.value));
+    }
+
+    const withMatches: T[] = [];
+    const withoutMatches: T[] = [];
+    for (const c of candidates) {
+      if (matched.has(String(idOf(c)))) withMatches.push(c);
+      else withoutMatches.push(c);
+    }
+    return [...withMatches, ...withoutMatches];
+  } catch {
+    return candidates;
+  }
+}

--- a/apps/web/src/lib/search/typesense-filters.ts
+++ b/apps/web/src/lib/search/typesense-filters.ts
@@ -13,7 +13,11 @@ export function buildFilterString(
   if (!filters) return "";
   const parts: string[] = [];
 
-  if (filters.companyId) {
+  // companyId reaches here from "use server" actions that clients can call
+  // directly with arbitrary strings. Shape-validate before raw interpolation
+  // so a hostile caller can't break out of the filter clause. Bad input is
+  // dropped silently — a missing company scope is safer than an injection.
+  if (filters.companyId && /^[0-9a-z_-]{8,64}$/i.test(filters.companyId)) {
     parts.push(`company_id:=${filters.companyId}`);
   }
 

--- a/apps/web/src/lib/search/typesense-filters.ts
+++ b/apps/web/src/lib/search/typesense-filters.ts
@@ -1,5 +1,3 @@
-import type { HistogramFilters } from "./types";
-
 /**
  * Build a Typesense filter_by string from user-specified filter dimensions.
  *
@@ -77,13 +75,4 @@ export function buildFilterString(
   }
 
   return parts.join(" && ");
-}
-
-/**
- * Build a filter string from HistogramFilters (subset of SearchFilters).
- * `keywords` is the search query, not a filter clause — buildFilterString
- * silently ignores it.
- */
-export function buildHistogramFilterString(filters: HistogramFilters): string {
-  return buildFilterString(filters);
 }

--- a/apps/web/src/lib/search/typesense-filters.ts
+++ b/apps/web/src/lib/search/typesense-filters.ts
@@ -13,6 +13,10 @@ export function buildFilterString(
   if (!filters) return "";
   const parts: string[] = [];
 
+  if (filters.companyId) {
+    parts.push(`company_id:=${filters.companyId}`);
+  }
+
   if (filters.locationIds?.length) {
     parts.push(`location_ids:[${filters.locationIds.join(",")}]`);
   }
@@ -73,13 +77,9 @@ export function buildFilterString(
 
 /**
  * Build a filter string from HistogramFilters (subset of SearchFilters).
+ * `keywords` is the search query, not a filter clause — buildFilterString
+ * silently ignores it.
  */
 export function buildHistogramFilterString(filters: HistogramFilters): string {
-  return buildFilterString({
-    locationIds: filters.locationIds,
-    occupationIds: filters.occupationIds,
-    seniorityIds: filters.seniorityIds,
-    technologyIds: filters.technologyIds,
-    languages: filters.languages,
-  });
+  return buildFilterString(filters);
 }

--- a/apps/web/src/lib/search/typesense.ts
+++ b/apps/web/src/lib/search/typesense.ts
@@ -571,10 +571,7 @@ export class TypesenseSearchProvider implements SearchProvider {
       const q = hasKeywords ? f.keywords!.join(" ") : "*";
       const client = getSearchClient();
 
-      let filterBy = `is_active:true && salary_eur:>0${filterStr ? " && " + filterStr : ""}`;
-      if (f.companyId) {
-        filterBy += ` && company_id:=${f.companyId}`;
-      }
+      const filterBy = `is_active:true && salary_eur:>0${filterStr ? " && " + filterStr : ""}`;
 
       const result: TsSearchResponse<JobPostingDoc> = await client
         .collections<JobPostingDoc>("job_posting")
@@ -616,10 +613,7 @@ export class TypesenseSearchProvider implements SearchProvider {
       const q = hasKeywords ? f.keywords!.join(" ") : "*";
       const client = getSearchClient();
 
-      let filterBy = `is_active:true && experience_min:>=0${filterStr ? " && " + filterStr : ""}`;
-      if (f.companyId) {
-        filterBy += ` && company_id:=${f.companyId}`;
-      }
+      const filterBy = `is_active:true && experience_min:>=0${filterStr ? " && " + filterStr : ""}`;
 
       const result: TsSearchResponse<JobPostingDoc> = await client
         .collections<JobPostingDoc>("job_posting")

--- a/apps/web/src/lib/search/typesense.ts
+++ b/apps/web/src/lib/search/typesense.ts
@@ -4,7 +4,7 @@ import type {
   SearchResponseFacetCountSchema,
 } from "typesense/lib/Typesense/Documents";
 import { getSearchClient } from "./typesense-client";
-import { buildFilterString, buildHistogramFilterString } from "./typesense-filters";
+import { buildFilterString } from "./typesense-filters";
 import type {
   PostingLocation,
   SearchFilters,
@@ -566,7 +566,7 @@ export class TypesenseSearchProvider implements SearchProvider {
   ): Promise<SalaryBucket[]> {
     try {
       const f = filters ?? {};
-      const filterStr = buildHistogramFilterString(f);
+      const filterStr = buildFilterString(f);
       const hasKeywords = f.keywords && f.keywords.length > 0;
       const q = hasKeywords ? f.keywords!.join(" ") : "*";
       const client = getSearchClient();
@@ -608,7 +608,7 @@ export class TypesenseSearchProvider implements SearchProvider {
   ): Promise<ExperienceBucket[]> {
     try {
       const f = filters ?? {};
-      const filterStr = buildHistogramFilterString(f);
+      const filterStr = buildFilterString(f);
       const hasKeywords = f.keywords && f.keywords.length > 0;
       const q = hasKeywords ? f.keywords!.join(" ") : "*";
       const client = getSearchClient();

--- a/apps/web/src/lib/viewer.ts
+++ b/apps/web/src/lib/viewer.ts
@@ -1,0 +1,19 @@
+"use server";
+
+import { getSession } from "@/lib/sessionCache";
+import { getPreferences } from "@/lib/actions/preferences";
+import { resolveJobLanguages } from "@/lib/job-languages";
+
+/**
+ * Resolve the current viewer's effective job-language filter.
+ * Anonymous viewers (no session) fall through to `[locale]` — same as
+ * logged-in users whose preference is unset. Keeps
+ * explore/company/watchlist pages behaving identically across auth state.
+ *
+ * Returns `[]` when the viewer opted into "all languages" (`"*"`).
+ */
+export async function getViewerLanguages(locale: string): Promise<string[]> {
+  const session = await getSession();
+  const prefs = session ? await getPreferences() : null;
+  return resolveJobLanguages(prefs?.jobLanguages ?? [], locale);
+}


### PR DESCRIPTION
## Summary

Five related fixes that make modal counts and result lists in the web app honest about the user's active filters and language preference.

1. **Company-page modals not scoped to the company.** `buildFilterString` silently dropped `companyId`, so the Role / Level / Technology / Location browse-all modals on a company page showed counts across *all* companies. Salary / Experience histograms compensated manually — duplicated logic. Fixed by handling `companyId` in `buildFilterString` (single source of truth) and dropping the manual appends.
2. **Watchlist modal counts ignored language preference.** `watchlist-view-page.tsx` didn't receive `jobLanguages`. Now resolved server-side in `fetchWatchlistPageData` (mirrors `explore-data.ts` / `company-page-data.ts`) and threaded into `histogramFilters`.
3. **Watchlist postings query ignored language preference.** `getWatchlistPostings` (Typesense, Postgres, batched) now accepts `languages?: string[]` and applies it. The Postgres clause matches Typesense `_none` semantics via `cardinality(jp.locales) = 0`.
4. **Watchlist company picker ignored language.** `searchCompaniesForWatchlist` and `CompanySearchFilters` now carry `languages` so per-company match counts in the picker are language-scoped.
5. **Typeahead suggestions didn't reflect current filters.** New `boostByFilterMatches` helper does a single `job_posting` facet query over the candidate IDs under the current filters and re-ranks: matched suggestions appear above unmatched ones (zero-match suggestions are kept, just lower). Wired into `suggestOccupations` / `suggestSeniorities` / `suggestTechnologies` / `suggestLocations` and threaded from `SearchToolbar` → `SearchBar`. Each typeahead omits its own dimension from the boost filters (matches the browse-all modal convention). Falls back to original order on any Typesense error — typeahead must never break.

## Test plan

- [ ] **#1** Load `/en/company/<slug>` and open Role / Level / Technology / Location modals — counts should equal the on-page results when no other filter is set, and shrink when filters are added.
- [ ] **#1 regression** Salary and Experience histograms on a company page must look identical to before.
- [ ] **#2** Set `jobLanguages = ["en"]`, open a German-heavy watchlist; modal counts shrink. Toggle to `["*"]`; counts grow back.
- [ ] **#3** Same watchlist — visible postings list and total drop to English postings only; `["*"]` restores all.
- [ ] **#4** Open the company picker on a watchlist while `jobLanguages = ["de"]`; per-company `activeMatches` reflect German postings only.
- [ ] **#5** Set `jobLanguages = ["de"]`, type "data" in the search bar — occupations whose German posting count is 0 should rank below those with German postings. With no filters, ordering should match today.
- [ ] Run `pnpm test src/lib/search/__tests__/typesense.e2e.test.ts` (Typesense must be reachable).

## Out of scope

- Public anonymous endpoints (`/api/v1/search`, `/api/v1/taxonomies`) — no user setting available.
- Live-updating `languages` prop after a Settings change without navigation.
- AppHeader's global SearchBar (no page-filter context to derive boost from).

🤖 Generated with [Claude Code](https://claude.com/claude-code)