### PR TITLE
fix(web): year-count queries should not require is_active (Closes #2965, Refs #2950)

### DIFF
--- a/apps/web/src/components/search/company-card.tsx
+++ b/apps/web/src/components/search/company-card.tsx
@@ -113,21 +113,10 @@ export function CompanyCard({ result, keywords, locationIds, locations, occupati
       </div>
 
       {/* Stats */}
-      {/*
-        Hide the "in the last year" tail when it equals the active count.
-        The crawler dataset is younger than 365d (#2950), so the year filter
-        is currently a no-op vs active and shows confusingly identical numbers.
-        Self-healing: once postings start aging out (year-count < active-count),
-        the tail re-appears organically.
-      */}
       <p className="mt-2 text-xs text-muted">
         {activeMatches} <Trans id="search.card.active" comment="Active matches label on company card">active</Trans>
-        {yearMatches !== activeMatches && (
-          <>
-            {" · "}
-            {yearMatches} <Trans id="search.card.yearCount" comment="Yearly matches label on company card">in the last year</Trans>
-          </>
-        )}
+        {" · "}
+        {yearMatches} <Trans id="search.card.yearCount" comment="Yearly matches label on company card">in the last year</Trans>
       </p>
 
       {/* Divider */}

--- a/apps/web/src/components/search/language-stats-row.tsx
+++ b/apps/web/src/components/search/language-stats-row.tsx
@@ -23,17 +23,10 @@ type Props = {
  *
  * Numbers are locale-formatted (`toLocaleString`) so the thousands
  * separator follows the page locale.
- *
- * `yearCount === activeCount`: the crawler dataset is younger than 365d
- * (#2950), so the year filter degenerates to "all active". Hiding the
- * "in the last year" segment when it equals active avoids the confusing
- * "5 active · 5 in the last year" display. Self-healing: once postings
- * begin aging out, the segment re-appears organically.
  */
 export function LanguageStatsRow({ jobLanguages, locale, activeCount, yearCount }: Props) {
   const active = activeCount.toLocaleString(locale);
   const year = yearCount.toLocaleString(locale);
-  const showYear = yearCount !== activeCount;
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between gap-4">
@@ -41,15 +34,11 @@ export function LanguageStatsRow({ jobLanguages, locale, activeCount, yearCount 
         <p className="hidden whitespace-nowrap text-xs text-muted md:block">
           {active}{" "}
           <Trans id="common.stats.active" comment="Active postings count">active</Trans>
-          {showYear && (
-            <>
-              {" · "}
-              {year}{" "}
-              <Trans id="common.stats.yearCount" comment="Postings seen in the last year count">
-                in the last year
-              </Trans>
-            </>
-          )}
+          {" · "}
+          {year}{" "}
+          <Trans id="common.stats.yearCount" comment="Postings seen in the last year count">
+            in the last year
+          </Trans>
         </p>
       </div>
       <div className="flex items-center justify-between text-xs text-muted md:hidden">
@@ -57,14 +46,12 @@ export function LanguageStatsRow({ jobLanguages, locale, activeCount, yearCount 
           {active}{" "}
           <Trans id="common.stats.active" comment="Active postings count">active</Trans>
         </span>
-        {showYear && (
-          <span>
-            {year}{" "}
-            <Trans id="common.stats.yearCount" comment="Postings seen in the last year count">
-              in the last year
-            </Trans>
-          </span>
-        )}
+        <span>
+          {year}{" "}
+          <Trans id="common.stats.yearCount" comment="Postings seen in the last year count">
+            in the last year
+          </Trans>
+        </span>
       </div>
     </div>
   );

--- a/apps/web/src/components/watchlist/company-search-modal.tsx
+++ b/apps/web/src/components/watchlist/company-search-modal.tsx
@@ -316,16 +316,8 @@ export function CompanySearchModal({
                           <span className={`text-sm font-medium ${isSelected ? "text-primary" : ""}`}>
                             {c.name}
                           </span>
-                          {/*
-                            Hide the "in the last year" tail when it equals active.
-                            Crawler dataset is <365d so year-filter == active right
-                            now (#2950); self-healing once postings start aging out.
-                          */}
                           <span className="text-xs text-muted">
-                            {c.activeMatches} active
-                            {c.yearMatches !== c.activeMatches && (
-                              <> · {c.yearMatches} in the last year</>
-                            )}
+                            {c.activeMatches} active · {c.yearMatches} in the last year
                           </span>
                         </div>
                         {c.description && (

--- a/apps/web/src/lib/search/__tests__/typesense-filters.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense-filters.test.ts
@@ -1,7 +1,11 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { POSTING_BASE_FILTER, buildFilterString } from "../typesense-filters";
+import {
+  POSTING_BASE_FILTER,
+  POSTING_FLOW_FILTER,
+  buildFilterString,
+} from "../typesense-filters";
 
 describe("POSTING_BASE_FILTER", () => {
   it("includes is_active:true", () => {
@@ -17,6 +21,27 @@ describe("POSTING_BASE_FILTER", () => {
 
   it("composes the two clauses with `&&`", () => {
     expect(POSTING_BASE_FILTER).toBe("is_active:true && has_content:!=false");
+  });
+});
+
+// =====================================================================
+// Issue #2965: year-count queries measure FLOW (postings first seen in a
+// time window, regardless of current is_active state), not snapshot.
+// POSTING_FLOW_FILTER drops `is_active:true` so delisted-but-still-recent
+// postings count toward the "in the last year" total.
+// =====================================================================
+
+describe("POSTING_FLOW_FILTER (#2965)", () => {
+  it("does NOT include is_active — flow queries must include delisted postings", () => {
+    expect(POSTING_FLOW_FILTER).not.toContain("is_active");
+  });
+
+  it("retains has_content:!=false (don't surface broken postings)", () => {
+    expect(POSTING_FLOW_FILTER).toContain("has_content:!=false");
+  });
+
+  it("is exactly the content-quality clause", () => {
+    expect(POSTING_FLOW_FILTER).toBe("has_content:!=false");
   });
 });
 
@@ -39,26 +64,28 @@ describe("buildFilterString", () => {
 });
 
 // =====================================================================
-// Issue #2926: every `first_seen_at:>` (year-count) filter string in the
-// Typesense providers must compose with POSTING_BASE_FILTER. Skipping it
-// inflates yearly-posting badges to include incomplete postings.
+// Issue #2965: every `first_seen_at:>` (year-count) filter string in the
+// Typesense providers must compose with POSTING_FLOW_FILTER, NOT
+// POSTING_BASE_FILTER. Including `is_active:true` collapses year-count
+// to active-count (an active job, by definition, was first-seen in the
+// past — so the time window selects no extra docs once is_active is on).
 // =====================================================================
 
-describe("year-count badge filters reference POSTING_BASE_FILTER (#2926)", () => {
+describe("year-count badge filters reference POSTING_FLOW_FILTER (#2965)", () => {
   const SOURCES = [
     "../typesense.ts",
     "../typesense-browser.ts",
   ] as const;
 
   for (const rel of SOURCES) {
-    it(`${rel}: every \`first_seen_at:>\` filter string mentions POSTING_BASE_FILTER`, () => {
+    it(`${rel}: every \`first_seen_at:>\` filter string mentions POSTING_FLOW_FILTER`, () => {
       const path = join(__dirname, rel);
       const src = readFileSync(path, "utf8");
       const lines = src.split("\n");
 
       // Match template-literal substrings starting with `first_seen_at:>`
       // and ending at the closing backtick on the same line. The four call
-      // sites in #2926 all build the year filter on a single line.
+      // sites in #2965 all build the year filter on a single line.
       const yearFilterLines = lines.filter((line) =>
         line.includes("first_seen_at:>") &&
         // ignore comment-only lines so we don't false-positive on docs
@@ -69,9 +96,13 @@ describe("year-count badge filters reference POSTING_BASE_FILTER (#2926)", () =>
 
       for (const line of yearFilterLines) {
         expect(
-          line.includes("POSTING_BASE_FILTER"),
-          `expected POSTING_BASE_FILTER in line:\n  ${line.trim()}`,
+          line.includes("POSTING_FLOW_FILTER"),
+          `expected POSTING_FLOW_FILTER in line:\n  ${line.trim()}`,
         ).toBe(true);
+        expect(
+          line.includes("POSTING_BASE_FILTER"),
+          `year-count line must NOT use POSTING_BASE_FILTER (it inflates to is_active filter):\n  ${line.trim()}`,
+        ).toBe(false);
       }
     });
   }

--- a/apps/web/src/lib/search/typesense-browser.ts
+++ b/apps/web/src/lib/search/typesense-browser.ts
@@ -1,4 +1,4 @@
-import { buildFilterString, POSTING_BASE_FILTER } from "./typesense-filters";
+import { buildFilterString, POSTING_BASE_FILTER, POSTING_FLOW_FILTER } from "./typesense-filters";
 import {
   getTypesenseBrowserConfig,
   type TypesenseBrowserConfig,
@@ -146,7 +146,7 @@ async function fetchYearCounts(
 ): Promise<Map<string, number>> {
   if (companyIds.length === 0) return new Map();
   const yearFilter =
-    `${POSTING_BASE_FILTER} && first_seen_at:>${oneYearAgoUnix()} && company_id:[${companyIds.join(",")}]` +
+    `${POSTING_FLOW_FILTER} && first_seen_at:>${oneYearAgoUnix()} && company_id:[${companyIds.join(",")}]` +
     (filterStr ? ` && ${filterStr}` : "");
   const r = await searchOne<JobPostingDoc>(cfg, "job_posting", {
     q,
@@ -414,7 +414,7 @@ export class TypesenseBrowserProvider implements SearchProvider {
       searchOne<JobPostingDoc>(cfg, "job_posting", {
         q,
         query_by: "title",
-        filter_by: `${POSTING_BASE_FILTER} && first_seen_at:>${oneYearAgoUnix()} && ${baseFilter}`,
+        filter_by: `${POSTING_FLOW_FILTER} && first_seen_at:>${oneYearAgoUnix()} && ${baseFilter}`,
         per_page: 0,
       }),
     ]);

--- a/apps/web/src/lib/search/typesense-filters.ts
+++ b/apps/web/src/lib/search/typesense-filters.ts
@@ -1,6 +1,6 @@
 /**
- * Base filter applied to **every** `job_posting` query — hides postings
- * the crawler couldn't extract usable content for.
+ * Base filter applied to **every** `job_posting` snapshot query — hides
+ * postings the crawler couldn't extract usable content for.
  *
  * - `is_active:true` — only currently-listed roles
  * - `has_content:!=false` — exclude postings with empty title or no
@@ -13,9 +13,34 @@
  *   the filter is fully active.
  *
  * Use this constant — never the bare `is_active:true` string — when
- * composing `filter_by` for any search/listing surface.
+ * composing `filter_by` for any search/listing surface that displays
+ * the **current** state (active counts, listing pages, watchlist hits).
+ *
+ * For **flow** queries (year-count badges, "X in the last year"), use
+ * {@link POSTING_FLOW_FILTER} instead — those should include delisted
+ * postings to measure actual posting activity over time.
  */
 export const POSTING_BASE_FILTER = "is_active:true && has_content:!=false";
+
+/**
+ * Filter for **flow** queries that count postings first seen in a time
+ * window, regardless of current `is_active` state — i.e. measuring
+ * activity over time, not the live snapshot.
+ *
+ * Drops `is_active:true` (vs {@link POSTING_BASE_FILTER}) because the
+ * "in the last year" badge should include delisted postings — otherwise
+ * year-count collapses to active-count whenever delistings happen at the
+ * same rate as new listings (issue #2965). Empirically on 2026-05-09:
+ *
+ *   active only                       =>   709,051
+ *   active && first_seen_at:>1y (bug) =>   709,051  (BUG: same as active)
+ *   first_seen_at:>1y (correct)       => 1,400,449
+ *
+ * Retains `has_content:!=false` to keep parity with the active filter on
+ * the content-quality dimension (don't surface broken postings even in
+ * historical counts).
+ */
+export const POSTING_FLOW_FILTER = "has_content:!=false";
 
 /**
  * Build a Typesense filter_by string from user-specified filter dimensions.

--- a/apps/web/src/lib/search/typesense.ts
+++ b/apps/web/src/lib/search/typesense.ts
@@ -4,7 +4,7 @@ import type {
   SearchResponseFacetCountSchema,
 } from "typesense/lib/Typesense/Documents";
 import { getSearchClient } from "./typesense-client";
-import { buildFilterString, POSTING_BASE_FILTER } from "./typesense-filters";
+import { buildFilterString, POSTING_BASE_FILTER, POSTING_FLOW_FILTER } from "./typesense-filters";
 import type {
   PostingLocation,
   SearchFilters,
@@ -165,7 +165,7 @@ async function fetchYearCountsFiltered(
   if (companyIds.length === 0) return new Map();
 
   const client = getSearchClient();
-  const yearFilter = `${POSTING_BASE_FILTER} && first_seen_at:>${oneYearAgoUnix()} && company_id:[${companyIds.join(",")}]${filterStr ? " && " + filterStr : ""}`;
+  const yearFilter = `${POSTING_FLOW_FILTER} && first_seen_at:>${oneYearAgoUnix()} && company_id:[${companyIds.join(",")}]${filterStr ? " && " + filterStr : ""}`;
 
   const result: TsSearchResponse<JobPostingDoc> = await client
     .collections<JobPostingDoc>("job_posting")
@@ -543,7 +543,7 @@ export class TypesenseSearchProvider implements SearchProvider {
           .search({
             q,
             query_by: "title",
-            filter_by: `${POSTING_BASE_FILTER} && first_seen_at:>${oneYearAgoUnix()} && ${baseFilter}`,
+            filter_by: `${POSTING_FLOW_FILTER} && first_seen_at:>${oneYearAgoUnix()} && ${baseFilter}`,
             per_page: 0,
           }),
       ]);


### PR DESCRIPTION
## Summary
- Adds `POSTING_FLOW_FILTER = "has_content:!=false"` (drops `is_active:true`) for year-count badge queries that measure flow, not snapshot
- Updates 4 year-count call sites in `typesense.ts` (lines 168, 546) and `typesense-browser.ts` (lines 149, 417) to use the new constant
- Reverts PR #2951's hide-when-equal logic in 3 components — that artifact was a symptom of this bug, not a real UX issue

## Background
PR #2945 (closes #2926) made year-count queries use `POSTING_BASE_FILTER` (which includes `is_active:true`). PR #2951 (closes #2950) hid the "in the last year" badge when it equaled active count, attributing the equality to dataset youth.

Both were wrong. User caught it: *"The fact that X in the past year is equal to X active just means that X in the past year are not computed properly. It basically means that there were no delistings which is impossible."*

The year-count should mean "postings first seen in the past year, regardless of current `is_active` state" — capturing flow/activity, not snapshot. Including `is_active:true` collapses year-count to active-count.

## Empirical (production Typesense, 2026-05-09)

| Filter | Found |
|---|---|
| Active only (`is_active && has_content:!=false`) | 709,052 |
| Year (buggy: with `is_active`) | 709,052 |
| Year (correct: drops `is_active`) | **1,400,450** |
| Total docs | 1,493,123 |

The fix roughly doubles the year-count value to include delisted postings, as expected.

## PR #2951 decision
**Option A** (revert hide-when-equal): now that year-count computes correctly, the two values diverge naturally. The "hide when equal" workaround was solving a symptom, not a real UX problem — code removed in this PR.

## Test plan
- [x] `pnpm exec vitest run src/lib/search/__tests__/typesense-filters.test.ts` — 10 tests pass (existing 4 + 3 new `POSTING_FLOW_FILTER` shape + flipped 2 guard tests + 1 negative invariant)
- [x] `pnpm exec vitest run` (full suite) — 551 tests pass; only `app/mcp/route.test.ts` fails on a pre-existing missing-module error (unrelated)
- [x] `pnpm exec tsc --noEmit` — clean except the same pre-existing `@jseek/mcp-server/handler` error
- [x] Empirical Typesense queries confirm year-count now returns ~1.4M vs active 709k

🤖 Generated with [Claude Code](https://claude.com/claude-code)