### PR TITLE
fix(web): refresh search after language-pref change (Closes #2916)

### DIFF
--- a/apps/web/src/components/settings/GeneralSettings.tsx
+++ b/apps/web/src/components/settings/GeneralSettings.tsx
@@ -139,15 +139,25 @@ export function GeneralSettings({ savedJobLanguages, savedDisplayCurrency, saved
     [currentLocale],
   );
 
-  // Persist language preference changes (outside updater to avoid setState-during-render)
+  // Persist language preference changes (outside updater to avoid setState-during-render).
+  // After the server-action resolves, `router.refresh()` flushes Next.js's
+  // client-side router cache so the next navigation back to /explore
+  // (or any other page that reads `jobLanguages`) refetches the RSC
+  // payload — without this, the user lands on a stale prerender that
+  // predates the toggle and only sees the new filter after a hard
+  // reload (#2916). The server-action already invalidates the
+  // per-region `'use cache'` layer via `revalidatePath`; both layers
+  // need clearing.
   const initialLangsRef = useRef(true);
   useEffect(() => {
     if (initialLangsRef.current) {
       initialLangsRef.current = false;
       return;
     }
-    void updatePreferences({ jobLanguages });
-  }, [jobLanguages]);
+    void updatePreferences({ jobLanguages }).then(() => {
+      router.refresh();
+    });
+  }, [jobLanguages, router]);
 
   return (
     <div className="space-y-10">

--- a/apps/web/src/lib/actions/__tests__/preferences-revalidation.test.ts
+++ b/apps/web/src/lib/actions/__tests__/preferences-revalidation.test.ts
@@ -1,0 +1,182 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Server actions transitively import `server-only`, which throws in a
+// non-Next runtime. Neutralize before module-under-test loads.
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  revalidatePath: vi.fn(),
+  cacheLife: vi.fn(),
+  getSessionUserId: vi.fn(),
+  getSession: vi.fn().mockResolvedValue(null),
+  writeAnonJobLanguagesCookie: vi.fn(),
+  readAnonJobLanguagesCookie: vi.fn(),
+  // Drizzle surface — `update().set().where().returning()` and
+  // `insert().values().onConflictDoUpdate().returning()` need to chain
+  // and resolve. Each test wires up via `dbUpdateChain` /
+  // `dbInsertChain` returning a thenable that yields a single row.
+  selectLimitResult: vi.fn(),
+  updateReturningResult: vi.fn(),
+  insertReturningResult: vi.fn(),
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: mocks.revalidatePath,
+  cacheLife: mocks.cacheLife,
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+vi.mock("@/lib/sessionCache", () => ({
+  getSessionUserId: mocks.getSessionUserId,
+  getSession: mocks.getSession,
+}));
+
+vi.mock("@/lib/anon-preferences", () => ({
+  writeAnonJobLanguagesCookie: mocks.writeAnonJobLanguagesCookie,
+  readAnonJobLanguagesCookie: mocks.readAnonJobLanguagesCookie,
+}));
+
+// Drizzle: minimal fluent-API stub that records calls and lets tests
+// queue the leaf result.
+const buildSelectChain = () => ({
+  from: () => ({
+    where: () => ({
+      limit: () => mocks.selectLimitResult(),
+    }),
+  }),
+});
+const buildUpdateChain = () => ({
+  set: () => ({
+    where: () => ({
+      returning: () => mocks.updateReturningResult(),
+    }),
+  }),
+});
+const buildInsertChain = () => ({
+  values: () => ({
+    onConflictDoUpdate: () => ({
+      returning: () => mocks.insertReturningResult(),
+    }),
+  }),
+});
+
+vi.mock("@/db", () => ({
+  db: {
+    select: () => buildSelectChain(),
+    update: () => buildUpdateChain(),
+    insert: () => buildInsertChain(),
+    execute: vi.fn(),
+  },
+}));
+
+// Mock auth surface (only `auth.api.setPassword` is referenced via
+// import-time evaluation; not exercised by these tests but the module
+// graph still loads it).
+vi.mock("@/lib/auth", () => ({ auth: { api: { setPassword: vi.fn() } } }));
+
+const PATHS = [
+  "/[lang]/(app)/explore",
+  "/[lang]/(app)/[userSlug]/[watchlistSlug]",
+  "/[lang]/(app)/company/[slug]",
+];
+
+describe("updatePreferences invalidates job-language-dependent pages (#2916)", () => {
+  beforeEach(() => {
+    mocks.revalidatePath.mockReset();
+    mocks.getSessionUserId.mockReset();
+    mocks.writeAnonJobLanguagesCookie.mockReset();
+    mocks.selectLimitResult.mockReset();
+    mocks.updateReturningResult.mockReset();
+    mocks.insertReturningResult.mockReset();
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("anon path: writes cookie and revalidates every dependent page", async () => {
+    mocks.getSessionUserId.mockResolvedValue(null);
+    const { updatePreferences } = await import("../preferences");
+
+    await updatePreferences({ jobLanguages: ["fr"] });
+
+    expect(mocks.writeAnonJobLanguagesCookie).toHaveBeenCalledWith(["fr"]);
+    expect(mocks.revalidatePath).toHaveBeenCalledTimes(PATHS.length);
+    for (const p of PATHS) {
+      expect(mocks.revalidatePath).toHaveBeenCalledWith(p);
+    }
+  });
+
+  it("anon path: skips revalidation when jobLanguages is not in payload", async () => {
+    mocks.getSessionUserId.mockResolvedValue(null);
+    const { updatePreferences } = await import("../preferences");
+
+    await updatePreferences({ theme: "dark" });
+
+    expect(mocks.writeAnonJobLanguagesCookie).not.toHaveBeenCalled();
+    expect(mocks.revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("auth update path: revalidates when jobLanguages is set", async () => {
+    mocks.getSessionUserId.mockResolvedValue("user-1");
+    mocks.selectLimitResult.mockResolvedValue([
+      { userId: "user-1", jobLanguages: [], dismissedBanners: [] },
+    ]);
+    mocks.updateReturningResult.mockResolvedValue([{ userId: "user-1", jobLanguages: ["fr"] }]);
+    const { updatePreferences } = await import("../preferences");
+
+    await updatePreferences({ jobLanguages: ["fr"] });
+
+    expect(mocks.revalidatePath).toHaveBeenCalledTimes(PATHS.length);
+    for (const p of PATHS) {
+      expect(mocks.revalidatePath).toHaveBeenCalledWith(p);
+    }
+  });
+
+  it("auth update path: does NOT revalidate when only theme changes", async () => {
+    mocks.getSessionUserId.mockResolvedValue("user-1");
+    mocks.selectLimitResult.mockResolvedValue([
+      { userId: "user-1", jobLanguages: [], dismissedBanners: [] },
+    ]);
+    mocks.updateReturningResult.mockResolvedValue([{ userId: "user-1", theme: "dark" }]);
+    const { updatePreferences } = await import("../preferences");
+
+    await updatePreferences({ theme: "dark" });
+
+    expect(mocks.revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it("auth insert path: revalidates when jobLanguages is set", async () => {
+    mocks.getSessionUserId.mockResolvedValue("user-2");
+    // No existing row → falls through to insert
+    mocks.selectLimitResult.mockResolvedValue([]);
+    mocks.insertReturningResult.mockResolvedValue([{ userId: "user-2", jobLanguages: ["fr"] }]);
+    const { updatePreferences } = await import("../preferences");
+
+    await updatePreferences({ jobLanguages: ["fr"] });
+
+    expect(mocks.revalidatePath).toHaveBeenCalledTimes(PATHS.length);
+    for (const p of PATHS) {
+      expect(mocks.revalidatePath).toHaveBeenCalledWith(p);
+    }
+  });
+
+  it("revalidatePath failure is swallowed (preference write must not 500)", async () => {
+    mocks.getSessionUserId.mockResolvedValue(null);
+    mocks.revalidatePath.mockImplementation(() => {
+      throw new Error("revalidate broken");
+    });
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { updatePreferences } = await import("../preferences");
+
+    // Should resolve without throwing even though every revalidate call fails.
+    await expect(updatePreferences({ jobLanguages: ["fr"] })).resolves.toBeNull();
+    expect(mocks.writeAnonJobLanguagesCookie).toHaveBeenCalledWith(["fr"]);
+    // One warn per path
+    expect(warn).toHaveBeenCalledTimes(PATHS.length);
+    warn.mockRestore();
+  });
+});

--- a/apps/web/src/lib/actions/preferences.ts
+++ b/apps/web/src/lib/actions/preferences.ts
@@ -2,7 +2,7 @@
 
 import { eq, sql } from "drizzle-orm";
 import { headers } from "next/headers";
-import { cacheLife } from "next/cache";
+import { cacheLife, revalidatePath } from "next/cache";
 import { db } from "@/db";
 import { account, userPreferences } from "@/db/schema";
 import { auth } from "@/lib/auth";
@@ -20,6 +20,54 @@ const PASSWORD_RESET_COOLDOWN_SECONDS = 60;
  */
 function sanitizeJobLanguages(input: string[]): string[] {
   return input.filter((c) => c === "*" || getLanguage(c) != null);
+}
+
+/**
+ * Routes whose `'use cache'` output depends on the viewer's job-language
+ * filter (DB row for auth users, `JSEEK_JOB_LANGUAGES` cookie for anon).
+ * After `updatePreferences` mutates `jobLanguages`, every cached layer
+ * across these routes needs to be invalidated — otherwise the user
+ * navigates back to a stale prerender that predates the cookie write
+ * (#2916). Stays in sync with the read sites enumerated in PR #2914.
+ */
+const JOB_LANGUAGE_DEPENDENT_PATHS = [
+  "/[lang]/(app)/explore",
+  "/[lang]/(app)/[userSlug]/[watchlistSlug]",
+  "/[lang]/(app)/company/[slug]",
+] as const;
+
+/**
+ * Invalidate every `'use cache'` page that reads the viewer's
+ * `jobLanguages` so the next render reflects the just-persisted value.
+ *
+ * `revalidatePath` is the right primitive here even though the data
+ * dependency comes via cookie/DB rather than a `cacheTag`: it evicts
+ * the per-region cache entry for the route and forces a fresh server
+ * render on the next request. The caller (a client component in
+ * /settings) ALSO calls `router.refresh()` to flush the client-side
+ * router cache that holds a snapshot of /explore in memory across
+ * back-nav (#2916). Both layers must be cleared — the per-region
+ * cache is the source for the RSC payload server-side, the router
+ * cache is the source the browser uses on back-nav.
+ *
+ * Failures are swallowed because a successful preference write is the
+ * load-bearing operation; a revalidation hiccup must not 500 the form
+ * submit. The user's next hard reload would self-heal anyway.
+ */
+function invalidateJobLanguageDependentPages(): void {
+  for (const path of JOB_LANGUAGE_DEPENDENT_PATHS) {
+    try {
+      // Match the existing convention from
+      // `app/api/web/companies/request/[run_id]/status/route.ts` —
+      // single-arg call invalidates that page's cache entries across
+      // every locale. Passing the second `"page"` arg is also valid
+      // but the unspecified default is what the rest of the codebase
+      // uses for App-Router page paths.
+      revalidatePath(path);
+    } catch (err) {
+      console.warn("[preferences] revalidatePath failed for", path, err);
+    }
+  }
 }
 
 export async function getPreferences() {
@@ -78,6 +126,12 @@ export async function updatePreferences(
     // server-resolved field. See issue #2850 + `anon-preferences.ts`.
     if (data.jobLanguages !== undefined) {
       await writeAnonJobLanguagesCookie(data.jobLanguages);
+      // Cookie write happened — flush every page whose `'use cache'`
+      // output depends on the cookie. Without this the back-nav from
+      // /settings to /explore renders the prerender that predates the
+      // toggle; the user only sees the new filter after a hard reload
+      // (#2916).
+      invalidateJobLanguageDependentPages();
     }
     return null;
   }
@@ -143,6 +197,16 @@ export async function updatePreferences(
       .where(eq(userPreferences.userId, userId))
       .returning();
 
+    // `jobLanguages` was part of this write — flush every cached
+    // page whose render reads it. Mirrors the anon path (#2916). The
+    // mutation for other fields (theme/locale/currency) is observed
+    // by the caller via `router.refresh()` and doesn't need a
+    // server-side `revalidatePath` because none of those flow into
+    // the explore/watchlist `'use cache'` outputs.
+    if (data.jobLanguages !== undefined) {
+      invalidateJobLanguageDependentPages();
+    }
+
     return row;
   }
 
@@ -166,6 +230,15 @@ export async function updatePreferences(
       },
     })
     .returning();
+
+  // First-write inserts always materialise `jobLanguages` (defaults to
+  // `[]` when omitted), which still affects every dependent page if
+  // the caller passed a non-default — invalidate when the field was
+  // explicitly set so the upsert path stays consistent with the
+  // update path above (#2916).
+  if (data.jobLanguages !== undefined) {
+    invalidateJobLanguageDependentPages();
+  }
 
   return row;
 }


### PR DESCRIPTION
## Summary

Fixes #2916. PR #2914 (just merged) made the anon `jobLanguages` cookie persist, but the user-visible flow still failed: after setting a French-only filter in /settings, browsing back to /explore kept showing \"all languages\" until a hard reload. The page-level `'use cache'` on `/[lang]/(app)/explore` (60s revalidate) plus Next.js's client-side router cache held a snapshot that predated the cookie write.

Two cache layers — both flushed on every `jobLanguages` mutation:

1. **Server**: `revalidatePath` on the three pages whose `'use cache'` output reads the filter — explore, watchlist, company. Anon and auth code paths both invalidate, gated on `data.jobLanguages !== undefined` so neutral updates (theme, currency, dismissBanner) don't churn the cache.
2. **Client**: `router.refresh()` in `GeneralSettings`'s `jobLanguages` effect after `updatePreferences` resolves, so the in-memory router cache for /explore is dropped.

`revalidatePath` failures are swallowed with a `console.warn` so a transient cache hiccup never 500s a preference write.

## Why both layers

`revalidatePath` evicts the per-region `'use cache'` entry server-side — necessary for the next *server* request to see fresh data. `router.refresh()` drops the *client* router cache so the very next navigation back to /explore (Link click or browser back) refetches the RSC payload instead of replaying the in-memory tree. Either alone leaves a hole.

## Cache-components contract

Build classification stays `◐ Partial Prerender` for /[lang]/explore plus the watchlist / company routes — verified via `pnpm test:isr`. `revalidatePath` is a tag-style eviction, not a runtime API access, so it doesn't taint any cache boundary.

## Test plan

- [x] `pnpm test` — 511/511 pass (incl. new 6-case `preferences-revalidation.test.ts` covering anon cookie + auth update + auth insert paths + swallow-failure contract).
- [x] `pnpm test:isr` — 14/14 pass; /[lang]/explore, /[lang]/[userSlug]/[watchlistSlug], /[lang]/company/[slug] all stay ◐ Partial Prerender.
- [x] `pnpm exec tsc --noEmit` — clean.
- [x] Empirical (production build, anon flow):
  - **BEFORE** the fix (architectural reading + curl seed): cookie `[\"*\"]` -> click français in /settings -> goto /en/explore renders \"Showing jobs in all languages\" until hard reload.
  - **AFTER**: cookie `[\"fr\"]` -> goto /en/explore renders \"Showing jobs in français\" without any reload. Reload still consistent. Real browser-back via `goBack()` also consistent.
- [x] Auth-flow regression: `revalidatePath` only fires when `data.jobLanguages` is in the payload, so theme/currency/locale-only writes are unchanged. No live auth-DB end-to-end this PR (same as #2914) — happy-path covered by the auth update + auth insert tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)