### PR TITLE
fix(seo): noindex legal/policy/how-we-index pages

### DIFF
--- a/apps/web/app/[lang]/(public)/how-we-index/page.tsx
+++ b/apps/web/app/[lang]/(public)/how-we-index/page.tsx
@@ -25,6 +25,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title,
     description,
     alternates: buildAlternates("/how-we-index", locale),
+    // Excluded from the index (#2822): policy/methodology page reached
+    // from the footer; not a search-discovery surface. `follow` keeps
+    // PageRank flowing.
+    robots: { index: false, follow: true },
     openGraph: { title, description, url: `${siteConfig.url}/${locale}/how-we-index` },
   };
 }

--- a/apps/web/app/[lang]/(public)/license/page.tsx
+++ b/apps/web/app/[lang]/(public)/license/page.tsx
@@ -25,6 +25,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title,
     description,
     alternates: buildAlternates("/license", locale),
+    // Excluded from the index (#2822): nobody Googles "jobseek license";
+    // the page is reachable from the footer of every page, which is
+    // sufficient for legal accessibility. Indexing it dilutes the
+    // surface and wastes crawl budget. `follow` keeps PageRank flowing.
+    robots: { index: false, follow: true },
     openGraph: { title, description, url: `${siteConfig.url}/${locale}/license` },
   };
 }

--- a/apps/web/app/[lang]/(public)/privacy-policy/page.tsx
+++ b/apps/web/app/[lang]/(public)/privacy-policy/page.tsx
@@ -25,6 +25,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title,
     description,
     alternates: buildAlternates("/privacy-policy", locale),
+    // Excluded from the index (#2822): footer link satisfies legal
+    // accessibility; nobody discovers the page via search. `follow`
+    // keeps PageRank flowing.
+    robots: { index: false, follow: true },
     openGraph: { title, description, url: `${siteConfig.url}/${locale}/privacy-policy` },
   };
 }

--- a/apps/web/app/[lang]/(public)/terms/page.tsx
+++ b/apps/web/app/[lang]/(public)/terms/page.tsx
@@ -25,6 +25,10 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     title,
     description,
     alternates: buildAlternates("/terms", locale),
+    // Excluded from the index (#2822): footer link satisfies legal
+    // accessibility; nobody discovers the page via search. `follow`
+    // keeps PageRank flowing.
+    robots: { index: false, follow: true },
     openGraph: { title, description, url: `${siteConfig.url}/${locale}/terms` },
   };
 }

--- a/apps/web/src/content/config.ts
+++ b/apps/web/src/content/config.ts
@@ -190,6 +190,11 @@ export const siteConfig = {
       "/reset-password",
       "/verify-email",
     ],
+    // Only pages users actually search for. Legal/policy pages
+    // (license, privacy-policy, terms, how-we-index) are reached from
+    // the footer of every page and are noindex per #2822 — adding
+    // them here would round-trip the discovery for no SEO benefit.
+    //
     // Bump `lastModified` per entry whenever the page's bot-visible
     // content (copy, hero, layout) substantively changes. Stable dates
     // are an honest re-crawl signal for Bing — `new Date()` on every
@@ -199,10 +204,6 @@ export const siteConfig = {
       { path: "/", changeFrequency: "weekly", priority: 1, lastModified: "2026-05-01" },
       { path: "/about", changeFrequency: "monthly", priority: 0.7, lastModified: "2026-05-01" },
       { path: "/faq", changeFrequency: "monthly", priority: 0.7, lastModified: "2026-05-01" },
-      { path: "/how-we-index", changeFrequency: "monthly", priority: 0.6, lastModified: "2026-05-01" },
-      { path: "/license", changeFrequency: "monthly", priority: 0.5, lastModified: "2026-05-01" },
-      { path: "/privacy-policy", changeFrequency: "monthly", priority: 0.5, lastModified: "2026-05-01" },
-      { path: "/terms", changeFrequency: "monthly", priority: 0.5, lastModified: "2026-05-01" },
     ],
     // The /explore prerendered shell — bump when filter UI / hero /
     // initial-data layout substantively changes (#2824).


### PR DESCRIPTION
Closes #2822.

## Summary

Legal/policy pages (Privacy Policy, Terms, License, How-we-index) are reached from the footer of every page — that's sufficient for accessibility. Nobody discovers them via search, and indexing them dilutes the surface and wastes crawl budget.

## Changes

- `robots: { index: false, follow: true }` added to `generateMetadata` of:
  - `app/[lang]/(public)/license/page.tsx`
  - `app/[lang]/(public)/privacy-policy/page.tsx`
  - `app/[lang]/(public)/terms/page.tsx`
  - `app/[lang]/(public)/how-we-index/page.tsx`
- `siteConfig.seo.sitemap` drops the four entries; only `/`, `/about`, `/faq` remain.

`follow` is kept so PageRank from any external links flows through to internal targets.

## Test plan

- [x] `pnpm test` — 308 tests pass.
- [x] `pnpm lint` — clean.
- [ ] Post-deploy: `curl https://jseek.co/en/privacy-policy` returns `<meta name="robots" content="noindex,follow">`. (Same for `/license`, `/terms`, `/how-we-index`.)
- [ ] Post-deploy: `curl https://jseek.co/sitemap/0.xml` no longer lists those four URLs.
- [ ] Pages remain reachable via the footer on any page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)