### PR TITLE
fix(a11y): add skip-to-content link in (app) layout (closes #3163)

### DIFF
--- a/apps/web/app/[lang]/(app)/layout.tsx
+++ b/apps/web/app/[lang]/(app)/layout.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { Trans } from "@lingui/react/macro";
 
 import { AppBootstrapProvider } from "@/components/AppBootstrapProvider";
 import { AppHeader } from "@/components/AppHeader";
@@ -19,13 +20,22 @@ export default async function AppLayout({ children }: Props) {
   return (
     <AppBootstrapProvider>
       <SearchStateProvider>
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only fixed top-2 left-2 z-[100] rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-contrast focus:outline-none"
+        >
+          <Trans id="common.a11y.skipToContent" comment="Skip to main content link for keyboard users">Skip to content</Trans>
+        </a>
         <div className="flex min-h-dvh flex-col">
           <AppHeader />
           <div className="flex min-h-0 flex-1 flex-col md:pt-12">
             <CookieBanner aboveBottomBar />
             <UpgradeBanner aboveBottomBar />
             <WatchlistTipBanner aboveBottomBar />
-            <main className="mx-auto w-full max-w-[1200px] px-4 py-8 pb-20 md:pb-8">
+            <main
+              id="main-content"
+              className="mx-auto w-full max-w-[1200px] px-4 py-8 pb-20 md:pb-8"
+            >
               {children}
             </main>
           </div>

--- a/apps/web/app/[lang]/(app)/layout.tsx
+++ b/apps/web/app/[lang]/(app)/layout.tsx
@@ -1,5 +1,4 @@
 import type { ReactNode } from "react";
-import { Trans } from "@lingui/react/macro";
 
 import { AppBootstrapProvider } from "@/components/AppBootstrapProvider";
 import { AppHeader } from "@/components/AppHeader";
@@ -24,7 +23,7 @@ export default async function AppLayout({ children }: Props) {
           href="#main-content"
           className="sr-only focus:not-sr-only fixed top-2 left-2 z-[100] rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-contrast focus:outline-none"
         >
-          <Trans id="common.a11y.skipToContent" comment="Skip to main content link for keyboard users">Skip to content</Trans>
+          Skip to content
         </a>
         <div className="flex min-h-dvh flex-col">
           <AppHeader />


### PR DESCRIPTION
## Summary

Adds a keyboard skip-to-content link in the `(app)` layout, matching the (public) layout's pattern. Keyboard-only users on `/explore`, `/watchlists`, `/settings` no longer have to tab through the header on every page.

## Implementation note

The link uses a **literal English string** (`"Skip to content"`) rather than the `<Trans>` Lingui macro. Initial attempts using `<Trans id="common.a11y.skipToContent">` consistently failed `Test Web ISR (slow)` with a silent `pnpm build` crash before the route summary printed — even after rebasing and rerunning across 3+ CI runs. Removing the macro (commit `dbd36e395`) makes CI pass green on all 9 checks.

The literal-string fallback is acceptable for this surface: skip-to-content links are keyboard-only, fire only on Tab focus, and screen reader users typically navigate via landmarks rather than skip links. The translation effort/benefit ratio is poor here. Filing a follow-up issue to investigate the underlying Trans-macro-in-(app)-layout build crash separately.

## Verification

- Playwright (port 3023): single `Tab` on `/en/explore`, `/en/watchlists`, `/en/settings` — first focusable element is the skip link, visible (size 126×18, light-on-dark), pressing Enter jumps to `#main-content`.
- TSC clean, 785/785 tests pass.
- All 9 CI checks green on `dbd36e395`.

## Out of scope (filed as follow-up)

- The build crash with `<Trans>` macro in the `(app)` async server-component layout. The (public) layout has the same pattern and works; the (app) layout is structurally different (wrapped in `<SearchStateProvider>` client boundary) but it's not clear why that would crash the build. Worth a focused investigation.

Closes #3163.