### PR TITLE
fix(web): correct hourly salary (cents) + i18n period suffixes (closes #3174 #3144)

### DIFF
--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -26,7 +26,7 @@ msgstr ""
 
 #. CC right 1
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:80
+#: src/components/LicenseContent.tsx:79
 msgid "license.data.r1"
 msgstr "„Viktor Shcherbakov, Sammlung von Stellenanzeigen\" mit einem Link zur Quelle."
 
@@ -41,12 +41,12 @@ msgstr "„Viktor Shcherbakov, Sammlung von Stellenanzeigen\" mit einem Link zur
 #. js-lingui-explicit-id
 #: src/components/Footer.tsx:41
 #: src/components/Footer.tsx:47
-#: src/components/HowWeIndexContent.tsx:196
-#: src/components/LicenseContent.tsx:64
-#: src/components/LicenseContent.tsx:89
-#: src/components/PrivacyPolicyContent.tsx:74
+#: src/components/HowWeIndexContent.tsx:194
+#: src/components/LicenseContent.tsx:63
+#: src/components/LicenseContent.tsx:88
+#: src/components/PrivacyPolicyContent.tsx:73
 #: src/components/PublicDomainArt.tsx:115
-#: src/components/TermsContent.tsx:62
+#: src/components/TermsContent.tsx:61
 msgid "common.a11y.opensInNewTab"
 msgstr "(öffnet in neuem Tab)"
 
@@ -212,8 +212,8 @@ msgstr "Kontomenü"
 #. Active postings count on company page
 #. Active postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:554
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:564
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:561
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:571
 msgid "company.page.active"
 msgstr "aktiv"
 
@@ -239,7 +239,7 @@ msgstr "Unternehmen hinzufügen"
 
 #. Link to add a description to the watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:438
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:446
 msgid "watchlists.view.addDescription"
 msgstr "Beschreibung hinzufügen"
 
@@ -293,7 +293,7 @@ msgstr "Alle {totalCountries} Länder geladen"
 
 #. Encryption
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:47
+#: src/components/PrivacyPolicyContent.tsx:46
 msgid "privacy.short.r5"
 msgstr "Alle Daten werden bei Übertragung und Speicherung verschlüsselt."
 
@@ -303,16 +303,16 @@ msgstr "Alle Daten werden bei Übertragung und Speicherung verschlüsselt."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Alle Branchen"
 
-#. All languages option
-#. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:253
-msgid "settings.general.jobLanguages.all"
-msgstr "Alle Sprachen"
-
 #. Title for the all-languages modal in settings
 #. js-lingui-explicit-id
 #: src/components/settings/JobLanguageModal.tsx:56
 msgid "settings.jobLanguages.modal.title"
+msgstr "Alle Sprachen"
+
+#. All languages option
+#. js-lingui-explicit-id
+#: src/components/settings/GeneralSettings.tsx:253
+msgid "settings.general.jobLanguages.all"
 msgstr "Alle Sprachen"
 
 #. Title for the all-locations modal on company page
@@ -335,7 +335,7 @@ msgstr "Bereits ein Konto? <0>Anmelden</0>"
 
 #. Username is taken
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:295
+#: src/components/settings/AccountSettings.tsx:292
 msgid "settings.account.username.taken"
 msgstr "Bereits vergeben"
 
@@ -352,19 +352,19 @@ msgstr "Beliebig"
 
 #. Toggle to show jobs from all companies
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:466
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:474
 msgid "watchlists.view.anyCompany"
 msgstr "Alle Unternehmen"
 
 #. MIT license section title
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:50
+#: src/components/LicenseContent.tsx:49
 msgid "license.code.title"
 msgstr "Anwendungscode (MIT-Lizenz)"
 
 #. TOC: Application code (MIT)
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:23
+#: src/components/LicenseContent.tsx:22
 msgid "license.toc.code"
 msgstr "Anwendungscode (MIT)"
 
@@ -422,16 +422,16 @@ msgstr "Beworben"
 msgid "myJobs.status.applied"
 msgstr "Beworben"
 
-#. Status option in dropdown: applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:36
-msgid "myJobs.statusOption.applied"
-msgstr "Beworben"
-
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
+msgstr "Beworben"
+
+#. Status option in dropdown: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:36
+msgid "myJobs.statusOption.applied"
 msgstr "Beworben"
 
 #. Apply salary filter
@@ -460,19 +460,19 @@ msgstr "Apr"
 
 #. Step 3 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:131
+#: src/components/HowWeIndexContent.tsx:129
 msgid "indexing.ingestion.s3.body"
 msgstr "Als letztes Mittel parsen wir die Karriereseiten selbst, bevorzugen dabei die neuesten Einträge zuerst und stoppen, sobald bereits indexierte Stellen wieder auftauchen, anstatt jede Seite zu durchsuchen."
 
 #. Username too short hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:283
+#: src/components/settings/AccountSettings.tsx:280
 msgid "settings.account.username.tooShort"
 msgstr "Mindestens 3 Zeichen"
 
 #. Username too long hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:285
+#: src/components/settings/AccountSettings.tsx:282
 msgid "settings.account.username.tooLong"
 msgstr "Maximal 30 Zeichen"
 
@@ -484,20 +484,20 @@ msgstr "Aug"
 
 #. Username is available
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:293
+#: src/components/settings/AccountSettings.tsx:290
 msgid "settings.account.username.available"
 msgstr "Verfügbar"
-
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Zurück zur Anmeldung"
 
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Zurück zur Anmeldung"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Zurück zur Anmeldung"
 
 #. Link back to sign-in from forgot password
@@ -544,18 +544,18 @@ msgstr "Blog"
 msgid "blog.post.backToIndex"
 msgstr "Blog"
 
+#. Footer link to /blog index page
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:52
+msgid "common.footer.blog"
+msgstr "Blog"
+
 #. Nav link: Blog
 #. Nav link: Blog
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:74
 #: src/components/MobileMenu.tsx:98
 msgid "common.nav.blog"
-msgstr "Blog"
-
-#. Footer link to /blog index page
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
-msgid "common.footer.blog"
 msgstr "Blog"
 
 #. Subtitle on the sign-in CTA card shown to anonymous users at the end of the similar-companies strip
@@ -566,7 +566,7 @@ msgstr "Alle Mitbewerber durchsuchen"
 
 #. Link text for browsing the repo
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:192
+#: src/components/HowWeIndexContent.tsx:190
 msgid "indexing.oss.browseRepo"
 msgstr "Repository ansehen unter"
 
@@ -590,7 +590,7 @@ msgstr "Von Jobsuchenden entwickelt, für Jobsuchende"
 
 #. Terms page description
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:23
+#: src/components/TermsContent.tsx:22
 msgid "terms.hero.description"
 msgstr "Mit der Nutzung von Job Seek stimmst du diesen Bedingungen zu. Hier eine verständliche Zusammenfassung."
 
@@ -607,7 +607,7 @@ msgstr "Abbrechen"
 
 #. Cancel delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:535
+#: src/components/settings/AccountSettings.tsx:532
 msgid "settings.account.delete.cancel"
 msgstr "Abbrechen"
 
@@ -619,7 +619,7 @@ msgstr "ändern"
 
 #. Change email section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:373
+#: src/components/settings/AccountSettings.tsx:370
 msgid "settings.account.email.title"
 msgstr "E-Mail ändern"
 
@@ -637,7 +637,7 @@ msgstr "Sprache ändern"
 
 #. Password section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:180
+#: src/components/settings/AccountSettings.tsx:177
 msgid "settings.account.password.description"
 msgstr "Ändere dein Passwort über einen sicheren E-Mail-Link."
 
@@ -647,21 +647,21 @@ msgstr "Ändere dein Passwort über einen sicheren E-Mail-Link."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Ändern…"
 
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "E-Mail prüfen"
-
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
 msgstr "E-Mail überprüfen"
 
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
+msgstr "E-Mail prüfen"
+
 #. Checking username availability
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:291
+#: src/components/settings/AccountSettings.tsx:288
 msgid "settings.account.username.checking"
 msgstr "Verfügbarkeit wird geprüft..."
 
@@ -711,14 +711,14 @@ msgstr "Zurücksetzen"
 
 #. Button to remove all companies from watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:484
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:492
 msgid "watchlists.view.clearAllCompanies"
 msgstr "Alle entfernen"
 
 #. Button to clear all active search filters
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:616
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:624
 #: src/components/search/search-toolbar.tsx:337
 msgid "search.filters.clearAll"
 msgstr "Alle löschen"
@@ -731,19 +731,19 @@ msgstr "Alle entfernen"
 
 #. Tooltip for clicking to edit watchlist description
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:426
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:434
 msgid "watchlists.view.editDescription"
 msgstr "Klicken, um Beschreibung zu bearbeiten"
 
 #. Tooltip for clicking to edit watchlist title
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:376
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:384
 msgid "watchlists.view.editTitle"
 msgstr "Klicken zum Umbenennen"
 
 #. Step 2 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:121
+#: src/components/HowWeIndexContent.tsx:119
 msgid "indexing.ingestion.s2.title"
 msgstr "Client-APIs als Zweites."
 
@@ -755,7 +755,7 @@ msgstr "Menü schließen"
 
 #. Label for inactive/closed job postings on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:656
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:663
 msgid "company.page.closed"
 msgstr "Geschlossen"
 
@@ -773,7 +773,7 @@ msgstr "Coding"
 
 #. CC license section title
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:71
+#: src/components/LicenseContent.tsx:70
 msgid "license.data.title"
 msgstr "Sammlung von Stellenanzeigen (CC BY-NC 4.0)"
 
@@ -809,7 +809,7 @@ msgstr "Beobachtete Unternehmen"
 
 #. Button to open company search modal
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:455
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:463
 msgid "watchlists.view.addCompany"
 msgstr "Unternehmen"
 
@@ -851,7 +851,7 @@ msgstr "Unternehmens-Tracking-Tool für gezielte Jobsuchende — Watchlists, E-M
 
 #. Confirm delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:528
+#: src/components/settings/AccountSettings.tsx:525
 msgid "settings.account.delete.confirm"
 msgstr "Löschen bestätigen"
 
@@ -863,25 +863,25 @@ msgstr "Passwort bestätigen"
 
 #. Connect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:478
+#: src/components/settings/AccountSettings.tsx:475
 msgid "settings.account.socials.connect"
 msgstr "Verbinden"
 
 #. Connected accounts section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:453
+#: src/components/settings/AccountSettings.tsx:450
 msgid "settings.account.socials.title"
 msgstr "Verknüpfte Konten"
 
 #. TOC: Contact
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:25
+#: src/components/LicenseContent.tsx:24
 msgid "license.toc.contact"
 msgstr "Kontakt"
 
 #. Contact section title
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:96
+#: src/components/LicenseContent.tsx:95
 msgid "license.contact.title"
 msgstr "Kontakt"
 
@@ -893,13 +893,13 @@ msgstr "Kontakt"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
+#: src/components/LicenseContent.tsx:17
 msgid "license.toc.title"
 msgstr "Inhalt"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
+#: src/components/HowWeIndexContent.tsx:21
 msgid "indexing.toc.title"
 msgstr "Inhalt"
 
@@ -929,13 +929,13 @@ msgstr "Weiter mit LinkedIn"
 
 #. Employment type: contract
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:14
+#: src/components/search/employment-type-modal.tsx:15
 msgid "search.employmentType.contract"
 msgstr "Freiberuflich"
 
 #. Cookies
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:46
+#: src/components/PrivacyPolicyContent.tsx:45
 msgid "privacy.short.r4"
 msgstr "Cookies dienen nur der Sitzung — keine Werbung, kein Tracking."
 
@@ -947,7 +947,7 @@ msgstr "Kopiert"
 
 #. MIT right 1
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:58
+#: src/components/LicenseContent.tsx:57
 msgid "license.code.r1"
 msgstr "Den Code für jeden Zweck kopieren und ändern, einschließlich kommerzieller Produkte."
 
@@ -985,13 +985,13 @@ msgstr "Crawler-Quellcode"
 
 #. TOC: Crawling assurances
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:28
+#: src/components/HowWeIndexContent.tsx:26
 msgid "indexing.toc.assurances"
 msgstr "Crawling-Zusicherungen"
 
 #. Assurances section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:63
+#: src/components/HowWeIndexContent.tsx:61
 msgid "indexing.assurances.title"
 msgstr "Crawling-Zusicherungen"
 
@@ -1055,6 +1055,12 @@ msgstr "Währung"
 msgid "settings.billing.currentPlan"
 msgstr "Aktuell"
 
+#. Salary period suffix shown after the amount, e.g. '300 EUR / daily'
+#. js-lingui-explicit-id
+#: src/components/SalaryDisplayProvider.tsx:59
+msgid "common.salary.period.daily"
+msgstr "täglich"
+
 #. Daily pay period option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:372
@@ -1111,13 +1117,13 @@ msgstr "Löschen"
 
 #. Delete account section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:511
+#: src/components/settings/AccountSettings.tsx:508
 msgid "settings.account.delete.title"
 msgstr "Konto löschen"
 
 #. Delete account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:521
+#: src/components/settings/AccountSettings.tsx:518
 msgid "settings.account.delete.button"
 msgstr "Mein Konto löschen"
 
@@ -1129,13 +1135,13 @@ msgstr "Watchlist löschen?"
 
 #. Delete button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:527
+#: src/components/settings/AccountSettings.tsx:524
 msgid "settings.account.delete.deleting"
 msgstr "Löschen…"
 
 #. Placeholder for watchlist description textarea
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:418
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:426
 msgid "watchlists.view.descriptionPlaceholder"
 msgstr "Diese Watchlist beschreiben …"
 
@@ -1171,7 +1177,7 @@ msgstr "Benachrichtigungen deaktivieren"
 
 #. Disconnect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:477
+#: src/components/settings/AccountSettings.tsx:474
 msgid "settings.account.socials.disconnect"
 msgstr "Trennen"
 
@@ -1194,7 +1200,7 @@ msgstr "Noch kein Konto? <0>Registrieren</0>"
 
 #. No scraping
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:45
+#: src/components/TermsContent.tsx:44
 msgid "terms.short.r3"
 msgstr "Kein Scraping, keine automatisierten Bewerbungen, kein Missbrauch der Plattform."
 
@@ -1256,7 +1262,7 @@ msgstr "E-Mail bestätigt"
 
 #. Title for the employment type selection modal
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:48
+#: src/components/search/employment-type-modal.tsx:74
 msgid "search.employmentTypeModal.title"
 msgstr "Beschäftigungsart"
 
@@ -1280,7 +1286,7 @@ msgstr "Gib unten dein neues Passwort ein."
 
 #. Assurance 3 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:80
+#: src/components/HowWeIndexContent.tsx:78
 msgid "indexing.assurances.i3.body"
 msgstr "Auch nach der Entdeckung rufen wir Stellendetailseiten mit einem strikten Limit von einer Anfrage pro Seite pro Minute ab."
 
@@ -1292,7 +1298,7 @@ msgstr "Jeder Filter, den ein Jobsuchender wirklich braucht"
 
 #. Assurance 1 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:68
+#: src/components/HowWeIndexContent.tsx:66
 msgid "indexing.assurances.i1.body"
 msgstr "Jedes Wiederholungsfenster nutzt exponentielles Backoff, damit wir einen Server nie überlasten, und wir brechen ab, wenn ein Host weiterhin Timeouts liefert."
 
@@ -1315,16 +1321,16 @@ msgstr "E-Mail-Benachrichtigungen bei neuen Stellen"
 msgid "faq.description"
 msgstr "Alles, was du über Job Seek wissen musst. Du findest nicht, was du suchst? Schreib uns an <0>{0}</0>."
 
-#. Label for experience filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:231
-msgid "search.advanced.experience"
-msgstr "Erfahrung"
-
 #. Title for experience filter modal
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:186
 msgid "search.experienceModal.title"
+msgstr "Erfahrung"
+
+#. Label for experience filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:231
+msgid "search.advanced.experience"
 msgstr "Erfahrung"
 
 #. Breadcrumb label for the Explore page
@@ -1346,27 +1352,27 @@ msgstr "Jobs entdecken"
 
 #. Generic email change error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:363
+#: src/components/settings/AccountSettings.tsx:360
 msgid "settings.account.email.error"
 msgstr "E-Mail-Änderung fehlgeschlagen"
 
 #. Error when linking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:429
+#: src/components/settings/AccountSettings.tsx:426
 msgid "settings.account.socials.connectError"
 msgstr "Konto konnte nicht verbunden werden"
 
 #. Generic account deletion error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:502
+#: src/components/settings/AccountSettings.tsx:499
 msgid "settings.account.delete.error"
 msgstr "Konto konnte nicht gelöscht werden"
 
 #. Error when unlinking social account fails
 #. Error when unlinking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:440
-#: src/components/settings/AccountSettings.tsx:445
+#: src/components/settings/AccountSettings.tsx:437
+#: src/components/settings/AccountSettings.tsx:442
 msgid "settings.account.socials.disconnectError"
 msgstr "Konto konnte nicht getrennt werden"
 
@@ -1384,7 +1390,7 @@ msgstr "Passwort konnte nicht zurückgesetzt werden. Der Link ist möglicherweis
 
 #. Generic password reset error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:167
+#: src/components/settings/AccountSettings.tsx:164
 msgid "settings.account.password.error"
 msgstr "Zurücksetzungs-E-Mail konnte nicht gesendet werden"
 
@@ -1396,7 +1402,7 @@ msgstr "Passwort konnte nicht gesetzt werden"
 
 #. Generic username update error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:264
+#: src/components/settings/AccountSettings.tsx:261
 msgid "settings.account.username.error"
 msgstr "Benutzername konnte nicht aktualisiert werden"
 
@@ -1587,7 +1593,7 @@ msgstr "Volle Suche, eine Watchlist und ein integrierter Bewerbungstracker, um d
 
 #. Employment type: full-time
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:12
+#: src/components/search/employment-type-modal.tsx:13
 msgid "search.employmentType.fullTime"
 msgstr "Vollzeit"
 
@@ -1645,7 +1651,7 @@ msgstr "Verstanden"
 
 #. Step 3 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:129
+#: src/components/HowWeIndexContent.tsx:127
 msgid "indexing.ingestion.s3.title"
 msgstr "Behutsames Seiten-Parsing."
 
@@ -1666,6 +1672,12 @@ msgstr "Hiring Manager"
 #: app/[lang]/(app)/company/[slug]/company-head.tsx:49
 msgid "breadcrumb.home"
 msgstr "Startseite"
+
+#. Salary period suffix shown after the amount, e.g. '26 USD / hourly'
+#. js-lingui-explicit-id
+#: src/components/SalaryDisplayProvider.tsx:61
+msgid "common.salary.period.hourly"
+msgstr "stündlich"
 
 #. Hourly pay period option
 #. js-lingui-explicit-id
@@ -1702,19 +1714,19 @@ msgstr "Wie oft werden Stellenanzeigen aktualisiert?"
 
 #. TOC: How postings enter the index
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:29
+#: src/components/HowWeIndexContent.tsx:27
 msgid "indexing.toc.ingestion"
 msgstr "Wie Stellenanzeigen in den Index gelangen"
 
 #. Ingestion section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:104
+#: src/components/HowWeIndexContent.tsx:102
 msgid "indexing.ingestion.title"
 msgstr "Wie Stellenanzeigen in den Index gelangen"
 
 #. Indexing page title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:48
+#: src/components/HowWeIndexContent.tsx:46
 msgid "indexing.hero.title"
 msgstr "Wie wir Stellenanzeigen finden und verarbeiten"
 
@@ -1729,10 +1741,10 @@ msgstr "So indexieren wir"
 #. Work mode: hybrid (mixed onsite/remote)
 #. Work mode: hybrid (mixed onsite/remote)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:579
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:587
 #: src/components/search/search-bar.tsx:812
 #: src/components/search/search-toolbar.tsx:260
-#: src/components/search/work-mode-modal.tsx:21
+#: src/components/search/work-mode-modal.tsx:27
 msgid "search.workMode.hybrid"
 msgstr "Hybrid"
 
@@ -1744,19 +1756,19 @@ msgstr "Falls ein Konto mit dieser E-Mail-Adresse existiert, haben wir einen Lin
 
 #. Step 2 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:123
+#: src/components/HowWeIndexContent.tsx:121
 msgid "indexing.ingestion.s2.body"
 msgstr "Falls keine Sitemap existiert, untersuchen wir die Client-Anwendung auf JSON-APIs, die sie aufruft; wenn wir welche finden, nutzen wir diese Endpunkte direkt, um Stellenanzeigen-URLs aufzulisten, ohne das DOM zu scrapen."
 
 #. Opt-out section body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:164
+#: src/components/HowWeIndexContent.tsx:162
 msgid "indexing.optOut.body"
 msgstr "Wenn du unerwartete Aktivitäten unseres Crawlers bemerkst oder es vorziehst, dass deine Karriereseite nicht indexiert wird, schreib uns bitte eine E-Mail und wir werden umgehend antworten."
 
 #. Outreach section body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:206
+#: src/components/HowWeIndexContent.tsx:204
 msgid "indexing.outreach.body"
 msgstr "Wenn du ungewöhnliches Crawler-Verhalten bemerkst, es vorziehst, dass wir deine Inhalte nicht indexieren, oder Vorschläge zur Verbesserung unserer Schutzmaßnahmen hast, kontaktiere uns bitte."
 
@@ -1768,8 +1780,8 @@ msgstr "in {locations}"
 #. Year postings count on company page
 #. Year postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:556
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:568
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:563
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:575
 msgid "company.page.yearCount"
 msgstr "im letzten Jahr"
 
@@ -1801,7 +1813,7 @@ msgstr "In {ancestorName} enthalten"
 
 #. Indexing page eyebrow
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:45
+#: src/components/HowWeIndexContent.tsx:43
 msgid "indexing.hero.eyebrow"
 msgstr "Indexierungsrichtlinie"
 
@@ -1843,7 +1855,7 @@ msgstr "Statt darauf zu warten, dass Unternehmen ihre Stellen auf Drittanbieter-
 
 #. Employment type: internship
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:15
+#: src/components/search/employment-type-modal.tsx:16
 msgid "search.employmentType.internship"
 msgstr "Praktikum"
 
@@ -1936,7 +1948,7 @@ msgstr "Job"
 
 #. TOC: Job data (CC BY-NC 4.0)
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:24
+#: src/components/LicenseContent.tsx:23
 msgid "license.toc.data"
 msgstr "Stellendaten (CC BY-NC 4.0)"
 
@@ -1989,7 +2001,7 @@ msgstr "Job Seek hilft dir dabei, die Unternehmen zu verfolgen, bei denen du arb
 
 #. Indexing page description — company-tracking framing, not 'search engine'
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:51
+#: src/components/HowWeIndexContent.tsx:49
 msgid "indexing.hero.description"
 msgstr "Job Seek ist ein Unternehmens-Tracking-Tool — es überwacht tausende Karriereseiten von Unternehmen, damit Nutzer Watchlists erstellen und Benachrichtigungen über neue Stellen erhalten können. Diese Seite dokumentiert genau, wie sich unser Crawler verhält, welche Kontrollen ihn höflich halten und wie Stellen letztlich in den Index gelangen."
 
@@ -2025,7 +2037,7 @@ msgstr "Job Seek Watchlist mit kuratierten Robotik-Ingenieurstellen in Zürich"
 
 #. License page description
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:38
+#: src/components/LicenseContent.tsx:37
 msgid "license.hero.description"
 msgstr "Die Codebasis von Job Seek ist Open Source unter MIT. Die von uns gesammelten und aufbereiteten Stellendaten stehen unter Creative Commons BY-NC 4.0. Nachfolgend eine verständliche Zusammenfassung — bitte lies die vollständigen Lizenzen für die genauen Bedingungen."
 
@@ -2100,13 +2112,13 @@ msgstr "Letzte Stunde"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:28
+#: src/components/TermsContent.tsx:27
 msgid "terms.hero.lastUpdated"
 msgstr "Zuletzt aktualisiert:"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:28
+#: src/components/PrivacyPolicyContent.tsx:27
 msgid "privacy.hero.lastUpdated"
 msgstr "Zuletzt aktualisiert:"
 
@@ -2122,16 +2134,16 @@ msgstr "Letzte Woche"
 msgid "home.hero.secondaryCta"
 msgstr "Mehr erfahren"
 
-#. Label for seniority/level filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:202
-msgid "search.advanced.level"
-msgstr "Stufe"
-
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:730
 msgid "search.bar.level"
+msgstr "Stufe"
+
+#. Label for seniority/level filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:202
+msgid "search.advanced.level"
 msgstr "Stufe"
 
 #. js-lingui-explicit-id
@@ -2154,13 +2166,13 @@ msgstr "Lizenz"
 
 #. License page title
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:37
+#: src/components/LicenseContent.tsx:36
 msgid "license.hero.title"
 msgstr "Lizenz von Job Seek"
 
 #. License page eyebrow
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:36
+#: src/components/LicenseContent.tsx:35
 msgid "license.hero.eyebrow"
 msgstr "Lizenzierung"
 
@@ -2258,7 +2270,7 @@ msgstr "Abo verwalten"
 
 #. Connected accounts section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:456
+#: src/components/settings/AccountSettings.tsx:453
 msgid "settings.account.socials.description"
 msgstr "Verwalte deine verknüpften Social-Media-Konten."
 
@@ -2359,6 +2371,12 @@ msgstr "Mo"
 msgid "app.schema.feature.monitor"
 msgstr "Karriereseiten von Unternehmen überwachen"
 
+#. Salary period suffix shown after the amount, e.g. '5k EUR / monthly'
+#. js-lingui-explicit-id
+#: src/components/SalaryDisplayProvider.tsx:57
+msgid "common.salary.period.monthly"
+msgstr "monatlich"
+
 #. Monthly pay period option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:369
@@ -2432,19 +2450,19 @@ msgstr "Name"
 
 #. TOC: Need to reach us?
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:33
+#: src/components/HowWeIndexContent.tsx:31
 msgid "indexing.toc.outreach"
 msgstr "Kontakt aufnehmen?"
 
 #. Outreach section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:203
+#: src/components/HowWeIndexContent.tsx:201
 msgid "indexing.outreach.title"
 msgstr "Kontakt aufnehmen?"
 
 #. New email input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:385
+#: src/components/settings/AccountSettings.tsx:382
 msgid "settings.account.email.label"
 msgstr "Neue E-Mail"
 
@@ -2468,7 +2486,7 @@ msgstr "Keine Bewerbungen am {date}"
 
 #. CC right 2
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:84
+#: src/components/LicenseContent.tsx:83
 msgid "license.data.r2"
 msgstr "Keine kommerzielle Weiterverbreitung oder Weiterverkauf ohne Genehmigung."
 
@@ -2496,21 +2514,21 @@ msgstr "Keine Jobs gefunden."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Keine Sprachen entsprechen deiner Suche."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:309
-msgid "company.locationModal.noResults"
-msgstr "Keine Standorte entsprechen Ihrer Suche."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:513
 msgid "search.locationModal.noResults"
 msgstr "Keine Standorte gefunden."
 
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:309
+msgid "company.locationModal.noResults"
+msgstr "Keine Standorte entsprechen Ihrer Suche."
+
 #. No postings found message on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:637
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:644
 msgid "company.page.noResults"
 msgstr "Keine passenden Stellenanzeigen gefunden."
 
@@ -2558,7 +2576,7 @@ msgstr "Noch keine verfolgten Jobs. Speichern Sie Jobs aus den Suchergebnissen, 
 
 #. MIT right 3
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:60
+#: src/components/LicenseContent.tsx:59
 msgid "license.code.r3"
 msgstr "Keine Gewährleistung — Nutzung auf eigenes Risiko."
 
@@ -2638,16 +2656,16 @@ msgstr "Angebot"
 msgid "myJobs.group.offered"
 msgstr "Angebot"
 
-#. Status option in dropdown: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:38
-msgid "myJobs.statusOption.offered"
-msgstr "Angebot"
-
 #. Sankey funnel node: offered
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:43
 msgid "myJobs.funnel.offered"
+msgstr "Angebot"
+
+#. Status option in dropdown: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:38
+msgid "myJobs.statusOption.offered"
 msgstr "Angebot"
 
 #. Cookie banner accept button
@@ -2661,28 +2679,28 @@ msgstr "Ok"
 #. Work mode: onsite (in-office)
 #. Work mode: onsite (in-office)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:577
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:585
 #: src/components/search/search-bar.tsx:810
 #: src/components/search/search-toolbar.tsx:258
-#: src/components/search/work-mode-modal.tsx:20
+#: src/components/search/work-mode-modal.tsx:26
 msgid "search.workMode.onsite"
 msgstr "Vor Ort"
 
 #. Step 4 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:139
+#: src/components/HowWeIndexContent.tsx:137
 msgid "indexing.ingestion.s4.body"
 msgstr "Sobald wir eine einzelne Stellenanzeige abrufen, speichern wir nur die stellenspezifischen Metadaten (Titel, Rollenbeschreibung, Standort, Vergütungshinweise, Stellen-URL und Zeitstempel) sowie extrahierte strukturierte Felder. Wir archivieren keine nicht verwandten Seiteninhalte."
 
 #. Assurance 3 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:79
+#: src/components/HowWeIndexContent.tsx:77
 msgid "indexing.assurances.i3.title"
 msgstr "Eine Seite pro Minute."
 
 #. Username invalid characters hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:287
+#: src/components/settings/AccountSettings.tsx:284
 msgid "settings.account.username.invalidChars"
 msgstr "Nur Kleinbuchstaben, Zahlen und Bindestriche (nicht am Anfang/Ende)"
 
@@ -2705,25 +2723,25 @@ msgstr "Offene Stellen"
 
 #. TOC: Open-source crawlers
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:32
+#: src/components/HowWeIndexContent.tsx:30
 msgid "indexing.toc.oss"
 msgstr "Open-Source-Crawler"
 
 #. Open-source section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:185
+#: src/components/HowWeIndexContent.tsx:183
 msgid "indexing.oss.title"
 msgstr "Open-Source-Crawler"
 
 #. TOC: Opt-out or questions
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:30
+#: src/components/HowWeIndexContent.tsx:28
 msgid "indexing.toc.optOut"
 msgstr "Opt-out oder Fragen"
 
 #. Opt-out section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:161
+#: src/components/HowWeIndexContent.tsx:159
 msgid "indexing.optOut.title"
 msgstr "Opt-out oder Fragen"
 
@@ -2759,43 +2777,43 @@ msgstr "Sonstige"
 
 #. Assurance 2 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:73
+#: src/components/HowWeIndexContent.tsx:71
 msgid "indexing.assurances.i2.body"
 msgstr "Unser Crawler liest <0>robots.txt</0>, befolgt Disallow-Regeln, identifiziert sich über <1>User-Agent</1> und respektiert den W3C-<2>TDM-Reservation</2>-Header — wenn eine Seite Reservation signalisiert, überspringen wir sie."
 
 #. TOC: Our stance on automation
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:31
+#: src/components/HowWeIndexContent.tsx:29
 msgid "indexing.toc.automation"
 msgstr "Unsere Haltung zur Automatisierung"
 
 #. Automation stance title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:174
+#: src/components/HowWeIndexContent.tsx:172
 msgid "indexing.automation.title"
 msgstr "Unsere Haltung zur Automatisierung"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:22
+#: src/components/LicenseContent.tsx:21
 msgid "license.toc.overview"
 msgstr "Überblick"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
+#: src/components/HowWeIndexContent.tsx:25
 msgid "indexing.toc.overview"
 msgstr "Überblick"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:19
+#: src/components/LicenseContent.tsx:18
 msgid "license.toc.ariaLabel"
 msgstr "Seiteninhalt"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
+#: src/components/HowWeIndexContent.tsx:22
 msgid "indexing.toc.ariaLabel"
 msgstr "Seiteninhalt"
 
@@ -2813,7 +2831,7 @@ msgstr "Panel"
 
 #. Employment type: part-time
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:13
+#: src/components/search/employment-type-modal.tsx:14
 msgid "search.employmentType.partTime"
 msgstr "Teilzeit"
 
@@ -2827,13 +2845,13 @@ msgstr "Passwort"
 #. Password section heading
 #. js-lingui-explicit-id
 #: src/components/settings/AccountSettings.tsx:89
-#: src/components/settings/AccountSettings.tsx:177
+#: src/components/settings/AccountSettings.tsx:174
 msgid "settings.account.password.title"
 msgstr "Passwort"
 
 #. Success message after password reset request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:169
+#: src/components/settings/AccountSettings.tsx:166
 msgid "settings.account.password.success"
 msgstr "Link zum Zurücksetzen des Passworts gesendet. Bitte überprüfe dein Postfach. Es kann einige Minuten dauern, bis die E-Mail ankommt."
 
@@ -2887,7 +2905,7 @@ msgstr "Zeitraum"
 
 #. Delete account section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:514
+#: src/components/settings/AccountSettings.tsx:511
 msgid "settings.account.delete.description"
 msgstr "Lösche dein Konto und alle zugehörigen Daten dauerhaft. Diese Aktion kann nicht rückgängig gemacht werden."
 
@@ -2923,7 +2941,7 @@ msgstr "Bitte geben Sie einen Firmennamen oder eine URL ein."
 
 #. Error when email field is empty
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:353
+#: src/components/settings/AccountSettings.tsx:350
 msgid "settings.account.email.required"
 msgstr "Bitte gib eine neue E-Mail-Adresse ein"
 
@@ -3003,7 +3021,7 @@ msgstr "Preise"
 
 #. Privacy policy page eyebrow
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:21
+#: src/components/PrivacyPolicyContent.tsx:20
 msgid "privacy.hero.eyebrow"
 msgstr "Datenschutz"
 
@@ -3015,7 +3033,7 @@ msgstr "Datenschutz"
 
 #. Privacy policy page title
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:22
+#: src/components/PrivacyPolicyContent.tsx:21
 msgid "privacy.hero.title"
 msgstr "Datenschutz bei Job Seek"
 
@@ -3051,43 +3069,43 @@ msgstr "Gemeinfrei"
 
 #. Contact call to action
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:99
+#: src/components/LicenseContent.tsx:98
 msgid "license.contactCta"
 msgstr "Fragen zur Lizenzierung oder kommerziellen Nutzung? Schreib uns eine E-Mail."
 
 #. Terms contact call to action
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:54
+#: src/components/TermsContent.tsx:53
 msgid "terms.contact.description"
 msgstr "Fragen? Schreib uns eine E-Mail."
 
 #. Privacy contact call to action
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:66
+#: src/components/PrivacyPolicyContent.tsx:65
 msgid "privacy.contact.description"
 msgstr "Fragen? Schreib uns eine E-Mail."
 
 #. Link to full CC license
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:88
+#: src/components/LicenseContent.tsx:87
 msgid "license.data.linkLabel"
 msgstr "CC BY-NC 4.0 Lizenz lesen"
 
 #. Link to full MIT license
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:63
+#: src/components/LicenseContent.tsx:62
 msgid "license.code.linkLabel"
 msgstr "Vollständige MIT-Lizenz lesen"
 
 #. Link to full privacy policy text
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:73
+#: src/components/PrivacyPolicyContent.tsx:72
 msgid "privacy.extras.fullPolicyLink"
 msgstr "Vollständige Datenschutzrichtlinie lesen"
 
 #. Link to full terms of service text
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:61
+#: src/components/TermsContent.tsx:60
 msgid "terms.fullTermsLink"
 msgstr "Vollständige Nutzungsbedingungen lesen"
 
@@ -3110,7 +3128,7 @@ msgstr "Halte jede Interview-Runde mit Datum, Art und Notizen fest, damit nichts
 
 #. MIT right 2
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:59
+#: src/components/LicenseContent.tsx:58
 msgid "license.code.r2"
 msgstr "Deine Änderungen weiterverbreiten, solange du den MIT-Hinweis beifügst."
 
@@ -3126,16 +3144,16 @@ msgstr "Deine Änderungen weiterverbreiten, solange du den MIT-Hinweis beifügst
 msgid "location.type.region"
 msgstr "Region"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:319
-msgid "company.locationModal.regionsHeader"
-msgstr "Regionen"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:523
 msgid "search.locationModal.regionsHeader"
+msgstr "Regionen"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:319
+msgid "company.locationModal.regionsHeader"
 msgstr "Regionen"
 
 #. Status group heading: rejected
@@ -3156,16 +3174,16 @@ msgstr "Abgelehnt"
 msgid "myJobs.status.rejected"
 msgstr "Abgelehnt"
 
-#. Status option in dropdown: rejected
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:39
-msgid "myJobs.statusOption.rejected"
-msgstr "Abgelehnt"
-
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
+msgstr "Abgelehnt"
+
+#. Status option in dropdown: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:39
+msgid "myJobs.statusOption.rejected"
 msgstr "Abgelehnt"
 
 #. Footer license summary text
@@ -3179,10 +3197,10 @@ msgstr "Veröffentlicht unter der MIT-Lizenz. Stellendaten sind CC BY-NC 4.0."
 #. Work mode: remote (work-from-home)
 #. Work mode: remote (work-from-home)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:580
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:588
 #: src/components/search/search-bar.tsx:813
 #: src/components/search/search-toolbar.tsx:261
-#: src/components/search/work-mode-modal.tsx:22
+#: src/components/search/work-mode-modal.tsx:28
 msgid "search.workMode.remote"
 msgstr "Remote"
 
@@ -3236,7 +3254,7 @@ msgstr "Erneut senden in {cooldown}s"
 
 #. Reset password button during cooldown with seconds remaining
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:190
+#: src/components/settings/AccountSettings.tsx:187
 msgid "settings.account.password.cooldown"
 msgstr "Erneut senden in {cooldown}s"
 
@@ -3272,13 +3290,13 @@ msgstr "Wird zurückgesetzt…"
 
 #. Assurance 1 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:67
+#: src/components/HowWeIndexContent.tsx:65
 msgid "indexing.assurances.i1.title"
 msgstr "Respektvolles Tempo."
 
 #. Assurance 2 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:71
+#: src/components/HowWeIndexContent.tsx:69
 msgid "indexing.assurances.i2.title"
 msgstr "Robots, Attribution und TDM-Reservation."
 
@@ -3306,16 +3324,16 @@ msgstr "Runde"
 msgid "app.home.request.agent.runIdLabel"
 msgstr "Run-ID"
 
-#. Label for salary filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:225
-msgid "search.advanced.salary"
-msgstr "Gehalt"
-
 #. Salary override section heading
 #. js-lingui-explicit-id
 #: src/components/my-jobs/salary-override.tsx:76
 msgid "myJobs.detail.salary"
+msgstr "Gehalt"
+
+#. Label for salary filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:225
+msgid "search.advanced.salary"
 msgstr "Gehalt"
 
 #. Salary display settings section heading
@@ -3384,27 +3402,27 @@ msgstr "Gespeichert"
 msgid "myJobs.status.saved"
 msgstr "Gespeichert"
 
-#. Status option in dropdown: saved
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:35
-msgid "myJobs.statusOption.saved"
-msgstr "Gespeichert"
-
 #. Sankey funnel node: saved jobs
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:41
 msgid "myJobs.funnel.saved"
 msgstr "Gespeichert"
 
+#. Status option in dropdown: saved
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:35
+msgid "myJobs.statusOption.saved"
+msgstr "Gespeichert"
+
 #. Username save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:323
+#: src/components/settings/AccountSettings.tsx:320
 msgid "settings.account.username.saving"
 msgstr "Speichern..."
 
 #. Email save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:395
+#: src/components/settings/AccountSettings.tsx:392
 msgid "settings.account.email.saving"
 msgstr "Speichern…"
 
@@ -3427,16 +3445,16 @@ msgstr "Suche über tausende Unternehmen hinweg, direkt von ihren Karriereseiten
 msgid "company.page.searchPlaceholder"
 msgstr "Suchen bei {0}..."
 
-#. Placeholder for company search in modal
-#. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:217
-msgid "watchlists.companyModal.searchPlaceholder"
-msgstr "Unternehmen suchen..."
-
 #. Placeholder for company search in watchlist creation
 #. js-lingui-explicit-id
 #: src/components/watchlist/company-selector.tsx:91
 msgid "watchlists.companySelector.placeholder"
+msgstr "Unternehmen suchen..."
+
+#. Placeholder for company search in modal
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-search-modal.tsx:217
+msgid "watchlists.companyModal.searchPlaceholder"
 msgstr "Unternehmen suchen..."
 
 #. Option to search by title keyword in dropdown
@@ -3456,17 +3474,17 @@ msgstr "Durchsuche Jobs bei Tausenden von Unternehmen, direkt von Karriereseiten
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Sprachen suchen…"
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:288
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Standorte suchen…"
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:492
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Standorte suchen..."
+
+#. Placeholder for search input in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:288
+msgid "company.locationModal.searchPlaceholder"
+msgstr "Standorte suchen…"
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3536,7 +3554,7 @@ msgstr "Wähle deine bevorzugte Sprache."
 
 #. Step 4 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:137
+#: src/components/HowWeIndexContent.tsx:135
 msgid "indexing.ingestion.s4.title"
 msgstr "Selektive Speicherung."
 
@@ -3548,15 +3566,9 @@ msgstr "Link senden"
 
 #. Reset password button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:191
+#: src/components/settings/AccountSettings.tsx:188
 msgid "settings.account.password.send"
 msgstr "Link senden"
-
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Wird gesendet..."
 
 #. Resend button while sending
 #. js-lingui-explicit-id
@@ -3564,9 +3576,15 @@ msgstr "Wird gesendet..."
 msgid "auth.verify.resending"
 msgstr "Wird gesendet…"
 
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
+msgstr "Wird gesendet..."
+
 #. Reset password button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:188
+#: src/components/settings/AccountSettings.tsx:185
 msgid "settings.account.password.sending"
 msgstr "Senden…"
 
@@ -3746,7 +3764,7 @@ msgstr "Einfache, transparente Preise. Starte kostenlos und upgrade, wenn du dei
 
 #. Step 1 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:113
+#: src/components/HowWeIndexContent.tsx:111
 msgid "indexing.ingestion.s1.title"
 msgstr "Zuerst die Sitemap."
 
@@ -3932,13 +3950,13 @@ msgstr "Sag uns den Firmennamen und (idealerweise) die URL der Karriereseite. Wi
 
 #. Employment type: temporary
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:16
+#: src/components/search/employment-type-modal.tsx:17
 msgid "search.employmentType.temporary"
 msgstr "Befristet"
 
 #. Terms page eyebrow
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:21
+#: src/components/TermsContent.tsx:20
 msgid "terms.hero.eyebrow"
 msgstr "Nutzungsbedingungen"
 
@@ -3956,7 +3974,7 @@ msgstr "Nutzungsbedingungen"
 
 #. Terms page title
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:22
+#: src/components/TermsContent.tsx:21
 msgid "terms.hero.title"
 msgstr "Nutzungsbedingungen"
 
@@ -4002,19 +4020,19 @@ msgstr "Die Seite, die du suchst, existiert nicht oder wurde verschoben."
 
 #. Provided as-is
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:46
+#: src/components/TermsContent.tsx:45
 msgid "terms.short.r4"
 msgstr "Der Service wird ohne Gewährleistung bereitgestellt."
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:40
+#: src/components/TermsContent.tsx:39
 msgid "terms.short.title"
 msgstr "Die Kurzfassung"
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:40
+#: src/components/PrivacyPolicyContent.tsx:39
 msgid "privacy.short.title"
 msgstr "Die Kurzfassung"
 
@@ -4038,7 +4056,7 @@ msgstr "Diese Seite verwendet Cookies ausschließlich für Authentifizierung und
 
 #. Username is reserved hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:289
+#: src/components/settings/AccountSettings.tsx:286
 msgid "settings.account.username.reserved"
 msgstr "Dieser Benutzername ist reserviert"
 
@@ -4080,7 +4098,7 @@ msgstr "Verfolge deine Pipeline"
 
 #. Open-source section body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:188
+#: src/components/HowWeIndexContent.tsx:186
 msgid "indexing.oss.body"
 msgstr "Transparenz ist uns wichtig, daher ist der Code für unseren Job-Link-Erfassungsdienst und die Extraktionspipeline Open Source."
 
@@ -4122,7 +4140,7 @@ msgstr "In aktiver Entwicklung"
 
 #. Your rights intro
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:57
+#: src/components/PrivacyPolicyContent.tsx:56
 msgid "privacy.rights.intro"
 msgstr "Nach DSGVO kannst du eine Kopie deiner Daten anfordern, sie korrigieren oder löschen lassen, sie exportieren oder der Verarbeitung widersprechen. Löschst du dein Konto, werden alle Daten innerhalb von 30 Tagen gelöscht."
 
@@ -4157,19 +4175,19 @@ msgstr "Job entfernen"
 
 #. Email save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:396
+#: src/components/settings/AccountSettings.tsx:393
 msgid "settings.account.email.save"
 msgstr "E-Mail aktualisieren"
 
 #. Change email section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:376
+#: src/components/settings/AccountSettings.tsx:373
 msgid "settings.account.email.description"
 msgstr "Aktualisiere die mit deinem Konto verknüpfte E-Mail-Adresse."
 
 #. Username save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:324
+#: src/components/settings/AccountSettings.tsx:321
 msgid "settings.account.username.save"
 msgstr "Benutzername aktualisieren"
 
@@ -4210,25 +4228,25 @@ msgstr "Nutzer"
 
 #. Username section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:301
+#: src/components/settings/AccountSettings.tsx:298
 msgid "settings.account.username.title"
 msgstr "Benutzername"
 
 #. Username input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:313
+#: src/components/settings/AccountSettings.tsx:310
 msgid "settings.account.username.label"
 msgstr "Benutzername"
 
 #. Username updated success message
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:276
+#: src/components/settings/AccountSettings.tsx:273
 msgid "settings.account.username.success"
 msgstr "Benutzername aktualisiert."
 
 #. Success message after email change request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:365
+#: src/components/settings/AccountSettings.tsx:362
 msgid "settings.account.email.success"
 msgstr "Bestätigungs-E-Mail gesendet. Bitte überprüfe dein Postfach. Es kann einige Minuten dauern, bis die E-Mail ankommt."
 
@@ -4264,7 +4282,7 @@ msgstr "Stellenanzeige ansehen"
 
 #. Employment type: volunteer
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:17
+#: src/components/search/employment-type-modal.tsx:18
 msgid "search.employmentType.volunteer"
 msgstr "Ehrenamtlich"
 
@@ -4300,7 +4318,7 @@ msgstr "Watchlists"
 
 #. Back to watchlists link
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:344
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:352
 msgid "watchlists.view.back"
 msgstr "Watchlists"
 
@@ -4323,7 +4341,7 @@ msgstr "Watchlists und Bewerbungstracking"
 
 #. What the service does
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:44
+#: src/components/TermsContent.tsx:43
 msgid "terms.short.r2"
 msgstr "Wir aggregieren öffentliche Stellenanzeigen. Wir garantieren nicht, dass sie korrekt oder aktuell sind."
 
@@ -4335,13 +4353,13 @@ msgstr "Wir glauben, dass die Jobsuche von der suchenden Person gesteuert werden
 
 #. Privacy policy page description
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:23
+#: src/components/PrivacyPolicyContent.tsx:22
 msgid "privacy.hero.description"
 msgstr "Wir erheben nur, was wir brauchen, wir verkaufen deine Daten nicht, und du kannst jederzeit alles löschen."
 
 #. No selling
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:44
+#: src/components/PrivacyPolicyContent.tsx:43
 msgid "privacy.short.r2"
 msgstr "Wir verkaufen, vermieten oder teilen deine Daten nicht für Marketingzwecke."
 
@@ -4352,13 +4370,13 @@ msgstr "Wir indexieren Karriereseiten von Unternehmen direkt, nicht Drittanbiete
 
 #. Step 1 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:115
+#: src/components/HowWeIndexContent.tsx:113
 msgid "indexing.ingestion.s1.body"
 msgstr "Wir suchen nach einer Sitemap, die bereits alle Karriere- oder Stellendetailseiten auflistet — idealerweise von <0>robots.txt</0> verlinkt — und verlassen uns darauf, wann immer möglich."
 
 #. Ingestion section description
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:107
+#: src/components/HowWeIndexContent.tsx:105
 msgid "indexing.ingestion.description"
 msgstr "Wir suchen zuerst nach strukturierten Feeds, bevor wir rohes HTML scrapen. Zuerst prüfen wir auf Sitemaps, dann auf clientseitige JSON-APIs, und parsen vollständige Seiten nur, wenn beides nicht existiert."
 
@@ -4382,7 +4400,7 @@ msgstr "Wir haben festgestellt, dass diese Stelle kürzlich hinzugefügt wurde. 
 
 #. Automation stance body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:177
+#: src/components/HowWeIndexContent.tsx:175
 msgid "indexing.automation.body"
 msgstr "Wir lehnen es ab, Einstellungs- oder Jobsuch-Entscheidungen an undurchsichtige Automatisierung zu übergeben — ob auf Arbeitgeber- oder Bewerberseite. Jeder ausgehende Link enthält <0>utm_source=jobseek</0>, damit Recruiter den Traffic erkennen, und wir überprüfen kontinuierlich Nutzungsmuster und setzen Hürden ein, um automatisierte Bewerbungen zu verhindern."
 
@@ -4399,19 +4417,19 @@ msgstr "Wir haben einen Bestätigungslink an <0>{email}</0> gesendet. Klicke auf
 
 #. What we store
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:43
+#: src/components/PrivacyPolicyContent.tsx:42
 msgid "privacy.short.r1"
 msgstr "Wir speichern deinen Namen, deine E-Mail und dein Profilbild von deiner OAuth-Anmeldung sowie die Daten, die du in der App erstellst."
 
 #. Info box about sitemaps
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:151
+#: src/components/HowWeIndexContent.tsx:149
 msgid "indexing.sitemapNote"
 msgstr "Wir empfehlen ausdrücklich, eine leicht auffindbare Sitemap für deinen Karrierebereich zu veröffentlichen. Ohne eine solche senden wir regelmäßig leichtgewichtige <0>HEAD</0>-Anfragen an zuvor entdeckte Stellen-URLs, um zu prüfen, ob sie noch aktiv sind, was unnötigen Traffic verursacht."
 
 #. Third parties
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:45
+#: src/components/PrivacyPolicyContent.tsx:44
 msgid "privacy.short.r3"
 msgstr "Wir nutzen eine Handvoll Drittanbieter für Anmeldung, Hosting und Speicherung — sonst nichts."
 
@@ -4478,8 +4496,14 @@ msgstr "Arbeitsmodus"
 
 #. Title for the work-mode (onsite/hybrid/remote) selection modal
 #. js-lingui-explicit-id
-#: src/components/search/work-mode-modal.tsx:53
+#: src/components/search/work-mode-modal.tsx:82
 msgid "search.workModeModal.title"
+msgstr "Arbeitsweise"
+
+#. Section header for work-mode (onsite/hybrid/remote) suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:800
+msgid "search.bar.workMode"
 msgstr "Arbeitsweise"
 
 #. Label for work-mode (onsite/hybrid/remote) filter in advanced search
@@ -4488,11 +4512,11 @@ msgstr "Arbeitsweise"
 msgid "search.advanced.workMode"
 msgstr "Arbeitsweise"
 
-#. Section header for work-mode (onsite/hybrid/remote) suggestions in search bar
+#. Salary period suffix shown after the amount, e.g. '50k EUR / yearly'
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:800
-msgid "search.bar.workMode"
-msgstr "Arbeitsweise"
+#: src/components/SalaryDisplayProvider.tsx:55
+msgid "common.salary.period.yearly"
+msgstr "jährlich"
 
 #. Yearly pay period option
 #. js-lingui-explicit-id
@@ -4539,13 +4563,13 @@ msgstr "Gestern"
 
 #. Account deletion
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:47
+#: src/components/TermsContent.tsx:46
 msgid "terms.short.r5"
 msgstr "Du kannst dein Konto jederzeit löschen."
 
 #. CC right 3
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:85
+#: src/components/LicenseContent.tsx:84
 msgid "license.data.r3"
 msgstr "Du kannst die Daten für Forschung oder persönliche Dashboards remixen/transformieren."
 
@@ -4557,7 +4581,7 @@ msgstr "Du kannst das beschleunigen, indem du deinen KI-Agenten bittest, es übe
 
 #. MIT license summary
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:53
+#: src/components/LicenseContent.tsx:52
 msgid "license.code.summary"
 msgstr "Du kannst den Code in persönlichen oder kommerziellen Produkten verwenden, ändern und weiterverbreiten, solange du den Copyright- und Lizenzhinweis beifügst."
 
@@ -4569,13 +4593,13 @@ msgstr "Das könnte Sie auch interessieren"
 
 #. CC license summary
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:74
+#: src/components/LicenseContent.tsx:73
 msgid "license.data.summary"
 msgstr "Du darfst den Stellendatensatz mit Quellenangabe für nicht-kommerzielle Zwecke nutzen. Kommerzielle Nutzung erfordert vorherige schriftliche Zustimmung."
 
 #. Age requirement
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:43
+#: src/components/TermsContent.tsx:42
 msgid "terms.short.r1"
 msgstr "Du musst mindestens 16 Jahre alt sein, um Job Seek zu nutzen."
 
@@ -4637,12 +4661,12 @@ msgstr "Dein Passwort wurde zurückgesetzt. Du kannst dich jetzt mit deinem neue
 
 #. Your rights section title
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:54
+#: src/components/PrivacyPolicyContent.tsx:53
 msgid "privacy.rights.title"
 msgstr "Deine Rechte"
 
 #. Username section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:304
+#: src/components/settings/AccountSettings.tsx:301
 msgid "settings.account.username.description"
 msgstr "Dein eindeutiger Name für deine öffentliche Profil-URL."

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -26,7 +26,7 @@ msgstr ""
 
 #. CC right 1
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:80
+#: src/components/LicenseContent.tsx:79
 msgid "license.data.r1"
 msgstr "“Viktor Shcherbakov, Collection of Job Postings” with a link to the source."
 
@@ -41,12 +41,12 @@ msgstr "“Viktor Shcherbakov, Collection of Job Postings” with a link to the 
 #. js-lingui-explicit-id
 #: src/components/Footer.tsx:41
 #: src/components/Footer.tsx:47
-#: src/components/HowWeIndexContent.tsx:196
-#: src/components/LicenseContent.tsx:64
-#: src/components/LicenseContent.tsx:89
-#: src/components/PrivacyPolicyContent.tsx:74
+#: src/components/HowWeIndexContent.tsx:194
+#: src/components/LicenseContent.tsx:63
+#: src/components/LicenseContent.tsx:88
+#: src/components/PrivacyPolicyContent.tsx:73
 #: src/components/PublicDomainArt.tsx:115
-#: src/components/TermsContent.tsx:62
+#: src/components/TermsContent.tsx:61
 msgid "common.a11y.opensInNewTab"
 msgstr "(opens in new tab)"
 
@@ -212,8 +212,8 @@ msgstr "Account menu"
 #. Active postings count on company page
 #. Active postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:554
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:564
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:561
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:571
 msgid "company.page.active"
 msgstr "active"
 
@@ -239,7 +239,7 @@ msgstr "Add companies"
 
 #. Link to add a description to the watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:438
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:446
 msgid "watchlists.view.addDescription"
 msgstr "Add description"
 
@@ -293,7 +293,7 @@ msgstr "All {totalCountries} countries loaded"
 
 #. Encryption
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:47
+#: src/components/PrivacyPolicyContent.tsx:46
 msgid "privacy.short.r5"
 msgstr "All data is encrypted in transit and at rest."
 
@@ -303,16 +303,16 @@ msgstr "All data is encrypted in transit and at rest."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "All industries"
 
-#. All languages option
-#. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:253
-msgid "settings.general.jobLanguages.all"
-msgstr "All languages"
-
 #. Title for the all-languages modal in settings
 #. js-lingui-explicit-id
 #: src/components/settings/JobLanguageModal.tsx:56
 msgid "settings.jobLanguages.modal.title"
+msgstr "All languages"
+
+#. All languages option
+#. js-lingui-explicit-id
+#: src/components/settings/GeneralSettings.tsx:253
+msgid "settings.general.jobLanguages.all"
 msgstr "All languages"
 
 #. Title for the all-locations modal on company page
@@ -335,7 +335,7 @@ msgstr "Already have an account? <0>Sign in</0>"
 
 #. Username is taken
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:295
+#: src/components/settings/AccountSettings.tsx:292
 msgid "settings.account.username.taken"
 msgstr "Already taken"
 
@@ -352,19 +352,19 @@ msgstr "Any"
 
 #. Toggle to show jobs from all companies
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:466
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:474
 msgid "watchlists.view.anyCompany"
 msgstr "Any company"
 
 #. MIT license section title
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:50
+#: src/components/LicenseContent.tsx:49
 msgid "license.code.title"
 msgstr "Application code (MIT License)"
 
 #. TOC: Application code (MIT)
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:23
+#: src/components/LicenseContent.tsx:22
 msgid "license.toc.code"
 msgstr "Application code (MIT)"
 
@@ -422,16 +422,16 @@ msgstr "Applied"
 msgid "myJobs.status.applied"
 msgstr "Applied"
 
-#. Status option in dropdown: applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:36
-msgid "myJobs.statusOption.applied"
-msgstr "Applied"
-
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
+msgstr "Applied"
+
+#. Status option in dropdown: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:36
+msgid "myJobs.statusOption.applied"
 msgstr "Applied"
 
 #. Apply salary filter
@@ -460,19 +460,19 @@ msgstr "Apr"
 
 #. Step 3 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:131
+#: src/components/HowWeIndexContent.tsx:129
 msgid "indexing.ingestion.s3.body"
 msgstr "As a last resort we parse the careers pages themselves, preferring newest-first sorts and stopping once previously indexed roles reappear instead of crawling every page."
 
 #. Username too short hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:283
+#: src/components/settings/AccountSettings.tsx:280
 msgid "settings.account.username.tooShort"
 msgstr "At least 3 characters"
 
 #. Username too long hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:285
+#: src/components/settings/AccountSettings.tsx:282
 msgid "settings.account.username.tooLong"
 msgstr "At most 30 characters"
 
@@ -484,20 +484,20 @@ msgstr "Aug"
 
 #. Username is available
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:293
+#: src/components/settings/AccountSettings.tsx:290
 msgid "settings.account.username.available"
 msgstr "Available"
-
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Back to sign in"
 
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Back to sign in"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Back to sign in"
 
 #. Link back to sign-in from forgot password
@@ -544,18 +544,18 @@ msgstr "Blog"
 msgid "blog.post.backToIndex"
 msgstr "Blog"
 
+#. Footer link to /blog index page
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:52
+msgid "common.footer.blog"
+msgstr "Blog"
+
 #. Nav link: Blog
 #. Nav link: Blog
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:74
 #: src/components/MobileMenu.tsx:98
 msgid "common.nav.blog"
-msgstr "Blog"
-
-#. Footer link to /blog index page
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
-msgid "common.footer.blog"
 msgstr "Blog"
 
 #. Subtitle on the sign-in CTA card shown to anonymous users at the end of the similar-companies strip
@@ -566,7 +566,7 @@ msgstr "Browse every peer company"
 
 #. Link text for browsing the repo
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:192
+#: src/components/HowWeIndexContent.tsx:190
 msgid "indexing.oss.browseRepo"
 msgstr "Browse the repository at"
 
@@ -590,7 +590,7 @@ msgstr "Built by job seekers, for job seekers"
 
 #. Terms page description
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:23
+#: src/components/TermsContent.tsx:22
 msgid "terms.hero.description"
 msgstr "By using Job Seek you agree to these terms. Here’s a plain-language overview."
 
@@ -607,7 +607,7 @@ msgstr "Cancel"
 
 #. Cancel delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:535
+#: src/components/settings/AccountSettings.tsx:532
 msgid "settings.account.delete.cancel"
 msgstr "Cancel"
 
@@ -619,7 +619,7 @@ msgstr "change"
 
 #. Change email section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:373
+#: src/components/settings/AccountSettings.tsx:370
 msgid "settings.account.email.title"
 msgstr "Change email"
 
@@ -637,7 +637,7 @@ msgstr "Change language"
 
 #. Password section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:180
+#: src/components/settings/AccountSettings.tsx:177
 msgid "settings.account.password.description"
 msgstr "Change your password via a secure email link."
 
@@ -647,21 +647,21 @@ msgstr "Change your password via a secure email link."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Change..."
 
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "Check your email"
-
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
 msgstr "Check your email"
 
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
+msgstr "Check your email"
+
 #. Checking username availability
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:291
+#: src/components/settings/AccountSettings.tsx:288
 msgid "settings.account.username.checking"
 msgstr "Checking availability..."
 
@@ -711,14 +711,14 @@ msgstr "Clear"
 
 #. Button to remove all companies from watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:484
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:492
 msgid "watchlists.view.clearAllCompanies"
 msgstr "Clear all"
 
 #. Button to clear all active search filters
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:616
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:624
 #: src/components/search/search-toolbar.tsx:337
 msgid "search.filters.clearAll"
 msgstr "Clear all"
@@ -731,19 +731,19 @@ msgstr "Clear all"
 
 #. Tooltip for clicking to edit watchlist description
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:426
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:434
 msgid "watchlists.view.editDescription"
 msgstr "Click to edit description"
 
 #. Tooltip for clicking to edit watchlist title
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:376
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:384
 msgid "watchlists.view.editTitle"
 msgstr "Click to rename"
 
 #. Step 2 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:121
+#: src/components/HowWeIndexContent.tsx:119
 msgid "indexing.ingestion.s2.title"
 msgstr "Client APIs second."
 
@@ -755,7 +755,7 @@ msgstr "Close menu"
 
 #. Label for inactive/closed job postings on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:656
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:663
 msgid "company.page.closed"
 msgstr "Closed"
 
@@ -773,7 +773,7 @@ msgstr "Coding"
 
 #. CC license section title
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:71
+#: src/components/LicenseContent.tsx:70
 msgid "license.data.title"
 msgstr "Collection of job postings (CC BY-NC 4.0)"
 
@@ -809,7 +809,7 @@ msgstr "Companies Tracked"
 
 #. Button to open company search modal
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:455
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:463
 msgid "watchlists.view.addCompany"
 msgstr "Company"
 
@@ -851,7 +851,7 @@ msgstr "Company-tracking tool for targeted job seekers — watchlists, email ale
 
 #. Confirm delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:528
+#: src/components/settings/AccountSettings.tsx:525
 msgid "settings.account.delete.confirm"
 msgstr "Confirm deletion"
 
@@ -863,25 +863,25 @@ msgstr "Confirm password"
 
 #. Connect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:478
+#: src/components/settings/AccountSettings.tsx:475
 msgid "settings.account.socials.connect"
 msgstr "Connect"
 
 #. Connected accounts section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:453
+#: src/components/settings/AccountSettings.tsx:450
 msgid "settings.account.socials.title"
 msgstr "Connected accounts"
 
 #. TOC: Contact
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:25
+#: src/components/LicenseContent.tsx:24
 msgid "license.toc.contact"
 msgstr "Contact"
 
 #. Contact section title
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:96
+#: src/components/LicenseContent.tsx:95
 msgid "license.contact.title"
 msgstr "Contact"
 
@@ -893,13 +893,13 @@ msgstr "Contact"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
+#: src/components/LicenseContent.tsx:17
 msgid "license.toc.title"
 msgstr "Contents"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
+#: src/components/HowWeIndexContent.tsx:21
 msgid "indexing.toc.title"
 msgstr "Contents"
 
@@ -929,13 +929,13 @@ msgstr "Continue with LinkedIn"
 
 #. Employment type: contract
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:14
+#: src/components/search/employment-type-modal.tsx:15
 msgid "search.employmentType.contract"
 msgstr "Contract"
 
 #. Cookies
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:46
+#: src/components/PrivacyPolicyContent.tsx:45
 msgid "privacy.short.r4"
 msgstr "Cookies are session-only — no ads, no tracking."
 
@@ -947,7 +947,7 @@ msgstr "Copied"
 
 #. MIT right 1
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:58
+#: src/components/LicenseContent.tsx:57
 msgid "license.code.r1"
 msgstr "Copy and modify the code for any purpose, including commercial products."
 
@@ -985,13 +985,13 @@ msgstr "Crawler source code"
 
 #. TOC: Crawling assurances
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:28
+#: src/components/HowWeIndexContent.tsx:26
 msgid "indexing.toc.assurances"
 msgstr "Crawling assurances"
 
 #. Assurances section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:63
+#: src/components/HowWeIndexContent.tsx:61
 msgid "indexing.assurances.title"
 msgstr "Crawling assurances"
 
@@ -1055,6 +1055,12 @@ msgstr "Currency"
 msgid "settings.billing.currentPlan"
 msgstr "Current"
 
+#. Salary period suffix shown after the amount, e.g. '300 EUR / daily'
+#. js-lingui-explicit-id
+#: src/components/SalaryDisplayProvider.tsx:59
+msgid "common.salary.period.daily"
+msgstr "daily"
+
 #. Daily pay period option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:372
@@ -1111,13 +1117,13 @@ msgstr "Delete"
 
 #. Delete account section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:511
+#: src/components/settings/AccountSettings.tsx:508
 msgid "settings.account.delete.title"
 msgstr "Delete account"
 
 #. Delete account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:521
+#: src/components/settings/AccountSettings.tsx:518
 msgid "settings.account.delete.button"
 msgstr "Delete my account"
 
@@ -1129,13 +1135,13 @@ msgstr "Delete watchlist?"
 
 #. Delete button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:527
+#: src/components/settings/AccountSettings.tsx:524
 msgid "settings.account.delete.deleting"
 msgstr "Deleting..."
 
 #. Placeholder for watchlist description textarea
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:418
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:426
 msgid "watchlists.view.descriptionPlaceholder"
 msgstr "Describe this watchlist..."
 
@@ -1171,7 +1177,7 @@ msgstr "Disable alerts"
 
 #. Disconnect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:477
+#: src/components/settings/AccountSettings.tsx:474
 msgid "settings.account.socials.disconnect"
 msgstr "Disconnect"
 
@@ -1194,7 +1200,7 @@ msgstr "Don't have an account? <0>Sign up</0>"
 
 #. No scraping
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:45
+#: src/components/TermsContent.tsx:44
 msgid "terms.short.r3"
 msgstr "Don’t scrape the service, submit automated applications, or abuse the platform."
 
@@ -1256,7 +1262,7 @@ msgstr "Email verified"
 
 #. Title for the employment type selection modal
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:48
+#: src/components/search/employment-type-modal.tsx:74
 msgid "search.employmentTypeModal.title"
 msgstr "Employment type"
 
@@ -1280,7 +1286,7 @@ msgstr "Enter your new password below."
 
 #. Assurance 3 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:80
+#: src/components/HowWeIndexContent.tsx:78
 msgid "indexing.assurances.i3.body"
 msgstr "Even after discovery we retrieve job detail pages at a strict limit of one request per site per minute."
 
@@ -1292,7 +1298,7 @@ msgstr "Every filter a job seeker actually needs"
 
 #. Assurance 1 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:68
+#: src/components/HowWeIndexContent.tsx:66
 msgid "indexing.assurances.i1.body"
 msgstr "Every retry window uses exponential backoff so we never hammer an origin, and we bail if a host keeps timing out."
 
@@ -1315,16 +1321,16 @@ msgstr "Everything in Free"
 msgid "faq.description"
 msgstr "Everything you need to know about Job Seek. Can't find what you're looking for? Email us at <0>{0}</0>."
 
-#. Label for experience filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:231
-msgid "search.advanced.experience"
-msgstr "Experience"
-
 #. Title for experience filter modal
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:186
 msgid "search.experienceModal.title"
+msgstr "Experience"
+
+#. Label for experience filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:231
+msgid "search.advanced.experience"
 msgstr "Experience"
 
 #. Breadcrumb label for the Explore page
@@ -1346,27 +1352,27 @@ msgstr "Explore Jobs"
 
 #. Generic email change error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:363
+#: src/components/settings/AccountSettings.tsx:360
 msgid "settings.account.email.error"
 msgstr "Failed to change email"
 
 #. Error when linking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:429
+#: src/components/settings/AccountSettings.tsx:426
 msgid "settings.account.socials.connectError"
 msgstr "Failed to connect account"
 
 #. Generic account deletion error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:502
+#: src/components/settings/AccountSettings.tsx:499
 msgid "settings.account.delete.error"
 msgstr "Failed to delete account"
 
 #. Error when unlinking social account fails
 #. Error when unlinking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:440
-#: src/components/settings/AccountSettings.tsx:445
+#: src/components/settings/AccountSettings.tsx:437
+#: src/components/settings/AccountSettings.tsx:442
 msgid "settings.account.socials.disconnectError"
 msgstr "Failed to disconnect account"
 
@@ -1384,7 +1390,7 @@ msgstr "Failed to reset password. The link may have expired."
 
 #. Generic password reset error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:167
+#: src/components/settings/AccountSettings.tsx:164
 msgid "settings.account.password.error"
 msgstr "Failed to send reset email"
 
@@ -1396,7 +1402,7 @@ msgstr "Failed to set password"
 
 #. Generic username update error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:264
+#: src/components/settings/AccountSettings.tsx:261
 msgid "settings.account.username.error"
 msgstr "Failed to update username"
 
@@ -1587,7 +1593,7 @@ msgstr "Full search, one watchlist, and a built-in application tracker to manage
 
 #. Employment type: full-time
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:12
+#: src/components/search/employment-type-modal.tsx:13
 msgid "search.employmentType.fullTime"
 msgstr "Full-time"
 
@@ -1645,7 +1651,7 @@ msgstr "Got it"
 
 #. Step 3 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:129
+#: src/components/HowWeIndexContent.tsx:127
 msgid "indexing.ingestion.s3.title"
 msgstr "Graceful page parsing."
 
@@ -1666,6 +1672,12 @@ msgstr "Hiring Manager"
 #: app/[lang]/(app)/company/[slug]/company-head.tsx:49
 msgid "breadcrumb.home"
 msgstr "Home"
+
+#. Salary period suffix shown after the amount, e.g. '26 USD / hourly'
+#. js-lingui-explicit-id
+#: src/components/SalaryDisplayProvider.tsx:61
+msgid "common.salary.period.hourly"
+msgstr "hourly"
 
 #. Hourly pay period option
 #. js-lingui-explicit-id
@@ -1702,19 +1714,19 @@ msgstr "How often are job listings updated?"
 
 #. TOC: How postings enter the index
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:29
+#: src/components/HowWeIndexContent.tsx:27
 msgid "indexing.toc.ingestion"
 msgstr "How postings enter the index"
 
 #. Ingestion section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:104
+#: src/components/HowWeIndexContent.tsx:102
 msgid "indexing.ingestion.title"
 msgstr "How postings enter the index"
 
 #. Indexing page title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:48
+#: src/components/HowWeIndexContent.tsx:46
 msgid "indexing.hero.title"
 msgstr "How we find and process job postings"
 
@@ -1729,10 +1741,10 @@ msgstr "How We Index"
 #. Work mode: hybrid (mixed onsite/remote)
 #. Work mode: hybrid (mixed onsite/remote)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:579
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:587
 #: src/components/search/search-bar.tsx:812
 #: src/components/search/search-toolbar.tsx:260
-#: src/components/search/work-mode-modal.tsx:21
+#: src/components/search/work-mode-modal.tsx:27
 msgid "search.workMode.hybrid"
 msgstr "Hybrid"
 
@@ -1744,19 +1756,19 @@ msgstr "If an account exists for that email, we sent a password reset link."
 
 #. Step 2 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:123
+#: src/components/HowWeIndexContent.tsx:121
 msgid "indexing.ingestion.s2.body"
 msgstr "If no sitemap exists we inspect the client application for JSON APIs it calls; when found we hit those endpoints directly to enumerate posting URLs without scraping the DOM."
 
 #. Opt-out section body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:164
+#: src/components/HowWeIndexContent.tsx:162
 msgid "indexing.optOut.body"
 msgstr "If you notice unexpected activity from our crawler or prefer that your careers site not be indexed, please email us and we will respond promptly."
 
 #. Outreach section body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:206
+#: src/components/HowWeIndexContent.tsx:204
 msgid "indexing.outreach.body"
 msgstr "If you notice unusual crawler behaviour, prefer that we do not index your content, or have suggestions on how to improve our safeguards, please reach out."
 
@@ -1768,8 +1780,8 @@ msgstr "in {locations}"
 #. Year postings count on company page
 #. Year postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:556
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:568
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:563
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:575
 msgid "company.page.yearCount"
 msgstr "in the last year"
 
@@ -1801,7 +1813,7 @@ msgstr "Included in {ancestorName}"
 
 #. Indexing page eyebrow
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:45
+#: src/components/HowWeIndexContent.tsx:43
 msgid "indexing.hero.eyebrow"
 msgstr "Indexing policy"
 
@@ -1843,7 +1855,7 @@ msgstr "Instead of waiting for companies to push roles to third-party job boards
 
 #. Employment type: internship
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:15
+#: src/components/search/employment-type-modal.tsx:16
 msgid "search.employmentType.internship"
 msgstr "Internship"
 
@@ -1936,7 +1948,7 @@ msgstr "job"
 
 #. TOC: Job data (CC BY-NC 4.0)
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:24
+#: src/components/LicenseContent.tsx:23
 msgid "license.toc.data"
 msgstr "Job data (CC BY-NC 4.0)"
 
@@ -1989,7 +2001,7 @@ msgstr "Job Seek helps you track the companies you want to work at — watchlist
 
 #. Indexing page description — company-tracking framing, not 'search engine'
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:51
+#: src/components/HowWeIndexContent.tsx:49
 msgid "indexing.hero.description"
 msgstr "Job Seek is a company-tracking tool — it monitors thousands of company career pages so users can build watchlists and get alerts on new postings. This page documents exactly how our crawler behaves, the controls that keep it polite, and how jobs ultimately land in the index."
 
@@ -2025,7 +2037,7 @@ msgstr "Job Seek watchlist showing curated robotics engineering roles in Zurich"
 
 #. License page description
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:38
+#: src/components/LicenseContent.tsx:37
 msgid "license.hero.description"
 msgstr "Job Seek's codebase is open source under MIT. The job data we collect and enrich is Creative Commons BY-NC 4.0. Below is the plain-language summary — please read the full licenses for exact terms."
 
@@ -2100,13 +2112,13 @@ msgstr "Last hour"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:28
+#: src/components/TermsContent.tsx:27
 msgid "terms.hero.lastUpdated"
 msgstr "Last updated:"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:28
+#: src/components/PrivacyPolicyContent.tsx:27
 msgid "privacy.hero.lastUpdated"
 msgstr "Last updated:"
 
@@ -2122,16 +2134,16 @@ msgstr "Last week"
 msgid "home.hero.secondaryCta"
 msgstr "Learn more"
 
-#. Label for seniority/level filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:202
-msgid "search.advanced.level"
-msgstr "Level"
-
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:730
 msgid "search.bar.level"
+msgstr "Level"
+
+#. Label for seniority/level filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:202
+msgid "search.advanced.level"
 msgstr "Level"
 
 #. js-lingui-explicit-id
@@ -2154,13 +2166,13 @@ msgstr "License"
 
 #. License page title
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:37
+#: src/components/LicenseContent.tsx:36
 msgid "license.hero.title"
 msgstr "License of Job Seek"
 
 #. License page eyebrow
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:36
+#: src/components/LicenseContent.tsx:35
 msgid "license.hero.eyebrow"
 msgstr "Licensing"
 
@@ -2258,7 +2270,7 @@ msgstr "Manage subscription"
 
 #. Connected accounts section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:456
+#: src/components/settings/AccountSettings.tsx:453
 msgid "settings.account.socials.description"
 msgstr "Manage your linked social accounts."
 
@@ -2359,6 +2371,12 @@ msgstr "Mon"
 msgid "app.schema.feature.monitor"
 msgstr "Monitor company career pages"
 
+#. Salary period suffix shown after the amount, e.g. '5k EUR / monthly'
+#. js-lingui-explicit-id
+#: src/components/SalaryDisplayProvider.tsx:57
+msgid "common.salary.period.monthly"
+msgstr "monthly"
+
 #. Monthly pay period option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:369
@@ -2432,19 +2450,19 @@ msgstr "Name"
 
 #. TOC: Need to reach us?
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:33
+#: src/components/HowWeIndexContent.tsx:31
 msgid "indexing.toc.outreach"
 msgstr "Need to reach us?"
 
 #. Outreach section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:203
+#: src/components/HowWeIndexContent.tsx:201
 msgid "indexing.outreach.title"
 msgstr "Need to reach us?"
 
 #. New email input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:385
+#: src/components/settings/AccountSettings.tsx:382
 msgid "settings.account.email.label"
 msgstr "New email"
 
@@ -2468,7 +2486,7 @@ msgstr "No applications on {date}"
 
 #. CC right 2
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:84
+#: src/components/LicenseContent.tsx:83
 msgid "license.data.r2"
 msgstr "No commercial redistribution or resale without permission."
 
@@ -2496,21 +2514,21 @@ msgstr "No jobs found."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "No languages match your search."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:309
-msgid "company.locationModal.noResults"
-msgstr "No locations match your search."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:513
 msgid "search.locationModal.noResults"
 msgstr "No locations match your search."
 
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:309
+msgid "company.locationModal.noResults"
+msgstr "No locations match your search."
+
 #. No postings found message on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:637
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:644
 msgid "company.page.noResults"
 msgstr "No matching postings found."
 
@@ -2558,7 +2576,7 @@ msgstr "No tracked jobs yet. Save jobs from search results to start tracking you
 
 #. MIT right 3
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:60
+#: src/components/LicenseContent.tsx:59
 msgid "license.code.r3"
 msgstr "No warranty — use at your own risk."
 
@@ -2638,16 +2656,16 @@ msgstr "Offer"
 msgid "myJobs.group.offered"
 msgstr "Offered"
 
-#. Status option in dropdown: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:38
-msgid "myJobs.statusOption.offered"
-msgstr "Offered"
-
 #. Sankey funnel node: offered
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:43
 msgid "myJobs.funnel.offered"
+msgstr "Offered"
+
+#. Status option in dropdown: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:38
+msgid "myJobs.statusOption.offered"
 msgstr "Offered"
 
 #. Cookie banner accept button
@@ -2661,28 +2679,28 @@ msgstr "Ok"
 #. Work mode: onsite (in-office)
 #. Work mode: onsite (in-office)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:577
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:585
 #: src/components/search/search-bar.tsx:810
 #: src/components/search/search-toolbar.tsx:258
-#: src/components/search/work-mode-modal.tsx:20
+#: src/components/search/work-mode-modal.tsx:26
 msgid "search.workMode.onsite"
 msgstr "On-site"
 
 #. Step 4 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:139
+#: src/components/HowWeIndexContent.tsx:137
 msgid "indexing.ingestion.s4.body"
 msgstr "Once we fetch an individual posting we store only the job-specific metadata (title, role description, location, compensation notes, posting URL, and timestamps) plus extracted structured fields. We do not archive unrelated site content."
 
 #. Assurance 3 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:79
+#: src/components/HowWeIndexContent.tsx:77
 msgid "indexing.assurances.i3.title"
 msgstr "One page per minute."
 
 #. Username invalid characters hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:287
+#: src/components/settings/AccountSettings.tsx:284
 msgid "settings.account.username.invalidChars"
 msgstr "Only lowercase letters, numbers, and hyphens (cannot start/end with hyphen)"
 
@@ -2705,25 +2723,25 @@ msgstr "Open positions"
 
 #. TOC: Open-source crawlers
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:32
+#: src/components/HowWeIndexContent.tsx:30
 msgid "indexing.toc.oss"
 msgstr "Open-source crawlers"
 
 #. Open-source section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:185
+#: src/components/HowWeIndexContent.tsx:183
 msgid "indexing.oss.title"
 msgstr "Open-source crawlers"
 
 #. TOC: Opt-out or questions
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:30
+#: src/components/HowWeIndexContent.tsx:28
 msgid "indexing.toc.optOut"
 msgstr "Opt-out or questions"
 
 #. Opt-out section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:161
+#: src/components/HowWeIndexContent.tsx:159
 msgid "indexing.optOut.title"
 msgstr "Opt-out or questions"
 
@@ -2759,43 +2777,43 @@ msgstr "Other"
 
 #. Assurance 2 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:73
+#: src/components/HowWeIndexContent.tsx:71
 msgid "indexing.assurances.i2.body"
 msgstr "Our crawler reads <0>robots.txt</0>, honours disallow rules, identifies itself via <1>User-Agent</1>, and respects the W3C <2>TDM-Reservation</2> header—if a page signals reservation, we skip it."
 
 #. TOC: Our stance on automation
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:31
+#: src/components/HowWeIndexContent.tsx:29
 msgid "indexing.toc.automation"
 msgstr "Our stance on automation"
 
 #. Automation stance title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:174
+#: src/components/HowWeIndexContent.tsx:172
 msgid "indexing.automation.title"
 msgstr "Our stance on automation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:22
+#: src/components/LicenseContent.tsx:21
 msgid "license.toc.overview"
 msgstr "Overview"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
+#: src/components/HowWeIndexContent.tsx:25
 msgid "indexing.toc.overview"
 msgstr "Overview"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:19
+#: src/components/LicenseContent.tsx:18
 msgid "license.toc.ariaLabel"
 msgstr "Page contents"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
+#: src/components/HowWeIndexContent.tsx:22
 msgid "indexing.toc.ariaLabel"
 msgstr "Page contents"
 
@@ -2813,7 +2831,7 @@ msgstr "Panel"
 
 #. Employment type: part-time
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:13
+#: src/components/search/employment-type-modal.tsx:14
 msgid "search.employmentType.partTime"
 msgstr "Part-time"
 
@@ -2827,13 +2845,13 @@ msgstr "Password"
 #. Password section heading
 #. js-lingui-explicit-id
 #: src/components/settings/AccountSettings.tsx:89
-#: src/components/settings/AccountSettings.tsx:177
+#: src/components/settings/AccountSettings.tsx:174
 msgid "settings.account.password.title"
 msgstr "Password"
 
 #. Success message after password reset request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:169
+#: src/components/settings/AccountSettings.tsx:166
 msgid "settings.account.password.success"
 msgstr "Password reset link sent. Please check your inbox. It may take a few minutes to arrive."
 
@@ -2887,7 +2905,7 @@ msgstr "Period"
 
 #. Delete account section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:514
+#: src/components/settings/AccountSettings.tsx:511
 msgid "settings.account.delete.description"
 msgstr "Permanently delete your account and all associated data. This action cannot be undone."
 
@@ -2923,7 +2941,7 @@ msgstr "Please enter a company name or URL."
 
 #. Error when email field is empty
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:353
+#: src/components/settings/AccountSettings.tsx:350
 msgid "settings.account.email.required"
 msgstr "Please enter a new email address"
 
@@ -3003,7 +3021,7 @@ msgstr "Pricing"
 
 #. Privacy policy page eyebrow
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:21
+#: src/components/PrivacyPolicyContent.tsx:20
 msgid "privacy.hero.eyebrow"
 msgstr "Privacy"
 
@@ -3015,7 +3033,7 @@ msgstr "Privacy"
 
 #. Privacy policy page title
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:22
+#: src/components/PrivacyPolicyContent.tsx:21
 msgid "privacy.hero.title"
 msgstr "Privacy at Job Seek"
 
@@ -3051,43 +3069,43 @@ msgstr "Public Domain"
 
 #. Contact call to action
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:99
+#: src/components/LicenseContent.tsx:98
 msgid "license.contactCta"
 msgstr "Questions about licensing or commercial use? Email us."
 
 #. Terms contact call to action
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:54
+#: src/components/TermsContent.tsx:53
 msgid "terms.contact.description"
 msgstr "Questions? Email us."
 
 #. Privacy contact call to action
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:66
+#: src/components/PrivacyPolicyContent.tsx:65
 msgid "privacy.contact.description"
 msgstr "Questions? Email us."
 
 #. Link to full CC license
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:88
+#: src/components/LicenseContent.tsx:87
 msgid "license.data.linkLabel"
 msgstr "Read the CC BY-NC 4.0 License"
 
 #. Link to full MIT license
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:63
+#: src/components/LicenseContent.tsx:62
 msgid "license.code.linkLabel"
 msgstr "Read the full MIT License"
 
 #. Link to full privacy policy text
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:73
+#: src/components/PrivacyPolicyContent.tsx:72
 msgid "privacy.extras.fullPolicyLink"
 msgstr "Read the full Privacy Policy"
 
 #. Link to full terms of service text
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:61
+#: src/components/TermsContent.tsx:60
 msgid "terms.fullTermsLink"
 msgstr "Read the full Terms of Service"
 
@@ -3110,7 +3128,7 @@ msgstr "Record each interview round with date, type, and notes so nothing slips 
 
 #. MIT right 2
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:59
+#: src/components/LicenseContent.tsx:58
 msgid "license.code.r2"
 msgstr "Redistribute your changes, as long as you include the MIT notice."
 
@@ -3126,16 +3144,16 @@ msgstr "Redistribute your changes, as long as you include the MIT notice."
 msgid "location.type.region"
 msgstr "Region"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:319
-msgid "company.locationModal.regionsHeader"
-msgstr "Regions"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:523
 msgid "search.locationModal.regionsHeader"
+msgstr "Regions"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:319
+msgid "company.locationModal.regionsHeader"
 msgstr "Regions"
 
 #. Status group heading: rejected
@@ -3156,16 +3174,16 @@ msgstr "Rejected"
 msgid "myJobs.status.rejected"
 msgstr "Rejected"
 
-#. Status option in dropdown: rejected
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:39
-msgid "myJobs.statusOption.rejected"
-msgstr "Rejected"
-
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
+msgstr "Rejected"
+
+#. Status option in dropdown: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:39
+msgid "myJobs.statusOption.rejected"
 msgstr "Rejected"
 
 #. Footer license summary text
@@ -3179,10 +3197,10 @@ msgstr "Released under the MIT License. Job data is CC BY-NC 4.0."
 #. Work mode: remote (work-from-home)
 #. Work mode: remote (work-from-home)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:580
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:588
 #: src/components/search/search-bar.tsx:813
 #: src/components/search/search-toolbar.tsx:261
-#: src/components/search/work-mode-modal.tsx:22
+#: src/components/search/work-mode-modal.tsx:28
 msgid "search.workMode.remote"
 msgstr "Remote"
 
@@ -3236,7 +3254,7 @@ msgstr "Resend in {cooldown}s"
 
 #. Reset password button during cooldown with seconds remaining
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:190
+#: src/components/settings/AccountSettings.tsx:187
 msgid "settings.account.password.cooldown"
 msgstr "Resend in {cooldown}s"
 
@@ -3272,13 +3290,13 @@ msgstr "Resetting..."
 
 #. Assurance 1 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:67
+#: src/components/HowWeIndexContent.tsx:65
 msgid "indexing.assurances.i1.title"
 msgstr "Respectful pacing."
 
 #. Assurance 2 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:71
+#: src/components/HowWeIndexContent.tsx:69
 msgid "indexing.assurances.i2.title"
 msgstr "Robots, attribution, and TDM reservation."
 
@@ -3306,16 +3324,16 @@ msgstr "Round"
 msgid "app.home.request.agent.runIdLabel"
 msgstr "Run id"
 
-#. Label for salary filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:225
-msgid "search.advanced.salary"
-msgstr "Salary"
-
 #. Salary override section heading
 #. js-lingui-explicit-id
 #: src/components/my-jobs/salary-override.tsx:76
 msgid "myJobs.detail.salary"
+msgstr "Salary"
+
+#. Label for salary filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:225
+msgid "search.advanced.salary"
 msgstr "Salary"
 
 #. Salary display settings section heading
@@ -3384,27 +3402,27 @@ msgstr "Saved"
 msgid "myJobs.status.saved"
 msgstr "Saved"
 
-#. Status option in dropdown: saved
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:35
-msgid "myJobs.statusOption.saved"
-msgstr "Saved"
-
 #. Sankey funnel node: saved jobs
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:41
 msgid "myJobs.funnel.saved"
 msgstr "Saved"
 
+#. Status option in dropdown: saved
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:35
+msgid "myJobs.statusOption.saved"
+msgstr "Saved"
+
 #. Username save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:323
+#: src/components/settings/AccountSettings.tsx:320
 msgid "settings.account.username.saving"
 msgstr "Saving..."
 
 #. Email save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:395
+#: src/components/settings/AccountSettings.tsx:392
 msgid "settings.account.email.saving"
 msgstr "Saving..."
 
@@ -3427,16 +3445,16 @@ msgstr "Search across thousands of companies scraped directly from their career 
 msgid "company.page.searchPlaceholder"
 msgstr "Search at {0}..."
 
-#. Placeholder for company search in modal
-#. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:217
-msgid "watchlists.companyModal.searchPlaceholder"
-msgstr "Search companies..."
-
 #. Placeholder for company search in watchlist creation
 #. js-lingui-explicit-id
 #: src/components/watchlist/company-selector.tsx:91
 msgid "watchlists.companySelector.placeholder"
+msgstr "Search companies..."
+
+#. Placeholder for company search in modal
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-search-modal.tsx:217
+msgid "watchlists.companyModal.searchPlaceholder"
 msgstr "Search companies..."
 
 #. Option to search by title keyword in dropdown
@@ -3456,16 +3474,16 @@ msgstr "Search jobs across thousands of companies scraped directly from career p
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Search languages..."
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:288
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Search locations..."
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:492
 msgid "search.locationModal.searchPlaceholder"
+msgstr "Search locations..."
+
+#. Placeholder for search input in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:288
+msgid "company.locationModal.searchPlaceholder"
 msgstr "Search locations..."
 
 #. Back-to-search link on company page header
@@ -3536,7 +3554,7 @@ msgstr "Select your preferred language."
 
 #. Step 4 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:137
+#: src/components/HowWeIndexContent.tsx:135
 msgid "indexing.ingestion.s4.title"
 msgstr "Selective storage."
 
@@ -3548,15 +3566,9 @@ msgstr "Send reset link"
 
 #. Reset password button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:191
+#: src/components/settings/AccountSettings.tsx:188
 msgid "settings.account.password.send"
 msgstr "Send reset link"
-
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Sending..."
 
 #. Resend button while sending
 #. js-lingui-explicit-id
@@ -3564,9 +3576,15 @@ msgstr "Sending..."
 msgid "auth.verify.resending"
 msgstr "Sending..."
 
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
+msgstr "Sending..."
+
 #. Reset password button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:188
+#: src/components/settings/AccountSettings.tsx:185
 msgid "settings.account.password.sending"
 msgstr "Sending..."
 
@@ -3746,7 +3764,7 @@ msgstr "Simple, transparent pricing. Start for free and upgrade when you get ser
 
 #. Step 1 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:113
+#: src/components/HowWeIndexContent.tsx:111
 msgid "indexing.ingestion.s1.title"
 msgstr "Sitemap first."
 
@@ -3932,13 +3950,13 @@ msgstr "Tell us the company name and (ideally) a careers-page URL. We'll prepare
 
 #. Employment type: temporary
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:16
+#: src/components/search/employment-type-modal.tsx:17
 msgid "search.employmentType.temporary"
 msgstr "Temporary"
 
 #. Terms page eyebrow
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:21
+#: src/components/TermsContent.tsx:20
 msgid "terms.hero.eyebrow"
 msgstr "Terms"
 
@@ -3956,7 +3974,7 @@ msgstr "Terms of Service"
 
 #. Terms page title
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:22
+#: src/components/TermsContent.tsx:21
 msgid "terms.hero.title"
 msgstr "Terms of Service"
 
@@ -4002,19 +4020,19 @@ msgstr "The page you are looking for does not exist or has been moved."
 
 #. Provided as-is
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:46
+#: src/components/TermsContent.tsx:45
 msgid "terms.short.r4"
 msgstr "The service is provided as-is — no warranties."
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:40
+#: src/components/TermsContent.tsx:39
 msgid "terms.short.title"
 msgstr "The short version"
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:40
+#: src/components/PrivacyPolicyContent.tsx:39
 msgid "privacy.short.title"
 msgstr "The short version"
 
@@ -4038,7 +4056,7 @@ msgstr "This site uses cookies only for authentication and essential functionali
 
 #. Username is reserved hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:289
+#: src/components/settings/AccountSettings.tsx:286
 msgid "settings.account.username.reserved"
 msgstr "This username is reserved"
 
@@ -4080,7 +4098,7 @@ msgstr "Track your pipeline"
 
 #. Open-source section body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:188
+#: src/components/HowWeIndexContent.tsx:186
 msgid "indexing.oss.body"
 msgstr "Transparency matters, so the code for our job link collection service and extraction pipeline is open source."
 
@@ -4122,7 +4140,7 @@ msgstr "Under Active Development"
 
 #. Your rights intro
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:57
+#: src/components/PrivacyPolicyContent.tsx:56
 msgid "privacy.rights.intro"
 msgstr "Under GDPR you can ask for a copy of your data, have it corrected or deleted, export it, or object to processing. Delete your account and everything is wiped within 30 days."
 
@@ -4157,19 +4175,19 @@ msgstr "Unsave job"
 
 #. Email save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:396
+#: src/components/settings/AccountSettings.tsx:393
 msgid "settings.account.email.save"
 msgstr "Update email"
 
 #. Change email section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:376
+#: src/components/settings/AccountSettings.tsx:373
 msgid "settings.account.email.description"
 msgstr "Update the email address associated with your account."
 
 #. Username save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:324
+#: src/components/settings/AccountSettings.tsx:321
 msgid "settings.account.username.save"
 msgstr "Update username"
 
@@ -4210,25 +4228,25 @@ msgstr "user"
 
 #. Username section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:301
+#: src/components/settings/AccountSettings.tsx:298
 msgid "settings.account.username.title"
 msgstr "Username"
 
 #. Username input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:313
+#: src/components/settings/AccountSettings.tsx:310
 msgid "settings.account.username.label"
 msgstr "Username"
 
 #. Username updated success message
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:276
+#: src/components/settings/AccountSettings.tsx:273
 msgid "settings.account.username.success"
 msgstr "Username updated."
 
 #. Success message after email change request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:365
+#: src/components/settings/AccountSettings.tsx:362
 msgid "settings.account.email.success"
 msgstr "Verification email sent. Please check your inbox. It may take a few minutes to arrive."
 
@@ -4264,7 +4282,7 @@ msgstr "View posting"
 
 #. Employment type: volunteer
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:17
+#: src/components/search/employment-type-modal.tsx:18
 msgid "search.employmentType.volunteer"
 msgstr "Volunteer"
 
@@ -4300,7 +4318,7 @@ msgstr "Watchlists"
 
 #. Back to watchlists link
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:344
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:352
 msgid "watchlists.view.back"
 msgstr "Watchlists"
 
@@ -4323,7 +4341,7 @@ msgstr "Watchlists and application tracking"
 
 #. What the service does
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:44
+#: src/components/TermsContent.tsx:43
 msgid "terms.short.r2"
 msgstr "We aggregate public job postings. We do not guarantee they are accurate or up to date."
 
@@ -4335,13 +4353,13 @@ msgstr "We believe job search should be driven by the person searching, not by a
 
 #. Privacy policy page description
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:23
+#: src/components/PrivacyPolicyContent.tsx:22
 msgid "privacy.hero.description"
 msgstr "We collect only what we need, we don’t sell your data, and you can delete everything at any time."
 
 #. No selling
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:44
+#: src/components/PrivacyPolicyContent.tsx:43
 msgid "privacy.short.r2"
 msgstr "We don’t sell, rent, or share your data for marketing."
 
@@ -4352,13 +4370,13 @@ msgstr "We index company career pages directly, not third-party feeds. No recrui
 
 #. Step 1 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:115
+#: src/components/HowWeIndexContent.tsx:113
 msgid "indexing.ingestion.s1.body"
 msgstr "We look for a sitemap that already lists every careers or job detail page—ideally linked from <0>robots.txt</0>—and rely on it whenever possible."
 
 #. Ingestion section description
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:107
+#: src/components/HowWeIndexContent.tsx:105
 msgid "indexing.ingestion.description"
 msgstr "We look for structured feeds before scraping raw HTML. First we check for sitemaps, then client-side JSON APIs, and only parse full pages when neither exists."
 
@@ -4382,7 +4400,7 @@ msgstr "We noticed this job was recently added. Some details may still be proces
 
 #. Automation stance body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:177
+#: src/components/HowWeIndexContent.tsx:175
 msgid "indexing.automation.body"
 msgstr "We oppose handing hiring or job-search decisions over to black-box automation — whether on the employer or applicant side. Every outbound link we share includes <0>utm_source=jobseek</0> so recruiters recognise the traffic, and we continuously review usage patterns plus enforce friction to deter scripted applications."
 
@@ -4399,19 +4417,19 @@ msgstr "We sent a verification link to <0>{email}</0>. Click the link to verify 
 
 #. What we store
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:43
+#: src/components/PrivacyPolicyContent.tsx:42
 msgid "privacy.short.r1"
 msgstr "We store your name, email, and profile picture from your OAuth sign-in, plus the data you create while using the app."
 
 #. Info box about sitemaps
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:151
+#: src/components/HowWeIndexContent.tsx:149
 msgid "indexing.sitemapNote"
 msgstr "We strongly encourage publishing an easily discoverable sitemap for your careers section. Without it, we periodically mint lightweight <0>HEAD</0> requests against previously discovered job URLs to confirm they are still live, which introduces unnecessary traffic."
 
 #. Third parties
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:45
+#: src/components/PrivacyPolicyContent.tsx:44
 msgid "privacy.short.r3"
 msgstr "We use a handful of third-party services for sign-in, hosting, and storage — nothing else."
 
@@ -4478,8 +4496,14 @@ msgstr "Work mode"
 
 #. Title for the work-mode (onsite/hybrid/remote) selection modal
 #. js-lingui-explicit-id
-#: src/components/search/work-mode-modal.tsx:53
+#: src/components/search/work-mode-modal.tsx:82
 msgid "search.workModeModal.title"
+msgstr "Work mode"
+
+#. Section header for work-mode (onsite/hybrid/remote) suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:800
+msgid "search.bar.workMode"
 msgstr "Work mode"
 
 #. Label for work-mode (onsite/hybrid/remote) filter in advanced search
@@ -4488,11 +4512,11 @@ msgstr "Work mode"
 msgid "search.advanced.workMode"
 msgstr "Work mode"
 
-#. Section header for work-mode (onsite/hybrid/remote) suggestions in search bar
+#. Salary period suffix shown after the amount, e.g. '50k EUR / yearly'
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:800
-msgid "search.bar.workMode"
-msgstr "Work mode"
+#: src/components/SalaryDisplayProvider.tsx:55
+msgid "common.salary.period.yearly"
+msgstr "yearly"
 
 #. Yearly pay period option
 #. js-lingui-explicit-id
@@ -4539,13 +4563,13 @@ msgstr "Yesterday"
 
 #. Account deletion
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:47
+#: src/components/TermsContent.tsx:46
 msgid "terms.short.r5"
 msgstr "You can delete your account at any time."
 
 #. CC right 3
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:85
+#: src/components/LicenseContent.tsx:84
 msgid "license.data.r3"
 msgstr "You can remix/transform the data for research or personal dashboards."
 
@@ -4557,7 +4581,7 @@ msgstr "You can speed this up by asking your AI agent to complete it via Murmur.
 
 #. MIT license summary
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:53
+#: src/components/LicenseContent.tsx:52
 msgid "license.code.summary"
 msgstr "You can use, modify, and redistribute the code in personal or commercial products as long as you include the copyright and license notice."
 
@@ -4569,13 +4593,13 @@ msgstr "You may also be interested in"
 
 #. CC license summary
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:74
+#: src/components/LicenseContent.tsx:73
 msgid "license.data.summary"
 msgstr "You may reuse the job dataset with attribution for non-commercial purposes. Commercial usage requires prior written consent."
 
 #. Age requirement
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:43
+#: src/components/TermsContent.tsx:42
 msgid "terms.short.r1"
 msgstr "You must be at least 16 to use Job Seek."
 
@@ -4637,12 +4661,12 @@ msgstr "Your password has been reset. You can now sign in with your new password
 
 #. Your rights section title
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:54
+#: src/components/PrivacyPolicyContent.tsx:53
 msgid "privacy.rights.title"
 msgstr "Your rights"
 
 #. Username section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:304
+#: src/components/settings/AccountSettings.tsx:301
 msgid "settings.account.username.description"
 msgstr "Your unique handle used in your public profile URL."

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -26,7 +26,7 @@ msgstr ""
 
 #. CC right 1
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:80
+#: src/components/LicenseContent.tsx:79
 msgid "license.data.r1"
 msgstr "« Viktor Shcherbakov, Collection of Job Postings » avec un lien vers la source."
 
@@ -41,12 +41,12 @@ msgstr "« Viktor Shcherbakov, Collection of Job Postings » avec un lien vers l
 #. js-lingui-explicit-id
 #: src/components/Footer.tsx:41
 #: src/components/Footer.tsx:47
-#: src/components/HowWeIndexContent.tsx:196
-#: src/components/LicenseContent.tsx:64
-#: src/components/LicenseContent.tsx:89
-#: src/components/PrivacyPolicyContent.tsx:74
+#: src/components/HowWeIndexContent.tsx:194
+#: src/components/LicenseContent.tsx:63
+#: src/components/LicenseContent.tsx:88
+#: src/components/PrivacyPolicyContent.tsx:73
 #: src/components/PublicDomainArt.tsx:115
-#: src/components/TermsContent.tsx:62
+#: src/components/TermsContent.tsx:61
 msgid "common.a11y.opensInNewTab"
 msgstr "(ouvre dans un nouvel onglet)"
 
@@ -212,8 +212,8 @@ msgstr "Menu du compte"
 #. Active postings count on company page
 #. Active postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:554
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:564
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:561
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:571
 msgid "company.page.active"
 msgstr "actif"
 
@@ -239,7 +239,7 @@ msgstr "Ajouter des entreprises"
 
 #. Link to add a description to the watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:438
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:446
 msgid "watchlists.view.addDescription"
 msgstr "Ajouter une description"
 
@@ -293,7 +293,7 @@ msgstr "Tous les {totalCountries} pays chargés"
 
 #. Encryption
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:47
+#: src/components/PrivacyPolicyContent.tsx:46
 msgid "privacy.short.r5"
 msgstr "Toutes les données sont chiffrées en transit et au repos."
 
@@ -303,16 +303,16 @@ msgstr "Toutes les données sont chiffrées en transit et au repos."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Tous les secteurs"
 
-#. All languages option
-#. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:253
-msgid "settings.general.jobLanguages.all"
-msgstr "Toutes les langues"
-
 #. Title for the all-languages modal in settings
 #. js-lingui-explicit-id
 #: src/components/settings/JobLanguageModal.tsx:56
 msgid "settings.jobLanguages.modal.title"
+msgstr "Toutes les langues"
+
+#. All languages option
+#. js-lingui-explicit-id
+#: src/components/settings/GeneralSettings.tsx:253
+msgid "settings.general.jobLanguages.all"
 msgstr "Toutes les langues"
 
 #. Title for the all-locations modal on company page
@@ -335,7 +335,7 @@ msgstr "Déjà un compte ? <0>Se connecter</0>"
 
 #. Username is taken
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:295
+#: src/components/settings/AccountSettings.tsx:292
 msgid "settings.account.username.taken"
 msgstr "Déjà pris"
 
@@ -352,19 +352,19 @@ msgstr "Tous"
 
 #. Toggle to show jobs from all companies
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:466
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:474
 msgid "watchlists.view.anyCompany"
 msgstr "Toute entreprise"
 
 #. MIT license section title
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:50
+#: src/components/LicenseContent.tsx:49
 msgid "license.code.title"
 msgstr "Code applicatif (licence MIT)"
 
 #. TOC: Application code (MIT)
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:23
+#: src/components/LicenseContent.tsx:22
 msgid "license.toc.code"
 msgstr "Code applicatif (MIT)"
 
@@ -422,16 +422,16 @@ msgstr "Postulé"
 msgid "myJobs.status.applied"
 msgstr "Postulé"
 
-#. Status option in dropdown: applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:36
-msgid "myJobs.statusOption.applied"
-msgstr "Postulé"
-
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
+msgstr "Postulé"
+
+#. Status option in dropdown: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:36
+msgid "myJobs.statusOption.applied"
 msgstr "Postulé"
 
 #. Apply salary filter
@@ -460,19 +460,19 @@ msgstr "Avr"
 
 #. Step 3 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:131
+#: src/components/HowWeIndexContent.tsx:129
 msgid "indexing.ingestion.s3.body"
 msgstr "En dernier recours, nous analysons directement les pages carrières, en privilégiant le tri du plus récent au plus ancien et en nous arrêtant dès que des offres déjà indexées réapparaissent, plutôt que de parcourir chaque page."
 
 #. Username too short hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:283
+#: src/components/settings/AccountSettings.tsx:280
 msgid "settings.account.username.tooShort"
 msgstr "3 caractères minimum"
 
 #. Username too long hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:285
+#: src/components/settings/AccountSettings.tsx:282
 msgid "settings.account.username.tooLong"
 msgstr "30 caractères maximum"
 
@@ -484,20 +484,20 @@ msgstr "Aoû"
 
 #. Username is available
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:293
+#: src/components/settings/AccountSettings.tsx:290
 msgid "settings.account.username.available"
 msgstr "Disponible"
-
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Retour à la connexion"
 
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Retour à la connexion"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Retour à la connexion"
 
 #. Link back to sign-in from forgot password
@@ -544,18 +544,18 @@ msgstr "Blog"
 msgid "blog.post.backToIndex"
 msgstr "Blog"
 
+#. Footer link to /blog index page
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:52
+msgid "common.footer.blog"
+msgstr "Blog"
+
 #. Nav link: Blog
 #. Nav link: Blog
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:74
 #: src/components/MobileMenu.tsx:98
 msgid "common.nav.blog"
-msgstr "Blog"
-
-#. Footer link to /blog index page
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
-msgid "common.footer.blog"
 msgstr "Blog"
 
 #. Subtitle on the sign-in CTA card shown to anonymous users at the end of the similar-companies strip
@@ -566,7 +566,7 @@ msgstr "Parcourir toutes les entreprises similaires"
 
 #. Link text for browsing the repo
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:192
+#: src/components/HowWeIndexContent.tsx:190
 msgid "indexing.oss.browseRepo"
 msgstr "Parcourir le dépôt sur"
 
@@ -590,7 +590,7 @@ msgstr "Créé par des chercheurs d'emploi, pour des chercheurs d'emploi"
 
 #. Terms page description
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:23
+#: src/components/TermsContent.tsx:22
 msgid "terms.hero.description"
 msgstr "En utilisant Job Seek, tu acceptes ces conditions. Voici un résumé en langage clair."
 
@@ -607,7 +607,7 @@ msgstr "Annuler"
 
 #. Cancel delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:535
+#: src/components/settings/AccountSettings.tsx:532
 msgid "settings.account.delete.cancel"
 msgstr "Annuler"
 
@@ -619,7 +619,7 @@ msgstr "modifier"
 
 #. Change email section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:373
+#: src/components/settings/AccountSettings.tsx:370
 msgid "settings.account.email.title"
 msgstr "Changer l'e-mail"
 
@@ -637,7 +637,7 @@ msgstr "Changer de langue"
 
 #. Password section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:180
+#: src/components/settings/AccountSettings.tsx:177
 msgid "settings.account.password.description"
 msgstr "Modifie ton mot de passe via un lien e-mail sécurisé."
 
@@ -647,21 +647,21 @@ msgstr "Modifie ton mot de passe via un lien e-mail sécurisé."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Changer…"
 
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "Vérifiez votre e-mail"
-
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
 msgstr "Vérifie ton e-mail"
 
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
+msgstr "Vérifiez votre e-mail"
+
 #. Checking username availability
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:291
+#: src/components/settings/AccountSettings.tsx:288
 msgid "settings.account.username.checking"
 msgstr "Vérification de la disponibilité..."
 
@@ -711,14 +711,14 @@ msgstr "Réinitialiser"
 
 #. Button to remove all companies from watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:484
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:492
 msgid "watchlists.view.clearAllCompanies"
 msgstr "Tout effacer"
 
 #. Button to clear all active search filters
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:616
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:624
 #: src/components/search/search-toolbar.tsx:337
 msgid "search.filters.clearAll"
 msgstr "Tout effacer"
@@ -731,19 +731,19 @@ msgstr "Tout effacer"
 
 #. Tooltip for clicking to edit watchlist description
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:426
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:434
 msgid "watchlists.view.editDescription"
 msgstr "Cliquer pour modifier la description"
 
 #. Tooltip for clicking to edit watchlist title
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:376
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:384
 msgid "watchlists.view.editTitle"
 msgstr "Cliquer pour renommer"
 
 #. Step 2 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:121
+#: src/components/HowWeIndexContent.tsx:119
 msgid "indexing.ingestion.s2.title"
 msgstr "API clientes en second."
 
@@ -755,7 +755,7 @@ msgstr "Fermer le menu"
 
 #. Label for inactive/closed job postings on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:656
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:663
 msgid "company.page.closed"
 msgstr "Fermé"
 
@@ -773,7 +773,7 @@ msgstr "Coding"
 
 #. CC license section title
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:71
+#: src/components/LicenseContent.tsx:70
 msgid "license.data.title"
 msgstr "Collection d'offres d'emploi (CC BY-NC 4.0)"
 
@@ -809,7 +809,7 @@ msgstr "Entreprises suivies"
 
 #. Button to open company search modal
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:455
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:463
 msgid "watchlists.view.addCompany"
 msgstr "Entreprise"
 
@@ -851,7 +851,7 @@ msgstr "Outil de suivi d'entreprises pour les candidats ciblés — watchlists, 
 
 #. Confirm delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:528
+#: src/components/settings/AccountSettings.tsx:525
 msgid "settings.account.delete.confirm"
 msgstr "Confirmer la suppression"
 
@@ -863,25 +863,25 @@ msgstr "Confirmer le mot de passe"
 
 #. Connect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:478
+#: src/components/settings/AccountSettings.tsx:475
 msgid "settings.account.socials.connect"
 msgstr "Connecter"
 
 #. Connected accounts section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:453
+#: src/components/settings/AccountSettings.tsx:450
 msgid "settings.account.socials.title"
 msgstr "Comptes connectés"
 
 #. TOC: Contact
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:25
+#: src/components/LicenseContent.tsx:24
 msgid "license.toc.contact"
 msgstr "Contact"
 
 #. Contact section title
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:96
+#: src/components/LicenseContent.tsx:95
 msgid "license.contact.title"
 msgstr "Contact"
 
@@ -893,13 +893,13 @@ msgstr "Contact"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
+#: src/components/LicenseContent.tsx:17
 msgid "license.toc.title"
 msgstr "Sommaire"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
+#: src/components/HowWeIndexContent.tsx:21
 msgid "indexing.toc.title"
 msgstr "Sommaire"
 
@@ -929,13 +929,13 @@ msgstr "Continuer avec LinkedIn"
 
 #. Employment type: contract
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:14
+#: src/components/search/employment-type-modal.tsx:15
 msgid "search.employmentType.contract"
 msgstr "Freelance"
 
 #. Cookies
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:46
+#: src/components/PrivacyPolicyContent.tsx:45
 msgid "privacy.short.r4"
 msgstr "Les cookies servent uniquement à la session — pas de pub, pas de tracking."
 
@@ -947,7 +947,7 @@ msgstr "Copié"
 
 #. MIT right 1
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:58
+#: src/components/LicenseContent.tsx:57
 msgid "license.code.r1"
 msgstr "Copie et modifie le code pour tout usage, y compris des produits commerciaux."
 
@@ -985,13 +985,13 @@ msgstr "Code source du crawler"
 
 #. TOC: Crawling assurances
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:28
+#: src/components/HowWeIndexContent.tsx:26
 msgid "indexing.toc.assurances"
 msgstr "Garanties de crawl"
 
 #. Assurances section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:63
+#: src/components/HowWeIndexContent.tsx:61
 msgid "indexing.assurances.title"
 msgstr "Garanties de crawl"
 
@@ -1055,6 +1055,12 @@ msgstr "Devise"
 msgid "settings.billing.currentPlan"
 msgstr "Actuel"
 
+#. Salary period suffix shown after the amount, e.g. '300 EUR / daily'
+#. js-lingui-explicit-id
+#: src/components/SalaryDisplayProvider.tsx:59
+msgid "common.salary.period.daily"
+msgstr "par jour"
+
 #. Daily pay period option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:372
@@ -1111,13 +1117,13 @@ msgstr "Supprimer"
 
 #. Delete account section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:511
+#: src/components/settings/AccountSettings.tsx:508
 msgid "settings.account.delete.title"
 msgstr "Supprimer le compte"
 
 #. Delete account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:521
+#: src/components/settings/AccountSettings.tsx:518
 msgid "settings.account.delete.button"
 msgstr "Supprimer mon compte"
 
@@ -1129,13 +1135,13 @@ msgstr "Supprimer la liste de suivi ?"
 
 #. Delete button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:527
+#: src/components/settings/AccountSettings.tsx:524
 msgid "settings.account.delete.deleting"
 msgstr "Suppression…"
 
 #. Placeholder for watchlist description textarea
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:418
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:426
 msgid "watchlists.view.descriptionPlaceholder"
 msgstr "Décrire cette watchlist …"
 
@@ -1171,7 +1177,7 @@ msgstr "Désactiver les alertes"
 
 #. Disconnect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:477
+#: src/components/settings/AccountSettings.tsx:474
 msgid "settings.account.socials.disconnect"
 msgstr "Déconnecter"
 
@@ -1194,7 +1200,7 @@ msgstr "Pas encore de compte ? <0>S'inscrire</0>"
 
 #. No scraping
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:45
+#: src/components/TermsContent.tsx:44
 msgid "terms.short.r3"
 msgstr "Pas de scraping, pas de candidatures automatisées, pas d'abus de la plateforme."
 
@@ -1256,7 +1262,7 @@ msgstr "E-mail vérifié"
 
 #. Title for the employment type selection modal
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:48
+#: src/components/search/employment-type-modal.tsx:74
 msgid "search.employmentTypeModal.title"
 msgstr "Type d'emploi"
 
@@ -1280,7 +1286,7 @@ msgstr "Entre ton nouveau mot de passe ci-dessous."
 
 #. Assurance 3 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:80
+#: src/components/HowWeIndexContent.tsx:78
 msgid "indexing.assurances.i3.body"
 msgstr "Même après la découverte, nous récupérons les pages de détail des offres à un rythme strict d'une requête par site et par minute."
 
@@ -1292,7 +1298,7 @@ msgstr "Tous les filtres dont un chercheur d'emploi a vraiment besoin"
 
 #. Assurance 1 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:68
+#: src/components/HowWeIndexContent.tsx:66
 msgid "indexing.assurances.i1.body"
 msgstr "Chaque fenêtre de réessai utilise un backoff exponentiel afin de ne jamais surcharger un serveur d'origine, et nous abandonnons si un hôte continue de ne pas répondre."
 
@@ -1315,16 +1321,16 @@ msgstr "Alertes e-mail pour les nouvelles offres"
 msgid "faq.description"
 msgstr "Tout ce que vous devez savoir sur Job Seek. Vous ne trouvez pas ce que vous cherchez ? Écrivez-nous à <0>{0}</0>."
 
-#. Label for experience filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:231
-msgid "search.advanced.experience"
-msgstr "Expérience"
-
 #. Title for experience filter modal
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:186
 msgid "search.experienceModal.title"
+msgstr "Expérience"
+
+#. Label for experience filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:231
+msgid "search.advanced.experience"
 msgstr "Expérience"
 
 #. Breadcrumb label for the Explore page
@@ -1346,27 +1352,27 @@ msgstr "Explorer les emplois"
 
 #. Generic email change error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:363
+#: src/components/settings/AccountSettings.tsx:360
 msgid "settings.account.email.error"
 msgstr "Échec du changement d'e-mail"
 
 #. Error when linking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:429
+#: src/components/settings/AccountSettings.tsx:426
 msgid "settings.account.socials.connectError"
 msgstr "Échec de la connexion du compte"
 
 #. Generic account deletion error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:502
+#: src/components/settings/AccountSettings.tsx:499
 msgid "settings.account.delete.error"
 msgstr "Échec de la suppression du compte"
 
 #. Error when unlinking social account fails
 #. Error when unlinking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:440
-#: src/components/settings/AccountSettings.tsx:445
+#: src/components/settings/AccountSettings.tsx:437
+#: src/components/settings/AccountSettings.tsx:442
 msgid "settings.account.socials.disconnectError"
 msgstr "Échec de la déconnexion du compte"
 
@@ -1384,7 +1390,7 @@ msgstr "Impossible de réinitialiser le mot de passe. Le lien a peut-être expir
 
 #. Generic password reset error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:167
+#: src/components/settings/AccountSettings.tsx:164
 msgid "settings.account.password.error"
 msgstr "Échec de l'envoi de l'e-mail de réinitialisation"
 
@@ -1396,7 +1402,7 @@ msgstr "Échec de la définition du mot de passe"
 
 #. Generic username update error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:264
+#: src/components/settings/AccountSettings.tsx:261
 msgid "settings.account.username.error"
 msgstr "Échec de la mise à jour du nom d'utilisateur"
 
@@ -1587,7 +1593,7 @@ msgstr "Recherche complète, une watchlist et un suivi des candidatures intégr�
 
 #. Employment type: full-time
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:12
+#: src/components/search/employment-type-modal.tsx:13
 msgid "search.employmentType.fullTime"
 msgstr "Temps plein"
 
@@ -1645,7 +1651,7 @@ msgstr "Compris"
 
 #. Step 3 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:129
+#: src/components/HowWeIndexContent.tsx:127
 msgid "indexing.ingestion.s3.title"
 msgstr "Analyse de pages respectueuse."
 
@@ -1666,6 +1672,12 @@ msgstr "Responsable RH"
 #: app/[lang]/(app)/company/[slug]/company-head.tsx:49
 msgid "breadcrumb.home"
 msgstr "Accueil"
+
+#. Salary period suffix shown after the amount, e.g. '26 USD / hourly'
+#. js-lingui-explicit-id
+#: src/components/SalaryDisplayProvider.tsx:61
+msgid "common.salary.period.hourly"
+msgstr "par heure"
 
 #. Hourly pay period option
 #. js-lingui-explicit-id
@@ -1702,19 +1714,19 @@ msgstr "À quelle fréquence les offres d'emploi sont-elles mises à jour ?"
 
 #. TOC: How postings enter the index
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:29
+#: src/components/HowWeIndexContent.tsx:27
 msgid "indexing.toc.ingestion"
 msgstr "Comment les offres entrent dans l'index"
 
 #. Ingestion section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:104
+#: src/components/HowWeIndexContent.tsx:102
 msgid "indexing.ingestion.title"
 msgstr "Comment les offres entrent dans l'index"
 
 #. Indexing page title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:48
+#: src/components/HowWeIndexContent.tsx:46
 msgid "indexing.hero.title"
 msgstr "Comment nous trouvons et traitons les offres d'emploi"
 
@@ -1729,10 +1741,10 @@ msgstr "Comment nous indexons"
 #. Work mode: hybrid (mixed onsite/remote)
 #. Work mode: hybrid (mixed onsite/remote)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:579
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:587
 #: src/components/search/search-bar.tsx:812
 #: src/components/search/search-toolbar.tsx:260
-#: src/components/search/work-mode-modal.tsx:21
+#: src/components/search/work-mode-modal.tsx:27
 msgid "search.workMode.hybrid"
 msgstr "Hybride"
 
@@ -1744,19 +1756,19 @@ msgstr "Si un compte existe pour cette adresse e-mail, nous avons envoyé un lie
 
 #. Step 2 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:123
+#: src/components/HowWeIndexContent.tsx:121
 msgid "indexing.ingestion.s2.body"
 msgstr "En l'absence de sitemap, nous inspectons l'application cliente à la recherche d'API JSON qu'elle appelle ; lorsque nous en trouvons, nous interrogeons directement ces points d'accès pour énumérer les URL des offres sans scraper le DOM."
 
 #. Opt-out section body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:164
+#: src/components/HowWeIndexContent.tsx:162
 msgid "indexing.optOut.body"
 msgstr "Si tu constates une activité inattendue de notre robot d'indexation ou préfères que ton site carrières ne soit pas indexé, contacte-nous par e-mail et nous te répondrons rapidement."
 
 #. Outreach section body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:206
+#: src/components/HowWeIndexContent.tsx:204
 msgid "indexing.outreach.body"
 msgstr "Si tu remarques un comportement inhabituel de notre robot, préfères que nous n'indexions pas ton contenu, ou as des suggestions pour améliorer nos mesures de protection, n'hésite pas à nous contacter."
 
@@ -1768,8 +1780,8 @@ msgstr "à {locations}"
 #. Year postings count on company page
 #. Year postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:556
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:568
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:563
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:575
 msgid "company.page.yearCount"
 msgstr "au cours de la dernière année"
 
@@ -1801,7 +1813,7 @@ msgstr "Inclus dans {ancestorName}"
 
 #. Indexing page eyebrow
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:45
+#: src/components/HowWeIndexContent.tsx:43
 msgid "indexing.hero.eyebrow"
 msgstr "Politique d'indexation"
 
@@ -1843,7 +1855,7 @@ msgstr "Au lieu d'attendre que les entreprises publient leurs postes sur des sit
 
 #. Employment type: internship
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:15
+#: src/components/search/employment-type-modal.tsx:16
 msgid "search.employmentType.internship"
 msgstr "Stage"
 
@@ -1936,7 +1948,7 @@ msgstr "offre"
 
 #. TOC: Job data (CC BY-NC 4.0)
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:24
+#: src/components/LicenseContent.tsx:23
 msgid "license.toc.data"
 msgstr "Données d'emploi (CC BY-NC 4.0)"
 
@@ -1989,7 +2001,7 @@ msgstr "Job Seek t'aide à suivre les entreprises pour lesquelles tu veux travai
 
 #. Indexing page description — company-tracking framing, not 'search engine'
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:51
+#: src/components/HowWeIndexContent.tsx:49
 msgid "indexing.hero.description"
 msgstr "Job Seek est un outil de suivi d'entreprises — il surveille des milliers de pages carrières d'entreprises pour que les utilisateurs puissent créer des watchlists et recevoir des alertes sur les nouvelles offres. Cette page décrit précisément le comportement de notre robot d'indexation, les contrôles qui garantissent sa courtoisie, et comment les offres atterrissent dans l'index."
 
@@ -2025,7 +2037,7 @@ msgstr "Liste de suivi Job Seek montrant des postes sélectionnés en ingénieri
 
 #. License page description
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:38
+#: src/components/LicenseContent.tsx:37
 msgid "license.hero.description"
 msgstr "Le code source de Job Seek est ouvert sous licence MIT. Les données d'emploi que nous collectons et enrichissons sont sous Creative Commons BY-NC 4.0. Tu trouveras ci-dessous un résumé en langage clair — consulte les licences complètes pour les termes exacts."
 
@@ -2100,13 +2112,13 @@ msgstr "Dernière heure"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:28
+#: src/components/TermsContent.tsx:27
 msgid "terms.hero.lastUpdated"
 msgstr "Dernière mise à jour :"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:28
+#: src/components/PrivacyPolicyContent.tsx:27
 msgid "privacy.hero.lastUpdated"
 msgstr "Dernière mise à jour :"
 
@@ -2122,16 +2134,16 @@ msgstr "Dernière semaine"
 msgid "home.hero.secondaryCta"
 msgstr "En savoir plus"
 
-#. Label for seniority/level filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:202
-msgid "search.advanced.level"
-msgstr "Niveau"
-
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:730
 msgid "search.bar.level"
+msgstr "Niveau"
+
+#. Label for seniority/level filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:202
+msgid "search.advanced.level"
 msgstr "Niveau"
 
 #. js-lingui-explicit-id
@@ -2154,13 +2166,13 @@ msgstr "Licence"
 
 #. License page title
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:37
+#: src/components/LicenseContent.tsx:36
 msgid "license.hero.title"
 msgstr "Licence de Job Seek"
 
 #. License page eyebrow
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:36
+#: src/components/LicenseContent.tsx:35
 msgid "license.hero.eyebrow"
 msgstr "Licences"
 
@@ -2258,7 +2270,7 @@ msgstr "Gérer l'abonnement"
 
 #. Connected accounts section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:456
+#: src/components/settings/AccountSettings.tsx:453
 msgid "settings.account.socials.description"
 msgstr "Gère tes comptes sociaux liés."
 
@@ -2359,6 +2371,12 @@ msgstr "Lun"
 msgid "app.schema.feature.monitor"
 msgstr "Surveiller les pages carrières des entreprises"
 
+#. Salary period suffix shown after the amount, e.g. '5k EUR / monthly'
+#. js-lingui-explicit-id
+#: src/components/SalaryDisplayProvider.tsx:57
+msgid "common.salary.period.monthly"
+msgstr "par mois"
+
 #. Monthly pay period option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:369
@@ -2432,19 +2450,19 @@ msgstr "Nom"
 
 #. TOC: Need to reach us?
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:33
+#: src/components/HowWeIndexContent.tsx:31
 msgid "indexing.toc.outreach"
 msgstr "Besoin de nous contacter ?"
 
 #. Outreach section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:203
+#: src/components/HowWeIndexContent.tsx:201
 msgid "indexing.outreach.title"
 msgstr "Besoin de nous contacter ?"
 
 #. New email input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:385
+#: src/components/settings/AccountSettings.tsx:382
 msgid "settings.account.email.label"
 msgstr "Nouvel e-mail"
 
@@ -2468,7 +2486,7 @@ msgstr "Aucune candidature le {date}"
 
 #. CC right 2
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:84
+#: src/components/LicenseContent.tsx:83
 msgid "license.data.r2"
 msgstr "Aucune redistribution ou revente commerciale sans autorisation."
 
@@ -2496,21 +2514,21 @@ msgstr "Aucune offre trouvée."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Aucune langue ne correspond à votre recherche."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:309
-msgid "company.locationModal.noResults"
-msgstr "Aucun lieu ne correspond à votre recherche."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:513
 msgid "search.locationModal.noResults"
 msgstr "Aucun lieu ne correspond à votre recherche."
 
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:309
+msgid "company.locationModal.noResults"
+msgstr "Aucun lieu ne correspond à votre recherche."
+
 #. No postings found message on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:637
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:644
 msgid "company.page.noResults"
 msgstr "Aucune offre correspondante trouvée."
 
@@ -2558,7 +2576,7 @@ msgstr "Aucun emploi suivi pour le moment. Enregistrez des offres depuis les ré
 
 #. MIT right 3
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:60
+#: src/components/LicenseContent.tsx:59
 msgid "license.code.r3"
 msgstr "Aucune garantie — utilisation à tes risques et périls."
 
@@ -2638,16 +2656,16 @@ msgstr "Offre"
 msgid "myJobs.group.offered"
 msgstr "Offre"
 
-#. Status option in dropdown: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:38
-msgid "myJobs.statusOption.offered"
-msgstr "Offre"
-
 #. Sankey funnel node: offered
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:43
 msgid "myJobs.funnel.offered"
+msgstr "Offre"
+
+#. Status option in dropdown: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:38
+msgid "myJobs.statusOption.offered"
 msgstr "Offre"
 
 #. Cookie banner accept button
@@ -2661,28 +2679,28 @@ msgstr "Ok"
 #. Work mode: onsite (in-office)
 #. Work mode: onsite (in-office)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:577
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:585
 #: src/components/search/search-bar.tsx:810
 #: src/components/search/search-toolbar.tsx:258
-#: src/components/search/work-mode-modal.tsx:20
+#: src/components/search/work-mode-modal.tsx:26
 msgid "search.workMode.onsite"
 msgstr "Sur site"
 
 #. Step 4 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:139
+#: src/components/HowWeIndexContent.tsx:137
 msgid "indexing.ingestion.s4.body"
 msgstr "Une fois qu'une offre individuelle est récupérée, nous ne stockons que les métadonnées propres au poste (intitulé, description du rôle, localisation, informations de rémunération, URL de l'offre et horodatages) ainsi que les champs structurés extraits. Nous n'archivons pas les contenus du site sans rapport avec les offres d'emploi."
 
 #. Assurance 3 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:79
+#: src/components/HowWeIndexContent.tsx:77
 msgid "indexing.assurances.i3.title"
 msgstr "Une page par minute."
 
 #. Username invalid characters hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:287
+#: src/components/settings/AccountSettings.tsx:284
 msgid "settings.account.username.invalidChars"
 msgstr "Uniquement des lettres minuscules, des chiffres et des tirets (pas au début/fin)"
 
@@ -2705,25 +2723,25 @@ msgstr "Postes ouverts"
 
 #. TOC: Open-source crawlers
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:32
+#: src/components/HowWeIndexContent.tsx:30
 msgid "indexing.toc.oss"
 msgstr "Robots d'indexation open source"
 
 #. Open-source section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:185
+#: src/components/HowWeIndexContent.tsx:183
 msgid "indexing.oss.title"
 msgstr "Robots d'indexation open source"
 
 #. TOC: Opt-out or questions
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:30
+#: src/components/HowWeIndexContent.tsx:28
 msgid "indexing.toc.optOut"
 msgstr "Désinscription ou questions"
 
 #. Opt-out section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:161
+#: src/components/HowWeIndexContent.tsx:159
 msgid "indexing.optOut.title"
 msgstr "Désinscription ou questions"
 
@@ -2759,43 +2777,43 @@ msgstr "Autre"
 
 #. Assurance 2 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:73
+#: src/components/HowWeIndexContent.tsx:71
 msgid "indexing.assurances.i2.body"
 msgstr "Notre robot lit le fichier <0>robots.txt</0>, respecte les règles d'interdiction, s'identifie via <1>User-Agent</1> et respecte l'en-tête W3C <2>TDM-Reservation</2> — si une page signale une réservation, nous la passons."
 
 #. TOC: Our stance on automation
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:31
+#: src/components/HowWeIndexContent.tsx:29
 msgid "indexing.toc.automation"
 msgstr "Notre position sur l'automatisation"
 
 #. Automation stance title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:174
+#: src/components/HowWeIndexContent.tsx:172
 msgid "indexing.automation.title"
 msgstr "Notre position sur l'automatisation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:22
+#: src/components/LicenseContent.tsx:21
 msgid "license.toc.overview"
 msgstr "Aperçu"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
+#: src/components/HowWeIndexContent.tsx:25
 msgid "indexing.toc.overview"
 msgstr "Aperçu"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:19
+#: src/components/LicenseContent.tsx:18
 msgid "license.toc.ariaLabel"
 msgstr "Sommaire de la page"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
+#: src/components/HowWeIndexContent.tsx:22
 msgid "indexing.toc.ariaLabel"
 msgstr "Sommaire de la page"
 
@@ -2813,7 +2831,7 @@ msgstr "Panel"
 
 #. Employment type: part-time
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:13
+#: src/components/search/employment-type-modal.tsx:14
 msgid "search.employmentType.partTime"
 msgstr "Temps partiel"
 
@@ -2827,13 +2845,13 @@ msgstr "Mot de passe"
 #. Password section heading
 #. js-lingui-explicit-id
 #: src/components/settings/AccountSettings.tsx:89
-#: src/components/settings/AccountSettings.tsx:177
+#: src/components/settings/AccountSettings.tsx:174
 msgid "settings.account.password.title"
 msgstr "Mot de passe"
 
 #. Success message after password reset request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:169
+#: src/components/settings/AccountSettings.tsx:166
 msgid "settings.account.password.success"
 msgstr "Lien de réinitialisation envoyé. Vérifie ta boîte de réception. La réception peut prendre quelques minutes."
 
@@ -2887,7 +2905,7 @@ msgstr "Période"
 
 #. Delete account section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:514
+#: src/components/settings/AccountSettings.tsx:511
 msgid "settings.account.delete.description"
 msgstr "Supprime définitivement ton compte et toutes les données associées. Cette action est irréversible."
 
@@ -2923,7 +2941,7 @@ msgstr "Veuillez entrer un nom d'entreprise ou une URL."
 
 #. Error when email field is empty
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:353
+#: src/components/settings/AccountSettings.tsx:350
 msgid "settings.account.email.required"
 msgstr "Saisis une nouvelle adresse e-mail"
 
@@ -3003,7 +3021,7 @@ msgstr "Tarifs"
 
 #. Privacy policy page eyebrow
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:21
+#: src/components/PrivacyPolicyContent.tsx:20
 msgid "privacy.hero.eyebrow"
 msgstr "Confidentialité"
 
@@ -3015,7 +3033,7 @@ msgstr "Confidentialité"
 
 #. Privacy policy page title
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:22
+#: src/components/PrivacyPolicyContent.tsx:21
 msgid "privacy.hero.title"
 msgstr "Confidentialité chez Job Seek"
 
@@ -3051,43 +3069,43 @@ msgstr "Domaine public"
 
 #. Contact call to action
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:99
+#: src/components/LicenseContent.tsx:98
 msgid "license.contactCta"
 msgstr "Des questions sur les licences ou l'utilisation commerciale ? Écris-nous."
 
 #. Terms contact call to action
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:54
+#: src/components/TermsContent.tsx:53
 msgid "terms.contact.description"
 msgstr "Des questions ? Écris-nous."
 
 #. Privacy contact call to action
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:66
+#: src/components/PrivacyPolicyContent.tsx:65
 msgid "privacy.contact.description"
 msgstr "Des questions ? Écris-nous."
 
 #. Link to full CC license
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:88
+#: src/components/LicenseContent.tsx:87
 msgid "license.data.linkLabel"
 msgstr "Lire la licence CC BY-NC 4.0"
 
 #. Link to full MIT license
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:63
+#: src/components/LicenseContent.tsx:62
 msgid "license.code.linkLabel"
 msgstr "Lire la licence MIT complète"
 
 #. Link to full privacy policy text
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:73
+#: src/components/PrivacyPolicyContent.tsx:72
 msgid "privacy.extras.fullPolicyLink"
 msgstr "Lire la politique de confidentialité complète"
 
 #. Link to full terms of service text
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:61
+#: src/components/TermsContent.tsx:60
 msgid "terms.fullTermsLink"
 msgstr "Lire les conditions d'utilisation complètes"
 
@@ -3110,7 +3128,7 @@ msgstr "Note chaque tour d'entretien avec date, type et notes pour que rien ne p
 
 #. MIT right 2
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:59
+#: src/components/LicenseContent.tsx:58
 msgid "license.code.r2"
 msgstr "Redistribue tes modifications, à condition d'inclure la mention MIT."
 
@@ -3126,16 +3144,16 @@ msgstr "Redistribue tes modifications, à condition d'inclure la mention MIT."
 msgid "location.type.region"
 msgstr "Région"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:319
-msgid "company.locationModal.regionsHeader"
-msgstr "Régions"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:523
 msgid "search.locationModal.regionsHeader"
+msgstr "Régions"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:319
+msgid "company.locationModal.regionsHeader"
 msgstr "Régions"
 
 #. Status group heading: rejected
@@ -3156,16 +3174,16 @@ msgstr "Refusé"
 msgid "myJobs.status.rejected"
 msgstr "Refusé"
 
-#. Status option in dropdown: rejected
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:39
-msgid "myJobs.statusOption.rejected"
-msgstr "Refusé"
-
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
+msgstr "Refusé"
+
+#. Status option in dropdown: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:39
+msgid "myJobs.statusOption.rejected"
 msgstr "Refusé"
 
 #. Footer license summary text
@@ -3179,10 +3197,10 @@ msgstr "Publié sous licence MIT. Les données d'emploi sont sous CC BY-NC 4.0."
 #. Work mode: remote (work-from-home)
 #. Work mode: remote (work-from-home)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:580
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:588
 #: src/components/search/search-bar.tsx:813
 #: src/components/search/search-toolbar.tsx:261
-#: src/components/search/work-mode-modal.tsx:22
+#: src/components/search/work-mode-modal.tsx:28
 msgid "search.workMode.remote"
 msgstr "À distance"
 
@@ -3236,7 +3254,7 @@ msgstr "Renvoyer dans {cooldown}s"
 
 #. Reset password button during cooldown with seconds remaining
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:190
+#: src/components/settings/AccountSettings.tsx:187
 msgid "settings.account.password.cooldown"
 msgstr "Renvoyer dans {cooldown}s"
 
@@ -3272,13 +3290,13 @@ msgstr "Réinitialisation…"
 
 #. Assurance 1 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:67
+#: src/components/HowWeIndexContent.tsx:65
 msgid "indexing.assurances.i1.title"
 msgstr "Rythme respectueux."
 
 #. Assurance 2 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:71
+#: src/components/HowWeIndexContent.tsx:69
 msgid "indexing.assurances.i2.title"
 msgstr "Robots, attribution et réservation TDM."
 
@@ -3306,16 +3324,16 @@ msgstr "Tour"
 msgid "app.home.request.agent.runIdLabel"
 msgstr "Identifiant d'exécution"
 
-#. Label for salary filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:225
-msgid "search.advanced.salary"
-msgstr "Salaire"
-
 #. Salary override section heading
 #. js-lingui-explicit-id
 #: src/components/my-jobs/salary-override.tsx:76
 msgid "myJobs.detail.salary"
+msgstr "Salaire"
+
+#. Label for salary filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:225
+msgid "search.advanced.salary"
 msgstr "Salaire"
 
 #. Salary display settings section heading
@@ -3384,27 +3402,27 @@ msgstr "Enregistré"
 msgid "myJobs.status.saved"
 msgstr "Enregistré"
 
-#. Status option in dropdown: saved
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:35
-msgid "myJobs.statusOption.saved"
-msgstr "Enregistré"
-
 #. Sankey funnel node: saved jobs
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:41
 msgid "myJobs.funnel.saved"
 msgstr "Enregistré"
 
+#. Status option in dropdown: saved
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:35
+msgid "myJobs.statusOption.saved"
+msgstr "Enregistré"
+
 #. Username save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:323
+#: src/components/settings/AccountSettings.tsx:320
 msgid "settings.account.username.saving"
 msgstr "Enregistrement..."
 
 #. Email save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:395
+#: src/components/settings/AccountSettings.tsx:392
 msgid "settings.account.email.saving"
 msgstr "Enregistrement…"
 
@@ -3427,16 +3445,16 @@ msgstr "Cherche parmi des milliers d'entreprises scrapées directement depuis le
 msgid "company.page.searchPlaceholder"
 msgstr "Rechercher chez {0}..."
 
-#. Placeholder for company search in modal
-#. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:217
-msgid "watchlists.companyModal.searchPlaceholder"
-msgstr "Rechercher des entreprises..."
-
 #. Placeholder for company search in watchlist creation
 #. js-lingui-explicit-id
 #: src/components/watchlist/company-selector.tsx:91
 msgid "watchlists.companySelector.placeholder"
+msgstr "Rechercher des entreprises..."
+
+#. Placeholder for company search in modal
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-search-modal.tsx:217
+msgid "watchlists.companyModal.searchPlaceholder"
 msgstr "Rechercher des entreprises..."
 
 #. Option to search by title keyword in dropdown
@@ -3456,17 +3474,17 @@ msgstr "Recherchez des emplois dans des milliers d'entreprises, scrapés directe
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Rechercher des langues…"
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:288
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Rechercher des lieux…"
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:492
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Rechercher des lieux..."
+
+#. Placeholder for search input in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:288
+msgid "company.locationModal.searchPlaceholder"
+msgstr "Rechercher des lieux…"
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3536,7 +3554,7 @@ msgstr "Sélectionne ta langue préférée."
 
 #. Step 4 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:137
+#: src/components/HowWeIndexContent.tsx:135
 msgid "indexing.ingestion.s4.title"
 msgstr "Stockage sélectif."
 
@@ -3548,15 +3566,9 @@ msgstr "Envoyer le lien"
 
 #. Reset password button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:191
+#: src/components/settings/AccountSettings.tsx:188
 msgid "settings.account.password.send"
 msgstr "Envoyer le lien"
-
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Envoi en cours..."
 
 #. Resend button while sending
 #. js-lingui-explicit-id
@@ -3564,9 +3576,15 @@ msgstr "Envoi en cours..."
 msgid "auth.verify.resending"
 msgstr "Envoi en cours..."
 
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
+msgstr "Envoi en cours..."
+
 #. Reset password button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:188
+#: src/components/settings/AccountSettings.tsx:185
 msgid "settings.account.password.sending"
 msgstr "Envoi…"
 
@@ -3746,7 +3764,7 @@ msgstr "Des tarifs simples et transparents. Commence gratuitement et passe à la
 
 #. Step 1 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:113
+#: src/components/HowWeIndexContent.tsx:111
 msgid "indexing.ingestion.s1.title"
 msgstr "Sitemap d'abord."
 
@@ -3932,13 +3950,13 @@ msgstr "Indiquez-nous le nom de l'entreprise et (idéalement) l'URL de la page c
 
 #. Employment type: temporary
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:16
+#: src/components/search/employment-type-modal.tsx:17
 msgid "search.employmentType.temporary"
 msgstr "Temporaire"
 
 #. Terms page eyebrow
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:21
+#: src/components/TermsContent.tsx:20
 msgid "terms.hero.eyebrow"
 msgstr "Conditions d'utilisation"
 
@@ -3956,7 +3974,7 @@ msgstr "Conditions d'utilisation"
 
 #. Terms page title
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:22
+#: src/components/TermsContent.tsx:21
 msgid "terms.hero.title"
 msgstr "Conditions d'utilisation"
 
@@ -4002,19 +4020,19 @@ msgstr "La page que tu cherches n'existe pas ou a été déplacée."
 
 #. Provided as-is
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:46
+#: src/components/TermsContent.tsx:45
 msgid "terms.short.r4"
 msgstr "Le service est fourni tel quel, sans garantie."
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:40
+#: src/components/TermsContent.tsx:39
 msgid "terms.short.title"
 msgstr "En bref"
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:40
+#: src/components/PrivacyPolicyContent.tsx:39
 msgid "privacy.short.title"
 msgstr "En bref"
 
@@ -4038,7 +4056,7 @@ msgstr "Ce site utilise des cookies uniquement pour l'authentification et les fo
 
 #. Username is reserved hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:289
+#: src/components/settings/AccountSettings.tsx:286
 msgid "settings.account.username.reserved"
 msgstr "Ce nom d'utilisateur est réservé"
 
@@ -4080,7 +4098,7 @@ msgstr "Suis ton pipeline"
 
 #. Open-source section body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:188
+#: src/components/HowWeIndexContent.tsx:186
 msgid "indexing.oss.body"
 msgstr "La transparence compte, c'est pourquoi le code de notre service de collecte de liens d'offres et de notre pipeline d'extraction est open source."
 
@@ -4122,7 +4140,7 @@ msgstr "En développement actif"
 
 #. Your rights intro
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:57
+#: src/components/PrivacyPolicyContent.tsx:56
 msgid "privacy.rights.intro"
 msgstr "Selon le RGPD, tu peux demander une copie de tes données, les faire corriger ou supprimer, les exporter ou t'opposer au traitement. Supprime ton compte et tout est effacé sous 30 jours."
 
@@ -4157,19 +4175,19 @@ msgstr "Retirer l'offre"
 
 #. Email save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:396
+#: src/components/settings/AccountSettings.tsx:393
 msgid "settings.account.email.save"
 msgstr "Mettre à jour l'e-mail"
 
 #. Change email section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:376
+#: src/components/settings/AccountSettings.tsx:373
 msgid "settings.account.email.description"
 msgstr "Mets à jour l'adresse e-mail associée à ton compte."
 
 #. Username save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:324
+#: src/components/settings/AccountSettings.tsx:321
 msgid "settings.account.username.save"
 msgstr "Mettre à jour le nom d'utilisateur"
 
@@ -4210,25 +4228,25 @@ msgstr "utilisateur"
 
 #. Username section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:301
+#: src/components/settings/AccountSettings.tsx:298
 msgid "settings.account.username.title"
 msgstr "Nom d'utilisateur"
 
 #. Username input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:313
+#: src/components/settings/AccountSettings.tsx:310
 msgid "settings.account.username.label"
 msgstr "Nom d'utilisateur"
 
 #. Username updated success message
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:276
+#: src/components/settings/AccountSettings.tsx:273
 msgid "settings.account.username.success"
 msgstr "Nom d'utilisateur mis à jour."
 
 #. Success message after email change request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:365
+#: src/components/settings/AccountSettings.tsx:362
 msgid "settings.account.email.success"
 msgstr "E-mail de vérification envoyé. Vérifie ta boîte de réception. La réception peut prendre quelques minutes."
 
@@ -4264,7 +4282,7 @@ msgstr "Voir l'offre"
 
 #. Employment type: volunteer
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:17
+#: src/components/search/employment-type-modal.tsx:18
 msgid "search.employmentType.volunteer"
 msgstr "Bénévolat"
 
@@ -4300,7 +4318,7 @@ msgstr "Listes de suivi"
 
 #. Back to watchlists link
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:344
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:352
 msgid "watchlists.view.back"
 msgstr "Listes de suivi"
 
@@ -4323,7 +4341,7 @@ msgstr "Listes de suivi et suivi des candidatures"
 
 #. What the service does
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:44
+#: src/components/TermsContent.tsx:43
 msgid "terms.short.r2"
 msgstr "Nous agrégeons des offres d'emploi publiques. Nous ne garantissons pas qu'elles soient exactes ou à jour."
 
@@ -4335,13 +4353,13 @@ msgstr "Nous pensons que la recherche d'emploi devrait être dirigée par la per
 
 #. Privacy policy page description
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:23
+#: src/components/PrivacyPolicyContent.tsx:22
 msgid "privacy.hero.description"
 msgstr "Nous ne collectons que le nécessaire, nous ne vendons pas tes données, et tu peux tout supprimer à tout moment."
 
 #. No selling
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:44
+#: src/components/PrivacyPolicyContent.tsx:43
 msgid "privacy.short.r2"
 msgstr "Nous ne vendons, ne louons et ne partageons pas tes données à des fins marketing."
 
@@ -4352,13 +4370,13 @@ msgstr "Nous indexons les pages carrières des entreprises directement, pas des 
 
 #. Step 1 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:115
+#: src/components/HowWeIndexContent.tsx:113
 msgid "indexing.ingestion.s1.body"
 msgstr "Nous recherchons un sitemap qui liste déjà toutes les pages carrières ou de détail des offres — idéalement lié depuis le fichier <0>robots.txt</0> — et nous nous y fions autant que possible."
 
 #. Ingestion section description
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:107
+#: src/components/HowWeIndexContent.tsx:105
 msgid "indexing.ingestion.description"
 msgstr "Nous recherchons des flux structurés avant de scraper du HTML brut. Nous vérifions d'abord les sitemaps, puis les API JSON côté client, et n'analysons les pages complètes que lorsqu'aucune des deux options n'existe."
 
@@ -4382,7 +4400,7 @@ msgstr "Nous avons remarqué que cette offre a été ajoutée récemment. Certai
 
 #. Automation stance body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:177
+#: src/components/HowWeIndexContent.tsx:175
 msgid "indexing.automation.body"
 msgstr "Nous nous opposons à ce que les décisions de recrutement ou de recherche d'emploi soient confiées à une automatisation opaque — que ce soit côté employeur ou côté candidat. Chaque lien sortant que nous partageons inclut <0>utm_source=jobseek</0> afin que les recruteurs identifient le trafic, et nous examinons en permanence les schémas d'utilisation tout en imposant des frictions pour dissuader les candidatures automatisées."
 
@@ -4399,19 +4417,19 @@ msgstr "Nous avons envoyé un lien de vérification à <0>{email}</0>. Clique su
 
 #. What we store
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:43
+#: src/components/PrivacyPolicyContent.tsx:42
 msgid "privacy.short.r1"
 msgstr "Nous stockons ton nom, ton e-mail et ta photo de profil de ta connexion OAuth, ainsi que les données que tu crées dans l'appli."
 
 #. Info box about sitemaps
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:151
+#: src/components/HowWeIndexContent.tsx:149
 msgid "indexing.sitemapNote"
 msgstr "Nous encourageons vivement la publication d'un sitemap facilement découvrable pour ta section carrières. Sans cela, nous envoyons périodiquement des requêtes <0>HEAD</0> légères sur les URL d'offres précédemment découvertes pour vérifier qu'elles sont toujours actives, ce qui génère du trafic inutile."
 
 #. Third parties
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:45
+#: src/components/PrivacyPolicyContent.tsx:44
 msgid "privacy.short.r3"
 msgstr "Nous utilisons quelques services tiers pour la connexion, l’hébergement et le stockage — rien d’autre."
 
@@ -4478,8 +4496,14 @@ msgstr "Mode de travail"
 
 #. Title for the work-mode (onsite/hybrid/remote) selection modal
 #. js-lingui-explicit-id
-#: src/components/search/work-mode-modal.tsx:53
+#: src/components/search/work-mode-modal.tsx:82
 msgid "search.workModeModal.title"
+msgstr "Mode de travail"
+
+#. Section header for work-mode (onsite/hybrid/remote) suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:800
+msgid "search.bar.workMode"
 msgstr "Mode de travail"
 
 #. Label for work-mode (onsite/hybrid/remote) filter in advanced search
@@ -4488,11 +4512,11 @@ msgstr "Mode de travail"
 msgid "search.advanced.workMode"
 msgstr "Mode de travail"
 
-#. Section header for work-mode (onsite/hybrid/remote) suggestions in search bar
+#. Salary period suffix shown after the amount, e.g. '50k EUR / yearly'
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:800
-msgid "search.bar.workMode"
-msgstr "Mode de travail"
+#: src/components/SalaryDisplayProvider.tsx:55
+msgid "common.salary.period.yearly"
+msgstr "par an"
 
 #. Yearly pay period option
 #. js-lingui-explicit-id
@@ -4539,13 +4563,13 @@ msgstr "Hier"
 
 #. Account deletion
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:47
+#: src/components/TermsContent.tsx:46
 msgid "terms.short.r5"
 msgstr "Tu peux supprimer ton compte à tout moment."
 
 #. CC right 3
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:85
+#: src/components/LicenseContent.tsx:84
 msgid "license.data.r3"
 msgstr "Tu peux remixer ou transformer les données à des fins de recherche ou pour des tableaux de bord personnels."
 
@@ -4557,7 +4581,7 @@ msgstr "Vous pouvez accélérer en demandant à votre agent IA de l'effectuer vi
 
 #. MIT license summary
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:53
+#: src/components/LicenseContent.tsx:52
 msgid "license.code.summary"
 msgstr "Tu peux utiliser, modifier et redistribuer le code dans des produits personnels ou commerciaux à condition d'inclure la mention de droit d'auteur et de licence."
 
@@ -4569,13 +4593,13 @@ msgstr "Vous pourriez également être intéressé par"
 
 #. CC license summary
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:74
+#: src/components/LicenseContent.tsx:73
 msgid "license.data.summary"
 msgstr "Tu peux réutiliser le jeu de données d'emploi avec attribution à des fins non commerciales. Toute utilisation commerciale nécessite un accord écrit préalable."
 
 #. Age requirement
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:43
+#: src/components/TermsContent.tsx:42
 msgid "terms.short.r1"
 msgstr "Tu dois avoir au moins 16 ans pour utiliser Job Seek."
 
@@ -4637,12 +4661,12 @@ msgstr "Ton mot de passe a été réinitialisé. Tu peux maintenant te connecter
 
 #. Your rights section title
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:54
+#: src/components/PrivacyPolicyContent.tsx:53
 msgid "privacy.rights.title"
 msgstr "Tes droits"
 
 #. Username section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:304
+#: src/components/settings/AccountSettings.tsx:301
 msgid "settings.account.username.description"
 msgstr "Votre identifiant unique utilisé dans l'URL de votre profil public."

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -26,7 +26,7 @@ msgstr ""
 
 #. CC right 1
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:80
+#: src/components/LicenseContent.tsx:79
 msgid "license.data.r1"
 msgstr "\"Viktor Shcherbakov, Collection of Job Postings\" con un link alla fonte."
 
@@ -41,12 +41,12 @@ msgstr "\"Viktor Shcherbakov, Collection of Job Postings\" con un link alla font
 #. js-lingui-explicit-id
 #: src/components/Footer.tsx:41
 #: src/components/Footer.tsx:47
-#: src/components/HowWeIndexContent.tsx:196
-#: src/components/LicenseContent.tsx:64
-#: src/components/LicenseContent.tsx:89
-#: src/components/PrivacyPolicyContent.tsx:74
+#: src/components/HowWeIndexContent.tsx:194
+#: src/components/LicenseContent.tsx:63
+#: src/components/LicenseContent.tsx:88
+#: src/components/PrivacyPolicyContent.tsx:73
 #: src/components/PublicDomainArt.tsx:115
-#: src/components/TermsContent.tsx:62
+#: src/components/TermsContent.tsx:61
 msgid "common.a11y.opensInNewTab"
 msgstr "(apre in una nuova scheda)"
 
@@ -212,8 +212,8 @@ msgstr "Menu account"
 #. Active postings count on company page
 #. Active postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:554
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:564
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:561
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:571
 msgid "company.page.active"
 msgstr "attivo"
 
@@ -239,7 +239,7 @@ msgstr "Aggiungi aziende"
 
 #. Link to add a description to the watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:438
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:446
 msgid "watchlists.view.addDescription"
 msgstr "Aggiungi descrizione"
 
@@ -293,7 +293,7 @@ msgstr "Tutti i {totalCountries} paesi caricati"
 
 #. Encryption
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:47
+#: src/components/PrivacyPolicyContent.tsx:46
 msgid "privacy.short.r5"
 msgstr "Tutti i dati sono crittografati in transito e a riposo."
 
@@ -303,16 +303,16 @@ msgstr "Tutti i dati sono crittografati in transito e a riposo."
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Tutti i settori"
 
-#. All languages option
-#. js-lingui-explicit-id
-#: src/components/settings/GeneralSettings.tsx:253
-msgid "settings.general.jobLanguages.all"
-msgstr "Tutte le lingue"
-
 #. Title for the all-languages modal in settings
 #. js-lingui-explicit-id
 #: src/components/settings/JobLanguageModal.tsx:56
 msgid "settings.jobLanguages.modal.title"
+msgstr "Tutte le lingue"
+
+#. All languages option
+#. js-lingui-explicit-id
+#: src/components/settings/GeneralSettings.tsx:253
+msgid "settings.general.jobLanguages.all"
 msgstr "Tutte le lingue"
 
 #. Title for the all-locations modal on company page
@@ -335,7 +335,7 @@ msgstr "Hai già un account? <0>Accedi</0>"
 
 #. Username is taken
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:295
+#: src/components/settings/AccountSettings.tsx:292
 msgid "settings.account.username.taken"
 msgstr "Già in uso"
 
@@ -352,19 +352,19 @@ msgstr "Qualsiasi"
 
 #. Toggle to show jobs from all companies
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:466
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:474
 msgid "watchlists.view.anyCompany"
 msgstr "Qualsiasi azienda"
 
 #. MIT license section title
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:50
+#: src/components/LicenseContent.tsx:49
 msgid "license.code.title"
 msgstr "Codice dell'applicazione (MIT License)"
 
 #. TOC: Application code (MIT)
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:23
+#: src/components/LicenseContent.tsx:22
 msgid "license.toc.code"
 msgstr "Codice dell'applicazione (MIT)"
 
@@ -422,16 +422,16 @@ msgstr "Candidato"
 msgid "myJobs.status.applied"
 msgstr "Candidato"
 
-#. Status option in dropdown: applied
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:36
-msgid "myJobs.statusOption.applied"
-msgstr "Candidato"
-
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
 msgid "myJobs.funnel.applied"
+msgstr "Candidato"
+
+#. Status option in dropdown: applied
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:36
+msgid "myJobs.statusOption.applied"
 msgstr "Candidato"
 
 #. Apply salary filter
@@ -460,19 +460,19 @@ msgstr "Apr"
 
 #. Step 3 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:131
+#: src/components/HowWeIndexContent.tsx:129
 msgid "indexing.ingestion.s3.body"
 msgstr "Come ultima risorsa analizziamo le pagine carriere stesse, preferendo l'ordine dal più recente e fermandoci non appena ricompaiono posizioni già indicizzate, anziché scansionare ogni pagina."
 
 #. Username too short hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:283
+#: src/components/settings/AccountSettings.tsx:280
 msgid "settings.account.username.tooShort"
 msgstr "Minimo 3 caratteri"
 
 #. Username too long hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:285
+#: src/components/settings/AccountSettings.tsx:282
 msgid "settings.account.username.tooLong"
 msgstr "Massimo 30 caratteri"
 
@@ -484,20 +484,20 @@ msgstr "Ago"
 
 #. Username is available
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:293
+#: src/components/settings/AccountSettings.tsx:290
 msgid "settings.account.username.available"
 msgstr "Disponibile"
-
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Torna all'accesso"
 
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Torna all'accesso"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Torna all'accesso"
 
 #. Link back to sign-in from forgot password
@@ -544,18 +544,18 @@ msgstr "Blog"
 msgid "blog.post.backToIndex"
 msgstr "Blog"
 
+#. Footer link to /blog index page
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:52
+msgid "common.footer.blog"
+msgstr "Blog"
+
 #. Nav link: Blog
 #. Nav link: Blog
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:74
 #: src/components/MobileMenu.tsx:98
 msgid "common.nav.blog"
-msgstr "Blog"
-
-#. Footer link to /blog index page
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
-msgid "common.footer.blog"
 msgstr "Blog"
 
 #. Subtitle on the sign-in CTA card shown to anonymous users at the end of the similar-companies strip
@@ -566,7 +566,7 @@ msgstr "Sfoglia tutte le aziende simili"
 
 #. Link text for browsing the repo
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:192
+#: src/components/HowWeIndexContent.tsx:190
 msgid "indexing.oss.browseRepo"
 msgstr "Consulta il repository su"
 
@@ -590,7 +590,7 @@ msgstr "Creato da chi cerca lavoro, per chi cerca lavoro"
 
 #. Terms page description
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:23
+#: src/components/TermsContent.tsx:22
 msgid "terms.hero.description"
 msgstr "Utilizzando Job Seek accetti questi termini. Ecco un riassunto in parole semplici."
 
@@ -607,7 +607,7 @@ msgstr "Annulla"
 
 #. Cancel delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:535
+#: src/components/settings/AccountSettings.tsx:532
 msgid "settings.account.delete.cancel"
 msgstr "Annulla"
 
@@ -619,7 +619,7 @@ msgstr "modifica"
 
 #. Change email section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:373
+#: src/components/settings/AccountSettings.tsx:370
 msgid "settings.account.email.title"
 msgstr "Cambia email"
 
@@ -637,7 +637,7 @@ msgstr "Cambia lingua"
 
 #. Password section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:180
+#: src/components/settings/AccountSettings.tsx:177
 msgid "settings.account.password.description"
 msgstr "Cambia la tua password tramite un link email sicuro."
 
@@ -647,21 +647,21 @@ msgstr "Cambia la tua password tramite un link email sicuro."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Cambia…"
 
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "Controlla la tua e-mail"
-
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
 msgstr "Controlla la tua email"
 
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
+msgstr "Controlla la tua e-mail"
+
 #. Checking username availability
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:291
+#: src/components/settings/AccountSettings.tsx:288
 msgid "settings.account.username.checking"
 msgstr "Verifica disponibilità..."
 
@@ -711,14 +711,14 @@ msgstr "Reimposta"
 
 #. Button to remove all companies from watchlist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:484
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:492
 msgid "watchlists.view.clearAllCompanies"
 msgstr "Rimuovi tutti"
 
 #. Button to clear all active search filters
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:616
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:624
 #: src/components/search/search-toolbar.tsx:337
 msgid "search.filters.clearAll"
 msgstr "Cancella tutto"
@@ -731,19 +731,19 @@ msgstr "Rimuovi tutti"
 
 #. Tooltip for clicking to edit watchlist description
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:426
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:434
 msgid "watchlists.view.editDescription"
 msgstr "Clicca per modificare la descrizione"
 
 #. Tooltip for clicking to edit watchlist title
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:376
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:384
 msgid "watchlists.view.editTitle"
 msgstr "Clicca per rinominare"
 
 #. Step 2 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:121
+#: src/components/HowWeIndexContent.tsx:119
 msgid "indexing.ingestion.s2.title"
 msgstr "API client come seconda opzione."
 
@@ -755,7 +755,7 @@ msgstr "Chiudi menu"
 
 #. Label for inactive/closed job postings on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:656
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:663
 msgid "company.page.closed"
 msgstr "Chiuso"
 
@@ -773,7 +773,7 @@ msgstr "Coding"
 
 #. CC license section title
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:71
+#: src/components/LicenseContent.tsx:70
 msgid "license.data.title"
 msgstr "Raccolta di annunci di lavoro (CC BY-NC 4.0)"
 
@@ -809,7 +809,7 @@ msgstr "Aziende monitorate"
 
 #. Button to open company search modal
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:455
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:463
 msgid "watchlists.view.addCompany"
 msgstr "Azienda"
 
@@ -851,7 +851,7 @@ msgstr "Strumento di tracciamento aziende per chi cerca lavoro in modo mirato �
 
 #. Confirm delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:528
+#: src/components/settings/AccountSettings.tsx:525
 msgid "settings.account.delete.confirm"
 msgstr "Conferma eliminazione"
 
@@ -863,25 +863,25 @@ msgstr "Conferma password"
 
 #. Connect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:478
+#: src/components/settings/AccountSettings.tsx:475
 msgid "settings.account.socials.connect"
 msgstr "Collega"
 
 #. Connected accounts section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:453
+#: src/components/settings/AccountSettings.tsx:450
 msgid "settings.account.socials.title"
 msgstr "Account collegati"
 
 #. TOC: Contact
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:25
+#: src/components/LicenseContent.tsx:24
 msgid "license.toc.contact"
 msgstr "Contatti"
 
 #. Contact section title
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:96
+#: src/components/LicenseContent.tsx:95
 msgid "license.contact.title"
 msgstr "Contatti"
 
@@ -893,13 +893,13 @@ msgstr "Contatti"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
+#: src/components/LicenseContent.tsx:17
 msgid "license.toc.title"
 msgstr "Sommario"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:23
+#: src/components/HowWeIndexContent.tsx:21
 msgid "indexing.toc.title"
 msgstr "Sommario"
 
@@ -929,13 +929,13 @@ msgstr "Continua con LinkedIn"
 
 #. Employment type: contract
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:14
+#: src/components/search/employment-type-modal.tsx:15
 msgid "search.employmentType.contract"
 msgstr "Freelance"
 
 #. Cookies
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:46
+#: src/components/PrivacyPolicyContent.tsx:45
 msgid "privacy.short.r4"
 msgstr "I cookie servono solo per la sessione — niente pubblicità, niente tracciamento."
 
@@ -947,7 +947,7 @@ msgstr "Copiato"
 
 #. MIT right 1
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:58
+#: src/components/LicenseContent.tsx:57
 msgid "license.code.r1"
 msgstr "Copiare e modificare il codice per qualsiasi scopo, inclusi prodotti commerciali."
 
@@ -985,13 +985,13 @@ msgstr "Codice sorgente del crawler"
 
 #. TOC: Crawling assurances
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:28
+#: src/components/HowWeIndexContent.tsx:26
 msgid "indexing.toc.assurances"
 msgstr "Garanzie di crawling"
 
 #. Assurances section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:63
+#: src/components/HowWeIndexContent.tsx:61
 msgid "indexing.assurances.title"
 msgstr "Garanzie di crawling"
 
@@ -1055,6 +1055,12 @@ msgstr "Valuta"
 msgid "settings.billing.currentPlan"
 msgstr "Attuale"
 
+#. Salary period suffix shown after the amount, e.g. '300 EUR / daily'
+#. js-lingui-explicit-id
+#: src/components/SalaryDisplayProvider.tsx:59
+msgid "common.salary.period.daily"
+msgstr "al giorno"
+
 #. Daily pay period option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:372
@@ -1111,13 +1117,13 @@ msgstr "Elimina"
 
 #. Delete account section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:511
+#: src/components/settings/AccountSettings.tsx:508
 msgid "settings.account.delete.title"
 msgstr "Elimina account"
 
 #. Delete account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:521
+#: src/components/settings/AccountSettings.tsx:518
 msgid "settings.account.delete.button"
 msgstr "Elimina il mio account"
 
@@ -1129,13 +1135,13 @@ msgstr "Eliminare la lista di osservazione?"
 
 #. Delete button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:527
+#: src/components/settings/AccountSettings.tsx:524
 msgid "settings.account.delete.deleting"
 msgstr "Eliminazione…"
 
 #. Placeholder for watchlist description textarea
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:418
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:426
 msgid "watchlists.view.descriptionPlaceholder"
 msgstr "Descrivi questa watchlist …"
 
@@ -1171,7 +1177,7 @@ msgstr "Disattiva notifiche"
 
 #. Disconnect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:477
+#: src/components/settings/AccountSettings.tsx:474
 msgid "settings.account.socials.disconnect"
 msgstr "Scollega"
 
@@ -1194,7 +1200,7 @@ msgstr "Non hai un account? <0>Registrati</0>"
 
 #. No scraping
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:45
+#: src/components/TermsContent.tsx:44
 msgid "terms.short.r3"
 msgstr "Niente scraping, candidature automatizzate o abuso della piattaforma."
 
@@ -1256,7 +1262,7 @@ msgstr "Email verificata"
 
 #. Title for the employment type selection modal
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:48
+#: src/components/search/employment-type-modal.tsx:74
 msgid "search.employmentTypeModal.title"
 msgstr "Tipo di impiego"
 
@@ -1280,7 +1286,7 @@ msgstr "Inserisci la tua nuova password qui sotto."
 
 #. Assurance 3 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:80
+#: src/components/HowWeIndexContent.tsx:78
 msgid "indexing.assurances.i3.body"
 msgstr "Anche dopo la scoperta, recuperiamo le pagine di dettaglio degli annunci con un limite rigoroso di una richiesta per sito al minuto."
 
@@ -1292,7 +1298,7 @@ msgstr "Tutti i filtri di cui chi cerca lavoro ha davvero bisogno"
 
 #. Assurance 1 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:68
+#: src/components/HowWeIndexContent.tsx:66
 msgid "indexing.assurances.i1.body"
 msgstr "Ogni finestra di retry utilizza un backoff esponenziale, così non sovraccarichiamo mai un server, e ci fermiamo se un host continua a non rispondere."
 
@@ -1315,16 +1321,16 @@ msgstr "Avvisi e-mail per nuove offerte"
 msgid "faq.description"
 msgstr "Tutto quello che devi sapere su Job Seek. Non trovi quello che cerchi? Scrivici a <0>{0}</0>."
 
-#. Label for experience filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:231
-msgid "search.advanced.experience"
-msgstr "Esperienza"
-
 #. Title for experience filter modal
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:186
 msgid "search.experienceModal.title"
+msgstr "Esperienza"
+
+#. Label for experience filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:231
+msgid "search.advanced.experience"
 msgstr "Esperienza"
 
 #. Breadcrumb label for the Explore page
@@ -1346,27 +1352,27 @@ msgstr "Esplora lavori"
 
 #. Generic email change error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:363
+#: src/components/settings/AccountSettings.tsx:360
 msgid "settings.account.email.error"
 msgstr "Impossibile cambiare l'email"
 
 #. Error when linking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:429
+#: src/components/settings/AccountSettings.tsx:426
 msgid "settings.account.socials.connectError"
 msgstr "Impossibile collegare l'account"
 
 #. Generic account deletion error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:502
+#: src/components/settings/AccountSettings.tsx:499
 msgid "settings.account.delete.error"
 msgstr "Impossibile eliminare l'account"
 
 #. Error when unlinking social account fails
 #. Error when unlinking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:440
-#: src/components/settings/AccountSettings.tsx:445
+#: src/components/settings/AccountSettings.tsx:437
+#: src/components/settings/AccountSettings.tsx:442
 msgid "settings.account.socials.disconnectError"
 msgstr "Impossibile scollegare l'account"
 
@@ -1384,7 +1390,7 @@ msgstr "Impossibile reimpostare la password. Il link potrebbe essere scaduto."
 
 #. Generic password reset error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:167
+#: src/components/settings/AccountSettings.tsx:164
 msgid "settings.account.password.error"
 msgstr "Impossibile inviare l'email di reimpostazione"
 
@@ -1396,7 +1402,7 @@ msgstr "Impossibile impostare la password"
 
 #. Generic username update error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:264
+#: src/components/settings/AccountSettings.tsx:261
 msgid "settings.account.username.error"
 msgstr "Impossibile aggiornare il nome utente"
 
@@ -1587,7 +1593,7 @@ msgstr "Ricerca completa, una watchlist e un tracker delle candidature integrato
 
 #. Employment type: full-time
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:12
+#: src/components/search/employment-type-modal.tsx:13
 msgid "search.employmentType.fullTime"
 msgstr "Tempo pieno"
 
@@ -1645,7 +1651,7 @@ msgstr "Capito"
 
 #. Step 3 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:129
+#: src/components/HowWeIndexContent.tsx:127
 msgid "indexing.ingestion.s3.title"
 msgstr "Parsing delle pagine delicato."
 
@@ -1666,6 +1672,12 @@ msgstr "Hiring Manager"
 #: app/[lang]/(app)/company/[slug]/company-head.tsx:49
 msgid "breadcrumb.home"
 msgstr "Home"
+
+#. Salary period suffix shown after the amount, e.g. '26 USD / hourly'
+#. js-lingui-explicit-id
+#: src/components/SalaryDisplayProvider.tsx:61
+msgid "common.salary.period.hourly"
+msgstr "all'ora"
 
 #. Hourly pay period option
 #. js-lingui-explicit-id
@@ -1702,19 +1714,19 @@ msgstr "Con quale frequenza vengono aggiornate le offerte di lavoro?"
 
 #. TOC: How postings enter the index
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:29
+#: src/components/HowWeIndexContent.tsx:27
 msgid "indexing.toc.ingestion"
 msgstr "Come gli annunci entrano nell'indice"
 
 #. Ingestion section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:104
+#: src/components/HowWeIndexContent.tsx:102
 msgid "indexing.ingestion.title"
 msgstr "Come gli annunci entrano nell'indice"
 
 #. Indexing page title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:48
+#: src/components/HowWeIndexContent.tsx:46
 msgid "indexing.hero.title"
 msgstr "Come troviamo e processiamo gli annunci di lavoro"
 
@@ -1729,10 +1741,10 @@ msgstr "Come indicizziamo"
 #. Work mode: hybrid (mixed onsite/remote)
 #. Work mode: hybrid (mixed onsite/remote)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:579
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:587
 #: src/components/search/search-bar.tsx:812
 #: src/components/search/search-toolbar.tsx:260
-#: src/components/search/work-mode-modal.tsx:21
+#: src/components/search/work-mode-modal.tsx:27
 msgid "search.workMode.hybrid"
 msgstr "Ibrido"
 
@@ -1744,19 +1756,19 @@ msgstr "Se esiste un account per quell'indirizzo e-mail, abbiamo inviato un link
 
 #. Step 2 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:123
+#: src/components/HowWeIndexContent.tsx:121
 msgid "indexing.ingestion.s2.body"
 msgstr "Se non esiste una sitemap, ispezioniamo l'applicazione client alla ricerca di API JSON che utilizza; quando le troviamo, interroghiamo direttamente quegli endpoint per enumerare gli URL degli annunci senza fare scraping del DOM."
 
 #. Opt-out section body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:164
+#: src/components/HowWeIndexContent.tsx:162
 msgid "indexing.optOut.body"
 msgstr "Se noti attività impreviste del nostro crawler o preferisci che il tuo sito carriere non venga indicizzato, scrivici via email e risponderemo tempestivamente."
 
 #. Outreach section body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:206
+#: src/components/HowWeIndexContent.tsx:204
 msgid "indexing.outreach.body"
 msgstr "Se noti un comportamento anomalo del crawler, preferisci che non indicizziamo i tuoi contenuti o hai suggerimenti su come migliorare le nostre misure di sicurezza, contattaci."
 
@@ -1768,8 +1780,8 @@ msgstr "a {locations}"
 #. Year postings count on company page
 #. Year postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:556
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:568
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:563
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:575
 msgid "company.page.yearCount"
 msgstr "nell'ultimo anno"
 
@@ -1801,7 +1813,7 @@ msgstr "Incluso in {ancestorName}"
 
 #. Indexing page eyebrow
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:45
+#: src/components/HowWeIndexContent.tsx:43
 msgid "indexing.hero.eyebrow"
 msgstr "Politica di indicizzazione"
 
@@ -1843,7 +1855,7 @@ msgstr "Invece di aspettare che le aziende pubblichino le posizioni su portali d
 
 #. Employment type: internship
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:15
+#: src/components/search/employment-type-modal.tsx:16
 msgid "search.employmentType.internship"
 msgstr "Stage"
 
@@ -1936,7 +1948,7 @@ msgstr "offerta"
 
 #. TOC: Job data (CC BY-NC 4.0)
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:24
+#: src/components/LicenseContent.tsx:23
 msgid "license.toc.data"
 msgstr "Dati sugli annunci (CC BY-NC 4.0)"
 
@@ -1989,7 +2001,7 @@ msgstr "Job Seek ti aiuta a monitorare le aziende per cui vuoi lavorare — watc
 
 #. Indexing page description — company-tracking framing, not 'search engine'
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:51
+#: src/components/HowWeIndexContent.tsx:49
 msgid "indexing.hero.description"
 msgstr "Job Seek è uno strumento di tracciamento aziende — monitora migliaia di pagine carriere aziendali in modo che gli utenti possano creare watchlist e ricevere avvisi su nuovi annunci. Questa pagina documenta esattamente come si comporta il nostro crawler, i controlli che lo rendono rispettoso e come gli annunci finiscono nell'indice."
 
@@ -2025,7 +2037,7 @@ msgstr "Watchlist di Job Seek con posizioni selezionate in ingegneria robotica a
 
 #. License page description
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:38
+#: src/components/LicenseContent.tsx:37
 msgid "license.hero.description"
 msgstr "Il codice sorgente di Job Seek è open source sotto licenza MIT. I dati sugli annunci che raccogliamo e arricchiamo sono Creative Commons BY-NC 4.0. Di seguito il riepilogo in linguaggio semplice — si prega di leggere le licenze complete per i termini esatti."
 
@@ -2100,13 +2112,13 @@ msgstr "Ultima ora"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:28
+#: src/components/TermsContent.tsx:27
 msgid "terms.hero.lastUpdated"
 msgstr "Ultimo aggiornamento:"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:28
+#: src/components/PrivacyPolicyContent.tsx:27
 msgid "privacy.hero.lastUpdated"
 msgstr "Ultimo aggiornamento:"
 
@@ -2122,16 +2134,16 @@ msgstr "Ultima settimana"
 msgid "home.hero.secondaryCta"
 msgstr "Scopri di più"
 
-#. Label for seniority/level filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:202
-msgid "search.advanced.level"
-msgstr "Livello"
-
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:730
 msgid "search.bar.level"
+msgstr "Livello"
+
+#. Label for seniority/level filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:202
+msgid "search.advanced.level"
 msgstr "Livello"
 
 #. js-lingui-explicit-id
@@ -2154,13 +2166,13 @@ msgstr "Licenza"
 
 #. License page title
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:37
+#: src/components/LicenseContent.tsx:36
 msgid "license.hero.title"
 msgstr "Licenza di Job Seek"
 
 #. License page eyebrow
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:36
+#: src/components/LicenseContent.tsx:35
 msgid "license.hero.eyebrow"
 msgstr "Licenze"
 
@@ -2258,7 +2270,7 @@ msgstr "Gestisci abbonamento"
 
 #. Connected accounts section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:456
+#: src/components/settings/AccountSettings.tsx:453
 msgid "settings.account.socials.description"
 msgstr "Gestisci i tuoi account social collegati."
 
@@ -2359,6 +2371,12 @@ msgstr "Lun"
 msgid "app.schema.feature.monitor"
 msgstr "Monitorare le pagine carriere delle aziende"
 
+#. Salary period suffix shown after the amount, e.g. '5k EUR / monthly'
+#. js-lingui-explicit-id
+#: src/components/SalaryDisplayProvider.tsx:57
+msgid "common.salary.period.monthly"
+msgstr "al mese"
+
 #. Monthly pay period option
 #. js-lingui-explicit-id
 #: src/components/settings/GeneralSettings.tsx:369
@@ -2432,19 +2450,19 @@ msgstr "Nome"
 
 #. TOC: Need to reach us?
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:33
+#: src/components/HowWeIndexContent.tsx:31
 msgid "indexing.toc.outreach"
 msgstr "Vuoi contattarci?"
 
 #. Outreach section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:203
+#: src/components/HowWeIndexContent.tsx:201
 msgid "indexing.outreach.title"
 msgstr "Vuoi contattarci?"
 
 #. New email input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:385
+#: src/components/settings/AccountSettings.tsx:382
 msgid "settings.account.email.label"
 msgstr "Nuova email"
 
@@ -2468,7 +2486,7 @@ msgstr "Nessuna candidatura il {date}"
 
 #. CC right 2
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:84
+#: src/components/LicenseContent.tsx:83
 msgid "license.data.r2"
 msgstr "Nessuna ridistribuzione commerciale o rivendita senza autorizzazione."
 
@@ -2496,21 +2514,21 @@ msgstr "Nessuna offerta trovata."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Nessuna lingua corrisponde alla ricerca."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:309
-msgid "company.locationModal.noResults"
-msgstr "Nessuna sede corrisponde alla tua ricerca."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:513
 msgid "search.locationModal.noResults"
 msgstr "Nessun luogo corrisponde alla tua ricerca."
 
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:309
+msgid "company.locationModal.noResults"
+msgstr "Nessuna sede corrisponde alla tua ricerca."
+
 #. No postings found message on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:637
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:644
 msgid "company.page.noResults"
 msgstr "Nessun annuncio corrispondente trovato."
 
@@ -2558,7 +2576,7 @@ msgstr "Nessun lavoro monitorato. Salva offerte dai risultati di ricerca per ini
 
 #. MIT right 3
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:60
+#: src/components/LicenseContent.tsx:59
 msgid "license.code.r3"
 msgstr "Nessuna garanzia — l'uso è a proprio rischio e pericolo."
 
@@ -2638,16 +2656,16 @@ msgstr "Offerta"
 msgid "myJobs.group.offered"
 msgstr "Offerta"
 
-#. Status option in dropdown: offered
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:38
-msgid "myJobs.statusOption.offered"
-msgstr "Offerta"
-
 #. Sankey funnel node: offered
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:43
 msgid "myJobs.funnel.offered"
+msgstr "Offerta"
+
+#. Status option in dropdown: offered
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:38
+msgid "myJobs.statusOption.offered"
 msgstr "Offerta"
 
 #. Cookie banner accept button
@@ -2661,28 +2679,28 @@ msgstr "Ok"
 #. Work mode: onsite (in-office)
 #. Work mode: onsite (in-office)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:577
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:585
 #: src/components/search/search-bar.tsx:810
 #: src/components/search/search-toolbar.tsx:258
-#: src/components/search/work-mode-modal.tsx:20
+#: src/components/search/work-mode-modal.tsx:26
 msgid "search.workMode.onsite"
 msgstr "In sede"
 
 #. Step 4 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:139
+#: src/components/HowWeIndexContent.tsx:137
 msgid "indexing.ingestion.s4.body"
 msgstr "Una volta recuperato un singolo annuncio, memorizziamo solo i metadati specifici della posizione (titolo, descrizione del ruolo, sede, note sulla retribuzione, URL dell'annuncio e date) oltre ai campi strutturati estratti. Non archiviamo contenuti del sito non correlati."
 
 #. Assurance 3 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:79
+#: src/components/HowWeIndexContent.tsx:77
 msgid "indexing.assurances.i3.title"
 msgstr "Una pagina al minuto."
 
 #. Username invalid characters hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:287
+#: src/components/settings/AccountSettings.tsx:284
 msgid "settings.account.username.invalidChars"
 msgstr "Solo lettere minuscole, numeri e trattini (non all'inizio/fine)"
 
@@ -2705,25 +2723,25 @@ msgstr "Posizioni aperte"
 
 #. TOC: Open-source crawlers
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:32
+#: src/components/HowWeIndexContent.tsx:30
 msgid "indexing.toc.oss"
 msgstr "Crawler open source"
 
 #. Open-source section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:185
+#: src/components/HowWeIndexContent.tsx:183
 msgid "indexing.oss.title"
 msgstr "Crawler open source"
 
 #. TOC: Opt-out or questions
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:30
+#: src/components/HowWeIndexContent.tsx:28
 msgid "indexing.toc.optOut"
 msgstr "Opt-out o domande"
 
 #. Opt-out section title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:161
+#: src/components/HowWeIndexContent.tsx:159
 msgid "indexing.optOut.title"
 msgstr "Opt-out o domande"
 
@@ -2759,43 +2777,43 @@ msgstr "Altro"
 
 #. Assurance 2 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:73
+#: src/components/HowWeIndexContent.tsx:71
 msgid "indexing.assurances.i2.body"
 msgstr "Il nostro crawler legge il file <0>robots.txt</0>, rispetta le regole di disallow, si identifica tramite <1>User-Agent</1> e rispetta l'header W3C <2>TDM-Reservation</2> — se una pagina segnala una riserva, la saltiamo."
 
 #. TOC: Our stance on automation
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:31
+#: src/components/HowWeIndexContent.tsx:29
 msgid "indexing.toc.automation"
 msgstr "La nostra posizione sull'automazione"
 
 #. Automation stance title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:174
+#: src/components/HowWeIndexContent.tsx:172
 msgid "indexing.automation.title"
 msgstr "La nostra posizione sull'automazione"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:22
+#: src/components/LicenseContent.tsx:21
 msgid "license.toc.overview"
 msgstr "Panoramica"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:27
+#: src/components/HowWeIndexContent.tsx:25
 msgid "indexing.toc.overview"
 msgstr "Panoramica"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:19
+#: src/components/LicenseContent.tsx:18
 msgid "license.toc.ariaLabel"
 msgstr "Contenuti della pagina"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:24
+#: src/components/HowWeIndexContent.tsx:22
 msgid "indexing.toc.ariaLabel"
 msgstr "Contenuti della pagina"
 
@@ -2813,7 +2831,7 @@ msgstr "Panel"
 
 #. Employment type: part-time
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:13
+#: src/components/search/employment-type-modal.tsx:14
 msgid "search.employmentType.partTime"
 msgstr "Part-time"
 
@@ -2827,13 +2845,13 @@ msgstr "Password"
 #. Password section heading
 #. js-lingui-explicit-id
 #: src/components/settings/AccountSettings.tsx:89
-#: src/components/settings/AccountSettings.tsx:177
+#: src/components/settings/AccountSettings.tsx:174
 msgid "settings.account.password.title"
 msgstr "Password"
 
 #. Success message after password reset request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:169
+#: src/components/settings/AccountSettings.tsx:166
 msgid "settings.account.password.success"
 msgstr "Link per il reset della password inviato. Controlla la tua casella di posta. Potrebbe volerci qualche minuto per l'arrivo."
 
@@ -2887,7 +2905,7 @@ msgstr "Periodo"
 
 #. Delete account section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:514
+#: src/components/settings/AccountSettings.tsx:511
 msgid "settings.account.delete.description"
 msgstr "Elimina definitivamente il tuo account e tutti i dati associati. Questa azione non può essere annullata."
 
@@ -2923,7 +2941,7 @@ msgstr "Inserisci un nome di azienda o un URL."
 
 #. Error when email field is empty
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:353
+#: src/components/settings/AccountSettings.tsx:350
 msgid "settings.account.email.required"
 msgstr "Inserisci un nuovo indirizzo email"
 
@@ -3003,7 +3021,7 @@ msgstr "Prezzi"
 
 #. Privacy policy page eyebrow
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:21
+#: src/components/PrivacyPolicyContent.tsx:20
 msgid "privacy.hero.eyebrow"
 msgstr "Privacy"
 
@@ -3015,7 +3033,7 @@ msgstr "Privacy"
 
 #. Privacy policy page title
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:22
+#: src/components/PrivacyPolicyContent.tsx:21
 msgid "privacy.hero.title"
 msgstr "Privacy su Job Seek"
 
@@ -3051,43 +3069,43 @@ msgstr "Pubblico dominio"
 
 #. Contact call to action
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:99
+#: src/components/LicenseContent.tsx:98
 msgid "license.contactCta"
 msgstr "Domande sulle licenze o sull'uso commerciale? Scrivici via email."
 
 #. Terms contact call to action
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:54
+#: src/components/TermsContent.tsx:53
 msgid "terms.contact.description"
 msgstr "Domande? Scrivici."
 
 #. Privacy contact call to action
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:66
+#: src/components/PrivacyPolicyContent.tsx:65
 msgid "privacy.contact.description"
 msgstr "Domande? Scrivici."
 
 #. Link to full CC license
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:88
+#: src/components/LicenseContent.tsx:87
 msgid "license.data.linkLabel"
 msgstr "Leggi la licenza CC BY-NC 4.0"
 
 #. Link to full MIT license
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:63
+#: src/components/LicenseContent.tsx:62
 msgid "license.code.linkLabel"
 msgstr "Leggi la licenza MIT completa"
 
 #. Link to full privacy policy text
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:73
+#: src/components/PrivacyPolicyContent.tsx:72
 msgid "privacy.extras.fullPolicyLink"
 msgstr "Leggi l'informativa sulla privacy completa"
 
 #. Link to full terms of service text
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:61
+#: src/components/TermsContent.tsx:60
 msgid "terms.fullTermsLink"
 msgstr "Leggi i termini di servizio completi"
 
@@ -3110,7 +3128,7 @@ msgstr "Registra ogni round di colloquio con data, tipo e note così non ti sfug
 
 #. MIT right 2
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:59
+#: src/components/LicenseContent.tsx:58
 msgid "license.code.r2"
 msgstr "Ridistribuire le proprie modifiche, a condizione di includere l'avviso MIT."
 
@@ -3126,16 +3144,16 @@ msgstr "Ridistribuire le proprie modifiche, a condizione di includere l'avviso M
 msgid "location.type.region"
 msgstr "Regione"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:319
-msgid "company.locationModal.regionsHeader"
-msgstr "Regioni"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:523
 msgid "search.locationModal.regionsHeader"
+msgstr "Regioni"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:319
+msgid "company.locationModal.regionsHeader"
 msgstr "Regioni"
 
 #. Status group heading: rejected
@@ -3156,16 +3174,16 @@ msgstr "Rifiutato"
 msgid "myJobs.status.rejected"
 msgstr "Rifiutato"
 
-#. Status option in dropdown: rejected
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:39
-msgid "myJobs.statusOption.rejected"
-msgstr "Rifiutato"
-
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
 msgid "myJobs.funnel.rejected"
+msgstr "Rifiutato"
+
+#. Status option in dropdown: rejected
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:39
+msgid "myJobs.statusOption.rejected"
 msgstr "Rifiutato"
 
 #. Footer license summary text
@@ -3179,10 +3197,10 @@ msgstr "Rilasciato sotto licenza MIT. I dati sugli annunci sono CC BY-NC 4.0."
 #. Work mode: remote (work-from-home)
 #. Work mode: remote (work-from-home)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:580
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:588
 #: src/components/search/search-bar.tsx:813
 #: src/components/search/search-toolbar.tsx:261
-#: src/components/search/work-mode-modal.tsx:22
+#: src/components/search/work-mode-modal.tsx:28
 msgid "search.workMode.remote"
 msgstr "Remoto"
 
@@ -3236,7 +3254,7 @@ msgstr "Reinvia tra {cooldown}s"
 
 #. Reset password button during cooldown with seconds remaining
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:190
+#: src/components/settings/AccountSettings.tsx:187
 msgid "settings.account.password.cooldown"
 msgstr "Reinvia tra {cooldown}s"
 
@@ -3272,13 +3290,13 @@ msgstr "Reimpostazione…"
 
 #. Assurance 1 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:67
+#: src/components/HowWeIndexContent.tsx:65
 msgid "indexing.assurances.i1.title"
 msgstr "Ritmo rispettoso."
 
 #. Assurance 2 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:71
+#: src/components/HowWeIndexContent.tsx:69
 msgid "indexing.assurances.i2.title"
 msgstr "Robot, attribuzione e riserva TDM."
 
@@ -3306,16 +3324,16 @@ msgstr "Turno"
 msgid "app.home.request.agent.runIdLabel"
 msgstr "ID esecuzione"
 
-#. Label for salary filter in advanced search
-#. js-lingui-explicit-id
-#: src/components/search/advanced-search-panel.tsx:225
-msgid "search.advanced.salary"
-msgstr "Stipendio"
-
 #. Salary override section heading
 #. js-lingui-explicit-id
 #: src/components/my-jobs/salary-override.tsx:76
 msgid "myJobs.detail.salary"
+msgstr "Stipendio"
+
+#. Label for salary filter in advanced search
+#. js-lingui-explicit-id
+#: src/components/search/advanced-search-panel.tsx:225
+msgid "search.advanced.salary"
 msgstr "Stipendio"
 
 #. Salary display settings section heading
@@ -3384,27 +3402,27 @@ msgstr "Salvato"
 msgid "myJobs.status.saved"
 msgstr "Salvato"
 
-#. Status option in dropdown: saved
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:35
-msgid "myJobs.statusOption.saved"
-msgstr "Salvato"
-
 #. Sankey funnel node: saved jobs
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:41
 msgid "myJobs.funnel.saved"
 msgstr "Salvato"
 
+#. Status option in dropdown: saved
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:35
+msgid "myJobs.statusOption.saved"
+msgstr "Salvato"
+
 #. Username save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:323
+#: src/components/settings/AccountSettings.tsx:320
 msgid "settings.account.username.saving"
 msgstr "Salvataggio..."
 
 #. Email save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:395
+#: src/components/settings/AccountSettings.tsx:392
 msgid "settings.account.email.saving"
 msgstr "Salvataggio…"
 
@@ -3427,16 +3445,16 @@ msgstr "Cerca tra migliaia di aziende prese direttamente dalle loro pagine carri
 msgid "company.page.searchPlaceholder"
 msgstr "Cerca in {0}..."
 
-#. Placeholder for company search in modal
-#. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:217
-msgid "watchlists.companyModal.searchPlaceholder"
-msgstr "Cerca aziende..."
-
 #. Placeholder for company search in watchlist creation
 #. js-lingui-explicit-id
 #: src/components/watchlist/company-selector.tsx:91
 msgid "watchlists.companySelector.placeholder"
+msgstr "Cerca aziende..."
+
+#. Placeholder for company search in modal
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-search-modal.tsx:217
+msgid "watchlists.companyModal.searchPlaceholder"
 msgstr "Cerca aziende..."
 
 #. Option to search by title keyword in dropdown
@@ -3456,17 +3474,17 @@ msgstr "Cerca lavori in migliaia di aziende, scansionati direttamente dalle pagi
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Cerca lingue…"
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:288
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Cerca sedi…"
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:492
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Cerca luoghi..."
+
+#. Placeholder for search input in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:288
+msgid "company.locationModal.searchPlaceholder"
+msgstr "Cerca sedi…"
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3536,7 +3554,7 @@ msgstr "Seleziona la lingua preferita."
 
 #. Step 4 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:137
+#: src/components/HowWeIndexContent.tsx:135
 msgid "indexing.ingestion.s4.title"
 msgstr "Archiviazione selettiva."
 
@@ -3548,15 +3566,9 @@ msgstr "Invia link"
 
 #. Reset password button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:191
+#: src/components/settings/AccountSettings.tsx:188
 msgid "settings.account.password.send"
 msgstr "Invia il link"
-
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Invio in corso..."
 
 #. Resend button while sending
 #. js-lingui-explicit-id
@@ -3564,9 +3576,15 @@ msgstr "Invio in corso..."
 msgid "auth.verify.resending"
 msgstr "Invio in corso..."
 
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
+msgstr "Invio in corso..."
+
 #. Reset password button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:188
+#: src/components/settings/AccountSettings.tsx:185
 msgid "settings.account.password.sending"
 msgstr "Invio…"
 
@@ -3746,7 +3764,7 @@ msgstr "Prezzi semplici e trasparenti. Inizia gratis e passa al piano superiore 
 
 #. Step 1 title
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:113
+#: src/components/HowWeIndexContent.tsx:111
 msgid "indexing.ingestion.s1.title"
 msgstr "Prima la sitemap."
 
@@ -3932,13 +3950,13 @@ msgstr "Indicaci il nome dell'azienda e (idealmente) l'URL della pagina carriere
 
 #. Employment type: temporary
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:16
+#: src/components/search/employment-type-modal.tsx:17
 msgid "search.employmentType.temporary"
 msgstr "Temporaneo"
 
 #. Terms page eyebrow
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:21
+#: src/components/TermsContent.tsx:20
 msgid "terms.hero.eyebrow"
 msgstr "Termini di servizio"
 
@@ -3956,7 +3974,7 @@ msgstr "Termini di servizio"
 
 #. Terms page title
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:22
+#: src/components/TermsContent.tsx:21
 msgid "terms.hero.title"
 msgstr "Termini di servizio"
 
@@ -4002,19 +4020,19 @@ msgstr "La pagina che stai cercando non esiste o è stata spostata."
 
 #. Provided as-is
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:46
+#: src/components/TermsContent.tsx:45
 msgid "terms.short.r4"
 msgstr "Il servizio è fornito così com'è, senza garanzie."
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:40
+#: src/components/TermsContent.tsx:39
 msgid "terms.short.title"
 msgstr "In breve"
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:40
+#: src/components/PrivacyPolicyContent.tsx:39
 msgid "privacy.short.title"
 msgstr "In breve"
 
@@ -4038,7 +4056,7 @@ msgstr "Questo sito utilizza i cookie solo per l'autenticazione e le funzionalit
 
 #. Username is reserved hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:289
+#: src/components/settings/AccountSettings.tsx:286
 msgid "settings.account.username.reserved"
 msgstr "Questo nome utente è riservato"
 
@@ -4080,7 +4098,7 @@ msgstr "Monitora la tua pipeline"
 
 #. Open-source section body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:188
+#: src/components/HowWeIndexContent.tsx:186
 msgid "indexing.oss.body"
 msgstr "La trasparenza è importante, perciò il codice del nostro servizio di raccolta link e della pipeline di estrazione è open source."
 
@@ -4122,7 +4140,7 @@ msgstr "In fase di sviluppo"
 
 #. Your rights intro
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:57
+#: src/components/PrivacyPolicyContent.tsx:56
 msgid "privacy.rights.intro"
 msgstr "Secondo il GDPR puoi richiedere una copia dei tuoi dati, farli correggere o cancellare, esportarli o opporti al trattamento. Elimina il tuo account e tutto viene cancellato entro 30 giorni."
 
@@ -4157,19 +4175,19 @@ msgstr "Rimuovi offerta"
 
 #. Email save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:396
+#: src/components/settings/AccountSettings.tsx:393
 msgid "settings.account.email.save"
 msgstr "Aggiorna email"
 
 #. Change email section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:376
+#: src/components/settings/AccountSettings.tsx:373
 msgid "settings.account.email.description"
 msgstr "Aggiorna l'indirizzo email associato al tuo account."
 
 #. Username save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:324
+#: src/components/settings/AccountSettings.tsx:321
 msgid "settings.account.username.save"
 msgstr "Aggiorna nome utente"
 
@@ -4210,25 +4228,25 @@ msgstr "utente"
 
 #. Username section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:301
+#: src/components/settings/AccountSettings.tsx:298
 msgid "settings.account.username.title"
 msgstr "Nome utente"
 
 #. Username input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:313
+#: src/components/settings/AccountSettings.tsx:310
 msgid "settings.account.username.label"
 msgstr "Nome utente"
 
 #. Username updated success message
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:276
+#: src/components/settings/AccountSettings.tsx:273
 msgid "settings.account.username.success"
 msgstr "Nome utente aggiornato."
 
 #. Success message after email change request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:365
+#: src/components/settings/AccountSettings.tsx:362
 msgid "settings.account.email.success"
 msgstr "Email di verifica inviata. Controlla la tua casella di posta. Potrebbe volerci qualche minuto per l'arrivo."
 
@@ -4264,7 +4282,7 @@ msgstr "Vedi offerta"
 
 #. Employment type: volunteer
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:17
+#: src/components/search/employment-type-modal.tsx:18
 msgid "search.employmentType.volunteer"
 msgstr "Volontariato"
 
@@ -4300,7 +4318,7 @@ msgstr "Liste di osservazione"
 
 #. Back to watchlists link
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:344
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:352
 msgid "watchlists.view.back"
 msgstr "Liste di osservazione"
 
@@ -4323,7 +4341,7 @@ msgstr "Watchlist e tracciamento delle candidature"
 
 #. What the service does
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:44
+#: src/components/TermsContent.tsx:43
 msgid "terms.short.r2"
 msgstr "Aggreghiamo offerte di lavoro pubbliche. Non garantiamo che siano accurate o aggiornate."
 
@@ -4335,13 +4353,13 @@ msgstr "Crediamo che la ricerca di lavoro debba essere guidata dalla persona che
 
 #. Privacy policy page description
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:23
+#: src/components/PrivacyPolicyContent.tsx:22
 msgid "privacy.hero.description"
 msgstr "Raccogliamo solo il necessario, non vendiamo i tuoi dati e puoi cancellare tutto in qualsiasi momento."
 
 #. No selling
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:44
+#: src/components/PrivacyPolicyContent.tsx:43
 msgid "privacy.short.r2"
 msgstr "Non vendiamo, affittiamo o condividiamo i tuoi dati per scopi di marketing."
 
@@ -4352,13 +4370,13 @@ msgstr "Indicizziamo le pagine carriere delle aziende direttamente, non feed di 
 
 #. Step 1 body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:115
+#: src/components/HowWeIndexContent.tsx:113
 msgid "indexing.ingestion.s1.body"
 msgstr "Cerchiamo una sitemap che elenchi già tutte le pagine carriere o di dettaglio degli annunci — idealmente collegata da <0>robots.txt</0> — e ci affidiamo ad essa ogni volta che è possibile."
 
 #. Ingestion section description
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:107
+#: src/components/HowWeIndexContent.tsx:105
 msgid "indexing.ingestion.description"
 msgstr "Cerchiamo feed strutturati prima di fare scraping dell'HTML grezzo. Prima controlliamo le sitemap, poi le API JSON lato client, e analizziamo le pagine complete solo quando nessuno dei due è disponibile."
 
@@ -4382,7 +4400,7 @@ msgstr "Abbiamo notato che questa offerta è stata aggiunta di recente. Alcuni d
 
 #. Automation stance body
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:177
+#: src/components/HowWeIndexContent.tsx:175
 msgid "indexing.automation.body"
 msgstr "Ci opponiamo a delegare le decisioni di assunzione o di ricerca lavoro ad automazioni opache — sia dal lato dei datori di lavoro che dei candidati. Ogni link in uscita che condividiamo include <0>utm_source=jobseek</0> affinché i recruiter riconoscano il traffico, e monitoriamo continuamente i pattern di utilizzo applicando frizioni per scoraggiare le candidature automatizzate."
 
@@ -4399,19 +4417,19 @@ msgstr "Abbiamo inviato un link di verifica a <0>{email}</0>. Clicca il link per
 
 #. What we store
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:43
+#: src/components/PrivacyPolicyContent.tsx:42
 msgid "privacy.short.r1"
 msgstr "Conserviamo il tuo nome, la tua email e la foto del profilo dall'accesso OAuth, più i dati che crei nell'app."
 
 #. Info box about sitemaps
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:151
+#: src/components/HowWeIndexContent.tsx:149
 msgid "indexing.sitemapNote"
 msgstr "Incoraggiamo vivamente la pubblicazione di una sitemap facilmente individuabile per la tua sezione carriere. In assenza di una sitemap, inviamo periodicamente richieste <0>HEAD</0> leggere agli URL degli annunci già scoperti per verificare che siano ancora attivi, generando traffico non necessario."
 
 #. Third parties
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:45
+#: src/components/PrivacyPolicyContent.tsx:44
 msgid "privacy.short.r3"
 msgstr "Utilizziamo pochi servizi terzi per accesso, hosting e archiviazione — nient’altro."
 
@@ -4478,8 +4496,14 @@ msgstr "Modalità di lavoro"
 
 #. Title for the work-mode (onsite/hybrid/remote) selection modal
 #. js-lingui-explicit-id
-#: src/components/search/work-mode-modal.tsx:53
+#: src/components/search/work-mode-modal.tsx:82
 msgid "search.workModeModal.title"
+msgstr "Modalità di lavoro"
+
+#. Section header for work-mode (onsite/hybrid/remote) suggestions in search bar
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx:800
+msgid "search.bar.workMode"
 msgstr "Modalità di lavoro"
 
 #. Label for work-mode (onsite/hybrid/remote) filter in advanced search
@@ -4488,11 +4512,11 @@ msgstr "Modalità di lavoro"
 msgid "search.advanced.workMode"
 msgstr "Modalità di lavoro"
 
-#. Section header for work-mode (onsite/hybrid/remote) suggestions in search bar
+#. Salary period suffix shown after the amount, e.g. '50k EUR / yearly'
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:800
-msgid "search.bar.workMode"
-msgstr "Modalità di lavoro"
+#: src/components/SalaryDisplayProvider.tsx:55
+msgid "common.salary.period.yearly"
+msgstr "all'anno"
 
 #. Yearly pay period option
 #. js-lingui-explicit-id
@@ -4539,13 +4563,13 @@ msgstr "Ieri"
 
 #. Account deletion
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:47
+#: src/components/TermsContent.tsx:46
 msgid "terms.short.r5"
 msgstr "Puoi eliminare il tuo account in qualsiasi momento."
 
 #. CC right 3
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:85
+#: src/components/LicenseContent.tsx:84
 msgid "license.data.r3"
 msgstr "È possibile rielaborare/trasformare i dati per ricerche o dashboard personali."
 
@@ -4557,7 +4581,7 @@ msgstr "Puoi velocizzare il processo chiedendo al tuo agente AI di completarlo t
 
 #. MIT license summary
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:53
+#: src/components/LicenseContent.tsx:52
 msgid "license.code.summary"
 msgstr "È possibile utilizzare, modificare e ridistribuire il codice in prodotti personali o commerciali a condizione di includere l'avviso di copyright e licenza."
 
@@ -4569,13 +4593,13 @@ msgstr "Potresti anche essere interessato a"
 
 #. CC license summary
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:74
+#: src/components/LicenseContent.tsx:73
 msgid "license.data.summary"
 msgstr "È consentito riutilizzare il dataset degli annunci con attribuzione per scopi non commerciali. L'uso commerciale richiede il previo consenso scritto."
 
 #. Age requirement
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:43
+#: src/components/TermsContent.tsx:42
 msgid "terms.short.r1"
 msgstr "Devi avere almeno 16 anni per usare Job Seek."
 
@@ -4637,12 +4661,12 @@ msgstr "La tua password è stata reimpostata. Ora puoi accedere con la nuova pas
 
 #. Your rights section title
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:54
+#: src/components/PrivacyPolicyContent.tsx:53
 msgid "privacy.rights.title"
 msgstr "I tuoi diritti"
 
 #. Username section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:304
+#: src/components/settings/AccountSettings.tsx:301
 msgid "settings.account.username.description"
 msgstr "Il tuo identificativo unico utilizzato nell'URL del tuo profilo pubblico."

--- a/apps/web/src/components/SalaryDisplayProvider.tsx
+++ b/apps/web/src/components/SalaryDisplayProvider.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { createContext, useContext, useEffect, useState, useMemo, useCallback, type ReactNode } from "react";
+import { useLingui } from "@lingui/react/macro";
 import { getCurrencyRates, type CurrencyRate } from "@/lib/actions/search";
-import { formatSalary, type SalaryPeriod } from "@/lib/salary";
+import { formatSalary, type PeriodLabel, type SalaryPeriod } from "@/lib/salary";
 
 interface SalaryDisplayContextValue {
   displayCurrency: string | null;
@@ -30,6 +31,7 @@ export function SalaryDisplayProvider({
   salaryPeriod?: string | null;
   children: ReactNode;
 }) {
+  const { t } = useLingui();
   const [rates, setRates] = useState<CurrencyRate[]>([]);
   const [displayCurrency, setDisplayCurrency] = useState(initialCurrency);
   const [salaryPeriod, setSalaryPeriod] = useState(initialPeriod);
@@ -45,6 +47,21 @@ export function SalaryDisplayProvider({
     if (opts.salaryPeriod !== undefined) setSalaryPeriod(opts.salaryPeriod);
   }, []);
 
+  // Locale-aware period suffix used when the salary is shown as
+  // "<amount> <CCY> / <period>" on posting cards and detail pages.
+  const periodLabel: PeriodLabel = useCallback((p) => {
+    switch (p) {
+      case "yearly":
+        return t({ id: "common.salary.period.yearly", comment: "Salary period suffix shown after the amount, e.g. '50k EUR / yearly'", message: "yearly" });
+      case "monthly":
+        return t({ id: "common.salary.period.monthly", comment: "Salary period suffix shown after the amount, e.g. '5k EUR / monthly'", message: "monthly" });
+      case "daily":
+        return t({ id: "common.salary.period.daily", comment: "Salary period suffix shown after the amount, e.g. '300 EUR / daily'", message: "daily" });
+      case "hourly":
+        return t({ id: "common.salary.period.hourly", comment: "Salary period suffix shown after the amount, e.g. '26 USD / hourly'", message: "hourly" });
+    }
+  }, [t]);
+
   const value = useMemo<SalaryDisplayContextValue>(() => ({
     displayCurrency,
     displayPeriod,
@@ -54,9 +71,10 @@ export function SalaryDisplayProvider({
         displayCurrency,
         displayPeriod,
         rates,
+        periodLabel,
       }),
     update,
-  }), [displayCurrency, displayPeriod, rates, update]);
+  }), [displayCurrency, displayPeriod, rates, update, periodLabel]);
 
   return (
     <SalaryDisplayContext.Provider value={value}>

--- a/apps/web/src/components/__tests__/AppBootstrapProvider.test.tsx
+++ b/apps/web/src/components/__tests__/AppBootstrapProvider.test.tsx
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, act } from "@testing-library/react";
+// SalaryDisplayProvider (mounted via AppBootstrapProvider) now calls
+// `useLingui()` for the period-suffix label (#3144). Stub the Lingui
+// surface so the provider hierarchy can render without an I18n setup.
+import "@/test-utils/lingui-mock";
 import { useSession } from "../SessionProvider";
 
 // The real `@/lib/actions/bootstrap` is a server action that transitively

