### PR TITLE
Add in-process single-flight to typeahead suggest cache (fixes #2676)

### DIFF
--- a/apps/web/src/lib/__tests__/cache.test.ts
+++ b/apps/web/src/lib/__tests__/cache.test.ts
@@ -85,6 +85,106 @@ describe("cached", () => {
   });
 });
 
+describe("cached — single-flight stampede protection (#2676)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("collapses N concurrent identical fetches to one upstream call", async () => {
+    /** Cold-start scenario: N concurrent requests for the same key all
+     * miss the Redis cache. Without single-flight, all N would fan out to
+     * the upstream. With single-flight, the first seeds an in-flight
+     * promise and the rest await it. */
+    mockGet.mockResolvedValue(null);
+    mockSet.mockResolvedValue("OK");
+
+    let resolveFetcher: ((value: { v: string }) => void) | undefined;
+    const fetcher = vi.fn(
+      () =>
+        new Promise<{ v: string }>((res) => {
+          resolveFetcher = res;
+        }),
+    );
+
+    const callers = [
+      cached("hot-key", fetcher, { ttl: 60 }),
+      cached("hot-key", fetcher, { ttl: 60 }),
+      cached("hot-key", fetcher, { ttl: 60 }),
+      cached("hot-key", fetcher, { ttl: 60 }),
+      cached("hot-key", fetcher, { ttl: 60 }),
+    ];
+
+    // Yield once so the cached() bodies progress past the await on
+    // redis.get and seed the in-flight map.
+    await Promise.resolve();
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    resolveFetcher!({ v: "fresh" });
+    const results = await Promise.all(callers);
+
+    expect(results).toEqual([
+      { v: "fresh" },
+      { v: "fresh" },
+      { v: "fresh" },
+      { v: "fresh" },
+      { v: "fresh" },
+    ]);
+    // SET is also single-flighted (only one writer).
+    expect(mockSet).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the in-flight slot after success so the next call can start fresh", async () => {
+    mockGet.mockResolvedValue(null);
+    mockSet.mockResolvedValue("OK");
+    const fetcher = vi.fn().mockResolvedValue("v1");
+
+    await cached("k", fetcher, { ttl: 60 });
+    // Simulate the next request after the first finished — fetcher should
+    // run again because the in-flight slot was released.
+    fetcher.mockResolvedValueOnce("v2");
+    await cached("k", fetcher, { ttl: 60 });
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("releases the in-flight slot after rejection so retry isn't permanently blocked", async () => {
+    mockGet.mockResolvedValue(null);
+    const failing = vi.fn().mockRejectedValue(new Error("upstream down"));
+
+    await expect(
+      cached("k", failing, { ttl: 60 }),
+    ).rejects.toThrow("upstream down");
+
+    // Subsequent caller against a recovered upstream must NOT be blocked
+    // by a stale in-flight slot.
+    const recovered = vi.fn().mockResolvedValue({ v: "ok" });
+    mockSet.mockResolvedValue("OK");
+    const result = await cached("k", recovered, { ttl: 60 });
+
+    expect(result).toEqual({ v: "ok" });
+    expect(recovered).toHaveBeenCalledOnce();
+  });
+
+  it("only collapses fetches with the same key", async () => {
+    mockGet.mockResolvedValue(null);
+    mockSet.mockResolvedValue("OK");
+
+    const fetcherA = vi.fn().mockResolvedValue("a");
+    const fetcherB = vi.fn().mockResolvedValue("b");
+
+    const [a, b] = await Promise.all([
+      cached("key-a", fetcherA, { ttl: 60 }),
+      cached("key-b", fetcherB, { ttl: 60 }),
+    ]);
+
+    expect(a).toBe("a");
+    expect(b).toBe("b");
+    expect(fetcherA).toHaveBeenCalledOnce();
+    expect(fetcherB).toHaveBeenCalledOnce();
+  });
+});
+
 describe("invalidate", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/apps/web/src/lib/cache.ts
+++ b/apps/web/src/lib/cache.ts
@@ -9,7 +9,25 @@ interface CacheOptions<T = unknown> {
 }
 
 /**
- * Redis-backed cache-aside wrapper.
+ * In-process single-flight registry.
+ *
+ * On a cold start, N concurrent requests for the same key all miss the
+ * Redis cache and would otherwise each fan out to the upstream (Typesense /
+ * Postgres). The map collapses concurrent identical fetches **within a
+ * single Node instance** to one upstream call; the others await the same
+ * promise. Per-instance only — across Vercel's autoscaled instances the
+ * Redis cache layer is the cross-instance dedup once it warms up.
+ *
+ * The map is keyed by the user-supplied cache key (NOT the `cache:`-prefixed
+ * Redis key) so callers using identical `cached(...)` inputs share the
+ * same in-flight promise. Entries are deleted in a `finally` block so a
+ * failed upstream call doesn't pin the slot indefinitely.
+ */
+const _inflight = new Map<string, Promise<unknown>>();
+
+/**
+ * Redis-backed cache-aside wrapper with in-process single-flight
+ * stampede protection.
  *
  * Shared across all Vercel serverless instances (unlike `unstable_cache`
  * which is per-process). Falls back to the fetcher on Redis errors.
@@ -28,17 +46,32 @@ export async function cached<T>(
     // Redis unavailable — fall through to fetcher
   }
 
-  const data = await fetcher();
+  // Cold-start stampede protection: collapse concurrent identical fetches
+  // within this instance to a single upstream call. The first concurrent
+  // caller seeds the in-flight map; later callers await its promise.
+  const existing = _inflight.get(key) as Promise<T> | undefined;
+  if (existing !== undefined) return existing;
 
-  if (!options.skipIf?.(data)) {
+  const inflight = (async () => {
     try {
-      await redis.set(fullKey, JSON.stringify(data), { ex: options.ttl });
-    } catch {
-      // Redis unavailable — data still returned from fetcher
+      const data = await fetcher();
+      if (!options.skipIf?.(data)) {
+        try {
+          await redis.set(fullKey, JSON.stringify(data), { ex: options.ttl });
+        } catch {
+          // Redis unavailable — data still returned from fetcher
+        }
+      }
+      return data;
+    } finally {
+      // Always release the slot, even on fetcher rejection, so the next
+      // caller gets a chance to retry against a healthy upstream.
+      _inflight.delete(key);
     }
-  }
+  })();
 
-  return data;
+  _inflight.set(key, inflight);
+  return inflight;
 }
 
 /**


### PR DESCRIPTION
WIP — claim. Will add per-instance single-flight dedup to apps/web/src/lib/cache.ts so a cold-start burst of N concurrent identical fetches collapses to 1 fetch.