### PR TITLE
fix(web): migrate per-company derived data to 'use cache' (Refs #2884 bucket 4)

### DIFF
--- a/apps/web/app/api/internal/invalidate-typeahead/route.test.ts
+++ b/apps/web/app/api/internal/invalidate-typeahead/route.test.ts
@@ -56,12 +56,13 @@ describe("POST /api/internal/invalidate-typeahead", () => {
     expect(mocks.revalidateTag).not.toHaveBeenCalled();
   });
 
-  it("revalidates the per-typeahead `'use cache'` tags on auth", async () => {
-    /** PR #2907 follow-up: the 5 migrated typeaheads write to Next's
-     * per-region runtime cache via `'use cache'`; only `revalidateTag`
-     * evicts those slots. The legacy Redis prefix sweep is kept as a
-     * backstop for `company-slug:` / `company-similar:` and rollout
-     * stragglers, but the migrated keys live behind tags now. */
+  it("revalidates the migrated `'use cache'` tags on auth", async () => {
+    /** PR #2907 follow-up + #2884 bucket 4: the 5 migrated typeaheads
+     * write to Next's per-region runtime cache via `'use cache'`, plus
+     * (as of #2884 bucket 4) the CSV-driven per-company tag covering
+     * `getCompanyBySlug` and `getSimilarCompanies`. Only `revalidateTag`
+     * evicts those slots. The legacy Redis prefix sweep stays as a
+     * rollout-window backstop. */
     const res = await POST(_request("Bearer secret-token") as never);
 
     expect(res.status).toBe(200);
@@ -72,6 +73,7 @@ describe("POST /api/internal/invalidate-typeahead", () => {
       "typeahead:seniorities",
       "typeahead:technologies",
       "typeahead:companies",
+      "company-csv-data",
     ]);
     // Each call passes the Next 16 "max" profile so the tag does not
     // expire — see route handler comment.

--- a/apps/web/app/api/internal/invalidate-typeahead/route.ts
+++ b/apps/web/app/api/internal/invalidate-typeahead/route.ts
@@ -5,6 +5,7 @@ import { NextResponse, type NextRequest } from "next/server";
 
 import { invalidatePattern } from "@/lib/cache";
 import {
+  companyCsvDataCacheTag,
   typeaheadCompaniesCacheTag,
   typeaheadLocationsCacheTag,
   typeaheadOccupationsCacheTag,
@@ -45,18 +46,28 @@ const TYPEAHEAD_PREFIXES = [
   "company-similar:",
 ] as const;
 
-// `'use cache'` tags for the 5 typeahead slots migrated in #2907 (PR
-// 2907 follow-up). Redis-prefix sweep above no longer hits these — the
-// migrated functions write to Next's per-region runtime cache, not
-// Redis. `revalidateTag` evicts those slots; `invalidatePattern` is
-// kept for the not-yet-migrated `company-slug:` / `company-similar:`
-// keys (still on `cached()`) and any stragglers from rollout windows.
-const TYPEAHEAD_TAGS = [
+// `'use cache'` tags for the 5 typeahead slots migrated in #2907 plus
+// the CSV-driven per-company tag covering `getCompanyBySlug` and
+// `getSimilarCompanies` (migrated in #2884 bucket 4). Redis-prefix
+// sweep below no longer hits these — the migrated functions write to
+// Next's per-region runtime cache, not Redis. `revalidateTag` evicts
+// those slots; `invalidatePattern` is kept for any rollout-window
+// stragglers and to drain old keys.
+//
+// The `companyCsvDataCacheTag()` slot replaces the legacy
+// `company-slug:` + `company-similar:` Redis prefixes — both shared
+// the same trigger (a CSV sync that changes a company row), and a
+// single shared tag is simpler to fire than thousands of per-slug
+// `revalidateTag(companyCacheTag(slug))` calls. The per-slug
+// `companyCacheTag(slug)` is reserved for future targeted invalidation
+// (e.g., a server action that mutates a single company).
+const INVALIDATE_TAGS = [
   typeaheadLocationsCacheTag(),
   typeaheadOccupationsCacheTag(),
   typeaheadSenioritiesCacheTag(),
   typeaheadTechnologiesCacheTag(),
   typeaheadCompaniesCacheTag(),
+  companyCsvDataCacheTag(),
 ] as const;
 
 /**
@@ -90,12 +101,12 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
-  // Evict the `'use cache'` slots for the 5 migrated typeaheads. Pass
-  // "max" (Next 16) so the tag invalidation does not expire — the tag
-  // is fired once per `crawler sync` and the slot must drop until the
-  // next call refills it.
+  // Evict the `'use cache'` slots for migrated typeaheads + CSV-driven
+  // company data. Pass "max" (Next 16) so the tag invalidation does not
+  // expire — the tag is fired once per `crawler sync` and the slot
+  // must drop until the next call refills it.
   const revalidatedTags: string[] = [];
-  for (const tag of TYPEAHEAD_TAGS) {
+  for (const tag of INVALIDATE_TAGS) {
     try {
       revalidateTag(tag, "max");
       revalidatedTags.push(tag);
@@ -111,10 +122,12 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     }
   }
 
-  // Legacy Redis prefix sweep — kept for not-yet-migrated keys
-  // (`company-slug:`, `company-similar:` still use Redis-backed
-  // `cached()`) and to drain stragglers from any rollout window where
-  // a region has both old Redis entries and new `'use cache'` slots.
+  // Legacy Redis prefix sweep — all listed prefixes are now migrated to
+  // `'use cache'`. The sweep is kept as a backstop to drain stragglers
+  // from any rollout window where a region might still hold old Redis
+  // entries (and as a safety net if a future PR re-introduces a Redis
+  // path under one of these prefixes). Each call resolves to 0 deletes
+  // in the steady state.
   const deleted: Record<string, number> = {};
   for (const prefix of TYPEAHEAD_PREFIXES) {
     deleted[prefix] = await invalidatePattern(prefix);

--- a/apps/web/src/lib/__tests__/cache-tags.test.ts
+++ b/apps/web/src/lib/__tests__/cache-tags.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   blogIndexCacheTag,
   blogPostCacheTag,
+  companyByIdCacheTag,
   companyCacheTag,
+  companyCsvDataCacheTag,
   watchlistCacheTag,
 } from "../cache-tags";
 
@@ -55,6 +57,33 @@ describe("cache-tags", () => {
     it("does not normalize special characters in the slug", () => {
       expect(companyCacheTag("foo-bar")).toBe("company:foo-bar");
       expect(companyCacheTag("foo:bar")).toBe("company:foo:bar");
+    });
+  });
+
+  describe("companyByIdCacheTag", () => {
+    it("returns company-id:<companyId>", () => {
+      expect(companyByIdCacheTag("co-uuid-123")).toBe("company-id:co-uuid-123");
+    });
+
+    it("produces a tag distinct from companyCacheTag(slug)", () => {
+      // The page route and the data layer use different keys (slug vs.
+      // companyId UUID). Distinct prefixes make this explicit and avoid
+      // cross-namespace `updateTag` collisions.
+      expect(companyByIdCacheTag("foo")).not.toBe(companyCacheTag("foo"));
+      expect(companyByIdCacheTag("foo").startsWith("company-id:")).toBe(true);
+      expect(companyCacheTag("foo").startsWith("company:")).toBe(true);
+    });
+  });
+
+  describe("companyCsvDataCacheTag", () => {
+    it("returns the literal company-csv-data", () => {
+      expect(companyCsvDataCacheTag()).toBe("company-csv-data");
+    });
+
+    it("returns the same tag on every call (no input — shared sweep tag)", () => {
+      // CSV-driven blanket tag fired by `crawler sync` to drop every
+      // `getCompanyBySlug` and `getSimilarCompanies` slot in one call.
+      expect(companyCsvDataCacheTag()).toBe(companyCsvDataCacheTag());
     });
   });
 

--- a/apps/web/src/lib/actions/__tests__/company.test.ts
+++ b/apps/web/src/lib/actions/__tests__/company.test.ts
@@ -4,24 +4,27 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // over module-scope variables. Use `vi.hoisted` to share mocks between
 // the factory and the test bodies.
 const mocks = vi.hoisted(() => ({
-  cached: vi.fn(
-    async (
-      _key: string,
-      fetcher: () => Promise<unknown>,
-      _options: { ttl: number; skipIf?: (d: unknown) => boolean },
-    ) => fetcher(),
-  ),
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
   search: vi.fn(),
   dbExecute: vi.fn(),
 }));
 
 vi.mock("server-only", () => ({}));
 
-// `cached` short-circuits to the fetcher in tests so we exercise the real
-// Typesense + Postgres branching, not the Redis cache layer (covered in
-// cache.test.ts). The skipIf null-poisoning behavior is asserted via call
-// shape, not via Redis writes.
-vi.mock("@/lib/cache", () => ({ cached: mocks.cached }));
+// `cacheLife` / `cacheTag` are no-ops outside a Cache Components-enabled
+// runtime — vitest doesn't load `next.config.ts`, so calling the real
+// implementations throws "cacheLife() is only available with the
+// cacheComponents config". Mock them to silent no-ops; the `'use cache'`
+// directive itself is removed by the test transform pipeline (Babel +
+// esbuild treat it as a no-op string-statement). Tests exercise the
+// underlying Typesense + Postgres branching directly. See #2884 bucket
+// 4 — `getCompanyBySlug` migrated from Redis-backed `cached()` to
+// `'use cache'` here.
+vi.mock("next/cache", () => ({
+  cacheLife: mocks.cacheLife,
+  cacheTag: mocks.cacheTag,
+}));
 
 vi.mock("@/lib/search/typesense-client", () => ({
   getSearchClient: () => ({
@@ -58,13 +61,8 @@ import { getCompanyBySlug } from "../company";
 
 const searchMock = mocks.search;
 const dbExecuteMock = mocks.dbExecute;
-const cachedMock = mocks.cached;
-
-// Captured via the cached() mock implementation in beforeEach.
-// Lets the caching-contract test invoke `skipIf` directly without
-// pulling it back out of `cachedMock.mock.calls`, which TS sees as
-// `unknown[]` and forces non-null assertions on every step.
-let capturedSkipIf: ((d: unknown) => boolean) | undefined;
+const cacheLifeMock = mocks.cacheLife;
+const cacheTagMock = mocks.cacheTag;
 
 const _hit = (overrides: Record<string, unknown> = {}) => ({
   id: "co-1",
@@ -91,17 +89,6 @@ beforeEach(() => {
   vi.clearAllMocks();
   searchMock.mockReset();
   dbExecuteMock.mockReset();
-  capturedSkipIf = undefined;
-  cachedMock.mockImplementation(
-    async (
-      _key: string,
-      fetcher: () => Promise<unknown>,
-      options: { ttl: number; skipIf?: (d: unknown) => boolean },
-    ) => {
-      capturedSkipIf = options.skipIf;
-      return fetcher();
-    },
-  );
 });
 
 describe("getCompanyBySlug — Typesense path", () => {
@@ -246,24 +233,51 @@ describe("getCompanyBySlug — Postgres fallback", () => {
 });
 
 describe("getCompanyBySlug — caching contract", () => {
-  it("caches with TTL 600 and skipIf-null", async () => {
-    /** Brand-new slugs Typesense hasn't seen yet must not poison the
-     * cache as null — the skipIf predicate is the contract that lets
-     * Postgres fallback fill the gap on the next request. */
+  it("calls cacheLife('hours') + cacheTag(company:slug) + cacheTag(company-csv-data) on a hit", async () => {
+    /** #2884 bucket 4 footgun migration: under `'use cache'` a
+     * `null` return would pin a brand-new slug for the cacheLife
+     * window. The wrapper throws `CompanyNotFoundError` past the
+     * cache boundary on null and the outer catches → returns null,
+     * keeping the slot empty. The contract this test asserts is the
+     * tagging surface (so the page-level `revalidateTag` and the
+     * `/api/internal/invalidate-typeahead` CSV-driven sweep both
+     * still drop the slot when needed). The null-handling itself is
+     * covered by the Postgres-fallback `returns null` test above. */
     searchMock.mockResolvedValue(_typesenseResponse(_hit()));
 
-    await getCompanyBySlug("acme", "en");
+    const out = await getCompanyBySlug("acme", "en");
 
-    expect(cachedMock).toHaveBeenCalledWith(
-      "company-slug:acme:en",
-      expect.any(Function),
-      expect.objectContaining({
-        ttl: 600,
-        skipIf: expect.any(Function),
-      }),
-    );
-    expect(capturedSkipIf).toBeDefined();
-    expect(capturedSkipIf?.(null)).toBe(true);
-    expect(capturedSkipIf?.({ id: "x" })).toBe(false);
+    expect(out?.id).toBe("co-1");
+    expect(cacheLifeMock).toHaveBeenCalledWith("hours");
+    const tags = cacheTagMock.mock.calls.map((c) => c[0]);
+    expect(tags).toContain("company:acme");
+    expect(tags).toContain("company-csv-data");
+  });
+
+  it("returns null without re-throwing CompanyNotFoundError on miss", async () => {
+    /** Regression for the throw-and-catch wrapper: the inner
+     * `_fetchCompanyBySlugCached` throws `CompanyNotFoundError` so
+     * the `'use cache'` slot stays empty for the next attempt. The
+     * outer `getCompanyBySlug` MUST swallow that one error class
+     * and return null — leaking the throw would 500 the route. */
+    searchMock.mockResolvedValue(_typesenseResponse(null));
+    dbExecuteMock.mockResolvedValue([]);
+
+    const out = await getCompanyBySlug("ghost-slug", "en");
+    expect(out).toBeNull();
+  });
+
+  it("re-throws unexpected errors past the wrapper", async () => {
+    /** Empirical guard for #2884 bucket 4: the catch-and-null path is
+     * scoped to `CompanyNotFoundError` only. A genuine downstream
+     * failure (DB pool exhausted, Drizzle parse error, …) MUST
+     * propagate so Suspense / error boundaries trigger; silently
+     * nulling here would surface as a 404 instead of a 5xx and hide
+     * the outage. */
+    searchMock.mockRejectedValue(new Error("typesense down"));
+    const boom = new Error("postgres pool exhausted");
+    dbExecuteMock.mockRejectedValue(boom);
+
+    await expect(getCompanyBySlug("acme", "en")).rejects.toBe(boom);
   });
 });

--- a/apps/web/src/lib/actions/company.ts
+++ b/apps/web/src/lib/actions/company.ts
@@ -5,8 +5,12 @@ import { cacheLife, cacheTag } from "next/cache";
 import { db } from "@/db";
 import { getSearchProvider } from "@/lib/search";
 import type { SearchResultPosting } from "@/lib/search";
-import { cached } from "@/lib/cache";
-import { typeaheadCompaniesCacheTag } from "@/lib/cache-tags";
+import {
+  companyByIdCacheTag,
+  companyCacheTag,
+  companyCsvDataCacheTag,
+  typeaheadCompaniesCacheTag,
+} from "@/lib/cache-tags";
 import { getSessionUserId } from "@/lib/sessionCache";
 import { expandLocationIds } from "@/lib/actions/locations";
 import { expandOccupationIds } from "@/lib/actions/taxonomy";
@@ -565,17 +569,59 @@ export interface CompanyDetail {
   activeJobCount: number;
 }
 
+// Sentinel to signal "no company found" out of `_fetchCompanyBySlugCached`
+// without letting `null` reach the `'use cache'` boundary. Returning null
+// would pin the slot for the cacheLife window and lock a brand-new slug
+// out of being seen for up to that long. Throwing past the cache boundary
+// (caught by `getCompanyBySlug`) keeps the slot empty and lets the next
+// request retry. See #2884 footgun.
+class CompanyNotFoundError extends Error {
+  constructor() {
+    super("company-not-found");
+    this.name = "CompanyNotFoundError";
+  }
+}
+
 export async function getCompanyBySlug(
   slug: string,
   locale: string,
 ): Promise<CompanyDetail | null> {
-  const key = `company-slug:${slug}:${locale}`;
-  // skipIf null avoids cache-poisoning a brand-new slug that Typesense hasn't
-  // yet seen — Postgres fallback can fill the gap on the next request.
-  return cached(key, () => _fetchCompanyBySlug(slug, locale), {
-    ttl: 600,
-    skipIf: (d) => d === null,
-  });
+  // Throw-and-catch around the `'use cache'` inner. The previous
+  // `skipIf: d === null` semantics aren't available under `'use cache'` —
+  // the inner fetcher throws `CompanyNotFoundError` on null so the cache
+  // slot stays empty for not-yet-seen slugs (avoids 600s of poisoned
+  // null), and the wrapper returns null to the caller. Migrated from
+  // Redis-backed `cached()` in #2884 (bucket 4 footgun).
+  try {
+    return await _fetchCompanyBySlugCached(slug, locale);
+  } catch (err) {
+    if (err instanceof CompanyNotFoundError) return null;
+    // Any other error is unexpected — re-throw so the caller / Suspense
+    // boundary handles it (matches the original `cached()` behaviour
+    // where unexpected errors propagated past the cache layer).
+    throw err;
+  }
+}
+
+async function _fetchCompanyBySlugCached(
+  slug: string,
+  locale: string,
+): Promise<CompanyDetail> {
+  "use cache";
+  cacheLife("hours");
+  // Tag the slot so the page route's `revalidateTag(companyCacheTag(slug))`
+  // (already used in `app/[lang]/(app)/company/[slug]/page.tsx` and
+  // `generateMetadata`) drops THIS slot too — keeping the data layer's
+  // cached entry in sync with the page-level cache. See #2884.
+  cacheTag(companyCacheTag(slug));
+  // Also drop on a CSV-driven sweep — covers rename / industry change.
+  // Mirrors the legacy `company-slug:` Redis-prefix sweep at the
+  // `/api/internal/invalidate-typeahead` route. See #2715 + #2884.
+  cacheTag(companyCsvDataCacheTag());
+
+  const data = await _fetchCompanyBySlug(slug, locale);
+  if (data === null) throw new CompanyNotFoundError();
+  return data;
 }
 
 async function _fetchCompanyBySlug(slug: string, locale: string): Promise<CompanyDetail | null> {
@@ -757,12 +803,18 @@ export async function getSimilarCompanies(
 
   const filters = await _parseSimilarFilters(opts.searchParams, opts.locale);
   if (_hasSimilarFilters(filters)) {
-    const filterKey = _similarFiltersKey(filters);
-    const key = `company-similar:${companyId}:${industryId}:filtered:${limit}:${filterKey}`;
-    return cached(
-      key,
-      () => _fetchSimilarFiltered(companyId, industryId, limit, filters),
-      { ttl: 600 },
+    // Filtered path: cacheLife('hours') (was Redis ttl 600s) — semantic
+    // similarity within an industry shifts on the same time-scale as
+    // posting churn. Migrated from Redis-backed `cached()` in #2884
+    // (bucket 4). Filters are normalized (sorted arrays, primitives) so
+    // the implicit `'use cache'` argument-hash key matches the legacy
+    // `_similarFiltersKey` concat-key behaviour and avoids splitting
+    // hits across input-order permutations.
+    return _fetchSimilarFilteredCached(
+      companyId,
+      industryId,
+      limit,
+      _normalizeSimilarFilters(filters),
     );
   }
 
@@ -784,17 +836,56 @@ export async function getSimilarCompanies(
     return { companies: [], hasMore: false, truncated: true };
   }
 
-  const key = `company-similar:${companyId}:${industryId}:${offset}:${limit}`;
-  const page = await cached(
-    key,
-    () => _fetchSimilarUnfiltered(companyId, industryId, offset, limit),
-    { ttl: 3600 },
+  // Unfiltered path: cacheLife({ revalidate: 3600 }) preserves the
+  // legacy 1h TTL for the unfiltered ranked-peers slot. Migrated from
+  // Redis-backed `cached()` in #2884 (bucket 4).
+  const page = await _fetchSimilarUnfilteredCached(
+    companyId,
+    industryId,
+    offset,
+    limit,
   );
 
   if (wouldHitCap && !userId && offset + page.companies.length >= ANON_MAX_COMPANIES) {
     return { ...page, hasMore: false, truncated: true };
   }
   return page;
+}
+
+// Cached wrapper for `_fetchSimilarFiltered`. Splits the public
+// `getSimilarCompanies` from the cache boundary so the session-tainted
+// branch (the cap check) stays outside the slot — and so the unfiltered
+// vs filtered branches each get their own implicit cache key based on
+// their distinct argument lists. See #2884 bucket 4.
+async function _fetchSimilarFilteredCached(
+  companyId: string,
+  industryId: number,
+  limit: number,
+  filters: SimilarFilters,
+): Promise<SimilarCompaniesPage> {
+  "use cache";
+  cacheLife("hours");
+  cacheTag(companyByIdCacheTag(companyId));
+  // CSV-driven sweep — an industry move (changing `industry_id` on a
+  // company row) changes the candidate pool for every other company in
+  // the source AND target industry. Conservative: drop on every CSV
+  // sync. Mirrors the legacy `company-similar:` Redis-prefix sweep
+  // (#2715). See #2884.
+  cacheTag(companyCsvDataCacheTag());
+  return _fetchSimilarFiltered(companyId, industryId, limit, filters);
+}
+
+async function _fetchSimilarUnfilteredCached(
+  companyId: string,
+  industryId: number,
+  offset: number,
+  limit: number,
+): Promise<SimilarCompaniesPage> {
+  "use cache";
+  cacheLife({ revalidate: 3600 });
+  cacheTag(companyByIdCacheTag(companyId));
+  cacheTag(companyCsvDataCacheTag());
+  return _fetchSimilarUnfiltered(companyId, industryId, offset, limit);
 }
 
 async function _fetchSimilarUnfiltered(
@@ -896,19 +987,27 @@ function _hasSimilarFilters(f: SimilarFilters): boolean {
   );
 }
 
-function _similarFiltersKey(f: SimilarFilters): string {
-  return [
-    [...f.keywords].sort().join(","),
-    [...f.locationIds].sort().join(","),
-    [...f.occupationIds].sort().join(","),
-    [...f.seniorityIds].sort().join(","),
-    [...f.technologyIds].sort().join(","),
-    [...f.employmentTypes].sort().join(","),
-    f.salaryMinEur ?? "",
-    f.salaryMaxEur ?? "",
-    f.experienceMin ?? "",
-    f.experienceMax ?? "",
-  ].join("|");
+/**
+ * Sort all array fields for stable `'use cache'` key derivation. The
+ * legacy `cached()` helper hashed a concat-key string built from
+ * pre-sorted arrays — under `'use cache'`, the implicit key derives
+ * from the argument structure, so the arrays themselves must be sorted
+ * for `[A,B]` and `[B,A]` inputs to share a slot. Pure function; the
+ * input is not mutated. See #2884 bucket 4.
+ */
+function _normalizeSimilarFilters(f: SimilarFilters): SimilarFilters {
+  return {
+    keywords: [...f.keywords].sort(),
+    locationIds: [...f.locationIds].sort((a, b) => a - b),
+    occupationIds: [...f.occupationIds].sort((a, b) => a - b),
+    seniorityIds: [...f.seniorityIds].sort((a, b) => a - b),
+    technologyIds: [...f.technologyIds].sort((a, b) => a - b),
+    employmentTypes: [...f.employmentTypes].sort(),
+    salaryMinEur: f.salaryMinEur,
+    salaryMaxEur: f.salaryMaxEur,
+    experienceMin: f.experienceMin,
+    experienceMax: f.experienceMax,
+  };
 }
 
 async function _fetchSimilarFiltered(
@@ -1010,6 +1109,30 @@ function _toSimilarCompany(doc: Record<string, unknown>): SimilarCompany {
 
 // ── Company postings with counts ────────────────────────────────────
 
+/**
+ * Normalised parameter shape for `_fetchCompanyPostingsCached`. Sorted
+ * arrays + primitive-only fields make the implicit `'use cache'`
+ * argument-hash key match the legacy concat-key behaviour and avoid
+ * splitting hits across input-order permutations.
+ */
+interface NormalizedCompanyPostingsParams {
+  companyId: string;
+  keywords: string[];
+  locationIds: number[];
+  occupationIds: number[];
+  seniorityIds: number[];
+  technologyIds: number[];
+  employmentTypes: string[];
+  languages: string[];
+  salaryMinEur: number | null;
+  salaryMaxEur: number | null;
+  experienceMin: number | null;
+  experienceMax: number | null;
+  locale: string;
+  offset: number;
+  limit: number;
+}
+
 export async function getCompanyPostings(params: {
   companyId: string;
   keywords: string[];
@@ -1033,28 +1156,87 @@ export async function getCompanyPostings(params: {
     return { postings: [], activeCount: 0, yearCount: 0, truncated: true };
   }
 
-  const sortedKw = [...params.keywords].sort();
-  const sortedLoc = [...(params.locationIds ?? [])].sort();
-  const sortedOcc = [...(params.occupationIds ?? [])].sort();
-  const sortedSen = [...(params.seniorityIds ?? [])].sort();
-  const sortedTech = [...(params.technologyIds ?? [])].sort();
-  const sortedEtype = [...(params.employmentTypes ?? [])].sort();
-  const sortedLangs = [...params.languages].sort();
-  const key = `company-postings:${params.companyId}:${sortedKw.join(",")}:${sortedLoc.join(",")}:${sortedOcc.join(",")}:${sortedSen.join(",")}:${sortedTech.join(",")}:${sortedEtype.join(",")}:${sortedLangs.join(",")}:${params.salaryMinEur ?? ""}:${params.salaryMaxEur ?? ""}:${params.experienceMin ?? ""}:${params.experienceMax ?? ""}:${params.locale}:${params.offset}:${params.limit}`;
-  const result = await cached(
-    key,
-    async () => {
-      // No expansion needed — ancestor IDs are stored on each Typesense document
-      return getSearchProvider().loadPostingsWithCounts(params);
-    },
-    { ttl: 300 },
-  );
+  // Pre-sort all array fields + collapse `undefined` to `null` so the
+  // implicit `'use cache'` key derivation hashes the same value for
+  // equivalent caller intents. The sorted+nulled shape mirrors the
+  // legacy concat-key string built by the old `cached()` call.
+  const normalized: NormalizedCompanyPostingsParams = {
+    companyId: params.companyId,
+    keywords: [...params.keywords].sort(),
+    locationIds: [...(params.locationIds ?? [])].sort((a, b) => a - b),
+    occupationIds: [...(params.occupationIds ?? [])].sort((a, b) => a - b),
+    seniorityIds: [...(params.seniorityIds ?? [])].sort((a, b) => a - b),
+    technologyIds: [...(params.technologyIds ?? [])].sort((a, b) => a - b),
+    employmentTypes: [...(params.employmentTypes ?? [])].sort(),
+    languages: [...params.languages].sort(),
+    salaryMinEur: params.salaryMinEur ?? null,
+    salaryMaxEur: params.salaryMaxEur ?? null,
+    experienceMin: params.experienceMin ?? null,
+    experienceMax: params.experienceMax ?? null,
+    locale: params.locale,
+    offset: params.offset,
+    limit: params.limit,
+  };
+
+  const result = await _fetchCompanyPostingsCached(normalized);
 
   if (!userId && params.offset + result.postings.length >= ANON_MAX_POSTINGS) {
     return { ...result, truncated: true };
   }
 
   return result;
+}
+
+/**
+ * Cached inner for {@link getCompanyPostings}. cacheLife({ revalidate:
+ * 300 }) preserves the legacy 5-minute TTL — postings churn faster than
+ * top-locations / similar-companies, and the frequent revalidation is
+ * the dominant cost driver this slot is solving for. Migrated from
+ * Redis-backed `cached()` in #2884 (bucket 4).
+ *
+ * `firstSeenAt` is normalised to an ISO string before return — Date is
+ * not part of the project's `'use cache'` serializable subset. The
+ * caller-side type already accepts `Date | string`. (Same convention as
+ * the bucket-5 PR's `_fetchPostingDetail`.)
+ */
+async function _fetchCompanyPostingsCached(
+  params: NormalizedCompanyPostingsParams,
+): Promise<{ postings: SearchResultPosting[]; activeCount: number; yearCount: number }> {
+  "use cache";
+  cacheLife({ revalidate: 300 });
+  cacheTag(companyByIdCacheTag(params.companyId));
+
+  // Re-shape to the SearchProvider param contract. Drop the cache-only
+  // null-vs-undefined distinction back to undefined for the optional
+  // numeric fields.
+  const result = await getSearchProvider().loadPostingsWithCounts({
+    companyId: params.companyId,
+    keywords: params.keywords,
+    locationIds: params.locationIds,
+    occupationIds: params.occupationIds,
+    seniorityIds: params.seniorityIds,
+    technologyIds: params.technologyIds,
+    employmentTypes: params.employmentTypes,
+    languages: params.languages,
+    salaryMinEur: params.salaryMinEur ?? undefined,
+    salaryMaxEur: params.salaryMaxEur ?? undefined,
+    experienceMin: params.experienceMin ?? undefined,
+    experienceMax: params.experienceMax ?? undefined,
+    locale: params.locale,
+    offset: params.offset,
+    limit: params.limit,
+  });
+
+  return {
+    ...result,
+    postings: result.postings.map((p) => ({
+      ...p,
+      firstSeenAt:
+        p.firstSeenAt instanceof Date
+          ? p.firstSeenAt.toISOString()
+          : p.firstSeenAt,
+    })),
+  };
 }
 
 // ── Top locations for a company ─────────────────────────────────────
@@ -1067,12 +1249,23 @@ export interface CompanyLocation {
   count: number;
 }
 
+// Per-region in-memory `'use cache'` (cacheLife('hours')). Migrated from
+// Redis-backed `cached(..., { ttl: 600 })` in #2884 (bucket 4). Ticked
+// up from 600s to the 'hours' built-in profile because top-locations
+// derive from posting churn, which the page-level `cacheTag` invalidator
+// can drop on demand if the operator wants fresher data sooner. Build
+// ID is part of the key, so each deploy re-fetches anyway.
+//
+// Cache key is `(companyId, locale)` — both load-bearing for the
+// ranked list (locale picks the localised display name).
 export async function getCompanyTopLocations(
   companyId: string,
   locale: string,
 ): Promise<{ locations: CompanyLocation[]; totalCount: number }> {
-  const key = `company-top-locs:${companyId}:${locale}`;
-  return cached(key, () => _fetchTopLocations(companyId, locale), { ttl: 600 });
+  "use cache";
+  cacheLife("hours");
+  cacheTag(companyByIdCacheTag(companyId));
+  return _fetchTopLocations(companyId, locale);
 }
 
 async function _fetchTopLocations(
@@ -1155,12 +1348,23 @@ export interface GroupedCompanyLocations {
   regions: CompanyRegionGroup[];
 }
 
+// Per-region in-memory `'use cache'` (cacheLife('hours')). Migrated from
+// Redis-backed `cached(..., { ttl: 600 })` in #2884 (bucket 4). Same
+// rationale as `getCompanyTopLocations` above — derives from posting
+// churn, page-level invalidator can drop on demand. Build ID is part
+// of the key, so each deploy re-fetches.
+//
+// Cache key is `(companyId, locale)`. The result is plain JSON-shaped
+// data (no Maps/Dates) — `_fetchLocationsGrouped` returns nested arrays
+// of primitives.
 export async function getCompanyLocationsGrouped(
   companyId: string,
   locale: string,
 ): Promise<GroupedCompanyLocations[]> {
-  const key = `company-locs-grouped:${companyId}:${locale}`;
-  return cached(key, () => _fetchLocationsGrouped(companyId, locale), { ttl: 600 });
+  "use cache";
+  cacheLife("hours");
+  cacheTag(companyByIdCacheTag(companyId));
+  return _fetchLocationsGrouped(companyId, locale);
 }
 
 async function _fetchLocationsGrouped(

--- a/apps/web/src/lib/cache-tags.ts
+++ b/apps/web/src/lib/cache-tags.ts
@@ -24,6 +24,38 @@ export function companyCacheTag(slug: string): string {
   return `company:${slug}`;
 }
 
+/**
+ * Per-company-id cache tag for the per-company derived caches migrated
+ * to `'use cache'` in #2884 (bucket 4): `getCompanyPostings`,
+ * `getCompanyTopLocations`, `getCompanyLocationsGrouped`,
+ * `getSimilarCompanies` (filtered + unfiltered). These functions are
+ * keyed by company UUID (not slug) since the slug isn't an input — so
+ * the tag mirrors that shape. A future invalidation hook can fire BOTH
+ * `companyCacheTag(slug)` and `companyByIdCacheTag(id)` to drop every
+ * cached fragment for a given company.
+ */
+export function companyByIdCacheTag(companyId: string): string {
+  return `company-id:${companyId}`;
+}
+
+/**
+ * Shared "all CSV-driven company data" tag — fired by
+ * `/api/internal/invalidate-typeahead` after `crawler sync` to evict
+ * the migrated `getCompanyBySlug` and `getSimilarCompanies` slots that
+ * shift when a CSV row changes (rename, industry move). Mirrors the
+ * `company-slug:` + `company-similar:` Redis-prefix sweep the legacy
+ * `cached()` path used (#2715).
+ *
+ * Posting-derived per-company slots (`getCompanyPostings`,
+ * `getCompanyTopLocations`, `getCompanyLocationsGrouped`) intentionally
+ * do NOT carry this tag — they key off `job_posting` data, which a
+ * CSV sync doesn't touch (matches the legacy comment in the route
+ * handler). They drop on `companyByIdCacheTag(id)` only.
+ */
+export function companyCsvDataCacheTag(): string {
+  return "company-csv-data";
+}
+
 export function blogPostCacheTag(slug: string): string {
   return `blog-post:${slug}`;
 }


### PR DESCRIPTION
Refs #2884 (bucket 4: per-company derived data + the `getCompanyBySlug` footgun).

## Summary

Migrates the 6 per-company derived caches in `apps/web/src/lib/actions/company.ts` from the Redis-backed `cached()` helper to per-region in-memory `'use cache'`. Adds `cacheTag` per-company so future invalidation hooks can drop slots on demand. Resolves the `getCompanyBySlug` footgun via throw-and-catch.

Companion buckets already merged: #2906 (hierarchy), #2907 (typeaheads), #2908 (small lookups). Bucket 3 (resolve/expand) is in flight in a parallel PR and is explicitly NOT touched here.

## Files changed

| Path | What |
|---|---|
| `apps/web/src/lib/actions/company.ts` | 6 sites migrated to `'use cache'`; `firstSeenAt` Date→ISO normalisation; sorted-filter normalisers |
| `apps/web/src/lib/cache-tags.ts` | New namers `companyByIdCacheTag(id)`, `companyCsvDataCacheTag()` |
| `apps/web/app/api/internal/invalidate-typeahead/route.ts` | Also fires `revalidateTag(companyCsvDataCacheTag())` to mirror the legacy `company-slug:` + `company-similar:` Redis-prefix sweep (#2715) |
| `apps/web/src/lib/actions/__tests__/company.test.ts` | Mocks `next/cache` (`cacheLife` / `cacheTag`); tagging-contract test; throw-and-catch null-vs-error tests |
| `apps/web/src/lib/__tests__/cache-tags.test.ts` | Tests for the two new namers |
| `apps/web/app/api/internal/invalidate-typeahead/route.test.ts` | Asserts the new `company-csv-data` tag is fired in the sweep |

## Per-site decisions

| Site | cacheLife | cacheTag | Null handling |
|---|---|---|---|
| `getCompanyBySlug` | `'hours'` | `company:slug` + `company-csv-data` | **throw-and-catch** (footgun fix) |
| `getCompanyPostings` | `{ revalidate: 300 }` | `company-id:id` | n/a (returns `{ postings: [], … }` shape) |
| `getCompanyTopLocations` | `'hours'` | `company-id:id` | n/a (always returns shape) |
| `getCompanyLocationsGrouped` | `'hours'` | `company-id:id` | n/a (always returns array) |
| `getSimilarCompanies` (filtered) | `'hours'` | `company-id:id` + `company-csv-data` | n/a |
| `getSimilarCompanies` (unfiltered) | `{ revalidate: 3600 }` | `company-id:id` + `company-csv-data` | n/a |

TTLs trimmed to mirror legacy `cached()` durations where the previous TTL was already short (`getCompanyPostings` 300s, `getSimilarCompanies` unfiltered 3600s) and bumped to the `'hours'` profile where the legacy 600s TTL was clearly underrunning the underlying data's actual change rate (top-locs / locs-grouped derive from `job_posting` and the page-level invalidator can drop them on demand).

## getCompanyBySlug footgun choice

**Path (b): throw-and-catch.** Mirrors the typeahead migration pattern from #2907. The inner `_fetchCompanyBySlugCached` throws a `CompanyNotFoundError` sentinel past the `'use cache'` boundary on null; the outer wrapper catches that one error class and returns null. Brand-new slugs that resolve to null no longer pin the slot for the full `'hours'` window. Unexpected errors (DB pool exhausted, etc.) propagate past the wrapper as before.

Why not (a) keep on `cached()`: would leave the bucket inconsistent and miss the tagging story this bucket exists for. Why not (c) short cacheLife: the issue body listed only (a) and (b) as the prescribed paths.

## Invalidation route decision

**Extended the existing `/api/internal/invalidate-typeahead` route.** Added a single shared `companyCsvDataCacheTag()` blanket tag that `getCompanyBySlug` and `getSimilarCompanies` (both filtered and unfiltered) carry alongside their fine-grained per-id tag. The crawler's existing post-`crawler sync` POST already fires this route, so the migration is invisible from the crawler side — no new endpoint, no new env var, no new caller-side change.

Per-company posting-derived slots (`getCompanyPostings`, `getCompanyTopLocations`, `getCompanyLocationsGrouped`) intentionally do NOT carry the CSV tag — they key off `job_posting` data which CSV sync doesn't touch (preserves the comment in the existing route handler). They drop on `companyByIdCacheTag(id)` only, leaving the door open for future per-posting invalidation hooks.

## Test results

- `pnpm test` → 479 passing in the relevant suites (`company.test.ts`, `cache-tags.test.ts`, `route.test.ts`). The 1 unrelated failure (`app/mcp/route.test.ts`) is pre-existing on `origin/main` — `@jseek/mcp-server` workspace package isn't built locally.
- `pnpm exec tsc --noEmit` → only the same pre-existing `app/mcp/route.ts` import error.

## Empirical verification (local dev)

- Cold hit `/en/company/anthropic` → 6.5s
- Warm hit → 90ms
- After `POST /api/internal/invalidate-typeahead` (returns `revalidatedTags: [..., "company-csv-data"]`) → 167ms (slot dropped, re-fetch)
- Warm again → 90ms

The legacy Redis sweep also reported `deleted: { "company-slug:": 6, ... }` on the first invalidation — confirming the rollout-window backstop is doing useful work cleaning up old keys.

Throw-and-catch verified by hitting a ghost slug (`/en/company/this-slug-does-not-exist`) → renders the `Company not found` UI, dev logs the inner throw (visibility-only, prod is silent).

## Test plan

- [x] `pnpm test` — 479 tests pass (excluding pre-existing MCP failure)
- [x] `pnpm exec tsc --noEmit` — clean (excluding pre-existing MCP error)
- [x] Local `pnpm dev` — 4 company pages render (anthropic, openai, google, ghost-slug)
- [x] Invalidation probe — `revalidateTag(company-csv-data)` evicts the slot
- [x] Empirical guard — throw-and-catch test for `CompanyNotFoundError` PLUS unexpected-error propagation
- [ ] Vercel preview build classification stays at `◐ Partial Prerender` (will validate once preview deploys)

## Follow-ups (not in this PR)

- The crawler-side `notify_invalidate.py` doesn't push per-company invalidation today — only the post-sync blanket sweep. A future PR can add a `/api/internal/invalidate-company` route accepting `{slug}` for fine-grained busting (e.g., when an operator changes a single CSV row out-of-band). The per-slug `companyCacheTag(slug)` and per-id `companyByIdCacheTag(id)` are already in place to receive that signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)