### PR TITLE
feat(web): show 'Request {query}' item in search-bar dropdown when no exact match

### DIFF
--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -371,16 +371,16 @@ msgstr "Bewerbungstracker"
 msgid "faq.a.whatIsWatchlist"
 msgstr "Eine Watchlist ist eine gespeicherte Suche mit optionaler Unternehmensfilterung. Wähle die Unternehmen, die dich interessieren, setze deine Filter (Rolle, Standort, Seniorität, Gehalt) und erhalte einen Live-Feed passender Stellen. Du kannst Watchlists öffentlich teilen oder privat halten."
 
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/about/page.tsx:18
-#: app/[lang]/(public)/about/page.tsx:40
-msgid "about.meta.title"
-msgstr "Über uns"
-
 #. About page eyebrow
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:24
 msgid "about.eyebrow"
+msgstr "Über uns"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/about/page.tsx:18
+#: app/[lang]/(public)/about/page.tsx:40
+msgid "about.meta.title"
 msgstr "Über uns"
 
 #. Nav link: About
@@ -492,16 +492,16 @@ msgstr "Alle Daten werden bei Übertragung und Speicherung verschlüsselt."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Alle Branchen"
 
-#. Title for the all-languages modal in settings
-#. js-lingui-explicit-id
-#: src/components/settings/JobLanguageModal.tsx:56
-msgid "settings.jobLanguages.modal.title"
-msgstr "Alle Sprachen"
-
 #. All languages option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:234
 msgid "settings.general.jobLanguages.all"
+msgstr "Alle Sprachen"
+
+#. Title for the all-languages modal in settings
+#. js-lingui-explicit-id
+#: src/components/settings/JobLanguageModal.tsx:56
+msgid "settings.jobLanguages.modal.title"
 msgstr "Alle Sprachen"
 
 #. Title for the all-locations modal on company page
@@ -610,16 +610,16 @@ msgstr "Beworben"
 msgid "myJobs.status.applied"
 msgstr "Beworben"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:462
-msgid "search.tracker.applied"
-msgstr "Beworben"
-
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
+msgstr "Beworben"
+
+#. Application tracker status: applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:462
+msgid "search.tracker.applied"
 msgstr "Beworben"
 
 #. Status option in dropdown: applied
@@ -683,16 +683,16 @@ msgstr "Aug"
 msgid "settings.account.username.available"
 msgstr "Verfügbar"
 
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Zurück zur Anmeldung"
-
 #. Link back to sign-in after failed verification
 #. js-lingui-explicit-id
 #: app/[lang]/verify-email/page.tsx:68
 msgid "auth.verify.error.backToSignIn"
+msgstr "Zurück zur Anmeldung"
+
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
 msgstr "Zurück zur Anmeldung"
 
 #. Link back to sign-in from forgot password
@@ -953,7 +953,7 @@ msgstr "Demnächst verfügbar"
 
 #. Section header for company suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:706
+#: src/components/search/search-bar.tsx:748
 msgid "search.bar.companies"
 msgstr "Unternehmen"
 
@@ -2035,16 +2035,16 @@ msgstr "Gibt es ein Limit, wie viele Jobs ich verfolgen kann?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:31
-msgid "watchlists.card.jobSingular"
-msgstr "Job"
-
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:121
 msgid "watchlists.explore.jobSingular"
+msgstr "Job"
+
+#. Singular job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:31
+msgid "watchlists.card.jobSingular"
 msgstr "Job"
 
 #. js-lingui-explicit-id
@@ -2168,16 +2168,16 @@ msgstr "Die Codebasis von Job Seek ist Open Source unter MIT. Die von uns gesamm
 msgid "watchlist.meta.fallback"
 msgstr "Job-Watchlist von @{owner}"
 
-#. Plural job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:32
-msgid "watchlists.card.jobPlural"
-msgstr "Jobs"
-
 #. Plural job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:122
 msgid "watchlists.explore.jobPlural"
+msgstr "Jobs"
+
+#. Plural job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:32
+msgid "watchlists.card.jobPlural"
 msgstr "Jobs"
 
 #. js-lingui-explicit-id
@@ -2264,7 +2264,7 @@ msgstr "Mehr erfahren"
 
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:596
+#: src/components/search/search-bar.tsx:638
 msgid "search.bar.level"
 msgstr "Stufe"
 
@@ -2343,7 +2343,7 @@ msgstr "Standort"
 
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:666
+#: src/components/search/search-bar.tsx:708
 msgid "search.bar.locations"
 msgstr "Standorte"
 
@@ -2629,17 +2629,17 @@ msgstr "Keine Jobs gefunden."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Keine Sprachen entsprechen deiner Suche."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:171
-msgid "search.locationModal.noResults"
-msgstr "Keine Standorte gefunden."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:186
 msgid "company.locationModal.noResults"
 msgstr "Keine Standorte entsprechen Ihrer Suche."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:171
+msgid "search.locationModal.noResults"
+msgstr "Keine Standorte gefunden."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2711,16 +2711,16 @@ msgstr "Nein. Der Bewerbungstracker hat kein festes Limit — speichere so viele
 msgid "faq.a.dataPrivacy"
 msgstr "Nein. Wir verkaufen, vermieten oder teilen deine Daten nicht zu Marketingzwecken. Cookies sind nur sitzungsbasiert, ohne Werbung oder Tracking. Du kannst dein Konto löschen und alle Daten werden innerhalb von 30 Tagen entfernt."
 
-#. Application tracker status: not applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:461
-msgid "search.tracker.notApplied"
-msgstr "Nicht beworben"
-
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
+msgstr "Nicht beworben"
+
+#. Application tracker status: not applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:461
+msgid "search.tracker.notApplied"
 msgstr "Nicht beworben"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -3182,18 +3182,18 @@ msgstr "Gemeinfrei"
 msgid "license.contactCta"
 msgstr "Fragen zur Lizenzierung oder kommerziellen Nutzung? Schreib uns eine E-Mail."
 
-#. Terms contact call to action
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:59
-#: src/components/TermsContent.tsx:54
-msgid "terms.contact.description"
-msgstr "Fragen? Schreib uns eine E-Mail."
-
 #. Privacy contact call to action
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/privacy-policy/page.tsx:61
 #: src/components/PrivacyPolicyContent.tsx:66
 msgid "privacy.contact.description"
+msgstr "Fragen? Schreib uns eine E-Mail."
+
+#. Terms contact call to action
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/terms/page.tsx:59
+#: src/components/TermsContent.tsx:54
+msgid "terms.contact.description"
 msgstr "Fragen? Schreib uns eine E-Mail."
 
 #. Link to full CC license
@@ -3268,16 +3268,16 @@ msgstr "Abgelehnt"
 msgid "myJobs.status.rejected"
 msgstr "Abgelehnt"
 
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:465
-msgid "search.tracker.rejected"
-msgstr "Abgelehnt"
-
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
+msgstr "Abgelehnt"
+
+#. Application tracker status: rejected
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:465
+msgid "search.tracker.rejected"
 msgstr "Abgelehnt"
 
 #. Status option in dropdown: rejected
