### PR TITLE
fix(db): relax chk_employment_type to allow all 7 canonical types (#3006)

### DIFF
--- a/apps/web/drizzle/0077_relax_chk_employment_type.sql
+++ b/apps/web/drizzle/0077_relax_chk_employment_type.sql
@@ -1,0 +1,37 @@
+-- Relax chk_employment_type to allow all 7 canonical employment-type values (#3006).
+--
+-- Backstory: 0033_normalize_employment_type added the constraint with 5
+-- allowed values (full_time, part_time, contract, internship, full_or_part).
+-- Since then, the crawler-side normalizer in
+-- apps/crawler/src/core/enum_normalize.py::_EMPLOYMENT_TYPE_MAP has gained
+-- two additional canonical buckets — `temporary` and `volunteer`.
+-- Local Postgres + Typesense accept all 7; only Supabase's check constraint
+-- drifted, blocking the CDC exporter.
+--
+-- Empirical (2026-05-10): exporter cursor stuck at
+-- 2026-05-10T00:02:13.480402+00 because the next row past the cursor
+-- (Tesco posting 68acdabe-5daa-416d-87c9-0b0a5de1ff85, employment_type=
+-- 'temporary') fails chk_employment_type and rolls back the bulk batch.
+-- Result: 12k-row export lag visible on Grafana.
+--
+-- Fix: drop + re-add chk_employment_type with all 7 canonical values from
+-- _EMPLOYMENT_TYPE_MAP. NOT VALID + VALIDATE pattern matches 0033 (so any
+-- pre-existing rows that somehow snuck in are validated post-add).
+--
+-- Idempotent on purpose: DROP IF EXISTS makes this safe to re-run.
+
+ALTER TABLE job_posting DROP CONSTRAINT IF EXISTS chk_employment_type;
+
+ALTER TABLE job_posting ADD CONSTRAINT chk_employment_type
+  CHECK (employment_type IS NULL OR employment_type IN (
+    'full_time',
+    'part_time',
+    'contract',
+    'internship',
+    'temporary',
+    'volunteer',
+    'full_or_part'
+  ))
+  NOT VALID;
+
+ALTER TABLE job_posting VALIDATE CONSTRAINT chk_employment_type;

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -477,6 +477,13 @@
       "when": 1778198400000,
       "tag": "0076_drop_api_credit",
       "breakpoints": true
+    },
+    {
+      "idx": 68,
+      "version": "7",
+      "when": 1778716800000,
+      "tag": "0077_relax_chk_employment_type",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/drizzle/schema.ts
+++ b/apps/web/drizzle/schema.ts
@@ -436,7 +436,7 @@ export const jobPosting = pgTable("job_posting", {
 			name: "job_posting_seniority_id_fkey"
 		}),
 	unique("job_posting_source_url_unique").on(table.sourceUrl),
-	check("chk_employment_type", sql`(employment_type IS NULL) OR (employment_type = ANY (ARRAY['full_time'::text, 'part_time'::text, 'contract'::text, 'internship'::text, 'full_or_part'::text]))`),
+	check("chk_employment_type", sql`(employment_type IS NULL) OR (employment_type = ANY (ARRAY['full_time'::text, 'part_time'::text, 'contract'::text, 'internship'::text, 'temporary'::text, 'volunteer'::text, 'full_or_part'::text]))`),
 	check("chk_location_arrays_length", sql`((location_ids IS NULL) AND (location_types IS NULL)) OR (array_length(location_ids, 1) = array_length(location_types, 1))`),
 	check("chk_location_types", sql`location_types <@ ARRAY['onsite'::text, 'remote'::text, 'hybrid'::text]`),
 ]);


### PR DESCRIPTION
## Summary

