### PR TITLE
refactor(jobseek): lift probe/run (monitor + scraper) from CLI to importable async

### DIFF
--- a/apps/crawler/scripts/grep-lib-purity.sh
+++ b/apps/crawler/scripts/grep-lib-purity.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Purity gate for src/workspace/lib/.
+#
+# Lib modules must not import from CLI-only modules:
+#   - src.workspace.commands.*
+#   - src.workspace.cli
+#   - src.workspace.output (the global "out" helper)
+#
+# Exits non-zero on any forbidden import, printing the offending lines.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+LIB_DIR="src/workspace/lib"
+if [[ ! -d "$LIB_DIR" ]]; then
+    echo "grep-lib-purity: $LIB_DIR not found" >&2
+    exit 1
+fi
+
+# shellcheck disable=SC2086
+violations=$(
+    grep -RnE \
+        -e '^[[:space:]]*from[[:space:]]+src\.workspace\.commands' \
+        -e '^[[:space:]]*import[[:space:]]+src\.workspace\.commands' \
+        -e '^[[:space:]]*from[[:space:]]+src\.workspace\.cli' \
+        -e '^[[:space:]]*import[[:space:]]+src\.workspace\.cli' \
+        -e '^[[:space:]]*from[[:space:]]+src\.workspace[[:space:]]+import[[:space:]]+output' \
+        -e '^[[:space:]]*from[[:space:]]+src\.workspace\.output' \
+        -e '^[[:space:]]*import[[:space:]]+src\.workspace\.output' \
+        --include='*.py' \
+        "$LIB_DIR" \
+    || true
+)
+
+if [[ -n "$violations" ]]; then
+    echo "grep-lib-purity: forbidden imports in $LIB_DIR:" >&2
+    echo "$violations" >&2
+    exit 1
+fi
+
+echo "grep-lib-purity: OK ($LIB_DIR has no forbidden imports)"

--- a/apps/crawler/src/workspace/commands/crawl.py
+++ b/apps/crawler/src/workspace/commands/crawl.py
@@ -7,7 +7,6 @@ import json
 import math
 import random
 import re
-import time
 
 import click
 
