### PR TITLE
fix(build): allow sharp + esbuild postinstall under pnpm 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
       "hono": ">=4.12.14",
       "kysely": ">=0.28.14",
       "path-to-regexp": ">=8.4.0"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "esbuild",
+      "sharp"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

Production build log was full of:

\`\`\`
Can't load image https://jobseek-assets.colophon-group.org/companies/<slug>/icon.webp: Unsupported image type: image/webp
\`\`\`

even though the URLs serve valid WebP (\`RIFF…WEBPVP8X\`, \`content-type: image/webp\`, ~3.5 KB). Root cause is the warning at the start of every Vercel install:

\`\`\`
Ignored build scripts: esbuild@0.25.12, esbuild@0.27.3, esbuild@0.28.0, sharp@0.34.5.
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
\`\`\`

pnpm 10 default-denies install scripts. Sharp's \`install\` step (\`node install/check.js || npm run build\`) verifies the prebuilt libvips for the current platform and falls back to a from-source build. Without it, Sharp can land in a state where it loads but lacks codec support — failing on valid WebP at build time.

## Change

Add \`pnpm.onlyBuiltDependencies\` to the root \`package.json\` listing only \`esbuild\` and \`sharp\` — every other package stays in the default-deny security posture.

## Verification

Locally, after \`pnpm install --frozen-lockfile\`:

\`\`\`
.../sharp@0.34.5/node_modules/sharp install\$ node install/check.js || npm run build
.../sharp@0.34.5/node_modules/sharp install: Done
\`\`\`

And Sharp now decodes the failing icon:

\`\`\`
{ format: 'webp', size: 3450, width: 180, height: 180, channels: 4, hasAlpha: true }
\`\`\`

## Test plan

- [x] \`pnpm install --frozen-lockfile\` runs Sharp + esbuild postinstall without error
- [x] Sharp decodes \`speechify/icon.webp\` correctly
- [ ] Production build log no longer contains \`Unsupported image type: image/webp\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)