### PR TITLE
Prerender top-200 company OG images at build time

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/opengraph-image.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/opengraph-image.tsx
@@ -57,7 +57,14 @@ export async function generateStaticParams(): Promise<
       .map((h) => (h.document as Record<string, unknown>).slug)
       .filter((s): s is string => typeof s === "string");
     return slugs.flatMap((slug) => locales.map((lang) => ({ lang, slug })));
-  } catch {
+  } catch (err) {
+    // Misconfigured TYPESENSE_* in build env, transient Typesense outage,
+    // etc. Don't fail the build — but log so a silent zero-prerender is
+    // visible in CI output and observable as a deploy regression.
+    console.warn(
+      "[opengraph-image] generateStaticParams: skipping prerender",
+      err,
+    );
     return [];
   }
 }

--- a/apps/web/app/[lang]/(app)/company/[slug]/opengraph-image.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/opengraph-image.tsx
@@ -1,5 +1,6 @@
 import { ImageResponse } from "next/og";
 import { getCompanyBySlug } from "@/lib/actions/company";
+import { locales } from "@/lib/i18n";
 
 export const alt = "Company jobs";
 export const size = { width: 1200, height: 630 };
@@ -13,6 +14,53 @@ export const revalidate = 2592000;
 
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
+
+/**
+ * How many top companies (by active posting count) to prerender at build
+ * time, across every supported locale. The actual count of cells baked
+ * into the build is `OG_PRERENDER_TOP_N × locales.length` (4 today). At
+ * ~50 KB per PNG that's a ~40 MB increase to the build artifact for N=200.
+ *
+ * Long-tail companies still generate on first request and then live in
+ * Vercel's CDN for the `revalidate` window. Prebaking the top tier
+ * absorbs Twitter/LinkedIn/Slack crawl spikes that otherwise cold-start
+ * a function per (slug, locale).
+ *
+ * See issue #2645.
+ */
+const OG_PRERENDER_TOP_N = 200;
+
+/**
+ * Pick the top-N companies to prerender. Returns `[]` on any error so a
+ * build environment without Typesense access (or a transient outage)
+ * never fails the build — Next.js will fall back to dynamic rendering on
+ * first request, identical to the existing behavior.
+ */
+export async function generateStaticParams(): Promise<
+  { lang: string; slug: string }[]
+> {
+  try {
+    const { getSearchClient } = await import(
+      "@/lib/search/typesense-client"
+    );
+    const client = getSearchClient();
+    const result = await client.collections("company").documents().search({
+      q: "*",
+      query_by: "name",
+      filter_by: "active_posting_count:>0",
+      sort_by: "active_posting_count:desc",
+      per_page: OG_PRERENDER_TOP_N,
+      page: 1,
+      include_fields: "slug",
+    });
+    const slugs = (result.hits ?? [])
+      .map((h) => (h.document as Record<string, unknown>).slug)
+      .filter((s): s is string => typeof s === "string");
+    return slugs.flatMap((slug) => locales.map((lang) => ({ lang, slug })));
+  } catch {
+    return [];
+  }
+}
 
 // Satori only supports TTF/OTF, not woff2.
 const fontPromise = readFile(


### PR DESCRIPTION
## Summary
- Adds `generateStaticParams()` to the company OG image route.
- Picks the top 200 companies by `active_posting_count` from Typesense, fans out across all 4 locales (800 cells total).
- Failure-safe: returns `[]` on any error (build env without Typesense access, transient outage), so Next.js falls back to the existing on-demand behavior. Build won't fail.

Build size impact: ~50 KB × 800 ≈ 40 MB, within Vercel limits.
Build time impact: ~140ms × 800 ≈ 1.5–2 min added.
Steady-state cost cut: absorbs first-crawl spikes from Twitter/LinkedIn/Slack on the most-linked companies, where today every fresh slug-lang pair cold-starts a Satori + sharp render.

Closes #2645. Part of the Fluid optimization roadmap (#2649).

## Test plan
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm test --run` — 28/28 files, 190/190 cases passing
- [ ] Post-deploy: confirm Vercel Functions tab shows fewer cold invocations on `/[lang]/(app)/company/[slug]/opengraph-image`
- [ ] Spot-check a few pre-rendered OG images in the deployed build (`https://jseek.co/en/company/<top-slug>` should serve the OG meta with `x-vercel-cache: HIT` from the first request)