### PR TITLE
test(web): build-output classifier as ISR slow-lane (closes #2885)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,15 +150,25 @@ jobs:
       - run: pnpm --filter @jobseek/web test
 
   test-web-isr:
-    # Slow lane: runs `pnpm build` once and asserts the must-stay-cacheable
-    # routes (4 ISR pages + public marketing surfaces) are classified as
-    # `◐ Partial Prerender` or `○ Static` in Next 16's route summary —
-    # never `ƒ Dynamic`. Successor to the retired `app/__tests__/isr-routes.test.ts`
-    # line scanner, see #2885 (and incident #2243).
+    # Slow lane: runs `pnpm build` once via the vitest globalSetup
+    # (`apps/web/test-setup/run-prod-build.ts`) and asserts each
+    # must-stay-cacheable route is classified with its expected glyph
+    # (`◐ Partial Prerender` or `○ Static`) in Next 16's route summary.
+    # Catches three classes the build itself cannot: parser drift if
+    # Next's stdout shape changes, list rot if a route is removed, and
+    # ◐↔○ classification drift (the build only fails on `→ ƒ`). See
+    # #2885 (and incident #2243).
     name: Test Web ISR (slow)
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    # `Production` environment exposes DATABASE_URL + TYPESENSE_* secrets.
+    # The build needs DATABASE_URL because the blog `MdxMentions` server
+    # action (rendered for every per-post path during static generation)
+    # reads from Supabase — empirically validated in #2900 (replacing it
+    # with a stub DSN reproduces a Failed query / ECONNREFUSED prerender
+    # error on `/[lang]/blog/how-we-index-job-postings`).
+    environment: Production
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -177,6 +187,38 @@ jobs:
       # (`apps/web/test-setup/run-prod-build.ts`), so no separate build
       # step is needed.
       - run: pnpm --filter @jobseek/web test:isr
+        env:
+          # Required: blog `<Mention>` MDX components fetch company tooltips
+          # at build time. Without a real DSN the per-post prerender fails.
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}
+          # Build-time-readable Typesense client config. Present as Production
+          # secrets; provider falls back gracefully on connection error so
+          # the literal placeholder is fine when the secrets are missing in
+          # forks, but in the Production environment they resolve.
+          TYPESENSE_HOST: ${{ secrets.TYPESENSE_HOST }}
+          TYPESENSE_PORT: ${{ secrets.TYPESENSE_PORT }}
+          TYPESENSE_PROTOCOL: ${{ secrets.TYPESENSE_PROTOCOL }}
+          # Build-time-only stubs. These are NOT used to authenticate to
+          # any real service during the test build — auth/sso secrets and
+          # the search/write keys are only read at runtime by request
+          # handlers, which the build does not exercise. We pass literal
+          # placeholders so module-top-level reads (e.g. better-auth's
+          # OAuth provider config) don't throw and so search code paths
+          # that read these names see a non-empty string.
+          BETTER_AUTH_SECRET: ci-stub-better-auth-secret-not-used-at-build-time
+          BETTER_AUTH_URL: http://localhost:3000
+          TYPESENSE_SEARCH_KEY: ci-stub-not-used-at-build-time
+          TYPESENSE_WRITE_KEY: ci-stub-not-used-at-build-time
+          GITHUB_CLIENT_ID: ci-stub
+          GITHUB_CLIENT_SECRET: ci-stub
+          GOOGLE_CLIENT_ID: ci-stub
+          GOOGLE_CLIENT_SECRET: ci-stub
+          LINKEDIN_CLIENT_ID: ci-stub
+          LINKEDIN_CLIENT_SECRET: ci-stub
+          RESEND_API_KEY: ci-stub
+          UPSTASH_REDIS_REST_URL: https://stub.invalid
+          UPSTASH_REDIS_REST_TOKEN: ci-stub
 
   test-shim:
     name: Test Murmur Shim

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,35 @@ jobs:
 
       - run: pnpm --filter @jobseek/web test
 
+  test-web-isr:
+    # Slow lane: runs `pnpm build` once and asserts the must-stay-cacheable
+    # routes (4 ISR pages + public marketing surfaces) are classified as
+    # `◐ Partial Prerender` or `○ Static` in Next 16's route summary —
+    # never `ƒ Dynamic`. Successor to the retired `app/__tests__/isr-routes.test.ts`
+    # line scanner, see #2885 (and incident #2243).
+    name: Test Web ISR (slow)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm --filter @jseek/mcp-server build
+
+      # `pnpm test:isr` runs the build itself via vitest globalSetup
+      # (`apps/web/test-setup/run-prod-build.ts`), so no separate build
+      # step is needed.
+      - run: pnpm --filter @jobseek/web test:isr
+
   test-shim:
     name: Test Murmur Shim
     needs: changes

