### PR TITLE
feat(jobseek): pipeline registration script (POST /pipelines)

### DIFF
--- a/apps/crawler/murmur/README.md
+++ b/apps/crawler/murmur/README.md
@@ -1,6 +1,7 @@
-# `apps/crawler/murmur` — pipeline defs + validator
+# `apps/crawler/murmur` — pipeline defs, validator, registrar
 
-Authored as part of jobseek#2760 (P1, demo-minimum add-company pipeline).
+Authored as part of jobseek#2760 (P1, demo-minimum add-company pipeline) and
+jobseek#2761 (P2, registration script).
 
 ## Layout
 
@@ -8,12 +9,24 @@ Authored as part of jobseek#2760 (P1, demo-minimum add-company pipeline).
 pipelines/
   add-company.yaml             # the demo pipeline def (jobseek-add-company)
 scripts/
-  validate-pipeline.ts         # Ajv validator + route existence checker
-  pipeline-def.schema.json     # vendored copy of the M0 JSON Schema
+  validate-pipeline.ts         # Ajv validator + route existence checker (P1)
   validate-pipeline.test.ts    # vitest tests for the validator
+  pipeline-def.schema.json     # vendored copy of the M0 JSON Schema
+  register.ts                  # POST /pipelines registrar (P2)
+  register.test.ts             # vitest tests for the registrar
   fixtures/
     broken.yaml                # deliberately invalid fixture
 ```
+
+## Division of labour
+
+- **`validate-pipeline.ts`** does *local* schema + route existence checking
+  using the vendored M0 JSON Schema. Run it on every pre-commit /
+  pre-deploy.
+- **`register.ts`** does *no* validation locally; it only reads the YAML
+  raw and POSTs it to a running Murmur, which performs its own schema
+  validation. The two scripts deliberately split labour so a stale local
+  schema vendoring can never silently bypass the server's checks.
 
 ## Schema source
 
@@ -31,14 +44,46 @@ pnpm --filter @jobseek/murmur-pipelines validate-pipeline
 # Full check with routes (will fail until jobseek#2759 lands the /api/murmur/* routes)
 pnpm --filter @jobseek/murmur-pipelines validate-pipeline:full
 
+# Register the committed YAML against a running Murmur publisher.
+# Requires MURMUR_URL and MURMUR_TOKEN env vars (see contracts.md §2).
+# Idempotent: M4 upserts on `id` (last-write-wins).
+MURMUR_URL=https://murmur.colophon-group.org \
+  MURMUR_TOKEN=<bearer> \
+  pnpm --filter @jobseek/murmur-pipelines register-pipeline
+
 # Tests
 pnpm --filter @jobseek/murmur-pipelines test
 ```
+
+There are also root-level proxies: `pnpm validate-pipeline` and
+`pnpm register-pipeline`.
 
 The `--no-routes-check` flag in the default `validate-pipeline` script is a
 **temporary** escape hatch while jobseek#2759 (J5) has not yet shipped the
 `/api/murmur/*` Next.js routes. **Remove the flag once #2759 merges** and rely
 on the `validate-pipeline:full` shape.
