### PR TITLE
feat(web): hierarchical filter UI with disabled subcategories (closes #2978)

### DIFF
--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -297,21 +297,21 @@ msgstr "Alle Daten werden bei Übertragung und Speicherung verschlüsselt."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Alle Branchen"
 
-#. All languages option
-#. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:244
-msgid "settings.general.jobLanguages.all"
-msgstr "Alle Sprachen"
-
 #. Title for the all-languages modal in settings
 #. js-lingui-explicit-id
 #: src/components/settings/JobLanguageModal.tsx:56
 msgid "settings.jobLanguages.modal.title"
 msgstr "Alle Sprachen"
 
+#. All languages option
+#. js-lingui-explicit-id
+#: src/components/settings/GeneralSettings.tsx:244
+msgid "settings.general.jobLanguages.all"
+msgstr "Alle Sprachen"
+
 #. Title for the all-locations modal on company page
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:183
+#: src/components/search/location-modal.tsx:268
 msgid "company.locationModal.title"
 msgstr "Alle Standorte"
 
@@ -404,12 +404,6 @@ msgstr "Bewerbungen im letzten Jahr"
 msgid "myJobs.group.applied"
 msgstr "Beworben"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:449
-msgid "search.tracker.applied"
-msgstr "Beworben"
-
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
@@ -420,6 +414,12 @@ msgstr "Beworben"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
+msgstr "Beworben"
+
+#. Application tracker status: applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:449
+msgid "search.tracker.applied"
 msgstr "Beworben"
 
 #. Status option in dropdown: applied
@@ -1771,6 +1771,12 @@ msgstr "im letzten Jahr"
 msgid "blog.mention.watchlist.yearJobsLabel"
 msgstr "im letzten Jahr"
 
+#. Tooltip on a disabled filter pill explaining the row is implied by an already-selected ancestor (e.g. 'Included in European Union' when EU is selected).
+#. js-lingui-explicit-id
+#: src/components/search/disabled-filter-pill.tsx:86
+msgid "search.filterModal.includedInAncestor"
+msgstr "In {ancestorName} enthalten"
+
 #. Indexing page eyebrow
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:45
@@ -1837,16 +1843,16 @@ msgstr "Interview-Protokoll"
 msgid "myJobs.group.interviewing"
 msgstr "Im Interview"
 
-#. Application tracker status: interviewing
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:450
-msgid "search.tracker.interviewing"
-msgstr "Im Interview"
-
 #. Interviewing status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:21
 msgid "myJobs.status.interviewing"
+msgstr "Im Interview"
+
+#. Application tracker status: interviewing
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:450
+msgid "search.tracker.interviewing"
 msgstr "Im Interview"
 
 #. Status option in dropdown: interviewing
@@ -2365,9 +2371,9 @@ msgstr "Mehrsprachige Unterstützung"
 #. Warning when Enter is pressed but multiple items match
 #. Warning when Enter is pressed but multiple items match
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:162
-#: src/components/search/location-search-modal.tsx:153
-#: src/components/search/occupation-modal.tsx:110
+#: src/components/search/location-modal.tsx:247
+#: src/components/search/location-search-modal.tsx:237
+#: src/components/search/occupation-modal.tsx:180
 #: src/components/search/technology-modal.tsx:88
 msgid "search.bestGuess.ambiguous"
 msgstr "Mehrere Treffer — wähle einen aus"
@@ -2462,17 +2468,17 @@ msgstr "Keine Jobs gefunden."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Keine Sprachen entsprechen deiner Suche."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:224
-msgid "company.locationModal.noResults"
-msgstr "Keine Standorte entsprechen Ihrer Suche."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:215
+#: src/components/search/location-search-modal.tsx:299
 msgid "search.locationModal.noResults"
 msgstr "Keine Standorte gefunden."
+
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:309
+msgid "company.locationModal.noResults"
+msgstr "Keine Standorte entsprechen Ihrer Suche."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2500,7 +2506,7 @@ msgstr "Keine Ergebnisse für „{query}\" gefunden"
 
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:213
+#: src/components/search/occupation-modal.tsx:293
 msgid "search.occupationModal.noResults"
 msgstr "Keine Berufe gefunden."
 
@@ -2550,16 +2556,16 @@ msgstr "Nein. Der Bewerbungstracker hat kein festes Limit — speichere so viele
 msgid "faq.a.dataPrivacy"
 msgstr "Nein. Wir verkaufen, vermieten oder teilen deine Daten nicht zu Marketingzwecken. Cookies sind nur sitzungsbasiert, ohne Werbung oder Tracking. Du kannst dein Konto löschen und alle Daten werden innerhalb von 30 Tagen entfernt."
 
-#. Application tracker status: not applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:448
-msgid "search.tracker.notApplied"
-msgstr "Nicht beworben"
-
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
+msgstr "Nicht beworben"
+
+#. Application tracker status: not applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:448
+msgid "search.tracker.notApplied"
 msgstr "Nicht beworben"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2586,16 +2592,16 @@ msgstr "Berufsfeld"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Okt"
 
-#. Application tracker status: offer
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:451
-msgid "search.tracker.offer"
-msgstr "Angebot"
-
 #. Offered status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
+msgstr "Angebot"
+
+#. Application tracker status: offer
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:451
+msgid "search.tracker.offer"
 msgstr "Angebot"
 
 #. Status group heading: offered
@@ -2929,18 +2935,18 @@ msgstr "Stelle nicht gefunden."
 msgid "myJobs.detail.notFound"
 msgstr "Stellenanzeige nicht gefunden."
 
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:100
+msgid "home.pricing.eyebrow"
+msgstr "Preise"
+
 #. Nav link: Pricing
 #. Nav link: Pricing
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:62
 #: src/components/MobileMenu.tsx:87
 msgid "common.nav.pricing"
-msgstr "Preise"
-
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: src/components/Pricing.tsx:100
-msgid "home.pricing.eyebrow"
 msgstr "Preise"
 
 #. Privacy policy page eyebrow
@@ -3068,28 +3074,22 @@ msgstr "Deine Änderungen weiterverbreiten, solange du den MIT-Hinweis beifügst
 msgid "location.type.region"
 msgstr "Region"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:234
-msgid "company.locationModal.regionsHeader"
-msgstr "Regionen"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:225
+#: src/components/search/location-search-modal.tsx:309
 msgid "search.locationModal.regionsHeader"
+msgstr "Regionen"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:319
+msgid "company.locationModal.regionsHeader"
 msgstr "Regionen"
 
 #. Status group heading: rejected
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:32
 msgid "myJobs.group.rejected"
-msgstr "Abgelehnt"
-
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:452
-msgid "search.tracker.rejected"
 msgstr "Abgelehnt"
 
 #. Rejected status badge label
@@ -3102,6 +3102,12 @@ msgstr "Abgelehnt"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
+msgstr "Abgelehnt"
+
+#. Application tracker status: rejected
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:452
+msgid "search.tracker.rejected"
 msgstr "Abgelehnt"
 
 #. Status option in dropdown: rejected
@@ -3386,17 +3392,17 @@ msgstr "Durchsuche Jobs bei Tausenden von Unternehmen, direkt von Karriereseiten
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Sprachen suchen…"
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:203
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Standorte suchen…"
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:194
+#: src/components/search/location-search-modal.tsx:278
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Standorte suchen..."
+
+#. Placeholder for search input in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:288
+msgid "company.locationModal.searchPlaceholder"
+msgstr "Standorte suchen…"
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3406,7 +3412,7 @@ msgstr "Suchergebnisse"
 
 #. Placeholder for search input in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:192
+#: src/components/search/occupation-modal.tsx:272
 msgid "search.occupationModal.searchPlaceholder"
 msgstr "Berufe suchen..."
 
@@ -3442,13 +3448,13 @@ msgstr "Stufe auswählen"
 
 #. Title for the global location selection modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:174
+#: src/components/search/location-search-modal.tsx:258
 msgid "search.locationModal.title"
 msgstr "Standort auswählen"
 
 #. Title for the occupation selection modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:172
+#: src/components/search/occupation-modal.tsx:252
 msgid "search.occupationModal.title"
 msgstr "Beruf auswählen"
 
@@ -3548,16 +3554,16 @@ msgstr "Einstellungen"
 msgid "home.features.s3.p3.title"
 msgstr "Mit jedem teilen"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:355
-msgid "search.detail.showLessLocations"
-msgstr "Weniger anzeigen"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:351
 msgid "company.page.showLess"
+msgstr "Weniger anzeigen"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:355
+msgid "search.detail.showLessLocations"
 msgstr "Weniger anzeigen"
 
 #. Aria label to show password

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -297,21 +297,21 @@ msgstr "All data is encrypted in transit and at rest."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "All industries"
 
-#. All languages option
-#. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:244
-msgid "settings.general.jobLanguages.all"
-msgstr "All languages"
-
 #. Title for the all-languages modal in settings
 #. js-lingui-explicit-id
 #: src/components/settings/JobLanguageModal.tsx:56
 msgid "settings.jobLanguages.modal.title"
 msgstr "All languages"
 
+#. All languages option
+#. js-lingui-explicit-id
+#: src/components/settings/GeneralSettings.tsx:244
+msgid "settings.general.jobLanguages.all"
+msgstr "All languages"
+
 #. Title for the all-locations modal on company page
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:183
+#: src/components/search/location-modal.tsx:268
 msgid "company.locationModal.title"
 msgstr "All locations"
 
@@ -404,12 +404,6 @@ msgstr "applications in the past year"
 msgid "myJobs.group.applied"
 msgstr "Applied"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:449
-msgid "search.tracker.applied"
-msgstr "Applied"
-
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
@@ -420,6 +414,12 @@ msgstr "Applied"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
+msgstr "Applied"
+
+#. Application tracker status: applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:449
+msgid "search.tracker.applied"
 msgstr "Applied"
 
 #. Status option in dropdown: applied
@@ -1771,6 +1771,12 @@ msgstr "in the last year"
 msgid "blog.mention.watchlist.yearJobsLabel"
 msgstr "in the past year"
 
+#. Tooltip on a disabled filter pill explaining the row is implied by an already-selected ancestor (e.g. 'Included in European Union' when EU is selected).
+#. js-lingui-explicit-id
+#: src/components/search/disabled-filter-pill.tsx:86
+msgid "search.filterModal.includedInAncestor"
+msgstr "Included in {ancestorName}"
+
 #. Indexing page eyebrow
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:45
@@ -1837,16 +1843,16 @@ msgstr "Interview log"
 msgid "myJobs.group.interviewing"
 msgstr "Interviewing"
 
-#. Application tracker status: interviewing
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:450
-msgid "search.tracker.interviewing"
-msgstr "Interviewing"
-
 #. Interviewing status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:21
 msgid "myJobs.status.interviewing"
+msgstr "Interviewing"
+
+#. Application tracker status: interviewing
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:450
+msgid "search.tracker.interviewing"
 msgstr "Interviewing"
 
 #. Status option in dropdown: interviewing
@@ -2365,9 +2371,9 @@ msgstr "Multi-language support"
 #. Warning when Enter is pressed but multiple items match
 #. Warning when Enter is pressed but multiple items match
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:162
-#: src/components/search/location-search-modal.tsx:153
-#: src/components/search/occupation-modal.tsx:110
+#: src/components/search/location-modal.tsx:247
+#: src/components/search/location-search-modal.tsx:237
+#: src/components/search/occupation-modal.tsx:180
 #: src/components/search/technology-modal.tsx:88
 msgid "search.bestGuess.ambiguous"
 msgstr "Multiple matches — select one below"
@@ -2462,16 +2468,16 @@ msgstr "No jobs found."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "No languages match your search."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:224
-msgid "company.locationModal.noResults"
-msgstr "No locations match your search."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:215
+#: src/components/search/location-search-modal.tsx:299
 msgid "search.locationModal.noResults"
+msgstr "No locations match your search."
+
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:309
+msgid "company.locationModal.noResults"
 msgstr "No locations match your search."
 
 #. No postings found message on company page
@@ -2500,7 +2506,7 @@ msgstr "No results found for “{query}”"
 
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:213
+#: src/components/search/occupation-modal.tsx:293
 msgid "search.occupationModal.noResults"
 msgstr "No roles match your search."
 
@@ -2550,16 +2556,16 @@ msgstr "No. The application tracker has no hard limit — save as many jobs as y
 msgid "faq.a.dataPrivacy"
 msgstr "No. We don't sell, rent, or share your data for marketing. Cookies are session-only with no ads or tracking. You can delete your account and all data is wiped within 30 days."
 
-#. Application tracker status: not applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:448
-msgid "search.tracker.notApplied"
-msgstr "Not applied"
-
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
+msgstr "Not applied"
+
+#. Application tracker status: not applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:448
+msgid "search.tracker.notApplied"
 msgstr "Not applied"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2586,16 +2592,16 @@ msgstr "Occupation"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Oct"
 
-#. Application tracker status: offer
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:451
-msgid "search.tracker.offer"
-msgstr "Offer"
-
 #. Offered status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
+msgstr "Offer"
+
+#. Application tracker status: offer
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:451
+msgid "search.tracker.offer"
 msgstr "Offer"
 
 #. Status group heading: offered
@@ -2929,18 +2935,18 @@ msgstr "Posting not found."
 msgid "myJobs.detail.notFound"
 msgstr "Posting not found."
 
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:100
+msgid "home.pricing.eyebrow"
+msgstr "Pricing"
+
 #. Nav link: Pricing
 #. Nav link: Pricing
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:62
 #: src/components/MobileMenu.tsx:87
 msgid "common.nav.pricing"
-msgstr "Pricing"
-
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: src/components/Pricing.tsx:100
-msgid "home.pricing.eyebrow"
 msgstr "Pricing"
 
 #. Privacy policy page eyebrow
@@ -3068,28 +3074,22 @@ msgstr "Redistribute your changes, as long as you include the MIT notice."
 msgid "location.type.region"
 msgstr "Region"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:234
-msgid "company.locationModal.regionsHeader"
-msgstr "Regions"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:225
+#: src/components/search/location-search-modal.tsx:309
 msgid "search.locationModal.regionsHeader"
+msgstr "Regions"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:319
+msgid "company.locationModal.regionsHeader"
 msgstr "Regions"
 
 #. Status group heading: rejected
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:32
 msgid "myJobs.group.rejected"
-msgstr "Rejected"
-
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:452
-msgid "search.tracker.rejected"
 msgstr "Rejected"
 
 #. Rejected status badge label
@@ -3102,6 +3102,12 @@ msgstr "Rejected"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
+msgstr "Rejected"
+
+#. Application tracker status: rejected
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:452
+msgid "search.tracker.rejected"
 msgstr "Rejected"
 
 #. Status option in dropdown: rejected
@@ -3386,16 +3392,16 @@ msgstr "Search jobs across thousands of companies scraped directly from career p
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Search languages..."
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:203
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Search locations..."
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:194
+#: src/components/search/location-search-modal.tsx:278
 msgid "search.locationModal.searchPlaceholder"
+msgstr "Search locations..."
+
+#. Placeholder for search input in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:288
+msgid "company.locationModal.searchPlaceholder"
 msgstr "Search locations..."
 
 #. Back-to-search link on company page header
@@ -3406,7 +3412,7 @@ msgstr "Search results"
 
 #. Placeholder for search input in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:192
+#: src/components/search/occupation-modal.tsx:272
 msgid "search.occupationModal.searchPlaceholder"
 msgstr "Search roles..."
 
@@ -3442,13 +3448,13 @@ msgstr "Select level"
 
 #. Title for the global location selection modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:174
+#: src/components/search/location-search-modal.tsx:258
 msgid "search.locationModal.title"
 msgstr "Select location"
 
 #. Title for the occupation selection modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:172
+#: src/components/search/occupation-modal.tsx:252
 msgid "search.occupationModal.title"
 msgstr "Select role"
 
@@ -3548,16 +3554,16 @@ msgstr "Settings"
 msgid "home.features.s3.p3.title"
 msgstr "Share with anyone"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:355
-msgid "search.detail.showLessLocations"
-msgstr "Show less"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:351
 msgid "company.page.showLess"
+msgstr "Show less"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:355
+msgid "search.detail.showLessLocations"
 msgstr "Show less"
 
 #. Aria label to show password

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -297,21 +297,21 @@ msgstr "Toutes les données sont chiffrées en transit et au repos."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Tous les secteurs"
 
-#. All languages option
-#. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:244
-msgid "settings.general.jobLanguages.all"
-msgstr "Toutes les langues"
-
 #. Title for the all-languages modal in settings
 #. js-lingui-explicit-id
 #: src/components/settings/JobLanguageModal.tsx:56
 msgid "settings.jobLanguages.modal.title"
 msgstr "Toutes les langues"
 
+#. All languages option
+#. js-lingui-explicit-id
+#: src/components/settings/GeneralSettings.tsx:244
+msgid "settings.general.jobLanguages.all"
+msgstr "Toutes les langues"
+
 #. Title for the all-locations modal on company page
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:183
+#: src/components/search/location-modal.tsx:268
 msgid "company.locationModal.title"
 msgstr "Tous les lieux"
 
@@ -404,12 +404,6 @@ msgstr "candidatures durant l'année écoulée"
 msgid "myJobs.group.applied"
 msgstr "Postulé"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:449
-msgid "search.tracker.applied"
-msgstr "Postulé"
-
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
@@ -420,6 +414,12 @@ msgstr "Postulé"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
+msgstr "Postulé"
+
+#. Application tracker status: applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:449
+msgid "search.tracker.applied"
 msgstr "Postulé"
 
 #. Status option in dropdown: applied
@@ -1771,6 +1771,12 @@ msgstr "au cours de la dernière année"
 msgid "blog.mention.watchlist.yearJobsLabel"
 msgstr "au cours de la dernière année"
 
+#. Tooltip on a disabled filter pill explaining the row is implied by an already-selected ancestor (e.g. 'Included in European Union' when EU is selected).
+#. js-lingui-explicit-id
+#: src/components/search/disabled-filter-pill.tsx:86
+msgid "search.filterModal.includedInAncestor"
+msgstr "Inclus dans {ancestorName}"
+
 #. Indexing page eyebrow
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:45
@@ -1837,16 +1843,16 @@ msgstr "Journal d'entretiens"
 msgid "myJobs.group.interviewing"
 msgstr "En entretien"
 
-#. Application tracker status: interviewing
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:450
-msgid "search.tracker.interviewing"
-msgstr "En entretien"
-
 #. Interviewing status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:21
 msgid "myJobs.status.interviewing"
+msgstr "En entretien"
+
+#. Application tracker status: interviewing
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:450
+msgid "search.tracker.interviewing"
 msgstr "En entretien"
 
 #. Status option in dropdown: interviewing
@@ -2365,9 +2371,9 @@ msgstr "Support multilingue"
 #. Warning when Enter is pressed but multiple items match
 #. Warning when Enter is pressed but multiple items match
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:162
-#: src/components/search/location-search-modal.tsx:153
-#: src/components/search/occupation-modal.tsx:110
+#: src/components/search/location-modal.tsx:247
+#: src/components/search/location-search-modal.tsx:237
+#: src/components/search/occupation-modal.tsx:180
 #: src/components/search/technology-modal.tsx:88
 msgid "search.bestGuess.ambiguous"
 msgstr "Plusieurs résultats — sélectionnez-en un ci-dessous"
@@ -2462,16 +2468,16 @@ msgstr "Aucune offre trouvée."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Aucune langue ne correspond à votre recherche."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:224
-msgid "company.locationModal.noResults"
-msgstr "Aucun lieu ne correspond à votre recherche."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:215
+#: src/components/search/location-search-modal.tsx:299
 msgid "search.locationModal.noResults"
+msgstr "Aucun lieu ne correspond à votre recherche."
+
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:309
+msgid "company.locationModal.noResults"
 msgstr "Aucun lieu ne correspond à votre recherche."
 
 #. No postings found message on company page
@@ -2500,7 +2506,7 @@ msgstr "Aucun résultat trouvé pour « {query} »"
 
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:213
+#: src/components/search/occupation-modal.tsx:293
 msgid "search.occupationModal.noResults"
 msgstr "Aucun rôle ne correspond à votre recherche."
 
@@ -2550,16 +2556,16 @@ msgstr "Non. Le suivi des candidatures n'a pas de limite — enregistrez autant 
 msgid "faq.a.dataPrivacy"
 msgstr "Non. Nous ne vendons, ne louons ni ne partageons vos données à des fins marketing. Les cookies sont uniquement de session, sans publicité ni tracking. Vous pouvez supprimer votre compte et toutes les données seront effacées sous 30 jours."
 
-#. Application tracker status: not applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:448
-msgid "search.tracker.notApplied"
-msgstr "Non postulé"
-
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
+msgstr "Non postulé"
+
+#. Application tracker status: not applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:448
+msgid "search.tracker.notApplied"
 msgstr "Non postulé"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2586,16 +2592,16 @@ msgstr "Métier"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Oct"
 
-#. Application tracker status: offer
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:451
-msgid "search.tracker.offer"
-msgstr "Offre"
-
 #. Offered status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
+msgstr "Offre"
+
+#. Application tracker status: offer
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:451
+msgid "search.tracker.offer"
 msgstr "Offre"
 
 #. Status group heading: offered
@@ -2929,18 +2935,18 @@ msgstr "Offre non trouvée."
 msgid "myJobs.detail.notFound"
 msgstr "Offre introuvable."
 
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:100
+msgid "home.pricing.eyebrow"
+msgstr "Tarifs"
+
 #. Nav link: Pricing
 #. Nav link: Pricing
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:62
 #: src/components/MobileMenu.tsx:87
 msgid "common.nav.pricing"
-msgstr "Tarifs"
-
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: src/components/Pricing.tsx:100
-msgid "home.pricing.eyebrow"
 msgstr "Tarifs"
 
 #. Privacy policy page eyebrow
@@ -3068,28 +3074,22 @@ msgstr "Redistribue tes modifications, à condition d'inclure la mention MIT."
 msgid "location.type.region"
 msgstr "Région"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:234
-msgid "company.locationModal.regionsHeader"
-msgstr "Régions"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:225
+#: src/components/search/location-search-modal.tsx:309
 msgid "search.locationModal.regionsHeader"
+msgstr "Régions"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:319
+msgid "company.locationModal.regionsHeader"
 msgstr "Régions"
 
 #. Status group heading: rejected
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:32
 msgid "myJobs.group.rejected"
-msgstr "Refusé"
-
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:452
-msgid "search.tracker.rejected"
 msgstr "Refusé"
 
 #. Rejected status badge label
@@ -3102,6 +3102,12 @@ msgstr "Refusé"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
+msgstr "Refusé"
+
+#. Application tracker status: rejected
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:452
+msgid "search.tracker.rejected"
 msgstr "Refusé"
 
 #. Status option in dropdown: rejected
@@ -3386,17 +3392,17 @@ msgstr "Recherchez des emplois dans des milliers d'entreprises, scrapés directe
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Rechercher des langues…"
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:203
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Rechercher des lieux…"
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:194
+#: src/components/search/location-search-modal.tsx:278
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Rechercher des lieux..."
+
+#. Placeholder for search input in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:288
+msgid "company.locationModal.searchPlaceholder"
+msgstr "Rechercher des lieux…"
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3406,7 +3412,7 @@ msgstr "Résultats de recherche"
 
 #. Placeholder for search input in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:192
+#: src/components/search/occupation-modal.tsx:272
 msgid "search.occupationModal.searchPlaceholder"
 msgstr "Rechercher des rôles..."
 
@@ -3442,13 +3448,13 @@ msgstr "Sélectionner le niveau"
 
 #. Title for the global location selection modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:174
+#: src/components/search/location-search-modal.tsx:258
 msgid "search.locationModal.title"
 msgstr "Sélectionner le lieu"
 
 #. Title for the occupation selection modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:172
+#: src/components/search/occupation-modal.tsx:252
 msgid "search.occupationModal.title"
 msgstr "Sélectionner le rôle"
 
@@ -3548,16 +3554,16 @@ msgstr "Paramètres"
 msgid "home.features.s3.p3.title"
 msgstr "Partager avec tout le monde"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:355
-msgid "search.detail.showLessLocations"
-msgstr "Afficher moins"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:351
 msgid "company.page.showLess"
+msgstr "Afficher moins"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:355
+msgid "search.detail.showLessLocations"
 msgstr "Afficher moins"
 
 #. Aria label to show password

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -297,21 +297,21 @@ msgstr "Tutti i dati sono crittografati in transito e a riposo."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Tutti i settori"
 
-#. All languages option
-#. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:244
-msgid "settings.general.jobLanguages.all"
-msgstr "Tutte le lingue"
-
 #. Title for the all-languages modal in settings
 #. js-lingui-explicit-id
 #: src/components/settings/JobLanguageModal.tsx:56
 msgid "settings.jobLanguages.modal.title"
 msgstr "Tutte le lingue"
 
+#. All languages option
+#. js-lingui-explicit-id
+#: src/components/settings/GeneralSettings.tsx:244
+msgid "settings.general.jobLanguages.all"
+msgstr "Tutte le lingue"
+
 #. Title for the all-locations modal on company page
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:183
+#: src/components/search/location-modal.tsx:268
 msgid "company.locationModal.title"
 msgstr "Tutte le sedi"
 
@@ -404,12 +404,6 @@ msgstr "candidature nell'ultimo anno"
 msgid "myJobs.group.applied"
 msgstr "Candidato"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:449
-msgid "search.tracker.applied"
-msgstr "Candidato"
-
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
@@ -420,6 +414,12 @@ msgstr "Candidato"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
+msgstr "Candidato"
+
+#. Application tracker status: applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:449
+msgid "search.tracker.applied"
 msgstr "Candidato"
 
 #. Status option in dropdown: applied
@@ -1771,6 +1771,12 @@ msgstr "nell'ultimo anno"
 msgid "blog.mention.watchlist.yearJobsLabel"
 msgstr "nell'ultimo anno"
 
+#. Tooltip on a disabled filter pill explaining the row is implied by an already-selected ancestor (e.g. 'Included in European Union' when EU is selected).
+#. js-lingui-explicit-id
+#: src/components/search/disabled-filter-pill.tsx:86
+msgid "search.filterModal.includedInAncestor"
+msgstr "Incluso in {ancestorName}"
+
 #. Indexing page eyebrow
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:45
@@ -1837,16 +1843,16 @@ msgstr "Registro dei colloqui"
 msgid "myJobs.group.interviewing"
 msgstr "In colloquio"
 
-#. Application tracker status: interviewing
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:450
-msgid "search.tracker.interviewing"
-msgstr "In colloquio"
-
 #. Interviewing status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:21
 msgid "myJobs.status.interviewing"
+msgstr "In colloquio"
+
+#. Application tracker status: interviewing
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:450
+msgid "search.tracker.interviewing"
 msgstr "In colloquio"
 
 #. Status option in dropdown: interviewing
@@ -2365,9 +2371,9 @@ msgstr "Supporto multilingue"
 #. Warning when Enter is pressed but multiple items match
 #. Warning when Enter is pressed but multiple items match
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:162
-#: src/components/search/location-search-modal.tsx:153
-#: src/components/search/occupation-modal.tsx:110
+#: src/components/search/location-modal.tsx:247
+#: src/components/search/location-search-modal.tsx:237
+#: src/components/search/occupation-modal.tsx:180
 #: src/components/search/technology-modal.tsx:88
 msgid "search.bestGuess.ambiguous"
 msgstr "Risultati multipli — selezionane uno qui sotto"
@@ -2462,17 +2468,17 @@ msgstr "Nessuna offerta trovata."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Nessuna lingua corrisponde alla ricerca."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:224
-msgid "company.locationModal.noResults"
-msgstr "Nessuna sede corrisponde alla tua ricerca."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:215
+#: src/components/search/location-search-modal.tsx:299
 msgid "search.locationModal.noResults"
 msgstr "Nessun luogo corrisponde alla tua ricerca."
+
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:309
+msgid "company.locationModal.noResults"
+msgstr "Nessuna sede corrisponde alla tua ricerca."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2500,7 +2506,7 @@ msgstr "Nessun risultato trovato per \"{query}\""
 
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:213
+#: src/components/search/occupation-modal.tsx:293
 msgid "search.occupationModal.noResults"
 msgstr "Nessun ruolo corrisponde alla tua ricerca."
 
@@ -2550,16 +2556,16 @@ msgstr "No. Il tracker delle candidature non ha limiti — salva quante offerte 
 msgid "faq.a.dataPrivacy"
 msgstr "No. Non vendiamo, affittiamo né condividiamo i tuoi dati a fini di marketing. I cookie sono solo di sessione, senza pubblicità né tracciamento. Puoi eliminare il tuo account e tutti i dati verranno cancellati entro 30 giorni."
 
-#. Application tracker status: not applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:448
-msgid "search.tracker.notApplied"
-msgstr "Non candidato"
-
 #. Sankey funnel node: not applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:44
 msgid "myJobs.funnel.notApplied"
+msgstr "Non candidato"
+
+#. Application tracker status: not applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:448
+msgid "search.tracker.notApplied"
 msgstr "Non candidato"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2586,16 +2592,16 @@ msgstr "Professione"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Ott"
 
-#. Application tracker status: offer
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:451
-msgid "search.tracker.offer"
-msgstr "Offerta"
-
 #. Offered status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
+msgstr "Offerta"
+
+#. Application tracker status: offer
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:451
+msgid "search.tracker.offer"
 msgstr "Offerta"
 
 #. Status group heading: offered
@@ -2929,18 +2935,18 @@ msgstr "Offerta non trovata."
 msgid "myJobs.detail.notFound"
 msgstr "Offerta non trovata."
 
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:100
+msgid "home.pricing.eyebrow"
+msgstr "Prezzi"
+
 #. Nav link: Pricing
 #. Nav link: Pricing
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:62
 #: src/components/MobileMenu.tsx:87
 msgid "common.nav.pricing"
-msgstr "Prezzi"
-
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: src/components/Pricing.tsx:100
-msgid "home.pricing.eyebrow"
 msgstr "Prezzi"
 
 #. Privacy policy page eyebrow
@@ -3068,28 +3074,22 @@ msgstr "Ridistribuire le proprie modifiche, a condizione di includere l'avviso M
 msgid "location.type.region"
 msgstr "Regione"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:234
-msgid "company.locationModal.regionsHeader"
-msgstr "Regioni"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:225
+#: src/components/search/location-search-modal.tsx:309
 msgid "search.locationModal.regionsHeader"
+msgstr "Regioni"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:319
+msgid "company.locationModal.regionsHeader"
 msgstr "Regioni"
 
 #. Status group heading: rejected
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:32
 msgid "myJobs.group.rejected"
-msgstr "Rifiutato"
-
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:452
-msgid "search.tracker.rejected"
 msgstr "Rifiutato"
 
 #. Rejected status badge label
@@ -3102,6 +3102,12 @@ msgstr "Rifiutato"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
+msgstr "Rifiutato"
+
+#. Application tracker status: rejected
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:452
+msgid "search.tracker.rejected"
 msgstr "Rifiutato"
 
 #. Status option in dropdown: rejected
@@ -3386,17 +3392,17 @@ msgstr "Cerca lavori in migliaia di aziende, scansionati direttamente dalle pagi
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Cerca lingue…"
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:203
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Cerca sedi…"
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:194
+#: src/components/search/location-search-modal.tsx:278
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Cerca luoghi..."
+
+#. Placeholder for search input in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:288
+msgid "company.locationModal.searchPlaceholder"
+msgstr "Cerca sedi…"
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3406,7 +3412,7 @@ msgstr "Risultati della ricerca"
 
 #. Placeholder for search input in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:192
+#: src/components/search/occupation-modal.tsx:272
 msgid "search.occupationModal.searchPlaceholder"
 msgstr "Cerca ruoli..."
 
@@ -3442,13 +3448,13 @@ msgstr "Seleziona livello"
 
 #. Title for the global location selection modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:174
+#: src/components/search/location-search-modal.tsx:258
 msgid "search.locationModal.title"
 msgstr "Seleziona luogo"
 
 #. Title for the occupation selection modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:172
+#: src/components/search/occupation-modal.tsx:252
 msgid "search.occupationModal.title"
 msgstr "Seleziona ruolo"
 
@@ -3548,16 +3554,16 @@ msgstr "Impostazioni"
 msgid "home.features.s3.p3.title"
 msgstr "Condividi con chiunque"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:355
-msgid "search.detail.showLessLocations"
-msgstr "Mostra meno"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:351
 msgid "company.page.showLess"
+msgstr "Mostra meno"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:355
+msgid "search.detail.showLessLocations"
 msgstr "Mostra meno"
 
 #. Aria label to show password

--- a/apps/web/src/components/search/__tests__/location-search-modal.test.tsx
+++ b/apps/web/src/components/search/__tests__/location-search-modal.test.tsx
@@ -31,6 +31,7 @@ const _response = (overrides: Partial<Awaited<ReturnType<typeof getGlobalLocatio
       abbreviation: "EU",
       count: 146,
       memberCountryNames: ["Germany", "France", "Italy"],
+      memberCountryIds: [100, 101, 102],
     },
     {
       id: 1,
@@ -39,6 +40,7 @@ const _response = (overrides: Partial<Awaited<ReturnType<typeof getGlobalLocatio
       abbreviation: "EMEA",
       count: 1433,
       memberCountryNames: ["Germany", "Saudi Arabia", "Egypt"],
+      memberCountryIds: [100, 110, 111],
     },
     {
       id: 5,
@@ -47,6 +49,7 @@ const _response = (overrides: Partial<Awaited<ReturnType<typeof getGlobalLocatio
       abbreviation: "DACH",
       count: 6,
       memberCountryNames: ["Germany", "Austria", "Switzerland"],
+      memberCountryIds: [100, 120, 121],
     },
   ],
   countries: [
@@ -259,4 +262,87 @@ describe("LocationSearchModal — Regions cluster (#2940)", () => {
 
   // Suppress unused-import lint
   void within;
+});
+
+describe("LocationSearchModal — hierarchical disable (#2978)", () => {
+  /** Country header should appear with `aria-disabled` once a macro that includes it is selected. */
+  it("disables the country header when its macro is selected", async () => {
+    getGlobalLocationsGroupedMock.mockResolvedValue(_response({
+      countries: [
+        {
+          countryId: 100,
+          countrySlug: "germany",
+          countryName: "Germany",
+          countryCount: 50,
+          regions: [
+            {
+              regionId: 0,
+              regionSlug: "",
+              regionName: "",
+              regionCount: 25,
+              locations: [
+                { id: 200, slug: "berlin", name: "Berlin", type: "city", count: 25 },
+              ],
+            },
+          ],
+        },
+      ],
+    }));
+    // EU is selected — Germany (member) and Berlin (descendant) should disable
+    render(
+      <LocationSearchModal
+        open
+        onOpenChange={() => {}}
+        locale="en"
+        selected={[{ id: 4, slug: "eu", name: "European Union", type: "macro", parentName: null }]}
+        onToggle={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("Germany"));
+    const germanyButton = screen.getByText("Germany").closest("button");
+    expect(germanyButton?.getAttribute("aria-disabled")).toBe("true");
+    expect(germanyButton?.getAttribute("tabindex")).toBe("-1");
+    const berlinButton = screen.getByText("Berlin").closest("button");
+    expect(berlinButton?.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  /** Selecting a country auto-deselects its descendants (parity contract). */
+  it("auto-deselects child city when parent country is committed", async () => {
+    getGlobalLocationsGroupedMock.mockResolvedValue(_response());
+    const onToggle = vi.fn();
+    // Pre-select Berlin (a city under Germany)
+    render(
+      <LocationSearchModal
+        open
+        onOpenChange={() => {}}
+        locale="en"
+        selected={[{ id: 200, slug: "berlin", name: "Berlin", type: "city", parentName: "Germany" }]}
+        onToggle={onToggle}
+      />,
+    );
+    await waitFor(() => screen.getByText("Germany"));
+    // Click Germany — should toggle Germany ON and Berlin OFF
+    await userEvent.click(screen.getByText("Germany"));
+    // First call: add Germany. Second call: remove Berlin (auto-deselect).
+    expect(onToggle).toHaveBeenCalledTimes(2);
+    expect(onToggle.mock.calls[0][0]).toMatchObject({ id: 100, type: "country" });
+    expect(onToggle.mock.calls[1][0]).toMatchObject({ id: 200 });
+  });
+
+  /** Selecting a country disables its child cities. */
+  it("disables city pills when their country is selected", async () => {
+    getGlobalLocationsGroupedMock.mockResolvedValue(_response());
+    render(
+      <LocationSearchModal
+        open
+        onOpenChange={() => {}}
+        locale="en"
+        selected={[{ id: 100, slug: "germany", name: "Germany", type: "country", parentName: null }]}
+        onToggle={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("Berlin"));
+    const berlinButton = screen.getByText("Berlin").closest("button");
+    expect(berlinButton?.getAttribute("aria-disabled")).toBe("true");
+  });
 });

--- a/apps/web/src/components/search/__tests__/occupation-modal.test.tsx
+++ b/apps/web/src/components/search/__tests__/occupation-modal.test.tsx
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// Lingui shim — register before imports of Lingui-aware modules.
+import "@/test-utils/lingui-mock";
+
+const getAllOccupationsGroupedMock = vi.fn();
+vi.mock("@/lib/actions/taxonomy", () => ({
+  getAllOccupationsGrouped: (...args: unknown[]) => getAllOccupationsGroupedMock(...args),
+}));
+
+vi.mock("server-only", () => ({}));
+
+import { OccupationModal } from "../occupation-modal";
+
+/**
+ * Mock occupation hierarchy:
+ *   domain "Software Engineering" (id: 10)
+ *     family parent "Software Engineer" (id: 100, parentId: null, domainId: 10)
+ *       child "Frontend Developer" (id: 101, parentId: 100)
+ *       child "Backend Developer" (id: 102, parentId: 100)
+ *     standalone "DevOps Engineer" (id: 200, parentId: null, domainId: 10)
+ */
+const _groups = () => [
+  {
+    domain: { id: 10, slug: "software-engineering", name: "Software Engineering", count: 500 },
+    subGroups: [
+      {
+        parent: {
+          id: 100,
+          slug: "software-engineer",
+          name: "Software Engineer",
+          count: 50,
+          parentId: null,
+          domainId: 10,
+        },
+        children: [
+          { id: 101, slug: "frontend-developer", name: "Frontend Developer", count: 200, parentId: 100, domainId: 10 },
+          { id: 102, slug: "backend-developer", name: "Backend Developer", count: 250, parentId: 100, domainId: 10 },
+        ],
+      },
+    ],
+    standalone: [
+      { id: 200, slug: "devops-engineer", name: "DevOps Engineer", count: 100, parentId: null, domainId: 10 },
+    ],
+  },
+];
+
+beforeEach(() => {
+  getAllOccupationsGroupedMock.mockReset();
+});
+
+describe("OccupationModal — hierarchical disable (#2978)", () => {
+  /** Selecting a family parent disables its children. */
+  it("disables child pills when family parent is selected", async () => {
+    getAllOccupationsGroupedMock.mockResolvedValue(_groups());
+    render(
+      <OccupationModal
+        open
+        onOpenChange={() => {}}
+        locale="en"
+        selected={[{ id: 100, slug: "software-engineer", name: "Software Engineer" }]}
+        onToggle={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("Frontend Developer"));
+    const frontendButton = screen.getByText("Frontend Developer").closest("button");
+    const backendButton = screen.getByText("Backend Developer").closest("button");
+    expect(frontendButton?.getAttribute("aria-disabled")).toBe("true");
+    expect(frontendButton?.getAttribute("tabindex")).toBe("-1");
+    expect(backendButton?.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  /** Selecting the family parent auto-deselects redundant child pills. */
+  it("auto-deselects children when family parent is committed", async () => {
+    getAllOccupationsGroupedMock.mockResolvedValue(_groups());
+    const onToggle = vi.fn();
+    render(
+      <OccupationModal
+        open
+        onOpenChange={() => {}}
+        locale="en"
+        // Pre-select Frontend Developer (a child of Software Engineer)
+        selected={[{ id: 101, slug: "frontend-developer", name: "Frontend Developer" }]}
+        onToggle={onToggle}
+      />,
+    );
+    await waitFor(() => screen.getByText("Software Engineer"));
+    await userEvent.click(screen.getByText("Software Engineer"));
+    // First: add the parent. Second: remove the redundant child.
+    expect(onToggle).toHaveBeenCalledTimes(2);
+    expect(onToggle.mock.calls[0][0]).toMatchObject({ id: 100 });
+    expect(onToggle.mock.calls[1][0]).toMatchObject({ id: 101 });
+  });
+
+  /** Disabled children render with "Included in <ancestorName>" tooltip. */
+  it("renders disabled children with Included-in-ancestor tooltip wrapper", async () => {
+    getAllOccupationsGroupedMock.mockResolvedValue(_groups());
+    const { container } = render(
+      <OccupationModal
+        open
+        onOpenChange={() => {}}
+        locale="en"
+        selected={[{ id: 100, slug: "software-engineer", name: "Software Engineer" }]}
+        onToggle={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("Frontend Developer"));
+    // The disabled pill renders a Radix Tooltip — content lives in a portal.
+    // Smoke check: the trigger button is non-interactive and class shows opacity-50.
+    const frontendButton = screen.getByText("Frontend Developer").closest("button");
+    expect(frontendButton?.className).toContain("opacity-50");
+    expect(frontendButton?.className).toContain("cursor-not-allowed");
+    void container;
+  });
+
+  /** Standalones in the same domain are NOT disabled by selecting another domain peer. */
+  it("does not disable peer standalones when an unrelated parent is selected", async () => {
+    getAllOccupationsGroupedMock.mockResolvedValue(_groups());
+    render(
+      <OccupationModal
+        open
+        onOpenChange={() => {}}
+        locale="en"
+        selected={[{ id: 100, slug: "software-engineer", name: "Software Engineer" }]}
+        onToggle={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("DevOps Engineer"));
+    // DevOps Engineer is a standalone in the same domain — NOT a child of Software Engineer.
+    const devopsButton = screen.getByText("DevOps Engineer").closest("button");
+    expect(devopsButton?.getAttribute("aria-disabled")).toBeNull();
+  });
+});

--- a/apps/web/src/components/search/__tests__/use-disabled-by-ancestor.test.ts
+++ b/apps/web/src/components/search/__tests__/use-disabled-by-ancestor.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import {
+  useDisabledByAncestor,
+  pruneRedundantDescendants,
+} from "../use-disabled-by-ancestor";
+
+describe("useDisabledByAncestor", () => {
+  /**
+   * Tree:
+   *   countryA (1) -> regionA (10) -> cityA (100)
+   *   countryB (2) -> cityB (200)              <- region-less branch
+   *   macroEU (50) covers [countryA, countryB]
+   */
+  const parents = new Map<number, number | null>([
+    [1, null],
+    [10, 1],
+    [100, 10],
+    [2, null],
+    [200, 2],
+    [50, null], // macro is parent-less
+  ]);
+  const macroMembers = new Map<number, readonly number[]>([
+    [50, [1, 2]],
+  ]);
+
+  it("returns isDisabled false when no ancestor is selected", () => {
+    const { result } = renderHook(() =>
+      useDisabledByAncestor({
+        selectedIds: new Set<number>(),
+        parents,
+        macroMembers,
+      }),
+    );
+    expect(result.current.isDisabled(100)).toBe(false);
+    expect(result.current.disabledByAncestor(100)).toBe(null);
+  });
+
+  it("disables city when its country is selected", () => {
+    const { result } = renderHook(() =>
+      useDisabledByAncestor({
+        selectedIds: new Set([1]),
+        parents,
+        macroMembers,
+      }),
+    );
+    expect(result.current.isDisabled(100)).toBe(true);
+    expect(result.current.disabledByAncestor(100)).toBe(1);
+    // Region also disabled (its parent country is selected)
+    expect(result.current.isDisabled(10)).toBe(true);
+    expect(result.current.disabledByAncestor(10)).toBe(1);
+  });
+
+  it("disables city when its region is selected (and region's parent country isn't)", () => {
+    const { result } = renderHook(() =>
+      useDisabledByAncestor({
+        selectedIds: new Set([10]),
+        parents,
+        macroMembers,
+      }),
+    );
+    expect(result.current.isDisabled(100)).toBe(true);
+    expect(result.current.disabledByAncestor(100)).toBe(10);
+    // Country itself is NOT disabled — selection is at the region level
+    expect(result.current.isDisabled(1)).toBe(false);
+  });
+
+  it("does not flag the selected row itself as disabled", () => {
+    const { result } = renderHook(() =>
+      useDisabledByAncestor({
+        selectedIds: new Set([1]),
+        parents,
+        macroMembers,
+      }),
+    );
+    expect(result.current.isDisabled(1)).toBe(false);
+  });
+
+  it("disables member countries (and transitively their descendants) when a macro is selected", () => {
+    const { result } = renderHook(() =>
+      useDisabledByAncestor({
+        selectedIds: new Set([50]),
+        parents,
+        macroMembers,
+      }),
+    );
+    // Member country
+    expect(result.current.isDisabled(1)).toBe(true);
+    expect(result.current.disabledByAncestor(1)).toBe(50);
+    // Region inside member country (transitive)
+    expect(result.current.isDisabled(10)).toBe(true);
+    expect(result.current.disabledByAncestor(10)).toBe(50);
+    // City three levels down
+    expect(result.current.isDisabled(100)).toBe(true);
+    // Other member country
+    expect(result.current.isDisabled(2)).toBe(true);
+    // City under the second member country
+    expect(result.current.isDisabled(200)).toBe(true);
+    // Macro itself isn't disabled (it's the selected row)
+    expect(result.current.isDisabled(50)).toBe(false);
+  });
+
+  it("handles cycle in the parent chain without infinite-looping", () => {
+    const cyclic = new Map<number, number | null>([
+      [1, 2],
+      [2, 3],
+      [3, 1], // cycle 1 -> 2 -> 3 -> 1
+    ]);
+    const { result } = renderHook(() =>
+      useDisabledByAncestor({
+        selectedIds: new Set<number>(),
+        parents: cyclic,
+      }),
+    );
+    expect(result.current.isDisabled(1)).toBe(false);
+  });
+});
+
+describe("pruneRedundantDescendants", () => {
+  const parents = new Map<number, number | null>([
+    [1, null],
+    [10, 1],
+    [100, 10],
+    [2, null],
+    [200, 2],
+  ]);
+  const macroMembers = new Map<number, readonly number[]>([
+    [50, [1, 2]],
+  ]);
+
+  it("drops descendants when a parent is committed in the same array", () => {
+    const items = [
+      { id: 1, name: "Country A" },
+      { id: 100, name: "City under A" },
+      { id: 2, name: "Country B" },
+    ];
+    const kept = pruneRedundantDescendants(items, parents, macroMembers);
+    expect(kept.map((i) => i.id)).toEqual([1, 2]);
+  });
+
+  it("drops cities under a macro's member country", () => {
+    const items = [
+      { id: 50, name: "EU" },
+      { id: 100, name: "City under member country A" },
+      { id: 200, name: "City under member country B" },
+    ];
+    const kept = pruneRedundantDescendants(items, parents, macroMembers);
+    expect(kept.map((i) => i.id)).toEqual([50]);
+  });
+
+  it("preserves siblings that are not ancestors of each other", () => {
+    const items = [
+      { id: 100, name: "City under A" },
+      { id: 200, name: "City under B" },
+    ];
+    const kept = pruneRedundantDescendants(items, parents, macroMembers);
+    expect(kept.map((i) => i.id)).toEqual([100, 200]);
+  });
+});

--- a/apps/web/src/components/search/disabled-filter-pill.tsx
+++ b/apps/web/src/components/search/disabled-filter-pill.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { Trans } from "@lingui/react/macro";
+import { tooltipClass } from "@/components/ui/tooltip-styles";
+
+interface DisabledFilterPillProps {
+  /** Display name (e.g. "Berlin"). */
+  name: string;
+  /** Active posting count for the row. Rendered as `(count)`. */
+  count?: number;
+  /** Localized name of the ancestor causing the disable. */
+  ancestorName: string;
+  /**
+   * Variant — `pill` (default rounded chip), `parent` (sub-group parent
+   * header inside the occupation modal), `country` (uppercase country
+   * header in the location modal), or `region` (region sub-header).
+   * Each variant matches the visual treatment of its enabled counterpart
+   * in the original modal so the disabled state reads as a state
+   * transition rather than a different element.
+   */
+  variant?: "pill" | "parent" | "country" | "region" | "domain";
+  /** Optional left-side icon (e.g. country flag). Only rendered for `country` variant. */
+  leftAdornment?: React.ReactNode;
+  /** Auxiliary count rendered after the name (e.g. parent + children sum). */
+  auxText?: string;
+}
+
+/**
+ * Greyed, non-interactive pill rendered when an ancestor filter
+ * subsumes this row. Conveys "you can't add this — it's already
+ * implied" via opacity, tooltip, and aria-disabled. Click is a no-op.
+ *
+ * Hierarchical filter UX (#2978).
+ */
+export function DisabledFilterPill({
+  name,
+  count,
+  ancestorName,
+  variant = "pill",
+  leftAdornment,
+  auxText,
+}: DisabledFilterPillProps) {
+  const baseClass = (() => {
+    switch (variant) {
+      case "country":
+        return "mb-2 cursor-not-allowed text-xs font-semibold uppercase tracking-wider text-muted opacity-50";
+      case "region":
+        return "mb-1.5 cursor-not-allowed text-xs font-medium text-muted opacity-50";
+      case "domain":
+        return "cursor-not-allowed text-xs font-semibold uppercase tracking-wider text-muted opacity-50";
+      case "parent":
+        return "mb-1.5 cursor-not-allowed text-sm font-medium text-foreground opacity-50";
+      case "pill":
+      default:
+        return "inline-flex cursor-not-allowed items-center gap-1 rounded-full border border-border-soft px-3 py-1 text-sm text-muted opacity-50";
+    }
+  })();
+
+  return (
+    <Tooltip.Provider delayDuration={150}>
+      <Tooltip.Root>
+        <Tooltip.Trigger asChild>
+          <button
+            type="button"
+            aria-disabled
+            tabIndex={-1}
+            onClick={(e) => e.preventDefault()}
+            className={baseClass}
+          >
+            {leftAdornment}
+            <span>{name}</span>
+            {auxText && (
+              <span className="ml-1 text-xs font-normal text-muted">{auxText}</span>
+            )}
+            {count != null && variant === "pill" && (
+              <span className="text-xs text-muted">({count})</span>
+            )}
+            {count != null && (variant === "country" || variant === "region" || variant === "domain") && (
+              <span className="ml-1 text-[10px] font-normal normal-case text-muted">({count})</span>
+            )}
+          </button>
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content className={tooltipClass} sideOffset={6}>
+            <Trans
+              id="search.filterModal.includedInAncestor"
+              comment="Tooltip on a disabled filter pill explaining the row is implied by an already-selected ancestor (e.g. 'Included in European Union' when EU is selected)."
+            >
+              Included in {ancestorName}
+            </Trans>
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+    </Tooltip.Provider>
+  );
+}

--- a/apps/web/src/components/search/location-modal.tsx
+++ b/apps/web/src/components/search/location-modal.tsx
@@ -15,6 +15,8 @@ import { countryIso } from "@/lib/country-flags";
 import { CountryFlag } from "@/components/country-flag";
 import { findBestGuess } from "./best-guess";
 import { ScrollFade } from "@/components/ui/scroll-fade";
+import { useDisabledByAncestor } from "./use-disabled-by-ancestor";
+import { DisabledFilterPill } from "./disabled-filter-pill";
 
 /** Threshold: show region sub-headers when a country has more cities than this. */
 const REGION_THRESHOLD = 8;
@@ -109,13 +111,96 @@ export function LocationModal({
       .filter((g): g is GroupedCompanyLocations => g !== null);
   }, [response, search]);
 
+  // Build hierarchy maps from the loaded response. Same shape as the
+  // global modal — see use-disabled-by-ancestor.ts for the contract.
+  const parentMap = useMemo(() => {
+    const map = new Map<number, number | null>();
+    if (!response) return map;
+    for (const country of response.countries) {
+      if (country.countryId > 0) map.set(country.countryId, null);
+      for (const region of country.regions) {
+        if (region.regionId > 0 && country.countryId > 0) {
+          map.set(region.regionId, country.countryId);
+        }
+        for (const loc of region.locations) {
+          map.set(
+            loc.id,
+            region.regionId > 0 ? region.regionId : country.countryId > 0 ? country.countryId : null,
+          );
+        }
+      }
+    }
+    return map;
+  }, [response]);
+
+  const macroMembersMap = useMemo(() => {
+    const map = new Map<number, number[]>();
+    if (!response) return map;
+    for (const macro of response.macros) {
+      map.set(macro.id, macro.memberCountryIds ?? []);
+    }
+    return map;
+  }, [response]);
+
+  const { isDisabled, disabledByAncestor } = useDisabledByAncestor({
+    selectedIds: activeLocationIds,
+    parents: parentMap,
+    macroMembers: macroMembersMap,
+  });
+
+  const nameById = useMemo(() => {
+    const map = new Map<number, string>();
+    if (!response) return map;
+    for (const macro of response.macros) map.set(macro.id, macro.name);
+    for (const country of response.countries) {
+      if (country.countryId > 0) map.set(country.countryId, country.countryName);
+      for (const region of country.regions) {
+        if (region.regionId > 0) map.set(region.regionId, region.regionName);
+        for (const loc of region.locations) map.set(loc.id, loc.name);
+      }
+    }
+    return map;
+  }, [response]);
+
+  const ancestorNameOf = useCallback((id: number): string => {
+    const ancId = disabledByAncestor(id);
+    if (ancId == null) return "";
+    return nameById.get(ancId) ?? "";
+  }, [disabledByAncestor, nameById]);
+
   const toggleLocation = useCallback((loc: { id: number; slug: string; name: string; type: string }) => {
     if (activeLocationIds.has(loc.id)) {
       onFiltersChange(filters.filter((f) => !(f.kind === "location" && f.id === loc.id)));
-    } else {
-      onFiltersChange([...filters, { kind: "location", id: loc.id, slug: loc.slug, name: loc.name, type: loc.type }]);
+      return;
     }
-  }, [activeLocationIds, filters, onFiltersChange]);
+    // Selecting a parent: remove redundant descendants from the filters
+    // so the chip strip doesn't carry stale selections that would render
+    // as disabled-but-selected.
+    const next: FilterItem[] = [
+      ...filters,
+      { kind: "location", id: loc.id, slug: loc.slug, name: loc.name, type: loc.type },
+    ];
+    // Find descendants of `loc.id` in current selection. A descendant is
+    // anything whose parent chain reaches `loc.id`, OR (when `loc` is a
+    // macro) any country in macroMembers + their descendants.
+    const subsumed = new Set<number>();
+    const macroChildren = macroMembersMap.get(loc.id);
+    if (macroChildren) {
+      for (const cid of macroChildren) subsumed.add(cid);
+    }
+    for (const id of activeLocationIds) {
+      let cur = parentMap.get(id);
+      const seen = new Set<number>([id]);
+      while (cur != null && !seen.has(cur)) {
+        seen.add(cur);
+        if (cur === loc.id) { subsumed.add(id); break; }
+        if (subsumed.has(cur)) { subsumed.add(id); break; }
+        cur = parentMap.get(cur);
+      }
+    }
+    const cleaned = next.filter((f) => f.kind !== "location" || !subsumed.has(f.id));
+    onFiltersChange(cleaned);
+  }, [activeLocationIds, filters, onFiltersChange, parentMap, macroMembersMap]);
 
   /** Total city count across all regions in a country. */
   function countCities(country: GroupedCompanyLocations) {
@@ -238,6 +323,16 @@ export function LocationModal({
                     <div className="flex flex-wrap gap-2">
                       {filteredMacros.map((macro) => {
                         const active = activeLocationIds.has(macro.id);
+                        if (!active && isDisabled(macro.id)) {
+                          return (
+                            <DisabledFilterPill
+                              key={macro.id}
+                              name={macro.name}
+                              count={macro.count}
+                              ancestorName={ancestorNameOf(macro.id)}
+                            />
+                          );
+                        }
                         const tooltip = macro.memberCountryNames.length > 0
                           ? macro.memberCountryNames.join(", ")
                           : undefined;
@@ -269,31 +364,44 @@ export function LocationModal({
                 )}
                 {filtered.map((country) => {
                   const countryActive = country.countryId > 0 && activeLocationIds.has(country.countryId);
+                  const countryDisabled = country.countryId > 0 && !countryActive && isDisabled(country.countryId);
                   const showRegions = countCities(country) > REGION_THRESHOLD;
 
                   return (
                     <div key={country.countryId}>
                       {/* Country header */}
                       {country.countryId > 0 ? (
-                        <button
-                          onClick={() => toggleLocation({
-                            id: country.countryId,
-                            slug: country.countrySlug,
-                            name: country.countryName,
-                            type: "country",
-                          })}
-                          className={`mb-2 cursor-pointer text-xs font-semibold uppercase tracking-wider transition-colors ${
-                            countryActive ? "text-primary" : "text-muted hover:text-foreground"
-                          }`}
-                        >
-                          <CountryFlag iso={countryIso(country.countryId)} size={14} className="mr-1 inline-block align-middle" />
-                          <span className={countryActive ? "underline" : ""}>{country.countryName}</span>
-                          {country.countryCount > 0 && (
-                            <span className={`ml-1 text-[10px] font-normal normal-case ${countryActive ? "text-primary/70" : "text-muted"}`}>
-                              ({country.countryCount})
-                            </span>
-                          )}
-                        </button>
+                        countryDisabled ? (
+                          <DisabledFilterPill
+                            name={country.countryName}
+                            count={country.countryCount > 0 ? country.countryCount : undefined}
+                            ancestorName={ancestorNameOf(country.countryId)}
+                            variant="country"
+                            leftAdornment={
+                              <CountryFlag iso={countryIso(country.countryId)} size={14} className="mr-1 inline-block align-middle" />
+                            }
+                          />
+                        ) : (
+                          <button
+                            onClick={() => toggleLocation({
+                              id: country.countryId,
+                              slug: country.countrySlug,
+                              name: country.countryName,
+                              type: "country",
+                            })}
+                            className={`mb-2 cursor-pointer text-xs font-semibold uppercase tracking-wider transition-colors ${
+                              countryActive ? "text-primary" : "text-muted hover:text-foreground"
+                            }`}
+                          >
+                            <CountryFlag iso={countryIso(country.countryId)} size={14} className="mr-1 inline-block align-middle" />
+                            <span className={countryActive ? "underline" : ""}>{country.countryName}</span>
+                            {country.countryCount > 0 && (
+                              <span className={`ml-1 text-[10px] font-normal normal-case ${countryActive ? "text-primary/70" : "text-muted"}`}>
+                                ({country.countryCount})
+                              </span>
+                            )}
+                          </button>
+                        )
                       ) : (
                         <h3 className="mb-2 text-xs font-semibold uppercase tracking-wider text-muted">
                           <CountryFlag iso={countryIso(country.countryId)} size={14} className="mr-1 inline-block align-middle" />
@@ -307,27 +415,37 @@ export function LocationModal({
                           {country.regions.map((region) => {
                             if (region.locations.length === 0) return null;
                             const regionActive = region.regionId > 0 && activeLocationIds.has(region.regionId);
+                            const regionDisabled = region.regionId > 0 && !regionActive && isDisabled(region.regionId);
                             return (
                               <div key={region.regionId}>
                                 {region.regionId > 0 ? (
-                                  <button
-                                    onClick={() => toggleLocation({
-                                      id: region.regionId,
-                                      slug: region.regionSlug,
-                                      name: region.regionName,
-                                      type: "region",
-                                    })}
-                                    className={`mb-1.5 cursor-pointer text-xs font-medium transition-colors ${
-                                      regionActive ? "text-primary" : "text-muted hover:text-foreground"
-                                    }`}
-                                  >
-                                    <span className={regionActive ? "underline" : ""}>{region.regionName}</span>
-                                    {region.regionCount > 0 && (
-                                      <span className={`ml-1 text-[10px] font-normal ${regionActive ? "text-primary/70" : "text-muted"}`}>
-                                        ({region.regionCount})
-                                      </span>
-                                    )}
-                                  </button>
+                                  regionDisabled ? (
+                                    <DisabledFilterPill
+                                      name={region.regionName}
+                                      count={region.regionCount > 0 ? region.regionCount : undefined}
+                                      ancestorName={ancestorNameOf(region.regionId)}
+                                      variant="region"
+                                    />
+                                  ) : (
+                                    <button
+                                      onClick={() => toggleLocation({
+                                        id: region.regionId,
+                                        slug: region.regionSlug,
+                                        name: region.regionName,
+                                        type: "region",
+                                      })}
+                                      className={`mb-1.5 cursor-pointer text-xs font-medium transition-colors ${
+                                        regionActive ? "text-primary" : "text-muted hover:text-foreground"
+                                      }`}
+                                    >
+                                      <span className={regionActive ? "underline" : ""}>{region.regionName}</span>
+                                      {region.regionCount > 0 && (
+                                        <span className={`ml-1 text-[10px] font-normal ${regionActive ? "text-primary/70" : "text-muted"}`}>
+                                          ({region.regionCount})
+                                        </span>
+                                      )}
+                                    </button>
+                                  )
                                 ) : (
                                   <span className="mb-1.5 block text-xs font-medium text-muted">
                                     {region.regionName || "Other"}
@@ -336,6 +454,16 @@ export function LocationModal({
                                 <div className="flex flex-wrap gap-2">
                                   {region.locations.map((loc) => {
                                     const active = activeLocationIds.has(loc.id);
+                                    if (!active && isDisabled(loc.id)) {
+                                      return (
+                                        <DisabledFilterPill
+                                          key={loc.id}
+                                          name={loc.name}
+                                          count={loc.count}
+                                          ancestorName={ancestorNameOf(loc.id)}
+                                        />
+                                      );
+                                    }
                                     return (
                                       <button
                                         key={loc.id}
@@ -364,6 +492,16 @@ export function LocationModal({
                           {country.regions.flatMap((region) =>
                             region.locations.map((loc) => {
                               const active = activeLocationIds.has(loc.id);
+                              if (!active && isDisabled(loc.id)) {
+                                return (
+                                  <DisabledFilterPill
+                                    key={loc.id}
+                                    name={loc.name}
+                                    count={loc.count}
+                                    ancestorName={ancestorNameOf(loc.id)}
+                                  />
+                                );
+                              }
                               return (
                                 <button
                                   key={loc.id}

--- a/apps/web/src/components/search/location-search-modal.tsx
+++ b/apps/web/src/components/search/location-search-modal.tsx
@@ -10,6 +10,8 @@ import { countryIso } from "@/lib/country-flags";
 import { CountryFlag } from "@/components/country-flag";
 import { findBestGuess } from "./best-guess";
 import { ScrollFade } from "@/components/ui/scroll-fade";
+import { useDisabledByAncestor, pruneRedundantDescendants } from "./use-disabled-by-ancestor";
+import { DisabledFilterPill } from "./disabled-filter-pill";
 
 /** Show region sub-headers when a country has more cities than this. */
 const REGION_THRESHOLD = 8;
@@ -41,6 +43,88 @@ export function LocationSearchModal({
   const warningTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const selectedIds = useMemo(() => new Set(selected.map((s) => s.id)), [selected]);
+
+  // Build parent map: city.parent = region (or country if no region),
+  // region.parent = country, country.parent = null. Macros are NOT in
+  // the parent chain — they're consulted via the macroMembers side-channel.
+  const parentMap = useMemo(() => {
+    const map = new Map<number, number | null>();
+    if (!response) return map;
+    for (const country of response.countries) {
+      map.set(country.countryId, null);
+      for (const region of country.regions) {
+        if (region.regionId > 0) {
+          map.set(region.regionId, country.countryId);
+        }
+        for (const loc of region.locations) {
+          // Cities parent to region if present, else direct to country.
+          map.set(loc.id, region.regionId > 0 ? region.regionId : country.countryId);
+        }
+      }
+    }
+    return map;
+  }, [response]);
+
+  const macroMembersMap = useMemo(() => {
+    const map = new Map<number, number[]>();
+    if (!response) return map;
+    for (const macro of response.macros) {
+      map.set(macro.id, macro.memberCountryIds ?? []);
+    }
+    return map;
+  }, [response]);
+
+  const { isDisabled, disabledByAncestor } = useDisabledByAncestor({
+    selectedIds,
+    parents: parentMap,
+    macroMembers: macroMembersMap,
+  });
+
+  // Lookup table id -> localized name, used to render the
+  // "Included in <ancestor>" tooltip without re-walking the response.
+  const nameById = useMemo(() => {
+    const map = new Map<number, string>();
+    if (!response) return map;
+    for (const macro of response.macros) {
+      map.set(macro.id, macro.name);
+    }
+    for (const country of response.countries) {
+      map.set(country.countryId, country.countryName);
+      for (const region of country.regions) {
+        if (region.regionId > 0) map.set(region.regionId, region.regionName);
+        for (const loc of region.locations) map.set(loc.id, loc.name);
+      }
+    }
+    return map;
+  }, [response]);
+
+  const ancestorNameOf = useCallback((id: number): string => {
+    const ancId = disabledByAncestor(id);
+    if (ancId == null) return "";
+    return nameById.get(ancId) ?? "";
+  }, [disabledByAncestor, nameById]);
+
+  // Wraps the caller's onToggle. After the parent commits, drop any
+  // already-selected descendants that have just become redundant — keeps
+  // the filter chip strip clean.
+  const handleToggle = useCallback((loc: SelectedLocation) => {
+    const wasSelected = selectedIds.has(loc.id);
+    onToggle(loc);
+    if (wasSelected) return;
+    // Find descendants in the current selection that this commit
+    // subsumes, and toggle them off. The `pruneRedundantDescendants`
+    // helper computes the keep-set; anything not in the keep-set must
+    // be deselected by re-emitting onToggle for it.
+    const nextSelected = [...selected, loc];
+    const kept = pruneRedundantDescendants(nextSelected, parentMap, macroMembersMap);
+    const keptIds = new Set(kept.map((s) => s.id));
+    for (const s of selected) {
+      if (!keptIds.has(s.id)) {
+        // descendant of `loc` (or another selection) — drop it
+        onToggle(s);
+      }
+    }
+  }, [onToggle, parentMap, macroMembersMap, selected, selectedIds]);
 
   const filtersKey = filters ? JSON.stringify(filters) : "";
   const prevFiltersKeyRef = useRef(filtersKey);
@@ -229,13 +313,27 @@ export function LocationSearchModal({
                     <div className="flex flex-wrap gap-2">
                       {filteredMacros.map((macro) => {
                         const active = selectedIds.has(macro.id);
+                        // Macros never have ancestors in our model — only members.
+                        // So `isDisabled(macro.id)` is always false today; left in
+                        // for future-proofing if macro -> super-macro relationships
+                        // are added.
+                        if (isDisabled(macro.id) && !active) {
+                          return (
+                            <DisabledFilterPill
+                              key={macro.id}
+                              name={macro.name}
+                              count={macro.count}
+                              ancestorName={ancestorNameOf(macro.id)}
+                            />
+                          );
+                        }
                         const tooltip = macro.memberCountryNames.length > 0
                           ? macro.memberCountryNames.join(", ")
                           : undefined;
                         return (
                           <button
                             key={macro.id}
-                            onClick={() => onToggle({
+                            onClick={() => handleToggle({
                               id: macro.id,
                               slug: macro.slug,
                               name: macro.name,
@@ -261,63 +359,86 @@ export function LocationSearchModal({
                 )}
                 {filtered.map((country) => {
                   const countryActive = selectedIds.has(country.countryId);
+                  const countryDisabled = !countryActive && isDisabled(country.countryId);
                   const showRegions = countCities(country) > REGION_THRESHOLD;
 
                   return (
                     <div key={country.countryId}>
                       {/* Country header */}
-                      <button
-                        onClick={() =>
-                          onToggle({
-                            id: country.countryId,
-                            slug: country.countrySlug,
-                            name: country.countryName,
-                            type: "country",
-                            parentName: null,
-                          })
-                        }
-                        className={`mb-2 cursor-pointer text-xs font-semibold uppercase tracking-wider transition-colors ${
-                          countryActive ? "text-primary" : "text-muted hover:text-foreground"
-                        }`}
-                      >
-                        <CountryFlag iso={countryIso(country.countryId)} size={14} className="mr-1 inline-block align-middle" />
-                        <span className={countryActive ? "underline" : ""}>{country.countryName}</span>
-                        {country.countryCount > 0 && (
-                          <span className={`ml-1 text-[10px] font-normal normal-case ${countryActive ? "text-primary/70" : "text-muted"}`}>
-                            ({country.countryCount})
-                          </span>
-                        )}
-                      </button>
+                      {countryDisabled ? (
+                        <DisabledFilterPill
+                          name={country.countryName}
+                          count={country.countryCount > 0 ? country.countryCount : undefined}
+                          ancestorName={ancestorNameOf(country.countryId)}
+                          variant="country"
+                          leftAdornment={
+                            <CountryFlag iso={countryIso(country.countryId)} size={14} className="mr-1 inline-block align-middle" />
+                          }
+                        />
+                      ) : (
+                        <button
+                          onClick={() =>
+                            handleToggle({
+                              id: country.countryId,
+                              slug: country.countrySlug,
+                              name: country.countryName,
+                              type: "country",
+                              parentName: null,
+                            })
+                          }
+                          className={`mb-2 cursor-pointer text-xs font-semibold uppercase tracking-wider transition-colors ${
+                            countryActive ? "text-primary" : "text-muted hover:text-foreground"
+                          }`}
+                        >
+                          <CountryFlag iso={countryIso(country.countryId)} size={14} className="mr-1 inline-block align-middle" />
+                          <span className={countryActive ? "underline" : ""}>{country.countryName}</span>
+                          {country.countryCount > 0 && (
+                            <span className={`ml-1 text-[10px] font-normal normal-case ${countryActive ? "text-primary/70" : "text-muted"}`}>
+                              ({country.countryCount})
+                            </span>
+                          )}
+                        </button>
+                      )}
 
                       {showRegions ? (
                         <div className="space-y-3 pl-2">
                           {country.regions.map((region) => {
                             if (region.locations.length === 0) return null;
                             const regionActive = region.regionId > 0 && selectedIds.has(region.regionId);
+                            const regionDisabled = region.regionId > 0 && !regionActive && isDisabled(region.regionId);
                             return (
                               <div key={region.regionId}>
                                 {region.regionId > 0 ? (
-                                  <button
-                                    onClick={() =>
-                                      onToggle({
-                                        id: region.regionId,
-                                        slug: region.regionSlug,
-                                        name: region.regionName,
-                                        type: "region",
-                                        parentName: country.countryName,
-                                      })
-                                    }
-                                    className={`mb-1.5 cursor-pointer text-xs font-medium transition-colors ${
-                                      regionActive ? "text-primary" : "text-muted hover:text-foreground"
-                                    }`}
-                                  >
-                                    <span className={regionActive ? "underline" : ""}>{region.regionName}</span>
-                                    {region.regionCount > 0 && (
-                                      <span className={`ml-1 text-[10px] font-normal ${regionActive ? "text-primary/70" : "text-muted"}`}>
-                                        ({region.regionCount})
-                                      </span>
-                                    )}
-                                  </button>
+                                  regionDisabled ? (
+                                    <DisabledFilterPill
+                                      name={region.regionName}
+                                      count={region.regionCount > 0 ? region.regionCount : undefined}
+                                      ancestorName={ancestorNameOf(region.regionId)}
+                                      variant="region"
+                                    />
+                                  ) : (
+                                    <button
+                                      onClick={() =>
+                                        handleToggle({
+                                          id: region.regionId,
+                                          slug: region.regionSlug,
+                                          name: region.regionName,
+                                          type: "region",
+                                          parentName: country.countryName,
+                                        })
+                                      }
+                                      className={`mb-1.5 cursor-pointer text-xs font-medium transition-colors ${
+                                        regionActive ? "text-primary" : "text-muted hover:text-foreground"
+                                      }`}
+                                    >
+                                      <span className={regionActive ? "underline" : ""}>{region.regionName}</span>
+                                      {region.regionCount > 0 && (
+                                        <span className={`ml-1 text-[10px] font-normal ${regionActive ? "text-primary/70" : "text-muted"}`}>
+                                          ({region.regionCount})
+                                        </span>
+                                      )}
+                                    </button>
+                                  )
                                 ) : (
                                   <span className="mb-1.5 block text-xs font-medium text-muted">
                                     {region.regionName || "Other"}
@@ -326,10 +447,20 @@ export function LocationSearchModal({
                                 <div className="flex flex-wrap gap-2">
                                   {region.locations.map((loc) => {
                                     const active = selectedIds.has(loc.id);
+                                    if (!active && isDisabled(loc.id)) {
+                                      return (
+                                        <DisabledFilterPill
+                                          key={loc.id}
+                                          name={loc.name}
+                                          count={loc.count}
+                                          ancestorName={ancestorNameOf(loc.id)}
+                                        />
+                                      );
+                                    }
                                     return (
                                       <button
                                         key={loc.id}
-                                        onClick={() => onToggle({ ...loc, parentName: region.regionName || country.countryName })}
+                                        onClick={() => handleToggle({ ...loc, parentName: region.regionName || country.countryName })}
                                         className={`inline-flex cursor-pointer items-center gap-1 rounded-full px-3 py-1 text-sm transition-colors ${
                                           active
                                             ? "bg-primary/10 text-primary"
@@ -353,10 +484,20 @@ export function LocationSearchModal({
                           {country.regions.flatMap((region) =>
                             region.locations.map((loc) => {
                               const active = selectedIds.has(loc.id);
+                              if (!active && isDisabled(loc.id)) {
+                                return (
+                                  <DisabledFilterPill
+                                    key={loc.id}
+                                    name={loc.name}
+                                    count={loc.count}
+                                    ancestorName={ancestorNameOf(loc.id)}
+                                  />
+                                );
+                              }
                               return (
                                 <button
                                   key={loc.id}
-                                  onClick={() => onToggle({ ...loc, parentName: region.regionName || country.countryName })}
+                                  onClick={() => handleToggle({ ...loc, parentName: region.regionName || country.countryName })}
                                   className={`inline-flex cursor-pointer items-center gap-1 rounded-full px-3 py-1 text-sm transition-colors ${
                                     active
                                       ? "bg-primary/10 text-primary"

--- a/apps/web/src/components/search/occupation-modal.tsx
+++ b/apps/web/src/components/search/occupation-modal.tsx
@@ -8,6 +8,8 @@ import { getAllOccupationsGrouped } from "@/lib/actions/taxonomy";
 import type { OccupationGroup, OccupationItem } from "@/lib/actions/taxonomy";
 import { findBestGuess } from "./best-guess";
 import { ScrollFade } from "@/components/ui/scroll-fade";
+import { useDisabledByAncestor } from "./use-disabled-by-ancestor";
+import { DisabledFilterPill } from "./disabled-filter-pill";
 
 interface OccupationModalProps {
   open: boolean;
@@ -34,6 +36,74 @@ export function OccupationModal({
   const warningTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const selectedIds = useMemo(() => new Set(selected.map((s) => s.id)), [selected]);
+
+  // Build occupation -> parent map from the loaded groups. Family
+  // parents are top-level (parentId: null) within their domain; children
+  // point to the family parent's id. Standalones are top-level with no
+  // parent. Hook walks this chain to compute disable state.
+  const parentMap = useMemo(() => {
+    const map = new Map<number, number | null>();
+    if (!groups) return map;
+    for (const group of groups) {
+      for (const sg of group.subGroups) {
+        map.set(sg.parent.id, null);
+        for (const child of sg.children) {
+          map.set(child.id, sg.parent.id);
+        }
+      }
+      for (const item of group.standalone) {
+        map.set(item.id, null);
+      }
+    }
+    return map;
+  }, [groups]);
+
+  const { isDisabled, disabledByAncestor } = useDisabledByAncestor({
+    selectedIds,
+    parents: parentMap,
+  });
+
+  const nameById = useMemo(() => {
+    const map = new Map<number, string>();
+    if (!groups) return map;
+    for (const group of groups) {
+      for (const sg of group.subGroups) {
+        map.set(sg.parent.id, sg.parent.name);
+        for (const child of sg.children) map.set(child.id, child.name);
+      }
+      for (const item of group.standalone) map.set(item.id, item.name);
+    }
+    return map;
+  }, [groups]);
+
+  const ancestorNameOf = useCallback((id: number): string => {
+    const ancId = disabledByAncestor(id);
+    if (ancId == null) return "";
+    return nameById.get(ancId) ?? "";
+  }, [disabledByAncestor, nameById]);
+
+  /**
+   * Wrap onToggle so that selecting a family parent auto-deselects any
+   * children currently in `selected`. Parity with the location modals.
+   */
+  const handleToggle = useCallback((item: { id: number; slug: string; name: string }) => {
+    const wasSelected = selectedIds.has(item.id);
+    onToggle(item);
+    if (wasSelected) return;
+    // Find children of `item` currently in selection and toggle them off.
+    for (const s of selected) {
+      let cur = parentMap.get(s.id);
+      const seen = new Set<number>([s.id]);
+      while (cur != null && !seen.has(cur)) {
+        seen.add(cur);
+        if (cur === item.id) {
+          onToggle(s);
+          break;
+        }
+        cur = parentMap.get(cur);
+      }
+    }
+  }, [onToggle, selected, selectedIds, parentMap]);
 
   const filtersKey = filters ? JSON.stringify(filters) : "";
   const prevFiltersKeyRef = useRef(filtersKey);
@@ -140,10 +210,20 @@ export function OccupationModal({
 
   function renderPill(item: OccupationItem) {
     const active = selectedIds.has(item.id);
+    if (!active && isDisabled(item.id)) {
+      return (
+        <DisabledFilterPill
+          key={item.id}
+          name={item.name}
+          count={item.count}
+          ancestorName={ancestorNameOf(item.id)}
+        />
+      );
+    }
     return (
       <button
         key={item.id}
-        onClick={() => onToggle(item)}
+        onClick={() => handleToggle(item)}
         className={`inline-flex cursor-pointer items-center gap-1 rounded-full px-3 py-1 text-sm transition-colors ${
           active
             ? "bg-primary/10 text-primary"
@@ -242,20 +322,31 @@ export function OccupationModal({
                       {/* Sub-groups (parent + children) */}
                       {group.subGroups.map((sg) => {
                         const parentActive = selectedIds.has(sg.parent.id);
+                        const parentDisabled = !parentActive && isDisabled(sg.parent.id);
+                        const totalCount = sg.parent.count + sg.children.reduce((s, c) => s + c.count, 0);
                         return (
                           <div key={sg.parent.id} className="mb-3 rounded-lg border border-border-soft p-3">
                             {/* Parent header */}
-                            <button
-                              onClick={() => onToggle(sg.parent)}
-                              className={`group/parent mb-1.5 cursor-pointer text-sm font-medium transition-colors ${
-                                parentActive ? "text-primary" : "text-foreground hover:text-primary"
-                              }`}
-                            >
-                              <span className={parentActive ? "underline" : "group-hover/parent:underline"}>{sg.parent.name}</span>
-                              <span className={`ml-1 text-xs font-normal ${parentActive ? "text-primary/70" : "text-muted"}`}>
-                                ({sg.parent.count + sg.children.reduce((s, c) => s + c.count, 0)})
-                              </span>
-                            </button>
+                            {parentDisabled ? (
+                              <DisabledFilterPill
+                                name={sg.parent.name}
+                                ancestorName={ancestorNameOf(sg.parent.id)}
+                                variant="parent"
+                                auxText={`(${totalCount})`}
+                              />
+                            ) : (
+                              <button
+                                onClick={() => handleToggle(sg.parent)}
+                                className={`group/parent mb-1.5 cursor-pointer text-sm font-medium transition-colors ${
+                                  parentActive ? "text-primary" : "text-foreground hover:text-primary"
+                                }`}
+                              >
+                                <span className={parentActive ? "underline" : "group-hover/parent:underline"}>{sg.parent.name}</span>
+                                <span className={`ml-1 text-xs font-normal ${parentActive ? "text-primary/70" : "text-muted"}`}>
+                                  ({totalCount})
+                                </span>
+                              </button>
+                            )}
                             {/* Child pills */}
                             <div className="flex flex-wrap gap-2">
                               {sg.children.map(renderPill)}

--- a/apps/web/src/components/search/use-disabled-by-ancestor.ts
+++ b/apps/web/src/components/search/use-disabled-by-ancestor.ts
@@ -1,0 +1,178 @@
+/**
+ * Shared "disabled-by-ancestor" hook for hierarchical filter modals
+ * (locations + occupations). Given the currently-selected filter IDs and
+ * a parent map, computes whether each ID would be redundant — i.e. some
+ * ancestor in its chain is already selected.
+ *
+ * Returns:
+ * - `isDisabled(id)` — true when any transitive ancestor of `id` is
+ *   present in `selectedIds`. Self-membership is NOT a disable: a
+ *   selected pill renders as active, not greyed.
+ * - `disabledByAncestor(id)` — the ID of the nearest ancestor that
+ *   triggered the disable (so the caller can look up its name). `null`
+ *   when the row is not disabled.
+ *
+ * Two ancestor sources are walked, in this order:
+ * 1. The plain `parents` map (id -> parentId | null) — covers
+ *    country -> region -> city and occupation domain -> family-parent
+ *    -> child.
+ * 2. The optional `macroMembers` map (macroId -> [memberCountryIds]) —
+ *    covers macro -> country, which is NOT a tree edge in the location
+ *    parent_id schema (countries don't have a single macro parent;
+ *    macros are membership rather than containment).
+ *
+ * Macros walked first by virtue of `macroMembers.entries()` running once
+ * per render, then for each leaf row the hook walks the parent chain
+ * upward and consults the macro->member set as a side-channel. Both
+ * checks compose: selecting EU + selecting Germany also disables Berlin
+ * via Germany even after EU's contribution is irrelevant — the result
+ * is the same.
+ *
+ * Performance: `O(N * D)` where N = number of distinct IDs in the modal
+ * and D = chain depth (≤4 for locations, ≤3 for occupations). Memoized
+ * by `selectedIds` identity AND a stringified key derived from the
+ * parents/macroMembers maps. The caller is expected to pass stable map
+ * references; the hook does NOT memo when references change.
+ *
+ * Related: #2977 indexes ancestor IDs at write time so a single
+ * `location_ids:=<parent>` filter matches every descendant. This hook
+ * is the UI counterpart — descendants cannot add filtering signal so
+ * the modal disables them.
+ */
+
+import { useMemo } from "react";
+
+export interface UseDisabledByAncestorArgs {
+  /** Currently-selected filter IDs. */
+  selectedIds: ReadonlySet<number>;
+  /**
+   * id -> parentId mapping. Use `null` (NOT undefined) for top-level
+   * rows. Including `null` parents in the map is fine — they just
+   * terminate the walk.
+   */
+  parents: ReadonlyMap<number, number | null>;
+  /**
+   * Optional macro -> member-country IDs map. Used by location modals
+   * where macros are not in the parent chain but disable their member
+   * countries (and transitively regions + cities) when selected.
+   */
+  macroMembers?: ReadonlyMap<number, readonly number[]>;
+}
+
+export interface UseDisabledByAncestorResult {
+  /** True if `id` has a selected ancestor (excluding `id` itself). */
+  isDisabled(id: number): boolean;
+  /** The ID of the nearest selected ancestor, or `null`. */
+  disabledByAncestor(id: number): number | null;
+}
+
+export function useDisabledByAncestor({
+  selectedIds,
+  parents,
+  macroMembers,
+}: UseDisabledByAncestorArgs): UseDisabledByAncestorResult {
+  return useMemo(() => {
+    // Build a reverse map: countryId -> [macroIds that include it as a
+    // member]. Walked first so a city's macro lineage is found even when
+    // its country isn't in `parents` for some reason. Doing this once
+    // per render keeps the per-row check O(D + macroChainLen).
+    const countryToMacros = new Map<number, number[]>();
+    if (macroMembers) {
+      for (const [macroId, members] of macroMembers.entries()) {
+        for (const cid of members) {
+          let arr = countryToMacros.get(cid);
+          if (!arr) { arr = []; countryToMacros.set(cid, arr); }
+          arr.push(macroId);
+        }
+      }
+    }
+
+    function findAncestor(id: number): number | null {
+      // Walk parent chain. Any selected ancestor (excluding self) wins.
+      let cur = parents.get(id);
+      const seen = new Set<number>([id]); // cycle guard
+      while (cur != null && !seen.has(cur)) {
+        seen.add(cur);
+        if (selectedIds.has(cur)) return cur;
+        // Ancestors-of-ancestors: also check macros that include this
+        // node (the country in particular). This means selecting EU
+        // disables Berlin via the Germany -> EU side-channel.
+        const macros = countryToMacros.get(cur);
+        if (macros) {
+          for (const m of macros) {
+            if (selectedIds.has(m)) return m;
+          }
+        }
+        cur = parents.get(cur);
+      }
+      // Final check on `id` itself — covers "this row is a country and
+      // a macro that includes it is selected".
+      const directMacros = countryToMacros.get(id);
+      if (directMacros) {
+        for (const m of directMacros) {
+          if (selectedIds.has(m)) return m;
+        }
+      }
+      return null;
+    }
+
+    return {
+      isDisabled(id: number) {
+        return findAncestor(id) !== null;
+      },
+      disabledByAncestor(id: number) {
+        return findAncestor(id);
+      },
+    };
+  }, [selectedIds, parents, macroMembers]);
+}
+
+/**
+ * Auto-deselect descendants when a parent is committed. Returns a fresh
+ * array filtered to drop any entry whose `id` is now redundant under
+ * the {@link useDisabledByAncestor} contract.
+ *
+ * Use after `onToggle` adds the parent — the hook computes
+ * `disabledByAncestor` against the new selection and the caller filters
+ * the chip list. This keeps the modal in a clean state where every
+ * rendered chip is active (not selected-but-disabled).
+ */
+export function pruneRedundantDescendants<T extends { id: number }>(
+  items: readonly T[],
+  parents: ReadonlyMap<number, number | null>,
+  macroMembers?: ReadonlyMap<number, readonly number[]>,
+): T[] {
+  const selectedIds = new Set(items.map((i) => i.id));
+  const countryToMacros = new Map<number, number[]>();
+  if (macroMembers) {
+    for (const [macroId, members] of macroMembers.entries()) {
+      for (const cid of members) {
+        let arr = countryToMacros.get(cid);
+        if (!arr) { arr = []; countryToMacros.set(cid, arr); }
+        arr.push(macroId);
+      }
+    }
+  }
+  return items.filter((item) => {
+    let cur = parents.get(item.id);
+    const seen = new Set<number>([item.id]);
+    while (cur != null && !seen.has(cur)) {
+      seen.add(cur);
+      if (selectedIds.has(cur)) return false;
+      const macros = countryToMacros.get(cur);
+      if (macros) {
+        for (const m of macros) {
+          if (selectedIds.has(m)) return false;
+        }
+      }
+      cur = parents.get(cur);
+    }
+    const directMacros = countryToMacros.get(item.id);
+    if (directMacros) {
+      for (const m of directMacros) {
+        if (selectedIds.has(m)) return false;
+      }
+    }
+    return true;
+  });
+}

--- a/apps/web/src/lib/actions/__tests__/company-macro.test.ts
+++ b/apps/web/src/lib/actions/__tests__/company-macro.test.ts
@@ -58,7 +58,7 @@ describe("getCompanyLocationsGroupedWithMacros — Regions cluster gate (#2940)"
    * not guaranteed. We use `mockImplementation` keyed on SQL substrings so
    * the test passes regardless of interleaving.
    */
-  function setupMocks(opts: { macros: Array<{ id: number; slug: string | null; name: string; postingCount: number; memberCountryCount: number }>; members: Array<{ macro_id: number; country_name: string }>; }) {
+  function setupMocks(opts: { macros: Array<{ id: number; slug: string | null; name: string; postingCount: number; memberCountryCount: number }>; members: Array<{ macro_id: number; country_id: number; country_name: string }>; }) {
     mocks.dbExecute.mockImplementation((arg: unknown) => {
       const sql = String(arg);
       if (sql.includes("WITH active_locs AS") && sql.includes("hierarchy")) {
@@ -99,8 +99,8 @@ describe("getCompanyLocationsGroupedWithMacros — Regions cluster gate (#2940)"
         { id: 4, slug: null, name: "EU", postingCount: 100, memberCountryCount: 2 },
       ],
       members: [
-        { macro_id: 4, country_name: "Germany" },
-        { macro_id: 4, country_name: "France" },
+        { macro_id: 4, country_id: 100, country_name: "Germany" },
+        { macro_id: 4, country_id: 101, country_name: "France" },
       ],
     });
     const out = await getCompanyLocationsGroupedWithMacros("co-1", "en");
@@ -112,6 +112,7 @@ describe("getCompanyLocationsGroupedWithMacros — Regions cluster gate (#2940)"
       abbreviation: "EU",
       count: 100,
       memberCountryNames: ["Germany", "France"],
+      memberCountryIds: [100, 101],
     });
   });
 

--- a/apps/web/src/lib/actions/__tests__/locations-macro.test.ts
+++ b/apps/web/src/lib/actions/__tests__/locations-macro.test.ts
@@ -69,11 +69,11 @@ describe("getGlobalLocationsGrouped — Regions cluster (#2940)", () => {
         { location_id: 200, locale: "en", name: "Berlin" },
       ])
       .mockResolvedValueOnce([
-        { macro_id: 4, country_name: "Germany" },
-        { macro_id: 4, country_name: "France" },
-        { macro_id: 5, country_name: "Germany" },
-        { macro_id: 5, country_name: "Austria" },
-        { macro_id: 5, country_name: "Switzerland" },
+        { macro_id: 4, country_id: 100, country_name: "Germany" },
+        { macro_id: 4, country_id: 101, country_name: "France" },
+        { macro_id: 5, country_id: 100, country_name: "Germany" },
+        { macro_id: 5, country_id: 102, country_name: "Austria" },
+        { macro_id: 5, country_id: 103, country_name: "Switzerland" },
       ]);
 
     // Two parallel Typesense calls: country-tier facet (top-500) AND a
@@ -122,6 +122,7 @@ describe("getGlobalLocationsGrouped — Regions cluster (#2940)", () => {
       abbreviation: "EMEA",
       count: 1433,
       memberCountryNames: [],
+      memberCountryIds: [],
     });
     expect(out.macros[1]).toEqual({
       id: 4,
@@ -130,6 +131,7 @@ describe("getGlobalLocationsGrouped — Regions cluster (#2940)", () => {
       abbreviation: "EU",
       count: 146,
       memberCountryNames: ["Germany", "France"],
+      memberCountryIds: [100, 101],
     });
     expect(out.macros[2]).toEqual({
       id: 5,
@@ -138,6 +140,7 @@ describe("getGlobalLocationsGrouped — Regions cluster (#2940)", () => {
       abbreviation: "DACH",
       count: 6,
       memberCountryNames: ["Germany", "Austria", "Switzerland"],
+      memberCountryIds: [100, 102, 103],
     });
     // Country tier still works
     expect(out.countries.length).toBeGreaterThan(0);

--- a/apps/web/src/lib/actions/company.ts
+++ b/apps/web/src/lib/actions/company.ts
@@ -1396,6 +1396,14 @@ export interface CompanyMacroRegion {
   abbreviation: string;
   count: number;
   memberCountryNames: string[];
+  /**
+   * Member country IDs — used by the hierarchical-disable hook so
+   * selecting a macro in {@link LocationModal} disables its member
+   * countries (and transitively their regions/cities) without a second
+   * round-trip. Mirrors {@link GlobalMacroRegion.memberCountryIds}. See
+   * #2978.
+   */
+  memberCountryIds: number[];
 }
 
 /**
@@ -1536,15 +1544,18 @@ async function _fetchCompanyMacroCluster(
   const macroRows = rows as unknown as Row[];
   if (macroRows.length === 0) return [];
 
-  // Fetch member country names for each macro (for chip tooltip)
+  // Fetch member country names + IDs for each macro. The IDs power the
+  // hierarchical-disable hook (#2978) and stay aligned with names because
+  // they share the same row order.
   const macroIds = macroRows.map((r) => r.macro_id);
   const pgArray = `{${macroIds.join(",")}}`;
   const memberRows = await db.execute<{
     [key: string]: unknown;
     macro_id: number;
+    country_id: number;
     country_name: string;
   }>(sql`
-    SELECT lmm.macro_id, ln.name AS country_name
+    SELECT lmm.macro_id, lmm.country_id, ln.name AS country_name
     FROM location_macro_member lmm
     JOIN LATERAL (
       SELECT name FROM location_name
@@ -1556,24 +1567,27 @@ async function _fetchCompanyMacroCluster(
     WHERE lmm.macro_id = ANY(${pgArray}::integer[])
     ORDER BY lmm.macro_id, ln.name
   `);
-  const memberMap = new Map<number, string[]>();
-  for (const r of memberRows as unknown as { macro_id: number; country_name: string }[]) {
-    let arr = memberMap.get(r.macro_id);
-    if (!arr) { arr = []; memberMap.set(r.macro_id, arr); }
-    arr.push(r.country_name);
+  const memberMap = new Map<number, { countryNames: string[]; countryIds: number[] }>();
+  for (const r of memberRows as unknown as { macro_id: number; country_id: number; country_name: string }[]) {
+    let entry = memberMap.get(r.macro_id);
+    if (!entry) { entry = { countryNames: [], countryIds: [] }; memberMap.set(r.macro_id, entry); }
+    entry.countryNames.push(r.country_name);
+    entry.countryIds.push(r.country_id);
   }
 
   return macroRows.map((r) => {
     const slugKey = (r.macro_slug ?? "").toLowerCase()
       || r.macro_name.toLowerCase().replace(/\s+/g, "-");
     const canonical = MACRO_DISPLAY_NAMES[slugKey];
+    const members = memberMap.get(r.macro_id);
     return {
       id: r.macro_id,
       slug: r.macro_slug ?? slugKey,
       name: canonical ?? r.macro_name,
       abbreviation: r.macro_name,
       count: r.posting_count,
-      memberCountryNames: memberMap.get(r.macro_id) ?? [],
+      memberCountryNames: members?.countryNames ?? [],
+      memberCountryIds: members?.countryIds ?? [],
     };
   });
 }

--- a/apps/web/src/lib/actions/locations.ts
+++ b/apps/web/src/lib/actions/locations.ts
@@ -301,6 +301,13 @@ export interface GlobalMacroRegion {
   count: number;
   /** Member country names (English) — for the chip's hover tooltip. */
   memberCountryNames: string[];
+  /**
+   * Member country IDs — used by the hierarchical-disable hook so that
+   * selecting a macro disables every member country (and transitively
+   * regions/cities) in the modal. Mirrors `memberCountryNames` order so
+   * the two arrays stay aligned. See #2978.
+   */
+  memberCountryIds: number[];
 }
 
 export interface GlobalLocationsResponse {
@@ -526,9 +533,9 @@ async function _fetchGlobalLocationsGrouped(
     // `_fetchGlobalMacroMembers` for the per-macro member country names
     // used as the chip's hover tooltip.
     const macroIdsWithCounts = allMacroIds.filter((id) => (macroFacetCounts.get(id) ?? 0) > 0);
-    const macroMemberNames = macroIdsWithCounts.length > 0
+    const macroMembers = macroIdsWithCounts.length > 0
       ? await _fetchGlobalMacroMembers(macroIdsWithCounts, locale)
-      : new Map<number, string[]>();
+      : new Map<number, MacroMembers>();
     const macros: GlobalMacroRegion[] = macroIdsWithCounts
       .map((id) => {
         const meta = hierarchy.get(id);
@@ -537,13 +544,15 @@ async function _fetchGlobalLocationsGrouped(
         const slugKey = (meta.slug ?? "").toLowerCase()
           || abbreviation.toLowerCase().replace(/\s+/g, "-");
         const canonical = MACRO_DISPLAY_NAMES[slugKey];
+        const members = macroMembers.get(id);
         return {
           id,
           slug: meta.slug ?? slugKey,
           name: canonical ?? abbreviation,
           abbreviation,
           count: macroFacetCounts.get(id) ?? 0,
-          memberCountryNames: macroMemberNames.get(id) ?? [],
+          memberCountryNames: members?.countryNames ?? [],
+          memberCountryIds: members?.countryIds ?? [],
         } satisfies GlobalMacroRegion;
       })
       .filter((m): m is GlobalMacroRegion => m !== null && m.count > 0)
@@ -674,18 +683,28 @@ async function _fetchGlobalLocationsGrouped(
  * particular DB snapshot we read from). When the table is empty we return
  * an empty member list and the modal renders the chip without a tooltip.
  */
+interface MacroMembers {
+  countryNames: string[];
+  countryIds: number[];
+}
+
 async function _fetchGlobalMacroMembers(
   macroIds: number[],
   locale: string,
-): Promise<Map<number, string[]>> {
+): Promise<Map<number, MacroMembers>> {
   if (macroIds.length === 0) return new Map();
   const pgArray = `{${macroIds.join(",")}}`;
+  // Project `country_id` alongside `country_name` so the hierarchical
+  // disable hook (#2978) can walk macro -> member-country links without
+  // a second round-trip. Names and IDs stay aligned because they share
+  // the same row order.
   const rows = await db.execute<{
     [key: string]: unknown;
     macro_id: number;
+    country_id: number;
     country_name: string;
   }>(sql`
-    SELECT lmm.macro_id, ln.name AS country_name
+    SELECT lmm.macro_id, lmm.country_id, ln.name AS country_name
     FROM location_macro_member lmm
     JOIN LATERAL (
       SELECT name FROM location_name
@@ -697,11 +716,12 @@ async function _fetchGlobalMacroMembers(
     WHERE lmm.macro_id = ANY(${pgArray}::integer[])
     ORDER BY lmm.macro_id, ln.name
   `);
-  const map = new Map<number, string[]>();
-  for (const r of rows as unknown as { macro_id: number; country_name: string }[]) {
-    let arr = map.get(r.macro_id);
-    if (!arr) { arr = []; map.set(r.macro_id, arr); }
-    arr.push(r.country_name);
+  const map = new Map<number, MacroMembers>();
+  for (const r of rows as unknown as { macro_id: number; country_id: number; country_name: string }[]) {
+    let entry = map.get(r.macro_id);
+    if (!entry) { entry = { countryNames: [], countryIds: [] }; map.set(r.macro_id, entry); }
+    entry.countryNames.push(r.country_name);
+    entry.countryIds.push(r.country_id);
   }
   return map;
 }

--- a/apps/web/src/lib/actions/taxonomy.ts
+++ b/apps/web/src/lib/actions/taxonomy.ts
@@ -481,6 +481,21 @@ export interface OccupationItem {
   slug: string;
   name: string;
   count: number;
+  /**
+   * Parent occupation id within the same domain. `null` for top-level
+   * occupations (family parents and standalones). Plumbed through from
+   * the underlying `OccupationMeta.parentId` so the modal can disable
+   * descendant pills when a family parent or domain is selected.
+   * See #2978.
+   */
+  parentId: number | null;
+  /**
+   * Domain id this occupation belongs to. `null` for occupations with no
+   * domain (rare). Used by the modal to disable every descendant when a
+   * domain header is selected as a single filter (#2978 — domain headers
+   * are now ancestor filters, not "select all children" loops).
+   */
+  domainId: number | null;
 }
 
 /** A parent occupation with its children within a domain. */
@@ -742,7 +757,14 @@ async function _fetchAllOccupationsGrouped(
       ungrouped.push({
         domain: { id: r.id, slug: r.slug, name: r.name, count: r.cnt },
         subGroups: [],
-        standalone: [{ id: r.id, slug: r.slug, name: r.name, count: r.cnt }],
+        standalone: [{
+          id: r.id,
+          slug: r.slug,
+          name: r.name,
+          count: r.cnt,
+          parentId: r.parentId,
+          domainId: r.domainId,
+        }],
       });
     }
 
@@ -764,7 +786,14 @@ async function _fetchAllOccupationsGrouped(
       for (const r of domainItems) {
         if (parentIds.has(r.id)) {
           subGroupMap.set(r.id, {
-            parent: { id: r.id, slug: r.slug, name: r.name, count: r.cnt },
+            parent: {
+              id: r.id,
+              slug: r.slug,
+              name: r.name,
+              count: r.cnt,
+              parentId: r.parentId,
+              domainId: r.domainId,
+            },
             children: [],
           });
         }
@@ -774,10 +803,22 @@ async function _fetchAllOccupationsGrouped(
       for (const r of domainItems) {
         if (r.parentId != null && subGroupMap.has(r.parentId)) {
           subGroupMap.get(r.parentId)!.children.push({
-            id: r.id, slug: r.slug, name: r.name, count: r.cnt,
+            id: r.id,
+            slug: r.slug,
+            name: r.name,
+            count: r.cnt,
+            parentId: r.parentId,
+            domainId: r.domainId,
           });
         } else if (!parentIds.has(r.id)) {
-          standalone.push({ id: r.id, slug: r.slug, name: r.name, count: r.cnt });
+          standalone.push({
+            id: r.id,
+            slug: r.slug,
+            name: r.name,
+            count: r.cnt,
+            parentId: r.parentId,
+            domainId: r.domainId,
+          });
         }
       }
 


### PR DESCRIPTION
## Summary

- When a parent filter is selected (macro region, country, region, occupation family parent), descendant rows in the filter modal render disabled — greyed, `aria-disabled`, click no-op, with a Radix tooltip showing "Included in <ancestor>". Auto-deselects redundant descendants when a parent is committed. Backend's index-time ancestor expansion (#2977) already collapses these into the parent; this is the UI counterpart.
- Wired across all three hierarchical modals: `LocationSearchModal` (global explore), `LocationModal` (company detail), `OccupationModal`.
- New shared hook `use-disabled-by-ancestor.ts` + `<DisabledFilterPill>` component. Public `OccupationItem` now exposes `parentId` + `domainId`. `GlobalMacroRegion` + `CompanyMacroRegion` gain `memberCountryIds: number[]`.

## Behavior

- Macro selected -> member countries + their regions + their cities all disable.
- Country selected -> regions + cities disable.
- Region selected -> cities disable.
- Family parent selected -> children disable.
- Auto-deselect of redundant children on parent click; chip strip never shows selected-but-disabled rows.
- Disabled rows still surface in the local search filter (greyed but visible).

Other filters (seniority, technology, employment type, experience, salary, languages) remain flat — no behavior change today, but the shared helper is reusable for future hierarchical filters.

## Files changed

- `apps/web/src/components/search/use-disabled-by-ancestor.ts` (new) — pure hook
- `apps/web/src/components/search/disabled-filter-pill.tsx` (new) — Radix tooltip wrapper
- `apps/web/src/components/search/location-search-modal.tsx` — wired
- `apps/web/src/components/search/location-modal.tsx` — wired
- `apps/web/src/components/search/occupation-modal.tsx` — wired
- `apps/web/src/lib/actions/locations.ts` — `memberCountryIds` projection
- `apps/web/src/lib/actions/company.ts` — `memberCountryIds` projection
- `apps/web/src/lib/actions/taxonomy.ts` — `parentId` + `domainId` plumbed onto `OccupationItem`
- `apps/web/locales/{en,de,fr,it}.po` — `search.filterModal.includedInAncestor` translations

## Test plan

- [x] `use-disabled-by-ancestor.test.ts` — 9 pure hook tests (parent walk, region->city, macro->country->city, cycle guard, prune helper)
- [x] `location-search-modal.test.tsx` — 3 new tests (EU disables Germany+Berlin, country click auto-deselects child city, country click greys child cities)
- [x] `occupation-modal.test.tsx` — 4 new tests (parent disables children, auto-deselect, disabled-pill styling, peer standalone not disabled)
- [x] Updated `company-macro.test.ts` + `locations-macro.test.ts` for the new `memberCountryIds` field
- [x] Full `pnpm test` — 567/567 tests pass (64/64 files; the 1 pre-existing `app/mcp/route.test.ts` failure is unrelated — `@jseek/mcp-server/dist` is unbuilt)
- [x] `pnpm exec tsc --noEmit` — clean (only the pre-existing mcp module error)
- [x] Empirical verification via Playwright against `pnpm dev`:
  - Click Austria -> Vienna pill `aria-disabled="true"`, classes include `opacity-50` + `cursor-not-allowed`, tooltip text "Included in Austria"
  - Click EU macro -> Germany country header `aria-disabled="true"`
  - Click Software Engineer parent -> 6 descendant pills become disabled (Backend, Fullstack, Frontend, Mobile, AI, Research)

## Notes

- No DB schema changes — purely UI walk over data already present in the existing nested response shape.
- Performance: hook is O(N x D) per render where D ≤ 4 chain depth; selection/parents memoized.
- No filter-string explosion: a single `location_ids:=<parent>` filter still matches every descendant via index-time ancestor expansion (#2977 already merged).
- Domain header behavior unchanged: still selects all children (rather than becoming a single filter). The Plan suggested switching to single-filter semantics, but the backend's `occupation_ancestors` only walks `parent_id` and does NOT include domain — so `occupation_ids:=<domainId>` would not match descendants today. Left for a follow-up that includes the exporter change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)