### PR TITLE
fix(web): occupation domain toggle selects first-level only (#2979 follow-up)

### DIFF
--- a/apps/web/src/components/search/__tests__/occupation-modal.test.tsx
+++ b/apps/web/src/components/search/__tests__/occupation-modal.test.tsx
@@ -15,12 +15,16 @@ vi.mock("server-only", () => ({}));
 import { OccupationModal } from "../occupation-modal";
 
 /**
- * Mock occupation hierarchy:
+ * Mock occupation hierarchy mirrors production "Software Engineering"
+ * domain (id=1, see #2979 follow-up — production probe in PR description):
  *   domain "Software Engineering" (id: 10)
  *     family parent "Software Engineer" (id: 100, parentId: null, domainId: 10)
  *       child "Frontend Developer" (id: 101, parentId: 100)
  *       child "Backend Developer" (id: 102, parentId: 100)
- *     standalone "DevOps Engineer" (id: 200, parentId: null, domainId: 10)
+ *     family parent "DevOps Engineer" (id: 150, parentId: null, domainId: 10)
+ *       child "Release Engineer" (id: 151, parentId: 150)
+ *     standalone "QA Engineer" (id: 200, parentId: null, domainId: 10)
+ *       — orphan-at-first-level: top-level in domain, no children
  */
 const _groups = () => [
   {
@@ -40,9 +44,22 @@ const _groups = () => [
           { id: 102, slug: "backend-developer", name: "Backend Developer", count: 250, parentId: 100, domainId: 10 },
         ],
       },
+      {
+        parent: {
+          id: 150,
+          slug: "devops-engineer",
+          name: "DevOps Engineer",
+          count: 80,
+          parentId: null,
+          domainId: 10,
+        },
+        children: [
+          { id: 151, slug: "release-engineer", name: "Release Engineer", count: 20, parentId: 150, domainId: 10 },
+        ],
+      },
     ],
     standalone: [
-      { id: 200, slug: "devops-engineer", name: "DevOps Engineer", count: 100, parentId: null, domainId: 10 },
+      { id: 200, slug: "qa-engineer", name: "QA Engineer", count: 100, parentId: null, domainId: 10 },
     ],
   },
 ];
