### PR TITLE
Move watchlist active-posting count from Supabase to local Postgres

### DIFF
--- a/apps/crawler/src/cli.py
+++ b/apps/crawler/src/cli.py
@@ -197,7 +197,7 @@ async def run() -> None:
             else:
                 async with local_pool.acquire() as local_conn, supa_pool.acquire() as supa_conn:
                     await refresh_typesense_counts(local_conn, ts_client)
-                    await sync_watchlists_typesense(supa_conn, ts_client)
+                    await sync_watchlists_typesense(supa_conn, local_conn, ts_client)
                 log.info("refresh-typesense: done")
 
         elif args.command == "notify-indexnow":

--- a/apps/crawler/src/migrations/versions/0005_index_active_postings_by_company.py
+++ b/apps/crawler/src/migrations/versions/0005_index_active_postings_by_company.py
@@ -1,0 +1,38 @@
+"""Partial index on job_posting(company_id) WHERE is_active.
+
+The watchlist count aggregation (see ``sync_watchlists_typesense``) moved
+from Supabase to local Postgres to cut Supabase compute spend; the query
+shape is ``WHERE is_active AND company_id = ANY($1)``. Existing indexes
+are ``idx_jp_company(company_id)`` (full) and ``idx_jp_active WHERE
+is_active`` (flag only). Neither lets the planner drive a nested-loop
+that touches only active rows for a small set of companies. This partial
+index does.
+
+Created CONCURRENTLY so it does not lock ``job_posting`` on live boxes.
+
+Revision ID: 0005
+Create Date: 2026-04-24
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "0005"
+down_revision = "0004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+            "idx_jp_company_active ON job_posting (company_id) "
+            "WHERE is_active"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS idx_jp_company_active")

--- a/apps/crawler/src/sync.py
+++ b/apps/crawler/src/sync.py
@@ -20,6 +20,7 @@ import argparse
 import asyncio
 import json
 import time
+from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
@@ -1985,14 +1986,22 @@ def _is_trivial_watchlist(filters: dict | None, company_count: int) -> bool:
 
 async def sync_watchlists_typesense(
     supa_conn: asyncpg.Connection,
+    local_conn: asyncpg.Connection | None,
     client: typesense.Client,
 ) -> None:
     """Sync public watchlists to the Typesense ``watchlist`` collection.
 
-    Queries from Supabase only (watchlists only exist there). Trivial
-    watchlists (no companies, no meaningful filters) are deleted from
-    Typesense rather than upserted, so they're hidden from public search
-    and popular listings while still existing in Postgres for their owner.
+    Watchlists only exist in Supabase, so metadata and ``watchlist_company``
+    pairs come from there. The active-posting count per company is computed
+    against local Postgres (the job_posting source of truth) and aggregated
+    per watchlist in Python; company UUIDs are identical across both DBs
+    (see ``_mirror_companies_*``) so the counts match. This avoids a
+    watchlist_company ⨝ job_posting WHERE is_active hash join on Supabase,
+    which dominated Supabase compute spend. Falls back to the Supabase JOIN
+    when ``local_conn`` is None (dry-run, local Postgres unreachable).
+
+    Trivial watchlists (no companies, no meaningful filters) are deleted
+    from Typesense rather than upserted.
     """
     rows = await supa_conn.fetch(
         """
