### PR TITLE
feat(web): add Regions cluster to location modals (closes #2940)

### DIFF
--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -297,21 +297,21 @@ msgstr "Alle Daten werden bei Übertragung und Speicherung verschlüsselt."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Alle Branchen"
 
+#. All languages option
+#. js-lingui-explicit-id
+#: src/components/settings/GeneralSettings.tsx:244
+msgid "settings.general.jobLanguages.all"
+msgstr "Alle Sprachen"
+
 #. Title for the all-languages modal in settings
 #. js-lingui-explicit-id
 #: src/components/settings/JobLanguageModal.tsx:56
 msgid "settings.jobLanguages.modal.title"
 msgstr "Alle Sprachen"
 
-#. All languages option
-#. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:234
-msgid "settings.general.jobLanguages.all"
-msgstr "Alle Sprachen"
-
 #. Title for the all-locations modal on company page
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:145
+#: src/components/search/location-modal.tsx:183
 msgid "company.locationModal.title"
 msgstr "Alle Standorte"
 
@@ -639,17 +639,17 @@ msgstr "Ändere dein Passwort über einen sicheren E-Mail-Link."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Ändern…"
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "E-Mail überprüfen"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
 msgstr "E-Mail prüfen"
+
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
+msgstr "E-Mail überprüfen"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -659,13 +659,13 @@ msgstr "Verfügbarkeit wird geprüft..."
 
 #. Theme settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:160
+#: src/components/settings/GeneralSettings.tsx:170
 msgid "settings.general.theme.description"
 msgstr "Wähle das Erscheinungsbild von Job Seek."
 
 #. Salary display settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:305
+#: src/components/settings/GeneralSettings.tsx:315
 msgid "settings.general.salary.description"
 msgstr "Passen Sie an, wie Gehälter in Suchergebnissen und Stellendetails angezeigt werden."
 
@@ -683,7 +683,7 @@ msgstr "Wähle den passenden Plan"
 
 #. Job languages settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:219
+#: src/components/settings/GeneralSettings.tsx:229
 msgid "settings.general.jobLanguages.description"
 msgstr "Wähle aus, in welchen Sprachen du Stellenanzeigen sehen möchtest."
 
@@ -863,12 +863,6 @@ msgstr "Verbinden"
 msgid "settings.account.socials.title"
 msgstr "Verknüpfte Konten"
 
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Kontakt"
-
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:25
@@ -881,16 +875,22 @@ msgstr "Kontakt"
 msgid "license.contact.title"
 msgstr "Kontakt"
 
-#. Table of contents heading
+#. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
-msgstr "Inhalt"
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Kontakt"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
+msgstr "Inhalt"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Inhalt"
 
 #. Button to continue to app after verification
@@ -1029,7 +1029,7 @@ msgstr "Erstelle eine Watchlist für jede Nische"
 
 #. Label for currency selector
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:312
+#: src/components/settings/GeneralSettings.tsx:322
 msgid "settings.general.salary.currencyLabel"
 msgstr "Währung"
 
@@ -1047,7 +1047,7 @@ msgstr "Aktuell"
 
 #. Daily pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:353
+#: src/components/settings/GeneralSettings.tsx:363
 msgid "settings.general.salary.period.daily"
 msgstr "Täglich"
 
@@ -1465,7 +1465,7 @@ msgstr "Filter"
 
 #. Button to open modal with all languages
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:283
+#: src/components/settings/GeneralSettings.tsx:293
 msgid "settings.general.jobLanguages.findMore"
 msgstr "Weitere finden"
 
@@ -1659,7 +1659,7 @@ msgstr "Startseite"
 
 #. Hourly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:356
+#: src/components/settings/GeneralSettings.tsx:366
 msgid "settings.general.salary.period.hourly"
 msgstr "Stündlich"
 
@@ -1932,7 +1932,7 @@ msgstr "Indexierungsrichtlinie"
 
 #. Job languages settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:216
+#: src/components/settings/GeneralSettings.tsx:226
 msgid "settings.general.jobLanguages.title"
 msgstr "Stellensprachen"
 
@@ -2048,7 +2048,7 @@ msgstr "Stichwort"
 
 #. Language settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:187
+#: src/components/settings/GeneralSettings.tsx:197
 msgid "settings.general.language.title"
 msgstr "Sprache"
 
@@ -2172,16 +2172,16 @@ msgstr "Standort"
 msgid "search.advanced.location"
 msgstr "Standort"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
-msgstr "Standorte"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:708
 msgid "search.bar.locations"
+msgstr "Standorte"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:312
+msgid "search.detail.locations"
 msgstr "Standorte"
 
 #. Login button label
@@ -2327,7 +2327,7 @@ msgstr "Karriereseiten von Unternehmen überwachen"
 
 #. Monthly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:350
+#: src/components/settings/GeneralSettings.tsx:360
 msgid "settings.general.salary.period.monthly"
 msgstr "Monatlich"
 
@@ -2365,8 +2365,8 @@ msgstr "Mehrsprachige Unterstützung"
 #. Warning when Enter is pressed but multiple items match
 #. Warning when Enter is pressed but multiple items match
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:124
-#: src/components/search/location-search-modal.tsx:109
+#: src/components/search/location-modal.tsx:162
+#: src/components/search/location-search-modal.tsx:153
 #: src/components/search/occupation-modal.tsx:110
 #: src/components/search/technology-modal.tsx:88
 msgid "search.bestGuess.ambiguous"
@@ -2462,17 +2462,17 @@ msgstr "Keine Jobs gefunden."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Keine Sprachen entsprechen deiner Suche."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:171
-msgid "search.locationModal.noResults"
-msgstr "Keine Standorte gefunden."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:186
+#: src/components/search/location-modal.tsx:224
 msgid "company.locationModal.noResults"
 msgstr "Keine Standorte entsprechen Ihrer Suche."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:215
+msgid "search.locationModal.noResults"
+msgstr "Keine Standorte gefunden."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2689,7 +2689,7 @@ msgstr "oder"
 
 #. Original pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:344
+#: src/components/settings/GeneralSettings.tsx:354
 msgid "settings.general.salary.period.original"
 msgstr "Original"
 
@@ -2719,26 +2719,26 @@ msgstr "Unsere Haltung zur Automatisierung"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Überblick"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Überblick"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Seiteninhalt"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Überblick"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Seiteninhalt"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Seiteninhalt"
 
 #. Heading shown on the 404 page
@@ -2805,7 +2805,7 @@ msgstr "Geben Sie einen Firmennamen oder eine Karriereseiten-URL ein und wir beg
 
 #. Label for pay period selector
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:331
+#: src/components/settings/GeneralSettings.tsx:341
 msgid "settings.general.salary.periodLabel"
 msgstr "Zeitraum"
 
@@ -2929,18 +2929,18 @@ msgstr "Stelle nicht gefunden."
 msgid "myJobs.detail.notFound"
 msgstr "Stellenanzeige nicht gefunden."
 
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: src/components/Pricing.tsx:100
-msgid "home.pricing.eyebrow"
-msgstr "Preise"
-
 #. Nav link: Pricing
 #. Nav link: Pricing
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:62
 #: src/components/MobileMenu.tsx:87
 msgid "common.nav.pricing"
+msgstr "Preise"
+
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:100
+msgid "home.pricing.eyebrow"
 msgstr "Preise"
 
 #. Privacy policy page eyebrow
@@ -3067,6 +3067,18 @@ msgstr "Deine Änderungen weiterverbreiten, solange du den MIT-Hinweis beifügst
 #: src/components/search/location-pills.tsx:32
 msgid "location.type.region"
 msgstr "Region"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:234
+msgid "company.locationModal.regionsHeader"
+msgstr "Regionen"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:225
+msgid "search.locationModal.regionsHeader"
+msgstr "Regionen"
 
 #. Status group heading: rejected
 #. js-lingui-explicit-id
@@ -3224,21 +3236,21 @@ msgstr "Runde"
 msgid "app.home.request.agent.runIdLabel"
 msgstr "Run-ID"
 
-#. Salary override section heading
-#. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:76
-msgid "myJobs.detail.salary"
-msgstr "Gehalt"
-
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:171
 msgid "search.advanced.salary"
 msgstr "Gehalt"
 
+#. Salary override section heading
+#. js-lingui-explicit-id
+#: src/components/my-jobs/salary-override.tsx:76
+msgid "myJobs.detail.salary"
+msgstr "Gehalt"
+
 #. Salary display settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:302
+#: src/components/settings/GeneralSettings.tsx:312
 msgid "settings.general.salary.title"
 msgstr "Gehaltsanzeige"
 
@@ -3374,17 +3386,17 @@ msgstr "Durchsuche Jobs bei Tausenden von Unternehmen, direkt von Karriereseiten
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Sprachen suchen…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:150
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Standorte suchen..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:165
+#: src/components/search/location-modal.tsx:203
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Standorte suchen…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:194
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Standorte suchen..."
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3430,7 +3442,7 @@ msgstr "Stufe auswählen"
 
 #. Title for the global location selection modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:130
+#: src/components/search/location-search-modal.tsx:174
 msgid "search.locationModal.title"
 msgstr "Standort auswählen"
 
@@ -3448,7 +3460,7 @@ msgstr "Technologien auswählen"
 
 #. Language settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:190
+#: src/components/settings/GeneralSettings.tsx:200
 msgid "settings.general.language.description"
 msgstr "Wähle deine bevorzugte Sprache."
 
@@ -3470,17 +3482,17 @@ msgstr "Link senden"
 msgid "settings.account.password.send"
 msgstr "Link senden"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Wird gesendet…"
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
 msgstr "Wird gesendet..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
+msgstr "Wird gesendet…"
 
 #. Reset password button while loading
 #. js-lingui-explicit-id
@@ -3536,16 +3548,16 @@ msgstr "Einstellungen"
 msgid "home.features.s3.p3.title"
 msgstr "Mit jedem teilen"
 
-#. Collapse location pill list
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:351
-msgid "company.page.showLess"
-msgstr "Weniger anzeigen"
-
 #. Button to collapse location list
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:355
 msgid "search.detail.showLessLocations"
+msgstr "Weniger anzeigen"
+
+#. Collapse location pill list
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:351
+msgid "company.page.showLess"
 msgstr "Weniger anzeigen"
 
 #. Aria label to show password
@@ -3818,16 +3830,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technisch"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Technologien"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:673
 msgid "search.bar.technologies"
+msgstr "Technologien"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:397
+msgid "search.detail.technologies"
 msgstr "Technologien"
 
 #. Add technology filter
@@ -3932,7 +3944,7 @@ msgstr "Die Kurzfassung"
 
 #. Theme settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:157
+#: src/components/settings/GeneralSettings.tsx:167
 msgid "settings.general.theme.title"
 msgstr "Design"
 
@@ -4366,7 +4378,7 @@ msgstr "Welche Sprachen unterstützt Jobseek?"
 
 #. Yearly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:347
+#: src/components/settings/GeneralSettings.tsx:357
 msgid "settings.general.salary.period.yearly"
 msgstr "Jährlich"
 

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -297,21 +297,21 @@ msgstr "All data is encrypted in transit and at rest."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "All industries"
 
+#. All languages option
+#. js-lingui-explicit-id
+#: src/components/settings/GeneralSettings.tsx:244
+msgid "settings.general.jobLanguages.all"
+msgstr "All languages"
+
 #. Title for the all-languages modal in settings
 #. js-lingui-explicit-id
 #: src/components/settings/JobLanguageModal.tsx:56
 msgid "settings.jobLanguages.modal.title"
 msgstr "All languages"
 
-#. All languages option
-#. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:234
-msgid "settings.general.jobLanguages.all"
-msgstr "All languages"
-
 #. Title for the all-locations modal on company page
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:145
+#: src/components/search/location-modal.tsx:183
 msgid "company.locationModal.title"
 msgstr "All locations"
 
@@ -639,16 +639,16 @@ msgstr "Change your password via a secure email link."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Change..."
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "Check your email"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
+msgstr "Check your email"
+
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
 msgstr "Check your email"
 
 #. Checking username availability
@@ -659,13 +659,13 @@ msgstr "Checking availability..."
 
 #. Theme settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:160
+#: src/components/settings/GeneralSettings.tsx:170
 msgid "settings.general.theme.description"
 msgstr "Choose how Job Seek looks to you."
 
 #. Salary display settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:305
+#: src/components/settings/GeneralSettings.tsx:315
 msgid "settings.general.salary.description"
 msgstr "Choose how salaries are shown across the site."
 
@@ -683,7 +683,7 @@ msgstr "Choose the right plan for you"
 
 #. Job languages settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:219
+#: src/components/settings/GeneralSettings.tsx:229
 msgid "settings.general.jobLanguages.description"
 msgstr "Choose which languages you want to see job postings in."
 
@@ -863,12 +863,6 @@ msgstr "Connect"
 msgid "settings.account.socials.title"
 msgstr "Connected accounts"
 
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Contact"
-
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:25
@@ -881,16 +875,22 @@ msgstr "Contact"
 msgid "license.contact.title"
 msgstr "Contact"
 
-#. Table of contents heading
+#. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
-msgstr "Contents"
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Contact"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
+msgstr "Contents"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Contents"
 
 #. Button to continue to app after verification
@@ -1029,7 +1029,7 @@ msgstr "Curate a watchlist for any niche"
 
 #. Label for currency selector
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:312
+#: src/components/settings/GeneralSettings.tsx:322
 msgid "settings.general.salary.currencyLabel"
 msgstr "Currency"
 
@@ -1047,7 +1047,7 @@ msgstr "Current"
 
 #. Daily pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:353
+#: src/components/settings/GeneralSettings.tsx:363
 msgid "settings.general.salary.period.daily"
 msgstr "Daily"
 
@@ -1465,7 +1465,7 @@ msgstr "Filters"
 
 #. Button to open modal with all languages
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:283
+#: src/components/settings/GeneralSettings.tsx:293
 msgid "settings.general.jobLanguages.findMore"
 msgstr "Find more"
 
@@ -1659,7 +1659,7 @@ msgstr "Home"
 
 #. Hourly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:356
+#: src/components/settings/GeneralSettings.tsx:366
 msgid "settings.general.salary.period.hourly"
 msgstr "Hourly"
 
@@ -1932,7 +1932,7 @@ msgstr "Job indexing policy"
 
 #. Job languages settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:216
+#: src/components/settings/GeneralSettings.tsx:226
 msgid "settings.general.jobLanguages.title"
 msgstr "Job languages"
 
@@ -2048,7 +2048,7 @@ msgstr "Keyword"
 
 #. Language settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:187
+#: src/components/settings/GeneralSettings.tsx:197
 msgid "settings.general.language.title"
 msgstr "Language"
 
@@ -2172,16 +2172,16 @@ msgstr "Location"
 msgid "search.advanced.location"
 msgstr "Location"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
-msgstr "Locations"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:708
 msgid "search.bar.locations"
+msgstr "Locations"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:312
+msgid "search.detail.locations"
 msgstr "Locations"
 
 #. Login button label
@@ -2327,7 +2327,7 @@ msgstr "Monitor company career pages"
 
 #. Monthly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:350
+#: src/components/settings/GeneralSettings.tsx:360
 msgid "settings.general.salary.period.monthly"
 msgstr "Monthly"
 
@@ -2365,8 +2365,8 @@ msgstr "Multi-language support"
 #. Warning when Enter is pressed but multiple items match
 #. Warning when Enter is pressed but multiple items match
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:124
-#: src/components/search/location-search-modal.tsx:109
+#: src/components/search/location-modal.tsx:162
+#: src/components/search/location-search-modal.tsx:153
 #: src/components/search/occupation-modal.tsx:110
 #: src/components/search/technology-modal.tsx:88
 msgid "search.bestGuess.ambiguous"
@@ -2462,16 +2462,16 @@ msgstr "No jobs found."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "No languages match your search."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:171
-msgid "search.locationModal.noResults"
-msgstr "No locations match your search."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:186
+#: src/components/search/location-modal.tsx:224
 msgid "company.locationModal.noResults"
+msgstr "No locations match your search."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:215
+msgid "search.locationModal.noResults"
 msgstr "No locations match your search."
 
 #. No postings found message on company page
@@ -2689,7 +2689,7 @@ msgstr "or"
 
 #. Original pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:344
+#: src/components/settings/GeneralSettings.tsx:354
 msgid "settings.general.salary.period.original"
 msgstr "Original"
 
@@ -2719,26 +2719,26 @@ msgstr "Our stance on automation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Overview"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Overview"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Page contents"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Overview"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Page contents"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Page contents"
 
 #. Heading shown on the 404 page
@@ -2805,7 +2805,7 @@ msgstr "Paste a careers page URL for best results, or just type a company name."
 
 #. Label for pay period selector
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:331
+#: src/components/settings/GeneralSettings.tsx:341
 msgid "settings.general.salary.periodLabel"
 msgstr "Pay period"
 
@@ -2929,18 +2929,18 @@ msgstr "Posting not found."
 msgid "myJobs.detail.notFound"
 msgstr "Posting not found."
 
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: src/components/Pricing.tsx:100
-msgid "home.pricing.eyebrow"
-msgstr "Pricing"
-
 #. Nav link: Pricing
 #. Nav link: Pricing
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:62
 #: src/components/MobileMenu.tsx:87
 msgid "common.nav.pricing"
+msgstr "Pricing"
+
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:100
+msgid "home.pricing.eyebrow"
 msgstr "Pricing"
 
 #. Privacy policy page eyebrow
@@ -3067,6 +3067,18 @@ msgstr "Redistribute your changes, as long as you include the MIT notice."
 #: src/components/search/location-pills.tsx:32
 msgid "location.type.region"
 msgstr "Region"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:234
+msgid "company.locationModal.regionsHeader"
+msgstr "Regions"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:225
+msgid "search.locationModal.regionsHeader"
+msgstr "Regions"
 
 #. Status group heading: rejected
 #. js-lingui-explicit-id
@@ -3224,21 +3236,21 @@ msgstr "Round"
 msgid "app.home.request.agent.runIdLabel"
 msgstr "Run id"
 
-#. Salary override section heading
-#. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:76
-msgid "myJobs.detail.salary"
-msgstr "Salary"
-
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:171
 msgid "search.advanced.salary"
 msgstr "Salary"
 
+#. Salary override section heading
+#. js-lingui-explicit-id
+#: src/components/my-jobs/salary-override.tsx:76
+msgid "myJobs.detail.salary"
+msgstr "Salary"
+
 #. Salary display settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:302
+#: src/components/settings/GeneralSettings.tsx:312
 msgid "settings.general.salary.title"
 msgstr "Salary display"
 
@@ -3374,16 +3386,16 @@ msgstr "Search jobs across thousands of companies scraped directly from career p
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Search languages..."
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:150
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Search locations..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:165
+#: src/components/search/location-modal.tsx:203
 msgid "company.locationModal.searchPlaceholder"
+msgstr "Search locations..."
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:194
+msgid "search.locationModal.searchPlaceholder"
 msgstr "Search locations..."
 
 #. Back-to-search link on company page header
@@ -3430,7 +3442,7 @@ msgstr "Select level"
 
 #. Title for the global location selection modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:130
+#: src/components/search/location-search-modal.tsx:174
 msgid "search.locationModal.title"
 msgstr "Select location"
 
@@ -3448,7 +3460,7 @@ msgstr "Select technologies"
 
 #. Language settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:190
+#: src/components/settings/GeneralSettings.tsx:200
 msgid "settings.general.language.description"
 msgstr "Select your preferred language."
 
@@ -3470,16 +3482,16 @@ msgstr "Send reset link"
 msgid "settings.account.password.send"
 msgstr "Send reset link"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Sending..."
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
+msgstr "Sending..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
 msgstr "Sending..."
 
 #. Reset password button while loading
@@ -3536,16 +3548,16 @@ msgstr "Settings"
 msgid "home.features.s3.p3.title"
 msgstr "Share with anyone"
 
-#. Collapse location pill list
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:351
-msgid "company.page.showLess"
-msgstr "Show less"
-
 #. Button to collapse location list
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:355
 msgid "search.detail.showLessLocations"
+msgstr "Show less"
+
+#. Collapse location pill list
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:351
+msgid "company.page.showLess"
 msgstr "Show less"
 
 #. Aria label to show password
@@ -3818,16 +3830,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technical"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Technologies"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:673
 msgid "search.bar.technologies"
+msgstr "Technologies"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:397
+msgid "search.detail.technologies"
 msgstr "Technologies"
 
 #. Add technology filter
@@ -3932,7 +3944,7 @@ msgstr "The short version"
 
 #. Theme settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:157
+#: src/components/settings/GeneralSettings.tsx:167
 msgid "settings.general.theme.title"
 msgstr "Theme"
 
@@ -4366,7 +4378,7 @@ msgstr "Which languages does Jobseek support?"
 
 #. Yearly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:347
+#: src/components/settings/GeneralSettings.tsx:357
 msgid "settings.general.salary.period.yearly"
 msgstr "Yearly"
 

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -297,21 +297,21 @@ msgstr "Toutes les données sont chiffrées en transit et au repos."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Tous les secteurs"
 
+#. All languages option
+#. js-lingui-explicit-id
+#: src/components/settings/GeneralSettings.tsx:244
+msgid "settings.general.jobLanguages.all"
+msgstr "Toutes les langues"
+
 #. Title for the all-languages modal in settings
 #. js-lingui-explicit-id
 #: src/components/settings/JobLanguageModal.tsx:56
 msgid "settings.jobLanguages.modal.title"
 msgstr "Toutes les langues"
 
-#. All languages option
-#. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:234
-msgid "settings.general.jobLanguages.all"
-msgstr "Toutes les langues"
-
 #. Title for the all-locations modal on company page
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:145
+#: src/components/search/location-modal.tsx:183
 msgid "company.locationModal.title"
 msgstr "Tous les lieux"
 
@@ -639,17 +639,17 @@ msgstr "Modifie ton mot de passe via un lien e-mail sécurisé."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Changer…"
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "Vérifie ton e-mail"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
 msgstr "Vérifiez votre e-mail"
+
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
+msgstr "Vérifie ton e-mail"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -659,13 +659,13 @@ msgstr "Vérification de la disponibilité..."
 
 #. Theme settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:160
+#: src/components/settings/GeneralSettings.tsx:170
 msgid "settings.general.theme.description"
 msgstr "Choisis l'apparence de Job Seek."
 
 #. Salary display settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:305
+#: src/components/settings/GeneralSettings.tsx:315
 msgid "settings.general.salary.description"
 msgstr "Personnalisez l'affichage des salaires dans les résultats de recherche et les détails des offres."
 
@@ -683,7 +683,7 @@ msgstr "Choisis l'offre qui te convient"
 
 #. Job languages settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:219
+#: src/components/settings/GeneralSettings.tsx:229
 msgid "settings.general.jobLanguages.description"
 msgstr "Choisissez les langues dans lesquelles vous souhaitez voir les offres d'emploi."
 
@@ -863,12 +863,6 @@ msgstr "Connecter"
 msgid "settings.account.socials.title"
 msgstr "Comptes connectés"
 
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Contact"
-
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:25
@@ -881,16 +875,22 @@ msgstr "Contact"
 msgid "license.contact.title"
 msgstr "Contact"
 
-#. Table of contents heading
+#. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
-msgstr "Sommaire"
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Contact"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
+msgstr "Sommaire"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Sommaire"
 
 #. Button to continue to app after verification
@@ -1029,7 +1029,7 @@ msgstr "Crée une liste de suivi pour chaque niche"
 
 #. Label for currency selector
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:312
+#: src/components/settings/GeneralSettings.tsx:322
 msgid "settings.general.salary.currencyLabel"
 msgstr "Devise"
 
@@ -1047,7 +1047,7 @@ msgstr "Actuel"
 
 #. Daily pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:353
+#: src/components/settings/GeneralSettings.tsx:363
 msgid "settings.general.salary.period.daily"
 msgstr "Journalier"
 
@@ -1465,7 +1465,7 @@ msgstr "Filtres"
 
 #. Button to open modal with all languages
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:283
+#: src/components/settings/GeneralSettings.tsx:293
 msgid "settings.general.jobLanguages.findMore"
 msgstr "Rechercher"
 
@@ -1659,7 +1659,7 @@ msgstr "Accueil"
 
 #. Hourly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:356
+#: src/components/settings/GeneralSettings.tsx:366
 msgid "settings.general.salary.period.hourly"
 msgstr "Horaire"
 
@@ -1932,7 +1932,7 @@ msgstr "Politique d'indexation des offres"
 
 #. Job languages settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:216
+#: src/components/settings/GeneralSettings.tsx:226
 msgid "settings.general.jobLanguages.title"
 msgstr "Langues des offres"
 
@@ -2048,7 +2048,7 @@ msgstr "Mot-clé"
 
 #. Language settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:187
+#: src/components/settings/GeneralSettings.tsx:197
 msgid "settings.general.language.title"
 msgstr "Langue"
 
@@ -2172,16 +2172,16 @@ msgstr "Lieu"
 msgid "search.advanced.location"
 msgstr "Lieu"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
-msgstr "Lieux"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:708
 msgid "search.bar.locations"
+msgstr "Lieux"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:312
+msgid "search.detail.locations"
 msgstr "Lieux"
 
 #. Login button label
@@ -2327,7 +2327,7 @@ msgstr "Surveiller les pages carrières des entreprises"
 
 #. Monthly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:350
+#: src/components/settings/GeneralSettings.tsx:360
 msgid "settings.general.salary.period.monthly"
 msgstr "Mensuel"
 
@@ -2365,8 +2365,8 @@ msgstr "Support multilingue"
 #. Warning when Enter is pressed but multiple items match
 #. Warning when Enter is pressed but multiple items match
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:124
-#: src/components/search/location-search-modal.tsx:109
+#: src/components/search/location-modal.tsx:162
+#: src/components/search/location-search-modal.tsx:153
 #: src/components/search/occupation-modal.tsx:110
 #: src/components/search/technology-modal.tsx:88
 msgid "search.bestGuess.ambiguous"
@@ -2462,16 +2462,16 @@ msgstr "Aucune offre trouvée."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Aucune langue ne correspond à votre recherche."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:171
-msgid "search.locationModal.noResults"
-msgstr "Aucun lieu ne correspond à votre recherche."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:186
+#: src/components/search/location-modal.tsx:224
 msgid "company.locationModal.noResults"
+msgstr "Aucun lieu ne correspond à votre recherche."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:215
+msgid "search.locationModal.noResults"
 msgstr "Aucun lieu ne correspond à votre recherche."
 
 #. No postings found message on company page
@@ -2689,7 +2689,7 @@ msgstr "ou"
 
 #. Original pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:344
+#: src/components/settings/GeneralSettings.tsx:354
 msgid "settings.general.salary.period.original"
 msgstr "Original"
 
@@ -2719,26 +2719,26 @@ msgstr "Notre position sur l'automatisation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Aperçu"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Aperçu"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Sommaire de la page"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Aperçu"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Sommaire de la page"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Sommaire de la page"
 
 #. Heading shown on the 404 page
@@ -2805,7 +2805,7 @@ msgstr "Entrez un nom d'entreprise ou l'URL d'une page carrières et nous commen
 
 #. Label for pay period selector
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:331
+#: src/components/settings/GeneralSettings.tsx:341
 msgid "settings.general.salary.periodLabel"
 msgstr "Période"
 
@@ -2929,18 +2929,18 @@ msgstr "Offre non trouvée."
 msgid "myJobs.detail.notFound"
 msgstr "Offre introuvable."
 
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: src/components/Pricing.tsx:100
-msgid "home.pricing.eyebrow"
-msgstr "Tarifs"
-
 #. Nav link: Pricing
 #. Nav link: Pricing
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:62
 #: src/components/MobileMenu.tsx:87
 msgid "common.nav.pricing"
+msgstr "Tarifs"
+
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:100
+msgid "home.pricing.eyebrow"
 msgstr "Tarifs"
 
 #. Privacy policy page eyebrow
@@ -3067,6 +3067,18 @@ msgstr "Redistribue tes modifications, à condition d'inclure la mention MIT."
 #: src/components/search/location-pills.tsx:32
 msgid "location.type.region"
 msgstr "Région"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:234
+msgid "company.locationModal.regionsHeader"
+msgstr "Régions"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:225
+msgid "search.locationModal.regionsHeader"
+msgstr "Régions"
 
 #. Status group heading: rejected
 #. js-lingui-explicit-id
@@ -3224,21 +3236,21 @@ msgstr "Tour"
 msgid "app.home.request.agent.runIdLabel"
 msgstr "Identifiant d'exécution"
 
-#. Salary override section heading
-#. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:76
-msgid "myJobs.detail.salary"
-msgstr "Salaire"
-
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:171
 msgid "search.advanced.salary"
 msgstr "Salaire"
 
+#. Salary override section heading
+#. js-lingui-explicit-id
+#: src/components/my-jobs/salary-override.tsx:76
+msgid "myJobs.detail.salary"
+msgstr "Salaire"
+
 #. Salary display settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:302
+#: src/components/settings/GeneralSettings.tsx:312
 msgid "settings.general.salary.title"
 msgstr "Affichage du salaire"
 
@@ -3374,17 +3386,17 @@ msgstr "Recherchez des emplois dans des milliers d'entreprises, scrapés directe
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Rechercher des langues…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:150
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Rechercher des lieux..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:165
+#: src/components/search/location-modal.tsx:203
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Rechercher des lieux…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:194
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Rechercher des lieux..."
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3430,7 +3442,7 @@ msgstr "Sélectionner le niveau"
 
 #. Title for the global location selection modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:130
+#: src/components/search/location-search-modal.tsx:174
 msgid "search.locationModal.title"
 msgstr "Sélectionner le lieu"
 
@@ -3448,7 +3460,7 @@ msgstr "Sélectionner les technologies"
 
 #. Language settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:190
+#: src/components/settings/GeneralSettings.tsx:200
 msgid "settings.general.language.description"
 msgstr "Sélectionne ta langue préférée."
 
@@ -3470,16 +3482,16 @@ msgstr "Envoyer le lien"
 msgid "settings.account.password.send"
 msgstr "Envoyer le lien"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Envoi en cours..."
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
+msgstr "Envoi en cours..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
 msgstr "Envoi en cours..."
 
 #. Reset password button while loading
@@ -3536,16 +3548,16 @@ msgstr "Paramètres"
 msgid "home.features.s3.p3.title"
 msgstr "Partager avec tout le monde"
 
-#. Collapse location pill list
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:351
-msgid "company.page.showLess"
-msgstr "Afficher moins"
-
 #. Button to collapse location list
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:355
 msgid "search.detail.showLessLocations"
+msgstr "Afficher moins"
+
+#. Collapse location pill list
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:351
+msgid "company.page.showLess"
 msgstr "Afficher moins"
 
 #. Aria label to show password
@@ -3818,16 +3830,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technique"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Technologies"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:673
 msgid "search.bar.technologies"
+msgstr "Technologies"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:397
+msgid "search.detail.technologies"
 msgstr "Technologies"
 
 #. Add technology filter
@@ -3932,7 +3944,7 @@ msgstr "En bref"
 
 #. Theme settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:157
+#: src/components/settings/GeneralSettings.tsx:167
 msgid "settings.general.theme.title"
 msgstr "Thème"
 
@@ -4366,7 +4378,7 @@ msgstr "Quelles langues Jobseek prend-il en charge ?"
 
 #. Yearly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:347
+#: src/components/settings/GeneralSettings.tsx:357
 msgid "settings.general.salary.period.yearly"
 msgstr "Annuel"
 

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -297,21 +297,21 @@ msgstr "Tutti i dati sono crittografati in transito e a riposo."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Tutti i settori"
 
+#. All languages option
+#. js-lingui-explicit-id
+#: src/components/settings/GeneralSettings.tsx:244
+msgid "settings.general.jobLanguages.all"
+msgstr "Tutte le lingue"
+
 #. Title for the all-languages modal in settings
 #. js-lingui-explicit-id
 #: src/components/settings/JobLanguageModal.tsx:56
 msgid "settings.jobLanguages.modal.title"
 msgstr "Tutte le lingue"
 
-#. All languages option
-#. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:234
-msgid "settings.general.jobLanguages.all"
-msgstr "Tutte le lingue"
-
 #. Title for the all-locations modal on company page
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:145
+#: src/components/search/location-modal.tsx:183
 msgid "company.locationModal.title"
 msgstr "Tutte le sedi"
 
@@ -639,17 +639,17 @@ msgstr "Cambia la tua password tramite un link email sicuro."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Cambia…"
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "Controlla la tua email"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
 msgstr "Controlla la tua e-mail"
+
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
+msgstr "Controlla la tua email"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -659,13 +659,13 @@ msgstr "Verifica disponibilità..."
 
 #. Theme settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:160
+#: src/components/settings/GeneralSettings.tsx:170
 msgid "settings.general.theme.description"
 msgstr "Scegli l'aspetto di Job Seek."
 
 #. Salary display settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:305
+#: src/components/settings/GeneralSettings.tsx:315
 msgid "settings.general.salary.description"
 msgstr "Personalizza come vengono visualizzati gli stipendi nei risultati di ricerca e nei dettagli delle offerte."
 
@@ -683,7 +683,7 @@ msgstr "Scegli il piano giusto per te"
 
 #. Job languages settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:219
+#: src/components/settings/GeneralSettings.tsx:229
 msgid "settings.general.jobLanguages.description"
 msgstr "Scegli in quali lingue vuoi vedere le offerte di lavoro."
 
@@ -863,12 +863,6 @@ msgstr "Collega"
 msgid "settings.account.socials.title"
 msgstr "Account collegati"
 
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Contatti"
-
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:25
@@ -881,16 +875,22 @@ msgstr "Contatti"
 msgid "license.contact.title"
 msgstr "Contatti"
 
-#. Table of contents heading
+#. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
-msgstr "Sommario"
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Contatti"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
+msgstr "Sommario"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Sommario"
 
 #. Button to continue to app after verification
@@ -1029,7 +1029,7 @@ msgstr "Crea una watchlist per ogni nicchia"
 
 #. Label for currency selector
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:312
+#: src/components/settings/GeneralSettings.tsx:322
 msgid "settings.general.salary.currencyLabel"
 msgstr "Valuta"
 
@@ -1047,7 +1047,7 @@ msgstr "Attuale"
 
 #. Daily pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:353
+#: src/components/settings/GeneralSettings.tsx:363
 msgid "settings.general.salary.period.daily"
 msgstr "Giornaliero"
 
@@ -1465,7 +1465,7 @@ msgstr "Filtri"
 
 #. Button to open modal with all languages
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:283
+#: src/components/settings/GeneralSettings.tsx:293
 msgid "settings.general.jobLanguages.findMore"
 msgstr "Cerca altre"
 
@@ -1659,7 +1659,7 @@ msgstr "Home"
 
 #. Hourly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:356
+#: src/components/settings/GeneralSettings.tsx:366
 msgid "settings.general.salary.period.hourly"
 msgstr "Orario"
 
@@ -1932,7 +1932,7 @@ msgstr "Politica di indicizzazione delle offerte"
 
 #. Job languages settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:216
+#: src/components/settings/GeneralSettings.tsx:226
 msgid "settings.general.jobLanguages.title"
 msgstr "Lingue delle offerte"
 
@@ -2048,7 +2048,7 @@ msgstr "Parola chiave"
 
 #. Language settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:187
+#: src/components/settings/GeneralSettings.tsx:197
 msgid "settings.general.language.title"
 msgstr "Lingua"
 
@@ -2172,17 +2172,17 @@ msgstr "Luogo"
 msgid "search.advanced.location"
 msgstr "Luogo"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
-msgstr "Località"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:708
 msgid "search.bar.locations"
 msgstr "Sedi"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:312
+msgid "search.detail.locations"
+msgstr "Località"
 
 #. Login button label
 #. Login button label
@@ -2327,7 +2327,7 @@ msgstr "Monitorare le pagine carriere delle aziende"
 
 #. Monthly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:350
+#: src/components/settings/GeneralSettings.tsx:360
 msgid "settings.general.salary.period.monthly"
 msgstr "Mensile"
 
@@ -2365,8 +2365,8 @@ msgstr "Supporto multilingue"
 #. Warning when Enter is pressed but multiple items match
 #. Warning when Enter is pressed but multiple items match
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:124
-#: src/components/search/location-search-modal.tsx:109
+#: src/components/search/location-modal.tsx:162
+#: src/components/search/location-search-modal.tsx:153
 #: src/components/search/occupation-modal.tsx:110
 #: src/components/search/technology-modal.tsx:88
 msgid "search.bestGuess.ambiguous"
@@ -2462,17 +2462,17 @@ msgstr "Nessuna offerta trovata."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Nessuna lingua corrisponde alla ricerca."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:171
-msgid "search.locationModal.noResults"
-msgstr "Nessun luogo corrisponde alla tua ricerca."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:186
+#: src/components/search/location-modal.tsx:224
 msgid "company.locationModal.noResults"
 msgstr "Nessuna sede corrisponde alla tua ricerca."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:215
+msgid "search.locationModal.noResults"
+msgstr "Nessun luogo corrisponde alla tua ricerca."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2689,7 +2689,7 @@ msgstr "o"
 
 #. Original pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:344
+#: src/components/settings/GeneralSettings.tsx:354
 msgid "settings.general.salary.period.original"
 msgstr "Originale"
 
@@ -2719,26 +2719,26 @@ msgstr "La nostra posizione sull'automazione"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Panoramica"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Panoramica"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Contenuti della pagina"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Panoramica"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Contenuti della pagina"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Contenuti della pagina"
 
 #. Heading shown on the 404 page
@@ -2805,7 +2805,7 @@ msgstr "Inserisci il nome di un'azienda o l'URL di una pagina carriere e inizier
 
 #. Label for pay period selector
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:331
+#: src/components/settings/GeneralSettings.tsx:341
 msgid "settings.general.salary.periodLabel"
 msgstr "Periodo"
 
@@ -2929,18 +2929,18 @@ msgstr "Offerta non trovata."
 msgid "myJobs.detail.notFound"
 msgstr "Offerta non trovata."
 
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: src/components/Pricing.tsx:100
-msgid "home.pricing.eyebrow"
-msgstr "Prezzi"
-
 #. Nav link: Pricing
 #. Nav link: Pricing
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:62
 #: src/components/MobileMenu.tsx:87
 msgid "common.nav.pricing"
+msgstr "Prezzi"
+
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:100
+msgid "home.pricing.eyebrow"
 msgstr "Prezzi"
 
 #. Privacy policy page eyebrow
@@ -3067,6 +3067,18 @@ msgstr "Ridistribuire le proprie modifiche, a condizione di includere l'avviso M
 #: src/components/search/location-pills.tsx:32
 msgid "location.type.region"
 msgstr "Regione"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:234
+msgid "company.locationModal.regionsHeader"
+msgstr "Regioni"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:225
+msgid "search.locationModal.regionsHeader"
+msgstr "Regioni"
 
 #. Status group heading: rejected
 #. js-lingui-explicit-id
@@ -3224,21 +3236,21 @@ msgstr "Turno"
 msgid "app.home.request.agent.runIdLabel"
 msgstr "ID esecuzione"
 
-#. Salary override section heading
-#. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:76
-msgid "myJobs.detail.salary"
-msgstr "Stipendio"
-
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:171
 msgid "search.advanced.salary"
 msgstr "Stipendio"
 
+#. Salary override section heading
+#. js-lingui-explicit-id
+#: src/components/my-jobs/salary-override.tsx:76
+msgid "myJobs.detail.salary"
+msgstr "Stipendio"
+
 #. Salary display settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:302
+#: src/components/settings/GeneralSettings.tsx:312
 msgid "settings.general.salary.title"
 msgstr "Visualizzazione stipendio"
 
@@ -3374,17 +3386,17 @@ msgstr "Cerca lavori in migliaia di aziende, scansionati direttamente dalle pagi
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Cerca lingue…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:150
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Cerca luoghi..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:165
+#: src/components/search/location-modal.tsx:203
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Cerca sedi…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:194
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Cerca luoghi..."
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3430,7 +3442,7 @@ msgstr "Seleziona livello"
 
 #. Title for the global location selection modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:130
+#: src/components/search/location-search-modal.tsx:174
 msgid "search.locationModal.title"
 msgstr "Seleziona luogo"
 
@@ -3448,7 +3460,7 @@ msgstr "Seleziona tecnologie"
 
 #. Language settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:190
+#: src/components/settings/GeneralSettings.tsx:200
 msgid "settings.general.language.description"
 msgstr "Seleziona la lingua preferita."
 
@@ -3470,16 +3482,16 @@ msgstr "Invia link"
 msgid "settings.account.password.send"
 msgstr "Invia il link"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Invio in corso..."
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
+msgstr "Invio in corso..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
 msgstr "Invio in corso..."
 
 #. Reset password button while loading
@@ -3536,16 +3548,16 @@ msgstr "Impostazioni"
 msgid "home.features.s3.p3.title"
 msgstr "Condividi con chiunque"
 
-#. Collapse location pill list
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:351
-msgid "company.page.showLess"
-msgstr "Mostra meno"
-
 #. Button to collapse location list
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:355
 msgid "search.detail.showLessLocations"
+msgstr "Mostra meno"
+
+#. Collapse location pill list
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:351
+msgid "company.page.showLess"
 msgstr "Mostra meno"
 
 #. Aria label to show password
@@ -3818,16 +3830,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Tecnico"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Tecnologie"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:673
 msgid "search.bar.technologies"
+msgstr "Tecnologie"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:397
+msgid "search.detail.technologies"
 msgstr "Tecnologie"
 
 #. Add technology filter
@@ -3932,7 +3944,7 @@ msgstr "In breve"
 
 #. Theme settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:157
+#: src/components/settings/GeneralSettings.tsx:167
 msgid "settings.general.theme.title"
 msgstr "Tema"
 
@@ -4366,7 +4378,7 @@ msgstr "Quali lingue supporta Jobseek?"
 
 #. Yearly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:347
+#: src/components/settings/GeneralSettings.tsx:357
 msgid "settings.general.salary.period.yearly"
 msgstr "Annuale"
 

--- a/apps/web/src/components/search/__tests__/location-search-modal.test.tsx
+++ b/apps/web/src/components/search/__tests__/location-search-modal.test.tsx
@@ -1,0 +1,262 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Lingui shim — register before imports of Lingui-aware modules.
+import "@/test-utils/lingui-mock";
+
+const getGlobalLocationsGroupedMock = vi.fn();
+vi.mock("@/lib/actions/locations", () => ({
+  getGlobalLocationsGrouped: (...args: unknown[]) => getGlobalLocationsGroupedMock(...args),
+}));
+
+vi.mock("@/lib/country-flags", () => ({
+  countryIso: () => "DE",
+}));
+
+vi.mock("@/components/country-flag", () => ({
+  CountryFlag: () => null,
+}));
+
+vi.mock("server-only", () => ({}));
+
+import { LocationSearchModal } from "../location-search-modal";
+
+const _response = (overrides: Partial<Awaited<ReturnType<typeof getGlobalLocationsGroupedMock>>> = {}) => ({
+  macros: [
+    {
+      id: 4,
+      slug: "eu",
+      name: "European Union",
+      abbreviation: "EU",
+      count: 146,
+      memberCountryNames: ["Germany", "France", "Italy"],
+    },
+    {
+      id: 1,
+      slug: "emea",
+      name: "Europe, Middle East & Africa",
+      abbreviation: "EMEA",
+      count: 1433,
+      memberCountryNames: ["Germany", "Saudi Arabia", "Egypt"],
+    },
+    {
+      id: 5,
+      slug: "dach",
+      name: "DACH (Germany, Austria, Switzerland)",
+      abbreviation: "DACH",
+      count: 6,
+      memberCountryNames: ["Germany", "Austria", "Switzerland"],
+    },
+  ],
+  countries: [
+    {
+      countryId: 100,
+      countrySlug: "germany",
+      countryName: "Germany",
+      countryCount: 50,
+      regions: [
+        {
+          regionId: 0,
+          regionSlug: "",
+          regionName: "",
+          regionCount: 25,
+          locations: [
+            { id: 200, slug: "berlin", name: "Berlin", type: "city", count: 25 },
+          ],
+        },
+      ],
+    },
+  ],
+  ...overrides,
+});
+
+beforeEach(() => {
+  getGlobalLocationsGroupedMock.mockReset();
+});
+
+describe("LocationSearchModal — Regions cluster (#2940)", () => {
+  /**
+   * Modal renders a dedicated "Regions" header above the country list when
+   * macros are present. Chips show the canonical name (e.g. "European
+   * Union") plus the count.
+   */
+  it("renders the Regions cluster with macro chips above the country list", async () => {
+    getGlobalLocationsGroupedMock.mockResolvedValue(_response());
+    render(
+      <LocationSearchModal
+        open
+        onOpenChange={() => {}}
+        locale="en"
+        selected={[]}
+        onToggle={() => {}}
+      />,
+    );
+    // Wait for the data to load
+    await waitFor(() => expect(screen.getByText("Regions")).toBeTruthy());
+    expect(screen.getByText("European Union")).toBeTruthy();
+    expect(screen.getByText("Europe, Middle East & Africa")).toBeTruthy();
+    expect(screen.getByText("DACH (Germany, Austria, Switzerland)")).toBeTruthy();
+    // Country list is still rendered below
+    expect(screen.getByText("Germany")).toBeTruthy();
+  });
+
+  /**
+   * Clicking an EU chip emits onToggle with `type: "macro"` and the
+   * canonical `name: "European Union"` so the FilterBar/SearchBar chip
+   * displays the full label rather than the abbreviation.
+   */
+  it("clicking the EU chip emits a macro filter with the canonical 'European Union' name", async () => {
+    getGlobalLocationsGroupedMock.mockResolvedValue(_response());
+    const onToggle = vi.fn();
+    render(
+      <LocationSearchModal
+        open
+        onOpenChange={() => {}}
+        locale="en"
+        selected={[]}
+        onToggle={onToggle}
+      />,
+    );
+    await waitFor(() => screen.getByText("European Union"));
+    await userEvent.click(screen.getByText("European Union"));
+    expect(onToggle).toHaveBeenCalledWith({
+      id: 4,
+      slug: "eu",
+      name: "European Union",
+      type: "macro",
+      parentName: null,
+    });
+  });
+
+  /**
+   * Modal-internal text search filters the Regions cluster: typing
+   * "Europe" keeps both "European Union" and "Europe, Middle East &
+   * Africa" visible while filtering out DACH (no "europe" match in name,
+   * abbreviation, or member countries).
+   */
+  it("local search filters the Regions cluster by canonical name", async () => {
+    getGlobalLocationsGroupedMock.mockResolvedValue(_response());
+    render(
+      <LocationSearchModal
+        open
+        onOpenChange={() => {}}
+        locale="en"
+        selected={[]}
+        onToggle={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("European Union"));
+    const input = screen.getByPlaceholderText("Search locations...");
+    await userEvent.type(input, "Europe");
+    expect(screen.queryByText("European Union")).toBeTruthy();
+    expect(screen.queryByText("Europe, Middle East & Africa")).toBeTruthy();
+    expect(screen.queryByText("DACH (Germany, Austria, Switzerland)")).toBeNull();
+  });
+
+  /**
+   * Local search by abbreviation: typing "DACH" still keeps the macro
+   * chip visible (matched via `abbreviation` field).
+   */
+  it("local search matches macros by abbreviation", async () => {
+    getGlobalLocationsGroupedMock.mockResolvedValue(_response());
+    render(
+      <LocationSearchModal
+        open
+        onOpenChange={() => {}}
+        locale="en"
+        selected={[]}
+        onToggle={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("European Union"));
+    const input = screen.getByPlaceholderText("Search locations...");
+    await userEvent.type(input, "DACH");
+    expect(screen.queryByText("DACH (Germany, Austria, Switzerland)")).toBeTruthy();
+    expect(screen.queryByText("European Union")).toBeNull();
+  });
+
+  /**
+   * Member-country tooltip: hover on the chip shows the comma-separated
+   * member countries via the native `title` attribute.
+   */
+  it("renders member-country names as the chip's hover tooltip", async () => {
+    getGlobalLocationsGroupedMock.mockResolvedValue(_response());
+    render(
+      <LocationSearchModal
+        open
+        onOpenChange={() => {}}
+        locale="en"
+        selected={[]}
+        onToggle={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("European Union"));
+    const euButton = screen.getByText("European Union").closest("button");
+    expect(euButton?.getAttribute("title")).toBe("Germany, France, Italy");
+  });
+
+  /**
+   * Empty-macros fallback: when no macros have postings, the cluster is
+   * not rendered (no orphan "Regions" header).
+   */
+  it("does not render the Regions header when there are no macros", async () => {
+    getGlobalLocationsGroupedMock.mockResolvedValue({
+      macros: [],
+      countries: [
+        {
+          countryId: 100,
+          countrySlug: "germany",
+          countryName: "Germany",
+          countryCount: 5,
+          regions: [
+            {
+              regionId: 0,
+              regionSlug: "",
+              regionName: "",
+              regionCount: 5,
+              locations: [{ id: 200, slug: "berlin", name: "Berlin", type: "city", count: 5 }],
+            },
+          ],
+        },
+      ],
+    });
+    render(
+      <LocationSearchModal
+        open
+        onOpenChange={() => {}}
+        locale="en"
+        selected={[]}
+        onToggle={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("Germany"));
+    expect(screen.queryByText("Regions")).toBeNull();
+  });
+
+  /**
+   * Both clusters empty: search query that matches nothing still renders
+   * the empty-state "no locations match" text. Verifies the empty-state
+   * gate now considers BOTH macros and countries (previously only
+   * `filtered.length === 0`).
+   */
+  it("renders empty state when both macros and countries are empty after search", async () => {
+    getGlobalLocationsGroupedMock.mockResolvedValue(_response());
+    render(
+      <LocationSearchModal
+        open
+        onOpenChange={() => {}}
+        locale="en"
+        selected={[]}
+        onToggle={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("European Union"));
+    const input = screen.getByPlaceholderText("Search locations...");
+    await userEvent.type(input, "ZZZNomatch");
+    expect(screen.getByText("No locations match your search.")).toBeTruthy();
+  });
+
+  // Suppress unused-import lint
+  void within;
+});

--- a/apps/web/src/components/search/location-modal.tsx
+++ b/apps/web/src/components/search/location-modal.tsx
@@ -2,10 +2,14 @@
 
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
-import { X, Search, Loader2 } from "lucide-react";
+import { X, Search, Loader2, Globe } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
-import { getCompanyLocationsGrouped } from "@/lib/actions/company";
-import type { GroupedCompanyLocations, CompanyRegionGroup } from "@/lib/actions/company";
+import { getCompanyLocationsGroupedWithMacros } from "@/lib/actions/company";
+import type {
+  CompanyLocationsResponse,
+  GroupedCompanyLocations,
+  CompanyRegionGroup,
+} from "@/lib/actions/company";
 import type { FilterItem } from "./filter-bar";
 import { countryIso } from "@/lib/country-flags";
 import { CountryFlag } from "@/components/country-flag";
@@ -33,7 +37,7 @@ export function LocationModal({
   onFiltersChange,
 }: LocationModalProps) {
   const { t } = useLingui();
-  const [groups, setGroups] = useState<GroupedCompanyLocations[] | null>(null);
+  const [response, setResponse] = useState<CompanyLocationsResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [search, setSearch] = useState("");
   const [warning, setWarning] = useState("");
@@ -45,20 +49,36 @@ export function LocationModal({
   );
 
   useEffect(() => {
-    if (open && !groups) {
+    if (open && !response) {
       setLoading(true);
-      getCompanyLocationsGrouped(companyId, locale)
-        .then(setGroups)
+      getCompanyLocationsGroupedWithMacros(companyId, locale)
+        .then(setResponse)
         .finally(() => setLoading(false));
     }
-  }, [open, groups, companyId, locale]);
+  }, [open, response, companyId, locale]);
 
   useEffect(() => {
     if (!open) setSearch("");
   }, [open]);
 
+  // Filter macros: keep when canonical name OR abbreviation OR any member
+  // country name matches the local search. Mirrors the global modal —
+  // depends on #2939's `aliases[]` for richer alias matching once that
+  // ships.
+  const filteredMacros = useMemo(() => {
+    if (!response) return [];
+    if (!search.trim()) return response.macros;
+    const q = search.trim().toLowerCase();
+    return response.macros.filter((m) =>
+      m.name.toLowerCase().includes(q)
+      || m.abbreviation.toLowerCase().includes(q)
+      || m.memberCountryNames.some((c) => c.toLowerCase().includes(q)),
+    );
+  }, [response, search]);
+
   const filtered = useMemo(() => {
-    if (!groups) return [];
+    if (!response) return [];
+    const groups = response.countries;
     if (!search.trim()) return groups;
     const q = search.trim().toLowerCase();
     const matches = (aliases?: string[]) => aliases?.some((a) => a.includes(q)) ?? false;
@@ -87,7 +107,7 @@ export function LocationModal({
         return { ...country, regions: filteredRegions };
       })
       .filter((g): g is GroupedCompanyLocations => g !== null);
-  }, [groups, search]);
+  }, [response, search]);
 
   const toggleLocation = useCallback((loc: { id: number; slug: string; name: string; type: string }) => {
     if (activeLocationIds.has(loc.id)) {
@@ -111,13 +131,31 @@ export function LocationModal({
   const handleSearchKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key !== "Enter") return;
+      // Combine macros (canonical name + abbreviation) with city leaf items
+      // so Enter on "EU" or "European Union" picks the macro chip directly.
+      const macroCandidates = filteredMacros.flatMap((m) => {
+        const items: { id: number; slug: string; name: string; type: string }[] = [
+          { id: m.id, slug: m.slug, name: m.name, type: "macro" },
+        ];
+        if (m.abbreviation && m.abbreviation.toLowerCase() !== m.name.toLowerCase()) {
+          items.push({ id: m.id, slug: m.slug, name: m.abbreviation, type: "macro" });
+        }
+        return items;
+      });
       const leafItems = filtered.flatMap((c) =>
         c.regions.flatMap((r) => r.locations),
       );
-      const result = findBestGuess(search, leafItems);
+      const result = findBestGuess(search, [...macroCandidates, ...leafItems]);
       if (!result) return;
       if ("match" in result) {
-        toggleLocation(result.match);
+        // Always use the canonical display name on the resulting chip when
+        // the matched item is a macro (so abbreviation queries still yield
+        // "European Union" rather than "EU" on the filter pill).
+        const macro = filteredMacros.find((m) => m.id === result.match.id);
+        const final = macro
+          ? { id: macro.id, slug: macro.slug, name: macro.name, type: "macro" }
+          : result.match;
+        toggleLocation(final);
         setSearch("");
         setWarning("");
       } else {
@@ -128,7 +166,7 @@ export function LocationModal({
         }));
       }
     },
-    [filtered, search, toggleLocation, showWarning, t],
+    [filtered, filteredMacros, search, toggleLocation, showWarning, t],
   );
 
   return (
@@ -181,7 +219,7 @@ export function LocationModal({
               <div className="flex items-center justify-center py-12">
                 <Loader2 size={20} className="animate-spin text-muted" />
               </div>
-            ) : filtered.length === 0 ? (
+            ) : filtered.length === 0 && filteredMacros.length === 0 ? (
               <p className="py-8 text-center text-sm text-muted">
                 <Trans id="company.locationModal.noResults" comment="No locations match search in all-locations modal">
                   No locations match your search.
@@ -189,6 +227,46 @@ export function LocationModal({
               </p>
             ) : (
               <div className="space-y-5">
+                {filteredMacros.length > 0 && (
+                  <div>
+                    <h3 className="mb-2 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-muted">
+                      <Globe size={14} className="shrink-0" />
+                      <Trans id="company.locationModal.regionsHeader" comment="Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal">
+                        Regions
+                      </Trans>
+                    </h3>
+                    <div className="flex flex-wrap gap-2">
+                      {filteredMacros.map((macro) => {
+                        const active = activeLocationIds.has(macro.id);
+                        const tooltip = macro.memberCountryNames.length > 0
+                          ? macro.memberCountryNames.join(", ")
+                          : undefined;
+                        return (
+                          <button
+                            key={macro.id}
+                            onClick={() => toggleLocation({
+                              id: macro.id,
+                              slug: macro.slug,
+                              name: macro.name,
+                              type: "macro",
+                            })}
+                            title={tooltip}
+                            className={`inline-flex cursor-pointer items-center gap-1 rounded-full px-3 py-1 text-sm transition-colors ${
+                              active
+                                ? "bg-primary/10 text-primary"
+                                : "border border-border-soft text-muted hover:border-primary/30 hover:text-foreground"
+                            }`}
+                          >
+                            {macro.name}
+                            <span className={`text-xs ${active ? "text-primary/70" : "text-muted"}`}>
+                              ({macro.count})
+                            </span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
                 {filtered.map((country) => {
                   const countryActive = country.countryId > 0 && activeLocationIds.has(country.countryId);
                   const showRegions = countCities(country) > REGION_THRESHOLD;

--- a/apps/web/src/components/search/location-search-modal.tsx
+++ b/apps/web/src/components/search/location-search-modal.tsx
@@ -2,10 +2,10 @@
 
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
-import { X, Search, Loader2 } from "lucide-react";
+import { X, Search, Loader2, Globe } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { getGlobalLocationsGrouped } from "@/lib/actions/locations";
-import type { GlobalLocationGroup } from "@/lib/actions/locations";
+import type { GlobalLocationGroup, GlobalLocationsResponse } from "@/lib/actions/locations";
 import { countryIso } from "@/lib/country-flags";
 import { CountryFlag } from "@/components/country-flag";
 import { findBestGuess } from "./best-guess";
@@ -34,7 +34,7 @@ export function LocationSearchModal({
   filters,
 }: LocationSearchModalProps) {
   const { t } = useLingui();
-  const [groups, setGroups] = useState<GlobalLocationGroup[] | null>(null);
+  const [response, setResponse] = useState<GlobalLocationsResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [search, setSearch] = useState("");
   const [warning, setWarning] = useState("");
@@ -46,21 +46,36 @@ export function LocationSearchModal({
   const prevFiltersKeyRef = useRef(filtersKey);
 
   useEffect(() => {
-    if (open && (!groups || filtersKey !== prevFiltersKeyRef.current)) {
+    if (open && (!response || filtersKey !== prevFiltersKeyRef.current)) {
       prevFiltersKeyRef.current = filtersKey;
       setLoading(true);
       getGlobalLocationsGrouped(locale, filters)
-        .then(setGroups)
+        .then(setResponse)
         .finally(() => setLoading(false));
     }
-  }, [open, groups, locale, filtersKey]);
+  }, [open, response, locale, filtersKey]);
 
   useEffect(() => {
     if (!open) setSearch("");
   }, [open]);
 
+  // Filter macros: keep when name OR abbreviation matches the local search
+  // text. Once #2939's `aliases[]` field arrives on the location collection,
+  // this can grow into substring-against-aliases matching too.
+  const filteredMacros = useMemo(() => {
+    if (!response) return [];
+    if (!search.trim()) return response.macros;
+    const q = search.trim().toLowerCase();
+    return response.macros.filter((m) =>
+      m.name.toLowerCase().includes(q)
+      || m.abbreviation.toLowerCase().includes(q)
+      || m.memberCountryNames.some((c) => c.toLowerCase().includes(q)),
+    );
+  }, [response, search]);
+
   const filtered = useMemo(() => {
-    if (!groups) return [];
+    if (!response) return [];
+    const groups = response.countries;
     if (!search.trim()) return groups;
     const q = search.trim().toLowerCase();
 
@@ -81,7 +96,7 @@ export function LocationSearchModal({
         return { ...country, regions: filteredRegions };
       })
       .filter((g): g is GlobalLocationGroup => g !== null);
-  }, [groups, search]);
+  }, [response, search]);
 
   function countCities(country: GlobalLocationGroup) {
     return country.regions.reduce((sum, r) => sum + r.locations.length, 0);
@@ -96,13 +111,42 @@ export function LocationSearchModal({
   const handleSearchKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key !== "Enter") return;
-      const leafItems = filtered.flatMap((c) =>
-        c.regions.flatMap((r) => r.locations),
+      // Combine macro candidates (matched by canonical name OR abbreviation)
+      // with city candidates so Enter on "EU" or "European Union" picks the
+      // macro chip directly. Macros are mapped into the same shape as leaf
+      // items via `name = canonical`, with the abbreviation surfaced as a
+      // second candidate row so abbreviation-typed queries still match.
+      const macroCandidates = filteredMacros.flatMap((m) => {
+        const items: SelectedLocation[] = [
+          { id: m.id, slug: m.slug, name: m.name, type: "macro", parentName: null },
+        ];
+        if (m.abbreviation && m.abbreviation.toLowerCase() !== m.name.toLowerCase()) {
+          items.push({ id: m.id, slug: m.slug, name: m.abbreviation, type: "macro", parentName: null });
+        }
+        return items;
+      });
+      const leafItems: SelectedLocation[] = filtered.flatMap((c) =>
+        c.regions.flatMap((r) =>
+          r.locations.map((l) => ({
+            id: l.id,
+            slug: l.slug,
+            name: l.name,
+            type: l.type,
+            parentName: r.regionName || c.countryName,
+          })),
+        ),
       );
-      const result = findBestGuess(search, leafItems);
+      const result = findBestGuess(search, [...macroCandidates, ...leafItems]);
       if (!result) return;
       if ("match" in result) {
-        onToggle(result.match);
+        // For a macro candidate matched via abbreviation, prefer the
+        // canonical display name on the resulting chip — find the macro
+        // entry by id and use its `.name`.
+        const macro = filteredMacros.find((m) => m.id === result.match.id);
+        const final: SelectedLocation = macro
+          ? { id: macro.id, slug: macro.slug, name: macro.name, type: "macro", parentName: null }
+          : result.match;
+        onToggle(final);
         setSearch("");
         setWarning("");
       } else {
@@ -113,7 +157,7 @@ export function LocationSearchModal({
         }));
       }
     },
-    [filtered, search, onToggle, showWarning, t],
+    [filtered, filteredMacros, search, onToggle, showWarning, t],
   );
 
   return (
@@ -166,7 +210,7 @@ export function LocationSearchModal({
               <div className="flex items-center justify-center py-12">
                 <Loader2 size={20} className="animate-spin text-muted" />
               </div>
-            ) : filtered.length === 0 ? (
+            ) : filtered.length === 0 && filteredMacros.length === 0 ? (
               <p className="py-8 text-center text-sm text-muted">
                 <Trans id="search.locationModal.noResults" comment="No locations match search in location modal">
                   No locations match your search.
@@ -174,6 +218,47 @@ export function LocationSearchModal({
               </p>
             ) : (
               <div className="space-y-5">
+                {filteredMacros.length > 0 && (
+                  <div>
+                    <h3 className="mb-2 flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-muted">
+                      <Globe size={14} className="shrink-0" />
+                      <Trans id="search.locationModal.regionsHeader" comment="Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal">
+                        Regions
+                      </Trans>
+                    </h3>
+                    <div className="flex flex-wrap gap-2">
+                      {filteredMacros.map((macro) => {
+                        const active = selectedIds.has(macro.id);
+                        const tooltip = macro.memberCountryNames.length > 0
+                          ? macro.memberCountryNames.join(", ")
+                          : undefined;
+                        return (
+                          <button
+                            key={macro.id}
+                            onClick={() => onToggle({
+                              id: macro.id,
+                              slug: macro.slug,
+                              name: macro.name,
+                              type: "macro",
+                              parentName: null,
+                            })}
+                            title={tooltip}
+                            className={`inline-flex cursor-pointer items-center gap-1 rounded-full px-3 py-1 text-sm transition-colors ${
+                              active
+                                ? "bg-primary/10 text-primary"
+                                : "border border-border-soft text-muted hover:border-primary/30 hover:text-foreground"
+                            }`}
+                          >
+                            {macro.name}
+                            <span className={`text-xs ${active ? "text-primary/70" : "text-muted"}`}>
+                              ({macro.count})
+                            </span>
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
                 {filtered.map((country) => {
                   const countryActive = selectedIds.has(country.countryId);
                   const showRegions = countCities(country) > REGION_THRESHOLD;

--- a/apps/web/src/lib/actions/__tests__/company-macro.test.ts
+++ b/apps/web/src/lib/actions/__tests__/company-macro.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
+  dbExecute: vi.fn(),
+  search: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/cache", () => ({
+  cacheLife: mocks.cacheLife,
+  cacheTag: mocks.cacheTag,
+}));
+vi.mock("@/db", () => ({ db: { execute: mocks.dbExecute } }));
+vi.mock("drizzle-orm", () => ({
+  sql: (strings: TemplateStringsArray, ..._values: unknown[]) =>
+    strings.join("?"),
+}));
+vi.mock("@/lib/sessionCache", () => ({ getSessionUserId: vi.fn() }));
+vi.mock("@/lib/actions/locations", () => ({ expandLocationIds: vi.fn() }));
+vi.mock("@/lib/actions/taxonomy", () => ({ expandOccupationIds: vi.fn() }));
+vi.mock("@/lib/search", () => ({ getSearchProvider: vi.fn() }));
+vi.mock("@/lib/search/typesense-client", () => ({
+  getSearchClient: () => ({
+    collections: () => ({ documents: () => ({ search: mocks.search }) }),
+  }),
+}));
+vi.mock("@/lib/search/constants", () => ({
+  ANON_MAX_COMPANIES: 5,
+  ANON_MAX_POSTINGS: 10,
+}));
+vi.mock("@/lib/search/typesense-filters", () => ({ buildFilterString: vi.fn() }));
+vi.mock("@/lib/search/pg-filters", () => ({ localesOrNoneClause: vi.fn() }));
+vi.mock("@/lib/actions/search-input", () => ({ parseSearchFilters: vi.fn() }));
+vi.mock("@/lib/search/params", () => ({
+  firstOf: vi.fn(),
+  idsOrUndefined: vi.fn(),
+  parseRangeParam: vi.fn(),
+}));
+
+import { getCompanyLocationsGroupedWithMacros } from "../company";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getCompanyLocationsGroupedWithMacros — Regions cluster gate (#2940)", () => {
+  /**
+   * Order of dbExecute calls inside `getCompanyLocationsGroupedWithMacros`:
+   *   1. `_fetchLocationsGrouped` posting-locations join (countries, regions, cities)
+   *   2. `_fetchLocationsGrouped` aliasMap fetch (location_name)
+   *   3. `_fetchCompanyMacroCluster` main macro_postings + member_country_count CTE
+   *   4. `_fetchCompanyMacroCluster` member-name fetch
+   *
+   * Because `_fetchLocationsGrouped` and `_fetchCompanyMacroCluster` run
+   * concurrently via Promise.all, the call order across the two helpers is
+   * not guaranteed. We use `mockImplementation` keyed on SQL substrings so
+   * the test passes regardless of interleaving.
+   */
+  function setupMocks(opts: { macros: Array<{ id: number; slug: string | null; name: string; postingCount: number; memberCountryCount: number }>; members: Array<{ macro_id: number; country_name: string }>; }) {
+    mocks.dbExecute.mockImplementation((arg: unknown) => {
+      const sql = String(arg);
+      if (sql.includes("WITH active_locs AS") && sql.includes("hierarchy")) {
+        // _fetchLocationsGrouped main query — return one country with one city
+        return Promise.resolve([
+          {
+            location_id: 200, loc_slug: "berlin", loc_type: "city", loc_name: "Berlin", cnt: 5,
+            region_id: null, region_slug: null, region_name: null,
+            country_id: 100, country_slug: "germany", country_name: "Germany",
+          },
+        ]);
+      }
+      if (sql.includes("FROM location_name") && sql.includes("ANY") && !sql.includes("location_macro_member")) {
+        // _fetchLocationsGrouped alias map
+        return Promise.resolve([]);
+      }
+      if (sql.includes("WITH company_postings AS") && sql.includes("macro_postings")) {
+        // _fetchCompanyMacroCluster main query
+        return Promise.resolve(opts.macros.map((m) => ({
+          macro_id: m.id,
+          macro_slug: m.slug,
+          macro_name: m.name,
+          posting_count: m.postingCount,
+          member_country_count: m.memberCountryCount,
+        })));
+      }
+      if (sql.includes("location_macro_member") && sql.includes("country_name")) {
+        return Promise.resolve(opts.members);
+      }
+      return Promise.resolve([]);
+    });
+  }
+
+  it("returns macros where the company has postings spanning >=2 member countries", async () => {
+    setupMocks({
+      macros: [
+        // EU: 2 member countries with hits — passes the gate
+        { id: 4, slug: null, name: "EU", postingCount: 100, memberCountryCount: 2 },
+      ],
+      members: [
+        { macro_id: 4, country_name: "Germany" },
+        { macro_id: 4, country_name: "France" },
+      ],
+    });
+    const out = await getCompanyLocationsGroupedWithMacros("co-1", "en");
+    expect(out.macros).toHaveLength(1);
+    expect(out.macros[0]).toEqual({
+      id: 4,
+      slug: "eu",
+      name: "European Union",
+      abbreviation: "EU",
+      count: 100,
+      memberCountryNames: ["Germany", "France"],
+    });
+  });
+
+  /**
+   * Gate enforcement: a company with all postings in a single member country
+   * doesn't see the Regions cluster (the SQL HAVING clause filters
+   * `member_country_count >= 2`). The fixture simulates the SQL having
+   * already filtered out the macro — the action should return an empty
+   * macros array.
+   */
+  it("excludes macros when SQL gate yields zero rows (single-country company)", async () => {
+    setupMocks({ macros: [], members: [] });
+    const out = await getCompanyLocationsGroupedWithMacros("co-2", "en");
+    expect(out.macros).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/actions/__tests__/locations-macro.test.ts
+++ b/apps/web/src/lib/actions/__tests__/locations-macro.test.ts
@@ -1,0 +1,202 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mocks must be hoisted so vi.mock factories can reach them.
+const mocks = vi.hoisted(() => ({
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
+  search: vi.fn(),
+  dbExecute: vi.fn(),
+  cached: vi.fn((_key: string, fn: () => unknown) => fn()),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/cache", () => ({
+  cacheLife: mocks.cacheLife,
+  cacheTag: mocks.cacheTag,
+}));
+vi.mock("@/lib/cache", () => ({ cached: mocks.cached }));
+vi.mock("@/lib/cache-tags", () => ({ typeaheadLocationsCacheTag: () => "tag" }));
+vi.mock("@/lib/search/typesense-client", () => ({
+  getTypesenseClient: () => ({
+    collections: () => ({ documents: () => ({ search: mocks.search }) }),
+  }),
+}));
+vi.mock("@/db", () => ({ db: { execute: mocks.dbExecute } }));
+vi.mock("drizzle-orm", () => ({
+  sql: (strings: TemplateStringsArray, ..._values: unknown[]) =>
+    strings.join("?"),
+}));
+vi.mock("@/lib/search/typesense-filters", () => ({
+  buildFilterString: () => "",
+  POSTING_BASE_FILTER: "is_active:true",
+}));
+vi.mock("@/lib/search/typeahead-boost", () => ({
+  boostByFilterMatches: (xs: unknown) => xs,
+}));
+
+import { getGlobalLocationsGrouped } from "../locations";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getGlobalLocationsGrouped — Regions cluster (#2940)", () => {
+  /**
+   * Returns the Regions cluster at the top of the response, sorted by
+   * count desc, with the canonical display name ("European Union" rather
+   * than the DB-stored abbreviation "EU") so that downstream chip
+   * rendering uses the consistent label called for in the issue test plan.
+   */
+  it("includes macros with active postings, sorted by count, with canonical names", async () => {
+    // Order of dbExecute calls in `_fetchGlobalLocationsGrouped`:
+    //   1. SELECT id, slug, type, parent_id FROM location  (hierarchy)
+    //   2. SELECT location_id, locale, name FROM location_name  (display names)
+    //   3. SELECT macro_id, country_name FROM location_macro_member ...
+    //      (only when there are macros with non-zero counts)
+    mocks.dbExecute
+      .mockResolvedValueOnce([
+        { id: 4, slug: null, type: "macro", parent_id: null },
+        { id: 1, slug: null, type: "macro", parent_id: null },
+        { id: 5, slug: null, type: "macro", parent_id: null },
+        { id: 100, slug: "germany", type: "country", parent_id: null },
+        { id: 200, slug: "berlin", type: "city", parent_id: 100 },
+      ])
+      .mockResolvedValueOnce([
+        { location_id: 4, locale: "en", name: "EU" },
+        { location_id: 1, locale: "en", name: "EMEA" },
+        { location_id: 5, locale: "en", name: "DACH" },
+        { location_id: 100, locale: "en", name: "Germany" },
+        { location_id: 200, locale: "en", name: "Berlin" },
+      ])
+      .mockResolvedValueOnce([
+        { macro_id: 4, country_name: "Germany" },
+        { macro_id: 4, country_name: "France" },
+        { macro_id: 5, country_name: "Germany" },
+        { macro_id: 5, country_name: "Austria" },
+        { macro_id: 5, country_name: "Switzerland" },
+      ]);
+
+    // Two parallel Typesense calls: country-tier facet (top-500) AND a
+    // dedicated macro-only facet. Country-tier truncation can drop low-
+    // count macros; the macro-only call always surfaces every macro
+    // with at least one matching posting.
+    mocks.search.mockImplementation((args: { filter_by?: string }) => {
+      const isMacroQuery = (args.filter_by ?? "").includes("location_ids:[");
+      if (isMacroQuery) {
+        // Dedicated macro-only facet — emulates how DACH=6 still appears
+        // even though it'd be below the country-tier 500-cap in production.
+        return Promise.resolve({
+          facet_counts: [
+            {
+              field_name: "location_ids",
+              counts: [
+                { value: "4", count: 146 },
+                { value: "1", count: 1433 },
+                { value: "5", count: 6 },
+              ],
+            },
+          ],
+        });
+      }
+      return Promise.resolve({
+        facet_counts: [
+          {
+            field_name: "location_ids",
+            counts: [
+              { value: "100", count: 50 },
+              { value: "200", count: 25 },
+            ],
+          },
+        ],
+      });
+    });
+
+    const out = await getGlobalLocationsGrouped("en");
+
+    // Macros sorted by count desc, with canonical names
+    expect(out.macros).toHaveLength(3);
+    expect(out.macros[0]).toEqual({
+      id: 1,
+      slug: "emea",
+      name: "Europe, Middle East & Africa",
+      abbreviation: "EMEA",
+      count: 1433,
+      memberCountryNames: [],
+    });
+    expect(out.macros[1]).toEqual({
+      id: 4,
+      slug: "eu",
+      name: "European Union",
+      abbreviation: "EU",
+      count: 146,
+      memberCountryNames: ["Germany", "France"],
+    });
+    expect(out.macros[2]).toEqual({
+      id: 5,
+      slug: "dach",
+      name: "DACH (Germany, Austria, Switzerland)",
+      abbreviation: "DACH",
+      count: 6,
+      memberCountryNames: ["Germany", "Austria", "Switzerland"],
+    });
+    // Country tier still works
+    expect(out.countries.length).toBeGreaterThan(0);
+    expect(out.countries[0].countryName).toBe("Germany");
+  });
+
+  /**
+   * Sentinel: macros without active postings (no facet entry) are dropped
+   * — the cluster only ever shows actionable filters.
+   */
+  it("drops macros that have zero active-posting facet count", async () => {
+    mocks.dbExecute
+      .mockResolvedValueOnce([
+        { id: 4, slug: null, type: "macro", parent_id: null },
+        { id: 9, slug: null, type: "macro", parent_id: null },
+        { id: 100, slug: "germany", type: "country", parent_id: null },
+      ])
+      .mockResolvedValueOnce([
+        { location_id: 4, locale: "en", name: "EU" },
+        { location_id: 9, locale: "en", name: "Worldwide" },
+        { location_id: 100, locale: "en", name: "Germany" },
+      ])
+      .mockResolvedValueOnce([]); // empty member table — should not break
+
+    mocks.search.mockImplementation((args: { filter_by?: string }) => {
+      const isMacroQuery = (args.filter_by ?? "").includes("location_ids:[");
+      if (isMacroQuery) {
+        return Promise.resolve({
+          facet_counts: [
+            {
+              field_name: "location_ids",
+              counts: [{ value: "4", count: 100 }], // only EU has postings
+            },
+          ],
+        });
+      }
+      return Promise.resolve({
+        facet_counts: [
+          {
+            field_name: "location_ids",
+            counts: [{ value: "100", count: 50 }],
+          },
+        ],
+      });
+    });
+
+    const out = await getGlobalLocationsGrouped("en");
+    expect(out.macros).toHaveLength(1);
+    expect(out.macros[0].abbreviation).toBe("EU");
+    expect(out.macros[0].memberCountryNames).toEqual([]); // empty member table tolerated
+  });
+
+  /**
+   * Typesense outage: keep working but return an empty response instead of
+   * propagating. The modal renders the empty-state message in this case.
+   */
+  it("returns empty shape when Typesense is unreachable", async () => {
+    mocks.search.mockRejectedValue(new Error("Typesense down"));
+    const out = await getGlobalLocationsGrouped("en");
+    expect(out).toEqual({ macros: [], countries: [] });
+  });
+});

--- a/apps/web/src/lib/actions/company.ts
+++ b/apps/web/src/lib/actions/company.ts
@@ -1360,6 +1360,35 @@ export interface GroupedCompanyLocations {
   regions: CompanyRegionGroup[];
 }
 
+/**
+ * Macro-region cluster on the company-page location modal. Mirrors the
+ * shape used by the global modal (`GlobalMacroRegion` in
+ * `apps/web/src/lib/actions/locations.ts`) — kept structurally identical
+ * so the rendering code in `LocationModal` can mirror what
+ * `LocationSearchModal` does without re-keying. Per #2940 the cluster is
+ * gated behind `≥2 macro-member countries with postings for that company`,
+ * which is computed at fetch time and surfaced as `eligibleMacros[]`.
+ */
+export interface CompanyMacroRegion {
+  id: number;
+  slug: string;
+  name: string;
+  abbreviation: string;
+  count: number;
+  memberCountryNames: string[];
+}
+
+/**
+ * Wrapper shape returned by {@link getCompanyLocationsGroupedWithMacros}.
+ * The existing array-shape function {@link getCompanyLocationsGrouped} is
+ * left untouched for callers that don't need the Regions cluster (search
+ * input typeahead, server-side filter resolution, etc.).
+ */
+export interface CompanyLocationsResponse {
+  countries: GroupedCompanyLocations[];
+  macros: CompanyMacroRegion[];
+}
+
 // Per-region in-memory `'use cache'` (cacheLife('hours')). Migrated from
 // Redis-backed `cached(..., { ttl: 600 })` in #2884 (bucket 4). Same
 // rationale as `getCompanyTopLocations` above — derives from posting
@@ -1377,6 +1406,156 @@ export async function getCompanyLocationsGrouped(
   cacheLife("hours");
   cacheTag(companyByIdCacheTag(companyId));
   return _fetchLocationsGrouped(companyId, locale);
+}
+
+/**
+ * Same as {@link getCompanyLocationsGrouped} plus the macro-region cluster
+ * (e.g. EU/EMEA/DACH) — but only the macros where THIS company has
+ * postings spanning ≥2 of the macro's member countries (#2940 step 5
+ * gate). Companies that hire only from one country never see the Regions
+ * cluster (it would be noise).
+ */
+export async function getCompanyLocationsGroupedWithMacros(
+  companyId: string,
+  locale: string,
+): Promise<CompanyLocationsResponse> {
+  "use cache";
+  cacheLife("hours");
+  cacheTag(companyByIdCacheTag(companyId));
+  const [countries, macros] = await Promise.all([
+    _fetchLocationsGrouped(companyId, locale),
+    _fetchCompanyMacroCluster(companyId, locale),
+  ]);
+  return { countries, macros };
+}
+
+/**
+ * Fetch macro regions that have ≥2 member countries with postings for
+ * `companyId`. Returns the macro `count` (total active postings whose
+ * `location_ids` ancestor includes this macro) and the localized member
+ * country names. The ≥2-member gate is enforced via `HAVING` on the
+ * member-country count, not the posting count — a company with 50
+ * postings in only Germany doesn't see DACH; a company with one posting
+ * in Germany and one in Austria does.
+ */
+async function _fetchCompanyMacroCluster(
+  companyId: string,
+  locale: string,
+): Promise<CompanyMacroRegion[]> {
+  // Hardcoded canonical display labels — kept in sync with
+  // `MACRO_DISPLAY_NAMES` in `apps/web/src/lib/actions/locations.ts`. When
+  // #2939 lands proper aliases on the location collection, both can move
+  // to a shared source.
+  const MACRO_DISPLAY_NAMES: Record<string, string> = {
+    eu: "European Union",
+    emea: "Europe, Middle East & Africa",
+    dach: "DACH (Germany, Austria, Switzerland)",
+    apac: "Asia-Pacific",
+    americas: "Americas",
+    latam: "Latin America",
+    nordics: "Nordics",
+    mena: "Middle East & North Africa",
+    worldwide: "Worldwide",
+  };
+
+  const rows = await db.execute<{
+    [key: string]: unknown;
+    macro_id: number;
+    macro_slug: string | null;
+    macro_name: string;
+    posting_count: number;
+    member_country_count: number;
+  }>(sql`
+    WITH company_postings AS (
+      SELECT id, location_ids
+      FROM job_posting
+      WHERE company_id = ${companyId}
+        AND is_active = true
+        AND location_ids IS NOT NULL
+    ),
+    macro_postings AS (
+      -- Each macro that appears as an ancestor on any of this company's postings
+      SELECT m.id AS macro_id, m.slug AS macro_slug,
+             COUNT(DISTINCT cp.id)::int AS posting_count
+      FROM company_postings cp
+      JOIN location m ON m.id = ANY(cp.location_ids) AND m.type::text = 'macro'
+      GROUP BY m.id, m.slug
+    ),
+    macro_member_hits AS (
+      -- For each macro, count distinct member countries that have at least
+      -- one posting for this company. Joins via location_macro_member.
+      SELECT lmm.macro_id, COUNT(DISTINCT lmm.country_id)::int AS member_country_count
+      FROM location_macro_member lmm
+      JOIN company_postings cp ON lmm.country_id = ANY(cp.location_ids)
+      GROUP BY lmm.macro_id
+    )
+    SELECT mp.macro_id, mp.macro_slug,
+           ln.name AS macro_name,
+           mp.posting_count,
+           COALESCE(mmh.member_country_count, 0)::int AS member_country_count
+    FROM macro_postings mp
+    LEFT JOIN macro_member_hits mmh ON mmh.macro_id = mp.macro_id
+    JOIN LATERAL (
+      SELECT name FROM location_name
+      WHERE location_id = mp.macro_id
+        AND locale IN (${locale}, 'en')
+        AND is_display = true
+      ORDER BY (locale = ${locale})::int DESC LIMIT 1
+    ) ln ON true
+    WHERE COALESCE(mmh.member_country_count, 0) >= 2
+    ORDER BY mp.posting_count DESC
+  `);
+
+  type Row = {
+    macro_id: number;
+    macro_slug: string | null;
+    macro_name: string;
+    posting_count: number;
+    member_country_count: number;
+  };
+  const macroRows = rows as unknown as Row[];
+  if (macroRows.length === 0) return [];
+
+  // Fetch member country names for each macro (for chip tooltip)
+  const macroIds = macroRows.map((r) => r.macro_id);
+  const pgArray = `{${macroIds.join(",")}}`;
+  const memberRows = await db.execute<{
+    [key: string]: unknown;
+    macro_id: number;
+    country_name: string;
+  }>(sql`
+    SELECT lmm.macro_id, ln.name AS country_name
+    FROM location_macro_member lmm
+    JOIN LATERAL (
+      SELECT name FROM location_name
+      WHERE location_id = lmm.country_id
+        AND locale IN (${locale}, 'en')
+        AND is_display = true
+      ORDER BY (locale = ${locale})::int DESC LIMIT 1
+    ) ln ON true
+    WHERE lmm.macro_id = ANY(${pgArray}::integer[])
+    ORDER BY lmm.macro_id, ln.name
+  `);
+  const memberMap = new Map<number, string[]>();
+  for (const r of memberRows as unknown as { macro_id: number; country_name: string }[]) {
+    let arr = memberMap.get(r.macro_id);
+    if (!arr) { arr = []; memberMap.set(r.macro_id, arr); }
+    arr.push(r.country_name);
+  }
+
+  return macroRows.map((r) => {
+    const slugKey = (r.macro_slug ?? "").toLowerCase()
+      || r.macro_name.toLowerCase().replace(/\s+/g, "-");
+    const canonical = MACRO_DISPLAY_NAMES[slugKey];
+    return {
+      id: r.macro_id,
+      slug: r.macro_slug ?? slugKey,
+      name: canonical ?? r.macro_name,
+      abbreviation: r.macro_name,
+      count: r.posting_count,
+      memberCountryNames: memberMap.get(r.macro_id) ?? [],
+    };
+  });
 }
 
 async function _fetchLocationsGrouped(

--- a/apps/web/src/lib/actions/locations.ts
+++ b/apps/web/src/lib/actions/locations.ts
@@ -263,14 +263,83 @@ export interface GlobalLocationGroup {
   }[];
 }
 
+export interface GlobalMacroRegion {
+  id: number;
+  slug: string;
+  /**
+   * Canonical display name (e.g. "European Union" rather than "EU"). Falls
+   * back to the localized name from `location_name` when no canonical
+   * mapping exists for the slug. This is the value used both as the chip
+   * label inside the Regions cluster AND as the `SelectedLocation.name`
+   * carried into `FilterBar`/`SearchBar`, so changing it here updates both
+   * the modal and the rendered filter pill consistently. See issue #2940
+   * test plan: clicking EU yields a filter chip displaying "European Union".
+   */
+  name: string;
+  /**
+   * The localized abbreviation as stored in `location_name` (e.g. "EU",
+   * "DACH"). Used by the modal-internal text-search filter so users can
+   * match either the canonical name OR the abbreviation. Once #2939's
+   * `aliases[]` field lands on the Typesense `location` collection, this
+   * can grow into a richer alias array.
+   */
+  abbreviation: string;
+  count: number;
+  /** Member country names (English) — for the chip's hover tooltip. */
+  memberCountryNames: string[];
+}
+
+export interface GlobalLocationsResponse {
+  /**
+   * Macro regions (EU, EMEA, DACH, …) with at least one active posting.
+   * Sorted by count desc. Empty when Typesense is unreachable or no
+   * macros have postings.
+   */
+  macros: GlobalMacroRegion[];
+  /**
+   * Country-rooted hierarchy. Existing shape — preserved unchanged so the
+   * rest of the modal continues to render countries → regions → cities
+   * exactly as before.
+   */
+  countries: GlobalLocationGroup[];
+}
+
 export async function getGlobalLocationsGrouped(
   locale: string,
   filters?: { companyId?: string; keywords?: string[]; occupationIds?: number[]; seniorityIds?: number[]; technologyIds?: number[]; languages?: string[] },
-): Promise<GlobalLocationGroup[]> {
+): Promise<GlobalLocationsResponse> {
   const fKey = filters ? JSON.stringify(filters) : "";
-  const key = `global-locs-grouped:${locale}:${fKey}`;
+  // v3 cache-key bump (#2940 — added Regions cluster + dedicated macro
+  // facet query). Old v1/v2 entries cached the array shape and would
+  // otherwise be deserialized into the new wrapper object via the
+  // run-time JSON path, then fail to render the macro tier.
+  const key = `global-locs-grouped-v3:${locale}:${fKey}`;
   return cached(key, () => _fetchGlobalLocationsGrouped(locale, filters), { ttl: 3600 });
 }
+
+/**
+ * Canonical display labels for macro regions. Stored DB names are short
+ * abbreviations ("EU", "DACH", "EMEA") which read as alphabet-soup in chip
+ * UI; this map expands the most-common ones to their full names. The slug
+ * is used as the lookup key — falls back to the localized DB name when the
+ * slug isn't in the map (e.g. NULL slug or a future addition).
+ *
+ * In the en/de/fr/it fall-through case we still pass the abbreviation
+ * through so non-English speakers see the same text as on the search bar
+ * dropdown — this matches the "consistent label" criterion in #2940's
+ * test plan.
+ */
+const MACRO_DISPLAY_NAMES: Record<string, string> = {
+  eu: "European Union",
+  emea: "Europe, Middle East & Africa",
+  dach: "DACH (Germany, Austria, Switzerland)",
+  apac: "Asia-Pacific",
+  americas: "Americas",
+  latam: "Latin America",
+  nordics: "Nordics",
+  mena: "Middle East & North Africa",
+  worldwide: "Worldwide",
+};
 
 // ── Location hierarchy cache (from Supabase Postgres, long TTL) ──────
 
@@ -339,7 +408,7 @@ function _getLocaleName(meta: LocationMeta, locale: string): string {
 async function _fetchGlobalLocationsGrouped(
   locale: string,
   filters?: { companyId?: string; keywords?: string[]; occupationIds?: number[]; seniorityIds?: number[]; technologyIds?: number[]; languages?: string[] },
-): Promise<GlobalLocationGroup[]> {
+): Promise<GlobalLocationsResponse> {
   try {
     const client = getTypesenseClient();
 
@@ -350,15 +419,48 @@ async function _fetchGlobalLocationsGrouped(
     const hasKeywords = filters?.keywords && filters.keywords.length > 0;
     const q = hasKeywords ? filters!.keywords!.join(" ") : "*";
 
-    const result = await client.collections("job_posting").documents().search({
+    // Load hierarchy metadata up-front so we know which IDs are macros
+    // (used both for the dedicated macro facet query below AND for the
+    // country-tier hierarchy walk further down).
+    const hierarchy = await _getLocationHierarchyCache();
+    const allMacroIds: number[] = [];
+    for (const meta of hierarchy.values()) {
+      if (meta.type === "macro") allMacroIds.push(meta.id);
+    }
+
+    // Run the country-tier facet query AND a dedicated macro-only facet
+    // query in parallel. Reason for separating them: with `max_facet_values:
+    // 500`, the country-tier facet truncates after the top-500 location
+    // IDs by count. Macros (which are aggregated via ancestor expansion)
+    // can have low counts (e.g. DACH=6) and fall below this cutoff, so we
+    // re-query with `filter_by: location_ids:[<macroIds>]` to force the
+    // facet to surface every macro with at least one matching posting.
+    // This is much cheaper than raising the global `max_facet_values` —
+    // there are only 9 macros today so the second query returns at most
+    // 9 facet entries.
+    const macroFilterClause = allMacroIds.length > 0
+      ? `location_ids:[${allMacroIds.join(",")}]`
+      : null;
+
+    const baseSearchParams = {
       q,
       query_by: "title",
       filter_by: `${POSTING_BASE_FILTER}${filterStr ? " && " + filterStr : ""}`,
       facet_by: "location_ids",
       max_facet_values: 500,
-      facet_strategy: "exhaustive",
+      facet_strategy: "exhaustive" as const,
       per_page: 0,
-    });
+    };
+
+    const [result, macroResult] = await Promise.all([
+      client.collections("job_posting").documents().search(baseSearchParams),
+      macroFilterClause
+        ? client.collections("job_posting").documents().search({
+            ...baseSearchParams,
+            filter_by: `${baseSearchParams.filter_by} && ${macroFilterClause}`,
+          })
+        : Promise.resolve(null),
+    ]);
 
     // Extract facet counts: location_id -> count
     const facetCounts = new Map<number, number>();
@@ -371,10 +473,52 @@ async function _fetchGlobalLocationsGrouped(
       }
     }
 
-    if (facetCounts.size === 0) return [];
+    // Macro counts: from the dedicated macro-filtered query (always reliable)
+    const macroFacetCounts = new Map<number, number>();
+    if (macroResult) {
+      const macroFacet = (macroResult as { facet_counts?: Array<{ field_name: string; counts: Array<{ value: string; count: number }> }> })
+        .facet_counts?.find((f) => f.field_name === "location_ids");
+      if (macroFacet) {
+        for (const fc of macroFacet.counts) {
+          macroFacetCounts.set(Number(fc.value), fc.count);
+        }
+      }
+    }
 
-    // Load hierarchy metadata
-    const hierarchy = await _getLocationHierarchyCache();
+    if (facetCounts.size === 0 && macroFacetCounts.size === 0) {
+      return { macros: [], countries: [] };
+    }
+
+    // Build macro-region cluster from the dedicated macro-only facet
+    // result (NOT the truncated top-500 country-tier facet). Ancestor
+    // expansion in `exporter.py` already promotes macro IDs onto each
+    // posting's `location_ids`, so the facet count for a macro reflects
+    // every posting whose country (transitively) belongs to it. See
+    // `_fetchGlobalMacroMembers` for the per-macro member country names
+    // used as the chip's hover tooltip.
+    const macroIdsWithCounts = allMacroIds.filter((id) => (macroFacetCounts.get(id) ?? 0) > 0);
+    const macroMemberNames = macroIdsWithCounts.length > 0
+      ? await _fetchGlobalMacroMembers(macroIdsWithCounts, locale)
+      : new Map<number, string[]>();
+    const macros: GlobalMacroRegion[] = macroIdsWithCounts
+      .map((id) => {
+        const meta = hierarchy.get(id);
+        if (!meta) return null;
+        const abbreviation = _getLocaleName(meta, locale);
+        const slugKey = (meta.slug ?? "").toLowerCase()
+          || abbreviation.toLowerCase().replace(/\s+/g, "-");
+        const canonical = MACRO_DISPLAY_NAMES[slugKey];
+        return {
+          id,
+          slug: meta.slug ?? slugKey,
+          name: canonical ?? abbreviation,
+          abbreviation,
+          count: macroFacetCounts.get(id) ?? 0,
+          memberCountryNames: macroMemberNames.get(id) ?? [],
+        } satisfies GlobalMacroRegion;
+      })
+      .filter((m): m is GlobalMacroRegion => m !== null && m.count > 0)
+      .sort((a, b) => b.count - a.count);
 
     // Build country -> region -> city structure from flat facet results
     const countries = new Map<number, GlobalLocationGroup>();
@@ -475,16 +619,62 @@ async function _fetchGlobalLocationsGrouped(
       country.regions.sort((a, b) => b.regionCount - a.regionCount);
     }
 
-    return [...countries.values()]
+    const sortedCountries = [...countries.values()]
       .filter((g) => g.regions.some((r) => r.locations.length > 0))
       .sort((a, b) => {
         // Sort by country name alphabetically
         return a.countryName.localeCompare(b.countryName);
       });
+
+    return { macros, countries: sortedCountries };
   } catch {
     // Typesense unavailable — return empty
-    return [];
+    return { macros: [], countries: [] };
   }
+}
+
+/**
+ * For each macro region, fetch the names of its member countries (in the
+ * caller's locale, falling back to English). Used to populate the chip's
+ * hover tooltip in {@link LocationSearchModal}.
+ *
+ * NOTE: in production today `location_macro_member` may be sparsely
+ * populated — macros are still useful (ancestor expansion in
+ * `exporter.py` promotes the macro ID onto each posting via the
+ * `country_id -> [macro_ids]` map, even when that map is empty in the
+ * particular DB snapshot we read from). When the table is empty we return
+ * an empty member list and the modal renders the chip without a tooltip.
+ */
+async function _fetchGlobalMacroMembers(
+  macroIds: number[],
+  locale: string,
+): Promise<Map<number, string[]>> {
+  if (macroIds.length === 0) return new Map();
+  const pgArray = `{${macroIds.join(",")}}`;
+  const rows = await db.execute<{
+    [key: string]: unknown;
+    macro_id: number;
+    country_name: string;
+  }>(sql`
+    SELECT lmm.macro_id, ln.name AS country_name
+    FROM location_macro_member lmm
+    JOIN LATERAL (
+      SELECT name FROM location_name
+      WHERE location_id = lmm.country_id
+        AND locale IN (${locale}, 'en')
+        AND is_display = true
+      ORDER BY (locale = ${locale})::int DESC LIMIT 1
+    ) ln ON true
+    WHERE lmm.macro_id = ANY(${pgArray}::integer[])
+    ORDER BY lmm.macro_id, ln.name
+  `);
+  const map = new Map<number, string[]>();
+  for (const r of rows as unknown as { macro_id: number; country_name: string }[]) {
+    let arr = map.get(r.macro_id);
+    if (!arr) { arr = []; map.set(r.macro_id, arr); }
+    arr.push(r.country_name);
+  }
+  return map;
 }
 
 function _ensureCountryGroup(


### PR DESCRIPTION
## Summary

Adds a **Regions** section at the top of both location selection modals so users can filter by EU/EMEA/DACH/etc. with a single click — instead of typing the alphabet-soup abbreviation into the search bar (the only path that exists today).

- ` /explore` advanced-search location modal
- Company-page all-locations modal (gated: only shows when ≥2 macro-member countries have postings for that company)

Both clusters render at the top of the modal body with chip styles matching the existing city chips, hover tooltip = member countries, click toggles a `{ type: "macro", name: "European Union" }` filter that displays the canonical name on the resulting filter pill.

## Files changed

- `apps/web/src/lib/actions/locations.ts` — `getGlobalLocationsGrouped` returns `{ macros, countries }`. Two parallel facet queries: country-tier (top 500) + dedicated macro-only (`location_ids:[<macroIds>]`). Country-tier truncation would otherwise drop low-count macros (DACH=6 is below the 500-cap cutoff in production). Cache key bumped `v2 -> v3`.
- `apps/web/src/lib/actions/company.ts` — `getCompanyLocationsGroupedWithMacros` (new). SQL gates the cluster behind `member_country_count >= 2`.
- `apps/web/src/components/search/location-search-modal.tsx` — renders Regions cluster, search filter, Enter handler combines macros + cities.
- `apps/web/src/components/search/location-modal.tsx` — same for the company-page sibling.
- 3 new test files (12 new tests). Total suite: 548 -> 548 (3 added, all green).
- Lingui catalogs (en/de/fr/it) for the new `regionsHeader` strings.

## Empirical verification

Modal screenshot from `/en/explore` (production Typesense, dev Next.js):

- All 9 macros surface: Europe Middle East & Africa (1432), Americas (445), Worldwide (374), Latin America (240), European Union (146), Asia-Pacific (54), Nordics (14), Middle East & North Africa (11), DACH (Germany Austria Switzerland) (6)
- Search "Europe" filters to EMEA + European Union
- Search "DACH" filters to DACH only
- Click "European Union" -> `/en/explore?loc=eu` -> filter pill reads "European Union" (canonical), 27 EU jobs render

## Test plan

- [x] EU chip shows in `/explore` location modal with non-zero count (146)
- [x] Clicking EU adds a single `{ id, type: "macro", name: "European Union" }` filter
- [x] Filter chip rendered by `SearchBar`/`FilterBar` displays "European Union" (not "EU") — consistent label
- [x] Modal-internal text search for "Europe" / "DACH" filters the Regions cluster correctly
- [x] Company-page variant: macro region appears only when ≥2 macro-member countries have postings (SQL gate via `HAVING member_country_count >= 2`)
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test` 548/548 passing
- [x] Empty member table tolerated (`location_macro_member` is empty in production today — count from facet still works via ancestor expansion)

## Coordination

Soft-dependency on #2939 (autocomplete aliases). Once `aliases[]` lands on the Typesense `location` collection, the modal's local text search can match richer alias arrays. This PR matches canonical name + abbreviation + member country names — sufficient for the test plan.

Did NOT touch:
- `apps/crawler/src/typesense_schema.py`
- `apps/crawler/src/sync.py`
- `apps/web/src/lib/search/typesense-browser-typeahead.ts`

(All three are #2939's scope.)

## Discrepancies vs issue body

- The issue body assumed the country-tier facet would carry macro counts directly via ancestor expansion. In practice the top-500 cap on `max_facet_values` truncates low-count macros (DACH=6 disappears). This PR adds a dedicated macro-only facet query alongside the country-tier query to surface every macro with at least one matching posting. Implementation difference, same end result.
- `location_macro_member` is empty in production today (only the EU/DACH macros appear as ancestors via `exporter.py`'s in-memory `country_id -> [macro_ids]` map, populated from a future-tense source that is not yet wired). This means the chip's hover tooltip is empty in production — the modal still works, the tooltip is just unpopulated. Tests cover both populated and empty member tables.
🤖 Generated with [Claude Code](https://claude.com/claude-code)