### PR TITLE
fix(shim): allow optional sample_job_url on probe scraper

### DIFF
--- a/apps/crawler/murmur/pipelines/add-company.yaml
+++ b/apps/crawler/murmur/pipelines/add-company.yaml
@@ -332,6 +332,13 @@ subtasks:
             board_url:      { type: string, format: uri, pattern: "^https://" }
             monitor_type:   { type: string, minLength: 1 }
             monitor_config: { type: object }
+            # Optional explicit sample URL — the agent picks one from the
+            # prior `run monitor` response. Falls back to claim-kv state
+            # when absent (see apps/crawler/src/workspace/lib/probe.py).
+            sample_job_url:
+              type: string
+              format: uri
+              pattern: "^https://"
       - name: select scraper
         endpoint: POST https://jobseek.colophon-group.org/api/murmur/select/scraper
         input_schema:

--- a/apps/murmur-shim/app/api/murmur/_lib/schemas.ts
+++ b/apps/murmur-shim/app/api/murmur/_lib/schemas.ts
@@ -90,6 +90,13 @@ export const PROBE_SCRAPER_SCHEMA: SubcommandSchema = {
     board_url: { type: "string", format: "uri", pattern: "^https://" },
     monitor_type: { type: "string", minLength: 1 },
     monitor_config: { type: "object" },
+    // Optional explicit sample URL. The Python lib
+    // (`apps/crawler/src/workspace/lib/probe.py#probe_scraper`) falls
+    // back to `state.sample_urls` from claim-kv when absent; without
+    // this property the `additionalProperties:false` check rejects the
+    // field even though `cli_shim._do_probe_scraper` already plumbs
+    // it through.
+    sample_job_url: { type: "string", format: "uri", pattern: "^https://" },
   },
 } as const;
 


### PR DESCRIPTION
## Summary

`apps/crawler/src/workspace/lib/cli_shim.py#_do_probe_scraper` already passes `body.sample_job_url` through to the lib, but both the shim's `PROBE_SCRAPER_SCHEMA` and the pipeline-def's input_schema had `additionalProperties:false` without declaring the field — so agents passing it got rejected with a schema error before the lib ran.

Without the field, `probe_scraper` raises `WsConfigMissing` because `state.sample_urls` is never auto-populated by run_monitor: claim-kv state only stores monitor_type/scraper_type/configs, not URL lists.

## Discovered

End-to-end demo on Stripe:

- run_monitor returned 491 valid URLs ✅
- agent picks `https://stripe.com/jobs/search?gh_jid=...` and calls probe_scraper with it
- shim 400'd at the schema check before invoking the lib

## Fix

Declare `sample_job_url` as optional on both:

- `apps/murmur-shim/app/api/murmur/_lib/schemas.ts#PROBE_SCRAPER_SCHEMA`
- `apps/crawler/murmur/pipelines/add-company.yaml` (probe scraper subcommand input_schema)

The pipeline def needs re-registering against prod murmur after merge.

## Test plan

- [x] tsc clean
- [ ] After deploy + re-register: probe scraper with sample_job_url returns 200 + scraper candidates
- [ ] Full configure-board completes for Stripe (greenhouse, 491 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)