### PR TITLE
Add allowed-tools frontmatter to /jobseek-label-daily (fixes #2674)

### DIFF
--- a/.claude/commands/jobseek-label-daily.md
+++ b/.claude/commands/jobseek-label-daily.md
@@ -4,9 +4,9 @@ description: Daily labelled-postings routine — sample diverse job postings fro
 allowed-tools:
   - Bash(cd apps/crawler)
   - Bash(labeller *)
-  - Bash(uv run labeller *)
   - Read
   - Write
+  - Edit
   - Agent
 ---
 
@@ -281,12 +281,13 @@ Print a final summary:
 - Never modify the orchestrator's own prompt file or subagent files.
 - Never make direct Anthropic API calls — everything is an `Agent(...)` tool
   call inside this Claude Code session.
-- Never invoke `gh`, `git`, `curl`, or any other external mutation tool
+- Never invoke `gh`, `git`, `curl`, `mkdir`, `rm`, `mv`, `cat`,
+  `python`, or any other shell command outside `labeller *`
   during a labelling run. The pipeline only needs `labeller` CLI, `Read`,
-  `Write`, and `Agent`. The frontmatter pre-approves exactly that surface;
-  anything else falls through to the user's default permission policy and
-  will surface a prompt — treat that prompt as a stop signal, not as a
-  request to approve.
+  `Write`, `Edit`, and `Agent`. The frontmatter pre-approves exactly
+  that surface; anything else falls through to the user's default
+  permission policy and will surface a prompt — treat that prompt as a
+  stop signal, not as a request to approve.
 - If any command fails unexpectedly (non-zero exit that isn't a known
   validate-failed path), stop the run for that posting, record the error,
   continue to the next posting.
@@ -298,9 +299,10 @@ Print a final summary:
 
 The `allowed-tools:` frontmatter at the top of this file is **additive**:
 it pre-approves the legitimate orchestrator surface (`labeller` Bash
-invocations, `Read`, `Write`, `Agent`) so the routine runs without per-
-step prompts. It does **not** deny anything — Claude Code permissions are
-augmentative, not restrictive. The actual containment surface is:
+invocations, `Read`, `Write`, `Edit`, `Agent`) so the routine runs
+without per-step prompts. It does **not** deny anything — Claude Code
+permissions are augmentative, not restrictive. The actual containment
+surface is:
 
 1. The Hard rules above, which forbid out-of-lane invocations.
 2. The user's default permission policy: any tool call outside the

--- a/.claude/commands/jobseek-label-daily.md
+++ b/.claude/commands/jobseek-label-daily.md
@@ -1,6 +1,13 @@
 ---
 name: jobseek-label-daily
 description: Daily labelled-postings routine — sample diverse job postings from the last 24h, label them via specialized subagents, upload to HuggingFace. Invoke with optional --date and --count. Spec in docs/15-data-sampling-routine.md.
+allowed-tools:
+  - Bash(cd apps/crawler)
+  - Bash(labeller *)
+  - Bash(uv run labeller *)
+  - Read
+  - Write
+  - Agent
 ---
 
 You are the **orchestrator** for the daily labelled-postings routine. Follow
@@ -274,9 +281,35 @@ Print a final summary:
 - Never modify the orchestrator's own prompt file or subagent files.
 - Never make direct Anthropic API calls — everything is an `Agent(...)` tool
   call inside this Claude Code session.
+- Never invoke `gh`, `git`, `curl`, or any other external mutation tool
+  during a labelling run. The pipeline only needs `labeller` CLI, `Read`,
+  `Write`, and `Agent`. The frontmatter pre-approves exactly that surface;
+  anything else falls through to the user's default permission policy and
+  will surface a prompt — treat that prompt as a stop signal, not as a
+  request to approve.
 - If any command fails unexpectedly (non-zero exit that isn't a known
   validate-failed path), stop the run for that posting, record the error,
   continue to the next posting.
 - If more than 50% of postings end with `qa_verdict=rejected`, stop after
   the current posting and emit a warning in the summary — the normalizer
   or a subagent may need attention.
