### PR TITLE
perf(web): bound Next.js image-optimizer cache-key cardinality

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -19,6 +19,31 @@ const nextConfig: NextConfig = {
       { hostname: "jobseek-assets.colophon-group.org" },
       { hostname: "icons.duckduckgo.com" },
     ],
+    // Bound the cache-key cardinality. A transformation is billed once per
+    // unique (url, w, q, format). Default lists give 8 deviceSizes × 8
+    // imageSizes — anything along the device ladder is reachable, doubling
+    // (or worse) the per-source variant fan-out for no visible win on
+    // sources that are pixel-bound at the source resolution.
+    //
+    // qualities=[75]: lock to the default; no caller passes quality={N}.
+    // formats: explicit single format (Next 15+ default is webp; AVIF
+    //   would double transformation count for negligible byte savings on
+    //   the largest optimizer surfaces — 156-304 KB Features 1200×630
+    //   screenshot PNGs and 550-1024 px PublicDomainArt PNGs.
+    // deviceSizes: 8→4. The largest source emitted through the optimizer
+    //   is the 1200×630 Features screenshot. deviceSize > 1200 only
+    //   upscales (blurry, no extra information). 1920 keeps a small
+    //   buffer for moderate retina without paying for 2048/3840 variants.
+    // imageSizes: 8→6. Each existing company-icon width (16/20/24/28/32/36)
+    //   snaps to a rung still on this list (16, 32, 32, 32, 32, 48 — every
+    //   width has a smallest-≥ match), so the narrower list is safe for
+    //   the current call sites and is also forward-compatible with #2867
+    //   (which moves icons to `unoptimized`, dropping their imageSize use
+    //   entirely).
+    qualities: [75],
+    formats: ["image/webp"],
+    deviceSizes: [640, 1080, 1200, 1920],
+    imageSizes: [16, 32, 48, 64, 96, 128],
   },
   rewrites: async () => {
     const key = process.env.INDEXNOW_KEY;


### PR DESCRIPTION
Closes #2868.

## Summary

Add 4 allowlists to `apps/web/next.config.ts` `images`:
- `qualities: [75]` — single quality variant.
- `formats: ["image/webp"]` — explicit single format.
- `deviceSizes: [640, 1080, 1200, 1920]` — 8 → 4 (drops 750/828/2048/3840).
- `imageSizes: [16, 32, 48, 64, 96, 128]` — 8 → 6 (drops 256/384).

## Why

Per Vercel's image-optimization cache-key spec, each unique `(url, w, q, Accept)` is a billed transformation. The default config leaves the cardinality wide open — the per-source variant fan-out can be 16+ before any traffic hits.

Tightening these allowlists collapses the per-source fan-out without breaking any current call site. Reasoning is inline in the config comment.

## Order of operations

This PR is independent of #2874 (#2867) and safe to merge in either order:
- Pre-#2874: every existing company-icon width (16/20/24/28/32/36) snaps to a rung still on the new `imageSizes` list (16, 32, 32, 32, 32, 48). No call site breaks.
- Post-#2874: company icons go through `unoptimized` and don't consume `imageSizes` at all; the residual list covers any future small-width caller.

## Risk audit

- Features.tsx screenshots are 1200×630 PNGs. `deviceSize > 1200` only upscales (sharp upscales but produces blurry pixels — no extra information from a 1200px source). Capping at 1920 keeps moderate-retina headroom; 2048/3840 are wasted.
- PublicDomainArt sources are 550–1024 px wide. The new list still covers all viewport breakpoints (`(min-width: 1024px) 40vw, 100vw` resolves to ≤1080 in practice).
- No caller passes `quality={N}` — verified via `grep -rn "quality=\|quality:"`.
- AVIF kept off — would double transformation count for ~5–15 KB savings vs WebP on 156–304 KB PNG sources, not worth the cost on per-transformation billing.
- OG image routes use `ImageResponse` from `next/og` and bypass the images config entirely.

## Test plan

- [x] `tsc --noEmit` clean (3 pre-existing errors unrelated).
- [x] `eslint` clean.
- [ ] After deploy: verify image-optimization metrics on Vercel observability dashboard show fewer unique transformations per source URL.
- [ ] Visually smoke-test landing page (Features screenshots + PublicDomainArt) at 1×, 2× DPR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)