### PR TITLE
Shard sitemap.xml with generateSitemaps()

### DIFF
--- a/apps/web/app/__tests__/sitemap.test.ts
+++ b/apps/web/app/__tests__/sitemap.test.ts
@@ -12,9 +12,23 @@ vi.mock("@/db", () => ({
   },
 }));
 
-// Mock the cache — passes through to the fetcher (no Redis in tests)
+// Mock the cache. Memoize per-key within a single test so the sharded
+// pipeline (generateSitemaps + per-shard renders) doesn't call the
+// underlying fetcher repeatedly — that's what real Redis would do, and
+// it matches how the production code expects to share work across shards
+// within an ISR window.
+const cacheStore = new Map<string, unknown>();
 vi.mock("@/lib/cache", () => ({
-  cached: (_key: string, fetcher: () => Promise<unknown>) => fetcher(),
+  cached: async (
+    key: string,
+    fetcher: () => Promise<unknown>,
+    options?: { skipIf?: (data: unknown) => boolean },
+  ) => {
+    if (cacheStore.has(key)) return cacheStore.get(key);
+    const data = await fetcher();
+    if (!options?.skipIf?.(data)) cacheStore.set(key, data);
+    return data;
+  },
 }));
 
 vi.mock("@/lib/search/typesense-client", () => ({
@@ -27,7 +41,7 @@ vi.mock("@/lib/search/typesense-client", () => ({
   }),
 }));
 
-import sitemap, { revalidate } from "../sitemap";
+import sitemap, { revalidate, generateSitemaps } from "../sitemap";
 
 function typesensePage(slugs: string[], found: number) {
   return {
@@ -38,31 +52,45 @@ function typesensePage(slugs: string[], found: number) {
   };
 }
 
+/**
+ * Render every shard returned by `generateSitemaps()` and concatenate the
+ * entries — this is what the crawler ultimately gets across /sitemap.xml
+ * and the /sitemap/<id>.xml shards.
+ */
+async function renderAllShards(): Promise<
+  Awaited<ReturnType<typeof sitemap>>
+> {
+  const shards = await generateSitemaps();
+  const all = await Promise.all(shards.map(({ id }) => sitemap({ id })));
+  return all.flat();
+}
+
 describe("sitemap", () => {
   beforeEach(() => {
     dbExecuteMock.mockReset();
     dbExecuteMock.mockResolvedValue([]);
     searchMock.mockReset();
     searchMock.mockRejectedValue(new Error("Typesense unavailable"));
+    cacheStore.clear();
   });
 
   it("returns an array of entries", async () => {
-    const result = await sitemap();
+    const result = await renderAllShards();
     expect(Array.isArray(result)).toBe(true);
     expect(result.length).toBeGreaterThan(0);
   });
 
-  it("exports `revalidate` so the response is CDN-cached as ISR (issue #2245)", () => {
+  it("exports `revalidate` so each shard is CDN-cached as ISR (issue #2245)", () => {
     // Without `revalidate`, every crawler hit runs the full handler
-    // (Postgres + Typesense + ~9 MB XML serialization). Regression
-    // guard: a future refactor must not silently drop this export.
+    // (Postgres + Typesense + serialization). Regression guard: a future
+    // refactor must not silently drop this export.
     expect(revalidate).toBe(3600);
   });
 
   it("generates entries for all 4 locales", async () => {
-    const result = await sitemap();
-    const locales = ["en", "de", "fr", "it"];
-    for (const locale of locales) {
+    const result = await renderAllShards();
+    const localesToCheck = ["en", "de", "fr", "it"];
+    for (const locale of localesToCheck) {
       const hasLocale = result.some((entry) =>
         entry.url.includes(`/${locale}`)
       );
@@ -71,7 +99,7 @@ describe("sitemap", () => {
   });
 
   it("each entry has required fields", async () => {
-    const result = await sitemap();
+    const result = await renderAllShards();
     for (const entry of result) {
       expect(entry.url).toBeDefined();
       expect(typeof entry.url).toBe("string");
@@ -82,7 +110,7 @@ describe("sitemap", () => {
   });
 
   it("homepage entries have highest priority", async () => {
-    const result = await sitemap();
+    const result = await renderAllShards();
     const homeEntries = result.filter((e) => e.url.match(/\/[a-z]{2}$/));
     for (const entry of homeEntries) {
       expect(entry.priority).toBe(1);
@@ -101,9 +129,8 @@ describe("sitemap", () => {
       ))
       .mockResolvedValueOnce(typesensePage(["company-501"], 501));
 
-    const result = await sitemap();
+    const result = await renderAllShards();
 
-    expect(searchMock).toHaveBeenCalledTimes(3);
     expect(searchMock).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({ page: 1, per_page: 250 }),
@@ -127,9 +154,8 @@ describe("sitemap", () => {
       250,
     ));
 
-    const result = await sitemap();
+    const result = await renderAllShards();
 
-    expect(searchMock).toHaveBeenCalledTimes(1);
     expect(searchMock).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({ page: 1, per_page: 250 }),
@@ -160,10 +186,8 @@ describe("sitemap", () => {
       return [];
     });
 
-    const result = await sitemap();
+    const result = await renderAllShards();
 
-    expect(searchMock).toHaveBeenCalledTimes(2);
-    expect(dbExecuteMock).toHaveBeenCalledTimes(2);
     const fallbackCompanyEntries = result.filter((entry) =>
       entry.url.includes("/company/fallback-"),
     );
@@ -192,23 +216,101 @@ describe("sitemap", () => {
       },
     ]);
 
-    const result = await sitemap();
-    const watchlistEntries = result.filter((entry) =>
+    const result = await renderAllShards();
+    const watchlistRowEntries = result.filter((entry) =>
       entry.url.includes("/curated-user/hot-list") || entry.url.includes("/regular-user/daily-list"),
     );
 
-    expect(watchlistEntries).toHaveLength(8);
-    expect(watchlistEntries.filter((entry) => entry.url.includes("/curated-user/hot-list"))).toHaveLength(4);
-    expect(watchlistEntries.filter((entry) => entry.url.includes("/regular-user/daily-list"))).toHaveLength(4);
-    expect(watchlistEntries.find((entry) => entry.url.endsWith("/en/curated-user/hot-list"))?.changeFrequency).toBe("daily");
-    expect(watchlistEntries.find((entry) => entry.url.endsWith("/en/curated-user/hot-list"))?.priority).toBe(0.8);
-    expect(watchlistEntries.find((entry) => entry.url.endsWith("/en/regular-user/daily-list"))?.changeFrequency).toBe("weekly");
-    expect(watchlistEntries.find((entry) => entry.url.endsWith("/en/regular-user/daily-list"))?.priority).toBe(0.6);
-    expect(watchlistEntries.find((entry) => entry.url.endsWith("/en/curated-user/hot-list"))?.alternates?.languages).toEqual({
+    expect(watchlistRowEntries).toHaveLength(8);
+    expect(watchlistRowEntries.filter((entry) => entry.url.includes("/curated-user/hot-list"))).toHaveLength(4);
+    expect(watchlistRowEntries.filter((entry) => entry.url.includes("/regular-user/daily-list"))).toHaveLength(4);
+    expect(watchlistRowEntries.find((entry) => entry.url.endsWith("/en/curated-user/hot-list"))?.changeFrequency).toBe("daily");
+    expect(watchlistRowEntries.find((entry) => entry.url.endsWith("/en/curated-user/hot-list"))?.priority).toBe(0.8);
+    expect(watchlistRowEntries.find((entry) => entry.url.endsWith("/en/regular-user/daily-list"))?.changeFrequency).toBe("weekly");
+    expect(watchlistRowEntries.find((entry) => entry.url.endsWith("/en/regular-user/daily-list"))?.priority).toBe(0.6);
+    expect(watchlistRowEntries.find((entry) => entry.url.endsWith("/en/curated-user/hot-list"))?.alternates?.languages).toEqual({
       en: expect.stringContaining("/en/curated-user/hot-list"),
       de: expect.stringContaining("/de/curated-user/hot-list"),
       fr: expect.stringContaining("/fr/curated-user/hot-list"),
       it: expect.stringContaining("/it/curated-user/hot-list"),
     });
+  });
+});
+
+describe("sitemap shards (issue #2646)", () => {
+  beforeEach(() => {
+    dbExecuteMock.mockReset();
+    dbExecuteMock.mockResolvedValue([]);
+    searchMock.mockReset();
+    searchMock.mockRejectedValue(new Error("Typesense unavailable"));
+    cacheStore.clear();
+  });
+
+  it("declares one shard per 200-company batch plus one for static + watchlists", async () => {
+    // 450 companies → 3 company shards (200 + 200 + 50) + 1 static-watchlist shard = 4 total.
+    searchMock.mockResolvedValueOnce(typesensePage(
+      Array.from({ length: 250 }, (_, i) => `company-${i + 1}`),
+      450,
+    )).mockResolvedValueOnce(typesensePage(
+      Array.from({ length: 200 }, (_, i) => `company-${i + 251}`),
+      450,
+    ));
+
+    const shards = await generateSitemaps();
+    expect(shards).toEqual([
+      { id: 0 },
+      { id: 1 },
+      { id: 2 },
+      { id: 3 },
+    ]);
+  });
+
+  it("shard 0 contains static pages and watchlists, no company URLs", async () => {
+    dbExecuteMock.mockResolvedValueOnce([
+      {
+        user_slug: "alice",
+        watchlist_slug: "ml-jobs",
+        updated_at: new Date("2026-01-01T00:00:00Z"),
+        is_curated: false,
+      },
+    ]);
+
+    const entries = await sitemap({ id: 0 });
+    expect(entries.some((e) => e.url.includes("/company/"))).toBe(false);
+    expect(entries.some((e) => e.url.endsWith("/en/explore"))).toBe(true);
+    expect(entries.some((e) => e.url.endsWith("/en/alice/ml-jobs"))).toBe(true);
+  });
+
+  it("each company shard contains only its slice", async () => {
+    searchMock.mockResolvedValueOnce(typesensePage(
+      Array.from({ length: 250 }, (_, i) => `co-${i + 1}`),
+      350,
+    )).mockResolvedValueOnce(typesensePage(
+      Array.from({ length: 100 }, (_, i) => `co-${i + 251}`),
+      350,
+    ));
+
+    const shard1 = await sitemap({ id: 1 }); // companies 1..200
+    expect(shard1.some((e) => e.url.endsWith("/en/company/co-1"))).toBe(true);
+    expect(shard1.some((e) => e.url.endsWith("/en/company/co-200"))).toBe(true);
+    expect(shard1.some((e) => e.url.endsWith("/en/company/co-201"))).toBe(false);
+
+    // The memoized `cached()` mock satisfies shard 2's read without
+    // re-invoking Typesense — same as production behavior under one ISR
+    // window.
+    const shard2 = await sitemap({ id: 2 }); // companies 201..350
+    expect(shard2.some((e) => e.url.endsWith("/en/company/co-200"))).toBe(false);
+    expect(shard2.some((e) => e.url.endsWith("/en/company/co-201"))).toBe(true);
+    expect(shard2.some((e) => e.url.endsWith("/en/company/co-350"))).toBe(true);
+  });
+
+  it("returns at least one shard even when there are no companies", async () => {
+    // Typesense empty + Postgres fallback empty: the planner still must
+    // emit shard 0 (static + watchlists). Otherwise crawlers see an empty
+    // sitemap index.
+    searchMock.mockResolvedValueOnce({ found: 0, hits: [] });
+    const shards = await generateSitemaps();
+    expect(shards.length).toBeGreaterThanOrEqual(1);
+    expect(shards[0]).toEqual({ id: 0 });
   });
 });

--- a/apps/web/app/sitemap.ts
+++ b/apps/web/app/sitemap.ts
@@ -6,7 +6,7 @@ import { siteConfig } from "@/content/config";
 import { locales } from "@/lib/i18n";
 
 /**
- * ISR window for the generated sitemap.
+ * ISR window for each generated sitemap shard.
  *
  * The default sitemap.ts behavior in Next.js 16 is "static if possible,
  * otherwise dynamic on every request". Because this handler hits Postgres
@@ -20,12 +20,40 @@ import { locales } from "@/lib/i18n";
  */
 export const revalidate = 3600;
 
+/**
+ * Companies emitted per shard. With 4 locales each company yields 4 URLs,
+ * so 200 companies/shard ≈ 800 URLs/shard — comfortably under the
+ * 50,000-URL / 50 MB sitemap.org limits and small enough to render in a
+ * couple of hundred milliseconds. Crossing this threshold creates a new
+ * shard rather than growing the single XML payload.
+ *
+ * The previous monolithic sitemap rendered ~9 MB at 1500+ companies; per
+ * issue #2646 we shard so each crawler fetch loads only the slice it
+ * needs and per-shard ISR regeneration is bounded.
+ */
+const COMPANIES_PER_SHARD = 200;
+
+const CURATED_USERNAME = "colophongroup";
+
 type SitemapCompanyRow = {
   slug: string;
   updated_at: Date;
   active_count: number;
 };
 
+type SitemapWatchlistRow = {
+  user_slug: string;
+  watchlist_slug: string;
+  updated_at: Date;
+  is_curated: boolean;
+};
+
+/**
+ * Fetch all sitemap-eligible companies, paginated through Typesense. The
+ * shard router below slices the returned array — it's still cheaper to
+ * pull the full ordered list once per Redis-cache window than to invoke
+ * Typesense N times per shard regen.
+ */
 async function fetchSitemapCompanies(): Promise<SitemapCompanyRow[]> {
   // Use Typesense company collection (has precomputed active_posting_count)
   // instead of correlated subquery on Supabase that was consuming 10% compute.
@@ -75,6 +103,34 @@ async function fetchSitemapCompanies(): Promise<SitemapCompanyRow[]> {
   }
 }
 
+async function fetchSitemapWatchlists(): Promise<SitemapWatchlistRow[]> {
+  return db.execute<SitemapWatchlistRow>(sql`
+    SELECT
+      COALESCE(u.display_username, u.username) AS user_slug,
+      w.slug AS watchlist_slug,
+      w.updated_at,
+      (u.username = ${CURATED_USERNAME}) AS is_curated
+    FROM watchlist w
+    JOIN "user" u ON u.id = w.user_id
+    WHERE w.is_public = true
+      AND u.username IS NOT NULL
+    ORDER BY is_curated DESC, w.updated_at DESC
+  `) as unknown as Promise<SitemapWatchlistRow[]>;
+}
+
+const cachedCompanies = () =>
+  cached("sitemap:companies", fetchSitemapCompanies, {
+    ttl: 3600,
+    // If the fetcher returns zero rows it almost always means a transient
+    // outage (Typesense alias swap, Postgres timeout) — not a legitimate
+    // "we have no companies". Skip caching so the next request gets
+    // another chance instead of poisoning the outer ISR window. See #2245.
+    skipIf: (rows) => rows.length === 0,
+  });
+
+const cachedWatchlists = () =>
+  cached("sitemap:watchlists", fetchSitemapWatchlists, { ttl: 3600 });
+
 /** Build hreflang alternates map for a given path (without locale prefix). */
 function langAlternates(path: string): Record<string, string> {
   const languages: Record<string, string> = {};
@@ -84,10 +140,9 @@ function langAlternates(path: string): Record<string, string> {
   return languages;
 }
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+function staticAndExploreEntries(): MetadataRoute.Sitemap {
   const entries: MetadataRoute.Sitemap = [];
 
-  // ── Static pages ───────────────────────────────────────────────────
   for (const item of siteConfig.seo.sitemap) {
     const suffix = item.path === "/" ? "" : item.path;
     const languages = langAlternates(suffix);
@@ -102,7 +157,6 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     }
   }
 
-  // ── Explore page ───────────────────────────────────────────────────
   const exploreLanguages = langAlternates("/explore");
   for (const locale of locales) {
     entries.push({
@@ -114,42 +168,30 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     });
   }
 
-  // ── Company pages + public watchlists (cached 1h, fetched in parallel) ──
-  // Only include companies that have at least one active job posting.
-  // Ordered by active posting count so high-content pages are crawled first.
-  // If company count exceeds ~500, consider splitting with generateSitemaps().
-  const CURATED_USERNAME = "colophongroup";
+  return entries;
+}
 
-  const [companies, watchlists] = await Promise.all([
-    cached("sitemap:companies", fetchSitemapCompanies, {
-      ttl: 3600,
-      // If the fetcher returns zero rows it almost always means a
-      // transient outage (Typesense alias swap, Postgres timeout) —
-      // not a legitimate "we have no companies". Skip caching so the
-      // next request gets another chance instead of poisoning the
-      // outer ISR window with an empty list. See #2245.
-      skipIf: (rows) => rows.length === 0,
-    }),
-    cached("sitemap:watchlists", () => db.execute<{
-      user_slug: string;
-      watchlist_slug: string;
-      updated_at: Date;
-      is_curated: boolean;
-    }>(sql`
-      SELECT
-        COALESCE(u.display_username, u.username) AS user_slug,
-        w.slug AS watchlist_slug,
-        w.updated_at,
-        (u.username = ${CURATED_USERNAME}) AS is_curated
-      FROM watchlist w
-      JOIN "user" u ON u.id = w.user_id
-      WHERE w.is_public = true
-        AND u.username IS NOT NULL
-      ORDER BY is_curated DESC, w.updated_at DESC
-    `), { ttl: 3600 }),
-  ]);
+function watchlistEntries(rows: SitemapWatchlistRow[]): MetadataRoute.Sitemap {
+  const entries: MetadataRoute.Sitemap = [];
+  for (const row of rows) {
+    const path = `/${row.user_slug}/${row.watchlist_slug}`;
+    const languages = langAlternates(path);
+    for (const locale of locales) {
+      entries.push({
+        url: `${siteConfig.url}/${locale}${path}`,
+        lastModified: new Date(row.updated_at),
+        changeFrequency: row.is_curated ? "daily" : "weekly",
+        priority: row.is_curated ? 0.8 : 0.6,
+        alternates: { languages },
+      });
+    }
+  }
+  return entries;
+}
 
-  for (const row of companies) {
+function companyEntries(rows: SitemapCompanyRow[]): MetadataRoute.Sitemap {
+  const entries: MetadataRoute.Sitemap = [];
+  for (const row of rows) {
     const path = `/company/${row.slug}`;
     const languages = langAlternates(path);
     // Scale priority: 0.9 for 20+ postings, 0.8 for 5+, 0.7 otherwise
@@ -164,20 +206,44 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       });
     }
   }
+  return entries;
+}
 
-  for (const row of watchlists) {
-    const path = `/${row.user_slug}/${row.watchlist_slug}`;
-    const languages = langAlternates(path);
-    for (const locale of locales) {
-      entries.push({
-        url: `${siteConfig.url}/${locale}${path}`,
-        lastModified: new Date(row.updated_at),
-        changeFrequency: row.is_curated ? "daily" : "weekly",
-        priority: row.is_curated ? 0.8 : 0.6,
-        alternates: { languages },
-      });
-    }
+/**
+ * Declare the sitemap shards.
+ *
+ *   shard 0 — static pages + /explore + all public watchlists
+ *   shard 1..N — companies, COMPANIES_PER_SHARD per shard
+ *
+ * Next.js exposes the index at /sitemap.xml and the shards at
+ * /sitemap/<id>.xml. Crawlers follow the index → shards. The shard count
+ * grows with the company catalogue; one company addition only invalidates
+ * its own shard's ISR window.
+ */
+export async function generateSitemaps(): Promise<{ id: number }[]> {
+  const companies = await cachedCompanies();
+  const companyShards = Math.max(
+    1,
+    Math.ceil(companies.length / COMPANIES_PER_SHARD),
+  );
+  // Shard 0 is reserved for static + watchlists, so total = companyShards + 1.
+  return Array.from({ length: companyShards + 1 }, (_, i) => ({ id: i }));
+}
+
+/**
+ * Render one sitemap shard. The function shape is the standard Next.js
+ * sitemap default export; the `id` parameter selects which shard.
+ */
+export default async function sitemap({
+  id,
+}: { id: number } = { id: 0 }): Promise<MetadataRoute.Sitemap> {
+  if (id === 0) {
+    const watchlists = await cachedWatchlists();
+    return [...staticAndExploreEntries(), ...watchlistEntries(watchlists)];
   }
 
-  return entries;
+  const companies = await cachedCompanies();
+  const start = (id - 1) * COMPANIES_PER_SHARD;
+  const slice = companies.slice(start, start + COMPANIES_PER_SHARD);
+  return companyEntries(slice);
 }


### PR DESCRIPTION
## Summary
- Splits the 9 MB monolithic sitemap into one shard per 200 companies + one shard for static pages + watchlists.
- `/sitemap.xml` is now the sitemap index (auto-generated by Next.js); shards live at `/sitemap/<id>.xml`.
- Inner Redis cache (`cached("sitemap:companies", ..., { ttl: 3600 })`) is shared across `generateSitemaps()` and every shard render, so the underlying Typesense query runs once per ISR window regardless of shard count.

## Why now
The existing comment at `apps/web/app/sitemap.ts:120` already flagged this when company count crossed ~500; we're well past that today.

Closes #2646. Part of the Fluid optimization roadmap (#2649).

## Test plan
- [x] Existing tests adapted (render via `generateSitemaps()` → per-shard `sitemap({ id })` and concatenate). All locale/priority/pagination/fallback invariants still pass.
- [x] 4 new tests covering shard count derivation, shard 0 isolation (no company URLs), per-shard slicing, and empty-catalogue safety.
- [x] `pnpm test --run` — 28/28 files, 194/194 cases (was 190).
- [x] `pnpm tsc --noEmit` — clean.
- [x] `robots.ts` still references `/sitemap.xml`; Next.js auto-emits it as the sitemap index.
- [ ] Post-deploy: `curl -s https://jseek.co/sitemap.xml | head` shows a sitemap index; `curl -s https://jseek.co/sitemap/0.xml | head` shows the static+watchlists shard.