### PR TITLE
Restore ISR on watchlist detail page (fixes #2244)

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
@@ -1,20 +1,15 @@
-import { cache } from "react";
 import type { Metadata } from "next";
 import { isLocale, defaultLocale, loadCatalog } from "@/lib/i18n";
 import {
-  getWatchlistByUserAndSlug as _getWatchlistByUserAndSlug,
+  getPublicWatchlistByUserAndSlug,
   getWatchlistMatchingCompanyCount,
 } from "@/lib/actions/watchlists";
-import { getViewerLanguages } from "@/lib/viewer";
 import { isTrivialWatchlist } from "@/lib/watchlist-utils";
 import { siteConfig } from "@/content/config";
 import { buildAlternates } from "@/lib/seo";
 import { WatchlistContent } from "./watchlist-content";
 
 export const revalidate = 600; // ISR: cache metadata for 10 minutes
-
-// Deduplicate across generateMetadata + page component within a single render
-const getWatchlistByUserAndSlug = cache(_getWatchlistByUserAndSlug);
 
 type Props = {
   params: Promise<{ lang: string; userSlug: string; watchlistSlug: string }>;
@@ -24,7 +19,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { userSlug, watchlistSlug, lang } = await params;
   const locale = isLocale(lang) ? lang : defaultLocale;
   const [detail, { i18n }] = await Promise.all([
-    getWatchlistByUserAndSlug(userSlug, watchlistSlug),
+    // Public-only fetch: never reads session, so the page stays
+    // statically prerenderable (revalidate=600 above). The session-aware
+    // variant is only used by the client-fired server action that
+    // hydrates the page body. See issue #2244.
+    getPublicWatchlistByUserAndSlug(userSlug, watchlistSlug),
     loadCatalog(locale),
   ]);
   if (!detail) return {};
@@ -68,14 +67,16 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
           values: { owner: ownerLabel },
         });
   }
-  // For `anyCompany` watchlists, `detail.companies` is unrelated to what the
-  // watchlist actually tracks (it holds leftover rows from source copies).
-  // Ask Typesense how many distinct companies currently have postings matching
-  // the filter. Scope by the viewer's language preference so the social
-  // preview / page header match what the user actually sees below.
-  const languages = await getViewerLanguages(locale);
+  // For `anyCompany` watchlists, `detail.companies` is unrelated to what
+  // the watchlist actually tracks (it holds leftover rows from source
+  // copies). Ask Typesense how many distinct companies currently have
+  // postings matching the filter. Languages are intentionally NOT scoped
+  // to the viewer here — metadata is shared across all viewers via the
+  // CDN cache (ISR), so we use the broadest count (all languages). The
+  // page body re-runs the count scoped to the viewer's language
+  // preference once it hydrates.
   const companyCount = detail.filters.anyCompany