@@ -328,21 +327,23 @@ def probe_monitors(slug: str | None, board_alias: str | None, current_jobs: int,
 
     ws, board = _resolve_board(slug, board_alias)
 
-    async def _run():
-        from playwright.async_api import async_playwright
+    # Build the immutable lib snapshot and delegate to the importable async fn.
+    from src.workspace.lib import BoardConfigState, WsProbeFailed
+    from src.workspace.lib import probe_monitor as _lib_probe_monitor
 
-        from src.core.monitors import probe_all_monitors
-        from src.shared.http import create_http_client
+    state = BoardConfigState(
+        board_url=board.url,
+        alias=board.alias,
+        slug=slug,
+    )
+    try:
+        lib_result = asyncio.run(_lib_probe_monitor(state, current_jobs))
+    except WsProbeFailed as exc:
+        out.die(str(exc))
+        return  # pragma: no cover — out.die exits
 
-        http = create_http_client()
-        try:
-            async with async_playwright() as pw:
-                results = await probe_all_monitors(board.url, http, pw=pw)
-            return results
-        finally:
-            await _shutdown_http(http)
-
-    results = asyncio.run(_run())
+    # Re-derive the legacy tuple list so existing CLI helpers stay unchanged.
+    results = [(e.name, e.metadata, e.comment) for e in lib_result.entries]
 
     # Save probe artifact
     from src.workspace.artifacts import probe_run_dir, save_probe
@@ -484,20 +485,27 @@ def probe_scraper(slug: str | None, board_alias: str | None, urls: tuple[str, ..
 
     out.info("probe", f"Probing {len(target_urls)} sample URLs...")
 
-    async def _run():
-        from playwright.async_api import async_playwright
+    # Build the immutable lib snapshot and delegate to the importable async fn.
+    from src.workspace.lib import BoardConfigState, WsConfigMissing, WsProbeFailed
+    from src.workspace.lib import probe_scraper as _lib_probe_scraper
 
-        from src.core.scrapers import probe_scrapers
-        from src.shared.http import create_http_client
+    state = BoardConfigState(
+        board_url=board.url,
+        alias=board.alias,
+        slug=slug,
+        sample_urls=tuple(target_urls),
+    )
+    try:
+        lib_result = asyncio.run(_lib_probe_scraper(state, sample_urls=target_urls))
+    except WsConfigMissing as exc:
+        out.die(str(exc))
+        return  # pragma: no cover
+    except WsProbeFailed as exc:
+        out.die(str(exc))
+        return  # pragma: no cover
 
-        http = create_http_client()
-        try:
-            async with async_playwright() as pw:
-                return await probe_scrapers(target_urls, http, pw=pw)
-        finally:
-            await _shutdown_http(http)
-
-    results, spa_suspect = asyncio.run(_run())
+    results = [(e.name, e.metadata, e.comment) for e in lib_result.entries]
+    spa_suspect = lib_result.spa_suspect
 
     # Save artifacts
     from src.workspace.artifacts import save_probe, scraper_probe_run_dir
@@ -1190,34 +1198,36 @@ def run_monitor(slug: str | None, board_alias: str | None, config_name: str | No
     run_dir = monitor_run_dir(slug, board.alias)
     log_events = capture_structlog()
 
-    async def _run():
-        from playwright.async_api import async_playwright
+    # Build the immutable lib snapshot and delegate to the importable async fn.
+    from src.workspace.lib import BoardConfigState, WsConfigMissing, WsMonitorRunFailed
+    from src.workspace.lib import run_monitor as _lib_run_monitor
 
-        from src.core.monitor import monitor_one
-        from src.shared.http import create_logging_http_client
-
-        ssl_verify = (board.monitor_config or {}).get("ssl_verify", True)
-        use_proxy = bool((mon_config or {}).get("proxy"))
-        http, http_log = create_logging_http_client(verify=ssl_verify, use_proxy=use_proxy)
-        try:
-            async with async_playwright() as pw:
-                start = time.monotonic()
-                result = await monitor_one(
-                    board.url,
-                    mon_type,
-                    mon_config or None,
-                    http,
-                    artifact_dir=run_dir,
-                    pw=pw,
-                )
-                elapsed = time.monotonic() - start
-            return result, elapsed, http_log
-        finally:
-            await _shutdown_http(http)
+    state = BoardConfigState(
+        board_url=board.url,
+        alias=board.alias,
+        slug=slug,
+        monitor_type=mon_type,
+        monitor_config=mon_config or {},
+        ssl_verify=(board.monitor_config or {}).get("ssl_verify", True),
+        use_proxy=bool((mon_config or {}).get("proxy")),
+    )
 
     try:
-        result, elapsed, http_log = asyncio.run(_run())
-    except Exception as exc:
+        lib_result = asyncio.run(
+            _lib_run_monitor(
+                state,
+                config_name=config_name,
+                artifact_dir=run_dir,
+                log_events=log_events,
+            )
+        )
+        result = lib_result  # downstream code reads .urls / .jobs_by_url / .filtered_count
+        elapsed = lib_result.elapsed_seconds
+        http_log = lib_result.http_log
+    except WsConfigMissing as exc:
+        out.die(str(exc))
+        return  # pragma: no cover
+    except WsMonitorRunFailed as exc:
         detail = str(exc).strip() or exc.__class__.__name__
         out.error("monitor", f"Run failed: {detail}")
         out.plain("monitor", f"Monitor: {mon_type} | Board: {board.url}")
@@ -1668,45 +1678,42 @@ def run_scraper(
     run_dir = scraper_run_dir(slug, board.alias)
     log_events = capture_structlog()
 
-    async def _run():
-        from httpx import HTTPStatusError
-        from playwright.async_api import async_playwright
+    # Build the immutable lib snapshot and delegate to the importable async fn.
+    from src.workspace.lib import BoardConfigState, WsConfigMissing, WsScraperRunFailed
+    from src.workspace.lib import run_scraper as _lib_run_scraper
 
-        from src.core.scrape import scrape_one
-        from src.processing.scrape import _apply_defaults
-        from src.shared.http import create_logging_http_client
+    state = BoardConfigState(
+        board_url=board.url,
+        alias=board.alias,
+        slug=slug,
+        scraper_type=scr_type,
+        scraper_config=scr_config or {},
+        sample_urls=tuple(target_urls),
+        ssl_verify=(board.monitor_config or {}).get("ssl_verify", True),
+        use_proxy=bool((scr_config or {}).get("proxy")),
+    )
+    try:
+        lib_result = asyncio.run(
+            _lib_run_scraper(
+                state,
+                config_name=config_name,
+                sample_urls=target_urls,
+                artifact_dir=run_dir,
+                log_events=log_events,
+            )
+        )
+    except WsConfigMissing as exc:
+        out.die(str(exc))
+        return  # pragma: no cover
+    except WsScraperRunFailed as exc:
+        out.die(str(exc))
+        return  # pragma: no cover
 
-        ssl_verify = (board.monitor_config or {}).get("ssl_verify", True)
-        use_proxy = bool((scr_config or {}).get("proxy"))
-        http, http_log = create_logging_http_client(verify=ssl_verify, use_proxy=use_proxy)
-        results = []
-        skipped: list[tuple[str, str]] = []
-        try:
-            async with async_playwright() as pw:
-                for i, url in enumerate(target_urls):
-                    job_id = f"sample-{i}"
-                    start = time.monotonic()
-                    try:
-                        content = await scrape_one(
-                            url,
-                            scr_type,
-                            scr_config or None,
-                            http,
-                            artifact_dir=run_dir,
-                            job_id=job_id,
-                            pw=pw,
-                        )
-                    except HTTPStatusError as exc:
-                        skipped.append((url, str(exc.response.status_code)))
-                        continue
-                    content = _apply_defaults(content, scr_config or {})
-                    elapsed = time.monotonic() - start
-                    results.append((url, content, elapsed))
-            return results, http_log, skipped
-        finally:
-            await _shutdown_http(http)
-
-    results, http_log, skipped = asyncio.run(_run())
+    # Convert lib result back to the legacy (url, content, elapsed) tuples
+    # the rest of this handler operates on.
+    results = [(it.url, it.content, it.elapsed_seconds) for it in lib_result.items]
+    http_log = lib_result.http_log
+    skipped = lib_result.skipped
 
     # Save HTTP log and structlog events
     save_http_log(run_dir, http_log)

--- a/apps/crawler/src/workspace/lib/README.md
+++ b/apps/crawler/src/workspace/lib/README.md
@@ -1,0 +1,39 @@
+# `workspace/lib/` — pure async probe / run
+
+This package lifts the four CLI handlers
+(`ws probe monitor`, `ws probe scraper`, `ws run monitor`, `ws run scraper`)
+out of `src/workspace/commands/crawl.py` into pure, importable async
+functions.
+
+## Purity contract
+
+Modules in this package **must not** import from:
+
+- `src.workspace.commands.*`
+- `src.workspace.cli`
+- `src.workspace.output`
+
+These imports are blocked by `apps/crawler/scripts/grep-lib-purity.sh`
+(invoked from CI and from `tests/test_lib_purity.py`).  Reasons:
+
+1. The lib must be callable from non-CLI contexts (a long-running
+   probe pool, a future Murmur worker, etc.). Importing `out.die`
+   would tie any caller into `sys.exit`.
+2. Importing `commands/*` would pull in click, defeating the lift.
+
+## Public surface
+
+- `BoardConfigState` — frozen snapshot of board state
+- `WsLibError` (and subclasses) — typed exceptions
+- `probe_monitor`, `probe_scraper`, `run_monitor`, `run_scraper` — async
+
+Each function returns a JSON-serializable dataclass. See module docstrings.
+
+## What stays on the CLI side
+
+- File I/O on `.workspace/<slug>/` (artifact persistence)
+- Mutation of `state.WorkspaceState` / `Board` (write-back of run results)
+- Human-readable formatting (`out.info`, `out.warn`, tables)
+- `sys.exit` on user-facing failures (catch lib exceptions, `out.die`)
+
+The CLI handlers in `commands/crawl.py` are now thin adapters over this lib.

--- a/apps/crawler/src/workspace/lib/__init__.py
+++ b/apps/crawler/src/workspace/lib/__init__.py
@@ -1,0 +1,69 @@
+"""Pure async lib for probe / run (monitor + scraper).
+
+This package is the importable boundary that lifts work formerly bound to
+``ws probe ...`` / ``ws run ...`` click commands into pure async functions.
+
+Purity contract (verified by ``scripts/grep-lib-purity.sh`` and
+``tests/test_lib_purity.py``):
+
+- No imports from ``src.workspace.commands``
+- No imports from ``src.workspace.cli``
+- No imports from ``src.workspace.output``
+
+Lib functions:
+
+- accept an explicit :class:`BoardConfigState` snapshot
+- never mutate the input snapshot (frozen dataclass)
+- never touch ``state.WorkspaceState`` / :class:`Board`
+- never write to ``.workspace/`` or anywhere else on disk
+- raise typed exceptions instead of calling ``out.die``
+- return a JSON-serializable typed result dataclass
+"""
+
+from __future__ import annotations
+
+from src.workspace.lib.board_config import BoardConfigState
+from src.workspace.lib.exceptions import (
+    WsBoardNotFound,
+    WsConfigMissing,
+    WsLibError,
+    WsMonitorRunFailed,
+    WsProbeFailed,
+    WsScraperRunFailed,
+)
+from src.workspace.lib.probe import (
+    ProbeEntry,
+    ProbeMonitorResult,
+    ProbeScraperResult,
+    ScoredProbeEntry,
+    probe_monitor,
+    probe_scraper,
+)
+from src.workspace.lib.run import (
+    RunMonitorResult,
+    RunScraperResult,
+    ScrapedJob,
+    run_monitor,
+    run_scraper,
+)
+
+__all__ = [
+    "BoardConfigState",
+    "ProbeEntry",
+    "ProbeMonitorResult",
+    "ProbeScraperResult",
+    "RunMonitorResult",
+    "RunScraperResult",
+    "ScoredProbeEntry",
+    "ScrapedJob",
+    "WsBoardNotFound",
+    "WsConfigMissing",
+    "WsLibError",
+    "WsMonitorRunFailed",
+    "WsProbeFailed",
+    "WsScraperRunFailed",
+    "probe_monitor",
+    "probe_scraper",
+    "run_monitor",
+    "run_scraper",
+]

--- a/apps/crawler/src/workspace/lib/board_config.py
+++ b/apps/crawler/src/workspace/lib/board_config.py
@@ -1,0 +1,60 @@
+"""Immutable per-board state snapshot consumed by the lib functions.
+
+The CLI handlers in ``src.workspace.commands.crawl`` build a
+:class:`BoardConfigState` from a loaded ``Board`` and pass it to lib
+functions.  The lib functions never read or mutate :class:`Board` /
+:class:`Workspace` directly — this dataclass is the only state contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(frozen=True)
+class BoardConfigState:
+    """Frozen snapshot of the per-board state needed by probe / run lib.
+
+    ``frozen=True`` — lib functions cannot mutate it. Use ``dataclasses.replace``
+    if you need a derived snapshot.
+
+    Args:
+        board_url: The board URL to probe / monitor.
+        alias: Board alias (used for artifact paths by the CLI side, never by lib).
+        slug: Workspace slug (used for artifact paths by the CLI side, never by lib).
+        monitor_type: Monitor type name, e.g. ``"sitemap"`` / ``"greenhouse"``.
+            ``None`` means no monitor selected.
+        monitor_config: Monitor config dict (frozen by convention; lib treats as read-only).
+        scraper_type: Scraper type name. ``None`` means no scraper selected.
+        scraper_config: Scraper config dict.
+        sample_urls: Sample URLs from a previous monitor run (used by run_scraper).
+        ssl_verify: Whether to verify TLS certificates for outbound HTTP.
+        use_proxy: Whether to route monitor/scraper traffic through the proxy.
+    """
+
+    board_url: str
+    alias: str = ""
+    slug: str = ""
+    monitor_type: str | None = None
+    monitor_config: dict[str, Any] = field(default_factory=dict)
+    scraper_type: str | None = None
+    scraper_config: dict[str, Any] = field(default_factory=dict)
+    sample_urls: tuple[str, ...] = ()
+    ssl_verify: bool = True
+    use_proxy: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable dict (frozen-aware)."""
+        return {
+            "board_url": self.board_url,
+            "alias": self.alias,
+            "slug": self.slug,
+            "monitor_type": self.monitor_type,
+            "monitor_config": dict(self.monitor_config),
+            "scraper_type": self.scraper_type,
+            "scraper_config": dict(self.scraper_config),
+            "sample_urls": list(self.sample_urls),
+            "ssl_verify": self.ssl_verify,
+            "use_proxy": self.use_proxy,
+        }

--- a/apps/crawler/src/workspace/lib/exceptions.py
+++ b/apps/crawler/src/workspace/lib/exceptions.py
@@ -1,0 +1,46 @@
+"""Typed exceptions raised by the workspace lib.
+
+Replaces ``out.die(...)`` calls in the click handlers — the lib never
+prints and never calls ``sys.exit``.  Callers (the CLI adapter or other
+agents) catch these and decide how to surface the failure.
+"""
+
+from __future__ import annotations
+
+
+class WsLibError(Exception):
+    """Base class for all lib errors."""
+
+
+class WsBoardNotFound(WsLibError):
+    """Raised when the requested workspace / board does not exist."""
+
+
+class WsConfigMissing(WsLibError):
+    """Raised when the board lacks the configuration required for the operation.
+
+    Examples: ``run_monitor`` called with no monitor selected; ``run_scraper``
+    called with no scraper selected; ``run_scraper`` called with no sample URLs
+    available and no override list provided.
+    """
+
+
+class WsProbeFailed(WsLibError):
+    """Raised when a probe (monitor or scraper) hits a fatal upstream error.
+
+    The lib normally returns partial results when *individual* probes fail
+    (one entry per monitor/scraper type — failed entries have ``metadata=None``).
+    This exception is for fatal failures (e.g. cannot bring up Playwright).
+    """
+
+
+class WsMonitorRunFailed(WsLibError):
+    """Raised when ``monitor_one`` raises an exception.
+
+    Wraps the underlying exception; ``__cause__`` carries the original.
+    The CLI adapter inspects ``__cause__`` to print recovery hints.
+    """
+
+
+class WsScraperRunFailed(WsLibError):
+    """Raised when ``scrape_one`` raises a non-HTTP-status exception."""

--- a/apps/crawler/src/workspace/lib/probe.py
+++ b/apps/crawler/src/workspace/lib/probe.py
@@ -1,0 +1,305 @@
+"""Pure async probe functions: ``probe_monitor`` and ``probe_scraper``.
+
+Lifted from CLI bindings in ``src.workspace.commands.crawl``.  These
+functions exercise upstream probe machinery (``probe_all_monitors``,
+``probe_scrapers``) and return structured, JSON-serializable results.
+
+They:
+
+- never write to disk
+- never mutate the input :class:`BoardConfigState`
+- never call ``out.*`` / ``sys.exit``
+
+The CLI adapter is responsible for artifact persistence, board state
+write-back, and human-readable formatting.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from src.workspace.lib.board_config import BoardConfigState
+from src.workspace.lib.exceptions import WsProbeFailed
+
+# ── Cost scoring (lifted verbatim — same constants as the CLI module) ──
+
+_SUSPICIOUS_ROUND_THRESHOLDS = {1000, 5000, 10000, 50000, 100000}
+
+_SCRAPER_COST_PER_JOB: dict[str, float] = {
+    "json-ld": 0.3,
+    "nextdata": 0.3,
+    "embedded": 0.3,
+    "dom": 0.5,
+    "dom_render": 4.0,
+    "api_sniffer": 3.0,
+}
+
+_DEFAULT_SCRAPER_COST = 0.3
+
+
+# ── Result types ──────────────────────────────────────────────────────
+
+
+@dataclass
+class ProbeEntry:
+    """One probe result row.
+
+    ``metadata is None`` indicates the probe did not detect this monitor /
+    scraper type for the given URL.  ``comment`` carries a human-readable
+    diagnostic returned by the probe.
+    """
+
+    name: str
+    metadata: dict[str, Any] | None
+    comment: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "metadata": self.metadata, "comment": self.comment}
+
+
+@dataclass
+class ScoredProbeEntry:
+    """A :class:`ProbeEntry` with cost scoring fields."""
+
+    name: str
+    metadata: dict[str, Any] | None
+    comment: str
+    monitor_cost: float | None
+    initial_load: float
+    rich: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ProbeMonitorResult:
+    """Result of :func:`probe_monitor`.
+
+    ``entries`` is the raw probe output (one row per monitor type).
+    ``scored`` is the cost-scored view used by the CLI to print
+    high/low priority groups.
+    """
+
+    board_url: str
+    current_jobs: int
+    entries: list[ProbeEntry] = field(default_factory=list)
+    scored: list[ScoredProbeEntry] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "board_url": self.board_url,
+            "current_jobs": self.current_jobs,
+            "entries": [e.to_dict() for e in self.entries],
+            "scored": [s.to_dict() for s in self.scored],
+        }
+
+
+@dataclass
+class ProbeScraperResult:
+    """Result of :func:`probe_scraper`.
+
+    ``spa_suspect`` flags pages with very little static text (likely
+    JS-rendered SPAs whose static probes are unreliable).
+    """
+
+    sample_urls: list[str]
+    entries: list[ProbeEntry] = field(default_factory=list)
+    spa_suspect: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "sample_urls": list(self.sample_urls),
+            "entries": [e.to_dict() for e in self.entries],
+            "spa_suspect": self.spa_suspect,
+        }
+
+
+# ── Cost helpers ──────────────────────────────────────────────────────
+
+
+def estimate_monitor_cost(name: str, n_jobs: int, metadata: dict | None = None) -> float:
+    """Estimate seconds per single monitor invocation (one polling cycle).
+
+    Mirrors the legacy ``_estimate_monitor_cost`` heuristic exactly — used
+    by both the lib (for ``ProbeMonitorResult.scored``) and the CLI side
+    (for cost write-back into ``cfg["cost"]``).
+    """
+    from src.workspace._compat import api_monitor_types
+
+    if name in api_monitor_types():
+        return 1.0
+    if name == "api_sniffer":
+        page_size = (metadata or {}).get("items", 50)
+        pages = max(1, math.ceil(n_jobs / page_size))
+        if (metadata or {}).get("browser"):
+            return 5.0 + 0.5 * pages
+        return 0.3 * pages
+    if name == "sitemap":
+        return 1.5
+    if name in ("dom", "nextdata"):
+        return 1.0
+    return 2.0
+
+
+def estimate_initial_load(n_jobs: int, scraper_per_job: float = _DEFAULT_SCRAPER_COST) -> float:
+    """One-time cost to scrape all existing jobs on first run (URL-only monitors)."""
+    return n_jobs * scraper_per_job
+
+
+def score_probe_entries(entries: list[ProbeEntry], current_jobs: int) -> list[ScoredProbeEntry]:
+    """Compute cost scores and rich-classification for each probe entry."""
+    from src.workspace._compat import api_monitor_types
+
+    n_jobs = current_jobs or 200
+    scored: list[ScoredProbeEntry] = []
+    for entry in entries:
+        metadata = entry.metadata
+        if metadata is not None:
+            rich = entry.name in api_monitor_types() or (
+                entry.name == "api_sniffer" and bool((metadata or {}).get("fields"))
+            )
+            mon_cost = estimate_monitor_cost(entry.name, n_jobs, metadata)
+            init_load = 0.0 if rich else estimate_initial_load(n_jobs)
+            scored.append(
+                ScoredProbeEntry(
+                    name=entry.name,
+                    metadata=metadata,
+                    comment=entry.comment,
+                    monitor_cost=mon_cost,
+                    initial_load=init_load,
+                    rich=rich,
+                )
+            )
+        else:
+            scored.append(
+                ScoredProbeEntry(
+                    name=entry.name,
+                    metadata=None,
+                    comment=entry.comment,
+                    monitor_cost=None,
+                    initial_load=0.0,
+                    rich=False,
+                )
+            )
+    return scored
+
+
+# ── Public lib functions ──────────────────────────────────────────────
+
+
+async def probe_monitor(
+    state: BoardConfigState,
+    expected_count: int,
+) -> ProbeMonitorResult:
+    """Probe all monitor types for ``state.board_url``.
+
+    Args:
+        state: Frozen board snapshot. Only ``board_url`` is required;
+            ``alias`` / ``slug`` are not used by this function.
+        expected_count: The number of jobs the user reported visible on the
+            careers page. Used solely for cost scoring; pass ``0`` for
+            "unknown".
+
+    Returns:
+        :class:`ProbeMonitorResult` with raw entries and scored entries.
+
+    Raises:
+        WsProbeFailed: if Playwright / HTTP plumbing fails to start.
+    """
+    # Lazy imports keep this module fast to import (and avoid pulling
+    # Playwright into every CLI startup).
+    try:
+        from playwright.async_api import async_playwright
+
+        from src.core.monitors import probe_all_monitors
+        from src.shared.http import create_http_client
+    except ImportError as exc:  # pragma: no cover — environment issue
+        raise WsProbeFailed(f"probe_monitor: missing dependency: {exc}") from exc
+
+    http = create_http_client()
+    try:
+        async with async_playwright() as pw:
+            raw = await probe_all_monitors(state.board_url, http, pw=pw)
+    except Exception as exc:
+        raise WsProbeFailed(f"probe_monitor failed: {exc}") from exc
+    finally:
+        await http.aclose()
+
+    entries = [
+        ProbeEntry(name=name, metadata=metadata, comment=comment) for name, metadata, comment in raw
+    ]
+    scored = score_probe_entries(entries, expected_count)
+    return ProbeMonitorResult(
+        board_url=state.board_url,
+        current_jobs=expected_count,
+        entries=entries,
+        scored=scored,
+    )
+
+
+async def probe_scraper(
+    state: BoardConfigState,
+    sample_url: str | None = None,
+    sample_urls: list[str] | None = None,
+) -> ProbeScraperResult:
+    """Probe all scraper types against the provided sample URLs.
+
+    Args:
+        state: Frozen board snapshot. ``state.sample_urls`` provides the
+            default URL list (capped at 10).
+        sample_url: Convenience shorthand — a single URL override.
+        sample_urls: Multi-URL override. Wins over both ``sample_url`` and
+            ``state.sample_urls`` when provided.
+
+    Returns:
+        :class:`ProbeScraperResult` with entries and ``spa_suspect`` flag.
+
+    Raises:
+        WsConfigMissing: if no sample URLs are available.
+        WsProbeFailed: on upstream fatal errors.
+    """
+    from src.workspace.lib.exceptions import WsConfigMissing
+
+    # Resolve target URL list. Explicit overrides win.
+    targets: list[str]
+    if sample_urls is not None and sample_urls:
+        targets = list(sample_urls)
+    elif sample_url:
+        targets = [sample_url]
+    else:
+        targets = list(state.sample_urls)
+    targets = targets[:10]
+
+    if not targets:
+        raise WsConfigMissing(
+            "probe_scraper: no sample URLs available. Run a monitor first or pass sample_url(s)."
+        )
+
+    try:
+        from playwright.async_api import async_playwright
+
+        from src.core.scrapers import probe_scrapers
+        from src.shared.http import create_http_client
+    except ImportError as exc:  # pragma: no cover
+        raise WsProbeFailed(f"probe_scraper: missing dependency: {exc}") from exc
+
+    http = create_http_client()
+    try:
+        async with async_playwright() as pw:
+            raw, spa_suspect = await probe_scrapers(targets, http, pw=pw)
+    except Exception as exc:
+        raise WsProbeFailed(f"probe_scraper failed: {exc}") from exc
+    finally:
+        await http.aclose()
+
+    entries = [
+        ProbeEntry(name=name, metadata=metadata, comment=comment) for name, metadata, comment in raw
+    ]
+    return ProbeScraperResult(
+        sample_urls=targets,
+        entries=entries,
+        spa_suspect=bool(spa_suspect),
+    )

--- a/apps/crawler/src/workspace/lib/run.py
+++ b/apps/crawler/src/workspace/lib/run.py
@@ -1,0 +1,396 @@
+"""Pure async run functions: ``run_monitor`` and ``run_scraper``.
+
+Lifted from CLI bindings in ``src.workspace.commands.crawl``.  These
+functions exercise upstream pipelines (``monitor_one``, ``scrape_one``)
+and return structured, JSON-serializable results.
+
+They:
+
+- never write to disk (the caller persists ``artifact_dir`` via ``monitor_one``)
+- never mutate the input :class:`BoardConfigState`
+- never call ``out.*`` / ``sys.exit``
+
+The CLI adapter is responsible for artifact persistence (HTTP log,
+events, processed jobs/results, quality reports), board state write-back,
+and human-readable formatting.
+
+Note on artifact directory: ``monitor_one`` and ``scrape_one`` both
+accept an optional ``artifact_dir`` for raw-data dumps (HTML, raw API
+responses).  The lib accepts that path through the function signature
+so the *caller* controls where raw data lands; the lib itself does not
+construct or own those paths.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+from src.workspace.lib.board_config import BoardConfigState
+from src.workspace.lib.exceptions import (
+    WsConfigMissing,
+    WsMonitorRunFailed,
+    WsScraperRunFailed,
+)
+
+# ── Result types ──────────────────────────────────────────────────────
+
+
+@dataclass
+class RunMonitorResult:
+    """Structured result of :func:`run_monitor`.
+
+    Attributes mirror what the CLI adapter needs to render output, build
+    quality reports, and persist board state — all without re-running
+    the monitor.
+
+    ``urls`` is sorted for deterministic output (the underlying
+    ``MonitorResult.urls`` is a ``set``).  ``jobs_by_url`` is preserved
+    as the original dict so callers can run their own iteration order.
+    """
+
+    board_url: str
+    monitor_type: str
+    urls: list[str]
+    jobs_by_url: dict[str, Any] | None
+    filtered_count: int
+    elapsed_seconds: float
+    has_rich_data: bool
+    sample_urls: list[str]
+    description_samples: list[dict[str, Any]] = field(default_factory=list)
+    quality: dict[str, Any] | None = None
+    http_log: list[dict[str, Any]] = field(default_factory=list)
+    log_events: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        # ``jobs_by_url`` may contain DiscoveredJob dataclasses; we only
+        # expose URL keys + a length here for JSON safety. Callers that
+        # need the rich objects should use the attribute directly.
+        return {
+            "board_url": self.board_url,
+            "monitor_type": self.monitor_type,
+            "urls": list(self.urls),
+            "job_count": len(self.urls),
+            "has_rich_data": self.has_rich_data,
+            "filtered_count": self.filtered_count,
+            "elapsed_seconds": self.elapsed_seconds,
+            "sample_urls": list(self.sample_urls),
+            "description_samples": list(self.description_samples),
+            "quality": self.quality,
+        }
+
+
+@dataclass
+class ScrapedJob:
+    """One scraped item from :func:`run_scraper`.
+
+    ``content`` is the raw ``JobContent`` dataclass from the scraper —
+    callers can ``dataclasses.asdict(content)`` for JSON output.
+    """
+
+    url: str
+    content: Any  # core.scrapers.JobContent — kept loose to avoid hard import
+    elapsed_seconds: float
+
+    def to_dict(self) -> dict[str, Any]:
+        try:
+            content_dict = asdict(self.content) if self.content is not None else None
+        except TypeError:
+            content_dict = None
+        return {
+            "url": self.url,
+            "content": content_dict,
+            "elapsed_seconds": self.elapsed_seconds,
+        }
+
+
+@dataclass
+class RunScraperResult:
+    """Structured result of :func:`run_scraper`."""
+
+    scraper_type: str
+    items: list[ScrapedJob] = field(default_factory=list)
+    skipped: list[tuple[str, str]] = field(default_factory=list)
+    description_samples: list[dict[str, Any]] = field(default_factory=list)
+    avg_elapsed_seconds: float = 0.0
+    http_log: list[dict[str, Any]] = field(default_factory=list)
+    log_events: list[dict[str, Any]] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "scraper_type": self.scraper_type,
+            "count": len(self.items),
+            "skipped": [list(s) for s in self.skipped],
+            "items": [it.to_dict() for it in self.items],
+            "description_samples": list(self.description_samples),
+            "avg_elapsed_seconds": self.avg_elapsed_seconds,
+        }
+
+
+# ── Public lib functions ──────────────────────────────────────────────
+
+
+async def run_monitor(
+    state: BoardConfigState,
+    config_name: str | None = None,
+    *,
+    artifact_dir: Path | None = None,
+    capture_http_log: list[dict[str, Any]] | None = None,
+    log_events: list[dict[str, Any]] | None = None,
+) -> RunMonitorResult:
+    """Test-run ``monitor_one`` against ``state.board_url``.
+
+    Args:
+        state: Frozen board snapshot. Must have ``monitor_type`` set.
+        config_name: Informational; carried into the result for logging.
+            Lib does not look up configs by name — the caller already
+            resolved ``state.monitor_config`` from the named config.
+        artifact_dir: Optional path passed to ``monitor_one`` for raw-data
+            dumps. The lib does **not** create or write to this directory
+            itself — it merely forwards the path.  Pass ``None`` to skip.
+        capture_http_log: Pre-allocated list to collect HTTP exchanges.
+            If ``None``, the lib creates a fresh list and returns it on
+            the result.  Callers (the CLI) typically allocate one so
+            they can pass it to artifact persistence after the run.
+        log_events: Pre-allocated list to collect structlog events.
+
+    Returns:
+        :class:`RunMonitorResult` populated with URLs, jobs, timing, and
+        quality data.
+
+    Raises:
+        WsConfigMissing: if ``state.monitor_type`` is unset.
+        WsMonitorRunFailed: wraps any exception from ``monitor_one``.
+    """
+    if not state.monitor_type:
+        raise WsConfigMissing("run_monitor: no monitor_type in BoardConfigState")
+
+    try:
+        from playwright.async_api import async_playwright
+
+        from src.core.monitor import monitor_one
+        from src.shared.http import create_logging_http_client
+    except ImportError as exc:  # pragma: no cover
+        raise WsMonitorRunFailed(f"run_monitor: missing dependency: {exc}") from exc
+
+    http, http_log = create_logging_http_client(
+        verify=state.ssl_verify,
+        use_proxy=state.use_proxy,
+    )
+    if capture_http_log is not None:
+        # Caller wants their own list as the canonical log; we still rely
+        # on ``http_log`` from the factory and copy at the end.
+        pass
+
+    try:
+        async with async_playwright() as pw:
+            start = time.monotonic()
+            try:
+                raw_result = await monitor_one(
+                    state.board_url,
+                    state.monitor_type,
+                    state.monitor_config or None,
+                    http,
+                    artifact_dir=artifact_dir,
+                    pw=pw,
+                )
+            except Exception as exc:
+                raise WsMonitorRunFailed(str(exc) or exc.__class__.__name__) from exc
+            elapsed = time.monotonic() - start
+    finally:
+        await http.aclose()
+
+    urls = sorted(raw_result.urls)
+    has_rich = raw_result.jobs_by_url is not None
+
+    # Description samples for quality validation downstream (legacy parity).
+    desc_samples: list[dict[str, Any]] = []
+    if raw_result.jobs_by_url:
+        for job in list(raw_result.jobs_by_url.values())[:5]:
+            desc = getattr(job, "description", None)
+            if desc:
+                plain = re.sub(r"<[^>]+>", "", desc).strip()
+                desc_samples.append({"length": len(plain), "snippet": plain[:200]})
+
+    # Sample URLs (cap at 10, deterministic by sort to make snapshots stable).
+    # The legacy CLI used random.sample; we let the *caller* decide sampling
+    # if they want randomness — return the sorted top-10 here.  The CLI
+    # adapter passes the pre-existing random.sample call through if it wants
+    # legacy parity.
+    sample = list(urls)[:10]
+
+    # Quality report (rich monitors only).
+    quality: dict[str, Any] | None = None
+    if raw_result.jobs_by_url:
+        quality = _build_monitor_quality(raw_result.jobs_by_url)
+
+    final_http_log = capture_http_log if capture_http_log is not None else list(http_log)
+    if capture_http_log is not None:
+        capture_http_log.extend(http_log)
+    final_events = log_events if log_events is not None else []
+
+    return RunMonitorResult(
+        board_url=state.board_url,
+        monitor_type=state.monitor_type,
+        urls=urls,
+        jobs_by_url=raw_result.jobs_by_url,
+        filtered_count=raw_result.filtered_count,
+        elapsed_seconds=round(elapsed, 4),
+        has_rich_data=has_rich,
+        sample_urls=sample,
+        description_samples=desc_samples,
+        quality=quality,
+        http_log=final_http_log,
+        log_events=final_events,
+    )
+
+
+async def run_scraper(
+    state: BoardConfigState,
+    config_name: str | None = None,
+    sample_urls: list[str] | None = None,
+    *,
+    artifact_dir: Path | None = None,
+    capture_http_log: list[dict[str, Any]] | None = None,
+    log_events: list[dict[str, Any]] | None = None,
+) -> RunScraperResult:
+    """Test-run ``scrape_one`` against the provided / inherited sample URLs.
+
+    Args:
+        state: Frozen board snapshot. Must have ``scraper_type`` set.
+        config_name: Informational; carried into the result for logging.
+        sample_urls: Override list of URLs to scrape. ``None`` falls back
+            to ``state.sample_urls``.
+        artifact_dir: Optional path passed to ``scrape_one`` for raw HTML
+            dumps. Lib never creates or writes here.
+        capture_http_log: Pre-allocated list for HTTP exchanges.
+        log_events: Pre-allocated list for structlog events.
+
+    Returns:
+        :class:`RunScraperResult` with extracted content per URL.
+
+    Raises:
+        WsConfigMissing: when ``state.scraper_type`` is unset or no URLs.
+        WsScraperRunFailed: on a fatal upstream error (per-URL HTTP errors
+            are captured in ``result.skipped`` instead).
+    """
+    if not state.scraper_type:
+        raise WsConfigMissing("run_scraper: no scraper_type in BoardConfigState")
+
+    targets: list[str] = list(sample_urls) if sample_urls else list(state.sample_urls)
+    if not targets:
+        raise WsConfigMissing(
+            "run_scraper: no URLs to scrape. Run the monitor first or pass sample_urls."
+        )
+
+    try:
+        from httpx import HTTPStatusError
+        from playwright.async_api import async_playwright
+
+        from src.core.scrape import scrape_one
+        from src.processing.scrape import _apply_defaults
+        from src.shared.http import create_logging_http_client
+    except ImportError as exc:  # pragma: no cover
+        raise WsScraperRunFailed(f"run_scraper: missing dependency: {exc}") from exc
+
+    http, http_log = create_logging_http_client(
+        verify=state.ssl_verify,
+        use_proxy=state.use_proxy,
+    )
+
+    items: list[ScrapedJob] = []
+    skipped: list[tuple[str, str]] = []
+    try:
+        async with async_playwright() as pw:
+            for i, url in enumerate(targets):
+                job_id = f"sample-{i}"
+                start = time.monotonic()
+                try:
+                    content = await scrape_one(
+                        url,
+                        state.scraper_type,
+                        state.scraper_config or None,
+                        http,
+                        artifact_dir=artifact_dir,
+                        job_id=job_id,
+                        pw=pw,
+                    )
+                except HTTPStatusError as exc:
+                    skipped.append((url, str(exc.response.status_code)))
+                    continue
+                except Exception as exc:
+                    raise WsScraperRunFailed(str(exc) or exc.__class__.__name__) from exc
+                content = _apply_defaults(content, state.scraper_config or {})
+                elapsed = time.monotonic() - start
+                items.append(ScrapedJob(url=url, content=content, elapsed_seconds=elapsed))
+    finally:
+        await http.aclose()
+
+    # Description samples (first 5 with descriptions).
+    desc_samples: list[dict[str, Any]] = []
+    for it in items:
+        desc = getattr(it.content, "description", None)
+        if desc and len(desc_samples) < 5:
+            plain = re.sub(r"<[^>]+>", "", desc).strip()
+            desc_samples.append({"length": len(plain), "snippet": plain[:200]})
+
+    avg_elapsed = sum(it.elapsed_seconds for it in items) / len(items) if items else 0.0
+
+    final_http_log = capture_http_log if capture_http_log is not None else list(http_log)
+    if capture_http_log is not None:
+        capture_http_log.extend(http_log)
+    final_events = log_events if log_events is not None else []
+
+    return RunScraperResult(
+        scraper_type=state.scraper_type or "",
+        items=items,
+        skipped=skipped,
+        description_samples=desc_samples,
+        avg_elapsed_seconds=round(avg_elapsed, 4),
+        http_log=final_http_log,
+        log_events=final_events,
+    )
+
+
+# ── Quality helpers ───────────────────────────────────────────────────
+
+
+_MONITOR_QUALITY_FIELDS = (
+    "title",
+    "description",
+    "locations",
+    "employment_type",
+    "job_location_type",
+    "date_posted",
+    "base_salary",
+    "skills",
+    "responsibilities",
+    "qualifications",
+)
+
+_EXTRAS_FIELDS = {"skills", "responsibilities", "qualifications", "valid_through"}
+
+
+def _get_field(obj: object, field_name: str) -> object:
+    """Get a quality field value from a job object (extras-aware)."""
+    if field_name in _EXTRAS_FIELDS:
+        extras = getattr(obj, "extras", None)
+        if isinstance(extras, dict):
+            return extras.get(field_name)
+        return None
+    return getattr(obj, field_name, None)
+
+
+def _build_monitor_quality(jobs_by_url: dict[str, Any]) -> dict[str, Any]:
+    """Build the quality summary dict consumed by the CLI / artifacts."""
+    jobs = list(jobs_by_url.values())
+    total = len(jobs)
+    fields_summary: dict[str, dict[str, int]] = {}
+    for fname in _MONITOR_QUALITY_FIELDS:
+        count = sum(1 for j in jobs if _get_field(j, fname))
+        pct = round(count / total * 100) if total else 0
+        fields_summary[fname] = {"count": count, "pct": pct}
+    return {"total": total, "fields": fields_summary}

--- a/apps/crawler/tests/test_lib_probe.py
+++ b/apps/crawler/tests/test_lib_probe.py
@@ -1,0 +1,275 @@
+"""Tests for src.workspace.lib.probe — pure async probe functions."""
+
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.workspace.lib import (
+    BoardConfigState,
+    ProbeEntry,
+    ProbeMonitorResult,
+    ProbeScraperResult,
+    WsConfigMissing,
+    WsProbeFailed,
+    probe_monitor,
+    probe_scraper,
+)
+from src.workspace.lib.probe import (
+    estimate_initial_load,
+    estimate_monitor_cost,
+    score_probe_entries,
+)
+
+# ── Fixtures / helpers ─────────────────────────────────────────────────
+
+
+def _fixture_state(url: str = "https://test.example.com/jobs", **overrides) -> BoardConfigState:
+    return BoardConfigState(board_url=url, alias="careers", slug="test", **overrides)
+
+
+@pytest.fixture
+def patched_playwright_and_http():
+    """Patch Playwright async_playwright + http client used by probe lib."""
+    with (
+        patch("playwright.async_api.async_playwright") as pw_factory,
+        patch("src.shared.http.create_http_client") as http_factory,
+    ):
+        pw_ctx = AsyncMock()
+        pw_ctx.__aenter__.return_value = MagicMock(name="playwright")
+        pw_ctx.__aexit__.return_value = False
+        pw_factory.return_value = pw_ctx
+
+        http_client = AsyncMock()
+        http_client.aclose = AsyncMock()
+        http_factory.return_value = http_client
+
+        yield pw_factory, http_factory, http_client
+
+
+# ── probe_monitor ──────────────────────────────────────────────────────
+
+
+class TestProbeMonitorHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_entries_and_scored(self, patched_playwright_and_http):
+        with patch("src.core.monitors.probe_all_monitors", new_callable=AsyncMock) as probe_fn:
+            probe_fn.return_value = [
+                ("greenhouse", {"token": "acme"}, "GH detected"),
+                ("sitemap", {"urls": 12}, "sitemap"),
+                ("dom", None, "no jobs"),
+            ]
+            result = await probe_monitor(_fixture_state(), expected_count=200)
+
+        assert isinstance(result, ProbeMonitorResult)
+        assert result.board_url == "https://test.example.com/jobs"
+        assert result.current_jobs == 200
+        assert [e.name for e in result.entries] == ["greenhouse", "sitemap", "dom"]
+        # Scored mirrors entries; one rich (greenhouse) + URL-only (sitemap) + undetected (dom)
+        rich_entries = [s for s in result.scored if s.rich]
+        assert len(rich_entries) == 1
+        assert rich_entries[0].name == "greenhouse"
+        # Detected URL-only entry has cost
+        sitemap = next(s for s in result.scored if s.name == "sitemap")
+        assert sitemap.monitor_cost is not None
+        # Undetected entry has None cost
+        dom = next(s for s in result.scored if s.name == "dom")
+        assert dom.monitor_cost is None
+
+    @pytest.mark.asyncio
+    async def test_state_is_not_mutated(self, patched_playwright_and_http):
+        state = _fixture_state()
+        before = state.to_dict()
+        with patch("src.core.monitors.probe_all_monitors", new_callable=AsyncMock) as probe_fn:
+            probe_fn.return_value = []
+            await probe_monitor(state, expected_count=5)
+        # Frozen dataclass — mutation would have raised, but verify dict snapshot too.
+        assert state.to_dict() == before
+
+    @pytest.mark.asyncio
+    async def test_no_filesystem_writes(self, patched_playwright_and_http, tmp_path, monkeypatch):
+        """probe_monitor must not create or write to .workspace/."""
+        monkeypatch.chdir(tmp_path)
+        before_listing = sorted(os.listdir("."))
+        with patch("src.core.monitors.probe_all_monitors", new_callable=AsyncMock) as probe_fn:
+            probe_fn.return_value = [("sitemap", {"urls": 1}, "ok")]
+            await probe_monitor(_fixture_state(), expected_count=1)
+        after_listing = sorted(os.listdir("."))
+        assert before_listing == after_listing
+        assert not (tmp_path / ".workspace").exists()
+
+
+class TestProbeMonitorErrorCases:
+    @pytest.mark.asyncio
+    async def test_invalid_url_raises_typed(self, patched_playwright_and_http):
+        with patch("src.core.monitors.probe_all_monitors", new_callable=AsyncMock) as probe_fn:
+            probe_fn.side_effect = ValueError("Invalid URL: not-a-url")
+            with pytest.raises(WsProbeFailed) as exc_info:
+                await probe_monitor(_fixture_state(url="not-a-url"), expected_count=10)
+        assert "Invalid URL" in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, ValueError)
+
+    @pytest.mark.asyncio
+    async def test_timeout_5xx_raises_typed(self, patched_playwright_and_http):
+        with patch("src.core.monitors.probe_all_monitors", new_callable=AsyncMock) as probe_fn:
+            probe_fn.side_effect = TimeoutError("upstream 504")
+            with pytest.raises(WsProbeFailed):
+                await probe_monitor(_fixture_state(), expected_count=10)
+
+
+class TestProbeMonitorOutputSchema:
+    @pytest.mark.asyncio
+    async def test_to_dict_is_json_serializable(self, patched_playwright_and_http):
+        with patch("src.core.monitors.probe_all_monitors", new_callable=AsyncMock) as probe_fn:
+            probe_fn.return_value = [
+                ("sitemap", {"urls": 12, "sitemap_url": "https://x/s.xml"}, "ok"),
+                ("dom", None, "no detect"),
+            ]
+            result = await probe_monitor(_fixture_state(), expected_count=42)
+        d = result.to_dict()
+        # Round-trip through JSON ensures the snapshot stays JSON-safe
+        round_trip = json.loads(json.dumps(d))
+        assert round_trip["board_url"] == "https://test.example.com/jobs"
+        assert round_trip["current_jobs"] == 42
+        assert {"name", "metadata", "comment"} <= set(round_trip["entries"][0].keys())
+        assert {"monitor_cost", "rich", "initial_load"} <= set(round_trip["scored"][0].keys())
+
+
+# ── probe_scraper ──────────────────────────────────────────────────────
+
+
+class TestProbeScraperHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_entries_and_spa_flag(self, patched_playwright_and_http):
+        with patch("src.core.scrapers.probe_scrapers", new_callable=AsyncMock) as probe_fn:
+            probe_fn.return_value = (
+                [
+                    ("json-ld", {"titles": 2, "descriptions": 2, "config": {}}, "ok"),
+                    ("dom", None, "no schema"),
+                ],
+                False,
+            )
+            state = _fixture_state(sample_urls=("https://test.example.com/jobs/1",))
+            result = await probe_scraper(state)
+        assert isinstance(result, ProbeScraperResult)
+        assert result.spa_suspect is False
+        assert {e.name for e in result.entries} == {"json-ld", "dom"}
+
+    @pytest.mark.asyncio
+    async def test_explicit_sample_urls_override_state(self, patched_playwright_and_http):
+        urls_seen: list[list[str]] = []
+
+        async def _fake_probe(urls, http, pw):
+            urls_seen.append(list(urls))
+            return ([("json-ld", {"titles": 1, "descriptions": 1}, "ok")], False)
+
+        with patch("src.core.scrapers.probe_scrapers", side_effect=_fake_probe):
+            state = _fixture_state(sample_urls=("https://example.com/old/1",))
+            await probe_scraper(state, sample_urls=["https://example.com/new/1"])
+        assert urls_seen == [["https://example.com/new/1"]]
+
+    @pytest.mark.asyncio
+    async def test_no_filesystem_writes(self, patched_playwright_and_http, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        before = sorted(os.listdir("."))
+        with patch("src.core.scrapers.probe_scrapers", new_callable=AsyncMock) as probe_fn:
+            probe_fn.return_value = ([("json-ld", None, "no schema")], False)
+            await probe_scraper(_fixture_state(sample_urls=("https://example.com/x",)))
+        assert sorted(os.listdir(".")) == before
+
+
+class TestProbeScraperErrorCases:
+    @pytest.mark.asyncio
+    async def test_no_sample_urls_raises_config_missing(self, patched_playwright_and_http):
+        state = _fixture_state(sample_urls=())
+        with pytest.raises(WsConfigMissing):
+            await probe_scraper(state)
+
+    @pytest.mark.asyncio
+    async def test_upstream_failure_wraps(self, patched_playwright_and_http):
+        with patch("src.core.scrapers.probe_scrapers", new_callable=AsyncMock) as probe_fn:
+            probe_fn.side_effect = RuntimeError("playwright crashed")
+            state = _fixture_state(sample_urls=("https://example.com/x",))
+            with pytest.raises(WsProbeFailed):
+                await probe_scraper(state)
+
+
+class TestProbeScraperOutputSchema:
+    @pytest.mark.asyncio
+    async def test_to_dict_round_trips(self, patched_playwright_and_http):
+        with patch("src.core.scrapers.probe_scrapers", new_callable=AsyncMock) as probe_fn:
+            probe_fn.return_value = (
+                [("json-ld", {"titles": 1, "descriptions": 1, "config": {}}, "ok")],
+                True,
+            )
+            state = _fixture_state(sample_urls=("https://example.com/x",))
+            result = await probe_scraper(state)
+        d = json.loads(json.dumps(result.to_dict()))
+        assert d["spa_suspect"] is True
+        assert d["sample_urls"] == ["https://example.com/x"]
+        assert d["entries"][0]["name"] == "json-ld"
+
+
+# ── Cost helpers (pure-functional, deterministic) ──────────────────────
+
+
+class TestCostHelpers:
+    def test_estimate_monitor_cost_sitemap(self):
+        assert estimate_monitor_cost("sitemap", 100) == 1.5
+
+    def test_estimate_monitor_cost_dom(self):
+        assert estimate_monitor_cost("dom", 100) == 1.0
+
+    def test_estimate_monitor_cost_unknown_default(self):
+        assert estimate_monitor_cost("zzz_unknown", 100) == 2.0
+
+    def test_estimate_monitor_cost_api_sniffer_browser(self):
+        # browser=True path: base 5.0 + 0.5 per page
+        cost = estimate_monitor_cost("api_sniffer", 100, {"items": 50, "browser": True})
+        assert cost == pytest.approx(5.0 + 0.5 * 2)
+
+    def test_estimate_initial_load(self):
+        assert estimate_initial_load(100) == pytest.approx(30.0)
+
+    def test_score_entries_marks_rich_for_api_sniffer_with_fields(self):
+        entries = [
+            ProbeEntry(
+                name="api_sniffer", metadata={"fields": ["title"], "items": 10}, comment="ok"
+            ),
+            ProbeEntry(name="sitemap", metadata={"urls": 5}, comment="ok"),
+            ProbeEntry(name="dom", metadata=None, comment="no"),
+        ]
+        scored = score_probe_entries(entries, current_jobs=100)
+        assert scored[0].rich is True
+        assert scored[1].rich is False
+        assert scored[2].monitor_cost is None
+
+    def test_score_entries_is_pure(self):
+        """Same input → same output."""
+        entries = [ProbeEntry(name="sitemap", metadata={"urls": 5}, comment="ok")]
+        a = score_probe_entries(entries, 100)
+        b = score_probe_entries(entries, 100)
+        assert [s.to_dict() for s in a] == [s.to_dict() for s in b]
+
+
+# ── Determinism ────────────────────────────────────────────────────────
+
+
+class TestDeterminism:
+    @pytest.mark.asyncio
+    async def test_same_input_same_output(self, patched_playwright_and_http):
+        """Modulo HTTP nondeterminism, identical mocked inputs → identical outputs."""
+        fixture = [
+            ("sitemap", {"urls": 5}, "ok"),
+            ("dom", None, "no"),
+        ]
+        with patch("src.core.monitors.probe_all_monitors", new_callable=AsyncMock) as probe_fn:
+            probe_fn.return_value = fixture
+            r1 = await probe_monitor(_fixture_state(), expected_count=10)
+        with patch("src.core.monitors.probe_all_monitors", new_callable=AsyncMock) as probe_fn:
+            probe_fn.return_value = list(fixture)
+            r2 = await probe_monitor(_fixture_state(), expected_count=10)
+        assert r1.to_dict() == r2.to_dict()

--- a/apps/crawler/tests/test_lib_purity.py
+++ b/apps/crawler/tests/test_lib_purity.py
@@ -1,0 +1,55 @@
+"""CI gate: src/workspace/lib/ must not import CLI-only modules.
+
+Mirrors apps/crawler/scripts/grep-lib-purity.sh as a pytest test so the
+gate runs on every PR locally and in CI without a separate workflow step.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+LIB_DIR = Path(__file__).resolve().parent.parent / "src" / "workspace" / "lib"
+
+FORBIDDEN_PATTERNS = (
+    re.compile(r"^\s*from\s+src\.workspace\.commands"),
+    re.compile(r"^\s*import\s+src\.workspace\.commands"),
+    re.compile(r"^\s*from\s+src\.workspace\.cli"),
+    re.compile(r"^\s*import\s+src\.workspace\.cli"),
+    re.compile(r"^\s*from\s+src\.workspace\s+import\s+output"),
+    re.compile(r"^\s*from\s+src\.workspace\.output"),
+    re.compile(r"^\s*import\s+src\.workspace\.output"),
+)
+
+
+def test_lib_dir_exists():
+    assert LIB_DIR.is_dir(), f"lib dir not found: {LIB_DIR}"
+
+
+def test_no_forbidden_imports():
+    """Inspect each .py file in lib/ for forbidden imports."""
+    violations: list[str] = []
+    for py in LIB_DIR.rglob("*.py"):
+        for lineno, line in enumerate(py.read_text().splitlines(), 1):
+            for pat in FORBIDDEN_PATTERNS:
+                if pat.match(line):
+                    violations.append(f"{py.relative_to(LIB_DIR)}:{lineno}: {line.rstrip()}")
+    assert not violations, "Forbidden imports in lib/:\n" + "\n".join(violations)
+
+
+def test_grep_script_passes():
+    """Running the shell script directly must succeed."""
+    # tests/test_lib_purity.py → apps/crawler/scripts/grep-lib-purity.sh
+    crawler_root = Path(__file__).resolve().parent.parent
+    script = crawler_root / "scripts" / "grep-lib-purity.sh"
+    assert script.exists(), f"script not found: {script}"
+    result = subprocess.run(
+        ["bash", str(script)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"grep-lib-purity.sh failed:\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )

--- a/apps/crawler/tests/test_lib_run.py
+++ b/apps/crawler/tests/test_lib_run.py
@@ -1,0 +1,341 @@
+"""Tests for src.workspace.lib.run — pure async run functions."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.workspace.lib import (
+    BoardConfigState,
+    RunMonitorResult,
+    RunScraperResult,
+    WsConfigMissing,
+    WsMonitorRunFailed,
+    WsScraperRunFailed,
+    run_monitor,
+    run_scraper,
+)
+
+# ── Fixtures / helpers ─────────────────────────────────────────────────
+
+
+@dataclass
+class FakeMonitorResult:
+    urls: set[str] = field(default_factory=set)
+    jobs_by_url: dict | None = None
+    filtered_count: int = 0
+
+
+@dataclass
+class FakeJobContent:
+    title: str | None = None
+    description: str | None = None
+    locations: list[str] | None = None
+    employment_type: str | None = None
+    job_location_type: str | None = None
+    date_posted: str | None = None
+    base_salary: dict | None = None
+    language: str | None = None
+    extras: dict | None = None
+    metadata: dict | None = None
+
+
+@dataclass
+class FakeDiscoveredJob:
+    url: str
+    title: str | None = None
+    description: str | None = None
+    locations: list[str] | None = None
+    employment_type: str | None = None
+    job_location_type: str | None = None
+    date_posted: str | None = None
+    base_salary: dict | None = None
+    extras: dict | None = None
+
+
+def _state(**overrides) -> BoardConfigState:
+    base = dict(
+        board_url="https://test.example.com/jobs",
+        alias="careers",
+        slug="test",
+        monitor_type="sitemap",
+        monitor_config={},
+        scraper_type="json-ld",
+        scraper_config={},
+        sample_urls=("https://test.example.com/jobs/1", "https://test.example.com/jobs/2"),
+    )
+    base.update(overrides)
+    return BoardConfigState(**base)
+
+
+@pytest.fixture
+def patched_run_deps():
+    """Patch Playwright + logging http for run_monitor / run_scraper."""
+    with (
+        patch("playwright.async_api.async_playwright") as pw_factory,
+        patch("src.shared.http.create_logging_http_client") as http_factory,
+    ):
+        pw_ctx = AsyncMock()
+        pw_ctx.__aenter__.return_value = MagicMock(name="pw")
+        pw_ctx.__aexit__.return_value = False
+        pw_factory.return_value = pw_ctx
+
+        http_client = AsyncMock()
+        http_client.aclose = AsyncMock()
+        http_log: list[dict] = []
+        http_factory.return_value = (http_client, http_log)
+
+        yield pw_factory, http_factory, http_client, http_log
+
+
+# ── run_monitor ────────────────────────────────────────────────────────
+
+
+class TestRunMonitorHappyPath:
+    @pytest.mark.asyncio
+    async def test_url_only_result(self, patched_run_deps):
+        with patch("src.core.monitor.monitor_one", new_callable=AsyncMock) as fake:
+            fake.return_value = FakeMonitorResult(
+                urls={"https://test.example.com/jobs/1", "https://test.example.com/jobs/2"},
+                jobs_by_url=None,
+            )
+            result = await run_monitor(_state())
+        assert isinstance(result, RunMonitorResult)
+        assert result.has_rich_data is False
+        assert sorted(result.urls) == [
+            "https://test.example.com/jobs/1",
+            "https://test.example.com/jobs/2",
+        ]
+        assert result.quality is None
+
+    @pytest.mark.asyncio
+    async def test_rich_result_with_quality(self, patched_run_deps):
+        jobs = {
+            "https://test.example.com/jobs/1": FakeDiscoveredJob(
+                url="https://test.example.com/jobs/1",
+                title="Eng",
+                description="<p>ok</p>",
+                locations=["NYC"],
+                employment_type="FULL_TIME",
+            ),
+            "https://test.example.com/jobs/2": FakeDiscoveredJob(
+                url="https://test.example.com/jobs/2",
+                title="Des",
+                description="<p>do</p>",
+                locations=["SF"],
+            ),
+        }
+        with patch("src.core.monitor.monitor_one", new_callable=AsyncMock) as fake:
+            fake.return_value = FakeMonitorResult(
+                urls=set(jobs), jobs_by_url=jobs, filtered_count=3
+            )
+            result = await run_monitor(_state(monitor_type="greenhouse"))
+        assert result.has_rich_data is True
+        assert result.filtered_count == 3
+        assert result.quality is not None
+        assert result.quality["total"] == 2
+        assert result.quality["fields"]["title"]["count"] == 2
+        assert result.quality["fields"]["employment_type"]["count"] == 1
+        # Description samples populated
+        assert len(result.description_samples) == 2
+
+    @pytest.mark.asyncio
+    async def test_state_not_mutated(self, patched_run_deps):
+        state = _state()
+        before = state.to_dict()
+        with patch("src.core.monitor.monitor_one", new_callable=AsyncMock) as fake:
+            fake.return_value = FakeMonitorResult(urls=set(), jobs_by_url=None)
+            await run_monitor(state)
+        assert state.to_dict() == before
+
+    @pytest.mark.asyncio
+    async def test_no_filesystem_writes(self, patched_run_deps, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        before = sorted(os.listdir("."))
+        with patch("src.core.monitor.monitor_one", new_callable=AsyncMock) as fake:
+            fake.return_value = FakeMonitorResult(urls=set(), jobs_by_url=None)
+            await run_monitor(_state())
+        assert sorted(os.listdir(".")) == before
+        assert not (tmp_path / ".workspace").exists()
+
+
+class TestRunMonitorErrorCases:
+    @pytest.mark.asyncio
+    async def test_missing_monitor_type(self, patched_run_deps):
+        with pytest.raises(WsConfigMissing):
+            await run_monitor(_state(monitor_type=None))
+
+    @pytest.mark.asyncio
+    async def test_invalid_url_wraps_typed(self, patched_run_deps):
+        with patch("src.core.monitor.monitor_one", new_callable=AsyncMock) as fake:
+            fake.side_effect = ValueError("Cannot derive Greenhouse token from board URL")
+            with pytest.raises(WsMonitorRunFailed) as exc_info:
+                await run_monitor(_state(monitor_type="greenhouse"))
+        assert "Cannot derive" in str(exc_info.value)
+        assert isinstance(exc_info.value.__cause__, ValueError)
+
+    @pytest.mark.asyncio
+    async def test_timeout_5xx_wraps_typed(self, patched_run_deps):
+        with patch("src.core.monitor.monitor_one", new_callable=AsyncMock) as fake:
+            fake.side_effect = TimeoutError("upstream 504")
+            with pytest.raises(WsMonitorRunFailed):
+                await run_monitor(_state())
+
+
+class TestRunMonitorOutputSchema:
+    @pytest.mark.asyncio
+    async def test_to_dict_round_trips(self, patched_run_deps):
+        with patch("src.core.monitor.monitor_one", new_callable=AsyncMock) as fake:
+            fake.return_value = FakeMonitorResult(
+                urls={"https://test.example.com/jobs/1"}, jobs_by_url=None, filtered_count=2
+            )
+            result = await run_monitor(_state())
+        d = json.loads(json.dumps(result.to_dict()))
+        assert d["board_url"] == "https://test.example.com/jobs"
+        assert d["monitor_type"] == "sitemap"
+        assert d["job_count"] == 1
+        assert d["filtered_count"] == 2
+        assert d["has_rich_data"] is False
+
+
+# ── run_scraper ────────────────────────────────────────────────────────
+
+
+class TestRunScraperHappyPath:
+    @pytest.mark.asyncio
+    async def test_happy_path(self, patched_run_deps):
+        contents = [
+            FakeJobContent(title="Eng", description="<p>x</p>", locations=["NYC"]),
+            FakeJobContent(title="Des", description=None, locations=None),
+        ]
+        with (
+            patch("src.core.scrape.scrape_one", new_callable=AsyncMock) as fake,
+            patch("src.processing.scrape._apply_defaults", side_effect=lambda c, _cfg: c),
+        ):
+            fake.side_effect = contents
+            result = await run_scraper(_state())
+
+        assert isinstance(result, RunScraperResult)
+        assert len(result.items) == 2
+        assert result.items[0].url == "https://test.example.com/jobs/1"
+        assert result.items[0].content.title == "Eng"
+        assert result.skipped == []
+        # avg elapsed should be a non-negative float
+        assert result.avg_elapsed_seconds >= 0
+        # Description samples (only the one with description)
+        assert len(result.description_samples) == 1
+
+    @pytest.mark.asyncio
+    async def test_per_url_http_status_error_skipped(self, patched_run_deps):
+        from httpx import HTTPStatusError
+
+        # First URL 404s, second succeeds.
+        good = FakeJobContent(title="OK", description="<p>x</p>")
+        fake_response = MagicMock()
+        fake_response.status_code = 404
+
+        async def _scrape(url, *_, **__):
+            if url.endswith("/1"):
+                raise HTTPStatusError("404", request=MagicMock(), response=fake_response)
+            return good
+
+        with (
+            patch("src.core.scrape.scrape_one", side_effect=_scrape),
+            patch("src.processing.scrape._apply_defaults", side_effect=lambda c, _cfg: c),
+        ):
+            result = await run_scraper(_state())
+        assert len(result.items) == 1
+        assert result.items[0].url == "https://test.example.com/jobs/2"
+        assert result.skipped == [("https://test.example.com/jobs/1", "404")]
+
+    @pytest.mark.asyncio
+    async def test_state_not_mutated(self, patched_run_deps):
+        state = _state()
+        before = state.to_dict()
+        with (
+            patch("src.core.scrape.scrape_one", new_callable=AsyncMock) as fake,
+            patch("src.processing.scrape._apply_defaults", side_effect=lambda c, _cfg: c),
+        ):
+            fake.return_value = FakeJobContent(title="x", description="<p>y</p>")
+            await run_scraper(state)
+        assert state.to_dict() == before
+
+    @pytest.mark.asyncio
+    async def test_no_filesystem_writes(self, patched_run_deps, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        before = sorted(os.listdir("."))
+        with (
+            patch("src.core.scrape.scrape_one", new_callable=AsyncMock) as fake,
+            patch("src.processing.scrape._apply_defaults", side_effect=lambda c, _cfg: c),
+        ):
+            fake.return_value = FakeJobContent(title="x", description=None)
+            await run_scraper(_state())
+        assert sorted(os.listdir(".")) == before
+        assert not (tmp_path / ".workspace").exists()
+
+
+class TestRunScraperErrorCases:
+    @pytest.mark.asyncio
+    async def test_missing_scraper_type(self, patched_run_deps):
+        with pytest.raises(WsConfigMissing):
+            await run_scraper(_state(scraper_type=None))
+
+    @pytest.mark.asyncio
+    async def test_no_sample_urls(self, patched_run_deps):
+        with pytest.raises(WsConfigMissing):
+            await run_scraper(_state(sample_urls=()))
+
+    @pytest.mark.asyncio
+    async def test_fatal_scraper_error_wraps(self, patched_run_deps):
+        with (
+            patch("src.core.scrape.scrape_one", new_callable=AsyncMock) as fake,
+            patch("src.processing.scrape._apply_defaults", side_effect=lambda c, _cfg: c),
+        ):
+            fake.side_effect = RuntimeError("playwright died")
+            with pytest.raises(WsScraperRunFailed):
+                await run_scraper(_state())
+
+
+class TestRunScraperOutputSchema:
+    @pytest.mark.asyncio
+    async def test_to_dict_round_trips(self, patched_run_deps):
+        with (
+            patch("src.core.scrape.scrape_one", new_callable=AsyncMock) as fake,
+            patch("src.processing.scrape._apply_defaults", side_effect=lambda c, _cfg: c),
+        ):
+            fake.return_value = FakeJobContent(
+                title="Eng", description="<p>x</p>", locations=["NYC"]
+            )
+            result = await run_scraper(_state(sample_urls=("https://test.example.com/jobs/1",)))
+        d = json.loads(json.dumps(result.to_dict()))
+        assert d["scraper_type"] == "json-ld"
+        assert d["count"] == 1
+        assert d["items"][0]["url"] == "https://test.example.com/jobs/1"
+        assert d["items"][0]["content"]["title"] == "Eng"
+
+
+# ── Determinism ────────────────────────────────────────────────────────
+
+
+class TestDeterminism:
+    @pytest.mark.asyncio
+    async def test_run_monitor_same_input_same_output(self, patched_run_deps):
+        url_set = {"https://test.example.com/jobs/1"}
+
+        async def make():
+            with patch("src.core.monitor.monitor_one", new_callable=AsyncMock) as fake:
+                fake.return_value = FakeMonitorResult(urls=set(url_set), jobs_by_url=None)
+                return await run_monitor(_state())
+
+        r1 = await make()
+        r2 = await make()
+        # Strip elapsed_seconds (timing) for the equality assertion.
+        d1 = r1.to_dict()
+        d2 = r2.to_dict()
+        d1.pop("elapsed_seconds", None)
+        d2.pop("elapsed_seconds", None)
+        assert d1 == d2

--- a/apps/crawler/tests/test_ws_commands.py
+++ b/apps/crawler/tests/test_ws_commands.py
@@ -1012,8 +1012,103 @@ class TestSelectScraperValidation:
         assert "Optional: render" in result.output
 
 
+def _as_run_monitor_result(fake_result, elapsed, http_log, *, monitor_type="sitemap"):
+    """Adapter: legacy ``(FakeMonitorResult, elapsed, http_log)`` → ``RunMonitorResult``.
+
+    The CLI handler now consumes ``RunMonitorResult`` from the lib instead
+    of the bare tuple it built itself. Test helpers translate so existing
+    test bodies (which build ``FakeResult`` dataclasses) keep working.
+    """
+    from src.workspace.lib.run import RunMonitorResult, _build_monitor_quality
+
+    urls_list = sorted(fake_result.urls)
+    has_rich = fake_result.jobs_by_url is not None
+    quality = _build_monitor_quality(fake_result.jobs_by_url) if has_rich else None
+    desc_samples: list[dict] = []
+    if fake_result.jobs_by_url:
+        import re as _re
+
+        for job in list(fake_result.jobs_by_url.values())[:5]:
+            desc = getattr(job, "description", None)
+            if desc:
+                plain_desc = _re.sub(r"<[^>]+>", "", desc).strip()
+                desc_samples.append({"length": len(plain_desc), "snippet": plain_desc[:200]})
+    return RunMonitorResult(
+        board_url="https://test.com/jobs",
+        monitor_type=monitor_type,
+        urls=urls_list,
+        jobs_by_url=fake_result.jobs_by_url,
+        filtered_count=getattr(fake_result, "filtered_count", 0),
+        elapsed_seconds=elapsed,
+        has_rich_data=has_rich,
+        sample_urls=list(urls_list)[:10],
+        description_samples=desc_samples,
+        quality=quality,
+        http_log=list(http_log),
+        log_events=[],
+    )
+
+
+def _as_run_scraper_result(items, http_log, skipped, *, scraper_type="json-ld"):
+    """Adapter: legacy ``(items, http_log, skipped)`` → ``RunScraperResult``."""
+    from src.workspace.lib.run import RunScraperResult, ScrapedJob
+
+    scraped = [ScrapedJob(url=u, content=c, elapsed_seconds=e) for u, c, e in items]
+    avg = sum(it.elapsed_seconds for it in scraped) / len(scraped) if scraped else 0.0
+    desc_samples: list[dict] = []
+    import re as _re
+
+    for it in scraped:
+        desc = getattr(it.content, "description", None)
+        if desc and len(desc_samples) < 5:
+            plain_desc = _re.sub(r"<[^>]+>", "", desc).strip()
+            desc_samples.append({"length": len(plain_desc), "snippet": plain_desc[:200]})
+    return RunScraperResult(
+        scraper_type=scraper_type,
+        items=scraped,
+        skipped=list(skipped),
+        description_samples=desc_samples,
+        avg_elapsed_seconds=avg,
+        http_log=list(http_log),
+        log_events=[],
+    )
+
+
+def _as_probe_scraper_result(entries, spa_suspect, *, sample_urls=None):
+    """Adapter: legacy ``(entries, spa_suspect)`` → ``ProbeScraperResult``."""
+    from src.workspace.lib.probe import ProbeEntry, ProbeScraperResult
+
+    return ProbeScraperResult(
+        sample_urls=list(sample_urls or []),
+        entries=[ProbeEntry(name=n, metadata=m, comment=c) for n, m, c in entries],
+        spa_suspect=spa_suspect,
+    )
+
+
+def _as_probe_monitor_result(entries, *, board_url="https://test.com/jobs", current_jobs=200):
+    """Adapter: legacy ``[(name, metadata, comment), ...]`` → ``ProbeMonitorResult``."""
+    from src.workspace.lib.probe import (
+        ProbeEntry,
+        ProbeMonitorResult,
+        score_probe_entries,
+    )
+
+    probe_entries = [ProbeEntry(name=n, metadata=m, comment=c) for n, m, c in entries]
+    return ProbeMonitorResult(
+        board_url=board_url,
+        current_jobs=current_jobs,
+        entries=probe_entries,
+        scored=score_probe_entries(probe_entries, current_jobs),
+    )
+
+
 def _enter_monitor_patches(tmp_path) -> tuple[ExitStack, MagicMock]:
-    """Enter common patches for run monitor tests. Returns (stack, mock_asyncio)."""
+    """Enter common patches for run monitor tests. Returns (stack, mock_asyncio).
+
+    The mocked ``asyncio.run`` must return a :class:`RunMonitorResult` since
+    the CLI now delegates to ``src.workspace.lib.run.run_monitor``.
+    Existing tests pass tuples; use :func:`_as_run_monitor_result` to wrap.
+    """
     stack = ExitStack()
     mock_asyncio = stack.enter_context(patch("src.workspace.commands.crawl.asyncio"))
     stack.enter_context(
@@ -1031,7 +1126,12 @@ def _enter_monitor_patches(tmp_path) -> tuple[ExitStack, MagicMock]:
 
 
 def _enter_scraper_patches(tmp_path) -> tuple[ExitStack, MagicMock]:
-    """Enter common patches for run scraper tests. Returns (stack, mock_asyncio)."""
+    """Enter common patches for run scraper tests. Returns (stack, mock_asyncio).
+
+    The mocked ``asyncio.run`` must return a :class:`RunScraperResult` since
+    the CLI now delegates to ``src.workspace.lib.run.run_scraper``.
+    Existing tests pass tuples; use :func:`_as_run_scraper_result` to wrap.
+    """
     stack = ExitStack()
     mock_asyncio = stack.enter_context(patch("src.workspace.commands.crawl.asyncio"))
     stack.enter_context(
@@ -1076,7 +1176,7 @@ class TestRunMonitorOutput:
 
         stack, mock_asyncio = _enter_monitor_patches(tmp_path)
         with stack:
-            mock_asyncio.run.return_value = (fake_result, 1.5, [])
+            mock_asyncio.run.return_value = _as_run_monitor_result(fake_result, 1.5, [])
             runner = CliRunner()
             result = runner.invoke(ws, ["run", "monitor", "test"])
 
@@ -1100,7 +1200,7 @@ class TestRunMonitorOutput:
 
         stack, mock_asyncio = _enter_monitor_patches(tmp_path)
         with stack:
-            mock_asyncio.run.return_value = (fake_result, 2.0, [])
+            mock_asyncio.run.return_value = _as_run_monitor_result(fake_result, 2.0, [])
             runner = CliRunner()
             result = runner.invoke(ws, ["run", "monitor", "test"])
 
@@ -1110,15 +1210,23 @@ class TestRunMonitorOutput:
     def test_monitor_failure_shows_recovery_guidance(self, tmp_path, monkeypatch):
         self._setup_monitor_board(tmp_path, monkeypatch, monitor_type="greenhouse")
 
+        from src.workspace.lib import WsMonitorRunFailed
+
         stack, mock_asyncio = _enter_monitor_patches(tmp_path)
         with stack:
 
             def _fail(coro):
                 coro.close()
-                raise ValueError(
+                # The lib normally wraps the underlying ValueError in
+                # WsMonitorRunFailed; we simulate that here since the
+                # mocked asyncio.run bypasses the lib body.
+                inner = ValueError(
                     "Cannot derive Greenhouse token from board URL "
                     "'https://test.com/jobs' and no token in metadata"
                 )
+                wrapped = WsMonitorRunFailed(str(inner))
+                wrapped.__cause__ = inner
+                raise wrapped
 
             mock_asyncio.run.side_effect = _fail
             runner = CliRunner()
@@ -1164,7 +1272,7 @@ class TestRunMonitorOutput:
 
         stack, mock_asyncio = _enter_monitor_patches(tmp_path)
         with stack:
-            mock_asyncio.run.return_value = (fake_result, 1.0, [])
+            mock_asyncio.run.return_value = _as_run_monitor_result(fake_result, 1.0, [])
             runner = CliRunner()
             result = runner.invoke(ws, ["run", "monitor", "test"])
 
@@ -1200,7 +1308,7 @@ class TestRunScraperOutput:
 
         stack, mock_asyncio = _enter_scraper_patches(tmp_path)
         with stack:
-            mock_asyncio.run.return_value = (
+            mock_asyncio.run.return_value = _as_run_scraper_result(
                 [
                     ("https://test.com/jobs/1", contents[0], 0.5),
                     ("https://test.com/jobs/2", contents[1], 0.3),
@@ -1227,7 +1335,7 @@ class TestRunScraperOutput:
 
         stack, mock_asyncio = _enter_scraper_patches(tmp_path)
         with stack:
-            mock_asyncio.run.return_value = (
+            mock_asyncio.run.return_value = _as_run_scraper_result(
                 [
                     ("https://test.com/jobs/1", contents[0], 0.5),
                     ("https://test.com/jobs/2", contents[1], 0.3),
@@ -1261,7 +1369,7 @@ class TestRunScraperOutput:
 
         stack, mock_asyncio = _enter_scraper_patches(tmp_path)
         with stack:
-            mock_asyncio.run.return_value = (
+            mock_asyncio.run.return_value = _as_run_scraper_result(
                 [
                     ("https://test.com/jobs/1", contents[0], 0.5),
                     ("https://test.com/jobs/2", contents[1], 0.3),
@@ -1289,7 +1397,7 @@ class TestRunScraperOutput:
 
         stack, mock_asyncio = _enter_scraper_patches(tmp_path)
         with stack:
-            mock_asyncio.run.return_value = (
+            mock_asyncio.run.return_value = _as_run_scraper_result(
                 [
                     ("https://test.com/jobs/1", contents[0], 0.5),
                     ("https://test.com/jobs/2", contents[1], 0.3),
@@ -1320,7 +1428,7 @@ class TestRunScraperOutput:
 
         stack, mock_asyncio = _enter_scraper_patches(tmp_path)
         with stack:
-            mock_asyncio.run.return_value = (
+            mock_asyncio.run.return_value = _as_run_scraper_result(
                 [("https://test.com/jobs/1", contents[0], 0.5)],
                 [],
                 [],
@@ -1361,7 +1469,7 @@ class TestRunMonitorVerifyPrompt:
 
         stack, mock_asyncio = _enter_monitor_patches(tmp_path)
         with stack:
-            mock_asyncio.run.return_value = (fake_result, 2.0, [])
+            mock_asyncio.run.return_value = _as_run_monitor_result(fake_result, 2.0, [])
             runner = CliRunner()
             result = runner.invoke(ws, ["run", "monitor", "test"])
 
@@ -1381,7 +1489,7 @@ class TestRunMonitorVerifyPrompt:
 
         stack, mock_asyncio = _enter_monitor_patches(tmp_path)
         with stack:
-            mock_asyncio.run.return_value = (fake_result, 1.0, [])
+            mock_asyncio.run.return_value = _as_run_monitor_result(fake_result, 1.0, [])
             runner = CliRunner()
             result = runner.invoke(ws, ["run", "monitor", "test"])
 
@@ -1430,7 +1538,7 @@ class TestRunMonitorNamedConfig:
 
         stack, mock_asyncio = _enter_monitor_patches(tmp_path)
         with stack:
-            mock_asyncio.run.return_value = (fake_result, 1.0, [])
+            mock_asyncio.run.return_value = _as_run_monitor_result(fake_result, 1.0, [])
             runner = CliRunner()
             result = runner.invoke(ws, ["run", "monitor", "test", "--config", "greenhouse"])
 
@@ -1518,10 +1626,11 @@ class TestRunScraperNamedConfig:
 
         stack, mock_asyncio = _enter_scraper_patches(tmp_path)
         with stack:
-            mock_asyncio.run.return_value = (
+            mock_asyncio.run.return_value = _as_run_scraper_result(
                 [("https://test.com/jobs/3", fake_content, 0.5)],
                 [],
                 [],
+                scraper_type="dom",
             )
             runner = CliRunner()
             result = runner.invoke(ws, ["run", "scraper", "test", "--config", "alt"])
@@ -1599,7 +1708,9 @@ class TestProbeScraperQualityGate:
 
         stack, mock_asyncio = _enter_probe_scraper_patches(tmp_path)
         with stack:
-            mock_asyncio.run.return_value = (fake_results, True)
+            mock_asyncio.run.return_value = _as_probe_scraper_result(
+                fake_results, True, sample_urls=["https://test.com/jobs/1"]
+            )
             runner = CliRunner()
             result = runner.invoke(ws, ["probe", "scraper", "test"])
 
@@ -3263,7 +3374,7 @@ class TestMonitorRegression:
             stack.enter_context(
                 patch(
                     "src.workspace.commands.crawl.asyncio.run",
-                    return_value=(fake, 1.0, []),
+                    return_value=_as_run_monitor_result(fake, 1.0, [], monitor_type="greenhouse"),
                 )
             )
             stack.enter_context(patch("src.workspace.commands.crawl.save_board"))
@@ -3312,7 +3423,7 @@ class TestMonitorRegression:
             stack.enter_context(
                 patch(
                     "src.workspace.commands.crawl.asyncio.run",
-                    return_value=(fake, 1.0, []),
+                    return_value=_as_run_monitor_result(fake, 1.0, [], monitor_type="greenhouse"),
                 )
             )
             stack.enter_context(patch("src.workspace.commands.crawl.save_board"))


### PR DESCRIPTION
## Summary

Lifts the four CLI handlers (`ws probe monitor`, `ws probe scraper`, `ws run monitor`, `ws run scraper`) from `apps/crawler/src/workspace/commands/crawl.py` (~1700 LOC of CLI-bound state) into pure, importable async functions under `apps/crawler/src/workspace/lib/`. Each function takes an explicit `BoardConfigState` snapshot, raises typed exceptions instead of calling `out.die`, never writes to disk, and returns a JSON-serializable typed result. The CLI handlers become thin adapters that build the snapshot, call the lib, and persist artifacts / mutate board state from the result.

This is the largest single schedule risk per murmur DESIGN.md §5.2 — and a prerequisite for J2 (Murmur subtask wiring).

## Related issue

Closes colophon-group/jobseek#2755.

## Files added

- `apps/crawler/src/workspace/lib/__init__.py` — public re-exports
- `apps/crawler/src/workspace/lib/board_config.py` — frozen `BoardConfigState`
- `apps/crawler/src/workspace/lib/exceptions.py` — `WsLibError`, `WsBoardNotFound`, `WsConfigMissing`, `WsProbeFailed`, `WsMonitorRunFailed`, `WsScraperRunFailed`
- `apps/crawler/src/workspace/lib/probe.py` — `probe_monitor`, `probe_scraper` + `ProbeMonitorResult` / `ProbeScraperResult`
- `apps/crawler/src/workspace/lib/run.py` — `run_monitor`, `run_scraper` + `RunMonitorResult` / `RunScraperResult`
- `apps/crawler/src/workspace/lib/README.md` — purity contract
- `apps/crawler/scripts/grep-lib-purity.sh` — grep gate (lib must not import `commands/`, `cli`, `output`)
- `apps/crawler/tests/test_lib_probe.py` — 20 tests
- `apps/crawler/tests/test_lib_run.py` — 17 tests
- `apps/crawler/tests/test_lib_purity.py` — 3 tests (CI grep gate)

## Files changed (high-level)

- `apps/crawler/src/workspace/commands/crawl.py` — four target handlers now build a `BoardConfigState` and call into the lib; everything downstream (artifact persistence, board write-back, formatted output) is unchanged
- `apps/crawler/tests/test_ws_commands.py` — fixture helpers `_as_run_monitor_result` / `_as_run_scraper_result` / `_as_probe_scraper_result` adapt the legacy tuple form to the new lib result types so existing CLI tests stay green

## Before / after — `ws run monitor`

**Before** (excerpt from `commands/crawl.py:1202-1228`):

```python
async def _run():
    from playwright.async_api import async_playwright
    from src.core.monitor import monitor_one
    from src.shared.http import create_logging_http_client

    ssl_verify = (board.monitor_config or {}).get("ssl_verify", True)
    use_proxy = bool((mon_config or {}).get("proxy"))
    http, http_log = create_logging_http_client(verify=ssl_verify, use_proxy=use_proxy)
    try:
        async with async_playwright() as pw:
            start = time.monotonic()
            result = await monitor_one(
                board.url, mon_type, mon_config or None, http,
                artifact_dir=run_dir, pw=pw,
            )
            elapsed = time.monotonic() - start
        return result, elapsed, http_log
    finally:
        await _shutdown_http(http)

try:
    result, elapsed, http_log = asyncio.run(_run())
except Exception as exc:
    detail = str(exc).strip() or exc.__class__.__name__
    out.error("monitor", f"Run failed: {detail}")
    ...
    raise SystemExit(1) from exc
```

**After**:

```python
from src.workspace.lib import BoardConfigState, WsConfigMissing, WsMonitorRunFailed
from src.workspace.lib import run_monitor as _lib_run_monitor

state = BoardConfigState(
    board_url=board.url, alias=board.alias, slug=slug,
    monitor_type=mon_type, monitor_config=mon_config or {},
    ssl_verify=(board.monitor_config or {}).get("ssl_verify", True),
    use_proxy=bool((mon_config or {}).get("proxy")),
)
try:
    lib_result = asyncio.run(
        _lib_run_monitor(state, config_name=config_name,
                         artifact_dir=run_dir, log_events=log_events)
    )
    result = lib_result
    elapsed = lib_result.elapsed_seconds
    http_log = lib_result.http_log
except WsConfigMissing as exc:
    out.die(str(exc))
    return
except WsMonitorRunFailed as exc:
    detail = str(exc).strip() or exc.__class__.__name__
    out.error("monitor", f"Run failed: {detail}")
    ...
    raise SystemExit(1) from exc
```

Same downstream behavior (artifact save, board write-back, all stdout); the work is now also callable from any async context.

## Verification (from the issue)

- [x] 4 importable functions: `probe_monitor`, `probe_scraper`, `run_monitor`, `run_scraper`
- [x] Each `*Result` has stable JSON-serializable shape (round-tripped through `json.dumps` in tests)
- [x] Happy path against fixture board (mocked `probe_all_monitors` / `monitor_one` / `scrape_one`)
- [x] Error case: invalid URL → typed exception
- [x] Error case: timeout/5xx → typed exception
- [x] Output schema snapshot test (JSON round-trip equality)
- [x] Pure-functional: `same input → same output` test
- [x] No filesystem writes: `os.listdir(tmp_path)` snapshot before/after each lib call
- [x] No mutation of `BoardConfigState` (frozen dataclass; round-trip equality assertion)
- [x] `lib/probe.py` and `lib/run.py` have zero imports from `commands/`, `cli.py`, `output` — verified by `tests/test_lib_purity.py` and `scripts/grep-lib-purity.sh`
- [x] CLI golden / regression tests (`test_ws_commands.py`) all pass — 158 tests, including `TestRunMonitorOutput`, `TestRunScraperOutput`, `TestRunMonitorVerifyPrompt`, `TestRunMonitorNamedConfig`, `TestRunScraperNamedConfig`, `TestProbeScraperQualityGate`, `TestMonitorRegression`

## Manual checks run locally

- `uv run ruff check src/workspace/lib/ src/workspace/commands/crawl.py tests/test_lib_*.py` ✓
- `uv run mypy --ignore-missing-imports --explicit-package-bases src/workspace/lib/` ✓ (no issues)
- `uv run pytest tests/test_lib_probe.py tests/test_lib_run.py tests/test_lib_purity.py` ✓ (40 passed)
- `uv run pytest tests/test_ws_commands.py` ✓ (158 passed)
- `uv run pytest` (full crawler suite) ✓ (3977 passed, 37 skipped)
- `uv run pytest --cov=src/workspace/lib` ✓ — **98% line coverage** (well above the 85% gate)
- `bash apps/crawler/scripts/grep-lib-purity.sh` ✓

## Notes for reviewer

- The four lib functions deliberately do not load `state.WorkspaceState` / `Board` — they accept an explicit `BoardConfigState` so callers from outside the CLI (a Murmur worker, J2's subtask wiring) don't need a workspace on disk.
- `_probe_all_boards` (the `--all-boards` path) is intentionally left calling `probe_all_monitors` directly because it shares one Playwright instance across many boards. The four target click commands listed in the issue are fully migrated; multi-board sharing is out of scope here and can be a follow-up.
- The `random.sample` legacy call for `monitor_run.sample_urls` is kept on the CLI side (the lib returns a deterministic sorted top-10 in `RunMonitorResult.sample_urls`); the CLI then re-derives via `random.sample(sorted(result.urls), ...)` to keep existing tests' `random.sample` patches relevant.
- Test helpers `_as_run_monitor_result` / `_as_run_scraper_result` in `tests/test_ws_commands.py` translate the legacy `(FakeMonitorResult, elapsed, http_log)` tuple form into the new lib result types so most existing tests only needed a single-line wrap.
- This PR targets `murmur-demo`, not `main`. M0 contracts in murmur are not consumed here per orchestrator note 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)