### PR TITLE
fix(web): include workMode + employmentType in nonTrivialWatchlistPredicate (closes #3059)

### DIFF
--- a/apps/web/src/lib/__tests__/watchlist-utils.test.ts
+++ b/apps/web/src/lib/__tests__/watchlist-utils.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { isTrivialWatchlist, isQualifyingWatchlist } from "../watchlist-utils";
 import { buildWatchlistItemListJsonLd } from "../seo";
+import type { WatchlistFilters } from "../actions/watchlists";
 
 describe("isTrivialWatchlist", () => {
   it("returns true for empty filters and zero companies", () => {
@@ -16,6 +19,86 @@ describe("isTrivialWatchlist", () => {
     expect(isTrivialWatchlist({ keywords: ["x"] }, 0)).toBe(false);
     expect(isTrivialWatchlist({ locationSlugs: ["zurich"] }, 0)).toBe(false);
     expect(isTrivialWatchlist({ salaryMin: 100000 }, 0)).toBe(false);
+  });
+
+  // #3059 — workMode + employmentType were added to WatchlistFilters by
+  // #3053 but the trivial-watchlist predicate forgot about them. A
+  // public watchlist that filters only on workMode (e.g. remote-only)
+  // was being misclassified as trivial and excluded from popular/public
+  // listings + Typesense indexing.
+  it("returns false when only workMode is set (#3059)", () => {
+    expect(isTrivialWatchlist({ workMode: ["remote"] }, 0)).toBe(false);
+  });
+  it("returns false when only employmentType is set (#3059)", () => {
+    expect(
+      isTrivialWatchlist({ employmentType: ["full_time"] }, 0),
+    ).toBe(false);
+  });
+
+  // Drift-guard: every meaningful key in WatchlistFilters must be
+  // checked by `isTrivialWatchlist` AND by the SQL predicate
+  // `nonTrivialWatchlistPredicate` in `src/lib/actions/watchlists.ts`.
+  // If you add a new filter to WatchlistFilters, update both predicates
+  // or extend the IGNORED_KEYS allowlist with a justification comment.
+  describe("drift-guard vs WatchlistFilters keys", () => {
+    // Keys that legitimately do NOT count as "meaningful" filters.
+    // `anyCompany` is a UI toggle, `salaryCurrency` is a unit/pref that
+    // is paired with salaryMin/salaryMax (which ARE checked). The
+    // trivial-predicate comment in watchlist-utils.ts spells this out.
+    const IGNORED_KEYS: ReadonlySet<keyof WatchlistFilters> = new Set([
+      "anyCompany",
+      "salaryCurrency",
+    ]);
+
+    // Generate one sample value per key. The runtime `keyof T` trick
+    // doesn't survive type erasure, so we list keys explicitly and use
+    // the type-system to check we covered them. Adding a key to
+    // WatchlistFilters but not to this map triggers a TS compile error
+    // via the `Required<WatchlistFilters>` mapping below.
+    const SAMPLE_VALUES: { [K in keyof Required<WatchlistFilters>]: NonNullable<WatchlistFilters[K]> } = {
+      keywords: ["x"],
+      locationSlugs: ["zurich"],
+      occupationSlugs: ["software-engineer"],
+      senioritySlugs: ["senior"],
+      technologySlugs: ["go"],
+      workMode: ["remote"],
+      employmentType: ["full_time"],
+      salaryMin: 100000,
+      salaryMax: 200000,
+      salaryCurrency: "CHF",
+      experienceMin: 3,
+      experienceMax: 10,
+      anyCompany: true,
+    };
+    const ALL_KEYS = Object.keys(SAMPLE_VALUES) as (keyof WatchlistFilters)[];
+
+    it.each(
+      ALL_KEYS.filter((k) => !IGNORED_KEYS.has(k)).map((k) => [k] as const),
+    )("TS predicate flags only-%s as non-trivial", (key) => {
+      const filters = { [key]: SAMPLE_VALUES[key] } as WatchlistFilters;
+      expect(isTrivialWatchlist(filters, 0)).toBe(false);
+    });
+
+    it("SQL predicate mentions every non-ignored WatchlistFilters key", () => {
+      // Read the SQL fragment as source text so a future contributor
+      // adding a filter sees this test fail until they update the SQL.
+      const src = readFileSync(
+        join(__dirname, "..", "actions", "watchlists.ts"),
+        "utf-8",
+      );
+      const sqlMatch = src.match(
+        /nonTrivialWatchlistPredicate\s*=\s*sql`([\s\S]*?)`/,
+      );
+      expect(sqlMatch, "nonTrivialWatchlistPredicate sql template literal not found").toBeTruthy();
+      const sqlBody = sqlMatch![1];
+      for (const key of ALL_KEYS) {
+        if (IGNORED_KEYS.has(key)) continue;
+        expect(
+          sqlBody,
+          `SQL predicate missing reference to filter key "${key}"`,
+        ).toMatch(new RegExp(`'${key}'`));
+      }
+    });
   });
 });
 

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -828,6 +828,8 @@ const nonTrivialWatchlistPredicate = sql`(
   OR jsonb_array_length(COALESCE(w.filters->'occupationSlugs', '[]'::jsonb)) > 0
   OR jsonb_array_length(COALESCE(w.filters->'senioritySlugs', '[]'::jsonb)) > 0
   OR jsonb_array_length(COALESCE(w.filters->'technologySlugs', '[]'::jsonb)) > 0
+  OR jsonb_array_length(COALESCE(w.filters->'workMode', '[]'::jsonb)) > 0
+  OR jsonb_array_length(COALESCE(w.filters->'employmentType', '[]'::jsonb)) > 0
   OR (w.filters ? 'salaryMin')
   OR (w.filters ? 'salaryMax')
   OR (w.filters ? 'experienceMin')

--- a/apps/web/src/lib/watchlist-utils.ts
+++ b/apps/web/src/lib/watchlist-utils.ts
@@ -5,6 +5,11 @@ import type { WatchlistFilters } from "@/lib/actions/watchlists";
 // no companies — effectively a blank shell. We exclude these from public
 // listings and search engines so they don't dilute the index.
 // `anyCompany` and `salaryCurrency` alone don't count (they're defaults/prefs).
+//
+// Mirror of the `nonTrivialWatchlistPredicate` SQL fragment in
+// `@/lib/actions/watchlists`. Keep the two in sync — see the drift-guard
+// test in `__tests__/watchlist-utils.test.ts` which fails if a new key
+// is added to `WatchlistFilters` without being checked here.
 export function isTrivialWatchlist(
   filters: WatchlistFilters | null | undefined,
   companyCount: number,
@@ -17,6 +22,8 @@ export function isTrivialWatchlist(
     f.occupationSlugs?.length ||
     f.senioritySlugs?.length ||
     f.technologySlugs?.length ||
+    f.workMode?.length ||
+    f.employmentType?.length ||
     f.salaryMin != null ||
     f.salaryMax != null ||
     f.experienceMin != null ||


### PR DESCRIPTION
## Summary

Issue #3059. PR #3053 added `workMode` and `employmentType` to `WatchlistFilters`, but the trivial-watchlist predicate was not updated. A user who creates a public watchlist with only `workMode: [\"remote\"]` (no companies, no other filters) was being classified as trivial and excluded from popular/public listings + Typesense indexing.

This PR teaches both mirrors about the two new keys and lands a drift-guard test so the next filter addition can't silently regress.

## Changes

- `apps/web/src/lib/actions/watchlists.ts:831-832` — SQL `nonTrivialWatchlistPredicate` now checks `jsonb_array_length` on `workMode` and `employmentType`.
- `apps/web/src/lib/watchlist-utils.ts:25-26` — `isTrivialWatchlist` now considers `f.workMode?.length` and `f.employmentType?.length`. Also added a comment pointing at the SQL mirror + drift-guard test.
- `apps/web/src/lib/__tests__/watchlist-utils.test.ts` — added:
  - Two bug-regression tests (only-`workMode`, only-`employmentType`).
  - A drift-guard `describe` block that enumerates every key of `WatchlistFilters` via a typed sample-value map and asserts:
    - `isTrivialWatchlist` returns `false` for each non-default key.
    - The SQL template literal in `watchlists.ts` references each non-default key literally.
  - Default-only keys (`anyCompany`, `salaryCurrency`) live in an `IGNORED_KEYS` allowlist with a justification comment.

## Before / after behavior

| Scenario | Before | After |
|---|---|---|
| Public watchlist, only `workMode: [\"remote\"]` | trivial (hidden from popular + not indexed) | non-trivial (visible + indexed) |
| Public watchlist, only `employmentType: [\"full_time\"]` | trivial | non-trivial |
| All previously-meaningful filter sets | unchanged | unchanged |

## Empirical bug verification

Ran the new failing tests against `origin/main` HEAD (`913ef47cc`) before applying the fix. 5 failures reported, all pinpointing the gap:

```
FAIL  isTrivialWatchlist > returns false when only workMode is set (#3059)
FAIL  isTrivialWatchlist > returns false when only employmentType is set (#3059)
FAIL  drift-guard > TS predicate flags only-workMode as non-trivial
FAIL  drift-guard > TS predicate flags only-employmentType as non-trivial
FAIL  drift-guard > SQL predicate mentions every non-ignored WatchlistFilters key
```

After the fix all 28 tests pass.

## Test plan

- [x] `pnpm exec vitest run src/lib/__tests__/watchlist-utils.test.ts` — 28/28 passing (5 failing before fix)
- [x] `pnpm exec tsc --noEmit` — clean (after one-time `pnpm --filter @jseek/mcp-server build` to populate the workspace package dist)
- [x] `pnpm --filter @jobseek/web test` — 738/738 passing across 81 files
- [ ] Smoke-test post-merge: create a public watchlist with only `workMode: [\"remote\"]` on staging and confirm it appears in `/popular` and gets indexed in Typesense

🤖 Generated with [Claude Code](https://claude.com/claude-code)