### PR TITLE
fix(web): enforce watchlist limits with proper UX cues (closes #3036)

### DIFF
--- a/apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { getUserWatchlists, type WatchlistSummary } from "@/lib/actions/watchlists";
+import { getUserWatchlistsWithLimit, type WatchlistSummary } from "@/lib/actions/watchlists";
 import { useSession } from "@/components/SessionProvider";
 import { WatchlistsPage } from "./watchlists-page";
 
@@ -21,11 +21,15 @@ export function WatchlistsLoader({ locale }: { locale: string }) {
       setData({ watchlists: [], username: null, limitReached: true });
       return;
     }
-    getUserWatchlists(locale).then((watchlists) => {
+    // Issue #3036: previously hardcoded ``limitReached: false`` here,
+    // which left ``CreateWatchlistCard`` permanently enabled even for
+    // users at the plan limit. Server now returns both so the card
+    // surfaces its disabled state + upgrade modal correctly.
+    getUserWatchlistsWithLimit(locale).then(({ watchlists, limitReached }) => {
       setData({
         watchlists,
         username: user.username ?? null,
-        limitReached: false,
+        limitReached,
       });
     });
   }, [user, isPending, locale]);

--- a/apps/web/app/[lang]/(app)/watchlists/watchlists-page.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/watchlists-page.tsx
@@ -10,6 +10,7 @@ import type { WatchlistSummary, WatchlistFilters } from "@/lib/actions/watchlist
 import { createWatchlist } from "@/lib/actions/watchlists";
 import { WatchlistCard, CreateWatchlistCard } from "@/components/watchlist/watchlist-card";
 import { PublicWatchlistSearch } from "@/components/watchlist/public-watchlist-search";
+import { UpgradeModal, useUpgradeModal } from "@/components/ui/upgrade-modal";
 import { Button } from "@/components/ui/Button";
 
 export function WatchlistsPage({
@@ -27,11 +28,24 @@ export function WatchlistsPage({
   const { user, isLoggedIn } = useAuth();
   const searchParams = useSearchParams();
   const [creating, setCreating] = useState(false);
+  const upgrade = useUpgradeModal();
+
+  function showLimitUpgrade() {
+    upgrade.show(t({
+      id: "upgrade.reason.watchlistLimit",
+      comment: "Reason shown in upgrade modal when watchlist creation limit reached",
+      message: "You've reached your watchlist limit. Upgrade your plan to create more watchlists.",
+    }));
+  }
 
   async function handleCreate(prefill?: { title?: string; description?: string; filters?: WatchlistFilters }) {
     if (creating || !isLoggedIn) return;
     if (limitReached) {
-      router.push(lp("/settings"));
+      // Issue #3036: redirecting to /settings (general tab) hid the
+      // reason from the user and put them on a tab unrelated to plans.
+      // Surface the same upgrade modal used elsewhere in the gating
+      // subsystem so the destination (billing) is explicit.
+      showLimitUpgrade();
       return;
     }
     setCreating(true);
@@ -42,6 +56,12 @@ export function WatchlistsPage({
         companyIds: [],
         filters: prefill?.filters,
       });
+      if ("error" in result) {
+        // Server-side race: client thought limit wasn't reached, but a
+        // concurrent create elsewhere raised the count. Same UX.
+        if (result.error === "limit_reached") showLimitUpgrade();
+        return;
+      }
       if ("slug" in result && (username ?? user?.username)) {
         router.push(lp(`/${username ?? user?.username}/${result.slug}`));
       } else {
@@ -55,7 +75,14 @@ export function WatchlistsPage({
   // Auto-create watchlist from URL params (e.g. from /api/v1/watchlist/create)
   useEffect(() => {
     const title = searchParams.get("title");
-    if (!title || !isLoggedIn || limitReached) return;
+    if (!title || !isLoggedIn) return;
+    if (limitReached) {
+      // Issue #3036: arriving with `?title=...` while at the plan
+      // limit used to silently no-op. Tell the user why nothing
+      // happened by surfacing the same upgrade modal.
+      showLimitUpgrade();
+      return;
+    }
 
     const q = searchParams.get("q");
     const loc = searchParams.get("loc");
@@ -92,6 +119,7 @@ export function WatchlistsPage({
   }, []);
 
   return (
+    <>
     <div className="space-y-8">
       {/* My watchlists */}
       <div>
@@ -162,5 +190,7 @@ export function WatchlistsPage({
       {/* Public search — always visible */}
       <PublicWatchlistSearch />
     </div>
+    <UpgradeModal open={upgrade.open} onOpenChange={upgrade.setOpen} reason={upgrade.reason} />
+    </>
   );
 }

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -186,14 +186,14 @@ msgstr "Über uns"
 #. Nav link: About
 #. Nav link: About
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:56
-#: src/components/MobileMenu.tsx:77
+#: src/components/Header.tsx:62
+#: src/components/MobileMenu.tsx:78
 msgid "common.nav.about"
 msgstr "Über uns"
 
 #. Account bottom bar label
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:218
+#: src/components/AppHeader.tsx:207
 msgid "app.header.nav.account"
 msgstr "Konto"
 
@@ -205,7 +205,7 @@ msgstr "Konto"
 
 #. Aria label for user avatar menu
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:84
+#: src/components/AppHeader.tsx:76
 msgid "app.header.avatar.label"
 msgstr "Kontomenü"
 
@@ -285,6 +285,12 @@ msgstr "hinzugefügt — öffnen"
 msgid "app.home.request.agent.promptRegionLabel"
 msgstr "Agent-Prompt"
 
+#. Footer shown after all paged countries have been loaded into the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:756
+msgid "search.locationModal.allLoaded"
+msgstr "Alle {totalCountries} Länder geladen"
+
 #. Encryption
 #. js-lingui-explicit-id
 #: src/components/PrivacyPolicyContent.tsx:47
@@ -299,7 +305,7 @@ msgstr "Alle Branchen"
 
 #. All languages option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:244
+#: src/components/settings/GeneralSettings.tsx:253
 msgid "settings.general.jobLanguages.all"
 msgstr "Alle Sprachen"
 
@@ -329,7 +335,7 @@ msgstr "Bereits ein Konto? <0>Anmelden</0>"
 
 #. Username is taken
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:276
+#: src/components/settings/AccountSettings.tsx:295
 msgid "settings.account.username.taken"
 msgstr "Bereits vergeben"
 
@@ -404,28 +410,28 @@ msgstr "Bewerbungen im letzten Jahr"
 msgid "myJobs.group.applied"
 msgstr "Beworben"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:449
-msgid "search.tracker.applied"
-msgstr "Beworben"
-
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
 msgid "myJobs.status.applied"
 msgstr "Beworben"
 
-#. Sankey funnel node: applied
+#. Application tracker status: applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:42
-msgid "myJobs.funnel.applied"
+#: src/components/search/job-detail-dialog.tsx:449
+msgid "search.tracker.applied"
 msgstr "Beworben"
 
 #. Status option in dropdown: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.applied"
+msgstr "Beworben"
+
+#. Sankey funnel node: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:42
+msgid "myJobs.funnel.applied"
 msgstr "Beworben"
 
 #. Apply salary filter
@@ -460,13 +466,13 @@ msgstr "Als letztes Mittel parsen wir die Karriereseiten selbst, bevorzugen dabe
 
 #. Username too short hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:264
+#: src/components/settings/AccountSettings.tsx:283
 msgid "settings.account.username.tooShort"
 msgstr "Mindestens 3 Zeichen"
 
 #. Username too long hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:266
+#: src/components/settings/AccountSettings.tsx:285
 msgid "settings.account.username.tooLong"
 msgstr "Maximal 30 Zeichen"
 
@@ -478,7 +484,7 @@ msgstr "Aug"
 
 #. Username is available
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:274
+#: src/components/settings/AccountSettings.tsx:293
 msgid "settings.account.username.available"
 msgstr "Verfügbar"
 
@@ -518,12 +524,6 @@ msgstr "Nach oben"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Verhalten"
 
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:145
-msgid "blog.post.backToIndex"
-msgstr "Blog"
-
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:27
@@ -536,18 +536,24 @@ msgstr "Blog"
 msgid "blog.index.heading"
 msgstr "Blog"
 
-#. Nav link: Blog
-#. Nav link: Blog
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:68
-#: src/components/MobileMenu.tsx:97
-msgid "common.nav.blog"
+#: app/[lang]/(public)/blog/[slug]/page.tsx:145
+msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Footer link to /blog index page
 #. js-lingui-explicit-id
 #: src/components/Footer.tsx:52
 msgid "common.footer.blog"
+msgstr "Blog"
+
+#. Nav link: Blog
+#. Nav link: Blog
+#. js-lingui-explicit-id
+#: src/components/Header.tsx:74
+#: src/components/MobileMenu.tsx:98
+msgid "common.nav.blog"
 msgstr "Blog"
 
 #. Subtitle on the sign-in CTA card shown to anonymous users at the end of the similar-companies strip
@@ -599,7 +605,7 @@ msgstr "Abbrechen"
 
 #. Cancel delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:516
+#: src/components/settings/AccountSettings.tsx:535
 msgid "settings.account.delete.cancel"
 msgstr "Abbrechen"
 
@@ -611,7 +617,7 @@ msgstr "ändern"
 
 #. Change email section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:354
+#: src/components/settings/AccountSettings.tsx:373
 msgid "settings.account.email.title"
 msgstr "E-Mail ändern"
 
@@ -629,7 +635,7 @@ msgstr "Sprache ändern"
 
 #. Password section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:174
+#: src/components/settings/AccountSettings.tsx:180
 msgid "settings.account.password.description"
 msgstr "Ändere dein Passwort über einen sicheren E-Mail-Link."
 
@@ -639,33 +645,33 @@ msgstr "Ändere dein Passwort über einen sicheren E-Mail-Link."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Ändern…"
 
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "E-Mail prüfen"
-
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
 msgstr "E-Mail überprüfen"
 
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
+msgstr "E-Mail prüfen"
+
 #. Checking username availability
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:272
+#: src/components/settings/AccountSettings.tsx:291
 msgid "settings.account.username.checking"
 msgstr "Verfügbarkeit wird geprüft..."
 
 #. Theme settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:170
+#: src/components/settings/GeneralSettings.tsx:179
 msgid "settings.general.theme.description"
 msgstr "Wähle das Erscheinungsbild von Job Seek."
 
 #. Salary display settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:315
+#: src/components/settings/GeneralSettings.tsx:324
 msgid "settings.general.salary.description"
 msgstr "Passen Sie an, wie Gehälter in Suchergebnissen und Stellendetails angezeigt werden."
 
@@ -677,13 +683,13 @@ msgstr "Wählen Sie den Plan, der zu Ihnen passt."
 
 #. Pricing section heading
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:103
+#: src/components/Pricing.tsx:106
 msgid "home.pricing.title"
 msgstr "Wähle den passenden Plan"
 
 #. Job languages settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:229
+#: src/components/settings/GeneralSettings.tsx:238
 msgid "settings.general.jobLanguages.description"
 msgstr "Wähle aus, in welchen Sprachen du Stellenanzeigen sehen möchtest."
 
@@ -741,7 +747,7 @@ msgstr "Client-APIs als Zweites."
 
 #. Aria label for close mobile menu button
 #. js-lingui-explicit-id
-#: src/components/MobileMenu.tsx:65
+#: src/components/MobileMenu.tsx:66
 msgid "common.mobileMenu.close"
 msgstr "Menü schließen"
 
@@ -830,18 +836,18 @@ msgid "company.notFound.title"
 msgstr "Unternehmen nicht gefunden"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:111
+#: app/[lang]/layout.tsx:120
 msgid "app.schema.description"
 msgstr "Unternehmens-Tracking-Tool für Jobsuchende, die schon wissen, bei welchen Unternehmen sie arbeiten möchten. Erstelle Watchlists, erhalte E-Mail-Benachrichtigungen, sobald neue Stellen frei werden, und verfolge Bewerbungen an einem Ort — Stellenanzeigen direkt von den Karriereseiten der Unternehmen."
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:76
+#: app/[lang]/layout.tsx:85
 msgid "app.schema.org.description"
 msgstr "Unternehmens-Tracking-Tool für gezielte Jobsuchende — Watchlists, E-Mail-Benachrichtigungen und Stellenanzeigen direkt von den Karriereseiten der Unternehmen. Entwickelt von der Colophon Group, einem kleinen Entwicklerstudio in der Schweiz."
 
 #. Confirm delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:509
+#: src/components/settings/AccountSettings.tsx:528
 msgid "settings.account.delete.confirm"
 msgstr "Löschen bestätigen"
 
@@ -853,21 +859,15 @@ msgstr "Passwort bestätigen"
 
 #. Connect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:459
+#: src/components/settings/AccountSettings.tsx:478
 msgid "settings.account.socials.connect"
 msgstr "Verbinden"
 
 #. Connected accounts section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:434
+#: src/components/settings/AccountSettings.tsx:453
 msgid "settings.account.socials.title"
 msgstr "Verknüpfte Konten"
-
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Kontakt"
 
 #. TOC: Contact
 #. js-lingui-explicit-id
@@ -881,16 +881,22 @@ msgstr "Kontakt"
 msgid "license.contact.title"
 msgstr "Kontakt"
 
-#. Table of contents heading
+#. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
-msgstr "Inhalt"
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Kontakt"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
+msgstr "Inhalt"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Inhalt"
 
 #. Button to continue to app after verification
@@ -999,7 +1005,7 @@ msgstr "Erstellen Sie ein kostenloses Konto, um alle Ergebnisse zu durchsuchen, 
 
 #. Tooltip explaining save search creates a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:106
+#: src/components/search/save-search-button.tsx:117
 msgid "search.saveSearch.tooltip"
 msgstr "Erstelle eine Watchlist aus deinen aktuellen Filtern"
 
@@ -1011,7 +1017,7 @@ msgstr "Konto erstellen"
 
 #. Button to create first watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:139
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:167
 msgid "watchlists.page.createFirst"
 msgstr "Watchlist erstellen"
 
@@ -1029,7 +1035,7 @@ msgstr "Erstelle eine Watchlist für jede Nische"
 
 #. Label for currency selector
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:322
+#: src/components/settings/GeneralSettings.tsx:331
 msgid "settings.general.salary.currencyLabel"
 msgstr "Währung"
 
@@ -1047,7 +1053,7 @@ msgstr "Aktuell"
 
 #. Daily pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:363
+#: src/components/settings/GeneralSettings.tsx:372
 msgid "settings.general.salary.period.daily"
 msgstr "Täglich"
 
@@ -1101,13 +1107,13 @@ msgstr "Löschen"
 
 #. Delete account section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:492
+#: src/components/settings/AccountSettings.tsx:511
 msgid "settings.account.delete.title"
 msgstr "Konto löschen"
 
 #. Delete account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:502
+#: src/components/settings/AccountSettings.tsx:521
 msgid "settings.account.delete.button"
 msgstr "Mein Konto löschen"
 
@@ -1119,7 +1125,7 @@ msgstr "Watchlist löschen?"
 
 #. Delete button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:508
+#: src/components/settings/AccountSettings.tsx:527
 msgid "settings.account.delete.deleting"
 msgstr "Löschen…"
 
@@ -1161,7 +1167,7 @@ msgstr "Benachrichtigungen deaktivieren"
 
 #. Disconnect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:458
+#: src/components/settings/AccountSettings.tsx:477
 msgid "settings.account.socials.disconnect"
 msgstr "Trennen"
 
@@ -1325,7 +1331,7 @@ msgstr "Entdecken"
 
 #. Explore nav icon tooltip
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:54
+#: src/components/AppHeader.tsx:55
 msgid "app.header.nav.explore"
 msgstr "Entdecken"
 
@@ -1336,27 +1342,27 @@ msgstr "Jobs entdecken"
 
 #. Generic email change error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:344
+#: src/components/settings/AccountSettings.tsx:363
 msgid "settings.account.email.error"
 msgstr "E-Mail-Änderung fehlgeschlagen"
 
 #. Error when linking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:410
+#: src/components/settings/AccountSettings.tsx:429
 msgid "settings.account.socials.connectError"
 msgstr "Konto konnte nicht verbunden werden"
 
 #. Generic account deletion error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:483
+#: src/components/settings/AccountSettings.tsx:502
 msgid "settings.account.delete.error"
 msgstr "Konto konnte nicht gelöscht werden"
 
 #. Error when unlinking social account fails
 #. Error when unlinking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:421
-#: src/components/settings/AccountSettings.tsx:426
+#: src/components/settings/AccountSettings.tsx:440
+#: src/components/settings/AccountSettings.tsx:445
 msgid "settings.account.socials.disconnectError"
 msgstr "Konto konnte nicht getrennt werden"
 
@@ -1374,19 +1380,19 @@ msgstr "Passwort konnte nicht zurückgesetzt werden. Der Link ist möglicherweis
 
 #. Generic password reset error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:161
+#: src/components/settings/AccountSettings.tsx:167
 msgid "settings.account.password.error"
 msgstr "Zurücksetzungs-E-Mail konnte nicht gesendet werden"
 
 #. Generic set password error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:72
+#: src/components/settings/AccountSettings.tsx:78
 msgid "settings.account.password.setError"
 msgstr "Passwort konnte nicht gesetzt werden"
 
 #. Generic username update error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:252
+#: src/components/settings/AccountSettings.tsx:264
 msgid "settings.account.username.error"
 msgstr "Benutzername konnte nicht aktualisiert werden"
 
@@ -1398,16 +1404,16 @@ msgstr "FAQ"
 #. Nav link: FAQ
 #. Nav link: FAQ
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:65
-#: src/components/MobileMenu.tsx:92
+#: src/components/Header.tsx:71
+#: src/components/MobileMenu.tsx:93
 msgid "common.nav.faq"
 msgstr "FAQ"
 
 #. Nav link: Features
 #. Nav link: Features
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:59
-#: src/components/MobileMenu.tsx:82
+#: src/components/Header.tsx:65
+#: src/components/MobileMenu.tsx:83
 msgid "common.nav.features"
 msgstr "Funktionen"
 
@@ -1465,7 +1471,7 @@ msgstr "Filter"
 
 #. Button to open modal with all languages
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:293
+#: src/components/settings/GeneralSettings.tsx:302
 msgid "settings.general.jobLanguages.findMore"
 msgstr "Weitere finden"
 
@@ -1565,7 +1571,7 @@ msgid "settings.billing.free.f2"
 msgstr "Vollständige Jobsuche"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:121
+#: app/[lang]/layout.tsx:130
 msgid "app.schema.offer.free"
 msgstr "Vollständige Suche, 1 Watchlist, Bewerbungstracker"
 
@@ -1597,9 +1603,9 @@ msgstr "Kontakt aufnehmen"
 #. Hero primary call-to-action
 #. Hero primary call-to-action
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:32
+#: src/components/Header.tsx:33
 #: src/components/Hero.tsx:15
-#: src/components/MobileMenu.tsx:31
+#: src/components/MobileMenu.tsx:32
 msgid "home.hero.primaryCta"
 msgstr "Jetzt starten"
 
@@ -1659,7 +1665,7 @@ msgstr "Startseite"
 
 #. Hourly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:366
+#: src/components/settings/GeneralSettings.tsx:375
 msgid "settings.general.salary.period.hourly"
 msgstr "Stündlich"
 
@@ -1853,16 +1859,16 @@ msgstr "Interview-Protokoll"
 msgid "myJobs.group.interviewing"
 msgstr "Im Interview"
 
-#. Application tracker status: interviewing
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:450
-msgid "search.tracker.interviewing"
-msgstr "Im Interview"
-
 #. Interviewing status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:21
 msgid "myJobs.status.interviewing"
+msgstr "Im Interview"
+
+#. Application tracker status: interviewing
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:450
+msgid "search.tracker.interviewing"
 msgstr "Im Interview"
 
 #. Status option in dropdown: interviewing
@@ -1910,16 +1916,16 @@ msgstr "Gibt es ein Limit, wie viele Jobs ich verfolgen kann?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:121
-msgid "watchlists.explore.jobSingular"
-msgstr "Job"
-
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31
 msgid "watchlists.card.jobSingular"
+msgstr "Job"
+
+#. Singular job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:121
+msgid "watchlists.explore.jobSingular"
 msgstr "Job"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -1948,7 +1954,7 @@ msgstr "Indexierungsrichtlinie"
 
 #. Job languages settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:226
+#: src/components/settings/GeneralSettings.tsx:235
 msgid "settings.general.jobLanguages.title"
 msgstr "Stellensprachen"
 
@@ -2022,16 +2028,16 @@ msgstr "Die Codebasis von Job Seek ist Open Source unter MIT. Die von uns gesamm
 msgid "watchlist.meta.fallback"
 msgstr "Job-Watchlist von @{owner}"
 
-#. Plural job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:122
-msgid "watchlists.explore.jobPlural"
-msgstr "Jobs"
-
 #. Plural job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:32
 msgid "watchlists.card.jobPlural"
+msgstr "Jobs"
+
+#. Plural job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:122
+msgid "watchlists.explore.jobPlural"
 msgstr "Jobs"
 
 #. js-lingui-explicit-id
@@ -2064,7 +2070,7 @@ msgstr "Stichwort"
 
 #. Language settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:197
+#: src/components/settings/GeneralSettings.tsx:206
 msgid "settings.general.language.title"
 msgstr "Sprache"
 
@@ -2188,35 +2194,35 @@ msgstr "Standort"
 msgid "search.advanced.location"
 msgstr "Standort"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
-msgstr "Standorte"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:842
 msgid "search.bar.locations"
 msgstr "Standorte"
 
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:312
+msgid "search.detail.locations"
+msgstr "Standorte"
+
 #. Login button label
 #. Login button label
 #. Login button label
 #. Login button label
 #. Login button label
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:117
-#: src/components/AppHeader.tsx:177
-#: src/components/AppHeader.tsx:230
-#: src/components/settings/AccountSettings.tsx:39
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:145
+#: src/components/AppHeader.tsx:168
+#: src/components/AppHeader.tsx:219
+#: src/components/settings/AccountSettings.tsx:45
 #: src/components/settings/BillingSettings.tsx:30
 msgid "common.auth.login"
 msgstr "Anmelden"
 
 #. Tooltip when user needs to log in to save search
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:111
+#: src/components/search/save-search-button.tsx:122
 msgid "search.saveSearch.tooltipLogin"
 msgstr "Melde dich an, um diese Suche als Watchlist zu speichern"
 
@@ -2246,7 +2252,7 @@ msgstr "Abo verwalten"
 
 #. Connected accounts section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:437
+#: src/components/settings/AccountSettings.tsx:456
 msgid "settings.account.socials.description"
 msgstr "Verwalte deine verknüpften Social-Media-Konten."
 
@@ -2273,6 +2279,12 @@ msgstr "Als Angebot markieren"
 #: src/components/my-jobs/quick-actions.tsx:20
 msgid "myJobs.action.markRejected"
 msgstr "Als abgelehnt markieren"
+
+#. Header for the server-side search-results cluster shown when the user types in the location modal search box
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:538
+msgid "search.locationModal.searchHitsHeader"
+msgstr "Treffer"
 
 #. Maximum salary label
 #. js-lingui-explicit-id
@@ -2337,13 +2349,13 @@ msgid "myJobs.heatmap.day.mon"
 msgstr "Mo"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:133
+#: app/[lang]/layout.tsx:142
 msgid "app.schema.feature.monitor"
 msgstr "Karriereseiten von Unternehmen überwachen"
 
 #. Monthly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:360
+#: src/components/settings/GeneralSettings.tsx:369
 msgid "settings.general.salary.period.monthly"
 msgstr "Monatlich"
 
@@ -2372,7 +2384,7 @@ msgid "home.features.s1.p2.title"
 msgstr "Mehrdimensionale Filter"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:135
+#: app/[lang]/layout.tsx:144
 msgid "app.schema.feature.languages"
 msgstr "Mehrsprachige Unterstützung"
 
@@ -2382,7 +2394,7 @@ msgstr "Mehrsprachige Unterstützung"
 #. Warning when Enter is pressed but multiple items match
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:247
-#: src/components/search/location-search-modal.tsx:237
+#: src/components/search/location-search-modal.tsx:399
 #: src/components/search/occupation-modal.tsx:180
 #: src/components/search/technology-modal.tsx:88
 msgid "search.bestGuess.ambiguous"
@@ -2402,7 +2414,7 @@ msgstr "Meine Jobs"
 
 #. My Jobs nav icon tooltip
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:56
+#: src/components/AppHeader.tsx:57
 msgid "app.header.nav.myJobs"
 msgstr "Meine Jobs"
 
@@ -2426,7 +2438,7 @@ msgstr "Kontakt aufnehmen?"
 
 #. New email input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:366
+#: src/components/settings/AccountSettings.tsx:385
 msgid "settings.account.email.label"
 msgstr "Neue E-Mail"
 
@@ -2438,7 +2450,7 @@ msgstr "Neues Passwort"
 
 #. New password input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:96
+#: src/components/settings/AccountSettings.tsx:102
 msgid "settings.account.password.newLabel"
 msgstr "Neues Passwort"
 
@@ -2478,17 +2490,17 @@ msgstr "Keine Jobs gefunden."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Keine Sprachen entsprechen deiner Suche."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:299
-msgid "search.locationModal.noResults"
-msgstr "Keine Standorte gefunden."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:309
 msgid "company.locationModal.noResults"
 msgstr "Keine Standorte entsprechen Ihrer Suche."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:469
+msgid "search.locationModal.noResults"
+msgstr "Keine Standorte gefunden."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2552,7 +2564,7 @@ msgstr "Keine Watchlists gefunden."
 
 #. Empty state when user has no watchlists
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:124
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:152
 msgid "watchlists.page.empty"
 msgstr "Noch keine Watchlists. Erstelle eine, um Jobs von deinen Lieblingsunternehmen zu verfolgen."
 
@@ -2602,16 +2614,16 @@ msgstr "Berufsfeld"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Okt"
 
-#. Application tracker status: offer
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:451
-msgid "search.tracker.offer"
-msgstr "Angebot"
-
 #. Offered status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
+msgstr "Angebot"
+
+#. Application tracker status: offer
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:451
+msgid "search.tracker.offer"
 msgstr "Angebot"
 
 #. Status group heading: offered
@@ -2620,16 +2632,16 @@ msgstr "Angebot"
 msgid "myJobs.group.offered"
 msgstr "Angebot"
 
-#. Sankey funnel node: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:43
-msgid "myJobs.funnel.offered"
-msgstr "Angebot"
-
 #. Status option in dropdown: offered
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:38
 msgid "myJobs.statusOption.offered"
+msgstr "Angebot"
+
+#. Sankey funnel node: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:43
+msgid "myJobs.funnel.offered"
 msgstr "Angebot"
 
 #. Cookie banner accept button
@@ -2662,7 +2674,7 @@ msgstr "Eine Seite pro Minute."
 
 #. Username invalid characters hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:268
+#: src/components/settings/AccountSettings.tsx:287
 msgid "settings.account.username.invalidChars"
 msgstr "Nur Kleinbuchstaben, Zahlen und Bindestriche (nicht am Anfang/Ende)"
 
@@ -2674,7 +2686,7 @@ msgstr "Vor Ort"
 
 #. Aria label for mobile menu button
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:83
+#: src/components/Header.tsx:89
 msgid "common.header.openMenu"
 msgstr "Hauptmenü öffnen"
 
@@ -2715,7 +2727,7 @@ msgstr "oder"
 
 #. Original pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:354
+#: src/components/settings/GeneralSettings.tsx:363
 msgid "settings.general.salary.period.original"
 msgstr "Original"
 
@@ -2745,26 +2757,26 @@ msgstr "Unsere Haltung zur Automatisierung"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Überblick"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Überblick"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Seiteninhalt"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Überblick"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Seiteninhalt"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Seiteninhalt"
 
 #. Heading shown on the 404 page
@@ -2794,20 +2806,20 @@ msgstr "Passwort"
 #. Password section heading
 #. Password section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:83
-#: src/components/settings/AccountSettings.tsx:171
+#: src/components/settings/AccountSettings.tsx:89
+#: src/components/settings/AccountSettings.tsx:177
 msgid "settings.account.password.title"
 msgstr "Passwort"
 
 #. Success message after password reset request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:163
+#: src/components/settings/AccountSettings.tsx:169
 msgid "settings.account.password.success"
 msgstr "Link zum Zurücksetzen des Passworts gesendet. Bitte überprüfe dein Postfach. Es kann einige Minuten dauern, bis die E-Mail ankommt."
 
 #. Success message after setting password
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:74
+#: src/components/settings/AccountSettings.tsx:80
 msgid "settings.account.password.setSuccess"
 msgstr "Passwort erfolgreich gesetzt."
 
@@ -2831,7 +2843,7 @@ msgstr "Geben Sie einen Firmennamen oder eine Karriereseiten-URL ein und wir beg
 
 #. Label for pay period selector
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:341
+#: src/components/settings/GeneralSettings.tsx:350
 msgid "settings.general.salary.periodLabel"
 msgstr "Zeitraum"
 
@@ -2855,7 +2867,7 @@ msgstr "Zeitraum"
 
 #. Delete account section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:495
+#: src/components/settings/AccountSettings.tsx:514
 msgid "settings.account.delete.description"
 msgstr "Lösche dein Konto und alle zugehörigen Daten dauerhaft. Diese Aktion kann nicht rückgängig gemacht werden."
 
@@ -2891,7 +2903,7 @@ msgstr "Bitte geben Sie einen Firmennamen oder eine URL ein."
 
 #. Error when email field is empty
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:334
+#: src/components/settings/AccountSettings.tsx:353
 msgid "settings.account.email.required"
 msgstr "Bitte gib eine neue E-Mail-Adresse ein"
 
@@ -2903,7 +2915,7 @@ msgstr "Bitte gib ein neues Passwort ein"
 
 #. Error when new password is empty
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:65
+#: src/components/settings/AccountSettings.tsx:71
 msgid "settings.account.password.newRequired"
 msgstr "Bitte gib ein Passwort ein"
 
@@ -2933,7 +2945,7 @@ msgstr "Bitte fülle alle Felder aus"
 
 #. Message when user must log in to see account settings
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:34
+#: src/components/settings/AccountSettings.tsx:40
 msgid "settings.account.loginRequired"
 msgstr "Bitte melde dich an, um deine Kontoeinstellungen zu verwalten."
 
@@ -2955,18 +2967,18 @@ msgstr "Stelle nicht gefunden."
 msgid "myJobs.detail.notFound"
 msgstr "Stellenanzeige nicht gefunden."
 
-#. Nav link: Pricing
-#. Nav link: Pricing
-#. js-lingui-explicit-id
-#: src/components/Header.tsx:62
-#: src/components/MobileMenu.tsx:87
-msgid "common.nav.pricing"
-msgstr "Preise"
-
 #. Pricing section eyebrow
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:100
+#: src/components/Pricing.tsx:103
 msgid "home.pricing.eyebrow"
+msgstr "Preise"
+
+#. Nav link: Pricing
+#. Nav link: Pricing
+#. js-lingui-explicit-id
+#: src/components/Header.tsx:68
+#: src/components/MobileMenu.tsx:88
+msgid "common.nav.pricing"
 msgstr "Preise"
 
 #. Privacy policy page eyebrow
@@ -3060,7 +3072,7 @@ msgid "terms.fullTermsLink"
 msgstr "Vollständige Nutzungsbedingungen lesen"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:134
+#: app/[lang]/layout.tsx:143
 msgid "app.schema.feature.alerts"
 msgstr "Echtzeit-Benachrichtigungen über neue Stellen"
 
@@ -3094,16 +3106,16 @@ msgstr "Deine Änderungen weiterverbreiten, solange du den MIT-Hinweis beifügst
 msgid "location.type.region"
 msgstr "Region"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:309
-msgid "search.locationModal.regionsHeader"
-msgstr "Regionen"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:319
 msgid "company.locationModal.regionsHeader"
+msgstr "Regionen"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:479
+msgid "search.locationModal.regionsHeader"
 msgstr "Regionen"
 
 #. Status group heading: rejected
@@ -3112,28 +3124,28 @@ msgstr "Regionen"
 msgid "myJobs.group.rejected"
 msgstr "Abgelehnt"
 
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:452
-msgid "search.tracker.rejected"
-msgstr "Abgelehnt"
-
 #. Rejected status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:23
 msgid "myJobs.status.rejected"
 msgstr "Abgelehnt"
 
-#. Sankey funnel node label prefix: rejected
+#. Application tracker status: rejected
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:45
-msgid "myJobs.funnel.rejected"
+#: src/components/search/job-detail-dialog.tsx:452
+msgid "search.tracker.rejected"
 msgstr "Abgelehnt"
 
 #. Status option in dropdown: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:39
 msgid "myJobs.statusOption.rejected"
+msgstr "Abgelehnt"
+
+#. Sankey funnel node label prefix: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:45
+msgid "myJobs.funnel.rejected"
 msgstr "Abgelehnt"
 
 #. Footer license summary text
@@ -3202,7 +3214,7 @@ msgstr "Erneut senden in {cooldown}s"
 
 #. Reset password button during cooldown with seconds remaining
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:184
+#: src/components/settings/AccountSettings.tsx:190
 msgid "settings.account.password.cooldown"
 msgstr "Erneut senden in {cooldown}s"
 
@@ -3286,7 +3298,7 @@ msgstr "Gehalt"
 
 #. Salary display settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:312
+#: src/components/settings/GeneralSettings.tsx:321
 msgid "settings.general.salary.title"
 msgstr "Gehaltsanzeige"
 
@@ -3334,7 +3346,7 @@ msgstr "Speichern Sie Jobs und verfolgen Sie Ihre Bewerbungen, um hier Statistik
 
 #. Button label to save current search as a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:99
+#: src/components/search/save-search-button.tsx:110
 msgid "search.saveSearch.label"
 msgstr "Diese Suche speichern"
 
@@ -3350,27 +3362,27 @@ msgstr "Gespeichert"
 msgid "myJobs.status.saved"
 msgstr "Gespeichert"
 
-#. Sankey funnel node: saved jobs
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:41
-msgid "myJobs.funnel.saved"
-msgstr "Gespeichert"
-
 #. Status option in dropdown: saved
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:35
 msgid "myJobs.statusOption.saved"
 msgstr "Gespeichert"
 
+#. Sankey funnel node: saved jobs
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:41
+msgid "myJobs.funnel.saved"
+msgstr "Gespeichert"
+
 #. Username save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:304
+#: src/components/settings/AccountSettings.tsx:323
 msgid "settings.account.username.saving"
 msgstr "Speichern..."
 
 #. Email save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:376
+#: src/components/settings/AccountSettings.tsx:395
 msgid "settings.account.email.saving"
 msgstr "Speichern…"
 
@@ -3422,17 +3434,17 @@ msgstr "Durchsuche Jobs bei Tausenden von Unternehmen, direkt von Karriereseiten
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Sprachen suchen…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:278
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Standorte suchen..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:288
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Standorte suchen…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:448
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Standorte suchen..."
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3478,7 +3490,7 @@ msgstr "Stufe auswählen"
 
 #. Title for the global location selection modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:258
+#: src/components/search/location-search-modal.tsx:428
 msgid "search.locationModal.title"
 msgstr "Standort auswählen"
 
@@ -3496,7 +3508,7 @@ msgstr "Technologien auswählen"
 
 #. Language settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:200
+#: src/components/settings/GeneralSettings.tsx:209
 msgid "settings.general.language.description"
 msgstr "Wähle deine bevorzugte Sprache."
 
@@ -3514,15 +3526,9 @@ msgstr "Link senden"
 
 #. Reset password button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:185
+#: src/components/settings/AccountSettings.tsx:191
 msgid "settings.account.password.send"
 msgstr "Link senden"
-
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Wird gesendet..."
 
 #. Resend button while sending
 #. js-lingui-explicit-id
@@ -3530,9 +3536,15 @@ msgstr "Wird gesendet..."
 msgid "auth.verify.resending"
 msgstr "Wird gesendet…"
 
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
+msgstr "Wird gesendet..."
+
 #. Reset password button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:182
+#: src/components/settings/AccountSettings.tsx:188
 msgid "settings.account.password.sending"
 msgstr "Senden…"
 
@@ -3556,13 +3568,13 @@ msgstr "Neues Passwort setzen"
 
 #. Set password button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:107
+#: src/components/settings/AccountSettings.tsx:113
 msgid "settings.account.password.set"
 msgstr "Passwort setzen"
 
 #. Set password button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:106
+#: src/components/settings/AccountSettings.tsx:112
 msgid "settings.account.password.setting"
 msgstr "Setzen…"
 
@@ -3574,7 +3586,7 @@ msgstr "Einstellungen"
 
 #. Settings nav icon tooltip
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:57
+#: src/components/AppHeader.tsx:58
 msgid "app.header.nav.settings"
 msgstr "Einstellungen"
 
@@ -3584,16 +3596,16 @@ msgstr "Einstellungen"
 msgid "home.features.s3.p3.title"
 msgstr "Mit jedem teilen"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:355
-msgid "search.detail.showLessLocations"
-msgstr "Weniger anzeigen"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:351
 msgid "company.page.showLess"
+msgstr "Weniger anzeigen"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:355
+msgid "search.detail.showLessLocations"
 msgstr "Weniger anzeigen"
 
 #. Aria label to show password
@@ -3646,7 +3658,7 @@ msgstr "Für mehr anmelden"
 
 #. Prompt for non-logged-in users to sign in to create watchlists
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:108
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:136
 msgid "watchlists.page.loginPrompt"
 msgstr "Melde dich an, um deine eigenen Watchlists zu erstellen und zu verwalten."
 
@@ -3670,7 +3682,7 @@ msgstr "Anmelden, um mehr Stellenangebote zu sehen"
 
 #. Sign out dropdown menu item
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:117
+#: src/components/AppHeader.tsx:108
 msgid "app.header.signOut"
 msgstr "Abmelden"
 
@@ -3706,7 +3718,7 @@ msgstr "Ähnliche Unternehmen"
 
 #. Pricing section description
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:106
+#: src/components/Pricing.tsx:109
 msgid "home.pricing.description"
 msgstr "Einfache, transparente Preise. Starte kostenlos und upgrade, wenn du deine Jobsuche ernst meinst."
 
@@ -3728,12 +3740,6 @@ msgstr "Zum Inhalt springen"
 msgid "error.title"
 msgstr "Etwas ist schiefgelaufen"
 
-#. Generic forgot password error
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:43
-msgid "auth.forgotPassword.error.generic"
-msgstr "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
-
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
@@ -3745,6 +3751,12 @@ msgstr "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
 #: src/components/search/request-company.tsx:23
 msgid "app.home.request.error.unknown"
 msgstr "Etwas ist schiefgelaufen. Bitte versuchen Sie es erneut."
+
+#. Generic forgot password error
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:43
+msgid "auth.forgotPassword.error.generic"
+msgstr "Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut."
 
 #. Companies-request page heading when a company name was supplied via query string
 #. js-lingui-explicit-id
@@ -3866,16 +3878,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technisch"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Technologien"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:765
 msgid "search.bar.technologies"
+msgstr "Technologien"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:397
+msgid "search.detail.technologies"
 msgstr "Technologien"
 
 #. Add technology filter
@@ -3980,7 +3992,7 @@ msgstr "Die Kurzfassung"
 
 #. Theme settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:167
+#: src/components/settings/GeneralSettings.tsx:176
 msgid "settings.general.theme.title"
 msgstr "Design"
 
@@ -3998,7 +4010,7 @@ msgstr "Diese Seite verwendet Cookies ausschließlich für Authentifizierung und
 
 #. Username is reserved hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:270
+#: src/components/settings/AccountSettings.tsx:289
 msgid "settings.account.username.reserved"
 msgstr "Dieser Benutzername ist reserviert"
 
@@ -4087,7 +4099,7 @@ msgid "home.pricing.pro.description"
 msgstr "Unbegrenzte Watchlists mit E-Mail-Benachrichtigungen, damit du keine Stelle verpasst."
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:129
+#: app/[lang]/layout.tsx:138
 msgid "app.schema.offer.pro"
 msgstr "Unbegrenzte Watchlists, E-Mail-Benachrichtigungen bei neuen Treffern"
 
@@ -4105,19 +4117,19 @@ msgstr "Job entfernen"
 
 #. Email save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:377
+#: src/components/settings/AccountSettings.tsx:396
 msgid "settings.account.email.save"
 msgstr "E-Mail aktualisieren"
 
 #. Change email section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:357
+#: src/components/settings/AccountSettings.tsx:376
 msgid "settings.account.email.description"
 msgstr "Aktualisiere die mit deinem Konto verknüpfte E-Mail-Adresse."
 
 #. Username save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:305
+#: src/components/settings/AccountSettings.tsx:324
 msgid "settings.account.username.save"
 msgstr "Benutzername aktualisieren"
 
@@ -4158,25 +4170,25 @@ msgstr "Nutzer"
 
 #. Username section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:282
+#: src/components/settings/AccountSettings.tsx:301
 msgid "settings.account.username.title"
 msgstr "Benutzername"
 
 #. Username input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:294
+#: src/components/settings/AccountSettings.tsx:313
 msgid "settings.account.username.label"
 msgstr "Benutzername"
 
 #. Username updated success message
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:256
+#: src/components/settings/AccountSettings.tsx:276
 msgid "settings.account.username.success"
 msgstr "Benutzername aktualisiert."
 
 #. Success message after email change request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:346
+#: src/components/settings/AccountSettings.tsx:365
 msgid "settings.account.email.success"
 msgstr "Bestätigungs-E-Mail gesendet. Bitte überprüfe dein Postfach. Es kann einige Minuten dauern, bis die E-Mail ankommt."
 
@@ -4236,7 +4248,7 @@ msgstr "Watchlist-Limit erreicht"
 
 #. Title of the watchlists exploration page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:99
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:127
 msgid "watchlists.page.title"
 msgstr "Watchlists"
 
@@ -4248,7 +4260,7 @@ msgstr "Watchlists"
 
 #. Watchlists nav icon tooltip
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:55
+#: src/components/AppHeader.tsx:56
 msgid "app.header.nav.watchlists"
 msgstr "Watchlists"
 
@@ -4259,7 +4271,7 @@ msgid "home.features.s1.p3.title"
 msgstr "Watchlists und Benachrichtigungen"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:136
+#: app/[lang]/layout.tsx:145
 msgid "app.schema.feature.watchlists"
 msgstr "Watchlists und Bewerbungstracking"
 
@@ -4432,7 +4444,7 @@ msgstr "Arbeitsweise"
 
 #. Yearly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:357
+#: src/components/settings/GeneralSettings.tsx:366
 msgid "settings.general.salary.period.yearly"
 msgstr "Jährlich"
 
@@ -4517,7 +4529,7 @@ msgstr "Du musst mindestens 16 Jahre alt sein, um Job Seek zu nutzen."
 
 #. Set password description for OAuth users
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:86
+#: src/components/settings/AccountSettings.tsx:92
 msgid "settings.account.password.setDescription"
 msgstr "Du hast dich mit einem Social-Media-Konto angemeldet. Setze ein Passwort, um E-Mail-Änderungen und zusätzliche Sicherheit zu ermöglichen."
 
@@ -4534,7 +4546,9 @@ msgid "app.home.request.agent.rateLimited"
 msgstr "Du hast das Stundenlimit für Unternehmensanfragen erreicht. Bitte versuche es später erneut."
 
 #. Reason shown in upgrade modal when watchlist creation limit reached
+#. Reason shown in upgrade modal when watchlist creation limit reached
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:34
 #: src/components/watchlist/watchlist-card.tsx:45
 msgid "upgrade.reason.watchlistLimit"
 msgstr "Du hast dein Watchlist-Limit erreicht. Upgrade deinen Plan, um weitere Watchlists zu erstellen."
@@ -4544,6 +4558,12 @@ msgstr "Du hast dein Watchlist-Limit erreicht. Upgrade deinen Plan, um weitere W
 #: src/components/watchlist/watchlist-action-bar.tsx:93
 msgid "upgrade.reason.mirrorLimit"
 msgstr "Du hast dein Watchlist-Limit erreicht. Upgrade deinen Plan, um weitere Watchlists zu spiegeln."
+
+#. Reason shown in upgrade modal when saving a search hits the watchlist limit
+#. js-lingui-explicit-id
+#: src/components/search/save-search-button.tsx:93
+msgid "upgrade.reason.saveSearch"
+msgstr "Du hast dein Watchlist-Limit erreicht. Upgrade deinen Plan, um weitere Suchen als Watchlist zu speichern."
 
 #. Feature section 3 eyebrow text
 #. js-lingui-explicit-id
@@ -4571,6 +4591,6 @@ msgstr "Deine Rechte"
 
 #. Username section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:285
+#: src/components/settings/AccountSettings.tsx:304
 msgid "settings.account.username.description"
 msgstr "Dein eindeutiger Name für deine öffentliche Profil-URL."

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -186,14 +186,14 @@ msgstr "About"
 #. Nav link: About
 #. Nav link: About
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:56
-#: src/components/MobileMenu.tsx:77
+#: src/components/Header.tsx:62
+#: src/components/MobileMenu.tsx:78
 msgid "common.nav.about"
 msgstr "About"
 
 #. Account bottom bar label
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:218
+#: src/components/AppHeader.tsx:207
 msgid "app.header.nav.account"
 msgstr "Account"
 
@@ -205,7 +205,7 @@ msgstr "Account"
 
 #. Aria label for user avatar menu
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:84
+#: src/components/AppHeader.tsx:76
 msgid "app.header.avatar.label"
 msgstr "Account menu"
 
@@ -285,6 +285,12 @@ msgstr "added — open it"
 msgid "app.home.request.agent.promptRegionLabel"
 msgstr "Agent prompt"
 
+#. Footer shown after all paged countries have been loaded into the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:756
+msgid "search.locationModal.allLoaded"
+msgstr "All {totalCountries} countries loaded"
+
 #. Encryption
 #. js-lingui-explicit-id
 #: src/components/PrivacyPolicyContent.tsx:47
@@ -299,7 +305,7 @@ msgstr "All industries"
 
 #. All languages option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:244
+#: src/components/settings/GeneralSettings.tsx:253
 msgid "settings.general.jobLanguages.all"
 msgstr "All languages"
 
@@ -329,7 +335,7 @@ msgstr "Already have an account? <0>Sign in</0>"
 
 #. Username is taken
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:276
+#: src/components/settings/AccountSettings.tsx:295
 msgid "settings.account.username.taken"
 msgstr "Already taken"
 
@@ -404,28 +410,28 @@ msgstr "applications in the past year"
 msgid "myJobs.group.applied"
 msgstr "Applied"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:449
-msgid "search.tracker.applied"
-msgstr "Applied"
-
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
 msgid "myJobs.status.applied"
 msgstr "Applied"
 
-#. Sankey funnel node: applied
+#. Application tracker status: applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:42
-msgid "myJobs.funnel.applied"
+#: src/components/search/job-detail-dialog.tsx:449
+msgid "search.tracker.applied"
 msgstr "Applied"
 
 #. Status option in dropdown: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.applied"
+msgstr "Applied"
+
+#. Sankey funnel node: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:42
+msgid "myJobs.funnel.applied"
 msgstr "Applied"
 
 #. Apply salary filter
@@ -460,13 +466,13 @@ msgstr "As a last resort we parse the careers pages themselves, preferring newes
 
 #. Username too short hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:264
+#: src/components/settings/AccountSettings.tsx:283
 msgid "settings.account.username.tooShort"
 msgstr "At least 3 characters"
 
 #. Username too long hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:266
+#: src/components/settings/AccountSettings.tsx:285
 msgid "settings.account.username.tooLong"
 msgstr "At most 30 characters"
 
@@ -478,7 +484,7 @@ msgstr "Aug"
 
 #. Username is available
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:274
+#: src/components/settings/AccountSettings.tsx:293
 msgid "settings.account.username.available"
 msgstr "Available"
 
@@ -518,12 +524,6 @@ msgstr "Back to top"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Behavioral"
 
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:145
-msgid "blog.post.backToIndex"
-msgstr "Blog"
-
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:27
@@ -536,18 +536,24 @@ msgstr "Blog"
 msgid "blog.index.heading"
 msgstr "Blog"
 
-#. Nav link: Blog
-#. Nav link: Blog
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:68
-#: src/components/MobileMenu.tsx:97
-msgid "common.nav.blog"
+#: app/[lang]/(public)/blog/[slug]/page.tsx:145
+msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Footer link to /blog index page
 #. js-lingui-explicit-id
 #: src/components/Footer.tsx:52
 msgid "common.footer.blog"
+msgstr "Blog"
+
+#. Nav link: Blog
+#. Nav link: Blog
+#. js-lingui-explicit-id
+#: src/components/Header.tsx:74
+#: src/components/MobileMenu.tsx:98
+msgid "common.nav.blog"
 msgstr "Blog"
 
 #. Subtitle on the sign-in CTA card shown to anonymous users at the end of the similar-companies strip
@@ -599,7 +605,7 @@ msgstr "Cancel"
 
 #. Cancel delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:516
+#: src/components/settings/AccountSettings.tsx:535
 msgid "settings.account.delete.cancel"
 msgstr "Cancel"
 
@@ -611,7 +617,7 @@ msgstr "change"
 
 #. Change email section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:354
+#: src/components/settings/AccountSettings.tsx:373
 msgid "settings.account.email.title"
 msgstr "Change email"
 
@@ -629,7 +635,7 @@ msgstr "Change language"
 
 #. Password section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:174
+#: src/components/settings/AccountSettings.tsx:180
 msgid "settings.account.password.description"
 msgstr "Change your password via a secure email link."
 
@@ -639,33 +645,33 @@ msgstr "Change your password via a secure email link."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Change..."
 
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "Check your email"
-
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
 msgstr "Check your email"
 
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
+msgstr "Check your email"
+
 #. Checking username availability
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:272
+#: src/components/settings/AccountSettings.tsx:291
 msgid "settings.account.username.checking"
 msgstr "Checking availability..."
 
 #. Theme settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:170
+#: src/components/settings/GeneralSettings.tsx:179
 msgid "settings.general.theme.description"
 msgstr "Choose how Job Seek looks to you."
 
 #. Salary display settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:315
+#: src/components/settings/GeneralSettings.tsx:324
 msgid "settings.general.salary.description"
 msgstr "Choose how salaries are shown across the site."
 
@@ -677,13 +683,13 @@ msgstr "Choose the plan that works for you."
 
 #. Pricing section heading
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:103
+#: src/components/Pricing.tsx:106
 msgid "home.pricing.title"
 msgstr "Choose the right plan for you"
 
 #. Job languages settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:229
+#: src/components/settings/GeneralSettings.tsx:238
 msgid "settings.general.jobLanguages.description"
 msgstr "Choose which languages you want to see job postings in."
 
@@ -741,7 +747,7 @@ msgstr "Client APIs second."
 
 #. Aria label for close mobile menu button
 #. js-lingui-explicit-id
-#: src/components/MobileMenu.tsx:65
+#: src/components/MobileMenu.tsx:66
 msgid "common.mobileMenu.close"
 msgstr "Close menu"
 
@@ -830,18 +836,18 @@ msgid "company.notFound.title"
 msgstr "Company not found"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:111
+#: app/[lang]/layout.tsx:120
 msgid "app.schema.description"
 msgstr "Company-tracking tool for job seekers who already know which companies they want to work at. Build watchlists, get email alerts when new roles open up, and track applications in one place — postings sourced directly from company career pages."
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:76
+#: app/[lang]/layout.tsx:85
 msgid "app.schema.org.description"
 msgstr "Company-tracking tool for targeted job seekers — watchlists, email alerts, and postings sourced directly from company career pages. Built by Colophon Group, a small developer studio in Switzerland."
 
 #. Confirm delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:509
+#: src/components/settings/AccountSettings.tsx:528
 msgid "settings.account.delete.confirm"
 msgstr "Confirm deletion"
 
@@ -853,21 +859,15 @@ msgstr "Confirm password"
 
 #. Connect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:459
+#: src/components/settings/AccountSettings.tsx:478
 msgid "settings.account.socials.connect"
 msgstr "Connect"
 
 #. Connected accounts section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:434
+#: src/components/settings/AccountSettings.tsx:453
 msgid "settings.account.socials.title"
 msgstr "Connected accounts"
-
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Contact"
 
 #. TOC: Contact
 #. js-lingui-explicit-id
@@ -881,16 +881,22 @@ msgstr "Contact"
 msgid "license.contact.title"
 msgstr "Contact"
 
-#. Table of contents heading
+#. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
-msgstr "Contents"
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Contact"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
+msgstr "Contents"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Contents"
 
 #. Button to continue to app after verification
@@ -999,7 +1005,7 @@ msgstr "Create a free account to browse all results, save jobs, track applicatio
 
 #. Tooltip explaining save search creates a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:106
+#: src/components/search/save-search-button.tsx:117
 msgid "search.saveSearch.tooltip"
 msgstr "Create a watchlist from your current filters"
 
@@ -1011,7 +1017,7 @@ msgstr "Create an account"
 
 #. Button to create first watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:139
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:167
 msgid "watchlists.page.createFirst"
 msgstr "Create watchlist"
 
@@ -1029,7 +1035,7 @@ msgstr "Curate a watchlist for any niche"
 
 #. Label for currency selector
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:322
+#: src/components/settings/GeneralSettings.tsx:331
 msgid "settings.general.salary.currencyLabel"
 msgstr "Currency"
 
@@ -1047,7 +1053,7 @@ msgstr "Current"
 
 #. Daily pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:363
+#: src/components/settings/GeneralSettings.tsx:372
 msgid "settings.general.salary.period.daily"
 msgstr "Daily"
 
@@ -1101,13 +1107,13 @@ msgstr "Delete"
 
 #. Delete account section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:492
+#: src/components/settings/AccountSettings.tsx:511
 msgid "settings.account.delete.title"
 msgstr "Delete account"
 
 #. Delete account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:502
+#: src/components/settings/AccountSettings.tsx:521
 msgid "settings.account.delete.button"
 msgstr "Delete my account"
 
@@ -1119,7 +1125,7 @@ msgstr "Delete watchlist?"
 
 #. Delete button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:508
+#: src/components/settings/AccountSettings.tsx:527
 msgid "settings.account.delete.deleting"
 msgstr "Deleting..."
 
@@ -1161,7 +1167,7 @@ msgstr "Disable alerts"
 
 #. Disconnect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:458
+#: src/components/settings/AccountSettings.tsx:477
 msgid "settings.account.socials.disconnect"
 msgstr "Disconnect"
 
@@ -1325,7 +1331,7 @@ msgstr "Explore"
 
 #. Explore nav icon tooltip
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:54
+#: src/components/AppHeader.tsx:55
 msgid "app.header.nav.explore"
 msgstr "Explore"
 
@@ -1336,27 +1342,27 @@ msgstr "Explore Jobs"
 
 #. Generic email change error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:344
+#: src/components/settings/AccountSettings.tsx:363
 msgid "settings.account.email.error"
 msgstr "Failed to change email"
 
 #. Error when linking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:410
+#: src/components/settings/AccountSettings.tsx:429
 msgid "settings.account.socials.connectError"
 msgstr "Failed to connect account"
 
 #. Generic account deletion error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:483
+#: src/components/settings/AccountSettings.tsx:502
 msgid "settings.account.delete.error"
 msgstr "Failed to delete account"
 
 #. Error when unlinking social account fails
 #. Error when unlinking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:421
-#: src/components/settings/AccountSettings.tsx:426
+#: src/components/settings/AccountSettings.tsx:440
+#: src/components/settings/AccountSettings.tsx:445
 msgid "settings.account.socials.disconnectError"
 msgstr "Failed to disconnect account"
 
@@ -1374,19 +1380,19 @@ msgstr "Failed to reset password. The link may have expired."
 
 #. Generic password reset error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:161
+#: src/components/settings/AccountSettings.tsx:167
 msgid "settings.account.password.error"
 msgstr "Failed to send reset email"
 
 #. Generic set password error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:72
+#: src/components/settings/AccountSettings.tsx:78
 msgid "settings.account.password.setError"
 msgstr "Failed to set password"
 
 #. Generic username update error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:252
+#: src/components/settings/AccountSettings.tsx:264
 msgid "settings.account.username.error"
 msgstr "Failed to update username"
 
@@ -1398,16 +1404,16 @@ msgstr "FAQ"
 #. Nav link: FAQ
 #. Nav link: FAQ
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:65
-#: src/components/MobileMenu.tsx:92
+#: src/components/Header.tsx:71
+#: src/components/MobileMenu.tsx:93
 msgid "common.nav.faq"
 msgstr "FAQ"
 
 #. Nav link: Features
 #. Nav link: Features
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:59
-#: src/components/MobileMenu.tsx:82
+#: src/components/Header.tsx:65
+#: src/components/MobileMenu.tsx:83
 msgid "common.nav.features"
 msgstr "Features"
 
@@ -1465,7 +1471,7 @@ msgstr "Filters"
 
 #. Button to open modal with all languages
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:293
+#: src/components/settings/GeneralSettings.tsx:302
 msgid "settings.general.jobLanguages.findMore"
 msgstr "Find more"
 
@@ -1565,7 +1571,7 @@ msgid "settings.billing.free.f2"
 msgstr "Full job search"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:121
+#: app/[lang]/layout.tsx:130
 msgid "app.schema.offer.free"
 msgstr "Full search, 1 watchlist, application tracker"
 
@@ -1597,9 +1603,9 @@ msgstr "Get in touch"
 #. Hero primary call-to-action
 #. Hero primary call-to-action
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:32
+#: src/components/Header.tsx:33
 #: src/components/Hero.tsx:15
-#: src/components/MobileMenu.tsx:31
+#: src/components/MobileMenu.tsx:32
 msgid "home.hero.primaryCta"
 msgstr "Get started"
 
@@ -1659,7 +1665,7 @@ msgstr "Home"
 
 #. Hourly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:366
+#: src/components/settings/GeneralSettings.tsx:375
 msgid "settings.general.salary.period.hourly"
 msgstr "Hourly"
 
@@ -1853,16 +1859,16 @@ msgstr "Interview log"
 msgid "myJobs.group.interviewing"
 msgstr "Interviewing"
 
-#. Application tracker status: interviewing
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:450
-msgid "search.tracker.interviewing"
-msgstr "Interviewing"
-
 #. Interviewing status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:21
 msgid "myJobs.status.interviewing"
+msgstr "Interviewing"
+
+#. Application tracker status: interviewing
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:450
+msgid "search.tracker.interviewing"
 msgstr "Interviewing"
 
 #. Status option in dropdown: interviewing
@@ -1910,16 +1916,16 @@ msgstr "Is there a limit to how many jobs I can track?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:121
-msgid "watchlists.explore.jobSingular"
-msgstr "job"
-
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31
 msgid "watchlists.card.jobSingular"
+msgstr "job"
+
+#. Singular job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:121
+msgid "watchlists.explore.jobSingular"
 msgstr "job"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -1948,7 +1954,7 @@ msgstr "Job indexing policy"
 
 #. Job languages settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:226
+#: src/components/settings/GeneralSettings.tsx:235
 msgid "settings.general.jobLanguages.title"
 msgstr "Job languages"
 
@@ -2022,16 +2028,16 @@ msgstr "Job Seek's codebase is open source under MIT. The job data we collect an
 msgid "watchlist.meta.fallback"
 msgstr "Job watchlist by @{owner}"
 
-#. Plural job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:122
-msgid "watchlists.explore.jobPlural"
-msgstr "jobs"
-
 #. Plural job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:32
 msgid "watchlists.card.jobPlural"
+msgstr "jobs"
+
+#. Plural job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:122
+msgid "watchlists.explore.jobPlural"
 msgstr "jobs"
 
 #. js-lingui-explicit-id
@@ -2064,7 +2070,7 @@ msgstr "Keyword"
 
 #. Language settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:197
+#: src/components/settings/GeneralSettings.tsx:206
 msgid "settings.general.language.title"
 msgstr "Language"
 
@@ -2188,35 +2194,35 @@ msgstr "Location"
 msgid "search.advanced.location"
 msgstr "Location"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
-msgstr "Locations"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:842
 msgid "search.bar.locations"
 msgstr "Locations"
 
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:312
+msgid "search.detail.locations"
+msgstr "Locations"
+
 #. Login button label
 #. Login button label
 #. Login button label
 #. Login button label
 #. Login button label
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:117
-#: src/components/AppHeader.tsx:177
-#: src/components/AppHeader.tsx:230
-#: src/components/settings/AccountSettings.tsx:39
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:145
+#: src/components/AppHeader.tsx:168
+#: src/components/AppHeader.tsx:219
+#: src/components/settings/AccountSettings.tsx:45
 #: src/components/settings/BillingSettings.tsx:30
 msgid "common.auth.login"
 msgstr "Log in"
 
 #. Tooltip when user needs to log in to save search
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:111
+#: src/components/search/save-search-button.tsx:122
 msgid "search.saveSearch.tooltipLogin"
 msgstr "Log in to save this search as a watchlist"
 
@@ -2246,7 +2252,7 @@ msgstr "Manage subscription"
 
 #. Connected accounts section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:437
+#: src/components/settings/AccountSettings.tsx:456
 msgid "settings.account.socials.description"
 msgstr "Manage your linked social accounts."
 
@@ -2273,6 +2279,12 @@ msgstr "Mark offer"
 #: src/components/my-jobs/quick-actions.tsx:20
 msgid "myJobs.action.markRejected"
 msgstr "Mark rejected"
+
+#. Header for the server-side search-results cluster shown when the user types in the location modal search box
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:538
+msgid "search.locationModal.searchHitsHeader"
+msgstr "Matches"
 
 #. Maximum salary label
 #. js-lingui-explicit-id
@@ -2337,13 +2349,13 @@ msgid "myJobs.heatmap.day.mon"
 msgstr "Mon"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:133
+#: app/[lang]/layout.tsx:142
 msgid "app.schema.feature.monitor"
 msgstr "Monitor company career pages"
 
 #. Monthly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:360
+#: src/components/settings/GeneralSettings.tsx:369
 msgid "settings.general.salary.period.monthly"
 msgstr "Monthly"
 
@@ -2372,7 +2384,7 @@ msgid "home.features.s1.p2.title"
 msgstr "Multi-dimensional filters"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:135
+#: app/[lang]/layout.tsx:144
 msgid "app.schema.feature.languages"
 msgstr "Multi-language support"
 
@@ -2382,7 +2394,7 @@ msgstr "Multi-language support"
 #. Warning when Enter is pressed but multiple items match
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:247
-#: src/components/search/location-search-modal.tsx:237
+#: src/components/search/location-search-modal.tsx:399
 #: src/components/search/occupation-modal.tsx:180
 #: src/components/search/technology-modal.tsx:88
 msgid "search.bestGuess.ambiguous"
@@ -2402,7 +2414,7 @@ msgstr "My Jobs"
 
 #. My Jobs nav icon tooltip
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:56
+#: src/components/AppHeader.tsx:57
 msgid "app.header.nav.myJobs"
 msgstr "My Jobs"
 
@@ -2426,7 +2438,7 @@ msgstr "Need to reach us?"
 
 #. New email input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:366
+#: src/components/settings/AccountSettings.tsx:385
 msgid "settings.account.email.label"
 msgstr "New email"
 
@@ -2438,7 +2450,7 @@ msgstr "New password"
 
 #. New password input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:96
+#: src/components/settings/AccountSettings.tsx:102
 msgid "settings.account.password.newLabel"
 msgstr "New password"
 
@@ -2478,16 +2490,16 @@ msgstr "No jobs found."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "No languages match your search."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:299
-msgid "search.locationModal.noResults"
-msgstr "No locations match your search."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:309
 msgid "company.locationModal.noResults"
+msgstr "No locations match your search."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:469
+msgid "search.locationModal.noResults"
 msgstr "No locations match your search."
 
 #. No postings found message on company page
@@ -2552,7 +2564,7 @@ msgstr "No watchlists found."
 
 #. Empty state when user has no watchlists
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:124
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:152
 msgid "watchlists.page.empty"
 msgstr "No watchlists yet. Create one to track jobs from your favorite companies."
 
@@ -2602,16 +2614,16 @@ msgstr "Occupation"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Oct"
 
-#. Application tracker status: offer
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:451
-msgid "search.tracker.offer"
-msgstr "Offer"
-
 #. Offered status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
+msgstr "Offer"
+
+#. Application tracker status: offer
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:451
+msgid "search.tracker.offer"
 msgstr "Offer"
 
 #. Status group heading: offered
@@ -2620,16 +2632,16 @@ msgstr "Offer"
 msgid "myJobs.group.offered"
 msgstr "Offered"
 
-#. Sankey funnel node: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:43
-msgid "myJobs.funnel.offered"
-msgstr "Offered"
-
 #. Status option in dropdown: offered
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:38
 msgid "myJobs.statusOption.offered"
+msgstr "Offered"
+
+#. Sankey funnel node: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:43
+msgid "myJobs.funnel.offered"
 msgstr "Offered"
 
 #. Cookie banner accept button
@@ -2662,7 +2674,7 @@ msgstr "One page per minute."
 
 #. Username invalid characters hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:268
+#: src/components/settings/AccountSettings.tsx:287
 msgid "settings.account.username.invalidChars"
 msgstr "Only lowercase letters, numbers, and hyphens (cannot start/end with hyphen)"
 
@@ -2674,7 +2686,7 @@ msgstr "Onsite"
 
 #. Aria label for mobile menu button
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:83
+#: src/components/Header.tsx:89
 msgid "common.header.openMenu"
 msgstr "Open main menu"
 
@@ -2715,7 +2727,7 @@ msgstr "or"
 
 #. Original pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:354
+#: src/components/settings/GeneralSettings.tsx:363
 msgid "settings.general.salary.period.original"
 msgstr "Original"
 
@@ -2745,26 +2757,26 @@ msgstr "Our stance on automation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Overview"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Overview"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Page contents"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Overview"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Page contents"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Page contents"
 
 #. Heading shown on the 404 page
@@ -2794,20 +2806,20 @@ msgstr "Password"
 #. Password section heading
 #. Password section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:83
-#: src/components/settings/AccountSettings.tsx:171
+#: src/components/settings/AccountSettings.tsx:89
+#: src/components/settings/AccountSettings.tsx:177
 msgid "settings.account.password.title"
 msgstr "Password"
 
 #. Success message after password reset request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:163
+#: src/components/settings/AccountSettings.tsx:169
 msgid "settings.account.password.success"
 msgstr "Password reset link sent. Please check your inbox. It may take a few minutes to arrive."
 
 #. Success message after setting password
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:74
+#: src/components/settings/AccountSettings.tsx:80
 msgid "settings.account.password.setSuccess"
 msgstr "Password set successfully."
 
@@ -2831,7 +2843,7 @@ msgstr "Paste a careers page URL for best results, or just type a company name."
 
 #. Label for pay period selector
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:341
+#: src/components/settings/GeneralSettings.tsx:350
 msgid "settings.general.salary.periodLabel"
 msgstr "Pay period"
 
@@ -2855,7 +2867,7 @@ msgstr "Period"
 
 #. Delete account section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:495
+#: src/components/settings/AccountSettings.tsx:514
 msgid "settings.account.delete.description"
 msgstr "Permanently delete your account and all associated data. This action cannot be undone."
 
@@ -2891,7 +2903,7 @@ msgstr "Please enter a company name or URL."
 
 #. Error when email field is empty
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:334
+#: src/components/settings/AccountSettings.tsx:353
 msgid "settings.account.email.required"
 msgstr "Please enter a new email address"
 
@@ -2903,7 +2915,7 @@ msgstr "Please enter a new password"
 
 #. Error when new password is empty
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:65
+#: src/components/settings/AccountSettings.tsx:71
 msgid "settings.account.password.newRequired"
 msgstr "Please enter a password"
 
@@ -2933,7 +2945,7 @@ msgstr "Please fill in all fields"
 
 #. Message when user must log in to see account settings
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:34
+#: src/components/settings/AccountSettings.tsx:40
 msgid "settings.account.loginRequired"
 msgstr "Please log in to manage your account settings."
 
@@ -2955,18 +2967,18 @@ msgstr "Posting not found."
 msgid "myJobs.detail.notFound"
 msgstr "Posting not found."
 
-#. Nav link: Pricing
-#. Nav link: Pricing
-#. js-lingui-explicit-id
-#: src/components/Header.tsx:62
-#: src/components/MobileMenu.tsx:87
-msgid "common.nav.pricing"
-msgstr "Pricing"
-
 #. Pricing section eyebrow
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:100
+#: src/components/Pricing.tsx:103
 msgid "home.pricing.eyebrow"
+msgstr "Pricing"
+
+#. Nav link: Pricing
+#. Nav link: Pricing
+#. js-lingui-explicit-id
+#: src/components/Header.tsx:68
+#: src/components/MobileMenu.tsx:88
+msgid "common.nav.pricing"
 msgstr "Pricing"
 
 #. Privacy policy page eyebrow
@@ -3060,7 +3072,7 @@ msgid "terms.fullTermsLink"
 msgstr "Read the full Terms of Service"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:134
+#: app/[lang]/layout.tsx:143
 msgid "app.schema.feature.alerts"
 msgstr "Real-time job posting alerts"
 
@@ -3094,16 +3106,16 @@ msgstr "Redistribute your changes, as long as you include the MIT notice."
 msgid "location.type.region"
 msgstr "Region"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:309
-msgid "search.locationModal.regionsHeader"
-msgstr "Regions"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:319
 msgid "company.locationModal.regionsHeader"
+msgstr "Regions"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:479
+msgid "search.locationModal.regionsHeader"
 msgstr "Regions"
 
 #. Status group heading: rejected
@@ -3112,28 +3124,28 @@ msgstr "Regions"
 msgid "myJobs.group.rejected"
 msgstr "Rejected"
 
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:452
-msgid "search.tracker.rejected"
-msgstr "Rejected"
-
 #. Rejected status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:23
 msgid "myJobs.status.rejected"
 msgstr "Rejected"
 
-#. Sankey funnel node label prefix: rejected
+#. Application tracker status: rejected
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:45
-msgid "myJobs.funnel.rejected"
+#: src/components/search/job-detail-dialog.tsx:452
+msgid "search.tracker.rejected"
 msgstr "Rejected"
 
 #. Status option in dropdown: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:39
 msgid "myJobs.statusOption.rejected"
+msgstr "Rejected"
+
+#. Sankey funnel node label prefix: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:45
+msgid "myJobs.funnel.rejected"
 msgstr "Rejected"
 
 #. Footer license summary text
@@ -3202,7 +3214,7 @@ msgstr "Resend in {cooldown}s"
 
 #. Reset password button during cooldown with seconds remaining
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:184
+#: src/components/settings/AccountSettings.tsx:190
 msgid "settings.account.password.cooldown"
 msgstr "Resend in {cooldown}s"
 
@@ -3286,7 +3298,7 @@ msgstr "Salary"
 
 #. Salary display settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:312
+#: src/components/settings/GeneralSettings.tsx:321
 msgid "settings.general.salary.title"
 msgstr "Salary display"
 
@@ -3334,7 +3346,7 @@ msgstr "Save some jobs and track your applications to see stats here."
 
 #. Button label to save current search as a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:99
+#: src/components/search/save-search-button.tsx:110
 msgid "search.saveSearch.label"
 msgstr "Save this search"
 
@@ -3350,27 +3362,27 @@ msgstr "Saved"
 msgid "myJobs.status.saved"
 msgstr "Saved"
 
-#. Sankey funnel node: saved jobs
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:41
-msgid "myJobs.funnel.saved"
-msgstr "Saved"
-
 #. Status option in dropdown: saved
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:35
 msgid "myJobs.statusOption.saved"
 msgstr "Saved"
 
+#. Sankey funnel node: saved jobs
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:41
+msgid "myJobs.funnel.saved"
+msgstr "Saved"
+
 #. Username save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:304
+#: src/components/settings/AccountSettings.tsx:323
 msgid "settings.account.username.saving"
 msgstr "Saving..."
 
 #. Email save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:376
+#: src/components/settings/AccountSettings.tsx:395
 msgid "settings.account.email.saving"
 msgstr "Saving..."
 
@@ -3422,16 +3434,16 @@ msgstr "Search jobs across thousands of companies scraped directly from career p
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Search languages..."
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:278
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Search locations..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:288
 msgid "company.locationModal.searchPlaceholder"
+msgstr "Search locations..."
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:448
+msgid "search.locationModal.searchPlaceholder"
 msgstr "Search locations..."
 
 #. Back-to-search link on company page header
@@ -3478,7 +3490,7 @@ msgstr "Select level"
 
 #. Title for the global location selection modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:258
+#: src/components/search/location-search-modal.tsx:428
 msgid "search.locationModal.title"
 msgstr "Select location"
 
@@ -3496,7 +3508,7 @@ msgstr "Select technologies"
 
 #. Language settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:200
+#: src/components/settings/GeneralSettings.tsx:209
 msgid "settings.general.language.description"
 msgstr "Select your preferred language."
 
@@ -3514,15 +3526,9 @@ msgstr "Send reset link"
 
 #. Reset password button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:185
+#: src/components/settings/AccountSettings.tsx:191
 msgid "settings.account.password.send"
 msgstr "Send reset link"
-
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Sending..."
 
 #. Resend button while sending
 #. js-lingui-explicit-id
@@ -3530,9 +3536,15 @@ msgstr "Sending..."
 msgid "auth.verify.resending"
 msgstr "Sending..."
 
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
+msgstr "Sending..."
+
 #. Reset password button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:182
+#: src/components/settings/AccountSettings.tsx:188
 msgid "settings.account.password.sending"
 msgstr "Sending..."
 
@@ -3556,13 +3568,13 @@ msgstr "Set new password"
 
 #. Set password button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:107
+#: src/components/settings/AccountSettings.tsx:113
 msgid "settings.account.password.set"
 msgstr "Set password"
 
 #. Set password button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:106
+#: src/components/settings/AccountSettings.tsx:112
 msgid "settings.account.password.setting"
 msgstr "Setting..."
 
@@ -3574,7 +3586,7 @@ msgstr "Settings"
 
 #. Settings nav icon tooltip
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:57
+#: src/components/AppHeader.tsx:58
 msgid "app.header.nav.settings"
 msgstr "Settings"
 
@@ -3584,16 +3596,16 @@ msgstr "Settings"
 msgid "home.features.s3.p3.title"
 msgstr "Share with anyone"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:355
-msgid "search.detail.showLessLocations"
-msgstr "Show less"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:351
 msgid "company.page.showLess"
+msgstr "Show less"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:355
+msgid "search.detail.showLessLocations"
 msgstr "Show less"
 
 #. Aria label to show password
@@ -3646,7 +3658,7 @@ msgstr "Sign in for more"
 
 #. Prompt for non-logged-in users to sign in to create watchlists
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:108
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:136
 msgid "watchlists.page.loginPrompt"
 msgstr "Sign in to create and manage your own watchlists."
 
@@ -3670,7 +3682,7 @@ msgstr "Sign in to see more job postings"
 
 #. Sign out dropdown menu item
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:117
+#: src/components/AppHeader.tsx:108
 msgid "app.header.signOut"
 msgstr "Sign out"
 
@@ -3706,7 +3718,7 @@ msgstr "Similar companies"
 
 #. Pricing section description
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:106
+#: src/components/Pricing.tsx:109
 msgid "home.pricing.description"
 msgstr "Simple, transparent pricing. Start for free and upgrade when you get serious about your job search."
 
@@ -3728,12 +3740,6 @@ msgstr "Skip to content"
 msgid "error.title"
 msgstr "Something went wrong"
 
-#. Generic forgot password error
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:43
-msgid "auth.forgotPassword.error.generic"
-msgstr "Something went wrong. Please try again."
-
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
@@ -3744,6 +3750,12 @@ msgstr "Something went wrong. Please try again."
 #: app/[lang]/(app)/progress/company-request-form.tsx:22
 #: src/components/search/request-company.tsx:23
 msgid "app.home.request.error.unknown"
+msgstr "Something went wrong. Please try again."
+
+#. Generic forgot password error
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:43
+msgid "auth.forgotPassword.error.generic"
 msgstr "Something went wrong. Please try again."
 
 #. Companies-request page heading when a company name was supplied via query string
@@ -3866,16 +3878,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technical"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Technologies"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:765
 msgid "search.bar.technologies"
+msgstr "Technologies"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:397
+msgid "search.detail.technologies"
 msgstr "Technologies"
 
 #. Add technology filter
@@ -3980,7 +3992,7 @@ msgstr "The short version"
 
 #. Theme settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:167
+#: src/components/settings/GeneralSettings.tsx:176
 msgid "settings.general.theme.title"
 msgstr "Theme"
 
@@ -3998,7 +4010,7 @@ msgstr "This site uses cookies only for authentication and essential functionali
 
 #. Username is reserved hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:270
+#: src/components/settings/AccountSettings.tsx:289
 msgid "settings.account.username.reserved"
 msgstr "This username is reserved"
 
@@ -4087,7 +4099,7 @@ msgid "home.pricing.pro.description"
 msgstr "Unlimited watchlists with email alerts so you never miss an opening."
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:129
+#: app/[lang]/layout.tsx:138
 msgid "app.schema.offer.pro"
 msgstr "Unlimited watchlists, email alerts on new matches"
 
@@ -4105,19 +4117,19 @@ msgstr "Unsave job"
 
 #. Email save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:377
+#: src/components/settings/AccountSettings.tsx:396
 msgid "settings.account.email.save"
 msgstr "Update email"
 
 #. Change email section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:357
+#: src/components/settings/AccountSettings.tsx:376
 msgid "settings.account.email.description"
 msgstr "Update the email address associated with your account."
 
 #. Username save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:305
+#: src/components/settings/AccountSettings.tsx:324
 msgid "settings.account.username.save"
 msgstr "Update username"
 
@@ -4158,25 +4170,25 @@ msgstr "user"
 
 #. Username section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:282
+#: src/components/settings/AccountSettings.tsx:301
 msgid "settings.account.username.title"
 msgstr "Username"
 
 #. Username input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:294
+#: src/components/settings/AccountSettings.tsx:313
 msgid "settings.account.username.label"
 msgstr "Username"
 
 #. Username updated success message
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:256
+#: src/components/settings/AccountSettings.tsx:276
 msgid "settings.account.username.success"
 msgstr "Username updated."
 
 #. Success message after email change request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:346
+#: src/components/settings/AccountSettings.tsx:365
 msgid "settings.account.email.success"
 msgstr "Verification email sent. Please check your inbox. It may take a few minutes to arrive."
 
@@ -4236,7 +4248,7 @@ msgstr "Watchlist limit reached"
 
 #. Title of the watchlists exploration page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:99
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:127
 msgid "watchlists.page.title"
 msgstr "Watchlists"
 
@@ -4248,7 +4260,7 @@ msgstr "Watchlists"
 
 #. Watchlists nav icon tooltip
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:55
+#: src/components/AppHeader.tsx:56
 msgid "app.header.nav.watchlists"
 msgstr "Watchlists"
 
@@ -4259,7 +4271,7 @@ msgid "home.features.s1.p3.title"
 msgstr "Watchlists and alerts"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:136
+#: app/[lang]/layout.tsx:145
 msgid "app.schema.feature.watchlists"
 msgstr "Watchlists and application tracking"
 
@@ -4432,7 +4444,7 @@ msgstr "Work mode"
 
 #. Yearly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:357
+#: src/components/settings/GeneralSettings.tsx:366
 msgid "settings.general.salary.period.yearly"
 msgstr "Yearly"
 
@@ -4517,7 +4529,7 @@ msgstr "You must be at least 16 to use Job Seek."
 
 #. Set password description for OAuth users
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:86
+#: src/components/settings/AccountSettings.tsx:92
 msgid "settings.account.password.setDescription"
 msgstr "You signed in with a social account. Set a password to enable email changes and additional security."
 
@@ -4534,7 +4546,9 @@ msgid "app.home.request.agent.rateLimited"
 msgstr "You've hit the hourly limit for company requests. Please try again later."
 
 #. Reason shown in upgrade modal when watchlist creation limit reached
+#. Reason shown in upgrade modal when watchlist creation limit reached
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:34
 #: src/components/watchlist/watchlist-card.tsx:45
 msgid "upgrade.reason.watchlistLimit"
 msgstr "You've reached your watchlist limit. Upgrade your plan to create more watchlists."
@@ -4544,6 +4558,12 @@ msgstr "You've reached your watchlist limit. Upgrade your plan to create more wa
 #: src/components/watchlist/watchlist-action-bar.tsx:93
 msgid "upgrade.reason.mirrorLimit"
 msgstr "You've reached your watchlist limit. Upgrade your plan to mirror more watchlists."
+
+#. Reason shown in upgrade modal when saving a search hits the watchlist limit
+#. js-lingui-explicit-id
+#: src/components/search/save-search-button.tsx:93
+msgid "upgrade.reason.saveSearch"
+msgstr "You've reached your watchlist limit. Upgrade your plan to save more searches as watchlists."
 
 #. Feature section 3 eyebrow text
 #. js-lingui-explicit-id
@@ -4571,6 +4591,6 @@ msgstr "Your rights"
 
 #. Username section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:285
+#: src/components/settings/AccountSettings.tsx:304
 msgid "settings.account.username.description"
 msgstr "Your unique handle used in your public profile URL."

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -186,14 +186,14 @@ msgstr "À propos"
 #. Nav link: About
 #. Nav link: About
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:56
-#: src/components/MobileMenu.tsx:77
+#: src/components/Header.tsx:62
+#: src/components/MobileMenu.tsx:78
 msgid "common.nav.about"
 msgstr "À propos"
 
 #. Account bottom bar label
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:218
+#: src/components/AppHeader.tsx:207
 msgid "app.header.nav.account"
 msgstr "Compte"
 
@@ -205,7 +205,7 @@ msgstr "Compte"
 
 #. Aria label for user avatar menu
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:84
+#: src/components/AppHeader.tsx:76
 msgid "app.header.avatar.label"
 msgstr "Menu du compte"
 
@@ -285,6 +285,12 @@ msgstr "ajouté — ouvrir"
 msgid "app.home.request.agent.promptRegionLabel"
 msgstr "Prompt de l'agent"
 
+#. Footer shown after all paged countries have been loaded into the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:756
+msgid "search.locationModal.allLoaded"
+msgstr "Tous les {totalCountries} pays chargés"
+
 #. Encryption
 #. js-lingui-explicit-id
 #: src/components/PrivacyPolicyContent.tsx:47
@@ -299,7 +305,7 @@ msgstr "Tous les secteurs"
 
 #. All languages option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:244
+#: src/components/settings/GeneralSettings.tsx:253
 msgid "settings.general.jobLanguages.all"
 msgstr "Toutes les langues"
 
@@ -329,7 +335,7 @@ msgstr "Déjà un compte ? <0>Se connecter</0>"
 
 #. Username is taken
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:276
+#: src/components/settings/AccountSettings.tsx:295
 msgid "settings.account.username.taken"
 msgstr "Déjà pris"
 
@@ -404,28 +410,28 @@ msgstr "candidatures durant l'année écoulée"
 msgid "myJobs.group.applied"
 msgstr "Postulé"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:449
-msgid "search.tracker.applied"
-msgstr "Postulé"
-
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
 msgid "myJobs.status.applied"
 msgstr "Postulé"
 
-#. Sankey funnel node: applied
+#. Application tracker status: applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:42
-msgid "myJobs.funnel.applied"
+#: src/components/search/job-detail-dialog.tsx:449
+msgid "search.tracker.applied"
 msgstr "Postulé"
 
 #. Status option in dropdown: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.applied"
+msgstr "Postulé"
+
+#. Sankey funnel node: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:42
+msgid "myJobs.funnel.applied"
 msgstr "Postulé"
 
 #. Apply salary filter
@@ -460,13 +466,13 @@ msgstr "En dernier recours, nous analysons directement les pages carrières, en 
 
 #. Username too short hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:264
+#: src/components/settings/AccountSettings.tsx:283
 msgid "settings.account.username.tooShort"
 msgstr "3 caractères minimum"
 
 #. Username too long hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:266
+#: src/components/settings/AccountSettings.tsx:285
 msgid "settings.account.username.tooLong"
 msgstr "30 caractères maximum"
 
@@ -478,7 +484,7 @@ msgstr "Aoû"
 
 #. Username is available
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:274
+#: src/components/settings/AccountSettings.tsx:293
 msgid "settings.account.username.available"
 msgstr "Disponible"
 
@@ -518,12 +524,6 @@ msgstr "Retour en haut"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Comportemental"
 
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:145
-msgid "blog.post.backToIndex"
-msgstr "Blog"
-
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:27
@@ -536,18 +536,24 @@ msgstr "Blog"
 msgid "blog.index.heading"
 msgstr "Blog"
 
-#. Nav link: Blog
-#. Nav link: Blog
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:68
-#: src/components/MobileMenu.tsx:97
-msgid "common.nav.blog"
+#: app/[lang]/(public)/blog/[slug]/page.tsx:145
+msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Footer link to /blog index page
 #. js-lingui-explicit-id
 #: src/components/Footer.tsx:52
 msgid "common.footer.blog"
+msgstr "Blog"
+
+#. Nav link: Blog
+#. Nav link: Blog
+#. js-lingui-explicit-id
+#: src/components/Header.tsx:74
+#: src/components/MobileMenu.tsx:98
+msgid "common.nav.blog"
 msgstr "Blog"
 
 #. Subtitle on the sign-in CTA card shown to anonymous users at the end of the similar-companies strip
@@ -599,7 +605,7 @@ msgstr "Annuler"
 
 #. Cancel delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:516
+#: src/components/settings/AccountSettings.tsx:535
 msgid "settings.account.delete.cancel"
 msgstr "Annuler"
 
@@ -611,7 +617,7 @@ msgstr "modifier"
 
 #. Change email section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:354
+#: src/components/settings/AccountSettings.tsx:373
 msgid "settings.account.email.title"
 msgstr "Changer l'e-mail"
 
@@ -629,7 +635,7 @@ msgstr "Changer de langue"
 
 #. Password section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:174
+#: src/components/settings/AccountSettings.tsx:180
 msgid "settings.account.password.description"
 msgstr "Modifie ton mot de passe via un lien e-mail sécurisé."
 
@@ -639,33 +645,33 @@ msgstr "Modifie ton mot de passe via un lien e-mail sécurisé."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Changer…"
 
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "Vérifiez votre e-mail"
-
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
 msgstr "Vérifie ton e-mail"
 
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
+msgstr "Vérifiez votre e-mail"
+
 #. Checking username availability
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:272
+#: src/components/settings/AccountSettings.tsx:291
 msgid "settings.account.username.checking"
 msgstr "Vérification de la disponibilité..."
 
 #. Theme settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:170
+#: src/components/settings/GeneralSettings.tsx:179
 msgid "settings.general.theme.description"
 msgstr "Choisis l'apparence de Job Seek."
 
 #. Salary display settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:315
+#: src/components/settings/GeneralSettings.tsx:324
 msgid "settings.general.salary.description"
 msgstr "Personnalisez l'affichage des salaires dans les résultats de recherche et les détails des offres."
 
@@ -677,13 +683,13 @@ msgstr "Choisissez le plan qui vous convient."
 
 #. Pricing section heading
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:103
+#: src/components/Pricing.tsx:106
 msgid "home.pricing.title"
 msgstr "Choisis l'offre qui te convient"
 
 #. Job languages settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:229
+#: src/components/settings/GeneralSettings.tsx:238
 msgid "settings.general.jobLanguages.description"
 msgstr "Choisissez les langues dans lesquelles vous souhaitez voir les offres d'emploi."
 
@@ -741,7 +747,7 @@ msgstr "API clientes en second."
 
 #. Aria label for close mobile menu button
 #. js-lingui-explicit-id
-#: src/components/MobileMenu.tsx:65
+#: src/components/MobileMenu.tsx:66
 msgid "common.mobileMenu.close"
 msgstr "Fermer le menu"
 
@@ -830,18 +836,18 @@ msgid "company.notFound.title"
 msgstr "Entreprise introuvable"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:111
+#: app/[lang]/layout.tsx:120
 msgid "app.schema.description"
 msgstr "Outil de suivi d'entreprises pour les candidats qui savent déjà dans quelles entreprises ils veulent travailler. Crée des watchlists, reçois des alertes par e-mail dès qu'un nouveau poste s'ouvre, et suis tes candidatures en un seul endroit — les offres viennent directement des pages carrières des entreprises."
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:76
+#: app/[lang]/layout.tsx:85
 msgid "app.schema.org.description"
 msgstr "Outil de suivi d'entreprises pour les candidats ciblés — watchlists, alertes par e-mail et offres directement issues des pages carrières des entreprises. Créé par Colophon Group, un petit studio de développeurs en Suisse."
 
 #. Confirm delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:509
+#: src/components/settings/AccountSettings.tsx:528
 msgid "settings.account.delete.confirm"
 msgstr "Confirmer la suppression"
 
@@ -853,21 +859,15 @@ msgstr "Confirmer le mot de passe"
 
 #. Connect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:459
+#: src/components/settings/AccountSettings.tsx:478
 msgid "settings.account.socials.connect"
 msgstr "Connecter"
 
 #. Connected accounts section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:434
+#: src/components/settings/AccountSettings.tsx:453
 msgid "settings.account.socials.title"
 msgstr "Comptes connectés"
-
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Contact"
 
 #. TOC: Contact
 #. js-lingui-explicit-id
@@ -881,16 +881,22 @@ msgstr "Contact"
 msgid "license.contact.title"
 msgstr "Contact"
 
-#. Table of contents heading
+#. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
-msgstr "Sommaire"
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Contact"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
+msgstr "Sommaire"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Sommaire"
 
 #. Button to continue to app after verification
@@ -999,7 +1005,7 @@ msgstr "Créez un compte gratuit pour parcourir tous les résultats, enregistrer
 
 #. Tooltip explaining save search creates a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:106
+#: src/components/search/save-search-button.tsx:117
 msgid "search.saveSearch.tooltip"
 msgstr "Créer une liste de suivi à partir de vos filtres actuels"
 
@@ -1011,7 +1017,7 @@ msgstr "Créer un compte"
 
 #. Button to create first watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:139
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:167
 msgid "watchlists.page.createFirst"
 msgstr "Créer une liste de suivi"
 
@@ -1029,7 +1035,7 @@ msgstr "Crée une liste de suivi pour chaque niche"
 
 #. Label for currency selector
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:322
+#: src/components/settings/GeneralSettings.tsx:331
 msgid "settings.general.salary.currencyLabel"
 msgstr "Devise"
 
@@ -1047,7 +1053,7 @@ msgstr "Actuel"
 
 #. Daily pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:363
+#: src/components/settings/GeneralSettings.tsx:372
 msgid "settings.general.salary.period.daily"
 msgstr "Journalier"
 
@@ -1101,13 +1107,13 @@ msgstr "Supprimer"
 
 #. Delete account section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:492
+#: src/components/settings/AccountSettings.tsx:511
 msgid "settings.account.delete.title"
 msgstr "Supprimer le compte"
 
 #. Delete account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:502
+#: src/components/settings/AccountSettings.tsx:521
 msgid "settings.account.delete.button"
 msgstr "Supprimer mon compte"
 
@@ -1119,7 +1125,7 @@ msgstr "Supprimer la liste de suivi ?"
 
 #. Delete button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:508
+#: src/components/settings/AccountSettings.tsx:527
 msgid "settings.account.delete.deleting"
 msgstr "Suppression…"
 
@@ -1161,7 +1167,7 @@ msgstr "Désactiver les alertes"
 
 #. Disconnect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:458
+#: src/components/settings/AccountSettings.tsx:477
 msgid "settings.account.socials.disconnect"
 msgstr "Déconnecter"
 
@@ -1325,7 +1331,7 @@ msgstr "Explorer"
 
 #. Explore nav icon tooltip
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:54
+#: src/components/AppHeader.tsx:55
 msgid "app.header.nav.explore"
 msgstr "Explorer"
 
@@ -1336,27 +1342,27 @@ msgstr "Explorer les emplois"
 
 #. Generic email change error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:344
+#: src/components/settings/AccountSettings.tsx:363
 msgid "settings.account.email.error"
 msgstr "Échec du changement d'e-mail"
 
 #. Error when linking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:410
+#: src/components/settings/AccountSettings.tsx:429
 msgid "settings.account.socials.connectError"
 msgstr "Échec de la connexion du compte"
 
 #. Generic account deletion error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:483
+#: src/components/settings/AccountSettings.tsx:502
 msgid "settings.account.delete.error"
 msgstr "Échec de la suppression du compte"
 
 #. Error when unlinking social account fails
 #. Error when unlinking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:421
-#: src/components/settings/AccountSettings.tsx:426
+#: src/components/settings/AccountSettings.tsx:440
+#: src/components/settings/AccountSettings.tsx:445
 msgid "settings.account.socials.disconnectError"
 msgstr "Échec de la déconnexion du compte"
 
@@ -1374,19 +1380,19 @@ msgstr "Impossible de réinitialiser le mot de passe. Le lien a peut-être expir
 
 #. Generic password reset error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:161
+#: src/components/settings/AccountSettings.tsx:167
 msgid "settings.account.password.error"
 msgstr "Échec de l'envoi de l'e-mail de réinitialisation"
 
 #. Generic set password error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:72
+#: src/components/settings/AccountSettings.tsx:78
 msgid "settings.account.password.setError"
 msgstr "Échec de la définition du mot de passe"
 
 #. Generic username update error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:252
+#: src/components/settings/AccountSettings.tsx:264
 msgid "settings.account.username.error"
 msgstr "Échec de la mise à jour du nom d'utilisateur"
 
@@ -1398,16 +1404,16 @@ msgstr "FAQ"
 #. Nav link: FAQ
 #. Nav link: FAQ
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:65
-#: src/components/MobileMenu.tsx:92
+#: src/components/Header.tsx:71
+#: src/components/MobileMenu.tsx:93
 msgid "common.nav.faq"
 msgstr "FAQ"
 
 #. Nav link: Features
 #. Nav link: Features
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:59
-#: src/components/MobileMenu.tsx:82
+#: src/components/Header.tsx:65
+#: src/components/MobileMenu.tsx:83
 msgid "common.nav.features"
 msgstr "Fonctionnalités"
 
@@ -1465,7 +1471,7 @@ msgstr "Filtres"
 
 #. Button to open modal with all languages
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:293
+#: src/components/settings/GeneralSettings.tsx:302
 msgid "settings.general.jobLanguages.findMore"
 msgstr "Rechercher"
 
@@ -1565,7 +1571,7 @@ msgid "settings.billing.free.f2"
 msgstr "Recherche d'emploi complète"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:121
+#: app/[lang]/layout.tsx:130
 msgid "app.schema.offer.free"
 msgstr "Recherche complète, 1 liste de suivi, suivi des candidatures"
 
@@ -1597,9 +1603,9 @@ msgstr "Nous contacter"
 #. Hero primary call-to-action
 #. Hero primary call-to-action
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:32
+#: src/components/Header.tsx:33
 #: src/components/Hero.tsx:15
-#: src/components/MobileMenu.tsx:31
+#: src/components/MobileMenu.tsx:32
 msgid "home.hero.primaryCta"
 msgstr "Commencer"
 
@@ -1659,7 +1665,7 @@ msgstr "Accueil"
 
 #. Hourly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:366
+#: src/components/settings/GeneralSettings.tsx:375
 msgid "settings.general.salary.period.hourly"
 msgstr "Horaire"
 
@@ -1853,16 +1859,16 @@ msgstr "Journal d'entretiens"
 msgid "myJobs.group.interviewing"
 msgstr "En entretien"
 
-#. Application tracker status: interviewing
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:450
-msgid "search.tracker.interviewing"
-msgstr "En entretien"
-
 #. Interviewing status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:21
 msgid "myJobs.status.interviewing"
+msgstr "En entretien"
+
+#. Application tracker status: interviewing
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:450
+msgid "search.tracker.interviewing"
 msgstr "En entretien"
 
 #. Status option in dropdown: interviewing
@@ -1910,16 +1916,16 @@ msgstr "Y a-t-il une limite au nombre d'offres que je peux suivre ?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:121
-msgid "watchlists.explore.jobSingular"
-msgstr "offre"
-
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31
 msgid "watchlists.card.jobSingular"
+msgstr "offre"
+
+#. Singular job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:121
+msgid "watchlists.explore.jobSingular"
 msgstr "offre"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -1948,7 +1954,7 @@ msgstr "Politique d'indexation des offres"
 
 #. Job languages settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:226
+#: src/components/settings/GeneralSettings.tsx:235
 msgid "settings.general.jobLanguages.title"
 msgstr "Langues des offres"
 
@@ -2022,16 +2028,16 @@ msgstr "Le code source de Job Seek est ouvert sous licence MIT. Les données d'e
 msgid "watchlist.meta.fallback"
 msgstr "Liste d'emplois de @{owner}"
 
-#. Plural job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:122
-msgid "watchlists.explore.jobPlural"
-msgstr "offres"
-
 #. Plural job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:32
 msgid "watchlists.card.jobPlural"
+msgstr "offres"
+
+#. Plural job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:122
+msgid "watchlists.explore.jobPlural"
 msgstr "offres"
 
 #. js-lingui-explicit-id
@@ -2064,7 +2070,7 @@ msgstr "Mot-clé"
 
 #. Language settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:197
+#: src/components/settings/GeneralSettings.tsx:206
 msgid "settings.general.language.title"
 msgstr "Langue"
 
@@ -2188,35 +2194,35 @@ msgstr "Lieu"
 msgid "search.advanced.location"
 msgstr "Lieu"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
-msgstr "Lieux"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:842
 msgid "search.bar.locations"
 msgstr "Lieux"
 
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:312
+msgid "search.detail.locations"
+msgstr "Lieux"
+
 #. Login button label
 #. Login button label
 #. Login button label
 #. Login button label
 #. Login button label
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:117
-#: src/components/AppHeader.tsx:177
-#: src/components/AppHeader.tsx:230
-#: src/components/settings/AccountSettings.tsx:39
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:145
+#: src/components/AppHeader.tsx:168
+#: src/components/AppHeader.tsx:219
+#: src/components/settings/AccountSettings.tsx:45
 #: src/components/settings/BillingSettings.tsx:30
 msgid "common.auth.login"
 msgstr "Se connecter"
 
 #. Tooltip when user needs to log in to save search
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:111
+#: src/components/search/save-search-button.tsx:122
 msgid "search.saveSearch.tooltipLogin"
 msgstr "Connectez-vous pour enregistrer cette recherche comme liste de suivi"
 
@@ -2246,7 +2252,7 @@ msgstr "Gérer l'abonnement"
 
 #. Connected accounts section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:437
+#: src/components/settings/AccountSettings.tsx:456
 msgid "settings.account.socials.description"
 msgstr "Gère tes comptes sociaux liés."
 
@@ -2273,6 +2279,12 @@ msgstr "Marquer comme offre"
 #: src/components/my-jobs/quick-actions.tsx:20
 msgid "myJobs.action.markRejected"
 msgstr "Marquer comme refusé"
+
+#. Header for the server-side search-results cluster shown when the user types in the location modal search box
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:538
+msgid "search.locationModal.searchHitsHeader"
+msgstr "Correspondances"
 
 #. Maximum salary label
 #. js-lingui-explicit-id
@@ -2337,13 +2349,13 @@ msgid "myJobs.heatmap.day.mon"
 msgstr "Lun"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:133
+#: app/[lang]/layout.tsx:142
 msgid "app.schema.feature.monitor"
 msgstr "Surveiller les pages carrières des entreprises"
 
 #. Monthly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:360
+#: src/components/settings/GeneralSettings.tsx:369
 msgid "settings.general.salary.period.monthly"
 msgstr "Mensuel"
 
@@ -2372,7 +2384,7 @@ msgid "home.features.s1.p2.title"
 msgstr "Filtres multi-dimensionnels"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:135
+#: app/[lang]/layout.tsx:144
 msgid "app.schema.feature.languages"
 msgstr "Support multilingue"
 
@@ -2382,7 +2394,7 @@ msgstr "Support multilingue"
 #. Warning when Enter is pressed but multiple items match
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:247
-#: src/components/search/location-search-modal.tsx:237
+#: src/components/search/location-search-modal.tsx:399
 #: src/components/search/occupation-modal.tsx:180
 #: src/components/search/technology-modal.tsx:88
 msgid "search.bestGuess.ambiguous"
@@ -2402,7 +2414,7 @@ msgstr "Mes emplois"
 
 #. My Jobs nav icon tooltip
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:56
+#: src/components/AppHeader.tsx:57
 msgid "app.header.nav.myJobs"
 msgstr "Mes emplois"
 
@@ -2426,7 +2438,7 @@ msgstr "Besoin de nous contacter ?"
 
 #. New email input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:366
+#: src/components/settings/AccountSettings.tsx:385
 msgid "settings.account.email.label"
 msgstr "Nouvel e-mail"
 
@@ -2438,7 +2450,7 @@ msgstr "Nouveau mot de passe"
 
 #. New password input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:96
+#: src/components/settings/AccountSettings.tsx:102
 msgid "settings.account.password.newLabel"
 msgstr "Nouveau mot de passe"
 
@@ -2478,16 +2490,16 @@ msgstr "Aucune offre trouvée."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Aucune langue ne correspond à votre recherche."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:299
-msgid "search.locationModal.noResults"
-msgstr "Aucun lieu ne correspond à votre recherche."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:309
 msgid "company.locationModal.noResults"
+msgstr "Aucun lieu ne correspond à votre recherche."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:469
+msgid "search.locationModal.noResults"
 msgstr "Aucun lieu ne correspond à votre recherche."
 
 #. No postings found message on company page
@@ -2552,7 +2564,7 @@ msgstr "Aucune liste de suivi trouvée."
 
 #. Empty state when user has no watchlists
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:124
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:152
 msgid "watchlists.page.empty"
 msgstr "Aucune liste de suivi pour l'instant. Créez-en une pour suivre les offres de vos entreprises préférées."
 
@@ -2602,16 +2614,16 @@ msgstr "Métier"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Oct"
 
-#. Application tracker status: offer
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:451
-msgid "search.tracker.offer"
-msgstr "Offre"
-
 #. Offered status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
+msgstr "Offre"
+
+#. Application tracker status: offer
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:451
+msgid "search.tracker.offer"
 msgstr "Offre"
 
 #. Status group heading: offered
@@ -2620,16 +2632,16 @@ msgstr "Offre"
 msgid "myJobs.group.offered"
 msgstr "Offre"
 
-#. Sankey funnel node: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:43
-msgid "myJobs.funnel.offered"
-msgstr "Offre"
-
 #. Status option in dropdown: offered
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:38
 msgid "myJobs.statusOption.offered"
+msgstr "Offre"
+
+#. Sankey funnel node: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:43
+msgid "myJobs.funnel.offered"
 msgstr "Offre"
 
 #. Cookie banner accept button
@@ -2662,7 +2674,7 @@ msgstr "Une page par minute."
 
 #. Username invalid characters hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:268
+#: src/components/settings/AccountSettings.tsx:287
 msgid "settings.account.username.invalidChars"
 msgstr "Uniquement des lettres minuscules, des chiffres et des tirets (pas au début/fin)"
 
@@ -2674,7 +2686,7 @@ msgstr "Sur site"
 
 #. Aria label for mobile menu button
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:83
+#: src/components/Header.tsx:89
 msgid "common.header.openMenu"
 msgstr "Ouvrir le menu principal"
 
@@ -2715,7 +2727,7 @@ msgstr "ou"
 
 #. Original pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:354
+#: src/components/settings/GeneralSettings.tsx:363
 msgid "settings.general.salary.period.original"
 msgstr "Original"
 
@@ -2745,26 +2757,26 @@ msgstr "Notre position sur l'automatisation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Aperçu"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Aperçu"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Sommaire de la page"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Aperçu"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Sommaire de la page"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Sommaire de la page"
 
 #. Heading shown on the 404 page
@@ -2794,20 +2806,20 @@ msgstr "Mot de passe"
 #. Password section heading
 #. Password section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:83
-#: src/components/settings/AccountSettings.tsx:171
+#: src/components/settings/AccountSettings.tsx:89
+#: src/components/settings/AccountSettings.tsx:177
 msgid "settings.account.password.title"
 msgstr "Mot de passe"
 
 #. Success message after password reset request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:163
+#: src/components/settings/AccountSettings.tsx:169
 msgid "settings.account.password.success"
 msgstr "Lien de réinitialisation envoyé. Vérifie ta boîte de réception. La réception peut prendre quelques minutes."
 
 #. Success message after setting password
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:74
+#: src/components/settings/AccountSettings.tsx:80
 msgid "settings.account.password.setSuccess"
 msgstr "Mot de passe défini avec succès."
 
@@ -2831,7 +2843,7 @@ msgstr "Entrez un nom d'entreprise ou l'URL d'une page carrières et nous commen
 
 #. Label for pay period selector
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:341
+#: src/components/settings/GeneralSettings.tsx:350
 msgid "settings.general.salary.periodLabel"
 msgstr "Période"
 
@@ -2855,7 +2867,7 @@ msgstr "Période"
 
 #. Delete account section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:495
+#: src/components/settings/AccountSettings.tsx:514
 msgid "settings.account.delete.description"
 msgstr "Supprime définitivement ton compte et toutes les données associées. Cette action est irréversible."
 
@@ -2891,7 +2903,7 @@ msgstr "Veuillez entrer un nom d'entreprise ou une URL."
 
 #. Error when email field is empty
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:334
+#: src/components/settings/AccountSettings.tsx:353
 msgid "settings.account.email.required"
 msgstr "Saisis une nouvelle adresse e-mail"
 
@@ -2903,7 +2915,7 @@ msgstr "Entre un nouveau mot de passe"
 
 #. Error when new password is empty
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:65
+#: src/components/settings/AccountSettings.tsx:71
 msgid "settings.account.password.newRequired"
 msgstr "Saisis un mot de passe"
 
@@ -2933,7 +2945,7 @@ msgstr "Remplis tous les champs"
 
 #. Message when user must log in to see account settings
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:34
+#: src/components/settings/AccountSettings.tsx:40
 msgid "settings.account.loginRequired"
 msgstr "Connecte-toi pour gérer les paramètres de ton compte."
 
@@ -2955,18 +2967,18 @@ msgstr "Offre non trouvée."
 msgid "myJobs.detail.notFound"
 msgstr "Offre introuvable."
 
-#. Nav link: Pricing
-#. Nav link: Pricing
-#. js-lingui-explicit-id
-#: src/components/Header.tsx:62
-#: src/components/MobileMenu.tsx:87
-msgid "common.nav.pricing"
-msgstr "Tarifs"
-
 #. Pricing section eyebrow
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:100
+#: src/components/Pricing.tsx:103
 msgid "home.pricing.eyebrow"
+msgstr "Tarifs"
+
+#. Nav link: Pricing
+#. Nav link: Pricing
+#. js-lingui-explicit-id
+#: src/components/Header.tsx:68
+#: src/components/MobileMenu.tsx:88
+msgid "common.nav.pricing"
 msgstr "Tarifs"
 
 #. Privacy policy page eyebrow
@@ -3060,7 +3072,7 @@ msgid "terms.fullTermsLink"
 msgstr "Lire les conditions d'utilisation complètes"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:134
+#: app/[lang]/layout.tsx:143
 msgid "app.schema.feature.alerts"
 msgstr "Alertes en temps réel sur les nouvelles offres"
 
@@ -3094,16 +3106,16 @@ msgstr "Redistribue tes modifications, à condition d'inclure la mention MIT."
 msgid "location.type.region"
 msgstr "Région"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:309
-msgid "search.locationModal.regionsHeader"
-msgstr "Régions"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:319
 msgid "company.locationModal.regionsHeader"
+msgstr "Régions"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:479
+msgid "search.locationModal.regionsHeader"
 msgstr "Régions"
 
 #. Status group heading: rejected
@@ -3112,28 +3124,28 @@ msgstr "Régions"
 msgid "myJobs.group.rejected"
 msgstr "Refusé"
 
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:452
-msgid "search.tracker.rejected"
-msgstr "Refusé"
-
 #. Rejected status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:23
 msgid "myJobs.status.rejected"
 msgstr "Refusé"
 
-#. Sankey funnel node label prefix: rejected
+#. Application tracker status: rejected
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:45
-msgid "myJobs.funnel.rejected"
+#: src/components/search/job-detail-dialog.tsx:452
+msgid "search.tracker.rejected"
 msgstr "Refusé"
 
 #. Status option in dropdown: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:39
 msgid "myJobs.statusOption.rejected"
+msgstr "Refusé"
+
+#. Sankey funnel node label prefix: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:45
+msgid "myJobs.funnel.rejected"
 msgstr "Refusé"
 
 #. Footer license summary text
@@ -3202,7 +3214,7 @@ msgstr "Renvoyer dans {cooldown}s"
 
 #. Reset password button during cooldown with seconds remaining
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:184
+#: src/components/settings/AccountSettings.tsx:190
 msgid "settings.account.password.cooldown"
 msgstr "Renvoyer dans {cooldown}s"
 
@@ -3286,7 +3298,7 @@ msgstr "Salaire"
 
 #. Salary display settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:312
+#: src/components/settings/GeneralSettings.tsx:321
 msgid "settings.general.salary.title"
 msgstr "Affichage du salaire"
 
@@ -3334,7 +3346,7 @@ msgstr "Enregistrez des offres et suivez vos candidatures pour voir des statisti
 
 #. Button label to save current search as a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:99
+#: src/components/search/save-search-button.tsx:110
 msgid "search.saveSearch.label"
 msgstr "Enregistrer cette recherche"
 
@@ -3350,27 +3362,27 @@ msgstr "Enregistré"
 msgid "myJobs.status.saved"
 msgstr "Enregistré"
 
-#. Sankey funnel node: saved jobs
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:41
-msgid "myJobs.funnel.saved"
-msgstr "Enregistré"
-
 #. Status option in dropdown: saved
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:35
 msgid "myJobs.statusOption.saved"
 msgstr "Enregistré"
 
+#. Sankey funnel node: saved jobs
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:41
+msgid "myJobs.funnel.saved"
+msgstr "Enregistré"
+
 #. Username save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:304
+#: src/components/settings/AccountSettings.tsx:323
 msgid "settings.account.username.saving"
 msgstr "Enregistrement..."
 
 #. Email save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:376
+#: src/components/settings/AccountSettings.tsx:395
 msgid "settings.account.email.saving"
 msgstr "Enregistrement…"
 
@@ -3422,17 +3434,17 @@ msgstr "Recherchez des emplois dans des milliers d'entreprises, scrapés directe
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Rechercher des langues…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:278
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Rechercher des lieux..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:288
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Rechercher des lieux…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:448
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Rechercher des lieux..."
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3478,7 +3490,7 @@ msgstr "Sélectionner le niveau"
 
 #. Title for the global location selection modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:258
+#: src/components/search/location-search-modal.tsx:428
 msgid "search.locationModal.title"
 msgstr "Sélectionner le lieu"
 
@@ -3496,7 +3508,7 @@ msgstr "Sélectionner les technologies"
 
 #. Language settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:200
+#: src/components/settings/GeneralSettings.tsx:209
 msgid "settings.general.language.description"
 msgstr "Sélectionne ta langue préférée."
 
@@ -3514,15 +3526,9 @@ msgstr "Envoyer le lien"
 
 #. Reset password button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:185
+#: src/components/settings/AccountSettings.tsx:191
 msgid "settings.account.password.send"
 msgstr "Envoyer le lien"
-
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Envoi en cours..."
 
 #. Resend button while sending
 #. js-lingui-explicit-id
@@ -3530,9 +3536,15 @@ msgstr "Envoi en cours..."
 msgid "auth.verify.resending"
 msgstr "Envoi en cours..."
 
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
+msgstr "Envoi en cours..."
+
 #. Reset password button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:182
+#: src/components/settings/AccountSettings.tsx:188
 msgid "settings.account.password.sending"
 msgstr "Envoi…"
 
@@ -3556,13 +3568,13 @@ msgstr "Définir un nouveau mot de passe"
 
 #. Set password button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:107
+#: src/components/settings/AccountSettings.tsx:113
 msgid "settings.account.password.set"
 msgstr "Définir le mot de passe"
 
 #. Set password button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:106
+#: src/components/settings/AccountSettings.tsx:112
 msgid "settings.account.password.setting"
 msgstr "Définition…"
 
@@ -3574,7 +3586,7 @@ msgstr "Paramètres"
 
 #. Settings nav icon tooltip
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:57
+#: src/components/AppHeader.tsx:58
 msgid "app.header.nav.settings"
 msgstr "Paramètres"
 
@@ -3584,16 +3596,16 @@ msgstr "Paramètres"
 msgid "home.features.s3.p3.title"
 msgstr "Partager avec tout le monde"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:355
-msgid "search.detail.showLessLocations"
-msgstr "Afficher moins"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:351
 msgid "company.page.showLess"
+msgstr "Afficher moins"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:355
+msgid "search.detail.showLessLocations"
 msgstr "Afficher moins"
 
 #. Aria label to show password
@@ -3646,7 +3658,7 @@ msgstr "Se connecter pour en voir plus"
 
 #. Prompt for non-logged-in users to sign in to create watchlists
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:108
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:136
 msgid "watchlists.page.loginPrompt"
 msgstr "Connectez-vous pour créer et gérer vos propres listes de suivi."
 
@@ -3670,7 +3682,7 @@ msgstr "Connectez-vous pour voir plus d'offres d'emploi"
 
 #. Sign out dropdown menu item
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:117
+#: src/components/AppHeader.tsx:108
 msgid "app.header.signOut"
 msgstr "Se déconnecter"
 
@@ -3706,7 +3718,7 @@ msgstr "Entreprises similaires"
 
 #. Pricing section description
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:106
+#: src/components/Pricing.tsx:109
 msgid "home.pricing.description"
 msgstr "Des tarifs simples et transparents. Commence gratuitement et passe à la vitesse supérieure quand ta recherche d'emploi devient sérieuse."
 
@@ -3728,12 +3740,6 @@ msgstr "Aller au contenu"
 msgid "error.title"
 msgstr "Une erreur est survenue"
 
-#. Generic forgot password error
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:43
-msgid "auth.forgotPassword.error.generic"
-msgstr "Une erreur est survenue. Veuillez réessayer."
-
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
@@ -3745,6 +3751,12 @@ msgstr "Une erreur est survenue. Veuillez réessayer."
 #: src/components/search/request-company.tsx:23
 msgid "app.home.request.error.unknown"
 msgstr "Une erreur s'est produite. Veuillez réessayer."
+
+#. Generic forgot password error
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:43
+msgid "auth.forgotPassword.error.generic"
+msgstr "Une erreur est survenue. Veuillez réessayer."
 
 #. Companies-request page heading when a company name was supplied via query string
 #. js-lingui-explicit-id
@@ -3866,16 +3878,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technique"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Technologies"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:765
 msgid "search.bar.technologies"
+msgstr "Technologies"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:397
+msgid "search.detail.technologies"
 msgstr "Technologies"
 
 #. Add technology filter
@@ -3980,7 +3992,7 @@ msgstr "En bref"
 
 #. Theme settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:167
+#: src/components/settings/GeneralSettings.tsx:176
 msgid "settings.general.theme.title"
 msgstr "Thème"
 
@@ -3998,7 +4010,7 @@ msgstr "Ce site utilise des cookies uniquement pour l'authentification et les fo
 
 #. Username is reserved hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:270
+#: src/components/settings/AccountSettings.tsx:289
 msgid "settings.account.username.reserved"
 msgstr "Ce nom d'utilisateur est réservé"
 
@@ -4087,7 +4099,7 @@ msgid "home.pricing.pro.description"
 msgstr "Watchlists illimitées avec alertes par e-mail pour ne jamais rater une ouverture."
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:129
+#: app/[lang]/layout.tsx:138
 msgid "app.schema.offer.pro"
 msgstr "Listes de suivi illimitées, alertes email sur les nouveaux résultats"
 
@@ -4105,19 +4117,19 @@ msgstr "Retirer l'offre"
 
 #. Email save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:377
+#: src/components/settings/AccountSettings.tsx:396
 msgid "settings.account.email.save"
 msgstr "Mettre à jour l'e-mail"
 
 #. Change email section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:357
+#: src/components/settings/AccountSettings.tsx:376
 msgid "settings.account.email.description"
 msgstr "Mets à jour l'adresse e-mail associée à ton compte."
 
 #. Username save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:305
+#: src/components/settings/AccountSettings.tsx:324
 msgid "settings.account.username.save"
 msgstr "Mettre à jour le nom d'utilisateur"
 
@@ -4158,25 +4170,25 @@ msgstr "utilisateur"
 
 #. Username section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:282
+#: src/components/settings/AccountSettings.tsx:301
 msgid "settings.account.username.title"
 msgstr "Nom d'utilisateur"
 
 #. Username input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:294
+#: src/components/settings/AccountSettings.tsx:313
 msgid "settings.account.username.label"
 msgstr "Nom d'utilisateur"
 
 #. Username updated success message
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:256
+#: src/components/settings/AccountSettings.tsx:276
 msgid "settings.account.username.success"
 msgstr "Nom d'utilisateur mis à jour."
 
 #. Success message after email change request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:346
+#: src/components/settings/AccountSettings.tsx:365
 msgid "settings.account.email.success"
 msgstr "E-mail de vérification envoyé. Vérifie ta boîte de réception. La réception peut prendre quelques minutes."
 
@@ -4236,7 +4248,7 @@ msgstr "Limite de listes atteinte"
 
 #. Title of the watchlists exploration page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:99
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:127
 msgid "watchlists.page.title"
 msgstr "Listes de suivi"
 
@@ -4248,7 +4260,7 @@ msgstr "Listes de suivi"
 
 #. Watchlists nav icon tooltip
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:55
+#: src/components/AppHeader.tsx:56
 msgid "app.header.nav.watchlists"
 msgstr "Listes de suivi"
 
@@ -4259,7 +4271,7 @@ msgid "home.features.s1.p3.title"
 msgstr "Watchlists et alertes"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:136
+#: app/[lang]/layout.tsx:145
 msgid "app.schema.feature.watchlists"
 msgstr "Listes de suivi et suivi des candidatures"
 
@@ -4432,7 +4444,7 @@ msgstr "Mode de travail"
 
 #. Yearly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:357
+#: src/components/settings/GeneralSettings.tsx:366
 msgid "settings.general.salary.period.yearly"
 msgstr "Annuel"
 
@@ -4517,7 +4529,7 @@ msgstr "Tu dois avoir au moins 16 ans pour utiliser Job Seek."
 
 #. Set password description for OAuth users
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:86
+#: src/components/settings/AccountSettings.tsx:92
 msgid "settings.account.password.setDescription"
 msgstr "Tu t'es connecté avec un compte social. Définis un mot de passe pour permettre les changements d'e-mail et renforcer la sécurité."
 
@@ -4534,7 +4546,9 @@ msgid "app.home.request.agent.rateLimited"
 msgstr "Vous avez atteint la limite horaire de demandes d'entreprises. Veuillez réessayer plus tard."
 
 #. Reason shown in upgrade modal when watchlist creation limit reached
+#. Reason shown in upgrade modal when watchlist creation limit reached
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:34
 #: src/components/watchlist/watchlist-card.tsx:45
 msgid "upgrade.reason.watchlistLimit"
 msgstr "Vous avez atteint la limite de vos listes de suivi. Passez à un plan supérieur pour en créer davantage."
@@ -4544,6 +4558,12 @@ msgstr "Vous avez atteint la limite de vos listes de suivi. Passez à un plan su
 #: src/components/watchlist/watchlist-action-bar.tsx:93
 msgid "upgrade.reason.mirrorLimit"
 msgstr "Vous avez atteint la limite de vos listes de suivi. Passez à un plan supérieur pour en copier davantage."
+
+#. Reason shown in upgrade modal when saving a search hits the watchlist limit
+#. js-lingui-explicit-id
+#: src/components/search/save-search-button.tsx:93
+msgid "upgrade.reason.saveSearch"
+msgstr "Vous avez atteint la limite de vos listes de suivi. Passez à un plan supérieur pour enregistrer davantage de recherches."
 
 #. Feature section 3 eyebrow text
 #. js-lingui-explicit-id
@@ -4571,6 +4591,6 @@ msgstr "Tes droits"
 
 #. Username section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:285
+#: src/components/settings/AccountSettings.tsx:304
 msgid "settings.account.username.description"
 msgstr "Votre identifiant unique utilisé dans l'URL de votre profil public."

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -186,14 +186,14 @@ msgstr "Chi siamo"
 #. Nav link: About
 #. Nav link: About
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:56
-#: src/components/MobileMenu.tsx:77
+#: src/components/Header.tsx:62
+#: src/components/MobileMenu.tsx:78
 msgid "common.nav.about"
 msgstr "Chi siamo"
 
 #. Account bottom bar label
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:218
+#: src/components/AppHeader.tsx:207
 msgid "app.header.nav.account"
 msgstr "Account"
 
@@ -205,7 +205,7 @@ msgstr "Account"
 
 #. Aria label for user avatar menu
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:84
+#: src/components/AppHeader.tsx:76
 msgid "app.header.avatar.label"
 msgstr "Menu account"
 
@@ -285,6 +285,12 @@ msgstr "aggiunta — apri"
 msgid "app.home.request.agent.promptRegionLabel"
 msgstr "Prompt dell'agente"
 
+#. Footer shown after all paged countries have been loaded into the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:756
+msgid "search.locationModal.allLoaded"
+msgstr "Tutti i {totalCountries} paesi caricati"
+
 #. Encryption
 #. js-lingui-explicit-id
 #: src/components/PrivacyPolicyContent.tsx:47
@@ -299,7 +305,7 @@ msgstr "Tutti i settori"
 
 #. All languages option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:244
+#: src/components/settings/GeneralSettings.tsx:253
 msgid "settings.general.jobLanguages.all"
 msgstr "Tutte le lingue"
 
@@ -329,7 +335,7 @@ msgstr "Hai già un account? <0>Accedi</0>"
 
 #. Username is taken
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:276
+#: src/components/settings/AccountSettings.tsx:295
 msgid "settings.account.username.taken"
 msgstr "Già in uso"
 
@@ -404,28 +410,28 @@ msgstr "candidature nell'ultimo anno"
 msgid "myJobs.group.applied"
 msgstr "Candidato"
 
-#. Application tracker status: applied
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:449
-msgid "search.tracker.applied"
-msgstr "Candidato"
-
 #. Applied status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:20
 msgid "myJobs.status.applied"
 msgstr "Candidato"
 
-#. Sankey funnel node: applied
+#. Application tracker status: applied
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:42
-msgid "myJobs.funnel.applied"
+#: src/components/search/job-detail-dialog.tsx:449
+msgid "search.tracker.applied"
 msgstr "Candidato"
 
 #. Status option in dropdown: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.applied"
+msgstr "Candidato"
+
+#. Sankey funnel node: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:42
+msgid "myJobs.funnel.applied"
 msgstr "Candidato"
 
 #. Apply salary filter
@@ -460,13 +466,13 @@ msgstr "Come ultima risorsa analizziamo le pagine carriere stesse, preferendo l'
 
 #. Username too short hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:264
+#: src/components/settings/AccountSettings.tsx:283
 msgid "settings.account.username.tooShort"
 msgstr "Minimo 3 caratteri"
 
 #. Username too long hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:266
+#: src/components/settings/AccountSettings.tsx:285
 msgid "settings.account.username.tooLong"
 msgstr "Massimo 30 caratteri"
 
@@ -478,7 +484,7 @@ msgstr "Ago"
 
 #. Username is available
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:274
+#: src/components/settings/AccountSettings.tsx:293
 msgid "settings.account.username.available"
 msgstr "Disponibile"
 
@@ -518,12 +524,6 @@ msgstr "Torna su"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Comportamentale"
 
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:145
-msgid "blog.post.backToIndex"
-msgstr "Blog"
-
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:27
@@ -536,18 +536,24 @@ msgstr "Blog"
 msgid "blog.index.heading"
 msgstr "Blog"
 
-#. Nav link: Blog
-#. Nav link: Blog
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:68
-#: src/components/MobileMenu.tsx:97
-msgid "common.nav.blog"
+#: app/[lang]/(public)/blog/[slug]/page.tsx:145
+msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Footer link to /blog index page
 #. js-lingui-explicit-id
 #: src/components/Footer.tsx:52
 msgid "common.footer.blog"
+msgstr "Blog"
+
+#. Nav link: Blog
+#. Nav link: Blog
+#. js-lingui-explicit-id
+#: src/components/Header.tsx:74
+#: src/components/MobileMenu.tsx:98
+msgid "common.nav.blog"
 msgstr "Blog"
 
 #. Subtitle on the sign-in CTA card shown to anonymous users at the end of the similar-companies strip
@@ -599,7 +605,7 @@ msgstr "Annulla"
 
 #. Cancel delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:516
+#: src/components/settings/AccountSettings.tsx:535
 msgid "settings.account.delete.cancel"
 msgstr "Annulla"
 
@@ -611,7 +617,7 @@ msgstr "modifica"
 
 #. Change email section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:354
+#: src/components/settings/AccountSettings.tsx:373
 msgid "settings.account.email.title"
 msgstr "Cambia email"
 
@@ -629,7 +635,7 @@ msgstr "Cambia lingua"
 
 #. Password section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:174
+#: src/components/settings/AccountSettings.tsx:180
 msgid "settings.account.password.description"
 msgstr "Cambia la tua password tramite un link email sicuro."
 
@@ -639,33 +645,33 @@ msgstr "Cambia la tua password tramite un link email sicuro."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Cambia…"
 
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "Controlla la tua e-mail"
-
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
 msgstr "Controlla la tua email"
 
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
+msgstr "Controlla la tua e-mail"
+
 #. Checking username availability
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:272
+#: src/components/settings/AccountSettings.tsx:291
 msgid "settings.account.username.checking"
 msgstr "Verifica disponibilità..."
 
 #. Theme settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:170
+#: src/components/settings/GeneralSettings.tsx:179
 msgid "settings.general.theme.description"
 msgstr "Scegli l'aspetto di Job Seek."
 
 #. Salary display settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:315
+#: src/components/settings/GeneralSettings.tsx:324
 msgid "settings.general.salary.description"
 msgstr "Personalizza come vengono visualizzati gli stipendi nei risultati di ricerca e nei dettagli delle offerte."
 
@@ -677,13 +683,13 @@ msgstr "Scegli il piano più adatto a te."
 
 #. Pricing section heading
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:103
+#: src/components/Pricing.tsx:106
 msgid "home.pricing.title"
 msgstr "Scegli il piano giusto per te"
 
 #. Job languages settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:229
+#: src/components/settings/GeneralSettings.tsx:238
 msgid "settings.general.jobLanguages.description"
 msgstr "Scegli in quali lingue vuoi vedere le offerte di lavoro."
 
@@ -741,7 +747,7 @@ msgstr "API client come seconda opzione."
 
 #. Aria label for close mobile menu button
 #. js-lingui-explicit-id
-#: src/components/MobileMenu.tsx:65
+#: src/components/MobileMenu.tsx:66
 msgid "common.mobileMenu.close"
 msgstr "Chiudi menu"
 
@@ -830,18 +836,18 @@ msgid "company.notFound.title"
 msgstr "Azienda non trovata"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:111
+#: app/[lang]/layout.tsx:120
 msgid "app.schema.description"
 msgstr "Strumento di tracciamento aziende per chi cerca lavoro e sa già in quali aziende vuole lavorare. Crea watchlist, ricevi avvisi via email quando si aprono nuove posizioni e monitora le candidature in un unico posto — annunci direttamente dalle pagine carriere delle aziende."
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:76
+#: app/[lang]/layout.tsx:85
 msgid "app.schema.org.description"
 msgstr "Strumento di tracciamento aziende per chi cerca lavoro in modo mirato — watchlist, avvisi via email e annunci direttamente dalle pagine carriere delle aziende. Creato da Colophon Group, un piccolo studio di sviluppatori in Svizzera."
 
 #. Confirm delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:509
+#: src/components/settings/AccountSettings.tsx:528
 msgid "settings.account.delete.confirm"
 msgstr "Conferma eliminazione"
 
@@ -853,21 +859,15 @@ msgstr "Conferma password"
 
 #. Connect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:459
+#: src/components/settings/AccountSettings.tsx:478
 msgid "settings.account.socials.connect"
 msgstr "Collega"
 
 #. Connected accounts section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:434
+#: src/components/settings/AccountSettings.tsx:453
 msgid "settings.account.socials.title"
 msgstr "Account collegati"
-
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Contatti"
 
 #. TOC: Contact
 #. js-lingui-explicit-id
@@ -881,16 +881,22 @@ msgstr "Contatti"
 msgid "license.contact.title"
 msgstr "Contatti"
 
-#. Table of contents heading
+#. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
-msgid "indexing.toc.title"
-msgstr "Sommario"
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Contatti"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.title"
+msgstr "Sommario"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:23
+msgid "indexing.toc.title"
 msgstr "Sommario"
 
 #. Button to continue to app after verification
@@ -999,7 +1005,7 @@ msgstr "Crea un account gratuito per consultare tutti i risultati, salvare offer
 
 #. Tooltip explaining save search creates a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:106
+#: src/components/search/save-search-button.tsx:117
 msgid "search.saveSearch.tooltip"
 msgstr "Crea una watchlist dai tuoi filtri attuali"
 
@@ -1011,7 +1017,7 @@ msgstr "Crea un account"
 
 #. Button to create first watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:139
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:167
 msgid "watchlists.page.createFirst"
 msgstr "Crea lista di osservazione"
 
@@ -1029,7 +1035,7 @@ msgstr "Crea una watchlist per ogni nicchia"
 
 #. Label for currency selector
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:322
+#: src/components/settings/GeneralSettings.tsx:331
 msgid "settings.general.salary.currencyLabel"
 msgstr "Valuta"
 
@@ -1047,7 +1053,7 @@ msgstr "Attuale"
 
 #. Daily pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:363
+#: src/components/settings/GeneralSettings.tsx:372
 msgid "settings.general.salary.period.daily"
 msgstr "Giornaliero"
 
@@ -1101,13 +1107,13 @@ msgstr "Elimina"
 
 #. Delete account section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:492
+#: src/components/settings/AccountSettings.tsx:511
 msgid "settings.account.delete.title"
 msgstr "Elimina account"
 
 #. Delete account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:502
+#: src/components/settings/AccountSettings.tsx:521
 msgid "settings.account.delete.button"
 msgstr "Elimina il mio account"
 
@@ -1119,7 +1125,7 @@ msgstr "Eliminare la lista di osservazione?"
 
 #. Delete button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:508
+#: src/components/settings/AccountSettings.tsx:527
 msgid "settings.account.delete.deleting"
 msgstr "Eliminazione…"
 
@@ -1161,7 +1167,7 @@ msgstr "Disattiva notifiche"
 
 #. Disconnect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:458
+#: src/components/settings/AccountSettings.tsx:477
 msgid "settings.account.socials.disconnect"
 msgstr "Scollega"
 
@@ -1325,7 +1331,7 @@ msgstr "Esplora"
 
 #. Explore nav icon tooltip
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:54
+#: src/components/AppHeader.tsx:55
 msgid "app.header.nav.explore"
 msgstr "Esplora"
 
@@ -1336,27 +1342,27 @@ msgstr "Esplora lavori"
 
 #. Generic email change error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:344
+#: src/components/settings/AccountSettings.tsx:363
 msgid "settings.account.email.error"
 msgstr "Impossibile cambiare l'email"
 
 #. Error when linking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:410
+#: src/components/settings/AccountSettings.tsx:429
 msgid "settings.account.socials.connectError"
 msgstr "Impossibile collegare l'account"
 
 #. Generic account deletion error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:483
+#: src/components/settings/AccountSettings.tsx:502
 msgid "settings.account.delete.error"
 msgstr "Impossibile eliminare l'account"
 
 #. Error when unlinking social account fails
 #. Error when unlinking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:421
-#: src/components/settings/AccountSettings.tsx:426
+#: src/components/settings/AccountSettings.tsx:440
+#: src/components/settings/AccountSettings.tsx:445
 msgid "settings.account.socials.disconnectError"
 msgstr "Impossibile scollegare l'account"
 
@@ -1374,19 +1380,19 @@ msgstr "Impossibile reimpostare la password. Il link potrebbe essere scaduto."
 
 #. Generic password reset error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:161
+#: src/components/settings/AccountSettings.tsx:167
 msgid "settings.account.password.error"
 msgstr "Impossibile inviare l'email di reimpostazione"
 
 #. Generic set password error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:72
+#: src/components/settings/AccountSettings.tsx:78
 msgid "settings.account.password.setError"
 msgstr "Impossibile impostare la password"
 
 #. Generic username update error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:252
+#: src/components/settings/AccountSettings.tsx:264
 msgid "settings.account.username.error"
 msgstr "Impossibile aggiornare il nome utente"
 
@@ -1398,16 +1404,16 @@ msgstr "FAQ"
 #. Nav link: FAQ
 #. Nav link: FAQ
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:65
-#: src/components/MobileMenu.tsx:92
+#: src/components/Header.tsx:71
+#: src/components/MobileMenu.tsx:93
 msgid "common.nav.faq"
 msgstr "FAQ"
 
 #. Nav link: Features
 #. Nav link: Features
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:59
-#: src/components/MobileMenu.tsx:82
+#: src/components/Header.tsx:65
+#: src/components/MobileMenu.tsx:83
 msgid "common.nav.features"
 msgstr "Funzionalità"
 
@@ -1465,7 +1471,7 @@ msgstr "Filtri"
 
 #. Button to open modal with all languages
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:293
+#: src/components/settings/GeneralSettings.tsx:302
 msgid "settings.general.jobLanguages.findMore"
 msgstr "Cerca altre"
 
@@ -1565,7 +1571,7 @@ msgid "settings.billing.free.f2"
 msgstr "Ricerca lavoro completa"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:121
+#: app/[lang]/layout.tsx:130
 msgid "app.schema.offer.free"
 msgstr "Ricerca completa, 1 watchlist, tracker delle candidature"
 
@@ -1597,9 +1603,9 @@ msgstr "Contattaci"
 #. Hero primary call-to-action
 #. Hero primary call-to-action
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:32
+#: src/components/Header.tsx:33
 #: src/components/Hero.tsx:15
-#: src/components/MobileMenu.tsx:31
+#: src/components/MobileMenu.tsx:32
 msgid "home.hero.primaryCta"
 msgstr "Inizia ora"
 
@@ -1659,7 +1665,7 @@ msgstr "Home"
 
 #. Hourly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:366
+#: src/components/settings/GeneralSettings.tsx:375
 msgid "settings.general.salary.period.hourly"
 msgstr "Orario"
 
@@ -1853,16 +1859,16 @@ msgstr "Registro dei colloqui"
 msgid "myJobs.group.interviewing"
 msgstr "In colloquio"
 
-#. Application tracker status: interviewing
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:450
-msgid "search.tracker.interviewing"
-msgstr "In colloquio"
-
 #. Interviewing status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:21
 msgid "myJobs.status.interviewing"
+msgstr "In colloquio"
+
+#. Application tracker status: interviewing
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:450
+msgid "search.tracker.interviewing"
 msgstr "In colloquio"
 
 #. Status option in dropdown: interviewing
@@ -1910,16 +1916,16 @@ msgstr "C'è un limite al numero di offerte che posso tracciare?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Gen"
 
-#. Singular job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:121
-msgid "watchlists.explore.jobSingular"
-msgstr "offerta"
-
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31
 msgid "watchlists.card.jobSingular"
+msgstr "offerta"
+
+#. Singular job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:121
+msgid "watchlists.explore.jobSingular"
 msgstr "offerta"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -1948,7 +1954,7 @@ msgstr "Politica di indicizzazione delle offerte"
 
 #. Job languages settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:226
+#: src/components/settings/GeneralSettings.tsx:235
 msgid "settings.general.jobLanguages.title"
 msgstr "Lingue delle offerte"
 
@@ -2022,16 +2028,16 @@ msgstr "Il codice sorgente di Job Seek è open source sotto licenza MIT. I dati 
 msgid "watchlist.meta.fallback"
 msgstr "Lista lavori di @{owner}"
 
-#. Plural job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:122
-msgid "watchlists.explore.jobPlural"
-msgstr "offerte"
-
 #. Plural job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:32
 msgid "watchlists.card.jobPlural"
+msgstr "offerte"
+
+#. Plural job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:122
+msgid "watchlists.explore.jobPlural"
 msgstr "offerte"
 
 #. js-lingui-explicit-id
@@ -2064,7 +2070,7 @@ msgstr "Parola chiave"
 
 #. Language settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:197
+#: src/components/settings/GeneralSettings.tsx:206
 msgid "settings.general.language.title"
 msgstr "Lingua"
 
@@ -2188,35 +2194,35 @@ msgstr "Luogo"
 msgid "search.advanced.location"
 msgstr "Luogo"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
-msgstr "Località"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:842
 msgid "search.bar.locations"
 msgstr "Sedi"
 
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:312
+msgid "search.detail.locations"
+msgstr "Località"
+
 #. Login button label
 #. Login button label
 #. Login button label
 #. Login button label
 #. Login button label
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:117
-#: src/components/AppHeader.tsx:177
-#: src/components/AppHeader.tsx:230
-#: src/components/settings/AccountSettings.tsx:39
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:145
+#: src/components/AppHeader.tsx:168
+#: src/components/AppHeader.tsx:219
+#: src/components/settings/AccountSettings.tsx:45
 #: src/components/settings/BillingSettings.tsx:30
 msgid "common.auth.login"
 msgstr "Accedi"
 
 #. Tooltip when user needs to log in to save search
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:111
+#: src/components/search/save-search-button.tsx:122
 msgid "search.saveSearch.tooltipLogin"
 msgstr "Accedi per salvare questa ricerca come watchlist"
 
@@ -2246,7 +2252,7 @@ msgstr "Gestisci abbonamento"
 
 #. Connected accounts section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:437
+#: src/components/settings/AccountSettings.tsx:456
 msgid "settings.account.socials.description"
 msgstr "Gestisci i tuoi account social collegati."
 
@@ -2273,6 +2279,12 @@ msgstr "Segna come offerta"
 #: src/components/my-jobs/quick-actions.tsx:20
 msgid "myJobs.action.markRejected"
 msgstr "Segna come rifiutato"
+
+#. Header for the server-side search-results cluster shown when the user types in the location modal search box
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:538
+msgid "search.locationModal.searchHitsHeader"
+msgstr "Risultati"
 
 #. Maximum salary label
 #. js-lingui-explicit-id
@@ -2337,13 +2349,13 @@ msgid "myJobs.heatmap.day.mon"
 msgstr "Lun"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:133
+#: app/[lang]/layout.tsx:142
 msgid "app.schema.feature.monitor"
 msgstr "Monitorare le pagine carriere delle aziende"
 
 #. Monthly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:360
+#: src/components/settings/GeneralSettings.tsx:369
 msgid "settings.general.salary.period.monthly"
 msgstr "Mensile"
 
@@ -2372,7 +2384,7 @@ msgid "home.features.s1.p2.title"
 msgstr "Filtri multidimensionali"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:135
+#: app/[lang]/layout.tsx:144
 msgid "app.schema.feature.languages"
 msgstr "Supporto multilingue"
 
@@ -2382,7 +2394,7 @@ msgstr "Supporto multilingue"
 #. Warning when Enter is pressed but multiple items match
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:247
-#: src/components/search/location-search-modal.tsx:237
+#: src/components/search/location-search-modal.tsx:399
 #: src/components/search/occupation-modal.tsx:180
 #: src/components/search/technology-modal.tsx:88
 msgid "search.bestGuess.ambiguous"
@@ -2402,7 +2414,7 @@ msgstr "I miei lavori"
 
 #. My Jobs nav icon tooltip
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:56
+#: src/components/AppHeader.tsx:57
 msgid "app.header.nav.myJobs"
 msgstr "I miei lavori"
 
@@ -2426,7 +2438,7 @@ msgstr "Vuoi contattarci?"
 
 #. New email input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:366
+#: src/components/settings/AccountSettings.tsx:385
 msgid "settings.account.email.label"
 msgstr "Nuova email"
 
@@ -2438,7 +2450,7 @@ msgstr "Nuova password"
 
 #. New password input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:96
+#: src/components/settings/AccountSettings.tsx:102
 msgid "settings.account.password.newLabel"
 msgstr "Nuova password"
 
@@ -2478,17 +2490,17 @@ msgstr "Nessuna offerta trovata."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Nessuna lingua corrisponde alla ricerca."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:299
-msgid "search.locationModal.noResults"
-msgstr "Nessun luogo corrisponde alla tua ricerca."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:309
 msgid "company.locationModal.noResults"
 msgstr "Nessuna sede corrisponde alla tua ricerca."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:469
+msgid "search.locationModal.noResults"
+msgstr "Nessun luogo corrisponde alla tua ricerca."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2552,7 +2564,7 @@ msgstr "Nessuna lista trovata."
 
 #. Empty state when user has no watchlists
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:124
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:152
 msgid "watchlists.page.empty"
 msgstr "Nessuna lista di osservazione. Creane una per seguire le offerte delle tue aziende preferite."
 
@@ -2602,16 +2614,16 @@ msgstr "Professione"
 msgid "myJobs.heatmap.month.oct"
 msgstr "Ott"
 
-#. Application tracker status: offer
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:451
-msgid "search.tracker.offer"
-msgstr "Offerta"
-
 #. Offered status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:22
 msgid "myJobs.status.offered"
+msgstr "Offerta"
+
+#. Application tracker status: offer
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:451
+msgid "search.tracker.offer"
 msgstr "Offerta"
 
 #. Status group heading: offered
@@ -2620,16 +2632,16 @@ msgstr "Offerta"
 msgid "myJobs.group.offered"
 msgstr "Offerta"
 
-#. Sankey funnel node: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:43
-msgid "myJobs.funnel.offered"
-msgstr "Offerta"
-
 #. Status option in dropdown: offered
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:38
 msgid "myJobs.statusOption.offered"
+msgstr "Offerta"
+
+#. Sankey funnel node: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:43
+msgid "myJobs.funnel.offered"
 msgstr "Offerta"
 
 #. Cookie banner accept button
@@ -2662,7 +2674,7 @@ msgstr "Una pagina al minuto."
 
 #. Username invalid characters hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:268
+#: src/components/settings/AccountSettings.tsx:287
 msgid "settings.account.username.invalidChars"
 msgstr "Solo lettere minuscole, numeri e trattini (non all'inizio/fine)"
 
@@ -2674,7 +2686,7 @@ msgstr "In sede"
 
 #. Aria label for mobile menu button
 #. js-lingui-explicit-id
-#: src/components/Header.tsx:83
+#: src/components/Header.tsx:89
 msgid "common.header.openMenu"
 msgstr "Apri menu principale"
 
@@ -2715,7 +2727,7 @@ msgstr "o"
 
 #. Original pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:354
+#: src/components/settings/GeneralSettings.tsx:363
 msgid "settings.general.salary.period.original"
 msgstr "Originale"
 
@@ -2745,26 +2757,26 @@ msgstr "La nostra posizione sull'automazione"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
-msgid "indexing.toc.overview"
-msgstr "Panoramica"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:22
 msgid "license.toc.overview"
 msgstr "Panoramica"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
-msgid "indexing.toc.ariaLabel"
-msgstr "Contenuti della pagina"
+#: src/components/HowWeIndexContent.tsx:27
+msgid "indexing.toc.overview"
+msgstr "Panoramica"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:19
 msgid "license.toc.ariaLabel"
+msgstr "Contenuti della pagina"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:24
+msgid "indexing.toc.ariaLabel"
 msgstr "Contenuti della pagina"
 
 #. Heading shown on the 404 page
@@ -2794,20 +2806,20 @@ msgstr "Password"
 #. Password section heading
 #. Password section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:83
-#: src/components/settings/AccountSettings.tsx:171
+#: src/components/settings/AccountSettings.tsx:89
+#: src/components/settings/AccountSettings.tsx:177
 msgid "settings.account.password.title"
 msgstr "Password"
 
 #. Success message after password reset request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:163
+#: src/components/settings/AccountSettings.tsx:169
 msgid "settings.account.password.success"
 msgstr "Link per il reset della password inviato. Controlla la tua casella di posta. Potrebbe volerci qualche minuto per l'arrivo."
 
 #. Success message after setting password
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:74
+#: src/components/settings/AccountSettings.tsx:80
 msgid "settings.account.password.setSuccess"
 msgstr "Password impostata con successo."
 
@@ -2831,7 +2843,7 @@ msgstr "Inserisci il nome di un'azienda o l'URL di una pagina carriere e inizier
 
 #. Label for pay period selector
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:341
+#: src/components/settings/GeneralSettings.tsx:350
 msgid "settings.general.salary.periodLabel"
 msgstr "Periodo"
 
@@ -2855,7 +2867,7 @@ msgstr "Periodo"
 
 #. Delete account section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:495
+#: src/components/settings/AccountSettings.tsx:514
 msgid "settings.account.delete.description"
 msgstr "Elimina definitivamente il tuo account e tutti i dati associati. Questa azione non può essere annullata."
 
@@ -2891,7 +2903,7 @@ msgstr "Inserisci un nome di azienda o un URL."
 
 #. Error when email field is empty
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:334
+#: src/components/settings/AccountSettings.tsx:353
 msgid "settings.account.email.required"
 msgstr "Inserisci un nuovo indirizzo email"
 
@@ -2903,7 +2915,7 @@ msgstr "Inserisci una nuova password"
 
 #. Error when new password is empty
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:65
+#: src/components/settings/AccountSettings.tsx:71
 msgid "settings.account.password.newRequired"
 msgstr "Inserisci una password"
 
@@ -2933,7 +2945,7 @@ msgstr "Compila tutti i campi"
 
 #. Message when user must log in to see account settings
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:34
+#: src/components/settings/AccountSettings.tsx:40
 msgid "settings.account.loginRequired"
 msgstr "Effettua l'accesso per gestire le impostazioni del tuo account."
 
@@ -2955,18 +2967,18 @@ msgstr "Offerta non trovata."
 msgid "myJobs.detail.notFound"
 msgstr "Offerta non trovata."
 
-#. Nav link: Pricing
-#. Nav link: Pricing
-#. js-lingui-explicit-id
-#: src/components/Header.tsx:62
-#: src/components/MobileMenu.tsx:87
-msgid "common.nav.pricing"
-msgstr "Prezzi"
-
 #. Pricing section eyebrow
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:100
+#: src/components/Pricing.tsx:103
 msgid "home.pricing.eyebrow"
+msgstr "Prezzi"
+
+#. Nav link: Pricing
+#. Nav link: Pricing
+#. js-lingui-explicit-id
+#: src/components/Header.tsx:68
+#: src/components/MobileMenu.tsx:88
+msgid "common.nav.pricing"
 msgstr "Prezzi"
 
 #. Privacy policy page eyebrow
@@ -3060,7 +3072,7 @@ msgid "terms.fullTermsLink"
 msgstr "Leggi i termini di servizio completi"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:134
+#: app/[lang]/layout.tsx:143
 msgid "app.schema.feature.alerts"
 msgstr "Avvisi in tempo reale sulle nuove offerte"
 
@@ -3094,16 +3106,16 @@ msgstr "Ridistribuire le proprie modifiche, a condizione di includere l'avviso M
 msgid "location.type.region"
 msgstr "Regione"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:309
-msgid "search.locationModal.regionsHeader"
-msgstr "Regioni"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:319
 msgid "company.locationModal.regionsHeader"
+msgstr "Regioni"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:479
+msgid "search.locationModal.regionsHeader"
 msgstr "Regioni"
 
 #. Status group heading: rejected
@@ -3112,28 +3124,28 @@ msgstr "Regioni"
 msgid "myJobs.group.rejected"
 msgstr "Rifiutato"
 
-#. Application tracker status: rejected
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:452
-msgid "search.tracker.rejected"
-msgstr "Rifiutato"
-
 #. Rejected status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:23
 msgid "myJobs.status.rejected"
 msgstr "Rifiutato"
 
-#. Sankey funnel node label prefix: rejected
+#. Application tracker status: rejected
 #. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:45
-msgid "myJobs.funnel.rejected"
+#: src/components/search/job-detail-dialog.tsx:452
+msgid "search.tracker.rejected"
 msgstr "Rifiutato"
 
 #. Status option in dropdown: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:39
 msgid "myJobs.statusOption.rejected"
+msgstr "Rifiutato"
+
+#. Sankey funnel node label prefix: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:45
+msgid "myJobs.funnel.rejected"
 msgstr "Rifiutato"
 
 #. Footer license summary text
@@ -3202,7 +3214,7 @@ msgstr "Reinvia tra {cooldown}s"
 
 #. Reset password button during cooldown with seconds remaining
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:184
+#: src/components/settings/AccountSettings.tsx:190
 msgid "settings.account.password.cooldown"
 msgstr "Reinvia tra {cooldown}s"
 
@@ -3286,7 +3298,7 @@ msgstr "Stipendio"
 
 #. Salary display settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:312
+#: src/components/settings/GeneralSettings.tsx:321
 msgid "settings.general.salary.title"
 msgstr "Visualizzazione stipendio"
 
@@ -3334,7 +3346,7 @@ msgstr "Salva offerte e monitora le tue candidature per vedere le statistiche qu
 
 #. Button label to save current search as a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:99
+#: src/components/search/save-search-button.tsx:110
 msgid "search.saveSearch.label"
 msgstr "Salva questa ricerca"
 
@@ -3350,27 +3362,27 @@ msgstr "Salvato"
 msgid "myJobs.status.saved"
 msgstr "Salvato"
 
-#. Sankey funnel node: saved jobs
-#. js-lingui-explicit-id
-#: src/components/my-jobs/sankey-funnel.tsx:41
-msgid "myJobs.funnel.saved"
-msgstr "Salvato"
-
 #. Status option in dropdown: saved
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:35
 msgid "myJobs.statusOption.saved"
 msgstr "Salvato"
 
+#. Sankey funnel node: saved jobs
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx:41
+msgid "myJobs.funnel.saved"
+msgstr "Salvato"
+
 #. Username save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:304
+#: src/components/settings/AccountSettings.tsx:323
 msgid "settings.account.username.saving"
 msgstr "Salvataggio..."
 
 #. Email save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:376
+#: src/components/settings/AccountSettings.tsx:395
 msgid "settings.account.email.saving"
 msgstr "Salvataggio…"
 
@@ -3422,17 +3434,17 @@ msgstr "Cerca lavori in migliaia di aziende, scansionati direttamente dalle pagi
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Cerca lingue…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:278
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Cerca luoghi..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:288
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Cerca sedi…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:448
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Cerca luoghi..."
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3478,7 +3490,7 @@ msgstr "Seleziona livello"
 
 #. Title for the global location selection modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:258
+#: src/components/search/location-search-modal.tsx:428
 msgid "search.locationModal.title"
 msgstr "Seleziona luogo"
 
@@ -3496,7 +3508,7 @@ msgstr "Seleziona tecnologie"
 
 #. Language settings description
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:200
+#: src/components/settings/GeneralSettings.tsx:209
 msgid "settings.general.language.description"
 msgstr "Seleziona la lingua preferita."
 
@@ -3514,15 +3526,9 @@ msgstr "Invia link"
 
 #. Reset password button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:185
+#: src/components/settings/AccountSettings.tsx:191
 msgid "settings.account.password.send"
 msgstr "Invia il link"
-
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Invio in corso..."
 
 #. Resend button while sending
 #. js-lingui-explicit-id
@@ -3530,9 +3536,15 @@ msgstr "Invio in corso..."
 msgid "auth.verify.resending"
 msgstr "Invio in corso..."
 
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
+msgstr "Invio in corso..."
+
 #. Reset password button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:182
+#: src/components/settings/AccountSettings.tsx:188
 msgid "settings.account.password.sending"
 msgstr "Invio…"
 
@@ -3556,13 +3568,13 @@ msgstr "Imposta nuova password"
 
 #. Set password button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:107
+#: src/components/settings/AccountSettings.tsx:113
 msgid "settings.account.password.set"
 msgstr "Imposta password"
 
 #. Set password button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:106
+#: src/components/settings/AccountSettings.tsx:112
 msgid "settings.account.password.setting"
 msgstr "Impostazione…"
 
@@ -3574,7 +3586,7 @@ msgstr "Impostazioni"
 
 #. Settings nav icon tooltip
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:57
+#: src/components/AppHeader.tsx:58
 msgid "app.header.nav.settings"
 msgstr "Impostazioni"
 
@@ -3584,16 +3596,16 @@ msgstr "Impostazioni"
 msgid "home.features.s3.p3.title"
 msgstr "Condividi con chiunque"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:355
-msgid "search.detail.showLessLocations"
-msgstr "Mostra meno"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:351
 msgid "company.page.showLess"
+msgstr "Mostra meno"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:355
+msgid "search.detail.showLessLocations"
 msgstr "Mostra meno"
 
 #. Aria label to show password
@@ -3646,7 +3658,7 @@ msgstr "Accedi per vederne altri"
 
 #. Prompt for non-logged-in users to sign in to create watchlists
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:108
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:136
 msgid "watchlists.page.loginPrompt"
 msgstr "Accedi per creare e gestire le tue liste di osservazione."
 
@@ -3670,7 +3682,7 @@ msgstr "Accedi per vedere più offerte di lavoro"
 
 #. Sign out dropdown menu item
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:117
+#: src/components/AppHeader.tsx:108
 msgid "app.header.signOut"
 msgstr "Esci"
 
@@ -3706,7 +3718,7 @@ msgstr "Aziende simili"
 
 #. Pricing section description
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:106
+#: src/components/Pricing.tsx:109
 msgid "home.pricing.description"
 msgstr "Prezzi semplici e trasparenti. Inizia gratis e passa al piano superiore quando fai sul serio con la tua ricerca di lavoro."
 
@@ -3728,12 +3740,6 @@ msgstr "Vai al contenuto"
 msgid "error.title"
 msgstr "Qualcosa è andato storto"
 
-#. Generic forgot password error
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:43
-msgid "auth.forgotPassword.error.generic"
-msgstr "Qualcosa è andato storto. Riprova."
-
 #. Generic error when company request fails
 #. Generic error when company request fails
 #. Generic error when company request fails
@@ -3744,6 +3750,12 @@ msgstr "Qualcosa è andato storto. Riprova."
 #: app/[lang]/(app)/progress/company-request-form.tsx:22
 #: src/components/search/request-company.tsx:23
 msgid "app.home.request.error.unknown"
+msgstr "Qualcosa è andato storto. Riprova."
+
+#. Generic forgot password error
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:43
+msgid "auth.forgotPassword.error.generic"
 msgstr "Qualcosa è andato storto. Riprova."
 
 #. Companies-request page heading when a company name was supplied via query string
@@ -3866,16 +3878,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Tecnico"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Tecnologie"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:765
 msgid "search.bar.technologies"
+msgstr "Tecnologie"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:397
+msgid "search.detail.technologies"
 msgstr "Tecnologie"
 
 #. Add technology filter
@@ -3980,7 +3992,7 @@ msgstr "In breve"
 
 #. Theme settings section heading
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:167
+#: src/components/settings/GeneralSettings.tsx:176
 msgid "settings.general.theme.title"
 msgstr "Tema"
 
@@ -3998,7 +4010,7 @@ msgstr "Questo sito utilizza i cookie solo per l'autenticazione e le funzionalit
 
 #. Username is reserved hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:270
+#: src/components/settings/AccountSettings.tsx:289
 msgid "settings.account.username.reserved"
 msgstr "Questo nome utente è riservato"
 
@@ -4087,7 +4099,7 @@ msgid "home.pricing.pro.description"
 msgstr "Watchlist illimitate con avvisi via email così non perdi mai un'apertura."
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:129
+#: app/[lang]/layout.tsx:138
 msgid "app.schema.offer.pro"
 msgstr "Watchlist illimitate, avvisi email sui nuovi risultati"
 
@@ -4105,19 +4117,19 @@ msgstr "Rimuovi offerta"
 
 #. Email save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:377
+#: src/components/settings/AccountSettings.tsx:396
 msgid "settings.account.email.save"
 msgstr "Aggiorna email"
 
 #. Change email section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:357
+#: src/components/settings/AccountSettings.tsx:376
 msgid "settings.account.email.description"
 msgstr "Aggiorna l'indirizzo email associato al tuo account."
 
 #. Username save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:305
+#: src/components/settings/AccountSettings.tsx:324
 msgid "settings.account.username.save"
 msgstr "Aggiorna nome utente"
 
@@ -4158,25 +4170,25 @@ msgstr "utente"
 
 #. Username section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:282
+#: src/components/settings/AccountSettings.tsx:301
 msgid "settings.account.username.title"
 msgstr "Nome utente"
 
 #. Username input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:294
+#: src/components/settings/AccountSettings.tsx:313
 msgid "settings.account.username.label"
 msgstr "Nome utente"
 
 #. Username updated success message
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:256
+#: src/components/settings/AccountSettings.tsx:276
 msgid "settings.account.username.success"
 msgstr "Nome utente aggiornato."
 
 #. Success message after email change request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:346
+#: src/components/settings/AccountSettings.tsx:365
 msgid "settings.account.email.success"
 msgstr "Email di verifica inviata. Controlla la tua casella di posta. Potrebbe volerci qualche minuto per l'arrivo."
 
@@ -4236,7 +4248,7 @@ msgstr "Limite liste raggiunto"
 
 #. Title of the watchlists exploration page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/watchlists/watchlists-page.tsx:99
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:127
 msgid "watchlists.page.title"
 msgstr "Liste di osservazione"
 
@@ -4248,7 +4260,7 @@ msgstr "Liste di osservazione"
 
 #. Watchlists nav icon tooltip
 #. js-lingui-explicit-id
-#: src/components/AppHeader.tsx:55
+#: src/components/AppHeader.tsx:56
 msgid "app.header.nav.watchlists"
 msgstr "Liste di osservazione"
 
@@ -4259,7 +4271,7 @@ msgid "home.features.s1.p3.title"
 msgstr "Watchlist e avvisi"
 
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:136
+#: app/[lang]/layout.tsx:145
 msgid "app.schema.feature.watchlists"
 msgstr "Watchlist e tracciamento delle candidature"
 
@@ -4432,7 +4444,7 @@ msgstr "Modalità di lavoro"
 
 #. Yearly pay period option
 #. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:357
+#: src/components/settings/GeneralSettings.tsx:366
 msgid "settings.general.salary.period.yearly"
 msgstr "Annuale"
 
@@ -4517,7 +4529,7 @@ msgstr "Devi avere almeno 16 anni per usare Job Seek."
 
 #. Set password description for OAuth users
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:86
+#: src/components/settings/AccountSettings.tsx:92
 msgid "settings.account.password.setDescription"
 msgstr "Hai effettuato l'accesso con un account social. Imposta una password per abilitare le modifiche email e maggiore sicurezza."
 
@@ -4534,7 +4546,9 @@ msgid "app.home.request.agent.rateLimited"
 msgstr "Hai raggiunto il limite orario per le richieste di aziende. Riprova più tardi."
 
 #. Reason shown in upgrade modal when watchlist creation limit reached
+#. Reason shown in upgrade modal when watchlist creation limit reached
 #. js-lingui-explicit-id
+#: app/[lang]/(app)/watchlists/watchlists-page.tsx:34
 #: src/components/watchlist/watchlist-card.tsx:45
 msgid "upgrade.reason.watchlistLimit"
 msgstr "Hai raggiunto il limite delle tue liste di osservazione. Effettua l'upgrade per crearne altre."
@@ -4544,6 +4558,12 @@ msgstr "Hai raggiunto il limite delle tue liste di osservazione. Effettua l'upgr
 #: src/components/watchlist/watchlist-action-bar.tsx:93
 msgid "upgrade.reason.mirrorLimit"
 msgstr "Hai raggiunto il limite delle tue liste di osservazione. Effettua l'upgrade per copiarne altre."
+
+#. Reason shown in upgrade modal when saving a search hits the watchlist limit
+#. js-lingui-explicit-id
+#: src/components/search/save-search-button.tsx:93
+msgid "upgrade.reason.saveSearch"
+msgstr "Hai raggiunto il limite delle tue liste di osservazione. Effettua l'upgrade per salvare altre ricerche."
 
 #. Feature section 3 eyebrow text
 #. js-lingui-explicit-id
@@ -4571,6 +4591,6 @@ msgstr "I tuoi diritti"
 
 #. Username section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:285
+#: src/components/settings/AccountSettings.tsx:304
 msgid "settings.account.username.description"
 msgstr "Il tuo identificativo unico utilizzato nell'URL del tuo profilo pubblico."

--- a/apps/web/src/components/search/__tests__/save-search-button.test.tsx
+++ b/apps/web/src/components/search/__tests__/save-search-button.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Tests for SaveSearchButton — issue #3036 sub-bug 1.
+ *
+ * When createWatchlist returns `{ error: "limit_reached" }`, the
+ * pre-fix behavior was a silent `router.push("/settings")` (opaque
+ * redirect to the General tab, no reason shown). Post-fix the same
+ * upgrade modal used elsewhere in the gating subsystem opens; its CTA
+ * links to `/settings/billing` (locked down by upgrade-modal.test.tsx).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import "@/test-utils/lingui-mock";
+
+const pushMock = vi.fn();
+const createWatchlistMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: Record<string, unknown>) => (
+    <a href={href as string} {...props}>{children as React.ReactNode}</a>
+  ),
+}));
+
+vi.mock("@/lib/useLocalePath", () => ({
+  useLocalePath: () => (p: string) => `/en${p}`,
+}));
+
+vi.mock("@/lib/useAuth", () => ({
+  useAuth: () => ({ user: { username: "alice" }, isLoggedIn: true }),
+}));
+
+vi.mock("@/lib/actions/watchlists", () => ({
+  createWatchlist: (...args: unknown[]) => createWatchlistMock(...args),
+}));
+
+import { SaveSearchButton } from "../save-search-button";
+
+describe("SaveSearchButton (issue #3036)", () => {
+  beforeEach(() => {
+    pushMock.mockReset();
+    createWatchlistMock.mockReset();
+  });
+
+  it("opens upgrade modal (not a redirect) when the server reports limit_reached", async () => {
+    createWatchlistMock.mockResolvedValue({ error: "limit_reached" });
+
+    render(
+      <SaveSearchButton
+        keywords={["engineer"]}
+        locations={[]}
+        occupations={[]}
+        seniorities={[]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /save this search/i }));
+
+    // Upgrade CTA appears (linking to /settings/billing — sub-bug 3) and
+    // there is NO opaque router.push to /settings (sub-bug 1).
+    const upgradeLink = await screen.findByRole("link", { name: /upgrade/i });
+    expect(upgradeLink.getAttribute("href")).toBe("/en/settings/billing");
+    await waitFor(() => expect(createWatchlistMock).toHaveBeenCalledTimes(1));
+    expect(pushMock).not.toHaveBeenCalledWith("/en/settings");
+  });
+
+  it("navigates to the new watchlist on success", async () => {
+    createWatchlistMock.mockResolvedValue({ id: "w1", slug: "my-search" });
+
+    render(
+      <SaveSearchButton
+        keywords={["engineer"]}
+        locations={[]}
+        occupations={[]}
+        seniorities={[]}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /save this search/i }));
+
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/en/alice/my-search"));
+  });
+});

--- a/apps/web/src/components/search/save-search-button.tsx
+++ b/apps/web/src/components/search/save-search-button.tsx
@@ -9,6 +9,7 @@ import { tooltipClass } from "@/components/ui/tooltip-styles";
 import { useLocalePath } from "@/lib/useLocalePath";
 import { useAuth } from "@/lib/useAuth";
 import { createWatchlist, type WatchlistFilters } from "@/lib/actions/watchlists";
+import { UpgradeModal, useUpgradeModal } from "@/components/ui/upgrade-modal";
 import type { SelectedLocation } from "@/components/search/location-pills";
 import type { WorkMode } from "@/lib/search/types";
 
@@ -46,6 +47,7 @@ export function SaveSearchButton({
   const lp = useLocalePath();
   const { user, isLoggedIn } = useAuth();
   const [saving, setSaving] = useState(false);
+  const upgrade = useUpgradeModal();
 
   async function handleSave() {
     if (!isLoggedIn) {
@@ -83,7 +85,16 @@ export function SaveSearchButton({
 
       if ("error" in result) {
         if (result.error === "limit_reached") {
-          router.push(lp("/settings"));
+          // Surface the upgrade modal with billing CTA instead of an
+          // opaque redirect to /settings — mirrors the pattern used by
+          // "make private", "enable alerts", and "mirror" in
+          // watchlist-action-bar. The modal itself links to
+          // /settings/billing (see upgrade-modal.tsx).
+          upgrade.show(t({
+            id: "upgrade.reason.saveSearch",
+            comment: "Reason shown in upgrade modal when saving a search hits the watchlist limit",
+            message: "You've reached your watchlist limit. Upgrade your plan to save more searches as watchlists.",
+          }));
         }
         return;
       }
@@ -115,25 +126,28 @@ export function SaveSearchButton({
       });
 
   return (
-    <Tooltip.Provider delayDuration={0} skipDelayDuration={300}>
-    <Tooltip.Root>
-      <Tooltip.Trigger asChild>
-        <button
-          onClick={handleSave}
-          disabled={saving}
-          className="inline-flex shrink-0 cursor-pointer items-center gap-1 text-xs text-primary transition-colors hover:text-primary/80 disabled:opacity-50"
-        >
-          {saving ? <Loader2 size={12} className="animate-spin" /> : <Eye size={12} />}
-          {label}
-        </button>
-      </Tooltip.Trigger>
-      <Tooltip.Portal>
-        <Tooltip.Content className={tooltipClass} sideOffset={5}>
-          {tooltip}
-          <Tooltip.Arrow className="fill-surface" />
-        </Tooltip.Content>
-      </Tooltip.Portal>
-    </Tooltip.Root>
-    </Tooltip.Provider>
+    <>
+      <Tooltip.Provider delayDuration={0} skipDelayDuration={300}>
+      <Tooltip.Root>
+        <Tooltip.Trigger asChild>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            className="inline-flex shrink-0 cursor-pointer items-center gap-1 text-xs text-primary transition-colors hover:text-primary/80 disabled:opacity-50"
+          >
+            {saving ? <Loader2 size={12} className="animate-spin" /> : <Eye size={12} />}
+            {label}
+          </button>
+        </Tooltip.Trigger>
+        <Tooltip.Portal>
+          <Tooltip.Content className={tooltipClass} sideOffset={5}>
+            {tooltip}
+            <Tooltip.Arrow className="fill-surface" />
+          </Tooltip.Content>
+        </Tooltip.Portal>
+      </Tooltip.Root>
+      </Tooltip.Provider>
+      <UpgradeModal open={upgrade.open} onOpenChange={upgrade.setOpen} reason={upgrade.reason} />
+    </>
   );
 }

--- a/apps/web/src/components/ui/__tests__/upgrade-modal.test.tsx
+++ b/apps/web/src/components/ui/__tests__/upgrade-modal.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Tests for the upgrade modal — issue #3036 sub-bug 3.
+ *
+ * The CTA used to link to `/settings`, dropping users on the General
+ * tab unrelated to plans. Lock the destination to `/settings/billing`
+ * so we don't silently regress.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@/test-utils/lingui-mock";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: Record<string, unknown>) => (
+    <a href={href as string} {...props}>{children as React.ReactNode}</a>
+  ),
+}));
+
+vi.mock("@/lib/useLocalePath", () => ({
+  useLocalePath: () => (p: string) => `/en${p}`,
+}));
+
+import { UpgradeModal } from "../upgrade-modal";
+
+describe("UpgradeModal (issue #3036)", () => {
+  it("links its Upgrade CTA to /settings/billing, not /settings", () => {
+    render(
+      <UpgradeModal
+        open={true}
+        onOpenChange={() => {}}
+        reason="You've reached your watchlist limit."
+      />,
+    );
+
+    const link = screen.getByRole("link", { name: /upgrade/i });
+    expect(link.getAttribute("href")).toBe("/en/settings/billing");
+    // Negative check: the broken pre-fix URL would land users on the
+    // wrong tab.
+    expect(link.getAttribute("href")).not.toBe("/en/settings");
+  });
+
+  it("renders the reason text passed in", () => {
+    render(
+      <UpgradeModal
+        open={true}
+        onOpenChange={() => {}}
+        reason="custom reason xyz"
+      />,
+    );
+    expect(screen.getByText("custom reason xyz")).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/ui/upgrade-modal.tsx
+++ b/apps/web/src/components/ui/upgrade-modal.tsx
@@ -67,7 +67,7 @@ export function UpgradeModal({
               </button>
             </Dialog.Close>
             <Link
-              href={lp("/settings")}
+              href={lp("/settings/billing")}
               onClick={() => onOpenChange(false)}
               className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-contrast transition-opacity hover:opacity-90"
             >

--- a/apps/web/src/components/watchlist/__tests__/watchlist-card.test.tsx
+++ b/apps/web/src/components/watchlist/__tests__/watchlist-card.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Tests for the watchlist CreateWatchlistCard disabled state — issue
+ * #3036 sub-bug 2. The card must:
+ *   1. dim visually (`opacity-50`) when `disabled`
+ *   2. not invoke `onClick` when `disabled` (so it can't create a 2nd
+ *      watchlist on a free plan)
+ *   3. open the upgrade modal instead, telling the user why nothing
+ *      happened
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@/test-utils/lingui-mock";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, ...props }: Record<string, unknown>) => (
+    <a href={href as string} {...props}>{children as React.ReactNode}</a>
+  ),
+}));
+
+vi.mock("@/lib/useLocalePath", () => ({
+  useLocalePath: () => (p: string) => `/en${p}`,
+}));
+
+import { CreateWatchlistCard } from "../watchlist-card";
+
+describe("CreateWatchlistCard (issue #3036)", () => {
+  it("applies dimmed styling when disabled", () => {
+    render(<CreateWatchlistCard onClick={() => {}} disabled />);
+    // The button is the Tooltip trigger when disabled; find by accessible
+    // text "Create".
+    const btn = screen.getByRole("button", { name: /create/i });
+    expect(btn.className).toContain("opacity-50");
+  });
+
+  it("does not call onClick when disabled (gating intact)", () => {
+    const onClick = vi.fn();
+    render(<CreateWatchlistCard onClick={onClick} disabled />);
+    const btn = screen.getByRole("button", { name: /create/i });
+    fireEvent.click(btn);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("opens the upgrade modal (with billing CTA) when clicked while disabled", async () => {
+    render(<CreateWatchlistCard onClick={() => {}} disabled />);
+    const btn = screen.getByRole("button", { name: /create/i });
+    fireEvent.click(btn);
+
+    // The upgrade modal portals a link to /settings/billing — sub-bug 3.
+    const link = await screen.findByRole("link", { name: /upgrade/i });
+    expect(link.getAttribute("href")).toBe("/en/settings/billing");
+  });
+
+  it("calls onClick when enabled", () => {
+    const onClick = vi.fn();
+    render(<CreateWatchlistCard onClick={onClick} />);
+    const btn = screen.getByRole("button", { name: /create/i });
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -528,6 +528,28 @@ export async function toggleWatchlistAlerts(
   return { enabled: newVal };
 }
 
+/**
+ * Combined fetch for the watchlists overview page: returns the user's
+ * watchlist summaries AND whether they've reached their plan limit.
+ *
+ * Issue #3036: the loader previously hardcoded ``limitReached: false``,
+ * which meant the ``CreateWatchlistCard`` never rendered its disabled
+ * state (tooltip + dimmed + upgrade modal on click). Compute the real
+ * value server-side so the gating UX matches the watchlist-detail page.
+ */
+export async function getUserWatchlistsWithLimit(
+  locale: string,
+): Promise<{ watchlists: WatchlistSummary[]; limitReached: boolean }> {
+  const userId = await getSessionUserId();
+  if (!userId) return { watchlists: [], limitReached: true };
+
+  const [watchlists, limit] = await Promise.all([
+    getUserWatchlists(locale),
+    canCreateWatchlist(userId),
+  ]);
+  return { watchlists, limitReached: !limit.allowed };
+}
+
 export async function getUserWatchlists(locale: string): Promise<WatchlistSummary[]> {
   const userId = await getSessionUserId();
   if (!userId) return [];


### PR DESCRIPTION
Closes #3036.

## Summary

Three sub-bugs in the plan-gating subsystem shared a root cause: inconsistent "limit reached" handling that either redirected to the wrong page or silently did nothing.

### Sub-bug 1: Save-this-search silently redirected to wrong page

Search page → click "Save this search" while at watchlist limit → user was pushed to `/en/settings` (General tab) with no explanation.

**Before:** ![before-1](https://github.com/user-attachments/assets/before-1)
**After:** Upgrade modal opens explaining why and offering an Upgrade CTA to `/settings/billing` — the same pattern already used by "make private", "enable alerts", and "mirror".

Root cause: `apps/web/src/components/search/save-search-button.tsx` matched on `limit_reached` and called `router.push(lp("/settings"))` instead of surfacing the existing `UpgradeModal` pattern.

### Sub-bug 2: CreateWatchlistCard rendered with no disabled cue

`/watchlists` page → user at limit → "Create" card looked enabled, clicking it did nothing visible.

**Before:** Card showed full opacity, click silently no-op'd (server returned `limit_reached`, page refresh produced no change).
**After:** Card is dimmed (`opacity-50`), tooltip shows "Watchlist limit reached" on hover, click opens the upgrade modal.

Root cause: `apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx` hardcoded `limitReached: false` after fetching the watchlist list. The `CreateWatchlistCard` already had all the right behaviors gated on the `disabled` prop — they were just never enabled. Fixed by adding `getUserWatchlistsWithLimit()` which fetches both the watchlist summaries AND `canCreateWatchlist()` in parallel, then passes the real value through.

### Sub-bug 3: Upgrade modal CTA went to wrong settings tab

Any upgrade modal (from "make private", "mirror", "enable alerts", and now save-search / create-card) → "Upgrade" button → opened `/en/settings` (General tab) instead of `/en/settings/billing`.

**Before:** ![before-3](https://github.com/user-attachments/assets/before-3) — Settings opens on General, user has to navigate again.
**After:** Lands on `/en/settings/billing` with the Pro plan upsell visible.

Root cause: `apps/web/src/components/ui/upgrade-modal.tsx` linked to `lp("/settings")`.

## Files changed

- `apps/web/src/components/ui/upgrade-modal.tsx` — link `/settings/billing`
- `apps/web/src/components/search/save-search-button.tsx` — replace redirect with `UpgradeModal`
- `apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx` — call new `getUserWatchlistsWithLimit()` instead of hardcoding `limitReached: false`
- `apps/web/app/[lang]/(app)/watchlists/watchlists-page.tsx` — show `UpgradeModal` from non-card create paths (empty-state button, URL-driven auto-create) for consistency
- `apps/web/src/lib/actions/watchlists.ts` — new server action `getUserWatchlistsWithLimit()` that returns watchlists + limitReached together
- `apps/web/locales/{en,de,fr,it}.po` — i18n catalog updates (new `upgrade.reason.saveSearch` reason + auto-extracted location-modal strings from prior PRs)

## Tests

Added 8 new tests locking down the gating behavior so a future edit can't silently regress any of the three:

- `src/components/ui/__tests__/upgrade-modal.test.tsx` (2) — CTA href is `/settings/billing`, reason text renders.
- `src/components/watchlist/__tests__/watchlist-card.test.tsx` (4) — dimmed when disabled, `onClick` gated, upgrade modal opens on disabled click (with billing CTA), `onClick` fires when enabled.
- `src/components/search/__tests__/save-search-button.test.tsx` (2) — modal opens (not redirect) on `limit_reached`, navigates to new watchlist on success.

```
Test Files  77 passed | 1 failed (pre-existing mcp-server unrelated)
Tests       700 passed
```

TSC clean (only the pre-existing `@jseek/mcp-server/handler` missing-module error which is unrelated to this PR).

## Test plan

- [x] Reproduce each bug on `main` (verified visually with Playwright before fix)
- [x] Apply fix and verify each bug visually fixed (screenshots in `/tmp/3036-screenshots/`)
- [x] `pnpm exec tsc --noEmit` — clean (except pre-existing mcp-server)
- [x] `pnpm test --run` — 700/700 pass, +8 new
- [x] `pnpm extract && pnpm compile` — i18n catalogs healthy
- [ ] Manual smoke on Vercel preview: create user with 1 watchlist, verify save-search shows modal + Create card dimmed + Upgrade CTA lands on billing

## Tangentials

- `pnpm extract` updated a lot of line numbers across `.po` files (Lingui hygiene) and added translations for two previously-unextracted strings (`search.locationModal.allLoaded`, `search.locationModal.searchHitsHeader`) which the i18n-coverage pre-commit hook required. Not in scope but unavoidable to land this PR.
- `CreateWatchlistCard` already had a self-contained `UpgradeModal` in its click handler. After this PR, both that modal AND the page-level modal can render — but only one is shown at a time per click source (card-click → card's modal; empty-state button / URL auto-create → page's modal). Keeping both keeps each component self-contained.