### PR TITLE
fix(web): rename middleware.ts to proxy.ts (Next 16 deprecation)

### DIFF
--- a/apps/web/app/[lang]/layout.tsx
+++ b/apps/web/app/[lang]/layout.tsx
@@ -31,8 +31,8 @@ export const metadata: Metadata = {
   },
   // `images` here is the fallback for any page whose own
   // `generateMetadata` doesn't return its own `openGraph.images`. The
-  // `/opengraph-image` URL is exempt from the locale-redirect middleware
-  // (`apps/web/middleware.ts:52`), so the og:image meta tag resolves
+  // `/opengraph-image` URL is exempt from the locale-redirect proxy
+  // (`apps/web/proxy.ts:52`), so the og:image meta tag resolves
   // directly to `app/opengraph-image.tsx` without a 308 to `/<locale>/...`.
   openGraph: {
     type: "website",

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -4,7 +4,7 @@ import { siteConfig } from "@/content/config";
 import "./globals.css";
 
 // Top-level not-found handler for paths that don't match any `/[lang]/...`
-// route — typically URLs with dots that the locale-redirect middleware
+// route — typically URLs with dots that the locale-redirect proxy
 // excludes (e.g. `/random.html`, `/foo.txt`). Without a root `app/layout.tsx`,
 // Next.js requires this file to render its own `<html>` + `<body>`. The
 // localized `[lang]/not-found.tsx` (with translated copy) handles

--- a/apps/web/app/opengraph-image.tsx
+++ b/apps/web/app/opengraph-image.tsx
@@ -14,10 +14,10 @@ export const contentType = "image/png";
 // — keeping this at root sidesteps the lookup ambiguity).
 //
 // The og:image URL Next.js generates is `/opengraph-image-<hash>`,
-// without a locale prefix. The locale-redirect middleware excludes this
+// without a locale prefix. The locale-redirect proxy excludes this
 // path so the response goes to this handler directly without a 308 to
 // `/<locale>/opengraph-image-<hash>` (which would 404). See
-// `apps/web/middleware.ts:52`.
+// `apps/web/proxy.ts:52`.
 //
 // Long-cache via explicit Cache-Control headers; Vercel CDN is purged
 // on every deploy so `immutable` is safe.

--- a/apps/web/app/robots.ts
+++ b/apps/web/app/robots.ts
@@ -6,7 +6,7 @@ function expandDisallow(paths: readonly string[]): string[] {
   const out: string[] = [];
   for (const path of paths) {
     out.push(path);
-    // API routes are not locale-prefixed (middleware excludes /api/*),
+    // API routes are not locale-prefixed (proxy excludes /api/*),
     // so only expand non-API paths to their locale-prefixed variants.
     if (path.startsWith("/api/")) continue;
     for (const locale of locales) {

--- a/apps/web/docs/edge-requests.md
+++ b/apps/web/docs/edge-requests.md
@@ -34,11 +34,14 @@ Pages that check authentication or read cookies are rendered on every request:
 
 This is correct — these pages genuinely need per-request data.
 
-### Middleware
+### Proxy (formerly Middleware)
 
-The middleware only runs for paths **without** a locale prefix (e.g. bare `/`, `/how-we-index`). It redirects to the locale-prefixed version based on `Accept-Language`.
+The proxy only runs for paths **without** a locale prefix (e.g. bare `/`, `/how-we-index`). It redirects to the locale-prefixed version based on `Accept-Language`.
 
-Paths that already have a locale prefix (`/en/...`, `/de/...`) **skip the middleware entirely** — no edge invocation.
+Paths that already have a locale prefix (`/en/...`, `/de/...`) **skip the proxy entirely** — no edge invocation.
+
+> Renamed from `middleware.ts` to `proxy.ts` for Next.js 16 (#2887).
+> Same APIs, same execution model — see https://nextjs.org/docs/messages/middleware-to-proxy.
 
 ### Theme
 
@@ -60,9 +63,9 @@ If you need request data, put it in a **route-group layout** that only wraps the
 
 This tells Next.js which locale variants to pre-render. Without it, `[lang]` is treated as a fully dynamic segment and every page requires an edge invocation.
 
-### Keep the middleware matcher narrow
+### Keep the proxy matcher narrow
 
-The middleware matcher explicitly excludes locale-prefixed paths. When adding a new locale, **add it to the matcher exclusion list** in `middleware.ts` — otherwise every request to that locale will unnecessarily invoke the middleware.
+The proxy matcher explicitly excludes locale-prefixed paths. When adding a new locale, **add it to the matcher exclusion list** in `proxy.ts` — otherwise every request to that locale will unnecessarily invoke the proxy.
 
 ### Use route groups to separate static from dynamic
 
@@ -314,7 +317,7 @@ invocations.
 | API route request | Node.js | `/api/v1/*`, `/api/auth/*`, `/api/stripe/*` |
 | OG image generation | Node.js | `opengraph-image.tsx` routes |
 | `sitemap.xml` / `robots.txt` | Node.js | Generated dynamically per request |
-| Middleware | Edge | Lightweight locale redirect only |
+| Proxy (formerly Middleware) | Edge | Lightweight locale redirect only |
 
 Static pages (`(public)`) and cached CDN assets do **not** invoke functions.
 

--- a/apps/web/docs/edge-requests/README.md
+++ b/apps/web/docs/edge-requests/README.md
@@ -4,7 +4,7 @@ Per-page breakdown of Vercel edge requests and serverless function compute for
 the Job Seek web app.
 
 Every HTTP request that reaches the Vercel deployment counts as an **edge
-request**, including static assets served from CDN, middleware invocations,
+request**, including static assets served from CDN, proxy invocations,
 serverless function routing, and dynamically generated resources.
 
 Every dynamic page render, server action, or API route call triggers a
@@ -21,7 +21,7 @@ These edge requests are made on **every** page load (first visit, cold cache):
 | # | Request | Type | Notes |
 |---|---------|------|-------|
 | 1 | HTML document | SSR or static | The page itself |
-| 2 | Middleware redirect | Edge function | Only if path has no locale prefix (e.g. `/about` -> `/en/about`). Skipped for locale-prefixed paths, `_next`, `api`, `flags`, `fonts`, `publicdomain`, `favicon.ico` |
+| 2 | Proxy redirect | Edge function | Only if path has no locale prefix (e.g. `/about` -> `/en/about`). Skipped for locale-prefixed paths, `_next`, `api`, `flags`, `fonts`, `publicdomain`, `favicon.ico` |
 | 3-6 | `/_next/static/chunks/*.js` | Static (CDN) | Framework + page JS bundles (varies per page, typically 3-8 chunks) |
 | 7 | `/_next/static/css/*.css` | Static (CDN) | Compiled Tailwind CSS |
 | 8 | `/fonts/JetBrainsMono-Regular.woff2` | Static (CDN) | Primary font (others loaded on demand: Medium, SemiBold, Bold) |

--- a/apps/web/docs/edge-requests/landing.md
+++ b/apps/web/docs/edge-requests/landing.md
@@ -51,7 +51,7 @@ These 3-4 phantom SSR invocations per landing page visit are now eliminated.
 ## Fluid compute (serverless function duration)
 
 **Zero function compute.** Pre-rendered at build time. Served from CDN with
-no serverless invocation. Only the analytics beacon POST and middleware
+no serverless invocation. Only the analytics beacon POST and proxy
 redirect (if no locale prefix) touch edge/serverless infrastructure.
 
 ## Estimated edge requests

--- a/apps/web/docs/i18n.md
+++ b/apps/web/docs/i18n.md
@@ -87,7 +87,7 @@ Keep IDs **lowercase**, use **camelCase** only for the element segment when need
    const langScript = `try{var l=location.pathname.split('/')[1];if(['en','de','fr','it','es'].includes(l))document.documentElement.lang=l}catch(e){}`;
    ```
 
-4. **`middleware.ts`** — add the new code to the matcher so locale-prefixed paths skip the middleware:
+4. **`proxy.ts`** — add the new code to the matcher so locale-prefixed paths skip the proxy:
    ```ts
    matcher: ["/((?!_next|api|flags|fonts|publicdomain|favicon\\.ico|en|de|fr|it|es|.*\\..*).*)" ],
    ```

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -21,7 +21,7 @@ function getLocale(request: NextRequest): string {
   return match(languages, locales as unknown as string[], defaultLocale);
 }
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const cookieLocale = request.cookies.get(COOKIE_NAME)?.value;
   const locale = getLocale(request);
   const url = request.nextUrl.clone();
@@ -31,7 +31,7 @@ export function middleware(request: NextRequest) {
   // Cache the redirect at Vercel's CDN when the chosen locale comes from
   // Accept-Language negotiation. Repeat requests with matching headers (most
   // bot/shared-link traffic on root URLs) then reuse the redirect without
-  // re-invoking the middleware. We deliberately skip the cache when an
+  // re-invoking the proxy. We deliberately skip the cache when an
   // explicit NEXT_LOCALE cookie is set: that path varies per user and Vary:
   // Cookie would shard the cache by every session token. See issue #2642.
   if (!cookieLocale || !isLocale(cookieLocale)) {
@@ -48,7 +48,7 @@ export function middleware(request: NextRequest) {
 export const config = {
   // Only match paths that do NOT start with a locale prefix, static assets,
   // API routes, or Next.js internals.  Locale-prefixed paths (e.g. /en/…)
-  // skip the middleware entirely — no edge invocation needed.
+  // skip the proxy entirely — no edge invocation needed.
   //
   // `opengraph-image*` is excluded so `og:image` URLs that the Metadata
   // API generates against the root `app/opengraph-image.tsx` reach the

--- a/apps/web/src/components/PreferencesInitializer.tsx
+++ b/apps/web/src/components/PreferencesInitializer.tsx
@@ -51,7 +51,7 @@ export function PreferencesInitializer({
     const urlLocale = pathname.split("/")[1] || "en";
 
     if (localLocaleTs && dbLocaleTs && new Date(localLocaleTs) > new Date(dbLocaleTs)) {
-      // Local wins — sync cookie so middleware redirects correctly
+      // Local wins — sync cookie so proxy redirects correctly
       if (localLocale) {
         document.cookie = `NEXT_LOCALE=${localLocale}; path=/; max-age=31536000; SameSite=Lax`;
       }
@@ -63,7 +63,7 @@ export function PreferencesInitializer({
         void updatePreferences({ locale: localLocale as "en" | "de" | "fr" | "it", localeUpdatedAt: localLocaleTs });
       }
     } else if (dbLocale) {
-      // DB wins — sync cookie so middleware redirects correctly on next request
+      // DB wins — sync cookie so proxy redirects correctly on next request
       document.cookie = `NEXT_LOCALE=${dbLocale}; path=/; max-age=31536000; SameSite=Lax`;
       if (dbLocale !== urlLocale) {
         const newPath = pathname.replace(`/${urlLocale}`, `/${dbLocale}`);

--- a/apps/web/src/lib/__tests__/proxy.test.ts
+++ b/apps/web/src/lib/__tests__/proxy.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockRedirect = vi.fn();
 
 // Headers-like wrapper around a plain Map. We don't need a full Headers
-// implementation — the middleware only calls set(), and tests only need get().
+// implementation — the proxy only calls set(), and tests only need get().
 class MockHeaders {
   private store = new Map<string, string>();
   set(name: string, value: string) {
@@ -29,7 +29,7 @@ vi.mock("next/server", () => {
   };
 });
 
-import { middleware, config } from "../../../middleware";
+import { proxy, config } from "../../../proxy";
 import type { NextRequest } from "next/server";
 
 function createMockRequest(
@@ -59,62 +59,62 @@ function createMockRequest(
   } as unknown as NextRequest;
 }
 
-describe("middleware", () => {
+describe("proxy", () => {
   beforeEach(() => {
     mockRedirect.mockClear();
   });
 
   it("redirects to default locale when no accept-language", () => {
-    middleware(createMockRequest("/about"));
+    proxy(createMockRequest("/about"));
     expect(mockRedirect).toHaveBeenCalledTimes(1);
     const redirectUrl = mockRedirect.mock.calls[0][0] as URL;
     expect(redirectUrl.pathname).toBe("/en/about");
   });
 
   it("redirects to German when de is preferred", () => {
-    middleware(createMockRequest("/about", "de-DE,de;q=0.9,en;q=0.8"));
+    proxy(createMockRequest("/about", "de-DE,de;q=0.9,en;q=0.8"));
     const redirectUrl = mockRedirect.mock.calls[0][0] as URL;
     expect(redirectUrl.pathname).toBe("/de/about");
   });
 
   it("redirects to French when fr is preferred", () => {
-    middleware(createMockRequest("/pricing", "fr-FR,fr;q=0.9"));
+    proxy(createMockRequest("/pricing", "fr-FR,fr;q=0.9"));
     const redirectUrl = mockRedirect.mock.calls[0][0] as URL;
     expect(redirectUrl.pathname).toBe("/fr/pricing");
   });
 
   it("falls back to default locale for unsupported languages", () => {
-    middleware(createMockRequest("/about", "ja,zh;q=0.9"));
+    proxy(createMockRequest("/about", "ja,zh;q=0.9"));
     const redirectUrl = mockRedirect.mock.calls[0][0] as URL;
     expect(redirectUrl.pathname).toBe("/en/about");
   });
 
   it("respects quality weights", () => {
-    middleware(createMockRequest("/", "en;q=0.5,it;q=0.9"));
+    proxy(createMockRequest("/", "en;q=0.5,it;q=0.9"));
     const redirectUrl = mockRedirect.mock.calls[0][0] as URL;
     expect(redirectUrl.pathname).toBe("/it/");
   });
 
   it("handles root path", () => {
-    middleware(createMockRequest("/"));
+    proxy(createMockRequest("/"));
     const redirectUrl = mockRedirect.mock.calls[0][0] as URL;
     expect(redirectUrl.pathname).toBe("/en/");
   });
 
   it("uses the cookie locale when present", () => {
-    middleware(createMockRequest("/about", "de-DE,de;q=0.9", "fr"));
+    proxy(createMockRequest("/about", "de-DE,de;q=0.9", "fr"));
     const redirectUrl = mockRedirect.mock.calls[0][0] as URL;
     expect(redirectUrl.pathname).toBe("/fr/about");
   });
 });
 
-describe("middleware caching", () => {
+describe("proxy caching", () => {
   beforeEach(() => {
     mockRedirect.mockClear();
   });
 
   it("sets Cache-Control + Vary on Accept-Language redirects", () => {
-    const response = middleware(
+    const response = proxy(
       createMockRequest("/about", "de-DE,de;q=0.9"),
     ) as unknown as { headers: { get: (n: string) => string | null } };
     expect(response.headers.get("cache-control")).toBe(
@@ -124,7 +124,7 @@ describe("middleware caching", () => {
   });
 
   it("sets cache headers on the default-locale fallback redirect", () => {
-    const response = middleware(createMockRequest("/")) as unknown as {
+    const response = proxy(createMockRequest("/")) as unknown as {
       headers: { get: (n: string) => string | null };
     };
     expect(response.headers.get("cache-control")).toBe(
@@ -133,7 +133,7 @@ describe("middleware caching", () => {
   });
 
   it("does NOT cache when a NEXT_LOCALE cookie is present", () => {
-    const response = middleware(
+    const response = proxy(
       createMockRequest("/about", undefined, "fr"),
     ) as unknown as { headers: { get: (n: string) => string | null } };
     expect(response.headers.get("cache-control")).toBeNull();
@@ -141,7 +141,7 @@ describe("middleware caching", () => {
   });
 
   it("ignores an invalid cookie locale and still caches", () => {
-    const response = middleware(
+    const response = proxy(
       createMockRequest("/about", "de-DE,de;q=0.9", "xx"),
     ) as unknown as { headers: { get: (n: string) => string | null } };
     expect(response.headers.get("cache-control")).toBe(
@@ -150,7 +150,7 @@ describe("middleware caching", () => {
   });
 });
 
-describe("middleware config", () => {
+describe("proxy config", () => {
   it("has a matcher pattern", () => {
     expect(config.matcher).toBeDefined();
     expect(config.matcher.length).toBeGreaterThan(0);


### PR DESCRIPTION
Closes #2887.

## Summary

Next.js 16 deprecates the `middleware` file convention in favor of `proxy`. Same APIs, same execution model — just a rename, per the official codemod at https://nextjs.org/docs/messages/middleware-to-proxy.

```
- export function middleware() {
+ export function proxy() {
```

The deprecation warning quoted in the issue body appears in `pnpm dev` (not just `pnpm build`) until renamed.

## Changes

- `apps/web/middleware.ts` → `apps/web/proxy.ts` (git rename, 92% similarity)
- `apps/web/src/lib/__tests__/middleware.test.ts` → `apps/web/src/lib/__tests__/proxy.test.ts` (git rename, 83% similarity)
- Renamed exported function `middleware` → `proxy` (per Next 16 codemod behavior — not new behavior)
- Updated `describe()` block names + import path in the test file
- Updated file-path / locale-redirect references in: `app/[lang]/layout.tsx`, `app/opengraph-image.tsx`, `app/not-found.tsx`, `app/robots.ts`, `src/components/PreferencesInitializer.tsx`
- Updated docs that name the file/concept: `docs/i18n.md`, `docs/edge-requests.md`, `docs/edge-requests/README.md`, `docs/edge-requests/landing.md`

No matcher changes. No new behavior. No `x-jseek-locale` (issue-body explicitly out of scope).

## Verified by

```
$ git mv apps/web/middleware.ts apps/web/proxy.ts
$ git status
        renamed:    apps/web/middleware.ts -> apps/web/proxy.ts
```

```
$ grep -rn 'middleware\.ts' apps/web --include='*.ts' --include='*.tsx' --include='*.md' --include='*.json'
apps/web/docs/edge-requests.md:43:> Renamed from `middleware.ts` to `proxy.ts` for Next.js 16 (#2887).
apps/web/docs/edge-requests.md:44:> Same APIs, same execution model — see https://nextjs.org/docs/messages/middleware-to-proxy.
```
(Both remaining hits are an intentional historical migration note in the doc I added — no live `middleware.ts` path references remain.)

```
$ cd apps/web && pnpm exec tsc --noEmit
app/mcp/route.ts(1,34): error TS2307: Cannot find module '@jseek/mcp-server/handler' or its corresponding type declarations.
```
Single pre-existing error, unrelated to this PR — same error reproduces on `origin/main` (verified by checking out the unrelated baseline). All other paths typecheck clean.

```
$ cd apps/web && pnpm exec vitest run src/lib/__tests__/proxy.test.ts
 ✓ src/lib/__tests__/proxy.test.ts (12 tests) 17ms
 Test Files  1 passed (1)
      Tests  12 passed (12)
```

```
$ cd apps/web && pnpm dev
▲ Next.js 16.2.3 (Turbopack)
- Local:         http://localhost:3001
✓ Ready in 723ms
- Cache Components enabled

$ curl -sI http://localhost:3001/
HTTP/1.1 307 Temporary Redirect
cache-control: public, max-age=86400, s-maxage=86400
location: /en
vary: Accept-Language
```
Proxy executes (redirect + Cache-Control + Vary headers from `proxy.ts` logic). Crucially, the dev log contains **no** `The "middleware" file convention is deprecated` warning:

```
$ grep -i "middleware\|deprecat" /tmp/proxy-dev.log
(no matches)
```

## Out of scope

- Two generic `middleware` mentions in docs (`apps/web/docs/data-fetching.md:46` "No auth middleware needed" and `apps/web/docs/cache-components.md:178` "middleware-set header") were left as-is. Both use `middleware` as a generic concept term — not a file-path or Next.js-convention reference. The cache-components mention also describes a header-setting pattern; per issue body this `x-jseek-locale` pattern was rejected in #2888, so the doc may need a follow-up rewrite, but that is unrelated to this rename.
- No matcher pattern changes.

## Discrepancies surfaced

- The issue body says to update `apps/web/AGENTS.md` — that file does not exist (`ls apps/web/AGENTS.md` returns "No such file or directory"). Web-app conventions live under `apps/web/docs/` instead, which is what I updated.
- The Next.js docs codemod also renames the exported `middleware` function to `proxy`. The issue body said "same APIs … just a rename"; renaming the function is part of that rename (and `proxy.ts` would still be picked up by Next.js with the old export name in 16.2.3, but the tests imported `middleware` directly so the test would break either way — and this PR follows the codemod for forward compatibility).

🤖 Generated with [Claude Code](https://claude.com/claude-code)