### PR TITLE
build(deploy): linux/amd64 Dockerfile for jobseek-murmur-shim

### DIFF
--- a/apps/murmur-shim/Dockerfile
+++ b/apps/murmur-shim/Dockerfile
@@ -1,6 +1,13 @@
 # syntax=docker/dockerfile:1.7
 #
-# jobseek-murmur-shim — production image (linux/arm64).
+# jobseek-murmur-shim — production image (linux/amd64).
+#
+# Target host: the Hetzner crawler box at 116.203.192.19, which is
+# x86_64 (`uname -m` → `x86_64`). This Dockerfile has no hard-coded
+# `--platform` pin in its `FROM` stages, so buildx picks the platform
+# from `--platform=linux/<arch>` at invocation time. Production
+# builds (and CI) MUST pass `--platform=linux/amd64` so the image
+# manifest matches the deploy target.
 #
 # Source spec: colophon-group/jobseek#2774 (H2). Sibling pattern of
 # colophon-group/murmur's Dockerfile (multi-stage Node-on-Alpine,
@@ -46,7 +53,7 @@
 # Invoke as:
 #
 #     docker buildx build \
-#       --platform=linux/arm64 \
+#       --platform=linux/amd64 \
 #       -f apps/murmur-shim/Dockerfile \
 #       -t jobseek-murmur-shim:test \
 #       .

