### PR TITLE
fix(web): add work_mode + employment_type to watchlist filter editor (closes #3037)

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
-import { X, Loader2, MapPin, Briefcase, BarChart3, Code2, DollarSign, Clock, Building2, Pencil } from "lucide-react";
+import { X, Loader2, MapPin, Briefcase, BarChart3, Code2, DollarSign, Clock, Building2, Pencil, CalendarDays, Home } from "lucide-react";
 import { BackLink } from "@/components/BackLink";
 import { useLingui } from "@lingui/react/macro";
 import { useLocalePath } from "@/lib/useLocalePath";
@@ -25,7 +25,15 @@ import { WatchlistJobList } from "@/components/watchlist/watchlist-job-list";
 import { FilterPillsReadOnly } from "@/components/search/filter-pills-readonly";
 import { AdvancedSearchPanel } from "@/components/search/advanced-search-panel";
 import type { SelectedLocation } from "@/components/search/location-pills";
-import type { HistogramFilters } from "@/lib/search";
+import type { HistogramFilters, WorkMode } from "@/lib/search";
+
+// Sentinel set used to re-validate the JSONB-stored `workMode` strings
+// before they reach Typesense. The watchlist column accepts arbitrary
+// JSON, so older clients (or hand-written DB writes) could leave
+// garbage here that would otherwise corrupt the `location_types:[…]`
+// filter. Issue #3037 (mirrors the same defensive guard documented on
+// `WatchlistFilters.workMode`).
+const WORK_MODE_VALUES = new Set<WorkMode>(["onsite", "hybrid", "remote"]);
 
 type Company = { id: string; name: string; slug: string; icon: string | null };
 type TaxonomyItem = { id: number; slug: string; name: string };
@@ -160,6 +168,16 @@ export function WatchlistViewPage({
   const [salaryMax, setSalaryMax] = useState<number | undefined>(detail.filters.salaryMax);
   const [experienceMin, setExperienceMin] = useState<number | undefined>(detail.filters.experienceMin);
   const [experienceMax, setExperienceMax] = useState<number | undefined>(detail.filters.experienceMax);
+  // Issue #3037 — close the watchlist/explore filter-parity gap. Both
+  // arrays are seeded defensively: workMode strings come from JSONB so
+  // we re-validate against `WORK_MODE_VALUES` before letting them flow
+  // into Typesense (mirrors the comment on `WatchlistFilters.workMode`),
+  // and employmentType values pass through untouched (handled raw by
+  // `buildFilterString` downstream).
+  const [workMode, setWorkMode] = useState<WorkMode[]>(
+    (detail.filters.workMode ?? []).filter((m): m is WorkMode => WORK_MODE_VALUES.has(m as WorkMode)),
+  );
+  const [employmentTypes, setEmploymentTypes] = useState<string[]>(detail.filters.employmentType ?? []);
 
   const histogramFilters: HistogramFilters = useMemo(() => ({
     locationIds: locations.length > 0 ? locations.map((l) => l.id) : undefined,
@@ -190,6 +208,7 @@ export function WatchlistViewPage({
   function buildFilters(overrides: Partial<{
     kw: string[]; locs: SelectedLocation[]; occs: TaxonomyItem[];
     sens: TaxonomyItem[]; techs: TaxonomyItem[];
+    wm: WorkMode[]; et: string[];
     salCur: string; salMin: number | undefined; salMax: number | undefined;
     expMin: number | undefined; expMax: number | undefined;
     ac: boolean;
@@ -199,6 +218,8 @@ export function WatchlistViewPage({
     const occs = overrides.occs ?? occupations;
     const sens = overrides.sens ?? seniorities;
     const techs = overrides.techs ?? technologies;
+    const wm = overrides.wm ?? workMode;
+    const et = overrides.et ?? employmentTypes;
     const ac = overrides.ac ?? anyCompany;
     return {
       keywords: kw.length > 0 ? kw : undefined,
@@ -206,6 +227,8 @@ export function WatchlistViewPage({
       occupationSlugs: occs.length > 0 ? occs.map((o) => o.slug) : undefined,
       senioritySlugs: sens.length > 0 ? sens.map((s) => s.slug) : undefined,
       technologySlugs: techs.length > 0 ? techs.map((t) => t.slug) : undefined,
+      workMode: wm.length > 0 ? wm : undefined,
+      employmentType: et.length > 0 ? et : undefined,
       salaryCurrency: overrides.salCur ?? salaryCurrency,
       salaryMin: overrides.salMin !== undefined ? overrides.salMin : salaryMin,
       salaryMax: overrides.salMax !== undefined ? overrides.salMax : salaryMax,
@@ -261,6 +284,20 @@ export function WatchlistViewPage({
     setTechnologies(next);
     persistFilters(buildFilters({ techs: next }));
   }
+  function onToggleEmploymentType(type: string) {
+    const next = employmentTypes.includes(type)
+      ? employmentTypes.filter((t) => t !== type)
+      : [...employmentTypes, type];
+    setEmploymentTypes(next);
+    persistFilters(buildFilters({ et: next }));
+  }
+  function onToggleWorkMode(mode: WorkMode) {
+    const next = workMode.includes(mode)
+      ? workMode.filter((m) => m !== mode)
+      : [...workMode, mode];
+    setWorkMode(next);
+    persistFilters(buildFilters({ wm: next }));
+  }
   function onSalaryChange(currency: string, min: number | undefined, max: number | undefined) {
     setSalaryCurrency(currency);
     setSalaryMin(min);
@@ -278,6 +315,8 @@ export function WatchlistViewPage({
     setOccupations([]);
     setSeniorities([]);
     setTechnologies([]);
+    setWorkMode([]);
+    setEmploymentTypes([]);
     setSalaryMin(undefined);
     setSalaryMax(undefined);
     setExperienceMin(undefined);
@@ -291,6 +330,8 @@ export function WatchlistViewPage({
     occupations.length > 0 ||
     seniorities.length > 0 ||
     technologies.length > 0 ||
+    workMode.length > 0 ||
+    employmentTypes.length > 0 ||
     salaryMin != null ||
     salaryMax != null ||
     experienceMin != null ||
@@ -491,6 +532,10 @@ export function WatchlistViewPage({
               onRemoveSeniority={onRemoveSeniority}
               onAddTechnology={onAddTechnology}
               onRemoveTechnology={onRemoveTechnology}
+              employmentTypes={employmentTypes}
+              onToggleEmploymentType={onToggleEmploymentType}
+              workMode={workMode}
+              onToggleWorkMode={onToggleWorkMode}
               onSalaryChange={onSalaryChange}
               onExperienceChange={onExperienceChange}
               histogramFilters={histogramFilters}
@@ -516,6 +561,24 @@ export function WatchlistViewPage({
                     <Code2 size={12} className="shrink-0" />
                     {tech.name}
                     <button onClick={() => onRemoveTechnology(tech.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"><X size={12} /></button>
+                  </span>
+                ))}
+                {employmentTypes.map((et) => (
+                  <span key={`et-${et}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm capitalize text-primary">
+                    <CalendarDays size={12} className="shrink-0" />
+                    {et.replace(/_/g, " ")}
+                    <button onClick={() => onToggleEmploymentType(et)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"><X size={12} /></button>
+                  </span>
+                ))}
+                {workMode.map((wm) => (
+                  <span key={`wm-${wm}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
+                    <Home size={12} className="shrink-0" />
+                    {wm === "onsite"
+                      ? t({ id: "search.workMode.onsite", comment: "Work mode: onsite (in-office)", message: "On-site" })
+                      : wm === "hybrid"
+                        ? t({ id: "search.workMode.hybrid", comment: "Work mode: hybrid (mixed onsite/remote)", message: "Hybrid" })
+                        : t({ id: "search.workMode.remote", comment: "Work mode: remote (work-from-home)", message: "Remote" })}
+                    <button onClick={() => onToggleWorkMode(wm)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"><X size={12} /></button>
                   </span>
                 ))}
                 {(salaryMin != null || salaryMax != null) && (
@@ -562,6 +625,10 @@ export function WatchlistViewPage({
             occupations={resolvedOccupations}
             seniorities={resolvedSeniorities}
             technologies={resolvedTechnologies}
+            workMode={
+              (detail.filters.workMode ?? []).filter((m): m is WorkMode => WORK_MODE_VALUES.has(m as WorkMode))
+            }
+            employmentType={detail.filters.employmentType}
           />
         )}
       </div>
@@ -579,6 +646,8 @@ export function WatchlistViewPage({
           occupationIds: occupations.length > 0 ? occupations.map((o) => o.id) : undefined,
           seniorityIds: seniorities.length > 0 ? seniorities.map((s) => s.id) : undefined,
           technologyIds: technologies.length > 0 ? technologies.map((t) => t.id) : undefined,
+          workMode: workMode.length > 0 ? workMode : undefined,
+          employmentType: employmentTypes.length > 0 ? employmentTypes : undefined,
           salaryMin,
           salaryMax,
           experienceMin,

--- a/apps/web/src/components/search/filter-pills-readonly.tsx
+++ b/apps/web/src/components/search/filter-pills-readonly.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MapPin, Briefcase, BarChart3, Code2, DollarSign, Clock, Home } from "lucide-react";
+import { MapPin, Briefcase, BarChart3, Code2, DollarSign, Clock, Home, CalendarDays } from "lucide-react";
 import type { WatchlistFilters } from "@/lib/actions/watchlists";
 import type { SelectedLocation } from "@/components/search/location-pills";
 import type { WorkMode } from "@/lib/search/types";
@@ -20,6 +20,7 @@ export function FilterPillsReadOnly({
   seniorities,
   technologies,
   workMode,
+  employmentType,
 }: {
   filters: WatchlistFilters;
   locations?: SelectedLocation[];
@@ -27,12 +28,20 @@ export function FilterPillsReadOnly({
   seniorities?: TaxonomyItem[];
   technologies?: TaxonomyItem[];
   /**
-   * Optional work-mode filter slugs to render as read-only pills
-   * (issue #2983). The watchlist filter shape doesn't yet persist
-   * work-mode, but the prop is accepted now so the explore-page
-   * "save snapshot" view can show it.
+   * Work-mode pills (issue #2983). The watchlist filter shape persists
+   * `workMode` on `WatchlistFilters`; callers may either pass the
+   * already-validated array here, or rely on `filters.workMode` if they
+   * have re-validated it themselves. We accept both so the explore-page
+   * "save snapshot" view (which only has the in-memory array, not a
+   * persisted filter row) can render too.
    */
   workMode?: WorkMode[];
+  /**
+   * Employment-type pills (issue #3037). Same defensive pattern as
+   * workMode — callers either pre-validate and pass it, or omit and
+   * fall back to `filters.employmentType`.
+   */
+  employmentType?: string[];
 }) {
   const pills: { key: string; icon: React.ReactNode; label: string }[] = [];
 
@@ -78,6 +87,20 @@ export function FilterPillsReadOnly({
   } else if (filters.technologySlugs?.length) {
     for (const slug of filters.technologySlugs) {
       pills.push({ key: `tech-${slug}`, icon: <Code2 size={12} />, label: slug });
+    }
+  }
+  const effectiveEmploymentType = employmentType ?? filters.employmentType;
+  if (effectiveEmploymentType && effectiveEmploymentType.length > 0) {
+    for (const et of effectiveEmploymentType) {
+      pills.push({
+        key: `et-${et}`,
+        icon: <CalendarDays size={12} />,
+        // Same display rule as search-toolbar pills: replace underscores
+        // and rely on Tailwind `capitalize` if the consumer wants — we
+        // keep it lowercase here to match the unfiltered text rendering
+        // and avoid mismatches with the localised labels in the modal.
+        label: et.replace(/_/g, " "),
+      });
     }
   }
   if (workMode && workMode.length > 0) {

--- a/apps/web/src/components/watchlist/watchlist-filter-editor.tsx
+++ b/apps/web/src/components/watchlist/watchlist-filter-editor.tsx
@@ -1,9 +1,28 @@
 "use client";
 
 import { useState } from "react";
-import { X, Plus, Check, Loader2, MapPin, Briefcase, Award, Cpu, DollarSign, Clock } from "lucide-react";
+import { X, Plus, Check, Loader2, MapPin, Briefcase, Award, Cpu, DollarSign, Clock, Home, CalendarDays } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import type { WatchlistFilters } from "@/lib/actions/watchlists";
+import type { WorkMode } from "@/lib/search/types";
+
+// Closed sets for the two enum-shaped filters added in issue #3037.
+// Defining them client-side mirrors the Typesense canonical values and
+// keeps the editor decoupled from server-only modules.
+const WORK_MODE_OPTIONS: { value: WorkMode; labelKey: string; fallback: string }[] = [
+  { value: "onsite", labelKey: "search.workMode.onsite", fallback: "On-site" },
+  { value: "hybrid", labelKey: "search.workMode.hybrid", fallback: "Hybrid" },
+  { value: "remote", labelKey: "search.workMode.remote", fallback: "Remote" },
+];
+
+const EMPLOYMENT_TYPE_OPTIONS: { value: string; labelKey: string; fallback: string }[] = [
+  { value: "full_time", labelKey: "search.employmentType.fullTime", fallback: "Full-time" },
+  { value: "part_time", labelKey: "search.employmentType.partTime", fallback: "Part-time" },
+  { value: "contract", labelKey: "search.employmentType.contract", fallback: "Contract" },
+  { value: "internship", labelKey: "search.employmentType.internship", fallback: "Internship" },
+  { value: "temporary", labelKey: "search.employmentType.temporary", fallback: "Temporary" },
+  { value: "volunteer", labelKey: "search.employmentType.volunteer", fallback: "Volunteer" },
+];
 
 function FilterPill({
   icon,
@@ -29,7 +48,7 @@ function FilterPill({
   );
 }
 
-type AddingType = "keyword" | "location" | "occupation" | "seniority" | "technology" | null;
+type AddingType = "keyword" | "location" | "occupation" | "seniority" | "technology" | "workMode" | "employmentType" | null;
 
 export function WatchlistFilterEditor({
   filters,
@@ -74,6 +93,16 @@ export function WatchlistFilterEditor({
       technologySlugs: (filters.technologySlugs ?? []).filter((s) => s !== slug),
     });
   }
+  function toggleWorkMode(mode: WorkMode) {
+    const cur = filters.workMode ?? [];
+    const next = cur.includes(mode) ? cur.filter((m) => m !== mode) : [...cur, mode];
+    onChange({ ...filters, workMode: next.length > 0 ? next : undefined });
+  }
+  function toggleEmploymentType(type: string) {
+    const cur = filters.employmentType ?? [];
+    const next = cur.includes(type) ? cur.filter((t) => t !== type) : [...cur, type];
+    onChange({ ...filters, employmentType: next.length > 0 ? next : undefined });
+  }
   function removeSalary() {
     onChange({
       ...filters,
@@ -91,6 +120,15 @@ export function WatchlistFilterEditor({
   }
 
   function submitInput() {
+    // workMode / employmentType use chip-toggle UI, not the free-text
+    // input — short-circuit here so an accidental Enter on the input
+    // while one of those tabs is active doesn't append the raw string
+    // as a slug.
+    if (adding === "workMode" || adding === "employmentType") {
+      setInputValue("");
+      setAdding(null);
+      return;
+    }
     const val = inputValue.trim();
     if (!val || !adding) return;
 
@@ -123,6 +161,8 @@ export function WatchlistFilterEditor({
     (filters.occupationSlugs?.length ?? 0) > 0 ||
     (filters.senioritySlugs?.length ?? 0) > 0 ||
     (filters.technologySlugs?.length ?? 0) > 0 ||
+    (filters.workMode?.length ?? 0) > 0 ||
+    (filters.employmentType?.length ?? 0) > 0 ||
     filters.salaryMin != null ||
     filters.salaryMax != null ||
     filters.experienceMin != null ||
@@ -134,6 +174,8 @@ export function WatchlistFilterEditor({
     { type: "occupation", icon: <Briefcase size={12} />, label: t({ id: "watchlists.filters.occupation", comment: "Add occupation filter", message: "Occupation" }) },
     { type: "seniority", icon: <Award size={12} />, label: t({ id: "watchlists.filters.seniority", comment: "Add seniority filter", message: "Seniority" }) },
     { type: "technology", icon: <Cpu size={12} />, label: t({ id: "watchlists.filters.technology", comment: "Add technology filter", message: "Technology" }) },
+    { type: "employmentType", icon: <CalendarDays size={12} />, label: t({ id: "watchlists.filters.employmentType", comment: "Add employment type filter", message: "Type" }) },
+    { type: "workMode", icon: <Home size={12} />, label: t({ id: "watchlists.filters.workMode", comment: "Add work-mode (onsite/hybrid/remote) filter", message: "Work mode" }) },
   ];
 
   return (
@@ -163,6 +205,24 @@ export function WatchlistFilterEditor({
         ))}
         {filters.technologySlugs?.map((slug) => (
           <FilterPill key={`tech-${slug}`} icon={<Cpu size={12} />} label={slug} onRemove={() => removeTechnology(slug)} />
+        ))}
+        {filters.employmentType?.map((type) => (
+          <FilterPill
+            key={`et-${type}`}
+            icon={<CalendarDays size={12} />}
+            label={
+              EMPLOYMENT_TYPE_OPTIONS.find((o) => o.value === type)?.fallback ?? type.replace(/_/g, " ")
+            }
+            onRemove={() => toggleEmploymentType(type)}
+          />
+        ))}
+        {filters.workMode?.map((mode) => (
+          <FilterPill
+            key={`wm-${mode}`}
+            icon={<Home size={12} />}
+            label={WORK_MODE_OPTIONS.find((o) => o.value === mode)?.fallback ?? mode}
+            onRemove={() => toggleWorkMode(mode as WorkMode)}
+          />
         ))}
         {(filters.salaryMin != null || filters.salaryMax != null) && (
           <FilterPill
@@ -228,40 +288,76 @@ export function WatchlistFilterEditor({
             ))}
           </div>
 
-          {/* Value input */}
-          <div className="flex items-center gap-1">
-            <input
-              type="text"
-              value={inputValue}
-              onChange={(e) => setInputValue(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter") submitInput();
-                if (e.key === "Escape") { setAdding(null); setInputValue(""); }
-              }}
-              placeholder={t({
-                id: "watchlists.filters.inputPlaceholder",
-                comment: "Placeholder for filter value input",
-                message: "Type slug and press Enter",
+          {/* Value input — chip-toggle for enum filters, text for slugs */}
+          {adding === "workMode" || adding === "employmentType" ? (
+            <div className="flex flex-wrap items-center gap-1">
+              {(adding === "workMode" ? WORK_MODE_OPTIONS : EMPLOYMENT_TYPE_OPTIONS).map((opt) => {
+                const isActive =
+                  adding === "workMode"
+                    ? (filters.workMode ?? []).includes(opt.value as WorkMode)
+                    : (filters.employmentType ?? []).includes(opt.value);
+                const onClick =
+                  adding === "workMode"
+                    ? () => toggleWorkMode(opt.value as WorkMode)
+                    : () => toggleEmploymentType(opt.value);
+                return (
+                  <button
+                    key={opt.value}
+                    type="button"
+                    onClick={onClick}
+                    className={`rounded-full border px-2.5 py-1 text-xs transition-colors cursor-pointer ${
+                      isActive
+                        ? "border-primary bg-primary/10 text-primary"
+                        : "border-border-soft text-muted hover:border-primary/30 hover:text-foreground"
+                    }`}
+                  >
+                    {t({ id: opt.labelKey, comment: "Filter option label", message: opt.fallback })}
+                  </button>
+                );
               })}
-              autoFocus
-              className="w-40 rounded-md border border-border-soft bg-transparent px-2 py-1 text-sm outline-none focus:border-primary placeholder:text-muted"
-            />
-            <button
-              type="button"
-              onClick={submitInput}
-              disabled={!inputValue.trim()}
-              className="rounded-md p-1 text-muted transition-colors hover:text-foreground disabled:opacity-40 cursor-pointer"
-            >
-              <Check size={14} />
-            </button>
-            <button
-              type="button"
-              onClick={() => { setAdding(null); setInputValue(""); }}
-              className="rounded-md p-1 text-muted transition-colors hover:text-foreground cursor-pointer"
-            >
-              <X size={14} />
-            </button>
-          </div>
+              <button
+                type="button"
+                onClick={() => { setAdding(null); setInputValue(""); }}
+                className="rounded-md p-1 text-muted transition-colors hover:text-foreground cursor-pointer"
+              >
+                <X size={14} />
+              </button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-1">
+              <input
+                type="text"
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") submitInput();
+                  if (e.key === "Escape") { setAdding(null); setInputValue(""); }
+                }}
+                placeholder={t({
+                  id: "watchlists.filters.inputPlaceholder",
+                  comment: "Placeholder for filter value input",
+                  message: "Type slug and press Enter",
+                })}
+                autoFocus
+                className="w-40 rounded-md border border-border-soft bg-transparent px-2 py-1 text-sm outline-none focus:border-primary placeholder:text-muted"
+              />
+              <button
+                type="button"
+                onClick={submitInput}
+                disabled={!inputValue.trim()}
+                className="rounded-md p-1 text-muted transition-colors hover:text-foreground disabled:opacity-40 cursor-pointer"
+              >
+                <Check size={14} />
+              </button>
+              <button
+                type="button"
+                onClick={() => { setAdding(null); setInputValue(""); }}
+                className="rounded-md p-1 text-muted transition-colors hover:text-foreground cursor-pointer"
+              >
+                <X size={14} />
+              </button>
+            </div>
+          )}
         </div>
       )}
 

--- a/apps/web/src/components/watchlist/watchlist-job-list.tsx
+++ b/apps/web/src/components/watchlist/watchlist-job-list.tsx
@@ -29,6 +29,10 @@ export interface WatchlistJobListFilters {
   occupationIds?: number[];
   seniorityIds?: number[];
   technologyIds?: number[];
+  /** Work-mode filter — `onsite | hybrid | remote` (issue #3037). */
+  workMode?: ("onsite" | "hybrid" | "remote")[];
+  /** Employment-type filter (issue #3037). */
+  employmentType?: string[];
   salaryMin?: number;
   salaryMax?: number;
   experienceMin?: number;

--- a/apps/web/src/lib/actions/watchlist-page-data.ts
+++ b/apps/web/src/lib/actions/watchlist-page-data.ts
@@ -93,6 +93,13 @@ export async function fetchWatchlistPageData(params: {
     .map((slug) => techMap.get(slug))
     .filter((t): t is NonNullable<typeof t> => t != null);
 
+  // Re-validate workMode strings before letting them flow into the
+  // Typesense filter — JSONB column means we can't trust the shape.
+  // Mirrors the same guard in the client-side editor (issue #3037).
+  const WORK_MODE_VALUES = new Set(["onsite", "hybrid", "remote"] as const);
+  const validatedWorkMode = (filters.workMode ?? []).filter(
+    (m): m is "onsite" | "hybrid" | "remote" => WORK_MODE_VALUES.has(m),
+  );
   const sharedCountsParams = {
     companyIds: filters.anyCompany ? [] : detail.companies.map((c) => c.id),
     anyCompany: filters.anyCompany,
@@ -101,6 +108,8 @@ export async function fetchWatchlistPageData(params: {
     occupationIds: resolvedOccupations.map((o) => o.id),
     seniorityIds: resolvedSeniorities.map((s) => s.id),
     technologyIds: resolvedTechnologies.map((t) => t.id),
+    workMode: validatedWorkMode.length > 0 ? validatedWorkMode : undefined,
+    employmentType: filters.employmentType?.length ? filters.employmentType : undefined,
     salaryMin: filters.salaryMin,
     salaryMax: filters.salaryMax,
     experienceMin: filters.experienceMin,

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -47,6 +47,18 @@ export type WatchlistFilters = {
    * legacy garbage from older client versions).
    */
   workMode?: ("onsite" | "hybrid" | "remote")[];
+  /**
+   * Employment-type filter — `full_time | part_time | contract |
+   * internship | temporary | volunteer`. Issue #3037 — closes the
+   * parity gap between this watchlist editor and the explore page's
+   * `AdvancedSearchPanel`. Same backwards-compat shape as `workMode`:
+   * missing on legacy rows ⇒ undefined ⇒ no filter applied. The
+   * column is JSONB and untrusted at read time; downstream consumers
+   * forward values straight into Typesense `filter_by` so any future
+   * sanitisation must live in `buildFilterString` (already accepts
+   * `employmentTypes`).
+   */
+  employmentType?: string[];
   salaryMin?: number;
   salaryMax?: number;
   salaryCurrency?: string;
@@ -809,6 +821,8 @@ function buildFilterCacheKey(f: WatchlistFilters, companyIds: string[]): string 
   if (f.occupationSlugs?.length) parts.push(`occ:${[...f.occupationSlugs].sort().join(",")}`);
   if (f.senioritySlugs?.length) parts.push(`sen:${[...f.senioritySlugs].sort().join(",")}`);
   if (f.technologySlugs?.length) parts.push(`tech:${[...f.technologySlugs].sort().join(",")}`);
+  if (f.workMode?.length) parts.push(`wm:${[...f.workMode].sort().join(",")}`);
+  if (f.employmentType?.length) parts.push(`et:${[...f.employmentType].sort().join(",")}`);
   if (f.salaryMin != null) parts.push(`smin:${f.salaryMin}`);
   if (f.salaryMax != null) parts.push(`smax:${f.salaryMax}`);
   if (f.experienceMin != null) parts.push(`emin:${f.experienceMin}`);
@@ -841,6 +855,8 @@ export async function getWatchlistMatchingCompanyCount(
       occupationIds: occMap.size > 0 ? [...occMap.values()].map((o) => o.id) : undefined,
       seniorityIds: senMap.size > 0 ? [...senMap.values()].map((s) => s.id) : undefined,
       technologyIds: techMap.size > 0 ? [...techMap.values()].map((t) => t.id) : undefined,
+      workMode: f.workMode?.length ? f.workMode : undefined,
+      employmentTypes: f.employmentType?.length ? f.employmentType : undefined,
       salaryMinEur: f.salaryMin,
       salaryMaxEur: f.salaryMax,
       experienceMin: f.experienceMin,
@@ -903,6 +919,8 @@ async function resolveFilteredJobCount(
       occupationIds: occMap.size > 0 ? [...occMap.values()].map((o) => o.id) : undefined,
       seniorityIds: senMap.size > 0 ? [...senMap.values()].map((s) => s.id) : undefined,
       technologyIds: techMap.size > 0 ? [...techMap.values()].map((t) => t.id) : undefined,
+      workMode: f.workMode?.length ? f.workMode : undefined,
+      employmentType: f.employmentType?.length ? f.employmentType : undefined,
       salaryMin: f.salaryMin,
       salaryMax: f.salaryMax,
       experienceMin: f.experienceMin,
@@ -1077,6 +1095,13 @@ export async function getWatchlistPostings(params: {
   occupationIds?: number[];
   seniorityIds?: number[];
   technologyIds?: number[];
+  /** Work-mode filter — `onsite | hybrid | remote` (issue #3037). */
+  workMode?: ("onsite" | "hybrid" | "remote")[];
+  /** Employment-type filter (issue #3037). Untyped because legacy
+   * documents may carry strings outside the canonical six; downstream
+   * `buildFilterString` joins values raw, so any sanitisation must
+   * happen there. */
+  employmentType?: string[];
   salaryMin?: number;
   salaryMax?: number;
   experienceMin?: number;
@@ -1119,6 +1144,8 @@ export async function getWatchlistPostingYearCount(params: {
   occupationIds?: number[];
   seniorityIds?: number[];
   technologyIds?: number[];
+  workMode?: ("onsite" | "hybrid" | "remote")[];
+  employmentType?: string[];
   salaryMin?: number;
   salaryMax?: number;
   experienceMin?: number;
@@ -1133,6 +1160,8 @@ export async function getWatchlistPostingYearCount(params: {
       occupationIds: params.occupationIds,
       seniorityIds: params.seniorityIds,
       technologyIds: params.technologyIds,
+      workMode: params.workMode?.length ? params.workMode : undefined,
+      employmentTypes: params.employmentType?.length ? params.employmentType : undefined,
       salaryMinEur: params.salaryMin,
       salaryMaxEur: params.salaryMax,
       experienceMin: params.experienceMin,
@@ -1498,6 +1527,8 @@ async function _getWatchlistPostingsTypesense(
     occupationIds?: number[];
     seniorityIds?: number[];
     technologyIds?: number[];
+    workMode?: ("onsite" | "hybrid" | "remote")[];
+    employmentType?: string[];
     salaryMin?: number;
     salaryMax?: number;
     experienceMin?: number;
@@ -1516,6 +1547,8 @@ async function _getWatchlistPostingsTypesense(
     occupationIds: params.occupationIds,
     seniorityIds: params.seniorityIds,
     technologyIds: params.technologyIds,
+    workMode: params.workMode?.length ? params.workMode : undefined,
+    employmentTypes: params.employmentType?.length ? params.employmentType : undefined,
     salaryMinEur: params.salaryMin,
     salaryMaxEur: params.salaryMax,
     experienceMin: params.experienceMin,
@@ -1590,6 +1623,8 @@ async function _getWatchlistPostingsBatched(
     occupationIds?: number[];
     seniorityIds?: number[];
     technologyIds?: number[];
+    workMode?: ("onsite" | "hybrid" | "remote")[];
+    employmentType?: string[];
     salaryMin?: number;
     salaryMax?: number;
     experienceMin?: number;
@@ -1606,6 +1641,8 @@ async function _getWatchlistPostingsBatched(
     occupationIds: params.occupationIds,
     seniorityIds: params.seniorityIds,
     technologyIds: params.technologyIds,
+    workMode: params.workMode?.length ? params.workMode : undefined,
+    employmentTypes: params.employmentType?.length ? params.employmentType : undefined,
     salaryMinEur: params.salaryMin,
     salaryMaxEur: params.salaryMax,
     experienceMin: params.experienceMin,
@@ -1703,6 +1740,8 @@ async function _getWatchlistPostingsPostgres(
     occupationIds?: number[];
     seniorityIds?: number[];
     technologyIds?: number[];
+    workMode?: ("onsite" | "hybrid" | "remote")[];
+    employmentType?: string[];
     salaryMin?: number;
     salaryMax?: number;
     experienceMin?: number;
@@ -1759,6 +1798,19 @@ async function _getWatchlistPostingsPostgres(
   if (params.technologyIds && params.technologyIds.length > 0) {
     const pgArr = `{${params.technologyIds.join(",")}}`;
     clauses.push(sql`jp.technology_ids && ${pgArr}::integer[]`);
+  }
+  if (params.workMode && params.workMode.length > 0) {
+    // `location_types` is `text[]`. Use && (array overlap) to mirror
+    // Typesense `location_types:[a,b]` (OR semantics across values).
+    // Postings with NULL/empty `location_types` (~0.9% of active on
+    // 2026-05-09) drop out silently — matches the Typesense path.
+    const pgArr = `{${params.workMode.join(",")}}`;
+    clauses.push(sql`jp.location_types && ${pgArr}::text[]`);
+  }
+  if (params.employmentType && params.employmentType.length > 0) {
+    // `employment_type` is a single text column — use `= ANY(...)`.
+    const pgArr = `{${params.employmentType.join(",")}}`;
+    clauses.push(sql`jp.employment_type = ANY(${pgArr}::text[])`);
   }
   if (params.salaryMin != null && params.salaryMax != null) {
     clauses.push(sql`jp.salary_eur BETWEEN ${params.salaryMin} AND ${params.salaryMax}`);

--- a/apps/web/src/lib/search/search-runner.ts
+++ b/apps/web/src/lib/search/search-runner.ts
@@ -105,6 +105,10 @@ type WatchlistPostingsInput = {
   occupationIds?: number[];
   seniorityIds?: number[];
   technologyIds?: number[];
+  /** Work-mode filter — `onsite | hybrid | remote` (issue #3037). */
+  workMode?: ("onsite" | "hybrid" | "remote")[];
+  /** Employment-type filter (issue #3037). */
+  employmentType?: string[];
   salaryMin?: number;
   salaryMax?: number;
   experienceMin?: number;

--- a/apps/web/src/lib/search/typesense-browser-watchlist.ts
+++ b/apps/web/src/lib/search/typesense-browser-watchlist.ts
@@ -69,6 +69,10 @@ export interface WatchlistPostingsParams {
   occupationIds?: number[];
   seniorityIds?: number[];
   technologyIds?: number[];
+  /** Work-mode filter — `onsite | hybrid | remote` (issue #3037). */
+  workMode?: ("onsite" | "hybrid" | "remote")[];
+  /** Employment-type filter (issue #3037). */
+  employmentType?: string[];
   salaryMin?: number;
   salaryMax?: number;
   experienceMin?: number;
@@ -100,6 +104,8 @@ export async function getWatchlistPostingsBrowser(
     occupationIds: params.occupationIds,
     seniorityIds: params.seniorityIds,
     technologyIds: params.technologyIds,
+    workMode: params.workMode?.length ? params.workMode : undefined,
+    employmentTypes: params.employmentType?.length ? params.employmentType : undefined,
     salaryMinEur: params.salaryMin,
     salaryMaxEur: params.salaryMax,
     experienceMin: params.experienceMin,


### PR DESCRIPTION
The watchlist owner-edit `AdvancedSearchPanel` was missing the work-mode and employment-type filter buttons because the host page never passed the corresponding callbacks. Wires `onToggleWorkMode` / `onToggleEmploymentType` through, persists `workMode` + `employmentType` on `WatchlistFilters` (already typed for `workMode` under #2983; `employmentType` is new), and forwards them through Typesense + Postgres + browser query paths so the result list and active/year counts react to the new filters.

The non-owner `FilterPillsReadOnly` view, the watchlist-page-data seeder, the year-count action, the cache key, and the alternate inline `WatchlistFilterEditor` (chip-toggle UI for the two enum-shaped filters) all get the same treatment so the two new fields behave consistently end-to-end.

Screenshots attached locally at `/tmp/3037-screenshots/` (before/after for full page, expanded filters, work-mode modal, applied filters, persisted state after reload, read-only pills).

Closes #3037.

🤖 Generated with [Claude Code](https://claude.com/claude-code)