### PR TITLE
feat(jobseek): SSRF allowlist with DNS-rebinding protection for agent URLs

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,8 @@
     "optimize:svg": "svgo public/*.svg --multipass",
     "screenshots": "tsx script/capture-screenshots.ts",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "grep:validateurl-boundary": "bash scripts/grep-validateurl-boundary.sh"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.888.0",

--- a/apps/web/scripts/grep-validateurl-boundary.sh
+++ b/apps/web/scripts/grep-validateurl-boundary.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# grep-validateurl-boundary.sh
+#
+# Asserts the caller boundary for `validateUrl` (and `safeFetch`) from
+# `apps/web/src/lib/murmur/ssrf.ts`: those names must only be imported
+# from
+#   - apps/web/app/api/**/route.ts          (route handlers)
+#   - apps/web/src/lib/murmur/ssrf.ts       (defining module — re-exports)
+#   - apps/web/src/lib/murmur/ssrf.test.ts  (its own test)
+#
+# Anywhere else is a boundary violation: SSRF validation must happen at
+# the request boundary so the structured `url_*` error code can be
+# surfaced to the agent in the response envelope. Pushing it deeper
+# means individual call sites won't be checked.
+#
+# Usage:  bash apps/web/scripts/grep-validateurl-boundary.sh
+# Exit:   0 if clean, 1 if any unauthorised import is found.
+#
+# @see colophon-group/jobseek#2758
+
+set -euo pipefail
+
+# Resolve repo root from this script's location so the gate works the
+# same whether invoked from CI, lefthook, or `pnpm grep:*`.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WEB_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$WEB_ROOT/../.." && pwd)"
+
+cd "$REPO_ROOT"
+
+# Files that import `validateUrl` or `safeFetch` from the ssrf module.
+# Two patterns: relative `./ssrf` or `@/lib/murmur/ssrf`.
+matches=$(
+  grep -rEn \
+    --include='*.ts' --include='*.tsx' \
+    "from ['\"](.*lib/murmur/ssrf|\\./ssrf|\\.\\./ssrf|@/lib/murmur/ssrf)['\"]" \
+    apps/web 2>/dev/null || true
+)
+
+violations=""
+while IFS= read -r line; do
+  [ -z "$line" ] && continue
+  file="${line%%:*}"
+  case "$file" in
+    apps/web/app/api/*/route.ts) ;;
+    apps/web/app/api/*/*/route.ts) ;;
+    apps/web/app/api/*/*/*/route.ts) ;;
+    apps/web/app/api/*/*/*/*/route.ts) ;;
+    apps/web/src/lib/murmur/ssrf.ts) ;;
+    apps/web/src/lib/murmur/ssrf.test.ts) ;;
+    *)
+      violations+="$line"$'\n'
+      ;;
+  esac
+done <<< "$matches"
+
+if [ -n "$violations" ]; then
+  echo "validateUrl/safeFetch must only be imported at route boundaries." >&2
+  echo "Offending imports:" >&2
+  printf '%s' "$violations" >&2
+  exit 1
+fi
+
+echo "grep-validateurl-boundary: clean."

--- a/apps/web/src/lib/murmur/ssrf.test.ts
+++ b/apps/web/src/lib/murmur/ssrf.test.ts
@@ -1,15 +1,25 @@
 /**
  * Tests for ssrf.ts.
  *
- * No real network access; all DNS calls are intercepted via a mocked
- * `node:dns/promises`. Each test queues the (address, family) tuples the
+ * No real network access on the unit suites; all DNS calls are
+ * intercepted via a mocked `node:dns/promises`, and `node:http` /
+ * `node:https` `request` are stubbed so we can assert the request
+ * options (especially `lookup`, `servername`, `hostname`) without
+ * opening a socket. Each test queues the (address, family) tuples the
  * resolver should return, in order. The DNS-rebinding case queues two
  * different answers so the second lookup observably differs from the
  * first.
  *
+ * The bottom suite spins up a real loopback `http.Server` to verify
+ * end-to-end that the captured IP is used for the connection while the
+ * original hostname is preserved on the request line / Host header.
+ *
  * @see colophon-group/jobseek#2758
  */
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import http from "node:http";
+import { Readable } from "node:stream";
+import type { AddressInfo } from "node:net";
 
 // Queue of DNS answers consumed in order by the mocked `lookup`.
 // Stored on globalThis so the hoisted `vi.mock` factory can see them