@@ -3303,6 +3303,12 @@ msgstr "Stichwort entfernen"
 #: src/components/search/location-pills.tsx:201
 msgid "search.locations.remove"
 msgstr "Standort entfernen"
+
+#. Synthetic dropdown row that lets the user request a company that's not in the catalog
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:811
+msgid "search.bar.request"
+msgstr ""
 
 #. Companies-request page heading when no company name was supplied
 #. js-lingui-explicit-id
@@ -3393,7 +3399,7 @@ msgstr "Beruf"
 
 #. Section header for occupation suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:561
+#: src/components/search/search-bar.tsx:603
 msgid "search.bar.roles"
 msgstr "Berufe"
 
@@ -3547,7 +3553,7 @@ msgstr "Unternehmen suchen..."
 
 #. Option to search by title keyword in dropdown
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:549
+#: src/components/search/search-bar.tsx:591
 msgid "search.bar.keyword"
 msgstr "Nach \"{trimmedInput}\" in Jobtiteln suchen"
 
@@ -3562,17 +3568,17 @@ msgstr "Durchsuche Jobs bei Tausenden von Unternehmen, direkt von Karriereseiten
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Sprachen suchen…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:150
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Standorte suchen..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:165
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Standorte suchen…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:150
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Standorte suchen..."
 
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/page.tsx:22
@@ -3607,7 +3613,7 @@ msgstr "Alles, was du brauchst, um vorne zu bleiben"
 
 #. Placeholder for the main search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:478
+#: src/components/search/search-bar.tsx:518
 msgid "search.bar.placeholder"
 msgstr "Suchen…"
 
@@ -4039,7 +4045,7 @@ msgstr "Technisch"
 
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:631
+#: src/components/search/search-bar.tsx:673
 msgid "search.bar.technologies"
 msgstr "Technologien"
 
@@ -4142,16 +4148,16 @@ msgstr "Der Service wird ohne Gewährleistung bereitgestellt."
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:51
-#: src/components/TermsContent.tsx:40
-msgid "terms.short.title"
+#: app/[lang]/(public)/privacy-policy/page.tsx:51
+#: src/components/PrivacyPolicyContent.tsx:40
+msgid "privacy.short.title"
 msgstr "Die Kurzfassung"
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:51
-#: src/components/PrivacyPolicyContent.tsx:40
-msgid "privacy.short.title"
+#: app/[lang]/(public)/terms/page.tsx:51
+#: src/components/TermsContent.tsx:40
+msgid "terms.short.title"
 msgstr "Die Kurzfassung"
 
 #. Theme settings section heading
@@ -4530,6 +4536,12 @@ msgstr "Wir empfehlen ausdrücklich, eine leicht auffindbare Sitemap für deinen
 #: src/components/PrivacyPolicyContent.tsx:45
 msgid "privacy.short.r3"
 msgstr "Wir nutzen eine Handvoll Drittanbieter für Anmeldung, Hosting und Speicherung — sonst nichts."
+
+#. Secondary line under the Request <query> dropdown row
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:818
+msgid "search.bar.request.subtext"
+msgstr ""
 
 #. Heading prefix on the agent-prompt success card; followed by the company name
 #. js-lingui-explicit-id

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -302,16 +302,16 @@ msgstr "1 watchlist"
 msgid "faq.a.whatIsWatchlist"
 msgstr "A watchlist is a saved search with optional company filtering. Pick the companies you care about, set your filters (role, location, seniority, salary), and get a live feed of matching jobs. You can share watchlists publicly or keep them private."
 
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/about/page.tsx:18
-#: app/[lang]/(public)/about/page.tsx:40
-msgid "about.meta.title"
-msgstr "About"
-
 #. About page eyebrow
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:24
 msgid "about.eyebrow"
+msgstr "About"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/about/page.tsx:18
+#: app/[lang]/(public)/about/page.tsx:40
+msgid "about.meta.title"
 msgstr "About"
 
 #. Nav link: About
@@ -423,16 +423,16 @@ msgstr "All data is encrypted in transit and at rest."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "All industries"
 
-#. Title for the all-languages modal in settings
-#. js-lingui-explicit-id
-#: src/components/settings/JobLanguageModal.tsx:56
-msgid "settings.jobLanguages.modal.title"
-msgstr "All languages"
-
 #. All languages option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:234
 msgid "settings.general.jobLanguages.all"
+msgstr "All languages"
+
+#. Title for the all-languages modal in settings
+#. js-lingui-explicit-id
+#: src/components/settings/JobLanguageModal.tsx:56
+msgid "settings.jobLanguages.modal.title"
 msgstr "All languages"
 
 #. Title for the all-locations modal on company page
@@ -538,16 +538,16 @@ msgstr "Applied"
 msgid "myJobs.status.applied"
 msgstr "Applied"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:462
-msgid "search.tracker.applied"
-msgstr "Applied"
-
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
+msgstr "Applied"
+
+#. Application tracker status: applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:462
+msgid "search.tracker.applied"
 msgstr "Applied"
 
 #. Status option in dropdown: applied
@@ -611,16 +611,16 @@ msgstr "Aug"
 msgid "settings.account.username.available"
 msgstr "Available"
 
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Back to sign in"
-
 #. Link back to sign-in after failed verification
 #. js-lingui-explicit-id
 #: app/[lang]/verify-email/page.tsx:68
 msgid "auth.verify.error.backToSignIn"
+msgstr "Back to sign in"
+
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
 msgstr "Back to sign in"
 
 #. Link back to sign-in from forgot password
@@ -881,7 +881,7 @@ msgstr "Coming soon"
 
 #. Section header for company suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:706
+#: src/components/search/search-bar.tsx:748
 msgid "search.bar.companies"
 msgstr "Companies"
 
@@ -1963,16 +1963,16 @@ msgstr "Is there a limit to how many jobs I can track?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:31
-msgid "watchlists.card.jobSingular"
-msgstr "job"
-
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:121
 msgid "watchlists.explore.jobSingular"
+msgstr "job"
+
+#. Singular job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:31
+msgid "watchlists.card.jobSingular"
 msgstr "job"
 
 #. js-lingui-explicit-id
@@ -2096,16 +2096,16 @@ msgstr "Job Seek's codebase is open source under MIT. The job data we collect an
 msgid "watchlist.meta.fallback"
 msgstr "Job watchlist by @{owner}"
 
-#. Plural job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:32
-msgid "watchlists.card.jobPlural"
-msgstr "jobs"
-
 #. Plural job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:122
 msgid "watchlists.explore.jobPlural"
+msgstr "jobs"
+
+#. Plural job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:32
+msgid "watchlists.card.jobPlural"
 msgstr "jobs"
 
 #. js-lingui-explicit-id
@@ -2192,7 +2192,7 @@ msgstr "Learn more"
 
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:596
+#: src/components/search/search-bar.tsx:638
 msgid "search.bar.level"
 msgstr "Level"
 
