### PR TITLE
fix(web): bail on missing FX rate instead of silent 1:1 fallback (closes #3184)

### DIFF
--- a/apps/web/src/lib/__tests__/salary.test.ts
+++ b/apps/web/src/lib/__tests__/salary.test.ts
@@ -104,18 +104,146 @@ describe("convertAmount — #3194 hourly annualization parity with crawler", () 
   it("converts $25/hour to $52,000/year (2080 × 25), matching crawler salary_eur", () => {
     // Crawler stores $25/hr as 2500 cents → salary_eur uses 25 * 2080 = 52,000
     // Web's convertAmount takes whole units (post-decode), so $25 directly.
-    expect(convertAmount(25, "USD", "USD", "hourly", "yearly", [])).toBe(52000);
+    expect(convertAmount(25, "USD", "USD", "hourly", "yearly", [])).toEqual({
+      amount: 52000,
+      currency: "USD",
+    });
   });
 
   it("converts $50/hour to $104,000/year (2080 × 50)", () => {
-    expect(convertAmount(50, "USD", "USD", "hourly", "yearly", [])).toBe(104000);
+    expect(convertAmount(50, "USD", "USD", "hourly", "yearly", [])).toEqual({
+      amount: 104000,
+      currency: "USD",
+    });
   });
 
   it("round-trips hourly→yearly→hourly without drift (within rounding)", () => {
     const hourly = 30;
     const yearly = convertAmount(hourly, "USD", "USD", "hourly", "yearly", []);
-    const back = convertAmount(yearly, "USD", "USD", "yearly", "hourly", []);
-    expect(back).toBe(hourly);
+    const back = convertAmount(yearly.amount, "USD", "USD", "yearly", "hourly", []);
+    expect(back.amount).toBe(hourly);
+  });
+});
+
+describe("convertAmount — #3184 bail on missing FX rate", () => {
+  // The pre-fix code used `?? 1` for both the source and target rate, which
+  // silently produced a 1:1 conversion and mislabeled the result. A
+  // ¥5,000,000 yearly salary would render as "5,000k EUR" — a €5M-looking
+  // role at a click rate roughly 166× too high. The fix: bail to the source
+  // currency when either rate is missing.
+
+  it("bails to source currency when rates list is empty (JPY → EUR)", () => {
+    // The headline scenario from #3184: 5M JPY yearly, no rates loaded.
+    // Pre-fix produced { amount: 5_000_000, currency: "EUR" } via 1:1.
+    expect(convertAmount(5_000_000, "JPY", "EUR", "yearly", "yearly", [])).toEqual({
+      amount: 5_000_000,
+      currency: "JPY",
+    });
+  });
+
+  it("bails to source currency when only the target rate is present (JPY → EUR)", () => {
+    // EUR rate exists but JPY does not — still must bail (was 5M * 1 / 1 = 5M EUR pre-fix).
+    expect(
+      convertAmount(5_000_000, "JPY", "EUR", "yearly", "yearly", [
+        { currency: "EUR", toEur: 1 },
+      ]),
+    ).toEqual({ amount: 5_000_000, currency: "JPY" });
+  });
+
+  it("bails to source currency when only the source rate is present (JPY → EUR)", () => {
+    // Symmetric case: JPY rate exists but EUR does not. In practice EUR is
+    // always 1.0 and present, but the bail logic must still trip for safety.
+    expect(
+      convertAmount(5_000_000, "JPY", "EUR", "yearly", "yearly", [
+        { currency: "JPY", toEur: 0.006 },
+      ]),
+    ).toEqual({ amount: 5_000_000, currency: "JPY" });
+  });
+
+  it("converts correctly to EUR when both rates are present (~30,000 EUR for 5M JPY)", () => {
+    // 5_000_000 * 0.006 / 1 = 30_000 EUR — the post-fix correct output.
+    expect(
+      convertAmount(5_000_000, "JPY", "EUR", "yearly", "yearly", [
+        { currency: "JPY", toEur: 0.006 },
+        { currency: "EUR", toEur: 1 },
+      ]),
+    ).toEqual({ amount: 30_000, currency: "EUR" });
+  });
+
+  it("preserves identity branch — fromCurrency === toCurrency never bails", () => {
+    // Empty rates list, but no conversion needed. Must not bail to a different currency.
+    expect(convertAmount(5_000_000, "JPY", "JPY", "yearly", "yearly", [])).toEqual({
+      amount: 5_000_000,
+      currency: "JPY",
+    });
+    expect(convertAmount(100_000, "USD", "USD", "yearly", "yearly", [])).toEqual({
+      amount: 100_000,
+      currency: "USD",
+    });
+  });
+
+  it("still applies period conversion on the bail path (period math is FX-independent)", () => {
+    // 60_000 / 12 = 5_000 monthly. Currency bails to source (USD), but period still converts.
+    expect(convertAmount(60_000, "USD", "EUR", "yearly", "monthly", [])).toEqual({
+      amount: 5_000,
+      currency: "USD",
+    });
+  });
+});
+
+describe("formatSalary — #3184 missing-FX-rate display fallback", () => {
+  // End-to-end: a EUR-displaying user looking at a 5M JPY posting must not
+  // see "5,000k EUR". The display falls back to source currency rather than
+  // lying about the value.
+
+  it("displays 5M JPY in JPY when no rates are loaded (not '5,000k EUR')", () => {
+    const out = formatSalary(5_000_000, null, "JPY", "yearly", {
+      displayCurrency: "EUR",
+      rates: [],
+    });
+    // The 'rates: []' branch in formatSalary short-circuits `toCur = fromCur`,
+    // so no conversion is even attempted. Asserts the user-visible contract:
+    // an EUR-displaying user never sees JPY mislabeled as EUR.
+    expect(out).toBe("5000k+ JPY");
+    expect(out).not.toContain("EUR");
+  });
+
+  it("displays 5M JPY in JPY when rates exist but JPY is missing", () => {
+    // This is the realistic bug path: rates are populated (so the
+    // `opts.rates?.length` guard in formatSalary lets toCur = EUR), but the
+    // specific source currency is absent — exactly what #3184 describes.
+    const out = formatSalary(5_000_000, null, "JPY", "yearly", {
+      displayCurrency: "EUR",
+      rates: [
+        { currency: "EUR", toEur: 1 },
+        { currency: "USD", toEur: 0.92 },
+      ],
+    });
+    expect(out).toBe("5000k+ JPY");
+    expect(out).not.toContain("EUR");
+  });
+
+  it("converts 5M JPY to ~30k EUR when both rates are present", () => {
+    const out = formatSalary(5_000_000, null, "JPY", "yearly", {
+      displayCurrency: "EUR",
+      rates: [
+        { currency: "JPY", toEur: 0.006 },
+        { currency: "EUR", toEur: 1 },
+      ],
+    });
+    expect(out).toBe("30k+ EUR");
+  });
+
+  it("renders a JPY range with both bounds when rates are missing", () => {
+    const out = formatSalary(4_000_000, 6_000_000, "JPY", "yearly", {
+      displayCurrency: "EUR",
+      rates: [{ currency: "EUR", toEur: 1 }],
+    });
+    expect(out).toBe("4000k–6000k JPY");
+  });
+
+  it("identity case (display === source) preserved when no rates are loaded", () => {
+    expect(formatSalary(5_000_000, null, "JPY", "yearly")).toBe("5000k+ JPY");
   });
 });
 

