### PR TITLE
feat(jobseek): HTTP shim routes for 7 Murmur subcommands

### DIFF
--- a/apps/crawler/src/workspace/lib/cli_shim.py
+++ b/apps/crawler/src/workspace/lib/cli_shim.py
@@ -1,0 +1,272 @@
+"""JSON-in / JSON-out entry point for jobseek's HTTP shim routes.
+
+Spawned by `apps/web/app/api/murmur/_lib/invoke-lib.ts` (pattern (a) per
+J5's IPC decision). Reads a single JSON object on stdin::
+
+    {
+      "subcommand": "probe_monitor" | "run_monitor" | ...,
+      "body":       { ... },              # request body validated by TS
+      "claim_token": "<opaque token>",
+      "db_dsn":     "postgresql://..."    # for select/feedback/run/probe
+    }
+
+and writes a single JSON envelope on stdout::
+
+    { "ok": true,  "data": { ... } }
+    { "ok": false, "errors": [ "<token>", ... ] }
+
+Exit code is always 0 on a clean envelope (success OR known typed
+failure). Non-zero exit codes plus uncaught exceptions are reserved for
+catastrophic shim bugs — the TS side maps those to
+``{"ok": false, "errors": ["internal_error"]}``.
+
+Error mapping (typed exception → envelope token)::
+
+    WsBoardNotFound          -> "board_not_found"
+    WsConfigMissing          -> "config_missing"
+    WsConfigInvalid          -> "config_invalid"
+    WsProbeFailed            -> "probe_failed"
+    WsMonitorRunFailed       -> "monitor_run_failed"
+    WsScraperRunFailed       -> "scraper_run_failed"
+    WsFeedbackIncomplete     -> "feedback_incomplete"
+    Exception (other)        -> "internal_error" (full trace -> stderr)
+
+@see colophon-group/jobseek#2759
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import traceback
+from typing import Any, Awaitable, Callable
+
+from src.workspace.lib import (
+    BoardConfigState,
+    WsBoardNotFound,
+    WsConfigInvalid,
+    WsConfigMissing,
+    WsFeedbackIncomplete,
+    WsLibError,
+    WsMonitorRunFailed,
+    WsProbeFailed,
+    WsScraperRunFailed,
+    feedback,
+    probe_monitor,
+    probe_scraper,
+    run_monitor,
+    run_scraper,
+    select_monitor,
+    select_scraper,
+)
+from src.workspace.lib.postgres_claim_kv import PostgresClaimKV
+
+
+# ── Error mapping ─────────────────────────────────────────────────────
+
+
+_ERROR_TOKENS: dict[type[BaseException], str] = {
+    WsBoardNotFound: "board_not_found",
+    WsConfigMissing: "config_missing",
+    WsConfigInvalid: "config_invalid",
+    WsProbeFailed: "probe_failed",
+    WsMonitorRunFailed: "monitor_run_failed",
+    WsScraperRunFailed: "scraper_run_failed",
+    WsFeedbackIncomplete: "feedback_incomplete",
+}
+
+
+def _map_exception(exc: BaseException) -> str:
+    for cls, token in _ERROR_TOKENS.items():
+        if isinstance(exc, cls):
+            return token
+    if isinstance(exc, WsLibError):
+        # An unmapped lib exception subclass — treat as internal_error
+        # but log so we notice and add a token next time.
+        return "internal_error"
+    return "internal_error"
+
+
+# ── Subcommand dispatchers ────────────────────────────────────────────
+
+
+async def _do_probe_monitor(
+    body: dict[str, Any], _kv: PostgresClaimKV | None
+) -> dict[str, Any]:
+    state = BoardConfigState(board_url=body["board_url"])
+    expected = int(body.get("expected_count", 0) or 0)
+    result = await probe_monitor(state, expected)
+    return result.to_dict()
+
+
+async def _do_probe_scraper(
+    body: dict[str, Any], _kv: PostgresClaimKV | None
+) -> dict[str, Any]:
+    state = BoardConfigState(board_url=body["board_url"])
+    sample_url = body.get("sample_job_url")
+    result = await probe_scraper(state, sample_url=sample_url)
+    return result.to_dict()
+
+
+async def _do_run_monitor(
+    body: dict[str, Any], kv: PostgresClaimKV | None
+) -> dict[str, Any]:
+    if kv is None:
+        raise WsConfigInvalid("run_monitor: claim_kv unavailable")
+    active = await kv.get_active()
+    slot: dict[str, Any] = {}
+    if active:
+        s = await kv.get(active)
+        if isinstance(s, dict):
+            slot = s
+    state = BoardConfigState(
+        board_url=body["board_url"],
+        monitor_type=slot.get("monitor_type"),
+        monitor_config=dict(slot.get("monitor_config") or {}),
+    )
+    result = await run_monitor(state)
+    return result.to_dict()
+
+
+async def _do_run_scraper(
+    body: dict[str, Any], kv: PostgresClaimKV | None
+) -> dict[str, Any]:
+    if kv is None:
+        raise WsConfigInvalid("run_scraper: claim_kv unavailable")
+    active = await kv.get_active()
+    slot: dict[str, Any] = {}
+    if active:
+        s = await kv.get(active)
+        if isinstance(s, dict):
+            slot = s
+    sample_urls: list[str] | None = None
+    if "sample_job_url" in body and body["sample_job_url"]:
+        sample_urls = [body["sample_job_url"]]
+    state = BoardConfigState(
+        board_url=body["board_url"],
+        scraper_type=slot.get("scraper_type"),
+        scraper_config=dict(slot.get("scraper_config") or {}),
+    )
+    result = await run_scraper(state, sample_urls=sample_urls)
+    return result.to_dict()
+
+
+async def _do_select_monitor(
+    body: dict[str, Any], kv: PostgresClaimKV | None
+) -> dict[str, Any]:
+    if kv is None:
+        raise WsConfigInvalid("select_monitor: claim_kv unavailable")
+    # The agent supplies `candidate_id` rather than a (monitor_type,
+    # monitor_config) pair; for the demo we store `candidate_id` as the
+    # monitor type so the named slot survives the round trip. A
+    # production implementation would resolve `candidate_id` against
+    # the prior probe's candidate list.
+    name = body["candidate_id"]
+    result = await select_monitor(kv, monitor_type=name, name=name, config={})
+    return result.to_dict()
+
+
+async def _do_select_scraper(
+    body: dict[str, Any], kv: PostgresClaimKV | None
+) -> dict[str, Any]:
+    if kv is None:
+        raise WsConfigInvalid("select_scraper: claim_kv unavailable")
+    name = body["candidate_id"]
+    result = await select_scraper(kv, scraper_type=name, name=name, config={})
+    return result.to_dict()
+
+
+async def _do_feedback(
+    body: dict[str, Any], kv: PostgresClaimKV | None
+) -> dict[str, Any]:
+    if kv is None:
+        raise WsConfigInvalid("feedback: claim_kv unavailable")
+    verdict = body["verdict"]
+    # The YAML's verdict enum (`ok` / `needs-work` / `rejected`) differs
+    # from the lib's tighter vocabulary (`good` / `acceptable` / `poor`
+    # / `unusable`). Map demo-vocab → lib-vocab one way:
+    verdict_map = {"ok": "good", "needs-work": "acceptable", "rejected": "poor"}
+    lib_verdict = verdict_map.get(verdict, verdict)
+    notes = body.get("notes", "")
+    per_field = body.get("per_field") or None
+    if isinstance(per_field, dict):
+        # Coerce the demo's `{field: "clean"}` shorthand to the lib's
+        # `{field: {"quality": "clean"}}` shape if needed.
+        normalised: dict[str, dict[str, str]] = {}
+        for k, v in per_field.items():
+            if isinstance(v, dict):
+                normalised[k] = {kk: str(vv) for kk, vv in v.items()}
+            elif isinstance(v, str):
+                normalised[k] = {"quality": v}
+        per_field = normalised
+    result = await feedback(
+        kv, verdict=lib_verdict, per_field=per_field, verdict_notes=notes
+    )
+    return result.to_dict()
+
+
+_DISPATCH: dict[
+    str,
+    Callable[[dict[str, Any], PostgresClaimKV | None], Awaitable[dict[str, Any]]],
+] = {
+    "probe_monitor": _do_probe_monitor,
+    "probe_scraper": _do_probe_scraper,
+    "run_monitor": _do_run_monitor,
+    "run_scraper": _do_run_scraper,
+    "select_monitor": _do_select_monitor,
+    "select_scraper": _do_select_scraper,
+    "feedback": _do_feedback,
+}
+
+
+# ── Top-level entry point ─────────────────────────────────────────────
+
+
+async def run_envelope(payload: dict[str, Any]) -> dict[str, Any]:
+    """Execute the requested subcommand and return an M0 envelope dict."""
+    subcommand = payload.get("subcommand")
+    body = payload.get("body") or {}
+    claim_token = payload.get("claim_token") or ""
+    dsn = payload.get("db_dsn") or ""
+
+    if not isinstance(subcommand, str) or subcommand not in _DISPATCH:
+        return {"ok": False, "errors": ["unknown_subcommand"]}
+    if not isinstance(body, dict):
+        return {"ok": False, "errors": ["invalid_body"]}
+
+    kv: PostgresClaimKV | None = None
+    if claim_token and dsn:
+        kv = PostgresClaimKV(claim_token=claim_token, dsn=dsn)
+
+    handler = _DISPATCH[subcommand]
+    try:
+        data = await handler(body, kv)
+    except WsLibError as exc:
+        token = _map_exception(exc)
+        # Log full trace to stderr; the TS side only ever sees the token.
+        traceback.print_exc(file=sys.stderr)
+        return {"ok": False, "errors": [token]}
+    except Exception:
+        traceback.print_exc(file=sys.stderr)
+        return {"ok": False, "errors": ["internal_error"]}
+    return {"ok": True, "data": data}
+
+
+def main() -> int:
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw) if raw.strip() else {}
+    except json.JSONDecodeError:
+        sys.stdout.write(json.dumps({"ok": False, "errors": ["invalid_json"]}))
+        return 0
+    if not isinstance(payload, dict):
+        sys.stdout.write(json.dumps({"ok": False, "errors": ["invalid_payload"]}))
+        return 0
+    result = asyncio.run(run_envelope(payload))
+    sys.stdout.write(json.dumps(result))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/crawler/src/workspace/lib/cli_shim.py
+++ b/apps/crawler/src/workspace/lib/cli_shim.py
@@ -40,7 +40,8 @@ import asyncio
 import json
 import sys
 import traceback
-from typing import Any, Awaitable, Callable
+from collections.abc import Awaitable, Callable
+from typing import Any
 
 from src.workspace.lib import (
     BoardConfigState,
@@ -61,7 +62,6 @@ from src.workspace.lib import (
     select_scraper,
 )
 from src.workspace.lib.postgres_claim_kv import PostgresClaimKV
-
 
 # ── Error mapping ─────────────────────────────────────────────────────
 
@@ -91,27 +91,21 @@ def _map_exception(exc: BaseException) -> str:
 # ── Subcommand dispatchers ────────────────────────────────────────────
 
 
-async def _do_probe_monitor(
-    body: dict[str, Any], _kv: PostgresClaimKV | None
-) -> dict[str, Any]:
+async def _do_probe_monitor(body: dict[str, Any], _kv: PostgresClaimKV | None) -> dict[str, Any]:
     state = BoardConfigState(board_url=body["board_url"])
     expected = int(body.get("expected_count", 0) or 0)
     result = await probe_monitor(state, expected)
     return result.to_dict()
 
 
-async def _do_probe_scraper(
-    body: dict[str, Any], _kv: PostgresClaimKV | None
-) -> dict[str, Any]:
+async def _do_probe_scraper(body: dict[str, Any], _kv: PostgresClaimKV | None) -> dict[str, Any]:
     state = BoardConfigState(board_url=body["board_url"])
     sample_url = body.get("sample_job_url")
     result = await probe_scraper(state, sample_url=sample_url)
     return result.to_dict()
 
 
-async def _do_run_monitor(
-    body: dict[str, Any], kv: PostgresClaimKV | None
-) -> dict[str, Any]:
+async def _do_run_monitor(body: dict[str, Any], kv: PostgresClaimKV | None) -> dict[str, Any]:
     if kv is None:
         raise WsConfigInvalid("run_monitor: claim_kv unavailable")
     active = await kv.get_active()
@@ -129,9 +123,7 @@ async def _do_run_monitor(
     return result.to_dict()
 
 
-async def _do_run_scraper(
-    body: dict[str, Any], kv: PostgresClaimKV | None
-) -> dict[str, Any]:
+async def _do_run_scraper(body: dict[str, Any], kv: PostgresClaimKV | None) -> dict[str, Any]:
     if kv is None:
         raise WsConfigInvalid("run_scraper: claim_kv unavailable")
     active = await kv.get_active()
@@ -152,9 +144,7 @@ async def _do_run_scraper(
     return result.to_dict()
 
 
-async def _do_select_monitor(
-    body: dict[str, Any], kv: PostgresClaimKV | None
-) -> dict[str, Any]:
+async def _do_select_monitor(body: dict[str, Any], kv: PostgresClaimKV | None) -> dict[str, Any]:
     if kv is None:
         raise WsConfigInvalid("select_monitor: claim_kv unavailable")
     # The agent supplies `candidate_id` rather than a (monitor_type,
@@ -167,9 +157,7 @@ async def _do_select_monitor(
     return result.to_dict()
 
 
-async def _do_select_scraper(
-    body: dict[str, Any], kv: PostgresClaimKV | None
-) -> dict[str, Any]:
+async def _do_select_scraper(body: dict[str, Any], kv: PostgresClaimKV | None) -> dict[str, Any]:
     if kv is None:
         raise WsConfigInvalid("select_scraper: claim_kv unavailable")
     name = body["candidate_id"]
@@ -177,9 +165,7 @@ async def _do_select_scraper(
     return result.to_dict()
 
 
-async def _do_feedback(
-    body: dict[str, Any], kv: PostgresClaimKV | None
-) -> dict[str, Any]:
+async def _do_feedback(body: dict[str, Any], kv: PostgresClaimKV | None) -> dict[str, Any]:
     if kv is None:
         raise WsConfigInvalid("feedback: claim_kv unavailable")
     verdict = body["verdict"]
@@ -200,9 +186,7 @@ async def _do_feedback(
             elif isinstance(v, str):
                 normalised[k] = {"quality": v}
         per_field = normalised
-    result = await feedback(
-        kv, verdict=lib_verdict, per_field=per_field, verdict_notes=notes
-    )
+    result = await feedback(kv, verdict=lib_verdict, per_field=per_field, verdict_notes=notes)
     return result.to_dict()
 
 

--- a/apps/crawler/src/workspace/lib/postgres_claim_kv.py
+++ b/apps/crawler/src/workspace/lib/postgres_claim_kv.py
@@ -1,0 +1,130 @@
+"""Postgres-backed :class:`ClaimKV` for the Murmur HTTP shim.
+
+Mirrors the TS `apps/web/src/lib/murmur/claim-kv.ts` module against the
+same `murmur_claim_kv` table. Used only by the HTTP shim entry point
+(`cli_shim`); the regular CLI keeps using the in-memory implementation
+or the YAML-backed adapter.
+
+Schema (ddl owned by `apps/web/src/db/schema.ts`)::
+
+    CREATE TABLE murmur_claim_kv (
+        claim_token  text          NOT NULL,
+        name         text          NOT NULL,
+        value        jsonb         NOT NULL,
+        created_at   timestamptz   NOT NULL DEFAULT now(),
+        updated_at   timestamptz   NOT NULL DEFAULT now(),
+        PRIMARY KEY (claim_token, name)
+    );
+
+The class binds a single ``claim_token`` at construction time so callers
+do not have to thread it through every call. ``ACTIVE_KEY`` is treated
+as a regular slot for read/write purposes; ``list_all`` filters it out.
+
+@see colophon-group/jobseek#2759
+@see colophon-group/jobseek#2757 (TS counterpart)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import asyncpg  # type: ignore[import-untyped]
+
+from src.workspace.lib.claim_kv import ACTIVE_KEY
+
+
+class PostgresClaimKV:
+    """:class:`~src.workspace.lib.claim_kv.ClaimKV` backed by Postgres.
+
+    Each call opens a short-lived connection. The HTTP shim is invoked
+    once per agent request, so connection pooling at the asyncpg level
+    is not needed for the demo; a single ``connect / fetch / close``
+    per call is fine.
+    """
+
+    def __init__(self, claim_token: str, dsn: str) -> None:
+        if not claim_token:
+            raise ValueError("PostgresClaimKV: claim_token must be non-empty")
+        if not dsn:
+            raise ValueError("PostgresClaimKV: dsn must be non-empty")
+        self._claim_token = claim_token
+        self._dsn = dsn
+
+    async def _connect(self) -> "asyncpg.Connection[Any]":
+        return await asyncpg.connect(self._dsn)
+
+    async def get(self, name: str) -> Any | None:  # noqa: ANN401
+        conn = await self._connect()
+        try:
+            row = await conn.fetchrow(
+                "SELECT value FROM murmur_claim_kv "
+                "WHERE claim_token = $1 AND name = $2",
+                self._claim_token,
+                name,
+            )
+        finally:
+            await conn.close()
+        if row is None:
+            return None
+        raw = row["value"]
+        # asyncpg returns jsonb as the raw text by default; if the user
+        # has installed a json codec it may already be parsed. Handle
+        # both cases idempotently.
+        if isinstance(raw, str):
+            return json.loads(raw)
+        return raw
+
+    async def set(self, name: str, value: Any) -> None:  # noqa: ANN401
+        conn = await self._connect()
+        try:
+            await conn.execute(
+                "INSERT INTO murmur_claim_kv (claim_token, name, value) "
+                "VALUES ($1, $2, $3::jsonb) "
+                "ON CONFLICT (claim_token, name) "
+                "DO UPDATE SET value = EXCLUDED.value, updated_at = now()",
+                self._claim_token,
+                name,
+                json.dumps(value),
+            )
+        finally:
+            await conn.close()
+
+    async def list_all(self) -> dict[str, Any]:
+        conn = await self._connect()
+        try:
+            rows = await conn.fetch(
+                "SELECT name, value FROM murmur_claim_kv "
+                "WHERE claim_token = $1",
+                self._claim_token,
+            )
+        finally:
+            await conn.close()
+        out: dict[str, Any] = {}
+        for r in rows:
+            n = r["name"]
+            if n == ACTIVE_KEY:
+                continue
+            raw = r["value"]
+            out[n] = json.loads(raw) if isinstance(raw, str) else raw
+        return out
+
+    async def clear(self) -> None:
+        conn = await self._connect()
+        try:
+            await conn.execute(
+                "DELETE FROM murmur_claim_kv WHERE claim_token = $1",
+                self._claim_token,
+            )
+        finally:
+            await conn.close()
+
+    async def get_active(self) -> str | None:
+        v = await self.get(ACTIVE_KEY)
+        return v if isinstance(v, str) else None
+
+    async def set_active(self, name: str) -> None:
+        await self.set(ACTIVE_KEY, name)
+
+
+__all__ = ["PostgresClaimKV"]

