### PR TITLE
fix(seo): sitemap lastmod correctness + hreflang x-default

### DIFF
--- a/apps/web/src/content/config.ts
+++ b/apps/web/src/content/config.ts
@@ -190,15 +190,23 @@ export const siteConfig = {
       "/reset-password",
       "/verify-email",
     ],
+    // Bump `lastModified` per entry whenever the page's bot-visible
+    // content (copy, hero, layout) substantively changes. Stable dates
+    // are an honest re-crawl signal for Bing — `new Date()` on every
+    // regen would always say "modified now" and the engine eventually
+    // discounts the signal (#2824).
     sitemap: [
-      { path: "/", changeFrequency: "weekly", priority: 1 },
-      { path: "/about", changeFrequency: "monthly", priority: 0.7 },
-      { path: "/faq", changeFrequency: "monthly", priority: 0.7 },
-      { path: "/how-we-index", changeFrequency: "monthly", priority: 0.6 },
-      { path: "/license", changeFrequency: "monthly", priority: 0.5 },
-      { path: "/privacy-policy", changeFrequency: "monthly", priority: 0.5 },
-      { path: "/terms", changeFrequency: "monthly", priority: 0.5 },
+      { path: "/", changeFrequency: "weekly", priority: 1, lastModified: "2026-05-01" },
+      { path: "/about", changeFrequency: "monthly", priority: 0.7, lastModified: "2026-05-01" },
+      { path: "/faq", changeFrequency: "monthly", priority: 0.7, lastModified: "2026-05-01" },
+      { path: "/how-we-index", changeFrequency: "monthly", priority: 0.6, lastModified: "2026-05-01" },
+      { path: "/license", changeFrequency: "monthly", priority: 0.5, lastModified: "2026-05-01" },
+      { path: "/privacy-policy", changeFrequency: "monthly", priority: 0.5, lastModified: "2026-05-01" },
+      { path: "/terms", changeFrequency: "monthly", priority: 0.5, lastModified: "2026-05-01" },
     ],
+    // The /explore prerendered shell — bump when filter UI / hero /
+    // initial-data layout substantively changes (#2824).
+    exploreLastModified: "2026-05-01",
   },
 
   footer: {

--- a/apps/web/src/lib/__tests__/sitemap.test.ts
+++ b/apps/web/src/lib/__tests__/sitemap.test.ts
@@ -123,6 +123,46 @@ describe("sitemap data layer", () => {
     }
   });
 
+  it("static + explore lastModified are stable (not request-time, #2824)", async () => {
+    // Previously every regen claimed `lastModified: new Date()`, which
+    // Bing eventually discounts as a useless re-crawl signal. The
+    // values must come from `siteConfig.seo.sitemap[i].lastModified`
+    // and `siteConfig.seo.exploreLastModified`.
+    const before = Date.now();
+    const result = await renderAllShards();
+    const after = Date.now();
+    const staticAndExplore = result.filter(
+      (e) => !e.url.match(/\/(company|[^/]+)\/[^/]+$/)
+        || e.url.endsWith("/explore"),
+    );
+    expect(staticAndExplore.length).toBeGreaterThan(0);
+    for (const entry of staticAndExplore) {
+      const ts = entry.lastModified instanceof Date
+        ? entry.lastModified.getTime()
+        : new Date(entry.lastModified!).getTime();
+      // A request-time `new Date()` would land between before/after.
+      // A stable hardcoded date pre-dates the test run by months.
+      expect(ts).toBeLessThan(before);
+      // sanity: not in the future
+      expect(ts).toBeLessThanOrEqual(after);
+    }
+  });
+
+  it("hreflang map includes x-default pointing at /en (#2825)", async () => {
+    const result = await renderAllShards();
+    // Pick any entry with alternates — the homepage will do.
+    const homepageEn = result.find((e) => e.url === "https://jseek.co/en");
+    expect(homepageEn?.alternates?.languages).toBeDefined();
+    expect(homepageEn?.alternates?.languages?.["x-default"]).toBe(
+      "https://jseek.co/en",
+    );
+    // Non-/ paths should also carry x-default at /en/<path>.
+    const aboutEn = result.find((e) => e.url === "https://jseek.co/en/about");
+    expect(aboutEn?.alternates?.languages?.["x-default"]).toBe(
+      "https://jseek.co/en/about",
+    );
+  });
+
   it("paginates Typesense company results so later pages reach the sitemap", async () => {
     searchMock
       .mockResolvedValueOnce(typesensePage(
@@ -239,6 +279,7 @@ describe("sitemap data layer", () => {
       de: expect.stringContaining("/de/curated-user/hot-list"),
       fr: expect.stringContaining("/fr/curated-user/hot-list"),
       it: expect.stringContaining("/it/curated-user/hot-list"),
+      "x-default": expect.stringContaining("/en/curated-user/hot-list"),
     });
   });
 });