--- a/apps/murmur-shim/Dockerfile
+++ b/apps/murmur-shim/Dockerfile
@@ -1,0 +1,190 @@
+# syntax=docker/dockerfile:1.7
+#
+# jobseek-murmur-shim — production image (linux/arm64).
+#
+# Source spec: colophon-group/jobseek#2774 (H2). Sibling pattern of
+# colophon-group/murmur's Dockerfile (multi-stage Node-on-Alpine,
+# Corepack-pinned pnpm, tini PID 1, non-root `node` user).
+#
+# ── Why this is multi-stage ────────────────────────────────────────
+#
+# Builder stage carries Corepack + pnpm + the entire workspace + dev
+# deps so it can run `pnpm --filter @jobseek/murmur-shim build`. The
+# build emits a Next.js `output: "standalone"` tree at
+# `apps/murmur-shim/.next/standalone/` containing a self-contained
+# `server.js` and a pruned `node_modules/` with only the runtime deps
+# (no typescript, no eslint, no vitest). Runtime stage copies just
+# that tree + the static assets and discards everything else.
+#
+# ── Why no Python in this image ────────────────────────────────────
+#
+# The shim's `_lib/invoke-lib.ts` spawns `python3` to dispatch into
+# the crawler's `cli_shim`. Baking Python + Playwright + browser
+# binaries into this image would cost ~1.5 GB and duplicate what the
+# `apps/crawler` image already provides on the same Hetzner host.
+# Instead, compose mounts the crawler venv from the host:
+#
+#     /opt/jobseek-crawler/.venv  →  /opt/jobseek-crawler-venv
+#     /opt/jobseek-crawler/src    →  /opt/jobseek-crawler-src
+#
+# and passes the env vars `MURMUR_PY=/opt/jobseek-crawler-venv/bin/python3`
+# and `MURMUR_CRAWLER_ROOT=/opt/jobseek-crawler-src` (read by
+# `invoke-lib.ts` at call time). This image only needs to be able to
+# `spawn()` that interpreter — no native deps.
+#
+# Note: jobseek#2774 originally wrote `VENV_PYTHON` and `PYTHONPATH`
+# as the env names, but the actual code reads `MURMUR_PY` and
+# `MURMUR_CRAWLER_ROOT` (`PYTHONPATH` is set to `MURMUR_CRAWLER_ROOT`
+# automatically inside the spawn — the operator does not pass it).
+# Compose (H3) wires the names that the code reads.
+#
+# ── Build context ──────────────────────────────────────────────────
+#
+# Build context MUST be the monorepo root, because the shim's
+# `src/db/schema.ts` re-exports `apps/web/src/db/schema.ts` and the
+# pnpm workspace install needs the root lockfile + workspace manifest.
+# Invoke as:
+#
+#     docker buildx build \
+#       --platform=linux/arm64 \
+#       -f apps/murmur-shim/Dockerfile \
+#       -t jobseek-murmur-shim:test \
+#       .
+#
+# The colocated `Dockerfile.dockerignore` is honored by BuildKit when
+# the `-f` flag points at this Dockerfile.
+#
+# ── Runtime invariants ─────────────────────────────────────────────
+#
+# - PID 1 is `tini`, which forwards SIGTERM and reaps zombies.
+# - Process runs as `node` (uid 1000), which exists in node:22-alpine
+#   by default. We never `chown -R node:node /app/.next`; the COPY
+#   --chown does it in a single layer.
+# - EXPOSE 8080. Compose binds it to 127.0.0.1 only; cloudflared is
+#   the public ingress.
+# - HEALTHCHECK hits `/health` (added by jobseek#2774 alongside this
+#   Dockerfile) — see app/health/route.ts for the route, which is
+#   intentionally bearer-free so the healthcheck and the cloudflared
+#   origin-up probe both work without secrets.
+
+ARG NODE_IMAGE=node:22-alpine
+# pnpm@10.30.0 matches the root `package.json`'s `packageManager` field.
+# Mismatched versions would emit a hard Corepack error rather than
+# silent drift.
+ARG PNPM_VERSION=10.30.0
+
+# ───────────────────────── builder ──────────────────────────
+FROM ${NODE_IMAGE} AS builder
+
+# libc6-compat is needed for some npm postinstall scripts (sharp's
+# native bindings, esbuild). We don't pull g++/make/python3 because
+# the shim has no native deps — drizzle-orm and postgres are pure JS.
+RUN apk add --no-cache libc6-compat
+
+# Activate pnpm via Corepack in a globally-readable location so
+# subsequent stages (and humans `docker exec`-ing) can use it.
+ENV COREPACK_HOME=/opt/corepack
+ARG PNPM_VERSION
+RUN mkdir -p /opt/corepack \
+ && corepack enable \
+ && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+WORKDIR /app
+
+# Copy lockfile + workspace manifests first so `pnpm install` can be
+# cached independently of source changes. The workspace's package
+# manifests are tiny; we copy the whole tree of them in one shot
+# (any package.json under apps/* or packages/*).
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+
+# Workspace member manifests required so `pnpm install` resolves the
+# graph. Missing any of these would make pnpm refuse to install (the
+# lockfile pins workspace-wide). The order tracks `pnpm-workspace.yaml`:
+# `apps/*` (every apps/<name> with a package.json), then
+# `apps/crawler/murmur`, then `packages/*`.
+COPY apps/murmur-shim/package.json ./apps/murmur-shim/
+COPY apps/web/package.json ./apps/web/
+COPY apps/trace-viewer/package.json ./apps/trace-viewer/
+COPY apps/crawler/murmur/package.json ./apps/crawler/murmur/
+COPY packages/mcp-server/package.json ./packages/mcp-server/
+
+# Frozen install: fail fast on lockfile drift. `--prefer-offline`
+# reduces network round-trips on warm builds.
+RUN pnpm install --frozen-lockfile --prefer-offline
+
+# Copy the rest of the workspace. Dockerfile.dockerignore filters out
+# .git, .next, coverage, *.test.ts, etc.
+COPY apps/murmur-shim/ ./apps/murmur-shim/
+# `apps/web/src/db/schema.ts` is re-exported by the shim's
+# `src/db/schema.ts`; Next's standalone tracer follows the relative
+# path at build time and inlines the table definitions into a server
+# chunk. We only need that one file from web — copying it explicitly
+# avoids dragging the rest of the web app into the build context.
+COPY apps/web/src/db/schema.ts ./apps/web/src/db/schema.ts
+
+# Build the standalone Next.js bundle.
+RUN pnpm --filter @jobseek/murmur-shim build
+
+# ───────────────────────── runtime ──────────────────────────
+FROM ${NODE_IMAGE} AS runtime
+
+# tini for proper PID 1 behaviour. wget is already present via
+# busybox-extras (alpine ships busybox-wget); we use it in HEALTHCHECK
+# below.
+RUN apk add --no-cache tini
+
+WORKDIR /app
+
+# Copy ONLY the standalone build output + static assets. The standalone
+# tree is structured as `<outputFileTracingRoot>/apps/murmur-shim/...`
+# — i.e., it preserves the monorepo layout because the build set
+# `outputFileTracingRoot` to the repo root. We mirror that layout in
+# the image so `node apps/murmur-shim/server.js` finds its peers
+# (the bundled `apps/murmur-shim/.next/server/chunks/...` files and
+# the `node_modules/` at `/app/node_modules` that standalone's tracer
+# pruned to runtime-only deps).
+#
+# `--chown=node:node` sets ownership in the same layer as the COPY,
+# which is much cheaper than a follow-up `chown -R` (no duplicate
+# inode layer).
+COPY --from=builder --chown=node:node \
+     /app/apps/murmur-shim/.next/standalone/ ./
+# Static assets (chunks/, css/) live outside the standalone tree; Next
+# expects them at `<app>/.next/static/`.
+COPY --from=builder --chown=node:node \
+     /app/apps/murmur-shim/.next/static/ ./apps/murmur-shim/.next/static/
+
+USER node
+
+ENV NODE_ENV=production
+# `HOSTNAME=0.0.0.0` is required by Next's standalone server.js to
+# bind to all interfaces; the default `localhost` only listens on the
+# loopback inside the container, which the docker-proxy can't reach.
+ENV HOSTNAME=0.0.0.0
+ENV PORT=8080
+
+# Sane defaults for the venv-mount paths. Compose may override these;
+# a healthy local `docker run` (without compose) will get a
+# `MURMUR_DB_DSN` is empty error before it ever tries to spawn python,
+# so these defaults can stay even when the volumes aren't mounted.
+ENV MURMUR_PY=/opt/jobseek-crawler-venv/bin/python3
+ENV MURMUR_CRAWLER_ROOT=/opt/jobseek-crawler-src
+
+EXPOSE 8080
+
+# Image-level healthcheck. Compose's healthcheck will override this
+# when launched via `docker compose up`; the duplicate exists so plain
+# `docker run` smoke tests still surface health, and so that a host-
+# orchestrated `docker ps` shows the container's true state.
+#
+# `wget -q -O- ... || exit 1` — busybox wget exits non-zero on any
+# 4xx/5xx, which is what we want. The `-q` keeps stderr quiet so
+# `docker logs` doesn't fill with health probe noise.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -q -O- http://127.0.0.1:8080/health || exit 1
+
+# tini handles signals; node runs the standalone server entrypoint.
+# The entrypoint lives at `apps/murmur-shim/server.js` because the
+# build's outputFileTracingRoot was the monorepo root.
+ENTRYPOINT ["/sbin/tini", "--"]
+CMD ["node", "apps/murmur-shim/server.js"]

