### PR TITLE
Fix daily-error-review #2622 / #2621: Typesense partial updates + richer exporter error log

### DIFF
--- a/apps/crawler/src/exporter.py
+++ b/apps/crawler/src/exporter.py
@@ -480,6 +480,34 @@ async def _noop() -> None:
     """No-op coroutine for gather slots."""
 
 
+def _exc_fields(exc: BaseException) -> dict[str, object]:
+    """Structured fields for logging an exception caught by ``asyncio.gather``.
+
+    ``str(exc)`` alone is empty for several common failure modes (CancelledError,
+    bare asyncpg errors, httpx errors with no body), which leaves the log line
+    useless for diagnosis. See issue #2621.
+    """
+    fields: dict[str, object] = {
+        "error_type": type(exc).__name__,
+        "error": str(exc) or repr(exc),
+    }
+    # PostgresError carries richer fields than str(exc) (which is just message).
+    for attr in ("detail", "hint", "sqlstate"):
+        value = getattr(exc, attr, None)
+        if value:
+            fields[attr] = value
+    # httpx.HTTPStatusError — surface the status + body snippet.
+    response = getattr(exc, "response", None)
+    if response is not None:
+        status = getattr(response, "status_code", None)
+        if status is not None:
+            fields["http_status"] = status
+        text = getattr(response, "text", None)
+        if isinstance(text, str) and text:
+            fields["http_body"] = text[:500]
+    return fields
+
+
 async def _upsert_to_supabase(
     supa_pool: asyncpg.Pool,
     rows: list,
@@ -568,7 +596,10 @@ async def _export_postings_dual(
     new_supa_cursor = supa_cursor
     if supa_rows:
         if isinstance(results[0], BaseException):
-            log.error("exporter.supabase_upsert_error", error=str(results[0]))
+            log.error(
+                "exporter.supabase_upsert_error",
+                **_exc_fields(results[0]),
+            )
         else:
             last = supa_rows[-1]
             new_supa_cursor = (last["updated_at"], last["id"])
@@ -576,7 +607,10 @@ async def _export_postings_dual(
     new_ts_cursor = ts_cursor
     if ts_rows:
         if isinstance(results[1], BaseException):
-            log.error("exporter.typesense_upsert_error", error=str(results[1]))
+            log.error(
+                "exporter.typesense_upsert_error",
+                **_exc_fields(results[1]),
+            )
         else:
             last = ts_rows[-1]
             new_ts_cursor = (last["updated_at"], last["id"])

--- a/apps/crawler/src/sync.py
+++ b/apps/crawler/src/sync.py
@@ -1465,8 +1465,14 @@ def _ts_bulk_upsert(
     client: typesense.Client,
     collection: str,
     docs: list[dict],
+    action: str = "upsert",
 ) -> None:
-    """Bulk upsert documents to a Typesense collection.
+    """Bulk write documents to a Typesense collection.
+
+    ``action`` is a Typesense import action:
+    - ``"upsert"`` (default): replaces each doc; requires all non-optional fields
+    - ``"update"``: partial merge into an existing doc; 404s if the doc doesn't exist
+    - ``"emplace"``: partial merge if the doc exists, otherwise creates it
 
     Splits into batches of ``_TYPESENSE_BATCH_SIZE``. Logs errors but does
     not raise — Typesense writes are fire-and-forget.
@@ -1475,18 +1481,20 @@ def _ts_bulk_upsert(
         return
     for i in range(0, len(docs), _TYPESENSE_BATCH_SIZE):
         batch = docs[i : i + _TYPESENSE_BATCH_SIZE]
-        results = client.collections[collection].documents.import_(batch, {"action": "upsert"})
+        results = client.collections[collection].documents.import_(batch, {"action": action})
         errors = [r for r in results if not r.get("success", True)]
         if errors:
             log.warning(
                 "typesense.bulk_upsert.errors",
                 collection=collection,
+                action=action,
                 error_count=len(errors),
                 sample=errors[:3],
             )
     log.info(
         "typesense.bulk_upsert.done",
         collection=collection,
+        action=action,
         doc_count=len(docs),
     )
 
@@ -2108,6 +2116,11 @@ async def refresh_typesense_counts(
     """
     loop = asyncio.get_event_loop()
 
+    # Count refresh uses action="update" (partial merge). The taxonomy and
+    # company docs are fully written by sync_*_typesense; here we only touch
+    # the *_posting_count fields, so we must not require the schema's other
+    # non-optional fields like `name`. See issue #2622.
+
     # --- Locations ---
     loc_rows = await local_conn.fetch(
         """
@@ -2124,7 +2137,7 @@ async def refresh_typesense_counts(
             }
             for r in loc_rows
         ]
-        await loop.run_in_executor(None, _ts_bulk_upsert, client, "location", loc_docs)
+        await loop.run_in_executor(None, _ts_bulk_upsert, client, "location", loc_docs, "update")
 
     # --- Occupations ---
     occ_rows = await local_conn.fetch(
@@ -2145,7 +2158,7 @@ async def refresh_typesense_counts(
                         "has_active_postings": True,
                     }
                 )
-        await loop.run_in_executor(None, _ts_bulk_upsert, client, "occupation", occ_docs)
+        await loop.run_in_executor(None, _ts_bulk_upsert, client, "occupation", occ_docs, "update")
 
     # --- Seniorities ---
     sen_rows = await local_conn.fetch(
@@ -2165,7 +2178,7 @@ async def refresh_typesense_counts(
                         "has_active_postings": True,
                     }
                 )
-        await loop.run_in_executor(None, _ts_bulk_upsert, client, "seniority", sen_docs)
+        await loop.run_in_executor(None, _ts_bulk_upsert, client, "seniority", sen_docs, "update")
 
     # --- Technologies ---
     tech_rows = await local_conn.fetch(
@@ -2183,7 +2196,7 @@ async def refresh_typesense_counts(
             }
             for r in tech_rows
         ]
-        await loop.run_in_executor(None, _ts_bulk_upsert, client, "technology", tech_docs)
+        await loop.run_in_executor(None, _ts_bulk_upsert, client, "technology", tech_docs, "update")
 
     # --- Companies ---
     active_rows = await local_conn.fetch(
@@ -2210,7 +2223,7 @@ async def refresh_typesense_counts(
             }
             for cid in all_ids
         ]
-        await loop.run_in_executor(None, _ts_bulk_upsert, client, "company", company_docs)
+        await loop.run_in_executor(None, _ts_bulk_upsert, client, "company", company_docs, "update")
 
     log.info("typesense.refresh_counts.done")
 
@@ -2276,7 +2289,9 @@ async def _apply_taxonomy_renames(
             )
             if posting_rows:
                 docs = [{"id": str(r["id"]), "occupation_name": new_name} for r in posting_rows]
-                await loop.run_in_executor(None, _ts_bulk_upsert, client, "job_posting", docs)
+                await loop.run_in_executor(
+                    None, _ts_bulk_upsert, client, "job_posting", docs, "update"
+                )
 
     # Seniority renames
     for sen_id, new_name in after.get("seniority", {}).items():
@@ -2293,7 +2308,9 @@ async def _apply_taxonomy_renames(
             )
             if posting_rows:
                 docs = [{"id": str(r["id"]), "seniority_name": new_name} for r in posting_rows]
-                await loop.run_in_executor(None, _ts_bulk_upsert, client, "job_posting", docs)
+                await loop.run_in_executor(
+                    None, _ts_bulk_upsert, client, "job_posting", docs, "update"
+                )
 
     # Technology renames
     for tech_id, new_name in after.get("technology", {}).items():
@@ -2329,6 +2346,7 @@ async def _apply_taxonomy_renames(
                                 client,
                                 "job_posting",
                                 [{"id": str(pr["id"]), "technology_names": tech_names}],
+                                "update",
                             )
 
 


### PR DESCRIPTION
## Summary

Fixes two issues from the 2026-04-24 daily error review.

### #2622 — refresh-typesense upserts rejected for missing `name`

`crawler refresh-typesense` was using Typesense `action=upsert` for count-only refresh documents, so ~all 4 400 company docs (plus technology/seniority/occupation/location) were rejected every run with:

```
Field `name` has been declared in the schema, but is not found in the document.
```

Fix: `_ts_bulk_upsert` gains an `action` parameter; `refresh_typesense_counts` passes `action="update"` (partial merge) on all five count-refresh callsites.

**Latent bug found during review** — `_apply_taxonomy_renames` sends partial `{id, occupation_name}` / `{id, seniority_name}` / `{id, technology_names}` docs to `job_posting`, which has many non-optional fields (title, company_id, location_ids, etc.). All three rename branches were silently failing with the same error. Fixed to pass `action="update"` too.

**Trade-off:** Typesense `action=update` 404s per-doc for ids that don't yet exist (rare race: `refresh-typesense` running before the first `sync` after a new company/taxonomy row). Non-fatal — only logged as a warning. `emplace` was considered but doesn't help (it still needs `name` to create).

### #2621 — exporter.supabase_upsert_error empty-error spam

`str(exc)` is empty for several common failure modes (`CancelledError`, some asyncpg errors, httpx errors with empty body), so the log statement was dropping all diagnostic info for 749 events/day.

Fix: new `_exc_fields(exc)` helper returns a structured dict of:
- `error_type` (class name)
- `error` (`str(exc)` with `repr(exc)` fallback)
- asyncpg `detail` / `hint` / `sqlstate` when present
- httpx response `http_status` + `http_body` (500-char cap) when present

Applied at both `exporter.supabase_upsert_error` and `exporter.typesense_upsert_error` sites.

## Test plan
- [x] `uv run pytest tests/test_sync.py tests/test_exporter.py` — 73 passed
- [x] `uv run python -c "from src import exporter, sync"` — import clean
- [ ] After deploy to Hetzner: verify `typesense.bulk_upsert.done` log now carries `action="update"` and the "field `name` not found" rejection count drops to zero (or only occurs for brand-new ids between sync ticks)
- [ ] After deploy: verify `exporter.supabase_upsert_error` log lines now carry `error_type` + non-empty `error` so the 749/day signal becomes diagnosable

Closes #2622
Closes #2621

🤖 Generated with [Claude Code](https://claude.com/claude-code)