### PR TITLE
fix(web): extend withDbRetry to build-critical db.execute sites

### DIFF
--- a/apps/web/src/lib/actions/__tests__/db-retry-coverage.test.ts
+++ b/apps/web/src/lib/actions/__tests__/db-retry-coverage.test.ts
@@ -1,0 +1,250 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Issue #2930: extends `withDbRetry` (#2929 / #2918) to additional
+ * build-critical and runtime-critical `db.execute` call sites across
+ * `lib/actions/*` and `lib/sitemap.ts`.
+ *
+ * The retry helper itself has 18 dedicated unit tests in
+ * `apps/web/src/lib/__tests__/db-retry.test.ts` covering retry
+ * semantics (backoff, jitter, code/message matching, `cause`-recursion,
+ * non-retryable propagation). This file is a small integration-style
+ * check that the wrapper is actually wired through on representative
+ * call sites — i.e. that a transient ECONNRESET from `db.execute`
+ * is retried (rather than rethrown) and the second attempt's success
+ * surfaces back to the caller.
+ *
+ * One spec per representative module:
+ *   - `_fetchPublicWatchlistByUserAndSlug` — build-critical (blog
+ *     mention prerender + watchlist OG + watchlist page metadata).
+ *   - `fetchSitemapWatchlists` (via `cachedSitemapWatchlists`) —
+ *     build-critical (the route handler runs at every sitemap fetch).
+ *   - `getCurrencyRates` (via `_fetchCurrencyRates`) — runtime-hot;
+ *     used by /explore, /company/<slug>, settings, and salary modal.
+ *   - `getCompanyTopLocations` (via `_fetchTopLocations`) — explicitly
+ *     called out in the #2918 follow-up bullet list.
+ *
+ * Each spec mocks `db.execute` to throw an ECONNRESET on the first
+ * call and resolve normally on the second. Asserting `toHaveBeenCalledTimes(2)`
+ * proves that the wrapper retried — without the wrapper, the first
+ * rejection would propagate out untouched.
+ */
+
+vi.mock("server-only", () => ({}));
+
+const dbExecuteMock = vi.fn();
+const cachedMock = vi.fn(
+  async (_key: string, fetcher: () => Promise<unknown>) => fetcher(),
+);
+
+vi.mock("@/db", () => ({
+  db: {
+    execute: dbExecuteMock,
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        innerJoin: vi.fn(() => ({
+          where: vi.fn(() => ({
+            orderBy: vi.fn().mockResolvedValue([]),
+          })),
+        })),
+      })),
+    })),
+  },
+}));
+
+vi.mock("@/lib/cache", () => ({
+  cached: cachedMock,
+  invalidate: vi.fn(),
+  invalidatePattern: vi.fn(),
+}));
+
+vi.mock("@/lib/sessionCache", () => ({
+  getSessionUserId: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/viewer", () => ({
+  getViewerLanguages: vi.fn().mockResolvedValue(["en"]),
+}));
+
+// `next/server` and `next/cache` aren't reachable in the vitest runtime
+// — the modules under test pull them in transitively via Next's server
+// helpers, so neutralise them.
+vi.mock("next/server", () => ({ after: vi.fn() }));
+vi.mock("next/cache", () => ({
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
+  updateTag: vi.fn(),
+}));
+
+// Search clients aren't in scope; every call site under test reaches
+// Postgres directly (or through the helper).
+vi.mock("@/lib/search/typesense-client", () => ({
+  getSearchClient: vi.fn(() => ({
+    collections: () => ({
+      documents: () => ({
+        search: vi.fn().mockRejectedValue(new Error("typesense unreachable")),
+      }),
+    }),
+  })),
+  getTypesenseClient: vi.fn(() => ({
+    collections: () => ({
+      documents: () => ({
+        search: vi.fn().mockRejectedValue(new Error("typesense unreachable")),
+      }),
+    }),
+  })),
+}));
+
+vi.mock("@/lib/search/typesense-watchlist", () => ({
+  upsertWatchlist: vi.fn(),
+  deleteWatchlist: vi.fn(),
+  updateWatchlistField: vi.fn(),
+}));
+
+vi.mock("@/lib/indexnow", () => ({
+  notifyIndexNow: vi.fn().mockResolvedValue({ kind: "submitted", status: 200 }),
+}));
+
+vi.mock("@/lib/db-retry", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/db-retry")
+  >("@/lib/db-retry");
+  return {
+    ...actual,
+    // Override the `withDbRetry` default sleep so the suite doesn't
+    // wait 200ms+ between retries. We import the real implementation
+    // (so the policy stays under test) and only collapse the timer.
+    withDbRetry: <T,>(
+      fn: () => Promise<T>,
+      opts: Parameters<typeof actual.withDbRetry>[1] = {},
+    ) =>
+      actual.withDbRetry(fn, {
+        ...opts,
+        sleep: () => Promise.resolve(),
+      }),
+  };
+});
+
+const econnreset = (): Error => {
+  const e = new Error("read ECONNRESET") as Error & { code: string };
+  e.code = "ECONNRESET";
+  return e;
+};
+
+describe("issue #2930 — withDbRetry covers additional call sites", () => {
+  beforeEach(() => {
+    dbExecuteMock.mockReset();
+    cachedMock.mockClear();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("retries _fetchPublicWatchlistByUserAndSlug after ECONNRESET", async () => {
+    // First execute() rejects (transient pooler reset), second
+    // execute() returns the watchlist row.
+    dbExecuteMock.mockRejectedValueOnce(econnreset()).mockResolvedValueOnce([
+      {
+        wl_id: "wl-1",
+        slug: "remote-frontend",
+        title: "Remote Frontend",
+        description: null,
+        is_public: true,
+        alerts_enabled: false,
+        filters: {},
+        source_watchlist_id: null,
+        created_at: new Date(),
+        user_id: "u-1",
+        owner_id: "u-1",
+        username: "alice",
+        display_username: "alice",
+        owner_name: "Alice",
+      },
+    ]);
+
+    const { getPublicWatchlistByUserAndSlug } = await import(
+      "@/lib/actions/watchlists"
+    );
+    const result = await getPublicWatchlistByUserAndSlug(
+      "alice",
+      "remote-frontend",
+    );
+
+    expect(result?.slug).toBe("remote-frontend");
+    expect(dbExecuteMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries cachedSitemapWatchlists after ECONNRESET", async () => {
+    dbExecuteMock
+      .mockRejectedValueOnce(econnreset())
+      .mockResolvedValueOnce([
+        {
+          user_slug: "alice",
+          watchlist_slug: "remote-frontend",
+          updated_at: new Date(),
+          is_curated: false,
+        },
+      ]);
+
+    const { cachedSitemapWatchlists } = await import("@/lib/sitemap");
+    const rows = await cachedSitemapWatchlists();
+
+    expect(rows.length).toBe(1);
+    expect(dbExecuteMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries getCurrencyRates after ECONNRESET", async () => {
+    dbExecuteMock
+      .mockRejectedValueOnce(econnreset())
+      .mockResolvedValueOnce([
+        { currency: "EUR", to_eur: "1.0" },
+        { currency: "USD", to_eur: "0.92" },
+      ]);
+
+    const { getCurrencyRates } = await import("@/lib/actions/search");
+    const rates = await getCurrencyRates();
+
+    expect(rates.find((r) => r.currency === "USD")?.toEur).toBeCloseTo(0.92);
+    expect(dbExecuteMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries getCompanyTopLocations after ECONNRESET", async () => {
+    dbExecuteMock
+      .mockRejectedValueOnce(econnreset())
+      .mockResolvedValueOnce([
+        {
+          location_id: 1,
+          loc_slug: "berlin",
+          loc_type: "city",
+          loc_name: "Berlin",
+          cnt: 5,
+          total_locations: 1,
+        },
+      ]);
+
+    const { getCompanyTopLocations } = await import("@/lib/actions/company");
+    const result = await getCompanyTopLocations("c-1", "en");
+
+    expect(result.locations).toHaveLength(1);
+    expect(result.locations[0]?.slug).toBe("berlin");
+    expect(dbExecuteMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates non-retryable errors (syntax) without retrying", async () => {
+    // Sanity check: the wrapper should not retry on errors that aren't
+    // connection-class. Pick any wrapped site.
+    const syntaxErr = new Error('syntax error at or near "FROM"');
+    dbExecuteMock.mockRejectedValue(syntaxErr);
+
+    const { getCurrencyRates } = await import("@/lib/actions/search");
+
+    // `getCurrencyRates` outer try/catch swallows errors and returns the
+    // EUR fallback shape. Assert we got the fallback AND `db.execute`
+    // was called exactly once (no retry).
+    const rates = await getCurrencyRates();
+    expect(rates).toEqual([{ currency: "EUR", toEur: 1 }]);
+    expect(dbExecuteMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/actions/bootstrap.ts
+++ b/apps/web/src/lib/actions/bootstrap.ts
@@ -2,6 +2,7 @@
 
 import { sql } from "drizzle-orm";
 import { db } from "@/db";
+import { withDbRetry } from "@/lib/db-retry";
 import { getSession } from "@/lib/sessionCache";
 import type { SavedJobStatus } from "@/lib/actions/saved-jobs";
 
@@ -56,35 +57,39 @@ async function _fetchBootstrapForUser(userId: string): Promise<{
     starred_ids: { company_id: string }[];
   };
 
-  const rows = await db.execute<Row & Record<string, unknown>>(sql`
-    SELECT
-      (SELECT row_to_json(p) FROM (
+  const rows = await withDbRetry(
+    () =>
+      db.execute<Row & Record<string, unknown>>(sql`
         SELECT
-          theme,
-          theme_updated_at AS "themeUpdatedAt",
-          locale,
-          locale_updated_at AS "localeUpdatedAt",
-          cookie_consent AS "cookieConsent",
-          display_currency AS "displayCurrency",
-          salary_period AS "salaryPeriod",
-          dismissed_banners AS "dismissedBanners",
-          job_languages AS "jobLanguages"
-        FROM user_preferences
-        WHERE user_id = ${userId}
-        LIMIT 1
-      ) p) AS prefs,
-      (SELECT coalesce(json_agg(s), '[]'::json) FROM (
-        SELECT
-          job_posting_id AS "postingId",
-          id AS "savedJobId",
-          status
-        FROM saved_job
-        WHERE user_id = ${userId}
-      ) s) AS saved_statuses,
-      (SELECT coalesce(json_agg(c), '[]'::json) FROM (
-        SELECT company_id FROM followed_company WHERE user_id = ${userId}
-      ) c) AS starred_ids
-  `);
+          (SELECT row_to_json(p) FROM (
+            SELECT
+              theme,
+              theme_updated_at AS "themeUpdatedAt",
+              locale,
+              locale_updated_at AS "localeUpdatedAt",
+              cookie_consent AS "cookieConsent",
+              display_currency AS "displayCurrency",
+              salary_period AS "salaryPeriod",
+              dismissed_banners AS "dismissedBanners",
+              job_languages AS "jobLanguages"
+            FROM user_preferences
+            WHERE user_id = ${userId}
+            LIMIT 1
+          ) p) AS prefs,
+          (SELECT coalesce(json_agg(s), '[]'::json) FROM (
+            SELECT
+              job_posting_id AS "postingId",
+              id AS "savedJobId",
+              status
+            FROM saved_job
+            WHERE user_id = ${userId}
+          ) s) AS saved_statuses,
+          (SELECT coalesce(json_agg(c), '[]'::json) FROM (
+            SELECT company_id FROM followed_company WHERE user_id = ${userId}
+          ) c) AS starred_ids
+      `),
+    { label: "appBootstrap" },
+  );
 
   const row = (rows as unknown as Row[])[0];
   if (!row) return { prefs: null, savedStatuses: [], starredIds: [] };

--- a/apps/web/src/lib/actions/company.ts
+++ b/apps/web/src/lib/actions/company.ts
@@ -56,36 +56,40 @@ async function _queryCompanySuggestionsCached(
   // instead of waiting up to 3600s for the TTL. See #2907 follow-up.
   cacheTag(typeaheadCompaniesCacheTag());
 
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    id: string;
-    name: string;
-    slug: string;
-    icon: string | null;
-    match_rank: number;
-  }>(sql`
-    WITH prefix_matches AS (
-      SELECT c.id, c.name, c.slug, c.icon, 1 AS match_rank
-      FROM company c
-      WHERE lower(c.name) LIKE ${q + "%"}
-        AND EXISTS (SELECT 1 FROM job_posting jp WHERE jp.company_id = c.id AND jp.is_active = true)
-      LIMIT 5
-    ),
-    fuzzy_matches AS (
-      SELECT c.id, c.name, c.slug, c.icon, 2 AS match_rank
-      FROM company c
-      WHERE length(${q}) >= 3
-        AND similarity(lower(c.name), ${q}) > 0.3
-        AND c.id NOT IN (SELECT id FROM prefix_matches)
-        AND EXISTS (SELECT 1 FROM job_posting jp WHERE jp.company_id = c.id AND jp.is_active = true)
-      ORDER BY similarity(lower(c.name), ${q}) DESC
-      LIMIT 5
-    )
-    SELECT * FROM prefix_matches
-    UNION ALL
-    SELECT * FROM fuzzy_matches
-    LIMIT 5
-  `);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        id: string;
+        name: string;
+        slug: string;
+        icon: string | null;
+        match_rank: number;
+      }>(sql`
+        WITH prefix_matches AS (
+          SELECT c.id, c.name, c.slug, c.icon, 1 AS match_rank
+          FROM company c
+          WHERE lower(c.name) LIKE ${q + "%"}
+            AND EXISTS (SELECT 1 FROM job_posting jp WHERE jp.company_id = c.id AND jp.is_active = true)
+          LIMIT 5
+        ),
+        fuzzy_matches AS (
+          SELECT c.id, c.name, c.slug, c.icon, 2 AS match_rank
+          FROM company c
+          WHERE length(${q}) >= 3
+            AND similarity(lower(c.name), ${q}) > 0.3
+            AND c.id NOT IN (SELECT id FROM prefix_matches)
+            AND EXISTS (SELECT 1 FROM job_posting jp WHERE jp.company_id = c.id AND jp.is_active = true)
+          ORDER BY similarity(lower(c.name), ${q}) DESC
+          LIMIT 5
+        )
+        SELECT * FROM prefix_matches
+        UNION ALL
+        SELECT * FROM fuzzy_matches
+        LIMIT 5
+      `),
+    { label: "companySuggestions" },
+  );
 
   type Row = { id: string; name: string; slug: string; icon: string | null; match_rank: number };
   return (rows as unknown as Row[]).map((r) => ({
@@ -457,9 +461,13 @@ async function _searchCompaniesForWatchlistPostgres(params: {
   if (localesClause) jobClauses.push(localesClause);
   const jobWhere = sql.join(jobClauses, sql` AND `);
 
-  const [totalRow] = await db.execute<{ [key: string]: unknown; cnt: number }>(sql`
-    SELECT count(*)::int AS cnt FROM company c WHERE ${companyWhere}
-  `);
+  const [totalRow] = await withDbRetry(
+    () =>
+      db.execute<{ [key: string]: unknown; cnt: number }>(sql`
+        SELECT count(*)::int AS cnt FROM company c WHERE ${companyWhere}
+      `),
+    { label: "searchCompaniesForWatchlistPostgres.count" },
+  );
   const total = (totalRow as unknown as { cnt: number })?.cnt ?? 0;
   if (total === 0) return { companies: [], total: 0 };
 
@@ -471,31 +479,35 @@ async function _searchCompaniesForWatchlistPostgres(params: {
     ? sql`CASE WHEN c.id = ANY(${starredArray}::uuid[]) THEN 0 ELSE 1 END, active_matches DESC, c.name`
     : sql`active_matches DESC, c.name`;
 
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    id: string;
-    name: string;
-    slug: string;
-    icon: string | null;
-    description: string | null;
-    active_matches: number;
-    year_matches: number;
-  }>(sql`
-    SELECT c.id, c.name, c.slug, c.icon,
-           COALESCE(cd.description, c.description) AS description,
-           (SELECT count(*)::int FROM job_posting jp
-            WHERE jp.company_id = c.id AND ${jobWhere}) AS active_matches,
-           (SELECT count(*)::int FROM job_posting jp
-            WHERE jp.company_id = c.id
-              AND jp.first_seen_at >= now() - interval '1 year'
-              AND ${jobWhere}) AS year_matches
-    FROM company c
-    LEFT JOIN company_description cd ON cd.company_id = c.id AND cd.locale = ${params.locale}
-    WHERE ${companyWhere}
-    ORDER BY ${orderClause}
-    OFFSET ${params.offset}
-    LIMIT ${params.limit}
-  `);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        id: string;
+        name: string;
+        slug: string;
+        icon: string | null;
+        description: string | null;
+        active_matches: number;
+        year_matches: number;
+      }>(sql`
+        SELECT c.id, c.name, c.slug, c.icon,
+               COALESCE(cd.description, c.description) AS description,
+               (SELECT count(*)::int FROM job_posting jp
+                WHERE jp.company_id = c.id AND ${jobWhere}) AS active_matches,
+               (SELECT count(*)::int FROM job_posting jp
+                WHERE jp.company_id = c.id
+                  AND jp.first_seen_at >= now() - interval '1 year'
+                  AND ${jobWhere}) AS year_matches
+        FROM company c
+        LEFT JOIN company_description cd ON cd.company_id = c.id AND cd.locale = ${params.locale}
+        WHERE ${companyWhere}
+        ORDER BY ${orderClause}
+        OFFSET ${params.offset}
+        LIMIT ${params.limit}
+      `),
+    { label: "searchCompaniesForWatchlistPostgres.rows" },
+  );
 
   type Row = {
     id: string; name: string; slug: string; icon: string | null;
@@ -529,25 +541,29 @@ export async function suggestIndustries(params: {
   const q = params.query?.trim().toLowerCase();
   const hasQuery = q && q.length >= 1;
 
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    id: number;
-    name: string;
-  }>(sql`
-    SELECT i.id,
-           COALESCE(
-             (SELECT idn.name FROM industry_name idn
-              WHERE idn.industry_id = i.id AND idn.locale = ${params.locale} AND idn.is_display = true
-              LIMIT 1),
-             i.name
-           ) AS name
-    FROM industry i
-    ${hasQuery ? sql`WHERE lower(i.name) LIKE ${q + "%"} OR EXISTS (
-      SELECT 1 FROM industry_name idn
-      WHERE idn.industry_id = i.id AND lower(idn.name) LIKE ${q + "%"}
-    )` : sql``}
-    ORDER BY i.name
-  `);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        id: number;
+        name: string;
+      }>(sql`
+        SELECT i.id,
+               COALESCE(
+                 (SELECT idn.name FROM industry_name idn
+                  WHERE idn.industry_id = i.id AND idn.locale = ${params.locale} AND idn.is_display = true
+                  LIMIT 1),
+                 i.name
+               ) AS name
+        FROM industry i
+        ${hasQuery ? sql`WHERE lower(i.name) LIKE ${q + "%"} OR EXISTS (
+          SELECT 1 FROM industry_name idn
+          WHERE idn.industry_id = i.id AND lower(idn.name) LIKE ${q + "%"}
+        )` : sql``}
+        ORDER BY i.name
+      `),
+    { label: "suggestIndustries" },
+  );
 
   type Row = { id: number; name: string };
   return (rows as unknown as Row[]).map((r) => ({ id: r.id, name: r.name }));
@@ -1284,43 +1300,47 @@ async function _fetchTopLocations(
   companyId: string,
   locale: string,
 ): Promise<{ locations: CompanyLocation[]; totalCount: number }> {
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    location_id: number;
-    loc_slug: string;
-    loc_type: string;
-    loc_name: string;
-    cnt: number;
-    total_locations: number;
-  }>(sql`
-    WITH active_locs AS (
-      SELECT unnest(jp.location_ids) AS location_id
-      FROM job_posting jp
-      WHERE jp.company_id = ${companyId}
-        AND jp.is_active = true
-        AND jp.location_ids IS NOT NULL
-    ),
-    grouped AS (
-      SELECT
-        al.location_id,
-        l.slug AS loc_slug,
-        l.type::text AS loc_type,
-        ln.name AS loc_name,
-        COUNT(*)::int AS cnt
-      FROM active_locs al
-      JOIN location l ON l.id = al.location_id
-      JOIN LATERAL (
-        SELECT name FROM location_name
-        WHERE location_id = al.location_id AND locale IN (${locale}, 'en') AND is_display = true
-        ORDER BY (locale = ${locale})::int DESC LIMIT 1
-      ) ln ON true
-      GROUP BY al.location_id, l.slug, l.type, ln.name
-    )
-    SELECT *, COUNT(*) OVER ()::int AS total_locations
-    FROM grouped
-    ORDER BY cnt DESC
-    LIMIT 15
-  `);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        location_id: number;
+        loc_slug: string;
+        loc_type: string;
+        loc_name: string;
+        cnt: number;
+        total_locations: number;
+      }>(sql`
+        WITH active_locs AS (
+          SELECT unnest(jp.location_ids) AS location_id
+          FROM job_posting jp
+          WHERE jp.company_id = ${companyId}
+            AND jp.is_active = true
+            AND jp.location_ids IS NOT NULL
+        ),
+        grouped AS (
+          SELECT
+            al.location_id,
+            l.slug AS loc_slug,
+            l.type::text AS loc_type,
+            ln.name AS loc_name,
+            COUNT(*)::int AS cnt
+          FROM active_locs al
+          JOIN location l ON l.id = al.location_id
+          JOIN LATERAL (
+            SELECT name FROM location_name
+            WHERE location_id = al.location_id AND locale IN (${locale}, 'en') AND is_display = true
+            ORDER BY (locale = ${locale})::int DESC LIMIT 1
+          ) ln ON true
+          GROUP BY al.location_id, l.slug, l.type, ln.name
+        )
+        SELECT *, COUNT(*) OVER ()::int AS total_locations
+        FROM grouped
+        ORDER BY cnt DESC
+        LIMIT 15
+      `),
+    { label: `companyTopLocations[${companyId}]` },
+  );
 
   type Row = { location_id: number; loc_slug: string; loc_type: string; loc_name: string; cnt: number; total_locations: number };
   const all = rows as unknown as Row[];
@@ -1383,20 +1403,22 @@ async function _fetchLocationsGrouped(
   companyId: string,
   locale: string,
 ): Promise<GroupedCompanyLocations[]> {
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    location_id: number;
-    loc_slug: string;
-    loc_type: string;
-    loc_name: string;
-    cnt: number;
-    region_id: number | null;
-    region_slug: string | null;
-    region_name: string | null;
-    country_id: number | null;
-    country_slug: string | null;
-    country_name: string | null;
-  }>(sql`
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        location_id: number;
+        loc_slug: string;
+        loc_type: string;
+        loc_name: string;
+        cnt: number;
+        region_id: number | null;
+        region_slug: string | null;
+        region_name: string | null;
+        country_id: number | null;
+        country_slug: string | null;
+        country_name: string | null;
+      }>(sql`
     WITH active_locs AS (
       SELECT unnest(jp.location_ids) AS location_id
       FROM job_posting jp
@@ -1455,7 +1477,9 @@ async function _fetchLocationsGrouped(
       ORDER BY (locale = ${locale})::int DESC LIMIT 1
     ) cn ON true
     ORDER BY cn.name NULLS LAST, rn.name NULLS LAST, h.cnt DESC
-  `);
+  `),
+    { label: `companyLocationsGrouped[${companyId}]` },
+  );
 
   type Row = {
     location_id: number; loc_slug: string; loc_type: string; loc_name: string; cnt: number;
@@ -1475,16 +1499,20 @@ async function _fetchLocationsGrouped(
   const aliasMap = new Map<number, string[]>();
   if (allLocIds.size > 0) {
     const pgArray = `{${[...allLocIds].join(",")}}`;
-    const aliasRows = await db.execute<{
-      [key: string]: unknown;
-      location_id: number;
-      name: string;
-    }>(sql`
-      SELECT location_id, lower(name) AS name
-      FROM location_name
-      WHERE location_id = ANY(${pgArray}::integer[])
-        AND locale IN (${locale}, 'en')
-    `);
+    const aliasRows = await withDbRetry(
+      () =>
+        db.execute<{
+          [key: string]: unknown;
+          location_id: number;
+          name: string;
+        }>(sql`
+          SELECT location_id, lower(name) AS name
+          FROM location_name
+          WHERE location_id = ANY(${pgArray}::integer[])
+            AND locale IN (${locale}, 'en')
+        `),
+      { label: `companyLocationsGrouped.aliases[${companyId}]` },
+    );
     for (const a of aliasRows as unknown as { location_id: number; name: string }[]) {
       let arr = aliasMap.get(a.location_id);
       if (!arr) { arr = []; aliasMap.set(a.location_id, arr); }

--- a/apps/web/src/lib/actions/locations.ts
+++ b/apps/web/src/lib/actions/locations.ts
@@ -4,6 +4,7 @@ import { sql } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 import { db } from "@/db";
 import { cached } from "@/lib/cache";
+import { withDbRetry } from "@/lib/db-retry";
 import { typeaheadLocationsCacheTag } from "@/lib/cache-tags";
 import { getTypesenseClient, type TypesenseHit } from "@/lib/search/typesense-client";
 import { buildFilterString, POSTING_BASE_FILTER } from "@/lib/search/typesense-filters";
@@ -153,23 +154,27 @@ export async function expandLocationIds(locationId: number): Promise<number[]> {
   cacheLife("days");
   cacheTag(typeaheadLocationsCacheTag());
 
-  const rows = await db.execute<{ [key: string]: unknown; id: number }>(sql`
-    WITH RECURSIVE seeds AS (
-      -- The location itself
-      SELECT id FROM location WHERE id = ${locationId}
-      UNION
-      -- If it's a macro region, include its member countries
-      SELECT lm.country_id AS id
-      FROM location_macro_member lm
-      WHERE lm.macro_id = ${locationId}
-    ),
-    descendants AS (
-      SELECT id FROM seeds
-      UNION ALL
-      SELECT l.id FROM location l JOIN descendants d ON l.parent_id = d.id
-    )
-    SELECT id FROM descendants
-  `);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{ [key: string]: unknown; id: number }>(sql`
+        WITH RECURSIVE seeds AS (
+          -- The location itself
+          SELECT id FROM location WHERE id = ${locationId}
+          UNION
+          -- If it's a macro region, include its member countries
+          SELECT lm.country_id AS id
+          FROM location_macro_member lm
+          WHERE lm.macro_id = ${locationId}
+        ),
+        descendants AS (
+          SELECT id FROM seeds
+          UNION ALL
+          SELECT l.id FROM location l JOIN descendants d ON l.parent_id = d.id
+        )
+        SELECT id FROM descendants
+      `),
+    { label: `expandLocationIds[${locationId}]` },
+  );
   return (rows as unknown as { id: number }[]).map((r) => r.id);
 }
 
@@ -210,30 +215,34 @@ async function _resolveLocationSlugsCached(
   cacheTag(typeaheadLocationsCacheTag());
 
   const pgArray = `{${sortedSlugs.join(",")}}`;
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    id: number;
-    slug: string;
-    type: string;
-    name: string;
-    parent_name: string | null;
-  }>(sql`
-    SELECT l.id, l.slug, l.type::text AS type,
-      ln.name,
-      pln.name AS parent_name
-    FROM location l
-    JOIN LATERAL (
-      SELECT name FROM location_name
-      WHERE location_id = l.id AND locale IN (${locale}, 'en') AND is_display = true
-      ORDER BY (locale = ${locale})::int DESC LIMIT 1
-    ) ln ON true
-    LEFT JOIN LATERAL (
-      SELECT name FROM location_name
-      WHERE location_id = l.parent_id AND locale IN (${locale}, 'en') AND is_display = true
-      ORDER BY (locale = ${locale})::int DESC LIMIT 1
-    ) pln ON true
-    WHERE l.slug = ANY(${pgArray}::text[])
-  `);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        id: number;
+        slug: string;
+        type: string;
+        name: string;
+        parent_name: string | null;
+      }>(sql`
+        SELECT l.id, l.slug, l.type::text AS type,
+          ln.name,
+          pln.name AS parent_name
+        FROM location l
+        JOIN LATERAL (
+          SELECT name FROM location_name
+          WHERE location_id = l.id AND locale IN (${locale}, 'en') AND is_display = true
+          ORDER BY (locale = ${locale})::int DESC LIMIT 1
+        ) ln ON true
+        LEFT JOIN LATERAL (
+          SELECT name FROM location_name
+          WHERE location_id = l.parent_id AND locale IN (${locale}, 'en') AND is_display = true
+          ORDER BY (locale = ${locale})::int DESC LIMIT 1
+        ) pln ON true
+        WHERE l.slug = ANY(${pgArray}::text[])
+      `),
+    { label: "resolveLocationSlugs" },
+  );
   const result: Record<string, ResolvedLocation> = {};
   for (const r of rows as unknown as { id: number; slug: string; type: string; name: string; parent_name: string | null }[]) {
     result[r.slug] = {
@@ -292,20 +301,28 @@ async function _fetchLocationHierarchyData(): Promise<Record<string, LocationMet
   "use cache";
   cacheLife("days");
 
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    id: number;
-    slug: string;
-    type: string;
-    parent_id: number | null;
-  }>(sql`SELECT id, slug, type::text AS type, parent_id FROM location`);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        id: number;
+        slug: string;
+        type: string;
+        parent_id: number | null;
+      }>(sql`SELECT id, slug, type::text AS type, parent_id FROM location`),
+    { label: "locationHierarchy.locations" },
+  );
 
-  const nameRows = await db.execute<{
-    [key: string]: unknown;
-    location_id: number;
-    locale: string;
-    name: string;
-  }>(sql`SELECT location_id, locale, name FROM location_name WHERE is_display = true`);
+  const nameRows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        location_id: number;
+        locale: string;
+        name: string;
+      }>(sql`SELECT location_id, locale, name FROM location_name WHERE is_display = true`),
+    { label: "locationHierarchy.names" },
+  );
 
   const nameMap = new Map<number, Record<string, string>>();
   for (const nr of nameRows as unknown as { location_id: number; locale: string; name: string }[]) {

--- a/apps/web/src/lib/actions/my-jobs-stats.ts
+++ b/apps/web/src/lib/actions/my-jobs-stats.ts
@@ -2,6 +2,7 @@
 
 import { sql } from "drizzle-orm";
 import { db } from "@/db";
+import { withDbRetry } from "@/lib/db-retry";
 import { getSessionUserId } from "@/lib/sessionCache";
 
 export interface FunnelData {
@@ -60,36 +61,44 @@ export async function getStats(params?: {
 
   // Run funnel + activity queries in parallel (independent aggregations)
   const [rows, activityRows] = await Promise.all([
-    db.execute<{
-      [key: string]: unknown;
-      status: string;
-      interview_count: number;
-      max_round: number;
-    }>(sql`
-      SELECT
-        sj.status,
-        coalesce(ic.cnt, 0)::int AS interview_count,
-        coalesce(ic.max_round, 0)::int AS max_round
-      FROM saved_job sj
-      LEFT JOIN (
-        SELECT saved_job_id, count(*) AS cnt, max(round) AS max_round
-        FROM application_interview
-        GROUP BY saved_job_id
-      ) ic ON ic.saved_job_id = sj.id
-      WHERE sj.user_id = ${userId} ${dateFilter}
-    `),
-    db.execute<{
-      [key: string]: unknown;
-      day: string;
-      cnt: number;
-    }>(sql`
-      SELECT to_char(saved_at, 'YYYY-MM-DD') AS day, count(*)::int AS cnt
-      FROM saved_job
-      WHERE user_id = ${userId}
-        AND saved_at >= now() - interval '52 weeks'
-      GROUP BY day
-      ORDER BY day
-    `),
+    withDbRetry(
+      () =>
+        db.execute<{
+          [key: string]: unknown;
+          status: string;
+          interview_count: number;
+          max_round: number;
+        }>(sql`
+          SELECT
+            sj.status,
+            coalesce(ic.cnt, 0)::int AS interview_count,
+            coalesce(ic.max_round, 0)::int AS max_round
+          FROM saved_job sj
+          LEFT JOIN (
+            SELECT saved_job_id, count(*) AS cnt, max(round) AS max_round
+            FROM application_interview
+            GROUP BY saved_job_id
+          ) ic ON ic.saved_job_id = sj.id
+          WHERE sj.user_id = ${userId} ${dateFilter}
+        `),
+      { label: "myJobsStats.funnel" },
+    ),
+    withDbRetry(
+      () =>
+        db.execute<{
+          [key: string]: unknown;
+          day: string;
+          cnt: number;
+        }>(sql`
+          SELECT to_char(saved_at, 'YYYY-MM-DD') AS day, count(*)::int AS cnt
+          FROM saved_job
+          WHERE user_id = ${userId}
+            AND saved_at >= now() - interval '52 weeks'
+          GROUP BY day
+          ORDER BY day
+        `),
+      { label: "myJobsStats.activity" },
+    ),
   ]);
 
   type Row = { status: string; interview_count: number; max_round: number };

--- a/apps/web/src/lib/actions/search.ts
+++ b/apps/web/src/lib/actions/search.ts
@@ -6,6 +6,7 @@ import { db } from "@/db";
 import { getSearchProvider } from "@/lib/search";
 import type { SearchResponse, SearchResultPosting, HistogramFilters } from "@/lib/search";
 import { cached } from "@/lib/cache";
+import { withDbRetry } from "@/lib/db-retry";
 import { getSessionUserId } from "@/lib/sessionCache";
 import { ANON_MAX_COMPANIES, ANON_MAX_CARD_POSTINGS } from "@/lib/search/constants";
 
@@ -49,27 +50,31 @@ async function resolvePostingLocations(
 ): Promise<PostingDetail["locations"]> {
   if (!locationIds || locationIds.length === 0) return [];
   const pgArray = `{${locationIds.join(",")}}`;
-  const locRows = await db.execute<{
-    [key: string]: unknown;
-    location_id: number;
-    name: string;
-    type: string;
-    parent_name: string | null;
-  }>(sql`
-    SELECT DISTINCT ON (ln.location_id) ln.location_id, ln.name, l.type::text,
-      (SELECT pn.name FROM location_name pn
-       WHERE pn.location_id = l.parent_id
-         AND pn.locale IN (${locale}, 'en')
-         AND pn.is_display = true
-       ORDER BY (pn.locale = ${locale})::int DESC
-       LIMIT 1) AS parent_name
-    FROM location_name ln
-    JOIN location l ON l.id = ln.location_id
-    WHERE ln.location_id = ANY(${pgArray}::integer[])
-      AND ln.locale IN (${locale}, 'en')
-      AND ln.is_display = true
-    ORDER BY ln.location_id, (ln.locale = ${locale})::int DESC
-  `);
+  const locRows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        location_id: number;
+        name: string;
+        type: string;
+        parent_name: string | null;
+      }>(sql`
+        SELECT DISTINCT ON (ln.location_id) ln.location_id, ln.name, l.type::text,
+          (SELECT pn.name FROM location_name pn
+           WHERE pn.location_id = l.parent_id
+             AND pn.locale IN (${locale}, 'en')
+             AND pn.is_display = true
+           ORDER BY (pn.locale = ${locale})::int DESC
+           LIMIT 1) AS parent_name
+        FROM location_name ln
+        JOIN location l ON l.id = ln.location_id
+        WHERE ln.location_id = ANY(${pgArray}::integer[])
+          AND ln.locale IN (${locale}, 'en')
+          AND ln.is_display = true
+        ORDER BY ln.location_id, (ln.locale = ${locale})::int DESC
+      `),
+    { label: "postingLocations" },
+  );
   const nameMap = new Map<number, { name: string; geoType: string; parentName?: string }>();
   for (const r of locRows as unknown as { location_id: number; name: string; type: string; parent_name: string | null }[]) {
     nameMap.set(r.location_id, { name: r.name, geoType: r.type, parentName: r.parent_name ?? undefined });
@@ -93,8 +98,12 @@ async function resolvePostingTechnologies(
 ): Promise<{ id: number; name: string }[]> {
   if (!technologyIds || technologyIds.length === 0) return [];
   const techArray = `{${technologyIds.join(",")}}`;
-  const techRows = await db.execute<{ [key: string]: unknown; id: number; name: string | null }>(
-    sql`SELECT id, name FROM technology WHERE id = ANY(${techArray}::integer[]) ORDER BY name`,
+  const techRows = await withDbRetry(
+    () =>
+      db.execute<{ [key: string]: unknown; id: number; name: string | null }>(
+        sql`SELECT id, name FROM technology WHERE id = ANY(${techArray}::integer[]) ORDER BY name`,
+      ),
+    { label: "postingTechnologies" },
   );
   return (techRows as unknown as { id: number; name: string | null }[])
     .filter((t) => t.name)
@@ -113,41 +122,45 @@ async function _fetchPostingDetail(
 ): Promise<PostingDetail | null> {
   "use cache";
   cacheLife({ revalidate: 300 });
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    id: string;
-    title: string | null;
-    company_id: string;
-    company_name: string;
-    company_slug: string;
-    company_logo: string | null;
-    company_icon: string | null;
-    location_ids: number[] | null;
-    location_types: string[] | null;
-    employment_type: string | null;
-    source_url: string;
-    first_seen_at: Date;
-    locales: string[];
-  }>(sql`
-    SELECT jp.id, jp.titles[1] AS title,
-      c.id AS company_id, c.name AS company_name, c.slug AS company_slug,
-      c.logo AS company_logo, c.icon AS company_icon,
-      jp.location_ids, jp.location_types,
-      jp.employment_type, jp.source_url, jp.first_seen_at,
-      jp.locales,
-      jp.experience_min, jp.experience_max, jp.technology_ids,
-      jp.salary_min, jp.salary_max, jp.salary_currency, jp.salary_period,
-      jp.seniority_id, s.slug AS seniority_slug, sn.name AS seniority_name
-    FROM job_posting jp
-    JOIN company c ON c.id = jp.company_id
-    LEFT JOIN seniority s ON s.id = jp.seniority_id
-    LEFT JOIN LATERAL (
-      SELECT name FROM seniority_name
-      WHERE seniority_id = jp.seniority_id AND locale IN (${locale}, 'en') AND is_display = true
-      ORDER BY (locale = ${locale})::int DESC LIMIT 1
-    ) sn ON true
-    WHERE jp.id = ${postingId}
-  `);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        id: string;
+        title: string | null;
+        company_id: string;
+        company_name: string;
+        company_slug: string;
+        company_logo: string | null;
+        company_icon: string | null;
+        location_ids: number[] | null;
+        location_types: string[] | null;
+        employment_type: string | null;
+        source_url: string;
+        first_seen_at: Date;
+        locales: string[];
+      }>(sql`
+        SELECT jp.id, jp.titles[1] AS title,
+          c.id AS company_id, c.name AS company_name, c.slug AS company_slug,
+          c.logo AS company_logo, c.icon AS company_icon,
+          jp.location_ids, jp.location_types,
+          jp.employment_type, jp.source_url, jp.first_seen_at,
+          jp.locales,
+          jp.experience_min, jp.experience_max, jp.technology_ids,
+          jp.salary_min, jp.salary_max, jp.salary_currency, jp.salary_period,
+          jp.seniority_id, s.slug AS seniority_slug, sn.name AS seniority_name
+        FROM job_posting jp
+        JOIN company c ON c.id = jp.company_id
+        LEFT JOIN seniority s ON s.id = jp.seniority_id
+        LEFT JOIN LATERAL (
+          SELECT name FROM seniority_name
+          WHERE seniority_id = jp.seniority_id AND locale IN (${locale}, 'en') AND is_display = true
+          ORDER BY (locale = ${locale})::int DESC LIMIT 1
+        ) sn ON true
+        WHERE jp.id = ${postingId}
+      `),
+    { label: `postingDetail[${postingId}]` },
+  );
 
   type Row = {
     id: string; title: string | null;
@@ -346,8 +359,12 @@ export interface CurrencyRate {
 async function _fetchCurrencyRates(): Promise<CurrencyRate[]> {
   "use cache";
   cacheLife("hours");
-  const rows = await db.execute<{ [key: string]: unknown; currency: string; to_eur: string }>(
-    sql`SELECT currency, to_eur FROM currency_rate ORDER BY currency`,
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{ [key: string]: unknown; currency: string; to_eur: string }>(
+        sql`SELECT currency, to_eur FROM currency_rate ORDER BY currency`,
+      ),
+    { label: "currencyRates" },
   );
   return (rows as unknown as { currency: string; to_eur: string }[]).map((r) => ({
     currency: r.currency,

--- a/apps/web/src/lib/actions/taxonomy.ts
+++ b/apps/web/src/lib/actions/taxonomy.ts
@@ -4,6 +4,7 @@ import { sql } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 import { db } from "@/db";
 import { cached } from "@/lib/cache";
+import { withDbRetry } from "@/lib/db-retry";
 import {
   typeaheadOccupationsCacheTag,
   typeaheadSenioritiesCacheTag,
@@ -338,21 +339,25 @@ async function _resolveOccupationSlugsCached(
   cacheTag(typeaheadOccupationsCacheTag());
 
   const pgArray = `{${sortedSlugs.join(",")}}`;
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    id: number;
-    slug: string;
-    name: string;
-  }>(sql`
-    SELECT o.id, o.slug, dn.name
-    FROM occupation o
-    JOIN LATERAL (
-      SELECT name FROM occupation_name
-      WHERE occupation_id = o.id AND locale IN (${locale}, 'en') AND is_display = true
-      ORDER BY (locale = ${locale})::int DESC LIMIT 1
-    ) dn ON true
-    WHERE o.slug = ANY(${pgArray}::text[])
-  `);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        id: number;
+        slug: string;
+        name: string;
+      }>(sql`
+        SELECT o.id, o.slug, dn.name
+        FROM occupation o
+        JOIN LATERAL (
+          SELECT name FROM occupation_name
+          WHERE occupation_id = o.id AND locale IN (${locale}, 'en') AND is_display = true
+          ORDER BY (locale = ${locale})::int DESC LIMIT 1
+        ) dn ON true
+        WHERE o.slug = ANY(${pgArray}::text[])
+      `),
+    { label: "resolveOccupationSlugs" },
+  );
   const result: Record<string, TaxonomySuggestion> = {};
   for (const r of rows as unknown as { id: number; slug: string; name: string }[]) {
     result[r.slug] = { id: r.id, slug: r.slug, name: r.name };
@@ -379,21 +384,25 @@ async function _resolveSenioritySlugsCached(
   cacheTag(typeaheadSenioritiesCacheTag());
 
   const pgArray = `{${sortedSlugs.join(",")}}`;
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    id: number;
-    slug: string;
-    name: string;
-  }>(sql`
-    SELECT s.id, s.slug, dn.name
-    FROM seniority s
-    JOIN LATERAL (
-      SELECT name FROM seniority_name
-      WHERE seniority_id = s.id AND locale IN (${locale}, 'en') AND is_display = true
-      ORDER BY (locale = ${locale})::int DESC LIMIT 1
-    ) dn ON true
-    WHERE s.slug = ANY(${pgArray}::text[])
-  `);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        id: number;
+        slug: string;
+        name: string;
+      }>(sql`
+        SELECT s.id, s.slug, dn.name
+        FROM seniority s
+        JOIN LATERAL (
+          SELECT name FROM seniority_name
+          WHERE seniority_id = s.id AND locale IN (${locale}, 'en') AND is_display = true
+          ORDER BY (locale = ${locale})::int DESC LIMIT 1
+        ) dn ON true
+        WHERE s.slug = ANY(${pgArray}::text[])
+      `),
+    { label: "resolveSenioritySlugs" },
+  );
   const result: Record<string, TaxonomySuggestion> = {};
   for (const r of rows as unknown as { id: number; slug: string; name: string }[]) {
     result[r.slug] = { id: r.id, slug: r.slug, name: r.name };
@@ -415,14 +424,18 @@ export async function expandOccupationIds(occupationId: number): Promise<number[
   cacheLife("days");
   cacheTag(typeaheadOccupationsCacheTag());
 
-  const rows = await db.execute<{ [key: string]: unknown; id: number }>(sql`
-    WITH RECURSIVE descendants AS (
-      SELECT id FROM occupation WHERE id = ${occupationId}
-      UNION ALL
-      SELECT o.id FROM occupation o JOIN descendants d ON o.parent_id = d.id
-    )
-    SELECT id FROM descendants
-  `);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{ [key: string]: unknown; id: number }>(sql`
+        WITH RECURSIVE descendants AS (
+          SELECT id FROM occupation WHERE id = ${occupationId}
+          UNION ALL
+          SELECT o.id FROM occupation o JOIN descendants d ON o.parent_id = d.id
+        )
+        SELECT id FROM descendants
+      `),
+    { label: `expandOccupationIds[${occupationId}]` },
+  );
   return (rows as unknown as { id: number }[]).map((r) => r.id);
 }
 
@@ -443,13 +456,17 @@ async function _resolveTechnologySlugsCached(
   cacheTag(typeaheadTechnologiesCacheTag());
 
   const pgArray = `{${sortedSlugs.join(",")}}`;
-  const rows = await db.execute<{
-    [key: string]: unknown; id: number; slug: string; name: string;
-  }>(sql`
-    SELECT t.id, t.slug, COALESCE(t.name, t.slug) AS name
-    FROM technology t
-    WHERE t.slug = ANY(${pgArray}::text[])
-  `);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown; id: number; slug: string; name: string;
+      }>(sql`
+        SELECT t.id, t.slug, COALESCE(t.name, t.slug) AS name
+        FROM technology t
+        WHERE t.slug = ANY(${pgArray}::text[])
+      `),
+    { label: "resolveTechnologySlugs" },
+  );
   const result: Record<string, TaxonomySuggestion> = {};
   for (const r of rows as unknown as { id: number; slug: string; name: string }[]) {
     result[r.slug] = { id: r.id, slug: r.slug, name: r.name };
@@ -519,20 +536,28 @@ async function _fetchOccupationHierarchyData(): Promise<{
   cacheLife("days");
 
   // Fetch occupations
-  const occRows = await db.execute<{
-    [key: string]: unknown;
-    id: number;
-    slug: string;
-    parent_id: number | null;
-    domain_id: number | null;
-  }>(sql`SELECT id, slug, parent_id, domain_id FROM occupation`);
+  const occRows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        id: number;
+        slug: string;
+        parent_id: number | null;
+        domain_id: number | null;
+      }>(sql`SELECT id, slug, parent_id, domain_id FROM occupation`),
+    { label: "occupationHierarchy.occupations" },
+  );
 
-  const occNameRows = await db.execute<{
-    [key: string]: unknown;
-    occupation_id: number;
-    locale: string;
-    name: string;
-  }>(sql`SELECT occupation_id, locale, name FROM occupation_name WHERE is_display = true`);
+  const occNameRows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        occupation_id: number;
+        locale: string;
+        name: string;
+      }>(sql`SELECT occupation_id, locale, name FROM occupation_name WHERE is_display = true`),
+    { label: "occupationHierarchy.names" },
+  );
 
   const occNameMap = new Map<number, Record<string, string>>();
   for (const nr of occNameRows as unknown as { occupation_id: number; locale: string; name: string }[]) {
@@ -553,18 +578,26 @@ async function _fetchOccupationHierarchyData(): Promise<{
   }
 
   // Fetch domains
-  const domainRows = await db.execute<{
-    [key: string]: unknown;
-    id: number;
-    slug: string;
-  }>(sql`SELECT id, slug FROM occupation_domain`);
+  const domainRows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        id: number;
+        slug: string;
+      }>(sql`SELECT id, slug FROM occupation_domain`),
+    { label: "occupationHierarchy.domains" },
+  );
 
-  const domainNameRows = await db.execute<{
-    [key: string]: unknown;
-    domain_id: number;
-    locale: string;
-    name: string;
-  }>(sql`SELECT domain_id, locale, name FROM occupation_domain_name WHERE is_display = true`);
+  const domainNameRows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        domain_id: number;
+        locale: string;
+        name: string;
+      }>(sql`SELECT domain_id, locale, name FROM occupation_domain_name WHERE is_display = true`),
+    { label: "occupationHierarchy.domainNames" },
+  );
 
   const domainNameMap = new Map<number, Record<string, string>>();
   for (const nr of domainNameRows as unknown as { domain_id: number; locale: string; name: string }[]) {
@@ -807,18 +840,26 @@ async function _fetchSeniorityHierarchyData(): Promise<Record<string, SeniorityM
   "use cache";
   cacheLife("days");
 
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    id: number;
-    slug: string;
-  }>(sql`SELECT id, slug FROM seniority`);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        id: number;
+        slug: string;
+      }>(sql`SELECT id, slug FROM seniority`),
+    { label: "seniorityHierarchy.seniorities" },
+  );
 
-  const nameRows = await db.execute<{
-    [key: string]: unknown;
-    seniority_id: number;
-    locale: string;
-    name: string;
-  }>(sql`SELECT seniority_id, locale, name FROM seniority_name WHERE is_display = true`);
+  const nameRows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        seniority_id: number;
+        locale: string;
+        name: string;
+      }>(sql`SELECT seniority_id, locale, name FROM seniority_name WHERE is_display = true`),
+    { label: "seniorityHierarchy.names" },
+  );
 
   const nameMap = new Map<number, Record<string, string>>();
   for (const nr of nameRows as unknown as { seniority_id: number; locale: string; name: string }[]) {
@@ -937,13 +978,17 @@ async function _fetchTechnologyHierarchyData(): Promise<Record<string, Technolog
   // matching the typeahead slot's invalidation.
   cacheTag(typeaheadTechnologiesCacheTag());
 
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    id: number;
-    slug: string;
-    name: string | null;
-    category: string | null;
-  }>(sql`SELECT id, slug, name, category FROM technology`);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        id: number;
+        slug: string;
+        name: string | null;
+        category: string | null;
+      }>(sql`SELECT id, slug, name, category FROM technology`),
+    { label: "technologyHierarchy" },
+  );
 
   const result: Record<string, TechnologyMeta> = {};
   for (const r of rows as unknown as { id: number; slug: string; name: string | null; category: string | null }[]) {

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -12,6 +12,7 @@ import {
 import { getSessionUserId } from "@/lib/sessionCache";
 import { getViewerLanguages } from "@/lib/viewer";
 import { cached, invalidate } from "@/lib/cache";
+import { withDbRetry } from "@/lib/db-retry";
 import { watchlistCacheTag } from "@/lib/cache-tags";
 import { canCreateWatchlist, getUserPlan, PLAN_LIMITS } from "@/lib/plans";
 import { generateUniqueSlug } from "@/lib/watchlist-slug";
@@ -524,27 +525,31 @@ export async function getUserWatchlists(locale: string): Promise<WatchlistSummar
 
   const languages = await getViewerLanguages(locale);
 
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    id: string;
-    slug: string;
-    title: string;
-    is_public: boolean;
-    alerts_enabled: boolean;
-    filters: WatchlistFilters;
-    last_accessed_at: Date;
-    created_at: Date;
-    company_count: number;
-    company_ids: string[];
-  }>(sql`
-    SELECT w.id, w.slug, w.title, w.description, w.is_public, w.alerts_enabled, w.filters,
-           w.last_accessed_at, w.created_at,
-           (SELECT count(*)::int FROM watchlist_company wc WHERE wc.watchlist_id = w.id) AS company_count,
-           (SELECT coalesce(array_agg(wc.company_id), '{}') FROM watchlist_company wc WHERE wc.watchlist_id = w.id) AS company_ids
-    FROM watchlist w
-    WHERE w.user_id = ${userId}
-    ORDER BY w.last_accessed_at DESC
-  `);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        id: string;
+        slug: string;
+        title: string;
+        is_public: boolean;
+        alerts_enabled: boolean;
+        filters: WatchlistFilters;
+        last_accessed_at: Date;
+        created_at: Date;
+        company_count: number;
+        company_ids: string[];
+      }>(sql`
+        SELECT w.id, w.slug, w.title, w.description, w.is_public, w.alerts_enabled, w.filters,
+               w.last_accessed_at, w.created_at,
+               (SELECT count(*)::int FROM watchlist_company wc WHERE wc.watchlist_id = w.id) AS company_count,
+               (SELECT coalesce(array_agg(wc.company_id), '{}') FROM watchlist_company wc WHERE wc.watchlist_id = w.id) AS company_ids
+        FROM watchlist w
+        WHERE w.user_id = ${userId}
+        ORDER BY w.last_accessed_at DESC
+      `),
+    { label: "userWatchlists" },
+  );
 
   type Row = {
     id: string; slug: string; title: string; description: string | null; is_public: boolean;
@@ -595,19 +600,23 @@ export async function getWatchlistByUserAndSlug(
   // detail page resolves the same URLs the sitemap exposes.  Exact username
   // match is preferred via ORDER BY when both columns happen to collide
   // across users.
-  const rows = await db.execute<{ [key: string]: unknown } & WatchlistJoinRow>(sql`
-    SELECT
-      w.id AS wl_id, w.slug, w.title, w.description,
-      w.is_public, w.alerts_enabled, w.filters,
-      w.source_watchlist_id, w.created_at, w.user_id,
-      u.id AS owner_id, u.username, u.display_username, u.name AS owner_name
-    FROM watchlist w
-    JOIN "user" u ON u.id = w.user_id
-    WHERE (u.username = ${userSlug} OR u.display_username = ${userSlug})
-      AND w.slug = ${watchlistSlug}
-    ORDER BY (u.username = ${userSlug})::int DESC
-    LIMIT 1
-  `);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{ [key: string]: unknown } & WatchlistJoinRow>(sql`
+        SELECT
+          w.id AS wl_id, w.slug, w.title, w.description,
+          w.is_public, w.alerts_enabled, w.filters,
+          w.source_watchlist_id, w.created_at, w.user_id,
+          u.id AS owner_id, u.username, u.display_username, u.name AS owner_name
+        FROM watchlist w
+        JOIN "user" u ON u.id = w.user_id
+        WHERE (u.username = ${userSlug} OR u.display_username = ${userSlug})
+          AND w.slug = ${watchlistSlug}
+        ORDER BY (u.username = ${userSlug})::int DESC
+        LIMIT 1
+      `),
+    { label: `watchlistByUserAndSlug[${userSlug}/${watchlistSlug}]` },
+  );
 
   const row = (rows as unknown as WatchlistJoinRow[])[0];
   if (!row) return null;
@@ -695,20 +704,24 @@ async function _fetchPublicWatchlistByUserAndSlug(
     display_username: string | null; owner_name: string;
   };
 
-  const rows = await db.execute<{ [key: string]: unknown } & WatchlistJoinRow>(sql`
-    SELECT
-      w.id AS wl_id, w.slug, w.title, w.description,
-      w.is_public, w.alerts_enabled, w.filters,
-      w.source_watchlist_id, w.created_at, w.user_id,
-      u.id AS owner_id, u.username, u.display_username, u.name AS owner_name
-    FROM watchlist w
-    JOIN "user" u ON u.id = w.user_id
-    WHERE (u.username = ${userSlug} OR u.display_username = ${userSlug})
-      AND w.slug = ${watchlistSlug}
-      AND w.is_public = true
-    ORDER BY (u.username = ${userSlug})::int DESC
-    LIMIT 1
-  `);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{ [key: string]: unknown } & WatchlistJoinRow>(sql`
+        SELECT
+          w.id AS wl_id, w.slug, w.title, w.description,
+          w.is_public, w.alerts_enabled, w.filters,
+          w.source_watchlist_id, w.created_at, w.user_id,
+          u.id AS owner_id, u.username, u.display_username, u.name AS owner_name
+        FROM watchlist w
+        JOIN "user" u ON u.id = w.user_id
+        WHERE (u.username = ${userSlug} OR u.display_username = ${userSlug})
+          AND w.slug = ${watchlistSlug}
+          AND w.is_public = true
+        ORDER BY (u.username = ${userSlug})::int DESC
+        LIMIT 1
+      `),
+    { label: `publicWatchlistByUserAndSlug[${userSlug}/${watchlistSlug}]` },
+  );
 
   const row = (rows as unknown as WatchlistJoinRow[])[0];
   if (!row) return null;
@@ -898,34 +911,42 @@ async function queryPublicWatchlists(params: {
   limit: number;
   languages?: string[];
 }): Promise<{ watchlists: PublicWatchlistEntry[]; total: number }> {
-  const [totalRow] = await db.execute<{ [key: string]: unknown; cnt: number }>(sql`
-    SELECT count(*)::int AS cnt FROM watchlist w WHERE ${params.whereClause}
-  `);
+  const [totalRow] = await withDbRetry(
+    () =>
+      db.execute<{ [key: string]: unknown; cnt: number }>(sql`
+        SELECT count(*)::int AS cnt FROM watchlist w WHERE ${params.whereClause}
+      `),
+    { label: "queryPublicWatchlists.count" },
+  );
   const total = (totalRow as unknown as { cnt: number })?.cnt ?? 0;
   if (total === 0) return { watchlists: [], total: 0 };
 
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    id: string; slug: string; title: string; is_public: boolean;
-    alerts_enabled: boolean; filters: WatchlistFilters;
-    last_accessed_at: Date; created_at: Date;
-    owner_name: string; owner_username: string | null;
-    company_count: number; company_ids: string[];
-    mirror_count: number;
-  }>(sql`
-    SELECT w.id, w.slug, w.title, w.description, w.is_public, w.alerts_enabled, w.filters,
-           w.last_accessed_at, w.created_at,
-           u.name AS owner_name, u.username AS owner_username,
-           (SELECT count(*)::int FROM watchlist_company wc WHERE wc.watchlist_id = w.id) AS company_count,
-           (SELECT coalesce(array_agg(wc.company_id), '{}') FROM watchlist_company wc WHERE wc.watchlist_id = w.id) AS company_ids,
-           (SELECT count(*)::int FROM watchlist w2 WHERE w2.source_watchlist_id = w.id) AS mirror_count
-    FROM watchlist w
-    JOIN "user" u ON u.id = w.user_id
-    WHERE ${params.whereClause}
-    ORDER BY ${params.orderClause}
-    OFFSET ${params.offset}
-    LIMIT ${params.limit}
-  `);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        id: string; slug: string; title: string; is_public: boolean;
+        alerts_enabled: boolean; filters: WatchlistFilters;
+        last_accessed_at: Date; created_at: Date;
+        owner_name: string; owner_username: string | null;
+        company_count: number; company_ids: string[];
+        mirror_count: number;
+      }>(sql`
+        SELECT w.id, w.slug, w.title, w.description, w.is_public, w.alerts_enabled, w.filters,
+               w.last_accessed_at, w.created_at,
+               u.name AS owner_name, u.username AS owner_username,
+               (SELECT count(*)::int FROM watchlist_company wc WHERE wc.watchlist_id = w.id) AS company_count,
+               (SELECT coalesce(array_agg(wc.company_id), '{}') FROM watchlist_company wc WHERE wc.watchlist_id = w.id) AS company_ids,
+               (SELECT count(*)::int FROM watchlist w2 WHERE w2.source_watchlist_id = w.id) AS mirror_count
+        FROM watchlist w
+        JOIN "user" u ON u.id = w.user_id
+        WHERE ${params.whereClause}
+        ORDER BY ${params.orderClause}
+        OFFSET ${params.offset}
+        LIMIT ${params.limit}
+      `),
+    { label: "queryPublicWatchlists.rows" },
+  );
 
   type Row = {
     id: string; slug: string; title: string; description: string | null; is_public: boolean;
@@ -1419,17 +1440,21 @@ async function _enrichWatchlistsWithRealCounts(
   if (ids.length === 0) return watchlists;
 
   const pgArr = `{${ids.join(",")}}`;
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    id: string;
-    filters: WatchlistFilters | null;
-    company_ids: string[];
-  }>(sql`
-    SELECT w.id, w.filters,
-           (SELECT coalesce(array_agg(wc.company_id), '{}') FROM watchlist_company wc WHERE wc.watchlist_id = w.id) AS company_ids
-    FROM watchlist w
-    WHERE w.id = ANY(${pgArr}::uuid[])
-  `);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        id: string;
+        filters: WatchlistFilters | null;
+        company_ids: string[];
+      }>(sql`
+        SELECT w.id, w.filters,
+               (SELECT coalesce(array_agg(wc.company_id), '{}') FROM watchlist_company wc WHERE wc.watchlist_id = w.id) AS company_ids
+        FROM watchlist w
+        WHERE w.id = ANY(${pgArr}::uuid[])
+      `),
+    { label: "enrichWatchlistsWithRealCounts" },
+  );
 
   type Row = { id: string; filters: WatchlistFilters | null; company_ids: string[] };
   const rowMap = new Map<string, Row>();