--- a/apps/murmur-shim/Dockerfile.dockerignore
+++ b/apps/murmur-shim/Dockerfile.dockerignore
@@ -1,0 +1,78 @@
+# BuildKit reads `<Dockerfile>.dockerignore` (this file) when the build
+# is invoked with `-f apps/murmur-shim/Dockerfile <ctx>`. We ship this
+# alongside the Dockerfile so the exclusion list lives next to the
+# image it governs, regardless of whether the build context is the
+# repo root or some other parent directory.
+#
+# Source: jobseek#2774 (H2 — Dockerfile + image for jobseek-murmur-shim).
+#
+# Patterns are evaluated against paths inside the build context. We
+# build with context = monorepo root.
+#
+# Philosophy: we only PRUNE noise — we don't try to be surgical about
+# sibling apps. The Dockerfile's runtime stage COPY's only the
+# `.next/standalone` + `.next/static` trees from the builder, so what
+# ends up in the final image is bounded by the build, not by the
+# build context. The exclusions below speed up `docker build`'s
+# initial "transferring context" phase but don't affect image size.
+
+# ──────────────── never copy ────────────────
+
+# Local dev artefacts. The builder stage rebuilds node_modules from
+# pnpm-lock.yaml; carrying the host's node_modules across is both
+# wasteful and a source of "works on my machine" drift (different OS /
+# arch native bindings).
+**/node_modules/
+**/.next/
+**/.turbo/
+**/dist/
+**/coverage/
+**/.vitest-cache/
+
+# Tests are not needed in the runtime image. The builder stage runs
+# `pnpm --filter @jobseek/murmur-shim build` which bundles only the
+# routes / pages, not test files; excluding here just shrinks the
+# context payload.
+**/__tests__/
+**/*.test.ts
+**/*.test.tsx
+**/*.spec.ts
+**/*.spec.tsx
+
+# Repo metadata. Git history serves no build/runtime purpose;
+# .github/ is CI-only.
+.git/
+.github/
+.gitignore
+.gitattributes
+.husky/
+lefthook.yml
+.lefthook.yml
+
+# Editor / OS noise.
+.idea/
+.vscode/
+.DS_Store
+**/*.log
+**/.eslintcache
+
+# Secrets. Never bake env files into an image — compose passes them at
+# runtime via `env_file:`. Excluding here is belt-and-braces; the
+# Dockerfile itself never `COPY`s `.env*`.
+.env
+.env.*
+!.env.example
+
+# Documentation. None of these affect what the image runs; trimming
+# them keeps the build context small.
+**/*.md
+LICENSE
+LICENCE
+CHANGELOG*
+
+# Crawler venv / data (large, not needed in shim image — shim spawns
+# python from a host-mounted venv at runtime, never bakes one in).
+apps/crawler/.venv/
+apps/crawler/.uv-cache/
+apps/crawler/data/
+apps/crawler/traces/

--- a/apps/murmur-shim/app/health/health.test.ts
+++ b/apps/murmur-shim/app/health/health.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Tests for the public /health endpoint.
+ *
+ * Pinned by colophon-group/jobseek#2774 (H2). The Docker image's
+ * `HEALTHCHECK`, the compose stack's healthcheck, and the cloudflared
+ * origin-up probe all hit this route without an Authorization header,
+ * so the handler MUST be reachable without `MURMUR_TOKEN` configured
+ * and MUST NOT call `requireBearer`. These tests pin both behaviours.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { GET } from "./route";
+
+describe("GET /health", () => {
+  const originalToken = process.env.MURMUR_TOKEN;
+
+  beforeEach(() => {
+    delete process.env.MURMUR_TOKEN;
+  });
+
+  afterEach(() => {
+    if (originalToken === undefined) {
+      delete process.env.MURMUR_TOKEN;
+    } else {
+      process.env.MURMUR_TOKEN = originalToken;
+    }
+  });
+
+  it("returns 200 and { ok: true } with no Authorization header", async () => {
+    const res = GET();
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { ok: boolean };
+    expect(body).toEqual({ ok: true });
+  });
+
+  it("returns 200 even when MURMUR_TOKEN is unset (probes pre-date secret)", async () => {
+    // Sanity: the bearered routes return 401 in this state. The health
+    // route must not — otherwise the docker healthcheck flaps the
+    // container before MURMUR_TOKEN is wired up by compose.
+    expect(process.env.MURMUR_TOKEN).toBeUndefined();
+    const res = GET();
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 200 even when MURMUR_TOKEN is set (probe never sends bearer)", async () => {
+    process.env.MURMUR_TOKEN = "any-non-empty-value";
+    const res = GET();
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/murmur-shim/app/health/route.ts
+++ b/apps/murmur-shim/app/health/route.ts
@@ -1,0 +1,38 @@
+/**
+ * Public health endpoint for the murmur-shim container.
+ *
+ * Three callers depend on this route, none of which can present a
+ * bearer token:
+ *
+ *   1. The Docker image's `HEALTHCHECK` directive (busybox `wget`
+ *      against `http://localhost:8080/health`).
+ *   2. The compose-level healthcheck in H3's docker-compose.yml.
+ *   3. Cloudflared's `originRequest.proxyAddress` upstream-up probe in
+ *      the H4 deploy.
+ *
+ * Auth in this app is per-route (each handler calls `requireBearer`
+ * itself — there is no global Hono-style middleware). Leaving this
+ * handler off the bearer path is therefore sufficient to make it
+ * publicly reachable; we don't need an explicit exemption.
+ *
+ * The body is intentionally trivial (`{ ok: true }`). It exists only to
+ * prove the Node process is up and the routing layer answers; the route
+ * does NOT touch the database or the Python venv on purpose — a degraded
+ * DB or a missing venv-mount must not cause the container to be marked
+ * unhealthy and restart-looped, since the same shim is what reports the
+ * problem to the agent.
+ *
+ * @see colophon-group/jobseek#2774 (H2 — Dockerfile + image)
+ */
+
+import { NextResponse } from "next/server";
+
+// Force the route handler to be evaluated per-request rather than
+// statically pre-rendered; Next 16 otherwise treats simple GET handlers
+// without dynamic markers as cacheable, which would mask real outages
+// (a stale cached "ok" served while the process is wedged).
+export const dynamic = "force-dynamic";
+
+export function GET(): NextResponse {
+  return NextResponse.json({ ok: true });
+}


