### PR TITLE
fix(web): pass workMode + employmentTypes to histogramFilters on /explore + /company (closes #3066)

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
@@ -543,8 +543,15 @@ export function CompanyPage({
     occupationIds: occupations.length > 0 ? occupations.map((o) => o.id) : undefined,
     seniorityIds: seniorities.length > 0 ? seniorities.map((s) => s.id) : undefined,
     technologyIds: technologies.length > 0 ? technologies.map((t) => t.id) : undefined,
+    // #3066 — workMode + employmentTypes flow through so the work-mode and
+    // employment-type modals can cross-filter their per-option counts against
+    // each other (parity with watchlist-view-page). AdvancedSearchPanel strips
+    // the active dimension before passing this object down to the matching
+    // modal, so the counts answer "what would I see if I toggled this on".
+    workMode: workMode.length > 0 ? workMode : undefined,
+    employmentTypes: employmentTypes.length > 0 ? employmentTypes : undefined,
     languages: languages.length > 0 ? languages : undefined,
-  }), [company.id, keywords, locations, occupations, seniorities, technologies, languages]);
+  }), [company.id, keywords, locations, occupations, seniorities, technologies, workMode, employmentTypes, languages]);
 
   // Desktop: stats sit inline on the language-note row (right side).
   // Hidden on mobile so it can drop to its own row below, split

--- a/apps/web/app/[lang]/(app)/explore/search-page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/search-page.tsx
@@ -717,8 +717,15 @@ export function SearchPage({
     occupationIds: occupations.length > 0 ? occupations.map((o) => o.id) : undefined,
     seniorityIds: seniorities.length > 0 ? seniorities.map((s) => s.id) : undefined,
     technologyIds: technologies.length > 0 ? technologies.map((t) => t.id) : undefined,
+    // #3066 — workMode + employmentTypes flow through so the work-mode and
+    // employment-type modals can cross-filter their per-option counts against
+    // each other (parity with watchlist-view-page). AdvancedSearchPanel strips
+    // the active dimension before passing this object down to the matching
+    // modal, so the counts answer "what would I see if I toggled this on".
+    workMode: workMode.length > 0 ? workMode : undefined,
+    employmentTypes: employmentTypes.length > 0 ? employmentTypes : undefined,
     languages: languages.length > 0 ? languages : undefined,
-  }), [keywords, locations, occupations, seniorities, technologies, languages]);
+  }), [keywords, locations, occupations, seniorities, technologies, workMode, employmentTypes, languages]);
 
   const searchColumn = (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary

After #3065 added cross-filter context for work-mode and employment-type modal counts on the watchlist surface, the same modals open on `/explore` and `/company/[slug]` but their `histogramFilters` memos did NOT pass `workMode` + `employmentTypes`. Other axes (location/occupation/level/etc.) cross-filtered correctly. Effect: opening the work-mode modal while an employment-type filter is applied (or vice versa) showed counts that didn't reflect the cross-filter.

## What changed

| File | Change |
|------|--------|
| `apps/web/app/[lang]/(app)/explore/search-page.tsx` | Add `workMode` + `employmentTypes` to the `histogramFilters` memo (and to deps), mirroring the watchlist-view-page pattern from #3065. |
| `apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx` | Same — add both fields to the `histogramFilters` memo + deps. `companyId` was already included. |

`AdvancedSearchPanel` already strips the active axis before passing the object down to the matching modal (`apps/web/src/components/search/advanced-search-panel.tsx:283-310`), so this is a one-line-shape change at the producer side.

## Verification (screenshots at `/tmp/3066-screenshots/`)

Captured via headless Playwright against `http://localhost:3008/{en/explore, en/company/accenture}` in this dev worktree. Each route was captured BEFORE (file checked out at HEAD~1) and AFTER (file at HEAD) on the same running dev server.

### /explore — cross-filter context refresh

BEFORE — `before-explore-04-empType-baseline.png` -> Full-time (318619), Part-time (15914), Contract (3434), Internship (1770), Temporary (671), Volunteer (51) — unfiltered baseline.

BEFORE — `before-explore-06-workMode-with-fulltime.png` -> Full-Time chip applied, Work mode shows On-site (567118), Hybrid (18697), Remote (29918). **Buggy**: On-site (567118) > Full-time total (318619), so the counts are clearly NOT scoped by the Full-Time filter.

AFTER — `after-explore-06-workMode-with-fulltime.png` -> Full-Time chip applied, Work mode shows On-site (268436), Hybrid (16341), Remote (13942). Sum ~298k is consistent with Full-time total (318619); counts are now correctly cross-filtered.

AFTER — `after-explore-08-empType-with-remote.png` -> Remote chip applied, Full-time drops to 13942 (was 318619 unfiltered) and other types collapse to small values — cross-filter live on the reverse direction.

### /company/accenture — cross-filter context refresh

BEFORE — `before-company-06-workMode-with-fulltime.png` -> Full Time chip applied, Work mode shows On-site (54410), Hybrid (42), Remote (224). Sum 54676 ≈ Accenture's 54694 active postings, so the counts are NOT scoped by Full-Time.

AFTER — `after-company-06-workMode-with-fulltime.png` -> Full Time chip applied, Work mode all (0). This is consistent with Accenture postings not tagging `employment_type` (the field is `optional: true` in the Typesense schema and Accenture data simply doesn't set it). The cross-filter now correctly resolves to zero matches for `companyId=Accenture AND employment_type=Full-time`. Result list confirms "No matching postings found".

(The `/company` empType modal shows all-zero counts in both BEFORE and AFTER because Accenture's data lacks `employment_type` values entirely — that's an unrelated data-population issue, not the bug we're fixing. The work-mode side is the proof.)

## Tangentials

- `script/3066-capture.mjs` was used locally to drive the headless captures but is not committed (verification-only).
- No type or test impact: `HistogramFilters` already declared both `workMode` and `employmentTypes` (added in #3065), and `buildFilterString` already handled them (#3053). Only the producer-side memos on these two routes were missing them.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean (only `.next/dev/types/validator.ts` noise from Next dev cache)
- [x] `pnpm --filter @jobseek/web test` — 81 files, 743 tests pass
- [x] Playwright BEFORE/AFTER screenshots on `/explore` and `/company/accenture` verify cross-filter is wired in both directions
- [x] Pre-commit hooks (ESLint, Lingui coverage) — passed