### PR TITLE
fix(seo): watchlist sitemap quality gate + ItemList JSON-LD (#2823 part 1)

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
@@ -1,13 +1,21 @@
 import type { Metadata } from "next";
+import { cache } from "react";
 import { isLocale, defaultLocale, loadCatalog } from "@/lib/i18n";
 import {
   getPublicWatchlistByUserAndSlug,
   getWatchlistMatchingCompanyCount,
 } from "@/lib/actions/watchlists";
-import { isTrivialWatchlist } from "@/lib/watchlist-utils";
+import { isQualifyingWatchlist } from "@/lib/watchlist-utils";
 import { siteConfig } from "@/content/config";
-import { buildAlternates } from "@/lib/seo";
+import { buildAlternates, buildWatchlistItemListJsonLd, JsonLd } from "@/lib/seo";
 import { WatchlistContent } from "./watchlist-content";
+
+/**
+ * Per-request memoization so the watchlist detail is fetched once even
+ * though both `generateMetadata` (above) and the page render (below)
+ * need it. Without this, a single ISR regen runs the SQL twice.
+ */
+const cachedDetail = cache(getPublicWatchlistByUserAndSlug);
 
 // ISR window for the rendered metadata + page shell.
 //
@@ -27,10 +35,11 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const locale = isLocale(lang) ? lang : defaultLocale;
   const [detail, { i18n }] = await Promise.all([
     // Public-only fetch: never reads session, so the page stays
-    // statically prerenderable (revalidate=600 above). The session-aware
-    // variant is only used by the client-fired server action that
-    // hydrates the page body. See issue #2244.
-    getPublicWatchlistByUserAndSlug(userSlug, watchlistSlug),
+    // statically prerenderable. The session-aware variant is only used
+    // by the client-fired server action that hydrates the page body.
+    // See issue #2244. `cachedDetail` is the React-cache-wrapped form
+    // so this call shares its result with the page-render call below.
+    cachedDetail(userSlug, watchlistSlug),
     loadCatalog(locale),
   ]);
   if (!detail) return {};
@@ -94,7 +103,17 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   }
 
   const path = `/${userSlug}/${watchlistSlug}`;
-  const trivial = isTrivialWatchlist(detail.filters, detail.companies.length);
+  // Mirror the sitemap quality gate (#2823): if the watchlist wouldn't
+  // be in the sitemap, also `noindex,follow` it on direct discovery
+  // (someone shares the link, Google crawls it). Predicate lives in
+  // `watchlist-utils.ts::isQualifyingWatchlist` so SQL and JS stay in
+  // lockstep.
+  const indexable = isQualifyingWatchlist({
+    title: detail.title,
+    filters: detail.filters,
+    companyCount: detail.companies.length,
+    createdAt: detail.createdAt,
+  });
   return {
     title,
     description,
@@ -105,12 +124,39 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       url: `${siteConfig.url}/${locale}${path}`,
       type: "website",
     },
-    ...(trivial && { robots: { index: false, follow: true } }),
+    ...(!indexable && { robots: { index: false, follow: true } }),
   };
 }
 
 export default async function WatchlistRoute({ params }: Props) {
   const { lang, userSlug, watchlistSlug } = await params;
+  const locale = isLocale(lang) ? lang : defaultLocale;
 
-  return <WatchlistContent lang={lang} userSlug={userSlug} watchlistSlug={watchlistSlug} />;
+  // Re-fetch via the React-cache-wrapped form so this call shares its
+  // result with `generateMetadata` above (single SQL per ISR regen).
+  // The body is client-rendered via WatchlistContent, but the
+  // structured data must reach non-JS consumers (AI retrievers,
+  // search-engine crawlers that don't execute JS) — emitting it
+  // server-side is the only path.
+  const detail = await cachedDetail(userSlug, watchlistSlug);
+
+  // For `anyCompany` watchlists, `detail.companies` is unrelated to
+  // what the watchlist actually tracks (it holds leftover rows from
+  // source copies — see existing comment in `generateMetadata`).
+  // Emitting `Organization` references for that noise would mislead
+  // schema consumers. Skip JSON-LD entirely for those; the page
+  // metadata description still describes the watchlist correctly.
+  const itemListJsonLd = detail && !detail.filters.anyCompany
+    ? buildWatchlistItemListJsonLd(
+        { title: detail.title, companies: detail.companies },
+        locale,
+      )
+    : null;
+
+  return (
+    <>
+      {itemListJsonLd && <JsonLd data={itemListJsonLd} />}
+      <WatchlistContent lang={lang} userSlug={userSlug} watchlistSlug={watchlistSlug} />
+    </>
+  );
 }

