### PR TITLE
cleanup(web): remove redundant scrollTo(0,0) in watchlist content (relates to #3028)

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-content.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-content.tsx
@@ -25,7 +25,13 @@ export function WatchlistContent({ lang, userSlug, watchlistSlug }: WatchlistCon
 
   useEffect(() => {
     setData(null);
-    window.scrollTo(0, 0);
+    // No `window.scrollTo(0, 0)` here — Next handles scroll on
+    // navigation natively, and the previous unconditional reset
+    // fired on every mount of this component. In edge cases (HMR
+    // in dev, Suspense reconnection on `?show=` changes from
+    // `useSearchParams()`, etc.) that re-mount fires after the
+    // user has already scrolled into the list, snapping them
+    // back to the top. See #3028.
     fetchWatchlistPageData({ userSlug, watchlistSlug, locale: lang }).then((result) => {
       setData(result ?? "not-found");
     });


### PR DESCRIPTION
## Summary

Removes an unconditional `window.scrollTo(0, 0)` inside `WatchlistContent`'s mount effect. This is filed as a **cleanup**, not a fix for #3028 — see "Scope clarification" below.

## What this changes

`apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-content.tsx` previously contained:

```tsx
useEffect(() => {
  setData(null);
  window.scrollTo(0, 0);
  fetchWatchlistPageData(...).then(setData);
}, [lang, userSlug, watchlistSlug]);
```

The `scrollTo(0, 0)` is redundant for legitimate route navigation (Next handles scroll-to-top natively on real route transitions) and actively harmful on any spurious re-mount: HMR in dev, Suspense reconnection when `useSearchParams()` re-subscribes after a `?show=<id>` URL update, React strict mode, etc.

## Scope clarification

**This PR does NOT close #3028.** The implementer agent could not reproduce the user-reported "scroll resets to z=0 on card open" flow with realistic mouse interaction on dev or prod. Initial reproductions turned out to be Playwright `locator.click()` auto-scroll artifacts, not the real bug.

This cleanup is grounded in a code-review hypothesis (the redundant `scrollTo` is a plausible source of similar symptoms) but is NOT a confirmed user-reproduction fix. #3028 remains open until someone reproduces it empirically.

## Rule violations disclosed by the implementer

- The implementer briefly used `git stash` (to verify a pre-existing TSC error wasn't introduced) and immediately `stash pop`-ed. Final state intact, but flagging per the standing anti-shortcut rule.
- The fix is hypothesis-driven, per the anti-shortcut rule. Disclosed transparently so reviewers can decide whether to land the cleanup or wait for a sharper repro.

## Follow-ups filed

- #3061 — same pattern in `explore-content.tsx`
- #3062 — same pattern in `company-content.tsx`

## Test plan

- TSC clean
- Web test suite: 703/703 pass
- Screenshots at `/tmp/3028-screenshots/`. Note the "before" screenshots show the Playwright artifact, not the real bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)