### PR TITLE
fix(web): sitemap.xml route handles renderSitemapShard null return (Vercel build hotfix)

### DIFF
--- a/apps/web/app/sitemap.xml/route.ts
+++ b/apps/web/app/sitemap.xml/route.ts
@@ -1,3 +1,4 @@
+import type { MetadataRoute } from "next";
 import {
   planSitemapShards,
   renderSitemapShard,
@@ -32,16 +33,22 @@ import {
  * restore robots.ts to declare every shard.
  */
 export async function GET(): Promise<Response> {
-  let entries: Awaited<ReturnType<typeof renderSitemapShard>> = [];
+  let entries: MetadataRoute.Sitemap = [];
   try {
     const shards = await planSitemapShards();
     // Render shards in parallel; the data layer's Redis cache + per-key
     // single-flight (see lib/cache.ts) ensures the underlying Typesense /
     // Postgres queries fan in to one upstream call regardless of N.
+    // `renderSitemapShard` returns null for ids outside the current
+    // plan (a defensive 404 path); planSitemapShards never hands one
+    // here today, but the filter keeps the types honest if the planner
+    // ever loosens.
     const renderedShards = await Promise.all(
       shards.map(({ id }) => renderSitemapShard(id)),
     );
-    entries = renderedShards.flat();
+    entries = renderedShards
+      .filter((shard): shard is MetadataRoute.Sitemap => shard !== null)
+      .flat();
   } catch {
     // Defense-in-depth: serializeUrlset emits a syntactically valid
     // empty <urlset/> rather than letting the route 500 — crawlers


### PR DESCRIPTION
## Summary

- Vercel production build fails immediately after #2846 merge with TypeScript error in \`apps/web/app/sitemap.xml/route.ts:44\`.
- \`renderSitemapShard\` returns \`Promise<Sitemap | null>\`; flattening an array of those produces \`(SitemapEntry | null)[]\` which can't satisfy \`MetadataRoute.Sitemap\`.
- Filter out null shards before flattening. Planner returns a single shard today so the filter is a no-op for the current plan, but keeps the types honest.

## Vercel error log (excerpt)

\`\`\`
./app/sitemap.xml/route.ts:44:5
Type error: Type '({ url: string; ... } | null)[]' is not assignable to type '{ url: string; ... }[]'.
  Type 'null' is not assignable to type '{ url: string; ... }'.

> 44 |     entries = renderedShards.flat();
     |     ^
\`\`\`

## Test plan

- [x] \`pnpm exec tsc --noEmit\` in \`apps/web/\` no longer flags route.ts:44 (the only remaining errors are pre-existing strict-mode issues in \`company.test.ts\`, tracked in #2847).
- [ ] Vercel production build passes once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)