### PR TITLE
Jobylon parser hardening + transport-error semantics

### DIFF
--- a/apps/crawler/src/core/monitors/jobylon.py
+++ b/apps/crawler/src/core/monitors/jobylon.py
@@ -65,13 +65,13 @@ _JOBYLON_HOSTS: frozenset[str] = frozenset(
 # ``job-lang-XX``.  We prefer the latter.
 _LANG_CODE_RE = re.compile(r"job-lang-([a-z]{2})")
 
-# Top-level embed-jobs block we need to capture.  The delimiter uses
-# single quotes inside a bracketed key to avoid confusion with the
-# widget's ng-init attributes.
-_JOBS_BLOCK_RE = re.compile(
-    r"JBL\.embed_v2\['jobs'\]\s*=\s*(\[.*?\]);",
-    re.DOTALL,
-)
+# Anchor for the top-level embed-jobs assignment.  We locate the
+# ``JBL.embed_v2['jobs'] = [`` prefix via regex, then use a
+# string-aware bracket scanner to find the matching ``]``.  A pure
+# ``(\[.*?\]);`` capture would terminate at the first ``];`` that
+# appears *inside* a string value — verified empirically on fixtures
+# with titles containing ``];``-like glyphs.
+_JOBS_BLOCK_START_RE = re.compile(r"JBL\.embed_v2\['jobs'\]\s*=\s*\[")
 
 # Regex to locate an ``iframe src=""`` pointing at cdn.jobylon.com, used
 # during page-level detection of Jobylon.
@@ -163,26 +163,115 @@ def _single_to_double_quoted(text: str) -> str:
 _TRAILING_COMMA_RE = re.compile(r",(\s*[}\]])")
 
 
+def _quote_unquoted_keys_outside_strings(text: str) -> str:
+    """Run ``_UNQUOTED_KEY_RE`` substitution only outside double-quoted
+    strings. The naive ``re.sub`` would also match ``{foo:`` patterns
+    inside a string value (e.g. a code-snippet description), corrupting
+    it. This pass is string-state-aware.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    in_double = False
+    while i < n:
+        ch = text[i]
+        if in_double:
+            if ch == "\\" and i + 1 < n:
+                out.append(ch)
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if ch == '"':
+                in_double = False
+            out.append(ch)
+            i += 1
+            continue
+        if ch == '"':
+            in_double = True
+            out.append(ch)
+            i += 1
+            continue
+        # Not in a string — try the key-quoting regex against this
+        # position. ``_UNQUOTED_KEY_RE`` requires a ``{`` or ``,`` as
+        # the prefix anchor, so we can scan forward cheaply.
+        m = _UNQUOTED_KEY_RE.match(text, i)
+        if m:
+            out.append(f'{m.group("prefix")}"{m.group("key")}":')
+            i = m.end()
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
 def _js_object_literal_to_json(text: str) -> str:
     """Translate the relevant JS-object-literal subset to valid JSON.
 
-    Steps: quote unquoted keys, rewrite single-quoted strings into
-    double-quoted JSON strings, then strip JS-style trailing commas.
+    Quote-rewrite strings first so the subsequent key-quoting pass can
+    skip every in-string position. The combined pass is linear-time
+    and produces a string that ``json.loads`` accepts (after trailing-
+    comma stripping).
     """
-    quoted_keys = _UNQUOTED_KEY_RE.sub(
-        lambda m: f'{m.group("prefix")}"{m.group("key")}":',
-        text,
-    )
-    double_quoted = _single_to_double_quoted(quoted_keys)
-    return _TRAILING_COMMA_RE.sub(r"\1", double_quoted)
+    double_quoted = _single_to_double_quoted(text)
+    quoted_keys = _quote_unquoted_keys_outside_strings(double_quoted)
+    return _TRAILING_COMMA_RE.sub(r"\1", quoted_keys)
+
+
+def _find_jobs_array_extent(html: str, start: int) -> int | None:
+    """Locate the end of the ``[...]`` array starting at *html[start]*.
+
+    String-aware bracket scanner. Handles both single- and
+    double-quoted strings (Jobylon mixes them) and respects ``\\``
+    escapes inside either. Returns the index one past the closing
+    ``]``, or ``None`` if the array is unterminated.
+    """
+    if start >= len(html) or html[start] != "[":
+        return None
+    depth = 0
+    i = start
+    in_single = False
+    in_double = False
+    while i < len(html):
+        ch = html[i]
+        if in_single or in_double:
+            if ch == "\\" and i + 1 < len(html):
+                i += 2
+                continue
+            if in_single and ch == "'":
+                in_single = False
+            elif in_double and ch == '"':
+                in_double = False
+            i += 1
+            continue
+        if ch == "'":
+            in_single = True
+            i += 1
+            continue
+        if ch == '"':
+            in_double = True
+            i += 1
+            continue
+        if ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+            if depth == 0:
+                return i + 1
+        i += 1
+    return None
 
 
 def _parse_jobs_block(html: str) -> list[dict[str, Any]]:
     """Extract and parse the ``JBL.embed_v2['jobs']`` array from a page."""
-    match = _JOBS_BLOCK_RE.search(html)
+    match = _JOBS_BLOCK_START_RE.search(html)
     if not match:
         return []
-    raw = match.group(1)
+    bracket_start = match.end() - 1  # position of the opening ``[``
+    end = _find_jobs_array_extent(html, bracket_start)
+    if end is None:
+        log.warning("jobylon.parse_unterminated_array", start=bracket_start)
+        return []
+    raw = html[bracket_start:end]
     try:
         as_json = _js_object_literal_to_json(raw)
         data = json.loads(as_json)
@@ -421,16 +510,20 @@ def _ids_from_url(url: str) -> tuple[str | None, str | None]:
 # ── Discovery ────────────────────────────────────────────────────────────
 
 
-async def _fetch_embed(url: str, client: httpx.AsyncClient) -> str | None:
-    try:
-        resp = await client.get(url, follow_redirects=True)
-    except httpx.HTTPError as exc:
-        log.warning("jobylon.fetch_error", url=url, error=str(exc))
-        return None
+class _JobylonGone(Exception):
+    """Sentinel — the Jobylon embed returned 404 (board genuinely gone)."""
+
+
+async def _fetch_embed(url: str, client: httpx.AsyncClient) -> str:
+    """Fetch an embed page. Raises ``_JobylonGone`` on 404, ``HTTPError``
+    on transport failures / non-404 non-2xx. Never returns ``None`` —
+    callers need to distinguish "board deleted" from "Cloudflare hiccup"
+    and silent ``None`` conflates the two.
+    """
+    resp = await client.get(url, follow_redirects=True)
     if resp.status_code == 404:
-        return None
-    if resp.status_code != 200:
-        resp.raise_for_status()
+        raise _JobylonGone(url)
+    resp.raise_for_status()
     return resp.text
 
 
@@ -457,12 +550,16 @@ async def discover(board: dict, client: httpx.AsyncClient, pw=None) -> list[Disc
         company_id, company_group_id = _ids_from_url(board.get("board_url") or "")
 
     url = _embed_url(company_id, company_group_id)
-    html = await _fetch_embed(url, client)
-    if html is None:
+    try:
+        html = await _fetch_embed(url, client)
+    except _JobylonGone:
         raise BoardGoneError(
             f"Jobylon embed returned 404 for {url!r}",
             url=url,
-        )
+        ) from None
+    # httpx transport errors / non-404 HTTP errors propagate — the
+    # pipeline retries them; flipping a live board to "gone" on a
+    # transient ConnectError would cause spurious delistings.
 
     raw_jobs = _parse_jobs_block(html)
     jobs: list[DiscoveredJob] = []
@@ -503,10 +600,18 @@ async def _probe_embed(
     company_group_id: str | None,
     client: httpx.AsyncClient,
 ) -> int | None:
-    """Verify a Jobylon embed exists and count its jobs."""
+    """Verify a Jobylon embed exists and count its jobs.
+
+    Returns ``None`` for both 404 and transport errors — this path is
+    used by ``can_handle`` / auto-detection, where either signal means
+    "not a Jobylon board we can use from here," so collapsing them is
+    fine. The ``discover`` path distinguishes them so gone-detection
+    doesn't trip on network flakiness.
+    """
     url = _embed_url(company_id, company_group_id)
-    html = await _fetch_embed(url, client)
-    if html is None:
+    try:
+        html = await _fetch_embed(url, client)
+    except (_JobylonGone, httpx.HTTPError):
         return None
     return len(_parse_jobs_block(html))
 

--- a/apps/crawler/tests/test_jobylon_monitor.py
+++ b/apps/crawler/tests/test_jobylon_monitor.py
@@ -210,6 +210,45 @@ class TestParseJobsBlock:
         jobs = _parse_jobs_block(html)
         assert "McDonald's" in jobs[0]["title"]
 
+    def test_string_value_containing_close_bracket_semicolon(self):
+        """B1: a job title with ``];`` inside a string must not truncate
+        the array. The previous regex-only extraction (``\\[.*?\\];``)
+        stopped at the first ``];`` — even inside a quoted value.
+        """
+        literal = (
+            "["
+            "{id: '1', title: 'lead with ];', url: '/jobs/1-x/'},"
+            "{id: '2', title: 'second', url: '/jobs/2-y/'}"
+            "]"
+        )
+        html = _embed_html(literal)
+        jobs = _parse_jobs_block(html)
+        assert len(jobs) == 2
+        assert jobs[0]["title"] == "lead with ];"
+        assert jobs[1]["id"] == "2"
+
+    def test_string_value_containing_unquoted_key_pattern(self):
+        """B2: a description containing ``{foo: bar}`` patterns must not
+        get its interior keys quoted. Unquoted-key rewriting has to run
+        *after* single→double-quote conversion so every ``foo:``
+        candidate inside a string is already enclosed in double-quotes
+        and thus ignored by the key regex.
+        """
+        literal = (
+            "[{id: '1', url: '/jobs/1-x/', summary: 'config snippet: {host: localhost, port: 80}'}]"
+        )
+        html = _embed_html(literal)
+        jobs = _parse_jobs_block(html)
+        assert len(jobs) == 1
+        assert jobs[0]["summary"] == "config snippet: {host: localhost, port: 80}"
+
+    def test_unterminated_array_returns_empty(self):
+        """Malformed embed (no closing ``]``) is logged and skipped,
+        not a crash. Ensures ``_find_jobs_array_extent`` fails safely.
+        """
+        html = "<script>JBL.embed_v2['jobs'] = [{id: '1'</script>"
+        assert _parse_jobs_block(html) == []
+
 
 class TestParseJob:
     def test_basic_mapping(self):
@@ -644,11 +683,11 @@ class TestTransientErrors:
             with pytest.raises(httpx.HTTPStatusError):
                 await discover(board, client)
 
-    async def test_transport_error_raises_board_gone(self):
-        # httpx.ConnectError/etc. are swallowed by ``_fetch_embed`` and
-        # surface as BoardGoneError from ``discover`` — documented
-        # behavior of the current implementation.  If this changes in
-        # the future, loosen this test.
+    async def test_transport_error_propagates(self):
+        # Transport errors (ConnectError, ReadTimeout, etc.) must
+        # propagate as retriable, NOT map to BoardGoneError. A
+        # Cloudflare hiccup or a Jobylon outage would otherwise flip a
+        # live board to "gone" and trigger spurious delistings.
         def handler(request):
             raise httpx.ConnectError("boom")
 
@@ -657,7 +696,7 @@ class TestTransientErrors:
                 "board_url": "https://example.com/careers",
                 "metadata": {"company_id": "1955"},
             }
-            with pytest.raises(BoardGoneError):
+            with pytest.raises(httpx.ConnectError):
                 await discover(board, client)
 
 


### PR DESCRIPTION
## Why

Three review findings on #2438 — two parser blockers and one error-handling bug that would cause spurious board delistings. Stacked on #2438's branch so it can be squashed in before merge.

### B1 — ``_JOBS_BLOCK_RE`` truncates at ``];`` inside a string

The capture ``(\[.*?\]);`` with non-greedy ``.*?`` stops at the *first* ``];`` — including ones inside quoted values. Verified empirically:

```python
>>> html = \"JBL.embed_v2['jobs'] = [{id: '1', title: 'lead with ];'}, {id: '2'}];\"
>>> _JOBS_BLOCK_RE.search(html).group(1)
\"[{id: '1', title: 'lead with ]\"  # truncated at the first ']'
```

Any posting with ``];`` in title/summary/locations_text silently drops the rest. Fix: anchor on the ``JBL.embed_v2['jobs'] = [`` prefix, then scan for the matching ``]`` with a string-aware bracket counter that tracks single/double quotes + ``\\`` escapes.

### B2 — unquoted-key rewriter mutates strings

Order was: key-quote pass → string rewrite. The key regex ``[\{,]\s*[A-Za-z_]\w*:`` doesn't know about string boundaries, so a value like:

```
summary: 'config snippet: {host: localhost, port: 80}'
```

became:

```
summary: 'config snippet: {\"host\": localhost, \"port\": 80}'
```

Fix: convert strings to double quotes first, then run a dedicated ``_quote_unquoted_keys_outside_strings`` that tracks in-string state and only substitutes outside.

### N2 — transport errors treated as ``BoardGoneError``

``_fetch_embed`` caught ``httpx.HTTPError`` → returned ``None`` → ``discover`` raised ``BoardGoneError``. One ``ConnectError`` during a Cloudflare hiccup flips a healthy tenant to ""gone"" and starts delist processing. Only 404 is a permanent-gone signal now; transport errors bubble up and get retried by the worker.

## Verification

- 4 new unit tests: B1 (string ``];``), B2 (string ``{foo:``), unterminated-array safety, transport-error propagation.
- The pre-existing ``test_transport_error_raises_board_gone`` test asserted the bug as intentional; inverted to ``test_transport_error_propagates``.
- Full suite: ``uv run pytest tests/`` — **3321 passed**.

## Merge order

Squash into #2438 at merge time, or merge this on top after #2438.

🤖 Generated with [Claude Code](https://claude.com/claude-code)