### PR TITLE
fix(web): server-render /settings data instead of client useEffect waterfall

### DIFF
--- a/apps/web/app/[lang]/(app)/settings/page.tsx
+++ b/apps/web/app/[lang]/(app)/settings/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { isLocale, defaultLocale } from "@/lib/i18n";
 import { SettingsLoader } from "./settings-loader";
 
@@ -5,8 +6,29 @@ type Props = {
   params: Promise<{ lang: string }>;
 };
 
+/**
+ * The Suspense fallback matches the previous client-side spinner so
+ * the perceived loading state is unchanged on cold loads — only the
+ * happy path is faster (no client `useEffect` waterfall, see
+ * `settings-loader.tsx`). cacheComponents requires every dynamic
+ * subtree to live inside a `<Suspense>` boundary; `SettingsLoader`
+ * reads `headers()`/`cookies()` transitively via Better Auth so it
+ * is the dynamic hole here.
+ */
+function SettingsFallback() {
+  return (
+    <div className="flex items-center justify-center py-24">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary" />
+    </div>
+  );
+}
+
 export default async function SettingsPage({ params }: Props) {
   const { lang } = await params;
   const locale = isLocale(lang) ? lang : defaultLocale;
-  return <SettingsLoader locale={locale} />;
+  return (
+    <Suspense fallback={<SettingsFallback />}>
+      <SettingsLoader locale={locale} />
+    </Suspense>
+  );
 }

--- a/apps/web/app/[lang]/(app)/settings/settings-loader.tsx
+++ b/apps/web/app/[lang]/(app)/settings/settings-loader.tsx
@@ -1,62 +1,69 @@
-"use client";
-
-import { useEffect, useState } from "react";
 import { GeneralSettings } from "@/components/settings/GeneralSettings";
 import {
   getPreferences,
   getAvailableJobLanguages,
   getViewerJobLanguages,
-  type AvailableLanguage,
 } from "@/lib/actions/preferences";
 import { getCurrencyRates } from "@/lib/actions/search";
+import { getSession } from "@/lib/sessionCache";
 
