### PR TITLE
Set wefox.name to unblock deploys (prod is down)

### DIFF
--- a/apps/crawler/data/companies.csv
+++ b/apps/crawler/data/companies.csv
@@ -4240,4 +4240,4 @@ zurich-insurance,Zurich Insurance,https://www.zurich.com,https://jobseek-assets.
 zus-health,Zus Health,https://zushealth.com,https://jobseek-assets.colophon-group.org/companies/zus-health/logo.png,https://jobseek-assets.colophon-group.org/companies/zus-health/icon.webp,wordmark+icon,,,,"{""sameAs"": [""https://www.facebook.com/ZusHealthHQ"", ""https://x.com/zushealthhq"", ""https://www.linkedin.com/company/zus-health/""]}"
 zwift,Zwift,https://www.zwift.com,https://jobseek-assets.colophon-group.org/companies/zwift/logo.jpg,https://jobseek-assets.colophon-group.org/companies/zwift/icon.webp,wordmark,1,,2014,"{""sameAs"": [""https://twitter.com/GoZwift""], ""wikidataId"": ""Q47461874""}"
 zynga,Zynga,https://www.zyngacareers.com,https://jobseek-assets.colophon-group.org/companies/zynga/logo.jpg,https://jobseek-assets.colophon-group.org/companies/zynga/icon.webp,wordmark,6,,,
-wefox,,,,,,,,,
+wefox,Wefox,https://www.wefox.com,,,,,,,


### PR DESCRIPTION
## Summary

`wefox` was added in #2427 with all fields NULL. `crawler sync` upserts companies.csv into the `company` table, which has `name TEXT NOT NULL`. Every deploy since 07:46 UTC has failed with:

```
asyncpg.exceptions.NotNullViolationError: null value in column "name" of relation "company" violates not-null constraint
DETAIL: Failing row contains (c15bd2ec..., wefox, null, null, ...).
```

All 8 deploys since 07:46 failed at the sync step, so the Hetzner compose stack is DOWN — only redis is running. No workers, browser-1, exporter, drain, or indexnow.

This PR populates `wefox.name = "Wefox"` + website, which is the minimum to pass the NOT NULL constraint. No board is configured for wefox yet, so the company is a no-op until a monitor is added later.

## Follow-ups (not in this PR)
- Harden `sync.py` to skip + warn on NULL-name rows so a broken stub CSV can never brick all deploys again.
- Revisit the company-request workflow so stubs aren't merged to main before having at least a name.

## Test plan
- [ ] Merge → next deploy run should pass the sync step
- [ ] Verify `docker compose ps` on browser worker shows all services healthy after deploy completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)