### PR TITLE
ws-package: include src/processing + src/queries in wheel

### DIFF
--- a/apps/web/src/lib/actions/company-page-data.ts
+++ b/apps/web/src/lib/actions/company-page-data.ts
@@ -3,7 +3,7 @@
 import { getCompanyBySlug, getCompanyPostings, type CompanyDetail } from "@/lib/actions/company";
 import { parseSearchFilters, type ParsedSearchFilters } from "@/lib/actions/search-input";
 import { getPreferences } from "@/lib/actions/preferences";
-import { getViewerLanguages } from "@/lib/viewer";
+import { resolveJobLanguages } from "@/lib/job-languages";
 import { firstOf, idsOrUndefined, parseRangeParam, getGeoFromHeaders } from "@/lib/search/params";
 import type { SearchResultPosting } from "@/lib/search";
 
@@ -51,14 +51,14 @@ export async function fetchCompanyPageData(params: {
 
   const { userLat, userLng } = await getGeoFromHeaders();
 
-  const [parsed, prefs, languages] = await Promise.all([
+  const [parsed, prefs] = await Promise.all([
     parseSearchFilters({ q, loc, occ, sen, tech, locale, userLat, userLng }),
     getPreferences(),
-    getViewerLanguages(locale),
   ]);
 
   const jobLanguages = prefs?.jobLanguages ?? [];
   const displayCurrency = prefs?.displayCurrency ?? "EUR";
+  const languages = resolveJobLanguages(jobLanguages, locale);
 
   const locationIds = idsOrUndefined(parsed.locations);
   const occupationIds = idsOrUndefined(parsed.occupations);

--- a/apps/web/src/lib/actions/explore-data.ts
+++ b/apps/web/src/lib/actions/explore-data.ts
@@ -3,7 +3,7 @@
 import { searchJobs, listTopCompanies } from "@/lib/actions/search";
 import { parseSearchFilters, type ParsedSearchFilters } from "@/lib/actions/search-input";
 import { getPreferences } from "@/lib/actions/preferences";
-import { getViewerLanguages } from "@/lib/viewer";
+import { resolveJobLanguages } from "@/lib/job-languages";
 import { firstOf, idsOrUndefined, parseRangeParam, getGeoFromHeaders } from "@/lib/search/params";
 import type { SearchResponse } from "@/lib/search";
 
@@ -41,14 +41,14 @@ export async function fetchExploreData(params: {
 
   const { userLat, userLng } = await getGeoFromHeaders();
 
-  const [parsed, prefs, languages] = await Promise.all([
+  const [parsed, prefs] = await Promise.all([
     parseSearchFilters({ q, loc, occ, sen, tech, locale, userLat, userLng }),
     getPreferences(),
-    getViewerLanguages(locale),
   ]);
 
   const jobLanguages = prefs?.jobLanguages ?? [];
   const displayCurrency = prefs?.displayCurrency ?? "EUR";
+  const languages = resolveJobLanguages(jobLanguages, locale);
 
   const locationIds = idsOrUndefined(parsed.locations);
   const occupationIds = idsOrUndefined(parsed.occupations);

--- a/apps/web/src/lib/actions/watchlist-page-data.ts
+++ b/apps/web/src/lib/actions/watchlist-page-data.ts
@@ -10,7 +10,7 @@ import { getUserPlan, PLAN_LIMITS, canCreateWatchlist } from "@/lib/plans";
 import { resolveLocationSlugs } from "@/lib/actions/locations";
 import { resolveOccupationSlugs, resolveSenioritySlugs, resolveTechnologySlugs } from "@/lib/actions/taxonomy";
 import { getPreferences } from "@/lib/actions/preferences";
-import { getViewerLanguages } from "@/lib/viewer";
+import { resolveJobLanguages } from "@/lib/job-languages";
 import type { WatchlistPostingEntry } from "@/lib/actions/watchlists";
 
 export interface WatchlistPageData {
@@ -43,16 +43,16 @@ export async function fetchWatchlistPageData(params: {
   const session = await getSession();
   const isOwner = session?.user?.id === detail.owner.id;
 
-  const [plan, limit, prefs, languages] = await Promise.all([
+  const [plan, limit, prefs] = await Promise.all([
     session ? getUserPlan(session.user.id) : ("free" as const),
     session ? canCreateWatchlist(session.user.id) : { allowed: false, current: 0, max: 0 },
     session ? getPreferences() : Promise.resolve(null),
-    getViewerLanguages(locale),
   ]);
   const isPaidPlan = PLAN_LIMITS[plan].canReceiveAlerts;
   const limitReached = !limit.allowed;
 
   const jobLanguages = prefs?.jobLanguages ?? [];
+  const languages = resolveJobLanguages(jobLanguages, locale);
 
   const filters = detail.filters;
 


### PR DESCRIPTION
## Summary

ws v0.8.58 wheel was missing `src/processing/` and `src/queries/`, so `ws run scraper` crashed with `ModuleNotFoundError: No module named 'src.processing'` for **every** board type, not just workday.

## Root cause

Commit a0e4654b (\"Fix ws run scraper not applying defaults to scraped content\") added:

\`\`\`python
from src.processing.scrape import _apply_defaults
\`\`\`

in \`src/workspace/commands/crawl.py\` but didn't update \`apps/crawler/ws-package/pyproject.toml\`'s \`force-include\` manifest. The dev install via \`uv sync\` worked because all source is on the path; only the slim PyPI wheel was broken.

\`src.processing.scrape\` transitively imports \`src.queries.{lookups,scrape}\` and the other \`src.processing\` modules, so the whole \`src/processing/\` and \`src/queries/\` trees go in.

## Fix

Added two entries to \`force-include\`:

\`\`\`toml
\"../src/processing/\" = \"src/processing/\"
\"../src/queries/\" = \"src/queries/\"
\`\`\`

VERSION bumped 0.8.58 → 0.8.59.

## Discovery

Caught by the post-config quality verification on PR #2346 (Workday) — the original config agent dismissed the \`ModuleNotFoundError\` as a \"known limitation\"; a follow-up verification agent traced it to the missing force-include entries.

## Test plan

- [x] Built wheel locally: \`uv build --wheel ws-package/\` → \`jobseek_crawler_setup-0.8.59-py3-none-any.whl\`
- [x] Verified wheel contains \`src/processing/{__init__,board,cpu,r2_stage,scrape}.py\` and \`src/queries/{__init__,lookups,monitor,scrape}.py\`
- [x] Installed wheel via \`uv tool install --reinstall\` and confirmed \`ws --version\` reports 0.8.59
- [ ] After merge: confirm published \`jobseek-crawler-setup\` wheel on PyPI ships these modules
- [ ] After merge: \`ws run scraper <slug>\` works end-to-end on a real workspace (was the symptom in PR #2346)

🤖 Generated with [Claude Code](https://claude.com/claude-code)