- Supabase \`chk_employment_type\` was missing 3 of the 7 canonical employment-type values defined by the crawler-side central normalizer (\`apps/crawler/src/core/enum_normalize.py::_EMPLOYMENT_TYPE_MAP\`, post-#2973). The Tesco \`temporary\` posting at the head of the export queue rolled back every batch, freezing the exporter cursor and producing a 12k-row Supabase export lag visible on Grafana (#3006).
- New idempotent migration \`0077_relax_chk_employment_type.sql\` drops and re-adds the constraint with all 7 canonical values. Applied to Supabase via direct \`psql\` per the operational pattern from #2876 (0068/0069 path).

## Constraint def — before

\`\`\`sql
CHECK ((employment_type IS NULL) OR (employment_type = ANY
  (ARRAY['full_time'::text, 'part_time'::text, 'contract'::text,
         'internship'::text, 'full_or_part'::text])))
\`\`\`

Missing values that were producing \`CheckViolationError\` rows on every export tick:

| value          | active rows in local Postgres |
|----------------|------------------------------:|
| \`temporary\`    |                           300 |
| \`volunteer\`    |                             1 |

(\`full_or_part\` — 208 active rows — was already allowed; the issue was only \`temporary\` and \`volunteer\`.)

## Constraint def — after (verified on Supabase)

\`\`\`sql
CHECK ((employment_type IS NULL) OR (employment_type = ANY
  (ARRAY['full_time'::text, 'part_time'::text, 'contract'::text,
         'internship'::text, 'temporary'::text, 'volunteer'::text,
         'full_or_part'::text])))
\`\`\`

Drift inventory — 7 canonical types now allowed: \`full_time\`, \`part_time\`, \`contract\`, \`internship\`, \`temporary\`, \`volunteer\`, \`full_or_part\`. Matches \`apps/crawler/src/core/enum_normalize.py::_EMPLOYMENT_TYPE_MAP\`.

## Empirical proof

\`\`\`text
exporter_state (Hetzner local Postgres):

  before:  last_export_ts:job_posting           = 2026-05-10T00:02:13.480402+00 (10h11m old)
           last_export_ts:typesense:job_posting = 2026-05-10T01:19:12.453281+00 ( 8h54m old)

  after migration applied (one tick later):
           last_export_ts:job_posting           = 2026-05-10T10:20:19.806860+00 (28s old)
           last_export_ts:typesense:job_posting = 2026-05-10T10:20:19.806860+00 (28s old)

  one tick after that:
           last_export_ts:job_posting           = 2026-05-10T10:22:11.978048+00 (6.7s old)

Pending rows past cursor: 0.
\`\`\`

Re-attempt of the formerly-failing Tesco row \`68acdabe-5daa-416d-87c9-0b0a5de1ff85\`:

\`\`\`text
UPDATE job_posting SET employment_type='temporary' WHERE id='68acdabe-5daa-416d-87c9-0b0a5de1ff85';
                  id                  | employment_type
--------------------------------------+-----------------
 68acdabe-5daa-416d-87c9-0b0a5de1ff85 | temporary
UPDATE 1
\`\`\`

\`volunteer\` separately verified in a transaction + rollback (also accepted).

## Why drift happened

\`0033_normalize_employment_type.sql\` introduced the constraint with the 5 values the web filter UI exposed at the time. \`apps/crawler/src/core/enum_normalize.py::_EMPLOYMENT_TYPE_MAP\` later gained \`temporary\` and \`volunteer\` buckets (per the \"Canonical employment-type values\" docstring at the top of that file). Local Postgres on Hetzner has **no** \`chk_employment_type\` constraint at all (empirically verified), so writes succeed there and Typesense indexes the values fine — only the Supabase CDC mirror was rejecting them.

The exporter's bulk upsert is transactional: one \`temporary\` row at the cursor head rolled back the whole batch, leaving the cursor pinned.

## What this PR does NOT do

- Add a \`chk_employment_type\` constraint to local Hetzner Postgres. Local has no constraint by design today; tightening it is a separate decision.
- Wire \`pnpm db:migrate\` into the deploy workflow. Per #2876 follow-up, that's its own PR (needs prod-only gating for preview branches). 0077 was applied via direct psql; the file lives in source control + journal so a future migrate run picks it up idempotently.
- Bump VERSION. The constraint isn't generated from any \`apps/crawler/\` model file, so no crawler bump per the issue brief.

## Test plan

- [x] \`pg_get_constraintdef\` on Supabase shows all 7 canonical values
- [x] Manual update of the formerly-failing Tesco row to \`employment_type='temporary'\` succeeds
- [x] \`volunteer\` value also accepted (tx + rollback test)
- [x] Exporter cursor advances past \`2026-05-10T00:02:16\` within one tick
- [x] No rows pending past cursor (12k backlog drained)
- [x] ESLint pre-commit hook passes
- [ ] Future export ticks emit no further \`CheckViolationError\` for any of the 7 canonical types (will confirm via Grafana over next 24h)

Closes #3006

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)