### PR TITLE
Fold fetchAppBootstrap into a single Postgres round-trip

### DIFF
--- a/apps/web/src/lib/actions/__tests__/bootstrap.test.ts
+++ b/apps/web/src/lib/actions/__tests__/bootstrap.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Server actions transitively import `server-only`, which throws in a
+// non-Next runtime. Neutralize it before any module under test loads.
+vi.mock("server-only", () => ({}));
+
+// db.execute is the only side-effect path in the bootstrap action.
+const mockExecute = vi.fn();
+vi.mock("@/db", () => ({
+  db: { execute: (...args: unknown[]) => mockExecute(...args) },
+}));
+
+// Session resolution is exercised separately. Stub it so we control the
+// branch under test.
+const mockGetSession = vi.fn();
+vi.mock("@/lib/sessionCache", () => ({
+  getSession: () => mockGetSession(),
+  getSessionUserId: () => mockGetSession()?.user?.id ?? null,
+}));
+
+// Drizzle's tagged-template `sql` helper — bootstrap.ts only constructs a
+// query and passes it to db.execute, so a no-op stand-in is sufficient.
+vi.mock("drizzle-orm", () => ({
+  sql: (..._args: unknown[]) => ({ _isSql: true }),
+}));
+
+import { fetchAppBootstrap } from "../bootstrap";
+
+beforeEach(() => {
+  mockExecute.mockReset();
+  mockGetSession.mockReset();
+});
+
+describe("fetchAppBootstrap", () => {
+  it("returns the anonymous shape when no session", async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const result = await fetchAppBootstrap();
+
+    expect(result).toEqual({
+      user: null,
+      prefs: null,
+      savedStatuses: [],
+      starredIds: [],
+    });
+    expect(mockExecute).not.toHaveBeenCalled();
+  });
+
+  it("maps the single-row JSON aggregate result to AppBootstrapData", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: "u1", email: "a@b.c", name: "Alice", emailVerified: true },
+    });
+
+    mockExecute.mockResolvedValue([
+      {
+        prefs: {
+          theme: "dark",
+          themeUpdatedAt: "2026-04-25T10:00:00.000Z",
+          locale: "de",
+          localeUpdatedAt: "2026-04-25T10:00:00.000Z",
+          cookieConsent: true,
+          displayCurrency: "EUR",
+          salaryPeriod: "year",
+          dismissedBanners: ["upgrade"],
+          jobLanguages: ["en", "de"],
+        },
+        saved_statuses: [
+          { postingId: "p1", savedJobId: "s1", status: "saved" },
+          { postingId: "p2", savedJobId: "s2", status: "applied" },
+        ],
+        starred_ids: [{ company_id: "c1" }, { company_id: "c2" }],
+      },
+    ]);
+
+    const result = await fetchAppBootstrap();
+
+    expect(result.user).toEqual({
+      id: "u1",
+      email: "a@b.c",
+      name: "Alice",
+      emailVerified: true,
+    });
+    expect(result.prefs?.theme).toBe("dark");
+    expect(result.prefs?.locale).toBe("de");
+    // Timestamps must come back as Date instances, not raw ISO strings.
+    expect(result.prefs?.themeUpdatedAt).toBeInstanceOf(Date);
+    expect(result.prefs?.localeUpdatedAt).toBeInstanceOf(Date);
+    expect(result.savedStatuses).toEqual([
+      { postingId: "p1", savedJobId: "s1", status: "saved" },
+      { postingId: "p2", savedJobId: "s2", status: "applied" },
+    ]);
+    expect(result.starredIds).toEqual(["c1", "c2"]);
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles a user with no prefs row + empty save/star sets", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: "u2", email: "x@y.z", name: "New User", emailVerified: true },
+    });
+
+    mockExecute.mockResolvedValue([
+      { prefs: null, saved_statuses: [], starred_ids: [] },
+    ]);
+
+    const result = await fetchAppBootstrap();
+
+    expect(result.prefs).toBeNull();
+    expect(result.savedStatuses).toEqual([]);
+    expect(result.starredIds).toEqual([]);
+  });
+
+  it("survives a totally empty execute result (defensive)", async () => {
+    // If the query somehow returns zero rows, we should not blow up — fall
+    // back to anonymous-shaped data instead.
+    mockGetSession.mockResolvedValue({
+      user: { id: "u3", email: "x@y.z", name: "Edge", emailVerified: true },
+    });
+    mockExecute.mockResolvedValue([]);
+
+    const result = await fetchAppBootstrap();
+
+    expect(result.prefs).toBeNull();
+    expect(result.savedStatuses).toEqual([]);
+    expect(result.starredIds).toEqual([]);
+  });
+
+  it("preserves null timestamp fields without coercing to invalid Dates", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: "u4", email: "x@y.z", name: "T", emailVerified: true },
+    });
+    mockExecute.mockResolvedValue([
+      {
+        prefs: {
+          theme: "light",
+          themeUpdatedAt: null,
+          locale: "en",
+          localeUpdatedAt: null,
+          cookieConsent: false,
+          displayCurrency: "EUR",
+          salaryPeriod: null,
+          dismissedBanners: [],
+          jobLanguages: [],
+        },
+        saved_statuses: [],
+        starred_ids: [],
+      },
+    ]);
+
+    const result = await fetchAppBootstrap();
+
+    expect(result.prefs?.themeUpdatedAt).toBeNull();
+    expect(result.prefs?.localeUpdatedAt).toBeNull();
+  });
+
+  it("issues exactly one db.execute call (no parallel fan-out)", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: "u5", email: "x@y.z", name: "Fan", emailVerified: true },
+    });
+    mockExecute.mockResolvedValue([
+      { prefs: null, saved_statuses: [], starred_ids: [] },
+    ]);
+
+    await fetchAppBootstrap();
+
+    expect(mockExecute).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/actions/bootstrap.ts
+++ b/apps/web/src/lib/actions/bootstrap.ts
@@ -1,9 +1,9 @@
 "use server";
 
