### PR TITLE
Fix Greenhouse monitor crash on salary text with trailing sentence dot

### DIFF
--- a/apps/crawler/src/core/salary_extract.py
+++ b/apps/crawler/src/core/salary_extract.py
@@ -44,7 +44,10 @@ def _html_to_text(html: str) -> str:
 def _parse_number(s: str) -> float:
     """Parse '137,300.00' or '137300' or '1 800' or '120'000' → float."""
     s = s.replace(",", "").replace(" ", "").replace("'", "").replace("\u2019", "")
-    # Handle K/k suffix: "85K" → 85000
+    # Defense in depth: currency regexes are tightened to forbid trailing
+    # dots, but if any capture still arrives with a sentence-ending dot
+    # (e.g. "£115,500.00."), it's never a decimal point on its own.
+    s = s.rstrip(".")
     if s.upper().endswith("K"):
         return float(s[:-1]) * 1000
     return float(s)
@@ -257,7 +260,7 @@ def _extract_bare_range(text: str) -> list[SalaryRange]:
 #   "$107.40/hr", "$120,000 per year", "$105,000 Annually"
 
 _SINGLE_DOLLAR_PERIOD_RE = re.compile(
-    r"\$([\d,.]+)\s*"
+    r"\$([\d,]+(?:\.\d+)?)\s*"
     r"(per year|per annum|annually|annual|/year|/yr|"
     r"per hour|hourly|/hour|/hr)",
     re.IGNORECASE,
@@ -411,11 +414,13 @@ def _extract_eur(text: str) -> list[SalaryRange]:
 # ── Pattern 6: GBP ──────────────────────────────────────────────────
 
 _GBP_RANGE_RE = re.compile(
-    r"£([\d,.]+)\s*[-–—]\s*£?([\d,.]+)"
+    r"£([\d,]+(?:\.\d+)?)\s*[-–—]\s*£?([\d,]+(?:\.\d+)?)"
     r"(\s*.{0,50})",
 )
 
-_GBP_SINGLE_RE = re.compile(r"£([\d,.]+)\s*(per hour|hourly|per year|annually|/hr|/hour|/year)")
+_GBP_SINGLE_RE = re.compile(
+    r"£([\d,]+(?:\.\d+)?)\s*(per hour|hourly|per year|annually|/hr|/hour|/year)"
+)
 
 
 def _extract_gbp(text: str) -> list[SalaryRange]:

--- a/apps/crawler/tests/test_salary_extract.py
+++ b/apps/crawler/tests/test_salary_extract.py
@@ -138,6 +138,20 @@ class TestGBP:
         assert result[0].min == 1285
         assert result[0].period == "hourly"
 
+    def test_range_trailing_sentence_period(self):
+        # Regression: Asana Greenhouse posting had
+        # "...between £98,000.00-£115,500.00. The actual base salary..."
+        # The sentence-ending dot was glued onto the max value and the
+        # greedy [\d,.]+ capture pulled it into _parse_number, raising
+        # "could not convert string to float: '115500.00.'" every cycle.
+        html = (
+            "<p>For this role, the estimated base salary range is between "
+            "£98,000.00-£115,500.00. The actual base salary will vary.</p>"
+        )
+        result = extract_salary(html)
+        assert len(result) == 1
+        assert result[0] == SalaryRange(min=98000, max=115500, currency="GBP", period="yearly")
+
 
 class TestFalsePositives:
     """These must return empty — 0 false positives is the goal."""


### PR DESCRIPTION
## Summary

Closes #2187.

Asana's _Solutions Consultant, AI Studio_ posting contains:

> ...the estimated base salary range is between **£98,000.00-£115,500.00.** The actual base salary will vary...

The sentence-ending dot is glued onto the max value. `_GBP_RANGE_RE` uses the greedy char class `[\d,.]+`, which happily captures `115,500.00.` (with the trailing dot). `_parse_number` then does `float("115500.00.")` → `ValueError: could not convert string to float: '115500.00.'`. The board failed every monitor cycle and got auto-disabled at 38 consecutive failures (`board_status='disabled'`, `last_error='could not convert string to float: '115500.00.''`).

`_SINGLE_DOLLAR_PERIOD_RE` and `_GBP_SINGLE_RE` had the same shape and same vulnerability to trailing punctuation.

## Fix

Two layers, so a future posting can't reopen the class of bug:

1. **Tighten the three loose regex patterns** from `[\d,.]+` to `[\d,]+(?:\.\d+)?`, forcing the capture to end on a digit. The strict `[\d,]+\.?\d*` patterns already used elsewhere (`_LOCATION_SALARY_RE`, `_BARE_RANGE_CURRENCY_RE`) are immune — now the GBP/single-dollar patterns are too.
2. **`_parse_number` rstrips trailing dots** as defense in depth. If any future greedy capture still slips a sentence-ending dot through, the number decodes cleanly instead of crashing the monitor.

## Test plan

- [x] New regression test covering the exact Asana snippet — `test_range_trailing_sentence_period` — asserts `SalaryRange(min=98000, max=115500, currency="GBP", period="yearly")`
- [x] `uv run pytest tests/test_salary_extract.py` — 35 passed (all 34 existing tests still green, +1 new)
- [x] Verified end-to-end on the live Asana Greenhouse API content — `extract_salary_unified` now returns a valid range

## Post-merge cleanup

The Asana board is currently stuck at `board_status='disabled', consecutive_failures=38`. After this lands and deploys, run on the Postgres box:

```sql
UPDATE job_board
SET board_status='active', consecutive_failures=0, last_error=NULL
WHERE id='26ee5173-f8a0-4cf1-b819-d9917f8b8594';
```

(or `crawler sync` will flip `is_enabled` back to true on its own, and the next successful run will clear the counters via `_RECORD_SUCCESS_NONEMPTY`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)