### PR TITLE
Invalidate company-detail cache on rename (fixes #2715)

### DIFF
--- a/apps/web/app/api/internal/invalidate-typeahead/route.test.ts
+++ b/apps/web/app/api/internal/invalidate-typeahead/route.test.ts
@@ -67,6 +67,8 @@ describe("POST /api/internal/invalidate-typeahead", () => {
       "sen-suggest:": 0,
       "tech-suggest:": 0,
       "company-suggest:": 2,
+      "company-slug:": 0,
+      "company-similar:": 0,
     });
 
     const calls = mocks.invalidatePattern.mock.calls.map((c) => c[0]);
@@ -76,7 +78,27 @@ describe("POST /api/internal/invalidate-typeahead", () => {
       "sen-suggest:",
       "tech-suggest:",
       "company-suggest:",
+      "company-slug:",
+      "company-similar:",
     ]);
+  });
+
+  it("sweeps company-detail caches (company-slug + company-similar)", async () => {
+    /** Regression for #2715: a company rename via crawler sync would
+     * otherwise leave /company/<slug> stale up to the 10-minute TTL on
+     * `company-slug:`. The same sweep also covers `company-similar:`,
+     * whose ranked-peers result depends on industry membership. */
+    mocks.invalidatePattern.mockImplementation(async (prefix: string) =>
+      prefix === "company-slug:" ? 4 : prefix === "company-similar:" ? 3 : 0,
+    );
+
+    const res = await POST(_request("Bearer secret-token") as never);
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.deleted["company-slug:"]).toBe(4);
+    expect(body.deleted["company-similar:"]).toBe(3);
+    expect(body.total).toBe(7);
   });
 
   it("does not accept arbitrary prefixes from the caller", async () => {

--- a/apps/web/app/api/internal/invalidate-typeahead/route.ts
+++ b/apps/web/app/api/internal/invalidate-typeahead/route.ts
@@ -18,23 +18,36 @@ function _safeBearerEqual(presented: string | null, expected: string): boolean {
 export const runtime = "nodejs";
 
 // Closed list — every cache key prefix that would go stale after a
-// `crawler sync` taxonomy mutation. Defined here (not in the caller) so
-// the crawler can't accidentally request a sweep of an unrelated namespace.
-// Mirrors the keys built in apps/web/src/lib/actions/{locations,taxonomy,company}.ts.
+// `crawler sync` mutation (taxonomy renames, company CSV edits). Defined
+// here (not in the caller) so the crawler can't accidentally request a
+// sweep of an unrelated namespace. Mirrors the keys built in
+// apps/web/src/lib/actions/{locations,taxonomy,company}.ts.
+//
+// company-slug: + company-similar: were added in #2715 — a company
+// rename / industry change otherwise leaves /company/<slug> stale up to
+// the 10-minute company-slug TTL. The posting-derived caches
+// (company-top-locs:, company-locs-grouped:, company-postings:) key off
+// job_posting data, which a CSV sync doesn't touch, so they're left to
+// their TTLs.
 const TYPEAHEAD_PREFIXES = [
   "loc-suggest:",
   "occ-suggest:",
   "sen-suggest:",
   "tech-suggest:",
   "company-suggest:",
+  "company-slug:",
+  "company-similar:",
 ] as const;
 
 /**
  * POST /api/internal/invalidate-typeahead
  *
  * Called by the crawler after `sync_typesense` to drop stale typeahead
- * suggestions across all locales. Authenticated via a bearer token shared
- * out-of-band (`INTERNAL_REVALIDATE_TOKEN` env var on both sides).
+ * suggestions and company-detail caches across all locales (see the
+ * `TYPEAHEAD_PREFIXES` list for the full scope — kept under the original
+ * route name so the crawler caller doesn't need a URL change).
+ * Authenticated via a bearer token shared out-of-band
+ * (`INTERNAL_REVALIDATE_TOKEN` env var on both sides).
  *
  * Returns 200 on success with `{ ok: true, deleted: { <prefix>: <n> } }`.
  * Returns 401 if the bearer token is missing or wrong.


### PR DESCRIPTION
## Summary

Follow-up to #2692. After a `crawler sync` that renames a company, edits its industry, or otherwise mutates the row, `/company/<slug>` was stale up to 10 minutes (the `company-slug:` TTL), and the same-industry peer strip up to an hour (the unfiltered `company-similar:` TTL).

Adds `company-slug:` and `company-similar:` to the closed `TYPEAHEAD_PREFIXES` list in `/api/internal/invalidate-typeahead`. Kept under the original route name so the crawler caller (`notify_invalidate.py`, `WEB_INVALIDATE_URL` env, `crawler invalidate-typeahead` CLI) doesn't need a URL change — i.e. no crawler / VERSION bump.

The other company-* caches (`company-top-locs:`, `company-locs-grouped:`, `company-postings:`) key off `job_posting` data, which a CSV sync doesn't touch, so they're left to their TTLs (300-600s).

## Test plan

- [x] `npx vitest run app/api/internal/invalidate-typeahead/route.test.ts` — 6 tests pass (5 existing + 1 new regression case)
- [x] Existing prefix-list test updated for the expanded list
- [x] New `sweeps company-detail caches` test asserts both new prefixes are swept and the per-prefix counts are propagated to the response body

🤖 Generated with [Claude Code](https://claude.com/claude-code)