### PR TITLE
fix(web): use timestamptz for Better-Auth + user_preferences columns (closes #3204)

### DIFF
--- a/apps/web/drizzle/0079_tz_aware_auth_columns.sql
+++ b/apps/web/drizzle/0079_tz_aware_auth_columns.sql
@@ -1,0 +1,112 @@
+-- Convert Better-Auth + user_preferences timestamp columns to timestamptz (#3204).
+--
+-- Backstory: Drizzle's `timestamp(...)` defaults to `timestamp without time
+-- zone`. The Better-Auth schema and `user_preferences` were declared this
+-- way at table-creation time (0000 / 0058 / 0059 / 0067 / 0069). When the
+-- Node app writes a JS `Date` instant via `postgres-js`, the driver
+-- serialises the wall-clock seen by the client and Postgres stores it as
+-- a bare local-time string with no offset info. On read, the driver
+-- reinterprets the string using the DB session's `TimeZone` GUC.
+--
+-- That breaks the moment writer TZ ≠ reader TZ:
+-- * Hetzner DB defaulting to `Europe/Berlin` reading a token written by
+--   a Vercel function in UTC → all auth timestamps drift by 2 hours.
+-- * Dev box on `TZ=Europe/Berlin` writes 23:00 UTC, the bare timestamp
+--   `2026-05-14 01:00:00` lands in the column. Better-Auth reads it back
+--   via a UTC connection and sees a TTL that is 2 hours longer than
+--   intended.
+-- * The same applies to `accessTokenExpiresAt` / `refreshTokenExpiresAt`:
+--   OAuth token validity windows drift by the wall-clock offset between
+--   writer and reader.
+--
+-- Fix: switch every affected column to `timestamp with time zone`. The
+-- `AT TIME ZONE 'UTC'` clause in the USING expression is load-bearing —
+-- it tells Postgres "reinterpret the existing wall-clock strings as if
+-- they were UTC instants", which matches how the Node app actually
+-- wrote them. Without this, Postgres uses the server's session timezone
+-- (which on Hetzner is `Europe/Berlin`) and existing rows shift by N
+-- hours — sessions reset, OAuth tokens look expired.
+--
+-- Why hand-written: drizzle-kit's auto-generated `SET DATA TYPE
+-- timestamp with time zone` omits the USING expression, so it falls
+-- back to the implicit cast which uses the session TZ. We have to spell
+-- out `USING ... AT TIME ZONE 'UTC'` ourselves. See 0021 for the
+-- precedent of an in-place TZ-naive → TZ-aware conversion (job_posting,
+-- which got it without the USING clause back when prod was small).
+--
+-- Affected columns (15 total):
+--   user.created_at / updated_at
+--   session.expires_at / created_at / updated_at
+--   account.access_token_expires_at / refresh_token_expires_at /
+--     created_at / updated_at
+--   verification.expires_at / created_at / updated_at
+--   user_preferences.theme_updated_at / locale_updated_at /
+--     last_password_reset_at / updated_at
+--
+-- Operator note: ALTER COLUMN ... SET DATA TYPE rewrites the column,
+-- which takes an `AccessExclusiveLock` on each table for the duration
+-- of the rewrite. Auth tables are tiny relative to job_posting, so
+-- this should be sub-second on prod. Run during a low-traffic window
+-- anyway — Better-Auth holds open `session` reads on every request.
+
+BEGIN;
+
+-- ── user ────────────────────────────────────────────────────────────
+ALTER TABLE "user"
+  ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone
+    USING "created_at" AT TIME ZONE 'UTC';
+ALTER TABLE "user"
+  ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone
+    USING "updated_at" AT TIME ZONE 'UTC';
+
+-- ── session ─────────────────────────────────────────────────────────
+ALTER TABLE "session"
+  ALTER COLUMN "expires_at" SET DATA TYPE timestamp with time zone
+    USING "expires_at" AT TIME ZONE 'UTC';
+ALTER TABLE "session"
+  ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone
+    USING "created_at" AT TIME ZONE 'UTC';
+ALTER TABLE "session"
+  ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone
+    USING "updated_at" AT TIME ZONE 'UTC';
+
+-- ── account ─────────────────────────────────────────────────────────
+ALTER TABLE "account"
+  ALTER COLUMN "access_token_expires_at" SET DATA TYPE timestamp with time zone
+    USING "access_token_expires_at" AT TIME ZONE 'UTC';
+ALTER TABLE "account"
+  ALTER COLUMN "refresh_token_expires_at" SET DATA TYPE timestamp with time zone
+    USING "refresh_token_expires_at" AT TIME ZONE 'UTC';
+ALTER TABLE "account"
+  ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone
+    USING "created_at" AT TIME ZONE 'UTC';
+ALTER TABLE "account"
+  ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone
+    USING "updated_at" AT TIME ZONE 'UTC';
+
+-- ── verification ────────────────────────────────────────────────────
+ALTER TABLE "verification"
+  ALTER COLUMN "expires_at" SET DATA TYPE timestamp with time zone
+    USING "expires_at" AT TIME ZONE 'UTC';
+ALTER TABLE "verification"
+  ALTER COLUMN "created_at" SET DATA TYPE timestamp with time zone
+    USING "created_at" AT TIME ZONE 'UTC';
+ALTER TABLE "verification"
+  ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone
+    USING "updated_at" AT TIME ZONE 'UTC';
+
+-- ── user_preferences ────────────────────────────────────────────────
+ALTER TABLE "user_preferences"
+  ALTER COLUMN "theme_updated_at" SET DATA TYPE timestamp with time zone
+    USING "theme_updated_at" AT TIME ZONE 'UTC';
+ALTER TABLE "user_preferences"
+  ALTER COLUMN "locale_updated_at" SET DATA TYPE timestamp with time zone
+    USING "locale_updated_at" AT TIME ZONE 'UTC';
+ALTER TABLE "user_preferences"
+  ALTER COLUMN "last_password_reset_at" SET DATA TYPE timestamp with time zone
+    USING "last_password_reset_at" AT TIME ZONE 'UTC';
+ALTER TABLE "user_preferences"
+  ALTER COLUMN "updated_at" SET DATA TYPE timestamp with time zone
+    USING "updated_at" AT TIME ZONE 'UTC';
+
+COMMIT;

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -491,6 +491,13 @@
       "when": 1778976000000,
       "tag": "0078_application_interview_unique_round",
       "breakpoints": true
+    },
+    {
+      "idx": 70,
+      "version": "7",
+      "when": 1779148800000,
+      "tag": "0079_tz_aware_auth_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/db/__tests__/timestamptz-coverage.test.ts
+++ b/apps/web/src/db/__tests__/timestamptz-coverage.test.ts
@@ -1,0 +1,160 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+import { getTableColumns } from "drizzle-orm";
+import { PgTimestamp } from "drizzle-orm/pg-core";
+
+import {
+  account,
+  session,
+  user,
+  userPreferences,
+  verification,
+} from "@/db/schema";
+
+/**
+ * Coverage for #3204. Better-Auth + user_preferences columns used to be
+ * declared as TZ-naive `timestamp(...)`, which made auth-token TTLs
+ * silently drift whenever the writer and reader disagreed about the
+ * session timezone. Both axes are pinned here:
+ *
+ * 1. Drizzle introspection — every affected column reports
+ *    `withTimezone === true`, so the TS schema (which Better-Auth
+ *    consumes via the drizzle adapter) keeps round-tripping `Date`
+ *    instants correctly.
+ * 2. Migration SQL — the 0079 hand-written migration includes the
+ *    `AT TIME ZONE 'UTC'` clause for every column. That clause is
+ *    load-bearing: without it Postgres uses the session TZ to
+ *    reinterpret existing rows, which on Hetzner (Europe/Berlin)
+ *    would shift every auth timestamp by 2 hours and reset every
+ *    session.
+ */
+
+const AFFECTED_COLUMNS = [
+  // user
+  { table: user, tableName: "user", column: "created_at" },
+  { table: user, tableName: "user", column: "updated_at" },
+  // session
+  { table: session, tableName: "session", column: "expires_at" },
+  { table: session, tableName: "session", column: "created_at" },
+  { table: session, tableName: "session", column: "updated_at" },
+  // account
+  { table: account, tableName: "account", column: "access_token_expires_at" },
+  { table: account, tableName: "account", column: "refresh_token_expires_at" },
+  { table: account, tableName: "account", column: "created_at" },
+  { table: account, tableName: "account", column: "updated_at" },
+  // verification
+  { table: verification, tableName: "verification", column: "expires_at" },
+  { table: verification, tableName: "verification", column: "created_at" },
+  { table: verification, tableName: "verification", column: "updated_at" },
+  // user_preferences
+  {
+    table: userPreferences,
+    tableName: "user_preferences",
+    column: "theme_updated_at",
+  },
+  {
+    table: userPreferences,
+    tableName: "user_preferences",
+    column: "locale_updated_at",
+  },
+  {
+    table: userPreferences,
+    tableName: "user_preferences",
+    column: "last_password_reset_at",
+  },
+  {
+    table: userPreferences,
+    tableName: "user_preferences",
+    column: "updated_at",
+  },
+] as const;
+
+function findColumn(table: unknown, sqlName: string) {
+  const cols = getTableColumns(table as Parameters<typeof getTableColumns>[0]);
+  for (const value of Object.values(cols)) {
+    if ((value as { name: string }).name === sqlName) return value;
+  }
+  return undefined;
+}
+
+describe("Better-Auth + user_preferences TZ-aware schema (#3204)", () => {
+  it.each(AFFECTED_COLUMNS)(
+    "$tableName.$column is declared with withTimezone=true",
+    ({ table, column }) => {
+      const col = findColumn(table, column);
+      expect(col, `column ${column} not found in schema`).toBeDefined();
+      // Belt-and-braces: the column must be a PgTimestamp (not, say,
+      // PgTimestampString) AND the timezone flag must be on.
+      expect(col).toBeInstanceOf(PgTimestamp);
+      expect((col as PgTimestamp<never>).withTimezone).toBe(true);
+    },
+  );
+});
+
+describe("0079_tz_aware_auth_columns migration uses AT TIME ZONE 'UTC'", () => {
+  const migrationPath = join(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "drizzle",
+    "0079_tz_aware_auth_columns.sql",
+  );
+  const sql = readFileSync(migrationPath, "utf8");
+
+  it.each(AFFECTED_COLUMNS)(
+    "$tableName.$column has TYPE timestamp with time zone USING ... AT TIME ZONE 'UTC'",
+    ({ tableName, column }) => {
+      // Match the ALTER TABLE ... ALTER COLUMN ... USING line for this
+      // (table, column) pair. The line MUST end in "AT TIME ZONE 'UTC'"
+      // — anything else (default cast, AT TIME ZONE 'Europe/Berlin',
+      // …) shifts existing rows by N hours.
+      const pattern = new RegExp(
+        `ALTER TABLE\\s+"${tableName}"[\\s\\S]*?` +
+          `ALTER COLUMN\\s+"${column}"\\s+SET DATA TYPE\\s+timestamp with time zone\\s+` +
+          `USING\\s+"${column}"\\s+AT TIME ZONE\\s+'UTC'`,
+      );
+      expect(sql).toMatch(pattern);
+    },
+  );
+
+  // Strip SQL line comments so the prose header (which discusses
+  // AT TIME ZONE 'UTC' in english) doesn't get counted as actual SQL.
+  const sqlNoComments = sql
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("--"))
+    .join("\n");
+
+  it("has exactly one AT TIME ZONE 'UTC' clause per affected column (in SQL, not comments)", () => {
+    const matches = sqlNoComments.match(/AT TIME ZONE\s+'UTC'/g) ?? [];
+    expect(matches).toHaveLength(AFFECTED_COLUMNS.length);
+  });
+
+  it("references only 'UTC' as the source timezone — no host-local TZ", () => {
+    // Any AT TIME ZONE 'X' where X !== 'UTC' would silently reinterpret
+    // rows using a non-UTC origin, which is exactly the bug.
+    const tzClauses = sqlNoComments.match(/AT TIME ZONE\s+'([^']+)'/g) ?? [];
+    for (const clause of tzClauses) {
+      expect(clause).toMatch(/AT TIME ZONE\s+'UTC'/);
+    }
+  });
+
+  it("is registered in drizzle's _journal.json", () => {
+    const journalPath = join(
+      __dirname,
+      "..",
+      "..",
+      "..",
+      "drizzle",
+      "meta",
+      "_journal.json",
+    );
+    const journal = JSON.parse(readFileSync(journalPath, "utf8")) as {
+      entries: { tag: string }[];
+    };
+    const tags = journal.entries.map((e) => e.tag);
+    expect(tags).toContain("0079_tz_aware_auth_columns");
+  });
+});

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -28,8 +28,10 @@ export const user = pgTable("user", {
   image: text("image"),
   username: text("username").unique(),
   displayUsername: text("display_username"),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  updatedAt: timestamp("updated_at")
+  createdAt: timestamp("created_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
     .defaultNow()
     .$onUpdate(() => new Date())
     .notNull(),
@@ -39,10 +41,12 @@ export const session = pgTable(
   "session",
   {
     id: text("id").primaryKey(),
-    expiresAt: timestamp("expires_at").notNull(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
     token: text("token").notNull().unique(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
       .$onUpdate(() => new Date())
       .notNull(),
     ipAddress: text("ip_address"),
@@ -66,12 +70,18 @@ export const account = pgTable(
     accessToken: text("access_token"),
     refreshToken: text("refresh_token"),
     idToken: text("id_token"),
-    accessTokenExpiresAt: timestamp("access_token_expires_at"),
-    refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+    accessTokenExpiresAt: timestamp("access_token_expires_at", {
+      withTimezone: true,
+    }),
+    refreshTokenExpiresAt: timestamp("refresh_token_expires_at", {
+      withTimezone: true,
+    }),
     scope: text("scope"),
     password: text("password"),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
       .$onUpdate(() => new Date())
       .notNull(),
   },
@@ -84,9 +94,11 @@ export const verification = pgTable(
     id: text("id").primaryKey(),
     identifier: text("identifier").notNull(),
     value: text("value").notNull(),
-    expiresAt: timestamp("expires_at").notNull(),
-    createdAt: timestamp("created_at").defaultNow().notNull(),
-    updatedAt: timestamp("updated_at")
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
       .defaultNow()
       .$onUpdate(() => new Date())
       .notNull(),
@@ -111,10 +123,12 @@ export const userPreferences = pgTable("user_preferences", {
   salaryPeriod: text("salary_period"),
   cookieConsent: boolean("cookie_consent").default(false).notNull(),
   dismissedBanners: text("dismissed_banners").array().notNull().default([]),
-  themeUpdatedAt: timestamp("theme_updated_at"),
-  localeUpdatedAt: timestamp("locale_updated_at"),
-  lastPasswordResetAt: timestamp("last_password_reset_at"),
-  updatedAt: timestamp("updated_at")
+  themeUpdatedAt: timestamp("theme_updated_at", { withTimezone: true }),
+  localeUpdatedAt: timestamp("locale_updated_at", { withTimezone: true }),
+  lastPasswordResetAt: timestamp("last_password_reset_at", {
+    withTimezone: true,
+  }),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
     .defaultNow()
     .$onUpdate(() => new Date())
     .notNull(),


### PR DESCRIPTION
## Concrete bug scenario

Drizzle's `timestamp(...)` defaults to `timestamp without time zone`. The Better-Auth schema and `user_preferences` were declared TZ-naive at table-creation time, so the Node app's JS `Date` instants were serialized by `postgres-js` as bare local-time strings without offset info. On read the driver reinterprets them using the DB session's `TimeZone` GUC, which produces silently wrong values the moment writer TZ ≠ reader TZ.

From the issue (#3204):

> For a user signing in at **2026-05-13 23:00 UTC** on a dev box running `TZ=Europe/Berlin` (UTC+2):
> * App writes the instant as a `Date`.
> * Driver serializes wall-clock seen by the app: `2026-05-14 01:00:00`.
> * DB stores `2026-05-14 01:00:00` as bare timestamp.
> * Better-Auth then compares server `now()` against `expiresAt`. If the DB session is UTC, `now()` is `2026-05-13 23:00`, and the comparison "is expiresAt > now()" looks correct — but the actual TTL is 2 hours longer than intended.

The same applies to `accessTokenExpiresAt` / `refreshTokenExpiresAt`: OAuth token validity windows drift by the wall-clock offset between writer and reader.

## Schema diff (15 columns)

`apps/web/src/db/schema.ts` — every `timestamp("...")` for the listed columns now has `{ withTimezone: true }`:

- `user.createdAt` / `updatedAt`
- `session.expiresAt` / `createdAt` / `updatedAt`
- `account.accessTokenExpiresAt` / `refreshTokenExpiresAt` / `createdAt` / `updatedAt`
- `verification.expiresAt` / `createdAt` / `updatedAt`
- `userPreferences.themeUpdatedAt` / `localeUpdatedAt` / `lastPasswordResetAt` / `updatedAt`

TS types don't change (still `Date` / `Date | null`), so Better-Auth — which consumes the schema via the drizzle adapter — is unaffected by the change.

## Migration: `AT TIME ZONE 'UTC'` is load-bearing

`apps/web/drizzle/0079_tz_aware_auth_columns.sql` is hand-written because drizzle-kit's auto-generated `ALTER COLUMN ... SET DATA TYPE timestamp with time zone` omits the `USING` expression. That falls back to an implicit cast that uses the **session timezone** — on Hetzner-local Postgres (which defaults to `Europe/Berlin`) that would shift every existing row by 2 hours and reset every active session.

The migration spells the source TZ out explicitly:

```sql
ALTER TABLE "session"
  ALTER COLUMN "expires_at" SET DATA TYPE timestamp with time zone
    USING "expires_at" AT TIME ZONE 'UTC';
```

…for every one of the 15 columns. `AT TIME ZONE 'UTC'` tells Postgres "reinterpret the existing wall-clock string as a UTC instant", which matches how Node was writing them.

## Tests

`apps/web/src/db/__tests__/timestamptz-coverage.test.ts` — 35 assertions across two axes:

1. **Drizzle introspection** — every affected column reports `withTimezone === true` via `getTableColumns` + `PgTimestamp.withTimezone`. This is what Better-Auth sees through the drizzle adapter, so if a future PR drops `{ withTimezone: true }` from any of the 15 entries, the test fails.
2. **Migration SQL inspection** — every column has an `ALTER ... SET DATA TYPE timestamp with time zone USING ... AT TIME ZONE 'UTC'` line; the count of `AT TIME ZONE 'UTC'` clauses (outside comments) equals 15; no other TZ literal slipped in; the migration is registered in `_journal.json`.

All 923 web tests pass; `pnpm exec tsc --noEmit` is clean.

## Operator note

Apply during a low-traffic window. `ALTER COLUMN ... SET DATA TYPE` takes `AccessExclusiveLock` per table for the column-rewrite duration. Auth tables are tiny relative to `job_posting` (sub-second rewrite expected), but Better-Auth holds open `session` reads on every request — concurrent traffic will queue against the lock.

The migration is wrapped in a single `BEGIN; ... COMMIT;` block so it's atomic per-deploy: either all 15 columns flip, or none do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)