### PR TITLE
fix(web): show counts on work-mode and employment-type filter modals (closes #3032)

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
@@ -184,8 +184,16 @@ export function WatchlistViewPage({
     occupationIds: occupations.length > 0 ? occupations.map((o) => o.id) : undefined,
     seniorityIds: seniorities.length > 0 ? seniorities.map((s) => s.id) : undefined,
     technologyIds: technologies.length > 0 ? technologies.map((t) => t.id) : undefined,
+    // workMode + employmentTypes flow through so the modal-side facet
+    // helpers can cross-filter their counts against each other (#3032).
+    // The advanced-search-panel strips the active dimension before
+    // passing this object down to the matching modal — e.g. the
+    // work-mode modal sees `employmentTypes` but NOT `workMode`, so
+    // counts represent "what would I see if I toggled this mode on".
+    workMode: workMode.length > 0 ? workMode : undefined,
+    employmentTypes: employmentTypes.length > 0 ? employmentTypes : undefined,
     languages: languages.length > 0 ? languages : undefined,
-  }), [locations, occupations, seniorities, technologies, languages]);
+  }), [locations, occupations, seniorities, technologies, workMode, employmentTypes, languages]);
 
   // Persist filters to DB (debounced, cleaned up on unmount)
   const saveFiltersTimeout = useRef<ReturnType<typeof setTimeout>>(undefined);

