### PR TITLE
fix(web): list every sitemap shard in robots.txt

### DIFF
--- a/apps/web/app/__tests__/robots.test.ts
+++ b/apps/web/app/__tests__/robots.test.ts
@@ -1,28 +1,42 @@
-import { describe, it, expect } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
+
+const { planSitemapShardsMock } = vi.hoisted(() => ({
+  planSitemapShardsMock: vi.fn(),
+}));
+
+vi.mock("@/lib/sitemap", () => ({
+  planSitemapShards: planSitemapShardsMock,
+}));
+
 import robots from "../robots";
 
 describe("robots", () => {
-  it("returns a valid robots config", () => {
-    const result = robots();
+  beforeEach(() => {
+    planSitemapShardsMock.mockReset();
+    planSitemapShardsMock.mockResolvedValue([{ id: 0 }, { id: 1 }, { id: 2 }]);
+  });
+
+  it("returns a valid robots config", async () => {
+    const result = await robots();
     expect(result.rules).toBeDefined();
   });
 
-  it("allows all user agents", () => {
-    const result = robots();
+  it("allows all user agents", async () => {
+    const result = await robots();
     const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
     const wildcard = rules.find((r) => r.userAgent === "*");
     expect(wildcard).toBeDefined();
   });
 
-  it("allows root path", () => {
-    const result = robots();
+  it("allows root path", async () => {
+    const result = await robots();
     const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
     const wildcard = rules.find((r) => r.userAgent === "*");
     expect(wildcard?.allow).toContain("/");
   });
 
-  it("disallows dashboard and auth pages", () => {
-    const result = robots();
+  it("disallows dashboard and auth pages", async () => {
+    const result = await robots();
     const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
     const wildcard = rules.find((r) => r.userAgent === "*");
     expect(wildcard).toBeDefined();
@@ -32,8 +46,8 @@ describe("robots", () => {
     expect(disallow).toContain("/sign-up");
   });
 
-  it("disallows locale-prefixed variants of private pages", () => {
-    const result = robots();
+  it("disallows locale-prefixed variants of private pages", async () => {
+    const result = await robots();
     const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
     const wildcard = rules.find((r) => r.userAgent === "*");
     const disallow = wildcard!.disallow as string[];
@@ -45,8 +59,8 @@ describe("robots", () => {
     }
   });
 
-  it("disallows private API routes but not public v1", () => {
-    const result = robots();
+  it("disallows private API routes but not public v1", async () => {
+    const result = await robots();
     const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
     const wildcard = rules.find((r) => r.userAgent === "*");
     const disallow = wildcard!.disallow as string[];
@@ -56,8 +70,8 @@ describe("robots", () => {
     expect(disallow).not.toContain("/api/");
   });
 
-  it("does not locale-prefix API paths", () => {
-    const result = robots();
+  it("does not locale-prefix API paths", async () => {
+    const result = await robots();
     const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
     const wildcard = rules.find((r) => r.userAgent === "*");
     const disallow = wildcard!.disallow as string[];
@@ -66,8 +80,31 @@ describe("robots", () => {
     }
   });
 
-  it("includes sitemap URL", () => {
-    const result = robots();
-    expect(result.sitemap).toContain("sitemap.xml");
+  it("declares the sitemap index plus every shard from the planner", async () => {
+    // Belt-and-braces: long-tail bots that don't recurse into a
+    // <sitemapindex> still need a direct pointer at every shard.
+    planSitemapShardsMock.mockResolvedValueOnce([
+      { id: 0 },
+      { id: 1 },
+      { id: 2 },
+    ]);
+
+    const result = await robots();
+    expect(result.sitemap).toEqual([
+      "https://jseek.co/sitemap.xml",
+      "https://jseek.co/sitemap/0.xml",
+      "https://jseek.co/sitemap/1.xml",
+      "https://jseek.co/sitemap/2.xml",
+    ]);
+  });
+
+  it("falls back to just the index when the planner rejects", async () => {
+    // The planner already swallows fetcher errors, but if a future
+    // change makes it throw, robots.txt must still ship at least the
+    // index URL — same defense-in-depth pattern as sitemap.xml.
+    planSitemapShardsMock.mockRejectedValueOnce(new Error("planner blew up"));
+
+    const result = await robots();
+    expect(result.sitemap).toEqual(["https://jseek.co/sitemap.xml"]);
   });
 });

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,6 +1,11 @@
 import type { MetadataRoute } from "next";
 import { siteConfig } from "@/content/config";
 import { locales } from "@/lib/i18n";
+import { planSitemapShards } from "@/lib/sitemap";
+
+// Match the sitemap-index handler's CDN window so robots.txt and the
+// sitemap stay in lockstep when shards are added or removed.
+export const revalidate = 3600;
 
 function expandDisallow(paths: readonly string[]): string[] {
   const out: string[] = [];
@@ -16,8 +21,23 @@ function expandDisallow(paths: readonly string[]): string[] {
   return out;
 }
 
-export default function robots(): MetadataRoute.Robots {
+export default async function robots(): Promise<MetadataRoute.Robots> {
   const disallow = expandDisallow(siteConfig.seo.disallow as unknown as string[]);
+
+  // Belt-and-braces: declare both the sitemap *index* and every
+  // *shard* directly. Standards-compliant crawlers follow the index
+  // entries on their own, but listing shards explicitly here gives
+  // long-tail bots that don't recurse into <sitemapindex> a direct
+  // path to the URLs. planSitemapShards already catches its own
+  // upstream errors and falls back to [{id:0}], so this never throws.
+  let shardUrls: string[] = [];
+  try {
+    const shards = await planSitemapShards();
+    shardUrls = shards.map(({ id }) => `${siteConfig.url}/sitemap/${id}.xml`);
+  } catch {
+    // Defense-in-depth: if a future change makes the planner throw,
+    // robots.txt still ships with at least the index entry.
+  }
 
   return {
     rules: [
@@ -33,6 +53,6 @@ export default function robots(): MetadataRoute.Robots {
         disallow,
       },
     ],
-    sitemap: `${siteConfig.url}/sitemap.xml`,
+    sitemap: [`${siteConfig.url}/sitemap.xml`, ...shardUrls],
   };
 }


### PR DESCRIPTION
## Summary

\`robots.txt\` currently advertises only the sitemap **index** URL. Standards-compliant crawlers follow the 23 \`<sitemap>\` entries on their own, but long-tail bots that don't recurse into a \`<sitemapindex>\` never see the per-shard URLs — so they miss every per-company sitemap.

## Change

- \`app/robots.ts\` becomes async, calls \`planSitemapShards()\`, and emits both the index URL **and** every \`/sitemap/<id>.xml\` shard.
- \`revalidate = 3600\` ties robots.txt to the sitemap-index handler's CDN window so the two stay in lockstep when shards are added/removed.
- \`planSitemapShards\` already swallows upstream Typesense/Postgres errors and falls back to \`[{id:0}]\`, so this never throws. Defensive try/catch keeps the index entry in robots.txt even if a future change makes the planner reject.

## Result

Before:

\`\`\`
Sitemap: https://jseek.co/sitemap.xml
\`\`\`

After:

\`\`\`
Sitemap: https://jseek.co/sitemap.xml
Sitemap: https://jseek.co/sitemap/0.xml
Sitemap: https://jseek.co/sitemap/1.xml
…
Sitemap: https://jseek.co/sitemap/22.xml
\`\`\`

## Test plan

- [x] All 9 robots tests pass (added 2 new ones for shard listing + planner-reject fallback)
- [x] Existing 29 sitemap tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)