### PR TITLE
fix(a11y): add h1 to /explore + use h2 in AccountSettings (closes #3196)

### DIFF
--- a/apps/web/app/[lang]/(app)/explore/__tests__/search-page-heading.test.tsx
+++ b/apps/web/app/[lang]/(app)/explore/__tests__/search-page-heading.test.tsx
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+
+import "@/test-utils/lingui-mock";
+
+/**
+ * Regression test for #3196 — `/explore` had no `<h1>` and screen-reader
+ * users pressing H from the top of the page skipped straight into job
+ * titles. The fix mounts a visually-hidden `<h1>` inside `SearchPage`.
+ *
+ * `SearchPage` has a heavy dependency tree (Typesense client, session
+ * provider, search toolbar with its own sub-modals, etc.). This suite
+ * stubs every non-essential dependency so the render exercises only the
+ * heading + skeleton outline that we care about for the a11y assertion.
+ */
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/en/explore",
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+}));
+
+vi.mock("@/components/SessionProvider", () => ({
+  useSession: () => ({ isLoggedIn: false }),
+}));
+
+vi.mock("@/components/SearchStateProvider", () => ({
+  useSearchStateStore: () => ({
+    get: () => null,
+    set: vi.fn(),
+    setPageActions: vi.fn(),
+  }),
+  buildCacheKey: () => "",
+  shouldRestoreSnapshot: () => false,
+}));
+
+// Heavy children: stub to deterministic markers so the test focuses
+// on the h1 we just added.
+vi.mock("@/components/search/search-toolbar", () => ({
+  SearchToolbar: () => <div data-testid="search-toolbar-stub" />,
+}));
+
+vi.mock("@/components/search/search-results", () => ({
+  SearchResults: () => <div data-testid="search-results-stub" />,
+}));
+
+vi.mock("@/components/search/zero-results", () => ({
+  ZeroResults: () => <div data-testid="zero-results-stub" />,
+}));
+
+vi.mock("@/components/search/skeleton-card", () => ({
+  SkeletonCards: () => <div data-testid="skeleton-cards-stub" />,
+}));
+
+vi.mock("@/components/search/job-detail-dialog", () => ({
+  JobDetailPanel: () => null,
+}));
+
+vi.mock("@/lib/actions/search", () => ({
+  getCurrencyRates: () => Promise.resolve([]),
+}));
+
+vi.mock("@/lib/search/search-runner", () => ({
+  runSearchJobs: vi.fn().mockResolvedValue({ companies: [], totalCompanies: 0, truncated: false }),
+  runListTopCompanies: vi.fn().mockResolvedValue({ companies: [], totalCompanies: 0, truncated: false }),
+}));
+
+vi.mock("@/lib/search/use-clear-typesense-on-auth-change", () => ({
+  useClearTypesenseOnAuthChange: () => {},
+}));
+
+vi.mock("@/lib/actions/search-input", () => ({
+  parseSearchFilters: vi.fn().mockResolvedValue({
+    keywords: [],
+    locations: [],
+    occupations: [],
+    seniorities: [],
+    technologies: [],
+    workMode: [],
+  }),
+}));
+
+vi.mock("@/lib/search/query-params", () => ({
+  buildFilteredPath: () => "/en/explore",
+}));
+
+import { SearchPage } from "../search-page";
+
+beforeEach(() => {
+  // jsdom/happy-dom may not set up window.history.replaceState identically
+  // across versions; stub to a no-op so the component's URL syncs do not
+  // throw in the test environment.
+  window.history.replaceState = vi.fn() as typeof window.history.replaceState;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("SearchPage — heading landmark (#3196)", () => {
+  it("renders exactly one level-1 heading for /explore", async () => {
+    await act(async () => {
+      render(
+        <SearchPage
+          initialCompanies={[]}
+          initialTotalCompanies={0}
+          initialKeywords={[]}
+          initialLocations={[]}
+          initialOccupations={[]}
+          initialSeniorities={[]}
+          initialTechnologies={[]}
+          initialWorkMode={[]}
+          locale="en"
+          displayCurrency="EUR"
+          jobLanguages={[]}
+          languages={[]}
+        />,
+      );
+    });
+
+    // `getByRole` throws if there are zero or multiple matches — this
+    // is the contract that makes the test a regression guard rather
+    // than a coincidence: it pins down "exactly one h1 in the page".
+    const h1 = screen.getByRole("heading", { level: 1 });
+    expect(h1).toBeTruthy();
+    expect(h1.textContent).toMatch(/explore/i);
+    // sr-only is the load-bearing class — without it, a visible h1
+    // would shift the visual design unexpectedly.
+    expect(h1.className).toMatch(/\bsr-only\b/);
+  });
+});

--- a/apps/web/app/[lang]/(app)/explore/search-page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/search-page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
+import { Trans } from "@lingui/react/macro";
 
 import type { SelectedLocation } from "@/components/search/location-pills";
 import { SearchResults } from "@/components/search/search-results";
@@ -729,6 +730,17 @@ export function SearchPage({
 
   const searchColumn = (
     <div className="space-y-6">
+      {/*
+        Visually-hidden h1 so screen-reader users have a top-level
+        heading to anchor heading-jump navigation. The visual design
+        leads with the search toolbar, so the h1 is sr-only. See
+        WCAG 1.3.1 / issue #3196.
+      */}
+      <h1 className="sr-only">
+        <Trans id="explore.h1" comment="Hidden page H1 for /explore — screen-reader landmark">
+          Explore Jobs
+        </Trans>
+      </h1>
       <SearchToolbar
         locale={locale}
         userLat={userLat}

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -58,7 +58,7 @@ msgid "search.detail.showMoreLocations"
 msgstr "{0} weitere"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:40
+#: app/[lang]/(app)/company/[slug]/page.tsx:41
 msgid "company.meta.positionCount"
 msgstr "{count, plural, one {# offene Stelle} other {# offene Stellen}}"
 
@@ -93,7 +93,7 @@ msgstr "{count, plural, one {# Unternehmen beobachtet} other {# Unternehmen beob
 
 #. Heatmap tooltip for multiple applications
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:80
+#: src/components/my-jobs/activity-heatmap.tsx:85
 msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} Bewerbungen am {date}"
 
@@ -103,12 +103,12 @@ msgid "watchlist.meta.moreCompanies"
 msgstr "{count} weitere"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:52
+#: app/[lang]/(app)/company/[slug]/page.tsx:53
 msgid "company.meta.descriptionBasic"
 msgstr "{countText} bei {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:47
+#: app/[lang]/(app)/company/[slug]/page.tsx:48
 msgid "company.meta.descriptionWithInfo"
 msgstr "{countText} bei {name}. {description}"
 
@@ -156,7 +156,7 @@ msgstr "10 $ / Monat"
 
 #. Heatmap tooltip for 1 application
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:79
+#: src/components/my-jobs/activity-heatmap.tsx:84
 msgid "myJobs.heatmap.tooltipOne"
 msgstr "1 Bewerbung am {date}"
 
@@ -255,16 +255,16 @@ msgstr "Unternehmen hinzufügen"
 msgid "watchlists.view.addDescription"
 msgstr "Beschreibung hinzufügen"
 
-#. Button to add an interview round
-#. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:76
-msgid "myJobs.detail.addInterview"
-msgstr "Interview hinzufügen"
-
 #. Quick action tooltip: add interview round
 #. js-lingui-explicit-id
 #: src/components/my-jobs/quick-actions.tsx:19
 msgid "myJobs.action.addInterview"
+msgstr "Interview hinzufügen"
+
+#. Button to add an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx:76
+msgid "myJobs.detail.addInterview"
 msgstr "Interview hinzufügen"
 
 #. Placeholder in the add keyword input
@@ -394,7 +394,7 @@ msgstr "Bewerbungsstatistiken"
 
 #. Stats page title
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:38
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:43
 msgid "myJobs.stats.title"
 msgstr "Bewerbungsstatistik"
 
@@ -412,7 +412,7 @@ msgstr "Bewerbungstracker mit Interview-Protokoll"
 
 #. Subtitle showing total applications in past year
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:47
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:52
 msgid "myJobs.stats.activitySubtitle"
 msgstr "Bewerbungen im letzten Jahr"
 
@@ -466,7 +466,7 @@ msgstr "Bewerben"
 
 #. Short April label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:60
+#: src/components/my-jobs/activity-heatmap.tsx:65
 msgid "myJobs.heatmap.month.apr"
 msgstr "Apr"
 
@@ -490,7 +490,7 @@ msgstr "Maximal 30 Zeichen"
 
 #. Short August label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:64
+#: src/components/my-jobs/activity-heatmap.tsx:69
 msgid "myJobs.heatmap.month.aug"
 msgstr "Aug"
 
@@ -538,12 +538,6 @@ msgstr "Nach oben"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Verhalten"
 
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:146
-msgid "blog.post.backToIndex"
-msgstr "Blog"
-
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:28
@@ -554,6 +548,12 @@ msgstr "Blog"
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:79
 msgid "blog.index.heading"
+msgstr "Blog"
+
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:146
+msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -717,7 +717,7 @@ msgstr "Stadt"
 
 #. Clear date filter
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:87
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:92
 msgid "myJobs.stats.clearDates"
 msgstr "Zurücksetzen"
 
@@ -846,8 +846,8 @@ msgstr "Unternehmen"
 #. Heading shown when a company page slug does not exist
 #. Heading shown when the company URL slug doesn't resolve to a known company
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-content.tsx:19
-#: app/[lang]/(app)/company/[slug]/page.tsx:88
+#: app/[lang]/(app)/company/[slug]/company-content.tsx:51
+#: app/[lang]/(app)/company/[slug]/page.tsx:89
 msgid "company.notFound.title"
 msgstr "Unternehmen nicht gefunden"
 
@@ -1105,7 +1105,7 @@ msgstr "Speicherdatum"
 
 #. Short December label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:68
+#: src/components/my-jobs/activity-heatmap.tsx:73
 msgid "myJobs.heatmap.month.dec"
 msgstr "Dez"
 
@@ -1362,6 +1362,12 @@ msgstr "Entdecken"
 msgid "explore.meta.title"
 msgstr "Jobs entdecken"
 
+#. Hidden page H1 for /explore — screen-reader landmark
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/explore/search-page.tsx:740
+msgid "explore.h1"
+msgstr "Jobs entdecken"
+
 #. Generic email change error
 #. js-lingui-explicit-id
 #: src/components/settings/AccountSettings.tsx:360
@@ -1441,7 +1447,7 @@ msgstr "Funktionen"
 
 #. Short February label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:58
+#: src/components/my-jobs/activity-heatmap.tsx:63
 msgid "myJobs.heatmap.month.feb"
 msgstr "Feb"
 
@@ -1576,7 +1582,7 @@ msgstr "Häufig gestellte Fragen"
 
 #. Short Friday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:49
+#: src/components/my-jobs/activity-heatmap.tsx:54
 msgid "myJobs.heatmap.day.fri"
 msgstr "Fr"
 
@@ -1942,7 +1948,7 @@ msgstr "Gibt es ein Limit, wie viele Jobs ich verfolgen kann?"
 
 #. Short January label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:57
+#: src/components/my-jobs/activity-heatmap.tsx:62
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
@@ -2071,7 +2077,7 @@ msgid "watchlists.explore.jobPlural"
 msgstr "Jobs"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:33
+#: app/[lang]/(app)/company/[slug]/page.tsx:34
 msgid "company.meta.title"
 msgstr "Jobs bei {name}"
 
@@ -2082,13 +2088,13 @@ msgstr "Jobs bei {names}"
 
 #. Short July label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:63
+#: src/components/my-jobs/activity-heatmap.tsx:68
 msgid "myJobs.heatmap.month.jul"
 msgstr "Jul"
 
 #. Short June label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:62
+#: src/components/my-jobs/activity-heatmap.tsx:67
 msgid "myJobs.heatmap.month.jun"
 msgstr "Jun"
 
@@ -2202,7 +2208,7 @@ msgstr "Hell"
 
 #. Loading indicator
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:92
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:97
 msgid "myJobs.stats.loading"
 msgstr "Laden…"
 
@@ -2288,7 +2294,7 @@ msgstr "Verwalte deine verknüpften Social-Media-Konten."
 
 #. Short March label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:59
+#: src/components/my-jobs/activity-heatmap.tsx:64
 msgid "myJobs.heatmap.month.mar"
 msgstr "Mär"
 
@@ -2324,7 +2330,7 @@ msgstr "Max"
 
 #. Short May label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:61
+#: src/components/my-jobs/activity-heatmap.tsx:66
 msgid "myJobs.heatmap.month.may"
 msgstr "Mai"
 
@@ -2374,7 +2380,7 @@ msgstr "Ein Unternehmen fehlt? Füge die Karriereseiten-URL ein und wir beginnen
 
 #. Short Monday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:45
+#: src/components/my-jobs/activity-heatmap.tsx:50
 msgid "myJobs.heatmap.day.mon"
 msgstr "Mo"
 
@@ -2438,7 +2444,7 @@ msgstr "Mehrere Treffer — wähle einen aus"
 
 #. Back link to my jobs
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:35
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:40
 msgid "myJobs.stats.back"
 msgstr "Meine Jobs"
 
@@ -2492,7 +2498,7 @@ msgstr "Neues Passwort"
 
 #. Heatmap tooltip when no applications on a date
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:78
+#: src/components/my-jobs/activity-heatmap.tsx:83
 msgid "myJobs.heatmap.tooltipNone"
 msgstr "Keine Bewerbungen am {date}"
 
@@ -2634,7 +2640,7 @@ msgstr "Hinweis: Wir konnten kein Tracking-Issue erstellen, aber Ihre Anfrage wu
 
 #. Short November label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:67
+#: src/components/my-jobs/activity-heatmap.tsx:72
 msgid "myJobs.heatmap.month.nov"
 msgstr "Nov"
 
@@ -2646,7 +2652,7 @@ msgstr "Berufsfeld"
 
 #. Short October label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:66
+#: src/components/my-jobs/activity-heatmap.tsx:71
 msgid "myJobs.heatmap.month.oct"
 msgstr "Okt"
 
@@ -2729,7 +2735,7 @@ msgid "common.header.openMenu"
 msgstr "Hauptmenü öffnen"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:45
+#: app/[lang]/(app)/company/[slug]/page.tsx:46
 msgid "company.meta.openPositions"
 msgstr "Offene Stellen"
 
@@ -2905,7 +2911,7 @@ msgstr "pro Monat"
 
 #. Period filter heading
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:57
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:62
 msgid "myJobs.stats.period"
 msgstr "Zeitraum"
 
@@ -3392,7 +3398,7 @@ msgstr "Jobs speichern"
 
 #. Empty state for stats
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:101
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:106
 msgid "myJobs.stats.empty"
 msgstr "Speichern Sie Jobs und verfolgen Sie Ihre Bewerbungen, um hier Statistiken zu sehen."
 
@@ -3608,7 +3614,7 @@ msgstr "Erfahrungsstufe"
 
 #. Short September label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:65
+#: src/components/my-jobs/activity-heatmap.tsx:70
 msgid "myJobs.heatmap.month.sep"
 msgstr "Sep"
 
@@ -3998,13 +4004,13 @@ msgstr "Nutzungsbedingungen von Job Seek — Nutzungsregeln, geistiges Eigentum,
 
 #. Body text shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:93
+#: app/[lang]/(app)/company/[slug]/page.tsx:94
 msgid "company.notFound.message"
 msgstr "Das gesuchte Unternehmen existiert nicht oder wurde entfernt."
 
 #. Body text for the company-not-found page; explains the company is either gone or never existed
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-content.tsx:27
+#: app/[lang]/(app)/company/[slug]/company-content.tsx:59
 msgid "company.notFound.body"
 msgstr "Das gesuchte Unternehmen existiert nicht oder wurde entfernt."
 
@@ -4459,7 +4465,7 @@ msgstr "Wir arbeiten am Hinzufügen von"
 
 #. Short Wednesday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:47
+#: src/components/my-jobs/activity-heatmap.tsx:52
 msgid "myJobs.heatmap.day.wed"
 msgstr "Mi"
 

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -58,7 +58,7 @@ msgid "search.detail.showMoreLocations"
 msgstr "{0} more"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:40
+#: app/[lang]/(app)/company/[slug]/page.tsx:41
 msgid "company.meta.positionCount"
 msgstr "{count, plural, one {# open position} other {# open positions}}"
 
@@ -93,7 +93,7 @@ msgstr "{count, plural, one {Tracking # company} other {Tracking # companies}}. 
 
 #. Heatmap tooltip for multiple applications
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:80
+#: src/components/my-jobs/activity-heatmap.tsx:85
 msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} applications on {date}"
 
@@ -103,12 +103,12 @@ msgid "watchlist.meta.moreCompanies"
 msgstr "{count} more"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:52
+#: app/[lang]/(app)/company/[slug]/page.tsx:53
 msgid "company.meta.descriptionBasic"
 msgstr "{countText} at {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:47
+#: app/[lang]/(app)/company/[slug]/page.tsx:48
 msgid "company.meta.descriptionWithInfo"
 msgstr "{countText} at {name}. {description}"
 
@@ -156,7 +156,7 @@ msgstr "$10 / month"
 
 #. Heatmap tooltip for 1 application
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:79
+#: src/components/my-jobs/activity-heatmap.tsx:84
 msgid "myJobs.heatmap.tooltipOne"
 msgstr "1 application on {date}"
 
@@ -255,16 +255,16 @@ msgstr "Add companies"
 msgid "watchlists.view.addDescription"
 msgstr "Add description"
 
-#. Button to add an interview round
-#. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:76
-msgid "myJobs.detail.addInterview"
-msgstr "Add interview"
-
 #. Quick action tooltip: add interview round
 #. js-lingui-explicit-id
 #: src/components/my-jobs/quick-actions.tsx:19
 msgid "myJobs.action.addInterview"
+msgstr "Add interview"
+
+#. Button to add an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx:76
+msgid "myJobs.detail.addInterview"
 msgstr "Add interview"
 
 #. Placeholder in the add keyword input
@@ -394,7 +394,7 @@ msgstr "Application stats"
 
 #. Stats page title
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:38
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:43
 msgid "myJobs.stats.title"
 msgstr "Application Stats"
 
@@ -412,7 +412,7 @@ msgstr "Application tracker with interview log"
 
 #. Subtitle showing total applications in past year
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:47
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:52
 msgid "myJobs.stats.activitySubtitle"
 msgstr "applications in the past year"
 
@@ -466,7 +466,7 @@ msgstr "Apply"
 
 #. Short April label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:60
+#: src/components/my-jobs/activity-heatmap.tsx:65
 msgid "myJobs.heatmap.month.apr"
 msgstr "Apr"
 
@@ -490,7 +490,7 @@ msgstr "At most 30 characters"
 
 #. Short August label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:64
+#: src/components/my-jobs/activity-heatmap.tsx:69
 msgid "myJobs.heatmap.month.aug"
 msgstr "Aug"
 
@@ -538,12 +538,6 @@ msgstr "Back to top"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Behavioral"
 
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:146
-msgid "blog.post.backToIndex"
-msgstr "Blog"
-
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:28
@@ -554,6 +548,12 @@ msgstr "Blog"
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:79
 msgid "blog.index.heading"
+msgstr "Blog"
+
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:146
+msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -717,7 +717,7 @@ msgstr "City"
 
 #. Clear date filter
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:87
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:92
 msgid "myJobs.stats.clearDates"
 msgstr "Clear"
 
@@ -846,8 +846,8 @@ msgstr "Company"
 #. Heading shown when a company page slug does not exist
 #. Heading shown when the company URL slug doesn't resolve to a known company
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-content.tsx:19
-#: app/[lang]/(app)/company/[slug]/page.tsx:88
+#: app/[lang]/(app)/company/[slug]/company-content.tsx:51
+#: app/[lang]/(app)/company/[slug]/page.tsx:89
 msgid "company.notFound.title"
 msgstr "Company not found"
 
@@ -1105,7 +1105,7 @@ msgstr "Date saved"
 
 #. Short December label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:68
+#: src/components/my-jobs/activity-heatmap.tsx:73
 msgid "myJobs.heatmap.month.dec"
 msgstr "Dec"
 
@@ -1362,6 +1362,12 @@ msgstr "Explore"
 msgid "explore.meta.title"
 msgstr "Explore Jobs"
 
+#. Hidden page H1 for /explore — screen-reader landmark
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/explore/search-page.tsx:740
+msgid "explore.h1"
+msgstr "Explore Jobs"
+
 #. Generic email change error
 #. js-lingui-explicit-id
 #: src/components/settings/AccountSettings.tsx:360
@@ -1441,7 +1447,7 @@ msgstr "Features"
 
 #. Short February label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:58
+#: src/components/my-jobs/activity-heatmap.tsx:63
 msgid "myJobs.heatmap.month.feb"
 msgstr "Feb"
 
@@ -1576,7 +1582,7 @@ msgstr "Frequently asked questions"
 
 #. Short Friday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:49
+#: src/components/my-jobs/activity-heatmap.tsx:54
 msgid "myJobs.heatmap.day.fri"
 msgstr "Fri"
 
@@ -1942,7 +1948,7 @@ msgstr "Is there a limit to how many jobs I can track?"
 
 #. Short January label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:57
+#: src/components/my-jobs/activity-heatmap.tsx:62
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
@@ -2071,7 +2077,7 @@ msgid "watchlists.explore.jobPlural"
 msgstr "jobs"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:33
+#: app/[lang]/(app)/company/[slug]/page.tsx:34
 msgid "company.meta.title"
 msgstr "Jobs at {name}"
 
@@ -2082,13 +2088,13 @@ msgstr "Jobs at {names}"
 
 #. Short July label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:63
+#: src/components/my-jobs/activity-heatmap.tsx:68
 msgid "myJobs.heatmap.month.jul"
 msgstr "Jul"
 
 #. Short June label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:62
+#: src/components/my-jobs/activity-heatmap.tsx:67
 msgid "myJobs.heatmap.month.jun"
 msgstr "Jun"
 
@@ -2202,7 +2208,7 @@ msgstr "Light"
 
 #. Loading indicator
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:92
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:97
 msgid "myJobs.stats.loading"
 msgstr "Loading…"
 
@@ -2288,7 +2294,7 @@ msgstr "Manage your linked social accounts."
 
 #. Short March label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:59
+#: src/components/my-jobs/activity-heatmap.tsx:64
 msgid "myJobs.heatmap.month.mar"
 msgstr "Mar"
 
@@ -2324,7 +2330,7 @@ msgstr "Max"
 
 #. Short May label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:61
+#: src/components/my-jobs/activity-heatmap.tsx:66
 msgid "myJobs.heatmap.month.may"
 msgstr "May"
 
@@ -2374,7 +2380,7 @@ msgstr "Missing a company? Paste its careers page URL and we start indexing it f
 
 #. Short Monday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:45
+#: src/components/my-jobs/activity-heatmap.tsx:50
 msgid "myJobs.heatmap.day.mon"
 msgstr "Mon"
 
@@ -2438,7 +2444,7 @@ msgstr "Multiple matches — select one below"
 
 #. Back link to my jobs
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:35
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:40
 msgid "myJobs.stats.back"
 msgstr "My Jobs"
 
@@ -2492,7 +2498,7 @@ msgstr "New password"
 
 #. Heatmap tooltip when no applications on a date
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:78
+#: src/components/my-jobs/activity-heatmap.tsx:83
 msgid "myJobs.heatmap.tooltipNone"
 msgstr "No applications on {date}"
 
@@ -2634,7 +2640,7 @@ msgstr "Note: We couldn't create a tracking issue, but your request was saved."
 
 #. Short November label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:67
+#: src/components/my-jobs/activity-heatmap.tsx:72
 msgid "myJobs.heatmap.month.nov"
 msgstr "Nov"
 
@@ -2646,7 +2652,7 @@ msgstr "Occupation"
 
 #. Short October label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:66
+#: src/components/my-jobs/activity-heatmap.tsx:71
 msgid "myJobs.heatmap.month.oct"
 msgstr "Oct"
 
@@ -2729,7 +2735,7 @@ msgid "common.header.openMenu"
 msgstr "Open main menu"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:45
+#: app/[lang]/(app)/company/[slug]/page.tsx:46
 msgid "company.meta.openPositions"
 msgstr "Open positions"
 
@@ -2905,7 +2911,7 @@ msgstr "per month"
 
 #. Period filter heading
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:57
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:62
 msgid "myJobs.stats.period"
 msgstr "Period"
 
@@ -3392,7 +3398,7 @@ msgstr "Save jobs"
 
 #. Empty state for stats
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:101
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:106
 msgid "myJobs.stats.empty"
 msgstr "Save some jobs and track your applications to see stats here."
 
@@ -3608,7 +3614,7 @@ msgstr "Seniority"
 
 #. Short September label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:65
+#: src/components/my-jobs/activity-heatmap.tsx:70
 msgid "myJobs.heatmap.month.sep"
 msgstr "Sep"
 
@@ -3998,13 +4004,13 @@ msgstr "Terms of Service for Job Seek — usage rules, intellectual property, ac
 
 #. Body text shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:93
+#: app/[lang]/(app)/company/[slug]/page.tsx:94
 msgid "company.notFound.message"
 msgstr "The company you are looking for does not exist or has been removed."
 
 #. Body text for the company-not-found page; explains the company is either gone or never existed
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-content.tsx:27
+#: app/[lang]/(app)/company/[slug]/company-content.tsx:59
 msgid "company.notFound.body"
 msgstr "The company you are looking for does not exist or has been removed."
 
@@ -4459,7 +4465,7 @@ msgstr "We're working on adding"
 
 #. Short Wednesday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:47
+#: src/components/my-jobs/activity-heatmap.tsx:52
 msgid "myJobs.heatmap.day.wed"
 msgstr "Wed"
 

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -58,7 +58,7 @@ msgid "search.detail.showMoreLocations"
 msgstr "{0} de plus"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:40
+#: app/[lang]/(app)/company/[slug]/page.tsx:41
 msgid "company.meta.positionCount"
 msgstr "{count, plural, one {# poste ouvert} other {# postes ouverts}}"
 
@@ -93,7 +93,7 @@ msgstr "{count, plural, one {# entreprise suivie} other {# entreprises suivies}}
 
 #. Heatmap tooltip for multiple applications
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:80
+#: src/components/my-jobs/activity-heatmap.tsx:85
 msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} candidatures le {date}"
 
@@ -103,12 +103,12 @@ msgid "watchlist.meta.moreCompanies"
 msgstr "{count} de plus"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:52
+#: app/[lang]/(app)/company/[slug]/page.tsx:53
 msgid "company.meta.descriptionBasic"
 msgstr "{countText} chez {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:47
+#: app/[lang]/(app)/company/[slug]/page.tsx:48
 msgid "company.meta.descriptionWithInfo"
 msgstr "{countText} chez {name}. {description}"
 
@@ -156,7 +156,7 @@ msgstr "10 $ / mois"
 
 #. Heatmap tooltip for 1 application
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:79
+#: src/components/my-jobs/activity-heatmap.tsx:84
 msgid "myJobs.heatmap.tooltipOne"
 msgstr "1 candidature le {date}"
 
@@ -255,16 +255,16 @@ msgstr "Ajouter des entreprises"
 msgid "watchlists.view.addDescription"
 msgstr "Ajouter une description"
 
-#. Button to add an interview round
-#. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:76
-msgid "myJobs.detail.addInterview"
-msgstr "Ajouter un entretien"
-
 #. Quick action tooltip: add interview round
 #. js-lingui-explicit-id
 #: src/components/my-jobs/quick-actions.tsx:19
 msgid "myJobs.action.addInterview"
+msgstr "Ajouter un entretien"
+
+#. Button to add an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx:76
+msgid "myJobs.detail.addInterview"
 msgstr "Ajouter un entretien"
 
 #. Placeholder in the add keyword input
@@ -394,7 +394,7 @@ msgstr "Statistiques de candidatures"
 
 #. Stats page title
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:38
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:43
 msgid "myJobs.stats.title"
 msgstr "Statistiques des candidatures"
 
@@ -412,7 +412,7 @@ msgstr "Suivi des candidatures avec journal d'entretiens"
 
 #. Subtitle showing total applications in past year
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:47
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:52
 msgid "myJobs.stats.activitySubtitle"
 msgstr "candidatures durant l'année écoulée"
 
@@ -466,7 +466,7 @@ msgstr "Postuler"
 
 #. Short April label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:60
+#: src/components/my-jobs/activity-heatmap.tsx:65
 msgid "myJobs.heatmap.month.apr"
 msgstr "Avr"
 
@@ -490,7 +490,7 @@ msgstr "30 caractères maximum"
 
 #. Short August label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:64
+#: src/components/my-jobs/activity-heatmap.tsx:69
 msgid "myJobs.heatmap.month.aug"
 msgstr "Aoû"
 
@@ -538,12 +538,6 @@ msgstr "Retour en haut"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Comportemental"
 
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:146
-msgid "blog.post.backToIndex"
-msgstr "Blog"
-
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:28
@@ -554,6 +548,12 @@ msgstr "Blog"
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:79
 msgid "blog.index.heading"
+msgstr "Blog"
+
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:146
+msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -717,7 +717,7 @@ msgstr "Ville"
 
 #. Clear date filter
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:87
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:92
 msgid "myJobs.stats.clearDates"
 msgstr "Réinitialiser"
 
@@ -846,8 +846,8 @@ msgstr "Entreprise"
 #. Heading shown when a company page slug does not exist
 #. Heading shown when the company URL slug doesn't resolve to a known company
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-content.tsx:19
-#: app/[lang]/(app)/company/[slug]/page.tsx:88
+#: app/[lang]/(app)/company/[slug]/company-content.tsx:51
+#: app/[lang]/(app)/company/[slug]/page.tsx:89
 msgid "company.notFound.title"
 msgstr "Entreprise introuvable"
 
@@ -1105,7 +1105,7 @@ msgstr "Date d'enregistrement"
 
 #. Short December label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:68
+#: src/components/my-jobs/activity-heatmap.tsx:73
 msgid "myJobs.heatmap.month.dec"
 msgstr "Déc"
 
@@ -1362,6 +1362,12 @@ msgstr "Explorer"
 msgid "explore.meta.title"
 msgstr "Explorer les emplois"
 
+#. Hidden page H1 for /explore — screen-reader landmark
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/explore/search-page.tsx:740
+msgid "explore.h1"
+msgstr "Explorer les emplois"
+
 #. Generic email change error
 #. js-lingui-explicit-id
 #: src/components/settings/AccountSettings.tsx:360
@@ -1441,7 +1447,7 @@ msgstr "Fonctionnalités"
 
 #. Short February label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:58
+#: src/components/my-jobs/activity-heatmap.tsx:63
 msgid "myJobs.heatmap.month.feb"
 msgstr "Fév"
 
@@ -1576,7 +1582,7 @@ msgstr "Questions fréquentes"
 
 #. Short Friday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:49
+#: src/components/my-jobs/activity-heatmap.tsx:54
 msgid "myJobs.heatmap.day.fri"
 msgstr "Ven"
 
@@ -1942,7 +1948,7 @@ msgstr "Y a-t-il une limite au nombre d'offres que je peux suivre ?"
 
 #. Short January label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:57
+#: src/components/my-jobs/activity-heatmap.tsx:62
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
@@ -2071,7 +2077,7 @@ msgid "watchlists.explore.jobPlural"
 msgstr "offres"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:33
+#: app/[lang]/(app)/company/[slug]/page.tsx:34
 msgid "company.meta.title"
 msgstr "Emplois chez {name}"
 
@@ -2082,13 +2088,13 @@ msgstr "Emplois chez {names}"
 
 #. Short July label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:63
+#: src/components/my-jobs/activity-heatmap.tsx:68
 msgid "myJobs.heatmap.month.jul"
 msgstr "Jul"
 
 #. Short June label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:62
+#: src/components/my-jobs/activity-heatmap.tsx:67
 msgid "myJobs.heatmap.month.jun"
 msgstr "Jun"
 
@@ -2202,7 +2208,7 @@ msgstr "Clair"
 
 #. Loading indicator
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:92
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:97
 msgid "myJobs.stats.loading"
 msgstr "Chargement…"
 
@@ -2288,7 +2294,7 @@ msgstr "Gère tes comptes sociaux liés."
 
 #. Short March label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:59
+#: src/components/my-jobs/activity-heatmap.tsx:64
 msgid "myJobs.heatmap.month.mar"
 msgstr "Mar"
 
@@ -2324,7 +2330,7 @@ msgstr "Max"
 
 #. Short May label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:61
+#: src/components/my-jobs/activity-heatmap.tsx:66
 msgid "myJobs.heatmap.month.may"
 msgstr "Mai"
 
@@ -2374,7 +2380,7 @@ msgstr "Une entreprise manque ? Colle l'URL de sa page carrières et nous commen
 
 #. Short Monday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:45
+#: src/components/my-jobs/activity-heatmap.tsx:50
 msgid "myJobs.heatmap.day.mon"
 msgstr "Lun"
 
@@ -2438,7 +2444,7 @@ msgstr "Plusieurs résultats — sélectionnez-en un ci-dessous"
 
 #. Back link to my jobs
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:35
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:40
 msgid "myJobs.stats.back"
 msgstr "Mes emplois"
 
@@ -2492,7 +2498,7 @@ msgstr "Nouveau mot de passe"
 
 #. Heatmap tooltip when no applications on a date
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:78
+#: src/components/my-jobs/activity-heatmap.tsx:83
 msgid "myJobs.heatmap.tooltipNone"
 msgstr "Aucune candidature le {date}"
 
@@ -2634,7 +2640,7 @@ msgstr "Remarque : Nous n'avons pas pu créer un ticket de suivi, mais votre dem
 
 #. Short November label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:67
+#: src/components/my-jobs/activity-heatmap.tsx:72
 msgid "myJobs.heatmap.month.nov"
 msgstr "Nov"
 
@@ -2646,7 +2652,7 @@ msgstr "Métier"
 
 #. Short October label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:66
+#: src/components/my-jobs/activity-heatmap.tsx:71
 msgid "myJobs.heatmap.month.oct"
 msgstr "Oct"
 
@@ -2729,7 +2735,7 @@ msgid "common.header.openMenu"
 msgstr "Ouvrir le menu principal"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:45
+#: app/[lang]/(app)/company/[slug]/page.tsx:46
 msgid "company.meta.openPositions"
 msgstr "Postes ouverts"
 
@@ -2905,7 +2911,7 @@ msgstr "par mois"
 
 #. Period filter heading
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:57
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:62
 msgid "myJobs.stats.period"
 msgstr "Période"
 
@@ -3392,7 +3398,7 @@ msgstr "Sauvegarder des offres"
 
 #. Empty state for stats
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:101
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:106
 msgid "myJobs.stats.empty"
 msgstr "Enregistrez des offres et suivez vos candidatures pour voir des statistiques ici."
 
@@ -3608,7 +3614,7 @@ msgstr "Niveau d'expérience"
 
 #. Short September label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:65
+#: src/components/my-jobs/activity-heatmap.tsx:70
 msgid "myJobs.heatmap.month.sep"
 msgstr "Sep"
 
@@ -3998,13 +4004,13 @@ msgstr "Conditions d'utilisation de Job Seek — règles d'usage, propriété in
 
 #. Body text shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:93
+#: app/[lang]/(app)/company/[slug]/page.tsx:94
 msgid "company.notFound.message"
 msgstr "L'entreprise que vous recherchez n'existe pas ou a été supprimée."
 
 #. Body text for the company-not-found page; explains the company is either gone or never existed
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-content.tsx:27
+#: app/[lang]/(app)/company/[slug]/company-content.tsx:59
 msgid "company.notFound.body"
 msgstr "L'entreprise que vous recherchez n'existe pas ou a été supprimée."
 
@@ -4459,7 +4465,7 @@ msgstr "Nous travaillons à ajouter"
 
 #. Short Wednesday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:47
+#: src/components/my-jobs/activity-heatmap.tsx:52
 msgid "myJobs.heatmap.day.wed"
 msgstr "Mer"
 

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -58,7 +58,7 @@ msgid "search.detail.showMoreLocations"
 msgstr "{0} in più"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:40
+#: app/[lang]/(app)/company/[slug]/page.tsx:41
 msgid "company.meta.positionCount"
 msgstr "{count, plural, one {# posizione aperta} other {# posizioni aperte}}"
 
@@ -93,7 +93,7 @@ msgstr "{count, plural, one {# azienda monitorata} other {# aziende monitorate}}
 
 #. Heatmap tooltip for multiple applications
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:80
+#: src/components/my-jobs/activity-heatmap.tsx:85
 msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} candidature il {date}"
 
@@ -103,12 +103,12 @@ msgid "watchlist.meta.moreCompanies"
 msgstr "altre {count}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:52
+#: app/[lang]/(app)/company/[slug]/page.tsx:53
 msgid "company.meta.descriptionBasic"
 msgstr "{countText} presso {name}"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:47
+#: app/[lang]/(app)/company/[slug]/page.tsx:48
 msgid "company.meta.descriptionWithInfo"
 msgstr "{countText} presso {name}. {description}"
 
@@ -156,7 +156,7 @@ msgstr "10 $ / mese"
 
 #. Heatmap tooltip for 1 application
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:79
+#: src/components/my-jobs/activity-heatmap.tsx:84
 msgid "myJobs.heatmap.tooltipOne"
 msgstr "1 candidatura il {date}"
 
@@ -255,16 +255,16 @@ msgstr "Aggiungi aziende"
 msgid "watchlists.view.addDescription"
 msgstr "Aggiungi descrizione"
 
-#. Button to add an interview round
-#. js-lingui-explicit-id
-#: src/components/my-jobs/interview-list.tsx:76
-msgid "myJobs.detail.addInterview"
-msgstr "Aggiungi colloquio"
-
 #. Quick action tooltip: add interview round
 #. js-lingui-explicit-id
 #: src/components/my-jobs/quick-actions.tsx:19
 msgid "myJobs.action.addInterview"
+msgstr "Aggiungi colloquio"
+
+#. Button to add an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx:76
+msgid "myJobs.detail.addInterview"
 msgstr "Aggiungi colloquio"
 
 #. Placeholder in the add keyword input
@@ -394,7 +394,7 @@ msgstr "Statistiche delle candidature"
 
 #. Stats page title
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:38
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:43
 msgid "myJobs.stats.title"
 msgstr "Statistiche candidature"
 
@@ -412,7 +412,7 @@ msgstr "Tracker delle candidature con registro dei colloqui"
 
 #. Subtitle showing total applications in past year
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:47
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:52
 msgid "myJobs.stats.activitySubtitle"
 msgstr "candidature nell'ultimo anno"
 
@@ -466,7 +466,7 @@ msgstr "Candidati"
 
 #. Short April label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:60
+#: src/components/my-jobs/activity-heatmap.tsx:65
 msgid "myJobs.heatmap.month.apr"
 msgstr "Apr"
 
@@ -490,7 +490,7 @@ msgstr "Massimo 30 caratteri"
 
 #. Short August label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:64
+#: src/components/my-jobs/activity-heatmap.tsx:69
 msgid "myJobs.heatmap.month.aug"
 msgstr "Ago"
 
@@ -538,12 +538,6 @@ msgstr "Torna su"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Comportamentale"
 
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:146
-msgid "blog.post.backToIndex"
-msgstr "Blog"
-
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:28
@@ -554,6 +548,12 @@ msgstr "Blog"
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:79
 msgid "blog.index.heading"
+msgstr "Blog"
+
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:146
+msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -717,7 +717,7 @@ msgstr "Città"
 
 #. Clear date filter
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:87
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:92
 msgid "myJobs.stats.clearDates"
 msgstr "Reimposta"
 
@@ -846,8 +846,8 @@ msgstr "Azienda"
 #. Heading shown when a company page slug does not exist
 #. Heading shown when the company URL slug doesn't resolve to a known company
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-content.tsx:19
-#: app/[lang]/(app)/company/[slug]/page.tsx:88
+#: app/[lang]/(app)/company/[slug]/company-content.tsx:51
+#: app/[lang]/(app)/company/[slug]/page.tsx:89
 msgid "company.notFound.title"
 msgstr "Azienda non trovata"
 
@@ -1105,7 +1105,7 @@ msgstr "Data di salvataggio"
 
 #. Short December label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:68
+#: src/components/my-jobs/activity-heatmap.tsx:73
 msgid "myJobs.heatmap.month.dec"
 msgstr "Dic"
 
@@ -1362,6 +1362,12 @@ msgstr "Esplora"
 msgid "explore.meta.title"
 msgstr "Esplora lavori"
 
+#. Hidden page H1 for /explore — screen-reader landmark
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/explore/search-page.tsx:740
+msgid "explore.h1"
+msgstr "Esplora lavori"
+
 #. Generic email change error
 #. js-lingui-explicit-id
 #: src/components/settings/AccountSettings.tsx:360
@@ -1441,7 +1447,7 @@ msgstr "Funzionalità"
 
 #. Short February label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:58
+#: src/components/my-jobs/activity-heatmap.tsx:63
 msgid "myJobs.heatmap.month.feb"
 msgstr "Feb"
 
@@ -1576,7 +1582,7 @@ msgstr "Domande frequenti"
 
 #. Short Friday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:49
+#: src/components/my-jobs/activity-heatmap.tsx:54
 msgid "myJobs.heatmap.day.fri"
 msgstr "Ven"
 
@@ -1942,7 +1948,7 @@ msgstr "C'è un limite al numero di offerte che posso tracciare?"
 
 #. Short January label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:57
+#: src/components/my-jobs/activity-heatmap.tsx:62
 msgid "myJobs.heatmap.month.jan"
 msgstr "Gen"
 
@@ -2071,7 +2077,7 @@ msgid "watchlists.explore.jobPlural"
 msgstr "offerte"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:33
+#: app/[lang]/(app)/company/[slug]/page.tsx:34
 msgid "company.meta.title"
 msgstr "Lavori presso {name}"
 
@@ -2082,13 +2088,13 @@ msgstr "Lavori presso {names}"
 
 #. Short July label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:63
+#: src/components/my-jobs/activity-heatmap.tsx:68
 msgid "myJobs.heatmap.month.jul"
 msgstr "Lug"
 
 #. Short June label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:62
+#: src/components/my-jobs/activity-heatmap.tsx:67
 msgid "myJobs.heatmap.month.jun"
 msgstr "Giu"
 
@@ -2202,7 +2208,7 @@ msgstr "Chiaro"
 
 #. Loading indicator
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:92
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:97
 msgid "myJobs.stats.loading"
 msgstr "Caricamento…"
 
@@ -2288,7 +2294,7 @@ msgstr "Gestisci i tuoi account social collegati."
 
 #. Short March label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:59
+#: src/components/my-jobs/activity-heatmap.tsx:64
 msgid "myJobs.heatmap.month.mar"
 msgstr "Mar"
 
@@ -2324,7 +2330,7 @@ msgstr "Max"
 
 #. Short May label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:61
+#: src/components/my-jobs/activity-heatmap.tsx:66
 msgid "myJobs.heatmap.month.may"
 msgstr "Mag"
 
@@ -2374,7 +2380,7 @@ msgstr "Manca un'azienda? Incolla l'URL della sua pagina carriere e iniziamo a i
 
 #. Short Monday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:45
+#: src/components/my-jobs/activity-heatmap.tsx:50
 msgid "myJobs.heatmap.day.mon"
 msgstr "Lun"
 
@@ -2438,7 +2444,7 @@ msgstr "Risultati multipli — selezionane uno qui sotto"
 
 #. Back link to my jobs
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:35
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:40
 msgid "myJobs.stats.back"
 msgstr "I miei lavori"
 
@@ -2492,7 +2498,7 @@ msgstr "Nuova password"
 
 #. Heatmap tooltip when no applications on a date
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:78
+#: src/components/my-jobs/activity-heatmap.tsx:83
 msgid "myJobs.heatmap.tooltipNone"
 msgstr "Nessuna candidatura il {date}"
 
@@ -2634,7 +2640,7 @@ msgstr "Nota: Non siamo riusciti a creare un ticket di monitoraggio, ma la tua r
 
 #. Short November label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:67
+#: src/components/my-jobs/activity-heatmap.tsx:72
 msgid "myJobs.heatmap.month.nov"
 msgstr "Nov"
 
@@ -2646,7 +2652,7 @@ msgstr "Professione"
 
 #. Short October label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:66
+#: src/components/my-jobs/activity-heatmap.tsx:71
 msgid "myJobs.heatmap.month.oct"
 msgstr "Ott"
 
@@ -2729,7 +2735,7 @@ msgid "common.header.openMenu"
 msgstr "Apri menu principale"
 
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:45
+#: app/[lang]/(app)/company/[slug]/page.tsx:46
 msgid "company.meta.openPositions"
 msgstr "Posizioni aperte"
 
@@ -2905,7 +2911,7 @@ msgstr "al mese"
 
 #. Period filter heading
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:57
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:62
 msgid "myJobs.stats.period"
 msgstr "Periodo"
 
@@ -3392,7 +3398,7 @@ msgstr "Salva offerte"
 
 #. Empty state for stats
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:101
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:106
 msgid "myJobs.stats.empty"
 msgstr "Salva offerte e monitora le tue candidature per vedere le statistiche qui."
 
@@ -3608,7 +3614,7 @@ msgstr "Livello di esperienza"
 
 #. Short September label
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:65
+#: src/components/my-jobs/activity-heatmap.tsx:70
 msgid "myJobs.heatmap.month.sep"
 msgstr "Set"
 
@@ -3998,13 +4004,13 @@ msgstr "Termini di servizio di Job Seek — regole d'uso, proprietà intellettua
 
 #. Body text shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:93
+#: app/[lang]/(app)/company/[slug]/page.tsx:94
 msgid "company.notFound.message"
 msgstr "L'azienda che stai cercando non esiste o è stata rimossa."
 
 #. Body text for the company-not-found page; explains the company is either gone or never existed
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-content.tsx:27
+#: app/[lang]/(app)/company/[slug]/company-content.tsx:59
 msgid "company.notFound.body"
 msgstr "L'azienda che stai cercando non esiste o è stata rimossa."
 
@@ -4459,7 +4465,7 @@ msgstr "Stiamo lavorando per aggiungere"
 
 #. Short Wednesday label for heatmap
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:47
+#: src/components/my-jobs/activity-heatmap.tsx:52
 msgid "myJobs.heatmap.day.wed"
 msgstr "Mer"
 

--- a/apps/web/src/components/settings/AccountSettings.tsx
+++ b/apps/web/src/components/settings/AccountSettings.tsx
@@ -85,9 +85,9 @@ function SetPasswordFlow({ onSuccess }: { onSuccess: () => void }) {
 
   return (
     <section>
-      <h3 className="mb-1 text-base font-semibold">
+      <h2 className="mb-1 text-base font-semibold">
         <Trans id="settings.account.password.title" comment="Password section heading">Password</Trans>
-      </h3>
+      </h2>
       <p className="mb-4 text-sm text-muted">
         <Trans id="settings.account.password.setDescription" comment="Set password description for OAuth users">
           You signed in with a social account. Set a password to enable email changes and additional security.
@@ -170,9 +170,9 @@ function ResetPasswordFlow({ initialCooldown }: { initialCooldown: number }) {
 
   return (
     <section>
-      <h3 className="mb-1 text-base font-semibold">
+      <h2 className="mb-1 text-base font-semibold">
         <Trans id="settings.account.password.title" comment="Password section heading">Password</Trans>
-      </h3>
+      </h2>
       <p className="mb-4 text-sm text-muted">
         <Trans id="settings.account.password.description" comment="Password section description">
           Change your password via a secure email link.
@@ -294,9 +294,9 @@ function UsernameSection({ currentUsername }: { currentUsername: string }) {
 
   return (
     <section>
-      <h3 className="mb-1 text-base font-semibold">
+      <h2 className="mb-1 text-base font-semibold">
         <Trans id="settings.account.username.title" comment="Username section heading">Username</Trans>
-      </h3>
+      </h2>
       <p className="mb-4 text-sm text-muted">
         <Trans id="settings.account.username.description" comment="Username section description">
           Your unique handle used in your public profile URL.
@@ -366,9 +366,9 @@ function ChangeEmailSection() {
 
   return (
     <section>
-      <h3 className="mb-1 text-base font-semibold">
+      <h2 className="mb-1 text-base font-semibold">
         <Trans id="settings.account.email.title" comment="Change email section heading">Change email</Trans>
-      </h3>
+      </h2>
       <p className="mb-4 text-sm text-muted">
         <Trans id="settings.account.email.description" comment="Change email section description">
           Update the email address associated with your account.
@@ -446,9 +446,9 @@ function ConnectedAccountsSection({ accounts, onDisconnect }: { accounts: Connec
 
   return (
     <section>
-      <h3 className="mb-1 text-base font-semibold">
+      <h2 className="mb-1 text-base font-semibold">
         <Trans id="settings.account.socials.title" comment="Connected accounts section heading">Connected accounts</Trans>
-      </h3>
+      </h2>
       <p className="mb-4 text-sm text-muted">
         <Trans id="settings.account.socials.description" comment="Connected accounts section description">
           Manage your linked social accounts.
@@ -504,9 +504,9 @@ function DeleteAccountSection() {
 
   return (
     <section className="rounded-md border border-error-border bg-error-bg p-4">
-      <h3 className="mb-1 text-base font-semibold text-error">
+      <h2 className="mb-1 text-base font-semibold text-error">
         <Trans id="settings.account.delete.title" comment="Delete account section heading">Delete account</Trans>
-      </h3>
+      </h2>
       <p className="mb-4 text-sm text-error">
         <Trans id="settings.account.delete.description" comment="Delete account section description">
           Permanently delete your account and all associated data. This action cannot be undone.

--- a/apps/web/src/components/settings/__tests__/AccountSettings-heading-hierarchy.test.tsx
+++ b/apps/web/src/components/settings/__tests__/AccountSettings-heading-hierarchy.test.tsx
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+import "@/test-utils/lingui-mock";
+
+/**
+ * Regression test for #3196 — the settings page renders an `<h1>` in
+ * the layout (`Settings`), and `AccountSettings` was jumping straight
+ * to `<h3>` for every section, skipping h2 entirely. WCAG 1.3.1
+ * forbids the gap; `GeneralSettings` already uses h2 correctly. This
+ * suite locks the section level at h2 so a future refactor cannot
+ * regress to h3.
+ */
+
+vi.mock("server-only", () => ({}));
+
+// Settings page hands `useRouter` to AccountSettings via UsernameSection.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+// SessionProvider drives useAuth — stub a logged-in user so the
+// component renders its real sections rather than the LoginPrompt
+// short-circuit.
+vi.mock("@/components/SessionProvider", () => ({
+  useSession: () => ({
+    user: { email: "test@example.com", username: "test" },
+    isLoggedIn: true,
+    isPending: false,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/useAuth", () => ({
+  useAuth: () => ({
+    user: { email: "test@example.com", username: "test" },
+    isLoggedIn: true,
+    isPending: false,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/useLocalePath", () => ({
+  useLocalePath: () => (path: string) => `/en${path}`,
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    isUsernameAvailable: vi.fn().mockResolvedValue({ data: { available: true } }),
+    requestPasswordReset: vi.fn().mockResolvedValue({ error: null }),
+    changeEmail: vi.fn().mockResolvedValue({ error: null }),
+    linkSocial: vi.fn().mockResolvedValue({ error: null }),
+    unlinkAccount: vi.fn().mockResolvedValue({ error: null }),
+    deleteUser: vi.fn().mockResolvedValue({ error: null }),
+  },
+}));
+
+vi.mock("@/lib/actions/preferences", () => ({
+  setPassword: vi.fn().mockResolvedValue({ error: null }),
+  recordPasswordResetRequest: vi.fn().mockResolvedValue({ error: null }),
+  getAccountPageData: vi.fn().mockResolvedValue(null),
+  renameUsername: vi.fn().mockResolvedValue({ error: null }),
+}));
+
+import { AccountSettings } from "../AccountSettings";
+
+const initialData = {
+  accounts: [] as { providerId: string; accountId: string }[],
+  hasPassword: false,
+  username: "testuser",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AccountSettings — section heading level (#3196)", () => {
+  it("renders all section headings at level 2 (h2), not h3", () => {
+    render(<AccountSettings initialData={{ ...initialData }} />);
+
+    // Every section heading must be an h2 — the page-level h1 lives in
+    // the settings layout, so h2 is the correct next step.
+    const h2s = screen.getAllByRole("heading", { level: 2 });
+    // Username, Password, Change email, Connected accounts, Delete
+    // account = 5 sections. PasswordSection branches on `hasPassword`
+    // and renders one of two sub-components, each with its own heading
+    // — so there are 5 h2s, not 6, for any given render.
+    expect(h2s.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("renders no h3 at the section level (WCAG 1.3.1 — no skipped heading levels)", () => {
+    render(<AccountSettings initialData={{ ...initialData }} />);
+
+    const h3s = screen.queryAllByRole("heading", { level: 3 });
+    expect(h3s).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Restores valid heading hierarchy on two app surfaces flagged by audit-a11y issue #3196. Screen-reader users navigating by heading (H key in NVDA/JAWS, rotor in VoiceOver) were skipping the page topic on `/explore` and skipping a level on `/settings/account`.

**WCAG criterion**: 1.3.1 Info and Relationships (Level A) — heading levels must form a valid hierarchy.

### Thread 1 — `/explore` had no `<h1>`

Added a visually-hidden `<h1>` to the top of `SearchPage` (`apps/web/app/[lang]/(app)/explore/search-page.tsx`). The visual design leads with the search toolbar, so the heading is `sr-only` — present in the accessibility tree but invisible. New i18n string: `explore.h1` ("Explore Jobs") with translations in `en`, `de`, `fr`, `it`.

### Thread 2 — `/settings/account` skipped h2 → went to h3

Swapped all six `<h3>` section headings in `AccountSettings.tsx` to `<h2>` so the hierarchy under the layout's `h1`("Settings") is contiguous:

- `UsernameSection`
- `SetPasswordFlow` (one of two PasswordSection branches)
- `ResetPasswordFlow` (the other PasswordSection branch)
- `ChangeEmailSection`
- `ConnectedAccountsSection`
- `DeleteAccountSection`

**Visual styling preserved**: Tailwind classes (`mb-1 text-base font-semibold` plus `text-error` for the delete section) are unchanged; only the semantic tag changed. The pattern mirrors `GeneralSettings.tsx`, which already uses `h2`.

## Tests

Two new tests, locked the regressions in:

- `app/[lang]/(app)/explore/__tests__/search-page-heading.test.tsx` — mounts `SearchPage` with stubbed heavy deps and asserts exactly one level-1 heading is present, text matches `/explore/i`, and the `sr-only` class is on it.
- `src/components/settings/__tests__/AccountSettings-heading-hierarchy.test.tsx` — asserts at least 5 h2 headings and zero h3 headings at the section level.

## New translations

- `explore.h1` — "Explore Jobs" (en) / "Jobs entdecken" (de) / "Explorer les emplois" (fr) / "Esplora lavori" (it)

## Test plan

- [x] `pnpm test` — all 856 tests pass (98 files)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm extract && pnpm compile` — catalogs in sync, 0 missing per locale
- [x] `pnpm exec eslint <changed files>` — clean
- [x] `scripts/check-i18n-coverage.sh` (pre-commit gate) — passes

## Scope decisions

- Did not audit other settings sub-pages (`BillingSettings`, etc.) for heading hierarchy — issue called out only the two threads above; staying narrow.
- Did not change visual font size of the AccountSettings h2s. Issue called out "Visual styling can stay (Tailwind class is decoupled from semantic level)"; preserving the existing `text-base` to avoid visual regression.

Closes #3196

🤖 Generated with [Claude Code](https://claude.com/claude-code)