### PR DESCRIPTION
## Summary
Multi-stage Dockerfile under `apps/murmur-shim/` that produces a small **linux/amd64** image (no Python baked in — runtime spawns `python3` from a host-mounted crawler venv). Adds a public `/health` route so the docker `HEALTHCHECK` and the cloudflared origin-up probe can hit it without a bearer token.

The Hetzner crawler box (`116.203.192.19`) is **x86_64** (`uname -m` → `x86_64`), so the production image targets `linux/amd64`. The Dockerfile itself has no hard-coded `--platform` pin in its `FROM` stages — buildx picks the arch from the `--platform=...` flag at invocation time, so the same Dockerfile can be used for amd64 production and arm64 local sanity-builds. Production/CI MUST pass `--platform=linux/amd64`.

## Related issue
Closes colophon-group/jobseek#2774

## Files changed (high-level)
- `apps/murmur-shim/Dockerfile` — multi-stage build (`node:22-alpine` builder + runtime, Corepack-pinned pnpm 10.30.0, tini PID 1, non-root `node` user, EXPOSE 8080). Header documents the linux/amd64 target.
- `apps/murmur-shim/Dockerfile.dockerignore` — context exclusions (`node_modules`, `.next`, `.git`, tests, docs, crawler venv/data).
- `apps/murmur-shim/app/health/route.ts` — `GET /health` returning `{ ok: true }` with `dynamic = "force-dynamic"`. Added in this PR (the issue called it out as fast-follow; cheap to do here).
- `apps/murmur-shim/app/health/health.test.ts` — pins the no-bearer behaviour: returns 200 with `MURMUR_TOKEN` unset, set, or no `Authorization` header at all.

