### PR TITLE
feat(blog): remote-engineering-jobs-2026 + remark-gfm + chart palette

### DIFF
--- a/apps/web/app/[lang]/(public)/blog/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(public)/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { compileMDX } from "next-mdx-remote/rsc";
+import remarkGfm from "remark-gfm";
 import { getI18n } from "@lingui/react/server";
 import { initI18nForPage, isLocale, defaultLocale } from "@/lib/i18n";
 import { siteConfig } from "@/content/config";
@@ -123,7 +124,10 @@ export default async function BlogPostPage({ params }: Props) {
 
   const { content } = await compileMDX<Record<string, never>>({
     source: post.body,
-    options: { parseFrontmatter: false },
+    options: {
+      parseFrontmatter: false,
+      mdxOptions: { remarkPlugins: [remarkGfm] },
+    },
     components: buildMdxComponents(locale),
   });
   const minutes = readingTimeMinutes(post.body);

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -78,6 +78,12 @@
   --code-border: rgba(24, 24, 27, 0.15);
   --tooltip-bg: rgba(50, 50, 50, 0.92);
   --tooltip-warning-bg: rgba(120, 53, 0, 0.92);
+
+  /* Chart palette — neutrals + one accent (used by blog data figures) */
+  --chart-bar-dominant: #52525b;
+  --chart-bar-accent: #2563eb;
+  --chart-bar-mid: #94a3b8;
+  --chart-bar-faint: #cbd5e1;
 }
 
 /* ── Dark ── */
@@ -111,6 +117,12 @@
   --code-border: rgba(255, 255, 255, 0.15);
   --tooltip-bg: rgba(30, 30, 30, 0.92);
   --tooltip-warning-bg: rgba(180, 83, 9, 0.92);
+
+  /* Chart palette — neutrals + one accent (dark-mode tints) */
+  --chart-bar-dominant: #71717a;
+  --chart-bar-accent: #60a5fa;
+  --chart-bar-mid: #475569;
+  --chart-bar-faint: #334155;
 }
 
 /* ── Job description typography ── */
@@ -240,6 +252,46 @@
   font-size: inherit;
 }
 .blog-post *:first-child { margin-top: 0; }
+
+/* ── Inline horizontal stacked-bar figure (used by data posts) ── */
+.blog-post figure.share-bar {
+  margin: 1.75em 0;
+}
+.blog-post figure.share-bar svg {
+  display: block;
+  width: 100%;
+  height: 36px;
+  border-radius: 4px;
+  overflow: hidden;
+}
+.blog-post figure.share-bar .seg-onsite { fill: var(--chart-bar-dominant); }
+.blog-post figure.share-bar .seg-remote { fill: var(--chart-bar-accent); }
+.blog-post figure.share-bar .seg-hybrid { fill: var(--chart-bar-mid); }
+.blog-post figure.share-bar .seg-untagged { fill: var(--chart-bar-faint); }
+.blog-post figure.share-bar figcaption {
+  margin-top: 0.75em;
+  font-size: 0.85em;
+  color: var(--muted);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4em 1.25em;
+}
+.blog-post figure.share-bar figcaption span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45em;
+}
+.blog-post figure.share-bar .swatch {
+  display: inline-block;
+  width: 0.85em;
+  height: 0.85em;
+  border-radius: 2px;
+  flex-shrink: 0;
+}
+.blog-post figure.share-bar .swatch.seg-onsite { background: var(--chart-bar-dominant); }
+.blog-post figure.share-bar .swatch.seg-remote { background: var(--chart-bar-accent); }
+.blog-post figure.share-bar .swatch.seg-hybrid { background: var(--chart-bar-mid); }
+.blog-post figure.share-bar .swatch.seg-untagged { background: var(--chart-bar-faint); }
 
 /* ── Scrollbar hide (keeps scroll, hides scrollbar) ── */
 .scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -51,6 +51,7 @@
     "next": "^16.2.3",
     "next-mdx-remote": "^6.0.0",
     "next-themes": "^0.4.6",
+    "remark-gfm": "^4.0.0",
     "postgres": "^3.4.8",
     "react": "^19",
     "react-dom": "^19",