+import { sql } from "drizzle-orm";
+import { db } from "@/db";
 import { getSession } from "@/lib/sessionCache";
-import { getPreferences } from "@/lib/actions/preferences";
-import { getSavedJobStatuses, type SavedJobStatus } from "@/lib/actions/saved-jobs";
-import { getStarredCompanyIds } from "@/lib/actions/starred-companies";
+import type { SavedJobStatus } from "@/lib/actions/saved-jobs";
 
 export type SessionUser = {
   id: string;
@@ -34,21 +34,97 @@ export type AppBootstrapData = {
   starredIds: string[];
 };
 
+/**
+ * Single Postgres round-trip that returns everything `AppBootstrapProvider`
+ * needs after the session lookup. Replaces the previous parallel fan-out of
+ * `getPreferences`, `getSavedJobStatuses`, and `getStarredCompanyIds` —
+ * `Promise.all` was three round-trips on a cold pool, this is one. See
+ * issue #2643.
+ *
+ * The shape mirrors the public actions so existing call sites stay
+ * unchanged. JSON aggregation is wrapped in `coalesce(..., '[]'::json)` so
+ * an empty bookmark/starred set returns `[]` instead of `null`.
+ */
+async function _fetchBootstrapForUser(userId: string): Promise<{
+  prefs: AppPreferences | null;
+  savedStatuses: SavedJobStatus[];
+  starredIds: string[];
+}> {
+  type Row = {
+    prefs: AppPreferences | null;
+    saved_statuses: SavedJobStatus[];
+    starred_ids: { company_id: string }[];
+  };
+
+  const rows = await db.execute<Row & Record<string, unknown>>(sql`
+    SELECT
+      (SELECT row_to_json(p) FROM (
+        SELECT
+          theme,
+          theme_updated_at AS "themeUpdatedAt",
+          locale,
+          locale_updated_at AS "localeUpdatedAt",
+          cookie_consent AS "cookieConsent",
+          display_currency AS "displayCurrency",
+          salary_period AS "salaryPeriod",
+          dismissed_banners AS "dismissedBanners",
+          job_languages AS "jobLanguages"
+        FROM user_preferences
+        WHERE user_id = ${userId}
+        LIMIT 1
+      ) p) AS prefs,
+      (SELECT coalesce(json_agg(s), '[]'::json) FROM (
+        SELECT
+          job_posting_id AS "postingId",
+          id AS "savedJobId",
+          status
+        FROM saved_job
+        WHERE user_id = ${userId}
+      ) s) AS saved_statuses,
+      (SELECT coalesce(json_agg(c), '[]'::json) FROM (
+        SELECT company_id FROM followed_company WHERE user_id = ${userId}
+      ) c) AS starred_ids
+  `);
+
+  const row = (rows as unknown as Row[])[0];
+  if (!row) return { prefs: null, savedStatuses: [], starredIds: [] };
+
+  const prefs = row.prefs
+    ? {
+        ...row.prefs,
+        // Postgres returns timestamp columns as ISO strings inside json — restore
+        // Date instances so downstream type checks (DB-row shape) keep working.
+        themeUpdatedAt:
+          row.prefs.themeUpdatedAt != null
+            ? new Date(row.prefs.themeUpdatedAt as unknown as string)
+            : null,
+        localeUpdatedAt:
+          row.prefs.localeUpdatedAt != null
+            ? new Date(row.prefs.localeUpdatedAt as unknown as string)
+            : null,
+      }
+    : null;
+
+  return {
+    prefs,
+    savedStatuses: row.saved_statuses ?? [],
+    starredIds: (row.starred_ids ?? []).map((c) => c.company_id),
+  };
+}
+
 export async function fetchAppBootstrap(): Promise<AppBootstrapData> {
   const session = await getSession();
   if (!session) {
     return { user: null, prefs: null, savedStatuses: [], starredIds: [] };
   }
 
-  const [prefs, savedStatuses, starredIds] = await Promise.all([
-    getPreferences(),
-    getSavedJobStatuses(),
-    getStarredCompanyIds(),
-  ]);
+  const { prefs, savedStatuses, starredIds } = await _fetchBootstrapForUser(
+    session.user.id,
+  );
 
   return {
     user: session.user as SessionUser,
-    prefs: prefs as AppPreferences | null,
+    prefs,
     savedStatuses,
     starredIds,
   };


### PR DESCRIPTION
## Summary
- Replaces the 3-way `Promise.all([getPreferences, getSavedJobStatuses, getStarredCompanyIds])` with one `db.execute` returning a row of three JSON aggregates.
- Public actions stay unchanged — they have other callers (settings page, app pages directly).
- Round-trip count: 3 → 1. Wall-time win is largest on cold instances where the connection pool is establishing TLS for the first time.

Closes #2643. Part of the Fluid optimization roadmap (#2649).

## Test plan
- [x] New `bootstrap.test.ts` mocks `db.execute` and verifies the JSON-shape transformation (anon, fully populated, no prefs row, empty execute result, null timestamps, single-call assertion).
- [x] `pnpm test --run` — 29/29 files, 196/196 cases (was 190).
- [x] `pnpm tsc --noEmit` — clean.
- [ ] Post-deploy: verify Vercel function p50 dropped on `(app)` pages and that prefs/saved/starred state still hydrates correctly in the UI.