### PR TITLE
fix(ci): switch murmur-shim workflow to linux/amd64

### DIFF
--- a/.github/workflows/deploy-murmur-shim.yml
+++ b/.github/workflows/deploy-murmur-shim.yml
@@ -94,7 +94,7 @@ jobs:
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: ./apps/murmur-shim
-          platforms: linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ghcr.io/colophon-group/jobseek-murmur-shim:latest


### PR DESCRIPTION
## Summary
H4 (#2776, PR #2782, merged) shipped `.github/workflows/deploy-murmur-shim.yml` building for `linux/arm64`, but the jobseek crawler box (116.203.192.19) is x86_64. The orchestrator generalized the platform from the murmur box (which IS arm64) without checking that the jobseek crawler box differs. One-line swap to `linux/amd64`.

## Related issue
Closes colophon-group/jobseek#2784

## Files changed (high-level)
- `.github/workflows/deploy-murmur-shim.yml` — `platforms: linux/arm64` -> `platforms: linux/amd64`

## Verification (from the issue)
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-murmur-shim.yml'))"` succeeds
- [x] `grep -n 'arm64' .github/workflows/deploy-murmur-shim.yml` shows zero references after the edit
- [x] `actionlint .github/workflows/deploy-murmur-shim.yml` clean

## Notes for reviewer
- Single-file, single-line change. No interaction with H2 (#2783), which fixes the same arch mismatch on the Dockerfile/base-image side.
- Real verification — first deploy actually pulls and runs on the crawler box — happens post-merge once H3 lands the compose service.