### PR TITLE
fix(web): bust stale caches on username rename (closes #3022)

### DIFF
--- a/apps/web/src/components/AppBootstrapProvider.tsx
+++ b/apps/web/src/components/AppBootstrapProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 import { fetchAppBootstrap, type AppBootstrapData } from "@/lib/actions/bootstrap";
 import { SessionProvider } from "@/components/SessionProvider";
 import { SavedJobsProvider } from "@/components/SavedJobsProvider";
@@ -20,6 +20,20 @@ const ANON_BOOTSTRAP: AppBootstrapData = {
 export function AppBootstrapProvider({ children }: { children: ReactNode }) {
   const [data, setData] = useState<AppBootstrapData | null>(null);
 
+  // Re-fetch the bootstrap payload and replace state in place. Used by
+  // identity-mutation flows (e.g. `UsernameSection.handleSubmit` after
+  // a successful `renameUsername`) so the SessionProvider stops
+  // serving the pre-mutation `user.username` to client components
+  // (#3022). Intentionally does NOT set `data = null` first — that
+  // would flip `isPending = true` across every `useAuth()` consumer
+  // (header avatar, watchlist job list, etc.) and produce a transient
+  // flicker. Replacing `data` once the new payload resolves is enough.
+  const refresh = useCallback(async () => {
+    const result = await fetchAppBootstrap();
+    if (!result.user) clearLoggedInHint();
+    setData(result);
+  }, []);
+
   useEffect(() => {
     // Skip the server-action RPC when the `logged_in` hint cookie is
     // absent — the vast majority of traffic is anonymous, and this path
@@ -31,21 +45,15 @@ export function AppBootstrapProvider({ children }: { children: ReactNode }) {
       setData(ANON_BOOTSTRAP);
       return;
     }
-    fetchAppBootstrap().then((result) => {
-      // Self-heal a stale hint: if the server says we have no session
-      // but our hint said we did, drop the hint so subsequent page
-      // loads don't keep paying for the same empty round-trip.
-      if (!result.user) clearLoggedInHint();
-      setData(result);
-    });
-  }, []);
+    refresh();
+  }, [refresh]);
 
   const isPending = data === null;
   const user = data?.user ?? null;
   const prefs = data?.prefs;
 
   return (
-    <SessionProvider user={user} isPending={isPending}>
+    <SessionProvider user={user} isPending={isPending} refresh={refresh}>
       <SavedJobsProvider initialStatuses={data?.savedStatuses}>
         <StarredCompaniesProvider initialIds={data?.starredIds}>
           <SalaryDisplayProvider

--- a/apps/web/src/components/SessionProvider.tsx
+++ b/apps/web/src/components/SessionProvider.tsx
@@ -16,25 +16,48 @@ type SessionContextValue = {
   user: SessionUser | null;
   isLoggedIn: boolean;
   isPending: boolean;
+  /**
+   * Re-fetch the session payload from the server and update the
+   * SessionProvider state in place. Use after a server-side mutation
+   * that changes the viewer's identity (e.g. `renameUsername` from
+   * `actions/preferences.ts`) so that client components reading
+   * `user.username` rebuild URLs from the fresh value rather than the
+   * one bootstrapped on the initial mount. See issue #3022.
+   *
+   * The default no-op is here for stand-alone test mounts that don't
+   * wrap children in `AppBootstrapProvider`; the production tree
+   * always supplies a real implementation.
+   */
+  refresh: () => Promise<void>;
 };
 
 const SessionContext = createContext<SessionContextValue>({
   user: null,
   isLoggedIn: false,
   isPending: true,
+  refresh: async () => {},
 });
 
 export function SessionProvider({
   user,
   isPending = false,
+  refresh,
   children,
 }: {
   user: SessionUser | null;
   isPending?: boolean;
+  refresh?: () => Promise<void>;
   children: ReactNode;
 }) {
   return (
-    <SessionContext.Provider value={{ user, isLoggedIn: Boolean(user), isPending }}>
+    <SessionContext.Provider
+      value={{
+        user,
+        isLoggedIn: Boolean(user),
+        isPending,
+        refresh: refresh ?? (async () => {}),
+      }}
+    >
       {children}
     </SessionContext.Provider>
   );

--- a/apps/web/src/components/__tests__/AppBootstrapProvider.test.tsx
+++ b/apps/web/src/components/__tests__/AppBootstrapProvider.test.tsx
@@ -150,6 +150,91 @@ describe("AppBootstrapProvider", () => {
     expect(screen.getByTestId("pending").textContent).toBe("false");
   });
 
+  it("exposes refresh() that re-fetches bootstrap and replaces state without an isPending flicker (#3022)", async () => {
+    setDocumentCookie("logged_in=1; NEXT_LOCALE=en");
+
+    // First mount → returns the OLD identity. Subsequent refresh() →
+    // returns the NEW identity. We assert (a) the user name flips
+    // after refresh() resolves, and (b) `isPending` stays `false`
+    // throughout the refresh — replacing `data` in place must not
+    // null it out and flash the spinner on every `useAuth()` consumer.
+    mockBootstrap.mockResolvedValueOnce({
+      user: {
+        id: "u1",
+        email: "x@x",
+        name: "Alice",
+        emailVerified: true,
+        username: "oldname",
+      },
+      prefs: null,
+      savedStatuses: [],
+      starredIds: [],
+    });
+
+    let resolveRefresh!: (v: unknown) => void;
+    mockBootstrap.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRefresh = resolve;
+      }),
+    );
+
+    let triggerRefresh!: () => Promise<void>;
+    function RefreshProbe() {
+      const { refresh } = useSession();
+      triggerRefresh = refresh;
+      return null;
+    }
+
+    render(
+      <AppBootstrapProvider>
+        <SessionProbe />
+        <RefreshProbe />
+      </AppBootstrapProvider>,
+    );
+
+    // Initial mount finishes — OLD identity visible.
+    await waitFor(() => {
+      expect(screen.getByTestId("user-name").textContent).toBe("Alice");
+    });
+    expect(screen.getByTestId("pending").textContent).toBe("false");
+
+    // Kick off refresh; do NOT resolve the inner promise yet.
+    let refreshDone = false;
+    await act(async () => {
+      triggerRefresh().then(() => {
+        refreshDone = true;
+      });
+    });
+
+    // While refresh is in-flight, isPending must STILL be false (no
+    // flicker for consumers) and the old identity is still shown.
+    expect(screen.getByTestId("pending").textContent).toBe("false");
+    expect(screen.getByTestId("user-name").textContent).toBe("Alice");
+
+    // Resolve the refresh with the new identity.
+    await act(async () => {
+      resolveRefresh({
+        user: {
+          id: "u1",
+          email: "x@x",
+          name: "Alice Renamed",
+          emailVerified: true,
+          username: "newname",
+        },
+        prefs: null,
+        savedStatuses: [],
+        starredIds: [],
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user-name").textContent).toBe("Alice Renamed");
+    });
+    expect(refreshDone).toBe(true);
+    expect(screen.getByTestId("pending").textContent).toBe("false");
+    expect(mockBootstrap).toHaveBeenCalledTimes(2);
+  });
+
   it("does not substring-match `logged_in` against other cookie names", async () => {
     // Regression guard for a prior plan using bare `.includes`. A cookie
     // named `x_logged_in_ago` should NOT be treated as the hint.

--- a/apps/web/src/components/settings/AccountSettings.tsx
+++ b/apps/web/src/components/settings/AccountSettings.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import { useRouter } from "next/navigation";
 import { Trans } from "@lingui/react/macro";
 import { useLingui } from "@lingui/react/macro";
 import { GitHubIcon } from "@/components/icons/GitHubIcon";
@@ -8,7 +9,12 @@ import { authClient } from "@/lib/auth-client";
 import { isReservedUsername } from "@/lib/username";
 import { useAuth } from "@/lib/useAuth";
 import { useLocalePath } from "@/lib/useLocalePath";
-import { setPassword as setPasswordAction, recordPasswordResetRequest, getAccountPageData } from "@/lib/actions/preferences";
+import {
+  setPassword as setPasswordAction,
+  recordPasswordResetRequest,
+  getAccountPageData,
+  renameUsername,
+} from "@/lib/actions/preferences";
 import { Button } from "@/components/ui/Button";
 import { FormField } from "@/components/ui/FormField";
 import { ErrorAlert } from "@/components/ui/ErrorAlert";
@@ -194,6 +200,8 @@ const USERNAME_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
 
 function UsernameSection({ currentUsername }: { currentUsername: string }) {
   const { t } = useLingui();
+  const router = useRouter();
+  const { refresh: refreshSession } = useAuth();
   const [savedUsername, setSavedUsername] = useState(currentUsername);
   const [value, setValue] = useState(currentUsername);
   const [loading, setLoading] = useState(false);
@@ -246,15 +254,26 @@ function UsernameSection({ currentUsername }: { currentUsername: string }) {
     setError("");
     setSuccess("");
     setLoading(true);
-    const { error } = await authClient.updateUser({ username: normalized });
-    setLoading(false);
+    // Server action wraps `auth.api.updateUser` AND fans out every
+    // cache layer the rename invalidates (Redis session, watchlist
+    // cache tags, Typesense `owner_username`, sitemap). See #3022 +
+    // the action's docstring.
+    const { error } = await renameUsername(normalized);
     if (error) {
-      setError(error.message ?? t({ id: "settings.account.username.error", comment: "Generic username update error", message: "Failed to update username" }));
-    } else {
-      setSavedUsername(normalized);
-      setAvailable(null);
-      setSuccess(t({ id: "settings.account.username.success", comment: "Username updated success message", message: "Username updated." }));
+      setLoading(false);
+      setError(error ?? t({ id: "settings.account.username.error", comment: "Generic username update error", message: "Failed to update username" }));
+      return;
     }
+    // Re-pull the bootstrap payload so SessionProvider stops handing
+    // the stale `user.username` to URL-building components like
+    // WatchlistCard / save-search / mirror. router.refresh() rebuilds
+    // any RSC tree currently rendered with the old slug.
+    await refreshSession();
+    router.refresh();
+    setLoading(false);
+    setSavedUsername(normalized);
+    setAvailable(null);
+    setSuccess(t({ id: "settings.account.username.success", comment: "Username updated success message", message: "Username updated." }));
   }
 
   // hint is derived from the validated flags above (which already use savedUsername)

--- a/apps/web/src/lib/__tests__/sessionCache.test.ts
+++ b/apps/web/src/lib/__tests__/sessionCache.test.ts
@@ -9,6 +9,8 @@ vi.mock("@/lib/redis", () => ({
     get: vi.fn(),
     set: vi.fn(),
     del: vi.fn(),
+    scan: vi.fn(),
+    mget: vi.fn(),
   },
 }));
 
@@ -37,11 +39,18 @@ vi.mock("react", () => ({
 }));
 
 import { redis } from "@/lib/redis";
-import { getSession, getSessionUserId, invalidateSessionCache } from "../sessionCache";
+import {
+  getSession,
+  getSessionUserId,
+  invalidateSessionCache,
+  invalidateAllUserSessionCacheEntries,
+} from "../sessionCache";
 
 const mockRedisGet = redis.get as ReturnType<typeof vi.fn>;
 const mockRedisSet = redis.set as ReturnType<typeof vi.fn>;
 const mockRedisDel = redis.del as ReturnType<typeof vi.fn>;
+const mockRedisScan = redis.scan as ReturnType<typeof vi.fn>;
+const mockRedisMget = redis.mget as ReturnType<typeof vi.fn>;
 
 describe("getSession", () => {
   beforeEach(() => {
@@ -171,5 +180,109 @@ describe("invalidateSessionCache", () => {
     mockRedisDel.mockRejectedValue(new Error("Redis unavailable"));
 
     await expect(invalidateSessionCache("my-token")).resolves.toBeUndefined();
+  });
+});
+
+describe("invalidateAllUserSessionCacheEntries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("scans session:* and deletes only entries whose user.id matches", async () => {
+    // Two scan pages exercise the cursor loop AND the per-page filter.
+    // Cursor "0" (Upstash returns string) terminates iteration.
+    mockRedisScan
+      .mockResolvedValueOnce([
+        "42",
+        ["session:cookie-a", "session:cookie-b", "session:cookie-c"],
+      ])
+      .mockResolvedValueOnce(["0", ["session:cookie-d"]]);
+    mockRedisMget
+      .mockResolvedValueOnce([
+        { user: { id: "target" }, session: { token: "t-a" } }, // match
+        { user: { id: "other" }, session: { token: "t-b" } }, // skip
+        { user: { id: "target" }, session: { token: "t-c" } }, // match
+      ])
+      .mockResolvedValueOnce([
+        { user: { id: "target" }, session: { token: "t-d" } }, // match
+      ]);
+    mockRedisDel.mockResolvedValueOnce(2).mockResolvedValueOnce(1);
+
+    const deleted = await invalidateAllUserSessionCacheEntries("target");
+
+    expect(deleted).toBe(3);
+    expect(mockRedisScan).toHaveBeenCalledTimes(2);
+    expect(mockRedisScan.mock.calls[0][0]).toBe(0);
+    expect(mockRedisScan.mock.calls[0][1]).toEqual({
+      match: "session:*",
+      count: 100,
+    });
+    expect(mockRedisScan.mock.calls[1][0]).toBe("42");
+    // First DEL gets the two matches from page 1; second gets the
+    // single match from page 2. The non-target row is NOT included.
+    expect(mockRedisDel).toHaveBeenNthCalledWith(
+      1,
+      "session:cookie-a",
+      "session:cookie-c",
+    );
+    expect(mockRedisDel).toHaveBeenNthCalledWith(2, "session:cookie-d");
+  });
+
+  it("returns 0 when no keys match the namespace", async () => {
+    mockRedisScan.mockResolvedValueOnce(["0", []]);
+
+    const deleted = await invalidateAllUserSessionCacheEntries("target");
+
+    expect(deleted).toBe(0);
+    expect(mockRedisMget).not.toHaveBeenCalled();
+    expect(mockRedisDel).not.toHaveBeenCalled();
+  });
+
+  it("returns 0 when the page contains only non-matching users", async () => {
+    mockRedisScan.mockResolvedValueOnce([
+      "0",
+      ["session:k1", "session:k2"],
+    ]);
+    mockRedisMget.mockResolvedValueOnce([
+      { user: { id: "u-other" } },
+      { user: { id: "u-other" } },
+    ]);
+
+    const deleted = await invalidateAllUserSessionCacheEntries("target");
+
+    expect(deleted).toBe(0);
+    expect(mockRedisDel).not.toHaveBeenCalled();
+  });
+
+  it("tolerates malformed payloads (null entry, missing user.id)", async () => {
+    mockRedisScan.mockResolvedValueOnce([
+      "0",
+      ["session:k1", "session:k2", "session:k3"],
+    ]);
+    mockRedisMget.mockResolvedValueOnce([
+      null,
+      { user: null },
+      {} as unknown,
+    ]);
+
+    const deleted = await invalidateAllUserSessionCacheEntries("target");
+
+    expect(deleted).toBe(0);
+    expect(mockRedisDel).not.toHaveBeenCalled();
+  });
+
+  it("logs and returns the partial count when SCAN errors mid-sweep", async () => {
+    mockRedisScan
+      .mockResolvedValueOnce(["1", ["session:k1"]])
+      .mockRejectedValueOnce(new Error("redis down"));
+    mockRedisMget.mockResolvedValueOnce([{ user: { id: "target" } }]);
+    mockRedisDel.mockResolvedValueOnce(1);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const deleted = await invalidateAllUserSessionCacheEntries("target");
+
+    expect(deleted).toBe(1);
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
   });
 });

--- a/apps/web/src/lib/actions/__tests__/preferences-revalidation.test.ts
+++ b/apps/web/src/lib/actions/__tests__/preferences-revalidation.test.ts
@@ -171,6 +171,12 @@ describe("updatePreferences invalidates job-language-dependent pages (#2916)", (
     });
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const { updatePreferences } = await import("../preferences");
+    // Drop module-init warnings (Upstash Redis fires
+    // `console.warn("[Upstash Redis] ...")` when its env vars are
+    // missing, which they are in this test environment — the redis
+    // client is loaded transitively via `@/lib/cache` for unrelated
+    // server actions in the same module).
+    warn.mockClear();
 
     // Should resolve without throwing even though every revalidate call fails.
     await expect(updatePreferences({ jobLanguages: ["fr"] })).resolves.toBeNull();

--- a/apps/web/src/lib/actions/__tests__/rename-username.test.ts
+++ b/apps/web/src/lib/actions/__tests__/rename-username.test.ts
@@ -1,0 +1,530 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Server actions transitively import `server-only`, which throws in a
+// non-Next runtime. Neutralize before module-under-test loads.
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  // next/cache
+  revalidatePath: vi.fn(),
+  cacheLife: vi.fn(),
+  updateTag: vi.fn(),
+  // next/server after() — invoke the callback synchronously so the test
+  // can assert IndexNow side effects without yielding to a scheduler.
+  after: vi.fn(<T,>(cb: () => T) => cb()),
+  // session cache
+  getSession: vi.fn(),
+  getSessionUserId: vi.fn(),
+  invalidateAllUserSessionCacheEntries: vi.fn().mockResolvedValue(0),
+  // redis cache layer
+  invalidateRedis: vi.fn().mockResolvedValue(undefined),
+  // typesense
+  tsUpdateWatchlistField: vi.fn(),
+  // indexnow
+  notifyIndexNow: vi.fn().mockResolvedValue(undefined),
+  // watchlist-utils — explicit signature so mockImplementation accepts
+  // a (filters, companyCount) predicate in the "trivial subset" test.
+  isTrivialWatchlist: vi.fn<(filters: unknown, companyCount: number) => boolean>(
+    () => false,
+  ),
+  // auth
+  updateUser: vi.fn().mockResolvedValue({ status: true }),
+  setPassword: vi.fn(),
+  // anon prefs (loaded by preferences module graph)
+  writeAnonJobLanguagesCookie: vi.fn(),
+  readAnonJobLanguagesCookie: vi.fn(),
+  // Drizzle: `db.select(...).from(user).where().limit(1)` is the OLD
+  // user-row lookup; `db.execute(sql\`SELECT ... FROM watchlist ...\`)`
+  // is the watchlist snapshot. Tests queue them in this order.
+  selectQueue: [] as unknown[],
+  executeQueue: [] as unknown[],
+}));
+
+vi.mock("next/cache", () => ({
+  revalidatePath: mocks.revalidatePath,
+  cacheLife: mocks.cacheLife,
+  updateTag: mocks.updateTag,
+}));
+
+vi.mock("next/server", () => ({
+  after: mocks.after,
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+vi.mock("@/lib/sessionCache", () => ({
+  getSession: mocks.getSession,
+  getSessionUserId: mocks.getSessionUserId,
+  invalidateAllUserSessionCacheEntries: mocks.invalidateAllUserSessionCacheEntries,
+}));
+
+vi.mock("@/lib/cache", () => ({
+  invalidate: mocks.invalidateRedis,
+}));
+
+vi.mock("@/lib/cache-tags", () => ({
+  // Stable, predictable tag format so assertions can match precisely.
+  watchlistCacheTag: (userSlug: string, watchlistSlug: string) =>
+    `watchlist:${userSlug}:${watchlistSlug}`,
+}));
+
+vi.mock("@/lib/search/typesense-watchlist", () => ({
+  updateWatchlistField: mocks.tsUpdateWatchlistField,
+}));
+
+vi.mock("@/lib/watchlist-utils", () => ({
+  isTrivialWatchlist: mocks.isTrivialWatchlist,
+}));
+
+vi.mock("@/lib/indexnow", () => ({
+  notifyIndexNow: mocks.notifyIndexNow,
+}));
+
+vi.mock("@/lib/anon-preferences", () => ({
+  writeAnonJobLanguagesCookie: mocks.writeAnonJobLanguagesCookie,
+  readAnonJobLanguagesCookie: mocks.readAnonJobLanguagesCookie,
+}));
+
+// preferences.ts also imports getSearchClient at module-load time via
+// `getAvailableJobLanguages`. Stub it so the import graph resolves.
+vi.mock("@/lib/search/typesense-client", () => ({
+  getSearchClient: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      updateUser: mocks.updateUser,
+      setPassword: mocks.setPassword,
+    },
+  },
+}));
+
+// Minimal Drizzle stub. Each select() returns a chain whose `where()` is
+// thenable AND has `.limit()` — supports both
+// `select().from().where()` (the watchlists read) and
+// `select().from().where().limit(1)` (the user read).
+const buildSelectChain = () => ({
+  from: () => ({
+    where: () => {
+      const result = mocks.selectQueue.shift() ?? [];
+      const p: Promise<unknown> & { limit?: () => Promise<unknown> } =
+        Promise.resolve(result);
+      p.limit = () => Promise.resolve(result);
+      return p;
+    },
+  }),
+});
+
+vi.mock("@/db", () => ({
+  db: {
+    select: () => buildSelectChain(),
+    execute: () =>
+      Promise.resolve(mocks.executeQueue.shift() ?? []),
+  },
+}));
+
+describe("renameUsername", () => {
+  beforeEach(() => {
+    mocks.revalidatePath.mockReset();
+    mocks.updateTag.mockReset();
+    mocks.after.mockReset().mockImplementation(<T,>(cb: () => T) => cb());
+    mocks.getSession.mockReset();
+    mocks.invalidateAllUserSessionCacheEntries.mockReset().mockResolvedValue(0);
+    mocks.invalidateRedis.mockReset().mockResolvedValue(undefined);
+    mocks.tsUpdateWatchlistField.mockReset();
+    mocks.notifyIndexNow.mockReset().mockResolvedValue(undefined);
+    mocks.isTrivialWatchlist.mockReset().mockReturnValue(false);
+    mocks.updateUser.mockReset().mockResolvedValue({ status: true });
+    mocks.selectQueue.length = 0;
+    mocks.executeQueue.length = 0;
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it("returns error when not authenticated", async () => {
+    mocks.getSession.mockResolvedValue(null);
+    const { renameUsername } = await import("../preferences");
+
+    const result = await renameUsername("newname");
+
+    expect(result).toEqual({ error: "Not authenticated" });
+    expect(mocks.updateUser).not.toHaveBeenCalled();
+  });
+
+  it("validates length", async () => {
+    mocks.getSession.mockResolvedValue({ user: { id: "u1" } });
+    const { renameUsername } = await import("../preferences");
+
+    expect(await renameUsername("ab")).toEqual({
+      error: "Username must be 3-30 characters",
+    });
+    expect(
+      await renameUsername("a".repeat(31)),
+    ).toEqual({ error: "Username must be 3-30 characters" });
+    expect(mocks.updateUser).not.toHaveBeenCalled();
+  });
+
+  it("validates character set after lowercase-normalization", async () => {
+    mocks.getSession.mockResolvedValue({ user: { id: "u1" } });
+    const { renameUsername } = await import("../preferences");
+
+    // Hyphen at the start / end is rejected by the regex (matches the
+    // client-side check in `UsernameSection`).
+    expect(await renameUsername("-leading-hyphen")).toEqual({
+      error: "Username has invalid characters",
+    });
+    expect(await renameUsername("trailing-")).toEqual({
+      error: "Username has invalid characters",
+    });
+    // Special chars that survive normalization but aren't [a-z0-9-].
+    expect(await renameUsername("has space")).toEqual({
+      error: "Username has invalid characters",
+    });
+    expect(await renameUsername("with.dot")).toEqual({
+      error: "Username has invalid characters",
+    });
+    expect(mocks.updateUser).not.toHaveBeenCalled();
+  });
+
+  it("rejects reserved usernames", async () => {
+    mocks.getSession.mockResolvedValue({ user: { id: "u1" } });
+    const { renameUsername } = await import("../preferences");
+
+    expect(await renameUsername("admin")).toEqual({
+      error: "Username is reserved",
+    });
+    expect(mocks.updateUser).not.toHaveBeenCalled();
+  });
+
+  it("no-ops when the new name already matches the current one", async () => {
+    mocks.getSession.mockResolvedValue({ user: { id: "u1" } });
+    mocks.selectQueue.push([
+      { username: "samename", displayUsername: "samename" },
+    ]);
+    const { renameUsername } = await import("../preferences");
+
+    const result = await renameUsername("samename");
+
+    expect(result).toEqual({});
+    expect(mocks.updateUser).not.toHaveBeenCalled();
+    expect(mocks.updateTag).not.toHaveBeenCalled();
+    expect(mocks.invalidateAllUserSessionCacheEntries).not.toHaveBeenCalled();
+  });
+
+  it("fans out cache invalidations against the OLD slug for each watchlist", async () => {
+    mocks.getSession.mockResolvedValue({ user: { id: "user-1" } });
+    mocks.selectQueue.push([
+      { username: "old", displayUsername: "old" }, // user row
+    ]);
+    mocks.executeQueue.push([
+      {
+        id: "wl-a",
+        slug: "alpha",
+        is_public: true,
+        filters: { keywords: ["k1", "k2"] },
+        company_count: 5,
+      },
+      {
+        id: "wl-b",
+        slug: "beta",
+        is_public: true,
+        filters: { keywords: ["k1", "k2"] },
+        company_count: 5,
+      },
+    ]);
+    const { renameUsername } = await import("../preferences");
+
+    const result = await renameUsername("new");
+    expect(result).toEqual({});
+
+    // Better Auth was asked to do the actual rename.
+    expect(mocks.updateUser).toHaveBeenCalledTimes(1);
+    expect(mocks.updateUser).toHaveBeenCalledWith(
+      expect.objectContaining({ body: { username: "new" } }),
+    );
+
+    // updateTag was called for the OLD user slug + each watchlist slug.
+    expect(mocks.updateTag).toHaveBeenCalledWith("watchlist:old:alpha");
+    expect(mocks.updateTag).toHaveBeenCalledWith("watchlist:old:beta");
+
+    // Redis public-watchlist:OLD:slug invalidations.
+    expect(mocks.invalidateRedis).toHaveBeenCalledWith(
+      "public-watchlist:old:alpha",
+    );
+    expect(mocks.invalidateRedis).toHaveBeenCalledWith(
+      "public-watchlist:old:beta",
+    );
+
+    // Sitemap Redis bust.
+    expect(mocks.invalidateRedis).toHaveBeenCalledWith("sitemap:watchlists");
+
+    // Typesense docs patched with NEW owner_username and is_featured
+    // (derived from `normalized === "colophongroup"`, false here).
+    expect(mocks.tsUpdateWatchlistField).toHaveBeenCalledWith("wl-a", {
+      owner_username: "new",
+      is_featured: false,
+    });
+    expect(mocks.tsUpdateWatchlistField).toHaveBeenCalledWith("wl-b", {
+      owner_username: "new",
+      is_featured: false,
+    });
+
+    // Multi-device session cache bust.
+    expect(mocks.invalidateAllUserSessionCacheEntries).toHaveBeenCalledWith(
+      "user-1",
+    );
+
+    // IndexNow ping (after()): new + old URLs for both qualifying watchlists.
+    expect(mocks.notifyIndexNow).toHaveBeenCalledTimes(1);
+    const indexNowUrls = mocks.notifyIndexNow.mock.calls[0][0] as string[];
+    expect(indexNowUrls).toEqual(
+      expect.arrayContaining([
+        "/new/alpha",
+        "/old/alpha",
+        "/new/beta",
+        "/old/beta",
+      ]),
+    );
+  });
+
+  it("refreshes Typesense is_featured when renaming TO the featured handle", async () => {
+    mocks.getSession.mockResolvedValue({ user: { id: "u-feat" } });
+    mocks.selectQueue.push([
+      { username: "old", displayUsername: null },
+    ]);
+    mocks.executeQueue.push([
+      {
+        id: "wl-1",
+        slug: "s",
+        is_public: false,
+        filters: null,
+        company_count: 0,
+      },
+    ]);
+    const { renameUsername } = await import("../preferences");
+
+    await renameUsername("colophongroup");
+
+    expect(mocks.tsUpdateWatchlistField).toHaveBeenCalledWith("wl-1", {
+      owner_username: "colophongroup",
+      is_featured: true,
+    });
+  });
+
+  it("busts BOTH username and displayUsername variants when they differ", async () => {
+    mocks.getSession.mockResolvedValue({ user: { id: "user-2" } });
+    mocks.selectQueue.push([
+      { username: "old-canonical", displayUsername: "old-display" },
+    ]);
+    mocks.executeQueue.push([
+      {
+        id: "wl-x",
+        slug: "x",
+        is_public: false,
+        filters: null,
+        company_count: 0,
+      },
+    ]);
+    const { renameUsername } = await import("../preferences");
+
+    await renameUsername("new");
+
+    // Both old slug variants get their cache tag busted — the route
+    // resolver matches `u.username = X OR u.display_username = X`, so
+    // either form could be the live URL segment.
+    expect(mocks.updateTag).toHaveBeenCalledWith(
+      "watchlist:old-canonical:x",
+    );
+    expect(mocks.updateTag).toHaveBeenCalledWith("watchlist:old-display:x");
+    expect(mocks.invalidateRedis).toHaveBeenCalledWith(
+      "public-watchlist:old-canonical:x",
+    );
+    expect(mocks.invalidateRedis).toHaveBeenCalledWith(
+      "public-watchlist:old-display:x",
+    );
+  });
+
+  it("normalizes input (lowercase + trim) before validation and rename", async () => {
+    mocks.getSession.mockResolvedValue({ user: { id: "u3" } });
+    mocks.selectQueue.push([{ username: "old", displayUsername: null }]);
+    mocks.executeQueue.push([]);
+    const { renameUsername } = await import("../preferences");
+
+    const result = await renameUsername("  NewName  ");
+    expect(result).toEqual({});
+    expect(mocks.updateUser).toHaveBeenCalledWith(
+      expect.objectContaining({ body: { username: "newname" } }),
+    );
+  });
+
+  it("surfaces Better Auth errors and does NOT run the fanout", async () => {
+    mocks.getSession.mockResolvedValue({ user: { id: "u4" } });
+    mocks.selectQueue.push([{ username: "old", displayUsername: null }]);
+    mocks.executeQueue.push([
+      {
+        id: "wl-1",
+        slug: "s",
+        is_public: true,
+        filters: { keywords: ["k1", "k2"] },
+        company_count: 3,
+      },
+    ]);
+    mocks.updateUser.mockRejectedValue(new Error("Username already taken"));
+    const { renameUsername } = await import("../preferences");
+
+    const result = await renameUsername("taken");
+    expect(result).toEqual({ error: "Username already taken" });
+    expect(mocks.updateTag).not.toHaveBeenCalled();
+    expect(mocks.invalidateRedis).not.toHaveBeenCalled();
+    expect(mocks.tsUpdateWatchlistField).not.toHaveBeenCalled();
+    expect(mocks.invalidateAllUserSessionCacheEntries).not.toHaveBeenCalled();
+    expect(mocks.notifyIndexNow).not.toHaveBeenCalled();
+  });
+
+  it("succeeds with no watchlists (still busts session + sitemap)", async () => {
+    mocks.getSession.mockResolvedValue({ user: { id: "u5" } });
+    mocks.selectQueue.push([{ username: "old", displayUsername: null }]);
+    mocks.executeQueue.push([]); // no watchlists
+    const { renameUsername } = await import("../preferences");
+
+    const result = await renameUsername("new");
+    expect(result).toEqual({});
+    expect(mocks.updateUser).toHaveBeenCalled();
+    expect(mocks.tsUpdateWatchlistField).not.toHaveBeenCalled();
+    // updateTag never called for per-watchlist tags, but sitemap and
+    // session cache busts still run.
+    expect(mocks.updateTag).not.toHaveBeenCalled();
+    expect(mocks.invalidateRedis).toHaveBeenCalledWith("sitemap:watchlists");
+    expect(mocks.invalidateAllUserSessionCacheEntries).toHaveBeenCalledWith(
+      "u5",
+    );
+  });
+
+  it("redis invalidate failure is logged but does not fail the rename", async () => {
+    mocks.getSession.mockResolvedValue({ user: { id: "u6" } });
+    mocks.selectQueue.push([{ username: "old", displayUsername: null }]);
+    mocks.executeQueue.push([
+      {
+        id: "wl-1",
+        slug: "s",
+        is_public: false,
+        filters: null,
+        company_count: 0,
+      },
+    ]);
+    mocks.invalidateRedis.mockRejectedValue(new Error("redis down"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { renameUsername } = await import("../preferences");
+
+    const result = await renameUsername("new");
+    expect(result).toEqual({});
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it("skips IndexNow for private or trivial watchlists", async () => {
+    mocks.getSession.mockResolvedValue({ user: { id: "u-idx" } });
+    mocks.selectQueue.push([{ username: "old", displayUsername: null }]);
+    mocks.executeQueue.push([
+      // Private — skip.
+      {
+        id: "wl-private",
+        slug: "private",
+        is_public: false,
+        filters: { keywords: ["a", "b"] },
+        company_count: 5,
+      },
+      // Public but trivial (mocked predicate returns true for it) — skip.
+      {
+        id: "wl-trivial",
+        slug: "trivial",
+        is_public: true,
+        filters: {},
+        company_count: 0,
+      },
+      // Public + non-trivial — ping.
+      {
+        id: "wl-good",
+        slug: "good",
+        is_public: true,
+        filters: { keywords: ["a", "b"] },
+        company_count: 4,
+      },
+    ]);
+    // Mark only the "trivial" row as trivial.
+    mocks.isTrivialWatchlist.mockImplementation((_filters, companyCount) =>
+      companyCount === 0,
+    );
+    const { renameUsername } = await import("../preferences");
+
+    await renameUsername("new");
+
+    expect(mocks.notifyIndexNow).toHaveBeenCalledTimes(1);
+    const urls = mocks.notifyIndexNow.mock.calls[0][0] as string[];
+    expect(urls).toEqual(["/new/good", "/old/good"]);
+    expect(urls).not.toEqual(
+      expect.arrayContaining(["/new/private", "/new/trivial"]),
+    );
+  });
+
+  it("skips notifyIndexNow entirely when no qualifying watchlists exist", async () => {
+    mocks.getSession.mockResolvedValue({ user: { id: "u-empty" } });
+    mocks.selectQueue.push([{ username: "old", displayUsername: null }]);
+    mocks.executeQueue.push([
+      {
+        id: "wl-1",
+        slug: "s",
+        is_public: false,
+        filters: null,
+        company_count: 0,
+      },
+    ]);
+    const { renameUsername } = await import("../preferences");
+
+    await renameUsername("new");
+
+    expect(mocks.notifyIndexNow).not.toHaveBeenCalled();
+  });
+
+  it("calls auth.api.updateUser BEFORE any cache fanout (ordering)", async () => {
+    mocks.getSession.mockResolvedValue({ user: { id: "u-order" } });
+    mocks.selectQueue.push([{ username: "old", displayUsername: null }]);
+    mocks.executeQueue.push([
+      {
+        id: "wl-1",
+        slug: "s",
+        is_public: true,
+        filters: { keywords: ["a", "b"] },
+        company_count: 3,
+      },
+    ]);
+    const { renameUsername } = await import("../preferences");
+
+    await renameUsername("new");
+
+    // `invocationCallOrder` is monotonically increasing across all
+    // mocks in the run — comparing them enforces the sequence:
+    // (1) Better Auth runs FIRST (so the DB row is flipped under the
+    // user's nose), then (2) the per-watchlist cache tags / Redis /
+    // Typesense / IndexNow run against the snapshotted OLD slug. A
+    // future refactor that reorders the fanout pre-rename would break
+    // the snapshot-of-OLD-row contract and this assertion would catch
+    // it.
+    const updateUserOrder = mocks.updateUser.mock.invocationCallOrder[0];
+    const updateTagOrder = mocks.updateTag.mock.invocationCallOrder[0];
+    const sessionBustOrder =
+      mocks.invalidateAllUserSessionCacheEntries.mock.invocationCallOrder[0];
+    const tsUpsertOrder =
+      mocks.tsUpdateWatchlistField.mock.invocationCallOrder[0];
+
+    expect(updateUserOrder).toBeDefined();
+    expect(updateTagOrder).toBeGreaterThan(updateUserOrder);
+    expect(tsUpsertOrder).toBeGreaterThan(updateUserOrder);
+    expect(sessionBustOrder).toBeGreaterThan(updateUserOrder);
+  });
+});

--- a/apps/web/src/lib/actions/preferences.ts
+++ b/apps/web/src/lib/actions/preferences.ts
@@ -1,15 +1,27 @@
 "use server";
 
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { headers } from "next/headers";
-import { cacheLife, revalidatePath } from "next/cache";
+import { cacheLife, revalidatePath, updateTag } from "next/cache";
+import { after } from "next/server";
 import { db } from "@/db";
-import { account, userPreferences } from "@/db/schema";
+import { account, user, userPreferences } from "@/db/schema";
 import { auth } from "@/lib/auth";
-import { getSession, getSessionUserId } from "@/lib/sessionCache";
+import {
+  getSession,
+  getSessionUserId,
+  invalidateAllUserSessionCacheEntries,
+} from "@/lib/sessionCache";
 import { getLanguage } from "@/lib/job-languages";
 import { writeAnonJobLanguagesCookie, readAnonJobLanguagesCookie } from "@/lib/anon-preferences";
 import { getSearchClient } from "@/lib/search/typesense-client";
+import { invalidate as invalidateRedis } from "@/lib/cache";
+import { watchlistCacheTag } from "@/lib/cache-tags";
+import { updateWatchlistField as tsUpdateWatchlistField } from "@/lib/search/typesense-watchlist";
+import { isReservedUsername } from "@/lib/username";
+import { isTrivialWatchlist } from "@/lib/watchlist-utils";
+import { notifyIndexNow } from "@/lib/indexnow";
+import type { WatchlistFilters } from "@/lib/actions/watchlists";
 
 const PASSWORD_RESET_COOLDOWN_SECONDS = 60;
 
@@ -303,6 +315,230 @@ export async function setPassword(newPassword: string): Promise<{ error?: string
     const message = e instanceof Error ? e.message : "Failed to set password";
     return { error: message };
   }
+}
+
+const USERNAME_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
+
+/**
+ * Rename the current user's username and fan out every cache invalidation
+ * the rename invalidates.
+ *
+ * Wraps Better Auth's `/update-user` (which only rewrites the DB row +
+ * re-signs the session cookie) with the application-level invalidations
+ * the platform also needs:
+ *
+ *  - The Redis-cached `getSession()` blob (keyed by the signed cookie
+ *    value, which Better Auth does NOT rotate on rename) keeps the old
+ *    `user.username` for up to 5 min — busted for every active session
+ *    token so other devices see the new username promptly.
+ *  - The watchlist detail `'use cache'` entries are tagged by
+ *    `watchlistCacheTag(userSlug, watchlistSlug)`. Once the user-row
+ *    flips both `username` and `display_username` to the new value
+ *    (Better Auth's username plugin mirrors `body.username` →
+ *    `body.displayUsername` in its before-hook for `/update-user`), the
+ *    OLD slug no longer matches the DB and every visit under the old
+ *    URL 404s. The cache tags + Redis `public-watchlist:` entries keyed
+ *    on the old slug are busted here so the 404 surfaces immediately
+ *    instead of being papered over by a stale render.
+ *  - Typesense `watchlist` docs carry a denormalised `owner_username`
+ *    that's only rewritten when the watchlist itself is mutated. Each
+ *    of the user's existing docs is patched here so public watchlist
+ *    search reflects the new owner slug without waiting for the next
+ *    per-watchlist mutation.
+ *  - The sitemap Redis cache holds rendered watchlist URLs for 1h; the
+ *    cache is dropped so the next crawl pulls the new slugs.
+ *
+ * Returns `{ error }` with a human-readable message on validation or
+ * uniqueness failures, `{}` on success. No-ops when the requested name
+ * already matches the stored value.
+ */
+export async function renameUsername(
+  newUsername: string,
+): Promise<{ error?: string }> {
+  const currentSession = await getSession();
+  if (!currentSession) return { error: "Not authenticated" };
+  const userId = currentSession.user.id;
+
+  // Mirror the client-side validation in `UsernameSection` so a stray
+  // direct call to this server action can't bypass it.
+  const normalized = newUsername.toLowerCase().trim();
+  if (normalized.length < 3 || normalized.length > 30) {
+    return { error: "Username must be 3-30 characters" };
+  }
+  if (!USERNAME_RE.test(normalized)) {
+    return { error: "Username has invalid characters" };
+  }
+  if (isReservedUsername(normalized)) {
+    return { error: "Username is reserved" };
+  }
+
+  // Snapshot the pre-rename state BEFORE handing off to Better Auth.
+  // We need both the OLD slug variants (for the cache-tag bust) and the
+  // full set of the user's watchlist ids + the session-token list (for
+  // the Typesense + multi-device session-cache bust) at a point in time
+  // where the user row still holds the OLD username.
+  const [oldUserRow] = await db
+    .select({
+      username: user.username,
+      displayUsername: user.displayUsername,
+    })
+    .from(user)
+    .where(eq(user.id, userId))
+    .limit(1);
+  if (!oldUserRow) return { error: "User not found" };
+
+  if (oldUserRow.username === normalized) return {}; // no-op rename
+
+  // Snapshot every watchlist the user owns with the fields the fanout
+  // needs: `slug` (cache-tag bust + IndexNow URL), `isPublic` +
+  // `filters` + `company_count` (qualifying check for IndexNow — only
+  // public, non-trivial watchlists are indexed by sitemap.ts and
+  // therefore worth pinging on rename). Single SQL with a correlated
+  // subquery so we don't pay N+1 round-trips inside the rename critical
+  // path; the same idea as `_getOwnerInfo` in `watchlists.ts`.
+  const watchlistRows = await db.execute<{
+    [key: string]: unknown;
+    id: string;
+    slug: string;
+    is_public: boolean;
+    filters: WatchlistFilters | null;
+    company_count: number;
+  }>(sql`
+    SELECT
+      w.id, w.slug, w.is_public, w.filters,
+      COALESCE(
+        (SELECT count(*)::int FROM watchlist_company wc WHERE wc.watchlist_id = w.id),
+        0
+      ) AS company_count
+    FROM watchlist w
+    WHERE w.user_id = ${userId}
+  `);
+  type WatchlistSnapshot = {
+    id: string;
+    slug: string;
+    isPublic: boolean;
+    filters: WatchlistFilters;
+    companyCount: number;
+  };
+  const userWatchlists: WatchlistSnapshot[] = (
+    watchlistRows as unknown as Array<{
+      id: string;
+      slug: string;
+      is_public: boolean;
+      filters: WatchlistFilters | null;
+      company_count: number;
+    }>
+  ).map((r) => ({
+    id: r.id,
+    slug: r.slug,
+    isPublic: r.is_public,
+    filters: (r.filters ?? {}) as WatchlistFilters,
+    companyCount: r.company_count,
+  }));
+
+  // Delegate the actual DB write + cookie re-sign to Better Auth so the
+  // username plugin's uniqueness check and the `usernameValidator`
+  // configured in `auth.ts` run authoritatively. Failures (taken, format,
+  // etc.) surface as APIErrors with messages we forward to the caller.
+  try {
+    await auth.api.updateUser({
+      body: { username: normalized },
+      headers: await headers(),
+    });
+  } catch (e: unknown) {
+    const message = e instanceof Error ? e.message : "Failed to update username";
+    return { error: message };
+  }
+
+  // ── Fanout below this point — best-effort, never rollback the rename ──
+
+  const oldUserSlugs = new Set<string>();
+  if (oldUserRow.username) oldUserSlugs.add(oldUserRow.username);
+  if (oldUserRow.displayUsername) oldUserSlugs.add(oldUserRow.displayUsername);
+
+  // Watchlist detail caches are keyed by whichever userSlug variant the
+  // visitor hit (`username` or `display_username` — see the route
+  // resolver in `getWatchlistByUserAndSlug`). Bust both for every
+  // owned watchlist so the old `/{userSlug}/{watchlistSlug}` cached
+  // render is evicted and the next visit fetches the fresh DB row
+  // (which now 404s — engines should learn it).
+  for (const oldSlug of oldUserSlugs) {
+    for (const wl of userWatchlists) {
+      updateTag(watchlistCacheTag(oldSlug, wl.slug));
+      try {
+        await invalidateRedis(`public-watchlist:${oldSlug}:${wl.slug}`);
+      } catch (err) {
+        console.error(
+          "[renameUsername] redis public-watchlist invalidate failed",
+          err,
+        );
+      }
+    }
+  }
+
+  // Refresh Typesense `owner_username` for each existing watchlist doc
+  // so the public watchlist search shows the new `@username` without
+  // waiting for the next per-watchlist mutation. `is_featured` is also
+  // derived from `username.toLowerCase() === "colophongroup"` in the
+  // mutation hooks (`watchlists.ts:158,273,471`) — a rename TO or AWAY
+  // from that handle has to refresh the flag or it stays stale until
+  // the next mutation. Partial update is a no-op if the doc doesn't
+  // exist (private / trivial watchlists). `tsUpdateWatchlistField` is
+  // fire-and-forget; errors are caught + logged inside the helper.
+  const newIsFeatured = normalized === "colophongroup";
+  for (const wl of userWatchlists) {
+    tsUpdateWatchlistField(wl.id, {
+      owner_username: normalized,
+      is_featured: newIsFeatured,
+    });
+  }
+
+  // Sitemap entries embed `display_username ?? username` per row and
+  // are cached for `SITEMAP_TTL_SECONDS` (1h). Drop the cache so the
+  // next sitemap request reflects the new slugs.
+  try {
+    await invalidateRedis("sitemap:watchlists");
+  } catch (err) {
+    console.error("[renameUsername] sitemap invalidate failed", err);
+  }
+
+  // Bust the Redis-cached `getSession()` blob for every device the user
+  // is logged in on. The cookie Better Auth re-signs in
+  // `setSessionCookie` keeps the same `session.token` and thus the same
+  // signed cookie value, so `session:<signed-value>` in Redis still
+  // holds the pre-rename user payload until the 5-min TTL expires.
+  // SCAN-filtered eviction is the simplest cross-device bust we can do
+  // without duplicating better-call's signing code or maintaining a
+  // userId → token index.
+  await invalidateAllUserSessionCacheEntries(userId);
+
+  // Ping IndexNow for every qualifying watchlist's NEW + OLD URLs so
+  // engines re-crawl the old slug (which now 404s) and discover the
+  // new slug. Mirrors the qualifying predicate used by other watchlist
+  // mutations (`watchlists.ts:154,291,457`) and the sitemap filter
+  // (`sitemap.ts` — only public, non-trivial watchlists are indexed).
+  // Runs in `after()` so the response returns before the outbound
+  // HTTP call to the IndexNow endpoint. Failures are logged, never
+  // surfaced — IndexNow is best-effort SEO hygiene.
+  after(async () => {
+    const urls: string[] = [];
+    for (const wl of userWatchlists) {
+      if (!wl.isPublic) continue;
+      if (isTrivialWatchlist(wl.filters, wl.companyCount)) continue;
+      urls.push(`/${normalized}/${wl.slug}`);
+      for (const oldSlug of oldUserSlugs) {
+        urls.push(`/${oldSlug}/${wl.slug}`);
+      }
+    }
+    if (urls.length === 0) return;
+    try {
+      await notifyIndexNow(urls);
+    } catch (err) {
+      console.error("[renameUsername] indexnow failed", err);
+    }
+  });
+
+  return {};
 }
 
 /**

--- a/apps/web/src/lib/sessionCache.ts
+++ b/apps/web/src/lib/sessionCache.ts
@@ -88,3 +88,57 @@ export async function invalidateSessionCache(token: string): Promise<void> {
     // Best effort — TTL will clean up eventually
   }
 }
+
+/**
+ * Bust every `session:*` Redis cache entry whose cached `SessionResult`
+ * belongs to ``userId``.
+ *
+ * The Redis cache key is `session:<signed-cookie-value>` (NOT
+ * `session:<raw-token>` — the cookie value is `HMAC(secret, token)`
+ * appended to the token), so callers that only have a list of raw
+ * session tokens from the DB can't construct the cache keys directly.
+ * SCAN over the namespace and filter by the payload's `user.id` is the
+ * pragmatic way to bust all of a user's devices in one shot.
+ *
+ * Used by `renameUsername` so a username change is visible on every
+ * device the user is logged into within seconds (vs. the 5-min cache
+ * TTL otherwise). Iterates Upstash via SCAN cursors so a partial sweep
+ * doesn't block on a giant single command. Best-effort: failures are
+ * logged and swallowed because the rename has already succeeded — TTL
+ * would still self-heal eventually.
+ */
+export async function invalidateAllUserSessionCacheEntries(
+  userId: string,
+): Promise<number> {
+  let cursor: string | number = 0;
+  let deleted = 0;
+  try {
+    do {
+      const [next, keys] = (await redis.scan(cursor, {
+        match: "session:*",
+        count: 100,
+      })) as [string | number, string[]];
+      cursor = next;
+      if (keys.length === 0) continue;
+
+      // mget returns the parsed JSON for each value (or null). Each cached
+      // entry is the full SessionResult: `{ session: {...}, user: {...} }`.
+      const values = (await redis.mget(...keys)) as Array<
+        { user?: { id?: string } } | null
+      >;
+      const toDelete: string[] = [];
+      for (let i = 0; i < keys.length; i++) {
+        if (values[i]?.user?.id === userId) toDelete.push(keys[i]);
+      }
+      if (toDelete.length > 0) {
+        deleted += await redis.del(...toDelete);
+      }
+    } while (String(cursor) !== "0");
+  } catch (err) {
+    console.error(
+      "[invalidateAllUserSessionCacheEntries] redis scan failed",
+      err,
+    );
+  }
+  return deleted;
+}

--- a/apps/web/src/lib/useAuth.ts
+++ b/apps/web/src/lib/useAuth.ts
@@ -8,8 +8,13 @@ import { useSession } from "@/components/SessionProvider";
  * `isPending` is true while the initial bootstrap fetch is in progress.
  * Components should show neutral/skeleton UI while isPending to avoid
  * flashing auth-dependent content.
+ *
+ * `refresh()` re-fetches the session payload from the server — call it
+ * after an identity-mutating server action (e.g. `renameUsername`) so
+ * downstream URL builders rebuild against the new `user.username`
+ * rather than the value bootstrapped on initial mount (#3022).
  */
 export function useAuth() {
-  const { user, isLoggedIn, isPending } = useSession();
-  return { isLoggedIn, user, isPending };
+  const { user, isLoggedIn, isPending, refresh } = useSession();
+  return { isLoggedIn, user, isPending, refresh };
 }


### PR DESCRIPTION
## Summary

After a user renames their username in Settings → Account, every cache layer that holds the OLD slug (client SessionProvider, Redis session cache, watchlist `'use cache'` tags, public-watchlist Redis fetch, Typesense `owner_username`/`is_featured`, sitemap Redis) keeps serving it. Watchlist URLs built from `useAuth().user.username` push to `/{old-username}/{slug}`, which the route resolver — `WHERE u.username = X OR u.display_username = X` — can't match because Better Auth's username plugin overwrites both columns on rename. The page 404s.

This PR wraps the rename in a `renameUsername` server action that snapshots OLD slugs + watchlists, delegates the DB write to `auth.api.updateUser`, then fans out invalidations to every affected layer. Closes #3022.

## What changes

- **`apps/web/src/lib/actions/preferences.ts`**: new `renameUsername` server action. Validates server-side, snapshots OLD `username`/`displayUsername` + the user's watchlists in a single SQL (id, slug, is_public, filters, company_count). Calls Better Auth. Fans out:
  - `updateTag(watchlistCacheTag(oldSlug, slug))` for both OLD username variants × each watchlist
  - Redis `invalidate("public-watchlist:OLD:slug")` for each pair
  - Typesense `updateWatchlistField(id, { owner_username, is_featured })` per doc — `is_featured` is derived from `username === "colophongroup"`, so a rename to/from that handle has to refresh the flag
  - Redis `invalidate("sitemap:watchlists")` for the 1h-cached sitemap
  - `invalidateAllUserSessionCacheEntries(userId)` (new helper) — multi-device session-cache bust
  - `after(notifyIndexNow([new + old URLs]))` per qualifying watchlist so engines re-crawl old URLs (404) and discover the new ones
- **`apps/web/src/lib/sessionCache.ts`**: new `invalidateAllUserSessionCacheEntries(userId)` — SCAN over `session:*`, MGET, filter by `value.user.id`, DEL matching keys. Necessary because Better Auth's `setSessionCookie` keeps the same `session.token` (no rotation), so `session:<signed-cookie>` in Redis stays keyed the same; the cached blob would otherwise serve the pre-rename user for the full 5-min TTL.
- **`apps/web/src/components/SessionProvider.tsx` + `AppBootstrapProvider.tsx` + `useAuth.ts`**: SessionContext now exposes `refresh: () => Promise<void>`. AppBootstrapProvider supplies a real implementation that re-runs `fetchAppBootstrap()` and replaces state IN PLACE — does NOT null `data` first, so `isPending` stays `false` across the refresh and `useAuth()` consumers (header avatar, watchlist job list) don't flicker.
- **`AccountSettings.tsx` (UsernameSection)**: replaces `authClient.updateUser` with `renameUsername`; on success calls `await refreshSession()` then `router.refresh()`.

## Test plan

- [x] `pnpm exec vitest run` — 675 individual tests pass; 25 new tests (rename-username fanout + ordering, refresh-without-flicker, SCAN-based session bust).
- [x] `pnpm exec tsc --noEmit` — clean (only pre-existing `app/mcp/route.ts` import error, unrelated to this PR).
- [x] `pnpm exec eslint .` — clean.
- [ ] Manual: sign in, change username in /settings/account, navigate to /watchlists, click a card → opens new URL (not stale 404). Mirror + Save-search push to new URL too.
- [ ] Manual: second browser logged in as the same user — within a request, server reads fresh username (multi-device SCAN bust).

## Scope notes

Per the issue's "Strongly recommended" section, all four latent staleness layers are included: cache tags, Typesense, sitemap, multi-device session. The 60-120s `popular-watchlists:*` / `public-watchlist-search:*` Redis caches are intentionally NOT busted — they self-heal on TTL after the per-doc Typesense patch lands, and busting a prefix sweep on every rename is a poor cost-benefit at jobseek scale (cleared by critic review). The sitemap CDN s-maxage 1h and OG image 24h cache are also accepted self-heal — per the existing comments in those files.

The 301-vs-404 product question for old `/{old-username}/{slug}` URLs is still open and intentionally out of scope; this PR pushes both old and new URLs to IndexNow so engines learn the 404 and discover the new URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)