### PR TITLE
fix(web): use authoritative IP for rate-limit keys (closes #3219)

### DIFF
--- a/apps/web/app/api/auth/[...all]/route.ts
+++ b/apps/web/app/api/auth/[...all]/route.ts
@@ -1,13 +1,7 @@
 import { auth } from "@/lib/auth";
 import { toNextJsHandler } from "better-auth/next-js";
-import { authLimiter } from "@/lib/rate-limit";
+import { authLimiter, getClientIp } from "@/lib/rate-limit";
 import { type NextRequest, NextResponse } from "next/server";
-
-function getClientIp(request: NextRequest): string {
-  return (
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown"
-  );
-}
 
 const { GET: authGet, POST: authPost } = toNextJsHandler(auth);
 
@@ -27,7 +21,7 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const ip = getClientIp(request);
+    const ip = getClientIp(request.headers);
     const { success, reset } = await authLimiter.limit(ip);
     if (!success) return rateLimitResponse(reset);
   } catch {

--- a/apps/web/app/api/v1/_shared.ts
+++ b/apps/web/app/api/v1/_shared.ts
@@ -1,13 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { apiLimiter } from "@/lib/rate-limit";
+import { apiLimiter, getClientIp } from "@/lib/rate-limit";
 import { siteConfig } from "@/content/config";
-
-/** Extract client IP from request headers. */
-export function getClientIp(request: NextRequest): string {
-  return (
-    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown"
-  );
-}
 
 /** Rate-limit result to thread through to apiResponse(). */
 export type RateLimitInfo = { limit: number; remaining: number; reset: number };
@@ -16,7 +9,7 @@ export type RateLimitInfo = { limit: number; remaining: number; reset: number };
 export async function checkRateLimit(
   request: NextRequest,
 ): Promise<NextResponse | RateLimitInfo | null> {
-  const ip = getClientIp(request);
+  const ip = getClientIp(request.headers);
   try {
     const { success, limit, remaining, reset } = await apiLimiter.limit(ip);
     if (!success) {

--- a/apps/web/src/lib/__tests__/rate-limit.test.ts
+++ b/apps/web/src/lib/__tests__/rate-limit.test.ts
@@ -23,6 +23,10 @@ let mockLimitResult = {
   reset: Date.now() + 60000,
 };
 
+// Captures the identifier that was passed to `Ratelimit.limit()` so tests can
+// assert the rate-limit key, not just the response.
+const limitCalls: string[] = [];
+
 // Mock @upstash/ratelimit
 vi.mock("@upstash/ratelimit", () => {
   class MockRatelimit {
@@ -36,7 +40,8 @@ vi.mock("@upstash/ratelimit", () => {
       this.prefix = opts.prefix;
     }
 
-    async limit(_identifier: string) {
+    async limit(identifier: string) {
+      limitCalls.push(identifier);
       return { ...mockLimitResult };
     }
 
@@ -58,6 +63,7 @@ import {
   passwordResetLimiter,
   companyRequestLimiter,
   apiLimiter,
+  getClientIp,
 } from "../rate-limit";
 import { checkRateLimit } from "../../../app/api/v1/_shared";
 
@@ -65,6 +71,10 @@ function fakeRequest(ip = "1.2.3.4"): NextRequest {
   return new NextRequest("https://example.com/api/v1/test", {
     headers: { "x-forwarded-for": ip },
   });
+}
+
+function makeHeaders(init: Record<string, string>): Headers {
+  return new Headers(init);
 }
 
 describe("rate-limit exports", () => {
@@ -130,5 +140,119 @@ describe("checkRateLimit", () => {
     expect(headers.get("Retry-After")).toBeDefined();
     expect(headers.get("X-RateLimit-Limit")).toBe("30");
     expect(headers.get("X-RateLimit-Remaining")).toBe("0");
+  });
+});
+
+// Regression: see issue #3219. Vercel **appends** the real client IP to
+// `x-forwarded-for`, so the **first** entry is attacker-controlled. Using
+// the first entry as a rate-limit key let any caller bypass every limit
+// (e.g. password-stuffing on Better Auth, DoS on /api/v1/search) by varying
+// a single header on each request.
+describe("getClientIp (issue #3219 — x-forwarded-for spoofing)", () => {
+  it("prefers x-real-ip over x-forwarded-for", () => {
+    const h = makeHeaders({
+      "x-forwarded-for": "1.2.3.4, 10.0.0.1, 203.0.113.7",
+      "x-real-ip": "203.0.113.7",
+    });
+    expect(getClientIp(h)).toBe("203.0.113.7");
+  });
+
+  it("returns the LAST entry of x-forwarded-for (Vercel's appended IP), not the first", () => {
+    // First entry "9.9.9.9" is what a malicious client would supply; the
+    // rest is what Vercel appends.
+    const h = makeHeaders({
+      "x-forwarded-for": "9.9.9.9, 10.0.0.1, 203.0.113.7",
+    });
+    const ip = getClientIp(h);
+    expect(ip).toBe("203.0.113.7");
+    expect(ip).not.toBe("9.9.9.9");
+  });
+
+  it("does NOT trust a spoofed first entry even when only one extra hop exists", () => {
+    const h = makeHeaders({
+      "x-forwarded-for": "evil.spoofed.ip, 203.0.113.7",
+    });
+    expect(getClientIp(h)).toBe("203.0.113.7");
+  });
+
+  it("falls back to 'unknown' when no IP headers are present", () => {
+    expect(getClientIp(makeHeaders({}))).toBe("unknown");
+  });
+
+  it("handles a single-entry x-forwarded-for (no comma)", () => {
+    expect(getClientIp(makeHeaders({ "x-forwarded-for": "203.0.113.7" }))).toBe(
+      "203.0.113.7",
+    );
+  });
+
+  it("trims whitespace and skips trailing empty tokens", () => {
+    expect(
+      getClientIp(makeHeaders({ "x-forwarded-for": "9.9.9.9, 203.0.113.7,  " })),
+    ).toBe("203.0.113.7");
+  });
+
+  it("handles IPv6 addresses in the last position", () => {
+    expect(
+      getClientIp(
+        makeHeaders({ "x-forwarded-for": "9.9.9.9, 2001:db8::1" }),
+      ),
+    ).toBe("2001:db8::1");
+  });
+});
+
+// Regression: assert that the rate-limit key actually passed into
+// `Ratelimit.limit()` is the authoritative IP, not the attacker-controlled
+// first entry of `x-forwarded-for`. This is the surface that issue #3219
+// exploits — even if `getClientIp()` is correct in isolation, the call
+// site must call it correctly.
+describe("checkRateLimit identifier (issue #3219)", () => {
+  beforeEach(() => {
+    limitCalls.length = 0;
+    mockLimitResult = {
+      success: true,
+      limit: 30,
+      remaining: 29,
+      reset: Date.now() + 60000,
+    };
+  });
+
+  it("keys the API rate limit by Vercel's appended IP, not the spoofed first entry", async () => {
+    const spoofed = "9.9.9.9";
+    const real = "203.0.113.7";
+    const req = new NextRequest("https://example.com/api/v1/test", {
+      headers: { "x-forwarded-for": `${spoofed}, ${real}` },
+    });
+
+    await checkRateLimit(req);
+
+    expect(limitCalls).toHaveLength(1);
+    expect(limitCalls[0]).toBe(real);
+    expect(limitCalls[0]).not.toBe(spoofed);
+  });
+
+  it("prefers x-real-ip even when x-forwarded-for is present", async () => {
+    const req = new NextRequest("https://example.com/api/v1/test", {
+      headers: {
+        "x-forwarded-for": "9.9.9.9, 10.0.0.1",
+        "x-real-ip": "203.0.113.7",
+      },
+    });
+
+    await checkRateLimit(req);
+
+    expect(limitCalls).toHaveLength(1);
+    expect(limitCalls[0]).toBe("203.0.113.7");
+  });
+
+  it("buckets repeated requests with different spoofed first entries under the same real IP", async () => {
+    const real = "203.0.113.7";
+    for (const spoofed of ["1.1.1.1", "2.2.2.2", "3.3.3.3"]) {
+      const req = new NextRequest("https://example.com/api/v1/test", {
+        headers: { "x-forwarded-for": `${spoofed}, ${real}` },
+      });
+      await checkRateLimit(req);
+    }
+
+    expect(limitCalls).toEqual([real, real, real]);
   });
 });

--- a/apps/web/src/lib/rate-limit.ts
+++ b/apps/web/src/lib/rate-limit.ts
@@ -2,6 +2,38 @@ import "server-only";
 import { Ratelimit } from "@upstash/ratelimit";
 import { redis } from "@/lib/redis";
 
+/**
+ * Extract the platform-authoritative client IP from request headers.
+ *
+ * Threat model: `x-forwarded-for` is a list that any upstream hop (including
+ * the client) can prepend to. Vercel **appends** the real client IP as the
+ * last entry, so the **first** entry is attacker-controlled. Using the first
+ * entry as a rate-limit key lets an attacker bypass every limit by sending
+ * `X-Forwarded-For: <random-ip>` on each request.
+ *
+ * Preference order:
+ *   1. `x-real-ip` — Vercel sets this to a single platform-authoritative IP.
+ *   2. Last non-empty entry of `x-forwarded-for` — the entry Vercel appended.
+ *   3. `"unknown"` — degrade closed: all unidentified callers share a key.
+ *
+ * Reference: https://vercel.com/docs/edge-network/headers/request-headers
+ */
+export function getClientIp(headers: Headers): string {
+  const real = headers.get("x-real-ip")?.trim();
+  if (real) return real;
+  const xff = headers.get("x-forwarded-for");
+  if (xff) {
+    // Walk from the right; skip empty/whitespace tokens to be tolerant of
+    // malformed headers (e.g. trailing commas).
+    const parts = xff.split(",");
+    for (let i = parts.length - 1; i >= 0; i--) {
+      const candidate = parts[i]?.trim();
+      if (candidate) return candidate;
+    }
+  }
+  return "unknown";
+}
+
 /** Auth endpoints: 10 requests per 60 seconds per IP. */
 export const authLimiter = new Ratelimit({
   redis,


### PR DESCRIPTION
## Summary

Closes #3219. Rate-limit keys for **both** IP-keyed surfaces were derived from the **first** entry of `x-forwarded-for`. That entry is client-controlled — Vercel **appends** the real client IP to `x-forwarded-for`, it does not replace the header. The bug let any caller bypass every IP-keyed limit by varying a single HTTP header per request.

## Threat model

| Surface | Limit | Exploit before fix |
|---|---|---|
| `POST /api/auth/*` (Better Auth catch-all) | 10 req / 60 s / IP | Password-stuffing: send `X-Forwarded-For: <rand>` per attempt -> unlimited credential checks |
| `GET /api/v1/*` (`checkRateLimit` in `_shared.ts`) | 30 req / 60 s / IP | DoS on `/api/v1/search` etc. -> unlimited request rate |

Spec compliance: per [Vercel docs](https://vercel.com/docs/edge-network/headers/request-headers), Vercel appends to `x-forwarded-for` (last entry = platform-authoritative) and also sets `x-real-ip` to a single authoritative value.

## Fix

New shared `getClientIp(headers: Headers)` in `apps/web/src/lib/rate-limit.ts`. Preference order:
1. `x-real-ip` (Vercel single authoritative IP)
2. **Last** non-empty entry of `x-forwarded-for` (Vercel's appended IP — tolerant of empty/whitespace tokens and trailing commas)
3. `"unknown"` (fail-closed: all unidentified callers share one bucket)

Both call sites now consume the shared helper. Removed the duplicate buggy implementation from each.

## Regression tests

`apps/web/src/lib/__tests__/rate-limit.test.ts` adds **10 new tests** across two suites:

**`getClientIp` (unit):**
- prefers `x-real-ip` over `x-forwarded-for`
- returns the LAST entry of `x-forwarded-for`, not the first (3-hop case)
- does NOT trust a spoofed first entry with only one extra hop (2-hop case — the realistic Vercel shape)
- falls back to `"unknown"` when no IP headers are present
- handles a single-entry `x-forwarded-for` (no comma)
- trims whitespace and skips trailing empty tokens
- handles IPv6 addresses in the last position

**`checkRateLimit` identifier (end-to-end):**
- keys the API rate limit by Vercel's appended IP, not the spoofed first entry
- prefers `x-real-ip` even when `x-forwarded-for` is present
- buckets repeated requests with different spoofed first entries under the same real IP (the core threat-model test)

The mock `Ratelimit.limit()` now records every identifier it receives, so tests assert on the actual rate-limit key, not just the response shape.

**Failing-on-main verification:** I temporarily restored the old `headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown"` implementation and re-ran the suite — 8 of the 10 new tests fail, including all 3 `checkRateLimit identifier` tests. The 2 that pass are the degenerate cases (single-entry XFF and no-headers fallback), which are the same on either implementation.

## Test plan

- [x] `pnpm vitest run src/lib/__tests__/rate-limit.test.ts` -> 17/17 pass with fix; 9/17 pass with reverted helper (8 new tests fail as expected)
- [x] `pnpm test` (full suite) -> 83 files, 764 tests, all pass
- [x] `pnpm exec tsc --noEmit` -> exit 0
- [x] `pnpm exec eslint` on changed files -> clean
- [ ] Manual smoke after deploy: hit `/api/v1/search` with `X-Forwarded-For: 1.1.1.1` from a single source, verify Upstash bucket grows on the real source IP, not on the spoofed value

🤖 Generated with [Claude Code](https://claude.com/claude-code)