### PR TITLE
fix(web): migrate typeaheads to 'use cache' (Refs #2884)

### DIFF
--- a/apps/web/app/api/internal/invalidate-typeahead/route.test.ts
+++ b/apps/web/app/api/internal/invalidate-typeahead/route.test.ts
@@ -4,9 +4,11 @@ vi.mock("server-only", () => ({}));
 
 const mocks = vi.hoisted(() => ({
   invalidatePattern: vi.fn(),
+  revalidateTag: vi.fn(),
 }));
 
 vi.mock("@/lib/cache", () => ({ invalidatePattern: mocks.invalidatePattern }));
+vi.mock("next/cache", () => ({ revalidateTag: mocks.revalidateTag }));
 
 import { POST } from "./route";
 
@@ -15,6 +17,7 @@ const _ORIGINAL_TOKEN = process.env.INTERNAL_REVALIDATE_TOKEN;
 beforeEach(() => {
   mocks.invalidatePattern.mockReset();
   mocks.invalidatePattern.mockResolvedValue(0);
+  mocks.revalidateTag.mockReset();
   process.env.INTERNAL_REVALIDATE_TOKEN = "secret-token";
 });
 
@@ -36,18 +39,47 @@ describe("POST /api/internal/invalidate-typeahead", () => {
     const res = await POST(_request("Bearer secret-token") as never);
     expect(res.status).toBe(503);
     expect(mocks.invalidatePattern).not.toHaveBeenCalled();
+    expect(mocks.revalidateTag).not.toHaveBeenCalled();
   });
 
   it("returns 401 when bearer token is missing", async () => {
     const res = await POST(_request() as never);
     expect(res.status).toBe(401);
     expect(mocks.invalidatePattern).not.toHaveBeenCalled();
+    expect(mocks.revalidateTag).not.toHaveBeenCalled();
   });
 
   it("returns 401 when bearer token is wrong", async () => {
     const res = await POST(_request("Bearer wrong-token") as never);
     expect(res.status).toBe(401);
     expect(mocks.invalidatePattern).not.toHaveBeenCalled();
+    expect(mocks.revalidateTag).not.toHaveBeenCalled();
+  });
+
+  it("revalidates the per-typeahead `'use cache'` tags on auth", async () => {
+    /** PR #2907 follow-up: the 5 migrated typeaheads write to Next's
+     * per-region runtime cache via `'use cache'`; only `revalidateTag`
+     * evicts those slots. The legacy Redis prefix sweep is kept as a
+     * backstop for `company-slug:` / `company-similar:` and rollout
+     * stragglers, but the migrated keys live behind tags now. */
+    const res = await POST(_request("Bearer secret-token") as never);
+
+    expect(res.status).toBe(200);
+    const tags = mocks.revalidateTag.mock.calls.map((c) => c[0]);
+    expect(tags).toEqual([
+      "typeahead:locations",
+      "typeahead:occupations",
+      "typeahead:seniorities",
+      "typeahead:technologies",
+      "typeahead:companies",
+    ]);
+    // Each call passes the Next 16 "max" profile so the tag does not
+    // expire — see route handler comment.
+    for (const call of mocks.revalidateTag.mock.calls) {
+      expect(call[1]).toBe("max");
+    }
+    const body = await res.json();
+    expect(body.revalidatedTags).toEqual(tags);
   });
 
   it("invokes invalidatePattern for every typeahead prefix", async () => {

--- a/apps/web/app/api/internal/invalidate-typeahead/route.ts
+++ b/apps/web/app/api/internal/invalidate-typeahead/route.ts
@@ -1,8 +1,16 @@
 import { timingSafeEqual } from "node:crypto";
 
+import { revalidateTag } from "next/cache";
 import { NextResponse, type NextRequest } from "next/server";
 
 import { invalidatePattern } from "@/lib/cache";
+import {
+  typeaheadCompaniesCacheTag,
+  typeaheadLocationsCacheTag,
+  typeaheadOccupationsCacheTag,
+  typeaheadSenioritiesCacheTag,
+  typeaheadTechnologiesCacheTag,
+} from "@/lib/cache-tags";
 
 function _safeBearerEqual(presented: string | null, expected: string): boolean {
   if (presented === null) return false;
@@ -37,6 +45,20 @@ const TYPEAHEAD_PREFIXES = [
   "company-similar:",
 ] as const;
 
+// `'use cache'` tags for the 5 typeahead slots migrated in #2907 (PR
+// 2907 follow-up). Redis-prefix sweep above no longer hits these — the
+// migrated functions write to Next's per-region runtime cache, not
+// Redis. `revalidateTag` evicts those slots; `invalidatePattern` is
+// kept for the not-yet-migrated `company-slug:` / `company-similar:`
+// keys (still on `cached()`) and any stragglers from rollout windows.
+const TYPEAHEAD_TAGS = [
+  typeaheadLocationsCacheTag(),
+  typeaheadOccupationsCacheTag(),
+  typeaheadSenioritiesCacheTag(),
+  typeaheadTechnologiesCacheTag(),
+  typeaheadCompaniesCacheTag(),
+] as const;
+
 /**
  * POST /api/internal/invalidate-typeahead
  *
@@ -68,10 +90,40 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
+  // Evict the `'use cache'` slots for the 5 migrated typeaheads. Pass
+  // "max" (Next 16) so the tag invalidation does not expire — the tag
+  // is fired once per `crawler sync` and the slot must drop until the
+  // next call refills it.
+  const revalidatedTags: string[] = [];
+  for (const tag of TYPEAHEAD_TAGS) {
+    try {
+      revalidateTag(tag, "max");
+      revalidatedTags.push(tag);
+    } catch (err) {
+      // A revalidation hiccup must not fail the sweep — the legacy
+      // Redis prefix loop below is the backstop for any straggler keys,
+      // and the slot's 3600s TTL is the ultimate backstop.
+      console.warn(
+        "[invalidate-typeahead] revalidateTag failed",
+        tag,
+        err,
+      );
+    }
+  }
+
+  // Legacy Redis prefix sweep — kept for not-yet-migrated keys
+  // (`company-slug:`, `company-similar:` still use Redis-backed
+  // `cached()`) and to drain stragglers from any rollout window where
+  // a region has both old Redis entries and new `'use cache'` slots.
   const deleted: Record<string, number> = {};
   for (const prefix of TYPEAHEAD_PREFIXES) {
     deleted[prefix] = await invalidatePattern(prefix);
   }
   const total = Object.values(deleted).reduce((a, b) => a + b, 0);
-  return NextResponse.json({ ok: true, deleted, total });
+  return NextResponse.json({
+    ok: true,
+    deleted,
+    total,
+    revalidatedTags,
+  });
 }

--- a/apps/web/src/lib/actions/company.ts
+++ b/apps/web/src/lib/actions/company.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { sql } from "drizzle-orm";
+import { cacheLife } from "next/cache";
 import { db } from "@/db";
 import { getSearchProvider } from "@/lib/search";
 import type { SearchResultPosting } from "@/lib/search";
@@ -30,11 +31,21 @@ export async function suggestCompanies(params: {
   const q = params.query.trim().toLowerCase();
   if (q.length < 2) return [];
 
-  const key = `company-suggest:${q}`;
-  return cached(key, () => _queryCompanySuggestions(q), { ttl: 600 });
+  // Per-region in-memory `'use cache'` (revalidate 3600s). Migrated from
+  // Redis-backed `cached()` in #2884 (typeaheads slice). The previous TTL
+  // was 600s; bumped to 3600s to match the other 4 typeahead sites
+  // (issue prescription). The inner fetcher returns `CompanySuggestion[]`
+  // (plain serializable objects, never null), so no throw-and-catch
+  // wrapper is needed here.
+  return _queryCompanySuggestionsCached(q);
 }
 
-async function _queryCompanySuggestions(q: string): Promise<CompanySuggestion[]> {
+async function _queryCompanySuggestionsCached(
+  q: string,
+): Promise<CompanySuggestion[]> {
+  "use cache";
+  cacheLife({ revalidate: 3600 });
+
   const rows = await db.execute<{
     [key: string]: unknown;
     id: string;

--- a/apps/web/src/lib/actions/company.ts
+++ b/apps/web/src/lib/actions/company.ts
@@ -1,11 +1,12 @@
 "use server";
 
 import { sql } from "drizzle-orm";
-import { cacheLife } from "next/cache";
+import { cacheLife, cacheTag } from "next/cache";
 import { db } from "@/db";
 import { getSearchProvider } from "@/lib/search";
 import type { SearchResultPosting } from "@/lib/search";
 import { cached } from "@/lib/cache";
+import { typeaheadCompaniesCacheTag } from "@/lib/cache-tags";
 import { getSessionUserId } from "@/lib/sessionCache";
 import { expandLocationIds } from "@/lib/actions/locations";
 import { expandOccupationIds } from "@/lib/actions/taxonomy";
@@ -45,6 +46,10 @@ async function _queryCompanySuggestionsCached(
 ): Promise<CompanySuggestion[]> {
   "use cache";
   cacheLife({ revalidate: 3600 });
+  // Tag the slot so `revalidateTag(typeaheadCompaniesCacheTag())` from
+  // /api/internal/invalidate-typeahead drops it after `crawler sync`,
+  // instead of waiting up to 3600s for the TTL. See #2907 follow-up.
+  cacheTag(typeaheadCompaniesCacheTag());
 
   const rows = await db.execute<{
     [key: string]: unknown;

--- a/apps/web/src/lib/actions/locations.ts
+++ b/apps/web/src/lib/actions/locations.ts
@@ -30,25 +30,31 @@ export async function suggestLocations(params: {
   // share a cache slot. Typesense ranks by `coordinates(lat,lng, precision:
   // 5km)` so this granularity keeps results indistinguishable in practice
   // while delivering a usable hit rate. See issue #2641.
-  const geoKey =
-    params.userLat != null && params.userLng != null
-      ? `${params.userLat.toFixed(1)},${params.userLng.toFixed(1)}`
-      : "no-geo";
+  // The bucketed lat/lng are passed to `_fetchLocationSuggestionsCached`
+  // as the cache-key inputs (raw lat/lng would shred the hit rate).
+  const bucketedLat =
+    params.userLat != null ? Number(params.userLat.toFixed(1)) : null;
+  const bucketedLng =
+    params.userLng != null ? Number(params.userLng.toFixed(1)) : null;
 
-  const cacheKey = `loc-suggest:${q.toLowerCase()}:${params.locale}:${geoKey}`;
-  const cachedResult = await cached(
-    cacheKey,
-    () => _fetchLocationSuggestions(q, params.locale, params.userLat, params.userLng),
-    {
-      ttl: 3600,
-      // Treat null as "Typesense was unavailable" — don't poison the cache.
-      // Empty array is a legitimate "no match" result (e.g. nonsense query)
-      // and is worth caching to absorb crawler noise.
-      skipIf: (r) => r === null,
-    },
-  );
-
-  const suggestions = cachedResult ?? [];
+  // Per-region in-memory `'use cache'` (revalidate 3600s). Build ID is
+  // included in the key automatically. Migrated from Redis-backed
+  // `cached()` in #2884 (typeaheads slice). The previous `skipIf: r ===
+  // null` semantics aren't available under `'use cache'`, so the inner
+  // fetcher throws on Typesense unavailability and the wrapper catches
+  // and returns `[]` — preventing outage-shaped empties from being pinned.
+  // See `apps/web/docs/cache-components.md`.
+  let suggestions: LocationSuggestion[];
+  try {
+    suggestions = await _fetchLocationSuggestionsCached(
+      q.toLowerCase(),
+      params.locale,
+      bucketedLat,
+      bucketedLng,
+    );
+  } catch {
+    suggestions = [];
+  }
 
   // Boost is per-call (depends on the user's currently-selected filters),
   // so it must run *after* the cached layer. Boosting is a pure re-sort
@@ -63,27 +69,37 @@ export async function suggestLocations(params: {
 }
 
 /**
- * Inner fetch + mapping for {@link suggestLocations}. Returns `null` if
- * Typesense is unreachable so the cache layer can avoid poisoning the slot
- * with an outage-shaped empty list.
+ * Cached inner fetch + mapping for {@link suggestLocations}. Throws if
+ * Typesense is unreachable so the wrapper can swallow the error and avoid
+ * pinning an outage-shaped empty list inside the `'use cache'` boundary.
+ * Empty array is a legitimate "no match" result and IS cached.
+ *
+ * The function takes scalar args (not the params object) so the implicit
+ * `'use cache'` argument-hash key reflects exactly the inputs that affect
+ * the result. `bucketedLat`/`bucketedLng` are pre-rounded to 1-decimal
+ * by the caller for cross-user hit-rate (see issue #2641).
  */
-async function _fetchLocationSuggestions(
+async function _fetchLocationSuggestionsCached(
   q: string,
   locale: string,
-  userLat: number | undefined,
-  userLng: number | undefined,
-): Promise<LocationSuggestion[] | null> {
-  const hasGeo = userLat != null && userLng != null;
+  bucketedLat: number | null,
+  bucketedLng: number | null,
+): Promise<LocationSuggestion[]> {
+  "use cache";
+  cacheLife({ revalidate: 3600 });
+
+  const hasGeo = bucketedLat != null && bucketedLng != null;
   const sortBy = hasGeo
-    ? `_text_match:desc,coordinates(${userLat},${userLng}, precision: 5km):asc,active_posting_count:desc`
+    ? `_text_match:desc,coordinates(${bucketedLat},${bucketedLng}, precision: 5km):asc,active_posting_count:desc`
     : "_text_match:desc,active_posting_count:desc";
 
   const queryByFields = locale !== "en" ? `name_${locale},name_en` : "name_en";
   const queryByWeights = locale !== "en" ? "3,1" : "1";
 
+  let result;
   try {
     const client = getTypesenseClient();
-    const result = await client.collections("location").documents().search({
+    result = await client.collections("location").documents().search({
       q,
       query_by: queryByFields,
       query_by_weights: queryByWeights,
@@ -94,14 +110,16 @@ async function _fetchLocationSuggestions(
       num_typos: "1",
       drop_tokens_threshold: 0,
     });
-
-    if (!result.hits || result.hits.length === 0) return [];
-    return result.hits.map((hit) =>
-      _mapLocationHit(hit as unknown as TypesenseHit, locale),
-    );
-  } catch {
-    return null;
+  } catch (err) {
+    // Throw past the cache boundary so the wrapper can return `[]` without
+    // poisoning the cache slot for the next 3600s.
+    throw err instanceof Error ? err : new Error(String(err));
   }
+
+  if (!result.hits || result.hits.length === 0) return [];
+  return result.hits.map((hit) =>
+    _mapLocationHit(hit as unknown as TypesenseHit, locale),
+  );
 }
 
 function _mapLocationHit(hit: TypesenseHit, locale: string): LocationSuggestion {

--- a/apps/web/src/lib/actions/locations.ts
+++ b/apps/web/src/lib/actions/locations.ts
@@ -1,9 +1,10 @@
 "use server";
 
 import { sql } from "drizzle-orm";
-import { cacheLife } from "next/cache";
+import { cacheLife, cacheTag } from "next/cache";
 import { db } from "@/db";
 import { cached } from "@/lib/cache";
+import { typeaheadLocationsCacheTag } from "@/lib/cache-tags";
 import { getTypesenseClient, type TypesenseHit } from "@/lib/search/typesense-client";
 import { buildFilterString } from "@/lib/search/typesense-filters";
 import { boostByFilterMatches, type TypeaheadBoostFilters } from "@/lib/search/typeahead-boost";
@@ -87,6 +88,10 @@ async function _fetchLocationSuggestionsCached(
 ): Promise<LocationSuggestion[]> {
   "use cache";
   cacheLife({ revalidate: 3600 });
+  // Tag the slot so `revalidateTag(typeaheadLocationsCacheTag())` from
+  // /api/internal/invalidate-typeahead drops it after `crawler sync`,
+  // instead of waiting up to 3600s for the TTL. See #2907 follow-up.
+  cacheTag(typeaheadLocationsCacheTag());
 
   const hasGeo = bucketedLat != null && bucketedLng != null;
   const sortBy = hasGeo

--- a/apps/web/src/lib/actions/taxonomy.ts
+++ b/apps/web/src/lib/actions/taxonomy.ts
@@ -1,9 +1,14 @@
 "use server";
 
 import { sql } from "drizzle-orm";
-import { cacheLife } from "next/cache";
+import { cacheLife, cacheTag } from "next/cache";
 import { db } from "@/db";
 import { cached } from "@/lib/cache";
+import {
+  typeaheadOccupationsCacheTag,
+  typeaheadSenioritiesCacheTag,
+  typeaheadTechnologiesCacheTag,
+} from "@/lib/cache-tags";
 import { getTypesenseClient, type TypesenseHit } from "@/lib/search/typesense-client";
 import { buildFilterString } from "@/lib/search/typesense-filters";
 import { boostByFilterMatches, type TypeaheadBoostFilters } from "@/lib/search/typeahead-boost";
@@ -59,6 +64,10 @@ async function _fetchOccupationSuggestionsCached(
 ): Promise<TaxonomySuggestion[]> {
   "use cache";
   cacheLife({ revalidate: 3600 });
+  // Tag the slot so `revalidateTag(typeaheadOccupationsCacheTag())` from
+  // /api/internal/invalidate-typeahead drops it after `crawler sync`,
+  // instead of waiting up to 3600s for the TTL. See #2907 follow-up.
+  cacheTag(typeaheadOccupationsCacheTag());
 
   let result;
   try {
@@ -155,6 +164,10 @@ async function _fetchSenioritySuggestionsCached(
 ): Promise<TaxonomySuggestion[]> {
   "use cache";
   cacheLife({ revalidate: 3600 });
+  // Tag the slot so `revalidateTag(typeaheadSenioritiesCacheTag())` from
+  // /api/internal/invalidate-typeahead drops it after `crawler sync`,
+  // instead of waiting up to 3600s for the TTL. See #2907 follow-up.
+  cacheTag(typeaheadSenioritiesCacheTag());
 
   let result;
   try {
@@ -254,6 +267,10 @@ async function _fetchTechnologySuggestionsCached(
 ): Promise<TaxonomySuggestion[]> {
   "use cache";
   cacheLife({ revalidate: 3600 });
+  // Tag the slot so `revalidateTag(typeaheadTechnologiesCacheTag())` from
+  // /api/internal/invalidate-typeahead drops it after `crawler sync`,
+  // instead of waiting up to 3600s for the TTL. See #2907 follow-up.
+  cacheTag(typeaheadTechnologiesCacheTag());
 
   let result;
   try {

--- a/apps/web/src/lib/actions/taxonomy.ts
+++ b/apps/web/src/lib/actions/taxonomy.ts
@@ -26,14 +26,18 @@ export async function suggestOccupations(params: {
   const q = params.query.trim();
   if (q.length < 2) return [];
 
-  const cacheKey = `occ-suggest:${q.toLowerCase()}:${params.locale}`;
-  const cachedResult = await cached(
-    cacheKey,
-    () => _fetchOccupationSuggestions(q, params.locale),
-    { ttl: 3600, skipIf: (r) => r === null },
-  );
-
-  const suggestions = cachedResult ?? [];
+  // Per-region in-memory `'use cache'`. See note on
+  // `_fetchOccupationSuggestionsCached` below for null-vs-empty semantics.
+  // Migrated from Redis-backed `cached()` in #2884 (typeaheads slice).
+  let suggestions: TaxonomySuggestion[];
+  try {
+    suggestions = await _fetchOccupationSuggestionsCached(
+      q.toLowerCase(),
+      params.locale,
+    );
+  } catch {
+    suggestions = [];
+  }
   if (!params.filters) return suggestions;
   return boostByFilterMatches(
     suggestions,
@@ -43,15 +47,25 @@ export async function suggestOccupations(params: {
   );
 }
 
-async function _fetchOccupationSuggestions(
+/**
+ * Cached inner fetch + mapping for {@link suggestOccupations}. Throws if
+ * Typesense is unreachable so the wrapper can swallow the error and avoid
+ * pinning an outage-shaped empty list inside the `'use cache'` boundary.
+ * Empty array is a legitimate "no match" result and IS cached.
+ */
+async function _fetchOccupationSuggestionsCached(
   q: string,
   locale: string,
-): Promise<TaxonomySuggestion[] | null> {
+): Promise<TaxonomySuggestion[]> {
+  "use cache";
+  cacheLife({ revalidate: 3600 });
+
+  let result;
   try {
     const client = getTypesenseClient();
 
     // Search locale-specific documents first
-    let result = await client.collections("occupation").documents().search({
+    result = await client.collections("occupation").documents().search({
       q,
       query_by: "name,aliases",
       filter_by: `has_active_postings:true && locale:${locale}`,
@@ -73,14 +87,16 @@ async function _fetchOccupationSuggestions(
         num_typos: "1",
       });
     }
-
-    if (!result.hits || result.hits.length === 0) return [];
-    return result.hits.map((hit) =>
-      _mapOccupationHit(hit as unknown as TypesenseHit),
-    );
-  } catch {
-    return null;
+  } catch (err) {
+    // Throw past the cache boundary so the wrapper returns `[]` without
+    // pinning the slot for the next 3600s.
+    throw err instanceof Error ? err : new Error(String(err));
   }
+
+  if (!result.hits || result.hits.length === 0) return [];
+  return result.hits.map((hit) =>
+    _mapOccupationHit(hit as unknown as TypesenseHit),
+  );
 }
 
 function _mapOccupationHit(hit: TypesenseHit): TaxonomySuggestion {
@@ -106,14 +122,18 @@ export async function suggestSeniorities(params: {
   const q = params.query.trim();
   if (q.length < 2) return [];
 
-  const cacheKey = `sen-suggest:${q.toLowerCase()}:${params.locale}`;
-  const cachedResult = await cached(
-    cacheKey,
-    () => _fetchSenioritySuggestions(q, params.locale),
-    { ttl: 3600, skipIf: (r) => r === null },
-  );
-
-  const suggestions = cachedResult ?? [];
+  // Per-region in-memory `'use cache'`. See note on
+  // `_fetchSenioritySuggestionsCached` below for null-vs-empty semantics.
+  // Migrated from Redis-backed `cached()` in #2884 (typeaheads slice).
+  let suggestions: TaxonomySuggestion[];
+  try {
+    suggestions = await _fetchSenioritySuggestionsCached(
+      q.toLowerCase(),
+      params.locale,
+    );
+  } catch {
+    suggestions = [];
+  }
   if (!params.filters) return suggestions;
   return boostByFilterMatches(
     suggestions,
@@ -123,14 +143,24 @@ export async function suggestSeniorities(params: {
   );
 }
 
-async function _fetchSenioritySuggestions(
+/**
+ * Cached inner fetch + mapping for {@link suggestSeniorities}. Throws if
+ * Typesense is unreachable so the wrapper can swallow the error and avoid
+ * pinning an outage-shaped empty list inside the `'use cache'` boundary.
+ * Empty array is a legitimate "no match" result and IS cached.
+ */
+async function _fetchSenioritySuggestionsCached(
   q: string,
   locale: string,
-): Promise<TaxonomySuggestion[] | null> {
+): Promise<TaxonomySuggestion[]> {
+  "use cache";
+  cacheLife({ revalidate: 3600 });
+
+  let result;
   try {
     const client = getTypesenseClient();
 
-    let result = await client.collections("seniority").documents().search({
+    result = await client.collections("seniority").documents().search({
       q,
       query_by: "name,aliases",
       filter_by: `has_active_postings:true && locale:${locale}`,
@@ -152,14 +182,16 @@ async function _fetchSenioritySuggestions(
         num_typos: "1",
       });
     }
-
-    if (!result.hits || result.hits.length === 0) return [];
-    return result.hits.map((hit) =>
-      _mapSeniorityHit(hit as unknown as TypesenseHit),
-    );
-  } catch {
-    return null;
+  } catch (err) {
+    // Throw past the cache boundary so the wrapper returns `[]` without
+    // pinning the slot for the next 3600s.
+    throw err instanceof Error ? err : new Error(String(err));
   }
+
+  if (!result.hits || result.hits.length === 0) return [];
+  return result.hits.map((hit) =>
+    _mapSeniorityHit(hit as unknown as TypesenseHit),
+  );
 }
 
 function _mapSeniorityHit(hit: TypesenseHit): TaxonomySuggestion {
@@ -186,16 +218,18 @@ export async function suggestTechnologies(params: {
   if (q.length < 2) return [];
 
   // Technologies are locale-agnostic but the public function accepts locale
-  // for parity with the other taxonomy suggesters. Drop it from the cache
-  // key so all locales share one slot.
-  const cacheKey = `tech-suggest:${q.toLowerCase()}`;
-  const cachedResult = await cached(
-    cacheKey,
-    () => _fetchTechnologySuggestions(q),
-    { ttl: 3600, skipIf: (r) => r === null },
-  );
-
-  const suggestions = cachedResult ?? [];
+  // for parity with the other taxonomy suggesters. The inner cached fetcher
+  // takes ONLY `q` so all locales share the same `'use cache'` slot — the
+  // implicit argument-hash key drops `locale` because it isn't a parameter.
+  // (#2884 footgun — was an explicit cache-key drop under the manual-key
+  // `cached()` helper; under `'use cache'` we encode it via the function
+  // signature instead.) Migrated from Redis-backed `cached()` in #2884.
+  let suggestions: TaxonomySuggestion[];
+  try {
+    suggestions = await _fetchTechnologySuggestionsCached(q.toLowerCase());
+  } catch {
+    suggestions = [];
+  }
   if (!params.filters) return suggestions;
   return boostByFilterMatches(
     suggestions,
@@ -205,13 +239,27 @@ export async function suggestTechnologies(params: {
   );
 }
 
-async function _fetchTechnologySuggestions(
+/**
+ * Cached inner fetch + mapping for {@link suggestTechnologies}. Throws if
+ * Typesense is unreachable so the wrapper can swallow the error and avoid
+ * pinning an outage-shaped empty list inside the `'use cache'` boundary.
+ * Empty array is a legitimate "no match" result and IS cached.
+ *
+ * Takes only `q` (no `locale` arg) — technologies are locale-agnostic, so
+ * stripping locale from the cache-key inputs lets all locales share the
+ * same slot. See note on the {@link suggestTechnologies} wrapper.
+ */
+async function _fetchTechnologySuggestionsCached(
   q: string,
-): Promise<TaxonomySuggestion[] | null> {
+): Promise<TaxonomySuggestion[]> {
+  "use cache";
+  cacheLife({ revalidate: 3600 });
+
+  let result;
   try {
     const client = getTypesenseClient();
 
-    const result = await client.collections("technology").documents().search({
+    result = await client.collections("technology").documents().search({
       q,
       query_by: "name,slug",
       filter_by: "has_active_postings:true",
@@ -220,19 +268,21 @@ async function _fetchTechnologySuggestions(
       prefix: "true",
       num_typos: "0", // no typo tolerance — match current prefix-only behavior
     });
-
-    if (!result.hits || result.hits.length === 0) return [];
-    return result.hits.map((hit) => {
-      const doc = (hit as unknown as TypesenseHit).document;
-      return {
-        id: doc.technology_id as number,
-        slug: doc.slug as string,
-        name: (doc.name ?? doc.slug) as string,
-      };
-    });
-  } catch {
-    return null;
+  } catch (err) {
+    // Throw past the cache boundary so the wrapper returns `[]` without
+    // pinning the slot for the next 3600s.
+    throw err instanceof Error ? err : new Error(String(err));
   }
+
+  if (!result.hits || result.hits.length === 0) return [];
+  return result.hits.map((hit) => {
+    const doc = (hit as unknown as TypesenseHit).document;
+    return {
+      id: doc.technology_id as number,
+      slug: doc.slug as string,
+      name: (doc.name ?? doc.slug) as string,
+    };
+  });
 }
 
 // ── Resolve functions (kept on Postgres with cached()) ──────────────

--- a/apps/web/src/lib/cache-tags.ts
+++ b/apps/web/src/lib/cache-tags.ts
@@ -31,3 +31,31 @@ export function blogPostCacheTag(slug: string): string {
 export function blogIndexCacheTag(): string {
   return "blog-index";
 }
+
+/**
+ * Per-typeahead cache tags for the 5 typeahead suggestion functions
+ * migrated to `'use cache'` in #2884 (typeaheads slice). Invalidated by
+ * the crawler after `crawler sync` via the
+ * `/api/internal/invalidate-typeahead` route — see that route handler
+ * for the full sweep.
+ *
+ * Per-prefix granularity (rather than a single shared tag) mirrors the
+ * `TYPEAHEAD_PREFIXES` list in the route 1:1, keeping the door open for
+ * targeted future invalidation while preserving today's blanket-sweep
+ * semantics.
+ */
+export function typeaheadLocationsCacheTag(): string {
+  return "typeahead:locations";
+}
+export function typeaheadOccupationsCacheTag(): string {
+  return "typeahead:occupations";
+}
+export function typeaheadSenioritiesCacheTag(): string {
+  return "typeahead:seniorities";
+}
+export function typeaheadTechnologiesCacheTag(): string {
+  return "typeahead:technologies";
+}
+export function typeaheadCompaniesCacheTag(): string {
+  return "typeahead:companies";
+}


### PR DESCRIPTION
Refs #2884 — bucket 2 (typeaheads) + tech-suggest footgun.

This is a partial fix; do **not** auto-close the parent issue. Bucket 1
(hierarchy caches) shipped in #2906; buckets 3–5 (resolve/expand,
per-company derived data, small high-frequency lookups, plus the
`getCompanyBySlug` footgun) remain out of scope here.

## Summary

Migrate the 5 typeahead suggestion functions from the Redis-backed
`cached()` helper to per-region in-memory `'use cache'`:

- `suggestLocations` — `apps/web/src/lib/actions/locations.ts:38`
- `suggestOccupations` — `apps/web/src/lib/actions/taxonomy.ts:29`
- `suggestSeniorities` — `apps/web/src/lib/actions/taxonomy.ts:109`
- `suggestTechnologies` — `apps/web/src/lib/actions/taxonomy.ts:191` (incl. footgun)
- `suggestCompanies` — `apps/web/src/lib/actions/company.ts:34`

All five use `cacheLife({ revalidate: 3600 })` per issue prescription.
`suggestCompanies` previously used a 600s TTL — bumped to 3600s for
parity with the other 4 sites (issue task list says "5 sites …
cacheLife({ revalidate: 3600 })"). Flagging here in case you'd rather
keep 600s; trivial to change.

## Pattern

Matches PR #2906 (hierarchy caches). The inner fetcher is lifted into
a sibling function with `'use cache'` + `cacheLife({ revalidate: 3600 })`
that returns `T[]` (non-null, serializable). The wrapper handles the
"Typesense unavailable -> don't poison the slot" semantics formerly
provided by `skipIf: r => r === null` (which has no equivalent under
`'use cache'`): the inner fetcher **throws** on Typesense errors, the
outer wrapper **catches** and returns `[]`. Empty-array hits are
cached (legitimate "no match" results, worth absorbing), only the
throw path is skipped.

## Tech-suggest footgun

`taxonomy.ts:191` previously dropped `locale` from the manual cache key
intentionally (technologies are locale-agnostic — all locales should
share one slot). Under `'use cache'`, the implicit argument-hash key
reflects exactly the function arguments, so the lifted
`_fetchTechnologySuggestionsCached` takes only `q` (no `locale` arg) —
locale is stripped at the function-signature boundary, preserving the
single-slot behaviour. Justification: the inner fetcher already only
needed `q` to do its work, so removing the unused `locale` param from
its signature is the lowest-risk change and produces the desired
cache-key shape implicitly.

## Files changed

- `apps/web/src/lib/actions/locations.ts` — `suggestLocations` migrated; lat/lng now bucketed-then-passed (instead of raw + composed cache-key string), so the implicit argument-hash key preserves the 1-decimal geo bucketing from #2641
- `apps/web/src/lib/actions/taxonomy.ts` — `suggestOccupations`, `suggestSeniorities`, `suggestTechnologies` migrated; tech-suggest footgun fix encoded via inner-fetcher signature (no `locale` arg)
- `apps/web/src/lib/actions/company.ts` — `suggestCompanies` migrated, `cacheLife` import added; TTL 600 -> 3600

Other buckets (resolve/expand, per-company derived data, small
lookups, `getCompanyBySlug` footgun) remain on `cached()` and will be
addressed in follow-up PRs against #2884.

## Test plan

- [x] `pnpm exec tsc --noEmit` from `apps/web/` — clean
- [x] `pnpm test` from `apps/web/` — 54/54 files, 483/483 tests pass
- [x] Manual curl against `/api/v1/resolve?type={locations,occupations,seniority,technologies}&q=...&locale=en` and `/api/v1/companies?q=...` — all 5 return expected results
- [x] Empirical guard: temporarily made `_fetchTechnologySuggestionsCached` throw unconditionally, confirmed the outer wrapper swallowed the throw and route returned `matches: []`. Reverted; `git status` clean.
- [x] Serializability: every `'use cache'` function returns `T[]` of plain `{ id, slug, name, ... }` objects — no Maps/Sets/Dates/class instances inside the cache boundary.

## Discrepancies vs issue body

None on line numbers — all 5 sites + the footgun matched the issue's
claimed lines exactly. Only mechanical scope expansion: bumped
`suggestCompanies` TTL from 600s to 3600s to follow the issue's "5
sites … cacheLife({ revalidate: 3600 })" prescription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)