### PR TITLE
Fix IndexNow watchlist notify silently broken (after() outside request scope)

### DIFF
--- a/apps/web/src/lib/__tests__/indexnow.test.ts
+++ b/apps/web/src/lib/__tests__/indexnow.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { notifyIndexNow } from "../indexnow";
@@ -60,11 +63,33 @@ describe("notifyIndexNow", () => {
     );
   });
 
-  it("dedupes URLs across paths", async () => {
+  it("dedupes URLs across paths and pins ordering", async () => {
     process.env.INDEXNOW_KEY = "test-key";
     await notifyIndexNow(["/foo", "/foo"]);
     const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
-    expect(body.urlList).toHaveLength(4); // 4 locales × 1 unique path
+    expect(body.urlList).toEqual([
+      "https://jseek.co/en/foo",
+      "https://jseek.co/de/foo",
+      "https://jseek.co/fr/foo",
+      "https://jseek.co/it/foo",
+    ]);
+  });
+
+  it("caps the batch at 10_000 URLs (IndexNow protocol limit)", async () => {
+    process.env.INDEXNOW_KEY = "test-key";
+    // 2_501 paths × 4 locales = 10_004 expanded URLs → must be trimmed.
+    const paths = Array.from({ length: 2_501 }, (_, i) => `/p${i}`);
+    await notifyIndexNow(paths);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.urlList).toHaveLength(10_000);
+  });
+
+  it("does not log on a 200 response (success is silent)", async () => {
+    process.env.INDEXNOW_KEY = "test-key";
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await notifyIndexNow(["/foo"]);
+    expect(errSpy).not.toHaveBeenCalled();
   });
 
   it("logs (does not throw) when the endpoint rejects with 4xx", async () => {
@@ -73,6 +98,7 @@ describe("notifyIndexNow", () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     await expect(notifyIndexNow(["/foo"])).resolves.toBeUndefined();
     expect(errSpy).toHaveBeenCalledOnce();
+    expect(String(errSpy.mock.calls[0][0])).toContain("403");
   });
 
   it("logs (does not throw) on network errors", async () => {
@@ -81,6 +107,22 @@ describe("notifyIndexNow", () => {
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     await expect(notifyIndexNow(["/foo"])).resolves.toBeUndefined();
     expect(errSpy).toHaveBeenCalledOnce();
+  });
+
+  it("does not import next/server (caller owns after() wrapping)", () => {
+    // Structural regression guard. The original bug was that
+    // notifyIndexNow called after() internally, which silently failed
+    // when callers wrapped it inside a detached `_getOwnerInfo(...)
+    // .then(...)` chain (request scope already torn down). The fix
+    // moved after() up to the call sites in
+    // apps/web/src/lib/actions/watchlists.ts. A future refactor that
+    // re-imports `after` from "next/server" into indexnow.ts would
+    // re-introduce the same failure mode.
+    const src = readFileSync(
+      join(__dirname, "..", "indexnow.ts"),
+      "utf-8",
+    );
+    expect(src).not.toMatch(/from\s+["']next\/server["']/);
   });
 
   it("awaits the fetch (returns only after the POST resolves)", async () => {

--- a/apps/web/src/lib/__tests__/indexnow.test.ts
+++ b/apps/web/src/lib/__tests__/indexnow.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { notifyIndexNow } from "../indexnow";
+
+const ORIGINAL_KEY = process.env.INDEXNOW_KEY;
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", fetchMock);
+  fetchMock.mockReset();
+  fetchMock.mockResolvedValue(new Response(null, { status: 200 }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  if (ORIGINAL_KEY === undefined) delete process.env.INDEXNOW_KEY;
+  else process.env.INDEXNOW_KEY = ORIGINAL_KEY;
+  vi.restoreAllMocks();
+});
+
+describe("notifyIndexNow", () => {
+  it("no-ops when INDEXNOW_KEY is unset", async () => {
+    delete process.env.INDEXNOW_KEY;
+    await notifyIndexNow(["/foo"]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when paths is empty", async () => {
+    process.env.INDEXNOW_KEY = "test-key";
+    await notifyIndexNow([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("expands one path to one URL per locale and posts a single batch", async () => {
+    process.env.INDEXNOW_KEY = "test-key";
+    await notifyIndexNow(["/u/wl"]);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [endpoint, init] = fetchMock.mock.calls[0];
+    expect(endpoint).toBe("https://api.indexnow.org/indexnow");
+    expect(init.method).toBe("POST");
+    const body = JSON.parse(init.body as string);
+    expect(body.host).toBe("jseek.co");
+    expect(body.key).toBe("test-key");
+    expect(body.keyLocation).toBe("https://jseek.co/indexnow-key.txt");
+    expect(body.urlList).toEqual([
+      "https://jseek.co/en/u/wl",
+      "https://jseek.co/de/u/wl",
+      "https://jseek.co/fr/u/wl",
+      "https://jseek.co/it/u/wl",
+    ]);
+  });
+
+  it("encodes path segments with spaces and unicode", async () => {
+    process.env.INDEXNOW_KEY = "test-key";
+    await notifyIndexNow(["/user name/lübeck-jobs"]);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.urlList[0]).toBe(
+      "https://jseek.co/en/user%20name/l%C3%BCbeck-jobs",
+    );
+  });
+
+  it("dedupes URLs across paths", async () => {
+    process.env.INDEXNOW_KEY = "test-key";
+    await notifyIndexNow(["/foo", "/foo"]);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.urlList).toHaveLength(4); // 4 locales × 1 unique path
+  });
+
+  it("logs (does not throw) when the endpoint rejects with 4xx", async () => {
+    process.env.INDEXNOW_KEY = "test-key";
+    fetchMock.mockResolvedValue(new Response("bad key", { status: 403 }));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(notifyIndexNow(["/foo"])).resolves.toBeUndefined();
+    expect(errSpy).toHaveBeenCalledOnce();
+  });
+
+  it("logs (does not throw) on network errors", async () => {
+    process.env.INDEXNOW_KEY = "test-key";
+    fetchMock.mockRejectedValue(new Error("ECONNRESET"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(notifyIndexNow(["/foo"])).resolves.toBeUndefined();
+    expect(errSpy).toHaveBeenCalledOnce();
+  });
+
+  it("awaits the fetch (returns only after the POST resolves)", async () => {
+    // Regression guard: an earlier shape wrapped fetch in next/server
+    // after() internally and returned synchronously, which broke when
+    // callers wrapped notifyIndexNow in a detached .then() chain. The
+    // current contract is: notifyIndexNow awaits fetch directly and
+    // the caller is responsible for invoking it inside after().
+    process.env.INDEXNOW_KEY = "test-key";
+    let resolved = false;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    fetchMock.mockImplementation(async () => {
+      await gate;
+      return new Response(null, { status: 200 });
+    });
+    const promise = notifyIndexNow(["/foo"]).then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    release();
+    await promise;
+    expect(resolved).toBe(true);
+  });
+});

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { after } from "next/server";
 import { eq, and, sql } from "drizzle-orm";
 import { db } from "@/db";
 import {
@@ -131,37 +132,43 @@ export async function createWatchlist(params: {
     );
   }
 
-  // Typesense write hook: upsert if public and non-trivial (fire-and-forget)
+  // Typesense + IndexNow hook: upsert if public and non-trivial.
+  // Wrapped in after() so the registration is synchronous in the
+  // request scope — calling notifyIndexNow from a detached .then()
+  // chain (the previous shape) silently broke because next/server's
+  // after() requires a live request context to attach work.
   const isPublic = params.isPublic ?? true;
   const mergedFilters = { anyCompany: true, ...params.filters };
   const trivial = isTrivialWatchlist(mergedFilters, params.companyIds.length);
   if (isPublic && !trivial) {
-    // Fetch owner info for the Typesense doc + IndexNow notification
-    _getOwnerInfo(userId).then((owner) => {
-      if (!owner) return;
-      tsUpsertWatchlist({
-        id: row.id,
-        slug,
-        title: params.title,
-        description: params.description,
-        owner_name: owner.name,
-        owner_username: owner.username ?? undefined,
-        company_count: params.companyIds.length,
-        active_job_count: 0, // will be refreshed by reconciliation cron
-        mirror_count: 0,
-        is_featured: (owner.username ?? "").toLowerCase() === "colophongroup",
-        has_description: !!params.description,
-        created_at: Math.floor(Date.now() / 1000),
-        is_public: true,
-      });
-      // Match sitemap semantics: only notify URLs the sitemap also exposes
-      // (see apps/web/app/sitemap.ts — filters `u.username IS NOT NULL`).
-      if (owner.username) {
-        const userSlug = owner.displayUsername ?? owner.username;
-        notifyIndexNow([`/${userSlug}/${slug}`]);
+    after(async () => {
+      try {
+        const owner = await _getOwnerInfo(userId);
+        if (!owner) return;
+        tsUpsertWatchlist({
+          id: row.id,
+          slug,
+          title: params.title,
+          description: params.description,
+          owner_name: owner.name,
+          owner_username: owner.username ?? undefined,
+          company_count: params.companyIds.length,
+          active_job_count: 0, // will be refreshed by reconciliation cron
+          mirror_count: 0,
+          is_featured: (owner.username ?? "").toLowerCase() === "colophongroup",
+          has_description: !!params.description,
+          created_at: Math.floor(Date.now() / 1000),
+          is_public: true,
+        });
+        // Match sitemap semantics: only notify URLs the sitemap also exposes
+        // (see apps/web/app/sitemap.ts — filters `u.username IS NOT NULL`).
+        if (owner.username) {
+          const userSlug = owner.displayUsername ?? owner.username;
+          await notifyIndexNow([`/${userSlug}/${slug}`]);
+        }
+      } catch (err) {
+        console.error("[createWatchlist] post-mutation hook failed", err);
       }
-    }).catch((err) => {
-      console.error("[createWatchlist] Typesense hook failed", err);
     });
   }
 
@@ -229,64 +236,69 @@ export async function updateWatchlist(params: {
     }
   }
 
-  // Typesense write hook (fire-and-forget).
-  // A doc is indexed when the watchlist is both public and non-trivial.
+  // Typesense + IndexNow hook. A doc is indexed when the watchlist is
+  // both public and non-trivial. after() must be called synchronously
+  // here so it registers in the request scope; the awaited work runs
+  // after the response is flushed but before Vercel terminates the
+  // function.
   const wasPublic = wl.isPublic;
   const nowPublic = params.isPublic !== undefined ? params.isPublic : wasPublic;
   const newFilters = params.filters !== undefined
     ? params.filters
     : (wl.filters ?? {}) as WatchlistFilters;
 
-  (async () => {
-    const newCompanyCount = params.companyIds !== undefined
-      ? params.companyIds.length
-      : await _countWatchlistCompanies(params.watchlistId);
-    const shouldIndex = nowPublic && !isTrivialWatchlist(newFilters, newCompanyCount);
+  after(async () => {
+    try {
+      const newCompanyCount = params.companyIds !== undefined
+        ? params.companyIds.length
+        : await _countWatchlistCompanies(params.watchlistId);
+      const shouldIndex = nowPublic && !isTrivialWatchlist(newFilters, newCompanyCount);
 
-    if (shouldIndex) {
-      // Idempotent upsert — doc may or may not exist (public↔private or
-      // trivial↔non-trivial transitions can leave stale or missing docs).
-      const owner = await _getOwnerInfo(userId);
-      if (!owner) return;
-      const desc = params.description !== undefined ? params.description : wl.description;
-      tsUpsertWatchlist({
-        id: params.watchlistId,
-        slug: newSlug,
-        title: params.title ?? wl.title,
-        description: desc ?? undefined,
-        owner_name: owner.name,
-        owner_username: owner.username ?? undefined,
-        company_count: newCompanyCount,
-        active_job_count: 0, // refreshed by reconciliation cron
-        mirror_count: 0,
-        is_featured: (owner.username ?? "").toLowerCase() === "colophongroup",
-        has_description: !!desc,
-        created_at: Math.floor(Date.now() / 1000),
-        is_public: true,
-      });
-      if (owner.username) {
-        const userSlug = owner.displayUsername ?? owner.username;
-        // Notify the new URL, plus the old slug if the title rename
-        // produced a new slug — the old URL now 404s and we want the
-        // engines to discover that.
-        const urls = [`/${userSlug}/${newSlug}`];
-        if (newSlug !== wl.slug) urls.push(`/${userSlug}/${wl.slug}`);
-        notifyIndexNow(urls);
+      if (shouldIndex) {
+        // Idempotent upsert — doc may or may not exist (public↔private or
+        // trivial↔non-trivial transitions can leave stale or missing docs).
+        const owner = await _getOwnerInfo(userId);
+        if (!owner) return;
+        const desc = params.description !== undefined ? params.description : wl.description;
+        tsUpsertWatchlist({
+          id: params.watchlistId,
+          slug: newSlug,
+          title: params.title ?? wl.title,
+          description: desc ?? undefined,
+          owner_name: owner.name,
+          owner_username: owner.username ?? undefined,
+          company_count: newCompanyCount,
+          active_job_count: 0, // refreshed by reconciliation cron
+          mirror_count: 0,
+          is_featured: (owner.username ?? "").toLowerCase() === "colophongroup",
+          has_description: !!desc,
+          created_at: Math.floor(Date.now() / 1000),
+          is_public: true,
+        });
+        if (owner.username) {
+          const userSlug = owner.displayUsername ?? owner.username;
+          // Notify the new URL, plus the old slug if the title rename
+          // produced a new slug — the old URL now 404s and we want the
+          // engines to discover that.
+          const urls = [`/${userSlug}/${newSlug}`];
+          if (newSlug !== wl.slug) urls.push(`/${userSlug}/${wl.slug}`);
+          await notifyIndexNow(urls);
+        }
+      } else if (wasPublic) {
+        // Was indexed and shouldn't be now — delete from Typesense and
+        // ping IndexNow so engines re-crawl and discover the 404/private
+        // response. IndexNow has no explicit delete; submitting the URL
+        // is the canonical re-crawl trigger.
+        tsDeleteWatchlist(params.watchlistId);
+        const owner = await _getOwnerInfo(userId);
+        if (owner?.username) {
+          const userSlug = owner.displayUsername ?? owner.username;
+          await notifyIndexNow([`/${userSlug}/${wl.slug}`]);
+        }
       }
-    } else if (wasPublic) {
-      // Was indexed and shouldn't be now — delete from Typesense and
-      // ping IndexNow so engines re-crawl and discover the 404/private
-      // response. IndexNow has no explicit delete; submitting the URL
-      // is the canonical re-crawl trigger.
-      tsDeleteWatchlist(params.watchlistId);
-      const owner = await _getOwnerInfo(userId);
-      if (owner?.username) {
-        const userSlug = owner.displayUsername ?? owner.username;
-        notifyIndexNow([`/${userSlug}/${wl.slug}`]);
-      }
+    } catch (err) {
+      console.error("[updateWatchlist] post-mutation hook failed", err);
     }
-  })().catch((err) => {
-    console.error("[updateWatchlist] Typesense hook failed", err);
   });
 
   return { slug: newSlug };
@@ -313,15 +325,20 @@ export async function deleteWatchlist(
 
   // IndexNow notification — only for URLs that were indexable (public).
   // The submission is a re-crawl trigger; engines will discover the 404
-  // and drop the URL from their index.
+  // and drop the URL from their index. Wrapped in after() so the work
+  // survives the response being flushed without blocking it; calling
+  // notifyIndexNow off a detached .then() loses the request scope.
   if (wl.isPublic) {
-    _getOwnerInfo(userId).then((owner) => {
-      if (owner?.username) {
-        const userSlug = owner.displayUsername ?? owner.username;
-        notifyIndexNow([`/${userSlug}/${wl.slug}`]);
+    after(async () => {
+      try {
+        const owner = await _getOwnerInfo(userId);
+        if (owner?.username) {
+          const userSlug = owner.displayUsername ?? owner.username;
+          await notifyIndexNow([`/${userSlug}/${wl.slug}`]);
+        }
+      } catch (err) {
+        console.error("[deleteWatchlist] IndexNow hook failed", err);
       }
-    }).catch((err) => {
-      console.error("[deleteWatchlist] IndexNow hook failed", err);
     });
   }
 
@@ -386,40 +403,50 @@ export async function copyWatchlist(
     );
   }
 
-  // Typesense write hooks (fire-and-forget):
-  // 1. Upsert the new copy (copies are always public) — unless trivial
+  // Typesense + IndexNow hooks. Wrapped in after() so work registers
+  // in the request scope; the previous detached .then() pattern broke
+  // notifyIndexNow because the inner after() lost its request context
+  // by the time the chain resolved.
   if (!isTrivialWatchlist(sourceFilters, companies.length)) {
-    _getOwnerInfo(userId).then((owner) => {
-      if (!owner) return;
-      tsUpsertWatchlist({
-        id: row.id,
-        slug,
-        title: source.title,
-        description: source.description ?? undefined,
-        owner_name: owner.name,
-        owner_username: owner.username ?? undefined,
-        company_count: companies.length,
-        active_job_count: 0, // refreshed by reconciliation cron
-        mirror_count: 0,
-        is_featured: (owner.username ?? "").toLowerCase() === "colophongroup",
-        has_description: !!source.description,
-        created_at: Math.floor(Date.now() / 1000),
-        is_public: true,
-      });
-      if (owner.username) {
-        const userSlug = owner.displayUsername ?? owner.username;
-        notifyIndexNow([`/${userSlug}/${slug}`]);
+    // 1. Upsert the new copy (copies are always public) — unless trivial.
+    after(async () => {
+      try {
+        const owner = await _getOwnerInfo(userId);
+        if (!owner) return;
+        tsUpsertWatchlist({
+          id: row.id,
+          slug,
+          title: source.title,
+          description: source.description ?? undefined,
+          owner_name: owner.name,
+          owner_username: owner.username ?? undefined,
+          company_count: companies.length,
+          active_job_count: 0, // refreshed by reconciliation cron
+          mirror_count: 0,
+          is_featured: (owner.username ?? "").toLowerCase() === "colophongroup",
+          has_description: !!source.description,
+          created_at: Math.floor(Date.now() / 1000),
+          is_public: true,
+        });
+        if (owner.username) {
+          const userSlug = owner.displayUsername ?? owner.username;
+          await notifyIndexNow([`/${userSlug}/${slug}`]);
+        }
+      } catch (err) {
+        console.error("[copyWatchlist] Typesense upsert hook failed", err);
       }
-    }).catch((err) => {
-      console.error("[copyWatchlist] Typesense upsert hook failed", err);
     });
   }
 
-  // 2. Update source watchlist's mirror_count (increment)
-  _getWatchlistMirrorCount(watchlistId).then((count) => {
-    tsUpdateWatchlistField(watchlistId, { mirror_count: count });
-  }).catch((err) => {
-    console.error("[copyWatchlist] Typesense mirror_count hook failed", err);
+  // 2. Update source watchlist's mirror_count (increment). No IndexNow
+  // here — the source URL hasn't changed visible content.
+  after(async () => {
+    try {
+      const count = await _getWatchlistMirrorCount(watchlistId);
+      tsUpdateWatchlistField(watchlistId, { mirror_count: count });
+    } catch (err) {
+      console.error("[copyWatchlist] Typesense mirror_count hook failed", err);
+    }
   });
 
   return { id: row.id, slug };

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -320,27 +320,25 @@ export async function deleteWatchlist(
 
   await db.delete(watchlist).where(eq(watchlist.id, watchlistId));
 
-  // Typesense write hook: delete (fire-and-forget, safe even if doc doesn't exist)
-  tsDeleteWatchlist(watchlistId);
-
-  // IndexNow notification — only for URLs that were indexable (public).
-  // The submission is a re-crawl trigger; engines will discover the 404
-  // and drop the URL from their index. Wrapped in after() so the work
-  // survives the response being flushed without blocking it; calling
-  // notifyIndexNow off a detached .then() loses the request scope.
-  if (wl.isPublic) {
-    after(async () => {
-      try {
+  // Typesense delete + IndexNow re-crawl trigger. Both post-mutation
+  // effects share one after() so registration is synchronous in the
+  // request scope. IndexNow only fires if the URL was indexable; the
+  // Typesense delete is idempotent so it runs unconditionally (safe
+  // even when the doc doesn't exist).
+  after(async () => {
+    try {
+      tsDeleteWatchlist(watchlistId);
+      if (wl.isPublic) {
         const owner = await _getOwnerInfo(userId);
         if (owner?.username) {
           const userSlug = owner.displayUsername ?? owner.username;
           await notifyIndexNow([`/${userSlug}/${wl.slug}`]);
         }
-      } catch (err) {
-        console.error("[deleteWatchlist] IndexNow hook failed", err);
       }
-    });
-  }
+    } catch (err) {
+      console.error("[deleteWatchlist] post-mutation hook failed", err);
+    }
+  });
 
   return { ok: true };
 }

--- a/apps/web/src/lib/indexnow.ts
+++ b/apps/web/src/lib/indexnow.ts
@@ -11,11 +11,12 @@ const INDEXNOW_ENDPOINT = "https://api.indexnow.org/indexnow";
  * to `api.indexnow.org` propagates to Bing, Yandex, Seznam, Naver, and
  * Microsoft Yep. Google does not participate in IndexNow.
  *
- * **Caller responsibility**: invoke from inside an `after()` block in
- * the originating server action / route handler. This function awaits
- * the fetch directly; without `after()`, the unawaited promise is
- * detached and Vercel may terminate the function before the POST
- * completes.
+ * **Caller contract**: this function awaits its fetch directly. In a
+ * Vercel server action / route handler, the caller should invoke it
+ * from inside `after()` (next/server) so the work survives the
+ * response being flushed without blocking it. In contexts where you
+ * can simply `await` to completion (route handlers that don't need to
+ * stream early, scripts, tests), no wrapping is required.
  *
  * Earlier revisions wrapped the fetch in `after()` internally, but
  * call sites were chaining `notifyIndexNow` off detached

--- a/apps/web/src/lib/indexnow.ts
+++ b/apps/web/src/lib/indexnow.ts
@@ -1,30 +1,36 @@
-import { after } from "next/server";
 import { siteConfig } from "@/content/config";
 import { locales } from "@/lib/i18n";
 
 const INDEXNOW_ENDPOINT = "https://api.indexnow.org/indexnow";
 
 /**
- * Deferred IndexNow notification for one or more app paths.
+ * Submit one or more app paths to IndexNow.
  *
  * Each path is expanded to every supported locale prefix — a single
  * user-facing mutation covers all hreflang alternates. A single POST
  * to `api.indexnow.org` propagates to Bing, Yandex, Seznam, Naver, and
  * Microsoft Yep. Google does not participate in IndexNow.
  *
- * Uses `after()` from `next/server`: the callback runs after the server
- * action's response has been streamed, but before the serverless
- * invocation is allowed to terminate. This avoids the classic
- * "fire-and-forget promise gets killed when the function returns"
- * failure mode on Vercel.
+ * **Caller responsibility**: invoke from inside an `after()` block in
+ * the originating server action / route handler. This function awaits
+ * the fetch directly; without `after()`, the unawaited promise is
+ * detached and Vercel may terminate the function before the POST
+ * completes.
+ *
+ * Earlier revisions wrapped the fetch in `after()` internally, but
+ * call sites were chaining `notifyIndexNow` off detached
+ * `_getOwnerInfo(...).then(...)` promises — by the time the chain
+ * resolved the request scope was gone and the inner `after()` no
+ * longer registered anything. Pulling `after()` up to the call site
+ * keeps the registration synchronous with the request.
  *
  * No-op when `INDEXNOW_KEY` is unset (local dev, preview deploys
- * without the secret). All errors are swallowed and logged — callers
- * must never observe failures.
+ * without the secret) or when `paths` is empty. All errors are caught
+ * and logged — callers must never observe failures.
  *
  * @param paths Locale-less app paths, e.g. ["/user/watchlist-slug"].
  */
-export function notifyIndexNow(paths: string[]): void {
+export async function notifyIndexNow(paths: string[]): Promise<void> {
   const key = process.env.INDEXNOW_KEY;
   if (!key || paths.length === 0) return;
 
@@ -47,23 +53,21 @@ export function notifyIndexNow(paths: string[]): void {
     urlList: unique,
   };
 
-  after(async () => {
-    try {
-      const res = await fetch(INDEXNOW_ENDPOINT, {
-        method: "POST",
-        headers: { "Content-Type": "application/json; charset=utf-8" },
-        body: JSON.stringify(payload),
-        signal: AbortSignal.timeout(10_000),
-      });
-      if (res.status !== 200 && res.status !== 202) {
-        console.error(
-          `[indexnow] submission rejected (${res.status}) for ${unique.length} urls`,
-        );
-      }
-    } catch (err) {
-      console.error("[indexnow] submission failed", err);
+  try {
+    const res = await fetch(INDEXNOW_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (res.status !== 200 && res.status !== 202) {
+      console.error(
+        `[indexnow] submission rejected (${res.status}) for ${unique.length} urls`,
+      );
     }
-  });
+  } catch (err) {
+    console.error("[indexnow] submission failed", err);
+  }
 }
 
 /**

--- a/docs/13-seo-and-indexnow.md
+++ b/docs/13-seo-and-indexnow.md
@@ -120,7 +120,7 @@ The key file is served by `apps/web/app/indexnow-key.txt/route.ts` with `dynamic
 Implementation:
 
 - No diff table. The mutation is the event — we know something changed because we just committed to Postgres.
-- Uses `after()` from `next/server` so the POST runs after the response is flushed but before the serverless function terminates on Vercel (avoids the classic "fire-and-forget promise killed at function exit" failure mode).
+- Each call site wraps the post-mutation hook (Typesense upsert / delete + `notifyIndexNow`) in `after()` from `next/server`. `after()` must be invoked **synchronously inside the request scope** — calling it from a detached `.then()` chain (an earlier shape of this code) silently no-ops because the request context is already torn down by the time the chain resolves. `notifyIndexNow` itself is a plain async function and assumes the caller provides `after()`; it does not call `after()` internally.
 - `encodeURIComponent` per path segment guards against user slugs with spaces / unicode / `%`-sequences.
 - Gated on `owner.username` being truthy, matching the sitemap's `WHERE u.username IS NOT NULL` filter — we don't notify URLs the sitemap doesn't expose.
 - No-op if `process.env.INDEXNOW_KEY` is unset (safe locally + on preview deploys without the secret).


### PR DESCRIPTION
## Summary

The web-side IndexNow notifier silently stopped firing for watchlist mutations.

**Symptom:** Bing's IndexNow dashboard shows the most recent submission at 17 Apr 2026 14:00 UTC (the crawler-side bootstrap of 16,684 company-locale URLs). Since then, **11 public watchlists were created** between Apr 13 and Apr 17 — including 2 *after* the bootstrap (16:51 and 18:38 UTC on Apr 17) — and **none reached IndexNow**.

The crawler-side container is healthy: hourly ticks all log `indexnow.nothing_to_submit unchanged=16684`, which is the expected steady state when no company stable fields or descriptions have changed in Postgres (`companies.csv` last touched 2026-04-09). The gap is web-side only.

## Root cause

`notifyIndexNow` (`apps/web/src/lib/indexnow.ts`) wrapped its `fetch` in `after()` from `next/server`. But every call site in `apps/web/src/lib/actions/watchlists.ts` invoked it from inside a detached promise:

```ts
_getOwnerInfo(userId).then((owner) => {
  // ...
  notifyIndexNow([`/${userSlug}/${slug}`]);  // calls after() here
}).catch((err) => { console.error(err) });

return { id, slug };
```

`after()` must be called **synchronously inside the request scope**. Once the action returns and `workAsyncStorage` exits, the inner `after()` throws `"after() was called outside a request scope"`. The wrapping `.catch()` swallowed it. (And once the request is torn down, even the `console.error` itself may not reach Vercel's log sink — which explains why a `vercel logs --since=6d --level error` grep across 5,000+ lines for `request scope` / `hook failed` / `indexnow` returns zero matches. The same lifecycle that breaks `after()` also drops late `console.error`.)

## Fix

- **`apps/web/src/lib/indexnow.ts`** — `notifyIndexNow` becomes a plain async function. Awaits its fetch directly; no internal `after()`. Docstring documents that the caller in a Vercel handler should wrap in `after()`.
- **`apps/web/src/lib/actions/watchlists.ts`** — wraps the post-mutation hook in `after(async () => { … })` at four call sites: `createWatchlist`, `updateWatchlist` (both indexed + unindex paths), `deleteWatchlist`, `copyWatchlist`. The Typesense upsert/delete invocations were moved inside the same `after()` block for consistency.
- **`apps/web/src/lib/__tests__/indexnow.test.ts`** — new file, 11 tests covering: no-op paths, locale expansion (exact URL list per path), encoding edge cases, dedupe + ordering, 10,000 URL cap, success-is-silent, 4xx error log includes status, network error logging, structural guard that the file does **not** import from `"next/server"`, and that the function awaits its fetch.
- **`docs/13-seo-and-indexnow.md`** — updated the implementation note to reflect that callers own the `after()` wrap and call out why.

## Known limitations / out of scope

- **Typesense fire-and-forget**. `tsUpsertWatchlist` / `tsDeleteWatchlist` / `tsUpdateWatchlistField` (in `apps/web/src/lib/search/typesense-watchlist.ts`) still return `void` and detach their internal `.upsert(...).catch(...)` promise. Wrapping their *invocations* in `after()` keeps the function alive long enough for the call to be issued, but doesn't await its completion. Making Typesense reliably durable would require changing those helpers to return `Promise<void>` — separate PR.
- **`addCompanyToWatchlist` / `clearWatchlistCompanies` / `removeCompanyFromWatchlist`** (~lines 1031, 1066) have the same detached `_countWatchlistCompanies(...).then(tsUpdateWatchlistField)` shape but it's Typesense-only with no IndexNow involvement, so they're not in this PR's blast radius.
- **Action-level integration tests**. There are no tests for `apps/web/src/lib/actions/watchlists.ts` (no `actions/__tests__/` directory exists). A useful follow-up is one test per action that mocks `next/server`'s `after`, captures the registered callback, runs it, and asserts `notifyIndexNow` is invoked with the expected URL list. Heavy mock surface (db / session / typesense / indexnow) so deferred to its own PR.

## Test plan

- [x] `pnpm test` in `apps/web` — 162 tests pass (11 new in `indexnow.test.ts`)
- [x] `pnpm tsc --noEmit` — clean (the only error is pre-existing `@jseek/mcp-server/handler` not built locally)
- [x] Verified `INDEXNOW_KEY` is set on Vercel: `curl https://jseek.co/indexnow-key.txt` returns `70974894bca8f34855a86ba0efd14d54` (matches the crawler's env)
- [ ] After deploy: create a public watchlist on prod and confirm a new entry appears on Bing's IndexNow submission dashboard within a few minutes

## Verification details (kept here for the postmortem)

- Crawler container: `deploy-indexnow-1` up 39h, hourly ticks, all `unchanged=16684`
- Postgres `indexnow_submission`: 16,684 rows, all `last_submitted_at` between `2026-04-17 12:00:17` and `12:00:19` UTC (the v2 hash bootstrap window)
- Supabase `watchlist`: 11 public rows since 2026-04-13, none reflected in Bing dashboard
- Vercel logs: 0 hits across 5,000+ lines for `request scope` / `hook failed` / `indexnow` — consistent with the `console.error` from the detached `.catch()` itself being dropped after the function exits

🤖 Generated with [Claude Code](https://claude.com/claude-code)