--- a/apps/web/src/lib/__tests__/sitemap.test.ts
+++ b/apps/web/src/lib/__tests__/sitemap.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, it, expect, vi } from "vitest";
+import { siteConfig } from "@/content/config";
 
 const { dbExecuteMock, searchMock } = vi.hoisted(() => ({
   dbExecuteMock: vi.fn(),
@@ -128,14 +129,35 @@ describe("sitemap data layer", () => {
     // Bing eventually discounts as a useless re-crawl signal. The
     // values must come from `siteConfig.seo.sitemap[i].lastModified`
     // and `siteConfig.seo.exploreLastModified`.
+    //
+    // Anchor on the actual static-page set: every URL listed in
+    // `siteConfig.seo.sitemap` plus the explicit `/explore` entry.
+    // A regex-based filter is too lenient — the previous version of
+    // this test matched only homepage + /explore, which let regressions
+    // on /about, /faq, /privacy-policy, /terms slip through.
     const before = Date.now();
     const result = await renderAllShards();
     const after = Date.now();
-    const staticAndExplore = result.filter(
-      (e) => !e.url.match(/\/(company|[^/]+)\/[^/]+$/)
-        || e.url.endsWith("/explore"),
+    const sitemapPaths = siteConfig.seo.sitemap.map((s) =>
+      s.path === "/" ? "" : s.path,
     );
-    expect(staticAndExplore.length).toBeGreaterThan(0);
+    const expectedSuffixes = [...sitemapPaths, "/explore"];
+    const staticAndExplore = result.filter((e) =>
+      expectedSuffixes.some((suffix) => {
+        // URL pattern: ${siteConfig.url}/{locale}${suffix}
+        const url = e.url;
+        for (const locale of ["en", "de", "fr", "it"]) {
+          const expected = `${siteConfig.url}/${locale}${suffix}`;
+          if (url === expected) return true;
+        }
+        return false;
+      }),
+    );
+    // 4 locales × (sitemap entries + /explore) — sanity that the filter
+    // matched everything we expect, not just a subset.
+    expect(staticAndExplore.length).toBe(
+      (siteConfig.seo.sitemap.length + 1) * 4,
+    );
     for (const entry of staticAndExplore) {
       const ts = entry.lastModified instanceof Date
         ? entry.lastModified.getTime()

--- a/apps/web/src/lib/sitemap.ts
+++ b/apps/web/src/lib/sitemap.ts
@@ -137,12 +137,21 @@ export const cachedSitemapWatchlists = () =>
     ttl: SITEMAP_TTL_SECONDS,
   });
 
-/** Build hreflang alternates map for a given path (without locale prefix). */
+/**
+ * Build hreflang alternates map for a given path (without locale prefix).
+ *
+ * Includes `x-default` pointing at the English variant — matching the
+ * convention in `buildAlternates` (`@/lib/seo`) so page metadata and
+ * sitemap hreflang stay consistent (#2825). Without `x-default`, Bing
+ * raises an ambiguity warning and Google's "alternate page with
+ * proper canonical tag" classification gets noisier.
+ */
 function langAlternates(path: string): Record<string, string> {
   const languages: Record<string, string> = {};
   for (const locale of locales) {
     languages[locale] = `${siteConfig.url}/${locale}${path}`;
   }
+  languages["x-default"] = `${siteConfig.url}/en${path}`;
   return languages;
 }
 
@@ -152,10 +161,16 @@ export function staticAndExploreEntries(): MetadataRoute.Sitemap {
   for (const item of siteConfig.seo.sitemap) {
     const suffix = item.path === "/" ? "" : item.path;
     const languages = langAlternates(suffix);
+    // `lastModified` reflects the last time the page's bot-visible
+    // content changed. `new Date()` (the previous behavior) makes
+    // every regen claim "modified now" and Bing eventually discounts
+    // the signal (#2824). Real content changes should bump the
+    // per-entry value in `siteConfig.seo.sitemap`.
+    const lastModified = new Date(item.lastModified);
     for (const locale of locales) {
       entries.push({
         url: `${siteConfig.url}/${locale}${suffix}`,
-        lastModified: new Date(),
+        lastModified,
         changeFrequency: item.changeFrequency as "weekly" | "monthly",
         priority: item.priority,
         alternates: { languages },
@@ -164,10 +179,16 @@ export function staticAndExploreEntries(): MetadataRoute.Sitemap {
   }
 
   const exploreLanguages = langAlternates("/explore");
+  // `/explore` hosts Typesense-backed search results that change
+  // continuously, but the bot-visible HTML shell (filters, top-level
+  // copy) only changes on deploy. A stable date pinned to recent
+  // explore-page deploys is a more honest signal than `new Date()`.
+  // Bump when the prerendered shell substantively changes.
+  const exploreLastModified = new Date(siteConfig.seo.exploreLastModified);
   for (const locale of locales) {
     entries.push({
       url: `${siteConfig.url}/${locale}/explore`,
-      lastModified: new Date(),
+      lastModified: exploreLastModified,
       changeFrequency: "daily",
       priority: 0.9,
       alternates: { languages: exploreLanguages },


### PR DESCRIPTION
Closes #2824, #2825.

## Summary

Two small sitemap-hygiene fixes folded into one PR — both touch `apps/web/src/lib/sitemap.ts`, both tiny, easier to review together than as two PRs.

## Changes

### #2824 — `<lastmod>` correctness

`staticAndExploreEntries` emitted `lastModified: new Date()` on every regen, making `<lastmod>` equal "now" for every static/explore URL. Bing trusts lastmod for re-crawl scheduling and would eventually discount the signal as noise.

- `siteConfig.seo.sitemap[i]` gains a `lastModified` ISO-string field per entry.
- `siteConfig.seo.exploreLastModified` for the `/explore` shell.
- `staticAndExploreEntries` reads those values instead of `new Date()`.
- Bump these dates manually when the page's bot-visible content substantively changes.

### #2825 — hreflang `x-default`

`langAlternates` (sitemap) emitted only the four locale keys. `buildAlternates` (page metadata in `seo.tsx`) emitted those plus `x-default` pointing at `/en`. The inconsistency triggered Bing ambiguity warnings and Google's "alternate page with proper canonical tag" classification noise.

- Add `languages["x-default"] = ${siteConfig.url}/en${path}` to `langAlternates`.

## Tests

- New: `static + explore lastModified are stable (not request-time, #2824)` — verifies values pre-date the test run.
- New: `hreflang map includes x-default pointing at /en (#2825)` — verifies the new key on homepage and an `/about`-style entry.
- Updated: existing watchlist locale-coverage test — now expects `x-default` alongside `en/de/fr/it`.

## Test plan

- [x] `pnpm test` — 310 tests pass.
- [x] `pnpm lint` — clean.
- [ ] Post-deploy: `curl https://jseek.co/sitemap/0.xml` shows real `<lastmod>` values (not "now").
- [ ] Post-deploy: same XML shows `<xhtml:link rel="alternate" hreflang="x-default" href=".../en/...">` rows on every entry.

## Note on overlap with #2821

Issue #2821 (drop companies from index) deletes `fetchSitemapCompanies` entirely; the company-side fix this PR's issue body originally mentioned (Typesense `include_fields` adding `updated_at`) is moot once #2821 lands. Scope kept tight here to just the static + explore + watchlist hreflang fixes that survive both worlds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)