+
+## `register.ts` — wire format
+
+The script POSTs the body shape M4 expects (see
+`docs/contracts.md` §1 and Murmur's `src/api/publisher/pipelines.ts`):
+
+```json
+{ "id": "jobseek-add-company", "def_yaml": "<raw YAML string>" }
+```
+
+`def_yaml` is the file's bytes verbatim — no JSON conversion locally;
+Murmur parses YAML server-side. The `id` is read from the YAML's
+top-level `id` field once, locally, just to satisfy the M4 body shape.
+
+Exit codes:
+
+- `0` — pipeline registered (HTTP 2xx + `{ ok: true }` envelope)
+- `1` — registration failed (non-2xx, transport error, or `{ ok: false }`)
+- `2` — usage / I/O / config error (missing argv, missing env, unreadable file)
+
+The script **never logs `MURMUR_TOKEN`**. Missing-env messages reference
+the variable *name* only.
 
 ## Provider enum
 

--- a/apps/crawler/murmur/package.json
+++ b/apps/crawler/murmur/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "validate-pipeline": "tsx scripts/validate-pipeline.ts pipelines/add-company.yaml --no-routes-check",
     "validate-pipeline:full": "tsx scripts/validate-pipeline.ts pipelines/add-company.yaml --app-dir ../../web/app",
+    "register-pipeline": "tsx scripts/register.ts pipelines/add-company.yaml",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/apps/crawler/murmur/scripts/register.test.ts
+++ b/apps/crawler/murmur/scripts/register.test.ts
@@ -1,0 +1,489 @@
+/**
+ * Tests for register.ts (jobseek#2761, P2).
+ *
+ * Verification matrix from the issue:
+ *
+ *   1. `pnpm register-pipeline` against a stub Murmur server (vitest mock)
+ *      succeeds with a valid YAML.
+ *   2. Same script against a stub returning 4xx exits with non-zero.
+ *   3. Same script with `MURMUR_URL` or `MURMUR_TOKEN` unset exits with a
+ *      clear error message.
+ *   4. Idempotent: running twice with the same YAML succeeds (Murmur's
+ *      last-write-wins).
+ *
+ * Quality gates from the issue:
+ *
+ *   5. Script does not log the token.
+ *   6. Script reads YAML once and posts the JSON-converted body
+ *      (server-side parsing happens; no double-conversion bugs) — i.e.
+ *      `def_yaml` on the wire is the raw file contents verbatim.
+ */
+import { describe, it, expect } from "vitest";
+import { fileURLToPath } from "node:url";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import {
+  buildPipelinesUrl,
+  checkEnv,
+  extractPipelineId,
+  formatFailure,
+  main,
+  parseArgs,
+  postPipeline,
+  readYamlRaw,
+  type FetchImpl,
+  type PostPipelineResult,
+  type RegisterEnv,
+  type WritableStreamLike,
+} from "./register.ts";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PKG_ROOT = path.resolve(HERE, "..");
+const YAML_PATH = path.join(PKG_ROOT, "pipelines", "add-company.yaml");
+
+const FAKE_TOKEN = "test-token-do-not-log-me-0123456789ABCDEFGHIJ";
+const FAKE_URL = "https://murmur.example.test";
+
+interface CapturedRequest {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string;
+}
+
+interface FakeFetchOptions {
+  /** Response status to return. Default 200. */
+  status?: number;
+  /** Response body shape. Default `{ ok: true, data: { id: "<id>" } }`. */
+  body?: unknown;
+  /** If set, the fake throws to simulate transport failure. */
+  throwError?: Error;
+}
+
+/**
+ * Build a fake fetch + capture array. Each call appends to the array
+ * and returns the configured response.
+ */
+function makeFakeFetch(
+  options: FakeFetchOptions = {},
+): { fetchImpl: FetchImpl; calls: CapturedRequest[] } {
+  const calls: CapturedRequest[] = [];
+  const fetchImpl = ((async (url: string | URL | Request, init?: RequestInit) => {
+    if (options.throwError) throw options.throwError;
+    const headers: Record<string, string> = {};
+    const initHeaders = init?.headers as Record<string, string> | undefined;
+    if (initHeaders) {
+      for (const [k, v] of Object.entries(initHeaders)) headers[k] = v;
+    }
+    calls.push({
+      url: typeof url === "string" ? url : url.toString(),
+      method: init?.method ?? "GET",
+      headers,
+      body: typeof init?.body === "string" ? init.body : "",
+    });
+    const status = options.status ?? 200;
+    const body =
+      options.body === undefined
+        ? { ok: true, data: { id: "jobseek-add-company" } }
+        : options.body;
+    const text =
+      typeof body === "string" ? body : JSON.stringify(body);
+    return new Response(text, {
+      status,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown) as FetchImpl;
+  return { fetchImpl, calls };
+}
+
+class StringStream implements WritableStreamLike {
+  buf = "";
+  write(chunk: string): boolean {
+    this.buf += chunk;
+    return true;
+  }
+}
+
+function freshStreams(): { stdout: StringStream; stderr: StringStream } {
+  return { stdout: new StringStream(), stderr: new StringStream() };
+}
+
+const VALID_ENV: RegisterEnv = {
+  MURMUR_URL: FAKE_URL,
+  MURMUR_TOKEN: FAKE_TOKEN,
+};
+
+describe("readYamlRaw", () => {
+  it("reads the committed pipeline YAML as text", () => {
+    const text = readYamlRaw(YAML_PATH);
+    expect(text).toBeTypeOf("string");
+    expect(text.length).toBeGreaterThan(0);
+    expect(text).toContain("id: jobseek-add-company");
+  });
+
+  it("throws on a missing file", () => {
+    expect(() => readYamlRaw(path.join(HERE, "does-not-exist.yaml"))).toThrow();
+  });
+});
+
+describe("extractPipelineId", () => {
+  it("returns the top-level id from the committed YAML", () => {
+    const text = readYamlRaw(YAML_PATH);
+    expect(extractPipelineId(text)).toBe("jobseek-add-company");
+  });
+
+  it("throws when the YAML has no id", () => {
+    expect(() => extractPipelineId("subtasks: []\n")).toThrow(/id/i);
+  });
+
+  it("throws when YAML parses to a non-object (array)", () => {
+    expect(() => extractPipelineId("- one\n- two\n")).toThrow();
+  });
+
+  it("throws on completely malformed YAML", () => {
+    expect(() => extractPipelineId(":\n  : :\n  -")).toThrow();
+  });
+});
+
+describe("buildPipelinesUrl", () => {
+  it("appends /pipelines to a clean base", () => {
+    expect(buildPipelinesUrl("https://m.example")).toBe(
+      "https://m.example/pipelines",
+    );
+  });
+
+  it("trims trailing slashes", () => {
+    expect(buildPipelinesUrl("https://m.example///")).toBe(
+      "https://m.example/pipelines",
+    );
+  });
+});
+
+describe("checkEnv", () => {
+  it("returns no missing names when both vars are set", () => {
+    expect(checkEnv(VALID_ENV)).toEqual([]);
+  });
+
+  it("flags MURMUR_URL when missing", () => {
+    expect(checkEnv({ MURMUR_TOKEN: FAKE_TOKEN })).toEqual(["MURMUR_URL"]);
+  });
+
+  it("flags MURMUR_TOKEN when missing", () => {
+    expect(checkEnv({ MURMUR_URL: FAKE_URL })).toEqual(["MURMUR_TOKEN"]);
+  });
+
+  it("flags both when both are missing", () => {
+    expect(checkEnv({})).toEqual(["MURMUR_URL", "MURMUR_TOKEN"]);
+  });
+
+  it("treats empty string as missing", () => {
+    expect(checkEnv({ MURMUR_URL: "", MURMUR_TOKEN: "" })).toEqual([
+      "MURMUR_URL",
+      "MURMUR_TOKEN",
+    ]);
+  });
+});
+
+describe("postPipeline", () => {
+  it("POSTs JSON with bearer auth and returns the parsed envelope", async () => {
+    const { fetchImpl, calls } = makeFakeFetch({ status: 200 });
+    const result = await postPipeline(
+      `${FAKE_URL}/pipelines`,
+      FAKE_TOKEN,
+      { id: "jobseek-add-company", def_yaml: "id: jobseek-add-company\n" },
+      fetchImpl,
+    );
+    expect(result.status).toBe(200);
+    expect("ok" in result.body && result.body.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    const call = calls[0]!;
+    expect(call.method).toBe("POST");
+    expect(call.url).toBe(`${FAKE_URL}/pipelines`);
+    expect(call.headers["Authorization"]).toBe(`Bearer ${FAKE_TOKEN}`);
+    expect(call.headers["Content-Type"]).toBe("application/json");
+    const sent = JSON.parse(call.body) as { id: string; def_yaml: string };
+    expect(sent.id).toBe("jobseek-add-company");
+    expect(sent.def_yaml).toBe("id: jobseek-add-company\n");
+  });
+
+  it("returns parsed err envelope on 4xx without throwing", async () => {
+    const { fetchImpl } = makeFakeFetch({
+      status: 400,
+      body: { ok: false, errors: ["validation:/id:bad"] },
+    });
+    const result = await postPipeline(
+      `${FAKE_URL}/pipelines`,
+      FAKE_TOKEN,
+      { id: "x", def_yaml: "id: x\n" },
+      fetchImpl,
+    );
+    expect(result.status).toBe(400);
+    expect("ok" in result.body && result.body.ok === false).toBe(true);
+  });
+
+  it("propagates transport errors", async () => {
+    const { fetchImpl } = makeFakeFetch({ throwError: new Error("ECONNREFUSED") });
+    await expect(
+      postPipeline(
+        `${FAKE_URL}/pipelines`,
+        FAKE_TOKEN,
+        { id: "x", def_yaml: "id: x\n" },
+        fetchImpl,
+      ),
+    ).rejects.toThrow(/ECONNREFUSED/);
+  });
+
+  it("falls back to {raw: ...} when the body isn't JSON", async () => {
+    const { fetchImpl } = makeFakeFetch({ status: 502, body: "<html>nope</html>" });
+    const result = await postPipeline(
+      `${FAKE_URL}/pipelines`,
+      FAKE_TOKEN,
+      { id: "x", def_yaml: "id: x\n" },
+      fetchImpl,
+    );
+    expect(result.status).toBe(502);
+    expect("raw" in result.body).toBe(true);
+  });
+});
+
+describe("formatFailure", () => {
+  it("includes status and errors for an err envelope", () => {
+    const r: PostPipelineResult = {
+      status: 400,
+      body: { ok: false, errors: ["validation:/id"] },
+    };
+    expect(formatFailure(r)).toContain("HTTP 400");
+    expect(formatFailure(r)).toContain("validation:/id");
+  });
+
+  it("handles non-JSON bodies", () => {
+    const r: PostPipelineResult = { status: 502, body: { raw: "<html>" } };
+    expect(formatFailure(r)).toContain("HTTP 502");
+    expect(formatFailure(r)).toContain("non-JSON");
+  });
+});
+
+describe("parseArgs", () => {
+  it("returns the single positional yaml path", () => {
+    expect(parseArgs(["pipelines/x.yaml"]).yamlPath).toBe("pipelines/x.yaml");
+  });
+
+  it("returns yamlPath: null on empty argv", () => {
+    expect(parseArgs([]).yamlPath).toBeNull();
+  });
+
+  it("rejects unknown flags", () => {
+    expect(() => parseArgs(["--what"])).toThrow();
+  });
+
+  it("rejects multiple positional args", () => {
+    expect(() => parseArgs(["a.yaml", "b.yaml"])).toThrow();
+  });
+});
+
+describe("main — verification cases", () => {
+  it("(1) succeeds with a valid YAML against a 200 stub", async () => {
+    const { fetchImpl, calls } = makeFakeFetch({ status: 200 });
+    const { stdout, stderr } = freshStreams();
+    const code = await main(
+      [YAML_PATH],
+      VALID_ENV,
+      fetchImpl,
+      stdout,
+      stderr,
+    );
+    expect(code).toBe(0);
+    expect(stderr.buf).toBe("");
+    expect(stdout.buf).toContain("registered pipeline");
+    expect(stdout.buf).toContain("jobseek-add-company");
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(`${FAKE_URL}/pipelines`);
+  });
+
+  it("(2) exits non-zero against a 4xx stub", async () => {
+    const { fetchImpl } = makeFakeFetch({
+      status: 400,
+      body: { ok: false, errors: ["validation:/id:bad"] },
+    });
+    const { stdout, stderr } = freshStreams();
+    const code = await main(
+      [YAML_PATH],
+      VALID_ENV,
+      fetchImpl,
+      stdout,
+      stderr,
+    );
+    expect(code).not.toBe(0);
+    expect(stderr.buf).toContain("HTTP 400");
+    expect(stderr.buf).toContain("validation:/id:bad");
+  });
+
+  it("(3a) MURMUR_URL unset — clear error message naming the var", async () => {
+    const { fetchImpl, calls } = makeFakeFetch();
+    const { stdout, stderr } = freshStreams();
+    const code = await main(
+      [YAML_PATH],
+      { MURMUR_TOKEN: FAKE_TOKEN },
+      fetchImpl,
+      stdout,
+      stderr,
+    );
+    expect(code).not.toBe(0);
+    expect(stderr.buf).toContain("MURMUR_URL");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("(3b) MURMUR_TOKEN unset — clear error message naming the var", async () => {
+    const { fetchImpl, calls } = makeFakeFetch();
+    const { stdout, stderr } = freshStreams();
+    const code = await main(
+      [YAML_PATH],
+      { MURMUR_URL: FAKE_URL },
+      fetchImpl,
+      stdout,
+      stderr,
+    );
+    expect(code).not.toBe(0);
+    expect(stderr.buf).toContain("MURMUR_TOKEN");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("(3c) MURMUR_TOKEN missing-error never echoes a token-shaped value", async () => {
+    // Even though no token was provided, double-check the error message
+    // does not echo any value next to the variable name.
+    const sneakyEnv: RegisterEnv = { MURMUR_URL: FAKE_URL };
+    const { fetchImpl } = makeFakeFetch();
+    const { stdout, stderr } = freshStreams();
+    await main([YAML_PATH], sneakyEnv, fetchImpl, stdout, stderr);
+    // Generic guard — no equals sign after MURMUR_TOKEN that would
+    // indicate accidental "MURMUR_TOKEN=<value>" leakage.
+    expect(stderr.buf).not.toMatch(/MURMUR_TOKEN\s*=/);
+  });
+
+  it("(4) idempotent: two consecutive 200 responses both succeed", async () => {
+    const { fetchImpl, calls } = makeFakeFetch({ status: 200 });
+    const first = freshStreams();
+    const second = freshStreams();
+
+    const code1 = await main(
+      [YAML_PATH],
+      VALID_ENV,
+      fetchImpl,
+      first.stdout,
+      first.stderr,
+    );
+    const code2 = await main(
+      [YAML_PATH],
+      VALID_ENV,
+      fetchImpl,
+      second.stdout,
+      second.stderr,
+    );
+
+    expect(code1).toBe(0);
+    expect(code2).toBe(0);
+    expect(calls).toHaveLength(2);
+    // Both calls send identical bodies — bit-identical, no
+    // re-serialisation churn.
+    expect(calls[0]!.body).toBe(calls[1]!.body);
+  });
+});
+
+describe("main — quality gates", () => {
+  it("(5) never logs the token to stdout/stderr (200 path)", async () => {
+    const { fetchImpl } = makeFakeFetch({ status: 200 });
+    const { stdout, stderr } = freshStreams();
+    await main([YAML_PATH], VALID_ENV, fetchImpl, stdout, stderr);
+    expect(stdout.buf).not.toContain(FAKE_TOKEN);
+    expect(stderr.buf).not.toContain(FAKE_TOKEN);
+  });
+
+  it("(5) never logs the token to stdout/stderr (4xx path)", async () => {
+    const { fetchImpl } = makeFakeFetch({
+      status: 401,
+      body: { ok: false, errors: ["unauthorised"] },
+    });
+    const { stdout, stderr } = freshStreams();
+    await main([YAML_PATH], VALID_ENV, fetchImpl, stdout, stderr);
+    expect(stdout.buf).not.toContain(FAKE_TOKEN);
+    expect(stderr.buf).not.toContain(FAKE_TOKEN);
+  });
+
+  it("(5) never logs the token on transport-error path", async () => {
+    const { fetchImpl } = makeFakeFetch({
+      throwError: new Error("ECONNREFUSED"),
+    });
+    const { stdout, stderr } = freshStreams();
+    const code = await main([YAML_PATH], VALID_ENV, fetchImpl, stdout, stderr);
+    expect(code).toBe(1);
+    expect(stdout.buf).not.toContain(FAKE_TOKEN);
+    expect(stderr.buf).not.toContain(FAKE_TOKEN);
+  });
+
+  it("(6) reads YAML once and sends the raw text — no double-conversion", async () => {
+    const { fetchImpl, calls } = makeFakeFetch({ status: 200 });
+    const { stdout, stderr } = freshStreams();
+    await main([YAML_PATH], VALID_ENV, fetchImpl, stdout, stderr);
+    expect(calls).toHaveLength(1);
+    const sent = JSON.parse(calls[0]!.body) as {
+      id: string;
+      def_yaml: string;
+    };
+    const onDisk = readFileSync(YAML_PATH, "utf-8");
+    // Bit-identical: the YAML on the wire equals the YAML on disk.
+    expect(sent.def_yaml).toBe(onDisk);
+    // The committed YAML uses kebab-case id; the request must echo it.
+    expect(sent.id).toBe("jobseek-add-company");
+    // And only the two expected keys are on the body — no leakage.
+    const sentKeys = Object.keys(JSON.parse(calls[0]!.body)).sort();
+    expect(sentKeys).toEqual(["def_yaml", "id"]);
+  });
+
+  it("(6) sends the bearer token in Authorization header (and only there)", async () => {
+    const { fetchImpl, calls } = makeFakeFetch({ status: 200 });
+    const { stdout, stderr } = freshStreams();
+    await main([YAML_PATH], VALID_ENV, fetchImpl, stdout, stderr);
+    const call = calls[0]!;
+    expect(call.headers["Authorization"]).toBe(`Bearer ${FAKE_TOKEN}`);
+    // Token must NOT appear in the body.
+    expect(call.body).not.toContain(FAKE_TOKEN);
+    // Token must NOT appear in the URL.
+    expect(call.url).not.toContain(FAKE_TOKEN);
+  });
+});
+
+describe("main — usage / argv errors", () => {
+  it("returns 2 and writes usage line when no argv given", async () => {
+    const { fetchImpl } = makeFakeFetch();
+    const { stdout, stderr } = freshStreams();
+    const code = await main([], VALID_ENV, fetchImpl, stdout, stderr);
+    expect(code).toBe(2);
+    expect(stderr.buf).toContain("usage");
+  });
+
+  it("returns 2 when the YAML file does not exist", async () => {
+    const { fetchImpl, calls } = makeFakeFetch();
+    const { stdout, stderr } = freshStreams();
+    const code = await main(
+      [path.join(HERE, "does-not-exist.yaml")],
+      VALID_ENV,
+      fetchImpl,
+      stdout,
+      stderr,
+    );
+    expect(code).toBe(2);
+    expect(stderr.buf).toContain("does-not-exist");
+    expect(calls).toHaveLength(0);
+  });
+
+  it("returns 1 on transport failure", async () => {
+    const { fetchImpl } = makeFakeFetch({
+      throwError: new Error("ECONNREFUSED"),
+    });
+    const { stdout, stderr } = freshStreams();
+    const code = await main([YAML_PATH], VALID_ENV, fetchImpl, stdout, stderr);
+    expect(code).toBe(1);
+    expect(stderr.buf).toContain("transport error");
+  });
+});

--- a/apps/crawler/murmur/scripts/register.ts
+++ b/apps/crawler/murmur/scripts/register.ts
@@ -1,0 +1,194 @@
+/**
+ * register-pipeline
+ *
+ * Registers a Murmur pipeline-def YAML against a running Murmur publisher
+ * via authenticated `POST /pipelines`. Run once before demo rehearsal (and
+ * any time the pipeline def changes).
+ *
+ * Body shape sent to Murmur (per docs/contracts.md §1 and M4's
+ * `src/api/publisher/pipelines.ts`):
+ *
+ *   { "id": "<pipeline-id>", "def_yaml": "<raw YAML string>" }
+ *
+ * Murmur parses the YAML server-side and validates against its own
+ * pipeline-def schema. This script does NOT validate the YAML — that
+ * is `validate-pipeline`'s job (jobseek#2760, P1). The two scripts
+ * deliberately split labour: validate locally, then register.
+ *
+ * Idempotence: M4 upserts on `id` (`INSERT ... ON CONFLICT(id) DO
+ * UPDATE`). Running this script twice with the same YAML returns 200
+ * both times.
+ *
+ * Usage:
+ *   tsx register.ts <yaml-path>
+ *
+ * Required env:
+ *   MURMUR_URL    Base URL, e.g. https://murmur.colophon-group.org
+ *   MURMUR_TOKEN  Bearer token (per docs/contracts.md §2)
+ *
+ * Exit codes:
+ *   0  — pipeline registered (HTTP 2xx with `{ ok: true }` envelope)
+ *   1  — registration failed (non-2xx, network error, or `{ ok: false }`)
+ *   2  — usage / I/O / config error (missing argv, missing env, unreadable file)
+ *
+ * NEVER LOGS THE TOKEN. The token value is only ever placed in the
+ * outgoing `Authorization` header. Missing-env messages reference
+ * variable names, not values.
+ *
+ * @module register-pipeline
+ */
+
+/**
+ * The minimum set of env vars this script needs. Both must be present
+ * and non-empty.
+ */
+export interface RegisterEnv {
+  readonly MURMUR_URL?: string | undefined;
+  readonly MURMUR_TOKEN?: string | undefined;
+}
+
+/**
+ * Injectable `fetch` for unit tests. Defaults to global `fetch` at
+ * CLI invocation time.
+ */
+export type FetchImpl = typeof fetch;
+
+/**
+ * Outgoing body shape for `POST /pipelines`. Matches M4 exactly
+ * (`src/api/publisher/pipelines.ts` PostPipelinesBody).
+ */
+export interface RegisterRequestBody {
+  readonly id: string;
+  readonly def_yaml: string;
+}
+
+/**
+ * Murmur's success envelope for `POST /pipelines`.
+ */
+export interface MurmurOkResponse {
+  readonly ok: true;
+  readonly data?: { readonly id: string };
+}
+
+/**
+ * Murmur's failure envelope.
+ */
+export interface MurmurErrResponse {
+  readonly ok: false;
+  readonly errors: ReadonlyArray<string | Record<string, unknown>>;
+}
+
+/**
+ * Result of a single `POST /pipelines` round-trip from `postPipeline`.
+ * `status` is the HTTP status; `body` is the parsed envelope, or a
+ * stringified body on JSON-parse failure.
+ */
+export interface PostPipelineResult {
+  readonly status: number;
+  readonly body: MurmurOkResponse | MurmurErrResponse | { readonly raw: string };
+}
+
+/**
+ * Streams used by `main`. Real CLI uses `process.stdout` /
+ * `process.stderr`; tests use an in-memory accumulator.
+ */
+export interface WritableStreamLike {
+  write(chunk: string): boolean | unknown;
+}
+
+/**
+ * Read a YAML file as raw text and return it verbatim. The string is
+ * what we POST to Murmur — no JSON conversion locally (avoids
+ * double-conversion bugs; server does its own YAML parse).
+ *
+ * @param filePath - Absolute path to a YAML file.
+ * @returns The file contents as UTF-8 text.
+ * @throws on I/O failure (file not found, unreadable).
+ */
+export function readYamlRaw(_filePath: string): string {
+  throw new Error("not implemented");
+}
+
+/**
+ * Extract the top-level `id` field from a pipeline-def YAML string.
+ * The Murmur `POST /pipelines` body requires `id` alongside the raw
+ * YAML; we parse just enough locally to produce that field. The full
+ * pipeline shape is validated server-side.
+ *
+ * @param yamlText - Raw YAML contents.
+ * @returns The `id` value.
+ * @throws if the YAML doesn't parse, isn't an object, or has no
+ *   non-empty string `id`.
+ */
+export function extractPipelineId(_yamlText: string): string {
+  throw new Error("not implemented");
+}
+
+/**
+ * Build the absolute URL for `POST /pipelines` given a base URL.
+ * Tolerates trailing slashes on the base.
+ */
+export function buildPipelinesUrl(_baseUrl: string): string {
+  throw new Error("not implemented");
+}
+
+/**
+ * Validate that the env carries both required vars. Returns a list of
+ * missing variable NAMES (not values). Empty list = OK.
+ */
+export function checkEnv(_env: RegisterEnv): string[] {
+  throw new Error("not implemented");
+}
+
+/**
+ * POST a pipeline def to Murmur. Returns the parsed envelope; does NOT
+ * throw on non-2xx — caller decides how to react.
+ *
+ * @throws only on transport-level failure (the `fetch` call itself
+ *   rejected, e.g. DNS or refused connection).
+ */
+export async function postPipeline(
+  _url: string,
+  _token: string,
+  _body: RegisterRequestBody,
+  _fetchImpl: FetchImpl,
+): Promise<PostPipelineResult> {
+  throw new Error("not implemented");
+}
+
+/**
+ * Format a non-success response into a one-line stderr message. Never
+ * includes the bearer token (the token is not on the response anyway,
+ * but this is documented to anchor the test.)
+ */
+export function formatFailure(_result: PostPipelineResult): string {
+  throw new Error("not implemented");
+}
+
+interface ParsedArgs {
+  readonly yamlPath: string | null;
+}
+
+/**
+ * Parse CLI argv (sans `node` and script). Single positional arg.
+ */
+export function parseArgs(_argv: ReadonlyArray<string>): ParsedArgs {
+  throw new Error("not implemented");
+}
+
+/**
+ * Programmable entry point. CLI calls this with `process.argv.slice(2)`,
+ * `process.env`, global `fetch`, and the real stdio streams. Tests pass
+ * stubs.
+ *
+ * @returns process exit code (0/1/2 per module docs).
+ */
+export async function main(
+  _argv: ReadonlyArray<string>,
+  _env: RegisterEnv,
+  _fetchImpl: FetchImpl,
+  _stdout: WritableStreamLike,
+  _stderr: WritableStreamLike,
+): Promise<number> {
+  throw new Error("not implemented");
+}

--- a/apps/crawler/murmur/scripts/register.ts
+++ b/apps/crawler/murmur/scripts/register.ts
@@ -37,6 +37,10 @@
  *
  * @module register-pipeline
  */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import YAML from "yaml";
 
 /**
  * The minimum set of env vars this script needs. Both must be present
@@ -79,24 +83,6 @@ export interface MurmurErrResponse {
 }
 
 /**
- * Result of a single `POST /pipelines` round-trip from `postPipeline`.
- * `status` is the HTTP status; `body` is the parsed envelope, or a
- * stringified body on JSON-parse failure.
- */
-export interface PostPipelineResult {
-  readonly status: number;
-  readonly body: MurmurOkResponse | MurmurErrResponse | { readonly raw: string };
-}
-
-/**
- * Streams used by `main`. Real CLI uses `process.stdout` /
- * `process.stderr`; tests use an in-memory accumulator.
- */
-export interface WritableStreamLike {
-  write(chunk: string): boolean | unknown;
-}
-
-/**
  * Read a YAML file as raw text and return it verbatim. The string is
  * what we POST to Murmur — no JSON conversion locally (avoids
  * double-conversion bugs; server does its own YAML parse).
@@ -105,8 +91,8 @@ export interface WritableStreamLike {
  * @returns The file contents as UTF-8 text.
  * @throws on I/O failure (file not found, unreadable).
  */
-export function readYamlRaw(_filePath: string): string {
-  throw new Error("not implemented");
+export function readYamlRaw(filePath: string): string {
+  return readFileSync(filePath, "utf-8");
 }
 
 /**
@@ -120,24 +106,46 @@ export function readYamlRaw(_filePath: string): string {
  * @throws if the YAML doesn't parse, isn't an object, or has no
  *   non-empty string `id`.
  */
-export function extractPipelineId(_yamlText: string): string {
-  throw new Error("not implemented");
+export function extractPipelineId(yamlText: string): string {
+  const parsed: unknown = YAML.parse(yamlText);
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("pipeline-def YAML must parse to a top-level object");
+  }
+  const candidate = (parsed as { id?: unknown }).id;
+  if (typeof candidate !== "string" || candidate.length === 0) {
+    throw new Error("pipeline-def YAML missing required top-level `id`");
+  }
+  return candidate;
 }
 
 /**
  * Build the absolute URL for `POST /pipelines` given a base URL.
  * Tolerates trailing slashes on the base.
  */
-export function buildPipelinesUrl(_baseUrl: string): string {
-  throw new Error("not implemented");
+export function buildPipelinesUrl(baseUrl: string): string {
+  const trimmed = baseUrl.replace(/\/+$/, "");
+  return `${trimmed}/pipelines`;
 }
 
 /**
  * Validate that the env carries both required vars. Returns a list of
  * missing variable NAMES (not values). Empty list = OK.
  */
-export function checkEnv(_env: RegisterEnv): string[] {
-  throw new Error("not implemented");
+export function checkEnv(env: RegisterEnv): string[] {
+  const missing: string[] = [];
+  if (!env.MURMUR_URL || env.MURMUR_URL.length === 0) missing.push("MURMUR_URL");
+  if (!env.MURMUR_TOKEN || env.MURMUR_TOKEN.length === 0) missing.push("MURMUR_TOKEN");
+  return missing;
+}
+
+/**
+ * Result of a single `POST /pipelines` round-trip from `postPipeline`.
+ * `status` is the HTTP status; `body` is the parsed envelope, or a
+ * stringified body on JSON-parse failure.
+ */
+export interface PostPipelineResult {
+  readonly status: number;
+  readonly body: MurmurOkResponse | MurmurErrResponse | { readonly raw: string };
 }
 
 /**
@@ -148,12 +156,27 @@ export function checkEnv(_env: RegisterEnv): string[] {
  *   rejected, e.g. DNS or refused connection).
  */
 export async function postPipeline(
-  _url: string,
-  _token: string,
-  _body: RegisterRequestBody,
-  _fetchImpl: FetchImpl,
+  url: string,
+  token: string,
+  body: RegisterRequestBody,
+  fetchImpl: FetchImpl,
 ): Promise<PostPipelineResult> {
-  throw new Error("not implemented");
+  const res = await fetchImpl(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  let parsed: PostPipelineResult["body"];
+  try {
+    parsed = JSON.parse(text) as MurmurOkResponse | MurmurErrResponse;
+  } catch {
+    parsed = { raw: text };
+  }
+  return { status: res.status, body: parsed };
 }
 
 /**
@@ -161,8 +184,27 @@ export async function postPipeline(
  * includes the bearer token (the token is not on the response anyway,
  * but this is documented to anchor the test.)
  */
-export function formatFailure(_result: PostPipelineResult): string {
-  throw new Error("not implemented");
+export function formatFailure(result: PostPipelineResult): string {
+  const { status, body } = result;
+  if ("ok" in body && body.ok === false) {
+    return `register-pipeline: HTTP ${status}; errors=${JSON.stringify(body.errors)}`;
+  }
+  if ("ok" in body && body.ok === true) {
+    // Should not occur on the failure path; defensive.
+    return `register-pipeline: HTTP ${status}; unexpected ok=true on failure path`;
+  }
+  if ("raw" in body) {
+    return `register-pipeline: HTTP ${status}; non-JSON body=${body.raw.slice(0, 200)}`;
+  }
+  return `register-pipeline: HTTP ${status}; unknown body shape`;
+}
+
+/**
+ * Streams used by `main`. Real CLI uses `process.stdout` /
+ * `process.stderr`; tests use an in-memory accumulator.
+ */
+export interface WritableStreamLike {
+  write(chunk: string): boolean | unknown;
 }
 
 interface ParsedArgs {
@@ -172,8 +214,21 @@ interface ParsedArgs {
 /**
  * Parse CLI argv (sans `node` and script). Single positional arg.
  */
-export function parseArgs(_argv: ReadonlyArray<string>): ParsedArgs {
-  throw new Error("not implemented");
+export function parseArgs(argv: ReadonlyArray<string>): ParsedArgs {
+  const positional: string[] = [];
+  for (const arg of argv) {
+    if (arg.startsWith("--")) {
+      throw new Error(`unknown argument: ${arg}`);
+    }
+    positional.push(arg);
+  }
+  if (positional.length === 0) return { yamlPath: null };
+  if (positional.length > 1) {
+    throw new Error(
+      `expected exactly one positional arg (yaml path); got ${positional.length}`,
+    );
+  }
+  return { yamlPath: positional[0] ?? null };
 }
 
 /**
@@ -184,11 +239,115 @@ export function parseArgs(_argv: ReadonlyArray<string>): ParsedArgs {
  * @returns process exit code (0/1/2 per module docs).
  */
 export async function main(
-  _argv: ReadonlyArray<string>,
-  _env: RegisterEnv,
-  _fetchImpl: FetchImpl,
-  _stdout: WritableStreamLike,
-  _stderr: WritableStreamLike,
+  argv: ReadonlyArray<string>,
+  env: RegisterEnv,
+  fetchImpl: FetchImpl,
+  stdout: WritableStreamLike,
+  stderr: WritableStreamLike,
 ): Promise<number> {
-  throw new Error("not implemented");
+  // 1. Parse argv.
+  let args: ParsedArgs;
+  try {
+    args = parseArgs(argv);
+  } catch (e) {
+    stderr.write(`register-pipeline: ${(e as Error).message}\n`);
+    return 2;
+  }
+  if (!args.yamlPath) {
+    stderr.write("register-pipeline: usage: register-pipeline <yaml-path>\n");
+    return 2;
+  }
+
+  // 2. Env check (do this BEFORE reading the file so a misconfigured
+  //    invocation fails fast; also makes the missing-env tests easy).
+  const missing = checkEnv(env);
+  if (missing.length > 0) {
+    stderr.write(
+      `register-pipeline: missing required env: ${missing.join(", ")}\n`,
+    );
+    return 2;
+  }
+
+  // 3. Read YAML once.
+  const absPath = path.resolve(args.yamlPath);
+  let yamlText: string;
+  try {
+    yamlText = readYamlRaw(absPath);
+  } catch (e) {
+    stderr.write(
+      `register-pipeline: failed to read ${absPath}: ${(e as Error).message}\n`,
+    );
+    return 2;
+  }
+
+  // 4. Extract the top-level id locally (Murmur's body shape requires it
+  //    alongside the raw YAML).
+  let pipelineId: string;
+  try {
+    pipelineId = extractPipelineId(yamlText);
+  } catch (e) {
+    stderr.write(`register-pipeline: ${(e as Error).message}\n`);
+    return 2;
+  }
+
+  // 5. POST to Murmur.
+  // checkEnv already proved both vars are non-empty strings.
+  const baseUrl = env.MURMUR_URL as string;
+  const token = env.MURMUR_TOKEN as string;
+  const url = buildPipelinesUrl(baseUrl);
+  const body: RegisterRequestBody = { id: pipelineId, def_yaml: yamlText };
+
+  let result: PostPipelineResult;
+  try {
+    result = await postPipeline(url, token, body, fetchImpl);
+  } catch (e) {
+    stderr.write(
+      `register-pipeline: transport error POSTing to ${url}: ${(e as Error).message}\n`,
+    );
+    return 1;
+  }
+
+  // 6. Branch on status.
+  if (result.status >= 200 && result.status < 300) {
+    if ("ok" in result.body && result.body.ok === true) {
+      stdout.write(
+        `register-pipeline: registered pipeline id=${pipelineId} at ${url} (HTTP ${result.status})\n`,
+      );
+      return 0;
+    }
+    // 2xx but envelope says ok=false (or unparseable). Treat as failure.
+    stderr.write(`${formatFailure(result)}\n`);
+    return 1;
+  }
+
+  stderr.write(`${formatFailure(result)}\n`);
+  return 1;
 }
+
+// Direct CLI execution.
+if (
+  typeof process !== "undefined" &&
+  process.argv[1] !== undefined &&
+  import.meta.url === `file://${process.argv[1]}`
+) {
+  // Stash to avoid passing `process.env` (which has many other keys we
+  // don't need) deeper in. Only pull what we use.
+  const env: RegisterEnv = {
+    MURMUR_URL: process.env.MURMUR_URL,
+    MURMUR_TOKEN: process.env.MURMUR_TOKEN,
+  };
+  // `fetch` is global on Node ≥ 18.
+  const fetchImpl: FetchImpl = globalThis.fetch.bind(globalThis);
+  main(process.argv.slice(2), env, fetchImpl, process.stdout, process.stderr).then(
+    (code) => {
+      process.exit(code);
+    },
+    (err) => {
+      process.stderr.write(
+        `register-pipeline: unexpected error: ${(err as Error).stack ?? err}\n`,
+      );
+      process.exit(2);
+    },
+  );
+}
+

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "build": "turbo run build",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
-    "validate-pipeline": "pnpm --filter @jobseek/murmur-pipelines validate-pipeline"
+    "validate-pipeline": "pnpm --filter @jobseek/murmur-pipelines validate-pipeline",
+    "register-pipeline": "pnpm --filter @jobseek/murmur-pipelines register-pipeline"
   },
   "devDependencies": {
     "turbo": "^2"


### PR DESCRIPTION
## Summary

Adds `apps/crawler/murmur/scripts/register.ts` — a small TS CLI that reads
the demo pipeline YAML once and POSTs `{ id, def_yaml }` to
`${MURMUR_URL}/pipelines` with bearer auth, matching M4's body shape from
`docs/contracts.md` §1 and `src/api/publisher/pipelines.ts`. Server does
its own YAML parse + validation; this script does **not** validate
locally — that's `validate-pipeline.ts`'s job (P1). The two scripts split
labour deliberately so a stale local schema vendoring can never silently
bypass the server's checks.

Wired as `pnpm register-pipeline` (root proxy) /
`pnpm --filter @jobseek/murmur-pipelines register-pipeline`.

## Related issue

Closes colophon-group/jobseek#2761

## Files changed (high-level)

- `apps/crawler/murmur/scripts/register.ts` — registrar (interfaces, env
  check, single-shot YAML read, POST, exit-code branching).
- `apps/crawler/murmur/scripts/register.test.ts` — 37 vitest cases
  covering every Verification bullet + quality gates.
- `apps/crawler/murmur/package.json` — adds `register-pipeline` script.
- `package.json` (root) — adds `register-pipeline` proxy parallel to
  the existing `validate-pipeline` proxy.
- `apps/crawler/murmur/README.md` — documents the script + division of
  labour vs P1.

## Verification (from the issue)

- [x] Stub Murmur server (vitest fake fetch) succeeds with valid YAML
- [x] Stub returning 4xx exits non-zero
- [x] `MURMUR_URL` unset — exits 2 with clear message naming the var
- [x] `MURMUR_TOKEN` unset — exits 2 with clear message naming the var
- [x] Idempotent: two consecutive POSTs both return 200, both exit 0
- [x] Token never appears in stdout/stderr (200, 4xx, transport-error paths)
- [x] YAML read exactly once; `def_yaml` on the wire is bit-identical to
      the file on disk (no double-conversion)

## Manual checks run locally

- `pnpm --filter @jobseek/murmur-pipelines test` — 51 passed (37 new + 14 P1)
- `npx tsc --noEmit` (in `apps/crawler/murmur`) — clean
- `pnpm register-pipeline` with no env — exits 2, error names both vars
- `pnpm register-pipeline` with bogus env — fails fast (would call the
  network; verified via test stubs)

## Notes for reviewer

- M4's body shape is `{ id, def_yaml }` — `id` is required even though
  the YAML carries it; `extractPipelineId` parses the YAML locally just
  enough to read the top-level id and nothing else.
- The token leak guard is a string-search assertion in three test cases
  (200, 4xx, transport-error). It would also catch accidental
  template-string interpolation into log lines.
- `main()` takes injectable `env`, `fetch`, and stream stubs — that's
  what makes the verification matrix testable without a real network.
- I did NOT wire GitHub Actions integration (the issue lists this as
  optional and the orchestrator note flagged it as half-baked without a
  real Murmur deploy to register against).