### PR TITLE
Add aircall

### DIFF
--- a/apps/crawler/data/companies.csv
+++ b/apps/crawler/data/companies.csv
@@ -4165,3 +4165,4 @@ zurich-insurance,Zurich Insurance,https://www.zurich.com,https://jobseek-assets.
 zus-health,Zus Health,https://zushealth.com,https://jobseek-assets.colophon-group.org/companies/zus-health/logo.png,https://jobseek-assets.colophon-group.org/companies/zus-health/icon.webp,wordmark+icon,,,,"{""sameAs"": [""https://www.facebook.com/ZusHealthHQ"", ""https://x.com/zushealthhq"", ""https://www.linkedin.com/company/zus-health/""]}"
 zwift,Zwift,https://www.zwift.com,https://jobseek-assets.colophon-group.org/companies/zwift/logo.jpg,https://jobseek-assets.colophon-group.org/companies/zwift/icon.webp,wordmark,1,,2014,"{""sameAs"": [""https://twitter.com/GoZwift""], ""wikidataId"": ""Q47461874""}"
 zynga,Zynga,https://www.zyngacareers.com,https://jobseek-assets.colophon-group.org/companies/zynga/logo.jpg,https://jobseek-assets.colophon-group.org/companies/zynga/icon.webp,wordmark,6,,,
+aircall,,,,,,,,,


### PR DESCRIPTION
Closes #2260

## Aircall
https://aircall.io
logo_type: wordmark+icon

| Full Logo | Minified Logo |
|-----------|----------------|
| ![full-logo](https://raw.githubusercontent.com/colophon-group/jobseek/93b4b5f9995f240d45c9dc3cb5f07351f9efa40b/apps/crawler/data/images/aircall/logo.png) | ![minified-logo](https://raw.githubusercontent.com/colophon-group/jobseek/93b4b5f9995f240d45c9dc3cb5f07351f9efa40b/apps/crawler/data/images/aircall/icon.png) |

|  | aircall-careers |
|---|---|
| URL | https://jobs.lever.co/aircall |
| Monitor | `lever` · `{"token": "aircall"}` |
| Scraper | *(auto)* |
| Jobs | 128 |
| Cost | ~16.14s/cycle |
| title | 128/128 (clean) |
| description | 128/128 (clean) |
| locations | 128/128 (clean) |
| employment_type | 125/128 (noisy) |
| job_location_type | 128/128 (clean) |
| date_posted | 0/128 (absent) |
| base_salary | 50/128 (clean) |
| skills | 0/128 (absent) |
| qualifications | 0/128 (absent) |
| responsibilities | 0/128 (absent) |
| valid_through | 0/128 (absent) |
| **Verdict** | **good** — Lever API returns full rich data for 128 jobs. All required fields clean. employment_type shows raw Lever commitment values (not normalized enum). date_posted absent. salary present for 50/128 jobs. |