-type SettingsData = {
-  jobLanguages: string[];
-  displayCurrency: string;
-  salaryPeriod: string | null;
-  availableCurrencies: string[];
-  availableLanguages: AvailableLanguage[];
-};
+/**
+ * Server-side data fetcher for the /settings (general) page.
+ *
+ * Runs all four data dependencies in parallel inside the React server
+ * tree so the client receives the form fully hydrated — no
+ * post-mount `useEffect` waterfall, no spinner. This is the second
+ * half of the #2918 fix: PR #2921 cut `getAvailableJobLanguages` from
+ * 4s to ~700ms by switching it to a Typesense facet, but the four
+ * server actions still ran *sequentially after hydration* in the
+ * client `useEffect`, so the slowest call (Typesense round-trip)
+ * gated "fully settled" on every cold load. Moving the awaits into
+ * the server tree:
+ *
+ * - merges the four POST round-trips into the initial document GET
+ * - lets the cacheable calls (`getAvailableJobLanguages`,
+ *   `getCurrencyRates`, both `'use cache'`) be served from the
+ *   per-region in-memory cache without ever crossing the wire
+ * - keeps the session-scoped reads (`getPreferences`,
+ *   `getViewerJobLanguages`) on their existing dynamic path; they
+ *   read `headers()` via Better Auth so the parent `<Suspense>` in
+ *   `page.tsx` is what makes them PPR-compatible.
+ *
+ * The leading `getSession()` await is the load-bearing dynamic gate:
+ * it reads `headers()` via Better Auth, so under cacheComponents the
+ * build-time prerender bails *before* the parallel Typesense /
+ * Postgres reads ever fire. Without this gate, the Typesense calls
+ * (inside `'use cache'`) populate during the prerender's parallel
+ * sweep across 974 pages and contend with the rest of the build for
+ * Typesense's request budget — producing build-time HTTP 429s. With
+ * the gate first, the function only ever executes at request time,
+ * where the per-region `'use cache'` layer absorbs the read cost.
+ *
+ * The remaining three awaits stay in a single `Promise.all` so the
+ * slowest read is the bound rather than the sum (~932ms cold vs
+ * ~1.2s sequential under cacheComponents per-boundary clean-snapshot
+ * semantics).
+ */
+export async function SettingsLoader({ locale }: { locale: string }) {
+  // Dynamic gate — see comment above. Discarded result; the same
+  // session is re-resolved (per-request memoised) inside
+  // `getPreferences` and `getViewerJobLanguages` below.
+  await getSession();
 
-export function SettingsLoader({ locale }: { locale: string }) {
-  const [data, setData] = useState<SettingsData | null>(null);
-
-  useEffect(() => {
-    // ``getViewerJobLanguages`` unifies the auth (DB row) and anon
-    // (cookie) paths so the toggle reflects the persisted state for
-    // both. Other prefs (currency / salary period) are auth-only —
-    // the anon defaults are baked into ``GeneralSettings``.
-    Promise.all([
-      getPreferences(),
-      getViewerJobLanguages(),
-      getAvailableJobLanguages(),
-      getCurrencyRates(),
-    ]).then(([prefs, jobLanguages, availableLanguages, currencyRates]) => {
-      setData({
-        jobLanguages,
-        displayCurrency: prefs?.displayCurrency ?? "EUR",
-        salaryPeriod: prefs?.salaryPeriod ?? null,
-        availableCurrencies: currencyRates.map((r) => r.currency),
-        availableLanguages,
-      });
-    });
-  }, []);
-
-  if (!data) {
-    return (
-      <div className="flex items-center justify-center py-24">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary" />
-      </div>
-    );
-  }
+  const [prefs, jobLanguages, availableLanguages, currencyRates] = await Promise.all([
+    getPreferences(),
+    getViewerJobLanguages(),
+    getAvailableJobLanguages(),
+    getCurrencyRates(),
+  ]);
 
   return (
     <GeneralSettings
-      savedJobLanguages={data.jobLanguages}
-      savedDisplayCurrency={data.displayCurrency}
-      savedSalaryPeriod={data.salaryPeriod}
-      availableCurrencies={data.availableCurrencies}
-      availableLanguages={data.availableLanguages}
+      savedJobLanguages={jobLanguages}
+      savedDisplayCurrency={prefs?.displayCurrency ?? "EUR"}
+      savedSalaryPeriod={prefs?.salaryPeriod ?? null}
+      availableCurrencies={currencyRates.map((r) => r.currency)}
+      availableLanguages={availableLanguages}
       locale={locale}
     />
   );


### PR DESCRIPTION
## Summary

PR #2921 cut `getAvailableJobLanguages` from 4s to ~700ms by switching to a Typesense facet, but the four server actions still ran *after hydration* in a client `useEffect`. The slowest call (~939ms cold dev / ~1.0s cold prod) gated "fully settled" on every cold load.

This PR moves the four data fetches into a server component (`Promise.all`) so the data is part of the initial RSC payload — no client `useEffect`, no post-mount POST round-trip, no spinner cycle. `<Suspense>` in `page.tsx` keeps it cacheComponents-PPR-compatible.

The leading `getSession()` await is the load-bearing dynamic gate: it reads `headers()` via Better Auth, so under cacheComponents the build-time prerender bails *before* the parallel Typesense reads ever fire. Without it the `'use cache'` calls populate during the 974-page prerender sweep and contend with the rest of the build for Typesense's request budget — producing build-time HTTP 429s.

## Measurements

Playwright "fully settled" = wait for `.animate-spin` to disappear (form rendered).

| Surface | Before #2918 | After #2921 (current `main`) | This PR |
|---|---|---|---|
| Dev cold | 9778ms | 6334ms | **5335ms** |
| Dev warm | n/a | 416ms | **223ms** |
| Prod cold (anon, cache-bust) | n/a | ~1500ms | projected ~500–800ms |
| Prod warm | n/a | ~250ms | projected ~150ms |

The remaining ~5s of dev cold time is Turbopack's first-compile of the route, inherent to dev mode and not reproducible in prod. The dev server log shows `next.js: 4.4s` (Turbopack) on cold compile of `/[lang]/settings`.

## Server-side per-call breakdown (cold dev, before this PR)
```
getCurrencyRates:           309ms
getPreferences:               2ms
getViewerJobLanguages:        3ms
getAvailableJobLanguages:   932ms  ← gating critical path
```
After this PR these 4 calls run in parallel (`Promise.all`) inside the server component — slowest is the bound (~932ms cold), and they run *during* the initial document GET rather than as a separate post-hydration round-trip.

## Build classification

- `/[lang]/settings`: ◐ (Partial Prerender) — preserved.
- Pre-existing `mcp-server/handler` import error in `apps/web/app/mcp/route.ts` is environmental (workspace `@jseek/mcp-server` `dist/` not built locally) and is fixed by `pnpm --filter @jseek/mcp-server build`.

## Test plan

- [x] `pnpm test` — 511 tests pass
- [x] `pnpm exec tsc --noEmit` — clean (no settings-related errors)
- [x] `pnpm build` — `/[lang]/settings` classifies as ◐, no Typesense 429 build failures
- [x] Visual verification (Playwright screenshot) — Theme/Language/Job-languages/Salary-display sections all render with populated data
- [x] Smoke test: page loads cleanly with no console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)