### PR TITLE
fix(web): fail-closed Stripe webhook signature verification (closes #3209)

### DIFF
--- a/apps/web/app/api/stripe/webhook/route.test.ts
+++ b/apps/web/app/api/stripe/webhook/route.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for `/api/stripe/webhook`.
+ *
+ * Regression context: #3209 — the route's signature-verification block was
+ * commented out, leaving a "stub" path that parsed JSON directly and wrote
+ * to the `subscription` table. A one-line `curl POST` of a forged
+ * `checkout.session.completed` event could upgrade any user to
+ * `plan: "unlimited"` or cancel any subscription.
+ *
+ * These tests assert the fail-closed behaviour when the env var is absent
+ * AND the fail-closed behaviour when a signature is missing or invalid.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// We never touch the DB in these tests — the request must be rejected
+// before any handler logic runs. We still need to mock `@/db` because the
+// route imports it at module top.
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn(() => {
+      throw new Error("db.select called — webhook should have rejected before reaching DB");
+    }),
+    insert: vi.fn(() => {
+      throw new Error("db.insert called — webhook should have rejected before reaching DB");
+    }),
+    update: vi.fn(() => {
+      throw new Error("db.update called — webhook should have rejected before reaching DB");
+    }),
+  },
+}));
+
+// Mock the schema barrel so importing the route doesn't pull in
+// drizzle-zod / postgres-js at test time.
+vi.mock("@/db/schema", () => ({
+  subscription: {
+    userId: "userId",
+    stripeSubscriptionId: "stripeSubscriptionId",
+    id: "id",
+  },
+}));
+
+import { POST } from "./route";
+
+const URL_BASE = "http://localhost/api/stripe/webhook";
+
+function makeRequest(
+  body: unknown,
+  init: { signature?: string | null } = {},
+): Request {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (init.signature !== null && init.signature !== undefined) {
+    headers["stripe-signature"] = init.signature;
+  }
+  return new Request(URL_BASE, {
+    method: "POST",
+    body: typeof body === "string" ? body : JSON.stringify(body),
+    headers,
+  });
+}
+
+const FORGED_CHECKOUT_EVENT = {
+  id: "evt_forged_001",
+  type: "checkout.session.completed",
+  data: {
+    object: {
+      customer: "cus_attacker",
+      subscription: "sub_attacker",
+      metadata: { userId: "victim-user-id" },
+    },
+  },
+};
+
+let warnSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  delete process.env.STRIPE_WEBHOOK_SECRET;
+});
+
+afterEach(() => {
+  warnSpy.mockRestore();
+  delete process.env.STRIPE_WEBHOOK_SECRET;
+  delete process.env.STRIPE_SECRET_KEY;
+});
+
+describe("POST /api/stripe/webhook — fail-closed when STRIPE_WEBHOOK_SECRET unset", () => {
+  it("returns 503 when STRIPE_WEBHOOK_SECRET is not set (regression: #3209)", async () => {
+    // This is THE security regression test. On main (before this fix) the
+    // route's signature-verification block was commented out and the
+    // handler would parse JSON directly, advancing to `activateSubscription`.
+    // After the fix, the request must be rejected with 503 before any DB
+    // write is attempted.
+    const res = await POST(
+      makeRequest(FORGED_CHECKOUT_EVENT, { signature: "t=1,v1=anything" }),
+    );
+    expect(res.status).toBe(503);
+    // Cache-Control: no-store guards against an intermediary caching the
+    // 503 and serving it to a legitimate Stripe retry once the env var is
+    // set.
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    // Log line for operability — the warning helps detect misconfiguration.
+    expect(warnSpy).toHaveBeenCalled();
+    const warnMsg = String(warnSpy.mock.calls[0]?.[0] ?? "");
+    expect(warnMsg).toContain("STRIPE_WEBHOOK_SECRET");
+  });
+
+  it("returns 503 when STRIPE_WEBHOOK_SECRET is the empty string", async () => {
+    process.env.STRIPE_WEBHOOK_SECRET = "";
+    const res = await POST(
+      makeRequest(FORGED_CHECKOUT_EVENT, { signature: "t=1,v1=anything" }),
+    );
+    expect(res.status).toBe(503);
+  });
+
+  it("503 path returns even when no signature header is present", async () => {
+    // The env gate runs BEFORE the signature header check, so a forged
+    // request without any signature still gets 503 (not 400) when the env
+    // var is unset.
+    const res = await POST(makeRequest(FORGED_CHECKOUT_EVENT, { signature: null }));
+    expect(res.status).toBe(503);
+  });
+});
+
+describe("POST /api/stripe/webhook — signature verification when STRIPE_WEBHOOK_SECRET set", () => {
+  beforeEach(() => {
+    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test_only_not_a_real_secret";
+    process.env.STRIPE_SECRET_KEY = "sk_test_unused";
+  });
+
+  it("returns 400 when stripe-signature header is missing", async () => {
+    const res = await POST(makeRequest(FORGED_CHECKOUT_EVENT, { signature: null }));
+    expect(res.status).toBe(400);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Missing stripe-signature header");
+  });
+
+  it("returns 400 when stripe-signature header is malformed / does not verify", async () => {
+    // A signature header that doesn't match the body+secret HMAC must be
+    // rejected with 400. We use a value that's syntactically plausible to
+    // Stripe's parser but cryptographically invalid.
+    const res = await POST(
+      makeRequest(FORGED_CHECKOUT_EVENT, {
+        signature: "t=1,v1=0000000000000000000000000000000000000000000000000000000000000000",
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("Invalid signature");
+  });
+
+  it("returns 400 when stripe-signature header is total garbage", async () => {
+    const res = await POST(
+      makeRequest(FORGED_CHECKOUT_EVENT, { signature: "garbage" }),
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/web/app/api/stripe/webhook/route.ts
+++ b/apps/web/app/api/stripe/webhook/route.ts
@@ -1,50 +1,103 @@
 import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
+import Stripe from "stripe";
 import { db } from "@/db";
 import { subscription } from "@/db/schema";
 
-// import Stripe from "stripe";
-// const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+// Lazily instantiated so the route can boot in environments where Stripe is
+// not yet wired (STRIPE_WEBHOOK_SECRET unset). We never construct a real
+// Stripe client until we have a secret to verify with.
+let _stripe: Stripe | null = null;
+function getStripe(): Stripe {
+  if (_stripe) return _stripe;
+  // The secret key is required only for the Stripe SDK constructor; webhook
+  // verification itself uses the webhook signing secret. We pass a non-empty
+  // string fallback so the SDK can construct on machines that have the
+  // webhook secret but not yet the API key (legitimate during incremental
+  // rollout — verification only needs HMAC).
+  const apiKey = process.env.STRIPE_SECRET_KEY ?? "sk_placeholder_unused";
+  _stripe = new Stripe(apiKey);
+  return _stripe;
+}
 
 /**
  * Stripe webhook endpoint.
  *
- * To enable:
- * 1. Install stripe: pnpm add stripe
- * 2. Set STRIPE_SECRET_KEY and STRIPE_WEBHOOK_SECRET env vars
- * 3. Uncomment the Stripe import and verification code below
+ * Threat model
+ * ------------
+ * Stripe webhook handlers mutate the `subscription` table on
+ * `checkout.session.completed`, `customer.subscription.updated`, and
+ * `customer.subscription.deleted` events. Without HMAC verification, any
+ * unauthenticated client could POST a forged event and upgrade an arbitrary
+ * user to `plan: "unlimited"` or cancel any subscription (#3209).
+ *
+ * Behavior
+ * --------
+ * - If `STRIPE_WEBHOOK_SECRET` is unset or empty → return 503 (fail-CLOSED).
+ *   We log a single warning per request so the issue is visible in logs but
+ *   we do not leak which env var is missing in the response body.
+ * - If `STRIPE_WEBHOOK_SECRET` is set → require the `stripe-signature` header
+ *   and verify the body with `stripe.webhooks.constructEvent(...)`. A missing
+ *   header or a failed verification returns 400.
+ *
+ * To enable in production:
+ * 1. Set `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` env vars.
+ * 2. Register this endpoint in the Stripe dashboard.
  */
 export async function POST(request: Request) {
-  // ── 1. Verify signature ──────────────────────────────────────────
-  // const body = await request.text();
-  // const sig = request.headers.get("stripe-signature")!;
-  // let event: Stripe.Event;
-  // try {
-  //   event = stripe.webhooks.constructEvent(
-  //     body,
-  //     sig,
-  //     process.env.STRIPE_WEBHOOK_SECRET!,
-  //   );
-  // } catch {
-  //   return NextResponse.json({ error: "Invalid signature" }, { status: 400 });
-  // }
+  // ── 0. Env-gated kill switch (fail-closed) ─────────────────────────
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+  if (!webhookSecret) {
+    console.warn(
+      "[stripe/webhook] STRIPE_WEBHOOK_SECRET is not set — refusing webhook (fail-closed)",
+    );
+    return NextResponse.json(
+      { error: "Stripe webhook endpoint is not configured" },
+      { status: 503, headers: { "Cache-Control": "no-store" } },
+    );
+  }
 
-  // ── Stub: parse JSON directly (remove when Stripe is wired) ─────
-  let event: { type: string; data: { object: Record<string, unknown> } };
+  // ── 1. Verify signature ────────────────────────────────────────────
+  // We need the raw text body for HMAC verification — must NOT parse JSON
+  // first, since serialization differences would invalidate the signature.
+  const body = await request.text();
+  const signature = request.headers.get("stripe-signature");
+  if (!signature) {
+    return NextResponse.json(
+      { error: "Missing stripe-signature header" },
+      { status: 400, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
+  let event: Stripe.Event;
   try {
-    event = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+    event = getStripe().webhooks.constructEvent(body, signature, webhookSecret);
+  } catch (err) {
+    // Stripe raises `StripeSignatureVerificationError` for bad signatures;
+    // other parse failures also land here. Either way the request is
+    // untrusted — log enough to debug, return a generic 400.
+    const message = err instanceof Error ? err.message : "unknown error";
+    console.warn("[stripe/webhook] signature verification failed", {
+      reason: message,
+    });
+    return NextResponse.json(
+      { error: "Invalid signature" },
+      { status: 400, headers: { "Cache-Control": "no-store" } },
+    );
   }
 
   // ── 2. Handle events ─────────────────────────────────────────────
-  const obj = event.data.object;
+  // The cast goes through `unknown` because the Stripe.Event union is wider
+  // than `Record<string, unknown>` (some members are nominal classes). The
+  // switch below narrows on `event.type` and only reads fields that exist
+  // on the relevant payload variant.
+  const obj = event.data.object as unknown as Record<string, unknown>;
 
   switch (event.type) {
     case "checkout.session.completed": {
-      const userId = (obj.metadata as Record<string, string>)?.userId;
-      const customerId = obj.customer as string;
-      const subscriptionId = obj.subscription as string;
+      const userId = (obj.metadata as Record<string, string> | undefined)?.userId;
+      const customerId = obj.customer as string | undefined;
+      const subscriptionId = obj.subscription as string | undefined;
       if (userId && customerId && subscriptionId) {
         await activateSubscription(userId, customerId, subscriptionId);
       }
@@ -52,16 +105,16 @@ export async function POST(request: Request) {
     }
 
     case "customer.subscription.updated": {
-      const subscriptionId = obj.id as string;
-      const status = obj.status as string;
-      if (subscriptionId) {
+      const subscriptionId = obj.id as string | undefined;
+      const status = obj.status as string | undefined;
+      if (subscriptionId && status) {
         await updateSubscriptionStatus(subscriptionId, status);
       }
       break;
     }
 
     case "customer.subscription.deleted": {
-      const subscriptionId = obj.id as string;
+      const subscriptionId = obj.id as string | undefined;
       if (subscriptionId) {
         await cancelSubscription(subscriptionId);
       }


### PR DESCRIPTION
## Summary

Closes #3209.

### Threat model

`apps/web/app/api/stripe/webhook/route.ts` is mounted at `/api/stripe/webhook` and writes to the `subscription` table on `checkout.session.completed`, `customer.subscription.updated`, and `customer.subscription.deleted` events. On `main`, the signature-verification block was commented out and the stub path that parsed JSON directly was the LIVE path. A one-line unauthenticated `curl POST`:

```
curl -X POST https://jseek.co/api/stripe/webhook \
  -H 'Content-Type: application/json' \
  -d '{"type":"checkout.session.completed","data":{"object":{"customer":"cus_x","subscription":"sub_x","metadata":{"userId":"victim"}}}}'
```

…could upgrade any user to `plan: "unlimited"` or, via `customer.subscription.deleted`, cancel any subscription. Stripe is not yet fully wired (`createCheckoutSession` returns a placeholder error) but the webhook route was live and exploitable.

### Behavior after this PR

- **`STRIPE_WEBHOOK_SECRET` unset or empty** → return `503` with `Cache-Control: no-store` and log a warning. **Fail-CLOSED** — this is the current production state, so forged events now bounce.
- **`STRIPE_WEBHOOK_SECRET` set** →
  - Missing `stripe-signature` header → `400 {"error":"Missing stripe-signature header"}`.
  - Bad signature (`StripeSignatureVerificationError` from `stripe.webhooks.constructEvent`) → `400 {"error":"Invalid signature"}`.
  - Valid signature → the existing handler logic runs unchanged (activate / update / cancel / payment_failed).
- All error responses carry `Cache-Control: no-store` so an intermediary cannot poison a Stripe retry once the env var is set.
- The Stripe SDK is now imported (not commented out); `stripe@^17` was already a `dependencies` entry.

Once Stripe is fully wired, flipping `STRIPE_WEBHOOK_SECRET` in Vercel env switches the route from fail-closed to real HMAC verification with no code change.

### Files changed

- `apps/web/app/api/stripe/webhook/route.ts` — env-gated kill switch + real `constructEvent` verification.
- `apps/web/app/api/stripe/webhook/route.test.ts` — new regression suite (6 cases).

### Failing-on-main verification

I verified empirically that the new tests fail on `origin/main`: replaced `route.ts` with `git show origin/main:apps/web/app/api/stripe/webhook/route.ts`, re-ran `pnpm test app/api/stripe/webhook/` — all 6 tests fail with `db.select called — webhook should have rejected before reaching DB` because the unsigned/forged event reaches `activateSubscription`. Restoring the fix restores the green. The DB mock throws on any invocation, so a "request advanced to the handler" failure is what we see on `main`.

## Test plan

- [x] `pnpm test app/api/stripe/webhook/` — 6 tests pass on this branch; all 6 fail on `origin/main` (forged event reaches `db.select`).
- [x] `pnpm test` — full suite passes (791 tests).
- [x] `pnpm typecheck` (`next typegen && tsc`) — clean.
- [x] `pnpm lint --quiet` — clean.
- [ ] After merge: set `STRIPE_WEBHOOK_SECRET` in Vercel (Preview + Production) once the Stripe checkout flow is ready; route will flip from 503 to real verification with no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)