### PR TITLE
fix(web): persist anon-user job-language filter via cookie (Closes #2850)

### DIFF
--- a/apps/web/app/[lang]/(app)/explore/explore-content.tsx
+++ b/apps/web/app/[lang]/(app)/explore/explore-content.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { fetchExploreData, type ExploreData } from "@/lib/actions/explore-data";
-import { hasLoggedInHint } from "@/lib/client-cookies";
+import { hasLoggedInHint, hasAnonJobLanguagesHint } from "@/lib/client-cookies";
 import { ExploreSkeleton } from "@/components/search/explore-skeleton";
 import { SearchPage } from "./search-page";
 
@@ -38,15 +38,22 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
   const [data, setData] = useState<ExploreData | null>(initialData ?? null);
 
   // Re-fetch on mount only when the prerendered ``initialData`` doesn't
-  // reflect the user's actual view — i.e. they have filter searchParams
-  // OR the ``logged_in`` hint cookie is present (their preferences /
-  // job-language filter / display currency would change the result set).
-  // Anonymous, no-filter visitors get the prerendered data with zero
-  // function invocations — the bulk of organic traffic per #2640.
+  // reflect the user's actual view — i.e. they have filter searchParams,
+  // the ``logged_in`` hint cookie is present (their DB-backed
+  // preferences / job-language filter / display currency would change
+  // the result set), OR they have an anonymous job-language cookie
+  // set (#2850 — anon viewers persist `jobLanguages` via a cookie
+  // that the server side reads in `fetchExploreData`). Anonymous, no-
+  // filter, no-job-lang-cookie visitors still get the prerendered data
+  // with zero function invocations — the bulk of organic traffic per
+  // #2640.
   useEffect(() => {
     window.scrollTo(0, 0);
     const needsPersonalizedFetch =
-      hasLoggedInHint() || hasAnyFilterParam(searchParams) || initialData === undefined;
+      hasLoggedInHint() ||
+      hasAnonJobLanguagesHint() ||
+      hasAnyFilterParam(searchParams) ||
+      initialData === undefined;
     if (!needsPersonalizedFetch) return;
 
     const sp: Record<string, string | undefined> = {};

--- a/apps/web/app/[lang]/(app)/settings/settings-loader.tsx
+++ b/apps/web/app/[lang]/(app)/settings/settings-loader.tsx
@@ -2,7 +2,12 @@
 
 import { useEffect, useState } from "react";
 import { GeneralSettings } from "@/components/settings/GeneralSettings";
-import { getPreferences, getAvailableJobLanguages, type AvailableLanguage } from "@/lib/actions/preferences";
+import {
+  getPreferences,
+  getAvailableJobLanguages,
+  getViewerJobLanguages,
+  type AvailableLanguage,
+} from "@/lib/actions/preferences";
 import { getCurrencyRates } from "@/lib/actions/search";
 
 type SettingsData = {
@@ -17,17 +22,24 @@ export function SettingsLoader({ locale }: { locale: string }) {
   const [data, setData] = useState<SettingsData | null>(null);
 
   useEffect(() => {
-    Promise.all([getPreferences(), getAvailableJobLanguages(), getCurrencyRates()]).then(
-      ([prefs, availableLanguages, currencyRates]) => {
-        setData({
-          jobLanguages: prefs?.jobLanguages ?? [],
-          displayCurrency: prefs?.displayCurrency ?? "EUR",
-          salaryPeriod: prefs?.salaryPeriod ?? null,
-          availableCurrencies: currencyRates.map((r) => r.currency),
-          availableLanguages,
-        });
-      },
-    );
+    // ``getViewerJobLanguages`` unifies the auth (DB row) and anon
+    // (cookie) paths so the toggle reflects the persisted state for
+    // both. Other prefs (currency / salary period) are auth-only —
+    // the anon defaults are baked into ``GeneralSettings``.
+    Promise.all([
+      getPreferences(),
+      getViewerJobLanguages(),
+      getAvailableJobLanguages(),
+      getCurrencyRates(),
+    ]).then(([prefs, jobLanguages, availableLanguages, currencyRates]) => {
+      setData({
+        jobLanguages,
+        displayCurrency: prefs?.displayCurrency ?? "EUR",
+        salaryPeriod: prefs?.salaryPeriod ?? null,
+        availableCurrencies: currencyRates.map((r) => r.currency),
+        availableLanguages,
+      });
+    });
   }, []);
 
   if (!data) {

--- a/apps/web/src/lib/__tests__/anon-preferences.test.ts
+++ b/apps/web/src/lib/__tests__/anon-preferences.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock server-only to prevent import error
+vi.mock("server-only", () => ({}));
+
+/**
+ * The cookie helper module imports `next/headers` (`cookies()`). We mock
+ * it with an in-memory store so tests can drive both read + write paths
+ * deterministically without booting a Next request lifecycle.
+ */
+const _store = new Map<string, string>();
+const _deleted = new Set<string>();
+const cookieMock = {
+  get: (name: string) => (_store.has(name) ? { name, value: _store.get(name)! } : undefined),
+  set: (
+    name: string,
+    value: string,
+    _opts?: { sameSite?: string; maxAge?: number; path?: string; secure?: boolean },
+  ) => {
+    _store.set(name, value);
+    _deleted.delete(name);
+  },
+  delete: (name: string) => {
+    _store.delete(name);
+    _deleted.add(name);
+  },
+};
+vi.mock("next/headers", () => ({
+  cookies: () => Promise.resolve(cookieMock),
+}));
+
+import {
+  JOB_LANGUAGES_COOKIE,
+  readAnonJobLanguagesCookie,
+  writeAnonJobLanguagesCookie,
+} from "../anon-preferences";
+
+describe("anon-preferences cookie helper (#2850)", () => {
+  beforeEach(() => {
+    _store.clear();
+    _deleted.clear();
+  });
+
+  describe("readAnonJobLanguagesCookie", () => {
+    it("returns null when the cookie is absent", async () => {
+      expect(await readAnonJobLanguagesCookie()).toBeNull();
+    });
+
+    it("returns null when the cookie value is not valid JSON", async () => {
+      _store.set(JOB_LANGUAGES_COOKIE, "not-json");
+      expect(await readAnonJobLanguagesCookie()).toBeNull();
+    });
+
+    it("returns null when the parsed value is not an array", async () => {
+      _store.set(JOB_LANGUAGES_COOKIE, JSON.stringify({ fr: true }));
+      expect(await readAnonJobLanguagesCookie()).toBeNull();
+    });
+
+    it("returns null when an array element is not a string", async () => {
+      _store.set(JOB_LANGUAGES_COOKIE, JSON.stringify(["en", 1]));
+      expect(await readAnonJobLanguagesCookie()).toBeNull();
+    });
+
+    it("returns the array verbatim when all codes are known", async () => {
+      _store.set(JOB_LANGUAGES_COOKIE, JSON.stringify(["en", "fr"]));
+      expect(await readAnonJobLanguagesCookie()).toEqual(["en", "fr"]);
+    });
+
+    it("preserves the all-languages sentinel `*`", async () => {
+      _store.set(JOB_LANGUAGES_COOKIE, JSON.stringify(["*"]));
+      expect(await readAnonJobLanguagesCookie()).toEqual(["*"]);
+    });
+
+    it("drops unknown language codes silently", async () => {
+      _store.set(
+        JOB_LANGUAGES_COOKIE,
+        JSON.stringify(["en", "totally-not-a-language", "fr"]),
+      );
+      expect(await readAnonJobLanguagesCookie()).toEqual(["en", "fr"]);
+    });
+
+    it("returns [] for a literal empty-array cookie", async () => {
+      _store.set(JOB_LANGUAGES_COOKIE, JSON.stringify([]));
+      expect(await readAnonJobLanguagesCookie()).toEqual([]);
+    });
+  });
+
+  describe("writeAnonJobLanguagesCookie", () => {
+    it("writes a valid array as JSON", async () => {
+      await writeAnonJobLanguagesCookie(["en", "fr"]);
+      expect(_store.get(JOB_LANGUAGES_COOKIE)).toBe('["en","fr"]');
+    });
+
+    it("preserves the all-languages sentinel", async () => {
+      await writeAnonJobLanguagesCookie(["*"]);
+      expect(_store.get(JOB_LANGUAGES_COOKIE)).toBe('["*"]');
+    });
+
+    it("filters out unknown codes before writing", async () => {
+      await writeAnonJobLanguagesCookie(["en", "bogus", "fr"]);
+      expect(_store.get(JOB_LANGUAGES_COOKIE)).toBe('["en","fr"]');
+    });
+
+    it("deletes the cookie when the input is empty", async () => {
+      _store.set(JOB_LANGUAGES_COOKIE, '["fr"]');
+      await writeAnonJobLanguagesCookie([]);
+      expect(_store.has(JOB_LANGUAGES_COOKIE)).toBe(false);
+      expect(_deleted.has(JOB_LANGUAGES_COOKIE)).toBe(true);
+    });
+
+    it("deletes the cookie when every input code is unknown", async () => {
+      _store.set(JOB_LANGUAGES_COOKIE, '["fr"]');
+      await writeAnonJobLanguagesCookie(["bogus", "alsobogus"]);
+      expect(_store.has(JOB_LANGUAGES_COOKIE)).toBe(false);
+      expect(_deleted.has(JOB_LANGUAGES_COOKIE)).toBe(true);
+    });
+  });
+
+  describe("round-trip", () => {
+    it("write → read returns the same shape", async () => {
+      await writeAnonJobLanguagesCookie(["en", "fr"]);
+      expect(await readAnonJobLanguagesCookie()).toEqual(["en", "fr"]);
+    });
+
+    it("write * → read returns [\"*\"]", async () => {
+      await writeAnonJobLanguagesCookie(["*"]);
+      expect(await readAnonJobLanguagesCookie()).toEqual(["*"]);
+    });
+  });
+});

--- a/apps/web/src/lib/actions/company-page-data.ts
+++ b/apps/web/src/lib/actions/company-page-data.ts
@@ -3,6 +3,8 @@
 import { getCompanyBySlug, getCompanyPostings, type CompanyDetail } from "@/lib/actions/company";
 import { parseSearchFilters, type ParsedSearchFilters } from "@/lib/actions/search-input";
 import { getPreferences } from "@/lib/actions/preferences";
+import { readAnonJobLanguagesCookie } from "@/lib/anon-preferences";
+import { getSession } from "@/lib/sessionCache";
 import { resolveJobLanguages } from "@/lib/job-languages";
 import { firstOf, idsOrUndefined, parseRangeParam, getGeoFromHeaders } from "@/lib/search/params";
 import type { SearchResultPosting } from "@/lib/search";
@@ -51,12 +53,16 @@ export async function fetchCompanyPageData(params: {
 
   const { userLat, userLng } = await getGeoFromHeaders();
 
-  const [parsed, prefs] = await Promise.all([
+  // Auth users persist `jobLanguages` in `user_preferences`; anon users
+  // mirror it into a cookie (issue #2850 + `anon-preferences.ts`).
+  const session = await getSession();
+  const [parsed, prefs, anonJobLangs] = await Promise.all([
     parseSearchFilters({ q, loc, occ, sen, tech, locale, userLat, userLng }),
-    getPreferences(),
+    session ? getPreferences() : Promise.resolve(null),
+    session ? Promise.resolve(null) : readAnonJobLanguagesCookie(),
   ]);
 
-  const jobLanguages = prefs?.jobLanguages ?? [];
+  const jobLanguages = prefs?.jobLanguages ?? anonJobLangs ?? [];
   const displayCurrency = prefs?.displayCurrency ?? "EUR";
   const languages = resolveJobLanguages(jobLanguages, locale);
 

--- a/apps/web/src/lib/actions/explore-data.ts
+++ b/apps/web/src/lib/actions/explore-data.ts
@@ -8,6 +8,8 @@ import {
 import { parseSearchFilters, type ParsedSearchFilters } from "@/lib/actions/search-input";
 import { getPreferences } from "@/lib/actions/preferences";
 import { resolveJobLanguages } from "@/lib/job-languages";
+import { readAnonJobLanguagesCookie } from "@/lib/anon-preferences";
+import { getSession } from "@/lib/sessionCache";
 import { firstOf, idsOrUndefined, parseRangeParam, getGeoFromHeaders } from "@/lib/search/params";
 import type { SearchResponse } from "@/lib/search";
 
@@ -55,12 +57,19 @@ export async function fetchExploreData(params: {
 
   const { userLat, userLng } = await getGeoFromHeaders();
 
-  const [parsed, prefs] = await Promise.all([
+  // For authenticated users, `getPreferences` returns the DB row.
+  // For anon users, we mirror `jobLanguages` into a cookie (see
+  // issue #2850 + `anon-preferences.ts`) — read it here so anon
+  // toggles in /settings actually flow through to the server-side
+  // search. Other prefs (display currency etc.) stay anon-defaults.
+  const session = await getSession();
+  const [parsed, prefs, anonJobLangs] = await Promise.all([
     parseSearchFilters({ q, loc, occ, sen, tech, locale, userLat, userLng }),
-    getPreferences(),
+    session ? getPreferences() : Promise.resolve(null),
+    session ? Promise.resolve(null) : readAnonJobLanguagesCookie(),
   ]);
 
-  const jobLanguages = prefs?.jobLanguages ?? [];
+  const jobLanguages = prefs?.jobLanguages ?? anonJobLangs ?? [];
   const displayCurrency = prefs?.displayCurrency ?? "EUR";
   const languages = resolveJobLanguages(jobLanguages, locale);
 

--- a/apps/web/src/lib/actions/preferences.ts
+++ b/apps/web/src/lib/actions/preferences.ts
@@ -8,6 +8,7 @@ import { account, userPreferences } from "@/db/schema";
 import { auth } from "@/lib/auth";
 import { getSession, getSessionUserId } from "@/lib/sessionCache";
 import { getLanguage } from "@/lib/job-languages";
+import { writeAnonJobLanguagesCookie, readAnonJobLanguagesCookie } from "@/lib/anon-preferences";
 
 const PASSWORD_RESET_COOLDOWN_SECONDS = 60;
 
@@ -34,6 +35,26 @@ export async function getPreferences() {
   return row ?? null;
 }
 
+/**
+ * Resolve the viewer's currently-saved `jobLanguages` preference,
+ * unifying the authenticated (DB-row) and anonymous (cookie) paths.
+ *
+ * Returns the same shape the rest of the codebase expects:
+ *   - `[]` when nothing is set (UI treats as "default = locale only")
+ *   - `["*"]` when the viewer opted into "all languages"
+ *   - explicit codes otherwise (e.g. `["en","de"]`)
+ *
+ * Used by the settings page so the toggle reflects the persisted state
+ * for anon viewers — without this, the toggle would visibly forget the
+ * selection on the next render even though the cookie is set. See
+ * #2850 + `anon-preferences.ts`.
+ */
+export async function getViewerJobLanguages(): Promise<string[]> {
+  const prefs = await getPreferences();
+  if (prefs) return prefs.jobLanguages ?? [];
+  return (await readAnonJobLanguagesCookie()) ?? [];
+}
+
 export async function updatePreferences(
   data: {
     theme?: "light" | "dark";
@@ -48,7 +69,18 @@ export async function updatePreferences(
   },
 ) {
   const userId = await getSessionUserId();
-  if (!userId) return null;
+  if (!userId) {
+    // Anonymous users have no DB row, but we still persist
+    // `jobLanguages` so the explore/watchlist filter actually applies
+    // on subsequent renders. Other prefs (theme, locale, currency,
+    // dismissBanner, …) are persisted client-side via `localPrefs` /
+    // `next-themes` / Lingui's locale prefix, so we only mirror the
+    // server-resolved field. See issue #2850 + `anon-preferences.ts`.
+    if (data.jobLanguages !== undefined) {
+      await writeAnonJobLanguagesCookie(data.jobLanguages);
+    }
+    return null;
+  }
 
   const [existing] = await db
     .select()

--- a/apps/web/src/lib/actions/watchlist-page-data.ts
+++ b/apps/web/src/lib/actions/watchlist-page-data.ts
@@ -10,6 +10,7 @@ import { getUserPlan, PLAN_LIMITS, canCreateWatchlist } from "@/lib/plans";
 import { resolveLocationSlugs } from "@/lib/actions/locations";
 import { resolveOccupationSlugs, resolveSenioritySlugs, resolveTechnologySlugs } from "@/lib/actions/taxonomy";
 import { getPreferences } from "@/lib/actions/preferences";
+import { readAnonJobLanguagesCookie } from "@/lib/anon-preferences";
 import { resolveJobLanguages } from "@/lib/job-languages";
 import type { WatchlistPostingEntry } from "@/lib/actions/watchlists";
 
@@ -43,15 +44,19 @@ export async function fetchWatchlistPageData(params: {
   const session = await getSession();
   const isOwner = session?.user?.id === detail.owner.id;
 
-  const [plan, limit, prefs] = await Promise.all([
+  // Auth users persist `jobLanguages` in `user_preferences`; anon
+  // users mirror it into a cookie (issue #2850 + `anon-preferences.ts`).
+  // Read whichever applies so the watchlist body filters consistently.
+  const [plan, limit, prefs, anonJobLangs] = await Promise.all([
     session ? getUserPlan(session.user.id) : ("free" as const),
     session ? canCreateWatchlist(session.user.id) : { allowed: false, current: 0, max: 0 },
     session ? getPreferences() : Promise.resolve(null),
+    session ? Promise.resolve(null) : readAnonJobLanguagesCookie(),
   ]);
   const isPaidPlan = PLAN_LIMITS[plan].canReceiveAlerts;
   const limitReached = !limit.allowed;
 
-  const jobLanguages = prefs?.jobLanguages ?? [];
+  const jobLanguages = prefs?.jobLanguages ?? anonJobLangs ?? [];
   const languages = resolveJobLanguages(jobLanguages, locale);
 
   const filters = detail.filters;

--- a/apps/web/src/lib/anon-preferences.ts
+++ b/apps/web/src/lib/anon-preferences.ts
@@ -1,0 +1,96 @@
+import "server-only";
+import { cookies } from "next/headers";
+import { getLanguage } from "@/lib/job-languages";
+
+/**
+ * Cookie used to persist anonymous-viewer job-language preferences.
+ *
+ * Authenticated users persist `jobLanguages` in `user_preferences` (DB).
+ * Anonymous users have no DB row, so we mirror the same shape into a
+ * cookie so `getViewerLanguages` can resolve a non-empty filter for
+ * them. Without this cookie, `updatePreferences` silently no-ops for
+ * anon callers (`if (!userId) return null`) and the UI toggle visibly
+ * does nothing — see issue #2850.
+ *
+ * Cookie value is a JSON-encoded `string[]` matching the DB column
+ * (`["*"]` for all-languages, `["en","de"]` for explicit). The empty
+ * default `[]` is represented by deleting the cookie, so callers
+ * don't need a separate "is set" probe.
+ */
+export const JOB_LANGUAGES_COOKIE = "JSEEK_JOB_LANGUAGES";
+
+/** One year — matches `NEXT_LOCALE` and other persisted UX prefs. */
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+/**
+ * Sanitize a freshly-decoded cookie value into the same shape stored
+ * in `user_preferences.jobLanguages`. Mirrors the write-side validator
+ * in `actions/preferences.ts::sanitizeJobLanguages` — the cookie is
+ * untrusted client input, and these strings flow into Typesense
+ * `filter_by` and Postgres array literals via raw interpolation.
+ */
+function sanitize(input: unknown): string[] | null {
+  if (!Array.isArray(input)) return null;
+  const out: string[] = [];
+  for (const item of input) {
+    if (typeof item !== "string") return null;
+    if (item === "*" || getLanguage(item) != null) out.push(item);
+  }
+  return out;
+}
+
+/**
+ * Read the anonymous viewer's persisted `jobLanguages` preference from
+ * the request cookie. Returns `null` when:
+ *
+ *   - the cookie is missing,
+ *   - the cookie value is not valid JSON,
+ *   - the parsed value is not an array of known language codes.
+ *
+ * Callers that need a default (`[]`) on the missing-cookie path should
+ * check for `null` and substitute `[]` themselves — keeping the two
+ * states distinguishable lets `getViewerLanguages` log malformed
+ * cookies without conflating them with the default case.
+ */
+export async function readAnonJobLanguagesCookie(): Promise<string[] | null> {
+  const store = await cookies();
+  const raw = store.get(JOB_LANGUAGES_COOKIE)?.value;
+  if (!raw) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Malformed cookie — treat as missing. Don't throw; the page must
+    // still render, and the next legitimate write will overwrite.
+    return null;
+  }
+  return sanitize(parsed);
+}
+
+/**
+ * Persist the anonymous viewer's `jobLanguages` preference as a cookie
+ * mirroring `user_preferences.jobLanguages`. Sanitizes the input first
+ * so the read path can trust the cookie blindly. The empty default
+ * (`[]`) is encoded as cookie deletion so a user can "reset" by
+ * removing all selections.
+ *
+ * `path: "/"` so every page sees the cookie. `sameSite: "lax"` because
+ * the value is read by GET-rendered pages (the read happens during
+ * RSC payload generation, which uses GET semantics). Not `httpOnly` —
+ * `secure` only when the request was over HTTPS so dev (`http://`)
+ * still works without special-casing.
+ */
+export async function writeAnonJobLanguagesCookie(input: string[]): Promise<void> {
+  const safe = sanitize(input) ?? [];
+  const store = await cookies();
+  if (safe.length === 0) {
+    store.delete(JOB_LANGUAGES_COOKIE);
+    return;
+  }
+  store.set(JOB_LANGUAGES_COOKIE, JSON.stringify(safe), {
+    sameSite: "lax",
+    maxAge: COOKIE_MAX_AGE_SECONDS,
+    path: "/",
+    secure: process.env.NODE_ENV === "production",
+  });
+}

--- a/apps/web/src/lib/client-cookies.ts
+++ b/apps/web/src/lib/client-cookies.ts
@@ -8,6 +8,17 @@
 export const LOGGED_IN_COOKIE = "logged_in";
 
 /**
+ * Name of the non-httpOnly cookie that persists anonymous-viewer
+ * `jobLanguages` preferences. The same cookie is the canonical source
+ * of truth on the server (read by `viewer.ts::getViewerLanguages` and
+ * `explore-data.ts::fetchExploreData`); the client only needs to know
+ * whether it's set so it can decide to re-fetch the personalised
+ * `ExploreData` instead of using the anon-default static prerender
+ * (#2850). MUST stay in sync with `lib/anon-preferences.ts`.
+ */
+export const JOB_LANGUAGES_COOKIE = "JSEEK_JOB_LANGUAGES";
+
+/**
  * Parse a raw Cookie-header-style string (either `document.cookie` or a
  * server `Cookie` request header) and return whether `name` is present
  * as an actual cookie name — not a substring of another name.
@@ -37,6 +48,19 @@ export function hasCookieNamed(cookieHeader: string, name: string): boolean {
 export function hasLoggedInHint(): boolean {
   if (typeof document === "undefined") return false;
   return hasCookieNamed(document.cookie, LOGGED_IN_COOKIE);
+}
+
+/**
+ * Client-only: does the current browser have a stored anon
+ * `jobLanguages` cookie? Used by ``ExploreContent`` (and its peers) to
+ * decide whether to refetch the personalised ``ExploreData`` even when
+ * the viewer is anonymous and the URL has no filter searchParams.
+ * Without this, the static anon-default prerender would render with
+ * `[locale]` filters regardless of the cookie state. See #2850.
+ */
+export function hasAnonJobLanguagesHint(): boolean {
+  if (typeof document === "undefined") return false;
+  return hasCookieNamed(document.cookie, JOB_LANGUAGES_COOKIE);
 }
 
 /**

--- a/apps/web/src/lib/viewer.ts
+++ b/apps/web/src/lib/viewer.ts
@@ -3,17 +3,29 @@
 import { getSession } from "@/lib/sessionCache";
 import { getPreferences } from "@/lib/actions/preferences";
 import { resolveJobLanguages } from "@/lib/job-languages";
+import { readAnonJobLanguagesCookie } from "@/lib/anon-preferences";
 
 /**
  * Resolve the current viewer's effective job-language filter.
- * Anonymous viewers (no session) fall through to `[locale]` — same as
- * logged-in users whose preference is unset. Keeps
- * explore/company/watchlist pages behaving identically across auth state.
+ * Authenticated viewers read `jobLanguages` from `user_preferences`.
+ * Anonymous viewers read it from the `JSEEK_JOB_LANGUAGES` cookie
+ * (written by `updatePreferences` for the same shape — see issue
+ * #2850 + `anon-preferences.ts`); the previous behaviour was to fall
+ * straight through to `[locale]`, which silently dropped any anon
+ * toggle on the client.
  *
- * Returns `[]` when the viewer opted into "all languages" (`"*"`).
+ * In both cases, an unset preference falls through to `[locale]` via
+ * `resolveJobLanguages`. Returns `[]` when the viewer opted into "all
+ * languages" (`"*"`).
  */
 export async function getViewerLanguages(locale: string): Promise<string[]> {
   const session = await getSession();
-  const prefs = session ? await getPreferences() : null;
-  return resolveJobLanguages(prefs?.jobLanguages ?? [], locale);
+  let stored: string[];
+  if (session) {
+    const prefs = await getPreferences();
+    stored = prefs?.jobLanguages ?? [];
+  } else {
+    stored = (await readAnonJobLanguagesCookie()) ?? [];
+  }
+  return resolveJobLanguages(stored, locale);
 }


### PR DESCRIPTION
## Summary

Fixes #2850. Anonymous viewers' \`Job languages\` toggle in /settings was silently discarded because:

1. \`updatePreferences\` returned early for unsessioned callers (\`if (!userId) return null\`).
2. \`getViewerLanguages\` always fell through to \`[locale]\` regardless of any anon state.

This PR implements **Approach A** from the issue investigation comment — mirror \`jobLanguages\` into a non-httpOnly cookie so the read path resolves the same shape for anon viewers as for logged-in ones.

### Implementation
- New helper \`apps/web/src/lib/anon-preferences.ts\` — \`readAnonJobLanguagesCookie\` / \`writeAnonJobLanguagesCookie\`. Both sanitize against the known language list (Typesense \`filter_by\` / Postgres array literals are still raw-interpolated downstream).
- \`updatePreferences\`: anon callers with \`jobLanguages\` set the cookie; auth callers unchanged.
- \`getViewerLanguages\`, \`fetchExploreData\`, \`fetchWatchlistPageData\`, \`fetchCompanyPageData\`, \`SettingsLoader\`: read the cookie when there's no session.
- \`ExploreContent\`: \`hasAnonJobLanguagesHint()\` joins \`hasLoggedInHint()\` + filter searchParams as a refetch trigger so the static prerender doesn't paint stale data once the cookie is set.

### Cache-components contract
Build classification stays \`◐ Partial Prerender\` for all four #2835 ISR routes plus marketing pages — verified via \`pnpm test:isr\`. The cookie reads happen inside server actions or already-dynamic shells; the static prerender body never touches \`cookies()\`.

### Out of scope (explicit, per #2850 investigation)
- URL-query-param shape (Approach 2) — more UX-correct but a multi-file SearchToolbar refactor; defer to a follow-up.
- Anon-cookie merge into the DB row on sign-in — keeps the auth path free of new behaviour for this PR.

## Test plan

- [x] \`pnpm test\` — 505/505 pass (incl. new 15-case \`anon-preferences.test.ts\`)
- [x] \`pnpm exec tsc --noEmit\` — clean
- [x] \`pnpm test:isr\` — 14/14 pass; \`/[lang]/explore\`, \`/[lang]/[userSlug]/[watchlistSlug]\`, \`/[lang]/company/[slug]\`, \`/[lang]\`, \`/[lang]/blog\`, \`/[lang]/blog/[slug]\`, marketing pages all stay \`◐ Partial Prerender\`
- [x] Empirical reproduction: BEFORE — \`Showing jobs in English\` after toggling French (cookie absent). AFTER — cookie \`["fr","en"]\` persisted, \`/en/explore\` renders \`Showing jobs in français, English\`.
- [x] Auth-user regression: \`updatePreferences\` early-return only fires when \`getSessionUserId()\` returns null; auth-user DB write path is structurally unchanged. Confirmed via tsc + tests; live-DB happy-path not exercised end-to-end this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)