### PR TITLE
fix(security): wire up passwordResetLimiter on auth reset paths (closes #3223)

### DIFF
--- a/apps/web/app/api/auth/[...all]/__tests__/route.test.ts
+++ b/apps/web/app/api/auth/[...all]/__tests__/route.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+/**
+ * Issue colophon-group/jobseek#3223 — `passwordResetLimiter` was defined in
+ * `@/lib/rate-limit` (3 requests / 300 s, prefix `rl:pw-reset`) but never
+ * called in production. Better-Auth's password-reset flow runs through the
+ * `/api/auth/[...all]` catch-all, which only consulted the broader
+ * `authLimiter` (10/60s). An attacker could issue ten reset emails per
+ * minute per IP via Resend.
+ *
+ * These specs lock in the wiring:
+ *   1. Requests to `/api/auth/request-password-reset` (POST), `/api/auth/
+ *      reset-password` (POST), and `/api/auth/reset-password/:token` (GET)
+ *      consult `passwordResetLimiter` BEFORE `authLimiter`.
+ *   2. The 4th reset-path request in a 300 s window returns 429 with a
+ *      `Retry-After` header.
+ *   3. Non-reset auth paths (sign-in, sign-up, OAuth callbacks) are NOT
+ *      gated by `passwordResetLimiter` — `authLimiter` alone still applies.
+ *   4. Redis outages degrade OPEN (we never fail-closed on auth), matching
+ *      the pre-existing `authLimiter` failure mode.
+ *   5. The rate-limit key is the platform-authoritative IP from
+ *      `getClientIp`, which is hardened against `x-forwarded-for`
+ *      spoofing (#3219).
+ */
+
+vi.mock("server-only", () => ({}));
+
+// Capture each call to either limiter so tests can assert call order and
+// per-limiter call counts.
+const limiterCalls = vi.hoisted(() => ({
+  authLimit: vi.fn(),
+  passwordResetLimit: vi.fn(),
+  getClientIp: vi.fn(),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  authLimiter: { limit: limiterCalls.authLimit },
+  passwordResetLimiter: { limit: limiterCalls.passwordResetLimit },
+  getClientIp: limiterCalls.getClientIp,
+}));
+
+const betterAuthHandlers = vi.hoisted(() => ({
+  GET: vi.fn(),
+  POST: vi.fn(),
+}));
+
+vi.mock("better-auth/next-js", () => ({
+  toNextJsHandler: () => ({
+    GET: betterAuthHandlers.GET,
+    POST: betterAuthHandlers.POST,
+  }),
+}));
+
+// `@/lib/auth` re-exports a fully-configured Better-Auth instance which
+// pulls in drizzle, the username plugin, etc. We only care that the
+// route's pre-handler logic runs before delegating, so stub it out.
+vi.mock("@/lib/auth", () => ({ auth: { handler: vi.fn() } }));
+
+function makeRequest(
+  method: "GET" | "POST",
+  pathname: string,
+  ip = "203.0.113.7",
+): NextRequest {
+  const url = new URL(pathname, "https://example.com").toString();
+  return new NextRequest(url, {
+    method,
+    headers: { "x-forwarded-for": ip },
+  });
+}
+
+const RESET_OK = { success: true, limit: 3, remaining: 2, reset: 0 };
+const AUTH_OK = { success: true, limit: 10, remaining: 9, reset: 0 };
+
+describe("auth catch-all route — passwordResetLimiter wiring (#3223)", () => {
+  beforeEach(() => {
+    limiterCalls.authLimit.mockReset();
+    limiterCalls.passwordResetLimit.mockReset();
+    limiterCalls.getClientIp.mockReset();
+    betterAuthHandlers.GET.mockReset();
+    betterAuthHandlers.POST.mockReset();
+
+    limiterCalls.getClientIp.mockReturnValue("203.0.113.7");
+    limiterCalls.authLimit.mockResolvedValue(AUTH_OK);
+    limiterCalls.passwordResetLimit.mockResolvedValue(RESET_OK);
+    betterAuthHandlers.GET.mockResolvedValue(new Response("ok"));
+    betterAuthHandlers.POST.mockResolvedValue(new Response("ok"));
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  // --- A: reset paths consult passwordResetLimiter ----------------------
+
+  it("POST /api/auth/request-password-reset consults passwordResetLimiter before delegating", async () => {
+    const { POST } = await import("../route");
+
+    const res = await POST(makeRequest("POST", "/api/auth/request-password-reset"));
+
+    expect(res.status).toBe(200);
+    expect(limiterCalls.passwordResetLimit).toHaveBeenCalledTimes(1);
+    expect(limiterCalls.passwordResetLimit.mock.calls[0][0]).toBe("203.0.113.7");
+    expect(betterAuthHandlers.POST).toHaveBeenCalledTimes(1);
+  });
+
+  it("POST /api/auth/reset-password consults passwordResetLimiter before delegating", async () => {
+    const { POST } = await import("../route");
+
+    const res = await POST(makeRequest("POST", "/api/auth/reset-password"));
+
+    expect(res.status).toBe(200);
+    expect(limiterCalls.passwordResetLimit).toHaveBeenCalledTimes(1);
+    expect(betterAuthHandlers.POST).toHaveBeenCalledTimes(1);
+  });
+
+  it("GET /api/auth/reset-password/:token consults passwordResetLimiter (token-validity oracle)", async () => {
+    const { GET } = await import("../route");
+
+    const res = await GET(
+      makeRequest("GET", "/api/auth/reset-password/some-token-abcdef"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(limiterCalls.passwordResetLimit).toHaveBeenCalledTimes(1);
+    expect(betterAuthHandlers.GET).toHaveBeenCalledTimes(1);
+  });
+
+  // --- B: 4th request in window is rejected with 429 --------------------
+
+  it("blocks the 4th reset request within the 300 s window with 429 + Retry-After", async () => {
+    // First three calls succeed (3/300s — the limiter contract), the
+    // fourth returns success:false.
+    limiterCalls.passwordResetLimit
+      .mockResolvedValueOnce(RESET_OK)
+      .mockResolvedValueOnce(RESET_OK)
+      .mockResolvedValueOnce(RESET_OK)
+      .mockResolvedValueOnce({
+        success: false,
+        limit: 3,
+        remaining: 0,
+        reset: Date.now() + 250_000,
+      });
+
+    const { POST } = await import("../route");
+
+    for (let i = 0; i < 3; i++) {
+      const res = await POST(
+        makeRequest("POST", "/api/auth/request-password-reset"),
+      );
+      expect(res.status).toBe(200);
+    }
+
+    const blocked = await POST(
+      makeRequest("POST", "/api/auth/request-password-reset"),
+    );
+
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get("Retry-After")).toBeTruthy();
+    // Better-Auth handler is NOT invoked when the limiter blocks.
+    expect(betterAuthHandlers.POST).toHaveBeenCalledTimes(3);
+  });
+
+  // --- C: non-reset paths skip passwordResetLimiter ---------------------
+
+  it("POST /api/auth/sign-in/email does NOT consult passwordResetLimiter", async () => {
+    const { POST } = await import("../route");
+
+    const res = await POST(makeRequest("POST", "/api/auth/sign-in/email"));
+
+    expect(res.status).toBe(200);
+    expect(limiterCalls.passwordResetLimit).not.toHaveBeenCalled();
+    expect(limiterCalls.authLimit).toHaveBeenCalledTimes(1);
+    expect(betterAuthHandlers.POST).toHaveBeenCalledTimes(1);
+  });
+
+  it("POST /api/auth/sign-up/email does NOT consult passwordResetLimiter", async () => {
+    const { POST } = await import("../route");
+
+    const res = await POST(makeRequest("POST", "/api/auth/sign-up/email"));
+
+    expect(res.status).toBe(200);
+    expect(limiterCalls.passwordResetLimit).not.toHaveBeenCalled();
+    expect(limiterCalls.authLimit).toHaveBeenCalledTimes(1);
+  });
+
+  it("GET /api/auth/callback/github (OAuth callback) does NOT consult passwordResetLimiter", async () => {
+    const { GET } = await import("../route");
+
+    const res = await GET(makeRequest("GET", "/api/auth/callback/github"));
+
+    expect(res.status).toBe(200);
+    expect(limiterCalls.passwordResetLimit).not.toHaveBeenCalled();
+    expect(limiterCalls.authLimit).toHaveBeenCalledTimes(1);
+  });
+
+  // --- D: defence-in-depth — authLimiter also applies on reset paths ----
+
+  it("reset paths still consult authLimiter (defence-in-depth on the 10/60s axis)", async () => {
+    const { POST } = await import("../route");
+
+    await POST(makeRequest("POST", "/api/auth/request-password-reset"));
+
+    expect(limiterCalls.passwordResetLimit).toHaveBeenCalledTimes(1);
+    expect(limiterCalls.authLimit).toHaveBeenCalledTimes(1);
+  });
+
+  it("authLimiter still gates reset paths if passwordResetLimiter allows but authLimiter blocks", async () => {
+    limiterCalls.passwordResetLimit.mockResolvedValue(RESET_OK);
+    limiterCalls.authLimit.mockResolvedValue({
+      success: false,
+      limit: 10,
+      remaining: 0,
+      reset: Date.now() + 30_000,
+    });
+
+    const { POST } = await import("../route");
+
+    const res = await POST(makeRequest("POST", "/api/auth/request-password-reset"));
+
+    expect(res.status).toBe(429);
+    expect(betterAuthHandlers.POST).not.toHaveBeenCalled();
+  });
+
+  // --- E: Redis outage degrades open ------------------------------------
+
+  it("passwordResetLimiter throwing (Redis outage) lets the request through", async () => {
+    limiterCalls.passwordResetLimit.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const { POST } = await import("../route");
+
+    const res = await POST(makeRequest("POST", "/api/auth/request-password-reset"));
+
+    expect(res.status).toBe(200);
+    expect(limiterCalls.authLimit).toHaveBeenCalledTimes(1);
+    expect(betterAuthHandlers.POST).toHaveBeenCalledTimes(1);
+  });
+
+  it("authLimiter throwing (Redis outage) lets the request through", async () => {
+    limiterCalls.authLimit.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const { POST } = await import("../route");
+
+    const res = await POST(makeRequest("POST", "/api/auth/sign-in/email"));
+
+    expect(res.status).toBe(200);
+    expect(betterAuthHandlers.POST).toHaveBeenCalledTimes(1);
+  });
+
+  // --- F: rate-limit key is the platform-authoritative IP ---------------
+
+  it("uses getClientIp output as the rate-limit identifier (#3219 hardening)", async () => {
+    limiterCalls.getClientIp.mockReturnValue("198.51.100.42");
+
+    const { POST } = await import("../route");
+
+    await POST(makeRequest("POST", "/api/auth/request-password-reset"));
+
+    expect(limiterCalls.passwordResetLimit.mock.calls[0][0]).toBe("198.51.100.42");
+    expect(limiterCalls.authLimit.mock.calls[0][0]).toBe("198.51.100.42");
+  });
+
+  // --- G: passwordResetLimiter is consulted BEFORE authLimiter ---------
+
+  it("calls passwordResetLimiter before authLimiter on reset paths (so the tighter axis wins on coincident exhaustion)", async () => {
+    const order: string[] = [];
+    limiterCalls.passwordResetLimit.mockImplementation(async () => {
+      order.push("pw-reset");
+      return RESET_OK;
+    });
+    limiterCalls.authLimit.mockImplementation(async () => {
+      order.push("auth");
+      return AUTH_OK;
+    });
+
+    const { POST } = await import("../route");
+
+    await POST(makeRequest("POST", "/api/auth/request-password-reset"));
+
+    expect(order).toEqual(["pw-reset", "auth"]);
+  });
+});

--- a/apps/web/app/api/auth/[...all]/route.ts
+++ b/apps/web/app/api/auth/[...all]/route.ts
@@ -1,6 +1,10 @@
 import { auth } from "@/lib/auth";
 import { toNextJsHandler } from "better-auth/next-js";
-import { authLimiter, getClientIp } from "@/lib/rate-limit";
+import {
+  authLimiter,
+  getClientIp,
+  passwordResetLimiter,
+} from "@/lib/rate-limit";
 import { type NextRequest, NextResponse } from "next/server";
 
 const { GET: authGet, POST: authPost } = toNextJsHandler(auth);
@@ -15,17 +19,77 @@ function rateLimitResponse(reset: number): NextResponse {
   });
 }
 
-export async function GET(request: NextRequest) {
-  return authGet(request);
+/**
+ * Better-Auth password-reset endpoints (v1.4.x, the version pinned in
+ * `apps/web/package.json`). The catch-all rewrites `/api/auth/<x>` -> the
+ * Better-Auth handler's internal path `/<x>`, but `request.nextUrl.pathname`
+ * carries the full URL path, so we match on the `/api/auth/...` prefix.
+ *
+ *   - POST /api/auth/request-password-reset   -- triggers sendResetPassword
+ *                                                (THE email-bombing vector)
+ *   - GET  /api/auth/reset-password/:token    -- token validity callback
+ *                                                (enumeration oracle)
+ *   - POST /api/auth/reset-password           -- submit new password
+ *                                                (token-stuffing vector)
+ *
+ * The legacy `/forget-password` alias only exists for the email-otp plugin,
+ * which we don't enable. See colophon-group/jobseek#3223.
+ */
+function isPasswordResetPath(pathname: string): boolean {
+  return (
+    pathname === "/api/auth/request-password-reset" ||
+    pathname === "/api/auth/reset-password" ||
+    pathname.startsWith("/api/auth/reset-password/")
+  );
 }
 
-export async function POST(request: NextRequest) {
+/**
+ * Apply the tighter password-reset limiter (3/300s) on top of the broader
+ * `authLimiter` (10/60s) when the request targets a reset endpoint. Both
+ * limiters are keyed on the same IP-extraction function so an attacker
+ * cannot cycle the `x-forwarded-for` header to bypass either layer (see
+ * `getClientIp` + issue #3219). Returns the 429 response if either limiter
+ * blocks, or `null` to indicate the request may proceed.
+ *
+ * Redis outage degrades open (matches the existing `authLimiter` behaviour
+ * — fail-closed would lock all users out of auth during a Redis incident).
+ */
+async function applyAuthLimits(
+  request: NextRequest,
+): Promise<NextResponse | null> {
+  const ip = getClientIp(request.headers);
+  const pathname = request.nextUrl.pathname;
+
+  if (isPasswordResetPath(pathname)) {
+    try {
+      const { success, reset } = await passwordResetLimiter.limit(ip);
+      if (!success) return rateLimitResponse(reset);
+    } catch {
+      // Redis unavailable — degrade open, mirroring authLimiter behaviour
+    }
+  }
+
   try {
-    const ip = getClientIp(request.headers);
     const { success, reset } = await authLimiter.limit(ip);
     if (!success) return rateLimitResponse(reset);
   } catch {
     // Redis unavailable — allow request through
   }
+  return null;
+}
+
+export async function GET(request: NextRequest) {
+  // The GET handler is reached for OAuth callbacks and the password-reset
+  // token-validity redirect (`/reset-password/:token`). Rate-limiting the
+  // latter prevents using the endpoint as a token-validity oracle; OAuth
+  // callbacks share the IP-keyed `authLimiter` bucket as before.
+  const limited = await applyAuthLimits(request);
+  if (limited) return limited;
+  return authGet(request);
+}
+
+export async function POST(request: NextRequest) {
+  const limited = await applyAuthLimits(request);
+  if (limited) return limited;
   return authPost(request);
 }


### PR DESCRIPTION
## Risk

`passwordResetLimiter` (3/300s, prefix `rl:pw-reset`) was defined in
`apps/web/src/lib/rate-limit.ts` but never called in production. The
catch-all `/api/auth/[...all]/route.ts` only consulted `authLimiter`
(10/60s), so:

- **Email bombing** — an attacker with any registered user's email could
  drive ten Resend `sendResetPassword` mails per minute per IP against
  that mailbox.
- **User enumeration** — Better-Auth's reset response shape is consistent
  by design (the route always returns the "if this email exists..."
  message), but the token-validity callback at `/reset-password/:token`
  can be hammered as a token-existence oracle against guessed tokens.
- **Token stuffing** — `POST /reset-password` with random `token` strings.

The 10/60s budget is a soft cap, not a reset-specific cap. Closes #3223.

## Approach — URL-prefix detection (option A from the brief)

`request.nextUrl.pathname` carries the full URL path even though
Better-Auth's internal router sees `/<x>` after the catch-all rewrite.
We sniff for the three Better-Auth v1.4.x reset endpoints and gate them
with `passwordResetLimiter` BEFORE `authLimiter`:

| Method | Path                                       | Vector                |
|--------|--------------------------------------------|-----------------------|
| POST   | `/api/auth/request-password-reset`         | Email bombing         |
| POST   | `/api/auth/reset-password`                 | Token stuffing        |
| GET    | `/api/auth/reset-password/:token`          | Enumeration oracle    |

The legacy `/forget-password` alias only exists for the `email-otp`
plugin (`node_modules/better-auth/dist/plugins/email-otp/routes.mjs`),
which we don't enable, so it's intentionally not matched.

Approach **B** (wrapping `sendResetPasswordEmail` in `auth.ts`) was
considered and rejected: per-call key would have to be the email address,
letting an attacker iterate over targets to bypass the per-IP cap.

## Existing auth limiter coexistence

`authLimiter` still fires on every request, including reset paths.
On reset paths the order is:

1. `passwordResetLimiter.limit(ip)` — tighter axis (3/300s). Block -> 429.
2. `authLimiter.limit(ip)` — broader axis (10/60s). Block -> 429.
3. Delegate to Better-Auth.

This is defence-in-depth: a target IP that's hammering the reset
endpoint will trip the 3/300s axis first, but if the reset axis ever
fails open (Redis outage in that key range), the broader 10/60s axis
still applies. Both limiters key on `getClientIp(request.headers)`,
hardened in #3219 against `x-forwarded-for` spoofing, so cycling the
header doesn't escape either bucket.

Redis outages on EITHER limiter degrade open — `authLimiter`'s
pre-existing behaviour. Failing closed would lock users out of auth
during a Redis incident.

## Tests added

`apps/web/app/api/auth/[...all]/__tests__/route.test.ts` — 13 specs:

- **Wiring**: each of the three reset endpoints consults
  `passwordResetLimiter` before delegating.
- **Threshold**: the 4th reset-path request in a 300 s window returns
  429 with `Retry-After`, and the Better-Auth handler is NOT invoked.
- **Scope**: `sign-in/email`, `sign-up/email`, and OAuth `/callback/github`
  do NOT consult `passwordResetLimiter` — only `authLimiter` applies.
- **Defence-in-depth**: reset paths still call `authLimiter`; if
  `authLimiter` blocks, the request is rejected even when
  `passwordResetLimiter` allows.
- **Redis outages**: either limiter throwing degrades open.
- **Key**: both limiters key on `getClientIp`'s output (#3219 surface).
- **Order**: `passwordResetLimiter` is consulted before `authLimiter`.

## Scope decisions

- Only `passwordResetLimiter`. `companyRequestLimiter` was wired up in
  #3285 (out of scope per the brief). `authLimiter` and `apiLimiter`
  were already wired.
- No changes to the `sendResetPasswordEmail` hook in `auth.ts` —
  approach B was rejected (see above).
- The legacy `/forget-password` alias is intentionally not matched —
  it only exists in the email-otp plugin which we don't enable.

## Test plan

- [x] `pnpm test` — 952 pass / 952 total (13 new)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec eslint <changed files>` — clean
- [ ] (manual) verify sign-in / sign-up still flows through `authLimiter`
      on staging once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)