### PR TITLE
fix(web): handle concurrent slug generation race (closes #3201)

### DIFF
--- a/apps/web/src/lib/__tests__/watchlist-slug-race.test.ts
+++ b/apps/web/src/lib/__tests__/watchlist-slug-race.test.ts
@@ -1,0 +1,466 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * #3201 — `generateUniqueSlug` is TOCTOU.
+ *
+ * Before the fix, `createWatchlist`/`copyWatchlist` ran two statements:
+ *   1. `SELECT slug FROM watchlist WHERE user_id = ? AND slug LIKE ?`
+ *   2. `INSERT INTO watchlist (user_id, slug, ...) VALUES (?, ?, ...)`
+ *
+ * Two concurrent callers with the same title (a double-fire of the
+ * "Create" button or two tabs of the same modal) both observed an
+ * empty SELECT and both attempted `INSERT slug = 'my-list'`. The
+ * `idx_wl_user_slug` UNIQUE index caught the duplicate, but the loser
+ * received an un-handled Postgres `23505` that bubbled out of the
+ * server action as a 500.
+ *
+ * The fix wraps the INSERT in `insertWatchlistWithUniqueSlug`, which
+ * catches `23505` on `idx_wl_user_slug`, re-runs `generateUniqueSlug`
+ * (which now sees the winner's row), and retries up to 5 times.
+ *
+ * Test strategy
+ * -------------
+ * The unit-under-test is `insertWatchlistWithUniqueSlug`. Its only
+ * collaborators are (a) the slug picker `generateUniqueSlug` and (b)
+ * the inserter callback the caller passes in. We replace the `@/db`
+ * module with an in-memory mock so we can:
+ *
+ *   - have the picker reflect "current" table state (other callers'
+ *     winners are visible to the next pick),
+ *   - have the inserter race against itself under `Promise.all` and
+ *     reproduce the 23505 the index would raise in production,
+ *   - assert that the retry loop converges on a unique slug.
+ *
+ * Calibration: a second describe-block runs the legacy buggy
+ * `generateUniqueSlug` + INSERT shape (no retry) against the SAME
+ * mock and asserts it crashes one of the concurrent callers. Without
+ * this calibration the test could trivially pass for both shapes.
+ */
+
+vi.mock("server-only", () => ({}));
+
+interface WatchlistRow {
+  id: string;
+  user_id: string;
+  slug: string;
+  title: string;
+}
+
+const mocks = vi.hoisted(() => {
+  const watchlistTable: WatchlistRow[] = [];
+
+  let idCounter = 0;
+  const nextId = (): string => `wl-${++idCounter}`;
+
+  const uniqueViolation = (slug: string): Error => {
+    const e = new Error(
+      `duplicate key value violates unique constraint "idx_wl_user_slug" (slug=${slug})`,
+    ) as Error & { code: string; constraint_name: string };
+    e.code = "23505";
+    e.constraint_name = "idx_wl_user_slug";
+    return e;
+  };
+
+  // Drizzle compiles `db.select(...).from(watchlist).where(and(eq(userId, userId), sql`LIKE ${prefix}%`))`
+  // down through a fluent chain. The mock sniffs the parameters by
+  // capturing whatever the action passes into `where(...)`. drizzle's
+  // `eq` operator returns an `SQL` object with `.queryChunks`; `and`
+  // wraps them in another SQL. We don't need to parse drizzle's AST
+  // precisely — we walk every nested queryChunks and pluck out the
+  // primitive Param values in encounter order. For `generateUniqueSlug`
+  // the first two non-column-ref Params are `userId` (eq) and `base + "%"`
+  // (LIKE).
+  const dbSelect = () => {
+    let userIdFilter: string | undefined;
+    let likeStringFilter: string | undefined;
+    const chain: Record<string, unknown> = {
+      from: () => chain,
+      where: (clause: unknown) => {
+        const params = extractParams(clause);
+        // generateUniqueSlug passes (userId, base + "%") — first string param is user, second is LIKE.
+        const strs = params.filter((p): p is string => typeof p === "string");
+        if (strs.length >= 1) userIdFilter = strs[0];
+        if (strs.length >= 2) likeStringFilter = strs[1];
+        return chain;
+      },
+    };
+    chain.then = (
+      resolve: (v: unknown) => unknown,
+      _reject?: (e: unknown) => unknown,
+    ) => {
+      const u = userIdFilter;
+      const likeStr = likeStringFilter ?? "";
+      // postgres LIKE '%' wildcard at end → prefix match.
+      const prefix = likeStr.endsWith("%") ? likeStr.slice(0, -1) : likeStr;
+      const rows = u
+        ? watchlistTable
+            .filter((r) => r.user_id === u && r.slug.startsWith(prefix))
+            .map((r) => ({ slug: r.slug }))
+        : [];
+      return resolve(rows);
+    };
+    return chain;
+  };
+
+  const dbInsert = () => ({
+    values: (v: {
+      userId: string;
+      slug: string;
+      title: string;
+      [k: string]: unknown;
+    }) => {
+      const exec = async (): Promise<Array<{ id: string }>> => {
+        // Yield once so two parallel calls can interleave their
+        // generateUniqueSlug → INSERT pipelines.
+        await Promise.resolve();
+        const conflict = watchlistTable.some(
+          (r) => r.user_id === v.userId && r.slug === v.slug,
+        );
+        if (conflict) throw uniqueViolation(v.slug);
+        const id = nextId();
+        watchlistTable.push({
+          id,
+          user_id: v.userId,
+          slug: v.slug,
+          title: v.title,
+        });
+        return [{ id }];
+      };
+      return {
+        returning: () => exec(),
+        then: (
+          resolve: (val: unknown) => unknown,
+          reject?: (err: unknown) => unknown,
+        ) => exec().then(resolve, reject),
+      };
+    },
+  });
+
+  return {
+    watchlistTable,
+    reset: () => {
+      watchlistTable.length = 0;
+      idCounter = 0;
+    },
+    dbSelect,
+    dbInsert,
+    uniqueViolation,
+  };
+});
+
+/**
+ * Walk drizzle's `SQL` object (returned from `and`/`eq`/`sql`...) and
+ * collect every primitive Param value, in encounter order. Param
+ * objects look like `{ value: <primitive>, encoder: ... }`; nested
+ * SQLs expose `.queryChunks`. StringChunks expose `.value: string[]`
+ * (no encoder) — we skip them. Recurses one level via `cause` /
+ * `queryChunks` to handle `and(...)` and tagged-template nesting.
+ */
+function extractParams(node: unknown, depth = 0): unknown[] {
+  if (depth > 8 || node === null || node === undefined) return [];
+  if (typeof node !== "object") return [];
+  const acc: unknown[] = [];
+  const queryChunks = (node as { queryChunks?: unknown[] }).queryChunks;
+  if (Array.isArray(queryChunks)) {
+    for (const chunk of queryChunks) {
+      if (chunk === null || chunk === undefined) continue;
+      const t = typeof chunk;
+      if (t === "string" || t === "number" || t === "bigint" || t === "boolean") {
+        acc.push(chunk);
+        continue;
+      }
+      if (t === "object") {
+        const c = chunk as { value?: unknown; encoder?: unknown };
+        const hasEncoder = c.encoder !== undefined;
+        if (hasEncoder && c.value !== undefined) {
+          acc.push(c.value);
+          continue;
+        }
+        // Nested SQL — recurse.
+        acc.push(...extractParams(chunk, depth + 1));
+      }
+    }
+  }
+  // Fallback: some operator returns expose `.value` directly (eq).
+  const direct = (node as { value?: unknown }).value;
+  if (direct !== undefined && typeof direct !== "object" && acc.length === 0) {
+    acc.push(direct);
+  }
+  return acc;
+}
+
+vi.mock("@/db", () => ({
+  db: {
+    select: () => mocks.dbSelect(),
+    insert: () => mocks.dbInsert(),
+  },
+}));
+
+// ---- Module under test ---------------------------------------------
+
+import {
+  insertWatchlistWithUniqueSlug,
+  generateUniqueSlug,
+  isWatchlistSlugUniqueViolation,
+} from "../watchlist-slug";
+
+// Sanity check: confirm the mock wiring lets the real
+// `generateUniqueSlug` observe our in-memory table. If this assertion
+// fails, every downstream test is using stale params and the rest of
+// the file is meaningless — fail fast and visibly.
+describe("#3201 — test harness sanity", () => {
+  beforeEach(() => {
+    mocks.reset();
+  });
+
+  it("generateUniqueSlug sees the in-memory table via the mock", async () => {
+    expect(await generateUniqueSlug("user-1", "My List")).toBe("my-list");
+
+    mocks.watchlistTable.push({
+      id: "seed",
+      user_id: "user-1",
+      slug: "my-list",
+      title: "My List",
+    });
+    expect(await generateUniqueSlug("user-1", "My List")).toBe("my-list-2");
+
+    mocks.watchlistTable.push({
+      id: "seed2",
+      user_id: "user-1",
+      slug: "my-list-2",
+      title: "My List",
+    });
+    expect(await generateUniqueSlug("user-1", "My List")).toBe("my-list-3");
+  });
+
+  it("isWatchlistSlugUniqueViolation only matches the targeted constraint", () => {
+    expect(isWatchlistSlugUniqueViolation(mocks.uniqueViolation("x"))).toBe(true);
+    const other = new Error("dup") as Error & { code: string; constraint_name: string };
+    other.code = "23505";
+    other.constraint_name = "some_other_unique";
+    expect(isWatchlistSlugUniqueViolation(other)).toBe(false);
+    expect(isWatchlistSlugUniqueViolation(new Error("network"))).toBe(false);
+    // Message-fallback path (no constraint_name field, but message
+    // contains the constraint name — covers drivers that omit the
+    // structured field).
+    const msgOnly = new Error(
+      'duplicate key value violates unique constraint "idx_wl_user_slug"',
+    ) as Error & { code: string };
+    msgOnly.code = "23505";
+    expect(isWatchlistSlugUniqueViolation(msgOnly)).toBe(true);
+  });
+});
+
+describe("#3201 — insertWatchlistWithUniqueSlug retries on idx_wl_user_slug 23505", () => {
+  beforeEach(() => {
+    mocks.reset();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Reusable inserter — mirrors the production `createWatchlist` shape:
+  // `db.insert(watchlist).values({...}).returning({id})`.
+  function productionInserter(userId: string, title: string) {
+    return async (slug: string): Promise<{ id: string }> => {
+      const r = await mocks
+        .dbInsert()
+        .values({ userId, slug, title })
+        .returning();
+      return r[0];
+    };
+  }
+
+  it("single insert succeeds with the picker's slug", async () => {
+    const { row, slug } = await insertWatchlistWithUniqueSlug(
+      "user-1",
+      "My List",
+      productionInserter("user-1", "My List"),
+    );
+
+    expect(slug).toBe("my-list");
+    expect(row.id).toMatch(/^wl-/);
+    expect(mocks.watchlistTable.map((r) => r.slug)).toEqual(["my-list"]);
+  });
+
+  it("picker auto-advances around a pre-existing row", async () => {
+    mocks.watchlistTable.push({
+      id: "wl-seed",
+      user_id: "user-1",
+      slug: "my-list",
+      title: "My List",
+    });
+
+    const { slug } = await insertWatchlistWithUniqueSlug(
+      "user-1",
+      "My List",
+      productionInserter("user-1", "My List"),
+    );
+
+    expect(slug).toBe("my-list-2");
+    expect(mocks.watchlistTable.map((r) => r.slug).sort()).toEqual([
+      "my-list",
+      "my-list-2",
+    ]);
+  });
+
+  it("retries on 23505 from a racing winner and lands on -2", async () => {
+    // Custom inserter that throws 23505 on the first attempt to
+    // simulate a racing caller landing their commit between this
+    // call's SELECT and INSERT. We seed the winner's row before
+    // throwing so the retry's picker observes the conflict and
+    // advances to `-2`.
+    let attempts = 0;
+    const inserter = async (candidate: string): Promise<{ id: string }> => {
+      attempts += 1;
+      if (attempts === 1) {
+        // Winner committed.
+        mocks.watchlistTable.push({
+          id: "wl-winner",
+          user_id: "user-1",
+          slug: candidate,
+          title: "My List",
+        });
+        throw mocks.uniqueViolation(candidate);
+      }
+      return (
+        await mocks
+          .dbInsert()
+          .values({ userId: "user-1", slug: candidate, title: "My List" })
+          .returning()
+      )[0];
+    };
+
+    const { slug } = await insertWatchlistWithUniqueSlug(
+      "user-1",
+      "My List",
+      inserter,
+    );
+
+    expect(attempts).toBe(2);
+    expect(slug).toBe("my-list-2");
+    const slugs = mocks.watchlistTable
+      .filter((r) => r.user_id === "user-1")
+      .map((r) => r.slug)
+      .sort();
+    expect(slugs).toEqual(["my-list", "my-list-2"]);
+    // The whole point of the fix: every slug is unique within the
+    // user's namespace, even under contention.
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it("two concurrent inserts produce distinct slugs (the headline guarantee)", async () => {
+    const inserter = productionInserter("user-1", "My List");
+
+    // Under Promise.all the two SELECTs both see an empty table and
+    // both pick "my-list"; one INSERT wins, the other throws 23505;
+    // the loser's retry sees the winner's row and picks "my-list-2".
+    const [r1, r2] = await Promise.all([
+      insertWatchlistWithUniqueSlug("user-1", "My List", inserter),
+      insertWatchlistWithUniqueSlug("user-1", "My List", inserter),
+    ]);
+
+    expect(r1.slug).not.toBe(r2.slug);
+    const slugs = [r1.slug, r2.slug].sort();
+    expect(slugs).toEqual(["my-list", "my-list-2"]);
+
+    const tableSlugs = mocks.watchlistTable
+      .filter((r) => r.user_id === "user-1")
+      .map((r) => r.slug)
+      .sort();
+    expect(tableSlugs).toEqual(["my-list", "my-list-2"]);
+    expect(new Set(tableSlugs).size).toBe(tableSlugs.length);
+  });
+
+  it("non-slug 23505 (different constraint) propagates immediately", async () => {
+    const otherUniqueErr = new Error(
+      'duplicate key value violates unique constraint "some_other_unique"',
+    ) as Error & { code: string; constraint_name: string };
+    otherUniqueErr.code = "23505";
+    otherUniqueErr.constraint_name = "some_other_unique";
+
+    let calls = 0;
+    await expect(
+      insertWatchlistWithUniqueSlug("user-1", "My List", async () => {
+        calls += 1;
+        throw otherUniqueErr;
+      }),
+    ).rejects.toThrow(/some_other_unique/);
+    // No retry — proves the predicate is narrow.
+    expect(calls).toBe(1);
+  });
+
+  it("non-unique-violation errors propagate immediately without retry", async () => {
+    let calls = 0;
+    await expect(
+      insertWatchlistWithUniqueSlug("user-1", "My List", async () => {
+        calls += 1;
+        throw new Error("ECONNRESET");
+      }),
+    ).rejects.toThrow(/ECONNRESET/);
+    expect(calls).toBe(1);
+  });
+
+  it("exhausts the retry budget if every attempt conflicts and surfaces the violation", async () => {
+    // The picker always sees an empty table because we don't add to
+    // it. Every inserter call throws 23505. The retry loop runs the
+    // configured budget (5 attempts) then surfaces the last error.
+    let calls = 0;
+    await expect(
+      insertWatchlistWithUniqueSlug("user-1", "My List", async (candidate) => {
+        calls += 1;
+        throw mocks.uniqueViolation(candidate);
+      }),
+    ).rejects.toMatchObject({ code: "23505" });
+    expect(calls).toBeGreaterThanOrEqual(2);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────
+// Calibration: prove the harness can distinguish fixed from broken by
+// running the legacy buggy algorithm (raw SELECT + INSERT, no retry)
+// against the SAME mock and asserting it crashes one of the concurrent
+// callers. Without this the suite could pass for both shapes.
+// ─────────────────────────────────────────────────────────────────────
+
+describe("#3201 — race-mock calibration (buggy shape crashes loser)", () => {
+  beforeEach(() => {
+    mocks.reset();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("buggy SELECT-then-INSERT shape throws 23505 under Promise.all", async () => {
+    const buggyCreateWatchlist = async (
+      userId: string,
+      title: string,
+    ): Promise<{ slug: string }> => {
+      // Step 1: pick a slug (the legacy code path).
+      const slug = await generateUniqueSlug(userId, title);
+      // Step 2: insert. NO retry, NO unique-violation catch.
+      const [r] = await mocks
+        .dbInsert()
+        .values({ userId, slug, title })
+        .returning();
+      return { slug, ...r };
+    };
+
+    await expect(
+      Promise.all([
+        buggyCreateWatchlist("user-1", "My List"),
+        buggyCreateWatchlist("user-1", "My List"),
+      ]),
+    ).rejects.toMatchObject({ code: "23505" });
+
+    // The winner's row still landed.
+    const slugs = mocks.watchlistTable
+      .filter((r) => r.user_id === "user-1")
+      .map((r) => r.slug);
+    expect(slugs).toEqual(["my-list"]);
+  });
+});

--- a/apps/web/src/lib/actions/__tests__/watchlists-invalidation.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-invalidation.test.ts
@@ -47,6 +47,21 @@ const mocks = vi.hoisted(() => ({
   tsDeleteWatchlist: vi.fn(),
   tsUpdateWatchlistField: vi.fn(),
   generateUniqueSlug: vi.fn(),
+  // #3201: the new helper wraps `generateUniqueSlug` + the INSERT with
+  // a retry-on-23505 loop. For unrelated cache-invalidation tests we
+  // mock it as a thin pass-through: pick a slug via the same
+  // `generateUniqueSlug` stub and run the inserter exactly once.
+  insertWatchlistWithUniqueSlug: vi.fn(
+    async (
+      userId: string,
+      title: string,
+      insert: (slug: string) => Promise<unknown>,
+    ) => {
+      const slug = await mocks.generateUniqueSlug(userId, title);
+      const row = await insert(slug);
+      return { row, slug };
+    },
+  ),
   canCreateWatchlist: vi.fn().mockResolvedValue({ allowed: true }),
   getUserPlan: vi.fn().mockResolvedValue("free"),
 }));
@@ -82,6 +97,7 @@ vi.mock("@/lib/plans", () => ({
 
 vi.mock("@/lib/watchlist-slug", () => ({
   generateUniqueSlug: mocks.generateUniqueSlug,
+  insertWatchlistWithUniqueSlug: mocks.insertWatchlistWithUniqueSlug,
 }));
 
 vi.mock("@/lib/indexnow", () => ({ notifyIndexNow: mocks.notifyIndexNow }));
@@ -257,6 +273,18 @@ beforeEach(() => {
   });
   mocks.getSessionUserId.mockResolvedValue(USER_ID);
   mocks.generateUniqueSlug.mockResolvedValue(SLUG);
+  // Re-prime the helper pass-through that vi.clearAllMocks() reset.
+  mocks.insertWatchlistWithUniqueSlug.mockImplementation(
+    async (
+      userId: string,
+      title: string,
+      insert: (slug: string) => Promise<unknown>,
+    ) => {
+      const slug = await mocks.generateUniqueSlug(userId, title);
+      const row = await insert(slug);
+      return { row, slug };
+    },
+  );
   mocks.afterCallbacks.length = 0;
 });
 

--- a/apps/web/src/lib/actions/__tests__/watchlists-listing-perf.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-listing-perf.test.ts
@@ -55,6 +55,20 @@ const mocks = vi.hoisted(() => ({
   tsDeleteWatchlist: vi.fn(),
   tsUpdateWatchlistField: vi.fn(),
   generateUniqueSlug: vi.fn(),
+  // #3201: pass-through that runs the inserter once with the picker's
+  // slug. Listing-perf tests don't exercise the createWatchlist path
+  // but the module-level import needs the export.
+  insertWatchlistWithUniqueSlug: vi.fn(
+    async (
+      userId: string,
+      title: string,
+      insert: (slug: string) => Promise<unknown>,
+    ) => {
+      const slug = await mocks.generateUniqueSlug(userId, title);
+      const row = await insert(slug);
+      return { row, slug };
+    },
+  ),
 }));
 
 vi.mock("next/server", () => ({ after: (cb: () => unknown) => cb() }));
@@ -110,6 +124,7 @@ vi.mock("@/lib/search/typesense-watchlist", () => ({
 
 vi.mock("@/lib/watchlist-slug", () => ({
   generateUniqueSlug: mocks.generateUniqueSlug,
+  insertWatchlistWithUniqueSlug: mocks.insertWatchlistWithUniqueSlug,
 }));
 
 // One mock entry point for ALL Typesense reads. Every

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -20,7 +20,10 @@ import {
 import { withDbRetry } from "@/lib/db-retry";
 import { watchlistCacheTag } from "@/lib/cache-tags";
 import { canCreateWatchlist, getUserPlan, PLAN_LIMITS } from "@/lib/plans";
-import { generateUniqueSlug } from "@/lib/watchlist-slug";
+import {
+  generateUniqueSlug,
+  insertWatchlistWithUniqueSlug,
+} from "@/lib/watchlist-slug";
 import { ANON_MAX_WATCHLIST_POSTINGS, COMPANY_BATCH_SIZE } from "@/lib/search/constants";
 import { expandLocationIds, resolveLocationSlugs } from "@/lib/actions/locations";
 import { expandOccupationIds, resolveOccupationSlugs, resolveSenioritySlugs, resolveTechnologySlugs } from "@/lib/actions/taxonomy";
@@ -138,19 +141,30 @@ export async function createWatchlist(params: {
   const { allowed } = await canCreateWatchlist(userId);
   if (!allowed) return { error: "limit_reached" };
 
-  const slug = await generateUniqueSlug(userId, params.title);
-
-  const [row] = await db
-    .insert(watchlist)
-    .values({
-      userId,
-      slug,
-      title: params.title,
-      description: params.description ?? null,
-      isPublic: params.isPublic ?? true,
-      filters: { anyCompany: true, ...params.filters },
-    })
-    .returning({ id: watchlist.id });
+  // Slug allocation is concurrency-safe: `insertWatchlistWithUniqueSlug`
+  // wraps the INSERT in a retry loop that recovers from the SELECT-then-
+  // INSERT race on `idx_wl_user_slug` (#3201). Two browser tabs (or a
+  // double-fire of the Create button) used to crash one of the two
+  // callers with an un-handled 23505 here; the helper catches the
+  // violation, regenerates a fresh `-N` suffix, and retries.
+  const { row, slug } = await insertWatchlistWithUniqueSlug(
+    userId,
+    params.title,
+    async (candidate) => {
+      const [r] = await db
+        .insert(watchlist)
+        .values({
+          userId,
+          slug: candidate,
+          title: params.title,
+          description: params.description ?? null,
+          isPublic: params.isPublic ?? true,
+          filters: { anyCompany: true, ...params.filters },
+        })
+        .returning({ id: watchlist.id });
+      return r;
+    },
+  );
 
   if (params.companyIds.length > 0) {
     await db.insert(watchlistCompany).values(
@@ -252,6 +266,15 @@ export async function updateWatchlist(params: {
 
   if (params.title !== undefined) {
     updates.title = params.title;
+    // The `generateUniqueSlug` call here is still subject to the same
+    // SELECT-then-write race that #3201 fixed on create/copy, but in
+    // the UPDATE path the race shape is benign in practice: the slug
+    // is being changed on a row that already exists (same id), so two
+    // concurrent renames of the same watchlist are last-write-wins on
+    // the row, not a UNIQUE conflict. Cross-row collisions
+    // (update-rename → slug that an unrelated row just took) remain
+    // theoretically possible but out of scope for the create/copy
+    // crash fix; see the issue for the analysis.
     newSlug = await generateUniqueSlug(userId, params.title);
     updates.slug = newSlug;
   }
@@ -423,22 +446,31 @@ export async function copyWatchlist(
     return { error: "not_found" };
   }
 
-  const slug = await generateUniqueSlug(userId, source.title);
-
   const sourceFilters = (source.filters ?? {}) as WatchlistFilters;
 
-  const [row] = await db
-    .insert(watchlist)
-    .values({
-      userId,
-      slug,
-      title: source.title,
-      description: source.description,
-      isPublic: true,
-      filters: sourceFilters,
-      sourceWatchlistId: watchlistId,
-    })
-    .returning({ id: watchlist.id });
+  // Same race shape as createWatchlist (#3201): two fast clicks of the
+  // "Copy" button on a public watchlist used to race the SELECT-then-
+  // INSERT slug pick and crash the loser. The helper retries on a
+  // `idx_wl_user_slug` 23505.
+  const { row, slug } = await insertWatchlistWithUniqueSlug(
+    userId,
+    source.title,
+    async (candidate) => {
+      const [r] = await db
+        .insert(watchlist)
+        .values({
+          userId,
+          slug: candidate,
+          title: source.title,
+          description: source.description,
+          isPublic: true,
+          filters: sourceFilters,
+          sourceWatchlistId: watchlistId,
+        })
+        .returning({ id: watchlist.id });
+      return r;
+    },
+  );
 
   // Copy companies (even in anyCompany mode, so toggling it off reveals them)
   const companies = await db

--- a/apps/web/src/lib/watchlist-slug.ts
+++ b/apps/web/src/lib/watchlist-slug.ts
@@ -38,3 +38,112 @@ export async function generateUniqueSlug(
   while (existing.has(`${base}-${i}`)) i++;
   return `${base}-${i}`;
 }
+
+/**
+ * Name of the UNIQUE index that backs `(user_id, slug)` on the
+ * `watchlist` table (see `apps/web/src/db/schema.ts`). Used to scope
+ * the retry helper to only the conflict it knows how to recover from —
+ * any other unique violation (e.g. a future column gains its own
+ * constraint) propagates unchanged so the underlying bug surfaces
+ * instead of being silently retried.
+ */
+export const WATCHLIST_SLUG_UNIQUE_CONSTRAINT = "idx_wl_user_slug";
+
+/**
+ * Detect Postgres `unique_violation` (SQLSTATE 23505) errors that hit
+ * the `(user_id, slug)` index. postgres.js surfaces `code` and
+ * `constraint_name` on the thrown Error; drizzle and Vercel's runtime
+ * pass these through verbatim. We check both: `code === "23505"` alone
+ * is too broad (would absorb conflicts on unrelated indices); requiring
+ * the constraint name keeps the retry narrow.
+ */
+export function isWatchlistSlugUniqueViolation(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const e = err as { code?: unknown; constraint_name?: unknown };
+  if (e.code !== "23505") return false;
+  // Some drivers / proxies might omit constraint_name. If absent, fall
+  // back to a substring match against the message (postgres prints the
+  // constraint name verbatim in the human-readable message).
+  if (typeof e.constraint_name === "string") {
+    return e.constraint_name === WATCHLIST_SLUG_UNIQUE_CONSTRAINT;
+  }
+  const message = (err as { message?: unknown }).message;
+  return typeof message === "string"
+    && message.includes(WATCHLIST_SLUG_UNIQUE_CONSTRAINT);
+}
+
+/**
+ * Maximum number of insert attempts before giving up. The first attempt
+ * uses the slug picked by `generateUniqueSlug`; each subsequent attempt
+ * re-runs the picker (which now sees the conflicting row(s)) and tries
+ * the next free `-N` suffix. Five is generous — a real-world burst of
+ * five concurrent same-title creates from the same user is implausible.
+ */
+const SLUG_INSERT_MAX_ATTEMPTS = 5;
+
+/**
+ * Insert a watchlist row with a slug that's unique within the user's
+ * namespace, retrying on `(user_id, slug)` unique-violation races.
+ *
+ * Why this exists — issue #3201: the legacy shape was
+ *
+ *   const slug = await generateUniqueSlug(userId, title); // SELECT
+ *   await db.insert(watchlist).values({ slug, ... });     // INSERT
+ *
+ * a classic TOCTOU: two parallel callers with the same title both
+ * observe an empty SELECT and both INSERT the same slug. The
+ * `idx_wl_user_slug` UNIQUE index catches the duplicate, but the loser
+ * receives an un-handled Postgres `23505` error that propagates out of
+ * the server action as a 500.
+ *
+ * This helper closes the race by treating the unique violation as
+ * recoverable: catch it, re-run `generateUniqueSlug` (which now sees
+ * the winner's row and picks `-N+1`), and retry the INSERT. The
+ * UNIQUE constraint is the source of truth — `generateUniqueSlug` is
+ * only an optimisation that picks a sensible starting suffix without
+ * spamming the retry loop in the no-contention case.
+ *
+ * @param userId  authenticated user owning the new watchlist
+ * @param title   user-supplied title; used to derive the slug
+ * @param insert  callback that runs the actual INSERT given a slug
+ *                candidate. Must throw on conflict (the typical drizzle
+ *                `.insert().values({ slug, ... }).returning(...)` shape
+ *                already does — postgres.js raises the 23505).
+ * @returns       the inserted row's data + the final slug. The caller
+ *                must trust this slug rather than recomputing it (the
+ *                last candidate the loop committed may not match the
+ *                first one `generateUniqueSlug` returned).
+ */
+export async function insertWatchlistWithUniqueSlug<T>(
+  userId: string,
+  title: string,
+  insert: (slug: string) => Promise<T>,
+): Promise<{ row: T; slug: string }> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < SLUG_INSERT_MAX_ATTEMPTS; attempt++) {
+    // Re-pick the slug on every attempt. On retry, the previous
+    // winner's row is now visible to generateUniqueSlug, so the next
+    // candidate naturally advances (`my-list` → `my-list-2` → …).
+    const slug = await generateUniqueSlug(userId, title);
+    try {
+      const row = await insert(slug);
+      return { row, slug };
+    } catch (err) {
+      lastErr = err;
+      if (isWatchlistSlugUniqueViolation(err)) {
+        // Another concurrent caller landed the same slug first. Loop
+        // back, re-pick, retry.
+        continue;
+      }
+      // Any other error (network, validation, distinct constraint)
+      // propagates immediately so the real failure surfaces.
+      throw err;
+    }
+  }
+  // Exhausted the retry budget. Surface the last unique-violation so
+  // the caller's existing error handling kicks in instead of returning
+  // a silently-wrong row. In practice this branch is unreachable — five
+  // concurrent same-title creates from a single user requires sustained
+  // contention that no UI surface can produce.
+  throw lastErr;
+}


### PR DESCRIPTION
## Summary

- Closes #3201 — `generateUniqueSlug` had a classic SELECT-then-INSERT TOCTOU. Two concurrent `createWatchlist` / `copyWatchlist` calls from the same user with the same title both observed an empty SELECT, both attempted `INSERT slug = 'my-list'`, and the loser crashed with an un-handled `23505` from `idx_wl_user_slug`.
- Wrap the INSERT in `insertWatchlistWithUniqueSlug` — a retry helper that catches `23505` scoped to `idx_wl_user_slug` (via `code` + `constraint_name`), re-runs `generateUniqueSlug` (which now sees the winner's row), and retries up to 5 times. The UNIQUE index is the source of truth; the picker is just an optimisation that avoids spamming the loop in the no-contention path.
- Applied to `createWatchlist` + `copyWatchlist`. `updateWatchlist` is in scope but the race shape there is benign (last-write-wins on the same row id — no UNIQUE violation), so it's annotated rather than wrapped to keep PR scope tight.

## Root cause

The race is the textbook check-then-act:
```ts
const slug = await generateUniqueSlug(userId, params.title);  // SELECT, empty
const row  = await db.insert(watchlist).values({ slug, ... }); // INSERT — racy
```
Two parallel callers serialise their SELECTs (both empty) and their INSERTs (loser hits the UNIQUE index). The DB-side constraint is correctly in place (`apps/web/src/db/schema.ts:791` — `uniqueIndex("idx_wl_user_slug").on(table.userId, table.slug)`), so the data is never corrupted — just the loser crashes.

## Approach (option A from issue)

Retry-on-conflict. Chosen over the single-statement CTE because:
1. The UNIQUE constraint already exists — no migration needed.
2. The codebase already has a precedent (`apps/web/src/lib/actions/my-jobs.ts:419-427`, the `addInterview` round-number race from #3160 / #3114) using the same retry-on-23505 shape; reusing the pattern keeps the codebase consistent.
3. The picker logic (slugify + `LIKE` scan) stays in TypeScript where it lives today.

The retry is scoped narrowly to `code === "23505" && constraint_name === "idx_wl_user_slug"` so any other unique violation (e.g. a future column gains its own constraint) propagates unchanged and the real bug surfaces. A message-substring fallback handles drivers that omit `constraint_name`.

## Test coverage

`apps/web/src/lib/__tests__/watchlist-slug-race.test.ts` — 10 tests:

- **Harness sanity** — `generateUniqueSlug` against an in-memory table picks `my-list`, `my-list-2`, `my-list-3` as rows accumulate. Verifies the mock wiring is correct.
- **Predicate scoping** — `isWatchlistSlugUniqueViolation` matches the targeted constraint (by `constraint_name` AND by message-fallback) and rejects unrelated 23505s + non-23505 errors.
- **Happy path** — single insert with the picker's slug.
- **Picker auto-advance** — pre-existing row → `-2`.
- **Forced retry** — first attempt throws 23505, second succeeds with `-2`. Asserts the retry happened (`attempts === 2`) and slugs are unique.
- **Headline concurrency guarantee** — `Promise.all([insert, insert])` with same title produces `{my-list, my-list-2}`, both rows persist, all unique.
- **Non-slug 23505** — different constraint → no retry, immediate propagation.
- **Non-unique error** — ECONNRESET → no retry, immediate propagation.
- **Retry budget exhaustion** — every attempt conflicts → 23505 surfaces after budget exhaustion (this branch is unreachable in production but proves the loop terminates).
- **Calibration** — runs the legacy buggy `generateUniqueSlug` + INSERT shape against the **same** in-memory mock under `Promise.all`. Asserts the buggy shape crashes one of the callers with 23505. Without this, the suite could trivially pass for both fixed and broken implementations.

Also touched the two existing watchlist tests (`watchlists-invalidation.test.ts`, `watchlists-listing-perf.test.ts`) that partial-mock `@/lib/watchlist-slug` — they now also export `insertWatchlistWithUniqueSlug` as a pass-through stub.

## Schema change

None. The UNIQUE index `idx_wl_user_slug` already exists.

## Test plan

- [x] `pnpm test` — 823 passed (10 new)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec eslint <changed files>` — clean
- [ ] (Not run per user preference) `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)