--- a/apps/web/__tests__/build-output.test.ts
+++ b/apps/web/__tests__/build-output.test.ts
@@ -5,74 +5,84 @@ import { describe, expect, it } from "vitest";
  * Build-output classifier (#2885 — successor to the retired
  * `app/__tests__/isr-routes.test.ts` line scanner).
  *
- * The build itself rejects the patterns the old scanner looked for
- * once `cacheComponents: true` is on (#2835). What it doesn't do:
- * tell a developer who broke ISR which page slipped to dynamic and
- * what the canonical fix is. The build error is "X is dynamic"
- * without the prescribed remediation, so the regressing PR has to
- * dig through Next.js docs to recover.
+ * Once `cacheComponents: true` is on (#2835) the production build itself
+ * rejects most of the patterns the old line scanner caught — a regression
+ * fails compile, not lint. So this test deliberately does NOT try to
+ * recreate the build's own ƒ-Dynamic guard. Instead it covers the gaps
+ * the build cannot:
  *
- * This test reads Next 16's per-route classification from the build
- * stdout — one of:
+ *   1. Parse-guard. The build summary is captured to disk by the vitest
+ *      globalSetup (`test-setup/run-prod-build.ts`). If the parser finds
+ *      zero routes, either the build never reached the summary line
+ *      (silent failure earlier) or Next 16's stdout shape changed and
+ *      our regex no longer matches. Either way the rest of the assertions
+ *      are vacuous, so we surface that root cause first.
  *
- *   ○  (Static)             prerendered as static content
- *   ◐  (Partial Prerender)  prerendered static HTML + dynamic streams
- *   ƒ  (Dynamic)            server-rendered on demand
+ *   2. Classification drift (the load-bearing assertion). For each
+ *      must-stay-cacheable route we encode the EXPECTED glyph — `◐`
+ *      (Partial Prerender) or `○` (Static) — and assert the build
+ *      classified it that way. The build already fails on `ƒ`; what
+ *      it does not catch is e.g. an `◐` route accidentally collapsing
+ *      to `○` (lost a `<Suspense>` boundary, lost a dynamic island —
+ *      no longer streams personalised data) or vice-versa (`○` legal
+ *      page accidentally pulled in a server-side fetch). Both shapes
+ *      compile cleanly but represent semantic regressions.
  *
- * For an explicit list of routes that must stay cacheable (the 4 ISR
- * pages from #2835 + the public marketing surfaces), it asserts the
- * classification is `◐` or `○` — not `ƒ`. On failure the diagnostic
- * names the route AND prescribes the canonical fix.
+ *   3. Routes-of-interest list freshness. If a route in the must-stay
+ *      list was deleted or renamed in the source tree, the route key
+ *      stops appearing in the build summary. The list rots silently —
+ *      we'd think we were guarding a route we no longer ship. The
+ *      "expected this route in build output" assertion catches that.
  *
- * The build stdout is captured by the vitest globalSetup at
- * `test-setup/run-prod-build.ts`. CI may pre-build and pass the
- * captured log via `BUILD_OUTPUT_LOG=<path>` to skip a redundant
- * second build.
- *
- * Background incident: #2243 (ISR-leakage CPU-quota incident — a
- * single dynamic-API leak on `/[lang]/company/[slug]` blew the
- * monthly Vercel function quota).
+ * Background incident: #2243 (ISR-leakage CPU-quota incident — a single
+ * dynamic-API leak on `/[lang]/company/[slug]` blew the monthly Vercel
+ * function quota). The old line scanner caught this in lint; the new
+ * test catches the residual classes that survive `cacheComponents: true`.
  */
-
-/**
- * Routes that must stay cacheable. Each entry is a Next.js route key
- * exactly as Next prints it in the build summary (no locale prefix —
- * dynamic `[lang]` is preserved, the locale row is the parent).
- *
- * The list comprises:
- *   - The 4 ISR pages explicitly migrated in #2835:
- *       `/[lang]/explore`, `/[lang]/company/[slug]`,
- *       `/[lang]/[userSlug]/[watchlistSlug]`, `/[lang]/blog`,
- *       plus `/[lang]/blog/[slug]` (per-post render path is the
- *       hot SEO surface — should also stay cacheable).
- *   - Public marketing surfaces under `(public)`: the home page
- *     `/[lang]`, plus `/[lang]/{about,faq,how-we-index,license,
- *     privacy-policy,terms}`. These are static-shell pages that
- *     should never opt into dynamic rendering.
- *
- * If you intentionally remove a route from this list (say a marketing
- * page that becomes auth-gated), update the list AND link the
- * justification in the PR — falling off this list is a CPU-cost
- * regression.
- */
-const MUST_STAY_CACHEABLE: ReadonlyArray<string> = [
-  // 4 ISR pages (#2835 migration targets)
-  "/[lang]/explore",
-  "/[lang]/company/[slug]",
-  "/[lang]/[userSlug]/[watchlistSlug]",
-  "/[lang]/blog",
-  "/[lang]/blog/[slug]",
-  // Public marketing surfaces — home + (public) route group children
-  "/[lang]",
-  "/[lang]/about",
-  "/[lang]/faq",
-  "/[lang]/how-we-index",
-  "/[lang]/license",
-  "/[lang]/privacy-policy",
-  "/[lang]/terms",
-];
 
 type Classification = "static" | "partial" | "dynamic";
+
+/**
+ * Routes that must stay cacheable, plus the EXPECTED Next 16 glyph.
+ *
+ * - `partial` (◐ Partial Prerender) is the right answer for any page
+ *   that streams per-viewer or otherwise personalised content inside a
+ *   static shell (the four #2835 ISR pages, blog list/post, the home
+ *   `(public)/page.tsx` shell, and the marketing pages that use
+ *   `getViewerLanguages`/`headers()` for CTAs and locale routing).
+ *
+ * - `static` (○ Static) is the right answer for pages with zero dynamic
+ *   islands — pure content. We do not currently ship any pages in this
+ *   bucket: every public page reads at least viewer locale or auth
+ *   state. The map shape supports it for when we do, and so the test
+ *   distinguishes "drifted from ◐ to ○" (lost personalisation) from
+ *   "drifted from ◐ to ƒ" (lost cacheability).
+ *
+ * If a route is intentionally removed (e.g. a marketing page becomes
+ * auth-gated), update this map AND link the justification in the PR —
+ * silent drop is a CPU-cost regression, see #2243.
+ */
+const EXPECTED_CLASSIFICATIONS: ReadonlyMap<string, Classification> = new Map([
+  // The 4 ISR pages explicitly migrated in #2835 — all stream per-viewer
+  // data inside a static shell.
+  ["/[lang]/explore", "partial"],
+  ["/[lang]/company/[slug]", "partial"],
+  ["/[lang]/[userSlug]/[watchlistSlug]", "partial"],
+  ["/[lang]/blog", "partial"],
+  // Per-post render path is the hot SEO surface — must stay cacheable.
+  ["/[lang]/blog/[slug]", "partial"],
+  // Public marketing surfaces — home page + (public) route group.
+  // All currently ◐ because the shell reads viewer locale/auth state for
+  // CTAs and locale-prefixed links. If a page collapses to ○ that means
+  // the locale-aware island was dropped — fail loudly.
+  ["/[lang]", "partial"],
+  ["/[lang]/about", "partial"],
+  ["/[lang]/faq", "partial"],
+  ["/[lang]/how-we-index", "partial"],
+  ["/[lang]/license", "partial"],
+  ["/[lang]/privacy-policy", "partial"],
+  ["/[lang]/terms", "partial"],
+]);
 
 const SYMBOL_TO_CLASSIFICATION: Record<string, Classification> = {
   "○": "static",
@@ -124,41 +134,107 @@ function parseRouteClassifications(buildOutput: string): Map<string, Classificat
   return map;
 }
 
-function fixHint(route: string): string {
-  return [
-    `Route \`${route}\` was classified as ƒ Dynamic in the production build,`,
-    "but it must stay statically prerenderable (◐ Partial Prerender or ○ Static).",
+/**
+ * Diagnostic for a route that was found in the build output but with
+ * the wrong glyph. Distinguishes the two non-trivial drift directions
+ * (the build itself catches `→ ƒ`, but `◐ → ○` and `○ → ◐` survive).
+ */
+function driftDiagnostic(route: string, expected: Classification, actual: Classification): string {
+  const expectedLabel = CLASSIFICATION_LABEL[expected];
+  const actualLabel = CLASSIFICATION_LABEL[actual];
+  const lines: string[] = [
+    `Route \`${route}\` was classified as ${actualLabel} in the production`,
+    `build, but EXPECTED_CLASSIFICATIONS pins it to ${expectedLabel}.`,
     "",
-    "Canonical fix: check that the page body and `generateMetadata` both have",
-    "`'use cache'` + `cacheLife({ revalidate: N })` and that no helper on the",
-    "render path reads runtime APIs (`cookies()`, `headers()`, `searchParams`",
-    "without `await`-then-passing-into-a-cache-fn). Helpers that internally",
-    "read request state — `getSession`, `getSessionUserId`, `getViewerLanguages`,",
-    "`getGeoFromHeaders`, `getPreferences`, `fetchExploreData`, `listTopCompanies` —",
-    "must move into a `<Suspense>`-wrapped child or a server action fired",
-    "from the client. See `apps/web/docs/cache-components.md` and #2243.",
+  ];
+  if (actual === "dynamic") {
+    // Should be unreachable with `cacheComponents: true` — the build
+    // itself rejects this — but keep the prescription for the rare
+    // case where the build loosens or the assertion order changes.
+    lines.push(
+      "Canonical fix: check that the page body and `generateMetadata` both have",
+      "`'use cache'` + `cacheLife({ revalidate: N })` and that no helper on the",
+      "render path reads runtime APIs (`cookies()`, `headers()`, `searchParams`",
+      "without `await`-then-passing-into-a-cache-fn). Helpers that internally",
+      "read request state — `getSession`, `getSessionUserId`, `getViewerLanguages`,",
+      "`getGeoFromHeaders`, `getPreferences`, `fetchExploreData`, `listTopCompanies` —",
+      "must move into a `<Suspense>`-wrapped child or a server action fired",
+      "from the client. See `apps/web/docs/cache-components.md` and #2243.",
+    );
+  } else if (expected === "partial" && actual === "static") {
+    lines.push(
+      "A `◐ → ○` drift means the page lost a dynamic island — the build no",
+      "longer detects any per-viewer streaming content inside the shell.",
+      "That is silently a UX regression (e.g. a personalised CTA collapsed",
+      "to a hard-coded one) and a cacheability regression for pages that",
+      "depend on viewer-language routing.",
+      "",
+      "Likely causes: a `<Suspense>`-wrapped island was deleted or its data",
+      "fetcher was inlined into the cached parent. Review the latest diff",
+      "to the page file and any helper it imports — anything that previously",
+      "read `headers()` / `cookies()` / `getViewerLanguages()` should still be",
+      "doing so inside a Suspense boundary.",
+      "",
+      "If this drift is intentional (page genuinely no longer needs per-viewer",
+      "data), update EXPECTED_CLASSIFICATIONS to `static` AND link the",
+      "justification in the PR.",
+    );
+  } else {
+    lines.push(
+      "A `○ → ◐` drift means a page that should be pure-static now contains",
+      "a dynamic island. That is a CPU-cost regression — every request now",
+      "incurs a function invocation for the streamed subtree.",
+      "",
+      "Likely causes: a helper imported by the page (or its layout) started",
+      "reading runtime state (`headers()`, `cookies()`, viewer-derived data)",
+      "where it previously did not.",
+      "",
+      "If this drift is intentional, update EXPECTED_CLASSIFICATIONS to",
+      "`partial` AND link the justification in the PR.",
+    );
+  }
+  return lines.join("\n");
+}
+
+function missingRouteDiagnostic(route: string, expected: Classification): string {
+  return [
+    `Route \`${route}\` was not present in the production build's route summary,`,
+    `but EXPECTED_CLASSIFICATIONS pins it to ${CLASSIFICATION_LABEL[expected]}.`,
+    "",
+    "Either the route was renamed/removed in the source tree (in which case",
+    "remove it from EXPECTED_CLASSIFICATIONS — the must-stay-cacheable list",
+    "rots silently if entries no longer match real routes), or the build",
+    "never printed the summary (look for build failures earlier in the log).",
+    "",
+    "This guard exists because a stale list would silently drop coverage —",
+    "we'd think we were watching a route we no longer ship. See #2885.",
   ].join("\n");
 }
 
-describe("Production build keeps must-stay-cacheable routes prerenderable", () => {
+describe("build-output classifier (slow lane, #2885)", () => {
   const logPath = process.env.BUILD_OUTPUT_LOG;
 
-  it("globalSetup captured the build output", () => {
+  /** Parse-guard: the globalSetup must have produced a log path. */
+  it("globalSetup captured a build-output log", () => {
     expect(
       logPath,
       "BUILD_OUTPUT_LOG must be set by the globalSetup (test-setup/run-prod-build.ts)",
     ).toBeTruthy();
-    expect(existsSync(logPath!), `build output log not found at ${logPath}`).toBe(true);
+    expect(existsSync(logPath!), `build-output log not found at ${logPath}`).toBe(true);
   });
 
   // Eagerly parse so per-route assertions don't reparse the whole log.
   const buildOutput = logPath && existsSync(logPath) ? readFileSync(logPath, "utf8") : "";
   const classifications = parseRouteClassifications(buildOutput);
 
-  it("parsed at least one route from the build output", () => {
-    // If the parser found nothing, every per-route assertion below will
-    // give a confusing "expected partial got undefined" — surface the
-    // root cause first.
+  /**
+   * Parse-guard #2: ensure the parser actually matched routes. If the
+   * build silently failed before the summary, or Next 16's stdout shape
+   * changed and our regex no longer matches, every per-route assertion
+   * below would degrade to a confusing "got undefined" — surface the
+   * root cause first.
+   */
+  it("parsed at least one route from the build summary", () => {
     expect(
       classifications.size,
       [
@@ -171,23 +247,23 @@ describe("Production build keeps must-stay-cacheable routes prerenderable", () =
     ).toBeGreaterThan(0);
   });
 
-  for (const route of MUST_STAY_CACHEABLE) {
-    it(`${route} is not classified as Dynamic`, () => {
-      const cls = classifications.get(route);
-      expect(
-        cls,
-        [
-          `Route \`${route}\` was not present in the production build's route summary.`,
-          "Either the route was removed (in which case update MUST_STAY_CACHEABLE),",
-          "or the build never printed the summary (look for build failures earlier",
-          "in the log).",
-        ].join("\n"),
-      ).toBeDefined();
-      expect(cls, fixHint(route)).not.toBe("dynamic");
-      expect(
-        cls === "static" || cls === "partial",
-        `Route \`${route}\` was classified as ${CLASSIFICATION_LABEL[cls!]} — expected ◐ or ○.`,
-      ).toBe(true);
+  for (const [route, expected] of EXPECTED_CLASSIFICATIONS) {
+    const expectedLabel = CLASSIFICATION_LABEL[expected];
+
+    /**
+     * Per-route assertion. Combines (b) drift and (c) list freshness:
+     *
+     *   - If the route is missing from the build output → list rotted
+     *     (route was renamed/removed). Diagnose with missingRouteDiagnostic.
+     *   - If the actual glyph differs from expected → semantic drift
+     *     (◐↔○ collapse, or the rare ƒ that the build itself missed).
+     *     Diagnose with driftDiagnostic, naming both glyphs and the
+     *     direction-specific fix prescription.
+     */
+    it(`${route} stays ${expectedLabel}`, () => {
+      const actual = classifications.get(route);
+      expect(actual, missingRouteDiagnostic(route, expected)).toBeDefined();
+      expect(actual, driftDiagnostic(route, expected, actual!)).toBe(expected);
     });
   }
 });

--- a/apps/web/__tests__/build-output.test.ts
+++ b/apps/web/__tests__/build-output.test.ts
@@ -1,0 +1,193 @@
+import { existsSync, readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Build-output classifier (#2885 — successor to the retired
+ * `app/__tests__/isr-routes.test.ts` line scanner).
+ *
+ * The build itself rejects the patterns the old scanner looked for
+ * once `cacheComponents: true` is on (#2835). What it doesn't do:
+ * tell a developer who broke ISR which page slipped to dynamic and
+ * what the canonical fix is. The build error is "X is dynamic"
+ * without the prescribed remediation, so the regressing PR has to
+ * dig through Next.js docs to recover.
+ *
+ * This test reads Next 16's per-route classification from the build
+ * stdout — one of:
+ *
+ *   ○  (Static)             prerendered as static content
+ *   ◐  (Partial Prerender)  prerendered static HTML + dynamic streams
+ *   ƒ  (Dynamic)            server-rendered on demand
+ *
+ * For an explicit list of routes that must stay cacheable (the 4 ISR
+ * pages from #2835 + the public marketing surfaces), it asserts the
+ * classification is `◐` or `○` — not `ƒ`. On failure the diagnostic
+ * names the route AND prescribes the canonical fix.
+ *
+ * The build stdout is captured by the vitest globalSetup at
+ * `test-setup/run-prod-build.ts`. CI may pre-build and pass the
+ * captured log via `BUILD_OUTPUT_LOG=<path>` to skip a redundant
+ * second build.
+ *
+ * Background incident: #2243 (ISR-leakage CPU-quota incident — a
+ * single dynamic-API leak on `/[lang]/company/[slug]` blew the
+ * monthly Vercel function quota).
+ */
+
+/**
+ * Routes that must stay cacheable. Each entry is a Next.js route key
+ * exactly as Next prints it in the build summary (no locale prefix —
+ * dynamic `[lang]` is preserved, the locale row is the parent).
+ *
+ * The list comprises:
+ *   - The 4 ISR pages explicitly migrated in #2835:
+ *       `/[lang]/explore`, `/[lang]/company/[slug]`,
+ *       `/[lang]/[userSlug]/[watchlistSlug]`, `/[lang]/blog`,
+ *       plus `/[lang]/blog/[slug]` (per-post render path is the
+ *       hot SEO surface — should also stay cacheable).
+ *   - Public marketing surfaces under `(public)`: the home page
+ *     `/[lang]`, plus `/[lang]/{about,faq,how-we-index,license,
+ *     privacy-policy,terms}`. These are static-shell pages that
+ *     should never opt into dynamic rendering.
+ *
+ * If you intentionally remove a route from this list (say a marketing
+ * page that becomes auth-gated), update the list AND link the
+ * justification in the PR — falling off this list is a CPU-cost
+ * regression.
+ */
+const MUST_STAY_CACHEABLE: ReadonlyArray<string> = [
+  // 4 ISR pages (#2835 migration targets)
+  "/[lang]/explore",
+  "/[lang]/company/[slug]",
+  "/[lang]/[userSlug]/[watchlistSlug]",
+  "/[lang]/blog",
+  "/[lang]/blog/[slug]",
+  // Public marketing surfaces — home + (public) route group children
+  "/[lang]",
+  "/[lang]/about",
+  "/[lang]/faq",
+  "/[lang]/how-we-index",
+  "/[lang]/license",
+  "/[lang]/privacy-policy",
+  "/[lang]/terms",
+];
+
+type Classification = "static" | "partial" | "dynamic";
+
+const SYMBOL_TO_CLASSIFICATION: Record<string, Classification> = {
+  "○": "static",
+  "◐": "partial",
+  "ƒ": "dynamic",
+};
+
+const CLASSIFICATION_LABEL: Record<Classification, string> = {
+  static: "○ Static",
+  partial: "◐ Partial Prerender",
+  dynamic: "ƒ Dynamic",
+};
+
+/**
+ * Parse Next 16's route summary out of the build stdout.
+ *
+ * The summary block starts with a `Route (app)` header and lists each
+ * route on its own line in the form:
+ *
+ *   ┌ ○ /_not-found
+ *   ├ ◐ /[lang]
+ *   │ ├ /[lang]
+ *   │ ├ /en
+ *   │ └ [+2 more paths]
+ *   ├ ƒ /api/v1/job
+ *   └ ƒ /sitemap.xml
+ *
+ * The leading box-drawing characters and the indented child rows are
+ * irrelevant — we only want the parent rows that begin with a top-level
+ * `┌`/`├`/`└` followed by a single classification glyph.
+ */
+function parseRouteClassifications(buildOutput: string): Map<string, Classification> {
+  const map = new Map<string, Classification>();
+  // Match a top-level route row: starts with one of `┌├└` (no `│ ` prefix
+  // which marks indented children), then the classification symbol, then
+  // the route path (everything up to optional whitespace + revalidate
+  // columns at the end).
+  const lineRe = /^[┌├└]\s*([○◐ƒ])\s+(\S+)/u;
+  for (const rawLine of buildOutput.split(/\r?\n/)) {
+    const line = rawLine.replace(/\s+$/u, "");
+    const match = lineRe.exec(line);
+    if (!match) continue;
+    const symbol = match[1];
+    const route = match[2];
+    const cls = SYMBOL_TO_CLASSIFICATION[symbol];
+    if (!cls) continue;
+    map.set(route, cls);
+  }
+  return map;
+}
+
+function fixHint(route: string): string {
+  return [
+    `Route \`${route}\` was classified as ƒ Dynamic in the production build,`,
+    "but it must stay statically prerenderable (◐ Partial Prerender or ○ Static).",
+    "",
+    "Canonical fix: check that the page body and `generateMetadata` both have",
+    "`'use cache'` + `cacheLife({ revalidate: N })` and that no helper on the",
+    "render path reads runtime APIs (`cookies()`, `headers()`, `searchParams`",
+    "without `await`-then-passing-into-a-cache-fn). Helpers that internally",
+    "read request state — `getSession`, `getSessionUserId`, `getViewerLanguages`,",
+    "`getGeoFromHeaders`, `getPreferences`, `fetchExploreData`, `listTopCompanies` —",
+    "must move into a `<Suspense>`-wrapped child or a server action fired",
+    "from the client. See `apps/web/docs/cache-components.md` and #2243.",
+  ].join("\n");
+}
+
+describe("Production build keeps must-stay-cacheable routes prerenderable", () => {
+  const logPath = process.env.BUILD_OUTPUT_LOG;
+
+  it("globalSetup captured the build output", () => {
+    expect(
+      logPath,
+      "BUILD_OUTPUT_LOG must be set by the globalSetup (test-setup/run-prod-build.ts)",
+    ).toBeTruthy();
+    expect(existsSync(logPath!), `build output log not found at ${logPath}`).toBe(true);
+  });
+
+  // Eagerly parse so per-route assertions don't reparse the whole log.
+  const buildOutput = logPath && existsSync(logPath) ? readFileSync(logPath, "utf8") : "";
+  const classifications = parseRouteClassifications(buildOutput);
+
+  it("parsed at least one route from the build output", () => {
+    // If the parser found nothing, every per-route assertion below will
+    // give a confusing "expected partial got undefined" — surface the
+    // root cause first.
+    expect(
+      classifications.size,
+      [
+        "Could not parse any route classifications from the build output.",
+        `Log path: ${logPath ?? "(unset)"}`,
+        "Either the build failed before the route summary printed, or the",
+        "Next.js stdout format changed. Re-run `pnpm build` and inspect the",
+        "tail of the log — the summary should look like `┌ ○ /_not-found`.",
+      ].join("\n"),
+    ).toBeGreaterThan(0);
+  });
+
+  for (const route of MUST_STAY_CACHEABLE) {
+    it(`${route} is not classified as Dynamic`, () => {
+      const cls = classifications.get(route);
+      expect(
+        cls,
+        [
+          `Route \`${route}\` was not present in the production build's route summary.`,
+          "Either the route was removed (in which case update MUST_STAY_CACHEABLE),",
+          "or the build never printed the summary (look for build failures earlier",
+          "in the log).",
+        ].join("\n"),
+      ).toBeDefined();
+      expect(cls, fixHint(route)).not.toBe("dynamic");
+      expect(
+        cls === "static" || cls === "partial",
+        `Route \`${route}\` was classified as ${CLASSIFICATION_LABEL[cls!]} — expected ◐ or ○.`,
+      ).toBe(true);
+    });
+  }
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "notify-blog-indexnow": "tsx script/notify-blog-indexnow.ts",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:isr": "vitest run --config vitest.isr.config.ts",
     "typecheck": "next typegen && tsc"
   },
   "dependencies": {

--- a/apps/web/test-setup/run-prod-build.ts
+++ b/apps/web/test-setup/run-prod-build.ts
@@ -1,0 +1,58 @@
+import { execSync } from "node:child_process";
+import { writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Vitest globalSetup for the ISR build-output classifier slow lane.
+ *
+ * Runs `pnpm build` once before the test file and writes the captured
+ * stdout to a known artifact path that the test reads. The test then
+ * parses the per-route classification (`◐` / `○` / `ƒ`) from the build
+ * output and asserts that each route in the must-stay-cacheable list
+ * is NOT classified as `ƒ Dynamic`. See `apps/web/__tests__/build-output.test.ts`.
+ *
+ * Skipping the build: set `BUILD_OUTPUT_LOG` to point at an existing
+ * captured-stdout file. CI splits this into a separate job that already
+ * runs the build, so it sets the env var to skip the second build here.
+ *
+ * The build output is captured at `apps/web/.next/build-output.log` so
+ * a developer running `pnpm test:isr` locally can re-read it after the
+ * fact for diagnosis.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const webRoot = join(here, "..");
+const defaultLogPath = join(webRoot, ".next", "build-output.log");
+
+export default async function setup(): Promise<void> {
+  const explicit = process.env.BUILD_OUTPUT_LOG;
+  if (explicit && existsSync(explicit)) {
+    process.env.BUILD_OUTPUT_LOG = explicit;
+    return;
+  }
+
+  // Ensure .next exists so we can write the log inside it.
+  mkdirSync(join(webRoot, ".next"), { recursive: true });
+
+  // Run the production build, capture combined stdout+stderr for parsing.
+  // We don't fail the setup on a non-zero exit code: if the build fails,
+  // the test itself surfaces a clearer "no route summary found" error.
+  let output = "";
+  try {
+    output = execSync("pnpm build", {
+      cwd: webRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      maxBuffer: 1024 * 1024 * 64,
+    });
+  } catch (err) {
+    const e = err as { stdout?: string | Buffer; stderr?: string | Buffer };
+    const out = typeof e.stdout === "string" ? e.stdout : (e.stdout?.toString() ?? "");
+    const errOut = typeof e.stderr === "string" ? e.stderr : (e.stderr?.toString() ?? "");
+    output = `${out}\n${errOut}`;
+  }
+
+  writeFileSync(defaultLogPath, output, "utf8");
+  process.env.BUILD_OUTPUT_LOG = defaultLogPath;
+}

--- a/apps/web/vitest.isr.config.ts
+++ b/apps/web/vitest.isr.config.ts
@@ -1,0 +1,37 @@
+import { defineConfig } from "vitest/config";
+import path from "path";
+
+/**
+ * Slow-lane vitest config for the ISR build-output classifier
+ * (`apps/web/__tests__/build-output.test.ts`, see #2885).
+ *
+ * Runs `pnpm build` once via globalSetup, captures the per-route
+ * classification (`◐` / `○` / `ƒ`) from stdout, and asserts the
+ * must-stay-cacheable routes are not Dynamic. Excluded from the
+ * default `pnpm test` config (which only includes `src/**` and
+ * `app/**`).
+ *
+ * Usage:
+ *   pnpm test:isr          # run build + classifier locally
+ *   BUILD_OUTPUT_LOG=path  # skip build, read pre-captured log (CI split)
+ */
+export default defineConfig({
+  esbuild: {
+    jsx: "automatic",
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["__tests__/build-output.test.ts"],
+    globalSetup: ["./test-setup/run-prod-build.ts"],
+    // The build itself eats 1-3 minutes; per-test timeout has to clear it
+    // since the globalSetup blocks until pnpm build finishes.
+    testTimeout: 600_000,
+    hookTimeout: 600_000,
+  },
+});


### PR DESCRIPTION
## Summary
Successor to the retired `app/__tests__/isr-routes.test.ts` line-by-line scanner (#2835). Under cacheComponents the build itself rejects the patterns the old scanner caught, but the build error is "X is dynamic" without the prescribed fix — so a regressing PR has to dig through Next.js docs to recover.

The new test reads Next 16's per-route classification (◐/○/ƒ) from `pnpm build`'s stdout and asserts the must-stay-cacheable routes (4 ISR pages + public marketing surfaces) are not ƒ Dynamic. On failure it names the route AND prescribes the canonical fix verbatim.

## Files
- `apps/web/__tests__/build-output.test.ts` — the test itself
- `apps/web/test-setup/run-prod-build.ts` — vitest globalSetup that runs `pnpm build` once and writes stdout to `.next/build-output.log`. CI may pre-build and pass `BUILD_OUTPUT_LOG=<path>` to skip
- `apps/web/vitest.isr.config.ts` — slow-lane vitest config
- `apps/web/package.json` — adds `pnpm test:isr` script
- `.github/workflows/ci.yml` — adds `test-web-isr` slow-lane job

## Decisions
- **Artifact source: stdout regex on `┌├└ <symbol> <route>` rows.** The `prerender-manifest.json` only lists explicitly-prerendered static routes, so it can't distinguish ◐ from ƒ for dynamic-segment routes (`company/[slug]`, `[userSlug]/[watchlistSlug]`).
- **Slow-lane: vitest globalSetup that runs the build before the test file.** Matches the issue's `globalSetup=run-prod-build` hint exactly.
- **Routes-of-interest** (12 total): 4 ISR pages from #2835 (`/[lang]/explore`, `/[lang]/company/[slug]`, `/[lang]/[userSlug]/[watchlistSlug]`, `/[lang]/blog`) + `/[lang]/blog/[slug]` + 7 public marketing pages (`/[lang]`, `/[lang]/about`, `/[lang]/faq`, `/[lang]/how-we-index`, `/[lang]/license`, `/[lang]/privacy-policy`, `/[lang]/terms`).

## Test placement
Lives at `apps/web/__tests__/build-output.test.ts` (NOT under `app/__tests__`) so it falls outside the default vitest config's include globs (`src/**`, `app/**`) — `pnpm test` stays fast (~5s, 483 tests) and excludes the slow lane automatically without an `exclude` rule.

## Empirical break test
Flipped `◐` to `ƒ` for `/[lang]/explore` in a captured build log and ran `BUILD_OUTPUT_LOG=... pnpm test:isr`. The failure named the route and printed the canonical-fix guidance verbatim:

```
AssertionError: Route `/[lang]/explore` was classified as ƒ Dynamic in the production build,
but it must stay statically prerenderable (◐ Partial Prerender or ○ Static).

Canonical fix: check that the page body and `generateMetadata` both have
`'use cache'` + `cacheLife({ revalidate: N })` and that no helper on the
render path reads runtime APIs (`cookies()`, `headers()`, `searchParams`
without `await`-then-passing-into-a-cache-fn). ...
```

## Test plan
- [x] `pnpm test:isr` passes locally (14 tests: 12 routes + 2 setup sanity checks)
- [x] `pnpm test` (default) does not include the slow file (54 files, 483 tests, ~5s)
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm lint` clean
- [x] Empirical break test fires the named-route diagnostic
- [x] `git status` clean after revert
- [ ] CI `test-web-isr` job runs and passes

## Background
- Closes #2885
- Background incident: #2243 (single dynamic-API leak on `company/[slug]` blew the monthly Vercel CPU quota)
- Predecessor scanner retired in: #2835

🤖 Generated with [Claude Code](https://claude.com/claude-code)