### PR TITLE
obs(web): plumb NotifyIndexNowResult to structured logs at all call sites (closes #3202)

### DIFF
--- a/apps/web/src/lib/__tests__/indexnow-observability.test.ts
+++ b/apps/web/src/lib/__tests__/indexnow-observability.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Observability tests for `logIndexNowResult` (#3202).
+ *
+ * The 5 web-side call sites in `apps/web/src/lib/actions/watchlists.ts`
+ * used to discard the `NotifyIndexNowResult` envelope, leaving operators
+ * blind to rejection storms (e.g. a stale INDEXNOW_KEY cached on Bing
+ * for 24h after a rotation, with Yandex/Seznam returning 422/403). The
+ * helper plumbs every outcome to a single structured log line so the
+ * rejection rate is filterable in Vercel logs.
+ *
+ * These tests don't exercise `notifyIndexNow` itself — that surface is
+ * covered by `indexnow.test.ts`. We only assert the log-shape contract
+ * the helper produces from each envelope shape.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  logIndexNowResult,
+  INDEXNOW_LOG_EVENT,
+  type NotifyIndexNowResult,
+} from "../indexnow";
+
+let infoSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+let debugSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("logIndexNowResult", () => {
+  it("emits a console.info line with the stable event name for submitted results", () => {
+    const result: NotifyIndexNowResult = {
+      kind: "submitted",
+      status: 200,
+      urlCount: 4,
+    };
+    logIndexNowResult("createWatchlist", result);
+
+    expect(infoSpy).toHaveBeenCalledOnce();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(debugSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    const [event, payload] = infoSpy.mock.calls[0];
+    expect(event).toBe(INDEXNOW_LOG_EVENT);
+    expect(event).toBe("indexnow.result");
+    expect(payload).toMatchObject({
+      label: "createWatchlist",
+      kind: "submitted",
+      status: 200,
+      urlCount: 4,
+      host: "api.indexnow.org",
+    });
+  });
+
+  it("emits console.warn with status + host for rejected results (the actionable case)", () => {
+    const result: NotifyIndexNowResult = {
+      kind: "rejected",
+      status: 422,
+      urlCount: 8,
+    };
+    logIndexNowResult("updateWatchlist", result);
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(debugSpy).not.toHaveBeenCalled();
+
+    const [event, payload] = warnSpy.mock.calls[0];
+    expect(event).toBe(INDEXNOW_LOG_EVENT);
+    expect(payload).toMatchObject({
+      label: "updateWatchlist",
+      kind: "rejected",
+      status: 422,
+      urlCount: 8,
+      host: "api.indexnow.org",
+    });
+  });
+
+  it("emits console.warn with the error message (not the raw object) for errored results", () => {
+    const networkErr = new Error("ECONNRESET");
+    const result: NotifyIndexNowResult = {
+      kind: "errored",
+      error: networkErr,
+      urlCount: 4,
+    };
+    logIndexNowResult("deleteWatchlist", result);
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const [event, payload] = warnSpy.mock.calls[0];
+    expect(event).toBe(INDEXNOW_LOG_EVENT);
+    expect(payload).toMatchObject({
+      label: "deleteWatchlist",
+      kind: "errored",
+      error: "ECONNRESET",
+      urlCount: 4,
+    });
+  });
+
+  it("stringifies non-Error errored values defensively", () => {
+    // `notifyIndexNow` types `error` as `unknown`. A non-Error throw
+    // (string, number, AbortSignal timeout's DOMException-ish object)
+    // must still serialise cleanly to a log line.
+    const result: NotifyIndexNowResult = {
+      kind: "errored",
+      error: "raw string thrown",
+      urlCount: 4,
+    };
+    logIndexNowResult("copyWatchlist", result);
+
+    expect(warnSpy).toHaveBeenCalledOnce();
+    const payload = warnSpy.mock.calls[0][1] as { error: string };
+    expect(payload.error).toBe("raw string thrown");
+  });
+
+  it("emits console.debug (minimal output) for skipped results — preview deploys without INDEXNOW_KEY", () => {
+    const result: NotifyIndexNowResult = {
+      kind: "skipped",
+      reason: "no-key",
+    };
+    logIndexNowResult("createWatchlist", result);
+
+    expect(debugSpy).toHaveBeenCalledOnce();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    const [event, payload] = debugSpy.mock.calls[0];
+    expect(event).toBe(INDEXNOW_LOG_EVENT);
+    expect(payload).toMatchObject({
+      label: "createWatchlist",
+      kind: "skipped",
+      reason: "no-key",
+      urlCount: 0,
+    });
+  });
+
+  it("carries the call-site label through verbatim so logs are attributable", () => {
+    // Each of the 5 watchlist call sites passes a unique label; the
+    // helper must never rewrite it. This guards against an accidental
+    // refactor that collapses labels (e.g. via a default arg).
+    const labels = [
+      "createWatchlist",
+      "updateWatchlist",
+      "updateWatchlist:unpublish",
+      "deleteWatchlist",
+      "copyWatchlist",
+    ];
+    for (const label of labels) {
+      logIndexNowResult(label, {
+        kind: "submitted",
+        status: 200,
+        urlCount: 1,
+      });
+    }
+    expect(infoSpy).toHaveBeenCalledTimes(labels.length);
+    for (let i = 0; i < labels.length; i++) {
+      expect(infoSpy.mock.calls[i][1]).toMatchObject({ label: labels[i] });
+    }
+  });
+
+  it("uses the same stable event name for every outcome (one Vercel filter catches them all)", () => {
+    const envelopes: NotifyIndexNowResult[] = [
+      { kind: "submitted", status: 200, urlCount: 4 },
+      { kind: "skipped", reason: "no-key" },
+      { kind: "rejected", status: 403, urlCount: 4 },
+      { kind: "errored", error: new Error("boom"), urlCount: 4 },
+    ];
+    for (const r of envelopes) logIndexNowResult("test", r);
+
+    const allCalls = [
+      ...infoSpy.mock.calls,
+      ...debugSpy.mock.calls,
+      ...warnSpy.mock.calls,
+    ];
+    expect(allCalls).toHaveLength(envelopes.length);
+    for (const call of allCalls) {
+      expect(call[0]).toBe("indexnow.result");
+    }
+  });
+});

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -35,7 +35,7 @@ import {
   updateWatchlistField as tsUpdateWatchlistField,
 } from "@/lib/search/typesense-watchlist";
 import { isTrivialWatchlist } from "@/lib/watchlist-utils";
-import { notifyIndexNow } from "@/lib/indexnow";
+import { notifyIndexNow, logIndexNowResult } from "@/lib/indexnow";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -222,7 +222,8 @@ export async function createWatchlist(params: {
         // (see apps/web/src/lib/sitemap.ts — filters `u.username IS NOT NULL`).
         if (owner.username) {
           const userSlug = owner.displayUsername ?? owner.username;
-          await notifyIndexNow([`/${userSlug}/${slug}`]);
+          const r = await notifyIndexNow([`/${userSlug}/${slug}`]);
+          logIndexNowResult("createWatchlist", r);
         }
       } catch (err) {
         console.error("[createWatchlist] post-mutation hook failed", err);
@@ -357,7 +358,8 @@ export async function updateWatchlist(params: {
           // engines to discover that.
           const urls = [`/${userSlug}/${newSlug}`];
           if (newSlug !== wl.slug) urls.push(`/${userSlug}/${wl.slug}`);
-          await notifyIndexNow(urls);
+          const r = await notifyIndexNow(urls);
+          logIndexNowResult("updateWatchlist", r);
         }
       } else if (wasPublic) {
         // Was indexed and shouldn't be now — delete from Typesense and
@@ -368,7 +370,8 @@ export async function updateWatchlist(params: {
         const owner = await _getOwnerInfo(userId);
         if (owner?.username) {
           const userSlug = owner.displayUsername ?? owner.username;
-          await notifyIndexNow([`/${userSlug}/${wl.slug}`]);
+          const r = await notifyIndexNow([`/${userSlug}/${wl.slug}`]);
+          logIndexNowResult("updateWatchlist:unpublish", r);
         }
       }
     } catch (err) {
@@ -408,7 +411,8 @@ export async function deleteWatchlist(
         const owner = await _getOwnerInfo(userId);
         if (owner?.username) {
           const userSlug = owner.displayUsername ?? owner.username;
-          await notifyIndexNow([`/${userSlug}/${wl.slug}`]);
+          const r = await notifyIndexNow([`/${userSlug}/${wl.slug}`]);
+          logIndexNowResult("deleteWatchlist", r);
         }
       }
     } catch (err) {
@@ -525,7 +529,8 @@ export async function copyWatchlist(
         });
         if (owner.username) {
           const userSlug = owner.displayUsername ?? owner.username;
-          await notifyIndexNow([`/${userSlug}/${slug}`]);
+          const r = await notifyIndexNow([`/${userSlug}/${slug}`]);
+          logIndexNowResult("copyWatchlist", r);
         }
       } catch (err) {
         console.error("[copyWatchlist] Typesense upsert hook failed", err);

--- a/apps/web/src/lib/indexnow.ts
+++ b/apps/web/src/lib/indexnow.ts
@@ -118,3 +118,91 @@ function encodePath(path: string): string {
     .map((segment) => (segment ? encodeURIComponent(segment) : segment))
     .join("/");
 }
+
+/**
+ * Stable event name used by every structured log line emitted from
+ * `logIndexNowResult`. Filter Vercel logs by this prefix to aggregate
+ * IndexNow outcomes across all watchlist call sites (#3202).
+ */
+export const INDEXNOW_LOG_EVENT = "indexnow.result";
+
+/**
+ * Hostname of the IndexNow aggregator. The IndexNow protocol uses a
+ * single endpoint that fans out to Bing, Yandex, Seznam, Naver, and
+ * Microsoft Yep — there is no per-engine status code returned to the
+ * submitter, so the `host` field is necessarily the aggregator and
+ * the status code is whatever it returns (typically 200/202 on accept,
+ * 4xx on key/quota issues). The blog-side script in
+ * `apps/web/script/notify-blog-indexnow.ts` makes the same trade-off.
+ */
+const INDEXNOW_HOST = "api.indexnow.org";
+
+/**
+ * Emit a single structured log line for an IndexNow result, so the
+ * rejection rate / skip rate / error rate can be aggregated from
+ * Vercel function logs (#3202). Previously, every watchlist call site
+ * discarded the `NotifyIndexNowResult` envelope — a 422 storm from
+ * Yandex after a key rotation was invisible to operators, and a
+ * `skipped: "no-key"` on a preview deploy without `INDEXNOW_KEY` was
+ * silent. Pairs with `notifyIndexNow`'s already-correct return shape.
+ *
+ * Log level is chosen so production filtering surfaces only the
+ * actionable cases by default:
+ *
+ *   - `submitted` → `console.info`  (normal path, low signal)
+ *   - `skipped`   → `console.debug` (no-op; expected on previews)
+ *   - `rejected`  → `console.warn`  (HTTP non-2xx — actionable)
+ *   - `errored`   → `console.warn`  (network/abort — actionable)
+ *
+ * All lines start with the stable event name {@link INDEXNOW_LOG_EVENT}
+ * (`"indexnow.result"`) as their first argument so a single Vercel log
+ * filter catches every outcome. The structured payload follows as the
+ * second argument; Vercel's log viewer preserves it as JSON.
+ *
+ * @param label Short call-site identifier — e.g. `"createWatchlist"`.
+ *              Surfaces in the log line so operators can attribute a
+ *              rejection storm to the right server action without
+ *              digging through stack traces.
+ * @param result The envelope returned by `notifyIndexNow`.
+ */
+export function logIndexNowResult(
+  label: string,
+  result: NotifyIndexNowResult,
+): void {
+  switch (result.kind) {
+    case "submitted":
+      console.info(INDEXNOW_LOG_EVENT, {
+        label,
+        kind: "submitted",
+        status: result.status,
+        urlCount: result.urlCount,
+        host: INDEXNOW_HOST,
+      });
+      return;
+    case "skipped":
+      console.debug(INDEXNOW_LOG_EVENT, {
+        label,
+        kind: "skipped",
+        reason: result.reason,
+        urlCount: 0,
+      });
+      return;
+    case "rejected":
+      console.warn(INDEXNOW_LOG_EVENT, {
+        label,
+        kind: "rejected",
+        status: result.status,
+        urlCount: result.urlCount,
+        host: INDEXNOW_HOST,
+      });
+      return;
+    case "errored":
+      console.warn(INDEXNOW_LOG_EVENT, {
+        label,
+        kind: "errored",
+        error: result.error instanceof Error ? result.error.message : String(result.error),
+        urlCount: result.urlCount,
+      });
+      return;
+  }
+}


### PR DESCRIPTION
## Summary

The 5 web-side `notifyIndexNow()` call sites in `apps/web/src/lib/actions/watchlists.ts` discarded the `NotifyIndexNowResult` envelope. Result: a 422 storm from Yandex after a key rotation, or a `skipped:"no-key"` on a preview deploy without `INDEXNOW_KEY`, were both invisible. Closes #3202.

## Changes

- **`apps/web/src/lib/indexnow.ts`** — exports new helper `logIndexNowResult(label, result)` plus the stable event name `INDEXNOW_LOG_EVENT = "indexnow.result"`. `notifyIndexNow` itself is untouched (per scope).
- **`apps/web/src/lib/actions/watchlists.ts`** — 5 call sites now capture the result and pass it to the helper:
  - `createWatchlist`
  - `updateWatchlist`
  - `updateWatchlist:unpublish`
  - `deleteWatchlist`
  - `copyWatchlist`
- **`apps/web/src/lib/__tests__/indexnow-observability.test.ts`** — new file, 7 tests.

## Log shape

Every outcome emits a single line, all sharing event name `"indexnow.result"` (so one Vercel filter catches every outcome):

| `kind`      | Level             | Fields                                                           |
| ----------- | ----------------- | ---------------------------------------------------------------- |
| `submitted` | `console.info`    | `label`, `kind`, `status`, `urlCount`, `host`                    |
| `skipped`   | `console.debug`   | `label`, `kind`, `reason`, `urlCount` (always 0)                 |
| `rejected`  | `console.warn`    | `label`, `kind`, `status`, `urlCount`, `host`                    |
| `errored`   | `console.warn`    | `label`, `kind`, `error` (stringified message), `urlCount`       |

`host` is `api.indexnow.org` (the aggregator). The IndexNow protocol fans out to Bing/Yandex/Seznam/Naver/Yep from one POST and doesn't return per-engine status to the submitter, so per-engine `host` isn't reachable from this layer — the blog-side script makes the same trade-off.

## Precedent

The blog-side script `apps/web/script/notify-blog-indexnow.ts` already reads the result envelope to fail its workflow on rejections. This PR brings the watchlist side up to parity. The blog script is **untouched** (per scope).

## Test plan

- [x] `pnpm test` — 102 files, 888 tests passing (incl. 7 new)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec eslint <changed files>` — clean
- [ ] Manual verification post-deploy: rotate `INDEXNOW_KEY` on a preview, mutate a watchlist, confirm a `kind:"rejected"` line shows up in Vercel logs filtered on `indexnow.result`

🤖 Generated with [Claude Code](https://claude.com/claude-code)