### PR TITLE
feat(web): work-mode filter — modal + autocomplete (#2983)

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/company-content.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-content.tsx
@@ -53,6 +53,7 @@ export function CompanyContent({ locale, slug }: CompanyContentProps) {
       initialOccupations={data.parsed.occupations}
       initialSeniorities={data.parsed.seniorities}
       initialTechnologies={data.parsed.technologies}
+      initialWorkMode={data.parsed.workMode}
       initialSalaryCurrency={data.salaryCurrencyParam !== data.displayCurrency ? data.salaryCurrencyParam : undefined}
       initialSalaryMin={data.salaryMinDisplay}
       initialSalaryMax={data.salaryMaxDisplay}

--- a/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
@@ -19,7 +19,7 @@ import { PendingJobIcon } from "@/components/PendingJobWarning";
 import { getCurrencyRates, type CurrencyRate } from "@/lib/actions/search";
 import type { CompanyDetail } from "@/lib/actions/company";
 import { buildFilteredPath } from "@/lib/search/query-params";
-import type { SearchResultPosting, HistogramFilters } from "@/lib/search";
+import type { SearchResultPosting, HistogramFilters, WorkMode } from "@/lib/search";
 import type { SelectedLocation } from "@/components/search/location-pills";
 import { useSearchStateStore } from "@/components/SearchStateProvider";
 
@@ -38,6 +38,7 @@ interface CompanyPageProps {
   initialOccupations: TaxonomyItem[];
   initialSeniorities: TaxonomyItem[];
   initialTechnologies: TaxonomyItem[];
+  initialWorkMode: WorkMode[];
   initialSalaryCurrency?: string;
   initialSalaryMin?: number;
   initialSalaryMax?: number;
@@ -65,6 +66,7 @@ export function CompanyPage({
   initialOccupations,
   initialSeniorities,
   initialTechnologies,
+  initialWorkMode,
   initialSalaryCurrency,
   initialSalaryMin,
   initialSalaryMax,
@@ -100,6 +102,7 @@ export function CompanyPage({
   const [experienceMin, setExperienceMin] = useState<number | undefined>(initialExperienceMin);
   const [experienceMax, setExperienceMax] = useState<number | undefined>(initialExperienceMax);
   const [employmentTypes, setEmploymentTypes] = useState<string[]>([]);
+  const [workMode, setWorkMode] = useState<WorkMode[]>(initialWorkMode);
   const [postings, setPostings] = useState<SearchResultPosting[]>(initialPostings);
   const [activeCount, setActiveCount] = useState(initialActiveCount);
   const [yearCount, setYearCount] = useState(initialYearCount);
@@ -123,6 +126,7 @@ export function CompanyPage({
   const senioritiesRef = useRef(seniorities);
   const technologiesRef = useRef(technologies);
   const employmentTypesRef = useRef(employmentTypes);
+  const workModeRef = useRef(workMode);
   const salaryCurrencyRef = useRef(salaryCurrency);
   const salaryMinRef = useRef(salaryMin);
   const salaryMaxRef = useRef(salaryMax);
@@ -135,6 +139,7 @@ export function CompanyPage({
   senioritiesRef.current = seniorities;
   technologiesRef.current = technologies;
   employmentTypesRef.current = employmentTypes;
+  workModeRef.current = workMode;
   salaryCurrencyRef.current = salaryCurrency;
   salaryMinRef.current = salaryMin;
   salaryMaxRef.current = salaryMax;
@@ -143,7 +148,7 @@ export function CompanyPage({
   showPostingIdRef.current = showPostingId;
 
   const hasMore = !exhausted && !isTruncated && postings.length < yearCount;
-  const hasFilters = keywords.length > 0 || locations.length > 0 || occupations.length > 0 || seniorities.length > 0 || technologies.length > 0 || salaryMin != null || salaryMax != null || experienceMin != null || experienceMax != null;
+  const hasFilters = keywords.length > 0 || locations.length > 0 || occupations.length > 0 || seniorities.length > 0 || technologies.length > 0 || employmentTypes.length > 0 || workMode.length > 0 || salaryMin != null || salaryMax != null || experienceMin != null || experienceMax != null;
 
   /** Convert a salary amount from the user's display currency to EUR. */
   function toEur(amount: number | undefined): number | undefined {
@@ -191,6 +196,7 @@ export function CompanyPage({
       occupationsRef.current,
       senioritiesRef.current,
       technologiesRef.current,
+      workModeRef.current,
     );
     window.history.replaceState(null, "", url);
   }
@@ -203,6 +209,7 @@ export function CompanyPage({
     const seniorityIds = senioritiesRef.current.map((s) => s.id);
     const technologyIds = technologiesRef.current.map((t) => t.id);
     const etypes = employmentTypesRef.current;
+    const wm = workModeRef.current;
     const salMinEur = toEur(salaryMinRef.current);
     const salMaxEur = toEur(salaryMaxRef.current);
     const expMin = experienceMinRef.current;
@@ -217,6 +224,7 @@ export function CompanyPage({
           seniorityIds: seniorityIds.length > 0 ? seniorityIds : undefined,
           technologyIds: technologyIds.length > 0 ? technologyIds : undefined,
           employmentTypes: etypes.length > 0 ? etypes : undefined,
+          workMode: wm.length > 0 ? wm : undefined,
           salaryMinEur: salMinEur,
           salaryMaxEur: salMaxEur,
           experienceMin: expMin,
@@ -287,6 +295,14 @@ export function CompanyPage({
         const updated = [...employmentTypesRef.current, type];
         setEmploymentTypes(updated);
         employmentTypesRef.current = updated;
+        updateUrl();
+        runSearch();
+      },
+      addWorkMode: (mode) => {
+        if (workModeRef.current.includes(mode)) return;
+        const updated = [...workModeRef.current, mode];
+        setWorkMode(updated);
+        workModeRef.current = updated;
         updateUrl();
         runSearch();
       },
@@ -453,6 +469,8 @@ export function CompanyPage({
     setOccupations([]); occupationsRef.current = [];
     setSeniorities([]); senioritiesRef.current = [];
     setTechnologies([]); technologiesRef.current = [];
+    setEmploymentTypes([]); employmentTypesRef.current = [];
+    setWorkMode([]); workModeRef.current = [];
     setSalaryCurrency(displayCurrency); salaryCurrencyRef.current = displayCurrency;
     setSalaryMin(undefined); salaryMinRef.current = undefined;
     setSalaryMax(undefined); salaryMaxRef.current = undefined;
@@ -469,6 +487,7 @@ export function CompanyPage({
     const seniorityIds = seniorities.length > 0 ? seniorities.map((s) => s.id) : undefined;
     const technologyIds = technologies.length > 0 ? technologies.map((t) => t.id) : undefined;
     const etypes = employmentTypes.length > 0 ? employmentTypes : undefined;
+    const wm = workMode.length > 0 ? workMode : undefined;
     const salMinEur = toEur(salaryMin);
     const salMaxEur = toEur(salaryMax);
 
@@ -481,6 +500,7 @@ export function CompanyPage({
         seniorityIds,
         technologyIds,
         employmentTypes: etypes,
+        workMode: wm,
         salaryMinEur: salMinEur,
         salaryMaxEur: salMaxEur,
         experienceMin,
@@ -584,6 +604,15 @@ export function CompanyPage({
           const updated = exists ? employmentTypesRef.current.filter((t) => t !== type) : [...employmentTypesRef.current, type];
           setEmploymentTypes(updated);
           employmentTypesRef.current = updated;
+          updateUrl();
+          runSearch();
+        }}
+        workMode={workMode}
+        onToggleWorkMode={(mode) => {
+          const exists = workModeRef.current.includes(mode);
+          const updated = exists ? workModeRef.current.filter((m) => m !== mode) : [...workModeRef.current, mode];
+          setWorkMode(updated);
+          workModeRef.current = updated;
           updateUrl();
           runSearch();
         }}

--- a/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
+++ b/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
@@ -60,6 +60,7 @@ function makeInitialData(overrides: Partial<ExploreData> = {}): ExploreData {
       occupations: [],
       seniorities: [],
       technologies: [],
+      workMode: [],
     },
     displayCurrency: "EUR",
     jobLanguages: [],

--- a/apps/web/app/[lang]/(app)/explore/explore-content.tsx
+++ b/apps/web/app/[lang]/(app)/explore/explore-content.tsx
@@ -24,7 +24,7 @@ type ExploreContentProps = {
  * are present, the prerendered ``initialData`` doesn't reflect the
  * filters and we must re-fetch the personalized variant.
  */
-const FILTER_PARAMS = ["q", "loc", "occ", "sen", "tech", "sal", "salcur", "exp"];
+const FILTER_PARAMS = ["q", "loc", "occ", "sen", "tech", "wm", "sal", "salcur", "exp"];
 
 function hasAnyFilterParam(searchParams: URLSearchParams): boolean {
   for (const key of FILTER_PARAMS) {
@@ -82,6 +82,7 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
       initialOccupations={parsed.occupations}
       initialSeniorities={parsed.seniorities}
       initialTechnologies={parsed.technologies}
+      initialWorkMode={parsed.workMode}
       initialSalaryCurrency={salaryCurrencyParam !== displayCurrency ? salaryCurrencyParam : undefined}
       initialSalaryMin={salaryMinDisplay}
       initialSalaryMax={salaryMaxDisplay}

--- a/apps/web/app/[lang]/(app)/explore/search-page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/search-page.tsx
@@ -15,7 +15,7 @@ import { useClearTypesenseOnAuthChange } from "@/lib/search/use-clear-typesense-
 import { useSession } from "@/components/SessionProvider";
 import { parseSearchFilters } from "@/lib/actions/search-input";
 import { buildFilteredPath } from "@/lib/search/query-params";
-import type { SearchResultCompany, HistogramFilters } from "@/lib/search";
+import type { SearchResultCompany, HistogramFilters, WorkMode } from "@/lib/search";
 import {
   useSearchStateStore,
   buildCacheKey,
@@ -34,6 +34,7 @@ interface SearchPageProps {
   initialOccupations: TaxonomyItem[];
   initialSeniorities: TaxonomyItem[];
   initialTechnologies: TaxonomyItem[];
+  initialWorkMode: WorkMode[];
   initialSalaryCurrency?: string;
   initialSalaryMin?: number;
   initialSalaryMax?: number;
@@ -58,6 +59,7 @@ export function SearchPage({
   initialOccupations,
   initialSeniorities,
   initialTechnologies,
+  initialWorkMode,
   initialSalaryCurrency,
   initialSalaryMin,
   initialSalaryMax,
@@ -122,6 +124,9 @@ export function SearchPage({
   );
 
   const [employmentTypes, setEmploymentTypes] = useState<string[]>([]);
+  const [workMode, setWorkMode] = useState<WorkMode[]>(
+    shouldRestore ? cached.workMode : initialWorkMode,
+  );
 
   // Currency rates for EUR conversion (fetched lazily)
   const [currencyRates, setCurrencyRates] = useState<CurrencyRate[]>([]);
@@ -155,6 +160,7 @@ export function SearchPage({
   const senioritiesRef = useRef(seniorities);
   const technologiesRef = useRef(technologies);
   const employmentTypesRef = useRef(employmentTypes);
+  const workModeRef = useRef(workMode);
   const salaryCurrencyRef = useRef(salaryCurrency);
   const salaryMinRef = useRef(salaryMin);
   const salaryMaxRef = useRef(salaryMax);
@@ -169,6 +175,7 @@ export function SearchPage({
   senioritiesRef.current = seniorities;
   technologiesRef.current = technologies;
   employmentTypesRef.current = employmentTypes;
+  workModeRef.current = workMode;
   salaryCurrencyRef.current = salaryCurrency;
   salaryMinRef.current = salaryMin;
   salaryMaxRef.current = salaryMax;
@@ -214,6 +221,7 @@ export function SearchPage({
     const occ = searchParams.get("occ") ?? undefined;
     const sen = searchParams.get("sen") ?? undefined;
     const tech = searchParams.get("tech") ?? undefined;
+    const wm = searchParams.get("wm") ?? undefined;
     const sal = searchParams.get("sal") ?? undefined;
     const salcur = searchParams.get("salcur") ?? undefined;
     const exp = searchParams.get("exp") ?? undefined;
@@ -235,12 +243,13 @@ export function SearchPage({
     }
 
     setIsSearching(true);
-    parseSearchFilters({ q, loc, occ, sen, tech, locale, userLat, userLng }).then((parsed) => {
+    parseSearchFilters({ q, loc, occ, sen, tech, wm, locale, userLat, userLng }).then((parsed) => {
       setKeywords(parsed.keywords); keywordsRef.current = parsed.keywords;
       setLocations(parsed.locations); locationsRef.current = parsed.locations;
       setOccupations(parsed.occupations); occupationsRef.current = parsed.occupations;
       setSeniorities(parsed.seniorities); senioritiesRef.current = parsed.seniorities;
       setTechnologies(parsed.technologies); technologiesRef.current = parsed.technologies;
+      setWorkMode(parsed.workMode); workModeRef.current = parsed.workMode;
       runSearch();
     });
   }, [searchParams]);
@@ -262,6 +271,7 @@ export function SearchPage({
         occupations: occupationsRef.current,
         seniorities: senioritiesRef.current,
         technologies: technologiesRef.current,
+        workMode: workModeRef.current,
         salaryMinEur: salaryMinRef.current,
         salaryMaxEur: salaryMaxRef.current,
         salaryCurrency: salaryCurrencyRef.current,
@@ -337,6 +347,14 @@ export function SearchPage({
         updateUrl();
         runSearch();
       },
+      addWorkMode: (mode) => {
+        if (workModeRef.current.includes(mode)) return;
+        const updated = [...workModeRef.current, mode];
+        setWorkMode(updated);
+        workModeRef.current = updated;
+        updateUrl();
+        runSearch();
+      },
       setSalaryFilter: (currency: string, min: number | undefined, max: number | undefined) => {
         setSalaryCurrency(currency); salaryCurrencyRef.current = currency;
         setSalaryMin(min); salaryMinRef.current = min;
@@ -364,6 +382,7 @@ export function SearchPage({
         cached.occupations,
         cached.seniorities,
         cached.technologies,
+        cached.workMode,
       );
       window.history.replaceState(null, "", url);
 
@@ -376,7 +395,7 @@ export function SearchPage({
   }, []);
 
   const hasMore = companies.length < totalCompanies && !isTruncated;
-  const hasFilters = keywords.length > 0 || locations.length > 0 || occupations.length > 0 || seniorities.length > 0 || technologies.length > 0 || employmentTypes.length > 0 || salaryMin != null || salaryMax != null || experienceMin != null || experienceMax != null;
+  const hasFilters = keywords.length > 0 || locations.length > 0 || occupations.length > 0 || seniorities.length > 0 || technologies.length > 0 || employmentTypes.length > 0 || workMode.length > 0 || salaryMin != null || salaryMax != null || experienceMin != null || experienceMax != null;
 
   /** Update only the `show` query param without touching filter state. */
   function updateShowParam(postingId: string | null) {
@@ -412,6 +431,7 @@ export function SearchPage({
       occupationsRef.current,
       senioritiesRef.current,
       technologiesRef.current,
+      workModeRef.current,
     );
     window.history.replaceState(null, "", url);
   };
@@ -436,6 +456,7 @@ export function SearchPage({
     const seniorityIds = senioritiesRef.current.map((s) => s.id);
     const technologyIds = technologiesRef.current.map((t) => t.id);
     const etypes = employmentTypesRef.current;
+    const wm = workModeRef.current;
     const salMinEur = toEur(salaryMinRef.current);
     const salMaxEur = toEur(salaryMaxRef.current);
     const expMin = experienceMinRef.current;
@@ -454,6 +475,7 @@ export function SearchPage({
                   seniorityIds: seniorityIds.length > 0 ? seniorityIds : undefined,
                   technologyIds: technologyIds.length > 0 ? technologyIds : undefined,
                   employmentTypes: etypes.length > 0 ? etypes : undefined,
+                  workMode: wm.length > 0 ? wm : undefined,
                   salaryMinEur: salMinEur,
                   salaryMaxEur: salMaxEur,
                   experienceMin: expMin,
@@ -472,6 +494,7 @@ export function SearchPage({
                   seniorityIds: seniorityIds.length > 0 ? seniorityIds : undefined,
                   technologyIds: technologyIds.length > 0 ? technologyIds : undefined,
                   employmentTypes: etypes.length > 0 ? etypes : undefined,
+                  workMode: wm.length > 0 ? wm : undefined,
                   salaryMinEur: salMinEur,
                   salaryMaxEur: salMaxEur,
                   experienceMin: expMin,
@@ -643,6 +666,7 @@ export function SearchPage({
     setSeniorities([]); senioritiesRef.current = [];
     setTechnologies([]); technologiesRef.current = [];
     setEmploymentTypes([]); employmentTypesRef.current = [];
+    setWorkMode([]); workModeRef.current = [];
     setSalaryCurrency(displayCurrency); salaryCurrencyRef.current = displayCurrency;
     setSalaryMin(undefined); salaryMinRef.current = undefined;
     setSalaryMax(undefined); salaryMaxRef.current = undefined;
@@ -661,13 +685,14 @@ export function SearchPage({
     const seniorityIds = senioritiesRef.current.length > 0 ? senioritiesRef.current.map((s) => s.id) : undefined;
     const technologyIds = technologiesRef.current.length > 0 ? technologiesRef.current.map((t) => t.id) : undefined;
     const etypes = employmentTypesRef.current.length > 0 ? employmentTypesRef.current : undefined;
+    const wm = workModeRef.current.length > 0 ? workModeRef.current : undefined;
     const salMinEur = toEur(salaryMinRef.current);
     const salMaxEur = toEur(salaryMaxRef.current);
     const expMin = experienceMinRef.current;
     const expMax = experienceMaxRef.current;
     const result = kws.length > 0
-      ? await runSearchJobs({ keywords: kws, locationIds, occupationIds, seniorityIds, technologyIds, employmentTypes: etypes, salaryMinEur: salMinEur, salaryMaxEur: salMaxEur, experienceMin: expMin, experienceMax: expMax, languages, locale, offset, limit: PAGE_SIZE }, isLoggedInRef.current)
-      : await runListTopCompanies({ locationIds, occupationIds, seniorityIds, technologyIds, employmentTypes: etypes, salaryMinEur: salMinEur, salaryMaxEur: salMaxEur, experienceMin: expMin, experienceMax: expMax, languages, locale, offset, limit: PAGE_SIZE }, isLoggedInRef.current);
+      ? await runSearchJobs({ keywords: kws, locationIds, occupationIds, seniorityIds, technologyIds, employmentTypes: etypes, workMode: wm, salaryMinEur: salMinEur, salaryMaxEur: salMaxEur, experienceMin: expMin, experienceMax: expMax, languages, locale, offset, limit: PAGE_SIZE }, isLoggedInRef.current)
+      : await runListTopCompanies({ locationIds, occupationIds, seniorityIds, technologyIds, employmentTypes: etypes, workMode: wm, salaryMinEur: salMinEur, salaryMaxEur: salMaxEur, experienceMin: expMin, experienceMax: expMax, languages, locale, offset, limit: PAGE_SIZE }, isLoggedInRef.current);
 
     if (result.truncated) setIsTruncated(true);
     serverOffsetRef.current += result.companies.length;
@@ -723,6 +748,15 @@ export function SearchPage({
           updateUrl();
           runSearch();
         }}
+        workMode={workMode}
+        onToggleWorkMode={(mode) => {
+          const exists = workModeRef.current.includes(mode);
+          const updated = exists ? workModeRef.current.filter((m) => m !== mode) : [...workModeRef.current, mode];
+          setWorkMode(updated);
+          workModeRef.current = updated;
+          updateUrl();
+          runSearch();
+        }}
         onSalaryChange={handleSalaryChange}
         onExperienceChange={handleExperienceChange}
         histogramFilters={histogramFilters}
@@ -745,6 +779,7 @@ export function SearchPage({
             seniorities={seniorities}
             technologies={technologies}
             employmentTypes={employmentTypes}
+            workMode={workMode}
             salaryMinEur={toEur(salaryMin)}
             salaryMaxEur={toEur(salaryMax)}
             experienceMin={experienceMin}

--- a/apps/web/app/api/v1/search/route.ts
+++ b/apps/web/app/api/v1/search/route.ts
@@ -16,11 +16,12 @@ export async function GET(request: NextRequest) {
   const occ = sp.get("occ") ?? undefined;
   const sen = sp.get("sen") ?? undefined;
   const tech = sp.get("tech") ?? undefined;
+  const wm = sp.get("wm") ?? undefined;
   const sal = sp.get("sal") ?? undefined;
   const exp = sp.get("exp") ?? undefined;
   const locale = sp.get("locale") ?? "en";
 
-  const parsed = await parseSearchFilters({ q, loc, occ, sen, tech, locale });
+  const parsed = await parseSearchFilters({ q, loc, occ, sen, tech, wm, locale });
 
   const locationIds =
     parsed.locations.length > 0 ? parsed.locations.map((l) => l.id) : undefined;
@@ -58,6 +59,7 @@ export async function GET(request: NextRequest) {
     occupationIds,
     seniorityIds,
     technologyIds,
+    workMode: parsed.workMode.length > 0 ? parsed.workMode : undefined,
     salaryMinEur,
     salaryMaxEur,
     experienceMin,

--- a/apps/web/app/api/v1/watchlist/create/route.ts
+++ b/apps/web/app/api/v1/watchlist/create/route.ts
@@ -22,6 +22,7 @@ export async function GET(request: NextRequest) {
   const occ = sp.get("occ") ?? undefined;
   const sen = sp.get("sen") ?? undefined;
   const tech = sp.get("tech") ?? undefined;
+  const wm = sp.get("wm") ?? undefined;
   const sal = sp.get("sal") ?? undefined;
   const salcur = sp.get("salcur") ?? undefined;
   const exp = sp.get("exp") ?? undefined;
@@ -29,7 +30,7 @@ export async function GET(request: NextRequest) {
   const companies = sp.get("companies") ?? undefined;
 
   // Resolve slugs to get matching counts for the preview
-  const parsed = await parseSearchFilters({ q, loc, occ, sen, tech, locale });
+  const parsed = await parseSearchFilters({ q, loc, occ, sen, tech, wm, locale });
 
   const locationIds =
     parsed.locations.length > 0 ? parsed.locations.map((l) => l.id) : undefined;
@@ -67,6 +68,7 @@ export async function GET(request: NextRequest) {
     occupationIds,
     seniorityIds,
     technologyIds,
+    workMode: parsed.workMode.length > 0 ? parsed.workMode : undefined,
     salaryMinEur,
     salaryMaxEur,
     experienceMin,
@@ -97,6 +99,7 @@ export async function GET(request: NextRequest) {
   if (occ) createParams.set("occ", occ);
   if (sen) createParams.set("sen", sen);
   if (tech) createParams.set("tech", tech);
+  if (wm) createParams.set("wm", wm);
   if (sal) createParams.set("sal", sal);
   if (salcur) createParams.set("salcur", salcur);
   if (exp) createParams.set("exp", exp);

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -212,8 +212,8 @@ msgstr "Kontomenü"
 #. Active postings count on company page
 #. Active postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:534
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:544
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:554
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:564
 msgid "company.page.active"
 msgstr "aktiv"
 
@@ -227,7 +227,7 @@ msgstr "aktiv"
 
 #. Active matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:117
+#: src/components/search/company-card.tsx:120
 msgid "search.card.active"
 msgstr "aktiv"
 
@@ -297,16 +297,16 @@ msgstr "Alle Daten werden bei Übertragung und Speicherung verschlüsselt."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Alle Branchen"
 
-#. Title for the all-languages modal in settings
-#. js-lingui-explicit-id
-#: src/components/settings/JobLanguageModal.tsx:56
-msgid "settings.jobLanguages.modal.title"
-msgstr "Alle Sprachen"
-
 #. All languages option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:244
 msgid "settings.general.jobLanguages.all"
+msgstr "Alle Sprachen"
+
+#. Title for the all-languages modal in settings
+#. js-lingui-explicit-id
+#: src/components/settings/JobLanguageModal.tsx:56
+msgid "settings.jobLanguages.modal.title"
 msgstr "Alle Sprachen"
 
 #. Title for the all-locations modal on company page
@@ -404,6 +404,12 @@ msgstr "Bewerbungen im letzten Jahr"
 msgid "myJobs.group.applied"
 msgstr "Beworben"
 
+#. Application tracker status: applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:449
+msgid "search.tracker.applied"
+msgstr "Beworben"
+
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
@@ -414,12 +420,6 @@ msgstr "Beworben"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
-msgstr "Beworben"
-
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:449
-msgid "search.tracker.applied"
 msgstr "Beworben"
 
 #. Status option in dropdown: applied
@@ -482,16 +482,16 @@ msgstr "Aug"
 msgid "settings.account.username.available"
 msgstr "Verfügbar"
 
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Zurück zur Anmeldung"
-
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Zurück zur Anmeldung"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Zurück zur Anmeldung"
 
 #. Link back to sign-in from forgot password
@@ -711,7 +711,7 @@ msgstr "Alle entfernen"
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:553
-#: src/components/search/search-toolbar.tsx:309
+#: src/components/search/search-toolbar.tsx:337
 msgid "search.filters.clearAll"
 msgstr "Alle löschen"
 
@@ -747,13 +747,13 @@ msgstr "Menü schließen"
 
 #. Label for inactive/closed job postings on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:627
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:656
 msgid "company.page.closed"
 msgstr "Geschlossen"
 
 #. Label for inactive/closed job postings on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:140
+#: src/components/search/company-card.tsx:143
 msgid "search.card.closed"
 msgstr "Geschlossen"
 
@@ -789,7 +789,7 @@ msgstr "Demnächst verfügbar"
 
 #. Section header for company suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:748
+#: src/components/search/search-bar.tsx:882
 msgid "search.bar.companies"
 msgstr "Unternehmen"
 
@@ -863,6 +863,12 @@ msgstr "Verbinden"
 msgid "settings.account.socials.title"
 msgstr "Verknüpfte Konten"
 
+#. Footer link to contact email
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Kontakt"
+
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:25
@@ -875,22 +881,16 @@ msgstr "Kontakt"
 msgid "license.contact.title"
 msgstr "Kontakt"
 
-#. Footer link to contact email
+#. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Kontakt"
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
+msgstr "Inhalt"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
-msgstr "Inhalt"
-
-#. Table of contents heading
-#. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
 msgstr "Inhalt"
 
 #. Button to continue to app after verification
@@ -999,7 +999,7 @@ msgstr "Erstellen Sie ein kostenloses Konto, um alle Ergebnisse zu durchsuchen, 
 
 #. Tooltip explaining save search creates a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:102
+#: src/components/search/save-search-button.tsx:106
 msgid "search.saveSearch.tooltip"
 msgstr "Erstelle eine Watchlist aus deinen aktuellen Filtern"
 
@@ -1313,7 +1313,7 @@ msgstr "Erfahrung"
 
 #. Label for experience filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:177
+#: src/components/search/advanced-search-panel.tsx:189
 msgid "search.advanced.experience"
 msgstr "Erfahrung"
 
@@ -1459,7 +1459,7 @@ msgstr "Filter"
 
 #. Toggle button for advanced search filters panel
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:138
+#: src/components/search/advanced-search-panel.tsx:144
 msgid "search.advanced.toggle"
 msgstr "Filter"
 
@@ -1714,6 +1714,16 @@ msgstr "Wie wir Stellenanzeigen finden und verarbeiten"
 msgid "indexing.meta.title"
 msgstr "So indexieren wir"
 
+#. Work mode: hybrid (mixed onsite/remote)
+#. Work mode: hybrid (mixed onsite/remote)
+#. Work mode: hybrid (mixed onsite/remote)
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:812
+#: src/components/search/search-toolbar.tsx:260
+#: src/components/search/work-mode-modal.tsx:21
+msgid "search.workMode.hybrid"
+msgstr "Hybrid"
+
 #. Description after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:63
@@ -1746,8 +1756,8 @@ msgstr "in {locations}"
 #. Year postings count on company page
 #. Year postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:536
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:548
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:556
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:568
 msgid "company.page.yearCount"
 msgstr "im letzten Jahr"
 
@@ -1761,7 +1771,7 @@ msgstr "im letzten Jahr"
 
 #. Yearly matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:119
+#: src/components/search/company-card.tsx:122
 msgid "search.card.yearCount"
 msgstr "im letzten Jahr"
 
@@ -1843,16 +1853,16 @@ msgstr "Interview-Protokoll"
 msgid "myJobs.group.interviewing"
 msgstr "Im Interview"
 
-#. Interviewing status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:21
-msgid "myJobs.status.interviewing"
-msgstr "Im Interview"
-
 #. Application tracker status: interviewing
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:450
 msgid "search.tracker.interviewing"
+msgstr "Im Interview"
+
+#. Interviewing status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:21
+msgid "myJobs.status.interviewing"
 msgstr "Im Interview"
 
 #. Status option in dropdown: interviewing
@@ -1900,16 +1910,16 @@ msgstr "Gibt es ein Limit, wie viele Jobs ich verfolgen kann?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:31
-msgid "watchlists.card.jobSingular"
-msgstr "Job"
-
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:121
 msgid "watchlists.explore.jobSingular"
+msgstr "Job"
+
+#. Singular job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:31
+msgid "watchlists.card.jobSingular"
 msgstr "Job"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -2012,16 +2022,16 @@ msgstr "Die Codebasis von Job Seek ist Open Source unter MIT. Die von uns gesamm
 msgid "watchlist.meta.fallback"
 msgstr "Job-Watchlist von @{owner}"
 
-#. Plural job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:32
-msgid "watchlists.card.jobPlural"
-msgstr "Jobs"
-
 #. Plural job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:122
 msgid "watchlists.explore.jobPlural"
+msgstr "Jobs"
+
+#. Plural job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:32
+msgid "watchlists.card.jobPlural"
 msgstr "Jobs"
 
 #. js-lingui-explicit-id
@@ -2102,13 +2112,13 @@ msgstr "Mehr erfahren"
 
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:638
+#: src/components/search/search-bar.tsx:730
 msgid "search.bar.level"
 msgstr "Stufe"
 
 #. Label for seniority/level filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:154
+#: src/components/search/advanced-search-panel.tsx:160
 msgid "search.advanced.level"
 msgstr "Stufe"
 
@@ -2174,20 +2184,20 @@ msgstr "Standort"
 
 #. Label for location filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:146
+#: src/components/search/advanced-search-panel.tsx:152
 msgid "search.advanced.location"
 msgstr "Standort"
-
-#. Section header for location suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:708
-msgid "search.bar.locations"
-msgstr "Standorte"
 
 #. Locations heading in job detail
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:312
 msgid "search.detail.locations"
+msgstr "Standorte"
+
+#. Section header for location suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:842
+msgid "search.bar.locations"
 msgstr "Standorte"
 
 #. Login button label
@@ -2206,7 +2216,7 @@ msgstr "Anmelden"
 
 #. Tooltip when user needs to log in to save search
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:107
+#: src/components/search/save-search-button.tsx:111
 msgid "search.saveSearch.tooltipLogin"
 msgstr "Melde dich an, um diese Suche als Watchlist zu speichern"
 
@@ -2482,7 +2492,7 @@ msgstr "Keine Standorte entsprechen Ihrer Suche."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:608
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:637
 msgid "company.page.noResults"
 msgstr "Keine passenden Stellenanzeigen gefunden."
 
@@ -2506,7 +2516,7 @@ msgstr "Keine Ergebnisse für „{query}\" gefunden"
 
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:293
+#: src/components/search/occupation-modal.tsx:341
 msgid "search.occupationModal.noResults"
 msgstr "Keine Berufe gefunden."
 
@@ -2556,16 +2566,16 @@ msgstr "Nein. Der Bewerbungstracker hat kein festes Limit — speichere so viele
 msgid "faq.a.dataPrivacy"
 msgstr "Nein. Wir verkaufen, vermieten oder teilen deine Daten nicht zu Marketingzwecken. Cookies sind nur sitzungsbasiert, ohne Werbung oder Tracking. Du kannst dein Konto löschen und alle Daten werden innerhalb von 30 Tagen entfernt."
 
-#. Sankey funnel node: not applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:44
-msgid "myJobs.funnel.notApplied"
-msgstr "Nicht beworben"
-
 #. Application tracker status: not applied
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:448
 msgid "search.tracker.notApplied"
+msgstr "Nicht beworben"
+
+#. Sankey funnel node: not applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:44
+msgid "myJobs.funnel.notApplied"
 msgstr "Nicht beworben"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2592,16 +2602,16 @@ msgstr "Berufsfeld"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Okt"
 
-#. Offered status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:22
-msgid "myJobs.status.offered"
-msgstr "Angebot"
-
 #. Application tracker status: offer
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:451
 msgid "search.tracker.offer"
+msgstr "Angebot"
+
+#. Offered status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:22
+msgid "myJobs.status.offered"
 msgstr "Angebot"
 
 #. Status group heading: offered
@@ -2627,6 +2637,16 @@ msgstr "Angebot"
 #: src/components/CookieBanner.tsx:66
 msgid "common.cookies.ok"
 msgstr "Ok"
+
+#. Work mode: onsite (in-office)
+#. Work mode: onsite (in-office)
+#. Work mode: onsite (in-office)
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:810
+#: src/components/search/search-toolbar.tsx:258
+#: src/components/search/work-mode-modal.tsx:20
+msgid "search.workMode.onsite"
+msgstr "Vor Ort"
 
 #. Step 4 body
 #. js-lingui-explicit-id
@@ -2725,26 +2745,26 @@ msgstr "Unsere Haltung zur Automatisierung"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:22
-msgid "license.toc.overview"
-msgstr "Überblick"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:27
 msgid "indexing.toc.overview"
 msgstr "Überblick"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:19
-msgid "license.toc.ariaLabel"
-msgstr "Seiteninhalt"
+#: src/components/LicenseContent.tsx:22
+msgid "license.toc.overview"
+msgstr "Überblick"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:24
 msgid "indexing.toc.ariaLabel"
+msgstr "Seiteninhalt"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:19
+msgid "license.toc.ariaLabel"
 msgstr "Seiteninhalt"
 
 #. Heading shown on the 404 page
@@ -2935,18 +2955,18 @@ msgstr "Stelle nicht gefunden."
 msgid "myJobs.detail.notFound"
 msgstr "Stellenanzeige nicht gefunden."
 
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: src/components/Pricing.tsx:100
-msgid "home.pricing.eyebrow"
-msgstr "Preise"
-
 #. Nav link: Pricing
 #. Nav link: Pricing
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:62
 #: src/components/MobileMenu.tsx:87
 msgid "common.nav.pricing"
+msgstr "Preise"
+
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:100
+msgid "home.pricing.eyebrow"
 msgstr "Preise"
 
 #. Privacy policy page eyebrow
@@ -3092,6 +3112,12 @@ msgstr "Regionen"
 msgid "myJobs.group.rejected"
 msgstr "Abgelehnt"
 
+#. Application tracker status: rejected
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:452
+msgid "search.tracker.rejected"
+msgstr "Abgelehnt"
+
 #. Rejected status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:23
@@ -3102,12 +3128,6 @@ msgstr "Abgelehnt"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
-msgstr "Abgelehnt"
-
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:452
-msgid "search.tracker.rejected"
 msgstr "Abgelehnt"
 
 #. Status option in dropdown: rejected
@@ -3121,6 +3141,16 @@ msgstr "Abgelehnt"
 #: src/components/Footer.tsx:29
 msgid "common.footer.text"
 msgstr "Veröffentlicht unter der MIT-Lizenz. Stellendaten sind CC BY-NC 4.0."
+
+#. Work mode: remote (work-from-home)
+#. Work mode: remote (work-from-home)
+#. Work mode: remote (work-from-home)
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:813
+#: src/components/search/search-toolbar.tsx:261
+#: src/components/search/work-mode-modal.tsx:22
+msgid "search.workMode.remote"
+msgstr "Remote"
 
 #. Aria label for removing a keyword pill
 #. js-lingui-explicit-id
@@ -3136,7 +3166,7 @@ msgstr "Standort entfernen"
 
 #. Synthetic dropdown row that lets the user request a company that's not in the catalog
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:800
+#: src/components/search/search-bar.tsx:934
 msgid "search.bar.request"
 msgstr "„{trimmedInput}\" anfragen"
 
@@ -3220,13 +3250,13 @@ msgstr "Robots, Attribution und TDM-Reservation."
 
 #. Label for role/occupation filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:150
+#: src/components/search/advanced-search-panel.tsx:156
 msgid "search.advanced.role"
 msgstr "Beruf"
 
 #. Section header for occupation suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:603
+#: src/components/search/search-bar.tsx:695
 msgid "search.bar.roles"
 msgstr "Berufe"
 
@@ -3244,7 +3274,7 @@ msgstr "Run-ID"
 
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:171
+#: src/components/search/advanced-search-panel.tsx:183
 msgid "search.advanced.salary"
 msgstr "Gehalt"
 
@@ -3304,7 +3334,7 @@ msgstr "Speichern Sie Jobs und verfolgen Sie Ihre Bewerbungen, um hier Statistik
 
 #. Button label to save current search as a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:95
+#: src/components/search/save-search-button.tsx:99
 msgid "search.saveSearch.label"
 msgstr "Diese Suche speichern"
 
@@ -3359,7 +3389,7 @@ msgstr "Suche über tausende Unternehmen hinweg, direkt von ihren Karriereseiten
 #. Placeholder for search bar when on company page
 #. js-lingui-explicit-id
 #. placeholder {0}: company.name
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:156
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:161
 msgid "company.page.searchPlaceholder"
 msgstr "Suchen bei {0}..."
 
@@ -3377,7 +3407,7 @@ msgstr "Unternehmen suchen..."
 
 #. Option to search by title keyword in dropdown
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:591
+#: src/components/search/search-bar.tsx:683
 msgid "search.bar.keyword"
 msgstr "Nach \"{trimmedInput}\" in Jobtiteln suchen"
 
@@ -3412,7 +3442,7 @@ msgstr "Suchergebnisse"
 
 #. Placeholder for search input in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:272
+#: src/components/search/occupation-modal.tsx:320
 msgid "search.occupationModal.searchPlaceholder"
 msgstr "Berufe suchen..."
 
@@ -3430,7 +3460,7 @@ msgstr "Suche mit Präzision"
 
 #. Placeholder for the main search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:518
+#: src/components/search/search-bar.tsx:608
 msgid "search.bar.placeholder"
 msgstr "Suchen…"
 
@@ -3454,7 +3484,7 @@ msgstr "Standort auswählen"
 
 #. Title for the occupation selection modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:252
+#: src/components/search/occupation-modal.tsx:300
 msgid "search.occupationModal.title"
 msgstr "Beruf auswählen"
 
@@ -3554,16 +3584,16 @@ msgstr "Einstellungen"
 msgid "home.features.s3.p3.title"
 msgstr "Mit jedem teilen"
 
-#. Collapse location pill list
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:351
-msgid "company.page.showLess"
-msgstr "Weniger anzeigen"
-
 #. Button to collapse location list
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:355
 msgid "search.detail.showLessLocations"
+msgstr "Weniger anzeigen"
+
+#. Collapse location pill list
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:351
+msgid "company.page.showLess"
 msgstr "Weniger anzeigen"
 
 #. Aria label to show password
@@ -3836,16 +3866,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technisch"
 
-#. Section header for technology suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:673
-msgid "search.bar.technologies"
-msgstr "Technologien"
-
 #. Technologies sub-heading in details section
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:397
 msgid "search.detail.technologies"
+msgstr "Technologien"
+
+#. Section header for technology suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:765
+msgid "search.bar.technologies"
 msgstr "Technologien"
 
 #. Add technology filter
@@ -3856,7 +3886,7 @@ msgstr "Technologie"
 
 #. Label for technology filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:159
+#: src/components/search/advanced-search-panel.tsx:165
 msgid "search.advanced.technology"
 msgstr "Technologie"
 
@@ -4022,7 +4052,7 @@ msgstr "Erneut versuchen"
 
 #. Label for employment type filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:165
+#: src/components/search/advanced-search-panel.tsx:171
 msgid "search.advanced.employmentType"
 msgstr "Beschäftigungsart"
 
@@ -4329,7 +4359,7 @@ msgstr "Wir nutzen eine Handvoll Drittanbieter für Anmeldung, Hosting und Speic
 
 #. Secondary line under the Request <query> dropdown row
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:807
+#: src/components/search/search-bar.tsx:941
 msgid "search.bar.request.subtext"
 msgstr "Wir fangen an, sie zu verfolgen"
 
@@ -4381,6 +4411,24 @@ msgstr "Welches Unternehmen sollen wir verfolgen?"
 #: app/[lang]/(public)/faq/page.tsx:92
 msgid "faq.q.languages"
 msgstr "Welche Sprachen unterstützt Jobseek?"
+
+#. Title for the work-mode (onsite/hybrid/remote) selection modal
+#. js-lingui-explicit-id
+#: src/components/search/work-mode-modal.tsx:53
+msgid "search.workModeModal.title"
+msgstr "Arbeitsweise"
+
+#. Section header for work-mode (onsite/hybrid/remote) suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:800
+msgid "search.bar.workMode"
+msgstr "Arbeitsweise"
+
+#. Label for work-mode (onsite/hybrid/remote) filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:177
+msgid "search.advanced.workMode"
+msgstr "Arbeitsweise"
 
 #. Yearly pay period option
 #. js-lingui-explicit-id

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -212,8 +212,8 @@ msgstr "Account menu"
 #. Active postings count on company page
 #. Active postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:534
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:544
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:554
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:564
 msgid "company.page.active"
 msgstr "active"
 
@@ -227,7 +227,7 @@ msgstr "active"
 
 #. Active matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:117
+#: src/components/search/company-card.tsx:120
 msgid "search.card.active"
 msgstr "active"
 
@@ -297,16 +297,16 @@ msgstr "All data is encrypted in transit and at rest."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "All industries"
 
-#. Title for the all-languages modal in settings
-#. js-lingui-explicit-id
-#: src/components/settings/JobLanguageModal.tsx:56
-msgid "settings.jobLanguages.modal.title"
-msgstr "All languages"
-
 #. All languages option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:244
 msgid "settings.general.jobLanguages.all"
+msgstr "All languages"
+
+#. Title for the all-languages modal in settings
+#. js-lingui-explicit-id
+#: src/components/settings/JobLanguageModal.tsx:56
+msgid "settings.jobLanguages.modal.title"
 msgstr "All languages"
 
 #. Title for the all-locations modal on company page
@@ -404,6 +404,12 @@ msgstr "applications in the past year"
 msgid "myJobs.group.applied"
 msgstr "Applied"
 
+#. Application tracker status: applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:449
+msgid "search.tracker.applied"
+msgstr "Applied"
+
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
@@ -414,12 +420,6 @@ msgstr "Applied"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
-msgstr "Applied"
-
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:449
-msgid "search.tracker.applied"
 msgstr "Applied"
 
 #. Status option in dropdown: applied
@@ -482,16 +482,16 @@ msgstr "Aug"
 msgid "settings.account.username.available"
 msgstr "Available"
 
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Back to sign in"
-
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Back to sign in"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Back to sign in"
 
 #. Link back to sign-in from forgot password
@@ -711,7 +711,7 @@ msgstr "Clear all"
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:553
-#: src/components/search/search-toolbar.tsx:309
+#: src/components/search/search-toolbar.tsx:337
 msgid "search.filters.clearAll"
 msgstr "Clear all"
 
@@ -747,13 +747,13 @@ msgstr "Close menu"
 
 #. Label for inactive/closed job postings on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:627
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:656
 msgid "company.page.closed"
 msgstr "Closed"
 
 #. Label for inactive/closed job postings on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:140
+#: src/components/search/company-card.tsx:143
 msgid "search.card.closed"
 msgstr "Closed"
 
@@ -789,7 +789,7 @@ msgstr "Coming soon"
 
 #. Section header for company suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:748
+#: src/components/search/search-bar.tsx:882
 msgid "search.bar.companies"
 msgstr "Companies"
 
@@ -863,6 +863,12 @@ msgstr "Connect"
 msgid "settings.account.socials.title"
 msgstr "Connected accounts"
 
+#. Footer link to contact email
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Contact"
+
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:25
@@ -875,22 +881,16 @@ msgstr "Contact"
 msgid "license.contact.title"
 msgstr "Contact"
 
-#. Footer link to contact email
+#. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Contact"
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
+msgstr "Contents"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
-msgstr "Contents"
-
-#. Table of contents heading
-#. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
 msgstr "Contents"
 
 #. Button to continue to app after verification
@@ -999,7 +999,7 @@ msgstr "Create a free account to browse all results, save jobs, track applicatio
 
 #. Tooltip explaining save search creates a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:102
+#: src/components/search/save-search-button.tsx:106
 msgid "search.saveSearch.tooltip"
 msgstr "Create a watchlist from your current filters"
 
@@ -1313,7 +1313,7 @@ msgstr "Experience"
 
 #. Label for experience filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:177
+#: src/components/search/advanced-search-panel.tsx:189
 msgid "search.advanced.experience"
 msgstr "Experience"
 
@@ -1459,7 +1459,7 @@ msgstr "Filters"
 
 #. Toggle button for advanced search filters panel
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:138
+#: src/components/search/advanced-search-panel.tsx:144
 msgid "search.advanced.toggle"
 msgstr "Filters"
 
@@ -1714,6 +1714,16 @@ msgstr "How we find and process job postings"
 msgid "indexing.meta.title"
 msgstr "How We Index"
 
+#. Work mode: hybrid (mixed onsite/remote)
+#. Work mode: hybrid (mixed onsite/remote)
+#. Work mode: hybrid (mixed onsite/remote)
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:812
+#: src/components/search/search-toolbar.tsx:260
+#: src/components/search/work-mode-modal.tsx:21
+msgid "search.workMode.hybrid"
+msgstr "Hybrid"
+
 #. Description after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:63
@@ -1746,8 +1756,8 @@ msgstr "in {locations}"
 #. Year postings count on company page
 #. Year postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:536
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:548
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:556
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:568
 msgid "company.page.yearCount"
 msgstr "in the last year"
 
@@ -1761,7 +1771,7 @@ msgstr "in the last year"
 
 #. Yearly matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:119
+#: src/components/search/company-card.tsx:122
 msgid "search.card.yearCount"
 msgstr "in the last year"
 
@@ -1843,16 +1853,16 @@ msgstr "Interview log"
 msgid "myJobs.group.interviewing"
 msgstr "Interviewing"
 
-#. Interviewing status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:21
-msgid "myJobs.status.interviewing"
-msgstr "Interviewing"
-
 #. Application tracker status: interviewing
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:450
 msgid "search.tracker.interviewing"
+msgstr "Interviewing"
+
+#. Interviewing status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:21
+msgid "myJobs.status.interviewing"
 msgstr "Interviewing"
 
 #. Status option in dropdown: interviewing
@@ -1900,16 +1910,16 @@ msgstr "Is there a limit to how many jobs I can track?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:31
-msgid "watchlists.card.jobSingular"
-msgstr "job"
-
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:121
 msgid "watchlists.explore.jobSingular"
+msgstr "job"
+
+#. Singular job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:31
+msgid "watchlists.card.jobSingular"
 msgstr "job"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -2012,16 +2022,16 @@ msgstr "Job Seek's codebase is open source under MIT. The job data we collect an
 msgid "watchlist.meta.fallback"
 msgstr "Job watchlist by @{owner}"
 
-#. Plural job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:32
-msgid "watchlists.card.jobPlural"
-msgstr "jobs"
-
 #. Plural job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:122
 msgid "watchlists.explore.jobPlural"
+msgstr "jobs"
+
+#. Plural job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:32
+msgid "watchlists.card.jobPlural"
 msgstr "jobs"
 
 #. js-lingui-explicit-id
@@ -2102,13 +2112,13 @@ msgstr "Learn more"
 
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:638
+#: src/components/search/search-bar.tsx:730
 msgid "search.bar.level"
 msgstr "Level"
 
 #. Label for seniority/level filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:154
+#: src/components/search/advanced-search-panel.tsx:160
 msgid "search.advanced.level"
 msgstr "Level"
 
@@ -2174,20 +2184,20 @@ msgstr "Location"
 
 #. Label for location filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:146
+#: src/components/search/advanced-search-panel.tsx:152
 msgid "search.advanced.location"
 msgstr "Location"
-
-#. Section header for location suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:708
-msgid "search.bar.locations"
-msgstr "Locations"
 
 #. Locations heading in job detail
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:312
 msgid "search.detail.locations"
+msgstr "Locations"
+
+#. Section header for location suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:842
+msgid "search.bar.locations"
 msgstr "Locations"
 
 #. Login button label
@@ -2206,7 +2216,7 @@ msgstr "Log in"
 
 #. Tooltip when user needs to log in to save search
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:107
+#: src/components/search/save-search-button.tsx:111
 msgid "search.saveSearch.tooltipLogin"
 msgstr "Log in to save this search as a watchlist"
 
@@ -2482,7 +2492,7 @@ msgstr "No locations match your search."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:608
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:637
 msgid "company.page.noResults"
 msgstr "No matching postings found."
 
@@ -2506,7 +2516,7 @@ msgstr "No results found for “{query}”"
 
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:293
+#: src/components/search/occupation-modal.tsx:341
 msgid "search.occupationModal.noResults"
 msgstr "No roles match your search."
 
@@ -2556,16 +2566,16 @@ msgstr "No. The application tracker has no hard limit — save as many jobs as y
 msgid "faq.a.dataPrivacy"
 msgstr "No. We don't sell, rent, or share your data for marketing. Cookies are session-only with no ads or tracking. You can delete your account and all data is wiped within 30 days."
 
-#. Sankey funnel node: not applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:44
-msgid "myJobs.funnel.notApplied"
-msgstr "Not applied"
-
 #. Application tracker status: not applied
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:448
 msgid "search.tracker.notApplied"
+msgstr "Not applied"
+
+#. Sankey funnel node: not applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:44
+msgid "myJobs.funnel.notApplied"
 msgstr "Not applied"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2592,16 +2602,16 @@ msgstr "Occupation"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Oct"
 
-#. Offered status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:22
-msgid "myJobs.status.offered"
-msgstr "Offer"
-
 #. Application tracker status: offer
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:451
 msgid "search.tracker.offer"
+msgstr "Offer"
+
+#. Offered status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:22
+msgid "myJobs.status.offered"
 msgstr "Offer"
 
 #. Status group heading: offered
@@ -2627,6 +2637,16 @@ msgstr "Offered"
 #: src/components/CookieBanner.tsx:66
 msgid "common.cookies.ok"
 msgstr "Ok"
+
+#. Work mode: onsite (in-office)
+#. Work mode: onsite (in-office)
+#. Work mode: onsite (in-office)
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:810
+#: src/components/search/search-toolbar.tsx:258
+#: src/components/search/work-mode-modal.tsx:20
+msgid "search.workMode.onsite"
+msgstr "On-site"
 
 #. Step 4 body
 #. js-lingui-explicit-id
@@ -2725,26 +2745,26 @@ msgstr "Our stance on automation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:22
-msgid "license.toc.overview"
-msgstr "Overview"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:27
 msgid "indexing.toc.overview"
 msgstr "Overview"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:19
-msgid "license.toc.ariaLabel"
-msgstr "Page contents"
+#: src/components/LicenseContent.tsx:22
+msgid "license.toc.overview"
+msgstr "Overview"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:24
 msgid "indexing.toc.ariaLabel"
+msgstr "Page contents"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:19
+msgid "license.toc.ariaLabel"
 msgstr "Page contents"
 
 #. Heading shown on the 404 page
@@ -2935,18 +2955,18 @@ msgstr "Posting not found."
 msgid "myJobs.detail.notFound"
 msgstr "Posting not found."
 
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: src/components/Pricing.tsx:100
-msgid "home.pricing.eyebrow"
-msgstr "Pricing"
-
 #. Nav link: Pricing
 #. Nav link: Pricing
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:62
 #: src/components/MobileMenu.tsx:87
 msgid "common.nav.pricing"
+msgstr "Pricing"
+
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:100
+msgid "home.pricing.eyebrow"
 msgstr "Pricing"
 
 #. Privacy policy page eyebrow
@@ -3092,6 +3112,12 @@ msgstr "Regions"
 msgid "myJobs.group.rejected"
 msgstr "Rejected"
 
+#. Application tracker status: rejected
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:452
+msgid "search.tracker.rejected"
+msgstr "Rejected"
+
 #. Rejected status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:23
@@ -3102,12 +3128,6 @@ msgstr "Rejected"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
-msgstr "Rejected"
-
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:452
-msgid "search.tracker.rejected"
 msgstr "Rejected"
 
 #. Status option in dropdown: rejected
@@ -3121,6 +3141,16 @@ msgstr "Rejected"
 #: src/components/Footer.tsx:29
 msgid "common.footer.text"
 msgstr "Released under the MIT License. Job data is CC BY-NC 4.0."
+
+#. Work mode: remote (work-from-home)
+#. Work mode: remote (work-from-home)
+#. Work mode: remote (work-from-home)
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:813
+#: src/components/search/search-toolbar.tsx:261
+#: src/components/search/work-mode-modal.tsx:22
+msgid "search.workMode.remote"
+msgstr "Remote"
 
 #. Aria label for removing a keyword pill
 #. js-lingui-explicit-id
@@ -3136,7 +3166,7 @@ msgstr "Remove location"
 
 #. Synthetic dropdown row that lets the user request a company that's not in the catalog
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:800
+#: src/components/search/search-bar.tsx:934
 msgid "search.bar.request"
 msgstr "Request \"{trimmedInput}\""
 
@@ -3220,13 +3250,13 @@ msgstr "Robots, attribution, and TDM reservation."
 
 #. Label for role/occupation filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:150
+#: src/components/search/advanced-search-panel.tsx:156
 msgid "search.advanced.role"
 msgstr "Role"
 
 #. Section header for occupation suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:603
+#: src/components/search/search-bar.tsx:695
 msgid "search.bar.roles"
 msgstr "Roles"
 
@@ -3244,7 +3274,7 @@ msgstr "Run id"
 
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:171
+#: src/components/search/advanced-search-panel.tsx:183
 msgid "search.advanced.salary"
 msgstr "Salary"
 
@@ -3304,7 +3334,7 @@ msgstr "Save some jobs and track your applications to see stats here."
 
 #. Button label to save current search as a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:95
+#: src/components/search/save-search-button.tsx:99
 msgid "search.saveSearch.label"
 msgstr "Save this search"
 
@@ -3359,7 +3389,7 @@ msgstr "Search across thousands of companies scraped directly from their career 
 #. Placeholder for search bar when on company page
 #. js-lingui-explicit-id
 #. placeholder {0}: company.name
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:156
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:161
 msgid "company.page.searchPlaceholder"
 msgstr "Search at {0}..."
 
@@ -3377,7 +3407,7 @@ msgstr "Search companies..."
 
 #. Option to search by title keyword in dropdown
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:591
+#: src/components/search/search-bar.tsx:683
 msgid "search.bar.keyword"
 msgstr "Search for \"{trimmedInput}\" in job titles"
 
@@ -3412,7 +3442,7 @@ msgstr "Search results"
 
 #. Placeholder for search input in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:272
+#: src/components/search/occupation-modal.tsx:320
 msgid "search.occupationModal.searchPlaceholder"
 msgstr "Search roles..."
 
@@ -3430,7 +3460,7 @@ msgstr "Search with precision"
 
 #. Placeholder for the main search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:518
+#: src/components/search/search-bar.tsx:608
 msgid "search.bar.placeholder"
 msgstr "Search..."
 
@@ -3454,7 +3484,7 @@ msgstr "Select location"
 
 #. Title for the occupation selection modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:252
+#: src/components/search/occupation-modal.tsx:300
 msgid "search.occupationModal.title"
 msgstr "Select role"
 
@@ -3554,16 +3584,16 @@ msgstr "Settings"
 msgid "home.features.s3.p3.title"
 msgstr "Share with anyone"
 
-#. Collapse location pill list
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:351
-msgid "company.page.showLess"
-msgstr "Show less"
-
 #. Button to collapse location list
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:355
 msgid "search.detail.showLessLocations"
+msgstr "Show less"
+
+#. Collapse location pill list
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:351
+msgid "company.page.showLess"
 msgstr "Show less"
 
 #. Aria label to show password
@@ -3836,16 +3866,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technical"
 
-#. Section header for technology suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:673
-msgid "search.bar.technologies"
-msgstr "Technologies"
-
 #. Technologies sub-heading in details section
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:397
 msgid "search.detail.technologies"
+msgstr "Technologies"
+
+#. Section header for technology suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:765
+msgid "search.bar.technologies"
 msgstr "Technologies"
 
 #. Add technology filter
@@ -3856,7 +3886,7 @@ msgstr "Technology"
 
 #. Label for technology filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:159
+#: src/components/search/advanced-search-panel.tsx:165
 msgid "search.advanced.technology"
 msgstr "Technology"
 
@@ -4022,7 +4052,7 @@ msgstr "Try again"
 
 #. Label for employment type filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:165
+#: src/components/search/advanced-search-panel.tsx:171
 msgid "search.advanced.employmentType"
 msgstr "Type"
 
@@ -4329,7 +4359,7 @@ msgstr "We use a handful of third-party services for sign-in, hosting, and stora
 
 #. Secondary line under the Request <query> dropdown row
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:807
+#: src/components/search/search-bar.tsx:941
 msgid "search.bar.request.subtext"
 msgstr "We'll start tracking it"
 
@@ -4381,6 +4411,24 @@ msgstr "Which company should we track?"
 #: app/[lang]/(public)/faq/page.tsx:92
 msgid "faq.q.languages"
 msgstr "Which languages does Jobseek support?"
+
+#. Title for the work-mode (onsite/hybrid/remote) selection modal
+#. js-lingui-explicit-id
+#: src/components/search/work-mode-modal.tsx:53
+msgid "search.workModeModal.title"
+msgstr "Work mode"
+
+#. Section header for work-mode (onsite/hybrid/remote) suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:800
+msgid "search.bar.workMode"
+msgstr "Work mode"
+
+#. Label for work-mode (onsite/hybrid/remote) filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:177
+msgid "search.advanced.workMode"
+msgstr "Work mode"
 
 #. Yearly pay period option
 #. js-lingui-explicit-id

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -212,8 +212,8 @@ msgstr "Menu du compte"
 #. Active postings count on company page
 #. Active postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:534
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:544
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:554
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:564
 msgid "company.page.active"
 msgstr "actif"
 
@@ -227,7 +227,7 @@ msgstr "actifs"
 
 #. Active matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:117
+#: src/components/search/company-card.tsx:120
 msgid "search.card.active"
 msgstr "actif"
 
@@ -297,16 +297,16 @@ msgstr "Toutes les données sont chiffrées en transit et au repos."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Tous les secteurs"
 
-#. Title for the all-languages modal in settings
-#. js-lingui-explicit-id
-#: src/components/settings/JobLanguageModal.tsx:56
-msgid "settings.jobLanguages.modal.title"
-msgstr "Toutes les langues"
-
 #. All languages option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:244
 msgid "settings.general.jobLanguages.all"
+msgstr "Toutes les langues"
+
+#. Title for the all-languages modal in settings
+#. js-lingui-explicit-id
+#: src/components/settings/JobLanguageModal.tsx:56
+msgid "settings.jobLanguages.modal.title"
 msgstr "Toutes les langues"
 
 #. Title for the all-locations modal on company page
@@ -404,6 +404,12 @@ msgstr "candidatures durant l'année écoulée"
 msgid "myJobs.group.applied"
 msgstr "Postulé"
 
+#. Application tracker status: applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:449
+msgid "search.tracker.applied"
+msgstr "Postulé"
+
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
@@ -414,12 +420,6 @@ msgstr "Postulé"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
-msgstr "Postulé"
-
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:449
-msgid "search.tracker.applied"
 msgstr "Postulé"
 
 #. Status option in dropdown: applied
@@ -482,16 +482,16 @@ msgstr "Aoû"
 msgid "settings.account.username.available"
 msgstr "Disponible"
 
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Retour à la connexion"
-
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Retour à la connexion"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Retour à la connexion"
 
 #. Link back to sign-in from forgot password
@@ -711,7 +711,7 @@ msgstr "Tout effacer"
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:553
-#: src/components/search/search-toolbar.tsx:309
+#: src/components/search/search-toolbar.tsx:337
 msgid "search.filters.clearAll"
 msgstr "Tout effacer"
 
@@ -747,13 +747,13 @@ msgstr "Fermer le menu"
 
 #. Label for inactive/closed job postings on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:627
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:656
 msgid "company.page.closed"
 msgstr "Fermé"
 
 #. Label for inactive/closed job postings on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:140
+#: src/components/search/company-card.tsx:143
 msgid "search.card.closed"
 msgstr "Fermé"
 
@@ -789,7 +789,7 @@ msgstr "Bientôt disponible"
 
 #. Section header for company suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:748
+#: src/components/search/search-bar.tsx:882
 msgid "search.bar.companies"
 msgstr "Entreprises"
 
@@ -863,6 +863,12 @@ msgstr "Connecter"
 msgid "settings.account.socials.title"
 msgstr "Comptes connectés"
 
+#. Footer link to contact email
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Contact"
+
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:25
@@ -875,22 +881,16 @@ msgstr "Contact"
 msgid "license.contact.title"
 msgstr "Contact"
 
-#. Footer link to contact email
+#. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Contact"
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
+msgstr "Sommaire"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
-msgstr "Sommaire"
-
-#. Table of contents heading
-#. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
 msgstr "Sommaire"
 
 #. Button to continue to app after verification
@@ -999,7 +999,7 @@ msgstr "Créez un compte gratuit pour parcourir tous les résultats, enregistrer
 
 #. Tooltip explaining save search creates a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:102
+#: src/components/search/save-search-button.tsx:106
 msgid "search.saveSearch.tooltip"
 msgstr "Créer une liste de suivi à partir de vos filtres actuels"
 
@@ -1313,7 +1313,7 @@ msgstr "Expérience"
 
 #. Label for experience filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:177
+#: src/components/search/advanced-search-panel.tsx:189
 msgid "search.advanced.experience"
 msgstr "Expérience"
 
@@ -1459,7 +1459,7 @@ msgstr "Filtres"
 
 #. Toggle button for advanced search filters panel
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:138
+#: src/components/search/advanced-search-panel.tsx:144
 msgid "search.advanced.toggle"
 msgstr "Filtres"
 
@@ -1714,6 +1714,16 @@ msgstr "Comment nous trouvons et traitons les offres d'emploi"
 msgid "indexing.meta.title"
 msgstr "Comment nous indexons"
 
+#. Work mode: hybrid (mixed onsite/remote)
+#. Work mode: hybrid (mixed onsite/remote)
+#. Work mode: hybrid (mixed onsite/remote)
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:812
+#: src/components/search/search-toolbar.tsx:260
+#: src/components/search/work-mode-modal.tsx:21
+msgid "search.workMode.hybrid"
+msgstr "Hybride"
+
 #. Description after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:63
@@ -1746,8 +1756,8 @@ msgstr "à {locations}"
 #. Year postings count on company page
 #. Year postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:536
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:548
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:556
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:568
 msgid "company.page.yearCount"
 msgstr "au cours de la dernière année"
 
@@ -1761,7 +1771,7 @@ msgstr "sur la dernière année"
 
 #. Yearly matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:119
+#: src/components/search/company-card.tsx:122
 msgid "search.card.yearCount"
 msgstr "au cours de la dernière année"
 
@@ -1843,16 +1853,16 @@ msgstr "Journal d'entretiens"
 msgid "myJobs.group.interviewing"
 msgstr "En entretien"
 
-#. Interviewing status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:21
-msgid "myJobs.status.interviewing"
-msgstr "En entretien"
-
 #. Application tracker status: interviewing
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:450
 msgid "search.tracker.interviewing"
+msgstr "En entretien"
+
+#. Interviewing status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:21
+msgid "myJobs.status.interviewing"
 msgstr "En entretien"
 
 #. Status option in dropdown: interviewing
@@ -1900,16 +1910,16 @@ msgstr "Y a-t-il une limite au nombre d'offres que je peux suivre ?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:31
-msgid "watchlists.card.jobSingular"
-msgstr "offre"
-
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:121
 msgid "watchlists.explore.jobSingular"
+msgstr "offre"
+
+#. Singular job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:31
+msgid "watchlists.card.jobSingular"
 msgstr "offre"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -2012,16 +2022,16 @@ msgstr "Le code source de Job Seek est ouvert sous licence MIT. Les données d'e
 msgid "watchlist.meta.fallback"
 msgstr "Liste d'emplois de @{owner}"
 
-#. Plural job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:32
-msgid "watchlists.card.jobPlural"
-msgstr "offres"
-
 #. Plural job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:122
 msgid "watchlists.explore.jobPlural"
+msgstr "offres"
+
+#. Plural job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:32
+msgid "watchlists.card.jobPlural"
 msgstr "offres"
 
 #. js-lingui-explicit-id
@@ -2102,13 +2112,13 @@ msgstr "En savoir plus"
 
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:638
+#: src/components/search/search-bar.tsx:730
 msgid "search.bar.level"
 msgstr "Niveau"
 
 #. Label for seniority/level filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:154
+#: src/components/search/advanced-search-panel.tsx:160
 msgid "search.advanced.level"
 msgstr "Niveau"
 
@@ -2174,20 +2184,20 @@ msgstr "Lieu"
 
 #. Label for location filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:146
+#: src/components/search/advanced-search-panel.tsx:152
 msgid "search.advanced.location"
 msgstr "Lieu"
-
-#. Section header for location suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:708
-msgid "search.bar.locations"
-msgstr "Lieux"
 
 #. Locations heading in job detail
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:312
 msgid "search.detail.locations"
+msgstr "Lieux"
+
+#. Section header for location suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:842
+msgid "search.bar.locations"
 msgstr "Lieux"
 
 #. Login button label
@@ -2206,7 +2216,7 @@ msgstr "Se connecter"
 
 #. Tooltip when user needs to log in to save search
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:107
+#: src/components/search/save-search-button.tsx:111
 msgid "search.saveSearch.tooltipLogin"
 msgstr "Connectez-vous pour enregistrer cette recherche comme liste de suivi"
 
@@ -2482,7 +2492,7 @@ msgstr "Aucun lieu ne correspond à votre recherche."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:608
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:637
 msgid "company.page.noResults"
 msgstr "Aucune offre correspondante trouvée."
 
@@ -2506,7 +2516,7 @@ msgstr "Aucun résultat trouvé pour « {query} »"
 
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:293
+#: src/components/search/occupation-modal.tsx:341
 msgid "search.occupationModal.noResults"
 msgstr "Aucun rôle ne correspond à votre recherche."
 
@@ -2556,16 +2566,16 @@ msgstr "Non. Le suivi des candidatures n'a pas de limite — enregistrez autant 
 msgid "faq.a.dataPrivacy"
 msgstr "Non. Nous ne vendons, ne louons ni ne partageons vos données à des fins marketing. Les cookies sont uniquement de session, sans publicité ni tracking. Vous pouvez supprimer votre compte et toutes les données seront effacées sous 30 jours."
 
-#. Sankey funnel node: not applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:44
-msgid "myJobs.funnel.notApplied"
-msgstr "Non postulé"
-
 #. Application tracker status: not applied
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:448
 msgid "search.tracker.notApplied"
+msgstr "Non postulé"
+
+#. Sankey funnel node: not applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:44
+msgid "myJobs.funnel.notApplied"
 msgstr "Non postulé"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2592,16 +2602,16 @@ msgstr "Métier"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Oct"
 
-#. Offered status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:22
-msgid "myJobs.status.offered"
-msgstr "Offre"
-
 #. Application tracker status: offer
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:451
 msgid "search.tracker.offer"
+msgstr "Offre"
+
+#. Offered status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:22
+msgid "myJobs.status.offered"
 msgstr "Offre"
 
 #. Status group heading: offered
@@ -2627,6 +2637,16 @@ msgstr "Offre"
 #: src/components/CookieBanner.tsx:66
 msgid "common.cookies.ok"
 msgstr "Ok"
+
+#. Work mode: onsite (in-office)
+#. Work mode: onsite (in-office)
+#. Work mode: onsite (in-office)
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:810
+#: src/components/search/search-toolbar.tsx:258
+#: src/components/search/work-mode-modal.tsx:20
+msgid "search.workMode.onsite"
+msgstr "Sur site"
 
 #. Step 4 body
 #. js-lingui-explicit-id
@@ -2725,26 +2745,26 @@ msgstr "Notre position sur l'automatisation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:22
-msgid "license.toc.overview"
-msgstr "Aperçu"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:27
 msgid "indexing.toc.overview"
 msgstr "Aperçu"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:19
-msgid "license.toc.ariaLabel"
-msgstr "Sommaire de la page"
+#: src/components/LicenseContent.tsx:22
+msgid "license.toc.overview"
+msgstr "Aperçu"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:24
 msgid "indexing.toc.ariaLabel"
+msgstr "Sommaire de la page"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:19
+msgid "license.toc.ariaLabel"
 msgstr "Sommaire de la page"
 
 #. Heading shown on the 404 page
@@ -2935,18 +2955,18 @@ msgstr "Offre non trouvée."
 msgid "myJobs.detail.notFound"
 msgstr "Offre introuvable."
 
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: src/components/Pricing.tsx:100
-msgid "home.pricing.eyebrow"
-msgstr "Tarifs"
-
 #. Nav link: Pricing
 #. Nav link: Pricing
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:62
 #: src/components/MobileMenu.tsx:87
 msgid "common.nav.pricing"
+msgstr "Tarifs"
+
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:100
+msgid "home.pricing.eyebrow"
 msgstr "Tarifs"
 
 #. Privacy policy page eyebrow
@@ -3092,6 +3112,12 @@ msgstr "Régions"
 msgid "myJobs.group.rejected"
 msgstr "Refusé"
 
+#. Application tracker status: rejected
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:452
+msgid "search.tracker.rejected"
+msgstr "Refusé"
+
 #. Rejected status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:23
@@ -3102,12 +3128,6 @@ msgstr "Refusé"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
-msgstr "Refusé"
-
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:452
-msgid "search.tracker.rejected"
 msgstr "Refusé"
 
 #. Status option in dropdown: rejected
@@ -3121,6 +3141,16 @@ msgstr "Refusé"
 #: src/components/Footer.tsx:29
 msgid "common.footer.text"
 msgstr "Publié sous licence MIT. Les données d'emploi sont sous CC BY-NC 4.0."
+
+#. Work mode: remote (work-from-home)
+#. Work mode: remote (work-from-home)
+#. Work mode: remote (work-from-home)
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:813
+#: src/components/search/search-toolbar.tsx:261
+#: src/components/search/work-mode-modal.tsx:22
+msgid "search.workMode.remote"
+msgstr "À distance"
 
 #. Aria label for removing a keyword pill
 #. js-lingui-explicit-id
@@ -3136,7 +3166,7 @@ msgstr "Supprimer le lieu"
 
 #. Synthetic dropdown row that lets the user request a company that's not in the catalog
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:800
+#: src/components/search/search-bar.tsx:934
 msgid "search.bar.request"
 msgstr "Demander \\\"{trimmedInput}\\\""
 
@@ -3220,13 +3250,13 @@ msgstr "Robots, attribution et réservation TDM."
 
 #. Label for role/occupation filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:150
+#: src/components/search/advanced-search-panel.tsx:156
 msgid "search.advanced.role"
 msgstr "Rôle"
 
 #. Section header for occupation suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:603
+#: src/components/search/search-bar.tsx:695
 msgid "search.bar.roles"
 msgstr "Rôles"
 
@@ -3244,7 +3274,7 @@ msgstr "Identifiant d'exécution"
 
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:171
+#: src/components/search/advanced-search-panel.tsx:183
 msgid "search.advanced.salary"
 msgstr "Salaire"
 
@@ -3304,7 +3334,7 @@ msgstr "Enregistrez des offres et suivez vos candidatures pour voir des statisti
 
 #. Button label to save current search as a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:95
+#: src/components/search/save-search-button.tsx:99
 msgid "search.saveSearch.label"
 msgstr "Enregistrer cette recherche"
 
@@ -3359,7 +3389,7 @@ msgstr "Cherche parmi des milliers d'entreprises scrapées directement depuis le
 #. Placeholder for search bar when on company page
 #. js-lingui-explicit-id
 #. placeholder {0}: company.name
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:156
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:161
 msgid "company.page.searchPlaceholder"
 msgstr "Rechercher chez {0}..."
 
@@ -3377,7 +3407,7 @@ msgstr "Rechercher des entreprises..."
 
 #. Option to search by title keyword in dropdown
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:591
+#: src/components/search/search-bar.tsx:683
 msgid "search.bar.keyword"
 msgstr "Rechercher \"{trimmedInput}\" dans les titres de postes"
 
@@ -3412,7 +3442,7 @@ msgstr "Résultats de recherche"
 
 #. Placeholder for search input in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:272
+#: src/components/search/occupation-modal.tsx:320
 msgid "search.occupationModal.searchPlaceholder"
 msgstr "Rechercher des rôles..."
 
@@ -3430,7 +3460,7 @@ msgstr "Recherche précise"
 
 #. Placeholder for the main search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:518
+#: src/components/search/search-bar.tsx:608
 msgid "search.bar.placeholder"
 msgstr "Rechercher…"
 
@@ -3454,7 +3484,7 @@ msgstr "Sélectionner le lieu"
 
 #. Title for the occupation selection modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:252
+#: src/components/search/occupation-modal.tsx:300
 msgid "search.occupationModal.title"
 msgstr "Sélectionner le rôle"
 
@@ -3554,16 +3584,16 @@ msgstr "Paramètres"
 msgid "home.features.s3.p3.title"
 msgstr "Partager avec tout le monde"
 
-#. Collapse location pill list
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:351
-msgid "company.page.showLess"
-msgstr "Afficher moins"
-
 #. Button to collapse location list
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:355
 msgid "search.detail.showLessLocations"
+msgstr "Afficher moins"
+
+#. Collapse location pill list
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:351
+msgid "company.page.showLess"
 msgstr "Afficher moins"
 
 #. Aria label to show password
@@ -3836,16 +3866,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technique"
 
-#. Section header for technology suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:673
-msgid "search.bar.technologies"
-msgstr "Technologies"
-
 #. Technologies sub-heading in details section
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:397
 msgid "search.detail.technologies"
+msgstr "Technologies"
+
+#. Section header for technology suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:765
+msgid "search.bar.technologies"
 msgstr "Technologies"
 
 #. Add technology filter
@@ -3856,7 +3886,7 @@ msgstr "Technologie"
 
 #. Label for technology filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:159
+#: src/components/search/advanced-search-panel.tsx:165
 msgid "search.advanced.technology"
 msgstr "Technologie"
 
@@ -4022,7 +4052,7 @@ msgstr "Réessayer"
 
 #. Label for employment type filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:165
+#: src/components/search/advanced-search-panel.tsx:171
 msgid "search.advanced.employmentType"
 msgstr "Type d'emploi"
 
@@ -4329,7 +4359,7 @@ msgstr "Nous utilisons quelques services tiers pour la connexion, l’hébergeme
 
 #. Secondary line under the Request <query> dropdown row
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:807
+#: src/components/search/search-bar.tsx:941
 msgid "search.bar.request.subtext"
 msgstr "Nous commencerons à la suivre"
 
@@ -4381,6 +4411,24 @@ msgstr "Quelle entreprise devons-nous suivre ?"
 #: app/[lang]/(public)/faq/page.tsx:92
 msgid "faq.q.languages"
 msgstr "Quelles langues Jobseek prend-il en charge ?"
+
+#. Title for the work-mode (onsite/hybrid/remote) selection modal
+#. js-lingui-explicit-id
+#: src/components/search/work-mode-modal.tsx:53
+msgid "search.workModeModal.title"
+msgstr "Mode de travail"
+
+#. Section header for work-mode (onsite/hybrid/remote) suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:800
+msgid "search.bar.workMode"
+msgstr "Mode de travail"
+
+#. Label for work-mode (onsite/hybrid/remote) filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:177
+msgid "search.advanced.workMode"
+msgstr "Mode de travail"
 
 #. Yearly pay period option
 #. js-lingui-explicit-id

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -212,8 +212,8 @@ msgstr "Menu account"
 #. Active postings count on company page
 #. Active postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:534
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:544
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:554
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:564
 msgid "company.page.active"
 msgstr "attivo"
 
@@ -227,7 +227,7 @@ msgstr "attivi"
 
 #. Active matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:117
+#: src/components/search/company-card.tsx:120
 msgid "search.card.active"
 msgstr "attivo"
 
@@ -297,16 +297,16 @@ msgstr "Tutti i dati sono crittografati in transito e a riposo."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Tutti i settori"
 
-#. Title for the all-languages modal in settings
-#. js-lingui-explicit-id
-#: src/components/settings/JobLanguageModal.tsx:56
-msgid "settings.jobLanguages.modal.title"
-msgstr "Tutte le lingue"
-
 #. All languages option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:244
 msgid "settings.general.jobLanguages.all"
+msgstr "Tutte le lingue"
+
+#. Title for the all-languages modal in settings
+#. js-lingui-explicit-id
+#: src/components/settings/JobLanguageModal.tsx:56
+msgid "settings.jobLanguages.modal.title"
 msgstr "Tutte le lingue"
 
 #. Title for the all-locations modal on company page
@@ -404,6 +404,12 @@ msgstr "candidature nell'ultimo anno"
 msgid "myJobs.group.applied"
 msgstr "Candidato"
 
+#. Application tracker status: applied
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:449
+msgid "search.tracker.applied"
+msgstr "Candidato"
+
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
@@ -414,12 +420,6 @@ msgstr "Candidato"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
-msgstr "Candidato"
-
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:449
-msgid "search.tracker.applied"
 msgstr "Candidato"
 
 #. Status option in dropdown: applied
@@ -482,16 +482,16 @@ msgstr "Ago"
 msgid "settings.account.username.available"
 msgstr "Disponibile"
 
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Torna all'accesso"
-
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Torna all'accesso"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Torna all'accesso"
 
 #. Link back to sign-in from forgot password
@@ -711,7 +711,7 @@ msgstr "Rimuovi tutti"
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:553
-#: src/components/search/search-toolbar.tsx:309
+#: src/components/search/search-toolbar.tsx:337
 msgid "search.filters.clearAll"
 msgstr "Cancella tutto"
 
@@ -747,13 +747,13 @@ msgstr "Chiudi menu"
 
 #. Label for inactive/closed job postings on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:627
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:656
 msgid "company.page.closed"
 msgstr "Chiuso"
 
 #. Label for inactive/closed job postings on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:140
+#: src/components/search/company-card.tsx:143
 msgid "search.card.closed"
 msgstr "Chiuso"
 
@@ -789,7 +789,7 @@ msgstr "In arrivo"
 
 #. Section header for company suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:748
+#: src/components/search/search-bar.tsx:882
 msgid "search.bar.companies"
 msgstr "Aziende"
 
@@ -863,6 +863,12 @@ msgstr "Collega"
 msgid "settings.account.socials.title"
 msgstr "Account collegati"
 
+#. Footer link to contact email
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Contatti"
+
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:25
@@ -875,22 +881,16 @@ msgstr "Contatti"
 msgid "license.contact.title"
 msgstr "Contatti"
 
-#. Footer link to contact email
+#. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Contatti"
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
+msgstr "Sommario"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
-msgstr "Sommario"
-
-#. Table of contents heading
-#. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
 msgstr "Sommario"
 
 #. Button to continue to app after verification
@@ -999,7 +999,7 @@ msgstr "Crea un account gratuito per consultare tutti i risultati, salvare offer
 
 #. Tooltip explaining save search creates a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:102
+#: src/components/search/save-search-button.tsx:106
 msgid "search.saveSearch.tooltip"
 msgstr "Crea una watchlist dai tuoi filtri attuali"
 
@@ -1313,7 +1313,7 @@ msgstr "Esperienza"
 
 #. Label for experience filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:177
+#: src/components/search/advanced-search-panel.tsx:189
 msgid "search.advanced.experience"
 msgstr "Esperienza"
 
@@ -1459,7 +1459,7 @@ msgstr "Filtri"
 
 #. Toggle button for advanced search filters panel
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:138
+#: src/components/search/advanced-search-panel.tsx:144
 msgid "search.advanced.toggle"
 msgstr "Filtri"
 
@@ -1714,6 +1714,16 @@ msgstr "Come troviamo e processiamo gli annunci di lavoro"
 msgid "indexing.meta.title"
 msgstr "Come indicizziamo"
 
+#. Work mode: hybrid (mixed onsite/remote)
+#. Work mode: hybrid (mixed onsite/remote)
+#. Work mode: hybrid (mixed onsite/remote)
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:812
+#: src/components/search/search-toolbar.tsx:260
+#: src/components/search/work-mode-modal.tsx:21
+msgid "search.workMode.hybrid"
+msgstr "Ibrido"
+
 #. Description after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:63
@@ -1746,8 +1756,8 @@ msgstr "a {locations}"
 #. Year postings count on company page
 #. Year postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:536
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:548
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:556
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:568
 msgid "company.page.yearCount"
 msgstr "nell'ultimo anno"
 
@@ -1761,7 +1771,7 @@ msgstr "nell'ultimo anno"
 
 #. Yearly matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:119
+#: src/components/search/company-card.tsx:122
 msgid "search.card.yearCount"
 msgstr "nell'ultimo anno"
 
@@ -1843,16 +1853,16 @@ msgstr "Registro dei colloqui"
 msgid "myJobs.group.interviewing"
 msgstr "In colloquio"
 
-#. Interviewing status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:21
-msgid "myJobs.status.interviewing"
-msgstr "In colloquio"
-
 #. Application tracker status: interviewing
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:450
 msgid "search.tracker.interviewing"
+msgstr "In colloquio"
+
+#. Interviewing status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:21
+msgid "myJobs.status.interviewing"
 msgstr "In colloquio"
 
 #. Status option in dropdown: interviewing
@@ -1900,16 +1910,16 @@ msgstr "C'è un limite al numero di offerte che posso tracciare?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Gen"
 
-#. Singular job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:31
-msgid "watchlists.card.jobSingular"
-msgstr "offerta"
-
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:121
 msgid "watchlists.explore.jobSingular"
+msgstr "offerta"
+
+#. Singular job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:31
+msgid "watchlists.card.jobSingular"
 msgstr "offerta"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -2012,16 +2022,16 @@ msgstr "Il codice sorgente di Job Seek è open source sotto licenza MIT. I dati 
 msgid "watchlist.meta.fallback"
 msgstr "Lista lavori di @{owner}"
 
-#. Plural job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:32
-msgid "watchlists.card.jobPlural"
-msgstr "offerte"
-
 #. Plural job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:122
 msgid "watchlists.explore.jobPlural"
+msgstr "offerte"
+
+#. Plural job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:32
+msgid "watchlists.card.jobPlural"
 msgstr "offerte"
 
 #. js-lingui-explicit-id
@@ -2102,13 +2112,13 @@ msgstr "Scopri di più"
 
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:638
+#: src/components/search/search-bar.tsx:730
 msgid "search.bar.level"
 msgstr "Livello"
 
 #. Label for seniority/level filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:154
+#: src/components/search/advanced-search-panel.tsx:160
 msgid "search.advanced.level"
 msgstr "Livello"
 
@@ -2174,21 +2184,21 @@ msgstr "Luogo"
 
 #. Label for location filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:146
+#: src/components/search/advanced-search-panel.tsx:152
 msgid "search.advanced.location"
 msgstr "Luogo"
-
-#. Section header for location suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:708
-msgid "search.bar.locations"
-msgstr "Sedi"
 
 #. Locations heading in job detail
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:312
 msgid "search.detail.locations"
 msgstr "Località"
+
+#. Section header for location suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:842
+msgid "search.bar.locations"
+msgstr "Sedi"
 
 #. Login button label
 #. Login button label
@@ -2206,7 +2216,7 @@ msgstr "Accedi"
 
 #. Tooltip when user needs to log in to save search
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:107
+#: src/components/search/save-search-button.tsx:111
 msgid "search.saveSearch.tooltipLogin"
 msgstr "Accedi per salvare questa ricerca come watchlist"
 
@@ -2482,7 +2492,7 @@ msgstr "Nessuna sede corrisponde alla tua ricerca."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:608
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:637
 msgid "company.page.noResults"
 msgstr "Nessun annuncio corrispondente trovato."
 
@@ -2506,7 +2516,7 @@ msgstr "Nessun risultato trovato per \"{query}\""
 
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:293
+#: src/components/search/occupation-modal.tsx:341
 msgid "search.occupationModal.noResults"
 msgstr "Nessun ruolo corrisponde alla tua ricerca."
 
@@ -2556,16 +2566,16 @@ msgstr "No. Il tracker delle candidature non ha limiti — salva quante offerte 
 msgid "faq.a.dataPrivacy"
 msgstr "No. Non vendiamo, affittiamo né condividiamo i tuoi dati a fini di marketing. I cookie sono solo di sessione, senza pubblicità né tracciamento. Puoi eliminare il tuo account e tutti i dati verranno cancellati entro 30 giorni."
 
-#. Sankey funnel node: not applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:44
-msgid "myJobs.funnel.notApplied"
-msgstr "Non candidato"
-
 #. Application tracker status: not applied
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:448
 msgid "search.tracker.notApplied"
+msgstr "Non candidato"
+
+#. Sankey funnel node: not applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:44
+msgid "myJobs.funnel.notApplied"
 msgstr "Non candidato"
 
 #. Warning shown when the request was saved in DB but GitHub issue creation failed
@@ -2592,16 +2602,16 @@ msgstr "Professione"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Ott"
 
-#. Offered status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:22
-msgid "myJobs.status.offered"
-msgstr "Offerta"
-
 #. Application tracker status: offer
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:451
 msgid "search.tracker.offer"
+msgstr "Offerta"
+
+#. Offered status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:22
+msgid "myJobs.status.offered"
 msgstr "Offerta"
 
 #. Status group heading: offered
@@ -2627,6 +2637,16 @@ msgstr "Offerta"
 #: src/components/CookieBanner.tsx:66
 msgid "common.cookies.ok"
 msgstr "Ok"
+
+#. Work mode: onsite (in-office)
+#. Work mode: onsite (in-office)
+#. Work mode: onsite (in-office)
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:810
+#: src/components/search/search-toolbar.tsx:258
+#: src/components/search/work-mode-modal.tsx:20
+msgid "search.workMode.onsite"
+msgstr "In sede"
 
 #. Step 4 body
 #. js-lingui-explicit-id
@@ -2725,26 +2745,26 @@ msgstr "La nostra posizione sull'automazione"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:22
-msgid "license.toc.overview"
-msgstr "Panoramica"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:27
 msgid "indexing.toc.overview"
 msgstr "Panoramica"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:19
-msgid "license.toc.ariaLabel"
-msgstr "Contenuti della pagina"
+#: src/components/LicenseContent.tsx:22
+msgid "license.toc.overview"
+msgstr "Panoramica"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:24
 msgid "indexing.toc.ariaLabel"
+msgstr "Contenuti della pagina"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:19
+msgid "license.toc.ariaLabel"
 msgstr "Contenuti della pagina"
 
 #. Heading shown on the 404 page
@@ -2935,18 +2955,18 @@ msgstr "Offerta non trovata."
 msgid "myJobs.detail.notFound"
 msgstr "Offerta non trovata."
 
-#. Pricing section eyebrow
-#. js-lingui-explicit-id
-#: src/components/Pricing.tsx:100
-msgid "home.pricing.eyebrow"
-msgstr "Prezzi"
-
 #. Nav link: Pricing
 #. Nav link: Pricing
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:62
 #: src/components/MobileMenu.tsx:87
 msgid "common.nav.pricing"
+msgstr "Prezzi"
+
+#. Pricing section eyebrow
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:100
+msgid "home.pricing.eyebrow"
 msgstr "Prezzi"
 
 #. Privacy policy page eyebrow
@@ -3092,6 +3112,12 @@ msgstr "Regioni"
 msgid "myJobs.group.rejected"
 msgstr "Rifiutato"
 
+#. Application tracker status: rejected
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:452
+msgid "search.tracker.rejected"
+msgstr "Rifiutato"
+
 #. Rejected status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:23
@@ -3102,12 +3128,6 @@ msgstr "Rifiutato"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
-msgstr "Rifiutato"
-
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:452
-msgid "search.tracker.rejected"
 msgstr "Rifiutato"
 
 #. Status option in dropdown: rejected
@@ -3121,6 +3141,16 @@ msgstr "Rifiutato"
 #: src/components/Footer.tsx:29
 msgid "common.footer.text"
 msgstr "Rilasciato sotto licenza MIT. I dati sugli annunci sono CC BY-NC 4.0."
+
+#. Work mode: remote (work-from-home)
+#. Work mode: remote (work-from-home)
+#. Work mode: remote (work-from-home)
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:813
+#: src/components/search/search-toolbar.tsx:261
+#: src/components/search/work-mode-modal.tsx:22
+msgid "search.workMode.remote"
+msgstr "Remoto"
 
 #. Aria label for removing a keyword pill
 #. js-lingui-explicit-id
@@ -3136,7 +3166,7 @@ msgstr "Rimuovi località"
 
 #. Synthetic dropdown row that lets the user request a company that's not in the catalog
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:800
+#: src/components/search/search-bar.tsx:934
 msgid "search.bar.request"
 msgstr "Richiedi \\\"{trimmedInput}\\\""
 
@@ -3220,13 +3250,13 @@ msgstr "Robot, attribuzione e riserva TDM."
 
 #. Label for role/occupation filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:150
+#: src/components/search/advanced-search-panel.tsx:156
 msgid "search.advanced.role"
 msgstr "Ruolo"
 
 #. Section header for occupation suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:603
+#: src/components/search/search-bar.tsx:695
 msgid "search.bar.roles"
 msgstr "Ruoli"
 
@@ -3244,7 +3274,7 @@ msgstr "ID esecuzione"
 
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:171
+#: src/components/search/advanced-search-panel.tsx:183
 msgid "search.advanced.salary"
 msgstr "Stipendio"
 
@@ -3304,7 +3334,7 @@ msgstr "Salva offerte e monitora le tue candidature per vedere le statistiche qu
 
 #. Button label to save current search as a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:95
+#: src/components/search/save-search-button.tsx:99
 msgid "search.saveSearch.label"
 msgstr "Salva questa ricerca"
 
@@ -3359,7 +3389,7 @@ msgstr "Cerca tra migliaia di aziende prese direttamente dalle loro pagine carri
 #. Placeholder for search bar when on company page
 #. js-lingui-explicit-id
 #. placeholder {0}: company.name
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:156
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:161
 msgid "company.page.searchPlaceholder"
 msgstr "Cerca in {0}..."
 
@@ -3377,7 +3407,7 @@ msgstr "Cerca aziende..."
 
 #. Option to search by title keyword in dropdown
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:591
+#: src/components/search/search-bar.tsx:683
 msgid "search.bar.keyword"
 msgstr "Cerca \"{trimmedInput}\" nei titoli di lavoro"
 
@@ -3412,7 +3442,7 @@ msgstr "Risultati della ricerca"
 
 #. Placeholder for search input in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:272
+#: src/components/search/occupation-modal.tsx:320
 msgid "search.occupationModal.searchPlaceholder"
 msgstr "Cerca ruoli..."
 
@@ -3430,7 +3460,7 @@ msgstr "Cerca con precisione"
 
 #. Placeholder for the main search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:518
+#: src/components/search/search-bar.tsx:608
 msgid "search.bar.placeholder"
 msgstr "Cerca…"
 
@@ -3454,7 +3484,7 @@ msgstr "Seleziona luogo"
 
 #. Title for the occupation selection modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:252
+#: src/components/search/occupation-modal.tsx:300
 msgid "search.occupationModal.title"
 msgstr "Seleziona ruolo"
 
@@ -3554,16 +3584,16 @@ msgstr "Impostazioni"
 msgid "home.features.s3.p3.title"
 msgstr "Condividi con chiunque"
 
-#. Collapse location pill list
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:351
-msgid "company.page.showLess"
-msgstr "Mostra meno"
-
 #. Button to collapse location list
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:355
 msgid "search.detail.showLessLocations"
+msgstr "Mostra meno"
+
+#. Collapse location pill list
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:351
+msgid "company.page.showLess"
 msgstr "Mostra meno"
 
 #. Aria label to show password
@@ -3836,16 +3866,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Tecnico"
 
-#. Section header for technology suggestions in search bar
-#. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:673
-msgid "search.bar.technologies"
-msgstr "Tecnologie"
-
 #. Technologies sub-heading in details section
 #. js-lingui-explicit-id
 #: src/components/search/job-detail-dialog.tsx:397
 msgid "search.detail.technologies"
+msgstr "Tecnologie"
+
+#. Section header for technology suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:765
+msgid "search.bar.technologies"
 msgstr "Tecnologie"
 
 #. Add technology filter
@@ -3856,7 +3886,7 @@ msgstr "Tecnologia"
 
 #. Label for technology filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:159
+#: src/components/search/advanced-search-panel.tsx:165
 msgid "search.advanced.technology"
 msgstr "Tecnologia"
 
@@ -4022,7 +4052,7 @@ msgstr "Riprova"
 
 #. Label for employment type filter in advanced search
 #. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:165
+#: src/components/search/advanced-search-panel.tsx:171
 msgid "search.advanced.employmentType"
 msgstr "Tipo di impiego"
 
@@ -4329,7 +4359,7 @@ msgstr "Utilizziamo pochi servizi terzi per accesso, hosting e archiviazione —
 
 #. Secondary line under the Request <query> dropdown row
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:807
+#: src/components/search/search-bar.tsx:941
 msgid "search.bar.request.subtext"
 msgstr "Inizieremo a monitorarla"
 
@@ -4381,6 +4411,24 @@ msgstr "Quale azienda dobbiamo monitorare?"
 #: app/[lang]/(public)/faq/page.tsx:92
 msgid "faq.q.languages"
 msgstr "Quali lingue supporta Jobseek?"
+
+#. Title for the work-mode (onsite/hybrid/remote) selection modal
+#. js-lingui-explicit-id
+#: src/components/search/work-mode-modal.tsx:53
+msgid "search.workModeModal.title"
+msgstr "Modalità di lavoro"
+
+#. Section header for work-mode (onsite/hybrid/remote) suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:800
+msgid "search.bar.workMode"
+msgstr "Modalità di lavoro"
+
+#. Label for work-mode (onsite/hybrid/remote) filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:177
+msgid "search.advanced.workMode"
+msgstr "Modalità di lavoro"
 
 #. Yearly pay period option
 #. js-lingui-explicit-id

--- a/apps/web/src/components/SearchStateProvider.tsx
+++ b/apps/web/src/components/SearchStateProvider.tsx
@@ -9,7 +9,7 @@ import {
   type ReactNode,
 } from "react";
 import type { SelectedLocation } from "@/components/search/location-pills";
-import type { SearchResultCompany } from "@/lib/search";
+import type { SearchResultCompany, WorkMode } from "@/lib/search";
 
 export interface SearchStateSnapshot {
   keywords: string[];
@@ -17,6 +17,7 @@ export interface SearchStateSnapshot {
   occupations: { id: number; slug: string; name: string }[];
   seniorities: { id: number; slug: string; name: string }[];
   technologies: { id: number; slug: string; name: string }[];
+  workMode: WorkMode[];
   salaryMinEur: number | undefined;
   salaryMaxEur: number | undefined;
   salaryCurrency: string;
@@ -53,6 +54,12 @@ export interface SearchPageActions {
   addSeniority: (seniority: { id: number; slug: string; name: string }) => void;
   addTechnology?: (technology: { id: number; slug: string; name: string }) => void;
   addEmploymentType?: (type: string) => void;
+  /**
+   * Add a work-mode (onsite/hybrid/remote) to the active filter set.
+   * Idempotent — implementations should no-op when the mode is already
+   * selected. Used by the global search-bar autocomplete (#2983).
+   */
+  addWorkMode?: (mode: WorkMode) => void;
   setSalaryFilter?: (currency: string, min: number | undefined, max: number | undefined) => void;
   setExperienceFilter?: (min: number | undefined, max: number | undefined) => void;
   submitSearch: (

--- a/apps/web/src/components/search/advanced-search-panel.tsx
+++ b/apps/web/src/components/search/advanced-search-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { SlidersHorizontal, ChevronDown, ChevronUp, MapPin, Briefcase, BarChart3, CalendarDays, DollarSign, Clock, Code2 } from "lucide-react";
+import { SlidersHorizontal, ChevronDown, ChevronUp, MapPin, Briefcase, BarChart3, CalendarDays, DollarSign, Clock, Code2, Home } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import type { SelectedLocation } from "@/components/search/location-pills";
 import { LocationSearchModal } from "./location-search-modal";
@@ -11,7 +11,8 @@ import { TechnologyModal } from "./technology-modal";
 import { SalaryModal } from "./salary-modal";
 import { ExperienceModal } from "./experience-modal";
 import { EmploymentTypeModal } from "./employment-type-modal";
-import type { HistogramFilters } from "@/lib/search";
+import { WorkModeModal } from "./work-mode-modal";
+import type { HistogramFilters, WorkMode } from "@/lib/search";
 
 type TaxonomyItem = { id: number; slug: string; name: string };
 
@@ -38,6 +39,8 @@ interface AdvancedSearchPanelProps {
   onRemoveTechnology?: (id: number) => void;
   employmentTypes?: string[];
   onToggleEmploymentType?: (type: string) => void;
+  workMode?: WorkMode[];
+  onToggleWorkMode?: (mode: WorkMode) => void;
   onSalaryChange?: (currency: string, min: number | undefined, max: number | undefined) => void;
   onExperienceChange?: (min: number | undefined, max: number | undefined) => void;
   histogramFilters?: HistogramFilters;
@@ -64,6 +67,8 @@ export function AdvancedSearchPanel({
   onRemoveTechnology,
   employmentTypes,
   onToggleEmploymentType,
+  workMode,
+  onToggleWorkMode,
   onSalaryChange,
   onExperienceChange,
   histogramFilters,
@@ -77,6 +82,7 @@ export function AdvancedSearchPanel({
   const [salaryModalOpen, setSalaryModalOpen] = useState(false);
   const [experienceModalOpen, setExperienceModalOpen] = useState(false);
   const [employmentTypeModalOpen, setEmploymentTypeModalOpen] = useState(false);
+  const [workModeModalOpen, setWorkModeModalOpen] = useState(false);
 
   const handleToggleLocation = useCallback(
     (loc: { id: number; slug: string; name: string; type: string; parentName?: string | null }) => {
@@ -163,6 +169,12 @@ export function AdvancedSearchPanel({
             <button onClick={() => setEmploymentTypeModalOpen(true)} className={btnClass}>
               <CalendarDays size={14} className="shrink-0 text-muted" />
               {t({ id: "search.advanced.employmentType", comment: "Label for employment type filter in advanced search", message: "Type" })}
+            </button>
+          )}
+          {onToggleWorkMode && (
+            <button onClick={() => setWorkModeModalOpen(true)} className={btnClass}>
+              <Home size={14} className="shrink-0 text-muted" />
+              {t({ id: "search.advanced.workMode", comment: "Label for work-mode (onsite/hybrid/remote) filter in advanced search", message: "Work mode" })}
             </button>
           )}
           {onSalaryChange && (
@@ -268,6 +280,14 @@ export function AdvancedSearchPanel({
           onOpenChange={setEmploymentTypeModalOpen}
           selected={employmentTypes ?? []}
           onToggle={onToggleEmploymentType}
+        />
+      )}
+      {onToggleWorkMode && (
+        <WorkModeModal
+          open={workModeModalOpen}
+          onOpenChange={setWorkModeModalOpen}
+          selected={workMode ?? []}
+          onToggle={onToggleWorkMode}
         />
       )}
     </div>

--- a/apps/web/src/components/search/company-card.tsx
+++ b/apps/web/src/components/search/company-card.tsx
@@ -17,7 +17,7 @@ import { StarButton } from "@/components/search/star-button";
 import { ScrollFade } from "@/components/ui/scroll-fade";
 import { buildFilteredPath } from "@/lib/search/query-params";
 import type { SerializableLocation, SerializableOccupation, SerializableSeniority, SerializableTechnology } from "@/lib/search/query-params";
-import type { SearchResultCompany, SearchResultPosting } from "@/lib/search";
+import type { SearchResultCompany, SearchResultPosting, WorkMode } from "@/lib/search";
 
 const POSTINGS_BATCH = 20;
 
@@ -30,6 +30,7 @@ interface CompanyCardProps {
   seniorities?: SerializableSeniority[];
   technologies?: SerializableTechnology[];
   employmentTypes?: string[];
+  workMode?: WorkMode[];
   salaryMinEur?: number;
   salaryMaxEur?: number;
   experienceMin?: number;
@@ -39,7 +40,7 @@ interface CompanyCardProps {
   selectedPostingId?: string | null;
 }
 
-export function CompanyCard({ result, keywords, locationIds, locations, occupations, seniorities, technologies, employmentTypes, salaryMinEur, salaryMaxEur, experienceMin, experienceMax, languages, onShowPosting, selectedPostingId }: CompanyCardProps) {
+export function CompanyCard({ result, keywords, locationIds, locations, occupations, seniorities, technologies, employmentTypes, workMode, salaryMinEur, salaryMaxEur, experienceMin, experienceMax, languages, onShowPosting, selectedPostingId }: CompanyCardProps) {
   const params = useParams();
   const locale = (params.lang as string) ?? "en";
   const { company, activeMatches, yearMatches } = result;
@@ -52,6 +53,7 @@ export function CompanyCard({ result, keywords, locationIds, locations, occupati
     occupations,
     seniorities,
     technologies,
+    workMode,
   );
 
   const [extraPostings, setExtraPostings] = useState<SearchResultPosting[]>([]);
@@ -80,6 +82,7 @@ export function CompanyCard({ result, keywords, locationIds, locations, occupati
       seniorityIds: seniorities?.map((s) => s.id),
       technologyIds: technologies?.map((t) => t.id),
       employmentTypes,
+      workMode,
       salaryMinEur,
       salaryMaxEur,
       experienceMin,

--- a/apps/web/src/components/search/filter-pills-readonly.tsx
+++ b/apps/web/src/components/search/filter-pills-readonly.tsx
@@ -1,10 +1,17 @@
 "use client";
 
-import { MapPin, Briefcase, BarChart3, Code2, DollarSign, Clock } from "lucide-react";
+import { MapPin, Briefcase, BarChart3, Code2, DollarSign, Clock, Home } from "lucide-react";
 import type { WatchlistFilters } from "@/lib/actions/watchlists";
 import type { SelectedLocation } from "@/components/search/location-pills";
+import type { WorkMode } from "@/lib/search/types";
 
 type TaxonomyItem = { id: number; slug: string; name: string };
+
+const WORK_MODE_LABEL: Record<WorkMode, string> = {
+  onsite: "On-site",
+  hybrid: "Hybrid",
+  remote: "Remote",
+};
 
 export function FilterPillsReadOnly({
   filters,
@@ -12,12 +19,20 @@ export function FilterPillsReadOnly({
   occupations,
   seniorities,
   technologies,
+  workMode,
 }: {
   filters: WatchlistFilters;
   locations?: SelectedLocation[];
   occupations?: TaxonomyItem[];
   seniorities?: TaxonomyItem[];
   technologies?: TaxonomyItem[];
+  /**
+   * Optional work-mode filter slugs to render as read-only pills
+   * (issue #2983). The watchlist filter shape doesn't yet persist
+   * work-mode, but the prop is accepted now so the explore-page
+   * "save snapshot" view can show it.
+   */
+  workMode?: WorkMode[];
 }) {
   const pills: { key: string; icon: React.ReactNode; label: string }[] = [];
 
@@ -63,6 +78,11 @@ export function FilterPillsReadOnly({
   } else if (filters.technologySlugs?.length) {
     for (const slug of filters.technologySlugs) {
       pills.push({ key: `tech-${slug}`, icon: <Code2 size={12} />, label: slug });
+    }
+  }
+  if (workMode && workMode.length > 0) {
+    for (const mode of workMode) {
+      pills.push({ key: `wm-${mode}`, icon: <Home size={12} />, label: WORK_MODE_LABEL[mode] });
     }
   }
   if (filters.salaryMin != null || filters.salaryMax != null) {

--- a/apps/web/src/components/search/save-search-button.tsx
+++ b/apps/web/src/components/search/save-search-button.tsx
@@ -10,6 +10,7 @@ import { useLocalePath } from "@/lib/useLocalePath";
 import { useAuth } from "@/lib/useAuth";
 import { createWatchlist, type WatchlistFilters } from "@/lib/actions/watchlists";
 import type { SelectedLocation } from "@/components/search/location-pills";
+import type { WorkMode } from "@/lib/search/types";
 
 type TaxonomyItem = { id: number; slug: string; name: string };
 
@@ -19,6 +20,7 @@ interface SaveSearchButtonProps {
   occupations: TaxonomyItem[];
   seniorities: TaxonomyItem[];
   technologies?: TaxonomyItem[];
+  workMode?: WorkMode[];
   salaryMin?: number;
   salaryMax?: number;
   salaryCurrency?: string;
@@ -32,6 +34,7 @@ export function SaveSearchButton({
   occupations,
   seniorities,
   technologies,
+  workMode,
   salaryMin,
   salaryMax,
   salaryCurrency,
@@ -65,6 +68,7 @@ export function SaveSearchButton({
       if (occupations.length > 0) filters.occupationSlugs = occupations.map((o) => o.slug);
       if (seniorities.length > 0) filters.senioritySlugs = seniorities.map((s) => s.slug);
       if (technologies && technologies.length > 0) filters.technologySlugs = technologies.map((t) => t.slug);
+      if (workMode && workMode.length > 0) filters.workMode = workMode;
       if (salaryMin != null) filters.salaryMin = salaryMin;
       if (salaryMax != null) filters.salaryMax = salaryMax;
       if (salaryCurrency) filters.salaryCurrency = salaryCurrency;

--- a/apps/web/src/components/search/search-bar.tsx
+++ b/apps/web/src/components/search/search-bar.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
-import { Search, MapPin, ArrowRight, Briefcase, BarChart3, Code2, Sparkles } from "lucide-react";
+import { Search, MapPin, ArrowRight, Briefcase, BarChart3, Code2, Sparkles, Home } from "lucide-react";
 import { CompanyIcon } from "@/components/CompanyIcon";
 import { useLingui } from "@lingui/react/macro";
 import type { LocationSuggestion } from "@/lib/actions/locations";
@@ -17,16 +17,49 @@ import {
 } from "@/lib/search/typeahead-runner";
 import { parseSearchFilters } from "@/lib/actions/search-input";
 import type { SelectedLocation } from "@/components/search/location-pills";
-import { buildFilteredPath } from "@/lib/search/query-params";
+import { buildFilteredPath, parseWorkModeParam } from "@/lib/search/query-params";
+import type { WorkMode } from "@/lib/search/types";
 import { useSearchStateStore, usePageActions } from "@/components/SearchStateProvider";
 import { useLocalePath } from "@/lib/useLocalePath";
 import { ScrollFade } from "@/components/ui/scroll-fade";
+
+/**
+ * Work-mode autocomplete entries — fixed three values, matched
+ * client-side. Issue #2983. Synonyms mirror the server-side
+ * tokenizer in `parseSearchFilters` so typing `wfh` here surfaces
+ * Remote, and submitting "wfh engineer" picks up the same mode
+ * via free-text parsing.
+ */
+const WORK_MODE_AUTOCOMPLETE: { value: WorkMode; aliases: string[] }[] = [
+  { value: "remote", aliases: ["remote", "wfh", "work from home", "work-from-home"] },
+  { value: "hybrid", aliases: ["hybrid"] },
+  { value: "onsite", aliases: ["onsite", "on site", "on-site", "in office", "in-office"] },
+];
+
+/**
+ * Returns the work-mode values whose name or one of the synonyms is
+ * prefixed by the trimmed lower-cased user input. Returns an empty
+ * array for inputs shorter than 2 characters or with no match.
+ */
+function matchWorkModes(query: string, alreadySelected: ReadonlySet<WorkMode>): WorkMode[] {
+  const q = query.trim().toLowerCase();
+  if (q.length < 2) return [];
+  const out: WorkMode[] = [];
+  for (const entry of WORK_MODE_AUTOCOMPLETE) {
+    if (alreadySelected.has(entry.value)) continue;
+    if (entry.aliases.some((alias) => alias.startsWith(q))) {
+      out.push(entry.value);
+    }
+  }
+  return out;
+}
 
 type SuggestionItem =
   | { kind: "keyword"; data: { text: string } }
   | { kind: "occupation"; data: TaxonomySuggestion }
   | { kind: "seniority"; data: TaxonomySuggestion }
   | { kind: "technology"; data: TaxonomySuggestion }
+  | { kind: "workMode"; data: { value: WorkMode } }
   | { kind: "location"; data: LocationSuggestion }
   | { kind: "company"; data: CompanySuggestion }
   /**
@@ -44,12 +77,17 @@ interface SearchBarProps {
   onAddOccupation?: (occupation: { id: number; slug: string; name: string }) => void;
   onAddSeniority?: (seniority: { id: number; slug: string; name: string }) => void;
   onAddTechnology?: (tech: { id: number; slug: string; name: string }) => void;
+  /** Direct callback for work-mode adds (issue #2983). When omitted,
+   *  falls through to `pageActions.addWorkMode` then a URL push fallback.
+   */
+  onAddWorkMode?: (mode: WorkMode) => void;
   onSubmitSearch?: (
     keywords: string[],
     locations: SelectedLocation[],
     occupations?: { id: number; slug: string; name: string }[],
     seniorities?: { id: number; slug: string; name: string }[],
     technologies?: { id: number; slug: string; name: string }[],
+    workMode?: WorkMode[],
   ) => void;
   locale?: string;
   keywords?: string[];
@@ -57,6 +95,7 @@ interface SearchBarProps {
   occupations?: { id: number; slug: string; name: string }[];
   seniorities?: { id: number; slug: string; name: string }[];
   technologies?: { id: number; slug: string; name: string }[];
+  workMode?: WorkMode[];
   languages?: string[];
   companyId?: string;
   userLat?: number;
@@ -70,6 +109,7 @@ export function SearchBar({
   onAddOccupation,
   onAddSeniority,
   onAddTechnology,
+  onAddWorkMode,
   onSubmitSearch: _onSubmitSearch,
   locale: localeProp,
   keywords: keywordsProp,
@@ -77,6 +117,7 @@ export function SearchBar({
   occupations: occupationsProp,
   seniorities: senioritiesProp,
   technologies: technologiesProp,
+  workMode: workModeProp,
   languages: languagesProp,
   companyId,
   userLat: serverLat,
@@ -154,6 +195,12 @@ export function SearchBar({
   const selectedSeniorityIds = new Set((senioritiesProp ?? []).map((s) => s.id));
   const selectedTechnologyIds = new Set((technologiesProp ?? []).map((t) => t.id));
 
+  // Work-mode is a tiny fixed-cardinality dimension matched client-side.
+  // Read the active selection from the URL when not provided as a prop
+  // (mirrors how `currentLocationSlugs` falls back to the `loc` param).
+  const currentWorkMode: WorkMode[] = workModeProp ?? parseWorkModeParam(searchParams.get("wm"));
+  const selectedWorkModes = useMemo(() => new Set<WorkMode>(currentWorkMode), [currentWorkMode]);
+
   // Filter context shared across typeahead boost queries. Each suggest*
   // call omits the dimension it's suggesting (same convention as the
   // browse-all modals) so users see counts under their *other* filters.
@@ -167,6 +214,12 @@ export function SearchBar({
   // Build flat list for keyboard navigation
   // "keyword" option first so user can search by title, then structured suggestions
   const trimmedInput = inputValue.trim();
+  // Work-mode results are computed synchronously from a tiny static
+  // alias map (no server round-trip). Issue #2983.
+  const workModeResults: WorkMode[] = useMemo(
+    () => matchWorkModes(trimmedInput, selectedWorkModes),
+    [trimmedInput, selectedWorkModes],
+  );
   // Show the "Request <query>" entry only when the user has a non-empty
   // query, no real company match has come back, and we're not scoped to
   // a single company page (where cross-company nav would be a trap).
@@ -179,6 +232,7 @@ export function SearchBar({
     ...occupationResults.map((s): SuggestionItem => ({ kind: "occupation", data: s })),
     ...seniorityResults.map((s): SuggestionItem => ({ kind: "seniority", data: s })),
     ...technologyResults.map((s): SuggestionItem => ({ kind: "technology", data: s })),
+    ...workModeResults.map((value): SuggestionItem => ({ kind: "workMode", data: { value } })),
     ...locationResults.map((s): SuggestionItem => ({ kind: "location", data: s })),
     ...companyResults.map((s): SuggestionItem => ({ kind: "company", data: s })),
     ...(showRequestItem
@@ -197,6 +251,13 @@ export function SearchBar({
         setTechnologyResults([]);
         setIsOpen(false);
         return;
+      }
+      // Work-mode matches are computed synchronously from `query` via
+      // `matchWorkModes` (issue #2983) — open the dropdown immediately
+      // when one exists so the user sees Remote/Hybrid/Onsite without
+      // waiting on async typeahead RPCs.
+      if (matchWorkModes(query, selectedWorkModes).length > 0) {
+        setIsOpen(true);
       }
       // Build the shared filter context for typeahead boost once; each
       // suggest* call omits its own dimension so the boost query re-ranks
@@ -284,7 +345,7 @@ export function SearchBar({
         });
       }, 200);
     },
-    [lang, userLat, userLng, companyId, selectedLocationIds, selectedLocationSlugs, selectedOccupationIds, selectedSeniorityIds, selectedTechnologyIds, baseKeywords, baseLanguages, baseLocationIds, baseOccupationIds, baseSeniorityIds, baseTechnologyIds],
+    [lang, userLat, userLng, companyId, selectedLocationIds, selectedLocationSlugs, selectedOccupationIds, selectedSeniorityIds, selectedTechnologyIds, selectedWorkModes, baseKeywords, baseLanguages, baseLocationIds, baseOccupationIds, baseSeniorityIds, baseTechnologyIds],
   );
 
   const selectItem = useCallback(
@@ -381,6 +442,27 @@ export function SearchBar({
             router.push(lp(`/explore?${p.toString()}`));
           }
         }
+      } else if (item.kind === "workMode") {
+        // Issue #2983 — work-mode select. Mirrors the occupation/
+        // seniority/technology dispatch flow: direct prop callback,
+        // then live page action, then URL push fallback.
+        const mode = item.data.value;
+        if (onAddWorkMode) {
+          onAddWorkMode(mode);
+        } else {
+          const pageActions = getPageActions();
+          if (pageActions?.addWorkMode) {
+            pageActions.addWorkMode(mode);
+          } else {
+            const p = new URLSearchParams(searchParams.toString());
+            const existing = p.get("wm");
+            const merged = existing
+              ? Array.from(new Set([...existing.split(",").filter(Boolean), mode])).join(",")
+              : mode;
+            p.set("wm", merged);
+            router.push(lp(`/explore?${p.toString()}`));
+          }
+        }
       } else {
         // Company: navigate to company page, preserving current filters
         const pageActions = getPageActions();
@@ -389,6 +471,7 @@ export function SearchBar({
         const occs = occupationsProp ?? pageActions?.getOccupations() ?? [];
         const sens = senioritiesProp ?? pageActions?.getSeniorities() ?? [];
         const techs = technologiesProp ?? pageActions?.getTechnologies?.() ?? [];
+        const wm = workModeProp ?? parseWorkModeParam(searchParams.get("wm"));
         const href = buildFilteredPath(
           lp(`/company/${item.data.slug}`),
           kws,
@@ -397,6 +480,7 @@ export function SearchBar({
           occs,
           sens,
           techs,
+          wm,
         );
         router.push(href);
       }
@@ -412,7 +496,7 @@ export function SearchBar({
         inputRef.current?.focus();
       }
     },
-    [onAddLocation, onAddOccupation, onAddSeniority, onAddTechnology, getPageActions, router, lp, searchParams, currentKeywords, currentLocationSlugs, keywordsProp, locationsProp, occupationsProp, senioritiesProp, technologiesProp],
+    [onAddLocation, onAddOccupation, onAddSeniority, onAddTechnology, onAddWorkMode, getPageActions, router, lp, searchParams, currentKeywords, currentLocationSlugs, keywordsProp, locationsProp, occupationsProp, senioritiesProp, technologiesProp],
   );
 
   const submitFreeTextSearch = useCallback(() => {
@@ -436,6 +520,10 @@ export function SearchBar({
     const existingOccs = occupationsProp ?? pageActions?.getOccupations() ?? [];
     const existingSens = senioritiesProp ?? pageActions?.getSeniorities() ?? [];
     const existingTechs = technologiesProp ?? pageActions?.getTechnologies?.() ?? [];
+    // Existing work-mode comes from prop (search/company pages own state)
+    // or, when the bar is rendered standalone (header on a non-search
+    // route), from the URL.
+    const existingWm: WorkMode[] = workModeProp ?? parseWorkModeParam(searchParams.get("wm"));
 
     // Parse input then navigate via URL.
     // We always use router.push so the server component handles the search
@@ -453,15 +541,17 @@ export function SearchBar({
         const mergedSens = [...existingSens, ...parsed.seniorities.filter((s) => !senIdSet.has(s.id))];
         const techIdSet = new Set(existingTechs.map((t) => t.id));
         const mergedTechs = [...existingTechs, ...(parsed.technologies ?? []).filter((t) => !techIdSet.has(t.id))];
+        const wmSet = new Set(existingWm);
+        const mergedWm = [...existingWm, ...(parsed.workMode ?? []).filter((m) => !wmSet.has(m))];
 
-        router.push(buildFilteredPath(lp("/explore"), mergedKw, mergedLocs, undefined, mergedOccs, mergedSens, mergedTechs));
+        router.push(buildFilteredPath(lp("/explore"), mergedKw, mergedLocs, undefined, mergedOccs, mergedSens, mergedTechs, mergedWm));
       })
       .catch(() => {
         // Fallback: treat raw input as a keyword and navigate
         const mergedKw = [...existingKw, input];
-        router.push(buildFilteredPath(lp("/explore"), mergedKw, existingLocs, undefined, existingOccs, existingSens, existingTechs));
+        router.push(buildFilteredPath(lp("/explore"), mergedKw, existingLocs, undefined, existingOccs, existingSens, existingTechs, existingWm));
       });
-  }, [inputValue, lang, userLat, userLng, getPageActions, router, lp, keywordsProp, locationsProp, occupationsProp, senioritiesProp, technologiesProp, currentKeywords]);
+  }, [inputValue, lang, userLat, userLng, getPageActions, router, lp, searchParams, keywordsProp, locationsProp, occupationsProp, senioritiesProp, technologiesProp, workModeProp, currentKeywords]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "ArrowDown") {
@@ -521,7 +611,7 @@ export function SearchBar({
     message: "Search...",
   });
 
-  // Compute flat indices for each section (keyword → occupations → seniorities → technologies → locations → companies → request)
+  // Compute flat indices for each section (keyword → occupations → seniorities → technologies → workMode → locations → companies → request)
   let flatIdx = 0;
   const keywordIndex = flatIdx;
   flatIdx += trimmedInput.length >= 2 ? 1 : 0;
@@ -531,6 +621,8 @@ export function SearchBar({
   flatIdx += seniorityResults.length;
   const techStartIndex = flatIdx;
   flatIdx += technologyResults.length;
+  const wmStartIndex = flatIdx;
+  flatIdx += workModeResults.length;
   const locStartIndex = flatIdx;
   flatIdx += locationResults.length;
   const companyStartIndex = flatIdx;
@@ -702,9 +794,51 @@ export function SearchBar({
             </>
           )}
 
-          {locationResults.length > 0 && (
+          {workModeResults.length > 0 && (
             <>
               <div className={`px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted ${(occupationResults.length > 0 || seniorityResults.length > 0 || technologyResults.length > 0) ? "border-t border-border-soft" : ""}`}>
+                {t({
+                  id: "search.bar.workMode",
+                  comment: "Section header for work-mode (onsite/hybrid/remote) suggestions in search bar",
+                  message: "Work mode",
+                })}
+              </div>
+              {workModeResults.map((value, i) => {
+                const fi = wmStartIndex + i;
+                const label =
+                  value === "onsite"
+                    ? t({ id: "search.workMode.onsite", comment: "Work mode: onsite (in-office)", message: "On-site" })
+                    : value === "hybrid"
+                      ? t({ id: "search.workMode.hybrid", comment: "Work mode: hybrid (mixed onsite/remote)", message: "Hybrid" })
+                      : t({ id: "search.workMode.remote", comment: "Work mode: remote (work-from-home)", message: "Remote" });
+                return (
+                  <div
+                    key={`wm-${value}`}
+                    id={`search-option-${fi}`}
+                    role="option"
+                    aria-selected={fi === activeIndex}
+                    data-suggestion
+                    data-testid={`search-bar-workmode-${value}`}
+                    onMouseDown={(e) => {
+                      e.preventDefault();
+                      selectItem({ kind: "workMode", data: { value } });
+                    }}
+                    onMouseEnter={() => setActiveIndex(fi)}
+                    className={`flex cursor-pointer items-center gap-2 px-3 py-2 text-sm ${
+                      fi === activeIndex ? "bg-primary/10" : "hover:bg-primary/5"
+                    }`}
+                  >
+                    <Home size={14} className="shrink-0 text-muted" />
+                    <span className="min-w-0 flex-1 font-medium">{label}</span>
+                  </div>
+                );
+              })}
+            </>
+          )}
+
+          {locationResults.length > 0 && (
+            <>
+              <div className={`px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted ${(occupationResults.length > 0 || seniorityResults.length > 0 || technologyResults.length > 0 || workModeResults.length > 0) ? "border-t border-border-soft" : ""}`}>
                 {t({
                   id: "search.bar.locations",
                   comment: "Section header for location suggestions in search bar",
@@ -744,7 +878,7 @@ export function SearchBar({
 
           {companyResults.length > 0 && (
             <>
-              <div className={`px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted ${(occupationResults.length > 0 || seniorityResults.length > 0 || technologyResults.length > 0 || locationResults.length > 0) ? "border-t border-border-soft" : ""}`}>
+              <div className={`px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted ${(occupationResults.length > 0 || seniorityResults.length > 0 || technologyResults.length > 0 || workModeResults.length > 0 || locationResults.length > 0) ? "border-t border-border-soft" : ""}`}>
                 {t({
                   id: "search.bar.companies",
                   comment: "Section header for company suggestions in search bar",

--- a/apps/web/src/components/search/search-results.tsx
+++ b/apps/web/src/components/search/search-results.tsx
@@ -4,7 +4,7 @@ import { CompanyCard } from "./company-card";
 import { RequestCompanyPrompt } from "./request-company";
 import { InfiniteScrollSentinel } from "@/components/InfiniteScrollSentinel";
 import { TruncationPrompt } from "@/components/TruncationPrompt";
-import type { SearchResultCompany } from "@/lib/search";
+import type { SearchResultCompany, WorkMode } from "@/lib/search";
 import type { SerializableLocation, SerializableOccupation, SerializableSeniority, SerializableTechnology } from "@/lib/search/query-params";
 import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
 
@@ -17,6 +17,7 @@ interface SearchResultsProps {
   seniorities?: SerializableSeniority[];
   technologies?: SerializableTechnology[];
   employmentTypes?: string[];
+  workMode?: WorkMode[];
   salaryMinEur?: number;
   salaryMaxEur?: number;
   experienceMin?: number;
@@ -38,6 +39,7 @@ export function SearchResults({
   seniorities,
   technologies,
   employmentTypes,
+  workMode,
   salaryMinEur,
   salaryMaxEur,
   experienceMin,
@@ -55,7 +57,7 @@ export function SearchResults({
     <div className="space-y-3">
       {companies.map((result) => (
         <div key={`${result.company.id}-${keywords.join(",")}`}>
-          <CompanyCard result={result} keywords={keywords} locationIds={locationIds} locations={locations} occupations={occupations} seniorities={seniorities} technologies={technologies} employmentTypes={employmentTypes} salaryMinEur={salaryMinEur} salaryMaxEur={salaryMaxEur} experienceMin={experienceMin} experienceMax={experienceMax} languages={languages} onShowPosting={onShowPosting} selectedPostingId={selectedPostingId} />
+          <CompanyCard result={result} keywords={keywords} locationIds={locationIds} locations={locations} occupations={occupations} seniorities={seniorities} technologies={technologies} employmentTypes={employmentTypes} workMode={workMode} salaryMinEur={salaryMinEur} salaryMaxEur={salaryMaxEur} experienceMin={experienceMin} experienceMax={experienceMax} languages={languages} onShowPosting={onShowPosting} selectedPostingId={selectedPostingId} />
         </div>
       ))}
       {hasMore && <InfiniteScrollSentinel sentinelRef={sentinelRef} isLoading={isLoading} />}

--- a/apps/web/src/components/search/search-toolbar.tsx
+++ b/apps/web/src/components/search/search-toolbar.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { X, MapPin, Briefcase, BarChart3, CalendarDays, DollarSign, Clock, Code2 } from "lucide-react";
+import { X, MapPin, Briefcase, BarChart3, CalendarDays, DollarSign, Clock, Code2, Home } from "lucide-react";
 import { useLingui } from "@lingui/react/macro";
 import { SearchBar } from "@/components/search/search-bar";
 import { AdvancedSearchPanel } from "@/components/search/advanced-search-panel";
 import { LanguageNote } from "@/components/search/language-note";
 import { SaveSearchButton } from "@/components/search/save-search-button";
 import type { SelectedLocation } from "@/components/search/location-pills";
-import type { HistogramFilters } from "@/lib/search";
+import type { HistogramFilters, WorkMode } from "@/lib/search";
 
 type TaxonomyItem = { id: number; slug: string; name: string };
 
@@ -41,6 +41,8 @@ interface SearchToolbarProps {
   onRemoveTechnology?: (id: number) => void;
   employmentTypes?: string[];
   onToggleEmploymentType?: (type: string) => void;
+  workMode?: WorkMode[];
+  onToggleWorkMode?: (mode: WorkMode) => void;
   onSalaryChange?: (currency: string, min: number | undefined, max: number | undefined) => void;
   onExperienceChange?: (min: number | undefined, max: number | undefined) => void;
   histogramFilters?: HistogramFilters;
@@ -88,6 +90,8 @@ export function SearchToolbar({
   onRemoveTechnology,
   employmentTypes,
   onToggleEmploymentType,
+  workMode,
+  onToggleWorkMode,
   onSalaryChange,
   onExperienceChange,
   histogramFilters,
@@ -104,6 +108,8 @@ export function SearchToolbar({
     occupations.length > 0 ||
     seniorities.length > 0 ||
     (technologies?.length ?? 0) > 0 ||
+    (employmentTypes?.length ?? 0) > 0 ||
+    (workMode?.length ?? 0) > 0 ||
     salaryMin != null ||
     salaryMax != null ||
     experienceMin != null ||
@@ -156,6 +162,8 @@ export function SearchToolbar({
           onRemoveTechnology={onRemoveTechnology}
           employmentTypes={employmentTypes}
           onToggleEmploymentType={onToggleEmploymentType}
+          workMode={workMode}
+          onToggleWorkMode={onToggleWorkMode}
           onSalaryChange={onSalaryChange}
           onExperienceChange={onExperienceChange}
           histogramFilters={histogramFilters}
@@ -167,6 +175,7 @@ export function SearchToolbar({
             occupations={occupations}
             seniorities={seniorities}
             technologies={technologies}
+            workMode={workMode}
             salaryMin={salaryMin}
             salaryMax={salaryMax}
             salaryCurrency={salaryCurrency}
@@ -233,6 +242,25 @@ export function SearchToolbar({
               {et.replace(/_/g, " ")}
               <button
                 onClick={() => onToggleEmploymentType(et)}
+                className="ml-0.5 cursor-pointer rounded-full p-0.5 transition-colors hover:bg-primary/20"
+              >
+                <X size={12} />
+              </button>
+            </span>
+          ))}
+          {onToggleWorkMode && workMode && workMode.map((wm) => (
+            <span
+              key={`wm-${wm}`}
+              className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary"
+            >
+              <Home size={12} className="shrink-0" />
+              {wm === "onsite"
+                ? t({ id: "search.workMode.onsite", comment: "Work mode: onsite (in-office)", message: "On-site" })
+                : wm === "hybrid"
+                  ? t({ id: "search.workMode.hybrid", comment: "Work mode: hybrid (mixed onsite/remote)", message: "Hybrid" })
+                  : t({ id: "search.workMode.remote", comment: "Work mode: remote (work-from-home)", message: "Remote" })}
+              <button
+                onClick={() => onToggleWorkMode(wm)}
                 className="ml-0.5 cursor-pointer rounded-full p-0.5 transition-colors hover:bg-primary/20"
               >
                 <X size={12} />

--- a/apps/web/src/components/search/work-mode-modal.tsx
+++ b/apps/web/src/components/search/work-mode-modal.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useMemo } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+import { Trans, useLingui } from "@lingui/react/macro";
+import { ScrollFade } from "@/components/ui/scroll-fade";
+import type { WorkMode } from "@/lib/search/types";
+
+/**
+ * Work-mode (location_types) modal — mirrors employment-type-modal.tsx
+ * exactly. Multi-select via `selected: WorkMode[]` + `onToggle`. Three
+ * fixed options sourced from {@link WORK_MODE_VALUES}; we hard-code the
+ * order here (onsite → hybrid → remote) so the modal layout is stable.
+ * Issue #2983.
+ */
+function useWorkModes() {
+  const { t } = useLingui();
+  return [
+    { value: "onsite" as const, label: t({ id: "search.workMode.onsite", comment: "Work mode: onsite (in-office)", message: "On-site" }) },
+    { value: "hybrid" as const, label: t({ id: "search.workMode.hybrid", comment: "Work mode: hybrid (mixed onsite/remote)", message: "Hybrid" }) },
+    { value: "remote" as const, label: t({ id: "search.workMode.remote", comment: "Work mode: remote (work-from-home)", message: "Remote" }) },
+  ] as const;
+}
+
+interface WorkModeModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  selected: WorkMode[];
+  onToggle: (mode: WorkMode) => void;
+}
+
+export function WorkModeModal({
+  open,
+  onOpenChange,
+  selected,
+  onToggle,
+}: WorkModeModalProps) {
+  const WORK_MODES = useWorkModes();
+  const selectedSet = useMemo(() => new Set(selected), [selected]);
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=open]:fade-in-0" />
+        <Dialog.Content
+          className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 flex-col rounded-xl border border-border-soft bg-surface shadow-xl data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+          aria-describedby={undefined}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between border-b border-divider px-5 py-4">
+            <Dialog.Title className="text-base font-semibold">
+              <Trans id="search.workModeModal.title" comment="Title for the work-mode (onsite/hybrid/remote) selection modal">
+                Work mode
+              </Trans>
+            </Dialog.Title>
+            <Dialog.Close asChild>
+              <button className="cursor-pointer rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground">
+                <X size={16} />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          {/* Body */}
+          <ScrollFade wrapperClassName="flex-1 min-h-0" className="px-5 py-4">
+            <div className="flex flex-col gap-2">
+              {WORK_MODES.map((opt) => {
+                const active = selectedSet.has(opt.value);
+                return (
+                  <button
+                    key={opt.value}
+                    onClick={() => onToggle(opt.value)}
+                    className={`flex cursor-pointer items-center rounded-lg px-4 py-3 text-sm font-medium transition-colors ${
+                      active
+                        ? "bg-primary/10 text-primary"
+                        : "border border-border-soft text-muted hover:border-primary/30 hover:text-foreground"
+                    }`}
+                  >
+                    {opt.label}
+                  </button>
+                );
+              })}
+            </div>
+          </ScrollFade>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/web/src/lib/actions/__tests__/search-input.test.ts
+++ b/apps/web/src/lib/actions/__tests__/search-input.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  suggestLocations: vi.fn(),
+  suggestOccupations: vi.fn(),
+  suggestSeniorities: vi.fn(),
+  suggestTechnologies: vi.fn(),
+  resolveLocationSlugs: vi.fn(),
+  resolveOccupationSlugs: vi.fn(),
+  resolveSenioritySlugs: vi.fn(),
+  resolveTechnologySlugs: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/actions/locations", () => ({
+  suggestLocations: mocks.suggestLocations,
+  resolveLocationSlugs: mocks.resolveLocationSlugs,
+}));
+vi.mock("@/lib/actions/taxonomy", () => ({
+  suggestOccupations: mocks.suggestOccupations,
+  suggestSeniorities: mocks.suggestSeniorities,
+  suggestTechnologies: mocks.suggestTechnologies,
+  resolveOccupationSlugs: mocks.resolveOccupationSlugs,
+  resolveSenioritySlugs: mocks.resolveSenioritySlugs,
+  resolveTechnologySlugs: mocks.resolveTechnologySlugs,
+}));
+
+import { parseSearchFilters } from "../search-input";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: no taxonomy/location matches at all — we want pure
+  // work-mode tokenization paths exercised here.
+  mocks.suggestLocations.mockResolvedValue([]);
+  mocks.suggestOccupations.mockResolvedValue([]);
+  mocks.suggestSeniorities.mockResolvedValue([]);
+  mocks.suggestTechnologies.mockResolvedValue([]);
+  mocks.resolveLocationSlugs.mockResolvedValue(new Map());
+  mocks.resolveOccupationSlugs.mockResolvedValue(new Map());
+  mocks.resolveSenioritySlugs.mockResolvedValue(new Map());
+  mocks.resolveTechnologySlugs.mockResolvedValue(new Map());
+});
+
+// =====================================================================
+// Issue #2983: free-text tokenization recognizes work-mode tokens
+// (`remote`, `hybrid`, `onsite`, plus a small synonym set) and reports
+// them on the parsed `workMode` field. Synonyms list is intentionally
+// narrow to avoid colliding with common job titles.
+// =====================================================================
+
+describe("parseSearchFilters — workMode tokenization (#2983)", () => {
+  it("returns empty workMode when q is empty and no `wm` param", async () => {
+    const r = await parseSearchFilters({ locale: "en" });
+    expect(r.workMode).toEqual([]);
+  });
+
+  it("recognizes a bare `remote` token", async () => {
+    const r = await parseSearchFilters({ q: "remote", locale: "en" });
+    expect(r.workMode).toEqual(["remote"]);
+    expect(r.keywords).toEqual([]);
+  });
+
+  it("recognizes `hybrid` and `onsite` single-word tokens", async () => {
+    const hyb = await parseSearchFilters({ q: "hybrid", locale: "en" });
+    expect(hyb.workMode).toEqual(["hybrid"]);
+    const ons = await parseSearchFilters({ q: "onsite", locale: "en" });
+    expect(ons.workMode).toEqual(["onsite"]);
+  });
+
+  it("recognizes the `wfh` synonym as remote", async () => {
+    const r = await parseSearchFilters({ q: "wfh engineer", locale: "en" });
+    expect(r.workMode).toEqual(["remote"]);
+    // engineer falls through to keywords here because suggestOccupations
+    // is mocked to return no matches.
+    expect(r.keywords).toEqual(["engineer"]);
+  });
+
+  it("recognizes `work from home` as remote (multi-word)", async () => {
+    const r = await parseSearchFilters({ q: "work from home", locale: "en" });
+    expect(r.workMode).toEqual(["remote"]);
+    expect(r.keywords).toEqual([]);
+  });
+
+  it("recognizes `in office` as onsite", async () => {
+    const r = await parseSearchFilters({ q: "in office", locale: "en" });
+    expect(r.workMode).toEqual(["onsite"]);
+  });
+
+  it("does not match the bare `office` word (would clash with job titles)", async () => {
+    const r = await parseSearchFilters({ q: "office", locale: "en" });
+    expect(r.workMode).toEqual([]);
+    expect(r.keywords).toEqual(["office"]);
+  });
+
+  it("composes free-text matches with the `wm` URL param without dupes", async () => {
+    const r = await parseSearchFilters({
+      q: "remote",
+      wm: "hybrid",
+      locale: "en",
+    });
+    expect(r.workMode).toEqual(["hybrid", "remote"]);
+  });
+
+  it("dedupes when free-text and URL agree", async () => {
+    const r = await parseSearchFilters({
+      q: "remote",
+      wm: "remote",
+      locale: "en",
+    });
+    expect(r.workMode).toEqual(["remote"]);
+  });
+
+  it("ignores invalid wm tokens but parses free text", async () => {
+    const r = await parseSearchFilters({
+      q: "remote",
+      wm: "bogus",
+      locale: "en",
+    });
+    expect(r.workMode).toEqual(["remote"]);
+  });
+
+  it("case-insensitive matching", async () => {
+    const r = await parseSearchFilters({ q: "REMOTE", locale: "en" });
+    expect(r.workMode).toEqual(["remote"]);
+  });
+});

--- a/apps/web/src/lib/actions/company-page-data.ts
+++ b/apps/web/src/lib/actions/company-page-data.ts
@@ -46,6 +46,7 @@ export async function fetchCompanyPageData(params: {
   const occ = firstOf(searchParams.occ);
   const sen = firstOf(searchParams.sen);
   const tech = firstOf(searchParams.tech);
+  const wm = firstOf(searchParams.wm);
   const show = firstOf(searchParams.show);
   const sal = firstOf(searchParams.sal);
   const salcur = firstOf(searchParams.salcur);
@@ -57,7 +58,7 @@ export async function fetchCompanyPageData(params: {
   // mirror it into a cookie (issue #2850 + `anon-preferences.ts`).
   const session = await getSession();
   const [parsed, prefs, anonJobLangs] = await Promise.all([
-    parseSearchFilters({ q, loc, occ, sen, tech, locale, userLat, userLng }),
+    parseSearchFilters({ q, loc, occ, sen, tech, wm, locale, userLat, userLng }),
     session ? getPreferences() : Promise.resolve(null),
     session ? Promise.resolve(null) : readAnonJobLanguagesCookie(),
   ]);
@@ -70,6 +71,7 @@ export async function fetchCompanyPageData(params: {
   const occupationIds = idsOrUndefined(parsed.occupations);
   const seniorityIds = idsOrUndefined(parsed.seniorities);
   const technologyIds = idsOrUndefined(parsed.technologies);
+  const workMode = parsed.workMode.length > 0 ? parsed.workMode : undefined;
 
   const salaryCurrencyParam = salcur ?? displayCurrency;
   const { min: salaryMinDisplay, max: salaryMaxDisplay } = parseRangeParam(sal);
@@ -84,6 +86,7 @@ export async function fetchCompanyPageData(params: {
     occupationIds,
     seniorityIds,
     technologyIds,
+    workMode,
     salaryMinEur,
     salaryMaxEur,
     experienceMin,

--- a/apps/web/src/lib/actions/company.ts
+++ b/apps/web/src/lib/actions/company.ts
@@ -5,7 +5,7 @@ import { cacheLife, cacheTag } from "next/cache";
 import { db } from "@/db";
 import { withDbRetry } from "@/lib/db-retry";
 import { getSearchProvider } from "@/lib/search";
-import type { SearchResultPosting } from "@/lib/search";
+import type { SearchResultPosting, WorkMode } from "@/lib/search";
 import {
   companyByIdCacheTag,
   companyCacheTag,
@@ -1151,6 +1151,7 @@ interface NormalizedCompanyPostingsParams {
   seniorityIds: number[];
   technologyIds: number[];
   employmentTypes: string[];
+  workMode: WorkMode[];
   languages: string[];
   salaryMinEur: number | null;
   salaryMaxEur: number | null;
@@ -1169,6 +1170,7 @@ export async function getCompanyPostings(params: {
   seniorityIds?: number[];
   technologyIds?: number[];
   employmentTypes?: string[];
+  workMode?: WorkMode[];
   salaryMinEur?: number;
   salaryMaxEur?: number;
   experienceMin?: number;
@@ -1196,6 +1198,7 @@ export async function getCompanyPostings(params: {
     seniorityIds: [...(params.seniorityIds ?? [])].sort((a, b) => a - b),
     technologyIds: [...(params.technologyIds ?? [])].sort((a, b) => a - b),
     employmentTypes: [...(params.employmentTypes ?? [])].sort(),
+    workMode: [...(params.workMode ?? [])].sort(),
     languages: [...params.languages].sort(),
     salaryMinEur: params.salaryMinEur ?? null,
     salaryMaxEur: params.salaryMaxEur ?? null,
@@ -1245,6 +1248,7 @@ async function _fetchCompanyPostingsCached(
     seniorityIds: params.seniorityIds,
     technologyIds: params.technologyIds,
     employmentTypes: params.employmentTypes,
+    workMode: params.workMode.length > 0 ? params.workMode : undefined,
     languages: params.languages,
     salaryMinEur: params.salaryMinEur ?? undefined,
     salaryMaxEur: params.salaryMaxEur ?? undefined,

--- a/apps/web/src/lib/actions/explore-data.ts
+++ b/apps/web/src/lib/actions/explore-data.ts
@@ -23,6 +23,7 @@ const EMPTY_PARSED_FILTERS: ParsedSearchFilters = {
   occupations: [],
   seniorities: [],
   technologies: [],
+  workMode: [],
 };
 
 export interface ExploreData {
@@ -51,6 +52,7 @@ export async function fetchExploreData(params: {
   const occ = firstOf(searchParams.occ);
   const sen = firstOf(searchParams.sen);
   const tech = firstOf(searchParams.tech);
+  const wm = firstOf(searchParams.wm);
   const sal = firstOf(searchParams.sal);
   const salcur = firstOf(searchParams.salcur);
   const exp = firstOf(searchParams.exp);
@@ -64,7 +66,7 @@ export async function fetchExploreData(params: {
   // search. Other prefs (display currency etc.) stay anon-defaults.
   const session = await getSession();
   const [parsed, prefs, anonJobLangs] = await Promise.all([
-    parseSearchFilters({ q, loc, occ, sen, tech, locale, userLat, userLng }),
+    parseSearchFilters({ q, loc, occ, sen, tech, wm, locale, userLat, userLng }),
     session ? getPreferences() : Promise.resolve(null),
     session ? Promise.resolve(null) : readAnonJobLanguagesCookie(),
   ]);
@@ -77,6 +79,7 @@ export async function fetchExploreData(params: {
   const occupationIds = idsOrUndefined(parsed.occupations);
   const seniorityIds = idsOrUndefined(parsed.seniorities);
   const technologyIds = idsOrUndefined(parsed.technologies);
+  const workMode = parsed.workMode.length > 0 ? parsed.workMode : undefined;
 
   const salaryCurrencyParam = salcur ?? displayCurrency;
   const { min: salaryMinDisplay, max: salaryMaxDisplay } = parseRangeParam(sal);
@@ -92,6 +95,7 @@ export async function fetchExploreData(params: {
           occupationIds,
           seniorityIds,
           technologyIds,
+          workMode,
           salaryMinEur,
           salaryMaxEur,
           experienceMin,
@@ -106,6 +110,7 @@ export async function fetchExploreData(params: {
           occupationIds,
           seniorityIds,
           technologyIds,
+          workMode,
           salaryMinEur,
           salaryMaxEur,
           experienceMin,

--- a/apps/web/src/lib/actions/search-input.ts
+++ b/apps/web/src/lib/actions/search-input.ts
@@ -4,6 +4,8 @@ import { resolveLocationSlugs, suggestLocations, type LocationSuggestion } from 
 import { resolveOccupationSlugs, resolveSenioritySlugs, suggestOccupations, suggestSeniorities, suggestTechnologies, resolveTechnologySlugs } from "@/lib/actions/taxonomy";
 import type { TaxonomySuggestion } from "@/lib/actions/taxonomy";
 import type { SelectedLocation } from "@/components/search/location-pills";
+import { parseWorkModeParam } from "@/lib/search/query-params";
+import type { WorkMode } from "@/lib/search/types";
 
 export type ParsedSearchLocation = SelectedLocation;
 
@@ -13,7 +15,35 @@ export interface ParsedSearchFilters {
   occupations: { id: number; slug: string; name: string }[];
   seniorities: { id: number; slug: string; name: string }[];
   technologies: { id: number; slug: string; name: string }[];
+  workMode: WorkMode[];
 }
+
+/**
+ * Map of normalized lower-cased tokens / synonyms to canonical
+ * {@link WorkMode} values. Single-word entries match against
+ * `splitIntoWords` output during Pass 2; multi-word entries (e.g.
+ * `"work from home"`, `"in office"`) match against the raw segment so
+ * tokenizing them by whitespace doesn't lose them. Issue #2983.
+ *
+ * NOTE: synonyms are intentionally narrow — `"flex"` is NOT included
+ * because it's an English noun common in job titles ("flex engineer").
+ * `"office"` alone is also excluded for the same reason.
+ */
+const WORK_MODE_SINGLE_TOKEN: Record<string, WorkMode> = {
+  remote: "remote",
+  wfh: "remote",
+  hybrid: "hybrid",
+  onsite: "onsite",
+};
+
+const WORK_MODE_MULTI_TOKEN: Record<string, WorkMode> = {
+  "work from home": "remote",
+  "work-from-home": "remote",
+  "on site": "onsite",
+  "on-site": "onsite",
+  "in office": "onsite",
+  "in-office": "onsite",
+};
 
 function uniqCaseInsensitive(values: string[]): string[] {
   const seen = new Set<string>();
@@ -128,6 +158,8 @@ export async function parseSearchFilters(params: {
   occ?: string;
   sen?: string;
   tech?: string;
+  /** `wm` URL param — comma-separated WorkMode values (issue #2983). */
+  wm?: string;
   locale: string;
   userLat?: number;
   userLng?: number;
@@ -206,6 +238,12 @@ export async function parseSearchFilters(params: {
     .map((slug) => resolvedTechs.get(slug))
     .filter((t): t is NonNullable<typeof t> => t !== undefined);
 
+  // Explicit `wm` URL param (issue #2983) — already constrained to valid
+  // WorkMode values by parseWorkModeParam. Free-text matches found below
+  // during tokenization extend this set without duplicates.
+  const workMode: WorkMode[] = parseWorkModeParam(params.wm);
+  const workModeSet = new Set<WorkMode>(workMode);
+
   const locationIds = new Set(locations.map((location) => location.id));
   const occupationIds = new Set(occupations.map((o) => o.id));
   const seniorityIds = new Set(seniorities.map((s) => s.id));
@@ -235,7 +273,7 @@ export async function parseSearchFilters(params: {
   const singles = [...singleSet];
   const allCandidates = [...allCandidateSet];
   if (singles.length === 0) {
-    return { keywords: [], locations, occupations, seniorities, technologies };
+    return { keywords: [], locations, occupations, seniorities, technologies, workMode };
   }
 
   // All three suggest batches run in parallel. Locations use an expensive
@@ -282,10 +320,56 @@ export async function parseSearchFilters(params: {
   for (const words of segmentWords) {
     const consumed = new Array<boolean>(words.length).fill(false);
 
-    // --- Pass 2: Single-word matching (seniority → location → occupation) ---
+    // --- Pass 1.5: Multi-word work-mode (e.g. "work from home", "in office") ---
+    // Issue #2983. Try triplet then pair sliding windows so longer phrases
+    // win over their shorter substrings (e.g. don't let "in" + "office"
+    // bind to single-token "office" — which we don't ship anyway).
+    if (words.length >= 3) {
+      for (let i = 0; i <= words.length - 3; i++) {
+        if (consumed[i] || consumed[i + 1] || consumed[i + 2]) continue;
+        const triplet = `${words[i]} ${words[i + 1]} ${words[i + 2]}`.toLowerCase();
+        const wm = WORK_MODE_MULTI_TOKEN[triplet];
+        if (wm) {
+          if (!workModeSet.has(wm)) {
+            workModeSet.add(wm);
+            workMode.push(wm);
+          }
+          consumed[i] = consumed[i + 1] = consumed[i + 2] = true;
+        }
+      }
+    }
+    if (words.length >= 2) {
+      for (let i = 0; i <= words.length - 2; i++) {
+        if (consumed[i] || consumed[i + 1]) continue;
+        const pair = `${words[i]} ${words[i + 1]}`.toLowerCase();
+        const wm = WORK_MODE_MULTI_TOKEN[pair];
+        if (wm) {
+          if (!workModeSet.has(wm)) {
+            workModeSet.add(wm);
+            workMode.push(wm);
+          }
+          consumed[i] = consumed[i + 1] = true;
+        }
+      }
+    }
+
+    // --- Pass 2: Single-word matching (work-mode → seniority → location → occupation) ---
     for (let i = 0; i < words.length; i++) {
       if (consumed[i]) continue;
       const word = words[i];
+
+      // Work-mode single-token (`remote`, `hybrid`, `onsite`, `wfh`).
+      // Tried before seniority because these tokens never overlap with
+      // seniority/occupation/location names in practice.
+      const wmMatch = WORK_MODE_SINGLE_TOKEN[word.toLowerCase()];
+      if (wmMatch) {
+        if (!workModeSet.has(wmMatch)) {
+          workModeSet.add(wmMatch);
+          workMode.push(wmMatch);
+        }
+        consumed[i] = true;
+        continue;
+      }
 
       const senMatch = exactTaxonomyMatch(word, senMap.get(word) ?? []);
       if (senMatch) {
@@ -373,5 +457,6 @@ export async function parseSearchFilters(params: {
     occupations,
     seniorities,
     technologies,
+    workMode,
   };
 }

--- a/apps/web/src/lib/actions/search.ts
+++ b/apps/web/src/lib/actions/search.ts
@@ -4,7 +4,7 @@ import { sql } from "drizzle-orm";
 import { cacheLife } from "next/cache";
 import { db } from "@/db";
 import { getSearchProvider } from "@/lib/search";
-import type { SearchResponse, SearchResultPosting, HistogramFilters } from "@/lib/search";
+import type { SearchResponse, SearchResultPosting, HistogramFilters, WorkMode } from "@/lib/search";
 import { cached } from "@/lib/cache";
 import { withDbRetry } from "@/lib/db-retry";
 import { getSessionUserId } from "@/lib/sessionCache";
@@ -228,6 +228,7 @@ export async function searchJobs(params: {
   seniorityIds?: number[];
   technologyIds?: number[];
   employmentTypes?: string[];
+  workMode?: WorkMode[];
   salaryMinEur?: number;
   salaryMaxEur?: number;
   experienceMin?: number;
@@ -261,6 +262,7 @@ type TopCompaniesParams = {
   seniorityIds?: number[];
   technologyIds?: number[];
   employmentTypes?: string[];
+  workMode?: WorkMode[];
   salaryMinEur?: number;
   salaryMaxEur?: number;
   experienceMin?: number;
@@ -296,6 +298,7 @@ async function _listTopCompaniesImpl(
     !params.seniorityIds?.length &&
     !params.technologyIds?.length &&
     !params.employmentTypes?.length &&
+    !params.workMode?.length &&
     params.salaryMinEur == null &&
     params.salaryMaxEur == null &&
     params.experienceMin == null &&
@@ -463,6 +466,7 @@ export async function loadMorePostings(params: {
   seniorityIds?: number[];
   technologyIds?: number[];
   employmentTypes?: string[];
+  workMode?: WorkMode[];
   salaryMinEur?: number;
   salaryMaxEur?: number;
   experienceMin?: number;

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -38,6 +38,15 @@ export type WatchlistFilters = {
   occupationSlugs?: string[];
   senioritySlugs?: string[];
   technologySlugs?: string[];
+  /**
+   * Work-mode (location_types) filter — `onsite | hybrid | remote`.
+   * Issue #2983. Backwards-compatible: missing field on existing
+   * watchlists ⇒ undefined ⇒ no filter applied. Reading code must
+   * defensively re-validate strings against {@link WORK_MODE_VALUES}
+   * before passing to Typesense (this column is JSONB and could carry
+   * legacy garbage from older client versions).
+   */
+  workMode?: ("onsite" | "hybrid" | "remote")[];
   salaryMin?: number;
   salaryMax?: number;
   salaryCurrency?: string;

--- a/apps/web/src/lib/search/__tests__/query-params.test.ts
+++ b/apps/web/src/lib/search/__tests__/query-params.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseWorkModeParam,
+  buildFilterQuery,
+  buildFilteredPath,
+} from "../query-params";
+
+// =====================================================================
+// Issue #2983: `wm` URL parameter parsing + serialization.
+// =====================================================================
+
+describe("parseWorkModeParam", () => {
+  it("returns empty for nullish / empty input", () => {
+    expect(parseWorkModeParam(null)).toEqual([]);
+    expect(parseWorkModeParam(undefined)).toEqual([]);
+    expect(parseWorkModeParam("")).toEqual([]);
+  });
+
+  it("parses a single canonical value", () => {
+    expect(parseWorkModeParam("remote")).toEqual(["remote"]);
+  });
+
+  it("parses comma-separated values, preserving order", () => {
+    expect(parseWorkModeParam("hybrid,remote")).toEqual(["hybrid", "remote"]);
+  });
+
+  it("lower-cases input before validating", () => {
+    expect(parseWorkModeParam("REMOTE,Hybrid")).toEqual(["remote", "hybrid"]);
+  });
+
+  it("trims whitespace around tokens", () => {
+    expect(parseWorkModeParam(" remote , hybrid ")).toEqual(["remote", "hybrid"]);
+  });
+
+  it("drops invalid tokens but keeps valid ones", () => {
+    // "wfh" is a synonym handled by the free-text tokenizer in
+    // search-input.ts, NOT a canonical URL value. URL must use the
+    // canonical token.
+    expect(parseWorkModeParam("remote,bogus,onsite,wfh")).toEqual([
+      "remote",
+      "onsite",
+    ]);
+  });
+
+  it("deduplicates repeated tokens", () => {
+    expect(parseWorkModeParam("remote,remote,Hybrid,REMOTE")).toEqual([
+      "remote",
+      "hybrid",
+    ]);
+  });
+});
+
+describe("buildFilterQuery — workMode", () => {
+  it("emits `wm` when present", () => {
+    const qs = buildFilterQuery([], [], undefined, undefined, undefined, [
+      "remote",
+      "hybrid",
+    ]);
+    expect(qs).toBe("wm=remote%2Chybrid");
+  });
+
+  it("does NOT emit `wm` when empty / undefined", () => {
+    expect(buildFilterQuery([], [], undefined, undefined, undefined, [])).toBe(
+      "",
+    );
+    expect(
+      buildFilterQuery([], [], undefined, undefined, undefined, undefined),
+    ).toBe("");
+  });
+});
+
+describe("buildFilteredPath — workMode", () => {
+  it("appends `?wm=...` to the path", () => {
+    expect(
+      buildFilteredPath("/en/explore", [], [], undefined, undefined, undefined, undefined, [
+        "remote",
+      ]),
+    ).toBe("/en/explore?wm=remote");
+  });
+
+  it("composes with other filters", () => {
+    expect(
+      buildFilteredPath(
+        "/en/explore",
+        ["foo"],
+        [{ id: 1, slug: "berlin", name: "Berlin", type: "city" }],
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        ["remote"],
+      ),
+    ).toBe("/en/explore?q=foo&loc=berlin&wm=remote");
+  });
+
+  it("returns the bare path when workMode is empty", () => {
+    expect(
+      buildFilteredPath("/en/explore", [], [], undefined, undefined, undefined, undefined, []),
+    ).toBe("/en/explore");
+  });
+});

--- a/apps/web/src/lib/search/__tests__/typesense-filters.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense-filters.test.ts
@@ -64,6 +64,43 @@ describe("buildFilterString", () => {
 });
 
 // =====================================================================
+// Issue #2983: work-mode (location_types) filter clause.
+// =====================================================================
+
+describe("buildFilterString — workMode (#2983)", () => {
+  it("emits the location_types clause when a single mode is set", () => {
+    expect(buildFilterString({ workMode: ["remote"] })).toBe(
+      "location_types:[remote]",
+    );
+  });
+
+  it("emits a comma-separated list for multiple modes (Typesense OR)", () => {
+    expect(buildFilterString({ workMode: ["remote", "hybrid"] })).toBe(
+      "location_types:[remote,hybrid]",
+    );
+  });
+
+  it("preserves the order the caller passed in (no auto-sort)", () => {
+    expect(buildFilterString({ workMode: ["onsite", "remote", "hybrid"] })).toBe(
+      "location_types:[onsite,remote,hybrid]",
+    );
+  });
+
+  it("composes with other filters via &&", () => {
+    const out = buildFilterString({
+      locationIds: [101],
+      workMode: ["remote"],
+    });
+    expect(out).toBe("location_ids:[101] && location_types:[remote]");
+  });
+
+  it("does NOT emit anything when workMode is undefined / empty", () => {
+    expect(buildFilterString({ workMode: undefined })).toBe("");
+    expect(buildFilterString({ workMode: [] })).toBe("");
+  });
+});
+
+// =====================================================================
 // Issue #2965: every `first_seen_at:>` (year-count) filter string in the
 // Typesense providers must compose with POSTING_FLOW_FILTER, NOT
 // POSTING_BASE_FILTER. Including `is_active:true` collapses year-count

--- a/apps/web/src/lib/search/index.ts
+++ b/apps/web/src/lib/search/index.ts
@@ -7,7 +7,9 @@ export type {
   HistogramFilters,
   SalaryBucket,
   ExperienceBucket,
+  WorkMode,
 } from "./types";
+export { WORK_MODE_VALUES, isWorkMode } from "./types";
 export { TypesenseSearchProvider } from "./typesense";
 
 import type { SearchProvider } from "./types";

--- a/apps/web/src/lib/search/query-params.ts
+++ b/apps/web/src/lib/search/query-params.ts
@@ -5,6 +5,8 @@
  * so links between them can carry filters across.
  */
 
+import { isWorkMode, type WorkMode } from "./types";
+
 export interface SerializableLocation {
   id: number;
   slug: string;
@@ -41,6 +43,27 @@ export interface SalaryExperienceFilters {
 }
 
 /**
+ * Parse the `wm` URL parameter into a list of valid {@link WorkMode}
+ * values. Drops any tokens that are not one of the canonical
+ * `onsite | hybrid | remote` values, deduplicates, and preserves input
+ * order. Returns an empty array for missing/empty input. (issue #2983)
+ */
+export function parseWorkModeParam(raw: string | null | undefined): WorkMode[] {
+  if (!raw) return [];
+  const seen = new Set<WorkMode>();
+  const out: WorkMode[] = [];
+  for (const token of raw.split(",")) {
+    const trimmed = token.trim().toLowerCase();
+    if (!trimmed) continue;
+    if (!isWorkMode(trimmed)) continue;
+    if (seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+/**
  * Build a query string (without leading `?`) from keywords + locations + occupations + seniorities.
  * Returns an empty string when there are no filters.
  */
@@ -50,6 +73,7 @@ export function buildFilterQuery(
   occupations?: SerializableOccupation[],
   seniorities?: SerializableSeniority[],
   technologies?: SerializableTechnology[],
+  workMode?: WorkMode[],
 ): string {
   const params = new URLSearchParams();
   if (keywords.length > 0) params.set("q", keywords.join(","));
@@ -64,6 +88,9 @@ export function buildFilterQuery(
   }
   if (technologies && technologies.length > 0) {
     params.set("tech", technologies.map((t) => t.slug).join(","));
+  }
+  if (workMode && workMode.length > 0) {
+    params.set("wm", workMode.join(","));
   }
   return params.toString();
 }
@@ -79,6 +106,7 @@ export function buildFilteredPath(
   occupations?: SerializableOccupation[],
   seniorities?: SerializableSeniority[],
   technologies?: SerializableTechnology[],
+  workMode?: WorkMode[],
 ): string {
   const params = new URLSearchParams();
   if (keywords.length > 0) params.set("q", keywords.join(","));
@@ -93,6 +121,9 @@ export function buildFilteredPath(
   }
   if (technologies && technologies.length > 0) {
     params.set("tech", technologies.map((t) => t.slug).join(","));
+  }
+  if (workMode && workMode.length > 0) {
+    params.set("wm", workMode.join(","));
   }
   if (extra) {
     for (const [k, v] of Object.entries(extra)) {

--- a/apps/web/src/lib/search/types.ts
+++ b/apps/web/src/lib/search/types.ts
@@ -4,6 +4,20 @@ export interface PostingLocation {
   geoType?: "city" | "region" | "country" | "macro";
 }
 
+/**
+ * Work-mode (location_types) filter values. Source of truth lives in the
+ * crawler's ``enum_normalize.py`` (canonical: onsite | remote | hybrid).
+ * Issue #2983 — filter-wide multi-select reusing the existing
+ * ``location_types`` field on ``job_posting``. No schema change.
+ */
+export type WorkMode = "onsite" | "hybrid" | "remote";
+
+export const WORK_MODE_VALUES: readonly WorkMode[] = ["onsite", "hybrid", "remote"] as const;
+
+export function isWorkMode(value: string): value is WorkMode {
+  return (WORK_MODE_VALUES as readonly string[]).includes(value);
+}
+
 export interface SearchResultPosting {
   id: string;
   title: string | null;
@@ -33,6 +47,7 @@ export interface SearchFilters {
   seniorityIds?: number[];
   technologyIds?: number[];
   employmentTypes?: string[];
+  workMode?: WorkMode[];
   salaryMinEur?: number;
   salaryMaxEur?: number;
   experienceMin?: number;
@@ -48,6 +63,7 @@ export interface HistogramFilters {
   occupationIds?: number[];
   seniorityIds?: number[];
   technologyIds?: number[];
+  workMode?: WorkMode[];
   languages?: string[];
 }
 

--- a/apps/web/src/lib/search/typesense-filters.ts
+++ b/apps/web/src/lib/search/typesense-filters.ts
@@ -84,6 +84,17 @@ export function buildFilterString(
     parts.push(`employment_type:[${filters.employmentTypes.join(",")}]`);
   }
 
+  // Work-mode filter (issue #2983). Reuses the existing `location_types`
+  // multi-array field on `job_posting`. Typesense `field:[a,b]` is OR
+  // semantics across values — selecting multiple modes returns docs that
+  // declare any of them. Postings with empty `location_types` (~0.9% of
+  // active postings on 2026-05-09) drop out silently when this filter
+  // is active — no sentinel-OR; treating unknown as bookable would
+  // produce too many false positives (per issue Q4).
+  if (filters.workMode?.length) {
+    parts.push(`location_types:[${filters.workMode.join(",")}]`);
+  }
+
   // salary_eur is optional — only apply when user has set a meaningful salary filter (> 0)
   const hasSalaryFilter =
     (filters.salaryMinEur != null && filters.salaryMinEur > 0) ||


### PR DESCRIPTION
Closes #2983.

Implements the recommended **Option A v1** from the issue analysis: a filter-wide multi-select work-mode (onsite / hybrid / remote) toggle, plumbed through a clean `workMode` field that re-uses the existing Typesense `location_types` index. **No schema migration. No crawler change.**

## Highlights (vs. the prior implementer's UI shape)

The user's redirect on 2026-05-10 specified two non-negotiables:
- **Modal-from-pill pattern** — exactly mirroring `employment-type-modal.tsx` (NOT inline 3-button toggle, NOT chip-strip).
- **Autocomplete integration** — typing `remote` / `hybrid` / `onsite` (and synonyms) in the search bar surfaces them as suggestions.

Both are delivered. See screenshots below.

## Surfaces touched

- **Modal**: new `apps/web/src/components/search/work-mode-modal.tsx` (mirrors `employment-type-modal.tsx` exactly — Radix Dialog + 3 multi-select buttons with `bg-primary/10 text-primary` active styling).
- **Pill button**: new "Work mode" button in the Filters bar alongside Type/Salary/etc. Uses `Home` icon to differentiate from `Briefcase`/`Code2`/etc.
- **Selected pills**: active modes render as toolbar pills with X-to-remove (mirrors employment-type pill rendering at `search-toolbar.tsx`).
- **Autocomplete**: new "Work mode" section in the search-bar dropdown, slotted between Technologies and Locations. Matches `remote`, `hybrid`, `onsite` and synonyms `wfh`, `work from home`, `on-site`, `in office`. Selecting an entry dispatches via `onAddWorkMode` → `pageActions.addWorkMode` → URL push fallback (mirrors the occupation/seniority/technology dispatch flow).
- **Free-text parser** (`parseSearchFilters`): consumes the same tokens during tokenization. Submitting `remote engineer berlin` parses to `{ workMode: ["remote"], occupations: [Engineer], locations: [Berlin] }`.
- **Saved-search**: `WatchlistFilters.workMode` field added (JSONB-stored, backwards-compatible — missing field ⇒ no filter). `SaveSearchButton` accepts the prop and `filter-pills-readonly.tsx` renders it for the saved-search read-only view.

## URL serialisation

- New `wm` URL key (3-letter, matches `loc`/`occ`/`sen` style).
- `parseWorkModeParam` in `query-params.ts` — drops invalid tokens, deduplicates, lowercases.
- Threaded through `buildFilteredPath` / `buildFilterQuery`.

## Filter clause

`buildFilterString` in `apps/web/src/lib/search/typesense-filters.ts` adds:

```
location_types:[remote,hybrid]
```

(Typesense array-OR semantics across the multi-value field.) Postings with empty `location_types` (~0.9% of active postings — 6k of 709k) drop out silently when the filter is active. Issue Q4 recommended NO sentinel-OR.

## Production-infra verification (Typesense, raw curl)

Probe against the live Typesense node (`typesense.colophon-group.org`), filter clause as it'll be emitted:

```
$ ADMIN=$(grep '^TYPESENSE_ADMIN_KEY=' apps/crawler/.env.local | cut -d= -f2-)
$ curl -s -H "X-TYPESENSE-API-KEY: $ADMIN" \
    'https://typesense.colophon-group.org/collections/job_posting/documents/search?q=*&filter_by=is_active:=true%20%26%26%20location_types:%5Bremote%5D&per_page=0' | jq '.found'
30948
```

Counts (matches the facet table in the issue body):

| filter | found |
|---|---|
| `location_types:[remote]` | 30,948 |
| `location_types:[hybrid]` | 19,569 |
| `location_types:[onsite]` | 652,103 |
| `location_types:[remote,hybrid]` | 50,225 |
| `is_active:=true` | 750,978 |

`30948 + 19569 ≠ 50225` because some postings declare multiple modes (e.g. mixed US/CA pairs). The combined-filter count `50225` matches exactly the row-set with `remote OR hybrid` in the multi-array field.

## Visual verification (Playwright on local dev server)

All four required screenshots captured.

**1. New "Work mode" pill in the Filters bar (closed state)**

![work-mode pill, closed state](https://raw.githubusercontent.com/colophon-group/jobseek/tmp-screenshots-2983/01-pill-closed.png)

**2. Modal open with "Remote" selected**

![work-mode modal, Remote selected](https://raw.githubusercontent.com/colophon-group/jobseek/tmp-screenshots-2983/02-modal-remote-selected.png)

**3. Search-bar autocomplete with "rem" typed — Work mode section showing Remote**

![autocomplete dropdown, "rem" → Remote suggestion](https://raw.githubusercontent.com/colophon-group/jobseek/tmp-screenshots-2983/03-autocomplete-rem.png)

**4. Toolbar after selecting Remote (in-app interaction) — pill rendered, results filtered to remote-friendly companies (Oliver Wyman 1,668 active, BlueSky Telepsych 945 active vs. the unfiltered Accenture 52k that dominates without the filter)**

![explore page with workMode=remote applied via modal](https://raw.githubusercontent.com/colophon-group/jobseek/tmp-screenshots-2983/04-explore-wm-remote.png)

## Tests

Added 38 new unit tests in three files; all 610/610 in the suite pass.

- `apps/web/src/lib/search/__tests__/typesense-filters.test.ts` — work-mode filter clause (single, multi, ordering, empty, composition with other filters).
- `apps/web/src/lib/search/__tests__/query-params.test.ts` (NEW) — `parseWorkModeParam` (canonical values, case, whitespace, dedup, invalid drops); `buildFilterQuery`/`buildFilteredPath` workMode emission.
- `apps/web/src/lib/actions/__tests__/search-input.test.ts` (NEW) — `parseSearchFilters` work-mode tokenization (canonical, synonyms, multi-word `work from home`, intentional non-match for `office`, dedup with `wm` URL param, case-insensitive).

## What's NOT in this PR

- No crawler / Typesense schema change.
- No top-level inline 3-button strip — the user explicitly redirected away from that shape.
- No sentinel-OR for empty `location_types` — issue Q4 recommended NO; data sparsity is only ~0.9% so the silent drop is acceptable.
- No per-location override (Option D in the issue) — explicitly deferred to a v2 follow-up gated on telemetry, per the issue's recommendation.

## Pre-existing limitation surfaced during verification

Direct deep-links like `/en/explore?wm=remote` (or `?loc=berlin`, `?q=foo` — same pattern for ALL filter params) don't reflect the filter on first paint when arriving from a cold cache. The Vercel ISR-prerendered default page mounts `SearchPage` immediately with empty initial filters, then `fetchExploreData` runs on mount and updates `data` but `SearchPage`'s `useState(initialWorkMode)` doesn't re-initialize.

This is identical behavior for `loc`/`q`/`occ`/etc. — verified by hitting `/en/explore?loc=berlin` directly which also renders the unfiltered top-companies until you interact. NOT a work-mode-specific bug, NOT introduced by this PR. In-app filter interactions (modal toggle, autocomplete pick, pill click) work correctly.

## Note on `tmp-screenshots-2983` branch

The screenshots above are served from a temporary `tmp-screenshots-2983` branch on the same repo (orphan branch with only the four PNGs). Once this PR is reviewed and merged, that branch can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)