### PR TITLE
fix(web): retry Postgres queries on transient connection errors

### DIFF
--- a/apps/web/src/lib/__tests__/db-retry.test.ts
+++ b/apps/web/src/lib/__tests__/db-retry.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { isRetryableError, withDbRetry } from "../db-retry";
+
+/**
+ * Coverage for the #2918 follow-up retry helper. The build at
+ * 2026-05-09T15:41:49Z died on a single `read ECONNRESET` during
+ * `_fetchCompanyBySlugFromPostgres`; this helper retries that class
+ * of error and lets non-retryable errors propagate untouched.
+ */
+
+const _econnreset = (): Error => {
+  const e = new Error("read ECONNRESET") as Error & { code: string };
+  e.code = "ECONNRESET";
+  return e;
+};
+
+describe("isRetryableError", () => {
+  it("matches by Node `code` (ECONNRESET)", () => {
+    expect(isRetryableError(_econnreset())).toBe(true);
+  });
+
+  it.each(["ETIMEDOUT", "ECONNREFUSED", "EPIPE"])(
+    "matches by Node `code` (%s)",
+    (code) => {
+      const e = new Error("net") as Error & { code: string };
+      e.code = code;
+      expect(isRetryableError(e)).toBe(true);
+    },
+  );
+
+  it("matches Supabase pooler restart message", () => {
+    const e = new Error(
+      "terminating connection due to administrator command",
+    );
+    expect(isRetryableError(e)).toBe(true);
+  });
+
+  it("matches postgres.js 'Connection terminated unexpectedly'", () => {
+    expect(isRetryableError(new Error("Connection terminated unexpectedly")))
+      .toBe(true);
+  });
+
+  it("recurses into `cause` (postgres.js wraps the network error)", () => {
+    const inner = _econnreset();
+    const outer = new Error("Failed query: SELECT …");
+    (outer as Error & { cause: unknown }).cause = inner;
+    expect(isRetryableError(outer)).toBe(true);
+  });
+
+  it("does NOT match unrelated Postgres errors (syntax, constraint)", () => {
+    expect(isRetryableError(new Error("syntax error at or near \"FROM\""))).toBe(
+      false,
+    );
+    expect(
+      isRetryableError(
+        new Error("duplicate key value violates unique constraint"),
+      ),
+    ).toBe(false);
+  });
+
+  it("returns false for non-error inputs", () => {
+    expect(isRetryableError(null)).toBe(false);
+    expect(isRetryableError(undefined)).toBe(false);
+    expect(isRetryableError("string")).toBe(false);
+    expect(isRetryableError(42)).toBe(false);
+  });
+});
+
+describe("withDbRetry", () => {
+  // Pin Math.random so the jitter component is deterministic in the
+  // sleep-arg assertion. 0 jitter keeps the math obvious: each delay
+  // equals the base.
+  beforeEach(() => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the result on the first attempt without retrying", async () => {
+    const fn = vi.fn().mockResolvedValue("ok");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const out = await withDbRetry(fn, { sleep });
+
+    expect(out).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it("retries once after ECONNRESET, succeeds on second attempt", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(_econnreset())
+      .mockResolvedValueOnce("ok");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const out = await withDbRetry(fn, { sleep });
+
+    expect(out).toBe("ok");
+    expect(fn).toHaveBeenCalledTimes(2);
+    // First retry waits 200ms (base) + 0 jitter = 200ms
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(200);
+    expect(console.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("exhausts 3 attempts on persistent ECONNRESET, throws the last error", async () => {
+    const finalErr = _econnreset();
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(_econnreset())
+      .mockRejectedValueOnce(_econnreset())
+      .mockRejectedValueOnce(finalErr);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await expect(withDbRetry(fn, { sleep })).rejects.toBe(finalErr);
+
+    expect(fn).toHaveBeenCalledTimes(3);
+    // 2 sleeps between 3 attempts: 200ms then 400ms (jitter pinned to 0)
+    expect(sleep).toHaveBeenNthCalledWith(1, 200);
+    expect(sleep).toHaveBeenNthCalledWith(2, 400);
+    // No log on the final failure (we don't tell observability "retrying"
+    // when we're not retrying); only attempts 1 and 2 log.
+    expect(console.warn).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT retry on non-retryable errors (syntax error)", async () => {
+    const syntaxErr = new Error("syntax error at or near \"FROM\"");
+    const fn = vi.fn().mockRejectedValue(syntaxErr);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await expect(withDbRetry(fn, { sleep })).rejects.toBe(syntaxErr);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it("does NOT retry on constraint violations", async () => {
+    const constraintErr = new Error(
+      "duplicate key value violates unique constraint \"company_slug_key\"",
+    );
+    const fn = vi.fn().mockRejectedValue(constraintErr);
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await expect(withDbRetry(fn, { sleep })).rejects.toBe(constraintErr);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses backoff schedule [200, 400, 800] by default", async () => {
+    // 4 attempts forces all 3 sleep windows to fire in sequence.
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(_econnreset())
+      .mockRejectedValueOnce(_econnreset())
+      .mockRejectedValueOnce(_econnreset())
+      .mockResolvedValueOnce("ok");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const out = await withDbRetry(fn, { sleep, attempts: 4 });
+
+    expect(out).toBe("ok");
+    expect(sleep).toHaveBeenNthCalledWith(1, 200);
+    expect(sleep).toHaveBeenNthCalledWith(2, 400);
+    expect(sleep).toHaveBeenNthCalledWith(3, 800);
+  });
+
+  it("adds jitter on top of the base delay (Math.random pinned high)", async () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.99); // → floor(0.99 * 101) = 99
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(_econnreset())
+      .mockResolvedValueOnce("ok");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await withDbRetry(fn, { sleep });
+
+    expect(sleep).toHaveBeenCalledWith(200 + 99);
+  });
+
+  it("respects fake timers (sleep helper is overridable)", async () => {
+    // Assert the contract: callers can pass `sleep` (we use it under
+    // vi.useFakeTimers in the suite). This test pins fake timers,
+    // hands withDbRetry a real-ish sleep that resolves on tick, and
+    // verifies the loop awaits each sleep.
+    vi.useFakeTimers();
+    try {
+      const fn = vi
+        .fn()
+        .mockRejectedValueOnce(_econnreset())
+        .mockResolvedValueOnce("ok");
+      let sleeps = 0;
+      const sleep = (_ms: number): Promise<void> => {
+        sleeps += 1;
+        return Promise.resolve();
+      };
+
+      const out = await withDbRetry(fn, { sleep });
+      expect(out).toBe("ok");
+      expect(sleeps).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("logs the label so observability can tell call sites apart", async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(_econnreset())
+      .mockResolvedValueOnce("ok");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    await withDbRetry(fn, { sleep, label: "companyBySlug[chevron]" });
+
+    const warnArg = (console.warn as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as string;
+    expect(warnArg).toContain("companyBySlug[chevron]");
+    expect(warnArg).toContain("ECONNRESET");
+  });
+});

--- a/apps/web/src/lib/actions/__tests__/company.test.ts
+++ b/apps/web/src/lib/actions/__tests__/company.test.ts
@@ -230,6 +230,31 @@ describe("getCompanyBySlug — Postgres fallback", () => {
     const out = await getCompanyBySlug("acme", "en");
     expect(out).toBeNull();
   });
+
+  it("retries the Postgres query on transient ECONNRESET (#2918 follow-up)", async () => {
+    /** The 2026-05-09 Vercel build died on a single `read ECONNRESET`
+     * during this exact code path (OG-image prerender →
+     * `_fetchCompanyBySlugFromPostgres`). The next build 2 min later
+     * succeeded — a flake, not a structural break. The retry helper
+     * must turn this single transient error into a successful query
+     * so the prerender finishes. */
+    searchMock.mockRejectedValue(new Error("typesense down"));
+    const econn = new Error("read ECONNRESET") as Error & { code: string };
+    econn.code = "ECONNRESET";
+    dbExecuteMock
+      .mockRejectedValueOnce(econn)
+      .mockResolvedValueOnce([_pgRow]);
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+
+    const out = await getCompanyBySlug("acme", "en");
+
+    expect(out?.description).toBe("From Postgres");
+    expect(dbExecuteMock).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
 });
 
 describe("getCompanyBySlug — caching contract", () => {

--- a/apps/web/src/lib/actions/company.ts
+++ b/apps/web/src/lib/actions/company.ts
@@ -3,6 +3,7 @@
 import { sql } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 import { db } from "@/db";
+import { withDbRetry } from "@/lib/db-retry";
 import { getSearchProvider } from "@/lib/search";
 import type { SearchResultPosting } from "@/lib/search";
 import {
@@ -690,37 +691,48 @@ async function _fetchCompanyBySlugFromPostgres(
   slug: string,
   locale: string,
 ): Promise<CompanyDetail | null> {
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    id: string;
-    name: string;
-    slug: string;
-    icon: string | null;
-    logo: string | null;
-    website: string | null;
-    description: string | null;
-    industry_id: number | null;
-    industry_name: string | null;
-    employee_count_range: number | null;
-    founded_year: number | null;
-  }>(sql`
-    SELECT c.id, c.name, c.slug, c.icon, c.logo, c.website,
-      COALESCE(cd.description, c.description) AS description,
-      c.industry AS industry_id,
-      COALESCE(ind_name.name, i.name) AS industry_name,
-      c.employee_count_range,
-      c.founded_year
-    FROM company c
-    LEFT JOIN industry i ON i.id = c.industry
-    LEFT JOIN company_description cd
-      ON cd.company_id = c.id AND cd.locale = ${locale}
-    LEFT JOIN LATERAL (
-      SELECT name FROM industry_name
-      WHERE industry_id = c.industry AND locale IN (${locale}, 'en') AND is_display = true
-      ORDER BY (locale = ${locale})::int DESC LIMIT 1
-    ) ind_name ON c.industry IS NOT NULL
-    WHERE c.slug = ${slug}
-  `);
+  // Retry on transient connection-class errors (#2918): the build that
+  // killed prerender at 2026-05-09T15:41:49Z hit `read ECONNRESET` from
+  // the Supabase pooler on this exact query. The next build 2 min later
+  // succeeded → flake, not structural break. `withDbRetry` only retries
+  // ECONNRESET / ETIMEDOUT / ECONNREFUSED / EPIPE / "Connection
+  // terminated"-class messages; syntax / constraint / business errors
+  // propagate immediately so the original signal is preserved.
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        id: string;
+        name: string;
+        slug: string;
+        icon: string | null;
+        logo: string | null;
+        website: string | null;
+        description: string | null;
+        industry_id: number | null;
+        industry_name: string | null;
+        employee_count_range: number | null;
+        founded_year: number | null;
+      }>(sql`
+        SELECT c.id, c.name, c.slug, c.icon, c.logo, c.website,
+          COALESCE(cd.description, c.description) AS description,
+          c.industry AS industry_id,
+          COALESCE(ind_name.name, i.name) AS industry_name,
+          c.employee_count_range,
+          c.founded_year
+        FROM company c
+        LEFT JOIN industry i ON i.id = c.industry
+        LEFT JOIN company_description cd
+          ON cd.company_id = c.id AND cd.locale = ${locale}
+        LEFT JOIN LATERAL (
+          SELECT name FROM industry_name
+          WHERE industry_id = c.industry AND locale IN (${locale}, 'en') AND is_display = true
+          ORDER BY (locale = ${locale})::int DESC LIMIT 1
+        ) ind_name ON c.industry IS NOT NULL
+        WHERE c.slug = ${slug}
+      `),
+    { label: `companyBySlug[${slug}]` },
+  );
 
   type Row = {
     id: string; name: string; slug: string; icon: string | null;

--- a/apps/web/src/lib/db-retry.ts
+++ b/apps/web/src/lib/db-retry.ts
@@ -1,0 +1,140 @@
+/**
+ * Postgres connection-class retry helper.
+ *
+ * Background — issue #2918: a Vercel production build at
+ * 2026-05-09T15:41:49Z failed during OG-image prerender for
+ * `/en/company/chevron/opengraph-image-y6bp13`. The next build two
+ * minutes later succeeded. The failing query was the company-by-slug
+ * Postgres fallback (`_fetchCompanyBySlugFromPostgres`), and the cause
+ * was `read ECONNRESET` against the Supabase pooler — a transient
+ * connection event, not a structural break.
+ *
+ * Project memory rule: "Supabase is fragile — light queries only ...
+ * use local Postgres for company/posting counts." This helper does NOT
+ * violate that rule; it makes existing queries more resilient to known
+ * transient fragility (pooler restarts, idle-connection drops) by
+ * retrying connection-class errors with exponential backoff + jitter.
+ *
+ * Retry policy:
+ *   - 3 attempts total (initial + 2 retries)
+ *   - Exponential backoff: 200ms / 400ms / 800ms baseline + 0..100ms jitter
+ *   - Retry only on transient connection errors (see `isRetryable`)
+ *   - Non-retryable errors (syntax, constraint, business logic) propagate
+ *     immediately so callers see the real failure
+ *   - `console.warn` on every retry so observability picks it up
+ *
+ * Scope of this PR: wraps `_fetchCompanyBySlugFromPostgres` only. Other
+ * build-critical Postgres call sites (sitemap, related-posts, company
+ * directory) are likely to want the same protection — flagged as a
+ * follow-up rather than expanded mechanically here.
+ */
+
+const RETRYABLE_ERROR_CODES = new Set([
+  "ECONNRESET",
+  "ETIMEDOUT",
+  "ECONNREFUSED",
+  "EPIPE",
+]);
+
+/**
+ * Substring matches against `err.message` for transient pooler/server
+ * events that don't surface a Node `code`. These come from postgres.js
+ * and the Supabase pgbouncer:
+ *   - "Connection terminated"           — postgres.js socket closed
+ *   - "terminating connection due to administrator command" — pooler restart
+ *   - "Connection terminated unexpectedly" — postgres.js variant
+ *   - "Connection ended"                — postgres.js graceful close
+ */
+const RETRYABLE_MESSAGE_FRAGMENTS = [
+  "connection terminated",
+  "terminating connection",
+  "connection ended",
+  "connection closed",
+];
+
+export function isRetryableError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const e = err as { code?: unknown; message?: unknown; cause?: unknown };
+  if (typeof e.code === "string" && RETRYABLE_ERROR_CODES.has(e.code)) {
+    return true;
+  }
+  if (typeof e.message === "string") {
+    const lower = e.message.toLowerCase();
+    for (const frag of RETRYABLE_MESSAGE_FRAGMENTS) {
+      if (lower.includes(frag)) return true;
+    }
+  }
+  // postgres.js wraps the network error in a `Failed query: ... [cause]: …`
+  // shape — recurse into `cause` once so we still catch the inner ECONNRESET.
+  if (e.cause !== undefined && e.cause !== err) {
+    return isRetryableError(e.cause);
+  }
+  return false;
+}
+
+export interface DbRetryOptions {
+  /** Total attempts (initial + retries). Defaults to 3. */
+  attempts?: number;
+  /**
+   * Base delays in ms before each retry attempt. The N-th retry waits
+   * `baseDelaysMs[N-1] + jitter`. Defaults to [200, 400, 800].
+   */
+  baseDelaysMs?: number[];
+  /** Max additional jitter added to each delay. Defaults to 100ms. */
+  maxJitterMs?: number;
+  /** Sleep override for tests. */
+  sleep?: (ms: number) => Promise<void>;
+  /** Predicate override for tests / niche call-sites. */
+  isRetryable?: (err: unknown) => boolean;
+  /** Label used in retry log lines. */
+  label?: string;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Run `fn`, retrying on transient connection-class errors. Returns the
+ * first successful result, or throws the last error after exhausting
+ * the attempt budget. The final throw preserves the original exception
+ * (no wrapping) so call-site error handling stays unchanged.
+ */
+export async function withDbRetry<T>(
+  fn: () => Promise<T>,
+  opts: DbRetryOptions = {},
+): Promise<T> {
+  const attempts = opts.attempts ?? 3;
+  const baseDelays = opts.baseDelaysMs ?? [200, 400, 800];
+  const maxJitter = opts.maxJitterMs ?? 100;
+  const sleep = opts.sleep ?? defaultSleep;
+  const retryable = opts.isRetryable ?? isRetryableError;
+  const label = opts.label ?? "db";
+
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      const isLast = attempt >= attempts;
+      if (isLast || !retryable(err)) {
+        throw err;
+      }
+      const baseDelay = baseDelays[attempt - 1] ?? baseDelays[baseDelays.length - 1] ?? 200;
+      const jitter = Math.floor(Math.random() * (maxJitter + 1));
+      const delay = baseDelay + jitter;
+      const code = (err as { code?: unknown }).code;
+      const message = (err as { message?: unknown }).message;
+      console.warn(
+        `[${label}] transient error on attempt ${attempt}/${attempts}, ` +
+          `retrying in ${delay}ms ` +
+          `(code=${typeof code === "string" ? code : "n/a"}, ` +
+          `message=${typeof message === "string" ? message.slice(0, 200) : "n/a"})`,
+      );
+      await sleep(delay);
+    }
+  }
+  // Unreachable: the loop either returns or throws. Re-throw lastErr to
+  // satisfy the type checker.
+  throw lastErr;
+}


### PR DESCRIPTION
## Summary

Fixes the Vercel build flake at deployment `https://jobseek-h9nbb3m59-viktor-shcherbakovs-projects.vercel.app` (2026-05-09T15:41:49Z) — Postgres `ECONNRESET` during company OG image prerender for `/en/company/chevron/opengraph-image-y6bp13` and `/it/company/sun-pharmaceutical/...`. Next build succeeded; confirms transient.

Adds `withDbRetry(fn, opts)` at `apps/web/src/lib/db-retry.ts`. Retry policy:
- 3 attempts (initial + 2 retries)
- Exponential backoff 200/400/800ms + 0-100ms jitter
- Retryable: `ECONNRESET`, `ETIMEDOUT`, `ECONNREFUSED`, `EPIPE`, plus `terminating connection`/`connection terminated`/`connection ended`/`connection closed` (Supabase pooler restarts)
- Recurses into `err.cause` once (postgres.js wraps network errors)
- `console.warn` per retry for observability

Wraps `_fetchCompanyBySlugFromPostgres` only — the path that actually flaked. Other `db.execute` call sites listed as follow-up in #2930.

## Refs

Refs #2930 (the build-resilience issue this fix addresses).

## Tests

- 18 unit tests for the helper itself (predicate semantics, retry counts, backoff schedule, jitter math, label propagation, fake-timer compat)
- 1 integration test in `company.test.ts` for retry-then-success through `getCompanyBySlug`
- Empirical break test: `attempts = 1` causes 7 retry-dependent tests to fail