### PR TITLE
Skip fetchAppBootstrap() for anonymous users via logged_in hint cookie (fixes #2246)

### DIFF
--- a/apps/web/docs/edge-requests.md
+++ b/apps/web/docs/edge-requests.md
@@ -104,6 +104,9 @@ re-adding `useSession()`:
 - **Non-httpOnly cookie hint**: Set a lightweight `logged_in=1` cookie
   (non-httpOnly) at sign-in. Client JS can check `document.cookie` without
   a network request. Clear it on sign-out.
+  Already implemented — see `src/lib/auth.ts` `after` hook and
+  `src/lib/client-cookies.ts`. `AppBootstrapProvider` uses this to skip
+  `fetchAppBootstrap()` entirely for anonymous users (issue #2246).
 - **Deferred component**: Use `next/dynamic` with `ssr: false` to load the
   auth-dependent fragment only after the main page renders, so it doesn't
   block or slow initial paint.

--- a/apps/web/src/components/AppBootstrapProvider.tsx
+++ b/apps/web/src/components/AppBootstrapProvider.tsx
@@ -8,12 +8,36 @@ import { StarredCompaniesProvider } from "@/components/StarredCompaniesProvider"
 import { SalaryDisplayProvider } from "@/components/SalaryDisplayProvider";
 import { BannerProvider } from "@/components/BannerProvider";
 import { PreferencesInitializer } from "@/components/PreferencesInitializer";
+import { clearLoggedInHint, hasLoggedInHint } from "@/lib/client-cookies";
+
+const ANON_BOOTSTRAP: AppBootstrapData = {
+  user: null,
+  prefs: null,
+  savedStatuses: [],
+  starredIds: [],
+};
 
 export function AppBootstrapProvider({ children }: { children: ReactNode }) {
   const [data, setData] = useState<AppBootstrapData | null>(null);
 
   useEffect(() => {
-    fetchAppBootstrap().then(setData);
+    // Skip the server-action RPC when the `logged_in` hint cookie is
+    // absent — the vast majority of traffic is anonymous, and this path
+    // produces zero Vercel function invocations. The real session
+    // cookie is httpOnly so we cannot read it from JS; the non-httpOnly
+    // hint is maintained by the Better Auth `after` hook (see auth.ts)
+    // on every sign-in / sign-out / session-revocation. See #2246.
+    if (!hasLoggedInHint()) {
+      setData(ANON_BOOTSTRAP);
+      return;
+    }
+    fetchAppBootstrap().then((result) => {
+      // Self-heal a stale hint: if the server says we have no session
+      // but our hint said we did, drop the hint so subsequent page
+      // loads don't keep paying for the same empty round-trip.
+      if (!result.user) clearLoggedInHint();
+      setData(result);
+    });
   }, []);
 
   const isPending = data === null;

--- a/apps/web/src/components/__tests__/AppBootstrapProvider.test.tsx
+++ b/apps/web/src/components/__tests__/AppBootstrapProvider.test.tsx
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { useSession } from "../SessionProvider";
+
+// The real `@/lib/actions/bootstrap` is a server action that transitively
+// imports `server-only`, which throws when loaded in a non-Next runtime.
+// Neutralize it, then swap the action itself for a spy.
+vi.mock("server-only", () => ({}));
+const mockBootstrap = vi.fn();
+vi.mock("@/lib/actions/bootstrap", () => ({
+  fetchAppBootstrap: (...args: unknown[]) => mockBootstrap(...args),
+}));
+
+// BannerProvider reads window.localStorage during render. happy-dom's
+// localStorage implementation doesn't always expose getItem as a plain
+// function on the prototype, so stub it here — this test isn't
+// exercising that code path.
+if (typeof window !== "undefined") {
+  const memory = new Map<string, string>();
+  const stub: Storage = {
+    get length() {
+      return memory.size;
+    },
+    clear: () => memory.clear(),
+    getItem: (k: string) => (memory.has(k) ? (memory.get(k) as string) : null),
+    key: (i: number) => Array.from(memory.keys())[i] ?? null,
+    removeItem: (k: string) => {
+      memory.delete(k);
+    },
+    setItem: (k: string, v: string) => {
+      memory.set(k, v);
+    },
+  };
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: stub,
+  });
+}
+
+// Import after the mock is installed.
+import { AppBootstrapProvider } from "../AppBootstrapProvider";
+
+function SessionProbe() {
+  const { user, isLoggedIn, isPending } = useSession();
+  return (
+    <>
+      <span data-testid="pending">{String(isPending)}</span>
+      <span data-testid="logged-in">{String(isLoggedIn)}</span>
+      <span data-testid="user-name">{user?.name ?? "none"}</span>
+    </>
+  );
+}
+
+let cookieSpy: ReturnType<typeof vi.spyOn> | undefined;
+function setDocumentCookie(value: string) {
+  cookieSpy?.mockRestore();
+  cookieSpy = vi.spyOn(document, "cookie", "get").mockReturnValue(value);
+}
+
+beforeEach(() => {
+  mockBootstrap.mockReset();
+});
+
+afterEach(() => {
+  cookieSpy?.mockRestore();
+  cookieSpy = undefined;
+});
+
+describe("AppBootstrapProvider", () => {
+  it("does not call fetchAppBootstrap when the `logged_in` hint cookie is absent", async () => {
+    setDocumentCookie("utm_source=google; NEXT_LOCALE=en");
+    mockBootstrap.mockResolvedValue({
+      user: { id: "ghost", email: "x@x", name: "Ghost", emailVerified: true },
+      prefs: null,
+      savedStatuses: [],
+      starredIds: [],
+    });
+
+    render(
+      <AppBootstrapProvider>
+        <SessionProbe />
+      </AppBootstrapProvider>,
+    );
+
+    // Give any queued effects a chance to run.
+    await waitFor(() => {
+      expect(screen.getByTestId("pending").textContent).toBe("false");
+    });
+
+    expect(mockBootstrap).not.toHaveBeenCalled();
+    expect(screen.getByTestId("logged-in").textContent).toBe("false");
+    expect(screen.getByTestId("user-name").textContent).toBe("none");
+  });
+
+  it("calls fetchAppBootstrap and propagates user state when the hint cookie is present", async () => {
+    setDocumentCookie("logged_in=1; NEXT_LOCALE=en");
+    mockBootstrap.mockResolvedValue({
+      user: {
+        id: "u1",
+        email: "alice@example.com",
+        name: "Alice",
+        emailVerified: true,
+      },
+      prefs: null,
+      savedStatuses: [],
+      starredIds: [],
+    });
+
+    render(
+      <AppBootstrapProvider>
+        <SessionProbe />
+      </AppBootstrapProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("logged-in").textContent).toBe("true");
+    });
+    expect(mockBootstrap).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("user-name").textContent).toBe("Alice");
+  });
+
+  it("is pending at first render when bootstrap is required", async () => {
+    setDocumentCookie("logged_in=1");
+    let resolveBootstrap!: (v: unknown) => void;
+    mockBootstrap.mockReturnValue(
+      new Promise((resolve) => {
+        resolveBootstrap = resolve;
+      }),
+    );
+
+    render(
+      <AppBootstrapProvider>
+        <SessionProbe />
+      </AppBootstrapProvider>,
+    );
+
+    // Pre-resolution: waiting on the server action.
+    expect(screen.getByTestId("pending").textContent).toBe("true");
+    expect(mockBootstrap).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveBootstrap({
+        user: null,
+        prefs: null,
+        savedStatuses: [],
+        starredIds: [],
+      });
+    });
+
+    expect(screen.getByTestId("pending").textContent).toBe("false");
+  });
+
+  it("does not substring-match `logged_in` against other cookie names", async () => {
+    // Regression guard for a prior plan using bare `.includes`. A cookie
+    // named `x_logged_in_ago` should NOT be treated as the hint.
+    setDocumentCookie("x_logged_in_ago=1; NEXT_LOCALE=en");
+    mockBootstrap.mockResolvedValue({
+      user: null,
+      prefs: null,
+      savedStatuses: [],
+      starredIds: [],
+    });
+
+    render(
+      <AppBootstrapProvider>
+        <SessionProbe />
+      </AppBootstrapProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("pending").textContent).toBe("false");
+    });
+    expect(mockBootstrap).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/__tests__/client-cookies.test.ts
+++ b/apps/web/src/lib/__tests__/client-cookies.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { hasCookieNamed, LOGGED_IN_COOKIE } from "../client-cookies";
+
+describe("hasCookieNamed", () => {
+  const SESSION = "better-auth.session_token";
+  const SECURE_SESSION = "__Secure-better-auth.session_token";
+
+  it("returns false for empty cookie header", () => {
+    expect(hasCookieNamed("", SESSION)).toBe(false);
+  });
+
+  it("returns false when the cookie is not present", () => {
+    expect(hasCookieNamed("utm_source=google; utm_medium=cpc", SESSION)).toBe(
+      false,
+    );
+  });
+
+  it("finds the dev-mode cookie name", () => {
+    expect(hasCookieNamed(`${SESSION}=abc123`, SESSION)).toBe(true);
+  });
+
+  it("finds the prod-mode __Secure- cookie name", () => {
+    expect(hasCookieNamed(`${SECURE_SESSION}=xyz`, SECURE_SESSION)).toBe(true);
+  });
+
+  it("treats an empty value as still present", () => {
+    // Cookie-bomb defense: even `name=` counts as the cookie existing.
+    expect(hasCookieNamed(`${SESSION}=`, SESSION)).toBe(true);
+  });
+
+  it("does NOT match when the name is only a suffix", () => {
+    // Substring false-positive regression: bare `.includes` would match.
+    expect(hasCookieNamed(`x_${SESSION}=val`, SESSION)).toBe(false);
+  });
+
+  it("does NOT match when the name is only a prefix", () => {
+    expect(hasCookieNamed(`${SESSION}_old=val`, SESSION)).toBe(false);
+  });
+
+  it("finds the cookie when it is the first of several", () => {
+    expect(hasCookieNamed(`${SESSION}=a; other=b`, SESSION)).toBe(true);
+  });
+
+  it("finds the cookie when it is in the middle", () => {
+    expect(
+      hasCookieNamed(`a=1; ${SECURE_SESSION}=xyz; b=2`, SECURE_SESSION),
+    ).toBe(true);
+  });
+
+  it("finds the cookie when it is last", () => {
+    expect(hasCookieNamed(`a=1; b=2; ${SESSION}=val`, SESSION)).toBe(true);
+  });
+
+  it("ignores leading whitespace around entries", () => {
+    expect(hasCookieNamed(`a=1;   ${SESSION}=val`, SESSION)).toBe(true);
+  });
+
+  it("tolerates trailing semicolons", () => {
+    expect(hasCookieNamed(`${SESSION}=val;`, SESSION)).toBe(true);
+  });
+
+  it("tolerates repeated internal semicolons", () => {
+    expect(hasCookieNamed(`a=1;;; ${SESSION}=val;;;`, SESSION)).toBe(true);
+  });
+
+  it("handles a cookie value containing URL-encoded characters", () => {
+    expect(hasCookieNamed(`${SESSION}=abc%20def`, SESSION)).toBe(true);
+  });
+
+  it("accepts a bare cookie name with no `=` (unusual but valid input shape)", () => {
+    // Matches RFC-liberal behavior: treat `foo` alone as an implicit `foo=`.
+    expect(hasCookieNamed(`${SESSION}`, SESSION)).toBe(true);
+  });
+
+  it("works with the exported LOGGED_IN_COOKIE constant", () => {
+    expect(hasCookieNamed(`${LOGGED_IN_COOKIE}=1`, LOGGED_IN_COOKIE)).toBe(
+      true,
+    );
+    expect(hasCookieNamed("other=1", LOGGED_IN_COOKIE)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -8,8 +8,15 @@ import { db } from "@/db";
 import { sendVerificationEmail, sendResetPasswordEmail } from "@/lib/email";
 import { type Locale, defaultLocale, isLocale } from "@/lib/i18n";
 import { invalidateSessionCache } from "@/lib/sessionCache";
+import { LOGGED_IN_COOKIE } from "@/lib/client-cookies";
 import { sql } from "drizzle-orm";
 import { usernameFromEmail, withRandomSuffix, isReservedUsername } from "@/lib/username";
+
+// Max age for the `logged_in` hint cookie. Tracks Better Auth's default
+// session TTL (30 days). A slight mismatch here is self-healing:
+// `AppBootstrapProvider` clears the hint client-side if it turns out to
+// be stale (hint present but server says no session).
+const LOGGED_IN_COOKIE_MAX_AGE = 60 * 60 * 24 * 30;
 
 function localeFromRequest(request?: Request): Locale {
   const referer = request?.headers.get("referer") ?? "";
@@ -63,12 +70,13 @@ export const auth = betterAuth({
   },
   hooks: {
     after: createAuthMiddleware(async (ctx) => {
-      if (
+      const isSessionEndingPath =
         ctx.path.startsWith("/sign-out") ||
         ctx.path.startsWith("/revoke-session") ||
         ctx.path.startsWith("/revoke-sessions") ||
-        ctx.path.startsWith("/reset-password")
-      ) {
+        ctx.path.startsWith("/reset-password");
+
+      if (isSessionEndingPath) {
         const cookie = ctx.headers?.get("cookie") ?? "";
         for (const part of cookie.split(";")) {
           const trimmed = part.trim();
@@ -84,6 +92,34 @@ export const auth = betterAuth({
             break;
           }
         }
+      }
+
+      // Maintain the non-httpOnly `logged_in` hint cookie so that
+      // AppBootstrapProvider can skip the bootstrap server action for
+      // anonymous clients without a network round-trip. The real
+      // session token remains httpOnly/Secure — this cookie carries
+      // no security meaning. See docs/edge-requests.md and issue #2246.
+      const baseURL = ctx.context.options.baseURL ?? "";
+      const secure = baseURL.startsWith("https://");
+
+      if (ctx.context.newSession) {
+        // Sign-in (email/OAuth/username), autoSignInAfterVerification,
+        // or any other path where Better Auth established a new session.
+        ctx.setCookie(LOGGED_IN_COOKIE, "1", {
+          httpOnly: false,
+          sameSite: "lax",
+          secure,
+          path: "/",
+          maxAge: LOGGED_IN_COOKIE_MAX_AGE,
+        });
+      } else if (isSessionEndingPath) {
+        ctx.setCookie(LOGGED_IN_COOKIE, "", {
+          httpOnly: false,
+          sameSite: "lax",
+          secure,
+          path: "/",
+          maxAge: 0,
+        });
       }
     }),
   },

--- a/apps/web/src/lib/client-cookies.ts
+++ b/apps/web/src/lib/client-cookies.ts
@@ -1,0 +1,56 @@
+/**
+ * Name of the non-httpOnly "hint" cookie that mirrors the presence of a
+ * Better Auth session cookie. It carries no security meaning — the real
+ * session_token is still httpOnly and Secure — but lets client code
+ * skip network round trips for anonymous users by reading
+ * `document.cookie`. See `docs/edge-requests.md` and issue #2246.
+ */
+export const LOGGED_IN_COOKIE = "logged_in";
+
+/**
+ * Parse a raw Cookie-header-style string (either `document.cookie` or a
+ * server `Cookie` request header) and return whether `name` is present
+ * as an actual cookie name — not a substring of another name.
+ *
+ * Accepts missing / whitespace / trailing-semicolon inputs. Refuses to
+ * match values; the caller only cares that the cookie exists.
+ */
+export function hasCookieNamed(cookieHeader: string, name: string): boolean {
+  if (!cookieHeader) return false;
+  // Cookies are separated by `;`. Each entry is `name=value` with
+  // optional leading whitespace. A valid cookie name contains no `=`
+  // and no whitespace (per RFC 6265), so a trimmed segment matching
+  // `name=...` or `name=` or exactly `name` proves existence.
+  for (const raw of cookieHeader.split(";")) {
+    const part = raw.trim();
+    if (part === name) return true;
+    if (part.startsWith(`${name}=`)) return true;
+  }
+  return false;
+}
+
+/**
+ * Client-only: does the current browser have the `logged_in` hint cookie?
+ * Returns `false` on the server (no `document`) so callers get the safe
+ * "assume anonymous" default during SSR.
+ */
+export function hasLoggedInHint(): boolean {
+  if (typeof document === "undefined") return false;
+  return hasCookieNamed(document.cookie, LOGGED_IN_COOKIE);
+}
+
+/**
+ * Clear the `logged_in` hint cookie from the client side. Used to
+ * self-heal a stale hint when the server tells us the session has
+ * actually expired (e.g. `fetchAppBootstrap()` returns `{user: null}`
+ * while the hint was present).
+ */
+export function clearLoggedInHint(): void {
+  if (typeof document === "undefined") return;
+  // Max-Age=0 + Path=/ matches the attributes the server sets, so the
+  // UA removes the cookie. `Secure` is not strictly required to clear,
+  // but matching server behavior avoids creating a "second" cookie.
+  const secure = window.location.protocol === "https:" ? "; Secure" : "";
+  document.cookie =
+    `${LOGGED_IN_COOKIE}=; Max-Age=0; Path=/; SameSite=Lax${secure}`;
+}


### PR DESCRIPTION
## Summary
- Every page mount in the `(app)` route group fires a server-action RPC (`fetchAppBootstrap`) — even for anonymous viewers, who make up the bulk of traffic. For an anon, that RPC immediately returns an empty payload but still costs one Vercel function invocation.
- Fix: maintain a non-httpOnly `logged_in=1` hint cookie via a Better Auth `after` hook. `AppBootstrapProvider` reads it from `document.cookie` and short-circuits to the anon payload synchronously when absent — zero RPC, zero flicker.
- The real session cookie stays `httpOnly` / `Secure`; the hint carries no security meaning. `docs/edge-requests.md` already recommended this pattern — this PR implements it.

## Diligence applied (per user's bias-aware directive)

The fix I initially proposed was **fundamentally broken**. The bias-aware process caught it before any code was written:

- A targeted docs-research agent confirmed Better Auth's session cookie is `httpOnly` by default. A naive `document.cookie.includes("session_token=")` check always returns `false` — it would have permanently broken bootstrap for every signed-in user.
- A dedicated devil's-advocate agent independently flagged the same issue + called out stale-hint scenarios, which the fix now self-heals (the client clears the hint when the server confirms no session).
- The alternative of moving bootstrap server-side in the `(app)` layout was considered and rejected: reading `headers()` there would taint ISR and undo the gains from #2248 / #2249.

## Shape of the change

- **`src/lib/client-cookies.ts`** (new): `hasCookieNamed()` with strict matching (no substring false positives), plus `hasLoggedInHint()` and `clearLoggedInHint()`. 16 unit tests cover empty / trailing-semicolon / prefix-collision / suffix-collision / URL-encoded / dev vs `__Secure-` / bare-name cases.
- **`src/lib/auth.ts`**: extended the existing Better Auth `after` hook. On `ctx.context.newSession` (sign-in, OAuth callback, auto-sign-in-after-verification), set `logged_in=1` with `httpOnly: false, sameSite: lax, secure: <https?>, maxAge: 30d`. On `/sign-out`, `/revoke-session`, `/revoke-sessions`, `/reset-password`, clear it. Existing Redis invalidation logic is untouched.
- **`src/components/AppBootstrapProvider.tsx`**: `useEffect` short-circuits to the anon payload when the hint is absent. When the hint is present but the server returns `{user: null}` (stale hint), the client clears the hint so subsequent mounts stop paying for the same empty round-trip.
- **`src/components/__tests__/AppBootstrapProvider.test.tsx`** (new): 4 integration tests using `vi.spyOn(document, "cookie", "get")`: no hint → no RPC; hint present → RPC fires and user propagates; RPC pending → `isPending=true`; substring-collision regression guard.
- **`docs/edge-requests.md`**: marked the documented pattern as implemented, pointed at the code.

## Honest sizing of the impact

The initial audit estimated 10–20% CPU savings. Devil's-advocate review tempered that: `fetchSession()` for anon is sub-millisecond (no Redis/DB hit), so the dominant cost is per-invocation function overhead — ~20–100 ms warm, 200–500 ms cold. Realistic reduction is probably **2–5% of function CPU**, plus a meaningful drop in raw function-invocation count (matters for Vercel's request-based billing). Ship-worthy because the fix is small, test-covered, and the hint-cookie plumbing is reusable.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test` (184 tests pass — 20 new)
- [x] Verified the substring-collision guard catches `x_logged_in_ago=1` (regression guard in test file)
- [ ] After deploy: verify `logged_in=1` cookie is set on sign-in response and cleared on sign-out; anonymous DevTools → Network pane shows NO POST to `fetchAppBootstrap` on first load of `/explore`; logged-in Network pane still shows the POST firing.

## Risks / edge cases (explicitly enumerated)

- **Stale hint cookie**: if the session expires server-side while the hint persists, the first post-expiry load pays one extra empty RPC. The client then clears the hint — subsequent loads are clean. Self-healing.
- **Sign-in mid-session via modal**: not a current flow (sign-in uses the dedicated `(auth)` route group), but if one is added, the hint would be set by the server response and would take effect on the next mount. A future `authClient.signIn` wrapper could `router.refresh()` to force re-mount.
- **Multi-tab sign-in**: when tab A signs in, the browser writes the hint cookie. Tab B's existing mounted `AppBootstrapProvider` does not re-fire its `useEffect`, so the user would need to navigate or reload in tab B to pick up the change. Same limitation as today's bootstrap flow — not a regression.
- **OAuth callback**: the `after` hook fires on `/callback/*` paths; `ctx.context.newSession` is set and the hint cookie is attached to the redirect response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)