### PR TITLE
fix(web): emit <lastmod> on sitemap-index entries

### DIFF
--- a/apps/web/app/__tests__/sitemap-xml-route.test.ts
+++ b/apps/web/app/__tests__/sitemap-xml-route.test.ts
@@ -35,6 +35,22 @@ describe("/sitemap.xml route handler (issue #2694)", () => {
     expect(body).toContain("</sitemapindex>");
   });
 
+  it("emits a <lastmod> on every <sitemap> entry so crawlers re-walk children", async () => {
+    // Without <lastmod>, Google can stick on a stale view of the
+    // index for days. The value just needs to be a valid W3C
+    // datetime; we use the current time bounded by the 1h cache TTL.
+    planSitemapShardsMock.mockResolvedValue([{ id: 0 }, { id: 1 }]);
+
+    const res = await GET();
+    const body = await res.text();
+
+    const sitemapEntries = body.match(/<sitemap>[\s\S]*?<\/sitemap>/g) ?? [];
+    expect(sitemapEntries).toHaveLength(2);
+    for (const entry of sitemapEntries) {
+      expect(entry).toMatch(/<lastmod>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z<\/lastmod>/);
+    }
+  });
+
   it("falls back to a single-shard index when planSitemapShards throws", async () => {
     // Defense-in-depth: planSitemapShards already swallows fetcher
     // errors, but if a future change makes it throw the index must

--- a/apps/web/app/sitemap.xml/route.ts
+++ b/apps/web/app/sitemap.xml/route.ts
@@ -29,6 +29,14 @@ export async function GET(): Promise<Response> {
     shards = [{ id: 0 }];
   }
 
+  // <lastmod> on each <sitemap> entry tells crawlers when to re-fetch
+  // the child. Without it, Google can stick on a stale view of the
+  // index ("0 discovered pages") until it eventually decides to
+  // re-walk every child — days on a large index. Tying lastmod to the
+  // cache-fill window (1h s-maxage) gives a steady "this index moves
+  // hourly, re-walk the children" signal without per-request churn.
+  const lastmod = new Date().toISOString();
+
   const lines: string[] = [
     `<?xml version="1.0" encoding="UTF-8"?>`,
     `<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`,
@@ -39,7 +47,7 @@ export async function GET(): Promise<Response> {
   // shard URLs that don't exist.
   for (const { id } of shards) {
     lines.push(
-      `  <sitemap><loc>${siteConfig.url}/sitemap/${id}.xml</loc></sitemap>`,
+      `  <sitemap><loc>${siteConfig.url}/sitemap/${id}.xml</loc><lastmod>${lastmod}</lastmod></sitemap>`,
     );
   }
   lines.push(`</sitemapindex>`, "");


### PR DESCRIPTION
## Summary

Emergency hotfix: GSC reports \`/sitemap.xml\` as having "Total discovered pages 0" despite the index pointing at 23 healthy shards (~17K URLs).

The \`<sitemap>\` entries in the index had no \`<lastmod>\`. Per the sitemap protocol that's the freshness signal crawlers use to decide whether to re-walk a child sitemap. Without it, Google can stick on its prior read of the index for days — matching the symptom even when every shard returns valid content.

## Change

- Add \`<lastmod>\` (current ISO time) to each \`<sitemap>\` entry emitted by \`app/sitemap.xml/route.ts\`.
- Vercel's CDN already caches the index for 1h (\`s-maxage=3600\`), so the value is stable per cache window — a clean "this index moves hourly, re-walk the children" signal that doesn't churn per request.
- New unit test in \`sitemap-xml-route.test.ts\` asserts every \`<sitemap>\` entry carries a W3C-format \`<lastmod>\`.

## What was ruled out during investigation

- XML validity (clean per \`xmllint\`)
- Bot UA differences (Googlebot/Bingbot/Yandex/DDG/FB all get the same 200 + valid XML)
- robots.txt blocks (none on \`/sitemap/*\`)
- Shard 5xx for any \`id\` 0–22 (all return 200 with thousands of URLs)
- www variant (DNS doesn't resolve, no canonical mismatch)
- Recent \`main\` commits since #2699 — none touch sitemap

## Test plan

- [x] \`pnpm test\` for the three sitemap test files — 29/29 passing
- [ ] Wait for production deploy
- [ ] Resubmit sitemap in Search Console to trigger immediate re-read

🤖 Generated with [Claude Code](https://claude.com/claude-code)