### PR TITLE
build(deps): auto-build @jseek/mcp-server on install (closes #3043)

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "prepare": "tsc",
     "start": "node dist/index.js",
     "start:http": "node dist/http.js",
     "typecheck": "tsc --noEmit"


### PR DESCRIPTION
## Summary

- Adds `"prepare": "tsc"` to `packages/mcp-server/package.json` so `pnpm install` builds the package automatically.
- Fixes the bug where a fresh `git worktree add` leaves `packages/mcp-server/dist/` absent, breaking `pnpm exec tsc --noEmit` in `apps/web` (which imports `@jseek/mcp-server/handler` → `dist/handler.js`).
- Reported by 3 of 4 batch-1 implementer agents; manual workaround had been `pnpm --filter @jseek/mcp-server build`.

## Why `prepare`

pnpm runs `prepare` on every install (and on `git clone` for git-installed deps). We accept the small `tsc` cost on each install for the ergonomics win of never having to remember the manual build after a fresh checkout.

Closes #3043.

## Verification

- Deleted `packages/mcp-server/dist/` twice and confirmed `pnpm install` from the repo root recreates it (`prepare` script ran in both passes).
- `pnpm --filter @jobseek/web exec tsc --noEmit` → exit 0 (clean).
- `pnpm lint` → 3/3 tasks successful (turbo).

## Test plan

- [x] Delete `packages/mcp-server/dist/`, run `pnpm install`, confirm `dist/index.js` is recreated.
- [x] `pnpm --filter @jobseek/web exec tsc --noEmit` is clean (no `@jseek/mcp-server/handler` cannot find module errors).
- [x] `pnpm lint` clean.

## Tangential observed (not in scope)

`pnpm install` from a state with `dist/` missing emits one warning before `prepare` runs: `WARN  Failed to create bin at .../apps/web/node_modules/.bin/jobseek-mcp. ENOENT: ... packages/mcp-server/dist/index.js`. After `prepare` completes, the bin symlink is created correctly. Functionally harmless (verified by inspecting `apps/web/node_modules/.bin/jobseek-mcp`); leaving as-is to keep this PR a one-line change.