--- a/apps/web/src/content/blog/remote-engineering-jobs-2026.de.mdx
+++ b/apps/web/src/content/blog/remote-engineering-jobs-2026.de.mdx
@@ -1,0 +1,157 @@
+---
+title: "Wo Remote-Engineering noch einstellt, Mai 2026"
+description: "JLL meldet: 54% der Fortune 100 sind auf voller RTO. Wir beobachten 4.400 Karriereseiten direkt. Hier stellt Remote-Engineering im Mai 2026 noch ein."
+datePublished: "2026-05-07"
+author: "Viktor Shcherbakov"
+tags: ["data-analysis", "remote-work"]
+relatedCompanies: ["nvidia", "tether", "sezzle", "disney", "clickhouse", "netflix", "grafana-labs", "affirm", "veeva", "samsara", "oliver-wyman", "instacart", "cresta", "gitlab", "kraken", "accenture", "reddit", "clickup", "keeper-security", "twilio"]
+relatedWatchlists: ["colophongroup/big-tech-jobs-in-united-kingdom", "colophongroup/big-tech-jobs-in-germany", "colophongroup/big-tech-jobs-in-spain"]
+---
+
+2025 setzte sich eine neue Standardweisheit durch: Remote-Arbeit ist vorbei. JLLs [US Office Market Dynamics-Bericht](https://www.jll.com/en-us/insights/us-office-market-dynamics) für Q2 2025 lieferte die Schlagzeile: 54% der Fortune-100-Belegschaften unterliegen einer Vollzeit-Büropflicht, gegenüber 11% im Vorjahr. <Company slug="microsoft" /> [führte](https://www.geekwire.com/2026/microsofts-new-rto-policy-starts-feb-23-bringing-seattle-area-workers-back-3-days-a-week/) eine 3-Tage-Büropflicht ein. <Company slug="amazon" /> [ging gleich auf 5](https://www.aboutamazon.com/news/company-news/ceo-andy-jassy-latest-update-on-amazon-return-to-office-manager-team-ratio). <Company slug="goldman-sachs" /> und <Company slug="jpmorgan" /> folgten. Die Fachpresse erledigte den Rest.
+
+Aber die Fortune 100 sind 100 Arbeitgeber. Wir beobachten 4.441. Über diesen Index hinweg sind am Morgen des 7. Mai 2026 4.338 von 89.517 aktiven Engineering-Stellen als remote-fähig getaggt. Das sind 4,8%: klein genug, um die Schlagzeile zu bestätigen („die meisten Stellen sind vor Ort"), groß genug, um eine Liste mit Namen zu verdienen („aber hier sind die Tausenden, die es nicht sind"). Das ist diese Liste.
+
+<figure className="share-bar" aria-label="Engineering-Stellen nach Standorttyp: 89,3% vor Ort, 4,8% remote, 4,3% hybrid, 1,6% ohne Tag">
+  <svg viewBox="0 0 600 36" preserveAspectRatio="none" role="presentation" aria-hidden="true">
+    <rect x="0" y="0" width="535.8" height="36" className="seg-onsite" />
+    <rect x="535.8" y="0" width="28.8" height="36" className="seg-remote" />
+    <rect x="564.6" y="0" width="25.8" height="36" className="seg-hybrid" />
+    <rect x="590.4" y="0" width="9.6" height="36" className="seg-untagged" />
+  </svg>
+  <figcaption>
+    <span><span className="swatch seg-onsite" />Vor Ort 89,3%</span>
+    <span><span className="swatch seg-remote" />Remote 4,8%</span>
+    <span><span className="swatch seg-hybrid" />Hybrid 4,3%</span>
+    <span><span className="swatch seg-untagged" />Ohne Tag 1,6%</span>
+  </figcaption>
+</figure>
+
+## Wer noch einstellt
+
+Zwanzig Unternehmen machen etwa ein Drittel aller aktuell gelisteten remote-fähigen Engineering-Stellen in unserem Index aus.
+
+| Unternehmen | Aktive Remote-Engineering-Stellen |
+|---|---:|
+| <Company slug="nvidia" /> | 174 |
+| <Company slug="tether" /> | 117 |
+| <Company slug="sezzle" /> | 106 |
+| <Company slug="disney" /> | 99 |
+| <Company slug="clickhouse" /> | 81 |
+| <Company slug="netflix" /> | 78 |
+| <Company slug="grafana-labs" /> | 77 |
+| <Company slug="affirm" /> | 61 |
+| <Company slug="veeva" /> | 45 |
+| <Company slug="samsara" /> | 43 |
+| <Company slug="oliver-wyman" /> | 43 |
+| <Company slug="instacart" /> | 42 |
+| <Company slug="cresta" /> | 41 |
+| <Company slug="gitlab" /> | 39 |
+| <Company slug="kraken" /> | 38 |
+| <Company slug="accenture" /> | 38 |
+| <Company slug="reddit" /> | 36 |
+| <Company slug="clickup" /> | 34 |
+| <Company slug="keeper-security" /> | 34 |
+| <Company slug="twilio" /> | 33 |
+
+Ein paar Muster fallen auf. Krypto- und Payment-Infrastruktur ist gut vertreten (<Company slug="tether" />, <Company slug="kraken" />, <Company slug="sezzle" />, <Company slug="affirm" />), ebenso die Open-Source- und Devtools-Häuser (<Company slug="clickhouse" />, <Company slug="grafana-labs" />, <Company slug="gitlab" />). <Company slug="nvidia" />, <Company slug="netflix" />, <Company slug="reddit" /> und <Company slug="pinterest" /> (knapp ausserhalb der Top 20) sind Big-Tech-Namen, deren remote-freundliche Einstellungspraxis nicht die Pressedeckung bekommt, die <Company slug="microsoft" /> und <Company slug="amazon" />s RTO-Mandate erhalten. Mid-Market-SaaS rundet ab: <Company slug="twilio" />, <Company slug="instacart" />, <Company slug="clickup" />, <Company slug="samsara" />. Ein Name, an den die wenigsten denken würden: <Company slug="oliver-wyman" />, eine Unternehmensberatung mit 43 Remote-Engineering-Stellen — eine reale interne Tech-Aufstellung, versteckt in einer Branche, die niemand für remote-freundlich hält.
+
+Was *nicht* auf der Liste steht, ist ebenfalls eine Geschichte. Keiner der RTO-Hardliner aus dem Lead — <Company slug="microsoft" />, <Company slug="amazon" />, <Company slug="goldman-sachs" />, <Company slug="jpmorgan" /> — hat in unserem Index nennenswerte Remote-Engineering-Stellen. Mandate und Stellenanzeigen stimmen überein.
+
+## Die Geografie
+
+Remote ist nicht ortlos. Stellen taggen weiterhin eine Einstellungs-Jurisdiktion (Zeitzonen-Bänder, Arbeitsberechtigung oder eine Lohnabrechnungs-Entität). Über die 4.338 remote-fähigen Engineering-Stellen verteilt sich diese Tagging-Geografie so:
+
+| Region | Stellen |
+|---|---:|
+| Vereinigte Staaten | 2.277 |
+| Kanada | 431 |
+| Vereinigtes Königreich | 259 |
+| Spanien | 218 |
+| Indien | 189 |
+| Polen | 184 |
+| Deutschland | 164 |
+| Irland | 146 |
+| Brasilien | 132 |
+| Mexiko | 130 |
+| Argentinien | 121 |
+
+Die Tabellenspitze ist erwartbar: die USA plus der EU-Pay-Transparency-Gürtel. Der spannendere Teil ist der *Kontrast* zum übrigen Engineering-Markt.
+
+Unser Index hat ein Indien-lastiges Schwergewicht beim Engineering. Bengaluru allein zählt 16.941 aktive Engineering-Stellen, mehr als New York und San Francisco zusammen. **Davon sind nur 67 remote-fähig.** Das sind 0,4%. Hyderabad, Pune, Chennai sehen ähnlich aus. Indisches Engineering-Recruiting ist grundsätzlich ein Vor-Ort-Markt: Die globalen Tech-Arbeitgeber posten dort viel, und sie posten für Schreibtische.
+
+Die Konsequenz: Remote-fähiges Engineering konkurriert nicht mit dem globalen Engineering-Arbeitsmarkt. Es konkurriert mit dem Ausschnitt, der für nordamerikanische oder westeuropäische Einstellung getaggt ist.
+
+## Die Senioritäts-Verzerrung
+
+Von den 4.338 remote-fähigen Engineering-Stellen sind **1.995 (46%) als Senior getaggt**, weitere 11% als Staff, 3% Principal, 2% Lead. Etwa 62% der Stichprobe sind auf Senior+ angesetzt. **Entry-Level-Stellen sind 0,7%: 31 Anzeigen von 4.338.** Praktika sind 0,5%.
+
+Die Erzählung lautete jahrelang, Remote-Arbeit würde den Einstieg bei besseren Arbeitgebern demokratisieren. Die Daten sagen das Gegenteil. Remote konsolidiert sich um Beschäftigte, denen ein Unternehmen bereits vertraut, ohne Aufsicht zu arbeiten. Wer unter 2 Jahren Berufserfahrung hat und einen remote-fähigen Einstiegsjob in unseren Daten sucht, dem bleiben rund 31 Stellen, vor dem Hintergrund von über 89.000 Engineering-Öffnungen insgesamt.
+
+31 gegen über 89.000. Gut zu wissen, bevor man darauf eine Suchstrategie aufbaut.
+
+## Welcher Stack gefragt ist
+
+Das Skill-Profil von Remote-Engineering ist wiedererkennbar und etwas enger als das Engineering-Recruiting insgesamt. Anteil der 4.338 remote-fähigen Stellen, die jede Technologie nennen:
+
+| Skill | Anteil der Remote-Engineering-Stellen |
+|---|---:|
+| Python | 49% |
+| AWS | 37% |
+| Kubernetes | 27% |
+| SQL | 24% |
+| React | 23% |
+| TypeScript | 22% |
+| Java | 19% |
+| Google Cloud | 18% |
+| Docker | 16% |
+| PostgreSQL | 16% |
+| Terraform | 14% |
+
+Das ist der Cloud-Native-, Python-und-typed-JavaScript-Stack: derjenige, der sich für asynchrone Arbeit über Zeitzonen eignet. Embedded ist dünn vertreten, Low-Level-Systems sind dünn, Game-Development noch dünner. C++ taucht in 10% der Stellen auf; Go in 7%; Rust in 6%. Was eine Werkbank, eine Grafikkarte am Schreibtisch oder ein co-lokalisiertes Ops-Team braucht, wird nicht remote ausgeschrieben.
+
+Wer seine Skills auf Remote-Beschäftigungsfähigkeit hin optimiert, sollte auf die Tabelle oben hin optimieren.
+
+## Gehaltstransparenz
+
+**31% der Remote-Engineering-Stellen in unserem Index enthalten ein parsbares Gehaltsband. Bei Vor-Ort-Engineering sind es 14%.** Remote-Stellen sind ungefähr doppelt so transparent.
+
+Der Grund ist nicht, dass remote-freundliche Unternehmen tugendhafter wären. Es ist geografische Konzentration. US-Bundesstaaten mit Pay-Transparency-Gesetzen (Kalifornien, New York, Colorado, Washington, Illinois) und die [EU-Pay-Transparency-Richtlinie 2023/970](https://eur-lex.europa.eu/eli/dir/2023/970/oj/deu) (Mitgliedsstaaten-Umsetzung bis 7. Juni 2026) sind genau dort, wo Remote-Engineering am stärksten konzentriert ist. Derselbe Grund, aus dem eine Stelle remote-getaggt ist, ist ein wesentlicher Grund, warum sie auch gehaltsgetaggt ist.
+
+Wer Vergütung im Voraus sehen will: Die remote-fähige Schicht unseres Index liefert sie ungefähr doppelt so oft beim ersten Lesen.
+
+## Was du mit dieser Liste machen kannst
+
+Der Datensatz hinter diesem Beitrag ist der Datensatz hinter der Suche. Auf der [Explore-Seite](/de/explore) lässt sich direkt nach „remote" filtern und das Ganze mit Seniorität, Gehaltsband und Stack kombinieren — und die Suche dann als eigene Watchlist sichern. Das ist der Weg, den wir an der Stelle des Lesers gehen würden.
+
+Drei der Länder-Watchlists, die wir pflegen, liegen genau auf dem EU-Remote-Schwerpunkt — UK, Deutschland, Spanien (die obersten drei EU-Geografien aus der Tabelle oben). Sie enthalten auch Vor-Ort-Stellen, sind aber die nächstgelegenen vorgefertigten Linsen auf den Datensatz hinter diesem Beitrag.
+
+<WatchlistCard owner="colophongroup" slug="big-tech-jobs-in-united-kingdom" />
+
+<WatchlistCard owner="colophongroup" slug="big-tech-jobs-in-germany" />
+
+<WatchlistCard owner="colophongroup" slug="big-tech-jobs-in-spain" />
+
+<h2 id="methodology">Methodik</h2>
+
+- **Stichtag.** Alle Werte stammen aus einer einzigen Typesense-Facet-Abfrage gegen unsere `job_posting_v1`-Collection vom 7. Mai 2026, ca. 13:00 UTC. Das `is_active=true`-Flag wird vom Crawler gesetzt, wenn eine Stelle zuletzt innerhalb der Delisting-Toleranzen auf der Quelle gesehen wurde (definiert pro ATS in unserer [Indizierungsrichtlinie](/de/how-we-index)).
+- **Engineering-Definition.** Stellen, deren normalisierte Berufsabstammung eine der folgenden enthält: software-engineer (mit den Kindern frontend, backend, fullstack, mobile, embedded, game, AI Engineer, Research Engineer), devops-engineer (inkl. SRE-, Platform-, Cloud-, Release-Varianten), qa-engineer, data-engineer, data-scientist, ml-engineer, data-analyst, data-annotator. Elektro-, Maschinenbau- und Bauingenieurwesen sind ausserhalb der Software/Daten-Domäne getaggt und ausgeschlossen.
+- **„Remote-fähig".** Eine Stelle, in deren normalisiertem `location_types`-Array `remote` enthalten ist. Etwa 28% dieser Stellen tragen zusätzlich ein `onsite`-Tag, was wir als „remote-fähig mit optionalem HQ-Zugang" lesen, nicht als „nur remote". Eine strikte Nur-Remote-Definition wäre eine kleinere Zahl; wir nehmen die breitere, weil sie dem entspricht, worauf man sich als Bewerber*in tatsächlich bewerben kann.
+- **Senioritäts-Tagging.** Etwa 64% der Remote-Engineering-Stellen (2.767 von 4.338) tragen ein normalisiertes Senioritäts-Tag. Prozentwerte in diesem Beitrag werden als Anteil der vollen 4.338 berechnet — wenn wir „0,7% Entry-Level" sagen, ist die absolute Zahl (31) belastbar, der Prozentwert unterstellt aber, dass die 36% nicht-getaggter Stellen eine ähnliche Niveauverteilung haben. Wahrscheinlich neigen sie zu Mid-Level (das oft nicht getaggt wird), was die Senioritäts-Verzerrungs-Aussage *verstärken* würde, nicht abschwächen.
+- **Coverage-Vorbehalt.** Unser Index umfasst 4.441 Unternehmen. Er ist keine repräsentative Stichprobe des globalen Arbeitsmarkts: Wir beobachten gezielt Unternehmen in Westeuropa, der Schweiz und ausgewählte US-Tech-Arbeitgeber, deren globale Tochter-Stellen mitgenommen werden, sofern die Karriereseite überwachbar ist. Die Datenform folgt dieser Schiefe.
+- **Die „Vereinigte Staaten"-Zeile.** Der US-Wert in der Geografie-Tabelle (2.277) wird gegen `location_ids`-Vorfahren in unserer Standorthierarchie berechnet — jede Stelle, die mit einer US-Stadt, einem Bundesstaat oder „United States" getaggt ist, rollt hoch. Die anderen Tabellenzeilen sind direkte Facet-Counts auf `location_names`. Der Unterschied wirkt hier, weil Remote-Stellen oft eine US-Stadt oder einen Bundesstaat statt der Länderwurzel taggen.
+- **Snapshot, kein Trend.** Das früheste `first_seen_at` für eine noch aktive Stelle ist der 9. März 2026. Stellen, die älter sind, mögen auf Quellen existieren, erscheinen aber erst ab unserer ersten Crawl-Entdeckung im Index. Wir machen aus diesem Snapshot keine Trend-Aussagen. Im selben Zwei-Monats-Fenster sind 4.233 remote-fähige Engineering-Stellen *geschlossen* worden — der Markt fluktuiert, er steht nicht.
+- **Reproduzierbarkeit.** Jeder Wert oben lässt sich mit einer einzigen Typesense-`documents/search`-Anfrage gegen unsere `job_posting_v1`-Collection mit passendem `filter_by` und `facet_by` reproduzieren. Das Schema liegt unter `apps/crawler/src/typesense_schema.py` in unserem [Open-Source-Repository](https://github.com/colophon-group/jobseek).
+- **Was das nicht ist.** Das ist eine Aufnahme von *ausgeschriebenen* Stellen, keine Messung von *Headcount*, *Besetzungen* oder Unternehmensstrategie. Ein Unternehmen kann viel posten und wenig einstellen, oder wenig posten und schnell wachsen. Was hier zu sehen ist: was Karriereseiten gerade ausschreiben — nützlich, um zu entscheiden, wo man sich bewirbt, weniger nützlich, um auf das Innenleben zu schließen.
+
+## Quellen
+
+Im Beitrag zitierte externe Quellen:
+
+- **JLL.** *U.S. Office Market Dynamics, Q2 2025.* Die Schlagzeile „54% der Fortune 100 / hoch von 11%". Bericht-Landingpage: [jll.com/en-us/insights/us-office-market-dynamics](https://www.jll.com/en-us/insights/us-office-market-dynamics). Pressezusammenfassung: [Bisnow, „Majority of Employees at Fortune 100 Firms Now Have 5-Day Office Mandate"](https://www.bisnow.com/national/news/office/more-than-half-of-fortune-100-employees-are-in-office-full-time-130262).
+- **Amazon.** Andy Jassy, *„Update on Amazon return-to-office and manager-team ratio"*, 16. September 2024 — das Memo zur Fünf-Tage-Büropflicht. [aboutamazon.com](https://www.aboutamazon.com/news/company-news/ceo-andy-jassy-latest-update-on-amazon-return-to-office-manager-team-ratio).
+- **Microsoft.** Drei-Tage-Büropflicht, angekündigt im September 2025, gestaffelter Roll-out ab 23. Februar 2026 (Puget Sound zuerst). Berichterstattung mit Primärquellen-Detail: [GeekWire, „Microsoft's new RTO policy starts Feb. 23"](https://www.geekwire.com/2026/microsofts-new-rto-policy-starts-feb-23-bringing-seattle-area-workers-back-3-days-a-week/).
+- **EU-Rat.** *Richtlinie (EU) 2023/970* des Europäischen Parlaments und des Rates zur Lohntransparenz, in Kraft seit 6. Juni 2023; Umsetzungsfrist der Mitgliedsstaaten bis 7. Juni 2026. Artikel 5 ist die Klausel zum Gehalt in der Stellenausschreibung. [EUR-Lex offizieller Text](https://eur-lex.europa.eu/eli/dir/2023/970/oj/deu).
+- **Goldman-Sachs- / JPMorgan-Fünf-Tage-Büropflichten** werden über JLLs Q2-2025-Bericht (oben) referenziert, der sie unter den Fortune-100-Firmen nennt, die im ersten Quartal 2025 auf Fünf-Tage-Pflicht umgestellt haben.
+
+US-Pay-Transparency-Gesetze sind kollektiv referenziert (California SB 1162, New York Pay Transparency Law, Colorado Equal Pay for Equal Work Act, Washington SB 5761, Illinois HB 3129) und auf der Übersichtsseite des [US Department of Labor zu Pay Equity](https://www.dol.gov/agencies/wb/topics/equal-pay) zusammengefasst.

--- a/apps/web/src/content/blog/remote-engineering-jobs-2026.fr.mdx
+++ b/apps/web/src/content/blog/remote-engineering-jobs-2026.fr.mdx
@@ -1,0 +1,157 @@
+---
+title: "Où le remote engineering recrute encore, mai 2026"
+description: "JLL chiffre 54% des employés du Fortune 100 en RTO complet. Nous suivons 4 400 pages carrières en direct. Voici où le remote engineering recrute encore en mai 2026."
+datePublished: "2026-05-07"
+author: "Viktor Shcherbakov"
+tags: ["data-analysis", "remote-work"]
+relatedCompanies: ["nvidia", "tether", "sezzle", "disney", "clickhouse", "netflix", "grafana-labs", "affirm", "veeva", "samsara", "oliver-wyman", "instacart", "cresta", "gitlab", "kraken", "accenture", "reddit", "clickup", "keeper-security", "twilio"]
+relatedWatchlists: ["colophongroup/big-tech-jobs-in-united-kingdom", "colophongroup/big-tech-jobs-in-germany", "colophongroup/big-tech-jobs-in-spain"]
+---
+
+Une nouvelle conventional wisdom s'est imposée en 2025 : le télétravail, c'est fini. Le [rapport US Office Market Dynamics](https://www.jll.com/en-us/insights/us-office-market-dynamics) de JLL pour le T2 2025 a livré le chiffre clef : 54% des employés du Fortune 100 sont soumis à une obligation de présence 5 jours par semaine, contre 11% un an plus tôt. <Company slug="microsoft" /> [a déployé](https://www.geekwire.com/2026/microsofts-new-rto-policy-starts-feb-23-bringing-seattle-area-workers-back-3-days-a-week/) un mandat de 3 jours au bureau. <Company slug="amazon" /> [est passé directement à 5](https://www.aboutamazon.com/news/company-news/ceo-andy-jassy-latest-update-on-amazon-return-to-office-manager-team-ratio). <Company slug="goldman-sachs" /> et <Company slug="jpmorgan" /> ont suivi. La presse spécialisée a fait le reste.
+
+Mais le Fortune 100, c'est 100 employeurs. Nous en suivons 4 441. À travers cet index, le matin du 7 mai 2026, 4 338 des 89 517 offres d'engineering actives sont taguées remote-eligible. Cela fait 4,8% : un chiffre assez petit pour confirmer le titre (« la plupart des postes sont sur site »), assez grand pour mériter une liste de noms (« mais voici les milliers qui ne le sont pas »). Voici cette liste.
+
+<figure className="share-bar" aria-label="Postes engineering par type de localisation : 89,3% sur site, 4,8% remote, 4,3% hybride, 1,6% non tagué">
+  <svg viewBox="0 0 600 36" preserveAspectRatio="none" role="presentation" aria-hidden="true">
+    <rect x="0" y="0" width="535.8" height="36" className="seg-onsite" />
+    <rect x="535.8" y="0" width="28.8" height="36" className="seg-remote" />
+    <rect x="564.6" y="0" width="25.8" height="36" className="seg-hybrid" />
+    <rect x="590.4" y="0" width="9.6" height="36" className="seg-untagged" />
+  </svg>
+  <figcaption>
+    <span><span className="swatch seg-onsite" />Sur site 89,3%</span>
+    <span><span className="swatch seg-remote" />Remote 4,8%</span>
+    <span><span className="swatch seg-hybrid" />Hybride 4,3%</span>
+    <span><span className="swatch seg-untagged" />Non tagué 1,6%</span>
+  </figcaption>
+</figure>
+
+## Qui embauche encore
+
+Vingt entreprises totalisent environ un tiers des postes remote-eligible en engineering actuellement listés dans notre index.
+
+| Entreprise | Postes remote engineering actifs |
+|---|---:|
+| <Company slug="nvidia" /> | 174 |
+| <Company slug="tether" /> | 117 |
+| <Company slug="sezzle" /> | 106 |
+| <Company slug="disney" /> | 99 |
+| <Company slug="clickhouse" /> | 81 |
+| <Company slug="netflix" /> | 78 |
+| <Company slug="grafana-labs" /> | 77 |
+| <Company slug="affirm" /> | 61 |
+| <Company slug="veeva" /> | 45 |
+| <Company slug="samsara" /> | 43 |
+| <Company slug="oliver-wyman" /> | 43 |
+| <Company slug="instacart" /> | 42 |
+| <Company slug="cresta" /> | 41 |
+| <Company slug="gitlab" /> | 39 |
+| <Company slug="kraken" /> | 38 |
+| <Company slug="accenture" /> | 38 |
+| <Company slug="reddit" /> | 36 |
+| <Company slug="clickup" /> | 34 |
+| <Company slug="keeper-security" /> | 34 |
+| <Company slug="twilio" /> | 33 |
+
+Quelques motifs ressortent. La crypto et les rails de paiement sont bien représentés (<Company slug="tether" />, <Company slug="kraken" />, <Company slug="sezzle" />, <Company slug="affirm" />), tout comme les acteurs open-source et devtools (<Company slug="clickhouse" />, <Company slug="grafana-labs" />, <Company slug="gitlab" />). <Company slug="nvidia" />, <Company slug="netflix" />, <Company slug="reddit" /> et <Company slug="pinterest" /> (juste hors top 20) sont des noms de big tech dont la posture remote-friendly ne reçoit pas la couverture médiatique des mandats RTO de <Company slug="microsoft" /> et <Company slug="amazon" />. Le SaaS de milieu de marché complète : <Company slug="twilio" />, <Company slug="instacart" />, <Company slug="clickup" />, <Company slug="samsara" />. Un nom auquel peu de candidats penseraient : <Company slug="oliver-wyman" />, un cabinet de conseil avec 43 postes remote engineering — une vraie empreinte tech interne, dans un secteur que personne ne croit remote-friendly.
+
+Ce qui *ne figure pas* sur la liste raconte aussi quelque chose. Aucun des partisans du RTO nommés dans le lead — <Company slug="microsoft" />, <Company slug="amazon" />, <Company slug="goldman-sachs" />, <Company slug="jpmorgan" /> — n'a de postes remote engineering significatifs dans notre index. Les mandats et les annonces sont alignés.
+
+## La géographie
+
+Le remote n'est pas hors-sol. Les annonces taguent toujours une juridiction d'embauche (fuseaux horaires, droit de travailler, ou entité de paie). Sur les 4 338 postes remote-eligible en engineering, les tags se répartissent ainsi :
+
+| Région | Postes |
+|---|---:|
+| États-Unis | 2 277 |
+| Canada | 431 |
+| Royaume-Uni | 259 |
+| Espagne | 218 |
+| Inde | 189 |
+| Pologne | 184 |
+| Allemagne | 164 |
+| Irlande | 146 |
+| Brésil | 132 |
+| Mexique | 130 |
+| Argentine | 121 |
+
+Le haut du tableau est attendu : les États-Unis et la ceinture de transparence salariale européenne. La partie intéressante, c'est le *contraste* avec le reste du marché de l'engineering.
+
+Notre index a un centre de gravité indien pour l'engineering. Bengaluru à elle seule compte 16 941 postes engineering actifs, plus que New York et San Francisco réunies. **Sur ces 16 941, seuls 67 sont remote-eligible.** Soit 0,4%. Hyderabad, Pune, Chennai sont similaires. L'embauche engineering en Inde est fondamentalement un marché sur site : les grands employeurs tech globaux y publient massivement, et ils publient pour des postes au bureau.
+
+Le corollaire : le remote engineering ne concurrence pas le marché global du travail engineering. Il concurrence la tranche taguée pour de l'embauche en Amérique du Nord ou en Europe occidentale.
+
+## Le biais de séniorité
+
+Sur les 4 338 postes remote-eligible en engineering, **1 995 (46%) sont tagués Senior**, 11% Staff, 3% Principal, 2% Lead. Environ 62% de l'échantillon est filtré au seuil senior+. **Les postes Entry-Level représentent 0,7% : 31 annonces sur 4 338.** Les stages 0,5%.
+
+Pendant des années, le récit a été que le télétravail démocratiserait l'accès aux meilleurs employeurs pour les débutants. Les données disent l'inverse. Le remote se concentre autour de salariés à qui l'entreprise fait déjà confiance pour travailler sans supervision directe. Si vous avez moins de 2 ans d'expérience et cherchez un poste remote-first en début de carrière dans nos données, il vous reste environ 31 annonces, sur fond de plus de 89 000 offres engineering au total.
+
+31 contre plus de 89 000. À savoir avant de bâtir une stratégie de recherche dessus.
+
+## Quel stack est demandé
+
+Le profil de compétences du remote engineering est reconnaissable, et un peu plus étroit que celui de l'engineering global. Part des 4 338 postes remote-eligible qui mentionnent chaque technologie :
+
+| Compétence | Part des postes remote engineering |
+|---|---:|
+| Python | 49% |
+| AWS | 37% |
+| Kubernetes | 27% |
+| SQL | 24% |
+| React | 23% |
+| TypeScript | 22% |
+| Java | 19% |
+| Google Cloud | 18% |
+| Docker | 16% |
+| PostgreSQL | 16% |
+| Terraform | 14% |
+
+C'est le stack cloud-native, Python-et-JavaScript-typé : celui qui se prête au travail asynchrone à travers les fuseaux. L'embarqué est rare, le bas-niveau est rare, le développement de jeux encore plus. C++ apparaît dans 10% des annonces ; Go dans 7% ; Rust dans 6%. Ce qui demande un banc d'essai, une carte graphique sur le bureau, ou une équipe ops co-localisée n'est pas ce qui s'affiche en remote.
+
+Si vous optimisez vos compétences pour l'employabilité remote, le tableau ci-dessus est celui qu'il faut viser.
+
+## Transparence salariale
+
+**31% des postes remote engineering dans notre index incluent une fourchette salariale parsable. Pour l'engineering sur site, c'est 14%.** Les annonces remote sont environ deux fois plus transparentes.
+
+La raison n'est pas que les entreprises remote-friendly sont plus vertueuses. C'est une concentration géographique. Les États américains avec des lois de transparence salariale (Californie, New York, Colorado, Washington, Illinois) et la [directive européenne sur la transparence des rémunérations 2023/970](https://eur-lex.europa.eu/eli/dir/2023/970/oj/fra) (transposition par les États membres avant le 7 juin 2026) sont précisément là où le remote engineering est le plus concentré. La même raison qui fait qu'une annonce est taguée remote est une raison majeure pour qu'elle soit aussi taguée salaire.
+
+Si vous voulez voir la rémunération à l'avance, la tranche remote-eligible de notre index a deux fois plus de chances de vous la donner d'emblée.
+
+## Que faire de cette liste
+
+Le jeu de données derrière ce billet est le jeu de données derrière la recherche. La [page explore](/fr/explore) permet de filtrer directement sur remote, et de combiner avec séniorité, fourchette salariale et stack — puis de sauvegarder la recherche comme votre propre watchlist. C'est le chemin que nous prendrions à votre place.
+
+Trois des watchlists par pays que nous maintenons recouvrent justement le pôle remote européen — Royaume-Uni, Allemagne, Espagne (les trois premières géographies européennes du tableau ci-dessus). Elles incluent aussi des postes sur site, mais ce sont les lentilles préfabriquées les plus proches du jeu de données qui nourrit ce billet.
+
+<WatchlistCard owner="colophongroup" slug="big-tech-jobs-in-united-kingdom" />
+
+<WatchlistCard owner="colophongroup" slug="big-tech-jobs-in-germany" />
+
+<WatchlistCard owner="colophongroup" slug="big-tech-jobs-in-spain" />
+
+<h2 id="methodology">Méthodologie</h2>
+
+- **Date de l'instantané.** Tous les chiffres viennent d'une seule requête de facettes Typesense sur notre collection `job_posting_v1` le 7 mai 2026 vers 13:00 UTC. Le drapeau `is_active=true` est posé par notre crawler quand une annonce a été vue pour la dernière fois sur sa source dans les tolérances de delisting (définies par ATS dans notre [politique d'indexation](/fr/how-we-index)).
+- **Définition d'engineering.** Postes dont la lignée d'occupation normalisée contient l'un des suivants : software-engineer (avec les enfants frontend, backend, fullstack, mobile, embedded, game, AI Engineer, Research Engineer), devops-engineer (variantes SRE, platform, cloud, release), qa-engineer, data-engineer, data-scientist, ml-engineer, data-analyst, data-annotator. L'ingénierie électrique, mécanique et civile est taguée hors du domaine logiciel/données et exclue.
+- **« Remote-eligible ».** Une annonce dont le tableau `location_types` normalisé contient `remote`. Environ 28% de ces annonces portent aussi un tag `onsite`, ce que nous lisons comme « remote-eligible avec accès optionnel au siège » plutôt que « strictement remote ». Une définition strict-remote-only donnerait un chiffre plus petit ; nous prenons la définition large parce qu'elle correspond à ce sur quoi un candidat peut effectivement postuler.
+- **Tagging de séniorité.** Environ 64% des postes remote engineering (2 767 sur 4 338) portent un tag de séniorité normalisé. Les pourcentages sont calculés comme part des 4 338 complets — quand nous disons « 0,7% Entry-Level », l'effectif (31) est solide, mais le pourcentage suppose que les 36% non tagués ont une distribution de niveau similaire. Ils penchent probablement Mid-Level (souvent non tagué), ce qui *renforcerait* l'argument du biais senior plutôt que de l'affaiblir.
+- **Réserve de couverture.** Notre index couvre 4 441 entreprises. Ce n'est pas un échantillon représentatif du marché du travail mondial : nous suivons délibérément des entreprises en Europe occidentale, en Suisse et un sous-ensemble d'employeurs tech américains, avec leurs filiales globales lorsque la page carrières est surveillable. La forme des données suit ce biais.
+- **La ligne « États-Unis ».** Le compte US du tableau de géographie (2 277) est calculé contre les ancêtres `location_ids` dans notre hiérarchie de localisation — toute annonce taguée avec une ville américaine, un État ou « United States » lui-même remonte. Les autres lignes du tableau sont des facets directes sur `location_names`. La différence importe ici parce que les annonces remote taguent souvent une ville ou un État américain plutôt que la racine du pays.
+- **Instantané, pas tendance.** Le `first_seen_at` le plus ancien d'une annonce encore active est le 9 mars 2026. Des annonces plus anciennes existent peut-être sur les sources mais n'apparaissent dans notre index qu'à partir de leur première découverte par le crawler. Aucune affirmation tendancielle ne sort de ce snapshot. Sur la même fenêtre de deux mois, 4 233 annonces remote-eligible en engineering ont *fermé* — le marché est en mouvement, pas figé.
+- **Reproductibilité.** Chaque chiffre ci-dessus est reproductible avec une seule requête Typesense `documents/search` sur notre collection `job_posting_v1`, avec les bons `filter_by` et `facet_by`. Le schéma se trouve dans `apps/crawler/src/typesense_schema.py` de notre [dépôt open source](https://github.com/colophon-group/jobseek).
+- **Ce que ce n'est pas.** C'est un instantané d'annonces *publiées*, pas une mesure de *headcount*, de *recrutements effectifs* ou de stratégie d'entreprise. Une boîte peut publier beaucoup et embaucher peu, ou publier peu et grandir vite. Ce que vous voyez ici, c'est « ce que les pages carrières affichent en ce moment » — utile pour décider où postuler, moins utile pour inférer ce qui se passe en interne.
+
+## Références
+
+Sources externes citées ci-dessus :
+
+- **JLL.** *U.S. Office Market Dynamics, Q2 2025.* La manchette « 54% du Fortune 100 / contre 11% ». Page du rapport : [jll.com/en-us/insights/us-office-market-dynamics](https://www.jll.com/en-us/insights/us-office-market-dynamics). Reprise médiatique : [Bisnow, « Majority of Employees at Fortune 100 Firms Now Have 5-Day Office Mandate »](https://www.bisnow.com/national/news/office/more-than-half-of-fortune-100-employees-are-in-office-full-time-130262).
+- **Amazon.** Andy Jassy, *« Update on Amazon return-to-office and manager-team ratio »*, 16 septembre 2024 — le mémo annonçant l'obligation de présence 5 jours par semaine. [aboutamazon.com](https://www.aboutamazon.com/news/company-news/ceo-andy-jassy-latest-update-on-amazon-return-to-office-manager-team-ratio).
+- **Microsoft.** Mandat de 3 jours au bureau annoncé en septembre 2025, déploiement par phases à partir du 23 février 2026 (Puget Sound en premier). Couverture avec détails de source primaire : [GeekWire, « Microsoft's new RTO policy starts Feb. 23 »](https://www.geekwire.com/2026/microsofts-new-rto-policy-starts-feb-23-bringing-seattle-area-workers-back-3-days-a-week/).
+- **Conseil de l'UE.** *Directive (UE) 2023/970* du Parlement européen et du Conseil sur la transparence des rémunérations, en vigueur depuis le 6 juin 2023 ; échéance de transposition par les États membres au 7 juin 2026. L'article 5 est la clause sur le salaire dans l'annonce d'emploi. [Texte officiel EUR-Lex](https://eur-lex.europa.eu/eli/dir/2023/970/oj/fra).
+- **Mandats Goldman Sachs / JPMorgan** : référencés via le rapport JLL Q2 2025 (ci-dessus), qui les cite parmi les firmes du Fortune 100 passées à 5 jours au bureau au premier trimestre 2025.
+
+Lois de transparence salariale aux États-Unis référencées collectivement (California SB 1162, New York Pay Transparency Law, Colorado Equal Pay for Equal Work Act, Washington SB 5761, Illinois HB 3129) et résumées sur la page [Pay Equity du US Department of Labor](https://www.dol.gov/agencies/wb/topics/equal-pay).

--- a/apps/web/src/content/blog/remote-engineering-jobs-2026.it.mdx
+++ b/apps/web/src/content/blog/remote-engineering-jobs-2026.it.mdx
@@ -1,0 +1,157 @@
+---
+title: "Dove l'engineering remoto assume ancora, maggio 2026"
+description: "JLL: il 54% dei dipendenti Fortune 100 è in RTO totale. Noi seguiamo 4.400 pagine carriere in diretta. Ecco dove l'engineering remoto assume ancora a maggio 2026."
+datePublished: "2026-05-07"
+author: "Viktor Shcherbakov"
+tags: ["data-analysis", "remote-work"]
+relatedCompanies: ["nvidia", "tether", "sezzle", "disney", "clickhouse", "netflix", "grafana-labs", "affirm", "veeva", "samsara", "oliver-wyman", "instacart", "cresta", "gitlab", "kraken", "accenture", "reddit", "clickup", "keeper-security", "twilio"]
+relatedWatchlists: ["colophongroup/big-tech-jobs-in-united-kingdom", "colophongroup/big-tech-jobs-in-germany", "colophongroup/big-tech-jobs-in-spain"]
+---
+
+Nel 2025 si è imposta una nuova saggezza convenzionale: il lavoro remoto è finito. Il [rapporto US Office Market Dynamics](https://www.jll.com/en-us/insights/us-office-market-dynamics) di JLL del Q2 2025 ha fornito il numero da titolo: il 54% dei dipendenti delle Fortune 100 è soggetto a una settimana intera in ufficio, contro l'11% un anno prima. <Company slug="microsoft" /> [ha imposto](https://www.geekwire.com/2026/microsofts-new-rto-policy-starts-feb-23-bringing-seattle-area-workers-back-3-days-a-week/) un mandato di 3 giorni in ufficio. <Company slug="amazon" /> [è andata direttamente a 5](https://www.aboutamazon.com/news/company-news/ceo-andy-jassy-latest-update-on-amazon-return-to-office-manager-team-ratio). <Company slug="goldman-sachs" /> e <Company slug="jpmorgan" /> hanno seguito. La stampa di settore ha fatto il resto.
+
+Ma le Fortune 100 sono 100 datori di lavoro. Noi ne seguiamo 4.441. Su quell'indice, la mattina del 7 maggio 2026, 4.338 dei 89.517 annunci di engineering attivi sono taggati come remote-eligible. Sono il 4,8%: un numero abbastanza piccolo da confermare il titolo (« la maggior parte dei posti è in sede »), abbastanza grande da meritare una lista di nomi (« ma ecco le migliaia che non lo sono »). Questa è la lista.
+
+<figure className="share-bar" aria-label="Annunci di engineering per tipologia di sede: 89,3% in sede, 4,8% remoto, 4,3% ibrido, 1,6% senza tag">
+  <svg viewBox="0 0 600 36" preserveAspectRatio="none" role="presentation" aria-hidden="true">
+    <rect x="0" y="0" width="535.8" height="36" className="seg-onsite" />
+    <rect x="535.8" y="0" width="28.8" height="36" className="seg-remote" />
+    <rect x="564.6" y="0" width="25.8" height="36" className="seg-hybrid" />
+    <rect x="590.4" y="0" width="9.6" height="36" className="seg-untagged" />
+  </svg>
+  <figcaption>
+    <span><span className="swatch seg-onsite" />In sede 89,3%</span>
+    <span><span className="swatch seg-remote" />Remoto 4,8%</span>
+    <span><span className="swatch seg-hybrid" />Ibrido 4,3%</span>
+    <span><span className="swatch seg-untagged" />Senza tag 1,6%</span>
+  </figcaption>
+</figure>
+
+## Chi sta ancora assumendo
+
+Venti aziende coprono circa un terzo di tutti gli annunci remote-eligible di engineering attualmente listati nel nostro indice.
+
+| Azienda | Annunci remote engineering attivi |
+|---|---:|
+| <Company slug="nvidia" /> | 174 |
+| <Company slug="tether" /> | 117 |
+| <Company slug="sezzle" /> | 106 |
+| <Company slug="disney" /> | 99 |
+| <Company slug="clickhouse" /> | 81 |
+| <Company slug="netflix" /> | 78 |
+| <Company slug="grafana-labs" /> | 77 |
+| <Company slug="affirm" /> | 61 |
+| <Company slug="veeva" /> | 45 |
+| <Company slug="samsara" /> | 43 |
+| <Company slug="oliver-wyman" /> | 43 |
+| <Company slug="instacart" /> | 42 |
+| <Company slug="cresta" /> | 41 |
+| <Company slug="gitlab" /> | 39 |
+| <Company slug="kraken" /> | 38 |
+| <Company slug="accenture" /> | 38 |
+| <Company slug="reddit" /> | 36 |
+| <Company slug="clickup" /> | 34 |
+| <Company slug="keeper-security" /> | 34 |
+| <Company slug="twilio" /> | 33 |
+
+Emergono alcuni schemi. Crypto e infrastrutture di pagamento sono ben rappresentate (<Company slug="tether" />, <Company slug="kraken" />, <Company slug="sezzle" />, <Company slug="affirm" />), così come i player open-source e devtools (<Company slug="clickhouse" />, <Company slug="grafana-labs" />, <Company slug="gitlab" />). <Company slug="nvidia" />, <Company slug="netflix" />, <Company slug="reddit" /> e <Company slug="pinterest" /> (appena fuori dalla top 20) sono nomi big tech la cui postura remote-friendly non riceve la copertura mediatica dei mandati RTO di <Company slug="microsoft" /> e <Company slug="amazon" />. Il SaaS di mid-market completa il quadro: <Company slug="twilio" />, <Company slug="instacart" />, <Company slug="clickup" />, <Company slug="samsara" />. Un nome a cui pochi candidati penserebbero: <Company slug="oliver-wyman" />, una società di consulenza con 43 ruoli remote engineering — un'impronta tech interna concreta, dentro un settore che nessuno considera remote-friendly.
+
+Ciò che *non* è in lista è anch'esso una storia. Nessuno dei mandatari RTO citati nel lead — <Company slug="microsoft" />, <Company slug="amazon" />, <Company slug="goldman-sachs" />, <Company slug="jpmorgan" /> — ha annunci remote engineering significativi nel nostro indice. I mandati e gli annunci coincidono.
+
+## La geografia
+
+Il remoto non è privo di luogo. Gli annunci taggano comunque una giurisdizione di assunzione (fasce orarie, idoneità lavorativa o entità di payroll). Sui 4.338 annunci remote-eligible di engineering, i tag si distribuiscono così:
+
+| Regione | Annunci |
+|---|---:|
+| Stati Uniti | 2.277 |
+| Canada | 431 |
+| Regno Unito | 259 |
+| Spagna | 218 |
+| India | 189 |
+| Polonia | 184 |
+| Germania | 164 |
+| Irlanda | 146 |
+| Brasile | 132 |
+| Messico | 130 |
+| Argentina | 121 |
+
+La parte alta della tabella è prevedibile: gli Stati Uniti più la cintura europea della trasparenza salariale. La parte interessante è il *contrasto* col resto del mercato dell'engineering.
+
+Il nostro indice ha un baricentro indiano per l'engineering. La sola Bengaluru conta 16.941 annunci di engineering attivi, più di New York e San Francisco messe insieme. **Di quei 16.941, solo 67 sono remote-eligible.** Lo 0,4%. Hyderabad, Pune, Chennai sono simili. L'engineering hiring in India è fondamentalmente un mercato in sede: i grandi datori di lavoro tech globali pubblicano lì in massa, e pubblicano per scrivanie.
+
+Il corollario: l'engineering remote-eligible non compete con il mercato globale dell'engineering. Compete con la fetta taggata per assunzione in Nord America o in Europa occidentale.
+
+## Lo squilibrio di seniority
+
+Sui 4.338 ruoli remote-eligible di engineering, **1.995 (46%) sono taggati Senior**, un altro 11% Staff, 3% Principal, 2% Lead. Circa il 62% del campione è gated su livelli senior+. **I ruoli Entry-Level sono lo 0,7%: 31 annunci su 4.338.** Gli stage lo 0,5%.
+
+Per anni la narrazione è stata che il lavoro remoto avrebbe democratizzato l'accesso entry-level ai datori di lavoro migliori. I dati dicono il contrario. Il remoto si concentra su dipendenti di cui un'azienda già si fida nel lavorare senza supervisione. Se hai meno di 2 anni di esperienza e cerchi un primo ruolo remote-first nei nostri dati, hai circa 31 annunci a cui candidarti, su uno sfondo di oltre 89.000 aperture engineering complessive.
+
+31 contro oltre 89.000. Da sapere prima di costruirci una strategia di ricerca.
+
+## Quale stack viene richiesto
+
+Il profilo skill del remote engineering è riconoscibile, e un po' più stretto di quello dell'engineering complessivo. Quota dei 4.338 annunci remote-eligible che cita ciascuna tecnologia:
+
+| Skill | Quota degli annunci remote engineering |
+|---|---:|
+| Python | 49% |
+| AWS | 37% |
+| Kubernetes | 27% |
+| SQL | 24% |
+| React | 23% |
+| TypeScript | 22% |
+| Java | 19% |
+| Google Cloud | 18% |
+| Docker | 16% |
+| PostgreSQL | 16% |
+| Terraform | 14% |
+
+Questo è lo stack cloud-native, Python-e-JavaScript-tipato: quello che si presta al lavoro asincrono attraverso i fusi. L'embedded è raro, il low-level è raro, lo sviluppo videoludico ancora di più. C++ compare nel 10% degli annunci; Go nel 7%; Rust nel 6%. Quello che richiede un banco di prova, una scheda grafica sulla scrivania, o un team ops co-localizzato non è ciò che viene pubblicizzato in remoto.
+
+Se stai ottimizzando le tue skill per l'occupabilità remoto, la tabella sopra è quella su cui ottimizzare.
+
+## Trasparenza retributiva
+
+**Il 31% degli annunci remote engineering nel nostro indice include una fascia salariale leggibile. Per l'engineering in sede la quota è 14%.** Gli annunci remote sono circa il doppio più trasparenti.
+
+La ragione non è che le aziende remote-friendly siano più virtuose. È concentrazione geografica. Gli stati USA con leggi sulla trasparenza retributiva (California, New York, Colorado, Washington, Illinois) e la [direttiva UE sulla trasparenza retributiva 2023/970](https://eur-lex.europa.eu/eli/dir/2023/970/oj/ita) (recepimento da parte degli Stati membri entro il 7 giugno 2026) sono esattamente dove il remote engineering è più concentrato. La stessa ragione per cui un annuncio è taggato remote è una ragione importante per cui è anche taggato salario.
+
+Se vuoi vedere la retribuzione fin dall'inizio, la fetta remote-eligible del nostro indice ha probabilità doppie di mostrartela alla prima lettura.
+
+## Cosa fare con questa lista
+
+Il dataset dietro questo post è il dataset dietro la ricerca. La [pagina explore](/it/explore) consente di filtrare direttamente su remote e combinare con seniority, fascia salariale e stack — quindi salvare la ricerca come tua watchlist. È la strada che prenderemmo al posto del lettore.
+
+Tre delle watchlist per paese che manteniamo coincidono con il polo remoto europeo — Regno Unito, Germania, Spagna (le prime tre geografie europee della tabella sopra). Includono anche ruoli in sede, ma sono le lenti già pronte più vicine al dataset che alimenta questo post.
+
+<WatchlistCard owner="colophongroup" slug="big-tech-jobs-in-united-kingdom" />
+
+<WatchlistCard owner="colophongroup" slug="big-tech-jobs-in-germany" />
+
+<WatchlistCard owner="colophongroup" slug="big-tech-jobs-in-spain" />
+
+<h2 id="methodology">Metodologia</h2>
+
+- **Data dello snapshot.** Tutti i conteggi vengono da una singola query di facet su Typesense contro la nostra collection `job_posting_v1`, il 7 maggio 2026 verso le 13:00 UTC. Il flag `is_active=true` viene impostato dal nostro crawler quando un annuncio è stato visto per l'ultima volta sulla sua sorgente entro le tolleranze di delisting (definite per ATS nella nostra [policy di indicizzazione](/it/how-we-index)).
+- **Definizione di engineering.** Annunci la cui catena di occupation normalizzata include uno tra: software-engineer (con i figli frontend, backend, fullstack, mobile, embedded, game, AI Engineer, Research Engineer), devops-engineer (varianti SRE, platform, cloud, release), qa-engineer, data-engineer, data-scientist, ml-engineer, data-analyst, data-annotator. L'ingegneria elettrica, meccanica e civile è taggata fuori dal dominio software/dati ed esclusa.
+- **« Remote-eligible ».** Un annuncio in cui il nostro array `location_types` normalizzato contiene `remote`. Circa il 28% di questi annunci porta anche un tag `onsite`, che leggiamo come « remote-eligible con accesso opzionale all'HQ » piuttosto che « solo remoto ». Una definizione strict-remote-only darebbe un numero più piccolo; usiamo la definizione larga perché corrisponde a ciò su cui un candidato può effettivamente candidarsi.
+- **Tagging della seniority.** Circa il 64% degli annunci remote engineering (2.767 su 4.338) porta un tag di seniority normalizzato. Le percentuali in questo post sono calcolate come quota dei 4.338 totali — quando diciamo « 0,7% Entry-Level », il numero assoluto (31) è solido, ma la percentuale assume che il 36% non taggato abbia una distribuzione di livello simile. Probabilmente pende verso Mid-Level (spesso non taggato), il che *rafforza* l'argomento dello squilibrio senior, non lo indebolisce.
+- **Riserva di copertura.** Il nostro indice copre 4.441 aziende. Non è un campione rappresentativo del mercato del lavoro globale: seguiamo deliberatamente aziende in Europa occidentale, Svizzera, e un sottoinsieme di datori di lavoro tech statunitensi, con i loro annunci di filiali globali quando la pagina carriere è monitorabile. La forma dei dati segue questa distorsione.
+- **La riga « Stati Uniti ».** Il conteggio US della tabella di geografia (2.277) è calcolato contro gli antenati `location_ids` nella nostra gerarchia di location — ogni annuncio taggato con una città USA, uno stato o « United States » stesso si arrampica. Le altre righe della tabella sono facet count diretti su `location_names`. La differenza conta qui perché gli annunci remote spesso taggano una città o uno stato USA invece della radice del paese.
+- **Snapshot, non trend.** Il `first_seen_at` più antico per un annuncio ancora attivo è il 9 marzo 2026. Annunci più vecchi possono esistere sulle sorgenti ma compaiono nel nostro indice solo dalla prima crawl-discovery. Da questo snapshot non facciamo affermazioni di tendenza. Nella stessa finestra di due mesi, 4.233 annunci remote-eligible di engineering si sono *chiusi* — il mercato si muove, non è fermo.
+- **Riproducibilità.** Ogni numero qui sopra è riproducibile con una singola richiesta Typesense `documents/search` contro la nostra collection `job_posting_v1`, con `filter_by` e `facet_by` adeguati. Lo schema è in `apps/crawler/src/typesense_schema.py` nel nostro [repository open source](https://github.com/colophon-group/jobseek).
+- **Cosa non è.** È uno snapshot di annunci *pubblicati*, non una misurazione di *headcount*, *assunzioni concrete* o strategia aziendale. Un'azienda può pubblicare molto e assumere poco, o pubblicare poco e crescere veloce. Quel che vedi qui è « cosa stanno pubblicizzando le pagine carriere ora » — utile per decidere dove candidarsi, meno utile per inferire cosa accade dentro.
+
+## Riferimenti
+
+Fonti esterne citate sopra:
+
+- **JLL.** *U.S. Office Market Dynamics, Q2 2025.* Il titolo « 54% delle Fortune 100 / dall'11% ». Pagina del rapporto: [jll.com/en-us/insights/us-office-market-dynamics](https://www.jll.com/en-us/insights/us-office-market-dynamics). Riassunto giornalistico: [Bisnow, « Majority of Employees at Fortune 100 Firms Now Have 5-Day Office Mandate »](https://www.bisnow.com/national/news/office/more-than-half-of-fortune-100-employees-are-in-office-full-time-130262).
+- **Amazon.** Andy Jassy, *« Update on Amazon return-to-office and manager-team ratio »*, 16 settembre 2024 — il memo che annuncia il mandato di cinque giorni in ufficio. [aboutamazon.com](https://www.aboutamazon.com/news/company-news/ceo-andy-jassy-latest-update-on-amazon-return-to-office-manager-team-ratio).
+- **Microsoft.** Mandato di 3 giorni in ufficio annunciato a settembre 2025, rollout per fasi a partire dal 23 febbraio 2026 (Puget Sound per primo). Copertura con dettaglio dalla fonte primaria: [GeekWire, « Microsoft's new RTO policy starts Feb. 23 »](https://www.geekwire.com/2026/microsofts-new-rto-policy-starts-feb-23-bringing-seattle-area-workers-back-3-days-a-week/).
+- **Consiglio UE.** *Direttiva (UE) 2023/970* del Parlamento europeo e del Consiglio sulla trasparenza retributiva, in vigore dal 6 giugno 2023; recepimento da parte degli Stati membri entro il 7 giugno 2026. L'articolo 5 è la clausola sulla retribuzione nell'annuncio di lavoro. [Testo ufficiale EUR-Lex](https://eur-lex.europa.eu/eli/dir/2023/970/oj/ita).
+- **Mandati Goldman Sachs / JPMorgan**: referenziati tramite il rapporto JLL Q2 2025 (sopra), che li nomina tra le aziende del Fortune 100 passate al mandato di cinque giorni nel primo trimestre 2025.
+
+Le leggi statali USA sulla trasparenza retributiva sono referenziate collettivamente (California SB 1162, New York Pay Transparency Law, Colorado Equal Pay for Equal Work Act, Washington SB 5761, Illinois HB 3129) e riassunte sulla pagina [Pay Equity dello US Department of Labor](https://www.dol.gov/agencies/wb/topics/equal-pay).

--- a/apps/web/src/content/blog/remote-engineering-jobs-2026.mdx
+++ b/apps/web/src/content/blog/remote-engineering-jobs-2026.mdx
@@ -1,0 +1,157 @@
+---
+title: "Where remote engineering still hires, May 2026"
+description: "JLL says 54% of the Fortune 100 are on full RTO. We monitor 4,400 careers pages directly. Here's where remote engineering still hires in May 2026."
+datePublished: "2026-05-07"
+author: "Viktor Shcherbakov"
+tags: ["data-analysis", "remote-work"]
+relatedCompanies: ["nvidia", "tether", "sezzle", "disney", "clickhouse", "netflix", "grafana-labs", "affirm", "veeva", "samsara", "oliver-wyman", "instacart", "cresta", "gitlab", "kraken", "accenture", "reddit", "clickup", "keeper-security", "twilio"]
+relatedWatchlists: ["colophongroup/big-tech-jobs-in-united-kingdom", "colophongroup/big-tech-jobs-in-germany", "colophongroup/big-tech-jobs-in-spain"]
+---
+
+A new piece of conventional wisdom landed in 2025: remote work is over. JLL's Q2 2025 [US Office Market Dynamics report](https://www.jll.com/en-us/insights/us-office-market-dynamics) had the headline number: 54% of Fortune 100 employees subject to full-week office requirements, up from 11% the year before. <Company slug="microsoft" /> [rolled out](https://www.geekwire.com/2026/microsofts-new-rto-policy-starts-feb-23-bringing-seattle-area-workers-back-3-days-a-week/) a 3-day-in-office mandate. <Company slug="amazon" /> [went all the way to 5](https://www.aboutamazon.com/news/company-news/ceo-andy-jassy-latest-update-on-amazon-return-to-office-manager-team-ratio). <Company slug="goldman-sachs" /> and <Company slug="jpmorgan" /> followed. The trade press did the rest.
+
+But the Fortune 100 are 100 employers. We monitor 4,441 of them. Across that index, on the morning of May 7 2026, 4,338 of the 89,517 active engineering postings are tagged remote-eligible. That's 4.8%: a number small enough to confirm the headline ("most jobs are onsite"), big enough to deserve a list of names ("but here are the thousands that aren't"). This is that list.
+
+<figure className="share-bar" aria-label="Engineering postings by location type: 89.3% onsite, 4.8% remote, 4.3% hybrid, 1.6% untagged">
+  <svg viewBox="0 0 600 36" preserveAspectRatio="none" role="presentation" aria-hidden="true">
+    <rect x="0" y="0" width="535.8" height="36" className="seg-onsite" />
+    <rect x="535.8" y="0" width="28.8" height="36" className="seg-remote" />
+    <rect x="564.6" y="0" width="25.8" height="36" className="seg-hybrid" />
+    <rect x="590.4" y="0" width="9.6" height="36" className="seg-untagged" />
+  </svg>
+  <figcaption>
+    <span><span className="swatch seg-onsite" />Onsite 89.3%</span>
+    <span><span className="swatch seg-remote" />Remote 4.8%</span>
+    <span><span className="swatch seg-hybrid" />Hybrid 4.3%</span>
+    <span><span className="swatch seg-untagged" />Untagged 1.6%</span>
+  </figcaption>
+</figure>
+
+## Who's still hiring
+
+Twenty companies account for about a third of all currently-listed remote-eligible engineering roles in our index.
+
+| Company | Active remote engineering postings |
+|---|---:|
+| <Company slug="nvidia" /> | 174 |
+| <Company slug="tether" /> | 117 |
+| <Company slug="sezzle" /> | 106 |
+| <Company slug="disney" /> | 99 |
+| <Company slug="clickhouse" /> | 81 |
+| <Company slug="netflix" /> | 78 |
+| <Company slug="grafana-labs" /> | 77 |
+| <Company slug="affirm" /> | 61 |
+| <Company slug="veeva" /> | 45 |
+| <Company slug="samsara" /> | 43 |
+| <Company slug="oliver-wyman" /> | 43 |
+| <Company slug="instacart" /> | 42 |
+| <Company slug="cresta" /> | 41 |
+| <Company slug="gitlab" /> | 39 |
+| <Company slug="kraken" /> | 38 |
+| <Company slug="accenture" /> | 38 |
+| <Company slug="reddit" /> | 36 |
+| <Company slug="clickup" /> | 34 |
+| <Company slug="keeper-security" /> | 34 |
+| <Company slug="twilio" /> | 33 |
+
+A few patterns stand out. Crypto and payments infrastructure is well-represented (<Company slug="tether" />, <Company slug="kraken" />, <Company slug="sezzle" />, <Company slug="affirm" />), as are the open-source and devtools shops (<Company slug="clickhouse" />, <Company slug="grafana-labs" />, <Company slug="gitlab" />). <Company slug="nvidia" />, <Company slug="netflix" />, <Company slug="reddit" />, and <Company slug="pinterest" /> (just outside the top 20) are big-tech names whose remote-friendly hiring posture doesn't get the press coverage that <Company slug="microsoft" /> and <Company slug="amazon" />'s RTO mandates do. Mid-market SaaS rounds it out: <Company slug="twilio" />, <Company slug="instacart" />, <Company slug="clickup" />, <Company slug="samsara" />. One name most candidates wouldn't think to check: <Company slug="oliver-wyman" />, a management consultancy with 43 remote engineering roles — a real internal-tech footprint hiding inside a category nobody thinks of as remote-friendly.
+
+What's *not* on the list is also a story. None of the headline RTO mandators we named in the lede — <Company slug="microsoft" />, <Company slug="amazon" />, <Company slug="goldman-sachs" />, <Company slug="jpmorgan" /> — carry meaningful remote engineering listings in our index. The mandates and the postings agree.
+
+## The geography
+
+Remote isn't location-free. Postings still tag a hiring jurisdiction (timezone bands, work-eligibility, or a payroll entity). Across the 4,338 remote-eligible engineering postings, the distribution of those tags:
+
+| Region | Postings |
+|---|---:|
+| United States | 2,277 |
+| Canada | 431 |
+| United Kingdom | 259 |
+| Spain | 218 |
+| India | 189 |
+| Poland | 184 |
+| Germany | 164 |
+| Ireland | 146 |
+| Brazil | 132 |
+| Mexico | 130 |
+| Argentina | 121 |
+
+The top of the table is what you'd expect: the US plus the EU pay-transparency belt. The interesting part is the *contrast* with the rest of the engineering market.
+
+Our index has an India-heavy gravitational center for engineering. Bengaluru alone has 16,941 active engineering postings, more than New York and San Francisco combined. **Of those 16,941, just 67 are remote-eligible.** That's 0.4%. Hyderabad, Pune, Chennai are similar. Indian engineering hiring is fundamentally an onsite market: the big global tech employers post heavily there, and they post for desks.
+
+The corollary is that remote-eligible engineering isn't competing with the global engineering labor market. It's competing with the slice that happens to be tagged for North American or Western European hiring.
+
+## The seniority skew
+
+Of the 4,338 remote-eligible engineering roles, **1,995 (46%) are tagged Senior**, another 11% are Staff, 3% Principal, 2% Lead. About 62% of the sample is gated at senior+ levels. **Entry-level roles are 0.7%: 31 listings out of 4,338.** Internships are 0.5%.
+
+The narrative for years was that remote work would democratize entry-level access to better employers. The data says the opposite is happening. Remote is consolidating around employees a company can already trust to operate without supervision. If you're under 2 years of experience and looking for a remote-first entry-level role in our data, you have approximately 31 listings to apply to, against a backdrop of more than 89,000 engineering openings overall.
+
+31 against more than 89,000. Worth knowing before you build a search strategy.
+
+## What stack is being asked for
+
+The skills profile of remote engineering is recognizable, and a little narrower than overall engineering hiring. The percentage of the 4,338 remote-eligible postings that mention each technology:
+
+| Skill | Share of remote eng postings |
+|---|---:|
+| Python | 49% |
+| AWS | 37% |
+| Kubernetes | 27% |
+| SQL | 24% |
+| React | 23% |
+| TypeScript | 22% |
+| Java | 19% |
+| Google Cloud | 18% |
+| Docker | 16% |
+| PostgreSQL | 16% |
+| Terraform | 14% |
+
+This is the cloud-native, Python-and-typed-JavaScript stack: the one that lends itself to async work across timezones. Embedded engineering is sparse, low-level systems are sparse, game development is sparser still. C++ shows up in 10% of postings; Go in 7%; Rust in 6%. Things that need a lab bench, a graphics card on the desk, or a co-located ops team aren't what's getting advertised remote.
+
+If you're optimizing your skills for remote employability, the table above is the one to optimize against.
+
+## Salary transparency
+
+**31% of remote engineering postings in our index include a parseable salary range. For onsite engineering, that figure is 14%.** Remote postings are roughly twice as transparent.
+
+The reason isn't that remote-friendly companies are more virtuous. It's geographic concentration. US states with pay-transparency laws (California, New York, Colorado, Washington, Illinois) and the [EU Pay Transparency Directive 2023/970](https://eur-lex.europa.eu/eli/dir/2023/970/oj/eng) (member-state transposition due June 7 2026) are exactly where remote engineering is most concentrated. The same reason a posting is remote-tagged is a major reason it's also salary-tagged.
+
+If you want comp upfront, the remote-eligible slice of our index is twice as likely to give it to you on the first read.
+
+## What to do with this list
+
+The dataset behind this post is the dataset behind the search. The [explore page](/en/explore) lets you filter on remote directly and combine with seniority, salary band, and stack — then save the search as your own watchlist. That's the path we'd take if we were the reader.
+
+Three of the country watchlists we maintain happen to sit on top of where the EU remote slice concentrates — UK, Germany, Spain (top three EU geographies in the table above). They include onsite roles too, but they're the closest pre-built lenses on the data that backs this post.
+
+<WatchlistCard owner="colophongroup" slug="big-tech-jobs-in-united-kingdom" />
+
+<WatchlistCard owner="colophongroup" slug="big-tech-jobs-in-germany" />
+
+<WatchlistCard owner="colophongroup" slug="big-tech-jobs-in-spain" />
+
+<h2 id="methodology">Methodology</h2>
+
+- **Snapshot date.** All counts come from a single Typesense facet query against our `job_posting_v1` collection on May 7 2026 at ~13:00 UTC. The `is_active=true` flag is set by our crawler when a posting was last seen on its source board within delisting tolerances (defined per-ATS in our [indexing policy](/en/how-we-index)).
+- **Engineering definition.** Postings whose normalized occupation lineage includes any of: software-engineer (with children frontend, backend, fullstack, mobile, embedded, game, AI engineer, research engineer), devops-engineer (with SRE, platform, cloud, release variants), qa-engineer, data-engineer, data-scientist, ml-engineer, data-analyst, data-annotator. Electrical, mechanical, and civil engineering are tagged outside the software/data domain and excluded.
+- **"Remote-eligible".** A posting where our normalized `location_types` array contains `remote`. About 28% of those postings also carry an `onsite` tag, which we read as "remote-eligible with optional HQ access" rather than "remote-only." Strict-remote-only would be a smaller number; we use the broader definition because it matches what a job seeker can actually apply to.
+- **Seniority tagging.** About 64% of remote engineering postings (2,767 of 4,338) carry a normalized seniority tag. Percentages in this post are computed as a share of the full 4,338 — so when we say "0.7% entry-level," the absolute count (31) is firm but the percentage assumes that the 36% of untagged postings have a similar level distribution. They probably skew mid-level (which often goes untagged), which would *strengthen* the senior-skew claim, not weaken it.
+- **Coverage caveat.** Our index is 4,441 companies. It is not a representative sample of the global labor market: we deliberately track companies in Western Europe, Switzerland, and selected US tech employers, with their global subsidiaries' postings included where the careers page is monitorable. The shape of the data follows that bias.
+- **The "United States" row.** The geography table's US count (2,277) is computed against `location_ids` ancestors in our location hierarchy — every posting tagged with a US city, state, or "United States" itself rolls up. The other rows in the table are facet counts on `location_names` directly. The difference matters here because remote postings often tag a US state or city rather than the country root.
+- **Snapshot, not trend.** Our crawler's earliest `first_seen_at` for a still-active posting is March 9 2026. Postings older than that may exist on source boards but only appear in our index from their first crawl-discovery onwards. We make no trend claims based on this snapshot. During the same 2-month window, 4,233 remote-eligible engineering postings have *closed* — the market is churning, not stagnant.
+- **Reproducibility.** Every count above can be reproduced with a single Typesense `documents/search` request against our `job_posting_v1` collection with appropriate `filter_by` and `facet_by` parameters. The schema lives at `apps/crawler/src/typesense_schema.py` in our [open-source repository](https://github.com/colophon-group/jobseek).
+- **What this isn't.** This is a snapshot of *advertised* postings, not a measurement of *headcount*, *fills*, or company strategy. A company can post heavy and hire light, post light and grow fast. The picture here is "what do their careers pages currently advertise" — useful for figuring out where to apply, less useful for inferring what's happening inside.
+
+## References
+
+External sources cited above:
+
+- **JLL.** *U.S. Office Market Dynamics, Q2 2025.* The "54% of Fortune 100 / up from 11%" headline. Report landing page: [jll.com/en-us/insights/us-office-market-dynamics](https://www.jll.com/en-us/insights/us-office-market-dynamics). Summary coverage: [Bisnow, "Majority of Employees at Fortune 100 Firms Now Have 5-Day Office Mandate"](https://www.bisnow.com/national/news/office/more-than-half-of-fortune-100-employees-are-in-office-full-time-130262).
+- **Amazon.** Andy Jassy, *"Update on Amazon return-to-office and manager-team ratio,"* September 16 2024 — the memo announcing the five-day-in-office mandate. [aboutamazon.com](https://www.aboutamazon.com/news/company-news/ceo-andy-jassy-latest-update-on-amazon-return-to-office-manager-team-ratio).
+- **Microsoft.** Three-day-in-office mandate announced September 2025, phased rollout starting February 23 2026 (Puget Sound first). Coverage with primary-source detail: [GeekWire, "Microsoft's new RTO policy starts Feb. 23"](https://www.geekwire.com/2026/microsofts-new-rto-policy-starts-feb-23-bringing-seattle-area-workers-back-3-days-a-week/).
+- **EU Council.** *Directive (EU) 2023/970* of the European Parliament and Council on pay transparency, in force June 6 2023; member-state transposition deadline June 7 2026. Article 5 is the salary-in-job-vacancy clause. [EUR-Lex official text](https://eur-lex.europa.eu/eli/dir/2023/970/oj/eng).
+- **Goldman Sachs / JPMorgan five-day-office mandates** are referenced via JLL's Q2 2025 report (above), which names them among Fortune 100 firms that moved to five-day mandates in the first quarter of 2025.
+
+US state pay-transparency laws referenced collectively (California SB 1162, New York Pay Transparency Law, Colorado Equal Pay for Equal Work Act, Washington SB 5761, Illinois HB 3129) are summarized at the [US Department of Labor's Pay Equity resources](https://www.dol.gov/agencies/wb/topics/equal-pay).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -238,6 +238,9 @@ importers:
       react-dom:
         specifier: ^19
         version: 19.2.4(react@19.2.4)
+      remark-gfm:
+        specifier: ^4.0.0
+        version: 4.0.1
       resend:
         specifier: ^6.9.2
         version: 6.9.2
@@ -3756,6 +3759,10 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
+
   escodegen@2.1.0:
     resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
     engines: {node: '>=6.0'}
@@ -4505,12 +4512,36 @@ packages:
     resolution: {integrity: sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q==}
     engines: {node: '>=16'}
 
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
   mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
 
   mdast-util-mdx-expression@2.0.1:
     resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
@@ -4559,6 +4590,27 @@ packages:
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
 
   micromark-extension-mdx-expression@3.0.1:
     resolution: {integrity: sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q==}
@@ -5072,6 +5124,9 @@ packages:
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
 
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
   remark-mdx@3.1.1:
     resolution: {integrity: sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg==}
 
@@ -5080,6 +5135,9 @@ packages:
 
   remark-rehype@11.1.2:
     resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -8554,7 +8612,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.11)(@vitest/ui@4.0.18)(happy-dom@20.8.9)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.17)(@vitest/ui@4.0.18)(happy-dom@20.8.9)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)(yaml@2.8.3)
 
   '@vitest/utils@4.0.18':
     dependencies:
@@ -9349,6 +9407,8 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  escape-string-regexp@5.0.0: {}
+
   escodegen@2.1.0:
     dependencies:
       esprima: 4.0.1
@@ -10083,7 +10143,16 @@ snapshots:
 
   markdown-extensions@2.0.0: {}
 
+  markdown-table@3.0.4: {}
+
   math-intrinsics@1.1.0: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   mdast-util-from-markdown@2.0.3:
     dependencies:
@@ -10099,6 +10168,63 @@ snapshots:
       micromark-util-symbol: 2.0.1
       micromark-util-types: 2.0.2
       unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -10213,6 +10339,64 @@ snapshots:
       micromark-util-resolve-all: 2.0.1
       micromark-util-subtokenize: 2.1.0
       micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
       micromark-util-types: 2.0.2
 
   micromark-extension-mdx-expression@3.0.1:
@@ -10848,6 +11032,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
   remark-mdx@3.1.1:
     dependencies:
       mdast-util-mdx: 3.0.0
@@ -10871,6 +11066,12 @@ snapshots:
       mdast-util-to-hast: 13.2.1
       unified: 11.0.5
       vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   require-from-string@2.0.2: {}
 


### PR DESCRIPTION
## Summary
- New data post **"Where remote engineering still hires, May 2026"** — snapshot of the 4,338 remote-eligible engineering postings (4.8% of 89,517) across our 4,441-company index, with top-20 employer mention-pill table, geography contrast (the Bengaluru-vs-US split), seniority skew (0.7% entry-level), stack signature, salary-transparency 2x lift, EU-country watchlist CTAs, and a References section with primary-source links (JLL Q2 2025 Office Market Dynamics, Andy Jassy memo, Microsoft RTO announcement, EU Directive 2023/970)
- EN canonical + DE/FR/IT translations
- Wired `remark-gfm` into the blog `compileMDX` pipeline so markdown tables render (the `.blog-post table` CSS already anticipated them)
- Added a chart palette (`--chart-bar-dominant/accent/mid/faint`) in light + dark themes, used by an inline `figure.share-bar` for the hero data viz; CSS in globals.css

## Critic-review cycle
Ran the mandatory three reviewers per `apps/web/src/content/blog/README.md`:
- **Cold reader (round 2):** SHIP — minor phrasing fixes applied
- **Fact-checker (round 2):** SHIP — every count reproduces against live Typesense; one number off in round 1 (Go 12% → 7%) corrected
- **Editorial (round 1):** PUBLISH AFTER MINOR EDITS — all applied

## Test plan
- [x] `pnpm exec tsc --noEmit` passes (per Vercel-strict-tsc memory)
- [x] Pre-commit hooks pass (ESLint web, Lingui translation coverage)
- [x] Visual verification in both light + dark mode via Playwright screenshots — hero share-bar, top-20 table, geography contrast, seniority section, stack table, watchlist cards, methodology, references all render
- [x] All 4 locale URLs return 200 + valid `Article` JSON-LD + working `#methodology` anchor
- [x] OG image renders 1200×630 PNG
- [x] Mention pill slugs verified to resolve (28 companies, 3 watchlists)
- [x] Inline reference URLs verified to return 200 (one DOL link is Akamai-protected, real for human readers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)