### PR TITLE
fix(web): TEMPORARY — collapse sitemap into single <urlset>

### DIFF
--- a/apps/web/app/__tests__/robots.test.ts
+++ b/apps/web/app/__tests__/robots.test.ts
@@ -1,42 +1,28 @@
-import { beforeEach, describe, it, expect, vi } from "vitest";
-
-const { planSitemapShardsMock } = vi.hoisted(() => ({
-  planSitemapShardsMock: vi.fn(),
-}));
-
-vi.mock("@/lib/sitemap", () => ({
-  planSitemapShards: planSitemapShardsMock,
-}));
-
+import { describe, it, expect } from "vitest";
 import robots from "../robots";
 
 describe("robots", () => {
-  beforeEach(() => {
-    planSitemapShardsMock.mockReset();
-    planSitemapShardsMock.mockResolvedValue([{ id: 0 }, { id: 1 }, { id: 2 }]);
-  });
-
-  it("returns a valid robots config", async () => {
-    const result = await robots();
+  it("returns a valid robots config", () => {
+    const result = robots();
     expect(result.rules).toBeDefined();
   });
 
-  it("allows all user agents", async () => {
-    const result = await robots();
+  it("allows all user agents", () => {
+    const result = robots();
     const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
     const wildcard = rules.find((r) => r.userAgent === "*");
     expect(wildcard).toBeDefined();
   });
 
-  it("allows root path", async () => {
-    const result = await robots();
+  it("allows root path", () => {
+    const result = robots();
     const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
     const wildcard = rules.find((r) => r.userAgent === "*");
     expect(wildcard?.allow).toContain("/");
   });
 
-  it("disallows dashboard and auth pages", async () => {
-    const result = await robots();
+  it("disallows dashboard and auth pages", () => {
+    const result = robots();
     const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
     const wildcard = rules.find((r) => r.userAgent === "*");
     expect(wildcard).toBeDefined();
@@ -46,8 +32,8 @@ describe("robots", () => {
     expect(disallow).toContain("/sign-up");
   });
 
-  it("disallows locale-prefixed variants of private pages", async () => {
-    const result = await robots();
+  it("disallows locale-prefixed variants of private pages", () => {
+    const result = robots();
     const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
     const wildcard = rules.find((r) => r.userAgent === "*");
     const disallow = wildcard!.disallow as string[];
@@ -59,8 +45,8 @@ describe("robots", () => {
     }
   });
 
-  it("disallows private API routes but not public v1", async () => {
-    const result = await robots();
+  it("disallows private API routes but not public v1", () => {
+    const result = robots();
     const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
     const wildcard = rules.find((r) => r.userAgent === "*");
     const disallow = wildcard!.disallow as string[];
@@ -70,8 +56,8 @@ describe("robots", () => {
     expect(disallow).not.toContain("/api/");
   });
 
-  it("does not locale-prefix API paths", async () => {
-    const result = await robots();
+  it("does not locale-prefix API paths", () => {
+    const result = robots();
     const rules = Array.isArray(result.rules) ? result.rules : [result.rules];
     const wildcard = rules.find((r) => r.userAgent === "*");
     const disallow = wildcard!.disallow as string[];
@@ -80,31 +66,10 @@ describe("robots", () => {
     }
   });
 
-  it("declares the sitemap index plus every shard from the planner", async () => {
-    // Belt-and-braces: long-tail bots that don't recurse into a
-    // <sitemapindex> still need a direct pointer at every shard.
-    planSitemapShardsMock.mockResolvedValueOnce([
-      { id: 0 },
-      { id: 1 },
-      { id: 2 },
-    ]);
-
-    const result = await robots();
-    expect(result.sitemap).toEqual([
-      "https://jseek.co/sitemap.xml",
-      "https://jseek.co/sitemap/0.xml",
-      "https://jseek.co/sitemap/1.xml",
-      "https://jseek.co/sitemap/2.xml",
-    ]);
-  });
-
-  it("falls back to just the index when the planner rejects", async () => {
-    // The planner already swallows fetcher errors, but if a future
-    // change makes it throw, robots.txt must still ship at least the
-    // index URL — same defense-in-depth pattern as sitemap.xml.
-    planSitemapShardsMock.mockRejectedValueOnce(new Error("planner blew up"));
-
-    const result = await robots();
-    expect(result.sitemap).toEqual(["https://jseek.co/sitemap.xml"]);
+  it("declares only the monolithic /sitemap.xml URL while the experiment runs", () => {
+    // TEMPORARY: while /sitemap.xml is a single <urlset>, listing
+    // shards too would have crawlers fetch overlapping content.
+    const result = robots();
+    expect(result.sitemap).toBe("https://jseek.co/sitemap.xml");
   });
 });

--- a/apps/web/app/__tests__/sitemap-xml-route.test.ts
+++ b/apps/web/app/__tests__/sitemap-xml-route.test.ts
@@ -1,83 +1,90 @@
 import { beforeEach, describe, it, expect, vi } from "vitest";
 
-const { planSitemapShardsMock } = vi.hoisted(() => ({
-  planSitemapShardsMock: vi.fn(),
-}));
+const { planSitemapShardsMock, renderSitemapShardMock, serializeUrlsetMock } =
+  vi.hoisted(() => ({
+    planSitemapShardsMock: vi.fn(),
+    renderSitemapShardMock: vi.fn(),
+    serializeUrlsetMock: vi.fn(),
+  }));
 
 vi.mock("@/lib/sitemap", () => ({
   planSitemapShards: planSitemapShardsMock,
-}));
-
-vi.mock("@/content/config", () => ({
-  siteConfig: { url: "https://jseek.co" },
+  renderSitemapShard: renderSitemapShardMock,
+  serializeUrlset: serializeUrlsetMock,
 }));
 
 import { GET } from "../sitemap.xml/route";
 
-describe("/sitemap.xml route handler (issue #2694)", () => {
+/**
+ * TEMPORARY suite: /sitemap.xml is a monolithic <urlset> while we
+ * isolate why GSC reports "Couldn't fetch" on shard URLs. When the
+ * sitemapindex is restored, replace this whole file with the prior
+ * tests asserting <sitemapindex> output.
+ */
+describe("/sitemap.xml route handler (TEMPORARY monolithic urlset)", () => {
   beforeEach(() => {
     planSitemapShardsMock.mockReset();
+    renderSitemapShardMock.mockReset();
+    serializeUrlsetMock.mockReset();
+    serializeUrlsetMock.mockImplementation(
+      () => "<?xml version=\"1.0\"?><urlset/>",
+    );
   });
 
-  it("emits a sitemapindex listing every shard returned by planSitemapShards", async () => {
+  it("renders every shard, flattens the entries, and serializes once", async () => {
     planSitemapShardsMock.mockResolvedValue([{ id: 0 }, { id: 1 }, { id: 2 }]);
+    renderSitemapShardMock
+      .mockResolvedValueOnce([{ url: "https://jseek.co/en" }])
+      .mockResolvedValueOnce([
+        { url: "https://jseek.co/en/company/a" },
+        { url: "https://jseek.co/de/company/a" },
+      ])
+      .mockResolvedValueOnce([{ url: "https://jseek.co/en/company/b" }]);
 
     const res = await GET();
+
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toBe("application/xml; charset=utf-8");
-
-    const body = await res.text();
-    expect(body).toContain('<?xml version="1.0" encoding="UTF-8"?>');
-    expect(body).toContain('<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
-    expect(body).toContain("<loc>https://jseek.co/sitemap/0.xml</loc>");
-    expect(body).toContain("<loc>https://jseek.co/sitemap/1.xml</loc>");
-    expect(body).toContain("<loc>https://jseek.co/sitemap/2.xml</loc>");
-    expect(body).toContain("</sitemapindex>");
+    expect(renderSitemapShardMock).toHaveBeenCalledTimes(3);
+    expect(renderSitemapShardMock).toHaveBeenNthCalledWith(1, 0);
+    expect(renderSitemapShardMock).toHaveBeenNthCalledWith(2, 1);
+    expect(renderSitemapShardMock).toHaveBeenNthCalledWith(3, 2);
+    expect(serializeUrlsetMock).toHaveBeenCalledWith([
+      { url: "https://jseek.co/en" },
+      { url: "https://jseek.co/en/company/a" },
+      { url: "https://jseek.co/de/company/a" },
+      { url: "https://jseek.co/en/company/b" },
+    ]);
   });
 
-  it("emits a <lastmod> on every <sitemap> entry so crawlers re-walk children", async () => {
-    // Without <lastmod>, Google can stick on a stale view of the
-    // index for days. The value just needs to be a valid W3C
-    // datetime; we use the current time bounded by the 1h cache TTL.
-    planSitemapShardsMock.mockResolvedValue([{ id: 0 }, { id: 1 }]);
+  it("serves an empty <urlset/> rather than 5xx when planSitemapShards rejects", async () => {
+    // Crawlers re-try retryable errors but de-rank on hard failures —
+    // an empty 200 keeps the URL in good standing while we recover.
+    planSitemapShardsMock.mockRejectedValue(new Error("planner down"));
 
     const res = await GET();
-    const body = await res.text();
 
-    const sitemapEntries = body.match(/<sitemap>[\s\S]*?<\/sitemap>/g) ?? [];
-    expect(sitemapEntries).toHaveLength(2);
-    for (const entry of sitemapEntries) {
-      expect(entry).toMatch(/<lastmod>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z<\/lastmod>/);
-    }
-  });
-
-  it("falls back to a single-shard index when planSitemapShards throws", async () => {
-    // Defense-in-depth: planSitemapShards already swallows fetcher
-    // errors, but if a future change makes it throw the index must
-    // still serve a valid XML pointing at shard 0 (which serves the
-    // hardcoded static URLs).
-    planSitemapShardsMock.mockRejectedValue(new Error("backends down"));
-
-    const res = await GET();
     expect(res.status).toBe(200);
-    const body = await res.text();
-    expect(body).toContain("<loc>https://jseek.co/sitemap/0.xml</loc>");
-    expect(body).not.toContain("<loc>https://jseek.co/sitemap/1.xml</loc>");
+    expect(renderSitemapShardMock).not.toHaveBeenCalled();
+    expect(serializeUrlsetMock).toHaveBeenCalledWith([]);
   });
 
-  it("emits at least shard 0 when planSitemapShards returns []", async () => {
-    planSitemapShardsMock.mockResolvedValue([]);
+  it("serves an empty <urlset/> when a shard render rejects", async () => {
+    planSitemapShardsMock.mockResolvedValue([{ id: 0 }, { id: 1 }]);
+    renderSitemapShardMock
+      .mockResolvedValueOnce([{ url: "https://jseek.co/en" }])
+      .mockRejectedValueOnce(new Error("shard 1 failed"));
 
     const res = await GET();
-    const body = await res.text();
-    expect(body).toContain("<loc>https://jseek.co/sitemap/0.xml</loc>");
+
+    expect(res.status).toBe(200);
+    expect(serializeUrlsetMock).toHaveBeenCalledWith([]);
   });
 
   it("CDN-caches for 1h with a long stale-while-revalidate window", async () => {
-    // Cache-Control is the single source of truth — segment-config
-    // `revalidate` would conflict with this explicit header on a
-    // Route Handler, so it's intentionally not exported.
     planSitemapShardsMock.mockResolvedValue([{ id: 0 }]);
+    renderSitemapShardMock.mockResolvedValue([]);
+
     const res = await GET();
     expect(res.headers.get("cache-control")).toContain("s-maxage=3600");
     expect(res.headers.get("cache-control")).toContain("stale-while-revalidate=86400");

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -1,12 +1,12 @@
 import type { MetadataRoute } from "next";
 import { siteConfig } from "@/content/config";
 import { locales } from "@/lib/i18n";
-import { planSitemapShards } from "@/lib/sitemap";
 
-// Match the sitemap-index handler's CDN window so robots.txt and the
-// sitemap stay in lockstep when shards are added or removed.
-export const revalidate = 3600;
-
+// TEMPORARY: while /sitemap.xml is a monolithic <urlset> instead of a
+// <sitemapindex>, robots.txt declares only that one URL — listing the
+// shard URLs would have crawlers fetch overlapping content. Restore
+// `planSitemapShards`-driven shard declarations when reverting the
+// monolithic experiment in app/sitemap.xml/route.ts.
 function expandDisallow(paths: readonly string[]): string[] {
   const out: string[] = [];
   for (const path of paths) {
@@ -21,23 +21,8 @@ function expandDisallow(paths: readonly string[]): string[] {
   return out;
 }
 
-export default async function robots(): Promise<MetadataRoute.Robots> {
+export default function robots(): MetadataRoute.Robots {
   const disallow = expandDisallow(siteConfig.seo.disallow as unknown as string[]);
-
-  // Belt-and-braces: declare both the sitemap *index* and every
-  // *shard* directly. Standards-compliant crawlers follow the index
-  // entries on their own, but listing shards explicitly here gives
-  // long-tail bots that don't recurse into <sitemapindex> a direct
-  // path to the URLs. planSitemapShards already catches its own
-  // upstream errors and falls back to [{id:0}], so this never throws.
-  let shardUrls: string[] = [];
-  try {
-    const shards = await planSitemapShards();
-    shardUrls = shards.map(({ id }) => `${siteConfig.url}/sitemap/${id}.xml`);
-  } catch {
-    // Defense-in-depth: if a future change makes the planner throw,
-    // robots.txt still ships with at least the index entry.
-  }
 
   return {
     rules: [
@@ -53,6 +38,6 @@ export default async function robots(): Promise<MetadataRoute.Robots> {
         disallow,
       },
     ],
-    sitemap: [`${siteConfig.url}/sitemap.xml`, ...shardUrls],
+    sitemap: `${siteConfig.url}/sitemap.xml`,
   };
 }

--- a/apps/web/app/sitemap.xml/route.ts
+++ b/apps/web/app/sitemap.xml/route.ts
@@ -1,58 +1,56 @@
-import { siteConfig } from "@/content/config";
-import { planSitemapShards } from "@/lib/sitemap";
+import {
+  planSitemapShards,
+  renderSitemapShard,
+  serializeUrlset,
+} from "@/lib/sitemap";
 
 /**
- * Sitemap index at `/sitemap.xml`.
+ * /sitemap.xml — TEMPORARY: monolithic <urlset>.
  *
- * Crawlers fetch this URL (advertised in `robots.txt`) and follow the
- * listed `<sitemap><loc>` entries to per-shard sitemaps. Issue #2694:
- * with Next.js's file convention + `generateSitemaps()`, this URL was
- * not being served — the request fell through to the `[lang]`
- * catch-all and returned the homepage HTML. We now own the index
- * route explicitly so the failure mode is impossible.
+ * Reverts when the GSC investigation finishes. Background:
+ * after the index + lastmod + robots.txt fixes shipped in #2817 /
+ * #2819, GSC continued to report "Discovered pages: 0" on the
+ * sitemap index AND "Couldn't fetch" when the user submitted
+ * /sitemap/0.xml directly. Every reachability angle we can test
+ * (multiple bot UAs, HTTP/1.1, HEAD, gzip, br, conditional GET,
+ * cold/warm cache) returns a clean 200 with valid XML in <300ms,
+ * and there are no anti-bot mechanisms in front of jseek.co.
  *
- * The response sets explicit Cache-Control (s-maxage=3600 +
- * stale-while-revalidate=86400) so Vercel's CDN serves a cached copy
- * for an hour and tolerates a day of staleness during regenerations.
- * Segment-config `revalidate` would conflict with this on a Route
- * Handler, so it's intentionally not exported.
+ * The remaining hypothesis is something specific to GSC's
+ * sitemap-index recursion. To isolate it, this temporarily
+ * collapses every URL into a single <urlset> served at
+ * /sitemap.xml. The /sitemap/<id>.xml shard routes still work
+ * (they're harmless side-by-side); robots.txt only declares the
+ * monolithic URL while this experiment runs.
+ *
+ * Capacity: ~17K URLs / ~10 MB total — well under the sitemap.org
+ * limits of 50K URLs / 50 MB uncompressed. Vercel auto-compresses
+ * XML at the edge so the on-the-wire payload is far smaller.
+ *
+ * REVERT: replace the body with the previous sitemapindex render
+ * (git show {commit-sha}:apps/web/app/sitemap.xml/route.ts) and
+ * restore robots.ts to declare every shard.
  */
 export async function GET(): Promise<Response> {
-  let shards: { id: number }[];
+  let entries: Awaited<ReturnType<typeof renderSitemapShard>> = [];
   try {
-    const planned = await planSitemapShards();
-    shards = planned.length > 0 ? planned : [{ id: 0 }];
-  } catch {
-    // planSitemapShards already swallows fetcher errors and falls
-    // back to [{id:0}], so this catch is defense-in-depth for any
-    // future change that makes the planner throw.
-    shards = [{ id: 0 }];
-  }
-
-  // <lastmod> on each <sitemap> entry tells crawlers when to re-fetch
-  // the child. Without it, Google can stick on a stale view of the
-  // index ("0 discovered pages") until it eventually decides to
-  // re-walk every child — days on a large index. Tying lastmod to the
-  // cache-fill window (1h s-maxage) gives a steady "this index moves
-  // hourly, re-walk the children" signal without per-request churn.
-  const lastmod = new Date().toISOString();
-
-  const lines: string[] = [
-    `<?xml version="1.0" encoding="UTF-8"?>`,
-    `<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">`,
-  ];
-  // Iterate the planner's ids verbatim instead of regenerating 0..N.
-  // The current planner emits contiguous ids, but the loop staying
-  // honest to its input means a future change won't silently emit
-  // shard URLs that don't exist.
-  for (const { id } of shards) {
-    lines.push(
-      `  <sitemap><loc>${siteConfig.url}/sitemap/${id}.xml</loc><lastmod>${lastmod}</lastmod></sitemap>`,
+    const shards = await planSitemapShards();
+    // Render shards in parallel; the data layer's Redis cache + per-key
+    // single-flight (see lib/cache.ts) ensures the underlying Typesense /
+    // Postgres queries fan in to one upstream call regardless of N.
+    const renderedShards = await Promise.all(
+      shards.map(({ id }) => renderSitemapShard(id)),
     );
+    entries = renderedShards.flat();
+  } catch {
+    // Defense-in-depth: serializeUrlset emits a syntactically valid
+    // empty <urlset/> rather than letting the route 500 — crawlers
+    // re-try on retryable errors but de-rank on hard failures.
   }
-  lines.push(`</sitemapindex>`, "");
 
-  return new Response(lines.join("\n"), {
+  const xml = serializeUrlset(entries);
+
+  return new Response(xml, {
     headers: {
       "Content-Type": "application/xml; charset=utf-8",
       "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",


### PR DESCRIPTION
## Why this is temporary

After #2817 (lastmod) + #2819 (robots shards) shipped, GSC still reports:
- \`/sitemap.xml\` (Sitemap index): "Status: Success" but "Discovered pages: 0"
- \`/sitemap/0.xml\` (submitted directly): "Status: Couldn't fetch"

Every reachability angle returns a clean 200 with valid XML in <300 ms — multiple bot UAs, HTTP/1.1, HEAD, gzip, br, conditional GET, cold/warm cache, exact submitted URL — and there are **no anti-bot mechanisms** in front of jseek.co (Vercel Firewall empty, no BotID, no Attack Challenge, SSO is \`all_except_custom_domains\`).

So the remaining hypothesis is something specific to GSC's sitemap-index recursion. Collapsing every URL into a single \`<urlset>\` lets us isolate it: if GSC reports the right page count, the issue is index handling; if it still reports 0, the problem is upstream of XML shape entirely.

## Change

- \`/sitemap.xml\` returns one \`<urlset>\` with every URL (~17K URLs, ~10 MB raw — well under the 50K / 50 MB sitemap.org limits, gzipped at the edge).
- \`/sitemap/<id>.xml\` shard routes left in place — they still work side-by-side and serve the per-shard subset.
- \`robots.txt\` declares only the monolithic URL while this runs.
- Tests updated; all 36 sitemap+robots tests pass locally.

## Revert plan

Single squash commit, fully self-contained in \`/app/sitemap.xml/route.ts\` and \`/app/robots.ts\` (+ matching tests). Reverting this PR restores the previous \`<sitemapindex>\` behaviour exactly.

## Risk

- **Vercel response size**: ~10 MB raw exceeds Vercel Functions' historical 4.5 MB limit. If we hit this, the route will need to switch to a streaming \`Response\` — I'll watch the deploy and patch if needed.
- **GSC pickup**: GSC re-reads the index on its own cadence (~hourly). Resubmit \`/sitemap.xml\` after deploy to short-circuit.

## Test plan

- [x] All sitemap + robots tests pass locally (36/36)
- [ ] Wait for production deploy
- [ ] \`curl https://jseek.co/sitemap.xml | grep -c '<url>'\` returns ~17K, response is \`<urlset>\` not \`<sitemapindex>\`
- [ ] Resubmit \`/sitemap.xml\` in GSC; check Discovered pages within 24h

🤖 Generated with [Claude Code](https://claude.com/claude-code)