@@ -2271,7 +2271,7 @@ msgstr "Location"
 
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:666
+#: src/components/search/search-bar.tsx:708
 msgid "search.bar.locations"
 msgstr "Locations"
 
@@ -2557,16 +2557,16 @@ msgstr "No jobs found."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "No languages match your search."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:171
-msgid "search.locationModal.noResults"
-msgstr "No locations match your search."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:186
 msgid "company.locationModal.noResults"
+msgstr "No locations match your search."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:171
+msgid "search.locationModal.noResults"
 msgstr "No locations match your search."
 
 #. No postings found message on company page
@@ -2639,16 +2639,16 @@ msgstr "No. The application tracker has no hard limit — save as many jobs as y
 msgid "faq.a.dataPrivacy"
 msgstr "No. We don't sell, rent, or share your data for marketing. Cookies are session-only with no ads or tracking. You can delete your account and all data is wiped within 30 days."
 
-#. Application tracker status: not applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:461
-msgid "search.tracker.notApplied"
-msgstr "Not applied"
-
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
+msgstr "Not applied"
+
+#. Application tracker status: not applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:461
+msgid "search.tracker.notApplied"
 msgstr "Not applied"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -3098,18 +3098,18 @@ msgstr "Public Domain"
 msgid "license.contactCta"
 msgstr "Questions about licensing or commercial use? Email us."
 
-#. Terms contact call to action
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:59
-#: src/components/TermsContent.tsx:54
-msgid "terms.contact.description"
-msgstr "Questions? Email us."
-
 #. Privacy contact call to action
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/privacy-policy/page.tsx:61
 #: src/components/PrivacyPolicyContent.tsx:66
 msgid "privacy.contact.description"
+msgstr "Questions? Email us."
+
+#. Terms contact call to action
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/terms/page.tsx:59
+#: src/components/TermsContent.tsx:54
+msgid "terms.contact.description"
 msgstr "Questions? Email us."
 
 #. Link to full CC license
@@ -3184,16 +3184,16 @@ msgstr "Rejected"
 msgid "myJobs.status.rejected"
 msgstr "Rejected"
 
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:465
-msgid "search.tracker.rejected"
-msgstr "Rejected"
-
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
+msgstr "Rejected"
+
+#. Application tracker status: rejected
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:465
+msgid "search.tracker.rejected"
 msgstr "Rejected"
 
 #. Status option in dropdown: rejected
@@ -3219,6 +3219,12 @@ msgstr "Remove keyword"
 #: src/components/search/location-pills.tsx:201
 msgid "search.locations.remove"
 msgstr "Remove location"
+
+#. Synthetic dropdown row that lets the user request a company that's not in the catalog
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:811
+msgid "search.bar.request"
+msgstr "Request \"{trimmedInput}\""
 
 #. Companies-request page heading when no company name was supplied
 #. js-lingui-explicit-id
@@ -3309,7 +3315,7 @@ msgstr "Role"
 
 #. Section header for occupation suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:561
+#: src/components/search/search-bar.tsx:603
 msgid "search.bar.roles"
 msgstr "Roles"
 
@@ -3463,7 +3469,7 @@ msgstr "Search companies..."
 
 #. Option to search by title keyword in dropdown
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:549
+#: src/components/search/search-bar.tsx:591
 msgid "search.bar.keyword"
 msgstr "Search for \"{trimmedInput}\" in job titles"
 
@@ -3478,16 +3484,16 @@ msgstr "Search jobs across thousands of companies scraped directly from career p
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Search languages..."
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:150
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Search locations..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:165
 msgid "company.locationModal.searchPlaceholder"
+msgstr "Search locations..."
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:150
+msgid "search.locationModal.searchPlaceholder"
 msgstr "Search locations..."
 
 #. js-lingui-explicit-id
@@ -3523,7 +3529,7 @@ msgstr "Search with precision"
 
 #. Placeholder for the main search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:478
+#: src/components/search/search-bar.tsx:518
 msgid "search.bar.placeholder"
 msgstr "Search..."
 
@@ -3931,7 +3937,7 @@ msgstr "Technical"
 
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:631
+#: src/components/search/search-bar.tsx:673
 msgid "search.bar.technologies"
 msgstr "Technologies"
 
@@ -4034,16 +4040,16 @@ msgstr "The service is provided as-is — no warranties."
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:51
-#: src/components/TermsContent.tsx:40
-msgid "terms.short.title"
+#: app/[lang]/(public)/privacy-policy/page.tsx:51
+#: src/components/PrivacyPolicyContent.tsx:40
+msgid "privacy.short.title"
 msgstr "The short version"
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:51
-#: src/components/PrivacyPolicyContent.tsx:40
-msgid "privacy.short.title"
+#: app/[lang]/(public)/terms/page.tsx:51
+#: src/components/TermsContent.tsx:40
+msgid "terms.short.title"
 msgstr "The short version"
 
 #. Theme settings section heading
@@ -4422,6 +4428,12 @@ msgstr "We strongly encourage publishing an easily discoverable sitemap for your
 #: src/components/PrivacyPolicyContent.tsx:45
 msgid "privacy.short.r3"
 msgstr "We use a handful of third-party services for sign-in, hosting, and storage — nothing else."
+
+#. Secondary line under the Request <query> dropdown row
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:818
+msgid "search.bar.request.subtext"
+msgstr "We'll start tracking it"
 
 #. Heading prefix on the agent-prompt success card; followed by the company name
 #. js-lingui-explicit-id

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -371,16 +371,16 @@ msgstr "Suivi des candidatures"
 msgid "faq.a.whatIsWatchlist"
 msgstr "Une liste de suivi est une recherche enregistrée avec filtrage optionnel par entreprise. Choisissez les entreprises qui vous intéressent, définissez vos filtres (poste, lieu, séniorité, salaire) et obtenez un flux en direct des offres correspondantes. Vous pouvez partager vos listes publiquement ou les garder privées."
 
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/about/page.tsx:18
-#: app/[lang]/(public)/about/page.tsx:40
-msgid "about.meta.title"
-msgstr "À propos"
-
 #. About page eyebrow
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:24
 msgid "about.eyebrow"
+msgstr "À propos"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/about/page.tsx:18
+#: app/[lang]/(public)/about/page.tsx:40
+msgid "about.meta.title"
 msgstr "À propos"
 
 #. Nav link: About
@@ -492,16 +492,16 @@ msgstr "Toutes les données sont chiffrées en transit et au repos."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Tous les secteurs"
 
-#. Title for the all-languages modal in settings
-#. js-lingui-explicit-id
-#: src/components/settings/JobLanguageModal.tsx:56
-msgid "settings.jobLanguages.modal.title"
-msgstr "Toutes les langues"
-
 #. All languages option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:234
 msgid "settings.general.jobLanguages.all"
