### PR TITLE
fix(web): atomic round-number assignment in addInterview (closes #3160)

### DIFF
--- a/apps/web/drizzle/0078_application_interview_unique_round.sql
+++ b/apps/web/drizzle/0078_application_interview_unique_round.sql
@@ -1,0 +1,72 @@
+-- Enforce uniqueness of (saved_job_id, round) on application_interview
+-- to close the duplicate-round race window between concurrent
+-- `addInterview` calls and the `updateJobStatus` auto-create branch.
+--
+-- Backstory: #3114 / #3160 — both call sites in my-jobs.ts compute the
+-- next round number with `SELECT max(round) + 1` and then `INSERT`. Two
+-- concurrent callers both read `max=N`, both insert `round=N+1`, and the
+-- application layer is the sole enforcer of round uniqueness. The
+-- existing `idx_ai_saved_job_round` is a non-unique B-tree index, so the
+-- database happily accepts duplicates. The deletion path
+-- (`deleteInterview`) then renumbers ORDER BY round, leaving the two
+-- duplicates permanently glued together.
+--
+-- Fix: promote the index to a uniqueness constraint. This converts the
+-- race into a `unique_violation` Postgres error, which the application
+-- layer now retries (`addInterview`) or absorbs as a no-op
+-- (`updateJobStatus` auto-create, via ON CONFLICT DO NOTHING).
+--
+-- NOTE on duplicates: if any duplicates already exist (low-probability
+-- but possible — both filed issues classify it as "low–medium"), this
+-- migration will fail at the UNIQUE INDEX build step. We dedupe first by
+-- keeping the lowest `created_at` per (saved_job_id, round) and renumber
+-- the rest. The dedupe is a one-shot cleanup; ongoing protection comes
+-- from the uniqueness constraint built afterwards.
+
+BEGIN;
+
+-- Dedupe existing rows: for each (saved_job_id, round) with duplicates,
+-- keep the earliest (lowest created_at, then lowest id as a stable
+-- tiebreak) and shift the rest to fresh round numbers at the tail.
+WITH ranked AS (
+  SELECT
+    id,
+    saved_job_id,
+    round,
+    row_number() OVER (
+      PARTITION BY saved_job_id, round
+      ORDER BY created_at ASC, id ASC
+    ) AS rn
+  FROM application_interview
+),
+max_per_job AS (
+  SELECT saved_job_id, max(round) AS mx
+  FROM application_interview
+  GROUP BY saved_job_id
+),
+to_shift AS (
+  SELECT
+    r.id,
+    r.saved_job_id,
+    m.mx + row_number() OVER (
+      PARTITION BY r.saved_job_id
+      ORDER BY r.round ASC, r.id ASC
+    ) AS new_round
+  FROM ranked r
+  JOIN max_per_job m ON m.saved_job_id = r.saved_job_id
+  WHERE r.rn > 1
+)
+UPDATE application_interview ai
+SET round = ts.new_round
+FROM to_shift ts
+WHERE ai.id = ts.id;
+
+-- Drop the non-unique companion index — superseded by the unique index.
+DROP INDEX IF EXISTS idx_ai_saved_job_round;
+
+-- Promote to UNIQUE. Same column list, same name, so Drizzle's snapshot
+-- stays aligned with the schema.ts uniqueIndex(...) declaration.
+CREATE UNIQUE INDEX idx_ai_saved_job_round
+  ON application_interview (saved_job_id, round);
+
+COMMIT;

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -484,6 +484,13 @@
       "when": 1778716800000,
       "tag": "0077_relax_chk_employment_type",
       "breakpoints": true
+    },
+    {
+      "idx": 69,
+      "version": "7",
+      "when": 1778976000000,
+      "tag": "0078_application_interview_unique_round",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/drizzle/schema.ts
+++ b/apps/web/drizzle/schema.ts
@@ -196,7 +196,7 @@ export const applicationInterview = pgTable("application_interview", {
 	scheduledAt: timestamp("scheduled_at", { withTimezone: true, mode: 'string' }),
 	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
 }, (table) => [
-	index("idx_ai_saved_job_round").using("btree", table.savedJobId.asc().nullsLast(), table.round.asc().nullsLast()),
+	uniqueIndex("idx_ai_saved_job_round").using("btree", table.savedJobId.asc().nullsLast(), table.round.asc().nullsLast()),
 	foreignKey({
 			columns: [table.savedJobId],
 			foreignColumns: [savedJob.id],

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -613,7 +613,12 @@ export const applicationInterview = pgTable(
     createdAt: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
   },
   (table) => [
-    index("idx_ai_saved_job_round").on(table.savedJobId, table.round),
+    // UNIQUE on (saved_job_id, round) — closes the duplicate-round race
+    // between concurrent addInterview calls and the updateJobStatus
+    // auto-create branch (#3114 / #3160). Application layer pairs this
+    // with ON CONFLICT DO NOTHING and a single-statement
+    // INSERT … SELECT max(round)+1 …
+    uniqueIndex("idx_ai_saved_job_round").on(table.savedJobId, table.round),
   ],
 );
 

--- a/apps/web/src/lib/actions/__tests__/my-jobs-interview-race.test.ts
+++ b/apps/web/src/lib/actions/__tests__/my-jobs-interview-race.test.ts
@@ -1,0 +1,430 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * #3160 (and #3114) — `addInterview` round-number race.
+ *
+ * Before the fix, `addInterview` ran two statements:
+ *   1. `SELECT coalesce(max(round), 0) AS max_round` from
+ *      `application_interview` for the saved_job
+ *   2. `INSERT INTO application_interview (..., round) VALUES (max_round + 1, ...)`
+ *
+ * Two concurrent callers (a flaky double-tap, two tabs, or
+ * `addInterview` racing with the `updateJobStatus('interviewing')`
+ * auto-create branch) both observed the same `max_round` and both
+ * inserted the same `round`. The non-unique `idx_ai_saved_job_round`
+ * index meant the DB did not catch this; `deleteInterview`'s
+ * round-by-position renumber preserved the duplicate forever.
+ *
+ * The fix collapses the two statements into one
+ * `INSERT INTO application_interview … SELECT coalesce(max(round), 0) + 1 …`
+ * (atomic in postgres) and pairs it with a UNIQUE `(saved_job_id, round)`
+ * constraint (migration 0078) plus a retry-on-23505 loop in the action.
+ *
+ * This test runs the fixed `addInterview` against an in-memory mock
+ * that mirrors postgres semantics:
+ *   - `db.execute(sql)` is atomic — its body runs without await
+ *     interleaving, so two parallel calls each compute `max+1` against
+ *     a fresh table snapshot. UNIQUE (saved_job_id, round) is enforced
+ *     in the mock; truly racing INSERT…SELECTs surface as 23505.
+ *   - `db.insert(...).onConflictDoNothing({target: ...})` honours the
+ *     conflict target and absorbs duplicates silently.
+ *
+ * On main (separate SELECT + INSERT, no UNIQUE, no ON CONFLICT) the
+ * same harness reproduces the duplicate-round outcome — captured in a
+ * separate spec below that imports the legacy reference algorithm.
+ */
+
+vi.mock("server-only", () => ({}));
+
+interface InterviewRow {
+  id: string;
+  saved_job_id: string;
+  round: number;
+  type: string;
+  scheduled_at: Date | null;
+  created_at: Date;
+}
+
+const mocks = vi.hoisted(() => {
+  // Verbatim row store, sole source of truth for "table contents".
+  const interviewTable: Array<{
+    id: string;
+    saved_job_id: string;
+    round: number;
+    type: string;
+    scheduled_at: Date | null;
+    created_at: Date;
+  }> = [];
+
+  let idCounter = 0;
+  const nextId = (): string => `iv-${++idCounter}`;
+
+  const uniqueViolation = (): Error => {
+    const e = new Error(
+      'duplicate key value violates unique constraint "idx_ai_saved_job_round"',
+    ) as Error & { code: string };
+    e.code = "23505";
+    return e;
+  };
+
+  let ownerRow: { id: string; status: string } | null = null;
+
+  // ---- db.execute(sql) — atomic INSERT…SELECT (the fix) -----------
+  //
+  // The action only invokes db.execute for the addInterview path. We
+  // sniff the saved_job_id and type out of the tagged-template `sql`
+  // call by walking its `queryChunks` field (drizzle-orm's internal
+  // representation). The body is fully synchronous between the entry
+  // and the return, mirroring postgres's single-statement atomicity.
+  const dbExecute = async (sqlObj: unknown): Promise<unknown[]> => {
+    const args = extractSqlParams(sqlObj);
+    const [savedJobId, type] = args as [string, string];
+
+    // Yield once so callers can interleave their pre-execute work
+    // (ownership check, etc.). Once we land inside this function from
+    // here on the work is atomic — no more awaits.
+    await Promise.resolve();
+
+    const existing = interviewTable.filter(
+      (r) => r.saved_job_id === savedJobId,
+    );
+    const maxRound = existing.reduce((m, r) => Math.max(m, r.round), 0);
+    const round = maxRound + 1;
+
+    // Defensive: if a concurrent INSERT…SELECT raced and added the
+    // same round under a different microtask window, the UNIQUE
+    // constraint surfaces 23505. The action's retry loop catches it.
+    if (existing.some((r) => r.round === round)) throw uniqueViolation();
+
+    const row = {
+      id: nextId(),
+      saved_job_id: savedJobId,
+      round,
+      type,
+      scheduled_at: null,
+      created_at: new Date(),
+    };
+    interviewTable.push(row);
+    return [row];
+  };
+
+  // ---- db.insert(...).values(...).onConflictDoNothing/returning ----
+  //
+  // Used by updateJobStatus auto-create. Honours the conflict target.
+  const dbInsert = () => ({
+    values: (v: { savedJobId: string; round: number; type: string }) => {
+      // Capture v here in this closure so concurrent inserts don't
+      // clobber each other's pending state.
+      const exec = async ({
+        absorbConflict,
+      }: {
+        absorbConflict: boolean;
+      }): Promise<InterviewRow[]> => {
+        await Promise.resolve();
+        const conflict = interviewTable.some(
+          (r) => r.saved_job_id === v.savedJobId && r.round === v.round,
+        );
+        if (conflict) {
+          if (absorbConflict) return [];
+          throw uniqueViolation();
+        }
+        const row = {
+          id: nextId(),
+          saved_job_id: v.savedJobId,
+          round: v.round,
+          type: v.type,
+          scheduled_at: null,
+          created_at: new Date(),
+        };
+        interviewTable.push(row);
+        return [row];
+      };
+      return {
+        onConflictDoNothing: (_opts?: unknown) =>
+          exec({ absorbConflict: true }),
+        returning: () => exec({ absorbConflict: false }),
+        // Make the chain awaitable directly (no .returning / no
+        // .onConflict). Returns the inserted-row array. Forward both
+        // resolve and reject so a thrown unique_violation surfaces to
+        // the caller's await instead of hanging.
+        then: (
+          resolve: (v: unknown) => unknown,
+          reject?: (err: unknown) => unknown,
+        ) => exec({ absorbConflict: false }).then(resolve, reject),
+      };
+    },
+  });
+
+  // ---- db.select() ------------------------------------------------
+  //
+  // The action under test uses select() only for ownership (the
+  // updateJobStatus auto-create branch no longer reads via select).
+  // We sniff projection shape to route.
+  const dbSelect = (cols: unknown) => {
+    const c = cols as Record<string, unknown>;
+    const isOwner = c && "status" in c && "id" in c;
+
+    const chain = {
+      from: () => chain,
+      innerJoin: () => chain,
+      where: () => chain,
+      limit: async () => {
+        await Promise.resolve();
+        if (isOwner) return ownerRow ? [ownerRow] : [];
+        return [];
+      },
+      // Some legacy paths terminate at .where() with a thenable.
+      then: async (
+        resolve: (v: unknown) => unknown,
+        _reject?: (err: unknown) => unknown,
+      ) => {
+        await Promise.resolve();
+        return resolve([]);
+      },
+    };
+    return chain;
+  };
+
+  // ---- db.update() — used for status auto-transition --------------
+  const dbUpdate = () => {
+    const chain = {
+      set: () => chain,
+      where: async () => undefined,
+    };
+    return chain;
+  };
+
+  // ---- db.delete() — unused here but harmless ---------------------
+  const dbDelete = () => {
+    const chain = {
+      where: async () => undefined,
+    };
+    return chain;
+  };
+
+  return {
+    interviewTable,
+    setOwner: (id: string, status: string) => {
+      ownerRow = { id, status };
+    },
+    seedInterviews: (
+      rows: Array<{ savedJobId: string; round: number; type: string }>,
+    ) => {
+      for (const r of rows) {
+        interviewTable.push({
+          id: nextId(),
+          saved_job_id: r.savedJobId,
+          round: r.round,
+          type: r.type,
+          scheduled_at: null,
+          created_at: new Date(),
+        });
+      }
+    },
+    reset: () => {
+      interviewTable.length = 0;
+      idCounter = 0;
+      ownerRow = null;
+    },
+    getSessionUserId: vi.fn(),
+    dbExecute,
+    dbInsert,
+    dbSelect,
+    dbUpdate,
+    dbDelete,
+  };
+});
+
+/**
+ * Drizzle's `sql\`...\`` tagged template stores its parts on
+ * `queryChunks: Array<Param | StringChunk>`. The interpolated values
+ * appear as bare primitives directly in the array; the SQL fragments
+ * are wrapped in `{ value: [string] }` (StringChunk). Walk the chunks
+ * top level and pick out only the bare primitives — those are the
+ * parameters the action passed to `sql\`…${param}…\``.
+ */
+function extractSqlParams(sqlObj: unknown): unknown[] {
+  const params: unknown[] = [];
+  const queryChunks = (sqlObj as { queryChunks?: unknown[] }).queryChunks;
+  if (!Array.isArray(queryChunks)) return params;
+  for (const chunk of queryChunks) {
+    if (chunk === null || chunk === undefined) continue;
+    const t = typeof chunk;
+    if (t === "string" || t === "number" || t === "bigint" || t === "boolean") {
+      params.push(chunk);
+    } else if (t === "object") {
+      // Drizzle Param wrapper: `.value` carries the actual parameter,
+      // `.encoder` is the codec. StringChunk has `.value: string[]` and
+      // no `.encoder`. We want Param.
+      const v = (chunk as { value?: unknown; encoder?: unknown }).value;
+      const hasEncoder = (chunk as { encoder?: unknown }).encoder !== undefined;
+      if (hasEncoder && v !== undefined) params.push(v);
+    }
+  }
+  return params;
+}
+
+vi.mock("@/lib/sessionCache", () => ({
+  getSessionUserId: mocks.getSessionUserId,
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    select: (cols: unknown) => mocks.dbSelect(cols),
+    insert: () => mocks.dbInsert(),
+    update: () => mocks.dbUpdate(),
+    delete: () => mocks.dbDelete(),
+    execute: (sqlObj: unknown) => mocks.dbExecute(sqlObj),
+  },
+}));
+
+describe("#3160 — addInterview round-number race", () => {
+  beforeEach(() => {
+    mocks.reset();
+    mocks.getSessionUserId.mockResolvedValue("user-1");
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("two concurrent addInterview calls produce distinct round numbers", async () => {
+    mocks.setOwner("sj-1", "interviewing");
+
+    const { addInterview } = await import("@/lib/actions/my-jobs");
+
+    // Critical assertion: under Promise.all (interleaved microtasks),
+    // each interview gets a unique round. On the buggy main shape the
+    // two callers' `SELECT max(round)` reads both return 0, both INSERT
+    // round=1, and the table ends up with two round=1 rows.
+    const [r1, r2] = await Promise.all([
+      addInterview("sj-1", "phone_screen"),
+      addInterview("sj-1", "video_call"),
+    ]);
+
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+
+    const rounds = mocks.interviewTable
+      .filter((r) => r.saved_job_id === "sj-1")
+      .map((r) => r.round)
+      .sort();
+
+    expect(rounds).toEqual([1, 2]);
+    expect(new Set(rounds).size).toBe(rounds.length);
+  });
+
+  it("addInterview against existing interviews picks the next round", async () => {
+    mocks.setOwner("sj-1", "interviewing");
+    mocks.seedInterviews([
+      { savedJobId: "sj-1", round: 1, type: "phone_screen" },
+      { savedJobId: "sj-1", round: 2, type: "video_call" },
+    ]);
+
+    const { addInterview } = await import("@/lib/actions/my-jobs");
+
+    const r = await addInterview("sj-1", "technical");
+    expect(r.ok).toBe(true);
+    expect(r.interview?.round).toBe(3);
+
+    const rounds = mocks.interviewTable
+      .filter((r) => r.saved_job_id === "sj-1")
+      .map((r) => r.round)
+      .sort();
+    expect(rounds).toEqual([1, 2, 3]);
+  });
+
+  it("updateJobStatus('interviewing') auto-create is a no-op when interview exists", async () => {
+    // Race scenario: addInterview already inserted round=1, then a
+    // concurrent updateJobStatus auto-create runs. With ON CONFLICT DO
+    // NOTHING + UNIQUE constraint, the auto-create is a silent no-op
+    // instead of inserting a second round=1.
+    mocks.setOwner("sj-1", "applied");
+    mocks.seedInterviews([
+      { savedJobId: "sj-1", round: 1, type: "video_call" },
+    ]);
+
+    const { updateJobStatus } = await import("@/lib/actions/my-jobs");
+    const r = await updateJobStatus("sj-1", "interviewing");
+    expect(r.ok).toBe(true);
+
+    const rounds = mocks.interviewTable
+      .filter((r) => r.saved_job_id === "sj-1")
+      .map((r) => r.round)
+      .sort();
+
+    expect(rounds).toEqual([1]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Reference: the buggy main algorithm. We re-implement the pre-fix
+// addInterview shape (separate SELECT max + INSERT) and run it against
+// the SAME mock harness. The assertion is that the harness reproduces
+// the duplicate-round behaviour under the buggy algorithm — proving
+// the harness can distinguish fixed from broken.
+//
+// This isn't a unit test of the production code (the production code
+// is the fixed version); it's a calibration spec that gives us
+// confidence the harness wouldn't trivially pass for both shapes.
+// ─────────────────────────────────────────────────────────────────────
+
+describe("#3160 — race-mock calibration (buggy algorithm reproduces duplicates)", () => {
+  beforeEach(() => {
+    mocks.reset();
+    mocks.getSessionUserId.mockResolvedValue("user-1");
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("buggy SELECT-then-INSERT shape produces duplicate round=1 under Promise.all", async () => {
+    // Lay down an explicit shared state and run the buggy algorithm
+    // directly against the in-memory table. This proves the harness
+    // (specifically, microtask interleaving + no UNIQUE check in the
+    // direct path) can produce the bug.
+    mocks.setOwner("sj-1", "interviewing");
+
+    const buggyAddInterview = async (
+      savedJobId: string,
+      type: string,
+    ): Promise<void> => {
+      // Step 1: read max.
+      const existing = mocks.interviewTable.filter(
+        (r) => r.saved_job_id === savedJobId,
+      );
+      // Microtask hop — mimics await on a DB roundtrip.
+      await Promise.resolve();
+      const maxRound = existing.reduce((m, r) => Math.max(m, r.round), 0);
+      const nextRound = maxRound + 1;
+      // Step 2: insert. No UNIQUE check (the pre-migration world).
+      await Promise.resolve();
+      mocks.interviewTable.push({
+        id: `iv-buggy-${mocks.interviewTable.length + 1}`,
+        saved_job_id: savedJobId,
+        round: nextRound,
+        type,
+        scheduled_at: null,
+        created_at: new Date(),
+      });
+    };
+
+    await Promise.all([
+      buggyAddInterview("sj-1", "phone_screen"),
+      buggyAddInterview("sj-1", "video_call"),
+    ]);
+
+    const rounds = mocks.interviewTable
+      .filter((r) => r.saved_job_id === "sj-1")
+      .map((r) => r.round);
+
+    // Two rows, BOTH with round=1 — the canonical bug shape.
+    expect(rounds.length).toBe(2);
+    expect(new Set(rounds).size).toBe(1);
+    expect(rounds[0]).toBe(1);
+    expect(rounds[1]).toBe(1);
+  });
+});

--- a/apps/web/src/lib/actions/my-jobs.ts
+++ b/apps/web/src/lib/actions/my-jobs.ts
@@ -298,21 +298,26 @@ export async function updateJobStatus(
     .set(updates)
     .where(eq(savedJob.id, savedJobId));
 
-  // Auto-create first interview if transitioning to interviewing with none
+  // Auto-create first interview if transitioning to interviewing with none.
+  //
+  // Race with `addInterview` (#3160): two tabs running
+  // `updateJobStatus('interviewing')` and `addInterview(...)` for the same
+  // saved_job both observe "no interviews yet" and both insert round=1.
+  // Fix: rely on the UNIQUE (saved_job_id, round) constraint added in
+  // migration 0078 and use INSERT … ON CONFLICT DO NOTHING. If the other
+  // call already inserted round=1, this is a silent no-op (caller didn't
+  // ask for a specific interview row, only that one exists).
   if (newStatus === "interviewing") {
-    const [existing] = await db
-      .select({ id: applicationInterview.id })
-      .from(applicationInterview)
-      .where(eq(applicationInterview.savedJobId, savedJobId))
-      .limit(1);
-
-    if (!existing) {
-      await db.insert(applicationInterview).values({
+    await db
+      .insert(applicationInterview)
+      .values({
         savedJobId,
         round: 1,
         type: "phone_screen",
+      })
+      .onConflictDoNothing({
+        target: [applicationInterview.savedJobId, applicationInterview.round],
       });
-    }
   }
 
   return { ok: true };
@@ -336,18 +341,103 @@ export async function addInterview(
 
   if (!row) return { ok: false, error: "Not found" };
 
-  // Get next round number
-  const [maxRow] = await db
-    .select({ maxRound: sql<number>`coalesce(max(round), 0)` })
-    .from(applicationInterview)
-    .where(eq(applicationInterview.savedJobId, savedJobId));
+  // Atomic round-number assignment (#3160 / #3114).
+  //
+  // Previous shape was two statements — `SELECT coalesce(max(round), 0)`
+  // followed by an `INSERT` with the read value — which races between
+  // any two concurrent callers (double-tap, two tabs, addInterview vs
+  // updateJobStatus auto-create). Both observe the same max and both
+  // INSERT the same round.
+  //
+  // New shape: a single `INSERT … SELECT coalesce(max(round), 0) + 1 …`
+  // is atomic in postgres — the inner SELECT and the row write happen
+  // under the same statement, and the UNIQUE (saved_job_id, round)
+  // constraint (migration 0078) is the backstop. If two such statements
+  // serialize and the second observes the first's row, MAX returns the
+  // new value and the round increments cleanly. If they truly tie under
+  // the same snapshot (a window narrowed but not eliminated by SELECT's
+  // read consistency), the UNIQUE constraint trips the loser with a
+  // 23505 unique_violation and the retry loop computes a fresh round.
+  //
+  // The retry budget is small (4 attempts) — the only way to exhaust it
+  // is a many-way concurrent burst, which the application surface (a
+  // single "Add interview" button) cannot generate.
+  const MAX_ATTEMPTS = 4;
+  let inserted:
+    | {
+        id: string;
+        round: number;
+        type: string;
+        scheduledAt: Date | null;
+        createdAt: Date;
+      }
+    | undefined;
+  let lastErr: unknown;
 
-  const nextRound = (maxRow?.maxRound ?? 0) + 1;
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    try {
+      const rows = await db.execute<{
+        id: string;
+        round: number;
+        type: string;
+        scheduled_at: Date | null;
+        created_at: Date;
+      }>(sql`
+        INSERT INTO application_interview (saved_job_id, round, type)
+        SELECT
+          ${savedJobId}::uuid,
+          coalesce(max(round), 0) + 1,
+          ${type}
+        FROM application_interview
+        WHERE saved_job_id = ${savedJobId}::uuid
+        RETURNING id, round, type, scheduled_at, created_at
+      `);
 
-  const [inserted] = await db
-    .insert(applicationInterview)
-    .values({ savedJobId, round: nextRound, type })
-    .returning();
+      const r = (rows as unknown as Array<{
+        id: string;
+        round: number;
+        type: string;
+        scheduled_at: Date | null;
+        created_at: Date;
+      }>)[0];
+
+      if (!r) {
+        // Defensive: postgres should always return the inserted row.
+        // Treat as a transient miss and retry.
+        lastErr = new Error("addInterview: INSERT…SELECT returned no row");
+        continue;
+      }
+
+      inserted = {
+        id: r.id,
+        round: r.round,
+        type: r.type,
+        scheduledAt: r.scheduled_at,
+        createdAt: r.created_at,
+      };
+      break;
+    } catch (err) {
+      lastErr = err;
+      // Postgres unique_violation: another concurrent caller won the
+      // race for this round number. Recompute via another INSERT…SELECT
+      // pass (which will see the conflicting row and pick the next round).
+      const code = (err as { code?: unknown }).code;
+      if (code === "23505") continue;
+      // Non-conflict errors propagate.
+      throw err;
+    }
+  }
+
+  if (!inserted) {
+    // Exhausted the retry budget without a successful insert. Surface as
+    // a soft error so the caller can decide (the UI shows a toast). The
+    // server log path picks up the underlying postgres error.
+    console.warn(
+      "[addInterview] failed to assign unique round after retries",
+      { savedJobId, type, lastErr },
+    );
+    return { ok: false, error: "Could not assign interview round" };
+  }
 
   // Auto-transition to interviewing if currently applied
   if (row.status === "applied") {


### PR DESCRIPTION
## Summary

- Replace the two-statement `SELECT max(round) + INSERT` race window in `addInterview` with a single atomic `INSERT … SELECT coalesce(max(round), 0) + 1 …` postgres statement
- Add migration `0078_application_interview_unique_round.sql` promoting `idx_ai_saved_job_round` to UNIQUE on `(saved_job_id, round)` so the database is the backstop, not the application layer
- Switch `updateJobStatus('interviewing')` auto-create from `SELECT-then-INSERT` to `INSERT … ON CONFLICT (saved_job_id, round) DO NOTHING` so the addInterview <-> updateJobStatus cross-action race becomes a silent no-op

## Race scenario (from #3160)

Two actors, same saved job:

```
T0  sj.status = 'applied', no interviews exist.
T0  tab A `updateJobStatus(sj, "interviewing")` → updates saved_job.
T0  tab B `addInterview(sj, "video_call")` → SELECT max(round) = 0.
T1  tab A SELECT FROM application_interview … = no rows.
T1  tab B INSERT (sj, 1, "video_call") → commits.
T2  tab A INSERT (sj, 1, "phone_screen") → commits.
→ two rows with round=1, permanent (deleteInterview's renumber preserves duplicates).
```

The same shape applies to two parallel `addInterview` calls (#3114).

## Fix design

1. **Migration `0078`**: `idx_ai_saved_job_round` becomes UNIQUE. Includes a one-shot dedupe (keep earliest row by `created_at, id` per `(saved_job_id, round)`, shift the rest to fresh tail rounds) so the build doesn't fail on any pre-existing duplicates.
2. **`addInterview`**: single atomic `INSERT … SELECT` puts the MAX read and the row write under the same statement. A small retry-on-23505 loop (4 attempts) catches the unlikely case of two such statements truly tying.
3. **`updateJobStatus` auto-create**: `INSERT … ON CONFLICT (saved_job_id, round) DO NOTHING`. The caller only requires that one interview exists, not that this call produced it.

## Regression test

`apps/web/src/lib/actions/__tests__/my-jobs-interview-race.test.ts` (4 tests):

- `two concurrent addInterview calls produce distinct round numbers` — `Promise.all` of two parallel calls against an in-memory mock that mirrors postgres atomicity + UNIQUE.
- `addInterview against existing interviews picks the next round` — single-caller correctness.
- `updateJobStatus('interviewing') auto-create is a no-op when interview exists` — covers the cross-action race in #3160.
- `buggy SELECT-then-INSERT shape produces duplicate round=1 under Promise.all` — **calibration spec** that runs the legacy algorithm directly against the same harness and proves duplicates emerge. Without this spec the other three could be vacuously passing.

Verified failing-on-main: reverted `my-jobs.ts` to `origin/main`, the 3 fix-target tests fail (TypeError / unique_violation), calibration spec still passes. Restored the fix, all 4 flip to green.

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm lint` — green
- [x] `pnpm test` — 758 tests pass (+4 new vs main's 754)
- [x] Reverted to main, confirmed the 3 fix-target tests fail (TypeError on undefined `inserted`, unique_violation on direct INSERT)

Closes #3160. Partial close of #3114 (the `addInterview` and `updateJobStatus` items; transaction wrapping of watchlist mutators is left for a follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)