### PR TITLE
fix(web): localize Pricing.tsx price labels (closes #3148)

### DIFF
--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -58,7 +58,7 @@ msgid "search.detail.showMoreLocations"
 msgstr "{0} weitere"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:39
+#: app/[lang]/(app)/company/[slug]/page.tsx:40
 msgid "company.meta.positionCount"
 msgstr "{count, plural, one {# offene Stelle} other {# offene Stellen}}"
 
@@ -87,7 +87,7 @@ msgid "blog.mention.watchlist.companiesLabel"
 msgstr "{count, plural, one {Unternehmen} other {Unternehmen}}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:103
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:104
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {# Unternehmen beobachtet} other {# Unternehmen beobachtet}}. {description}"
 
@@ -98,23 +98,23 @@ msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} Bewerbungen am {date}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:61
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:62
 msgid "watchlist.meta.moreCompanies"
 msgstr "{count} weitere"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:51
+#: app/[lang]/(app)/company/[slug]/page.tsx:52
 msgid "company.meta.descriptionBasic"
 msgstr "{countText} bei {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:46
+#: app/[lang]/(app)/company/[slug]/page.tsx:47
 msgid "company.meta.descriptionWithInfo"
 msgstr "{countText} bei {name}. {description}"
 
 #. Reading-time label shown in the blog post byline. {minutes} is the integer minute count.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:150
+#: app/[lang]/(public)/blog/[slug]/page.tsx:151
 msgid "blog.post.readingTime"
 msgstr "{minutes, plural, one {# Min. Lesezeit} other {# Min. Lesezeit}}"
 
@@ -130,11 +130,23 @@ msgstr "{range} Mitarbeiter"
 msgid "blog.mention.company.employeesCount"
 msgstr "{range} Mitarbeitende"
 
+#. Free tier price displayed prominently on the home pricing card. Source is USD ($0); translators may render the symbol+number per locale convention (e.g. German '0 $').
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:26
+msgid "home.pricing.free.price"
+msgstr "0 $"
+
 #. Free plan price display
 #. js-lingui-explicit-id
 #: src/components/settings/BillingSettings.tsx:146
 msgid "settings.billing.plan.freePrice"
 msgstr "0 $ / Monat"
+
+#. Pro tier price displayed prominently on the home pricing card. Source is USD ($10/month); translators may render the symbol+number per locale convention (e.g. German '10 $').
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:68
+msgid "home.pricing.pro.price"
+msgstr "10 $"
 
 #. Pro plan price display
 #. js-lingui-explicit-id
@@ -150,7 +162,7 @@ msgstr "1 Bewerbung am {date}"
 
 #. Free feature: one watchlist
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:45
+#: src/components/Pricing.tsx:51
 msgid "home.pricing.free.f2"
 msgstr "1 Watchlist"
 
@@ -243,16 +255,16 @@ msgstr "Unternehmen hinzufügen"
 msgid "watchlists.view.addDescription"
 msgstr "Beschreibung hinzufügen"
 
-#. Quick action tooltip: add interview round
-#. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:19
-msgid "myJobs.action.addInterview"
-msgstr "Interview hinzufügen"
-
 #. Button to add an interview round
 #. js-lingui-explicit-id
 #: src/components/my-jobs/interview-list.tsx:76
 msgid "myJobs.detail.addInterview"
+msgstr "Interview hinzufügen"
+
+#. Quick action tooltip: add interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/quick-actions.tsx:19
+msgid "myJobs.action.addInterview"
 msgstr "Interview hinzufügen"
 
 #. Placeholder in the add keyword input
@@ -394,7 +406,7 @@ msgstr "Bewerbungstracker"
 
 #. Free feature: application tracker
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:46
+#: src/components/Pricing.tsx:52
 msgid "home.pricing.free.f3"
 msgstr "Bewerbungstracker mit Interview-Protokoll"
 
@@ -488,16 +500,16 @@ msgstr "Aug"
 msgid "settings.account.username.available"
 msgstr "Verfügbar"
 
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Zurück zur Anmeldung"
-
 #. Link back to sign-in after failed verification
 #. js-lingui-explicit-id
 #: app/[lang]/verify-email/page.tsx:68
 msgid "auth.verify.error.backToSignIn"
+msgstr "Zurück zur Anmeldung"
+
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
 msgstr "Zurück zur Anmeldung"
 
 #. Link back to sign-in from forgot password
@@ -526,28 +538,22 @@ msgstr "Nach oben"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Verhalten"
 
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:146
+msgid "blog.post.backToIndex"
+msgstr "Blog"
+
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:27
+#: app/[lang]/(public)/blog/page.tsx:28
 msgid "blog.meta.title"
 msgstr "Blog"
 
 #. <h1> on the blog index page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:78
+#: app/[lang]/(public)/blog/page.tsx:79
 msgid "blog.index.heading"
-msgstr "Blog"
-
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:145
-msgid "blog.post.backToIndex"
-msgstr "Blog"
-
-#. Footer link to /blog index page
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
-msgid "common.footer.blog"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -556,6 +562,12 @@ msgstr "Blog"
 #: src/components/Header.tsx:74
 #: src/components/MobileMenu.tsx:98
 msgid "common.nav.blog"
+msgstr "Blog"
+
+#. Footer link to /blog index page
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:52
+msgid "common.footer.blog"
 msgstr "Blog"
 
 #. Subtitle on the sign-in CTA card shown to anonymous users at the end of the similar-companies strip
@@ -647,17 +659,17 @@ msgstr "Ändere dein Passwort über einen sicheren E-Mail-Link."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Ändern…"
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "E-Mail überprüfen"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
 msgstr "E-Mail prüfen"
+
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
+msgstr "E-Mail überprüfen"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -685,7 +697,7 @@ msgstr "Wählen Sie den Plan, der zu Ihnen passt."
 
 #. Pricing section heading
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:106
+#: src/components/Pricing.tsx:118
 msgid "home.pricing.title"
 msgstr "Wähle den passenden Plan"
 
@@ -791,7 +803,7 @@ msgstr "Kombiniere bestimmte Unternehmen mit Rollenfiltern, um genau die Positio
 
 #. Pro tier CTA — disabled until subscriptions launch
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:61
+#: src/components/Pricing.tsx:67
 msgid "home.pricing.pro.cta"
 msgstr "Demnächst verfügbar"
 
@@ -835,7 +847,7 @@ msgstr "Unternehmen"
 #. Heading shown when the company URL slug doesn't resolve to a known company
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/company/[slug]/company-content.tsx:19
-#: app/[lang]/(app)/company/[slug]/page.tsx:87
+#: app/[lang]/(app)/company/[slug]/page.tsx:88
 msgid "company.notFound.title"
 msgstr "Unternehmen nicht gefunden"
 
@@ -1075,13 +1087,13 @@ msgstr "Dunkel"
 
 #. Meta description (under 160 chars) for the blog index page — covers data analyses + report breakdowns + news commentary
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:32
+#: app/[lang]/(public)/blog/page.tsx:33
 msgid "blog.meta.description"
 msgstr "Datenanalysen, Nachrichten und Zusammenfassungen von Branchenberichten – basierend auf den Stellenanzeigen, die wir auf den Karriereseiten tausender Unternehmen verfolgen."
 
 #. One-line tagline under the blog index <h1> — covers data analyses + reports/papers + news
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:83
+#: app/[lang]/(public)/blog/page.tsx:84
 msgid "blog.index.tagline"
 msgstr "Datenanalysen, Nachrichten und Zusammenfassungen von Branchenberichten und Studien – basierend auf den Stellenanzeigen, die wir verfolgen."
 
@@ -1244,7 +1256,7 @@ msgstr "Unbegrenzt Unternehmen folgen"
 
 #. Pro feature: email alerts
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:82
+#: src/components/Pricing.tsx:94
 msgid "home.pricing.pro.f2"
 msgstr "E-Mail-Benachrichtigungen bei neuen Treffern"
 
@@ -1304,7 +1316,7 @@ msgstr "Jedes Wiederholungsfenster nutzt exponentielles Backoff, damit wir einen
 
 #. Pro feature: includes free
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:80
+#: src/components/Pricing.tsx:92
 msgid "home.pricing.pro.f0"
 msgstr "Alles aus Kostenlos"
 
@@ -1346,7 +1358,7 @@ msgid "app.header.nav.explore"
 msgstr "Entdecken"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:31
+#: app/[lang]/(app)/explore/page.tsx:32
 msgid "explore.meta.title"
 msgstr "Jobs entdecken"
 
@@ -1511,7 +1523,7 @@ msgstr "Für Jobsuchende, die schon wissen, wo sie arbeiten möchten."
 
 #. Free tier period
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:37
+#: src/components/Pricing.tsx:43
 msgid "home.pricing.free.period"
 msgstr "Für immer"
 
@@ -1541,7 +1553,7 @@ msgstr "Gegründet {year}"
 
 #. Free tier name
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:32
+#: src/components/Pricing.tsx:38
 msgid "home.pricing.free.name"
 msgstr "Kostenlos"
 
@@ -1587,7 +1599,7 @@ msgstr "Vollständige Suche, 1 Watchlist, Bewerbungstracker"
 
 #. Free tier description
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:41
+#: src/components/Pricing.tsx:47
 msgid "home.pricing.free.description"
 msgstr "Volle Suche, eine Watchlist und ein integrierter Bewerbungstracker, um deine Pipeline zu verwalten."
 
@@ -1773,7 +1785,7 @@ msgid "indexing.outreach.body"
 msgstr "Wenn du ungewöhnliches Crawler-Verhalten bemerkst, es vorziehst, dass wir deine Inhalte nicht indexieren, oder Vorschläge zur Verbesserung unserer Schutzmaßnahmen hast, kontaktiere uns bitte."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:77
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:78
 msgid "watchlist.meta.inLocations"
 msgstr "in {locations}"
 
@@ -2042,7 +2054,7 @@ msgid "license.hero.description"
 msgstr "Die Codebasis von Job Seek ist Open Source unter MIT. Die von uns gesammelten und aufbereiteten Stellendaten stehen unter Creative Commons BY-NC 4.0. Nachfolgend eine verständliche Zusammenfassung — bitte lies die vollständigen Lizenzen für die genauen Bedingungen."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:85
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:86
 msgid "watchlist.meta.fallback"
 msgstr "Job-Watchlist von @{owner}"
 
@@ -2059,12 +2071,12 @@ msgid "watchlists.explore.jobPlural"
 msgstr "Jobs"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:32
+#: app/[lang]/(app)/company/[slug]/page.tsx:33
 msgid "company.meta.title"
 msgstr "Jobs bei {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:67
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:68
 msgid "watchlist.meta.jobsAt"
 msgstr "Jobs bei {names}"
 
@@ -2212,16 +2224,16 @@ msgstr "Standort"
 msgid "search.advanced.location"
 msgstr "Standort"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
-msgstr "Standorte"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:842
 msgid "search.bar.locations"
+msgstr "Standorte"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:312
+msgid "search.detail.locations"
 msgstr "Standorte"
 
 #. Login button label
@@ -2514,17 +2526,17 @@ msgstr "Keine Jobs gefunden."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Keine Sprachen entsprechen deiner Suche."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:513
-msgid "search.locationModal.noResults"
-msgstr "Keine Standorte gefunden."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:309
 msgid "company.locationModal.noResults"
 msgstr "Keine Standorte entsprechen Ihrer Suche."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:513
+msgid "search.locationModal.noResults"
+msgstr "Keine Standorte gefunden."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2534,7 +2546,7 @@ msgstr "Keine passenden Stellenanzeigen gefunden."
 
 #. Empty-state message shown when no blog posts have been published yet
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:88
+#: app/[lang]/(public)/blog/page.tsx:89
 msgid "blog.index.empty"
 msgstr "Noch keine Beiträge – schauen Sie bald wieder vorbei."
 
@@ -2717,7 +2729,7 @@ msgid "common.header.openMenu"
 msgstr "Hauptmenü öffnen"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:44
+#: app/[lang]/(app)/company/[slug]/page.tsx:45
 msgid "company.meta.openPositions"
 msgstr "Offene Stellen"
 
@@ -2887,7 +2899,7 @@ msgstr "Zeitraum"
 
 #. Pro tier period
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:73
+#: src/components/Pricing.tsx:85
 msgid "home.pricing.pro.period"
 msgstr "pro Monat"
 
@@ -3007,7 +3019,7 @@ msgstr "Stellenanzeige nicht gefunden."
 
 #. Pricing section eyebrow
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:103
+#: src/components/Pricing.tsx:115
 msgid "home.pricing.eyebrow"
 msgstr "Preise"
 
@@ -3051,7 +3063,7 @@ msgstr "Private Watchlists sind eine kostenpflichtige Funktion. Upgrade, um dein
 
 #. Pro tier name
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:68
+#: src/components/Pricing.tsx:80
 msgid "home.pricing.pro.name"
 msgstr "Pro"
 
@@ -3144,16 +3156,16 @@ msgstr "Deine Änderungen weiterverbreiten, solange du den MIT-Hinweis beifügst
 msgid "location.type.region"
 msgstr "Region"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:523
-msgid "search.locationModal.regionsHeader"
-msgstr "Regionen"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:319
 msgid "company.locationModal.regionsHeader"
+msgstr "Regionen"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:523
+msgid "search.locationModal.regionsHeader"
 msgstr "Regionen"
 
 #. Status group heading: rejected
@@ -3324,16 +3336,16 @@ msgstr "Runde"
 msgid "app.home.request.agent.runIdLabel"
 msgstr "Run-ID"
 
-#. Salary override section heading
-#. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:76
-msgid "myJobs.detail.salary"
-msgstr "Gehalt"
-
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:225
 msgid "search.advanced.salary"
+msgstr "Gehalt"
+
+#. Salary override section heading
+#. js-lingui-explicit-id
+#: src/components/my-jobs/salary-override.tsx:76
+msgid "myJobs.detail.salary"
 msgstr "Gehalt"
 
 #. Salary display settings section heading
@@ -3428,7 +3440,7 @@ msgstr "Speichern…"
 
 #. Free feature: full search
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:44
+#: src/components/Pricing.tsx:50
 msgid "home.pricing.free.f1"
 msgstr "Suche über alle Unternehmen und Filter hinweg"
 
@@ -3464,7 +3476,7 @@ msgid "search.bar.keyword"
 msgstr "Nach \"{trimmedInput}\" in Jobtiteln suchen"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:32
+#: app/[lang]/(app)/explore/page.tsx:33
 msgid "explore.meta.description"
 msgstr "Durchsuche Jobs bei Tausenden von Unternehmen, direkt von Karriereseiten gecrawlt. Filtere nach Erfahrungsstufe, Tech-Stack, Gehalt und Standort — erstelle Watchlists und erhalte Benachrichtigungen."
 
@@ -3474,17 +3486,17 @@ msgstr "Durchsuche Jobs bei Tausenden von Unternehmen, direkt von Karriereseiten
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Sprachen suchen…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:492
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Standorte suchen..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:288
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Standorte suchen…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:492
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Standorte suchen..."
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3570,17 +3582,17 @@ msgstr "Link senden"
 msgid "settings.account.password.send"
 msgstr "Link senden"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Wird gesendet…"
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
 msgstr "Wird gesendet..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
+msgstr "Wird gesendet…"
 
 #. Reset password button while loading
 #. js-lingui-explicit-id
@@ -3636,16 +3648,16 @@ msgstr "Einstellungen"
 msgid "home.features.s3.p3.title"
 msgstr "Mit jedem teilen"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:355
-msgid "search.detail.showLessLocations"
-msgstr "Weniger anzeigen"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:351
 msgid "company.page.showLess"
+msgstr "Weniger anzeigen"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:355
+msgid "search.detail.showLessLocations"
 msgstr "Weniger anzeigen"
 
 #. Aria label to show password
@@ -3758,7 +3770,7 @@ msgstr "Ähnliche Unternehmen"
 
 #. Pricing section description
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:109
+#: src/components/Pricing.tsx:121
 msgid "home.pricing.description"
 msgstr "Einfache, transparente Preise. Starte kostenlos und upgrade, wenn du deine Jobsuche ernst meinst."
 
@@ -3918,16 +3930,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technisch"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Technologien"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:765
 msgid "search.bar.technologies"
+msgstr "Technologien"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:397
+msgid "search.detail.technologies"
 msgstr "Technologien"
 
 #. Add technology filter
@@ -3986,7 +3998,7 @@ msgstr "Nutzungsbedingungen von Job Seek — Nutzungsregeln, geistiges Eigentum,
 
 #. Body text shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:92
+#: app/[lang]/(app)/company/[slug]/page.tsx:93
 msgid "company.notFound.message"
 msgstr "Das gesuchte Unternehmen existiert nicht oder wurde entfernt."
 
@@ -4146,13 +4158,13 @@ msgstr "Nach DSGVO kannst du eine Kopie deiner Daten anfordern, sie korrigieren 
 
 #. Pro feature: unlimited watchlists
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:81
+#: src/components/Pricing.tsx:93
 msgid "home.pricing.pro.f1"
 msgstr "Unbegrenzte Watchlists"
 
 #. Pro tier description
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:77
+#: src/components/Pricing.tsx:89
 msgid "home.pricing.pro.description"
 msgstr "Unbegrenzte Watchlists mit E-Mail-Benachrichtigungen, damit du keine Stelle verpasst."
 

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -58,7 +58,7 @@ msgid "search.detail.showMoreLocations"
 msgstr "{0} more"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:39
+#: app/[lang]/(app)/company/[slug]/page.tsx:40
 msgid "company.meta.positionCount"
 msgstr "{count, plural, one {# open position} other {# open positions}}"
 
@@ -87,7 +87,7 @@ msgid "blog.mention.watchlist.companiesLabel"
 msgstr "{count, plural, one {company} other {companies}}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:103
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:104
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {Tracking # company} other {Tracking # companies}}. {description}"
 
@@ -98,23 +98,23 @@ msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} applications on {date}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:61
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:62
 msgid "watchlist.meta.moreCompanies"
 msgstr "{count} more"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:51
+#: app/[lang]/(app)/company/[slug]/page.tsx:52
 msgid "company.meta.descriptionBasic"
 msgstr "{countText} at {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:46
+#: app/[lang]/(app)/company/[slug]/page.tsx:47
 msgid "company.meta.descriptionWithInfo"
 msgstr "{countText} at {name}. {description}"
 
 #. Reading-time label shown in the blog post byline. {minutes} is the integer minute count.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:150
+#: app/[lang]/(public)/blog/[slug]/page.tsx:151
 msgid "blog.post.readingTime"
 msgstr "{minutes, plural, one {# min read} other {# min read}}"
 
@@ -130,11 +130,23 @@ msgstr "{range} employees"
 msgid "blog.mention.company.employeesCount"
 msgstr "{range} employees"
 
+#. Free tier price displayed prominently on the home pricing card. Source is USD ($0); translators may render the symbol+number per locale convention (e.g. German '0 $').
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:26
+msgid "home.pricing.free.price"
+msgstr "$0"
+
 #. Free plan price display
 #. js-lingui-explicit-id
 #: src/components/settings/BillingSettings.tsx:146
 msgid "settings.billing.plan.freePrice"
 msgstr "$0 / month"
+
+#. Pro tier price displayed prominently on the home pricing card. Source is USD ($10/month); translators may render the symbol+number per locale convention (e.g. German '10 $').
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:68
+msgid "home.pricing.pro.price"
+msgstr "$10"
 
 #. Pro plan price display
 #. js-lingui-explicit-id
@@ -150,7 +162,7 @@ msgstr "1 application on {date}"
 
 #. Free feature: one watchlist
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:45
+#: src/components/Pricing.tsx:51
 msgid "home.pricing.free.f2"
 msgstr "1 watchlist"
 
@@ -243,16 +255,16 @@ msgstr "Add companies"
 msgid "watchlists.view.addDescription"
 msgstr "Add description"
 
-#. Quick action tooltip: add interview round
-#. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:19
-msgid "myJobs.action.addInterview"
-msgstr "Add interview"
-
 #. Button to add an interview round
 #. js-lingui-explicit-id
 #: src/components/my-jobs/interview-list.tsx:76
 msgid "myJobs.detail.addInterview"
+msgstr "Add interview"
+
+#. Quick action tooltip: add interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/quick-actions.tsx:19
+msgid "myJobs.action.addInterview"
 msgstr "Add interview"
 
 #. Placeholder in the add keyword input
@@ -394,7 +406,7 @@ msgstr "Application tracker"
 
 #. Free feature: application tracker
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:46
+#: src/components/Pricing.tsx:52
 msgid "home.pricing.free.f3"
 msgstr "Application tracker with interview log"
 
@@ -488,16 +500,16 @@ msgstr "Aug"
 msgid "settings.account.username.available"
 msgstr "Available"
 
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Back to sign in"
-
 #. Link back to sign-in after failed verification
 #. js-lingui-explicit-id
 #: app/[lang]/verify-email/page.tsx:68
 msgid "auth.verify.error.backToSignIn"
+msgstr "Back to sign in"
+
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
 msgstr "Back to sign in"
 
 #. Link back to sign-in from forgot password
@@ -526,28 +538,22 @@ msgstr "Back to top"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Behavioral"
 
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:146
+msgid "blog.post.backToIndex"
+msgstr "Blog"
+
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:27
+#: app/[lang]/(public)/blog/page.tsx:28
 msgid "blog.meta.title"
 msgstr "Blog"
 
 #. <h1> on the blog index page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:78
+#: app/[lang]/(public)/blog/page.tsx:79
 msgid "blog.index.heading"
-msgstr "Blog"
-
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:145
-msgid "blog.post.backToIndex"
-msgstr "Blog"
-
-#. Footer link to /blog index page
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
-msgid "common.footer.blog"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -556,6 +562,12 @@ msgstr "Blog"
 #: src/components/Header.tsx:74
 #: src/components/MobileMenu.tsx:98
 msgid "common.nav.blog"
+msgstr "Blog"
+
+#. Footer link to /blog index page
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:52
+msgid "common.footer.blog"
 msgstr "Blog"
 
 #. Subtitle on the sign-in CTA card shown to anonymous users at the end of the similar-companies strip
@@ -647,16 +659,16 @@ msgstr "Change your password via a secure email link."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Change..."
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "Check your email"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
+msgstr "Check your email"
+
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
 msgstr "Check your email"
 
 #. Checking username availability
@@ -685,7 +697,7 @@ msgstr "Choose the plan that works for you."
 
 #. Pricing section heading
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:106
+#: src/components/Pricing.tsx:118
 msgid "home.pricing.title"
 msgstr "Choose the right plan for you"
 
@@ -791,7 +803,7 @@ msgstr "Combine specific companies with role filters to zero in on exactly the p
 
 #. Pro tier CTA — disabled until subscriptions launch
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:61
+#: src/components/Pricing.tsx:67
 msgid "home.pricing.pro.cta"
 msgstr "Coming soon"
 
@@ -835,7 +847,7 @@ msgstr "Company"
 #. Heading shown when the company URL slug doesn't resolve to a known company
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/company/[slug]/company-content.tsx:19
-#: app/[lang]/(app)/company/[slug]/page.tsx:87
+#: app/[lang]/(app)/company/[slug]/page.tsx:88
 msgid "company.notFound.title"
 msgstr "Company not found"
 
@@ -1075,13 +1087,13 @@ msgstr "Dark"
 
 #. Meta description (under 160 chars) for the blog index page — covers data analyses + report breakdowns + news commentary
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:32
+#: app/[lang]/(public)/blog/page.tsx:33
 msgid "blog.meta.description"
 msgstr "Data analyses, news, and breakdowns of industry reports — drawn from the postings we monitor across thousands of company career pages."
 
 #. One-line tagline under the blog index <h1> — covers data analyses + reports/papers + news
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:83
+#: app/[lang]/(public)/blog/page.tsx:84
 msgid "blog.index.tagline"
 msgstr "Data analyses, news, and breakdowns of industry reports and papers — drawn from the postings we monitor."
 
@@ -1244,7 +1256,7 @@ msgstr "Email alerts for new postings"
 
 #. Pro feature: email alerts
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:82
+#: src/components/Pricing.tsx:94
 msgid "home.pricing.pro.f2"
 msgstr "Email alerts on new matches"
 
@@ -1304,7 +1316,7 @@ msgstr "Every retry window uses exponential backoff so we never hammer an origin
 
 #. Pro feature: includes free
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:80
+#: src/components/Pricing.tsx:92
 msgid "home.pricing.pro.f0"
 msgstr "Everything in Free"
 
@@ -1346,7 +1358,7 @@ msgid "app.header.nav.explore"
 msgstr "Explore"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:31
+#: app/[lang]/(app)/explore/page.tsx:32
 msgid "explore.meta.title"
 msgstr "Explore Jobs"
 
@@ -1511,7 +1523,7 @@ msgstr "For job seekers who already know where they want to work."
 
 #. Free tier period
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:37
+#: src/components/Pricing.tsx:43
 msgid "home.pricing.free.period"
 msgstr "Forever"
 
@@ -1541,7 +1553,7 @@ msgstr "Founded {year}"
 
 #. Free tier name
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:32
+#: src/components/Pricing.tsx:38
 msgid "home.pricing.free.name"
 msgstr "Free"
 
@@ -1587,7 +1599,7 @@ msgstr "Full search, 1 watchlist, application tracker"
 
 #. Free tier description
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:41
+#: src/components/Pricing.tsx:47
 msgid "home.pricing.free.description"
 msgstr "Full search, one watchlist, and a built-in application tracker to manage your pipeline."
 
@@ -1773,7 +1785,7 @@ msgid "indexing.outreach.body"
 msgstr "If you notice unusual crawler behaviour, prefer that we do not index your content, or have suggestions on how to improve our safeguards, please reach out."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:77
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:78
 msgid "watchlist.meta.inLocations"
 msgstr "in {locations}"
 
@@ -2042,7 +2054,7 @@ msgid "license.hero.description"
 msgstr "Job Seek's codebase is open source under MIT. The job data we collect and enrich is Creative Commons BY-NC 4.0. Below is the plain-language summary — please read the full licenses for exact terms."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:85
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:86
 msgid "watchlist.meta.fallback"
 msgstr "Job watchlist by @{owner}"
 
@@ -2059,12 +2071,12 @@ msgid "watchlists.explore.jobPlural"
 msgstr "jobs"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:32
+#: app/[lang]/(app)/company/[slug]/page.tsx:33
 msgid "company.meta.title"
 msgstr "Jobs at {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:67
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:68
 msgid "watchlist.meta.jobsAt"
 msgstr "Jobs at {names}"
 
@@ -2212,16 +2224,16 @@ msgstr "Location"
 msgid "search.advanced.location"
 msgstr "Location"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
-msgstr "Locations"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:842
 msgid "search.bar.locations"
+msgstr "Locations"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:312
+msgid "search.detail.locations"
 msgstr "Locations"
 
 #. Login button label
@@ -2514,16 +2526,16 @@ msgstr "No jobs found."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "No languages match your search."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:513
-msgid "search.locationModal.noResults"
-msgstr "No locations match your search."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:309
 msgid "company.locationModal.noResults"
+msgstr "No locations match your search."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:513
+msgid "search.locationModal.noResults"
 msgstr "No locations match your search."
 
 #. No postings found message on company page
@@ -2534,7 +2546,7 @@ msgstr "No matching postings found."
 
 #. Empty-state message shown when no blog posts have been published yet
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:88
+#: app/[lang]/(public)/blog/page.tsx:89
 msgid "blog.index.empty"
 msgstr "No posts yet — check back soon."
 
@@ -2717,7 +2729,7 @@ msgid "common.header.openMenu"
 msgstr "Open main menu"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:44
+#: app/[lang]/(app)/company/[slug]/page.tsx:45
 msgid "company.meta.openPositions"
 msgstr "Open positions"
 
@@ -2887,7 +2899,7 @@ msgstr "Pay period"
 
 #. Pro tier period
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:73
+#: src/components/Pricing.tsx:85
 msgid "home.pricing.pro.period"
 msgstr "per month"
 
@@ -3007,7 +3019,7 @@ msgstr "Posting not found."
 
 #. Pricing section eyebrow
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:103
+#: src/components/Pricing.tsx:115
 msgid "home.pricing.eyebrow"
 msgstr "Pricing"
 
@@ -3051,7 +3063,7 @@ msgstr "Private watchlists are a paid feature. Upgrade to hide your watchlists f
 
 #. Pro tier name
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:68
+#: src/components/Pricing.tsx:80
 msgid "home.pricing.pro.name"
 msgstr "Pro"
 
@@ -3144,16 +3156,16 @@ msgstr "Redistribute your changes, as long as you include the MIT notice."
 msgid "location.type.region"
 msgstr "Region"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:523
-msgid "search.locationModal.regionsHeader"
-msgstr "Regions"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:319
 msgid "company.locationModal.regionsHeader"
+msgstr "Regions"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:523
+msgid "search.locationModal.regionsHeader"
 msgstr "Regions"
 
 #. Status group heading: rejected
@@ -3324,16 +3336,16 @@ msgstr "Round"
 msgid "app.home.request.agent.runIdLabel"
 msgstr "Run id"
 
-#. Salary override section heading
-#. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:76
-msgid "myJobs.detail.salary"
-msgstr "Salary"
-
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:225
 msgid "search.advanced.salary"
+msgstr "Salary"
+
+#. Salary override section heading
+#. js-lingui-explicit-id
+#: src/components/my-jobs/salary-override.tsx:76
+msgid "myJobs.detail.salary"
 msgstr "Salary"
 
 #. Salary display settings section heading
@@ -3428,7 +3440,7 @@ msgstr "Saving..."
 
 #. Free feature: full search
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:44
+#: src/components/Pricing.tsx:50
 msgid "home.pricing.free.f1"
 msgstr "Search across all companies and filters"
 
@@ -3464,7 +3476,7 @@ msgid "search.bar.keyword"
 msgstr "Search for \"{trimmedInput}\" in job titles"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:32
+#: app/[lang]/(app)/explore/page.tsx:33
 msgid "explore.meta.description"
 msgstr "Search jobs across thousands of companies scraped directly from career pages. Filter by seniority, tech stack, salary, and location — then save watchlists and get alerts."
 
@@ -3474,16 +3486,16 @@ msgstr "Search jobs across thousands of companies scraped directly from career p
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Search languages..."
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:492
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Search locations..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:288
 msgid "company.locationModal.searchPlaceholder"
+msgstr "Search locations..."
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:492
+msgid "search.locationModal.searchPlaceholder"
 msgstr "Search locations..."
 
 #. Back-to-search link on company page header
@@ -3570,16 +3582,16 @@ msgstr "Send reset link"
 msgid "settings.account.password.send"
 msgstr "Send reset link"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Sending..."
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
+msgstr "Sending..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
 msgstr "Sending..."
 
 #. Reset password button while loading
@@ -3636,16 +3648,16 @@ msgstr "Settings"
 msgid "home.features.s3.p3.title"
 msgstr "Share with anyone"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:355
-msgid "search.detail.showLessLocations"
-msgstr "Show less"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:351
 msgid "company.page.showLess"
+msgstr "Show less"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:355
+msgid "search.detail.showLessLocations"
 msgstr "Show less"
 
 #. Aria label to show password
@@ -3758,7 +3770,7 @@ msgstr "Similar companies"
 
 #. Pricing section description
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:109
+#: src/components/Pricing.tsx:121
 msgid "home.pricing.description"
 msgstr "Simple, transparent pricing. Start for free and upgrade when you get serious about your job search."
 
@@ -3918,16 +3930,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technical"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Technologies"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:765
 msgid "search.bar.technologies"
+msgstr "Technologies"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:397
+msgid "search.detail.technologies"
 msgstr "Technologies"
 
 #. Add technology filter
@@ -3986,7 +3998,7 @@ msgstr "Terms of Service for Job Seek — usage rules, intellectual property, ac
 
 #. Body text shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:92
+#: app/[lang]/(app)/company/[slug]/page.tsx:93
 msgid "company.notFound.message"
 msgstr "The company you are looking for does not exist or has been removed."
 
@@ -4146,13 +4158,13 @@ msgstr "Under GDPR you can ask for a copy of your data, have it corrected or del
 
 #. Pro feature: unlimited watchlists
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:81
+#: src/components/Pricing.tsx:93
 msgid "home.pricing.pro.f1"
 msgstr "Unlimited watchlists"
 
 #. Pro tier description
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:77
+#: src/components/Pricing.tsx:89
 msgid "home.pricing.pro.description"
 msgstr "Unlimited watchlists with email alerts so you never miss an opening."
 

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -58,7 +58,7 @@ msgid "search.detail.showMoreLocations"
 msgstr "{0} de plus"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:39
+#: app/[lang]/(app)/company/[slug]/page.tsx:40
 msgid "company.meta.positionCount"
 msgstr "{count, plural, one {# poste ouvert} other {# postes ouverts}}"
 
@@ -87,7 +87,7 @@ msgid "blog.mention.watchlist.companiesLabel"
 msgstr "{count, plural, one {entreprise} other {entreprises}}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:103
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:104
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {# entreprise suivie} other {# entreprises suivies}}. {description}"
 
@@ -98,23 +98,23 @@ msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} candidatures le {date}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:61
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:62
 msgid "watchlist.meta.moreCompanies"
 msgstr "{count} de plus"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:51
+#: app/[lang]/(app)/company/[slug]/page.tsx:52
 msgid "company.meta.descriptionBasic"
 msgstr "{countText} chez {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:46
+#: app/[lang]/(app)/company/[slug]/page.tsx:47
 msgid "company.meta.descriptionWithInfo"
 msgstr "{countText} chez {name}. {description}"
 
 #. Reading-time label shown in the blog post byline. {minutes} is the integer minute count.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:150
+#: app/[lang]/(public)/blog/[slug]/page.tsx:151
 msgid "blog.post.readingTime"
 msgstr "{minutes, plural, one {# min de lecture} other {# min de lecture}}"
 
@@ -130,11 +130,23 @@ msgstr "{range} employés"
 msgid "blog.mention.company.employeesCount"
 msgstr "{range} salariés"
 
+#. Free tier price displayed prominently on the home pricing card. Source is USD ($0); translators may render the symbol+number per locale convention (e.g. German '0 $').
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:26
+msgid "home.pricing.free.price"
+msgstr "0 $"
+
 #. Free plan price display
 #. js-lingui-explicit-id
 #: src/components/settings/BillingSettings.tsx:146
 msgid "settings.billing.plan.freePrice"
 msgstr "0 $ / mois"
+
+#. Pro tier price displayed prominently on the home pricing card. Source is USD ($10/month); translators may render the symbol+number per locale convention (e.g. German '10 $').
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:68
+msgid "home.pricing.pro.price"
+msgstr "10 $"
 
 #. Pro plan price display
 #. js-lingui-explicit-id
@@ -150,7 +162,7 @@ msgstr "1 candidature le {date}"
 
 #. Free feature: one watchlist
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:45
+#: src/components/Pricing.tsx:51
 msgid "home.pricing.free.f2"
 msgstr "1 watchlist"
 
@@ -243,16 +255,16 @@ msgstr "Ajouter des entreprises"
 msgid "watchlists.view.addDescription"
 msgstr "Ajouter une description"
 
-#. Quick action tooltip: add interview round
-#. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:19
-msgid "myJobs.action.addInterview"
-msgstr "Ajouter un entretien"
-
 #. Button to add an interview round
 #. js-lingui-explicit-id
 #: src/components/my-jobs/interview-list.tsx:76
 msgid "myJobs.detail.addInterview"
+msgstr "Ajouter un entretien"
+
+#. Quick action tooltip: add interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/quick-actions.tsx:19
+msgid "myJobs.action.addInterview"
 msgstr "Ajouter un entretien"
 
 #. Placeholder in the add keyword input
@@ -394,7 +406,7 @@ msgstr "Suivi de candidature"
 
 #. Free feature: application tracker
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:46
+#: src/components/Pricing.tsx:52
 msgid "home.pricing.free.f3"
 msgstr "Suivi des candidatures avec journal d'entretiens"
 
@@ -488,16 +500,16 @@ msgstr "Aoû"
 msgid "settings.account.username.available"
 msgstr "Disponible"
 
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Retour à la connexion"
-
 #. Link back to sign-in after failed verification
 #. js-lingui-explicit-id
 #: app/[lang]/verify-email/page.tsx:68
 msgid "auth.verify.error.backToSignIn"
+msgstr "Retour à la connexion"
+
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
 msgstr "Retour à la connexion"
 
 #. Link back to sign-in from forgot password
@@ -526,28 +538,22 @@ msgstr "Retour en haut"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Comportemental"
 
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:146
+msgid "blog.post.backToIndex"
+msgstr "Blog"
+
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:27
+#: app/[lang]/(public)/blog/page.tsx:28
 msgid "blog.meta.title"
 msgstr "Blog"
 
 #. <h1> on the blog index page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:78
+#: app/[lang]/(public)/blog/page.tsx:79
 msgid "blog.index.heading"
-msgstr "Blog"
-
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:145
-msgid "blog.post.backToIndex"
-msgstr "Blog"
-
-#. Footer link to /blog index page
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
-msgid "common.footer.blog"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -556,6 +562,12 @@ msgstr "Blog"
 #: src/components/Header.tsx:74
 #: src/components/MobileMenu.tsx:98
 msgid "common.nav.blog"
+msgstr "Blog"
+
+#. Footer link to /blog index page
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:52
+msgid "common.footer.blog"
 msgstr "Blog"
 
 #. Subtitle on the sign-in CTA card shown to anonymous users at the end of the similar-companies strip
@@ -647,17 +659,17 @@ msgstr "Modifie ton mot de passe via un lien e-mail sécurisé."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Changer…"
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "Vérifie ton e-mail"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
 msgstr "Vérifiez votre e-mail"
+
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
+msgstr "Vérifie ton e-mail"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -685,7 +697,7 @@ msgstr "Choisissez le plan qui vous convient."
 
 #. Pricing section heading
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:106
+#: src/components/Pricing.tsx:118
 msgid "home.pricing.title"
 msgstr "Choisis l'offre qui te convient"
 
@@ -791,7 +803,7 @@ msgstr "Combine des entreprises spécifiques avec des filtres de rôle pour cibl
 
 #. Pro tier CTA — disabled until subscriptions launch
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:61
+#: src/components/Pricing.tsx:67
 msgid "home.pricing.pro.cta"
 msgstr "Bientôt disponible"
 
@@ -835,7 +847,7 @@ msgstr "Entreprise"
 #. Heading shown when the company URL slug doesn't resolve to a known company
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/company/[slug]/company-content.tsx:19
-#: app/[lang]/(app)/company/[slug]/page.tsx:87
+#: app/[lang]/(app)/company/[slug]/page.tsx:88
 msgid "company.notFound.title"
 msgstr "Entreprise introuvable"
 
@@ -1075,13 +1087,13 @@ msgstr "Sombre"
 
 #. Meta description (under 160 chars) for the blog index page — covers data analyses + report breakdowns + news commentary
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:32
+#: app/[lang]/(public)/blog/page.tsx:33
 msgid "blog.meta.description"
 msgstr "Analyses de données, actualités et résumés de rapports sectoriels — issus des offres d'emploi que nous suivons sur les pages carrières de milliers d'entreprises."
 
 #. One-line tagline under the blog index <h1> — covers data analyses + reports/papers + news
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:83
+#: app/[lang]/(public)/blog/page.tsx:84
 msgid "blog.index.tagline"
 msgstr "Analyses de données, actualités et résumés de rapports sectoriels et d'études — issus des offres d'emploi que nous suivons."
 
@@ -1244,7 +1256,7 @@ msgstr "Suivi illimité d'entreprises"
 
 #. Pro feature: email alerts
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:82
+#: src/components/Pricing.tsx:94
 msgid "home.pricing.pro.f2"
 msgstr "Alertes e-mail sur les nouvelles correspondances"
 
@@ -1304,7 +1316,7 @@ msgstr "Chaque fenêtre de réessai utilise un backoff exponentiel afin de ne ja
 
 #. Pro feature: includes free
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:80
+#: src/components/Pricing.tsx:92
 msgid "home.pricing.pro.f0"
 msgstr "Tout ce qui est dans Gratuit"
 
@@ -1346,7 +1358,7 @@ msgid "app.header.nav.explore"
 msgstr "Explorer"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:31
+#: app/[lang]/(app)/explore/page.tsx:32
 msgid "explore.meta.title"
 msgstr "Explorer les emplois"
 
@@ -1511,7 +1523,7 @@ msgstr "Pour les chercheurs d'emploi qui savent déjà où ils veulent travaille
 
 #. Free tier period
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:37
+#: src/components/Pricing.tsx:43
 msgid "home.pricing.free.period"
 msgstr "Pour toujours"
 
@@ -1541,7 +1553,7 @@ msgstr "Fondée en {year}"
 
 #. Free tier name
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:32
+#: src/components/Pricing.tsx:38
 msgid "home.pricing.free.name"
 msgstr "Gratuit"
 
@@ -1587,7 +1599,7 @@ msgstr "Recherche complète, 1 liste de suivi, suivi des candidatures"
 
 #. Free tier description
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:41
+#: src/components/Pricing.tsx:47
 msgid "home.pricing.free.description"
 msgstr "Recherche complète, une watchlist et un suivi des candidatures intégré pour gérer ton pipeline."
 
@@ -1773,7 +1785,7 @@ msgid "indexing.outreach.body"
 msgstr "Si tu remarques un comportement inhabituel de notre robot, préfères que nous n'indexions pas ton contenu, ou as des suggestions pour améliorer nos mesures de protection, n'hésite pas à nous contacter."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:77
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:78
 msgid "watchlist.meta.inLocations"
 msgstr "à {locations}"
 
@@ -2042,7 +2054,7 @@ msgid "license.hero.description"
 msgstr "Le code source de Job Seek est ouvert sous licence MIT. Les données d'emploi que nous collectons et enrichissons sont sous Creative Commons BY-NC 4.0. Tu trouveras ci-dessous un résumé en langage clair — consulte les licences complètes pour les termes exacts."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:85
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:86
 msgid "watchlist.meta.fallback"
 msgstr "Liste d'emplois de @{owner}"
 
@@ -2059,12 +2071,12 @@ msgid "watchlists.explore.jobPlural"
 msgstr "offres"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:32
+#: app/[lang]/(app)/company/[slug]/page.tsx:33
 msgid "company.meta.title"
 msgstr "Emplois chez {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:67
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:68
 msgid "watchlist.meta.jobsAt"
 msgstr "Emplois chez {names}"
 
@@ -2212,16 +2224,16 @@ msgstr "Lieu"
 msgid "search.advanced.location"
 msgstr "Lieu"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
-msgstr "Lieux"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:842
 msgid "search.bar.locations"
+msgstr "Lieux"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:312
+msgid "search.detail.locations"
 msgstr "Lieux"
 
 #. Login button label
@@ -2514,16 +2526,16 @@ msgstr "Aucune offre trouvée."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Aucune langue ne correspond à votre recherche."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:513
-msgid "search.locationModal.noResults"
-msgstr "Aucun lieu ne correspond à votre recherche."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:309
 msgid "company.locationModal.noResults"
+msgstr "Aucun lieu ne correspond à votre recherche."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:513
+msgid "search.locationModal.noResults"
 msgstr "Aucun lieu ne correspond à votre recherche."
 
 #. No postings found message on company page
@@ -2534,7 +2546,7 @@ msgstr "Aucune offre correspondante trouvée."
 
 #. Empty-state message shown when no blog posts have been published yet
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:88
+#: app/[lang]/(public)/blog/page.tsx:89
 msgid "blog.index.empty"
 msgstr "Aucun article pour le moment — revenez bientôt."
 
@@ -2717,7 +2729,7 @@ msgid "common.header.openMenu"
 msgstr "Ouvrir le menu principal"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:44
+#: app/[lang]/(app)/company/[slug]/page.tsx:45
 msgid "company.meta.openPositions"
 msgstr "Postes ouverts"
 
@@ -2887,7 +2899,7 @@ msgstr "Période"
 
 #. Pro tier period
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:73
+#: src/components/Pricing.tsx:85
 msgid "home.pricing.pro.period"
 msgstr "par mois"
 
@@ -3007,7 +3019,7 @@ msgstr "Offre introuvable."
 
 #. Pricing section eyebrow
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:103
+#: src/components/Pricing.tsx:115
 msgid "home.pricing.eyebrow"
 msgstr "Tarifs"
 
@@ -3051,7 +3063,7 @@ msgstr "Les listes de suivi privées sont une fonctionnalité payante. Passez à
 
 #. Pro tier name
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:68
+#: src/components/Pricing.tsx:80
 msgid "home.pricing.pro.name"
 msgstr "Pro"
 
@@ -3144,16 +3156,16 @@ msgstr "Redistribue tes modifications, à condition d'inclure la mention MIT."
 msgid "location.type.region"
 msgstr "Région"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:523
-msgid "search.locationModal.regionsHeader"
-msgstr "Régions"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:319
 msgid "company.locationModal.regionsHeader"
+msgstr "Régions"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:523
+msgid "search.locationModal.regionsHeader"
 msgstr "Régions"
 
 #. Status group heading: rejected
@@ -3324,16 +3336,16 @@ msgstr "Tour"
 msgid "app.home.request.agent.runIdLabel"
 msgstr "Identifiant d'exécution"
 
-#. Salary override section heading
-#. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:76
-msgid "myJobs.detail.salary"
-msgstr "Salaire"
-
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:225
 msgid "search.advanced.salary"
+msgstr "Salaire"
+
+#. Salary override section heading
+#. js-lingui-explicit-id
+#: src/components/my-jobs/salary-override.tsx:76
+msgid "myJobs.detail.salary"
 msgstr "Salaire"
 
 #. Salary display settings section heading
@@ -3428,7 +3440,7 @@ msgstr "Enregistrement…"
 
 #. Free feature: full search
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:44
+#: src/components/Pricing.tsx:50
 msgid "home.pricing.free.f1"
 msgstr "Recherche dans toutes les entreprises et tous les filtres"
 
@@ -3464,7 +3476,7 @@ msgid "search.bar.keyword"
 msgstr "Rechercher \"{trimmedInput}\" dans les titres de postes"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:32
+#: app/[lang]/(app)/explore/page.tsx:33
 msgid "explore.meta.description"
 msgstr "Recherchez des emplois dans des milliers d'entreprises, scrapés directement des pages carrières. Filtrez par niveau, stack technique, salaire et localisation — créez des watchlists et recevez des alertes."
 
@@ -3474,17 +3486,17 @@ msgstr "Recherchez des emplois dans des milliers d'entreprises, scrapés directe
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Rechercher des langues…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:492
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Rechercher des lieux..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:288
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Rechercher des lieux…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:492
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Rechercher des lieux..."
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3570,16 +3582,16 @@ msgstr "Envoyer le lien"
 msgid "settings.account.password.send"
 msgstr "Envoyer le lien"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Envoi en cours..."
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
+msgstr "Envoi en cours..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
 msgstr "Envoi en cours..."
 
 #. Reset password button while loading
@@ -3636,16 +3648,16 @@ msgstr "Paramètres"
 msgid "home.features.s3.p3.title"
 msgstr "Partager avec tout le monde"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:355
-msgid "search.detail.showLessLocations"
-msgstr "Afficher moins"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:351
 msgid "company.page.showLess"
+msgstr "Afficher moins"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:355
+msgid "search.detail.showLessLocations"
 msgstr "Afficher moins"
 
 #. Aria label to show password
@@ -3758,7 +3770,7 @@ msgstr "Entreprises similaires"
 
 #. Pricing section description
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:109
+#: src/components/Pricing.tsx:121
 msgid "home.pricing.description"
 msgstr "Des tarifs simples et transparents. Commence gratuitement et passe à la vitesse supérieure quand ta recherche d'emploi devient sérieuse."
 
@@ -3918,16 +3930,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technique"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Technologies"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:765
 msgid "search.bar.technologies"
+msgstr "Technologies"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:397
+msgid "search.detail.technologies"
 msgstr "Technologies"
 
 #. Add technology filter
@@ -3986,7 +3998,7 @@ msgstr "Conditions d'utilisation de Job Seek — règles d'usage, propriété in
 
 #. Body text shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:92
+#: app/[lang]/(app)/company/[slug]/page.tsx:93
 msgid "company.notFound.message"
 msgstr "L'entreprise que vous recherchez n'existe pas ou a été supprimée."
 
@@ -4146,13 +4158,13 @@ msgstr "Selon le RGPD, tu peux demander une copie de tes données, les faire cor
 
 #. Pro feature: unlimited watchlists
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:81
+#: src/components/Pricing.tsx:93
 msgid "home.pricing.pro.f1"
 msgstr "Watchlists illimitées"
 
 #. Pro tier description
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:77
+#: src/components/Pricing.tsx:89
 msgid "home.pricing.pro.description"
 msgstr "Watchlists illimitées avec alertes par e-mail pour ne jamais rater une ouverture."
 

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -58,7 +58,7 @@ msgid "search.detail.showMoreLocations"
 msgstr "{0} in più"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:39
+#: app/[lang]/(app)/company/[slug]/page.tsx:40
 msgid "company.meta.positionCount"
 msgstr "{count, plural, one {# posizione aperta} other {# posizioni aperte}}"
 
@@ -87,7 +87,7 @@ msgid "blog.mention.watchlist.companiesLabel"
 msgstr "{count, plural, one {azienda} other {aziende}}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:103
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:104
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {# azienda monitorata} other {# aziende monitorate}}. {description}"
 
@@ -98,23 +98,23 @@ msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} candidature il {date}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:61
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:62
 msgid "watchlist.meta.moreCompanies"
 msgstr "altre {count}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:51
+#: app/[lang]/(app)/company/[slug]/page.tsx:52
 msgid "company.meta.descriptionBasic"
 msgstr "{countText} presso {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:46
+#: app/[lang]/(app)/company/[slug]/page.tsx:47
 msgid "company.meta.descriptionWithInfo"
 msgstr "{countText} presso {name}. {description}"
 
 #. Reading-time label shown in the blog post byline. {minutes} is the integer minute count.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:150
+#: app/[lang]/(public)/blog/[slug]/page.tsx:151
 msgid "blog.post.readingTime"
 msgstr "{minutes, plural, one {# min di lettura} other {# min di lettura}}"
 
@@ -130,11 +130,23 @@ msgstr "{range} dipendenti"
 msgid "blog.mention.company.employeesCount"
 msgstr "{range} dipendenti"
 
+#. Free tier price displayed prominently on the home pricing card. Source is USD ($0); translators may render the symbol+number per locale convention (e.g. German '0 $').
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:26
+msgid "home.pricing.free.price"
+msgstr "0 $"
+
 #. Free plan price display
 #. js-lingui-explicit-id
 #: src/components/settings/BillingSettings.tsx:146
 msgid "settings.billing.plan.freePrice"
 msgstr "0 $ / mese"
+
+#. Pro tier price displayed prominently on the home pricing card. Source is USD ($10/month); translators may render the symbol+number per locale convention (e.g. German '10 $').
+#. js-lingui-explicit-id
+#: src/components/Pricing.tsx:68
+msgid "home.pricing.pro.price"
+msgstr "10 $"
 
 #. Pro plan price display
 #. js-lingui-explicit-id
@@ -150,7 +162,7 @@ msgstr "1 candidatura il {date}"
 
 #. Free feature: one watchlist
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:45
+#: src/components/Pricing.tsx:51
 msgid "home.pricing.free.f2"
 msgstr "1 watchlist"
 
@@ -243,16 +255,16 @@ msgstr "Aggiungi aziende"
 msgid "watchlists.view.addDescription"
 msgstr "Aggiungi descrizione"
 
-#. Quick action tooltip: add interview round
-#. js-lingui-explicit-id
-#: src/components/my-jobs/quick-actions.tsx:19
-msgid "myJobs.action.addInterview"
-msgstr "Aggiungi colloquio"
-
 #. Button to add an interview round
 #. js-lingui-explicit-id
 #: src/components/my-jobs/interview-list.tsx:76
 msgid "myJobs.detail.addInterview"
+msgstr "Aggiungi colloquio"
+
+#. Quick action tooltip: add interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/quick-actions.tsx:19
+msgid "myJobs.action.addInterview"
 msgstr "Aggiungi colloquio"
 
 #. Placeholder in the add keyword input
@@ -394,7 +406,7 @@ msgstr "Monitoraggio candidatura"
 
 #. Free feature: application tracker
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:46
+#: src/components/Pricing.tsx:52
 msgid "home.pricing.free.f3"
 msgstr "Tracker delle candidature con registro dei colloqui"
 
@@ -488,16 +500,16 @@ msgstr "Ago"
 msgid "settings.account.username.available"
 msgstr "Disponibile"
 
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Torna all'accesso"
-
 #. Link back to sign-in after failed verification
 #. js-lingui-explicit-id
 #: app/[lang]/verify-email/page.tsx:68
 msgid "auth.verify.error.backToSignIn"
+msgstr "Torna all'accesso"
+
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
 msgstr "Torna all'accesso"
 
 #. Link back to sign-in from forgot password
@@ -526,28 +538,22 @@ msgstr "Torna su"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Comportamentale"
 
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:146
+msgid "blog.post.backToIndex"
+msgstr "Blog"
+
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:27
+#: app/[lang]/(public)/blog/page.tsx:28
 msgid "blog.meta.title"
 msgstr "Blog"
 
 #. <h1> on the blog index page
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:78
+#: app/[lang]/(public)/blog/page.tsx:79
 msgid "blog.index.heading"
-msgstr "Blog"
-
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:145
-msgid "blog.post.backToIndex"
-msgstr "Blog"
-
-#. Footer link to /blog index page
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
-msgid "common.footer.blog"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -556,6 +562,12 @@ msgstr "Blog"
 #: src/components/Header.tsx:74
 #: src/components/MobileMenu.tsx:98
 msgid "common.nav.blog"
+msgstr "Blog"
+
+#. Footer link to /blog index page
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:52
+msgid "common.footer.blog"
 msgstr "Blog"
 
 #. Subtitle on the sign-in CTA card shown to anonymous users at the end of the similar-companies strip
@@ -647,17 +659,17 @@ msgstr "Cambia la tua password tramite un link email sicuro."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Cambia…"
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "Controlla la tua email"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
 msgstr "Controlla la tua e-mail"
+
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
+msgstr "Controlla la tua email"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -685,7 +697,7 @@ msgstr "Scegli il piano più adatto a te."
 
 #. Pricing section heading
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:106
+#: src/components/Pricing.tsx:118
 msgid "home.pricing.title"
 msgstr "Scegli il piano giusto per te"
 
@@ -791,7 +803,7 @@ msgstr "Combina aziende specifiche con filtri per ruolo per individuare esattame
 
 #. Pro tier CTA — disabled until subscriptions launch
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:61
+#: src/components/Pricing.tsx:67
 msgid "home.pricing.pro.cta"
 msgstr "In arrivo"
 
@@ -835,7 +847,7 @@ msgstr "Azienda"
 #. Heading shown when the company URL slug doesn't resolve to a known company
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/company/[slug]/company-content.tsx:19
-#: app/[lang]/(app)/company/[slug]/page.tsx:87
+#: app/[lang]/(app)/company/[slug]/page.tsx:88
 msgid "company.notFound.title"
 msgstr "Azienda non trovata"
 
@@ -1075,13 +1087,13 @@ msgstr "Scuro"
 
 #. Meta description (under 160 chars) for the blog index page — covers data analyses + report breakdowns + news commentary
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:32
+#: app/[lang]/(public)/blog/page.tsx:33
 msgid "blog.meta.description"
 msgstr "Analisi dei dati, novità e riepiloghi di report di settore — tratti dagli annunci di lavoro che monitoriamo nelle pagine carriere di migliaia di aziende."
 
 #. One-line tagline under the blog index <h1> — covers data analyses + reports/papers + news
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:83
+#: app/[lang]/(public)/blog/page.tsx:84
 msgid "blog.index.tagline"
 msgstr "Analisi dei dati, novità e riepiloghi di report e studi di settore — tratti dagli annunci di lavoro che monitoriamo."
 
@@ -1244,7 +1256,7 @@ msgstr "Segui aziende illimitatamente"
 
 #. Pro feature: email alerts
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:82
+#: src/components/Pricing.tsx:94
 msgid "home.pricing.pro.f2"
 msgstr "Avvisi email sui nuovi risultati"
 
@@ -1304,7 +1316,7 @@ msgstr "Ogni finestra di retry utilizza un backoff esponenziale, così non sovra
 
 #. Pro feature: includes free
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:80
+#: src/components/Pricing.tsx:92
 msgid "home.pricing.pro.f0"
 msgstr "Tutto quello incluso in Gratuito"
 
@@ -1346,7 +1358,7 @@ msgid "app.header.nav.explore"
 msgstr "Esplora"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:31
+#: app/[lang]/(app)/explore/page.tsx:32
 msgid "explore.meta.title"
 msgstr "Esplora lavori"
 
@@ -1511,7 +1523,7 @@ msgstr "Per chi cerca lavoro e sa già dove vuole lavorare."
 
 #. Free tier period
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:37
+#: src/components/Pricing.tsx:43
 msgid "home.pricing.free.period"
 msgstr "Per sempre"
 
@@ -1541,7 +1553,7 @@ msgstr "Fondata nel {year}"
 
 #. Free tier name
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:32
+#: src/components/Pricing.tsx:38
 msgid "home.pricing.free.name"
 msgstr "Gratis"
 
@@ -1587,7 +1599,7 @@ msgstr "Ricerca completa, 1 watchlist, tracker delle candidature"
 
 #. Free tier description
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:41
+#: src/components/Pricing.tsx:47
 msgid "home.pricing.free.description"
 msgstr "Ricerca completa, una watchlist e un tracker delle candidature integrato per gestire la tua pipeline."
 
@@ -1773,7 +1785,7 @@ msgid "indexing.outreach.body"
 msgstr "Se noti un comportamento anomalo del crawler, preferisci che non indicizziamo i tuoi contenuti o hai suggerimenti su come migliorare le nostre misure di sicurezza, contattaci."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:77
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:78
 msgid "watchlist.meta.inLocations"
 msgstr "a {locations}"
 
@@ -2042,7 +2054,7 @@ msgid "license.hero.description"
 msgstr "Il codice sorgente di Job Seek è open source sotto licenza MIT. I dati sugli annunci che raccogliamo e arricchiamo sono Creative Commons BY-NC 4.0. Di seguito il riepilogo in linguaggio semplice — si prega di leggere le licenze complete per i termini esatti."
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:85
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:86
 msgid "watchlist.meta.fallback"
 msgstr "Lista lavori di @{owner}"
 
@@ -2059,12 +2071,12 @@ msgid "watchlists.explore.jobPlural"
 msgstr "offerte"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:32
+#: app/[lang]/(app)/company/[slug]/page.tsx:33
 msgid "company.meta.title"
 msgstr "Lavori presso {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:67
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:68
 msgid "watchlist.meta.jobsAt"
 msgstr "Lavori presso {names}"
 
@@ -2212,17 +2224,17 @@ msgstr "Luogo"
 msgid "search.advanced.location"
 msgstr "Luogo"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
-msgstr "Località"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:842
 msgid "search.bar.locations"
 msgstr "Sedi"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:312
+msgid "search.detail.locations"
+msgstr "Località"
 
 #. Login button label
 #. Login button label
@@ -2514,17 +2526,17 @@ msgstr "Nessuna offerta trovata."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Nessuna lingua corrisponde alla ricerca."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:513
-msgid "search.locationModal.noResults"
-msgstr "Nessun luogo corrisponde alla tua ricerca."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:309
 msgid "company.locationModal.noResults"
 msgstr "Nessuna sede corrisponde alla tua ricerca."
+
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:513
+msgid "search.locationModal.noResults"
+msgstr "Nessun luogo corrisponde alla tua ricerca."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2534,7 +2546,7 @@ msgstr "Nessun annuncio corrispondente trovato."
 
 #. Empty-state message shown when no blog posts have been published yet
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/page.tsx:88
+#: app/[lang]/(public)/blog/page.tsx:89
 msgid "blog.index.empty"
 msgstr "Ancora nessun articolo — torna presto."
 
@@ -2717,7 +2729,7 @@ msgid "common.header.openMenu"
 msgstr "Apri menu principale"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:44
+#: app/[lang]/(app)/company/[slug]/page.tsx:45
 msgid "company.meta.openPositions"
 msgstr "Posizioni aperte"
 
@@ -2887,7 +2899,7 @@ msgstr "Periodo"
 
 #. Pro tier period
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:73
+#: src/components/Pricing.tsx:85
 msgid "home.pricing.pro.period"
 msgstr "al mese"
 
@@ -3007,7 +3019,7 @@ msgstr "Offerta non trovata."
 
 #. Pricing section eyebrow
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:103
+#: src/components/Pricing.tsx:115
 msgid "home.pricing.eyebrow"
 msgstr "Prezzi"
 
@@ -3051,7 +3063,7 @@ msgstr "Le liste private sono una funzionalità a pagamento. Effettua l'upgrade 
 
 #. Pro tier name
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:68
+#: src/components/Pricing.tsx:80
 msgid "home.pricing.pro.name"
 msgstr "Pro"
 
@@ -3144,16 +3156,16 @@ msgstr "Ridistribuire le proprie modifiche, a condizione di includere l'avviso M
 msgid "location.type.region"
 msgstr "Regione"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:523
-msgid "search.locationModal.regionsHeader"
-msgstr "Regioni"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:319
 msgid "company.locationModal.regionsHeader"
+msgstr "Regioni"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:523
+msgid "search.locationModal.regionsHeader"
 msgstr "Regioni"
 
 #. Status group heading: rejected
@@ -3324,16 +3336,16 @@ msgstr "Turno"
 msgid "app.home.request.agent.runIdLabel"
 msgstr "ID esecuzione"
 
-#. Salary override section heading
-#. js-lingui-explicit-id
-#: src/components/my-jobs/salary-override.tsx:76
-msgid "myJobs.detail.salary"
-msgstr "Stipendio"
-
 #. Label for salary filter in advanced search
 #. js-lingui-explicit-id
 #: src/components/search/advanced-search-panel.tsx:225
 msgid "search.advanced.salary"
+msgstr "Stipendio"
+
+#. Salary override section heading
+#. js-lingui-explicit-id
+#: src/components/my-jobs/salary-override.tsx:76
+msgid "myJobs.detail.salary"
 msgstr "Stipendio"
 
 #. Salary display settings section heading
@@ -3428,7 +3440,7 @@ msgstr "Salvataggio…"
 
 #. Free feature: full search
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:44
+#: src/components/Pricing.tsx:50
 msgid "home.pricing.free.f1"
 msgstr "Ricerca su tutte le aziende e tutti i filtri"
 
@@ -3464,7 +3476,7 @@ msgid "search.bar.keyword"
 msgstr "Cerca \"{trimmedInput}\" nei titoli di lavoro"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:32
+#: app/[lang]/(app)/explore/page.tsx:33
 msgid "explore.meta.description"
 msgstr "Cerca lavori in migliaia di aziende, scansionati direttamente dalle pagine carriere. Filtra per livello, stack tecnologico, stipendio e località — crea watchlist e ricevi notifiche."
 
@@ -3474,17 +3486,17 @@ msgstr "Cerca lavori in migliaia di aziende, scansionati direttamente dalle pagi
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Cerca lingue…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:492
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Cerca luoghi..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:288
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Cerca sedi…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:492
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Cerca luoghi..."
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3570,16 +3582,16 @@ msgstr "Invia link"
 msgid "settings.account.password.send"
 msgstr "Invia il link"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Invio in corso..."
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
+msgstr "Invio in corso..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
 msgstr "Invio in corso..."
 
 #. Reset password button while loading
@@ -3636,16 +3648,16 @@ msgstr "Impostazioni"
 msgid "home.features.s3.p3.title"
 msgstr "Condividi con chiunque"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:355
-msgid "search.detail.showLessLocations"
-msgstr "Mostra meno"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:351
 msgid "company.page.showLess"
+msgstr "Mostra meno"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:355
+msgid "search.detail.showLessLocations"
 msgstr "Mostra meno"
 
 #. Aria label to show password
@@ -3758,7 +3770,7 @@ msgstr "Aziende simili"
 
 #. Pricing section description
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:109
+#: src/components/Pricing.tsx:121
 msgid "home.pricing.description"
 msgstr "Prezzi semplici e trasparenti. Inizia gratis e passa al piano superiore quando fai sul serio con la tua ricerca di lavoro."
 
@@ -3918,16 +3930,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Tecnico"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Tecnologie"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:765
 msgid "search.bar.technologies"
+msgstr "Tecnologie"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:397
+msgid "search.detail.technologies"
 msgstr "Tecnologie"
 
 #. Add technology filter
@@ -3986,7 +3998,7 @@ msgstr "Termini di servizio di Job Seek — regole d'uso, proprietà intellettua
 
 #. Body text shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:92
+#: app/[lang]/(app)/company/[slug]/page.tsx:93
 msgid "company.notFound.message"
 msgstr "L'azienda che stai cercando non esiste o è stata rimossa."
 
@@ -4146,13 +4158,13 @@ msgstr "Secondo il GDPR puoi richiedere una copia dei tuoi dati, farli corregger
 
 #. Pro feature: unlimited watchlists
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:81
+#: src/components/Pricing.tsx:93
 msgid "home.pricing.pro.f1"
 msgstr "Watchlist illimitate"
 
 #. Pro tier description
 #. js-lingui-explicit-id
-#: src/components/Pricing.tsx:77
+#: src/components/Pricing.tsx:89
 msgid "home.pricing.pro.description"
 msgstr "Watchlist illimitate con avvisi via email così non perdi mai un'apertura."
 

--- a/apps/web/src/components/Pricing.tsx
+++ b/apps/web/src/components/Pricing.tsx
@@ -23,6 +23,12 @@ function FreeTier() {
   const cfg = siteConfig.pricing.free;
   const ctaHref = lp(cfg.href);
   const ctaLabel = t({ id: "home.pricing.free.cta", comment: "Free tier CTA", message: "Start for free" });
+  const priceLabel = t({
+    id: "home.pricing.free.price",
+    comment:
+      "Free tier price displayed prominently on the home pricing card. Source is USD ($0); translators may render the symbol+number per locale convention (e.g. German '0 $').",
+    message: "$0",
+  });
 
   return (
     <div className="mx-auto flex w-full max-w-[500px] md:mx-0 md:max-w-[360px] md:flex-[1_1_320px]">
@@ -32,7 +38,7 @@ function FreeTier() {
             <Trans id="home.pricing.free.name" comment="Free tier name">Free</Trans>
           </p>
           <div className="mt-2 flex items-baseline gap-2">
-            <span className="text-3xl font-bold">$0</span>
+            <span className="text-3xl font-bold">{priceLabel}</span>
             <span className="text-muted">
               <Trans id="home.pricing.free.period" comment="Free tier period">Forever</Trans>
             </span>
@@ -59,6 +65,12 @@ function FreeTier() {
 function ProTier() {
   const { t } = useLingui();
   const ctaLabel = t({ id: "home.pricing.pro.cta", comment: "Pro tier CTA — disabled until subscriptions launch", message: "Coming soon" });
+  const priceLabel = t({
+    id: "home.pricing.pro.price",
+    comment:
+      "Pro tier price displayed prominently on the home pricing card. Source is USD ($10/month); translators may render the symbol+number per locale convention (e.g. German '10 $').",
+    message: "$10",
+  });
 
   return (
     <div className="mx-auto flex w-full max-w-[500px] md:mx-0 md:max-w-[360px] md:flex-[1_1_320px]">
@@ -68,7 +80,7 @@ function ProTier() {
             <Trans id="home.pricing.pro.name" comment="Pro tier name">Pro</Trans>
           </p>
           <div className="mt-2 flex items-baseline gap-2">
-            <span className="text-3xl font-bold">$10</span>
+            <span className="text-3xl font-bold">{priceLabel}</span>
             <span className="text-muted">
               <Trans id="home.pricing.pro.period" comment="Pro tier period">per month</Trans>
             </span>


### PR DESCRIPTION
## Summary

- Move hardcoded `$0` / `$10` in `src/components/Pricing.tsx` into Lingui `t()` macros with explicit `id` + `comment` so non-English locales can format the price per locale convention.
- Add catalog entries `home.pricing.free.price` / `home.pricing.pro.price`. English keeps `$0` / `$10`; de/fr/it render `0 $` / `10 $`, matching the existing suffix-style convention already used by `settings.billing.plan.{free,pro}Price` in `BillingSettings.tsx`.
- No behavior change in `BillingSettings.tsx` — its `freePrice` / `proPrice` strings already route through `t()` with localized catalogs (verified `de: "0 $ / Monat"`, `fr: "0 $ / mois"`, `it: "0 $ / mese"`).

## Why this fix (over fancier currency formatting)

The product price is a single canonical USD amount; there is no `preferredCurrency` plumbed through the pricing/checkout surface today. Routing the literal price through `t()` is the minimum correct fix: it lets translators control symbol/number ordering for their locale (a German speaker will not read `$10 per month` naturally even when `per month` is translated). Full `Intl.NumberFormat` + per-locale conversion would require a price-source-of-truth refactor that is out of scope for this issue.

## JSON-LD `priceCurrency` (flagged for separate evaluation)

`app/[lang]/layout.tsx` lines 129 and 136 hardcode `priceCurrency: "USD"` in the `WebApplication` Offer JSON-LD. Since the canonical price is USD (Stripe checkout sets the actual transaction currency), this is **correct** structured data — search engines should see the canonical price, not the display formatting. I left it as-is; flagging here in case product wants to revisit alongside a full per-locale pricing rollout.

## Test plan

- [x] `pnpm extract` -> 0 missing translations in de/fr/it after manual fill
- [x] `pnpm compile` clean
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm test --run` -> 785/785 passing
- [x] Pre-commit hooks pass (ESLint + Lingui translation coverage)
- [x] Visual verification at `localhost:3022` on en / de / fr / it (screenshots in PR thread)
- [ ] Reviewer eyeballs the four screenshots and confirms the suffix-style is the desired convention (matches `settings/billing` plan card)

### Screenshots

`pricing-en.png`, `pricing-de.png`, `pricing-fr.png`, `pricing-it.png` (attached separately — local files at `/tmp/pricing-screenshots/`).

| Locale | Free price | Pro price |
| --- | --- | --- |
| en | `$0` | `$10` |
| de | `0 $` | `10 $` |
| fr | `0 $` | `10 $` |
| it | `0 $` | `10 $` |

Closes #3148.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)