### PR TITLE
fix(web): hide "in the last year" stats tail when equal to active (closes #2950)

### DIFF
--- a/apps/web/src/components/search/company-card.tsx
+++ b/apps/web/src/components/search/company-card.tsx
@@ -113,10 +113,21 @@ export function CompanyCard({ result, keywords, locationIds, locations, occupati
       </div>
 
       {/* Stats */}
+      {/*
+        Hide the "in the last year" tail when it equals the active count.
+        The crawler dataset is younger than 365d (#2950), so the year filter
+        is currently a no-op vs active and shows confusingly identical numbers.
+        Self-healing: once postings start aging out (year-count < active-count),
+        the tail re-appears organically.
+      */}
       <p className="mt-2 text-xs text-muted">
         {activeMatches} <Trans id="search.card.active" comment="Active matches label on company card">active</Trans>
-        {" · "}
-        {yearMatches} <Trans id="search.card.yearCount" comment="Yearly matches label on company card">in the last year</Trans>
+        {yearMatches !== activeMatches && (
+          <>
+            {" · "}
+            {yearMatches} <Trans id="search.card.yearCount" comment="Yearly matches label on company card">in the last year</Trans>
+          </>
+        )}
       </p>
 
       {/* Divider */}

--- a/apps/web/src/components/search/language-stats-row.tsx
+++ b/apps/web/src/components/search/language-stats-row.tsx
@@ -23,10 +23,17 @@ type Props = {
  *
  * Numbers are locale-formatted (`toLocaleString`) so the thousands
  * separator follows the page locale.
+ *
+ * `yearCount === activeCount`: the crawler dataset is younger than 365d
+ * (#2950), so the year filter degenerates to "all active". Hiding the
+ * "in the last year" segment when it equals active avoids the confusing
+ * "5 active · 5 in the last year" display. Self-healing: once postings
+ * begin aging out, the segment re-appears organically.
  */
 export function LanguageStatsRow({ jobLanguages, locale, activeCount, yearCount }: Props) {
   const active = activeCount.toLocaleString(locale);
   const year = yearCount.toLocaleString(locale);
+  const showYear = yearCount !== activeCount;
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between gap-4">
@@ -34,11 +41,15 @@ export function LanguageStatsRow({ jobLanguages, locale, activeCount, yearCount 
         <p className="hidden whitespace-nowrap text-xs text-muted md:block">
           {active}{" "}
           <Trans id="common.stats.active" comment="Active postings count">active</Trans>
-          {" · "}
-          {year}{" "}
-          <Trans id="common.stats.yearCount" comment="Postings seen in the last year count">
-            in the last year
-          </Trans>
+          {showYear && (
+            <>
+              {" · "}
+              {year}{" "}
+              <Trans id="common.stats.yearCount" comment="Postings seen in the last year count">
+                in the last year
+              </Trans>
+            </>
+          )}
         </p>
       </div>
       <div className="flex items-center justify-between text-xs text-muted md:hidden">
@@ -46,12 +57,14 @@ export function LanguageStatsRow({ jobLanguages, locale, activeCount, yearCount 
           {active}{" "}
           <Trans id="common.stats.active" comment="Active postings count">active</Trans>
         </span>
-        <span>
-          {year}{" "}
-          <Trans id="common.stats.yearCount" comment="Postings seen in the last year count">
-            in the last year
-          </Trans>
-        </span>
+        {showYear && (
+          <span>
+            {year}{" "}
+            <Trans id="common.stats.yearCount" comment="Postings seen in the last year count">
+              in the last year
+            </Trans>
+          </span>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/watchlist/company-search-modal.tsx
+++ b/apps/web/src/components/watchlist/company-search-modal.tsx
@@ -316,8 +316,16 @@ export function CompanySearchModal({
                           <span className={`text-sm font-medium ${isSelected ? "text-primary" : ""}`}>
                             {c.name}
                           </span>
+                          {/*
+                            Hide the "in the last year" tail when it equals active.
+                            Crawler dataset is <365d so year-filter == active right
+                            now (#2950); self-healing once postings start aging out.
+                          */}
                           <span className="text-xs text-muted">
-                            {c.activeMatches} active · {c.yearMatches} in the last year
+                            {c.activeMatches} active
+                            {c.yearMatches !== c.activeMatches && (
+                              <> · {c.yearMatches} in the last year</>
+                            )}
                           </span>
                         </div>
                         {c.description && (


### PR DESCRIPTION
## Summary

User report: \"When I search anything, I get the same number of active postings and postings in the last year.\"

Production Typesense (read 2026-05-09) confirms the badges were accurate, but the year filter is currently a mathematical no-op:

| Filter | Found |
|---|---|
| `is_active:=true && has_content:!=false` | 709,143 |
| `is_active:=true && has_content:!=false && first_seen_at:>1746814886` | 709,143 |
| total docs | 1,493,099 |
| docs with `first_seen_at < year_ago` | 0 |

Oldest `first_seen_at` in the index = 1773085007 (2026-03-09T22:36Z). Today is 2026-05-09 — the dataset is ~2 months old. Every doc satisfies `first_seen_at:>oneYearAgo`, so `yearCount === activeCount` everywhere.

This is not a regression from #2945. PR #2945's filter additions are correct. The discrepancy is a dataset-age artifact: the badge becomes meaningful once a meaningful chunk of postings ages past 365d (~2027-03 at earliest).

## Fix

Hide the \"· N in the last year\" segment when `yearCount === activeCount`. Self-healing: when the dataset matures past 365d AND inactive postings start aging out, the segment re-appears organically without further code changes.

Three surfaces:
- `apps/web/src/components/search/company-card.tsx` — search-result tile (the user's reported surface)
- `apps/web/src/components/search/language-stats-row.tsx` — watchlist + company-detail stats row
- `apps/web/src/components/watchlist/company-search-modal.tsx` — watchlist company picker

No backend / query changes.

## Test plan

- [x] `pnpm exec vitest run` — 548 tests pass; only pre-existing `app/mcp/route.ts` failure unrelated to this change
- [x] `pnpm exec tsc --noEmit` — only pre-existing `@jseek/mcp-server/handler` build-artifact error
- [x] `typesense-filters.test.ts` (PR #2945's filter pin) still passes
- [ ] Visual smoke on Vercel preview: `/explore` should now show only \"N active\" on result tiles
- [ ] Watchlist view: `Showing jobs in {locales} · N active` (no year tail)
- [ ] Watchlist company picker modal: `{name}  N active` (no year tail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)