### PR TITLE
ci(blog): replace 5-min sleep with workflow_run / polling (closes #3097)

### DIFF
--- a/.github/workflows/notify-blog-indexnow.yml
+++ b/.github/workflows/notify-blog-indexnow.yml
@@ -82,6 +82,18 @@ jobs:
         # sleep, and we cap at 10 min so a stuck Vercel build fails
         # the job loudly instead of submitting against a stale
         # surface.
+        #
+        # We filter the deployment list by `creator.login == "vercel[bot]"`
+        # because multiple workflows in this repo (ci.yml's "Test Web ISR
+        # (slow)", crawler-scheduled-maintenance.yml,
+        # deploy-crawler-browser.yml, sync-data.yml, deploy-murmur-shim.yml)
+        # also declare `environment: production` and therefore create their
+        # own Production deployment records via the GitHub Actions runner.
+        # Without the creator filter we could match a CI workflow's
+        # short-lived deployment (which finishes in seconds) instead of
+        # Vercel's actual build, race past it, and submit to IndexNow
+        # before content is live — exactly the race the original
+        # 5-min sleep guarded against.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPLOY_SHA: ${{ github.sha }}
@@ -90,14 +102,16 @@ jobs:
           set -euo pipefail
           deadline=$(( $(date +%s) + 600 ))
           while :; do
-            # Collect every status state across every deployment matching
-            # this SHA in the Production environment. In practice there's
-            # exactly one (Vercel publishes one per SHA), but we don't
-            # depend on that. Statuses are returned newest-first, so the
-            # first terminal state in the stream wins.
+            # Collect every status state across every Vercel-bot deployment
+            # matching this SHA in the Production environment. In practice
+            # there's exactly one Vercel deployment per SHA, but we don't
+            # depend on that. The `creator.login` filter excludes Production
+            # deployment records this repo's own CI workflows create for
+            # their `environment: production` jobs. Statuses are returned
+            # newest-first, so the first terminal state in the stream wins.
             states=$(gh api \
               "repos/${REPO}/deployments?sha=${DEPLOY_SHA}&environment=Production&per_page=10" \
-              --jq '.[].statuses_url' \
+              --jq '.[] | select(.creator.login == "vercel[bot]") | .statuses_url' \
             | while read -r url; do
                 gh api "$url" --jq '.[].state'
               done) || true

--- a/.github/workflows/notify-blog-indexnow.yml
+++ b/.github/workflows/notify-blog-indexnow.yml
@@ -14,11 +14,15 @@ name: Notify IndexNow on blog content changes
 # Vercel race: pushing to main triggers a Vercel prod deploy in
 # parallel. If we POST to IndexNow before Vercel's deploy completes,
 # engines get a brief 404 window on a brand-new post (translated MDX
-# file added in the same commit). The 5-minute pre-submit sleep lets
-# most prod deploys finish (the app's typical build is 2–5 min;
-# slower builds have a 1–7 day engine retry cushion to forgive the
-# initial 404). Re-submission on the next blog commit re-pings the
-# URL anyway.
+# file added in the same commit). To avoid blindly burning 5 min of
+# runner time per push, we poll the GitHub Deployments API (Vercel
+# publishes a `Production`-environment deployment per SHA via its
+# GitHub App). We bail out as soon as that deployment reaches
+# `success`; we time out at 10 min if it never does, which surfaces
+# real Vercel outages instead of silently submitting against a stale
+# build. Re-submission on the next blog commit re-pings the URL
+# anyway, so the 1–7-day engine retry cushion still covers the worst
+# case.
 #
 # Why a separate workflow vs piggybacking on a deploy hook: keeps the
 # secret scope narrow (only this workflow needs INDEXNOW_KEY in the
@@ -50,6 +54,12 @@ jobs:
     # this repo declares the same — see deploy-crawler-browser.yml,
     # deploy-murmur-shim.yml, crawler-scheduled-maintenance.yml.
     environment: production
+    # `deployments: read` lets the poll step query Vercel's prod
+    # deployment status via the GitHub Deployments API. All other
+    # default permissions stay at their workflow defaults.
+    permissions:
+      contents: read
+      deployments: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -63,13 +73,59 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Wait for Vercel prod deploy to settle
-        # Crude but reliable: app prod builds typically finish in
-        # 2–5 minutes, and 300s is well inside the engine retry
-        # cushion if we still race a long build. A more precise
-        # signal would be polling Vercel's deployment-succeeded
-        # webhook; not worth the plumbing for a 1–7-day-cadence
-        # signal.
-        run: sleep 300
+        # Poll GitHub Deployments API for a `success` status on the
+        # `Production` deployment matching this push's SHA. Vercel
+        # publishes one via its GitHub App per prod build, with
+        # state transitions `in_progress` -> `success` (or
+        # `failure`/`error`). We exit 0 the moment we see success,
+        # which typically saves ~3-4 min compared to a flat 5-min
+        # sleep, and we cap at 10 min so a stuck Vercel build fails
+        # the job loudly instead of submitting against a stale
+        # surface.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEPLOY_SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          deadline=$(( $(date +%s) + 600 ))
+          while :; do
+            # Collect every status state across every deployment matching
+            # this SHA in the Production environment. In practice there's
+            # exactly one (Vercel publishes one per SHA), but we don't
+            # depend on that. Statuses are returned newest-first, so the
+            # first terminal state in the stream wins.
+            states=$(gh api \
+              "repos/${REPO}/deployments?sha=${DEPLOY_SHA}&environment=Production&per_page=10" \
+              --jq '.[].statuses_url' \
+            | while read -r url; do
+                gh api "$url" --jq '.[].state'
+              done) || true
+            status=$(printf '%s\n' "$states" \
+              | grep -E '^(success|failure|error|inactive)$' \
+              | head -n1 || true)
+            case "$status" in
+              success)
+                echo "Vercel prod deploy succeeded for ${DEPLOY_SHA}"
+                exit 0
+                ;;
+              failure|error)
+                echo "Vercel prod deploy reported '${status}' for ${DEPLOY_SHA}" >&2
+                exit 1
+                ;;
+              inactive)
+                # Superseded by a newer deploy — the URL is live on
+                # the newer one, so we can proceed.
+                echo "Vercel prod deploy for ${DEPLOY_SHA} was superseded ('inactive'); proceeding"
+                exit 0
+                ;;
+            esac
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              echo "Timed out after 10 min waiting for Vercel prod deploy on ${DEPLOY_SHA}" >&2
+              exit 1
+            fi
+            sleep 15
+          done
 
       - name: Submit blog post URLs
         env:


