### PR TITLE
fix(web): drop immutable on watchlist OG cache header (#2890)

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/opengraph-image.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/opengraph-image.tsx
@@ -6,13 +6,22 @@ import { getPublicWatchlistByUserAndSlug } from "@/lib/actions/watchlists";
 export const alt = "Watchlist on Job Seek";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
-// 30-day cache via explicit `Cache-Control` headers on the
+// 1-day cache via explicit `Cache-Control` headers on the
 // ImageResponse — `'use cache'` doesn't apply (ImageResponse is a
-// class instance). Mirrors the company OG image
-// (apps/web/app/[lang]/(app)/company/[slug]/opengraph-image.tsx).
-// Vercel purges the CDN on every deploy so `immutable` is safe.
+// class instance).
+//
+// Unlike the company OG (which is `immutable` for 30 days because
+// companies don't toggle visibility on the web), watchlists CAN be
+// flipped from public to private at any time by their owner. PR #2888
+// busts the page-level `'use cache'` and Redis on toggle, but social
+// previews on Twitter/LinkedIn/Slack/Facebook fetch the OG card while
+// the watchlist was public and respect `Cache-Control` themselves —
+// `immutable` would tell them never to revalidate, leaking the card
+// for up to 30 days after privacy toggle. Drop `immutable` and cap
+// max-age at 1 day so third-party social caches refetch within 24h
+// of any visibility change. Issue #2890 (privacy follow-up to #2888).
 const CACHE_HEADERS = {
-  "Cache-Control": "public, max-age=2592000, s-maxage=2592000, immutable",
+  "Cache-Control": "public, max-age=86400, s-maxage=86400",
 };
 
 // Satori (used by next/og) only supports TTF/OTF, not woff2.

--- a/apps/web/docs/cache-components.md
+++ b/apps/web/docs/cache-components.md
@@ -332,7 +332,21 @@ When moving an existing component or route from the legacy model to cacheCompone
 | `cookies()` / `headers()` in a server component | Move into a `<Suspense>`-wrapped subtree, OR extract the value to a client read, OR pass as an argument into a `'use cache'` function |
 | `new Date()` / `Date.now()` / `Math.random()` in a server-render path | Pre-compute at module scope (build-time deploy refresh), OR move into a `<Suspense>` subtree that calls `connection()` first, OR put inside `'use cache'` if "value at cache build time" is acceptable |
 | `unstable_cache(fn, key, opts)` | `'use cache'` directive inside `fn` body; replace `opts.tags` with `cacheTag()` calls; replace `opts.revalidate` with `cacheLife({ revalidate: N })`. Drop the manual `key` array — args + closures become the key automatically. See "How cache keys are derived" above |
-| OpenGraph image function with `revalidate = N` | Remove the export — `next/og` `ImageResponse` is a class instance and isn't serializable for `'use cache'`. The framework caches OG images via HTTP `Cache-Control` headers automatically |
+| OpenGraph image function with `revalidate = N` | Remove the export — `next/og` `ImageResponse` is a class instance and isn't serializable for `'use cache'`. Set `Cache-Control` headers on the `ImageResponse` directly; pick `immutable` vs `must-revalidate` per the OG cache trade-off below |
+
+### OG image cache trade-off: `immutable` vs short TTL
+
+OG image route handlers can't use `'use cache'` (the `ImageResponse` is a class instance), so we set `Cache-Control` on the response. The choice of `immutable` vs a short TTL is load-bearing for **privacy** — third-party social-media caches (Twitter, LinkedIn, Slack, Facebook) honor the header, and `immutable` tells them never to revalidate.
+
+| OG handler | Cache-Control | Why |
+|---|---|---|
+| `app/opengraph-image.tsx` (root site card) | `public, max-age=2592000, s-maxage=2592000, immutable` | Static brand asset; rebakes on deploy |
+| `app/[lang]/(public)/blog/[slug]/opengraph-image.tsx` | `public, max-age=2592000, s-maxage=2592000, immutable` | MDX from disk; deploy-flushes on edit |
+| `app/[lang]/(public)/how-we-index/opengraph-image.tsx` | `public, max-age=2592000, s-maxage=2592000, immutable` | Static page; deploy-flushes on edit |
+| `app/[lang]/(app)/company/[slug]/opengraph-image.tsx` | `public, max-age=2592000, s-maxage=2592000, immutable` | Companies are CSV-managed; no per-user visibility toggle on the web |
+| `app/[lang]/(app)/[userSlug]/[watchlistSlug]/opengraph-image.tsx` | `public, max-age=86400, s-maxage=86400` (no `immutable`) | Owners can toggle a watchlist private at any time. `immutable` would let third-party caches keep the card for up to 30 days post-toggle (the leak window described in #2890). 1-day TTL bounds third-party staleness to 24h |
+
+Rule of thumb: an OG card is `immutable`-safe only when the underlying entity has **no per-user visibility flag** that can change after the card is fetched. Anything that can flip from public to private at runtime needs a bounded TTL and no `immutable`.
 
 ## References
 


### PR DESCRIPTION
Closes #2890

## Summary

Watchlists can be flipped from public to private at any time by their owner. Before this PR, the watchlist OG handler emitted `Cache-Control: public, max-age=2592000, s-maxage=2592000, immutable` — telling Twitter/LinkedIn/Slack/Facebook social-preview caches to never revalidate the OG card for 30 days. PR #2888 already busts the page-level `'use cache'` (via `updateTag`) and Redis (`invalidate("public-watchlist:...")`) on visibility toggle, so the page meta correctly drops to `noindex,follow` — but the OG image URL stays in third-party social caches honoring our `immutable` header. That's the leak window described in the issue body.

## Choice: option (2) per issue body

Picked **option (2)** — short TTL (`max-age=86400, s-maxage=86400`, no `immutable`). This bounds the worst-case third-party staleness to 24h. Option (1) (`immutable` removed but `max-age=2592000` retained + `must-revalidate`) would still allow third parties to serve stale up to 30 days because `must-revalidate` only kicks in *after* `max-age` expires; that's not a meaningful improvement over the status quo for the leak window. Option (2) is the issue body's recommendation and the right balance: most social caches re-fetch within hours of first surfacing anyway.

## Verification

### Files changed (only watchlist OG + docs)

```
$ git diff --stat HEAD~1
 .../[userSlug]/[watchlistSlug]/opengraph-image.tsx    | 19 ++++++++++++++-----
 apps/web/docs/cache-components.md                     | 16 +++++++++++++++-
 2 files changed, 29 insertions(+), 6 deletions(-)
```

Company OG (`apps/web/app/[lang]/(app)/company/[slug]/opengraph-image.tsx`) and blog OG (`apps/web/app/[lang]/(public)/blog/[slug]/opengraph-image.tsx`) are untouched — confirmed by `git diff --stat` above showing only the two in-scope files.

### Verified the new header on the watchlist OG handler

The watchlist OG handler now declares:

```ts
const CACHE_HEADERS = {
  "Cache-Control": "public, max-age=86400, s-maxage=86400",
};
```

(`apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/opengraph-image.tsx` lines 23–25.)

### `curl -sI` against dev server: not directly verifiable in this worktree

I started `pnpm dev` from `apps/web/` and curled `http://localhost:3000/en/<userSlug>/<watchlistSlug>/opengraph-image` with several slug variants. Every request returned `404 Not Found` because:

- The worktree has no `.env.local` (no `DATABASE_URL`, no Redis URL, no `TYPESENSE_SEARCH_KEY` — confirmed by error logs from the dev server: `[Upstash Redis] Redis client was initialized without url or token` and `Error: TYPESENSE_SEARCH_KEY is not set`).
- `getPublicWatchlistByUserAndSlug` therefore can't run, the OG handler errors, and Next.js dev surfaces the global `not-found.tsx` instead of the handler's own `ImageResponse`.

```
$ curl -sI 'http://localhost:3000/en/test-user/test-watchlist/opengraph-image'
HTTP/1.1 404 Not Found
Cache-Control: no-cache, must-revalidate
Content-Type: text/html; charset=utf-8
```

That `Cache-Control: no-cache, must-revalidate` is Next.js's default 404 shell — not from our handler.

For comparison, `/opengraph-image` (the root site card, no DB read) responds correctly with the unchanged `immutable` header — proving the OG-handler code path emits its declared headers when it can run:

```
$ curl -sI 'http://localhost:3000/opengraph-image'
HTTP/1.1 200 OK
cache-control: public, max-age=2592000, s-maxage=2592000, immutable
```

The watchlist OG header is set in code at the same point in the same way; the change will surface on the deployed Vercel preview where the DB is reachable. Will verify post-merge with `curl -sI https://jseek.co/en/<owner>/<slug>/opengraph-image`.

### TypeScript

```
$ pnpm exec tsc --noEmit 2>&1 | tail
app/mcp/route.ts(1,34): error TS2307: Cannot find module '@jseek/mcp-server/handler' or its corresponding type declarations.
```

This single error is **pre-existing on main** (caused by `@jseek/mcp-server` workspace not being built — the `pnpm install` step in this worktree warned `Failed to create bin... @jseek/mcp-server/dist/index.js`). Confirmed by stashing my changes and re-running `tsc` — same error, same line. Zero new TS errors from this PR.

## Test plan

- [ ] After Vercel preview deploys, `curl -sI <preview>/en/<owner>/<wl>/opengraph-image` shows `cache-control: public, max-age=86400, s-maxage=86400` (no `immutable`).
- [ ] Toggle a public watchlist private; existing social-card crawls revalidate within 24h instead of being pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)