### PR TITLE
fix(web): wire scrollToTopOnNav on Footer, RelatedPosts, CookieBanner, blog inline links (closes #3046)

### DIFF
--- a/apps/web/src/components/CookieBanner.tsx
+++ b/apps/web/src/components/CookieBanner.tsx
@@ -6,7 +6,7 @@ import { useLingui } from "@lingui/react/macro";
 import { useLocalePath } from "@/lib/useLocalePath";
 import { updatePreferences } from "@/lib/actions/preferences";
 import { useBanner } from "@/components/BannerProvider";
-import Link from "next/link";
+import { NavLink } from "@/components/NavLink";
 import { Info } from "lucide-react";
 
 const BANNER_ID = "cookie-consent";
@@ -52,13 +52,13 @@ export function CookieBanner({ aboveBottomBar, serverConsent }: CookieBannerProp
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-2 self-end sm:self-auto">
-          <Link
+          <NavLink
             href={lp("/privacy-policy")}
             prefetch={false}
             className="rounded-full px-2.5 py-1 font-medium transition-colors hover:bg-info-border"
           >
             {t({ id: "common.cookies.details", comment: "Cookie banner details button", message: "Details" })}
-          </Link>
+          </NavLink>
           <button
             onClick={dismiss}
             className="rounded-full bg-info-border px-2.5 py-1 font-medium transition-colors hover:opacity-80 cursor-pointer"

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -1,8 +1,8 @@
-import Link from "next/link";
 import { Trans } from "@lingui/react/macro";
 import { msg } from "@lingui/core/macro";
 import { getI18n } from "@lingui/react/server";
 import { siteConfig } from "@/content/config";
+import { NavLink } from "@/components/NavLink";
 
 type FooterProps = {
   lang?: string;
@@ -48,24 +48,24 @@ export function Footer({ lang }: FooterProps) {
               </a>
             </li>
             <li>
-              <Link className={linkClass} prefetch={false} href={`${prefix}${links.blog.href}`}>
+              <NavLink className={linkClass} prefetch={false} href={`${prefix}${links.blog.href}`}>
                 <Trans id="common.footer.blog" comment="Footer link to /blog index page">Blog</Trans>
-              </Link>
+              </NavLink>
             </li>
             <li>
-              <Link className={linkClass} prefetch={false} href={`${prefix}${links.license.href}`}>
+              <NavLink className={linkClass} prefetch={false} href={`${prefix}${links.license.href}`}>
                 <Trans id="common.footer.licenseLink" comment="Footer link to license page">License</Trans>
-              </Link>
+              </NavLink>
             </li>
             <li>
-              <Link className={linkClass} prefetch={false} href={`${prefix}${links.privacy.href}`}>
+              <NavLink className={linkClass} prefetch={false} href={`${prefix}${links.privacy.href}`}>
                 <Trans id="common.footer.privacyLink" comment="Footer link to privacy policy page">Privacy</Trans>
-              </Link>
+              </NavLink>
             </li>
             <li>
-              <Link className={linkClass} prefetch={false} href={`${prefix}${links.terms.href}`}>
+              <NavLink className={linkClass} prefetch={false} href={`${prefix}${links.terms.href}`}>
                 <Trans id="common.footer.termsLink" comment="Footer link to terms of service page">Terms</Trans>
-              </Link>
+              </NavLink>
             </li>
           </ul>
         </nav>

--- a/apps/web/src/components/NavLink.tsx
+++ b/apps/web/src/components/NavLink.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import Link from "next/link";
+import type { ComponentProps } from "react";
+import { scrollToTopOnNav } from "@/lib/scroll-on-nav";
+
+/**
+ * Client-side wrapper around `next/link::Link` that auto-wires
+ * `scrollToTopOnNav(href)` on click (#3046).
+ *
+ * Use this anywhere a `<Link>` participates in cross-page navigation
+ * and should land the new page at scroll-top — Footer links, blog
+ * cross-links, banner CTAs, MDX mention pills/cards.
+ *
+ * Why a wrapper instead of sprinkling `onClick={() => scrollToTopOnNav(href)}`:
+ *
+ *  - Three of the four target surfaces in #3046 (`Footer`, `RelatedPosts`,
+ *    `MdxMentions`) are server components. RSC parents cannot serialise
+ *    inline event-handler closures into Client Components, so each call
+ *    site would otherwise need to flip its file to `"use client"` —
+ *    losing async data fetching (`await listBlogPosts()`,
+ *    `await cachedCompany(...)`).
+ *  - One thin client boundary per surface is cheaper than seven, both
+ *    in bundle size and in mental overhead.
+ *  - Header / MobileMenu stay on the sprinkle pattern (#3030, #3042)
+ *    because they are already `"use client"` and use `usePathname()` for
+ *    `aria-current`; converting them to NavLink would require either
+ *    forwarding the `aria-current` prop or wiring two components, which
+ *    is more code than the existing call sites.
+ *
+ * `href` is required as a string so we can pass it to `scrollToTopOnNav`.
+ * `next/link::Link` accepts `UrlObject` too, but every internal route in
+ * this app is rendered as a string template (see grep for `<Link href=`).
+ * Hash-anchor hrefs are auto-skipped inside `scrollToTopOnNav`.
+ */
+type NavLinkProps = Omit<ComponentProps<typeof Link>, "href" | "onClick"> & {
+  href: string;
+};
+
+export function NavLink({ href, ...rest }: NavLinkProps) {
+  return (
+    <Link
+      href={href}
+      onClick={() => scrollToTopOnNav(href)}
+      {...rest}
+    />
+  );
+}

--- a/apps/web/src/components/__tests__/NavLink.test.tsx
+++ b/apps/web/src/components/__tests__/NavLink.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { NavLink } from "../NavLink";
+
+// Stub `next/link` so React's renderer doesn't pull in router internals
+// (no App Router instrumentation in this unit test). The stub preserves
+// the `onClick` handler so we can assert the wired call. `prefetch` is
+// dropped — passing it to a plain `<a>` triggers a React warning about
+// non-boolean attributes.
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, onClick, children, prefetch: _prefetch, ...rest }: {
+    href: string;
+    onClick?: (e: React.MouseEvent) => void;
+    children: React.ReactNode;
+    prefetch?: boolean;
+  }) => (
+    <a href={href} onClick={onClick} {...rest}>{children}</a>
+  ),
+}));
+
+describe("NavLink (#3046)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls window.scrollTo on click for plain hrefs", () => {
+    const spy = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+    render(<NavLink href="/en/blog">Blog</NavLink>);
+    fireEvent.click(screen.getByText("Blog"));
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith({ top: 0, left: 0, behavior: "instant" });
+  });
+
+  it("skips window.scrollTo when href contains a hash anchor", () => {
+    const spy = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+    render(<NavLink href="/en/#features">Features</NavLink>);
+    fireEvent.click(screen.getByText("Features"));
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("forwards className and other Link props through", () => {
+    render(
+      <NavLink href="/en/license" className="link-class" prefetch={false}>
+        License
+      </NavLink>,
+    );
+    const anchor = screen.getByText("License") as HTMLAnchorElement;
+    expect(anchor.getAttribute("href")).toBe("/en/license");
+    expect(anchor.className).toContain("link-class");
+  });
+});

