### PR TITLE
feat(jobseek): Murmur webhook accept handler

### DIFF
--- a/apps/web/app/api/murmur/README.md
+++ b/apps/web/app/api/murmur/README.md
@@ -93,3 +93,49 @@ Every route enforces, in order:
 | `MURMUR_PY` (optional) | Python interpreter path; defaults to `python3`. |
 | `MURMUR_CRAWLER_ROOT` (optional) | Path to the crawler app root; defaults to `<cwd>/../crawler`. |
 | `MURMUR_INVOKE_TIMEOUT_MS` (optional) | Wallclock cap per call; defaults to 30 000 ms. |
+
+## Webhook accept handler — `POST /api/murmur/accept`
+
+Tracking issue: [colophon-group/jobseek#2763](https://github.com/colophon-group/jobseek/issues/2763).
+
+Murmur POSTs the composed `final_output` for a completed run here when
+the pipeline declares `webhook: …/api/murmur/accept` (Murmur DESIGN.md
+§4.1). The contract:
+
+- `Authorization: Bearer <MURMUR_TOKEN>` — the same shared bearer used by
+  the seven shim routes. Wrong / missing → 401.
+- `Idempotency-Key: <run_id>` — required. Missing → 400. The handler
+  stores a SHA-256 of the canonicalised JSON body and dedupes on
+  `(run_id)`. Same run\_id + same hash returns
+  `{ ok: true, data: { applied: false, reason: "already_applied" } }`;
+  same run\_id + different hash returns `reason: "body_mismatch"` and
+  logs a warning.
+- Body cap: 5 MB. Larger payloads are rejected 413 — checked twice
+  (Content-Length fast-path + post-read buffer).
+- Schema validation: the `final_output` shape from
+  `apps/crawler/murmur/pipelines/add-company.yaml` is vendored at
+  `_lib/accept-schema.ts`; per-field errors come back as
+  `errors: ["validation:<json-pointer>:<token>"]`.
+- Defense-in-depth probe re-run: every board in the validated
+  `final_output` is fed back through `invokeLib("probe_monitor", …)` —
+  same Python lib the agent used. The subprocess fan-out is wrapped in
+  a 30 s wallclock budget (`MURMUR_ACCEPT_PROBE_TIMEOUT_MS`); on
+  timeout the route returns 504 with `errors: ["probe_timeout"]`. On
+  per-board failure the route returns HTTP 200 with
+  `{ ok: false, errors: [...] }` so Murmur's one-retry budget burns
+  cleanly instead of forever.
+- Catalog write: `MURMUR_ACCEPT_TARGET=postgres` (default) writes to
+  the `company` + `job_board` tables alongside the
+  `murmur_accept_log` ledger row in one transaction. The PRIMARY KEY
+  on `murmur_accept_log.run_id` is the durable UNIQUE the issue
+  requires. `MURMUR_ACCEPT_TARGET=csv` switches to appending
+  `apps/crawler/data/companies.csv` + `boards.csv` for operator-side
+  debugging — not concurrency-safe.
+
+### Additional environment
+
+| Variable | Purpose |
+|---|---|
+| `MURMUR_ACCEPT_TARGET` | `postgres` (default) or `csv`. |
+| `MURMUR_ACCEPT_CSV_DIR` | Override the CSV-backend output dir; defaults to `<cwd>/../crawler/data`. |
+| `MURMUR_ACCEPT_PROBE_TIMEOUT_MS` | Probe re-run wallclock cap; defaults to 30 000 ms. Must match Murmur's webhook retry interval (DESIGN.md §4.1). |

--- a/apps/web/app/api/murmur/__tests__/accept-validate.test.ts
+++ b/apps/web/app/api/murmur/__tests__/accept-validate.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for the `final_output` schema validator.
+ *
+ * Covers:
+ *   - top-level required fields
+ *   - additionalProperties: false at every level
+ *   - per-field type / pattern / minLength / maxLength / enum
+ *   - array fields: type, items, minItems, maxItems
+ *   - deep recursion through `boards[*]` (object inside array)
+ *   - error path is a JSON Pointer (`/boards/0/board_url` etc.)
+ *
+ * @see colophon-group/jobseek#2763
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { FINAL_OUTPUT_SCHEMA } from "../_lib/accept-schema";
+import { validateAcceptBody } from "../_lib/accept-validate";
+
+const VALID = {
+  canonical_name: "Acme",
+  canonical_website: "https://acme.example.com",
+  slug: "acme",
+  description: "Test fixture company.",
+  industry_ids: ["software"],
+  boards: [
+    {
+      alias: "global",
+      board_url: "https://job-boards.greenhouse.io/acme",
+      provider: "greenhouse",
+      outcome: "configured",
+      monitor_type: "greenhouse",
+      monitor_config: { token: "acme" },
+      scraper_type: "skip",
+      scraper_config: {},
+      verdict: "ok",
+    },
+  ],
+};
+
+describe("validateAcceptBody", () => {
+  it("returns no errors on a valid body", () => {
+    expect(validateAcceptBody(VALID, FINAL_OUTPUT_SCHEMA)).toEqual([]);
+  });
+
+  it("flags missing top-level required fields", () => {
+    const errs = validateAcceptBody(
+      { canonical_name: "Acme" },
+      FINAL_OUTPUT_SCHEMA,
+    );
+    const paths = errs.map((e) => e.path);
+    expect(paths).toEqual(
+      expect.arrayContaining([
+        "/canonical_website",
+        "/slug",
+        "/description",
+        "/industry_ids",
+        "/boards",
+      ]),
+    );
+    for (const e of errs) {
+      if (e.path !== "" && e.path !== "/canonical_name") {
+        expect(e.message).toBe("missing");
+      }
+    }
+  });
+
+  it("rejects unknown top-level keys", () => {
+    const errs = validateAcceptBody(
+      { ...VALID, sneaky: 1 },
+      FINAL_OUTPUT_SCHEMA,
+    );
+    expect(errs).toEqual(
+      expect.arrayContaining([{ path: "/sneaky", message: "unknown_property" }]),
+    );
+  });
+
+  it("rejects a slug that violates the kebab-case pattern", () => {
+    const errs = validateAcceptBody(
+      { ...VALID, slug: "Bad Slug!" },
+      FINAL_OUTPUT_SCHEMA,
+    );
+    expect(errs).toEqual(
+      expect.arrayContaining([{ path: "/slug", message: "pattern_mismatch" }]),
+    );
+  });
+
+  it("rejects a description over 400 chars", () => {
+    const errs = validateAcceptBody(
+      { ...VALID, description: "a".repeat(401) },
+      FINAL_OUTPUT_SCHEMA,
+    );
+    expect(errs).toEqual(
+      expect.arrayContaining([
+        { path: "/description", message: "too_long" },
+      ]),
+    );
+  });
+
+  it("rejects an empty boards array (minItems: 1)", () => {
+    const errs = validateAcceptBody(
+      { ...VALID, boards: [] },
+      FINAL_OUTPUT_SCHEMA,
+    );
+    expect(errs).toEqual(
+      expect.arrayContaining([{ path: "/boards", message: "too_short" }]),
+    );
+  });
+
+  it("rejects industry_ids over 4", () => {
+    const errs = validateAcceptBody(
+      { ...VALID, industry_ids: ["a", "b", "c", "d", "e"] },
+      FINAL_OUTPUT_SCHEMA,
+    );
+    expect(errs).toEqual(
+      expect.arrayContaining([
+        { path: "/industry_ids", message: "too_long" },
+      ]),
+    );
+  });
+
+  it("rejects a board with a missing required field", () => {
+    const broken = {
+      ...VALID,
+      boards: [{ ...VALID.boards[0], board_url: undefined }],
+    };
+    const errs = validateAcceptBody(broken, FINAL_OUTPUT_SCHEMA);
+    const paths = errs.map((e) => e.path);
+    expect(paths).toContain("/boards/0/board_url");
+  });
+
+  it("rejects a board verdict not in the enum", () => {
+    const broken = {
+      ...VALID,
+      boards: [{ ...VALID.boards[0], verdict: "maybe" }],
+    };
+    const errs = validateAcceptBody(broken, FINAL_OUTPUT_SCHEMA);
+    expect(errs).toEqual(
+      expect.arrayContaining([
+        { path: "/boards/0/verdict", message: "not_in_enum" },
+      ]),
+    );
+  });
+
+  it("rejects a board_url that is not https://", () => {
+    const broken = {
+      ...VALID,
+      boards: [{ ...VALID.boards[0], board_url: "http://insecure.example.com/x" }],
+    };
+    const errs = validateAcceptBody(broken, FINAL_OUTPUT_SCHEMA);
+    const paths = errs.map((e) => `${e.path}:${e.message}`);
+    expect(paths).toContain("/boards/0/board_url:pattern_mismatch");
+  });
+
+  it("rejects a non-object root", () => {
+    expect(validateAcceptBody("not an object", FINAL_OUTPUT_SCHEMA)).toEqual([
+      { path: "", message: "must_be_object" },
+    ]);
+  });
+});

--- a/apps/web/app/api/murmur/__tests__/accept.test.ts
+++ b/apps/web/app/api/murmur/__tests__/accept.test.ts
@@ -135,12 +135,11 @@ describe("POST /api/murmur/accept", () => {
     expect(await res.json()).toEqual({ ok: false, errors: ["unauthorized"] });
   });
 
-  it("returns 413 when Content-Length exceeds 5 MB", async () => {
+  it("returns 413 when the body exceeds 5 MB", async () => {
     const { POST } = await loadRoute();
+    const huge = "a".repeat(6 * 1024 * 1024);
     const res = await POST(
-      webhookRequest(VALID_FINAL_OUTPUT, {
-        contentLength: String(6 * 1024 * 1024),
-      }),
+      webhookRequest(null, { rawBody: JSON.stringify({ huge }) }),
     );
     expect(res.status).toBe(413);
     const body = (await res.json()) as { ok: boolean; errors: string[] };
@@ -148,13 +147,24 @@ describe("POST /api/murmur/accept", () => {
     expect(appliedCalls).toHaveLength(0);
   });
 
-  it("returns 413 when the post-read buffer exceeds 5 MB even if Content-Length lied", async () => {
+  it("returns 413 fast-path when Content-Length declares > 5 MB even if body is smaller", async () => {
+    // This case verifies that the route looks at Content-Length BEFORE
+    // reading the body buffer — important when a malicious / buggy
+    // client lies about the size to provoke a large allocation. We
+    // construct a `Request`-shaped object directly so happy-dom doesn't
+    // overwrite Content-Length.
     const { POST } = await loadRoute();
-    // 6 MB of payload, but Content-Length unset (some HTTP clients omit it).
-    const huge = "a".repeat(6 * 1024 * 1024);
-    const res = await POST(
-      webhookRequest(null, { rawBody: JSON.stringify({ huge }) }),
-    );
+    const headers = new Headers({
+      "content-type": "application/json",
+      authorization: `Bearer ${process.env.MURMUR_TOKEN ?? "test-token"}`,
+      "idempotency-key": "run-cl-lied",
+      "content-length": String(6 * 1024 * 1024),
+    });
+    const fakeRequest = {
+      headers,
+      text: async () => JSON.stringify(VALID_FINAL_OUTPUT),
+    } as unknown as Request;
+    const res = await POST(fakeRequest);
     expect(res.status).toBe(413);
   });
 
@@ -319,5 +329,68 @@ describe("POST /api/murmur/accept", () => {
     const { POST } = await loadRoute();
     const res = await POST(webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-H" }));
     expect(res.status).toBeLessThan(500);
+  });
+
+  // ── Murmur one-retry simulations (issue #2763 e2e bullet) ──────────
+
+  it("simulates Murmur 200 + 200 retry: idempotency holds, only one row written", async () => {
+    const { POST } = await loadRoute();
+    // First fire — applied.
+    const res1 = await POST(webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-retry-A" }));
+    expect((await res1.json()).data.applied).toBe(true);
+    expect(appliedCalls).toHaveLength(1);
+    // Second fire (Murmur thought the first one timed out and retried)
+    // — same body, same run_id. Idempotency catches it; no second
+    // catalog row.
+    const res2 = await POST(webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-retry-A" }));
+    const body2 = await res2.json();
+    expect(body2.ok).toBe(true);
+    expect(body2.data.applied).toBe(false);
+    expect(body2.data.reason).toBe("already_applied");
+    expect(appliedCalls).toHaveLength(1);
+  });
+
+  it("simulates Murmur 503 + 200 retry: first attempt fails, retry succeeds, only one row", async () => {
+    const { POST } = await loadRoute();
+    // Round 1: catalog backend simulates a transient outage.
+    let firstCall = true;
+    ApplyCatalogHolder.current = (async (_t, _b, _ctx) => {
+      if (firstCall) {
+        firstCall = false;
+        throw new Error("simulated transient DB outage");
+      }
+      appliedCalls.push({ body: _b, context: _ctx });
+      return {
+        companyId: "00000000-0000-0000-0000-000000000003",
+        boardCount: 1,
+        warnings: [],
+      };
+    }) as ApplyCatalog;
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const res1 = await POST(webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-retry-B" }));
+    // Catalog write failure surfaces in the envelope; Murmur sees a
+    // 200 with ok:false, classifies it as a soft failure, and retries
+    // (the issue's "503 + 200" pattern is shorthand for "first
+    // attempt was non-2xx, retry succeeded").
+    expect((await res1.json()).ok).toBe(false);
+    expect(appliedCalls).toHaveLength(0);
+
+    // Round 2: backend recovers. Same run_id, same body — the
+    // in-process ledger has NOT yet recorded this run (apply failed),
+    // so the retry proceeds and writes the row.
+    const res2 = await POST(webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-retry-B" }));
+    const body2 = await res2.json();
+    expect(body2.ok).toBe(true);
+    expect(body2.data.applied).toBe(true);
+    expect(appliedCalls).toHaveLength(1);
+
+    // Round 3 (Murmur's bug-budget belt-and-suspenders): even if a
+    // duplicate fires AGAIN after success, it's deduped.
+    const res3 = await POST(webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-retry-B" }));
+    expect((await res3.json()).data.applied).toBe(false);
+    expect(appliedCalls).toHaveLength(1);
+
+    errSpy.mockRestore();
   });
 });

--- a/apps/web/app/api/murmur/__tests__/accept.test.ts
+++ b/apps/web/app/api/murmur/__tests__/accept.test.ts
@@ -33,6 +33,10 @@ import {
   RerunHolder,
   type RerunProbes,
 } from "../_lib/accept-pipeline";
+import {
+  LedgerReaderHolder,
+  type LedgerReader,
+} from "../_lib/idempotency";
 
 /** Minimum-shape `final_output` body that passes schema validation. */
 const VALID_FINAL_OUTPUT = {
@@ -92,13 +96,22 @@ let appliedCalls: Array<{
   context: { runId: string; bodyHash: string };
 }> = [];
 let rerunCalls: number;
+/**
+ * Stub durable ledger backing store, keyed by run_id. Tests that want
+ * to simulate a cold-start replay seed this directly (bypassing the
+ * route's in-process Map) and then clear the Map.
+ */
+let durableLedger: Map<string, string>;
 
 beforeEach(() => {
   appliedCalls = [];
   rerunCalls = 0;
-  // Default: catalog applies cleanly with no warnings.
+  durableLedger = new Map();
+  // Default: catalog applies cleanly with no warnings. Records into the
+  // durable ledger stub so the cold-start-replay tests below see it.
   ApplyCatalogHolder.current = (async (_target, body, context) => {
     appliedCalls.push({ body, context });
+    durableLedger.set(context.runId, context.bodyHash);
     return {
       companyId: "00000000-0000-0000-0000-000000000001",
       boardCount: 1,
@@ -110,7 +123,29 @@ beforeEach(() => {
     rerunCalls += 1;
     return { status: "ok" } as const;
   }) as RerunProbes;
+  // Default: durable ledger reader consults the in-memory map. Tests
+  // that exercise cold-start replays clear the Map (via the dedicated
+  // helper) but keep the durableLedger entry — that asymmetry is the
+  // whole point of the test.
+  LedgerReaderHolder.current = (async (runId, bodyHash) => {
+    const seen = durableLedger.get(runId);
+    if (seen === undefined) return { status: "fresh" };
+    if (seen === bodyHash)
+      return { status: "already_applied", companyId: null };
+    return { status: "body_mismatch", companyId: null };
+  }) as LedgerReader;
 });
+
+/**
+ * Clear the in-process Map used by `accept/route.ts`. Cold-start tests
+ * call this between requests to simulate a process restart while
+ * keeping the `durableLedger` populated.
+ */
+async function clearInProcessLedger(): Promise<void> {
+  const mod = await import("../accept/route");
+  const map = (mod as unknown as { __ledger?: Map<string, string> }).__ledger;
+  if (map) map.clear();
+}
 
 async function loadRoute() {
   return await import("../accept/route");
@@ -304,7 +339,7 @@ describe("POST /api/murmur/accept", () => {
     errSpy.mockRestore();
   });
 
-  it("surfaces catalog writer warnings as errors:['catalog:<token>'] but still applies", async () => {
+  it("surfaces catalog writer warnings on the response but still applies", async () => {
     ApplyCatalogHolder.current = (async (_t, _body, _ctx) => ({
       companyId: "00000000-0000-0000-0000-000000000002",
       boardCount: 1,
@@ -347,6 +382,164 @@ describe("POST /api/murmur/accept", () => {
     expect(body2.ok).toBe(true);
     expect(body2.data.applied).toBe(false);
     expect(body2.data.reason).toBe("already_applied");
+    expect(appliedCalls).toHaveLength(1);
+  });
+
+  // ── Cold-start replay (durable ledger source-of-truth) ─────────────
+
+  it("cold-start replay (Postgres path): Map cleared, durable ledger returns already_applied", async () => {
+    // Seed: first fire applies cleanly and writes the durable ledger.
+    const { POST } = await loadRoute();
+    const res1 = await POST(
+      webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-cold-A" }),
+    );
+    expect((await res1.json()).data.applied).toBe(true);
+    expect(durableLedger.has("run-cold-A")).toBe(true);
+    expect(appliedCalls).toHaveLength(1);
+
+    // Simulate a process restart: clear the in-process Map only.
+    await clearInProcessLedger();
+
+    // Same body re-fires after restart. The Map miss must fall through
+    // to the durable ledger and return already_applied — NOT re-apply.
+    const res2 = await POST(
+      webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-cold-A" }),
+    );
+    const body2 = await res2.json();
+    expect(res2.status).toBe(200);
+    expect(body2.ok).toBe(true);
+    expect(body2.data.applied).toBe(false);
+    expect(body2.data.reason).toBe("already_applied");
+    // Critical: catalog writer was NOT called a second time despite the
+    // empty in-process Map.
+    expect(appliedCalls).toHaveLength(1);
+    // Critical: the probe re-runner was also short-circuited.
+    expect(rerunCalls).toBe(1);
+  });
+
+  it("cold-start replay (CSV path): Map cleared, durable ledger returns already_applied", async () => {
+    // The route doesn't care about the catalog target for the
+    // idempotency-classification step — it always defers to the ledger
+    // reader. We force the env var so the same code path the CSV
+    // backend would hit in production is what ledger-reader sees.
+    const prevTarget = process.env.MURMUR_ACCEPT_TARGET;
+    process.env.MURMUR_ACCEPT_TARGET = "csv";
+    try {
+      const { POST } = await loadRoute();
+      const res1 = await POST(
+        webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-cold-csv" }),
+      );
+      expect((await res1.json()).data.applied).toBe(true);
+      expect(durableLedger.has("run-cold-csv")).toBe(true);
+
+      await clearInProcessLedger();
+
+      const res2 = await POST(
+        webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-cold-csv" }),
+      );
+      const body2 = await res2.json();
+      expect(body2.data.applied).toBe(false);
+      expect(body2.data.reason).toBe("already_applied");
+      expect(appliedCalls).toHaveLength(1);
+    } finally {
+      if (prevTarget === undefined) {
+        delete process.env.MURMUR_ACCEPT_TARGET;
+      } else {
+        process.env.MURMUR_ACCEPT_TARGET = prevTarget;
+      }
+    }
+  });
+
+  it("cold-start body_mismatch: Map cleared, durable ledger holds different hash", async () => {
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const { POST } = await loadRoute();
+
+    const res1 = await POST(
+      webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-cold-B" }),
+    );
+    expect((await res1.json()).data.applied).toBe(true);
+
+    // Restart: Map empty, durable ledger has the FIRST body's hash.
+    await clearInProcessLedger();
+
+    const tampered = {
+      ...VALID_FINAL_OUTPUT,
+      description: "Different description after restart.",
+    };
+    const res2 = await POST(webhookRequest(tampered, { runId: "run-cold-B" }));
+    const body2 = await res2.json();
+    expect(res2.status).toBe(200);
+    expect(body2.ok).toBe(true);
+    expect(body2.data.applied).toBe(false);
+    expect(body2.data.reason).toBe("body_mismatch");
+    // Catalog NOT called for the tampered body.
+    expect(appliedCalls).toHaveLength(1);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  // ── UNIQUE-constraint integration: concurrent first-write race ─────
+
+  it("UNIQUE constraint integration: catalog writer throws CatalogIdempotencyConflict → already_applied", async () => {
+    // Simulate the exact scenario the issue's quality gate calls out:
+    // two concurrent first-writes for the same run_id race into the
+    // catalog writer. The first one lands; the second one's `tx
+    // .insert(murmurAcceptLog).onConflictDoNothing().returning()`
+    // returns an empty array, the writer raises
+    // CatalogIdempotencyConflict, and the route surfaces
+    // already_applied (NOT a 500, NOT a duplicate row).
+    const { CatalogIdempotencyConflict } = await import("../_lib/catalog");
+    let firstWriterCompleted = false;
+    ApplyCatalogHolder.current = (async (_t, _b, ctx) => {
+      if (!firstWriterCompleted) {
+        firstWriterCompleted = true;
+        appliedCalls.push({ body: _b, context: ctx });
+        durableLedger.set(ctx.runId, ctx.bodyHash);
+        return {
+          companyId: "00000000-0000-0000-0000-000000000099",
+          boardCount: 1,
+          warnings: [],
+        };
+      }
+      throw new CatalogIdempotencyConflict(ctx.runId);
+    }) as ApplyCatalog;
+
+    // Force the durable-ledger reader to miss for both calls so both
+    // requests proceed past idempotency classification and into the
+    // catalog writer — that is the exact race the UNIQUE constraint
+    // guards against (the in-process Map and the durable ledger both
+    // miss on the second request because the first writer hasn't
+    // committed yet from THIS process's perspective).
+    LedgerReaderHolder.current = (async () => ({
+      status: "fresh" as const,
+    })) as LedgerReader;
+
+    const { POST } = await loadRoute();
+    // First fire — wins the UNIQUE.
+    const res1 = await POST(
+      webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-race-X" }),
+    );
+    const body1 = await res1.json();
+    expect(body1.ok).toBe(true);
+    expect(body1.data.applied).toBe(true);
+
+    // Clear the Map so the second request also reaches the catalog
+    // writer (otherwise the in-process Map short-circuits).
+    await clearInProcessLedger();
+
+    // Second concurrent fire — loses the UNIQUE; route surfaces
+    // already_applied via the CatalogIdempotencyConflict catch.
+    const res2 = await POST(
+      webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-race-X" }),
+    );
+    expect(res2.status).toBe(200);
+    const body2 = await res2.json();
+    expect(body2.ok).toBe(true);
+    expect(body2.data.applied).toBe(false);
+    expect(body2.data.reason).toBe("already_applied");
+    // Exactly one catalog row was written.
     expect(appliedCalls).toHaveLength(1);
   });
 

--- a/apps/web/app/api/murmur/__tests__/accept.test.ts
+++ b/apps/web/app/api/murmur/__tests__/accept.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Unit tests for `POST /api/murmur/accept` — the Murmur webhook handler.
+ *
+ * Covers the full Verification matrix from jobseek#2763:
+ *
+ *   - Bearer missing                         → 401
+ *   - Bearer wrong                           → 401
+ *   - Body > 5 MB                            → 413
+ *   - Idempotency-Key missing                → 400
+ *   - Body parse failure                     → 400
+ *   - Schema-invalid body                    → 400 with validation:* errors
+ *   - Idempotent replay (same hash)          → 200 applied:false reason:already_applied
+ *   - Idempotent replay (different hash)     → 200 applied:false reason:body_mismatch
+ *   - Re-run probes succeed                  → 200 applied:true, catalog written
+ *   - Re-run probes fail                     → 200 ok:false, no catalog write
+ *   - Re-run probes time out                 → 504 ok:false errors:["probe_timeout"]
+ *   - Catalog writer throws                  → 200 ok:false errors:["catalog_write_failed"]
+ *
+ * The catalog writer + idempotency ledger + probe re-runner are all
+ * stubbed via the holders defined alongside the production functions.
+ *
+ * @see colophon-group/jobseek#2763
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import "./_helpers";
+import {
+  ApplyCatalogHolder,
+  type ApplyCatalog,
+} from "../_lib/catalog";
+import {
+  RerunHolder,
+  type RerunProbes,
+} from "../_lib/accept-pipeline";
+
+/** Minimum-shape `final_output` body that passes schema validation. */
+const VALID_FINAL_OUTPUT = {
+  canonical_name: "Acme",
+  canonical_website: "https://acme.example.com",
+  slug: "acme",
+  description: "Test fixture company.",
+  industry_ids: ["software"],
+  boards: [
+    {
+      alias: "global",
+      board_url: "https://job-boards.greenhouse.io/acme",
+      provider: "greenhouse",
+      outcome: "configured",
+      monitor_type: "greenhouse",
+      monitor_config: { token: "acme" },
+      scraper_type: "skip",
+      scraper_config: {},
+      verdict: "ok",
+    },
+  ],
+} as const;
+
+/** Build a fully-formed authorised webhook request. */
+function webhookRequest(
+  body: unknown,
+  overrides?: {
+    bearer?: string | null;
+    runId?: string | null;
+    rawBody?: string;
+    contentLength?: string;
+  },
+): Request {
+  const headers = new Headers({ "content-type": "application/json" });
+  if (overrides?.bearer !== null) {
+    headers.set(
+      "authorization",
+      `Bearer ${overrides?.bearer ?? process.env.MURMUR_TOKEN ?? "test-token"}`,
+    );
+  }
+  if (overrides?.runId !== null) {
+    headers.set("idempotency-key", overrides?.runId ?? "run-test-1");
+  }
+  const raw = overrides?.rawBody ?? JSON.stringify(body);
+  if (overrides?.contentLength !== undefined) {
+    headers.set("content-length", overrides.contentLength);
+  }
+  return new Request("https://jobseek.test/api/murmur/accept", {
+    method: "POST",
+    headers,
+    body: raw,
+  });
+}
+
+let appliedCalls: Array<{
+  body: unknown;
+  context: { runId: string; bodyHash: string };
+}> = [];
+let rerunCalls: number;
+
+beforeEach(() => {
+  appliedCalls = [];
+  rerunCalls = 0;
+  // Default: catalog applies cleanly with no warnings.
+  ApplyCatalogHolder.current = (async (_target, body, context) => {
+    appliedCalls.push({ body, context });
+    return {
+      companyId: "00000000-0000-0000-0000-000000000001",
+      boardCount: 1,
+      warnings: [],
+    };
+  }) as ApplyCatalog;
+  // Default: probe re-run succeeds.
+  RerunHolder.current = (async () => {
+    rerunCalls += 1;
+    return { status: "ok" } as const;
+  }) as RerunProbes;
+});
+
+async function loadRoute() {
+  return await import("../accept/route");
+}
+
+describe("POST /api/murmur/accept", () => {
+  it("returns 401 when the bearer is missing", async () => {
+    const { POST } = await loadRoute();
+    const res = await POST(webhookRequest(VALID_FINAL_OUTPUT, { bearer: null }));
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ ok: false, errors: ["unauthorized"] });
+    expect(appliedCalls).toHaveLength(0);
+    expect(rerunCalls).toBe(0);
+  });
+
+  it("returns 401 when the bearer is wrong", async () => {
+    const { POST } = await loadRoute();
+    const res = await POST(
+      webhookRequest(VALID_FINAL_OUTPUT, { bearer: "WRONG-TOKEN" }),
+    );
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ ok: false, errors: ["unauthorized"] });
+  });
+
+  it("returns 413 when Content-Length exceeds 5 MB", async () => {
+    const { POST } = await loadRoute();
+    const res = await POST(
+      webhookRequest(VALID_FINAL_OUTPUT, {
+        contentLength: String(6 * 1024 * 1024),
+      }),
+    );
+    expect(res.status).toBe(413);
+    const body = (await res.json()) as { ok: boolean; errors: string[] };
+    expect(body).toEqual({ ok: false, errors: ["payload_too_large"] });
+    expect(appliedCalls).toHaveLength(0);
+  });
+
+  it("returns 413 when the post-read buffer exceeds 5 MB even if Content-Length lied", async () => {
+    const { POST } = await loadRoute();
+    // 6 MB of payload, but Content-Length unset (some HTTP clients omit it).
+    const huge = "a".repeat(6 * 1024 * 1024);
+    const res = await POST(
+      webhookRequest(null, { rawBody: JSON.stringify({ huge }) }),
+    );
+    expect(res.status).toBe(413);
+  });
+
+  it("returns 400 when Idempotency-Key header is missing", async () => {
+    const { POST } = await loadRoute();
+    const res = await POST(
+      webhookRequest(VALID_FINAL_OUTPUT, { runId: null }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { errors: string[] };
+    expect(body.errors).toEqual(["missing_header:idempotency-key"]);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const { POST } = await loadRoute();
+    const res = await POST(
+      webhookRequest(null, { rawBody: "{not json" }),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { errors: string[] };
+    expect(body.errors).toEqual(["invalid_json"]);
+  });
+
+  it("returns 400 with validation:* errors on a schema-invalid body", async () => {
+    const { POST } = await loadRoute();
+    const bad = {
+      ...VALID_FINAL_OUTPUT,
+      slug: "Bad Slug!", // pattern violation
+      boards: [], // minItems: 1
+    };
+    const res = await POST(webhookRequest(bad));
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { ok: boolean; errors: string[] };
+    expect(body.ok).toBe(false);
+    expect(body.errors.length).toBeGreaterThan(0);
+    for (const err of body.errors) {
+      expect(err).toMatch(/^validation:\/[^:]*:[a-z_]+$/);
+    }
+    expect(appliedCalls).toHaveLength(0);
+    expect(rerunCalls).toBe(0);
+  });
+
+  it("idempotent replay (same run_id, same body): applied:false reason:already_applied, no second write", async () => {
+    const { POST } = await loadRoute();
+    // First call — fresh.
+    const res1 = await POST(webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-A" }));
+    expect(res1.status).toBe(200);
+    const body1 = await res1.json();
+    expect(body1.ok).toBe(true);
+    expect(body1.data.applied).toBe(true);
+    expect(appliedCalls).toHaveLength(1);
+
+    // Second call with the same body — should hit the ledger.
+    const res2 = await POST(webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-A" }));
+    expect(res2.status).toBe(200);
+    const body2 = await res2.json();
+    expect(body2.ok).toBe(true);
+    expect(body2.data.applied).toBe(false);
+    expect(body2.data.reason).toBe("already_applied");
+    expect(body2.data.run_id).toBe("run-A");
+    // Catalog writer NOT called a second time.
+    expect(appliedCalls).toHaveLength(1);
+  });
+
+  it("idempotent replay (same run_id, different body): applied:false reason:body_mismatch, no second write, warning", async () => {
+    const { POST } = await loadRoute();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const res1 = await POST(webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-B" }));
+    expect(res1.status).toBe(200);
+    expect(appliedCalls).toHaveLength(1);
+
+    const tampered = {
+      ...VALID_FINAL_OUTPUT,
+      description: "Different description.",
+    };
+    const res2 = await POST(webhookRequest(tampered, { runId: "run-B" }));
+    expect(res2.status).toBe(200);
+    const body2 = await res2.json();
+    expect(body2.ok).toBe(true);
+    expect(body2.data.applied).toBe(false);
+    expect(body2.data.reason).toBe("body_mismatch");
+    expect(appliedCalls).toHaveLength(1);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("happy path: re-run probes succeed → catalog written, applied:true", async () => {
+    const { POST } = await loadRoute();
+    const res = await POST(webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-C" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.applied).toBe(true);
+    expect(body.data.run_id).toBe("run-C");
+    expect(rerunCalls).toBe(1);
+    expect(appliedCalls).toHaveLength(1);
+    expect(appliedCalls[0]?.context.runId).toBe("run-C");
+  });
+
+  it("re-run probes fail → no catalog write, 200 with ok:false errors:[...]", async () => {
+    RerunHolder.current = (async () => ({
+      status: "failed",
+      errors: ["probe_failed:global"],
+    })) as RerunProbes;
+    const { POST } = await loadRoute();
+    const res = await POST(webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-D" }));
+    // Not 5xx — Murmur retry budget would burn forever.
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.errors).toEqual(["probe_failed:global"]);
+    expect(appliedCalls).toHaveLength(0);
+  });
+
+  it("re-run probes time out → 504 with errors:['probe_timeout']", async () => {
+    RerunHolder.current = (async () => ({ status: "timeout" })) as RerunProbes;
+    const { POST } = await loadRoute();
+    const res = await POST(webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-E" }));
+    expect(res.status).toBe(504);
+    const body = await res.json();
+    expect(body).toEqual({ ok: false, errors: ["probe_timeout"] });
+    expect(appliedCalls).toHaveLength(0);
+  });
+
+  it("catalog writer throws → 200 ok:false errors:['catalog_write_failed']", async () => {
+    ApplyCatalogHolder.current = (async () => {
+      throw new Error("simulated DB outage");
+    }) as ApplyCatalog;
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const { POST } = await loadRoute();
+    const res = await POST(webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-F" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ ok: false, errors: ["catalog_write_failed"] });
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it("surfaces catalog writer warnings as errors:['catalog:<token>'] but still applies", async () => {
+    ApplyCatalogHolder.current = (async (_t, _body, _ctx) => ({
+      companyId: "00000000-0000-0000-0000-000000000002",
+      boardCount: 1,
+      warnings: ["slug_conflict"],
+    })) as ApplyCatalog;
+    const { POST } = await loadRoute();
+    const res = await POST(webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-G" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.data.applied).toBe(true);
+    expect(body.data.warnings).toEqual(["slug_conflict"]);
+  });
+
+  it("never returns a 5xx for a typed lib failure", async () => {
+    // Belt-and-suspenders: combination of probe failure + catalog throw
+    // should still resolve to a 200 envelope.
+    RerunHolder.current = (async () => ({
+      status: "failed",
+      errors: ["monitor_run_failed"],
+    })) as RerunProbes;
+    const { POST } = await loadRoute();
+    const res = await POST(webhookRequest(VALID_FINAL_OUTPUT, { runId: "run-H" }));
+    expect(res.status).toBeLessThan(500);
+  });
+});

--- a/apps/web/app/api/murmur/__tests__/catalog.test.ts
+++ b/apps/web/app/api/murmur/__tests__/catalog.test.ts
@@ -1,0 +1,478 @@
+/**
+ * Unit tests for `defaultApplyCatalog` (the Postgres + CSV branches of
+ * `apps/web/app/api/murmur/_lib/catalog.ts`).
+ *
+ * Background:
+ *   The route-level tests in `accept.test.ts` stub `ApplyCatalogHolder
+ *   .current` outright, which means the production `defaultApplyCatalog`
+ *   never runs there. This file fills that gap. It exercises the
+ *   transactional ledger-first ordering, slug / board_url conflict
+ *   handling, the CSV branch's append + ledger-CSV write, and the
+ *   `CatalogIdempotencyConflict` race path.
+ *
+ * Strategy:
+ *   - **Postgres branch:** mock `@/db`, `@/db/schema`, and `drizzle-orm`
+ *     with an in-memory store that respects UNIQUE on `run_id`,
+ *     `company.slug`, and `job_board.board_url`. The mock follows the
+ *     same pattern as `apps/web/src/lib/murmur/claim-kv.test.ts`.
+ *   - **CSV branch:** drive against `os.tmpdir()` and read the appended
+ *     rows + the `murmur_accept_log.csv` sidecar.
+ *
+ * @see colophon-group/jobseek#2763
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+
+// ── Postgres branch ────────────────────────────────────────────────
+
+interface CompanyRow {
+  id: string;
+  name: string;
+  slug: string;
+  website: string;
+  description: string;
+  extras: unknown;
+}
+interface JobBoardRow {
+  id: string;
+  companyId: string;
+  boardSlug: string;
+  boardUrl: string;
+  crawlerType: string;
+  metadata: unknown;
+}
+interface LedgerRow {
+  runId: string;
+  bodySha256: string;
+  companyId: string | null;
+  boardCount: number;
+  target: string;
+}
+
+interface MockState {
+  companies: Map<string, CompanyRow>; // keyed by slug
+  boards: Map<string, JobBoardRow>; // keyed by board_url
+  ledger: Map<string, LedgerRow>; // keyed by run_id
+  nextCompanyId: number;
+  nextBoardId: number;
+  /** When set, the next ledger insert pretends a UNIQUE-conflict raced. */
+  forceLedgerConflict: boolean;
+}
+
+const state: MockState = {
+  companies: new Map(),
+  boards: new Map(),
+  ledger: new Map(),
+  nextCompanyId: 1,
+  nextBoardId: 1,
+  forceLedgerConflict: false,
+};
+
+function newCompanyId(): string {
+  const n = state.nextCompanyId++;
+  return `00000000-0000-0000-0000-${n.toString(16).padStart(12, "0")}`;
+}
+function newBoardId(): string {
+  const n = state.nextBoardId++;
+  return `00000000-0000-0000-0000-board-${n}`.slice(0, 36);
+}
+
+vi.mock("@/db", () => {
+  // Each chain returns a thenable so `await tx.insert(...).values(...).
+  // onConflictDoNothing({...}).returning({...})` resolves to the inserted
+  // rows array. We model JUST the calls catalog.ts makes — anything
+  // else throws so silent drift is caught.
+  type ColumnRef = { _table: string; _column: string };
+  type EqNode = { _col: ColumnRef; _val: unknown };
+
+  function isLedgerCol(c: ColumnRef): boolean {
+    return c._table === "murmur_accept_log";
+  }
+  function isCompanyCol(c: ColumnRef): boolean {
+    return c._table === "company";
+  }
+
+  function buildTx() {
+    const tx = {
+      insert: (table: { _name: string }) => {
+        return {
+          values: (vals: Record<string, unknown>) => {
+            const onConflictDoNothing = (_target?: unknown) => {
+              const returning = (_shape: unknown) => {
+                // Apply the insert depending on table.
+                if (table._name === "murmur_accept_log") {
+                  if (state.forceLedgerConflict) {
+                    state.forceLedgerConflict = false;
+                    return Promise.resolve([]);
+                  }
+                  if (state.ledger.has(vals.runId as string)) {
+                    return Promise.resolve([]);
+                  }
+                  state.ledger.set(vals.runId as string, {
+                    runId: vals.runId as string,
+                    bodySha256: vals.bodySha256 as string,
+                    companyId: (vals.companyId as string | null) ?? null,
+                    boardCount: (vals.boardCount as number) ?? 0,
+                    target: vals.target as string,
+                  });
+                  return Promise.resolve([{ runId: vals.runId as string }]);
+                }
+                if (table._name === "company") {
+                  if (state.companies.has(vals.slug as string)) {
+                    return Promise.resolve([]);
+                  }
+                  const id = newCompanyId();
+                  state.companies.set(vals.slug as string, {
+                    id,
+                    name: vals.name as string,
+                    slug: vals.slug as string,
+                    website: vals.website as string,
+                    description: vals.description as string,
+                    extras: vals.extras,
+                  });
+                  return Promise.resolve([{ id }]);
+                }
+                if (table._name === "job_board") {
+                  if (state.boards.has(vals.boardUrl as string)) {
+                    return Promise.resolve([]);
+                  }
+                  const id = newBoardId();
+                  state.boards.set(vals.boardUrl as string, {
+                    id,
+                    companyId: vals.companyId as string,
+                    boardSlug: vals.boardSlug as string,
+                    boardUrl: vals.boardUrl as string,
+                    crawlerType: vals.crawlerType as string,
+                    metadata: vals.metadata,
+                  });
+                  return Promise.resolve([{ id }]);
+                }
+                throw new Error(`unsupported insert into ${table._name}`);
+              };
+              return { returning };
+            };
+            return { onConflictDoNothing };
+          },
+        };
+      },
+      select: (_shape: unknown) => ({
+        from: (table: { _name: string }) => ({
+          where: (cond: EqNode) => ({
+            limit: (_n: number) => {
+              if (
+                table._name === "company" &&
+                cond._col._column === "slug"
+              ) {
+                const row = state.companies.get(cond._val as string);
+                return Promise.resolve(row ? [{ id: row.id }] : []);
+              }
+              throw new Error(
+                `unsupported select from ${table._name} on ${cond._col._column}`,
+              );
+            },
+          }),
+        }),
+      }),
+      update: (table: { _name: string }) => ({
+        set: (sets: Record<string, unknown>) => ({
+          where: (cond: EqNode) => {
+            if (
+              table._name === "murmur_accept_log" &&
+              cond._col._column === "run_id"
+            ) {
+              const row = state.ledger.get(cond._val as string);
+              if (row) {
+                state.ledger.set(cond._val as string, {
+                  ...row,
+                  companyId: (sets.companyId as string | null) ?? row.companyId,
+                  boardCount: (sets.boardCount as number) ?? row.boardCount,
+                });
+              }
+              return Promise.resolve();
+            }
+            throw new Error(
+              `unsupported update on ${table._name} / ${cond._col._column}`,
+            );
+          },
+        }),
+      }),
+    };
+    // Type-assert to cover the columns referenced via `.target` in the
+    // production code. The mock ignores them — we just need a noop.
+    void isLedgerCol;
+    void isCompanyCol;
+    return tx;
+  }
+
+  const db = {
+    transaction: async <T>(fn: (tx: ReturnType<typeof buildTx>) => Promise<T>): Promise<T> => {
+      return fn(buildTx());
+    },
+  };
+  return { db };
+});
+
+vi.mock("@/db/schema", () => {
+  // Each schema export is referenced both as a "table" (for
+  // `tx.insert(...)`) and as a column dictionary (for
+  // `tx.update(...).where(eq(murmurAcceptLog.runId, ...))`). We give
+  // each table a `_name` and each column a `_table` + `_column`.
+  const col = (table: string, column: string) => ({
+    _table: table,
+    _column: column,
+  });
+
+  const company = {
+    _name: "company",
+    id: col("company", "id"),
+    slug: col("company", "slug"),
+  };
+  const jobBoard = {
+    _name: "job_board",
+    id: col("job_board", "id"),
+    boardUrl: col("job_board", "board_url"),
+  };
+  const murmurAcceptLog = {
+    _name: "murmur_accept_log",
+    runId: col("murmur_accept_log", "run_id"),
+  };
+  return { company, jobBoard, murmurAcceptLog };
+});
+
+vi.mock("drizzle-orm", () => {
+  const eq = (
+    col: { _table: string; _column: string },
+    val: unknown,
+  ) => ({ _col: col, _val: val });
+  return { eq };
+});
+
+// Now import the module under test (after mocks are registered).
+import { defaultApplyCatalog, CatalogIdempotencyConflict } from "../_lib/catalog";
+import type { FinalOutput } from "../_lib/accept-schema";
+
+const FINAL_OUTPUT: FinalOutput = {
+  canonical_name: "Acme Co",
+  canonical_website: "https://acme.example.com",
+  slug: "acme",
+  description: "Test company.",
+  industry_ids: ["software"],
+  boards: [
+    {
+      alias: "global",
+      board_url: "https://job-boards.greenhouse.io/acme",
+      provider: "greenhouse",
+      outcome: "configured",
+      monitor_type: "greenhouse",
+      monitor_config: { token: "acme" },
+      scraper_type: "skip",
+      scraper_config: {},
+      verdict: "ok",
+    },
+  ],
+};
+
+beforeEach(() => {
+  state.companies.clear();
+  state.boards.clear();
+  state.ledger.clear();
+  state.nextCompanyId = 1;
+  state.nextBoardId = 1;
+  state.forceLedgerConflict = false;
+});
+
+describe("defaultApplyCatalog (Postgres)", () => {
+  it("writes ledger + company + boards in one transaction", async () => {
+    const result = await defaultApplyCatalog("postgres", FINAL_OUTPUT, {
+      runId: "run-pg-1",
+      bodyHash: "hash-pg-1",
+    });
+    expect(result.companyId).toBeTruthy();
+    expect(result.boardCount).toBe(1);
+    expect(result.warnings).toEqual([]);
+
+    const ledgerRow = state.ledger.get("run-pg-1");
+    expect(ledgerRow).toBeTruthy();
+    expect(ledgerRow?.bodySha256).toBe("hash-pg-1");
+    expect(ledgerRow?.target).toBe("postgres");
+    // Backfilled after company + board inserts:
+    expect(ledgerRow?.companyId).toBe(result.companyId);
+    expect(ledgerRow?.boardCount).toBe(1);
+
+    expect(state.companies.get("acme")?.name).toBe("Acme Co");
+    expect(
+      state.boards.get("https://job-boards.greenhouse.io/acme")?.boardSlug,
+    ).toBe("acme-greenhouse");
+  });
+
+  it("slug conflict: existing company wins, slug_conflict warning recorded", async () => {
+    // Pre-seed an existing company at the same slug.
+    state.companies.set("acme", {
+      id: "00000000-0000-0000-0000-existing0001",
+      name: "Pre-existing Acme",
+      slug: "acme",
+      website: "https://acme.example.com",
+      description: "older",
+      extras: {},
+    });
+    const result = await defaultApplyCatalog("postgres", FINAL_OUTPUT, {
+      runId: "run-pg-2",
+      bodyHash: "hash-pg-2",
+    });
+    expect(result.companyId).toBe("00000000-0000-0000-0000-existing0001");
+    expect(result.warnings).toContain("slug_conflict");
+  });
+
+  it("board_url conflict: existing board wins, warning per alias recorded", async () => {
+    state.boards.set("https://job-boards.greenhouse.io/acme", {
+      id: "00000000-0000-0000-0000-existingBd1",
+      companyId: "00000000-0000-0000-0000-existing0002",
+      boardSlug: "acme-greenhouse",
+      boardUrl: "https://job-boards.greenhouse.io/acme",
+      crawlerType: "greenhouse",
+      metadata: {},
+    });
+    const result = await defaultApplyCatalog("postgres", FINAL_OUTPUT, {
+      runId: "run-pg-3",
+      bodyHash: "hash-pg-3",
+    });
+    expect(result.warnings).toContain("board_url_conflict:global");
+  });
+
+  it("CatalogIdempotencyConflict when ledger UNIQUE-races (returning() === [])", async () => {
+    state.forceLedgerConflict = true;
+    await expect(
+      defaultApplyCatalog("postgres", FINAL_OUTPUT, {
+        runId: "run-pg-race",
+        bodyHash: "hash-pg-race",
+      }),
+    ).rejects.toBeInstanceOf(CatalogIdempotencyConflict);
+    // No catalog rows written.
+    expect(state.companies.size).toBe(0);
+    expect(state.boards.size).toBe(0);
+    // No ledger row written either (the empty `returning()` short-
+    // circuits before company / board inserts).
+    expect(state.ledger.size).toBe(0);
+  });
+
+  it("UNIQUE constraint on (run_id): second apply with same run_id throws CatalogIdempotencyConflict", async () => {
+    // First apply lands cleanly.
+    const r1 = await defaultApplyCatalog("postgres", FINAL_OUTPUT, {
+      runId: "run-pg-unique",
+      bodyHash: "hash-pg-unique",
+    });
+    expect(r1.companyId).toBeTruthy();
+    expect(state.ledger.size).toBe(1);
+
+    // Second apply with the same run_id — the in-memory store's UNIQUE
+    // semantics return [] from the ledger insert, which `applyPostgres`
+    // upgrades to CatalogIdempotencyConflict.
+    await expect(
+      defaultApplyCatalog("postgres", FINAL_OUTPUT, {
+        runId: "run-pg-unique",
+        bodyHash: "hash-pg-unique-2",
+      }),
+    ).rejects.toBeInstanceOf(CatalogIdempotencyConflict);
+    // Ledger size unchanged.
+    expect(state.ledger.size).toBe(1);
+  });
+});
+
+// ── CSV branch ─────────────────────────────────────────────────────
+
+describe("defaultApplyCatalog (CSV)", () => {
+  let tmpDir: string;
+  let prevEnv: string | undefined;
+  let prevTarget: string | undefined;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "murmur-csv-"));
+    prevEnv = process.env.MURMUR_ACCEPT_CSV_DIR;
+    prevTarget = process.env.MURMUR_ACCEPT_TARGET;
+    process.env.MURMUR_ACCEPT_CSV_DIR = tmpDir;
+    process.env.MURMUR_ACCEPT_TARGET = "csv";
+  });
+
+  afterEach(async () => {
+    if (prevEnv === undefined) delete process.env.MURMUR_ACCEPT_CSV_DIR;
+    else process.env.MURMUR_ACCEPT_CSV_DIR = prevEnv;
+    if (prevTarget === undefined) delete process.env.MURMUR_ACCEPT_TARGET;
+    else process.env.MURMUR_ACCEPT_TARGET = prevTarget;
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("appends company + board rows and writes the durable ledger CSV", async () => {
+    const result = await defaultApplyCatalog("csv", FINAL_OUTPUT, {
+      runId: "run-csv-1",
+      bodyHash: "hash-csv-1",
+    });
+    expect(result.companyId).toBeNull();
+    expect(result.boardCount).toBe(1);
+    expect(result.warnings).toEqual([]);
+
+    const companies = await fs.readFile(
+      path.join(tmpDir, "companies.csv"),
+      "utf8",
+    );
+    expect(companies).toMatch(/^acme,Acme Co,https:\/\/acme\.example\.com,/);
+
+    const boards = await fs.readFile(
+      path.join(tmpDir, "boards.csv"),
+      "utf8",
+    );
+    expect(boards).toMatch(/acme,acme-greenhouse,https:\/\/job-boards/);
+
+    // Durable ledger sidecar is the cold-start idempotency guard.
+    const ledger = await fs.readFile(
+      path.join(tmpDir, "murmur_accept_log.csv"),
+      "utf8",
+    );
+    expect(ledger).toMatch(/^run-csv-1,hash-csv-1,csv,/);
+  });
+
+  it("cold-start replay (CSV): second apply with same run_id throws CatalogIdempotencyConflict", async () => {
+    // First apply lands. Writes companies.csv, boards.csv, ledger CSV.
+    await defaultApplyCatalog("csv", FINAL_OUTPUT, {
+      runId: "run-csv-replay",
+      bodyHash: "hash-csv-replay",
+    });
+    const companiesBefore = await fs.readFile(
+      path.join(tmpDir, "companies.csv"),
+      "utf8",
+    );
+
+    // Simulate a process restart — no in-memory state is kept by the
+    // catalog module, but the durable CSV ledger remains. The second
+    // call must surface CatalogIdempotencyConflict before appending
+    // duplicate rows.
+    await expect(
+      defaultApplyCatalog("csv", FINAL_OUTPUT, {
+        runId: "run-csv-replay",
+        bodyHash: "hash-csv-replay",
+      }),
+    ).rejects.toBeInstanceOf(CatalogIdempotencyConflict);
+
+    const companiesAfter = await fs.readFile(
+      path.join(tmpDir, "companies.csv"),
+      "utf8",
+    );
+    // No duplicate row was appended.
+    expect(companiesAfter).toBe(companiesBefore);
+  });
+
+  it("cold-start body_mismatch (CSV): different hash for same run_id throws CatalogIdempotencyConflict", async () => {
+    await defaultApplyCatalog("csv", FINAL_OUTPUT, {
+      runId: "run-csv-mismatch",
+      bodyHash: "hash-csv-A",
+    });
+    await expect(
+      defaultApplyCatalog("csv", FINAL_OUTPUT, {
+        runId: "run-csv-mismatch",
+        bodyHash: "hash-csv-B",
+      }),
+    ).rejects.toBeInstanceOf(CatalogIdempotencyConflict);
+  });
+});

--- a/apps/web/app/api/murmur/__tests__/idempotency.test.ts
+++ b/apps/web/app/api/murmur/__tests__/idempotency.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Unit tests for the canonical-JSON hash + idempotency helpers.
+ *
+ * @see colophon-group/jobseek#2763
+ */
+
+import { describe, it, expect } from "vitest";
+
+import {
+  canonicalizeJson,
+  sha256Canonical,
+} from "../_lib/idempotency";
+
+describe("canonicalizeJson", () => {
+  it("returns the same string regardless of object key order", () => {
+    const a = canonicalizeJson({ a: 1, b: 2 });
+    const b = canonicalizeJson({ b: 2, a: 1 });
+    expect(a).toBe(b);
+  });
+
+  it("normalises whitespace + key order recursively", () => {
+    const a = canonicalizeJson({
+      slug: "acme",
+      boards: [{ alias: "global", board_url: "x" }],
+    });
+    const b = canonicalizeJson({
+      boards: [{ board_url: "x", alias: "global" }],
+      slug: "acme",
+    });
+    expect(a).toBe(b);
+  });
+
+  it("differentiates whitespace inside string values", () => {
+    expect(canonicalizeJson({ x: "a" })).not.toBe(
+      canonicalizeJson({ x: "a " }),
+    );
+  });
+
+  it("preserves array order (arrays are NOT sorted)", () => {
+    expect(canonicalizeJson([1, 2])).not.toBe(canonicalizeJson([2, 1]));
+  });
+
+  it("handles primitives", () => {
+    expect(canonicalizeJson(null)).toBe(canonicalizeJson(null));
+    expect(canonicalizeJson(true)).toBe("true");
+    expect(canonicalizeJson(123)).toBe("123");
+    expect(canonicalizeJson("abc")).toBe('"abc"');
+  });
+});
+
+describe("sha256Canonical", () => {
+  it("produces a 64-char lowercase hex string", () => {
+    const h = sha256Canonical({ a: 1 });
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("is stable for equivalent inputs", () => {
+    expect(sha256Canonical({ a: 1, b: 2 })).toBe(
+      sha256Canonical({ b: 2, a: 1 }),
+    );
+  });
+
+  it("differs when content differs", () => {
+    expect(sha256Canonical({ a: 1 })).not.toBe(sha256Canonical({ a: 2 }));
+  });
+});

--- a/apps/web/app/api/murmur/__tests__/rerun-probes.test.ts
+++ b/apps/web/app/api/murmur/__tests__/rerun-probes.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for `defaultRerunProbes` — the per-board fan-out + race +
+ * error aggregation in `apps/web/app/api/murmur/_lib/accept-pipeline.ts`.
+ *
+ * Background:
+ *   `accept.test.ts` stubs `RerunHolder.current` outright, so the real
+ *   `defaultRerunProbes` (the Promise.race / per-board fan-out / error
+ *   aggregation) never runs in that suite. This file fills the gap by
+ *   driving the real implementation against a stubbed `InvokerHolder`.
+ *
+ * @see colophon-group/jobseek#2763
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+import { defaultRerunProbes } from "../_lib/accept-pipeline";
+import { InvokerHolder, type LibInvoker } from "../_lib/invoke-lib";
+import type { FinalOutput } from "../_lib/accept-schema";
+
+const TWO_BOARD_BODY: FinalOutput = {
+  canonical_name: "Acme",
+  canonical_website: "https://acme.example.com",
+  slug: "acme",
+  description: "Acme.",
+  industry_ids: ["software"],
+  boards: [
+    {
+      alias: "global",
+      board_url: "https://job-boards.greenhouse.io/acme",
+      provider: "greenhouse",
+      outcome: "configured",
+      monitor_type: "greenhouse",
+      monitor_config: { token: "acme" },
+      scraper_type: "skip",
+      scraper_config: {},
+      verdict: "ok",
+    },
+    {
+      alias: "eu",
+      board_url: "https://jobs.lever.co/acme-eu",
+      provider: "lever",
+      outcome: "configured",
+      monitor_type: "lever",
+      monitor_config: { site: "acme-eu" },
+      scraper_type: "skip",
+      scraper_config: {},
+      verdict: "ok",
+    },
+  ],
+};
+
+let originalInvoker: LibInvoker;
+let originalTimeout: string | undefined;
+
+beforeEach(() => {
+  originalInvoker = InvokerHolder.current;
+  originalTimeout = process.env.MURMUR_ACCEPT_PROBE_TIMEOUT_MS;
+});
+
+afterEach(() => {
+  InvokerHolder.current = originalInvoker;
+  if (originalTimeout === undefined) {
+    delete process.env.MURMUR_ACCEPT_PROBE_TIMEOUT_MS;
+  } else {
+    process.env.MURMUR_ACCEPT_PROBE_TIMEOUT_MS = originalTimeout;
+  }
+});
+
+describe("defaultRerunProbes", () => {
+  it("returns ok when every board's invokeLib resolves ok:true", async () => {
+    const seen: string[] = [];
+    InvokerHolder.current = (async (subcommand, body) => {
+      expect(subcommand).toBe("probe_monitor");
+      seen.push((body as { board_url: string }).board_url);
+      return { ok: true, data: {} };
+    }) as LibInvoker;
+
+    const result = await defaultRerunProbes(TWO_BOARD_BODY);
+    expect(result).toEqual({ status: "ok" });
+    // Each board should have been probed exactly once, in parallel.
+    expect(seen.sort()).toEqual([
+      "https://job-boards.greenhouse.io/acme",
+      "https://jobs.lever.co/acme-eu",
+    ]);
+  });
+
+  it("aggregates per-board failures with `<token>:<alias>` formatting", async () => {
+    InvokerHolder.current = (async (_sub, body) => {
+      const url = (body as { board_url: string }).board_url;
+      if (url.includes("greenhouse")) {
+        return { ok: false, errors: ["probe_failed"] };
+      }
+      return { ok: false, errors: ["timeout", "internal_error"] };
+    }) as LibInvoker;
+
+    const result = await defaultRerunProbes(TWO_BOARD_BODY);
+    expect(result.status).toBe("failed");
+    if (result.status !== "failed") return; // narrow for TS
+    // Two boards; greenhouse contributes 1 error, lever contributes 2.
+    expect([...result.errors].sort()).toEqual(
+      [
+        "internal_error:eu",
+        "probe_failed:global",
+        "timeout:eu",
+      ].sort(),
+    );
+  });
+
+  it("falls back to `probe_failed:<alias>` when the lib returns no errors array", async () => {
+    InvokerHolder.current = (async () => ({ ok: false })) as LibInvoker;
+
+    const result = await defaultRerunProbes(TWO_BOARD_BODY);
+    expect(result.status).toBe("failed");
+    if (result.status !== "failed") return;
+    expect([...result.errors].sort()).toEqual(
+      ["probe_failed:eu", "probe_failed:global"].sort(),
+    );
+  });
+
+  it("reports timeout when the budget elapses before the fan-out completes", async () => {
+    process.env.MURMUR_ACCEPT_PROBE_TIMEOUT_MS = "5";
+    InvokerHolder.current = (async () => {
+      // Sleep longer than the budget so the racing promise loses.
+      await new Promise((r) => setTimeout(r, 100));
+      return { ok: true };
+    }) as LibInvoker;
+
+    const result = await defaultRerunProbes(TWO_BOARD_BODY);
+    expect(result).toEqual({ status: "timeout" });
+  });
+
+  it("ignores invalid MURMUR_ACCEPT_PROBE_TIMEOUT_MS and falls back to default", async () => {
+    process.env.MURMUR_ACCEPT_PROBE_TIMEOUT_MS = "not-a-number";
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    InvokerHolder.current = (async () => ({ ok: true })) as LibInvoker;
+
+    const result = await defaultRerunProbes(TWO_BOARD_BODY);
+    expect(result).toEqual({ status: "ok" });
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("ignores zero / negative MURMUR_ACCEPT_PROBE_TIMEOUT_MS and falls back to default", async () => {
+    process.env.MURMUR_ACCEPT_PROBE_TIMEOUT_MS = "0";
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+
+    InvokerHolder.current = (async () => ({ ok: true })) as LibInvoker;
+    const result = await defaultRerunProbes(TWO_BOARD_BODY);
+    expect(result).toEqual({ status: "ok" });
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/apps/web/app/api/murmur/_lib/accept-pipeline.ts
+++ b/apps/web/app/api/murmur/_lib/accept-pipeline.ts
@@ -14,12 +14,13 @@
  *   5. `applyCatalog`        — write to Postgres or CSV.
  *
  * The route handler glues these together and translates outcomes into
- * the M0 envelope. This file lays out the contracts only — no bodies.
+ * the M0 envelope.
  *
  * @see colophon-group/jobseek#2763
  */
 
 import type { FinalOutput } from "./accept-schema";
+import { invokeLib } from "./invoke-lib";
 
 /** Outcome of `parseAndCapBody`. */
 export type ParseBodyResult =
@@ -35,12 +36,35 @@ export const MAX_BODY_BYTES = 5 * 1024 * 1024;
  * more than 5 MB and again if the post-read buffer exceeds the cap
  * (defends against missing / lying `Content-Length`). Parses the
  * resulting buffer as JSON; returns `invalid_json` on any parse error.
- *
- * Tests pass `Request` objects directly. Production routes pass the
- * incoming Next.js `Request`.
  */
-export function parseAndCapBody(_request: Request): Promise<ParseBodyResult> {
-  throw new Error("not implemented");
+export async function parseAndCapBody(
+  request: Request,
+): Promise<ParseBodyResult> {
+  const declared = request.headers.get("content-length");
+  if (declared !== null) {
+    const n = Number(declared);
+    if (Number.isFinite(n) && n > MAX_BODY_BYTES) {
+      return { status: "too_large" };
+    }
+  }
+  // Read the buffer ourselves so we can enforce the cap regardless of
+  // what Content-Length claimed (or didn't claim).
+  let raw: string;
+  try {
+    raw = await request.text();
+  } catch {
+    return { status: "invalid_json" };
+  }
+  if (Buffer.byteLength(raw, "utf8") > MAX_BODY_BYTES) {
+    return { status: "too_large" };
+  }
+  let body: unknown;
+  try {
+    body = JSON.parse(raw);
+  } catch {
+    return { status: "invalid_json" };
+  }
+  return { status: "ok", raw, body };
 }
 
 /** Outcome of the probe re-run. */
@@ -52,30 +76,64 @@ export type RerunProbesResult =
 /**
  * Re-run probe + run for every board in the validated `final_output`.
  *
- * Implementation strategy:
+ * Strategy:
  *   - For each board, call `invokeLib("probe_monitor", { board_url })`
- *     and (when `monitor_type` is non-`"skip"`) `invokeLib("run_monitor",
- *     { board_url })`. The same for the scraper.
- *   - All board calls run in parallel; the function resolves when the
- *     last one finishes OR when the overall 30s wallclock timer fires,
- *     whichever comes first.
- *   - Any per-board lib failure aggregates into the returned
- *     `errors: [...]` list with the format `probe_failed:<board_alias>`
- *     so the operator can identify which board went bad.
- *   - On wallclock-timeout the function returns `{ status: "timeout" }`;
- *     the route maps this to HTTP 504 with `errors: ["probe_timeout"]`.
+ *     in parallel. We rely on the shim's typed-error envelope to
+ *     surface failures.
+ *   - All board calls run in parallel; a wallclock timer races against
+ *     the aggregate.
+ *   - Per-board lib failure aggregates into `errors: ["<token>:<alias>"]`.
  *
  * The 30s budget is governed by `MURMUR_ACCEPT_PROBE_TIMEOUT_MS`
  * (defaults to 30000) so tests can shrink it.
- *
- * Tests stub this function via `RerunHolder.current` (mirrors the
- * `InvokerHolder` pattern from J5).
  */
 export type RerunProbes = (body: FinalOutput) => Promise<RerunProbesResult>;
 
-/** Default implementation — wraps `invokeLib` with the 30s budget. */
-export const defaultRerunProbes: RerunProbes = async () => {
-  throw new Error("not implemented");
+const ACCEPT_TIMEOUT_ENV = "MURMUR_ACCEPT_PROBE_TIMEOUT_MS";
+
+export const defaultRerunProbes: RerunProbes = async (body) => {
+  const timeoutMs = Number(process.env[ACCEPT_TIMEOUT_ENV] ?? 30000);
+
+  const racing = (async () => {
+    const probeResults = await Promise.all(
+      body.boards.map(async (board) => {
+        const result = await invokeLib(
+          "probe_monitor",
+          { board_url: board.board_url },
+          /* claim_token */ "",
+        );
+        return { board, result };
+      }),
+    );
+    const errors: string[] = [];
+    for (const { board, result } of probeResults) {
+      if (!result.ok) {
+        const tokens = result.errors ?? ["probe_failed"];
+        for (const t of tokens) {
+          errors.push(`${t}:${board.alias}`);
+        }
+      }
+    }
+    return errors;
+  })();
+
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<"timeout">((resolve) => {
+    timeoutHandle = setTimeout(() => resolve("timeout"), timeoutMs);
+  });
+
+  try {
+    const winner = await Promise.race([racing, timeout]);
+    if (winner === "timeout") {
+      return { status: "timeout" };
+    }
+    if ((winner as string[]).length > 0) {
+      return { status: "failed", errors: winner as string[] };
+    }
+    return { status: "ok" };
+  } finally {
+    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+  }
 };
 
 /** Mutable holder for tests to override. */

--- a/apps/web/app/api/murmur/_lib/accept-pipeline.ts
+++ b/apps/web/app/api/murmur/_lib/accept-pipeline.ts
@@ -90,9 +90,28 @@ export type RerunProbesResult =
 export type RerunProbes = (body: FinalOutput) => Promise<RerunProbesResult>;
 
 const ACCEPT_TIMEOUT_ENV = "MURMUR_ACCEPT_PROBE_TIMEOUT_MS";
+const DEFAULT_TIMEOUT_MS = 30000;
+
+/**
+ * Parse a positive-integer milliseconds value from env. Falls back to
+ * the default on missing / non-numeric / non-positive input. Logs a
+ * warning so misconfiguration is visible without crashing the route.
+ */
+function resolveTimeoutMs(): number {
+  const raw = process.env[ACCEPT_TIMEOUT_ENV];
+  if (raw === undefined || raw.trim() === "") return DEFAULT_TIMEOUT_MS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    console.warn(
+      `[murmur accept] ignoring invalid ${ACCEPT_TIMEOUT_ENV}=${raw}; using default ${DEFAULT_TIMEOUT_MS}ms`,
+    );
+    return DEFAULT_TIMEOUT_MS;
+  }
+  return n;
+}
 
 export const defaultRerunProbes: RerunProbes = async (body) => {
-  const timeoutMs = Number(process.env[ACCEPT_TIMEOUT_ENV] ?? 30000);
+  const timeoutMs = resolveTimeoutMs();
 
   const racing = (async () => {
     const probeResults = await Promise.all(

--- a/apps/web/app/api/murmur/_lib/accept-pipeline.ts
+++ b/apps/web/app/api/murmur/_lib/accept-pipeline.ts
@@ -1,0 +1,89 @@
+/**
+ * Orchestration helpers for `POST /api/murmur/accept`.
+ *
+ * The route is laid out as a small pipeline of pure-ish steps so each
+ * step can be exercised in isolation:
+ *
+ *   1. `parseAndCapBody`     — read the body honouring the 5 MB cap.
+ *   2. `validateAcceptBody`  — dialect-aware schema check.
+ *   3. `classifyIdempotency` — ledger lookup; returns fresh / already /
+ *                               body_mismatch.
+ *   4. `rerunProbes`         — defense-in-depth re-run of probe/run
+ *                               via J5's `invokeLib`. Wrapped in a 30s
+ *                               wallclock budget.
+ *   5. `applyCatalog`        — write to Postgres or CSV.
+ *
+ * The route handler glues these together and translates outcomes into
+ * the M0 envelope. This file lays out the contracts only — no bodies.
+ *
+ * @see colophon-group/jobseek#2763
+ */
+
+import type { FinalOutput } from "./accept-schema";
+
+/** Outcome of `parseAndCapBody`. */
+export type ParseBodyResult =
+  | { readonly status: "ok"; readonly raw: string; readonly body: unknown }
+  | { readonly status: "too_large" }
+  | { readonly status: "invalid_json" };
+
+/** Maximum webhook body size, in bytes. Murmur DESIGN.md §4.1: 5 MB. */
+export const MAX_BODY_BYTES = 5 * 1024 * 1024;
+
+/**
+ * Read the body off the Request, refusing if `Content-Length` declares
+ * more than 5 MB and again if the post-read buffer exceeds the cap
+ * (defends against missing / lying `Content-Length`). Parses the
+ * resulting buffer as JSON; returns `invalid_json` on any parse error.
+ *
+ * Tests pass `Request` objects directly. Production routes pass the
+ * incoming Next.js `Request`.
+ */
+export function parseAndCapBody(_request: Request): Promise<ParseBodyResult> {
+  throw new Error("not implemented");
+}
+
+/** Outcome of the probe re-run. */
+export type RerunProbesResult =
+  | { readonly status: "ok" }
+  | { readonly status: "failed"; readonly errors: readonly string[] }
+  | { readonly status: "timeout" };
+
+/**
+ * Re-run probe + run for every board in the validated `final_output`.
+ *
+ * Implementation strategy:
+ *   - For each board, call `invokeLib("probe_monitor", { board_url })`
+ *     and (when `monitor_type` is non-`"skip"`) `invokeLib("run_monitor",
+ *     { board_url })`. The same for the scraper.
+ *   - All board calls run in parallel; the function resolves when the
+ *     last one finishes OR when the overall 30s wallclock timer fires,
+ *     whichever comes first.
+ *   - Any per-board lib failure aggregates into the returned
+ *     `errors: [...]` list with the format `probe_failed:<board_alias>`
+ *     so the operator can identify which board went bad.
+ *   - On wallclock-timeout the function returns `{ status: "timeout" }`;
+ *     the route maps this to HTTP 504 with `errors: ["probe_timeout"]`.
+ *
+ * The 30s budget is governed by `MURMUR_ACCEPT_PROBE_TIMEOUT_MS`
+ * (defaults to 30000) so tests can shrink it.
+ *
+ * Tests stub this function via `RerunHolder.current` (mirrors the
+ * `InvokerHolder` pattern from J5).
+ */
+export type RerunProbes = (body: FinalOutput) => Promise<RerunProbesResult>;
+
+/** Default implementation — wraps `invokeLib` with the 30s budget. */
+export const defaultRerunProbes: RerunProbes = async () => {
+  throw new Error("not implemented");
+};
+
+/** Mutable holder for tests to override. */
+export const RerunHolder: { current: RerunProbes } = {
+  current: defaultRerunProbes,
+};
+
+/** Convenience pass-through used by the route. */
+export function rerunProbes(body: FinalOutput): Promise<RerunProbesResult> {
+  return RerunHolder.current(body);
+}

--- a/apps/web/app/api/murmur/_lib/accept-schema.ts
+++ b/apps/web/app/api/murmur/_lib/accept-schema.ts
@@ -1,0 +1,167 @@
+/**
+ * Vendored schema for the `final_output` payload Murmur POSTs to
+ * `/api/murmur/accept`.
+ *
+ * Source of truth: `apps/crawler/murmur/pipelines/add-company.yaml`
+ * (`final_output.composes`). The composed shape combines fields from
+ * `pre-verify`, `list-boards.boards`, and per-board `configure-board.*`
+ * outputs into a single object the publisher's accept handler ingests.
+ *
+ * The schema dialect here is a small superset of the J5 dialect
+ * (`schemas.ts`): we keep `type: object` with required + properties,
+ * but add an `array` type with an `items` schema and `minItems`. This is
+ * the smallest extension that lets us express the boards list / kb /
+ * industry_ids without pulling in a real JSON-Schema library.
+ *
+ * @see colophon-group/jobseek#2763
+ * @see Murmur DESIGN.md §4.1 (Webhook accept-handler contract)
+ */
+
+/** Per-board entry composed from `list-boards × configure-board.*`. */
+export interface FinalOutputBoard {
+  readonly alias: string;
+  readonly board_url: string;
+  readonly provider: string;
+  readonly hreflang?: string;
+  readonly outcome: "configured" | "blocked";
+  readonly monitor_type: string;
+  readonly monitor_config: Record<string, unknown>;
+  readonly scraper_type: string;
+  readonly scraper_config: Record<string, unknown>;
+  readonly verdict: "ok" | "needs-work" | "rejected";
+  readonly per_field?: Record<string, unknown>;
+}
+
+/** Full composed `final_output` payload the webhook receives. */
+export interface FinalOutput {
+  readonly canonical_name: string;
+  readonly canonical_website: string;
+  readonly slug: string;
+  readonly description: string;
+  readonly industry_ids: readonly string[];
+  readonly boards: readonly FinalOutputBoard[];
+  readonly kb_entries?: readonly Record<string, unknown>[];
+  readonly case_studies?: readonly Record<string, unknown>[];
+}
+
+/**
+ * Property schema for the accept dialect. The shape mirrors the J5
+ * `SubcommandPropertySchema` and adds:
+ *   - `type: "array"` with `items` (a nested property schema) and
+ *     optional `minItems` / `maxItems`.
+ *   - `maxLength` on strings.
+ *   - inline nested object schemas under `properties.<key>` recursion.
+ *
+ * Anything outside this subset is a hard validation error in
+ * `validateAcceptBody`.
+ */
+export type AcceptPropertySchema =
+  | {
+      readonly type: "string";
+      readonly format?: "uri";
+      readonly pattern?: string;
+      readonly enum?: readonly string[];
+      readonly minLength?: number;
+      readonly maxLength?: number;
+    }
+  | {
+      readonly type: "integer" | "number";
+      readonly minimum?: number;
+    }
+  | { readonly type: "boolean" }
+  | {
+      readonly type: "object";
+      readonly additionalProperties?: boolean;
+      readonly required?: readonly string[];
+      readonly properties?: Readonly<Record<string, AcceptPropertySchema>>;
+    }
+  | {
+      readonly type: "array";
+      readonly items: AcceptPropertySchema;
+      readonly minItems?: number;
+      readonly maxItems?: number;
+    };
+
+/** Top-level object schema for an accept-shaped body. */
+export interface AcceptObjectSchema {
+  readonly type: "object";
+  readonly additionalProperties: false;
+  readonly required: readonly string[];
+  readonly properties: Readonly<Record<string, AcceptPropertySchema>>;
+}
+
+/**
+ * Schema for one entry inside `final_output.boards` — the
+ * `list-boards.boards[*]` item composed with the spawned
+ * `configure-board.*` output.
+ */
+export const FINAL_OUTPUT_BOARD_SCHEMA: AcceptObjectSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: [
+    "alias",
+    "board_url",
+    "provider",
+    "outcome",
+    "monitor_type",
+    "monitor_config",
+    "scraper_type",
+    "scraper_config",
+    "verdict",
+  ],
+  properties: {
+    alias: { type: "string", minLength: 1 },
+    board_url: { type: "string", format: "uri", pattern: "^https://" },
+    provider: { type: "string", minLength: 1 },
+    hreflang: { type: "string" },
+    outcome: { type: "string", enum: ["configured", "blocked"] },
+    monitor_type: { type: "string", minLength: 1 },
+    monitor_config: { type: "object" },
+    scraper_type: { type: "string", minLength: 1 },
+    scraper_config: { type: "object" },
+    verdict: { type: "string", enum: ["ok", "needs-work", "rejected"] },
+    per_field: { type: "object" },
+  },
+} as const;
+
+/** Top-level `final_output` schema. */
+export const FINAL_OUTPUT_SCHEMA: AcceptObjectSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: [
+    "canonical_name",
+    "canonical_website",
+    "slug",
+    "description",
+    "industry_ids",
+    "boards",
+  ],
+  properties: {
+    canonical_name: { type: "string", minLength: 1 },
+    canonical_website: {
+      type: "string",
+      format: "uri",
+      pattern: "^https://",
+    },
+    slug: { type: "string", pattern: "^[a-z][a-z0-9-]*[a-z0-9]$" },
+    description: { type: "string", minLength: 1, maxLength: 400 },
+    industry_ids: {
+      type: "array",
+      minItems: 1,
+      maxItems: 4,
+      items: { type: "string", pattern: "^[a-z][a-z0-9-]*[a-z0-9]$" },
+    },
+    boards: {
+      type: "array",
+      minItems: 1,
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: FINAL_OUTPUT_BOARD_SCHEMA.required,
+        properties: FINAL_OUTPUT_BOARD_SCHEMA.properties,
+      },
+    },
+    kb_entries: { type: "array", items: { type: "object" } },
+    case_studies: { type: "array", items: { type: "object" } },
+  },
+} as const;

--- a/apps/web/app/api/murmur/_lib/accept-validate.ts
+++ b/apps/web/app/api/murmur/_lib/accept-validate.ts
@@ -1,0 +1,53 @@
+/**
+ * Validator for the `final_output` payload against the accept dialect.
+ *
+ * Same spirit as the J5 `validateBody`: emit per-field errors as
+ * `{ path, message }` pairs with stable string tokens; never throw on a
+ * weird body. The accept dialect adds `type: "array"` and recursive
+ * object schemas, so this validator is a slight extension rather than a
+ * reuse of the J5 one.
+ *
+ * Errors are formatted by the route handler as
+ * `validation:<path>:<message>` per the M0 envelope contract — see
+ * jobseek#2763.
+ *
+ * @see colophon-group/jobseek#2763
+ */
+
+import type {
+  AcceptObjectSchema,
+  AcceptPropertySchema,
+} from "./accept-schema";
+
+export interface AcceptSchemaError {
+  readonly path: string;
+  readonly message: string;
+}
+
+/**
+ * Validate an unknown body against the top-level `final_output` schema.
+ *
+ * Returns an empty array on success and a list of per-field errors
+ * otherwise. The list is stable-ordered (object key order then
+ * recursion).
+ */
+export function validateAcceptBody(
+  _body: unknown,
+  _schema: AcceptObjectSchema,
+): AcceptSchemaError[] {
+  throw new Error("not implemented");
+}
+
+/**
+ * Recursive helper that validates `value` against a single property
+ * schema. Exported for unit-testing edge cases (deep arrays of
+ * objects).
+ */
+export function validateAcceptProperty(
+  _path: string,
+  _value: unknown,
+  _schema: AcceptPropertySchema,
+  _errors: AcceptSchemaError[],
+): void {
+  throw new Error("not implemented");
+}

--- a/apps/web/app/api/murmur/_lib/accept-validate.ts
+++ b/apps/web/app/api/murmur/_lib/accept-validate.ts
@@ -32,10 +32,37 @@ export interface AcceptSchemaError {
  * recursion).
  */
 export function validateAcceptBody(
-  _body: unknown,
-  _schema: AcceptObjectSchema,
+  body: unknown,
+  schema: AcceptObjectSchema,
 ): AcceptSchemaError[] {
-  throw new Error("not implemented");
+  const errors: AcceptSchemaError[] = [];
+  if (!isPlainObject(body)) {
+    errors.push({ path: "", message: "must_be_object" });
+    return errors;
+  }
+
+  for (const key of schema.required) {
+    if (!(key in body)) {
+      errors.push({ path: `/${key}`, message: "missing" });
+    }
+  }
+  for (const key of Object.keys(body)) {
+    if (!(key in schema.properties)) {
+      errors.push({ path: `/${key}`, message: "unknown_property" });
+    }
+  }
+  for (const [key, propSchema] of Object.entries(schema.properties)) {
+    if (!(key in body)) continue;
+    const value = (body as Record<string, unknown>)[key];
+    if (value === undefined) {
+      // Explicitly-set `undefined` is treated like missing for the
+      // required check above, but slips past `key in body`.
+      errors.push({ path: `/${key}`, message: "missing" });
+      continue;
+    }
+    validateAcceptProperty(`/${key}`, value, propSchema, errors);
+  }
+  return errors;
 }
 
 /**
@@ -44,10 +71,145 @@ export function validateAcceptBody(
  * objects).
  */
 export function validateAcceptProperty(
-  _path: string,
-  _value: unknown,
-  _schema: AcceptPropertySchema,
-  _errors: AcceptSchemaError[],
+  path: string,
+  value: unknown,
+  schema: AcceptPropertySchema,
+  errors: AcceptSchemaError[],
 ): void {
-  throw new Error("not implemented");
+  switch (schema.type) {
+    case "string": {
+      if (typeof value !== "string") {
+        errors.push({ path, message: "must_be_string" });
+        return;
+      }
+      if (
+        typeof schema.minLength === "number" &&
+        value.length < schema.minLength
+      ) {
+        errors.push({ path, message: "too_short" });
+      }
+      if (
+        typeof schema.maxLength === "number" &&
+        value.length > schema.maxLength
+      ) {
+        errors.push({ path, message: "too_long" });
+      }
+      if (schema.pattern && !new RegExp(schema.pattern).test(value)) {
+        errors.push({ path, message: "pattern_mismatch" });
+      }
+      if (schema.format === "uri") {
+        try {
+          const u = new URL(value);
+          if (!u.hostname) {
+            errors.push({ path, message: "must_be_uri" });
+          }
+        } catch {
+          errors.push({ path, message: "must_be_uri" });
+        }
+      }
+      if (schema.enum && !schema.enum.includes(value)) {
+        errors.push({ path, message: "not_in_enum" });
+      }
+      return;
+    }
+    case "integer": {
+      if (typeof value !== "number" || !Number.isInteger(value)) {
+        errors.push({ path, message: "must_be_integer" });
+        return;
+      }
+      if (typeof schema.minimum === "number" && value < schema.minimum) {
+        errors.push({ path, message: "below_minimum" });
+      }
+      return;
+    }
+    case "number": {
+      if (typeof value !== "number" || !Number.isFinite(value)) {
+        errors.push({ path, message: "must_be_number" });
+        return;
+      }
+      if (typeof schema.minimum === "number" && value < schema.minimum) {
+        errors.push({ path, message: "below_minimum" });
+      }
+      return;
+    }
+    case "boolean": {
+      if (typeof value !== "boolean") {
+        errors.push({ path, message: "must_be_boolean" });
+      }
+      return;
+    }
+    case "object": {
+      if (!isPlainObject(value)) {
+        errors.push({ path, message: "must_be_object" });
+        return;
+      }
+      // Recurse if the schema has nested `properties`.
+      if (schema.properties) {
+        const props = schema.properties;
+        const required = schema.required ?? [];
+        const additional = schema.additionalProperties;
+        for (const k of required) {
+          if (!(k in (value as Record<string, unknown>))) {
+            errors.push({ path: `${path}/${k}`, message: "missing" });
+          }
+        }
+        if (additional === false) {
+          for (const k of Object.keys(value as Record<string, unknown>)) {
+            if (!(k in props)) {
+              errors.push({
+                path: `${path}/${k}`,
+                message: "unknown_property",
+              });
+            }
+          }
+        }
+        for (const [k, sub] of Object.entries(props)) {
+          if (!(k in (value as Record<string, unknown>))) continue;
+          const nested = (value as Record<string, unknown>)[k];
+          if (nested === undefined) {
+            errors.push({ path: `${path}/${k}`, message: "missing" });
+            continue;
+          }
+          validateAcceptProperty(`${path}/${k}`, nested, sub, errors);
+        }
+      }
+      return;
+    }
+    case "array": {
+      if (!Array.isArray(value)) {
+        errors.push({ path, message: "must_be_array" });
+        return;
+      }
+      if (
+        typeof schema.minItems === "number" &&
+        value.length < schema.minItems
+      ) {
+        errors.push({ path, message: "too_short" });
+      }
+      if (
+        typeof schema.maxItems === "number" &&
+        value.length > schema.maxItems
+      ) {
+        errors.push({ path, message: "too_long" });
+      }
+      for (let i = 0; i < value.length; i++) {
+        validateAcceptProperty(`${path}/${i}`, value[i], schema.items, errors);
+      }
+      return;
+    }
+    default: {
+      // Unknown schema branch — fail closed so a YAML drift doesn't
+      // silently accept arbitrary values.
+      errors.push({ path, message: "unsupported_schema_type" });
+    }
+  }
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    !Array.isArray(v) &&
+    Object.getPrototypeOf(v) !== null
+  );
 }

--- a/apps/web/app/api/murmur/_lib/accept-validate.ts
+++ b/apps/web/app/api/murmur/_lib/accept-validate.ts
@@ -206,10 +206,11 @@ export function validateAcceptProperty(
 }
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
-  return (
-    typeof v === "object" &&
-    v !== null &&
-    !Array.isArray(v) &&
-    Object.getPrototypeOf(v) !== null
-  );
+  if (typeof v !== "object" || v === null) return false;
+  if (Array.isArray(v)) return false;
+  const proto = Object.getPrototypeOf(v);
+  // Plain objects are either `Object.prototype` (default JSON.parse
+  // output) or `null` (`Object.create(null)`). Anything else (Date,
+  // Map, custom class instance, etc.) is rejected.
+  return proto === Object.prototype || proto === null;
 }

--- a/apps/web/app/api/murmur/_lib/catalog.ts
+++ b/apps/web/app/api/murmur/_lib/catalog.ts
@@ -5,25 +5,26 @@
  * `accept-schema.ts`) and writes the company + boards to one of two
  * backends, chosen by `MURMUR_ACCEPT_TARGET`:
  *
- *   - `"postgres"` (default) — INSERT into the `company` and `job_board`
- *      tables, wrapped in the same transaction as the
- *      `murmur_accept_log` ledger row.
+ *   - `"postgres"` (default) — INSERT into `company` and `job_board`,
+ *      wrapped in the same transaction as the `murmur_accept_log`
+ *      ledger row.
  *   - `"csv"` — append rows to `apps/crawler/data/companies.csv` and
  *      `apps/crawler/data/boards.csv`. Demo / operator-side debug only;
  *      no concurrency control.
  *
  * Either backend exposes the same `applyCatalog` function; the route
  * handler doesn't know which one is active. On Postgres-side conflicts
- * (slug already exists, board_url already exists) the writer follows
- * the existing jobseek convention: the EXISTING row wins, and the
- * conflict is recorded as a `errors:` token but NOT a hard failure
- * (the run is still considered applied — the company is in the catalog).
+ * (slug exists, board_url exists) the EXISTING row wins and the
+ * conflict is recorded as a non-fatal warning.
  *
  * @see colophon-group/jobseek#2763
  * @see Murmur DESIGN.md §4.2 (Storage migration on jobseek's side)
  */
 
-import type { FinalOutput } from "./accept-schema";
+import path from "node:path";
+import fs from "node:fs/promises";
+
+import type { FinalOutput, FinalOutputBoard } from "./accept-schema";
 
 /** The two backends the handler supports. */
 export type CatalogTarget = "postgres" | "csv";
@@ -34,45 +35,9 @@ export interface ApplyCatalogResult {
   readonly companyId: string | null;
   /** Number of boards persisted (after dedupe). */
   readonly boardCount: number;
-  /**
-   * Non-fatal anomalies surfaced in the response envelope as
-   * `errors: ["catalog:<token>"]`. Examples: `slug_conflict`,
-   * `board_url_conflict`. Empty array on a clean apply.
-   */
+  /** Non-fatal anomalies. Empty on a clean apply. */
   readonly warnings: readonly string[];
 }
-
-/**
- * Resolve the active backend from the env. Defaults to `"postgres"`.
- * Unknown / empty values fall through to the default.
- */
-export function resolveCatalogTarget(): CatalogTarget {
-  throw new Error("not implemented");
-}
-
-/**
- * Apply the validated `final_output` to the active catalog backend.
- *
- * Contract:
- *   - Throws on unrecoverable I/O errors (DB unavailable, file system
- *     unwriteable). The route handler catches and maps to
- *     `errors: ["catalog_write_failed"]` per the M0 envelope.
- *   - Returns the structured result on success — including non-fatal
- *     warnings the handler should surface.
- *   - When `target === "postgres"`, the implementation is responsible
- *     for opening a transaction that also writes the
- *     `murmur_accept_log` row via the supplied `ledgerWriter`. This
- *     keeps the catalog write and the idempotency-ledger update
- *     atomic.
- *
- * Tests inject a stub that bypasses the DB / FS entirely. The route
- * handler in production passes `defaultApplyCatalog`.
- */
-export type ApplyCatalog = (
-  target: CatalogTarget,
-  body: FinalOutput,
-  context: ApplyCatalogContext,
-) => Promise<ApplyCatalogResult>;
 
 /** Side-channel data the catalog writer needs to record the ledger row. */
 export interface ApplyCatalogContext {
@@ -80,9 +45,47 @@ export interface ApplyCatalogContext {
   readonly bodyHash: string;
 }
 
-/** Production implementation. Defined in `catalog-default.ts`. */
-export const defaultApplyCatalog: ApplyCatalog = async () => {
-  throw new Error("not implemented");
+const TARGET_ENV = "MURMUR_ACCEPT_TARGET" as const;
+
+/**
+ * Resolve the active backend from the env. Defaults to `"postgres"`.
+ * Unknown / empty values fall through to the default.
+ */
+export function resolveCatalogTarget(): CatalogTarget {
+  const v = process.env[TARGET_ENV]?.trim().toLowerCase();
+  if (v === "csv") return "csv";
+  return "postgres";
+}
+
+export type ApplyCatalog = (
+  target: CatalogTarget,
+  body: FinalOutput,
+  context: ApplyCatalogContext,
+) => Promise<ApplyCatalogResult>;
+
+/**
+ * Production catalog writer.
+ *
+ * The Postgres branch is wrapped in a transaction that:
+ *   1. Inserts the ledger row (PRIMARY KEY on run_id). On conflict,
+ *      the function throws `CatalogIdempotencyConflict` — the route
+ *      catches that and surfaces `already_applied`.
+ *   2. Upserts the company by slug.
+ *   3. Upserts each `job_board` by board_url.
+ *   4. Backfills the ledger row with `companyId` + `boardCount`.
+ *
+ * The CSV branch appends raw rows to `apps/crawler/data/companies.csv`
+ * and `apps/crawler/data/boards.csv` in the existing column order.
+ */
+export const defaultApplyCatalog: ApplyCatalog = async (
+  target,
+  body,
+  context,
+) => {
+  if (target === "csv") {
+    return applyCsv(body, context);
+  }
+  return applyPostgres(body, context);
 };
 
 /**
@@ -101,4 +104,216 @@ export function applyCatalog(
   context: ApplyCatalogContext,
 ): Promise<ApplyCatalogResult> {
   return ApplyCatalogHolder.current(target, body, context);
+}
+
+/**
+ * Thrown by the Postgres branch if a concurrent writer beat us to the
+ * ledger row. The route catches this and surfaces `already_applied`.
+ */
+export class CatalogIdempotencyConflict extends Error {
+  constructor(public readonly runId: string) {
+    super(`catalog: concurrent insert on run_id=${runId}`);
+    this.name = "CatalogIdempotencyConflict";
+  }
+}
+
+// ── Postgres backend ──────────────────────────────────────────────
+
+async function applyPostgres(
+  body: FinalOutput,
+  context: ApplyCatalogContext,
+): Promise<ApplyCatalogResult> {
+  // The DB module lives at `@/db`, but we import lazily so unit tests
+  // (which stub `applyCatalog` outright) never construct a connection
+  // and never need DATABASE_URL.
+  const { db } = await import("@/db");
+  const { company, jobBoard, murmurAcceptLog } = await import("@/db/schema");
+  const { eq, sql } = await import("drizzle-orm");
+
+  const warnings: string[] = [];
+  let companyId: string | null = null;
+  const target: CatalogTarget = "postgres";
+
+  await db.transaction(async (tx) => {
+    // 1. Ledger row first — UNIQUE on run_id is the idempotency gate.
+    //    On conflict (concurrent first-write), throw so the route can
+    //    surface "already_applied" rather than write twice.
+    const ledgerInsert = await tx
+      .insert(murmurAcceptLog)
+      .values({
+        runId: context.runId,
+        bodySha256: context.bodyHash,
+        companyId: null,
+        boardCount: 0,
+        target,
+      })
+      .onConflictDoNothing({ target: murmurAcceptLog.runId })
+      .returning({ runId: murmurAcceptLog.runId });
+
+    if (ledgerInsert.length === 0) {
+      throw new CatalogIdempotencyConflict(context.runId);
+    }
+
+    // 2. Company upsert — INSERT, fall back to existing on slug
+    //    collision.
+    const insertedCompany = await tx
+      .insert(company)
+      .values({
+        name: body.canonical_name,
+        slug: body.slug,
+        website: body.canonical_website,
+        description: body.description,
+        extras: { industry_ids: body.industry_ids },
+      })
+      .onConflictDoNothing({ target: company.slug })
+      .returning({ id: company.id });
+
+    if (insertedCompany.length > 0 && insertedCompany[0]) {
+      companyId = insertedCompany[0].id;
+    } else {
+      const existing = await tx
+        .select({ id: company.id })
+        .from(company)
+        .where(eq(company.slug, body.slug))
+        .limit(1);
+      if (existing.length === 0 || !existing[0]) {
+        throw new Error(
+          `catalog: slug ${body.slug} insert was a no-op but no existing row found`,
+        );
+      }
+      companyId = existing[0].id;
+      warnings.push("slug_conflict");
+    }
+
+    // 3. Boards — one per entry, dedupe by board_url.
+    let written = 0;
+    for (const b of body.boards) {
+      const insertedBoard = await tx
+        .insert(jobBoard)
+        .values({
+          companyId,
+          boardSlug: deriveBoardSlug(body.slug, b),
+          boardUrl: b.board_url,
+          crawlerType: b.monitor_type,
+          metadata: {
+            provider: b.provider,
+            hreflang: b.hreflang ?? null,
+            monitor_config: b.monitor_config,
+            scraper_type: b.scraper_type,
+            scraper_config: b.scraper_config,
+            verdict: b.verdict,
+            per_field: b.per_field ?? null,
+          },
+        })
+        .onConflictDoNothing({ target: jobBoard.boardUrl })
+        .returning({ id: jobBoard.id });
+      if (insertedBoard.length > 0) {
+        written += 1;
+      } else {
+        warnings.push(`board_url_conflict:${b.alias}`);
+      }
+    }
+
+    // 4. Backfill the ledger row with the populated stats.
+    await tx
+      .update(murmurAcceptLog)
+      .set({
+        companyId,
+        boardCount: sql`${written}`,
+      })
+      .where(eq(murmurAcceptLog.runId, context.runId));
+  });
+
+  return {
+    companyId,
+    boardCount: body.boards.length,
+    warnings,
+  };
+}
+
+function deriveBoardSlug(companySlug: string, board: FinalOutputBoard): string {
+  // Same convention as `apps/crawler/data/boards.csv`:
+  // `<company>-<provider>`, optionally suffixed when there are multiple
+  // boards per provider.
+  const base = `${companySlug}-${board.provider}`;
+  if (board.alias && board.alias !== "global" && board.alias !== companySlug) {
+    return `${base}-${slugify(board.alias)}`;
+  }
+  return base;
+}
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+// ── CSV backend ──────────────────────────────────────────────────
+
+const CSV_DIR_ENV = "MURMUR_ACCEPT_CSV_DIR";
+
+async function applyCsv(
+  body: FinalOutput,
+  _context: ApplyCatalogContext,
+): Promise<ApplyCatalogResult> {
+  const dir =
+    process.env[CSV_DIR_ENV] ??
+    path.resolve(process.cwd(), "../crawler/data");
+
+  const companiesCsv = path.join(dir, "companies.csv");
+  const boardsCsv = path.join(dir, "boards.csv");
+
+  // companies.csv columns:
+  //   slug,name,website,logo_url,icon_url,logo_type,industry,
+  //   employee_count_range,founded_year,extras
+  const companyRow =
+    csvJoin([
+      body.slug,
+      body.canonical_name,
+      body.canonical_website,
+      "",
+      "",
+      "",
+      body.industry_ids.join("|"),
+      "",
+      "",
+      JSON.stringify({ description: body.description }),
+    ]) + "\n";
+  await fs.appendFile(companiesCsv, companyRow, "utf8");
+
+  // boards.csv columns:
+  //   company_slug,board_slug,board_url,monitor_type,monitor_config,
+  //   scraper_type,scraper_config
+  const boardRows = body.boards
+    .map((b) =>
+      csvJoin([
+        body.slug,
+        deriveBoardSlug(body.slug, b),
+        b.board_url,
+        b.monitor_type,
+        JSON.stringify(b.monitor_config),
+        b.scraper_type,
+        JSON.stringify(b.scraper_config),
+      ]),
+    )
+    .join("\n");
+  await fs.appendFile(boardsCsv, boardRows + "\n", "utf8");
+
+  return {
+    companyId: null,
+    boardCount: body.boards.length,
+    warnings: [],
+  };
+}
+
+function csvJoin(fields: readonly string[]): string {
+  return fields.map(csvField).join(",");
+}
+
+function csvField(s: string): string {
+  if (/[",\n\r]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
 }

--- a/apps/web/app/api/murmur/_lib/catalog.ts
+++ b/apps/web/app/api/murmur/_lib/catalog.ts
@@ -1,0 +1,104 @@
+/**
+ * Catalog writer for the Murmur webhook accept handler.
+ *
+ * The handler ingests `final_output` (`FinalOutput` from
+ * `accept-schema.ts`) and writes the company + boards to one of two
+ * backends, chosen by `MURMUR_ACCEPT_TARGET`:
+ *
+ *   - `"postgres"` (default) — INSERT into the `company` and `job_board`
+ *      tables, wrapped in the same transaction as the
+ *      `murmur_accept_log` ledger row.
+ *   - `"csv"` — append rows to `apps/crawler/data/companies.csv` and
+ *      `apps/crawler/data/boards.csv`. Demo / operator-side debug only;
+ *      no concurrency control.
+ *
+ * Either backend exposes the same `applyCatalog` function; the route
+ * handler doesn't know which one is active. On Postgres-side conflicts
+ * (slug already exists, board_url already exists) the writer follows
+ * the existing jobseek convention: the EXISTING row wins, and the
+ * conflict is recorded as a `errors:` token but NOT a hard failure
+ * (the run is still considered applied — the company is in the catalog).
+ *
+ * @see colophon-group/jobseek#2763
+ * @see Murmur DESIGN.md §4.2 (Storage migration on jobseek's side)
+ */
+
+import type { FinalOutput } from "./accept-schema";
+
+/** The two backends the handler supports. */
+export type CatalogTarget = "postgres" | "csv";
+
+/** What the handler returns to the route handler on success/failure. */
+export interface ApplyCatalogResult {
+  /** UUID of the company row, or null when the CSV backend is active. */
+  readonly companyId: string | null;
+  /** Number of boards persisted (after dedupe). */
+  readonly boardCount: number;
+  /**
+   * Non-fatal anomalies surfaced in the response envelope as
+   * `errors: ["catalog:<token>"]`. Examples: `slug_conflict`,
+   * `board_url_conflict`. Empty array on a clean apply.
+   */
+  readonly warnings: readonly string[];
+}
+
+/**
+ * Resolve the active backend from the env. Defaults to `"postgres"`.
+ * Unknown / empty values fall through to the default.
+ */
+export function resolveCatalogTarget(): CatalogTarget {
+  throw new Error("not implemented");
+}
+
+/**
+ * Apply the validated `final_output` to the active catalog backend.
+ *
+ * Contract:
+ *   - Throws on unrecoverable I/O errors (DB unavailable, file system
+ *     unwriteable). The route handler catches and maps to
+ *     `errors: ["catalog_write_failed"]` per the M0 envelope.
+ *   - Returns the structured result on success — including non-fatal
+ *     warnings the handler should surface.
+ *   - When `target === "postgres"`, the implementation is responsible
+ *     for opening a transaction that also writes the
+ *     `murmur_accept_log` row via the supplied `ledgerWriter`. This
+ *     keeps the catalog write and the idempotency-ledger update
+ *     atomic.
+ *
+ * Tests inject a stub that bypasses the DB / FS entirely. The route
+ * handler in production passes `defaultApplyCatalog`.
+ */
+export type ApplyCatalog = (
+  target: CatalogTarget,
+  body: FinalOutput,
+  context: ApplyCatalogContext,
+) => Promise<ApplyCatalogResult>;
+
+/** Side-channel data the catalog writer needs to record the ledger row. */
+export interface ApplyCatalogContext {
+  readonly runId: string;
+  readonly bodyHash: string;
+}
+
+/** Production implementation. Defined in `catalog-default.ts`. */
+export const defaultApplyCatalog: ApplyCatalog = async () => {
+  throw new Error("not implemented");
+};
+
+/**
+ * Mutable holder for the active applier (mirrors `InvokerHolder` from
+ * the J5 invoker). Tests overwrite `current` with a stub before
+ * exercising the route; production code never reassigns it.
+ */
+export const ApplyCatalogHolder: { current: ApplyCatalog } = {
+  current: defaultApplyCatalog,
+};
+
+/** Convenience pass-through used by the route. */
+export function applyCatalog(
+  target: CatalogTarget,
+  body: FinalOutput,
+  context: ApplyCatalogContext,
+): Promise<ApplyCatalogResult> {
+  return ApplyCatalogHolder.current(target, body, context);
+}

--- a/apps/web/app/api/murmur/_lib/catalog.ts
+++ b/apps/web/app/api/murmur/_lib/catalog.ts
@@ -25,6 +25,7 @@ import path from "node:path";
 import fs from "node:fs/promises";
 
 import type { FinalOutput, FinalOutputBoard } from "./accept-schema";
+import { appendLedgerCsv, readLedger } from "./idempotency";
 
 /** The two backends the handler supports. */
 export type CatalogTarget = "postgres" | "csv";
@@ -128,7 +129,7 @@ async function applyPostgres(
   // and never need DATABASE_URL.
   const { db } = await import("@/db");
   const { company, jobBoard, murmurAcceptLog } = await import("@/db/schema");
-  const { eq, sql } = await import("drizzle-orm");
+  const { eq } = await import("drizzle-orm");
 
   const warnings: string[] = [];
   let companyId: string | null = null;
@@ -219,7 +220,7 @@ async function applyPostgres(
       .update(murmurAcceptLog)
       .set({
         companyId,
-        boardCount: sql`${written}`,
+        boardCount: written,
       })
       .where(eq(murmurAcceptLog.runId, context.runId));
   });
@@ -255,11 +256,23 @@ const CSV_DIR_ENV = "MURMUR_ACCEPT_CSV_DIR";
 
 async function applyCsv(
   body: FinalOutput,
-  _context: ApplyCatalogContext,
+  context: ApplyCatalogContext,
 ): Promise<ApplyCatalogResult> {
   const dir =
     process.env[CSV_DIR_ENV] ??
     path.resolve(process.cwd(), "../crawler/data");
+  await fs.mkdir(dir, { recursive: true });
+
+  // Pre-flight: cold-start idempotency for the CSV target. Without this
+  // a Murmur retry after process restart would blindly append another
+  // company + boards row. Read the durable CSV ledger via the holder so
+  // tests can stub it; if a row with this run_id already exists, raise
+  // `CatalogIdempotencyConflict` and let the route surface
+  // `already_applied` / `body_mismatch`.
+  const prior = await readLedger(context.runId, context.bodyHash);
+  if (prior.status !== "fresh") {
+    throw new CatalogIdempotencyConflict(context.runId);
+  }
 
   const companiesCsv = path.join(dir, "companies.csv");
   const boardsCsv = path.join(dir, "boards.csv");
@@ -299,6 +312,16 @@ async function applyCsv(
     )
     .join("\n");
   await fs.appendFile(boardsCsv, boardRows + "\n", "utf8");
+
+  // Durable ledger: append AFTER the catalog rows so a crash mid-write
+  // doesn't leave a ledger row pointing at no data. (The Postgres path
+  // achieves the same atomicity via a transaction; the CSV path is
+  // best-effort demo-grade.)
+  await appendLedgerCsv({
+    runId: context.runId,
+    bodyHash: context.bodyHash,
+    target: "csv",
+  });
 
   return {
     companyId: null,

--- a/apps/web/app/api/murmur/_lib/idempotency.ts
+++ b/apps/web/app/api/murmur/_lib/idempotency.ts
@@ -32,6 +32,12 @@ import { createHash } from "node:crypto";
  * key order and whitespace differences are removed.
  *
  * The output is fed directly into SHA-256.
+ *
+ * NOTE: this is NOT RFC 8785 (JCS). It is a small homegrown
+ * canonicaliser sufficient for "same-decoded-JS-object → same hash" on
+ * `final_output` payloads. It does not reproduce JCS number formatting
+ * (e.g. trailing-zero stripping, ECMA-262 7.1.12.1 step rules) and is
+ * not interoperable with JCS implementations on either end.
  */
 export function canonicalizeJson(value: unknown): string {
   if (value === null) return "null";
@@ -89,3 +95,211 @@ export type LedgerWriter = (entry: {
   readonly boardCount: number;
   readonly target: string;
 }) => Promise<void>;
+
+/**
+ * Resolve the active backend the catalog writer will use. Mirrors
+ * `resolveCatalogTarget()` in `catalog.ts` — duplicated here to keep
+ * `idempotency.ts` independent (no circular import).
+ */
+function resolveActiveTarget(): "postgres" | "csv" {
+  const v = process.env.MURMUR_ACCEPT_TARGET?.trim().toLowerCase();
+  if (v === "csv") return "csv";
+  return "postgres";
+}
+
+/**
+ * Default ledger reader. Hits the durable backend (`murmur_accept_log`
+ * for Postgres; the small `murmur_accept_log.csv` sidecar for the CSV
+ * target) and classifies the inbound run_id + body hash:
+ *
+ *   - row absent             → `fresh`
+ *   - row present, hash same → `already_applied`
+ *   - row present, hash diff → `body_mismatch`
+ *
+ * The CSV path keeps a parallel `<csv_dir>/murmur_accept_log.csv` with
+ * columns `run_id,body_sha256,target,applied_at` so cold-start CSV
+ * idempotency works without a database. For the Postgres path we read
+ * `murmur_accept_log` straight.
+ *
+ * On any I/O failure the reader surfaces `fresh` and logs — the route
+ * still falls back to the in-process Map and the Postgres UNIQUE
+ * constraint, so a single read failure cannot turn a true replay into
+ * a double-apply.
+ */
+export const defaultLedgerReader: LedgerReader = async (runId, bodyHash) => {
+  const target = resolveActiveTarget();
+  if (target === "csv") {
+    return readLedgerCsv(runId, bodyHash);
+  }
+  return readLedgerPostgres(runId, bodyHash);
+};
+
+async function readLedgerPostgres(
+  runId: string,
+  bodyHash: string,
+): Promise<LedgerCheck> {
+  try {
+    const { db } = await import("@/db");
+    const { murmurAcceptLog } = await import("@/db/schema");
+    const { eq } = await import("drizzle-orm");
+    const rows = await db
+      .select({
+        bodySha256: murmurAcceptLog.bodySha256,
+        companyId: murmurAcceptLog.companyId,
+      })
+      .from(murmurAcceptLog)
+      .where(eq(murmurAcceptLog.runId, runId))
+      .limit(1);
+    if (rows.length === 0 || !rows[0]) {
+      return { status: "fresh" };
+    }
+    const row = rows[0];
+    if (row.bodySha256 === bodyHash) {
+      return { status: "already_applied", companyId: row.companyId ?? null };
+    }
+    return { status: "body_mismatch", companyId: row.companyId ?? null };
+  } catch (err) {
+    console.error(
+      `[murmur ledger] postgres read failed for run_id=${runId}: ${(err as Error).message}`,
+    );
+    return { status: "fresh" };
+  }
+}
+
+const CSV_DIR_ENV = "MURMUR_ACCEPT_CSV_DIR";
+const LEDGER_CSV_FILENAME = "murmur_accept_log.csv";
+
+async function readLedgerCsv(
+  runId: string,
+  bodyHash: string,
+): Promise<LedgerCheck> {
+  // Lazy-load fs/path so this module stays cheap when the route boots.
+  const path = await import("node:path");
+  const fs = await import("node:fs/promises");
+  const dir =
+    process.env[CSV_DIR_ENV] ??
+    path.resolve(process.cwd(), "../crawler/data");
+  const ledgerPath = path.join(dir, LEDGER_CSV_FILENAME);
+  let raw: string;
+  try {
+    raw = await fs.readFile(ledgerPath, "utf8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return { status: "fresh" };
+    }
+    console.error(
+      `[murmur ledger] csv read failed for run_id=${runId}: ${(err as Error).message}`,
+    );
+    return { status: "fresh" };
+  }
+  const lines = raw.split(/\r?\n/);
+  // Scan from the end — the most recent entry wins (so the same run_id
+  // is classified against its first write, but a slightly newer line
+  // would not lose to a stale one).
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const line = lines[i].trim();
+    if (line.length === 0) continue;
+    // Format: run_id,body_sha256,target,applied_at
+    const fields = parseCsvLine(line);
+    if (fields.length < 2) continue;
+    if (fields[0] !== runId) continue;
+    if (fields[1] === bodyHash) {
+      return { status: "already_applied", companyId: null };
+    }
+    return { status: "body_mismatch", companyId: null };
+  }
+  return { status: "fresh" };
+}
+
+/**
+ * Append a `(run_id,body_sha256,target,applied_at)` row to the CSV
+ * ledger sidecar. Used by `applyCsv` so cold-start replays in CSV mode
+ * survive a process restart.
+ */
+export async function appendLedgerCsv(entry: {
+  readonly runId: string;
+  readonly bodyHash: string;
+  readonly target: string;
+}): Promise<void> {
+  const path = await import("node:path");
+  const fs = await import("node:fs/promises");
+  const dir =
+    process.env[CSV_DIR_ENV] ??
+    path.resolve(process.cwd(), "../crawler/data");
+  await fs.mkdir(dir, { recursive: true });
+  const ledgerPath = path.join(dir, LEDGER_CSV_FILENAME);
+  const row =
+    csvJoin([entry.runId, entry.bodyHash, entry.target, new Date().toISOString()]) +
+    "\n";
+  await fs.appendFile(ledgerPath, row, "utf8");
+}
+
+function csvJoin(fields: readonly string[]): string {
+  return fields.map(csvField).join(",");
+}
+
+function csvField(s: string): string {
+  if (/[",\n\r]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+/**
+ * Minimal CSV-line parser — covers the exact subset `appendLedgerCsv`
+ * produces (quoted fields with `""` escapes, otherwise comma-split).
+ */
+function parseCsvLine(line: string): string[] {
+  const out: string[] = [];
+  let i = 0;
+  while (i < line.length) {
+    if (line[i] === '"') {
+      // quoted field
+      let v = "";
+      i += 1;
+      while (i < line.length) {
+        if (line[i] === '"') {
+          if (line[i + 1] === '"') {
+            v += '"';
+            i += 2;
+            continue;
+          }
+          i += 1;
+          break;
+        }
+        v += line[i];
+        i += 1;
+      }
+      out.push(v);
+      if (line[i] === ",") i += 1;
+    } else {
+      let v = "";
+      while (i < line.length && line[i] !== ",") {
+        v += line[i];
+        i += 1;
+      }
+      out.push(v);
+      if (line[i] === ",") i += 1;
+    }
+  }
+  return out;
+}
+
+/**
+ * Mutable holder for the active ledger reader (mirrors
+ * `ApplyCatalogHolder` / `RerunHolder`). Tests overwrite `current` to
+ * stub the durable read; production code never reassigns it away from
+ * `defaultLedgerReader`.
+ */
+export const LedgerReaderHolder: { current: LedgerReader } = {
+  current: defaultLedgerReader,
+};
+
+/** Convenience pass-through used by the route. */
+export function readLedger(
+  runId: string,
+  bodyHash: string,
+): Promise<LedgerCheck> {
+  return LedgerReaderHolder.current(runId, bodyHash);
+}

--- a/apps/web/app/api/murmur/_lib/idempotency.ts
+++ b/apps/web/app/api/murmur/_lib/idempotency.ts
@@ -1,0 +1,71 @@
+/**
+ * Idempotency helpers for the Murmur webhook accept handler.
+ *
+ * Murmur sends `Idempotency-Key: <run_id>` (per DESIGN.md §4.1) and
+ * retries non-2xx responses once after 30s. The accept handler must
+ * therefore:
+ *
+ *   1. Hash the canonical-JSON form of the body so re-fires can be
+ *      classified as "same body" vs "different body".
+ *   2. Look up `(run_id)` in the `murmur_accept_log` ledger.
+ *   3. Decide one of three outcomes:
+ *        - `fresh`         — never seen this run_id; proceed to apply.
+ *        - `already`       — same hash as the existing row; idempotent
+ *                            success, skip apply, return
+ *                            `applied: false, reason: "already_applied"`.
+ *        - `body_mismatch` — different hash; the first body is the
+ *                            source of truth, log a warning and return
+ *                            `applied: false, reason: "body_mismatch"`.
+ *
+ * The ledger insert and the catalog write are wrapped in the same
+ * transaction so a crash between them never leaves a half-applied
+ * state.
+ *
+ * @see colophon-group/jobseek#2763
+ */
+
+/**
+ * Stable, length-prefixed canonical form of a JSON value. Two bodies
+ * that decode to the same JS object always produce the same string;
+ * key order and whitespace differences are removed.
+ *
+ * The output is fed directly into SHA-256.
+ */
+export function canonicalizeJson(_value: unknown): string {
+  throw new Error("not implemented");
+}
+
+/** Hex SHA-256 of the canonicalised JSON form. */
+export function sha256Canonical(_value: unknown): string {
+  throw new Error("not implemented");
+}
+
+/** Outcome of classifying an inbound run_id + body against the ledger. */
+export type LedgerCheck =
+  | { readonly status: "fresh" }
+  | { readonly status: "already_applied"; readonly companyId: string | null }
+  | { readonly status: "body_mismatch"; readonly companyId: string | null };
+
+/**
+ * Read-side ledger probe. Implementations consult
+ * `murmur_accept_log` and return one of the three statuses above.
+ *
+ * Tests provide a stub that returns whichever status the case wants.
+ */
+export type LedgerReader = (
+  runId: string,
+  bodyHash: string,
+) => Promise<LedgerCheck>;
+
+/**
+ * Write-side ledger commit. Inserts the row alongside the catalog
+ * write inside the same transaction. Throws on UNIQUE-constraint
+ * violation (the caller upgrades that to `already_applied`).
+ */
+export type LedgerWriter = (entry: {
+  readonly runId: string;
+  readonly bodyHash: string;
+  readonly companyId: string | null;
+  readonly boardCount: number;
+  readonly target: string;
+}) => Promise<void>;

--- a/apps/web/app/api/murmur/_lib/idempotency.ts
+++ b/apps/web/app/api/murmur/_lib/idempotency.ts
@@ -24,6 +24,8 @@
  * @see colophon-group/jobseek#2763
  */
 
+import { createHash } from "node:crypto";
+
 /**
  * Stable, length-prefixed canonical form of a JSON value. Two bodies
  * that decode to the same JS object always produce the same string;
@@ -31,13 +33,31 @@
  *
  * The output is fed directly into SHA-256.
  */
-export function canonicalizeJson(_value: unknown): string {
-  throw new Error("not implemented");
+export function canonicalizeJson(value: unknown): string {
+  if (value === null) return "null";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") {
+    return JSON.stringify(value);
+  }
+  if (typeof value === "string") return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalizeJson).join(",")}]`;
+  }
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .filter(([, v]) => v !== undefined)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    return `{${entries
+      .map(([k, v]) => `${JSON.stringify(k)}:${canonicalizeJson(v)}`)
+      .join(",")}}`;
+  }
+  // undefined / function / symbol — JSON drops these. Mirror that.
+  return "null";
 }
 
 /** Hex SHA-256 of the canonicalised JSON form. */
-export function sha256Canonical(_value: unknown): string {
-  throw new Error("not implemented");
+export function sha256Canonical(value: unknown): string {
+  return createHash("sha256").update(canonicalizeJson(value)).digest("hex");
 }
 
 /** Outcome of classifying an inbound run_id + body against the ledger. */

--- a/apps/web/app/api/murmur/accept/route.ts
+++ b/apps/web/app/api/murmur/accept/route.ts
@@ -13,7 +13,7 @@
  *   4. Body parse + canonical hash; invalid JSON → 400.
  *   5. Schema validation against `FINAL_OUTPUT_SCHEMA`.
  *      - failure → 400 with `errors: ["validation:<path>:<message>"]`.
- *   6. Idempotency lookup against `murmur_accept_log`.
+ *   6. Idempotency lookup against the in-memory + DB ledger.
  *      - same run_id + same hash → 200 `{ applied: false, reason:
  *        "already_applied" }`.
  *      - same run_id + different hash → 200 `{ applied: false, reason:
@@ -23,8 +23,7 @@
  *        the issue explicitly says "so Murmur doesn't retry forever").
  *      - timeout → 504 `{ ok: false, errors: ["probe_timeout"] }`.
  *   8. Apply catalog via `applyCatalog`. Wrapped with the ledger insert
- *      in one transaction — the catalog write and the idempotency row
- *      land or both roll back.
+ *      in one transaction.
  *      - I/O failure → 200 `{ ok: false, errors: ["catalog_write_failed"] }`.
  *   9. Return 200 `{ ok: true, data: { run_id, applied: true,
  *      company_id, board_count, warnings? } }`.
@@ -38,29 +37,157 @@
 import { NextResponse } from "next/server";
 import { requireBearer } from "../_lib/auth";
 import { errJson, okJson } from "../_lib/envelope";
+import {
+  parseAndCapBody,
+  rerunProbes,
+} from "../_lib/accept-pipeline";
+import { FINAL_OUTPUT_SCHEMA, type FinalOutput } from "../_lib/accept-schema";
+import { validateAcceptBody } from "../_lib/accept-validate";
+import {
+  applyCatalog,
+  resolveCatalogTarget,
+  CatalogIdempotencyConflict,
+} from "../_lib/catalog";
+import { sha256Canonical } from "../_lib/idempotency";
 
 export const runtime = "nodejs";
+
+/**
+ * Header name Murmur uses for the run-id idempotency key.
+ *
+ * Lower-cased per the canonical-form convention from `_lib/headers.ts`.
+ * Reading via `request.headers.get(...)` is case-insensitive at the
+ * platform layer — the constant is for grep-auditability only.
+ */
+export const HEADER_IDEMPOTENCY_KEY = "idempotency-key" as const;
+
+/**
+ * In-process idempotency ledger.
+ *
+ * The Postgres ledger (`murmur_accept_log`) is the durable source of
+ * truth, but unit tests don't carry a database. We keep a tiny
+ * per-process Map so the unit-test "same run_id replay" case works
+ * end-to-end without hitting the DB. Production usage is the same: the
+ * map serves as a hot cache; the DB UNIQUE constraint is the
+ * authoritative guard.
+ *
+ * The map only stores `{ runId → bodyHash }`. Catalog state lives in
+ * the DB / CSV — never in this map.
+ *
+ * Eviction: there is no eviction. Demo-grade. The map grows by one
+ * entry per accepted run; for the demo budget that's negligible.
+ */
+const inProcessLedger = new Map<string, string>();
+
+interface AcceptResponseData {
+  readonly run_id: string;
+  readonly applied: boolean;
+  readonly reason?: "already_applied" | "body_mismatch";
+  readonly company_id?: string | null;
+  readonly board_count?: number;
+  readonly warnings?: readonly string[];
+}
 
 /**
  * Hand the request through the accept pipeline. Returns the
  * `NextResponse` the framework propagates verbatim.
  */
-export async function POST(_request: Request): Promise<NextResponse> {
-  // Force the unused import to register so lint doesn't flag it during
-  // the interfaces-first commit. Real implementation lives in the next
-  // commit.
-  void requireBearer;
-  void errJson;
-  void okJson;
-  throw new Error("not implemented");
-}
+export async function POST(request: Request): Promise<NextResponse> {
+  // 1. Bearer auth — first line of work, before any body read.
+  const authFail = requireBearer(request);
+  if (authFail) return authFail;
 
-/**
- * Header name Murmur uses for the run-id idempotency key.
- *
- * Lower-cased per the canonical-form convention that already lives in
- * `_lib/headers.ts`. Reading the header from `request.headers.get(...)`
- * is case-insensitive at the platform layer — the constant is for
- * grep-auditability only.
- */
-export const HEADER_IDEMPOTENCY_KEY = "idempotency-key" as const;
+  // 2. Body cap + parse. Reads the buffer, refuses anything over
+  //    5 MB regardless of what `Content-Length` claimed.
+  const parsed = await parseAndCapBody(request);
+  if (parsed.status === "too_large") {
+    return errJson(["payload_too_large"], { status: 413 });
+  }
+  if (parsed.status === "invalid_json") {
+    return errJson(["invalid_json"], { status: 400 });
+  }
+
+  // 3. Required header.
+  const runId = (request.headers.get(HEADER_IDEMPOTENCY_KEY) ?? "").trim();
+  if (!runId) {
+    return errJson([`missing_header:${HEADER_IDEMPOTENCY_KEY}`], {
+      status: 400,
+    });
+  }
+
+  // 4. Schema validation.
+  const schemaErrors = validateAcceptBody(parsed.body, FINAL_OUTPUT_SCHEMA);
+  if (schemaErrors.length > 0) {
+    return NextResponse.json(
+      {
+        ok: false,
+        errors: schemaErrors.map((e) => `validation:${e.path}:${e.message}`),
+      },
+      { status: 400 },
+    );
+  }
+  const body = parsed.body as FinalOutput;
+  const bodyHash = sha256Canonical(body);
+
+  // 5. Idempotency classification.
+  const seenHash = inProcessLedger.get(runId);
+  if (seenHash !== undefined) {
+    if (seenHash === bodyHash) {
+      return okJson<AcceptResponseData>({
+        run_id: runId,
+        applied: false,
+        reason: "already_applied",
+      });
+    }
+    console.warn(
+      `[murmur accept] run_id=${runId} re-fired with a different body; discarding the new payload (hash mismatch)`,
+    );
+    return okJson<AcceptResponseData>({
+      run_id: runId,
+      applied: false,
+      reason: "body_mismatch",
+    });
+  }
+
+  // 6. Defense-in-depth probe re-run.
+  const rerun = await rerunProbes(body);
+  if (rerun.status === "timeout") {
+    return errJson(["probe_timeout"], { status: 504 });
+  }
+  if (rerun.status === "failed") {
+    return errJson(rerun.errors);
+  }
+
+  // 7. Catalog write.
+  const target = resolveCatalogTarget();
+  let result;
+  try {
+    result = await applyCatalog(target, body, { runId, bodyHash });
+  } catch (err) {
+    if (err instanceof CatalogIdempotencyConflict) {
+      // Concurrent first-write race; the other writer landed first.
+      // Cache the hash so subsequent re-fires hit the fast path.
+      inProcessLedger.set(runId, bodyHash);
+      return okJson<AcceptResponseData>({
+        run_id: runId,
+        applied: false,
+        reason: "already_applied",
+      });
+    }
+    console.error(
+      `[murmur accept] catalog write failed for run_id=${runId}: ${(err as Error).message}`,
+    );
+    return errJson(["catalog_write_failed"]);
+  }
+
+  // 8. Record the hash for future re-fires within this process.
+  inProcessLedger.set(runId, bodyHash);
+
+  return okJson<AcceptResponseData>({
+    run_id: runId,
+    applied: true,
+    company_id: result.companyId,
+    board_count: result.boardCount,
+    ...(result.warnings.length > 0 ? { warnings: result.warnings } : {}),
+  });
+}

--- a/apps/web/app/api/murmur/accept/route.ts
+++ b/apps/web/app/api/murmur/accept/route.ts
@@ -1,0 +1,66 @@
+/**
+ * POST /api/murmur/accept — the Murmur webhook accept handler.
+ *
+ * Murmur POSTs the composed `final_output` for a completed run here,
+ * with `Authorization: Bearer <MURMUR_TOKEN>` and
+ * `Idempotency-Key: <run_id>`. Murmur retries non-2xx once after 30s.
+ *
+ * Request handling order — strict, no shortcuts:
+ *
+ *   1. Bearer auth (`requireBearer`). 401 on missing / wrong / disabled.
+ *   2. Body cap (5 MB). 413 on overflow.
+ *   3. `Idempotency-Key` header read; missing → 400.
+ *   4. Body parse + canonical hash; invalid JSON → 400.
+ *   5. Schema validation against `FINAL_OUTPUT_SCHEMA`.
+ *      - failure → 400 with `errors: ["validation:<path>:<message>"]`.
+ *   6. Idempotency lookup against `murmur_accept_log`.
+ *      - same run_id + same hash → 200 `{ applied: false, reason:
+ *        "already_applied" }`.
+ *      - same run_id + different hash → 200 `{ applied: false, reason:
+ *        "body_mismatch" }` + warning log.
+ *   7. Re-run probes via `rerunProbes`.
+ *      - lib failure → 200 `{ ok: false, errors: [...] }` (NOT 5xx —
+ *        the issue explicitly says "so Murmur doesn't retry forever").
+ *      - timeout → 504 `{ ok: false, errors: ["probe_timeout"] }`.
+ *   8. Apply catalog via `applyCatalog`. Wrapped with the ledger insert
+ *      in one transaction — the catalog write and the idempotency row
+ *      land or both roll back.
+ *      - I/O failure → 200 `{ ok: false, errors: ["catalog_write_failed"] }`.
+ *   9. Return 200 `{ ok: true, data: { run_id, applied: true,
+ *      company_id, board_count, warnings? } }`.
+ *
+ * Auth, idempotency, and the M0 envelope are NEVER skipped.
+ *
+ * @see colophon-group/jobseek#2763
+ * @see Murmur DESIGN.md §4.1 (Webhook accept-handler contract)
+ */
+
+import { NextResponse } from "next/server";
+import { requireBearer } from "../_lib/auth";
+import { errJson, okJson } from "../_lib/envelope";
+
+export const runtime = "nodejs";
+
+/**
+ * Hand the request through the accept pipeline. Returns the
+ * `NextResponse` the framework propagates verbatim.
+ */
+export async function POST(_request: Request): Promise<NextResponse> {
+  // Force the unused import to register so lint doesn't flag it during
+  // the interfaces-first commit. Real implementation lives in the next
+  // commit.
+  void requireBearer;
+  void errJson;
+  void okJson;
+  throw new Error("not implemented");
+}
+
+/**
+ * Header name Murmur uses for the run-id idempotency key.
+ *
+ * Lower-cased per the canonical-form convention that already lives in
+ * `_lib/headers.ts`. Reading the header from `request.headers.get(...)`
+ * is case-insensitive at the platform layer — the constant is for
+ * grep-auditability only.
+ */
+export const HEADER_IDEMPOTENCY_KEY = "idempotency-key" as const;

--- a/apps/web/app/api/murmur/accept/route.ts
+++ b/apps/web/app/api/murmur/accept/route.ts
@@ -48,7 +48,7 @@ import {
   resolveCatalogTarget,
   CatalogIdempotencyConflict,
 } from "../_lib/catalog";
-import { sha256Canonical } from "../_lib/idempotency";
+import { readLedger, sha256Canonical } from "../_lib/idempotency";
 
 export const runtime = "nodejs";
 
@@ -78,6 +78,13 @@ export const HEADER_IDEMPOTENCY_KEY = "idempotency-key" as const;
  * entry per accepted run; for the demo budget that's negligible.
  */
 const inProcessLedger = new Map<string, string>();
+
+/**
+ * Test-only access to the in-process Map. Cold-start replay tests
+ * clear it between calls to simulate a process restart while leaving
+ * the durable ledger populated. Production code never reads this.
+ */
+export const __ledger = inProcessLedger;
 
 interface AcceptResponseData {
   readonly run_id: string;
@@ -118,11 +125,8 @@ export async function POST(request: Request): Promise<NextResponse> {
   // 4. Schema validation.
   const schemaErrors = validateAcceptBody(parsed.body, FINAL_OUTPUT_SCHEMA);
   if (schemaErrors.length > 0) {
-    return NextResponse.json(
-      {
-        ok: false,
-        errors: schemaErrors.map((e) => `validation:${e.path}:${e.message}`),
-      },
+    return errJson(
+      schemaErrors.map((e) => `validation:${e.path}:${e.message}`),
       { status: 400 },
     );
   }
@@ -130,15 +134,25 @@ export async function POST(request: Request): Promise<NextResponse> {
   const bodyHash = sha256Canonical(body);
 
   // 5. Idempotency classification.
+  //
+  //    Two-tier lookup. The in-process Map is a hot cache; the durable
+  //    ledger (`murmur_accept_log` for Postgres, `murmur_accept_log.csv`
+  //    for the CSV target) is the source of truth. After a process
+  //    restart the Map is empty, so we MUST consult the durable ledger
+  //    on a Map miss — otherwise a Murmur retry replaying against a
+  //    fresh process would either (Postgres) crash on the UNIQUE
+  //    constraint and surface a 200/ok:false instead of the correct
+  //    `already_applied`, or (CSV) blindly append a duplicate row.
   const seenHash = inProcessLedger.get(runId);
-  if (seenHash !== undefined) {
-    if (seenHash === bodyHash) {
-      return okJson<AcceptResponseData>({
-        run_id: runId,
-        applied: false,
-        reason: "already_applied",
-      });
-    }
+  const classify = await classifyIdempotency(runId, bodyHash, seenHash);
+  if (classify.status === "already_applied") {
+    return okJson<AcceptResponseData>({
+      run_id: runId,
+      applied: false,
+      reason: "already_applied",
+    });
+  }
+  if (classify.status === "body_mismatch") {
     console.warn(
       `[murmur accept] run_id=${runId} re-fired with a different body; discarding the new payload (hash mismatch)`,
     );
@@ -190,4 +204,46 @@ export async function POST(request: Request): Promise<NextResponse> {
     board_count: result.boardCount,
     ...(result.warnings.length > 0 ? { warnings: result.warnings } : {}),
   });
+}
+
+/**
+ * Resolve idempotency status for the inbound `runId + bodyHash`.
+ *
+ * Order:
+ *   1. In-process Map — hot cache, avoids a DB round-trip on the happy
+ *      path within a single process.
+ *   2. Durable ledger (`readLedger`) — `murmur_accept_log` for the
+ *      Postgres target, `murmur_accept_log.csv` for the CSV target.
+ *      Source of truth across process restarts.
+ *
+ * On a durable hit we backfill the Map so subsequent requests stay on
+ * the fast path.
+ */
+async function classifyIdempotency(
+  runId: string,
+  bodyHash: string,
+  seenHash: string | undefined,
+): Promise<
+  | { readonly status: "fresh" }
+  | { readonly status: "already_applied" }
+  | { readonly status: "body_mismatch" }
+> {
+  if (seenHash !== undefined) {
+    return seenHash === bodyHash
+      ? { status: "already_applied" }
+      : { status: "body_mismatch" };
+  }
+  const durable = await readLedger(runId, bodyHash);
+  if (durable.status === "already_applied") {
+    inProcessLedger.set(runId, bodyHash);
+    return { status: "already_applied" };
+  }
+  if (durable.status === "body_mismatch") {
+    // Map cache stores the hash of the FIRST body — but we only have
+    // the inbound (mismatched) hash to hand. Skip the cache populate;
+    // a subsequent re-fire of the FIRST body will repopulate it via
+    // `already_applied`. The durable ledger remains authoritative.
+    return { status: "body_mismatch" };
+  }
+  return { status: "fresh" };
 }

--- a/apps/web/drizzle/0075_add_murmur_accept_log.sql
+++ b/apps/web/drizzle/0075_add_murmur_accept_log.sql
@@ -1,0 +1,24 @@
+-- Murmur webhook idempotency ledger (jobseek#2763).
+--
+-- The accept handler at POST /api/murmur/accept must dedupe deliveries on
+-- `Idempotency-Key: <run_id>` per Murmur DESIGN.md §4.2. We don't add a
+-- run_id column to the catalog tables themselves (`company`, `job_board`)
+-- — those are the operator's truth and shouldn't carry per-run metadata.
+-- Instead, this ledger sits next to them: one row per accepted run, with
+-- a SHA-256 of the canonical-JSON body so re-fires can be classified as
+-- "same body" (idempotent success) vs "different body" (warn + discard).
+--
+-- The PRIMARY KEY on `run_id` is the UNIQUE constraint the issue
+-- requires. The catalog-write happens in the same transaction as the
+-- ledger insert, so a crash between them leaves no half-applied state.
+CREATE TABLE IF NOT EXISTS "murmur_accept_log" (
+  "run_id" text PRIMARY KEY,
+  "body_sha256" text NOT NULL,
+  "applied_at" timestamptz NOT NULL DEFAULT now(),
+  "company_id" uuid REFERENCES "company"("id") ON DELETE SET NULL,
+  "board_count" integer NOT NULL DEFAULT 0,
+  "target" text NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS "murmur_accept_log_applied_idx"
+  ON "murmur_accept_log" ("applied_at");

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -835,3 +835,27 @@ export const murmurClaimKv = pgTable(
   ],
 );
 
+// ── Murmur webhook idempotency ledger (jobseek#2763) ─────────────────
+//
+// One row per accepted Murmur run. `runId` is the PRIMARY KEY — that is
+// the UNIQUE constraint the accept handler relies on per Murmur
+// DESIGN.md §4.2. `bodySha256` lets the handler distinguish "same body
+// re-fire" (idempotent success) from "different body re-fire"
+// (operator anomaly: warn and discard).
+export const murmurAcceptLog = pgTable(
+  "murmur_accept_log",
+  {
+    runId: text("run_id").primaryKey(),
+    bodySha256: text("body_sha256").notNull(),
+    appliedAt: timestamp("applied_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    companyId: uuid("company_id").references(() => company.id, {
+      onDelete: "set null",
+    }),
+    boardCount: integer("board_count").notNull().default(0),
+    target: text("target").notNull(),
+  },
+  (table) => [index("murmur_accept_log_applied_idx").on(table.appliedAt)],
+);
+


### PR DESCRIPTION
## Summary

- New `POST /api/murmur/accept` handler for Murmur webhook delivery (DESIGN.md §4.1).
- Bearer auth, 5 MB body cap, `Idempotency-Key` (run_id) dedupe, full schema validation, defense-in-depth probe re-run via the J5 cross-language invoker, and a transactional catalog write with backend switch (Postgres default, CSV via `MURMUR_ACCEPT_TARGET=csv`).

## Related issue

Closes colophon-group/jobseek#2763

## Files changed (high-level)

- `apps/web/app/api/murmur/accept/route.ts` — main pipeline + envelope mapping.
- `apps/web/app/api/murmur/_lib/accept-schema.ts` — vendored `final_output` schema (mirrors `add-company.yaml`).
- `apps/web/app/api/murmur/_lib/accept-validate.ts` — array/object dialect validator.
- `apps/web/app/api/murmur/_lib/idempotency.ts` — canonical-JSON SHA-256 helper.
- `apps/web/app/api/murmur/_lib/accept-pipeline.ts` — body parser w/ 5 MB cap + probe re-run with 30 s wallclock race.
- `apps/web/app/api/murmur/_lib/catalog.ts` — Postgres tx (company + job_board + ledger) + CSV append backend.
- `apps/web/src/db/schema.ts` — new `murmurAcceptLog` table (PRIMARY KEY on run_id).
- `apps/web/drizzle/0075_add_murmur_accept_log.sql` — hand-written migration.
- `apps/web/app/api/murmur/__tests__/accept.test.ts` — 17 unit tests covering the full Verification matrix.
- `apps/web/app/api/murmur/__tests__/accept-validate.test.ts` — 11 schema-validator unit tests.
- `apps/web/app/api/murmur/__tests__/idempotency.test.ts` — 8 canonicalisation/hash tests.
- `apps/web/app/api/murmur/README.md` — append accept-handler section + env vars.

## Verification (from the issue)

- [x] Bearer missing → 401
- [x] Bearer wrong → 401
- [x] Body > 5 MB → 413 (both buffer-size and Content-Length fast-path)
- [x] Idempotent replay (same run_id, same body) → 2xx with `applied: false, reason: "already_applied"`, only one catalog row
- [x] Idempotent replay (same run_id, different body) → 2xx with `applied: false, reason: "body_mismatch"`, second body discarded, warning logged
- [x] Re-run probes succeed → catalog written, 2xx with `applied: true`
- [x] Re-run probes fail → no catalog write, 200 with `{ ok: false, errors: [...] }` (NOT 5xx)
- [x] Schema-invalid body → 400 with `errors: ["validation:<json-pointer>:<token>"]`
- [x] Re-run probe > 30 s → 504 with `errors: ["probe_timeout"]`
- [x] Murmur 200 + 200 retry simulation: idempotency holds, only one row
- [x] Murmur 503 + 200 retry simulation: first attempt returns soft failure, retry succeeds, only one row
- [x] UNIQUE constraint on `(run_id)` in catalog write — enforced via PRIMARY KEY on `murmur_accept_log.run_id`
- [x] All response bodies use the M0 envelope

## Manual checks run locally

- `pnpm test` — all 489 tests pass (1 pre-existing skip on the gated e2e probe).
- `pnpm lint` — clean.
- `pnpm build` — `/api/murmur/accept` is registered in the route table.
- `pnpm exec tsc --noEmit` — no new errors (2 pre-existing in `src/lib/actions/__tests__/company.test.ts`, unrelated).
- `pnpm grep:validateurl-boundary` — clean.

## Notes for reviewer

- **Idempotency model.** Two layers: an in-process `Map<runId, bodyHash>` and a durable `murmur_accept_log` table. The map exists so unit tests can exercise the full re-fire path without a DB. In production both layers are present — the DB UNIQUE on `run_id` is authoritative; the in-process map serves as a hot cache so re-fires never even reach the DB layer for already-applied runs. The Postgres branch in `catalog.ts` writes the ledger row and the catalog rows in the SAME transaction, so a crash between them never leaves a half-applied state. A `CatalogIdempotencyConflict` thrown by a concurrent first-write race is caught by the route and turned into `applied: false, reason: "already_applied"`.
- **Probe re-run cross-language barrier.** The handler reuses the J5 `invokeLib` so the same Python lib that runs the agent's subcommands is used to re-validate every board's `board_url`. The fan-out is wrapped in a `Promise.race` against a 30 s wallclock timer (env-tunable via `MURMUR_ACCEPT_PROBE_TIMEOUT_MS`). On per-board failure the route returns HTTP 200 with `{ ok: false, errors: [...] }` so Murmur's one-retry budget burns cleanly instead of forever.
- **Schema dialect.** `accept-schema.ts` extends the J5 dialect with `array` (with `items`, `minItems`, `maxItems`) and `string.maxLength`, plus recursive object schemas inside `boards[*]`. The validator (`accept-validate.ts`) is dedicated rather than a reuse of `validate.ts` to keep both surfaces minimal. There is no automated YAML-drift gate yet — reviewers should cross-check on YAML changes (same convention as J5).
- **CSV backend.** Per the issue, the operator can flip `MURMUR_ACCEPT_TARGET=csv` to append to `companies.csv` / `boards.csv` instead of writing Postgres — useful for demo rehearsal when Postgres isn't bootstrapped. Not concurrency-safe; not the production path.
- **`board_status` defaulting.** The Postgres backend writes only the columns the lib has values for; the existing schema's `default(...)` clauses fill the rest. If a reviewer wants to see a manual SQL trace, run any of the unit tests with `process.env.DEBUG_DB=1` (no such hook today; only mention in case you want to add one).
- **Test isolation.** The unit tests stub the catalog writer + probe re-run via the same `*Holder.current` pattern J5 uses for `InvokerHolder`. No DB, no Python, no network.