### PR TITLE
ci(deploy): also fire shim deploy on push to main

### DIFF
--- a/.github/workflows/deploy-murmur-shim.yml
+++ b/.github/workflows/deploy-murmur-shim.yml
@@ -53,7 +53,12 @@ name: Deploy murmur-shim
 
 on:
   push:
-    branches: [murmur-demo]
+    # `murmur-demo` was the long-lived integration branch during H1–H3
+    # and was squash-merged into `main` in #2793; subsequent work flows
+    # through main like the rest of jobseek. Both branches stay in the
+    # trigger list — main is the load-bearing one, `murmur-demo` is
+    # kept for the unlikely case anyone still pushes there.
+    branches: [main, murmur-demo]
     paths:
       - apps/murmur-shim/**
       - apps/crawler/docker-compose.yml


### PR DESCRIPTION
## Summary

`murmur-demo` was squash-merged into `main` in #2793; subsequent shim work flows through `main` like the rest of jobseek. The deploy-murmur-shim workflow only triggered on `murmur-demo`, so every shim PR landed on main now needs manual `workflow_dispatch`. Adding `main` to the trigger restores autopilot.

`murmur-demo` stays in the list as a safety net — main is load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)