### PR TITLE
fix(web): scroll to top on header-nav clicks (closes #3030)

### DIFF
--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -9,6 +9,7 @@ import { ThemeToggleButton } from "@/components/ThemeToggleButton";
 import { LocaleSwitcher } from "@/components/LocaleSwitcher";
 import { ThemedImage } from "@/components/ThemedImage";
 import { useLocalePath } from "@/lib/useLocalePath";
+import { scrollToTopOnNav } from "@/lib/scroll-on-nav";
 import { Button } from "@/components/ui/Button";
 import { Menu } from "lucide-react";
 
@@ -34,7 +35,12 @@ export function Header({ onOpenMobileAction }: HeaderProps) {
   return (
     <header className="border-b border-divider bg-surface-alpha backdrop-blur-md">
       <div className="mx-auto flex h-12 max-w-[1200px] items-center gap-4 px-4">
-        <Link href={lp("/")} prefetch={false} className="inline-flex shrink-0 items-center gap-2">
+        <Link
+          href={lp("/")}
+          prefetch={false}
+          onClick={() => scrollToTopOnNav(lp("/"))}
+          className="inline-flex shrink-0 items-center gap-2"
+        >
           <ThemedImage
             lightSrc={siteConfig.logoWide.light}
             darkSrc={siteConfig.logoWide.dark}
@@ -52,19 +58,19 @@ export function Header({ onOpenMobileAction }: HeaderProps) {
             toward Vercel's edge request quota. Dynamic pages (/explore, /sign-in)
             would trigger full SSR with DB queries on prefetch. */}
         <nav className="hidden items-center gap-5 lg:flex">
-          <Link href={lp(siteConfig.nav.about.href)} prefetch={false} className={navLinkClass} aria-current={ariaCurrent(lp(siteConfig.nav.about.href))}>
+          <Link href={lp(siteConfig.nav.about.href)} prefetch={false} onClick={() => scrollToTopOnNav(siteConfig.nav.about.href)} className={navLinkClass} aria-current={ariaCurrent(lp(siteConfig.nav.about.href))}>
             <Trans id="common.nav.about" comment="Nav link: About">About</Trans>
           </Link>
-          <Link href={lp(siteConfig.nav.features.href)} prefetch={false} className={navLinkClass} aria-current={ariaCurrent(lp(siteConfig.nav.features.href))}>
+          <Link href={lp(siteConfig.nav.features.href)} prefetch={false} onClick={() => scrollToTopOnNav(siteConfig.nav.features.href)} className={navLinkClass} aria-current={ariaCurrent(lp(siteConfig.nav.features.href))}>
             <Trans id="common.nav.features" comment="Nav link: Features">Features</Trans>
           </Link>
-          <Link href={lp(siteConfig.nav.pricing.href)} prefetch={false} className={navLinkClass} aria-current={ariaCurrent(lp(siteConfig.nav.pricing.href))}>
+          <Link href={lp(siteConfig.nav.pricing.href)} prefetch={false} onClick={() => scrollToTopOnNav(siteConfig.nav.pricing.href)} className={navLinkClass} aria-current={ariaCurrent(lp(siteConfig.nav.pricing.href))}>
             <Trans id="common.nav.pricing" comment="Nav link: Pricing">Pricing</Trans>
           </Link>
-          <Link href={lp(siteConfig.nav.faq.href)} prefetch={false} className={navLinkClass} aria-current={ariaCurrent(lp(siteConfig.nav.faq.href))}>
+          <Link href={lp(siteConfig.nav.faq.href)} prefetch={false} onClick={() => scrollToTopOnNav(siteConfig.nav.faq.href)} className={navLinkClass} aria-current={ariaCurrent(lp(siteConfig.nav.faq.href))}>
             <Trans id="common.nav.faq" comment="Nav link: FAQ">FAQ</Trans>
           </Link>
-          <Link href={lp(siteConfig.nav.blog.href)} prefetch={false} className={navLinkClass} aria-current={ariaCurrent(lp(siteConfig.nav.blog.href))}>
+          <Link href={lp(siteConfig.nav.blog.href)} prefetch={false} onClick={() => scrollToTopOnNav(siteConfig.nav.blog.href)} className={navLinkClass} aria-current={ariaCurrent(lp(siteConfig.nav.blog.href))}>
             <Trans id="common.nav.blog" comment="Nav link: Blog">Blog</Trans>
           </Link>
         </nav>

--- a/apps/web/src/components/MobileMenu.tsx
+++ b/apps/web/src/components/MobileMenu.tsx
@@ -9,6 +9,7 @@ import { ThemeToggleButton } from "@/components/ThemeToggleButton";
 import { LocaleSwitcher } from "@/components/LocaleSwitcher";
 import { ThemedImage } from "@/components/ThemedImage";
 import { useLocalePath } from "@/lib/useLocalePath";
+import { scrollToTopOnNav } from "@/lib/scroll-on-nav";
 import { Button } from "@/components/ui/Button";
 import * as Dialog from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
@@ -44,7 +45,7 @@ export function MobileMenu({ open, onCloseAction }: MobileMenuProps) {
               <Link
                 href={lp("/")}
                 prefetch={false}
-                onClick={onCloseAction}
+                onClick={() => { scrollToTopOnNav("/"); onCloseAction(); }}
                 className="inline-flex items-center gap-2 no-underline"
               >
                 <ThemedImage
@@ -73,27 +74,27 @@ export function MobileMenu({ open, onCloseAction }: MobileMenuProps) {
             <nav className="mt-6">
               <ul className="flex flex-col">
                 <li>
-                  <Link href={lp(siteConfig.nav.about.href)} prefetch={false} onClick={onCloseAction} className="block rounded-md px-3 py-2.5 transition-colors hover:bg-border-soft" aria-current={ariaCurrent(lp(siteConfig.nav.about.href))}>
+                  <Link href={lp(siteConfig.nav.about.href)} prefetch={false} onClick={() => { scrollToTopOnNav(siteConfig.nav.about.href); onCloseAction(); }} className="block rounded-md px-3 py-2.5 transition-colors hover:bg-border-soft" aria-current={ariaCurrent(lp(siteConfig.nav.about.href))}>
                     <Trans id="common.nav.about" comment="Nav link: About">About</Trans>
                   </Link>
                 </li>
                 <li>
-                  <Link href={lp(siteConfig.nav.features.href)} prefetch={false} onClick={onCloseAction} className="block rounded-md px-3 py-2.5 transition-colors hover:bg-border-soft" aria-current={ariaCurrent(lp(siteConfig.nav.features.href))}>
+                  <Link href={lp(siteConfig.nav.features.href)} prefetch={false} onClick={() => { scrollToTopOnNav(siteConfig.nav.features.href); onCloseAction(); }} className="block rounded-md px-3 py-2.5 transition-colors hover:bg-border-soft" aria-current={ariaCurrent(lp(siteConfig.nav.features.href))}>
                     <Trans id="common.nav.features" comment="Nav link: Features">Features</Trans>
                   </Link>
                 </li>
                 <li>
-                  <Link href={lp(siteConfig.nav.pricing.href)} prefetch={false} onClick={onCloseAction} className="block rounded-md px-3 py-2.5 transition-colors hover:bg-border-soft" aria-current={ariaCurrent(lp(siteConfig.nav.pricing.href))}>
+                  <Link href={lp(siteConfig.nav.pricing.href)} prefetch={false} onClick={() => { scrollToTopOnNav(siteConfig.nav.pricing.href); onCloseAction(); }} className="block rounded-md px-3 py-2.5 transition-colors hover:bg-border-soft" aria-current={ariaCurrent(lp(siteConfig.nav.pricing.href))}>
                     <Trans id="common.nav.pricing" comment="Nav link: Pricing">Pricing</Trans>
                   </Link>
                 </li>
                 <li>
-                  <Link href={lp(siteConfig.nav.faq.href)} prefetch={false} onClick={onCloseAction} className="block rounded-md px-3 py-2.5 transition-colors hover:bg-border-soft" aria-current={ariaCurrent(lp(siteConfig.nav.faq.href))}>
+                  <Link href={lp(siteConfig.nav.faq.href)} prefetch={false} onClick={() => { scrollToTopOnNav(siteConfig.nav.faq.href); onCloseAction(); }} className="block rounded-md px-3 py-2.5 transition-colors hover:bg-border-soft" aria-current={ariaCurrent(lp(siteConfig.nav.faq.href))}>
                     <Trans id="common.nav.faq" comment="Nav link: FAQ">FAQ</Trans>
                   </Link>
                 </li>
                 <li>
-                  <Link href={lp(siteConfig.nav.blog.href)} prefetch={false} onClick={onCloseAction} className="block rounded-md px-3 py-2.5 transition-colors hover:bg-border-soft" aria-current={ariaCurrent(lp(siteConfig.nav.blog.href))}>
+                  <Link href={lp(siteConfig.nav.blog.href)} prefetch={false} onClick={() => { scrollToTopOnNav(siteConfig.nav.blog.href); onCloseAction(); }} className="block rounded-md px-3 py-2.5 transition-colors hover:bg-border-soft" aria-current={ariaCurrent(lp(siteConfig.nav.blog.href))}>
                     <Trans id="common.nav.blog" comment="Nav link: Blog">Blog</Trans>
                   </Link>
                 </li>

--- a/apps/web/src/lib/__tests__/scroll-on-nav.test.ts
+++ b/apps/web/src/lib/__tests__/scroll-on-nav.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { scrollToTopOnNav } from "../scroll-on-nav";
+
+describe("scrollToTopOnNav", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("scrolls to top when href has no hash", () => {
+    const spy = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+    scrollToTopOnNav("/blog");
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith({ top: 0, left: 0, behavior: "instant" });
+  });
+
+  it("scrolls when href is just a locale-prefixed path", () => {
+    const spy = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+    scrollToTopOnNav("/en/blog");
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT scroll when href contains a hash anchor", () => {
+    const spy = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+    scrollToTopOnNav("/#features");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT scroll when href is a bare hash", () => {
+    const spy = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+    scrollToTopOnNav("#section");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("does NOT scroll when href has hash with query", () => {
+    const spy = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+    scrollToTopOnNav("/page?q=x#anchor");
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/scroll-on-nav.ts
+++ b/apps/web/src/lib/scroll-on-nav.ts
@@ -1,0 +1,21 @@
+// Reset scroll to top synchronously on click, so users see new pages
+// at the top of the viewport even when the route transition takes
+// >100ms (e.g. a Cache Components prerender hit that streams in
+// dynamic data). Without this, the URL flip + new-page commit happens
+// after the network round-trip, and the user briefly sees the new
+// content rendered at the old scroll position before Next's built-in
+// scroll-to-top fires. See #3030.
+//
+// Hash-anchor links (e.g. `/#features`) are skipped — the browser will
+// scroll to the anchor on arrival, and pre-scrolling to top would
+// cause a visible jump-to-top then jump-to-anchor flash.
+//
+// Same-URL clicks (e.g. user is on /blog and clicks the "Blog" header
+// link) also benefit: Next treats those as no-ops, so without this
+// handler the scroll stays wherever the user was.
+
+export function scrollToTopOnNav(href: string): void {
+  if (href.includes("#")) return;
+  if (typeof window === "undefined") return;
+  window.scrollTo({ top: 0, left: 0, behavior: "instant" });
+}


### PR DESCRIPTION
## Summary

- Header / MobileMenu nav links now call `window.scrollTo(0, 0)` synchronously in `onClick`, so the new page lands at the top of the viewport regardless of how long Next.js takes to commit the RSC transition.
- Hash-anchor links (`/#features`, `/#pricing`) are skipped — they keep their native anchor-scroll behavior.
- Same-URL self-clicks (e.g. user on `/blog` clicks the Blog nav link) now also reset scroll — previously they were a no-op because Next treats same-route clicks as no-ops.

## Root cause

Blog / FAQ / About all live under `app/[lang]/(public)/` and share the public layout. When the user clicks a header link, Next App Router does fire its built-in scroll-to-top — but only **after** the new RSC payload arrives and commits. With Cache Components + `cacheLife` on `/blog`, that round-trip can take 100ms+ in dev and over a second in production. During that window the URL has flipped but the new page renders at the user's old scroll position, giving a "didn't reset to z=0" feel.

The fix is at the source of navigation — the header link's `onClick` — so it pre-empts the framework's delayed reset without touching the per-page render path or breaking browser back/forward scroll restoration.

## Empirical observations

Traced scroll position during the transition, source scrolled to `y=600` before clicking the header link (`1280x600` viewport):

| transition | before fix (dev) | before fix (prod jseek.co) | after fix (dev) |
|---|---|---|---|
| `blog -> faq` | `12ms:600 146ms:0` | `11ms:600 219ms:0` | `12ms:600 82ms:0` |
| `faq -> about` | `6ms:600 78ms:0` | `13ms:600 137ms:0` | `6ms:600 75ms:0` |
| `about -> blog` | `10ms:600 103ms:0` | `6ms:600 **1218ms**:0` | `12ms:600 44ms:0` |

The prod `about -> blog` case was the worst — over a full second of visible old scroll on the new page. The header-onClick reset is effectively instant.

Same-URL self-click, before fix:
```
BUG  self-click blog  before=182 after=182
BUG  self-click faq   before=400 after=400
BUG  self-click about before=400 after=400
```
After fix: all `OK  after=0`.

## Test plan

- [x] Six Blog↔FAQ↔About permutations reset scrollY to 0 (screenshots at `/tmp/3030-screenshots/<from>-to-<to>.png`)
- [x] Same-URL self-click on each of `/blog`, `/faq`, `/about` resets scroll
- [x] `/#features` and `/#pricing` from `/en` still land on the anchored element (`scrollY === target`)
- [x] Cross-page hash anchor `/blog -> /#features` still works
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm lint` clean
- [x] `pnpm exec vitest run` — 691 / 691 pass (5 new tests in `scroll-on-nav.test.ts`)
- [ ] Manual smoke once preview deploy is up

## Tangential observations (not fixed in this PR)

- `RelatedPosts.tsx`, `Footer.tsx`, blog-post inline links, the cookie banner "Details" link — none of these have the scroll-reset onClick. The reset-on-route-change problem affects them too in principle, but the issue only flagged the top-nav surface and a narrower fix is safer. A future PR could factor a `NavLink` wrapper if the same complaint surfaces elsewhere.
- `(app)` pages already handle scroll-on-nav in a different way: `explore-content.tsx`, `company-content.tsx`, `watchlist-content.tsx` each have `useEffect(() => window.scrollTo(0, 0))`. That works because those routes are top-level page components (not shared layouts), but it pays one render of old-scroll-on-new-page before the effect fires — the same race that #3030 reports. Issue #3028 ("Watchlist page reset to z=0 on job card opened") looks like the same family of bug for that surface.