### PR TITLE
test(web): cache-tags namers + OG prebake fail-loud (closes #2891)

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/opengraph-image-prebake.test.ts
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/opengraph-image-prebake.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for the OG prebake's `generateStaticParams` fail-loud condition
+ * (issue #2891 / PR #2888 round-3 critic ask).
+ *
+ * The module under test exports `generateStaticParams`, which dynamically
+ * imports `@/lib/search/typesense-client` so the dependency can be mocked
+ * here without touching the surrounding `ImageResponse` handler.
+ *
+ * The fail-loud gate: `isProductionBuild && hasTypesenseConfig`. When both
+ * are true and Typesense throws, we re-throw to fail the Vercel deploy
+ * (silently shipping zero prerender hides a real outage). All three other
+ * quadrants soft-fail with a console.warn and an empty array.
+ */
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type MockInstance,
+} from "vitest";
+
+const { searchMock } = vi.hoisted(() => ({
+  searchMock: vi.fn(),
+}));
+
+vi.mock("@/lib/search/typesense-client", () => ({
+  getSearchClient: () => ({
+    collections: () => ({
+      documents: () => ({
+        search: searchMock,
+      }),
+    }),
+  }),
+}));
+
+// `getCompanyBySlug` is only called by the default OG handler, which we
+// don't exercise here — mock it to a no-op so importing the module
+// doesn't pull in db / Typesense / cache transitive deps unnecessarily.
+vi.mock("@/lib/actions/company", () => ({
+  getCompanyBySlug: vi.fn(),
+}));
+
+import { generateStaticParams } from "../opengraph-image";
+
+describe("opengraph-image generateStaticParams", () => {
+  let warnSpy: MockInstance<typeof console.warn>;
+  const ORIGINAL_VERCEL_ENV = process.env.VERCEL_ENV;
+  const ORIGINAL_TYPESENSE_HOST = process.env.TYPESENSE_HOST;
+
+  beforeEach(() => {
+    searchMock.mockReset();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    // Restore env to whatever the test runner set it to. Using delete
+    // when the original was undefined avoids leaking the literal string
+    // "undefined" into subsequent tests.
+    if (ORIGINAL_VERCEL_ENV === undefined) {
+      delete process.env.VERCEL_ENV;
+    } else {
+      process.env.VERCEL_ENV = ORIGINAL_VERCEL_ENV;
+    }
+    if (ORIGINAL_TYPESENSE_HOST === undefined) {
+      delete process.env.TYPESENSE_HOST;
+    } else {
+      process.env.TYPESENSE_HOST = ORIGINAL_TYPESENSE_HOST;
+    }
+  });
+
+  it(
+    "production + Typesense configured + Typesense throws -> re-throws (fail loud)",
+    async () => {
+      process.env.VERCEL_ENV = "production";
+      process.env.TYPESENSE_HOST = "typesense.example.com";
+      const err = new Error("connection refused");
+      searchMock.mockRejectedValue(err);
+
+      await expect(generateStaticParams()).rejects.toThrow("connection refused");
+      // Fail-loud path doesn't warn — it throws, surfacing in the
+      // Vercel build log directly.
+      expect(warnSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it(
+    "production + Typesense configured + zero hits -> warns and returns []",
+    async () => {
+      process.env.VERCEL_ENV = "production";
+      process.env.TYPESENSE_HOST = "typesense.example.com";
+      searchMock.mockResolvedValue({ hits: [] });
+
+      const result = await generateStaticParams();
+
+      expect(result).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = warnSpy.mock.calls[0]?.[0] as string;
+      expect(message).toContain("0 companies returned from");
+      expect(message).toContain("Typesense");
+    },
+  );
+
+  it(
+    "preview env + Typesense throws -> warns and returns []",
+    async () => {
+      process.env.VERCEL_ENV = "preview";
+      // TYPESENSE_HOST may or may not be set on previews; clear it
+      // to exercise the "not configured" branch alongside non-prod
+      // env. Either way this quadrant must NOT throw.
+      delete process.env.TYPESENSE_HOST;
+      searchMock.mockRejectedValue(new Error("dns failure"));
+
+      const result = await generateStaticParams();
+
+      expect(result).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0]?.[0]).toContain(
+        "skipping prerender",
+      );
+    },
+  );
+
+  it(
+    "local build (no VERCEL_ENV, no TYPESENSE_HOST) + Typesense throws -> warns and returns []",
+    async () => {
+      delete process.env.VERCEL_ENV;
+      delete process.env.TYPESENSE_HOST;
+      searchMock.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const result = await generateStaticParams();
+
+      expect(result).toEqual([]);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it(
+    "happy path: returns slug × locale matrix (en/de/fr/it)",
+    async () => {
+      process.env.VERCEL_ENV = "production";
+      process.env.TYPESENSE_HOST = "typesense.example.com";
+      searchMock.mockResolvedValue({
+        hits: [{ document: { slug: "stripe" } }, { document: { slug: "airbnb" } }],
+      });
+
+      const result = await generateStaticParams();
+
+      // 2 slugs × 4 locales = 8 entries.
+      expect(result).toHaveLength(8);
+      const stripeLocales = result
+        .filter((entry) => entry.slug === "stripe")
+        .map((entry) => entry.lang)
+        .sort();
+      expect(stripeLocales).toEqual(["de", "en", "fr", "it"]);
+      expect(warnSpy).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/apps/web/src/lib/__tests__/cache-tags.test.ts
+++ b/apps/web/src/lib/__tests__/cache-tags.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  blogIndexCacheTag,
+  blogPostCacheTag,
+  companyCacheTag,
+  watchlistCacheTag,
+} from "../cache-tags";
+
+/**
+ * The contract these tests guard: the strings emitted by the namers ARE
+ * the tags `updateTag()` is called with from server actions, and the
+ * same strings are passed to `cacheTag()` inside `'use cache'` boundaries.
+ * If the format drifts, mutations stop busting their cached pages — a
+ * silent staleness bug. So these are exact-string assertions on purpose.
+ *
+ * See PR #2888 for the original feature context and round-3/round-4
+ * critic asks behind this test file.
+ */
+describe("cache-tags", () => {
+  describe("watchlistCacheTag", () => {
+    it("returns watchlist:<userSlug>:<watchlistSlug>", () => {
+      expect(watchlistCacheTag("alice", "saved-jobs")).toBe(
+        "watchlist:alice:saved-jobs",
+      );
+    });
+
+    it("produces different tags for different inputs", () => {
+      expect(watchlistCacheTag("alice", "a")).not.toBe(
+        watchlistCacheTag("alice", "b"),
+      );
+      expect(watchlistCacheTag("alice", "x")).not.toBe(
+        watchlistCacheTag("bob", "x"),
+      );
+    });
+
+    it("does not normalize special characters (slugs are validated upstream)", () => {
+      // The namer is a pure string concat — it doesn't sanitize. Slug
+      // shape is the caller's responsibility. Verify pass-through so we
+      // catch any future change that adds normalization.
+      expect(watchlistCacheTag("user:1", "wl/2")).toBe(
+        "watchlist:user:1:wl/2",
+      );
+    });
+  });
+
+  describe("companyCacheTag", () => {
+    it("returns company:<slug>", () => {
+      expect(companyCacheTag("stripe")).toBe("company:stripe");
+    });
+
+    it("produces different tags for different slugs", () => {
+      expect(companyCacheTag("stripe")).not.toBe(companyCacheTag("airbnb"));
+    });
+
+    it("does not normalize special characters in the slug", () => {
+      expect(companyCacheTag("foo-bar")).toBe("company:foo-bar");
+      expect(companyCacheTag("foo:bar")).toBe("company:foo:bar");
+    });
+  });
+
+  describe("blogPostCacheTag", () => {
+    it("returns blog-post:<slug>", () => {
+      expect(blogPostCacheTag("hello-world")).toBe("blog-post:hello-world");
+    });
+
+    it("produces different tags for different slugs", () => {
+      expect(blogPostCacheTag("hello-world")).not.toBe(
+        blogPostCacheTag("goodbye-world"),
+      );
+    });
+
+    it("does not normalize special characters in the slug", () => {
+      expect(blogPostCacheTag("with spaces")).toBe("blog-post:with spaces");
+      expect(blogPostCacheTag("a:b")).toBe("blog-post:a:b");
+    });
+  });
+
+  describe("blogIndexCacheTag", () => {
+    it("returns the literal blog-index", () => {
+      expect(blogIndexCacheTag()).toBe("blog-index");
+    });
+
+    it("returns the same tag on every call (no input)", () => {
+      expect(blogIndexCacheTag()).toBe(blogIndexCacheTag());
+    });
+  });
+
+  describe("namer namespace separation", () => {
+    // Cross-namer regression guard. If anyone collapses two namers to
+    // share a prefix, an `updateTag('blog-post:slug')` call could
+    // accidentally bust unrelated cached pages.
+    it("each namer uses a distinct resource prefix", () => {
+      expect(watchlistCacheTag("u", "w").startsWith("watchlist:")).toBe(true);
+      expect(companyCacheTag("s").startsWith("company:")).toBe(true);
+      expect(blogPostCacheTag("s").startsWith("blog-post:")).toBe(true);
+      expect(blogIndexCacheTag()).toBe("blog-index");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2891. Two missing test surfaces flagged in PR #2888 round-3 / round-4 critic review.

- `apps/web/src/lib/__tests__/cache-tags.test.ts` — 12 tests covering all 4 namers (`watchlistCacheTag`, `companyCacheTag`, `blogPostCacheTag`, `blogIndexCacheTag`): exact returned-string format, different-input-different-tag invariant, special-character pass-through (slugs are URL-validated upstream — namers do not normalize), and a cross-namer prefix-uniqueness regression guard.
- `apps/web/app/[lang]/(app)/company/[slug]/__tests__/opengraph-image-prebake.test.ts` — 5 tests on `generateStaticParams` exercising all four env x Typesense quadrants from the issue plus the happy path.

## Approach (OG prebake)

The prebake function is already exported as `generateStaticParams`, and it dynamically `import`s `@/lib/search/typesense-client` inside the `try` block. That made `vi.mock("@/lib/search/typesense-client")` sufficient to drive every quadrant without extracting a helper or touching the production file — no source changes required. `vi.spyOn(console, "warn")` asserts the soft-fail vs. fail-loud split deterministically; env vars are saved/restored in `beforeEach`/`afterEach` so the four quadrants do not leak into each other.

`getCompanyBySlug` is also mocked at module-load to keep the test isolated from db/Typesense/cache transitive deps it would otherwise pull in (the default `OgImage` handler isn't exercised here).

## Coverage of the fail-loud condition

All four env x Typesense state quadrants asked for in the issue:

| `VERCEL_ENV` | `TYPESENSE_HOST` | Typesense | Expected |
|---|---|---|---|
| `production` | set | throws | re-throws |
| `production` | set | returns 0 | warns, `[]` |
| `preview` | unset | throws | warns, `[]` |
| unset | unset | throws | warns, `[]` |

Plus a happy-path test (2 slugs x 4 locales = 8 entries) covering the slug x locale matrix construction.

## Test runner output

Two-file scoped run:

```
 ✓ src/lib/__tests__/cache-tags.test.ts (12 tests) 3ms
 ✓ app/[lang]/(app)/company/[slug]/__tests__/opengraph-image-prebake.test.ts (5 tests) 8ms

 Test Files  2 passed (2)
      Tests  17 passed (17)
```

Full suite (`pnpm test`):

```
 Test Files  53 passed (53)
      Tests  467 passed (467)
   Duration  4.34s
```

`pnpm exec tsc --noEmit` exit 0; `pnpm lint` clean.

## Test plan

- [x] `pnpm test src/lib/__tests__/cache-tags.test.ts 'app/[lang]/(app)/company/[slug]/__tests__/opengraph-image-prebake.test.ts'` — both pass (17 tests).
- [x] `pnpm test` — full suite still passes (53 files / 467 tests).
- [x] `pnpm exec tsc --noEmit` — clean.
- [x] `pnpm lint` — clean.
- [ ] CI green on the PR.

## Mechanical scope expansion

None. The OG production file is unchanged; no helper extraction was required because `generateStaticParams` is already a named export and uses dynamic `import()` for the only dependency that needed mocking.