### PR TITLE
Bump /companies + /resolve CDN cache TTL to 1h

### DIFF
--- a/apps/web/app/api/v1/companies/route.ts
+++ b/apps/web/app/api/v1/companies/route.ts
@@ -28,5 +28,8 @@ export async function GET(request: NextRequest) {
     url: siteUrl(`/${locale}/company/${c.slug}`),
   }));
 
-  return apiResponse({ companies }, { rateLimit: rl });
+  // Autocomplete suggestions are very stable (a single new company per few
+  // days, slug shape never changes). Bumped from the 300s default to 1h
+  // for higher CDN reuse on common queries — see issue #2644.
+  return apiResponse({ companies }, { maxAge: 3600, rateLimit: rl });
 }

--- a/apps/web/app/api/v1/resolve/route.ts
+++ b/apps/web/app/api/v1/resolve/route.ts
@@ -76,12 +76,16 @@ export async function GET(request: NextRequest) {
     }
   }
 
+  // Resolve responses (taxonomy/location autocomplete) are stable — the
+  // taxonomy collections change on a daily-deploy cadence at most. Bumped
+  // from the 300s default to 1h for higher CDN reuse on common queries.
+  // See issue #2644 + alignment with /api/v1/taxonomies which is already 1h.
   return apiResponse(
     {
       type,
       query: q,
       matches: matches.slice(0, 10),
     },
-    { rateLimit: rl },
+    { maxAge: 3600, rateLimit: rl },
   );
 }


### PR DESCRIPTION
## Summary
- `/api/v1/companies` and `/api/v1/resolve` autocomplete endpoints bumped from 5min to 1h CDN cache.
- Aligns with `/api/v1/taxonomies` which already uses 1h.
- `/api/v1/search` and `/api/v1/job` stay at 5min (stale-sensitive data).

## Verification (closes the audit half of #2644)
Pre-merge curl confirms caching is working today — every `/api/v1/*` route I tested showed `x-vercel-cache: HIT` on the second call. Per-response `X-RateLimit-*` headers do **not** bust the cache (Vercel just replays the cached response, so there's no fresh function invocation or Redis Lua call on hits).

```
cache-control: public, max-age=300
x-ratelimit-limit: 30
x-ratelimit-remaining: 29
x-vercel-cache: HIT
age: 31
```

So the only outstanding action was raising TTL on the routes still on the 300s default. New companies arrive every few days; taxonomy/location data changes on a deploy cadence — both are safe at 1h.

Closes #2644. Part of the Fluid optimization roadmap (#2649).

## Test plan
- [x] `pnpm test --run` — 28/28 files, 190/190 cases (no test changes; behavior unchanged for callers).
- [x] `pnpm tsc --noEmit` — clean.
- [ ] Post-deploy: `curl -sSI https://jseek.co/api/v1/companies?q=stripe&locale=en | grep cache-control` shows `max-age=3600`.