### PR TITLE
ws feedback: omit 0/N coverage when no per-field sample exists

### DIFF
--- a/apps/web/src/lib/actions/company-page-data.ts
+++ b/apps/web/src/lib/actions/company-page-data.ts
@@ -3,7 +3,7 @@
 import { getCompanyBySlug, getCompanyPostings, type CompanyDetail } from "@/lib/actions/company";
 import { parseSearchFilters, type ParsedSearchFilters } from "@/lib/actions/search-input";
 import { getPreferences } from "@/lib/actions/preferences";
-import { getViewerLanguages } from "@/lib/viewer";
+import { resolveJobLanguages } from "@/lib/job-languages";
 import { firstOf, idsOrUndefined, parseRangeParam, getGeoFromHeaders } from "@/lib/search/params";
 import type { SearchResultPosting } from "@/lib/search";
 
@@ -51,14 +51,14 @@ export async function fetchCompanyPageData(params: {
 
   const { userLat, userLng } = await getGeoFromHeaders();
 
-  const [parsed, prefs, languages] = await Promise.all([
+  const [parsed, prefs] = await Promise.all([
     parseSearchFilters({ q, loc, occ, sen, tech, locale, userLat, userLng }),
     getPreferences(),
-    getViewerLanguages(locale),
   ]);
 
   const jobLanguages = prefs?.jobLanguages ?? [];
   const displayCurrency = prefs?.displayCurrency ?? "EUR";
+  const languages = resolveJobLanguages(jobLanguages, locale);
 
   const locationIds = idsOrUndefined(parsed.locations);
   const occupationIds = idsOrUndefined(parsed.occupations);

--- a/apps/web/src/lib/actions/explore-data.ts
+++ b/apps/web/src/lib/actions/explore-data.ts
@@ -3,7 +3,7 @@
 import { searchJobs, listTopCompanies } from "@/lib/actions/search";
 import { parseSearchFilters, type ParsedSearchFilters } from "@/lib/actions/search-input";
 import { getPreferences } from "@/lib/actions/preferences";
-import { getViewerLanguages } from "@/lib/viewer";
+import { resolveJobLanguages } from "@/lib/job-languages";
 import { firstOf, idsOrUndefined, parseRangeParam, getGeoFromHeaders } from "@/lib/search/params";
 import type { SearchResponse } from "@/lib/search";
 
@@ -41,14 +41,14 @@ export async function fetchExploreData(params: {
 
   const { userLat, userLng } = await getGeoFromHeaders();
 
-  const [parsed, prefs, languages] = await Promise.all([
+  const [parsed, prefs] = await Promise.all([
     parseSearchFilters({ q, loc, occ, sen, tech, locale, userLat, userLng }),
     getPreferences(),
-    getViewerLanguages(locale),
   ]);
 
   const jobLanguages = prefs?.jobLanguages ?? [];
   const displayCurrency = prefs?.displayCurrency ?? "EUR";
+  const languages = resolveJobLanguages(jobLanguages, locale);
 
   const locationIds = idsOrUndefined(parsed.locations);
   const occupationIds = idsOrUndefined(parsed.occupations);

--- a/apps/web/src/lib/actions/watchlist-page-data.ts
+++ b/apps/web/src/lib/actions/watchlist-page-data.ts
@@ -10,7 +10,7 @@ import { getUserPlan, PLAN_LIMITS, canCreateWatchlist } from "@/lib/plans";
 import { resolveLocationSlugs } from "@/lib/actions/locations";
 import { resolveOccupationSlugs, resolveSenioritySlugs, resolveTechnologySlugs } from "@/lib/actions/taxonomy";
 import { getPreferences } from "@/lib/actions/preferences";
-import { getViewerLanguages } from "@/lib/viewer";
+import { resolveJobLanguages } from "@/lib/job-languages";
 import type { WatchlistPostingEntry } from "@/lib/actions/watchlists";
 
 export interface WatchlistPageData {
@@ -43,16 +43,16 @@ export async function fetchWatchlistPageData(params: {
   const session = await getSession();
   const isOwner = session?.user?.id === detail.owner.id;
 
-  const [plan, limit, prefs, languages] = await Promise.all([
+  const [plan, limit, prefs] = await Promise.all([
     session ? getUserPlan(session.user.id) : ("free" as const),
     session ? canCreateWatchlist(session.user.id) : { allowed: false, current: 0, max: 0 },
     session ? getPreferences() : Promise.resolve(null),
-    getViewerLanguages(locale),
   ]);
   const isPaidPlan = PLAN_LIMITS[plan].canReceiveAlerts;
   const limitReached = !limit.allowed;
 
   const jobLanguages = prefs?.jobLanguages ?? [];
+  const languages = resolveJobLanguages(jobLanguages, locale);
 
   const filters = detail.filters;
 


### PR DESCRIPTION
## Summary

When the monitor doesn't expose per-field quality data (URL-only monitors like workday) AND the agent's \`ws run scraper\` failed to produce a sample (e.g. earlier \`src.processing\` import bug, fixed in PR #2350), \`ws feedback --title clean\` synthesized misleading coverage strings like \"0/617 (clean)\" — implying 0 of 617 jobs had the field, when in reality the agent assessed quality manually via direct API calls.

## Fix

When \`coverage_data\` is empty:
1. Skip the auto-\`absent\` default (no measurement happened, can't conclude absence).
2. Leave the \`coverage\` fraction off the stored entry — the PR body already renders missing coverage as just the quality label via \`_format_field_quality\` (log.py:69-79).
3. Tier summary skips numeric aggregation when coverage is absent, but still propagates the worst quality across the tier.

When \`coverage_data\` has any per-field counts, behavior is unchanged: missing fields still auto-default to \`absent\` and show \`0/N (absent)\`.

## Test added

\`test_feedback_no_per_field_data_omits_coverage\` — a URL-only board with \`run.quality\` empty receives \`--title clean\` etc. and stores quality without a coverage fraction; tier summary still computes (\"0/0\").

## Discovery

Surfaced by the user reading PR #2358 (CrowdStrike) — the table showed \"0/617 (clean)\" for every field even though the agent had verified them manually via Workday's detail API. The fix in PR #2350 (src/processing in ws-package) prevents this scenario going forward; this PR additionally fixes the rendering for any case where field-level counts are absent.

## Test plan

- [x] \`uv run pytest tests/test_ws_commands.py::TestFeedback\` — 8/8 pass (incl. new test)
- [x] \`uv run pytest tests/\` — 3227/3227 pass
- [x] \`uv run ruff check\` clean
- [x] VERSION bumped 0.8.61 → 0.8.62

🤖 Generated with [Claude Code](https://claude.com/claude-code)