### PR TITLE
Drop render from merck-global-en (partial follow-up to #2229)

### DIFF
--- a/apps/crawler/data/boards.csv
+++ b/apps/crawler/data/boards.csv
@@ -2597,7 +2597,7 @@ merck,merck-cn-zh,https://careers.merckgroup.com/cn/zh/search-results,sitemap,"{
 merck,merck-de-de,https://careers.merckgroup.com/de/de/search-results,sitemap,"{""url"": ""https://careers.merckgroup.com/de/de/search-results/sitemap.xml"", ""url_filter"": ""/job/\\d+""}",json-ld,
 merck,merck-es-es,https://careers.merckgroup.com/es/es/search-results,sitemap,"{""url"": ""https://careers.merckgroup.com/es/es/search-results/sitemap.xml"", ""url_filter"": ""/job/\\d+""}",json-ld,
 merck,merck-fr-fr,https://careers.merckgroup.com/fr/fr/search-results,sitemap,"{""url"": ""https://careers.merckgroup.com/fr/fr/search-results/sitemap.xml"", ""url_filter"": ""/job/\\d+""}",json-ld,
-merck,merck-global-en,https://careers.merckgroup.com/global/en/search-results,sitemap,"{""url"": ""https://careers.merckgroup.com/global/en/search-results/sitemap.xml"", ""url_filter"": ""/job/\\d+""}",json-ld,"{""render"": true}"
+merck,merck-global-en,https://careers.merckgroup.com/global/en/search-results,sitemap,"{""url"": ""https://careers.merckgroup.com/global/en/search-results/sitemap.xml"", ""url_filter"": ""/job/\\d+""}",json-ld,
 merck,merck-it-it,https://careers.merckgroup.com/it/it/search-results,sitemap,"{""url"": ""https://careers.merckgroup.com/it/it/search-results/sitemap.xml"", ""url_filter"": ""/job/\\d+""}",json-ld,
 merck,merck-jp-ja,https://careers.merckgroup.com/jp/ja/search-results,sitemap,"{""url"": ""https://careers.merckgroup.com/jp/ja/search-results/sitemap.xml"", ""url_filter"": ""/job/\\d+""}",json-ld,
 merck,merck-kr-ko,https://careers.merckgroup.com/kr/ko/search-results,sitemap,"{""url"": ""https://careers.merckgroup.com/kr/ko/search-results/sitemap.xml"", ""url_filter"": ""/job/\\d+""}",json-ld,


### PR DESCRIPTION
## Summary

Follow-up sweep of the other `jsonld.not_found` hosts flagged in #2229. Only **Merck** is safely moveable off render; RTX / TI / Nokia / Tesco / MMC all still need it. Brings `merck-global-en` in line with the 7 other merck-* locale boards that already ship with empty scraper_config.

## Relentless verification from Hetzner

Egress IP `2a01:4f8:1c18:adf3::1` (Hetzner datacenter IPv6, same as production). Real failing URLs pulled from Loki's last 12h of `jsonld.not_found` events for each host.

### Merck — safe to drop render

```
LIVE  status=200 jsonld=2 JobPosting=2 in 0.33s  (http-only)
LIVE  status=200 jsonld=2 JobPosting=2 in 7.8s   (render=true)
GONE  status=410                                 (http-only → HTTPStatusError 410)
GONE  silent jsonld.not_found                    (render=true, current bug)
```

Live-URL A/B through the actual `jsonld.scrape()` function inside the production `crawler-full` container:

```
✓ /job/296398/Distribution-Supervisor   old=7.84s new=0.33s  (identical title)
```

Gone URLs (from Loki) via new config now raise `HTTPStatusError 410` → logged as `batch.scrape.error` instead of silent `jsonld.not_found`.

### Hosts that still need render — left alone

Verified from Hetzner with the crawler's default headers:

| host | status | jsonld | verdict |
|---|---|---:|---|
| `careers.rtx.com` | 200 but intermittent **403** on http-only (live URL `…01815827/Ada-…` returns HTTPStatusError 403 via raw HTTPX but extracts via render) | 2 via render, 0 via http on blocked URLs | **Keep render** — WAF sometimes blocks bot HTTP |
| `careers.ti.com` | 200 | **0** | **Keep render** — Oracle HCM SPA shell |
| `jobs.nokia.com` | 200 | **0** | **Keep render** — Oracle HCM SPA shell |
| `mmc.wd1.myworkdayjobs.com` | 200 (5785 bytes) | 0 | **Keep render** — Workday SPA shell |
| `careers.tesco.com` | 404 on every sampled URL | — | **Investigate separately** — list endpoint may be broken |

## Impact

Before (Merck global-en):
```
 35 jsonld.not_found/h  careers.merckgroup.com  (silent warnings on expired jobs)
~ slow scrapes hitting 45s network-idle tails for all posting fetches
```

After: live scrapes complete in ~0.3s (was ~7.8s); expired postings fire `HTTPStatusError 410` → `batch.scrape.error` which is caught by the existing 3-strike failure path and naturally drains from the queue.

## Test plan

- [x] `validate_csvs()` — 0 errors
- [x] `pytest -k "jsonld or sitemap"` — 119 passed
- [x] Live Hetzner A/B on 1 live URL: extracts identical title, 21× speedup
- [x] Live Hetzner on 2 Loki-failing URLs: both raise HTTPStatusError 410
- [ ] After deploy: `jsonld.not_found{host="careers.merckgroup.com"}` drops below 5/h

## Future follow-ups

- **RTX**: investigate the WAF pattern on `careers.rtx.com`. If the 403s are consistent per-request-without-browser-headers, stealth headers might unblock. If IP-based, proxy routing.
- **Tesco**: all sampled Loki URLs return 404 — the board's monitor may be producing stale URLs. Separate from the render question.
- **TI / Nokia**: already on Oracle HCM infrastructure; could possibly switch to the `oracle_hcm` monitor/scraper for an API-based path instead of relying on a rendered jsonld scrape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)