+
+## Security model
+
+The `allowed-tools:` frontmatter at the top of this file is **additive**:
+it pre-approves the legitimate orchestrator surface (`labeller` Bash
+invocations, `Read`, `Write`, `Agent`) so the routine runs without per-
+step prompts. It does **not** deny anything — Claude Code permissions are
+augmentative, not restrictive. The actual containment surface is:
+
+1. The Hard rules above, which forbid out-of-lane invocations.
+2. The user's default permission policy: any tool call outside the
+   pre-approved set surfaces a permission prompt that the operator can
+   reject. A prompt during a labelling run is itself a red flag — the
+   playbook should never need approval beyond what's pre-approved.
+3. For stronger enforcement, the operator can add `Bash(gh *)`,
+   `Bash(git *)`, `Bash(curl *)` to the `deny` list in
+   `.claude/settings.json` (project-wide) or
+   `.claude/settings.local.json` (operator-local). Project-wide deny is
+   currently *not* set because it would interfere with non-labeller
+   sessions that legitimately need those tools.

--- a/.claude/commands/jobseek-label-daily.md
+++ b/.claude/commands/jobseek-label-daily.md
@@ -282,12 +282,13 @@ Print a final summary:
 - Never make direct Anthropic API calls — everything is an `Agent(...)` tool
   call inside this Claude Code session.
 - Never invoke `gh`, `git`, `curl`, `mkdir`, `rm`, `mv`, `cat`,
-  `python`, or any other shell command outside `labeller *`
-  during a labelling run. The pipeline only needs `labeller` CLI, `Read`,
-  `Write`, `Edit`, and `Agent`. The frontmatter pre-approves exactly
-  that surface; anything else falls through to the user's default
-  permission policy and will surface a prompt — treat that prompt as a
-  stop signal, not as a request to approve.
+  `python`, or any other shell command outside `cd apps/crawler` and
+  `labeller *` during a labelling run. The pipeline only needs the
+  `labeller` CLI (with `cd apps/crawler` as the cwd-setting prelude in
+  Step 0), plus `Read`, `Write`, `Edit`, and `Agent`. The frontmatter
+  pre-approves exactly that surface; anything else falls through to the
+  user's default permission policy and will surface a prompt — treat
+  that prompt as a stop signal, not as a request to approve.
 - If any command fails unexpectedly (non-zero exit that isn't a known
   validate-failed path), stop the run for that posting, record the error,
   continue to the next posting.


### PR DESCRIPTION
## Summary

Adds `allowed-tools:` frontmatter to `.claude/commands/jobseek-label-daily.md` so the orchestrator runs the labelling routine without per-step prompts, and tightens the Hard rules to forbid out-of-lane shell commands. Per the security review of #2627 (issue #2674).

The pre-approved surface is the minimal one the playbook actually uses:
- `Bash(cd apps/crawler)` (Step 0 cwd prelude)
- `Bash(labeller *)` (the entire pipeline)
- `Read`, `Write`, `Edit`, `Agent`

A new "Security model" section documents that `allowed-tools` in Claude Code is **augmentative, not restrictive** — it grants pre-approval, it does not deny anything. The real boundary remains the Hard rules + the user's default permission policy. Operators wanting stronger enforcement can add `gh`/`git`/`curl` to a `deny` list in `.claude/settings.json` (a project-wide deny is intentionally not added because it would interfere with non-labeller sessions).

## Test plan

- [x] Inspect frontmatter syntax against Claude Code permission rule format (`Tool(specifier)` / bare tool name).
- [x] Walk the playbook (lines 1-280) for any Bash invocation outside `cd apps/crawler` / `labeller *` — none.
- [x] Hard rules and frontmatter agree (cd is explicitly listed in both after review).