### PR TITLE
refactor(web): drop unnecessary 'as unknown as' assertions in client components (closes #3107)

### DIFF
--- a/apps/web/src/components/settings/AccountSettings.tsx
+++ b/apps/web/src/components/settings/AccountSettings.tsx
@@ -155,10 +155,7 @@ function ResetPasswordFlow({ initialCooldown }: { initialCooldown: number }) {
       return;
     }
 
-    const { error } = await (authClient as unknown as {
-      requestPasswordReset: (opts: { email: string; redirectTo: string }) =>
-        Promise<{ error: { message?: string } | null }>;
-    }).requestPasswordReset({
+    const { error } = await authClient.requestPasswordReset({
       email: user.email,
       redirectTo: "/reset-password",
     });
@@ -240,7 +237,7 @@ function UsernameSection({ currentUsername }: { currentUsername: string }) {
     debounceRef.current = setTimeout(async () => {
       try {
         const res = await authClient.isUsernameAvailable({ username: norm });
-        setAvailable(!!(res.data as unknown as { available: boolean })?.available);
+        setAvailable(!!res.data?.available);
       } catch {
         setAvailable(null);
       }


### PR DESCRIPTION
## Summary

The TypeScript audit (#3107) found 50+ non-test `as unknown as` casts in `apps/web/src/`. This PR cleans the **client-component** subset (server-action / DB-row casts are tracked in #3085 and out of scope here).

Scope grep: `apps/web/src/components/`, `apps/web/app/[lang]/`.

After excluding tests, only one client-component file held assertions, both unnecessary. Both are calls to the Better Auth client whose return shapes are already fully typed — the casts were dead weight (likely carried over from an earlier better-auth version with weaker typings).

## Files cleaned (1 file, 2 assertions removed)

### `apps/web/src/components/settings/AccountSettings.tsx`

**Before (line 158):**
```ts
const { error } = await (authClient as unknown as {
  requestPasswordReset: (opts: { email: string; redirectTo: string }) =>
    Promise<{ error: { message?: string } | null }>;
}).requestPasswordReset({
  email: user.email,
  redirectTo: "/reset-password",
});
```

**After:**
```ts
const { error } = await authClient.requestPasswordReset({
  email: user.email,
  redirectTo: "/reset-password",
});
```

`requestPasswordReset` is exposed natively on `createAuthClient` and is correctly typed by Better Auth 1.4.18.

---

**Before (line 240):**
```ts
const res = await authClient.isUsernameAvailable({ username: norm });
setAvailable(!!(res.data as unknown as { available: boolean })?.available);
```

**After:**
```ts
const res = await authClient.isUsernameAvailable({ username: norm });
setAvailable(!!res.data?.available);
```

`isUsernameAvailable` comes from the `usernameClient()` plugin and returns properly typed data including `available: boolean`.

## Intentionally left

All other `as unknown as` sites within the grep pattern are inside `__tests__/` (out of scope for this issue per the audit, and intentionally narrowing mock objects to platform types like `IntersectionObserver` / `NextRequest`).

Sites in `apps/web/src/lib/actions/**`, `apps/web/src/lib/sitemap.ts`, `apps/web/src/lib/search/typesense-client.ts`, `apps/web/src/db/index.ts`, and `apps/web/app/robots.ts` are out of scope:
- `lib/actions/**` casts are the typed-DB-row pattern called out in #3085.
- `lib/search/typesense-client.ts` and `db/index.ts` use `globalThis as unknown as { ... }` for the conventional dev-HMR singleton cache pattern.
- `app/robots.ts` is a metadata route handler, not a client component.

## Verification

- [x] `pnpm exec tsc --noEmit` — clean before and after.
- [x] `pnpm test` — 738/738 vitest tests pass.
- [x] ESLint clean on the modified file.

## Test plan

- [ ] Sign in with a social account, request a password reset — confirm reset email arrives.
- [ ] On `/settings/account`, type a candidate username and confirm the "Available" / "Already taken" hint still appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)