--- a/apps/web/src/lib/__tests__/salary.test.ts
+++ b/apps/web/src/lib/__tests__/salary.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from "vitest";
+import { formatSalary, decodeStoredAmount, type PeriodLabel } from "../salary";
+
+describe("decodeStoredAmount", () => {
+  it("divides hourly amounts by 100 (cents → whole units)", () => {
+    expect(decodeStoredAmount(2550, "hourly")).toBe(25.5);
+    expect(decodeStoredAmount(1425, "hourly")).toBe(14.25);
+  });
+
+  it("leaves non-hourly amounts untouched", () => {
+    expect(decodeStoredAmount(120000, "yearly")).toBe(120000);
+    expect(decodeStoredAmount(5000, "monthly")).toBe(5000);
+    expect(decodeStoredAmount(300, "daily")).toBe(300);
+  });
+});
+
+describe("formatSalary — #3174 hourly cents bug", () => {
+  // Crawler stores hourly salaries in cents: $25.50/hr → 2550, $14.25/hr → 1425.
+  // Before the fix, formatSalary treated these as whole-unit amounts and
+  // produced "3k USD / hourly" instead of "26 USD / hourly".
+
+  it("formats $25.50/hr stored as 2550 cents as 26 USD / hourly (not 3k)", () => {
+    const out = formatSalary(2550, null, "USD", "hourly");
+    expect(out).toBe("26+ USD / hourly");
+    expect(out).not.toContain("k");
+  });
+
+  it("formats $14.25/hr stored as 1425 cents as 14 USD / hourly (not 1k or 1425)", () => {
+    const out = formatSalary(1425, null, "USD", "hourly");
+    expect(out).toBe("14+ USD / hourly");
+    expect(out).not.toContain("k");
+    expect(out).not.toContain("1425");
+  });
+
+  it("formats hourly range $37-$65/hr (3700-6500 in cents) as 37–65 USD / hourly", () => {
+    const out = formatSalary(3700, 6500, "USD", "hourly");
+    expect(out).toBe("37–65 USD / hourly");
+  });
+
+  it("does not divide yearly amounts (regression check)", () => {
+    const out = formatSalary(120000, 150000, "USD", "yearly");
+    expect(out).toBe("120k–150k USD");
+  });
+
+  it("does not divide monthly amounts (regression check)", () => {
+    const out = formatSalary(5000, null, "EUR", "monthly");
+    expect(out).toBe("5k+ EUR / monthly");
+  });
+});
+
+describe("formatSalary — #3144 period suffix i18n", () => {
+  // The default period label is English. When the SalaryDisplayProvider
+  // injects a `periodLabel` (via useLingui), the output uses translated terms.
+
+  it("uses English period suffix by default", () => {
+    expect(formatSalary(120000, 150000, "USD", "yearly", { displayPeriod: "yearly" })).toBe("120k–150k USD");
+    expect(formatSalary(5000, null, "EUR", "monthly", { displayPeriod: "monthly" })).toBe("5k+ EUR / monthly");
+    expect(formatSalary(2550, null, "USD", "hourly", { displayPeriod: "hourly" })).toBe("26+ USD / hourly");
+  });
+
+  it("uses injected periodLabel for the suffix (German)", () => {
+    const deLabel: PeriodLabel = (p) =>
+      ({ yearly: "jährlich", monthly: "monatlich", daily: "täglich", hourly: "stündlich" })[p];
+    expect(formatSalary(5000, null, "EUR", "monthly", { periodLabel: deLabel })).toBe("5k+ EUR / monatlich");
+    expect(formatSalary(2550, null, "USD", "hourly", { periodLabel: deLabel })).toBe("26+ USD / stündlich");
+  });
+
+  it("uses injected periodLabel for the suffix (French)", () => {
+    const frLabel: PeriodLabel = (p) =>
+      ({ yearly: "par an", monthly: "par mois", daily: "par jour", hourly: "par heure" })[p];
+    expect(formatSalary(2550, null, "USD", "hourly", { periodLabel: frLabel })).toBe("26+ USD / par heure");
+  });
+
+  it("uses injected periodLabel for the suffix (Italian)", () => {
+    const itLabel: PeriodLabel = (p) =>
+      ({ yearly: "annuale", monthly: "mensile", daily: "giornaliero", hourly: "orario" })[p];
+    expect(formatSalary(2550, null, "USD", "hourly", { periodLabel: itLabel })).toBe("26+ USD / orario");
+  });
+
+  it("omits the suffix when the period is yearly (no '/ yearly' clutter)", () => {
+    const deLabel: PeriodLabel = (p) =>
+      ({ yearly: "jährlich", monthly: "monatlich", daily: "täglich", hourly: "stündlich" })[p];
+    const out = formatSalary(120000, 150000, "USD", "yearly", { periodLabel: deLabel });
+    expect(out).toBe("120k–150k USD");
+    expect(out).not.toContain("jährlich");
+  });
+});
+
+describe("formatSalary — null / empty handling (regression)", () => {
+  it("returns empty string when min and max are both null", () => {
+    expect(formatSalary(null, null, "USD", "yearly")).toBe("");
+  });
+
+  it("handles max-only", () => {
+    expect(formatSalary(null, 150000, "USD", "yearly")).toBe("≤150k USD");
+  });
+});