@@ -1747,33 +1772,41 @@ async function _getWatchlistPostingsPostgres(
 
   const whereClause = sql.join(clauses, sql` AND `);
 
-  const [totalRow] = await db.execute<{ [key: string]: unknown; cnt: number }>(
-    sql`SELECT count(*)::int AS cnt FROM job_posting jp WHERE ${whereClause}`,
+  const [totalRow] = await withDbRetry(
+    () =>
+      db.execute<{ [key: string]: unknown; cnt: number }>(
+        sql`SELECT count(*)::int AS cnt FROM job_posting jp WHERE ${whereClause}`,
+      ),
+    { label: "getWatchlistPostingsPostgres.count" },
   );
   const total = (totalRow as unknown as { cnt: number })?.cnt ?? 0;
   if (total === 0 || params.limit === 0) return { postings: [], total };
 
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    id: string;
-    title: string | null;
-    source_url: string;
-    first_seen_at: Date;
-    is_active: boolean;
-    company_id: string;
-    company_name: string;
-    company_slug: string;
-    company_icon: string | null;
-  }>(sql`
-    SELECT jp.id, jp.titles[1] AS title, jp.source_url, jp.first_seen_at, jp.is_active,
-           c.id AS company_id, c.name AS company_name, c.slug AS company_slug, c.icon AS company_icon
-    FROM job_posting jp
-    JOIN company c ON c.id = jp.company_id
-    WHERE ${whereClause}
-    ORDER BY jp.first_seen_at DESC
-    OFFSET ${params.offset}
-    LIMIT ${params.limit}
-  `);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        id: string;
+        title: string | null;
+        source_url: string;
+        first_seen_at: Date;
+        is_active: boolean;
+        company_id: string;
+        company_name: string;
+        company_slug: string;
+        company_icon: string | null;
+      }>(sql`
+        SELECT jp.id, jp.titles[1] AS title, jp.source_url, jp.first_seen_at, jp.is_active,
+               c.id AS company_id, c.name AS company_name, c.slug AS company_slug, c.icon AS company_icon
+        FROM job_posting jp
+        JOIN company c ON c.id = jp.company_id
+        WHERE ${whereClause}
+        ORDER BY jp.first_seen_at DESC
+        OFFSET ${params.offset}
+        LIMIT ${params.limit}
+      `),
+    { label: "getWatchlistPostingsPostgres.rows" },
+  );
 
   type Row = {
     id: string; title: string | null; source_url: string; first_seen_at: Date;
@@ -1846,12 +1879,16 @@ async function _invalidateWatchlistCaches(
 async function _getOwnerInfo(
   userId: string,
 ): Promise<{ name: string; username: string | null; displayUsername: string | null } | null> {
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    name: string;
-    username: string | null;
-    display_username: string | null;
-  }>(sql`SELECT name, username, display_username FROM "user" WHERE id = ${userId} LIMIT 1`);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        name: string;
+        username: string | null;
+        display_username: string | null;
+      }>(sql`SELECT name, username, display_username FROM "user" WHERE id = ${userId} LIMIT 1`),
+    { label: `ownerInfo[${userId}]` },
+  );
   const row = (rows as unknown as { name: string; username: string | null; display_username: string | null }[])[0];
   if (!row) return null;
   return { name: row.name, username: row.username, displayUsername: row.display_username };
