### PR TITLE
feat(jobseek): per-claim KV table for named configs

### DIFF
--- a/apps/web/drizzle/0074_add_murmur_claim_kv.sql
+++ b/apps/web/drizzle/0074_add_murmur_claim_kv.sql
@@ -1,0 +1,11 @@
+-- Per-claim KV table for jobseek's named-config state (jobseek#2757).
+CREATE TABLE IF NOT EXISTS "murmur_claim_kv" (
+  "claim_token" text NOT NULL,
+  "name" text NOT NULL,
+  "value" jsonb NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY ("claim_token", "name")
+);
+CREATE INDEX IF NOT EXISTS "murmur_claim_kv_token_idx"
+  ON "murmur_claim_kv" ("claim_token");

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -814,3 +814,24 @@ export const watchlistCompany = pgTable(
   ],
 );
 
+// ── Murmur per-claim KV (named-config state, jobseek#2757) ───────────
+
+export const murmurClaimKv = pgTable(
+  "murmur_claim_kv",
+  {
+    claimToken: text("claim_token").notNull(),
+    name: text("name").notNull(),
+    value: jsonb("value").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.claimToken, table.name] }),
+    index("murmur_claim_kv_token_idx").on(table.claimToken),
+  ],
+);
+

--- a/apps/web/src/lib/murmur/claim-kv.test.ts
+++ b/apps/web/src/lib/murmur/claim-kv.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Tests for claim-kv.ts.
+ *
+ * The repo convention (see lib/actions/__tests__/bootstrap.test.ts) is to
+ * mock `@/db` rather than spin up a live Postgres. We mirror that pattern,
+ * but to faithfully exercise the verification list from jobseek#2757 we
+ * back the mock with an in-memory store that respects the table's
+ * `(claim_token, name)` primary key and the UPSERT semantics promised by
+ * the production module.
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+interface Row {
+  claim_token: string;
+  name: string;
+  value: unknown;
+  created_at: Date;
+  updated_at: Date;
+}
+
+// Keyed by `${claim_token}\x00${name}` to match the composite PK.
+const store = new Map<string, Row>();
+const k = (token: string, name: string) => `${token}\x00${name}`;
+
+interface FakeQuery {
+  claim_token?: string;
+  name?: string;
+  value?: unknown;
+  op: "select" | "insert" | "delete";
+  fields?: "value" | "name+value";
+  conflictUpsert?: boolean;
+}
+
+// Reset between tests so each case starts from a clean store.
+beforeEach(() => {
+  store.clear();
+});
+
+// The mock parses the chained Drizzle builder into an intent object,
+// then runs it against the in-memory store at await time.
+vi.mock("@/db", () => {
+  function execute(q: FakeQuery): Promise<unknown> {
+    return new Promise((resolve) => {
+      // Microtask delay so concurrent callers genuinely interleave.
+      queueMicrotask(() => {
+        if (q.op === "select") {
+          const out: Array<Record<string, unknown>> = [];
+          for (const row of store.values()) {
+            if (q.claim_token !== undefined && row.claim_token !== q.claim_token) continue;
+            if (q.name !== undefined && row.name !== q.name) continue;
+            if (q.fields === "value") out.push({ value: row.value });
+            else out.push({ name: row.name, value: row.value });
+          }
+          resolve(out);
+          return;
+        }
+        if (q.op === "insert") {
+          const key = k(q.claim_token!, q.name!);
+          const now = new Date();
+          const existing = store.get(key);
+          if (existing && q.conflictUpsert) {
+            existing.value = q.value;
+            existing.updated_at = now;
+          } else if (!existing) {
+            store.set(key, {
+              claim_token: q.claim_token!,
+              name: q.name!,
+              value: q.value,
+              created_at: now,
+              updated_at: now,
+            });
+          }
+          // If existing && !conflictUpsert, a real PG would throw. The
+          // production module always sets conflictUpsert=true, so this
+          // branch is unreachable from claim-kv.ts.
+          resolve(undefined);
+          return;
+        }
+        if (q.op === "delete") {
+          for (const [key, row] of store.entries()) {
+            if (q.claim_token !== undefined && row.claim_token !== q.claim_token) continue;
+            store.delete(key);
+          }
+          resolve(undefined);
+          return;
+        }
+        resolve(undefined);
+      });
+    });
+  }
+
+  // Drizzle builders under test:
+  // - select({...}).from(table).where(and(eq(claim_token,t), eq(name,n))).limit(1)
+  // - select({name,value}).from(table).where(eq(claim_token,t))
+  // - insert(table).values({...}).onConflictDoUpdate({target:[claim_token,name], set:{...}})
+  // - delete(table).where(eq(claim_token,t))
+  //
+  // Our condition objects are tagged so the mock can introspect them.
+  const selectBuilder = (fieldShape: "value" | "name+value") => ({
+    from: () => ({
+      where: (cond: { token?: string; name?: string }) => {
+        const queryTail = {
+          claim_token: cond.token,
+          name: cond.name,
+          op: "select" as const,
+          fields: fieldShape,
+        };
+        const promise = execute(queryTail);
+        return Object.assign(promise, {
+          limit: () => execute(queryTail),
+        });
+      },
+    }),
+  });
+
+  const db = {
+    select: (shape: { value?: unknown; name?: unknown }) => {
+      const fieldShape: "value" | "name+value" =
+        "name" in shape ? "name+value" : "value";
+      return selectBuilder(fieldShape);
+    },
+    insert: () => ({
+      values: (v: { claimToken: string; name: string; value: unknown }) => {
+        const onConflictDoUpdate = (_args: unknown) =>
+          execute({
+            op: "insert",
+            claim_token: v.claimToken,
+            name: v.name,
+            value: v.value,
+            conflictUpsert: true,
+          });
+        const insertPromise = execute({
+          op: "insert",
+          claim_token: v.claimToken,
+          name: v.name,
+          value: v.value,
+          conflictUpsert: false,
+        });
+        return Object.assign(insertPromise, { onConflictDoUpdate });
+      },
+    }),
+    delete: () => ({
+      where: (cond: { token?: string }) =>
+        execute({ op: "delete", claim_token: cond.token }),
+    }),
+  };
+
+  return { db };
+});
+
+// drizzle-orm helpers: the real `eq`/`and` build SQL operator nodes.
+// Our mock doesn't run real SQL, so we model them as plain objects that
+// the fake builder can introspect.
+vi.mock("drizzle-orm", () => {
+  // `eq` produces a tagged node whose role depends on context: when nested
+  // inside `and(...)`, the `_col`/`_val` fields are aggregated; when used
+  // bare in `.where(eq(...))`, the node also carries `token`/`name`
+  // shortcut fields so the fake builder can read them directly.
+  const eq = (col: { _name: string }, val: unknown) => {
+    const node: {
+      _col: string;
+      _val: unknown;
+      token?: string;
+      name?: string;
+    } = { _col: col._name, _val: val };
+    if (col._name === "claim_token") node.token = val as string;
+    if (col._name === "name") node.name = val as string;
+    return node;
+  };
+
+  const and = (
+    ...nodes: Array<{ _col: string; _val: unknown }>
+  ) => {
+    const out: { token?: string; name?: string } = {};
+    for (const n of nodes) {
+      if (n._col === "claim_token") out.token = n._val as string;
+      if (n._col === "name") out.name = n._val as string;
+    }
+    return out;
+  };
+
+  return { eq, and };
+});
+
+// The schema columns are referenced by name; our drizzle-orm mock keys
+// off `_name`, so expose just enough for the production module to compile.
+vi.mock("@/db/schema", () => ({
+  murmurClaimKv: {
+    claimToken: { _name: "claim_token" },
+    name: { _name: "name" },
+    value: { _name: "value" },
+  },
+}));
+
+// Now import the module under test (after the mocks are registered).
+import { getKV, setKV, listKV, clearKV } from "./claim-kv";
+
+describe("claim-kv", () => {
+  it("setKV then getKV returns the same value", async () => {
+    await setKV("tok-1", "config-a", { foo: "bar", n: 42 });
+    const got = await getKV("tok-1", "config-a");
+    expect(got).toEqual({ foo: "bar", n: 42 });
+  });
+
+  it("setKV overwrite under same (token, name) updates updated_at and overwrites value (UPSERT)", async () => {
+    await setKV("tok-2", "config-a", "first");
+    const before = store.get(k("tok-2", "config-a"))!;
+    const beforeUpdated = before.updated_at;
+
+    // Force a measurable wall-clock gap so the timestamp comparison is
+    // unambiguous even on fast machines.
+    await new Promise((r) => setTimeout(r, 5));
+
+    await setKV("tok-2", "config-a", "second");
+
+    const after = store.get(k("tok-2", "config-a"))!;
+    expect(after.value).toBe("second");
+    expect(after.updated_at.getTime()).toBeGreaterThan(beforeUpdated.getTime());
+    // created_at must NOT change on UPSERT.
+    expect(after.created_at.getTime()).toBe(before.created_at.getTime());
+
+    // And the public getter reflects the overwrite.
+    expect(await getKV("tok-2", "config-a")).toBe("second");
+  });
+
+  it("getKV for unknown token/name returns null", async () => {
+    expect(await getKV("missing-token", "missing-name")).toBeNull();
+    await setKV("tok-3", "x", 1);
+    expect(await getKV("tok-3", "y")).toBeNull();
+    expect(await getKV("other-token", "x")).toBeNull();
+  });
+
+  it("listKV returns all (name -> value) pairs for a given token", async () => {
+    await setKV("tok-4", "a", 1);
+    await setKV("tok-4", "b", { nested: true });
+    await setKV("tok-4", "c", "three");
+    // Different token must NOT be included.
+    await setKV("tok-other", "a", "noise");
+
+    const all = await listKV("tok-4");
+    expect(all).toEqual({ a: 1, b: { nested: true }, c: "three" });
+  });
+
+  it("clearKV removes all rows for a token; other tokens unaffected", async () => {
+    await setKV("tok-5", "a", 1);
+    await setKV("tok-5", "b", 2);
+    await setKV("tok-keep", "a", "keep-me");
+
+    await clearKV("tok-5");
+
+    expect(await listKV("tok-5")).toEqual({});
+    expect(await getKV("tok-5", "a")).toBeNull();
+    expect(await getKV("tok-keep", "a")).toBe("keep-me");
+  });
+
+  it("concurrent setKV calls under same (token, name) last-write-wins (no error)", async () => {
+    // Fire 50 setKV calls in parallel against the same key; the resolution
+    // order is non-deterministic from the caller's POV, but the contract
+    // is: no throws, exactly one row remains, the row's value is one of
+    // the inputs.
+    const inputs = Array.from({ length: 50 }, (_, i) => `v${i}`);
+    await expect(
+      Promise.all(inputs.map((v) => setKV("tok-6", "shared", v))),
+    ).resolves.toBeDefined();
+
+    const final = (await getKV("tok-6", "shared")) as string;
+    expect(inputs).toContain(final);
+
+    // Exactly one row, not 50.
+    let count = 0;
+    for (const row of store.values()) {
+      if (row.claim_token === "tok-6" && row.name === "shared") count++;
+    }
+    expect(count).toBe(1);
+  });
+
+  it("stores JSON-serializable values without extra encoding (jsonb round-trip)", async () => {
+    const cases: unknown[] = [
+      null,
+      true,
+      0,
+      "",
+      "hello",
+      42.5,
+      [1, 2, 3],
+      { a: { b: { c: [true, false] } } },
+    ];
+
+    for (let i = 0; i < cases.length; i++) {
+      const v = cases[i];
+      await setKV("tok-7", `case-${i}`, v);
+    }
+
+    for (let i = 0; i < cases.length; i++) {
+      const round = await getKV("tok-7", `case-${i}`);
+      // jsonb should preserve identity for these JSON-safe types — the
+      // module must not wrap or stringify them.
+      expect(round).toEqual(cases[i]);
+    }
+  });
+});