## Verification (from the issue, re-run on amd64)
- [x] `docker buildx build --platform=linux/amd64 -f apps/murmur-shim/Dockerfile .` succeeds → **68.3 MB** (image manifest: `amd64/linux`)
- [x] `docker buildx build --platform=linux/arm64 ...` also succeeds (same Dockerfile, different `--platform` flag) — used during initial dev as a native sanity build on Apple silicon.
- [x] `curl -sfI http://localhost:8082/health` → `HTTP/1.1 200 OK`, body `{"ok":true}`, served within 5 s of `docker run`
- [x] `curl -X POST http://localhost:8082/api/murmur/probes/monitor` (no bearer) → `401` (auth still rejects on amd64; GET → 405 because the route is POST-only).
- [x] Image size **< 250 MB** target — 68.3 MB, well under.
- [x] `id` → `uid=1000(node) gid=1000(node)` (non-root).
- [x] `which python3 || echo no-python` → `no-python` (Python NOT in image).
- [x] `node --check /app/apps/murmur-shim/server.js` → ok (standalone bundle is well-formed under amd64).

## Manual checks run locally
- `pnpm --filter @jobseek/murmur-shim build` ✓ (Next emits `/health` as `ƒ` dynamic route)
- `pnpm --filter @jobseek/murmur-shim test` ✓ (199 passed, 1 skipped — includes 3 health tests)
- `pnpm --filter @jobseek/murmur-shim lint` ✓
- `docker buildx build --platform=linux/amd64 --load ...` ✓ (cross-build via QEMU on Apple silicon, ~2 min)
- `docker run -d -p 8082:8080 ... && curl /health` ✓ on amd64 (warning is just docker noting host platform mismatch, expected)

