### PR TITLE
perf(web): lazy-load nivo sankey funnel on /my-jobs/stats (closes #3189)

### DIFF
--- a/apps/web/app/[lang]/(app)/my-jobs/stats/stats-page.tsx
+++ b/apps/web/app/[lang]/(app)/my-jobs/stats/stats-page.tsx
@@ -4,7 +4,7 @@ import { useState, useCallback } from "react";
 import { Trans } from "@lingui/react/macro";
 import { useLocalePath } from "@/lib/useLocalePath";
 import { BackLink } from "@/components/BackLink";
-import { SankeyFunnel } from "@/components/my-jobs/sankey-funnel";
+import { SankeyFunnel } from "@/components/my-jobs/sankey-funnel-lazy";
 import { ActivityHeatmap } from "@/components/my-jobs/activity-heatmap";
 import { getStats, type StatsData } from "@/lib/actions/my-jobs-stats";
 import { getViewerTz } from "@/lib/viewer-tz";

--- a/apps/web/src/components/my-jobs/__tests__/sankey-funnel-lazy.test.tsx
+++ b/apps/web/src/components/my-jobs/__tests__/sankey-funnel-lazy.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import type { FunnelData } from "@/lib/actions/my-jobs-stats";
+
+/**
+ * #3189 — Lazy-load nivo Sankey funnel on /my-jobs/stats.
+ *
+ * The funnel pulls in ~250 KB of `@nivo/sankey` + `@nivo/core`. We lazy-load
+ * it via `next/dynamic`. These tests pin the contract:
+ *
+ *   - While the dynamic import is pending, a skeleton placeholder is rendered
+ *     in place of the chart (so the page doesn't shift when the chart loads).
+ *   - Once the import resolves, the real `SankeyFunnel` mounts and renders.
+ */
+
+// Stub Lingui — the real funnel uses it for translated labels.
+vi.mock("@lingui/react/macro", () => ({
+  useLingui: () => ({
+    t: ({ message }: { message?: string }) => message ?? "",
+  }),
+}));
+
+// Stub next-themes — the real funnel reads `resolvedTheme`.
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ resolvedTheme: "light" }),
+}));
+
+// Stub `@nivo/sankey` so the test runner doesn't have to pull in the real
+// chart (we're only verifying the lazy-load wiring, not nivo's rendering).
+vi.mock("@nivo/sankey", () => ({
+  ResponsiveSankey: () => <div data-testid="sankey-chart" />,
+}));
+
+function makeFunnelData(): FunnelData {
+  return {
+    saved: 10,
+    applied: 5,
+    offered: 1,
+    offeredWithoutInterview: 0,
+    rejectedAtSaved: 2,
+    rejectedAtApplied: 1,
+    noResponseAtSaved: 3,
+    noResponseAtApplied: 1,
+    interviewRounds: [{ round: 1, count: 3 }],
+    rejectedAtRound: [],
+    noResponseAtRound: [],
+    offeredAtRound: [{ round: 1, count: 1 }],
+  };
+}
+
+describe("SankeyFunnel (lazy wrapper) — #3189", () => {
+  it("renders a skeleton placeholder while the chart import is pending and swaps in the chart once it resolves", async () => {
+    // Don't mock next/dynamic — exercise the real Next.js lazy loader so we
+    // pin the genuine load → swap sequence.
+    const { SankeyFunnel } = await import("../sankey-funnel-lazy");
+    const { container } = render(<SankeyFunnel data={makeFunnelData()} />);
+
+    // Skeleton: a div sized to match the rendered funnel, marked aria-hidden
+    // so screen readers ignore the loading state. It uses the
+    // `animate-pulse` Tailwind class to indicate loading.
+    const skeleton = container.querySelector('[aria-hidden="true"]');
+    expect(skeleton).not.toBeNull();
+    expect(skeleton!.className).toContain("animate-pulse");
+    expect(skeleton!.className).toContain("h-[400px]");
+
+    // The actual chart shows up after the dynamic import resolves.
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="sankey-chart"]')).not.toBeNull();
+    });
+  });
+
+  it("mounts the real funnel component (not the skeleton) once loaded", async () => {
+    const { SankeyFunnel } = await import("../sankey-funnel-lazy");
+    const { container } = render(<SankeyFunnel data={makeFunnelData()} />);
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-testid="sankey-chart"]')).not.toBeNull();
+    });
+
+    // After resolution the skeleton is gone.
+    expect(container.querySelector('[aria-hidden="true"]')).toBeNull();
+  });
+});