+msgstr "Toutes les langues"
+
+#. Title for the all-languages modal in settings
+#. js-lingui-explicit-id
+#: src/components/settings/JobLanguageModal.tsx:56
+msgid "settings.jobLanguages.modal.title"
 msgstr "Toutes les langues"
 
 #. Title for the all-locations modal on company page
@@ -610,16 +610,16 @@ msgstr "Postulé"
 msgid "myJobs.status.applied"
 msgstr "Postulé"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:462
-msgid "search.tracker.applied"
-msgstr "Postulé"
-
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
+msgstr "Postulé"
+
+#. Application tracker status: applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:462
+msgid "search.tracker.applied"
 msgstr "Postulé"
 
 #. Status option in dropdown: applied
@@ -683,16 +683,16 @@ msgstr "Aoû"
 msgid "settings.account.username.available"
 msgstr "Disponible"
 
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Retour à la connexion"
-
 #. Link back to sign-in after failed verification
 #. js-lingui-explicit-id
 #: app/[lang]/verify-email/page.tsx:68
 msgid "auth.verify.error.backToSignIn"
+msgstr "Retour à la connexion"
+
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
 msgstr "Retour à la connexion"
 
 #. Link back to sign-in from forgot password
@@ -953,7 +953,7 @@ msgstr "Bientôt disponible"
 
 #. Section header for company suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:706
+#: src/components/search/search-bar.tsx:748
 msgid "search.bar.companies"
 msgstr "Entreprises"
 
@@ -2035,16 +2035,16 @@ msgstr "Y a-t-il une limite au nombre d'offres que je peux suivre ?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:31
-msgid "watchlists.card.jobSingular"
-msgstr "offre"
-
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:121
 msgid "watchlists.explore.jobSingular"
+msgstr "offre"
+
+#. Singular job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:31
+msgid "watchlists.card.jobSingular"
 msgstr "offre"
 
 #. js-lingui-explicit-id
@@ -2168,16 +2168,16 @@ msgstr "Le code source de Job Seek est ouvert sous licence MIT. Les données d'e
 msgid "watchlist.meta.fallback"
 msgstr "Liste d'emplois de @{owner}"
 
-#. Plural job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:32
-msgid "watchlists.card.jobPlural"
-msgstr "offres"
-
 #. Plural job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:122
 msgid "watchlists.explore.jobPlural"
+msgstr "offres"
+
+#. Plural job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:32
+msgid "watchlists.card.jobPlural"
 msgstr "offres"
 
 #. js-lingui-explicit-id
@@ -2264,7 +2264,7 @@ msgstr "En savoir plus"
 
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:596
+#: src/components/search/search-bar.tsx:638
 msgid "search.bar.level"
 msgstr "Niveau"
 
@@ -2343,7 +2343,7 @@ msgstr "Lieu"
 
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:666
+#: src/components/search/search-bar.tsx:708
 msgid "search.bar.locations"
 msgstr "Lieux"
 
@@ -2629,16 +2629,16 @@ msgstr "Aucune offre trouvée."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Aucune langue ne correspond à votre recherche."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:171
-msgid "search.locationModal.noResults"
-msgstr "Aucun lieu ne correspond à votre recherche."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:186
 msgid "company.locationModal.noResults"
+msgstr "Aucun lieu ne correspond à votre recherche."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:171
+msgid "search.locationModal.noResults"
 msgstr "Aucun lieu ne correspond à votre recherche."
 
 #. No postings found message on company page
@@ -2711,16 +2711,16 @@ msgstr "Non. Le suivi des candidatures n'a pas de limite — enregistrez autant 
 msgid "faq.a.dataPrivacy"
 msgstr "Non. Nous ne vendons, ne louons ni ne partageons vos données à des fins marketing. Les cookies sont uniquement de session, sans publicité ni tracking. Vous pouvez supprimer votre compte et toutes les données seront effacées sous 30 jours."
 
-#. Application tracker status: not applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:461
-msgid "search.tracker.notApplied"
-msgstr "Non postulé"
-
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
+msgstr "Non postulé"
+
+#. Application tracker status: not applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:461
+msgid "search.tracker.notApplied"
 msgstr "Non postulé"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -3182,18 +3182,18 @@ msgstr "Domaine public"
 msgid "license.contactCta"
 msgstr "Des questions sur les licences ou l'utilisation commerciale ? Écris-nous."
 
-#. Terms contact call to action
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:59
-#: src/components/TermsContent.tsx:54
-msgid "terms.contact.description"
-msgstr "Des questions ? Écris-nous."
-
 #. Privacy contact call to action
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/privacy-policy/page.tsx:61
 #: src/components/PrivacyPolicyContent.tsx:66
 msgid "privacy.contact.description"
+msgstr "Des questions ? Écris-nous."
+
+#. Terms contact call to action
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/terms/page.tsx:59
+#: src/components/TermsContent.tsx:54
+msgid "terms.contact.description"
 msgstr "Des questions ? Écris-nous."
 
 #. Link to full CC license
@@ -3268,16 +3268,16 @@ msgstr "Refusé"
 msgid "myJobs.status.rejected"
 msgstr "Refusé"
 
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:465
-msgid "search.tracker.rejected"
-msgstr "Refusé"
-
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
+msgstr "Refusé"
+
+#. Application tracker status: rejected
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:465
+msgid "search.tracker.rejected"
 msgstr "Refusé"
 
 #. Status option in dropdown: rejected
@@ -3303,6 +3303,12 @@ msgstr "Supprimer le mot-clé"
 #: src/components/search/location-pills.tsx:201
 msgid "search.locations.remove"
 msgstr "Supprimer le lieu"
+
+#. Synthetic dropdown row that lets the user request a company that's not in the catalog
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:811
+msgid "search.bar.request"
+msgstr ""
 
 #. Companies-request page heading when no company name was supplied
 #. js-lingui-explicit-id
@@ -3393,7 +3399,7 @@ msgstr "Rôle"
 
 #. Section header for occupation suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:561
+#: src/components/search/search-bar.tsx:603
 msgid "search.bar.roles"
 msgstr "Rôles"
 
@@ -3547,7 +3553,7 @@ msgstr "Rechercher des entreprises..."
 
 #. Option to search by title keyword in dropdown
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:549
+#: src/components/search/search-bar.tsx:591
 msgid "search.bar.keyword"
 msgstr "Rechercher \"{trimmedInput}\" dans les titres de postes"
 
@@ -3562,17 +3568,17 @@ msgstr "Recherchez des emplois dans des milliers d'entreprises, scrapés directe
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Rechercher des langues…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:150
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Rechercher des lieux..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:165
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Rechercher des lieux…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:150
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Rechercher des lieux..."
 
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/page.tsx:22
@@ -3607,7 +3613,7 @@ msgstr "Tout ce qu'il te faut pour garder une longueur d'avance"
 
 #. Placeholder for the main search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:478
+#: src/components/search/search-bar.tsx:518
 msgid "search.bar.placeholder"
 msgstr "Rechercher…"
 
