### PR TITLE
fix(shim): read MURMUR_DB_DSN first, fall back to DATABASE_URL

### DIFF
--- a/apps/murmur-shim/src/db/index.ts
+++ b/apps/murmur-shim/src/db/index.ts
@@ -20,6 +20,16 @@
  * import would require either making web a workspace package or wiring
  * a relative import that tunnels through web's tsconfig. Either path
  * is more friction than the 14 lines below.
+ *
+ * DSN selection: `MURMUR_DB_DSN` first, `DATABASE_URL` as fallback.
+ * Per the colophon-group/jobseek protocol, the local Hetzner Postgres
+ * machine is the primary read-write DB; Supabase is a read-only mirror
+ * (CDC). All shim writes (`murmur_claim_kv`, `murmur_accept_log`)
+ * MUST go through the primary, so prod compose forwards
+ * `LOCAL_DATABASE_URL → MURMUR_DB_DSN`. `DATABASE_URL` stays as a
+ * fallback so local dev / tests still work when only the latter is
+ * set, and so the apps/web schema re-export is backward-compatible
+ * with the original `DATABASE_URL` convention.
  */
 import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
@@ -30,14 +40,35 @@ const globalForDb = globalThis as unknown as {
   _murmurShimDb?: PostgresJsDatabase<typeof schema>;
 };
 
+/**
+ * Resolve the Postgres DSN for the shim. Reads `MURMUR_DB_DSN` first
+ * (the prod-side var the compose forwards from `LOCAL_DATABASE_URL` —
+ * the Hetzner Postgres primary that holds `murmur_claim_kv` and
+ * `murmur_accept_log`), then falls back to `DATABASE_URL` for local
+ * dev / tests where only the latter is set. Returns the variable NAME
+ * for diagnostics so an unset config surfaces a clear error without
+ * leaking the value.
+ */
+function resolveDsn(): { value: string; name: string } {
+  const dsn = process.env.MURMUR_DB_DSN ?? process.env.DATABASE_URL;
+  if (!dsn) {
+    throw new Error(
+      "Neither MURMUR_DB_DSN nor DATABASE_URL is set; the shim needs " +
+        "a Postgres DSN to write `murmur_claim_kv` / `murmur_accept_log`.",
+    );
+  }
+  return {
+    value: dsn,
+    name: process.env.MURMUR_DB_DSN ? "MURMUR_DB_DSN" : "DATABASE_URL",
+  };
+}
+
 export const db = new Proxy({} as PostgresJsDatabase<typeof schema>, {
   get(_target, prop, receiver) {
     if (!globalForDb._murmurShimDb) {
-      if (!process.env.DATABASE_URL) {
-        throw new Error("DATABASE_URL is not set");
-      }
+      const dsn = resolveDsn();
       globalForDb._murmurShimDb = drizzle(
-        postgres(process.env.DATABASE_URL, {
+        postgres(dsn.value, {
           max: 10,
           idle_timeout: 20,
           max_lifetime: 300,


### PR DESCRIPTION
## Summary

Per the colophon-group/jobseek protocol, the local Hetzner Postgres machine is the primary read-write database; Supabase is a read-only mirror downstream of CDC. All shim writes (`murmur_claim_kv`, `murmur_accept_log`) MUST go to the primary.

Prod compose already forwards `LOCAL_DATABASE_URL → MURMUR_DB_DSN` on the murmur-shim service. Until now the shim's Drizzle client only read `DATABASE_URL`, which was unset inside the container — every `select`/`run`/`feedback` call surfaced as `errors:["internal_error"]`.

## How discovered

End-to-end demo run on Stripe:

- `probe monitor` → 200 OK (stateless probe; no DB)
- `select monitor` → 500 `internal_error` (claim-kv UPSERT throws)
- `run monitor` → 500 `internal_error` (claim-kv read throws)

The handle.ts try/catch swallowed the `DATABASE_URL is not set` throw and returned `internal_error` to the caller.

## Fix

`resolveDsn()` reads `MURMUR_DB_DSN` first, falls back to `DATABASE_URL`. Prod uses MURMUR_DB_DSN end-to-end. Local dev / unit tests that only set DATABASE_URL keep working.

Migrations 0074 + 0075 are already applied to the LOCAL Hetzner Postgres (where `company` lives, satisfying the accept_log FK). The Supabase mirror invariant is preserved — no orphan tables created on the read-only side; Supabase will receive these tables via CDC when local rows arrive.

## Test plan

- [x] `pnpm test src/lib/murmur/claim-kv` — 7 tests passing
- [x] `pnpm exec tsc --noEmit -p .` — clean (no source errors)
- [ ] On merge: shim restarts; `select monitor` returns 200 OK + persists into local `murmur_claim_kv`
- [ ] Full configure-board loop completes for Stripe (greenhouse, 491 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)