### PR TITLE
fix(crawler): phenom uses strict child-shard fetch (closes #2974)

### DIFF
--- a/apps/crawler/src/core/monitors/phenom.py
+++ b/apps/crawler/src/core/monitors/phenom.py
@@ -63,6 +63,7 @@ from src.core.monitors.sitemap import (
     MAX_URLS,
     _extract_child_sitemaps,
     _extract_urls,
+    _fetch_child_xml,
     _is_sitemap_index,
     _try_fetch_xml,
 )
@@ -150,6 +151,21 @@ async def _collect_urls(
 
     Returns ``(urls, truncated)`` where *truncated* is True when we hit
     ``sitemap.MAX_URLS`` during accumulation; the caller may log this.
+
+    Child shards use the strict :func:`_fetch_child_xml` rather than the
+    lenient :func:`_try_fetch_xml`. This mirrors the sitemap monitor's
+    #2722 hardening: a transient 5xx / 429 / timeout on a child shard
+    raises :exc:`PaginationFetchError` after the retry budget, which
+    propagates up through ``discover()`` to
+    ``_process_one_board_streaming`` and gets recorded as a failed run
+    rather than a partial-success that triggers
+    ``_MARK_GONE_BY_TIMESTAMP`` on the missing URLs. mchire's 906 ``-en``
+    shards make even a 1% per-shard transient failure rate produce
+    multi-thousand URL drops that tombstone real postings (#2974).
+
+    The index root itself stays on the lenient path: discovery of a new
+    sitemap location is allowed to fall through to the next candidate
+    on transient errors, same split as ``sitemap._discover_sitemap``.
     """
     root = await _try_fetch_xml(sitemap_url, client)
     if root is None:
@@ -176,8 +192,11 @@ async def _collect_urls(
         if len(urls) >= MAX_URLS:
             truncated = True
             break
-        child_root = await _try_fetch_xml(child_url, client)
+        # Strict fetch — transient errors raise PaginationFetchError
+        # rather than silently dropping the shard's URLs (#2974).
+        child_root = await _fetch_child_xml(child_url, client)
         if child_root is None:
+            # 404 / 410 / non-XML body — genuinely missing shard, skip.
             continue
         # Nested sitemap-index (rare; defensive): single-level recurse.
         if _is_sitemap_index(child_root):
@@ -185,7 +204,7 @@ async def _collect_urls(
                 if len(urls) >= MAX_URLS:
                     truncated = True
                     break
-                gc_root = await _try_fetch_xml(grandchild, client)
+                gc_root = await _fetch_child_xml(grandchild, client)
                 if gc_root is not None:
                     urls.update(_extract_urls(gc_root))
         else:
@@ -260,6 +279,8 @@ async def can_handle(
     Phenom host blocking the endpoint. The sitemap fingerprint is
     cheaper and does not require egress proxying.
     """
+    from src.shared.http_retry import PaginationFetchError
+
     if client is None:
         return None
     parsed = urlparse(url)
@@ -270,7 +291,20 @@ async def can_handle(
     children = _extract_child_sitemaps(root)
     if not any(_PHENOM_CHILD_RE.search(c) for c in children):
         return None
-    urls, _truncated = await _collect_urls(sitemap, client)
+    # Probe path: a transient PaginationFetchError on a single shard
+    # shouldn't fail the whole probe — return a partial count instead so
+    # the operator still gets a positive Phenom-detected signal. The
+    # discover() path keeps the strict semantics for production cycles.
+    try:
+        urls, _truncated = await _collect_urls(sitemap, client)
+    except PaginationFetchError as exc:
+        log.warning(
+            "phenom.can_handle.partial",
+            sitemap=sitemap,
+            url=exc.url,
+            last_status=exc.last_status,
+        )
+        return {"sitemap_url": sitemap, "urls": 0, "jobs": 0}
     job_urls = sum(1 for u in urls if _is_phenom_job_url(u))
     return {"sitemap_url": sitemap, "urls": len(urls), "jobs": job_urls}
 

--- a/apps/crawler/tests/test_phenom_monitor.py
+++ b/apps/crawler/tests/test_phenom_monitor.py
@@ -431,3 +431,122 @@ async def test_can_handle_rejects_missing_sitemap():
     async with httpx.AsyncClient(transport=transport) as client:
         meta = await can_handle("https://example.com/", client)
     assert meta is None
+
+
+# ── Strict child-shard fetch (#2974) ─────────────────────────────────────
+#
+# A transient 5xx on a single child shard must propagate
+# ``PaginationFetchError`` from ``discover()`` rather than silently
+# dropping the shard's URLs. The 906-shard mchire sitemap made even a
+# tiny per-shard transient failure rate produce multi-thousand URL gaps,
+# which then false-tombstoned active postings via
+# ``_MARK_GONE_BY_TIMESTAMP``. ``can_handle()`` is treated as a probe and
+# returns a partial result instead of raising.
+
+
+@pytest.mark.asyncio
+async def test_discover_propagates_pagination_fetch_error_on_5xx_shard(monkeypatch):
+    """One shard returning persistent 503 → discover() raises
+    ``PaginationFetchError`` (caught by ``_process_one_board_streaming``
+    so the run is recorded as a failure, not a partial success).
+    """
+    import asyncio
+
+    from src.shared.http_retry import PaginationFetchError
+
+    async def _no_sleep(_):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    def handler(request):
+        url = str(request.url)
+        if url == "https://careers.example.com/sitemap.xml":
+            return httpx.Response(
+                200,
+                content=_PHENOM_INDEX_SHARDED,
+                headers={"content-type": "application/xml"},
+            )
+        if url == "https://careers.example.com/sitemap-0001-en.xml":
+            return httpx.Response(
+                200,
+                content=_SHARD_1,
+                headers={"content-type": "application/xml"},
+            )
+        # Shard 2 is consistently 503 — should exhaust retries and raise.
+        if url == "https://careers.example.com/sitemap-0002-en.xml":
+            return httpx.Response(503)
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    board = {"id": "b1", "board_url": "https://careers.example.com", "metadata": {}}
+    async with httpx.AsyncClient(transport=transport) as client:
+        with pytest.raises(PaginationFetchError) as exc:
+            await discover(board, client)
+        assert exc.value.last_status == 503
+
+
+@pytest.mark.asyncio
+async def test_discover_skips_404_shard_without_raising():
+    """404 on a child shard is a genuinely-missing shard (e.g. removed
+    between index emit and our fetch) — skip it and return the rest of
+    the URLs without raising. Mirrors ``sitemap._fetch_child_xml``
+    semantics.
+    """
+
+    def handler(request):
+        url = str(request.url)
+        if url == "https://careers.example.com/sitemap.xml":
+            return httpx.Response(
+                200,
+                content=_PHENOM_INDEX_SHARDED,
+                headers={"content-type": "application/xml"},
+            )
+        if url == "https://careers.example.com/sitemap-0001-en.xml":
+            return httpx.Response(
+                200,
+                content=_SHARD_1,
+                headers={"content-type": "application/xml"},
+            )
+        # Shard 2 is missing — return None silently.
+        return httpx.Response(404)
+
+    transport = httpx.MockTransport(handler)
+    board = {"id": "b1", "board_url": "https://careers.example.com", "metadata": {}}
+    async with httpx.AsyncClient(transport=transport) as client:
+        urls, _ = await discover(board, client)
+    # Only shard-1 URLs present; shard-2 silently skipped (no raise).
+    assert urls == {"https://careers.example.com/crew-member/job/P8-1"}
+
+
+@pytest.mark.asyncio
+async def test_can_handle_partial_on_pagination_error(monkeypatch):
+    """Probe path: a transient shard error doesn't fail the whole probe.
+    Operator still gets a positive Phenom signal; discover() will be
+    strict on production cycles.
+    """
+    import asyncio
+
+    async def _no_sleep(_):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    def handler(request):
+        url = str(request.url)
+        if url == "https://careers.example.com/sitemap.xml":
+            return httpx.Response(
+                200,
+                content=_PHENOM_INDEX_SHARDED,
+                headers={"content-type": "application/xml"},
+            )
+        # Both shards 503 — _collect_urls would raise on the first.
+        return httpx.Response(503)
+
+    transport = httpx.MockTransport(handler)
+    async with httpx.AsyncClient(transport=transport) as client:
+        meta = await can_handle("https://careers.example.com/", client)
+    assert meta is not None
+    assert meta["sitemap_url"] == "https://careers.example.com/sitemap.xml"
+    assert meta["urls"] == 0
+    assert meta["jobs"] == 0


### PR DESCRIPTION
## Summary

- McDonald's US (`mcdonalds-us-restaurants`, board on `jobs.mchire.com`) flapped 10-20k active postings between cycles. Loki shows 5x/24h the phenom sitemap walk returned 12-33k URLs vs the steady-state 40,560.
- Root cause: `phenom._collect_urls` used `_try_fetch_xml` (lenient — silent skip on any error) for child shard fetches. With 906 ``-en`` shards, even a 1% per-shard transient failure rate drops enough URLs to fall *just below* the #2724 blast-radius floor and tombstone 7-13k postings via `_MARK_GONE_BY_TIMESTAMP` per affected cycle.
- Apply the same #2722 hardening that the `sitemap` monitor received: switch to `_fetch_child_xml` so transient 5xx/429/timeout raises `PaginationFetchError`, recording the run as failed instead of as a partial-success that triggers gone-detection.
- `can_handle()` (the probe path) wraps the call so a transient shard error returns a partial probe result rather than aborting the probe.

Full investigation, evidence tables, and per-board breakdown in #2974.

## Test plan

- [x] `uv run pytest tests/test_phenom_monitor.py` — 40 passed (37 existing + 3 new)
- [x] `uv run pytest tests/test_sitemap.py` — 47 passed (no regression)
- [ ] After deploy, watch `mcdonalds-us-restaurants` Loki history: cycles with discovered counts in the 12-33k partial-truncation band should be replaced by cleanly-failed runs (status code recorded, `_MARK_GONE_BY_TIMESTAMP` skipped). The active count should stabilize around 40,560.
- [ ] Confirm no false-positive failures on healthy phenom tenants (marriott, nike, nordstrom, elevance-health, mondelez, mcdonalds-au, mcdonalds-canada).

🤖 Generated with [Claude Code](https://claude.com/claude-code)