--- a/apps/web/src/components/search/__tests__/employment-type-modal.test.tsx
+++ b/apps/web/src/components/search/__tests__/employment-type-modal.test.tsx
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+// Lingui shim — register before imports of Lingui-aware modules.
+import "@/test-utils/lingui-mock";
+
+const getEmploymentTypeCountsMock = vi.fn();
+vi.mock("@/lib/actions/taxonomy", () => ({
+  getEmploymentTypeCounts: (...args: unknown[]) => getEmploymentTypeCountsMock(...args),
+}));
+
+vi.mock("server-only", () => ({}));
+
+import { EmploymentTypeModal } from "../employment-type-modal";
+
+beforeEach(() => {
+  getEmploymentTypeCountsMock.mockReset();
+});
+
+describe("EmploymentTypeModal — per-option counts (#3032)", () => {
+  it("renders counts next to each option from Typesense facet", async () => {
+    getEmploymentTypeCountsMock.mockResolvedValue({
+      full_time: 1234,
+      part_time: 56,
+      contract: 78,
+      internship: 9,
+      temporary: 2,
+      // volunteer omitted -> renders (0)
+    });
+    render(
+      <EmploymentTypeModal
+        open
+        onOpenChange={() => {}}
+        selected={[]}
+        onToggle={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(getEmploymentTypeCountsMock).toHaveBeenCalled());
+    // After data resolves, each option button shows its count alongside the label.
+    await waitFor(() => screen.getByText("(1234)"));
+    expect(screen.getByText("(1234)")).toBeTruthy();
+    expect(screen.getByText("(56)")).toBeTruthy();
+    expect(screen.getByText("(78)")).toBeTruthy();
+    expect(screen.getByText("(9)")).toBeTruthy();
+    expect(screen.getByText("(2)")).toBeTruthy();
+    // Missing key falls back to (0) for the static option.
+    expect(screen.getByText("(0)")).toBeTruthy();
+  });
+
+  it("forwards filters to the action and re-fetches on filter change", async () => {
+    getEmploymentTypeCountsMock.mockResolvedValue({ full_time: 10 });
+    const { rerender } = render(
+      <EmploymentTypeModal
+        open
+        onOpenChange={() => {}}
+        selected={[]}
+        onToggle={() => {}}
+        filters={{ locationIds: [1] }}
+      />,
+    );
+    await waitFor(() => expect(getEmploymentTypeCountsMock).toHaveBeenCalledTimes(1));
+    expect(getEmploymentTypeCountsMock).toHaveBeenLastCalledWith({ locationIds: [1] });
+
+    // Change filters → re-fetch
+    rerender(
+      <EmploymentTypeModal
+        open
+        onOpenChange={() => {}}
+        selected={[]}
+        onToggle={() => {}}
+        filters={{ locationIds: [2] }}
+      />,
+    );
+    await waitFor(() => expect(getEmploymentTypeCountsMock).toHaveBeenCalledTimes(2));
+    expect(getEmploymentTypeCountsMock).toHaveBeenLastCalledWith({ locationIds: [2] });
+  });
+
+  it("does not fetch when the modal is closed", async () => {
+    getEmploymentTypeCountsMock.mockResolvedValue({});
+    render(
+      <EmploymentTypeModal
+        open={false}
+        onOpenChange={() => {}}
+        selected={[]}
+        onToggle={() => {}}
+      />,
+    );
+    // Give the effect a tick — it should bail out when `open` is false.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(getEmploymentTypeCountsMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/search/__tests__/work-mode-modal.test.tsx
+++ b/apps/web/src/components/search/__tests__/work-mode-modal.test.tsx
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+
+// Lingui shim — register before imports of Lingui-aware modules.
+import "@/test-utils/lingui-mock";
+
+const getWorkModeCountsMock = vi.fn();
+vi.mock("@/lib/actions/taxonomy", () => ({
+  getWorkModeCounts: (...args: unknown[]) => getWorkModeCountsMock(...args),
+}));
+
+vi.mock("server-only", () => ({}));
+
+import { WorkModeModal } from "../work-mode-modal";
+
+beforeEach(() => {
+  getWorkModeCountsMock.mockReset();
+});
+
+describe("WorkModeModal — per-option counts (#3032)", () => {
+  it("renders counts next to each option from Typesense facet", async () => {
+    getWorkModeCountsMock.mockResolvedValue({
+      onsite: 42,
+      hybrid: 11,
+      remote: 7,
+    });
+    render(
+      <WorkModeModal
+        open
+        onOpenChange={() => {}}
+        selected={[]}
+        onToggle={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(getWorkModeCountsMock).toHaveBeenCalled());
+    await waitFor(() => screen.getByText("(42)"));
+    expect(screen.getByText("(42)")).toBeTruthy();
+    expect(screen.getByText("(11)")).toBeTruthy();
+    expect(screen.getByText("(7)")).toBeTruthy();
+  });
+
+  it("falls back to (0) for modes missing from the facet response", async () => {
+    getWorkModeCountsMock.mockResolvedValue({ remote: 99 });
+    render(
+      <WorkModeModal
+        open
+        onOpenChange={() => {}}
+        selected={[]}
+        onToggle={() => {}}
+      />,
+    );
+    await waitFor(() => screen.getByText("(99)"));
+    // onsite + hybrid both render (0) — assert there are two zero-counts.
+    const zeros = screen.getAllByText("(0)");
+    expect(zeros.length).toBe(2);
+  });
+
+  it("re-fetches when cross-filter context changes", async () => {
+    getWorkModeCountsMock.mockResolvedValue({ remote: 1 });
+    const { rerender } = render(
+      <WorkModeModal
+        open
+        onOpenChange={() => {}}
+        selected={[]}
+        onToggle={() => {}}
+        filters={{ occupationIds: [10] }}
+      />,
+    );
+    await waitFor(() => expect(getWorkModeCountsMock).toHaveBeenCalledTimes(1));
+    expect(getWorkModeCountsMock).toHaveBeenLastCalledWith({ occupationIds: [10] });
+
+    rerender(
+      <WorkModeModal
+        open
+        onOpenChange={() => {}}
+        selected={[]}
+        onToggle={() => {}}
+        filters={{ occupationIds: [10, 11] }}
+      />,
+    );
+    await waitFor(() => expect(getWorkModeCountsMock).toHaveBeenCalledTimes(2));
+    expect(getWorkModeCountsMock).toHaveBeenLastCalledWith({ occupationIds: [10, 11] });
+  });
+
+  it("does not fetch when the modal is closed", async () => {
+    getWorkModeCountsMock.mockResolvedValue({});
+    render(
+      <WorkModeModal
+        open={false}
+        onOpenChange={() => {}}
+        selected={[]}
+        onToggle={() => {}}
+      />,
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(getWorkModeCountsMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/search/advanced-search-panel.tsx
+++ b/apps/web/src/components/search/advanced-search-panel.tsx
@@ -280,6 +280,16 @@ export function AdvancedSearchPanel({
           onOpenChange={setEmploymentTypeModalOpen}
           selected={employmentTypes ?? []}
           onToggle={onToggleEmploymentType}
+          filters={histogramFilters ? {
+            companyId: histogramFilters.companyId,
+            keywords: histogramFilters.keywords,
+            locationIds: histogramFilters.locationIds,
+            occupationIds: histogramFilters.occupationIds,
+            seniorityIds: histogramFilters.seniorityIds,
+            technologyIds: histogramFilters.technologyIds,
+            workMode: histogramFilters.workMode,
+            languages: histogramFilters.languages,
+          } : undefined}
         />
       )}
       {onToggleWorkMode && (
@@ -288,6 +298,16 @@ export function AdvancedSearchPanel({
           onOpenChange={setWorkModeModalOpen}
           selected={workMode ?? []}
           onToggle={onToggleWorkMode}
+          filters={histogramFilters ? {
+            companyId: histogramFilters.companyId,
+            keywords: histogramFilters.keywords,
+            locationIds: histogramFilters.locationIds,
+            occupationIds: histogramFilters.occupationIds,
+            seniorityIds: histogramFilters.seniorityIds,
+            technologyIds: histogramFilters.technologyIds,
+            employmentTypes: histogramFilters.employmentTypes,
+            languages: histogramFilters.languages,
+          } : undefined}
         />
       )}
     </div>

--- a/apps/web/src/components/search/employment-type-modal.tsx
+++ b/apps/web/src/components/search/employment-type-modal.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
-import { X } from "lucide-react";
+import { Loader2, X } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { ScrollFade } from "@/components/ui/scroll-fade";
+import { getEmploymentTypeCounts } from "@/lib/actions/taxonomy";
 
 function useEmploymentTypes() {
   const { t } = useLingui();
@@ -23,6 +24,15 @@ interface EmploymentTypeModalProps {
   onOpenChange: (open: boolean) => void;
   selected: string[];
   onToggle: (type: string) => void;
+  /**
+   * Cross-filter context used to compute per-option counts via Typesense
+   * facets — mirrors the seniority/technology modal pattern. Pass the
+   * currently-applied filter set (minus `employmentTypes`, since that's
+   * the dimension being faceted) so counts reflect what the user would
+   * see if they toggled that option. Optional: when omitted, counts are
+   * fetched against the unfiltered active-postings universe. See #3032.
+   */
+  filters?: { companyId?: string; keywords?: string[]; locationIds?: number[]; occupationIds?: number[]; seniorityIds?: number[]; technologyIds?: number[]; workMode?: string[]; languages?: string[] };
 }
 
 export function EmploymentTypeModal({
@@ -30,9 +40,25 @@ export function EmploymentTypeModal({
   onOpenChange,
   selected,
   onToggle,
+  filters,
 }: EmploymentTypeModalProps) {
   const EMPLOYMENT_TYPES = useEmploymentTypes();
   const selectedSet = useMemo(() => new Set(selected), [selected]);
+
+  const [counts, setCounts] = useState<Record<string, number> | null>(null);
+  const [loading, setLoading] = useState(false);
+  const filtersKey = filters ? JSON.stringify(filters) : "";
+  const prevFiltersKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    if (counts !== null && filtersKey === prevFiltersKeyRef.current) return;
+    prevFiltersKeyRef.current = filtersKey;
+    setLoading(true);
+    getEmploymentTypeCounts(filters)
+      .then(setCounts)
+      .finally(() => setLoading(false));
+  }, [open, filtersKey]);
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -58,24 +84,34 @@ export function EmploymentTypeModal({
 
           {/* Body */}
           <ScrollFade wrapperClassName="flex-1 min-h-0" className="px-5 py-4">
-            <div className="flex flex-col gap-2">
-              {EMPLOYMENT_TYPES.map((opt) => {
-                const active = selectedSet.has(opt.value);
-                return (
-                  <button
-                    key={opt.value}
-                    onClick={() => onToggle(opt.value)}
-                    className={`flex cursor-pointer items-center rounded-lg px-4 py-3 text-sm font-medium transition-colors ${
-                      active
-                        ? "bg-primary/10 text-primary"
-                        : "border border-border-soft text-muted hover:border-primary/30 hover:text-foreground"
-                    }`}
-                  >
-                    {opt.label}
-                  </button>
-                );
-              })}
-            </div>
+            {loading && counts === null ? (
+              <div className="flex items-center justify-center py-12">
+                <Loader2 size={20} className="animate-spin text-muted" />
+              </div>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {EMPLOYMENT_TYPES.map((opt) => {
+                  const active = selectedSet.has(opt.value);
+                  const count = counts?.[opt.value] ?? 0;
+                  return (
+                    <button
+                      key={opt.value}
+                      onClick={() => onToggle(opt.value)}
+                      className={`flex cursor-pointer items-center justify-between rounded-lg px-4 py-3 text-sm font-medium transition-colors ${
+                        active
+                          ? "bg-primary/10 text-primary"
+                          : "border border-border-soft text-muted hover:border-primary/30 hover:text-foreground"
+                      }`}
+                    >
+                      <span>{opt.label}</span>
+                      <span className={`text-xs ${active ? "text-primary/70" : "text-muted"}`}>
+                        ({count})
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
           </ScrollFade>
         </Dialog.Content>
       </Dialog.Portal>

--- a/apps/web/src/components/search/work-mode-modal.tsx
+++ b/apps/web/src/components/search/work-mode-modal.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
-import { X } from "lucide-react";
+import { Loader2, X } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { ScrollFade } from "@/components/ui/scroll-fade";
+import { getWorkModeCounts } from "@/lib/actions/taxonomy";
 import type { WorkMode } from "@/lib/search/types";
 
 /**
@@ -13,6 +14,11 @@ import type { WorkMode } from "@/lib/search/types";
  * fixed options sourced from {@link WORK_MODE_VALUES}; we hard-code the
  * order here (onsite → hybrid → remote) so the modal layout is stable.
  * Issue #2983.
+ *
+ * Per-option counts come from a Typesense facet on `location_types`,
+ * cross-filtered against the currently-applied filter set (location,
+ * occupation, level, etc.). Same UX as seniority/technology modals.
+ * See #3032.
  */
 function useWorkModes() {
   const { t } = useLingui();
@@ -28,6 +34,13 @@ interface WorkModeModalProps {
   onOpenChange: (open: boolean) => void;
   selected: WorkMode[];
   onToggle: (mode: WorkMode) => void;
+  /**
+   * Cross-filter context for per-option facet counts. Pass the
+   * currently-applied filter set (minus `workMode`, since that's the
+   * dimension being faceted). Optional: when omitted, counts are
+   * fetched against the unfiltered active-postings universe. See #3032.
+   */
+  filters?: { companyId?: string; keywords?: string[]; locationIds?: number[]; occupationIds?: number[]; seniorityIds?: number[]; technologyIds?: number[]; employmentTypes?: string[]; languages?: string[] };
 }
 
 export function WorkModeModal({
@@ -35,9 +48,25 @@ export function WorkModeModal({
   onOpenChange,
   selected,
   onToggle,
+  filters,
 }: WorkModeModalProps) {
   const WORK_MODES = useWorkModes();
   const selectedSet = useMemo(() => new Set(selected), [selected]);
+
+  const [counts, setCounts] = useState<Record<string, number> | null>(null);
+  const [loading, setLoading] = useState(false);
+  const filtersKey = filters ? JSON.stringify(filters) : "";
+  const prevFiltersKeyRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    if (counts !== null && filtersKey === prevFiltersKeyRef.current) return;
+    prevFiltersKeyRef.current = filtersKey;
+    setLoading(true);
+    getWorkModeCounts(filters)
+      .then(setCounts)
+      .finally(() => setLoading(false));
+  }, [open, filtersKey]);
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -63,24 +92,34 @@ export function WorkModeModal({
 
           {/* Body */}
           <ScrollFade wrapperClassName="flex-1 min-h-0" className="px-5 py-4">
-            <div className="flex flex-col gap-2">
-              {WORK_MODES.map((opt) => {
-                const active = selectedSet.has(opt.value);
-                return (
-                  <button
-                    key={opt.value}
-                    onClick={() => onToggle(opt.value)}
-                    className={`flex cursor-pointer items-center rounded-lg px-4 py-3 text-sm font-medium transition-colors ${
-                      active
-                        ? "bg-primary/10 text-primary"
-                        : "border border-border-soft text-muted hover:border-primary/30 hover:text-foreground"
-                    }`}
-                  >
-                    {opt.label}
-                  </button>
-                );
-              })}
-            </div>
+            {loading && counts === null ? (
+              <div className="flex items-center justify-center py-12">
+                <Loader2 size={20} className="animate-spin text-muted" />
+              </div>
+            ) : (
+              <div className="flex flex-col gap-2">
+                {WORK_MODES.map((opt) => {
+                  const active = selectedSet.has(opt.value);
+                  const count = counts?.[opt.value] ?? 0;
+                  return (
+                    <button
+                      key={opt.value}
+                      onClick={() => onToggle(opt.value)}
+                      className={`flex cursor-pointer items-center justify-between rounded-lg px-4 py-3 text-sm font-medium transition-colors ${
+                        active
+                          ? "bg-primary/10 text-primary"
+                          : "border border-border-soft text-muted hover:border-primary/30 hover:text-foreground"
+                      }`}
+                    >
+                      <span>{opt.label}</span>
+                      <span className={`text-xs ${active ? "text-primary/70" : "text-muted"}`}>
+                        ({count})
+                      </span>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
           </ScrollFade>
         </Dialog.Content>
       </Dialog.Portal>

--- a/apps/web/src/lib/actions/taxonomy.ts
+++ b/apps/web/src/lib/actions/taxonomy.ts
@@ -1106,3 +1106,103 @@ async function _fetchAllTechnologiesGrouped(
     return [];
   }
 }
+
+// ── Facet-count helpers for fixed-option modals ──────────────────────
+//
+// `employment_type` and `location_types` (work-mode) are small fixed
+// enums; the modals own the option list and i18n labels (see
+// `employment-type-modal.tsx` and `work-mode-modal.tsx`). The web app
+// only needs per-option counts to display next to each label — same
+// UX parity as the seniority/technology modals. Issue #3032.
+//
+// Both helpers re-use the shared `buildFilterString` cross-filter
+// pipeline, so counts reflect the currently-applied filter context
+// (location, occupation, level, etc.) just like the other modals.
+// Missing keys in the returned record mean "0 matching postings" —
+// the modals render `(0)` for them.
+
+/** Map of employment_type value -> matching active-posting count. */
+export async function getEmploymentTypeCounts(
+  filters?: { companyId?: string; keywords?: string[]; locationIds?: number[]; occupationIds?: number[]; seniorityIds?: number[]; technologyIds?: number[]; workMode?: string[]; languages?: string[] },
+): Promise<Record<string, number>> {
+  const fKey = filters ? JSON.stringify(filters) : "";
+  const key = `emp-type-counts:${fKey}`;
+  return cached(key, () => _fetchEmploymentTypeCounts(filters), { ttl: 3600 });
+}
+
+async function _fetchEmploymentTypeCounts(
+  filters?: { companyId?: string; keywords?: string[]; locationIds?: number[]; occupationIds?: number[]; seniorityIds?: number[]; technologyIds?: number[]; workMode?: string[]; languages?: string[] },
+): Promise<Record<string, number>> {
+  try {
+    const client = getTypesenseClient();
+    const filterStr = buildFilterString(filters);
+
+    const hasKeywords = filters?.keywords && filters.keywords.length > 0;
+    const q = hasKeywords ? filters!.keywords!.join(" ") : "*";
+
+    const result = await client.collections("job_posting").documents().search({
+      q,
+      query_by: "title",
+      filter_by: `${POSTING_BASE_FILTER}${filterStr ? " && " + filterStr : ""}`,
+      facet_by: "employment_type",
+      max_facet_values: 50,
+      facet_strategy: "exhaustive",
+      per_page: 0,
+    });
+
+    const facet = result.facet_counts?.find(
+      (f) => (f as { field_name: string }).field_name === "employment_type",
+    );
+    if (!facet) return {};
+    const out: Record<string, number> = {};
+    for (const fc of (facet as { counts: Array<{ value: string; count: number }> }).counts) {
+      out[fc.value] = fc.count;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/** Map of work-mode value (`onsite`|`hybrid`|`remote`) -> matching active-posting count. */
+export async function getWorkModeCounts(
+  filters?: { companyId?: string; keywords?: string[]; locationIds?: number[]; occupationIds?: number[]; seniorityIds?: number[]; technologyIds?: number[]; employmentTypes?: string[]; languages?: string[] },
+): Promise<Record<string, number>> {
+  const fKey = filters ? JSON.stringify(filters) : "";
+  const key = `work-mode-counts:${fKey}`;
+  return cached(key, () => _fetchWorkModeCounts(filters), { ttl: 3600 });
+}
+
+async function _fetchWorkModeCounts(
+  filters?: { companyId?: string; keywords?: string[]; locationIds?: number[]; occupationIds?: number[]; seniorityIds?: number[]; technologyIds?: number[]; employmentTypes?: string[]; languages?: string[] },
+): Promise<Record<string, number>> {
+  try {
+    const client = getTypesenseClient();
+    const filterStr = buildFilterString(filters);
+
+    const hasKeywords = filters?.keywords && filters.keywords.length > 0;
+    const q = hasKeywords ? filters!.keywords!.join(" ") : "*";
+
+    const result = await client.collections("job_posting").documents().search({
+      q,
+      query_by: "title",
+      filter_by: `${POSTING_BASE_FILTER}${filterStr ? " && " + filterStr : ""}`,
+      facet_by: "location_types",
+      max_facet_values: 50,
+      facet_strategy: "exhaustive",
+      per_page: 0,
+    });
+
+    const facet = result.facet_counts?.find(
+      (f) => (f as { field_name: string }).field_name === "location_types",
+    );
+    if (!facet) return {};
+    const out: Record<string, number> = {};
+    for (const fc of (facet as { counts: Array<{ value: string; count: number }> }).counts) {
+      out[fc.value] = fc.count;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}

--- a/apps/web/src/lib/search/types.ts
+++ b/apps/web/src/lib/search/types.ts
@@ -64,6 +64,13 @@ export interface HistogramFilters {
   seniorityIds?: number[];
   technologyIds?: number[];
   workMode?: WorkMode[];
+  /**
+   * Cross-filter context for the employment-type modal facet counts.
+   * Added in #3032 so toggling work-mode/occupation/etc. live-updates
+   * employment-type counts in the same way that location/level already
+   * cross-filter into the seniority and technology modals.
+   */
+  employmentTypes?: string[];
   languages?: string[];
 }
 


### PR DESCRIPTION
## Summary

The work-mode and employment-type modals added by #3053 displayed only the option labels — no per-option counts, breaking parity with the seniority / technology / location modals. This PR wires both to the same Typesense facet pattern (cross-filtered, refetched on filter-context change).

## Root cause

Both modals were built from a static option list with no facet fetch — `EmploymentTypeModal` and `WorkModeModal` rendered the i18n labels directly with nothing to the right of them. The other modals already had this UX via `getAllSeniorities` / `getAllTechnologiesGrouped` and a `filters` prop driving cross-filter context.

## What changed

| File | Change |
|------|--------|
| `apps/web/src/lib/actions/taxonomy.ts` | Add `getEmploymentTypeCounts` + `getWorkModeCounts` — facet `job_posting` on `employment_type` / `location_types`, share `buildFilterString` cross-filter pipeline and the `cached()` Redis wrapper (`ttl: 3600`). Return `Record<value, count>` so the modals keep their own ordered static option list. |
| `apps/web/src/components/search/employment-type-modal.tsx` | Accept `filters` prop, fetch on open + filter-change, render `(count)` per option, fall back to `(0)` for options absent from the facet response. Loading spinner mirrors `SeniorityModal`. |
| `apps/web/src/components/search/work-mode-modal.tsx` | Same wiring as the employment-type modal — three options (`onsite` / `hybrid` / `remote`) get their facet counts. |
| `apps/web/src/components/search/advanced-search-panel.tsx` | Plumb `histogramFilters` into both modals. Own axis is stripped (work-mode modal gets `employmentTypes` but NOT `workMode`, etc.) so counts answer "what would I see if I toggled this option on", matching the seniority / technology / location pattern. |
| `apps/web/src/lib/search/types.ts` | Add `employmentTypes` to `HistogramFilters` so the two new dimensions cross-filter each other. |
| `apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx` | Flow `workMode` + `employmentTypes` into the `histogramFilters` memo so cross-filter context is live. |
| `apps/web/src/components/search/__tests__/{employment-type,work-mode}-modal.test.tsx` | New regression tests for both modals: count rendering, missing-key `(0)` fallback, filter-change refetch, no-fetch-when-closed. |

## Verification — screenshots (`/tmp/3032-screenshots/`)

Captured via Playwright against `http://localhost:3002/en/colophongroup/swe-robotics-zurich` (the same test watchlist as `script/capture-screenshots.ts`).

### Before — work-mode modal (no counts)

`before-work-mode-modal.png` shows "On-site" / "Hybrid" / "Remote" with bare labels.

### After — work-mode modal (counts visible)

`after-work-mode-modal.png` shows "On-site (181) / Hybrid (37) / Remote (21)".

### Before — employment-type modal (no counts)

`before-employment-type-modal.png` shows "Full-time" / "Part-time" / "Contract" / "Internship" / "Temporary" / "Volunteer" with bare labels.

### After — employment-type modal (counts visible)

`after-employment-type-modal.png` shows "Full-time (140) / Part-time (2) / Contract (1) / Internship (4) / Temporary (0) / Volunteer (0)".

### After — cross-filter context refresh

`after-work-mode-modal-with-level-filter.png` — after adding the "Intern" level pill, work-mode counts drop from 181/37/21 to 8/0/1.

`after-employment-type-modal-with-workmode-filter.png` — after toggling "Remote" in the work-mode modal, employment-type Full-time drops from 140 to 20 (only remote full-time roles) and the other types fall to 0.

## Where counts come from

Both modals call new server actions in `apps/web/src/lib/actions/taxonomy.ts`:

- `getEmploymentTypeCounts(filters)` -> Typesense `facet_by: "employment_type"` against `job_posting` with `POSTING_BASE_FILTER` + cross-filter from `buildFilterString`.
- `getWorkModeCounts(filters)` -> same shape but `facet_by: "location_types"`.

Both fields are already `facet: true` in `apps/crawler/src/typesense_schema.py` (line 48 and 57) — no crawler-side changes needed. Cache key includes the filters JSON so cross-filter combinations populate independently.

## How counts update

`useEffect` watches a memoized `filtersKey = JSON.stringify(filters)`. On open or key change, the modal re-issues the action; loading spinner shows during the first fetch but subsequent refetches keep the stale counts visible (avoids flicker). Same pattern as `SeniorityModal` (`apps/web/src/components/search/seniority-modal.tsx:33-44`).

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm --filter @jobseek/web test` — 81 files, 724 tests pass (was 717, 7 new)
- [x] `pnpm exec eslint` on changed files — clean
- [x] Playwright BEFORE/AFTER screenshots verify visual fix
- [x] Cross-filter context verified visually (level filter + work-mode filter both update facets)

## Tangentials

- `HistogramFilters` previously had `workMode` but not `employmentTypes`; this PR adds the latter for symmetry. No other call sites used the missing field.
- The shared `buildFilterString` already handled both `employmentTypes` and `workMode` (the cross-filter SQL was wired in #3053). Only the count-fetch side was missing.
- Schema verification: `employment_type` (`facet: true`, optional) and `location_types: string[]` (`facet: true`) both present in `apps/crawler/src/typesense_schema.py`. No crawler-side gap.