### PR TITLE
fix(web): speed up settings page cold load (Closes #2918)

### DIFF
--- a/apps/web/docs/edge-requests/settings.md
+++ b/apps/web/docs/edge-requests/settings.md
@@ -46,8 +46,8 @@
 | `getSavedJobStatuses()` | 1 | parallel | None | 10-30ms |
 | `getStarredCompanyIds()` | 1 | parallel | None | 10-30ms |
 | `getPreferences()` (page) | 0 | — | React `cache()` dedup | 0ms |
-| `getAvailableJobLanguages()` | 1 | — | Redis 1h | 10-25ms |
-| `getCurrencyRates()` | 1 | — | Redis 1h | 10-25ms |
+| `getAvailableJobLanguages()` | 1 (Typesense facet) | — | `'use cache'` 1h | ~600ms cold, <1ms warm |
+| `getCurrencyRates()` | 1 | — | `'use cache'` 1h | ~200ms cold, <1ms warm |
 
 **Total DB queries:** 7 (5 if languages + currencies cached)
 **Estimated function duration:** 40-120ms (warm instance)

--- a/apps/web/src/lib/actions/preferences.ts
+++ b/apps/web/src/lib/actions/preferences.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { eq, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { headers } from "next/headers";
 import { cacheLife } from "next/cache";
 import { db } from "@/db";
@@ -9,6 +9,7 @@ import { auth } from "@/lib/auth";
 import { getSession, getSessionUserId } from "@/lib/sessionCache";
 import { getLanguage } from "@/lib/job-languages";
 import { writeAnonJobLanguagesCookie, readAnonJobLanguagesCookie } from "@/lib/anon-preferences";
+import { getSearchClient } from "@/lib/search/typesense-client";
 
 const PASSWORD_RESET_COOLDOWN_SECONDS = 60;
 
@@ -258,25 +259,51 @@ export interface AvailableLanguage {
 
 /**
  * Returns distinct language codes from active job postings with counts, sorted by count desc.
- * Per-region in-memory `'use cache'` (cacheLife('hours')); migrated from
- * Redis-backed `cached(..., { ttl: 3600 })` in #2884 (bucket 5). Build ID
- * is part of the cache key, so each deploy re-fetches.
+ *
+ * Reads from Typesense (`job_posting` collection has `locales` as a faceted
+ * field). The previous Postgres implementation `unnest`ed `locales` over all
+ * active rows on every cold cache miss — at ~760k active postings that took
+ * ~4s on Supabase and dominated the /settings cold load (#2918). The
+ * Typesense facet variant returns the same shape in ~0.6s.
+ *
+ * Filters out the `_none` sentinel (rows with no detected locale; written
+ * by the exporter to keep `locales` non-empty for Typesense — see
+ * `apps/crawler/src/typesense_schema.py`).
+ *
+ * Per-region in-memory `'use cache'` (cacheLife('hours')) keeps repeat
+ * loads sub-millisecond; build ID is part of the cache key, so each deploy
+ * re-fetches. The fallback path returns `[]` uncached so a Typesense blip
+ * doesn't poison the cache for an hour. Migrated from Redis-backed
+ * `cached(..., { ttl: 3600 })` in #2884 (bucket 5).
  */
-export async function getAvailableJobLanguages(): Promise<AvailableLanguage[]> {
+async function _fetchAvailableJobLanguages(): Promise<AvailableLanguage[]> {
   "use cache";
   cacheLife("hours");
-  const rows = await db.execute<{ [key: string]: unknown; locale: string; cnt: number }>(sql`
-    SELECT locale, COUNT(*)::int AS cnt
-    FROM (
-      SELECT unnest(locales) AS locale
-      FROM job_posting
-      WHERE is_active = true AND array_length(locales, 1) > 0
-    ) sub
-    GROUP BY locale
-    ORDER BY cnt DESC
-  `);
-  return (rows as unknown as { locale: string; cnt: number }[]).map((r) => ({
-    code: r.locale,
-    count: r.cnt,
-  }));
+  const client = getSearchClient();
+  const result = await client
+    .collections("job_posting")
+    .documents()
+    .search({
+      q: "*",
+      filter_by: "is_active:=true",
+      facet_by: "locales",
+      // Typesense returns up to ~32 distinct values by default; bump well
+      // past the ~30 codes currently in production so we don't truncate.
+      max_facet_values: 100,
+      per_page: 0,
+    });
+  const counts = result.facet_counts?.[0]?.counts ?? [];
+  return counts
+    .filter((c) => c.value !== "_none")
+    .map((c) => ({ code: c.value, count: c.count }));
+}
+
+export async function getAvailableJobLanguages(): Promise<AvailableLanguage[]> {
+  try {
+    return await _fetchAvailableJobLanguages();
+  } catch {
+    // Typesense unreachable — return empty list rather than blocking the
+    // settings page render. The UI falls back to UI-locale-only filter.
+    return [];
+  }
 }


### PR DESCRIPTION
## Summary

- `/en/settings` cold load was ~9.8s end-to-end (data fully settled in browser).
- Per-call profiling fingered `getAvailableJobLanguages` as the dominant blocker: ~4.1s on every cold ``'use cache'`` miss because the underlying Postgres query `unnest`ed `locales` across ~760k active job postings.
- Rewrite `getAvailableJobLanguages` to use the Typesense `job_posting.locales` facet (already faceted in the schema). Same `{ code, count }[]` output shape; filters out the `_none` sentinel.

## Bottleneck

Cold-cache server-action timings on `/en/settings` (anon viewer):

| Call | Before | After |
|------|--------|-------|
| `getPreferences` (no session) | 2 ms | 2 ms |
| `getViewerJobLanguages` (anon) | 7 ms | 7 ms |
| `getCurrencyRates` (cold) | 362 ms | 362 ms |
| **`getAvailableJobLanguages` (cold)** | **4 088 ms** | **~700 ms** |

End-to-end browser timings (Playwright, fresh `.next`):

| Phase | Before | After |
|-------|--------|-------|
| DOMContentLoaded | 4 858 ms | 4 453 ms |
| Fully settled (form rendered) | 9 778 ms | 6 334 ms |

Speedup on the user-perceived cold settled time: **~1.55x** (3.4s shaved). On the actual bottleneck call: **~5.8x** (4.1s -> 0.7s).

Warm-cache behaviour is unchanged — `'use cache'` (cacheLife('hours')) keeps subsequent loads sub-millisecond.

## Implementation notes

- `'use cache'` boundary kept on a new `_fetchAvailableJobLanguages` inner function. Outer wrapper try/catches Typesense outages and returns `[]` **without** caching, mirroring the `getCurrencyRates` pattern (#2908) so a Typesense blip doesn't poison the hour-long cache.
- `max_facet_values: 100` — current production has ~30 distinct `locales` codes; bumped well past that so we don't truncate as new postings appear.
- `_none` sentinel filtered out at source (rows with no detected locale, written by exporter to satisfy Typesense's non-empty-array constraint — see `apps/crawler/src/typesense_schema.py`). `getLanguage("_none")` already returned `undefined` in the consumer, but filtering at source keeps count semantics clean and avoids wasted wire bytes.
- `apps/web/docs/edge-requests/settings.md` updated to reflect Typesense-backed source and `'use cache'` (was still claiming Redis 1h after #2884).

## Test plan

- [x] `pnpm test` — 505/505 pass
- [x] `pnpm exec tsc --noEmit` — clean (after building `@jseek/mcp-server` workspace package)
- [x] `pnpm build` — succeeds; `/[lang]/settings` classification stays ``◐`` (Partial Prerender)
- [x] Cold-cache reproduction: removed `.next`, restarted dev, confirmed ~5.8x speedup on the bottleneck call across 2 cold-runs
- [x] Warm-cache: <1ms after first hit (`'use cache'` working as intended)

Closes #2918.