### PR TITLE
Direct-browser Typesense follow-ups: empty-fallback, multi-tab, cache, hoists

### DIFF
--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -13,7 +13,7 @@ import { getViewerLanguages } from "@/lib/viewer";
 import { cached } from "@/lib/cache";
 import { canCreateWatchlist, getUserPlan, PLAN_LIMITS } from "@/lib/plans";
 import { generateUniqueSlug } from "@/lib/watchlist-slug";
-import { ANON_MAX_WATCHLIST_POSTINGS } from "@/lib/search/constants";
+import { ANON_MAX_WATCHLIST_POSTINGS, COMPANY_BATCH_SIZE } from "@/lib/search/constants";
 import { expandLocationIds, resolveLocationSlugs } from "@/lib/actions/locations";
 import { expandOccupationIds, resolveOccupationSlugs, resolveSenioritySlugs, resolveTechnologySlugs } from "@/lib/actions/taxonomy";
 import { getSearchClient } from "@/lib/search/typesense-client";
@@ -1290,7 +1290,6 @@ async function _enrichWatchlistsWithRealCounts(
 }
 
 /** Max company IDs per Typesense filter string batch (~7KB ≈ 200 UUIDs). */
-const COMPANY_BATCH_SIZE = 100;
 
 async function _getWatchlistPostingsTypesense(
   params: {

--- a/apps/web/src/lib/search/__tests__/use-clear-typesense-on-auth-change.test.tsx
+++ b/apps/web/src/lib/search/__tests__/use-clear-typesense-on-auth-change.test.tsx
@@ -1,0 +1,72 @@
+/** @vitest-environment happy-dom */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useClearTypesenseOnAuthChange } from "../use-clear-typesense-on-auth-change";
+import * as keyModule from "../typesense-browser-key";
+
+describe("useClearTypesenseOnAuthChange", () => {
+  let clearSpy: ReturnType<typeof vi.spyOn>;
+  const ORIGINAL_FLAG = process.env.NEXT_PUBLIC_TYPESENSE_DIRECT;
+
+  beforeEach(() => {
+    process.env.NEXT_PUBLIC_TYPESENSE_DIRECT = "1";
+    clearSpy = vi.spyOn(keyModule, "clearTypesenseBrowserConfig").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    clearSpy.mockRestore();
+    if (ORIGINAL_FLAG === undefined) {
+      delete process.env.NEXT_PUBLIC_TYPESENSE_DIRECT;
+    } else {
+      process.env.NEXT_PUBLIC_TYPESENSE_DIRECT = ORIGINAL_FLAG;
+    }
+  });
+
+  it("does NOT clear on first mount (would waste a key fetch on every soft nav)", () => {
+    renderHook((p: boolean) => useClearTypesenseOnAuthChange(p), {
+      initialProps: false,
+    });
+    expect(clearSpy).not.toHaveBeenCalled();
+  });
+
+  it("clears when isLoggedIn flips from false to true", () => {
+    const { rerender } = renderHook(
+      (p: boolean) => useClearTypesenseOnAuthChange(p),
+      { initialProps: false },
+    );
+    expect(clearSpy).not.toHaveBeenCalled();
+    rerender(true);
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears when isLoggedIn flips from true to false (sign-out)", () => {
+    const { rerender } = renderHook(
+      (p: boolean) => useClearTypesenseOnAuthChange(p),
+      { initialProps: true },
+    );
+    expect(clearSpy).not.toHaveBeenCalled();
+    rerender(false);
+    expect(clearSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-clear on identical re-renders", () => {
+    const { rerender } = renderHook(
+      (p: boolean) => useClearTypesenseOnAuthChange(p),
+      { initialProps: true },
+    );
+    rerender(true);
+    rerender(true);
+    rerender(true);
+    expect(clearSpy).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when feature flag is off, even on auth flip", () => {
+    process.env.NEXT_PUBLIC_TYPESENSE_DIRECT = "0";
+    const { rerender } = renderHook(
+      (p: boolean) => useClearTypesenseOnAuthChange(p),
+      { initialProps: false },
+    );
+    rerender(true);
+    expect(clearSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/search/constants.ts
+++ b/apps/web/src/lib/search/constants.ts
@@ -3,3 +3,10 @@ export const ANON_MAX_COMPANIES = 15; // 1.5 pages of PAGE_SIZE=10
 export const ANON_MAX_POSTINGS = 40; // 2 pages of PAGE_SIZE=20 (company detail page)
 export const ANON_MAX_CARD_POSTINGS = 20; // 10 initial + 1 batch (company card in search)
 export const ANON_MAX_WATCHLIST_POSTINGS = 20; // 1 page of 20 (watchlist detail page)
+
+/**
+ * Watchlist company-id batch size for Typesense queries. Watchlists tracking
+ * more companies require a batched/merge implementation. The browser provider
+ * throws above this size so the runner falls back to the server action.
+ */
+export const COMPANY_BATCH_SIZE = 100;

--- a/apps/web/src/lib/search/search-runner.ts
+++ b/apps/web/src/lib/search/search-runner.ts
@@ -146,14 +146,10 @@ export async function runGetCompanyPostings(
     try {
       const provider = await tryBrowserProvider();
       const result = await provider.loadPostingsWithCounts(params);
-      // Browser provider's catch returns activeCount: 0; treat as failure
-      // and fall back to the server action.
-      if (result.postings.length > 0 || result.activeCount > 0) {
-        if (!isLoggedIn && params.offset + result.postings.length >= ANON_MAX_POSTINGS) {
-          return { ...result, truncated: true };
-        }
-        return result;
+      if (!isLoggedIn && params.offset + result.postings.length >= ANON_MAX_POSTINGS) {
+        return { ...result, truncated: true };
       }
+      return result;
     } catch (err) {
       console.error("[search-runner] browser getCompanyPostings failed, falling back", err);
     }

--- a/apps/web/src/lib/search/typesense-browser-key.ts
+++ b/apps/web/src/lib/search/typesense-browser-key.ts
@@ -10,6 +10,19 @@ let cached: TypesenseBrowserConfig | null = null;
 let inflight: Promise<TypesenseBrowserConfig> | null = null;
 
 const REFRESH_LEAD_MS = 30_000;
+const BROADCAST_CHANNEL_NAME = "typesense-key-clear";
+
+let broadcastChannel: BroadcastChannel | null = null;
+
+function ensureBroadcastListener(): void {
+  if (typeof BroadcastChannel === "undefined") return;
+  if (broadcastChannel) return;
+  broadcastChannel = new BroadcastChannel(BROADCAST_CHANNEL_NAME);
+  broadcastChannel.onmessage = () => {
+    cached = null;
+    inflight = null;
+  };
+}
 
 async function fetchKey(): Promise<TypesenseBrowserConfig> {
   const res = await fetch("/api/typesense-key", { credentials: "same-origin" });
@@ -18,6 +31,7 @@ async function fetchKey(): Promise<TypesenseBrowserConfig> {
 }
 
 export async function getTypesenseBrowserConfig(): Promise<TypesenseBrowserConfig> {
+  ensureBroadcastListener();
   if (cached && cached.expiresAt - Date.now() > REFRESH_LEAD_MS) return cached;
   if (!inflight) {
     inflight = fetchKey()
@@ -32,7 +46,21 @@ export async function getTypesenseBrowserConfig(): Promise<TypesenseBrowserConfi
   return inflight;
 }
 
+/**
+ * Clears the cached scoped key in this tab AND broadcasts to other tabs so
+ * sign-in/out in tab A immediately invalidates the stale key in tab B.
+ */
 export function clearTypesenseBrowserConfig(): void {
   cached = null;
   inflight = null;
+  if (typeof BroadcastChannel === "undefined") return;
+  // Use a dedicated transient channel for the post — listeners on the
+  // long-lived channel pick it up. Closing immediately keeps GC tidy.
+  try {
+    const ch = new BroadcastChannel(BROADCAST_CHANNEL_NAME);
+    ch.postMessage({ type: "clear" });
+    ch.close();
+  } catch {
+    // BroadcastChannel can throw in private-mode browsers; safe to ignore.
+  }
 }

--- a/apps/web/src/lib/search/typesense-browser-typeahead.ts
+++ b/apps/web/src/lib/search/typesense-browser-typeahead.ts
@@ -1,20 +1,48 @@
 import { getTypesenseBrowserConfig, type TypesenseBrowserConfig } from "./typesense-browser-key";
 import { buildFilterString } from "./typesense-filters";
 import type { TypeaheadBoostFilters } from "./typeahead-boost";
+import type { LocationSuggestion } from "@/lib/actions/locations";
+import type { TaxonomySuggestion } from "@/lib/actions/taxonomy";
 
-export interface LocationSuggestion {
-  id: number;
-  slug: string;
-  name: string;
-  type: "macro" | "country" | "region" | "city";
-  parentName: string | null;
+export type { LocationSuggestion, TaxonomySuggestion };
+
+/**
+ * Tiny LRU cache for typeahead results. Replaces the 1h server-side
+ * `cached()` wrapper that the original `suggest*` server actions had —
+ * direct browser->Typesense bypasses Redis, so without this every keystroke
+ * cycle re-queries even when the user is just backspacing into a previous
+ * stroke. TTL kept short (the data changes hourly via taxonomy sync); cap
+ * keeps memory bounded across long-lived tabs.
+ */
+const SUGGEST_CACHE_TTL_MS = 60_000;
+const SUGGEST_CACHE_MAX = 80;
+const suggestCache = new Map<string, { at: number; value: unknown }>();
+
+function cacheGet<T>(key: string): T | null {
+  const entry = suggestCache.get(key);
+  if (!entry) return null;
+  if (Date.now() - entry.at > SUGGEST_CACHE_TTL_MS) {
+    suggestCache.delete(key);
+    return null;
+  }
+  // LRU: move to end on hit
+  suggestCache.delete(key);
+  suggestCache.set(key, entry);
+  return entry.value as T;
 }
 
-export interface TaxonomySuggestion {
-  id: number;
-  slug: string;
-  name: string;
-  matchedName?: string;
+function cacheSet<T>(key: string, value: T): void {
+  if (suggestCache.has(key)) suggestCache.delete(key);
+  suggestCache.set(key, { at: Date.now(), value });
+  while (suggestCache.size > SUGGEST_CACHE_MAX) {
+    const firstKey = suggestCache.keys().next().value;
+    if (firstKey === undefined) break;
+    suggestCache.delete(firstKey);
+  }
+}
+
+function suggestCacheKey(kind: string, ...parts: (string | number | undefined)[]): string {
+  return `${kind}:${parts.map((p) => p ?? "").join("|")}`;
 }
 
 interface SearchHit<T> {
@@ -111,6 +139,26 @@ export async function suggestLocationsBrowser(params: {
   if (q.length < 2) return [];
 
   const { locale, userLat, userLng } = params;
+
+  // Cache the un-boosted suggestions only — boost depends on the live filter
+  // set and would multiply cache keys. Boost runs after cache hit too.
+  const cacheKey = suggestCacheKey(
+    "loc",
+    q,
+    locale,
+    userLat != null ? Math.round(userLat * 100) / 100 : undefined,
+    userLng != null ? Math.round(userLng * 100) / 100 : undefined,
+  );
+  const hit = cacheGet<LocationSuggestion[]>(cacheKey);
+  if (hit) {
+    if (!params.filters) return hit;
+    try {
+      const cfg = await getTypesenseBrowserConfig();
+      return await boost(cfg, hit, "location_ids", (s) => s.id, params.filters);
+    } catch {
+      return hit;
+    }
+  }
   const hasGeo = userLat != null && userLng != null;
   const sortBy = hasGeo
     ? `_text_match:desc,coordinates(${userLat},${userLng}, precision: 5km):asc,active_posting_count:desc`
@@ -131,7 +179,10 @@ export async function suggestLocationsBrowser(params: {
       num_typos: "1",
       drop_tokens_threshold: 0,
     });
-    if (!r.hits || r.hits.length === 0) return [];
+    if (!r.hits || r.hits.length === 0) {
+      cacheSet(cacheKey, []);
+      return [];
+    }
     const suggestions: LocationSuggestion[] = r.hits.map((hit) => {
       const d = hit.document;
       return {
@@ -142,6 +193,7 @@ export async function suggestLocationsBrowser(params: {
         parentName: d.parent_name ?? null,
       };
     });
+    cacheSet(cacheKey, suggestions);
     if (!params.filters) return suggestions;
     return boost(cfg, suggestions, "location_ids", (s) => s.id, params.filters);
   } catch {
@@ -176,6 +228,76 @@ function mapAliasMatch(
   return matched && matched !== displayName ? matched : undefined;
 }
 
+interface LocaleAwareDoc {
+  slug: string;
+  name: string;
+}
+
+async function suggestLocaleAware<D extends LocaleAwareDoc>(opts: {
+  collection: string;
+  locale: string;
+  query: string;
+  filters?: TypeaheadBoostFilters;
+  facetField: string;
+  idOf: (d: D) => number;
+  cacheKind: string;
+}): Promise<TaxonomySuggestion[]> {
+  const cacheKey = suggestCacheKey(opts.cacheKind, opts.query, opts.locale);
+  const hit = cacheGet<TaxonomySuggestion[]>(cacheKey);
+  const finalize = async (
+    cfg: TypesenseBrowserConfig,
+    suggestions: TaxonomySuggestion[],
+  ): Promise<TaxonomySuggestion[]> => {
+    if (!opts.filters) return suggestions;
+    return boost(cfg, suggestions, opts.facetField, (s) => s.id, opts.filters);
+  };
+  if (hit) {
+    if (!opts.filters) return hit;
+    try {
+      const cfg = await getTypesenseBrowserConfig();
+      return await finalize(cfg, hit);
+    } catch {
+      return hit;
+    }
+  }
+
+  try {
+    const cfg = await getTypesenseBrowserConfig();
+    const baseParams = {
+      q: opts.query,
+      query_by: "name,aliases",
+      sort_by: "_text_match:desc,active_posting_count:desc",
+      per_page: 5,
+      prefix: "true",
+      num_typos: "1",
+    };
+    let r = await searchOne<D>(cfg, opts.collection, {
+      ...baseParams,
+      filter_by: `has_active_postings:true && locale:${opts.locale}`,
+    });
+    if ((!r.hits || r.hits.length === 0) && opts.locale !== "en") {
+      r = await searchOne<D>(cfg, opts.collection, {
+        ...baseParams,
+        filter_by: "has_active_postings:true && locale:en",
+      });
+    }
+    if (!r.hits || r.hits.length === 0) {
+      cacheSet(cacheKey, []);
+      return [];
+    }
+    const suggestions: TaxonomySuggestion[] = r.hits.map((h) => ({
+      id: opts.idOf(h.document),
+      slug: h.document.slug,
+      name: h.document.name,
+      matchedName: mapAliasMatch(h, h.document.name),
+    }));
+    cacheSet(cacheKey, suggestions);
+    return finalize(cfg, suggestions);
+  } catch {
+    return [];
+  }
+}
+
 export async function suggestOccupationsBrowser(params: {
   query: string;
   locale: string;
@@ -183,42 +305,15 @@ export async function suggestOccupationsBrowser(params: {
 }): Promise<TaxonomySuggestion[]> {
   const q = params.query.trim();
   if (q.length < 2) return [];
-
-  const { locale } = params;
-  try {
-    const cfg = await getTypesenseBrowserConfig();
-    let r = await searchOne<OccupationDoc>(cfg, "occupation", {
-      q,
-      query_by: "name,aliases",
-      filter_by: `has_active_postings:true && locale:${locale}`,
-      sort_by: "_text_match:desc,active_posting_count:desc",
-      per_page: 5,
-      prefix: "true",
-      num_typos: "1",
-    });
-    if ((!r.hits || r.hits.length === 0) && locale !== "en") {
-      r = await searchOne<OccupationDoc>(cfg, "occupation", {
-        q,
-        query_by: "name,aliases",
-        filter_by: "has_active_postings:true && locale:en",
-        sort_by: "_text_match:desc,active_posting_count:desc",
-        per_page: 5,
-        prefix: "true",
-        num_typos: "1",
-      });
-    }
-    if (!r.hits || r.hits.length === 0) return [];
-    const suggestions: TaxonomySuggestion[] = r.hits.map((hit) => ({
-      id: hit.document.occupation_id,
-      slug: hit.document.slug,
-      name: hit.document.name,
-      matchedName: mapAliasMatch(hit, hit.document.name),
-    }));
-    if (!params.filters) return suggestions;
-    return boost(cfg, suggestions, "occupation_id", (s) => s.id, params.filters);
-  } catch {
-    return [];
-  }
+  return suggestLocaleAware<OccupationDoc>({
+    collection: "occupation",
+    locale: params.locale,
+    query: q,
+    filters: params.filters,
+    facetField: "occupation_id",
+    idOf: (d) => d.occupation_id,
+    cacheKind: "occ",
+  });
 }
 
 export async function suggestSenioritiesBrowser(params: {
@@ -228,42 +323,15 @@ export async function suggestSenioritiesBrowser(params: {
 }): Promise<TaxonomySuggestion[]> {
   const q = params.query.trim();
   if (q.length < 2) return [];
-
-  const { locale } = params;
-  try {
-    const cfg = await getTypesenseBrowserConfig();
-    let r = await searchOne<SeniorityDoc>(cfg, "seniority", {
-      q,
-      query_by: "name,aliases",
-      filter_by: `has_active_postings:true && locale:${locale}`,
-      sort_by: "_text_match:desc,active_posting_count:desc",
-      per_page: 5,
-      prefix: "true",
-      num_typos: "1",
-    });
-    if ((!r.hits || r.hits.length === 0) && locale !== "en") {
-      r = await searchOne<SeniorityDoc>(cfg, "seniority", {
-        q,
-        query_by: "name,aliases",
-        filter_by: "has_active_postings:true && locale:en",
-        sort_by: "_text_match:desc,active_posting_count:desc",
-        per_page: 5,
-        prefix: "true",
-        num_typos: "1",
-      });
-    }
-    if (!r.hits || r.hits.length === 0) return [];
-    const suggestions: TaxonomySuggestion[] = r.hits.map((hit) => ({
-      id: hit.document.seniority_id,
-      slug: hit.document.slug,
-      name: hit.document.name,
-      matchedName: mapAliasMatch(hit, hit.document.name),
-    }));
-    if (!params.filters) return suggestions;
-    return boost(cfg, suggestions, "seniority_id", (s) => s.id, params.filters);
-  } catch {
-    return [];
-  }
+  return suggestLocaleAware<SeniorityDoc>({
+    collection: "seniority",
+    locale: params.locale,
+    query: q,
+    filters: params.filters,
+    facetField: "seniority_id",
+    idOf: (d) => d.seniority_id,
+    cacheKind: "sen",
+  });
 }
 
 export async function suggestTechnologiesBrowser(params: {
@@ -273,6 +341,18 @@ export async function suggestTechnologiesBrowser(params: {
 }): Promise<TaxonomySuggestion[]> {
   const q = params.query.trim();
   if (q.length < 2) return [];
+
+  const cacheKey = suggestCacheKey("tech", q);
+  const hit = cacheGet<TaxonomySuggestion[]>(cacheKey);
+  if (hit) {
+    if (!params.filters) return hit;
+    try {
+      const cfg = await getTypesenseBrowserConfig();
+      return await boost(cfg, hit, "technology_ids", (s) => s.id, params.filters);
+    } catch {
+      return hit;
+    }
+  }
 
   try {
     const cfg = await getTypesenseBrowserConfig();
@@ -285,12 +365,16 @@ export async function suggestTechnologiesBrowser(params: {
       prefix: "true",
       num_typos: "0",
     });
-    if (!r.hits || r.hits.length === 0) return [];
+    if (!r.hits || r.hits.length === 0) {
+      cacheSet(cacheKey, []);
+      return [];
+    }
     const suggestions: TaxonomySuggestion[] = r.hits.map((hit) => ({
       id: hit.document.technology_id,
       slug: hit.document.slug,
       name: hit.document.name ?? hit.document.slug,
     }));
+    cacheSet(cacheKey, suggestions);
     if (!params.filters) return suggestions;
     return boost(cfg, suggestions, "technology_ids", (s) => s.id, params.filters);
   } catch {

--- a/apps/web/src/lib/search/typesense-browser-watchlist.ts
+++ b/apps/web/src/lib/search/typesense-browser-watchlist.ts
@@ -1,8 +1,7 @@
 import { getTypesenseBrowserConfig, type TypesenseBrowserConfig } from "./typesense-browser-key";
 import { buildFilterString } from "./typesense-filters";
+import { COMPANY_BATCH_SIZE } from "./constants";
 import type { WatchlistPostingEntry } from "@/lib/actions/watchlists";
-
-export const COMPANY_BATCH_SIZE = 100;
 
 interface JobPostingDoc {
   id: string;

--- a/apps/web/src/lib/search/typesense-browser.ts
+++ b/apps/web/src/lib/search/typesense-browser.ts
@@ -386,50 +386,47 @@ export class TypesenseBrowserProvider implements SearchProvider {
     activeCount: number;
     yearCount: number;
   }> {
-    try {
-      const cfg = await this.cfg();
-      const { companyId, keywords, offset, limit, locationIds } = params;
-      const filterStr = buildFilterString(params);
-      const baseFilter = `company_id:=${companyId}${filterStr ? ` && ${filterStr}` : ""}`;
-      const q = keywords.length ? keywords.join(" ") : "*";
+    // Throws on transport / Typesense error so the runner can distinguish
+    // "errored, fall back to server action" from "legitimate zero matches".
+    const cfg = await this.cfg();
+    const { companyId, keywords, offset, limit, locationIds } = params;
+    const filterStr = buildFilterString(params);
+    const baseFilter = `company_id:=${companyId}${filterStr ? ` && ${filterStr}` : ""}`;
+    const q = keywords.length ? keywords.join(" ") : "*";
 
-      const [postingsResult, activeResult, yearResult] = await Promise.all([
-        searchOne<JobPostingDoc>(cfg, "job_posting", {
-          q,
-          query_by: "title",
-          filter_by: `is_active:true && ${baseFilter}`,
-          sort_by: keywords.length
-            ? "_text_match:desc,first_seen_at:desc"
-            : "first_seen_at:desc",
-          per_page: limit,
-          page: Math.floor(offset / limit) + 1,
-        }),
-        searchOne<JobPostingDoc>(cfg, "job_posting", {
-          q,
-          query_by: "title",
-          filter_by: `is_active:true && ${baseFilter}`,
-          per_page: 0,
-        }),
-        searchOne<JobPostingDoc>(cfg, "job_posting", {
-          q,
-          query_by: "title",
-          filter_by: `first_seen_at:>${oneYearAgoUnix()} && ${baseFilter}`,
-          per_page: 0,
-        }),
-      ]);
+    const [postingsResult, activeResult, yearResult] = await Promise.all([
+      searchOne<JobPostingDoc>(cfg, "job_posting", {
+        q,
+        query_by: "title",
+        filter_by: `is_active:true && ${baseFilter}`,
+        sort_by: keywords.length
+          ? "_text_match:desc,first_seen_at:desc"
+          : "first_seen_at:desc",
+        per_page: limit,
+        page: Math.floor(offset / limit) + 1,
+      }),
+      searchOne<JobPostingDoc>(cfg, "job_posting", {
+        q,
+        query_by: "title",
+        filter_by: `is_active:true && ${baseFilter}`,
+        per_page: 0,
+      }),
+      searchOne<JobPostingDoc>(cfg, "job_posting", {
+        q,
+        query_by: "title",
+        filter_by: `first_seen_at:>${oneYearAgoUnix()} && ${baseFilter}`,
+        per_page: 0,
+      }),
+    ]);
 
-      const postings = (postingsResult.hits ?? []).map((h) =>
-        mapHitToPosting(h, locationIds),
-      );
-      return {
-        postings,
-        activeCount: activeResult.found ?? 0,
-        yearCount: yearResult.found ?? 0,
-      };
-    } catch (err) {
-      console.error("[typesense-browser] loadPostingsWithCounts error", err);
-      return { postings: [], activeCount: 0, yearCount: 0 };
-    }
+    const postings = (postingsResult.hits ?? []).map((h) =>
+      mapHitToPosting(h, locationIds),
+    );
+    return {
+      postings,
+      activeCount: activeResult.found ?? 0,
+      yearCount: yearResult.found ?? 0,
+    };
   }
 
   async getSalaryHistogram(filters?: HistogramFilters): Promise<SalaryBucket[]> {

--- a/apps/web/src/lib/search/use-clear-typesense-on-auth-change.ts
+++ b/apps/web/src/lib/search/use-clear-typesense-on-auth-change.ts
@@ -1,18 +1,21 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { clearTypesenseBrowserConfig } from "./typesense-browser-key";
 
 /**
- * Clears the cached browser-side Typesense scoped key whenever the auth
- * state flips, so a sign-in/sign-out doesn't keep the wrong key (anon
- * truncation cap vs. authed unrestricted).
+ * Clears the cached browser-side Typesense scoped key on auth-state
+ * transitions. Skips first-mount: clearing on every page mount would
+ * waste a /api/typesense-key fetch on every soft navigation.
  *
  * Safe to call from any client page; no-ops unless NEXT_PUBLIC_TYPESENSE_DIRECT=1.
  */
 export function useClearTypesenseOnAuthChange(isLoggedIn: boolean): void {
+  const previous = useRef(isLoggedIn);
   useEffect(() => {
     if (process.env.NEXT_PUBLIC_TYPESENSE_DIRECT !== "1") return;
+    if (previous.current === isLoggedIn) return;
+    previous.current = isLoggedIn;
     clearTypesenseBrowserConfig();
   }, [isLoggedIn]);
 }


### PR DESCRIPTION
Follow-ups to merged PR #2675. Subagent review caught several real issues — fixing them before flipping the `NEXT_PUBLIC_TYPESENSE_DIRECT=1` flag in production.

## Summary

| # | Severity | Fix | File |
|---|----------|-----|------|
| 1 | Important | `runGetCompanyPostings` no longer falsely falls back to server on legitimate zero-result queries | `search-runner.ts`, `typesense-browser.ts` |
| 2 | Important | Sign-in/out in one tab now invalidates the cached scoped key in all tabs (`BroadcastChannel`) | `typesense-browser-key.ts` |
| 3 | Minor | `COMPANY_BATCH_SIZE` hoisted from two files to `constants.ts` so server / browser can't drift | `constants.ts`, `watchlists.ts`, `typesense-browser-watchlist.ts` |
| 4 | Important | `useClearTypesenseOnAuthChange` no longer clears the cached key on every page mount (was wasting `/api/typesense-key` fetches on every soft nav) | `use-clear-typesense-on-auth-change.ts` |
| 5 | Important | Browser typeahead was missing the server's 1h Redis cache: every keystroke fan-out re-hit Typesense. Now wrapped in a 60 s / 80-entry in-memory LRU (boost still runs filter-aware after cache hit) | `typesense-browser-typeahead.ts` |
| 6 | Hygiene | `suggestOccupations` / `suggestSeniorities` factored into one `suggestLocaleAware` helper; redeclared `LocationSuggestion` / `TaxonomySuggestion` types now imported from the actions module | `typesense-browser-typeahead.ts` |

## Why each matters before the flag flip

- **#1**: every empty-results filter combo would have doubled latency. Common during filter exploration on `/explore` and company detail pages.
- **#2**: real auth correctness bug — a signed-out user keeping an authed key for 5 min has wider permissions than they should; a signed-in user stuck on the anon-cap key sees a corrupted UX.
- **#4**: every soft navigation between `/explore`, `/company/[slug]`, and watchlist pages was burning one extra round-trip just to re-mint a key that was already valid.
- **#5**: per-keystroke direct calls without server cache pushed Typesense QPS up by ~5× over the server-action path. The CX22 box (4 GB / 2 vCPU) is the bottleneck — caching backfills the 1h Redis cache the server actions had.

## Test plan

- [x] 213/213 vitest pass (5 new tests for `useClearTypesenseOnAuthChange` cover all four state transitions + flag-off no-op)
- [x] tsc --noEmit clean
- [x] eslint clean
- [x] Empirical: zero-result Typesense query against the live cluster returns `{found: 0}` cleanly via the new throw-on-error path
- [ ] Manual on Vercel preview: sign-in / sign-out in one tab clears the key in another (DevTools network tab on `/api/typesense-key`)
- [ ] Manual on Vercel preview: filter chip change yielding empty results does NOT trigger a server-action fallback (DevTools no `searchJobs` POST after the Typesense `/multi_search` GET)

## Subagent findings not addressed (intentional)

- `searchOne` is duplicated across three browser modules — refactor risk vs. small drift today; deferred.
- `JobPostingDoc` interface duplicated — same call.
- `applyAnonCap` doesn't slice overflow when truncated — server-side `searchJobs` has the same shape, so this would be a behavior change, not a parity fix.
- Long URLs for 100-company watchlists (~4.5 KB GET) — well under Cloudflare's 16 KB limit; >100 case already falls back via explicit throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)