--- a/apps/web/src/lib/salary.ts
+++ b/apps/web/src/lib/salary.ts
@@ -33,6 +33,22 @@ export function decodeStoredAmount(amount: number, period: SalaryPeriod): number
   return period === "hourly" ? amount / 100 : amount;
 }
 
+/**
+ * Result of a salary conversion. The `currency` field signals whether the
+ * conversion actually happened in the requested target currency, or whether
+ * we bailed out and kept the source currency (issue #3184).
+ *
+ * A bailed-out result occurs when either `fromCurrency` or `toCurrency` is
+ * missing from `rates` — the old behavior silently substituted a 1:1 rate,
+ * which made e.g. ¥5,000,000 render as "5,000k EUR". Callers MUST check the
+ * returned `currency` and render accordingly instead of assuming the original
+ * target was used.
+ */
+export interface ConvertedAmount {
+  amount: number;
+  currency: string;
+}
+
 export function convertAmount(
   amount: number,
   fromCurrency: string,
@@ -40,22 +56,31 @@ export function convertAmount(
   fromPeriod: SalaryPeriod,
   toPeriod: SalaryPeriod,
   rates: CurrencyRate[],
-): number {
+): ConvertedAmount {
   let val = amount;
+  let currency = toCurrency;
 
-  // Currency conversion: source → EUR → target
+  // Currency conversion: source → EUR → target.
+  // If either the source or target rate is missing, bail out and keep the
+  // amount in its source currency. The pre-fix `?? 1` fallback silently
+  // produced a 1:1 conversion that mislabeled the result (issue #3184).
   if (fromCurrency !== toCurrency) {
-    const fromRate = rates.find((r) => r.currency === fromCurrency)?.toEur ?? 1;
-    const toRate = rates.find((r) => r.currency === toCurrency)?.toEur ?? 1;
-    val = val * fromRate / toRate;
+    const fromRate = rates.find((r) => r.currency === fromCurrency)?.toEur;
+    const toRate = rates.find((r) => r.currency === toCurrency)?.toEur;
+    if (fromRate == null || toRate == null) {
+      currency = fromCurrency;
+    } else {
+      val = val * fromRate / toRate;
+    }
   }
 
-  // Period conversion: source → yearly → target
+  // Period conversion: source → yearly → target.
+  // Period conversion is currency-independent and always safe to apply.
   if (fromPeriod !== toPeriod) {
     val = val * TO_YEARLY[fromPeriod] / TO_YEARLY[toPeriod];
   }
 
-  return Math.round(val);
+  return { amount: Math.round(val), currency };
 }
 
 /**
@@ -141,13 +166,21 @@ export function formatSalary(
   const cMin = min != null ? conv(min) : null;
   const cMax = max != null ? conv(max) : null;
 
+  // The currency label rendered after the amount. If convertAmount bailed
+  // (missing FX rate), both bounds will agree on the source currency since
+  // they share the same fromCur/toCur. Prefer cMin's resolved currency,
+  // falling back to cMax's. This guards against the #3184 "5M JPY → 5,000k
+  // EUR" bug: when rates are missing, we render the source currency, not
+  // the requested target.
+  const resolvedCurrency = cMin?.currency ?? cMax?.currency ?? toCur;
+
   const parts: string[] = [];
   if (cMin != null && cMax != null) {
-    parts.push(`${fmt(cMin)}–${fmt(cMax)} ${toCur}`);
+    parts.push(`${fmt(cMin.amount)}–${fmt(cMax.amount)} ${resolvedCurrency}`);
   } else if (cMin != null) {
-    parts.push(`${fmt(cMin)}+ ${toCur}`);
+    parts.push(`${fmt(cMin.amount)}+ ${resolvedCurrency}`);
   } else if (cMax != null) {
-    parts.push(`≤${fmt(cMax)} ${toCur}`);
+    parts.push(`≤${fmt(cMax.amount)} ${resolvedCurrency}`);
   }
 
   if (toPeriod !== "yearly") {


### PR DESCRIPTION
## Summary

Closes #3184.

A 5,000,000 JPY yearly salary (~30K EUR) was being rendered to EUR-displaying users as **"5,000k EUR"** — a value roughly 166x the truth — because `convertAmount` fell back to a silent 1:1 rate when JPY (or any other currency) was missing from the `currency_rate` table.

## The bug

`apps/web/src/lib/salary.ts` (before):

```ts
const fromRate = rates.find((r) => r.currency === fromCurrency)?.toEur ?? 1;
const toRate   = rates.find((r) => r.currency === toCurrency)?.toEur   ?? 1;
val = val * fromRate / toRate;
```

When `fromCurrency = "JPY"` was missing from `rates`, `fromRate` defaulted to 1 and `toRate` (EUR) was already 1, giving `val * 1 / 1 = 5_000_000`. The UI then labeled it as **EUR** — the requested display currency — producing "5,000k EUR".

The same fallback hits any currency missing from the rates table: INR, BRL, MXN, ZAR, SGD, AUD, etc.

## The fix

`convertAmount` now returns `{ amount, currency }`. When either the source or target rate is missing, the function keeps the amount in the source currency and reports that as the resolved currency. `formatSalary` reads the resolved currency for the rendered suffix.

```ts
if (fromCurrency !== toCurrency) {
  const fromRate = rates.find((r) => r.currency === fromCurrency)?.toEur;
  const toRate   = rates.find((r) => r.currency === toCurrency)?.toEur;
  if (fromRate == null || toRate == null) {
    currency = fromCurrency;          // bail — keep source
  } else {
    val = val * fromRate / toRate;
  }
}
```

## Display impact

A EUR-displaying user looking at a 5M JPY posting now sees **"5000k+ JPY"** (truthful — JPY is a high-zero currency) instead of **"5000k+ EUR"** (false — implied ~16,000,000× over). This matches the crawler-side behavior, where `salary_eur` is correctly NULL when the rate is missing (see `apps/crawler/src/processing/cpu.py`).

## Scope

Only `convertAmount` + its single consumer `formatSalary` in `apps/web/src/lib/salary.ts`. Crawler-side `salary_eur` computation untouched. Other helpers in the file (`decodeStoredAmount`, `convertToEur`) unchanged. The `convertAmount` return-shape change is invisible externally — its only call site is the `conv()` lambda inside `formatSalary`.

## Test plan

- [x] `pnpm exec vitest run src/lib/__tests__/salary.test.ts` — 38 tests pass (was 24; added 11 new + adjusted 3 to new return shape)
- [x] `pnpm test` (full suite) — 1086 tests pass
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec eslint <changed files>` — clean

New test coverage:
- `convertAmount(5_000_000, "JPY", "EUR", ..., [])` (empty rates) → `{amount: 5_000_000, currency: "JPY"}`
- `convertAmount(5_000_000, "JPY", "EUR", ..., [{EUR}])` (missing JPY) → bails to JPY
- `convertAmount(5_000_000, "JPY", "EUR", ..., [{JPY}])` (missing EUR) → bails to JPY
- `convertAmount(5_000_000, "JPY", "EUR", ..., [{JPY: 0.006}, {EUR: 1}])` → `{amount: 30_000, currency: "EUR"}`
- Identity (`from === to`) preserved
- Period conversion still applies on the bail path (FX-independent)
- `formatSalary` end-to-end: 5M JPY with missing rate → "5000k+ JPY"
- `formatSalary` end-to-end: 5M JPY with rate → "30k+ EUR"

🤖 Generated with [Claude Code](https://claude.com/claude-code)