@@ -4039,7 +4045,7 @@ msgstr "Technique"
 
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:631
+#: src/components/search/search-bar.tsx:673
 msgid "search.bar.technologies"
 msgstr "Technologies"
 
@@ -4142,16 +4148,16 @@ msgstr "Le service est fourni tel quel, sans garantie."
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:51
-#: src/components/TermsContent.tsx:40
-msgid "terms.short.title"
+#: app/[lang]/(public)/privacy-policy/page.tsx:51
+#: src/components/PrivacyPolicyContent.tsx:40
+msgid "privacy.short.title"
 msgstr "En bref"
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:51
-#: src/components/PrivacyPolicyContent.tsx:40
-msgid "privacy.short.title"
+#: app/[lang]/(public)/terms/page.tsx:51
+#: src/components/TermsContent.tsx:40
+msgid "terms.short.title"
 msgstr "En bref"
 
 #. Theme settings section heading
@@ -4530,6 +4536,12 @@ msgstr "Nous encourageons vivement la publication d'un sitemap facilement décou
 #: src/components/PrivacyPolicyContent.tsx:45
 msgid "privacy.short.r3"
 msgstr "Nous utilisons quelques services tiers pour la connexion, l’hébergement et le stockage — rien d’autre."
+
+#. Secondary line under the Request <query> dropdown row
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:818
+msgid "search.bar.request.subtext"
+msgstr ""
 
 #. Heading prefix on the agent-prompt success card; followed by the company name
 #. js-lingui-explicit-id

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -371,16 +371,16 @@ msgstr "Tracker delle candidature"
 msgid "faq.a.whatIsWatchlist"
 msgstr "Una watchlist è una ricerca salvata con filtro opzionale per azienda. Scegli le aziende che ti interessano, imposta i filtri (ruolo, località, seniority, stipendio) e ottieni un feed in tempo reale delle offerte corrispondenti. Puoi condividere le watchlist pubblicamente o mantenerle private."
 
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/about/page.tsx:18
-#: app/[lang]/(public)/about/page.tsx:40
-msgid "about.meta.title"
-msgstr "Chi siamo"
-
 #. About page eyebrow
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:24
 msgid "about.eyebrow"
+msgstr "Chi siamo"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/about/page.tsx:18
+#: app/[lang]/(public)/about/page.tsx:40
+msgid "about.meta.title"
 msgstr "Chi siamo"
 
 #. Nav link: About
@@ -492,16 +492,16 @@ msgstr "Tutti i dati sono crittografati in transito e a riposo."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Tutti i settori"
 
-#. Title for the all-languages modal in settings
-#. js-lingui-explicit-id
-#: src/components/settings/JobLanguageModal.tsx:56
-msgid "settings.jobLanguages.modal.title"
-msgstr "Tutte le lingue"
-
 #. All languages option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:234
 msgid "settings.general.jobLanguages.all"
+msgstr "Tutte le lingue"
+
+#. Title for the all-languages modal in settings
+#. js-lingui-explicit-id
+#: src/components/settings/JobLanguageModal.tsx:56
+msgid "settings.jobLanguages.modal.title"
 msgstr "Tutte le lingue"
 
 #. Title for the all-locations modal on company page
@@ -610,16 +610,16 @@ msgstr "Candidato"
 msgid "myJobs.status.applied"
 msgstr "Candidato"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:462
-msgid "search.tracker.applied"
-msgstr "Candidato"
-
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
+msgstr "Candidato"
+
+#. Application tracker status: applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:462
+msgid "search.tracker.applied"
 msgstr "Candidato"
 
 #. Status option in dropdown: applied
@@ -683,16 +683,16 @@ msgstr "Ago"
 msgid "settings.account.username.available"
 msgstr "Disponibile"
 
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Torna all'accesso"
-
 #. Link back to sign-in after failed verification
 #. js-lingui-explicit-id
 #: app/[lang]/verify-email/page.tsx:68
 msgid "auth.verify.error.backToSignIn"
+msgstr "Torna all'accesso"
+
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
 msgstr "Torna all'accesso"
 
 #. Link back to sign-in from forgot password
@@ -953,7 +953,7 @@ msgstr "In arrivo"
 
 #. Section header for company suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:706
+#: src/components/search/search-bar.tsx:748
 msgid "search.bar.companies"
 msgstr "Aziende"
 
@@ -2035,16 +2035,16 @@ msgstr "C'è un limite al numero di offerte che posso tracciare?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Gen"
 
-#. Singular job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:31
-msgid "watchlists.card.jobSingular"
-msgstr "offerta"
-
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:121
 msgid "watchlists.explore.jobSingular"
+msgstr "offerta"
+
+#. Singular job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:31
+msgid "watchlists.card.jobSingular"
 msgstr "offerta"
 
 #. js-lingui-explicit-id
@@ -2168,16 +2168,16 @@ msgstr "Il codice sorgente di Job Seek è open source sotto licenza MIT. I dati 
 msgid "watchlist.meta.fallback"
 msgstr "Lista lavori di @{owner}"
 
-#. Plural job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:32
-msgid "watchlists.card.jobPlural"
-msgstr "offerte"
-
 #. Plural job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:122
 msgid "watchlists.explore.jobPlural"
+msgstr "offerte"
+
+#. Plural job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:32
+msgid "watchlists.card.jobPlural"
 msgstr "offerte"
 
 #. js-lingui-explicit-id
@@ -2264,7 +2264,7 @@ msgstr "Scopri di più"
 
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:596
+#: src/components/search/search-bar.tsx:638
 msgid "search.bar.level"
 msgstr "Livello"
 
@@ -2343,7 +2343,7 @@ msgstr "Luogo"
 
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:666
+#: src/components/search/search-bar.tsx:708
 msgid "search.bar.locations"
 msgstr "Sedi"
 
@@ -2629,17 +2629,17 @@ msgstr "Nessuna offerta trovata."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Nessuna lingua corrisponde alla ricerca."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:171
-msgid "search.locationModal.noResults"
-msgstr "Nessun luogo corrisponde alla tua ricerca."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:186
 msgid "company.locationModal.noResults"
 msgstr "Nessuna sede corrisponde alla tua ricerca."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:171
+msgid "search.locationModal.noResults"
+msgstr "Nessun luogo corrisponde alla tua ricerca."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2711,16 +2711,16 @@ msgstr "No. Il tracker delle candidature non ha limiti — salva quante offerte 
 msgid "faq.a.dataPrivacy"
 msgstr "No. Non vendiamo, affittiamo né condividiamo i tuoi dati a fini di marketing. I cookie sono solo di sessione, senza pubblicità né tracciamento. Puoi eliminare il tuo account e tutti i dati verranno cancellati entro 30 giorni."
 
-#. Application tracker status: not applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:461
-msgid "search.tracker.notApplied"
-msgstr "Non candidato"
-
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
+msgstr "Non candidato"
+
+#. Application tracker status: not applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:461
+msgid "search.tracker.notApplied"
 msgstr "Non candidato"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -3182,18 +3182,18 @@ msgstr "Pubblico dominio"
 msgid "license.contactCta"
 msgstr "Domande sulle licenze o sull'uso commerciale? Scrivici via email."
 