@@ -67,6 +77,7 @@ import {
   isPrivateIp,
   HOST_ALLOWLIST,
   safeFetch,
+  createPinnedLookup,
 } from "./ssrf";
 
 describe("HOST_ALLOWLIST", () => {
@@ -152,6 +163,27 @@ describe("isPrivateIp", () => {
   it("classifies unspecified addresses as private", () => {
     expect(isPrivateIp("0.0.0.0")).toBe(true);
     expect(isPrivateIp("::")).toBe(true);
+  });
+
+  it("classifies CGNAT (100.64/10) at both boundaries as private", () => {
+    // Lower edge of 100.64.0.0/10
+    expect(isPrivateIp("100.64.0.0")).toBe(true);
+    expect(isPrivateIp("100.64.0.1")).toBe(true);
+    // Upper edge: /10 ends at 100.127.255.255
+    expect(isPrivateIp("100.127.255.255")).toBe(true);
+    // Just outside on either side — must still be public.
+    expect(isPrivateIp("100.63.255.255")).toBe(false);
+    expect(isPrivateIp("100.128.0.0")).toBe(false);
+  });
+
+  it("treats short-form `::xxxx` IPv6 addresses as private (fail-closed)", () => {
+    // `::abcd` is shorthand for 0:0:0:0:0:0:0:abcd — all zero groups
+    // except the last. That sits inside the legacy `::/96`
+    // (IPv4-compatible, deprecated) / `::/8` reserved space. We have
+    // no business reaching such addresses; the implementation must
+    // fail closed on them.
+    expect(isPrivateIp("::abcd")).toBe(true);
+    expect(isPrivateIp("::ff")).toBe(true);
   });
 
   it("treats public addresses as public", () => {
@@ -252,42 +284,226 @@ describe("validateUrl — IP filter", () => {
   });
 });
 
-describe("safeFetch — DNS rebinding scenario", () => {
-  // Stub global fetch so safeFetch never actually opens a socket on the
-  // happy path. It records the URL it was asked to fetch — the assertion
-  // we care about is that the URL is the captured (post-validation) IP,
-  // not the hostname (which a re-resolution could redirect).
-  const originalFetch = globalThis.fetch;
-  let lastFetchedUrl: string | URL | undefined;
+describe("createPinnedLookup", () => {
+  // The pinned lookup is the security-critical hinge: it must return
+  // the captured IP for the validated hostname and refuse anything
+  // else. Test it directly so we don't depend on the surrounding
+  // request stack to surface the right behaviour.
+
+  it("returns the captured (ip, family) tuple for the expected hostname", () => {
+    const lookup = createPinnedLookup("acme.greenhouse.io", "104.19.20.21", 4);
+    let result: { err: unknown; address: unknown; family: unknown } | null = null;
+    lookup("acme.greenhouse.io", { family: 0, all: false }, (err, address, family) => {
+      result = { err, address, family };
+    });
+    expect(result).not.toBeNull();
+    expect(result!.err).toBeNull();
+    expect(result!.address).toBe("104.19.20.21");
+    expect(result!.family).toBe(4);
+  });
+
+  it("matches the expected hostname case-insensitively", () => {
+    const lookup = createPinnedLookup("Acme.Greenhouse.IO", "104.19.20.21", 4);
+    let result: { err: unknown; address: unknown } | null = null;
+    lookup("ACME.greenhouse.io", { family: 0, all: false }, (err, address) => {
+      result = { err, address };
+    });
+    expect(result!.err).toBeNull();
+    expect(result!.address).toBe("104.19.20.21");
+  });
+
+  it("propagates IPv6 family unchanged", () => {
+    const lookup = createPinnedLookup("acme.greenhouse.io", "2606:4700::1111", 6);
+    let captured: { address: unknown; family: unknown } | null = null;
+    lookup("acme.greenhouse.io", { family: 0, all: false }, (err, address, family) => {
+      if (err) throw err;
+      captured = { address, family };
+    });
+    expect(captured!.address).toBe("2606:4700::1111");
+    expect(captured!.family).toBe(6);
+  });
+
+  it("fails closed with ENOTFOUND for any other hostname", () => {
+    const lookup = createPinnedLookup("acme.greenhouse.io", "104.19.20.21", 4);
+    let err: NodeJS.ErrnoException | null = null;
+    lookup("evil.example.com", { family: 0, all: false }, (e) => {
+      err = e;
+    });
+    expect(err).not.toBeNull();
+    expect(err!.code).toBe("ENOTFOUND");
+  });
+
+  it("fails closed for a sibling subdomain not equal to the expected host", () => {
+    const lookup = createPinnedLookup("acme.greenhouse.io", "104.19.20.21", 4);
+    let err: NodeJS.ErrnoException | null = null;
+    lookup("other.greenhouse.io", { family: 0, all: false }, (e) => {
+      err = e;
+    });
+    expect(err).not.toBeNull();
+    expect(err!.code).toBe("ENOTFOUND");
+  });
+
+  it("returns an array shape when called with `all: true` (Node's net.connect mode)", () => {
+    // Node's modern `net.connect` calls `lookup` with `all: true`,
+    // which expects the callback to receive `(err, addresses[])`. The
+    // pinned lookup must support this calling convention or the
+    // connection layer rejects with "Invalid IP address: undefined".
+    const lookup = createPinnedLookup("acme.greenhouse.io", "104.19.20.21", 4);
+    let captured:
+      | { err: NodeJS.ErrnoException | null; addresses: { address: string; family: number }[] }
+      | null = null;
+    lookup(
+      "acme.greenhouse.io",
+      { family: 0, all: true },
+      (err, addressOrAddresses) => {
+        captured = {
+          err: err as NodeJS.ErrnoException | null,
+          addresses: addressOrAddresses as { address: string; family: number }[],
+        };
+      },
+    );
+    expect(captured!.err).toBeNull();
+    expect(Array.isArray(captured!.addresses)).toBe(true);
+    expect(captured!.addresses).toEqual([{ address: "104.19.20.21", family: 4 }]);
+  });
+
+  it("returns an empty addresses array on error when called with `all: true`", () => {
+    const lookup = createPinnedLookup("acme.greenhouse.io", "104.19.20.21", 4);
+    let captured:
+      | { err: NodeJS.ErrnoException | null; addresses: unknown }
+      | null = null;
+    lookup("evil.com", { family: 0, all: true }, (err, addressOrAddresses) => {
+      captured = {
+        err: err as NodeJS.ErrnoException | null,
+        addresses: addressOrAddresses,
+      };
+    });
+    expect(captured!.err).not.toBeNull();
+    expect((captured!.err as NodeJS.ErrnoException).code).toBe("ENOTFOUND");
+    expect(Array.isArray(captured!.addresses)).toBe(true);
+    expect(captured!.addresses).toEqual([]);
+  });
+});
+
+// Capture for the mocked node:https.request call; populated by the
+// vi.mock factory below. The mocked module is hoisted, so we put the
+// shared state on globalThis to avoid the "top-level variables in
+// factory" rule.
+type CapturedRequestOptions = {
+  protocol?: string;
+  hostname?: string;
+  servername?: string;
+  port?: number;
+  method?: string;
+  path?: string;
+  headers?: Record<string, string>;
+  lookup?: (
+    hostname: string,
+    opts: { all?: boolean },
+    cb: (
+      err: NodeJS.ErrnoException | null,
+      addressOrAddresses: string | { address: string; family: number }[],
+      family?: number,
+    ) => void,
+  ) => void;
+};
+
+interface HttpsMockState {
+  callCount: number;
+  lastOptions: CapturedRequestOptions | null;
+}
+
+declare global {
+  var __ssrfHttpsMock: HttpsMockState | undefined;
+}
+
+globalThis.__ssrfHttpsMock = { callCount: 0, lastOptions: null };
+
+vi.mock("node:https", async () => {
+  const actual = await vi.importActual<typeof import("node:https")>("node:https");
+  return {
+    ...actual,
+    default: actual,
+    request: ((opts: CapturedRequestOptions, cb?: (res: unknown) => void) => {
+      const state = globalThis.__ssrfHttpsMock!;
+      state.callCount += 1;
+      state.lastOptions = opts;
+      const fakeRes = Object.assign(
+        new Readable({
+          read() {
+            this.push("ok");
+            this.push(null);
+          },
+        }),
+        {
+          statusCode: 200,
+          statusMessage: "OK",
+          headers: { "content-type": "text/plain" },
+        },
+      );
+      queueMicrotask(() => cb?.(fakeRes));
+      return {
+        on: () => undefined,
+        write: () => undefined,
+        end: () => undefined,
+      };
+    }) as unknown as typeof actual.request,
+  };
+});
+
+const httpsState = (): HttpsMockState => globalThis.__ssrfHttpsMock!;
+
+describe("safeFetch — request shape (mocked node:https)", () => {
+  // The mocked `node:https.request` records the options safeFetch
+  // passes so we can assert the TLS-correctness invariant: SNI uses
+  // the original hostname, the request line uses the original
+  // hostname, and the connection-time `lookup` is a pinned function
+  // that returns the captured IP only for that hostname.
   beforeEach(() => {
-    lastFetchedUrl = undefined;
-    globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
-      lastFetchedUrl = input instanceof Request ? input.url : input;
-      return new Response("ok", { status: 200 });
-    }) as typeof fetch;
-  });
-  // Restore after each test so the global fetch is back to its original
-  // value before subsequent suites (defensive — no other suite uses
-  // fetch, but the cleanup pattern is cheap).
-  afterEach(() => {
-    globalThis.fetch = originalFetch;
+    httpsState().callCount = 0;
+    httpsState().lastOptions = null;
   });
 
-  it("first call: pins the connection to the resolved (public) IP, not the hostname", async () => {
+  it("dispatches against the original hostname (not the resolved IP) and pins via `lookup`", async () => {
     dnsQueue.push({ address: "104.19.20.21", family: 4 });
-    const r = await safeFetch("https://acme.greenhouse.io/x");
+    const r = await safeFetch("https://acme.greenhouse.io/x?y=1");
     expect(r.status).toBe(200);
-    // The captured IP must be in the URL passed to fetch — that's the
-    // proof of pinning. A second DNS lookup at connect time has nothing
-    // to attack because the URL no longer references the hostname.
-    const fetched = String(lastFetchedUrl);
-    expect(fetched).toContain("104.19.20.21");
-    expect(fetched).not.toContain("acme.greenhouse.io");
+
+    const opts = httpsState().lastOptions;
+    expect(opts).not.toBeNull();
+    // SNI / request-line hostname must be the original, not the IP —
+    // this is the TLS-correctness fix from the review.
+    expect(opts!.hostname).toBe("acme.greenhouse.io");
+    expect(opts!.servername).toBe("acme.greenhouse.io");
+    expect(opts!.path).toBe("/x?y=1");
+    expect(opts!.protocol).toBe("https:");
+    expect(opts!.port).toBe(443);
+
+    // Verify the pinned lookup is wired correctly: invoking it with
+    // the expected hostname returns the captured IP; anything else
+    // fails closed.
+    let okAddr = "";
+    let okFamily: number | undefined;
+    opts!.lookup!("acme.greenhouse.io", { all: false }, (err, address, family) => {
+      if (err) throw err as Error;
+      okAddr = address as string;
+      okFamily = family;
+    });
+    expect(okAddr).toBe("104.19.20.21");
+    expect(okFamily).toBe(4);
+
+    let evilErr: NodeJS.ErrnoException | null = null;
+    opts!.lookup!("evil.com", { all: false }, (e) => {
+      evilErr = e as NodeJS.ErrnoException;
+    });
+    expect(evilErr).not.toBeNull();
+    expect(evilErr!.code).toBe("ENOTFOUND");
   });
 
-  it("rebind poisoning: a second lookup that resolves private is rejected, no connection opened", async () => {
-    // Simulate the post-resolution rebind: the queue now yields a
-    // private IP for the same hostname. safeFetch must fail closed.
+  it("rebind poisoning: a second resolution yielding a private IP is rejected without opening a socket", async () => {
+    // Simulate the rebind: the resolver now yields a private IP for
+    // the same hostname. safeFetch must reject before constructing a
+    // request.
     dnsQueue.push({ address: "10.0.0.5", family: 4 });
     let rebindError: { code?: string } | null = null;
     try {
@@ -297,7 +513,82 @@ describe("safeFetch — DNS rebinding scenario", () => {
     }
     expect(rebindError).not.toBeNull();
     expect(rebindError?.code).toBe("url_resolves_to_private");
-    // And critically: fetch was never invoked.
-    expect(lastFetchedUrl).toBeUndefined();
+    // And critically: the request layer was never reached.
+    expect(httpsState().callCount).toBe(0);
+  });
+});
+
+describe("safeFetch + createPinnedLookup — loopback integration", () => {
+  // End-to-end integration check (small, no TLS): stand up a real
+  // `http.Server` on 127.0.0.1, wire `createPinnedLookup` into a
+  // direct `http.request` call, and confirm the connection routed to
+  // the loopback address even though we asked for an arbitrary
+  // (non-resolved) hostname. This proves the lookup hook is honoured
+  // by Node's connection layer — the same hook safeFetch attaches.
+  //
+  // We don't drive `safeFetch` directly here because validateUrl
+  // would (correctly) refuse 127.0.0.1 as private. We're testing the
+  // lookup mechanism, not the validation pipeline.
+
+  let server: http.Server | null = null;
+  let port = 0;
+  let receivedHost: string | undefined;
+  let receivedRemoteAddr: string | undefined;
+
+  beforeEach(async () => {
+    receivedHost = undefined;
+    receivedRemoteAddr = undefined;
+    server = http.createServer((req, res) => {
+      receivedHost = req.headers.host;
+      receivedRemoteAddr = req.socket.remoteAddress ?? undefined;
+      res.statusCode = 200;
+      res.end("ok");
+    });
+    await new Promise<void>((resolve) => {
+      server!.listen(0, "127.0.0.1", resolve);
+    });
+    port = (server!.address() as AddressInfo).port;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+      server = null;
+    }
+  });
+
+  it("routes the connection to the captured 127.0.0.1 IP while the URL hostname is preserved on the wire", async () => {
+    // Pin a synthetic hostname to 127.0.0.1.
+    const lookup = createPinnedLookup("acme.greenhouse.io", "127.0.0.1", 4);
+
+    const body = await new Promise<string>((resolve, reject) => {
+      const req = http.request(
+        {
+          protocol: "http:",
+          hostname: "acme.greenhouse.io",
+          port,
+          method: "GET",
+          path: "/",
+          lookup,
+        },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on("data", (c) => chunks.push(c));
+          res.on("end", () => resolve(Buffer.concat(chunks).toString()));
+          res.on("error", reject);
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+
+    expect(body).toBe("ok");
+    // The Host header on the request line must be the original
+    // hostname (proves the IP did not leak into the URL/Host).
+    expect(receivedHost).toContain("acme.greenhouse.io");
+    // The TCP connection actually went to loopback (proves the
+    // lookup pin took effect).
+    // Node may report `::ffff:127.0.0.1` depending on platform.
+    expect(receivedRemoteAddr).toMatch(/^(::ffff:)?127\.0\.0\.1$/);
   });
 });

--- a/apps/web/src/lib/murmur/ssrf.test.ts
+++ b/apps/web/src/lib/murmur/ssrf.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Tests for ssrf.ts.
+ *
+ * No real network access; all DNS calls are intercepted via a mocked
+ * `node:dns/promises`. Each test queues the (address, family) tuples the
+ * resolver should return, in order. The DNS-rebinding case queues two
+ * different answers so the second lookup observably differs from the
+ * first.
+ *
+ * @see colophon-group/jobseek#2758
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Queue of DNS answers consumed in order by the mocked `lookup`.
+type DnsAnswer = { address: string; family: 4 | 6 };
+const dnsQueue: DnsAnswer[] = [];
+let dnsCallCount = 0;
+let dnsThrow: Error | null = null;
+
+vi.mock("node:dns/promises", () => ({
+  lookup: vi.fn(async (_hostname: string, _opts?: unknown) => {
+    dnsCallCount += 1;
+    if (dnsThrow) throw dnsThrow;
+    const answer = dnsQueue.shift();
+    if (!answer) {
+      throw Object.assign(new Error("ENOTFOUND"), { code: "ENOTFOUND" });
+    }
+    return answer;
+  }),
+}));
+
+beforeEach(() => {
+  dnsQueue.length = 0;
+  dnsCallCount = 0;
+  dnsThrow = null;
+});
+
+import {
+  validateUrl,
+  matchHostPattern,
+  isPrivateIp,
+  HOST_ALLOWLIST,
+  safeFetch,
+} from "./ssrf";
+
+describe("HOST_ALLOWLIST", () => {
+  it("includes the patterns called out by the issue", () => {
+    expect(HOST_ALLOWLIST).toEqual(
+      expect.arrayContaining([
+        "*.greenhouse.io",
+        "boards.greenhouse.io",
+        "job-boards.greenhouse.io",
+        "*.lever.co",
+        "jobs.lever.co",
+        "*.myworkdayjobs.com",
+      ]),
+    );
+  });
+});
+
+describe("matchHostPattern", () => {
+  it("matches an exact host", () => {
+    expect(matchHostPattern("boards.greenhouse.io", "boards.greenhouse.io")).toBe(true);
+  });
+
+  it("rejects a different host of the same suffix when pattern is exact", () => {
+    expect(matchHostPattern("evil.greenhouse.io", "boards.greenhouse.io")).toBe(false);
+  });
+
+  it("matches a subdomain wildcard", () => {
+    expect(matchHostPattern("acme.greenhouse.io", "*.greenhouse.io")).toBe(true);
+    expect(matchHostPattern("acme.boards.greenhouse.io", "*.greenhouse.io")).toBe(true);
+  });
+
+  it("does NOT match the bare apex on a wildcard pattern", () => {
+    expect(matchHostPattern("greenhouse.io", "*.greenhouse.io")).toBe(false);
+  });
+
+  it("does NOT match a sibling/spoofed suffix", () => {
+    expect(matchHostPattern("greenhouse.io.evil.com", "*.greenhouse.io")).toBe(false);
+    expect(matchHostPattern("notgreenhouse.io", "*.greenhouse.io")).toBe(false);
+  });
+
+  it("is case-insensitive", () => {
+    expect(matchHostPattern("Acme.Greenhouse.IO", "*.greenhouse.io")).toBe(true);
+    expect(matchHostPattern("BOARDS.GREENHOUSE.IO", "boards.greenhouse.io")).toBe(true);
+  });
+});
+
+describe("isPrivateIp", () => {
+  it("classifies loopback as private", () => {
+    expect(isPrivateIp("127.0.0.1")).toBe(true);
+    expect(isPrivateIp("127.255.255.254")).toBe(true);
+    expect(isPrivateIp("::1")).toBe(true);
+  });
+
+  it("classifies RFC1918 as private", () => {
+    expect(isPrivateIp("10.0.0.1")).toBe(true);
+    expect(isPrivateIp("172.16.0.1")).toBe(true);
+    expect(isPrivateIp("172.31.255.255")).toBe(true);
+    expect(isPrivateIp("192.168.1.1")).toBe(true);
+  });
+
+  it("does NOT classify 172.32.x as private (outside RFC1918 /12)", () => {
+    expect(isPrivateIp("172.32.0.1")).toBe(false);
+  });
+
+  it("classifies link-local as private", () => {
+    expect(isPrivateIp("169.254.0.1")).toBe(true);
+    expect(isPrivateIp("169.254.169.254")).toBe(true);
+    expect(isPrivateIp("fe80::1")).toBe(true);
+  });
+
+  it("classifies IPv6 ULA as private", () => {
+    expect(isPrivateIp("fc00::1")).toBe(true);
+    expect(isPrivateIp("fd00::1")).toBe(true);
+    expect(isPrivateIp("fdff:ffff::1")).toBe(true);
+  });
+
+  it("classifies IPv4-mapped IPv6 by the embedded v4", () => {
+    expect(isPrivateIp("::ffff:127.0.0.1")).toBe(true);
+    expect(isPrivateIp("::ffff:10.0.0.1")).toBe(true);
+    expect(isPrivateIp("::ffff:8.8.8.8")).toBe(false);
+  });
+
+  it("classifies unspecified addresses as private", () => {
+    expect(isPrivateIp("0.0.0.0")).toBe(true);
+    expect(isPrivateIp("::")).toBe(true);
+  });
+
+  it("treats public addresses as public", () => {
+    expect(isPrivateIp("8.8.8.8")).toBe(false);
+    expect(isPrivateIp("1.1.1.1")).toBe(false);
+    expect(isPrivateIp("2606:4700:4700::1111")).toBe(false);
+  });
+});
+
+describe("validateUrl — allowlist gate", () => {
+  it("accepts an allowed host that resolves to a public IP", async () => {
+    dnsQueue.push({ address: "104.19.20.21", family: 4 });
+    const r = await validateUrl("https://boards.greenhouse.io/acme");
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.resolvedIp).toBe("104.19.20.21");
+      expect(r.family).toBe(4);
+      expect(r.url.hostname).toBe("boards.greenhouse.io");
+    }
+  });
+
+  it("accepts a *.greenhouse.io subdomain match + public IP", async () => {
+    dnsQueue.push({ address: "104.19.20.21", family: 4 });
+    const r = await validateUrl("https://acme.greenhouse.io/");
+    expect(r.ok).toBe(true);
+  });
+
+  it("rejects a disallowed host with `url_not_allowed` and performs NO DNS lookup", async () => {
+    const r = await validateUrl("https://evil.example.com/");
+    expect(r).toEqual({ ok: false, error: "url_not_allowed" });
+    expect(dnsCallCount).toBe(0);
+  });
+
+  it("rejects an unparseable input with `url_invalid`", async () => {
+    const r = await validateUrl("not a url");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe("url_invalid");
+    expect(dnsCallCount).toBe(0);
+  });
+
+  it("rejects a non-http(s) scheme even on an allowed host", async () => {
+    const r = await validateUrl("ftp://boards.greenhouse.io/x");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.error).toBe("url_invalid");
+    expect(dnsCallCount).toBe(0);
+  });
+});
+
+describe("validateUrl — IP filter", () => {
+  it("rejects an allowed host that resolves to a private IP", async () => {
+    dnsQueue.push({ address: "10.0.0.5", family: 4 });
+    const r = await validateUrl("https://boards.greenhouse.io/x");
+    expect(r).toEqual({ ok: false, error: "url_resolves_to_private" });
+  });
+
+  it("rejects an allowed host that resolves to the AWS metadata IP", async () => {
+    dnsQueue.push({ address: "169.254.169.254", family: 4 });
+    const r = await validateUrl("https://acme.greenhouse.io/x");
+    expect(r).toEqual({ ok: false, error: "url_resolves_to_private" });
+  });
+
+  it("rejects a literal `localhost` URL (loopback)", async () => {
+    const r = await validateUrl("https://localhost/");
+    // `localhost` is not on the allowlist, so it must fail at the
+    // pattern gate without a DNS lookup.
+    expect(r).toEqual({ ok: false, error: "url_not_allowed" });
+    expect(dnsCallCount).toBe(0);
+  });
+
+  it("rejects a literal IP host (127.0.0.1) regardless of DNS", async () => {
+    const r = await validateUrl("https://127.0.0.1/");
+    expect(r.ok).toBe(false);
+    // Either url_not_allowed (literal IP isn't on the host allowlist)
+    // or url_resolves_to_private (if implementation chooses to short-
+    // circuit literal IPs through the IP filter). Both are correct
+    // outcomes; we just don't accept it.
+    if (!r.ok) {
+      expect(["url_not_allowed", "url_resolves_to_private"]).toContain(r.error);
+    }
+  });
+
+  it("rejects a link-local resolution (169.254.0.0/16) on an allowed host", async () => {
+    dnsQueue.push({ address: "169.254.42.1", family: 4 });
+    const r = await validateUrl("https://acme.greenhouse.io/x");
+    expect(r).toEqual({ ok: false, error: "url_resolves_to_private" });
+  });
+
+  it("rejects an IPv6 ULA (fc00::/7) resolution on an allowed host", async () => {
+    dnsQueue.push({ address: "fd12:3456:789a::1", family: 6 });
+    const r = await validateUrl("https://acme.greenhouse.io/x");
+    expect(r).toEqual({ ok: false, error: "url_resolves_to_private" });
+  });
+
+  it("returns `url_dns_failed` when the resolver throws", async () => {
+    dnsThrow = Object.assign(new Error("ENOTFOUND"), { code: "ENOTFOUND" });
+    const r = await validateUrl("https://acme.greenhouse.io/x");
+    expect(r).toEqual({ ok: false, error: "url_dns_failed" });
+  });
+});
+
+describe("safeFetch — DNS rebinding scenario", () => {
+  it("uses the post-resolution IP and rejects when a second lookup goes private", async () => {
+    // First lookup (from validateUrl) returns a public IP — passes.
+    // Second lookup (from a hypothetical re-resolution at fetch time)
+    // returns a private IP. safeFetch must NOT trust the second lookup;
+    // it must pin to the first answer, and we verify that by ensuring
+    // a second-answer-poisoned IP that's private gets rejected at the
+    // captured-IP check (not silently followed).
+    dnsQueue.push({ address: "104.19.20.21", family: 4 });
+    dnsQueue.push({ address: "10.0.0.5", family: 4 });
+
+    // We don't open a real connection; we only need to observe that
+    // safeFetch routes through the IP filter at connect-time. The
+    // standardised contract: if the captured IP from `validateUrl` is
+    // private, safeFetch throws with code `url_resolves_to_private`.
+    // To exercise that path here, simulate the rebind by validating
+    // first (which captures the public IP), then asking safeFetch to
+    // re-validate against the next queued answer (the private one).
+    //
+    // Implementation note: safeFetch performs its own validateUrl call
+    // at entry. With our queue containing [public, private], the FIRST
+    // call to safeFetch consumes the public answer and would proceed
+    // to open a TCP connection — which we cannot do in unit tests.
+    // Instead we test the rebinding-protection PROPERTY: a second,
+    // independent safeFetch on the same URL — simulating a rebind —
+    // will consume the (now poisoned) private answer and reject with
+    // `url_resolves_to_private`, never opening a connection to the
+    // attacker-controlled private IP.
+    let err: unknown = null;
+    try {
+      await safeFetch("https://acme.greenhouse.io/x");
+    } catch (e) {
+      err = e;
+    }
+    // The first safeFetch may either resolve (mock fetch) or throw at
+    // connect time; we don't constrain that. What we DO require is
+    // that a subsequent rebind-poisoned attempt fails closed.
+    void err;
+
+    // Drain anything left from the first call, then queue exactly one
+    // poisoned (private) answer and assert it's rejected.
+    dnsQueue.length = 0;
+    dnsQueue.push({ address: "10.0.0.5", family: 4 });
+    let rebindError: { code?: string } | null = null;
+    try {
+      await safeFetch("https://acme.greenhouse.io/x");
+    } catch (e) {
+      rebindError = e as { code?: string };
+    }
+    expect(rebindError).not.toBeNull();
+    expect(rebindError?.code).toBe("url_resolves_to_private");
+  });
+});

--- a/apps/web/src/lib/murmur/ssrf.test.ts
+++ b/apps/web/src/lib/murmur/ssrf.test.ts
@@ -9,30 +9,56 @@
  *
  * @see colophon-group/jobseek#2758
  */
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 // Queue of DNS answers consumed in order by the mocked `lookup`.
+// Stored on globalThis so the hoisted `vi.mock` factory can see them
+// without triggering vitest's "top-level variables in factory" rule.
 type DnsAnswer = { address: string; family: 4 | 6 };
-const dnsQueue: DnsAnswer[] = [];
-let dnsCallCount = 0;
-let dnsThrow: Error | null = null;
 
-vi.mock("node:dns/promises", () => ({
-  lookup: vi.fn(async (_hostname: string, _opts?: unknown) => {
-    dnsCallCount += 1;
-    if (dnsThrow) throw dnsThrow;
-    const answer = dnsQueue.shift();
+interface DnsMockState {
+  queue: DnsAnswer[];
+  callCount: number;
+  throwError: Error | null;
+}
+
+declare global {
+  var __ssrfDnsMock: DnsMockState | undefined;
+}
+
+globalThis.__ssrfDnsMock = { queue: [], callCount: 0, throwError: null };
+
+vi.mock("node:dns/promises", () => {
+  const lookup = async (_hostname: string, _opts?: unknown) => {
+    const state = globalThis.__ssrfDnsMock!;
+    state.callCount += 1;
+    if (state.throwError) throw state.throwError;
+    const answer = state.queue.shift();
     if (!answer) {
       throw Object.assign(new Error("ENOTFOUND"), { code: "ENOTFOUND" });
     }
     return answer;
-  }),
-}));
+  };
+  return { default: { lookup }, lookup };
+});
 
+const dnsState = (): DnsMockState => globalThis.__ssrfDnsMock!;
+const dnsQueue = {
+  push: (a: DnsAnswer) => dnsState().queue.push(a),
+  reset: () => {
+    dnsState().queue.length = 0;
+  },
+  get length() {
+    return dnsState().queue.length;
+  },
+  set length(n: number) {
+    dnsState().queue.length = n;
+  },
+};
 beforeEach(() => {
-  dnsQueue.length = 0;
-  dnsCallCount = 0;
-  dnsThrow = null;
+  dnsState().queue.length = 0;
+  dnsState().callCount = 0;
+  dnsState().throwError = null;
 });
 
 import {
@@ -156,21 +182,21 @@ describe("validateUrl — allowlist gate", () => {
   it("rejects a disallowed host with `url_not_allowed` and performs NO DNS lookup", async () => {
     const r = await validateUrl("https://evil.example.com/");
     expect(r).toEqual({ ok: false, error: "url_not_allowed" });
-    expect(dnsCallCount).toBe(0);
+    expect(dnsState().callCount).toBe(0);
   });
 
   it("rejects an unparseable input with `url_invalid`", async () => {
     const r = await validateUrl("not a url");
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error).toBe("url_invalid");
-    expect(dnsCallCount).toBe(0);
+    expect(dnsState().callCount).toBe(0);
   });
 
   it("rejects a non-http(s) scheme even on an allowed host", async () => {
     const r = await validateUrl("ftp://boards.greenhouse.io/x");
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.error).toBe("url_invalid");
-    expect(dnsCallCount).toBe(0);
+    expect(dnsState().callCount).toBe(0);
   });
 });
 
@@ -192,7 +218,7 @@ describe("validateUrl — IP filter", () => {
     // `localhost` is not on the allowlist, so it must fail at the
     // pattern gate without a DNS lookup.
     expect(r).toEqual({ ok: false, error: "url_not_allowed" });
-    expect(dnsCallCount).toBe(0);
+    expect(dnsState().callCount).toBe(0);
   });
 
   it("rejects a literal IP host (127.0.0.1) regardless of DNS", async () => {
@@ -220,54 +246,48 @@ describe("validateUrl — IP filter", () => {
   });
 
   it("returns `url_dns_failed` when the resolver throws", async () => {
-    dnsThrow = Object.assign(new Error("ENOTFOUND"), { code: "ENOTFOUND" });
+    dnsState().throwError = Object.assign(new Error("ENOTFOUND"), { code: "ENOTFOUND" });
     const r = await validateUrl("https://acme.greenhouse.io/x");
     expect(r).toEqual({ ok: false, error: "url_dns_failed" });
   });
 });
 
 describe("safeFetch — DNS rebinding scenario", () => {
-  it("uses the post-resolution IP and rejects when a second lookup goes private", async () => {
-    // First lookup (from validateUrl) returns a public IP — passes.
-    // Second lookup (from a hypothetical re-resolution at fetch time)
-    // returns a private IP. safeFetch must NOT trust the second lookup;
-    // it must pin to the first answer, and we verify that by ensuring
-    // a second-answer-poisoned IP that's private gets rejected at the
-    // captured-IP check (not silently followed).
+  // Stub global fetch so safeFetch never actually opens a socket on the
+  // happy path. It records the URL it was asked to fetch — the assertion
+  // we care about is that the URL is the captured (post-validation) IP,
+  // not the hostname (which a re-resolution could redirect).
+  const originalFetch = globalThis.fetch;
+  let lastFetchedUrl: string | URL | undefined;
+  beforeEach(() => {
+    lastFetchedUrl = undefined;
+    globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
+      lastFetchedUrl = input instanceof Request ? input.url : input;
+      return new Response("ok", { status: 200 });
+    }) as typeof fetch;
+  });
+  // Restore after each test so the global fetch is back to its original
+  // value before subsequent suites (defensive — no other suite uses
+  // fetch, but the cleanup pattern is cheap).
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("first call: pins the connection to the resolved (public) IP, not the hostname", async () => {
     dnsQueue.push({ address: "104.19.20.21", family: 4 });
-    dnsQueue.push({ address: "10.0.0.5", family: 4 });
+    const r = await safeFetch("https://acme.greenhouse.io/x");
+    expect(r.status).toBe(200);
+    // The captured IP must be in the URL passed to fetch — that's the
+    // proof of pinning. A second DNS lookup at connect time has nothing
+    // to attack because the URL no longer references the hostname.
+    const fetched = String(lastFetchedUrl);
+    expect(fetched).toContain("104.19.20.21");
+    expect(fetched).not.toContain("acme.greenhouse.io");
+  });
 
-    // We don't open a real connection; we only need to observe that
-    // safeFetch routes through the IP filter at connect-time. The
-    // standardised contract: if the captured IP from `validateUrl` is
-    // private, safeFetch throws with code `url_resolves_to_private`.
-    // To exercise that path here, simulate the rebind by validating
-    // first (which captures the public IP), then asking safeFetch to
-    // re-validate against the next queued answer (the private one).
-    //
-    // Implementation note: safeFetch performs its own validateUrl call
-    // at entry. With our queue containing [public, private], the FIRST
-    // call to safeFetch consumes the public answer and would proceed
-    // to open a TCP connection — which we cannot do in unit tests.
-    // Instead we test the rebinding-protection PROPERTY: a second,
-    // independent safeFetch on the same URL — simulating a rebind —
-    // will consume the (now poisoned) private answer and reject with
-    // `url_resolves_to_private`, never opening a connection to the
-    // attacker-controlled private IP.
-    let err: unknown = null;
-    try {
-      await safeFetch("https://acme.greenhouse.io/x");
-    } catch (e) {
-      err = e;
-    }
-    // The first safeFetch may either resolve (mock fetch) or throw at
-    // connect time; we don't constrain that. What we DO require is
-    // that a subsequent rebind-poisoned attempt fails closed.
-    void err;
-
-    // Drain anything left from the first call, then queue exactly one
-    // poisoned (private) answer and assert it's rejected.
-    dnsQueue.length = 0;
+  it("rebind poisoning: a second lookup that resolves private is rejected, no connection opened", async () => {
+    // Simulate the post-resolution rebind: the queue now yields a
+    // private IP for the same hostname. safeFetch must fail closed.
     dnsQueue.push({ address: "10.0.0.5", family: 4 });
     let rebindError: { code?: string } | null = null;
     try {
@@ -277,5 +297,7 @@ describe("safeFetch — DNS rebinding scenario", () => {
     }
     expect(rebindError).not.toBeNull();
     expect(rebindError?.code).toBe("url_resolves_to_private");
+    // And critically: fetch was never invoked.
+    expect(lastFetchedUrl).toBeUndefined();
   });
 });

--- a/apps/web/src/lib/murmur/ssrf.ts
+++ b/apps/web/src/lib/murmur/ssrf.ts
@@ -28,7 +28,12 @@
  */
 
 import { lookup as dnsLookup } from "node:dns/promises";
-import type { LookupAddress } from "node:dns";
+import type { LookupAddress, LookupOptions } from "node:dns";
+import * as http from "node:http";
+import * as https from "node:https";
+import type { IncomingMessage } from "node:http";
+import type { LookupFunction } from "node:net";
+import { Readable } from "node:stream";
 
 /**
  * Host-pattern allowlist. Each entry is either:
@@ -314,7 +319,10 @@ export async function validateUrl(input: string): Promise<ValidateUrlResult> {
     return { ok: false, error: "url_dns_failed" };
   }
 
-  const family = resolved.family === 6 ? 6 : 4;
+  // `node:dns/promises`.lookup types `family` as `4 | 6` already; no
+  // narrowing ternary needed. Validate at runtime defensively in case a
+  // mocked resolver returns something off-spec.
+  const family: 4 | 6 = resolved.family === 6 ? 6 : 4;
   if (isPrivateIp(resolved.address)) {
     return { ok: false, error: "url_resolves_to_private" };
   }
@@ -335,32 +343,125 @@ export class SafeFetchError extends Error {
 }
 
 /**
- * Fetch a URL after validation, with DNS-rebinding protection.
+ * Build a DNS `lookup`-compatible function that pins resolution to a
+ * pre-captured IP for one specific hostname.
  *
- * Resolves the hostname *once* via `validateUrl` and captures the IP.
- * The outbound request is then issued against a URL whose hostname has
- * been rewritten to that captured IP, with the original Host header
- * preserved on the request so virtual-hosted servers route correctly.
+ * The returned function matches Node's `net.LookupFunction` signature
+ * and is intended to be passed as the `lookup` option of
+ * `http.request` / `https.request` / `net.connect`. Its behaviour:
  *
- * Why this works as rebinding mitigation: by substituting the IP into
- * the URL we prevent any further DNS resolution. The connect call has
- * no opportunity to consult the resolver again, so an attacker who
- * controls the hostname's DNS cannot redirect us to a private IP after
- * the validation check has passed.
+ *   - If called for `expectedHostname` (case-insensitive), it returns
+ *     the captured `(ip, family)` tuple immediately, with no DNS query.
+ *   - If called for any other hostname, it fails closed with an
+ *     `ENOTFOUND` error. This protects against a connection helper that
+ *     might try to resolve a CNAME, a redirect target, or any other
+ *     name the request layer derives.
  *
- * Trade-off: this approach breaks TLS hostname verification (the
- * server's certificate is for the original hostname, not the IP). For
- * the M0 demo all probe targets are public ATS providers; if/when this
- * is reused for richer transport, swap to a `node:https` Agent with a
- * custom `lookup` AND `servername` so SNI continues to use the original
- * hostname while the connection still routes to the captured IP.
+ * Why this matters for SSRF: the outbound request is issued against the
+ * original hostname (so SNI / TLS SAN matching still works), but the
+ * underlying socket is forced onto the IP we already validated. An
+ * attacker who controls the authoritative DNS for that hostname has no
+ * second window to swap in a private IP — `lookup` is never given the
+ * opportunity to query the resolver.
  *
- * Returns whatever `fetch` produces. If validation fails, throws
- * `SafeFetchError` with `.code` matching `ValidateUrlErrCode`.
+ * Calling-convention note: Node calls `lookup` with EITHER `all: false`
+ * (callback receives `(err, address, family)`) OR `all: true` (callback
+ * receives `(err, addresses[])`). Modern `net.connect` uses
+ * `all: true`, so we support both calling conventions; otherwise the
+ * connection layer rejects with `Invalid IP address: undefined`.
+ *
+ * Exported for unit testing; route handlers should not call this
+ * directly, they should use `safeFetch`.
+ *
+ * @param expectedHostname Hostname that was validated by `validateUrl`.
+ *                         Compared case-insensitively.
+ * @param ip               Captured IPv4 / IPv6 address (string form).
+ * @param family           IP family of `ip` (4 or 6).
+ */
+export function createPinnedLookup(
+  expectedHostname: string,
+  ip: string,
+  family: 4 | 6,
+): LookupFunction {
+  const expected = expectedHostname.toLowerCase();
+  // We assert through `unknown` because Node's `LookupFunction`
+  // narrows the third arg to a union shape that's awkward to express
+  // structurally; the runtime contract is correct for both modes.
+  return ((
+    hostname: string,
+    options: LookupOptions,
+    callback: (
+      err: NodeJS.ErrnoException | null,
+      addressOrAddresses: string | LookupAddress[],
+      family?: number,
+    ) => void,
+  ) => {
+    if (hostname.toLowerCase() !== expected) {
+      const err: NodeJS.ErrnoException = Object.assign(
+        new Error(
+          `safeFetch: refusing to resolve unexpected hostname '${hostname}' (expected '${expected}')`,
+        ),
+        { code: "ENOTFOUND", hostname },
+      );
+      // Match Node's expected error-arg shape for either calling mode.
+      // The address arg is conventionally "" / [] on error; Node only
+      // checks `err`.
+      if (options && options.all) {
+        callback(err, []);
+      } else {
+        callback(err, "", 0);
+      }
+      return;
+    }
+    if (options && options.all) {
+      callback(null, [{ address: ip, family }]);
+    } else {
+      callback(null, ip, family);
+    }
+  }) as unknown as LookupFunction;
+}
+
+/**
+ * Fetch a URL after validation, with DNS-rebinding protection that
+ * preserves TLS correctness.
+ *
+ * Strategy:
+ *   1. `validateUrl` performs the allowlist + DNS + IP-filter check
+ *      and captures the resolved IP and family.
+ *   2. The outbound request is dispatched via `node:https.request`
+ *      (or `node:http.request` for plaintext) with a custom `lookup`
+ *      that always returns the captured IP for the original hostname
+ *      and rejects any other name. The request URL keeps the original
+ *      hostname, so:
+ *         - SNI sends the original hostname.
+ *         - The TLS layer validates the server cert's SAN against the
+ *           original hostname (the way certificates are actually
+ *           issued for hosts like `*.greenhouse.io`).
+ *         - The Host header is the original hostname (vhost routing
+ *           continues to work).
+ *      ...but the underlying socket connects to the captured IP only.
+ *   3. The Node `IncomingMessage` is wrapped in a Web `Response` so
+ *      callers get the same shape as `globalThis.fetch`.
+ *
+ * Why this is the correct rebinding fix: the connection-time `lookup`
+ * has no chance to consult the resolver. An attacker who flips the
+ * authoritative DNS between phase-2 validation and connect is bypassed
+ * because we never query DNS again.
+ *
+ * Throws `SafeFetchError` with `.code` matching `ValidateUrlErrCode` if
+ * validation fails. Network errors propagate as the underlying
+ * `Error` from `https.request`.
  *
  * Callers at route boundaries should still invoke `validateUrl` first
  * to surface a structured error to the agent; `safeFetch` is the
  * defence-in-depth wrapper for the actual outbound call.
+ *
+ * Note on body support: this implementation supports string and
+ * Uint8Array request bodies (covering JSON, form-encoded, and raw
+ * payloads). It does NOT support streaming `ReadableStream` bodies —
+ * none of the M0 publish/probe call sites need them, and adding stream
+ * piping here is out of scope. If a future caller needs streaming,
+ * extend in a separate change.
  */
 export async function safeFetch(
   input: string,
@@ -378,17 +479,96 @@ export async function safeFetch(
     throw new SafeFetchError("url_resolves_to_private");
   }
 
-  // Pin the connection to the captured IP by substituting it into the
-  // URL hostname. Bracket IPv6 literals.
-  const ipUrl = new URL(v.url.toString());
-  ipUrl.hostname = v.family === 6 ? `[${v.resolvedIp}]` : v.resolvedIp;
+  const lookup = createPinnedLookup(v.url.hostname, v.resolvedIp, v.family);
+  return performPinnedRequest(v.url, init, lookup);
+}
 
-  // Preserve the original Host header so virtual-hosted servers still
-  // route the request to the right vhost.
-  const headers = new Headers(init?.headers);
-  if (!headers.has("host")) {
-    headers.set("host", v.url.host);
+/**
+ * Internal: dispatch the request through `node:http(s).request` with the
+ * supplied `lookup`. Exposed within the module so it can be wrapped by
+ * tests; not exported.
+ */
+async function performPinnedRequest(
+  url: URL,
+  init: RequestInit | undefined,
+  lookup: ReturnType<typeof createPinnedLookup>,
+): Promise<Response> {
+  const method = (init?.method ?? "GET").toUpperCase();
+  const isHttps = url.protocol === "https:";
+  const requestFn = isHttps ? https.request : http.request;
+
+  // Convert RequestInit headers to a plain object http.request accepts.
+  const reqHeaders: Record<string, string> = {};
+  if (init?.headers) {
+    const h = new Headers(init.headers);
+    h.forEach((value, key) => {
+      reqHeaders[key] = value;
+    });
   }
 
-  return fetch(ipUrl, { ...init, headers });
+  // Serialise body. Streams are unsupported (see jsdoc).
+  let bodyBuf: Buffer | string | undefined;
+  if (init?.body !== undefined && init.body !== null) {
+    if (typeof init.body === "string") {
+      bodyBuf = init.body;
+    } else if (init.body instanceof Uint8Array) {
+      bodyBuf = Buffer.from(init.body);
+    } else if (init.body instanceof ArrayBuffer) {
+      bodyBuf = Buffer.from(init.body);
+    } else {
+      throw new TypeError(
+        "safeFetch: unsupported body type (only string / Uint8Array / ArrayBuffer)",
+      );
+    }
+  }
+
+  const port = url.port
+    ? Number(url.port)
+    : isHttps
+      ? 443
+      : 80;
+
+  return new Promise<Response>((resolve, reject) => {
+    const req = requestFn({
+      protocol: url.protocol,
+      hostname: url.hostname,
+      // SNI / SAN check use this hostname; do NOT swap it for the IP.
+      servername: isHttps ? url.hostname : undefined,
+      port,
+      method,
+      path: `${url.pathname}${url.search}`,
+      headers: reqHeaders,
+      // The pin: connection-time DNS resolution is forced to our
+      // captured IP for the validated hostname only.
+      lookup,
+    }, (res: IncomingMessage) => {
+      // Build a Web Response from the IncomingMessage.
+      const headers = new Headers();
+      for (const [k, v] of Object.entries(res.headers)) {
+        if (v === undefined) continue;
+        if (Array.isArray(v)) {
+          for (const item of v) headers.append(k, item);
+        } else {
+          headers.set(k, String(v));
+        }
+      }
+      // Adapt the Node Readable into a web ReadableStream. Node 18+
+      // exposes `Readable.toWeb` which does the right thing.
+      const webStream = Readable.toWeb(res) as unknown as ReadableStream<Uint8Array>;
+      resolve(
+        new Response(webStream, {
+          status: res.statusCode ?? 0,
+          statusText: res.statusMessage ?? "",
+          headers,
+        }),
+      );
+    });
+
+    req.on("error", reject);
+
+    if (bodyBuf !== undefined) {
+      req.write(bodyBuf);
+    }
+    req.end();
+  });
 }

--- a/apps/web/src/lib/murmur/ssrf.ts
+++ b/apps/web/src/lib/murmur/ssrf.ts
@@ -27,6 +27,9 @@
  * @see Murmur DESIGN.md §3.6 (Publisher SSRF defense), §4.2 (Probe SSRF defense)
  */
 
+import { lookup as dnsLookup } from "node:dns/promises";
+import type { LookupAddress } from "node:dns";
+
 /**
  * Host-pattern allowlist. Each entry is either:
  *   - A literal host (e.g. `boards.greenhouse.io`) — exact match only.
@@ -81,14 +84,186 @@ export type ValidateUrlResult = ValidateUrlOk | ValidateUrlErr;
  * No support for mid-string wildcards or path patterns; we deliberately
  * keep the matcher tiny so its behaviour is auditable in one glance.
  *
- * @param host    Lowercased hostname (no port, no path).
+ * @param host    Hostname (no port, no path).
  * @param pattern Allowlist pattern.
  * @returns true iff `host` is allowed by `pattern`.
  */
 export function matchHostPattern(host: string, pattern: string): boolean {
-  void host;
-  void pattern;
-  throw new Error("not implemented");
+  const h = host.toLowerCase();
+  const p = pattern.toLowerCase();
+
+  if (!p.startsWith("*.")) {
+    return h === p;
+  }
+
+  // `*.example.com` => suffix `.example.com` and at least one label
+  // before it. The bare apex `example.com` does NOT match.
+  const suffix = p.slice(1); // ".example.com"
+  if (!h.endsWith(suffix)) return false;
+  const prefix = h.slice(0, h.length - suffix.length);
+  // prefix must be one-or-more non-empty labels (i.e. not empty and not
+  // contain a leading dot).
+  if (prefix.length === 0) return false;
+  if (prefix.startsWith(".")) return false;
+  return true;
+}
+
+/**
+ * Internal helper: does `host` match ANY allowlist pattern?
+ */
+function isHostAllowed(host: string): boolean {
+  for (const pattern of HOST_ALLOWLIST) {
+    if (matchHostPattern(host, pattern)) return true;
+  }
+  return false;
+}
+
+/**
+ * Internal: parse a dotted-quad IPv4 string into 4 octets, or null.
+ */
+function parseIPv4(ip: string): [number, number, number, number] | null {
+  const parts = ip.split(".");
+  if (parts.length !== 4) return null;
+  const out: number[] = [];
+  for (const part of parts) {
+    if (!/^\d{1,3}$/.test(part)) return null;
+    const n = Number(part);
+    if (n < 0 || n > 255) return null;
+    out.push(n);
+  }
+  return out as [number, number, number, number];
+}
+
+/**
+ * Classify an IPv4 address as private/reserved.
+ */
+function isPrivateIPv4(ip: string): boolean {
+  const parts = parseIPv4(ip);
+  if (!parts) return false;
+  const [a, b] = parts;
+
+  // 0.0.0.0/8 unspecified / current network
+  if (a === 0) return true;
+  // 10.0.0.0/8 RFC1918
+  if (a === 10) return true;
+  // 100.64.0.0/10 CGNAT
+  if (a === 100 && b >= 64 && b <= 127) return true;
+  // 127.0.0.0/8 loopback
+  if (a === 127) return true;
+  // 169.254.0.0/16 link-local (includes metadata 169.254.169.254)
+  if (a === 169 && b === 254) return true;
+  // 172.16.0.0/12 RFC1918
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  // 192.0.0.0/24 IETF protocol assignments
+  if (a === 192 && b === 0 && parts[2] === 0) return true;
+  // 192.0.2.0/24 TEST-NET-1
+  if (a === 192 && b === 0 && parts[2] === 2) return true;
+  // 192.168.0.0/16 RFC1918
+  if (a === 192 && b === 168) return true;
+  // 198.18.0.0/15 benchmarking
+  if (a === 198 && (b === 18 || b === 19)) return true;
+  // 198.51.100.0/24 TEST-NET-2
+  if (a === 198 && b === 51 && parts[2] === 100) return true;
+  // 203.0.113.0/24 TEST-NET-3
+  if (a === 203 && b === 0 && parts[2] === 113) return true;
+  // 224.0.0.0/4 multicast
+  if (a >= 224 && a <= 239) return true;
+  // 240.0.0.0/4 reserved (and 255.255.255.255 broadcast)
+  if (a >= 240) return true;
+
+  return false;
+}
+
+/**
+ * Normalise an IPv6 string (lowercased, expanded `::`) into eight 16-bit
+ * groups. Returns null on parse failure.
+ */
+function parseIPv6(ip: string): number[] | null {
+  const lower = ip.toLowerCase();
+  // IPv4-mapped form: ::ffff:1.2.3.4 — caller handles separately.
+  if (lower.includes(".")) return null;
+
+  const parts = lower.split("::");
+  if (parts.length > 2) return null;
+
+  const head = parts[0] === "" ? [] : parts[0].split(":");
+  const tail = parts.length === 2 ? (parts[1] === "" ? [] : parts[1].split(":")) : [];
+
+  if (parts.length === 1 && head.length !== 8) return null;
+  if (parts.length === 2 && head.length + tail.length > 7) return null;
+
+  const fillCount = 8 - head.length - tail.length;
+  const groups: number[] = [];
+  for (const g of head) {
+    if (!/^[0-9a-f]{1,4}$/.test(g)) return null;
+    groups.push(parseInt(g, 16));
+  }
+  for (let i = 0; i < fillCount; i++) groups.push(0);
+  for (const g of tail) {
+    if (!/^[0-9a-f]{1,4}$/.test(g)) return null;
+    groups.push(parseInt(g, 16));
+  }
+  if (groups.length !== 8) return null;
+  return groups;
+}
+
+/**
+ * Classify an IPv6 address as private/reserved.
+ */
+function isPrivateIPv6(ip: string): boolean {
+  const lower = ip.toLowerCase();
+
+  // Unspecified `::`
+  if (lower === "::" || lower === "0:0:0:0:0:0:0:0") return true;
+  // Loopback `::1`
+  if (lower === "::1" || lower === "0:0:0:0:0:0:0:1") return true;
+
+  // IPv4-mapped IPv6: `::ffff:a.b.c.d` — re-classify the embedded v4.
+  const v4MappedMatch = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+  if (v4MappedMatch) {
+    return isPrivateIPv4(v4MappedMatch[1]);
+  }
+
+  const groups = parseIPv6(lower);
+  if (!groups) return false;
+
+  const first = groups[0];
+
+  // fe80::/10 link-local (first 10 bits = 1111111010)
+  if ((first & 0xffc0) === 0xfe80) return true;
+  // fc00::/7 ULA (first 7 bits = 1111110)
+  if ((first & 0xfe00) === 0xfc00) return true;
+  // ff00::/8 multicast
+  if ((first & 0xff00) === 0xff00) return true;
+  // ::/8 reserved (covers IPv4-compat and other legacy)
+  if ((first & 0xff00) === 0x0000 && groups.slice(1, 7).every((g) => g === 0)) {
+    // ::1 already handled; ::ffff: handled; bare :: handled. Any other
+    // ::xxxx is suspicious — treat as private to fail closed.
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Classify an IP address as public or private/reserved.
+ *
+ * Treats as PRIVATE (returns true):
+ *   - Loopback           (`127.0.0.0/8`, `::1`)
+ *   - RFC1918            (`10/8`, `172.16/12`, `192.168/16`)
+ *   - CGNAT              (`100.64/10`)
+ *   - Link-local         (`169.254.0.0/16`, `fe80::/10`)
+ *   - Metadata services  (`169.254.169.254`)
+ *   - IPv6 ULA           (`fc00::/7`)
+ *   - IPv4-mapped IPv6   (`::ffff:<v4>` — re-classify the embedded v4)
+ *   - Unspecified        (`0.0.0.0`, `::`)
+ *   - Multicast / broadcast / IETF-reserved ranges
+ *
+ * Anything else is public.
+ */
+export function isPrivateIp(ip: string): boolean {
+  if (parseIPv4(ip)) return isPrivateIPv4(ip);
+  return isPrivateIPv6(ip);
 }
 
 /**
@@ -107,55 +282,113 @@ export function matchHostPattern(host: string, pattern: string): boolean {
  *   - `url_resolves_to_private`  — resolved address is private, loopback, link-local, metadata, or ULA.
  */
 export async function validateUrl(input: string): Promise<ValidateUrlResult> {
-  void input;
-  throw new Error("not implemented");
+  // Phase 0: parse + scheme check.
+  let url: URL;
+  try {
+    url = new URL(input);
+  } catch {
+    return { ok: false, error: "url_invalid" };
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    return { ok: false, error: "url_invalid" };
+  }
+  if (!url.hostname) {
+    return { ok: false, error: "url_invalid" };
+  }
+
+  const host = url.hostname.toLowerCase();
+
+  // Phase 1: allowlist match. Performs NO DNS lookup on miss.
+  if (!isHostAllowed(host)) {
+    return { ok: false, error: "url_not_allowed" };
+  }
+
+  // Phase 2: DNS resolution + IP filter.
+  let resolved: LookupAddress;
+  try {
+    // `verbatim: false` asks Node to honour the system's address-family
+    // preference; it does NOT relax filtering. We capture both the
+    // address and the family so safeFetch can pin the connection.
+    resolved = await dnsLookup(host, { verbatim: false });
+  } catch {
+    return { ok: false, error: "url_dns_failed" };
+  }
+
+  const family = resolved.family === 6 ? 6 : 4;
+  if (isPrivateIp(resolved.address)) {
+    return { ok: false, error: "url_resolves_to_private" };
+  }
+
+  return { ok: true, url, resolvedIp: resolved.address, family };
+}
+
+/**
+ * Error thrown by `safeFetch` when validation fails.
+ */
+export class SafeFetchError extends Error {
+  public readonly code: ValidateUrlErrCode;
+  constructor(code: ValidateUrlErrCode, message?: string) {
+    super(message ?? code);
+    this.name = "SafeFetchError";
+    this.code = code;
+  }
 }
 
 /**
  * Fetch a URL after validation, with DNS-rebinding protection.
  *
- * Resolves once via `validateUrl`, captures the IP, and opens the TCP/TLS
- * connection to that captured IP — supplying the original hostname as the
- * `Host` header and TLS SNI so the server's certificate still validates.
- * If the agent's libc were to re-resolve mid-flight to a private address,
- * we don't see it: the connection has already been pinned.
+ * Resolves the hostname *once* via `validateUrl` and captures the IP.
+ * The outbound request is then issued against a URL whose hostname has
+ * been rewritten to that captured IP, with the original Host header
+ * preserved on the request so virtual-hosted servers route correctly.
  *
- * For non-https schemes the function still works (uses HttpAgent), but
- * production callers should prefer https.
+ * Why this works as rebinding mitigation: by substituting the IP into
+ * the URL we prevent any further DNS resolution. The connect call has
+ * no opportunity to consult the resolver again, so an attacker who
+ * controls the hostname's DNS cannot redirect us to a private IP after
+ * the validation check has passed.
  *
- * Returns the underlying `Response`. If validation fails, throws an Error
- * whose `.code` matches `ValidateUrlErrCode`. Callers at route boundaries
- * are expected to invoke `validateUrl` first and surface the structured
- * error to the agent; `safeFetch` is a defence-in-depth wrapper for the
- * actual outbound call.
+ * Trade-off: this approach breaks TLS hostname verification (the
+ * server's certificate is for the original hostname, not the IP). For
+ * the M0 demo all probe targets are public ATS providers; if/when this
+ * is reused for richer transport, swap to a `node:https` Agent with a
+ * custom `lookup` AND `servername` so SNI continues to use the original
+ * hostname while the connection still routes to the captured IP.
+ *
+ * Returns whatever `fetch` produces. If validation fails, throws
+ * `SafeFetchError` with `.code` matching `ValidateUrlErrCode`.
+ *
+ * Callers at route boundaries should still invoke `validateUrl` first
+ * to surface a structured error to the agent; `safeFetch` is the
+ * defence-in-depth wrapper for the actual outbound call.
  */
 export async function safeFetch(
   input: string,
   init?: RequestInit,
 ): Promise<Response> {
-  void input;
-  void init;
-  throw new Error("not implemented");
-}
+  const v = await validateUrl(input);
+  if (!v.ok) {
+    throw new SafeFetchError(v.error);
+  }
 
-/**
- * Internal: classify an IP address as public or private/reserved.
- * Exported only for unit tests.
- *
- * Treats as PRIVATE (returns true):
- *   - Loopback           (`127.0.0.0/8`, `::1`)
- *   - RFC1918            (`10/8`, `172.16/12`, `192.168/16`)
- *   - Link-local         (`169.254.0.0/16`, `fe80::/10`)
- *   - Metadata services  (`169.254.169.254`, `fd00:ec2::254`)
- *   - IPv6 ULA           (`fc00::/7`)
- *   - IPv4-mapped IPv6   (`::ffff:<v4>` — re-classify the embedded v4)
- *   - Unspecified        (`0.0.0.0`, `::`)
- *   - Multicast / broadcast / reserved ranges
- *
- * Anything else is public.
- */
-export function isPrivateIp(ip: string): boolean {
-  void ip;
-  throw new Error("not implemented");
-}
+  // Defence in depth: re-check the captured IP. If anything has stuffed
+  // a private IP into our captured value, fail closed before opening a
+  // socket.
+  if (isPrivateIp(v.resolvedIp)) {
+    throw new SafeFetchError("url_resolves_to_private");
+  }
 
+  // Pin the connection to the captured IP by substituting it into the
+  // URL hostname. Bracket IPv6 literals.
+  const ipUrl = new URL(v.url.toString());
+  ipUrl.hostname = v.family === 6 ? `[${v.resolvedIp}]` : v.resolvedIp;
+
+  // Preserve the original Host header so virtual-hosted servers still
+  // route the request to the right vhost.
+  const headers = new Headers(init?.headers);
+  if (!headers.has("host")) {
+    headers.set("host", v.url.host);
+  }
+
+  return fetch(ipUrl, { ...init, headers });
+}

--- a/apps/web/src/lib/murmur/ssrf.ts
+++ b/apps/web/src/lib/murmur/ssrf.ts
@@ -1,0 +1,161 @@
+/**
+ * SSRF allowlist + DNS-rebinding-aware fetcher for agent-supplied URLs.
+ *
+ * Used by every Murmur subcommand route in `apps/web/app/api/**` that
+ * accepts a URL field (`board_url`, `sample_url`, ...). Two phases:
+ *
+ *   1. Host-pattern allowlist (synchronous, no DNS).
+ *      Hard-coded list. Updates require a code change; no env-var
+ *      override.
+ *
+ *   2. DNS resolution + IP filter (rebinding-aware).
+ *      Resolve once; reject if the address is private, loopback,
+ *      link-local, an IANA-reserved cloud-metadata IP, or an IPv6 ULA.
+ *      `safeFetch` opens the connection to the *captured* IP so a second
+ *      DNS lookup cannot redirect us to a private address.
+ *
+ * Allowlist scope: the initial set covers the demo's most common board
+ * providers. Expand patterns as J5/#2759's routes encounter legitimate
+ * rejections in real demo runs. The full reference list of board hosts
+ * is at `apps/crawler/data/boards.csv`.
+ *
+ * Caller boundary: only files under `apps/web/app/api/**` (route
+ * boundaries) and this module's own test file may import from here. The
+ * `scripts/grep-validateurl-boundary.sh` gate enforces this.
+ *
+ * @see colophon-group/jobseek#2758
+ * @see Murmur DESIGN.md §3.6 (Publisher SSRF defense), §4.2 (Probe SSRF defense)
+ */
+
+/**
+ * Host-pattern allowlist. Each entry is either:
+ *   - A literal host (e.g. `boards.greenhouse.io`) — exact match only.
+ *   - A leading-wildcard pattern (e.g. `*.greenhouse.io`) — matches any
+ *     subdomain at any depth, but NOT the bare apex (`greenhouse.io`).
+ *
+ * To add a host: edit this array. Code review is the gate; no runtime
+ * override exists. Reference list of all known board hosts in use today:
+ * `apps/crawler/data/boards.csv` (the `board_url` column).
+ *
+ * Expand as J5 routes encounter legitimate rejections in real demo runs.
+ */
+export const HOST_ALLOWLIST: readonly string[] = [
+  // Greenhouse (most popular ATS in boards.csv)
+  "*.greenhouse.io",
+  "boards.greenhouse.io",
+  "job-boards.greenhouse.io",
+  // Lever
+  "*.lever.co",
+  "jobs.lever.co",
+  // Workday
+  "*.myworkdayjobs.com",
+];
+
+export type ValidateUrlOk = {
+  ok: true;
+  url: URL;
+  resolvedIp: string;
+  family: 4 | 6;
+};
+
+export type ValidateUrlErrCode =
+  | "url_invalid"
+  | "url_not_allowed"
+  | "url_dns_failed"
+  | "url_resolves_to_private";
+
+export type ValidateUrlErr = {
+  ok: false;
+  error: ValidateUrlErrCode;
+};
+
+export type ValidateUrlResult = ValidateUrlOk | ValidateUrlErr;
+
+/**
+ * Match a hostname against a single allowlist pattern.
+ *
+ * Patterns:
+ *   - `host.example.com` — exact match (case-insensitive).
+ *   - `*.example.com` — any strict subdomain (one or more labels).
+ *
+ * No support for mid-string wildcards or path patterns; we deliberately
+ * keep the matcher tiny so its behaviour is auditable in one glance.
+ *
+ * @param host    Lowercased hostname (no port, no path).
+ * @param pattern Allowlist pattern.
+ * @returns true iff `host` is allowed by `pattern`.
+ */
+export function matchHostPattern(host: string, pattern: string): boolean {
+  void host;
+  void pattern;
+  throw new Error("not implemented");
+}
+
+/**
+ * Validate a URL against the SSRF allowlist + IP filter.
+ *
+ * Performs phase 1 (allowlist) synchronously and phase 2 (DNS) only if
+ * phase 1 passes. Returns the resolved IP so the caller can route via a
+ * rebinding-aware fetcher.
+ *
+ * Never throws — all error states are encoded in the return shape.
+ *
+ * Error codes:
+ *   - `url_invalid`              — input was not a parseable absolute URL with `http(s):` scheme.
+ *   - `url_not_allowed`          — host did not match any allowlist pattern. NO DNS LOOKUP IS PERFORMED.
+ *   - `url_dns_failed`           — DNS resolution failed (NXDOMAIN, timeout, no A/AAAA record).
+ *   - `url_resolves_to_private`  — resolved address is private, loopback, link-local, metadata, or ULA.
+ */
+export async function validateUrl(input: string): Promise<ValidateUrlResult> {
+  void input;
+  throw new Error("not implemented");
+}
+
+/**
+ * Fetch a URL after validation, with DNS-rebinding protection.
+ *
+ * Resolves once via `validateUrl`, captures the IP, and opens the TCP/TLS
+ * connection to that captured IP — supplying the original hostname as the
+ * `Host` header and TLS SNI so the server's certificate still validates.
+ * If the agent's libc were to re-resolve mid-flight to a private address,
+ * we don't see it: the connection has already been pinned.
+ *
+ * For non-https schemes the function still works (uses HttpAgent), but
+ * production callers should prefer https.
+ *
+ * Returns the underlying `Response`. If validation fails, throws an Error
+ * whose `.code` matches `ValidateUrlErrCode`. Callers at route boundaries
+ * are expected to invoke `validateUrl` first and surface the structured
+ * error to the agent; `safeFetch` is a defence-in-depth wrapper for the
+ * actual outbound call.
+ */
+export async function safeFetch(
+  input: string,
+  init?: RequestInit,
+): Promise<Response> {
+  void input;
+  void init;
+  throw new Error("not implemented");
+}
+
+/**
+ * Internal: classify an IP address as public or private/reserved.
+ * Exported only for unit tests.
+ *
+ * Treats as PRIVATE (returns true):
+ *   - Loopback           (`127.0.0.0/8`, `::1`)
+ *   - RFC1918            (`10/8`, `172.16/12`, `192.168/16`)
+ *   - Link-local         (`169.254.0.0/16`, `fe80::/10`)
+ *   - Metadata services  (`169.254.169.254`, `fd00:ec2::254`)
+ *   - IPv6 ULA           (`fc00::/7`)
+ *   - IPv4-mapped IPv6   (`::ffff:<v4>` — re-classify the embedded v4)
+ *   - Unspecified        (`0.0.0.0`, `::`)
+ *   - Multicast / broadcast / reserved ranges
+ *
+ * Anything else is public.
+ */
+export function isPrivateIp(ip: string): boolean {
+  void ip;
+  throw new Error("not implemented");
+}
+


### PR DESCRIPTION
## Summary
Adds `apps/web/src/lib/murmur/ssrf.ts`, a single-file module that gates every agent-supplied URL on the Murmur subcommand routes. Two phases: (1) host-pattern allowlist (no DNS, fail closed on miss), (2) DNS resolution + IP filter that rejects loopback, RFC1918, link-local, IPv6 ULA, IANA reserved, and cloud-metadata addresses. A companion `safeFetch` performs the outbound call against the captured IP so a second DNS lookup at connect time has nothing to attack.

## Related issue
Closes colophon-group/jobseek#2758

## Files changed (high-level)
- `apps/web/src/lib/murmur/ssrf.ts` — `validateUrl`, `safeFetch`, `matchHostPattern`, `isPrivateIp`, `HOST_ALLOWLIST`, `SafeFetchError`. Single source of truth for the allowlist; comment block points at `apps/crawler/data/boards.csv` for reference and notes the J5 expansion path.
- `apps/web/src/lib/murmur/ssrf.test.ts` — 29 tests covering all 8 verification cases plus matcher and IP-classifier units. DNS is mocked via a hoist-safe global queue so each scenario is deterministic.
- `apps/web/scripts/grep-validateurl-boundary.sh` — boundary gate. Asserts `validateUrl`/`safeFetch` are imported only from `apps/web/app/api/**/route.ts`, the defining module, or the test file.
- `apps/web/package.json` — adds `grep:validateurl-boundary` script.

## Verification (from the issue)
- [x] Allowed host (`*.greenhouse.io` match) + public IP -> passes
- [x] Allowed host + private IP -> rejected with `url_resolves_to_private`
- [x] Allowed host + metadata IP (`169.254.169.254`) -> rejected
- [x] Disallowed host -> rejected with `url_not_allowed` (no DNS lookup performed)
- [x] Loopback (`localhost`, `127.0.0.1`) -> rejected
- [x] Link-local (`169.254.0.0/16`) -> rejected
- [x] IPv6 ULA (`fc00::/7`) -> rejected
- [x] DNS rebinding scenario: first lookup public, second lookup private; fetch uses post-resolution IP and rejects -> rejected
- [x] Test patterns documented in source as a static list (`HOST_ALLOWLIST` is a `readonly` const, no env-var override)
- [x] Module exports a single `validateUrl(url: string)` function with the exact return shape from the issue
- [ ] Module used in J5/#2759's routes (verified via codepath grep) — note: J5 is unmerged; this DoD item is intentionally unchecked and will be re-verified when J5 lands.

## Manual checks run locally
- `pnpm --filter @jobseek/web test src/lib/murmur/ssrf.test.ts` -> 29/29 pass
- `pnpm --filter @jobseek/web lint` -> clean
- `pnpm --filter @jobseek/web grep:validateurl-boundary` -> clean
- `pnpm --filter @jobseek/web exec tsc --noEmit` -> no new errors (the 3 unrelated existing errors in `app/mcp/route.ts` and `lib/actions/__tests__/company.test.ts` are pre-existing on `murmur-demo`).

## Notes for reviewer
- **Pinning approach.** `safeFetch` rewrites the URL hostname to the captured IP and preserves the original `Host` header. This is the simplest rebinding mitigation that requires no undici internals; the trade-off (TLS hostname check fails for the IP) is acceptable for the demo against public ATS endpoints. If we extend `safeFetch` to broader transport, swap to a `node:https` Agent with custom `lookup` + `servername` so SNI continues to use the original hostname.
- **Allowlist scope.** Six initial patterns covering Greenhouse, Lever, Workday — the dominant ATS providers in `apps/crawler/data/boards.csv`. Per the orchestrator note, I deliberately did not enumerate every host from `boards.csv`; the comment in `ssrf.ts` flags expansion as J5 routes encounter real rejections.
- **Boundary gate.** The bash gate is intentionally tiny and only checks import sites in `apps/web`. CI doesn't yet wire it up automatically; recommend adding it to whatever `grep:all` aggregator J* milestones eventually create.
- **Pre-existing test failure.** `app/mcp/route.test.ts` fails on `murmur-demo` independently of this PR (handler module is missing/uncompiled). Not addressed here.