### PR TITLE
Restore ISR on company detail page (fixes #2243)

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/company-back-link.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-back-link.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { BackLink } from "@/components/BackLink";
+import type { Locale } from "@/lib/i18n";
+
+type Props = {
+  locale: Locale;
+  label: string;
+};
+
+/**
+ * "Back to search" link that preserves the user's current URL filters.
+ *
+ * Lives in a client component (reading `useSearchParams()`) so the
+ * surrounding company page can stay statically prerendered. Wrapped
+ * in `<Suspense>` by the caller; until hydration the fallback shows
+ * a plain `/explore` link without filter params.
+ */
+export function CompanyBackLink({ locale, label }: Props) {
+  const sp = useSearchParams();
+  const qs = sp.toString();
+  const href = `/${locale}/explore${qs ? `?${qs}` : ""}`;
+  return <BackLink href={href}>{label}</BackLink>;
+}

--- a/apps/web/app/[lang]/(app)/company/[slug]/company-head.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-head.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import Image from "next/image";
 import { Building2 } from "lucide-react";
 import { getI18n } from "@lingui/react/server";
@@ -12,15 +13,14 @@ import {
 import { withUtmSource } from "@/lib/utm";
 import type { CompanyDetail } from "@/lib/actions/company";
 import type { Locale } from "@/lib/i18n";
+import { CompanyBackLink } from "./company-back-link";
 
 type Props = {
   company: CompanyDetail;
   locale: Locale;
-  /** Raw URL search params carried over into the "Search results" back link. */
-  backSearchParams: Record<string, string | string[] | undefined>;
 };
 
-export function CompanyHead({ company, locale, backSearchParams }: Props) {
+export function CompanyHead({ company, locale }: Props) {
   const i18n = getI18n()!;
 
   const metaParts: string[] = [];
@@ -65,9 +65,11 @@ export function CompanyHead({ company, locale, backSearchParams }: Props) {
 
   return (
     <div className="space-y-4">
-      <BackLink href={buildExploreHref(locale, backSearchParams)}>
-        {backLabel}
-      </BackLink>
+      <Suspense
+        fallback={<BackLink href={`/${locale}/explore`}>{backLabel}</BackLink>}
+      >
+        <CompanyBackLink locale={locale} label={backLabel} />
+      </Suspense>
 
       <div className="flex items-center gap-3">
         {company.icon ? (
@@ -130,19 +132,3 @@ export function CompanyHead({ company, locale, backSearchParams }: Props) {
   );
 }
 
-function buildExploreHref(
-  locale: Locale,
-  params: Record<string, string | string[] | undefined>,
-): string {
-  const qs = new URLSearchParams();
-  for (const [key, value] of Object.entries(params)) {
-    if (value === undefined) continue;
-    if (Array.isArray(value)) {
-      for (const v of value) qs.append(key, v);
-    } else {
-      qs.set(key, value);
-    }
-  }
-  const s = qs.toString();
-  return `/${locale}/explore${s ? `?${s}` : ""}`;
-}

--- a/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
@@ -1,10 +1,6 @@
-import { Suspense } from "react";
 import type { Metadata } from "next";
 import { isLocale, defaultLocale, loadCatalog, initI18nForPage } from "@/lib/i18n";
-import {
-  getCompanyBySlug,
-  getSimilarCompanies,
-} from "@/lib/actions/company";
+import { getCompanyBySlug } from "@/lib/actions/company";
 import { siteConfig } from "@/content/config";
 import { buildAlternates } from "@/lib/seo";
 import { CompanyHead } from "./company-head";
@@ -15,7 +11,6 @@ export const revalidate = 600; // ISR: cache metadata for 10 minutes
 
 type Props = {
   params: Promise<{ lang: string; slug: string }>;
-  searchParams: Promise<Record<string, string | string[] | undefined>>;
 };
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
@@ -86,39 +81,27 @@ async function CompanyNotFound() {
   );
 }
 
-export default async function CompanyPageRoute({ params, searchParams }: Props) {
+export default async function CompanyPageRoute({ params }: Props) {
   const locale = await initI18nForPage(params);
   const { slug } = await params;
-  const sp = await searchParams;
 
   const company = await getCompanyBySlug(slug, locale);
   if (!company) return <CompanyNotFound />;
 
-  // Fire-and-hold the similar-companies query. We do NOT `await` it
-  // here — the head + postings list must stream to the browser
-  // without waiting for Typesense. The Promise is unwrapped inside
-  // <Suspense>; if Typesense is slow the rest of the page is already
-  // visible by then.
-  const similarPromise = getSimilarCompanies(company.id, company.industryId, {
-    searchParams: sp,
-    locale,
-  });
-
+  // Note: this page must stay statically prerenderable (revalidate=600).
+  // Anything that reads `searchParams`, `headers()`, `cookies()`, or
+  // session state on the server-render path will silently turn the
+  // route dynamic. The back-link (filter-aware) and similar-companies
+  // strip live in client subtrees that read `useSearchParams()` so the
+  // shell here stays a pure ISR target. See issue #2243.
   return (
     <div className="space-y-4">
-      <CompanyHead
-        company={company}
+      <CompanyHead company={company} locale={locale} />
+      <SimilarSection
+        companyId={company.id}
+        industryId={company.industryId}
         locale={locale}
-        backSearchParams={sp}
       />
-      <Suspense fallback={null}>
-        <SimilarSection
-          promise={similarPromise}
-          companyId={company.id}
-          industryId={company.industryId}
-          locale={locale}
-        />
-      </Suspense>
       <CompanyContent locale={locale} slug={slug} />
     </div>
   );

--- a/apps/web/app/[lang]/(app)/company/[slug]/similar-section.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/similar-section.tsx
@@ -1,35 +1,31 @@
+"use client";
+
 import { SimilarCompaniesStrip } from "@/components/company/similar-companies-strip";
-import type { SimilarCompaniesPage } from "@/lib/actions/company";
 import type { Locale } from "@/lib/i18n";
 
 type Props = {
-  /**
-   * Unawaited promise. Rendered under <Suspense> so the rest of the
-   * company page (head + postings list) streams without waiting for
-   * Typesense. Resolving a `hasMore=false` empty result silently hides
-   * the section, matching the behaviour for companies with no
-   * industry or no peers.
-   */
-  promise: Promise<SimilarCompaniesPage>;
   companyId: string;
   industryId: number | null;
   locale: Locale;
 };
 
-export async function SimilarSection({ promise, companyId, industryId, locale }: Props) {
-  const { companies, hasMore, truncated } = await promise;
-  if (companies.length === 0) return null;
+/**
+ * Client wrapper that mounts the similar-companies strip with empty
+ * initial state. The strip fetches page 0 on mount via a server
+ * action; rendering it client-side keeps the parent company page
+ * fully statically prerenderable (no `searchParams` / `headers()` /
+ * `getSession()` reads on the server render path).
+ */
+export function SimilarSection({ companyId, industryId, locale }: Props) {
+  if (industryId == null) return null;
   return (
-    <>
-      <hr className="border-divider" />
-      <SimilarCompaniesStrip
-        companyId={companyId}
-        industryId={industryId}
-        initialCompanies={companies}
-        initialHasMore={hasMore}
-        initialTruncated={truncated ?? false}
-        locale={locale}
-      />
-    </>
+    <SimilarCompaniesStrip
+      companyId={companyId}
+      industryId={industryId}
+      initialCompanies={[]}
+      initialHasMore={true}
+      initialTruncated={false}
+      locale={locale}
+    />
   );
 }

--- a/apps/web/app/__tests__/isr-routes.test.ts
+++ b/apps/web/app/__tests__/isr-routes.test.ts
@@ -1,0 +1,162 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const webRoot = join(here, "..", "..");
+
+/**
+ * Pages that MUST stay statically prerenderable (ISR), per the Vercel
+ * CPU-cost audit. Each of these pages exports `revalidate = N`, which
+ * Next.js silently downgrades to dynamic rendering if any dynamic
+ * API (`searchParams`, `headers()`, `cookies()`, `draftMode()`, or any
+ * helper that internally reads them) is touched on the render path.
+ *
+ * When that happens, the route serves `cache-control: private,
+ * no-store` instead of being CDN-cached, and every request hits the
+ * function. SEO landing pages like `/[lang]/company/[slug]` get the
+ * bulk of organic traffic, so a single regression here can blow the
+ * monthly CPU quota.
+ *
+ * If you need request-bound data on one of these pages, hoist the
+ * read into a client subtree (`useSearchParams()`) or a server action
+ * fired from the client. After deploy, verify with:
+ *
+ *   curl -sSI https://jseek.co/<a representative path> | grep cache
+ *
+ * The response must show `cache-control: public` and — after a
+ * warmup request — `x-vercel-cache: HIT`.
+ *
+ * See issue #2243 for the original incident.
+ */
+const ISR_PROTECTED_PAGES = [
+  "app/[lang]/(app)/company/[slug]/page.tsx",
+  // TODO(#2244): re-enable once the watchlist-detail fix lands.
+  // "app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx",
+];
+
+/**
+ * Direct dynamic API references whose presence anywhere in a server
+ * page module forces dynamic rendering. The `fix` field is shown in
+ * the assertion error so a developer who breaks this knows what to
+ * do without having to dig through Next.js docs.
+ */
+const FORBIDDEN_IN_ISR: ReadonlyArray<{ pattern: RegExp; fix: string }> = [
+  {
+    pattern: /\bawait\s+searchParams\b/,
+    fix: "Reading `searchParams` in a server component opts the page into dynamic rendering. Read it in a client subcomponent via `useSearchParams()` instead.",
+  },
+  {
+    pattern: /\bsearchParams\s*:\s*Promise\s*</,
+    fix: "Declaring `searchParams` in Props signals server-side reads. Drop the prop and read in a client subtree.",
+  },
+  {
+    pattern: /\bawait\s+headers\(\s*\)/,
+    fix: "`headers()` forces dynamic rendering. Move the read into a server action fired from the client, not the page render path.",
+  },
+  {
+    pattern: /\bawait\s+cookies\(\s*\)/,
+    fix: "`cookies()` forces dynamic rendering. Move the read into a server action fired from the client.",
+  },
+  {
+    pattern: /\bawait\s+draftMode\(\s*\)/,
+    fix: "`draftMode()` forces dynamic rendering. Not appropriate on a public ISR page.",
+  },
+  {
+    pattern: /\bawait\s+connection\(\s*\)/,
+    fix: "`connection()` forces dynamic rendering. Restructure so the dynamic data is fetched from a Suspense boundary or a client child.",
+  },
+];
+
+/**
+ * Server helpers that internally read `headers()` / `cookies()` / a
+ * session token. Calling any of them from an ISR-protected page's
+ * render path will silently break ISR. Maintained alongside the
+ * `sessionCache` and `viewer` modules — if you add another helper
+ * that reads request state, list it here too.
+ */
+const TAINTED_HELPERS: ReadonlyArray<string> = [
+  "getSession",
+  "getSessionUserId",
+  "getViewerLanguages",
+  "getGeoFromHeaders",
+  "getPreferences",
+];
+
+function isClientComponent(source: string): boolean {
+  // Match the leading "use client" directive (allow whitespace/comments above).
+  return /^\s*(?:\/\*[\s\S]*?\*\/\s*|\/\/.*\n\s*)*['"]use client['"]/.test(
+    source,
+  );
+}
+
+function lineOf(source: string, index: number): number {
+  return source.slice(0, index).split("\n").length;
+}
+
+function scanFile(label: string, source: string): void {
+  for (const { pattern, fix } of FORBIDDEN_IN_ISR) {
+    const match = source.match(pattern);
+    if (match) {
+      throw new Error(
+        `${label} contains forbidden pattern matching ${pattern} (line ${
+          lineOf(source, match.index ?? 0)
+        }).\n  ${fix}`,
+      );
+    }
+  }
+  for (const helper of TAINTED_HELPERS) {
+    const re = new RegExp(`\\b${helper}\\s*\\(`);
+    const match = source.match(re);
+    if (match) {
+      throw new Error(
+        `${label} calls "${helper}()" (line ${
+          lineOf(source, match.index ?? 0)
+        }), which internally reads request headers/cookies and forces dynamic rendering.\n  Move the call into a client component or a server action fired from the client.`,
+      );
+    }
+  }
+}
+
+describe("ISR-protected page templates stay static", () => {
+  for (const pagePath of ISR_PROTECTED_PAGES) {
+    it(`${pagePath} renders without dynamic-render triggers`, () => {
+      const fullPath = join(webRoot, pagePath);
+      const source = readFileSync(fullPath, "utf-8");
+
+      // Sanity: the page must declare `revalidate`. If it doesn't, the
+      // test is guarding a route that's already dynamic — pointless.
+      expect(
+        source,
+        `${pagePath} must export 'revalidate' to qualify as ISR-protected`,
+      ).toMatch(/export\s+const\s+revalidate\s*=/);
+
+      // The page module itself.
+      scanFile(pagePath, source);
+
+      // Co-located server components in the same directory. (Client
+      // components — files starting with "use client" — are skipped:
+      // their reads are request-scoped on the client, not the server,
+      // so they don't taint static rendering.)
+      const pageDir = dirname(fullPath);
+      const siblings = readdirSync(pageDir, { withFileTypes: true })
+        .filter(
+          (d) =>
+            d.isFile() &&
+            (d.name.endsWith(".tsx") || d.name.endsWith(".ts")) &&
+            d.name !== "page.tsx" &&
+            !d.name.endsWith(".test.ts") &&
+            !d.name.endsWith(".test.tsx"),
+        )
+        .map((d) => join(pageDir, d.name));
+
+      for (const sibling of siblings) {
+        const siblingSource = readFileSync(sibling, "utf-8");
+        if (isClientComponent(siblingSource)) continue;
+        const label = relative(webRoot, sibling);
+        scanFile(label, siblingSource);
+      }
+    });
+  }
+});

--- a/apps/web/src/components/company/similar-companies-strip.tsx
+++ b/apps/web/src/components/company/similar-companies-strip.tsx
@@ -39,8 +39,11 @@ export function SimilarCompaniesStrip({
   // Empty string means no filters, matches SSR semantics.
   const paramsKey = searchParams.toString();
   const spObject = useMemo(() => _searchParamsToObject(searchParams), [paramsKey]);
-  // Skip the inaugural refetch (SSR already produced `initialCompanies`).
-  const didHydrate = useRef(false);
+  // Suppress the inaugural fetch only when SSR already produced
+  // cards. When the parent passes `initialCompanies=[]` (the page is
+  // statically prerendered and hands off to the client to load), the
+  // first effect run must fire to actually populate the strip.
+  const skipNextFetch = useRef(initialCompanies.length > 0);
 
   const [companies, setCompanies] = useState<SimilarCompany[]>(initialCompanies);
   const [hasMore, setHasMore] = useState(initialHasMore);
@@ -51,8 +54,8 @@ export function SimilarCompaniesStrip({
   // a filter on the search toolbar). Counts on each card stay in sync
   // with the same filter state that drives the postings list.
   useEffect(() => {
-    if (!didHydrate.current) {
-      didHydrate.current = true;
+    if (skipNextFetch.current) {
+      skipNextFetch.current = false;
       return;
     }
     let cancelled = false;
@@ -107,35 +110,38 @@ export function SimilarCompaniesStrip({
   });
 
   return (
-    <nav aria-labelledby={headingId} className="space-y-2">
-      <h2
-        id={headingId}
-        className="text-xs font-medium uppercase tracking-wide text-muted"
-      >
-        {heading}
-      </h2>
-      <ScrollFade direction="horizontal" scrollRef={scrollRef} deps={[companies.length, truncated]}>
-        <ul role="list" className="flex snap-x snap-mandatory gap-2 pb-2">
-          {companies.map((company) => (
-            <SimilarCompanyCard
-              key={company.id}
-              company={company}
-              locale={locale}
-              preserveParams={paramsKey}
-            />
-          ))}
-          {hasMore && (
-            <InfiniteScrollSentinel
-              sentinelRef={sentinelRef}
-              isLoading={isLoading}
-              size="sm"
-              orientation="horizontal"
-            />
-          )}
-          {!hasMore && truncated && <SignInPromptCard />}
-        </ul>
-      </ScrollFade>
-    </nav>
+    <>
+      <hr className="border-divider" />
+      <nav aria-labelledby={headingId} className="space-y-2">
+        <h2
+          id={headingId}
+          className="text-xs font-medium uppercase tracking-wide text-muted"
+        >
+          {heading}
+        </h2>
+        <ScrollFade direction="horizontal" scrollRef={scrollRef} deps={[companies.length, truncated]}>
+          <ul role="list" className="flex snap-x snap-mandatory gap-2 pb-2">
+            {companies.map((company) => (
+              <SimilarCompanyCard
+                key={company.id}
+                company={company}
+                locale={locale}
+                preserveParams={paramsKey}
+              />
+            ))}
+            {hasMore && (
+              <InfiniteScrollSentinel
+                sentinelRef={sentinelRef}
+                isLoading={isLoading}
+                size="sm"
+                orientation="horizontal"
+              />
+            )}
+            {!hasMore && truncated && <SignInPromptCard />}
+          </ul>
+        </ScrollFade>
+      </nav>
+    </>
   );
 }
 

--- a/apps/web/src/lib/actions/company.ts
+++ b/apps/web/src/lib/actions/company.ts
@@ -702,8 +702,15 @@ export async function getSimilarCompanies(
   // actions/search.ts::searchCompanies and TruncationPrompt usage).
   // The cache stays shared between logged-in and anon; the cap is
   // applied outside the cached() boundary so cache keys don't multiply.
-  const userId = await getSessionUserId();
-  if (!userId && offset >= ANON_MAX_COMPANIES) {
+  //
+  // The session lookup (which reads request headers and would force
+  // dynamic rendering on any caller) is gated to the load-more path.
+  // First-page calls never approach the cap, so callers rendered from
+  // a static page can fetch page 0 without tainting the server render.
+  // See issue #2243.
+  const wouldHitCap = offset + limit > ANON_MAX_COMPANIES;
+  const userId = wouldHitCap ? await getSessionUserId() : null;
+  if (wouldHitCap && !userId && offset >= ANON_MAX_COMPANIES) {
     return { companies: [], hasMore: false, truncated: true };
   }
 
@@ -714,7 +721,7 @@ export async function getSimilarCompanies(
     { ttl: 3600 },
   );
 
-  if (!userId && offset + page.companies.length >= ANON_MAX_COMPANIES) {
+  if (wouldHitCap && !userId && offset + page.companies.length >= ANON_MAX_COMPANIES) {
     return { ...page, hasMore: false, truncated: true };
   }
   return page;


### PR DESCRIPTION
## Summary
- The `/[lang]/company/[slug]` template was rendered dynamically on every request despite `revalidate = 600`. Two compounding triggers: `await searchParams` in the server page, and `getSimilarCompanies()` calling `getSessionUserId()` (→ `headers()`) on its unfiltered hot path.
- Fix moves the search-param-dependent UI into client subtrees so the shell stays prerenderable. Back link becomes a tiny `<CompanyBackLink>` client component inside `<Suspense>`; similar-companies strip is mounted with empty initial state and loads page 0 from its existing on-mount fetch effect.
- `getSimilarCompanies()` defers its session lookup until a request actually nears the anonymous-user pagination cap (`offset + limit > ANON_MAX_COMPANIES`). Page 0 calls now read no request state.
- Adds `app/__tests__/isr-routes.test.ts` — a CI guardrail that scans ISR-protected page modules and their server-component siblings for the patterns that broke this issue (`await searchParams`, `await headers()`, `getSession()`, `getSessionUserId()`, `getViewerLanguages()`, `getGeoFromHeaders()`, `getPreferences()`). Fails with a specific, actionable message naming the helper, the file, and the line.

## Empirical evidence

Before:
```
$ curl -sSI https://jseek.co/en/company/stripe | grep -iE 'cache-control|x-vercel-cache'
cache-control: private, no-cache, no-store, max-age=0, must-revalidate
x-vercel-cache: MISS
```

After deploy, the same request should return `cache-control: public, max-age=0, must-revalidate` and (on the second hit within the revalidate window) `x-vercel-cache: HIT, x-nextjs-prerender: 1`.

## User-visible changes

- **Back link** ("Search results"): SSR shell renders a fallback link to `/[locale]/explore` with no filters; the client effect upgrades it to include the user's filter query string after hydration. Click before hydration (rare, sub-100ms window) drops filters.
- **Similar-companies strip**: no longer streams server-rendered cards. First paint shows nothing in that slot; cards arrive after one server-action round-trip (~150–400ms). Strip behavior on filter changes is unchanged.
- **Anon-cap**: enforced lazily — only checked when the page being requested could actually exceed `ANON_MAX_COMPANIES`. Behavior at the cap is identical for end-users.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test` (165 tests pass, including new `isr-routes.test.ts`)
- [x] Manually verified the new test fails with a clear message when `searchParams: Promise<...>` is reintroduced into Props
- [ ] After deploy, `curl -sSI https://jseek.co/en/company/stripe | grep cache` returns `public` cache-control and a `HIT` on the second request within 10 minutes
- [ ] Spot-check a logged-in user can still see filtered similar-companies after applying explore filters and navigating to a company page

## Out of scope (tracked separately)
- #2244 Watchlist detail page has the same broken-ISR pattern. The new test will protect that route too once the parallel fix lands — a `TODO(#2244)` line in the test marks where to re-enable it.
- #2245, #2246, #2247 — other CPU-cost wins from the same audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)