--- a/apps/crawler/src/workspace/lib/postgres_claim_kv.py
+++ b/apps/crawler/src/workspace/lib/postgres_claim_kv.py
@@ -51,15 +51,14 @@ class PostgresClaimKV:
         self._claim_token = claim_token
         self._dsn = dsn
 
-    async def _connect(self) -> "asyncpg.Connection[Any]":
+    async def _connect(self) -> asyncpg.Connection[Any]:
         return await asyncpg.connect(self._dsn)
 
     async def get(self, name: str) -> Any | None:  # noqa: ANN401
         conn = await self._connect()
         try:
             row = await conn.fetchrow(
-                "SELECT value FROM murmur_claim_kv "
-                "WHERE claim_token = $1 AND name = $2",
+                "SELECT value FROM murmur_claim_kv WHERE claim_token = $1 AND name = $2",
                 self._claim_token,
                 name,
             )
@@ -94,8 +93,7 @@ class PostgresClaimKV:
         conn = await self._connect()
         try:
             rows = await conn.fetch(
-                "SELECT name, value FROM murmur_claim_kv "
-                "WHERE claim_token = $1",
+                "SELECT name, value FROM murmur_claim_kv WHERE claim_token = $1",
                 self._claim_token,
             )
         finally:

--- a/apps/crawler/tests/workspace/lib/test_cli_shim.py
+++ b/apps/crawler/tests/workspace/lib/test_cli_shim.py
@@ -28,9 +28,8 @@ from src.workspace.lib import (
     WsMonitorRunFailed,
     WsProbeFailed,
     WsScraperRunFailed,
+    cli_shim,
 )
-from src.workspace.lib import cli_shim
-
 
 # ── Dispatch map / unknown-subcommand handling ───────────────────────
 
@@ -43,9 +42,7 @@ async def test_unknown_subcommand_returns_envelope() -> None:
 
 @pytest.mark.asyncio
 async def test_invalid_body_type_returns_envelope() -> None:
-    out = await cli_shim.run_envelope(
-        {"subcommand": "probe_monitor", "body": "not-a-dict"}
-    )
+    out = await cli_shim.run_envelope({"subcommand": "probe_monitor", "body": "not-a-dict"})
     assert out == {"ok": False, "errors": ["invalid_body"]}
 
 
@@ -150,9 +147,7 @@ async def test_select_monitor_routes_through_kv_when_provided() -> None:
         def to_dict(self) -> dict[str, Any]:
             return {"name": "cfg-1", "kind": "monitor"}
 
-    async def stub_select_monitor(
-        kv: Any, monitor_type: str, name: str, config: Any
-    ) -> Any:
+    async def stub_select_monitor(kv: Any, monitor_type: str, name: str, config: Any) -> Any:
         received["type"] = monitor_type
         received["name"] = name
         return _StubResult()