--- a/apps/web/src/lib/murmur/claim-kv.ts
+++ b/apps/web/src/lib/murmur/claim-kv.ts
@@ -12,6 +12,10 @@
  * @see colophon-group/jobseek#2757
  */
 
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db";
+import { murmurClaimKv } from "@/db/schema";
+
 /**
  * Fetch a single named value for a claim.
  *
@@ -21,18 +25,28 @@
  *   this `(claim_token, name)` pair.
  */
 export async function getKV(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   claim_token: string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   name: string,
 ): Promise<unknown | null> {
-  throw new Error("not implemented");
+  const rows = await db
+    .select({ value: murmurClaimKv.value })
+    .from(murmurClaimKv)
+    .where(
+      and(
+        eq(murmurClaimKv.claimToken, claim_token),
+        eq(murmurClaimKv.name, name),
+      ),
+    )
+    .limit(1);
+
+  if (rows.length === 0) return null;
+  return rows[0]!.value as unknown;
 }
 
 /**
  * Store a named value for a claim. Performs an UPSERT keyed on
  * `(claim_token, name)`: if a row already exists it is overwritten and
- * `updated_at` is bumped to the current transaction time.
+ * `updated_at` is bumped to the current time.
  *
  * Concurrent writes under the same `(claim_token, name)` are last-write-
  * wins via Postgres' row-level locking — the function never throws on
@@ -43,14 +57,24 @@ export async function getKV(
  * @param value - Any JSON-serializable value.
  */
 export async function setKV(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   claim_token: string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   name: string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   value: unknown,
 ): Promise<void> {
-  throw new Error("not implemented");
+  await db
+    .insert(murmurClaimKv)
+    .values({
+      claimToken: claim_token,
+      name,
+      value: value as never,
+    })
+    .onConflictDoUpdate({
+      target: [murmurClaimKv.claimToken, murmurClaimKv.name],
+      set: {
+        value: value as never,
+        updatedAt: new Date(),
+      },
+    });
 }
 
 /**
@@ -61,10 +85,18 @@ export async function setKV(
  *   the token has no rows.
  */
 export async function listKV(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   claim_token: string,
 ): Promise<Record<string, unknown>> {
-  throw new Error("not implemented");
+  const rows = await db
+    .select({ name: murmurClaimKv.name, value: murmurClaimKv.value })
+    .from(murmurClaimKv)
+    .where(eq(murmurClaimKv.claimToken, claim_token));
+
+  const out: Record<string, unknown> = {};
+  for (const row of rows) {
+    out[row.name] = row.value as unknown;
+  }
+  return out;
 }
 
 /**
@@ -73,9 +105,8 @@ export async function listKV(
  *
  * @param claim_token - The opaque token identifying the claim row.
  */
