### PR TITLE
Cache locale-redirect middleware at the CDN

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -22,10 +22,27 @@ function getLocale(request: NextRequest): string {
 }
 
 export function middleware(request: NextRequest) {
+  const cookieLocale = request.cookies.get(COOKIE_NAME)?.value;
   const locale = getLocale(request);
   const url = request.nextUrl.clone();
   url.pathname = `/${locale}${request.nextUrl.pathname}`;
-  return NextResponse.redirect(url);
+  const response = NextResponse.redirect(url);
+
+  // Cache the redirect at Vercel's CDN when the chosen locale comes from
+  // Accept-Language negotiation. Repeat requests with matching headers (most
+  // bot/shared-link traffic on root URLs) then reuse the redirect without
+  // re-invoking the middleware. We deliberately skip the cache when an
+  // explicit NEXT_LOCALE cookie is set: that path varies per user and Vary:
+  // Cookie would shard the cache by every session token. See issue #2642.
+  if (!cookieLocale || !isLocale(cookieLocale)) {
+    response.headers.set(
+      "Cache-Control",
+      "public, max-age=86400, s-maxage=86400",
+    );
+    response.headers.set("Vary", "Accept-Language");
+  }
+
+  return response;
 }
 
 export const config = {

--- a/apps/web/src/lib/__tests__/middleware.test.ts
+++ b/apps/web/src/lib/__tests__/middleware.test.ts
@@ -2,8 +2,21 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockRedirect = vi.fn();
 
+// Headers-like wrapper around a plain Map. We don't need a full Headers
+// implementation — the middleware only calls set(), and tests only need get().
+class MockHeaders {
+  private store = new Map<string, string>();
+  set(name: string, value: string) {
+    this.store.set(name.toLowerCase(), value);
+  }
+  get(name: string): string | null {
+    return this.store.get(name.toLowerCase()) ?? null;
+  }
+}
+
 vi.mock("next/server", () => {
   class MockNextResponse {
+    headers = new MockHeaders();
     static redirect(url: URL) {
       mockRedirect(url);
       return new MockNextResponse();
@@ -19,7 +32,11 @@ vi.mock("next/server", () => {
 import { middleware, config } from "../../../middleware";
 import type { NextRequest } from "next/server";
 
-function createMockRequest(pathname: string, acceptLanguage?: string): NextRequest {
+function createMockRequest(
+  pathname: string,
+  acceptLanguage?: string,
+  cookieLocale?: string,
+): NextRequest {
   const url = new URL(`http://localhost${pathname}`);
   const headersMap = new Map<string, string>();
   if (acceptLanguage) headersMap.set("accept-language", acceptLanguage);
@@ -30,7 +47,10 @@ function createMockRequest(pathname: string, acceptLanguage?: string): NextReque
       forEach: (cb: (value: string, key: string) => void) => headersMap.forEach(cb),
     },
     cookies: {
-      get: (_name: string) => undefined,
+      get: (name: string) =>
+        name === "NEXT_LOCALE" && cookieLocale
+          ? { value: cookieLocale }
+          : undefined,
     },
     nextUrl: {
       clone: () => new URL(url),
@@ -79,6 +99,54 @@ describe("middleware", () => {
     middleware(createMockRequest("/"));
     const redirectUrl = mockRedirect.mock.calls[0][0] as URL;
     expect(redirectUrl.pathname).toBe("/en/");
+  });
+
+  it("uses the cookie locale when present", () => {
+    middleware(createMockRequest("/about", "de-DE,de;q=0.9", "fr"));
+    const redirectUrl = mockRedirect.mock.calls[0][0] as URL;
+    expect(redirectUrl.pathname).toBe("/fr/about");
+  });
+});
+
+describe("middleware caching", () => {
+  beforeEach(() => {
+    mockRedirect.mockClear();
+  });
+
+  it("sets Cache-Control + Vary on Accept-Language redirects", () => {
+    const response = middleware(
+      createMockRequest("/about", "de-DE,de;q=0.9"),
+    ) as unknown as { headers: { get: (n: string) => string | null } };
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=86400, s-maxage=86400",
+    );
+    expect(response.headers.get("vary")).toBe("Accept-Language");
+  });
+
+  it("sets cache headers on the default-locale fallback redirect", () => {
+    const response = middleware(createMockRequest("/")) as unknown as {
+      headers: { get: (n: string) => string | null };
+    };
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=86400, s-maxage=86400",
+    );
+  });
+
+  it("does NOT cache when a NEXT_LOCALE cookie is present", () => {
+    const response = middleware(
+      createMockRequest("/about", undefined, "fr"),
+    ) as unknown as { headers: { get: (n: string) => string | null } };
+    expect(response.headers.get("cache-control")).toBeNull();
+    expect(response.headers.get("vary")).toBeNull();
+  });
+
+  it("ignores an invalid cookie locale and still caches", () => {
+    const response = middleware(
+      createMockRequest("/about", "de-DE,de;q=0.9", "xx"),
+    ) as unknown as { headers: { get: (n: string) => string | null } };
+    expect(response.headers.get("cache-control")).toBe(
+      "public, max-age=86400, s-maxage=86400",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `Cache-Control: public, max-age=86400, s-maxage=86400` + `Vary: Accept-Language` to the locale-redirect response.
- Skips the cache when an explicit `NEXT_LOCALE` cookie is set, to avoid sharding the CDN cache by Better Auth session tokens.

Closes #2642. Part of the Fluid optimization roadmap (#2649).

## Test plan
- [x] `pnpm test middleware` — 12/12 (added 4 new cases covering cache headers, cookie skip, invalid-cookie fallback)
- [ ] Post-deploy: `curl -sSI https://jseek.co/ | grep -iE 'cache|vary'` shows the new headers
- [ ] Post-deploy: second curl from a warmed cache shows `x-vercel-cache: HIT`