### PR TITLE
ci: hygiene bundle — remove redundant mcp build, consolidate ISR env, add tsc step (closes #3076 #3084 #3110)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
+    # `packages/mcp-server/package.json` has `"prepare": "tsc"`, so
+    # `pnpm install --frozen-lockfile` below builds `dist/` automatically.
+    # No explicit `pnpm --filter @jseek/mcp-server build` step is needed.
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -142,8 +145,6 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-
-      - run: pnpm --filter @jseek/mcp-server build
 
       - run: pnpm --filter @jobseek/web test
 
@@ -167,6 +168,39 @@ jobs:
     # with a stub DSN reproduces a Failed query / ECONNREFUSED prerender
     # error on `/[lang]/blog/how-we-index-job-postings`).
     environment: Production
+    # Job-level env: declared once, applied to every step in the job.
+    # Real secrets come from the `Production` environment above; the
+    # `ci-stub-*` literals are build-time-only placeholders that satisfy
+    # module-top-level env reads (e.g. better-auth's OAuth provider
+    # config) without authenticating to any real service — auth/SSO and
+    # search/write keys are only consumed at runtime by request handlers,
+    # which the build does not exercise.
+    env:
+      # Required: blog `<Mention>` MDX components fetch company tooltips
+      # at build time. Without a real DSN the per-post prerender fails.
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}
+      # Build-time-readable Typesense client config. Present as Production
+      # secrets; provider falls back gracefully on connection error so the
+      # literal placeholder is fine when secrets are missing in forks, but
+      # in the Production environment they resolve.
+      TYPESENSE_HOST: ${{ secrets.TYPESENSE_HOST }}
+      TYPESENSE_PORT: ${{ secrets.TYPESENSE_PORT }}
+      TYPESENSE_PROTOCOL: ${{ secrets.TYPESENSE_PROTOCOL }}
+      # Build-time-only stubs (see job-level comment above).
+      BETTER_AUTH_SECRET: ci-stub-better-auth-secret-not-used-at-build-time
+      BETTER_AUTH_URL: http://localhost:3000
+      TYPESENSE_SEARCH_KEY: ci-stub-not-used-at-build-time
+      TYPESENSE_WRITE_KEY: ci-stub-not-used-at-build-time
+      GITHUB_CLIENT_ID: ci-stub
+      GITHUB_CLIENT_SECRET: ci-stub
+      GOOGLE_CLIENT_ID: ci-stub
+      GOOGLE_CLIENT_SECRET: ci-stub
+      LINKEDIN_CLIENT_ID: ci-stub
+      LINKEDIN_CLIENT_SECRET: ci-stub
+      RESEND_API_KEY: ci-stub
+      UPSTASH_REDIS_REST_URL: https://stub.invalid
+      UPSTASH_REDIS_REST_TOKEN: ci-stub
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -177,46 +211,13 @@ jobs:
           node-version: 22
           cache: pnpm
 
+      # `pnpm install` auto-builds `packages/mcp-server/dist/` via its
+      # `prepare` script (`"prepare": "tsc"`), so no explicit build step
+      # is needed. `pnpm test:isr` then runs `pnpm build` itself via
+      # vitest globalSetup (`apps/web/test-setup/run-prod-build.ts`).
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm --filter @jseek/mcp-server build
-
-      # `pnpm test:isr` runs the build itself via vitest globalSetup
-      # (`apps/web/test-setup/run-prod-build.ts`), so no separate build
-      # step is needed.
       - run: pnpm --filter @jobseek/web test:isr
-        env:
-          # Required: blog `<Mention>` MDX components fetch company tooltips
-          # at build time. Without a real DSN the per-post prerender fails.
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-          DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}
-          # Build-time-readable Typesense client config. Present as Production
-          # secrets; provider falls back gracefully on connection error so
-          # the literal placeholder is fine when the secrets are missing in
-          # forks, but in the Production environment they resolve.
-          TYPESENSE_HOST: ${{ secrets.TYPESENSE_HOST }}
-          TYPESENSE_PORT: ${{ secrets.TYPESENSE_PORT }}
-          TYPESENSE_PROTOCOL: ${{ secrets.TYPESENSE_PROTOCOL }}
-          # Build-time-only stubs. These are NOT used to authenticate to
-          # any real service during the test build — auth/sso secrets and
-          # the search/write keys are only read at runtime by request
-          # handlers, which the build does not exercise. We pass literal
-          # placeholders so module-top-level reads (e.g. better-auth's
-          # OAuth provider config) don't throw and so search code paths
-          # that read these names see a non-empty string.
-          BETTER_AUTH_SECRET: ci-stub-better-auth-secret-not-used-at-build-time
-          BETTER_AUTH_URL: http://localhost:3000
-          TYPESENSE_SEARCH_KEY: ci-stub-not-used-at-build-time
-          TYPESENSE_WRITE_KEY: ci-stub-not-used-at-build-time
-          GITHUB_CLIENT_ID: ci-stub
-          GITHUB_CLIENT_SECRET: ci-stub
-          GOOGLE_CLIENT_ID: ci-stub
-          GOOGLE_CLIENT_SECRET: ci-stub
-          LINKEDIN_CLIENT_ID: ci-stub
-          LINKEDIN_CLIENT_SECRET: ci-stub
-          RESEND_API_KEY: ci-stub
-          UPSTASH_REDIS_REST_URL: https://stub.invalid
-          UPSTASH_REDIS_REST_TOKEN: ci-stub
 
   test-shim:
     name: Test Murmur Shim


### PR DESCRIPTION
## Summary

Bundle of 3 small CI hygiene fixes — all touch `.github/workflows/ci.yml`.

- **#3076** — Removed the redundant `pnpm --filter @jseek/mcp-server build` step from `test-web` and `test-web-isr`. After #3067 added `"prepare": "tsc"` to `packages/mcp-server/package.json`, `pnpm install --frozen-lockfile` already builds `dist/` automatically. Added a short comment in each job pointing to the `prepare` script as the reason no explicit build is needed.
- **#3084** — Moved the 18 inline env vars on `test-web-isr`'s `test:isr` step to a job-level `env:` block. The real secrets (`DATABASE_URL`, `TYPESENSE_*`) continue to come from the `Production` environment; the `ci-stub-*` literals are unchanged build-time-only placeholders. Declared once at the job level so future steps in the same job inherit them automatically.
- **#3110** — **Already covered, closing as moot.** The existing `Type All` job (added in #2899) runs `pnpm typecheck`, which is `turbo run typecheck` and executes `next typegen && tsc` against `apps/web` (whose `tsconfig.json` has `"strict": true`). The grep evidence in the issue is stale — `apps/web/package.json` does have a `typecheck` script. Adding another `pnpm exec tsc --noEmit` step would be a duplicate `tsc` invocation against the same workspace. Will follow up with a comment + close on the issue itself.

## Test plan

- [ ] CI runs green on this PR (`Test Web`, `Test Web ISR (slow)`, `Type All`, etc.)
- [ ] `test-web-isr` still classifies must-stay-cacheable routes correctly (real secrets from `Production` env still reach the `test:isr` step via job-level `env:`)
- [ ] No env var lost in the move (compared diff: 18 keys in, 18 keys out, ordering preserved)

Closes #3076. Closes #3084. Closes #3110 (already covered by `Type All`).