@@ -1859,16 +1896,24 @@ async function _getOwnerInfo(
 
 /** Count companies in a watchlist. */
 async function _countWatchlistCompanies(watchlistId: string): Promise<number> {
-  const [row] = await db.execute<{ [key: string]: unknown; cnt: number }>(
-    sql`SELECT count(*)::int AS cnt FROM watchlist_company WHERE watchlist_id = ${watchlistId}`,
+  const [row] = await withDbRetry(
+    () =>
+      db.execute<{ [key: string]: unknown; cnt: number }>(
+        sql`SELECT count(*)::int AS cnt FROM watchlist_company WHERE watchlist_id = ${watchlistId}`,
+      ),
+    { label: `countWatchlistCompanies[${watchlistId}]` },
   );
   return (row as unknown as { cnt: number })?.cnt ?? 0;
 }
 
 /** Get the mirror count for a watchlist (number of copies). */
 async function _getWatchlistMirrorCount(watchlistId: string): Promise<number> {
-  const [row] = await db.execute<{ [key: string]: unknown; cnt: number }>(
-    sql`SELECT count(*)::int AS cnt FROM watchlist WHERE source_watchlist_id = ${watchlistId}`,
+  const [row] = await withDbRetry(
+    () =>
+      db.execute<{ [key: string]: unknown; cnt: number }>(
+        sql`SELECT count(*)::int AS cnt FROM watchlist WHERE source_watchlist_id = ${watchlistId}`,
+      ),
+    { label: `watchlistMirrorCount[${watchlistId}]` },
   );
   return (row as unknown as { cnt: number })?.cnt ?? 0;
 }

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -5,6 +5,7 @@ import { username } from "better-auth/plugins";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { nextCookies } from "better-auth/next-js";
 import { db } from "@/db";
+import { withDbRetry } from "@/lib/db-retry";
 import { sendVerificationEmail, sendResetPasswordEmail } from "@/lib/email";
 import { type Locale, defaultLocale, isLocale } from "@/lib/i18n";
 import { invalidateSessionCache } from "@/lib/sessionCache";
@@ -139,8 +140,12 @@ export const auth = betterAuth({
               candidate = withRandomSuffix(base);
               continue;
             }
-            const rows = await db.execute(
-              sql`SELECT 1 FROM "user" WHERE username = ${candidate} LIMIT 1`,
+            const rows = await withDbRetry(
+              () =>
+                db.execute(
+                  sql`SELECT 1 FROM "user" WHERE username = ${candidate} LIMIT 1`,
+                ),
+              { label: "auth.usernameAvailability" },
             );
             if (!rows.length) break;
             candidate = withRandomSuffix(base);

--- a/apps/web/src/lib/sitemap.ts
+++ b/apps/web/src/lib/sitemap.ts
@@ -2,6 +2,7 @@ import type { MetadataRoute } from "next";
 import { sql } from "drizzle-orm";
 import { db } from "@/db";
 import { cached } from "@/lib/cache";
+import { withDbRetry } from "@/lib/db-retry";
 import { siteConfig } from "@/content/config";
 import { locales } from "@/lib/i18n";
 import { listBlogPosts, getBlogPostLocales, type BlogPostSummary } from "@/lib/blog";
@@ -44,31 +45,35 @@ async function fetchSitemapWatchlists(): Promise<SitemapWatchlistRow[]> {
   //   - tracks ≥3 companies OR carries ≥1 keyword OR ≥2 taxonomy filters.
   //     Salary/experience-only watchlists don't qualify on their own —
   //     too thin to be a useful landing page.
-  return db.execute<SitemapWatchlistRow>(sql`
-    SELECT
-      COALESCE(u.display_username, u.username) AS user_slug,
-      w.slug AS watchlist_slug,
-      w.updated_at,
-      (u.username = ${CURATED_USERNAME}) AS is_curated
-    FROM watchlist w
-    JOIN "user" u ON u.id = w.user_id
-    LEFT JOIN watchlist_company wc ON wc.watchlist_id = w.id
-    WHERE w.is_public = true
-      AND u.username IS NOT NULL
-      AND w.title IS NOT NULL
-      AND LENGTH(TRIM(w.title)) >= 4
-      AND LOWER(TRIM(w.title)) <> 'new watchlist'
-      AND w.created_at < NOW() - INTERVAL '7 days'
-    GROUP BY w.id, u.username, u.display_username
-    HAVING
-      COUNT(wc.company_id) >= 3
-      OR COALESCE(jsonb_array_length(w.filters->'keywords'), 0) > 0
-      OR COALESCE(jsonb_array_length(w.filters->'locationSlugs'), 0)
-         + COALESCE(jsonb_array_length(w.filters->'occupationSlugs'), 0)
-         + COALESCE(jsonb_array_length(w.filters->'senioritySlugs'), 0)
-         + COALESCE(jsonb_array_length(w.filters->'technologySlugs'), 0) >= 2
-    ORDER BY is_curated DESC, w.updated_at DESC
-  `) as unknown as Promise<SitemapWatchlistRow[]>;
+  return withDbRetry(
+    () =>
+      db.execute<SitemapWatchlistRow>(sql`
+        SELECT
+          COALESCE(u.display_username, u.username) AS user_slug,
+          w.slug AS watchlist_slug,
+          w.updated_at,
+          (u.username = ${CURATED_USERNAME}) AS is_curated
+        FROM watchlist w
+        JOIN "user" u ON u.id = w.user_id
+        LEFT JOIN watchlist_company wc ON wc.watchlist_id = w.id
+        WHERE w.is_public = true
+          AND u.username IS NOT NULL
+          AND w.title IS NOT NULL
+          AND LENGTH(TRIM(w.title)) >= 4
+          AND LOWER(TRIM(w.title)) <> 'new watchlist'
+          AND w.created_at < NOW() - INTERVAL '7 days'
+        GROUP BY w.id, u.username, u.display_username
+        HAVING
+          COUNT(wc.company_id) >= 3
+          OR COALESCE(jsonb_array_length(w.filters->'keywords'), 0) > 0
+          OR COALESCE(jsonb_array_length(w.filters->'locationSlugs'), 0)
+             + COALESCE(jsonb_array_length(w.filters->'occupationSlugs'), 0)
+             + COALESCE(jsonb_array_length(w.filters->'senioritySlugs'), 0)
+             + COALESCE(jsonb_array_length(w.filters->'technologySlugs'), 0) >= 2
+        ORDER BY is_curated DESC, w.updated_at DESC
+      `),
+    { label: "sitemap.watchlists" },
+  ) as unknown as Promise<SitemapWatchlistRow[]>;
 }
 
 export const cachedSitemapWatchlists = () =>


### PR DESCRIPTION
## Summary
- Closes #2930 — extends the #2929 `withDbRetry` helper from one call site to **every read-path `db.execute`** in `apps/web/src/lib/` that runs during build prerender or hot runtime traffic, so a single transient Supabase ECONNRESET no longer fails the whole build (which is exactly how the build at 2026-05-09T15:41:49Z died).
- 9 source files modified, 1 new test file. Mutation paths (INSERT/UPDATE/DELETE) intentionally left bare — retry-on-failure for writes can double-write.
- New integration test `db-retry-coverage.test.ts` adds 5 assertions on representative wrapped sites (public watchlist, sitemap watchlists, currency rates, company top locations, non-retryable propagation). The retry helper itself keeps its 18-test unit suite from #2929 untouched.

## Wrapped sites (read-only, build- or runtime-critical)
| File | Functions |
|---|---|
| `sitemap.ts` | `fetchSitemapWatchlists` |
| `actions/watchlists.ts` | `getUserWatchlists`, `getWatchlistByUserAndSlug`, `_fetchPublicWatchlistByUserAndSlug`, `queryPublicWatchlists`, `_enrichWatchlistsWithRealCounts`, `_getWatchlistPostingsPostgres`, `_getOwnerInfo`, `_countWatchlistCompanies`, `_getWatchlistMirrorCount` |
| `actions/company.ts` | `_queryCompanySuggestionsCached`, `_searchCompaniesForWatchlistPostgres`, `suggestIndustries`, `_fetchTopLocations`, `_fetchLocationsGrouped` (+ alias rows) |
| `actions/locations.ts` | `expandLocationIds`, `_resolveLocationSlugsCached`, `_fetchLocationHierarchyData` |
| `actions/taxonomy.ts` | `_resolveOccupationSlugsCached`, `_resolveSenioritySlugsCached`, `_resolveTechnologySlugsCached`, `expandOccupationIds`, `_fetchOccupationHierarchyData`, `_fetchSeniorityHierarchyData`, `_fetchTechnologyHierarchyData` |
| `actions/search.ts` | `resolvePostingLocations`, `resolvePostingTechnologies`, `_fetchPostingDetail`, `_fetchCurrencyRates` |
| `actions/bootstrap.ts` | `_fetchBootstrapForUser` |
| `actions/my-jobs-stats.ts` | `getStats` (funnel + activity) |
| `auth.ts` | username availability check (Better Auth `user.create.before` hook — read query inside the create flow) |

## Skipped sites (and why)
- `admin/meta-apify-import.ts` — admin one-shot import; not on a user-facing path.
- Every drizzle `db.update(...)`, `db.insert(...)`, `db.delete(...)` mutation — retry on a write can double-write.

## Build-critical motivation
- Blog post pages (`/[lang]/blog/[slug]`) prerender via `getCompanyBySlug` + `getPublicWatchlistByUserAndSlug` from MDX `MdxMentions`.
- `/[lang]/[userSlug]/[watchlistSlug]/{page,opengraph-image}.tsx` all funnel through `_fetchPublicWatchlistByUserAndSlug`.
- `/sitemap.xml` runs `fetchSitemapWatchlists` on every revalidation.
- One transient ECONNRESET in any of these tanks the build the same way it tanked the company OG render at 2026-05-09T15:41:49Z (#2918).

## Test plan
- [x] `pnpm test` from `apps/web/` — 530 tests pass, 1 pre-existing failure unrelated to this PR (`app/mcp/route.test.ts` — missing `@jseek/mcp-server/handler` module; same error appears on `tsc` and is independent of any file in this diff).
- [x] `pnpm exec tsc --noEmit` — clean except for the same pre-existing `app/mcp/route.ts` import error.
- [ ] Vercel preview build — should green even when Supabase has a transient blip during the 17,600-OG prerender pass (the original failure mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)