-    ? await getWatchlistMatchingCompanyCount(detail.filters, languages)
+    ? await getWatchlistMatchingCompanyCount(detail.filters)
     : detail.companies.length;
   if (companyCount > 0) {
     description = i18n._({

--- a/apps/web/app/__tests__/isr-routes.test.ts
+++ b/apps/web/app/__tests__/isr-routes.test.ts
@@ -32,8 +32,7 @@ const webRoot = join(here, "..", "..");
  */
 const ISR_PROTECTED_PAGES = [
   "app/[lang]/(app)/company/[slug]/page.tsx",
-  // TODO(#2244): re-enable once the watchlist-detail fix lands.
-  // "app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx",
+  "app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx",
 ];
 
 /**

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -617,6 +617,78 @@ export async function getWatchlistByUserAndSlug(
   };
 }
 
+/**
+ * Public-only variant of {@link getWatchlistByUserAndSlug} that does not
+ * read the request session. Returns the watchlist iff `is_public=true`,
+ * regardless of viewer; private watchlists return null even for the owner.
+ *
+ * Use this from contexts that must stay statically prerenderable (ISR
+ * pages, `generateMetadata`, sitemaps). The session-aware variant reads
+ * `headers()` via `getSessionUserId()` and tainted the watchlist detail
+ * page's ISR — see issue #2244.
+ */
+export async function getPublicWatchlistByUserAndSlug(
+  userSlug: string,
+  watchlistSlug: string,
+): Promise<WatchlistDetail | null> {
+  type WatchlistJoinRow = {
+    wl_id: string; slug: string; title: string; description: string | null;
+    is_public: boolean; alerts_enabled: boolean; filters: WatchlistFilters | null;
+    source_watchlist_id: string | null; created_at: Date; user_id: string;
+    owner_id: string; username: string | null;
+    display_username: string | null; owner_name: string;
+  };
+
+  const rows = await db.execute<{ [key: string]: unknown } & WatchlistJoinRow>(sql`
+    SELECT
+      w.id AS wl_id, w.slug, w.title, w.description,
+      w.is_public, w.alerts_enabled, w.filters,
+      w.source_watchlist_id, w.created_at, w.user_id,
+      u.id AS owner_id, u.username, u.display_username, u.name AS owner_name
+    FROM watchlist w
+    JOIN "user" u ON u.id = w.user_id
+    WHERE (u.username = ${userSlug} OR u.display_username = ${userSlug})
+      AND w.slug = ${watchlistSlug}
+      AND w.is_public = true
+    ORDER BY (u.username = ${userSlug})::int DESC
+    LIMIT 1
+  `);
+
+  const row = (rows as unknown as WatchlistJoinRow[])[0];
+  if (!row) return null;
+
+  const companies = await db
+    .select({
+      id: company.id,
+      name: company.name,
+      slug: company.slug,
+      icon: company.icon,
+    })
+    .from(watchlistCompany)
+    .innerJoin(company, eq(watchlistCompany.companyId, company.id))
+    .where(eq(watchlistCompany.watchlistId, row.wl_id))
+    .orderBy(company.name);
+
+  return {
+    id: row.wl_id,
+    slug: row.slug,
+    title: row.title,
+    description: row.description,
+    isPublic: row.is_public,
+    alertsEnabled: row.alerts_enabled,
+    filters: (row.filters ?? {}) as WatchlistFilters,
+    sourceWatchlistId: row.source_watchlist_id,
+    createdAt: new Date(row.created_at).toISOString(),
+    owner: {
+      id: row.owner_id,
+      username: row.username,
+      displayUsername: row.display_username,
+      name: row.owner_name,
+    },
+    companies,
+  };
+}
+
 export type PublicWatchlistEntry = WatchlistSummary & {
   ownerName: string;
   ownerUsername: string | null;


### PR DESCRIPTION
## Summary
- The `/[lang]/[userSlug]/[watchlistSlug]` template was rendered dynamically on every request despite `revalidate = 600`. Two compounding triggers in `generateMetadata`, both via `headers()`:
  1. `getViewerLanguages(locale)` (line 76) → `getSession()` → `headers()`.
  2. `getWatchlistByUserAndSlug(...)` (line 27) → internally `getSessionUserId()` (`watchlists.ts:542`) → `getSession()` → `headers()`. Used to grant owners access to their private watchlists and to touch `lastAccessedAt`.

  Removing only #1 would not have restored ISR — the audit-other-pages agent caught #2 before I shipped a half-fix.

- Fix: split off a session-less variant for the public, ISR-cacheable path. The session-aware function stays for the client-fired `fetchWatchlistPageData` server action.
  - **`getPublicWatchlistByUserAndSlug` (new, `watchlists.ts`)** — same JOIN but enforces `is_public = true` in SQL; never reads session; skips the owner-only `lastAccessedAt` touch.
  - **`page.tsx`** — imports the new function, drops the React `cache()` wrapper (had no second caller — was dead dedup), drops `getViewerLanguages(locale)`, calls `getWatchlistMatchingCompanyCount(detail.filters)` without languages so the count is locale-stable across all viewers.
- **Enables `/[userSlug]/[watchlistSlug]` in the ISR guardrail test** added in #2243 (PR #2248) — the test now protects both detail templates.

## Empirical evidence

Before:
```
$ curl -sSI 'https://jseek.co/en/colophongroup/all-jobs' | grep -iE 'cache-control|x-vercel-cache'
cache-control: private, no-cache, no-store, max-age=0, must-revalidate
x-vercel-cache: MISS
```

The same probe on three other curated watchlists (`enterprise-sales-in-switzerland`, `swe-robotics-zurich`) returned `MISS` and `private, no-store` on every request. After deploy, the watchlist routes should return `cache-control: public` and `x-vercel-cache: HIT` after a warmup request.

## Sitemap inventory
27 unique watchlist slugs in the sitemap × 4 locales (108 `<loc>` entries). Mostly `colophongroup/*` curated lists plus a handful of public user-created ones — primarily SEO crawler traffic, but every visit was hitting a dynamic function.

## User-visible changes

- **Owner viewing their own private watchlist via metadata**: returns empty metadata (no title/description). The page body still hydrates correctly via the session-aware client server action. Private watchlists aren't in the sitemap and don't need rich social previews — acceptable.
- **`Tracking N companies` count in metadata** (`anyCompany` watchlists): now counts across all languages instead of the viewer's preferred language. The number is more inclusive and locale-stable; the page body re-runs the count scoped to the viewer's preference once it hydrates, so the visible number stays accurate.
- **`isTrivialWatchlist` decision (de-indexing for empty watchlists)**: unchanged. The helper reads `filters` and `companies.length` — never the count, so the `robots: noindex` decision behaves identically.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test` (166 tests pass — 1 more than `main` once #2248 lands, since the watchlist test is now active)
- [x] Verified the new test fails with a clear, line-precise message when a `getViewerLanguages` reference is reintroduced
- [ ] After deploy, `curl -sSI https://jseek.co/en/colophongroup/all-jobs | grep cache` returns `public` cache-control and a `HIT` on the second request within 10 minutes
- [ ] Spot-check a logged-out user can still see public watchlist content; spot-check the owner can still see their own private watchlist (page body, even if metadata is empty)

## Stacked on #2248
This PR is based on `fix-web/company-page-isr` (PR #2248) and now targets `main` so CI runs (the workflow only triggers on PRs to main). The diff includes both #2248's changes and this commit; once #2248 merges, GitHub will re-base this and the diff will shrink to just the watchlist-page commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)