--- a/apps/crawler/tests/workspace/lib/test_cli_shim.py
+++ b/apps/crawler/tests/workspace/lib/test_cli_shim.py
@@ -1,0 +1,235 @@
+"""Tests for the JSON-in / JSON-out HTTP shim entry point.
+
+The shim is the boundary the TS routes call into via subprocess. These
+tests stub the real lib functions so we can verify the shim's
+responsibilities in isolation:
+
+  - dispatch on `subcommand`
+  - typed-exception → envelope-token mapping
+  - generic exception → ``internal_error`` (no traceback in envelope)
+  - unknown subcommand → ``unknown_subcommand`` envelope
+  - body forwarded to the lib unchanged
+  - PostgresClaimKV is not constructed when claim_token is missing
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from src.workspace.lib import (
+    WsBoardNotFound,
+    WsConfigInvalid,
+    WsConfigMissing,
+    WsFeedbackIncomplete,
+    WsLibError,
+    WsMonitorRunFailed,
+    WsProbeFailed,
+    WsScraperRunFailed,
+)
+from src.workspace.lib import cli_shim
+
+
+# ── Dispatch map / unknown-subcommand handling ───────────────────────
+
+
+@pytest.mark.asyncio
+async def test_unknown_subcommand_returns_envelope() -> None:
+    out = await cli_shim.run_envelope({"subcommand": "no-such-thing", "body": {}})
+    assert out == {"ok": False, "errors": ["unknown_subcommand"]}
+
+
+@pytest.mark.asyncio
+async def test_invalid_body_type_returns_envelope() -> None:
+    out = await cli_shim.run_envelope(
+        {"subcommand": "probe_monitor", "body": "not-a-dict"}
+    )
+    assert out == {"ok": False, "errors": ["invalid_body"]}
+
+
+# ── Typed-exception mapping (one per error class) ────────────────────
+
+
+@pytest.mark.parametrize(
+    ("exc", "token"),
+    [
+        (WsBoardNotFound("nope"), "board_not_found"),
+        (WsConfigMissing("missing"), "config_missing"),
+        (WsConfigInvalid("invalid"), "config_invalid"),
+        (WsProbeFailed("pf"), "probe_failed"),
+        (WsMonitorRunFailed("mrf"), "monitor_run_failed"),
+        (WsScraperRunFailed("srf"), "scraper_run_failed"),
+        (WsFeedbackIncomplete("fb"), "feedback_incomplete"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_typed_exception_mapping(exc: WsLibError, token: str) -> None:
+    async def stub(_state: Any, _expected: Any) -> Any:
+        raise exc
+
+    with patch.object(cli_shim, "probe_monitor", stub):
+        out = await cli_shim.run_envelope(
+            {
+                "subcommand": "probe_monitor",
+                "body": {"board_url": "https://job-boards.greenhouse.io/x"},
+            }
+        )
+    assert out == {"ok": False, "errors": [token]}
+
+
+@pytest.mark.asyncio
+async def test_generic_exception_maps_to_internal_error() -> None:
+    async def stub(_state: Any, _expected: Any) -> Any:
+        raise RuntimeError("boom secret token=xxxx")
+
+    with patch.object(cli_shim, "probe_monitor", stub):
+        out = await cli_shim.run_envelope(
+            {
+                "subcommand": "probe_monitor",
+                "body": {"board_url": "https://job-boards.greenhouse.io/x"},
+            }
+        )
+    assert out == {"ok": False, "errors": ["internal_error"]}
+    # The envelope must not carry the underlying message.
+    assert "boom" not in str(out)
+
+
+# ── Happy path: probe / select dispatch via stub ─────────────────────
+
+
+@pytest.mark.asyncio
+async def test_probe_monitor_happy_path_stub() -> None:
+    captured: dict[str, Any] = {}
+
+    class _StubResult:
+        def to_dict(self) -> dict[str, Any]:
+            return {"sentinel": "probe-monitor"}
+
+    async def stub(state: Any, expected: int) -> Any:
+        captured["board_url"] = state.board_url
+        captured["expected"] = expected
+        return _StubResult()
+
+    with patch.object(cli_shim, "probe_monitor", stub):
+        out = await cli_shim.run_envelope(
+            {
+                "subcommand": "probe_monitor",
+                "body": {
+                    "board_url": "https://job-boards.greenhouse.io/x",
+                    "expected_count": 42,
+                },
+            }
+        )
+    assert out == {"ok": True, "data": {"sentinel": "probe-monitor"}}
+    assert captured == {
+        "board_url": "https://job-boards.greenhouse.io/x",
+        "expected": 42,
+    }
+
+
+@pytest.mark.asyncio
+async def test_select_monitor_routes_through_kv_when_provided() -> None:
+    received: dict[str, Any] = {}
+
+    class _StubKV:
+        async def set(self, name: str, value: Any) -> None:
+            received[("set", name)] = value
+
+        async def set_active(self, name: str) -> None:
+            received["active"] = name
+
+        async def get(self, name: str) -> Any:
+            return None
+
+        async def get_active(self) -> str | None:
+            return None
+
+    class _StubResult:
+        def to_dict(self) -> dict[str, Any]:
+            return {"name": "cfg-1", "kind": "monitor"}
+
+    async def stub_select_monitor(
+        kv: Any, monitor_type: str, name: str, config: Any
+    ) -> Any:
+        received["type"] = monitor_type
+        received["name"] = name
+        return _StubResult()
+
+    with (
+        patch.object(cli_shim, "select_monitor", stub_select_monitor),
+        patch.object(cli_shim, "PostgresClaimKV", lambda *a, **kw: _StubKV()),
+    ):
+        out = await cli_shim.run_envelope(
+            {
+                "subcommand": "select_monitor",
+                "body": {
+                    "candidate_id": "cfg-1",
+                    "board_url": "https://job-boards.greenhouse.io/x",
+                },
+                "claim_token": "claim-abc",
+                "db_dsn": "postgresql://stub",
+            }
+        )
+    assert out["ok"] is True
+    assert received["name"] == "cfg-1"
+
+
+@pytest.mark.asyncio
+async def test_select_monitor_without_kv_returns_config_invalid() -> None:
+    out = await cli_shim.run_envelope(
+        {
+            "subcommand": "select_monitor",
+            "body": {
+                "candidate_id": "cfg-1",
+                "board_url": "https://job-boards.greenhouse.io/x",
+            },
+            # No claim_token / db_dsn — KV unavailable.
+        }
+    )
+    assert out == {"ok": False, "errors": ["config_invalid"]}
+
+
+# ── Feedback verdict mapping ─────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_feedback_maps_demo_verdict_to_lib_vocab() -> None:
+    received: dict[str, Any] = {}
+
+    class _StubKV:
+        async def set(self, *a: Any, **kw: Any) -> None: ...
+        async def set_active(self, *a: Any, **kw: Any) -> None: ...
+        async def get(self, *a: Any, **kw: Any) -> Any:
+            return None
+
+        async def get_active(self, *a: Any, **kw: Any) -> Any:
+            return None
+
+    class _StubResult:
+        def to_dict(self) -> dict[str, Any]:
+            return {"verdict": "good"}
+
+    async def stub_feedback(kv: Any, verdict: str, **kw: Any) -> Any:
+        received["verdict"] = verdict
+        return _StubResult()
+
+    with (
+        patch.object(cli_shim, "feedback", stub_feedback),
+        patch.object(cli_shim, "PostgresClaimKV", lambda *a, **kw: _StubKV()),
+    ):
+        for demo, lib in (
+            ("ok", "good"),
+            ("needs-work", "acceptable"),
+            ("rejected", "poor"),
+        ):
+            await cli_shim.run_envelope(
+                {
+                    "subcommand": "feedback",
+                    "body": {"verdict": demo},
+                    "claim_token": "claim-abc",
+                    "db_dsn": "postgresql://stub",
+                }
+            )
+            assert received["verdict"] == lib

--- a/apps/web/app/api/murmur/README.md
+++ b/apps/web/app/api/murmur/README.md
@@ -1,0 +1,95 @@
+# Murmur HTTP shim routes
+
+This directory hosts the seven Next.js app-router routes that serve the
+demo-path subcommands listed in Murmur DESIGN.md §4.2:
+
+| Route | Subcommand | Lib function |
+|---|---|---|
+| `POST /api/murmur/probes/monitor` | `probe monitor` | `probe_monitor` |
+| `POST /api/murmur/run/monitor` | `run monitor` | `run_monitor` |
+| `POST /api/murmur/probes/scraper` | `probe scraper` | `probe_scraper` |
+| `POST /api/murmur/run/scraper` | `run scraper` | `run_scraper` |
+| `POST /api/murmur/select/monitor` | `select monitor` | `select_monitor` |
+| `POST /api/murmur/select/scraper` | `select scraper` | `select_scraper` |
+| `POST /api/murmur/feedback` | `feedback` | `feedback` |
+
+Tracking issue: [colophon-group/jobseek#2759](https://github.com/colophon-group/jobseek/issues/2759).
+
+## IPC pattern (the language boundary)
+
+The route handlers are TypeScript; the lib functions live in
+`apps/crawler/src/workspace/lib/*.py`. We chose **pattern (a):
+subprocess invocation** for the demo path:
+
+- Each route call spawns a fresh `python3 -m src.workspace.lib.cli_shim`
+  child, pipes a JSON payload on stdin, and reads a JSON envelope on
+  stdout.
+- The shim builds a `BoardConfigState` (probe/run) or a
+  `PostgresClaimKV` (select/feedback/run/probe) and dispatches to the
+  corresponding lib function.
+- Typed lib exceptions are mapped to stable `errors[]` tokens before
+  the envelope is written; full tracebacks go to stderr only.
+
+### Why pattern (a) and not (b) (long-lived sidecar)
+
+- Probe and run already need Playwright + the entire crawler module
+  tree. The 200–500 ms Python startup is in the noise compared to the
+  multi-second Playwright work the lib does — these are the dominant
+  call shapes by latency.
+- `select` and `feedback` are sub-second otherwise; spawning doubles
+  their wall-clock latency, but the result still lands inside the M0
+  15 s subcommand budget (DESIGN.md §3.6, §7.1) by an order of
+  magnitude.
+- Pattern (b) would add a second container to the Hetzner deploy
+  (DESIGN.md §6.2 today: `murmur` + `cloudflared` only), an extra
+  health-check, and a second process-manager surface — out of scope
+  for the demo's deploy footprint.
+- If rehearsal shows the per-call subprocess startup is the bottleneck,
+  swap the implementation behind `_lib/invoke-lib.ts`'s `defaultInvoker`
+  to a long-lived Unix-socket worker without changing route shape.
+
+## Request handling order (M0 contract)
+
+Every route enforces, in order:
+
+1. **Bearer auth** — `Authorization: Bearer <MURMUR_TOKEN>` checked with
+   `crypto.timingSafeEqual`. Wrong / missing → HTTP 401 with body
+   `{ ok: false, errors: ["unauthorized"] }`.
+2. **Murmur headers** — `X-Murmur-Claim-Token` and
+   `X-Murmur-Subcommand`. Empty string is treated as missing. Missing
+   → HTTP 400 with `{ ok: false, errors: ["missing_header:..."] }`.
+3. **Body parse + schema validation** — body must be a JSON object that
+   matches the vendored input schema in `_lib/schemas.ts`.
+   Validation failure → HTTP 400 with per-field
+   `errors: ["schema:/<path>:<token>"]` entries.
+4. **SSRF allowlist** — for routes that carry URL fields (declared in
+   the route's `urlFields`), each is run through `validateUrl()` from
+   `@/lib/murmur/ssrf`. Non-allowlisted host → HTTP 200 with
+   `{ ok: false, errors: ["url_not_allowed"] }` (or one of the
+   `validateUrl` error codes).
+5. **Lib invocation** — `invokeLib()` returns an envelope verbatim.
+6. **Envelope return** — never a 5xx for a typed lib failure; never a
+   raw stack trace.
+
+## Error mapping (Python → envelope)
+
+| Typed exception (`apps/crawler/src/workspace/lib/exceptions.py`) | Envelope token |
+|---|---|
+| `WsBoardNotFound` | `board_not_found` |
+| `WsConfigMissing` | `config_missing` |
+| `WsConfigInvalid` | `config_invalid` |
+| `WsProbeFailed` | `probe_failed` |
+| `WsMonitorRunFailed` | `monitor_run_failed` |
+| `WsScraperRunFailed` | `scraper_run_failed` |
+| `WsFeedbackIncomplete` | `feedback_incomplete` |
+| Any other `Exception` | `internal_error` (trace logged, never returned) |
+
+## Required environment
+
+| Variable | Purpose |
+|---|---|
+| `MURMUR_TOKEN` | The shared bearer the agent sends. Routes fail closed if unset. |
+| `MURMUR_DB_DSN` | Postgres DSN for the `PostgresClaimKV` (the same DB jobseek's TS app uses; J3 added the `murmur_claim_kv` table). |
+| `MURMUR_PY` (optional) | Python interpreter path; defaults to `python3`. |
+| `MURMUR_CRAWLER_ROOT` (optional) | Path to the crawler app root; defaults to `<cwd>/../crawler`. |
+| `MURMUR_INVOKE_TIMEOUT_MS` (optional) | Wallclock cap per call; defaults to 30 000 ms. |

--- a/apps/web/app/api/murmur/__tests__/_helpers.ts
+++ b/apps/web/app/api/murmur/__tests__/_helpers.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared test helpers for the Murmur shim route suites.
+ *
+ * Mocks the SSRF module + the lib invoker so unit tests run with no
+ * network and no Python subprocesses. Each test suite imports this
+ * module BEFORE importing the route it exercises so the `vi.mock`
+ * calls register first.
+ *
+ * @see colophon-group/jobseek#2759
+ */
+import { vi, beforeEach } from "vitest";
+
+// ── Mocks ──────────────────────────────────────────────────────────
+
+// SSRF mock — tests push allow/deny decisions per host pattern.
+vi.mock("@/lib/murmur/ssrf", () => {
+  const validateUrl = vi.fn(async (input: string) => {
+    if (typeof globalThis.__ssrfDecision === "function") {
+      return globalThis.__ssrfDecision(input);
+    }
+    // Default: pass-through if URL is parseable.
+    try {
+      const u = new URL(input);
+      return {
+        ok: true as const,
+        url: u,
+        resolvedIp: "203.0.113.10",
+        family: 4 as const,
+      };
+    } catch {
+      return { ok: false as const, error: "url_invalid" as const };
+    }
+  });
+  return { validateUrl };
+});
+
+// Lib invoker mock — tests overwrite `InvokerHolder.current` per case.
+// We don't mock the module: `InvokerHolder` is an object with a mutable
+// `current` field, so tests just replace the function reference.
+
+// ── Setup helpers ──────────────────────────────────────────────────
+
+declare global {
+  // SSRF decision override. Set to `null` / `undefined` for default.
+  // eslint-disable-next-line no-var
+  var __ssrfDecision:
+    | ((url: string) =>
+        | {
+            ok: true;
+            url: URL;
+            resolvedIp: string;
+            family: 4 | 6;
+          }
+        | { ok: false; error: string })
+    | null
+    | undefined;
+}
+
+beforeEach(() => {
+  globalThis.__ssrfDecision = null;
+  // Restore a known token for every case; individual cases mutate it.
+  process.env.MURMUR_TOKEN = "test-token";
+});
+
+/** Build a fully-formed authorised request with the canonical headers. */
+export function authedRequest(
+  url: string,
+  body: unknown,
+  overrides?: {
+    bearer?: string;
+    claimToken?: string | null;
+    subcommand?: string | null;
+    skipBearer?: boolean;
+  },
+): Request {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (!overrides?.skipBearer) {
+    const tok = overrides?.bearer ?? process.env.MURMUR_TOKEN ?? "test-token";
+    headers.set("authorization", `Bearer ${tok}`);
+  }
+  if (overrides?.claimToken !== null) {
+    headers.set("x-murmur-claim-token", overrides?.claimToken ?? "claim-abc");
+  }
+  if (overrides?.subcommand !== null) {
+    headers.set(
+      "x-murmur-subcommand",
+      overrides?.subcommand ?? "probe monitor",
+    );
+  }
+  return new Request(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+/** Stable greenhouse URL that passes the SSRF mock by default. */
+export const GREENHOUSE_URL = "https://job-boards.greenhouse.io/acme";
+/** Stable lever URL. */
+export const LEVER_URL = "https://jobs.lever.co/acme/post-1";

--- a/apps/web/app/api/murmur/__tests__/_helpers.ts
+++ b/apps/web/app/api/murmur/__tests__/_helpers.ts
@@ -42,7 +42,7 @@ vi.mock("@/lib/murmur/ssrf", () => {
 
 declare global {
   // SSRF decision override. Set to `null` / `undefined` for default.
-  // eslint-disable-next-line no-var
+
   var __ssrfDecision:
     | ((url: string) =>
         | {

--- a/apps/web/app/api/murmur/__tests__/auth.test.ts
+++ b/apps/web/app/api/murmur/__tests__/auth.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for `_lib/auth.ts` — `requireBearer`.
+ *
+ * Verifies:
+ *   - missing `Authorization` → 401 with stable error envelope
+ *   - wrong token             → 401 (constant-time comparison)
+ *   - misconfigured server    → 401 (fail closed)
+ *   - correct token           → null (proceed)
+ *
+ * @see colophon-group/jobseek#2759
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { requireBearer } from "../_lib/auth";
+
+beforeEach(() => {
+  process.env.MURMUR_TOKEN = "test-token";
+});
+
+const make = (auth?: string): Request => {
+  const headers = new Headers();
+  if (auth) headers.set("authorization", auth);
+  return new Request("https://test.local", { headers });
+};
+
+describe("requireBearer", () => {
+  it("returns 401 when the Authorization header is missing", async () => {
+    const res = requireBearer(make());
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+    const body = await res!.json();
+    expect(body).toEqual({ ok: false, errors: ["unauthorized"] });
+  });
+
+  it("returns 401 when the token is wrong", async () => {
+    const res = requireBearer(make("Bearer wrong-token"));
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+  });
+
+  it("accepts the correct token (returns null)", () => {
+    const res = requireBearer(make("Bearer test-token"));
+    expect(res).toBeNull();
+  });
+
+  it("accepts case-insensitive 'bearer' prefix", () => {
+    const res = requireBearer(make("bearer test-token"));
+    expect(res).toBeNull();
+  });
+
+  it("rejects malformed Authorization headers (no Bearer prefix)", () => {
+    const res = requireBearer(make("test-token"));
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+  });
+
+  it("rejects an empty bearer token", () => {
+    const res = requireBearer(make("Bearer "));
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+  });
+
+  it("fails closed when MURMUR_TOKEN is unset", async () => {
+    delete process.env.MURMUR_TOKEN;
+    const res = requireBearer(make("Bearer anything"));
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+  });
+
+  it("rejects a token of different length without throwing", () => {
+    // The constant-time helper short-circuits on length mismatch.
+    const res = requireBearer(make("Bearer xx"));
+    expect(res).not.toBeNull();
+    expect(res!.status).toBe(401);
+  });
+});

--- a/apps/web/app/api/murmur/__tests__/e2e.test.ts
+++ b/apps/web/app/api/murmur/__tests__/e2e.test.ts
@@ -1,0 +1,140 @@
+/**
+ * End-to-end test for the Murmur shim — exercises one route
+ * (`POST /api/murmur/probes/monitor`) all the way through the real
+ * `defaultInvoker`, which forks the Python `cli_shim` subprocess and
+ * runs `probe_monitor` against a fixture board.
+ *
+ * Why this test is gated:
+ *
+ *   - The default invoker spawns Python and pulls in Playwright +
+ *     httpx, so it's slow (~5–15 s) and depends on a working Python
+ *     env in `apps/crawler` (asyncpg, playwright, httpx, etc.).
+ *   - It also reaches the public network to probe a real greenhouse
+ *     board; we don't want CI flakes when greenhouse.io is rate-limiting
+ *     or returning HTML changes.
+ *
+ * Therefore the test is **opt-in** via `RUN_E2E_MURMUR=1`. The
+ * orchestrator runs it locally before merge; CI without the flag skips.
+ *
+ * Required local environment when running:
+ *   RUN_E2E_MURMUR=1                  (gate)
+ *   MURMUR_TOKEN=<anything>           (route auth — defaults to test-token here)
+ *   MURMUR_PY=<path/to/python>        (optional; defaults to `python3`. Use the
+ *                                      crawler venv: `apps/crawler/.venv/bin/python`)
+ *   MURMUR_CRAWLER_ROOT=<...>         (optional; defaults to ../crawler relative
+ *                                      to apps/web)
+ *   MURMUR_INVOKE_TIMEOUT_MS=<...>    (optional but recommended: a real probe
+ *                                      against greenhouse takes ~30 s, which
+ *                                      exceeds the 30 s production default.
+ *                                      Set to 120000 locally.)
+ *   DATABASE_URL=<...>                (optional; only required for routes that
+ *                                      touch PostgresClaimKV — `probes/monitor`
+ *                                      does not, so the test runs without a DB)
+ *
+ * Reproduce locally:
+ *
+ *   cd apps/web
+ *   MURMUR_INVOKE_TIMEOUT_MS=180000 \
+ *     MURMUR_PY=$(pwd)/../crawler/.venv/bin/python \
+ *     MURMUR_CRAWLER_ROOT=$(pwd)/../crawler \
+ *     pnpm test:e2e:murmur
+ *
+ * The SSRF module is still mocked here: J4 is exercised exhaustively in
+ * `routes.test.ts`. This test cares about the lib boundary, not the
+ * allowlist, so we let `validateUrl` pass through.
+ *
+ * @see colophon-group/jobseek#2759
+ */
+import { describe, it, expect } from "vitest";
+
+import "./_helpers";
+import { authedRequest, GREENHOUSE_URL } from "./_helpers";
+import { InvokerHolder, defaultInvoker } from "../_lib/invoke-lib";
+
+const E2E_ENABLED = process.env.RUN_E2E_MURMUR === "1";
+
+interface ProbeMonitorData {
+  board_url: string;
+  current_jobs: number;
+  entries: Array<{ name: string; metadata?: unknown; comment?: string }>;
+  scored: Array<{ name: string }>;
+}
+
+interface OkEnvelope {
+  ok: true;
+  data: ProbeMonitorData;
+}
+
+interface ErrEnvelope {
+  ok: false;
+  errors: string[];
+}
+
+type Envelope = OkEnvelope | ErrEnvelope;
+
+describe.skipIf(!E2E_ENABLED)("e2e: POST /api/murmur/probes/monitor", () => {
+  it(
+    "returns a probe-monitor envelope with the expected shape",
+    async () => {
+      // Use the real invoker. `_helpers.ts`'s `beforeEach` does NOT
+      // touch InvokerHolder.current, so this assignment sticks for the
+      // duration of the test.
+      InvokerHolder.current = defaultInvoker;
+
+      // Bump the invoker's wallclock cap unless the operator already
+      // overrode it: a real greenhouse probe runs ~30 s, which is right
+      // at the production default and trips the timeout intermittently.
+      if (!process.env.MURMUR_INVOKE_TIMEOUT_MS) {
+        process.env.MURMUR_INVOKE_TIMEOUT_MS = "180000";
+      }
+
+      // Allow the SSRF mock to pass the greenhouse URL through (default
+      // behaviour in _helpers.ts is allow-by-default for parseable URLs).
+      globalThis.__ssrfDecision = null;
+
+      // The route still requires a valid bearer; _helpers seeds
+      // process.env.MURMUR_TOKEN to "test-token" in beforeEach.
+      const mod = await import("../probes/monitor/route");
+      const url = `https://test.local/api/murmur/probes/monitor`;
+      const req = authedRequest(url, {
+        board_url: GREENHOUSE_URL,
+        expected_count: 0,
+      });
+
+      const res = await mod.POST(req);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Envelope;
+
+      // The envelope shape is the contract; the precise probe results
+      // (which monitors detected greenhouse, exact entry count) are
+      // owned by `apps/crawler`'s probe registry and must not be locked
+      // down here. We verify only structural invariants that a working
+      // probe must satisfy.
+      if (!body.ok) {
+        // Surface the errors loudly so a flaky network shows up clearly
+        // in the test output instead of failing on a missing field.
+        throw new Error(
+          `e2e probe_monitor returned an error envelope: ${JSON.stringify(body.errors)}`,
+        );
+      }
+
+      expect(body.ok).toBe(true);
+      expect(body.data).toBeDefined();
+      expect(body.data.board_url).toBe(GREENHOUSE_URL);
+      expect(typeof body.data.current_jobs).toBe("number");
+      expect(Array.isArray(body.data.entries)).toBe(true);
+      expect(Array.isArray(body.data.scored)).toBe(true);
+      // A real greenhouse probe has at least one entry per registered
+      // monitor (some not-detected, some detected). We don't pin the
+      // count, only that the registry returned something.
+      expect(body.data.entries.length).toBeGreaterThan(0);
+      // Every entry has a name (string).
+      for (const entry of body.data.entries) {
+        expect(typeof entry.name).toBe("string");
+      }
+    },
+    // Generous timeout: subprocess spawn (~500 ms) + Playwright/httpx
+    // probe of a public board (5–15 s) + safety margin.
+    60_000,
+  );
+});

--- a/apps/web/app/api/murmur/__tests__/headers-helper.test.ts
+++ b/apps/web/app/api/murmur/__tests__/headers-helper.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for `_lib/headers-helper.ts`.
+ *
+ * @see colophon-group/jobseek#2759
+ */
+import { describe, it, expect } from "vitest";
+import { requireMurmurHeaders } from "../_lib/headers-helper";
+
+const make = (h?: Record<string, string>): Request =>
+  new Request("https://test.local", { headers: new Headers(h ?? {}) });
+
+describe("requireMurmurHeaders", () => {
+  it("flags both headers as missing when neither is set", () => {
+    const r = requireMurmurHeaders(make());
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.missing).toEqual(
+        expect.arrayContaining([
+          "x-murmur-claim-token",
+          "x-murmur-subcommand",
+        ]),
+      );
+    }
+  });
+
+  it("flags claim-token alone when only it is missing", () => {
+    const r = requireMurmurHeaders(make({ "x-murmur-subcommand": "probe monitor" }));
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.missing).toEqual(["x-murmur-claim-token"]);
+    }
+  });
+
+  it("treats an empty-string claim-token as missing", () => {
+    const r = requireMurmurHeaders(
+      make({ "x-murmur-claim-token": "   ", "x-murmur-subcommand": "probe monitor" }),
+    );
+    expect(r.ok).toBe(false);
+  });
+
+  it("succeeds when both headers are present and non-empty", () => {
+    const r = requireMurmurHeaders(
+      make({
+        "x-murmur-claim-token": "claim-abc",
+        "x-murmur-subcommand": "probe monitor",
+      }),
+    );
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.claim_token).toBe("claim-abc");
+      expect(r.subcommand).toBe("probe monitor");
+    }
+  });
+});

--- a/apps/web/app/api/murmur/__tests__/invoke-lib.test.ts
+++ b/apps/web/app/api/murmur/__tests__/invoke-lib.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Direct unit tests for the `defaultInvoker` subprocess branches.
+ *
+ * The route-level tests in `routes.test.ts` stub the invoker because
+ * they care about the HTTP shim behaviour, not the subprocess wiring.
+ * These tests do the inverse: drive `defaultInvoker` with carefully
+ * chosen "interpreters" so we exercise each non-happy branch
+ * deterministically without forking a real Python.
+ *
+ * We point `MURMUR_PY` at:
+ *   - `false` (path probed)  — exits 1 immediately (non-zero exit branch)
+ *   - `/bin/echo`            — exits 0 but stdout is "-m src.workspace.lib.cli_shim",
+ *                              not valid JSON (parse-failure branch)
+ *   - a temp shell script    — runs `while :; do sleep 1; done` (timeout branch)
+ *   - a path that doesn't exist — `child.on('error')` (spawn-error branch)
+ *
+ * Happy-path coverage lives in `e2e.test.ts` against a real Python.
+ * We still set `MURMUR_CRAWLER_ROOT` to a real directory because
+ * Node's `spawn` validates `cwd`.
+ *
+ * @see colophon-group/jobseek#2759
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import os from "node:os";
+
+import { defaultInvoker } from "../_lib/invoke-lib";
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  // Make all spawn-cwds resolve to a real directory.
+  process.env.MURMUR_CRAWLER_ROOT = os.tmpdir();
+  process.env.MURMUR_DB_DSN = "";
+  // Default short timeout so the timeout test doesn't drag.
+  process.env.MURMUR_INVOKE_TIMEOUT_MS = "1000";
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe("defaultInvoker subprocess branches", () => {
+  it("maps a non-zero exit to { ok: false, errors: ['internal_error'] }", async () => {
+    // `false` lives at /usr/bin/false on macOS and /bin/false on Linux;
+    // probe both.
+    const fs = await import("node:fs/promises");
+    let falsePath = "/usr/bin/false";
+    try {
+      await fs.access(falsePath);
+    } catch {
+      falsePath = "/bin/false";
+    }
+    process.env.MURMUR_PY = falsePath;
+    const result = await defaultInvoker("probe_monitor", {}, "claim-x");
+    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual(["internal_error"]);
+  });
+
+  it("maps non-envelope stdout to { ok: false, errors: ['internal_error'] }", async () => {
+    // /bin/echo writes an arg to stdout and exits 0. The invoker passes
+    // `-m src.workspace.lib.cli_shim` as argv, so echo prints those.
+    // That's not valid JSON → parse fails → internal_error.
+    process.env.MURMUR_PY = "/bin/echo";
+    const result = await defaultInvoker("probe_monitor", {}, "claim-x");
+    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual(["internal_error"]);
+  });
+
+  it("times out long-running children and returns internal_error", async () => {
+    // We need a child that (a) ignores the hardcoded `-m
+    // src.workspace.lib.cli_shim` argv and (b) never exits on its own.
+    // `/bin/cat` with no args reads stdin until EOF and writes it back.
+    // The invoker calls `child.stdin.end()` after writing the payload,
+    // which would let cat exit promptly — but we want to test the
+    // wallclock-timeout branch, not the EOF-exit branch.
+    //
+    // Use `node -e <forever>`: node treats `-m ...` as positional args
+    // (warning + ignored under -e) and the script runs until killed.
+    //
+    // The invoker hardcodes argv to `["-m", "src.workspace.lib.cli_shim"]`.
+    // With node, this becomes `node -m src.workspace.lib.cli_shim` —
+    // node interprets `-m` as an unknown short flag and exits 9 with
+    // an error. So node is no good either.
+    //
+    // Cleanest alternative: a tiny shell script that loops forever and
+    // ignores all args. Write it to a tempfile.
+    const fs = await import("node:fs/promises");
+    const path = await import("node:path");
+    const tmpScript = path.join(os.tmpdir(), `murmur-sleep-${Date.now()}.sh`);
+    await fs.writeFile(
+      tmpScript,
+      "#!/bin/sh\nwhile :; do sleep 1; done\n",
+      { mode: 0o755 },
+    );
+    try {
+      process.env.MURMUR_PY = tmpScript;
+      process.env.MURMUR_INVOKE_TIMEOUT_MS = "300";
+      const start = Date.now();
+      const result = await defaultInvoker("probe_monitor", {}, "claim-x");
+      const elapsed = Date.now() - start;
+      expect(result.ok).toBe(false);
+      expect(result.errors).toEqual(["internal_error"]);
+      // The timer fires at 300 ms; allow slack for CI jitter.
+      expect(elapsed).toBeGreaterThanOrEqual(250);
+      expect(elapsed).toBeLessThan(5000);
+    } finally {
+      await fs.unlink(tmpScript).catch(() => {});
+    }
+  });
+
+  it("maps spawn-failure (interpreter not found) to internal_error", async () => {
+    process.env.MURMUR_PY = "/no/such/interpreter/exists/anywhere";
+    const result = await defaultInvoker("probe_monitor", {}, "claim-x");
+    expect(result.ok).toBe(false);
+    expect(result.errors).toEqual(["internal_error"]);
+  });
+});

--- a/apps/web/app/api/murmur/__tests__/routes.test.ts
+++ b/apps/web/app/api/murmur/__tests__/routes.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Route-level unit tests for the seven Murmur shim handlers.
+ *
+ * Each route is exercised through the documented matrix from
+ * jobseek#2759's Verification block:
+ *
+ *   - bearer header missing               → 401
+ *   - bearer header wrong                 → 401
+ *   - bearer ok + missing claim-token     → 400
+ *   - body schema-invalid                 → 400 with per-field path errors
+ *   - URL fields rejected by SSRF         → { ok: false, errors: ["url_not_allowed"] }
+ *   - happy path with stub lib            → { ok: true, data }
+ *   - lib throws typed exception → mapped → { ok: false, errors: [...] } (no 5xx)
+ *   - bearer-auth runs as the FIRST middleware (verified via lib-stub spy)
+ *   - no route returns a raw stack trace on error
+ *
+ * The lib invoker is replaced per test via `InvokerHolder.current`. The
+ * SSRF module is mocked in `_helpers.ts`.
+ *
+ * @see colophon-group/jobseek#2759
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import "./_helpers";
+import {
+  authedRequest,
+  GREENHOUSE_URL,
+  LEVER_URL,
+} from "./_helpers";
+import {
+  InvokerHolder,
+  type LibInvoker,
+} from "../_lib/invoke-lib";
+
+// Lazy-load route modules so mocks register first.
+async function loadRoute(name: string) {
+  switch (name) {
+    case "probes/monitor":
+      return await import("../probes/monitor/route");
+    case "probes/scraper":
+      return await import("../probes/scraper/route");
+    case "run/monitor":
+      return await import("../run/monitor/route");
+    case "run/scraper":
+      return await import("../run/scraper/route");
+    case "select/monitor":
+      return await import("../select/monitor/route");
+    case "select/scraper":
+      return await import("../select/scraper/route");
+    case "feedback":
+      return await import("../feedback/route");
+    default:
+      throw new Error(`unknown route: ${name}`);
+  }
+}
+
+interface RouteCase {
+  /** URL path under /api/murmur/. */
+  readonly path: string;
+  /** Expected `LibSubcommand` the route invokes. */
+  readonly libSubcommand: string;
+  /** A schema-valid body to use for happy-path / error mapping cases. */
+  readonly validBody: Record<string, unknown>;
+  /** Body that violates the route's schema (used for the 400 case). */
+  readonly invalidBody: Record<string, unknown>;
+  /**
+   * Optional URL field within the body. When present, this enables the
+   * SSRF rejection test. Routes with no URL fields skip that case.
+   */
+  readonly urlField?: string;
+}
+
+const ROUTE_CASES: readonly RouteCase[] = [
+  {
+    path: "probes/monitor",
+    libSubcommand: "probe_monitor",
+    validBody: { board_url: GREENHOUSE_URL, expected_count: 12 },
+    invalidBody: { expected_count: -1 }, // missing board_url + below_minimum
+    urlField: "board_url",
+  },
+  {
+    path: "probes/scraper",
+    libSubcommand: "probe_scraper",
+    validBody: {
+      board_url: GREENHOUSE_URL,
+      monitor_type: "greenhouse",
+      monitor_config: { foo: 1 },
+    },
+    invalidBody: {
+      board_url: GREENHOUSE_URL,
+      monitor_type: "",
+      // monitor_config missing
+    },
+    urlField: "board_url",
+  },
+  {
+    path: "run/monitor",
+    libSubcommand: "run_monitor",
+    validBody: { board_url: GREENHOUSE_URL },
+    invalidBody: { board_url: "not-a-url" },
+    urlField: "board_url",
+  },
+  {
+    path: "run/scraper",
+    libSubcommand: "run_scraper",
+    validBody: { board_url: GREENHOUSE_URL, sample_job_url: LEVER_URL },
+    invalidBody: { board_url: 123 },
+    urlField: "board_url",
+  },
+  {
+    path: "select/monitor",
+    libSubcommand: "select_monitor",
+    validBody: { candidate_id: "cfg-1", board_url: GREENHOUSE_URL },
+    invalidBody: { candidate_id: "", board_url: GREENHOUSE_URL },
+    urlField: "board_url",
+  },
+  {
+    path: "select/scraper",
+    libSubcommand: "select_scraper",
+    validBody: { candidate_id: "cfg-1", board_url: GREENHOUSE_URL },
+    invalidBody: { board_url: GREENHOUSE_URL }, // candidate_id missing
+    urlField: "board_url",
+  },
+  {
+    path: "feedback",
+    libSubcommand: "feedback",
+    validBody: { verdict: "ok", notes: "looks fine" },
+    invalidBody: { verdict: "maybe" }, // not in enum
+    // No URL field on /feedback per the YAML schema.
+  },
+];
+
+beforeEach(() => {
+  // Default to a passthrough invoker. Each test overrides as needed.
+  InvokerHolder.current = (async () => ({
+    ok: true,
+    data: { default: true },
+  })) as LibInvoker;
+});
+
+describe.each(ROUTE_CASES)("$path", (rc) => {
+  const url = `https://test.local/api/murmur/${rc.path}`;
+
+  it("returns 401 when the Authorization header is missing", async () => {
+    const mod = await loadRoute(rc.path);
+    const spy = vi.fn();
+    InvokerHolder.current = spy as unknown as LibInvoker;
+
+    const res = await mod.POST(
+      authedRequest(url, rc.validBody, { skipBearer: true }),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({ ok: false, errors: ["unauthorized"] });
+    expect(spy).not.toHaveBeenCalled(); // bearer is FIRST
+  });
+
+  it("returns 401 when the Authorization header is wrong", async () => {
+    const mod = await loadRoute(rc.path);
+    const spy = vi.fn();
+    InvokerHolder.current = spy as unknown as LibInvoker;
+
+    const res = await mod.POST(
+      authedRequest(url, rc.validBody, { bearer: "WRONG-TOKEN" }),
+    );
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body).toEqual({ ok: false, errors: ["unauthorized"] });
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when X-Murmur-Claim-Token is missing", async () => {
+    const mod = await loadRoute(rc.path);
+    const spy = vi.fn();
+    InvokerHolder.current = spy as unknown as LibInvoker;
+
+    const res = await mod.POST(
+      authedRequest(url, rc.validBody, { claimToken: null }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { ok: boolean; errors: string[] };
+    expect(body.ok).toBe(false);
+    expect(body.errors).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/^missing_header:x-murmur-claim-token$/),
+      ]),
+    );
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when X-Murmur-Subcommand is missing", async () => {
+    const mod = await loadRoute(rc.path);
+    const res = await mod.POST(
+      authedRequest(url, rc.validBody, { subcommand: null }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { errors: string[] };
+    expect(body.errors).toEqual(
+      expect.arrayContaining(["missing_header:x-murmur-subcommand"]),
+    );
+  });
+
+  it("returns 400 with per-field schema errors on invalid body", async () => {
+    const mod = await loadRoute(rc.path);
+    const spy = vi.fn();
+    InvokerHolder.current = spy as unknown as LibInvoker;
+
+    const res = await mod.POST(authedRequest(url, rc.invalidBody));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { ok: boolean; errors: string[] };
+    expect(body.ok).toBe(false);
+    // Every error has the per-field shape `schema:/<path>:<token>`.
+    for (const err of body.errors) {
+      expect(err).toMatch(/^schema:\/[^:]*:[a-z_]+$/);
+    }
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const mod = await loadRoute(rc.path);
+    const headers = new Headers({
+      "content-type": "application/json",
+      authorization: `Bearer ${process.env.MURMUR_TOKEN ?? "test-token"}`,
+      "x-murmur-claim-token": "claim-abc",
+      "x-murmur-subcommand": "probe monitor",
+    });
+    const req = new Request(url, {
+      method: "POST",
+      headers,
+      body: "{not json",
+    });
+    const res = await mod.POST(req);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { errors: string[] };
+    expect(body.errors).toEqual(["invalid_json"]);
+  });
+
+  if (rc.urlField) {
+    it("rejects URL fields that fail the SSRF allowlist", async () => {
+      globalThis.__ssrfDecision = () => ({
+        ok: false,
+        error: "url_not_allowed",
+      });
+      const spy = vi.fn();
+      InvokerHolder.current = spy as unknown as LibInvoker;
+      const mod = await loadRoute(rc.path);
+
+      const res = await mod.POST(authedRequest(url, rc.validBody));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { ok: boolean; errors: string[] };
+      expect(body).toEqual({ ok: false, errors: ["url_not_allowed"] });
+      expect(spy).not.toHaveBeenCalled(); // SSRF before lib
+    });
+  }
+
+  it("returns { ok: true, data } on the happy path", async () => {
+    const dataPayload = { sentinel: rc.libSubcommand };
+    let invokedWith: {
+      sub: string;
+      body: unknown;
+      claim: string;
+    } | null = null;
+    InvokerHolder.current = async (sub, body, claim) => {
+      invokedWith = { sub, body, claim };
+      return { ok: true, data: dataPayload };
+    };
+    const mod = await loadRoute(rc.path);
+
+    const res = await mod.POST(authedRequest(url, rc.validBody));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: true, data: dataPayload });
+    expect(invokedWith?.sub).toBe(rc.libSubcommand);
+    expect(invokedWith?.claim).toBe("claim-abc");
+    expect(invokedWith?.body).toEqual(rc.validBody);
+  });
+
+  it("maps a typed lib failure envelope to the response without leaking 5xx", async () => {
+    InvokerHolder.current = async () => ({
+      ok: false,
+      errors: ["probe_failed"],
+    });
+    const mod = await loadRoute(rc.path);
+
+    const res = await mod.POST(authedRequest(url, rc.validBody));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: false, errors: ["probe_failed"] });
+  });
+
+  it("never leaks a stack trace when the invoker throws unexpectedly", async () => {
+    InvokerHolder.current = async () => {
+      throw new Error("simulated\n    at /private/path/cli_shim.py:42");
+    };
+    const mod = await loadRoute(rc.path);
+
+    const res = await mod.POST(authedRequest(url, rc.validBody));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean; errors: string[] };
+    expect(body).toEqual({ ok: false, errors: ["internal_error"] });
+    const raw = JSON.stringify(body);
+    expect(raw).not.toMatch(/at\s+\/private/);
+    expect(raw).not.toMatch(/cli_shim\.py/);
+  });
+});

--- a/apps/web/app/api/murmur/__tests__/routes.test.ts
+++ b/apps/web/app/api/murmur/__tests__/routes.test.ts
@@ -256,13 +256,14 @@ describe.each(ROUTE_CASES)("$path", (rc) => {
 
   it("returns { ok: true, data } on the happy path", async () => {
     const dataPayload = { sentinel: rc.libSubcommand };
-    let invokedWith: {
+    interface InvokeRecord {
       sub: string;
       body: unknown;
       claim: string;
-    } | null = null;
+    }
+    const invokedWith: { value: InvokeRecord | null } = { value: null };
     InvokerHolder.current = async (sub, body, claim) => {
-      invokedWith = { sub, body, claim };
+      invokedWith.value = { sub, body, claim };
       return { ok: true, data: dataPayload };
     };
     const mod = await loadRoute(rc.path);
@@ -271,9 +272,10 @@ describe.each(ROUTE_CASES)("$path", (rc) => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body).toEqual({ ok: true, data: dataPayload });
-    expect(invokedWith?.sub).toBe(rc.libSubcommand);
-    expect(invokedWith?.claim).toBe("claim-abc");
-    expect(invokedWith?.body).toEqual(rc.validBody);
+    expect(invokedWith.value).not.toBeNull();
+    expect(invokedWith.value?.sub).toBe(rc.libSubcommand);
+    expect(invokedWith.value?.claim).toBe("claim-abc");
+    expect(invokedWith.value?.body).toEqual(rc.validBody);
   });
 
   it("maps a typed lib failure envelope to the response without leaking 5xx", async () => {

--- a/apps/web/app/api/murmur/__tests__/validate.test.ts
+++ b/apps/web/app/api/murmur/__tests__/validate.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for `_lib/validate.ts` — the JSON-Schema-subset validator.
+ *
+ * Covers the constructs used by the YAML schemas:
+ *   - missing required keys
+ *   - additionalProperties: false rejects unknown keys
+ *   - per-property type / minLength / pattern / format=uri / enum / minimum
+ *   - per-field error paths use JSON-Pointer shape
+ *
+ * @see colophon-group/jobseek#2759
+ */
+
+import { describe, it, expect } from "vitest";
+import { validateBody } from "../_lib/validate";
+import {
+  PROBE_MONITOR_SCHEMA,
+  FEEDBACK_SCHEMA,
+  SELECT_MONITOR_SCHEMA,
+  RUN_SCRAPER_SCHEMA,
+} from "../_lib/schemas";
+
+describe("validateBody — generic", () => {
+  it("returns must_be_object on a non-object body", () => {
+    const errs = validateBody(42, PROBE_MONITOR_SCHEMA);
+    expect(errs).toEqual([{ path: "", message: "must_be_object" }]);
+  });
+  it("returns must_be_object on null", () => {
+    const errs = validateBody(null, PROBE_MONITOR_SCHEMA);
+    expect(errs).toEqual([{ path: "", message: "must_be_object" }]);
+  });
+  it("returns must_be_object on an array", () => {
+    const errs = validateBody([], PROBE_MONITOR_SCHEMA);
+    expect(errs).toEqual([{ path: "", message: "must_be_object" }]);
+  });
+
+  it("flags missing required keys with /<key>:missing", () => {
+    const errs = validateBody({}, PROBE_MONITOR_SCHEMA);
+    expect(errs).toContainEqual({ path: "/board_url", message: "missing" });
+  });
+
+  it("flags unknown properties with unknown_property", () => {
+    const errs = validateBody(
+      { board_url: "https://job-boards.greenhouse.io/x", uninvited: true },
+      PROBE_MONITOR_SCHEMA,
+    );
+    expect(errs).toContainEqual({
+      path: "/uninvited",
+      message: "unknown_property",
+    });
+  });
+});
+
+describe("validateBody — strings (format=uri, pattern, minLength)", () => {
+  it("rejects non-https URLs (pattern)", () => {
+    const errs = validateBody(
+      { board_url: "http://example.com/x" },
+      PROBE_MONITOR_SCHEMA,
+    );
+    expect(errs).toContainEqual({
+      path: "/board_url",
+      message: "pattern_mismatch",
+    });
+  });
+  it("rejects unparseable URI strings", () => {
+    const errs = validateBody({ board_url: "not a url" }, PROBE_MONITOR_SCHEMA);
+    // Pattern + format both fail; we only assert format fired.
+    const messages = errs.filter((e) => e.path === "/board_url").map((e) => e.message);
+    expect(messages).toContain("must_be_uri");
+  });
+  it("rejects too-short strings (minLength)", () => {
+    const errs = validateBody(
+      { candidate_id: "", board_url: "https://x.greenhouse.io/" },
+      SELECT_MONITOR_SCHEMA,
+    );
+    expect(errs).toContainEqual({ path: "/candidate_id", message: "too_short" });
+  });
+  it("accepts a valid string", () => {
+    const errs = validateBody(
+      { board_url: "https://job-boards.greenhouse.io/acme" },
+      PROBE_MONITOR_SCHEMA,
+    );
+    expect(errs).toEqual([]);
+  });
+});
+
+describe("validateBody — integers / minimum", () => {
+  it("rejects non-integer values", () => {
+    const errs = validateBody(
+      { board_url: "https://job-boards.greenhouse.io/", expected_count: 1.5 },
+      PROBE_MONITOR_SCHEMA,
+    );
+    expect(errs).toContainEqual({
+      path: "/expected_count",
+      message: "must_be_integer",
+    });
+  });
+  it("rejects below-minimum integers", () => {
+    const errs = validateBody(
+      { board_url: "https://job-boards.greenhouse.io/", expected_count: -1 },
+      PROBE_MONITOR_SCHEMA,
+    );
+    expect(errs).toContainEqual({
+      path: "/expected_count",
+      message: "below_minimum",
+    });
+  });
+});
+
+describe("validateBody — enums", () => {
+  it("rejects values not in the enum", () => {
+    const errs = validateBody({ verdict: "maybe" }, FEEDBACK_SCHEMA);
+    expect(errs).toContainEqual({ path: "/verdict", message: "not_in_enum" });
+  });
+  it("accepts canonical enum values", () => {
+    for (const v of ["ok", "needs-work", "rejected"]) {
+      const errs = validateBody({ verdict: v }, FEEDBACK_SCHEMA);
+      expect(errs).toEqual([]);
+    }
+  });
+});
+
+describe("validateBody — optional fields are skipped when absent", () => {
+  it("does not flag optional sample_job_url when not present", () => {
+    const errs = validateBody(
+      { board_url: "https://job-boards.greenhouse.io/" },
+      RUN_SCRAPER_SCHEMA,
+    );
+    expect(errs).toEqual([]);
+  });
+});

--- a/apps/web/app/api/murmur/_lib/auth.ts
+++ b/apps/web/app/api/murmur/_lib/auth.ts
@@ -1,0 +1,84 @@
+/**
+ * Bearer-token auth helper for every Murmur shim route.
+ *
+ * Reads `MURMUR_TOKEN` from process.env at module load time. Compares
+ * the agent-supplied bearer with `crypto.timingSafeEqual` (constant-time)
+ * to avoid leaking the secret length / prefix via response timing.
+ *
+ * The function returns either `null` (auth ok — proceed with the request)
+ * or a Response object the route should return immediately. Routes call
+ * this as their FIRST line of work — before reading the body, before
+ * reading the claim-token header, before any I/O.
+ *
+ * Spec: Murmur DESIGN.md §3.6 (Demo-grade auth, single shared bearer),
+ * §5.2 (jobseek demo path).
+ *
+ * @see colophon-group/jobseek#2759
+ */
+
+import { NextResponse } from "next/server";
+import { timingSafeEqual } from "node:crypto";
+import { HEADER_AUTHORIZATION } from "./headers";
+
+const TOKEN_ENV_VAR = "MURMUR_TOKEN" as const;
+
+/**
+ * Read the configured token at call time (not module-load time) so tests
+ * can mutate `process.env.MURMUR_TOKEN` between cases.
+ */
+function getConfiguredToken(): string | undefined {
+  const t = process.env[TOKEN_ENV_VAR];
+  if (typeof t !== "string" || t.length === 0) return undefined;
+  return t;
+}
+
+/**
+ * Constant-time comparison of two strings. Returns `false` when lengths
+ * differ (avoids the obvious timing leak) and otherwise calls
+ * `crypto.timingSafeEqual` on the byte buffers. Never throws.
+ */
+function constantTimeEquals(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  if (ab.length !== bb.length) return false;
+  return timingSafeEqual(ab, bb);
+}
+
+/**
+ * Verify the `Authorization: Bearer <token>` header against
+ * `process.env.MURMUR_TOKEN`.
+ *
+ * @returns `null` when authorised; a 401 NextResponse otherwise.
+ *   The 401 response body is `{ ok: false, errors: ["unauthorized"] }` —
+ *   no detail leaks (missing vs wrong vs disabled all collapse to the
+ *   same response).
+ */
+export function requireBearer(request: Request): NextResponse | null {
+  const expected = getConfiguredToken();
+  if (!expected) {
+    // Server is misconfigured (no token set). Fail closed; an unauthorised
+    // 401 is the safest answer — never accept any token.
+    return unauthorized();
+  }
+
+  const header = request.headers.get(HEADER_AUTHORIZATION);
+  if (!header) return unauthorized();
+
+  // Accept "Bearer <token>" (canonical) and reject everything else.
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  if (!match) return unauthorized();
+
+  const presented = match[1].trim();
+  if (presented.length === 0) return unauthorized();
+
+  if (!constantTimeEquals(presented, expected)) return unauthorized();
+
+  return null;
+}
+
+function unauthorized(): NextResponse {
+  return NextResponse.json(
+    { ok: false, errors: ["unauthorized"] },
+    { status: 401 },
+  );
+}

--- a/apps/web/app/api/murmur/_lib/envelope.ts
+++ b/apps/web/app/api/murmur/_lib/envelope.ts
@@ -1,0 +1,53 @@
+/**
+ * `task_tool` request/response envelope per Murmur DESIGN.md §4.2:
+ *
+ *     { ok: boolean, errors: string[]?, data: object? }
+ *
+ * Every Murmur shim route returns this shape — never a raw stack trace,
+ * never an HTTP 5xx for a typed lib failure (those become
+ * `{ ok: false, errors: [...] }` with a 200). HTTP non-2xx is reserved
+ * for transport-level rejections (401 unauthorised, 400 missing /
+ * malformed headers).
+ *
+ * @see colophon-group/jobseek#2759
+ */
+
+import { NextResponse } from "next/server";
+
+/**
+ * Successful envelope shape. `errors` is omitted on success.
+ */
+export interface OkEnvelope<T> {
+  readonly ok: true;
+  readonly data: T;
+}
+
+/**
+ * Failure envelope shape. `errors` is a non-empty list of stable string
+ * tokens — never user-facing prose, never a stack trace.
+ */
+export interface ErrEnvelope {
+  readonly ok: false;
+  readonly errors: readonly string[];
+}
+
+export type Envelope<T = unknown> = OkEnvelope<T> | ErrEnvelope;
+
+/** Build an `{ ok: true, data }` 200 response. */
+export function okJson<T>(data: T): NextResponse {
+  const body: OkEnvelope<T> = { ok: true, data };
+  return NextResponse.json(body, { status: 200 });
+}
+
+/**
+ * Build an `{ ok: false, errors }` JSON response. The HTTP status
+ * defaults to 200 (envelope-only failure) but callers may override
+ * with 400 / 401 for transport-level rejections.
+ */
+export function errJson(
+  errors: readonly string[],
+  init?: { status?: number },
+): NextResponse {
+  const body: ErrEnvelope = { ok: false, errors };
+  return NextResponse.json(body, { status: init?.status ?? 200 });
+}

--- a/apps/web/app/api/murmur/_lib/handle.ts
+++ b/apps/web/app/api/murmur/_lib/handle.ts
@@ -103,7 +103,7 @@ export async function handleSubcommand(
   } catch (err) {
     // Defensive: the invoker should not throw, but if it does we map
     // to internal_error rather than leaking a 500.
-    // eslint-disable-next-line no-console
+
     console.error(
       `[murmur ${spec.libSubcommand}] invoker threw: ${(err as Error).message}`,
     );

--- a/apps/web/app/api/murmur/_lib/handle.ts
+++ b/apps/web/app/api/murmur/_lib/handle.ts
@@ -1,0 +1,118 @@
+/**
+ * Common request-handling shape for every Murmur shim route.
+ *
+ * Each route is a thin wrapper around `handleSubcommand` that pins:
+ *   - the subcommand id (the lib dispatch key),
+ *   - the input schema (vendored from the YAML),
+ *   - the URL fields to validate via SSRF.
+ *
+ * The wrapper enforces the documented order:
+ *   1. Bearer auth (FIRST — before any other I/O).
+ *   2. Required Murmur headers.
+ *   3. Body parse + schema validation.
+ *   4. SSRF allowlist check (per-route URL fields).
+ *   5. Lib invocation via `invokeLib`.
+ *   6. Envelope return.
+ *
+ * Steps 3–6 produce envelope-shaped failures (HTTP 200 with
+ * `{ ok: false, errors: [...] }`) per M0; only steps 1–2 produce
+ * transport-level non-2xx (401, 400).
+ *
+ * @see colophon-group/jobseek#2759
+ */
+
+import { NextResponse } from "next/server";
+import { validateUrl } from "@/lib/murmur/ssrf";
+import { requireBearer } from "./auth";
+import { requireMurmurHeaders } from "./headers-helper";
+import { errJson, okJson } from "./envelope";
+import { invokeLib, type LibSubcommand } from "./invoke-lib";
+import { validateBody } from "./validate";
+import type { SubcommandSchema } from "./schemas";
+
+/**
+ * Per-route configuration.
+ */
+export interface RouteSpec {
+  /** Lib dispatch key (matches Python shim). */
+  readonly libSubcommand: LibSubcommand;
+  /** Vendored input schema. */
+  readonly schema: SubcommandSchema;
+  /**
+   * Body fields that hold URLs the agent supplied. Each is run through
+   * `validateUrl` (J4). Missing fields are skipped — required-ness is
+   * already covered by the schema check before this step runs.
+   */
+  readonly urlFields: readonly string[];
+}
+
+/**
+ * Single shared entry point for every route. Returns the HTTP response
+ * the route must propagate verbatim.
+ */
+export async function handleSubcommand(
+  request: Request,
+  spec: RouteSpec,
+): Promise<NextResponse> {
+  // 1. Bearer auth — first line of work, no body read yet.
+  const authFail = requireBearer(request);
+  if (authFail) return authFail;
+
+  // 2. Required Murmur headers.
+  const headers = requireMurmurHeaders(request);
+  if (!headers.ok) {
+    return errJson(
+      headers.missing.map((h) => `missing_header:${h}`),
+      { status: 400 },
+    );
+  }
+
+  // 3. Body parse + schema validation.
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return errJson(["invalid_json"], { status: 400 });
+  }
+  const schemaErrors = validateBody(body, spec.schema);
+  if (schemaErrors.length > 0) {
+    return NextResponse.json(
+      {
+        ok: false,
+        errors: schemaErrors.map((e) => `schema:${e.path}:${e.message}`),
+      },
+      { status: 400 },
+    );
+  }
+
+  // 4. SSRF allowlist on declared URL fields.
+  for (const field of spec.urlFields) {
+    const raw = (body as Record<string, unknown>)[field];
+    if (typeof raw !== "string") continue;
+    const v = await validateUrl(raw);
+    if (!v.ok) {
+      return errJson([v.error]);
+    }
+  }
+
+  // 5. Lib invocation. Never throws on a typed lib failure — those are
+  //    expressed in the envelope shape.
+  let result;
+  try {
+    result = await invokeLib(spec.libSubcommand, body, headers.claim_token);
+  } catch (err) {
+    // Defensive: the invoker should not throw, but if it does we map
+    // to internal_error rather than leaking a 500.
+    // eslint-disable-next-line no-console
+    console.error(
+      `[murmur ${spec.libSubcommand}] invoker threw: ${(err as Error).message}`,
+    );
+    return errJson(["internal_error"]);
+  }
+
+  // 6. Envelope return — preserve whatever shape the lib returned.
+  if (result.ok) {
+    return okJson(result.data ?? null);
+  }
+  return errJson(result.errors ?? ["internal_error"]);
+}

--- a/apps/web/app/api/murmur/_lib/headers-helper.ts
+++ b/apps/web/app/api/murmur/_lib/headers-helper.ts
@@ -1,0 +1,37 @@
+/**
+ * Defensive reader for the two Murmur proxy headers
+ * (`X-Murmur-Claim-Token` + `X-Murmur-Subcommand`). Returns a structured
+ * result so the caller can build a 400 response listing every missing
+ * header in one shot.
+ *
+ * @see colophon-group/jobseek#2759
+ */
+
+import { HEADER_CLAIM_TOKEN, HEADER_SUBCOMMAND } from "./headers";
+
+export type RequiredHeadersResult =
+  | { ok: true; claim_token: string; subcommand: string }
+  | { ok: false; missing: readonly string[] };
+
+/**
+ * Read the two M0 proxy headers. The header names are taken from the
+ * `headers.ts` constants; this helper is the only place that decides
+ * "missing or empty == fail".
+ *
+ * Empty-string values are treated as missing — a `claim_token: ""` is
+ * never legitimate, and the per-claim KV's primary key would silently
+ * accept it.
+ */
+export function requireMurmurHeaders(request: Request): RequiredHeadersResult {
+  const claim_token = (request.headers.get(HEADER_CLAIM_TOKEN) ?? "").trim();
+  const subcommand = (request.headers.get(HEADER_SUBCOMMAND) ?? "").trim();
+
+  const missing: string[] = [];
+  if (!claim_token) missing.push(HEADER_CLAIM_TOKEN);
+  if (!subcommand) missing.push(HEADER_SUBCOMMAND);
+
+  if (missing.length > 0) {
+    return { ok: false, missing };
+  }
+  return { ok: true, claim_token, subcommand };
+}

--- a/apps/web/app/api/murmur/_lib/headers.ts
+++ b/apps/web/app/api/murmur/_lib/headers.ts
@@ -1,0 +1,33 @@
+/**
+ * Canonical Murmur header names — single source of truth.
+ *
+ * Every Murmur subcommand HTTP shim route reads these headers; the casing
+ * is locked by Murmur's M0 contract. Pulling them from one constant keeps
+ * grep-auditability tight and prevents accidental drift between routes.
+ *
+ * Spec: Murmur DESIGN.md §4.2 (Boundary contracts), §3.6 (proxy headers).
+ *
+ * @see colophon-group/jobseek#2759
+ */
+
+/**
+ * RFC 7235 / 9110 — bearer-token header on agent → publisher hops.
+ *
+ * Murmur sends the shared `MURMUR_TOKEN` here when proxying a subcommand
+ * call from the agent to the publisher. Routes verify the token with
+ * `crypto.timingSafeEqual` before doing anything else.
+ */
+export const HEADER_AUTHORIZATION = "authorization" as const;
+
+/**
+ * Identifies the agent's per-subtask claim. Used as the partition key
+ * for the per-claim KV (named-config state). M0-locked casing.
+ */
+export const HEADER_CLAIM_TOKEN = "x-murmur-claim-token" as const;
+
+/**
+ * Identifies which subcommand Murmur is dispatching. The route also knows
+ * which subcommand it is from its path; we still read the header
+ * defensively so a misrouted call (proxy bug, copy-paste) is rejected.
+ */
+export const HEADER_SUBCOMMAND = "x-murmur-subcommand" as const;

--- a/apps/web/app/api/murmur/_lib/invoke-lib.ts
+++ b/apps/web/app/api/murmur/_lib/invoke-lib.ts
@@ -1,0 +1,209 @@
+/**
+ * Cross-language boundary: TS route → Python lib via subprocess.
+ *
+ * Pattern (a) per the J5 IPC decision (see `../README.md`). Each call
+ * spawns a fresh Python interpreter that runs
+ * `apps.crawler.src.workspace.lib.cli_shim`. The shim reads JSON on
+ * stdin and writes a JSON envelope on stdout; the TS side parses that
+ * envelope and forwards it.
+ *
+ * Why subprocess and not in-process: the lib pulls Playwright +
+ * httpx + the entire crawler tree, which is Python-only. Spawning is
+ * 200–500ms per call; for probe/run that's noise next to multi-second
+ * Playwright work, and for select/feedback it's still well inside the
+ * M0 15 s subcommand budget.
+ *
+ * The shim's stdout schema is exactly the M0 envelope shape:
+ *
+ *     {"ok": true,  "data": {...}}
+ *     {"ok": false, "errors": ["..."]}
+ *
+ * Anything else (non-zero exit, parse failure, timeout) is mapped to
+ * `{ ok: false, errors: ["internal_error"] }`. The unparsed stderr is
+ * logged server-side; never returned to the agent.
+ *
+ * @see colophon-group/jobseek#2759
+ */
+
+import { spawn } from "node:child_process";
+import path from "node:path";
+
+/**
+ * Subcommand identifiers — must match the dispatch keys in
+ * `cli_shim.py`. The string is what the shim looks up to choose which
+ * Python function to call.
+ */
+export type LibSubcommand =
+  | "probe_monitor"
+  | "run_monitor"
+  | "probe_scraper"
+  | "run_scraper"
+  | "select_monitor"
+  | "select_scraper"
+  | "feedback";
+
+export interface InvokeLibResult {
+  readonly ok: boolean;
+  readonly data?: unknown;
+  readonly errors?: readonly string[];
+}
+
+/**
+ * Invocation injection seam. Tests pass a stub function so they don't
+ * fork a Python process. Production routes pass the real
+ * `defaultInvoker`. See `_lib/invoke-lib-default.ts` for the live impl.
+ */
+export type LibInvoker = (
+  subcommand: LibSubcommand,
+  body: unknown,
+  claim_token: string,
+) => Promise<InvokeLibResult>;
+
+/**
+ * Default invoker — spawns the Python shim with a 30 s wallclock cap.
+ *
+ * Environment:
+ *   - `MURMUR_PY` (optional)        — path to the Python interpreter.
+ *                                     Defaults to `python3`.
+ *   - `MURMUR_CRAWLER_ROOT` (opt)   — path to the crawler app root.
+ *                                     Defaults to `<repo>/apps/crawler`.
+ *   - `MURMUR_DB_DSN` (required)    — Postgres DSN forwarded to the
+ *                                     shim so it can build a
+ *                                     `PostgresClaimKV`.
+ *   - `MURMUR_INVOKE_TIMEOUT_MS` (opt) — wallclock cap; defaults to
+ *                                     30000.
+ */
+export const defaultInvoker: LibInvoker = async (
+  subcommand,
+  body,
+  claim_token,
+) => {
+  const interpreter = process.env.MURMUR_PY ?? "python3";
+  const crawlerRoot =
+    process.env.MURMUR_CRAWLER_ROOT ??
+    path.resolve(process.cwd(), "../crawler");
+  const dsn = process.env.MURMUR_DB_DSN ?? "";
+  const timeoutMs = Number(process.env.MURMUR_INVOKE_TIMEOUT_MS ?? 30000);
+
+  const payload = JSON.stringify({
+    subcommand,
+    body,
+    claim_token,
+    db_dsn: dsn,
+  });
+
+  return new Promise<InvokeLibResult>((resolve) => {
+    const child = spawn(interpreter, ["-m", "src.workspace.lib.cli_shim"], {
+      cwd: crawlerRoot,
+      env: { ...process.env, PYTHONPATH: crawlerRoot, MURMUR_DB_DSN: dsn },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const finish = (result: InvokeLibResult) => {
+      if (settled) return;
+      settled = true;
+      try {
+        child.kill("SIGKILL");
+      } catch {
+        // process may have already exited
+      }
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => {
+      // Log so operators can see why a request got `internal_error`.
+      // eslint-disable-next-line no-console
+      console.error(
+        `[murmur invoke-lib] ${subcommand} timed out after ${timeoutMs}ms`,
+      );
+      finish({ ok: false, errors: ["internal_error"] });
+    }, timeoutMs);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      // eslint-disable-next-line no-console
+      console.error(
+        `[murmur invoke-lib] ${subcommand} spawn failed: ${err.message}`,
+      );
+      finish({ ok: false, errors: ["internal_error"] });
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (settled) return;
+      if (code !== 0) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `[murmur invoke-lib] ${subcommand} exited with code ${code}; stderr: ${stderr}`,
+        );
+        finish({ ok: false, errors: ["internal_error"] });
+        return;
+      }
+      try {
+        const parsed: unknown = JSON.parse(stdout);
+        if (!isInvokeResult(parsed)) {
+          // eslint-disable-next-line no-console
+          console.error(
+            `[murmur invoke-lib] ${subcommand} returned non-envelope stdout: ${stdout.slice(0, 200)}`,
+          );
+          finish({ ok: false, errors: ["internal_error"] });
+          return;
+        }
+        finish(parsed);
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `[murmur invoke-lib] ${subcommand} stdout JSON parse error: ${(err as Error).message}; stdout=${stdout.slice(0, 200)}`,
+        );
+        finish({ ok: false, errors: ["internal_error"] });
+      }
+    });
+
+    child.stdin.write(payload);
+    child.stdin.end();
+  });
+};
+
+function isInvokeResult(v: unknown): v is InvokeLibResult {
+  if (typeof v !== "object" || v === null) return false;
+  const o = v as Record<string, unknown>;
+  if (typeof o.ok !== "boolean") return false;
+  if (
+    o.errors !== undefined &&
+    (!Array.isArray(o.errors) || o.errors.some((e) => typeof e !== "string"))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+// ── Test seam: route handlers read this overridable holder. ─────────
+
+/**
+ * Container for the active invoker. Tests overwrite `current` with a
+ * stub before exercising a route; production code never reassigns it
+ * away from `defaultInvoker`.
+ */
+export const InvokerHolder: { current: LibInvoker } = {
+  current: defaultInvoker,
+};
+
+/** Convenience pass-through used by route handlers. */
+export function invokeLib(
+  subcommand: LibSubcommand,
+  body: unknown,
+  claim_token: string,
+): Promise<InvokeLibResult> {
+  return InvokerHolder.current(subcommand, body, claim_token);
+}

--- a/apps/web/app/api/murmur/_lib/invoke-lib.ts
+++ b/apps/web/app/api/murmur/_lib/invoke-lib.ts
@@ -116,7 +116,7 @@ export const defaultInvoker: LibInvoker = async (
 
     const timer = setTimeout(() => {
       // Log so operators can see why a request got `internal_error`.
-      // eslint-disable-next-line no-console
+
       console.error(
         `[murmur invoke-lib] ${subcommand} timed out after ${timeoutMs}ms`,
       );
@@ -132,7 +132,7 @@ export const defaultInvoker: LibInvoker = async (
 
     child.on("error", (err) => {
       clearTimeout(timer);
-      // eslint-disable-next-line no-console
+
       console.error(
         `[murmur invoke-lib] ${subcommand} spawn failed: ${err.message}`,
       );
@@ -143,7 +143,7 @@ export const defaultInvoker: LibInvoker = async (
       clearTimeout(timer);
       if (settled) return;
       if (code !== 0) {
-        // eslint-disable-next-line no-console
+
         console.error(
           `[murmur invoke-lib] ${subcommand} exited with code ${code}; stderr: ${stderr}`,
         );
@@ -153,7 +153,7 @@ export const defaultInvoker: LibInvoker = async (
       try {
         const parsed: unknown = JSON.parse(stdout);
         if (!isInvokeResult(parsed)) {
-          // eslint-disable-next-line no-console
+
           console.error(
             `[murmur invoke-lib] ${subcommand} returned non-envelope stdout: ${stdout.slice(0, 200)}`,
           );
@@ -162,7 +162,7 @@ export const defaultInvoker: LibInvoker = async (
         }
         finish(parsed);
       } catch (err) {
-        // eslint-disable-next-line no-console
+
         console.error(
           `[murmur invoke-lib] ${subcommand} stdout JSON parse error: ${(err as Error).message}; stdout=${stdout.slice(0, 200)}`,
         );

--- a/apps/web/app/api/murmur/_lib/invoke-lib.ts
+++ b/apps/web/app/api/murmur/_lib/invoke-lib.ts
@@ -150,30 +150,81 @@ export const defaultInvoker: LibInvoker = async (
         finish({ ok: false, errors: ["internal_error"] });
         return;
       }
-      try {
-        const parsed: unknown = JSON.parse(stdout);
-        if (!isInvokeResult(parsed)) {
-
-          console.error(
-            `[murmur invoke-lib] ${subcommand} returned non-envelope stdout: ${stdout.slice(0, 200)}`,
-          );
-          finish({ ok: false, errors: ["internal_error"] });
-          return;
-        }
-        finish(parsed);
-      } catch (err) {
-
+      // The shim's stdout contract is a single JSON envelope, but in
+      // practice Python loggers (structlog, plain logging) sometimes
+      // leak human-readable lines onto stdout before the envelope.
+      // Be defensive: scan from the end and pick the first line that
+      // parses to a valid envelope. If no line qualifies, fall back to
+      // parsing the whole buffer (preserves the strict contract for
+      // shims that already do the right thing).
+      const parsed = extractEnvelope(stdout);
+      if (parsed === null) {
         console.error(
-          `[murmur invoke-lib] ${subcommand} stdout JSON parse error: ${(err as Error).message}; stdout=${stdout.slice(0, 200)}`,
+          `[murmur invoke-lib] ${subcommand} returned non-envelope stdout: ${stdout.slice(-400)}`,
         );
         finish({ ok: false, errors: ["internal_error"] });
+        return;
       }
+      finish(parsed);
     });
 
-    child.stdin.write(payload);
-    child.stdin.end();
+    // Guard against EPIPE / instant-crash races: if the child died
+    // before stdin is writable, `write` would throw synchronously.
+    child.stdin.on("error", (err) => {
+      console.error(
+        `[murmur invoke-lib] ${subcommand} stdin error: ${err.message}`,
+      );
+      finish({ ok: false, errors: ["internal_error"] });
+    });
+    try {
+      child.stdin.write(payload);
+      child.stdin.end();
+    } catch (err) {
+      console.error(
+        `[murmur invoke-lib] ${subcommand} stdin write threw: ${(err as Error).message}`,
+      );
+      finish({ ok: false, errors: ["internal_error"] });
+    }
   });
 };
+
+/**
+ * Pick the last well-formed envelope JSON object out of mixed stdout.
+ *
+ * Strategy:
+ *   1. Try parsing the whole buffer (fast happy path — the shim's
+ *      strict contract is one envelope, no extra noise).
+ *   2. If that fails or doesn't match the envelope shape, scan
+ *      newline-separated lines from the end and return the first one
+ *      that parses to a valid envelope.
+ *   3. Returns `null` when nothing matches.
+ *
+ * This tolerance is intentionally narrow: only the envelope shape
+ * `{ok: bool, ...}` qualifies. We never accept arbitrary JSON.
+ */
+function extractEnvelope(stdout: string): InvokeLibResult | null {
+  const trimmed = stdout.trim();
+  if (trimmed.length === 0) return null;
+  try {
+    const whole: unknown = JSON.parse(trimmed);
+    if (isInvokeResult(whole)) return whole;
+  } catch {
+    // fall through to per-line scan
+  }
+  const lines = trimmed.split(/\r?\n/);
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (line.length === 0) continue;
+    if (line[0] !== "{") continue;
+    try {
+      const parsed: unknown = JSON.parse(line);
+      if (isInvokeResult(parsed)) return parsed;
+    } catch {
+      // not JSON — keep scanning earlier lines
+    }
+  }
+  return null;
+}
 
 function isInvokeResult(v: unknown): v is InvokeLibResult {
   if (typeof v !== "object" || v === null) return false;

--- a/apps/web/app/api/murmur/_lib/schemas.ts
+++ b/apps/web/app/api/murmur/_lib/schemas.ts
@@ -1,0 +1,129 @@
+/**
+ * Vendored input_schemas for the seven Murmur subcommands jobseek serves.
+ *
+ * Source of truth: `apps/crawler/murmur/pipelines/add-company.yaml` —
+ * `subtasks[id=configure-board].subcommands[*].input_schema`. The schemas
+ * are duplicated here as TS constants so route handlers can validate
+ * synchronously without parsing YAML on every request.
+ *
+ * Whenever the YAML schemas change, mirror the change here. The
+ * `apps/web/__tests__/murmur-schemas-match-yaml.test.ts` (added under J5)
+ * does NOT exist — there is no automated drift gate. Reviewers should
+ * cross-check by hand on schema changes.
+ *
+ * The schema dialect is the demo-minimum subset declared in the YAML:
+ *
+ *   - `type: object`
+ *   - `additionalProperties: false`
+ *   - `required: [...]`
+ *   - per-property: `type`, `format: uri`, `pattern`, `enum`, `minLength`,
+ *     `minimum`
+ *
+ * Anything outside that subset must be rejected at validation time so we
+ * fail loudly rather than silently accept.
+ *
+ * @see colophon-group/jobseek#2759
+ */
+
+/**
+ * Minimal JSON-Schema-like shape we accept. Intentionally narrow.
+ * `format` is recognised only when set to `"uri"` — that's the only
+ * format the YAML uses today.
+ */
+export interface SubcommandSchema {
+  readonly type: "object";
+  readonly additionalProperties: false;
+  readonly required: readonly string[];
+  readonly properties: Readonly<Record<string, SubcommandPropertySchema>>;
+}
+
+export interface SubcommandPropertySchema {
+  readonly type: "string" | "integer" | "number" | "object" | "boolean";
+  readonly format?: "uri";
+  readonly pattern?: string;
+  readonly enum?: readonly string[];
+  readonly minLength?: number;
+  readonly minimum?: number;
+}
+
+// ── Subcommand schemas ─────────────────────────────────────────────
+
+/** `probe monitor` — POST /api/murmur/probes/monitor */
+export const PROBE_MONITOR_SCHEMA: SubcommandSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["board_url"],
+  properties: {
+    board_url: { type: "string", format: "uri", pattern: "^https://" },
+    hreflang: { type: "string" },
+    expected_count: { type: "integer", minimum: 0 },
+  },
+} as const;
+
+/** `select monitor` — POST /api/murmur/select/monitor */
+export const SELECT_MONITOR_SCHEMA: SubcommandSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["candidate_id", "board_url"],
+  properties: {
+    candidate_id: { type: "string", minLength: 1 },
+    board_url: { type: "string", format: "uri", pattern: "^https://" },
+  },
+} as const;
+
+/** `run monitor` — POST /api/murmur/run/monitor */
+export const RUN_MONITOR_SCHEMA: SubcommandSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["board_url"],
+  properties: {
+    board_url: { type: "string", format: "uri", pattern: "^https://" },
+  },
+} as const;
+
+/** `probe scraper` — POST /api/murmur/probes/scraper */
+export const PROBE_SCRAPER_SCHEMA: SubcommandSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["board_url", "monitor_type", "monitor_config"],
+  properties: {
+    board_url: { type: "string", format: "uri", pattern: "^https://" },
+    monitor_type: { type: "string", minLength: 1 },
+    monitor_config: { type: "object" },
+  },
+} as const;
+
+/** `select scraper` — POST /api/murmur/select/scraper */
+export const SELECT_SCRAPER_SCHEMA: SubcommandSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["candidate_id", "board_url"],
+  properties: {
+    candidate_id: { type: "string", minLength: 1 },
+    board_url: { type: "string", format: "uri", pattern: "^https://" },
+  },
+} as const;
+
+/** `run scraper` — POST /api/murmur/run/scraper */
+export const RUN_SCRAPER_SCHEMA: SubcommandSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["board_url"],
+  properties: {
+    board_url: { type: "string", format: "uri", pattern: "^https://" },
+    sample_job_url: { type: "string", format: "uri" },
+  },
+} as const;
+
+/** `feedback` — POST /api/murmur/feedback */
+export const FEEDBACK_SCHEMA: SubcommandSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["verdict"],
+  properties: {
+    verdict: { type: "string", enum: ["ok", "needs-work", "rejected"] },
+    kind: { type: "string" },
+    per_field: { type: "object" },
+    notes: { type: "string" },
+  },
+} as const;

--- a/apps/web/app/api/murmur/_lib/validate.ts
+++ b/apps/web/app/api/murmur/_lib/validate.ts
@@ -1,0 +1,147 @@
+/**
+ * Tiny JSON-Schema-subset validator for Murmur subcommand request bodies.
+ *
+ * Intentionally narrow: only the constructs used in the YAML schemas at
+ * `apps/crawler/murmur/pipelines/add-company.yaml` are recognised. Any
+ * unknown construct is treated as a hard validation error — we'd rather
+ * reject a body than silently let one through.
+ *
+ * The validator never throws on an unexpected body shape; instead it
+ * returns a list of `SchemaError` objects with JSON-Pointer paths
+ * (matching M0's `submit_result` validation-error shape per DESIGN.md
+ * §4.2 boundary contracts).
+ *
+ * @see colophon-group/jobseek#2759
+ */
+
+import type { SubcommandSchema, SubcommandPropertySchema } from "./schemas";
+
+/**
+ * One per-field error. `path` is a JSON Pointer (`/board_url`,
+ * `/per_field/title`); `message` is a stable string token, not prose.
+ */
+export interface SchemaError {
+  readonly path: string;
+  readonly message: string;
+}
+
+/** Validate an unknown body against an object subcommand schema. */
+export function validateBody(
+  body: unknown,
+  schema: SubcommandSchema,
+): SchemaError[] {
+  const errors: SchemaError[] = [];
+  if (!isPlainObject(body)) {
+    errors.push({ path: "", message: "must_be_object" });
+    return errors;
+  }
+
+  // Required-key check.
+  for (const key of schema.required) {
+    if (!(key in body)) {
+      errors.push({ path: `/${key}`, message: "missing" });
+    }
+  }
+
+  // additionalProperties: false — any unknown key is rejected.
+  for (const key of Object.keys(body)) {
+    if (!(key in schema.properties)) {
+      errors.push({ path: `/${key}`, message: "unknown_property" });
+    }
+  }
+
+  // Per-property validation for the keys we know about.
+  for (const [key, propSchema] of Object.entries(schema.properties)) {
+    if (!(key in body)) continue;
+    const value = (body as Record<string, unknown>)[key];
+    validateProperty(`/${key}`, value, propSchema, errors);
+  }
+
+  return errors;
+}
+
+function validateProperty(
+  path: string,
+  value: unknown,
+  schema: SubcommandPropertySchema,
+  errors: SchemaError[],
+): void {
+  switch (schema.type) {
+    case "string": {
+      if (typeof value !== "string") {
+        errors.push({ path, message: "must_be_string" });
+        return;
+      }
+      if (
+        typeof schema.minLength === "number" &&
+        value.length < schema.minLength
+      ) {
+        errors.push({ path, message: "too_short" });
+      }
+      if (schema.pattern && !new RegExp(schema.pattern).test(value)) {
+        errors.push({ path, message: "pattern_mismatch" });
+      }
+      if (schema.format === "uri") {
+        // URI: parse-able URL with a non-empty host. Scheme is enforced
+        // separately by `pattern: "^https://"` where the YAML wants it.
+        try {
+          const u = new URL(value);
+          if (!u.hostname) {
+            errors.push({ path, message: "must_be_uri" });
+          }
+        } catch {
+          errors.push({ path, message: "must_be_uri" });
+        }
+      }
+      if (schema.enum && !schema.enum.includes(value)) {
+        errors.push({ path, message: "not_in_enum" });
+      }
+      return;
+    }
+    case "integer": {
+      if (typeof value !== "number" || !Number.isInteger(value)) {
+        errors.push({ path, message: "must_be_integer" });
+        return;
+      }
+      if (typeof schema.minimum === "number" && value < schema.minimum) {
+        errors.push({ path, message: "below_minimum" });
+      }
+      return;
+    }
+    case "number": {
+      if (typeof value !== "number" || !Number.isFinite(value)) {
+        errors.push({ path, message: "must_be_number" });
+        return;
+      }
+      if (typeof schema.minimum === "number" && value < schema.minimum) {
+        errors.push({ path, message: "below_minimum" });
+      }
+      return;
+    }
+    case "boolean": {
+      if (typeof value !== "boolean") {
+        errors.push({ path, message: "must_be_boolean" });
+      }
+      return;
+    }
+    case "object": {
+      if (!isPlainObject(value)) {
+        errors.push({ path, message: "must_be_object" });
+      }
+      return;
+    }
+    default: {
+      // Unknown schema type — fail closed.
+      errors.push({ path, message: "unsupported_schema_type" });
+    }
+  }
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    !Array.isArray(v) &&
+    Object.getPrototypeOf(v) !== null
+  );
+}

--- a/apps/web/app/api/murmur/feedback/route.ts
+++ b/apps/web/app/api/murmur/feedback/route.ts
@@ -8,8 +8,8 @@
  * @see colophon-group/jobseek#2759
  */
 
-import { handleSubcommand } from "../../_lib/handle";
-import { FEEDBACK_SCHEMA } from "../../_lib/schemas";
+import { handleSubcommand } from "../_lib/handle";
+import { FEEDBACK_SCHEMA } from "../_lib/schemas";
 
 export async function POST(request: Request) {
   return handleSubcommand(request, {

--- a/apps/web/app/api/murmur/feedback/route.ts
+++ b/apps/web/app/api/murmur/feedback/route.ts
@@ -1,0 +1,20 @@
+/**
+ * POST /api/murmur/feedback — Murmur subcommand `feedback`.
+ *
+ * No URL fields. Lib function: `feedback` in
+ * `apps/crawler/src/workspace/lib/feedback.py`. Records the verdict on
+ * the claim's currently-active named config in the per-claim KV.
+ *
+ * @see colophon-group/jobseek#2759
+ */
+
+import { handleSubcommand } from "../../_lib/handle";
+import { FEEDBACK_SCHEMA } from "../../_lib/schemas";
+
+export async function POST(request: Request) {
+  return handleSubcommand(request, {
+    libSubcommand: "feedback",
+    schema: FEEDBACK_SCHEMA,
+    urlFields: [],
+  });
+}

--- a/apps/web/app/api/murmur/probes/monitor/route.ts
+++ b/apps/web/app/api/murmur/probes/monitor/route.ts
@@ -1,0 +1,19 @@
+/**
+ * POST /api/murmur/probes/monitor — Murmur subcommand `probe monitor`.
+ *
+ * Validates `board_url` via the SSRF allowlist (J4). Lib function:
+ * `probe_monitor` in `apps/crawler/src/workspace/lib/probe.py`.
+ *
+ * @see colophon-group/jobseek#2759
+ */
+
+import { handleSubcommand } from "../../_lib/handle";
+import { PROBE_MONITOR_SCHEMA } from "../../_lib/schemas";
+
+export async function POST(request: Request) {
+  return handleSubcommand(request, {
+    libSubcommand: "probe_monitor",
+    schema: PROBE_MONITOR_SCHEMA,
+    urlFields: ["board_url"],
+  });
+}

--- a/apps/web/app/api/murmur/probes/scraper/route.ts
+++ b/apps/web/app/api/murmur/probes/scraper/route.ts
@@ -1,0 +1,21 @@
+/**
+ * POST /api/murmur/probes/scraper — Murmur subcommand `probe scraper`.
+ *
+ * Validates `board_url` via the SSRF allowlist (J4). The agent does not
+ * supply `sample_url` here; the lib falls back to URLs already captured
+ * by a prior monitor run. Lib function: `probe_scraper` in
+ * `apps/crawler/src/workspace/lib/probe.py`.
+ *
+ * @see colophon-group/jobseek#2759
+ */
+
+import { handleSubcommand } from "../../_lib/handle";
+import { PROBE_SCRAPER_SCHEMA } from "../../_lib/schemas";
+
+export async function POST(request: Request) {
+  return handleSubcommand(request, {
+    libSubcommand: "probe_scraper",
+    schema: PROBE_SCRAPER_SCHEMA,
+    urlFields: ["board_url"],
+  });
+}

--- a/apps/web/app/api/murmur/run/monitor/route.ts
+++ b/apps/web/app/api/murmur/run/monitor/route.ts
@@ -1,0 +1,21 @@
+/**
+ * POST /api/murmur/run/monitor — Murmur subcommand `run monitor`.
+ *
+ * Validates `board_url` via the SSRF allowlist (J4). Lib function:
+ * `run_monitor` in `apps/crawler/src/workspace/lib/run.py`. The shim
+ * reads the active named config out of `PostgresClaimKV` and projects
+ * it into `BoardConfigState.monitor_type` / `monitor_config`.
+ *
+ * @see colophon-group/jobseek#2759
+ */
+
+import { handleSubcommand } from "../../_lib/handle";
+import { RUN_MONITOR_SCHEMA } from "../../_lib/schemas";
+
+export async function POST(request: Request) {
+  return handleSubcommand(request, {
+    libSubcommand: "run_monitor",
+    schema: RUN_MONITOR_SCHEMA,
+    urlFields: ["board_url"],
+  });
+}

--- a/apps/web/app/api/murmur/run/scraper/route.ts
+++ b/apps/web/app/api/murmur/run/scraper/route.ts
@@ -1,0 +1,21 @@
+/**
+ * POST /api/murmur/run/scraper — Murmur subcommand `run scraper`.
+ *
+ * Validates `board_url` and (optionally) `sample_job_url` via the SSRF
+ * allowlist (J4). Lib function: `run_scraper` in
+ * `apps/crawler/src/workspace/lib/run.py`. The shim resolves the active
+ * named scraper config from `PostgresClaimKV` before the call.
+ *
+ * @see colophon-group/jobseek#2759
+ */
+
+import { handleSubcommand } from "../../_lib/handle";
+import { RUN_SCRAPER_SCHEMA } from "../../_lib/schemas";
+
+export async function POST(request: Request) {
+  return handleSubcommand(request, {
+    libSubcommand: "run_scraper",
+    schema: RUN_SCRAPER_SCHEMA,
+    urlFields: ["board_url", "sample_job_url"],
+  });
+}

--- a/apps/web/app/api/murmur/select/monitor/route.ts
+++ b/apps/web/app/api/murmur/select/monitor/route.ts
@@ -6,6 +6,16 @@
  * `apps/crawler/src/workspace/lib/select.py`. The shim writes the
  * named-config slot to the per-claim KV (Postgres-backed).
  *
+ * Demo limitation: the shim currently stores the agent's
+ * `candidate_id` as both the `monitor_type` and `name` in the slot
+ * (see `cli_shim._do_select_monitor`). That's fine for the M0
+ * envelope contract — `select_monitor` succeeds and a subsequent
+ * `run_monitor` reads the slot back — but a real `run_monitor`
+ * against a live board would fail unless `candidate_id` happens to
+ * match a registered monitor type. A production implementation must
+ * resolve `candidate_id` against the prior probe's candidate list and
+ * persist the actual `(monitor_type, monitor_config)` pair.
+ *
  * @see colophon-group/jobseek#2759
  */
 

--- a/apps/web/app/api/murmur/select/monitor/route.ts
+++ b/apps/web/app/api/murmur/select/monitor/route.ts
@@ -1,0 +1,24 @@
+/**
+ * POST /api/murmur/select/monitor — Murmur subcommand `select monitor`.
+ *
+ * No URL fetched here; `board_url` is recorded for state but not
+ * dereferenced. Lib function: `select_monitor` in
+ * `apps/crawler/src/workspace/lib/select.py`. The shim writes the
+ * named-config slot to the per-claim KV (Postgres-backed).
+ *
+ * @see colophon-group/jobseek#2759
+ */
+
+import { handleSubcommand } from "../../_lib/handle";
+import { SELECT_MONITOR_SCHEMA } from "../../_lib/schemas";
+
+export async function POST(request: Request) {
+  return handleSubcommand(request, {
+    libSubcommand: "select_monitor",
+    schema: SELECT_MONITOR_SCHEMA,
+    // We still SSRF-validate the supplied board_url defensively even
+    // though no fetch happens here — keeps surface uniform across
+    // routes and prevents accidental log/replay of a bogus URL.
+    urlFields: ["board_url"],
+  });
+}

--- a/apps/web/app/api/murmur/select/scraper/route.ts
+++ b/apps/web/app/api/murmur/select/scraper/route.ts
@@ -5,6 +5,12 @@
  * `apps/crawler/src/workspace/lib/select.py`. Per-claim KV write only;
  * the URL is validated defensively but not dereferenced.
  *
+ * Demo limitation (mirrors `select/monitor`): the shim stores
+ * `candidate_id` as both the `scraper_type` and `name`. This satisfies
+ * the M0 envelope round-trip but a real `run_scraper` against a live
+ * board would need `candidate_id` to be resolved against the prior
+ * `probe_scraper` output. See `cli_shim._do_select_scraper`.
+ *
  * @see colophon-group/jobseek#2759
  */
 

--- a/apps/web/app/api/murmur/select/scraper/route.ts
+++ b/apps/web/app/api/murmur/select/scraper/route.ts
@@ -1,0 +1,20 @@
+/**
+ * POST /api/murmur/select/scraper — Murmur subcommand `select scraper`.
+ *
+ * Lib function: `select_scraper` in
+ * `apps/crawler/src/workspace/lib/select.py`. Per-claim KV write only;
+ * the URL is validated defensively but not dereferenced.
+ *
+ * @see colophon-group/jobseek#2759
+ */
+
+import { handleSubcommand } from "../../_lib/handle";
+import { SELECT_SCRAPER_SCHEMA } from "../../_lib/schemas";
+
+export async function POST(request: Request) {
+  return handleSubcommand(request, {
+    libSubcommand: "select_scraper",
+    schema: SELECT_SCRAPER_SCHEMA,
+    urlFields: ["board_url"],
+  });
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,7 @@
     "screenshots": "tsx script/capture-screenshots.ts",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e:murmur": "RUN_E2E_MURMUR=1 vitest run app/api/murmur/__tests__/e2e.test.ts",
     "grep:validateurl-boundary": "bash scripts/grep-validateurl-boundary.sh"
   },
   "dependencies": {

--- a/apps/web/scripts/grep-validateurl-boundary.sh
+++ b/apps/web/scripts/grep-validateurl-boundary.sh
@@ -4,9 +4,15 @@
 # Asserts the caller boundary for `validateUrl` (and `safeFetch`) from
 # `apps/web/src/lib/murmur/ssrf.ts`: those names must only be imported
 # from
-#   - apps/web/app/api/**/route.ts          (route handlers)
-#   - apps/web/src/lib/murmur/ssrf.ts       (defining module — re-exports)
-#   - apps/web/src/lib/murmur/ssrf.test.ts  (its own test)
+#   - apps/web/app/api/**/route.ts                       (route handlers)
+#   - apps/web/app/api/murmur/_lib/handle.ts             (J5 shared route
+#                                                         dispatcher — IS
+#                                                         the boundary,
+#                                                         called by all
+#                                                         seven Murmur
+#                                                         routes)
+#   - apps/web/src/lib/murmur/ssrf.ts                    (defining module)
+#   - apps/web/src/lib/murmur/ssrf.test.ts               (its own test)
 #
 # Anywhere else is a boundary violation: SSRF validation must happen at
 # the request boundary so the structured `url_*` error code can be
@@ -46,6 +52,7 @@ while IFS= read -r line; do
     apps/web/app/api/*/*/route.ts) ;;
     apps/web/app/api/*/*/*/route.ts) ;;
     apps/web/app/api/*/*/*/*/route.ts) ;;
+    apps/web/app/api/murmur/_lib/handle.ts) ;;
     apps/web/src/lib/murmur/ssrf.ts) ;;
     apps/web/src/lib/murmur/ssrf.test.ts) ;;
     *)


### PR DESCRIPTION
## Summary

Seven Next.js app-router routes under `apps/web/app/api/murmur/` that wrap the lifted lib functions (J1/J2) and serve as Murmur subcommand endpoints. Each route enforces bearer auth → required Murmur headers → schema validation → SSRF allowlist (J4) → lib invocation → typed envelope, in that fixed order. Cross-language boundary uses pattern (a) subprocess invocation per the issue's IPC choice.

## Related issue

Closes colophon-group/jobseek#2759

## IPC pattern chosen

**Pattern (a) — subprocess invocation.** Each route call spawns `python3 -m src.workspace.lib.cli_shim`, pipes a JSON payload on stdin, parses an M0 envelope on stdout. Reasoning + tradeoffs documented in `apps/web/app/api/murmur/README.md`. Headline: probe/run dominate latency-wise (Playwright), so 200–500 ms Python startup is in the noise; select/feedback are still well inside the M0 15 s subcommand budget. If rehearsal shows otherwise, swap the impl behind `_lib/invoke-lib.ts`'s `defaultInvoker` to a long-lived Unix-socket worker without changing route shape.

## Files changed (high-level)

### TypeScript (route boundary)
- `apps/web/app/api/murmur/_lib/headers.ts` — canonical Murmur header constants (`Authorization`, `X-Murmur-Claim-Token`, `X-Murmur-Subcommand`).
- `apps/web/app/api/murmur/_lib/auth.ts` — `requireBearer` (constant-time compare, fails closed when `MURMUR_TOKEN` unset).
- `apps/web/app/api/murmur/_lib/headers-helper.ts` — defensive `requireMurmurHeaders` (collects all missing in one pass).
- `apps/web/app/api/murmur/_lib/envelope.ts` — `okJson` / `errJson` shaping the M0 envelope.
- `apps/web/app/api/murmur/_lib/schemas.ts` — input_schema for each subcommand, vendored from the YAML in `apps/crawler/murmur/pipelines/add-company.yaml`.
- `apps/web/app/api/murmur/_lib/validate.ts` — JSON-Schema-subset validator (object/required/type/format=uri/pattern/enum/minLength/minimum/additionalProperties=false). Per-field JSON-Pointer error paths.
- `apps/web/app/api/murmur/_lib/invoke-lib.ts` — subprocess invoker with timeout + injection seam (`InvokerHolder.current`) for tests.
- `apps/web/app/api/murmur/_lib/handle.ts` — shared per-request orchestration; route handlers are 5-line wrappers.
- `apps/web/app/api/murmur/{probes/monitor,probes/scraper,run/monitor,run/scraper,select/monitor,select/scraper,feedback}/route.ts` — the seven routes.
- `apps/web/app/api/murmur/__tests__/{routes,auth,validate,headers-helper}.test.ts` + `_helpers.ts` — Vitest unit suites.
- `apps/web/app/api/murmur/README.md` — IPC choice + error mapping table + env-var reference.
- `apps/web/scripts/grep-validateurl-boundary.sh` — widened by one entry to permit `_lib/handle.ts` (the actual route boundary, even though it's not literally `route.ts`). Comment updated to match.

### Python (lib boundary)
- `apps/crawler/src/workspace/lib/cli_shim.py` — JSON stdin / stdout dispatcher; typed-exception → envelope-token mapping; full traceback to stderr only.
- `apps/crawler/src/workspace/lib/postgres_claim_kv.py` — `PostgresClaimKV` (asyncpg) implementing the lib's `ClaimKV` Protocol against the `murmur_claim_kv` table J3 added.
- `apps/crawler/tests/workspace/lib/test_cli_shim.py` — pytest suite covering dispatch, error mapping, verdict normalisation, no-KV path.

## Verification (from the issue)

- [x] each route — bearer header missing → 401 (test `routes.test.ts`)
- [x] each route — bearer header wrong → 401
- [x] each route — bearer ok + missing X-Murmur-Claim-Token → 400
- [x] each route — body schema-invalid → 400 with per-field path errors (`schema:/<path>:<token>`)
- [x] each URL-bearing route — URL rejected by SSRF → `{ ok: false, errors: ["url_not_allowed"] }`
- [x] each route — happy path with stub lib → `{ ok: true, data }` (invoker spy verifies subcommand id + claim_token + body forwarding)
- [x] each route — lib throws typed exception → mapped to `{ ok: false, errors: [...] }` (no 5xx leaked)
- [x] each route — bearer-auth as the FIRST middleware (lib-stub spy never called when auth fails)
- [x] no route returns a raw stack trace (verified by negative `match` against `/private/...` and `cli_shim.py`)
- [ ] e2e: `probes/monitor` against a fixture board — **NOT** added in this PR; the e2e harness needs a fixture board snapshot + Playwright browser install. Documented as a follow-up; the unit suite covers the route logic end-to-end with a stubbed invoker.

## Manual checks run locally

- `pnpm typecheck` ✓ (no new TS errors; the 3 pre-existing errors on `murmur-demo` — `app/mcp/route.ts` import + 2 in `company.test.ts` — are unaffected)
- `pnpm lint` ✓ zero warnings
- `pnpm test app/api/murmur` ✓ 95/95 tests passing
- `pnpm test` ✓ no regressions (the only failing file `app/mcp/route.test.ts` is pre-existing on `murmur-demo`)
- `pnpm grep:validateurl-boundary` ✓ clean (script widened with comment)
- `cd apps/crawler && uv run pytest tests/workspace/lib/` ✓ 52/52 passing including 14 new `test_cli_shim` cases
- `apps/crawler/scripts/grep-lib-purity.sh` ✓ no forbidden CLI imports leaked into the lib

## Notes for reviewer

- **`grep-validateurl-boundary.sh` change** is intentional: `_lib/handle.ts` is THE route boundary for all seven Murmur shim routes (every `route.ts` is a 5-line dispatch into it). Pushing the `validateUrl` call back into each route would only re-import the same shape seven times. The widened gate now allows exactly that one path; everything else still fails the gate.
- **Subprocess startup cost** is the load-bearing demo-day risk. If rehearsal shows >1 s wall-clock budget pressure, the swap point is `defaultInvoker` in `_lib/invoke-lib.ts`. Routes do not change.
- **`PostgresClaimKV`** uses one short-lived asyncpg connection per call (no pool). Fine for the demo (one Hetzner box, one MCP host); production-scale would want a pool. M0-acknowledged corner of §5 demo shortcuts.
- **`select/*` config persistence shortcut**: today the shim stores `candidate_id` as both the slot name AND the monitor/scraper type. A real implementation resolves `candidate_id` against the prior probe's candidate list and stores the proper `(monitor_type, monitor_config)`. Documented inline in `cli_shim.py`. The select_monitor / select_scraper lib functions and the per-claim KV are wired exactly as J3/J2 specified — only the agent-payload→lib-args projection is the demo shortcut.
- **`feedback` verdict mapping** (`ok`→`good`, `needs-work`→`acceptable`, `rejected`→`poor`) bridges the YAML's demo-vocab and the lib's tighter quality vocabulary. Documented in `cli_shim._do_feedback`.
- **`select_monitor` slot name == `candidate_id`**: keeps round-trip simple but means re-selecting the same `candidate_id` overwrites; matches the demo's `cfg-1` / `cfg-2` iteration pattern.
- **No 5xx is ever leaked** — every observable failure path returns either an envelope (with stable error tokens) or a 400/401 transport-level rejection. `internal_error` is the catch-all; the underlying message goes to stderr only.