### PR TITLE
Treat api_sniffer/nextdata with fields as skip-no-scrape (#2183)

### DIFF
--- a/apps/crawler/src/processing/scrape.py
+++ b/apps/crawler/src/processing/scrape.py
@@ -156,7 +156,9 @@ def _is_skip_no_scrape(metadata: dict, crawler_type: str | None = None) -> bool:
     1. ``metadata.scraper_type = "skip"`` with no enrichment — explicit.
     2. ``metadata.scraper_type`` is unset AND ``crawler_type`` auto-resolves
        to ``("skip", None)`` via ``auto_scraper_type()`` AND no enrichment —
-       implicit rich monitor that relies on CSV defaults.
+       implicit rich monitor that relies on CSV defaults. Includes
+       ``api_sniffer``/``nextdata`` when ``fields`` is set in the monitor
+       metadata (conditionally rich).
 
     Such boards provide full job data from the monitor and must never be
     sent through the scrape pipeline, or the placeholder ``skip`` scraper
@@ -182,6 +184,15 @@ def _is_skip_no_scrape(metadata: dict, crawler_type: str | None = None) -> bool:
         from src.workspace._compat import auto_skip_crawler_types
 
         if ct in auto_skip_crawler_types():
+            return True
+        # api_sniffer / nextdata are conditionally rich: they auto-resolve to
+        # ("skip", None) only when ``fields`` is set in their monitor
+        # metadata. Mirrors ``auto_scraper_type()`` and ``is_rich_monitor()``.
+        # Without this branch a stub URL insert from a partial-rich monitor
+        # cycle (e.g. McKinsey api_sniffer) leaks into the scrape pipeline,
+        # where the worker tries to run the api_sniffer scraper with empty
+        # config and crashes on browser launch from a slim worker.
+        if ct in ("api_sniffer", "nextdata") and bool(metadata.get("fields")):
             return True
     return False
 

--- a/apps/crawler/src/queries/scrape.py
+++ b/apps/crawler/src/queries/scrape.py
@@ -11,12 +11,15 @@ def _build_skip_no_scrape_predicate(board_alias: str = "jb") -> str:
     Mirrors ``_is_skip_no_scrape`` (``processing/scrape.py``). Returns a
     parenthesized boolean expression suitable for ``WHERE NOT ( … )``.
 
-    Two cases match:
+    Three cases match:
     1. ``metadata.scraper_type = 'skip'`` explicitly.
     2. ``metadata.scraper_type`` is unset AND ``crawler_type`` is in the
        auto-resolved rich-monitor set.
+    3. ``metadata.scraper_type`` is unset AND ``crawler_type`` is
+       ``api_sniffer`` / ``nextdata`` AND ``metadata.fields`` is set
+       (conditionally rich monitors).
 
-    Both cases additionally require no enrichment to be configured.
+    All three cases additionally require no enrichment to be configured.
     ``COALESCE`` wraps the ``? 'enrich'`` check because the JSONB ``?``
     operator returns NULL when ``scraper_config`` itself is NULL, and
     ``NOT NULL`` is NULL (not TRUE).
@@ -31,7 +34,13 @@ def _build_skip_no_scrape_predicate(board_alias: str = "jb") -> str:
             ({board_alias}.metadata->>'scraper_type' = 'skip'
              OR (
                  {board_alias}.metadata->>'scraper_type' IS NULL
-                 AND {board_alias}.crawler_type IN ({literal})
+                 AND (
+                     {board_alias}.crawler_type IN ({literal})
+                     OR (
+                         {board_alias}.crawler_type IN ('api_sniffer', 'nextdata')
+                         AND {board_alias}.metadata ? 'fields'
+                     )
+                 )
              )
             )
             AND NOT COALESCE({board_alias}.metadata->'scraper_config' ? 'enrich', false)

--- a/apps/crawler/src/workers/pipeline.py
+++ b/apps/crawler/src/workers/pipeline.py
@@ -314,13 +314,37 @@ async def _process_scrape_work(
                 metadata = {}
 
             crawler_type = board_config.get("crawler_type") or None
-            scraper_type = metadata.get("scraper_type") or crawler_type or "dom"
+            explicit_scraper = metadata.get("scraper_type") or None
             scraper_config = metadata.get("scraper_config")
             if isinstance(scraper_config, str):
                 try:
                     scraper_config = json.loads(scraper_config)
                 except (json.JSONDecodeError, TypeError):
                     scraper_config = None
+            if not isinstance(scraper_config, dict):
+                scraper_config = None
+
+            if explicit_scraper:
+                scraper_type = explicit_scraper
+            elif crawler_type:
+                # Resolve via auto_scraper_type, mirroring _load_board_scrapers.
+                # Falling straight through to ``crawler_type`` is unsafe: many
+                # crawler types ("greenhouse", "lever", …) aren't registered
+                # scrapers, and api_sniffer with an empty scraper_config
+                # silently switches to browser mode and tries to launch
+                # Playwright on slim workers. The skip-with-no-enrich case is
+                # handled by ``_is_skip_no_scrape`` below.
+                from src.workspace._compat import auto_scraper_type
+
+                auto = auto_scraper_type(crawler_type, metadata)
+                if auto and auto[0] != "skip":
+                    scraper_type = auto[0]
+                    if scraper_config is None:
+                        scraper_config = auto[1]
+                else:
+                    scraper_type = "dom"
+            else:
+                scraper_type = "dom"
         else:
             metadata = {}
             crawler_type = None

--- a/apps/crawler/tests/test_rich_monitor_scheduling.py
+++ b/apps/crawler/tests/test_rich_monitor_scheduling.py
@@ -125,6 +125,36 @@ class TestIsSkipNoScrape:
         # Still catches explicit skip regardless of crawler_type noise.
         assert _is_skip_no_scrape({"scraper_type": "skip"}, crawler_type="") is True
 
+    def test_implicit_api_sniffer_with_fields_is_skip(self):
+        """api_sniffer with ``fields`` in metadata is conditionally rich.
+
+        Mirrors ``auto_scraper_type`` and ``is_rich_monitor``, which both
+        return skip / rich for api_sniffer when ``fields`` is configured.
+        Without this branch a McKinsey-style stub URL leaks into the
+        scrape pipeline, where the api_sniffer scraper runs with empty
+        config and tries to launch Playwright on slim workers (issue #2183).
+        """
+        metadata = {"api_url": "https://example.com/api", "fields": {"title": "name"}}
+        assert _is_skip_no_scrape(metadata, crawler_type="api_sniffer") is True
+
+    def test_implicit_api_sniffer_without_fields_is_NOT_skip(self):
+        """api_sniffer without ``fields`` returns URL-only and DOES need scraping."""
+        metadata = {"api_url": "https://example.com/api"}
+        assert _is_skip_no_scrape(metadata, crawler_type="api_sniffer") is False
+
+    def test_implicit_nextdata_with_fields_is_skip(self):
+        """nextdata with ``fields`` is conditionally rich (same rule as api_sniffer)."""
+        metadata = {"fields": {"title": "props.title"}}
+        assert _is_skip_no_scrape(metadata, crawler_type="nextdata") is True
+
+    def test_implicit_api_sniffer_with_fields_and_enrich_is_NOT_skip(self):
+        """Enrich override still wins for conditionally-rich monitors."""
+        metadata = {
+            "fields": {"title": "name"},
+            "scraper_config": {"enrich": ["description"]},
+        }
+        assert _is_skip_no_scrape(metadata, crawler_type="api_sniffer") is False
+
 
 # ── _enqueue_scrapes_for_* guards ───────────────────────────────────────
 
@@ -507,6 +537,82 @@ class TestProcessScrapeWorkSkipGuard:
 
         mock_reschedule.assert_awaited_once()
 
+    @patch("src.workers.pipeline.reschedule_task", new_callable=AsyncMock)
+    @patch("src.workers.pipeline.claim_work", new_callable=AsyncMock)
+    @patch("src.redis_queue.get_redis")
+    async def test_implicit_scraper_type_uses_auto_scraper_type(
+        self, mock_get_redis, _mock_claim, mock_reschedule
+    ):
+        """When metadata.scraper_type is empty, resolve via auto_scraper_type.
+
+        Regression for issue #2183: the worker used to fall back to
+        ``crawler_type`` directly, so an api_sniffer board with empty
+        scraper_config would invoke the api_sniffer scraper with ``{}``,
+        which silently switches to browser mode and tries to launch
+        Playwright on slim workers. With ``auto_scraper_type`` we either
+        get a sensible mapping (workday → workday scraper) or a safe
+        default (``dom``), never the unguarded crawler_type fallback.
+        """
+        pool, _conn = self._mock_pool()
+        http = AsyncMock()
+
+        # Workday: crawler_type="workday" auto-maps to scraper_type="workday".
+        redis = self._mock_redis(
+            {
+                "metadata": json.dumps({"tenant": "acme", "board_id": "X"}),
+                "crawler_type": "workday",
+            }
+        )
+        mock_get_redis.return_value = redis
+
+        with patch(
+            "src.processing.scrape._process_one_scrape", new_callable=AsyncMock
+        ) as mock_scrape:
+            mock_scrape.return_value = (True, 0.1)
+            log = MagicMock()
+            await _process_scrape_work(log, self._scrape_work(), pool, http, browser=False)
+
+            mock_scrape.assert_awaited_once()
+            # Verify the resolved scraper_type was "workday", not the legacy
+            # ``crawler_type or "dom"`` fallback.
+            assert mock_scrape.await_args.args[3] == "workday"
+
+    @patch("src.workers.pipeline.reschedule_task", new_callable=AsyncMock)
+    @patch("src.workers.pipeline.claim_work", new_callable=AsyncMock)
+    @patch("src.redis_queue.get_redis")
+    async def test_unknown_crawler_type_falls_back_to_dom(
+        self, mock_get_redis, _mock_claim, mock_reschedule
+    ):
+        """Unknown crawler types resolve to "dom", not their own name.
+
+        ``crawler_type or "dom"`` would raise KeyError for names like
+        "greenhouse" that aren't registered scrapers. Defense in depth:
+        always end up with a known scraper.
+        """
+        pool, _conn = self._mock_pool()
+        http = AsyncMock()
+
+        redis = self._mock_redis(
+            {
+                # sitemap monitor with no metadata.scraper_type and no auto-
+                # configured fallback in auto_scraper_type → dom.
+                "metadata": json.dumps({"sitemap_url": "https://example.com/sitemap.xml"}),
+                "crawler_type": "sitemap",
+            }
+        )
+        mock_get_redis.return_value = redis
+
+        with patch(
+            "src.processing.scrape._process_one_scrape", new_callable=AsyncMock
+        ) as mock_scrape:
+            mock_scrape.return_value = (False, 0.1)
+            log = MagicMock()
+            await _process_scrape_work(log, self._scrape_work(), pool, http, browser=False)
+
+            mock_scrape.assert_awaited_once()
+            # No registered "sitemap" scraper — must fall back to "dom".
+            assert mock_scrape.await_args.args[3] == "dom"
+
 
 # ── _FETCH_DUE_JOB_POSTINGS filter shape ───────────────────────────────
 
@@ -533,6 +639,16 @@ class TestFetchDuePostingsFilter:
             assert f"'{t}'" in _FETCH_DUE_JOB_POSTINGS, f"missing {t} in fetch filter"
         # Oracle HCM (rich monitor with enrich) must NOT be in the list.
         assert "'oracle_hcm'" not in _FETCH_DUE_JOB_POSTINGS
+
+    def test_query_covers_conditionally_rich_api_sniffer(self):
+        """api_sniffer / nextdata with ``fields`` in metadata are excluded too."""
+        from src.queries.scrape import _FETCH_DUE_JOB_POSTINGS
+
+        # The conditional branch should mention both crawler types and the
+        # ``fields`` jsonb-key check.
+        assert "'api_sniffer'" in _FETCH_DUE_JOB_POSTINGS
+        assert "'nextdata'" in _FETCH_DUE_JOB_POSTINGS
+        assert "metadata ? 'fields'" in _FETCH_DUE_JOB_POSTINGS
 
 
 # ── _CLEAR_SCRAPE_FOR_RICH predicate scoping ──────────────────────────

--- a/scripts/backfill-clear-rich-scrape.py
+++ b/scripts/backfill-clear-rich-scrape.py
@@ -65,7 +65,13 @@ def _skip_no_scrape_predicate(alias: str = "jb") -> str:
         ({alias}.metadata->>'scraper_type' = 'skip'
          OR (
              {alias}.metadata->>'scraper_type' IS NULL
-             AND {alias}.crawler_type IN ({literal})
+             AND (
+                 {alias}.crawler_type IN ({literal})
+                 OR (
+                     {alias}.crawler_type IN ('api_sniffer', 'nextdata')
+                     AND {alias}.metadata ? 'fields'
+                 )
+             )
          )
         )
         AND NOT COALESCE({alias}.metadata->'scraper_config' ? 'enrich', false)


### PR DESCRIPTION
## Summary
- Fix issue #2183 — `api_sniffer_scraper.failed` spike from McKinsey-style boards leaking into the scrape pipeline and crashing on Playwright launch from slim workers.
- Make `_is_skip_no_scrape`, the SQL `_FETCH_DUE_JOB_POSTINGS` filter, and the operational backfill predicate all recognize `api_sniffer`/`nextdata` with `metadata.fields` as skip-no-scrape — mirroring `auto_scraper_type` and `is_rich_monitor`.
- Replace the `or crawler_type or "dom"` fallback in `_process_scrape_work` with proper `auto_scraper_type` resolution so empty-`scraper_type` Redis tasks can't dispatch crawler-type names as scrapers.

## Root cause
`_AUTO_SKIP_CRAWLER_TYPES` is computed from a static `_RICH_MONITORS` set that excludes the conditionally-rich monitors (`api_sniffer`/`nextdata` are rich only when `fields` is set). `auto_scraper_type()` correctly resolves them to `("skip", None)`, but the three skip-no-scrape guards (`_is_skip_no_scrape`, SQL predicate, defense-in-depth check) all consult the static set instead — so:

1. `_enqueue_scrapes_for_new` enqueued stub URLs for McKinsey-style boards (rich monitor returns `list[DiscoveredJob]` but partial rich data leaves some URLs as stubs).
2. `_FETCH_DUE_JOB_POSTINGS` didn't filter them out of the periodic rescraper.
3. The worker's defense-in-depth check didn't catch them.
4. The worker resolved `scraper_type = metadata.get("scraper_type") or crawler_type or "dom"` to `"api_sniffer"` (because crawler_type is `api_sniffer`), and `scraper_config = metadata.get("scraper_config")` was None.
5. `api_sniffer.scrape(url, {}, ...)` saw no `api_url` → switched to browser mode → tried to launch Playwright on slim worker → `Executable doesn't exist`.

## Test plan
- [x] `uv run pytest tests/` — 3033 passed, 37 skipped.
- [x] New tests in `test_rich_monitor_scheduling.py` cover api_sniffer/nextdata + fields, the SQL filter shape, and the worker's auto_scraper_type fallback.
- [ ] After merge: deploy crawler-slim, then run `uv run python ../../scripts/backfill-clear-rich-scrape.py --dry-run` on the Postgres box to count the McKinsey/PwC-CH/Jobylon/KPMG-CA/Florecruit cohort, then re-run without `--dry-run` to clear stale `next_scrape_at` values left behind from before the fix.
- [ ] Watch `api_sniffer_scraper.failed` and `crawler_tasks_total{kind="scrape", status="skipped_rich"}` in Grafana — expect the failure rate to fall back to baseline within one monitor cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)