### PR TITLE
fix(web): use timingSafeEqual for admin basic-auth comparison (closes #3225)

### DIFF
--- a/apps/web/src/lib/admin/__tests__/basic-auth.test.ts
+++ b/apps/web/src/lib/admin/__tests__/basic-auth.test.ts
@@ -17,4 +17,18 @@ describe("matchesBasicAuthorization", () => {
     expect(matchesBasicAuthorization("Basic wrong", "abc123")).toBe(false);
     expect(matchesBasicAuthorization("Basic abc123", undefined)).toBe(false);
   });
+
+  it("rejects a same-length wrong token", () => {
+    // Exercises the constant-time path: lengths match so the length
+    // pre-check passes and `timingSafeEqual` is the one returning false.
+    // A pre-#3225 `===` compare would have already returned false on
+    // the first differing byte; this test still passes against either
+    // impl but documents the constant-time intent.
+    expect(matchesBasicAuthorization("Basic abc124", "abc123")).toBe(false);
+  });
+
+  it("rejects an empty token after the Basic scheme", () => {
+    expect(matchesBasicAuthorization("Basic ", "abc123")).toBe(false);
+    expect(matchesBasicAuthorization("Basic", "abc123")).toBe(false);
+  });
 });

--- a/apps/web/src/lib/admin/basic-auth.ts
+++ b/apps/web/src/lib/admin/basic-auth.ts
@@ -1,10 +1,23 @@
 import "server-only";
 
+import { timingSafeEqual } from "node:crypto";
+
 export function matchesBasicAuthorization(
   authorization: string | null,
   expectedToken: string | undefined,
 ): boolean {
   if (!authorization || !expectedToken) return false;
   const [scheme, token] = authorization.split(" ", 2);
-  return scheme === "Basic" && token === expectedToken;
+  // Scheme is non-secret (the literal string "Basic"); plain `===` is fine.
+  if (scheme !== "Basic" || !token) return false;
+  // Constant-time compare on the secret token. Mirrors the
+  // `_safeBearerEqual` pattern in
+  // `apps/web/app/api/internal/invalidate-typeahead/route.ts`. The
+  // length pre-check is itself a timing oracle, but only leaks the
+  // expected-token length (a fixed per-env constant), not any bytes
+  // of the secret. See colophon-group/jobseek#3225.
+  const a = Buffer.from(token, "utf8");
+  const b = Buffer.from(expectedToken, "utf8");
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
 }


### PR DESCRIPTION
## Summary

Replace the V8 string `===` compare on the admin secret in `matchesBasicAuthorization` with `crypto.timingSafeEqual` on equal-length buffers, matching the `_safeBearerEqual` pattern already used in [`/api/internal/invalidate-typeahead`](../blob/main/apps/web/app/api/internal/invalidate-typeahead/route.ts#L16-L25). The scheme check (`"Basic"`) stays as plain `===` since it is non-secret.

Closes #3225.

## Risk

- Impact: **L-M** — timing oracle on the admin secret.
- Likelihood: **L** — over the public internet, network jitter dominates the V8 string-compare timing diff; only meaningful from a low-latency vantage point.
- The bigger reason to land this is **consistency**: the same codebase already does `timingSafeEqual` for the internal-route bearer compare, so the inconsistency itself was a maintainability red flag (a reviewer modelling new auth on the admin helper would pick the wrong pattern).

## Affected endpoints

Both share `ADMIN_SECRET`:
- `apps/web/app/api/admin/meta/apify-import/route.ts` — writes to `job_posting`.
- `apps/web/app/api/admin/murmur-demo/run/route.ts` — triggers a Murmur run.

## Implementation notes

- Length pre-check (`a.length !== b.length`) is itself a timing oracle, but only leaks the expected-token length — a fixed per-env constant, not any bytes of the secret. Matches the existing `_safeBearerEqual` trade-off.
- Added `if (scheme !== "Basic" || !token) return false;` to short-circuit before the buffer compare, so `"Basic"` (no token) and `"Bearer abc"` still fail without ever calling `timingSafeEqual`.
- Scope kept tight: only `matchesBasicAuthorization` touched. No audit of other `===` sites in this PR.

## Tests

- Updated `apps/web/src/lib/admin/__tests__/basic-auth.test.ts`:
  - New: same-length wrong token returns `false` (exercises the `timingSafeEqual` path, would have early-exited on `===`).
  - New: empty-token-after-scheme (`"Basic "` and `"Basic"`) returns `false`.
  - Existing: correct token returns `true`, malformed authorization returns `false` — still pass.
- `pnpm test`: 834 passed.
- `pnpm exec tsc --noEmit`: clean.
- `pnpm exec eslint apps/web/src/lib/admin/basic-auth.ts apps/web/src/lib/admin/__tests__/basic-auth.test.ts`: clean.

## Test plan

- [x] Unit tests cover the new constant-time path (same-length wrong token).
- [x] Unit tests cover regression cases (correct token, missing/malformed authorization, undefined expected token, empty token after scheme).
- [ ] After merge: confirm `/api/admin/meta/apify-import` and `/api/admin/murmur-demo/run` still return 200 for the correct `Authorization: Basic <ADMIN_SECRET>` and 401 for any wrong/missing header (smoke against preview deploy).

Reference: `_safeBearerEqual` in `apps/web/app/api/internal/invalidate-typeahead/route.ts` (lines 16-25) — the model this PR aligns the admin helper with.

Generated with [Claude Code](https://claude.com/claude-code)