### PR TITLE
Cache the suggest* Typesense fanout used by parseSearchFilters

### DIFF
--- a/apps/web/src/lib/actions/locations.ts
+++ b/apps/web/src/lib/actions/locations.ts
@@ -25,17 +25,59 @@ export async function suggestLocations(params: {
   const q = params.query.trim();
   if (q.length < 2) return [];
 
-  const { locale, userLat, userLng } = params;
-  const hasGeo = userLat != null && userLng != null;
+  // Bucket geo to 1-decimal precision (~10km) so callers in the same city
+  // share a cache slot. Typesense ranks by `coordinates(lat,lng, precision:
+  // 5km)` so this granularity keeps results indistinguishable in practice
+  // while delivering a usable hit rate. See issue #2641.
+  const geoKey =
+    params.userLat != null && params.userLng != null
+      ? `${params.userLat.toFixed(1)},${params.userLng.toFixed(1)}`
+      : "no-geo";
 
+  const cacheKey = `loc-suggest:${q.toLowerCase()}:${params.locale}:${geoKey}`;
+  const cachedResult = await cached(
+    cacheKey,
+    () => _fetchLocationSuggestions(q, params.locale, params.userLat, params.userLng),
+    {
+      ttl: 3600,
+      // Treat null as "Typesense was unavailable" — don't poison the cache.
+      // Empty array is a legitimate "no match" result (e.g. nonsense query)
+      // and is worth caching to absorb crawler noise.
+      skipIf: (r) => r === null,
+    },
+  );
+
+  const suggestions = cachedResult ?? [];
+
+  // Boost is per-call (depends on the user's currently-selected filters),
+  // so it must run *after* the cached layer. Boosting is a pure re-sort
+  // of the suggestion list and does no I/O.
+  if (!params.filters) return suggestions;
+  return boostByFilterMatches(
+    suggestions,
+    "location_ids",
+    (s) => s.id,
+    params.filters,
+  );
+}
+
+/**
+ * Inner fetch + mapping for {@link suggestLocations}. Returns `null` if
+ * Typesense is unreachable so the cache layer can avoid poisoning the slot
+ * with an outage-shaped empty list.
+ */
+async function _fetchLocationSuggestions(
+  q: string,
+  locale: string,
+  userLat: number | undefined,
+  userLng: number | undefined,
+): Promise<LocationSuggestion[] | null> {
+  const hasGeo = userLat != null && userLng != null;
   const sortBy = hasGeo
     ? `_text_match:desc,coordinates(${userLat},${userLng}, precision: 5km):asc,active_posting_count:desc`
     : "_text_match:desc,active_posting_count:desc";
 
-  // Determine query_by fields — prefer user locale, fall back to English
-  const queryByFields = locale !== "en"
-    ? `name_${locale},name_en`
-    : "name_en";
+  const queryByFields = locale !== "en" ? `name_${locale},name_en` : "name_en";
   const queryByWeights = locale !== "en" ? "3,1" : "1";
 
   try {
@@ -53,21 +95,11 @@ export async function suggestLocations(params: {
     });
 
     if (!result.hits || result.hits.length === 0) return [];
-
-    const suggestions = result.hits.map((hit) =>
+    return result.hits.map((hit) =>
       _mapLocationHit(hit as unknown as TypesenseHit, locale),
     );
-
-    if (!params.filters) return suggestions;
-    return boostByFilterMatches(
-      suggestions,
-      "location_ids",
-      (s) => s.id,
-      params.filters,
-    );
   } catch {
-    // Typesense unavailable — return empty (graceful degradation)
-    return [];
+    return null;
   }
 }
 

--- a/apps/web/src/lib/actions/taxonomy.ts
+++ b/apps/web/src/lib/actions/taxonomy.ts
@@ -25,9 +25,29 @@ export async function suggestOccupations(params: {
   const q = params.query.trim();
   if (q.length < 2) return [];
 
+  const cacheKey = `occ-suggest:${q.toLowerCase()}:${params.locale}`;
+  const cachedResult = await cached(
+    cacheKey,
+    () => _fetchOccupationSuggestions(q, params.locale),
+    { ttl: 3600, skipIf: (r) => r === null },
+  );
+
+  const suggestions = cachedResult ?? [];
+  if (!params.filters) return suggestions;
+  return boostByFilterMatches(
+    suggestions,
+    "occupation_id",
+    (s) => s.id,
+    params.filters,
+  );
+}
+
+async function _fetchOccupationSuggestions(
+  q: string,
+  locale: string,
+): Promise<TaxonomySuggestion[] | null> {
   try {
     const client = getTypesenseClient();
-    const { locale } = params;
 
     // Search locale-specific documents first
     let result = await client.collections("occupation").documents().search({
@@ -54,20 +74,11 @@ export async function suggestOccupations(params: {
     }
 
     if (!result.hits || result.hits.length === 0) return [];
-
-    const suggestions = result.hits.map((hit) =>
+    return result.hits.map((hit) =>
       _mapOccupationHit(hit as unknown as TypesenseHit),
     );
-
-    if (!params.filters) return suggestions;
-    return boostByFilterMatches(
-      suggestions,
-      "occupation_id",
-      (s) => s.id,
-      params.filters,
-    );
   } catch {
-    return [];
+    return null;
   }
 }
 
@@ -94,9 +105,29 @@ export async function suggestSeniorities(params: {
   const q = params.query.trim();
   if (q.length < 2) return [];
 
+  const cacheKey = `sen-suggest:${q.toLowerCase()}:${params.locale}`;
+  const cachedResult = await cached(
+    cacheKey,
+    () => _fetchSenioritySuggestions(q, params.locale),
+    { ttl: 3600, skipIf: (r) => r === null },
+  );
+
+  const suggestions = cachedResult ?? [];
+  if (!params.filters) return suggestions;
+  return boostByFilterMatches(
+    suggestions,
+    "seniority_id",
+    (s) => s.id,
+    params.filters,
+  );
+}
+
+async function _fetchSenioritySuggestions(
+  q: string,
+  locale: string,
+): Promise<TaxonomySuggestion[] | null> {
   try {
     const client = getTypesenseClient();
-    const { locale } = params;
 
     let result = await client.collections("seniority").documents().search({
       q,
@@ -122,20 +153,11 @@ export async function suggestSeniorities(params: {
     }
 
     if (!result.hits || result.hits.length === 0) return [];
-
-    const suggestions = result.hits.map((hit) =>
+    return result.hits.map((hit) =>
       _mapSeniorityHit(hit as unknown as TypesenseHit),
     );
-
-    if (!params.filters) return suggestions;
-    return boostByFilterMatches(
-      suggestions,
-      "seniority_id",
-      (s) => s.id,
-      params.filters,
-    );
   } catch {
-    return [];
+    return null;
   }
 }
 
@@ -162,6 +184,29 @@ export async function suggestTechnologies(params: {
   const q = params.query.trim();
   if (q.length < 2) return [];
 
+  // Technologies are locale-agnostic but the public function accepts locale
+  // for parity with the other taxonomy suggesters. Drop it from the cache
+  // key so all locales share one slot.
+  const cacheKey = `tech-suggest:${q.toLowerCase()}`;
+  const cachedResult = await cached(
+    cacheKey,
+    () => _fetchTechnologySuggestions(q),
+    { ttl: 3600, skipIf: (r) => r === null },
+  );
+
+  const suggestions = cachedResult ?? [];
+  if (!params.filters) return suggestions;
+  return boostByFilterMatches(
+    suggestions,
+    "technology_ids",
+    (s) => s.id,
+    params.filters,
+  );
+}
+
+async function _fetchTechnologySuggestions(
+  q: string,
+): Promise<TaxonomySuggestion[] | null> {
   try {
     const client = getTypesenseClient();
 
@@ -172,12 +217,11 @@ export async function suggestTechnologies(params: {
       sort_by: "_text_match:desc,active_posting_count:desc",
       per_page: 5,
       prefix: "true",
-      num_typos: "0",  // no typo tolerance — match current prefix-only behavior
+      num_typos: "0", // no typo tolerance — match current prefix-only behavior
     });
 
     if (!result.hits || result.hits.length === 0) return [];
-
-    const suggestions = result.hits.map((hit) => {
+    return result.hits.map((hit) => {
       const doc = (hit as unknown as TypesenseHit).document;
       return {
         id: doc.technology_id as number,
@@ -185,16 +229,8 @@ export async function suggestTechnologies(params: {
         name: (doc.name ?? doc.slug) as string,
       };
     });
-
-    if (!params.filters) return suggestions;
-    return boostByFilterMatches(
-      suggestions,
-      "technology_ids",
-      (s) => s.id,
-      params.filters,
-    );
   } catch {
-    return [];
+    return null;
   }
 }
 


### PR DESCRIPTION
## Summary
- Wraps the Typesense fetch in `suggestLocations`, `suggestOccupations`, `suggestSeniorities`, `suggestTechnologies` with a 1h Redis cache.
- Outage detection: inner helpers return `null` on error and `skipIf` keeps that out of the cache.
- Boost re-sort runs after the cache (depends on per-call user filters).
- Geo-bucketing for `suggestLocations` (lat/lng to 1-dp ≈ 10 km) so callers in the same area share a slot. Practically indistinguishable from the un-bucketed version since Typesense already ranks at 5 km precision.

A 5-keyword search currently fans out ~29 parallel Typesense calls via the Cloudflare tunnel; with cache warm, common terms ("python", "engineer", "berlin") will turn into Redis hits.

Closes #2641. Part of the Fluid optimization roadmap (#2649).

## Test plan
- [x] `pnpm test --run` — 28/28 files, 190/190 cases passing
- [x] `pnpm tsc --noEmit` — clean
- [ ] Post-deploy: monitor Vercel function p50/p99 for `/api/v1/search`, `/api/v1/resolve`, and the explore/company server actions