### PR TITLE
refactor(web): extract scroll-mt anchor offset to shared util (closes #3045)

### DIFF
--- a/apps/web/src/components/Features.tsx
+++ b/apps/web/src/components/Features.tsx
@@ -4,7 +4,7 @@ import type { ElementType, CSSProperties } from "react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { siteConfig } from "@/content/config";
 import { ThemedImage } from "@/components/ThemedImage";
-import { eyebrowClass, sectionHeadingClass } from "@/lib/styles";
+import { eyebrowClass, sectionHeadingClass, sectionScrollMarginClass } from "@/lib/styles";
 import { Globe, SlidersHorizontal, Bell, GitGraph, ClipboardList, BarChart3, Target, Building2, Share2 } from "lucide-react";
 
 const iconMap: Record<string, ElementType> = {
@@ -329,7 +329,7 @@ export function Features() {
   return (
     <section
       id={siteConfig.features.anchorId}
-      className="relative z-[1] scroll-mt-24 overflow-x-hidden overflow-y-visible py-16 pb-8 md:scroll-mt-32 md:py-24 md:pb-12"
+      className={`relative z-[1] overflow-x-hidden overflow-y-visible py-16 pb-8 md:py-24 md:pb-12 ${sectionScrollMarginClass}`}
     >
       <div className="flex flex-col gap-24 md:gap-32">
         {/* Order is ICP-first: watchlist (s3) → tracker (s2) → search (s1).

--- a/apps/web/src/components/HowWeIndexContent.tsx
+++ b/apps/web/src/components/HowWeIndexContent.tsx
@@ -5,10 +5,8 @@ import { useLingui } from "@lingui/react/macro";
 import { siteConfig, publicDomainAssets } from "@/content/config";
 import { PublicDomainArt } from "@/components/PublicDomainArt";
 import { TableOfContents } from "@/components/TableOfContents";
-import { eyebrowClass, sectionHeadingClass } from "@/lib/styles";
+import { eyebrowClass, sectionHeadingClass, sectionScrollMarginClass as sectionScroll } from "@/lib/styles";
 import { Info } from "lucide-react";
-
-const sectionScroll = "scroll-mt-24 md:scroll-mt-32";
 
 export function HowWeIndexContent() {
   const { t } = useLingui();

--- a/apps/web/src/components/LicenseContent.tsx
+++ b/apps/web/src/components/LicenseContent.tsx
@@ -5,8 +5,7 @@ import { useLingui } from "@lingui/react/macro";
 import { siteConfig } from "@/content/config";
 import { ContentPageHero } from "@/components/ContentPageHero";
 import { TableOfContents } from "@/components/TableOfContents";
-
-const sectionScroll = "scroll-mt-24 md:scroll-mt-32";
+import { sectionScrollMarginClass as sectionScroll } from "@/lib/styles";
 
 export function LicenseContent() {
   const { t } = useLingui();

--- a/apps/web/src/components/Pricing.tsx
+++ b/apps/web/src/components/Pricing.tsx
@@ -4,7 +4,7 @@ import { Trans } from "@lingui/react/macro";
 import { useLingui } from "@lingui/react/macro";
 import { siteConfig } from "@/content/config";
 import { useLocalePath } from "@/lib/useLocalePath";
-import { eyebrowClass, sectionHeadingClass } from "@/lib/styles";
+import { eyebrowClass, sectionHeadingClass, sectionScrollMarginClass } from "@/lib/styles";
 import { Button } from "@/components/ui/Button";
 import { CircleCheck } from "lucide-react";
 
@@ -96,7 +96,7 @@ export function Pricing() {
   return (
     <section
       id={siteConfig.pricing.anchorId}
-      className="mx-auto max-w-[1200px] scroll-mt-24 px-4 py-12 md:scroll-mt-32 md:py-20"
+      className={`mx-auto max-w-[1200px] px-4 py-12 md:py-20 ${sectionScrollMarginClass}`}
     >
       <div className="mx-auto flex max-w-[640px] flex-col gap-4 text-center">
         <span className={eyebrowClass}>

--- a/apps/web/src/components/PrivacyPolicyContent.tsx
+++ b/apps/web/src/components/PrivacyPolicyContent.tsx
@@ -3,8 +3,7 @@
 import { Trans } from "@lingui/react/macro";
 import { siteConfig } from "@/content/config";
 import { ContentPageHero } from "@/components/ContentPageHero";
-
-const sectionScroll = "scroll-mt-24 md:scroll-mt-32";
+import { sectionScrollMarginClass as sectionScroll } from "@/lib/styles";
 
 export function PrivacyPolicyContent() {
   const contactEmail = siteConfig.indexing.contactEmail;

--- a/apps/web/src/components/TermsContent.tsx
+++ b/apps/web/src/components/TermsContent.tsx
@@ -3,8 +3,7 @@
 import { Trans } from "@lingui/react/macro";
 import { siteConfig } from "@/content/config";
 import { ContentPageHero } from "@/components/ContentPageHero";
-
-const sectionScroll = "scroll-mt-24 md:scroll-mt-32";
+import { sectionScrollMarginClass as sectionScroll } from "@/lib/styles";
 
 export function TermsContent() {
   const contactEmail = siteConfig.indexing.contactEmail;

--- a/apps/web/src/lib/__tests__/styles.test.ts
+++ b/apps/web/src/lib/__tests__/styles.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { eyebrowClass, sectionHeadingClass } from "../styles";
+import { eyebrowClass, sectionHeadingClass, sectionScrollMarginClass } from "../styles";
 
 describe("style constants", () => {
   it("eyebrowClass is a non-empty string", () => {
@@ -10,5 +10,10 @@ describe("style constants", () => {
   it("sectionHeadingClass is a non-empty string", () => {
     expect(typeof sectionHeadingClass).toBe("string");
     expect(sectionHeadingClass.length).toBeGreaterThan(0);
+  });
+
+  it("sectionScrollMarginClass pairs mobile + desktop scroll-mt utilities", () => {
+    expect(sectionScrollMarginClass).toContain("scroll-mt-24");
+    expect(sectionScrollMarginClass).toContain("md:scroll-mt-32");
   });
 });

--- a/apps/web/src/lib/styles.ts
+++ b/apps/web/src/lib/styles.ts
@@ -1,2 +1,10 @@
 export const eyebrowClass = "text-xs font-semibold uppercase tracking-wider text-muted";
 export const sectionHeadingClass = "text-2xl font-bold md:text-3xl";
+
+/**
+ * Anchor scroll-margin for sections that may be targeted by `#hash` navigation.
+ * The sticky `<Header>` is `h-12` (48px) + 1px border = 49px tall, so we use
+ * `scroll-mt-24` (~96px on mobile) / `md:scroll-mt-32` (~128px on desktop) to
+ * give the anchored element breathing room below the header.
+ */
+export const sectionScrollMarginClass = "scroll-mt-24 md:scroll-mt-32";


### PR DESCRIPTION
## Summary

The `scroll-mt-24 md:scroll-mt-32` Tailwind chain was duplicated in six places: four content components defined it as a local `sectionScroll` const, and `Features` / `Pricing` had it inlined (added in #3039). This PR moves it to a single named export in `@/lib/styles` and reuses it across all six sites.

- **Source of truth**: `apps/web/src/lib/styles.ts` — new `sectionScrollMarginClass` named export with JSDoc referencing the `<Header>` `h-12` (49px including border) constraint.
- **No behavior change.** `getComputedStyle(...).scrollMarginTop` resolves to the same `96px` mobile / `128px` desktop value at every site after the change.

## Files updated

- `apps/web/src/lib/styles.ts` (added `sectionScrollMarginClass`)
- `apps/web/src/lib/__tests__/styles.test.ts` (smoke test for the new constant)
- `apps/web/src/components/Features.tsx` — was inline, now imports the constant and appends it via template literal
- `apps/web/src/components/Pricing.tsx` — same shape as Features
- `apps/web/src/components/LicenseContent.tsx` — drops `const sectionScroll = "…"`, imports as `sectionScrollMarginClass as sectionScroll` so the existing local identifier still works
- `apps/web/src/components/HowWeIndexContent.tsx` — same shape as License
- `apps/web/src/components/TermsContent.tsx` — same shape as License
- `apps/web/src/components/PrivacyPolicyContent.tsx` — same shape as License

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm --filter @jobseek/web test` — 717/717 tests pass (no regressions; new `styles.test.ts` case for `sectionScrollMarginClass` is included)
- [x] Visual verification via Playwright at all 6 anchor surfaces on `http://localhost:3006`, mobile (390px) + desktop (1280px) — `getComputedStyle(...).scrollMarginTop` is `96px` mobile / `128px` desktop at every site. Screenshots captured to `/tmp/3045-screenshots/` (12 PNGs).

Surfaces verified:
- `/en#features` (Features.tsx)
- `/en#pricing` (Pricing.tsx)
- `/en/license#license-overview` (LicenseContent.tsx)
- `/en/how-we-index#indexing-overview` (HowWeIndexContent.tsx)
- `/en/terms` first scroll target (TermsContent.tsx)
- `/en/privacy-policy` first scroll target (PrivacyPolicyContent.tsx)

Closes #3045.