--- a/apps/web/src/lib/__tests__/watchlist-utils.test.ts
+++ b/apps/web/src/lib/__tests__/watchlist-utils.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { isTrivialWatchlist, isQualifyingWatchlist } from "../watchlist-utils";
+import { buildWatchlistItemListJsonLd } from "../seo";
+
+describe("isTrivialWatchlist", () => {
+  it("returns true for empty filters and zero companies", () => {
+    expect(isTrivialWatchlist({}, 0)).toBe(true);
+    expect(isTrivialWatchlist(null, 0)).toBe(true);
+  });
+
+  it("returns false when any company is tracked", () => {
+    expect(isTrivialWatchlist({}, 1)).toBe(false);
+  });
+
+  it("returns false when any meaningful filter is set", () => {
+    expect(isTrivialWatchlist({ keywords: ["x"] }, 0)).toBe(false);
+    expect(isTrivialWatchlist({ locationSlugs: ["zurich"] }, 0)).toBe(false);
+    expect(isTrivialWatchlist({ salaryMin: 100000 }, 0)).toBe(false);
+  });
+});
+
+describe("isQualifyingWatchlist (#2823)", () => {
+  // Pin Date.now() so the 7-day age check is deterministic.
+  const NOW_MS = new Date("2026-05-15T00:00:00Z").getTime();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(NOW_MS));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function within7Days(): string {
+    return new Date(NOW_MS - 3 * 24 * 60 * 60 * 1000).toISOString();
+  }
+  function olderThan7Days(): string {
+    return new Date(NOW_MS - 30 * 24 * 60 * 60 * 1000).toISOString();
+  }
+
+  it("rejects watchlists newer than 7 days", () => {
+    expect(
+      isQualifyingWatchlist({
+        title: "Big Tech Jobs in Switzerland",
+        filters: { occupationSlugs: ["software-engineer"], locationSlugs: ["zurich"] },
+        companyCount: 5,
+        createdAt: within7Days(),
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects the default 'New watchlist' title regardless of substance", () => {
+    expect(
+      isQualifyingWatchlist({
+        title: "New watchlist",
+        filters: { occupationSlugs: ["se"], locationSlugs: ["zurich"] },
+        companyCount: 10,
+        createdAt: olderThan7Days(),
+      }),
+    ).toBe(false);
+    expect(
+      isQualifyingWatchlist({
+        title: "  NEW WATCHLIST  ",
+        filters: {},
+        companyCount: 5,
+        createdAt: olderThan7Days(),
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects sub-4-character titles", () => {
+    expect(
+      isQualifyingWatchlist({
+        title: "kdb",
+        filters: {},
+        companyCount: 5,
+        createdAt: olderThan7Days(),
+      }),
+    ).toBe(false);
+    expect(
+      isQualifyingWatchlist({
+        title: "  ab  ",
+        filters: { keywords: ["go"] },
+        companyCount: 0,
+        createdAt: olderThan7Days(),
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts watchlists with ≥3 companies and a substantive title", () => {
+    expect(
+      isQualifyingWatchlist({
+        title: "Top fintech",
+        filters: {},
+        companyCount: 3,
+        createdAt: olderThan7Days(),
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts watchlists with any keyword filter", () => {
+    expect(
+      isQualifyingWatchlist({
+        title: "Backend hiring",
+        filters: { keywords: ["rust"] },
+        companyCount: 0,
+        createdAt: olderThan7Days(),
+      }),
+    ).toBe(true);
+  });
+
+  it("accepts watchlists with ≥2 taxonomy filters", () => {
+    expect(
+      isQualifyingWatchlist({
+        title: "SWE Zurich",
+        filters: { occupationSlugs: ["software-engineer"], locationSlugs: ["zurich"] },
+        companyCount: 0,
+        createdAt: olderThan7Days(),
+      }),
+    ).toBe(true);
+  });
+
+  it("rejects watchlists with only 1 taxonomy filter and no companies/keywords", () => {
+    expect(
+      isQualifyingWatchlist({
+        title: "Munich",
+        filters: { locationSlugs: ["munich"] },
+        companyCount: 0,
+        createdAt: olderThan7Days(),
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects watchlists with only salary/experience filters", () => {
+    // salary/experience-only can apply to anything — too thin to be a
+    // useful landing page. Mirrors the SQL `HAVING` predicate.
+    expect(
+      isQualifyingWatchlist({
+        title: "High pay roles",
+        filters: { salaryMin: 200000, experienceMin: 5 },
+        companyCount: 0,
+        createdAt: olderThan7Days(),
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects when createdAt is invalid", () => {
+    expect(
+      isQualifyingWatchlist({
+        title: "Top fintech",
+        filters: { keywords: ["x"] },
+        companyCount: 5,
+        createdAt: "not-a-date",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("buildWatchlistItemListJsonLd (#2823)", () => {
+  it("returns null for an empty company list", () => {
+    expect(
+      buildWatchlistItemListJsonLd({ title: "Empty list", companies: [] }, "en"),
+    ).toBeNull();
+  });
+
+  it("emits a valid ItemList with Organization items", () => {
+    const result = buildWatchlistItemListJsonLd(
+      {
+        title: "Big Tech Jobs in Switzerland",
+        companies: [
+          { name: "Google", slug: "google" },
+          { name: "Microsoft", slug: "microsoft" },
+        ],
+      },
+      "de",
+    );
+    expect(result).toEqual({
+      "@context": "https://schema.org",
+      "@type": "ItemList",
+      name: "Big Tech Jobs in Switzerland",
+      numberOfItems: 2,
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          item: {
+            "@type": "Organization",
+            name: "Google",
+            url: "https://jseek.co/de/company/google",
+          },
+        },
+        {
+          "@type": "ListItem",
+          position: 2,
+          item: {
+            "@type": "Organization",
+            name: "Microsoft",
+            url: "https://jseek.co/de/company/microsoft",
+          },
+        },
+      ],
+    });
+  });
+});

--- a/apps/web/src/lib/seo.tsx
+++ b/apps/web/src/lib/seo.tsx
@@ -116,6 +116,43 @@ export function buildBreadcrumbJsonLd(
   };
 }
 
+export type WatchlistItemListInput = {
+  title: string;
+  companies: { name: string; slug: string }[];
+};
+
+/**
+ * Build schema.org `ItemList` payload for a public watchlist (#2823).
+ * Each list item is an `Organization` reference pointing at the
+ * tracked company's profile URL. Even though `/{locale}/company/{slug}`
+ * is `noindex,follow` (#2821), schema.org URLs are entity references —
+ * AI retrievers and Knowledge-Graph crawlers consume them regardless.
+ *
+ * Returns `null` when the watchlist tracks no companies — emitting an
+ * empty `ItemList` would be invalid schema and confuse validators.
+ */
+export function buildWatchlistItemListJsonLd(
+  input: WatchlistItemListInput,
+  locale: Locale,
+): Record<string, unknown> | null {
+  if (input.companies.length === 0) return null;
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: input.title,
+    numberOfItems: input.companies.length,
+    itemListElement: input.companies.map((c, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      item: {
+        "@type": "Organization",
+        name: c.name,
+        url: `${siteConfig.url}/${locale}/company/${c.slug}`,
+      },
+    })),
+  };
+}
+
 /**
  * Render JSON-LD structured data as a sanitized <script> tag.
  *

--- a/apps/web/src/lib/sitemap.ts
+++ b/apps/web/src/lib/sitemap.ts
@@ -107,6 +107,16 @@ async function fetchSitemapCompanies(): Promise<SitemapCompanyRow[]> {
 }
 
 async function fetchSitemapWatchlists(): Promise<SitemapWatchlistRow[]> {
+  // Quality gate (#2823). Without it, every public watchlist enters the
+  // sitemap regardless of substance — empirical inspection (~half of
+  // public watchlists are templated / default-titled / thin) shows
+  // that as the surface scales the templated ones become a doorway-
+  // page signal. Filter at emit time:
+  //   - title is substantive (≥4 chars, not the default "New watchlist")
+  //   - watchlist is at least 7 days old (lets the user populate it)
+  //   - tracks ≥3 companies OR carries ≥1 keyword OR ≥2 taxonomy filters.
+  //     Salary/experience-only watchlists don't qualify on their own —
+  //     too thin to be a useful landing page.
   return db.execute<SitemapWatchlistRow>(sql`
     SELECT
       COALESCE(u.display_username, u.username) AS user_slug,
@@ -115,8 +125,21 @@ async function fetchSitemapWatchlists(): Promise<SitemapWatchlistRow[]> {
       (u.username = ${CURATED_USERNAME}) AS is_curated
     FROM watchlist w
     JOIN "user" u ON u.id = w.user_id
+    LEFT JOIN watchlist_company wc ON wc.watchlist_id = w.id
     WHERE w.is_public = true
       AND u.username IS NOT NULL
+      AND w.title IS NOT NULL
+      AND LENGTH(TRIM(w.title)) >= 4
+      AND LOWER(TRIM(w.title)) <> 'new watchlist'
+      AND w.created_at < NOW() - INTERVAL '7 days'
+    GROUP BY w.id, u.username, u.display_username
+    HAVING
+      COUNT(wc.company_id) >= 3
+      OR COALESCE(jsonb_array_length(w.filters->'keywords'), 0) > 0
+      OR COALESCE(jsonb_array_length(w.filters->'locationSlugs'), 0)
+         + COALESCE(jsonb_array_length(w.filters->'occupationSlugs'), 0)
+         + COALESCE(jsonb_array_length(w.filters->'senioritySlugs'), 0)
+         + COALESCE(jsonb_array_length(w.filters->'technologySlugs'), 0) >= 2
     ORDER BY is_curated DESC, w.updated_at DESC
   `) as unknown as Promise<SitemapWatchlistRow[]>;
 }

--- a/apps/web/src/lib/watchlist-utils.ts
+++ b/apps/web/src/lib/watchlist-utils.ts
@@ -23,3 +23,50 @@ export function isTrivialWatchlist(
     f.experienceMax != null
   );
 }
+
+const WATCHLIST_INDEXABLE_MIN_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const WATCHLIST_INDEXABLE_MIN_TITLE_LENGTH = 4;
+const WATCHLIST_INDEXABLE_DEFAULT_TITLE = "new watchlist";
+
+/**
+ * Stricter quality check than {@link isTrivialWatchlist}. Mirrors the SQL
+ * predicate in `apps/web/src/lib/sitemap.ts::fetchSitemapWatchlists`
+ * (#2823) so the page's `<meta robots>` and the sitemap inclusion stay
+ * aligned: a watchlist that wouldn't survive the sitemap quality gate
+ * also gets `noindex,follow` if discovered via direct link.
+ *
+ * Qualifies when ALL of:
+ *   - title is substantive (≥4 chars after trim, not the default
+ *     "New watchlist") so users who never edited the auto-created
+ *     watchlist don't enter the index.
+ *   - watchlist is at least 7 days old (lets the user populate it
+ *     before the page hits the index).
+ *   - tracks ≥3 companies, OR carries ≥1 keyword, OR carries ≥2
+ *     taxonomy filters across location/occupation/seniority/technology.
+ */
+export function isQualifyingWatchlist(args: {
+  title: string;
+  filters: WatchlistFilters | null | undefined;
+  companyCount: number;
+  createdAt: string | Date;
+}): boolean {
+  const trimmedTitle = (args.title ?? "").trim();
+  if (trimmedTitle.length < WATCHLIST_INDEXABLE_MIN_TITLE_LENGTH) return false;
+  if (trimmedTitle.toLowerCase() === WATCHLIST_INDEXABLE_DEFAULT_TITLE) return false;
+
+  const createdAtMs = args.createdAt instanceof Date
+    ? args.createdAt.getTime()
+    : new Date(args.createdAt).getTime();
+  if (Number.isNaN(createdAtMs)) return false;
+  if (Date.now() - createdAtMs < WATCHLIST_INDEXABLE_MIN_AGE_MS) return false;
+
+  if (args.companyCount >= 3) return true;
+  const f = args.filters ?? {};
+  if (f.keywords?.length) return true;
+  const taxonomyCount =
+    (f.locationSlugs?.length ?? 0) +
+    (f.occupationSlugs?.length ?? 0) +
+    (f.senioritySlugs?.length ?? 0) +
+    (f.technologySlugs?.length ?? 0);
+  return taxonomyCount >= 2;
+}


### PR DESCRIPTION
Partially closes #2823 (sub-changes 1 + 3). Sub-changes 2 (title-cluster dedup) and 4 (LlmContentMirror) deferred to follow-ups.

## Summary

Today, every `is_public AND username NOT NULL` watchlist enters the sitemap. Empirical inspection (N=41 public watchlists) shows ~half are templated, default-titled, or near-duplicates ("SWE Zurich" ×5, "MAANG" ×3, "New watchlist" ×3). At current N this isn't a doorway-page risk yet, but as the watchlist surface scales (the goal — it's the only growing indexable content jseek has), the templated ones become a Site Reputation Abuse signal.

## Changes

### Sitemap quality gate (`apps/web/src/lib/sitemap.ts::fetchSitemapWatchlists`)

Reject at emit time:
- Empty / short (<4 char) / default-titled ("New watchlist") titles.
- Watchlists newer than 7 days (let users populate before indexing).
- Require at least one substantive substance signal: ≥3 tracked companies, OR ≥1 keyword filter, OR ≥2 taxonomy filters across location/occupation/seniority/technology. Salary/experience-only watchlists don't qualify on their own — too thin.

### Page-level `noindex` aligned with sitemap

`generateMetadata` swaps `isTrivialWatchlist` (companies==0 AND no filters — minimal) for `isQualifyingWatchlist` — the same predicate the sitemap uses. A watchlist that wouldn't be in the sitemap now also emits `<meta name="robots" content="noindex,follow">` on the page itself, so direct-link shares don't get indexed if they don't meet the quality bar.

**Concrete user-visible impact**: single-company watchlists, default-titled watchlists, and watchlists <7 days old now get `noindex` on direct discovery. Per spec.

### ItemList JSON-LD

Server-rendered `<JsonLd>` enumerates tracked companies as `Organization` references on the watchlist page. AI retrievers (Perplexity, GPTBot, ClaudeBot) and Knowledge-Graph crawlers consume this for entity grounding even though the page body is client-rendered.

- Skipped for `anyCompany` watchlists where `detail.companies` is leftover noise from source copies (existing comment: "unrelated to what the watchlist actually tracks").
- Item URLs point at `/{locale}/company/{slug}` — those pages are `noindex,follow` per #2821, but schema URLs are entity references, not discovery hints.

### Per-request fetch dedup

`generateMetadata` and the page render both need the watchlist detail. Wrapped in `react.cache()` so ISR regen runs the SQL once instead of twice.

## Files

- `apps/web/src/lib/sitemap.ts` — extended SQL with quality gate.
- `apps/web/src/lib/watchlist-utils.ts` — new `isQualifyingWatchlist` (mirrors the SQL).
- `apps/web/src/lib/seo.tsx` — new `buildWatchlistItemListJsonLd` helper.
- `apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx` — uses `cache()` wrapper, swaps trivial→qualifying, emits ItemList JSON-LD.
- `apps/web/src/lib/__tests__/watchlist-utils.test.ts` — new file, 14 tests.

## Critic-driven adjustments

A correctness critic flagged 3 items folded in before opening this PR:
1. Skip `ItemList` JSON-LD for `anyCompany` watchlists (the company list is leftover noise — emitting it would mislead schema consumers).
2. `react.cache()` wrap around the detail fetch so it doesn't run twice per ISR regen.
3. Snapshot test for `buildWatchlistItemListJsonLd` (null-on-empty + populated shape).

## Test plan

- [x] `pnpm test` — 322 tests pass (14 new).
- [x] `pnpm lint` — clean.
- [ ] Post-deploy: `curl https://jseek.co/sitemap/0.xml` watchlist URL count drops from 41×4=164 to ≈ N_qualifying × 4. (Run a sample query against Supabase to estimate the new count: filter by the SQL predicate.)
- [ ] Post-deploy: `curl /en/colophongroup/big-tech-jobs-in-switzerland` returns valid `ItemList` JSON-LD that passes the schema.org validator.
- [ ] Post-deploy: a default-titled or single-company watchlist returns `<meta name="robots" content="noindex,follow">` in the head.

## Out of scope (#2823 follow-ups)

- **Title-cluster dedup** — when ≥3 watchlists share a normalized lowercased title, the highest-quality one keeps canonical and the rest emit `<link rel="canonical">` to the winner + `noindex,follow`. At N=41 the clusters are below the doorway-page threshold; the quality gate handles the immediate concern. Will revisit at scale or once user-watchlist creation grows.
- **LlmContentMirror on the watchlist page** — requires extracting watchlist title/description/companies/filters into a server-rendered noscript mirror. The current `WatchlistContent` is fully client-rendered with non-trivial data dependencies (Typesense facet count, viewer-language scoping). Worth a focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)