### PR TITLE
fix(web): tighten SearchStateProvider restore to strict cache-key match (#2989)

### DIFF
--- a/apps/web/app/[lang]/(app)/explore/search-page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/search-page.tsx
@@ -19,6 +19,7 @@ import type { SearchResultCompany, HistogramFilters, WorkMode } from "@/lib/sear
 import {
   useSearchStateStore,
   buildCacheKey,
+  shouldRestoreSnapshot,
 } from "@/components/SearchStateProvider";
 
 const PAGE_SIZE = 10;
@@ -79,7 +80,7 @@ export function SearchPage({
   isLoggedInRef.current = isLoggedIn;
   const { get: getSearchState, set: setSearchState, setPageActions } = useSearchStateStore();
 
-  const cached = getSearchState();
+  const cachedSnapshot = getSearchState();
   const currentCacheKey = buildCacheKey(
     initialKeywords,
     initialLocations.map((l) => l.id),
@@ -87,10 +88,16 @@ export function SearchPage({
     initialSeniorities.map((s) => s.id),
     initialTechnologies.map((t) => t.id),
   );
-  const hasUrlFilters = initialKeywords.length > 0 || initialLocations.length > 0 || initialOccupations.length > 0 || initialSeniorities.length > 0 || initialTechnologies.length > 0;
-  const shouldRestore =
-    cached !== null &&
-    (cached.cacheKey === currentCacheKey || !hasUrlFilters);
+  // Restore the cached snapshot only when it matches the current URL
+  // filters exactly. Without the strict match, a snapshot saved from a
+  // previous filtered search (e.g. an empty-result query for
+  // "rare-keyword") would leak its ``keywords`` and empty
+  // ``companies`` into a fresh ``/explore`` visit, surfacing
+  // ``ZeroResults`` despite the URL having no filters. See #2989.
+  const cached = shouldRestoreSnapshot(cachedSnapshot, currentCacheKey)
+    ? cachedSnapshot
+    : null;
+  const shouldRestore = cached !== null;
 
   const [keywords, setKeywords] = useState<string[]>(
     shouldRestore ? cached.keywords : initialKeywords,

--- a/apps/web/src/components/SearchStateProvider.tsx
+++ b/apps/web/src/components/SearchStateProvider.tsx
@@ -47,6 +47,35 @@ export function buildCacheKey(
   return parts.join("|");
 }
 
+/**
+ * Decide whether the cached SearchStateProvider snapshot should hydrate
+ * the SearchPage that's about to mount.
+ *
+ * Returns ``true`` only when the snapshot's cache key matches the URL-
+ * derived cache key. The previous predicate also restored whenever the
+ * URL had no filters, which let a snapshot from a previous filtered
+ * search — including ``companies: []`` from an empty-result search —
+ * leak into a fresh ``/explore`` visit. The user then saw
+ * ``ZeroResults`` even though the URL had no filters and the
+ * prerendered ``initialData`` had ~10 top companies. See #2989.
+ *
+ * Restoration semantics now:
+ *   - Same URL filters (or both empty) → restore the snapshot.
+ *   - Different URL filters → ignore the snapshot, render the fresh
+ *     ``initialData`` from the server prerender / re-fetch.
+ *
+ * The strict match preserves the original intent of the cache (return
+ * to the same view after a posting-detail dive) without the poisoning
+ * footgun.
+ */
+export function shouldRestoreSnapshot(
+  cached: SearchStateSnapshot | null,
+  currentCacheKey: string,
+): boolean {
+  if (cached === null) return false;
+  return cached.cacheKey === currentCacheKey;
+}
+
 /** Live callbacks the search page registers so the header SearchBar can interact directly. */
 export interface SearchPageActions {
   addLocation: (location: SelectedLocation) => void;

--- a/apps/web/src/components/__tests__/SearchStateProvider-snapshot-mount.test.tsx
+++ b/apps/web/src/components/__tests__/SearchStateProvider-snapshot-mount.test.tsx
@@ -1,0 +1,207 @@
+import { describe, expect, it } from "vitest";
+import { render, act } from "@testing-library/react";
+import { useEffect } from "react";
+import {
+  SearchStateProvider,
+  useSearchStateStore,
+  shouldRestoreSnapshot,
+  buildCacheKey,
+} from "@/components/SearchStateProvider";
+import type { SearchResultCompany } from "@/lib/search";
+
+/**
+ * End-to-end mount test for #2989. Exercises the actual
+ * ``SearchStateProvider`` ref store via a minimal consumer that mirrors
+ * SearchPage's lifecycle:
+ *   - On mount, decides whether to restore from the cached snapshot.
+ *   - On unmount, persists its current state into the snapshot.
+ *
+ * The bug pre-fix: when the cached snapshot held a previous filtered
+ * search's keywords + empty companies, a fresh ``/explore`` mount (no
+ * URL filters) would restore the snapshot and surface ``ZeroResults``.
+ *
+ * The fix: ``shouldRestoreSnapshot`` requires a strict cache-key match,
+ * so an unfiltered URL never inherits a filtered snapshot's state.
+ */
+
+interface FakeSearchPageProps {
+  initialKeywords: string[];
+  initialCompanies: SearchResultCompany[];
+  /** Surface the resolved (post-restore) state for assertions. */
+  onResolved: (state: { keywords: string[]; companies: SearchResultCompany[] }) => void;
+}
+
+function FakeSearchPage({
+  initialKeywords,
+  initialCompanies,
+  onResolved,
+}: FakeSearchPageProps) {
+  const { get, set } = useSearchStateStore();
+
+  // Mount-time restore decision (mirrors SearchPage lines 82-93 in
+  // app/[lang]/(app)/explore/search-page.tsx).
+  const cached = get();
+  const currentCacheKey = buildCacheKey(initialKeywords, [], [], [], []);
+  const shouldRestore = shouldRestoreSnapshot(cached, currentCacheKey);
+
+  const resolvedKeywords = shouldRestore && cached ? cached.keywords : initialKeywords;
+  const resolvedCompanies = shouldRestore && cached ? cached.companies : initialCompanies;
+
+  // Surface the resolved state to the test.
+  useEffect(() => {
+    onResolved({ keywords: resolvedKeywords, companies: resolvedCompanies });
+  }, [onResolved, resolvedKeywords, resolvedCompanies]);
+
+  // Unmount-time snapshot save (mirrors SearchPage lines 266-294).
+  // Empty deps array — runs cleanup once on unmount. Captures the
+  // resolved values from the closure, exactly like SearchPage does.
+  useEffect(() => {
+    return () => {
+      set({
+        keywords: resolvedKeywords,
+        locations: [],
+        occupations: [],
+        seniorities: [],
+        technologies: [],
+        workMode: [],
+        salaryMinEur: undefined,
+        salaryMaxEur: undefined,
+        salaryCurrency: "EUR",
+        experienceMin: undefined,
+        experienceMax: undefined,
+        companies: resolvedCompanies,
+        totalCompanies: resolvedCompanies.length,
+        showPostingId: null,
+        scrollY: 0,
+        cacheKey: buildCacheKey(resolvedKeywords, [], [], [], []),
+      });
+    };
+  }, [set, resolvedCompanies, resolvedKeywords]);
+
+  return null;
+}
+
+function makeCompany(id: string, name: string): SearchResultCompany {
+  return {
+    company: { id, name, slug: name.toLowerCase(), icon: null },
+    activeMatches: 1,
+    yearMatches: 1,
+    postings: [],
+  };
+}
+
+/**
+ * Host that toggles between two phases. Phase 1 mounts a FakeSearchPage
+ * configured to look like a 0-result filtered search. The host then
+ * sets ``phase=null`` to fully unmount that page (so the cleanup fires
+ * and writes the snapshot). Phase 2 mounts a fresh FakeSearchPage with
+ * no filters — the question the test answers is whether mount #2
+ * inherits state from the saved snapshot.
+ */
+function ControlledHost({
+  phase,
+  onResolved,
+  filteredCompanies,
+  freshCompanies,
+}: {
+  phase: 1 | "between" | 2;
+  onResolved: (state: { keywords: string[]; companies: SearchResultCompany[] }) => void;
+  filteredCompanies: SearchResultCompany[];
+  freshCompanies: SearchResultCompany[];
+}) {
+  if (phase === 1) {
+    return (
+      <FakeSearchPage
+        key="filtered"
+        initialKeywords={["rare-keyword"]}
+        initialCompanies={filteredCompanies}
+        onResolved={onResolved}
+      />
+    );
+  }
+  if (phase === 2) {
+    return (
+      <FakeSearchPage
+        key="fresh"
+        initialKeywords={[]}
+        initialCompanies={freshCompanies}
+        onResolved={onResolved}
+      />
+    );
+  }
+  // "between": no FakeSearchPage mounted — forces full unmount of
+  // phase 1's component so its cleanup runs.
+  return null;
+}
+
+describe("SearchStateProvider — mount/unmount snapshot lifecycle (#2989)", () => {
+  it("does NOT restore a filtered snapshot onto a fresh /explore mount", async () => {
+    const observed: { keywords: string[]; companies: SearchResultCompany[] }[] = [];
+    const onResolved = (s: typeof observed[number]) => observed.push(s);
+
+    const top10 = Array.from({ length: 10 }, (_, i) =>
+      makeCompany(`c-${i}`, `Company ${i}`),
+    );
+
+    let view: ReturnType<typeof render>;
+
+    // Phase 1: filtered search, 0 results.
+    await act(async () => {
+      view = render(
+        <SearchStateProvider>
+          <ControlledHost
+            phase={1}
+            onResolved={onResolved}
+            filteredCompanies={[]}
+            freshCompanies={top10}
+          />
+        </SearchStateProvider>,
+      );
+    });
+    expect(observed.at(-1)).toEqual({
+      keywords: ["rare-keyword"],
+      companies: [],
+    });
+
+    // Phase "between": NO child mounted. This forces React to unmount
+    // the phase-1 FakeSearchPage and run its cleanup — which writes
+    // the poisoned snapshot. Without this intermediate phase, the
+    // cleanup would race with the phase-2 mount and the snapshot
+    // wouldn't be visible to phase 2's `get()` call.
+    await act(async () => {
+      view!.rerender(
+        <SearchStateProvider>
+          <ControlledHost
+            phase="between"
+            onResolved={onResolved}
+            filteredCompanies={[]}
+            freshCompanies={top10}
+          />
+        </SearchStateProvider>,
+      );
+    });
+
+    // Phase 2: fresh /explore visit — URL has no filters, prerendered
+    // initialCompanies has 10 top companies. With the fix, mount #2
+    // sees the (poisoned) snapshot but rejects it via the strict
+    // cache-key check, falling back to the prerendered top 10. Pre-
+    // fix, mount #2 would restore the snapshot's empty
+    // ``companies`` and surface ``ZeroResults``.
+    await act(async () => {
+      view!.rerender(
+        <SearchStateProvider>
+          <ControlledHost
+            phase={2}
+            onResolved={onResolved}
+            filteredCompanies={[]}
+            freshCompanies={top10}
+          />
+        </SearchStateProvider>,
+      );
+    });
+
+    const final = observed.at(-1);
+    expect(final?.keywords).toEqual([]);
+    expect(final?.companies).toHaveLength(10);
+  });
+});

--- a/apps/web/src/components/__tests__/SearchStateProvider.test.tsx
+++ b/apps/web/src/components/__tests__/SearchStateProvider.test.tsx
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCacheKey,
+  shouldRestoreSnapshot,
+  type SearchStateSnapshot,
+} from "@/components/SearchStateProvider";
+import type { SearchResultCompany } from "@/lib/search";
+
+/**
+ * Regression tests for #2989 — empty-results race / snapshot poisoning.
+ *
+ * Before #2989, the predicate read:
+ *   shouldRestore = cached !== null && (cached.cacheKey === currentCacheKey || !hasUrlFilters)
+ *
+ * The ``|| !hasUrlFilters`` branch let a previous filtered search's
+ * snapshot — including ``companies: []`` from a 0-result keyword query
+ * — leak into a fresh ``/explore`` visit (no URL filters). The user
+ * then saw ``ZeroResults`` for whatever stale keywords lived in the
+ * snapshot, even though the URL was clean.
+ *
+ * The strict cache-key match below ensures restoration only happens
+ * when the current URL filters match the snapshot's filters exactly.
+ */
+
+function makeSnapshot(
+  overrides: Partial<SearchStateSnapshot> = {},
+): SearchStateSnapshot {
+  return {
+    keywords: [],
+    locations: [],
+    occupations: [],
+    seniorities: [],
+    technologies: [],
+    workMode: [],
+    salaryMinEur: undefined,
+    salaryMaxEur: undefined,
+    salaryCurrency: "EUR",
+    experienceMin: undefined,
+    experienceMax: undefined,
+    companies: [] as SearchResultCompany[],
+    totalCompanies: 0,
+    showPostingId: null,
+    scrollY: 0,
+    cacheKey: buildCacheKey([], [], [], [], []),
+    ...overrides,
+  };
+}
+
+describe("buildCacheKey", () => {
+  it("renders the empty-filter case as ||||", () => {
+    expect(buildCacheKey([], [], [], [], [])).toBe("||||");
+  });
+
+  it("is stable under input ordering", () => {
+    expect(buildCacheKey(["a", "b"], [2, 1], [10, 5], [], [])).toBe(
+      buildCacheKey(["b", "a"], [1, 2], [5, 10], [], []),
+    );
+  });
+
+  it("differentiates filtered vs unfiltered", () => {
+    expect(buildCacheKey(["python"], [], [], [], [])).not.toBe(
+      buildCacheKey([], [], [], [], []),
+    );
+  });
+});
+
+describe("shouldRestoreSnapshot — #2989 regression", () => {
+  it("returns false when there is no cached snapshot", () => {
+    expect(shouldRestoreSnapshot(null, buildCacheKey([], [], [], [], []))).toBe(
+      false,
+    );
+  });
+
+  it("returns true when the cached snapshot's cache key matches the URL filters", () => {
+    const cached = makeSnapshot({
+      keywords: ["python"],
+      cacheKey: buildCacheKey(["python"], [], [], [], []),
+    });
+    const currentKey = buildCacheKey(["python"], [], [], [], []);
+    expect(shouldRestoreSnapshot(cached, currentKey)).toBe(true);
+  });
+
+  it("returns true when both snapshot and URL have no filters", () => {
+    const cached = makeSnapshot({
+      cacheKey: buildCacheKey([], [], [], [], []),
+    });
+    const currentKey = buildCacheKey([], [], [], [], []);
+    expect(shouldRestoreSnapshot(cached, currentKey)).toBe(true);
+  });
+
+  /**
+   * Core #2989 case: snapshot was saved from a previous filtered search
+   * that returned 0 results. User navigates to /explore (no URL
+   * filters). Without the strict cache-key match, the empty
+   * ``companies`` and stale ``keywords`` would leak into the fresh
+   * mount and trigger ``ZeroResults``.
+   */
+  it("does NOT restore a filtered snapshot onto an unfiltered URL (the bug)", () => {
+    const cached = makeSnapshot({
+      keywords: ["zzzzzznorealkeyword"],
+      companies: [],
+      totalCompanies: 0,
+      cacheKey: buildCacheKey(["zzzzzznorealkeyword"], [], [], [], []),
+    });
+    const currentKey = buildCacheKey([], [], [], [], []);
+    expect(shouldRestoreSnapshot(cached, currentKey)).toBe(false);
+  });
+
+  it("does NOT restore an unfiltered snapshot onto a filtered URL", () => {
+    const cached = makeSnapshot({
+      keywords: [],
+      cacheKey: buildCacheKey([], [], [], [], []),
+    });
+    const currentKey = buildCacheKey(["python"], [], [], [], []);
+    expect(shouldRestoreSnapshot(cached, currentKey)).toBe(false);
+  });
+
+  it("does NOT restore when the snapshot's location filter differs from the URL", () => {
+    const cached = makeSnapshot({
+      cacheKey: buildCacheKey([], [42], [], [], []),
+    });
+    const currentKey = buildCacheKey([], [99], [], [], []);
+    expect(shouldRestoreSnapshot(cached, currentKey)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #2989.

## Root cause (verified empirically)

`SearchPage` saves its filter + result state into the `(app)` layout's `SearchStateProvider` on unmount, so a `/explore` -> posting-detail -> back round-trip restores the same view. The mount-time predicate also restored the snapshot whenever the URL had no filters (`!hasUrlFilters`), even when the snapshot itself had been saved from a previous filtered search. After the user did a 0-result query for a rare keyword and then SPA-clicked the "Explore" logo, the snapshot's `keywords` and empty `companies` leaked into the fresh mount — surfacing `ZeroResults` despite the URL having no filters. The restore effect then `replaceState`'d `?q=<rare keyword>` back into the URL, locking the empty state in.

Hard reload "fixed" it because a full page load tears down the provider. A filter toggle "fixed" it because the toggle handler calls `runSearch()` and overwrites state.

## Reproduction

`/tmp/repro-2989-final.mjs` drives Playwright through:
1. Visit `/en/explore` (no filters) — top 10 companies render.
2. Type `zzzzzznorealkeyword` into the header search bar, ArrowDown -> Enter — `URL=/en/explore?q=zzzzzznorealkeyword`, `cardCount=0`, `noResultsHeading=1`.
3. SPA-nav to `/en/watchlists` (forces `SearchPage` unmount -> snapshot save).
4. SPA-click the Explore logo (`Link href=/en/explore`).

**Pre-fix step 4 result:** `URL=/en/explore?q=zzzzzznorealkeyword`, `cardCount=0`, `noResultsHeading=1` — the empty state is restored even though the user clicked a clean `/explore` link.

**Post-fix step 4 result:** `URL=/en/explore`, `cardCount=10`, `noResultsHeading=0` — fresh top companies.

## Fix

Extract the predicate into `shouldRestoreSnapshot` and require `cached.cacheKey === currentCacheKey`. Drop the permissive `|| !hasUrlFilters` branch.

```diff
-  const hasUrlFilters = initialKeywords.length > 0 || initialLocations.length > 0 || ...
-  const shouldRestore =
-    cached !== null &&
-    (cached.cacheKey === currentCacheKey || !hasUrlFilters);
+  const cached = shouldRestoreSnapshot(cachedSnapshot, currentCacheKey)
+    ? cachedSnapshot
+    : null;
+  const shouldRestore = cached !== null;
```

The same-filter restore (the posting-detail-and-back UX) still works: identical filters hash to the same cache key. Different filters or no-filter visits get the fresh `initialData` prerender.

## Tests

Two new test files in `apps/web/src/components/__tests__/`:

- `SearchStateProvider.test.tsx` — 9 unit tests covering `buildCacheKey` stability and `shouldRestoreSnapshot` semantics including the bug case ("does NOT restore a filtered snapshot onto an unfiltered URL").
- `SearchStateProvider-snapshot-mount.test.tsx` — end-to-end mount/unmount lifecycle test with a controlled three-phase host. Phase 1 mounts a `FakeSearchPage` configured like the 0-result filtered search; phase "between" fully unmounts (so the cleanup fires and writes the poisoned snapshot); phase 2 mounts a fresh page with no filters and asserts the resolved state shows the prerendered top 10 companies, not the snapshot's empty companies.

**Both tests fail when the pre-fix predicate is reintroduced** — verified by toggling the helper to the legacy logic and re-running:
```
× shouldRestoreSnapshot — does NOT restore a filtered snapshot onto an unfiltered URL (the bug)
× SearchStateProvider — does NOT restore a filtered snapshot onto a fresh /explore mount
```

`pnpm test` (web) — 16/16 relevant tests pass with the fix; the same 2 fail pre-fix.

## Test plan

- [x] `pnpm test src/components/__tests__/SearchStateProvider.test.tsx` (9 tests pass)
- [x] `pnpm test src/components/__tests__/SearchStateProvider-snapshot-mount.test.tsx` (1 test passes)
- [x] `pnpm test 'app/[lang]/(app)/explore/__tests__/explore-content.test.tsx'` (6 existing tests still pass)
- [x] `pnpm exec tsc --noEmit` — no new errors (only pre-existing `@jseek/mcp-server/handler` resolution failure)
- [x] `pnpm lint` — clean
- [x] Playwright reproduction shows the empty-state pre-fix and the top-10 list post-fix
- [ ] Vercel preview build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)