-#. Terms contact call to action
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:59
-#: src/components/TermsContent.tsx:54
-msgid "terms.contact.description"
-msgstr "Domande? Scrivici."
-
 #. Privacy contact call to action
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/privacy-policy/page.tsx:61
 #: src/components/PrivacyPolicyContent.tsx:66
 msgid "privacy.contact.description"
+msgstr "Domande? Scrivici."
+
+#. Terms contact call to action
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/terms/page.tsx:59
+#: src/components/TermsContent.tsx:54
+msgid "terms.contact.description"
 msgstr "Domande? Scrivici."
 
 #. Link to full CC license
@@ -3268,16 +3268,16 @@ msgstr "Rifiutato"
 msgid "myJobs.status.rejected"
 msgstr "Rifiutato"
 
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:465
-msgid "search.tracker.rejected"
-msgstr "Rifiutato"
-
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
+msgstr "Rifiutato"
+
+#. Application tracker status: rejected
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:465
+msgid "search.tracker.rejected"
 msgstr "Rifiutato"
 
 #. Status option in dropdown: rejected
@@ -3303,6 +3303,12 @@ msgstr "Rimuovi parola chiave"
 #: src/components/search/location-pills.tsx:201
 msgid "search.locations.remove"
 msgstr "Rimuovi località"
+
+#. Synthetic dropdown row that lets the user request a company that's not in the catalog
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:811
+msgid "search.bar.request"
+msgstr ""
 
 #. Companies-request page heading when no company name was supplied
 #. js-lingui-explicit-id
@@ -3393,7 +3399,7 @@ msgstr "Ruolo"
 
 #. Section header for occupation suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:561
+#: src/components/search/search-bar.tsx:603
 msgid "search.bar.roles"
 msgstr "Ruoli"
 
@@ -3547,7 +3553,7 @@ msgstr "Cerca aziende..."
 
 #. Option to search by title keyword in dropdown
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:549
+#: src/components/search/search-bar.tsx:591
 msgid "search.bar.keyword"
 msgstr "Cerca \"{trimmedInput}\" nei titoli di lavoro"
 
@@ -3562,17 +3568,17 @@ msgstr "Cerca lavori in migliaia di aziende, scansionati direttamente dalle pagi
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Cerca lingue…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:150
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Cerca luoghi..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:165
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Cerca sedi…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:150
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Cerca luoghi..."
 
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/page.tsx:22
@@ -3607,7 +3613,7 @@ msgstr "Tutto ciò che ti serve per restare al passo"
 
 #. Placeholder for the main search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:478
+#: src/components/search/search-bar.tsx:518
 msgid "search.bar.placeholder"
 msgstr "Cerca…"
 
@@ -4039,7 +4045,7 @@ msgstr "Tecnico"
 
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:631
+#: src/components/search/search-bar.tsx:673
 msgid "search.bar.technologies"
 msgstr "Tecnologie"
 
@@ -4142,16 +4148,16 @@ msgstr "Il servizio è fornito così com'è, senza garanzie."
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:51
-#: src/components/TermsContent.tsx:40
-msgid "terms.short.title"
+#: app/[lang]/(public)/privacy-policy/page.tsx:51
+#: src/components/PrivacyPolicyContent.tsx:40
+msgid "privacy.short.title"
 msgstr "In breve"
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:51
-#: src/components/PrivacyPolicyContent.tsx:40
-msgid "privacy.short.title"
+#: app/[lang]/(public)/terms/page.tsx:51
+#: src/components/TermsContent.tsx:40
+msgid "terms.short.title"
 msgstr "In breve"
 
 #. Theme settings section heading
@@ -4530,6 +4536,12 @@ msgstr "Incoraggiamo vivamente la pubblicazione di una sitemap facilmente indivi
 #: src/components/PrivacyPolicyContent.tsx:45
 msgid "privacy.short.r3"
 msgstr "Utilizziamo pochi servizi terzi per accesso, hosting e archiviazione — nient’altro."
+
+#. Secondary line under the Request <query> dropdown row
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:818
+msgid "search.bar.request.subtext"
+msgstr ""
 
 #. Heading prefix on the agent-prompt success card; followed by the company name
 #. js-lingui-explicit-id

