### PR TITLE
perf(web): memoize CompanyCard with custom comparator (closes #3198)

### DIFF
--- a/apps/web/app/[lang]/(app)/explore/search-page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/search-page.tsx
@@ -444,10 +444,17 @@ export function SearchPage({
   };
   function updateUrl() { internalUrlChangeRef.current = true; updateUrlRef.current(); }
 
-  function handleOpenPosting(postingId: string) {
+  // Stabilized for #3198 — passed into `SearchResults` -> `CompanyCard`
+  // which is wrapped in `React.memo` with a custom comparator that
+  // checks `onShowPosting` by reference. Without `useCallback`, every
+  // parent render hands every card a new function and the memo is
+  // a no-op. `setShowPostingId` / `updateShowParam` are stable
+  // (state setter + module-scoped function reading refs), so an empty
+  // dep array is correct here.
+  const handleOpenPosting = useCallback((postingId: string) => {
     setShowPostingId(postingId);
     updateShowParam(postingId);
-  }
+  }, []);
 
   function handleClosePosting() {
     setShowPostingId(null);
@@ -711,6 +718,12 @@ export function SearchPage({
     setTotalCompanies(result.totalCompanies);
   }
 
+  // Stabilized for #3198 — `locationIds` is fed into `SearchResults` and
+  // then into each `CompanyCard`. Inline `locations.map((l) => l.id)` in
+  // the JSX rebuilt a fresh array on every render, defeating the custom
+  // memo comparator's identity-first short-circuit on the array prop.
+  const locationIds = useMemo(() => locations.map((l) => l.id), [locations]);
+
   const histogramFilters: HistogramFilters = useMemo(() => ({
     keywords: keywords.length > 0 ? keywords : undefined,
     locationIds: locations.length > 0 ? locations.map((l) => l.id) : undefined,
@@ -787,7 +800,7 @@ export function SearchPage({
           <SearchResults
             companies={companies}
             keywords={keywords}
-            locationIds={locations.map((l) => l.id)}
+            locationIds={locationIds}
             locations={locations}
             occupations={occupations}
             seniorities={seniorities}

--- a/apps/web/src/components/search/__tests__/company-card.test.tsx
+++ b/apps/web/src/components/search/__tests__/company-card.test.tsx
@@ -1,0 +1,432 @@
+/**
+ * Tests for CompanyCard memoization (issue #3198).
+ *
+ * Before the fix, every filter mutation in `SearchPage` re-rendered every
+ * `CompanyCard` in `SearchResults` — there was no `React.memo`, and the
+ * filter props (`keywords`, `locationIds`, `locations`, ...) were
+ * reconstructed inline at the parent (e.g. `locations.map((l) => l.id)`)
+ * so even a default `React.memo` shallow check would have failed.
+ *
+ * The fix is two-step:
+ *   1. Wrap `CompanyCard` in `React.memo(impl, companyCardPropsEqual)`
+ *      where the comparator deep-equals each array prop by id / value.
+ *   2. Stabilize the array-ish props at the parent (`useMemo`'d
+ *      `locationIds`, `useCallback`'d `handleOpenPosting`).
+ *
+ * Two test groups:
+ *
+ * - Unit tests on `companyCardPropsEqual` — the comparator is pure,
+ *   exhaustive coverage is cheap, and it's the load-bearing piece:
+ *   returning `true` when a prop actually changed = stale UI.
+ *
+ * - Render-count integration test via `React.Profiler` — confirms the
+ *   `memo` wrapper actually skips renders when filter values are
+ *   logically identical but referentially fresh (the realistic
+ *   parent-render scenario described in #3198).
+ */
+import { useState } from "react";
+import { describe, it, expect, vi } from "vitest";
+import { render, fireEvent, screen } from "@testing-library/react";
+import "@/test-utils/lingui-mock";
+
+// --- Mocks for CompanyCard's heavy subtree -----------------------------------
+// Keep them minimal — we only need the component to mount and re-render
+// deterministically. None of these affect the memo decision (which is
+// what's actually under test).
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ lang: "en" }),
+}));
+
+vi.mock("next/link", () => ({
+  // `prefetch` is a `next/link`-specific prop and must NOT be forwarded
+  // to the underlying `<a>` (React warns about non-boolean attrs on DOM).
+  default: ({ children, href, prefetch: _prefetch, ...props }: Record<string, unknown>) => (
+    <a href={href as string} {...props}>{children as React.ReactNode}</a>
+  ),
+}));
+
+// CompanyIcon is rendered exactly once per CompanyCard subtree, so we use
+// it as a render-counter probe. When the memo skips, the icon won't be
+// re-invoked. Counts are keyed by `alt` (set by CompanyCard to
+// `company.name`), so each card has its own counter.
+const iconRenderCounts = new Map<string, number>();
+vi.mock("@/components/CompanyIcon", () => ({
+  CompanyIcon: ({ alt }: { alt: string }) => {
+    iconRenderCounts.set(alt, (iconRenderCounts.get(alt) ?? 0) + 1);
+    return <span data-testid="company-icon" data-name={alt} />;
+  },
+}));
+
+vi.mock("@/components/InfiniteScrollSentinel", () => ({
+  InfiniteScrollSentinel: () => null,
+}));
+
+vi.mock("@/components/TruncationPrompt", () => ({
+  TruncationPrompt: () => null,
+}));
+
+vi.mock("@/components/TrackingDot", () => ({
+  TrackingDot: () => null,
+}));
+
+vi.mock("@/components/PendingJobWarning", () => ({
+  PendingJobIcon: () => null,
+}));
+
+vi.mock("@/components/search/save-button", () => ({
+  SaveButton: () => null,
+}));
+
+vi.mock("@/components/search/star-button", () => ({
+  StarButton: () => null,
+}));
+
+vi.mock("@/components/ui/scroll-fade", () => ({
+  ScrollFade: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/use-infinite-scroll", () => ({
+  useInfiniteScroll: () => ({ sentinelRef: { current: null }, isLoading: false }),
+}));
+
+vi.mock("@/lib/actions/search", () => ({
+  loadMorePostings: vi.fn().mockResolvedValue({ postings: [], truncated: false }),
+}));
+
+vi.mock("@/lib/time", () => ({
+  timeAgoShort: () => "1d",
+}));
+
+vi.mock("@/lib/search/query-params", async () => {
+  // Keep the type-exporting module intact while overriding `buildFilteredPath`.
+  return {
+    buildFilteredPath: () => "/en/company/acme",
+  };
+});
+
+// Import AFTER mocks so vi.mock hoisting sees them.
+import { CompanyCard, companyCardPropsEqual } from "../company-card";
+import type { SearchResultCompany } from "@/lib/search";
+import type {
+  SerializableLocation,
+  SerializableOccupation,
+  SerializableSeniority,
+  SerializableTechnology,
+} from "@/lib/search/query-params";
+
+function makeResult(id: string, name = `Company ${id}`): SearchResultCompany {
+  return {
+    company: { id, name, slug: `company-${id}`, icon: null },
+    activeMatches: 1,
+    yearMatches: 1,
+    postings: [
+      {
+        id: `p-${id}`,
+        title: `Posting ${id}`,
+        firstSeenAt: "2026-05-01T00:00:00Z",
+        relevanceScore: 1,
+        locations: [],
+        isActive: true,
+      },
+    ],
+  };
+}
+
+function loc(id: number, name = `Loc ${id}`): SerializableLocation {
+  return { id, slug: `loc-${id}`, name, type: "city" };
+}
+function occ(id: number): SerializableOccupation {
+  return { id, slug: `occ-${id}`, name: `Occ ${id}` };
+}
+function sen(id: number): SerializableSeniority {
+  return { id, slug: `sen-${id}`, name: `Sen ${id}` };
+}
+function tech(id: number): SerializableTechnology {
+  return { id, slug: `tech-${id}`, name: `Tech ${id}` };
+}
+
+// =============================================================================
+// Comparator unit tests
+// =============================================================================
+
+describe("companyCardPropsEqual", () => {
+  const baseResult = makeResult("1");
+  const noop = () => {};
+
+  function baseProps() {
+    return {
+      result: baseResult,
+      keywords: ["engineer"],
+      locationIds: [10, 20],
+      locations: [loc(10), loc(20)],
+      occupations: [occ(1)],
+      seniorities: [sen(1)],
+      technologies: [tech(1)],
+      employmentTypes: ["fulltime"],
+      workMode: ["remote" as const],
+      salaryMinEur: 50000,
+      salaryMaxEur: 100000,
+      experienceMin: 1,
+      experienceMax: 5,
+      languages: ["en"],
+      onShowPosting: noop,
+      selectedPostingId: null,
+    };
+  }
+
+  it("returns true when every prop is referentially identical", () => {
+    const p = baseProps();
+    expect(companyCardPropsEqual(p, p)).toBe(true);
+  });
+
+  it("returns true when arrays are reconstructed with the same contents", () => {
+    const a = baseProps();
+    // Reconstruct every array — same contents, fresh references. This is the
+    // exact scenario described in #3198 (parent recomputing arrays inline).
+    const b = {
+      ...a,
+      keywords: ["engineer"],
+      locationIds: [10, 20],
+      locations: [loc(10), loc(20)],
+      occupations: [occ(1)],
+      seniorities: [sen(1)],
+      technologies: [tech(1)],
+      employmentTypes: ["fulltime"],
+      workMode: ["remote" as const],
+      languages: ["en"],
+    };
+    expect(companyCardPropsEqual(a, b)).toBe(true);
+  });
+
+  it("returns false when `result` reference changes (new search response)", () => {
+    const a = baseProps();
+    const b = { ...a, result: makeResult("1") }; // same id, different object
+    expect(companyCardPropsEqual(a, b)).toBe(false);
+  });
+
+  it("returns false when keywords differ", () => {
+    const a = baseProps();
+    expect(
+      companyCardPropsEqual(a, { ...a, keywords: ["engineer", "rust"] }),
+    ).toBe(false);
+    expect(
+      companyCardPropsEqual(a, { ...a, keywords: ["frontend"] }),
+    ).toBe(false);
+  });
+
+  it("returns false when locationIds differ (length OR content)", () => {
+    const a = baseProps();
+    expect(companyCardPropsEqual(a, { ...a, locationIds: [10] })).toBe(false);
+    expect(companyCardPropsEqual(a, { ...a, locationIds: [10, 30] })).toBe(false);
+  });
+
+  it("returns false when locations differ by id (even if same length)", () => {
+    const a = baseProps();
+    expect(
+      companyCardPropsEqual(a, { ...a, locations: [loc(10), loc(99)] }),
+    ).toBe(false);
+  });
+
+  it("returns true when locations have the same ids but different names", () => {
+    // Name/slug don't change at runtime for a given id in this app — taxonomy
+    // is server-rendered — so the comparator only checks id. If this rule ever
+    // changes, this test should fail and force a comparator update.
+    const a = baseProps();
+    const b = {
+      ...a,
+      locations: [loc(10, "Berlin renamed"), loc(20, "Munich renamed")],
+    };
+    expect(companyCardPropsEqual(a, b)).toBe(true);
+  });
+
+  it("returns false when occupations / seniorities / technologies differ by id", () => {
+    const a = baseProps();
+    expect(
+      companyCardPropsEqual(a, { ...a, occupations: [occ(99)] }),
+    ).toBe(false);
+    expect(
+      companyCardPropsEqual(a, { ...a, seniorities: [sen(99)] }),
+    ).toBe(false);
+    expect(
+      companyCardPropsEqual(a, { ...a, technologies: [tech(99)] }),
+    ).toBe(false);
+  });
+
+  it("returns false when employmentTypes / workMode / languages differ", () => {
+    const a = baseProps();
+    expect(
+      companyCardPropsEqual(a, { ...a, employmentTypes: ["parttime"] }),
+    ).toBe(false);
+    expect(
+      companyCardPropsEqual(a, { ...a, workMode: ["onsite" as const] }),
+    ).toBe(false);
+    expect(companyCardPropsEqual(a, { ...a, languages: ["de"] })).toBe(false);
+  });
+
+  it("returns false when any numeric primitive prop changes", () => {
+    const a = baseProps();
+    expect(companyCardPropsEqual(a, { ...a, salaryMinEur: 60000 })).toBe(false);
+    expect(companyCardPropsEqual(a, { ...a, salaryMaxEur: 120000 })).toBe(false);
+    expect(companyCardPropsEqual(a, { ...a, experienceMin: 2 })).toBe(false);
+    expect(companyCardPropsEqual(a, { ...a, experienceMax: 6 })).toBe(false);
+  });
+
+  it("returns false when selectedPostingId changes (highlight state)", () => {
+    const a = baseProps();
+    expect(
+      companyCardPropsEqual(a, { ...a, selectedPostingId: "p-1" }),
+    ).toBe(false);
+  });
+
+  it("returns false when onShowPosting identity changes", () => {
+    // We intentionally do NOT mask function identity changes — that would
+    // hide stale-closure bugs. Callers stabilize with `useCallback`.
+    const a = baseProps();
+    expect(
+      companyCardPropsEqual(a, { ...a, onShowPosting: () => {} }),
+    ).toBe(false);
+  });
+
+  it("handles undefined optional array props symmetrically", () => {
+    const a = { ...baseProps(), locationIds: undefined, languages: undefined };
+    const b = { ...baseProps(), locationIds: undefined, languages: undefined };
+    expect(companyCardPropsEqual(a, b)).toBe(true);
+
+    // One side defined, other undefined -> different
+    expect(
+      companyCardPropsEqual(a, { ...a, locationIds: [10] }),
+    ).toBe(false);
+  });
+});
+
+// =============================================================================
+// Render-count integration test
+// =============================================================================
+//
+// Wraps a stable `CompanyCard` in a parent that toggles ITS OWN state on
+// every interaction (mimicking `SearchPage` toggling filters), while
+// passing freshly-reconstructed arrays / identical-by-value callbacks to
+// the card. With memo + stable callback, the card should render exactly
+// ONCE. Without memo it would render twice.
+//
+// Render-count tracking uses the mocked `CompanyIcon` (see top of file):
+// every CompanyCard render invokes its child CompanyIcon, so the icon's
+// invocation count IS the card's render count. We don't use Profiler
+// here because Profiler fires onRender even when a child memoizes-bails
+// (the Profiler itself still commits when its parent does), so it can't
+// distinguish "child re-rendered" from "child bailed but parent did
+// not".
+
+describe("CompanyCard memoization (render count)", () => {
+  it("renders only ONCE when parent re-renders with same prop values (10 cards)", () => {
+    iconRenderCounts.clear();
+    // Stable references reused across renders, captured outside Harness.
+    const results = Array.from({ length: 10 }, (_, i) => makeResult(String(i + 1)));
+    const stableHandlerRef = () => {};
+
+    function Harness() {
+      // Parent state — toggle to force a re-render.
+      const [tick, setTick] = useState(0);
+
+      // Same logical values, fresh references each render. Mirrors the
+      // pre-#3198 inline-construction pattern in search-page.tsx
+      // (e.g. `locationIds={locations.map((l) => l.id)}`).
+      const keywords = ["engineer"];
+      const locationIds = [10, 20];
+      const locations = [loc(10), loc(20)];
+      const occupations = [occ(1)];
+      const seniorities = [sen(1)];
+      const technologies = [tech(1)];
+
+      return (
+        <>
+          <button onClick={() => setTick((t) => t + 1)}>tick {tick}</button>
+          {results.map((result) => (
+            <CompanyCard
+              key={result.company.id}
+              result={result}
+              keywords={keywords}
+              locationIds={locationIds}
+              locations={locations}
+              occupations={occupations}
+              seniorities={seniorities}
+              technologies={technologies}
+              employmentTypes={[]}
+              workMode={[]}
+              salaryMinEur={undefined}
+              salaryMaxEur={undefined}
+              experienceMin={undefined}
+              experienceMax={undefined}
+              languages={["en"]}
+              onShowPosting={stableHandlerRef}
+              selectedPostingId={null}
+            />
+          ))}
+        </>
+      );
+    }
+
+    render(<Harness />);
+
+    // Initial mount: every card rendered once.
+    for (const r of results) {
+      expect(iconRenderCounts.get(r.company.name)).toBe(1);
+    }
+
+    // Force a parent re-render. With memo + correct comparator, no card
+    // should re-render — they all should hit the equality short-circuit.
+    fireEvent.click(screen.getByText(/^tick/));
+
+    for (const r of results) {
+      expect(
+        iconRenderCounts.get(r.company.name),
+        `card ${r.company.name} re-rendered after parent re-render with identical-by-value props`,
+      ).toBe(1);
+    }
+
+    // Sanity: a SECOND parent re-render also stays at 1 (i.e. not flaky).
+    fireEvent.click(screen.getByText(/^tick/));
+    for (const r of results) {
+      expect(iconRenderCounts.get(r.company.name)).toBe(1);
+    }
+  });
+
+  it("DOES re-render when a card's own filter prop genuinely changes", () => {
+    // Sanity check on the negative case — confirm the memo doesn't
+    // accidentally over-skip when there's a real change.
+    iconRenderCounts.clear();
+    const stableHandler = () => {};
+    const result = makeResult("solo");
+
+    function Harness({ kw }: { kw: string[] }) {
+      return (
+        <CompanyCard
+          result={result}
+          keywords={kw}
+          locationIds={[]}
+          locations={[]}
+          occupations={[]}
+          seniorities={[]}
+          technologies={[]}
+          employmentTypes={[]}
+          workMode={[]}
+          languages={["en"]}
+          onShowPosting={stableHandler}
+          selectedPostingId={null}
+        />
+      );
+    }
+
+    const { rerender } = render(<Harness kw={["a"]} />);
+    expect(iconRenderCounts.get(result.company.name)).toBe(1);
+
+    // Same value — memo skips.
+    rerender(<Harness kw={["a"]} />);
+    expect(iconRenderCounts.get(result.company.name)).toBe(1);
+
+    // Different value — memo lets it through.
+    rerender(<Harness kw={["a", "b"]} />);
+    expect(iconRenderCounts.get(result.company.name)).toBe(2);
+  });
+});

--- a/apps/web/src/components/search/company-card.tsx
+++ b/apps/web/src/components/search/company-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useMemo } from "react";
+import { memo, useState, useRef, useMemo } from "react";
 import Link from "next/link";
 import { Trans } from "@lingui/react/macro";
 import { CompanyIcon } from "@/components/CompanyIcon";
@@ -40,7 +40,7 @@ interface CompanyCardProps {
   selectedPostingId?: string | null;
 }
 
-export function CompanyCard({ result, keywords, locationIds, locations, occupations, seniorities, technologies, employmentTypes, workMode, salaryMinEur, salaryMaxEur, experienceMin, experienceMax, languages, onShowPosting, selectedPostingId }: CompanyCardProps) {
+function CompanyCardImpl({ result, keywords, locationIds, locations, occupations, seniorities, technologies, employmentTypes, workMode, salaryMinEur, salaryMaxEur, experienceMin, experienceMax, languages, onShowPosting, selectedPostingId }: CompanyCardProps) {
   const params = useParams();
   const locale = (params.lang as string) ?? "en";
   const { company, activeMatches, yearMatches } = result;
@@ -164,3 +164,88 @@ export function CompanyCard({ result, keywords, locationIds, locations, occupati
     </div>
   );
 }
+
+// --- Memoization (issue #3198) -----------------------------------------------
+// CompanyCard is rendered in a list by SearchResults; without memoization,
+// every filter mutation in the parent SearchPage re-renders all N cards (10 on
+// initial page, up to 50+ with infinite scroll), each with its own internal
+// state machine and 3-5 child components. The parent passes arrays
+// (`keywords`, `locationIds`, `locations`, ...) that are reconstructed on
+// every render in the parent JSX (`locations.map((l) => l.id)`), so default
+// `React.memo` referential equality always fails.
+//
+// We compare each prop explicitly. For arrays we use a stable shallow
+// equality check on the relevant identity (IDs for taxonomy items, raw
+// strings for keywords/workMode/employmentTypes/languages). For functions
+// (`onShowPosting`) we compare by reference — callers MUST stabilize with
+// `useCallback` (search-results.tsx + search-page.tsx do so), otherwise we'd
+// hide stale-closure bugs.
+//
+// IMPORTANT: returning `true` here skips the render. If we omit a prop that
+// genuinely changed, the UI will go stale. Every prop in `CompanyCardProps`
+// must be reflected below.
+
+function arraysShallowEqual<T>(a: readonly T[] | undefined, b: readonly T[] | undefined): boolean {
+  if (a === b) return true;
+  if (a === undefined || b === undefined) return false;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+function idArraysEqual<T extends { id: string | number }>(
+  a: readonly T[] | undefined,
+  b: readonly T[] | undefined,
+): boolean {
+  if (a === b) return true;
+  if (a === undefined || b === undefined) return false;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i].id !== b[i].id) return false;
+  }
+  return true;
+}
+
+/**
+ * Exported for unit testing only (see __tests__/company-card.test.tsx).
+ * Not part of the public component API.
+ */
+export function companyCardPropsEqual(prev: CompanyCardProps, next: CompanyCardProps): boolean {
+  // `result` is a reference-identity check — the search runner replaces the
+  // companies array on every search response, so a new reference always
+  // signals genuinely new data. We don't deep-walk postings here.
+  if (prev.result !== next.result) return false;
+
+  // Primitives.
+  if (prev.salaryMinEur !== next.salaryMinEur) return false;
+  if (prev.salaryMaxEur !== next.salaryMaxEur) return false;
+  if (prev.experienceMin !== next.experienceMin) return false;
+  if (prev.experienceMax !== next.experienceMax) return false;
+  if (prev.selectedPostingId !== next.selectedPostingId) return false;
+
+  // Function identity — callers stabilize via `useCallback`. If a parent
+  // forgets, we'll over-render; we will NOT hide stale closures here.
+  if (prev.onShowPosting !== next.onShowPosting) return false;
+
+  // Arrays of primitives (strings / WorkMode literals).
+  if (!arraysShallowEqual(prev.keywords, next.keywords)) return false;
+  if (!arraysShallowEqual(prev.locationIds, next.locationIds)) return false;
+  if (!arraysShallowEqual(prev.employmentTypes, next.employmentTypes)) return false;
+  if (!arraysShallowEqual(prev.workMode, next.workMode)) return false;
+  if (!arraysShallowEqual(prev.languages, next.languages)) return false;
+
+  // Arrays of taxonomy objects — compare by `id` only. Cards use
+  // `.map((x) => x.id)` plus `name`/`slug` for the inline-link
+  // `companyHref`, but `name`/`slug` for a given id never change at
+  // runtime in this app (they come from server-rendered taxonomy data).
+  if (!idArraysEqual(prev.locations, next.locations)) return false;
+  if (!idArraysEqual(prev.occupations, next.occupations)) return false;
+  if (!idArraysEqual(prev.seniorities, next.seniorities)) return false;
+  if (!idArraysEqual(prev.technologies, next.technologies)) return false;
+
+  return true;
+}
+
+export const CompanyCard = memo(CompanyCardImpl, companyCardPropsEqual);

--- a/apps/web/src/components/search/search-results.tsx
+++ b/apps/web/src/components/search/search-results.tsx
@@ -56,6 +56,14 @@ export function SearchResults({
   return (
     <div className="space-y-3">
       {companies.map((result) => (
+        // Keyword-keyed wrapper: forces each card to remount when the
+        // user changes `keywords`, so the card's internal pagination
+        // state (`extraPostings`, `exhausted`, `offsetRef`) resets and
+        // doesn't show stale postings from a prior keyword search.
+        // The post-#3198 `React.memo` on `CompanyCard` still skips
+        // renders for non-keyword filter changes (salary, locations,
+        // occupations, ...), which is the hot path called out in the
+        // issue (salary slider drag).
         <div key={`${result.company.id}-${keywords.join(",")}`}>
           <CompanyCard result={result} keywords={keywords} locationIds={locationIds} locations={locations} occupations={occupations} seniorities={seniorities} technologies={technologies} employmentTypes={employmentTypes} workMode={workMode} salaryMinEur={salaryMinEur} salaryMaxEur={salaryMaxEur} experienceMin={experienceMin} experienceMax={experienceMax} languages={languages} onShowPosting={onShowPosting} selectedPostingId={selectedPostingId} />
         </div>


### PR DESCRIPTION
## Summary

- Wrap `CompanyCard` in `React.memo` with a custom comparator so filter-bar interactions (especially the salary slider drag tick) no longer re-render every card in the result list.
- Stabilize array-ish props at the parent: `useMemo`-ed `locationIds` and `useCallback`-ed `handleOpenPosting` in `search-page.tsx`.
- 15 new tests covering the comparator (every prop, including the "reconstructed-but-equal" hot path that #3198 specifically calls out) plus an end-to-end render-count check that confirms the `memo` wrapper actually skips renders.

## Re-render measurement (test-based)

`src/components/search/__tests__/company-card.test.tsx` includes a render-count probe (counts invocations of the mocked `CompanyIcon`, which is rendered exactly once per `CompanyCard` subtree).

- 10 cards, parent re-render with reconstructed-but-equal props: each card stays at render count `1` (was `2` pre-fix because props had fresh references each render).
- Second parent re-render: still `1` (no flake).
- Negative case: when a card's keywords genuinely change from `["a"]` to `["a","b"]`, the count climbs to `2` (memo correctly lets it through).

Profiler was tried first but isn't usable here — `Profiler.onRender` fires on every commit in its subtree even when the descendant `memo` bails, so it can't distinguish "card re-rendered" from "ancestor committed". The icon-probe approach gives an unambiguous count.

## Comparator semantics (`companyCardPropsEqual`)

Returns `true` (skip render) iff every prop below is unchanged. Each line is one explicit check — there's nothing implicit. Returning `true` when something changed = stale UI, so every prop in `CompanyCardProps` is reflected:

| Prop | Equality |
|---|---|
| `result` | by reference (search runner replaces on every server response) |
| `salaryMinEur`, `salaryMaxEur`, `experienceMin`, `experienceMax`, `selectedPostingId` | `===` |
| `onShowPosting` | by reference — caller MUST `useCallback` (we don't mask identity changes, that would hide stale closures) |
| `keywords`, `locationIds`, `employmentTypes`, `workMode`, `languages` | shallow array value equality (length + `===` per slot) |
| `locations`, `occupations`, `seniorities`, `technologies` | length + `id` equality per slot — taxonomy `name`/`slug` for a given id is server-rendered and doesn't change at runtime |

## Stabilized array props at the parent

- `app/[lang]/(app)/explore/search-page.tsx`: `const locationIds = useMemo(() => locations.map((l) => l.id), [locations])` — fixes the inline `locations.map((l) => l.id)` in the JSX that defeated the comparator's identity-first short-circuit.
- `app/[lang]/(app)/explore/search-page.tsx`: `handleOpenPosting` is now `useCallback`-wrapped (empty deps — it reads refs internally).

## Pre-existing keyword key on the wrapper is kept on purpose

`search-results.tsx` still keys each card by `${company.id}-${keywords.join(",")}`. That's an intentional remount-trigger that resets the card's internal pagination state (`extraPostings`, `exhausted`, `offsetRef`) when keywords change. The instruction was explicit about not refactoring `CompanyCard`'s internal state machine, so removing that key without adding a `useEffect` reset would have been a regression. The memo still wins for the hot path described in the issue (salary slider drag and other non-keyword filter changes — those don't bust the key, and the memo short-circuits all of them).

## Tests added

`apps/web/src/components/search/__tests__/company-card.test.tsx`:

- 13 unit tests on `companyCardPropsEqual` (exported for test-only)
- 2 render-count integration tests on the memoized `CompanyCard` (10-card list + single-card negative case)

## Test plan

- [x] `pnpm test` (868/868 pass)
- [x] `pnpm exec tsc --noEmit` (clean)
- [x] `pnpm exec eslint` on changed files (clean)
- [ ] `pnpm build` NOT run per orchestrator instructions
- [ ] Visual smoke test on `/en/explore` — verify salary slider drag feels smooth and cards stay mounted across non-keyword filter toggles

🤖 Generated with [Claude Code](https://claude.com/claude-code)