### PR TITLE
refactor(web): name TTL constants in cache layer (closes #3072)

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
 import { isLocale, defaultLocale, loadCatalog, ogLocale, ogAlternateLocales } from "@/lib/i18n";
 import { watchlistCacheTag } from "@/lib/cache-tags";
+import { CACHE_TTL_LONG } from "@/lib/cache-ttl";
 import {
   getPublicWatchlistByUserAndSlug,
   getWatchlistMatchingCompanyCount,
@@ -28,7 +29,7 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   "use cache";
-  cacheLife({ revalidate: 3600 });
+  cacheLife({ revalidate: CACHE_TTL_LONG });
   const { userSlug, watchlistSlug, lang } = await params;
   cacheTag(watchlistCacheTag(userSlug, watchlistSlug));
   const locale = isLocale(lang) ? lang : defaultLocale;
@@ -140,7 +141,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function WatchlistRoute({ params }: Props) {
   "use cache";
-  cacheLife({ revalidate: 3600 });
+  cacheLife({ revalidate: CACHE_TTL_LONG });
   const { lang, userSlug, watchlistSlug } = await params;
   cacheTag(watchlistCacheTag(userSlug, watchlistSlug));
   const locale = isLocale(lang) ? lang : defaultLocale;

--- a/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { cacheLife, cacheTag } from "next/cache";
 import { isLocale, defaultLocale, loadCatalog, initI18nForPage, ogLocale, ogAlternateLocales } from "@/lib/i18n";
 import { companyCacheTag } from "@/lib/cache-tags";
+import { CACHE_TTL_DETAIL } from "@/lib/cache-ttl";
 import { getCompanyBySlug } from "@/lib/actions/company";
 import { siteConfig } from "@/content/config";
 import { buildAlternates } from "@/lib/seo";
@@ -15,7 +16,7 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   "use cache";
-  cacheLife({ revalidate: 600 });
+  cacheLife({ revalidate: CACHE_TTL_DETAIL });
   const { slug, lang } = await params;
   cacheTag(companyCacheTag(slug));
   const locale = isLocale(lang) ? lang : defaultLocale;
@@ -104,7 +105,7 @@ async function CompanyNotFound() {
 
 export default async function CompanyPageRoute({ params }: Props) {
   "use cache";
-  cacheLife({ revalidate: 600 });
+  cacheLife({ revalidate: CACHE_TTL_DETAIL });
   const locale = await initI18nForPage(params);
   const { slug } = await params;
   cacheTag(companyCacheTag(slug));

--- a/apps/web/app/[lang]/(app)/explore/page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
 import { isLocale, defaultLocale, loadCatalog, ogLocale, ogAlternateLocales } from "@/lib/i18n";
+import { CACHE_TTL_SHORT } from "@/lib/cache-ttl";
 import { siteConfig } from "@/content/config";
 import { buildAlternates } from "@/lib/seo";
 import { fetchExploreDefaults } from "@/lib/actions/explore-data";
@@ -23,7 +24,7 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   "use cache";
-  cacheLife({ revalidate: 60 });
+  cacheLife({ revalidate: CACHE_TTL_SHORT });
   const { lang } = await params;
   const locale = isLocale(lang) ? lang : defaultLocale;
   const { i18n } = await loadCatalog(locale);
@@ -52,7 +53,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function AppPage({ params }: Props) {
   "use cache";
-  cacheLife({ revalidate: 60 });
+  cacheLife({ revalidate: CACHE_TTL_SHORT });
   const { lang } = await params;
   const locale = isLocale(lang) ? lang : defaultLocale;
   const initialData = await fetchExploreDefaults({ locale });

--- a/apps/web/app/[lang]/(public)/blog/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(public)/blog/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { cacheLife, cacheTag } from "next/cache";
 import { getI18n } from "@lingui/react/server";
 import { initI18nForPage, isLocale, defaultLocale, ogLocale } from "@/lib/i18n";
 import { blogPostCacheTag } from "@/lib/cache-tags";
+import { CACHE_TTL_DAY } from "@/lib/cache-ttl";
 import { siteConfig } from "@/content/config";
 import { buildAlternates, JsonLd } from "@/lib/seo";
 import {
@@ -40,7 +41,7 @@ export async function generateStaticParams(): Promise<{ lang: string; slug: stri
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   "use cache";
-  cacheLife({ revalidate: 86400 });
+  cacheLife({ revalidate: CACHE_TTL_DAY });
   const { lang, slug } = await params;
   cacheTag(blogPostCacheTag(slug));
   const locale = isLocale(lang) ? lang : defaultLocale;
@@ -124,7 +125,7 @@ function formatDate(iso: string, locale: string): string {
 
 export default async function BlogPostPage({ params }: Props) {
   "use cache";
-  cacheLife({ revalidate: 86400 });
+  cacheLife({ revalidate: CACHE_TTL_DAY });
   const locale = await initI18nForPage(params);
   const i18n = getI18n()!;
   const { slug } = await params;

--- a/apps/web/app/[lang]/(public)/blog/page.tsx
+++ b/apps/web/app/[lang]/(public)/blog/page.tsx
@@ -4,6 +4,7 @@ import { cacheLife, cacheTag } from "next/cache";
 import { getI18n } from "@lingui/react/server";
 import { initI18nForPage, isLocale, defaultLocale, loadCatalog, ogLocale, ogAlternateLocales } from "@/lib/i18n";
 import { blogIndexCacheTag } from "@/lib/cache-tags";
+import { CACHE_TTL_DAY } from "@/lib/cache-ttl";
 import { siteConfig } from "@/content/config";
 import { buildAlternates } from "@/lib/seo";
 import { listBlogPosts } from "@/lib/blog";
@@ -18,7 +19,7 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   "use cache";
-  cacheLife({ revalidate: 86400 });
+  cacheLife({ revalidate: CACHE_TTL_DAY });
   cacheTag(blogIndexCacheTag());
   const { lang } = await params;
   const locale = isLocale(lang) ? lang : defaultLocale;
@@ -65,7 +66,7 @@ function formatDate(iso: string, locale: string): string {
 
 export default async function BlogIndexPage({ params }: Props) {
   "use cache";
-  cacheLife({ revalidate: 86400 });
+  cacheLife({ revalidate: CACHE_TTL_DAY });
   cacheTag(blogIndexCacheTag());
   const locale = await initI18nForPage(params);
   const i18n = getI18n()!;

--- a/apps/web/app/api/v1/_shared.ts
+++ b/apps/web/app/api/v1/_shared.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { apiLimiter, getClientIp } from "@/lib/rate-limit";
+import { CACHE_TTL_MEDIUM } from "@/lib/cache-ttl";
 import { siteConfig } from "@/content/config";
 
 /** Rate-limit result to thread through to apiResponse(). */
@@ -40,7 +41,7 @@ export function apiResponse(
   data: unknown,
   options?: { maxAge?: number; rateLimit?: RateLimitInfo | null },
 ): NextResponse {
-  const maxAge = options?.maxAge ?? 300;
+  const maxAge = options?.maxAge ?? CACHE_TTL_MEDIUM;
   const headers: Record<string, string> = {
     "Cache-Control": `public, max-age=${maxAge}, s-maxage=${maxAge}`,
     "Access-Control-Allow-Origin": "*",

--- a/apps/web/app/api/v1/companies/route.ts
+++ b/apps/web/app/api/v1/companies/route.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { suggestCompanies } from "@/lib/actions/company";
+import { CACHE_TTL_LONG } from "@/lib/cache-ttl";
 import { checkRateLimit, apiResponse, siteUrl } from "../_shared";
 
 const MAX_RESULTS = 10;
@@ -31,5 +32,5 @@ export async function GET(request: NextRequest) {
   // Autocomplete suggestions are very stable (a single new company per few
   // days, slug shape never changes). Bumped from the 300s default to 1h
   // for higher CDN reuse on common queries — see issue #2644.
-  return apiResponse({ companies }, { maxAge: 3600, rateLimit: rl });
+  return apiResponse({ companies }, { maxAge: CACHE_TTL_LONG, rateLimit: rl });
 }

--- a/apps/web/app/api/v1/resolve/route.ts
+++ b/apps/web/app/api/v1/resolve/route.ts
@@ -6,6 +6,7 @@ import {
   suggestTechnologies,
 } from "@/lib/actions/taxonomy";
 import { suggestIndustries } from "@/lib/actions/company";
+import { CACHE_TTL_LONG } from "@/lib/cache-ttl";
 import { checkRateLimit, apiResponse } from "../_shared";
 
 const VALID_TYPES = [
@@ -86,6 +87,6 @@ export async function GET(request: NextRequest) {
       query: q,
       matches: matches.slice(0, 10),
     },
-    { maxAge: 3600, rateLimit: rl },
+    { maxAge: CACHE_TTL_LONG, rateLimit: rl },
   );
 }

--- a/apps/web/app/api/v1/taxonomies/route.ts
+++ b/apps/web/app/api/v1/taxonomies/route.ts
@@ -5,6 +5,7 @@ import {
   getAllTechnologiesGrouped,
 } from "@/lib/actions/taxonomy";
 import { suggestIndustries } from "@/lib/actions/company";
+import { CACHE_TTL_LONG } from "@/lib/cache-ttl";
 import { checkRateLimit, apiResponse } from "../_shared";
 
 const VALID_TYPES = ["seniority", "occupations", "technologies", "industries"] as const;
@@ -49,5 +50,5 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  return apiResponse({ type, items }, { maxAge: 3600, rateLimit: rl });
+  return apiResponse({ type, items }, { maxAge: CACHE_TTL_LONG, rateLimit: rl });
 }

--- a/apps/web/src/lib/actions/company.ts
+++ b/apps/web/src/lib/actions/company.ts
@@ -3,6 +3,7 @@
 import { sql } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 import { db } from "@/db";
+import { CACHE_TTL_MEDIUM, CACHE_TTL_LONG } from "@/lib/cache-ttl";
 import { withDbRetry } from "@/lib/db-retry";
 import { getSearchProvider } from "@/lib/search";
 import type { SearchResultPosting, WorkMode } from "@/lib/search";
@@ -50,7 +51,7 @@ async function _queryCompanySuggestionsCached(
   q: string,
 ): Promise<CompanySuggestion[]> {
   "use cache";
-  cacheLife({ revalidate: 3600 });
+  cacheLife({ revalidate: CACHE_TTL_LONG });
   // Tag the slot so `revalidateTag(typeaheadCompaniesCacheTag())` from
   // /api/internal/invalidate-typeahead drops it after `crawler sync`,
   // instead of waiting up to 3600s for the TTL. See #2907 follow-up.
@@ -910,7 +911,7 @@ async function _fetchSimilarUnfilteredCached(
   limit: number,
 ): Promise<SimilarCompaniesPage> {
   "use cache";
-  cacheLife({ revalidate: 3600 });
+  cacheLife({ revalidate: CACHE_TTL_LONG });
   cacheTag(companyByIdCacheTag(companyId));
   cacheTag(companyCsvDataCacheTag());
   return _fetchSimilarUnfiltered(companyId, industryId, offset, limit);
@@ -1234,7 +1235,7 @@ async function _fetchCompanyPostingsCached(
   params: NormalizedCompanyPostingsParams,
 ): Promise<{ postings: SearchResultPosting[]; activeCount: number; yearCount: number }> {
   "use cache";
-  cacheLife({ revalidate: 300 });
+  cacheLife({ revalidate: CACHE_TTL_MEDIUM });
   cacheTag(companyByIdCacheTag(params.companyId));
 
   // Re-shape to the SearchProvider param contract. Drop the cache-only

--- a/apps/web/src/lib/actions/locations.ts
+++ b/apps/web/src/lib/actions/locations.ts
@@ -4,6 +4,7 @@ import { sql } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 import { db } from "@/db";
 import { cached } from "@/lib/cache";
+import { CACHE_TTL_LONG } from "@/lib/cache-ttl";
 import { withDbRetry } from "@/lib/db-retry";
 import { typeaheadLocationsCacheTag } from "@/lib/cache-tags";
 import { getTypesenseClient, type TypesenseHit } from "@/lib/search/typesense-client";
@@ -89,7 +90,7 @@ async function _fetchLocationSuggestionsCached(
   bucketedLng: number | null,
 ): Promise<LocationSuggestion[]> {
   "use cache";
-  cacheLife({ revalidate: 3600 });
+  cacheLife({ revalidate: CACHE_TTL_LONG });
   // Tag the slot so `revalidateTag(typeaheadLocationsCacheTag())` from
   // /api/internal/invalidate-typeahead drops it after `crawler sync`,
   // instead of waiting up to 3600s for the TTL. See #2907 follow-up.
@@ -336,7 +337,7 @@ export async function getGlobalLocationsGrouped(
   // otherwise be deserialized into the new wrapper object via the
   // run-time JSON path, then fail to render the macro tier.
   const key = `global-locs-grouped-v3:${locale}:${fKey}`;
-  return cached(key, () => _fetchGlobalLocationsGrouped(locale, filters), { ttl: 3600 });
+  return cached(key, () => _fetchGlobalLocationsGrouped(locale, filters), { ttl: CACHE_TTL_LONG });
 }
 
 // ── Paged variant for fast modal TTFB (#2982) ─────────────────────────

--- a/apps/web/src/lib/actions/search.ts
+++ b/apps/web/src/lib/actions/search.ts
@@ -6,6 +6,7 @@ import { db } from "@/db";
 import { getSearchProvider } from "@/lib/search";
 import type { SearchResponse, SearchResultPosting, HistogramFilters, WorkMode } from "@/lib/search";
 import { cached } from "@/lib/cache";
+import { CACHE_TTL_SHORT, CACHE_TTL_MEDIUM } from "@/lib/cache-ttl";
 import { withDbRetry } from "@/lib/db-retry";
 import { getSessionUserId } from "@/lib/sessionCache";
 import { ANON_MAX_COMPANIES, ANON_MAX_CARD_POSTINGS } from "@/lib/search/constants";
@@ -121,7 +122,7 @@ async function _fetchPostingDetail(
   locale: string,
 ): Promise<PostingDetail | null> {
   "use cache";
-  cacheLife({ revalidate: 300 });
+  cacheLife({ revalidate: CACHE_TTL_MEDIUM });
   const rows = await withDbRetry(
     () =>
       db.execute<{
@@ -314,7 +315,7 @@ async function _listTopCompaniesImpl(
     result = await cached(
       `top-companies:${params.locale}:${langKey}:${params.offset}:${params.limit}`,
       fetch,
-      { ttl: 60, skipIf: (r: SearchResponse) => !!r.degraded },
+      { ttl: CACHE_TTL_SHORT, skipIf: (r: SearchResponse) => !!r.degraded },
     );
   } else {
     result = await fetch();

--- a/apps/web/src/lib/actions/taxonomy.ts
+++ b/apps/web/src/lib/actions/taxonomy.ts
@@ -4,6 +4,7 @@ import { sql } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 import { db } from "@/db";
 import { cached } from "@/lib/cache";
+import { CACHE_TTL_LONG } from "@/lib/cache-ttl";
 import { withDbRetry } from "@/lib/db-retry";
 import {
   typeaheadOccupationsCacheTag,
@@ -64,7 +65,7 @@ async function _fetchOccupationSuggestionsCached(
   locale: string,
 ): Promise<TaxonomySuggestion[]> {
   "use cache";
-  cacheLife({ revalidate: 3600 });
+  cacheLife({ revalidate: CACHE_TTL_LONG });
   // Tag the slot so `revalidateTag(typeaheadOccupationsCacheTag())` from
   // /api/internal/invalidate-typeahead drops it after `crawler sync`,
   // instead of waiting up to 3600s for the TTL. See #2907 follow-up.
@@ -164,7 +165,7 @@ async function _fetchSenioritySuggestionsCached(
   locale: string,
 ): Promise<TaxonomySuggestion[]> {
   "use cache";
-  cacheLife({ revalidate: 3600 });
+  cacheLife({ revalidate: CACHE_TTL_LONG });
   // Tag the slot so `revalidateTag(typeaheadSenioritiesCacheTag())` from
   // /api/internal/invalidate-typeahead drops it after `crawler sync`,
   // instead of waiting up to 3600s for the TTL. See #2907 follow-up.
@@ -267,7 +268,7 @@ async function _fetchTechnologySuggestionsCached(
   q: string,
 ): Promise<TaxonomySuggestion[]> {
   "use cache";
-  cacheLife({ revalidate: 3600 });
+  cacheLife({ revalidate: CACHE_TTL_LONG });
   // Tag the slot so `revalidateTag(typeaheadTechnologiesCacheTag())` from
   // /api/internal/invalidate-typeahead drops it after `crawler sync`,
   // instead of waiting up to 3600s for the TTL. See #2907 follow-up.
@@ -518,7 +519,7 @@ export async function getAllOccupationsGrouped(
 ): Promise<OccupationGroup[]> {
   const fKey = filters ? JSON.stringify(filters) : "";
   const key = `occ-all-grouped:${locale}:${fKey}`;
-  return cached(key, () => _fetchAllOccupationsGrouped(locale, filters), { ttl: 3600 });
+  return cached(key, () => _fetchAllOccupationsGrouped(locale, filters), { ttl: CACHE_TTL_LONG });
 }
 
 // ── Occupation hierarchy cache ───────────────────────────────────────
@@ -863,7 +864,7 @@ export async function getAllSeniorities(
 ): Promise<SeniorityOption[]> {
   const fKey = filters ? JSON.stringify(filters) : "";
   const key = `sen-all:${locale}:${fKey}`;
-  return cached(key, () => _fetchAllSeniorities(locale, filters), { ttl: 3600 });
+  return cached(key, () => _fetchAllSeniorities(locale, filters), { ttl: CACHE_TTL_LONG });
 }
 
 // ── Seniority metadata cache ─────────────────────────────────────────
@@ -993,7 +994,7 @@ export async function getAllTechnologiesGrouped(
 ): Promise<TechnologyGroup[]> {
   const fKey = filters ? JSON.stringify(filters) : "";
   const key = `tech-all-grouped:${fKey}`;
-  return cached(key, () => _fetchAllTechnologiesGrouped(filters), { ttl: 3600 });
+  return cached(key, () => _fetchAllTechnologiesGrouped(filters), { ttl: CACHE_TTL_LONG });
 }
 
 // ── Technology metadata cache ────────────────────────────────────────
@@ -1127,7 +1128,7 @@ export async function getEmploymentTypeCounts(
 ): Promise<Record<string, number>> {
   const fKey = filters ? JSON.stringify(filters) : "";
   const key = `emp-type-counts:${fKey}`;
-  return cached(key, () => _fetchEmploymentTypeCounts(filters), { ttl: 3600 });
+  return cached(key, () => _fetchEmploymentTypeCounts(filters), { ttl: CACHE_TTL_LONG });
 }
 
 async function _fetchEmploymentTypeCounts(
@@ -1170,7 +1171,7 @@ export async function getWorkModeCounts(
 ): Promise<Record<string, number>> {
   const fKey = filters ? JSON.stringify(filters) : "";
   const key = `work-mode-counts:${fKey}`;
-  return cached(key, () => _fetchWorkModeCounts(filters), { ttl: 3600 });
+  return cached(key, () => _fetchWorkModeCounts(filters), { ttl: CACHE_TTL_LONG });
 }
 
 async function _fetchWorkModeCounts(

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -12,6 +12,12 @@ import {
 import { getSessionUserId } from "@/lib/sessionCache";
 import { getViewerLanguages } from "@/lib/viewer";
 import { cached, invalidate } from "@/lib/cache";
+import {
+  CACHE_TTL_SHORT,
+  CACHE_TTL_POPULAR,
+  CACHE_TTL_MEDIUM,
+  CACHE_TTL_LONG,
+} from "@/lib/cache-ttl";
 import { withDbRetry } from "@/lib/db-retry";
 import { watchlistCacheTag } from "@/lib/cache-tags";
 import { canCreateWatchlist, getUserPlan, PLAN_LIMITS } from "@/lib/plans";
@@ -731,7 +737,7 @@ export async function getPublicWatchlistByUserAndSlug(
   return cached(
     `public-watchlist:${userSlug}:${watchlistSlug}`,
     () => _fetchPublicWatchlistByUserAndSlug(userSlug, watchlistSlug),
-    { ttl: 60, skipIf: (r) => r === null },
+    { ttl: CACHE_TTL_SHORT, skipIf: (r) => r === null },
   );
 }
 
@@ -911,7 +917,7 @@ export async function getWatchlistMatchingCompanyCount(
     // Aligned to the watchlist-detail ISR window (1h, see page.tsx). Bumped
     // from 600s with #2648 — metadata freshness from a viewer's perspective
     // comes from the client-hydrated body, not the cached count.
-  }, { ttl: 3600 });
+  }, { ttl: CACHE_TTL_LONG });
 }
 
 async function resolveFilteredJobCount(
@@ -952,7 +958,7 @@ async function resolveFilteredJobCount(
       languages,
     });
     return total;
-  }, { ttl: 300 });
+  }, { ttl: CACHE_TTL_MEDIUM });
 }
 
 async function queryPublicWatchlists(params: {
@@ -1070,7 +1076,7 @@ export async function searchPublicWatchlists(params: {
         languages,
       });
     },
-    { ttl: 60 },
+    { ttl: CACHE_TTL_SHORT },
   );
 }
 
@@ -1105,7 +1111,7 @@ export async function getPopularWatchlists(params: {
         languages,
       });
     },
-    { ttl: 120 },
+    { ttl: CACHE_TTL_POPULAR },
   );
 }
 

--- a/apps/web/src/lib/cache-ttl.ts
+++ b/apps/web/src/lib/cache-ttl.ts
@@ -1,0 +1,50 @@
+/**
+ * Named TTL constants for the cache layer (seconds).
+ *
+ * Centralises the magic numbers previously scattered across `'use cache'`
+ * + `cacheLife({ revalidate: N })`, Redis `cached(..., { ttl: N })`, and
+ * API-route `apiResponse({ maxAge: N })` call sites. Changing a tier here
+ * propagates to every consumer instead of hunting individual literals.
+ *
+ * Buckets reflect the values already in use across `apps/web/`:
+ *
+ * | Constant            | Seconds | Use cases                                    |
+ * |---------------------|---------|----------------------------------------------|
+ * | `CACHE_TTL_SHORT`   |   60    | Fast-moving lists (explore homepage,         |
+ * |                     |         | search degraded responses, public watchlist  |
+ * |                     |         | detail, new public watchlists search)        |
+ * | `CACHE_TTL_POPULAR` |  120    | Popular watchlists list (curated, slower-    |
+ * |                     |         | churn than freshly-created public lists)     |
+ * | `CACHE_TTL_MEDIUM`  |  300    | Moderate churn (posting detail, company      |
+ * |                     |         | postings, filtered watchlist counts,         |
+ * |                     |         | default API `maxAge`)                        |
+ * | `CACHE_TTL_DETAIL`  |  600    | Company detail page                          |
+ * | `CACHE_TTL_LONG`    | 3600    | Semi-static taxonomies, locations, similar   |
+ * |                     |         | companies, sitemap, watchlist matching count |
+ * | `CACHE_TTL_DAY`     |86400    | Very static / rare-change (blog pages)       |
+ *
+ * Notes:
+ * - Built-in Next.js `cacheLife()` profile names (`'hours'`, `'days'`,
+ *   `'minutes'`) are already named and remain in place — these constants
+ *   only replace numeric literals.
+ * - `cache.test.ts` keeps literal `60` / `120` values because those are
+ *   arbitrary fixtures for exercising the cache module, not policy.
+ */
+
+/** 60 seconds — fast-moving lists (explore, degraded search, new watchlists). */
+export const CACHE_TTL_SHORT = 60;
+
+/** 120 seconds — popular watchlists (curated, slower churn). */
+export const CACHE_TTL_POPULAR = 120;
+
+/** 300 seconds (5 min) — moderate churn (posting detail, company postings, default API). */
+export const CACHE_TTL_MEDIUM = 300;
+
+/** 600 seconds (10 min) — company detail page (cross-`'use cache'`-boundary dedup). */
+export const CACHE_TTL_DETAIL = 600;
+
+/** 3600 seconds (1 hour) — semi-static taxonomies, locations, sitemap, similar companies. */
+export const CACHE_TTL_LONG = 3600;
+
+/** 86400 seconds (1 day) — very static / rare-change (blog pages). */
+export const CACHE_TTL_DAY = 86400;

--- a/apps/web/src/lib/sitemap.ts
+++ b/apps/web/src/lib/sitemap.ts
@@ -2,6 +2,7 @@ import type { MetadataRoute } from "next";
 import { sql } from "drizzle-orm";
 import { db } from "@/db";
 import { cached } from "@/lib/cache";
+import { CACHE_TTL_LONG } from "@/lib/cache-ttl";
 import { withDbRetry } from "@/lib/db-retry";
 import { siteConfig } from "@/content/config";
 import { locales } from "@/lib/i18n";
@@ -23,7 +24,7 @@ import { listBlogPosts, getBlogPostLocales, type BlogPostSummary } from "@/lib/b
  */
 
 /** ISR window for cached watchlist data. */
-export const SITEMAP_TTL_SECONDS = 3600;
+export const SITEMAP_TTL_SECONDS = CACHE_TTL_LONG;
 
 const CURATED_USERNAME = "colophongroup";
 


### PR DESCRIPTION
## Summary

- Introduce `apps/web/src/lib/cache-ttl.ts` with named TTL constants for the web app's cache layer.
- Migrate every numeric TTL literal at active call sites (`cacheLife({ revalidate: N })`, Redis `cached(..., { ttl: N })`, and API `apiResponse({ maxAge: N })`) onto the named constants.
- Pure refactor — every constant matches the existing value at the call site. No behaviour change.

Closes #3072.

## Constants

| Constant | Seconds | Use cases |
|---|---|---|
| `CACHE_TTL_SHORT` | 60 | Fast-moving lists — `/explore` page, degraded search responses, new/freshly-fetched public watchlists |
| `CACHE_TTL_POPULAR` | 120 | Popular watchlists list (slower churn than freshly-created) |
| `CACHE_TTL_MEDIUM` | 300 | Moderate churn — posting detail, company postings, filtered watchlist counts, default API `maxAge` |
| `CACHE_TTL_DETAIL` | 600 | Company detail page (cross-`'use cache'`-boundary dedup) |
| `CACHE_TTL_LONG` | 3600 | Semi-static taxonomies, locations, sitemap, similar companies, watchlist matching count |
| `CACHE_TTL_DAY` | 86400 | Very static / rare-change (blog index + post pages) |

Built-in Next.js `cacheLife()` profile names (`'hours'`, `'days'`, `'minutes'`) are already named and were left in place — these constants only replace numeric literals.

## Sites migrated (35 call-site replacements across 15 modified files + 1 new file)

**Server actions** (`apps/web/src/lib/actions/`)
- `company.ts` — 3 `cacheLife` sites: 2x `CACHE_TTL_LONG`, 1x `CACHE_TTL_MEDIUM`.
- `locations.ts` — 1 `cacheLife` + 1 `cached(... { ttl })` -> `CACHE_TTL_LONG`.
- `search.ts` — 1 `cacheLife` -> `CACHE_TTL_MEDIUM`, 1 `cached(... { ttl })` -> `CACHE_TTL_SHORT`.
- `taxonomy.ts` — 3 `cacheLife` + 5 `cached(... { ttl })` -> all `CACHE_TTL_LONG`.
- `watchlists.ts` — 5 `cached(... { ttl })`: 2x `CACHE_TTL_SHORT`, 1x `CACHE_TTL_POPULAR`, 1x `CACHE_TTL_MEDIUM`, 1x `CACHE_TTL_LONG`.

**Pages** (`apps/web/app/[lang]/`)
- `(app)/[userSlug]/[watchlistSlug]/page.tsx` — 2x `CACHE_TTL_LONG`.
- `(app)/company/[slug]/page.tsx` — 2x `CACHE_TTL_DETAIL`.
- `(app)/explore/page.tsx` — 2x `CACHE_TTL_SHORT`.
- `(public)/blog/page.tsx` — 2x `CACHE_TTL_DAY`.
- `(public)/blog/[slug]/page.tsx` — 2x `CACHE_TTL_DAY`.

**API routes** (`apps/web/app/api/v1/`)
- `_shared.ts` — default `apiResponse({ maxAge })` -> `CACHE_TTL_MEDIUM`.
- `companies/route.ts`, `resolve/route.ts`, `taxonomies/route.ts` — `maxAge: CACHE_TTL_LONG` for cacheable responses.

**Other** (`apps/web/src/lib/`)
- `sitemap.ts` — `SITEMAP_TTL_SECONDS` now backed by `CACHE_TTL_LONG` (export preserved for `sitemap.test.ts` + `preferences.ts` reference).

## Intentionally left alone

- `maxAge: 0` in `auth.ts` (cookie clear) and API routes (no-cache error responses) — sentinel value, not a TTL tier.
- `'hours'` / `'days'` / `'minutes'` profile strings to `cacheLife()` — already named (Next.js built-in profiles).
- `cache.test.ts` literal `ttl: 60` / `ttl: 120` — arbitrary fixtures exercising the cache module, not policy.
- `SUGGEST_CACHE_TTL_MS` in `typesense-browser-typeahead.ts` — distinct module (milliseconds, browser-only typeahead).
- `LOGGED_IN_COOKIE_MAX_AGE`, `COOKIE_MAX_AGE_SECONDS`, `SESSION_TTL`, `PASSWORD_RESET_COOLDOWN_SECONDS`, `ANON_TTL_SECONDS`, `AUTHED_TTL_SECONDS`, `COOLDOWN_SECONDS` — already named, distinct semantic from cache layer.
- Comments referencing historical TTL numbers — these are doc strings recording the original Redis TTLs before #2884 migration; left unchanged because they're historical artefacts, not active TTL configuration.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 754 passed / 754
- [x] `pnpm lint` clean
- [x] Pre-commit hooks (ESLint web, Lingui coverage) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)