### PR TITLE
fix(web): migrate _getTechnologyCache to 'use cache' (Closes #2884)

### DIFF
--- a/apps/web/src/lib/actions/taxonomy.ts
+++ b/apps/web/src/lib/actions/taxonomy.ts
@@ -923,32 +923,42 @@ interface TechnologyMeta {
   category: string;
 }
 
-async function _getTechnologyCache(): Promise<Map<number, TechnologyMeta>> {
-  const key = "tech-hierarchy-cache";
-  const record = await cached(
-    key,
-    async () => {
-      const rows = await db.execute<{
-        [key: string]: unknown;
-        id: number;
-        slug: string;
-        name: string | null;
-        category: string | null;
-      }>(sql`SELECT id, slug, name, category FROM technology`);
+// Per-region in-memory `'use cache'` (cacheLife('days')). See note on
+// `_fetchOccupationHierarchyData` above. Migrated from Redis-backed
+// `cached()` in #2884 (hierarchy-cache slice — final slot, missed by
+// bucket 1 because the issue body filed it under bucket 3). Tagged so
+// `crawler sync` -> `/api/internal/invalidate-typeahead` evicts it
+// alongside the matching tech typeahead slot.
+async function _fetchTechnologyHierarchyData(): Promise<Record<string, TechnologyMeta>> {
+  "use cache";
+  cacheLife("days");
+  // Tag the slot so `revalidateTag(typeaheadTechnologiesCacheTag())` from
+  // /api/internal/invalidate-typeahead drops it after `crawler sync`,
+  // matching the typeahead slot's invalidation.
+  cacheTag(typeaheadTechnologiesCacheTag());
 
-      const result: Record<string, TechnologyMeta> = {};
-      for (const r of rows as unknown as { id: number; slug: string; name: string | null; category: string | null }[]) {
-        result[String(r.id)] = {
-          id: r.id,
-          slug: r.slug,
-          name: r.name ?? r.slug,
-          category: r.category ?? "other",
-        };
-      }
-      return result;
-    },
-    { ttl: 86400 },
-  );
+  const rows = await db.execute<{
+    [key: string]: unknown;
+    id: number;
+    slug: string;
+    name: string | null;
+    category: string | null;
+  }>(sql`SELECT id, slug, name, category FROM technology`);
+
+  const result: Record<string, TechnologyMeta> = {};
+  for (const r of rows as unknown as { id: number; slug: string; name: string | null; category: string | null }[]) {
+    result[String(r.id)] = {
+      id: r.id,
+      slug: r.slug,
+      name: r.name ?? r.slug,
+      category: r.category ?? "other",
+    };
+  }
+  return result;
+}
+
+async function _getTechnologyCache(): Promise<Map<number, TechnologyMeta>> {
+  const record = await _fetchTechnologyHierarchyData();
   return new Map(Object.entries(record).map(([k, v]) => [Number(k), v]));
 }
 


### PR DESCRIPTION
## Summary

Closes #2884 — final slice (tech hierarchy cache, completes bucket 1).

The tech hierarchy cache (`_getTechnologyCache` in `apps/web/src/lib/actions/taxonomy.ts:926`) was the **last** `cached()` call site listed in #2884. It was filed under bucket 3 in the issue body but is structurally a bucket-1 hierarchy cache (mirroring location/occupation/seniority — same shape, same TTL, same invalidation trigger). Bucket 1 (#2906) missed it for that reason; #2909 noted the discrepancy.

This PR completes the migration of all 24 sites enumerated in #2884.

## Pattern (matches #2906 exactly)

- Lift the inner DB fetch into `_fetchTechnologyHierarchyData()` with `'use cache'` + `cacheLife("days")`. Returns a serializable `Record<string, TechnologyMeta>`.
- `_getTechnologyCache()` becomes a thin wrapper that converts the Record to `Map<number, TechnologyMeta>` outside the cache boundary (Map isn't serializable for the `'use cache'` slot).
- Add `cacheTag(typeaheadTechnologiesCacheTag())` so the existing `/api/internal/invalidate-typeahead` route's `revalidateTag` sweep also evicts this slot alongside the matching tech typeahead — the trigger (CSV taxonomy rename) is the same.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test` — 54/54 suites, 490/490 tests pass
- [x] Empirical timing on `/api/v1/taxonomies?type=technologies` (after clearing both Redis `tech-all-grouped:` and the inner `'use cache'` slot via dev restart): cold 1.34s, warm 36-50ms
- [x] Empirical guard: temporary `throw` inside `_fetchTechnologyHierarchyData` surfaced as `items: []` (caught by the existing outer `try/catch` in `_fetchAllTechnologiesGrouped`). Reverted.
- [x] Invalidation probe: cold (1.46s) → warm (53ms) → POST `/api/internal/invalidate-typeahead` (returned `revalidatedTags` including `"typeahead:technologies"`) → cold-again (462ms application-code, vs 50ms warm — confirms the inner slot was evicted)

## History

This completes #2884. Prior bucket PRs:
- #2906 — bucket 1 (hierarchies: occupation/location/seniority — tech missed)
- #2907 — bucket 2 (typeaheads, plus the `cacheTag` namers used here)
- #2908 — bucket 5 (small lookups)
- #2909 — bucket 3 (taxonomy resolve / expand)
- #2910 — bucket 4 (per-company derived)

After this lands, all 24 sites are migrated.

Generated with [Claude Code](https://claude.com/claude-code)