### PR TITLE
Fix Typesense watchlist upsert 401 and sort overflow

### DIFF
--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -1112,7 +1112,7 @@ async function _getPopularWatchlistsTypesense(
     q: "*",
     query_by: "title,description",
     filter_by: "is_public:true",
-    sort_by: "is_featured:desc,mirror_count:desc,has_description:desc,created_at:desc",
+    sort_by: "is_featured:desc,mirror_count:desc,has_description:desc",
     per_page: limit,
     page: Math.floor(offset / limit) + 1,
   });

--- a/docs/11-typesense.md
+++ b/docs/11-typesense.md
@@ -42,7 +42,7 @@ Three scoped keys. Stored in: `apps/crawler/.env.local` (main branch), GitHub se
 |---------------------|-------|---------|-----------------|
 | `TYPESENSE_ADMIN_KEY` | Full access | Exporter, sync, backfill, setup scripts | Private network (crawler -> Typesense) |
 | `TYPESENSE_SEARCH_KEY` | `documents:search` on all collections | Web app search | Cloudflare tunnel |
-| `TYPESENSE_WRITE_KEY` | `documents:upsert/delete/update` on `watchlist` collection only | Web app watchlist mutations | Cloudflare tunnel |
+| `TYPESENSE_WRITE_KEY` | `documents:create/upsert/delete/update` on `watchlist` collection only | Web app watchlist mutations | Cloudflare tunnel |
 
 ## Collections
 


### PR DESCRIPTION
## Summary
- **Watchlist upsert 401**: Typesense 27.1 requires `documents:create` permission for upsert operations. Regenerated the write key with the missing action. **Manual step: update `TYPESENSE_WRITE_KEY` in Vercel env (new value in `apps/crawler/.env.local`) and redeploy.**
- **Popular watchlists 400**: `sort_by` had 4 fields but Typesense allows max 3. Dropped `created_at:desc`, keeping `is_featured`, `mirror_count`, and `has_description`.

## Test plan
- [ ] Update `TYPESENSE_WRITE_KEY` in Vercel env vars
- [ ] Redeploy and verify watchlist upserts no longer 401
- [ ] Verify popular watchlists page loads without 400 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)