### PR TITLE
feat(web): migrate hierarchy caches to 'use cache' (#2884 partial)

### DIFF
--- a/apps/web/src/lib/actions/locations.ts
+++ b/apps/web/src/lib/actions/locations.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { sql } from "drizzle-orm";
+import { cacheLife } from "next/cache";
 import { db } from "@/db";
 import { cached } from "@/lib/cache";
 import { getTypesenseClient, type TypesenseHit } from "@/lib/search/typesense-client";
@@ -241,47 +242,53 @@ interface LocationMeta {
   names: Record<string, string>; // locale -> display name
 }
 
+// Per-region in-memory `'use cache'` (cacheLife('days')). Build ID is
+// included in the key automatically — every deploy re-fetches, which is
+// the right TTL semantics for taxonomy data driven by `crawler sync`.
+// Returns a plain `Record` (serializable); the wrapper converts to `Map`
+// for O(1) lookup ergonomics. Migrated from Redis-backed `cached()` in
+// #2884 (hierarchy-cache slice). See `apps/web/docs/cache-components.md`.
+async function _fetchLocationHierarchyData(): Promise<Record<string, LocationMeta>> {
+  "use cache";
+  cacheLife("days");
+
+  const rows = await db.execute<{
+    [key: string]: unknown;
+    id: number;
+    slug: string;
+    type: string;
+    parent_id: number | null;
+  }>(sql`SELECT id, slug, type::text AS type, parent_id FROM location`);
+
+  const nameRows = await db.execute<{
+    [key: string]: unknown;
+    location_id: number;
+    locale: string;
+    name: string;
+  }>(sql`SELECT location_id, locale, name FROM location_name WHERE is_display = true`);
+
+  const nameMap = new Map<number, Record<string, string>>();
+  for (const nr of nameRows as unknown as { location_id: number; locale: string; name: string }[]) {
+    let names = nameMap.get(nr.location_id);
+    if (!names) { names = {}; nameMap.set(nr.location_id, names); }
+    names[nr.locale] = nr.name;
+  }
+
+  const result: Record<string, LocationMeta> = {};
+  for (const r of rows as unknown as { id: number; slug: string; type: string; parent_id: number | null }[]) {
+    result[String(r.id)] = {
+      id: r.id,
+      slug: r.slug,
+      type: r.type,
+      parentId: r.parent_id,
+      names: nameMap.get(r.id) ?? {},
+    };
+  }
+  return result;
+}
+
 async function _getLocationHierarchyCache(): Promise<Map<number, LocationMeta>> {
-  const key = "loc-hierarchy-cache";
-  const record = await cached(
-    key,
-    async () => {
-      const rows = await db.execute<{
-        [key: string]: unknown;
-        id: number;
-        slug: string;
-        type: string;
-        parent_id: number | null;
-      }>(sql`SELECT id, slug, type::text AS type, parent_id FROM location`);
-
-      const nameRows = await db.execute<{
-        [key: string]: unknown;
-        location_id: number;
-        locale: string;
-        name: string;
-      }>(sql`SELECT location_id, locale, name FROM location_name WHERE is_display = true`);
-
-      const nameMap = new Map<number, Record<string, string>>();
-      for (const nr of nameRows as unknown as { location_id: number; locale: string; name: string }[]) {
-        let names = nameMap.get(nr.location_id);
-        if (!names) { names = {}; nameMap.set(nr.location_id, names); }
-        names[nr.locale] = nr.name;
-      }
-
-      const result: Record<string, LocationMeta> = {};
-      for (const r of rows as unknown as { id: number; slug: string; type: string; parent_id: number | null }[]) {
-        result[String(r.id)] = {
-          id: r.id,
-          slug: r.slug,
-          type: r.type,
-          parentId: r.parent_id,
-          names: nameMap.get(r.id) ?? {},
-        };
-      }
-      return result;
-    },
-    { ttl: 86400 },
-  );
+  const record = await _fetchLocationHierarchyData();
   return new Map(Object.entries(record).map(([k, v]) => [Number(k), v]));
 }
 

--- a/apps/web/src/lib/actions/taxonomy.ts
+++ b/apps/web/src/lib/actions/taxonomy.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { sql } from "drizzle-orm";
+import { cacheLife } from "next/cache";
 import { db } from "@/db";
 import { cached } from "@/lib/cache";
 import { getTypesenseClient, type TypesenseHit } from "@/lib/search/typesense-client";
@@ -402,83 +403,91 @@ interface OccupationDomainMeta {
   names: Record<string, string>;
 }
 
+// Per-region in-memory `'use cache'` (cacheLife('days')). Build ID is
+// included in the key automatically — every deploy re-fetches, which is
+// the right TTL semantics for taxonomy data driven by `crawler sync`.
+// Returns plain `Record`s (serializable); callers convert to `Map` for
+// O(1) lookup ergonomics. Migrated from Redis-backed `cached()` in #2884
+// (hierarchy-cache slice). See `apps/web/docs/cache-components.md`.
+async function _fetchOccupationHierarchyData(): Promise<{
+  occupations: Record<string, OccupationMeta>;
+  domains: Record<string, OccupationDomainMeta>;
+}> {
+  "use cache";
+  cacheLife("days");
+
+  // Fetch occupations
+  const occRows = await db.execute<{
+    [key: string]: unknown;
+    id: number;
+    slug: string;
+    parent_id: number | null;
+    domain_id: number | null;
+  }>(sql`SELECT id, slug, parent_id, domain_id FROM occupation`);
+
+  const occNameRows = await db.execute<{
+    [key: string]: unknown;
+    occupation_id: number;
+    locale: string;
+    name: string;
+  }>(sql`SELECT occupation_id, locale, name FROM occupation_name WHERE is_display = true`);
+
+  const occNameMap = new Map<number, Record<string, string>>();
+  for (const nr of occNameRows as unknown as { occupation_id: number; locale: string; name: string }[]) {
+    let names = occNameMap.get(nr.occupation_id);
+    if (!names) { names = {}; occNameMap.set(nr.occupation_id, names); }
+    names[nr.locale] = nr.name;
+  }
+
+  const occupations: Record<string, OccupationMeta> = {};
+  for (const r of occRows as unknown as { id: number; slug: string; parent_id: number | null; domain_id: number | null }[]) {
+    occupations[String(r.id)] = {
+      id: r.id,
+      slug: r.slug,
+      parentId: r.parent_id,
+      domainId: r.domain_id,
+      names: occNameMap.get(r.id) ?? {},
+    };
+  }
+
+  // Fetch domains
+  const domainRows = await db.execute<{
+    [key: string]: unknown;
+    id: number;
+    slug: string;
+  }>(sql`SELECT id, slug FROM occupation_domain`);
+
+  const domainNameRows = await db.execute<{
+    [key: string]: unknown;
+    domain_id: number;
+    locale: string;
+    name: string;
+  }>(sql`SELECT domain_id, locale, name FROM occupation_domain_name WHERE is_display = true`);
+
+  const domainNameMap = new Map<number, Record<string, string>>();
+  for (const nr of domainNameRows as unknown as { domain_id: number; locale: string; name: string }[]) {
+    let names = domainNameMap.get(nr.domain_id);
+    if (!names) { names = {}; domainNameMap.set(nr.domain_id, names); }
+    names[nr.locale] = nr.name;
+  }
+
+  const domains: Record<string, OccupationDomainMeta> = {};
+  for (const r of domainRows as unknown as { id: number; slug: string }[]) {
+    domains[String(r.id)] = {
+      id: r.id,
+      slug: r.slug,
+      names: domainNameMap.get(r.id) ?? {},
+    };
+  }
+
+  return { occupations, domains };
+}
+
 async function _getOccupationHierarchyCache(): Promise<{
   occupations: Map<number, OccupationMeta>;
   domains: Map<number, OccupationDomainMeta>;
 }> {
-  const key = "occ-hierarchy-cache";
-  const record = await cached(
-    key,
-    async () => {
-      // Fetch occupations
-      const occRows = await db.execute<{
-        [key: string]: unknown;
-        id: number;
-        slug: string;
-        parent_id: number | null;
-        domain_id: number | null;
-      }>(sql`SELECT id, slug, parent_id, domain_id FROM occupation`);
-
-      const occNameRows = await db.execute<{
-        [key: string]: unknown;
-        occupation_id: number;
-        locale: string;
-        name: string;
-      }>(sql`SELECT occupation_id, locale, name FROM occupation_name WHERE is_display = true`);
-
-      const occNameMap = new Map<number, Record<string, string>>();
-      for (const nr of occNameRows as unknown as { occupation_id: number; locale: string; name: string }[]) {
-        let names = occNameMap.get(nr.occupation_id);
-        if (!names) { names = {}; occNameMap.set(nr.occupation_id, names); }
-        names[nr.locale] = nr.name;
-      }
-
-      const occupations: Record<string, OccupationMeta> = {};
-      for (const r of occRows as unknown as { id: number; slug: string; parent_id: number | null; domain_id: number | null }[]) {
-        occupations[String(r.id)] = {
-          id: r.id,
-          slug: r.slug,
-          parentId: r.parent_id,
-          domainId: r.domain_id,
-          names: occNameMap.get(r.id) ?? {},
-        };
-      }
-
-      // Fetch domains
-      const domainRows = await db.execute<{
-        [key: string]: unknown;
-        id: number;
-        slug: string;
-      }>(sql`SELECT id, slug FROM occupation_domain`);
-
-      const domainNameRows = await db.execute<{
-        [key: string]: unknown;
-        domain_id: number;
-        locale: string;
-        name: string;
-      }>(sql`SELECT domain_id, locale, name FROM occupation_domain_name WHERE is_display = true`);
-
-      const domainNameMap = new Map<number, Record<string, string>>();
-      for (const nr of domainNameRows as unknown as { domain_id: number; locale: string; name: string }[]) {
-        let names = domainNameMap.get(nr.domain_id);
-        if (!names) { names = {}; domainNameMap.set(nr.domain_id, names); }
-        names[nr.locale] = nr.name;
-      }
-
-      const domains: Record<string, OccupationDomainMeta> = {};
-      for (const r of domainRows as unknown as { id: number; slug: string }[]) {
-        domains[String(r.id)] = {
-          id: r.id,
-          slug: r.slug,
-          names: domainNameMap.get(r.id) ?? {},
-        };
-      }
-
-      return { occupations, domains };
-    },
-    { ttl: 86400 },
-  );
-
+  const record = await _fetchOccupationHierarchyData();
   return {
     occupations: new Map(Object.entries(record.occupations).map(([k, v]) => [Number(k), v])),
     domains: new Map(Object.entries(record.domains).map(([k, v]) => [Number(k), v])),
@@ -689,43 +698,46 @@ interface SeniorityMeta {
   names: Record<string, string>;
 }
 
+// Per-region in-memory `'use cache'` (cacheLife('days')). See note on
+// `_fetchOccupationHierarchyData` above. Migrated from Redis-backed
+// `cached()` in #2884 (hierarchy-cache slice).
+async function _fetchSeniorityHierarchyData(): Promise<Record<string, SeniorityMeta>> {
+  "use cache";
+  cacheLife("days");
+
+  const rows = await db.execute<{
+    [key: string]: unknown;
+    id: number;
+    slug: string;
+  }>(sql`SELECT id, slug FROM seniority`);
+
+  const nameRows = await db.execute<{
+    [key: string]: unknown;
+    seniority_id: number;
+    locale: string;
+    name: string;
+  }>(sql`SELECT seniority_id, locale, name FROM seniority_name WHERE is_display = true`);
+
+  const nameMap = new Map<number, Record<string, string>>();
+  for (const nr of nameRows as unknown as { seniority_id: number; locale: string; name: string }[]) {
+    let names = nameMap.get(nr.seniority_id);
+    if (!names) { names = {}; nameMap.set(nr.seniority_id, names); }
+    names[nr.locale] = nr.name;
+  }
+
+  const result: Record<string, SeniorityMeta> = {};
+  for (const r of rows as unknown as { id: number; slug: string }[]) {
+    result[String(r.id)] = {
+      id: r.id,
+      slug: r.slug,
+      names: nameMap.get(r.id) ?? {},
+    };
+  }
+  return result;
+}
+
 async function _getSeniorityCache(): Promise<Map<number, SeniorityMeta>> {
-  const key = "sen-hierarchy-cache";
-  const record = await cached(
-    key,
-    async () => {
-      const rows = await db.execute<{
-        [key: string]: unknown;
-        id: number;
-        slug: string;
-      }>(sql`SELECT id, slug FROM seniority`);
-
-      const nameRows = await db.execute<{
-        [key: string]: unknown;
-        seniority_id: number;
-        locale: string;
-        name: string;
-      }>(sql`SELECT seniority_id, locale, name FROM seniority_name WHERE is_display = true`);
-
-      const nameMap = new Map<number, Record<string, string>>();
-      for (const nr of nameRows as unknown as { seniority_id: number; locale: string; name: string }[]) {
-        let names = nameMap.get(nr.seniority_id);
-        if (!names) { names = {}; nameMap.set(nr.seniority_id, names); }
-        names[nr.locale] = nr.name;
-      }
-
-      const result: Record<string, SeniorityMeta> = {};
-      for (const r of rows as unknown as { id: number; slug: string }[]) {
-        result[String(r.id)] = {
-          id: r.id,
-          slug: r.slug,
-          names: nameMap.get(r.id) ?? {},
-        };
-      }
-      return result;
-    },
-    { ttl: 86400 },
-  );
+  const record = await _fetchSeniorityHierarchyData();
   return new Map(Object.entries(record).map(([k, v]) => [Number(k), v]));
 }
 


### PR DESCRIPTION
## Summary

Migrates the 3 MB-sized taxonomy hierarchy caches off the Redis-backed `cached()` helper onto per-region in-memory `'use cache'` with `cacheLife('days')`. **Bucket 1 only** of #2884 — the other buckets stay on `cached()` and are scope-deferred.

- `apps/web/src/lib/actions/taxonomy.ts` — `_fetchOccupationHierarchyData()` (was `occ-hierarchy-cache`)
- `apps/web/src/lib/actions/locations.ts` — `_fetchLocationHierarchyData()` (was `loc-hierarchy-cache`)
- `apps/web/src/lib/actions/taxonomy.ts` — `_fetchSeniorityHierarchyData()` (was `sen-hierarchy-cache`)

Per the issue body's reasoning: per-region in-memory after first hit makes these free vs. a 5-20ms Cloudflare-fronted Upstash round-trip on every cold instance. Build ID baked into `'use cache'` keys automatically eliminates the cross-deploy poisoned-cache risk.

## Pattern

The fetcher is lifted to a separate function with `'use cache'` returning a serializable `Record<string, T>`. The original `_get*Cache()` wrapper stays as the public callsite and converts the record to a `Map` outside the cache boundary (Maps are non-serializable; ergonomic `O(1)` lookup is preserved for callers).

```ts
// before
async function _getSeniorityCache(): Promise<Map<number, SeniorityMeta>> {
  const key = "sen-hierarchy-cache";
  const record = await cached(key, async () => { /* fetch */ }, { ttl: 86400 });
  return new Map(...);
}

// after
async function _fetchSeniorityHierarchyData(): Promise<Record<string, SeniorityMeta>> {
  "use cache";
  cacheLife("days");
  // ... same fetch logic
}

async function _getSeniorityCache(): Promise<Map<number, SeniorityMeta>> {
  const record = await _fetchSeniorityHierarchyData();
  return new Map(Object.entries(record).map(([k, v]) => [Number(k), v]));
}
```

## Out of scope (scope-deferred)

Other buckets in #2884 — typeaheads, resolve/expand, per-company derived data, small high-frequency lookups, and the two footguns — are explicitly scope-deferred and remain on `cached()` as today. They become follow-up issues.

## Notes

- No invalidation hooks needed: these caches were TTL-only (86400s) and the crawler-side `/api/internal/invalidate-typeahead` route never swept the hierarchy keys (closed list at `TYPEAHEAD_PREFIXES`; hierarchy keys not included).
- The `cached` import stays in both files — many other call sites in scope-deferred buckets still use it.
- The `tech-hierarchy-cache` (line 825 of taxonomy.ts) is **not** in #2884's bucket-1 list and is **untouched**.

## Test plan

- [x] `pnpm typecheck` passes (no new errors)
- [x] `pnpm test` passes (54 files / 483 tests)
- [x] `pnpm dev` boots; `/{en,de,fr,it}/explore` returns HTTP 200 with hierarchy-derived content (Switzerland, Senior, Lead, Software, Engineer, etc.)
- [x] `/api/v1/taxonomies?type=seniority&locale=fr` (cold key) returns localized seniorities (Stagiaire, Débutant, Sénior, ...) — confirms `'use cache'` boundary fetches DB and serializes correctly
- [x] `/api/v1/taxonomies?type=occupations&locale=fr` (cold key) returns localized occupations grouped by domain
- [x] `/api/v1/taxonomies?type=industries&locale=it` returns localized industries
- [x] **Empirical guard**: planted `throw` inside `_fetchSeniorityHierarchyData` → cold-key `?locale=de` returned `[]` (consumer's `try/catch` caught the propagated error). Confirms throws surface, are not swallowed by Next.js cache infrastructure.
- [x] **Serializability**: hierarchy fetchers return plain `Record<string, T>` (no Maps/Sets/class instances) — safe inside `'use cache'`.
- [x] No runtime errors in dev console; only the pre-existing image-cache warning.
- [ ] Vercel preview build classification stays at `◐ Partial Prerender` for affected routes (verify in PR preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)