### PR TITLE
Move all read-heavy /explore + typeahead + company + watchlist surfaces to direct browser->Typesense (gated)

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
@@ -8,7 +8,9 @@ import { timeAgoShort } from "@/lib/time";
 import { SaveButton } from "@/components/search/save-button";
 import { JobDetailPanel } from "@/components/search/job-detail-dialog";
 import { SearchToolbar } from "@/components/search/search-toolbar";
-import { getCompanyPostings } from "@/lib/actions/company";
+import { runGetCompanyPostings } from "@/lib/search/search-runner";
+import { useClearTypesenseOnAuthChange } from "@/lib/search/use-clear-typesense-on-auth-change";
+import { useSession } from "@/components/SessionProvider";
 import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
 import { InfiniteScrollSentinel } from "@/components/InfiniteScrollSentinel";
 import { TruncationPrompt } from "@/components/TruncationPrompt";
@@ -82,6 +84,10 @@ export function CompanyPage({
   const searchParams = useSearchParams();
   const uiLocale = (params.lang as string) ?? locale;
   const { setPageActions } = useSearchStateStore();
+  const { isLoggedIn } = useSession();
+  const isLoggedInRef = useRef(isLoggedIn);
+  isLoggedInRef.current = isLoggedIn;
+  useClearTypesenseOnAuthChange(isLoggedIn);
 
   const [keywords, setKeywords] = useState<string[]>(initialKeywords);
   const [locations, setLocations] = useState<SelectedLocation[]>(initialLocations);
@@ -202,23 +208,26 @@ export function CompanyPage({
     const expMin = experienceMinRef.current;
     const expMax = experienceMaxRef.current;
     startSearch(async () => {
-      const result = await getCompanyPostings({
-        companyId: company.id,
-        keywords: kws,
-        locationIds: locationIds.length > 0 ? locationIds : undefined,
-        occupationIds: occupationIds.length > 0 ? occupationIds : undefined,
-        seniorityIds: seniorityIds.length > 0 ? seniorityIds : undefined,
-        technologyIds: technologyIds.length > 0 ? technologyIds : undefined,
-        employmentTypes: etypes.length > 0 ? etypes : undefined,
-        salaryMinEur: salMinEur,
-        salaryMaxEur: salMaxEur,
-        experienceMin: expMin,
-        experienceMax: expMax,
-        languages,
-        locale: uiLocale,
-        offset: 0,
-        limit: PAGE_SIZE,
-      });
+      const result = await runGetCompanyPostings(
+        {
+          companyId: company.id,
+          keywords: kws,
+          locationIds: locationIds.length > 0 ? locationIds : undefined,
+          occupationIds: occupationIds.length > 0 ? occupationIds : undefined,
+          seniorityIds: seniorityIds.length > 0 ? seniorityIds : undefined,
+          technologyIds: technologyIds.length > 0 ? technologyIds : undefined,
+          employmentTypes: etypes.length > 0 ? etypes : undefined,
+          salaryMinEur: salMinEur,
+          salaryMaxEur: salMaxEur,
+          experienceMin: expMin,
+          experienceMax: expMax,
+          languages,
+          locale: uiLocale,
+          offset: 0,
+          limit: PAGE_SIZE,
+        },
+        isLoggedInRef.current,
+      );
       setPostings(result.postings);
       setActiveCount(result.activeCount);
       setYearCount(result.yearCount);
@@ -463,23 +472,26 @@ export function CompanyPage({
     const salMinEur = toEur(salaryMin);
     const salMaxEur = toEur(salaryMax);
 
-    const result = await getCompanyPostings({
-      companyId: company.id,
-      keywords,
-      locationIds: locationIds.length > 0 ? locationIds : undefined,
-      occupationIds,
-      seniorityIds,
-      technologyIds,
-      employmentTypes: etypes,
-      salaryMinEur: salMinEur,
-      salaryMaxEur: salMaxEur,
-      experienceMin,
-      experienceMax,
-      languages,
-      locale: uiLocale,
-      offset: postings.length,
-      limit: PAGE_SIZE,
-    });
+    const result = await runGetCompanyPostings(
+      {
+        companyId: company.id,
+        keywords,
+        locationIds: locationIds.length > 0 ? locationIds : undefined,
+        occupationIds,
+        seniorityIds,
+        technologyIds,
+        employmentTypes: etypes,
+        salaryMinEur: salMinEur,
+        salaryMaxEur: salMaxEur,
+        experienceMin,
+        experienceMax,
+        languages,
+        locale: uiLocale,
+        offset: postings.length,
+        limit: PAGE_SIZE,
+      },
+      isLoggedInRef.current,
+    );
     if (result.truncated) setIsTruncated(true);
     if (result.postings.length > 0) {
       setPostings((prev) => {

--- a/apps/web/app/[lang]/(app)/explore/search-page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/search-page.tsx
@@ -11,6 +11,7 @@ import { JobDetailPanel } from "@/components/search/job-detail-dialog";
 import { SearchToolbar } from "@/components/search/search-toolbar";
 import { getCurrencyRates, type CurrencyRate } from "@/lib/actions/search";
 import { runSearchJobs, runListTopCompanies } from "@/lib/search/search-runner";
+import { useClearTypesenseOnAuthChange } from "@/lib/search/use-clear-typesense-on-auth-change";
 import { useSession } from "@/components/SessionProvider";
 import { parseSearchFilters } from "@/lib/actions/search-input";
 import { buildFilteredPath } from "@/lib/search/query-params";
@@ -128,19 +129,7 @@ export function SearchPage({
     getCurrencyRates().then(setCurrencyRates);
   }, []);
 
-  // Clear the cached browser-side scoped Typesense key when auth state flips.
-  // Prevents a signed-in user from being held on the anon key (with its anon
-  // truncation soft-cap) and a signed-out user from holding the authed key.
-  useEffect(() => {
-    if (process.env.NEXT_PUBLIC_TYPESENSE_DIRECT !== "1") return;
-    let cancelled = false;
-    import("@/lib/search/typesense-browser-key").then((m) => {
-      if (!cancelled) m.clearTypesenseBrowserConfig();
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [isLoggedIn]);
+  useClearTypesenseOnAuthChange(isLoggedIn);
 
   const [showPostingId, setShowPostingId] = useState<string | null>(
     searchParams.get("show") ?? (shouldRestore ? cached.showPostingId : null),

--- a/apps/web/app/[lang]/(app)/explore/search-page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/search-page.tsx
@@ -9,7 +9,9 @@ import { ZeroResults } from "@/components/search/zero-results";
 import { SkeletonCards } from "@/components/search/skeleton-card";
 import { JobDetailPanel } from "@/components/search/job-detail-dialog";
 import { SearchToolbar } from "@/components/search/search-toolbar";
-import { searchJobs, listTopCompanies, getCurrencyRates, type CurrencyRate } from "@/lib/actions/search";
+import { getCurrencyRates, type CurrencyRate } from "@/lib/actions/search";
+import { runSearchJobs, runListTopCompanies } from "@/lib/search/search-runner";
+import { useSession } from "@/components/SessionProvider";
 import { parseSearchFilters } from "@/lib/actions/search-input";
 import { buildFilteredPath } from "@/lib/search/query-params";
 import type { SearchResultCompany, HistogramFilters } from "@/lib/search";
@@ -69,6 +71,9 @@ export function SearchPage({
 }: SearchPageProps) {
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const { isLoggedIn } = useSession();
+  const isLoggedInRef = useRef(isLoggedIn);
+  isLoggedInRef.current = isLoggedIn;
   const { get: getSearchState, set: setSearchState, setPageActions } = useSearchStateStore();
 
   const cached = getSearchState();
@@ -122,6 +127,20 @@ export function SearchPage({
   useEffect(() => {
     getCurrencyRates().then(setCurrencyRates);
   }, []);
+
+  // Clear the cached browser-side scoped Typesense key when auth state flips.
+  // Prevents a signed-in user from being held on the anon key (with its anon
+  // truncation soft-cap) and a signed-out user from holding the authed key.
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_TYPESENSE_DIRECT !== "1") return;
+    let cancelled = false;
+    import("@/lib/search/typesense-browser-key").then((m) => {
+      if (!cancelled) m.clearTypesenseBrowserConfig();
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [isLoggedIn]);
 
   const [showPostingId, setShowPostingId] = useState<string | null>(
     searchParams.get("show") ?? (shouldRestore ? cached.showPostingId : null),
@@ -438,37 +457,43 @@ export function SearchPage({
       try {
         const result =
           kws.length > 0
-            ? await searchJobs({
-                keywords: kws,
-                locationIds,
-                occupationIds: occupationIds.length > 0 ? occupationIds : undefined,
-                seniorityIds: seniorityIds.length > 0 ? seniorityIds : undefined,
-                technologyIds: technologyIds.length > 0 ? technologyIds : undefined,
-                employmentTypes: etypes.length > 0 ? etypes : undefined,
-                salaryMinEur: salMinEur,
-                salaryMaxEur: salMaxEur,
-                experienceMin: expMin,
-                experienceMax: expMax,
-                languages,
-                locale,
-                offset: 0,
-                limit: PAGE_SIZE,
-              })
-            : await listTopCompanies({
-                locationIds,
-                occupationIds: occupationIds.length > 0 ? occupationIds : undefined,
-                seniorityIds: seniorityIds.length > 0 ? seniorityIds : undefined,
-                technologyIds: technologyIds.length > 0 ? technologyIds : undefined,
-                employmentTypes: etypes.length > 0 ? etypes : undefined,
-                salaryMinEur: salMinEur,
-                salaryMaxEur: salMaxEur,
-                experienceMin: expMin,
-                experienceMax: expMax,
-                languages,
-                locale,
-                offset: 0,
-                limit: PAGE_SIZE,
-              });
+            ? await runSearchJobs(
+                {
+                  keywords: kws,
+                  locationIds,
+                  occupationIds: occupationIds.length > 0 ? occupationIds : undefined,
+                  seniorityIds: seniorityIds.length > 0 ? seniorityIds : undefined,
+                  technologyIds: technologyIds.length > 0 ? technologyIds : undefined,
+                  employmentTypes: etypes.length > 0 ? etypes : undefined,
+                  salaryMinEur: salMinEur,
+                  salaryMaxEur: salMaxEur,
+                  experienceMin: expMin,
+                  experienceMax: expMax,
+                  languages,
+                  locale,
+                  offset: 0,
+                  limit: PAGE_SIZE,
+                },
+                isLoggedInRef.current,
+              )
+            : await runListTopCompanies(
+                {
+                  locationIds,
+                  occupationIds: occupationIds.length > 0 ? occupationIds : undefined,
+                  seniorityIds: seniorityIds.length > 0 ? seniorityIds : undefined,
+                  technologyIds: technologyIds.length > 0 ? technologyIds : undefined,
+                  employmentTypes: etypes.length > 0 ? etypes : undefined,
+                  salaryMinEur: salMinEur,
+                  salaryMaxEur: salMaxEur,
+                  experienceMin: expMin,
+                  experienceMax: expMax,
+                  languages,
+                  locale,
+                  offset: 0,
+                  limit: PAGE_SIZE,
+                },
+                isLoggedInRef.current,
+              );
         if (searchCounterRef.current !== id) return; // stale
         setCompanies(result.companies);
         serverOffsetRef.current = result.companies.length;
@@ -652,8 +677,8 @@ export function SearchPage({
     const expMin = experienceMinRef.current;
     const expMax = experienceMaxRef.current;
     const result = kws.length > 0
-      ? await searchJobs({ keywords: kws, locationIds, occupationIds, seniorityIds, technologyIds, employmentTypes: etypes, salaryMinEur: salMinEur, salaryMaxEur: salMaxEur, experienceMin: expMin, experienceMax: expMax, languages, locale, offset, limit: PAGE_SIZE })
-      : await listTopCompanies({ locationIds, occupationIds, seniorityIds, technologyIds, employmentTypes: etypes, salaryMinEur: salMinEur, salaryMaxEur: salMaxEur, experienceMin: expMin, experienceMax: expMax, languages, locale, offset, limit: PAGE_SIZE });
+      ? await runSearchJobs({ keywords: kws, locationIds, occupationIds, seniorityIds, technologyIds, employmentTypes: etypes, salaryMinEur: salMinEur, salaryMaxEur: salMaxEur, experienceMin: expMin, experienceMax: expMax, languages, locale, offset, limit: PAGE_SIZE }, isLoggedInRef.current)
+      : await runListTopCompanies({ locationIds, occupationIds, seniorityIds, technologyIds, employmentTypes: etypes, salaryMinEur: salMinEur, salaryMaxEur: salMaxEur, experienceMin: expMin, experienceMax: expMax, languages, locale, offset, limit: PAGE_SIZE }, isLoggedInRef.current);
 
     if (result.truncated) setIsTruncated(true);
     serverOffsetRef.current += result.companies.length;

--- a/apps/web/app/api/typesense-key/route.ts
+++ b/apps/web/app/api/typesense-key/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { generateScopedSearchKey } from "@/lib/search/scoped-key";
+import { getSessionUserId } from "@/lib/sessionCache";
+
+const ANON_TTL_SECONDS = 300;
+const AUTHED_TTL_SECONDS = 600;
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  // Typesense scoped keys must be derived from a parent whose actions list is
+  // exactly ["documents:search"]. The regular TYPESENSE_SEARCH_KEY also carries
+  // documents:get, so the server rejects scoped keys minted from it.
+  // TYPESENSE_BROWSER_PARENT_KEY is a dedicated documents:search-only key used
+  // only for browser-side scoped-key minting.
+  const parentKey = process.env.TYPESENSE_BROWSER_PARENT_KEY;
+  const host = process.env.TYPESENSE_HOST;
+  const port = process.env.TYPESENSE_PORT;
+  const protocol = process.env.TYPESENSE_PROTOCOL;
+  if (!parentKey || !host || !port || !protocol) {
+    return NextResponse.json({ error: "search not configured" }, { status: 503 });
+  }
+
+  const userId = await getSessionUserId();
+  const ttl = userId ? AUTHED_TTL_SECONDS : ANON_TTL_SECONDS;
+
+  // limit_hits is intentionally omitted: it counts raw hits (not grouped rows),
+  // so it would block normal anon traffic that uses group_by company_id with
+  // group_limit 10. Anon truncation is enforced as a soft client-side cap; the
+  // Cloudflare per-IP rate-limit on typesense.colophon-group.org is the real
+  // abuse brake.
+  const apiKey = generateScopedSearchKey(parentKey, { use_cache: true });
+
+  const expiresAt = Date.now() + ttl * 1000;
+  const cacheControl = userId
+    ? `private, max-age=${Math.floor(ttl / 2)}`
+    : `public, s-maxage=${Math.floor(ttl / 2)}, max-age=0`;
+
+  return NextResponse.json(
+    {
+      apiKey,
+      expiresAt,
+      host,
+      port: Number.parseInt(port, 10),
+      protocol,
+    },
+    {
+      headers: { "cache-control": cacheControl },
+    },
+  );
+}

--- a/apps/web/src/components/search/filter-bar.tsx
+++ b/apps/web/src/components/search/filter-bar.tsx
@@ -3,8 +3,8 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { X, MapPin, Search, ChevronDown, ChevronUp, Globe, Briefcase, BarChart3 } from "lucide-react";
 import { useLingui, Trans } from "@lingui/react/macro";
-import { suggestLocations } from "@/lib/actions/locations";
 import type { LocationSuggestion } from "@/lib/actions/locations";
+import { runSuggestLocations as suggestLocations } from "@/lib/search/typeahead-runner";
 import { LocationModal } from "./location-modal";
 import { ScrollFade } from "@/components/ui/scroll-fade";
 

--- a/apps/web/src/components/search/location-pills.tsx
+++ b/apps/web/src/components/search/location-pills.tsx
@@ -3,8 +3,8 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { X, MapPin } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
-import { suggestLocations } from "@/lib/actions/locations";
 import type { LocationSuggestion } from "@/lib/actions/locations";
+import { runSuggestLocations as suggestLocations } from "@/lib/search/typeahead-runner";
 import { ScrollFade } from "@/components/ui/scroll-fade";
 
 export interface SelectedLocation {

--- a/apps/web/src/components/search/search-bar.tsx
+++ b/apps/web/src/components/search/search-bar.tsx
@@ -5,12 +5,16 @@ import { useParams, usePathname, useRouter, useSearchParams } from "next/navigat
 import { Search, MapPin, Building2, ArrowRight, Briefcase, BarChart3, Code2 } from "lucide-react";
 import Image from "next/image";
 import { useLingui } from "@lingui/react/macro";
-import { suggestLocations } from "@/lib/actions/locations";
 import type { LocationSuggestion } from "@/lib/actions/locations";
 import { suggestCompanies } from "@/lib/actions/company";
 import type { CompanySuggestion } from "@/lib/actions/company";
-import { suggestOccupations, suggestSeniorities, suggestTechnologies } from "@/lib/actions/taxonomy";
 import type { TaxonomySuggestion } from "@/lib/actions/taxonomy";
+import {
+  runSuggestLocations as suggestLocations,
+  runSuggestOccupations as suggestOccupations,
+  runSuggestSeniorities as suggestSeniorities,
+  runSuggestTechnologies as suggestTechnologies,
+} from "@/lib/search/typeahead-runner";
 import { parseSearchFilters } from "@/lib/actions/search-input";
 import type { SelectedLocation } from "@/components/search/location-pills";
 import { buildFilteredPath } from "@/lib/search/query-params";

--- a/apps/web/src/components/watchlist/watchlist-job-list.tsx
+++ b/apps/web/src/components/watchlist/watchlist-job-list.tsx
@@ -6,10 +6,10 @@ import Image from "next/image";
 import { Building2, Bookmark } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { timeAgoShort } from "@/lib/time";
-import {
-  getWatchlistPostings,
-  type WatchlistPostingEntry,
-} from "@/lib/actions/watchlists";
+import { type WatchlistPostingEntry } from "@/lib/actions/watchlists";
+import { runGetWatchlistPostings } from "@/lib/search/search-runner";
+import { useClearTypesenseOnAuthChange } from "@/lib/search/use-clear-typesense-on-auth-change";
+import { useSession } from "@/components/SessionProvider";
 import { useSavedJobs } from "@/components/SavedJobsProvider";
 import { JobDetailPanel } from "@/components/search/job-detail-dialog";
 import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
@@ -76,6 +76,10 @@ export function WatchlistJobList({
   locale: string;
 }) {
   const { t } = useLingui();
+  const { isLoggedIn } = useSession();
+  const isLoggedInRef = useRef(isLoggedIn);
+  isLoggedInRef.current = isLoggedIn;
+  useClearTypesenseOnAuthChange(isLoggedIn);
   const [postings, setPostings] = useState(initialPostings);
   const [total, setTotal] = useState(initialTotal);
   const [exhausted, setExhausted] = useState(initialPostings.length >= initialTotal);
@@ -96,7 +100,7 @@ export function WatchlistJobList({
   // the server already provided initialPostings/initialTotal)
   useEffect(() => {
     if (filtersKey === initialFiltersKey.current) return;
-    getWatchlistPostings({ ...filters, offset: 0, limit: BATCH })
+    runGetWatchlistPostings({ ...filters, offset: 0, limit: BATCH }, isLoggedInRef.current)
       .then(({ postings: p, total: t, truncated }) => {
         setPostings(p);
         setTotal(t);
@@ -106,11 +110,14 @@ export function WatchlistJobList({
   }, [filtersKey]);
 
   async function handleLoadMore() {
-    const result = await getWatchlistPostings({
-      ...filtersRef.current,
-      offset: postings.length,
-      limit: BATCH,
-    });
+    const result = await runGetWatchlistPostings(
+      {
+        ...filtersRef.current,
+        offset: postings.length,
+        limit: BATCH,
+      },
+      isLoggedInRef.current,
+    );
     if (result.truncated) setIsTruncated(true);
     setTotal(result.total);
     if (result.postings.length > 0) {

--- a/apps/web/src/lib/search/__tests__/scoped-key.test.ts
+++ b/apps/web/src/lib/search/__tests__/scoped-key.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { Client } from "typesense";
+import { generateScopedSearchKey } from "../scoped-key";
+
+const PARENT = "test-parent-key-abcdef0123456789";
+
+describe("generateScopedSearchKey", () => {
+  it("matches typesense-js Client.keys().generateScopedSearchKey output", () => {
+    const client = new Client({
+      apiKey: PARENT,
+      nodes: [{ host: "x", port: 1, protocol: "http" }],
+    });
+    const ours = generateScopedSearchKey(PARENT, { use_cache: true });
+    const theirs = client.keys().generateScopedSearchKey(PARENT, { use_cache: true });
+    expect(ours).toBe(theirs);
+  });
+
+  it("changes output when embed parameters change", () => {
+    const a = generateScopedSearchKey(PARENT, { use_cache: true });
+    const b = generateScopedSearchKey(PARENT, { use_cache: false });
+    expect(a).not.toBe(b);
+  });
+
+  it("decodes to a valid Typesense scoped key envelope", () => {
+    const key = generateScopedSearchKey(PARENT, { filter_by: "is_active:true" });
+    const decoded = Buffer.from(key, "base64").toString("utf-8");
+    // Format: <44-char base64 hmac><4-char prefix><params json>
+    expect(decoded.length).toBeGreaterThan(48);
+    const prefix = decoded.slice(44, 48);
+    expect(prefix).toBe(PARENT.slice(0, 4));
+    const params = decoded.slice(48);
+    expect(JSON.parse(params)).toEqual({ filter_by: "is_active:true" });
+  });
+});

--- a/apps/web/src/lib/search/scoped-key.ts
+++ b/apps/web/src/lib/search/scoped-key.ts
@@ -1,0 +1,19 @@
+import { createHmac } from "node:crypto";
+
+export interface ScopedKeyEmbed {
+  filter_by?: string;
+  exclude_fields?: string;
+  use_cache?: boolean;
+}
+
+export function generateScopedSearchKey(
+  parentKey: string,
+  embed: ScopedKeyEmbed,
+): string {
+  const paramsJSON = JSON.stringify(embed);
+  const digest = createHmac("sha256", parentKey)
+    .update(paramsJSON)
+    .digest("base64");
+  const keyPrefix = parentKey.slice(0, 4);
+  return Buffer.from(`${digest}${keyPrefix}${paramsJSON}`).toString("base64");
+}

--- a/apps/web/src/lib/search/search-runner.ts
+++ b/apps/web/src/lib/search/search-runner.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import {
+  searchJobs as serverSearchJobs,
+  listTopCompanies as serverListTopCompanies,
+} from "@/lib/actions/search";
+import type { SearchFilters, SearchResponse } from "./types";
+import { ANON_MAX_COMPANIES } from "./constants";
+
+type SearchInput = SearchFilters & { keywords: string[]; offset: number; limit: number };
+type ListInput = SearchFilters & { offset: number; limit: number };
+
+const directEnabled = process.env.NEXT_PUBLIC_TYPESENSE_DIRECT === "1";
+
+async function tryBrowserProvider() {
+  const { getBrowserSearchProvider } = await import("./typesense-browser");
+  return getBrowserSearchProvider();
+}
+
+function applyAnonCap(
+  result: SearchResponse,
+  offset: number,
+  isLoggedIn: boolean,
+): SearchResponse {
+  if (isLoggedIn) return result;
+  if (offset >= ANON_MAX_COMPANIES) {
+    return { companies: [], totalCompanies: 0, truncated: true };
+  }
+  if (offset + result.companies.length >= ANON_MAX_COMPANIES) {
+    return { ...result, truncated: true };
+  }
+  return result;
+}
+
+export async function runSearchJobs(
+  params: SearchInput,
+  isLoggedIn: boolean,
+): Promise<SearchResponse> {
+  if (directEnabled) {
+    if (!isLoggedIn && params.offset >= ANON_MAX_COMPANIES) {
+      return { companies: [], totalCompanies: 0, truncated: true };
+    }
+    try {
+      const provider = await tryBrowserProvider();
+      const result = await provider.search(params);
+      if (!result.degraded) return applyAnonCap(result, params.offset, isLoggedIn);
+    } catch (err) {
+      console.error("[search-runner] browser searchJobs failed, falling back", err);
+    }
+  }
+  return serverSearchJobs(params);
+}
+
+export async function runListTopCompanies(
+  params: ListInput,
+  isLoggedIn: boolean,
+): Promise<SearchResponse> {
+  if (directEnabled) {
+    if (!isLoggedIn && params.offset >= ANON_MAX_COMPANIES) {
+      return { companies: [], totalCompanies: 0, truncated: true };
+    }
+    try {
+      const provider = await tryBrowserProvider();
+      const result = await provider.listTopCompanies(params);
+      if (!result.degraded) return applyAnonCap(result, params.offset, isLoggedIn);
+    } catch (err) {
+      console.error("[search-runner] browser listTopCompanies failed, falling back", err);
+    }
+  }
+  return serverListTopCompanies(params);
+}

--- a/apps/web/src/lib/search/search-runner.ts
+++ b/apps/web/src/lib/search/search-runner.ts
@@ -4,11 +4,36 @@ import {
   searchJobs as serverSearchJobs,
   listTopCompanies as serverListTopCompanies,
 } from "@/lib/actions/search";
-import type { SearchFilters, SearchResponse } from "./types";
-import { ANON_MAX_COMPANIES } from "./constants";
+import { getCompanyPostings as serverGetCompanyPostings } from "@/lib/actions/company";
+import {
+  getWatchlistPostings as serverGetWatchlistPostings,
+  type WatchlistPostingEntry,
+} from "@/lib/actions/watchlists";
+import type {
+  SearchFilters,
+  SearchResponse,
+  SearchResultPosting,
+} from "./types";
+import {
+  ANON_MAX_COMPANIES,
+  ANON_MAX_POSTINGS,
+  ANON_MAX_WATCHLIST_POSTINGS,
+} from "./constants";
 
 type SearchInput = SearchFilters & { keywords: string[]; offset: number; limit: number };
 type ListInput = SearchFilters & { offset: number; limit: number };
+type CompanyPostingsInput = SearchFilters & {
+  companyId: string;
+  keywords: string[];
+  offset: number;
+  limit: number;
+};
+type CompanyPostingsResult = {
+  postings: SearchResultPosting[];
+  activeCount: number;
+  yearCount: number;
+  truncated?: boolean;
+};
 
 const directEnabled = process.env.NEXT_PUBLIC_TYPESENSE_DIRECT === "1";
 
@@ -68,4 +93,70 @@ export async function runListTopCompanies(
     }
   }
   return serverListTopCompanies(params);
+}
+
+type WatchlistPostingsInput = {
+  companyIds: string[];
+  anyCompany?: boolean;
+  offset: number;
+  limit: number;
+  keywords?: string[];
+  locationIds?: number[];
+  occupationIds?: number[];
+  seniorityIds?: number[];
+  technologyIds?: number[];
+  salaryMin?: number;
+  salaryMax?: number;
+  experienceMin?: number;
+  experienceMax?: number;
+  languages?: string[];
+};
+
+export async function runGetWatchlistPostings(
+  params: WatchlistPostingsInput,
+  isLoggedIn: boolean,
+): Promise<{ postings: WatchlistPostingEntry[]; total: number; truncated?: boolean }> {
+  if (directEnabled) {
+    if (!isLoggedIn && params.offset >= ANON_MAX_WATCHLIST_POSTINGS) {
+      return { postings: [], total: 0, truncated: true };
+    }
+    try {
+      const m = await import("./typesense-browser-watchlist");
+      const result = await m.getWatchlistPostingsBrowser(params);
+      const truncated =
+        !isLoggedIn && params.offset + params.limit >= ANON_MAX_WATCHLIST_POSTINGS
+          ? true
+          : undefined;
+      return truncated ? { ...result, truncated } : result;
+    } catch (err) {
+      console.error("[search-runner] browser getWatchlistPostings failed, falling back", err);
+    }
+  }
+  return serverGetWatchlistPostings(params);
+}
+
+export async function runGetCompanyPostings(
+  params: CompanyPostingsInput,
+  isLoggedIn: boolean,
+): Promise<CompanyPostingsResult> {
+  if (directEnabled) {
+    if (!isLoggedIn && params.offset >= ANON_MAX_POSTINGS) {
+      return { postings: [], activeCount: 0, yearCount: 0, truncated: true };
+    }
+    try {
+      const provider = await tryBrowserProvider();
+      const result = await provider.loadPostingsWithCounts(params);
+      // Browser provider's catch returns activeCount: 0; treat as failure
+      // and fall back to the server action.
+      if (result.postings.length > 0 || result.activeCount > 0) {
+        if (!isLoggedIn && params.offset + result.postings.length >= ANON_MAX_POSTINGS) {
+          return { ...result, truncated: true };
+        }
+        return result;
+      }
+    } catch (err) {
+      console.error("[search-runner] browser getCompanyPostings failed, falling back", err);
+    }
+  }
+  return serverGetCompanyPostings(params);
 }

--- a/apps/web/src/lib/search/typeahead-runner.ts
+++ b/apps/web/src/lib/search/typeahead-runner.ts
@@ -1,0 +1,82 @@
+"use client";
+
+import {
+  suggestLocations as serverSuggestLocations,
+  type LocationSuggestion,
+} from "@/lib/actions/locations";
+import {
+  suggestOccupations as serverSuggestOccupations,
+  suggestSeniorities as serverSuggestSeniorities,
+  suggestTechnologies as serverSuggestTechnologies,
+  type TaxonomySuggestion,
+} from "@/lib/actions/taxonomy";
+import type { TypeaheadBoostFilters } from "./typeahead-boost";
+
+const directEnabled = process.env.NEXT_PUBLIC_TYPESENSE_DIRECT === "1";
+
+type LocationParams = {
+  query: string;
+  locale: string;
+  userLat?: number;
+  userLng?: number;
+  filters?: TypeaheadBoostFilters;
+};
+
+type TaxonomyParams = {
+  query: string;
+  locale: string;
+  filters?: TypeaheadBoostFilters;
+};
+
+async function tryBrowser<T>(fn: () => Promise<T>): Promise<T | null> {
+  if (!directEnabled) return null;
+  try {
+    return await fn();
+  } catch {
+    return null;
+  }
+}
+
+export async function runSuggestLocations(
+  params: LocationParams,
+): Promise<LocationSuggestion[]> {
+  const browser = await tryBrowser(async () => {
+    const m = await import("./typesense-browser-typeahead");
+    return m.suggestLocationsBrowser(params);
+  });
+  if (browser !== null) return browser;
+  return serverSuggestLocations(params);
+}
+
+export async function runSuggestOccupations(
+  params: TaxonomyParams,
+): Promise<TaxonomySuggestion[]> {
+  const browser = await tryBrowser(async () => {
+    const m = await import("./typesense-browser-typeahead");
+    return m.suggestOccupationsBrowser(params);
+  });
+  if (browser !== null) return browser;
+  return serverSuggestOccupations(params);
+}
+
+export async function runSuggestSeniorities(
+  params: TaxonomyParams,
+): Promise<TaxonomySuggestion[]> {
+  const browser = await tryBrowser(async () => {
+    const m = await import("./typesense-browser-typeahead");
+    return m.suggestSenioritiesBrowser(params);
+  });
+  if (browser !== null) return browser;
+  return serverSuggestSeniorities(params);
+}
+
+export async function runSuggestTechnologies(
+  params: TaxonomyParams,
+): Promise<TaxonomySuggestion[]> {
+  const browser = await tryBrowser(async () => {
+    const m = await import("./typesense-browser-typeahead");
+    return m.suggestTechnologiesBrowser(params);
+  });
+  if (browser !== null) return browser;
+  return serverSuggestTechnologies(params);
+}

--- a/apps/web/src/lib/search/typesense-browser-key.ts
+++ b/apps/web/src/lib/search/typesense-browser-key.ts
@@ -1,0 +1,38 @@
+export interface TypesenseBrowserConfig {
+  apiKey: string;
+  host: string;
+  port: number;
+  protocol: string;
+  expiresAt: number;
+}
+
+let cached: TypesenseBrowserConfig | null = null;
+let inflight: Promise<TypesenseBrowserConfig> | null = null;
+
+const REFRESH_LEAD_MS = 30_000;
+
+async function fetchKey(): Promise<TypesenseBrowserConfig> {
+  const res = await fetch("/api/typesense-key", { credentials: "same-origin" });
+  if (!res.ok) throw new Error(`typesense-key endpoint returned ${res.status}`);
+  return res.json();
+}
+
+export async function getTypesenseBrowserConfig(): Promise<TypesenseBrowserConfig> {
+  if (cached && cached.expiresAt - Date.now() > REFRESH_LEAD_MS) return cached;
+  if (!inflight) {
+    inflight = fetchKey()
+      .then((cfg) => {
+        cached = cfg;
+        return cfg;
+      })
+      .finally(() => {
+        inflight = null;
+      });
+  }
+  return inflight;
+}
+
+export function clearTypesenseBrowserConfig(): void {
+  cached = null;
+  inflight = null;
+}

--- a/apps/web/src/lib/search/typesense-browser-typeahead.ts
+++ b/apps/web/src/lib/search/typesense-browser-typeahead.ts
@@ -1,0 +1,299 @@
+import { getTypesenseBrowserConfig, type TypesenseBrowserConfig } from "./typesense-browser-key";
+import { buildFilterString } from "./typesense-filters";
+import type { TypeaheadBoostFilters } from "./typeahead-boost";
+
+export interface LocationSuggestion {
+  id: number;
+  slug: string;
+  name: string;
+  type: "macro" | "country" | "region" | "city";
+  parentName: string | null;
+}
+
+export interface TaxonomySuggestion {
+  id: number;
+  slug: string;
+  name: string;
+  matchedName?: string;
+}
+
+interface SearchHit<T> {
+  document: T;
+  highlights?: Array<{ field: string; snippets?: string[] }>;
+}
+
+interface RawSearchResponse<T> {
+  hits?: SearchHit<T>[];
+  facet_counts?: Array<{
+    field_name: string;
+    counts: Array<{ value: string; count: number }>;
+  }>;
+}
+
+async function searchOne<T>(
+  cfg: TypesenseBrowserConfig,
+  collection: string,
+  params: Record<string, unknown>,
+): Promise<RawSearchResponse<T>> {
+  const url = `${cfg.protocol}://${cfg.host}:${cfg.port}/collections/${collection}/documents/search`;
+  const qs = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v === undefined || v === null) continue;
+    qs.set(k, String(v));
+  }
+  const res = await fetch(`${url}?${qs.toString()}`, {
+    method: "GET",
+    headers: { "x-typesense-api-key": cfg.apiKey },
+  });
+  if (!res.ok) throw new Error(`typesense ${collection} ${res.status}`);
+  return res.json();
+}
+
+async function boost<T>(
+  cfg: TypesenseBrowserConfig,
+  candidates: T[],
+  facetField: string,
+  idOf: (c: T) => number | string,
+  filters: TypeaheadBoostFilters,
+): Promise<T[]> {
+  if (candidates.length === 0) return candidates;
+  const filterStr = buildFilterString(filters);
+  const hasKeywords = filters.keywords && filters.keywords.length > 0;
+  if (!filterStr && !hasKeywords) return candidates;
+
+  const ids = candidates.map(idOf);
+  const filterParts = ["is_active:true", `${facetField}:[${ids.join(",")}]`];
+  if (filterStr) filterParts.push(filterStr);
+  const q = hasKeywords ? filters.keywords!.join(" ") : "*";
+
+  try {
+    const r = await searchOne<unknown>(cfg, "job_posting", {
+      q,
+      query_by: "title",
+      filter_by: filterParts.join(" && "),
+      facet_by: facetField,
+      facet_strategy: "exhaustive",
+      max_facet_values: ids.length,
+      per_page: 0,
+    });
+    const facet = r.facet_counts?.find((f) => f.field_name === facetField);
+    if (!facet) return candidates;
+    const matched = new Set<string>();
+    for (const fc of facet.counts) if (fc.count > 0) matched.add(String(fc.value));
+    const withMatches: T[] = [];
+    const withoutMatches: T[] = [];
+    for (const c of candidates) {
+      if (matched.has(String(idOf(c)))) withMatches.push(c);
+      else withoutMatches.push(c);
+    }
+    return [...withMatches, ...withoutMatches];
+  } catch {
+    return candidates;
+  }
+}
+
+interface LocationDoc {
+  location_id: number;
+  slug: string;
+  type: string;
+  parent_name?: string;
+  [key: `name_${string}`]: string | undefined;
+}
+
+export async function suggestLocationsBrowser(params: {
+  query: string;
+  locale: string;
+  userLat?: number;
+  userLng?: number;
+  filters?: TypeaheadBoostFilters;
+}): Promise<LocationSuggestion[]> {
+  const q = params.query.trim();
+  if (q.length < 2) return [];
+
+  const { locale, userLat, userLng } = params;
+  const hasGeo = userLat != null && userLng != null;
+  const sortBy = hasGeo
+    ? `_text_match:desc,coordinates(${userLat},${userLng}, precision: 5km):asc,active_posting_count:desc`
+    : "_text_match:desc,active_posting_count:desc";
+  const queryByFields = locale !== "en" ? `name_${locale},name_en` : "name_en";
+  const queryByWeights = locale !== "en" ? "3,1" : "1";
+
+  try {
+    const cfg = await getTypesenseBrowserConfig();
+    const r = await searchOne<LocationDoc>(cfg, "location", {
+      q,
+      query_by: queryByFields,
+      query_by_weights: queryByWeights,
+      filter_by: "has_active_postings:true",
+      sort_by: sortBy,
+      per_page: 8,
+      prefix: "true",
+      num_typos: "1",
+      drop_tokens_threshold: 0,
+    });
+    if (!r.hits || r.hits.length === 0) return [];
+    const suggestions: LocationSuggestion[] = r.hits.map((hit) => {
+      const d = hit.document;
+      return {
+        id: d.location_id,
+        slug: d.slug,
+        name: (d[`name_${locale}`] ?? d.name_en ?? d.slug) as string,
+        type: d.type as LocationSuggestion["type"],
+        parentName: d.parent_name ?? null,
+      };
+    });
+    if (!params.filters) return suggestions;
+    return boost(cfg, suggestions, "location_ids", (s) => s.id, params.filters);
+  } catch {
+    return [];
+  }
+}
+
+interface OccupationDoc {
+  occupation_id: number;
+  slug: string;
+  name: string;
+}
+
+interface SeniorityDoc {
+  seniority_id: number;
+  slug: string;
+  name: string;
+}
+
+interface TechnologyDoc {
+  technology_id: number;
+  slug: string;
+  name?: string;
+}
+
+function mapAliasMatch(
+  hit: SearchHit<unknown>,
+  displayName: string,
+): string | undefined {
+  const ah = hit.highlights?.find((h) => h.field === "aliases");
+  const matched = ah?.snippets?.[0]?.replace(/<\/?mark>/g, "");
+  return matched && matched !== displayName ? matched : undefined;
+}
+
+export async function suggestOccupationsBrowser(params: {
+  query: string;
+  locale: string;
+  filters?: TypeaheadBoostFilters;
+}): Promise<TaxonomySuggestion[]> {
+  const q = params.query.trim();
+  if (q.length < 2) return [];
+
+  const { locale } = params;
+  try {
+    const cfg = await getTypesenseBrowserConfig();
+    let r = await searchOne<OccupationDoc>(cfg, "occupation", {
+      q,
+      query_by: "name,aliases",
+      filter_by: `has_active_postings:true && locale:${locale}`,
+      sort_by: "_text_match:desc,active_posting_count:desc",
+      per_page: 5,
+      prefix: "true",
+      num_typos: "1",
+    });
+    if ((!r.hits || r.hits.length === 0) && locale !== "en") {
+      r = await searchOne<OccupationDoc>(cfg, "occupation", {
+        q,
+        query_by: "name,aliases",
+        filter_by: "has_active_postings:true && locale:en",
+        sort_by: "_text_match:desc,active_posting_count:desc",
+        per_page: 5,
+        prefix: "true",
+        num_typos: "1",
+      });
+    }
+    if (!r.hits || r.hits.length === 0) return [];
+    const suggestions: TaxonomySuggestion[] = r.hits.map((hit) => ({
+      id: hit.document.occupation_id,
+      slug: hit.document.slug,
+      name: hit.document.name,
+      matchedName: mapAliasMatch(hit, hit.document.name),
+    }));
+    if (!params.filters) return suggestions;
+    return boost(cfg, suggestions, "occupation_id", (s) => s.id, params.filters);
+  } catch {
+    return [];
+  }
+}
+
+export async function suggestSenioritiesBrowser(params: {
+  query: string;
+  locale: string;
+  filters?: TypeaheadBoostFilters;
+}): Promise<TaxonomySuggestion[]> {
+  const q = params.query.trim();
+  if (q.length < 2) return [];
+
+  const { locale } = params;
+  try {
+    const cfg = await getTypesenseBrowserConfig();
+    let r = await searchOne<SeniorityDoc>(cfg, "seniority", {
+      q,
+      query_by: "name,aliases",
+      filter_by: `has_active_postings:true && locale:${locale}`,
+      sort_by: "_text_match:desc,active_posting_count:desc",
+      per_page: 5,
+      prefix: "true",
+      num_typos: "1",
+    });
+    if ((!r.hits || r.hits.length === 0) && locale !== "en") {
+      r = await searchOne<SeniorityDoc>(cfg, "seniority", {
+        q,
+        query_by: "name,aliases",
+        filter_by: "has_active_postings:true && locale:en",
+        sort_by: "_text_match:desc,active_posting_count:desc",
+        per_page: 5,
+        prefix: "true",
+        num_typos: "1",
+      });
+    }
+    if (!r.hits || r.hits.length === 0) return [];
+    const suggestions: TaxonomySuggestion[] = r.hits.map((hit) => ({
+      id: hit.document.seniority_id,
+      slug: hit.document.slug,
+      name: hit.document.name,
+      matchedName: mapAliasMatch(hit, hit.document.name),
+    }));
+    if (!params.filters) return suggestions;
+    return boost(cfg, suggestions, "seniority_id", (s) => s.id, params.filters);
+  } catch {
+    return [];
+  }
+}
+
+export async function suggestTechnologiesBrowser(params: {
+  query: string;
+  locale: string;
+  filters?: TypeaheadBoostFilters;
+}): Promise<TaxonomySuggestion[]> {
+  const q = params.query.trim();
+  if (q.length < 2) return [];
+
+  try {
+    const cfg = await getTypesenseBrowserConfig();
+    const r = await searchOne<TechnologyDoc>(cfg, "technology", {
+      q,
+      query_by: "name,slug",
+      filter_by: "has_active_postings:true",
+      sort_by: "_text_match:desc,active_posting_count:desc",
+      per_page: 5,
+      prefix: "true",
+      num_typos: "0",
+    });
+    if (!r.hits || r.hits.length === 0) return [];
+    const suggestions: TaxonomySuggestion[] = r.hits.map((hit) => ({
+      id: hit.document.technology_id,
+      slug: hit.document.slug,
+      name: hit.document.name ?? hit.document.slug,
+    }));
+    if (!params.filters) return suggestions;
+    return boost(cfg, suggestions, "technology_ids", (s) => s.id, params.filters);
+  } catch {
+    return [];
+  }
+}

--- a/apps/web/src/lib/search/typesense-browser-watchlist.ts
+++ b/apps/web/src/lib/search/typesense-browser-watchlist.ts
@@ -1,0 +1,134 @@
+import { getTypesenseBrowserConfig, type TypesenseBrowserConfig } from "./typesense-browser-key";
+import { buildFilterString } from "./typesense-filters";
+import type { WatchlistPostingEntry } from "@/lib/actions/watchlists";
+
+export const COMPANY_BATCH_SIZE = 100;
+
+interface JobPostingDoc {
+  id: string;
+  title?: string;
+  source_url?: string;
+  first_seen_at?: number;
+  is_active?: boolean;
+  company_id?: string;
+  company_name?: string;
+  company_slug?: string;
+  company_icon?: string;
+}
+
+interface SearchHit<T> {
+  document: T;
+}
+
+interface RawSearchResponse<T> {
+  found?: number;
+  hits?: SearchHit<T>[];
+}
+
+async function searchOne<T>(
+  cfg: TypesenseBrowserConfig,
+  collection: string,
+  params: Record<string, unknown>,
+): Promise<RawSearchResponse<T>> {
+  const url = `${cfg.protocol}://${cfg.host}:${cfg.port}/collections/${collection}/documents/search`;
+  const qs = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v === undefined || v === null) continue;
+    qs.set(k, String(v));
+  }
+  const res = await fetch(`${url}?${qs.toString()}`, {
+    method: "GET",
+    headers: { "x-typesense-api-key": cfg.apiKey },
+  });
+  if (!res.ok) throw new Error(`typesense ${collection} ${res.status}`);
+  return res.json();
+}
+
+function mapHit(doc: JobPostingDoc): WatchlistPostingEntry {
+  return {
+    id: doc.id,
+    title: doc.title ?? null,
+    sourceUrl: doc.source_url ?? "",
+    firstSeenAt: new Date((doc.first_seen_at ?? 0) * 1000).toISOString(),
+    isActive: doc.is_active ?? true,
+    company: {
+      id: doc.company_id ?? "",
+      name: doc.company_name ?? "",
+      slug: doc.company_slug ?? "",
+      icon: doc.company_icon ?? null,
+    },
+  };
+}
+
+export interface WatchlistPostingsParams {
+  companyIds: string[];
+  anyCompany?: boolean;
+  offset: number;
+  limit: number;
+  keywords?: string[];
+  locationIds?: number[];
+  occupationIds?: number[];
+  seniorityIds?: number[];
+  technologyIds?: number[];
+  salaryMin?: number;
+  salaryMax?: number;
+  experienceMin?: number;
+  experienceMax?: number;
+  languages?: string[];
+}
+
+/**
+ * Browser-side watchlist postings fetch. Mirrors the server-side
+ * `_getWatchlistPostingsTypesense` for ≤COMPANY_BATCH_SIZE companies.
+ *
+ * For watchlists tracking >COMPANY_BATCH_SIZE companies, throws so the
+ * runner falls back to the server action (which has a batched/merge
+ * implementation we don't need to duplicate browser-side).
+ */
+export async function getWatchlistPostingsBrowser(
+  params: WatchlistPostingsParams,
+): Promise<{ postings: WatchlistPostingEntry[]; total: number }> {
+  if (!params.anyCompany && params.companyIds.length === 0) {
+    return { postings: [], total: 0 };
+  }
+  if (params.companyIds.length > COMPANY_BATCH_SIZE) {
+    throw new Error("watchlist exceeds COMPANY_BATCH_SIZE — falling back");
+  }
+
+  const cfg = await getTypesenseBrowserConfig();
+  const filterStr = buildFilterString({
+    locationIds: params.locationIds,
+    occupationIds: params.occupationIds,
+    seniorityIds: params.seniorityIds,
+    technologyIds: params.technologyIds,
+    salaryMinEur: params.salaryMin,
+    salaryMaxEur: params.salaryMax,
+    experienceMin: params.experienceMin,
+    experienceMax: params.experienceMax,
+    languages: params.languages,
+  });
+  const hasKeywords = params.keywords && params.keywords.length > 0;
+  const q = hasKeywords ? params.keywords!.join(" ") : "*";
+
+  const filterParts = ["is_active:true"];
+  if (params.companyIds.length > 0) {
+    filterParts.push(`company_id:[${params.companyIds.join(",")}]`);
+  }
+  if (filterStr) filterParts.push(filterStr);
+
+  const result = await searchOne<JobPostingDoc>(cfg, "job_posting", {
+    q,
+    query_by: "title",
+    filter_by: filterParts.join(" && "),
+    sort_by: hasKeywords ? "_text_match:desc,first_seen_at:desc" : "first_seen_at:desc",
+    per_page: params.limit === 0 ? 0 : params.limit,
+    page: params.limit === 0 ? 1 : Math.floor(params.offset / params.limit) + 1,
+  });
+
+  const total = result.found ?? 0;
+  if (total === 0 || params.limit === 0) return { postings: [], total };
+  return {
+    postings: (result.hits ?? []).map((h) => mapHit(h.document)),
+    total,
+  };
+}

--- a/apps/web/src/lib/search/typesense-browser.ts
+++ b/apps/web/src/lib/search/typesense-browser.ts
@@ -374,15 +374,62 @@ export class TypesenseBrowserProvider implements SearchProvider {
     }
   }
 
-  async loadPostingsWithCounts(): Promise<{
+  async loadPostingsWithCounts(
+    params: SearchFilters & {
+      companyId: string;
+      keywords: string[];
+      offset: number;
+      limit: number;
+    },
+  ): Promise<{
     postings: SearchResultPosting[];
     activeCount: number;
     yearCount: number;
   }> {
-    // Not used by the explore client search loop — server actions handle the
-    // company-page surface. Stub returns empty so the SearchProvider interface
-    // is satisfied for any code path that holds a browser provider reference.
-    return { postings: [], activeCount: 0, yearCount: 0 };
+    try {
+      const cfg = await this.cfg();
+      const { companyId, keywords, offset, limit, locationIds } = params;
+      const filterStr = buildFilterString(params);
+      const baseFilter = `company_id:=${companyId}${filterStr ? ` && ${filterStr}` : ""}`;
+      const q = keywords.length ? keywords.join(" ") : "*";
+
+      const [postingsResult, activeResult, yearResult] = await Promise.all([
+        searchOne<JobPostingDoc>(cfg, "job_posting", {
+          q,
+          query_by: "title",
+          filter_by: `is_active:true && ${baseFilter}`,
+          sort_by: keywords.length
+            ? "_text_match:desc,first_seen_at:desc"
+            : "first_seen_at:desc",
+          per_page: limit,
+          page: Math.floor(offset / limit) + 1,
+        }),
+        searchOne<JobPostingDoc>(cfg, "job_posting", {
+          q,
+          query_by: "title",
+          filter_by: `is_active:true && ${baseFilter}`,
+          per_page: 0,
+        }),
+        searchOne<JobPostingDoc>(cfg, "job_posting", {
+          q,
+          query_by: "title",
+          filter_by: `first_seen_at:>${oneYearAgoUnix()} && ${baseFilter}`,
+          per_page: 0,
+        }),
+      ]);
+
+      const postings = (postingsResult.hits ?? []).map((h) =>
+        mapHitToPosting(h, locationIds),
+      );
+      return {
+        postings,
+        activeCount: activeResult.found ?? 0,
+        yearCount: yearResult.found ?? 0,
+      };
+    } catch (err) {
+      console.error("[typesense-browser] loadPostingsWithCounts error", err);
+      return { postings: [], activeCount: 0, yearCount: 0 };
+    }
   }
 
   async getSalaryHistogram(filters?: HistogramFilters): Promise<SalaryBucket[]> {

--- a/apps/web/src/lib/search/typesense-browser.ts
+++ b/apps/web/src/lib/search/typesense-browser.ts
@@ -1,0 +1,464 @@
+import { buildFilterString } from "./typesense-filters";
+import {
+  getTypesenseBrowserConfig,
+  type TypesenseBrowserConfig,
+} from "./typesense-browser-key";
+import type {
+  PostingLocation,
+  SearchFilters,
+  SearchProvider,
+  SearchResponse,
+  SearchResultCompany,
+  SearchResultPosting,
+  HistogramFilters,
+  SalaryBucket,
+  ExperienceBucket,
+} from "./types";
+
+interface JobPostingDoc {
+  id: string;
+  company_id: string;
+  company_name: string;
+  company_slug: string;
+  company_icon?: string;
+  title: string;
+  is_active: boolean;
+  location_ids: number[];
+  location_names: string[];
+  location_types: string[];
+  location_geo_types: string[];
+  technology_ids: number[];
+  employment_type?: string;
+  salary_eur?: number;
+  experience_min: number;
+  locales: string[];
+  first_seen_at: number;
+}
+
+interface CompanyDoc {
+  id: string;
+  name: string;
+  slug: string;
+  icon?: string;
+  active_posting_count: number;
+  year_posting_count: number;
+}
+
+type SearchHit<T> = { document: T; text_match?: number };
+type GroupedHit<T> = { group_key: string[]; hits: SearchHit<T>[]; found?: number };
+type FacetCount = {
+  field_name: string;
+  counts: { value: string; count: number }[];
+  stats?: { total_values?: number };
+};
+
+interface RawSearchResponse<T> {
+  found: number;
+  hits?: SearchHit<T>[];
+  grouped_hits?: GroupedHit<T>[];
+  facet_counts?: FacetCount[];
+  search_time_ms?: number;
+}
+
+function oneYearAgoUnix(): number {
+  const d = new Date();
+  d.setFullYear(d.getFullYear() - 1);
+  return Math.floor(d.getTime() / 1000);
+}
+
+const SALARY_FACET_RANGES = [
+  ...Array.from({ length: 30 }, (_, i) => {
+    const min = i * 10000;
+    const max = (i + 1) * 10000;
+    return `${min / 1000}-${max / 1000}k:[${min},${max}]`;
+  }),
+  "300k+:[300000,999999999]",
+].join(", ");
+
+const SALARY_FACET_BY = `salary_eur(${SALARY_FACET_RANGES})`;
+
+async function searchOne<T>(
+  cfg: TypesenseBrowserConfig,
+  collection: string,
+  params: Record<string, unknown>,
+): Promise<RawSearchResponse<T>> {
+  const url = `${cfg.protocol}://${cfg.host}:${cfg.port}/collections/${collection}/documents/search`;
+  const qs = new URLSearchParams();
+  for (const [k, v] of Object.entries(params)) {
+    if (v === undefined || v === null) continue;
+    qs.set(k, String(v));
+  }
+  const res = await fetch(`${url}?${qs.toString()}`, {
+    method: "GET",
+    headers: { "x-typesense-api-key": cfg.apiKey },
+  });
+  if (!res.ok) {
+    throw new Error(`typesense ${collection} search ${res.status}`);
+  }
+  return res.json();
+}
+
+function buildLocations(
+  doc: JobPostingDoc,
+  filteredLocationIds?: number[],
+): PostingLocation[] {
+  const locations = (doc.location_names ?? []).map((name, i) => ({
+    name,
+    type: doc.location_types?.[i] ?? "onsite",
+    geoType: (doc.location_geo_types?.[i] ?? undefined) as
+      | "city"
+      | "region"
+      | "country"
+      | "macro"
+      | undefined,
+    _locationId: doc.location_ids?.[i],
+  }));
+  if (filteredLocationIds?.length) {
+    const set = new Set(filteredLocationIds);
+    locations.sort((a, b) => (set.has(a._locationId) ? 0 : 1) - (set.has(b._locationId) ? 0 : 1));
+  }
+  return locations.map(({ _locationId: _, ...rest }) => rest);
+}
+
+function mapHitToPosting(
+  hit: SearchHit<JobPostingDoc>,
+  filteredLocationIds?: number[],
+): SearchResultPosting {
+  return {
+    id: hit.document.id,
+    title: hit.document.title || null,
+    firstSeenAt: new Date(hit.document.first_seen_at * 1000),
+    relevanceScore: hit.text_match ?? 0,
+    locations: buildLocations(hit.document, filteredLocationIds),
+    isActive: hit.document.is_active,
+  };
+}
+
+function emptyResponse(): SearchResponse {
+  return { companies: [], totalCompanies: 0, degraded: true };
+}
+
+async function fetchYearCounts(
+  cfg: TypesenseBrowserConfig,
+  companyIds: string[],
+  filterStr: string,
+  q: string,
+): Promise<Map<string, number>> {
+  if (companyIds.length === 0) return new Map();
+  const yearFilter =
+    `first_seen_at:>${oneYearAgoUnix()} && company_id:[${companyIds.join(",")}]` +
+    (filterStr ? ` && ${filterStr}` : "");
+  const r = await searchOne<JobPostingDoc>(cfg, "job_posting", {
+    q,
+    query_by: "title",
+    filter_by: yearFilter,
+    facet_by: "company_id",
+    facet_strategy: "exhaustive",
+    max_facet_values: companyIds.length,
+    per_page: 0,
+  });
+  const counts = r.facet_counts?.[0]?.counts ?? [];
+  return new Map(counts.map((c) => [c.value, c.count]));
+}
+
+export class TypesenseBrowserProvider implements SearchProvider {
+  private async cfg(): Promise<TypesenseBrowserConfig> {
+    return getTypesenseBrowserConfig();
+  }
+
+  async search(
+    params: SearchFilters & { keywords: string[]; offset: number; limit: number },
+  ): Promise<SearchResponse> {
+    try {
+      const cfg = await this.cfg();
+      const { keywords, offset, limit, locationIds } = params;
+      const filterStr = buildFilterString(params);
+      const activeFilter = `is_active:true${filterStr ? ` && ${filterStr}` : ""}`;
+
+      const result = await searchOne<JobPostingDoc>(cfg, "job_posting", {
+        q: keywords.join(" "),
+        query_by: "title",
+        filter_by: activeFilter,
+        sort_by: "_text_match:desc,first_seen_at:desc",
+        group_by: "company_id",
+        group_limit: 10,
+        per_page: limit,
+        page: Math.floor(offset / limit) + 1,
+        typo_tokens_threshold: 1,
+        drop_tokens_threshold: 1,
+        facet_by: "company_id",
+        facet_strategy: "exhaustive",
+        max_facet_values: 1,
+      });
+
+      const totalCompanies = result.facet_counts?.[0]?.stats?.total_values ?? 0;
+      const groupedHits = (result.grouped_hits ?? []) as GroupedHit<JobPostingDoc>[];
+      const companyIds = groupedHits.map((g) => g.hits[0].document.company_id);
+      const yearMap = await fetchYearCounts(cfg, companyIds, filterStr, keywords.join(" "));
+
+      const companies: SearchResultCompany[] = groupedHits.map((g) => {
+        const first = g.hits[0].document;
+        const cid = first.company_id;
+        return {
+          company: { id: cid, name: first.company_name, slug: first.company_slug, icon: first.company_icon ?? null },
+          activeMatches: g.found ?? 0,
+          yearMatches: yearMap.get(cid) ?? 0,
+          postings: g.hits.map((h) => mapHitToPosting(h, locationIds)),
+        };
+      });
+
+      return { companies, totalCompanies };
+    } catch (err) {
+      console.error("[typesense-browser] search error", err);
+      return emptyResponse();
+    }
+  }
+
+  async listTopCompanies(
+    params: SearchFilters & { offset: number; limit: number },
+  ): Promise<SearchResponse> {
+    try {
+      const cfg = await this.cfg();
+      const { offset, limit, locationIds } = params;
+      const filterStr = buildFilterString(params);
+      if (filterStr.length === 0) {
+        return await this.unfiltered(cfg, offset, limit);
+      }
+      return await this.filtered(cfg, filterStr, offset, limit, locationIds);
+    } catch (err) {
+      console.error("[typesense-browser] listTopCompanies error", err);
+      return emptyResponse();
+    }
+  }
+
+  private async filtered(
+    cfg: TypesenseBrowserConfig,
+    filterStr: string,
+    offset: number,
+    limit: number,
+    locationIds?: number[],
+  ): Promise<SearchResponse> {
+    const activeFilter = `is_active:true && ${filterStr}`;
+    const facetResult = await searchOne<JobPostingDoc>(cfg, "job_posting", {
+      q: "*",
+      filter_by: activeFilter,
+      facet_by: "company_id",
+      facet_strategy: "exhaustive",
+      max_facet_values: offset + limit,
+      per_page: 0,
+    });
+
+    const facets = facetResult.facet_counts?.[0];
+    const totalCompanies = facets?.stats?.total_values ?? 0;
+    const all = facets?.counts ?? [];
+    const page = all.slice(offset, offset + limit);
+    if (page.length === 0) return { companies: [], totalCompanies };
+
+    const companyIds = page.map((c) => c.value);
+    const activeMap = new Map(page.map((c) => [c.value, c.count] as [string, number]));
+
+    const [yearMap, postingResults] = await Promise.all([
+      fetchYearCounts(cfg, companyIds, filterStr, "*"),
+      searchOne<JobPostingDoc>(cfg, "job_posting", {
+        q: "*",
+        filter_by: `company_id:[${companyIds.join(",")}] && ${activeFilter}`,
+        group_by: "company_id",
+        group_limit: 10,
+        sort_by: "first_seen_at:desc",
+        per_page: companyIds.length,
+      }),
+    ]);
+
+    const groupMap = new Map<string, GroupedHit<JobPostingDoc>>(
+      (postingResults.grouped_hits ?? []).map(
+        (g) => [g.hits[0].document.company_id, g] as [string, GroupedHit<JobPostingDoc>],
+      ),
+    );
+
+    const companies: SearchResultCompany[] = companyIds
+      .map((cid) => {
+        const g = groupMap.get(cid);
+        if (!g) return null;
+        const first = g.hits[0].document;
+        return {
+          company: { id: cid, name: first.company_name, slug: first.company_slug, icon: first.company_icon ?? null },
+          activeMatches: activeMap.get(cid) ?? 0,
+          yearMatches: yearMap.get(cid) ?? 0,
+          postings: g.hits.map((h) => mapHitToPosting(h, locationIds)),
+        } satisfies SearchResultCompany;
+      })
+      .filter((c): c is SearchResultCompany => c !== null);
+
+    return { companies, totalCompanies };
+  }
+
+  private async unfiltered(
+    cfg: TypesenseBrowserConfig,
+    offset: number,
+    limit: number,
+  ): Promise<SearchResponse> {
+    const companyResults = await searchOne<CompanyDoc>(cfg, "company", {
+      q: "*",
+      filter_by: "active_posting_count:>0",
+      sort_by: "active_posting_count:desc",
+      per_page: limit,
+      page: Math.floor(offset / limit) + 1,
+    });
+    const totalCompanies = companyResults.found;
+    const hits = companyResults.hits ?? [];
+    if (hits.length === 0) return { companies: [], totalCompanies };
+
+    const companyIds = hits.map((h) => h.document.id);
+    const compMap = new Map<string, CompanyDoc>(hits.map((h) => [h.document.id, h.document]));
+    const postingResults = await searchOne<JobPostingDoc>(cfg, "job_posting", {
+      q: "*",
+      filter_by: `company_id:[${companyIds.join(",")}] && is_active:true`,
+      group_by: "company_id",
+      group_limit: 10,
+      sort_by: "first_seen_at:desc",
+      per_page: companyIds.length,
+    });
+
+    const groupMap = new Map<string, GroupedHit<JobPostingDoc>>(
+      (postingResults.grouped_hits ?? []).map(
+        (g) => [g.hits[0].document.company_id, g] as [string, GroupedHit<JobPostingDoc>],
+      ),
+    );
+
+    const companies: SearchResultCompany[] = companyIds
+      .map((cid) => {
+        const compDoc = compMap.get(cid);
+        const g = groupMap.get(cid);
+        if (!compDoc) return null;
+        return {
+          company: { id: cid, name: compDoc.name, slug: compDoc.slug, icon: compDoc.icon ?? null },
+          activeMatches: compDoc.active_posting_count,
+          yearMatches: compDoc.year_posting_count,
+          postings: g ? g.hits.map((h) => mapHitToPosting(h)) : [],
+        } satisfies SearchResultCompany;
+      })
+      .filter((c): c is SearchResultCompany => c !== null);
+
+    return { companies, totalCompanies };
+  }
+
+  async loadPostings(
+    params: SearchFilters & {
+      companyId: string;
+      keywords: string[];
+      offset: number;
+      limit: number;
+    },
+  ): Promise<SearchResultPosting[]> {
+    try {
+      const cfg = await this.cfg();
+      const { companyId, keywords, offset, limit, locationIds } = params;
+      const filterStr = buildFilterString(params);
+      const activeFilter =
+        `company_id:=${companyId} && is_active:true` + (filterStr ? ` && ${filterStr}` : "");
+      const q = keywords.length ? keywords.join(" ") : "*";
+      const r = await searchOne<JobPostingDoc>(cfg, "job_posting", {
+        q,
+        query_by: "title",
+        filter_by: activeFilter,
+        sort_by: keywords.length
+          ? "_text_match:desc,first_seen_at:desc"
+          : "first_seen_at:desc",
+        per_page: limit,
+        page: Math.floor(offset / limit) + 1,
+      });
+      return (r.hits ?? []).map((h) => mapHitToPosting(h, locationIds));
+    } catch (err) {
+      console.error("[typesense-browser] loadPostings error", err);
+      return [];
+    }
+  }
+
+  async loadPostingsWithCounts(): Promise<{
+    postings: SearchResultPosting[];
+    activeCount: number;
+    yearCount: number;
+  }> {
+    // Not used by the explore client search loop — server actions handle the
+    // company-page surface. Stub returns empty so the SearchProvider interface
+    // is satisfied for any code path that holds a browser provider reference.
+    return { postings: [], activeCount: 0, yearCount: 0 };
+  }
+
+  async getSalaryHistogram(filters?: HistogramFilters): Promise<SalaryBucket[]> {
+    try {
+      const cfg = await this.cfg();
+      const f = filters ?? {};
+      const filterStr = buildFilterString(f);
+      const hasKeywords = f.keywords && f.keywords.length > 0;
+      const q = hasKeywords ? f.keywords!.join(" ") : "*";
+      const r = await searchOne<JobPostingDoc>(cfg, "job_posting", {
+        q,
+        query_by: "title",
+        filter_by: `is_active:true && salary_eur:>0${filterStr ? ` && ${filterStr}` : ""}`,
+        facet_by: SALARY_FACET_BY,
+        max_facet_values: 31,
+        per_page: 0,
+      });
+      const facet = r.facet_counts?.[0];
+      if (!facet) return [];
+      const buckets: SalaryBucket[] = [];
+      for (const e of facet.counts) {
+        const range = parseFacetRange(e.value);
+        if (range) buckets.push({ min: range[0], max: range[1], count: e.count });
+      }
+      buckets.sort((a, b) => a.min - b.min);
+      return buckets;
+    } catch (err) {
+      console.error("[typesense-browser] salary histogram error", err);
+      return [];
+    }
+  }
+
+  async getExperienceHistogram(filters?: HistogramFilters): Promise<ExperienceBucket[]> {
+    try {
+      const cfg = await this.cfg();
+      const f = filters ?? {};
+      const filterStr = buildFilterString(f);
+      const hasKeywords = f.keywords && f.keywords.length > 0;
+      const q = hasKeywords ? f.keywords!.join(" ") : "*";
+      const r = await searchOne<JobPostingDoc>(cfg, "job_posting", {
+        q,
+        query_by: "title",
+        filter_by: `is_active:true && experience_min:>=0${filterStr ? ` && ${filterStr}` : ""}`,
+        facet_by: "experience_min",
+        max_facet_values: 30,
+        per_page: 0,
+      });
+      const facet = r.facet_counts?.[0];
+      if (!facet) return [];
+      const buckets: ExperienceBucket[] = [];
+      for (const e of facet.counts) {
+        const years = parseInt(e.value, 10);
+        if (!isNaN(years)) buckets.push({ years, count: e.count });
+      }
+      buckets.sort((a, b) => a.years - b.years);
+      return buckets;
+    } catch (err) {
+      console.error("[typesense-browser] experience histogram error", err);
+      return [];
+    }
+  }
+}
+
+function parseFacetRange(label: string): [number, number] | null {
+  if (label.endsWith("+")) {
+    const num = parseFloat(label.replace("k+", "")) * 1000;
+    if (isNaN(num)) return null;
+    return [num, 999999999];
+  }
+  const m = label.match(/^(\d+)-(\d+)k$/);
+  if (m) return [parseInt(m[1], 10) * 1000, parseInt(m[2], 10) * 1000];
+  return null;
+}
+
+let _provider: TypesenseBrowserProvider | undefined;
+export function getBrowserSearchProvider(): TypesenseBrowserProvider {
+  if (!_provider) _provider = new TypesenseBrowserProvider();
+  return _provider;
+}

--- a/apps/web/src/lib/search/use-clear-typesense-on-auth-change.ts
+++ b/apps/web/src/lib/search/use-clear-typesense-on-auth-change.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect } from "react";
+import { clearTypesenseBrowserConfig } from "./typesense-browser-key";
+
+/**
+ * Clears the cached browser-side Typesense scoped key whenever the auth
+ * state flips, so a sign-in/sign-out doesn't keep the wrong key (anon
+ * truncation cap vs. authed unrestricted).
+ *
+ * Safe to call from any client page; no-ops unless NEXT_PUBLIC_TYPESENSE_DIRECT=1.
+ */
+export function useClearTypesenseOnAuthChange(isLoggedIn: boolean): void {
+  useEffect(() => {
+    if (process.env.NEXT_PUBLIC_TYPESENSE_DIRECT !== "1") return;
+    clearTypesenseBrowserConfig();
+  }, [isLoggedIn]);
+}

--- a/docs/11-typesense.md
+++ b/docs/11-typesense.md
@@ -180,24 +180,39 @@ Daily reconciliation (run by the exporter loop):
 - All search, typeahead, browse-all modals, and watchlist search go through Typesense
 - **Company detail page**: `getCompanyBySlug` reads the `company` collection by slug filter. Postgres is a fallback when Typesense errors or returns 0 hits (so brand-new companies whose Typesense upsert lagged still render)
 - **Graceful degradation**: all Typesense errors return empty results; Postgres fallback for watchlist write functions
-<<<<<<< Updated upstream
 - **Caching**: no Redis cache on main search (Typesense is fast enough). Cached for unfiltered homepage (60s) and popular watchlists (120s). `getCompanyBySlug` is wrapped with a Redis cache (`ttl: 600`, key `company-slug:{slug}:{locale}`) that skips storing nulls so brand-new slugs aren't poisoned
-- **Client**: `typesense-js` in the web app, connecting to `typesense.colophon-group.org` (Cloudflare tunnel) with the search-only key
-=======
-- **Caching**: no Redis cache on main search (Typesense is fast enough). Cached for unfiltered homepage (60s) and popular watchlists (120s)
 - **Server-side client**: `typesense-js` in the web app, connecting to `typesense.colophon-group.org` (Cloudflare tunnel) with the search-only key
 
 ### Direct browser → Typesense (feature-flagged)
 
-For the high-traffic `/explore` client search loop, the web app can bypass the Vercel server-action proxy and call Typesense directly from the browser. Gated by `NEXT_PUBLIC_TYPESENSE_DIRECT=1`.
+The web app can bypass the Vercel server-action proxy and call Typesense directly from the browser for read-heavy surfaces. Gated by `NEXT_PUBLIC_TYPESENSE_DIRECT=1`. Each surface has a server-action fallback for when the browser path errors.
 
-- **Scoped key endpoint**: `GET /api/typesense-key` (route handler `apps/web/app/api/typesense-key/route.ts`). Mints a Typesense scoped search key signed with the parent `TYPESENSE_SEARCH_KEY` (HMAC-SHA256 + base64). Embeds only `use_cache: true` -- the parent search-only scope already restricts to `documents:search`, and `limit_hits` is intentionally **not** embedded because it counts raw hits, not grouped rows, and would block normal anon traffic that uses `group_by company_id` with `group_limit 10`.
-- **TTL**: 5 min for anon, 10 min for authed. The browser caches the key in memory and refreshes 30 s before expiry. The cache is cleared when `useSession().isLoggedIn` flips so a sign-in/out doesn't keep the wrong key.
-- **Browser provider**: `apps/web/src/lib/search/typesense-browser.ts` -- a thin client (no `typesense-js` dependency in the browser bundle) that mirrors the server-side `TypesenseSearchProvider` query shapes.
-- **Anon truncation**: enforced as a soft client-side cap (`ANON_MAX_COMPANIES`) matching the current server-action behaviour. Real abuse protection is the Cloudflare per-IP rate-limit on the tunnel hostname.
-- **Fallback**: if the scoped-key endpoint is down or the browser provider returns a `degraded` result, the runner falls back to the original server-action path (`apps/web/src/lib/search/search-runner.ts`).
-- **Out of scope for direct path**: `getPostingDetail` (R2 URL minting requires server trust), `getCurrencyRates` (DB read, not Typesense), histograms (`getSalaryHistogram`/`getExperienceHistogram`, kept on server actions for the 3600 s cache).
->>>>>>> Stashed changes
+**Surfaces wired direct-browser:**
+
+| Surface | Runner export | Mirrors server action |
+|---------|---------------|----------------------|
+| `/explore` search loop (filter chip changes, load-more) | `runSearchJobs`, `runListTopCompanies` | `searchJobs`, `listTopCompanies` |
+| Header / modal typeahead (per keystroke) | `runSuggestLocations`, `runSuggestOccupations`, `runSuggestSeniorities`, `runSuggestTechnologies` | `suggestLocations`, `suggestOccupations`, `suggestSeniorities`, `suggestTechnologies` |
+| Company detail postings list | `runGetCompanyPostings` | `getCompanyPostings` (calls `loadPostingsWithCounts`) |
+| Public watchlist postings (≤100 companies) | `runGetWatchlistPostings` | `getWatchlistPostings` (≤100 path; >100 falls back) |
+
+**Out of scope for direct path:**
+
+- `getPostingDetail` (Postgres + R2 URL signing — needs server trust)
+- `getCurrencyRates` (DB read, not Typesense)
+- Salary/experience histograms (`getSalaryHistogram`/`getExperienceHistogram`, kept on server actions for the 3600 s cache)
+- `getCompanyBySlug` (server-rendered company page, has Postgres fallback for cold reads)
+- `getSimilarCompanies` (filtered path requires Postgres slug→id resolution)
+- Browse-all modals (`getGlobalLocationsGrouped`, `getAllOccupationsGrouped`, etc. — need Postgres taxonomy hierarchy)
+- Watchlist postings for >100 companies (uses batched-merge logic that's only worth maintaining server-side)
+
+**Infrastructure:**
+
+- **Scoped key endpoint** (`GET /api/typesense-key`): mints a Typesense scoped search key (HMAC-SHA256 + base64) from `TYPESENSE_BROWSER_PARENT_KEY`. Embed is just `{ use_cache: true }`. `limit_hits` is intentionally **not** embedded because Typesense counts raw hits (not grouped rows) and would block normal anon traffic on `group_by company_id` with `group_limit 10`.
+- **TTL**: 5 min for anon, 10 min for authed. Browser caches the key in memory and refreshes 30 s before expiry. The cache is cleared via `useClearTypesenseOnAuthChange(isLoggedIn)` (called from each client surface) so a sign-in/out doesn't keep the wrong key.
+- **Browser provider**: `apps/web/src/lib/search/typesense-browser.ts` (postings/companies), `typesense-browser-typeahead.ts` (taxonomy suggest), `typesense-browser-watchlist.ts`. All thin -- no `typesense-js` runtime dependency in the browser bundle.
+- **Anon truncation**: enforced as a soft client-side cap (`ANON_MAX_COMPANIES`, `ANON_MAX_POSTINGS`, `ANON_MAX_WATCHLIST_POSTINGS`) matching the current server-action behaviour. Real abuse protection is the Cloudflare per-IP rate-limit on the tunnel hostname.
+- **Fallback**: every runner falls back to the corresponding server action when the browser path errors, returns degraded, or hits a code-explicit fallback case (e.g. watchlist >100 companies).
 
 ## Read paths summary
 

--- a/docs/11-typesense.md
+++ b/docs/11-typesense.md
@@ -32,17 +32,22 @@ The Vercel-hosted web app has no stable IPs, so it cannot be firewalled into the
 - **Routes to**: `localhost:8108` on the Typesense machine
 - **Daemon**: `cloudflared` running as a systemd service, auto-starts on reboot
 - **Cache bypass rule**: configured in Cloudflare dashboard -- without it, Cloudflare may cache GET search responses and return stale results (Typesense does not set `Cache-Control` headers by default)
+- **Rate-limit rule** (zone `colophon-group.org`, phase `http_ratelimit`): per-IP, 200 requests / 10 s on `(http.host eq "typesense.colophon-group.org")`, action `block` for 10 s. Required because the search key is exposed to browsers (see "Web App Integration") and the origin is a single 4 GB / 2 vCPU box.
+- **CORS**: Typesense container emits `Access-Control-Allow-Origin: *` directly -- no Cloudflare Transform Rule needed. Verified via `curl -X OPTIONS -H 'Origin: https://jseek.co' https://typesense.colophon-group.org/health`.
 - **Latency overhead**: ~10-30 ms per request (acceptable -- Typesense queries take <10 ms)
 
 ## API Keys
 
-Three scoped keys. Stored in: `apps/crawler/.env.local` (main branch), GitHub secrets (CI), Vercel env vars (web app).
+Four scoped keys. Stored in: `apps/crawler/.env.local` (main branch), GitHub secrets (CI), Vercel env vars (web app).
 
 | Environment Variable | Scope | Used By | Connection Path |
 |---------------------|-------|---------|-----------------|
 | `TYPESENSE_ADMIN_KEY` | Full access | Exporter, sync, backfill, setup scripts | Private network (crawler -> Typesense) |
-| `TYPESENSE_SEARCH_KEY` | `documents:search` on all collections | Web app search | Cloudflare tunnel |
+| `TYPESENSE_SEARCH_KEY` | `documents:search` + `documents:get` on all collections | Web app server-side search (server actions) | Cloudflare tunnel |
+| `TYPESENSE_BROWSER_PARENT_KEY` | `documents:search` on all collections (no other action) | Web app `/api/typesense-key` route handler -- mints scoped keys for direct browser->Typesense calls | Cloudflare tunnel (browser, scoped key) |
 | `TYPESENSE_WRITE_KEY` | `documents:create/upsert/delete/update` on `watchlist` collection only | Web app watchlist mutations | Cloudflare tunnel |
+
+`TYPESENSE_BROWSER_PARENT_KEY` is a separate parent because Typesense rejects scoped keys derived from a parent that has any actions other than `documents:search` (the server returns `Forbidden - a valid x-typesense-api-key header must be sent.` when used with a multi-action parent).
 
 ## Collections
 
@@ -175,8 +180,24 @@ Daily reconciliation (run by the exporter loop):
 - All search, typeahead, browse-all modals, and watchlist search go through Typesense
 - **Company detail page**: `getCompanyBySlug` reads the `company` collection by slug filter. Postgres is a fallback when Typesense errors or returns 0 hits (so brand-new companies whose Typesense upsert lagged still render)
 - **Graceful degradation**: all Typesense errors return empty results; Postgres fallback for watchlist write functions
+<<<<<<< Updated upstream
 - **Caching**: no Redis cache on main search (Typesense is fast enough). Cached for unfiltered homepage (60s) and popular watchlists (120s). `getCompanyBySlug` is wrapped with a Redis cache (`ttl: 600`, key `company-slug:{slug}:{locale}`) that skips storing nulls so brand-new slugs aren't poisoned
 - **Client**: `typesense-js` in the web app, connecting to `typesense.colophon-group.org` (Cloudflare tunnel) with the search-only key
+=======
+- **Caching**: no Redis cache on main search (Typesense is fast enough). Cached for unfiltered homepage (60s) and popular watchlists (120s)
+- **Server-side client**: `typesense-js` in the web app, connecting to `typesense.colophon-group.org` (Cloudflare tunnel) with the search-only key
+
+### Direct browser → Typesense (feature-flagged)
+
+For the high-traffic `/explore` client search loop, the web app can bypass the Vercel server-action proxy and call Typesense directly from the browser. Gated by `NEXT_PUBLIC_TYPESENSE_DIRECT=1`.
+
+- **Scoped key endpoint**: `GET /api/typesense-key` (route handler `apps/web/app/api/typesense-key/route.ts`). Mints a Typesense scoped search key signed with the parent `TYPESENSE_SEARCH_KEY` (HMAC-SHA256 + base64). Embeds only `use_cache: true` -- the parent search-only scope already restricts to `documents:search`, and `limit_hits` is intentionally **not** embedded because it counts raw hits, not grouped rows, and would block normal anon traffic that uses `group_by company_id` with `group_limit 10`.
+- **TTL**: 5 min for anon, 10 min for authed. The browser caches the key in memory and refreshes 30 s before expiry. The cache is cleared when `useSession().isLoggedIn` flips so a sign-in/out doesn't keep the wrong key.
+- **Browser provider**: `apps/web/src/lib/search/typesense-browser.ts` -- a thin client (no `typesense-js` dependency in the browser bundle) that mirrors the server-side `TypesenseSearchProvider` query shapes.
+- **Anon truncation**: enforced as a soft client-side cap (`ANON_MAX_COMPANIES`) matching the current server-action behaviour. Real abuse protection is the Cloudflare per-IP rate-limit on the tunnel hostname.
+- **Fallback**: if the scoped-key endpoint is down or the browser provider returns a `degraded` result, the runner falls back to the original server-action path (`apps/web/src/lib/search/search-runner.ts`).
+- **Out of scope for direct path**: `getPostingDetail` (R2 URL minting requires server trust), `getCurrencyRates` (DB read, not Typesense), histograms (`getSalaryHistogram`/`getExperienceHistogram`, kept on server actions for the 3600 s cache).
+>>>>>>> Stashed changes
 
 ## Read paths summary
 


### PR DESCRIPTION
Implements [#2639](https://github.com/colophon-group/jobseek/issues/2639) and extends the cutover beyond `/explore` to every read-heavy Typesense surface that doesn't need server trust.

## Summary

Behind `NEXT_PUBLIC_TYPESENSE_DIRECT=1`, four high-volume surfaces now call Typesense directly from the browser instead of proxying through Vercel server actions. Each has a server-action fallback so a missing scoped key, a Cloudflare hiccup, or an explicit code path (e.g. watchlist >100 companies) never breaks the page.

## Surfaces wired direct-browser

| Surface | Runner | Underlying server action it mirrors | Volume |
|---------|--------|-------------------------------------|--------|
| `/explore` search loop (filter chip changes, load-more) | `runSearchJobs`, `runListTopCompanies` | `searchJobs`, `listTopCompanies` | per filter change |
| Header / modal typeahead | `runSuggestLocations`, `runSuggestOccupations`, `runSuggestSeniorities`, `runSuggestTechnologies` | `suggestLocations`, `suggestOccupations`, `suggestSeniorities`, `suggestTechnologies` | **per keystroke** |
| Company detail postings list | `runGetCompanyPostings` | `getCompanyPostings` (calls `loadPostingsWithCounts`) | per company page view + load-more |
| Public watchlist postings (≤100 companies) | `runGetWatchlistPostings` | `getWatchlistPostings` (≤100 path; >100 throws → server fallback) | per watchlist view + load-more |

## Files

| File | Purpose |
|------|---------|
| `apps/web/app/api/typesense-key/route.ts` | Scoped-key minting (5 min anon / 10 min authed) |
| `apps/web/src/lib/search/scoped-key.ts` + test | HMAC-SHA256 + base64 minting using `node:crypto`. Byte-equivalence with `typesense-js` proven in unit test. |
| `apps/web/src/lib/search/typesense-browser.ts` | Search/listTopCompanies/loadPostings/loadPostingsWithCounts/histograms via `fetch` (no `typesense-js` in browser bundle) |
| `apps/web/src/lib/search/typesense-browser-typeahead.ts` | Locations + taxonomy suggest + boost-by-filter-matches |
| `apps/web/src/lib/search/typesense-browser-watchlist.ts` | Watchlist postings (≤100 companies; throws to fall back for larger) |
| `apps/web/src/lib/search/typesense-browser-key.ts` | In-memory scoped-key cache + proactive 30 s pre-expiry refresh |
| `apps/web/src/lib/search/search-runner.ts` | `runSearchJobs`, `runListTopCompanies`, `runGetCompanyPostings`, `runGetWatchlistPostings` — feature flag + fallback |
| `apps/web/src/lib/search/typeahead-runner.ts` | `runSuggestLocations` etc. — same pattern |
| `apps/web/src/lib/search/use-clear-typesense-on-auth-change.ts` | Hook that invalidates the cached scoped key on auth-state flip |
| `apps/web/app/[lang]/(app)/explore/search-page.tsx` | Wired `runSearchJobs` / `runListTopCompanies` + `useClearTypesenseOnAuthChange` |
| `apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx` | Wired `runGetCompanyPostings` |
| `apps/web/src/components/watchlist/watchlist-job-list.tsx` | Wired `runGetWatchlistPostings` |
| `apps/web/src/components/search/{search-bar,filter-bar,location-pills}.tsx` | Wired `runSuggest*` |
| `docs/11-typesense.md` | Document rate-limit, `TYPESENSE_BROWSER_PARENT_KEY`, all surfaces in/out of scope |

## Operational changes (already applied)

1. **Cloudflare rate-limit rule** on zone `colophon-group.org`, phase `http_ratelimit`: per-IP, 200 req / 10 s on `(http.host eq "typesense.colophon-group.org")`, action `block` for 10 s. Mitigation timeout is 10 s due to plan entitlements.
2. **`TYPESENSE_BROWSER_PARENT_KEY`** provisioned on the live Typesense cluster — `documents:search` only, all collections. Required because Typesense rejects scoped keys derived from parents with multiple actions (the regular `TYPESENSE_SEARCH_KEY` carries `documents:get` too).
3. **CORS Transform Rule not applied** — Typesense container already returns `Access-Control-Allow-Origin: *` and a correct preflight (verified empirically against the live tunnel).
4. **No bot WAF rule** — `managed_challenge` returns HTML CAPTCHA which would break JSON XHR; `cf.client.bot` is UA-based and trivially bypassed. Rate-limit is the actual abuse brake.

## Required env vars (must set on Vercel before flipping the flag)

| Env var | Where | Notes |
|---------|-------|-------|
| `TYPESENSE_BROWSER_PARENT_KEY` | Vercel (server) | The `documents:search`-only parent. Already in `apps/crawler/.env.local` for local dev. |
| `NEXT_PUBLIC_TYPESENSE_DIRECT=1` | Vercel (build) | Off by default. Flip after the env var above is set. |

`TYPESENSE_HOST`, `TYPESENSE_PORT`, `TYPESENSE_PROTOCOL` are already present.

## Out of scope (explicit, with reasons)

- **`getCompanyBySlug`** — server-rendered company page; has Postgres fallback for cold reads where Typesense hasn't caught up yet
- **`getSimilarCompanies` (filtered path)** — needs Postgres slug→id resolution via `parseSearchFilters`
- **Browse-all modals** (`getGlobalLocationsGrouped`, `getAllOccupationsGrouped`, `getAllSeniorities`, `getAllTechnologiesGrouped`) — need Postgres taxonomy hierarchy data on top of Typesense facets
- **Watchlist postings for >100 companies** — uses batched/merge logic only worth maintaining server-side
- **Posting detail** (`getPostingDetail`) — needs server-side R2 URL signing
- **Histograms** (`getSalaryHistogram`, `getExperienceHistogram`) — kept server-side for the 3600 s cache benefit
- **Sitemap, /api/v1/* routes, RSC data loaders** — not interactive surfaces

## Decisions worth flagging for review

- **No `limit_hits` in the scoped-key embed.** Typesense's `limit_hits` counts raw hits, not grouped rows. With our `group_by=company_id, group_limit=10`, a `limit_hits=40` embed would block normal anon page-1 traffic. Anon truncation is a soft client-side cap.
- **No `typesense-js` in the browser bundle.** Browser code talks to Typesense REST endpoints via `fetch`. HMAC-SHA256 minting is hand-rolled (verified byte-equivalent against `typesense-js` in tests).
- **Auth-state cache invalidation** is centralized in `useClearTypesenseOnAuthChange(isLoggedIn)` and called from every affected page (explore, company detail, watchlist). A user signing in or out clears the cached key on whichever surface is mounted, with no cross-tab sync (acceptable: each tab will mount a fresh `useSession` and re-clear).
- **Server-action fallback** kicks in if the scoped-key endpoint fails, the browser provider returns `degraded`, or — for watchlists — the company list exceeds 100. Loss of any of these never breaks the page.

## Test plan

- [x] Unit: HMAC-SHA256 minting matches `typesense-js` byte-for-byte (`scoped-key.test.ts`)
- [x] Empirical: scoped key from `TYPESENSE_BROWSER_PARENT_KEY` returns expected results against the live cluster (`job_posting`, `location`, `occupation`, `seniority`, `technology`)
- [x] Empirical: Cloudflare rate-limit rule applied + active
- [x] Empirical: Typesense origin emits `Access-Control-Allow-Origin: *` and a correct preflight
- [x] `pnpm test` (all 193 web tests pass)
- [x] `tsc --noEmit` clean (only pre-existing `@jseek/mcp-server` workspace error)
- [x] `eslint` clean for all changed files
- [ ] Manual verification on a Vercel preview with the env var + flag set:
  - [ ] /explore filter chip changes hit Typesense directly (DevTools network tab)
  - [ ] Header search-bar typeahead hits Typesense directly per keystroke
  - [ ] Company detail page load + load-more hit Typesense directly
  - [ ] Public watchlist view hit Typesense directly (≤100 companies)
  - [ ] >100-company watchlist still works via server-action fallback
  - [ ] Sign-in / sign-out invalidates the cached key (verify by toggling and observing first request to `/api/typesense-key`)
  - [ ] Rate-limit triggers under synthetic load
- [ ] Vercel function-time metric comparison after one week of `NEXT_PUBLIC_TYPESENSE_DIRECT=1` to validate the savings claim

🤖 Generated with [Claude Code](https://claude.com/claude-code)