### PR TITLE
test(web): shared Lingui macro mock helper (closes #2814)

### DIFF
--- a/apps/web/app/[lang]/(app)/companies/request/__tests__/company-request-page-form.test.tsx
+++ b/apps/web/app/[lang]/(app)/companies/request/__tests__/company-request-page-form.test.tsx
@@ -34,21 +34,9 @@ vi.mock("@/components/search/request-company-success", () => ({
   ),
 }));
 
-// Lingui macros — stub so the component can be rendered outside a real i18n
-// provider. Mirrors the approach used by agent-prompt-card tests but for the
-// macro layer.
-vi.mock("@lingui/react", () => ({
-  useLingui: () => ({
-    _: (msg: { message?: string; id?: string } | string) =>
-      typeof msg === "string" ? msg : (msg.message ?? msg.id ?? ""),
-  }),
-}));
-vi.mock("@lingui/react/macro", () => ({
-  Trans: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-}));
-vi.mock("@lingui/core/macro", () => ({
-  msg: (m: { message?: string; id?: string }) => m,
-}));
+// Lingui macros — stub so the component can be rendered outside a real
+// i18n provider. Shared across every Lingui-aware test (#2814).
+import "@/test-utils/lingui-mock";
 
 import { CompanyRequestPageForm } from "../company-request-page-form";
 

--- a/apps/web/src/components/search/__tests__/search-bar-request.test.tsx
+++ b/apps/web/src/components/search/__tests__/search-bar-request.test.tsx
@@ -9,19 +9,9 @@ import userEvent from "@testing-library/user-event";
 // in isolation so the suite exercises only the dropdown wiring around
 // the synthetic "Request <query>" entry (issue #2807).
 
-// Lingui's `useLingui` macro normally needs the babel transform (see
-// apps/web/babel.config.json). Tests run under Vitest + esbuild without
-// that transform, so substitute a runtime-friendly hook that returns a
-// `t` which simply renders the descriptor's `message`.
-vi.mock("@lingui/react/macro", () => ({
-  useLingui: () => ({
-    t: (input: unknown) => {
-      if (typeof input === "string") return input;
-      const desc = input as { message?: string; id?: string };
-      return desc.message ?? desc.id ?? "";
-    },
-  }),
-}));
+// Lingui mocks live in a shared helper so every Lingui-aware
+// component test imports the same shape (#2814).
+import "@/test-utils/lingui-mock";
 
 const pushMock = vi.fn();
 const currentSearchParams = new URLSearchParams();

--- a/apps/web/src/test-utils/lingui-mock.ts
+++ b/apps/web/src/test-utils/lingui-mock.ts
@@ -1,0 +1,41 @@
+import type { ReactNode } from "react";
+import { vi } from "vitest";
+
+/**
+ * Mocks for the full Lingui surface that component tests typically
+ * need. Side-effect import: register at the top of a test file (above
+ * imports of components that use Lingui hooks):
+ *
+ *     import "@/test-utils/lingui-mock";
+ *
+ * Why side-effect: `vi.mock` is hoisted to the top of its containing
+ * module. Applying mocks via a helper module (rather than inline in
+ * each test) lets the next contributor add a Lingui-aware test by
+ * adding one import, instead of copying the boilerplate from prior
+ * tests where it has already drifted slightly between sites.
+ *
+ * Translation behavior: every macro/hook returns the descriptor's
+ * `message` (or its `id` as a fallback). That's enough for every
+ * assertion that just compares against the rendered text — none of
+ * the suites care about pluralization or interpolation today.
+ *
+ * Filed as #2814 follow-up to #2812.
+ */
+
+type MessageLike = { message?: string; id?: string } | string;
+
+const fromMessage = (input: MessageLike): string =>
+  typeof input === "string" ? input : (input.message ?? input.id ?? "");
+
+vi.mock("@lingui/react", () => ({
+  useLingui: () => ({ _: fromMessage }),
+}));
+
+vi.mock("@lingui/react/macro", () => ({
+  useLingui: () => ({ t: fromMessage }),
+  Trans: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock("@lingui/core/macro", () => ({
+  msg: (m: MessageLike) => m,
+}));


### PR DESCRIPTION
## Summary

Move the inline `vi.mock("@lingui/...", ...)` block (currently duplicated, with drift, in two test suites) into a shared `src/test-utils/lingui-mock.ts`. Side-effect import:

```ts
import "@/test-utils/lingui-mock";
```

Provides the four Lingui surfaces component tests typically need:
- `useLingui()._`  (non-macro hook)
- `useLingui().t`  (macro hook)
- `<Trans>`        (macro component, renders children)
- `msg()`          (macro tag)

## Why a side-effect import (option 1 from #2814) over global setup (option 2)

Opt-in. Tests that don't render Lingui-aware components stay free of a side-effect Lingui mock; we don't risk a server-only test silently picking up a stub. Adds one line per test that needs it, vs. setupFiles which would apply globally.

## Test plan

- [x] `pnpm --filter @jobseek/web test` → 441 pass (no regression).
- [x] `pnpm --filter @jobseek/web exec tsc` → clean except the pre-existing `company.test.ts` errors tracked in #2815.

Closes #2814.