### PR TITLE
fix(seo): buildAlternates accepts availableLocales for partial routes (closes #2849)

### DIFF
--- a/apps/web/app/[lang]/(public)/blog/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(public)/blog/[slug]/page.tsx
@@ -8,6 +8,7 @@ import { siteConfig } from "@/content/config";
 import { buildAlternates, JsonLd } from "@/lib/seo";
 import {
   getBlogPost,
+  getBlogPostLocales,
   listBlogSlugs,
   readingTimeMinutes,
   type BlogPost,
@@ -44,10 +45,17 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const post = await getBlogPost(slug, locale);
   if (!post) return {};
 
+  // Per-post hreflang: only advertise locales that actually have a
+  // translated MDX sibling on disk. Mirrors the sitemap's
+  // `blogPostEntries` behavior (#2828) — a future EN-only post stays
+  // off `<link rel="alternate" hreflang="de" ...>` instead of pointing
+  // crawlers at duplicate-content fallbacks (#2849).
+  const availableLocales = await getBlogPostLocales(slug);
+
   return {
     title: post.title,
     description: post.description,
-    alternates: buildAlternates(`/blog/${slug}`, locale),
+    alternates: buildAlternates(`/blog/${slug}`, locale, availableLocales),
     openGraph: {
       title: post.title,
       description: post.description,

--- a/apps/web/src/content/blog/README.md
+++ b/apps/web/src/content/blog/README.md
@@ -137,9 +137,11 @@ To translate a post:
 
 The blog page chrome (`<h1>`, "No posts yet" empty state, "min read", "← Blog" nav, etc.) IS translated for de/fr/it via Lingui — see `locales/{de,fr,it}.po` for the `blog.*` and `common.nav.blog` keys. A pre-commit hook (`scripts/check-i18n-coverage.sh`) blocks commits with untranslated chrome strings.
 
-**Known limitations** (tracked as follow-ups):
-
-- `buildAlternates` in `seo.tsx` always emits all 4 locale alternates in the page `<head>`, regardless of which locales have a translated MDX. The sitemap is correct; the page metadata is over-broad. Symptoms only when a future post ships EN-only — fix tracked.
+**Known limitations** (tracked as follow-ups): none currently. The
+former `buildAlternates`-over-broad hreflang gap is now closed (PR
+#2865) — page metadata's hreflang restricts to locales with a
+translated MDX, matching the sitemap's `blogPostEntries` per-post
+behavior.
 
 ## Local dev workflow
 

--- a/apps/web/src/lib/__tests__/seo.test.ts
+++ b/apps/web/src/lib/__tests__/seo.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { buildAlternates } from "../seo";
+import { siteConfig } from "@/content/config";
+
+describe("buildAlternates", () => {
+  it("emits all 4 locale alternates by default (fully-translated routes)", () => {
+    const out = buildAlternates("/about", "en");
+    expect(out.canonical).toBe(`${siteConfig.url}/en/about`);
+    expect(out.languages).toEqual({
+      en: `${siteConfig.url}/en/about`,
+      de: `${siteConfig.url}/de/about`,
+      fr: `${siteConfig.url}/fr/about`,
+      it: `${siteConfig.url}/it/about`,
+      "x-default": `${siteConfig.url}/en/about`,
+    });
+  });
+
+  it("anchors canonical at the requested locale", () => {
+    const out = buildAlternates("/about", "de");
+    expect(out.canonical).toBe(`${siteConfig.url}/de/about`);
+    // x-default still anchors at /en (#2825).
+    expect(out.languages["x-default"]).toBe(`${siteConfig.url}/en/about`);
+  });
+
+  it("restricts alternates when availableLocales is provided (#2849)", () => {
+    // Partial translation: blog post with only en + de translated.
+    const out = buildAlternates("/blog/post-x", "en", ["en", "de"]);
+    expect(out.languages).toEqual({
+      en: `${siteConfig.url}/en/blog/post-x`,
+      de: `${siteConfig.url}/de/blog/post-x`,
+      "x-default": `${siteConfig.url}/en/blog/post-x`,
+    });
+    expect(out.languages.fr).toBeUndefined();
+    expect(out.languages.it).toBeUndefined();
+  });
+
+  it("emits only one alternate when only one locale is available", () => {
+    const out = buildAlternates("/blog/en-only", "en", ["en"]);
+    expect(out.languages).toEqual({
+      en: `${siteConfig.url}/en/blog/en-only`,
+      "x-default": `${siteConfig.url}/en/blog/en-only`,
+    });
+  });
+
+  it("falls back to first available locale for x-default when en is missing", () => {
+    // Hypothetical de-only route — en isn't in the available set.
+    const out = buildAlternates("/blog/de-only", "de", ["de"]);
+    expect(out.languages).toEqual({
+      de: `${siteConfig.url}/de/blog/de-only`,
+      "x-default": `${siteConfig.url}/de/blog/de-only`,
+    });
+  });
+
+  it("treats explicit empty availableLocales as 'no alternates'", () => {
+    // Defensive: caller should never pass [], but if they do we emit
+    // just the canonical and no language alternates.
+    const out = buildAlternates("/about", "en", []);
+    expect(out.canonical).toBe(`${siteConfig.url}/en/about`);
+    expect(out.languages).toEqual({});
+  });
+});

--- a/apps/web/src/lib/seo.tsx
+++ b/apps/web/src/lib/seo.tsx
@@ -3,14 +3,35 @@ import { locales, type Locale } from "@/lib/i18n";
 
 /**
  * Build hreflang alternates for Next.js Metadata API.
- * Returns canonical URL (without query params) and language alternates including x-default.
+ *
+ * Returns canonical URL (without query params) and language alternates
+ * including x-default. By default emits all 4 site locales (correct for
+ * fully-translated app surfaces like `/about`, `/explore`).
+ *
+ * For partially-translated routes — blog posts, anything with optional
+ * locale-specific MDX siblings — pass `availableLocales` so the page
+ * `<head>` only advertises locales that actually have rendered content.
+ * Otherwise crawlers follow the alternate to a 404 (or worse, the
+ * canonical body served at a foreign-locale URL — see #2849, #2828).
+ *
+ * x-default convention: anchors at `/en` when EN is in the locale set
+ * (matches the sitemap hreflang in `@/lib/sitemap`, #2825), otherwise
+ * falls back to the first listed locale.
  */
-export function buildAlternates(path: string, currentLocale: Locale) {
+export function buildAlternates(
+  path: string,
+  currentLocale: Locale,
+  availableLocales?: readonly Locale[],
+) {
+  const targetLocales = availableLocales ?? locales;
   const languages: Record<string, string> = {};
-  for (const locale of locales) {
+  for (const locale of targetLocales) {
     languages[locale] = `${siteConfig.url}/${locale}${path}`;
   }
-  languages["x-default"] = `${siteConfig.url}/en${path}`;
+  const xdefault = targetLocales.includes("en") ? "en" : targetLocales[0];
+  if (xdefault) {
+    languages["x-default"] = `${siteConfig.url}/${xdefault}${path}`;
+  }
   return {
     canonical: `${siteConfig.url}/${currentLocale}${path}`,
     languages,


### PR DESCRIPTION
## Summary

`buildAlternates` (used by every page's `generateMetadata`) always emitted all 4 site locales in the hreflang map, regardless of whether the route actually had rendered content per locale. The sitemap already restricts blog post hreflang via `getBlogPostLocales` (#2828); this PR closes the equivalent gap in the page `<head>`.

A hypothetical EN-only blog post would have advertised `<link rel="alternate" hreflang="de" ...>` at a URL that returns 404 (or worse, the EN body served at a foreign-locale path — Google flags as alternate-page-with-canonical cluster).

Both shipped posts are fully translated today, so this is correctness pre-emption rather than a live regression.

## Changes

- `@/lib/seo::buildAlternates` gains an optional `availableLocales` third argument. Default behavior unchanged (emits all 4 locales). When provided, restricts alternates to that subset; `x-default` anchors at `/en` if EN is in the set (matches sitemap convention #2825), otherwise falls back to the first listed locale.
- `/[lang]/(public)/blog/[slug]/page.tsx` `generateMetadata` calls `getBlogPostLocales(slug)` and threads the result through `buildAlternates` so per-post hreflang stays consistent with the sitemap.
- New `apps/web/src/lib/__tests__/seo.test.ts` covers default-all-4, per-route restriction, single-locale, EN-missing fallback, and the defensive empty-array branch.

## Test plan

- [x] `pnpm --filter @jobseek/web test src/lib/__tests__/seo.test.ts` → 6 pass.
- [x] `pnpm --filter @jobseek/web exec tsc` → clean (only the pre-existing `company.test.ts` errors tracked in #2815, fixed in PR #2862).
- [ ] Vercel preview build succeeds.
- [ ] Manual: view-source on `/en/blog/welcome-to-the-job-seek-blog` preview, confirm 4 hreflang `<link>` tags + x-default — same shape as before since the post is fully translated.

Closes #2849.