### PR TITLE
Validate posting ID format before DB query

### DIFF
--- a/apps/web/src/lib/actions/search.ts
+++ b/apps/web/src/lib/actions/search.ts
@@ -30,11 +30,14 @@ export interface PostingDetail {
   descriptionUrl: string | null;
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 export async function getPostingDetail(params: {
   postingId: string;
   locale: string;
 }): Promise<PostingDetail | null> {
   const { postingId, locale } = params;
+  if (!UUID_RE.test(postingId)) return null;
   const key = `posting-detail:${postingId}:${locale}`;
   return cached(key, () => _fetchPostingDetail(postingId, locale), { ttl: 300 });
 }


### PR DESCRIPTION
## Summary
- Adds UUID format validation in `getPostingDetail` before the SQL query runs
- Non-UUID strings (e.g. `"test-id"`) now return `null` immediately instead of crashing Postgres with `invalid input syntax for type uuid`
- Protects all callers: API route, job detail dialog, my-jobs panel

## Test plan
- [ ] Visit `/api/v1/job?id=test-id` — should return 404, not 500
- [ ] Visit `/api/v1/job?id=<valid-uuid>` — should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)