-export async function clearKV(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  claim_token: string,
-): Promise<void> {
-  throw new Error("not implemented");
+export async function clearKV(claim_token: string): Promise<void> {
+  await db
+    .delete(murmurClaimKv)
+    .where(eq(murmurClaimKv.claimToken, claim_token));
 }

--- a/apps/web/src/lib/murmur/claim-kv.ts
+++ b/apps/web/src/lib/murmur/claim-kv.ts
@@ -1,0 +1,81 @@
+/**
+ * Per-claim KV store for jobseek's named-config state.
+ *
+ * Backed by the Postgres table `murmur_claim_kv`, keyed on
+ * `(claim_token, name)`. All values must be JSON-serializable; they are
+ * stored in a `jsonb` column so they round-trip through Drizzle without any
+ * additional encoding.
+ *
+ * Only this module is permitted to issue queries against
+ * `murmur_claim_kv`. All callers must go through these four functions.
+ *
+ * @see colophon-group/jobseek#2757
+ */
+
+/**
+ * Fetch a single named value for a claim.
+ *
+ * @param claim_token - The opaque token identifying the claim row.
+ * @param name - The named-config slot.
+ * @returns The previously-stored value, or `null` if no row exists for
+ *   this `(claim_token, name)` pair.
+ */
+export async function getKV(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  claim_token: string,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  name: string,
+): Promise<unknown | null> {
+  throw new Error("not implemented");
+}
+
+/**
+ * Store a named value for a claim. Performs an UPSERT keyed on
+ * `(claim_token, name)`: if a row already exists it is overwritten and
+ * `updated_at` is bumped to the current transaction time.
+ *
+ * Concurrent writes under the same `(claim_token, name)` are last-write-
+ * wins via Postgres' row-level locking — the function never throws on
+ * conflict.
+ *
+ * @param claim_token - The opaque token identifying the claim row.
+ * @param name - The named-config slot.
+ * @param value - Any JSON-serializable value.
+ */
+export async function setKV(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  claim_token: string,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  name: string,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  value: unknown,
+): Promise<void> {
+  throw new Error("not implemented");
+}
+
+/**
+ * List all named values for a claim.
+ *
+ * @param claim_token - The opaque token identifying the claim row.
+ * @returns An object mapping each `name` to its stored value. Empty when
+ *   the token has no rows.
+ */
+export async function listKV(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  claim_token: string,
+): Promise<Record<string, unknown>> {
+  throw new Error("not implemented");
+}
+
+/**
+ * Remove every named value belonging to a claim. Other claims are
+ * unaffected.
+ *
+ * @param claim_token - The opaque token identifying the claim row.
+ */
+export async function clearKV(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  claim_token: string,
+): Promise<void> {
+  throw new Error("not implemented");
+}


### PR DESCRIPTION
## Summary
Adds the `murmur_claim_kv` Postgres table (composite PK `(claim_token, name)`, jsonb value, `created_at` / `updated_at` timestamps) and a TS module at `apps/web/src/lib/murmur/claim-kv.ts` exposing `getKV` / `setKV` / `listKV` / `clearKV` for jobseek's named-config state. `setKV` is an UPSERT keyed on the composite PK; concurrent writers are last-write-wins via Postgres row-level locking.

## Related issue
Closes colophon-group/jobseek#2757

## Files changed (high-level)
- `apps/web/src/db/schema.ts` — adds the `murmurClaimKv` Drizzle table definition (composite PK + `murmur_claim_kv_token_idx` index).
- `apps/web/drizzle/0074_add_murmur_claim_kv.sql` — hand-written migration matching the issue's DDL exactly. Hand-written because the existing drizzle journal is severely out-of-sync with the live schema (snapshots stop at 0028, hand-written migrations run to 0073) and `drizzle-kit generate` prompts interactively for hundreds of unrelated phantom diffs; recent migrations 0072 and 0073 were also hand-written for the same reason. Reconciling the journal is out-of-scope for this issue and would change the diff for every column in the repo.
- `apps/web/src/lib/murmur/claim-kv.ts` — public surface. Imports the shared `db` from `@/db` and the `murmurClaimKv` table from `@/db/schema` (no naked SQL, no separate pool).
- `apps/web/src/lib/murmur/claim-kv.test.ts` — seven verification tests using the repo's existing mock-`@/db` pattern (see `lib/actions/__tests__/bootstrap.test.ts`), backed by an in-memory store that respects the composite PK and UPSERT semantics.

## Verification (from the issue)
- [x] setKV then getKV returns the same value
- [x] setKV overwrite under same (token, name) updates updated_at and overwrites value (UPSERT)
- [x] getKV for unknown token/name returns null
- [x] listKV returns all (name → value) pairs for a given token
- [x] clearKV removes all rows for a token; other tokens unaffected
- [x] Concurrent setKV calls under same (token, name) last-write-wins (no error)
- [x] All values are JSON-serializable (jsonb round-trip, no extra encoding)

## Manual checks run locally
- `pnpm test src/lib/murmur/claim-kv.test.ts` ✓ (7/7 pass)
- `pnpm test` ✓ (276 pass; 1 pre-existing failure in `app/mcp/route.test.ts` from `@jseek/mcp-server` not built locally — unchanged from origin/main and unrelated to this PR)
- `pnpm lint` ✓ (zero warnings)
- `npx tsc --noEmit` ✓ on changed files (3 pre-existing errors elsewhere, also present on origin/main)

## Notes for reviewer
- The TS module is the **only** caller permitted to touch `murmur_claim_kv`. Greppable: `grep -rn "murmur_claim_kv\|murmurClaimKv" apps/` shows only `schema.ts`, `claim-kv.ts`, the migration, and the test file.
- UPSERT is implemented with Drizzle's `onConflictDoUpdate({ target: [claim_token, name], set: { value, updated_at } })`. The migration sets `created_at` / `updated_at` to `NOT NULL DEFAULT now()` per the spec; `created_at` is preserved on conflict (only `updated_at` is bumped).
- The concurrent-writer test fires 50 parallel setKV calls and asserts (a) no throws, (b) exactly one row remains, (c) the surviving value is one of the inputs — modeling Postgres' row-level locking on the composite PK in the in-memory mock.
- `drizzle-kit generate` was attempted first (per orchestrator note) but is unusable against this repo's drifted snapshot; the hand-written migration matches the convention of recent migrations 0072 / 0073 and matches the issue's DDL byte-for-byte (modulo `IF NOT EXISTS` for re-runnability).