### PR TITLE
fix(web): fall back avatars to initials on broken image (closes #3035)

### DIFF
--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -14,6 +14,7 @@ import { authClient } from "@/lib/auth-client";
 import { Button } from "@/components/ui/Button";
 import { SearchBar } from "@/components/search/search-bar";
 import { tooltipClass } from "@/components/ui/tooltip-styles";
+import { UserAvatar } from "@/components/UserAvatar";
 
 const iconBtnClass =
   "inline-flex items-center justify-center rounded-md p-1.5 text-foreground hover:bg-border-soft transition-colors cursor-pointer";
@@ -57,15 +58,6 @@ export function AppHeader() {
   const settingsLabel = t({ id: "app.header.nav.settings", comment: "Settings nav icon tooltip", message: "Settings" });
 
 
-  function getInitials(name: string) {
-    return name
-      .split(" ")
-      .map((w) => w[0])
-      .join("")
-      .toUpperCase()
-      .slice(0, 2);
-  }
-
   async function handleSignOut() {
     await authClient.signOut();
     // Manually clear session cookies — better-auth's nextCookies() plugin
@@ -80,21 +72,20 @@ export function AppHeader() {
 
   const avatarButton = (
     <button
-      className="flex size-8 items-center justify-center rounded-full bg-primary text-xs font-semibold text-primary-contrast transition-opacity hover:opacity-90 cursor-pointer"
+      className="rounded-full transition-opacity hover:opacity-90 cursor-pointer"
       aria-label={t({
         id: "app.header.avatar.label",
         comment: "Aria label for user avatar menu",
         message: "Account menu",
       })}
     >
-      {user?.image ? (
-        // User avatars come from arbitrary OAuth providers.
-        // next/image remote host allowlist would block many of them.
-        // eslint-disable-next-line @next/next/no-img-element
-        <img src={user.image} alt="" className="size-8 rounded-full object-cover" />
-      ) : (
-        getInitials(user?.name ?? user?.email ?? "?")
-      )}
+      <UserAvatar
+        image={user?.image}
+        name={user?.name}
+        email={user?.email}
+        size={32}
+        initialsTextClass="text-xs"
+      />
     </button>
   );
 
@@ -205,15 +196,13 @@ export function AppHeader() {
             <DropdownMenu.Root>
               <DropdownMenu.Trigger asChild>
                 <button className="flex flex-1 flex-col items-center gap-0.5 py-1.5 transition-colors cursor-pointer">
-                  <span className="flex size-6 items-center justify-center rounded-full bg-primary text-[10px] font-semibold text-primary-contrast">
-                    {user.image ? (
-                      // User avatars come from arbitrary OAuth providers.
-                      // eslint-disable-next-line @next/next/no-img-element
-                      <img src={user.image} alt="" className="size-6 rounded-full object-cover" />
-                    ) : (
-                      getInitials(user.name ?? user.email ?? "?")
-                    )}
-                  </span>
+                  <UserAvatar
+                    image={user.image}
+                    name={user.name}
+                    email={user.email}
+                    size={24}
+                    initialsTextClass="text-[10px]"
+                  />
                   <span className="text-[10px] leading-tight text-foreground">
                     {t({ id: "app.header.nav.account", comment: "Account bottom bar label", message: "Account" })}
                   </span>

--- a/apps/web/src/components/UserAvatar.tsx
+++ b/apps/web/src/components/UserAvatar.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useState } from "react";
+import { clearStoredUserImage } from "@/lib/actions/preferences";
+
+/**
+ * Compute the 1-2 char initials placeholder displayed when no avatar
+ * image is available (or when the stored OAuth image URL has expired
+ * and is being healed — see `clearStoredUserImage`).
+ *
+ * Exported for tests and any standalone consumer; the main render path
+ * lives inside `<UserAvatar>` below.
+ */
+export function getUserInitials(label: string): string {
+  return label
+    .split(" ")
+    .map((w) => w[0])
+    .filter(Boolean)
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+type UserAvatarProps = {
+  /** Source URL — typically `user.image` from `useAuth()`. */
+  image: string | null | undefined;
+  /** Display name fed to `getUserInitials` for the fallback. */
+  name: string | null | undefined;
+  /** Used as a secondary `getUserInitials` source if `name` is missing. */
+  email?: string | null | undefined;
+  /** Pixel size of the circle (width + height). */
+  size: number;
+  /**
+   * Tailwind font-size class applied to the initials fallback. Both
+   * existing render sites need a different value (desktop `text-xs`,
+   * mobile bottom-bar `text-[10px]`), so it has to be a prop rather
+   * than derived from `size`.
+   */
+  initialsTextClass?: string;
+  /** Extra Tailwind classes appended to the wrapper. */
+  className?: string;
+  /**
+   * Override the default `clearStoredUserImage` server action — exists
+   * for tests, never set in production.
+   */
+  onBrokenImage?: () => Promise<void> | void;
+};
+
+/**
+ * Renders the viewer's avatar with a self-healing fallback to initials.
+ *
+ * - `image` null/empty → initials immediately.
+ * - `image` loads successfully → image.
+ * - `image` non-null but the request fails (404/410/invalid bytes/etc.)
+ *   → swap to initials in the current render AND fire the
+ *   `clearStoredUserImage` server action so the next session refresh
+ *   returns `image: null` and future loads skip the doomed network
+ *   call entirely. See issue #3035 — the symptom is an expired
+ *   LinkedIn signed-photo URL (`media.licdn.com/...?e=<past-epoch>`)
+ *   that the OAuth callback persisted at signup and the row never
+ *   updates back to.
+ *
+ * The healing call fires at most once per component mount per session
+ * (guarded by `healed` state); subsequent re-renders with the same
+ * broken URL won't re-fire even if React re-renders mid-flight.
+ */
+export function UserAvatar({
+  image,
+  name,
+  email,
+  size,
+  initialsTextClass = "text-xs",
+  className,
+  onBrokenImage,
+}: UserAvatarProps) {
+  const [broken, setBroken] = useState(false);
+  const [healed, setHealed] = useState(false);
+
+  const showImage = Boolean(image) && !broken;
+  const initialsSource = name?.trim() || email?.trim() || "?";
+  const initials = getUserInitials(initialsSource);
+
+  function handleError() {
+    setBroken(true);
+    if (healed) return;
+    setHealed(true);
+    // Fire-and-forget — the server action invalidates the session
+    // cache and the next bootstrap refresh returns `image: null`. Any
+    // failure is logged; nothing the UI can do about it.
+    Promise.resolve((onBrokenImage ?? clearStoredUserImage)()).catch(
+      (err) => {
+        console.warn("[UserAvatar] broken-image heal failed", err);
+      },
+    );
+  }
+
+  const wrapperClass = `flex items-center justify-center rounded-full bg-primary font-semibold text-primary-contrast overflow-hidden ${initialsTextClass} ${className ?? ""}`;
+
+  return (
+    <span
+      aria-hidden="true"
+      style={{ width: size, height: size }}
+      className={wrapperClass}
+    >
+      {showImage ? (
+        // User avatars come from arbitrary OAuth providers (Google,
+        // LinkedIn, GitHub, …). next/image remote-host allowlist would
+        // block many of them, so we render raw <img> and rely on the
+        // browser cache + onError fallback below.
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={image as string}
+          alt=""
+          width={size}
+          height={size}
+          style={{ width: size, height: size }}
+          className="rounded-full object-cover"
+          onError={handleError}
+          referrerPolicy="no-referrer"
+          data-testid="user-avatar-img"
+        />
+      ) : (
+        <span data-testid="user-avatar-initials">{initials}</span>
+      )}
+    </span>
+  );
+}

--- a/apps/web/src/components/__tests__/UserAvatar.test.tsx
+++ b/apps/web/src/components/__tests__/UserAvatar.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { UserAvatar, getUserInitials } from "../UserAvatar";
+
+// `UserAvatar` imports `clearStoredUserImage` from the server-actions
+// module, which transitively pulls "server-only" + the Drizzle adapter.
+// We swap in a stub so the test doesn't try to boot the DB; the
+// component's `onBrokenImage` prop is the production-equivalent escape
+// hatch we use to verify the heal call fires.
+vi.mock("@/lib/actions/preferences", () => ({
+  clearStoredUserImage: vi.fn(async () => {}),
+}));
+
+describe("getUserInitials", () => {
+  it("uppercases first letters of the first two words", () => {
+    expect(getUserInitials("Ada Lovelace")).toBe("AL");
+  });
+
+  it("handles a single-word name", () => {
+    expect(getUserInitials("Plato")).toBe("P");
+  });
+
+  it("ignores extra whitespace", () => {
+    expect(getUserInitials("  Marie   Curie  ")).toBe("MC");
+  });
+
+  it("falls back to the literal '?' when label is empty", () => {
+    expect(getUserInitials("?")).toBe("?");
+  });
+});
+
+describe("UserAvatar", () => {
+  it("renders initials when image is null", () => {
+    render(<UserAvatar image={null} name="Ada Lovelace" email="ada@test.com" size={32} />);
+    expect(screen.getByTestId("user-avatar-initials").textContent).toBe("AL");
+    expect(screen.queryByTestId("user-avatar-img")).toBeNull();
+  });
+
+  it("renders image when src is present", () => {
+    render(
+      <UserAvatar
+        image="https://example.com/avatar.png"
+        name="Ada Lovelace"
+        email="ada@test.com"
+        size={32}
+      />,
+    );
+    const img = screen.getByTestId("user-avatar-img") as HTMLImageElement;
+    expect(img.src).toBe("https://example.com/avatar.png");
+  });
+
+  it("falls back to initials on image error and fires the heal callback", async () => {
+    const onBrokenImage = vi.fn(async () => {});
+    render(
+      <UserAvatar
+        image="https://media.licdn.com/expired.jpg?e=1773878400"
+        name="Ada Lovelace"
+        email="ada@test.com"
+        size={32}
+        onBrokenImage={onBrokenImage}
+      />,
+    );
+
+    fireEvent.error(screen.getByTestId("user-avatar-img"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user-avatar-initials").textContent).toBe("AL");
+    });
+    expect(screen.queryByTestId("user-avatar-img")).toBeNull();
+    expect(onBrokenImage).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls the heal callback at most once even if the image errors repeatedly", async () => {
+    const onBrokenImage = vi.fn(async () => {});
+    const { rerender } = render(
+      <UserAvatar
+        image="https://media.licdn.com/expired.jpg?e=1773878400"
+        name="Ada Lovelace"
+        email="ada@test.com"
+        size={32}
+        onBrokenImage={onBrokenImage}
+      />,
+    );
+
+    fireEvent.error(screen.getByTestId("user-avatar-img"));
+    // After the first error the image is unmounted; the only way the
+    // <img> could fire again is a parent re-render that re-mounts it
+    // (e.g. a `key` change). Simulate that.
+    rerender(
+      <UserAvatar
+        image="https://media.licdn.com/expired.jpg?e=1773878400"
+        name="Ada Lovelace"
+        email="ada@test.com"
+        size={32}
+        onBrokenImage={onBrokenImage}
+      />,
+    );
+    // The internal `broken` state survives the re-render with the same
+    // props, so no <img> is re-mounted — the heal call stays at 1.
+    expect(onBrokenImage).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to email when name is missing", () => {
+    render(<UserAvatar image={null} name={null} email="abc@test.com" size={32} />);
+    expect(screen.getByTestId("user-avatar-initials").textContent).toBe("A");
+  });
+
+  it("renders '?' when both name and email are empty", () => {
+    render(<UserAvatar image={null} name="" email="" size={32} />);
+    expect(screen.getByTestId("user-avatar-initials").textContent).toBe("?");
+  });
+});

--- a/apps/web/src/lib/actions/preferences.ts
+++ b/apps/web/src/lib/actions/preferences.ts
@@ -256,6 +256,53 @@ export async function updatePreferences(
   return row;
 }
 
+/**
+ * Null out the current viewer's `user.image` column.
+ *
+ * Called from `UserAvatar`'s `onError` handler when the stored OAuth
+ * avatar URL fails to load. LinkedIn (`media.licdn.com`) signs profile
+ * photos with a time-limited `e=<epoch>` param; once the signature
+ * expires the URL 410s permanently — the image will never come back, so
+ * every subsequent page load was firing a doomed network request and
+ * flashing a broken-image icon. After this action returns, the next
+ * session refresh resolves `user.image` to `null` and the UI cleanly
+ * falls back to the initials placeholder. See issue #3035.
+ *
+ * Self-healing by construction: the only render path that calls this
+ * action is `<img>` with a non-null `src`. Once the row is nulled, no
+ * future render emits the `<img>`, so the action can never re-fire from
+ * the same user-agent on the same row. (A subsequent OAuth re-link
+ * would write a fresh `image` value via Better Auth; that's the only
+ * way back to a non-null state.)
+ *
+ * Best-effort: returns silently on auth-missing / write failure rather
+ * than throwing. The caller is a fire-and-forget client handler; a
+ * thrown promise from a server action turns into a console error with
+ * no UX recovery.
+ */
+export async function clearStoredUserImage(): Promise<void> {
+  const userId = await getSessionUserId();
+  if (!userId) return;
+
+  try {
+    await db
+      .update(user)
+      .set({ image: null, updatedAt: new Date() })
+      .where(eq(user.id, userId));
+  } catch (err) {
+    console.warn("[clearStoredUserImage] db write failed", err);
+    return;
+  }
+
+  // Bust the Redis-cached `getSession()` blob across every device the
+  // user is logged in on, so the next bootstrap fetch returns
+  // `image: null` instead of the just-cleared URL (TTL is 5 min
+  // otherwise). Mirrors the pattern from `renameUsername`. Failures
+  // are logged inside the helper — the DB write is the load-bearing
+  // operation and we already succeeded.
+  await invalidateAllUserSessionCacheEntries(userId);
+}
+
 export async function getPasswordResetCooldown(): Promise<number> {
   const session = await getSession();
   if (!session) return 0;


### PR DESCRIPTION
## Summary

Closes #3035. Fixes the broken profile-image icon for users whose stored OAuth `user.image` URL has expired or otherwise stopped resolving (e.g. an expired LinkedIn signed photo URL with a past `e=<epoch>` query param).

### Strategy: Option 2 (graceful fallback **+** self-heal)

The brief offered two options:
1. Add `onError` fallback only.
2. Also fire a server action that nulls the bad `user.image` in the DB.

**Picked option 2** because LinkedIn (`media.licdn.com`) signed URLs cannot heal themselves — once the `e=<epoch>` is in the past, the URL is permanently dead. Option 1 alone would keep firing a doomed network request on every page load forever (bandwidth, console noise, broken-icon flash before the React `onError` swap). Option 2 makes the broken URL a one-time event:

- On the first `<img>` `onError`, the component swaps to the initials placeholder **and** fires the new `clearStoredUserImage` server action.
- That action nulls `user.image` in the DB and busts every `session:*` Redis blob for the userId via the existing `invalidateAllUserSessionCacheEntries` helper (same pattern as `renameUsername`).
- The next bootstrap refresh resolves `user.image = null`, so future renders skip the `<img>` entirely. Self-healing by construction — no `<img>` means no future `onError`, so the action can never loop.

### Other observations
- Avatar rendering for `user.image` was duplicated across **two** sites in `AppHeader.tsx` (desktop header trigger + mobile bottom bar). Factored into a single `<UserAvatar>` component; both render sites now consume it.
- No other component in `apps/web/src/` reads `user.image` (grepped: only `AppHeader.tsx` was a caller, plus the type definitions in `SessionProvider.tsx` / `bootstrap.ts`).
- The DB schema (`user.image: text("image")`) is already nullable, so the heal-write needs no migration.
- Account settings page does not currently surface the avatar — no third render site to update.

## Test plan

- [x] `pnpm test src/components/__tests__/UserAvatar.test.tsx` — 10 new unit tests cover the happy path, `onError` -> initials swap, the one-shot heal-call guard, and the email/empty-string initials fallbacks.
- [x] Full `pnpm test` — 696 tests pass.
- [x] `pnpm exec tsc --noEmit` — clean.
- [x] `pnpm lint` — clean.
- [x] Playwright reproduction:
  - Pre-fix: desktop header + mobile bottom-bar both show the Chromium broken-image placeholder when the stored URL fails to load.
  - Post-fix: both sites show clean initials. Dropdown trigger + menu both render correctly.
- [ ] Vercel preview: visually inspect the avatar trigger after deploy.

### Screenshots
Saved locally to `/tmp/3035-screenshots/` (not committed):

- `before-desktop-broken.png` — bug: broken-image icon in desktop header
- `before-desktop-broken-dropdown.png` — bug: broken-image icon in dropdown trigger
- `before-mobile-broken.png` — bug: broken-image icon in mobile bottom-bar
- `after-desktop-broken.png` — fix: clean initials in desktop header
- `after-desktop-broken-dropdown.png` — fix: clean initials trigger + dropdown opens
- `after-mobile-broken.png` — fix: clean initials in mobile bottom-bar

The reproduction was forced via Playwright route interception: cookies signed in via `/api/auth/sign-in/email`, then the bootstrap server-action response was rewritten so `user.image` points at the actual broken LinkedIn URL from the bug report, with the host blocked at the network layer to guarantee the failure.

## Tangential issues spotted

- Other `<img>` surfaces (`country-flag.tsx`, blog `MdxMentions.tsx`) don't share this risk — country flags are R2-hosted, mentions use local data. Company logos use `next/image` against the allowlisted `jobseek-assets.colophon-group.org` (always available) with `icons.duckduckgo.com` as fallback (handled by `CompanyIcon.tsx`'s own retry logic).
- Better Auth never refreshes `user.image` on subsequent sign-ins — only the initial OAuth callback writes it. A LinkedIn user who re-links would still receive a fresh URL. Not in scope for this fix, but worth a follow-up if we want avatars to auto-refresh on session renewal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)