### PR TITLE
fix(web): refresh de/fr/it translations for watchlist-ICP copy (closes #2871)

### DIFF
--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -39,8 +39,8 @@ msgstr "„Viktor Shcherbakov, Sammlung von Stellenanzeigen\" mit einem Link zur
 #. Screen reader text for external links
 #. Screen reader text for external links
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:36
-#: src/components/Footer.tsx:42
+#: src/components/Footer.tsx:41
+#: src/components/Footer.tsx:47
 #: src/components/HowWeIndexContent.tsx:196
 #: src/components/LicenseContent.tsx:64
 #: src/components/LicenseContent.tsx:89
@@ -58,7 +58,7 @@ msgid "search.detail.showMoreLocations"
 msgstr "{0} weitere"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:32
+#: app/[lang]/(app)/company/[slug]/page.tsx:39
 msgid "company.meta.positionCount"
 msgstr "{count, plural, one {# offene Stelle} other {# offene Stellen}}"
 
@@ -87,7 +87,7 @@ msgid "blog.mention.watchlist.companiesLabel"
 msgstr "{count, plural, one {Unternehmen} other {Unternehmen}}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:98
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:103
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {# Unternehmen beobachtet} other {# Unternehmen beobachtet}}. {description}"
 
@@ -98,23 +98,23 @@ msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} Bewerbungen am {date}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:56
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:61
 msgid "watchlist.meta.moreCompanies"
 msgstr "{count} weitere"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:44
+#: app/[lang]/(app)/company/[slug]/page.tsx:51
 msgid "company.meta.descriptionBasic"
 msgstr "{countText} bei {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:39
+#: app/[lang]/(app)/company/[slug]/page.tsx:46
 msgid "company.meta.descriptionWithInfo"
 msgstr "{countText} bei {name}. {description}"
 
 #. Reading-time label shown in the blog post byline. {minutes} is the integer minute count.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:136
+#: app/[lang]/(public)/blog/[slug]/page.tsx:150
 msgid "blog.post.readingTime"
 msgstr "{minutes, plural, one {# Min. Lesezeit} other {# Min. Lesezeit}}"
 
@@ -152,7 +152,7 @@ msgstr "1 Bewerbung am {date}"
 #. js-lingui-explicit-id
 #: src/components/Pricing.tsx:45
 msgid "home.pricing.free.f2"
-msgstr "Bewerbungstracker"
+msgstr "1 Watchlist"
 
 #. Heading for the 'install the Murmur MCP server' step on the agent-prompt success card
 #. js-lingui-explicit-id
@@ -167,13 +167,13 @@ msgid "app.home.request.agent.run_heading"
 msgstr "2. Prompt ausführen"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:63
+#: app/[lang]/(public)/faq/page.tsx:69
 msgid "faq.a.whatIsWatchlist"
 msgstr "Eine Watchlist ist eine gespeicherte Suche mit optionaler Unternehmensfilterung. Wähle die Unternehmen, die dich interessieren, setze deine Filter (Rolle, Standort, Seniorität, Gehalt) und erhalte einen Live-Feed passender Stellen. Du kannst Watchlists öffentlich teilen oder privat halten."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/about/page.tsx:18
-#: app/[lang]/(public)/about/page.tsx:40
+#: app/[lang]/(public)/about/page.tsx:17
+#: app/[lang]/(public)/about/page.tsx:46
 msgid "about.meta.title"
 msgstr "Über uns"
 
@@ -287,7 +287,6 @@ msgstr "Agent-Prompt"
 
 #. Encryption
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:61
 #: src/components/PrivacyPolicyContent.tsx:47
 msgid "privacy.short.r5"
 msgstr "Alle Daten werden bei Übertragung und Speicherung verschlüsselt."
@@ -335,7 +334,7 @@ msgid "settings.account.username.taken"
 msgstr "Bereits vergeben"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:19
+#: app/[lang]/(public)/faq/page.tsx:18
 msgid "faq.meta.description"
 msgstr "Antworten auf häufige Fragen zu Job Seek — wie wir Karriereseiten crawlen, was die Tarife enthalten, wie wir mit deinen Daten umgehen und wie du dich abmelden kannst."
 
@@ -353,7 +352,6 @@ msgstr "Alle Unternehmen"
 
 #. MIT license section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:55
 #: src/components/LicenseContent.tsx:50
 msgid "license.code.title"
 msgstr "Anwendungscode (MIT-Lizenz)"
@@ -364,18 +362,17 @@ msgstr "Anwendungscode (MIT-Lizenz)"
 msgid "license.toc.code"
 msgstr "Anwendungscode (MIT)"
 
-#. Feature: application stats title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:89
-#: src/components/Features.tsx:251
-msgid "home.features.s2.p3.title"
-msgstr "Benachrichtigungen, die du steuerst"
-
 #. Link to application stats page
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:263
 msgid "myJobs.viewStats"
 msgstr "Bewerbungsstatistik"
+
+#. Feature: application stats title
+#. js-lingui-explicit-id
+#: src/components/Features.tsx:251
+msgid "home.features.s2.p3.title"
+msgstr "Bewerbungsstatistiken"
 
 #. Stats page title
 #. js-lingui-explicit-id
@@ -393,7 +390,7 @@ msgstr "Bewerbungstracker"
 #. js-lingui-explicit-id
 #: src/components/Pricing.tsx:46
 msgid "home.pricing.free.f3"
-msgstr "Gespeicherte Suchen"
+msgstr "Bewerbungstracker mit Interview-Protokoll"
 
 #. Subtitle showing total applications in past year
 #. js-lingui-explicit-id
@@ -457,7 +454,6 @@ msgstr "Apr"
 
 #. Step 3 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:66
 #: src/components/HowWeIndexContent.tsx:131
 msgid "indexing.ingestion.s3.body"
 msgstr "Als letztes Mittel parsen wir die Karriereseiten selbst, bevorzugen dabei die neuesten Einträge zuerst und stoppen, sobald bereits indexierte Stellen wieder auftauchen, anstatt jede Seite zu durchsuchen."
@@ -486,16 +482,16 @@ msgstr "Aug"
 msgid "settings.account.username.available"
 msgstr "Verfügbar"
 
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Zurück zur Anmeldung"
-
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Zurück zur Anmeldung"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Zurück zur Anmeldung"
 
 #. Link back to sign-in from forgot password
@@ -522,22 +518,22 @@ msgstr "Nach oben"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Verhalten"
 
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:145
+msgid "blog.post.backToIndex"
+msgstr "Blog"
+
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:24
+#: app/[lang]/(public)/blog/page.tsx:27
 msgid "blog.meta.title"
 msgstr "Blog"
 
 #. <h1> on the blog index page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:69
+#: app/[lang]/(public)/blog/page.tsx:78
 msgid "blog.index.heading"
-msgstr "Blog"
-
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:131
-msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -550,7 +546,7 @@ msgstr "Blog"
 
 #. Footer link to /blog index page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:47
+#: src/components/Footer.tsx:52
 msgid "common.footer.blog"
 msgstr "Blog"
 
@@ -567,14 +563,13 @@ msgid "indexing.oss.browseRepo"
 msgstr "Repository ansehen unter"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:22
-#: app/[lang]/(public)/page.tsx:47
+#: app/[lang]/(public)/page.tsx:21
+#: app/[lang]/(public)/page.tsx:53
 msgid "home.meta.description"
 msgstr "Erstelle Watchlists mit den Unternehmen, die dich interessieren, lasse dich per E-Mail benachrichtigen, wenn neue Stellen geöffnet werden, und verfolge Bewerbungen an einem Ort. Stellen kommen direkt von den Karriereseiten der Unternehmen, innerhalb weniger Stunden nach Veröffentlichung — kein Recruiter-Spam, keine wiederveröffentlichten Listings."
 
 #. Hero description paragraph — watchlist + alerts pitch with direct sourcing as supporting claim
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:72
 #: src/components/Hero.tsx:31
 msgid "home.hero.description"
 msgstr "Erstelle Watchlists mit den Unternehmen, die dich interessieren, lass dich per E-Mail benachrichtigen, sobald neue Stellen frei werden, und verfolge jede Bewerbung an einem Ort. Wir überwachen Karriereseiten direkt — Stellen erscheinen innerhalb weniger Stunden, bevor LinkedIn oder Indeed sie übernehmen."
@@ -582,19 +577,17 @@ msgstr "Erstelle Watchlists mit den Unternehmen, die dich interessieren, lass di
 #. About page heading
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:25
-#: app/[lang]/(public)/about/page.tsx:51
 msgid "about.title"
 msgstr "Von Jobsuchenden entwickelt, für Jobsuchende"
 
 #. Terms page description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:54
 #: src/components/TermsContent.tsx:23
 msgid "terms.hero.description"
 msgstr "Mit der Nutzung von Job Seek stimmst du diesen Bedingungen zu. Hier eine verständliche Zusammenfassung."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:74
+#: app/[lang]/(public)/faq/page.tsx:80
 msgid "faq.q.optOut"
 msgstr "Kann ich die Indexierung meines Unternehmens durch Jobseek ablehnen?"
 
@@ -646,17 +639,17 @@ msgstr "Ändere dein Passwort über einen sicheren E-Mail-Link."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Ändern…"
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "E-Mail überprüfen"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
 msgstr "E-Mail prüfen"
+
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
+msgstr "E-Mail überprüfen"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -684,7 +677,6 @@ msgstr "Wählen Sie den Plan, der zu Ihnen passt."
 
 #. Pricing section heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:102
 #: src/components/Pricing.tsx:103
 msgid "home.pricing.title"
 msgstr "Wähle den passenden Plan"
@@ -743,7 +735,6 @@ msgstr "Klicken zum Umbenennen"
 
 #. Step 2 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:65
 #: src/components/HowWeIndexContent.tsx:121
 msgid "indexing.ingestion.s2.title"
 msgstr "Client-APIs als Zweites."
@@ -774,21 +765,18 @@ msgstr "Coding"
 
 #. CC license section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:57
 #: src/components/LicenseContent.tsx:71
 msgid "license.data.title"
 msgstr "Sammlung von Stellenanzeigen (CC BY-NC 4.0)"
 
 #. Feature: multi-dimensional filters description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:79
 #: src/components/Features.tsx:186
 msgid "home.features.s1.p2.description"
-msgstr "Erfasse, wo du dich beworben hast, Status, Kontakte und nächste Schritte."
+msgstr "Kombiniere Seniorität, Technologien, Gehalt, Standort und Stellensprache in einer einzigen Abfrage. Schluss mit dem Sieben durch Rauschen."
 
 #. Feature: focused search description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:96
 #: src/components/Features.tsx:303
 msgid "home.features.s3.p1.description"
 msgstr "Kombiniere bestimmte Unternehmen mit Rollenfiltern, um genau die Positionen zu finden, die du suchst."
@@ -837,17 +825,17 @@ msgstr "Unternehmen"
 
 #. Heading shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:74
+#: app/[lang]/(app)/company/[slug]/page.tsx:87
 msgid "company.notFound.title"
 msgstr "Unternehmen nicht gefunden"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:77
+#: app/[lang]/layout.tsx:111
 msgid "app.schema.description"
 msgstr "Unternehmens-Tracking-Tool für Jobsuchende, die schon wissen, bei welchen Unternehmen sie arbeiten möchten. Erstelle Watchlists, erhalte E-Mail-Benachrichtigungen, sobald neue Stellen frei werden, und verfolge Bewerbungen an einem Ort — Stellenanzeigen direkt von den Karriereseiten der Unternehmen."
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:43
+#: app/[lang]/layout.tsx:76
 msgid "app.schema.org.description"
 msgstr "Unternehmens-Tracking-Tool für gezielte Jobsuchende — Watchlists, E-Mail-Benachrichtigungen und Stellenanzeigen direkt von den Karriereseiten der Unternehmen. Entwickelt von der Colophon Group, einem kleinen Entwicklerstudio in der Schweiz."
 
@@ -875,16 +863,9 @@ msgstr "Verbinden"
 msgid "settings.account.socials.title"
 msgstr "Verknüpfte Konten"
 
-#. Contact section title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:59
-#: src/components/LicenseContent.tsx:96
-msgid "license.contact.title"
-msgstr "Kontakt"
-
 #. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:41
+#: src/components/Footer.tsx:46
 msgid "common.footer.contact"
 msgstr "Kontakt"
 
@@ -892,6 +873,12 @@ msgstr "Kontakt"
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:25
 msgid "license.toc.contact"
+msgstr "Kontakt"
+
+#. Contact section title
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:96
+msgid "license.contact.title"
 msgstr "Kontakt"
 
 #. Table of contents heading
@@ -938,7 +925,6 @@ msgstr "Freiberuflich"
 
 #. Cookies
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:60
 #: src/components/PrivacyPolicyContent.tsx:46
 msgid "privacy.short.r4"
 msgstr "Cookies dienen nur der Sitzung — keine Werbung, kein Tracking."
@@ -987,17 +973,16 @@ msgstr "Land"
 msgid "about.link.crawler"
 msgstr "Crawler-Quellcode"
 
-#. Assurances section title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:55
-#: src/components/HowWeIndexContent.tsx:63
-msgid "indexing.assurances.title"
-msgstr "Crawling-Zusicherungen"
-
 #. TOC: Crawling assurances
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:28
 msgid "indexing.toc.assurances"
+msgstr "Crawling-Zusicherungen"
+
+#. Assurances section title
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:63
+msgid "indexing.assurances.title"
 msgstr "Crawling-Zusicherungen"
 
 #. Label on the create watchlist card
@@ -1038,7 +1023,6 @@ msgstr "Konto wird erstellt…"
 
 #. Feature section 3 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:93
 #: src/components/Features.tsx:293
 msgid "home.features.s3.title"
 msgstr "Erstelle eine Watchlist für jede Nische"
@@ -1075,13 +1059,13 @@ msgstr "Dunkel"
 
 #. Meta description (under 160 chars) for the blog index page — covers data analyses + report breakdowns + news commentary
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:29
+#: app/[lang]/(public)/blog/page.tsx:32
 msgid "blog.meta.description"
 msgstr "Datenanalysen, Nachrichten und Zusammenfassungen von Branchenberichten – basierend auf den Stellenanzeigen, die wir auf den Karriereseiten tausender Unternehmen verfolgen."
 
 #. One-line tagline under the blog index <h1> — covers data analyses + reports/papers + news
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:74
+#: app/[lang]/(public)/blog/page.tsx:83
 msgid "blog.index.tagline"
 msgstr "Datenanalysen, Nachrichten und Zusammenfassungen von Branchenberichten und Studien – basierend auf den Stellenanzeigen, die wir verfolgen."
 
@@ -1165,10 +1149,9 @@ msgstr "Haben Sie das gesuchte Unternehmen nicht gefunden?"
 
 #. Feature: direct from source title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:78
 #: src/components/Features.tsx:180
 msgid "home.features.s1.p1.title"
-msgstr "Unternehmens-Benachrichtigungen"
+msgstr "Direkt aus der Quelle"
 
 #. Disable alerts tooltip
 #. js-lingui-explicit-id
@@ -1189,7 +1172,7 @@ msgid "watchlists.explore.publicTitle"
 msgstr "Öffentliche Watchlists entdecken"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:82
+#: app/[lang]/(public)/faq/page.tsx:88
 msgid "faq.q.dataPrivacy"
 msgstr "Verkauft Jobseek meine Daten?"
 
@@ -1201,7 +1184,6 @@ msgstr "Noch kein Konto? <0>Registrieren</0>"
 
 #. No scraping
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:59
 #: src/components/TermsContent.tsx:45
 msgid "terms.short.r3"
 msgstr "Kein Scraping, keine automatisierten Bewerbungen, kein Missbrauch der Plattform."
@@ -1248,7 +1230,7 @@ msgstr "Unbegrenzt Unternehmen folgen"
 #. js-lingui-explicit-id
 #: src/components/Pricing.tsx:82
 msgid "home.pricing.pro.f2"
-msgstr "Bewerbungstracker"
+msgstr "E-Mail-Benachrichtigungen bei neuen Treffern"
 
 #. Email or username input label for sign-in
 #. js-lingui-explicit-id
@@ -1288,21 +1270,18 @@ msgstr "Gib unten dein neues Passwort ein."
 
 #. Assurance 3 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:59
 #: src/components/HowWeIndexContent.tsx:80
 msgid "indexing.assurances.i3.body"
 msgstr "Auch nach der Entdeckung rufen wir Stellendetailseiten mit einem strikten Limit von einer Anfrage pro Seite pro Minute ab."
 
 #. Feature section 1 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:75
 #: src/components/Features.tsx:171
 msgid "home.features.s1.title"
-msgstr "Entwickelt für aktive Jobsuchende"
+msgstr "Jeder Filter, den ein Jobsuchender wirklich braucht"
 
 #. Assurance 1 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:57
 #: src/components/HowWeIndexContent.tsx:68
 msgid "indexing.assurances.i1.body"
 msgstr "Jedes Wiederholungsfenster nutzt exponentielles Backoff, damit wir einen Server nie überlasten, und wir brechen ab, wenn ein Host weiterhin Timeouts liefert."
@@ -1322,7 +1301,7 @@ msgstr "E-Mail-Benachrichtigungen bei neuen Stellen"
 #. FAQ page description
 #. js-lingui-explicit-id
 #. placeholder {0}: siteConfig.indexing.contactEmail
-#: app/[lang]/(public)/faq/faq-content.tsx:45
+#: app/[lang]/(public)/faq/faq-content.tsx:42
 msgid "faq.description"
 msgstr "Alles, was du über Job Seek wissen musst. Du findest nicht, was du suchst? Schreib uns an <0>{0}</0>."
 
@@ -1412,7 +1391,7 @@ msgid "settings.account.username.error"
 msgstr "Benutzername konnte nicht aktualisiert werden"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:18
+#: app/[lang]/(public)/faq/page.tsx:17
 msgid "faq.meta.title"
 msgstr "FAQ"
 
@@ -1492,7 +1471,6 @@ msgstr "Weitere finden"
 
 #. Feature: focused search title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:96
 #: src/components/Features.tsx:302
 msgid "home.features.s3.p1.title"
 msgstr "Fokussierte Suche"
@@ -1505,7 +1483,7 @@ msgstr "Folge uns auf LinkedIn"
 
 #. Aria label for footer navigation
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:31
+#: src/components/Footer.tsx:36
 msgid "common.footer.ariaLabel"
 msgstr "Fußzeile"
 
@@ -1547,7 +1525,6 @@ msgstr "Gegründet {year}"
 
 #. Free tier name
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:104
 #: src/components/Pricing.tsx:32
 msgid "home.pricing.free.name"
 msgstr "Kostenlos"
@@ -1559,14 +1536,13 @@ msgid "settings.billing.plan.free"
 msgstr "Kostenlos"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:59
+#: app/[lang]/(public)/faq/page.tsx:65
 msgid "faq.a.freeVsPro"
 msgstr "Kostenlos bietet dir vollständige Suche über alle Unternehmen, eine Watchlist und den Bewerbungstracker mit Interview-Protokollierung. Pro fügt unbegrenzte Watchlists und E-Mail-Benachrichtigungen hinzu, wenn neue Stellen deinen Kriterien entsprechen."
 
 #. FAQ page heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/faq-content.tsx:42
-#: app/[lang]/(public)/faq/page.tsx:109
+#: app/[lang]/(public)/faq/faq-content.tsx:39
 msgid "faq.title"
 msgstr "Häufig gestellte Fragen"
 
@@ -1578,10 +1554,9 @@ msgstr "Fr"
 
 #. Feature section 2 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:84
 #: src/components/Features.tsx:232
 msgid "home.features.s2.title"
-msgstr "Der erste Job-Aggregator, der dich ans Steuer lässt"
+msgstr "Von der gespeicherten Stelle zum unterschriebenen Angebot — alles an einem Ort"
 
 #. Free plan feature: search
 #. js-lingui-explicit-id
@@ -1590,16 +1565,15 @@ msgid "settings.billing.free.f2"
 msgstr "Vollständige Jobsuche"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:87
+#: app/[lang]/layout.tsx:121
 msgid "app.schema.offer.free"
 msgstr "Vollständige Suche, 1 Watchlist, Bewerbungstracker"
 
 #. Free tier description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:104
 #: src/components/Pricing.tsx:41
 msgid "home.pricing.free.description"
-msgstr "Teste Job Seek mit genug Spielraum, um bei deinen Traumunternehmen auf dem Laufenden zu bleiben."
+msgstr "Volle Suche, eine Watchlist und ein integrierter Bewerbungstracker, um deine Pipeline zu verwalten."
 
 #. Employment type: full-time
 #. js-lingui-explicit-id
@@ -1637,13 +1611,13 @@ msgstr "Erste Schritte mit Job Seek"
 
 #. Footer link to GitHub repo
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:35
+#: src/components/Footer.tsx:40
 msgid "common.footer.github"
 msgstr "GitHub"
 
 #. Link to return to the homepage from a 404 page
 #. js-lingui-explicit-id
-#: app/[lang]/not-found.tsx:22
+#: app/[lang]/not-found-content.tsx:22
 msgid "notFound.goHome"
 msgstr "Zur Startseite"
 
@@ -1661,7 +1635,6 @@ msgstr "Verstanden"
 
 #. Step 3 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:66
 #: src/components/HowWeIndexContent.tsx:129
 msgid "indexing.ingestion.s3.title"
 msgstr "Behutsames Seiten-Parsing."
@@ -1697,32 +1670,25 @@ msgid "myJobs.salary.hourly"
 msgstr "Stündlich"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:54
+#: app/[lang]/(public)/faq/page.tsx:60
 msgid "faq.q.requestCompany"
 msgstr "Wie kann ich ein nicht gelistetes Unternehmen anfragen?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:70
+#: app/[lang]/(public)/faq/page.tsx:76
 msgid "faq.q.crawlingPolicy"
 msgstr "Wie verhält sich der Crawler auf der Website meines Unternehmens?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:19
-#: app/[lang]/(public)/how-we-index/page.tsx:45
+#: app/[lang]/(public)/how-we-index/page.tsx:18
+#: app/[lang]/(public)/how-we-index/page.tsx:50
 msgid "indexing.meta.description"
 msgstr "Wie Job Seek Stellenanzeigen entdeckt und indexiert: unser Sourcing-Ansatz, Crawl-Frequenz, Rate-Limits, robots.txt- und TDM-Reservation-Konformität und wie du dich abmeldest."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:46
+#: app/[lang]/(public)/faq/page.tsx:52
 msgid "faq.q.howOftenUpdated"
 msgstr "Wie oft werden Stellenanzeigen aktualisiert?"
-
-#. Ingestion section title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:62
-#: src/components/HowWeIndexContent.tsx:104
-msgid "indexing.ingestion.title"
-msgstr "Wie Stellenanzeigen in den Index gelangen"
 
 #. TOC: How postings enter the index
 #. js-lingui-explicit-id
@@ -1730,16 +1696,21 @@ msgstr "Wie Stellenanzeigen in den Index gelangen"
 msgid "indexing.toc.ingestion"
 msgstr "Wie Stellenanzeigen in den Index gelangen"
 
+#. Ingestion section title
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:104
+msgid "indexing.ingestion.title"
+msgstr "Wie Stellenanzeigen in den Index gelangen"
+
 #. Indexing page title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:52
 #: src/components/HowWeIndexContent.tsx:48
 msgid "indexing.hero.title"
 msgstr "Wie wir Stellenanzeigen finden und verarbeiten"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:18
-#: app/[lang]/(public)/how-we-index/page.tsx:44
+#: app/[lang]/(public)/how-we-index/page.tsx:17
+#: app/[lang]/(public)/how-we-index/page.tsx:49
 msgid "indexing.meta.title"
 msgstr "So indexieren wir"
 
@@ -1751,14 +1722,12 @@ msgstr "Falls ein Konto mit dieser E-Mail-Adresse existiert, haben wir einen Lin
 
 #. Step 2 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:65
 #: src/components/HowWeIndexContent.tsx:123
 msgid "indexing.ingestion.s2.body"
 msgstr "Falls keine Sitemap existiert, untersuchen wir die Client-Anwendung auf JSON-APIs, die sie aufruft; wenn wir welche finden, nutzen wir diese Endpunkte direkt, um Stellenanzeigen-URLs aufzulisten, ohne das DOM zu scrapen."
 
 #. Opt-out section body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:71
 #: src/components/HowWeIndexContent.tsx:164
 msgid "indexing.optOut.body"
 msgstr "Wenn du unerwartete Aktivitäten unseres Crawlers bemerkst oder es vorziehst, dass deine Karriereseite nicht indexiert wird, schreib uns bitte eine E-Mail und wir werden umgehend antworten."
@@ -1770,7 +1739,7 @@ msgid "indexing.outreach.body"
 msgstr "Wenn du ungewöhnliches Crawler-Verhalten bemerkst, es vorziehst, dass wir deine Inhalte nicht indexieren, oder Vorschläge zur Verbesserung unserer Schutzmaßnahmen hast, kontaktiere uns bitte."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:72
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:77
 msgid "watchlist.meta.inLocations"
 msgstr "in {locations}"
 
@@ -1841,7 +1810,6 @@ msgstr "Eingabe ist zu kurz."
 #. About paragraph 2: how it works — leads with direct sourcing and watchlist ICP, no platform listing
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:38
-#: app/[lang]/(public)/about/page.tsx:53
 msgid "about.p2"
 msgstr "Statt darauf zu warten, dass Unternehmen ihre Stellen auf Drittanbieter-Jobportalen veröffentlichen, gehen wir direkt zur Quelle. Unser Crawler überwacht tausende von Karriereseiten direkt und prüft sie häufig erneut, sodass neue Stellen hier innerhalb weniger Stunden nach Veröffentlichung auftauchen — typischerweise bevor sie die großen Aggregatoren erreichen. Erstelle eine Watchlist mit den Unternehmen, die dich interessieren, und werde benachrichtigt, sobald sie etwas posten."
 
@@ -1859,10 +1827,9 @@ msgstr "Interview"
 
 #. Feature: interview log title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:88
 #: src/components/Features.tsx:246
 msgid "home.features.s2.p2.title"
-msgstr "Schluss mit der 50-Tab-Routine"
+msgstr "Interview-Protokoll"
 
 #. Status group heading: interviewing
 #. js-lingui-explicit-id
@@ -1907,17 +1874,17 @@ msgid "auth.verify.error.invalidLink"
 msgstr "Ungültiger Bestätigungslink"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:42
+#: app/[lang]/(public)/faq/page.tsx:48
 msgid "faq.q.targetedSeeker"
 msgstr "Ist Job Seek das Richtige für mich, wenn ich schon weiß, bei welchen Unternehmen ich arbeiten möchte?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:78
+#: app/[lang]/(public)/faq/page.tsx:84
 msgid "faq.q.openSource"
 msgstr "Ist der Crawler Open Source?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:66
+#: app/[lang]/(public)/faq/page.tsx:72
 msgid "faq.q.trackerLimit"
 msgstr "Gibt es ein Limit, wie viele Jobs ich verfolgen kann?"
 
@@ -1982,19 +1949,18 @@ msgid "home.features.s2.screenshot.alt"
 msgstr "Job Seek Oberfläche zum Einreichen von Unternehmenslinks und Konfigurieren benutzerdefinierter Benachrichtigungen"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:39
+#: app/[lang]/(public)/faq/page.tsx:45
 msgid "faq.a.whatIsJobseek"
 msgstr "Job Seek hilft dir dabei, die Unternehmen zu verfolgen, bei denen du wirklich arbeiten möchtest. Erstelle eine Watchlist, lasse dich per E-Mail benachrichtigen, wenn neue Stellen geöffnet werden, und verfolge Bewerbungen an einem Ort. Stellen kommen direkt von den Karriereseiten der Unternehmen, sodass du sie innerhalb weniger Stunden nach Veröffentlichung siehst — typischerweise bevor LinkedIn oder Indeed sie übernehmen."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/about/page.tsx:19
-#: app/[lang]/(public)/about/page.tsx:41
+#: app/[lang]/(public)/about/page.tsx:18
+#: app/[lang]/(public)/about/page.tsx:47
 msgid "about.meta.description"
 msgstr "Job Seek hilft dir dabei, die Unternehmen zu verfolgen, bei denen du arbeiten möchtest — Watchlists, E-Mail-Benachrichtigungen und Stellen direkt von den Karriereseiten der Unternehmen. Entwickelt von Colophon Group, einem kleinen Entwicklerstudio in der Schweiz."
 
 #. Indexing page description — company-tracking framing, not 'search engine'
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:53
 #: src/components/HowWeIndexContent.tsx:51
 msgid "indexing.hero.description"
 msgstr "Job Seek ist ein Unternehmens-Tracking-Tool — es überwacht tausende Karriereseiten von Unternehmen, damit Nutzer Watchlists erstellen und Benachrichtigungen über neue Stellen erhalten können. Diese Seite dokumentiert genau, wie sich unser Crawler verhält, welche Kontrollen ihn höflich halten und wie Stellen letztlich in den Index gelangen."
@@ -2008,13 +1974,12 @@ msgstr "Job Seek wird aktiv entwickelt. Bleib dran für Updates!"
 #. About paragraph 1: who we are
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:26
-#: app/[lang]/(public)/about/page.tsx:52
 msgid "about.p1"
 msgstr "Job Seek wird von der Colophon Group entwickelt, einem kleinen Entwicklerteam in der Schweiz. Wir haben es gestartet, weil wir das gleiche Problem satt hatten, das jeder Jobsuchende kennt: Dutzende Browser-Tabs jonglieren, neue Stellen verpassen, weil ein Aggregator zu langsam war, und in algorithmischem Rauschen untergehen, das auf Klicks statt auf Relevanz optimiert."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:19
-#: app/[lang]/(public)/privacy-policy/page.tsx:45
+#: app/[lang]/(public)/privacy-policy/page.tsx:18
+#: app/[lang]/(public)/privacy-policy/page.tsx:51
 msgid "privacy.meta.description"
 msgstr "Datenschutzrichtlinie von Job Seek — welche personenbezogenen Daten wir erheben, wie wir sie verwenden, deine DSGVO-Rechte, Cookie-Richtlinie und Kontolöschung."
 
@@ -2032,13 +1997,12 @@ msgstr "Job Seek Watchlist mit kuratierten Robotik-Ingenieurstellen in Zürich"
 
 #. License page description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:54
 #: src/components/LicenseContent.tsx:38
 msgid "license.hero.description"
 msgstr "Die Codebasis von Job Seek ist Open Source unter MIT. Die von uns gesammelten und aufbereiteten Stellendaten stehen unter Creative Commons BY-NC 4.0. Nachfolgend eine verständliche Zusammenfassung — bitte lies die vollständigen Lizenzen für die genauen Bedingungen."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:80
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:85
 msgid "watchlist.meta.fallback"
 msgstr "Job-Watchlist von @{owner}"
 
@@ -2055,12 +2019,12 @@ msgid "watchlists.explore.jobPlural"
 msgstr "Jobs"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:25
+#: app/[lang]/(app)/company/[slug]/page.tsx:32
 msgid "company.meta.title"
 msgstr "Jobs bei {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:62
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:67
 msgid "watchlist.meta.jobsAt"
 msgstr "Jobs bei {names}"
 
@@ -2108,14 +2072,14 @@ msgstr "Letzte Stunde"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:28
-msgid "privacy.hero.lastUpdated"
+#: src/components/TermsContent.tsx:28
+msgid "terms.hero.lastUpdated"
 msgstr "Zuletzt aktualisiert:"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:28
-msgid "terms.hero.lastUpdated"
+#: src/components/PrivacyPolicyContent.tsx:28
+msgid "privacy.hero.lastUpdated"
 msgstr "Zuletzt aktualisiert:"
 
 #. Time range option: last week
@@ -2130,21 +2094,21 @@ msgstr "Letzte Woche"
 msgid "home.hero.secondaryCta"
 msgstr "Mehr erfahren"
 
-#. Label for seniority/level filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:154
-msgid "search.advanced.level"
-msgstr "Stufe"
-
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:638
 msgid "search.bar.level"
 msgstr "Stufe"
 
+#. Label for seniority/level filter in advanced search
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:18
-#: app/[lang]/(public)/license/page.tsx:45
+#: src/components/search/advanced-search-panel.tsx:154
+msgid "search.advanced.level"
+msgstr "Stufe"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/license/page.tsx:17
+#: app/[lang]/(public)/license/page.tsx:51
 msgid "license.meta.title"
 msgstr "Lizenz"
 
@@ -2156,13 +2120,12 @@ msgstr "Lizenz"
 
 #. Footer link to license page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
+#: src/components/Footer.tsx:57
 msgid "common.footer.licenseLink"
 msgstr "Lizenz"
 
 #. License page title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:53
 #: src/components/LicenseContent.tsx:37
 msgid "license.hero.title"
 msgstr "Lizenz von Job Seek"
@@ -2174,8 +2137,8 @@ msgid "license.hero.eyebrow"
 msgstr "Lizenzierung"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:19
-#: app/[lang]/(public)/license/page.tsx:46
+#: app/[lang]/(public)/license/page.tsx:18
+#: app/[lang]/(public)/license/page.tsx:52
 msgid "license.meta.description"
 msgstr "Lizenzierung von Job Seek — der Quellcode steht unter MIT-Lizenz, Stellenanzeigen unter CC BY-NC 4.0. Erfahre, was du mit unserem Code und unseren Daten tun darfst."
 
@@ -2209,16 +2172,16 @@ msgstr "Standort"
 msgid "search.advanced.location"
 msgstr "Standort"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
-msgstr "Standorte"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:708
 msgid "search.bar.locations"
+msgstr "Standorte"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:312
+msgid "search.detail.locations"
 msgstr "Standorte"
 
 #. Login button label
@@ -2243,7 +2206,6 @@ msgstr "Melde dich an, um diese Suche als Watchlist zu speichern"
 
 #. Feature: share watchlists description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:98
 #: src/components/Features.tsx:313
 msgid "home.features.s3.p3.description"
 msgstr "Mach eine Watchlist öffentlich und teile den Link mit Freunden, Communities oder deinem Netzwerk."
@@ -2348,7 +2310,6 @@ msgstr "Kopien"
 
 #. Feature: request companies description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:97
 #: src/components/Features.tsx:308
 msgid "home.features.s3.p2.description"
 msgstr "Ein Unternehmen fehlt? Füge die Karriereseiten-URL ein und wir beginnen, es für dich zu indexieren."
@@ -2360,7 +2321,7 @@ msgid "myJobs.heatmap.day.mon"
 msgstr "Mo"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:99
+#: app/[lang]/layout.tsx:133
 msgid "app.schema.feature.monitor"
 msgstr "Karriereseiten von Unternehmen überwachen"
 
@@ -2384,20 +2345,18 @@ msgstr "mehr"
 
 #. Feature: status tracking description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:87
 #: src/components/Features.tsx:242
 msgid "home.features.s2.p1.description"
-msgstr "Verweise uns auf eine beliebige Karriereseite oder ein Notion-Jobboard und Job Seek spiegelt sie innerhalb von Minuten in deinem Workspace."
+msgstr "Verschiebe jede Stelle von gespeichert zu beworben, im Interview, im Angebot oder abgelehnt. Du weißt immer, wo du stehst."
 
 #. Feature: multi-dimensional filters title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:79
 #: src/components/Features.tsx:185
 msgid "home.features.s1.p2.title"
-msgstr "Bewerbungstracker"
+msgstr "Mehrdimensionale Filter"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:101
+#: app/[lang]/layout.tsx:135
 msgid "app.schema.feature.languages"
 msgstr "Mehrsprachige Unterstützung"
 
@@ -2523,7 +2482,7 @@ msgstr "Keine passenden Stellenanzeigen gefunden."
 
 #. Empty-state message shown when no blog posts have been published yet
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:79
+#: app/[lang]/(public)/blog/page.tsx:88
 msgid "blog.index.empty"
 msgstr "Noch keine Beiträge – schauen Sie bald wieder vorbei."
 
@@ -2582,12 +2541,12 @@ msgid "watchlists.page.empty"
 msgstr "Noch keine Watchlists. Erstelle eine, um Jobs von deinen Lieblingsunternehmen zu verfolgen."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:67
+#: app/[lang]/(public)/faq/page.tsx:73
 msgid "faq.a.trackerLimit"
 msgstr "Nein. Der Bewerbungstracker hat kein festes Limit — speichere so viele Jobs, wie du möchtest, und verschiebe sie durch deine Pipeline."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:83
+#: app/[lang]/(public)/faq/page.tsx:89
 msgid "faq.a.dataPrivacy"
 msgstr "Nein. Wir verkaufen, vermieten oder teilen deine Daten nicht zu Marketingzwecken. Cookies sind nur sitzungsbasiert, ohne Werbung oder Tracking. Du kannst dein Konto löschen und alle Daten werden innerhalb von 30 Tagen entfernt."
 
@@ -2665,14 +2624,12 @@ msgstr "Ok"
 
 #. Step 4 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:67
 #: src/components/HowWeIndexContent.tsx:139
 msgid "indexing.ingestion.s4.body"
 msgstr "Sobald wir eine einzelne Stellenanzeige abrufen, speichern wir nur die stellenspezifischen Metadaten (Titel, Rollenbeschreibung, Standort, Vergütungshinweise, Stellen-URL und Zeitstempel) sowie extrahierte strukturierte Felder. Wir archivieren keine nicht verwandten Seiteninhalte."
 
 #. Assurance 3 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:59
 #: src/components/HowWeIndexContent.tsx:79
 msgid "indexing.assurances.i3.title"
 msgstr "Eine Seite pro Minute."
@@ -2696,16 +2653,9 @@ msgid "common.header.openMenu"
 msgstr "Hauptmenü öffnen"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:37
+#: app/[lang]/(app)/company/[slug]/page.tsx:44
 msgid "company.meta.openPositions"
 msgstr "Offene Stellen"
-
-#. Open-source section title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:76
-#: src/components/HowWeIndexContent.tsx:185
-msgid "indexing.oss.title"
-msgstr "Open-Source-Crawler"
 
 #. TOC: Open-source crawlers
 #. js-lingui-explicit-id
@@ -2713,17 +2663,22 @@ msgstr "Open-Source-Crawler"
 msgid "indexing.toc.oss"
 msgstr "Open-Source-Crawler"
 
-#. Opt-out section title
+#. Open-source section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:70
-#: src/components/HowWeIndexContent.tsx:161
-msgid "indexing.optOut.title"
-msgstr "Opt-out oder Fragen"
+#: src/components/HowWeIndexContent.tsx:185
+msgid "indexing.oss.title"
+msgstr "Open-Source-Crawler"
 
 #. TOC: Opt-out or questions
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:30
 msgid "indexing.toc.optOut"
+msgstr "Opt-out oder Fragen"
+
+#. Opt-out section title
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:161
+msgid "indexing.optOut.title"
 msgstr "Opt-out oder Fragen"
 
 #. Divider between form and OAuth buttons
@@ -2746,22 +2701,20 @@ msgstr "Sonstige"
 
 #. Assurance 2 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:58
 #: src/components/HowWeIndexContent.tsx:73
 msgid "indexing.assurances.i2.body"
 msgstr "Unser Crawler liest <0>robots.txt</0>, befolgt Disallow-Regeln, identifiziert sich über <1>User-Agent</1> und respektiert den W3C-<2>TDM-Reservation</2>-Header — wenn eine Seite Reservation signalisiert, überspringen wir sie."
-
-#. Automation stance title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:73
-#: src/components/HowWeIndexContent.tsx:174
-msgid "indexing.automation.title"
-msgstr "Unsere Haltung zur Automatisierung"
 
 #. TOC: Our stance on automation
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:31
 msgid "indexing.toc.automation"
+msgstr "Unsere Haltung zur Automatisierung"
+
+#. Automation stance title
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:174
+msgid "indexing.automation.title"
 msgstr "Unsere Haltung zur Automatisierung"
 
 #. TOC: Overview
@@ -2790,7 +2743,7 @@ msgstr "Seiteninhalt"
 
 #. Heading shown on the 404 page
 #. js-lingui-explicit-id
-#: app/[lang]/not-found.tsx:12
+#: app/[lang]/not-found-content.tsx:12
 msgid "notFound.title"
 msgstr "Seite nicht gefunden"
 
@@ -2858,7 +2811,6 @@ msgstr "Zeitraum"
 
 #. Pro tier period
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:73
 msgid "home.pricing.pro.period"
 msgstr "pro Monat"
@@ -2889,7 +2841,6 @@ msgstr "Telefoninterview"
 
 #. Feature section 3 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:94
 #: src/components/Features.tsx:296
 msgid "home.features.s3.description"
 msgstr "Wähle die Unternehmen, die dich interessieren, setze deine Filter und erhalte einen Live-Feed passender Stellen. Teile ihn öffentlich oder behalte ihn für dich."
@@ -2978,19 +2929,18 @@ msgstr "Stelle nicht gefunden."
 msgid "myJobs.detail.notFound"
 msgstr "Stellenanzeige nicht gefunden."
 
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:101
-#: src/components/Pricing.tsx:100
-msgid "home.pricing.eyebrow"
-msgstr "Preise"
-
 #. Nav link: Pricing
 #. Nav link: Pricing
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:62
 #: src/components/MobileMenu.tsx:87
 msgid "common.nav.pricing"
+msgstr "Preise"
+
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:100
+msgid "home.pricing.eyebrow"
 msgstr "Preise"
 
 #. Privacy policy page eyebrow
@@ -3001,20 +2951,19 @@ msgstr "Datenschutz"
 
 #. Footer link to privacy policy page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:57
+#: src/components/Footer.tsx:62
 msgid "common.footer.privacyLink"
 msgstr "Datenschutz"
 
 #. Privacy policy page title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:53
 #: src/components/PrivacyPolicyContent.tsx:22
 msgid "privacy.hero.title"
 msgstr "Datenschutz bei Job Seek"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:18
-#: app/[lang]/(public)/privacy-policy/page.tsx:44
+#: app/[lang]/(public)/privacy-policy/page.tsx:17
+#: app/[lang]/(public)/privacy-policy/page.tsx:50
 msgid "privacy.meta.title"
 msgstr "Datenschutzrichtlinie"
 
@@ -3026,7 +2975,6 @@ msgstr "Private Watchlists sind eine kostenpflichtige Funktion. Upgrade, um dein
 
 #. Pro tier name
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:68
 msgid "home.pricing.pro.name"
 msgstr "Pro"
@@ -3045,21 +2993,18 @@ msgstr "Gemeinfrei"
 
 #. Contact call to action
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:60
 #: src/components/LicenseContent.tsx:99
 msgid "license.contactCta"
 msgstr "Fragen zur Lizenzierung oder kommerziellen Nutzung? Schreib uns eine E-Mail."
 
 #. Terms contact call to action
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:63
 #: src/components/TermsContent.tsx:54
 msgid "terms.contact.description"
 msgstr "Fragen? Schreib uns eine E-Mail."
 
 #. Privacy contact call to action
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:65
 #: src/components/PrivacyPolicyContent.tsx:66
 msgid "privacy.contact.description"
 msgstr "Fragen? Schreib uns eine E-Mail."
@@ -3089,7 +3034,7 @@ msgid "terms.fullTermsLink"
 msgstr "Vollständige Nutzungsbedingungen lesen"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:100
+#: app/[lang]/layout.tsx:134
 msgid "app.schema.feature.alerts"
 msgstr "Echtzeit-Benachrichtigungen über neue Stellen"
 
@@ -3101,10 +3046,9 @@ msgstr "Kürzlich aktualisiert"
 
 #. Feature: interview log description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:88
 #: src/components/Features.tsx:247
 msgid "home.features.s2.p2.description"
-msgstr "Sammle alle interessanten Startups in einem Dashboard, statt mit Chrome-Fenstern und Lesezeichen zu jonglieren."
+msgstr "Halte jede Interview-Runde mit Datum, Art und Notizen fest, damit nichts durchs Raster fällt."
 
 #. MIT right 2
 #. js-lingui-explicit-id
@@ -3156,7 +3100,7 @@ msgstr "Abgelehnt"
 
 #. Footer license summary text
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:24
+#: src/components/Footer.tsx:29
 msgid "common.footer.text"
 msgstr "Veröffentlicht unter der MIT-Lizenz. Stellendaten sind CC BY-NC 4.0."
 
@@ -3186,7 +3130,6 @@ msgstr "Unternehmen anfragen"
 
 #. Feature: request companies title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:97
 #: src/components/Features.tsx:307
 msgid "home.features.s3.p2.title"
 msgstr "Beliebiges Unternehmen anfragen"
@@ -3247,14 +3190,12 @@ msgstr "Wird zurückgesetzt…"
 
 #. Assurance 1 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:57
 #: src/components/HowWeIndexContent.tsx:67
 msgid "indexing.assurances.i1.title"
 msgstr "Respektvolles Tempo."
 
 #. Assurance 2 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:58
 #: src/components/HowWeIndexContent.tsx:71
 msgid "indexing.assurances.i2.title"
 msgstr "Robots, Attribution und TDM-Reservation."
@@ -3309,17 +3250,15 @@ msgstr "Gehaltsspanne"
 
 #. Feature section 2 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:85
 #: src/components/Features.tsx:235
 msgid "home.features.s2.description"
-msgstr "Dein Lieblingsunternehmen fehlt im Feed? Füge den Karriereseiten-Link ein und wir beginnen, ihn für dich zu scrapen — keine Skripte, keine Tabellen, kein Warten in Support-Warteschlangen."
+msgstr "Speichere jede Stelle, die du findest, bewege sie durch deine Pipeline, während du dich bewirbst und Interviews führst, und sieh auf einen Blick, wo jede Bewerbung steht."
 
 #. Feature: watchlists and alerts description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:80
 #: src/components/Features.tsx:191
 msgid "home.features.s1.p3.description"
-msgstr "Speichere deine Filter für schnelle Überprüfungen, ohne alles neu eintippen zu müssen."
+msgstr "Speichere jede Suche als Watchlist und erhalte E-Mail-Benachrichtigungen, wenn neue Stellen deinen Kriterien entsprechen."
 
 #. Save job aria label
 #. js-lingui-explicit-id
@@ -3391,14 +3330,13 @@ msgstr "Speichern…"
 #. js-lingui-explicit-id
 #: src/components/Pricing.tsx:44
 msgid "home.pricing.free.f1"
-msgstr "Bis zu 5 Unternehmen abonnieren"
+msgstr "Suche über alle Unternehmen und Filter hinweg"
 
 #. Feature section 1 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:76
 #: src/components/Features.tsx:174
 msgid "home.features.s1.description"
-msgstr "Verfolge Stellen, werde benachrichtigt, wenn Unternehmen etwas Neues veröffentlichen, und halte deine Pipeline sauber."
+msgstr "Suche über tausende Unternehmen hinweg, direkt von ihren Karriereseiten gescraped. Filtere nach Seniorität, Tech-Stack, Gehaltsspanne, Standort und Sprache — alles auf einmal."
 
 #. Placeholder for search bar when on company page
 #. js-lingui-explicit-id
@@ -3468,10 +3406,9 @@ msgstr "Watchlists suchen..."
 
 #. Feature section 1 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:74
 #: src/components/Features.tsx:168
 msgid "home.features.s1.eyebrow"
-msgstr "Alles, was du brauchst, um vorne zu bleiben"
+msgstr "Suche mit Präzision"
 
 #. Placeholder for the main search bar
 #. js-lingui-explicit-id
@@ -3481,10 +3418,9 @@ msgstr "Suchen…"
 
 #. Feature: application stats description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:89
 #: src/components/Features.tsx:252
 msgid "home.features.s2.p3.description"
-msgstr "Lege die Frequenz pro Unternehmen fest, damit du von neuen Stellen erfährst, ohne den ganzen Tag durch Jobportale zu scrollen."
+msgstr "Sieh deinen Funnel, deine Konversionsraten und deine Aktivitäts-Heatmap, um zu verstehen, was funktioniert."
 
 #. Title for the seniority level selection modal
 #. js-lingui-explicit-id
@@ -3518,7 +3454,6 @@ msgstr "Wähle deine bevorzugte Sprache."
 
 #. Step 4 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:67
 #: src/components/HowWeIndexContent.tsx:137
 msgid "indexing.ingestion.s4.title"
 msgstr "Selektive Speicherung."
@@ -3535,17 +3470,17 @@ msgstr "Link senden"
 msgid "settings.account.password.send"
 msgstr "Link senden"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Wird gesendet…"
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
 msgstr "Wird gesendet..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
+msgstr "Wird gesendet…"
 
 #. Reset password button while loading
 #. js-lingui-explicit-id
@@ -3597,7 +3532,6 @@ msgstr "Einstellungen"
 
 #. Feature: share watchlists title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:98
 #: src/components/Features.tsx:312
 msgid "home.features.s3.p3.title"
 msgstr "Mit jedem teilen"
@@ -3724,21 +3658,19 @@ msgstr "Ähnliche Unternehmen"
 
 #. Pricing section description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:103
 #: src/components/Pricing.tsx:106
 msgid "home.pricing.description"
 msgstr "Einfache, transparente Preise. Starte kostenlos und upgrade, wenn du deine Jobsuche ernst meinst."
 
 #. Step 1 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:64
 #: src/components/HowWeIndexContent.tsx:113
 msgid "indexing.ingestion.s1.title"
 msgstr "Zuerst die Sitemap."
 
 #. Skip to main content link for keyboard users
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/layout.tsx:21
+#: app/[lang]/(public)/layout.tsx:25
 msgid "common.a11y.skipToContent"
 msgstr "Zum Inhalt springen"
 
@@ -3816,10 +3748,9 @@ msgstr "Status"
 
 #. Feature: status tracking title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:87
 #: src/components/Features.tsx:241
 msgid "home.features.s2.p1.title"
-msgstr "Link einfügen, Crawl starten"
+msgstr "Statusverfolgung"
 
 #. Footer shown on the agent-prompt success card after 30 minutes of polling without seeing the run complete
 #. js-lingui-explicit-id
@@ -3859,7 +3790,7 @@ msgstr "Abonnement"
 
 #. FAQ page eyebrow
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/faq-content.tsx:39
+#: app/[lang]/(public)/faq/faq-content.tsx:36
 msgid "faq.eyebrow"
 msgstr "Support"
 
@@ -3887,16 +3818,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technisch"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Technologien"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:673
 msgid "search.bar.technologies"
+msgstr "Technologien"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:397
+msgid "search.detail.technologies"
 msgstr "Technologien"
 
 #. Add technology filter
@@ -3931,75 +3862,70 @@ msgstr "Nutzungsbedingungen"
 
 #. Footer link to terms of service page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:62
+#: src/components/Footer.tsx:67
 msgid "common.footer.termsLink"
 msgstr "AGB"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:18
-#: app/[lang]/(public)/terms/page.tsx:44
+#: app/[lang]/(public)/terms/page.tsx:17
+#: app/[lang]/(public)/terms/page.tsx:50
 msgid "terms.meta.title"
 msgstr "Nutzungsbedingungen"
 
 #. Terms page title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:53
 #: src/components/TermsContent.tsx:22
 msgid "terms.hero.title"
 msgstr "Nutzungsbedingungen"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:19
-#: app/[lang]/(public)/terms/page.tsx:45
+#: app/[lang]/(public)/terms/page.tsx:18
+#: app/[lang]/(public)/terms/page.tsx:51
 msgid "terms.meta.description"
 msgstr "Nutzungsbedingungen von Job Seek — Nutzungsregeln, geistiges Eigentum, Kontoverantwortung, Haftungsbeschränkung und geltendes Recht der Jobsuchplattform."
 
 #. Body text shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:79
+#: app/[lang]/(app)/company/[slug]/page.tsx:92
 msgid "company.notFound.message"
 msgstr "Das gesuchte Unternehmen existiert nicht oder wurde entfernt."
 
 #. About transparency paragraph
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:54
-#: app/[lang]/(public)/about/page.tsx:56
 msgid "about.transparency.p1"
 msgstr "Der Crawler-Code ist Open Source, damit jeder prüfen kann, wie wir Daten sammeln. Wir respektieren robots.txt, beachten TDM-Reservation-Header und beschränken uns auf eine Anfrage pro Seite pro Minute. Jeder ausgehende Link enthält utm_source=jobseek, damit Arbeitgeber wissen, woher ihr Traffic kommt."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:47
+#: app/[lang]/(public)/faq/page.tsx:53
 msgid "faq.a.howOftenUpdated"
 msgstr "Der Crawler entdeckt neue Stellenanzeigen in einem stündlichen Zyklus und aktualisiert Stellendetails täglich. Die meisten Stellen erscheinen innerhalb weniger Stunden nach ihrer Veröffentlichung auf der Karriereseite eines Unternehmens."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:87
+#: app/[lang]/(public)/faq/page.tsx:93
 msgid "faq.a.languages"
 msgstr "Die Benutzeroberfläche ist auf Englisch, Deutsch, Französisch und Italienisch verfügbar. Du kannst Stellenanzeigen auch nach der Sprache filtern, in der sie verfasst wurden."
 
 #. Body text on the 404 page
 #. js-lingui-explicit-id
-#: app/[lang]/not-found.tsx:17
+#: app/[lang]/not-found-content.tsx:17
 msgid "notFound.body"
 msgstr "Die Seite, die du suchst, existiert nicht oder wurde verschoben."
 
 #. Provided as-is
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:60
 #: src/components/TermsContent.tsx:46
 msgid "terms.short.r4"
 msgstr "Der Service wird ohne Gewährleistung bereitgestellt."
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:55
 #: src/components/TermsContent.tsx:40
 msgid "terms.short.title"
 msgstr "Die Kurzfassung"
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:55
 #: src/components/PrivacyPolicyContent.tsx:40
 msgid "privacy.short.title"
 msgstr "Die Kurzfassung"
@@ -4042,27 +3968,24 @@ msgstr "Heute"
 
 #. Main heading on the landing page — leads with company-watchlist ICP
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:71
 #: src/components/Hero.tsx:28
 msgid "home.hero.title"
 msgstr "Verfolge die Unternehmen, bei denen du wirklich arbeiten willst."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:21
-#: app/[lang]/(public)/page.tsx:46
+#: app/[lang]/(public)/page.tsx:20
+#: app/[lang]/(public)/page.tsx:52
 msgid "home.meta.title"
 msgstr "Verfolge die Unternehmen, bei denen du arbeiten willst — Job Seek"
 
 #. Feature section 2 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:83
 #: src/components/Features.tsx:229
 msgid "home.features.s2.eyebrow"
-msgstr "Behalte die Kontrolle"
+msgstr "Verfolge deine Pipeline"
 
 #. Open-source section body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:77
 #: src/components/HowWeIndexContent.tsx:188
 msgid "indexing.oss.body"
 msgstr "Transparenz ist uns wichtig, daher ist der Code für unseren Job-Link-Erfassungsdienst und die Extraktionspipeline Open Source."
@@ -4070,7 +3993,6 @@ msgstr "Transparenz ist uns wichtig, daher ist der Code für unseren Job-Link-Er
 #. About transparency section heading
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:50
-#: app/[lang]/(public)/about/page.tsx:55
 msgid "about.transparency.title"
 msgstr "Standardmässig transparent"
 
@@ -4100,7 +4022,6 @@ msgstr "In aktiver Entwicklung"
 
 #. Your rights intro
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:64
 #: src/components/PrivacyPolicyContent.tsx:57
 msgid "privacy.rights.intro"
 msgstr "Nach DSGVO kannst du eine Kopie deiner Daten anfordern, sie korrigieren oder löschen lassen, sie exportieren oder der Verarbeitung widersprechen. Löschst du dein Konto, werden alle Daten innerhalb von 30 Tagen gelöscht."
@@ -4109,17 +4030,16 @@ msgstr "Nach DSGVO kannst du eine Kopie deiner Daten anfordern, sie korrigieren 
 #. js-lingui-explicit-id
 #: src/components/Pricing.tsx:81
 msgid "home.pricing.pro.f1"
-msgstr "Unbegrenzte Unternehmensabonnements"
+msgstr "Unbegrenzte Watchlists"
 
 #. Pro tier description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:77
 msgid "home.pricing.pro.description"
-msgstr "Für aktive Jobsuchende, die unbegrenzte Reichweite und schnellere Einblicke brauchen."
+msgstr "Unbegrenzte Watchlists mit E-Mail-Benachrichtigungen, damit du keine Stelle verpasst."
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:95
+#: app/[lang]/layout.tsx:129
 msgid "app.schema.offer.pro"
 msgstr "Unbegrenzte Watchlists, E-Mail-Benachrichtigungen bei neuen Treffern"
 
@@ -4178,7 +4098,7 @@ msgid "settings.billing.upgrading"
 msgstr "Upgrade l\\u00e4uft\\u2026"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:55
+#: app/[lang]/(public)/faq/page.tsx:61
 msgid "faq.a.requestCompany"
 msgstr "Nutze das Anfrageformular auf der Entdecken-Seite — füge eine Karriereseiten-URL oder einen Firmennamen ein und wir beginnen mit der Indexierung. Du kannst den Fortschritt über die Issue-Nummer verfolgen, die wir zurückgeben."
 
@@ -4286,19 +4206,17 @@ msgstr "Watchlists"
 
 #. Feature: watchlists and alerts title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:80
 #: src/components/Features.tsx:190
 msgid "home.features.s1.p3.title"
-msgstr "Gespeicherte Suchen"
+msgstr "Watchlists und Benachrichtigungen"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:102
+#: app/[lang]/layout.tsx:136
 msgid "app.schema.feature.watchlists"
 msgstr "Watchlists und Bewerbungstracking"
 
 #. What the service does
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:58
 #: src/components/TermsContent.tsx:44
 msgid "terms.short.r2"
 msgstr "Wir aggregieren öffentliche Stellenanzeigen. Wir garantieren nicht, dass sie korrekt oder aktuell sind."
@@ -4306,32 +4224,28 @@ msgstr "Wir aggregieren öffentliche Stellenanzeigen. Wir garantieren nicht, das
 #. About paragraph 3: philosophy
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:43
-#: app/[lang]/(public)/about/page.tsx:54
 msgid "about.p3"
 msgstr "Wir glauben, dass die Jobsuche von der suchenden Person gesteuert werden sollte, nicht von einem Algorithmus. Das bedeutet: keine Auto-Apply-Bots, keine auf Engagement optimierten Feeds und kein Verkauf deiner Daten. Du wählst die Unternehmen, du definierst die Filter, du verfolgst deine eigene Pipeline. Das Tool hält sich im Hintergrund."
 
 #. Privacy policy page description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:54
 #: src/components/PrivacyPolicyContent.tsx:23
 msgid "privacy.hero.description"
 msgstr "Wir erheben nur, was wir brauchen, wir verkaufen deine Daten nicht, und du kannst jederzeit alles löschen."
 
 #. No selling
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:58
 #: src/components/PrivacyPolicyContent.tsx:44
 msgid "privacy.short.r2"
 msgstr "Wir verkaufen, vermieten oder teilen deine Daten nicht für Marketingzwecke."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:51
+#: app/[lang]/(public)/faq/page.tsx:57
 msgid "faq.a.differentiation"
 msgstr "Wir indexieren Karriereseiten von Unternehmen direkt, nicht Drittanbieter-Feeds. Kein Recruiter-Spam, keine wiederveröffentlichten Ghost-Jobs, und wir prüfen Unternehmen häufig erneut — die meisten Stellen erscheinen hier also innerhalb weniger Stunden nach Veröffentlichung. Wir sind für Nutzer gemacht, die schon wissen, bei welchen Unternehmen sie arbeiten möchten, nicht für allgemeine Suchen nach irgendeinem Job."
 
 #. Step 1 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:64
 #: src/components/HowWeIndexContent.tsx:115
 msgid "indexing.ingestion.s1.body"
 msgstr "Wir suchen nach einer Sitemap, die bereits alle Karriere- oder Stellendetailseiten auflistet — idealerweise von <0>robots.txt</0> verlinkt — und verlassen uns darauf, wann immer möglich."
@@ -4344,7 +4258,6 @@ msgstr "Wir suchen zuerst nach strukturierten Feeds, bevor wir rohes HTML scrape
 
 #. Feature: direct from source description — no platform names, leads with the ICP differentiator
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:78
 #: src/components/Features.tsx:181
 msgid "home.features.s1.p1.description"
 msgstr "Wir überwachen Karriereseiten direkt, nicht Drittanbieter-Feeds — sodass Stellen hier innerhalb weniger Stunden auftauchen, typischerweise bevor LinkedIn oder Indeed sie übernehmen."
@@ -4363,13 +4276,12 @@ msgstr "Wir haben festgestellt, dass diese Stelle kürzlich hinzugefügt wurde. 
 
 #. Automation stance body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:74
 #: src/components/HowWeIndexContent.tsx:177
 msgid "indexing.automation.body"
 msgstr "Wir lehnen es ab, Einstellungs- oder Jobsuch-Entscheidungen an undurchsichtige Automatisierung zu übergeben — ob auf Arbeitgeber- oder Bewerberseite. Jeder ausgehende Link enthält <0>utm_source=jobseek</0>, damit Recruiter den Traffic erkennen, und wir überprüfen kontinuierlich Nutzungsmuster und setzen Hürden ein, um automatisierte Bewerbungen zu verhindern."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:71
+#: app/[lang]/(public)/faq/page.tsx:77
 msgid "faq.a.crawlingPolicy"
 msgstr "Wir respektieren robots.txt und TDM-Reservation-Header, beschränken Anfragen auf eine pro Seite pro Minute und verwenden exponentielles Backoff. Alle Anfragen identifizieren sich über den User-Agent. Weitere Details findest du auf unserer Indexierungsseite."
 
@@ -4381,7 +4293,6 @@ msgstr "Wir haben einen Bestätigungslink an <0>{email}</0> gesendet. Klicke auf
 
 #. What we store
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:57
 #: src/components/PrivacyPolicyContent.tsx:43
 msgid "privacy.short.r1"
 msgstr "Wir speichern deinen Namen, deine E-Mail und dein Profilbild von deiner OAuth-Anmeldung sowie die Daten, die du in der App erstellst."
@@ -4394,7 +4305,6 @@ msgstr "Wir empfehlen ausdrücklich, eine leicht auffindbare Sitemap für deinen
 
 #. Third parties
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:59
 #: src/components/PrivacyPolicyContent.tsx:45
 msgid "privacy.short.r3"
 msgstr "Wir nutzen eine Handvoll Drittanbieter für Anmeldung, Hosting und Speicherung — sonst nichts."
@@ -4424,22 +4334,22 @@ msgid "auth.signIn.subtitle"
 msgstr "Willkommen zurück"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:62
+#: app/[lang]/(public)/faq/page.tsx:68
 msgid "faq.q.whatIsWatchlist"
 msgstr "Was ist eine Watchlist?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:38
+#: app/[lang]/(public)/faq/page.tsx:44
 msgid "faq.q.whatIsJobseek"
 msgstr "Was ist Job Seek?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:50
+#: app/[lang]/(public)/faq/page.tsx:56
 msgid "faq.q.differentiation"
 msgstr "Was unterscheidet Job Seek von LinkedIn oder Indeed?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:58
+#: app/[lang]/(public)/faq/page.tsx:64
 msgid "faq.q.freeVsPro"
 msgstr "Was ist der Unterschied zwischen Kostenlos und Pro?"
 
@@ -4450,7 +4360,7 @@ msgid "app.home.request.heading"
 msgstr "Welches Unternehmen sollen wir verfolgen?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:86
+#: app/[lang]/(public)/faq/page.tsx:92
 msgid "faq.q.languages"
 msgstr "Welche Sprachen unterstützt Jobseek?"
 
@@ -4477,17 +4387,17 @@ msgid "search.experienceModal.years"
 msgstr "Jahre"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:43
+#: app/[lang]/(public)/faq/page.tsx:49
 msgid "faq.a.targetedSeeker"
 msgstr "Ja — genau dafür haben wir Job Seek entwickelt. Füge die Unternehmen, die dich interessieren, zu einer Watchlist hinzu, setze deine Filter (Rolle, Standort, Seniorität, Gehalt), und Job Seek überwacht ihre Karriereseiten und benachrichtigt dich, sobald neue passende Stellen erscheinen. Du musst nicht jede Unternehmenswebsite manuell prüfen oder gegen den LinkedIn-Algorithmus kämpfen."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:75
+#: app/[lang]/(public)/faq/page.tsx:81
 msgid "faq.a.optOut"
 msgstr "Ja. Schreib uns eine E-Mail und wir stellen das Crawlen deiner Karriereseite sofort ein und entfernen deine Stellenanzeigen aus dem Index."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:79
+#: app/[lang]/(public)/faq/page.tsx:85
 msgid "faq.a.openSource"
 msgstr "Ja. Der Crawler und die Extraktions-Pipeline sind vollständig Open Source auf GitHub. Der Anwendungscode ist MIT-lizenziert; die Stellendaten sind CC BY-NC 4.0."
 
@@ -4499,7 +4409,6 @@ msgstr "Gestern"
 
 #. Account deletion
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:61
 #: src/components/TermsContent.tsx:47
 msgid "terms.short.r5"
 msgstr "Du kannst dein Konto jederzeit löschen."
@@ -4518,7 +4427,6 @@ msgstr "Du kannst das beschleunigen, indem du deinen KI-Agenten bittest, es übe
 
 #. MIT license summary
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:56
 #: src/components/LicenseContent.tsx:53
 msgid "license.code.summary"
 msgstr "Du kannst den Code in persönlichen oder kommerziellen Produkten verwenden, ändern und weiterverbreiten, solange du den Copyright- und Lizenzhinweis beifügst."
@@ -4531,14 +4439,12 @@ msgstr "Das könnte Sie auch interessieren"
 
 #. CC license summary
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:58
 #: src/components/LicenseContent.tsx:74
 msgid "license.data.summary"
 msgstr "Du darfst den Stellendatensatz mit Quellenangabe für nicht-kommerzielle Zwecke nutzen. Kommerzielle Nutzung erfordert vorherige schriftliche Zustimmung."
 
 #. Age requirement
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:57
 #: src/components/TermsContent.tsx:43
 msgid "terms.short.r1"
 msgstr "Du musst mindestens 16 Jahre alt sein, um Job Seek zu nutzen."
@@ -4575,7 +4481,6 @@ msgstr "Du hast dein Watchlist-Limit erreicht. Upgrade deinen Plan, um weitere W
 
 #. Feature section 3 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:92
 #: src/components/Features.tsx:290
 msgid "home.features.s3.eyebrow"
 msgstr "Deine Unternehmen, deine Regeln"
@@ -4594,7 +4499,6 @@ msgstr "Dein Passwort wurde zurückgesetzt. Du kannst dich jetzt mit deinem neue
 
 #. Your rights section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:63
 #: src/components/PrivacyPolicyContent.tsx:54
 msgid "privacy.rights.title"
 msgstr "Deine Rechte"

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -39,8 +39,8 @@ msgstr "“Viktor Shcherbakov, Collection of Job Postings” with a link to the 
 #. Screen reader text for external links
 #. Screen reader text for external links
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:36
-#: src/components/Footer.tsx:42
+#: src/components/Footer.tsx:41
+#: src/components/Footer.tsx:47
 #: src/components/HowWeIndexContent.tsx:196
 #: src/components/LicenseContent.tsx:64
 #: src/components/LicenseContent.tsx:89
@@ -58,7 +58,7 @@ msgid "search.detail.showMoreLocations"
 msgstr "{0} more"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:32
+#: app/[lang]/(app)/company/[slug]/page.tsx:39
 msgid "company.meta.positionCount"
 msgstr "{count, plural, one {# open position} other {# open positions}}"
 
@@ -87,7 +87,7 @@ msgid "blog.mention.watchlist.companiesLabel"
 msgstr "{count, plural, one {company} other {companies}}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:98
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:103
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {Tracking # company} other {Tracking # companies}}. {description}"
 
@@ -98,23 +98,23 @@ msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} applications on {date}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:56
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:61
 msgid "watchlist.meta.moreCompanies"
 msgstr "{count} more"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:44
+#: app/[lang]/(app)/company/[slug]/page.tsx:51
 msgid "company.meta.descriptionBasic"
 msgstr "{countText} at {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:39
+#: app/[lang]/(app)/company/[slug]/page.tsx:46
 msgid "company.meta.descriptionWithInfo"
 msgstr "{countText} at {name}. {description}"
 
 #. Reading-time label shown in the blog post byline. {minutes} is the integer minute count.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:136
+#: app/[lang]/(public)/blog/[slug]/page.tsx:150
 msgid "blog.post.readingTime"
 msgstr "{minutes, plural, one {# min read} other {# min read}}"
 
@@ -167,13 +167,13 @@ msgid "app.home.request.agent.run_heading"
 msgstr "2. Run the prompt"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:63
+#: app/[lang]/(public)/faq/page.tsx:69
 msgid "faq.a.whatIsWatchlist"
 msgstr "A watchlist is a saved search with optional company filtering. Pick the companies you care about, set your filters (role, location, seniority, salary), and get a live feed of matching jobs. You can share watchlists publicly or keep them private."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/about/page.tsx:18
-#: app/[lang]/(public)/about/page.tsx:40
+#: app/[lang]/(public)/about/page.tsx:17
+#: app/[lang]/(public)/about/page.tsx:46
 msgid "about.meta.title"
 msgstr "About"
 
@@ -287,7 +287,6 @@ msgstr "Agent prompt"
 
 #. Encryption
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:61
 #: src/components/PrivacyPolicyContent.tsx:47
 msgid "privacy.short.r5"
 msgstr "All data is encrypted in transit and at rest."
@@ -335,7 +334,7 @@ msgid "settings.account.username.taken"
 msgstr "Already taken"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:19
+#: app/[lang]/(public)/faq/page.tsx:18
 msgid "faq.meta.description"
 msgstr "Answers to common questions about Job Seek — how we crawl career pages, what the free and Pro plans include, how we handle your data, and how to opt out."
 
@@ -353,7 +352,6 @@ msgstr "Any company"
 
 #. MIT license section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:55
 #: src/components/LicenseContent.tsx:50
 msgid "license.code.title"
 msgstr "Application code (MIT License)"
@@ -364,17 +362,16 @@ msgstr "Application code (MIT License)"
 msgid "license.toc.code"
 msgstr "Application code (MIT)"
 
-#. Feature: application stats title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:89
-#: src/components/Features.tsx:251
-msgid "home.features.s2.p3.title"
-msgstr "Application stats"
-
 #. Link to application stats page
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:263
 msgid "myJobs.viewStats"
+msgstr "Application stats"
+
+#. Feature: application stats title
+#. js-lingui-explicit-id
+#: src/components/Features.tsx:251
+msgid "home.features.s2.p3.title"
 msgstr "Application stats"
 
 #. Stats page title
@@ -457,7 +454,6 @@ msgstr "Apr"
 
 #. Step 3 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:66
 #: src/components/HowWeIndexContent.tsx:131
 msgid "indexing.ingestion.s3.body"
 msgstr "As a last resort we parse the careers pages themselves, preferring newest-first sorts and stopping once previously indexed roles reappear instead of crawling every page."
@@ -486,16 +482,16 @@ msgstr "Aug"
 msgid "settings.account.username.available"
 msgstr "Available"
 
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Back to sign in"
-
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Back to sign in"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Back to sign in"
 
 #. Link back to sign-in from forgot password
@@ -522,22 +518,22 @@ msgstr "Back to top"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Behavioral"
 
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:145
+msgid "blog.post.backToIndex"
+msgstr "Blog"
+
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:24
+#: app/[lang]/(public)/blog/page.tsx:27
 msgid "blog.meta.title"
 msgstr "Blog"
 
 #. <h1> on the blog index page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:69
+#: app/[lang]/(public)/blog/page.tsx:78
 msgid "blog.index.heading"
-msgstr "Blog"
-
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:131
-msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -550,7 +546,7 @@ msgstr "Blog"
 
 #. Footer link to /blog index page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:47
+#: src/components/Footer.tsx:52
 msgid "common.footer.blog"
 msgstr "Blog"
 
@@ -567,14 +563,13 @@ msgid "indexing.oss.browseRepo"
 msgstr "Browse the repository at"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:22
-#: app/[lang]/(public)/page.tsx:47
+#: app/[lang]/(public)/page.tsx:21
+#: app/[lang]/(public)/page.tsx:53
 msgid "home.meta.description"
 msgstr "Build watchlists of the companies you care about, get email alerts when new roles open up, and track applications in one place. Postings come direct from company career pages, within hours of going live — no recruiter spam, no reposted listings."
 
 #. Hero description paragraph — watchlist + alerts pitch with direct sourcing as supporting claim
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:72
 #: src/components/Hero.tsx:31
 msgid "home.hero.description"
 msgstr "Build watchlists of the companies you care about, get email alerts when new roles open up, and track every application in one place. We monitor career pages directly — postings show up within hours, before LinkedIn or Indeed cross-post them."
@@ -582,19 +577,17 @@ msgstr "Build watchlists of the companies you care about, get email alerts when 
 #. About page heading
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:25
-#: app/[lang]/(public)/about/page.tsx:51
 msgid "about.title"
 msgstr "Built by job seekers, for job seekers"
 
 #. Terms page description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:54
 #: src/components/TermsContent.tsx:23
 msgid "terms.hero.description"
 msgstr "By using Job Seek you agree to these terms. Here’s a plain-language overview."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:74
+#: app/[lang]/(public)/faq/page.tsx:80
 msgid "faq.q.optOut"
 msgstr "Can I opt out of Jobseek indexing my company?"
 
@@ -646,16 +639,16 @@ msgstr "Change your password via a secure email link."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Change..."
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "Check your email"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
+msgstr "Check your email"
+
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
 msgstr "Check your email"
 
 #. Checking username availability
@@ -684,7 +677,6 @@ msgstr "Choose the plan that works for you."
 
 #. Pricing section heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:102
 #: src/components/Pricing.tsx:103
 msgid "home.pricing.title"
 msgstr "Choose the right plan for you"
@@ -743,7 +735,6 @@ msgstr "Click to rename"
 
 #. Step 2 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:65
 #: src/components/HowWeIndexContent.tsx:121
 msgid "indexing.ingestion.s2.title"
 msgstr "Client APIs second."
@@ -774,21 +765,18 @@ msgstr "Coding"
 
 #. CC license section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:57
 #: src/components/LicenseContent.tsx:71
 msgid "license.data.title"
 msgstr "Collection of job postings (CC BY-NC 4.0)"
 
 #. Feature: multi-dimensional filters description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:79
 #: src/components/Features.tsx:186
 msgid "home.features.s1.p2.description"
 msgstr "Combine seniority, technologies, salary, location, and job language in a single query. No more sifting through noise."
 
 #. Feature: focused search description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:96
 #: src/components/Features.tsx:303
 msgid "home.features.s3.p1.description"
 msgstr "Combine specific companies with role filters to zero in on exactly the positions you want."
@@ -837,17 +825,17 @@ msgstr "Company"
 
 #. Heading shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:74
+#: app/[lang]/(app)/company/[slug]/page.tsx:87
 msgid "company.notFound.title"
 msgstr "Company not found"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:77
+#: app/[lang]/layout.tsx:111
 msgid "app.schema.description"
 msgstr "Company-tracking tool for job seekers who already know which companies they want to work at. Build watchlists, get email alerts when new roles open up, and track applications in one place — postings sourced directly from company career pages."
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:43
+#: app/[lang]/layout.tsx:76
 msgid "app.schema.org.description"
 msgstr "Company-tracking tool for targeted job seekers — watchlists, email alerts, and postings sourced directly from company career pages. Built by Colophon Group, a small developer studio in Switzerland."
 
@@ -875,16 +863,9 @@ msgstr "Connect"
 msgid "settings.account.socials.title"
 msgstr "Connected accounts"
 
-#. Contact section title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:59
-#: src/components/LicenseContent.tsx:96
-msgid "license.contact.title"
-msgstr "Contact"
-
 #. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:41
+#: src/components/Footer.tsx:46
 msgid "common.footer.contact"
 msgstr "Contact"
 
@@ -892,6 +873,12 @@ msgstr "Contact"
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:25
 msgid "license.toc.contact"
+msgstr "Contact"
+
+#. Contact section title
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:96
+msgid "license.contact.title"
 msgstr "Contact"
 
 #. Table of contents heading
@@ -938,7 +925,6 @@ msgstr "Contract"
 
 #. Cookies
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:60
 #: src/components/PrivacyPolicyContent.tsx:46
 msgid "privacy.short.r4"
 msgstr "Cookies are session-only — no ads, no tracking."
@@ -987,17 +973,16 @@ msgstr "Country"
 msgid "about.link.crawler"
 msgstr "Crawler source code"
 
-#. Assurances section title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:55
-#: src/components/HowWeIndexContent.tsx:63
-msgid "indexing.assurances.title"
-msgstr "Crawling assurances"
-
 #. TOC: Crawling assurances
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:28
 msgid "indexing.toc.assurances"
+msgstr "Crawling assurances"
+
+#. Assurances section title
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:63
+msgid "indexing.assurances.title"
 msgstr "Crawling assurances"
 
 #. Label on the create watchlist card
@@ -1038,7 +1023,6 @@ msgstr "Creating account..."
 
 #. Feature section 3 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:93
 #: src/components/Features.tsx:293
 msgid "home.features.s3.title"
 msgstr "Curate a watchlist for any niche"
@@ -1075,13 +1059,13 @@ msgstr "Dark"
 
 #. Meta description (under 160 chars) for the blog index page — covers data analyses + report breakdowns + news commentary
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:29
+#: app/[lang]/(public)/blog/page.tsx:32
 msgid "blog.meta.description"
 msgstr "Data analyses, news, and breakdowns of industry reports — drawn from the postings we monitor across thousands of company career pages."
 
 #. One-line tagline under the blog index <h1> — covers data analyses + reports/papers + news
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:74
+#: app/[lang]/(public)/blog/page.tsx:83
 msgid "blog.index.tagline"
 msgstr "Data analyses, news, and breakdowns of industry reports and papers — drawn from the postings we monitor."
 
@@ -1165,7 +1149,6 @@ msgstr "Did not find the company you were looking for?"
 
 #. Feature: direct from source title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:78
 #: src/components/Features.tsx:180
 msgid "home.features.s1.p1.title"
 msgstr "Direct from the source"
@@ -1189,7 +1172,7 @@ msgid "watchlists.explore.publicTitle"
 msgstr "Discover public watchlists"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:82
+#: app/[lang]/(public)/faq/page.tsx:88
 msgid "faq.q.dataPrivacy"
 msgstr "Does Jobseek sell my data?"
 
@@ -1201,7 +1184,6 @@ msgstr "Don't have an account? <0>Sign up</0>"
 
 #. No scraping
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:59
 #: src/components/TermsContent.tsx:45
 msgid "terms.short.r3"
 msgstr "Don’t scrape the service, submit automated applications, or abuse the platform."
@@ -1288,21 +1270,18 @@ msgstr "Enter your new password below."
 
 #. Assurance 3 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:59
 #: src/components/HowWeIndexContent.tsx:80
 msgid "indexing.assurances.i3.body"
 msgstr "Even after discovery we retrieve job detail pages at a strict limit of one request per site per minute."
 
 #. Feature section 1 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:75
 #: src/components/Features.tsx:171
 msgid "home.features.s1.title"
 msgstr "Every filter a job seeker actually needs"
 
 #. Assurance 1 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:57
 #: src/components/HowWeIndexContent.tsx:68
 msgid "indexing.assurances.i1.body"
 msgstr "Every retry window uses exponential backoff so we never hammer an origin, and we bail if a host keeps timing out."
@@ -1322,7 +1301,7 @@ msgstr "Everything in Free"
 #. FAQ page description
 #. js-lingui-explicit-id
 #. placeholder {0}: siteConfig.indexing.contactEmail
-#: app/[lang]/(public)/faq/faq-content.tsx:45
+#: app/[lang]/(public)/faq/faq-content.tsx:42
 msgid "faq.description"
 msgstr "Everything you need to know about Job Seek. Can't find what you're looking for? Email us at <0>{0}</0>."
 
@@ -1412,7 +1391,7 @@ msgid "settings.account.username.error"
 msgstr "Failed to update username"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:18
+#: app/[lang]/(public)/faq/page.tsx:17
 msgid "faq.meta.title"
 msgstr "FAQ"
 
@@ -1492,7 +1471,6 @@ msgstr "Find more"
 
 #. Feature: focused search title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:96
 #: src/components/Features.tsx:302
 msgid "home.features.s3.p1.title"
 msgstr "Focused search"
@@ -1505,7 +1483,7 @@ msgstr "Follow us on LinkedIn"
 
 #. Aria label for footer navigation
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:31
+#: src/components/Footer.tsx:36
 msgid "common.footer.ariaLabel"
 msgstr "Footer"
 
@@ -1547,7 +1525,6 @@ msgstr "Founded {year}"
 
 #. Free tier name
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:104
 #: src/components/Pricing.tsx:32
 msgid "home.pricing.free.name"
 msgstr "Free"
@@ -1559,14 +1536,13 @@ msgid "settings.billing.plan.free"
 msgstr "Free"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:59
+#: app/[lang]/(public)/faq/page.tsx:65
 msgid "faq.a.freeVsPro"
 msgstr "Free gives you full search across all companies, one watchlist, and the application tracker with interview logging. Pro adds unlimited watchlists and email alerts when new roles match your criteria."
 
 #. FAQ page heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/faq-content.tsx:42
-#: app/[lang]/(public)/faq/page.tsx:109
+#: app/[lang]/(public)/faq/faq-content.tsx:39
 msgid "faq.title"
 msgstr "Frequently asked questions"
 
@@ -1578,7 +1554,6 @@ msgstr "Fri"
 
 #. Feature section 2 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:84
 #: src/components/Features.tsx:232
 msgid "home.features.s2.title"
 msgstr "From saved role to signed offer, all in one place"
@@ -1590,13 +1565,12 @@ msgid "settings.billing.free.f2"
 msgstr "Full job search"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:87
+#: app/[lang]/layout.tsx:121
 msgid "app.schema.offer.free"
 msgstr "Full search, 1 watchlist, application tracker"
 
 #. Free tier description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:104
 #: src/components/Pricing.tsx:41
 msgid "home.pricing.free.description"
 msgstr "Full search, one watchlist, and a built-in application tracker to manage your pipeline."
@@ -1637,13 +1611,13 @@ msgstr "Get started with Job Seek"
 
 #. Footer link to GitHub repo
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:35
+#: src/components/Footer.tsx:40
 msgid "common.footer.github"
 msgstr "GitHub"
 
 #. Link to return to the homepage from a 404 page
 #. js-lingui-explicit-id
-#: app/[lang]/not-found.tsx:22
+#: app/[lang]/not-found-content.tsx:22
 msgid "notFound.goHome"
 msgstr "Go home"
 
@@ -1661,7 +1635,6 @@ msgstr "Got it"
 
 #. Step 3 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:66
 #: src/components/HowWeIndexContent.tsx:129
 msgid "indexing.ingestion.s3.title"
 msgstr "Graceful page parsing."
@@ -1697,32 +1670,25 @@ msgid "myJobs.salary.hourly"
 msgstr "Hourly"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:54
+#: app/[lang]/(public)/faq/page.tsx:60
 msgid "faq.q.requestCompany"
 msgstr "How do I request a company that isn't listed?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:70
+#: app/[lang]/(public)/faq/page.tsx:76
 msgid "faq.q.crawlingPolicy"
 msgstr "How does the crawler behave on my company's website?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:19
-#: app/[lang]/(public)/how-we-index/page.tsx:45
+#: app/[lang]/(public)/how-we-index/page.tsx:18
+#: app/[lang]/(public)/how-we-index/page.tsx:50
 msgid "indexing.meta.description"
 msgstr "How Job Seek discovers and indexes job postings: our sourcing approach, crawl frequency, rate limits, robots.txt and TDM-Reservation compliance, and how to opt out."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:46
+#: app/[lang]/(public)/faq/page.tsx:52
 msgid "faq.q.howOftenUpdated"
 msgstr "How often are job listings updated?"
-
-#. Ingestion section title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:62
-#: src/components/HowWeIndexContent.tsx:104
-msgid "indexing.ingestion.title"
-msgstr "How postings enter the index"
 
 #. TOC: How postings enter the index
 #. js-lingui-explicit-id
@@ -1730,16 +1696,21 @@ msgstr "How postings enter the index"
 msgid "indexing.toc.ingestion"
 msgstr "How postings enter the index"
 
+#. Ingestion section title
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:104
+msgid "indexing.ingestion.title"
+msgstr "How postings enter the index"
+
 #. Indexing page title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:52
 #: src/components/HowWeIndexContent.tsx:48
 msgid "indexing.hero.title"
 msgstr "How we find and process job postings"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:18
-#: app/[lang]/(public)/how-we-index/page.tsx:44
+#: app/[lang]/(public)/how-we-index/page.tsx:17
+#: app/[lang]/(public)/how-we-index/page.tsx:49
 msgid "indexing.meta.title"
 msgstr "How We Index"
 
@@ -1751,14 +1722,12 @@ msgstr "If an account exists for that email, we sent a password reset link."
 
 #. Step 2 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:65
 #: src/components/HowWeIndexContent.tsx:123
 msgid "indexing.ingestion.s2.body"
 msgstr "If no sitemap exists we inspect the client application for JSON APIs it calls; when found we hit those endpoints directly to enumerate posting URLs without scraping the DOM."
 
 #. Opt-out section body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:71
 #: src/components/HowWeIndexContent.tsx:164
 msgid "indexing.optOut.body"
 msgstr "If you notice unexpected activity from our crawler or prefer that your careers site not be indexed, please email us and we will respond promptly."
@@ -1770,7 +1739,7 @@ msgid "indexing.outreach.body"
 msgstr "If you notice unusual crawler behaviour, prefer that we do not index your content, or have suggestions on how to improve our safeguards, please reach out."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:72
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:77
 msgid "watchlist.meta.inLocations"
 msgstr "in {locations}"
 
@@ -1841,7 +1810,6 @@ msgstr "Input is too short."
 #. About paragraph 2: how it works — leads with direct sourcing and watchlist ICP, no platform listing
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:38
-#: app/[lang]/(public)/about/page.tsx:53
 msgid "about.p2"
 msgstr "Instead of waiting for companies to push roles to third-party job boards, we go straight to the source. Our crawler monitors thousands of company career pages directly and re-checks them frequently, so roles show up here within hours of going live — typically before they reach the large aggregators. Build a watchlist of the companies you care about and get notified the moment they post."
 
@@ -1859,7 +1827,6 @@ msgstr "Interview"
 
 #. Feature: interview log title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:88
 #: src/components/Features.tsx:246
 msgid "home.features.s2.p2.title"
 msgstr "Interview log"
@@ -1907,17 +1874,17 @@ msgid "auth.verify.error.invalidLink"
 msgstr "Invalid verification link"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:42
+#: app/[lang]/(public)/faq/page.tsx:48
 msgid "faq.q.targetedSeeker"
 msgstr "Is Job Seek for me if I already know which companies I want to work for?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:78
+#: app/[lang]/(public)/faq/page.tsx:84
 msgid "faq.q.openSource"
 msgstr "Is the crawler open source?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:66
+#: app/[lang]/(public)/faq/page.tsx:72
 msgid "faq.q.trackerLimit"
 msgstr "Is there a limit to how many jobs I can track?"
 
@@ -1982,19 +1949,18 @@ msgid "home.features.s2.screenshot.alt"
 msgstr "Job Seek application tracker showing saved jobs and interview details"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:39
+#: app/[lang]/(public)/faq/page.tsx:45
 msgid "faq.a.whatIsJobseek"
 msgstr "Job Seek helps you track the companies you actually want to work at. Build a watchlist, get email alerts when new roles open up, and track applications in one place. Postings come straight from company career pages, so you see them within hours of going live — typically before LinkedIn or Indeed cross-post them."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/about/page.tsx:19
-#: app/[lang]/(public)/about/page.tsx:41
+#: app/[lang]/(public)/about/page.tsx:18
+#: app/[lang]/(public)/about/page.tsx:47
 msgid "about.meta.description"
 msgstr "Job Seek helps you track the companies you want to work at — watchlists, email alerts, and postings sourced directly from company career pages. Built by Colophon Group, a small developer studio in Switzerland."
 
 #. Indexing page description — company-tracking framing, not 'search engine'
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:53
 #: src/components/HowWeIndexContent.tsx:51
 msgid "indexing.hero.description"
 msgstr "Job Seek is a company-tracking tool — it monitors thousands of company career pages so users can build watchlists and get alerts on new postings. This page documents exactly how our crawler behaves, the controls that keep it polite, and how jobs ultimately land in the index."
@@ -2008,13 +1974,12 @@ msgstr "Job Seek is being actively built. Stay tuned for updates!"
 #. About paragraph 1: who we are
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:26
-#: app/[lang]/(public)/about/page.tsx:52
 msgid "about.p1"
 msgstr "Job Seek is built by Colophon Group, a small team of developers based in Switzerland. We started it because we were tired of the same problem every job seeker faces: juggling dozens of browser tabs, missing new postings because an aggregator was slow to pick them up, and drowning in algorithmic noise that optimizes for clicks rather than relevance."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:19
-#: app/[lang]/(public)/privacy-policy/page.tsx:45
+#: app/[lang]/(public)/privacy-policy/page.tsx:18
+#: app/[lang]/(public)/privacy-policy/page.tsx:51
 msgid "privacy.meta.description"
 msgstr "Job Seek privacy policy — what personal data we collect, how we use it, your GDPR rights, cookie policy, and how to request deletion of your account and data."
 
@@ -2032,13 +1997,12 @@ msgstr "Job Seek watchlist showing curated robotics engineering roles in Zurich"
 
 #. License page description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:54
 #: src/components/LicenseContent.tsx:38
 msgid "license.hero.description"
 msgstr "Job Seek's codebase is open source under MIT. The job data we collect and enrich is Creative Commons BY-NC 4.0. Below is the plain-language summary — please read the full licenses for exact terms."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:80
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:85
 msgid "watchlist.meta.fallback"
 msgstr "Job watchlist by @{owner}"
 
@@ -2055,12 +2019,12 @@ msgid "watchlists.explore.jobPlural"
 msgstr "jobs"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:25
+#: app/[lang]/(app)/company/[slug]/page.tsx:32
 msgid "company.meta.title"
 msgstr "Jobs at {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:62
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:67
 msgid "watchlist.meta.jobsAt"
 msgstr "Jobs at {names}"
 
@@ -2108,14 +2072,14 @@ msgstr "Last hour"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:28
-msgid "privacy.hero.lastUpdated"
+#: src/components/TermsContent.tsx:28
+msgid "terms.hero.lastUpdated"
 msgstr "Last updated:"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:28
-msgid "terms.hero.lastUpdated"
+#: src/components/PrivacyPolicyContent.tsx:28
+msgid "privacy.hero.lastUpdated"
 msgstr "Last updated:"
 
 #. Time range option: last week
@@ -2130,21 +2094,21 @@ msgstr "Last week"
 msgid "home.hero.secondaryCta"
 msgstr "Learn more"
 
-#. Label for seniority/level filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:154
-msgid "search.advanced.level"
-msgstr "Level"
-
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:638
 msgid "search.bar.level"
 msgstr "Level"
 
+#. Label for seniority/level filter in advanced search
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:18
-#: app/[lang]/(public)/license/page.tsx:45
+#: src/components/search/advanced-search-panel.tsx:154
+msgid "search.advanced.level"
+msgstr "Level"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/license/page.tsx:17
+#: app/[lang]/(public)/license/page.tsx:51
 msgid "license.meta.title"
 msgstr "License"
 
@@ -2156,13 +2120,12 @@ msgstr "License"
 
 #. Footer link to license page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
+#: src/components/Footer.tsx:57
 msgid "common.footer.licenseLink"
 msgstr "License"
 
 #. License page title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:53
 #: src/components/LicenseContent.tsx:37
 msgid "license.hero.title"
 msgstr "License of Job Seek"
@@ -2174,8 +2137,8 @@ msgid "license.hero.eyebrow"
 msgstr "Licensing"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:19
-#: app/[lang]/(public)/license/page.tsx:46
+#: app/[lang]/(public)/license/page.tsx:18
+#: app/[lang]/(public)/license/page.tsx:52
 msgid "license.meta.description"
 msgstr "Licensing for Job Seek — application source code is MIT-licensed, job posting data is CC BY-NC 4.0. Learn what you can and cannot do with our code and data."
 
@@ -2209,16 +2172,16 @@ msgstr "Location"
 msgid "search.advanced.location"
 msgstr "Location"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
-msgstr "Locations"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:708
 msgid "search.bar.locations"
+msgstr "Locations"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:312
+msgid "search.detail.locations"
 msgstr "Locations"
 
 #. Login button label
@@ -2243,7 +2206,6 @@ msgstr "Log in to save this search as a watchlist"
 
 #. Feature: share watchlists description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:98
 #: src/components/Features.tsx:313
 msgid "home.features.s3.p3.description"
 msgstr "Make a watchlist public and share the link with friends, communities, or your network."
@@ -2348,7 +2310,6 @@ msgstr "mirrors"
 
 #. Feature: request companies description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:97
 #: src/components/Features.tsx:308
 msgid "home.features.s3.p2.description"
 msgstr "Missing a company? Paste its careers page URL and we start indexing it for you."
@@ -2360,7 +2321,7 @@ msgid "myJobs.heatmap.day.mon"
 msgstr "Mon"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:99
+#: app/[lang]/layout.tsx:133
 msgid "app.schema.feature.monitor"
 msgstr "Monitor company career pages"
 
@@ -2384,20 +2345,18 @@ msgstr "more"
 
 #. Feature: status tracking description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:87
 #: src/components/Features.tsx:242
 msgid "home.features.s2.p1.description"
 msgstr "Move each role from saved to applied, interviewing, offered, or rejected. Always know where you stand."
 
 #. Feature: multi-dimensional filters title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:79
 #: src/components/Features.tsx:185
 msgid "home.features.s1.p2.title"
 msgstr "Multi-dimensional filters"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:101
+#: app/[lang]/layout.tsx:135
 msgid "app.schema.feature.languages"
 msgstr "Multi-language support"
 
@@ -2523,7 +2482,7 @@ msgstr "No matching postings found."
 
 #. Empty-state message shown when no blog posts have been published yet
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:79
+#: app/[lang]/(public)/blog/page.tsx:88
 msgid "blog.index.empty"
 msgstr "No posts yet — check back soon."
 
@@ -2582,12 +2541,12 @@ msgid "watchlists.page.empty"
 msgstr "No watchlists yet. Create one to track jobs from your favorite companies."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:67
+#: app/[lang]/(public)/faq/page.tsx:73
 msgid "faq.a.trackerLimit"
 msgstr "No. The application tracker has no hard limit — save as many jobs as you want and move them through your pipeline."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:83
+#: app/[lang]/(public)/faq/page.tsx:89
 msgid "faq.a.dataPrivacy"
 msgstr "No. We don't sell, rent, or share your data for marketing. Cookies are session-only with no ads or tracking. You can delete your account and all data is wiped within 30 days."
 
@@ -2665,14 +2624,12 @@ msgstr "Ok"
 
 #. Step 4 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:67
 #: src/components/HowWeIndexContent.tsx:139
 msgid "indexing.ingestion.s4.body"
 msgstr "Once we fetch an individual posting we store only the job-specific metadata (title, role description, location, compensation notes, posting URL, and timestamps) plus extracted structured fields. We do not archive unrelated site content."
 
 #. Assurance 3 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:59
 #: src/components/HowWeIndexContent.tsx:79
 msgid "indexing.assurances.i3.title"
 msgstr "One page per minute."
@@ -2696,16 +2653,9 @@ msgid "common.header.openMenu"
 msgstr "Open main menu"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:37
+#: app/[lang]/(app)/company/[slug]/page.tsx:44
 msgid "company.meta.openPositions"
 msgstr "Open positions"
-
-#. Open-source section title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:76
-#: src/components/HowWeIndexContent.tsx:185
-msgid "indexing.oss.title"
-msgstr "Open-source crawlers"
 
 #. TOC: Open-source crawlers
 #. js-lingui-explicit-id
@@ -2713,17 +2663,22 @@ msgstr "Open-source crawlers"
 msgid "indexing.toc.oss"
 msgstr "Open-source crawlers"
 
-#. Opt-out section title
+#. Open-source section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:70
-#: src/components/HowWeIndexContent.tsx:161
-msgid "indexing.optOut.title"
-msgstr "Opt-out or questions"
+#: src/components/HowWeIndexContent.tsx:185
+msgid "indexing.oss.title"
+msgstr "Open-source crawlers"
 
 #. TOC: Opt-out or questions
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:30
 msgid "indexing.toc.optOut"
+msgstr "Opt-out or questions"
+
+#. Opt-out section title
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:161
+msgid "indexing.optOut.title"
 msgstr "Opt-out or questions"
 
 #. Divider between form and OAuth buttons
@@ -2746,22 +2701,20 @@ msgstr "Other"
 
 #. Assurance 2 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:58
 #: src/components/HowWeIndexContent.tsx:73
 msgid "indexing.assurances.i2.body"
 msgstr "Our crawler reads <0>robots.txt</0>, honours disallow rules, identifies itself via <1>User-Agent</1>, and respects the W3C <2>TDM-Reservation</2> header—if a page signals reservation, we skip it."
-
-#. Automation stance title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:73
-#: src/components/HowWeIndexContent.tsx:174
-msgid "indexing.automation.title"
-msgstr "Our stance on automation"
 
 #. TOC: Our stance on automation
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:31
 msgid "indexing.toc.automation"
+msgstr "Our stance on automation"
+
+#. Automation stance title
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:174
+msgid "indexing.automation.title"
 msgstr "Our stance on automation"
 
 #. TOC: Overview
@@ -2790,7 +2743,7 @@ msgstr "Page contents"
 
 #. Heading shown on the 404 page
 #. js-lingui-explicit-id
-#: app/[lang]/not-found.tsx:12
+#: app/[lang]/not-found-content.tsx:12
 msgid "notFound.title"
 msgstr "Page not found"
 
@@ -2858,7 +2811,6 @@ msgstr "Pay period"
 
 #. Pro tier period
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:73
 msgid "home.pricing.pro.period"
 msgstr "per month"
@@ -2889,7 +2841,6 @@ msgstr "Phone Screen"
 
 #. Feature section 3 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:94
 #: src/components/Features.tsx:296
 msgid "home.features.s3.description"
 msgstr "Pick the companies you care about, set your filters, and get a live feed of matching roles. Share it publicly or keep it private."
@@ -2978,19 +2929,18 @@ msgstr "Posting not found."
 msgid "myJobs.detail.notFound"
 msgstr "Posting not found."
 
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:101
-#: src/components/Pricing.tsx:100
-msgid "home.pricing.eyebrow"
-msgstr "Pricing"
-
 #. Nav link: Pricing
 #. Nav link: Pricing
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:62
 #: src/components/MobileMenu.tsx:87
 msgid "common.nav.pricing"
+msgstr "Pricing"
+
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:100
+msgid "home.pricing.eyebrow"
 msgstr "Pricing"
 
 #. Privacy policy page eyebrow
@@ -3001,20 +2951,19 @@ msgstr "Privacy"
 
 #. Footer link to privacy policy page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:57
+#: src/components/Footer.tsx:62
 msgid "common.footer.privacyLink"
 msgstr "Privacy"
 
 #. Privacy policy page title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:53
 #: src/components/PrivacyPolicyContent.tsx:22
 msgid "privacy.hero.title"
 msgstr "Privacy at Job Seek"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:18
-#: app/[lang]/(public)/privacy-policy/page.tsx:44
+#: app/[lang]/(public)/privacy-policy/page.tsx:17
+#: app/[lang]/(public)/privacy-policy/page.tsx:50
 msgid "privacy.meta.title"
 msgstr "Privacy Policy"
 
@@ -3026,7 +2975,6 @@ msgstr "Private watchlists are a paid feature. Upgrade to hide your watchlists f
 
 #. Pro tier name
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:68
 msgid "home.pricing.pro.name"
 msgstr "Pro"
@@ -3045,21 +2993,18 @@ msgstr "Public Domain"
 
 #. Contact call to action
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:60
 #: src/components/LicenseContent.tsx:99
 msgid "license.contactCta"
 msgstr "Questions about licensing or commercial use? Email us."
 
 #. Terms contact call to action
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:63
 #: src/components/TermsContent.tsx:54
 msgid "terms.contact.description"
 msgstr "Questions? Email us."
 
 #. Privacy contact call to action
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:65
 #: src/components/PrivacyPolicyContent.tsx:66
 msgid "privacy.contact.description"
 msgstr "Questions? Email us."
@@ -3089,7 +3034,7 @@ msgid "terms.fullTermsLink"
 msgstr "Read the full Terms of Service"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:100
+#: app/[lang]/layout.tsx:134
 msgid "app.schema.feature.alerts"
 msgstr "Real-time job posting alerts"
 
@@ -3101,7 +3046,6 @@ msgstr "Recently updated"
 
 #. Feature: interview log description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:88
 #: src/components/Features.tsx:247
 msgid "home.features.s2.p2.description"
 msgstr "Record each interview round with date, type, and notes so nothing slips through the cracks."
@@ -3156,7 +3100,7 @@ msgstr "Rejected"
 
 #. Footer license summary text
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:24
+#: src/components/Footer.tsx:29
 msgid "common.footer.text"
 msgstr "Released under the MIT License. Job data is CC BY-NC 4.0."
 
@@ -3186,7 +3130,6 @@ msgstr "Request a company"
 
 #. Feature: request companies title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:97
 #: src/components/Features.tsx:307
 msgid "home.features.s3.p2.title"
 msgstr "Request any company"
@@ -3247,14 +3190,12 @@ msgstr "Resetting..."
 
 #. Assurance 1 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:57
 #: src/components/HowWeIndexContent.tsx:67
 msgid "indexing.assurances.i1.title"
 msgstr "Respectful pacing."
 
 #. Assurance 2 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:58
 #: src/components/HowWeIndexContent.tsx:71
 msgid "indexing.assurances.i2.title"
 msgstr "Robots, attribution, and TDM reservation."
@@ -3309,14 +3250,12 @@ msgstr "Salary range"
 
 #. Feature section 2 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:85
 #: src/components/Features.tsx:235
 msgid "home.features.s2.description"
 msgstr "Save any role you find, move it through your pipeline as you apply and interview, and see where every application stands at a glance."
 
 #. Feature: watchlists and alerts description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:80
 #: src/components/Features.tsx:191
 msgid "home.features.s1.p3.description"
 msgstr "Save any search as a watchlist and get email alerts when new roles match your criteria."
@@ -3395,7 +3334,6 @@ msgstr "Search across all companies and filters"
 
 #. Feature section 1 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:76
 #: src/components/Features.tsx:174
 msgid "home.features.s1.description"
 msgstr "Search across thousands of companies scraped directly from their career pages. Filter by seniority, tech stack, salary range, location, and language — all at once."
@@ -3468,7 +3406,6 @@ msgstr "Search watchlists..."
 
 #. Feature section 1 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:74
 #: src/components/Features.tsx:168
 msgid "home.features.s1.eyebrow"
 msgstr "Search with precision"
@@ -3481,7 +3418,6 @@ msgstr "Search..."
 
 #. Feature: application stats description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:89
 #: src/components/Features.tsx:252
 msgid "home.features.s2.p3.description"
 msgstr "See your funnel, conversion rates, and activity heatmap to understand what is working."
@@ -3518,7 +3454,6 @@ msgstr "Select your preferred language."
 
 #. Step 4 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:67
 #: src/components/HowWeIndexContent.tsx:137
 msgid "indexing.ingestion.s4.title"
 msgstr "Selective storage."
@@ -3535,16 +3470,16 @@ msgstr "Send reset link"
 msgid "settings.account.password.send"
 msgstr "Send reset link"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Sending..."
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
+msgstr "Sending..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
 msgstr "Sending..."
 
 #. Reset password button while loading
@@ -3597,7 +3532,6 @@ msgstr "Settings"
 
 #. Feature: share watchlists title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:98
 #: src/components/Features.tsx:312
 msgid "home.features.s3.p3.title"
 msgstr "Share with anyone"
@@ -3724,21 +3658,19 @@ msgstr "Similar companies"
 
 #. Pricing section description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:103
 #: src/components/Pricing.tsx:106
 msgid "home.pricing.description"
 msgstr "Simple, transparent pricing. Start for free and upgrade when you get serious about your job search."
 
 #. Step 1 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:64
 #: src/components/HowWeIndexContent.tsx:113
 msgid "indexing.ingestion.s1.title"
 msgstr "Sitemap first."
 
 #. Skip to main content link for keyboard users
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/layout.tsx:21
+#: app/[lang]/(public)/layout.tsx:25
 msgid "common.a11y.skipToContent"
 msgstr "Skip to content"
 
@@ -3816,7 +3748,6 @@ msgstr "Status"
 
 #. Feature: status tracking title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:87
 #: src/components/Features.tsx:241
 msgid "home.features.s2.p1.title"
 msgstr "Status tracking"
@@ -3859,7 +3790,7 @@ msgstr "Subscription"
 
 #. FAQ page eyebrow
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/faq-content.tsx:39
+#: app/[lang]/(public)/faq/faq-content.tsx:36
 msgid "faq.eyebrow"
 msgstr "Support"
 
@@ -3887,16 +3818,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technical"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Technologies"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:673
 msgid "search.bar.technologies"
+msgstr "Technologies"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:397
+msgid "search.detail.technologies"
 msgstr "Technologies"
 
 #. Add technology filter
@@ -3931,75 +3862,70 @@ msgstr "Terms"
 
 #. Footer link to terms of service page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:62
+#: src/components/Footer.tsx:67
 msgid "common.footer.termsLink"
 msgstr "Terms"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:18
-#: app/[lang]/(public)/terms/page.tsx:44
+#: app/[lang]/(public)/terms/page.tsx:17
+#: app/[lang]/(public)/terms/page.tsx:50
 msgid "terms.meta.title"
 msgstr "Terms of Service"
 
 #. Terms page title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:53
 #: src/components/TermsContent.tsx:22
 msgid "terms.hero.title"
 msgstr "Terms of Service"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:19
-#: app/[lang]/(public)/terms/page.tsx:45
+#: app/[lang]/(public)/terms/page.tsx:18
+#: app/[lang]/(public)/terms/page.tsx:51
 msgid "terms.meta.description"
 msgstr "Terms of Service for Job Seek — usage rules, intellectual property, account responsibilities, limitation of liability, and governing law for the job search platform."
 
 #. Body text shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:79
+#: app/[lang]/(app)/company/[slug]/page.tsx:92
 msgid "company.notFound.message"
 msgstr "The company you are looking for does not exist or has been removed."
 
 #. About transparency paragraph
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:54
-#: app/[lang]/(public)/about/page.tsx:56
 msgid "about.transparency.p1"
 msgstr "The crawler code is open source so anyone can audit how we collect data. We respect robots.txt, honor TDM-Reservation headers, and limit ourselves to one request per site per minute. Every outbound link includes utm_source=jobseek so employers know where their traffic comes from."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:47
+#: app/[lang]/(public)/faq/page.tsx:53
 msgid "faq.a.howOftenUpdated"
 msgstr "The crawler discovers new postings on an hourly cycle and refreshes job details daily. Most roles appear within hours of being published on a company's careers page."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:87
+#: app/[lang]/(public)/faq/page.tsx:93
 msgid "faq.a.languages"
 msgstr "The interface is available in English, German, French, and Italian. You can also filter job postings by the language they were written in."
 
 #. Body text on the 404 page
 #. js-lingui-explicit-id
-#: app/[lang]/not-found.tsx:17
+#: app/[lang]/not-found-content.tsx:17
 msgid "notFound.body"
 msgstr "The page you are looking for does not exist or has been moved."
 
 #. Provided as-is
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:60
 #: src/components/TermsContent.tsx:46
 msgid "terms.short.r4"
 msgstr "The service is provided as-is — no warranties."
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:55
 #: src/components/TermsContent.tsx:40
 msgid "terms.short.title"
 msgstr "The short version"
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:55
 #: src/components/PrivacyPolicyContent.tsx:40
 msgid "privacy.short.title"
 msgstr "The short version"
@@ -4042,27 +3968,24 @@ msgstr "Today"
 
 #. Main heading on the landing page — leads with company-watchlist ICP
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:71
 #: src/components/Hero.tsx:28
 msgid "home.hero.title"
 msgstr "Track the companies you actually want to work at."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:21
-#: app/[lang]/(public)/page.tsx:46
+#: app/[lang]/(public)/page.tsx:20
+#: app/[lang]/(public)/page.tsx:52
 msgid "home.meta.title"
 msgstr "Track the companies you want to work at — Job Seek"
 
 #. Feature section 2 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:83
 #: src/components/Features.tsx:229
 msgid "home.features.s2.eyebrow"
 msgstr "Track your pipeline"
 
 #. Open-source section body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:77
 #: src/components/HowWeIndexContent.tsx:188
 msgid "indexing.oss.body"
 msgstr "Transparency matters, so the code for our job link collection service and extraction pipeline is open source."
@@ -4070,7 +3993,6 @@ msgstr "Transparency matters, so the code for our job link collection service an
 #. About transparency section heading
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:50
-#: app/[lang]/(public)/about/page.tsx:55
 msgid "about.transparency.title"
 msgstr "Transparent by default"
 
@@ -4100,7 +4022,6 @@ msgstr "Under Active Development"
 
 #. Your rights intro
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:64
 #: src/components/PrivacyPolicyContent.tsx:57
 msgid "privacy.rights.intro"
 msgstr "Under GDPR you can ask for a copy of your data, have it corrected or deleted, export it, or object to processing. Delete your account and everything is wiped within 30 days."
@@ -4113,13 +4034,12 @@ msgstr "Unlimited watchlists"
 
 #. Pro tier description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:77
 msgid "home.pricing.pro.description"
 msgstr "Unlimited watchlists with email alerts so you never miss an opening."
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:95
+#: app/[lang]/layout.tsx:129
 msgid "app.schema.offer.pro"
 msgstr "Unlimited watchlists, email alerts on new matches"
 
@@ -4178,7 +4098,7 @@ msgid "settings.billing.upgrading"
 msgstr "Upgrading…"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:55
+#: app/[lang]/(public)/faq/page.tsx:61
 msgid "faq.a.requestCompany"
 msgstr "Use the request form on the explore page — paste a careers page URL or company name and we'll start indexing it. You can track progress via the issue number we return."
 
@@ -4286,19 +4206,17 @@ msgstr "Watchlists"
 
 #. Feature: watchlists and alerts title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:80
 #: src/components/Features.tsx:190
 msgid "home.features.s1.p3.title"
 msgstr "Watchlists and alerts"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:102
+#: app/[lang]/layout.tsx:136
 msgid "app.schema.feature.watchlists"
 msgstr "Watchlists and application tracking"
 
 #. What the service does
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:58
 #: src/components/TermsContent.tsx:44
 msgid "terms.short.r2"
 msgstr "We aggregate public job postings. We do not guarantee they are accurate or up to date."
@@ -4306,32 +4224,28 @@ msgstr "We aggregate public job postings. We do not guarantee they are accurate 
 #. About paragraph 3: philosophy
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:43
-#: app/[lang]/(public)/about/page.tsx:54
 msgid "about.p3"
 msgstr "We believe job search should be driven by the person searching, not by an algorithm. That means no auto-apply bots, no engagement-optimized feeds, and no selling your data. You choose the companies, you define the filters, you track your own pipeline. The tool stays out of the way."
 
 #. Privacy policy page description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:54
 #: src/components/PrivacyPolicyContent.tsx:23
 msgid "privacy.hero.description"
 msgstr "We collect only what we need, we don’t sell your data, and you can delete everything at any time."
 
 #. No selling
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:58
 #: src/components/PrivacyPolicyContent.tsx:44
 msgid "privacy.short.r2"
 msgstr "We don’t sell, rent, or share your data for marketing."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:51
+#: app/[lang]/(public)/faq/page.tsx:57
 msgid "faq.a.differentiation"
 msgstr "We index company career pages directly, not third-party feeds. No recruiter spam, no reposted ghost jobs, and we re-check companies frequently — so most roles show up here within hours of being published. We're built for users who already know which companies they want to work at, not broad 'find me any job' searches."
 
 #. Step 1 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:64
 #: src/components/HowWeIndexContent.tsx:115
 msgid "indexing.ingestion.s1.body"
 msgstr "We look for a sitemap that already lists every careers or job detail page—ideally linked from <0>robots.txt</0>—and rely on it whenever possible."
@@ -4344,7 +4258,6 @@ msgstr "We look for structured feeds before scraping raw HTML. First we check fo
 
 #. Feature: direct from source description — no platform names, leads with the ICP differentiator
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:78
 #: src/components/Features.tsx:181
 msgid "home.features.s1.p1.description"
 msgstr "We monitor company career pages directly, not third-party feeds — so postings show up here within hours, typically before LinkedIn or Indeed cross-post them."
@@ -4363,13 +4276,12 @@ msgstr "We noticed this job was recently added. Some details may still be proces
 
 #. Automation stance body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:74
 #: src/components/HowWeIndexContent.tsx:177
 msgid "indexing.automation.body"
 msgstr "We oppose handing hiring or job-search decisions over to black-box automation — whether on the employer or applicant side. Every outbound link we share includes <0>utm_source=jobseek</0> so recruiters recognise the traffic, and we continuously review usage patterns plus enforce friction to deter scripted applications."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:71
+#: app/[lang]/(public)/faq/page.tsx:77
 msgid "faq.a.crawlingPolicy"
 msgstr "We respect robots.txt and TDM-Reservation headers, limit requests to one per site per minute, and use exponential backoff. All requests identify themselves via User-Agent. See our Job Indexing page for full details."
 
@@ -4381,7 +4293,6 @@ msgstr "We sent a verification link to <0>{email}</0>. Click the link to verify 
 
 #. What we store
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:57
 #: src/components/PrivacyPolicyContent.tsx:43
 msgid "privacy.short.r1"
 msgstr "We store your name, email, and profile picture from your OAuth sign-in, plus the data you create while using the app."
@@ -4394,7 +4305,6 @@ msgstr "We strongly encourage publishing an easily discoverable sitemap for your
 
 #. Third parties
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:59
 #: src/components/PrivacyPolicyContent.tsx:45
 msgid "privacy.short.r3"
 msgstr "We use a handful of third-party services for sign-in, hosting, and storage — nothing else."
@@ -4424,22 +4334,22 @@ msgid "auth.signIn.subtitle"
 msgstr "Welcome back"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:62
+#: app/[lang]/(public)/faq/page.tsx:68
 msgid "faq.q.whatIsWatchlist"
 msgstr "What is a watchlist?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:38
+#: app/[lang]/(public)/faq/page.tsx:44
 msgid "faq.q.whatIsJobseek"
 msgstr "What is Job Seek?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:50
+#: app/[lang]/(public)/faq/page.tsx:56
 msgid "faq.q.differentiation"
 msgstr "What makes Job Seek different from LinkedIn or Indeed?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:58
+#: app/[lang]/(public)/faq/page.tsx:64
 msgid "faq.q.freeVsPro"
 msgstr "What's the difference between Free and Pro?"
 
@@ -4450,7 +4360,7 @@ msgid "app.home.request.heading"
 msgstr "Which company should we track?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:86
+#: app/[lang]/(public)/faq/page.tsx:92
 msgid "faq.q.languages"
 msgstr "Which languages does Jobseek support?"
 
@@ -4477,17 +4387,17 @@ msgid "search.experienceModal.years"
 msgstr "years"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:43
+#: app/[lang]/(public)/faq/page.tsx:49
 msgid "faq.a.targetedSeeker"
 msgstr "Yes — that's the use case we built around. Add the companies you care about to a watchlist, set your filters (role, location, seniority, salary), and Job Seek monitors their career pages and alerts you the moment new roles match. You don't have to keep checking each company's site by hand or fight LinkedIn's algorithm."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:75
+#: app/[lang]/(public)/faq/page.tsx:81
 msgid "faq.a.optOut"
 msgstr "Yes. Email us and we'll stop crawling your careers site immediately and remove your postings from the index."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:79
+#: app/[lang]/(public)/faq/page.tsx:85
 msgid "faq.a.openSource"
 msgstr "Yes. The crawler and extraction pipeline are fully open source on GitHub. The application code is MIT licensed; job data is CC BY-NC 4.0."
 
@@ -4499,7 +4409,6 @@ msgstr "Yesterday"
 
 #. Account deletion
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:61
 #: src/components/TermsContent.tsx:47
 msgid "terms.short.r5"
 msgstr "You can delete your account at any time."
@@ -4518,7 +4427,6 @@ msgstr "You can speed this up by asking your AI agent to complete it via Murmur.
 
 #. MIT license summary
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:56
 #: src/components/LicenseContent.tsx:53
 msgid "license.code.summary"
 msgstr "You can use, modify, and redistribute the code in personal or commercial products as long as you include the copyright and license notice."
@@ -4531,14 +4439,12 @@ msgstr "You may also be interested in"
 
 #. CC license summary
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:58
 #: src/components/LicenseContent.tsx:74
 msgid "license.data.summary"
 msgstr "You may reuse the job dataset with attribution for non-commercial purposes. Commercial usage requires prior written consent."
 
 #. Age requirement
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:57
 #: src/components/TermsContent.tsx:43
 msgid "terms.short.r1"
 msgstr "You must be at least 16 to use Job Seek."
@@ -4575,7 +4481,6 @@ msgstr "You've reached your watchlist limit. Upgrade your plan to mirror more wa
 
 #. Feature section 3 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:92
 #: src/components/Features.tsx:290
 msgid "home.features.s3.eyebrow"
 msgstr "Your companies, your rules"
@@ -4594,7 +4499,6 @@ msgstr "Your password has been reset. You can now sign in with your new password
 
 #. Your rights section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:63
 #: src/components/PrivacyPolicyContent.tsx:54
 msgid "privacy.rights.title"
 msgstr "Your rights"

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -39,8 +39,8 @@ msgstr "« Viktor Shcherbakov, Collection of Job Postings » avec un lien vers l
 #. Screen reader text for external links
 #. Screen reader text for external links
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:36
-#: src/components/Footer.tsx:42
+#: src/components/Footer.tsx:41
+#: src/components/Footer.tsx:47
 #: src/components/HowWeIndexContent.tsx:196
 #: src/components/LicenseContent.tsx:64
 #: src/components/LicenseContent.tsx:89
@@ -58,7 +58,7 @@ msgid "search.detail.showMoreLocations"
 msgstr "{0} de plus"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:32
+#: app/[lang]/(app)/company/[slug]/page.tsx:39
 msgid "company.meta.positionCount"
 msgstr "{count, plural, one {# poste ouvert} other {# postes ouverts}}"
 
@@ -87,7 +87,7 @@ msgid "blog.mention.watchlist.companiesLabel"
 msgstr "{count, plural, one {entreprise} other {entreprises}}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:98
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:103
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {# entreprise suivie} other {# entreprises suivies}}. {description}"
 
@@ -98,23 +98,23 @@ msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} candidatures le {date}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:56
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:61
 msgid "watchlist.meta.moreCompanies"
 msgstr "{count} de plus"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:44
+#: app/[lang]/(app)/company/[slug]/page.tsx:51
 msgid "company.meta.descriptionBasic"
 msgstr "{countText} chez {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:39
+#: app/[lang]/(app)/company/[slug]/page.tsx:46
 msgid "company.meta.descriptionWithInfo"
 msgstr "{countText} chez {name}. {description}"
 
 #. Reading-time label shown in the blog post byline. {minutes} is the integer minute count.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:136
+#: app/[lang]/(public)/blog/[slug]/page.tsx:150
 msgid "blog.post.readingTime"
 msgstr "{minutes, plural, one {# min de lecture} other {# min de lecture}}"
 
@@ -152,7 +152,7 @@ msgstr "1 candidature le {date}"
 #. js-lingui-explicit-id
 #: src/components/Pricing.tsx:45
 msgid "home.pricing.free.f2"
-msgstr "Suivi des candidatures"
+msgstr "1 watchlist"
 
 #. Heading for the 'install the Murmur MCP server' step on the agent-prompt success card
 #. js-lingui-explicit-id
@@ -167,13 +167,13 @@ msgid "app.home.request.agent.run_heading"
 msgstr "2. Exécuter le prompt"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:63
+#: app/[lang]/(public)/faq/page.tsx:69
 msgid "faq.a.whatIsWatchlist"
 msgstr "Une liste de suivi est une recherche enregistrée avec filtrage optionnel par entreprise. Choisissez les entreprises qui vous intéressent, définissez vos filtres (poste, lieu, séniorité, salaire) et obtenez un flux en direct des offres correspondantes. Vous pouvez partager vos listes publiquement ou les garder privées."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/about/page.tsx:18
-#: app/[lang]/(public)/about/page.tsx:40
+#: app/[lang]/(public)/about/page.tsx:17
+#: app/[lang]/(public)/about/page.tsx:46
 msgid "about.meta.title"
 msgstr "À propos"
 
@@ -287,7 +287,6 @@ msgstr "Prompt de l'agent"
 
 #. Encryption
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:61
 #: src/components/PrivacyPolicyContent.tsx:47
 msgid "privacy.short.r5"
 msgstr "Toutes les données sont chiffrées en transit et au repos."
@@ -335,7 +334,7 @@ msgid "settings.account.username.taken"
 msgstr "Déjà pris"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:19
+#: app/[lang]/(public)/faq/page.tsx:18
 msgid "faq.meta.description"
 msgstr "Réponses aux questions fréquentes sur Job Seek — comment nous scrapons les pages carrières, ce que contiennent les forfaits, la gestion de vos données et comment se désinscrire."
 
@@ -353,7 +352,6 @@ msgstr "Toute entreprise"
 
 #. MIT license section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:55
 #: src/components/LicenseContent.tsx:50
 msgid "license.code.title"
 msgstr "Code applicatif (licence MIT)"
@@ -364,18 +362,17 @@ msgstr "Code applicatif (licence MIT)"
 msgid "license.toc.code"
 msgstr "Code applicatif (MIT)"
 
-#. Feature: application stats title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:89
-#: src/components/Features.tsx:251
-msgid "home.features.s2.p3.title"
-msgstr "Des alertes que tu contrôles vraiment"
-
 #. Link to application stats page
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:263
 msgid "myJobs.viewStats"
 msgstr "Statistiques des candidatures"
+
+#. Feature: application stats title
+#. js-lingui-explicit-id
+#: src/components/Features.tsx:251
+msgid "home.features.s2.p3.title"
+msgstr "Statistiques de candidatures"
 
 #. Stats page title
 #. js-lingui-explicit-id
@@ -393,7 +390,7 @@ msgstr "Suivi de candidature"
 #. js-lingui-explicit-id
 #: src/components/Pricing.tsx:46
 msgid "home.pricing.free.f3"
-msgstr "Recherches enregistrées"
+msgstr "Suivi des candidatures avec journal d'entretiens"
 
 #. Subtitle showing total applications in past year
 #. js-lingui-explicit-id
@@ -457,7 +454,6 @@ msgstr "Avr"
 
 #. Step 3 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:66
 #: src/components/HowWeIndexContent.tsx:131
 msgid "indexing.ingestion.s3.body"
 msgstr "En dernier recours, nous analysons directement les pages carrières, en privilégiant le tri du plus récent au plus ancien et en nous arrêtant dès que des offres déjà indexées réapparaissent, plutôt que de parcourir chaque page."
@@ -486,16 +482,16 @@ msgstr "Aoû"
 msgid "settings.account.username.available"
 msgstr "Disponible"
 
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Retour à la connexion"
-
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Retour à la connexion"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Retour à la connexion"
 
 #. Link back to sign-in from forgot password
@@ -522,22 +518,22 @@ msgstr "Retour en haut"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Comportemental"
 
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:145
+msgid "blog.post.backToIndex"
+msgstr "Blog"
+
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:24
+#: app/[lang]/(public)/blog/page.tsx:27
 msgid "blog.meta.title"
 msgstr "Blog"
 
 #. <h1> on the blog index page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:69
+#: app/[lang]/(public)/blog/page.tsx:78
 msgid "blog.index.heading"
-msgstr "Blog"
-
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:131
-msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -550,7 +546,7 @@ msgstr "Blog"
 
 #. Footer link to /blog index page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:47
+#: src/components/Footer.tsx:52
 msgid "common.footer.blog"
 msgstr "Blog"
 
@@ -567,14 +563,13 @@ msgid "indexing.oss.browseRepo"
 msgstr "Parcourir le dépôt sur"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:22
-#: app/[lang]/(public)/page.tsx:47
+#: app/[lang]/(public)/page.tsx:21
+#: app/[lang]/(public)/page.tsx:53
 msgid "home.meta.description"
 msgstr "Crée des watchlists des entreprises qui t'intéressent, reçois des alertes par e-mail dès qu'un nouveau poste s'ouvre, et suis tes candidatures en un seul endroit. Les offres viennent directement des pages carrières des entreprises, dans les heures suivant leur publication — pas de spam de recruteurs, pas d'annonces republiées."
 
 #. Hero description paragraph — watchlist + alerts pitch with direct sourcing as supporting claim
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:72
 #: src/components/Hero.tsx:31
 msgid "home.hero.description"
 msgstr "Crée des watchlists des entreprises qui t'intéressent, reçois des alertes par e-mail dès qu'un nouveau poste s'ouvre, et suis chaque candidature en un seul endroit. Nous surveillons les pages carrières directement — les offres apparaissent en quelques heures, avant que LinkedIn ou Indeed ne les relaient."
@@ -582,19 +577,17 @@ msgstr "Crée des watchlists des entreprises qui t'intéressent, reçois des ale
 #. About page heading
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:25
-#: app/[lang]/(public)/about/page.tsx:51
 msgid "about.title"
 msgstr "Créé par des chercheurs d'emploi, pour des chercheurs d'emploi"
 
 #. Terms page description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:54
 #: src/components/TermsContent.tsx:23
 msgid "terms.hero.description"
 msgstr "En utilisant Job Seek, tu acceptes ces conditions. Voici un résumé en langage clair."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:74
+#: app/[lang]/(public)/faq/page.tsx:80
 msgid "faq.q.optOut"
 msgstr "Puis-je refuser l'indexation de mon entreprise par Jobseek ?"
 
@@ -646,17 +639,17 @@ msgstr "Modifie ton mot de passe via un lien e-mail sécurisé."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Changer…"
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "Vérifie ton e-mail"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
 msgstr "Vérifiez votre e-mail"
+
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
+msgstr "Vérifie ton e-mail"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -684,7 +677,6 @@ msgstr "Choisissez le plan qui vous convient."
 
 #. Pricing section heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:102
 #: src/components/Pricing.tsx:103
 msgid "home.pricing.title"
 msgstr "Choisis l'offre qui te convient"
@@ -743,7 +735,6 @@ msgstr "Cliquer pour renommer"
 
 #. Step 2 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:65
 #: src/components/HowWeIndexContent.tsx:121
 msgid "indexing.ingestion.s2.title"
 msgstr "API clientes en second."
@@ -774,21 +765,18 @@ msgstr "Coding"
 
 #. CC license section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:57
 #: src/components/LicenseContent.tsx:71
 msgid "license.data.title"
 msgstr "Collection d'offres d'emploi (CC BY-NC 4.0)"
 
 #. Feature: multi-dimensional filters description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:79
 #: src/components/Features.tsx:186
 msgid "home.features.s1.p2.description"
-msgstr "Note où tu as postulé, le statut, les contacts et les prochaines étapes."
+msgstr "Combine séniorité, technologies, salaire, lieu et langue de l'offre dans une seule requête. Plus besoin de trier le bruit."
 
 #. Feature: focused search description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:96
 #: src/components/Features.tsx:303
 msgid "home.features.s3.p1.description"
 msgstr "Combinez des entreprises spécifiques avec des filtres de rôle pour cibler exactement les postes que vous recherchez."
@@ -837,17 +825,17 @@ msgstr "Entreprise"
 
 #. Heading shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:74
+#: app/[lang]/(app)/company/[slug]/page.tsx:87
 msgid "company.notFound.title"
 msgstr "Entreprise introuvable"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:77
+#: app/[lang]/layout.tsx:111
 msgid "app.schema.description"
 msgstr "Outil de suivi d'entreprises pour les candidats qui savent déjà dans quelles entreprises ils veulent travailler. Crée des watchlists, reçois des alertes par e-mail dès qu'un nouveau poste s'ouvre, et suis tes candidatures en un seul endroit — les offres viennent directement des pages carrières des entreprises."
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:43
+#: app/[lang]/layout.tsx:76
 msgid "app.schema.org.description"
 msgstr "Outil de suivi d'entreprises pour les candidats ciblés — watchlists, alertes par e-mail et offres directement issues des pages carrières des entreprises. Créé par Colophon Group, un petit studio de développeurs en Suisse."
 
@@ -875,16 +863,9 @@ msgstr "Connecter"
 msgid "settings.account.socials.title"
 msgstr "Comptes connectés"
 
-#. Contact section title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:59
-#: src/components/LicenseContent.tsx:96
-msgid "license.contact.title"
-msgstr "Contact"
-
 #. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:41
+#: src/components/Footer.tsx:46
 msgid "common.footer.contact"
 msgstr "Contact"
 
@@ -892,6 +873,12 @@ msgstr "Contact"
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:25
 msgid "license.toc.contact"
+msgstr "Contact"
+
+#. Contact section title
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:96
+msgid "license.contact.title"
 msgstr "Contact"
 
 #. Table of contents heading
@@ -938,7 +925,6 @@ msgstr "Freelance"
 
 #. Cookies
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:60
 #: src/components/PrivacyPolicyContent.tsx:46
 msgid "privacy.short.r4"
 msgstr "Les cookies servent uniquement à la session — pas de pub, pas de tracking."
@@ -987,17 +973,16 @@ msgstr "Pays"
 msgid "about.link.crawler"
 msgstr "Code source du crawler"
 
-#. Assurances section title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:55
-#: src/components/HowWeIndexContent.tsx:63
-msgid "indexing.assurances.title"
-msgstr "Garanties de crawl"
-
 #. TOC: Crawling assurances
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:28
 msgid "indexing.toc.assurances"
+msgstr "Garanties de crawl"
+
+#. Assurances section title
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:63
+msgid "indexing.assurances.title"
 msgstr "Garanties de crawl"
 
 #. Label on the create watchlist card
@@ -1038,7 +1023,6 @@ msgstr "Création du compte..."
 
 #. Feature section 3 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:93
 #: src/components/Features.tsx:293
 msgid "home.features.s3.title"
 msgstr "Créez une liste de suivi pour chaque niche"
@@ -1075,13 +1059,13 @@ msgstr "Sombre"
 
 #. Meta description (under 160 chars) for the blog index page — covers data analyses + report breakdowns + news commentary
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:29
+#: app/[lang]/(public)/blog/page.tsx:32
 msgid "blog.meta.description"
 msgstr "Analyses de données, actualités et résumés de rapports sectoriels — issus des offres d'emploi que nous suivons sur les pages carrières de milliers d'entreprises."
 
 #. One-line tagline under the blog index <h1> — covers data analyses + reports/papers + news
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:74
+#: app/[lang]/(public)/blog/page.tsx:83
 msgid "blog.index.tagline"
 msgstr "Analyses de données, actualités et résumés de rapports sectoriels et d'études — issus des offres d'emploi que nous suivons."
 
@@ -1165,10 +1149,9 @@ msgstr "Vous n'avez pas trouvé l'entreprise recherchée ?"
 
 #. Feature: direct from source title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:78
 #: src/components/Features.tsx:180
 msgid "home.features.s1.p1.title"
-msgstr "Alertes entreprises"
+msgstr "Direct depuis la source"
 
 #. Disable alerts tooltip
 #. js-lingui-explicit-id
@@ -1189,7 +1172,7 @@ msgid "watchlists.explore.publicTitle"
 msgstr "Découvrir des listes publiques"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:82
+#: app/[lang]/(public)/faq/page.tsx:88
 msgid "faq.q.dataPrivacy"
 msgstr "Jobseek vend-il mes données ?"
 
@@ -1201,7 +1184,6 @@ msgstr "Pas encore de compte ? <0>S'inscrire</0>"
 
 #. No scraping
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:59
 #: src/components/TermsContent.tsx:45
 msgid "terms.short.r3"
 msgstr "Pas de scraping, pas de candidatures automatisées, pas d'abus de la plateforme."
@@ -1248,7 +1230,7 @@ msgstr "Suivi illimité d'entreprises"
 #. js-lingui-explicit-id
 #: src/components/Pricing.tsx:82
 msgid "home.pricing.pro.f2"
-msgstr "Suivi des candidatures"
+msgstr "Alertes e-mail sur les nouvelles correspondances"
 
 #. Email or username input label for sign-in
 #. js-lingui-explicit-id
@@ -1288,21 +1270,18 @@ msgstr "Entre ton nouveau mot de passe ci-dessous."
 
 #. Assurance 3 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:59
 #: src/components/HowWeIndexContent.tsx:80
 msgid "indexing.assurances.i3.body"
 msgstr "Même après la découverte, nous récupérons les pages de détail des offres à un rythme strict d'une requête par site et par minute."
 
 #. Feature section 1 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:75
 #: src/components/Features.tsx:171
 msgid "home.features.s1.title"
-msgstr "Conçu pour les chercheurs d'emploi actifs"
+msgstr "Tous les filtres dont un chercheur d'emploi a vraiment besoin"
 
 #. Assurance 1 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:57
 #: src/components/HowWeIndexContent.tsx:68
 msgid "indexing.assurances.i1.body"
 msgstr "Chaque fenêtre de réessai utilise un backoff exponentiel afin de ne jamais surcharger un serveur d'origine, et nous abandonnons si un hôte continue de ne pas répondre."
@@ -1322,7 +1301,7 @@ msgstr "Alertes e-mail pour les nouvelles offres"
 #. FAQ page description
 #. js-lingui-explicit-id
 #. placeholder {0}: siteConfig.indexing.contactEmail
-#: app/[lang]/(public)/faq/faq-content.tsx:45
+#: app/[lang]/(public)/faq/faq-content.tsx:42
 msgid "faq.description"
 msgstr "Tout ce que vous devez savoir sur Job Seek. Vous ne trouvez pas ce que vous cherchez ? Écrivez-nous à <0>{0}</0>."
 
@@ -1412,7 +1391,7 @@ msgid "settings.account.username.error"
 msgstr "Échec de la mise à jour du nom d'utilisateur"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:18
+#: app/[lang]/(public)/faq/page.tsx:17
 msgid "faq.meta.title"
 msgstr "FAQ"
 
@@ -1492,7 +1471,6 @@ msgstr "Rechercher"
 
 #. Feature: focused search title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:96
 #: src/components/Features.tsx:302
 msgid "home.features.s3.p1.title"
 msgstr "Recherche ciblée"
@@ -1505,7 +1483,7 @@ msgstr "Suivez-nous sur LinkedIn"
 
 #. Aria label for footer navigation
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:31
+#: src/components/Footer.tsx:36
 msgid "common.footer.ariaLabel"
 msgstr "Pied de page"
 
@@ -1547,7 +1525,6 @@ msgstr "Fondée en {year}"
 
 #. Free tier name
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:104
 #: src/components/Pricing.tsx:32
 msgid "home.pricing.free.name"
 msgstr "Gratuit"
@@ -1559,14 +1536,13 @@ msgid "settings.billing.plan.free"
 msgstr "Gratuit"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:59
+#: app/[lang]/(public)/faq/page.tsx:65
 msgid "faq.a.freeVsPro"
 msgstr "La version gratuite vous offre une recherche complète sur toutes les entreprises, une liste de suivi et le suivi des candidatures avec journal des entretiens. Pro ajoute des listes de suivi illimitées et des alertes email lorsque de nouvelles offres correspondent à vos critères."
 
 #. FAQ page heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/faq-content.tsx:42
-#: app/[lang]/(public)/faq/page.tsx:109
+#: app/[lang]/(public)/faq/faq-content.tsx:39
 msgid "faq.title"
 msgstr "Questions fréquentes"
 
@@ -1578,10 +1554,9 @@ msgstr "Ven"
 
 #. Feature section 2 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:84
 #: src/components/Features.tsx:232
 msgid "home.features.s2.title"
-msgstr "Le premier agrégateur d'emploi qui te met aux commandes"
+msgstr "Du poste sauvegardé à l'offre signée, tout au même endroit"
 
 #. Free plan feature: search
 #. js-lingui-explicit-id
@@ -1590,16 +1565,15 @@ msgid "settings.billing.free.f2"
 msgstr "Recherche d'emploi complète"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:87
+#: app/[lang]/layout.tsx:121
 msgid "app.schema.offer.free"
 msgstr "Recherche complète, 1 liste de suivi, suivi des candidatures"
 
 #. Free tier description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:104
 #: src/components/Pricing.tsx:41
 msgid "home.pricing.free.description"
-msgstr "Teste Job Seek avec assez de marge pour rester à jour avec les entreprises de tes rêves."
+msgstr "Recherche complète, une watchlist et un suivi des candidatures intégré pour gérer ton pipeline."
 
 #. Employment type: full-time
 #. js-lingui-explicit-id
@@ -1637,13 +1611,13 @@ msgstr "Commence avec Job Seek"
 
 #. Footer link to GitHub repo
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:35
+#: src/components/Footer.tsx:40
 msgid "common.footer.github"
 msgstr "GitHub"
 
 #. Link to return to the homepage from a 404 page
 #. js-lingui-explicit-id
-#: app/[lang]/not-found.tsx:22
+#: app/[lang]/not-found-content.tsx:22
 msgid "notFound.goHome"
 msgstr "Retour à l'accueil"
 
@@ -1661,7 +1635,6 @@ msgstr "Compris"
 
 #. Step 3 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:66
 #: src/components/HowWeIndexContent.tsx:129
 msgid "indexing.ingestion.s3.title"
 msgstr "Analyse de pages respectueuse."
@@ -1697,32 +1670,25 @@ msgid "myJobs.salary.hourly"
 msgstr "Horaire"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:54
+#: app/[lang]/(public)/faq/page.tsx:60
 msgid "faq.q.requestCompany"
 msgstr "Comment demander l'ajout d'une entreprise non répertoriée ?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:70
+#: app/[lang]/(public)/faq/page.tsx:76
 msgid "faq.q.crawlingPolicy"
 msgstr "Comment le crawler se comporte-t-il sur le site de mon entreprise ?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:19
-#: app/[lang]/(public)/how-we-index/page.tsx:45
+#: app/[lang]/(public)/how-we-index/page.tsx:18
+#: app/[lang]/(public)/how-we-index/page.tsx:50
 msgid "indexing.meta.description"
 msgstr "Comment Job Seek découvre et indexe les offres d'emploi : notre approche de sourcing, fréquence de crawl, limites de débit, conformité robots.txt et TDM-Reservation, et comment se désinscrire."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:46
+#: app/[lang]/(public)/faq/page.tsx:52
 msgid "faq.q.howOftenUpdated"
 msgstr "À quelle fréquence les offres d'emploi sont-elles mises à jour ?"
-
-#. Ingestion section title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:62
-#: src/components/HowWeIndexContent.tsx:104
-msgid "indexing.ingestion.title"
-msgstr "Comment les offres entrent dans l'index"
 
 #. TOC: How postings enter the index
 #. js-lingui-explicit-id
@@ -1730,16 +1696,21 @@ msgstr "Comment les offres entrent dans l'index"
 msgid "indexing.toc.ingestion"
 msgstr "Comment les offres entrent dans l'index"
 
+#. Ingestion section title
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:104
+msgid "indexing.ingestion.title"
+msgstr "Comment les offres entrent dans l'index"
+
 #. Indexing page title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:52
 #: src/components/HowWeIndexContent.tsx:48
 msgid "indexing.hero.title"
 msgstr "Comment nous trouvons et traitons les offres d'emploi"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:18
-#: app/[lang]/(public)/how-we-index/page.tsx:44
+#: app/[lang]/(public)/how-we-index/page.tsx:17
+#: app/[lang]/(public)/how-we-index/page.tsx:49
 msgid "indexing.meta.title"
 msgstr "Comment nous indexons"
 
@@ -1751,14 +1722,12 @@ msgstr "Si un compte existe pour cette adresse e-mail, nous avons envoyé un lie
 
 #. Step 2 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:65
 #: src/components/HowWeIndexContent.tsx:123
 msgid "indexing.ingestion.s2.body"
 msgstr "En l'absence de sitemap, nous inspectons l'application cliente à la recherche d'API JSON qu'elle appelle ; lorsque nous en trouvons, nous interrogeons directement ces points d'accès pour énumérer les URL des offres sans scraper le DOM."
 
 #. Opt-out section body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:71
 #: src/components/HowWeIndexContent.tsx:164
 msgid "indexing.optOut.body"
 msgstr "Si tu constates une activité inattendue de notre robot d'indexation ou préfères que ton site carrières ne soit pas indexé, contacte-nous par e-mail et nous te répondrons rapidement."
@@ -1770,7 +1739,7 @@ msgid "indexing.outreach.body"
 msgstr "Si tu remarques un comportement inhabituel de notre robot, préfères que nous n'indexions pas ton contenu, ou as des suggestions pour améliorer nos mesures de protection, n'hésite pas à nous contacter."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:72
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:77
 msgid "watchlist.meta.inLocations"
 msgstr "à {locations}"
 
@@ -1841,7 +1810,6 @@ msgstr "L'entrée est trop courte."
 #. About paragraph 2: how it works — leads with direct sourcing and watchlist ICP, no platform listing
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:38
-#: app/[lang]/(public)/about/page.tsx:53
 msgid "about.p2"
 msgstr "Au lieu d'attendre que les entreprises publient leurs postes sur des sites d'emploi tiers, nous allons directement à la source. Notre crawler surveille des milliers de pages carrières directement et les revérifie fréquemment, donc les postes apparaissent ici dans les heures qui suivent leur publication — généralement avant qu'ils n'atteignent les grands agrégateurs. Crée une watchlist des entreprises qui t'intéressent et reçois une notification dès qu'elles publient."
 
@@ -1859,10 +1827,9 @@ msgstr "Entretien"
 
 #. Feature: interview log title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:88
 #: src/components/Features.tsx:246
 msgid "home.features.s2.p2.title"
-msgstr "Fini la routine des 50 onglets"
+msgstr "Journal d'entretiens"
 
 #. Status group heading: interviewing
 #. js-lingui-explicit-id
@@ -1907,17 +1874,17 @@ msgid "auth.verify.error.invalidLink"
 msgstr "Lien de vérification invalide"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:42
+#: app/[lang]/(public)/faq/page.tsx:48
 msgid "faq.q.targetedSeeker"
 msgstr "Job Seek est-il fait pour moi si je sais déjà dans quelles entreprises je veux travailler ?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:78
+#: app/[lang]/(public)/faq/page.tsx:84
 msgid "faq.q.openSource"
 msgstr "Le crawler est-il open source ?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:66
+#: app/[lang]/(public)/faq/page.tsx:72
 msgid "faq.q.trackerLimit"
 msgstr "Y a-t-il une limite au nombre d'offres que je peux suivre ?"
 
@@ -1982,19 +1949,18 @@ msgid "home.features.s2.screenshot.alt"
 msgstr "Interface Job Seek pour soumettre des liens d'entreprises et configurer des alertes personnalisées"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:39
+#: app/[lang]/(public)/faq/page.tsx:45
 msgid "faq.a.whatIsJobseek"
 msgstr "Job Seek t'aide à suivre les entreprises pour lesquelles tu veux vraiment travailler. Crée une watchlist, reçois des alertes par e-mail dès qu'un nouveau poste s'ouvre, et suis tes candidatures en un seul endroit. Les offres viennent directement des pages carrières des entreprises, donc tu les vois dans les heures suivant leur publication — généralement avant que LinkedIn ou Indeed ne les relaient."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/about/page.tsx:19
-#: app/[lang]/(public)/about/page.tsx:41
+#: app/[lang]/(public)/about/page.tsx:18
+#: app/[lang]/(public)/about/page.tsx:47
 msgid "about.meta.description"
 msgstr "Job Seek t'aide à suivre les entreprises pour lesquelles tu veux travailler — watchlists, alertes par e-mail et offres directement issues des pages carrières. Créé par Colophon Group, un petit studio de développeurs en Suisse."
 
 #. Indexing page description — company-tracking framing, not 'search engine'
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:53
 #: src/components/HowWeIndexContent.tsx:51
 msgid "indexing.hero.description"
 msgstr "Job Seek est un outil de suivi d'entreprises — il surveille des milliers de pages carrières d'entreprises pour que les utilisateurs puissent créer des watchlists et recevoir des alertes sur les nouvelles offres. Cette page décrit précisément le comportement de notre robot d'indexation, les contrôles qui garantissent sa courtoisie, et comment les offres atterrissent dans l'index."
@@ -2008,13 +1974,12 @@ msgstr "Job Seek est en cours de développement. Restez à l'écoute pour les mi
 #. About paragraph 1: who we are
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:26
-#: app/[lang]/(public)/about/page.tsx:52
 msgid "about.p1"
 msgstr "Job Seek est développé par Colophon Group, une petite équipe de développeurs basée en Suisse. Nous l'avons créé parce que nous en avions assez du même problème que rencontre chaque chercheur d'emploi : jongler entre des dizaines d'onglets, rater des offres parce qu'un agrégateur était trop lent, et se noyer dans du bruit algorithmique optimisé pour les clics plutôt que pour la pertinence."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:19
-#: app/[lang]/(public)/privacy-policy/page.tsx:45
+#: app/[lang]/(public)/privacy-policy/page.tsx:18
+#: app/[lang]/(public)/privacy-policy/page.tsx:51
 msgid "privacy.meta.description"
 msgstr "Politique de confidentialité de Job Seek — données collectées, utilisation, droits RGPD, politique de cookies et suppression de compte et de données."
 
@@ -2032,13 +1997,12 @@ msgstr "Liste de suivi Job Seek montrant des postes sélectionnés en ingénieri
 
 #. License page description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:54
 #: src/components/LicenseContent.tsx:38
 msgid "license.hero.description"
 msgstr "Le code source de Job Seek est ouvert sous licence MIT. Les données d'emploi que nous collectons et enrichissons sont sous Creative Commons BY-NC 4.0. Tu trouveras ci-dessous un résumé en langage clair — consulte les licences complètes pour les termes exacts."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:80
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:85
 msgid "watchlist.meta.fallback"
 msgstr "Liste d'emplois de @{owner}"
 
@@ -2055,12 +2019,12 @@ msgid "watchlists.explore.jobPlural"
 msgstr "offres"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:25
+#: app/[lang]/(app)/company/[slug]/page.tsx:32
 msgid "company.meta.title"
 msgstr "Emplois chez {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:62
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:67
 msgid "watchlist.meta.jobsAt"
 msgstr "Emplois chez {names}"
 
@@ -2108,14 +2072,14 @@ msgstr "Dernière heure"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:28
-msgid "privacy.hero.lastUpdated"
+#: src/components/TermsContent.tsx:28
+msgid "terms.hero.lastUpdated"
 msgstr "Dernière mise à jour :"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:28
-msgid "terms.hero.lastUpdated"
+#: src/components/PrivacyPolicyContent.tsx:28
+msgid "privacy.hero.lastUpdated"
 msgstr "Dernière mise à jour :"
 
 #. Time range option: last week
@@ -2130,21 +2094,21 @@ msgstr "Dernière semaine"
 msgid "home.hero.secondaryCta"
 msgstr "En savoir plus"
 
-#. Label for seniority/level filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:154
-msgid "search.advanced.level"
-msgstr "Niveau"
-
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:638
 msgid "search.bar.level"
 msgstr "Niveau"
 
+#. Label for seniority/level filter in advanced search
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:18
-#: app/[lang]/(public)/license/page.tsx:45
+#: src/components/search/advanced-search-panel.tsx:154
+msgid "search.advanced.level"
+msgstr "Niveau"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/license/page.tsx:17
+#: app/[lang]/(public)/license/page.tsx:51
 msgid "license.meta.title"
 msgstr "Licence"
 
@@ -2156,13 +2120,12 @@ msgstr "Licence"
 
 #. Footer link to license page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
+#: src/components/Footer.tsx:57
 msgid "common.footer.licenseLink"
 msgstr "Licence"
 
 #. License page title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:53
 #: src/components/LicenseContent.tsx:37
 msgid "license.hero.title"
 msgstr "Licence de Job Seek"
@@ -2174,8 +2137,8 @@ msgid "license.hero.eyebrow"
 msgstr "Licences"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:19
-#: app/[lang]/(public)/license/page.tsx:46
+#: app/[lang]/(public)/license/page.tsx:18
+#: app/[lang]/(public)/license/page.tsx:52
 msgid "license.meta.description"
 msgstr "Licences de Job Seek — le code source est sous licence MIT, les offres d'emploi sous CC BY-NC 4.0. Découvrez ce que vous pouvez faire avec notre code et nos données."
 
@@ -2209,16 +2172,16 @@ msgstr "Lieu"
 msgid "search.advanced.location"
 msgstr "Lieu"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
-msgstr "Lieux"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:708
 msgid "search.bar.locations"
+msgstr "Lieux"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:312
+msgid "search.detail.locations"
 msgstr "Lieux"
 
 #. Login button label
@@ -2243,7 +2206,6 @@ msgstr "Connectez-vous pour enregistrer cette recherche comme liste de suivi"
 
 #. Feature: share watchlists description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:98
 #: src/components/Features.tsx:313
 msgid "home.features.s3.p3.description"
 msgstr "Rendez une liste de suivi publique et partagez le lien avec vos amis, communautés ou votre réseau."
@@ -2348,7 +2310,6 @@ msgstr "copies"
 
 #. Feature: request companies description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:97
 #: src/components/Features.tsx:308
 msgid "home.features.s3.p2.description"
 msgstr "Une entreprise manque ? Collez l'URL de sa page carrières et nous commençons à l'indexer pour vous."
@@ -2360,7 +2321,7 @@ msgid "myJobs.heatmap.day.mon"
 msgstr "Lun"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:99
+#: app/[lang]/layout.tsx:133
 msgid "app.schema.feature.monitor"
 msgstr "Surveiller les pages carrières des entreprises"
 
@@ -2384,20 +2345,18 @@ msgstr "plus"
 
 #. Feature: status tracking description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:87
 #: src/components/Features.tsx:242
 msgid "home.features.s2.p1.description"
-msgstr "Indique-nous n'importe quelle page carrières ou tableau d'offres Notion et Job Seek le reproduit dans ton espace de travail en quelques minutes."
+msgstr "Fais passer chaque poste de sauvegardé à candidaté, en entretien, offre reçue ou refusé. Tu sais toujours où tu en es."
 
 #. Feature: multi-dimensional filters title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:79
 #: src/components/Features.tsx:185
 msgid "home.features.s1.p2.title"
-msgstr "Suivi des candidatures"
+msgstr "Filtres multi-dimensionnels"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:101
+#: app/[lang]/layout.tsx:135
 msgid "app.schema.feature.languages"
 msgstr "Support multilingue"
 
@@ -2523,7 +2482,7 @@ msgstr "Aucune offre correspondante trouvée."
 
 #. Empty-state message shown when no blog posts have been published yet
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:79
+#: app/[lang]/(public)/blog/page.tsx:88
 msgid "blog.index.empty"
 msgstr "Aucun article pour le moment — revenez bientôt."
 
@@ -2582,12 +2541,12 @@ msgid "watchlists.page.empty"
 msgstr "Aucune liste de suivi pour l'instant. Créez-en une pour suivre les offres de vos entreprises préférées."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:67
+#: app/[lang]/(public)/faq/page.tsx:73
 msgid "faq.a.trackerLimit"
 msgstr "Non. Le suivi des candidatures n'a pas de limite — enregistrez autant d'offres que vous voulez et faites-les avancer dans votre pipeline."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:83
+#: app/[lang]/(public)/faq/page.tsx:89
 msgid "faq.a.dataPrivacy"
 msgstr "Non. Nous ne vendons, ne louons ni ne partageons vos données à des fins marketing. Les cookies sont uniquement de session, sans publicité ni tracking. Vous pouvez supprimer votre compte et toutes les données seront effacées sous 30 jours."
 
@@ -2665,14 +2624,12 @@ msgstr "Ok"
 
 #. Step 4 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:67
 #: src/components/HowWeIndexContent.tsx:139
 msgid "indexing.ingestion.s4.body"
 msgstr "Une fois qu'une offre individuelle est récupérée, nous ne stockons que les métadonnées propres au poste (intitulé, description du rôle, localisation, informations de rémunération, URL de l'offre et horodatages) ainsi que les champs structurés extraits. Nous n'archivons pas les contenus du site sans rapport avec les offres d'emploi."
 
 #. Assurance 3 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:59
 #: src/components/HowWeIndexContent.tsx:79
 msgid "indexing.assurances.i3.title"
 msgstr "Une page par minute."
@@ -2696,16 +2653,9 @@ msgid "common.header.openMenu"
 msgstr "Ouvrir le menu principal"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:37
+#: app/[lang]/(app)/company/[slug]/page.tsx:44
 msgid "company.meta.openPositions"
 msgstr "Postes ouverts"
-
-#. Open-source section title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:76
-#: src/components/HowWeIndexContent.tsx:185
-msgid "indexing.oss.title"
-msgstr "Robots d'indexation open source"
 
 #. TOC: Open-source crawlers
 #. js-lingui-explicit-id
@@ -2713,17 +2663,22 @@ msgstr "Robots d'indexation open source"
 msgid "indexing.toc.oss"
 msgstr "Robots d'indexation open source"
 
-#. Opt-out section title
+#. Open-source section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:70
-#: src/components/HowWeIndexContent.tsx:161
-msgid "indexing.optOut.title"
-msgstr "Désinscription ou questions"
+#: src/components/HowWeIndexContent.tsx:185
+msgid "indexing.oss.title"
+msgstr "Robots d'indexation open source"
 
 #. TOC: Opt-out or questions
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:30
 msgid "indexing.toc.optOut"
+msgstr "Désinscription ou questions"
+
+#. Opt-out section title
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:161
+msgid "indexing.optOut.title"
 msgstr "Désinscription ou questions"
 
 #. Divider between form and OAuth buttons
@@ -2746,22 +2701,20 @@ msgstr "Autre"
 
 #. Assurance 2 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:58
 #: src/components/HowWeIndexContent.tsx:73
 msgid "indexing.assurances.i2.body"
 msgstr "Notre robot lit le fichier <0>robots.txt</0>, respecte les règles d'interdiction, s'identifie via <1>User-Agent</1> et respecte l'en-tête W3C <2>TDM-Reservation</2> — si une page signale une réservation, nous la passons."
-
-#. Automation stance title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:73
-#: src/components/HowWeIndexContent.tsx:174
-msgid "indexing.automation.title"
-msgstr "Notre position sur l'automatisation"
 
 #. TOC: Our stance on automation
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:31
 msgid "indexing.toc.automation"
+msgstr "Notre position sur l'automatisation"
+
+#. Automation stance title
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:174
+msgid "indexing.automation.title"
 msgstr "Notre position sur l'automatisation"
 
 #. TOC: Overview
@@ -2790,7 +2743,7 @@ msgstr "Sommaire de la page"
 
 #. Heading shown on the 404 page
 #. js-lingui-explicit-id
-#: app/[lang]/not-found.tsx:12
+#: app/[lang]/not-found-content.tsx:12
 msgid "notFound.title"
 msgstr "Page introuvable"
 
@@ -2858,7 +2811,6 @@ msgstr "Période"
 
 #. Pro tier period
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:73
 msgid "home.pricing.pro.period"
 msgstr "par mois"
@@ -2889,7 +2841,6 @@ msgstr "Entretien téléphonique"
 
 #. Feature section 3 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:94
 #: src/components/Features.tsx:296
 msgid "home.features.s3.description"
 msgstr "Choisissez les entreprises qui vous intéressent, définissez vos filtres et obtenez un flux en direct des postes correspondants. Partagez-le publiquement ou gardez-le privé."
@@ -2978,19 +2929,18 @@ msgstr "Offre non trouvée."
 msgid "myJobs.detail.notFound"
 msgstr "Offre introuvable."
 
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:101
-#: src/components/Pricing.tsx:100
-msgid "home.pricing.eyebrow"
-msgstr "Tarifs"
-
 #. Nav link: Pricing
 #. Nav link: Pricing
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:62
 #: src/components/MobileMenu.tsx:87
 msgid "common.nav.pricing"
+msgstr "Tarifs"
+
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:100
+msgid "home.pricing.eyebrow"
 msgstr "Tarifs"
 
 #. Privacy policy page eyebrow
@@ -3001,20 +2951,19 @@ msgstr "Confidentialité"
 
 #. Footer link to privacy policy page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:57
+#: src/components/Footer.tsx:62
 msgid "common.footer.privacyLink"
 msgstr "Confidentialité"
 
 #. Privacy policy page title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:53
 #: src/components/PrivacyPolicyContent.tsx:22
 msgid "privacy.hero.title"
 msgstr "Confidentialité chez Job Seek"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:18
-#: app/[lang]/(public)/privacy-policy/page.tsx:44
+#: app/[lang]/(public)/privacy-policy/page.tsx:17
+#: app/[lang]/(public)/privacy-policy/page.tsx:50
 msgid "privacy.meta.title"
 msgstr "Politique de confidentialité"
 
@@ -3026,7 +2975,6 @@ msgstr "Les listes de suivi privées sont une fonctionnalité payante. Passez à
 
 #. Pro tier name
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:68
 msgid "home.pricing.pro.name"
 msgstr "Pro"
@@ -3045,21 +2993,18 @@ msgstr "Domaine public"
 
 #. Contact call to action
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:60
 #: src/components/LicenseContent.tsx:99
 msgid "license.contactCta"
 msgstr "Des questions sur les licences ou l'utilisation commerciale ? Écris-nous."
 
 #. Terms contact call to action
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:63
 #: src/components/TermsContent.tsx:54
 msgid "terms.contact.description"
 msgstr "Des questions ? Écris-nous."
 
 #. Privacy contact call to action
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:65
 #: src/components/PrivacyPolicyContent.tsx:66
 msgid "privacy.contact.description"
 msgstr "Des questions ? Écris-nous."
@@ -3089,7 +3034,7 @@ msgid "terms.fullTermsLink"
 msgstr "Lire les conditions d'utilisation complètes"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:100
+#: app/[lang]/layout.tsx:134
 msgid "app.schema.feature.alerts"
 msgstr "Alertes en temps réel sur les nouvelles offres"
 
@@ -3101,10 +3046,9 @@ msgstr "Récemment mis à jour"
 
 #. Feature: interview log description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:88
 #: src/components/Features.tsx:247
 msgid "home.features.s2.p2.description"
-msgstr "Regroupe toutes les startups intéressantes dans un seul tableau de bord au lieu de jongler entre les fenêtres Chrome et les favoris."
+msgstr "Note chaque tour d'entretien avec date, type et notes pour que rien ne passe à travers les mailles."
 
 #. MIT right 2
 #. js-lingui-explicit-id
@@ -3156,7 +3100,7 @@ msgstr "Refusé"
 
 #. Footer license summary text
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:24
+#: src/components/Footer.tsx:29
 msgid "common.footer.text"
 msgstr "Publié sous licence MIT. Les données d'emploi sont sous CC BY-NC 4.0."
 
@@ -3186,7 +3130,6 @@ msgstr "Demander une entreprise"
 
 #. Feature: request companies title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:97
 #: src/components/Features.tsx:307
 msgid "home.features.s3.p2.title"
 msgstr "Demander n'importe quelle entreprise"
@@ -3247,14 +3190,12 @@ msgstr "Réinitialisation…"
 
 #. Assurance 1 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:57
 #: src/components/HowWeIndexContent.tsx:67
 msgid "indexing.assurances.i1.title"
 msgstr "Rythme respectueux."
 
 #. Assurance 2 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:58
 #: src/components/HowWeIndexContent.tsx:71
 msgid "indexing.assurances.i2.title"
 msgstr "Robots, attribution et réservation TDM."
@@ -3309,17 +3250,15 @@ msgstr "Fourchette salariale"
 
 #. Feature section 2 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:85
 #: src/components/Features.tsx:235
 msgid "home.features.s2.description"
-msgstr "Tu ne trouves pas ton entreprise préférée dans le flux ? Colle le lien de sa page carrières et on commence à la scraper pour toi — pas de scripts, pas de tableurs, pas d'attente au support."
+msgstr "Sauvegarde n'importe quel poste que tu trouves, fais-le avancer dans ton pipeline au fil des candidatures et des entretiens, et vois en un coup d'œil où en est chaque candidature."
 
 #. Feature: watchlists and alerts description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:80
 #: src/components/Features.tsx:191
 msgid "home.features.s1.p3.description"
-msgstr "Enregistre tes filtres pour des recherches rapides sans tout retaper à chaque fois."
+msgstr "Enregistre n'importe quelle recherche en watchlist et reçois des alertes par e-mail quand de nouveaux postes correspondent à tes critères."
 
 #. Save job aria label
 #. js-lingui-explicit-id
@@ -3391,14 +3330,13 @@ msgstr "Enregistrement…"
 #. js-lingui-explicit-id
 #: src/components/Pricing.tsx:44
 msgid "home.pricing.free.f1"
-msgstr "Suivi de 5 entreprises maximum"
+msgstr "Recherche dans toutes les entreprises et tous les filtres"
 
 #. Feature section 1 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:76
 #: src/components/Features.tsx:174
 msgid "home.features.s1.description"
-msgstr "Suis les postes, reçois des notifications quand les entreprises publient quelque chose de nouveau, et garde ton pipeline propre."
+msgstr "Cherche parmi des milliers d'entreprises scrapées directement depuis leurs pages carrières. Filtre par séniorité, stack technique, fourchette de salaire, lieu et langue — le tout en une seule requête."
 
 #. Placeholder for search bar when on company page
 #. js-lingui-explicit-id
@@ -3468,10 +3406,9 @@ msgstr "Rechercher des listes..."
 
 #. Feature section 1 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:74
 #: src/components/Features.tsx:168
 msgid "home.features.s1.eyebrow"
-msgstr "Tout ce qu'il te faut pour garder une longueur d'avance"
+msgstr "Recherche précise"
 
 #. Placeholder for the main search bar
 #. js-lingui-explicit-id
@@ -3481,10 +3418,9 @@ msgstr "Rechercher…"
 
 #. Feature: application stats description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:89
 #: src/components/Features.tsx:252
 msgid "home.features.s2.p3.description"
-msgstr "Définis la fréquence par entreprise pour être informé des nouvelles offres sans scroller les sites d'emploi toute la journée."
+msgstr "Visualise ton funnel, tes taux de conversion et ta heatmap d'activité pour comprendre ce qui marche."
 
 #. Title for the seniority level selection modal
 #. js-lingui-explicit-id
@@ -3518,7 +3454,6 @@ msgstr "Sélectionne ta langue préférée."
 
 #. Step 4 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:67
 #: src/components/HowWeIndexContent.tsx:137
 msgid "indexing.ingestion.s4.title"
 msgstr "Stockage sélectif."
@@ -3535,16 +3470,16 @@ msgstr "Envoyer le lien"
 msgid "settings.account.password.send"
 msgstr "Envoyer le lien"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Envoi en cours..."
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
+msgstr "Envoi en cours..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
 msgstr "Envoi en cours..."
 
 #. Reset password button while loading
@@ -3597,7 +3532,6 @@ msgstr "Paramètres"
 
 #. Feature: share watchlists title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:98
 #: src/components/Features.tsx:312
 msgid "home.features.s3.p3.title"
 msgstr "Partager avec tout le monde"
@@ -3724,21 +3658,19 @@ msgstr "Entreprises similaires"
 
 #. Pricing section description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:103
 #: src/components/Pricing.tsx:106
 msgid "home.pricing.description"
 msgstr "Des tarifs simples et transparents. Commence gratuitement et passe à la vitesse supérieure quand ta recherche d'emploi devient sérieuse."
 
 #. Step 1 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:64
 #: src/components/HowWeIndexContent.tsx:113
 msgid "indexing.ingestion.s1.title"
 msgstr "Sitemap d'abord."
 
 #. Skip to main content link for keyboard users
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/layout.tsx:21
+#: app/[lang]/(public)/layout.tsx:25
 msgid "common.a11y.skipToContent"
 msgstr "Aller au contenu"
 
@@ -3816,10 +3748,9 @@ msgstr "Statut"
 
 #. Feature: status tracking title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:87
 #: src/components/Features.tsx:241
 msgid "home.features.s2.p1.title"
-msgstr "Colle un lien, lance un crawl"
+msgstr "Suivi du statut"
 
 #. Footer shown on the agent-prompt success card after 30 minutes of polling without seeing the run complete
 #. js-lingui-explicit-id
@@ -3859,7 +3790,7 @@ msgstr "Abonnement"
 
 #. FAQ page eyebrow
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/faq-content.tsx:39
+#: app/[lang]/(public)/faq/faq-content.tsx:36
 msgid "faq.eyebrow"
 msgstr "Support"
 
@@ -3887,16 +3818,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technique"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Technologies"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:673
 msgid "search.bar.technologies"
+msgstr "Technologies"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:397
+msgid "search.detail.technologies"
 msgstr "Technologies"
 
 #. Add technology filter
@@ -3931,75 +3862,70 @@ msgstr "Conditions d'utilisation"
 
 #. Footer link to terms of service page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:62
+#: src/components/Footer.tsx:67
 msgid "common.footer.termsLink"
 msgstr "CGU"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:18
-#: app/[lang]/(public)/terms/page.tsx:44
+#: app/[lang]/(public)/terms/page.tsx:17
+#: app/[lang]/(public)/terms/page.tsx:50
 msgid "terms.meta.title"
 msgstr "Conditions d'utilisation"
 
 #. Terms page title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:53
 #: src/components/TermsContent.tsx:22
 msgid "terms.hero.title"
 msgstr "Conditions d'utilisation"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:19
-#: app/[lang]/(public)/terms/page.tsx:45
+#: app/[lang]/(public)/terms/page.tsx:18
+#: app/[lang]/(public)/terms/page.tsx:51
 msgid "terms.meta.description"
 msgstr "Conditions d'utilisation de Job Seek — règles d'usage, propriété intellectuelle, responsabilités du compte, limitation de responsabilité et droit applicable."
 
 #. Body text shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:79
+#: app/[lang]/(app)/company/[slug]/page.tsx:92
 msgid "company.notFound.message"
 msgstr "L'entreprise que vous recherchez n'existe pas ou a été supprimée."
 
 #. About transparency paragraph
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:54
-#: app/[lang]/(public)/about/page.tsx:56
 msgid "about.transparency.p1"
 msgstr "Le code du crawler est open source pour que tout le monde puisse vérifier comment nous collectons les données. Nous respectons robots.txt, honorons les en-têtes TDM-Reservation et nous limitons à une requête par site par minute. Chaque lien sortant inclut utm_source=jobseek pour que les employeurs sachent d'où vient leur trafic."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:47
+#: app/[lang]/(public)/faq/page.tsx:53
 msgid "faq.a.howOftenUpdated"
 msgstr "Le crawler découvre de nouvelles offres selon un cycle horaire et actualise les détails quotidiennement. La plupart des postes apparaissent dans les heures suivant leur publication sur la page carrières d'une entreprise."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:87
+#: app/[lang]/(public)/faq/page.tsx:93
 msgid "faq.a.languages"
 msgstr "L'interface est disponible en anglais, allemand, français et italien. Vous pouvez également filtrer les offres d'emploi par la langue dans laquelle elles ont été rédigées."
 
 #. Body text on the 404 page
 #. js-lingui-explicit-id
-#: app/[lang]/not-found.tsx:17
+#: app/[lang]/not-found-content.tsx:17
 msgid "notFound.body"
 msgstr "La page que tu cherches n'existe pas ou a été déplacée."
 
 #. Provided as-is
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:60
 #: src/components/TermsContent.tsx:46
 msgid "terms.short.r4"
 msgstr "Le service est fourni tel quel, sans garantie."
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:55
 #: src/components/TermsContent.tsx:40
 msgid "terms.short.title"
 msgstr "En bref"
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:55
 #: src/components/PrivacyPolicyContent.tsx:40
 msgid "privacy.short.title"
 msgstr "En bref"
@@ -4042,27 +3968,24 @@ msgstr "Aujourd'hui"
 
 #. Main heading on the landing page — leads with company-watchlist ICP
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:71
 #: src/components/Hero.tsx:28
 msgid "home.hero.title"
 msgstr "Suis les entreprises pour lesquelles tu veux vraiment travailler."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:21
-#: app/[lang]/(public)/page.tsx:46
+#: app/[lang]/(public)/page.tsx:20
+#: app/[lang]/(public)/page.tsx:52
 msgid "home.meta.title"
 msgstr "Suis les entreprises pour lesquelles tu veux travailler — Job Seek"
 
 #. Feature section 2 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:83
 #: src/components/Features.tsx:229
 msgid "home.features.s2.eyebrow"
-msgstr "Garde le contrôle"
+msgstr "Suis ton pipeline"
 
 #. Open-source section body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:77
 #: src/components/HowWeIndexContent.tsx:188
 msgid "indexing.oss.body"
 msgstr "La transparence compte, c'est pourquoi le code de notre service de collecte de liens d'offres et de notre pipeline d'extraction est open source."
@@ -4070,7 +3993,6 @@ msgstr "La transparence compte, c'est pourquoi le code de notre service de colle
 #. About transparency section heading
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:50
-#: app/[lang]/(public)/about/page.tsx:55
 msgid "about.transparency.title"
 msgstr "Transparent par défaut"
 
@@ -4100,7 +4022,6 @@ msgstr "En développement actif"
 
 #. Your rights intro
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:64
 #: src/components/PrivacyPolicyContent.tsx:57
 msgid "privacy.rights.intro"
 msgstr "Selon le RGPD, tu peux demander une copie de tes données, les faire corriger ou supprimer, les exporter ou t'opposer au traitement. Supprime ton compte et tout est effacé sous 30 jours."
@@ -4109,17 +4030,16 @@ msgstr "Selon le RGPD, tu peux demander une copie de tes données, les faire cor
 #. js-lingui-explicit-id
 #: src/components/Pricing.tsx:81
 msgid "home.pricing.pro.f1"
-msgstr "Abonnements entreprises illimités"
+msgstr "Watchlists illimitées"
 
 #. Pro tier description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:77
 msgid "home.pricing.pro.description"
-msgstr "Pour les chercheurs d'emploi actifs qui veulent une portée illimitée et des informations plus rapides."
+msgstr "Watchlists illimitées avec alertes par e-mail pour ne jamais rater une ouverture."
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:95
+#: app/[lang]/layout.tsx:129
 msgid "app.schema.offer.pro"
 msgstr "Listes de suivi illimitées, alertes email sur les nouveaux résultats"
 
@@ -4178,7 +4098,7 @@ msgid "settings.billing.upgrading"
 msgstr "Mise à jour…"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:55
+#: app/[lang]/(public)/faq/page.tsx:61
 msgid "faq.a.requestCompany"
 msgstr "Utilisez le formulaire de demande sur la page Explorer — collez l'URL d'une page carrières ou un nom d'entreprise et nous lancerons l'indexation. Vous pouvez suivre la progression via le numéro d'issue que nous vous renvoyons."
 
@@ -4286,19 +4206,17 @@ msgstr "Listes de suivi"
 
 #. Feature: watchlists and alerts title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:80
 #: src/components/Features.tsx:190
 msgid "home.features.s1.p3.title"
-msgstr "Recherches enregistrées"
+msgstr "Watchlists et alertes"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:102
+#: app/[lang]/layout.tsx:136
 msgid "app.schema.feature.watchlists"
 msgstr "Listes de suivi et suivi des candidatures"
 
 #. What the service does
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:58
 #: src/components/TermsContent.tsx:44
 msgid "terms.short.r2"
 msgstr "Nous agrégeons des offres d'emploi publiques. Nous ne garantissons pas qu'elles soient exactes ou à jour."
@@ -4306,32 +4224,28 @@ msgstr "Nous agrégeons des offres d'emploi publiques. Nous ne garantissons pas 
 #. About paragraph 3: philosophy
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:43
-#: app/[lang]/(public)/about/page.tsx:54
 msgid "about.p3"
 msgstr "Nous pensons que la recherche d'emploi devrait être dirigée par la personne qui cherche, pas par un algorithme. Cela signifie : pas de bots d'auto-candidature, pas de flux optimisés pour l'engagement, et pas de vente de vos données. Vous choisissez les entreprises, vous définissez les filtres, vous suivez votre propre pipeline. L'outil reste en retrait."
 
 #. Privacy policy page description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:54
 #: src/components/PrivacyPolicyContent.tsx:23
 msgid "privacy.hero.description"
 msgstr "Nous ne collectons que le nécessaire, nous ne vendons pas tes données, et tu peux tout supprimer à tout moment."
 
 #. No selling
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:58
 #: src/components/PrivacyPolicyContent.tsx:44
 msgid "privacy.short.r2"
 msgstr "Nous ne vendons, ne louons et ne partageons pas tes données à des fins marketing."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:51
+#: app/[lang]/(public)/faq/page.tsx:57
 msgid "faq.a.differentiation"
 msgstr "Nous indexons les pages carrières des entreprises directement, pas des flux tiers. Pas de spam de recruteurs, pas d'annonces fantômes republiées, et nous revérifions les entreprises fréquemment — la plupart des postes apparaissent donc ici dans les heures suivant leur publication. Nous sommes conçus pour les utilisateurs qui savent déjà dans quelles entreprises ils veulent travailler, pas pour des recherches générales du type « trouve-moi n'importe quel job »."
 
 #. Step 1 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:64
 #: src/components/HowWeIndexContent.tsx:115
 msgid "indexing.ingestion.s1.body"
 msgstr "Nous recherchons un sitemap qui liste déjà toutes les pages carrières ou de détail des offres — idéalement lié depuis le fichier <0>robots.txt</0> — et nous nous y fions autant que possible."
@@ -4344,7 +4258,6 @@ msgstr "Nous recherchons des flux structurés avant de scraper du HTML brut. Nou
 
 #. Feature: direct from source description — no platform names, leads with the ICP differentiator
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:78
 #: src/components/Features.tsx:181
 msgid "home.features.s1.p1.description"
 msgstr "Nous surveillons les pages carrières directement, pas des flux tiers — les offres apparaissent ici dans les heures qui suivent, généralement avant que LinkedIn ou Indeed ne les relaient."
@@ -4363,13 +4276,12 @@ msgstr "Nous avons remarqué que cette offre a été ajoutée récemment. Certai
 
 #. Automation stance body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:74
 #: src/components/HowWeIndexContent.tsx:177
 msgid "indexing.automation.body"
 msgstr "Nous nous opposons à ce que les décisions de recrutement ou de recherche d'emploi soient confiées à une automatisation opaque — que ce soit côté employeur ou côté candidat. Chaque lien sortant que nous partageons inclut <0>utm_source=jobseek</0> afin que les recruteurs identifient le trafic, et nous examinons en permanence les schémas d'utilisation tout en imposant des frictions pour dissuader les candidatures automatisées."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:71
+#: app/[lang]/(public)/faq/page.tsx:77
 msgid "faq.a.crawlingPolicy"
 msgstr "Nous respectons robots.txt et les en-têtes TDM-Reservation, limitons les requêtes à une par site par minute et utilisons un backoff exponentiel. Toutes les requêtes s'identifient via le User-Agent. Consultez notre page d'indexation pour tous les détails."
 
@@ -4381,7 +4293,6 @@ msgstr "Nous avons envoyé un lien de vérification à <0>{email}</0>. Clique su
 
 #. What we store
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:57
 #: src/components/PrivacyPolicyContent.tsx:43
 msgid "privacy.short.r1"
 msgstr "Nous stockons ton nom, ton e-mail et ta photo de profil de ta connexion OAuth, ainsi que les données que tu crées dans l'appli."
@@ -4394,7 +4305,6 @@ msgstr "Nous encourageons vivement la publication d'un sitemap facilement décou
 
 #. Third parties
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:59
 #: src/components/PrivacyPolicyContent.tsx:45
 msgid "privacy.short.r3"
 msgstr "Nous utilisons quelques services tiers pour la connexion, l’hébergement et le stockage — rien d’autre."
@@ -4424,22 +4334,22 @@ msgid "auth.signIn.subtitle"
 msgstr "Content de te revoir"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:62
+#: app/[lang]/(public)/faq/page.tsx:68
 msgid "faq.q.whatIsWatchlist"
 msgstr "Qu'est-ce qu'une liste de suivi ?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:38
+#: app/[lang]/(public)/faq/page.tsx:44
 msgid "faq.q.whatIsJobseek"
 msgstr "Qu'est-ce que Job Seek ?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:50
+#: app/[lang]/(public)/faq/page.tsx:56
 msgid "faq.q.differentiation"
 msgstr "Qu'est-ce qui distingue Job Seek de LinkedIn ou Indeed ?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:58
+#: app/[lang]/(public)/faq/page.tsx:64
 msgid "faq.q.freeVsPro"
 msgstr "Quelle est la différence entre Gratuit et Pro ?"
 
@@ -4450,7 +4360,7 @@ msgid "app.home.request.heading"
 msgstr "Quelle entreprise devons-nous suivre ?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:86
+#: app/[lang]/(public)/faq/page.tsx:92
 msgid "faq.q.languages"
 msgstr "Quelles langues Jobseek prend-il en charge ?"
 
@@ -4477,17 +4387,17 @@ msgid "search.experienceModal.years"
 msgstr "ans"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:43
+#: app/[lang]/(public)/faq/page.tsx:49
 msgid "faq.a.targetedSeeker"
 msgstr "Oui — c'est précisément le cas d'usage pour lequel nous l'avons conçu. Ajoute les entreprises qui t'intéressent à une watchlist, définis tes filtres (poste, lieu, séniorité, salaire), et Job Seek surveille leurs pages carrières et te prévient dès qu'un nouveau poste correspond. Plus besoin de vérifier chaque site d'entreprise à la main ni de combattre l'algorithme de LinkedIn."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:75
+#: app/[lang]/(public)/faq/page.tsx:81
 msgid "faq.a.optOut"
 msgstr "Oui. Envoyez-nous un email et nous cesserons immédiatement de crawler votre site carrières et retirerons vos offres de l'index."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:79
+#: app/[lang]/(public)/faq/page.tsx:85
 msgid "faq.a.openSource"
 msgstr "Oui. Le crawler et le pipeline d'extraction sont entièrement open source sur GitHub. Le code de l'application est sous licence MIT ; les données d'emploi sont sous CC BY-NC 4.0."
 
@@ -4499,7 +4409,6 @@ msgstr "Hier"
 
 #. Account deletion
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:61
 #: src/components/TermsContent.tsx:47
 msgid "terms.short.r5"
 msgstr "Tu peux supprimer ton compte à tout moment."
@@ -4518,7 +4427,6 @@ msgstr "Vous pouvez accélérer en demandant à votre agent IA de l'effectuer vi
 
 #. MIT license summary
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:56
 #: src/components/LicenseContent.tsx:53
 msgid "license.code.summary"
 msgstr "Tu peux utiliser, modifier et redistribuer le code dans des produits personnels ou commerciaux à condition d'inclure la mention de droit d'auteur et de licence."
@@ -4531,14 +4439,12 @@ msgstr "Vous pourriez également être intéressé par"
 
 #. CC license summary
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:58
 #: src/components/LicenseContent.tsx:74
 msgid "license.data.summary"
 msgstr "Tu peux réutiliser le jeu de données d'emploi avec attribution à des fins non commerciales. Toute utilisation commerciale nécessite un accord écrit préalable."
 
 #. Age requirement
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:57
 #: src/components/TermsContent.tsx:43
 msgid "terms.short.r1"
 msgstr "Tu dois avoir au moins 16 ans pour utiliser Job Seek."
@@ -4575,7 +4481,6 @@ msgstr "Vous avez atteint la limite de vos listes de suivi. Passez à un plan su
 
 #. Feature section 3 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:92
 #: src/components/Features.tsx:290
 msgid "home.features.s3.eyebrow"
 msgstr "Vos entreprises, vos règles"
@@ -4594,7 +4499,6 @@ msgstr "Ton mot de passe a été réinitialisé. Tu peux maintenant te connecter
 
 #. Your rights section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:63
 #: src/components/PrivacyPolicyContent.tsx:54
 msgid "privacy.rights.title"
 msgstr "Tes droits"

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -39,8 +39,8 @@ msgstr "\"Viktor Shcherbakov, Collection of Job Postings\" con un link alla font
 #. Screen reader text for external links
 #. Screen reader text for external links
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:36
-#: src/components/Footer.tsx:42
+#: src/components/Footer.tsx:41
+#: src/components/Footer.tsx:47
 #: src/components/HowWeIndexContent.tsx:196
 #: src/components/LicenseContent.tsx:64
 #: src/components/LicenseContent.tsx:89
@@ -58,7 +58,7 @@ msgid "search.detail.showMoreLocations"
 msgstr "{0} in più"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:32
+#: app/[lang]/(app)/company/[slug]/page.tsx:39
 msgid "company.meta.positionCount"
 msgstr "{count, plural, one {# posizione aperta} other {# posizioni aperte}}"
 
@@ -87,7 +87,7 @@ msgid "blog.mention.watchlist.companiesLabel"
 msgstr "{count, plural, one {azienda} other {aziende}}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:98
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:103
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {# azienda monitorata} other {# aziende monitorate}}. {description}"
 
@@ -98,23 +98,23 @@ msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} candidature il {date}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:56
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:61
 msgid "watchlist.meta.moreCompanies"
 msgstr "altre {count}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:44
+#: app/[lang]/(app)/company/[slug]/page.tsx:51
 msgid "company.meta.descriptionBasic"
 msgstr "{countText} presso {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:39
+#: app/[lang]/(app)/company/[slug]/page.tsx:46
 msgid "company.meta.descriptionWithInfo"
 msgstr "{countText} presso {name}. {description}"
 
 #. Reading-time label shown in the blog post byline. {minutes} is the integer minute count.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:136
+#: app/[lang]/(public)/blog/[slug]/page.tsx:150
 msgid "blog.post.readingTime"
 msgstr "{minutes, plural, one {# min di lettura} other {# min di lettura}}"
 
@@ -152,7 +152,7 @@ msgstr "1 candidatura il {date}"
 #. js-lingui-explicit-id
 #: src/components/Pricing.tsx:45
 msgid "home.pricing.free.f2"
-msgstr "Tracker delle candidature"
+msgstr "1 watchlist"
 
 #. Heading for the 'install the Murmur MCP server' step on the agent-prompt success card
 #. js-lingui-explicit-id
@@ -167,13 +167,13 @@ msgid "app.home.request.agent.run_heading"
 msgstr "2. Esegui il prompt"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:63
+#: app/[lang]/(public)/faq/page.tsx:69
 msgid "faq.a.whatIsWatchlist"
 msgstr "Una watchlist è una ricerca salvata con filtro opzionale per azienda. Scegli le aziende che ti interessano, imposta i filtri (ruolo, località, seniority, stipendio) e ottieni un feed in tempo reale delle offerte corrispondenti. Puoi condividere le watchlist pubblicamente o mantenerle private."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/about/page.tsx:18
-#: app/[lang]/(public)/about/page.tsx:40
+#: app/[lang]/(public)/about/page.tsx:17
+#: app/[lang]/(public)/about/page.tsx:46
 msgid "about.meta.title"
 msgstr "Chi siamo"
 
@@ -287,7 +287,6 @@ msgstr "Prompt dell'agente"
 
 #. Encryption
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:61
 #: src/components/PrivacyPolicyContent.tsx:47
 msgid "privacy.short.r5"
 msgstr "Tutti i dati sono crittografati in transito e a riposo."
@@ -335,7 +334,7 @@ msgid "settings.account.username.taken"
 msgstr "Già in uso"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:19
+#: app/[lang]/(public)/faq/page.tsx:18
 msgid "faq.meta.description"
 msgstr "Risposte alle domande frequenti su Job Seek — come scansioniamo le pagine carriere, cosa includono i piani, come gestiamo i tuoi dati e come disiscriversi."
 
@@ -353,7 +352,6 @@ msgstr "Qualsiasi azienda"
 
 #. MIT license section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:55
 #: src/components/LicenseContent.tsx:50
 msgid "license.code.title"
 msgstr "Codice dell'applicazione (MIT License)"
@@ -364,18 +362,17 @@ msgstr "Codice dell'applicazione (MIT License)"
 msgid "license.toc.code"
 msgstr "Codice dell'applicazione (MIT)"
 
-#. Feature: application stats title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:89
-#: src/components/Features.tsx:251
-msgid "home.features.s2.p3.title"
-msgstr "Avvisi che controlli davvero"
-
 #. Link to application stats page
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:263
 msgid "myJobs.viewStats"
 msgstr "Statistiche candidature"
+
+#. Feature: application stats title
+#. js-lingui-explicit-id
+#: src/components/Features.tsx:251
+msgid "home.features.s2.p3.title"
+msgstr "Statistiche delle candidature"
 
 #. Stats page title
 #. js-lingui-explicit-id
@@ -393,7 +390,7 @@ msgstr "Monitoraggio candidatura"
 #. js-lingui-explicit-id
 #: src/components/Pricing.tsx:46
 msgid "home.pricing.free.f3"
-msgstr "Ricerche salvate"
+msgstr "Tracker delle candidature con registro dei colloqui"
 
 #. Subtitle showing total applications in past year
 #. js-lingui-explicit-id
@@ -457,7 +454,6 @@ msgstr "Apr"
 
 #. Step 3 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:66
 #: src/components/HowWeIndexContent.tsx:131
 msgid "indexing.ingestion.s3.body"
 msgstr "Come ultima risorsa analizziamo le pagine carriere stesse, preferendo l'ordine dal più recente e fermandoci non appena ricompaiono posizioni già indicizzate, anziché scansionare ogni pagina."
@@ -486,16 +482,16 @@ msgstr "Ago"
 msgid "settings.account.username.available"
 msgstr "Disponibile"
 
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Torna all'accesso"
-
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Torna all'accesso"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Torna all'accesso"
 
 #. Link back to sign-in from forgot password
@@ -522,22 +518,22 @@ msgstr "Torna su"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Comportamentale"
 
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:145
+msgid "blog.post.backToIndex"
+msgstr "Blog"
+
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:24
+#: app/[lang]/(public)/blog/page.tsx:27
 msgid "blog.meta.title"
 msgstr "Blog"
 
 #. <h1> on the blog index page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:69
+#: app/[lang]/(public)/blog/page.tsx:78
 msgid "blog.index.heading"
-msgstr "Blog"
-
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:131
-msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -550,7 +546,7 @@ msgstr "Blog"
 
 #. Footer link to /blog index page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:47
+#: src/components/Footer.tsx:52
 msgid "common.footer.blog"
 msgstr "Blog"
 
@@ -567,14 +563,13 @@ msgid "indexing.oss.browseRepo"
 msgstr "Consulta il repository su"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:22
-#: app/[lang]/(public)/page.tsx:47
+#: app/[lang]/(public)/page.tsx:21
+#: app/[lang]/(public)/page.tsx:53
 msgid "home.meta.description"
 msgstr "Crea watchlist delle aziende che ti interessano, ricevi avvisi via email quando si aprono nuove posizioni, e monitora le candidature in un unico posto. Le offerte arrivano direttamente dalle pagine carriere delle aziende, entro poche ore dalla pubblicazione — niente spam dei recruiter, nessun annuncio ripubblicato."
 
 #. Hero description paragraph — watchlist + alerts pitch with direct sourcing as supporting claim
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:72
 #: src/components/Hero.tsx:31
 msgid "home.hero.description"
 msgstr "Crea watchlist delle aziende che ti interessano, ricevi avvisi via email quando si aprono nuove posizioni, e monitora ogni candidatura in un unico posto. Monitoriamo le pagine carriere direttamente — le posizioni appaiono entro poche ore, prima che LinkedIn o Indeed le ripubblichino."
@@ -582,19 +577,17 @@ msgstr "Crea watchlist delle aziende che ti interessano, ricevi avvisi via email
 #. About page heading
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:25
-#: app/[lang]/(public)/about/page.tsx:51
 msgid "about.title"
 msgstr "Creato da chi cerca lavoro, per chi cerca lavoro"
 
 #. Terms page description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:54
 #: src/components/TermsContent.tsx:23
 msgid "terms.hero.description"
 msgstr "Utilizzando Job Seek accetti questi termini. Ecco un riassunto in parole semplici."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:74
+#: app/[lang]/(public)/faq/page.tsx:80
 msgid "faq.q.optOut"
 msgstr "Posso rifiutare l'indicizzazione della mia azienda da parte di Jobseek?"
 
@@ -646,17 +639,17 @@ msgstr "Cambia la tua password tramite un link email sicuro."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Cambia…"
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "Controlla la tua email"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
 msgstr "Controlla la tua e-mail"
+
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
+msgstr "Controlla la tua email"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -684,7 +677,6 @@ msgstr "Scegli il piano più adatto a te."
 
 #. Pricing section heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:102
 #: src/components/Pricing.tsx:103
 msgid "home.pricing.title"
 msgstr "Scegli il piano giusto per te"
@@ -743,7 +735,6 @@ msgstr "Clicca per rinominare"
 
 #. Step 2 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:65
 #: src/components/HowWeIndexContent.tsx:121
 msgid "indexing.ingestion.s2.title"
 msgstr "API client come seconda opzione."
@@ -774,21 +765,18 @@ msgstr "Coding"
 
 #. CC license section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:57
 #: src/components/LicenseContent.tsx:71
 msgid "license.data.title"
 msgstr "Raccolta di annunci di lavoro (CC BY-NC 4.0)"
 
 #. Feature: multi-dimensional filters description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:79
 #: src/components/Features.tsx:186
 msgid "home.features.s1.p2.description"
-msgstr "Annota dove ti sei candidato, lo stato, i contatti e i prossimi passi."
+msgstr "Combina seniority, tecnologie, stipendio, località e lingua dell'offerta in un'unica query. Niente più rumore da setacciare."
 
 #. Feature: focused search description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:96
 #: src/components/Features.tsx:303
 msgid "home.features.s3.p1.description"
 msgstr "Combina aziende specifiche con filtri per ruolo per individuare esattamente le posizioni che cerchi."
@@ -837,17 +825,17 @@ msgstr "Azienda"
 
 #. Heading shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:74
+#: app/[lang]/(app)/company/[slug]/page.tsx:87
 msgid "company.notFound.title"
 msgstr "Azienda non trovata"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:77
+#: app/[lang]/layout.tsx:111
 msgid "app.schema.description"
 msgstr "Strumento di tracciamento aziende per chi cerca lavoro e sa già in quali aziende vuole lavorare. Crea watchlist, ricevi avvisi via email quando si aprono nuove posizioni e monitora le candidature in un unico posto — annunci direttamente dalle pagine carriere delle aziende."
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:43
+#: app/[lang]/layout.tsx:76
 msgid "app.schema.org.description"
 msgstr "Strumento di tracciamento aziende per chi cerca lavoro in modo mirato — watchlist, avvisi via email e annunci direttamente dalle pagine carriere delle aziende. Creato da Colophon Group, un piccolo studio di sviluppatori in Svizzera."
 
@@ -875,16 +863,9 @@ msgstr "Collega"
 msgid "settings.account.socials.title"
 msgstr "Account collegati"
 
-#. Contact section title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:59
-#: src/components/LicenseContent.tsx:96
-msgid "license.contact.title"
-msgstr "Contatti"
-
 #. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:41
+#: src/components/Footer.tsx:46
 msgid "common.footer.contact"
 msgstr "Contatti"
 
@@ -892,6 +873,12 @@ msgstr "Contatti"
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:25
 msgid "license.toc.contact"
+msgstr "Contatti"
+
+#. Contact section title
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:96
+msgid "license.contact.title"
 msgstr "Contatti"
 
 #. Table of contents heading
@@ -938,7 +925,6 @@ msgstr "Freelance"
 
 #. Cookies
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:60
 #: src/components/PrivacyPolicyContent.tsx:46
 msgid "privacy.short.r4"
 msgstr "I cookie servono solo per la sessione — niente pubblicità, niente tracciamento."
@@ -987,17 +973,16 @@ msgstr "Paese"
 msgid "about.link.crawler"
 msgstr "Codice sorgente del crawler"
 
-#. Assurances section title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:55
-#: src/components/HowWeIndexContent.tsx:63
-msgid "indexing.assurances.title"
-msgstr "Garanzie di crawling"
-
 #. TOC: Crawling assurances
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:28
 msgid "indexing.toc.assurances"
+msgstr "Garanzie di crawling"
+
+#. Assurances section title
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:63
+msgid "indexing.assurances.title"
 msgstr "Garanzie di crawling"
 
 #. Label on the create watchlist card
@@ -1038,7 +1023,6 @@ msgstr "Creazione account..."
 
 #. Feature section 3 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:93
 #: src/components/Features.tsx:293
 msgid "home.features.s3.title"
 msgstr "Crea una watchlist per ogni nicchia"
@@ -1075,13 +1059,13 @@ msgstr "Scuro"
 
 #. Meta description (under 160 chars) for the blog index page — covers data analyses + report breakdowns + news commentary
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:29
+#: app/[lang]/(public)/blog/page.tsx:32
 msgid "blog.meta.description"
 msgstr "Analisi dei dati, novità e riepiloghi di report di settore — tratti dagli annunci di lavoro che monitoriamo nelle pagine carriere di migliaia di aziende."
 
 #. One-line tagline under the blog index <h1> — covers data analyses + reports/papers + news
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:74
+#: app/[lang]/(public)/blog/page.tsx:83
 msgid "blog.index.tagline"
 msgstr "Analisi dei dati, novità e riepiloghi di report e studi di settore — tratti dagli annunci di lavoro che monitoriamo."
 
@@ -1165,10 +1149,9 @@ msgstr "Non hai trovato l'azienda che cercavi?"
 
 #. Feature: direct from source title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:78
 #: src/components/Features.tsx:180
 msgid "home.features.s1.p1.title"
-msgstr "Avvisi aziendali"
+msgstr "Direttamente dalla fonte"
 
 #. Disable alerts tooltip
 #. js-lingui-explicit-id
@@ -1189,7 +1172,7 @@ msgid "watchlists.explore.publicTitle"
 msgstr "Scopri liste pubbliche"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:82
+#: app/[lang]/(public)/faq/page.tsx:88
 msgid "faq.q.dataPrivacy"
 msgstr "Jobseek vende i miei dati?"
 
@@ -1201,7 +1184,6 @@ msgstr "Non hai un account? <0>Registrati</0>"
 
 #. No scraping
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:59
 #: src/components/TermsContent.tsx:45
 msgid "terms.short.r3"
 msgstr "Niente scraping, candidature automatizzate o abuso della piattaforma."
@@ -1248,7 +1230,7 @@ msgstr "Segui aziende illimitatamente"
 #. js-lingui-explicit-id
 #: src/components/Pricing.tsx:82
 msgid "home.pricing.pro.f2"
-msgstr "Tracker delle candidature"
+msgstr "Avvisi email sui nuovi risultati"
 
 #. Email or username input label for sign-in
 #. js-lingui-explicit-id
@@ -1288,21 +1270,18 @@ msgstr "Inserisci la tua nuova password qui sotto."
 
 #. Assurance 3 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:59
 #: src/components/HowWeIndexContent.tsx:80
 msgid "indexing.assurances.i3.body"
 msgstr "Anche dopo la scoperta, recuperiamo le pagine di dettaglio degli annunci con un limite rigoroso di una richiesta per sito al minuto."
 
 #. Feature section 1 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:75
 #: src/components/Features.tsx:171
 msgid "home.features.s1.title"
-msgstr "Pensato per chi cerca lavoro attivamente"
+msgstr "Tutti i filtri di cui chi cerca lavoro ha davvero bisogno"
 
 #. Assurance 1 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:57
 #: src/components/HowWeIndexContent.tsx:68
 msgid "indexing.assurances.i1.body"
 msgstr "Ogni finestra di retry utilizza un backoff esponenziale, così non sovraccarichiamo mai un server, e ci fermiamo se un host continua a non rispondere."
@@ -1322,7 +1301,7 @@ msgstr "Avvisi e-mail per nuove offerte"
 #. FAQ page description
 #. js-lingui-explicit-id
 #. placeholder {0}: siteConfig.indexing.contactEmail
-#: app/[lang]/(public)/faq/faq-content.tsx:45
+#: app/[lang]/(public)/faq/faq-content.tsx:42
 msgid "faq.description"
 msgstr "Tutto quello che devi sapere su Job Seek. Non trovi quello che cerchi? Scrivici a <0>{0}</0>."
 
@@ -1412,7 +1391,7 @@ msgid "settings.account.username.error"
 msgstr "Impossibile aggiornare il nome utente"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:18
+#: app/[lang]/(public)/faq/page.tsx:17
 msgid "faq.meta.title"
 msgstr "FAQ"
 
@@ -1492,7 +1471,6 @@ msgstr "Cerca altre"
 
 #. Feature: focused search title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:96
 #: src/components/Features.tsx:302
 msgid "home.features.s3.p1.title"
 msgstr "Ricerca mirata"
@@ -1505,7 +1483,7 @@ msgstr "Seguici su LinkedIn"
 
 #. Aria label for footer navigation
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:31
+#: src/components/Footer.tsx:36
 msgid "common.footer.ariaLabel"
 msgstr "Piè di pagina"
 
@@ -1547,7 +1525,6 @@ msgstr "Fondata nel {year}"
 
 #. Free tier name
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:104
 #: src/components/Pricing.tsx:32
 msgid "home.pricing.free.name"
 msgstr "Gratis"
@@ -1559,14 +1536,13 @@ msgid "settings.billing.plan.free"
 msgstr "Gratuito"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:59
+#: app/[lang]/(public)/faq/page.tsx:65
 msgid "faq.a.freeVsPro"
 msgstr "La versione gratuita offre ricerca completa su tutte le aziende, una watchlist e il tracker delle candidature con registro dei colloqui. Pro aggiunge watchlist illimitate e avvisi email quando nuove offerte corrispondono ai tuoi criteri."
 
 #. FAQ page heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/faq-content.tsx:42
-#: app/[lang]/(public)/faq/page.tsx:109
+#: app/[lang]/(public)/faq/faq-content.tsx:39
 msgid "faq.title"
 msgstr "Domande frequenti"
 
@@ -1578,10 +1554,9 @@ msgstr "Ven"
 
 #. Feature section 2 heading
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:84
 #: src/components/Features.tsx:232
 msgid "home.features.s2.title"
-msgstr "Il primo aggregatore di lavoro che ti mette al volante"
+msgstr "Dalla posizione salvata all'offerta firmata, tutto in un unico posto"
 
 #. Free plan feature: search
 #. js-lingui-explicit-id
@@ -1590,16 +1565,15 @@ msgid "settings.billing.free.f2"
 msgstr "Ricerca lavoro completa"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:87
+#: app/[lang]/layout.tsx:121
 msgid "app.schema.offer.free"
 msgstr "Ricerca completa, 1 watchlist, tracker delle candidature"
 
 #. Free tier description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:104
 #: src/components/Pricing.tsx:41
 msgid "home.pricing.free.description"
-msgstr "Prova Job Seek con abbastanza spazio per restare aggiornato sulle aziende dei tuoi sogni."
+msgstr "Ricerca completa, una watchlist e un tracker delle candidature integrato per gestire la tua pipeline."
 
 #. Employment type: full-time
 #. js-lingui-explicit-id
@@ -1637,13 +1611,13 @@ msgstr "Inizia con Job Seek"
 
 #. Footer link to GitHub repo
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:35
+#: src/components/Footer.tsx:40
 msgid "common.footer.github"
 msgstr "GitHub"
 
 #. Link to return to the homepage from a 404 page
 #. js-lingui-explicit-id
-#: app/[lang]/not-found.tsx:22
+#: app/[lang]/not-found-content.tsx:22
 msgid "notFound.goHome"
 msgstr "Torna alla home"
 
@@ -1661,7 +1635,6 @@ msgstr "Capito"
 
 #. Step 3 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:66
 #: src/components/HowWeIndexContent.tsx:129
 msgid "indexing.ingestion.s3.title"
 msgstr "Parsing delle pagine delicato."
@@ -1697,32 +1670,25 @@ msgid "myJobs.salary.hourly"
 msgstr "Orario"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:54
+#: app/[lang]/(public)/faq/page.tsx:60
 msgid "faq.q.requestCompany"
 msgstr "Come posso richiedere un'azienda non presente nell'elenco?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:70
+#: app/[lang]/(public)/faq/page.tsx:76
 msgid "faq.q.crawlingPolicy"
 msgstr "Come si comporta il crawler sul sito della mia azienda?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:19
-#: app/[lang]/(public)/how-we-index/page.tsx:45
+#: app/[lang]/(public)/how-we-index/page.tsx:18
+#: app/[lang]/(public)/how-we-index/page.tsx:50
 msgid "indexing.meta.description"
 msgstr "Come Job Seek scopre e indicizza le offerte di lavoro: il nostro approccio di sourcing, frequenza di crawl, limiti di frequenza, conformità a robots.txt e TDM-Reservation, e come disattivare."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:46
+#: app/[lang]/(public)/faq/page.tsx:52
 msgid "faq.q.howOftenUpdated"
 msgstr "Con quale frequenza vengono aggiornate le offerte di lavoro?"
-
-#. Ingestion section title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:62
-#: src/components/HowWeIndexContent.tsx:104
-msgid "indexing.ingestion.title"
-msgstr "Come gli annunci entrano nell'indice"
 
 #. TOC: How postings enter the index
 #. js-lingui-explicit-id
@@ -1730,16 +1696,21 @@ msgstr "Come gli annunci entrano nell'indice"
 msgid "indexing.toc.ingestion"
 msgstr "Come gli annunci entrano nell'indice"
 
+#. Ingestion section title
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:104
+msgid "indexing.ingestion.title"
+msgstr "Come gli annunci entrano nell'indice"
+
 #. Indexing page title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:52
 #: src/components/HowWeIndexContent.tsx:48
 msgid "indexing.hero.title"
 msgstr "Come troviamo e processiamo gli annunci di lavoro"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:18
-#: app/[lang]/(public)/how-we-index/page.tsx:44
+#: app/[lang]/(public)/how-we-index/page.tsx:17
+#: app/[lang]/(public)/how-we-index/page.tsx:49
 msgid "indexing.meta.title"
 msgstr "Come indicizziamo"
 
@@ -1751,14 +1722,12 @@ msgstr "Se esiste un account per quell'indirizzo e-mail, abbiamo inviato un link
 
 #. Step 2 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:65
 #: src/components/HowWeIndexContent.tsx:123
 msgid "indexing.ingestion.s2.body"
 msgstr "Se non esiste una sitemap, ispezioniamo l'applicazione client alla ricerca di API JSON che utilizza; quando le troviamo, interroghiamo direttamente quegli endpoint per enumerare gli URL degli annunci senza fare scraping del DOM."
 
 #. Opt-out section body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:71
 #: src/components/HowWeIndexContent.tsx:164
 msgid "indexing.optOut.body"
 msgstr "Se noti attività impreviste del nostro crawler o preferisci che il tuo sito carriere non venga indicizzato, scrivici via email e risponderemo tempestivamente."
@@ -1770,7 +1739,7 @@ msgid "indexing.outreach.body"
 msgstr "Se noti un comportamento anomalo del crawler, preferisci che non indicizziamo i tuoi contenuti o hai suggerimenti su come migliorare le nostre misure di sicurezza, contattaci."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:72
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:77
 msgid "watchlist.meta.inLocations"
 msgstr "a {locations}"
 
@@ -1841,7 +1810,6 @@ msgstr "L'input è troppo corto."
 #. About paragraph 2: how it works — leads with direct sourcing and watchlist ICP, no platform listing
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:38
-#: app/[lang]/(public)/about/page.tsx:53
 msgid "about.p2"
 msgstr "Invece di aspettare che le aziende pubblichino le posizioni su portali di lavoro esterni, andiamo direttamente alla fonte. Il nostro crawler monitora migliaia di pagine carriere direttamente e le ricontrolla frequentemente, così le posizioni appaiono qui entro poche ore dalla pubblicazione — tipicamente prima che raggiungano i grandi aggregatori. Crea una watchlist delle aziende che ti interessano e ricevi una notifica nel momento in cui pubblicano."
 
@@ -1859,10 +1827,9 @@ msgstr "Colloquio"
 
 #. Feature: interview log title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:88
 #: src/components/Features.tsx:246
 msgid "home.features.s2.p2.title"
-msgstr "Basta con le 50 schede aperte"
+msgstr "Registro dei colloqui"
 
 #. Status group heading: interviewing
 #. js-lingui-explicit-id
@@ -1907,17 +1874,17 @@ msgid "auth.verify.error.invalidLink"
 msgstr "Link di verifica non valido"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:42
+#: app/[lang]/(public)/faq/page.tsx:48
 msgid "faq.q.targetedSeeker"
 msgstr "Job Seek fa per me se so già in quali aziende voglio lavorare?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:78
+#: app/[lang]/(public)/faq/page.tsx:84
 msgid "faq.q.openSource"
 msgstr "Il crawler è open source?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:66
+#: app/[lang]/(public)/faq/page.tsx:72
 msgid "faq.q.trackerLimit"
 msgstr "C'è un limite al numero di offerte che posso tracciare?"
 
@@ -1982,19 +1949,18 @@ msgid "home.features.s2.screenshot.alt"
 msgstr "Interfaccia Job Seek per inviare link aziendali e configurare avvisi personalizzati"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:39
+#: app/[lang]/(public)/faq/page.tsx:45
 msgid "faq.a.whatIsJobseek"
 msgstr "Job Seek ti aiuta a monitorare le aziende per cui vuoi davvero lavorare. Crea una watchlist, ricevi avvisi via email quando si aprono nuove posizioni, e monitora le candidature in un unico posto. Le offerte arrivano direttamente dalle pagine carriere delle aziende, così le vedi entro poche ore dalla pubblicazione — tipicamente prima che LinkedIn o Indeed le ripubblichino."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/about/page.tsx:19
-#: app/[lang]/(public)/about/page.tsx:41
+#: app/[lang]/(public)/about/page.tsx:18
+#: app/[lang]/(public)/about/page.tsx:47
 msgid "about.meta.description"
 msgstr "Job Seek ti aiuta a monitorare le aziende per cui vuoi lavorare — watchlist, avvisi via email e offerte direttamente dalle pagine carriere delle aziende. Creato da Colophon Group, un piccolo studio di sviluppatori in Svizzera."
 
 #. Indexing page description — company-tracking framing, not 'search engine'
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:53
 #: src/components/HowWeIndexContent.tsx:51
 msgid "indexing.hero.description"
 msgstr "Job Seek è uno strumento di tracciamento aziende — monitora migliaia di pagine carriere aziendali in modo che gli utenti possano creare watchlist e ricevere avvisi su nuovi annunci. Questa pagina documenta esattamente come si comporta il nostro crawler, i controlli che lo rendono rispettoso e come gli annunci finiscono nell'indice."
@@ -2008,13 +1974,12 @@ msgstr "Job Seek è in fase di sviluppo attivo. Resta aggiornato per le novità!
 #. About paragraph 1: who we are
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:26
-#: app/[lang]/(public)/about/page.tsx:52
 msgid "about.p1"
 msgstr "Job Seek è sviluppato da Colophon Group, un piccolo team di sviluppatori con sede in Svizzera. L'abbiamo creato perché eravamo stanchi dello stesso problema che ogni persona in cerca di lavoro conosce: destreggiarsi tra decine di schede del browser, perdere nuove offerte perché un aggregatore era troppo lento, e annegare nel rumore algoritmico ottimizzato per i clic anziché per la rilevanza."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:19
-#: app/[lang]/(public)/privacy-policy/page.tsx:45
+#: app/[lang]/(public)/privacy-policy/page.tsx:18
+#: app/[lang]/(public)/privacy-policy/page.tsx:51
 msgid "privacy.meta.description"
 msgstr "Informativa sulla privacy di Job Seek — dati personali raccolti, utilizzo, diritti GDPR, politica sui cookie e come richiedere la cancellazione dell'account."
 
@@ -2032,13 +1997,12 @@ msgstr "Watchlist di Job Seek con posizioni selezionate in ingegneria robotica a
 
 #. License page description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:54
 #: src/components/LicenseContent.tsx:38
 msgid "license.hero.description"
 msgstr "Il codice sorgente di Job Seek è open source sotto licenza MIT. I dati sugli annunci che raccogliamo e arricchiamo sono Creative Commons BY-NC 4.0. Di seguito il riepilogo in linguaggio semplice — si prega di leggere le licenze complete per i termini esatti."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:80
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:85
 msgid "watchlist.meta.fallback"
 msgstr "Lista lavori di @{owner}"
 
@@ -2055,12 +2019,12 @@ msgid "watchlists.explore.jobPlural"
 msgstr "offerte"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:25
+#: app/[lang]/(app)/company/[slug]/page.tsx:32
 msgid "company.meta.title"
 msgstr "Lavori presso {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:62
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:67
 msgid "watchlist.meta.jobsAt"
 msgstr "Lavori presso {names}"
 
@@ -2108,14 +2072,14 @@ msgstr "Ultima ora"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:28
-msgid "privacy.hero.lastUpdated"
+#: src/components/TermsContent.tsx:28
+msgid "terms.hero.lastUpdated"
 msgstr "Ultimo aggiornamento:"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:28
-msgid "terms.hero.lastUpdated"
+#: src/components/PrivacyPolicyContent.tsx:28
+msgid "privacy.hero.lastUpdated"
 msgstr "Ultimo aggiornamento:"
 
 #. Time range option: last week
@@ -2130,21 +2094,21 @@ msgstr "Ultima settimana"
 msgid "home.hero.secondaryCta"
 msgstr "Scopri di più"
 
-#. Label for seniority/level filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:154
-msgid "search.advanced.level"
-msgstr "Livello"
-
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:638
 msgid "search.bar.level"
 msgstr "Livello"
 
+#. Label for seniority/level filter in advanced search
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:18
-#: app/[lang]/(public)/license/page.tsx:45
+#: src/components/search/advanced-search-panel.tsx:154
+msgid "search.advanced.level"
+msgstr "Livello"
+
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/license/page.tsx:17
+#: app/[lang]/(public)/license/page.tsx:51
 msgid "license.meta.title"
 msgstr "Licenza"
 
@@ -2156,13 +2120,12 @@ msgstr "Licenza"
 
 #. Footer link to license page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
+#: src/components/Footer.tsx:57
 msgid "common.footer.licenseLink"
 msgstr "Licenza"
 
 #. License page title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:53
 #: src/components/LicenseContent.tsx:37
 msgid "license.hero.title"
 msgstr "Licenza di Job Seek"
@@ -2174,8 +2137,8 @@ msgid "license.hero.eyebrow"
 msgstr "Licenze"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:19
-#: app/[lang]/(public)/license/page.tsx:46
+#: app/[lang]/(public)/license/page.tsx:18
+#: app/[lang]/(public)/license/page.tsx:52
 msgid "license.meta.description"
 msgstr "Licenze di Job Seek — il codice sorgente è sotto licenza MIT, le offerte di lavoro sotto CC BY-NC 4.0. Scopri cosa puoi fare con il nostro codice e i nostri dati."
 
@@ -2209,17 +2172,17 @@ msgstr "Luogo"
 msgid "search.advanced.location"
 msgstr "Luogo"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
-msgstr "Località"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:708
 msgid "search.bar.locations"
 msgstr "Sedi"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:312
+msgid "search.detail.locations"
+msgstr "Località"
 
 #. Login button label
 #. Login button label
@@ -2243,7 +2206,6 @@ msgstr "Accedi per salvare questa ricerca come watchlist"
 
 #. Feature: share watchlists description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:98
 #: src/components/Features.tsx:313
 msgid "home.features.s3.p3.description"
 msgstr "Rendi una watchlist pubblica e condividi il link con amici, community o il tuo network."
@@ -2348,7 +2310,6 @@ msgstr "copie"
 
 #. Feature: request companies description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:97
 #: src/components/Features.tsx:308
 msgid "home.features.s3.p2.description"
 msgstr "Manca un'azienda? Incolla l'URL della sua pagina carriere e iniziamo a indicizzarla per te."
@@ -2360,7 +2321,7 @@ msgid "myJobs.heatmap.day.mon"
 msgstr "Lun"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:99
+#: app/[lang]/layout.tsx:133
 msgid "app.schema.feature.monitor"
 msgstr "Monitorare le pagine carriere delle aziende"
 
@@ -2384,20 +2345,18 @@ msgstr "altro"
 
 #. Feature: status tracking description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:87
 #: src/components/Features.tsx:242
 msgid "home.features.s2.p1.description"
-msgstr "Indicaci qualsiasi pagina carriere o job board su Notion e Job Seek la replica nel tuo spazio di lavoro in pochi minuti."
+msgstr "Sposta ogni posizione da salvata a candidata, in colloquio, offerta ricevuta o rifiutata. Sai sempre a che punto sei."
 
 #. Feature: multi-dimensional filters title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:79
 #: src/components/Features.tsx:185
 msgid "home.features.s1.p2.title"
-msgstr "Tracker delle candidature"
+msgstr "Filtri multidimensionali"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:101
+#: app/[lang]/layout.tsx:135
 msgid "app.schema.feature.languages"
 msgstr "Supporto multilingue"
 
@@ -2523,7 +2482,7 @@ msgstr "Nessun annuncio corrispondente trovato."
 
 #. Empty-state message shown when no blog posts have been published yet
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:79
+#: app/[lang]/(public)/blog/page.tsx:88
 msgid "blog.index.empty"
 msgstr "Ancora nessun articolo — torna presto."
 
@@ -2582,12 +2541,12 @@ msgid "watchlists.page.empty"
 msgstr "Nessuna lista di osservazione. Creane una per seguire le offerte delle tue aziende preferite."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:67
+#: app/[lang]/(public)/faq/page.tsx:73
 msgid "faq.a.trackerLimit"
 msgstr "No. Il tracker delle candidature non ha limiti — salva quante offerte vuoi e spostale nella tua pipeline."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:83
+#: app/[lang]/(public)/faq/page.tsx:89
 msgid "faq.a.dataPrivacy"
 msgstr "No. Non vendiamo, affittiamo né condividiamo i tuoi dati a fini di marketing. I cookie sono solo di sessione, senza pubblicità né tracciamento. Puoi eliminare il tuo account e tutti i dati verranno cancellati entro 30 giorni."
 
@@ -2665,14 +2624,12 @@ msgstr "Ok"
 
 #. Step 4 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:67
 #: src/components/HowWeIndexContent.tsx:139
 msgid "indexing.ingestion.s4.body"
 msgstr "Una volta recuperato un singolo annuncio, memorizziamo solo i metadati specifici della posizione (titolo, descrizione del ruolo, sede, note sulla retribuzione, URL dell'annuncio e date) oltre ai campi strutturati estratti. Non archiviamo contenuti del sito non correlati."
 
 #. Assurance 3 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:59
 #: src/components/HowWeIndexContent.tsx:79
 msgid "indexing.assurances.i3.title"
 msgstr "Una pagina al minuto."
@@ -2696,16 +2653,9 @@ msgid "common.header.openMenu"
 msgstr "Apri menu principale"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:37
+#: app/[lang]/(app)/company/[slug]/page.tsx:44
 msgid "company.meta.openPositions"
 msgstr "Posizioni aperte"
-
-#. Open-source section title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:76
-#: src/components/HowWeIndexContent.tsx:185
-msgid "indexing.oss.title"
-msgstr "Crawler open source"
 
 #. TOC: Open-source crawlers
 #. js-lingui-explicit-id
@@ -2713,17 +2663,22 @@ msgstr "Crawler open source"
 msgid "indexing.toc.oss"
 msgstr "Crawler open source"
 
-#. Opt-out section title
+#. Open-source section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:70
-#: src/components/HowWeIndexContent.tsx:161
-msgid "indexing.optOut.title"
-msgstr "Opt-out o domande"
+#: src/components/HowWeIndexContent.tsx:185
+msgid "indexing.oss.title"
+msgstr "Crawler open source"
 
 #. TOC: Opt-out or questions
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:30
 msgid "indexing.toc.optOut"
+msgstr "Opt-out o domande"
+
+#. Opt-out section title
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:161
+msgid "indexing.optOut.title"
 msgstr "Opt-out o domande"
 
 #. Divider between form and OAuth buttons
@@ -2746,22 +2701,20 @@ msgstr "Altro"
 
 #. Assurance 2 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:58
 #: src/components/HowWeIndexContent.tsx:73
 msgid "indexing.assurances.i2.body"
 msgstr "Il nostro crawler legge il file <0>robots.txt</0>, rispetta le regole di disallow, si identifica tramite <1>User-Agent</1> e rispetta l'header W3C <2>TDM-Reservation</2> — se una pagina segnala una riserva, la saltiamo."
-
-#. Automation stance title
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:73
-#: src/components/HowWeIndexContent.tsx:174
-msgid "indexing.automation.title"
-msgstr "La nostra posizione sull'automazione"
 
 #. TOC: Our stance on automation
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:31
 msgid "indexing.toc.automation"
+msgstr "La nostra posizione sull'automazione"
+
+#. Automation stance title
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:174
+msgid "indexing.automation.title"
 msgstr "La nostra posizione sull'automazione"
 
 #. TOC: Overview
@@ -2790,7 +2743,7 @@ msgstr "Contenuti della pagina"
 
 #. Heading shown on the 404 page
 #. js-lingui-explicit-id
-#: app/[lang]/not-found.tsx:12
+#: app/[lang]/not-found-content.tsx:12
 msgid "notFound.title"
 msgstr "Pagina non trovata"
 
@@ -2858,7 +2811,6 @@ msgstr "Periodo"
 
 #. Pro tier period
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:73
 msgid "home.pricing.pro.period"
 msgstr "al mese"
@@ -2889,7 +2841,6 @@ msgstr "Colloquio telefonico"
 
 #. Feature section 3 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:94
 #: src/components/Features.tsx:296
 msgid "home.features.s3.description"
 msgstr "Scegli le aziende che ti interessano, imposta i filtri e ottieni un feed in tempo reale delle offerte corrispondenti. Condividilo pubblicamente o tienilo privato."
@@ -2978,19 +2929,18 @@ msgstr "Offerta non trovata."
 msgid "myJobs.detail.notFound"
 msgstr "Offerta non trovata."
 
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:101
-#: src/components/Pricing.tsx:100
-msgid "home.pricing.eyebrow"
-msgstr "Prezzi"
-
 #. Nav link: Pricing
 #. Nav link: Pricing
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:62
 #: src/components/MobileMenu.tsx:87
 msgid "common.nav.pricing"
+msgstr "Prezzi"
+
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:100
+msgid "home.pricing.eyebrow"
 msgstr "Prezzi"
 
 #. Privacy policy page eyebrow
@@ -3001,20 +2951,19 @@ msgstr "Privacy"
 
 #. Footer link to privacy policy page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:57
+#: src/components/Footer.tsx:62
 msgid "common.footer.privacyLink"
 msgstr "Privacy"
 
 #. Privacy policy page title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:53
 #: src/components/PrivacyPolicyContent.tsx:22
 msgid "privacy.hero.title"
 msgstr "Privacy su Job Seek"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:18
-#: app/[lang]/(public)/privacy-policy/page.tsx:44
+#: app/[lang]/(public)/privacy-policy/page.tsx:17
+#: app/[lang]/(public)/privacy-policy/page.tsx:50
 msgid "privacy.meta.title"
 msgstr "Informativa sulla privacy"
 
@@ -3026,7 +2975,6 @@ msgstr "Le liste private sono una funzionalità a pagamento. Effettua l'upgrade 
 
 #. Pro tier name
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:68
 msgid "home.pricing.pro.name"
 msgstr "Pro"
@@ -3045,21 +2993,18 @@ msgstr "Pubblico dominio"
 
 #. Contact call to action
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:60
 #: src/components/LicenseContent.tsx:99
 msgid "license.contactCta"
 msgstr "Domande sulle licenze o sull'uso commerciale? Scrivici via email."
 
 #. Terms contact call to action
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:63
 #: src/components/TermsContent.tsx:54
 msgid "terms.contact.description"
 msgstr "Domande? Scrivici."
 
 #. Privacy contact call to action
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:65
 #: src/components/PrivacyPolicyContent.tsx:66
 msgid "privacy.contact.description"
 msgstr "Domande? Scrivici."
@@ -3089,7 +3034,7 @@ msgid "terms.fullTermsLink"
 msgstr "Leggi i termini di servizio completi"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:100
+#: app/[lang]/layout.tsx:134
 msgid "app.schema.feature.alerts"
 msgstr "Avvisi in tempo reale sulle nuove offerte"
 
@@ -3101,10 +3046,9 @@ msgstr "Aggiornati di recente"
 
 #. Feature: interview log description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:88
 #: src/components/Features.tsx:247
 msgid "home.features.s2.p2.description"
-msgstr "Raccogli tutte le startup interessanti in un'unica dashboard invece di destreggiarti tra finestre di Chrome e segnalibri."
+msgstr "Registra ogni round di colloquio con data, tipo e note così non ti sfugge nulla."
 
 #. MIT right 2
 #. js-lingui-explicit-id
@@ -3156,7 +3100,7 @@ msgstr "Rifiutato"
 
 #. Footer license summary text
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:24
+#: src/components/Footer.tsx:29
 msgid "common.footer.text"
 msgstr "Rilasciato sotto licenza MIT. I dati sugli annunci sono CC BY-NC 4.0."
 
@@ -3186,7 +3130,6 @@ msgstr "Richiedi un'azienda"
 
 #. Feature: request companies title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:97
 #: src/components/Features.tsx:307
 msgid "home.features.s3.p2.title"
 msgstr "Richiedi qualsiasi azienda"
@@ -3247,14 +3190,12 @@ msgstr "Reimpostazione…"
 
 #. Assurance 1 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:57
 #: src/components/HowWeIndexContent.tsx:67
 msgid "indexing.assurances.i1.title"
 msgstr "Ritmo rispettoso."
 
 #. Assurance 2 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:58
 #: src/components/HowWeIndexContent.tsx:71
 msgid "indexing.assurances.i2.title"
 msgstr "Robot, attribuzione e riserva TDM."
@@ -3309,17 +3250,15 @@ msgstr "Fascia salariale"
 
 #. Feature section 2 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:85
 #: src/components/Features.tsx:235
 msgid "home.features.s2.description"
-msgstr "Non trovi la tua azienda preferita nel feed? Incolla il link alla pagina carriere e inizieremo a monitorarla per te — niente script, niente fogli di calcolo, niente attese."
+msgstr "Salva qualsiasi posizione che trovi, falla avanzare nella tua pipeline mentre ti candidi e fai colloqui, e vedi a colpo d'occhio a che punto è ogni candidatura."
 
 #. Feature: watchlists and alerts description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:80
 #: src/components/Features.tsx:191
 msgid "home.features.s1.p3.description"
-msgstr "Salva i tuoi filtri per scansioni rapide senza dover riscrivere tutto ogni volta."
+msgstr "Salva qualsiasi ricerca come watchlist e ricevi avvisi via email quando nuove posizioni corrispondono ai tuoi criteri."
 
 #. Save job aria label
 #. js-lingui-explicit-id
@@ -3391,14 +3330,13 @@ msgstr "Salvataggio…"
 #. js-lingui-explicit-id
 #: src/components/Pricing.tsx:44
 msgid "home.pricing.free.f1"
-msgstr "Segui fino a 5 aziende"
+msgstr "Ricerca su tutte le aziende e tutti i filtri"
 
 #. Feature section 1 description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:76
 #: src/components/Features.tsx:174
 msgid "home.features.s1.description"
-msgstr "Monitora le posizioni, ricevi notifiche quando le aziende pubblicano qualcosa di nuovo e tieni in ordine la tua pipeline."
+msgstr "Cerca tra migliaia di aziende prese direttamente dalle loro pagine carriere. Filtra per seniority, tech stack, fascia salariale, località e lingua — tutto in un'unica ricerca."
 
 #. Placeholder for search bar when on company page
 #. js-lingui-explicit-id
@@ -3468,10 +3406,9 @@ msgstr "Cerca liste..."
 
 #. Feature section 1 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:74
 #: src/components/Features.tsx:168
 msgid "home.features.s1.eyebrow"
-msgstr "Tutto ciò che ti serve per restare al passo"
+msgstr "Cerca con precisione"
 
 #. Placeholder for the main search bar
 #. js-lingui-explicit-id
@@ -3481,10 +3418,9 @@ msgstr "Cerca…"
 
 #. Feature: application stats description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:89
 #: src/components/Features.tsx:252
 msgid "home.features.s2.p3.description"
-msgstr "Imposta la frequenza per ogni azienda così ricevi aggiornamenti sulle nuove posizioni senza passare la giornata a scorrere siti di lavoro."
+msgstr "Visualizza il tuo funnel, i tassi di conversione e la heatmap delle attività per capire cosa funziona."
 
 #. Title for the seniority level selection modal
 #. js-lingui-explicit-id
@@ -3518,7 +3454,6 @@ msgstr "Seleziona la lingua preferita."
 
 #. Step 4 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:67
 #: src/components/HowWeIndexContent.tsx:137
 msgid "indexing.ingestion.s4.title"
 msgstr "Archiviazione selettiva."
@@ -3535,16 +3470,16 @@ msgstr "Invia link"
 msgid "settings.account.password.send"
 msgstr "Invia il link"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Invio in corso..."
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
+msgstr "Invio in corso..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
 msgstr "Invio in corso..."
 
 #. Reset password button while loading
@@ -3597,7 +3532,6 @@ msgstr "Impostazioni"
 
 #. Feature: share watchlists title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:98
 #: src/components/Features.tsx:312
 msgid "home.features.s3.p3.title"
 msgstr "Condividi con chiunque"
@@ -3724,21 +3658,19 @@ msgstr "Aziende simili"
 
 #. Pricing section description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:103
 #: src/components/Pricing.tsx:106
 msgid "home.pricing.description"
 msgstr "Prezzi semplici e trasparenti. Inizia gratis e passa al piano superiore quando fai sul serio con la tua ricerca di lavoro."
 
 #. Step 1 title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:64
 #: src/components/HowWeIndexContent.tsx:113
 msgid "indexing.ingestion.s1.title"
 msgstr "Prima la sitemap."
 
 #. Skip to main content link for keyboard users
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/layout.tsx:21
+#: app/[lang]/(public)/layout.tsx:25
 msgid "common.a11y.skipToContent"
 msgstr "Vai al contenuto"
 
@@ -3816,10 +3748,9 @@ msgstr "Stato"
 
 #. Feature: status tracking title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:87
 #: src/components/Features.tsx:241
 msgid "home.features.s2.p1.title"
-msgstr "Incolla un link, avvia il crawling"
+msgstr "Tracciamento dello stato"
 
 #. Footer shown on the agent-prompt success card after 30 minutes of polling without seeing the run complete
 #. js-lingui-explicit-id
@@ -3859,7 +3790,7 @@ msgstr "Abbonamento"
 
 #. FAQ page eyebrow
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/faq-content.tsx:39
+#: app/[lang]/(public)/faq/faq-content.tsx:36
 msgid "faq.eyebrow"
 msgstr "Supporto"
 
@@ -3887,16 +3818,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Tecnico"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Tecnologie"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:673
 msgid "search.bar.technologies"
+msgstr "Tecnologie"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:397
+msgid "search.detail.technologies"
 msgstr "Tecnologie"
 
 #. Add technology filter
@@ -3931,75 +3862,70 @@ msgstr "Termini di servizio"
 
 #. Footer link to terms of service page
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:62
+#: src/components/Footer.tsx:67
 msgid "common.footer.termsLink"
 msgstr "Termini"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:18
-#: app/[lang]/(public)/terms/page.tsx:44
+#: app/[lang]/(public)/terms/page.tsx:17
+#: app/[lang]/(public)/terms/page.tsx:50
 msgid "terms.meta.title"
 msgstr "Termini di servizio"
 
 #. Terms page title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:53
 #: src/components/TermsContent.tsx:22
 msgid "terms.hero.title"
 msgstr "Termini di servizio"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:19
-#: app/[lang]/(public)/terms/page.tsx:45
+#: app/[lang]/(public)/terms/page.tsx:18
+#: app/[lang]/(public)/terms/page.tsx:51
 msgid "terms.meta.description"
 msgstr "Termini di servizio di Job Seek — regole d'uso, proprietà intellettuale, responsabilità dell'account, limitazione di responsabilità e legge applicabile."
 
 #. Body text shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:79
+#: app/[lang]/(app)/company/[slug]/page.tsx:92
 msgid "company.notFound.message"
 msgstr "L'azienda che stai cercando non esiste o è stata rimossa."
 
 #. About transparency paragraph
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:54
-#: app/[lang]/(public)/about/page.tsx:56
 msgid "about.transparency.p1"
 msgstr "Il codice del crawler è open source, così chiunque può verificare come raccogliamo i dati. Rispettiamo robots.txt, onoriamo gli header TDM-Reservation e ci limitiamo a una richiesta per sito al minuto. Ogni link in uscita include utm_source=jobseek, così i datori di lavoro sanno da dove arriva il traffico."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:47
+#: app/[lang]/(public)/faq/page.tsx:53
 msgid "faq.a.howOftenUpdated"
 msgstr "Il crawler scopre nuove offerte con un ciclo orario e aggiorna i dettagli quotidianamente. La maggior parte delle posizioni appare entro poche ore dalla pubblicazione sulla pagina carriere di un'azienda."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:87
+#: app/[lang]/(public)/faq/page.tsx:93
 msgid "faq.a.languages"
 msgstr "L'interfaccia è disponibile in inglese, tedesco, francese e italiano. Puoi anche filtrare le offerte di lavoro per la lingua in cui sono state scritte."
 
 #. Body text on the 404 page
 #. js-lingui-explicit-id
-#: app/[lang]/not-found.tsx:17
+#: app/[lang]/not-found-content.tsx:17
 msgid "notFound.body"
 msgstr "La pagina che stai cercando non esiste o è stata spostata."
 
 #. Provided as-is
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:60
 #: src/components/TermsContent.tsx:46
 msgid "terms.short.r4"
 msgstr "Il servizio è fornito così com'è, senza garanzie."
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:55
 #: src/components/TermsContent.tsx:40
 msgid "terms.short.title"
 msgstr "In breve"
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:55
 #: src/components/PrivacyPolicyContent.tsx:40
 msgid "privacy.short.title"
 msgstr "In breve"
@@ -4042,27 +3968,24 @@ msgstr "Oggi"
 
 #. Main heading on the landing page — leads with company-watchlist ICP
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:71
 #: src/components/Hero.tsx:28
 msgid "home.hero.title"
 msgstr "Monitora le aziende per cui vuoi davvero lavorare."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:21
-#: app/[lang]/(public)/page.tsx:46
+#: app/[lang]/(public)/page.tsx:20
+#: app/[lang]/(public)/page.tsx:52
 msgid "home.meta.title"
 msgstr "Monitora le aziende per cui vuoi lavorare — Job Seek"
 
 #. Feature section 2 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:83
 #: src/components/Features.tsx:229
 msgid "home.features.s2.eyebrow"
-msgstr "Mantieni il controllo"
+msgstr "Monitora la tua pipeline"
 
 #. Open-source section body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:77
 #: src/components/HowWeIndexContent.tsx:188
 msgid "indexing.oss.body"
 msgstr "La trasparenza è importante, perciò il codice del nostro servizio di raccolta link e della pipeline di estrazione è open source."
@@ -4070,7 +3993,6 @@ msgstr "La trasparenza è importante, perciò il codice del nostro servizio di r
 #. About transparency section heading
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:50
-#: app/[lang]/(public)/about/page.tsx:55
 msgid "about.transparency.title"
 msgstr "Trasparente per impostazione predefinita"
 
@@ -4100,7 +4022,6 @@ msgstr "In fase di sviluppo"
 
 #. Your rights intro
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:64
 #: src/components/PrivacyPolicyContent.tsx:57
 msgid "privacy.rights.intro"
 msgstr "Secondo il GDPR puoi richiedere una copia dei tuoi dati, farli correggere o cancellare, esportarli o opporti al trattamento. Elimina il tuo account e tutto viene cancellato entro 30 giorni."
@@ -4109,17 +4030,16 @@ msgstr "Secondo il GDPR puoi richiedere una copia dei tuoi dati, farli corregger
 #. js-lingui-explicit-id
 #: src/components/Pricing.tsx:81
 msgid "home.pricing.pro.f1"
-msgstr "Abbonamenti aziendali illimitati"
+msgstr "Watchlist illimitate"
 
 #. Pro tier description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:105
 #: src/components/Pricing.tsx:77
 msgid "home.pricing.pro.description"
-msgstr "Per chi cerca lavoro attivamente e vuole una copertura illimitata e risultati più rapidi."
+msgstr "Watchlist illimitate con avvisi via email così non perdi mai un'apertura."
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:95
+#: app/[lang]/layout.tsx:129
 msgid "app.schema.offer.pro"
 msgstr "Watchlist illimitate, avvisi email sui nuovi risultati"
 
@@ -4178,7 +4098,7 @@ msgid "settings.billing.upgrading"
 msgstr "Aggiornamento…"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:55
+#: app/[lang]/(public)/faq/page.tsx:61
 msgid "faq.a.requestCompany"
 msgstr "Usa il modulo di richiesta nella pagina Esplora — incolla l'URL di una pagina carriere o il nome dell'azienda e inizieremo l'indicizzazione. Puoi seguire i progressi tramite il numero di issue che ti restituiamo."
 
@@ -4286,19 +4206,17 @@ msgstr "Liste di osservazione"
 
 #. Feature: watchlists and alerts title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:80
 #: src/components/Features.tsx:190
 msgid "home.features.s1.p3.title"
-msgstr "Ricerche salvate"
+msgstr "Watchlist e avvisi"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:102
+#: app/[lang]/layout.tsx:136
 msgid "app.schema.feature.watchlists"
 msgstr "Watchlist e tracciamento delle candidature"
 
 #. What the service does
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:58
 #: src/components/TermsContent.tsx:44
 msgid "terms.short.r2"
 msgstr "Aggreghiamo offerte di lavoro pubbliche. Non garantiamo che siano accurate o aggiornate."
@@ -4306,32 +4224,28 @@ msgstr "Aggreghiamo offerte di lavoro pubbliche. Non garantiamo che siano accura
 #. About paragraph 3: philosophy
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:43
-#: app/[lang]/(public)/about/page.tsx:54
 msgid "about.p3"
 msgstr "Crediamo che la ricerca di lavoro debba essere guidata dalla persona che cerca, non da un algoritmo. Questo significa: niente bot per candidature automatiche, niente feed ottimizzati per l'engagement e niente vendita dei tuoi dati. Tu scegli le aziende, tu definisci i filtri, tu gestisci la tua pipeline. Lo strumento resta in secondo piano."
 
 #. Privacy policy page description
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:54
 #: src/components/PrivacyPolicyContent.tsx:23
 msgid "privacy.hero.description"
 msgstr "Raccogliamo solo il necessario, non vendiamo i tuoi dati e puoi cancellare tutto in qualsiasi momento."
 
 #. No selling
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:58
 #: src/components/PrivacyPolicyContent.tsx:44
 msgid "privacy.short.r2"
 msgstr "Non vendiamo, affittiamo o condividiamo i tuoi dati per scopi di marketing."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:51
+#: app/[lang]/(public)/faq/page.tsx:57
 msgid "faq.a.differentiation"
 msgstr "Indicizziamo le pagine carriere delle aziende direttamente, non feed di terze parti. Niente spam dei recruiter, nessun annuncio fantasma ripubblicato, e ricontrolliamo le aziende frequentemente — così la maggior parte delle posizioni appare qui entro poche ore dalla pubblicazione. Siamo costruiti per chi sa già in quali aziende vuole lavorare, non per ricerche generiche del tipo «trovami un lavoro qualsiasi»."
 
 #. Step 1 body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:64
 #: src/components/HowWeIndexContent.tsx:115
 msgid "indexing.ingestion.s1.body"
 msgstr "Cerchiamo una sitemap che elenchi già tutte le pagine carriere o di dettaglio degli annunci — idealmente collegata da <0>robots.txt</0> — e ci affidiamo ad essa ogni volta che è possibile."
@@ -4344,7 +4258,6 @@ msgstr "Cerchiamo feed strutturati prima di fare scraping dell'HTML grezzo. Prim
 
 #. Feature: direct from source description — no platform names, leads with the ICP differentiator
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:78
 #: src/components/Features.tsx:181
 msgid "home.features.s1.p1.description"
 msgstr "Monitoriamo le pagine carriere direttamente, non feed di terze parti — così le posizioni appaiono qui entro poche ore, tipicamente prima che LinkedIn o Indeed le ripubblichino."
@@ -4363,13 +4276,12 @@ msgstr "Abbiamo notato che questa offerta è stata aggiunta di recente. Alcuni d
 
 #. Automation stance body
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:74
 #: src/components/HowWeIndexContent.tsx:177
 msgid "indexing.automation.body"
 msgstr "Ci opponiamo a delegare le decisioni di assunzione o di ricerca lavoro ad automazioni opache — sia dal lato dei datori di lavoro che dei candidati. Ogni link in uscita che condividiamo include <0>utm_source=jobseek</0> affinché i recruiter riconoscano il traffico, e monitoriamo continuamente i pattern di utilizzo applicando frizioni per scoraggiare le candidature automatizzate."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:71
+#: app/[lang]/(public)/faq/page.tsx:77
 msgid "faq.a.crawlingPolicy"
 msgstr "Rispettiamo robots.txt e gli header TDM-Reservation, limitiamo le richieste a una per sito al minuto e utilizziamo il backoff esponenziale. Tutte le richieste si identificano tramite User-Agent. Consulta la nostra pagina sull'indicizzazione per tutti i dettagli."
 
@@ -4381,7 +4293,6 @@ msgstr "Abbiamo inviato un link di verifica a <0>{email}</0>. Clicca il link per
 
 #. What we store
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:57
 #: src/components/PrivacyPolicyContent.tsx:43
 msgid "privacy.short.r1"
 msgstr "Conserviamo il tuo nome, la tua email e la foto del profilo dall'accesso OAuth, più i dati che crei nell'app."
@@ -4394,7 +4305,6 @@ msgstr "Incoraggiamo vivamente la pubblicazione di una sitemap facilmente indivi
 
 #. Third parties
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:59
 #: src/components/PrivacyPolicyContent.tsx:45
 msgid "privacy.short.r3"
 msgstr "Utilizziamo pochi servizi terzi per accesso, hosting e archiviazione — nient’altro."
@@ -4424,22 +4334,22 @@ msgid "auth.signIn.subtitle"
 msgstr "Bentornato"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:62
+#: app/[lang]/(public)/faq/page.tsx:68
 msgid "faq.q.whatIsWatchlist"
 msgstr "Cos'è una watchlist?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:38
+#: app/[lang]/(public)/faq/page.tsx:44
 msgid "faq.q.whatIsJobseek"
 msgstr "Cos'è Job Seek?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:50
+#: app/[lang]/(public)/faq/page.tsx:56
 msgid "faq.q.differentiation"
 msgstr "Cosa rende Job Seek diverso da LinkedIn o Indeed?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:58
+#: app/[lang]/(public)/faq/page.tsx:64
 msgid "faq.q.freeVsPro"
 msgstr "Qual è la differenza tra Gratuito e Pro?"
 
@@ -4450,7 +4360,7 @@ msgid "app.home.request.heading"
 msgstr "Quale azienda dobbiamo monitorare?"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:86
+#: app/[lang]/(public)/faq/page.tsx:92
 msgid "faq.q.languages"
 msgstr "Quali lingue supporta Jobseek?"
 
@@ -4477,17 +4387,17 @@ msgid "search.experienceModal.years"
 msgstr "anni"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:43
+#: app/[lang]/(public)/faq/page.tsx:49
 msgid "faq.a.targetedSeeker"
 msgstr "Sì — è esattamente il caso d'uso per cui l'abbiamo costruito. Aggiungi le aziende che ti interessano a una watchlist, imposta i tuoi filtri (ruolo, località, seniority, stipendio) e Job Seek monitora le loro pagine carriere e ti avvisa nel momento in cui appaiono nuove posizioni che corrispondono. Non devi più controllare ogni sito a mano né combattere contro l'algoritmo di LinkedIn."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:75
+#: app/[lang]/(public)/faq/page.tsx:81
 msgid "faq.a.optOut"
 msgstr "Sì. Inviaci un'email e smetteremo immediatamente di analizzare il tuo sito carriere e rimuoveremo le tue offerte dall'indice."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:79
+#: app/[lang]/(public)/faq/page.tsx:85
 msgid "faq.a.openSource"
 msgstr "Sì. Il crawler e la pipeline di estrazione sono completamente open source su GitHub. Il codice dell'applicazione è sotto licenza MIT; i dati sulle offerte sono CC BY-NC 4.0."
 
@@ -4499,7 +4409,6 @@ msgstr "Ieri"
 
 #. Account deletion
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:61
 #: src/components/TermsContent.tsx:47
 msgid "terms.short.r5"
 msgstr "Puoi eliminare il tuo account in qualsiasi momento."
@@ -4518,7 +4427,6 @@ msgstr "Puoi velocizzare il processo chiedendo al tuo agente AI di completarlo t
 
 #. MIT license summary
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:56
 #: src/components/LicenseContent.tsx:53
 msgid "license.code.summary"
 msgstr "È possibile utilizzare, modificare e ridistribuire il codice in prodotti personali o commerciali a condizione di includere l'avviso di copyright e licenza."
@@ -4531,14 +4439,12 @@ msgstr "Potresti anche essere interessato a"
 
 #. CC license summary
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:58
 #: src/components/LicenseContent.tsx:74
 msgid "license.data.summary"
 msgstr "È consentito riutilizzare il dataset degli annunci con attribuzione per scopi non commerciali. L'uso commerciale richiede il previo consenso scritto."
 
 #. Age requirement
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:57
 #: src/components/TermsContent.tsx:43
 msgid "terms.short.r1"
 msgstr "Devi avere almeno 16 anni per usare Job Seek."
@@ -4575,7 +4481,6 @@ msgstr "Hai raggiunto il limite delle tue liste di osservazione. Effettua l'upgr
 
 #. Feature section 3 eyebrow text
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:92
 #: src/components/Features.tsx:290
 msgid "home.features.s3.eyebrow"
 msgstr "Le tue aziende, le tue regole"
@@ -4594,7 +4499,6 @@ msgstr "La tua password è stata reimpostata. Ora puoi accedere con la nuova pas
 
 #. Your rights section title
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:63
 #: src/components/PrivacyPolicyContent.tsx:54
 msgid "privacy.rights.title"
 msgstr "I tuoi diritti"


### PR DESCRIPTION
## Summary

Issue #2871 acceptance criterion: "All 4 locales (en source + de/fr/it) translated."

PR #2882 rewrote the English source strings for Hero / Features (s1/s2) / Pricing (free/pro) and added the FAQ targetedSeeker Q&A — but left de/fr/it translations of those keys pointing at the older pre-positioning content. e.g. `home.features.s1.p1.title` is now "Direct from the source" in English but de/fr/it still showed "Unternehmens-Benachrichtigungen" / "Alertes entreprises" / "Avvisi aziendali" (the old "company alerts" copy). `home.pricing.free.f1` is now "Search across all companies and filters" in English but de/fr/it still showed "Bis zu 5 Unternehmen abonnieren" / "Suivi de 5 entreprises maximum" / "Segui fino a 5 aziende" — a feature that doesn't even exist anymore.

This PR refreshes the stale translations so all three non-English locales match the watchlist-ICP positioning landed in #2882.

## Files changed

- `apps/web/locales/de.po` — 16 stale translations refreshed
- `apps/web/locales/fr.po` — 16 stale translations refreshed
- `apps/web/locales/it.po` — 16 stale translations refreshed
- `apps/web/locales/en.po` — line-reference cosmetic reordering from `pnpm extract` (no msgid/msgstr content changes)

Strings refreshed (per locale):
- Features **s1**: eyebrow, title, description, p1.title, p2.title, p2.description, p3.title, p3.description
- Features **s2**: eyebrow, title, description, p1.title, p1.description, p2.title, p2.description, p3.title, p3.description
- **Pricing free**: description, f1, f2, f3
- **Pricing pro**: description, f1, f2

s3 (the watchlist block now rendered first), Hero, FAQ, About, How-We-Index, and unchanged keys were already fresh from #2882 and not touched here.

## Translation approach

- Voice mirrors the existing #2882 translations: du/tu/tu informal where the surrounding strings use that register.
- Brand terms ("watchlist") kept English, matching the existing .po convention.
- Conservative phrasing / calques where native idioms were uncertain — none of the new translations invent product features outside what the EN source describes.

## Test plan

- [x] `pnpm extract` — 0 missing across en/de/fr/it (736/736 each)
- [x] `pnpm compile` — clean, .js catalogs include the new strings (`grep -o "Cerca con precisione|Recherche précise|Suche mit Präzision" locales/*.js` matches all three)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm test --run` — 490 / 490 passing across 54 test files
- [x] `msgfmt --check` on all four .po files — clean
- [x] `curl -sL http://localhost:3000/{en,de,fr,it}/` shows the new s1.eyebrow / s2.eyebrow / pricing.free.description / pricing.pro.f1 strings rendered in each locale
- [x] `curl -sL http://localhost:3000/{en,de,fr,it}/faq` renders the targetedSeeker Q&A in each locale
- [x] `grep -rEn "ATS platforms|Workday, Greenhouse|alternative to (LinkedIn|Indeed)" apps/web/src apps/web/app apps/web/locales apps/web/public` — only the two intentional blog mentions in `apps/web/src/content/blog/*.mdx`; no live "alternative to" framings; obsolete `#~` markers in .po files don't render

## Acceptance criteria from #2871

- [x] Hero headline + meta lead with watchlist+alerts ICP — already done by #2882, verified
- [x] Features section is ICP-first (watchlist s3 → tracker s2 → search/filter s1 with direct-sourcing inside) — already done by #2882, verified
- [x] FAQ has the "is jseek for me?" Q&A (`faq.q.targetedSeeker`) — already done by #2882, verified to render in all four locales
- [x] No remaining ATS-platform listings in the web app outside intentional blog content
- [x] No "alternative to LinkedIn/Indeed" framings
- [x] **All four locales translated** — this PR closes the gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)