## Workspace re-export sanity check
The shim's `src/db/schema.ts` does `export * from "../../../web/src/db/schema"`. Verified that Next's standalone tracer follows the relative path and inlines all table definitions into a single bundled chunk:

```
.next/server/chunks/apps_murmur-shim_src_db_schema_ts_0-_iw4l._.js
```

That chunk contains both `murmurClaimKv` / `murmur_claim_kv` and `murmurAcceptLog` / `murmur_accept_log` (plus the rest of the web schema graph). The `.ts` source file at `.next/standalone/apps/murmur-shim/src/db/schema.ts` is a tracer breadcrumb left over from the build — it's not what runs at runtime; the bundled JS chunk is.

## /health auth audit
The shim's auth pattern is **per-route**: each existing handler calls `requireBearer(request)` as its first line of work (see `_lib/auth.ts` and the `accept` / `_lib/handle.ts` routes). There is no global Hono-style middleware. Leaving `requireBearer` off the `/health` handler is therefore sufficient to make it publicly reachable; the docker `HEALTHCHECK` and the H4 cloudflared upstream-up probe both work without `MURMUR_TOKEN`. A test file pins this — failing if a future refactor accidentally globalises auth.

## Notes for reviewer
- **Build context is the monorepo root**, not `apps/murmur-shim/`. Documented at the top of the Dockerfile. The shim's `next.config.ts` sets `outputFileTracingRoot` to the monorepo root, so the standalone tree mirrors the repo layout (`/app/apps/murmur-shim/server.js`); the runtime CMD is `node apps/murmur-shim/server.js`.
- The issue text mentioned `VENV_PYTHON` and `PYTHONPATH` as the runtime env names. The actual code in `_lib/invoke-lib.ts` reads `MURMUR_PY` and `MURMUR_CRAWLER_ROOT` (with `PYTHONPATH` set automatically inside the spawn). Documented the discrepancy in the Dockerfile comment block; the ENV defaults in the runtime stage use the names the code actually reads. Compose (H3) wires those.
- `apps/web/package.json`, `apps/trace-viewer/package.json`, `apps/crawler/murmur/package.json`, `packages/mcp-server/package.json` are copied into the builder stage as a workspace-resolution requirement (pnpm refuses to install if any workspace member's manifest is missing). They're discarded in the runtime stage.
- The Dockerfile uses `Dockerfile.dockerignore` (BuildKit colocated form) rather than a root-level `.dockerignore`. Docker reads it automatically when invoked with `-f apps/murmur-shim/Dockerfile`.

## H4 follow-ups (not this PR)
- CI workflow that does `docker buildx build --platform=linux/amd64` via QEMU on every PR touching `apps/murmur-shim/**` or `pnpm-lock.yaml` (issue calls out the quality-gate rebuild).
- Compose stack (H3) to wire the venv mounts and env vars.