### PR TITLE
fix(api): emit string slug for industries in /api/v1/resolve (closes #3228)

### DIFF
--- a/apps/web/app/api/v1/resolve/route.test.ts
+++ b/apps/web/app/api/v1/resolve/route.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Regression tests for `/api/v1/resolve` industry handling.
+ *
+ * Issue #3228: the `industries` case used to emit `slug: String(i.id)`,
+ * which violated the response contract — the field is named `slug`,
+ * documented as a URL-stable slug-shaped string (consistent with the
+ * other taxonomies — locations, occupations, seniority, technologies).
+ *
+ * The fix derives the slug from the localized display name via the
+ * canonical `slugifyTitle` helper (the same one watchlist titles use).
+ * Industries have no `slug` column today; the `id` is retained only as
+ * a fallback when the name slugifies to empty (unreachable for current
+ * taxonomy values, defensive for pathological future inputs).
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+
+// Bypass real rate limiter — degrades closed when the limiter throws.
+vi.mock("@/lib/rate-limit", () => ({
+  apiLimiter: {
+    limit: vi.fn(async () => {
+      throw new Error("no redis in unit tests");
+    }),
+  },
+  getClientIp: () => "test-ip",
+}));
+
+const mocks = vi.hoisted(() => ({
+  suggestIndustries: vi.fn(),
+  suggestLocations: vi.fn(),
+  suggestOccupations: vi.fn(),
+  suggestSeniorities: vi.fn(),
+  suggestTechnologies: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/company", () => ({
+  suggestIndustries: mocks.suggestIndustries,
+}));
+vi.mock("@/lib/actions/locations", () => ({
+  suggestLocations: mocks.suggestLocations,
+}));
+vi.mock("@/lib/actions/taxonomy", () => ({
+  suggestOccupations: mocks.suggestOccupations,
+  suggestSeniorities: mocks.suggestSeniorities,
+  suggestTechnologies: mocks.suggestTechnologies,
+}));
+
+import { GET } from "./route";
+
+function makeReq(qs: string): NextRequest {
+  return new NextRequest(`http://localhost/api/v1/resolve${qs}`);
+}
+
+async function call(qs: string) {
+  const res = await GET(makeReq(qs));
+  const body = (await res.json()) as {
+    type?: string;
+    query?: string;
+    matches?: { slug: string; name: string }[];
+    error?: string;
+  };
+  return { res, body };
+}
+
+describe("GET /api/v1/resolve?type=industries (issue #3228)", () => {
+  beforeEach(() => {
+    mocks.suggestIndustries.mockReset();
+  });
+
+  it("emits a slug-shaped string for each industry, NOT the stringified id", async () => {
+    mocks.suggestIndustries.mockResolvedValue([
+      { id: 3, name: "Technology" },
+      { id: 42, name: "Financial Services" },
+    ]);
+
+    const { res, body } = await call("?type=industries&q=tech");
+
+    expect(res.status).toBe(200);
+    expect(body.type).toBe("industries");
+    expect(body.matches).toEqual([
+      { slug: "technology", name: "Technology" },
+      { slug: "financial-services", name: "Financial Services" },
+    ]);
+    // Specifically: no entry's slug is a stringified integer.
+    for (const m of body.matches!) {
+      expect(m.slug).not.toMatch(/^\d+$/);
+    }
+  });
+
+  it("derives slug from the localized display name (locale=de)", async () => {
+    mocks.suggestIndustries.mockResolvedValue([
+      // The action localizes `name` per request locale; the route never
+      // needs the English name. We assert that whatever name comes back
+      // is what gets slugified.
+      { id: 3, name: "Technologie" },
+    ]);
+
+    const { body } = await call("?type=industries&q=tech&locale=de");
+
+    expect(mocks.suggestIndustries).toHaveBeenCalledWith({
+      query: "tech",
+      locale: "de",
+    });
+    expect(body.matches).toEqual([{ slug: "technologie", name: "Technologie" }]);
+  });
+
+  it("normalizes punctuation and casing through the canonical slugifier", async () => {
+    mocks.suggestIndustries.mockResolvedValue([
+      { id: 7, name: "Food & Beverage" },
+      { id: 8, name: "Oil + Gas" },
+      { id: 9, name: "Pharma / Biotech" },
+    ]);
+
+    const { body } = await call("?type=industries&q=foo");
+
+    expect(body.matches).toEqual([
+      // `&` -> `and`, `+` -> `plus`, `/` and spaces -> `-`.
+      { slug: "food-and-beverage", name: "Food & Beverage" },
+      { slug: "oil-plus-gas", name: "Oil + Gas" },
+      { slug: "pharma-biotech", name: "Pharma / Biotech" },
+    ]);
+  });
+
+  it("falls back to stringified id only when the name slugifies to empty", async () => {
+    mocks.suggestIndustries.mockResolvedValue([
+      // All-symbol name — `slugifyTitle` returns "" for this. The route
+      // falls back to `String(id)` so the field is never empty.
+      { id: 99, name: "!!!" },
+    ]);
+
+    const { body } = await call("?type=industries&q=foo");
+
+    expect(body.matches).toEqual([{ slug: "99", name: "!!!" }]);
+  });
+
+  it("caps the response at 10 matches (existing behavior, unchanged)", async () => {
+    const many = Array.from({ length: 25 }, (_, i) => ({
+      id: i + 1,
+      name: `Industry ${i + 1}`,
+    }));
+    mocks.suggestIndustries.mockResolvedValue(many);
+
+    const { body } = await call("?type=industries&q=ind");
+
+    expect(body.matches).toHaveLength(10);
+    // Each capped slug must still be slug-shaped (no bare integers).
+    for (const m of body.matches!) {
+      expect(m.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
+    }
+  });
+});

--- a/apps/web/app/api/v1/resolve/route.ts
+++ b/apps/web/app/api/v1/resolve/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/actions/taxonomy";
 import { suggestIndustries } from "@/lib/actions/company";
 import { CACHE_TTL_LONG } from "@/lib/cache-ttl";
+import { slugifyTitle } from "@/lib/watchlist-slug";
 import { checkRateLimit, apiResponse } from "../_shared";
 
 const VALID_TYPES = [
@@ -71,8 +72,19 @@ export async function GET(request: NextRequest) {
       break;
     }
     case "industries": {
+      // The `industry` table has no `slug` column today, but the response
+      // contract is uniform across taxonomies: callers expect `slug` to
+      // be a URL-stable slug-shaped string. Derive one from the localized
+      // display name with the same canonical slugifier the rest of the
+      // app uses, falling back to the numeric id if the name slugifies
+      // to empty (e.g., all-symbol pathological input). See issue #3228.
+      // Note: `/api/v1/search` does not currently accept an industry
+      // filter, so this is a response-shape fix; no roundtrip breakage.
       const data = await suggestIndustries({ query: q, locale });
-      matches = data.map((i) => ({ slug: String(i.id), name: i.name }));
+      matches = data.map((i) => ({
+        slug: slugifyTitle(i.name) || String(i.id),
+        name: i.name,
+      }));
       break;
     }
   }


### PR DESCRIPTION
## Contract violation

`/api/v1/resolve` declares its response shape as

```ts
let matches: { slug: string; name: string; type?: string; parentName?: string | null }[];
```

and all four other taxonomy cases (locations, occupations, seniority, technologies) emit a URL-stable slug-shaped string. The `industries` case, however, emitted `slug: String(i.id)` — i.e. `"3"`, `"42"`, `"175"` — even though it lives in a field literally named `slug`. A client building a fluent `/api/v1/search` URL by concatenating `loc=`, `occ=`, `sen=`, `tech=` from `resolve` responses would get a contract trap from `industries`.

## Approach

Per the issue, two options were on the table:

- **A.** If `industry` has a `slug` column → emit it like the other taxonomies.
- **B.** If not → derive a slug from the name server-side.

The DB schema (`apps/web/src/db/schema.ts`):

```ts
export const industry = pgTable("industry", {
  id: smallint("id").primaryKey(),
  name: text("name").notNull().unique(),
});
```

No slug column exists. Adding one is the M-effort path called out in the issue; the S-effort fix is to derive the slug. This PR takes the S path: derive at the API boundary using the canonical `slugifyTitle` helper (the same one watchlist titles use — single source of slugification across the app).

The derived slug:

- Uses the localized `i.name` (already locale-aware via the `industry_name` table).
- Falls back to `String(i.id)` only when the name slugifies to empty (all-symbol pathological input). For current industry names this branch is unreachable; it's a defensive guard so the `slug` field is never `""`.

Industry names are unique at the DB level (`name: text("name").notNull().unique()`), and current values like `Technology`, `Financial Services`, `Food & Beverage` slugify to distinct strings — no collision risk for today's taxonomy.

## Backwards-compatibility note

`/api/v1/search` does **not** accept an `industry`/`ind` param today (confirmed by grepping `apps/web/app/api/v1/search/route.ts` — no industry handling at all). So the previous `slug: "3"` shape was already unusable for any documented roundtrip; this is purely a response-shape consistency fix. No external caller could have been roundtripping the stringified id.

The only internal consumer of `suggestIndustries` (`apps/web/src/components/watchlist/company-search-modal.tsx`) reads `IndustrySuggestion.id` directly from the action, not from the resolve API, so it's unaffected.

## Tests

New test file `apps/web/app/api/v1/resolve/route.test.ts` covers:

- The bug regression: `slug` is now `"technology"` / `"financial-services"`, never a stringified integer
- Locale propagation: `locale=de` flows through to `suggestIndustries` and the German display name is what gets slugified
- Punctuation normalization: `&` → `and`, `+` → `plus`, `/` and whitespace → `-` (delegating to `slugifyTitle`)
- Empty-name fallback: pathological all-symbol names fall back to `String(id)` rather than emit `slug: ""`
- Cap-at-10 behavior is unchanged

## Gates

- `pnpm test` — 107 files / 1004 tests pass (5 new)
- `pnpm exec tsc --noEmit` — clean
- `pnpm exec eslint app/api/v1/resolve/route.{ts,test.ts}` — clean
- `pnpm build` not run per dispatch policy

## Scope

Only the `industries` case is touched. The other four taxonomies already emit correct slug-shaped strings and are not modified.

## Files changed

- `apps/web/app/api/v1/resolve/route.ts` — slug derivation for industries
- `apps/web/app/api/v1/resolve/route.test.ts` — new regression suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)