--- a/apps/web/src/components/search/__tests__/search-bar-request.test.tsx
+++ b/apps/web/src/components/search/__tests__/search-bar-request.test.tsx
@@ -1,0 +1,209 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// ── Mocks ────────────────────────────────────────────────────────────
+//
+// `SearchBar` has a heavy fan-in: server actions, the typeahead runner,
+// the lingui macro, and the navigation hooks. Each of those is mocked
+// in isolation so the suite exercises only the dropdown wiring around
+// the synthetic "Request <query>" entry (issue #2807).
+
+// Lingui's `useLingui` macro normally needs the babel transform (see
+// apps/web/babel.config.json). Tests run under Vitest + esbuild without
+// that transform, so substitute a runtime-friendly hook that returns a
+// `t` which simply renders the descriptor's `message`.
+vi.mock("@lingui/react/macro", () => ({
+  useLingui: () => ({
+    t: (input: unknown) => {
+      if (typeof input === "string") return input;
+      const desc = input as { message?: string; id?: string };
+      return desc.message ?? desc.id ?? "";
+    },
+  }),
+}));
+
+const pushMock = vi.fn();
+const currentSearchParams = new URLSearchParams();
+let currentPathname = "/en";
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock, replace: pushMock, refresh: () => {} }),
+  useSearchParams: () => currentSearchParams,
+  usePathname: () => currentPathname,
+  useParams: () => ({ lang: "en" }),
+}));
+
+// Server actions / typeahead runners — controlled per test.
+const suggestCompaniesMock = vi.fn();
+vi.mock("@/lib/actions/company", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/actions/company")>(
+      "@/lib/actions/company",
+    );
+  return {
+    ...actual,
+    suggestCompanies: (...args: unknown[]) => suggestCompaniesMock(...args),
+  };
+});
+
+vi.mock("@/lib/search/typeahead-runner", () => ({
+  runSuggestLocations: vi.fn(async () => []),
+  runSuggestOccupations: vi.fn(async () => []),
+  runSuggestSeniorities: vi.fn(async () => []),
+  runSuggestTechnologies: vi.fn(async () => []),
+}));
+
+// `parseSearchFilters` is a server action — only used on the keyword
+// fast-path so a noop is enough.
+vi.mock("@/lib/actions/search-input", () => ({
+  parseSearchFilters: vi.fn(async () => ({
+    keywords: [],
+    locations: [],
+    occupations: [],
+    seniorities: [],
+    technologies: [],
+  })),
+}));
+
+// `server-only` is imported transitively through company.ts; neutralise
+// the gate so happy-dom can load it.
+vi.mock("server-only", () => ({}));
+
+import { SearchBar } from "../search-bar";
+
+beforeEach(() => {
+  pushMock.mockReset();
+  suggestCompaniesMock.mockReset();
+  currentPathname = "/en";
+});
+
+afterEach(() => {
+  vi.clearAllTimers();
+});
+
+async function typeInBar(value: string) {
+  const input = screen.getByRole("combobox");
+  await userEvent.type(input, value);
+  // The dropdown's debounce is 200ms; advance both fake timers (if used)
+  // and real microtasks so the pending fetches settle before assertions.
+  await new Promise((r) => setTimeout(r, 250));
+}
+
+describe("SearchBar — synthetic 'Request <query>' dropdown row (#2807)", () => {
+  it("Type 'Anthropic' → dropdown shows 'Request \"Anthropic\"' item", async () => {
+    suggestCompaniesMock.mockResolvedValue([]);
+    render(<SearchBar />);
+    await act(async () => {
+      await typeInBar("Anthropic");
+    });
+
+    const row = await screen.findByTestId("search-bar-request-item");
+    expect(row).toBeTruthy();
+    expect(row.textContent).toContain("Anthropic");
+    // Distinct visual: opt to a non-default icon container — assert the
+    // request row is rendered with role=option so it's part of the
+    // listbox a11y tree.
+    expect(row.getAttribute("role")).toBe("option");
+  });
+
+  it("Type 'Stripe' (already in catalog) → dropdown shows the real Stripe entry, no Request item", async () => {
+    suggestCompaniesMock.mockResolvedValue([
+      { id: "co_stripe", name: "Stripe", slug: "stripe", icon: null },
+    ]);
+    render(<SearchBar />);
+    await act(async () => {
+      await typeInBar("Stripe");
+    });
+
+    expect(await screen.findByText("Stripe")).toBeTruthy();
+    expect(screen.queryByTestId("search-bar-request-item")).toBeNull();
+  });
+
+  it("Type '' (empty) → no Request item", async () => {
+    suggestCompaniesMock.mockResolvedValue([]);
+    render(<SearchBar />);
+    // Don't type anything — dropdown should not even open, and certainly
+    // no Request row.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByTestId("search-bar-request-item")).toBeNull();
+  });
+
+  it("Click the Request item → navigates to /en/companies/request?name=Anthropic", async () => {
+    suggestCompaniesMock.mockResolvedValue([]);
+    render(<SearchBar />);
+    await act(async () => {
+      await typeInBar("Anthropic");
+    });
+
+    const row = await screen.findByTestId("search-bar-request-item");
+    // Component listens on onMouseDown (preserves focus); fire that.
+    await act(async () => {
+      await userEvent.pointer({ keys: "[MouseLeft>]", target: row });
+    });
+
+    expect(pushMock).toHaveBeenCalledTimes(1);
+    expect(pushMock).toHaveBeenCalledWith(
+      "/en/companies/request?name=Anthropic",
+    );
+  });
+
+  it("Click the Request item with a multi-word query → URL-encodes the name", async () => {
+    suggestCompaniesMock.mockResolvedValue([]);
+    render(<SearchBar />);
+    await act(async () => {
+      await typeInBar("Some Company & Co.");
+    });
+
+    const row = await screen.findByTestId("search-bar-request-item");
+    await act(async () => {
+      await userEvent.pointer({ keys: "[MouseLeft>]", target: row });
+    });
+
+    expect(pushMock).toHaveBeenCalledWith(
+      `/en/companies/request?name=${encodeURIComponent("Some Company & Co.")}`,
+    );
+  });
+
+  it("Keyboard: arrow-down to the Request item, Enter activates it", async () => {
+    suggestCompaniesMock.mockResolvedValue([]);
+    render(<SearchBar />);
+    await act(async () => {
+      await typeInBar("Anthropic");
+    });
+
+    // The dropdown should have at least the keyword row + the request
+    // row at this point (since suggest* mocks return empty arrays). The
+    // request row is always last.
+    const input = screen.getByRole("combobox");
+    // Walk activeIndex down until the request row is highlighted. We
+    // press ArrowDown enough times to definitely reach the bottom — the
+    // handler clamps at the last index.
+    for (let i = 0; i < 10; i++) {
+      await act(async () => {
+        await userEvent.type(input, "{ArrowDown}");
+      });
+    }
+
+    const row = await screen.findByTestId("search-bar-request-item");
+    expect(row.getAttribute("aria-selected")).toBe("true");
+
+    await act(async () => {
+      await userEvent.type(input, "{Enter}");
+    });
+
+    expect(pushMock).toHaveBeenCalledWith(
+      "/en/companies/request?name=Anthropic",
+    );
+  });
+
+  it("Does NOT show the Request item when scoped to a company route", async () => {
+    suggestCompaniesMock.mockResolvedValue([]);
+    currentPathname = "/en/company/stripe";
+    render(<SearchBar />);
+    await act(async () => {
+      await typeInBar("Anthropic");
+    });
+
+    expect(screen.queryByTestId("search-bar-request-item")).toBeNull();
+  });
+});

--- a/apps/web/src/components/search/search-bar.tsx
+++ b/apps/web/src/components/search/search-bar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Search, MapPin, Building2, ArrowRight, Briefcase, BarChart3, Code2 } from "lucide-react";
+import { Search, MapPin, Building2, ArrowRight, Briefcase, BarChart3, Code2, Sparkles } from "lucide-react";
 import Image from "next/image";
 import { useLingui } from "@lingui/react/macro";
 import type { LocationSuggestion } from "@/lib/actions/locations";
@@ -28,7 +28,15 @@ type SuggestionItem =
   | { kind: "seniority"; data: TaxonomySuggestion }
   | { kind: "technology"; data: TaxonomySuggestion }
   | { kind: "location"; data: LocationSuggestion }
