### PR TITLE
fix(web): align watchlist year-count filter with active-count (closes #3029)

### DIFF
--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -20,7 +20,7 @@ import { ANON_MAX_WATCHLIST_POSTINGS, COMPANY_BATCH_SIZE } from "@/lib/search/co
 import { expandLocationIds, resolveLocationSlugs } from "@/lib/actions/locations";
 import { expandOccupationIds, resolveOccupationSlugs, resolveSenioritySlugs, resolveTechnologySlugs } from "@/lib/actions/taxonomy";
 import { getSearchClient } from "@/lib/search/typesense-client";
-import { buildFilterString, POSTING_BASE_FILTER } from "@/lib/search/typesense-filters";
+import { buildFilterString, POSTING_BASE_FILTER, POSTING_FLOW_FILTER } from "@/lib/search/typesense-filters";
 import { localesOrNoneClause } from "@/lib/search/pg-filters";
 import {
   upsertWatchlist as tsUpsertWatchlist,
@@ -1110,6 +1110,13 @@ export async function getWatchlistPostings(params: {
  * feed the "N active · M in the last year" stats row on the watchlist
  * view. `per_page: 0` so Typesense returns only the `found` total with
  * no documents — cheap and cacheable.
+ *
+ * Composes with {@link POSTING_FLOW_FILTER} (`has_content:!=false`) so
+ * the year-count stays consistent with the active-count's
+ * {@link POSTING_BASE_FILTER} on the content-quality dimension — see
+ * issue #3029 / follow-up to #2965. Without this, broken/empty
+ * postings inflate the year badge but are correctly hidden from the
+ * active badge, producing visible "active disagrees with year" rows.
  */
 export async function getWatchlistPostingYearCount(params: {
   companyIds: string[];
@@ -1142,7 +1149,7 @@ export async function getWatchlistPostingYearCount(params: {
     const hasKeywords = params.keywords && params.keywords.length > 0;
     const keywordsQ = hasKeywords ? params.keywords!.join(" ") : "*";
     const oneYearAgo = Math.floor((Date.now() - 365 * 24 * 3600 * 1000) / 1000);
-    const parts = [`first_seen_at:>${oneYearAgo}`];
+    const parts = [POSTING_FLOW_FILTER, `first_seen_at:>${oneYearAgo}`];
     if (params.companyIds.length > 0 && params.companyIds.length <= COMPANY_BATCH_SIZE) {
       parts.push(`company_id:[${params.companyIds.join(",")}]`);
     } else if (params.companyIds.length > COMPANY_BATCH_SIZE) {
@@ -1234,7 +1241,11 @@ export async function getWatchlistPostingDisplayCounts(
 
   const oneYearAgo = Math.floor((Date.now() - 365 * 24 * 3600 * 1000) / 1000);
   const activeFilter = baseFilterParts([POSTING_BASE_FILTER]);
-  const yearFilter = baseFilterParts([`first_seen_at:>${oneYearAgo}`]);
+  // Mirror `POSTING_FLOW_FILTER` (#2965) on the year filter so the
+  // year-count stays content-quality-consistent with the active filter
+  // (which already includes `has_content:!=false` via POSTING_BASE_FILTER).
+  // See issue #3029.
+  const yearFilter = baseFilterParts([POSTING_FLOW_FILTER, `first_seen_at:>${oneYearAgo}`]);
 
   try {
     const client = getSearchClient();

--- a/apps/web/src/lib/search/__tests__/typesense-filters.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense-filters.test.ts
@@ -106,12 +106,17 @@ describe("buildFilterString — workMode (#2983)", () => {
 // POSTING_BASE_FILTER. Including `is_active:true` collapses year-count
 // to active-count (an active job, by definition, was first-seen in the
 // past — so the time window selects no extra docs once is_active is on).
+//
+// Also (#3029): apply the same invariant to `actions/watchlists.ts`,
+// where the watchlist-page year-count was constructed without any
+// content-quality clause, inflating the year badge vs the active badge.
 // =====================================================================
 
-describe("year-count badge filters reference POSTING_FLOW_FILTER (#2965)", () => {
+describe("year-count badge filters reference POSTING_FLOW_FILTER (#2965, #3029)", () => {
   const SOURCES = [
     "../typesense.ts",
     "../typesense-browser.ts",
+    "../../actions/watchlists.ts",
   ] as const;
 
   for (const rel of SOURCES) {
@@ -121,8 +126,8 @@ describe("year-count badge filters reference POSTING_FLOW_FILTER (#2965)", () =>
       const lines = src.split("\n");
 
       // Match template-literal substrings starting with `first_seen_at:>`
-      // and ending at the closing backtick on the same line. The four call
-      // sites in #2965 all build the year filter on a single line.
+      // and ending at the closing backtick on the same line. The five call
+      // sites (#2965 + #3029) all build the year filter on a single line.
       const yearFilterLines = lines.filter((line) =>
         line.includes("first_seen_at:>") &&
         // ignore comment-only lines so we don't false-positive on docs


### PR DESCRIPTION
## Root cause

The watchlist page's "N active · M in the last year" stats row was constructing the year-count filter **without any content-quality clause**, while the active-count filter applied `POSTING_BASE_FILTER` (which includes `has_content:!=false`). The two counts then diverged whenever the watchlist matched any postings the exporter had stamped `has_content=false` — broken/empty postings appeared in the year badge but were correctly hidden from the active badge.

This was the missing follow-up to #2965/#2966, which fixed the same class of bug for `typesense.ts` and `typesense-browser.ts` but did not touch `actions/watchlists.ts`. The existing #2965 regression test only scanned the two provider files, so the watchlist-side year-count slipped through the net.

## Fix

Two surfaces:
- `getWatchlistPostingYearCount` (watchlist page initial render, called from `fetchWatchlistPageData`).
- `getWatchlistPostingDisplayCounts` (blog mention card stats, `WatchlistCard` in MDX blog posts).

Both now prepend `POSTING_FLOW_FILTER` (= `has_content:!=false`) to the year-count filter so it stays content-quality-consistent with the active-count's `POSTING_BASE_FILTER`.

Extended the #2965 regression test (`year-count badge filters reference POSTING_FLOW_FILTER`) to scan `actions/watchlists.ts` in addition to `typesense.ts` and `typesense-browser.ts`, so this can't regress.

## Empirical (production Typesense, 2026-05-13, `/en/colophongroup/swe-zurich`)

```
active && has_content:!=false (live)   => 211
first_seen_at:>1y               (bug)  => 400
first_seen_at:>1y && has_content (fix) => 397
```

The 3-doc delta is the broken postings the new clause filters out. The user-reported `396 in the past year` was the buggy 400 a few days earlier — matches normal data drift.

## Note on "active = 0"

The issue title says `active = 0`, but I could not reproduce that exact 0 on production (`211 active` consistently across re-fetches in EN). It's plausible the user saw a transient outlier (Typesense reindex window, or a specific `JSEEK_JOB_LANGUAGES` cookie value such as `["it"]` which legitimately yields 0 active Italian-language postings for that filter). The persistent, reproducible bug is the active-vs-year divergence (#3029 body explicitly cites the 396 number) — fixing the year-count to be consistent with active-count is the correct fix and resolves the visible "numbers disagree" complaint.

## Screenshots

Before (prod, buggy):

![before-stats-row](/tmp/3029-screenshots/before-stats-row.png)
`210 active · 400 in the last year`

After (local, fixed):

![after-stats-row](/tmp/3029-screenshots/after-stats-row.png)
`210 active · 397 in the last year` — year count tightens by the 3 has_content=false postings.

(Screenshots also at `/tmp/3029-screenshots/before-stats-row.png` and `/tmp/3029-screenshots/after-stats-row.png` in the implementer's machine; they show the dark-theme `LanguageStatsRow` from `apps/web/src/components/search/language-stats-row.tsx`.)

## Test plan

- [x] `pnpm exec tsc --noEmit` in `apps/web` — clean (after building `@jseek/mcp-server` which was a pre-existing worktree-only issue).
- [x] `pnpm --filter @jobseek/web test` — 704 tests / 75 files pass, including the new `actions/watchlists.ts` invariant.
- [x] Playwright verification on local dev (port 3001): `211 active · 397 in the last year` matches the empirical Typesense breakdown above.
- [x] Production curl confirmed buggy state still shows `211 active · 400 in the last year`.

## Tangential issues found

None blocking, but a few worth noting for backlog:

1. **`getWatchlistPostingYearCount` has no Postgres fallback.** Unlike `getWatchlistPostings` which falls back to Supabase Postgres on Typesense failure, the year-count silently returns 0 on error. If Typesense is down, users see `N active · 0 in the last year` rather than no stats row at all. Not in scope for #3029, but a candidate for a "decorative stats degrade gracefully" follow-up.
2. **`watchlist.active_job_count` in the watchlist Typesense doc does NOT apply watchlist filters** (sync.py:2225 — counts all is_active postings in watchlist_company, ignoring `anyCompany`, `locationSlugs`, etc.). That's a denormalized field used for sorting/listing in `searchPublicWatchlists`, not for the page itself, so it's not visible to the user — but the same field name in two different scopes is confusing.
3. **#2917's `has_content:!=false` filter relies on the exporter stamping `has_content` correctly.** If a future exporter regression marks all postings `has_content=false`, both `POSTING_BASE_FILTER` and the new `POSTING_FLOW_FILTER` collapse to 0. There's no monitoring alert on the ratio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