--- a/apps/web/src/lib/salary.ts
+++ b/apps/web/src/lib/salary.ts
@@ -10,6 +10,20 @@ const TO_YEARLY: Record<SalaryPeriod, number> = {
   hourly: 2016, // 252 × 8
 };
 
+/**
+ * Crawler-side encoding: hourly salaries are stored in **cents** (the smallest
+ * monetary unit of the source currency) so they can be exact integers
+ * (e.g. $25.50/hr → 2550). All other periods are stored as whole units.
+ * See `apps/crawler/src/processing/cpu.py::_extract_salary_fields` and the
+ * `SalaryRange` dataclass in `apps/crawler/src/core/salary_extract.py`.
+ *
+ * The DB stores raw values; consumers must scale back when the period is
+ * `hourly`. Returns the value in whole units (e.g. 25.50 for "$25.50/hr").
+ */
+export function decodeStoredAmount(amount: number, period: SalaryPeriod): number {
+  return period === "hourly" ? amount / 100 : amount;
+}
+
 export function convertAmount(
   amount: number,
   fromCurrency: string,
@@ -35,6 +49,15 @@ export function convertAmount(
   return Math.round(val);
 }
 
+/**
+ * Period-suffix label provider. Callers in client components inject a
+ * Lingui-translated label per period; default falls back to English so
+ * pure-function consumers (tests, server scripts) still work.
+ */
+export type PeriodLabel = (period: SalaryPeriod) => string;
+
+const DEFAULT_PERIOD_LABEL: PeriodLabel = (p) => p;
+
 export function formatSalary(
   min: number | null,
   max: number | null,
@@ -44,6 +67,7 @@ export function formatSalary(
     displayCurrency?: string | null;
     displayPeriod?: SalaryPeriod | null;
     rates?: CurrencyRate[];
+    periodLabel?: PeriodLabel;
   },
 ): string {
   if (min == null && max == null) return "";
@@ -53,9 +77,19 @@ export function formatSalary(
   const toCur = opts?.displayCurrency && opts.rates?.length ? opts.displayCurrency : fromCur;
   const toPeriod = opts?.displayPeriod ?? fromPeriod;
   const rates = opts?.rates ?? [];
+  const periodLabel = opts?.periodLabel ?? DEFAULT_PERIOD_LABEL;
 
-  const conv = (n: number) => convertAmount(n, fromCur, toCur, fromPeriod, toPeriod, rates);
-  const fmt = (n: number) => (n >= 1000 ? `${Math.round(n / 1000)}k` : String(n));
+  // Decode the storage convention: hourly values come in cents.
+  // Do this BEFORE currency/period conversion so downstream math is in whole units.
+  const decode = (n: number) => decodeStoredAmount(n, fromPeriod);
+  const conv = (n: number) => convertAmount(decode(n), fromCur, toCur, fromPeriod, toPeriod, rates);
+  const fmt = (n: number) => {
+    if (toPeriod === "hourly") {
+      // For hourly rates, the natural unit is a small whole number — round to integer.
+      return String(Math.round(n));
+    }
+    return n >= 1000 ? `${Math.round(n / 1000)}k` : String(Math.round(n));
+  };
 
   const cMin = min != null ? conv(min) : null;
   const cMax = max != null ? conv(max) : null;
@@ -70,7 +104,7 @@ export function formatSalary(
   }
 
   if (toPeriod !== "yearly") {
-    parts.push(`/ ${toPeriod}`);
+    parts.push(`/ ${periodLabel(toPeriod)}`);
   }
 
   return parts.join(" ");


### PR DESCRIPTION
## Summary

Bundles two related salary-display fixes.

- **#3174 (CRITICAL).** The crawler stores hourly salaries in **cents** of the source currency (e.g. \$25.50/hr -> 2550 — see `apps/crawler/src/processing/cpu.py::_extract_salary_fields`), but the web app's `formatSalary` treated those values as whole units. Every hourly posting was displayed at 100x its real rate — e.g. **\"3k+ USD / hourly\"** instead of **\"32+ USD / hourly\"** for the Everlane Color Design Associate role (3200 cents stored), or **\"3k-5k USD / hourly\"** instead of **\"27-48 USD / hourly\"** for an Amazon Data Center Technician (2700-4800 cents stored).
- **#3144.** The period suffix (\"/ yearly\", \"/ monthly\", \"/ daily\", \"/ hourly\") was hardcoded English and leaked into every locale. The detail dialog header rendered in German/French/Italian and then ended with an English suffix.

## Fixes

1. **Decode the storage convention** in `formatSalary` before currency/period conversion via a new `decodeStoredAmount(amount, period)` helper. The helper is exported and documented at the call site that establishes the convention.
2. **Round hourly outputs to integers** instead of the \"Nk\" shorthand — hourly rates are small whole numbers, not thousands.
3. **Route the period suffix through a `periodLabel` callback.** `SalaryDisplayProvider` (the only consumer of `formatSalary` today) injects a Lingui-translated label per period:
   - de: `jährlich` / `monatlich` / `täglich` / `stündlich`
   - fr: `par an` / `par mois` / `par jour` / `par heure`
   - it: `all'anno` / `al mese` / `al giorno` / `all'ora`

   The default falls back to English so pure-function callers (tests, server scripts) still work.

## Empirical verification

Ran the dev server (port 3015) against real Supabase data with two known hourly postings:

| Posting | Stored | Before (broken) | After (fixed) |
|---|---|---|---|
| Everlane Color Design Associate | `salary_min=3200` (= \$32/hr) | `3k+ USD / hourly` | `32+ USD / hourly` |
| Amazon Data Center Technician | `salary_min=2700, salary_max=4800` (= \$27-48/hr) | `3k-5k USD / hourly` | `27-48 USD / hourly` |
| Amazon Data Center Technician (de) | same | `3k-5k USD / hourly` | `27-48 USD / stündlich` |

The job description on both pages confirms ground truth (\"\$20.50-\$32.00 per hour\" on Everlane, \"27.00 - 48.00 USD hourly\" on Amazon).

Screenshots: `/tmp/3174-screenshots/{before,fix}-{en,de}-{everlane-color,amazon-data-center}.png`.

## Tests

- New `src/lib/__tests__/salary.test.ts` (14 tests). Verified to **fail on `main`** with the original `formatSalary` (9/14 fail — exact \"3k+ USD / hourly\" vs \"26+ USD / hourly\" mismatches in stderr) and **pass on this branch**.
- Adds `lingui-mock` to `AppBootstrapProvider.test.tsx` because the provider chain now calls `useLingui()`.
- Full suite: **768 / 768 passing**, **TSC clean**.

## Files changed

- `apps/web/src/lib/salary.ts` — decode hourly cents, accept `periodLabel`, round hourly integers
- `apps/web/src/components/SalaryDisplayProvider.tsx` — inject Lingui-translated `periodLabel`
- `apps/web/src/lib/__tests__/salary.test.ts` — new
- `apps/web/src/components/__tests__/AppBootstrapProvider.test.tsx` — add lingui mock import
- `apps/web/locales/{en,de,fr,it}.po` — `common.salary.period.{yearly,monthly,daily,hourly}`

## Test plan

- [x] Unit tests for both fixes (failing on main, passing on this branch)
- [x] Type check (`pnpm exec tsc --noEmit`) clean
- [x] Full vitest suite green (768/768)
- [x] Empirical browser verification on real hourly postings (Everlane, Amazon DC Tech) in both en + de
- [x] Lingui extract clean (0 missing translations across de/fr/it)
- [x] Pre-commit gate (ESLint, Lingui coverage) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)