### PR TITLE
fix(web): align activity-heatmap day buckets to viewer TZ (closes #3199)

### DIFF
--- a/apps/web/app/[lang]/(app)/my-jobs/stats/stats-loader.tsx
+++ b/apps/web/app/[lang]/(app)/my-jobs/stats/stats-loader.tsx
@@ -2,13 +2,17 @@
 
 import { useEffect, useState } from "react";
 import { getStats, type StatsData } from "@/lib/actions/my-jobs-stats";
+import { getViewerTz } from "@/lib/viewer-tz";
 import { StatsPage } from "./stats-page";
 
 export function StatsLoader({ locale: _locale }: { locale: string }) {
   const [data, setData] = useState<StatsData | null>(null);
 
   useEffect(() => {
-    getStats().then(setData);
+    // Pass the browser's resolved IANA timezone so server-side day
+    // bucketing for the activity heatmap matches what the client
+    // renders. See #3199.
+    getStats({ tz: getViewerTz() }).then(setData);
   }, []);
 
   if (!data) {

--- a/apps/web/app/[lang]/(app)/my-jobs/stats/stats-page.tsx
+++ b/apps/web/app/[lang]/(app)/my-jobs/stats/stats-page.tsx
@@ -7,6 +7,7 @@ import { BackLink } from "@/components/BackLink";
 import { SankeyFunnel } from "@/components/my-jobs/sankey-funnel";
 import { ActivityHeatmap } from "@/components/my-jobs/activity-heatmap";
 import { getStats, type StatsData } from "@/lib/actions/my-jobs-stats";
+import { getViewerTz } from "@/lib/viewer-tz";
 
 export function StatsPage({ initial }: { initial: StatsData }) {
   const lp = useLocalePath();
@@ -18,9 +19,13 @@ export function StatsPage({ initial }: { initial: StatsData }) {
   const handleFilter = useCallback(async (newFrom: string, newTo: string) => {
     setLoading(true);
     try {
+      // Pass the viewer's resolved IANA timezone so day bucketing and
+      // the `from`/`to` calendar-day filter both resolve at the user's
+      // local midnight, not Postgres-server midnight. See #3199.
       const result = await getStats({
         from: newFrom || undefined,
         to: newTo || undefined,
+        tz: getViewerTz(),
       });
       setData(result);
     } finally {

--- a/apps/web/src/components/my-jobs/__tests__/activity-heatmap.test.tsx
+++ b/apps/web/src/components/my-jobs/__tests__/activity-heatmap.test.tsx
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { ActivityHeatmap } from "../activity-heatmap";
+
+/**
+ * #3199 — Activity-heatmap grid alignment.
+ *
+ * The fix moves day bucketing on the server to `AT TIME ZONE <viewer-tz>`
+ * so the date keys the server returns match the keys the client builds
+ * (which use browser-TZ `Date.getFullYear/Month/Date`).
+ *
+ * The contract these tests pin:
+ *
+ *   - A data row with `{ date: "<today-YYYY-MM-DD>", count: N }` lights
+ *     up the cell at the *today* slot of the grid, not yesterday and
+ *     not tomorrow — for any browser TZ.
+ *   - A data row whose date is one day before today lights up the cell
+ *     immediately before today.
+ *   - A data row whose date is the server-UTC day but NOT the
+ *     browser-local day (the pre-fix shape) misses today's cell. The
+ *     calibration test below reproduces that bug shape against the
+ *     same component to prove the alignment matters.
+ */
+
+// Lingui hook is required by the component for label rendering; stub it.
+vi.mock("@lingui/react/macro", () => ({
+  useLingui: () => ({
+    t: ({ message }: { message?: string }) => message ?? "",
+  }),
+}));
+
+function formatLocal(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function getCells(container: HTMLElement): HTMLElement[] {
+  // The component renders two `<g>` groups (light + dark mode). Both
+  // contain the same data — pick either by querying any rect with a
+  // data-date attribute.
+  return Array.from(
+    container.querySelectorAll<HTMLElement>("rect[data-date]"),
+  );
+}
+
+function findCellByDate(
+  container: HTMLElement,
+  date: string,
+): HTMLElement | undefined {
+  return getCells(container).find((el) => el.getAttribute("data-date") === date);
+}
+
+describe("ActivityHeatmap — TZ-aligned cell rendering (#3199)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("renders a non-zero cell for today when data uses today's local date", () => {
+    // Pin "now" to 23:30 in the host's local TZ. The exact TZ does not
+    // matter here — what matters is that `today` (formatLocal(new Date()))
+    // matches the data key.
+    const now = new Date();
+    now.setHours(23, 30, 0, 0);
+    vi.setSystemTime(now);
+
+    const todayKey = formatLocal(now);
+    const { container } = render(
+      <ActivityHeatmap data={[{ date: todayKey, count: 1 }]} />,
+    );
+
+    const todayCell = findCellByDate(container, todayKey);
+    expect(todayCell, `expected a cell for ${todayKey}`).toBeDefined();
+    // Both light + dark groups exist, so the count appears on both.
+    const cells = getCells(container).filter(
+      (el) => el.getAttribute("data-date") === todayKey,
+    );
+    expect(cells.length).toBe(2);
+    for (const cell of cells) {
+      expect(cell.getAttribute("data-count")).toBe("1");
+    }
+  });
+
+  it("does NOT light up today when data uses a different (e.g. UTC-shifted) date — calibration", () => {
+    // This mirrors the pre-fix bug: server returns the UTC-bucketed
+    // day, which may be tomorrow relative to the user's local time.
+    // The component (using browser-local Date) never finds a match for
+    // that key as "today", so today's cell stays at count=0.
+    const now = new Date();
+    now.setHours(23, 30, 0, 0);
+    vi.setSystemTime(now);
+
+    const todayKey = formatLocal(now);
+    const tomorrow = new Date(now);
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const tomorrowKey = formatLocal(tomorrow);
+
+    const { container } = render(
+      <ActivityHeatmap data={[{ date: tomorrowKey, count: 1 }]} />,
+    );
+
+    // Today's cell is rendered (it's within the 52-week window) but
+    // its count is 0 — the dot is misplaced.
+    const todayCell = findCellByDate(container, todayKey);
+    expect(todayCell, `expected a cell for ${todayKey}`).toBeDefined();
+    expect(todayCell!.getAttribute("data-count")).toBe("0");
+
+    // And the cell at tomorrowKey doesn't exist in the grid: future
+    // days are filtered out (col.push(null)).
+    const tomorrowCell = findCellByDate(container, tomorrowKey);
+    expect(tomorrowCell).toBeUndefined();
+  });
+
+  it("lights up yesterday's cell when data uses yesterday's local date", () => {
+    const now = new Date();
+    now.setHours(12, 0, 0, 0);
+    vi.setSystemTime(now);
+
+    const yesterday = new Date(now);
+    yesterday.setDate(yesterday.getDate() - 1);
+    const yKey = formatLocal(yesterday);
+
+    const { container } = render(
+      <ActivityHeatmap data={[{ date: yKey, count: 4 }]} />,
+    );
+
+    const cell = findCellByDate(container, yKey);
+    expect(cell).toBeDefined();
+    expect(cell!.getAttribute("data-count")).toBe("4");
+
+    // Today's cell exists and has count=0.
+    const today = findCellByDate(container, formatLocal(now));
+    expect(today).toBeDefined();
+    expect(today!.getAttribute("data-count")).toBe("0");
+  });
+
+  it("renders an empty grid (all zero) for empty data", () => {
+    const { container } = render(<ActivityHeatmap data={[]} />);
+    const cells = getCells(container);
+    expect(cells.length).toBeGreaterThan(0);
+    for (const cell of cells) {
+      expect(cell.getAttribute("data-count")).toBe("0");
+    }
+  });
+});

--- a/apps/web/src/components/my-jobs/activity-heatmap.tsx
+++ b/apps/web/src/components/my-jobs/activity-heatmap.tsx
@@ -4,6 +4,11 @@ import { useMemo, useState, useRef } from "react";
 import { useLingui } from "@lingui/react/macro";
 import type { ActivityDay } from "@/lib/actions/my-jobs-stats";
 
+// Renders a YYYY-MM-DD key from a JS Date using the *browser's* TZ
+// (Date.getFullYear/Month/Date are local-TZ accessors). The server
+// side now buckets `saved_at` in the same IANA TZ passed by the
+// caller (see `getStats({ tz })`), so cell keys and data keys agree
+// even at the day boundary in the viewer's local time. See #3199.
 function formatLocal(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
@@ -138,8 +143,15 @@ export function ActivityHeatmap({ data }: { data: ActivityDay[] }) {
     return grid.map((col, w) =>
       col.map((cell, d) =>
         cell ? (
+          // `data-date` / `data-count` mirror the cell's bucket key
+          // and count. They make the heatmap inspectable from
+          // DevTools and let component-level tests assert that a
+          // given calendar day lights up at the right grid slot —
+          // the core invariant for the #3199 TZ-alignment fix.
           <rect
             key={`${w}-${d}`}
+            data-date={cell.date}
+            data-count={cell.count}
             x={labelW + w * STEP}
             y={monthH + d * STEP}
             width={CELL}

--- a/apps/web/src/lib/actions/__tests__/my-jobs-stats-tz.test.ts
+++ b/apps/web/src/lib/actions/__tests__/my-jobs-stats-tz.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * #3199 — Activity-heatmap TZ bug.
+ *
+ * Before the fix, `getStats()` bucketed `saved_at` via
+ * `to_char(saved_at, 'YYYY-MM-DD')` in Postgres's TZ (UTC on Supabase),
+ * while the client built cell keys with `Date.getFullYear/Month/Date`
+ * (browser TZ). A NYC user saving at 23:00 local time would see the
+ * dot appear on the *next* day's cell (or fall outside the rendered
+ * 52-week window).
+ *
+ * The fix:
+ *   - server: bucket `saved_at AT TIME ZONE $tz` where `$tz` is the
+ *     viewer's IANA timezone (passed from the client),
+ *   - server: interpret `from`/`to` calendar-day filters at that same
+ *     TZ's midnight rather than UTC midnight,
+ *   - server: validate the supplied TZ against an IANA-shaped pattern
+ *     and fall back to "UTC" otherwise — both as defense-in-depth and
+ *     so older clients (no `tz` field) keep working.
+ *
+ * The cell grid on the client still uses browser-TZ `Date` accessors,
+ * but with the server bucketing in the same TZ the day keys align.
+ *
+ * This spec asserts the SQL produced by `getStats({ tz })` reaches
+ * Postgres parameterised with the right TZ and the right shape, and
+ * that malformed inputs are coerced to "UTC".
+ */
+
+vi.mock("server-only", () => ({}));
+
+interface Captured {
+  sqlObjects: unknown[];
+}
+
+const captured: Captured = { sqlObjects: [] };
+
+vi.mock("@/lib/sessionCache", () => ({
+  getSessionUserId: vi.fn().mockResolvedValue("user-1"),
+}));
+
+vi.mock("@/lib/db-retry", () => ({
+  withDbRetry: <T>(fn: () => Promise<T>) => fn(),
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    execute: vi.fn(async (sqlObj: unknown) => {
+      captured.sqlObjects.push(sqlObj);
+      return [];
+    }),
+  },
+}));
+
+/**
+ * Drizzle's `sql\`...\`` tagged template stores its parts on
+ * `queryChunks`. Empirically (against drizzle-orm v0.x at the
+ * version pinned here), an interpolated *bare value* is left as a
+ * raw chunk of its primitive type (string, number, ...) — Param
+ * wrappers are produced by helpers like `sql.param()` but not by
+ * direct `${value}` interpolation. SQL fragments are stored as
+ * `StringChunk { value: string[] }` objects, and a nested `sql\`\``
+ * shows up as another object with its own `queryChunks` array.
+ *
+ * This walker recurses into nested chunks, treats every primitive
+ * encountered as a parameter, and concatenates string-array
+ * `StringChunk.value` arrays as the SQL body. The output is good
+ * enough to assert "this query contains `AT TIME ZONE` and was
+ * parameterised with `America/New_York`".
+ */
+function flatten(
+  sqlObj: unknown,
+): { text: string; params: unknown[] } {
+  const parts: string[] = [];
+  const params: unknown[] = [];
+
+  const walk = (obj: unknown): void => {
+    const queryChunks = (obj as { queryChunks?: unknown[] }).queryChunks;
+    if (!Array.isArray(queryChunks)) return;
+    for (const chunk of queryChunks) {
+      if (chunk === null || chunk === undefined) continue;
+      const t = typeof chunk;
+      if (t === "string") {
+        params.push(chunk);
+        parts.push("$?");
+        continue;
+      }
+      if (t === "number" || t === "bigint" || t === "boolean") {
+        params.push(chunk);
+        parts.push("$?");
+        continue;
+      }
+      if (t === "object") {
+        const c = chunk as {
+          value?: unknown;
+          encoder?: unknown;
+          queryChunks?: unknown[];
+        };
+        if (Array.isArray(c.queryChunks)) {
+          walk(c);
+          continue;
+        }
+        // Param wrapper: { value, encoder }
+        if (c.encoder !== undefined) {
+          params.push(c.value);
+          parts.push("$?");
+          continue;
+        }
+        // StringChunk: { value: string[] }
+        if (Array.isArray(c.value)) {
+          parts.push((c.value as string[]).join(""));
+          continue;
+        }
+        if (typeof c.value === "string") {
+          parts.push(c.value);
+          continue;
+        }
+      }
+    }
+  };
+  walk(sqlObj);
+  return { text: parts.join(""), params };
+}
+
+describe("#3199 — getStats TZ-aware day bucketing", () => {
+  beforeEach(() => {
+    captured.sqlObjects = [];
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("buckets activity in the viewer-supplied IANA TZ", async () => {
+    const { getStats } = await import("@/lib/actions/my-jobs-stats");
+    await getStats({ tz: "America/New_York" });
+
+    // Two queries: funnel + activity. The activity query is the one
+    // that references `to_char(... 'YYYY-MM-DD')`.
+    const activity = captured.sqlObjects
+      .map(flatten)
+      .find((q) => q.text.includes("to_char"));
+    expect(activity).toBeDefined();
+
+    // The SQL must apply AT TIME ZONE before to_char so the bucket
+    // is in viewer-local time, not Postgres-server time.
+    expect(activity!.text).toMatch(/saved_at\s+AT TIME ZONE/);
+    expect(activity!.text).toMatch(/to_char\(\s*saved_at AT TIME ZONE/);
+
+    // And the TZ must be passed in as a parameter (drizzle codegen
+    // replaces interpolated values with $? in the flattened text).
+    expect(activity!.params).toContain("America/New_York");
+  });
+
+  it("interprets from/to date filters at the viewer's local midnight", async () => {
+    const { getStats } = await import("@/lib/actions/my-jobs-stats");
+    await getStats({
+      from: "2026-05-13",
+      to: "2026-05-14",
+      tz: "America/New_York",
+    });
+
+    const funnel = captured.sqlObjects
+      .map(flatten)
+      .find((q) => q.text.includes("sj.saved_at"));
+    expect(funnel).toBeDefined();
+
+    // Both bounds must use AT TIME ZONE so 2026-05-13 means midnight
+    // in NYC, not UTC.
+    expect(funnel!.text).toMatch(/saved_at\s+>=\s+\(.*AT TIME ZONE/);
+    expect(funnel!.text).toMatch(/saved_at\s+<\s+\(.*AT TIME ZONE/);
+
+    // The TZ parameter must appear (at least once per bound).
+    const tzAppearances = funnel!.params.filter(
+      (p) => p === "America/New_York",
+    ).length;
+    expect(tzAppearances).toBeGreaterThanOrEqual(2);
+
+    // The from/to dates must also be parameters.
+    expect(funnel!.params).toContain("2026-05-13");
+    expect(funnel!.params).toContain("2026-05-14");
+  });
+
+  it("falls back to UTC when no tz is supplied (preserves legacy behaviour)", async () => {
+    const { getStats } = await import("@/lib/actions/my-jobs-stats");
+    await getStats({});
+
+    const activity = captured.sqlObjects
+      .map(flatten)
+      .find((q) => q.text.includes("to_char"));
+    expect(activity).toBeDefined();
+    expect(activity!.params).toContain("UTC");
+  });
+
+  it("rejects malformed TZ inputs and falls back to UTC", async () => {
+    const { getStats } = await import("@/lib/actions/my-jobs-stats");
+
+    const malformed = [
+      "'; DROP TABLE saved_job; --",
+      "UTC; SELECT 1",
+      "America/New_York'",
+      "../etc/passwd",
+      " ",
+      "a".repeat(100),
+    ];
+
+    for (const tz of malformed) {
+      captured.sqlObjects = [];
+      await getStats({ tz });
+      const activity = captured.sqlObjects
+        .map(flatten)
+        .find((q) => q.text.includes("to_char"));
+      expect(activity, `tz=${tz}`).toBeDefined();
+      // The malformed input must NEVER reach the SQL parameter slot.
+      expect(activity!.params).not.toContain(tz);
+      // Fallback is UTC.
+      expect(activity!.params).toContain("UTC");
+    }
+  });
+
+  it("accepts canonical IANA names with subzones", async () => {
+    const { getStats } = await import("@/lib/actions/my-jobs-stats");
+
+    const valid = [
+      "Europe/Zurich",
+      "America/Argentina/Buenos_Aires",
+      "Asia/Ho_Chi_Minh",
+      "Etc/GMT+5",
+      "UTC",
+    ];
+
+    for (const tz of valid) {
+      captured.sqlObjects = [];
+      await getStats({ tz });
+      const activity = captured.sqlObjects
+        .map(flatten)
+        .find((q) => q.text.includes("to_char"));
+      expect(activity, `tz=${tz}`).toBeDefined();
+      expect(activity!.params).toContain(tz);
+    }
+  });
+});

--- a/apps/web/src/lib/actions/my-jobs-stats.ts
+++ b/apps/web/src/lib/actions/my-jobs-stats.ts
@@ -5,6 +5,21 @@ import { db } from "@/db";
 import { withDbRetry } from "@/lib/db-retry";
 import { getSessionUserId } from "@/lib/sessionCache";
 
+// IANA time-zone names are limited to ASCII letters, digits, '+', '-',
+// '_', and '/'. The pattern intentionally rejects anything else (e.g.
+// SQL meta-characters, whitespace, quotes) before the value is handed
+// to Postgres. We still pass the value through a parameter via the
+// drizzle `sql` tagged template, but validating up-front lets the
+// fallback to UTC kick in cleanly when a bad / malformed value arrives.
+// Length is also bounded — the longest real IANA name today
+// ("America/Argentina/ComodRivadavia") is 32 chars, so 64 is generous.
+const IANA_TZ_RE = /^[A-Za-z][A-Za-z0-9_+\-/]{0,63}$/;
+
+function normalizeTz(tz: string | undefined | null): string {
+  if (!tz) return "UTC";
+  return IANA_TZ_RE.test(tz) ? tz : "UTC";
+}
+
 export interface FunnelData {
   saved: number;
   applied: number;
@@ -34,6 +49,14 @@ export interface StatsData {
 export async function getStats(params?: {
   from?: string;
   to?: string;
+  /**
+   * IANA timezone name from the viewer's browser (e.g.
+   * "America/New_York"). Used to bucket activity-heatmap days and to
+   * interpret the date-range filter at the viewer's local midnight
+   * rather than UTC. Falls back to "UTC" when missing or malformed —
+   * preserving the pre-#3199 behaviour for older clients. See #3199.
+   */
+  tz?: string;
 }): Promise<StatsData> {
   const userId = await getSessionUserId();
   if (!userId) {
@@ -49,14 +72,19 @@ export async function getStats(params?: {
     };
   }
 
+  const tz = normalizeTz(params?.tz);
   const from = params?.from ?? null;
   const to = params?.to ?? null;
+  // Date-range filter: interpret `from`/`to` as calendar days in the
+  // viewer's local TZ, not in Postgres's TZ. Otherwise a NYC user
+  // picking "2026-05-14" would silently mean UTC midnight, missing
+  // anything saved between 19:00 and midnight local on May 13.
   const dateFilter = from && to
-    ? sql`AND sj.saved_at >= ${from}::timestamptz AND sj.saved_at < (${to}::date + 1)::timestamptz`
+    ? sql`AND sj.saved_at >= (${from}::timestamp AT TIME ZONE ${tz}) AND sj.saved_at < ((${to}::date + 1)::timestamp AT TIME ZONE ${tz})`
     : from
-      ? sql`AND sj.saved_at >= ${from}::timestamptz`
+      ? sql`AND sj.saved_at >= (${from}::timestamp AT TIME ZONE ${tz})`
       : to
-        ? sql`AND sj.saved_at < (${to}::date + 1)::timestamptz`
+        ? sql`AND sj.saved_at < ((${to}::date + 1)::timestamp AT TIME ZONE ${tz})`
         : sql``;
 
   // Run funnel + activity queries in parallel (independent aggregations)
@@ -85,12 +113,18 @@ export async function getStats(params?: {
     ),
     withDbRetry(
       () =>
+        // Bucket `saved_at` (timestamptz, stored in UTC) into the
+        // viewer's local calendar day. Without `AT TIME ZONE` Postgres
+        // formats in its own TZ (UTC on Supabase), so a NYC user
+        // saving at 23:00 local lands on tomorrow's bucket while the
+        // client's heatmap grid is computed in browser TZ — the dot
+        // disappears or moves a cell. See #3199.
         db.execute<{
           [key: string]: unknown;
           day: string;
           cnt: number;
         }>(sql`
-          SELECT to_char(saved_at, 'YYYY-MM-DD') AS day, count(*)::int AS cnt
+          SELECT to_char(saved_at AT TIME ZONE ${tz}, 'YYYY-MM-DD') AS day, count(*)::int AS cnt
           FROM saved_job
           WHERE user_id = ${userId}
             AND saved_at >= now() - interval '52 weeks'

--- a/apps/web/src/lib/viewer-tz.ts
+++ b/apps/web/src/lib/viewer-tz.ts
@@ -1,0 +1,22 @@
+/**
+ * Resolve the IANA time-zone name of the current browser viewer.
+ *
+ * Falls back to `"UTC"` when:
+ *  - called during SSR (no Intl runtime context guarantee on Edge)
+ *  - `Intl.DateTimeFormat().resolvedOptions().timeZone` throws or
+ *    returns a falsy value (very old browsers, locked-down embedded
+ *    WebViews, exotic regex shenanigans, etc.)
+ *
+ * The fallback matches the server-side default in
+ * `getStats({ tz })`, so the worst case is pre-#3199 behaviour
+ * (UTC-bucketed days) instead of a crash.
+ */
+export function getViewerTz(): string {
+  if (typeof window === "undefined") return "UTC";
+  try {
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return tz || "UTC";
+  } catch {
+    return "UTC";
+  }
+}


### PR DESCRIPTION
## Summary

- Server bucketed `saved_at` via `to_char(..., 'YYYY-MM-DD')` in Postgres TZ (UTC on Supabase) while the client built cell keys with `Date.getFullYear/Month/Date` (browser TZ). A NYC user saving at 23:00 local would see the dot land on tomorrow's cell or vanish entirely (future cells are filtered out).
- Server now bucketed `saved_at AT TIME ZONE <viewer-tz>`, using an IANA TZ string the client passes from `Intl.DateTimeFormat().resolvedOptions().timeZone`. Same TZ is applied to the `from`/`to` filter so picked dates mean viewer-local midnight, not Postgres-server midnight.
- Malformed TZ values fall back to `"UTC"` — preserves pre-fix behaviour for legacy clients and protects the SQL surface regardless of the existing drizzle parameterisation.

## Scope

- `apps/web/src/lib/actions/my-jobs-stats.ts` — accept `tz` arg, validate against IANA-shaped regex, apply `AT TIME ZONE` to both the activity-day `to_char` bucket and the `from`/`to` range bounds.
- `apps/web/app/[lang]/(app)/my-jobs/stats/stats-loader.tsx`, `stats-page.tsx` — pass the browser-resolved TZ to `getStats`.
- `apps/web/src/lib/viewer-tz.ts` — new tiny helper, falls back to `"UTC"` on SSR / older WebViews.
- `apps/web/src/components/my-jobs/activity-heatmap.tsx` — adds `data-date` + `data-count` to `<rect>` cells (makes the alignment testable from DOM tests; documents the post-fix invariant inline near `formatLocal`).
- Tests:
  - `apps/web/src/lib/actions/__tests__/my-jobs-stats-tz.test.ts` — asserts SQL contains `AT TIME ZONE` parameterised with the viewer TZ; `from`/`to` bounds both use the viewer-local TZ; malformed TZ inputs fall back to UTC; canonical IANA names with subzones pass through.
  - `apps/web/src/components/my-jobs/__tests__/activity-heatmap.test.tsx` — data with today's local key lights today's cell; UTC-shifted-tomorrow data leaves today at count=0 (calibration that reproduces the pre-fix bug shape against the same component).

## Visual verification

Reproduced the bug + fix in a headless Chromium pinned to `America/New_York`, simulating a save at 23:00 local on 2026-05-12 (instant = 2026-05-13T03:00:00Z). The yellow ring marks today; the red halo marks where the dot for the save event lands.

**Pre-fix** — server returns `{ date: "2026-05-13", count: 1 }` (UTC bucket). Today's cell stays grey (count=0), and the saved-day cell doesn't exist in the grid at all (it's "future"). NO DOT VISIBLE.

**Post-fix** — server returns `{ date: "2026-05-12", count: 1 }` (NYC-local bucket). Today's cell is green (count=1). DOT PLACED AT 2026-05-12.

Screenshots posted as a follow-up comment.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm exec vitest run` — 794 tests across 88 files pass (including 9 new tests for #3199)
- [x] Playwright visual harness in `America/New_York` TZ — pre-fix today-count=0, post-fix today-count=1
- [ ] Manual: sign in, save a job at 23:00 local in a non-UTC TZ, confirm the dot appears on today's cell

Closes #3199

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>