### PR TITLE
feat(seo): IndexNow submission for blog posts (closes #2843)

### DIFF
--- a/.github/workflows/notify-blog-indexnow.yml
+++ b/.github/workflows/notify-blog-indexnow.yml
@@ -1,0 +1,69 @@
+name: Notify IndexNow on blog content changes
+
+# Submits blog post URLs to IndexNow (Bing/Yandex/Seznam/Naver/Yep)
+# whenever an MDX file under `apps/web/src/content/blog/` lands on
+# `main`. Per-post locales come from the same `getBlogPostLocales(slug)`
+# helper the sitemap and page hreflang use, so we never push engines
+# at locale variants that don't exist on disk.
+#
+# IndexNow accepts re-submitted URLs without churn — this fires on
+# every content commit, not just on first publish, and that's fine.
+# Re-submitting the same URL is a "please recrawl" signal, not a
+# duplicate. See docs/13-seo-and-indexnow.md.
+#
+# Vercel race: pushing to main triggers a Vercel prod deploy in
+# parallel. If we POST to IndexNow before Vercel's deploy completes,
+# engines get a brief 404 window on a brand-new post (translated MDX
+# file added in the same commit). The 5-minute pre-submit sleep lets
+# most prod deploys finish (the app's typical build is 2–5 min;
+# slower builds have a 1–7 day engine retry cushion to forgive the
+# initial 404). Re-submission on the next blog commit re-pings the
+# URL anyway.
+#
+# Why a separate workflow vs piggybacking on a deploy hook: keeps the
+# secret scope narrow (only this workflow needs INDEXNOW_KEY in the
+# Actions runner; Vercel env stays the source of truth for the
+# request-handler watchlist notifier). Also lets the path filter run
+# at action-dispatch time so a runner doesn't even spin up unless
+# blog content actually changed.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/web/src/content/blog/**/*.mdx'
+  workflow_dispatch:
+
+concurrency:
+  group: notify-blog-indexnow-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  notify:
+    name: Submit blog URLs to IndexNow
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Wait for Vercel prod deploy to settle
+        # Crude but reliable: app prod builds typically finish in
+        # 2–5 minutes, and 300s is well inside the engine retry
+        # cushion if we still race a long build. A more precise
+        # signal would be polling Vercel's deployment-succeeded
+        # webhook; not worth the plumbing for a 1–7-day-cadence
+        # signal.
+        run: sleep 300
+
+      - name: Submit blog post URLs
+        env:
+          INDEXNOW_KEY: ${{ secrets.INDEXNOW_KEY }}
+        run: pnpm --filter @jobseek/web notify-blog-indexnow

--- a/.github/workflows/notify-blog-indexnow.yml
+++ b/.github/workflows/notify-blog-indexnow.yml
@@ -42,6 +42,14 @@ jobs:
   notify:
     name: Submit blog URLs to IndexNow
     runs-on: ubuntu-latest
+    # `INDEXNOW_KEY` lives at the Production environment scope (alongside
+    # DATABASE_URL, R2_*, etc. — see `gh api repos/.../environments/`
+    # `Production/secrets`). Without this declaration `secrets.INDEXNOW_KEY`
+    # resolves to empty, the script's `if (!INDEXNOW_KEY)` short-circuits,
+    # and submissions silently no-op. Every other prod-secret consumer in
+    # this repo declares the same — see deploy-crawler-browser.yml,
+    # deploy-murmur-shim.yml, crawler-scheduled-maintenance.yml.
+    environment: production
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,7 +194,7 @@ cd apps/crawler && uv run python ../../scripts/typesense-backfill-local.py [--li
 
 ## SEO and IndexNow
 
-`/{locale}/company/{slug}` is now `noindex,follow` (#2821) — pages stay as the in-app product surface but are excluded from the sitemap. The crawler-side IndexNow notifier (which only ever covered company URLs) was retired in the same PR. Watchlist-side IndexNow notification from web server actions via `after()` remains active for the qualifying-watchlist surface (#2823); full IndexNow phase-out tracked in #2843.
+`/{locale}/company/{slug}` is now `noindex,follow` (#2821) — pages stay as the in-app product surface but are excluded from the sitemap. The crawler-side IndexNow notifier (which only ever covered company URLs) was retired in the same PR. Watchlist-side IndexNow notification from web server actions via `after()` remains active for the qualifying-watchlist surface (#2823). Blog post URLs are pushed to IndexNow by `.github/workflows/notify-blog-indexnow.yml` on every blog content commit (see `apps/web/script/notify-blog-indexnow.ts`).
 
 See [docs/13-seo-and-indexnow.md](docs/13-seo-and-indexnow.md).
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "analyze": "ANALYZE=true next build",
     "optimize:svg": "svgo public/*.svg --multipass",
     "screenshots": "tsx script/capture-screenshots.ts",
+    "notify-blog-indexnow": "tsx script/notify-blog-indexnow.ts",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "next typegen && tsc"

--- a/apps/web/script/notify-blog-indexnow.ts
+++ b/apps/web/script/notify-blog-indexnow.ts
@@ -1,0 +1,59 @@
+/**
+ * Submit every published blog post URL to IndexNow (#2843, scope-amended
+ * comment: "add notifications of blog posts"). Used as a deploy-time
+ * hook from `.github/workflows/notify-blog-indexnow.yml`.
+ *
+ * Per-post, the post's `getBlogPostLocales(slug)` is the source of
+ * truth for which locale variants exist on disk. We submit only those
+ * locales — same restriction the sitemap uses (#2828) and the page
+ * `<head>` hreflang map uses (#2849), so engines never get pointed
+ * at locale variants that fall back to the EN canonical body.
+ *
+ * Idempotency: re-running on a deploy where no MDX file changed is
+ * harmless — IndexNow tolerates re-submission of the same URL
+ * (engines dedupe their re-fetch behavior on the receiving side).
+ * The only cost is one HTTP POST per run.
+ *
+ * No-op when `INDEXNOW_KEY` is unset (`notifyIndexNow` short-circuits
+ * on missing env). Errors are caught and logged inside
+ * `notifyIndexNow`; the script always exits 0 unless a blog read
+ * itself errors. Crawlers re-fetch the sitemap on a 1–7 day cadence
+ * so a missed submission isn't catastrophic.
+ *
+ * Run with:
+ *   pnpm --filter @jobseek/web exec tsx script/notify-blog-indexnow.ts
+ */
+
+import { notifyIndexNow } from "../src/lib/indexnow";
+import { listBlogPosts, getBlogPostLocales } from "../src/lib/blog";
+
+async function main(): Promise<void> {
+  if (!process.env.INDEXNOW_KEY) {
+    console.log("[notify-blog-indexnow] INDEXNOW_KEY unset — exiting no-op");
+    return;
+  }
+
+  const posts = await listBlogPosts();
+  if (posts.length === 0) {
+    console.log("[notify-blog-indexnow] no posts found — exiting no-op");
+    return;
+  }
+
+  for (const post of posts) {
+    const localesForPost = await getBlogPostLocales(post.slug);
+    if (localesForPost.length === 0) {
+      console.log(`[notify-blog-indexnow] ${post.slug} has no translation files — skipping`);
+      continue;
+    }
+    await notifyIndexNow([`/blog/${post.slug}`], localesForPost);
+    console.log(
+      `[notify-blog-indexnow] submitted /blog/${post.slug} (locales: ${localesForPost.join(", ")})`,
+    );
+  }
+  console.log(`[notify-blog-indexnow] done — submitted ${posts.length} post(s)`);
+}
+
+main().catch((err) => {
+  console.error("[notify-blog-indexnow] failed", err);
+  process.exit(1);
+});

--- a/apps/web/script/notify-blog-indexnow.ts
+++ b/apps/web/script/notify-blog-indexnow.ts
@@ -39,16 +39,45 @@ async function main(): Promise<void> {
     return;
   }
 
+  // Track per-post failures so we can fail the workflow loudly. The
+  // catch inside `notifyIndexNow` swallows network/HTTP errors so
+  // existing watchlist `after()` callers stay fire-and-forget — script
+  // mode reads the result envelope and turns rejections into a
+  // non-zero exit. Without this, a revoked INDEXNOW_KEY or a Bing
+  // policy change would silently kill the signal for weeks.
+  const failures: string[] = [];
   for (const post of posts) {
     const localesForPost = await getBlogPostLocales(post.slug);
     if (localesForPost.length === 0) {
       console.log(`[notify-blog-indexnow] ${post.slug} has no translation files — skipping`);
       continue;
     }
-    await notifyIndexNow([`/blog/${post.slug}`], localesForPost);
-    console.log(
-      `[notify-blog-indexnow] submitted /blog/${post.slug} (locales: ${localesForPost.join(", ")})`,
+    const result = await notifyIndexNow([`/blog/${post.slug}`], localesForPost);
+    switch (result.kind) {
+      case "submitted":
+        console.log(
+          `[notify-blog-indexnow] submitted /blog/${post.slug} status=${result.status} urls=${result.urlCount} (locales: ${localesForPost.join(", ")})`,
+        );
+        break;
+      case "skipped":
+        console.log(
+          `[notify-blog-indexnow] /blog/${post.slug} skipped (${result.reason})`,
+        );
+        break;
+      case "rejected":
+        failures.push(`/blog/${post.slug} → ${result.status}`);
+        break;
+      case "errored":
+        failures.push(`/blog/${post.slug} → ${String(result.error)}`);
+        break;
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error(
+      `[notify-blog-indexnow] ${failures.length} failure(s):\n  ${failures.join("\n  ")}`,
     );
+    process.exit(1);
   }
   console.log(`[notify-blog-indexnow] done — submitted ${posts.length} post(s)`);
 }

--- a/apps/web/src/lib/__tests__/indexnow.test.ts
+++ b/apps/web/src/lib/__tests__/indexnow.test.ts
@@ -24,13 +24,15 @@ afterEach(() => {
 describe("notifyIndexNow", () => {
   it("no-ops when INDEXNOW_KEY is unset", async () => {
     delete process.env.INDEXNOW_KEY;
-    await notifyIndexNow(["/foo"]);
+    const result = await notifyIndexNow(["/foo"]);
+    expect(result).toEqual({ kind: "skipped", reason: "no-key" });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("no-ops when paths is empty", async () => {
     process.env.INDEXNOW_KEY = "test-key";
-    await notifyIndexNow([]);
+    const result = await notifyIndexNow([]);
+    expect(result).toEqual({ kind: "skipped", reason: "no-paths" });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -92,21 +94,30 @@ describe("notifyIndexNow", () => {
     expect(errSpy).not.toHaveBeenCalled();
   });
 
-  it("logs (does not throw) when the endpoint rejects with 4xx", async () => {
+  it("returns rejected (does not throw) when the endpoint rejects with 4xx", async () => {
     process.env.INDEXNOW_KEY = "test-key";
     fetchMock.mockResolvedValue(new Response("bad key", { status: 403 }));
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    await expect(notifyIndexNow(["/foo"])).resolves.toBeUndefined();
+    const result = await notifyIndexNow(["/foo"]);
+    expect(result).toEqual({ kind: "rejected", status: 403, urlCount: 4 });
     expect(errSpy).toHaveBeenCalledOnce();
     expect(String(errSpy.mock.calls[0][0])).toContain("403");
   });
 
-  it("logs (does not throw) on network errors", async () => {
+  it("returns errored (does not throw) on network errors", async () => {
     process.env.INDEXNOW_KEY = "test-key";
-    fetchMock.mockRejectedValue(new Error("ECONNRESET"));
+    const networkErr = new Error("ECONNRESET");
+    fetchMock.mockRejectedValue(networkErr);
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    await expect(notifyIndexNow(["/foo"])).resolves.toBeUndefined();
+    const result = await notifyIndexNow(["/foo"]);
+    expect(result).toEqual({ kind: "errored", error: networkErr, urlCount: 4 });
     expect(errSpy).toHaveBeenCalledOnce();
+  });
+
+  it("returns submitted with the URL count on a 200 response", async () => {
+    process.env.INDEXNOW_KEY = "test-key";
+    const result = await notifyIndexNow(["/foo"]);
+    expect(result).toEqual({ kind: "submitted", status: 200, urlCount: 4 });
   });
 
   it("restricts locale fan-out when availableLocales is provided (#2843, blog)", async () => {
@@ -130,7 +141,8 @@ describe("notifyIndexNow", () => {
 
   it("no-ops when availableLocales is an empty array (defensive)", async () => {
     process.env.INDEXNOW_KEY = "test-key";
-    await notifyIndexNow(["/blog/no-locales"], []);
+    const result = await notifyIndexNow(["/blog/no-locales"], []);
+    expect(result).toEqual({ kind: "skipped", reason: "no-locales" });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/lib/__tests__/indexnow.test.ts
+++ b/apps/web/src/lib/__tests__/indexnow.test.ts
@@ -109,6 +109,31 @@ describe("notifyIndexNow", () => {
     expect(errSpy).toHaveBeenCalledOnce();
   });
 
+  it("restricts locale fan-out when availableLocales is provided (#2843, blog)", async () => {
+    process.env.INDEXNOW_KEY = "test-key";
+    await notifyIndexNow(["/blog/welcome"], ["en", "de"]);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.urlList).toEqual([
+      "https://jseek.co/en/blog/welcome",
+      "https://jseek.co/de/blog/welcome",
+    ]);
+    expect(body.urlList).not.toContain("https://jseek.co/fr/blog/welcome");
+    expect(body.urlList).not.toContain("https://jseek.co/it/blog/welcome");
+  });
+
+  it("emits a single locale URL for an EN-only post", async () => {
+    process.env.INDEXNOW_KEY = "test-key";
+    await notifyIndexNow(["/blog/en-only"], ["en"]);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.urlList).toEqual(["https://jseek.co/en/blog/en-only"]);
+  });
+
+  it("no-ops when availableLocales is an empty array (defensive)", async () => {
+    process.env.INDEXNOW_KEY = "test-key";
+    await notifyIndexNow(["/blog/no-locales"], []);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("does not import next/server (caller owns after() wrapping)", () => {
     // Structural regression guard. The original bug was that
     // notifyIndexNow called after() internally, which silently failed

--- a/apps/web/src/lib/indexnow.ts
+++ b/apps/web/src/lib/indexnow.ts
@@ -44,15 +44,29 @@ const INDEXNOW_ENDPOINT = "https://api.indexnow.org/indexnow";
  *                         pages); pass a subset for routes whose
  *                         hreflang map is per-call.
  */
+/**
+ * Result envelope returned by `notifyIndexNow`. Existing watchlist
+ * call sites ignore the return (fire-and-forget inside `after()`);
+ * the blog deploy-hook script reads it to fail the workflow on a
+ * non-2xx submission so we get an actionable signal instead of a
+ * silent stderr line in a stack we never read.
+ */
+export type NotifyIndexNowResult =
+  | { kind: "submitted"; urlCount: number; status: number }
+  | { kind: "skipped"; reason: "no-key" | "no-paths" | "no-locales" | "no-urls" }
+  | { kind: "rejected"; status: number; urlCount: number }
+  | { kind: "errored"; error: unknown; urlCount: number };
+
 export async function notifyIndexNow(
   paths: string[],
   availableLocales?: readonly Locale[],
-): Promise<void> {
+): Promise<NotifyIndexNowResult> {
   const key = process.env.INDEXNOW_KEY;
-  if (!key || paths.length === 0) return;
+  if (!key) return { kind: "skipped", reason: "no-key" };
+  if (paths.length === 0) return { kind: "skipped", reason: "no-paths" };
 
   const targetLocales = availableLocales ?? locales;
-  if (targetLocales.length === 0) return;
+  if (targetLocales.length === 0) return { kind: "skipped", reason: "no-locales" };
 
   const urlList: string[] = [];
   for (const path of paths) {
@@ -64,7 +78,7 @@ export async function notifyIndexNow(
 
   // Dedupe and cap at the protocol limit (10k per request).
   const unique = [...new Set(urlList)].slice(0, 10_000);
-  if (unique.length === 0) return;
+  if (unique.length === 0) return { kind: "skipped", reason: "no-urls" };
 
   const payload = {
     host: siteConfig.domain,
@@ -84,9 +98,12 @@ export async function notifyIndexNow(
       console.error(
         `[indexnow] submission rejected (${res.status}) for ${unique.length} urls`,
       );
+      return { kind: "rejected", status: res.status, urlCount: unique.length };
     }
+    return { kind: "submitted", status: res.status, urlCount: unique.length };
   } catch (err) {
     console.error("[indexnow] submission failed", err);
+    return { kind: "errored", error: err, urlCount: unique.length };
   }
 }
 

--- a/apps/web/src/lib/indexnow.ts
+++ b/apps/web/src/lib/indexnow.ts
@@ -1,15 +1,22 @@
 import { siteConfig } from "@/content/config";
-import { locales } from "@/lib/i18n";
+import { type Locale, locales } from "@/lib/i18n";
 
 const INDEXNOW_ENDPOINT = "https://api.indexnow.org/indexnow";
 
 /**
  * Submit one or more app paths to IndexNow.
  *
- * Each path is expanded to every supported locale prefix — a single
- * user-facing mutation covers all hreflang alternates. A single POST
- * to `api.indexnow.org` propagates to Bing, Yandex, Seznam, Naver, and
- * Microsoft Yep. Google does not participate in IndexNow.
+ * Each path is expanded to every locale in `availableLocales` (default:
+ * all four supported locales). Pass a per-call subset for partially-
+ * translated routes — blog posts whose `getBlogPostLocales(slug)` is a
+ * proper subset of `locales`, for example — so engines aren't pointed
+ * at locale variants that 404 (or worse, serve the canonical body
+ * under a foreign-locale URL: an "alternate page with proper canonical
+ * tag" cluster).
+ *
+ * A single POST to `api.indexnow.org` propagates to Bing, Yandex,
+ * Seznam, Naver, and Microsoft Yep. Google does not participate in
+ * IndexNow.
  *
  * **Caller contract**: this function awaits its fetch directly. In a
  * Vercel server action / route handler, the caller should invoke it
@@ -29,16 +36,28 @@ const INDEXNOW_ENDPOINT = "https://api.indexnow.org/indexnow";
  * without the secret) or when `paths` is empty. All errors are caught
  * and logged — callers must never observe failures.
  *
- * @param paths Locale-less app paths, e.g. ["/user/watchlist-slug"].
+ * @param paths Locale-less app paths, e.g. `["/user/watchlist-slug"]`
+ *              or `["/blog/welcome-to-the-job-seek-blog"]`.
+ * @param availableLocales Restrict the locale fan-out for these paths.
+ *                         Defaults to every supported locale (correct
+ *                         for fully-translated surfaces like watchlist
+ *                         pages); pass a subset for routes whose
+ *                         hreflang map is per-call.
  */
-export async function notifyIndexNow(paths: string[]): Promise<void> {
+export async function notifyIndexNow(
+  paths: string[],
+  availableLocales?: readonly Locale[],
+): Promise<void> {
   const key = process.env.INDEXNOW_KEY;
   if (!key || paths.length === 0) return;
+
+  const targetLocales = availableLocales ?? locales;
+  if (targetLocales.length === 0) return;
 
   const urlList: string[] = [];
   for (const path of paths) {
     const encoded = encodePath(path);
-    for (const locale of locales) {
+    for (const locale of targetLocales) {
       urlList.push(`${siteConfig.url}/${locale}${encoded}`);
     }
   }

--- a/docs/13-seo-and-indexnow.md
+++ b/docs/13-seo-and-indexnow.md
@@ -141,6 +141,18 @@ Implementation:
 - No-op if `process.env.INDEXNOW_KEY` is unset (safe locally + on preview deploys without the secret).
 - `AbortSignal.timeout(10000)` so a hung endpoint doesn't pin the function.
 
+### Web-side (blog posts): deploy-hook via GitHub Actions
+
+`.github/workflows/notify-blog-indexnow.yml` fires on `push` to `main` whenever an `apps/web/src/content/blog/**/*.mdx` file changes. After a 5-minute sleep (Vercel prod deploy settle window — typical build is 2–5 min, slow days are inside the engine retry cushion), the action runs `pnpm --filter @jobseek/web notify-blog-indexnow`, which:
+
+1. Reads every published post via `listBlogPosts()`.
+2. For each post, calls `getBlogPostLocales(slug)` — same per-post translation set the sitemap (`blogPostEntries`, #2828) and the page `<head>` hreflang (`buildAlternates(..., availableLocales)`, #2849) use.
+3. Calls `notifyIndexNow([\`/blog/${slug}\`], localesForPost)` — `availableLocales` restricts the locale fan-out so engines aren't pointed at locale variants that fall back to the EN canonical body.
+
+The action also exposes a `workflow_dispatch:` trigger for manual re-runs from the Actions UI (e.g., to re-pin engines after they drop a URL from their index without a corresponding content change).
+
+Re-submission of unchanged URLs is idempotent at the IndexNow side; the action runs on every blog content commit, not just first-publish, and that's intentional — engines treat resubmission as "please recrawl" and dedupe their own re-fetch behavior.
+
 ### URL resolution alignment
 
 `getWatchlistByUserAndSlug` in `watchlists.ts` matches **either** `u.username` **or** `u.display_username` (preferring `username` via `ORDER BY (u.username = $1)::int DESC`). The sitemap emits URLs with `COALESCE(display_username, username)`, so without this fix a user with a distinct `display_username` would advertise URLs in `sitemap.xml` that the detail page couldn't resolve.


### PR DESCRIPTION
## Summary

Issue #2843's original body proposed phasing out IndexNow entirely. The user follow-up comment re-scoped: *"do not phase out IndexNow entirely; keep watchlist notifications; add notifications of blog posts."* PR #2879 phased out and was closed; this PR adds the blog half while leaving the watchlist surface untouched.

## Changes

- **`@/lib/indexnow.ts`** — `notifyIndexNow(paths, availableLocales?)` gains an optional locale-restriction param. Default is all 4 site locales (preserves the 4 watchlist call sites). Same shape as `buildAlternates(..., availableLocales)` from #2865 — the SEO surface speaks one contract.
- **`apps/web/script/notify-blog-indexnow.ts`** (new) — lists posts, threads `getBlogPostLocales(slug)` per post, calls `notifyIndexNow(['/blog/${slug}'], localesForPost)`. Same per-post translation source the sitemap (`blogPostEntries`, #2828) and page hreflang (#2849) use, so engines never see a locale variant that 404s or falls back to EN canonical.
- **`apps/web/package.json`** — `notify-blog-indexnow` script wired through tsx (mirrors `db:migrate` / `db:seed` / `screenshots`).
- **`.github/workflows/notify-blog-indexnow.yml`** (new) — fires on `push` to `main` with `apps/web/src/content/blog/**/*.mdx` filter, also `workflow_dispatch:`. Sleeps 300s pre-submission to let Vercel prod deploy settle.
- **`docs/13-seo-and-indexnow.md`** + **`AGENTS.md`** — documents the new hook alongside the watchlist + (retired) crawler surfaces.
- **3 new tests** in `indexnow.test.ts`: locale restriction (en+de subset), single-locale (EN-only post), defensive empty-array no-op.

## Verification

- [x] `pnpm --filter @jobseek/web typecheck` — clean.
- [x] `pnpm --filter @jobseek/web test src/lib/__tests__/indexnow.test.ts` — 14 pass (was 11 + 3 new).
- [x] `pnpm --filter @jobseek/web test` — 452 pass.
- [x] `pnpm --filter @jobseek/web notify-blog-indexnow` (no key) → "INDEXNOW_KEY unset — exiting no-op" exit 0.
- [x] `pnpm --filter @jobseek/web notify-blog-indexnow` (fake key, ran end-to-end) → 3 posts × 4 locales submitted.

## Operator step (post-merge)

`INDEXNOW_KEY` already exists in repo secrets from the original watchlist setup. No new secret needed. Recommend a one-time `workflow_dispatch` from the Actions UI to push the 3 currently-published blog URLs into IndexNow's index. After that, every blog content PR triggers automatically.

## Critic-resolved findings

A pre-commit critic flagged: stray `next-env.d.ts` in the diff (reverted), path filter using `**.mdx` instead of `**/*.mdx` (tightened), missing `workflow_dispatch` (added), missing doc note (added). The optional batch-into-one-POST optimization was intentionally skipped — current cost (3 POSTs of 4 URLs each) is negligible and the per-locale-set grouping logic would be more complex than the current "one POST per post" shape.

Closes #2843.