### PR TITLE
Exclude trivial watchlists from Typesense sync + Postgres fallbacks

### DIFF
--- a/apps/crawler/src/sync.py
+++ b/apps/crawler/src/sync.py
@@ -26,6 +26,7 @@ from urllib.parse import urlparse
 
 import polars as pl
 import structlog
+from typesense.exceptions import ObjectNotFound
 
 if TYPE_CHECKING:
     import asyncpg
@@ -1394,6 +1395,41 @@ def _ts_bulk_upsert(
     )
 
 
+def _ts_bulk_delete_ids(
+    client: typesense.Client,
+    collection: str,
+    ids: list[str],
+) -> None:
+    """Delete documents by id from a Typesense collection.
+
+    Iterates per-id (cheap at the scale this is used — excluding trivial
+    watchlists). 404s are expected for ids that were never indexed.
+    """
+    if not ids:
+        return
+    deleted = 0
+    for doc_id in ids:
+        try:
+            client.collections[collection].documents[doc_id].delete()
+            deleted += 1
+        except ObjectNotFound:
+            # Doc may never have been indexed — that's the whole point.
+            pass
+        except Exception as exc:
+            log.warning(
+                "typesense.delete.error",
+                collection=collection,
+                doc_id=doc_id,
+                error=str(exc),
+            )
+    log.info(
+        "typesense.delete.done",
+        collection=collection,
+        requested=len(ids),
+        deleted=deleted,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Typesense taxonomy sync
 # ---------------------------------------------------------------------------
@@ -1817,18 +1853,47 @@ async def sync_companies_typesense(
 # ---------------------------------------------------------------------------
 
 
+def _is_trivial_watchlist(filters: dict | None, company_count: int) -> bool:
+    """Mirror of the web app's ``isTrivialWatchlist``.
+
+    A watchlist is "trivial" when it tracks no companies and carries no
+    meaningful filters — effectively a blank shell. We exclude these from
+    the public ``watchlist`` collection so they don't dilute search/popular
+    listings. ``anyCompany`` and ``salaryCurrency`` alone don't count
+    (they're defaults/prefs). Keep in sync with
+    ``apps/web/src/lib/watchlist-utils.ts``.
+    """
+    if company_count > 0:
+        return False
+    f = filters or {}
+    return not (
+        f.get("keywords")
+        or f.get("locationSlugs")
+        or f.get("occupationSlugs")
+        or f.get("senioritySlugs")
+        or f.get("technologySlugs")
+        or f.get("salaryMin") is not None
+        or f.get("salaryMax") is not None
+        or f.get("experienceMin") is not None
+        or f.get("experienceMax") is not None
+    )
+
+
 async def sync_watchlists_typesense(
     supa_conn: asyncpg.Connection,
     client: typesense.Client,
 ) -> None:
     """Sync public watchlists to the Typesense ``watchlist`` collection.
 
-    Queries from Supabase only (watchlists only exist there).
+    Queries from Supabase only (watchlists only exist there). Trivial
+    watchlists (no companies, no meaningful filters) are deleted from
+    Typesense rather than upserted, so they're hidden from public search
+    and popular listings while still existing in Postgres for their owner.
     """
     rows = await supa_conn.fetch(
         """
         SELECT w.id, w.slug, w.title, w.description,
-               w.is_public, w.created_at,
+               w.is_public, w.created_at, w.filters,
                u.name AS owner_name, u.username AS owner_username
         FROM watchlist w
         JOIN "user" u ON u.id = w.user_id
@@ -1879,16 +1944,32 @@ async def sync_watchlists_typesense(
     mirror_counts = {str(r["source_watchlist_id"]): r["cnt"] for r in mirror_count_rows}
 
     docs: list[dict] = []
+    trivial_ids: list[str] = []
     for r in rows:
         wid = str(r["id"])
         created_ts = int(r["created_at"].timestamp()) if r["created_at"] else 0
+        company_count = company_counts.get(wid, 0)
+
+        raw_filters = r["filters"]
+        filters: dict | None
+        if isinstance(raw_filters, str):
+            try:
+                filters = json.loads(raw_filters)
+            except (ValueError, TypeError):
+                filters = None
+        else:
+            filters = raw_filters
+
+        if _is_trivial_watchlist(filters, company_count):
+            trivial_ids.append(wid)
+            continue
 
         doc: dict = {
             "id": wid,
             "slug": r["slug"] or "",
             "title": r["title"] or "",
             "owner_name": r["owner_name"] or "",
-            "company_count": company_counts.get(wid, 0),
+            "company_count": company_count,
             "active_job_count": job_counts.get(wid, 0),
             "mirror_count": mirror_counts.get(wid, 0),
             "is_featured": (r["owner_username"] or "").lower() == "colophongroup",
@@ -1904,7 +1985,15 @@ async def sync_watchlists_typesense(
 
     loop = asyncio.get_event_loop()
     await loop.run_in_executor(None, _ts_bulk_upsert, client, "watchlist", docs)
-    log.info("typesense.watchlists.synced", count=len(docs))
+    # Drop any trivial watchlists that were previously indexed (e.g. pre-#2177
+    # or a web-side write hook that got skipped). This only touches Typesense;
+    # the rows still exist in Postgres for their owner.
+    await loop.run_in_executor(None, _ts_bulk_delete_ids, client, "watchlist", trivial_ids)
+    log.info(
+        "typesense.watchlists.synced",
+        upserted=len(docs),
+        trivial_deleted=len(trivial_ids),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/apps/crawler/tests/test_sync.py
+++ b/apps/crawler/tests/test_sync.py
@@ -9,6 +9,7 @@ from src.sync import (
     _UPSERT_COMPANIES,
     _UPSERT_OCCUPATION_DOMAIN_NAMES,
     _UPSERT_OCCUPATION_DOMAINS,
+    _is_trivial_watchlist,
     _load_boards,
     _load_companies,
     run_sync,
@@ -686,3 +687,51 @@ class TestRunSync:
 
         mock_close_all_pools.assert_called_once()
         mock_close_redis.assert_called_once()
+
+
+class TestIsTrivialWatchlist:
+    def test_no_companies_no_filters_is_trivial(self):
+        assert _is_trivial_watchlist({}, 0) is True
+        assert _is_trivial_watchlist(None, 0) is True
+
+    def test_any_company_and_currency_alone_are_trivial(self):
+        # Defaults/prefs don't count as meaningful.
+        assert _is_trivial_watchlist({"anyCompany": True}, 0) is True
+        assert _is_trivial_watchlist({"salaryCurrency": "USD"}, 0) is True
+        assert _is_trivial_watchlist({"anyCompany": True, "salaryCurrency": "USD"}, 0) is True
+
+    def test_companies_make_non_trivial(self):
+        assert _is_trivial_watchlist({}, 1) is False
+        assert _is_trivial_watchlist({"anyCompany": True}, 3) is False
+
+    @pytest.mark.parametrize(
+        "filters",
+        [
+            {"keywords": ["python"]},
+            {"locationSlugs": ["zurich"]},
+            {"occupationSlugs": ["engineer"]},
+            {"senioritySlugs": ["senior"]},
+            {"technologySlugs": ["react"]},
+            {"salaryMin": 100000},
+            {"salaryMax": 200000},
+            {"experienceMin": 2},
+            {"experienceMax": 10},
+            {"experienceMin": 0},
+            {"salaryMin": 0},
+        ],
+    )
+    def test_meaningful_filters_make_non_trivial(self, filters):
+        assert _is_trivial_watchlist(filters, 0) is False
+
+    @pytest.mark.parametrize(
+        "filters",
+        [
+            {"keywords": []},
+            {"locationSlugs": []},
+            {"occupationSlugs": []},
+            {"senioritySlugs": []},
+            {"technologySlugs": []},
+        ],
+    )
+    def test_empty_filter_arrays_are_trivial(self, filters):
+        assert _is_trivial_watchlist(filters, 0) is True

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -554,6 +554,27 @@ function languagesCacheKey(languages: string[] | undefined): string {
   return languages.join(",");
 }
 
+/**
+ * SQL predicate: the watchlist is **not** trivial.
+ *
+ * Mirror of `isTrivialWatchlist` from `@/lib/watchlist-utils`. A watchlist is
+ * trivial when it tracks no companies and carries no meaningful filters; we
+ * use this in Postgres fallbacks for public listings to match the Typesense
+ * indexing rule. Keep the two in sync.
+ */
+const nonTrivialWatchlistPredicate = sql`(
+  (SELECT count(*) FROM watchlist_company wc WHERE wc.watchlist_id = w.id) > 0
+  OR jsonb_array_length(COALESCE(w.filters->'keywords', '[]'::jsonb)) > 0
+  OR jsonb_array_length(COALESCE(w.filters->'locationSlugs', '[]'::jsonb)) > 0
+  OR jsonb_array_length(COALESCE(w.filters->'occupationSlugs', '[]'::jsonb)) > 0
+  OR jsonb_array_length(COALESCE(w.filters->'senioritySlugs', '[]'::jsonb)) > 0
+  OR jsonb_array_length(COALESCE(w.filters->'technologySlugs', '[]'::jsonb)) > 0
+  OR (w.filters ? 'salaryMin')
+  OR (w.filters ? 'salaryMax')
+  OR (w.filters ? 'experienceMin')
+  OR (w.filters ? 'experienceMax')
+)`;
+
 function buildFilterCacheKey(f: WatchlistFilters, companyIds: string[]): string {
   const parts: string[] = [];
   if (f.anyCompany) parts.push("any");
@@ -764,7 +785,7 @@ export async function searchPublicWatchlists(params: {
       }
       // Empty Typesense result or error — fall back to Postgres
       return queryPublicWatchlists({
-        whereClause: sql`w.is_public = true AND (w.title ILIKE ${"%" + q + "%"} OR w.description ILIKE ${"%" + q + "%"})`,
+        whereClause: sql`w.is_public = true AND ${nonTrivialWatchlistPredicate} AND (w.title ILIKE ${"%" + q + "%"} OR w.description ILIKE ${"%" + q + "%"})`,
         orderClause: sql`w.created_at DESC`,
         offset: params.offset,
         limit: params.limit,
@@ -799,7 +820,7 @@ export async function getPopularWatchlists(params: {
       }
       // Empty Typesense result or error — fall back to Postgres
       return queryPublicWatchlists({
-        whereClause: sql`w.is_public = true`,
+        whereClause: sql`w.is_public = true AND ${nonTrivialWatchlistPredicate}`,
         orderClause: sql`(u.username = 'colophongroup')::int DESC, (SELECT count(*)::int FROM watchlist w2 WHERE w2.source_watchlist_id = w.id) DESC, (w.description IS NOT NULL AND w.description != '')::int DESC, w.created_at DESC`,
         offset: params.offset,
         limit: params.limit,


### PR DESCRIPTION
## Summary

Follow-up to #2177. Trivial watchlists (no companies, no meaningful filters) were still leaking into the public \`watchlist\` collection through two paths:

- **Crawler \`sync_watchlists_typesense\`** — upserts every \`is_public = true\` row on each \`refresh-typesense\` run, re-adding trivials indexed pre-#2177 or from any hook that didn't fire. This is the main reason trivial watchlists kept reappearing even after the web-app hooks started skipping them.
- **Postgres fallbacks** in \`getPopularWatchlists\` and \`searchPublicWatchlists\` — filter only by \`is_public = true\`, so any Typesense outage would briefly surface trivials from Postgres.

## What this changes

- Adds \`_is_trivial_watchlist\` to \`apps/crawler/src/sync.py\`, mirroring \`apps/web/src/lib/watchlist-utils.ts\`.
- \`sync_watchlists_typesense\` now fetches \`w.filters\`, upserts only non-trivial watchlists, and deletes any trivial ones that were previously indexed so the collection converges.
- Adds a \`nonTrivialWatchlistPredicate\` SQL fragment in \`watchlists.ts\` and applies it to both Postgres fallback queries.
- New unit tests in \`tests/test_sync.py\` cover the trivial predicate — including the "empty arrays don't count" and "experienceMin: 0 does count" edge cases.

## What this does NOT do

Trivial watchlists stay in Postgres. Owners still see them in their own dashboard (\`getUserWatchlists\`) and can still visit them by direct URL (\`getWatchlistByUserAndSlug\`). They're only hidden from the public listings / search / popular surfaces that are served through Typesense.

## Test plan

- [x] \`pytest tests/test_sync.py\` — all 41 tests pass
- [ ] Deploy crawler, run \`crawler refresh-typesense\`, confirm \`typesense.watchlists.synced\` log shows \`trivial_deleted > 0\` on first run, then \`= 0\` on subsequent runs
- [ ] Confirm the affected watchlists stop appearing on the public popular list but still load at their owner-scoped URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)