### PR TITLE
fix(web): use object-contain on CompanyIcon to stop logo stretch

### DIFF
--- a/apps/web/src/components/CompanyIcon.tsx
+++ b/apps/web/src/components/CompanyIcon.tsx
@@ -24,6 +24,13 @@ type CompanyIconProps = {
  * small WebP and Vercel docs say sub-10KB images shouldn't be transformed.
  * Width/height attrs preserved so CLS stays bounded; lazy/decoding=async
  * remain next/image defaults.
+ *
+ * `object-contain` preserves the source aspect ratio inside the square
+ * slot — R2 icons are stored at their natural aspect ratio (see #2935 and
+ * apps/crawler/src/image_sync.py::process_icon, which uses
+ * `image.thumbnail` to cap the longest edge while preserving ratio).
+ * Without object-contain, `width=height` + `size-N` would stretch wide
+ * wordmarks (Oracle 1509x962, NXP 1552x534, Coop 602x204, etc.).
  */
 export function CompanyIcon({ icon, alt, size, className = "" }: CompanyIconProps) {
   const { box, fallback } = SIZE_MAP[size];
@@ -36,7 +43,7 @@ export function CompanyIcon({ icon, alt, size, className = "" }: CompanyIconProp
         width={size}
         height={size}
         unoptimized
-        className={`${base} ${className}`.trim()}
+        className={`${base} object-contain ${className}`.trim()}
       />
     );
   }

--- a/apps/web/src/components/__tests__/CompanyIcon.test.tsx
+++ b/apps/web/src/components/__tests__/CompanyIcon.test.tsx
@@ -47,4 +47,16 @@ describe("CompanyIcon", () => {
     const img = container.querySelector("img")!;
     expect(img.getAttribute("srcset")).toBeNull();
   });
+
+  it("applies object-contain so non-square source assets are not stretched (#2935)", () => {
+    // R2 icons are stored at natural aspect ratio (image_sync.process_icon
+    // uses thumbnail() which preserves ratio). Forcing width=height onto a
+    // non-square source without object-fit stretches the image; object-contain
+    // letterboxes/pillarboxes instead.
+    const { container } = render(
+      <CompanyIcon icon="https://example.com/i.webp" alt="Acme" size={32} />,
+    );
+    const img = container.querySelector("img")!;
+    expect(img.className).toContain("object-contain");
+  });
 });


### PR DESCRIPTION
## Summary

- Closes #2935.
- Add `object-contain` to the rendered `<img>` in `CompanyIcon` so non-square R2 icons letterbox/pillarbox inside the square slot instead of stretching.

## Why this is a CSS-only fix

`apps/crawler/src/image_sync.py::process_icon` uses `image.thumbnail((128, 128))` which **preserves aspect ratio** — it caps the longest edge at 128 and lets the shorter edge fall where it lies. So R2 holds icons at the source aspect ratio (and some pre-#2877 assets are still much larger). The renderer was the missing half: `width={size}` + `height={size}` + `size-8` (32x32) with no `object-fit` stretches a wide wordmark vertically.

## Empirical evidence (probed live)

| Slug | Source dimensions | Aspect ratio | Pre-fix render |
| --- | --- | --- | --- |
| oracle | 1509x962 (webp) | 1.569 (wide) | stretched tall |
| nxp | 1552x534 (webp) | 2.906 (very wide) | stretched tall |
| salesforce | 92x64 (webp) | 1.438 (wide) | stretched tall |
| coop | 602x205 (svg viewBox) | 2.94 (very wide) | stretched tall |
| ibm | 100x101 (webp) | 0.99 (square) | rendered correctly (control case) |

Plus dozens of others surfaced by Playwright (next/icon webp 152x152, target 96x96, qualcomm 1361x1567, tailored-brands 231x43, ...).

## Verification

- `pnpm test src/components/__tests__/CompanyIcon.test.tsx` — 6/6 passing (5 prior + 1 new regression test asserting `object-contain` is on the rendered `<img>`).
- Local dev server inspection: `<img class="size-8 shrink-0 rounded object-contain" ...>` for all 5 affected slugs.
- Playwright `getComputedStyle().objectFit === "contain"` confirmed for every CompanyIcon on the 5 pages.
- Visual screenshots at 32x32 box: Oracle "O" mark renders as wide oval (correct), NXP wordmark renders short (correct), Salesforce cloud renders wider-than-tall (correct), Coop wordmark renders short (correct), IBM unchanged (square source).

## Out of scope

The IBM R2 bytes are still the Teamtailor "t" mark (PR #2934 may not have propagated, or Cloudflare cache hasn't evicted) — that is a separate data fix tracked in #2932/#2934, not this CSS fix.

## Test plan

- [x] `pnpm test` for CompanyIcon component
- [x] Local dev render of /en/company/oracle, /nxp, /salesforce, /coop, /ibm
- [ ] After merge, verify on jseek.co/en/company/oracle that the red "O" renders as a wide rounded rectangle, not a tall stretched shape