### PR DESCRIPTION
## Summary

Closes #3097. `.github/workflows/notify-blog-indexnow.yml` previously did `sleep 300` to wait out the parallel Vercel prod deploy before pinging IndexNow. That burned ~5 min of GitHub Actions runner time per blog commit, regardless of how fast the actual Vercel build was. Worst case (a hung Vercel build) it also submitted URLs against a stale surface and the comment "1-7 day engine retry cushion" silently absorbed the failure.

This PR replaces the flat sleep with a poll against the GitHub Deployments API. Vercel's GitHub App publishes a `Production`-environment deployment per SHA, with statuses `in_progress` -> `success` (or `failure`/`error`). We exit 0 as soon as the matching deployment hits `success`, exit 1 on `failure`/`error` (so a real Vercel outage fails the job loudly), and time out at 10 min if no terminal state appears.

## Alternatives considered (rationale for Option 2)

The issue listed three options. Picking the simplest that works:

1. **`workflow_run` trigger on the Vercel deploy workflow** — NOT viable. Vercel prod deploys are triggered by the Vercel GitHub App integration, not by a GitHub Actions workflow in this repo. There's no workflow to fire `workflow_run` off of. (Confirmed by `ls .github/workflows/` — only the crawler/murmur/CI workflows are GH-native; web prod deploys are Vercel-side.)
2. **Poll the Deployments API for `success` on the push SHA** — chosen. The GitHub Deployments API already records Vercel's deploys (verified via `gh api repos/colophon-group/jobseek/deployments?environment=Production`). Filter by `sha=$GITHUB_SHA`, walk statuses, watch for terminal state. Adds 30-60 s in the typical path vs. the previous flat 300 s, and surfaces real failures.
3. **Vercel deploy hooks -> `repository_dispatch`** — most plumbing (Vercel project webhook + repo secret + signature verification + a separate dispatch endpoint). Saves no runner time over Option 2 because we still need a runner to fetch the URLs and POST IndexNow. Not worth it for a 1-7 day-cadence signal.

## Behavioural notes

- The poll handles the `inactive` terminal state too — if a newer deploy supersedes this one before we get to it, the URL is live on the newer build and we proceed. Without this branch the job would otherwise sit until the 10-min timeout for any SHA quickly overtaken on a fast blog-commit cadence.
- `cancel-in-progress: false` is unchanged; queued back-to-back runs now exit within seconds of the deploy going live, instead of each sitting on its own 5-min sleep.
- Workflow now declares `permissions: { contents: read, deployments: read }` so the poll step's `gh api` call has the right scope. Default `GITHUB_TOKEN` permissions vary by repo settings; explicit is safer.

## File changed

- `.github/workflows/notify-blog-indexnow.yml`

## Test plan

- [x] YAML loads (`python3 -c 'import yaml; yaml.safe_load(open(...))'`)
- [x] `actionlint` passes
- [x] Dry-ran the poll body in bash against a real merged-to-main SHA (`e9164e0f...`): correctly resolved to a terminal state, the case branch fired, exited 0.
- [x] Dry-ran against a non-existent SHA: states empty, case falls through, deadline check / retry kicks in.
- [ ] Live verification: next blog content commit on main exercises the polling path. Until then, the workflow has `workflow_dispatch` so it can be invoked manually after a known deploy completes for a smoke test if needed.