### PR TITLE
fix(web): drop redundant setI18n in (public) and (app) layouts (closes #2883)

### DIFF
--- a/apps/web/app/[lang]/(app)/layout.tsx
+++ b/apps/web/app/[lang]/(app)/layout.tsx
@@ -1,8 +1,5 @@
 import type { ReactNode } from "react";
 
-import { setI18n } from "@lingui/react/server";
-import { isLocale, defaultLocale, loadCatalog, type Locale } from "@/lib/i18n";
-import { LinguiClientProvider } from "@/components/LinguiProvider";
 import { AppBootstrapProvider } from "@/components/AppBootstrapProvider";
 import { AppHeader } from "@/components/AppHeader";
 import { CookieBanner } from "@/components/CookieBanner";
@@ -12,18 +9,14 @@ import { WatchlistTipBanner } from "@/components/watchlist/watchlist-tip-banner"
 import { BackToTop } from "@/components/ui/back-to-top";
 
 type Props = {
-  params: Promise<{ lang: string }>;
   children: ReactNode;
 };
 
-export default async function AppLayout({ params, children }: Props) {
-  const { lang } = await params;
-  const locale: Locale = isLocale(lang) ? lang : defaultLocale;
-  const { i18n, messages } = await loadCatalog(locale);
-  setI18n(i18n);
-
+// i18n is initialized once in the parent `[lang]/layout.tsx` (loadCatalog +
+// setI18n + <LinguiClientProvider>); this layout no longer redoes that work.
+// See #2883.
+export default async function AppLayout({ children }: Props) {
   return (
-    <LinguiClientProvider locale={locale} messages={messages}>
     <AppBootstrapProvider>
       <SearchStateProvider>
         <div className="flex min-h-dvh flex-col">
@@ -40,6 +33,5 @@ export default async function AppLayout({ params, children }: Props) {
         </div>
       </SearchStateProvider>
     </AppBootstrapProvider>
-    </LinguiClientProvider>
   );
 }

--- a/apps/web/app/[lang]/(public)/layout.tsx
+++ b/apps/web/app/[lang]/(public)/layout.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { Trans } from "@lingui/react/macro";
-import { initI18nForPage } from "@/lib/i18n";
+import { defaultLocale, isLocale, type Locale } from "@/lib/i18n";
 import { HeaderShell } from "@/components/HeaderShell";
 import { Footer } from "@/components/Footer";
 
@@ -9,8 +9,12 @@ type Props = {
   params: Promise<{ lang: string }>;
 };
 
+// i18n is initialized once in the parent `[lang]/layout.tsx` (loadCatalog +
+// setI18n + <LinguiClientProvider>); this layout only resolves `locale` for
+// the <Footer lang={locale}> prop. See #2883.
 export default async function PublicLayout({ children, params }: Props) {
-  const locale = await initI18nForPage(params);
+  const { lang } = await params;
+  const locale: Locale = isLocale(lang) ? lang : defaultLocale;
 
   return (
     <>


### PR DESCRIPTION
## Summary

Closes #2883.

After #2835 (PPR / Cache Components), `app/[lang]/layout.tsx` already runs `loadCatalog` + `setI18n` and wraps `{children}` in `<LinguiClientProvider>`. The two route-group layouts were re-doing the same work on every render — twice on every public page render and twice on every app page render.

**Files changed:**
- `apps/web/app/[lang]/(public)/layout.tsx` — drop `initI18nForPage(params)` call (it does `loadCatalog` + `setI18n` internally), replace with simple `{lang}` -> `Locale` resolution. The `<Footer lang={locale}>` prop wiring is preserved per issue scope.
- `apps/web/app/[lang]/(app)/layout.tsx` — drop direct `loadCatalog` + `setI18n` and the redundant inner `<LinguiClientProvider>` wrapper. Locale param read removed because nothing else in the layout consumed it.

## Mechanical scope expansion (per setup mandate G)

The issue body lists "Drop the duplicate `loadCatalog` + `setI18n` calls" as the explicit scope. In `(app)/layout.tsx`, the inner `<LinguiClientProvider>` was the only remaining consumer of `loadCatalog`'s `messages` output, and it duplicates the parent `[lang]/layout.tsx`'s wrapper around `{children}`. Dropping that inner wrapper completes the cleanup; the parent already provides the same context to all descendants.

`initI18nForPage` itself is preserved in `src/lib/i18n.ts` because many individual page files still call it (settings layout, blog/page, faq/page, terms, privacy-policy, license, about, how-we-index, blog/[slug], (public)/page, (app)/company/[slug]/page) — out of scope.

## Verified by

**Issue body claims confirmed by reading sources** — all three layouts indeed called the i18n init machinery (lines 62-63 of `[lang]/layout.tsx`, line 13 of `(public)/layout.tsx` via `initI18nForPage`, lines 22-23 of `(app)/layout.tsx`). No discrepancies vs the issue body.

**Dev server (`pnpm dev`, port 3001):**

`<html lang>` correct on all 4 public pages and all 4 app pages:
```
GET /en           HTTP 200  <html lang="en">
GET /de           HTTP 200  <html lang="de">
GET /fr           HTTP 200  <html lang="fr">
GET /it           HTTP 200  <html lang="it">
GET /en/explore   HTTP 200  <html lang="en">
GET /de/explore   HTTP 200  <html lang="de">
GET /fr/explore   HTTP 200  <html lang="fr">
GET /it/explore   HTTP 200  <html lang="it">
```

Footer `aria-label` translation (per-locale, `common.footer.ariaLabel`) on the public surface:
```
/en  aria-label="Footer"
/de  aria-label="Fußzeile"
/fr  aria-label="Pied de page"
/it  aria-label="Piè di pagina"
```

App-surface translated content samples (`/<loc>/explore`):
```
/en  Watchlists, Sign in, Search jobs
/de  Anmelden, Stellen, Stellenanzeigen, Suchen
/fr  Connexion, Rechercher, Listes de suivi, Emplois, Offres
/it  Accedi, Cerca, Lavori, Watchlist
```

Smoke-checked nested `(app)/settings/layout.tsx` (still uses `initI18nForPage` itself, untouched) — all 4 locales return 200 with correct `<html lang>`.

**Type check** (`pnpm exec tsc --noEmit` from `apps/web/`):
```
app/mcp/route.ts(1,34): error TS2307: Cannot find module '@jseek/mcp-server/handler' or its corresponding type declarations.
```
Single error, pre-existing (workspace pkg `@jseek/mcp-server` `dist/` not built locally — see install warning). No new errors introduced by this change.

**Tests** (`pnpm test`): 439 passing across 50 test files; same `app/mcp/route.test.ts` pre-existing failure (same root cause). No layout/i18n tests regressed.

## Out of scope

- `'use cache'` migration of the catalog loader (explicit in issue).
- Dropping `initI18nForPage` from individual page files (still in active use; would be a separate cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)