--- a/apps/web/src/components/my-jobs/sankey-funnel-lazy.tsx
+++ b/apps/web/src/components/my-jobs/sankey-funnel-lazy.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import type { FunnelData } from "@/lib/actions/my-jobs-stats";
+
+/**
+ * Lazy wrapper for the nivo Sankey funnel.
+ *
+ * The chart is below the fold on /my-jobs/stats and pulls in ~250 KB of
+ * `@nivo/sankey` + `@nivo/core` + d3 dependencies. Loading it on demand
+ * keeps the stats route bundle small (closes #3189).
+ *
+ * `ssr: false` is required because nivo uses browser-only APIs (e.g.
+ * `window.matchMedia` and SVG measurement) that don't render meaningfully
+ * during server prerender.
+ *
+ * The skeleton's height approximates the rendered funnel's minimum height
+ * (~400 px) so swap-in doesn't shift surrounding content.
+ */
+export const SankeyFunnel = dynamic<{ data: FunnelData }>(
+  () => import("./sankey-funnel").then((m) => m.SankeyFunnel),
+  {
+    ssr: false,
+    loading: () => (
+      <div
+        aria-hidden
+        className="h-[400px] animate-pulse rounded-md bg-muted/20"
+      />
+    ),
+  },
+);


### PR DESCRIPTION
## Summary

- `apps/web/app/[lang]/(app)/my-jobs/stats/stats-page.tsx` previously imported `SankeyFunnel` statically, eagerly pulling in `@nivo/sankey` + `@nivo/core` + d3 (~250 KB minified, ~155 KB gzipped) into the route bundle even though the funnel renders below the fold.
- Introduced a thin lazy wrapper at `apps/web/src/components/my-jobs/sankey-funnel-lazy.tsx` that wraps the real funnel with `next/dynamic` and re-exports it under the same name. Stats page imports the wrapper instead.
- Added a fixed-height skeleton placeholder (`h-[400px]` `animate-pulse`) so the surrounding content layout doesn't shift when the chart resolves.

## Bundle size impact

Before: `/my-jobs/stats` route chunk included `@nivo/sankey` (~75 KB gz) + `@nivo/core` (~80 KB gz) + d3 transitive deps. Total ~250 KB min / ~155 KB gz of chart code shipped on first paint of the route.

After: those packages move into a separately-named lazy chunk fetched only after first paint when the chart mounts. The above-the-fold portion of the route (back link, header, activity heatmap, period filter) no longer waits on chart parse/compile.

## LCP impact

The Sankey funnel is below the fold of `/my-jobs/stats` (activity heatmap + filters sit above it). On a slow 3G connection that ~155 KB gzipped payload was costing **~1.5–2 s of LCP** on this route per the audit issue (#3189); on fast desktop, it was ~100–200 ms of parse/compile. The lazy chunk now loads in parallel after first contentful paint, so the LCP element (heatmap/header) is no longer blocked on chart code.

## `ssr: false` rationale

`@nivo/sankey` is browser-only — the existing `SankeyFunnel` reads `window.matchMedia` on mount (`useIsSmallScreen`) and nivo internally measures SVG dimensions. Server-prerendering would either error or produce a 0-sized chart that flashes on hydrate. The whole route is already client-loaded via `StatsLoader` (`useEffect` + `getStats`), so `ssr: false` doesn't change any user-visible behavior — it just sheds the SSR bundle inclusion.

## Tests added

`apps/web/src/components/my-jobs/__tests__/sankey-funnel-lazy.test.tsx`:
- Renders the lazy wrapper and asserts the `aria-hidden`, `animate-pulse`, `h-[400px]` skeleton is present in the initial render.
- Awaits the dynamic import and asserts the real funnel (with a stubbed `@nivo/sankey` `ResponsiveSankey`) mounts, and the skeleton is gone.

Run locally:

```
pnpm test                              # 1068/1068 pass
pnpm exec tsc --noEmit                 # clean
pnpm exec eslint <changed files>       # clean
```

## Scope decisions

Issue suggested optionally extending the same treatment to `ActivityHeatmap`. Deferred — `ActivityHeatmap` is a custom hand-rolled SVG with no heavy chart-library dep, and it's above the fold, so lazy-loading it would hurt LCP rather than help. Per the spec: no scope creep beyond the sankey.

## Test plan
- [ ] Navigate to `/my-jobs/stats` on a slow connection — confirm the skeleton placeholder renders in the funnel's spot while the chart chunk downloads, then the chart swaps in without layout shift.
- [ ] Confirm `next build` analyze output shows `@nivo/sankey` + `@nivo/core` in a route-async chunk (not the main route chunk).
- [ ] Verify the chart renders correctly in light + dark themes after lazy mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)