### PR TITLE
fix(web): apply has_content filter to year-count badge queries (Closes #2926)

### DIFF
--- a/apps/web/src/lib/search/__tests__/typesense-filters.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense-filters.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { POSTING_BASE_FILTER, buildFilterString } from "../typesense-filters";
 
@@ -34,4 +36,43 @@ describe("buildFilterString", () => {
     expect(out).not.toContain("has_content");
     expect(out).toBe("location_ids:[101]");
   });
+});
+
+// =====================================================================
+// Issue #2926: every `first_seen_at:>` (year-count) filter string in the
+// Typesense providers must compose with POSTING_BASE_FILTER. Skipping it
+// inflates yearly-posting badges to include incomplete postings.
+// =====================================================================
+
+describe("year-count badge filters reference POSTING_BASE_FILTER (#2926)", () => {
+  const SOURCES = [
+    "../typesense.ts",
+    "../typesense-browser.ts",
+  ] as const;
+
+  for (const rel of SOURCES) {
+    it(`${rel}: every \`first_seen_at:>\` filter string mentions POSTING_BASE_FILTER`, () => {
+      const path = join(__dirname, rel);
+      const src = readFileSync(path, "utf8");
+      const lines = src.split("\n");
+
+      // Match template-literal substrings starting with `first_seen_at:>`
+      // and ending at the closing backtick on the same line. The four call
+      // sites in #2926 all build the year filter on a single line.
+      const yearFilterLines = lines.filter((line) =>
+        line.includes("first_seen_at:>") &&
+        // ignore comment-only lines so we don't false-positive on docs
+        !/^\s*\/\//.test(line),
+      );
+
+      expect(yearFilterLines.length).toBeGreaterThan(0);
+
+      for (const line of yearFilterLines) {
+        expect(
+          line.includes("POSTING_BASE_FILTER"),
+          `expected POSTING_BASE_FILTER in line:\n  ${line.trim()}`,
+        ).toBe(true);
+      }
+    });
+  }
 });

--- a/apps/web/src/lib/search/typesense-browser.ts
+++ b/apps/web/src/lib/search/typesense-browser.ts
@@ -146,7 +146,7 @@ async function fetchYearCounts(
 ): Promise<Map<string, number>> {
   if (companyIds.length === 0) return new Map();
   const yearFilter =
-    `first_seen_at:>${oneYearAgoUnix()} && company_id:[${companyIds.join(",")}]` +
+    `${POSTING_BASE_FILTER} && first_seen_at:>${oneYearAgoUnix()} && company_id:[${companyIds.join(",")}]` +
     (filterStr ? ` && ${filterStr}` : "");
   const r = await searchOne<JobPostingDoc>(cfg, "job_posting", {
     q,
@@ -414,7 +414,7 @@ export class TypesenseBrowserProvider implements SearchProvider {
       searchOne<JobPostingDoc>(cfg, "job_posting", {
         q,
         query_by: "title",
-        filter_by: `first_seen_at:>${oneYearAgoUnix()} && ${baseFilter}`,
+        filter_by: `${POSTING_BASE_FILTER} && first_seen_at:>${oneYearAgoUnix()} && ${baseFilter}`,
         per_page: 0,
       }),
     ]);

--- a/apps/web/src/lib/search/typesense.ts
+++ b/apps/web/src/lib/search/typesense.ts
@@ -165,7 +165,7 @@ async function fetchYearCountsFiltered(
   if (companyIds.length === 0) return new Map();
 
   const client = getSearchClient();
-  const yearFilter = `first_seen_at:>${oneYearAgoUnix()} && company_id:[${companyIds.join(",")}]${filterStr ? " && " + filterStr : ""}`;
+  const yearFilter = `${POSTING_BASE_FILTER} && first_seen_at:>${oneYearAgoUnix()} && company_id:[${companyIds.join(",")}]${filterStr ? " && " + filterStr : ""}`;
 
   const result: TsSearchResponse<JobPostingDoc> = await client
     .collections<JobPostingDoc>("job_posting")
@@ -543,7 +543,7 @@ export class TypesenseSearchProvider implements SearchProvider {
           .search({
             q,
             query_by: "title",
-            filter_by: `first_seen_at:>${oneYearAgoUnix()} && ${baseFilter}`,
+            filter_by: `${POSTING_BASE_FILTER} && first_seen_at:>${oneYearAgoUnix()} && ${baseFilter}`,
             per_page: 0,
           }),
       ]);


### PR DESCRIPTION
## Summary

- 4 year-count badge queries in `typesense.ts` (lines 168, 546) and `typesense-browser.ts` (lines 149, 417) built `first_seen_at:>oneYearAgoUnix() && ...` without composing `POSTING_BASE_FILTER` (the `is_active:true && has_content:!=false` constant from PR #2923 / issue #2917). Inflated yearly-posting badge counts vs search-result counts, which already used the constant.
- Each site now prepends `${POSTING_BASE_FILTER} && ` to the year-window predicate. The filter is strictly stricter: same `is_active:true` semantics implied before (these are job listings — `has_content:!=false` is the new gate added by #2917), now matches the search count exactly.
- Added a static guard test in `typesense-filters.test.ts` that scans both provider files line-by-line and asserts every `first_seen_at:>` template literal mentions `POSTING_BASE_FILTER`, so future year-window queries can't silently regress.

## Test plan

- [x] `pnpm exec vitest run src/lib/search/__tests__/typesense-filters.test.ts` — 7/7 pass (3 BASE_FILTER + 2 buildFilterString + 2 new source-file guards).
- [x] `pnpm test` — 527 tests pass; one pre-existing failure (`app/mcp/route.test.ts`) is unrelated (`@jseek/mcp-server/handler` build artifact missing in `packages/mcp-server/dist/`, exists on origin/main).
- [x] `pnpm exec tsc --noEmit` — only pre-existing error in `app/mcp/route.ts` for the same MCP build artifact; no new errors in the search providers or tests.
- [x] Empirical Typesense probe (production) for unfiltered year-count:
      - `is_active:true && first_seen_at:>oneYearAgoUnix()` → **755,713**
      - `is_active:true && has_content:!=false && first_seen_at:>oneYearAgoUnix()` → **709,225**
      - delta = 46,488 (~6.1%) — same direction and order of magnitude as the ~31k / 4.14% number in the issue body; gap is from dataset growth since #2926 was filed.
- [ ] Visual: badge counts match search counts on the company detail page after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)