### PR TITLE
probe: DO NOT MERGE — adversarial CI probe for #2779

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
+    branches: [main, murmur-demo]
   workflow_dispatch:
 
 concurrency:
@@ -124,6 +124,30 @@ jobs:
       - run: pnpm --filter @jseek/mcp-server build
 
       - run: pnpm --filter @jobseek/web test
+
+  test-shim:
+    name: Test Murmur Shim
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm --filter @jobseek/murmur-shim test
+
+      - run: pnpm --filter @jobseek/murmur-shim build
+
+      - name: Boundary gate (validateUrl/safeFetch)
+        run: bash apps/murmur-shim/scripts/grep-validateurl-boundary.sh
 
   test-crawler:
     name: Test Crawler

--- a/apps/murmur-shim/src/lib/murmur/ssrf.test.ts
+++ b/apps/murmur-shim/src/lib/murmur/ssrf.test.ts
@@ -592,3 +592,12 @@ describe("safeFetch + createPinnedLookup — loopback integration", () => {
     expect(receivedRemoteAddr).toMatch(/^(::ffff:)?127\.0\.0\.1$/);
   });
 });
+
+// PROBE: deliberately-failing assertion for issue #2779 adversarial verification.
+// This proves the new Test Murmur Shim CI job actually fires on failure. The
+// probe branch (dev/2779-ci-probe-adversarial) must NEVER be merged.
+describe("ci-probe-2779", () => {
+  it("intentionally fails to prove CI catches it", () => {
+    expect(1).toBe(2);
+  });
+});


### PR DESCRIPTION
**DO NOT MERGE.**

Adversarial probe for colophon-group/jobseek#2779. Adds a deliberately-failing test (`expect(1).toBe(2)`) so we can confirm the new `Test Murmur Shim` CI job (introduced in PR #2780) actually catches failures rather than silently passing.

This PR is expected to:
- Trigger CI (proving the `pull_request: [..., murmur-demo]` filter expansion works).
- Show `Test Murmur Shim` job **failing** with the vitest assertion error.

Once CI reports failure, this PR will be closed without merge.

Refs colophon-group/jobseek#2779