### PR TITLE
Expand robots.txt disallow to locale-prefixed paths

### DIFF
--- a/apps/web/app/__tests__/robots.test.ts
+++ b/apps/web/app/__tests__/robots.test.ts
@@ -32,6 +32,19 @@ describe("robots", () => {
     expect(disallow).toContain("/sign-up");
   });
 
+  it("disallows locale-prefixed variants of private pages", () => {
+    const result = robots();
+    const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+    const wildcard = rules.find((r) => r.userAgent === "*");
+    const disallow = wildcard!.disallow as string[];
+    for (const locale of ["en", "de", "fr", "it"]) {
+      expect(disallow).toContain(`/${locale}/dashboard`);
+      expect(disallow).toContain(`/${locale}/sign-in`);
+      expect(disallow).toContain(`/${locale}/sign-up`);
+      expect(disallow).toContain(`/${locale}/settings`);
+    }
+  });
+
   it("disallows private API routes but not public v1", () => {
     const result = robots();
     const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
@@ -41,6 +54,16 @@ describe("robots", () => {
     expect(disallow).toContain("/api/admin/");
     expect(disallow).toContain("/api/stripe/");
     expect(disallow).not.toContain("/api/");
+  });
+
+  it("does not locale-prefix API paths", () => {
+    const result = robots();
+    const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
+    const wildcard = rules.find((r) => r.userAgent === "*");
+    const disallow = wildcard!.disallow as string[];
+    for (const locale of ["en", "de", "fr", "it"]) {
+      expect(disallow).not.toContain(`/${locale}/api/auth/`);
+    }
   });
 
   it("includes sitemap URL", () => {

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,8 +1,23 @@
 import type { MetadataRoute } from "next";
 import { siteConfig } from "@/content/config";
+import { locales } from "@/lib/i18n";
+
+function expandDisallow(paths: readonly string[]): string[] {
+  const out: string[] = [];
+  for (const path of paths) {
+    out.push(path);
+    // API routes are not locale-prefixed (middleware excludes /api/*),
+    // so only expand non-API paths to their locale-prefixed variants.
+    if (path.startsWith("/api/")) continue;
+    for (const locale of locales) {
+      out.push(`/${locale}${path}`);
+    }
+  }
+  return out;
+}
 
 export default function robots(): MetadataRoute.Robots {
-  const disallow = siteConfig.seo.disallow as unknown as string[];
+  const disallow = expandDisallow(siteConfig.seo.disallow as unknown as string[]);
 
   return {
     rules: [


### PR DESCRIPTION
## Summary
- `robots.txt` disallow entries are unprefixed (`/dashboard`, `/sign-in`, …), but every real URL is locale-prefixed (`/en/dashboard`, `/de/sign-in`, …) via `middleware.ts` + `app/[lang]/`. `Disallow: /dashboard` never matched, so private pages were effectively crawlable.
- `app/robots.ts` now expands each non-API disallow path to its `/{locale}{path}` variants for `en|de|fr|it`. `/api/*` paths stay unprefixed since the middleware matcher excludes them from locale routing.
- Added two test cases covering the locale-prefixed variants and the API non-prefixing behaviour.

## Test plan
- [x] `pnpm exec vitest run app/__tests__/robots.test.ts` — 8/8 passing
- [ ] Sanity-check `/robots.txt` on the preview deploy contains `/en/dashboard`, `/de/sign-in`, etc., and still contains `/api/auth/` without a locale prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)