### PR TITLE
feat(web): /[lang]/companies/request landing page with prefilled request form

### DIFF
--- a/apps/web/app/[lang]/(app)/companies/request/__tests__/company-request-page-form.test.tsx
+++ b/apps/web/app/[lang]/(app)/companies/request/__tests__/company-request-page-form.test.tsx
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("server-only", () => ({}));
+
+// Stub the server action — useActionState will treat the returned shape as
+// state. We return success so the success branch renders.
+const mockRequestCompany = vi.fn();
+vi.mock("@/lib/actions/stats", () => ({
+  requestCompany: (_prev: unknown, fd: FormData) => mockRequestCompany(fd),
+}));
+
+// Stub the agent-run client helper.
+const mockRequestAgentRun = vi.fn();
+vi.mock("@/lib/companies/request-agent-run", () => ({
+  requestAgentRun: (input: unknown) => mockRequestAgentRun(input),
+}));
+
+// Stub the success card so we can assert it rendered with the right inputs.
+vi.mock("@/components/search/request-company-success", () => ({
+  RequestCompanySuccess: (props: {
+    companyName: string;
+    agentRun: unknown;
+    serverActionState: { issueNumber?: number; issueCreationFailed?: boolean };
+  }) => (
+    <div
+      data-testid="success-stub"
+      data-company-name={props.companyName}
+      data-agent-run-kind={
+        (props.agentRun as { kind?: string } | null)?.kind ?? ""
+      }
+    />
+  ),
+}));
+
+// Lingui macros — stub so the component can be rendered outside a real i18n
+// provider. Mirrors the approach used by agent-prompt-card tests but for the
+// macro layer.
+vi.mock("@lingui/react", () => ({
+  useLingui: () => ({
+    _: (msg: { message?: string; id?: string } | string) =>
+      typeof msg === "string" ? msg : (msg.message ?? msg.id ?? ""),
+  }),
+}));
+vi.mock("@lingui/react/macro", () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock("@lingui/core/macro", () => ({
+  msg: (m: { message?: string; id?: string }) => m,
+}));
+
+import { CompanyRequestPageForm } from "../company-request-page-form";
+
+beforeEach(() => {
+  mockRequestCompany.mockReset();
+  mockRequestAgentRun.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("CompanyRequestPageForm", () => {
+  it("renders the input with `defaultName` when no website is provided", () => {
+    render(<CompanyRequestPageForm locale="en" defaultName="Anthropic" />);
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    expect(input.value).toBe("Anthropic");
+  });
+
+  it("renders the input prefilled with the website URL when both name + website are provided", () => {
+    render(
+      <CompanyRequestPageForm
+        locale="en"
+        defaultName="Anthropic"
+        defaultWebsite="https://anthropic.com"
+      />,
+    );
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    // The URL gives the agent-run path the website it needs; the legacy
+    // single-input form is URL-aware via parseRequestInput.
+    expect(input.value).toBe("https://anthropic.com");
+  });
+
+  it("renders an empty input when no defaults are provided", () => {
+    render(<CompanyRequestPageForm locale="en" />);
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    expect(input.value).toBe("");
+  });
+
+  it("renders a hidden `locale` field set from props", () => {
+    const { container } = render(<CompanyRequestPageForm locale="de" />);
+    const hidden = container.querySelector(
+      "input[type='hidden'][name='locale']",
+    ) as HTMLInputElement | null;
+    expect(hidden).not.toBeNull();
+    expect(hidden?.value).toBe("de");
+  });
+
+  it("submits the form, fires the server action AND the agent-run call when input is a URL, then renders the AgentPromptCard branch", async () => {
+    const user = userEvent.setup();
+    mockRequestCompany.mockResolvedValue({ success: true, issueNumber: 42 });
+    mockRequestAgentRun.mockResolvedValue({
+      kind: "ok",
+      runId: "run_abc",
+      agentPrompt: "Add anthropic.com to jobseek...",
+    });
+
+    render(
+      <CompanyRequestPageForm
+        locale="en"
+        defaultName="Anthropic"
+        defaultWebsite="https://anthropic.com"
+      />,
+    );
+
+    const submit = screen.getByRole("button");
+    await user.click(submit);
+
+    await waitFor(() => {
+      expect(mockRequestCompany).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(mockRequestAgentRun).toHaveBeenCalledTimes(1);
+    });
+    const arg = mockRequestAgentRun.mock.calls[0]?.[0] as {
+      companyName: string;
+      website: string;
+    };
+    expect(arg.website).toBe("https://anthropic.com");
+    expect(arg.companyName).toBe("anthropic.com");
+
+    await waitFor(() => {
+      expect(screen.getByTestId("success-stub")).toBeTruthy();
+    });
+    const stub = screen.getByTestId("success-stub");
+    expect(stub.getAttribute("data-agent-run-kind")).toBe("ok");
+  });
+
+  it("does NOT fire requestAgentRun when the input is not a URL (legacy GH-issue path)", async () => {
+    const user = userEvent.setup();
+    mockRequestCompany.mockResolvedValue({ success: true });
+
+    render(<CompanyRequestPageForm locale="en" defaultName="Anthropic" />);
+
+    const submit = screen.getByRole("button");
+    await user.click(submit);
+
+    await waitFor(() => {
+      expect(mockRequestCompany).toHaveBeenCalledTimes(1);
+    });
+    expect(mockRequestAgentRun).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/[lang]/(app)/companies/request/__tests__/page.test.tsx
+++ b/apps/web/app/[lang]/(app)/companies/request/__tests__/page.test.tsx
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// Neutralise the build-time guard transitively imported by sessionCache.
+vi.mock("server-only", () => ({}));
+
+// Mock session check — we toggle authed/unauthed per test.
+const mockGetSessionUserId = vi.fn<() => Promise<string | null>>();
+vi.mock("@/lib/sessionCache", () => ({
+  getSessionUserId: () => mockGetSessionUserId(),
+}));
+
+// Mock next/navigation's redirect so we can observe the call without
+// throwing through React's render path.
+const mockRedirect = vi.fn((url: string) => {
+  throw new Error(`__redirect__:${url}`);
+});
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => mockRedirect(url),
+}));
+
+// Stub the embedded form so we can introspect the props the page passes.
+vi.mock("../company-request-page-form", () => ({
+  CompanyRequestPageForm: (props: {
+    locale: string;
+    defaultName?: string;
+    defaultWebsite?: string;
+  }) => (
+    <div
+      data-testid="form-stub"
+      data-locale={props.locale}
+      data-default-name={props.defaultName ?? ""}
+      data-default-website={props.defaultWebsite ?? ""}
+    />
+  ),
+}));
+
+// i18n loader is heavy and depends on filesystem — stub it.
+vi.mock("@/lib/i18n", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/i18n")>("@/lib/i18n");
+  return {
+    ...actual,
+    loadCatalog: vi.fn(async () => ({
+      i18n: {
+        _: (msg: { id?: string; message?: string } | string) =>
+          typeof msg === "string"
+            ? msg
+            : (msg.message ?? msg.id ?? ""),
+      },
+      messages: {},
+    })),
+  };
+});
+
+vi.mock("@lingui/react/server", () => ({
+  setI18n: vi.fn(),
+}));
+
+import CompaniesRequestPage from "../page";
+
+function renderPage(opts: {
+  lang?: string;
+  name?: string;
+  website?: string;
+}) {
+  const params = Promise.resolve({ lang: opts.lang ?? "en" });
+  const searchParams = Promise.resolve({
+    name: opts.name,
+    website: opts.website,
+  });
+  return CompaniesRequestPage({ params, searchParams });
+}
+
+beforeEach(() => {
+  mockGetSessionUserId.mockReset();
+  mockRedirect.mockClear();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("/[lang]/companies/request page", () => {
+  it("renders with 'Anthropic' prefilled when ?name=Anthropic", async () => {
+    mockGetSessionUserId.mockResolvedValue("user_1");
+    const ui = await renderPage({ name: "Anthropic" });
+    render(ui);
+
+    const stub = screen.getByTestId("form-stub");
+    expect(stub.getAttribute("data-default-name")).toBe("Anthropic");
+    expect(stub.getAttribute("data-default-website")).toBe("");
+    expect(stub.getAttribute("data-locale")).toBe("en");
+  });
+
+  it("renders with both name and website prefilled when both are present", async () => {
+    mockGetSessionUserId.mockResolvedValue("user_1");
+    const ui = await renderPage({
+      name: "Anthropic",
+      website: "https://anthropic.com",
+    });
+    render(ui);
+
+    const stub = screen.getByTestId("form-stub");
+    expect(stub.getAttribute("data-default-name")).toBe("Anthropic");
+    expect(stub.getAttribute("data-default-website")).toBe(
+      "https://anthropic.com",
+    );
+  });
+
+  it("renders an empty form when no query params are provided", async () => {
+    mockGetSessionUserId.mockResolvedValue("user_1");
+    const ui = await renderPage({});
+    render(ui);
+
+    const stub = screen.getByTestId("form-stub");
+    expect(stub.getAttribute("data-default-name")).toBe("");
+    expect(stub.getAttribute("data-default-website")).toBe("");
+  });
+
+  it("renders the personalized heading when ?name is provided", async () => {
+    mockGetSessionUserId.mockResolvedValue("user_1");
+    const ui = await renderPage({ name: "Anthropic" });
+    render(ui);
+
+    // Heading copy: "Sorry, *Anthropic* isn't in our catalog yet. Want us to
+    // add it?" — assert the company name appears in the heading.
+    const heading = screen.getByRole("heading", { level: 1 });
+    expect(heading.textContent ?? "").toContain("Anthropic");
+  });
+
+  it("renders the generic heading when ?name is empty", async () => {
+    mockGetSessionUserId.mockResolvedValue("user_1");
+    const ui = await renderPage({});
+    render(ui);
+
+    const heading = screen.getByRole("heading", { level: 1 });
+    // Generic heading should not embed an empty placeholder.
+    expect(heading.textContent ?? "").not.toContain("undefined");
+    // And should contain a sensible prompt — we look for the word "company"
+    // (case-insensitive) so the test isn't tightly-coupled to phrasing.
+    expect(heading.textContent ?? "").toMatch(/company/i);
+  });
+
+  it("redirects unauthed users to the sign-in page with ?next= set", async () => {
+    mockGetSessionUserId.mockResolvedValue(null);
+    await expect(
+      renderPage({ name: "Anthropic", lang: "en" }),
+    ).rejects.toThrow(/__redirect__:/);
+
+    expect(mockRedirect).toHaveBeenCalledTimes(1);
+    const url = mockRedirect.mock.calls[0]?.[0] as string;
+    expect(url).toMatch(/^\/en\/sign-in\?next=/);
+    // The `next` param should encode our path + query so the user comes back.
+    const decoded = decodeURIComponent(url.split("next=")[1] ?? "");
+    expect(decoded).toContain("/en/companies/request");
+    expect(decoded).toContain("name=Anthropic");
+  });
+
+  it("renders a body paragraph that mentions the agent flow", async () => {
+    mockGetSessionUserId.mockResolvedValue("user_1");
+    const ui = await renderPage({ name: "Anthropic" });
+    const { container } = render(ui);
+
+    // Body paragraph should hint at the agent / Murmur flow that fires after
+    // submit. We assert "agent" appears somewhere in the page body to keep
+    // the test resilient to wording changes.
+    expect((container.textContent ?? "").toLowerCase()).toContain("agent");
+  });
+});

--- a/apps/web/app/[lang]/(app)/companies/request/__tests__/page.test.tsx
+++ b/apps/web/app/[lang]/(app)/companies/request/__tests__/page.test.tsx
@@ -36,6 +36,19 @@ vi.mock("../company-request-page-form", () => ({
 }));
 
 // i18n loader is heavy and depends on filesystem — stub it.
+// The stub `_` interpolates `{values}` placeholders so callers passing
+// `i18n._({ message: "Hello {name}", values: { name: "..." } })` get the
+// interpolated string back, which mirrors lingui's runtime behaviour
+// closely enough for these tests.
+function interpolate(
+  template: string,
+  values: Record<string, unknown> | undefined,
+): string {
+  if (!values) return template;
+  return template.replace(/\{(\w+)\}/g, (_, key) =>
+    key in values ? String(values[key]) : `{${key}}`,
+  );
+}
 vi.mock("@/lib/i18n", async () => {
   const actual =
     await vi.importActual<typeof import("@/lib/i18n")>("@/lib/i18n");
@@ -43,10 +56,19 @@ vi.mock("@/lib/i18n", async () => {
     ...actual,
     loadCatalog: vi.fn(async () => ({
       i18n: {
-        _: (msg: { id?: string; message?: string } | string) =>
-          typeof msg === "string"
-            ? msg
-            : (msg.message ?? msg.id ?? ""),
+        _: (
+          msg:
+            | {
+                id?: string;
+                message?: string;
+                values?: Record<string, unknown>;
+              }
+            | string,
+        ) => {
+          if (typeof msg === "string") return msg;
+          const tmpl = msg.message ?? msg.id ?? "";
+          return interpolate(tmpl, msg.values);
+        },
       },
       messages: {},
     })),

--- a/apps/web/app/[lang]/(app)/companies/request/company-request-page-form.tsx
+++ b/apps/web/app/[lang]/(app)/companies/request/company-request-page-form.tsx
@@ -1,5 +1,27 @@
 "use client";
 
+import { useActionState, useEffect, useRef, useState, useTransition } from "react";
+import { useLingui } from "@lingui/react";
+import { msg } from "@lingui/core/macro";
+import { Trans } from "@lingui/react/macro";
+import { requestCompany } from "@/lib/actions/stats";
+import { Button } from "@/components/ui/Button";
+import { ErrorAlert } from "@/components/ui/ErrorAlert";
+import { RequestCompanySuccess } from "@/components/search/request-company-success";
+import {
+  requestAgentRun,
+  type AgentRunRequestResult,
+} from "@/lib/companies/request-agent-run";
+import { parseRequestInput } from "@/lib/companies/parse-request-input";
+
+const errorMessages = {
+  empty: msg({ id: "app.home.request.error.empty", comment: "Error when company request input is empty", message: "Please enter a company name or URL." }),
+  too_short: msg({ id: "app.home.request.error.tooShort", comment: "Error when company request input is too short", message: "Input is too short." }),
+  too_long: msg({ id: "app.home.request.error.tooLong", comment: "Error when company request input is too long", message: "Input is too long." }),
+  invalid: msg({ id: "app.home.request.error.invalid", comment: "Error when company request input has no alphanumeric characters", message: "Please enter a valid company name or URL." }),
+  unknown: msg({ id: "app.home.request.error.unknown", comment: "Generic error when company request fails", message: "Something went wrong. Please try again." }),
+} as const;
+
 /**
  * Client form for the `/[lang]/companies/request` landing page.
  *
@@ -11,13 +33,11 @@
  *
  * The legacy single-field `input` is URL-aware (see `parseRequestInput`):
  *  - When both name and website are provided, we prefill with the URL so the
- *    agent-run path fires automatically.
+ *    agent-run path fires automatically on submit.
  *  - When only name is provided, we prefill with the raw name; the user can
  *    add a URL or submit as-is (legacy GH-issue path).
  *
  * Out of scope: changes to the shared `RequestCompanyPrompt` component.
- *
- * @throws never
  */
 export interface CompanyRequestPageFormProps {
   /** Locale code from the route params (used for the hidden `locale` field). */
@@ -28,6 +48,100 @@ export interface CompanyRequestPageFormProps {
   defaultWebsite?: string;
 }
 
-export function CompanyRequestPageForm(_: CompanyRequestPageFormProps) {
-  throw new Error("not implemented");
+function pickDefaultValue(name: string | undefined, website: string | undefined): string {
+  // Prefer the URL when present so the agent-run path fires (parseRequestInput
+  // requires an http(s) URL); fall back to the raw name otherwise.
+  if (website && website.trim().length > 0) return website;
+  if (name && name.trim().length > 0) return name;
+  return "";
+}
+
+export function CompanyRequestPageForm({
+  locale,
+  defaultName,
+  defaultWebsite,
+}: CompanyRequestPageFormProps) {
+  const { _: t } = useLingui();
+  const [state, action, isPending] = useActionState(requestCompany, null);
+  const formRef = useRef<HTMLFormElement>(null);
+  const [agentRun, setAgentRun] = useState<AgentRunRequestResult | null>(null);
+  const [submittedName, setSubmittedName] = useState<string>("");
+  const [, startTransition] = useTransition();
+
+  useEffect(() => {
+    if (state?.success) {
+      formRef.current?.reset();
+    }
+  }, [state]);
+
+  const errorMessage = state?.errorCode ? t(errorMessages[state.errorCode]) : "";
+
+  const initialValue = pickDefaultValue(defaultName, defaultWebsite);
+
+  function handleSubmit(formData: FormData) {
+    setAgentRun(null);
+    const raw = (formData.get("input") as string | null) ?? "";
+    const trimmed = raw.trim();
+
+    const fields = parseRequestInput(raw);
+    setSubmittedName(fields?.company_name ?? trimmed);
+
+    startTransition(() => {
+      action(formData);
+    });
+
+    if (fields) {
+      void requestAgentRun({
+        companyName: fields.company_name,
+        website: fields.website,
+      }).then(setAgentRun);
+    }
+  }
+
+  return (
+    <div className="mt-4 w-full max-w-md">
+      <form
+        ref={formRef}
+        action={handleSubmit}
+        className="flex flex-col gap-4 min-[480px]:flex-row min-[480px]:items-end"
+      >
+        <input type="hidden" name="locale" value={locale} />
+        <div className="flex-1">
+          <input
+            name="input"
+            type="text"
+            required
+            minLength={2}
+            maxLength={200}
+            defaultValue={initialValue}
+            placeholder={t(msg({
+              id: "app.home.request.placeholder",
+              comment: "Placeholder for the company request input field",
+              message: "e.g. https://boards.greenhouse.io/stripe",
+            }))}
+            className="w-full rounded-md border border-divider bg-background px-3 py-1.5 text-sm text-foreground outline-none focus:border-primary"
+            disabled={isPending}
+          />
+        </div>
+        <Button type="submit" disabled={isPending} size="sm">
+          {isPending
+            ? t(msg({ id: "app.home.request.submitting", comment: "Submit button while request is in progress", message: "Submitting..." }))
+            : <Trans id="app.home.request.submit" comment="Submit button for the company request form">Submit</Trans>}
+        </Button>
+      </form>
+      <div className="mt-3">
+        {state?.success && (
+          <RequestCompanySuccess
+            companyName={submittedName}
+            agentRun={agentRun}
+            serverActionState={{
+              issueNumber: state.issueNumber,
+              issueCreationFailed: state.issueCreationFailed,
+            }}
+          />
+        )}
+        <ErrorAlert message={errorMessage} />
+      </div>
+    </div>
+  );
 }

--- a/apps/web/app/[lang]/(app)/companies/request/company-request-page-form.tsx
+++ b/apps/web/app/[lang]/(app)/companies/request/company-request-page-form.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+/**
+ * Client form for the `/[lang]/companies/request` landing page.
+ *
+ * Mirrors the inline forms in `progress` and `explore` (single freeform
+ * `input` field, server action + parallel agent-run call, render
+ * `RequestCompanySuccess` on success). The only addition is the optional
+ * `defaultName` / `defaultWebsite` props used to prefill the input from the
+ * page's `?name=` / `?website=` query string.
+ *
+ * The legacy single-field `input` is URL-aware (see `parseRequestInput`):
+ *  - When both name and website are provided, we prefill with the URL so the
+ *    agent-run path fires automatically.
+ *  - When only name is provided, we prefill with the raw name; the user can
+ *    add a URL or submit as-is (legacy GH-issue path).
+ *
+ * Out of scope: changes to the shared `RequestCompanyPrompt` component.
+ *
+ * @throws never
+ */
+export interface CompanyRequestPageFormProps {
+  /** Locale code from the route params (used for the hidden `locale` field). */
+  locale: string;
+  /** Optional prefill from `?name=` query param. */
+  defaultName?: string;
+  /** Optional prefill from `?website=` query param. */
+  defaultWebsite?: string;
+}
+
+export function CompanyRequestPageForm(_: CompanyRequestPageFormProps) {
+  throw new Error("not implemented");
+}

--- a/apps/web/app/[lang]/(app)/companies/request/page.tsx
+++ b/apps/web/app/[lang]/(app)/companies/request/page.tsx
@@ -1,4 +1,8 @@
 import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+import { defaultLocale, isLocale, loadCatalog } from "@/lib/i18n";
+import { getSessionUserId } from "@/lib/sessionCache";
+import { CompanyRequestPageForm } from "./company-request-page-form";
 
 /**
  * `/[lang]/companies/request` — landing page for users who tried to find a
@@ -17,7 +21,7 @@ import type { Metadata } from "next";
  * @see colophon-group/jobseek#2807 (search-bar dropdown that links here)
  */
 export const metadata: Metadata = {
-  // The landing page is essentially a form, no value to crawlers.
+  // The landing page is essentially a form — no value to crawlers.
   robots: { index: false, follow: false },
 };
 
@@ -26,6 +30,68 @@ interface PageProps {
   searchParams: Promise<{ name?: string; website?: string }>;
 }
 
-export default async function CompaniesRequestPage(_: PageProps) {
-  throw new Error("not implemented");
+function buildSelfPath(
+  lang: string,
+  params: { name?: string; website?: string },
+): string {
+  const qs = new URLSearchParams();
+  if (params.name) qs.set("name", params.name);
+  if (params.website) qs.set("website", params.website);
+  const tail = qs.toString();
+  return `/${lang}/companies/request${tail.length > 0 ? `?${tail}` : ""}`;
+}
+
+export default async function CompaniesRequestPage({
+  params,
+  searchParams,
+}: PageProps) {
+  const { lang } = await params;
+  const sp = await searchParams;
+  const locale = isLocale(lang) ? lang : defaultLocale;
+
+  const userId = await getSessionUserId();
+  if (!userId) {
+    const next = encodeURIComponent(buildSelfPath(lang, sp));
+    redirect(`/${lang}/sign-in?next=${next}`);
+  }
+
+  const { i18n } = await loadCatalog(locale);
+
+  const name = (sp.name ?? "").trim();
+  const website = (sp.website ?? "").trim();
+
+  const heading = name
+    ? i18n._({
+        id: "companies.request.heading.named",
+        comment:
+          "Companies-request page heading when a company name was supplied via query string",
+        message: "Sorry, {name} isn't in our catalog yet. Want us to add it?",
+        values: { name },
+      })
+    : i18n._({
+        id: "companies.request.heading.generic",
+        comment:
+          "Companies-request page heading when no company name was supplied",
+        message: "Request a company",
+      });
+
+  const body = i18n._({
+    id: "companies.request.body",
+    comment:
+      "Companies-request page body paragraph explaining the agent-driven request flow",
+    message:
+      "Tell us the company name and (ideally) a careers-page URL. We'll prepare a prompt for your AI agent to add it to jobseek through Murmur — usually faster than waiting for our weekly batch.",
+  });
+
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col items-start gap-4 py-8">
+      <h1 className="text-2xl font-semibold text-foreground">{heading}</h1>
+      <p className="text-sm text-muted">{body}</p>
+      <CompanyRequestPageForm
+        locale={locale}
+        defaultName={name || undefined}
+        defaultWebsite={website || undefined}
+      />
+    </div>
+  );
 }

--- a/apps/web/app/[lang]/(app)/companies/request/page.tsx
+++ b/apps/web/app/[lang]/(app)/companies/request/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+
+/**
+ * `/[lang]/companies/request` — landing page for users who tried to find a
+ * company that isn't in the catalog yet.
+ *
+ * - Reads `?name=` / `?website=` from the query string and prefills the form.
+ * - Heading: "Sorry, *{name}* isn't in our catalog yet. Want us to add it?"
+ *   When `?name` is empty: "Request a company".
+ * - Auth-gated: signed-in users only. Unauthed visitors are redirected to
+ *   `/[lang]/sign-in?next=/[lang]/companies/request?...` so they come back.
+ * - On successful submit, the embedded form renders the AgentPromptCard
+ *   inline — the page does NOT redirect.
+ *
+ * @see colophon-group/jobseek#2808 (this issue)
+ * @see colophon-group/jobseek#2806 (agent-prompt card + RequestCompanySuccess)
+ * @see colophon-group/jobseek#2807 (search-bar dropdown that links here)
+ */
+export const metadata: Metadata = {
+  // The landing page is essentially a form, no value to crawlers.
+  robots: { index: false, follow: false },
+};
+
+interface PageProps {
+  params: Promise<{ lang: string }>;
+  searchParams: Promise<{ name?: string; website?: string }>;
+}
+
+export default async function CompaniesRequestPage(_: PageProps) {
+  throw new Error("not implemented");
+}

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -475,7 +475,7 @@ msgstr "Standort hinzufügen..."
 
 #. Aria label for the region containing the agent prompt code block
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:105
+#: src/components/search/request-company-success.tsx:110
 msgid "app.home.request.agent.promptRegionLabel"
 msgstr ""
 
@@ -610,16 +610,16 @@ msgstr "Beworben"
 msgid "myJobs.status.applied"
 msgstr "Beworben"
 
-#. Sankey funnel node: applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:42
-msgid "myJobs.funnel.applied"
-msgstr "Beworben"
-
 #. Application tracker status: applied
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:462
 msgid "search.tracker.applied"
+msgstr "Beworben"
+
+#. Sankey funnel node: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:42
+msgid "myJobs.funnel.applied"
 msgstr "Beworben"
 
 #. Status option in dropdown: applied
@@ -683,16 +683,16 @@ msgstr "Aug"
 msgid "settings.account.username.available"
 msgstr "Verfügbar"
 
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Zurück zur Anmeldung"
-
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Zurück zur Anmeldung"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Zurück zur Anmeldung"
 
 #. Link back to sign-in from forgot password
@@ -1081,7 +1081,7 @@ msgstr "Cookies dienen nur der Sitzung — keine Werbung, kein Tracking."
 
 #. Toast shown briefly after the agent prompt is copied
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:84
+#: src/components/search/request-company-success.tsx:89
 msgid "app.home.request.agent.copied"
 msgstr ""
 
@@ -1093,13 +1093,13 @@ msgstr "Den Code für jeden Zweck kopieren und ändern, einschließlich kommerzi
 
 #. Toast shown when copying the agent prompt to the clipboard failed
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:91
+#: src/components/search/request-company-success.tsx:96
 msgid "app.home.request.agent.copyFailed"
 msgstr ""
 
 #. Label for the copy-prompt button on the agent-prompt success card
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:77
+#: src/components/search/request-company-success.tsx:82
 msgid "app.home.request.agent.copyButton"
 msgstr ""
 
@@ -1277,7 +1277,7 @@ msgstr "Details"
 
 #. Subtext encouraging user to request a company when no results found
 #. js-lingui-explicit-id
-#: src/components/search/request-company.tsx:69
+#: src/components/search/request-company.tsx:75
 msgid "search.zero.subtext"
 msgstr "Haben Sie das gesuchte Unternehmen nicht gefunden?"
 
@@ -1327,10 +1327,12 @@ msgstr "Kein Scraping, keine automatisierten Bewerbungen, kein Missbrauch der Pl
 #. Placeholder for the company request input field
 #. Placeholder for the company request input field
 #. Placeholder for the company request input field
+#. Placeholder for the company request input field
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/company-request-form.tsx:75
-#: app/[lang]/(app)/progress/company-request-form.tsx:75
-#: src/components/search/request-company.tsx:88
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:117
+#: app/[lang]/(app)/explore/company-request-form.tsx:79
+#: app/[lang]/(app)/progress/company-request-form.tsx:79
+#: src/components/search/request-company.tsx:94
 msgid "app.home.request.placeholder"
 msgstr "z.B. Stripe, oder https://boards.greenhouse.io/stripe"
 
@@ -1928,7 +1930,9 @@ msgstr "Branche"
 #. Error when company request input is too long
 #. Error when company request input is too long
 #. Error when company request input is too long
+#. Error when company request input is too long
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:20
 #: app/[lang]/(app)/explore/company-request-form.tsx:20
 #: app/[lang]/(app)/progress/company-request-form.tsx:20
 #: src/components/search/request-company.tsx:21
@@ -1938,7 +1942,9 @@ msgstr "Eingabe ist zu lang."
 #. Error when company request input is too short
 #. Error when company request input is too short
 #. Error when company request input is too short
+#. Error when company request input is too short
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:19
 #: app/[lang]/(app)/explore/company-request-form.tsx:19
 #: app/[lang]/(app)/progress/company-request-form.tsx:19
 #: src/components/search/request-company.tsx:20
@@ -2705,21 +2711,21 @@ msgstr "Nein. Der Bewerbungstracker hat kein festes Limit — speichere so viele
 msgid "faq.a.dataPrivacy"
 msgstr "Nein. Wir verkaufen, vermieten oder teilen deine Daten nicht zu Marketingzwecken. Cookies sind nur sitzungsbasiert, ohne Werbung oder Tracking. Du kannst dein Konto löschen und alle Daten werden innerhalb von 30 Tagen entfernt."
 
-#. Sankey funnel node: not applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:44
-msgid "myJobs.funnel.notApplied"
-msgstr "Nicht beworben"
-
 #. Application tracker status: not applied
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:461
 msgid "search.tracker.notApplied"
 msgstr "Nicht beworben"
 
+#. Sankey funnel node: not applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:44
+msgid "myJobs.funnel.notApplied"
+msgstr "Nicht beworben"
+
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:172
+#: src/components/search/request-company-success.tsx:177
 msgid "app.home.request.issueWarning"
 msgstr "Hinweis: Wir konnten kein Tracking-Issue erstellen, aber Ihre Anfrage wurde gespeichert."
 
@@ -3029,7 +3035,9 @@ msgstr "Abo"
 #. Error when company request input is empty
 #. Error when company request input is empty
 #. Error when company request input is empty
+#. Error when company request input is empty
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:18
 #: app/[lang]/(app)/explore/company-request-form.tsx:18
 #: app/[lang]/(app)/progress/company-request-form.tsx:18
 #: src/components/search/request-company.tsx:19
@@ -3057,7 +3065,9 @@ msgstr "Bitte gib ein Passwort ein"
 #. Error when company request input has no alphanumeric characters
 #. Error when company request input has no alphanumeric characters
 #. Error when company request input has no alphanumeric characters
+#. Error when company request input has no alphanumeric characters
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:21
 #: app/[lang]/(app)/explore/company-request-form.tsx:21
 #: app/[lang]/(app)/progress/company-request-form.tsx:21
 #: src/components/search/request-company.tsx:22
@@ -3258,16 +3268,16 @@ msgstr "Abgelehnt"
 msgid "myJobs.status.rejected"
 msgstr "Abgelehnt"
 
-#. Sankey funnel node label prefix: rejected
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:45
-msgid "myJobs.funnel.rejected"
-msgstr "Abgelehnt"
-
 #. Application tracker status: rejected
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:465
 msgid "search.tracker.rejected"
+msgstr "Abgelehnt"
+
+#. Sankey funnel node label prefix: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:45
+msgid "myJobs.funnel.rejected"
 msgstr "Abgelehnt"
 
 #. Status option in dropdown: rejected
@@ -3294,6 +3304,12 @@ msgstr "Stichwort entfernen"
 msgid "search.locations.remove"
 msgstr "Standort entfernen"
 
+#. Companies-request page heading when no company name was supplied
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/page.tsx:71
+msgid "companies.request.heading.generic"
+msgstr ""
+
 #. Feature: request companies title
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/page.tsx:97
@@ -3303,13 +3319,13 @@ msgstr "Beliebiges Unternehmen anfragen"
 
 #. Success message after submitting a company request, with link to GitHub issue for tracking
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:141
+#: src/components/search/request-company-success.tsx:146
 msgid "app.home.request.success.withIssue"
 msgstr "Anfrage eingereicht! Verfolgen Sie den Fortschritt hier:"
 
 #. Success message when request was saved but GitHub issue could not be created
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:149
+#: src/components/search/request-company-success.tsx:154
 msgid "app.home.request.success.noIssue"
 msgstr "Anfrage eingereicht! Wir werden dieses Unternehmen in Kürze verfolgen."
 
@@ -3389,20 +3405,20 @@ msgstr "Runde"
 
 #. Label preceding the Murmur run id on the agent-prompt success card
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:98
+#: src/components/search/request-company-success.tsx:103
 msgid "app.home.request.agent.runIdLabel"
 msgstr ""
-
-#. Label for salary filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:171
-msgid "search.advanced.salary"
-msgstr "Gehalt"
 
 #. Salary override section heading
 #. js-lingui-explicit-id
 #: src/components/my-jobs/salary-override.tsx:76
 msgid "myJobs.detail.salary"
+msgstr "Gehalt"
+
+#. Label for salary filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:171
+msgid "search.advanced.salary"
 msgstr "Gehalt"
 
 #. Salary display settings section heading
@@ -3897,12 +3913,20 @@ msgstr "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
+#. Generic error when company request fails
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:22
 #: app/[lang]/(app)/explore/company-request-form.tsx:22
 #: app/[lang]/(app)/progress/company-request-form.tsx:22
 #: src/components/search/request-company.tsx:23
 msgid "app.home.request.error.unknown"
 msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
+
+#. Companies-request page heading when a company name was supplied via query string
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/page.tsx:64
+msgid "companies.request.heading.named"
+msgstr ""
 
 #. Star button label on company card
 #. js-lingui-explicit-id
@@ -3956,20 +3980,24 @@ msgstr "Link einfügen, Crawl starten"
 #. Submit button for the company request form
 #. Submit button for the company request form
 #. Submit button for the company request form
+#. Submit button for the company request form
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/company-request-form.tsx:87
-#: app/[lang]/(app)/progress/company-request-form.tsx:87
-#: src/components/search/request-company.tsx:100
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:129
+#: app/[lang]/(app)/explore/company-request-form.tsx:91
+#: app/[lang]/(app)/progress/company-request-form.tsx:91
+#: src/components/search/request-company.tsx:106
 msgid "app.home.request.submit"
 msgstr "Absenden"
 
 #. Submit button while request is in progress
 #. Submit button while request is in progress
 #. Submit button while request is in progress
+#. Submit button while request is in progress
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/company-request-form.tsx:86
-#: app/[lang]/(app)/progress/company-request-form.tsx:86
-#: src/components/search/request-company.tsx:99
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:128
+#: app/[lang]/(app)/explore/company-request-form.tsx:90
+#: app/[lang]/(app)/progress/company-request-form.tsx:90
+#: src/components/search/request-company.tsx:105
 msgid "app.home.request.submitting"
 msgstr "Wird gesendet..."
 
@@ -4032,6 +4060,12 @@ msgstr "Technologie"
 #: src/components/search/advanced-search-panel.tsx:159
 msgid "search.advanced.technology"
 msgstr "Technologie"
+
+#. Companies-request page body paragraph explaining the agent-driven request flow
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/page.tsx:78
+msgid "companies.request.body"
+msgstr ""
 
 #. Employment type: temporary
 #. js-lingui-explicit-id
@@ -4499,7 +4533,7 @@ msgstr "Wir nutzen eine Handvoll Drittanbieter für Anmeldung, Hosting und Speic
 
 #. Heading prefix on the agent-prompt success card; followed by the company name
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:62
+#: src/components/search/request-company-success.tsx:67
 msgid "app.home.request.agent.headingPrefix"
 msgstr ""
 
@@ -4599,7 +4633,7 @@ msgstr "Du kannst die Daten für Forschung oder persönliche Dashboards remixen/
 
 #. Body of the agent-prompt success card
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:69
+#: src/components/search/request-company-success.tsx:74
 msgid "app.home.request.agent.body"
 msgstr ""
 
@@ -4632,7 +4666,7 @@ msgstr "Du hast dich mit einem Social-Media-Konto angemeldet. Setze ein Passwort
 
 #. Message shown when the user has hit the per-hour limit on triggering Murmur company-add runs
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:122
+#: src/components/search/request-company-success.tsx:127
 msgid "app.home.request.agent.rateLimited"
 msgstr ""
 

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -406,7 +406,7 @@ msgstr "Add location..."
 
 #. Aria label for the region containing the agent prompt code block
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:105
+#: src/components/search/request-company-success.tsx:110
 msgid "app.home.request.agent.promptRegionLabel"
 msgstr "Agent prompt"
 
@@ -538,16 +538,16 @@ msgstr "Applied"
 msgid "myJobs.status.applied"
 msgstr "Applied"
 
-#. Sankey funnel node: applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:42
-msgid "myJobs.funnel.applied"
-msgstr "Applied"
-
 #. Application tracker status: applied
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:462
 msgid "search.tracker.applied"
+msgstr "Applied"
+
+#. Sankey funnel node: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:42
+msgid "myJobs.funnel.applied"
 msgstr "Applied"
 
 #. Status option in dropdown: applied
@@ -611,16 +611,16 @@ msgstr "Aug"
 msgid "settings.account.username.available"
 msgstr "Available"
 
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Back to sign in"
-
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Back to sign in"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Back to sign in"
 
 #. Link back to sign-in from forgot password
@@ -1009,7 +1009,7 @@ msgstr "Cookies are session-only — no ads, no tracking."
 
 #. Toast shown briefly after the agent prompt is copied
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:84
+#: src/components/search/request-company-success.tsx:89
 msgid "app.home.request.agent.copied"
 msgstr "Copied"
 
@@ -1021,13 +1021,13 @@ msgstr "Copy and modify the code for any purpose, including commercial products.
 
 #. Toast shown when copying the agent prompt to the clipboard failed
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:91
+#: src/components/search/request-company-success.tsx:96
 msgid "app.home.request.agent.copyFailed"
 msgstr "Copy failed"
 
 #. Label for the copy-prompt button on the agent-prompt success card
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:77
+#: src/components/search/request-company-success.tsx:82
 msgid "app.home.request.agent.copyButton"
 msgstr "Copy prompt"
 
@@ -1205,7 +1205,7 @@ msgstr "Details"
 
 #. Subtext encouraging user to request a company when no results found
 #. js-lingui-explicit-id
-#: src/components/search/request-company.tsx:69
+#: src/components/search/request-company.tsx:75
 msgid "search.zero.subtext"
 msgstr "Did not find the company you were looking for?"
 
@@ -1255,10 +1255,12 @@ msgstr "Don’t scrape the service, submit automated applications, or abuse the 
 #. Placeholder for the company request input field
 #. Placeholder for the company request input field
 #. Placeholder for the company request input field
+#. Placeholder for the company request input field
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/company-request-form.tsx:75
-#: app/[lang]/(app)/progress/company-request-form.tsx:75
-#: src/components/search/request-company.tsx:88
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:117
+#: app/[lang]/(app)/explore/company-request-form.tsx:79
+#: app/[lang]/(app)/progress/company-request-form.tsx:79
+#: src/components/search/request-company.tsx:94
 msgid "app.home.request.placeholder"
 msgstr "e.g. https://boards.greenhouse.io/stripe"
 
@@ -1856,7 +1858,9 @@ msgstr "Industry"
 #. Error when company request input is too long
 #. Error when company request input is too long
 #. Error when company request input is too long
+#. Error when company request input is too long
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:20
 #: app/[lang]/(app)/explore/company-request-form.tsx:20
 #: app/[lang]/(app)/progress/company-request-form.tsx:20
 #: src/components/search/request-company.tsx:21
@@ -1866,7 +1870,9 @@ msgstr "Input is too long."
 #. Error when company request input is too short
 #. Error when company request input is too short
 #. Error when company request input is too short
+#. Error when company request input is too short
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:19
 #: app/[lang]/(app)/explore/company-request-form.tsx:19
 #: app/[lang]/(app)/progress/company-request-form.tsx:19
 #: src/components/search/request-company.tsx:20
@@ -2633,21 +2639,21 @@ msgstr "No. The application tracker has no hard limit — save as many jobs as y
 msgid "faq.a.dataPrivacy"
 msgstr "No. We don't sell, rent, or share your data for marketing. Cookies are session-only with no ads or tracking. You can delete your account and all data is wiped within 30 days."
 
-#. Sankey funnel node: not applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:44
-msgid "myJobs.funnel.notApplied"
-msgstr "Not applied"
-
 #. Application tracker status: not applied
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:461
 msgid "search.tracker.notApplied"
 msgstr "Not applied"
 
+#. Sankey funnel node: not applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:44
+msgid "myJobs.funnel.notApplied"
+msgstr "Not applied"
+
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:172
+#: src/components/search/request-company-success.tsx:177
 msgid "app.home.request.issueWarning"
 msgstr "Note: We couldn't create a tracking issue, but your request was saved."
 
@@ -2945,7 +2951,9 @@ msgstr "Plan"
 #. Error when company request input is empty
 #. Error when company request input is empty
 #. Error when company request input is empty
+#. Error when company request input is empty
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:18
 #: app/[lang]/(app)/explore/company-request-form.tsx:18
 #: app/[lang]/(app)/progress/company-request-form.tsx:18
 #: src/components/search/request-company.tsx:19
@@ -2973,7 +2981,9 @@ msgstr "Please enter a password"
 #. Error when company request input has no alphanumeric characters
 #. Error when company request input has no alphanumeric characters
 #. Error when company request input has no alphanumeric characters
+#. Error when company request input has no alphanumeric characters
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:21
 #: app/[lang]/(app)/explore/company-request-form.tsx:21
 #: app/[lang]/(app)/progress/company-request-form.tsx:21
 #: src/components/search/request-company.tsx:22
@@ -3174,16 +3184,16 @@ msgstr "Rejected"
 msgid "myJobs.status.rejected"
 msgstr "Rejected"
 
-#. Sankey funnel node label prefix: rejected
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:45
-msgid "myJobs.funnel.rejected"
-msgstr "Rejected"
-
 #. Application tracker status: rejected
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:465
 msgid "search.tracker.rejected"
+msgstr "Rejected"
+
+#. Sankey funnel node label prefix: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:45
+msgid "myJobs.funnel.rejected"
 msgstr "Rejected"
 
 #. Status option in dropdown: rejected
@@ -3210,6 +3220,12 @@ msgstr "Remove keyword"
 msgid "search.locations.remove"
 msgstr "Remove location"
 
+#. Companies-request page heading when no company name was supplied
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/page.tsx:71
+msgid "companies.request.heading.generic"
+msgstr "Request a company"
+
 #. Feature: request companies title
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/page.tsx:97
@@ -3219,13 +3235,13 @@ msgstr "Request any company"
 
 #. Success message after submitting a company request, with link to GitHub issue for tracking
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:141
+#: src/components/search/request-company-success.tsx:146
 msgid "app.home.request.success.withIssue"
 msgstr "Request submitted! Track progress here:"
 
 #. Success message when request was saved but GitHub issue could not be created
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:149
+#: src/components/search/request-company-success.tsx:154
 msgid "app.home.request.success.noIssue"
 msgstr "Request submitted! We'll start tracking this company soon."
 
@@ -3305,20 +3321,20 @@ msgstr "Round"
 
 #. Label preceding the Murmur run id on the agent-prompt success card
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:98
+#: src/components/search/request-company-success.tsx:103
 msgid "app.home.request.agent.runIdLabel"
 msgstr "Run id"
-
-#. Label for salary filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:171
-msgid "search.advanced.salary"
-msgstr "Salary"
 
 #. Salary override section heading
 #. js-lingui-explicit-id
 #: src/components/my-jobs/salary-override.tsx:76
 msgid "myJobs.detail.salary"
+msgstr "Salary"
+
+#. Label for salary filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:171
+msgid "search.advanced.salary"
 msgstr "Salary"
 
 #. Salary display settings section heading
@@ -3789,12 +3805,20 @@ msgstr "Something went wrong. Please try again."
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
+#. Generic error when company request fails
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:22
 #: app/[lang]/(app)/explore/company-request-form.tsx:22
 #: app/[lang]/(app)/progress/company-request-form.tsx:22
 #: src/components/search/request-company.tsx:23
 msgid "app.home.request.error.unknown"
 msgstr "Something went wrong. Please try again."
+
+#. Companies-request page heading when a company name was supplied via query string
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/page.tsx:64
+msgid "companies.request.heading.named"
+msgstr "Sorry, {name} isn't in our catalog yet. Want us to add it?"
 
 #. Star button label on company card
 #. js-lingui-explicit-id
@@ -3848,20 +3872,24 @@ msgstr "Status tracking"
 #. Submit button for the company request form
 #. Submit button for the company request form
 #. Submit button for the company request form
+#. Submit button for the company request form
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/company-request-form.tsx:87
-#: app/[lang]/(app)/progress/company-request-form.tsx:87
-#: src/components/search/request-company.tsx:100
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:129
+#: app/[lang]/(app)/explore/company-request-form.tsx:91
+#: app/[lang]/(app)/progress/company-request-form.tsx:91
+#: src/components/search/request-company.tsx:106
 msgid "app.home.request.submit"
 msgstr "Submit"
 
 #. Submit button while request is in progress
 #. Submit button while request is in progress
 #. Submit button while request is in progress
+#. Submit button while request is in progress
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/company-request-form.tsx:86
-#: app/[lang]/(app)/progress/company-request-form.tsx:86
-#: src/components/search/request-company.tsx:99
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:128
+#: app/[lang]/(app)/explore/company-request-form.tsx:90
+#: app/[lang]/(app)/progress/company-request-form.tsx:90
+#: src/components/search/request-company.tsx:105
 msgid "app.home.request.submitting"
 msgstr "Submitting..."
 
@@ -3924,6 +3952,12 @@ msgstr "Technology"
 #: src/components/search/advanced-search-panel.tsx:159
 msgid "search.advanced.technology"
 msgstr "Technology"
+
+#. Companies-request page body paragraph explaining the agent-driven request flow
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/page.tsx:78
+msgid "companies.request.body"
+msgstr "Tell us the company name and (ideally) a careers-page URL. We'll prepare a prompt for your AI agent to add it to jobseek through Murmur — usually faster than waiting for our weekly batch."
 
 #. Employment type: temporary
 #. js-lingui-explicit-id
@@ -4391,7 +4425,7 @@ msgstr "We use a handful of third-party services for sign-in, hosting, and stora
 
 #. Heading prefix on the agent-prompt success card; followed by the company name
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:62
+#: src/components/search/request-company-success.tsx:67
 msgid "app.home.request.agent.headingPrefix"
 msgstr "We're working on adding"
 
@@ -4491,7 +4525,7 @@ msgstr "You can remix/transform the data for research or personal dashboards."
 
 #. Body of the agent-prompt success card
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:69
+#: src/components/search/request-company-success.tsx:74
 msgid "app.home.request.agent.body"
 msgstr "You can speed this up by asking your AI agent to complete it via Murmur."
 
@@ -4524,7 +4558,7 @@ msgstr "You signed in with a social account. Set a password to enable email chan
 
 #. Message shown when the user has hit the per-hour limit on triggering Murmur company-add runs
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:122
+#: src/components/search/request-company-success.tsx:127
 msgid "app.home.request.agent.rateLimited"
 msgstr "You've hit the hourly limit for company requests. Please try again later."
 

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -475,7 +475,7 @@ msgstr "Ajouter un lieu..."
 
 #. Aria label for the region containing the agent prompt code block
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:105
+#: src/components/search/request-company-success.tsx:110
 msgid "app.home.request.agent.promptRegionLabel"
 msgstr ""
 
@@ -610,16 +610,16 @@ msgstr "Postulé"
 msgid "myJobs.status.applied"
 msgstr "Postulé"
 
-#. Sankey funnel node: applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:42
-msgid "myJobs.funnel.applied"
-msgstr "Postulé"
-
 #. Application tracker status: applied
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:462
 msgid "search.tracker.applied"
+msgstr "Postulé"
+
+#. Sankey funnel node: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:42
+msgid "myJobs.funnel.applied"
 msgstr "Postulé"
 
 #. Status option in dropdown: applied
@@ -683,16 +683,16 @@ msgstr "Aoû"
 msgid "settings.account.username.available"
 msgstr "Disponible"
 
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Retour à la connexion"
-
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Retour à la connexion"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Retour à la connexion"
 
 #. Link back to sign-in from forgot password
@@ -1081,7 +1081,7 @@ msgstr "Les cookies servent uniquement à la session — pas de pub, pas de trac
 
 #. Toast shown briefly after the agent prompt is copied
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:84
+#: src/components/search/request-company-success.tsx:89
 msgid "app.home.request.agent.copied"
 msgstr ""
 
@@ -1093,13 +1093,13 @@ msgstr "Copie et modifie le code pour tout usage, y compris des produits commerc
 
 #. Toast shown when copying the agent prompt to the clipboard failed
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:91
+#: src/components/search/request-company-success.tsx:96
 msgid "app.home.request.agent.copyFailed"
 msgstr ""
 
 #. Label for the copy-prompt button on the agent-prompt success card
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:77
+#: src/components/search/request-company-success.tsx:82
 msgid "app.home.request.agent.copyButton"
 msgstr ""
 
@@ -1277,7 +1277,7 @@ msgstr "Détails"
 
 #. Subtext encouraging user to request a company when no results found
 #. js-lingui-explicit-id
-#: src/components/search/request-company.tsx:69
+#: src/components/search/request-company.tsx:75
 msgid "search.zero.subtext"
 msgstr "Vous n'avez pas trouvé l'entreprise recherchée ?"
 
@@ -1327,10 +1327,12 @@ msgstr "Pas de scraping, pas de candidatures automatisées, pas d'abus de la pla
 #. Placeholder for the company request input field
 #. Placeholder for the company request input field
 #. Placeholder for the company request input field
+#. Placeholder for the company request input field
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/company-request-form.tsx:75
-#: app/[lang]/(app)/progress/company-request-form.tsx:75
-#: src/components/search/request-company.tsx:88
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:117
+#: app/[lang]/(app)/explore/company-request-form.tsx:79
+#: app/[lang]/(app)/progress/company-request-form.tsx:79
+#: src/components/search/request-company.tsx:94
 msgid "app.home.request.placeholder"
 msgstr "ex. Stripe, ou https://boards.greenhouse.io/stripe"
 
@@ -1928,7 +1930,9 @@ msgstr "Secteur"
 #. Error when company request input is too long
 #. Error when company request input is too long
 #. Error when company request input is too long
+#. Error when company request input is too long
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:20
 #: app/[lang]/(app)/explore/company-request-form.tsx:20
 #: app/[lang]/(app)/progress/company-request-form.tsx:20
 #: src/components/search/request-company.tsx:21
@@ -1938,7 +1942,9 @@ msgstr "L'entrée est trop longue."
 #. Error when company request input is too short
 #. Error when company request input is too short
 #. Error when company request input is too short
+#. Error when company request input is too short
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:19
 #: app/[lang]/(app)/explore/company-request-form.tsx:19
 #: app/[lang]/(app)/progress/company-request-form.tsx:19
 #: src/components/search/request-company.tsx:20
@@ -2705,21 +2711,21 @@ msgstr "Non. Le suivi des candidatures n'a pas de limite — enregistrez autant 
 msgid "faq.a.dataPrivacy"
 msgstr "Non. Nous ne vendons, ne louons ni ne partageons vos données à des fins marketing. Les cookies sont uniquement de session, sans publicité ni tracking. Vous pouvez supprimer votre compte et toutes les données seront effacées sous 30 jours."
 
-#. Sankey funnel node: not applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:44
-msgid "myJobs.funnel.notApplied"
-msgstr "Non postulé"
-
 #. Application tracker status: not applied
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:461
 msgid "search.tracker.notApplied"
 msgstr "Non postulé"
 
+#. Sankey funnel node: not applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:44
+msgid "myJobs.funnel.notApplied"
+msgstr "Non postulé"
+
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:172
+#: src/components/search/request-company-success.tsx:177
 msgid "app.home.request.issueWarning"
 msgstr "Remarque : Nous n'avons pas pu créer un ticket de suivi, mais votre demande a été enregistrée."
 
@@ -3029,7 +3035,9 @@ msgstr "Abonnement"
 #. Error when company request input is empty
 #. Error when company request input is empty
 #. Error when company request input is empty
+#. Error when company request input is empty
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:18
 #: app/[lang]/(app)/explore/company-request-form.tsx:18
 #: app/[lang]/(app)/progress/company-request-form.tsx:18
 #: src/components/search/request-company.tsx:19
@@ -3057,7 +3065,9 @@ msgstr "Saisis un mot de passe"
 #. Error when company request input has no alphanumeric characters
 #. Error when company request input has no alphanumeric characters
 #. Error when company request input has no alphanumeric characters
+#. Error when company request input has no alphanumeric characters
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:21
 #: app/[lang]/(app)/explore/company-request-form.tsx:21
 #: app/[lang]/(app)/progress/company-request-form.tsx:21
 #: src/components/search/request-company.tsx:22
@@ -3258,16 +3268,16 @@ msgstr "Refusé"
 msgid "myJobs.status.rejected"
 msgstr "Refusé"
 
-#. Sankey funnel node label prefix: rejected
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:45
-msgid "myJobs.funnel.rejected"
-msgstr "Refusé"
-
 #. Application tracker status: rejected
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:465
 msgid "search.tracker.rejected"
+msgstr "Refusé"
+
+#. Sankey funnel node label prefix: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:45
+msgid "myJobs.funnel.rejected"
 msgstr "Refusé"
 
 #. Status option in dropdown: rejected
@@ -3294,6 +3304,12 @@ msgstr "Supprimer le mot-clé"
 msgid "search.locations.remove"
 msgstr "Supprimer le lieu"
 
+#. Companies-request page heading when no company name was supplied
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/page.tsx:71
+msgid "companies.request.heading.generic"
+msgstr ""
+
 #. Feature: request companies title
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/page.tsx:97
@@ -3303,13 +3319,13 @@ msgstr "Demander n'importe quelle entreprise"
 
 #. Success message after submitting a company request, with link to GitHub issue for tracking
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:141
+#: src/components/search/request-company-success.tsx:146
 msgid "app.home.request.success.withIssue"
 msgstr "Demande soumise ! Suivez la progression ici :"
 
 #. Success message when request was saved but GitHub issue could not be created
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:149
+#: src/components/search/request-company-success.tsx:154
 msgid "app.home.request.success.noIssue"
 msgstr "Demande soumise ! Nous commencerons bientôt à suivre cette entreprise."
 
@@ -3389,20 +3405,20 @@ msgstr "Tour"
 
 #. Label preceding the Murmur run id on the agent-prompt success card
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:98
+#: src/components/search/request-company-success.tsx:103
 msgid "app.home.request.agent.runIdLabel"
 msgstr ""
-
-#. Label for salary filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:171
-msgid "search.advanced.salary"
-msgstr "Salaire"
 
 #. Salary override section heading
 #. js-lingui-explicit-id
 #: src/components/my-jobs/salary-override.tsx:76
 msgid "myJobs.detail.salary"
+msgstr "Salaire"
+
+#. Label for salary filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:171
+msgid "search.advanced.salary"
 msgstr "Salaire"
 
 #. Salary display settings section heading
@@ -3897,12 +3913,20 @@ msgstr "Une erreur est survenue. Veuillez réessayer."
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
+#. Generic error when company request fails
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:22
 #: app/[lang]/(app)/explore/company-request-form.tsx:22
 #: app/[lang]/(app)/progress/company-request-form.tsx:22
 #: src/components/search/request-company.tsx:23
 msgid "app.home.request.error.unknown"
 msgstr "Une erreur s'est produite. Veuillez réessayer."
+
+#. Companies-request page heading when a company name was supplied via query string
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/page.tsx:64
+msgid "companies.request.heading.named"
+msgstr ""
 
 #. Star button label on company card
 #. js-lingui-explicit-id
@@ -3956,20 +3980,24 @@ msgstr "Colle un lien, lance un crawl"
 #. Submit button for the company request form
 #. Submit button for the company request form
 #. Submit button for the company request form
+#. Submit button for the company request form
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/company-request-form.tsx:87
-#: app/[lang]/(app)/progress/company-request-form.tsx:87
-#: src/components/search/request-company.tsx:100
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:129
+#: app/[lang]/(app)/explore/company-request-form.tsx:91
+#: app/[lang]/(app)/progress/company-request-form.tsx:91
+#: src/components/search/request-company.tsx:106
 msgid "app.home.request.submit"
 msgstr "Envoyer"
 
 #. Submit button while request is in progress
 #. Submit button while request is in progress
 #. Submit button while request is in progress
+#. Submit button while request is in progress
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/company-request-form.tsx:86
-#: app/[lang]/(app)/progress/company-request-form.tsx:86
-#: src/components/search/request-company.tsx:99
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:128
+#: app/[lang]/(app)/explore/company-request-form.tsx:90
+#: app/[lang]/(app)/progress/company-request-form.tsx:90
+#: src/components/search/request-company.tsx:105
 msgid "app.home.request.submitting"
 msgstr "Envoi en cours..."
 
@@ -4032,6 +4060,12 @@ msgstr "Technologie"
 #: src/components/search/advanced-search-panel.tsx:159
 msgid "search.advanced.technology"
 msgstr "Technologie"
+
+#. Companies-request page body paragraph explaining the agent-driven request flow
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/page.tsx:78
+msgid "companies.request.body"
+msgstr ""
 
 #. Employment type: temporary
 #. js-lingui-explicit-id
@@ -4499,7 +4533,7 @@ msgstr "Nous utilisons quelques services tiers pour la connexion, l’hébergeme
 
 #. Heading prefix on the agent-prompt success card; followed by the company name
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:62
+#: src/components/search/request-company-success.tsx:67
 msgid "app.home.request.agent.headingPrefix"
 msgstr ""
 
@@ -4599,7 +4633,7 @@ msgstr "Tu peux remixer ou transformer les données à des fins de recherche ou 
 
 #. Body of the agent-prompt success card
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:69
+#: src/components/search/request-company-success.tsx:74
 msgid "app.home.request.agent.body"
 msgstr ""
 
@@ -4632,7 +4666,7 @@ msgstr "Tu t'es connecté avec un compte social. Définis un mot de passe pour p
 
 #. Message shown when the user has hit the per-hour limit on triggering Murmur company-add runs
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:122
+#: src/components/search/request-company-success.tsx:127
 msgid "app.home.request.agent.rateLimited"
 msgstr ""
 

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -475,7 +475,7 @@ msgstr "Aggiungi località..."
 
 #. Aria label for the region containing the agent prompt code block
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:105
+#: src/components/search/request-company-success.tsx:110
 msgid "app.home.request.agent.promptRegionLabel"
 msgstr ""
 
@@ -610,16 +610,16 @@ msgstr "Candidato"
 msgid "myJobs.status.applied"
 msgstr "Candidato"
 
-#. Sankey funnel node: applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:42
-msgid "myJobs.funnel.applied"
-msgstr "Candidato"
-
 #. Application tracker status: applied
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:462
 msgid "search.tracker.applied"
+msgstr "Candidato"
+
+#. Sankey funnel node: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:42
+msgid "myJobs.funnel.applied"
 msgstr "Candidato"
 
 #. Status option in dropdown: applied
@@ -683,16 +683,16 @@ msgstr "Ago"
 msgid "settings.account.username.available"
 msgstr "Disponibile"
 
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Torna all'accesso"
-
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Torna all'accesso"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Torna all'accesso"
 
 #. Link back to sign-in from forgot password
@@ -1081,7 +1081,7 @@ msgstr "I cookie servono solo per la sessione — niente pubblicità, niente tra
 
 #. Toast shown briefly after the agent prompt is copied
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:84
+#: src/components/search/request-company-success.tsx:89
 msgid "app.home.request.agent.copied"
 msgstr ""
 
@@ -1093,13 +1093,13 @@ msgstr "Copiare e modificare il codice per qualsiasi scopo, inclusi prodotti com
 
 #. Toast shown when copying the agent prompt to the clipboard failed
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:91
+#: src/components/search/request-company-success.tsx:96
 msgid "app.home.request.agent.copyFailed"
 msgstr ""
 
 #. Label for the copy-prompt button on the agent-prompt success card
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:77
+#: src/components/search/request-company-success.tsx:82
 msgid "app.home.request.agent.copyButton"
 msgstr ""
 
@@ -1277,7 +1277,7 @@ msgstr "Dettagli"
 
 #. Subtext encouraging user to request a company when no results found
 #. js-lingui-explicit-id
-#: src/components/search/request-company.tsx:69
+#: src/components/search/request-company.tsx:75
 msgid "search.zero.subtext"
 msgstr "Non hai trovato l'azienda che cercavi?"
 
@@ -1327,10 +1327,12 @@ msgstr "Niente scraping, candidature automatizzate o abuso della piattaforma."
 #. Placeholder for the company request input field
 #. Placeholder for the company request input field
 #. Placeholder for the company request input field
+#. Placeholder for the company request input field
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/company-request-form.tsx:75
-#: app/[lang]/(app)/progress/company-request-form.tsx:75
-#: src/components/search/request-company.tsx:88
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:117
+#: app/[lang]/(app)/explore/company-request-form.tsx:79
+#: app/[lang]/(app)/progress/company-request-form.tsx:79
+#: src/components/search/request-company.tsx:94
 msgid "app.home.request.placeholder"
 msgstr "es. Stripe, oppure https://boards.greenhouse.io/stripe"
 
@@ -1928,7 +1930,9 @@ msgstr "Settore"
 #. Error when company request input is too long
 #. Error when company request input is too long
 #. Error when company request input is too long
+#. Error when company request input is too long
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:20
 #: app/[lang]/(app)/explore/company-request-form.tsx:20
 #: app/[lang]/(app)/progress/company-request-form.tsx:20
 #: src/components/search/request-company.tsx:21
@@ -1938,7 +1942,9 @@ msgstr "L'input è troppo lungo."
 #. Error when company request input is too short
 #. Error when company request input is too short
 #. Error when company request input is too short
+#. Error when company request input is too short
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:19
 #: app/[lang]/(app)/explore/company-request-form.tsx:19
 #: app/[lang]/(app)/progress/company-request-form.tsx:19
 #: src/components/search/request-company.tsx:20
@@ -2705,21 +2711,21 @@ msgstr "No. Il tracker delle candidature non ha limiti — salva quante offerte 
 msgid "faq.a.dataPrivacy"
 msgstr "No. Non vendiamo, affittiamo né condividiamo i tuoi dati a fini di marketing. I cookie sono solo di sessione, senza pubblicità né tracciamento. Puoi eliminare il tuo account e tutti i dati verranno cancellati entro 30 giorni."
 
-#. Sankey funnel node: not applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:44
-msgid "myJobs.funnel.notApplied"
-msgstr "Non candidato"
-
 #. Application tracker status: not applied
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:461
 msgid "search.tracker.notApplied"
 msgstr "Non candidato"
 
+#. Sankey funnel node: not applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:44
+msgid "myJobs.funnel.notApplied"
+msgstr "Non candidato"
+
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:172
+#: src/components/search/request-company-success.tsx:177
 msgid "app.home.request.issueWarning"
 msgstr "Nota: Non siamo riusciti a creare un ticket di monitoraggio, ma la tua richiesta è stata salvata."
 
@@ -3029,7 +3035,9 @@ msgstr "Piano"
 #. Error when company request input is empty
 #. Error when company request input is empty
 #. Error when company request input is empty
+#. Error when company request input is empty
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:18
 #: app/[lang]/(app)/explore/company-request-form.tsx:18
 #: app/[lang]/(app)/progress/company-request-form.tsx:18
 #: src/components/search/request-company.tsx:19
@@ -3057,7 +3065,9 @@ msgstr "Inserisci una password"
 #. Error when company request input has no alphanumeric characters
 #. Error when company request input has no alphanumeric characters
 #. Error when company request input has no alphanumeric characters
+#. Error when company request input has no alphanumeric characters
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:21
 #: app/[lang]/(app)/explore/company-request-form.tsx:21
 #: app/[lang]/(app)/progress/company-request-form.tsx:21
 #: src/components/search/request-company.tsx:22
@@ -3258,16 +3268,16 @@ msgstr "Rifiutato"
 msgid "myJobs.status.rejected"
 msgstr "Rifiutato"
 
-#. Sankey funnel node label prefix: rejected
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:45
-msgid "myJobs.funnel.rejected"
-msgstr "Rifiutato"
-
 #. Application tracker status: rejected
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:465
 msgid "search.tracker.rejected"
+msgstr "Rifiutato"
+
+#. Sankey funnel node label prefix: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:45
+msgid "myJobs.funnel.rejected"
 msgstr "Rifiutato"
 
 #. Status option in dropdown: rejected
@@ -3294,6 +3304,12 @@ msgstr "Rimuovi parola chiave"
 msgid "search.locations.remove"
 msgstr "Rimuovi località"
 
+#. Companies-request page heading when no company name was supplied
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/page.tsx:71
+msgid "companies.request.heading.generic"
+msgstr ""
+
 #. Feature: request companies title
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/page.tsx:97
@@ -3303,13 +3319,13 @@ msgstr "Richiedi qualsiasi azienda"
 
 #. Success message after submitting a company request, with link to GitHub issue for tracking
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:141
+#: src/components/search/request-company-success.tsx:146
 msgid "app.home.request.success.withIssue"
 msgstr "Richiesta inviata! Segui i progressi qui:"
 
 #. Success message when request was saved but GitHub issue could not be created
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:149
+#: src/components/search/request-company-success.tsx:154
 msgid "app.home.request.success.noIssue"
 msgstr "Richiesta inviata! Inizieremo presto a monitorare questa azienda."
 
@@ -3389,20 +3405,20 @@ msgstr "Turno"
 
 #. Label preceding the Murmur run id on the agent-prompt success card
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:98
+#: src/components/search/request-company-success.tsx:103
 msgid "app.home.request.agent.runIdLabel"
 msgstr ""
-
-#. Label for salary filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:171
-msgid "search.advanced.salary"
-msgstr "Stipendio"
 
 #. Salary override section heading
 #. js-lingui-explicit-id
 #: src/components/my-jobs/salary-override.tsx:76
 msgid "myJobs.detail.salary"
+msgstr "Stipendio"
+
+#. Label for salary filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:171
+msgid "search.advanced.salary"
 msgstr "Stipendio"
 
 #. Salary display settings section heading
@@ -3897,12 +3913,20 @@ msgstr "Qualcosa è andato storto. Riprova."
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
+#. Generic error when company request fails
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:22
 #: app/[lang]/(app)/explore/company-request-form.tsx:22
 #: app/[lang]/(app)/progress/company-request-form.tsx:22
 #: src/components/search/request-company.tsx:23
 msgid "app.home.request.error.unknown"
 msgstr "Qualcosa è andato storto. Riprova."
+
+#. Companies-request page heading when a company name was supplied via query string
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/page.tsx:64
+msgid "companies.request.heading.named"
+msgstr ""
 
 #. Star button label on company card
 #. js-lingui-explicit-id
@@ -3956,20 +3980,24 @@ msgstr "Incolla un link, avvia il crawling"
 #. Submit button for the company request form
 #. Submit button for the company request form
 #. Submit button for the company request form
+#. Submit button for the company request form
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/company-request-form.tsx:87
-#: app/[lang]/(app)/progress/company-request-form.tsx:87
-#: src/components/search/request-company.tsx:100
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:129
+#: app/[lang]/(app)/explore/company-request-form.tsx:91
+#: app/[lang]/(app)/progress/company-request-form.tsx:91
+#: src/components/search/request-company.tsx:106
 msgid "app.home.request.submit"
 msgstr "Invia"
 
 #. Submit button while request is in progress
 #. Submit button while request is in progress
 #. Submit button while request is in progress
+#. Submit button while request is in progress
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/company-request-form.tsx:86
-#: app/[lang]/(app)/progress/company-request-form.tsx:86
-#: src/components/search/request-company.tsx:99
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx:128
+#: app/[lang]/(app)/explore/company-request-form.tsx:90
+#: app/[lang]/(app)/progress/company-request-form.tsx:90
+#: src/components/search/request-company.tsx:105
 msgid "app.home.request.submitting"
 msgstr "Invio in corso..."
 
@@ -4032,6 +4060,12 @@ msgstr "Tecnologia"
 #: src/components/search/advanced-search-panel.tsx:159
 msgid "search.advanced.technology"
 msgstr "Tecnologia"
+
+#. Companies-request page body paragraph explaining the agent-driven request flow
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/page.tsx:78
+msgid "companies.request.body"
+msgstr ""
 
 #. Employment type: temporary
 #. js-lingui-explicit-id
@@ -4499,7 +4533,7 @@ msgstr "Utilizziamo pochi servizi terzi per accesso, hosting e archiviazione —
 
 #. Heading prefix on the agent-prompt success card; followed by the company name
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:62
+#: src/components/search/request-company-success.tsx:67
 msgid "app.home.request.agent.headingPrefix"
 msgstr ""
 
@@ -4599,7 +4633,7 @@ msgstr "È possibile rielaborare/trasformare i dati per ricerche o dashboard per
 
 #. Body of the agent-prompt success card
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:69
+#: src/components/search/request-company-success.tsx:74
 msgid "app.home.request.agent.body"
 msgstr ""
 
@@ -4632,7 +4666,7 @@ msgstr "Hai effettuato l'accesso con un account social. Imposta una password per
 
 #. Message shown when the user has hit the per-hour limit on triggering Murmur company-add runs
 #. js-lingui-explicit-id
-#: src/components/search/request-company-success.tsx:122
+#: src/components/search/request-company-success.tsx:127
 msgid "app.home.request.agent.rateLimited"
 msgstr ""
 


### PR DESCRIPTION
## Summary

New server-component page at `/[lang]/companies/request` that lands users who clicked a "Request *X*" item from elsewhere (e.g. the search-bar dropdown in #2807). It reads `?name=` and `?website=` from the query string, prefills a sibling client form (mirroring the inline forms in `progress` and `explore`), and renders the `RequestCompanySuccess` / `AgentPromptCard` UI from #2806 inline on submit — no redirect.

## Related issue

Closes colophon-group/jobseek#2808

## Files changed (high-level)

- `apps/web/app/[lang]/(app)/companies/request/page.tsx` — server component. Awaits `params` + `searchParams`, calls `getSessionUserId()`, redirects unauthed visitors to `/${lang}/sign-in?next=...`, then renders the localized heading + body + embedded form. Sets `metadata.robots = { index: false, follow: false }`.
- `apps/web/app/[lang]/(app)/companies/request/company-request-page-form.tsx` — client form. Mirrors `explore/company-request-form.tsx` exactly, with two new optional props (`defaultName`, `defaultWebsite`) wired into `<input defaultValue=...>`. The shared `RequestCompanyPrompt` is left untouched per the issue's "out of scope" guard — same pattern the existing `progress` and `explore` inline forms already use.
- `apps/web/app/[lang]/(app)/companies/request/__tests__/page.test.tsx` — 7 RSC unit tests (prefill, empty form, personalized vs generic heading, body-mentions-agent, unauth redirect with `?next=` carrying the original path + query).
- `apps/web/app/[lang]/(app)/companies/request/__tests__/company-request-page-form.test.tsx` — 6 client-form unit tests (`defaultValue` rendering for name-only / both-fields / empty cases, hidden `locale` field, submit fires server action + `requestAgentRun` when input is a URL, no `requestAgentRun` call when input is a non-URL name).
- `apps/web/locales/{en,de,fr,it}.po` (+ regenerated `.js`) — 3 new lingui catalog entries (`companies.request.heading.named`, `companies.request.heading.generic`, `companies.request.body`) extracted via `pnpm extract`. Non-en locales fall back to the source string per the existing demo convention.

## Verification (from the issue)

- [x] `/en/companies/request?name=Anthropic` renders with "Anthropic" prefilled
- [x] `/en/companies/request?name=Anthropic&website=https://anthropic.com` prefills both (form input shows the URL because the legacy single-input form is URL-aware via `parseRequestInput`; `defaultName` is forwarded via the success-card heading once the user submits)
- [x] Submit with valid input → AgentPromptCard appears (verified via the `RequestCompanySuccess` stub assertion in the form test)
- [x] No `name` query param → form is empty, no error
- [x] Lingui keys added for the heading + body copy

## Manual checks run locally

- `pnpm lint` (apps/web) clean
- `npx tsc --noEmit` (apps/web) — only the 2 pre-existing errors in `src/lib/actions/__tests__/company.test.ts` (called out in PR #2806 as known) remain; no new errors
- `pnpm test` (apps/web) — 375 / 375 passing (13 new tests across 2 new files)
- `pnpm extract` — 3 new msgids only (`companies.request.heading.named`, `companies.request.heading.generic`, `companies.request.body`); rest of the en.po diff is line-number churn from lingui's re-emission

## Notes for reviewer

- **`RequestCompanyPrompt` not modified.** The issue body says "Renders the existing `RequestCompany` component with prefill props"; the orchestrator's task instructions explicitly mark the shared component out-of-scope. The resolution mirrors how `progress` and `explore` already work — a sibling form that reuses the same lib helpers (`requestCompany`, `requestAgentRun`, `parseRequestInput`) and the shared `RequestCompanySuccess` card. All three callsites now share the same agent-prompt UX.
- **Auth gate uses `getSessionUserId`** per the issue's "same session-helper convention as the new endpoint" requirement; on miss we redirect to `/${lang}/sign-in?next=<encoded-path>`. The sign-in page does not yet honor `?next=` (no consumer in the repo today), but the param is encoded so a future change to `AuthForm` can pick it up without touching this page.
- **Prefill precedence** — when both `name` and `website` are provided, the input is prefilled with the URL so submit fires the agent-run path immediately (the legacy single-input form is URL-aware via `parseRequestInput`). When only `name` is provided, we prefill with the raw name and the user is one URL paste away from the agent path; submitting as-is still works via the legacy GH-issue branch.
- **`metadata.robots = noindex,nofollow`** because the page is a form with no SEO value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)