@@ -127,9 +144,129 @@ describe("OccupationModal — hierarchical disable (#2978)", () => {
         onToggle={() => {}}
       />,
     );
-    await waitFor(() => screen.getByText("DevOps Engineer"));
-    // DevOps Engineer is a standalone in the same domain — NOT a child of Software Engineer.
-    const devopsButton = screen.getByText("DevOps Engineer").closest("button");
-    expect(devopsButton?.getAttribute("aria-disabled")).toBeNull();
+    await waitFor(() => screen.getByText("QA Engineer"));
+    // QA Engineer is a standalone in the same domain — NOT a child of Software Engineer.
+    const qaButton = screen.getByText("QA Engineer").closest("button");
+    expect(qaButton?.getAttribute("aria-disabled")).toBeNull();
+  });
+});
+
+describe("OccupationModal — domain header toggles first-level only (#2979 follow-up)", () => {
+  /**
+   * User report (PR #2979 follow-up): clicking the "Software Engineering"
+   * domain header was selecting the family parents (Software Engineer +
+   * DevOps Engineer) AND every grandchild (Frontend, Backend, Release
+   * Engineer). Expectation: select first-level only — grandchildren render
+   * as disabled because their family parent is selected.
+   */
+  it("selects only first-level descendants on domain click", async () => {
+    getAllOccupationsGroupedMock.mockResolvedValue(_groups());
+    const onToggle = vi.fn();
+    render(
+      <OccupationModal
+        open
+        onOpenChange={() => {}}
+        locale="en"
+        selected={[]}
+        onToggle={onToggle}
+      />,
+    );
+    await waitFor(() => screen.getByText("Software Engineering"));
+    await userEvent.click(screen.getByText("Software Engineering"));
+
+    // First-level: Software Engineer (100), DevOps Engineer (150),
+    // QA Engineer (200) — three onToggle calls in some order.
+    const ids = onToggle.mock.calls.map((call) => (call[0] as { id: number }).id).sort((a, b) => a - b);
+    expect(ids).toEqual([100, 150, 200]);
+    // Grandchildren MUST NOT be in the toggle list.
+    expect(ids).not.toContain(101); // Frontend
+    expect(ids).not.toContain(102); // Backend
+    expect(ids).not.toContain(151); // Release Engineer
+  });
+
+  /** After domain click, grandchildren render disabled (parent in selection). */
+  it("renders grandchildren disabled after first-level family parents are selected", async () => {
+    getAllOccupationsGroupedMock.mockResolvedValue(_groups());
+    render(
+      <OccupationModal
+        open
+        onOpenChange={() => {}}
+        locale="en"
+        // State after domain click: first-level only.
+        selected={[
+          { id: 100, slug: "software-engineer", name: "Software Engineer" },
+          { id: 150, slug: "devops-engineer", name: "DevOps Engineer" },
+          { id: 200, slug: "qa-engineer", name: "QA Engineer" },
+        ]}
+        onToggle={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("Frontend Developer"));
+
+    // Grandchildren under Software Engineer
+    const frontend = screen.getByText("Frontend Developer").closest("button");
+    const backend = screen.getByText("Backend Developer").closest("button");
+    expect(frontend?.getAttribute("aria-disabled")).toBe("true");
+    expect(backend?.getAttribute("aria-disabled")).toBe("true");
+
+    // Grandchild under DevOps Engineer
+    const release = screen.getByText("Release Engineer").closest("button");
+    expect(release?.getAttribute("aria-disabled")).toBe("true");
+  });
+
+  /** QA Engineer is a top-level orphan — must be selected on domain click. */
+  it("selects orphan-at-first-level (QA Engineer) on domain click", async () => {
+    getAllOccupationsGroupedMock.mockResolvedValue(_groups());
+    const onToggle = vi.fn();
+    render(
+      <OccupationModal
+        open
+        onOpenChange={() => {}}
+        locale="en"
+        selected={[]}
+        onToggle={onToggle}
+      />,
+    );
+    await waitFor(() => screen.getByText("Software Engineering"));
+    await userEvent.click(screen.getByText("Software Engineering"));
+
+    const qaCall = onToggle.mock.calls.find(
+      (call) => (call[0] as { id: number }).id === 200,
+    );
+    expect(qaCall).toBeDefined();
+    expect(qaCall?.[0]).toMatchObject({ id: 200, slug: "qa-engineer" });
+  });
+
+  /**
+   * Domain header click is a toggle: when every first-level row is already
+   * selected, the second click deselects them — and any grandchildren that
+   * were independently selected get cleaned up too (would otherwise be
+   * orphan-selected with no visible ancestor).
+   */
+  it("deselects first-level rows + drops orphan grandchildren when fully selected", async () => {
+    getAllOccupationsGroupedMock.mockResolvedValue(_groups());
+    const onToggle = vi.fn();
+    render(
+      <OccupationModal
+        open
+        onOpenChange={() => {}}
+        locale="en"
+        selected={[
+          { id: 100, slug: "software-engineer", name: "Software Engineer" },
+          { id: 150, slug: "devops-engineer", name: "DevOps Engineer" },
+          { id: 200, slug: "qa-engineer", name: "QA Engineer" },
+          // Grandchild that snuck in independently of its parent.
+          { id: 101, slug: "frontend-developer", name: "Frontend Developer" },
+        ]}
+        onToggle={onToggle}
+      />,
+    );
+    await waitFor(() => screen.getByText("Software Engineering"));
+    await userEvent.click(screen.getByText("Software Engineering"));
+
+    const ids = onToggle.mock.calls.map((call) => (call[0] as { id: number }).id).sort((a, b) => a - b);
+    // Expect the three first-level rows to be deselected, plus the
+    // orphan grandchild (101) since its parent (100) is being dropped.
+    expect(ids).toEqual([100, 101, 150, 200]);
   });
 });

--- a/apps/web/src/components/search/occupation-modal.tsx
+++ b/apps/web/src/components/search/occupation-modal.tsx
@@ -187,24 +187,72 @@ export function OccupationModal({
     [filtered, search, onToggle, showWarning, t],
   );
 
-  /** Collect all selectable occupation items from a group (parents + children + standalone). */
-  function allItems(group: OccupationGroup): OccupationItem[] {
+  /**
+   * First-level descendants of a domain — the rows that render at depth-1
+   * in the modal tree. This is the set of items the domain header toggles
+   * (and the set used to compute the header's "all selected" indicator).
+   *
+   * Composition:
+   * - Family parents: `group.subGroups[].parent` — top-level occupations
+   *   in the domain that themselves have children (e.g. Software Engineer,
+   *   DevOps Engineer).
+   * - Standalones: `group.standalone[]` — top-level occupations in the
+   *   domain with no children (e.g. QA Engineer).
+   *
+   * Grandchildren (`sg.children`) are NOT first-level — selecting them via
+   * the domain header would be redundant once their family parent is
+   * selected. The disable hook handles their UI state via the
+   * parent-chain walk in `useDisabledByAncestor`.
+   */
+  function firstLevelItems(group: OccupationGroup): OccupationItem[] {
     const items: OccupationItem[] = [...group.standalone];
     for (const sg of group.subGroups) {
       items.push(sg.parent);
-      items.push(...sg.children);
     }
     return items;
   }
 
+  /**
+   * Domain header click selects every first-level descendant of the
+   * domain. Grandchildren (`sg.children`) are not added — they become
+   * disabled (greyed) via `useDisabledByAncestor` because their family
+   * parent is now selected. Mirrors the location modal's
+   * country-header / region-header semantics.
+   *
+   * On deselect: drops the first-level ids, and also drops any of their
+   * descendants currently in `selected` (which would otherwise be
+   * orphan-selected with no visible ancestor). Same rule as
+   * `handleToggle` for an individual family parent.
+   *
+   * #2978 follow-up — was previously a "select-all-children" loop that
+   * recursively activated grandchildren too.
+   */
   function handleDomainToggle(group: OccupationGroup) {
-    const items = allItems(group);
-    if (items.length === 0) return;
-    const allSelected = items.every((c) => selectedIds.has(c.id));
+    const firstLevel = firstLevelItems(group);
+    if (firstLevel.length === 0) return;
+    const allSelected = firstLevel.every((c) => selectedIds.has(c.id));
     if (allSelected) {
-      items.forEach((c) => { if (selectedIds.has(c.id)) onToggle(c); });
+      // Deselect every first-level row plus any of their descendants
+      // currently in the selection (grandchildren that were selected
+      // independently before the parent was committed).
+      const firstLevelIds = new Set(firstLevel.map((c) => c.id));
+      for (const c of firstLevel) onToggle(c);
+      for (const s of selected) {
+        if (firstLevelIds.has(s.id)) continue;
+        // Walk parent chain — drop if any ancestor is a first-level id.
+        let cur = parentMap.get(s.id);
+        const seen = new Set<number>([s.id]);
+        while (cur != null && !seen.has(cur)) {
+          seen.add(cur);
+          if (firstLevelIds.has(cur)) {
+            onToggle(s);
+            break;
+          }
+          cur = parentMap.get(cur);
+        }
+      }
     } else {
-      items.forEach((c) => { if (!selectedIds.has(c.id)) onToggle(c); });
+      firstLevel.forEach((c) => { if (!selectedIds.has(c.id)) onToggle(c); });
     }
   }
 
@@ -297,8 +345,12 @@ export function OccupationModal({
             ) : (
               <div className="space-y-5">
                 {filtered.map((group) => {
-                  const items = allItems(group);
-                  const allSelected = items.length > 0 && items.every((c) => selectedIds.has(c.id));
+                  // Domain header is "all selected" iff every first-level
+                  // descendant is selected — grandchildren don't count
+                  // because they're auto-disabled by the parent. Mirrors
+                  // the toggle semantics in `handleDomainToggle`.
+                  const firstLevel = firstLevelItems(group);
+                  const allSelected = firstLevel.length > 0 && firstLevel.every((c) => selectedIds.has(c.id));
 
                   return (
                     <div key={group.domain.slug}>


### PR DESCRIPTION
## Summary

User-reported UI bug from PR #2979 (just merged):

> "Clicked on 'Software Engineering', see Software Engineer and DevOps Engineer first-level subcategories activated, but also all subsubcategories under them as well. Expected just the first-level activated with the rest disabled. Note the QA Engineer without the first-level (or could perhaps be first-level classified) — should be selected."

`handleDomainToggle` was a "select-all-children" recursive loop. After the fix it selects only the immediate first-level descendants of the domain — `subGroups[].parent` + `standalone[]` — so grandchildren render as disabled (via `useDisabledByAncestor`) instead of as their own selected pills.

- Family parents (Software Engineer, DevOps Engineer) get selected
- Orphan-at-first-level (QA Engineer) gets selected — `parentId IS NULL, domainId = 1` rows with no children
- Grandchildren (Frontend, Backend, Fullstack, Mobile, Embedded, AI, Research, Game Developer, Release Engineer) render `aria-disabled="true"` with tooltip "Included in Software Engineer" / "Included in DevOps Engineer"
- Domain header "all selected" indicator switched to the same first-level set
- Deselect path drops orphan-selected grandchildren (would otherwise dangle without a visible ancestor)

## Production taxonomy probed

Domain `software-engineering` id=1, queried via Supabase mirror:

```
First-level (parent_id IS NULL, domain_id=1):
  id=1   software-engineer    Software Engineer   (family parent)
  id=6   devops-engineer      DevOps Engineer     (family parent)
  id=16  qa-engineer          QA Engineer         (orphan, no children)

Sub-sub (parent_id != NULL):
  id=85  AI Engineer           parent=1
  id=3   Backend Developer     parent=1
  id=39  Embedded Engineer     parent=1
  id=2   Frontend Developer    parent=1
  id=4   Fullstack Developer   parent=1
  id=40  Game Developer        parent=1
  id=5   Mobile Developer      parent=1
  id=38  Research Engineer     parent=1
  id=42  Release Engineer      parent=6 (under DevOps)
```

## Visual verification (Playwright, dev server)

After clicking the "Software Engineering" domain header in `/en/explore` -> Filters -> Role:

```
Software Engineer    isPrimary=true             (selected — family parent)
DevOps Engineer      isPrimary=true             (selected — family parent)
QA Engineer          isPrimary=true bgPrimary=true  (selected — pill)
Frontend Developer   ariaDisabled=true opacity-50  (disabled grandchild)
Backend Developer    ariaDisabled=true opacity-50
Fullstack Developer  ariaDisabled=true opacity-50
Mobile Developer     ariaDisabled=true opacity-50
Embedded Engineer    ariaDisabled=true opacity-50
AI Engineer          ariaDisabled=true opacity-50
Research Engineer    ariaDisabled=true opacity-50
Game Developer       ariaDisabled=true opacity-50
Release Engineer     ariaDisabled=true opacity-50  (under DevOps)
Tooltip on FE hover: "Included in Software Engineer"
```

## Test plan

- [x] `pnpm exec tsc --noEmit` — green except for unrelated pre-existing `app/mcp/route.ts` missing-module error (not touched by this PR)
- [x] `vitest run` — 571 passing tests across 64 files (excludes pre-existing-broken `app/mcp/route.test.ts` for the same missing-module reason)
- [x] `vitest run src/components/search/__tests__/occupation-modal.test.tsx` — 8/8 (was 4, +4 new domain-toggle cases)
- [x] Playwright visual verification on dev server confirming the three user expectations
- [x] Production taxonomy structure probed empirically (Supabase mirror)

## New tests

`apps/web/src/components/search/__tests__/occupation-modal.test.tsx`:
- `selects only first-level descendants on domain click` — onToggle ids === [100, 150, 200], MUST NOT contain 101/102/151
- `renders grandchildren disabled after first-level family parents are selected` — `aria-disabled="true"` on Frontend/Backend/Release
- `selects orphan-at-first-level (QA Engineer) on domain click`
- `deselects first-level rows + drops orphan grandchildren when fully selected`

The fixture was extended to mirror production: a second `subGroup` (DevOps Engineer with Release Engineer child) plus QA Engineer kept as the orphan-at-first-level standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)