-  | { kind: "company"; data: CompanySuggestion };
+  | { kind: "company"; data: CompanySuggestion }
+  /**
+   * Synthetic "Request <query>" entry rendered at the bottom of the
+   * dropdown when the user's query has no company match. Activating
+   * this item navigates to the company-request landing page with the
+   * raw query pre-filled. Owned by issue #2807; the landing page is
+   * jobseek#2808.
+   */
+  | { kind: "request"; data: { query: string } };
 
 interface SearchBarProps {
   /** Direct callback for location adds (used on the search page for mobile). */
@@ -159,6 +167,11 @@ export function SearchBar({
   // Build flat list for keyboard navigation
   // "keyword" option first so user can search by title, then structured suggestions
   const trimmedInput = inputValue.trim();
+  // Show the "Request <query>" entry only when the user has a non-empty
+  // query, no real company match has come back, and we're not scoped to
+  // a single company page (where cross-company nav would be a trap).
+  const showRequestItem =
+    trimmedInput.length >= 2 && companyResults.length === 0 && !scopedToCompany;
   const allSuggestions: SuggestionItem[] = [
     ...(trimmedInput.length >= 2
       ? [{ kind: "keyword" as const, data: { text: trimmedInput } }]
@@ -168,6 +181,9 @@ export function SearchBar({
     ...technologyResults.map((s): SuggestionItem => ({ kind: "technology", data: s })),
     ...locationResults.map((s): SuggestionItem => ({ kind: "location", data: s })),
     ...companyResults.map((s): SuggestionItem => ({ kind: "company", data: s })),
+    ...(showRequestItem
+      ? [{ kind: "request" as const, data: { query: trimmedInput } }]
+      : []),
   ];
 
   const fetchSuggestions = useCallback(
@@ -216,7 +232,14 @@ export function SearchBar({
         } else {
           suggestCompanies({ query }).then((companies) => {
             setCompanyResults(companies);
-            if (companies.length > 0) setIsOpen(true);
+            // Open the dropdown either when a real company match exists,
+            // or when no match exists for a non-empty query (so the
+            // synthetic "Request <query>" entry — issue #2807 — is
+            // visible). The Request branch is suppressed on
+            // company-scoped routes via the parent `if`.
+            if (companies.length > 0 || query.trim().length >= 2) {
+              setIsOpen(true);
+            }
           });
         }
         suggestLocations({
@@ -269,6 +292,23 @@ export function SearchBar({
       if (item.kind === "keyword") {
         // User selected "Search for 'X' as title keyword"
         void submitFreeTextSearch();
+        return;
+      }
+      if (item.kind === "request") {
+        // Navigate to the company-request landing page (jobseek#2808)
+        // with the raw query pre-filled. Encode the name so spaces and
+        // any URL-significant characters survive the round-trip.
+        router.push(
+          lp(`/companies/request?name=${encodeURIComponent(item.data.query)}`),
+        );
+        setInputValue("");
+        setLocationResults([]);
+        setCompanyResults([]);
+        setOccupationResults([]);
+        setSeniorityResults([]);
+        setTechnologyResults([]);
+        setIsOpen(false);
+        setActiveIndex(-1);
         return;
       }
       if (item.kind === "location") {
@@ -481,7 +521,7 @@ export function SearchBar({
     message: "Search...",
   });
 
-  // Compute flat indices for each section (keyword → occupations → seniorities → technologies → locations → companies)
+  // Compute flat indices for each section (keyword → occupations → seniorities → technologies → locations → companies → request)
   let flatIdx = 0;
   const keywordIndex = flatIdx;
   flatIdx += trimmedInput.length >= 2 ? 1 : 0;
@@ -494,6 +534,8 @@ export function SearchBar({
   const locStartIndex = flatIdx;
   flatIdx += locationResults.length;
   const companyStartIndex = flatIdx;
+  flatIdx += companyResults.length;
+  const requestIndex = flatIdx;
 
   return (
     <div className={`relative ${className ?? ""}`} ref={containerRef}>
@@ -745,6 +787,43 @@ export function SearchBar({
                 );
               })}
             </>
+          )}
+
+          {showRequestItem && (
+            <div
+              id={`search-option-${requestIndex}`}
+              role="option"
+              aria-selected={requestIndex === activeIndex}
+              data-suggestion
+              data-testid="search-bar-request-item"
+              onMouseDown={(e) => {
+                e.preventDefault();
+                selectItem({ kind: "request", data: { query: trimmedInput } });
+              }}
+              onMouseEnter={() => setActiveIndex(requestIndex)}
+              className={`flex cursor-pointer items-start gap-2 px-3 py-2 text-sm border-t border-border-soft ${
+                requestIndex === activeIndex ? "bg-primary/10" : "hover:bg-primary/5"
+              }`}
+            >
+              <Sparkles size={14} className="mt-0.5 shrink-0 text-primary" />
+              <div className="min-w-0 flex-1">
+                <div className="font-medium">
+                  {t({
+                    id: "search.bar.request",
+                    comment: "Synthetic dropdown row that lets the user request a company that's not in the catalog",
+                    message: `Request "${trimmedInput}"`,
+                  })}
+                </div>
+                <div className="text-xs text-muted">
+                  {t({
+                    id: "search.bar.request.subtext",
+                    comment: "Secondary line under the Request <query> dropdown row",
+                    message: "We'll start tracking it",
+                  })}
+                </div>
+              </div>
+              <ArrowRight size={12} className="mt-1 shrink-0 text-muted" />
+            </div>
           )}
         </ScrollFade>
         </div>


### PR DESCRIPTION
## Summary
When the global search bar's catalog lookup returns no companies for a non-empty query, the dropdown now ends with a synthetic "Request &lt;query&gt;" row (Sparkles icon + secondary "We'll start tracking it" line). Clicking or keyboard-activating the row navigates to `/[lang]/companies/request?name=<urlencoded>` — the request-this-company landing page being built in jobseek#2808.

## Related issue
Closes colophon-group/jobseek#2807

## Files changed (high-level)
- `apps/web/src/components/search/search-bar.tsx` — extends `SuggestionItem` with a `request` variant, adds a `showRequestItem` gate (non-empty query, zero company matches, not scoped to a company route), routes `selectItem` for the new variant, threads it through the keyboard-flat-index calculation, and renders the row.
- `apps/web/src/components/search/__tests__/search-bar-request.test.tsx` — new component test covering every Verification bullet (typing the unknown company, typing a known company, empty query, click navigation, keyboard nav + Enter, suppression on company-scoped routes).
- `apps/web/locales/{en,de,fr,it}.po` — `pnpm extract` regenerated catalogs; the only net-new strings are `search.bar.request` ("Request \"{query}\"") and `search.bar.request.subtext` ("We'll start tracking it"). Other reorderings are extract artefacts.

## Verification (from the issue)
- [x] Type "Anthropic" → dropdown shows "Request Anthropic" item.
- [x] Type "Stripe" (in catalog) → real Stripe entry, no Request item.
- [x] Type "" (empty) → no Request item.
- [x] Click the Request item → navigates to `?name=Anthropic`.
- [x] Keyboard: arrow-down to the Request item, Enter activates it.
- [x] Bonus: suppressed when bar is rendered inside a company route.

## Manual checks run locally
- `pnpm lint` ✓
- `tsc --noEmit` ✓ (only pre-existing errors in `mcp/route.ts` and `lib/actions/__tests__/company.test.ts` remain — unrelated)
- `pnpm test` ✓ (44/44 files, 369/369 tests; 7 new in `search-bar-request.test.tsx`)
- `pnpm extract` ✓ — only `search.bar.request` and `search.bar.request.subtext` are net new; other locale changes are extract reorderings.

## Notes for reviewer
- The dropdown previously stayed closed when every suggestion source returned zero results. To make the Request row reachable for unknown companies, the `suggestCompanies` resolver now opens the dropdown when `query.trim().length >= 2` even with zero matches. This is intentional and only affects the not-scoped-to-a-company path.
- The link target `/[lang]/companies/request` does not yet exist; jobseek#2808 owns it. The route is locked in advance per the issue brief.
- Out of scope per issue: the landing page (#2808), the agent prompt content (#2809), polling (#2810), and any change to `suggestCompanies`.