### PR TITLE
fix(web): stable cache keys for taxonomy/locations filters (closes #3187)

### DIFF
--- a/apps/web/src/lib/actions/locations.ts
+++ b/apps/web/src/lib/actions/locations.ts
@@ -10,6 +10,7 @@ import { typeaheadLocationsCacheTag } from "@/lib/cache-tags";
 import { getTypesenseClient, type TypesenseHit } from "@/lib/search/typesense-client";
 import { buildFilterString, POSTING_BASE_FILTER } from "@/lib/search/typesense-filters";
 import { boostByFilterMatches, type TypeaheadBoostFilters } from "@/lib/search/typeahead-boost";
+import { canonicalizeFilters } from "@/lib/search/canonicalize-filters";
 import { LOCATION_PAGE_SIZE } from "@/lib/search/location-paging";
 
 export interface LocationSuggestion {
@@ -331,7 +332,11 @@ export async function getGlobalLocationsGrouped(
   locale: string,
   filters?: { companyId?: string; keywords?: string[]; occupationIds?: number[]; seniorityIds?: number[]; technologyIds?: number[]; languages?: string[] },
 ): Promise<GlobalLocationsResponse> {
-  const fKey = filters ? JSON.stringify(filters) : "";
+  // `JSON.stringify` is sensitive to array element order, so without
+  // canonicalization `{occupationIds:[42,7]}` and `{occupationIds:[7,42]}`
+  // hit different cache slots even though they're semantically identical.
+  // See #3187.
+  const fKey = filters ? JSON.stringify(canonicalizeFilters(filters)) : "";
   // v4 cache-key bump (#3033 — hierarchical-modal counts now use the
   // direct facet entry for parent IDs instead of summing children). Old
   // v3 entries cache the buggy summed counts (e.g. "Chile (4)" when the

--- a/apps/web/src/lib/actions/taxonomy.ts
+++ b/apps/web/src/lib/actions/taxonomy.ts
@@ -14,6 +14,7 @@ import {
 import { getTypesenseClient, type TypesenseHit } from "@/lib/search/typesense-client";
 import { buildFilterString, POSTING_BASE_FILTER } from "@/lib/search/typesense-filters";
 import { boostByFilterMatches, type TypeaheadBoostFilters } from "@/lib/search/typeahead-boost";
+import { canonicalizeFilters } from "@/lib/search/canonicalize-filters";
 
 export interface TaxonomySuggestion {
   id: number;
@@ -517,7 +518,9 @@ export async function getAllOccupationsGrouped(
   locale: string,
   filters?: { companyId?: string; keywords?: string[]; locationIds?: number[]; seniorityIds?: number[]; technologyIds?: number[]; languages?: string[] },
 ): Promise<OccupationGroup[]> {
-  const fKey = filters ? JSON.stringify(filters) : "";
+  // Stable cache key across array permutations — see #3187 and the helper
+  // doc for the full rationale.
+  const fKey = filters ? JSON.stringify(canonicalizeFilters(filters)) : "";
   // v2 cache-key bump (#3033 — facet switched from `occupation_id` to the
   // ancestor-expanded `occupation_ids`, so parent counts are now subtree
   // counts directly; sub-group/domain totals dropped the
@@ -902,7 +905,8 @@ export async function getAllSeniorities(
   locale: string,
   filters?: { companyId?: string; keywords?: string[]; locationIds?: number[]; occupationIds?: number[]; technologyIds?: number[]; languages?: string[] },
 ): Promise<SeniorityOption[]> {
-  const fKey = filters ? JSON.stringify(filters) : "";
+  // Stable cache key across array permutations — see #3187.
+  const fKey = filters ? JSON.stringify(canonicalizeFilters(filters)) : "";
   const key = `sen-all:${locale}:${fKey}`;
   return cached(key, () => _fetchAllSeniorities(locale, filters), { ttl: CACHE_TTL_LONG });
 }
@@ -1032,7 +1036,8 @@ export interface TechnologyGroup {
 export async function getAllTechnologiesGrouped(
   filters?: { companyId?: string; keywords?: string[]; locationIds?: number[]; occupationIds?: number[]; seniorityIds?: number[]; languages?: string[] },
 ): Promise<TechnologyGroup[]> {
-  const fKey = filters ? JSON.stringify(filters) : "";
+  // Stable cache key across array permutations — see #3187.
+  const fKey = filters ? JSON.stringify(canonicalizeFilters(filters)) : "";
   const key = `tech-all-grouped:${fKey}`;
   return cached(key, () => _fetchAllTechnologiesGrouped(filters), { ttl: CACHE_TTL_LONG });
 }

--- a/apps/web/src/lib/search/__tests__/canonicalize-filters.test.ts
+++ b/apps/web/src/lib/search/__tests__/canonicalize-filters.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { canonicalizeFilters } from "../canonicalize-filters";
+
+describe("canonicalizeFilters — stable cache keys (#3187)", () => {
+  it("regression: same filter content in different array order JSON-encodes to the same string", () => {
+    // Before the fix, `getGlobalLocationsGrouped`,
+    // `getAllOccupationsGrouped`, `getAllSeniorities`, and
+    // `getAllTechnologiesGrouped` used `JSON.stringify(filters)` for
+    // their cache keys. Same content, different array order → different
+    // cache slots → cache pollution and miss-rate collapse.
+    const a = canonicalizeFilters({ locationIds: [42, 7] });
+    const b = canonicalizeFilters({ locationIds: [7, 42] });
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+    expect(JSON.stringify(a)).toBe('{"locationIds":[7,42]}');
+  });
+
+  it("collapses occupationIds permutations", () => {
+    const a = canonicalizeFilters({ occupationIds: [3, 1, 2] });
+    const b = canonicalizeFilters({ occupationIds: [2, 3, 1] });
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it("collapses seniorityIds permutations", () => {
+    const a = canonicalizeFilters({ seniorityIds: [5, 1] });
+    const b = canonicalizeFilters({ seniorityIds: [1, 5] });
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it("collapses technologyIds permutations", () => {
+    const a = canonicalizeFilters({ technologyIds: [10, 2, 7] });
+    const b = canonicalizeFilters({ technologyIds: [2, 7, 10] });
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it("sorts numeric IDs numerically (not lexicographically)", () => {
+    // Bare `.sort()` would produce `[10, 2]` not `[2, 10]` because
+    // it coerces to string. That alone is a cache-key bug.
+    const out = canonicalizeFilters({ locationIds: [10, 2, 100, 1] });
+    expect(out.locationIds).toEqual([1, 2, 10, 100]);
+  });
+
+  it("sorts keywords case-insensitively via canonicalStringCompare", () => {
+    // `canonicalStringCompare` folds accents and case (sensitivity:
+    // "base"), so `Apple` and `apple` collate to the same base position
+    // and `übung` sorts with the u-group, not after `z`.
+    const a = canonicalizeFilters({ keywords: ["zoom", "Apple", "übung"] });
+    const b = canonicalizeFilters({ keywords: ["übung", "zoom", "Apple"] });
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+    // Apple sorts first (base letter a); übung in the u-group, before zoom.
+    expect(a.keywords?.[0]?.toLowerCase()).toBe("apple");
+    expect(a.keywords?.[2]).toBe("zoom");
+  });
+
+  it("sorts languages with canonicalStringCompare too", () => {
+    const a = canonicalizeFilters({ languages: ["de", "en", "fr"] });
+    const b = canonicalizeFilters({ languages: ["fr", "de", "en"] });
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it("does not mutate the input arrays", () => {
+    const input = { locationIds: [42, 7], keywords: ["zoom", "apple"] };
+    const before = JSON.stringify(input);
+    canonicalizeFilters(input);
+    expect(JSON.stringify(input)).toBe(before);
+    expect(input.locationIds).toEqual([42, 7]);
+    expect(input.keywords).toEqual(["zoom", "apple"]);
+  });
+
+  it("preserves empty arrays (does not collapse to undefined)", () => {
+    // The original `JSON.stringify(filters)` path serialized `[]`
+    // distinctly from missing keys. Preserve that so we don't
+    // accidentally collide `{keywords: []}` with `{}` and change the
+    // downstream `buildFilterString` behaviour.
+    const out = canonicalizeFilters({ keywords: [], locationIds: [] });
+    expect(out.keywords).toEqual([]);
+    expect(out.locationIds).toEqual([]);
+    expect(JSON.stringify(out)).toBe('{"keywords":[],"locationIds":[]}');
+  });
+
+  it("preserves scalar fields like companyId unchanged", () => {
+    const out = canonicalizeFilters({ companyId: "acme-corp", locationIds: [9, 1] });
+    expect(out.companyId).toBe("acme-corp");
+    expect(out.locationIds).toEqual([1, 9]);
+  });
+
+  it("produces a stable JSON key irrespective of input property insertion order", () => {
+    // V8 preserves object insertion order for `JSON.stringify`. The
+    // helper assembles fields in a fixed order so callers that build
+    // `{technologyIds, keywords}` and callers that build
+    // `{keywords, technologyIds}` collapse to the same cache key.
+    const a = canonicalizeFilters({ technologyIds: [3, 1], keywords: ["a", "b"] });
+    const b = canonicalizeFilters({ keywords: ["b", "a"], technologyIds: [1, 3] });
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it("omits fields that are undefined on the input", () => {
+    // No need to spam the cache key with `"keywords":null` if the
+    // caller never set keywords. JSON.stringify already drops `undefined`
+    // entries; the helper must not re-introduce them as `null`.
+    const out = canonicalizeFilters({ locationIds: [1] });
+    expect(JSON.stringify(out)).toBe('{"locationIds":[1]}');
+  });
+
+  it("collapses combined permutations across multiple array dimensions", () => {
+    // The worst case: every dimension's permutation multiplies the
+    // keyspace. Verify that the helper folds them all into one key.
+    const a = canonicalizeFilters({
+      keywords: ["zoom", "apple"],
+      locationIds: [42, 7],
+      occupationIds: [3, 1],
+      seniorityIds: [5, 2],
+      technologyIds: [10, 4],
+      languages: ["fr", "de"],
+    });
+    const b = canonicalizeFilters({
+      languages: ["de", "fr"],
+      technologyIds: [4, 10],
+      seniorityIds: [2, 5],
+      occupationIds: [1, 3],
+      locationIds: [7, 42],
+      keywords: ["apple", "zoom"],
+    });
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+});

--- a/apps/web/src/lib/search/canonicalize-filters.ts
+++ b/apps/web/src/lib/search/canonicalize-filters.ts
@@ -1,0 +1,79 @@
+import { canonicalStringCompare } from "@/lib/sort";
+
+/**
+ * Superset of every filter shape used by the taxonomy/locations server
+ * actions whose Redis cache keys derive from `JSON.stringify(filters)`.
+ * Each consumer threads through a strict subset (e.g.
+ * `getGlobalLocationsGrouped` omits `locationIds`; `getAllOccupationsGrouped`
+ * omits `occupationIds`); we accept the union so a single helper covers
+ * every site without duplicating the per-field sort dance.
+ *
+ * Fields that are not arrays (e.g. `companyId`) pass through unchanged —
+ * `JSON.stringify` already produces a deterministic key for scalars, and
+ * V8 preserves object insertion order for non-numeric keys.
+ */
+export interface CanonicalizableFilters {
+  companyId?: string;
+  keywords?: string[];
+  locationIds?: number[];
+  occupationIds?: number[];
+  seniorityIds?: number[];
+  technologyIds?: number[];
+  languages?: string[];
+}
+
+/**
+ * Return a new filter object whose array fields are sorted into canonical
+ * order. The output is shaped so that
+ * `JSON.stringify(canonicalizeFilters(f))` is stable across permutations of
+ * the input arrays — `{locationIds:[42,7]}` and `{locationIds:[7,42]}`
+ * collapse to the same key.
+ *
+ * String arrays sort with `canonicalStringCompare` (locale-independent
+ * `Intl.Collator("en", { sensitivity: "base" })`) — the raw `Array#sort()`
+ * uses UTF-16 code unit order, where `"ü"` (U+00FC) sorts after `"z"`
+ * (U+007A). That would produce different cache keys for
+ * `["python","übung","zoom"]` depending on the caller's input
+ * permutation. See #3221.
+ *
+ * Numeric ID arrays sort with the standard numeric comparator. Bare
+ * `.sort()` would coerce them to strings (so `[10, 2]` sorts to `[10, 2]`
+ * not `[2, 10]`), splitting the cache further. See #3187.
+ *
+ * Pure function: the input is not mutated. Empty arrays survive as
+ * empty arrays (not collapsed to `undefined`) so the caller's downstream
+ * `buildFilterString` continues to see the same shape, and the cache key
+ * for `{keywords: []}` stays distinguishable from `{}` (matches the prior
+ * `JSON.stringify(filters)` behaviour).
+ *
+ * Closes #3187 — the bug fires whenever two callers produce semantically
+ * identical filters in different array order, splitting the Redis cache
+ * across `n!` permutations per dimension.
+ */
+export function canonicalizeFilters<T extends CanonicalizableFilters>(filters: T): T {
+  // Build the output in a fixed key order. Object insertion order is the
+  // tertiary stability axis (V8 preserves it for `JSON.stringify`), so
+  // even if a caller passes `{technologyIds, keywords}` and another
+  // passes `{keywords, technologyIds}`, both produce the same JSON.
+  const out: CanonicalizableFilters = {};
+  if (filters.companyId !== undefined) out.companyId = filters.companyId;
+  if (filters.keywords !== undefined) {
+    out.keywords = [...filters.keywords].sort(canonicalStringCompare);
+  }
+  if (filters.locationIds !== undefined) {
+    out.locationIds = [...filters.locationIds].sort((a, b) => a - b);
+  }
+  if (filters.occupationIds !== undefined) {
+    out.occupationIds = [...filters.occupationIds].sort((a, b) => a - b);
+  }
+  if (filters.seniorityIds !== undefined) {
+    out.seniorityIds = [...filters.seniorityIds].sort((a, b) => a - b);
+  }
+  if (filters.technologyIds !== undefined) {
+    out.technologyIds = [...filters.technologyIds].sort((a, b) => a - b);
+  }
+  if (filters.languages !== undefined) {
+    out.languages = [...filters.languages].sort(canonicalStringCompare);
+  }
+  return out as T;
+}


### PR DESCRIPTION
## Bug

`getGlobalLocationsGrouped`, `getAllOccupationsGrouped`, `getAllSeniorities`, and `getAllTechnologiesGrouped` each derived their Redis cache key from `JSON.stringify(filters)`. `JSON.stringify` is sensitive to array element order, so two callers with semantically identical filters but a different array order (URL params vs modal click order; sorted vs unsorted multi-select widgets) hashed to different cache keys.

For 4 filter dimensions x 5 IDs each, that's `5!^4 ≈ 200M` permutations of the same logical filter combo — each one a separate Redis entry. Cache hit rate collapsed to near-zero for power users, and every miss replayed the underlying Typesense facet query (200-500 ms).

## Fix

New helper `canonicalizeFilters(filters)` at `apps/web/src/lib/search/canonicalize-filters.ts`:

- Sorts `keywords` and `languages` with `canonicalStringCompare` (locale-independent `Intl.Collator("en", { sensitivity: "base" })` — matches the #3221 / #3083 / #3220 pattern, so accented strings don't shred the cache across viewer locales).
- Sorts `locationIds` / `occupationIds` / `seniorityIds` / `technologyIds` numerically (bare `.sort()` would coerce to string and produce `[10, 2]` instead of `[2, 10]`).
- Assembles the output object in a fixed property order, so callers that build `{technologyIds, keywords}` and callers that build `{keywords, technologyIds}` also collapse to the same JSON.
- Pure function — inputs are not mutated, empty arrays survive as empty arrays (so the cache key for `{keywords: []}` stays distinguishable from `{}`).

Applied at the four sites called out in #3187:
- `apps/web/src/lib/actions/locations.ts` — `getGlobalLocationsGrouped`
- `apps/web/src/lib/actions/taxonomy.ts` — `getAllOccupationsGrouped`, `getAllSeniorities`, `getAllTechnologiesGrouped`

## Scope decisions

- **Out of scope (filed implicitly via this body — happy to spin up a follow-up if you want a tracking issue)**: two more `JSON.stringify(filters)` sites in `taxonomy.ts` — `getEmploymentTypeCounts` (line 1169) and `getWorkModeCounts` (line 1212). They share the same shape and would benefit from the same fix, but #3187 enumerates only the four touched here, so I followed the stated scope.
- `#3083` already covers the watchlist `JSON.stringify(filters)` call and `_similarFiltersKey` in `company.ts` already sorts internally — neither was duplicated.
- The seven `JSON.stringify(filters)` sites under `apps/web/src/components/search/*-modal.tsx` are React `useEffect` deps, not cache keys — different problem, different fix, out of scope.

## Operator note

Existing Redis entries with old (unsorted) keys naturally expire under their TTL (`CACHE_TTL_LONG`). No migration required; cache hit rate will recover monotonically over one TTL window.

## Tests

13 new tests in `apps/web/src/lib/search/__tests__/canonicalize-filters.test.ts`:

- Permutations of `locationIds`, `occupationIds`, `seniorityIds`, `technologyIds`, `keywords`, `languages` all collapse to the same JSON string.
- Numeric ID arrays sort numerically (regression for the `.sort()` string-coercion footgun).
- Keywords sort case-insensitively via `canonicalStringCompare` (regression for `["python","übung","zoom"]`).
- Input is not mutated.
- Empty arrays preserved (`{keywords: []}` does not collide with `{}`).
- Scalars (`companyId`) pass through.
- Property insertion order on the input does not affect the output JSON.
- Combined multi-dimension permutations collapse correctly.

## Test plan

- [x] `pnpm exec vitest run src/lib/search/__tests__/canonicalize-filters.test.ts` — 13 pass
- [x] `pnpm test` — full suite: 1058 / 1058 pass, 111 files
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec eslint <changed files>` — clean
- [ ] Post-deploy: confirm `redis-cli --scan --pattern 'global-locs-grouped-*'` and `occ-all-grouped-*` keyspace shrinks toward 1 key per (locale, logical filter combo) over the next TTL window (currently shows the permutation explosion described in #3187).

Closes #3187.

Generated with [Claude Code](https://claude.com/claude-code)