### PR TITLE
fix(web): bump mobile header contrast against dark surfaces (closes #3044)

### DIFF
--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -33,7 +33,7 @@ export function Header({ onOpenMobileAction }: HeaderProps) {
   const appLabel = t({ id: "home.hero.primaryCta", comment: "Hero primary call-to-action", message: "Get started" });
 
   return (
-    <header className="border-b border-divider bg-surface-alpha backdrop-blur-md">
+    <header className="border-b border-divider bg-background/95 backdrop-blur-md">
       <div className="mx-auto flex h-12 max-w-[1200px] items-center gap-4 px-4">
         <Link
           href={lp("/")}


### PR DESCRIPTION
## Summary

The public-route header (`Header.tsx`, used on landing/blog/FAQ/about) used `bg-surface-alpha` (white@0.55 / black@0.5) + `backdrop-blur-md`. Where a **dark engraving or mid-grey photo** scrolls beneath the fixed header — landing hero art, the "Adam tills the soil" Holbein print on the about page, blog hero images — the translucent header composited over those pixels gave a noisy mid-grey backdrop, dropping logo + menu-icon contrast to ~7.9–9.0:1. Technically inside AA, but the busy texture bleeding through the blur made the fine-stroke `<job-seek>` SVG logo read as washed-out on mobile.

Switch the **public header only** to `bg-background/95` so it stays nearly opaque in the page-background tone (light `#f7f8fb`, dark `#09090b`) regardless of what scrolls beneath. Keeps `backdrop-blur-md` for the subtle frost feel; keeps the divider border.

Scoped on purpose: `AppHeader`, `back-to-top`, and the settings sub-header keep `bg-surface-alpha` since their layout context already gives them a flat backdrop and the bug report names only the public header.

## Contrast measurements (375px viewport, real pixel sampling)

The probe takes a screenshot of the viewport with the header hidden, reads the actual pixel under the header at five scroll positions (0 / 300 / 600 / 900 / 1200) across three x-positions (28 / 187 / 347), composites the header alpha + colour over that pixel, then computes WCAG contrast against the logo/menu colour.

| Route | Theme | Before | After | Worst-case beneath |
|---|---|---|---|---|
| `/en` | light | **9.04** | **15.55** | rgb(80,81,82) — hero art |
| `/en/blog` | light | 16.95 | 16.68 | — |
| `/en/faq` | light | 17.25 | 16.68 | — |
| `/en/about` | light | **9.45** | **15.69** | rgb(108,108,116) — Holbein print |
| `/en` | dark | **7.94** | **17.29** | rgb(149,149,150) — hero art highlight |
| `/en/blog` | dark | 18.21 | 18.10 | — |
| `/en/faq` | dark | 18.53 | 18.10 | — |
| `/en/about` | dark | **8.19** | **17.29** | rgb(145,145,146) — Holbein highlight |

All routes were inside AA both before and after, but **the four bolded rows are the cases the user is reporting**: the header sits over a strong dark/mid image and the translucent composite pushed perceived contrast into the visually-weak band. Post-fix, every cell sits comfortably above WCAG AA (4.5:1).

## Screenshots

Before / after pairs at the worst-case scroll positions in `/tmp/3044-screenshots/{before,after}/`:

- `landing-{light,dark}-y{0,300,900}-{before,after}.png`
- `about-{light,dark}-y{0,300,900}-{before,after}.png`
- `blog-{light,dark}-y{0,300,900}-{before,after}.png`
- `faq-{light,dark}-y{0,300,900}-{before,after}.png`

Plus aggregate metrics JSON at `/tmp/3044-screenshots/{before,after}/metrics.json`.

The most striking pair is **about-dark-y300** — before: header overlays the Holbein engraving and the white `<job-seek>` logo merges into the print texture; after: the header is solid near-black with the logo crisply separated from the engraving below.

## Files changed

- `apps/web/src/components/Header.tsx` — 1 line: `bg-surface-alpha` → `bg-background/95`

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm --filter @jobseek/web test` — 724/724 pass
- [x] Playwright screenshots captured on /, /blog, /faq, /about at 375px in light + dark themes
- [x] Real-pixel contrast probe at 5 scroll positions × 3 x-positions per (route, theme)
- [ ] Eyeball check on Vercel preview at iPhone-width

🤖 Generated with [Claude Code](https://claude.com/claude-code)