### PR TITLE
fix(api): separate locale from lang= in /api/v1/search (closes #3230)

### DIFF
--- a/apps/web/app/api/v1/_shared.ts
+++ b/apps/web/app/api/v1/_shared.ts
@@ -66,7 +66,18 @@ export function exploreUrl(
   locale: string = "en",
 ): string {
   const kept = new URLSearchParams();
-  for (const key of ["q", "loc", "occ", "sen", "tech", "sal", "salcur", "exp"]) {
+  for (const key of [
+    "q",
+    "loc",
+    "occ",
+    "sen",
+    "tech",
+    "wm",
+    "sal",
+    "salcur",
+    "exp",
+    "lang",
+  ]) {
     const val = params.get(key);
     if (val) kept.set(key, val);
   }

--- a/apps/web/app/api/v1/search/route.test.ts
+++ b/apps/web/app/api/v1/search/route.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+// The route imports `server-only`-marked modules via `@/lib/cache-ttl` and
+// the search actions. The admin-route tests use the same shim pattern.
+vi.mock("server-only", () => ({}));
+
+// Avoid touching Redis / Upstash from a unit test — `checkRateLimit`
+// degrades closed when the limiter throws.
+vi.mock("@/lib/rate-limit", () => ({
+  apiLimiter: {
+    limit: vi.fn(async () => {
+      throw new Error("no redis in unit tests");
+    }),
+  },
+  getClientIp: () => "test-ip",
+}));
+
+const mocks = vi.hoisted(() => ({
+  parseSearchFilters: vi.fn(),
+  searchJobs: vi.fn(),
+  listTopCompanies: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/search-input", () => ({
+  parseSearchFilters: mocks.parseSearchFilters,
+}));
+vi.mock("@/lib/actions/search", () => ({
+  searchJobs: mocks.searchJobs,
+  listTopCompanies: mocks.listTopCompanies,
+}));
+
+import { GET } from "./route";
+
+const emptyParsed = {
+  keywords: [],
+  locations: [],
+  occupations: [],
+  seniorities: [],
+  technologies: [],
+  workMode: [],
+};
+
+const emptyResult = { companies: [], totalCompanies: 0 };
+
+function makeReq(qs: string): NextRequest {
+  return new NextRequest(`http://localhost/api/v1/search${qs}`);
+}
+
+async function callRoute(qs: string) {
+  const res = await GET(makeReq(qs));
+  const body = (await res.json()) as Record<string, unknown>;
+  return { res, body };
+}
+
+describe("GET /api/v1/search — lang= param (issue #3230)", () => {
+  beforeEach(() => {
+    mocks.parseSearchFilters.mockReset();
+    mocks.parseSearchFilters.mockResolvedValue(emptyParsed);
+    mocks.searchJobs.mockReset();
+    mocks.searchJobs.mockResolvedValue(emptyResult);
+    mocks.listTopCompanies.mockReset();
+    mocks.listTopCompanies.mockResolvedValue(emptyResult);
+  });
+
+  it("defaults `languages` to `[]` (no filter) when `lang=` is absent", async () => {
+    const { res } = await callRoute("?locale=en");
+    expect(res.status).toBe(200);
+    // No keywords → listTopCompanies path
+    expect(mocks.listTopCompanies).toHaveBeenCalledTimes(1);
+    const call = mocks.listTopCompanies.mock.calls[0][0];
+    expect(call.languages).toEqual([]);
+    expect(call.locale).toBe("en");
+  });
+
+  it("passes a single-value `lang=de` through as `languages: ['de']`", async () => {
+    await callRoute("?locale=en&lang=de");
+    const call = mocks.listTopCompanies.mock.calls[0][0];
+    expect(call.languages).toEqual(["de"]);
+    // UI locale stays distinct from job-document language.
+    expect(call.locale).toBe("en");
+  });
+
+  it("parses a comma-separated `lang=de,fr` into a sorted multi-value filter", async () => {
+    await callRoute("?locale=en&lang=de,fr");
+    const call = mocks.listTopCompanies.mock.calls[0][0];
+    expect(call.languages).toEqual(["de", "fr"]);
+  });
+
+  it("dedupes repeated `lang=` codes", async () => {
+    await callRoute("?locale=en&lang=de,de,fr");
+    const call = mocks.listTopCompanies.mock.calls[0][0];
+    expect(call.languages).toEqual(["de", "fr"]);
+  });
+
+  it("trims whitespace around comma-separated `lang=` codes", async () => {
+    await callRoute("?locale=en&lang=de%20%2C%20fr");
+    const call = mocks.listTopCompanies.mock.calls[0][0];
+    expect(call.languages).toEqual(["de", "fr"]);
+  });
+
+  it("rejects `lang=xx` (unknown code) with an error response", async () => {
+    const { res, body } = await callRoute("?locale=en&lang=xx");
+    expect(res.status).toBe(200); // apiResponse always 200 with error body
+    expect(body.error).toMatch(/Invalid 'lang' value/);
+    expect(body.error).toContain("xx");
+    expect(mocks.listTopCompanies).not.toHaveBeenCalled();
+    expect(mocks.searchJobs).not.toHaveBeenCalled();
+  });
+
+  it("rejects `lang=` (empty) with an error response", async () => {
+    const { res, body } = await callRoute("?locale=en&lang=");
+    expect(res.status).toBe(200);
+    expect(body.error).toMatch(/Invalid 'lang' param/);
+    expect(mocks.listTopCompanies).not.toHaveBeenCalled();
+  });
+
+  it("rejects a mixed-valid/invalid `lang=en,xx` with an error response", async () => {
+    const { body } = await callRoute("?locale=en&lang=en,xx");
+    expect(body.error).toMatch(/Invalid 'lang' value/);
+    expect(body.error).toContain("xx");
+    expect(mocks.listTopCompanies).not.toHaveBeenCalled();
+  });
+
+  it("uses the `searchJobs` path when `q=` is set, still forwarding `languages`", async () => {
+    mocks.parseSearchFilters.mockResolvedValue({
+      ...emptyParsed,
+      keywords: ["engineer"],
+    });
+    await callRoute("?locale=en&q=engineer&lang=de");
+    expect(mocks.searchJobs).toHaveBeenCalledTimes(1);
+    expect(mocks.listTopCompanies).not.toHaveBeenCalled();
+    const call = mocks.searchJobs.mock.calls[0][0];
+    expect(call.keywords).toEqual(["engineer"]);
+    expect(call.languages).toEqual(["de"]);
+  });
+
+  it("includes `lang=` in the `moreAt` URL when present", async () => {
+    const { body } = await callRoute("?locale=en&q=engineer&lang=de,fr");
+    expect(typeof body.moreAt).toBe("string");
+    const moreAt = body.moreAt as string;
+    expect(moreAt).toContain("/en/explore");
+    const url = new URL(moreAt);
+    expect(url.searchParams.get("lang")).toBe("de,fr");
+    expect(url.searchParams.get("q")).toBe("engineer");
+  });
+
+  it("omits `lang=` from `moreAt` when not provided by the caller", async () => {
+    const { body } = await callRoute("?locale=en&q=engineer");
+    const url = new URL(body.moreAt as string);
+    expect(url.searchParams.has("lang")).toBe(false);
+    expect(url.searchParams.get("q")).toBe("engineer");
+  });
+
+  it("forwards `wm=remote` into `moreAt` (regression for lost work-mode param)", async () => {
+    // The API already accepted `wm` and forwarded it to searchJobs, but
+    // the moreAt-URL builder was dropping it (#3230 audit). After this
+    // fix the round-trip is intact.
+    mocks.parseSearchFilters.mockResolvedValue({
+      ...emptyParsed,
+      workMode: ["remote"],
+    });
+    const { body } = await callRoute("?locale=en&wm=remote");
+    const url = new URL(body.moreAt as string);
+    expect(url.searchParams.get("wm")).toBe("remote");
+  });
+});

--- a/apps/web/app/api/v1/search/route.ts
+++ b/apps/web/app/api/v1/search/route.ts
@@ -1,10 +1,56 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { searchJobs, listTopCompanies } from "@/lib/actions/search";
 import { parseSearchFilters } from "@/lib/actions/search-input";
+import { isLocale, locales } from "@/lib/i18n";
 import { checkRateLimit, apiResponse, siteUrl, exploreUrl } from "../_shared";
 
 const MAX_COMPANIES = 5;
 const MAX_POSTINGS_PER_COMPANY = 3;
+
+/**
+ * Parse the optional `lang=` query param into a validated list of job
+ * document language codes. Distinct from the UI ``locale`` (i18n labels
+ * + currency formatting) — ``lang`` filters by the language the posting
+ * itself is written in (`job_posting.locales` in Typesense).
+ *
+ * - absent / empty → returns ``null`` (caller should pass ``[]`` to
+ *   ``searchJobs`` / ``listTopCompanies`` so no language filter is
+ *   applied — this is a public REST API, callers are stateless and
+ *   should not be biased by the UI locale)
+ * - comma-separated codes (e.g. ``de`` or ``de,fr``) → returns the
+ *   validated subset. Unknown codes cause a ``400``.
+ *
+ * Validated against the same set of locales the UI supports
+ * (`apps/web/src/lib/i18n.ts` :data:`locales`).
+ */
+function parseLangParam(raw: string | null): {
+  ok: true;
+  langs: string[] | null;
+} | {
+  ok: false;
+  error: string;
+} {
+  if (raw === null) return { ok: true, langs: null };
+  const parts = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (parts.length === 0) {
+    return {
+      ok: false,
+      error: `Invalid 'lang' param: must be a comma-separated list of language codes (${locales.join(", ")})`,
+    };
+  }
+  const invalid = parts.filter((c) => !isLocale(c));
+  if (invalid.length > 0) {
+    return {
+      ok: false,
+      error: `Invalid 'lang' value(s): ${invalid.join(", ")}. Supported: ${locales.join(", ")}`,
+    };
+  }
+  // Dedupe preserving the validated form
+  return { ok: true, langs: Array.from(new Set(parts)) };
+}
 
 export async function GET(request: NextRequest) {
   const rl = await checkRateLimit(request);
@@ -20,6 +66,15 @@ export async function GET(request: NextRequest) {
   const sal = sp.get("sal") ?? undefined;
   const exp = sp.get("exp") ?? undefined;
   const locale = sp.get("locale") ?? "en";
+
+  const langParsed = parseLangParam(sp.get("lang"));
+  if (!langParsed.ok) {
+    return apiResponse({ error: langParsed.error }, { maxAge: 0 });
+  }
+  // `searchJobs` / `listTopCompanies` treat `languages: []` as "no
+  // filter" (see `apps/web/src/lib/search/typesense-filters.ts` —
+  // `filters.languages?.length` guards the locales clause).
+  const languages = langParsed.langs ?? [];
 
   const parsed = await parseSearchFilters({ q, loc, occ, sen, tech, wm, locale });
 
@@ -64,7 +119,7 @@ export async function GET(request: NextRequest) {
     salaryMaxEur,
     experienceMin,
     experienceMax,
-    languages: [locale],
+    languages,
     locale,
     offset: 0,
     limit: MAX_COMPANIES,

--- a/apps/web/public/api/openapi.json
+++ b/apps/web/public/api/openapi.json
@@ -11,17 +11,19 @@
       "get": {
         "operationId": "searchJobs",
         "summary": "Search jobs across companies",
-        "description": "Returns up to 5 companies with their top 3 job postings matching the filters. Only 'q' accepts freetext. All other filter params (loc, occ, sen, tech) require exact slugs — use /api/v1/resolve to convert freetext to slugs first.",
+        "description": "Returns up to 5 companies with their top 3 job postings matching the filters. Only 'q' accepts freetext. All other filter params (loc, occ, sen, tech) require exact slugs — use /api/v1/resolve to convert freetext to slugs first.\n\nUI ``locale`` (response labels) is distinct from ``lang`` (job document language). Omitting ``lang`` returns postings in any language — pass ``lang=en`` (or a comma-separated list) to filter to specific posting languages.",
         "parameters": [
           { "name": "q", "in": "query", "schema": { "type": "string" }, "description": "Keywords (free text search)" },
           { "name": "loc", "in": "query", "schema": { "type": "string" }, "description": "Location slugs, comma-separated (exact slugs only, use /resolve to look up)" },
           { "name": "occ", "in": "query", "schema": { "type": "string" }, "description": "Occupation slugs, comma-separated (exact slugs only, use /resolve to look up)" },
           { "name": "sen", "in": "query", "schema": { "type": "string" }, "description": "Seniority slugs, comma-separated (exact slugs only, use /resolve to look up)" },
           { "name": "tech", "in": "query", "schema": { "type": "string" }, "description": "Technology slugs, comma-separated (exact slugs only, use /resolve to look up)" },
+          { "name": "wm", "in": "query", "schema": { "type": "string", "enum": ["onsite", "hybrid", "remote"] }, "description": "Work-mode filter (single value)" },
           { "name": "sal", "in": "query", "schema": { "type": "string" }, "description": "Salary range in EUR, format: min-max (e.g. 80000-150000)" },
           { "name": "salcur", "in": "query", "schema": { "type": "string" }, "description": "Salary currency code (e.g. USD, EUR)" },
           { "name": "exp", "in": "query", "schema": { "type": "string" }, "description": "Experience range in years, format: min-max (e.g. 3-10)" },
-          { "name": "locale", "in": "query", "schema": { "type": "string", "default": "en" }, "description": "Response language (en, de, fr, it)" }
+          { "name": "lang", "in": "query", "schema": { "type": "string" }, "description": "Job document language filter (comma-separated codes — en, de, fr, it). Distinct from ``locale`` (which controls response labels/currency formatting). Omit to return postings in any language; the API does not fall back to a cookie or to ``locale`` (public APIs are stateless)." },
+          { "name": "locale", "in": "query", "schema": { "type": "string", "default": "en", "enum": ["en", "de", "fr", "it"] }, "description": "UI locale for response labels and currency formatting (en, de, fr, it). Does NOT filter postings by document language — use ``lang`` for that." }
         ],
         "responses": {
           "200": {


### PR DESCRIPTION
## Summary

Fixes #3230 — the public ``/api/v1/search`` route hardcoded ``languages: [locale]``, conflating the UI locale (response labels + currency formatting) with the job document language (Typesense ``locales`` filter on ``job_posting``).

### Contract violation

The response's ``moreAt`` field points back at ``/explore`` with the same query params, implying both views are filtered the same way. They were not:
- ``/api/v1/search?q=engineer&locale=en`` forced ``languages=['en']`` (English-only postings).
- ``/{lang}/explore?q=engineer`` reads the visitor's ``JSEEK_JOB_LANGUAGES`` cookie (or DB preference), defaulting to a different filter or to "all languages".

A consumer reading the API's total, then clicking ``moreAt``, could see a wildly different count (issue cites 142 vs 419 for the same query). An API consumer on ``locale=de`` had no way to retrieve English-language postings.

## Changes

- **New ``lang=`` query param** on ``/api/v1/search``. Comma-separated. Validated against the supported locale set ``en|de|fr|it`` (rejecting ``lang=`` and ``lang=xx`` with a structured error).
- **Default is "no filter"** when ``lang=`` is absent. The route used to default to ``languages: [locale]``; it now passes ``languages: []`` (which downstream ``typesense-filters.ts`` treats as "no language filter"). Public REST APIs are stateless — falling through to a visitor cookie (the way ``/explore`` does) would re-introduce the same divergence the issue describes.
- **``moreAt`` propagation**: the explore-URL builder in ``app/api/v1/_shared.ts:exploreUrl`` now carries ``lang=`` and ``wm=``. ``wm`` was already accepted as a search param but silently dropped on the round-trip into ``/explore``.
- **OpenAPI**: ``apps/web/public/api/openapi.json`` gets a ``lang`` parameter, the existing-but-undocumented ``wm`` parameter, and a clarified ``locale`` description so the contract distinction is explicit for consumers.

## Behavior change (worth flagging)

Existing callers that do **not** pass ``lang`` will now receive **more** results than before — postings in any language instead of only the URL locale's language. This was the requested behavior in the issue and matches the broader product direction (job-language is a user preference, not a UI concern). Callers that depended on the old narrowing should pass ``lang=<locale>`` explicitly.

## Tests

``apps/web/app/api/v1/search/route.test.ts`` (new, 12 cases):

- ``locale=en`` (no ``lang``) → ``languages: []`` (no filter).
- ``locale=en&lang=de`` → ``languages: ['de']``, ``locale: 'en'`` stays distinct.
- ``locale=en&lang=de,fr`` → ``languages: ['de', 'fr']``.
- Dedup + whitespace trimming on the CSV.
- Rejects ``lang=xx``, ``lang=``, and mixed valid/invalid ``lang=en,xx``.
- ``q=`` path uses ``searchJobs`` and still forwards ``languages``.
- ``moreAt`` contains ``lang=`` when set, omits it when not.
- ``moreAt`` contains ``wm=remote`` (regression coverage).

## Gates

- ``pnpm test`` — 106 files / 983 tests pass
- ``pnpm exec tsc --noEmit`` — clean
- ``pnpm exec eslint <changed files>`` — clean
- ``pnpm build`` — not run per instructions

## Test plan

- [x] Unit tests for ``lang=`` parsing, defaults, validation, ``moreAt`` propagation
- [x] tsc clean, eslint clean
- [ ] Manual smoke: ``/api/v1/search?locale=en`` returns more rows than before (expected behavior change)
- [ ] Manual smoke: ``/api/v1/search?locale=en&lang=de`` returns only ``de`` postings

🤖 Generated with [Claude Code](https://claude.com/claude-code)