### PR TITLE
fix(ci): build context = monorepo root for shim Dockerfile

### DIFF
--- a/.github/workflows/deploy-murmur-shim.yml
+++ b/.github/workflows/deploy-murmur-shim.yml
@@ -93,7 +93,12 @@ jobs:
       - name: Build & push jobseek-murmur-shim
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
-          context: ./apps/murmur-shim
+          # Build context is the monorepo root because the Dockerfile COPYs
+          # apps/web/src/db/schema.ts (wildcard re-export) plus pnpm-lock.yaml
+          # and pnpm-workspace.yaml from the workspace root. Dockerfile path
+          # is therefore relative to root, not to apps/murmur-shim.
+          context: .
+          file: ./apps/murmur-shim/Dockerfile
           platforms: linux/amd64
           push: true
           tags: |


### PR DESCRIPTION
The H2 Dockerfile (apps/murmur-shim/Dockerfile, merged in #2783) COPYs from the monorepo root — apps/web/src/db/schema.ts (wildcard re-export), pnpm-lock.yaml, pnpm-workspace.yaml, packages/, etc. — but the workflow set context: ./apps/murmur-shim, so buildx tried to compute checksums against a tree where those paths didn't exist:

\`\`\`
ERROR: failed to compute cache key: failed to calculate checksum of ref ...: "/apps/web/src/db/schema.ts": not found
\`\`\`

Fix: context: . (monorepo root) + explicit file: ./apps/murmur-shim/Dockerfile. Verified locally that the Dockerfile's expected COPY paths resolve correctly when context is root.

Discovered: the build job kept failing on the first real fire from the H2 merge (run 25136236300). PR #2785 fixed the platform; this fixes the context.