--- a/apps/web/src/components/blog/MdxMentions.tsx
+++ b/apps/web/src/components/blog/MdxMentions.tsx
@@ -33,9 +33,9 @@
  */
 
 import { cache } from "react";
-import Link from "next/link";
 import { Eye, Briefcase } from "lucide-react";
 import { CompanyIcon } from "@/components/CompanyIcon";
+import { NavLink } from "@/components/NavLink";
 import { loadCatalog, isLocale, defaultLocale, type Locale } from "@/lib/i18n";
 import { getCompanyBySlug } from "@/lib/actions/company";
 import {
@@ -80,7 +80,7 @@ function MentionPill({
   // inheritance. Without it, the prose `a` rule paints the whole pill
   // blue and underlines every word inside.
   return (
-    <Link
+    <NavLink
       href={href}
       className="mention inline-flex items-center gap-1.5 align-baseline rounded-md border border-border-soft bg-border-soft/40 px-2 py-0.5 text-[0.95em] transition-colors hover:bg-border-soft"
     >
@@ -89,7 +89,7 @@ function MentionPill({
       </span>
       <span className="font-medium">{label}</span>
       {meta && <span className="text-muted">{meta}</span>}
-    </Link>
+    </NavLink>
   );
 }
 
@@ -128,7 +128,7 @@ function MentionCard({
   // `app/globals.css` — undoes the post-body link underline + info-color
   // inheritance so the card's internal color/typography controls win.
   return (
-    <Link
+    <NavLink
       href={href}
       className="mention my-6 flex w-full flex-col gap-3 rounded-md border border-border-soft bg-border-soft/30 p-5 transition-colors hover:bg-border-soft"
     >
@@ -165,7 +165,7 @@ function MentionCard({
           ))}
         </ul>
       )}
-    </Link>
+    </NavLink>
   );
 }
 

--- a/apps/web/src/components/blog/RelatedPosts.tsx
+++ b/apps/web/src/components/blog/RelatedPosts.tsx
@@ -1,7 +1,7 @@
-import Link from "next/link";
 import { Trans } from "@lingui/react/macro";
 import { type Locale } from "@/lib/i18n";
 import { listBlogPosts, selectRelatedPosts, type BlogPostSummary } from "@/lib/blog";
+import { NavLink } from "@/components/NavLink";
 
 /**
  * "You may also be interested in" cross-link block (#2844). Renders
@@ -79,7 +79,7 @@ function RelatedPostCard({
   const firstTag = post.tags[0];
   const dateLabel = formatDate(post.datePublished, locale);
   return (
-    <Link
+    <NavLink
       href={`/${locale}/blog/${post.slug}`}
       className="mention flex h-full flex-col gap-2 rounded-md border border-border-soft bg-border-soft/30 p-4 transition-colors hover:bg-border-soft"
     >
@@ -98,6 +98,6 @@ function RelatedPostCard({
           </>
         )}
       </div>
-    </Link>
+    </NavLink>
   );
 }


### PR DESCRIPTION
## Summary

#3030 added `scrollToTopOnNav(href)` to defeat the brief "old-scroll flash" between URL flip and Next's built-in scroll-to-top on slow Cache Components routes; #3042 wired it on the public header. Other `<Link>` surfaces still inherited prior page scroll. This widens the fix to four call sites:

| Surface | File | Why it leaks scroll |
|---|---|---|
| Public footer (Blog / License / Privacy / Terms) | `apps/web/src/components/Footer.tsx:51-66` | RSC; the page-tail navigates from a deep-scrolled viewport |
| "You may also be interested in" cross-link | `apps/web/src/components/blog/RelatedPosts.tsx:82` | RSC; lives at post bottom, click always from large scrollY |
| Cookie banner "Details" → `/privacy-policy` | `apps/web/src/components/CookieBanner.tsx:55` | Already client; included for consistency |
| MDX mention pill + card | `apps/web/src/components/blog/MdxMentions.tsx:83,131` | RSC; embeds inside `compileMDX` post bodies |

## Pattern: `NavLink` wrapper

Introduces `apps/web/src/components/NavLink.tsx` — a thin `"use client"` wrapper around `next/link::Link` that auto-wires `onClick={() => scrollToTopOnNav(href)}`.

Decision rationale (sprinkle vs wrapper):

- **Three of the four target surfaces are RSC** (`Footer`, `RelatedPosts`, `MdxMentions`). RSC parents cannot serialise inline event-handler closures into Client Components. Sprinkling would force each file to flip to `"use client"`, losing `await listBlogPosts()`, `await cachedCompany(...)`, etc.
- One client boundary per surface (8 `<NavLink>` sites total) is cheaper in bundle output and clearer at call sites than seven near-identical inline closures.
- `Header.tsx` / `MobileMenu.tsx` stay on the sprinkle pattern from #3042 — they are already `"use client"` and rely on `usePathname()` for `aria-current`; converting them to `NavLink` would require forwarding `aria-current` or wiring two components for no net benefit.

API:

```tsx
type NavLinkProps = Omit<ComponentProps<typeof Link>, "href" | "onClick"> & { href: string };
```

`href` is narrowed to `string` (matches every internal-route call site in this app) so it can be passed straight to `scrollToTopOnNav`. The helper itself already skips hash-anchor hrefs.

## Empirical verification

Reproduce script: `/tmp/3046-reproduce.ts` (Playwright). Six target surfaces, each:

1. `page.goto(source)` and scroll to a Y > 0
2. `page.mouse.click(x, y)` at the link's bounding-box midpoint — **not** `locator.click()`, which auto-scrolls into view and would mask the bug (documented in #3063 critic findings)
3. Capture scrollY immediately after click + after navigation settles

Before fix (warm dev server, all destinations cached):

```
Footer→Privacy   immediately:0  after-nav:0  url:/en/privacy-policy
Footer→Terms     immediately:0  after-nav:0  url:/en/terms
Footer→Blog      immediately:0  after-nav:0  url:/en/blog
Footer→License   immediately:0  after-nav:0  url:/en/license
RelatedPosts     immediately:0  after-nav:0  url:/en/blog/remote-engineering-jobs-2026
MdxMention pill  immediately:1000  after-nav:0  url:/en/colophongroup/big-tech-jobs-in-switzerland
```

The MdxMention case is the visible reproduction — destination is a fresh, slug-driven watchlist page that the dev server has to compile + Typesense-query; for ~1s the URL is flipped but the user sees the old blog body at scrollY=1000.

After fix:

```
Footer→Privacy   immediately:0  after-nav:0
Footer→Terms     immediately:0  after-nav:0
Footer→Blog      immediately:0  after-nav:0
Footer→License   immediately:0  after-nav:0
RelatedPosts     immediately:0  after-nav:0
MdxMention pill  immediately:0  after-nav:0   <-- fixed
```

Screenshots: `/tmp/3046-screenshots/{before,after}-fix-*-{before-click,after-nav}.png` (28 PNGs total).

The other five surfaces happen to *also* land at scroll-top before the fix in this dev test — because all their destinations were pre-warmed and Next's built-in scroll fires within 1 RAF. Production with Cache Components streaming dynamic data is the bad case, exactly per #3030's prod measurements (`/about → /blog`: 1218ms of old-scroll-on-new-page). Applying the helper makes the behaviour deterministic across surfaces rather than dependent on per-target compile / cache state.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean (sole TS error in `app/mcp/route.ts` is the pre-existing missing `@jseek/mcp-server/dist/handler` — fixed locally by running `pnpm build` in `packages/mcp-server`)
- [x] `pnpm test` — 727 / 727 pass, including 3 new tests in `src/components/__tests__/NavLink.test.tsx` covering plain hrefs, hash-anchor skip, and prop forwarding
- [x] Playwright probe at 1280x800 viewport — all six surfaces land at scrollY=0
- [x] Six before-click / after-nav screenshot pairs saved under `/tmp/3046-screenshots/`
- [ ] Manual smoke once Vercel preview is up — verify the cookie-banner Details click in particular (Playwright probe excluded this surface; banner is conditional on `serverConsent` not being set)

## Tangentials (not in scope)

- `WatchlistCard` (`apps/web/src/components/watchlist/watchlist-card.tsx`) and `PublicWatchlistSearch` are deferred to #3064 per orchestrator brief.
- `(app)`-route content components (`explore-content.tsx`, `company-content.tsx`, `watchlist-content.tsx`) have their own `useEffect(() => window.scrollTo(0, 0))` pattern (called out in #3042's tangentials); deferred to #3061 / #3062 / #3064.
- The wrapper does not currently bundle `aria-current` — `Header` / `MobileMenu` keep their `usePathname()` + sprinkle pattern. If future call sites need both behaviours, `NavLink` can grow an `aria-current` derivation, but that's a larger surface change than this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)