### PR TITLE
Cache sitemap.xml at the Vercel CDN with ISR (fixes #2245)

### DIFF
--- a/apps/web/app/__tests__/sitemap.test.ts
+++ b/apps/web/app/__tests__/sitemap.test.ts
@@ -27,7 +27,7 @@ vi.mock("@/lib/search/typesense-client", () => ({
   }),
 }));
 
-import sitemap from "../sitemap";
+import sitemap, { revalidate } from "../sitemap";
 
 function typesensePage(slugs: string[], found: number) {
   return {
@@ -50,6 +50,13 @@ describe("sitemap", () => {
     const result = await sitemap();
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBeGreaterThan(0);
+  });
+
+  it("exports `revalidate` so the response is CDN-cached as ISR (issue #2245)", () => {
+    // Without `revalidate`, every crawler hit runs the full handler
+    // (Postgres + Typesense + ~9 MB XML serialization). Regression
+    // guard: a future refactor must not silently drop this export.
+    expect(revalidate).toBe(3600);
   });
 
   it("generates entries for all 4 locales", async () => {

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -5,6 +5,21 @@ import { cached } from "@/lib/cache";
 import { siteConfig } from "@/content/config";
 import { locales } from "@/lib/i18n";
 
+/**
+ * ISR window for the generated sitemap.
+ *
+ * The default sitemap.ts behavior in Next.js 16 is "static if possible,
+ * otherwise dynamic on every request". Because this handler hits Postgres
+ * + Typesense at runtime (and the build step has no DB credentials), it
+ * was falling all the way to fully dynamic — every Bing/Yandex/Seznam
+ * crawl regenerated the full ~9 MB XML response. Setting `revalidate`
+ * makes Vercel CDN-cache the rendered response for 1 hour and triggers
+ * background ISR regeneration on expiry; the inner `cached()` Redis
+ * wrapper stays as a defense-in-depth safety net for rare CDN evictions
+ * within the window. See issue #2245.
+ */
+export const revalidate = 3600;
+
 type SitemapCompanyRow = {
   slug: string;
   updated_at: Date;
@@ -106,7 +121,15 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const CURATED_USERNAME = "colophongroup";
 
   const [companies, watchlists] = await Promise.all([
-    cached("sitemap:companies", fetchSitemapCompanies, { ttl: 3600 }),
+    cached("sitemap:companies", fetchSitemapCompanies, {
+      ttl: 3600,
+      // If the fetcher returns zero rows it almost always means a
+      // transient outage (Typesense alias swap, Postgres timeout) —
+      // not a legitimate "we have no companies". Skip caching so the
+      // next request gets another chance instead of poisoning the
+      // outer ISR window with an empty list. See #2245.
+      skipIf: (rows) => rows.length === 0,
+    }),
     cached("sitemap:watchlists", () => db.execute<{
       user_slug: string;
       watchlist_slug: string;


### PR DESCRIPTION
## Summary
- The `/sitemap.xml` route was being regenerated on every crawler hit. Production headers showed `cache-control: public, max-age=0, must-revalidate` and `x-vercel-cache: MISS` on three back-to-back probes from the same edge region. Each render serialized **~8.8 MB / ~165 k lines / ~2 k URLs × 4 locales** and ran a paginated Typesense scan plus a Postgres JOIN.
- Fix: `export const revalidate = 3600` on `app/sitemap.ts`. Per the Next.js 16 metadata-route doc, sitemap.ts is "a special Route Handler that is cached by default unless it uses a Request-time API or dynamic config option" — but because the handler awaits async DB/Typesense calls it had been falling all the way to dynamic. The `revalidate` export pins it to 1-hour ISR; regen happens in the background while crawlers get the cached XML.
- Defensive `skipIf: rows => rows.length === 0` on the inner `cached("sitemap:companies", ...)` Redis call — prevents an outage during a Typesense alias swap (or similar transient empty-result) from being amplified to a 1-hour cached blank sitemap.

## Diligence applied (per bias-aware directive)

- **Empirical first**: timed the current sitemap (~460 ms, 8.8 MB, 165 k lines, MISS on 3 consecutive `fra1` probes).
- **Verified the fix path against the Next.js 16.2.3 docs shipped in node_modules**, not the docs-research agent's initial answer. The docs-research agent claimed `revalidate` was "removed in v16" — that's a Cache-Components-only claim. The shipped `route-segment-config.md` still lists `revalidate` for `route.ts | layout.tsx | page.tsx`, and the shipped `sitemap.md` explicitly says sitemap.js is cached by default. Empirical pages with `revalidate=600` (the company / watchlist fixes in #2248 / #2249) confirm `revalidate` is alive in this codebase's runtime.
- **Devil's-advocate agent flagged "empty sitemap poisoning"**: if Typesense returns an empty result during an alias swap, the inner `cached()` would lock in a blank companies list for an hour, and the new outer ISR cache would amplify that to a 1-hour blank sitemap served to Googlebot. Mitigated with `skipIf` on the inner cache.
- **Considered and rejected the devil's-advocate's "convert to `app/sitemap.xml/route.ts` with `force-dynamic` + manual `Cache-Control`" alternative**: throws away the Next.js convention, loses background ISR semantics, and gains nothing the simple `revalidate` export doesn't already provide.
- **Considered removing the inner `cached()` wrappers** (they overlap with outer ISR). Kept them — the 8.8 MB response is close to commonly-cited Vercel CDN entry limits and an early eviction would otherwise pay the full Postgres + Typesense cost.

## Pre-existing concerns NOT addressed (out of scope)

- `lastModified: new Date()` (`sitemap.ts:82, 95, 137, 149`) emits the request-time timestamp. With ISR the lie is shorter (1 h instead of permanent) but it's still a lie. Real fix is to plumb the actual content mtime through — separate refactor.
- No external invalidation hook on the crawler side. New companies appear after the next ISR window (max 1 h delay). Acceptable for a sitemap whose `change-frequency` hint is already `daily`.
- ~9 MB approaches commonly-cited Vercel CDN entry limits. If the URL count grows much further, switch to `generateSitemaps()` shards. Flagged for the next refactor.

## Test plan
- [x] `pnpm lint`
- [x] `pnpm test` (165 tests pass — 1 new regression guard asserting `revalidate === 3600`)
- [ ] After deploy: `curl -sSI https://jseek.co/sitemap.xml | grep -iE 'cache-control|x-vercel-cache|age'` returns `s-maxage=3600` and `x-vercel-cache: HIT` on the second probe within an hour.
- [ ] Confirm Vercel build succeeds (the build already attempts prerender today; this PR doesn't introduce a new prerender attempt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)