### PR TITLE
watchlist description: bump 200 → 1000 char limit, give it room

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
@@ -371,20 +371,20 @@ export function WatchlistViewPage({
                   }
                 }}
                 onBlur={saveDescription}
-                maxLength={200}
-                rows={2}
-                className="w-full resize-none rounded-md border border-border-soft bg-transparent px-2 py-1 text-sm text-muted outline-none focus:border-primary"
+                maxLength={1000}
+                rows={5}
+                className="w-full resize-y rounded-md border border-border-soft bg-transparent px-2 py-1 text-sm text-muted outline-none focus:border-primary"
                 placeholder={t({ id: "watchlists.view.descriptionPlaceholder", comment: "Placeholder for watchlist description textarea", message: "Describe this watchlist..." })}
               />
               {savingDescription && <Loader2 size={14} className="mt-1.5 animate-spin text-muted" />}
             </div>
           ) : description ? (
             <p
-              className="group/desc line-clamp-2 cursor-pointer rounded px-2 py-1 -mx-2 -my-1 text-sm text-muted transition-colors hover:bg-border-soft flex items-start gap-2"
+              className="group/desc cursor-pointer rounded px-2 py-1 -mx-2 -my-1 text-sm text-muted transition-colors hover:bg-border-soft flex items-start gap-2"
               onClick={() => setEditingDescription(true)}
               title={t({ id: "watchlists.view.editDescription", comment: "Tooltip for clicking to edit watchlist description", message: "Click to edit description" })}
             >
-              <span className="line-clamp-2">{description}</span>
+              <span className="line-clamp-6 whitespace-pre-wrap">{description}</span>
               <Pencil size={12} className="mt-0.5 shrink-0 text-muted opacity-0 transition-opacity group-hover/desc:opacity-100" />
             </p>
           ) : (
@@ -398,7 +398,7 @@ export function WatchlistViewPage({
             </button>
           )
         ) : description ? (
-          <p className="text-sm text-muted">{description}</p>
+          <p className="whitespace-pre-wrap text-sm text-muted">{description}</p>
         ) : null}
 
         {/* Companies */}


### PR DESCRIPTION
## Summary

The owner-side watchlist description textarea hard-capped at **200 chars** (\`maxLength={200}\`), too small for SEO-quality copy. Bump to **1000**.

## Surfaced by

The 9 marketing-driven country watchlists owned by \`colophongroup\` (\`big-tech-jobs-in-switzerland\`, …, \`big-tech-jobs-in-romania\`). Each was created via direct DB insert with ~500-char SEO copy mentioning Magnificent 7 + key cities + filter hints. The DB stored the full text (column is unbounded \`text\`), but if the owner ever opens the editor the textarea would silently truncate to 200 chars on save — and even read-only the visible portion was capped at \`line-clamp-2\` (≈100 chars at small font).

## Changes (owner view, watchlist page)

- \`maxLength={200}\` → \`maxLength={1000}\`
- \`rows={2}\` → \`rows={5}\` so the editor isn't cramped
- \`resize-none\` → \`resize-y\` so users can expand for very long copy
- displayed description \`line-clamp-2\` → \`line-clamp-6\` (about 500 chars visible at a glance)
- both owner display and public display gain \`whitespace-pre-wrap\` so any paragraph breaks the user typed survive (still rendered as plain text, not Markdown)

## What did NOT change

- DB schema — \`watchlist.description\` was already unbounded \`text\`
- Server actions \`createWatchlist\` / \`updateWatchlist\` — no length validation existed
- The OG / SEO meta description — already came from \`detail.description\` directly with no truncation in \`page.tsx:33-87\`
- Search-result thumbnails (\`public-watchlist-search.tsx:114\` keeps \`line-clamp-1\` — appropriate for a dropdown row)

## Test plan

- [x] ESLint clean
- [ ] Manual: edit one of the colophongroup country watchlists, paste a 500-char description, save, refresh — full text survives editing round-trip and displays.
- [ ] Manual: as anonymous viewer, full description renders without clamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)