### PR TITLE
perf(web): stop optimizing tiny company icons

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/company-head.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-head.tsx
@@ -1,8 +1,7 @@
 import { Suspense } from "react";
-import Image from "next/image";
-import { Building2 } from "lucide-react";
 import { getI18n } from "@lingui/react/server";
 import { BackLink } from "@/components/BackLink";
+import { CompanyIcon } from "@/components/CompanyIcon";
 import { StarButton } from "@/components/search/star-button";
 import {
   JsonLd,
@@ -72,23 +71,7 @@ export function CompanyHead({ company, locale }: Props) {
       </Suspense>
 
       <div className="flex items-center gap-3">
-        {company.icon ? (
-          <Image
-            src={company.icon}
-            alt=""
-            width={32}
-            height={32}
-            sizes="32px"
-            className="size-8 shrink-0 rounded"
-          />
-        ) : (
-          <div
-            aria-hidden="true"
-            className="flex size-8 shrink-0 items-center justify-center rounded bg-border-soft text-muted"
-          >
-            <Building2 size={18} />
-          </div>
-        )}
+        <CompanyIcon icon={company.icon} alt="" size={32} />
         <h1 className="m-0 text-lg font-semibold">
           {company.website ? (
             <a

--- a/apps/web/src/components/CompanyIcon.tsx
+++ b/apps/web/src/components/CompanyIcon.tsx
@@ -1,0 +1,51 @@
+import Image from "next/image";
+import { Building2 } from "lucide-react";
+
+const SIZE_MAP = {
+  16: { box: "size-4", fallback: 14 },
+  20: { box: "size-5", fallback: 14 },
+  24: { box: "size-6", fallback: 14 },
+  28: { box: "size-7", fallback: 16 },
+  32: { box: "size-8", fallback: 18 },
+  36: { box: "size-9", fallback: 20 },
+} as const;
+
+export type CompanyIconSize = keyof typeof SIZE_MAP;
+
+type CompanyIconProps = {
+  icon: string | null | undefined;
+  alt: string;
+  size: CompanyIconSize;
+  className?: string;
+};
+
+/**
+ * Bypasses next/image optimization (`unoptimized`) — R2 icons are already
+ * small WebP and Vercel docs say sub-10KB images shouldn't be transformed.
+ * Width/height attrs preserved so CLS stays bounded; lazy/decoding=async
+ * remain next/image defaults.
+ */
+export function CompanyIcon({ icon, alt, size, className = "" }: CompanyIconProps) {
+  const { box, fallback } = SIZE_MAP[size];
+  const base = `${box} shrink-0 rounded`;
+  if (icon) {
+    return (
+      <Image
+        src={icon}
+        alt={alt}
+        width={size}
+        height={size}
+        unoptimized
+        className={`${base} ${className}`.trim()}
+      />
+    );
+  }
+  return (
+    <div
+      aria-hidden="true"
+      className={`flex items-center justify-center bg-border-soft text-muted ${base} ${className}`.trim()}
+    >
+      <Building2 size={fallback} />
+    </div>
+  );
+}

--- a/apps/web/src/components/__tests__/CompanyIcon.test.tsx
+++ b/apps/web/src/components/__tests__/CompanyIcon.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@testing-library/react";
+import { CompanyIcon } from "../CompanyIcon";
+
+describe("CompanyIcon", () => {
+  it("renders an unoptimized image when icon URL is provided", () => {
+    const { container } = render(
+      <CompanyIcon icon="https://example.com/icon.webp" alt="Acme" size={32} />,
+    );
+    const img = container.querySelector("img")!;
+    expect(img).not.toBeNull();
+    expect(img.getAttribute("alt")).toBe("Acme");
+    expect(img.getAttribute("width")).toBe("32");
+    expect(img.getAttribute("height")).toBe("32");
+    // unoptimized means src is the source URL, not /_next/image?url=...
+    expect(img.getAttribute("src")).toBe("https://example.com/icon.webp");
+  });
+
+  it("renders Building2 fallback when icon is null", () => {
+    const { container } = render(<CompanyIcon icon={null} alt="" size={24} />);
+    expect(container.querySelector("img")).toBeNull();
+    expect(container.querySelector("svg")).not.toBeNull();
+    expect(container.firstElementChild?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("forwards className additions", () => {
+    const { container } = render(
+      <CompanyIcon icon="https://example.com/i.webp" alt="" size={32} className="mt-0.5" />,
+    );
+    const img = container.querySelector("img")!;
+    expect(img.className).toContain("size-8");
+    expect(img.className).toContain("mt-0.5");
+  });
+
+  it("emits explicit decorative alt for icon-present case", () => {
+    const { container } = render(
+      <CompanyIcon icon="https://example.com/i.webp" alt="" size={16} />,
+    );
+    const img = container.querySelector("img")!;
+    expect(img.getAttribute("alt")).toBe("");
+  });
+
+  it("emits no srcset (the point of unoptimized — single source request)", () => {
+    const { container } = render(
+      <CompanyIcon icon="https://example.com/i.webp" alt="Acme" size={32} />,
+    );
+    const img = container.querySelector("img")!;
+    expect(img.getAttribute("srcset")).toBeNull();
+  });
+});

--- a/apps/web/src/components/blog/MdxMentions.tsx
+++ b/apps/web/src/components/blog/MdxMentions.tsx
@@ -34,8 +34,8 @@
 
 import { cache } from "react";
 import Link from "next/link";
-import Image from "next/image";
-import { Building2, Eye, Briefcase } from "lucide-react";
+import { Eye, Briefcase } from "lucide-react";
+import { CompanyIcon } from "@/components/CompanyIcon";
 import { loadCatalog, isLocale, defaultLocale, type Locale } from "@/lib/i18n";
 import { getCompanyBySlug } from "@/lib/actions/company";
 import {
@@ -181,23 +181,8 @@ function companyIcon(
   icon: string | null | undefined,
   size: 16 | 24,
 ): React.ReactNode {
-  // `Building2` is the codebase's canonical company-fallback icon
-  // (see apps/web/docs/icons.md). Only swap to <Image> when the
-  // company has a real icon URL.
-  if (icon && icon.startsWith("http")) {
-    return (
-      <Image
-        src={icon}
-        alt=""
-        width={size}
-        height={size}
-        sizes={`${size}px`}
-        className="rounded"
-        style={{ width: size, height: size }}
-      />
-    );
-  }
-  return <Building2 size={size === 16 ? 14 : 20} aria-hidden="true" />;
+  const validUrl = icon && icon.startsWith("http") ? icon : null;
+  return <CompanyIcon icon={validUrl} alt="" size={size} />;
 }
 
 // ── Inline mentions ────────────────────────────────────────────────

--- a/apps/web/src/components/company/similar-company-card.tsx
+++ b/apps/web/src/components/company/similar-company-card.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import Link from "next/link";
-import Image from "next/image";
-import { Building2 } from "lucide-react";
 import { Plural } from "@lingui/react/macro";
+import { CompanyIcon } from "@/components/CompanyIcon";
 import type { SimilarCompany } from "@/lib/actions/company";
 import type { Locale } from "@/lib/i18n";
 
@@ -32,23 +31,7 @@ export function SimilarCompanyCard({ company, locale, preserveParams }: Props) {
         prefetch={false}
         className="flex h-full w-36 flex-col items-start gap-2 overflow-hidden rounded-md border border-border-soft bg-surface p-3 text-left transition-colors hover:border-primary/30 hover:bg-border-soft focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
       >
-        {company.icon ? (
-          <Image
-            src={company.icon}
-            alt=""
-            width={28}
-            height={28}
-            sizes="28px"
-            className="size-7 shrink-0 rounded"
-          />
-        ) : (
-          <div
-            aria-hidden="true"
-            className="flex size-7 shrink-0 items-center justify-center rounded bg-border-soft text-muted"
-          >
-            <Building2 size={16} />
-          </div>
-        )}
+        <CompanyIcon icon={company.icon} alt="" size={28} />
         <span className="line-clamp-2 w-full min-w-0 text-sm font-medium text-foreground [overflow-wrap:anywhere]">
           {company.name}
         </span>

--- a/apps/web/src/components/my-jobs/my-job-detail-panel.tsx
+++ b/apps/web/src/components/my-jobs/my-job-detail-panel.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import Image from "next/image";
 import Link from "next/link";
-import { Building2, X } from "lucide-react";
+import { X } from "lucide-react";
+import { CompanyIcon } from "@/components/CompanyIcon";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useLocalePath } from "@/lib/useLocalePath";
 import { getPostingDetail } from "@/lib/actions/search";
@@ -280,20 +280,7 @@ function PostingContent({ detail }: { detail: PostingDetail }) {
           href={lp(`/company/${company.slug}`)}
           className="flex items-center gap-3 transition-opacity hover:opacity-80"
         >
-          {company.icon ? (
-            <Image
-              src={company.icon}
-              alt={company.name}
-              width={36}
-              height={36}
-              sizes="36px"
-              className="size-9 shrink-0 rounded"
-            />
-          ) : (
-            <div className="flex size-9 shrink-0 items-center justify-center rounded bg-border-soft text-muted">
-              <Building2 size={20} />
-            </div>
-          )}
+          <CompanyIcon icon={company.icon} alt={company.name} size={36} />
           <span className="text-sm font-semibold">{company.name}</span>
         </Link>
         <a

--- a/apps/web/src/components/my-jobs/my-job-row.tsx
+++ b/apps/web/src/components/my-jobs/my-job-row.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import Image from "next/image";
-import { Building2 } from "lucide-react";
+import { CompanyIcon } from "@/components/CompanyIcon";
 import { timeAgoShort } from "@/lib/time";
 import { TrackingDot } from "@/components/TrackingDot";
 import { PendingJobIcon } from "@/components/PendingJobWarning";
@@ -29,20 +28,7 @@ export function MyJobRow({
       }`}
     >
       {/* Company icon */}
-      {entry.company.icon ? (
-        <Image
-          src={entry.company.icon}
-          alt={entry.company.name}
-          width={24}
-          height={24}
-          sizes="24px"
-          className="size-6 shrink-0 rounded"
-        />
-      ) : (
-        <div className="flex size-6 shrink-0 items-center justify-center rounded bg-border-soft text-muted">
-          <Building2 size={14} />
-        </div>
-      )}
+      <CompanyIcon icon={entry.company.icon} alt={entry.company.name} size={24} />
 
       {/* Company name */}
       <span className="shrink-0 text-xs text-muted">{entry.company.name}</span>

--- a/apps/web/src/components/search/company-card.tsx
+++ b/apps/web/src/components/search/company-card.tsx
@@ -1,10 +1,9 @@
 "use client";
 
 import { useState, useRef, useMemo } from "react";
-import Image from "next/image";
 import Link from "next/link";
-import { Building2 } from "lucide-react";
 import { Trans } from "@lingui/react/macro";
+import { CompanyIcon } from "@/components/CompanyIcon";
 import { useParams } from "next/navigation";
 import { timeAgoShort } from "@/lib/time";
 import { loadMorePostings } from "@/lib/actions/search";
@@ -107,20 +106,7 @@ export function CompanyCard({ result, keywords, locationIds, locations, occupati
       {/* Header */}
       <div className="flex items-center gap-3">
         <Link href={companyHref} prefetch={false} className="flex items-center gap-3 transition-opacity hover:opacity-80">
-          {company.icon ? (
-            <Image
-              src={company.icon}
-              alt={company.name}
-              width={32}
-              height={32}
-              sizes="32px"
-              className="size-8 shrink-0 rounded"
-            />
-          ) : (
-            <div className="flex size-8 shrink-0 items-center justify-center rounded bg-border-soft text-muted">
-              <Building2 size={18} />
-            </div>
-          )}
+          <CompanyIcon icon={company.icon} alt={company.name} size={32} />
           <span className="text-sm font-semibold">{company.name}</span>
         </Link>
         <StarButton companyId={company.id} />

--- a/apps/web/src/components/search/job-detail-dialog.tsx
+++ b/apps/web/src/components/search/job-detail-dialog.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import Image from "next/image";
 import Link from "next/link";
-import { BarChart3, Building2, CalendarDays, ChevronDown, ChevronUp, Clock, Code2, DollarSign, MapPin, X } from "lucide-react";
+import { BarChart3, CalendarDays, ChevronDown, ChevronUp, Clock, Code2, DollarSign, MapPin, X } from "lucide-react";
+import { CompanyIcon } from "@/components/CompanyIcon";
 import { Trans, useLingui } from "@lingui/react/macro";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { tooltipClass } from "@/components/ui/tooltip-styles";
@@ -171,20 +171,7 @@ function DetailContent({ detail, descriptionLoaded }: { detail: PostingDetail; d
       {/* Company header */}
       <div className="flex items-center gap-3">
         <Link href={lp(`/company/${company.slug}`)} prefetch={false} className="flex items-center gap-3 transition-opacity hover:opacity-80">
-          {company.icon ? (
-            <Image
-              src={company.icon}
-              alt={company.name}
-              width={36}
-              height={36}
-              sizes="36px"
-              className="size-9 shrink-0 rounded"
-            />
-          ) : (
-            <div className="flex size-9 shrink-0 items-center justify-center rounded bg-border-soft text-muted">
-              <Building2 size={20} />
-            </div>
-          )}
+          <CompanyIcon icon={company.icon} alt={company.name} size={36} />
           <span className="text-sm font-semibold">{company.name}</span>
         </Link>
         <div className="ml-auto flex shrink-0 items-center gap-2">

--- a/apps/web/src/components/search/search-bar.tsx
+++ b/apps/web/src/components/search/search-bar.tsx
@@ -2,8 +2,8 @@
 
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Search, MapPin, Building2, ArrowRight, Briefcase, BarChart3, Code2, Sparkles } from "lucide-react";
-import Image from "next/image";
+import { Search, MapPin, ArrowRight, Briefcase, BarChart3, Code2, Sparkles } from "lucide-react";
+import { CompanyIcon } from "@/components/CompanyIcon";
 import { useLingui } from "@lingui/react/macro";
 import type { LocationSuggestion } from "@/lib/actions/locations";
 import { suggestCompanies } from "@/lib/actions/company";
@@ -769,18 +769,7 @@ export function SearchBar({
                       fi === activeIndex ? "bg-primary/10" : "hover:bg-primary/5"
                     }`}
                   >
-                    {c.icon ? (
-                      <Image
-                        src={c.icon}
-                        alt=""
-                        width={16}
-                        height={16}
-                        sizes="16px"
-                        className="size-4 shrink-0 rounded-sm"
-                      />
-                    ) : (
-                      <Building2 size={14} className="shrink-0 text-muted" />
-                    )}
+                    <CompanyIcon icon={c.icon} alt="" size={16} />
                     <span className="min-w-0 flex-1 font-medium">{c.name}</span>
                     <ArrowRight size={12} className="shrink-0 text-muted" />
                   </div>

--- a/apps/web/src/components/watchlist/company-pill.tsx
+++ b/apps/web/src/components/watchlist/company-pill.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import Image from "next/image";
-import { Building2, X } from "lucide-react";
+import { X } from "lucide-react";
+import { CompanyIcon } from "@/components/CompanyIcon";
 
 export function CompanyPill({
   company,
@@ -12,18 +12,7 @@ export function CompanyPill({
 }) {
   return (
     <span className="inline-flex items-center gap-1.5 rounded-full border border-border-soft px-2.5 py-1 text-sm">
-      {company.icon ? (
-        <Image
-          src={company.icon}
-          alt={company.name}
-          width={16}
-          height={16}
-          sizes="16px"
-          className="size-4 shrink-0 rounded"
-        />
-      ) : (
-        <Building2 size={14} className="shrink-0 text-muted" />
-      )}
+      <CompanyIcon icon={company.icon} alt={company.name} size={16} />
       <span className="max-w-[120px] truncate">{company.name}</span>
       {onRemove && (
         <button

--- a/apps/web/src/components/watchlist/company-search-modal.tsx
+++ b/apps/web/src/components/watchlist/company-search-modal.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useState, useRef, useEffect, useMemo } from "react";
-import Image from "next/image";
 import * as Dialog from "@radix-ui/react-dialog";
-import { X, Search, Building2, Loader2, Check, ChevronDown } from "lucide-react";
+import { X, Search, Loader2, Check, ChevronDown } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
+import { CompanyIcon } from "@/components/CompanyIcon";
 import {
   searchCompaniesForWatchlist,
   suggestIndustries,
@@ -309,20 +309,7 @@ export function CompanySearchModal({
                         isSelected ? "bg-primary/5" : "hover:bg-border-soft"
                       }`}
                     >
-                      {c.icon ? (
-                        <Image
-                          src={c.icon}
-                          alt={c.name}
-                          width={32}
-                          height={32}
-                          sizes="32px"
-                          className="mt-0.5 size-8 shrink-0 rounded"
-                        />
-                      ) : (
-                        <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded bg-border-soft text-muted">
-                          <Building2 size={16} />
-                        </div>
-                      )}
+                      <CompanyIcon icon={c.icon} alt={c.name} size={32} className="mt-0.5" />
 
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-2">

--- a/apps/web/src/components/watchlist/company-selector.tsx
+++ b/apps/web/src/components/watchlist/company-selector.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
-import Image from "next/image";
-import { Search, Building2, Loader2 } from "lucide-react";
+import { Search, Loader2 } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
+import { CompanyIcon } from "@/components/CompanyIcon";
 import { suggestCompanies, type CompanySuggestion } from "@/lib/actions/company";
 import { CompanyPill } from "./company-pill";
 
@@ -107,13 +107,7 @@ export function CompanySelector({
                 onClick={() => handleSelect(s)}
                 className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm transition-colors hover:bg-border-soft cursor-pointer"
               >
-                {s.icon ? (
-                  <Image src={s.icon} alt={s.name} width={20} height={20} sizes="20px" className="size-5 rounded" />
-                ) : (
-                  <div className="flex size-5 items-center justify-center rounded bg-border-soft text-muted">
-                    <Building2 size={12} />
-                  </div>
-                )}
+                <CompanyIcon icon={s.icon} alt={s.name} size={20} />
                 <span>{s.name}</span>
               </button>
             ))}

--- a/apps/web/src/components/watchlist/watchlist-job-list.tsx
+++ b/apps/web/src/components/watchlist/watchlist-job-list.tsx
@@ -2,9 +2,9 @@
 
 import { useState, useEffect, useRef } from "react";
 import { useSearchParams } from "next/navigation";
-import Image from "next/image";
-import { Building2, Bookmark } from "lucide-react";
+import { Bookmark } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
+import { CompanyIcon } from "@/components/CompanyIcon";
 import { timeAgoShort } from "@/lib/time";
 import { type WatchlistPostingEntry } from "@/lib/actions/watchlists";
 import { runGetWatchlistPostings } from "@/lib/search/search-runner";
@@ -181,20 +181,7 @@ export function WatchlistJobList({
         }`}
       >
         <TrackingDot postingId={entry.id} />
-        {entry.company.icon ? (
-          <Image
-            src={entry.company.icon}
-            alt={entry.company.name}
-            width={24}
-            height={24}
-            sizes="24px"
-            className="size-6 shrink-0 rounded"
-          />
-        ) : (
-          <div className="flex size-6 shrink-0 items-center justify-center rounded bg-border-soft text-muted">
-            <Building2 size={14} />
-          </div>
-        )}
+        <CompanyIcon icon={entry.company.icon} alt={entry.company.name} size={24} />
 
         <span className="shrink-0 text-xs text-muted">
           {entry.company.name}


### PR DESCRIPTION
Closes #2867.

## Summary

- Introduce `<CompanyIcon>` wrapper that renders `<Image unoptimized>` for R2-hosted company icons (which are already small WebP, p50 = 2 KB) — bypasses Vercel's image optimizer entirely.
- Route all 12 existing company-icon call sites through the wrapper.
- Consolidate the duplicated `Building2` fallback (was inlined in 12 places).

## Why

Vercel transformation overage. Sampled 30 random R2 icons: p50 = 2 KB, p95 = 12 KB, max = 29.6 KB across dimensions 32×32 to 1512×1512. Per Vercel's [optimization-cost docs](https://vercel.com/docs/image-optimization/managing-image-optimization-costs), images under 10 KB shouldn't go through the optimizer. ~95 % of our icons fit that bucket. With 12 components rendering at 6 distinct widths × ~4400 companies × 2 DPR, the cache-key cardinality alone was driving us past the 5 K Hobby quota.

`<Image unoptimized>` keeps width/height attrs (CLS bounded), keeps `loading="lazy"` + `decoding="async"` defaults, drops the `srcset` (single source request to R2). Browser caches via the `Cache-Control: public, max-age=31536000, immutable` already set by `apps/crawler/src/image_sync.py::upload_icon`.

## Visual deltas to flag

- `company-search-modal.tsx`: Building2 fallback glyph 16→18 px in a 32 px box (now matches the wider convention).
- `company-selector.tsx`: Building2 fallback glyph 12→14 px in a 20 px box (same reason).
- `company-pill.tsx` and `search-bar.tsx`: empty-icon fallback now renders the same soft-grey rounded square the other surfaces use, instead of the bare SVG used previously. Trades a slightly heavier visual for cross-surface consistency.

## Test plan
- [x] `vitest run src/components/__tests__/CompanyIcon.test.tsx` — 5 tests pass (icon-present, fallback, className-merge, decorative alt, no srcset).
- [x] Full `vitest run` — 434/434 tests pass; 1 pre-existing failure (`@jseek/mcp-server/handler` resolution) unrelated to this PR.
- [x] `eslint` clean on changed files.
- [x] `tsc --noEmit` clean on changed files (3 pre-existing errors unrelated).
- [ ] Smoke-test in preview deploy: search results, watchlist company-pill, company detail header, MyJobs row, MdxMentions on /blog.
- [ ] After deploy, verify Vercel image-transformation count drops in the next billing window (#2868, #2869 are follow-ups).

## Out of scope

Tracking issues:
- #2868 — narrow `next.config.ts` `images` allowlists (qualities / imageSizes / deviceSizes / formats).
- #2869 — normalize R2 icon dimensions in `image_sync.process_icon` (~5 % of icons exceed 10 KB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)