### PR TITLE
fix(web): scroll-mt offset for Features/Pricing landing anchors (closes #3024)

### DIFF
--- a/apps/web/src/components/Features.tsx
+++ b/apps/web/src/components/Features.tsx
@@ -329,7 +329,7 @@ export function Features() {
   return (
     <section
       id={siteConfig.features.anchorId}
-      className="relative z-[1] overflow-x-hidden overflow-y-visible py-16 pb-8 md:py-24 md:pb-12"
+      className="relative z-[1] scroll-mt-24 overflow-x-hidden overflow-y-visible py-16 pb-8 md:scroll-mt-32 md:py-24 md:pb-12"
     >
       <div className="flex flex-col gap-24 md:gap-32">
         {/* Order is ICP-first: watchlist (s3) → tracker (s2) → search (s1).

--- a/apps/web/src/components/Pricing.tsx
+++ b/apps/web/src/components/Pricing.tsx
@@ -94,7 +94,10 @@ function ProTier() {
 
 export function Pricing() {
   return (
-    <section id={siteConfig.pricing.anchorId} className="mx-auto max-w-[1200px] px-4 py-12 md:py-20">
+    <section
+      id={siteConfig.pricing.anchorId}
+      className="mx-auto max-w-[1200px] scroll-mt-24 px-4 py-12 md:scroll-mt-32 md:py-20"
+    >
       <div className="mx-auto flex max-w-[640px] flex-col gap-4 text-center">
         <span className={eyebrowClass}>
           <Trans id="home.pricing.eyebrow" comment="Pricing section eyebrow">Pricing</Trans>


### PR DESCRIPTION
## Summary

The fixed 49px header was overlapping the top padding of the `#features` and `#pricing` `<section>` elements on the landing page. Clicking the **Features** / **Pricing** header links scrolled the section under the header, leaving the eyebrow 31-52px below the header instead of the 96/128px breathing room used elsewhere on the site.

Fix: add `scroll-mt-24 md:scroll-mt-32` (96px / 128px) inline on both sections — matching the `sectionScroll` constant already used by `License/Terms/HowWeIndex/PrivacyPolicy` content components.

Files touched:
- `apps/web/src/components/Features.tsx` — `<section id={siteConfig.features.anchorId}>`
- `apps/web/src/components/Pricing.tsx` — `<section id={siteConfig.pricing.anchorId}>`

## Verification

Measured against the dev server (`PORT=3001 pnpm dev`) using Playwright (chromium). All five cases now land the anchored section with ≥79px of breathing room below the 49px fixed header — well above the perceived-overlap threshold cited in the bug:

| Viewport       | Anchor    | Section top | Breathing room (top − 49px header) |
|----------------|-----------|-------------|-------------------------------------|
| 1280 desktop   | `#features` | 128px       | 79px                                |
| 1280 desktop   | `#pricing`  | 128px       | 79px                                |
| 375 mobile     | `#features` | 175px       | 126px                               |
| 375 mobile     | `#pricing`  | 175px       | 126px                               |
| Desktop, same-page click on header link | `#pricing` | 128px | 79px |

Screenshots (taken on this branch):

- `/tmp/3024-screenshots/features-desktop.png`
- `/tmp/3024-screenshots/pricing-desktop.png`
- `/tmp/3024-screenshots/features-mobile.png`
- `/tmp/3024-screenshots/pricing-mobile.png`
- `/tmp/3024-screenshots/click-pricing-desktop.png`

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm lint` clean
- [x] Pre-commit hooks (ESLint, Lingui translation coverage) pass
- [x] Desktop cold-load `/en#features` and `/en#pricing` — eyebrow lands clearly below header
- [x] Mobile (375×667) cold-load `/en#features` and `/en#pricing` — same
- [x] Same-page click on Pricing header link — same

Closes #3024.