### PR TITLE
Drop redundant getViewerLanguages from 3 page-data actions (#2247)

### DIFF
--- a/apps/web/src/lib/actions/company-page-data.ts
+++ b/apps/web/src/lib/actions/company-page-data.ts
@@ -3,7 +3,7 @@
 import { getCompanyBySlug, getCompanyPostings, type CompanyDetail } from "@/lib/actions/company";
 import { parseSearchFilters, type ParsedSearchFilters } from "@/lib/actions/search-input";
 import { getPreferences } from "@/lib/actions/preferences";
-import { getViewerLanguages } from "@/lib/viewer";
+import { resolveJobLanguages } from "@/lib/job-languages";
 import { firstOf, idsOrUndefined, parseRangeParam, getGeoFromHeaders } from "@/lib/search/params";
 import type { SearchResultPosting } from "@/lib/search";
 
@@ -51,14 +51,14 @@ export async function fetchCompanyPageData(params: {
 
   const { userLat, userLng } = await getGeoFromHeaders();
 
-  const [parsed, prefs, languages] = await Promise.all([
+  const [parsed, prefs] = await Promise.all([
     parseSearchFilters({ q, loc, occ, sen, tech, locale, userLat, userLng }),
     getPreferences(),
-    getViewerLanguages(locale),
   ]);
 
   const jobLanguages = prefs?.jobLanguages ?? [];
   const displayCurrency = prefs?.displayCurrency ?? "EUR";
+  const languages = resolveJobLanguages(jobLanguages, locale);
 
   const locationIds = idsOrUndefined(parsed.locations);
   const occupationIds = idsOrUndefined(parsed.occupations);

--- a/apps/web/src/lib/actions/explore-data.ts
+++ b/apps/web/src/lib/actions/explore-data.ts
@@ -3,7 +3,7 @@
 import { searchJobs, listTopCompanies } from "@/lib/actions/search";
 import { parseSearchFilters, type ParsedSearchFilters } from "@/lib/actions/search-input";
 import { getPreferences } from "@/lib/actions/preferences";
-import { getViewerLanguages } from "@/lib/viewer";
+import { resolveJobLanguages } from "@/lib/job-languages";
 import { firstOf, idsOrUndefined, parseRangeParam, getGeoFromHeaders } from "@/lib/search/params";
 import type { SearchResponse } from "@/lib/search";
 
@@ -41,14 +41,14 @@ export async function fetchExploreData(params: {
 
   const { userLat, userLng } = await getGeoFromHeaders();
 
-  const [parsed, prefs, languages] = await Promise.all([
+  const [parsed, prefs] = await Promise.all([
     parseSearchFilters({ q, loc, occ, sen, tech, locale, userLat, userLng }),
     getPreferences(),
-    getViewerLanguages(locale),
   ]);
 
   const jobLanguages = prefs?.jobLanguages ?? [];
   const displayCurrency = prefs?.displayCurrency ?? "EUR";
+  const languages = resolveJobLanguages(jobLanguages, locale);
 
   const locationIds = idsOrUndefined(parsed.locations);
   const occupationIds = idsOrUndefined(parsed.occupations);

--- a/apps/web/src/lib/actions/watchlist-page-data.ts
+++ b/apps/web/src/lib/actions/watchlist-page-data.ts
@@ -10,7 +10,7 @@ import { getUserPlan, PLAN_LIMITS, canCreateWatchlist } from "@/lib/plans";
 import { resolveLocationSlugs } from "@/lib/actions/locations";
 import { resolveOccupationSlugs, resolveSenioritySlugs, resolveTechnologySlugs } from "@/lib/actions/taxonomy";
 import { getPreferences } from "@/lib/actions/preferences";
-import { getViewerLanguages } from "@/lib/viewer";
+import { resolveJobLanguages } from "@/lib/job-languages";
 import type { WatchlistPostingEntry } from "@/lib/actions/watchlists";
 
 export interface WatchlistPageData {
@@ -43,16 +43,16 @@ export async function fetchWatchlistPageData(params: {
   const session = await getSession();
   const isOwner = session?.user?.id === detail.owner.id;
 
-  const [plan, limit, prefs, languages] = await Promise.all([
+  const [plan, limit, prefs] = await Promise.all([
     session ? getUserPlan(session.user.id) : ("free" as const),
     session ? canCreateWatchlist(session.user.id) : { allowed: false, current: 0, max: 0 },
     session ? getPreferences() : Promise.resolve(null),
-    getViewerLanguages(locale),
   ]);
   const isPaidPlan = PLAN_LIMITS[plan].canReceiveAlerts;
   const limitReached = !limit.allowed;
 
   const jobLanguages = prefs?.jobLanguages ?? [];
+  const languages = resolveJobLanguages(jobLanguages, locale);
 
   const filters = detail.filters;
 


### PR DESCRIPTION
## Summary

Each of `fetchExploreData` / `fetchCompanyPageData` / `fetchWatchlistPageData` was fetching preferences twice:
- once directly via `getPreferences()`
- once indirectly via `getViewerLanguages(locale)` (which itself calls `getPreferences()`)

Two DB roundtrips where one would do. This PR drops the second call and computes `languages` inline via `resolveJobLanguages(prefs?.jobLanguages ?? [], locale)`.

## Why this approach (vs. the issue's "hoist to client")

The issue suggested passing `prefs` + `languages` from the client (already in `AppBootstrapProvider` context). A devil's-advocate review surfaced four real problems with that approach:

1. **`prefs.jobLanguages` is NOT in any client context** — only `displayCurrency`, `salaryPeriod`, `dismissedBanners`, `theme`, `locale`, `cookieConsent` are exposed. Hoisting would require new context plumbing.
2. **Stale prefs after settings changes** — context only fetches once; settings updates don't invalidate it.
3. **Initial-render race** — `useEffect` page-data fetches can fire before `AppBootstrapProvider` resolves, so client would send `prefs: null` and stick with anonymous-defaults until refresh.
4. **Trust boundary** — `languages` flow into Typesense `filter_by` and Postgres array literals; sanitization would have to move to every read site.

The much smaller fix in this PR achieves the same CPU win (eliminating the duplicate `getPreferences` call per page-data fetch) without any of those costs.

## Test plan

- [x] `pnpm test --run` (190/190 pass)
- [x] `pnpm tsc --noEmit` (no new errors; pre-existing unrelated MCP error untouched)
- [ ] Manual: anonymous viewer renders with `[locale]` languages — unchanged
- [ ] Manual: logged-in user with `jobLanguages: ["en", "de"]` filters posts in those languages — unchanged
- [ ] Manual: logged-in user with `jobLanguages: ["*"]` (all languages) — unchanged

Closes #2247.

🤖 Generated with [Claude Code](https://claude.com/claude-code)