### PR TITLE
Extend watchlist-detail ISR window from 10min to 1h

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
@@ -9,7 +9,14 @@ import { siteConfig } from "@/content/config";
 import { buildAlternates } from "@/lib/seo";
 import { WatchlistContent } from "./watchlist-content";
 
-export const revalidate = 600; // ISR: cache metadata for 10 minutes
+// ISR window for the rendered metadata + page shell.
+//
+// The previous 10-minute window cycled the (DB lookup + Typesense facet
+// count) on every regen × every public watchlist. Watchlist metadata is
+// shared via the CDN, so freshness from a viewer's perspective comes from
+// the client-hydrated body, not metadata. Search engines re-crawl on a
+// much slower cadence than 10 minutes anyway. See issue #2648.
+export const revalidate = 3600;
 
 type Props = {
   params: Promise<{ lang: string; userSlug: string; watchlistSlug: string }>;

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -790,7 +790,10 @@ export async function getWatchlistMatchingCompanyCount(
       console.error("[getWatchlistMatchingCompanyCount] Typesense failed", err);
       return 0;
     }
-  }, { ttl: 600 });
+    // Aligned to the watchlist-detail ISR window (1h, see page.tsx). Bumped
+    // from 600s with #2648 — metadata freshness from a viewer's perspective
+    // comes from the client-hydrated body, not the cached count.
+  }, { ttl: 3600 });
 }
 
 async function resolveFilteredJobCount(


### PR DESCRIPTION
## Summary
- Bumps \`revalidate\` on \`/[lang]/[userSlug]/[watchlistSlug]\` from 600s to 3600s.
- Aligns the inner cache TTL on \`getWatchlistMatchingCompanyCount\` to 3600s so the metadata count refresh follows the same cadence.

The watchlist-detail metadata path is the only spot where an ISR regen runs a Typesense facet count (for \`anyCompany\` watchlists). At a 10-min cadence × every public watchlist × ~50ms Typesense, that adds up. User-facing freshness is unaffected — the page body re-counts on client hydration, and search engines re-crawl on a much slower cadence.

Closes #2648. Part of the Fluid optimization roadmap (#2649).

## Test plan
- [x] \`pnpm test app/__tests__/isr-routes.test.ts\` — 2/2 (ISR-protected route guard still applies)
- [ ] Post-deploy: \`curl -sSI https://jseek.co/en/colophongroup/<some-slug> | grep -i cache\` shows the new max-age window