@@ -2010,30 +2019,48 @@ async def sync_watchlists_typesense(
 
     watchlist_ids = [r["id"] for r in rows]
 
-    # Company counts
-    company_count_rows = await supa_conn.fetch(
+    wc_pairs = await supa_conn.fetch(
         """
-        SELECT watchlist_id, COUNT(*) AS cnt
+        SELECT watchlist_id, company_id
         FROM watchlist_company
         WHERE watchlist_id = ANY($1::uuid[])
-        GROUP BY 1
         """,
         watchlist_ids,
     )
-    company_counts = {str(r["watchlist_id"]): r["cnt"] for r in company_count_rows}
+    company_counts: dict[str, int] = defaultdict(int)
+    for r in wc_pairs:
+        company_counts[str(r["watchlist_id"])] += 1
 
-    # Active job counts (via watchlist companies)
-    job_count_rows = await supa_conn.fetch(
-        """
-        SELECT wc.watchlist_id, COUNT(jp.id) AS cnt
-        FROM watchlist_company wc
-        JOIN job_posting jp ON jp.company_id = wc.company_id AND jp.is_active
-        WHERE wc.watchlist_id = ANY($1::uuid[])
-        GROUP BY 1
-        """,
-        watchlist_ids,
-    )
-    job_counts = {str(r["watchlist_id"]): r["cnt"] for r in job_count_rows}
+    job_counts: dict[str, int]
+    if local_conn is not None:
+        distinct_company_ids = list({r["company_id"] for r in wc_pairs})
+        per_company: dict = {}
+        if distinct_company_ids:
+            active_rows = await local_conn.fetch(
+                """
+                SELECT company_id, COUNT(*) AS cnt
+                FROM job_posting
+                WHERE is_active AND company_id = ANY($1::uuid[])
+                GROUP BY 1
+                """,
+                distinct_company_ids,
+            )
+            per_company = {r["company_id"]: r["cnt"] for r in active_rows}
+        job_counts = defaultdict(int)
+        for r in wc_pairs:
+            job_counts[str(r["watchlist_id"])] += per_company.get(r["company_id"], 0)
+    else:
+        job_count_rows = await supa_conn.fetch(
+            """
+            SELECT wc.watchlist_id, COUNT(jp.id) AS cnt
+            FROM watchlist_company wc
+            JOIN job_posting jp ON jp.company_id = wc.company_id AND jp.is_active
+            WHERE wc.watchlist_id = ANY($1::uuid[])
+            GROUP BY 1
+            """,
+            watchlist_ids,
+        )
+        job_counts = {str(r["watchlist_id"]): r["cnt"] for r in job_count_rows}
 
     # Mirror counts
     mirror_count_rows = await supa_conn.fetch(
@@ -2391,7 +2418,7 @@ async def sync_typesense(
         log.exception("typesense.sync.companies.failed")
 
     try:
-        await sync_watchlists_typesense(supa_conn, client)
+        await sync_watchlists_typesense(supa_conn, local_conn, client)
     except Exception:
         log.exception("typesense.sync.watchlists.failed")
 


### PR DESCRIPTION
## Summary

- `sync_watchlists_typesense` issued a `watchlist_company ⨝ job_posting WHERE is_active` hash join against Supabase on every `refresh-typesense` / `sync` run. Observed: 20% of Supabase compute across ~43 calls — each call scans the full active-posting set.
- Split the query: fetch `(watchlist_id, company_id)` pairs from Supabase (cheap), run the active-count aggregate on local Postgres (source of truth for `job_posting`), sum in Python. Supabase-side fallback retained for dry-run / local-unreachable paths.
- Add partial index `idx_jp_company_active ON job_posting (company_id) WHERE is_active` on local Postgres via Alembic `0005`. `CREATE INDEX CONCURRENTLY` in an `autocommit_block()` so it doesn't lock the live table.

## Why this is safe

- Company UUIDs are shared across local and Supabase (`_mirror_companies_*` copies ids both ways), so the local aggregate matches the Supabase-joined one 1:1.
- `is_active` semantics match — exporter replicates the flag.
- Fallback keeps the old behavior when `local_conn` is `None`.
- Index creation is concurrent; zero downtime.

## Test plan

- [x] `uv run ruff check` clean
- [x] `uv run pytest tests/test_sync.py` — 44 passed
- [ ] After merge: deploy crawler image, run Alembic `0005` on local Postgres, trigger `crawler refresh-typesense` manually, confirm the top-N expensive queries on Supabase no longer include this one
- [ ] Confirm Typesense `watchlist` docs still show correct `active_job_count` values via sample diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)