### PR TITLE
fix(a11y): mark decorative lucide icons aria-hidden (closes #3177)

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
@@ -554,48 +554,54 @@ export function WatchlistViewPage({
                   <span key={`occ-${occ.id}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
                     <Briefcase size={12} className="shrink-0" />
                     {occ.name}
-                    <button onClick={() => onRemoveOccupation(occ.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"><X size={12} /></button>
+                    <button onClick={() => onRemoveOccupation(occ.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${occ.name} filter` })}><X size={12} aria-hidden="true" /></button>
                   </span>
                 ))}
                 {seniorities.map((sen) => (
                   <span key={`sen-${sen.id}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
                     <BarChart3 size={12} className="shrink-0" />
                     {sen.name}
-                    <button onClick={() => onRemoveSeniority(sen.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"><X size={12} /></button>
+                    <button onClick={() => onRemoveSeniority(sen.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${sen.name} filter` })}><X size={12} aria-hidden="true" /></button>
                   </span>
                 ))}
                 {technologies.map((tech) => (
                   <span key={`tech-${tech.id}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
                     <Code2 size={12} className="shrink-0" />
                     {tech.name}
-                    <button onClick={() => onRemoveTechnology(tech.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"><X size={12} /></button>
+                    <button onClick={() => onRemoveTechnology(tech.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${tech.name} filter` })}><X size={12} aria-hidden="true" /></button>
                   </span>
                 ))}
-                {employmentTypes.map((et) => (
-                  <span key={`et-${et}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm capitalize text-primary">
-                    <CalendarDays size={12} className="shrink-0" />
-                    {et.replace(/_/g, " ")}
-                    <button onClick={() => onToggleEmploymentType(et)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"><X size={12} /></button>
-                  </span>
-                ))}
-                {workMode.map((wm) => (
-                  <span key={`wm-${wm}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
-                    <Home size={12} className="shrink-0" />
-                    {wm === "onsite"
-                      ? t({ id: "search.workMode.onsite", comment: "Work mode: onsite (in-office)", message: "On-site" })
-                      : wm === "hybrid"
-                        ? t({ id: "search.workMode.hybrid", comment: "Work mode: hybrid (mixed onsite/remote)", message: "Hybrid" })
-                        : t({ id: "search.workMode.remote", comment: "Work mode: remote (work-from-home)", message: "Remote" })}
-                    <button onClick={() => onToggleWorkMode(wm)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"><X size={12} /></button>
-                  </span>
-                ))}
+                {employmentTypes.map((et) => {
+                  const etLabel = et.replace(/_/g, " ");
+                  return (
+                    <span key={`et-${et}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm capitalize text-primary">
+                      <CalendarDays size={12} className="shrink-0" />
+                      {etLabel}
+                      <button onClick={() => onToggleEmploymentType(et)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${etLabel} filter` })}><X size={12} aria-hidden="true" /></button>
+                    </span>
+                  );
+                })}
+                {workMode.map((wm) => {
+                  const wmLabel = wm === "onsite"
+                    ? t({ id: "search.workMode.onsite", comment: "Work mode: onsite (in-office)", message: "On-site" })
+                    : wm === "hybrid"
+                      ? t({ id: "search.workMode.hybrid", comment: "Work mode: hybrid (mixed onsite/remote)", message: "Hybrid" })
+                      : t({ id: "search.workMode.remote", comment: "Work mode: remote (work-from-home)", message: "Remote" });
+                  return (
+                    <span key={`wm-${wm}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
+                      <Home size={12} className="shrink-0" />
+                      {wmLabel}
+                      <button onClick={() => onToggleWorkMode(wm)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${wmLabel} filter` })}><X size={12} aria-hidden="true" /></button>
+                    </span>
+                  );
+                })}
                 {(salaryMin != null || salaryMax != null) && (
                   <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
                     <DollarSign size={12} className="shrink-0" />
                     {salaryMin != null && salaryMax != null
                       ? `${salaryCurrency} ${Math.round(salaryMin / 1000)}K – ${Math.round(salaryMax / 1000)}K`
                       : salaryMin != null ? `${salaryCurrency} ${Math.round(salaryMin / 1000)}K+` : `${salaryCurrency} ≤${Math.round(salaryMax! / 1000)}K`}
-                    <button onClick={() => onSalaryChange(salaryCurrency, undefined, undefined)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"><X size={12} /></button>
+                    <button onClick={() => onSalaryChange(salaryCurrency, undefined, undefined)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeSalary", comment: "Aria label for the X button that clears the salary-range filter", message: "Remove salary filter" })}><X size={12} aria-hidden="true" /></button>
                   </span>
                 )}
                 {(experienceMin != null || experienceMax != null) && (
@@ -604,22 +610,25 @@ export function WatchlistViewPage({
                     {experienceMin != null && experienceMax != null
                       ? `${experienceMin}–${experienceMax}y`
                       : experienceMin != null ? `${experienceMin}y+` : `≤${experienceMax}y`}
-                    <button onClick={() => onExperienceChange(undefined, undefined)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"><X size={12} /></button>
+                    <button onClick={() => onExperienceChange(undefined, undefined)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeExperience", comment: "Aria label for the X button that clears the experience-range filter", message: "Remove experience filter" })}><X size={12} aria-hidden="true" /></button>
                   </span>
                 )}
                 {keywords.map((kw) => (
                   <span key={kw} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
                     {kw}
-                    <button onClick={() => onRemoveKeyword(kw)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"><X size={12} /></button>
+                    <button onClick={() => onRemoveKeyword(kw)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeKeyword", comment: "Aria label for remove-keyword X button; {name} is the keyword", message: `Remove keyword ${kw}` })}><X size={12} aria-hidden="true" /></button>
                   </span>
                 ))}
-                {locations.map((loc) => (
-                  <span key={loc.id} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
-                    <MapPin size={12} className="shrink-0" />
-                    {loc.parentName && loc.type !== "country" && loc.type !== "macro" ? `${loc.name}, ${loc.parentName}` : loc.name}
-                    <button onClick={() => onRemoveLocation(loc.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"><X size={12} /></button>
-                  </span>
-                ))}
+                {locations.map((loc) => {
+                  const locLabel = loc.parentName && loc.type !== "country" && loc.type !== "macro" ? `${loc.name}, ${loc.parentName}` : loc.name;
+                  return (
+                    <span key={loc.id} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
+                      <MapPin size={12} className="shrink-0" />
+                      {locLabel}
+                      <button onClick={() => onRemoveLocation(loc.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeLocation", comment: "Aria label for remove-location X button; {name} is the location label", message: `Remove location ${locLabel}` })}><X size={12} aria-hidden="true" /></button>
+                    </span>
+                  );
+                })}
                 <button onClick={onClearAll} className="cursor-pointer text-xs text-muted transition-colors hover:text-foreground">
                   {t({ id: "search.filters.clearAll", comment: "Button to clear all active search filters", message: "Clear all" })}
                 </button>

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
@@ -550,39 +550,48 @@ export function WatchlistViewPage({
             />
             {hasFilters && (
               <div className="flex flex-wrap items-center gap-2">
-                {occupations.map((occ) => (
-                  <span key={`occ-${occ.id}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
-                    <Briefcase size={12} className="shrink-0" />
-                    {occ.name}
-                    <button onClick={() => onRemoveOccupation(occ.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${occ.name} filter` })}><X size={12} aria-hidden="true" /></button>
-                  </span>
-                ))}
-                {seniorities.map((sen) => (
-                  <span key={`sen-${sen.id}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
-                    <BarChart3 size={12} className="shrink-0" />
-                    {sen.name}
-                    <button onClick={() => onRemoveSeniority(sen.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${sen.name} filter` })}><X size={12} aria-hidden="true" /></button>
-                  </span>
-                ))}
-                {technologies.map((tech) => (
-                  <span key={`tech-${tech.id}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
-                    <Code2 size={12} className="shrink-0" />
-                    {tech.name}
-                    <button onClick={() => onRemoveTechnology(tech.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${tech.name} filter` })}><X size={12} aria-hidden="true" /></button>
-                  </span>
-                ))}
+                {occupations.map((occ) => {
+                  const name = occ.name;
+                  return (
+                    <span key={`occ-${occ.id}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
+                      <Briefcase size={12} className="shrink-0" />
+                      {name}
+                      <button onClick={() => onRemoveOccupation(occ.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${name} filter` })}><X size={12} aria-hidden="true" /></button>
+                    </span>
+                  );
+                })}
+                {seniorities.map((sen) => {
+                  const name = sen.name;
+                  return (
+                    <span key={`sen-${sen.id}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
+                      <BarChart3 size={12} className="shrink-0" />
+                      {name}
+                      <button onClick={() => onRemoveSeniority(sen.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${name} filter` })}><X size={12} aria-hidden="true" /></button>
+                    </span>
+                  );
+                })}
+                {technologies.map((tech) => {
+                  const name = tech.name;
+                  return (
+                    <span key={`tech-${tech.id}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
+                      <Code2 size={12} className="shrink-0" />
+                      {name}
+                      <button onClick={() => onRemoveTechnology(tech.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${name} filter` })}><X size={12} aria-hidden="true" /></button>
+                    </span>
+                  );
+                })}
                 {employmentTypes.map((et) => {
-                  const etLabel = et.replace(/_/g, " ");
+                  const name = et.replace(/_/g, " ");
                   return (
                     <span key={`et-${et}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm capitalize text-primary">
                       <CalendarDays size={12} className="shrink-0" />
-                      {etLabel}
-                      <button onClick={() => onToggleEmploymentType(et)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${etLabel} filter` })}><X size={12} aria-hidden="true" /></button>
+                      {name}
+                      <button onClick={() => onToggleEmploymentType(et)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${name} filter` })}><X size={12} aria-hidden="true" /></button>
                     </span>
                   );
                 })}
                 {workMode.map((wm) => {
-                  const wmLabel = wm === "onsite"
+                  const name = wm === "onsite"
                     ? t({ id: "search.workMode.onsite", comment: "Work mode: onsite (in-office)", message: "On-site" })
                     : wm === "hybrid"
                       ? t({ id: "search.workMode.hybrid", comment: "Work mode: hybrid (mixed onsite/remote)", message: "Hybrid" })
@@ -590,8 +599,8 @@ export function WatchlistViewPage({
                   return (
                     <span key={`wm-${wm}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
                       <Home size={12} className="shrink-0" />
-                      {wmLabel}
-                      <button onClick={() => onToggleWorkMode(wm)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${wmLabel} filter` })}><X size={12} aria-hidden="true" /></button>
+                      {name}
+                      <button onClick={() => onToggleWorkMode(wm)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${name} filter` })}><X size={12} aria-hidden="true" /></button>
                     </span>
                   );
                 })}
@@ -613,19 +622,22 @@ export function WatchlistViewPage({
                     <button onClick={() => onExperienceChange(undefined, undefined)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeExperience", comment: "Aria label for the X button that clears the experience-range filter", message: "Remove experience filter" })}><X size={12} aria-hidden="true" /></button>
                   </span>
                 )}
-                {keywords.map((kw) => (
-                  <span key={kw} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
-                    {kw}
-                    <button onClick={() => onRemoveKeyword(kw)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeKeyword", comment: "Aria label for remove-keyword X button; {name} is the keyword", message: `Remove keyword ${kw}` })}><X size={12} aria-hidden="true" /></button>
-                  </span>
-                ))}
+                {keywords.map((kw) => {
+                  const name = kw;
+                  return (
+                    <span key={kw} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
+                      {name}
+                      <button onClick={() => onRemoveKeyword(kw)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeKeyword", comment: "Aria label for remove-keyword X button; {name} is the keyword", message: `Remove keyword ${name}` })}><X size={12} aria-hidden="true" /></button>
+                    </span>
+                  );
+                })}
                 {locations.map((loc) => {
-                  const locLabel = loc.parentName && loc.type !== "country" && loc.type !== "macro" ? `${loc.name}, ${loc.parentName}` : loc.name;
+                  const name = loc.parentName && loc.type !== "country" && loc.type !== "macro" ? `${loc.name}, ${loc.parentName}` : loc.name;
                   return (
                     <span key={loc.id} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
                       <MapPin size={12} className="shrink-0" />
-                      {locLabel}
-                      <button onClick={() => onRemoveLocation(loc.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeLocation", comment: "Aria label for remove-location X button; {name} is the location label", message: `Remove location ${locLabel}` })}><X size={12} aria-hidden="true" /></button>
+                      {name}
+                      <button onClick={() => onRemoveLocation(loc.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeLocation", comment: "Aria label for remove-location X button; {name} is the location label", message: `Remove location ${name}` })}><X size={12} aria-hidden="true" /></button>
                     </span>
                   );
                 })}

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -53,7 +53,7 @@ msgstr "(öffnet in neuem Tab)"
 #. Button to show remaining collapsed locations
 #. js-lingui-explicit-id
 #. placeholder {0}: locations.length - LOCATIONS_COLLAPSED
-#: src/components/search/job-detail-dialog.tsx:359
+#: src/components/search/job-detail-dialog.tsx:361
 msgid "search.detail.showMoreLocations"
 msgstr "{0} weitere"
 
@@ -255,6 +255,12 @@ msgstr "Unternehmen hinzufügen"
 msgid "watchlists.view.addDescription"
 msgstr "Beschreibung hinzufügen"
 
+#. Aria label for the checkmark button that confirms adding a filter
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:448
+msgid "watchlists.filters.confirmAdd"
+msgstr "Filter hinzufügen"
+
 #. Quick action tooltip: add interview round
 #. js-lingui-explicit-id
 #: src/components/my-jobs/quick-actions.tsx:19
@@ -281,7 +287,7 @@ msgstr "Standort- oder Stichwortfilter hinzufügen…"
 
 #. Placeholder in the add location input
 #. js-lingui-explicit-id
-#: src/components/search/location-pills.tsx:176
+#: src/components/search/location-pills.tsx:174
 msgid "search.locations.addPlaceholder"
 msgstr "Standort hinzufügen..."
 
@@ -299,7 +305,7 @@ msgstr "Agent-Prompt"
 
 #. Footer shown after all paged countries have been loaded into the location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:813
+#: src/components/search/location-search-modal.tsx:816
 msgid "search.locationModal.allLoaded"
 msgstr "Alle {totalCountries} Länder geladen"
 
@@ -311,7 +317,7 @@ msgstr "Alle Daten werden bei Übertragung und Speicherung verschlüsselt."
 
 #. Option to show all industries
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:259
+#: src/components/watchlist/company-search-modal.tsx:262
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Alle Branchen"
 
@@ -335,7 +341,7 @@ msgstr "Alle Standorte"
 
 #. Button to open all-locations modal on company page
 #. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:342
+#: src/components/search/filter-bar.tsx:346
 msgid "company.page.allLocations"
 msgstr "Alle Standorte"
 
@@ -400,7 +406,7 @@ msgstr "Bewerbungsstatistik"
 
 #. Application tracker section heading in job detail
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:247
+#: src/components/search/job-detail-dialog.tsx:249
 msgid "search.detail.applicationTracker"
 msgstr "Bewerbungstracker"
 
@@ -424,7 +430,7 @@ msgstr "Beworben"
 
 #. Application tracker status: applied
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:449
+#: src/components/search/job-detail-dialog.tsx:451
 msgid "search.tracker.applied"
 msgstr "Beworben"
 
@@ -448,19 +454,19 @@ msgstr "Beworben"
 
 #. Apply salary filter
 #. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:320
+#: src/components/search/salary-modal.tsx:324
 msgid "search.salaryModal.apply"
 msgstr "Anwenden"
 
 #. Apply experience filter
 #. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:246
+#: src/components/search/experience-modal.tsx:249
 msgid "search.experienceModal.apply"
 msgstr "Anwenden"
 
 #. Apply button linking to original job posting
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:292
+#: src/components/my-jobs/my-job-detail-panel.tsx:293
 msgid "search.detail.apply"
 msgstr "Bewerben"
 
@@ -500,16 +506,16 @@ msgstr "Aug"
 msgid "settings.account.username.available"
 msgstr "Verfügbar"
 
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Zurück zur Anmeldung"
-
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Zurück zur Anmeldung"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Zurück zur Anmeldung"
 
 #. Link back to sign-in from forgot password
@@ -617,6 +623,14 @@ msgstr "Kann ich die Indexierung meines Unternehmens durch Jobseek ablehnen?"
 msgid "watchlists.delete.cancel"
 msgstr "Abbrechen"
 
+#. Aria label for the X button that cancels the inline add-filter UI
+#. Aria label for the X button that cancels the inline add-filter UI
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:420
+#: src/components/watchlist/watchlist-filter-editor.tsx:456
+msgid "watchlists.filters.cancel"
+msgstr "Abbrechen"
+
 #. Cancel delete button
 #. js-lingui-explicit-id
 #: src/components/settings/AccountSettings.tsx:532
@@ -711,7 +725,7 @@ msgstr "Wähle aus, in welchen Sprachen du Stellenanzeigen sehen möchtest."
 #. Location type label for cities
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:35
-#: src/components/search/location-pills.tsx:33
+#: src/components/search/location-pills.tsx:31
 msgid "location.type.city"
 msgstr "Stadt"
 
@@ -730,8 +744,8 @@ msgstr "Alle entfernen"
 #. Button to clear all active search filters
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:624
-#: src/components/search/search-toolbar.tsx:337
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:645
+#: src/components/search/search-toolbar.tsx:367
 msgid "search.filters.clearAll"
 msgstr "Alle löschen"
 
@@ -758,6 +772,90 @@ msgstr "Klicken zum Umbenennen"
 #: src/components/HowWeIndexContent.tsx:119
 msgid "indexing.ingestion.s2.title"
 msgstr "Client-APIs als Zweites."
+
+#. Aria label for close button on add-companies modal
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-search-modal.tsx:201
+msgid "watchlists.companyModal.close"
+msgstr "Schließen"
+
+#. Aria label for upgrade modal close button
+#. js-lingui-explicit-id
+#: src/components/ui/upgrade-modal.tsx:59
+msgid "upgrade.modal.close"
+msgstr "Schließen"
+
+#. Aria label for the job-languages modal close button
+#. js-lingui-explicit-id
+#: src/components/settings/JobLanguageModal.tsx:66
+msgid "settings.jobLanguages.modal.close"
+msgstr "Schließen"
+
+#. Aria label for the work-mode modal close button
+#. js-lingui-explicit-id
+#: src/components/search/work-mode-modal.tsx:90
+msgid "search.workModeModal.close"
+msgstr "Schließen"
+
+#. Aria label for the technology modal close button
+#. js-lingui-explicit-id
+#: src/components/search/technology-modal.tsx:117
+msgid "search.technologyModal.close"
+msgstr "Schließen"
+
+#. Aria label for the seniority modal close button
+#. js-lingui-explicit-id
+#: src/components/search/seniority-modal.tsx:65
+msgid "search.seniorityModal.close"
+msgstr "Schließen"
+
+#. Aria label for the salary modal close button
+#. js-lingui-explicit-id
+#: src/components/search/salary-modal.tsx:254
+msgid "search.salaryModal.close"
+msgstr "Schließen"
+
+#. Aria label for close button on the company-page all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:275
+msgid "company.locationModal.close"
+msgstr "Schließen"
+
+#. Aria label for the employment-type modal close button
+#. js-lingui-explicit-id
+#: src/components/search/employment-type-modal.tsx:82
+msgid "search.employmentTypeModal.close"
+msgstr "Schließen"
+
+#. Aria label for the location modal close button
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:479
+msgid "search.locationModal.close"
+msgstr "Schließen"
+
+#. Aria label for the experience modal close button
+#. js-lingui-explicit-id
+#: src/components/search/experience-modal.tsx:193
+msgid "search.experienceModal.close"
+msgstr "Schließen"
+
+#. Aria label for the occupation modal close button
+#. js-lingui-explicit-id
+#: src/components/search/occupation-modal.tsx:307
+msgid "search.occupationModal.close"
+msgstr "Schließen"
+
+#. Aria label for job detail panel close button
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:92
+msgid "search.detail.close"
+msgstr "Stellendetails schließen"
+
+#. Aria label for the my-jobs detail panel close button
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:173
+msgid "myJobs.detail.close"
+msgstr "Stellendetails schließen"
 
 #. Aria label for close mobile menu button
 #. js-lingui-explicit-id
@@ -885,6 +983,12 @@ msgstr "Verbinden"
 msgid "settings.account.socials.title"
 msgstr "Verknüpfte Konten"
 
+#. Footer link to contact email
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Kontakt"
+
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:24
@@ -895,12 +999,6 @@ msgstr "Kontakt"
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:95
 msgid "license.contact.title"
-msgstr "Kontakt"
-
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
 msgstr "Kontakt"
 
 #. Table of contents heading
@@ -985,7 +1083,7 @@ msgstr "Prompt kopieren"
 #. Location type label for countries
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:33
-#: src/components/search/location-pills.tsx:31
+#: src/components/search/location-pills.tsx:29
 msgid "location.type.country"
 msgstr "Land"
 
@@ -1165,7 +1263,7 @@ msgstr "Details"
 
 #. Collapsible section heading for extracted job details
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:387
+#: src/components/search/job-detail-dialog.tsx:389
 msgid "search.detail.details"
 msgstr "Details"
 
@@ -1274,7 +1372,7 @@ msgstr "E-Mail bestätigt"
 
 #. Title for the employment type selection modal
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:74
+#: src/components/search/employment-type-modal.tsx:75
 msgid "search.employmentTypeModal.title"
 msgstr "Beschäftigungsart"
 
@@ -1453,7 +1551,7 @@ msgstr "Feb"
 
 #. Button to add a filter to watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:295
+#: src/components/watchlist/watchlist-filter-editor.tsx:352
 msgid "watchlists.filters.add"
 msgstr "Filter"
 
@@ -1461,33 +1559,33 @@ msgstr "Filter"
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:116
-#: src/components/search/job-detail-dialog.tsx:300
-#: src/components/search/job-detail-dialog.tsx:378
+#: src/components/search/job-detail-dialog.tsx:118
+#: src/components/search/job-detail-dialog.tsx:302
+#: src/components/search/job-detail-dialog.tsx:380
 msgid "search.detail.filterByPrefix"
 msgstr "Filtern nach"
 
 #. Tooltip for salary filter pill
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:226
+#: src/components/search/job-detail-dialog.tsx:228
 msgid "search.detail.filterBySalary"
 msgstr "Nach Gehaltsbereich filtern"
 
 #. Placeholder for industry filter search
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:247
+#: src/components/watchlist/company-search-modal.tsx:250
 msgid "watchlists.companyModal.industrySearch"
 msgstr "Branchen filtern..."
 
 #. Placeholder for search input in technology modal
 #. js-lingui-explicit-id
-#: src/components/search/technology-modal.tsx:130
+#: src/components/search/technology-modal.tsx:133
 msgid "search.technologyModal.searchPlaceholder"
 msgstr "Technologien filtern..."
 
 #. Section title for filters in watchlist view
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:221
+#: src/components/watchlist/watchlist-filter-editor.tsx:224
 msgid "watchlists.view.filters"
 msgstr "Filter"
 
@@ -1663,7 +1761,7 @@ msgstr "Verstanden"
 
 #. Dismiss upgrade modal
 #. js-lingui-explicit-id
-#: src/components/ui/upgrade-modal.tsx:66
+#: src/components/ui/upgrade-modal.tsx:69
 msgid "upgrade.modal.dismiss"
 msgstr "Verstanden"
 
@@ -1759,9 +1857,9 @@ msgstr "So indexieren wir"
 #. Work mode: hybrid (mixed onsite/remote)
 #. Work mode: hybrid (mixed onsite/remote)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:587
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:597
 #: src/components/search/search-bar.tsx:812
-#: src/components/search/search-toolbar.tsx:260
+#: src/components/search/search-toolbar.tsx:271
 #: src/components/search/work-mode-modal.tsx:27
 msgid "search.workMode.hybrid"
 msgstr "Hybrid"
@@ -1837,7 +1935,7 @@ msgstr "Indexierungsrichtlinie"
 
 #. Industry filter label
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:235
+#: src/components/watchlist/company-search-modal.tsx:238
 msgid "watchlists.companyModal.industry"
 msgstr "Branche"
 
@@ -1897,7 +1995,7 @@ msgstr "Im Interview"
 
 #. Application tracker status: interviewing
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:450
+#: src/components/search/job-detail-dialog.tsx:452
 msgid "search.tracker.interviewing"
 msgstr "Im Interview"
 
@@ -1972,7 +2070,7 @@ msgstr "Stellendaten (CC BY-NC 4.0)"
 
 #. Job detail panel title
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:86
+#: src/components/search/job-detail-dialog.tsx:87
 msgid "search.detail.title"
 msgstr "Stellendetails"
 
@@ -2100,7 +2198,7 @@ msgstr "Jun"
 
 #. Add keyword filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:208
+#: src/components/watchlist/watchlist-filter-editor.tsx:211
 msgid "watchlists.filters.keyword"
 msgstr "Stichwort"
 
@@ -2220,7 +2318,7 @@ msgstr "Wird geladen\\u2026"
 
 #. Add location filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:209
+#: src/components/watchlist/watchlist-filter-editor.tsx:212
 msgid "watchlists.filters.location"
 msgstr "Standort"
 
@@ -2230,16 +2328,16 @@ msgstr "Standort"
 msgid "search.advanced.location"
 msgstr "Standort"
 
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:314
+msgid "search.detail.locations"
+msgstr "Standorte"
+
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:842
 msgid "search.bar.locations"
-msgstr "Standorte"
-
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
 msgstr "Standorte"
 
 #. Login button label
@@ -2318,7 +2416,7 @@ msgstr "Als abgelehnt markieren"
 
 #. Header for the server-side search-results cluster shown when the user types in the location modal search box
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:582
+#: src/components/search/location-search-modal.tsx:585
 msgid "search.locationModal.searchHitsHeader"
 msgstr "Treffer"
 
@@ -2409,7 +2507,7 @@ msgstr "Monatlich"
 
 #. Expand location pill list to show all
 #. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:356
+#: src/components/search/filter-bar.tsx:360
 msgid "company.page.showMore"
 msgstr "mehr"
 
@@ -2510,37 +2608,37 @@ msgstr "Keine kommerzielle Weiterverbreitung oder Weiterverkauf ohne Genehmigung
 
 #. Empty state when no filters are set
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:407
+#: src/components/watchlist/watchlist-filter-editor.tsx:467
 msgid "watchlists.filters.empty"
 msgstr "Keine Filter gesetzt. Füge Filter hinzu, um die Ergebnisse einzugrenzen."
 
 #. No industries match search
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:277
+#: src/components/watchlist/company-search-modal.tsx:280
 msgid "watchlists.companyModal.noIndustries"
 msgstr "Keine Branchen gefunden."
 
 #. Empty state when no jobs match the time range
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:207
+#: src/components/watchlist/watchlist-job-list.tsx:208
 msgid "watchlists.jobList.empty"
 msgstr "Keine Jobs gefunden."
 
 #. No languages match search in all-languages modal
 #. js-lingui-explicit-id
-#: src/components/settings/JobLanguageModal.tsx:92
+#: src/components/settings/JobLanguageModal.tsx:95
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Keine Sprachen entsprechen deiner Suche."
 
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:309
+#: src/components/search/location-modal.tsx:312
 msgid "company.locationModal.noResults"
 msgstr "Keine Standorte entsprechen Ihrer Suche."
 
 #. No locations match search in location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:513
+#: src/components/search/location-search-modal.tsx:516
 msgid "search.locationModal.noResults"
 msgstr "Keine Standorte gefunden."
 
@@ -2570,19 +2668,19 @@ msgstr "Keine Ergebnisse für „{query}\" gefunden"
 
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:341
+#: src/components/search/occupation-modal.tsx:344
 msgid "search.occupationModal.noResults"
 msgstr "Keine Berufe gefunden."
 
 #. No seniority levels available
 #. js-lingui-explicit-id
-#: src/components/search/seniority-modal.tsx:76
+#: src/components/search/seniority-modal.tsx:80
 msgid "search.seniorityModal.noResults"
 msgstr "Keine Erfahrungsstufen verfügbar."
 
 #. No technologies available or matching search
 #. js-lingui-explicit-id
-#: src/components/search/technology-modal.tsx:151
+#: src/components/search/technology-modal.tsx:154
 msgid "search.technologyModal.noResults"
 msgstr "Keine Technologien gefunden."
 
@@ -2622,7 +2720,7 @@ msgstr "Nein. Wir verkaufen, vermieten oder teilen deine Daten nicht zu Marketin
 
 #. Application tracker status: not applied
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:448
+#: src/components/search/job-detail-dialog.tsx:450
 msgid "search.tracker.notApplied"
 msgstr "Nicht beworben"
 
@@ -2646,7 +2744,7 @@ msgstr "Nov"
 
 #. Add occupation filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:210
+#: src/components/watchlist/watchlist-filter-editor.tsx:213
 msgid "watchlists.filters.occupation"
 msgstr "Berufsfeld"
 
@@ -2658,7 +2756,7 @@ msgstr "Okt"
 
 #. Application tracker status: offer
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:451
+#: src/components/search/job-detail-dialog.tsx:453
 msgid "search.tracker.offer"
 msgstr "Angebot"
 
@@ -2697,9 +2795,9 @@ msgstr "Ok"
 #. Work mode: onsite (in-office)
 #. Work mode: onsite (in-office)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:585
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:595
 #: src/components/search/search-bar.tsx:810
-#: src/components/search/search-toolbar.tsx:258
+#: src/components/search/search-toolbar.tsx:269
 #: src/components/search/work-mode-modal.tsx:26
 msgid "search.workMode.onsite"
 msgstr "Vor Ort"
@@ -2777,13 +2875,13 @@ msgstr "Original"
 
 #. Fallback label for a country header in the location modal when the city has no parent country in the hierarchy. Rare path.
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:635
+#: src/components/search/location-search-modal.tsx:638
 msgid "search.locationModal.otherCountry"
 msgstr "Sonstige"
 
 #. Fallback label for a region row in the location modal when the region has no display name (e.g. orphaned cities). Rare path; only shown when a city's parent region in the hierarchy has no localized name.
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:720
+#: src/components/search/location-search-modal.tsx:723
 msgid "search.locationModal.otherRegion"
 msgstr "Sonstige"
 
@@ -3013,13 +3111,13 @@ msgstr "Bitte melden Sie sich an, um Ihre Abrechnungseinstellungen zu verwalten.
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:101
+#: src/components/search/job-detail-dialog.tsx:103
 msgid "search.detail.notFound"
 msgstr "Stelle nicht gefunden."
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:183
+#: src/components/my-jobs/my-job-detail-panel.tsx:184
 msgid "myJobs.detail.notFound"
 msgstr "Stellenanzeige nicht gefunden."
 
@@ -3157,20 +3255,20 @@ msgstr "Deine Änderungen weiterverbreiten, solange du den MIT-Hinweis beifügst
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:32
 #: src/components/search/filter-bar.tsx:34
+#: src/components/search/location-pills.tsx:28
 #: src/components/search/location-pills.tsx:30
-#: src/components/search/location-pills.tsx:32
 msgid "location.type.region"
 msgstr "Region"
 
 #. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:319
+#: src/components/search/location-modal.tsx:322
 msgid "company.locationModal.regionsHeader"
 msgstr "Regionen"
 
 #. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:523
+#: src/components/search/location-search-modal.tsx:526
 msgid "search.locationModal.regionsHeader"
 msgstr "Regionen"
 
@@ -3182,7 +3280,7 @@ msgstr "Abgelehnt"
 
 #. Application tracker status: rejected
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:452
+#: src/components/search/job-detail-dialog.tsx:454
 msgid "search.tracker.rejected"
 msgstr "Abgelehnt"
 
@@ -3215,12 +3313,84 @@ msgstr "Veröffentlicht unter der MIT-Lizenz. Stellendaten sind CC BY-NC 4.0."
 #. Work mode: remote (work-from-home)
 #. Work mode: remote (work-from-home)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:588
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:598
 #: src/components/search/search-bar.tsx:813
-#: src/components/search/search-toolbar.tsx:261
+#: src/components/search/search-toolbar.tsx:272
 #: src/components/search/work-mode-modal.tsx:28
 msgid "search.workMode.remote"
 msgstr "Remote"
+
+#. Aria label for the X button that removes a company pill; {name} is the company name
+#. js-lingui-explicit-id
+#. placeholder {0}: company.name
+#: src/components/watchlist/company-pill.tsx:24
+msgid "watchlists.companyPill.remove"
+msgstr "{0} entfernen"
+
+#. Aria label for the X button that removes a filter pill; {name} is the filter value
+#. Aria label for the X button that removes a filter pill; {name} is the filter value
+#. js-lingui-explicit-id
+#. placeholder {0}: pill.filter.name
+#: src/components/search/filter-bar.tsx:279
+#: src/components/search/filter-bar.tsx:297
+msgid "company.page.removeFilter"
+msgstr "Filter {0} entfernen"
+
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:559
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:569
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:579
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:589
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:603
+#: src/components/search/search-toolbar.tsx:201
+#: src/components/search/search-toolbar.tsx:220
+#: src/components/search/search-toolbar.tsx:240
+#: src/components/search/search-toolbar.tsx:260
+#: src/components/search/search-toolbar.tsx:283
+msgid "search.filters.removeFilter"
+msgstr "Filter {name} entfernen"
+
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:240
+#: src/components/watchlist/watchlist-filter-editor.tsx:252
+#: src/components/watchlist/watchlist-filter-editor.tsx:264
+#: src/components/watchlist/watchlist-filter-editor.tsx:276
+#: src/components/watchlist/watchlist-filter-editor.tsx:288
+#: src/components/watchlist/watchlist-filter-editor.tsx:300
+#: src/components/watchlist/watchlist-filter-editor.tsx:312
+msgid "watchlists.filters.removeFilter"
+msgstr "Filter {name} entfernen"
+
+#. Aria label for the X button that clears the experience-range filter
+#. Aria label for the X button that clears the experience-range filter
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:622
+#: src/components/search/search-toolbar.tsx:318
+msgid "search.filters.removeExperience"
+msgstr "Erfahrungsfilter entfernen"
+
+#. Aria label for the X button that clears the experience-range watchlist filter
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:339
+msgid "watchlists.filters.removeExperience"
+msgstr "Erfahrungsfilter entfernen"
 
 #. Aria label for removing a keyword pill
 #. js-lingui-explicit-id
@@ -3228,11 +3398,55 @@ msgstr "Remote"
 msgid "search.keywords.remove"
 msgstr "Stichwort entfernen"
 
+#. Aria label for the X button that removes a keyword filter pill; {name} is the keyword
+#. js-lingui-explicit-id
+#. placeholder {0}: pill.filter.value
+#: src/components/search/filter-bar.tsx:261
+msgid "company.page.removeKeyword"
+msgstr "Stichwort {0} entfernen"
+
+#. Aria label for remove-keyword X button; {name} is the keyword
+#. Aria label for remove-keyword X button; {name} is the keyword
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:630
+#: src/components/search/search-toolbar.tsx:335
+msgid "search.filters.removeKeyword"
+msgstr "Stichwort {name} entfernen"
+
 #. Aria label for removing a location pill
 #. js-lingui-explicit-id
-#: src/components/search/location-pills.tsx:201
+#: src/components/search/location-pills.tsx:199
 msgid "search.locations.remove"
 msgstr "Standort entfernen"
+
+#. Aria label for the X button that removes a location filter pill; {name} is the location label
+#. js-lingui-explicit-id
+#. placeholder {0}: pill.filter.name
+#: src/components/search/filter-bar.tsx:315
+msgid "company.page.removeLocation"
+msgstr "Standort {0} entfernen"
+
+#. Aria label for remove-location X button; {name} is the location label
+#. Aria label for remove-location X button; {name} is the location label
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:640
+#: src/components/search/search-toolbar.tsx:356
+msgid "search.filters.removeLocation"
+msgstr "Standort {name} entfernen"
+
+#. Aria label for the X button that clears the salary-range filter
+#. Aria label for the X button that clears the salary-range filter
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:613
+#: src/components/search/search-toolbar.tsx:301
+msgid "search.filters.removeSalary"
+msgstr "Gehaltsfilter entfernen"
+
+#. Aria label for the X button that clears the salary-range watchlist filter
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:326
+msgid "watchlists.filters.removeSalary"
+msgstr "Gehaltsfilter entfernen"
 
 #. Synthetic dropdown row that lets the user request a company that's not in the catalog
 #. js-lingui-explicit-id
@@ -3284,13 +3498,13 @@ msgstr "Bestätigungs-E-Mail erneut senden"
 
 #. Reset salary filter
 #. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:314
+#: src/components/search/salary-modal.tsx:318
 msgid "search.salaryModal.reset"
 msgstr "Zurücksetzen"
 
 #. Reset experience filter
 #. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:240
+#: src/components/search/experience-modal.tsx:243
 msgid "search.experienceModal.reset"
 msgstr "Zurücksetzen"
 
@@ -3362,7 +3576,7 @@ msgstr "Gehaltsanzeige"
 
 #. Title for salary filter modal
 #. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:246
+#: src/components/search/salary-modal.tsx:247
 msgid "search.salaryModal.title"
 msgstr "Gehaltsspanne"
 
@@ -3471,7 +3685,7 @@ msgstr "Unternehmen suchen..."
 
 #. Placeholder for company search in modal
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:217
+#: src/components/watchlist/company-search-modal.tsx:220
 msgid "watchlists.companyModal.searchPlaceholder"
 msgstr "Unternehmen suchen..."
 
@@ -3488,19 +3702,19 @@ msgstr "Durchsuche Jobs bei Tausenden von Unternehmen, direkt von Karriereseiten
 
 #. Placeholder for search input in all-languages modal
 #. js-lingui-explicit-id
-#: src/components/settings/JobLanguageModal.tsx:78
+#: src/components/settings/JobLanguageModal.tsx:81
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Sprachen suchen…"
 
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:288
+#: src/components/search/location-modal.tsx:291
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Standorte suchen…"
 
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:492
+#: src/components/search/location-search-modal.tsx:495
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Standorte suchen..."
 
@@ -3512,7 +3726,7 @@ msgstr "Suchergebnisse"
 
 #. Placeholder for search input in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:320
+#: src/components/search/occupation-modal.tsx:323
 msgid "search.occupationModal.searchPlaceholder"
 msgstr "Berufe suchen..."
 
@@ -3542,7 +3756,7 @@ msgstr "Sieh deinen Funnel, deine Konversionsraten und deine Aktivitäts-Heatmap
 
 #. Title for the seniority level selection modal
 #. js-lingui-explicit-id
-#: src/components/search/seniority-modal.tsx:57
+#: src/components/search/seniority-modal.tsx:58
 msgid "search.seniorityModal.title"
 msgstr "Stufe auswählen"
 
@@ -3608,7 +3822,7 @@ msgstr "Senden…"
 
 #. Add seniority filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:211
+#: src/components/watchlist/watchlist-filter-editor.tsx:214
 msgid "watchlists.filters.seniority"
 msgstr "Erfahrungsstufe"
 
@@ -3654,16 +3868,16 @@ msgstr "Einstellungen"
 msgid "home.features.s3.p3.title"
 msgstr "Mit jedem teilen"
 
-#. Collapse location pill list
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:351
-msgid "company.page.showLess"
-msgstr "Weniger anzeigen"
-
 #. Button to collapse location list
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:355
+#: src/components/search/job-detail-dialog.tsx:357
 msgid "search.detail.showLessLocations"
+msgstr "Weniger anzeigen"
+
+#. Collapse location pill list
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:355
+msgid "company.page.showLess"
 msgstr "Weniger anzeigen"
 
 #. Aria label to show password
@@ -3860,7 +4074,7 @@ msgstr "Status"
 
 #. Status section heading
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:200
+#: src/components/my-jobs/my-job-detail-panel.tsx:201
 msgid "myJobs.detail.status"
 msgstr "Status"
 
@@ -3936,21 +4150,21 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technisch"
 
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:399
+msgid "search.detail.technologies"
+msgstr "Technologien"
+
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:765
 msgid "search.bar.technologies"
 msgstr "Technologien"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Technologien"
-
 #. Add technology filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:212
+#: src/components/watchlist/watchlist-filter-editor.tsx:215
 msgid "watchlists.filters.technology"
 msgstr "Technologie"
 
@@ -4134,7 +4348,7 @@ msgstr "Erneut versuchen"
 
 #. Add employment type filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:213
+#: src/components/watchlist/watchlist-filter-editor.tsx:216
 msgid "watchlists.filters.employmentType"
 msgstr "Art"
 
@@ -4146,7 +4360,7 @@ msgstr "Beschäftigungsart"
 
 #. Placeholder for filter value input
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:377
+#: src/components/watchlist/watchlist-filter-editor.tsx:435
 msgid "watchlists.filters.inputPlaceholder"
 msgstr "Slug eingeben und Enter drücken"
 
@@ -4211,7 +4425,7 @@ msgstr "Benutzername aktualisieren"
 
 #. Upgrade button in modal
 #. js-lingui-explicit-id
-#: src/components/ui/upgrade-modal.tsx:74
+#: src/components/ui/upgrade-modal.tsx:77
 msgid "upgrade.modal.upgrade"
 msgstr "Upgrade"
 
@@ -4294,7 +4508,7 @@ msgstr "Videoanruf"
 
 #. Link to the original job posting
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:186
+#: src/components/search/job-detail-dialog.tsx:188
 msgid "search.detail.viewPosting"
 msgstr "Stellenanzeige ansehen"
 
@@ -4508,13 +4722,13 @@ msgstr "Welche Sprachen unterstützt Jobseek?"
 
 #. Add work-mode (onsite/hybrid/remote) filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:214
+#: src/components/watchlist/watchlist-filter-editor.tsx:217
 msgid "watchlists.filters.workMode"
 msgstr "Arbeitsmodus"
 
 #. Title for the work-mode (onsite/hybrid/remote) selection modal
 #. js-lingui-explicit-id
-#: src/components/search/work-mode-modal.tsx:82
+#: src/components/search/work-mode-modal.tsx:83
 msgid "search.workModeModal.title"
 msgstr "Arbeitsweise"
 

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -53,7 +53,7 @@ msgstr "(opens in new tab)"
 #. Button to show remaining collapsed locations
 #. js-lingui-explicit-id
 #. placeholder {0}: locations.length - LOCATIONS_COLLAPSED
-#: src/components/search/job-detail-dialog.tsx:359
+#: src/components/search/job-detail-dialog.tsx:361
 msgid "search.detail.showMoreLocations"
 msgstr "{0} more"
 
@@ -255,6 +255,12 @@ msgstr "Add companies"
 msgid "watchlists.view.addDescription"
 msgstr "Add description"
 
+#. Aria label for the checkmark button that confirms adding a filter
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:448
+msgid "watchlists.filters.confirmAdd"
+msgstr "Add filter"
+
 #. Quick action tooltip: add interview round
 #. js-lingui-explicit-id
 #: src/components/my-jobs/quick-actions.tsx:19
@@ -281,7 +287,7 @@ msgstr "Add location or keyword filter..."
 
 #. Placeholder in the add location input
 #. js-lingui-explicit-id
-#: src/components/search/location-pills.tsx:176
+#: src/components/search/location-pills.tsx:174
 msgid "search.locations.addPlaceholder"
 msgstr "Add location..."
 
@@ -299,7 +305,7 @@ msgstr "Agent prompt"
 
 #. Footer shown after all paged countries have been loaded into the location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:813
+#: src/components/search/location-search-modal.tsx:816
 msgid "search.locationModal.allLoaded"
 msgstr "All {totalCountries} countries loaded"
 
@@ -311,7 +317,7 @@ msgstr "All data is encrypted in transit and at rest."
 
 #. Option to show all industries
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:259
+#: src/components/watchlist/company-search-modal.tsx:262
 msgid "watchlists.companyModal.allIndustries"
 msgstr "All industries"
 
@@ -335,7 +341,7 @@ msgstr "All locations"
 
 #. Button to open all-locations modal on company page
 #. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:342
+#: src/components/search/filter-bar.tsx:346
 msgid "company.page.allLocations"
 msgstr "All locations"
 
@@ -400,7 +406,7 @@ msgstr "Application Stats"
 
 #. Application tracker section heading in job detail
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:247
+#: src/components/search/job-detail-dialog.tsx:249
 msgid "search.detail.applicationTracker"
 msgstr "Application tracker"
 
@@ -424,7 +430,7 @@ msgstr "Applied"
 
 #. Application tracker status: applied
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:449
+#: src/components/search/job-detail-dialog.tsx:451
 msgid "search.tracker.applied"
 msgstr "Applied"
 
@@ -448,19 +454,19 @@ msgstr "Applied"
 
 #. Apply salary filter
 #. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:320
+#: src/components/search/salary-modal.tsx:324
 msgid "search.salaryModal.apply"
 msgstr "Apply"
 
 #. Apply experience filter
 #. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:246
+#: src/components/search/experience-modal.tsx:249
 msgid "search.experienceModal.apply"
 msgstr "Apply"
 
 #. Apply button linking to original job posting
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:292
+#: src/components/my-jobs/my-job-detail-panel.tsx:293
 msgid "search.detail.apply"
 msgstr "Apply"
 
@@ -500,16 +506,16 @@ msgstr "Aug"
 msgid "settings.account.username.available"
 msgstr "Available"
 
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Back to sign in"
-
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Back to sign in"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Back to sign in"
 
 #. Link back to sign-in from forgot password
@@ -617,6 +623,14 @@ msgstr "Can I opt out of Jobseek indexing my company?"
 msgid "watchlists.delete.cancel"
 msgstr "Cancel"
 
+#. Aria label for the X button that cancels the inline add-filter UI
+#. Aria label for the X button that cancels the inline add-filter UI
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:420
+#: src/components/watchlist/watchlist-filter-editor.tsx:456
+msgid "watchlists.filters.cancel"
+msgstr "Cancel"
+
 #. Cancel delete button
 #. js-lingui-explicit-id
 #: src/components/settings/AccountSettings.tsx:532
@@ -711,7 +725,7 @@ msgstr "Choose which languages you want to see job postings in."
 #. Location type label for cities
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:35
-#: src/components/search/location-pills.tsx:33
+#: src/components/search/location-pills.tsx:31
 msgid "location.type.city"
 msgstr "City"
 
@@ -730,8 +744,8 @@ msgstr "Clear all"
 #. Button to clear all active search filters
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:624
-#: src/components/search/search-toolbar.tsx:337
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:645
+#: src/components/search/search-toolbar.tsx:367
 msgid "search.filters.clearAll"
 msgstr "Clear all"
 
@@ -758,6 +772,90 @@ msgstr "Click to rename"
 #: src/components/HowWeIndexContent.tsx:119
 msgid "indexing.ingestion.s2.title"
 msgstr "Client APIs second."
+
+#. Aria label for close button on add-companies modal
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-search-modal.tsx:201
+msgid "watchlists.companyModal.close"
+msgstr "Close"
+
+#. Aria label for upgrade modal close button
+#. js-lingui-explicit-id
+#: src/components/ui/upgrade-modal.tsx:59
+msgid "upgrade.modal.close"
+msgstr "Close"
+
+#. Aria label for the job-languages modal close button
+#. js-lingui-explicit-id
+#: src/components/settings/JobLanguageModal.tsx:66
+msgid "settings.jobLanguages.modal.close"
+msgstr "Close"
+
+#. Aria label for the work-mode modal close button
+#. js-lingui-explicit-id
+#: src/components/search/work-mode-modal.tsx:90
+msgid "search.workModeModal.close"
+msgstr "Close"
+
+#. Aria label for the technology modal close button
+#. js-lingui-explicit-id
+#: src/components/search/technology-modal.tsx:117
+msgid "search.technologyModal.close"
+msgstr "Close"
+
+#. Aria label for the seniority modal close button
+#. js-lingui-explicit-id
+#: src/components/search/seniority-modal.tsx:65
+msgid "search.seniorityModal.close"
+msgstr "Close"
+
+#. Aria label for the salary modal close button
+#. js-lingui-explicit-id
+#: src/components/search/salary-modal.tsx:254
+msgid "search.salaryModal.close"
+msgstr "Close"
+
+#. Aria label for close button on the company-page all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:275
+msgid "company.locationModal.close"
+msgstr "Close"
+
+#. Aria label for the employment-type modal close button
+#. js-lingui-explicit-id
+#: src/components/search/employment-type-modal.tsx:82
+msgid "search.employmentTypeModal.close"
+msgstr "Close"
+
+#. Aria label for the location modal close button
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:479
+msgid "search.locationModal.close"
+msgstr "Close"
+
+#. Aria label for the experience modal close button
+#. js-lingui-explicit-id
+#: src/components/search/experience-modal.tsx:193
+msgid "search.experienceModal.close"
+msgstr "Close"
+
+#. Aria label for the occupation modal close button
+#. js-lingui-explicit-id
+#: src/components/search/occupation-modal.tsx:307
+msgid "search.occupationModal.close"
+msgstr "Close"
+
+#. Aria label for job detail panel close button
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:92
+msgid "search.detail.close"
+msgstr "Close job details"
+
+#. Aria label for the my-jobs detail panel close button
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:173
+msgid "myJobs.detail.close"
+msgstr "Close job details"
 
 #. Aria label for close mobile menu button
 #. js-lingui-explicit-id
@@ -885,6 +983,12 @@ msgstr "Connect"
 msgid "settings.account.socials.title"
 msgstr "Connected accounts"
 
+#. Footer link to contact email
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Contact"
+
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:24
@@ -895,12 +999,6 @@ msgstr "Contact"
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:95
 msgid "license.contact.title"
-msgstr "Contact"
-
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
 msgstr "Contact"
 
 #. Table of contents heading
@@ -985,7 +1083,7 @@ msgstr "Copy prompt"
 #. Location type label for countries
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:33
-#: src/components/search/location-pills.tsx:31
+#: src/components/search/location-pills.tsx:29
 msgid "location.type.country"
 msgstr "Country"
 
@@ -1165,7 +1263,7 @@ msgstr "Details"
 
 #. Collapsible section heading for extracted job details
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:387
+#: src/components/search/job-detail-dialog.tsx:389
 msgid "search.detail.details"
 msgstr "Details"
 
@@ -1274,7 +1372,7 @@ msgstr "Email verified"
 
 #. Title for the employment type selection modal
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:74
+#: src/components/search/employment-type-modal.tsx:75
 msgid "search.employmentTypeModal.title"
 msgstr "Employment type"
 
@@ -1453,7 +1551,7 @@ msgstr "Feb"
 
 #. Button to add a filter to watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:295
+#: src/components/watchlist/watchlist-filter-editor.tsx:352
 msgid "watchlists.filters.add"
 msgstr "Filter"
 
@@ -1461,33 +1559,33 @@ msgstr "Filter"
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:116
-#: src/components/search/job-detail-dialog.tsx:300
-#: src/components/search/job-detail-dialog.tsx:378
+#: src/components/search/job-detail-dialog.tsx:118
+#: src/components/search/job-detail-dialog.tsx:302
+#: src/components/search/job-detail-dialog.tsx:380
 msgid "search.detail.filterByPrefix"
 msgstr "Filter by"
 
 #. Tooltip for salary filter pill
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:226
+#: src/components/search/job-detail-dialog.tsx:228
 msgid "search.detail.filterBySalary"
 msgstr "Filter by this salary range"
 
 #. Placeholder for industry filter search
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:247
+#: src/components/watchlist/company-search-modal.tsx:250
 msgid "watchlists.companyModal.industrySearch"
 msgstr "Filter industries..."
 
 #. Placeholder for search input in technology modal
 #. js-lingui-explicit-id
-#: src/components/search/technology-modal.tsx:130
+#: src/components/search/technology-modal.tsx:133
 msgid "search.technologyModal.searchPlaceholder"
 msgstr "Filter technologies..."
 
 #. Section title for filters in watchlist view
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:221
+#: src/components/watchlist/watchlist-filter-editor.tsx:224
 msgid "watchlists.view.filters"
 msgstr "Filters"
 
@@ -1663,7 +1761,7 @@ msgstr "Got it"
 
 #. Dismiss upgrade modal
 #. js-lingui-explicit-id
-#: src/components/ui/upgrade-modal.tsx:66
+#: src/components/ui/upgrade-modal.tsx:69
 msgid "upgrade.modal.dismiss"
 msgstr "Got it"
 
@@ -1759,9 +1857,9 @@ msgstr "How We Index"
 #. Work mode: hybrid (mixed onsite/remote)
 #. Work mode: hybrid (mixed onsite/remote)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:587
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:597
 #: src/components/search/search-bar.tsx:812
-#: src/components/search/search-toolbar.tsx:260
+#: src/components/search/search-toolbar.tsx:271
 #: src/components/search/work-mode-modal.tsx:27
 msgid "search.workMode.hybrid"
 msgstr "Hybrid"
@@ -1837,7 +1935,7 @@ msgstr "Indexing policy"
 
 #. Industry filter label
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:235
+#: src/components/watchlist/company-search-modal.tsx:238
 msgid "watchlists.companyModal.industry"
 msgstr "Industry"
 
@@ -1897,7 +1995,7 @@ msgstr "Interviewing"
 
 #. Application tracker status: interviewing
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:450
+#: src/components/search/job-detail-dialog.tsx:452
 msgid "search.tracker.interviewing"
 msgstr "Interviewing"
 
@@ -1972,7 +2070,7 @@ msgstr "Job data (CC BY-NC 4.0)"
 
 #. Job detail panel title
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:86
+#: src/components/search/job-detail-dialog.tsx:87
 msgid "search.detail.title"
 msgstr "Job Details"
 
@@ -2100,7 +2198,7 @@ msgstr "Jun"
 
 #. Add keyword filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:208
+#: src/components/watchlist/watchlist-filter-editor.tsx:211
 msgid "watchlists.filters.keyword"
 msgstr "Keyword"
 
@@ -2220,7 +2318,7 @@ msgstr "Loading…"
 
 #. Add location filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:209
+#: src/components/watchlist/watchlist-filter-editor.tsx:212
 msgid "watchlists.filters.location"
 msgstr "Location"
 
@@ -2230,16 +2328,16 @@ msgstr "Location"
 msgid "search.advanced.location"
 msgstr "Location"
 
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:314
+msgid "search.detail.locations"
+msgstr "Locations"
+
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:842
 msgid "search.bar.locations"
-msgstr "Locations"
-
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
 msgstr "Locations"
 
 #. Login button label
@@ -2318,7 +2416,7 @@ msgstr "Mark rejected"
 
 #. Header for the server-side search-results cluster shown when the user types in the location modal search box
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:582
+#: src/components/search/location-search-modal.tsx:585
 msgid "search.locationModal.searchHitsHeader"
 msgstr "Matches"
 
@@ -2409,7 +2507,7 @@ msgstr "Monthly"
 
 #. Expand location pill list to show all
 #. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:356
+#: src/components/search/filter-bar.tsx:360
 msgid "company.page.showMore"
 msgstr "more"
 
@@ -2510,37 +2608,37 @@ msgstr "No commercial redistribution or resale without permission."
 
 #. Empty state when no filters are set
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:407
+#: src/components/watchlist/watchlist-filter-editor.tsx:467
 msgid "watchlists.filters.empty"
 msgstr "No filters set. Add filters to narrow job results."
 
 #. No industries match search
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:277
+#: src/components/watchlist/company-search-modal.tsx:280
 msgid "watchlists.companyModal.noIndustries"
 msgstr "No industries found."
 
 #. Empty state when no jobs match the time range
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:207
+#: src/components/watchlist/watchlist-job-list.tsx:208
 msgid "watchlists.jobList.empty"
 msgstr "No jobs found."
 
 #. No languages match search in all-languages modal
 #. js-lingui-explicit-id
-#: src/components/settings/JobLanguageModal.tsx:92
+#: src/components/settings/JobLanguageModal.tsx:95
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "No languages match your search."
 
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:309
+#: src/components/search/location-modal.tsx:312
 msgid "company.locationModal.noResults"
 msgstr "No locations match your search."
 
 #. No locations match search in location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:513
+#: src/components/search/location-search-modal.tsx:516
 msgid "search.locationModal.noResults"
 msgstr "No locations match your search."
 
@@ -2570,19 +2668,19 @@ msgstr "No results found for “{query}”"
 
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:341
+#: src/components/search/occupation-modal.tsx:344
 msgid "search.occupationModal.noResults"
 msgstr "No roles match your search."
 
 #. No seniority levels available
 #. js-lingui-explicit-id
-#: src/components/search/seniority-modal.tsx:76
+#: src/components/search/seniority-modal.tsx:80
 msgid "search.seniorityModal.noResults"
 msgstr "No seniority levels available."
 
 #. No technologies available or matching search
 #. js-lingui-explicit-id
-#: src/components/search/technology-modal.tsx:151
+#: src/components/search/technology-modal.tsx:154
 msgid "search.technologyModal.noResults"
 msgstr "No technologies found."
 
@@ -2622,7 +2720,7 @@ msgstr "No. We don't sell, rent, or share your data for marketing. Cookies are s
 
 #. Application tracker status: not applied
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:448
+#: src/components/search/job-detail-dialog.tsx:450
 msgid "search.tracker.notApplied"
 msgstr "Not applied"
 
@@ -2646,7 +2744,7 @@ msgstr "Nov"
 
 #. Add occupation filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:210
+#: src/components/watchlist/watchlist-filter-editor.tsx:213
 msgid "watchlists.filters.occupation"
 msgstr "Occupation"
 
@@ -2658,7 +2756,7 @@ msgstr "Oct"
 
 #. Application tracker status: offer
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:451
+#: src/components/search/job-detail-dialog.tsx:453
 msgid "search.tracker.offer"
 msgstr "Offer"
 
@@ -2697,9 +2795,9 @@ msgstr "Ok"
 #. Work mode: onsite (in-office)
 #. Work mode: onsite (in-office)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:585
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:595
 #: src/components/search/search-bar.tsx:810
-#: src/components/search/search-toolbar.tsx:258
+#: src/components/search/search-toolbar.tsx:269
 #: src/components/search/work-mode-modal.tsx:26
 msgid "search.workMode.onsite"
 msgstr "On-site"
@@ -2777,13 +2875,13 @@ msgstr "Original"
 
 #. Fallback label for a country header in the location modal when the city has no parent country in the hierarchy. Rare path.
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:635
+#: src/components/search/location-search-modal.tsx:638
 msgid "search.locationModal.otherCountry"
 msgstr "Other"
 
 #. Fallback label for a region row in the location modal when the region has no display name (e.g. orphaned cities). Rare path; only shown when a city's parent region in the hierarchy has no localized name.
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:720
+#: src/components/search/location-search-modal.tsx:723
 msgid "search.locationModal.otherRegion"
 msgstr "Other"
 
@@ -3013,13 +3111,13 @@ msgstr "Please log in to manage your billing settings."
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:101
+#: src/components/search/job-detail-dialog.tsx:103
 msgid "search.detail.notFound"
 msgstr "Posting not found."
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:183
+#: src/components/my-jobs/my-job-detail-panel.tsx:184
 msgid "myJobs.detail.notFound"
 msgstr "Posting not found."
 
@@ -3157,20 +3255,20 @@ msgstr "Redistribute your changes, as long as you include the MIT notice."
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:32
 #: src/components/search/filter-bar.tsx:34
+#: src/components/search/location-pills.tsx:28
 #: src/components/search/location-pills.tsx:30
-#: src/components/search/location-pills.tsx:32
 msgid "location.type.region"
 msgstr "Region"
 
 #. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:319
+#: src/components/search/location-modal.tsx:322
 msgid "company.locationModal.regionsHeader"
 msgstr "Regions"
 
 #. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:523
+#: src/components/search/location-search-modal.tsx:526
 msgid "search.locationModal.regionsHeader"
 msgstr "Regions"
 
@@ -3182,7 +3280,7 @@ msgstr "Rejected"
 
 #. Application tracker status: rejected
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:452
+#: src/components/search/job-detail-dialog.tsx:454
 msgid "search.tracker.rejected"
 msgstr "Rejected"
 
@@ -3215,12 +3313,84 @@ msgstr "Released under the MIT License. Job data is CC BY-NC 4.0."
 #. Work mode: remote (work-from-home)
 #. Work mode: remote (work-from-home)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:588
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:598
 #: src/components/search/search-bar.tsx:813
-#: src/components/search/search-toolbar.tsx:261
+#: src/components/search/search-toolbar.tsx:272
 #: src/components/search/work-mode-modal.tsx:28
 msgid "search.workMode.remote"
 msgstr "Remote"
+
+#. Aria label for the X button that removes a company pill; {name} is the company name
+#. js-lingui-explicit-id
+#. placeholder {0}: company.name
+#: src/components/watchlist/company-pill.tsx:24
+msgid "watchlists.companyPill.remove"
+msgstr "Remove {0}"
+
+#. Aria label for the X button that removes a filter pill; {name} is the filter value
+#. Aria label for the X button that removes a filter pill; {name} is the filter value
+#. js-lingui-explicit-id
+#. placeholder {0}: pill.filter.name
+#: src/components/search/filter-bar.tsx:279
+#: src/components/search/filter-bar.tsx:297
+msgid "company.page.removeFilter"
+msgstr "Remove {0} filter"
+
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:559
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:569
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:579
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:589
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:603
+#: src/components/search/search-toolbar.tsx:201
+#: src/components/search/search-toolbar.tsx:220
+#: src/components/search/search-toolbar.tsx:240
+#: src/components/search/search-toolbar.tsx:260
+#: src/components/search/search-toolbar.tsx:283
+msgid "search.filters.removeFilter"
+msgstr "Remove {name} filter"
+
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:240
+#: src/components/watchlist/watchlist-filter-editor.tsx:252
+#: src/components/watchlist/watchlist-filter-editor.tsx:264
+#: src/components/watchlist/watchlist-filter-editor.tsx:276
+#: src/components/watchlist/watchlist-filter-editor.tsx:288
+#: src/components/watchlist/watchlist-filter-editor.tsx:300
+#: src/components/watchlist/watchlist-filter-editor.tsx:312
+msgid "watchlists.filters.removeFilter"
+msgstr "Remove {name} filter"
+
+#. Aria label for the X button that clears the experience-range filter
+#. Aria label for the X button that clears the experience-range filter
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:622
+#: src/components/search/search-toolbar.tsx:318
+msgid "search.filters.removeExperience"
+msgstr "Remove experience filter"
+
+#. Aria label for the X button that clears the experience-range watchlist filter
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:339
+msgid "watchlists.filters.removeExperience"
+msgstr "Remove experience filter"
 
 #. Aria label for removing a keyword pill
 #. js-lingui-explicit-id
@@ -3228,11 +3398,55 @@ msgstr "Remote"
 msgid "search.keywords.remove"
 msgstr "Remove keyword"
 
+#. Aria label for the X button that removes a keyword filter pill; {name} is the keyword
+#. js-lingui-explicit-id
+#. placeholder {0}: pill.filter.value
+#: src/components/search/filter-bar.tsx:261
+msgid "company.page.removeKeyword"
+msgstr "Remove keyword {0}"
+
+#. Aria label for remove-keyword X button; {name} is the keyword
+#. Aria label for remove-keyword X button; {name} is the keyword
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:630
+#: src/components/search/search-toolbar.tsx:335
+msgid "search.filters.removeKeyword"
+msgstr "Remove keyword {name}"
+
 #. Aria label for removing a location pill
 #. js-lingui-explicit-id
-#: src/components/search/location-pills.tsx:201
+#: src/components/search/location-pills.tsx:199
 msgid "search.locations.remove"
 msgstr "Remove location"
+
+#. Aria label for the X button that removes a location filter pill; {name} is the location label
+#. js-lingui-explicit-id
+#. placeholder {0}: pill.filter.name
+#: src/components/search/filter-bar.tsx:315
+msgid "company.page.removeLocation"
+msgstr "Remove location {0}"
+
+#. Aria label for remove-location X button; {name} is the location label
+#. Aria label for remove-location X button; {name} is the location label
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:640
+#: src/components/search/search-toolbar.tsx:356
+msgid "search.filters.removeLocation"
+msgstr "Remove location {name}"
+
+#. Aria label for the X button that clears the salary-range filter
+#. Aria label for the X button that clears the salary-range filter
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:613
+#: src/components/search/search-toolbar.tsx:301
+msgid "search.filters.removeSalary"
+msgstr "Remove salary filter"
+
+#. Aria label for the X button that clears the salary-range watchlist filter
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:326
+msgid "watchlists.filters.removeSalary"
+msgstr "Remove salary filter"
 
 #. Synthetic dropdown row that lets the user request a company that's not in the catalog
 #. js-lingui-explicit-id
@@ -3284,13 +3498,13 @@ msgstr "Resend verification email"
 
 #. Reset salary filter
 #. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:314
+#: src/components/search/salary-modal.tsx:318
 msgid "search.salaryModal.reset"
 msgstr "Reset"
 
 #. Reset experience filter
 #. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:240
+#: src/components/search/experience-modal.tsx:243
 msgid "search.experienceModal.reset"
 msgstr "Reset"
 
@@ -3362,7 +3576,7 @@ msgstr "Salary display"
 
 #. Title for salary filter modal
 #. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:246
+#: src/components/search/salary-modal.tsx:247
 msgid "search.salaryModal.title"
 msgstr "Salary range"
 
@@ -3471,7 +3685,7 @@ msgstr "Search companies..."
 
 #. Placeholder for company search in modal
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:217
+#: src/components/watchlist/company-search-modal.tsx:220
 msgid "watchlists.companyModal.searchPlaceholder"
 msgstr "Search companies..."
 
@@ -3488,19 +3702,19 @@ msgstr "Search jobs across thousands of companies scraped directly from career p
 
 #. Placeholder for search input in all-languages modal
 #. js-lingui-explicit-id
-#: src/components/settings/JobLanguageModal.tsx:78
+#: src/components/settings/JobLanguageModal.tsx:81
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Search languages..."
 
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:288
+#: src/components/search/location-modal.tsx:291
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Search locations..."
 
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:492
+#: src/components/search/location-search-modal.tsx:495
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Search locations..."
 
@@ -3512,7 +3726,7 @@ msgstr "Search results"
 
 #. Placeholder for search input in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:320
+#: src/components/search/occupation-modal.tsx:323
 msgid "search.occupationModal.searchPlaceholder"
 msgstr "Search roles..."
 
@@ -3542,7 +3756,7 @@ msgstr "See your funnel, conversion rates, and activity heatmap to understand wh
 
 #. Title for the seniority level selection modal
 #. js-lingui-explicit-id
-#: src/components/search/seniority-modal.tsx:57
+#: src/components/search/seniority-modal.tsx:58
 msgid "search.seniorityModal.title"
 msgstr "Select level"
 
@@ -3608,7 +3822,7 @@ msgstr "Sending..."
 
 #. Add seniority filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:211
+#: src/components/watchlist/watchlist-filter-editor.tsx:214
 msgid "watchlists.filters.seniority"
 msgstr "Seniority"
 
@@ -3654,16 +3868,16 @@ msgstr "Settings"
 msgid "home.features.s3.p3.title"
 msgstr "Share with anyone"
 
-#. Collapse location pill list
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:351
-msgid "company.page.showLess"
-msgstr "Show less"
-
 #. Button to collapse location list
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:355
+#: src/components/search/job-detail-dialog.tsx:357
 msgid "search.detail.showLessLocations"
+msgstr "Show less"
+
+#. Collapse location pill list
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:355
+msgid "company.page.showLess"
 msgstr "Show less"
 
 #. Aria label to show password
@@ -3860,7 +4074,7 @@ msgstr "Status"
 
 #. Status section heading
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:200
+#: src/components/my-jobs/my-job-detail-panel.tsx:201
 msgid "myJobs.detail.status"
 msgstr "Status"
 
@@ -3936,21 +4150,21 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technical"
 
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:399
+msgid "search.detail.technologies"
+msgstr "Technologies"
+
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:765
 msgid "search.bar.technologies"
 msgstr "Technologies"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Technologies"
-
 #. Add technology filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:212
+#: src/components/watchlist/watchlist-filter-editor.tsx:215
 msgid "watchlists.filters.technology"
 msgstr "Technology"
 
@@ -4134,7 +4348,7 @@ msgstr "Try again"
 
 #. Add employment type filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:213
+#: src/components/watchlist/watchlist-filter-editor.tsx:216
 msgid "watchlists.filters.employmentType"
 msgstr "Type"
 
@@ -4146,7 +4360,7 @@ msgstr "Type"
 
 #. Placeholder for filter value input
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:377
+#: src/components/watchlist/watchlist-filter-editor.tsx:435
 msgid "watchlists.filters.inputPlaceholder"
 msgstr "Type slug and press Enter"
 
@@ -4211,7 +4425,7 @@ msgstr "Update username"
 
 #. Upgrade button in modal
 #. js-lingui-explicit-id
-#: src/components/ui/upgrade-modal.tsx:74
+#: src/components/ui/upgrade-modal.tsx:77
 msgid "upgrade.modal.upgrade"
 msgstr "Upgrade"
 
@@ -4294,7 +4508,7 @@ msgstr "Video Call"
 
 #. Link to the original job posting
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:186
+#: src/components/search/job-detail-dialog.tsx:188
 msgid "search.detail.viewPosting"
 msgstr "View posting"
 
@@ -4508,13 +4722,13 @@ msgstr "Which languages does Jobseek support?"
 
 #. Add work-mode (onsite/hybrid/remote) filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:214
+#: src/components/watchlist/watchlist-filter-editor.tsx:217
 msgid "watchlists.filters.workMode"
 msgstr "Work mode"
 
 #. Title for the work-mode (onsite/hybrid/remote) selection modal
 #. js-lingui-explicit-id
-#: src/components/search/work-mode-modal.tsx:82
+#: src/components/search/work-mode-modal.tsx:83
 msgid "search.workModeModal.title"
 msgstr "Work mode"
 

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -53,7 +53,7 @@ msgstr "(ouvre dans un nouvel onglet)"
 #. Button to show remaining collapsed locations
 #. js-lingui-explicit-id
 #. placeholder {0}: locations.length - LOCATIONS_COLLAPSED
-#: src/components/search/job-detail-dialog.tsx:359
+#: src/components/search/job-detail-dialog.tsx:361
 msgid "search.detail.showMoreLocations"
 msgstr "{0} de plus"
 
@@ -255,6 +255,12 @@ msgstr "Ajouter des entreprises"
 msgid "watchlists.view.addDescription"
 msgstr "Ajouter une description"
 
+#. Aria label for the checkmark button that confirms adding a filter
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:448
+msgid "watchlists.filters.confirmAdd"
+msgstr "Ajouter un filtre"
+
 #. Quick action tooltip: add interview round
 #. js-lingui-explicit-id
 #: src/components/my-jobs/quick-actions.tsx:19
@@ -281,7 +287,7 @@ msgstr "Ajouter un filtre de lieu ou mot-clé…"
 
 #. Placeholder in the add location input
 #. js-lingui-explicit-id
-#: src/components/search/location-pills.tsx:176
+#: src/components/search/location-pills.tsx:174
 msgid "search.locations.addPlaceholder"
 msgstr "Ajouter un lieu..."
 
@@ -299,7 +305,7 @@ msgstr "Prompt de l'agent"
 
 #. Footer shown after all paged countries have been loaded into the location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:813
+#: src/components/search/location-search-modal.tsx:816
 msgid "search.locationModal.allLoaded"
 msgstr "Tous les {totalCountries} pays chargés"
 
@@ -311,7 +317,7 @@ msgstr "Toutes les données sont chiffrées en transit et au repos."
 
 #. Option to show all industries
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:259
+#: src/components/watchlist/company-search-modal.tsx:262
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Tous les secteurs"
 
@@ -335,7 +341,7 @@ msgstr "Tous les lieux"
 
 #. Button to open all-locations modal on company page
 #. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:342
+#: src/components/search/filter-bar.tsx:346
 msgid "company.page.allLocations"
 msgstr "Tous les lieux"
 
@@ -400,7 +406,7 @@ msgstr "Statistiques des candidatures"
 
 #. Application tracker section heading in job detail
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:247
+#: src/components/search/job-detail-dialog.tsx:249
 msgid "search.detail.applicationTracker"
 msgstr "Suivi de candidature"
 
@@ -424,7 +430,7 @@ msgstr "Postulé"
 
 #. Application tracker status: applied
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:449
+#: src/components/search/job-detail-dialog.tsx:451
 msgid "search.tracker.applied"
 msgstr "Postulé"
 
@@ -448,19 +454,19 @@ msgstr "Postulé"
 
 #. Apply salary filter
 #. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:320
+#: src/components/search/salary-modal.tsx:324
 msgid "search.salaryModal.apply"
 msgstr "Appliquer"
 
 #. Apply experience filter
 #. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:246
+#: src/components/search/experience-modal.tsx:249
 msgid "search.experienceModal.apply"
 msgstr "Appliquer"
 
 #. Apply button linking to original job posting
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:292
+#: src/components/my-jobs/my-job-detail-panel.tsx:293
 msgid "search.detail.apply"
 msgstr "Postuler"
 
@@ -500,16 +506,16 @@ msgstr "Aoû"
 msgid "settings.account.username.available"
 msgstr "Disponible"
 
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Retour à la connexion"
-
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Retour à la connexion"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Retour à la connexion"
 
 #. Link back to sign-in from forgot password
@@ -617,6 +623,14 @@ msgstr "Puis-je refuser l'indexation de mon entreprise par Jobseek ?"
 msgid "watchlists.delete.cancel"
 msgstr "Annuler"
 
+#. Aria label for the X button that cancels the inline add-filter UI
+#. Aria label for the X button that cancels the inline add-filter UI
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:420
+#: src/components/watchlist/watchlist-filter-editor.tsx:456
+msgid "watchlists.filters.cancel"
+msgstr "Annuler"
+
 #. Cancel delete button
 #. js-lingui-explicit-id
 #: src/components/settings/AccountSettings.tsx:532
@@ -711,7 +725,7 @@ msgstr "Choisissez les langues dans lesquelles vous souhaitez voir les offres d'
 #. Location type label for cities
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:35
-#: src/components/search/location-pills.tsx:33
+#: src/components/search/location-pills.tsx:31
 msgid "location.type.city"
 msgstr "Ville"
 
@@ -730,8 +744,8 @@ msgstr "Tout effacer"
 #. Button to clear all active search filters
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:624
-#: src/components/search/search-toolbar.tsx:337
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:645
+#: src/components/search/search-toolbar.tsx:367
 msgid "search.filters.clearAll"
 msgstr "Tout effacer"
 
@@ -758,6 +772,90 @@ msgstr "Cliquer pour renommer"
 #: src/components/HowWeIndexContent.tsx:119
 msgid "indexing.ingestion.s2.title"
 msgstr "API clientes en second."
+
+#. Aria label for close button on add-companies modal
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-search-modal.tsx:201
+msgid "watchlists.companyModal.close"
+msgstr "Fermer"
+
+#. Aria label for upgrade modal close button
+#. js-lingui-explicit-id
+#: src/components/ui/upgrade-modal.tsx:59
+msgid "upgrade.modal.close"
+msgstr "Fermer"
+
+#. Aria label for the job-languages modal close button
+#. js-lingui-explicit-id
+#: src/components/settings/JobLanguageModal.tsx:66
+msgid "settings.jobLanguages.modal.close"
+msgstr "Fermer"
+
+#. Aria label for the work-mode modal close button
+#. js-lingui-explicit-id
+#: src/components/search/work-mode-modal.tsx:90
+msgid "search.workModeModal.close"
+msgstr "Fermer"
+
+#. Aria label for the technology modal close button
+#. js-lingui-explicit-id
+#: src/components/search/technology-modal.tsx:117
+msgid "search.technologyModal.close"
+msgstr "Fermer"
+
+#. Aria label for the seniority modal close button
+#. js-lingui-explicit-id
+#: src/components/search/seniority-modal.tsx:65
+msgid "search.seniorityModal.close"
+msgstr "Fermer"
+
+#. Aria label for the salary modal close button
+#. js-lingui-explicit-id
+#: src/components/search/salary-modal.tsx:254
+msgid "search.salaryModal.close"
+msgstr "Fermer"
+
+#. Aria label for close button on the company-page all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:275
+msgid "company.locationModal.close"
+msgstr "Fermer"
+
+#. Aria label for the employment-type modal close button
+#. js-lingui-explicit-id
+#: src/components/search/employment-type-modal.tsx:82
+msgid "search.employmentTypeModal.close"
+msgstr "Fermer"
+
+#. Aria label for the location modal close button
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:479
+msgid "search.locationModal.close"
+msgstr "Fermer"
+
+#. Aria label for the experience modal close button
+#. js-lingui-explicit-id
+#: src/components/search/experience-modal.tsx:193
+msgid "search.experienceModal.close"
+msgstr "Fermer"
+
+#. Aria label for the occupation modal close button
+#. js-lingui-explicit-id
+#: src/components/search/occupation-modal.tsx:307
+msgid "search.occupationModal.close"
+msgstr "Fermer"
+
+#. Aria label for job detail panel close button
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:92
+msgid "search.detail.close"
+msgstr "Fermer les détails de l’offre"
+
+#. Aria label for the my-jobs detail panel close button
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:173
+msgid "myJobs.detail.close"
+msgstr "Fermer les détails de l’offre"
 
 #. Aria label for close mobile menu button
 #. js-lingui-explicit-id
@@ -885,6 +983,12 @@ msgstr "Connecter"
 msgid "settings.account.socials.title"
 msgstr "Comptes connectés"
 
+#. Footer link to contact email
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Contact"
+
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:24
@@ -895,12 +999,6 @@ msgstr "Contact"
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:95
 msgid "license.contact.title"
-msgstr "Contact"
-
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
 msgstr "Contact"
 
 #. Table of contents heading
@@ -985,7 +1083,7 @@ msgstr "Copier le prompt"
 #. Location type label for countries
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:33
-#: src/components/search/location-pills.tsx:31
+#: src/components/search/location-pills.tsx:29
 msgid "location.type.country"
 msgstr "Pays"
 
@@ -1165,7 +1263,7 @@ msgstr "Détails"
 
 #. Collapsible section heading for extracted job details
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:387
+#: src/components/search/job-detail-dialog.tsx:389
 msgid "search.detail.details"
 msgstr "Détails"
 
@@ -1274,7 +1372,7 @@ msgstr "E-mail vérifié"
 
 #. Title for the employment type selection modal
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:74
+#: src/components/search/employment-type-modal.tsx:75
 msgid "search.employmentTypeModal.title"
 msgstr "Type d'emploi"
 
@@ -1453,7 +1551,7 @@ msgstr "Fév"
 
 #. Button to add a filter to watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:295
+#: src/components/watchlist/watchlist-filter-editor.tsx:352
 msgid "watchlists.filters.add"
 msgstr "Filtre"
 
@@ -1461,33 +1559,33 @@ msgstr "Filtre"
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:116
-#: src/components/search/job-detail-dialog.tsx:300
-#: src/components/search/job-detail-dialog.tsx:378
+#: src/components/search/job-detail-dialog.tsx:118
+#: src/components/search/job-detail-dialog.tsx:302
+#: src/components/search/job-detail-dialog.tsx:380
 msgid "search.detail.filterByPrefix"
 msgstr "Filtrer par"
 
 #. Tooltip for salary filter pill
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:226
+#: src/components/search/job-detail-dialog.tsx:228
 msgid "search.detail.filterBySalary"
 msgstr "Filtrer par cette fourchette salariale"
 
 #. Placeholder for industry filter search
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:247
+#: src/components/watchlist/company-search-modal.tsx:250
 msgid "watchlists.companyModal.industrySearch"
 msgstr "Filtrer les secteurs..."
 
 #. Placeholder for search input in technology modal
 #. js-lingui-explicit-id
-#: src/components/search/technology-modal.tsx:130
+#: src/components/search/technology-modal.tsx:133
 msgid "search.technologyModal.searchPlaceholder"
 msgstr "Filtrer les technologies..."
 
 #. Section title for filters in watchlist view
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:221
+#: src/components/watchlist/watchlist-filter-editor.tsx:224
 msgid "watchlists.view.filters"
 msgstr "Filtres"
 
@@ -1663,7 +1761,7 @@ msgstr "Compris"
 
 #. Dismiss upgrade modal
 #. js-lingui-explicit-id
-#: src/components/ui/upgrade-modal.tsx:66
+#: src/components/ui/upgrade-modal.tsx:69
 msgid "upgrade.modal.dismiss"
 msgstr "Compris"
 
@@ -1759,9 +1857,9 @@ msgstr "Comment nous indexons"
 #. Work mode: hybrid (mixed onsite/remote)
 #. Work mode: hybrid (mixed onsite/remote)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:587
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:597
 #: src/components/search/search-bar.tsx:812
-#: src/components/search/search-toolbar.tsx:260
+#: src/components/search/search-toolbar.tsx:271
 #: src/components/search/work-mode-modal.tsx:27
 msgid "search.workMode.hybrid"
 msgstr "Hybride"
@@ -1837,7 +1935,7 @@ msgstr "Politique d'indexation"
 
 #. Industry filter label
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:235
+#: src/components/watchlist/company-search-modal.tsx:238
 msgid "watchlists.companyModal.industry"
 msgstr "Secteur"
 
@@ -1897,7 +1995,7 @@ msgstr "En entretien"
 
 #. Application tracker status: interviewing
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:450
+#: src/components/search/job-detail-dialog.tsx:452
 msgid "search.tracker.interviewing"
 msgstr "En entretien"
 
@@ -1972,7 +2070,7 @@ msgstr "Données d'emploi (CC BY-NC 4.0)"
 
 #. Job detail panel title
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:86
+#: src/components/search/job-detail-dialog.tsx:87
 msgid "search.detail.title"
 msgstr "Détails de l'offre"
 
@@ -2100,7 +2198,7 @@ msgstr "Jun"
 
 #. Add keyword filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:208
+#: src/components/watchlist/watchlist-filter-editor.tsx:211
 msgid "watchlists.filters.keyword"
 msgstr "Mot-clé"
 
@@ -2220,7 +2318,7 @@ msgstr "Chargement…"
 
 #. Add location filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:209
+#: src/components/watchlist/watchlist-filter-editor.tsx:212
 msgid "watchlists.filters.location"
 msgstr "Lieu"
 
@@ -2230,16 +2328,16 @@ msgstr "Lieu"
 msgid "search.advanced.location"
 msgstr "Lieu"
 
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:314
+msgid "search.detail.locations"
+msgstr "Lieux"
+
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:842
 msgid "search.bar.locations"
-msgstr "Lieux"
-
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
 msgstr "Lieux"
 
 #. Login button label
@@ -2318,7 +2416,7 @@ msgstr "Marquer comme refusé"
 
 #. Header for the server-side search-results cluster shown when the user types in the location modal search box
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:582
+#: src/components/search/location-search-modal.tsx:585
 msgid "search.locationModal.searchHitsHeader"
 msgstr "Correspondances"
 
@@ -2409,7 +2507,7 @@ msgstr "Mensuel"
 
 #. Expand location pill list to show all
 #. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:356
+#: src/components/search/filter-bar.tsx:360
 msgid "company.page.showMore"
 msgstr "plus"
 
@@ -2510,37 +2608,37 @@ msgstr "Aucune redistribution ou revente commerciale sans autorisation."
 
 #. Empty state when no filters are set
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:407
+#: src/components/watchlist/watchlist-filter-editor.tsx:467
 msgid "watchlists.filters.empty"
 msgstr "Aucun filtre défini. Ajoutez des filtres pour affiner les résultats."
 
 #. No industries match search
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:277
+#: src/components/watchlist/company-search-modal.tsx:280
 msgid "watchlists.companyModal.noIndustries"
 msgstr "Aucun secteur trouvé."
 
 #. Empty state when no jobs match the time range
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:207
+#: src/components/watchlist/watchlist-job-list.tsx:208
 msgid "watchlists.jobList.empty"
 msgstr "Aucune offre trouvée."
 
 #. No languages match search in all-languages modal
 #. js-lingui-explicit-id
-#: src/components/settings/JobLanguageModal.tsx:92
+#: src/components/settings/JobLanguageModal.tsx:95
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Aucune langue ne correspond à votre recherche."
 
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:309
+#: src/components/search/location-modal.tsx:312
 msgid "company.locationModal.noResults"
 msgstr "Aucun lieu ne correspond à votre recherche."
 
 #. No locations match search in location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:513
+#: src/components/search/location-search-modal.tsx:516
 msgid "search.locationModal.noResults"
 msgstr "Aucun lieu ne correspond à votre recherche."
 
@@ -2570,19 +2668,19 @@ msgstr "Aucun résultat trouvé pour « {query} »"
 
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:341
+#: src/components/search/occupation-modal.tsx:344
 msgid "search.occupationModal.noResults"
 msgstr "Aucun rôle ne correspond à votre recherche."
 
 #. No seniority levels available
 #. js-lingui-explicit-id
-#: src/components/search/seniority-modal.tsx:76
+#: src/components/search/seniority-modal.tsx:80
 msgid "search.seniorityModal.noResults"
 msgstr "Aucun niveau d'ancienneté disponible."
 
 #. No technologies available or matching search
 #. js-lingui-explicit-id
-#: src/components/search/technology-modal.tsx:151
+#: src/components/search/technology-modal.tsx:154
 msgid "search.technologyModal.noResults"
 msgstr "Aucune technologie trouvée."
 
@@ -2622,7 +2720,7 @@ msgstr "Non. Nous ne vendons, ne louons ni ne partageons vos données à des fin
 
 #. Application tracker status: not applied
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:448
+#: src/components/search/job-detail-dialog.tsx:450
 msgid "search.tracker.notApplied"
 msgstr "Non postulé"
 
@@ -2646,7 +2744,7 @@ msgstr "Nov"
 
 #. Add occupation filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:210
+#: src/components/watchlist/watchlist-filter-editor.tsx:213
 msgid "watchlists.filters.occupation"
 msgstr "Métier"
 
@@ -2658,7 +2756,7 @@ msgstr "Oct"
 
 #. Application tracker status: offer
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:451
+#: src/components/search/job-detail-dialog.tsx:453
 msgid "search.tracker.offer"
 msgstr "Offre"
 
@@ -2697,9 +2795,9 @@ msgstr "Ok"
 #. Work mode: onsite (in-office)
 #. Work mode: onsite (in-office)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:585
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:595
 #: src/components/search/search-bar.tsx:810
-#: src/components/search/search-toolbar.tsx:258
+#: src/components/search/search-toolbar.tsx:269
 #: src/components/search/work-mode-modal.tsx:26
 msgid "search.workMode.onsite"
 msgstr "Sur site"
@@ -2777,13 +2875,13 @@ msgstr "Original"
 
 #. Fallback label for a country header in the location modal when the city has no parent country in the hierarchy. Rare path.
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:635
+#: src/components/search/location-search-modal.tsx:638
 msgid "search.locationModal.otherCountry"
 msgstr "Autre"
 
 #. Fallback label for a region row in the location modal when the region has no display name (e.g. orphaned cities). Rare path; only shown when a city's parent region in the hierarchy has no localized name.
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:720
+#: src/components/search/location-search-modal.tsx:723
 msgid "search.locationModal.otherRegion"
 msgstr "Autre"
 
@@ -3013,13 +3111,13 @@ msgstr "Veuillez vous connecter pour gérer vos paramètres de facturation."
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:101
+#: src/components/search/job-detail-dialog.tsx:103
 msgid "search.detail.notFound"
 msgstr "Offre non trouvée."
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:183
+#: src/components/my-jobs/my-job-detail-panel.tsx:184
 msgid "myJobs.detail.notFound"
 msgstr "Offre introuvable."
 
@@ -3157,20 +3255,20 @@ msgstr "Redistribue tes modifications, à condition d'inclure la mention MIT."
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:32
 #: src/components/search/filter-bar.tsx:34
+#: src/components/search/location-pills.tsx:28
 #: src/components/search/location-pills.tsx:30
-#: src/components/search/location-pills.tsx:32
 msgid "location.type.region"
 msgstr "Région"
 
 #. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:319
+#: src/components/search/location-modal.tsx:322
 msgid "company.locationModal.regionsHeader"
 msgstr "Régions"
 
 #. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:523
+#: src/components/search/location-search-modal.tsx:526
 msgid "search.locationModal.regionsHeader"
 msgstr "Régions"
 
@@ -3182,7 +3280,7 @@ msgstr "Refusé"
 
 #. Application tracker status: rejected
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:452
+#: src/components/search/job-detail-dialog.tsx:454
 msgid "search.tracker.rejected"
 msgstr "Refusé"
 
@@ -3215,12 +3313,84 @@ msgstr "Publié sous licence MIT. Les données d'emploi sont sous CC BY-NC 4.0."
 #. Work mode: remote (work-from-home)
 #. Work mode: remote (work-from-home)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:588
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:598
 #: src/components/search/search-bar.tsx:813
-#: src/components/search/search-toolbar.tsx:261
+#: src/components/search/search-toolbar.tsx:272
 #: src/components/search/work-mode-modal.tsx:28
 msgid "search.workMode.remote"
 msgstr "À distance"
+
+#. Aria label for the X button that removes a company pill; {name} is the company name
+#. js-lingui-explicit-id
+#. placeholder {0}: company.name
+#: src/components/watchlist/company-pill.tsx:24
+msgid "watchlists.companyPill.remove"
+msgstr "Supprimer {0}"
+
+#. Aria label for the X button that removes a filter pill; {name} is the filter value
+#. Aria label for the X button that removes a filter pill; {name} is the filter value
+#. js-lingui-explicit-id
+#. placeholder {0}: pill.filter.name
+#: src/components/search/filter-bar.tsx:279
+#: src/components/search/filter-bar.tsx:297
+msgid "company.page.removeFilter"
+msgstr "Supprimer le filtre {0}"
+
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:559
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:569
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:579
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:589
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:603
+#: src/components/search/search-toolbar.tsx:201
+#: src/components/search/search-toolbar.tsx:220
+#: src/components/search/search-toolbar.tsx:240
+#: src/components/search/search-toolbar.tsx:260
+#: src/components/search/search-toolbar.tsx:283
+msgid "search.filters.removeFilter"
+msgstr "Supprimer le filtre {name}"
+
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:240
+#: src/components/watchlist/watchlist-filter-editor.tsx:252
+#: src/components/watchlist/watchlist-filter-editor.tsx:264
+#: src/components/watchlist/watchlist-filter-editor.tsx:276
+#: src/components/watchlist/watchlist-filter-editor.tsx:288
+#: src/components/watchlist/watchlist-filter-editor.tsx:300
+#: src/components/watchlist/watchlist-filter-editor.tsx:312
+msgid "watchlists.filters.removeFilter"
+msgstr "Supprimer le filtre {name}"
+
+#. Aria label for the X button that clears the experience-range filter
+#. Aria label for the X button that clears the experience-range filter
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:622
+#: src/components/search/search-toolbar.tsx:318
+msgid "search.filters.removeExperience"
+msgstr "Supprimer le filtre d’expérience"
+
+#. Aria label for the X button that clears the experience-range watchlist filter
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:339
+msgid "watchlists.filters.removeExperience"
+msgstr "Supprimer le filtre d’expérience"
 
 #. Aria label for removing a keyword pill
 #. js-lingui-explicit-id
@@ -3228,11 +3398,55 @@ msgstr "À distance"
 msgid "search.keywords.remove"
 msgstr "Supprimer le mot-clé"
 
+#. Aria label for the X button that removes a keyword filter pill; {name} is the keyword
+#. js-lingui-explicit-id
+#. placeholder {0}: pill.filter.value
+#: src/components/search/filter-bar.tsx:261
+msgid "company.page.removeKeyword"
+msgstr "Supprimer le mot-clé {0}"
+
+#. Aria label for remove-keyword X button; {name} is the keyword
+#. Aria label for remove-keyword X button; {name} is the keyword
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:630
+#: src/components/search/search-toolbar.tsx:335
+msgid "search.filters.removeKeyword"
+msgstr "Supprimer le mot-clé {name}"
+
 #. Aria label for removing a location pill
 #. js-lingui-explicit-id
-#: src/components/search/location-pills.tsx:201
+#: src/components/search/location-pills.tsx:199
 msgid "search.locations.remove"
 msgstr "Supprimer le lieu"
+
+#. Aria label for the X button that removes a location filter pill; {name} is the location label
+#. js-lingui-explicit-id
+#. placeholder {0}: pill.filter.name
+#: src/components/search/filter-bar.tsx:315
+msgid "company.page.removeLocation"
+msgstr "Supprimer le lieu {0}"
+
+#. Aria label for remove-location X button; {name} is the location label
+#. Aria label for remove-location X button; {name} is the location label
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:640
+#: src/components/search/search-toolbar.tsx:356
+msgid "search.filters.removeLocation"
+msgstr "Supprimer le lieu {name}"
+
+#. Aria label for the X button that clears the salary-range filter
+#. Aria label for the X button that clears the salary-range filter
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:613
+#: src/components/search/search-toolbar.tsx:301
+msgid "search.filters.removeSalary"
+msgstr "Supprimer le filtre de salaire"
+
+#. Aria label for the X button that clears the salary-range watchlist filter
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:326
+msgid "watchlists.filters.removeSalary"
+msgstr "Supprimer le filtre de salaire"
 
 #. Synthetic dropdown row that lets the user request a company that's not in the catalog
 #. js-lingui-explicit-id
@@ -3284,13 +3498,13 @@ msgstr "Renvoyer l'e-mail de vérification"
 
 #. Reset salary filter
 #. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:314
+#: src/components/search/salary-modal.tsx:318
 msgid "search.salaryModal.reset"
 msgstr "Réinitialiser"
 
 #. Reset experience filter
 #. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:240
+#: src/components/search/experience-modal.tsx:243
 msgid "search.experienceModal.reset"
 msgstr "Réinitialiser"
 
@@ -3362,7 +3576,7 @@ msgstr "Affichage du salaire"
 
 #. Title for salary filter modal
 #. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:246
+#: src/components/search/salary-modal.tsx:247
 msgid "search.salaryModal.title"
 msgstr "Fourchette salariale"
 
@@ -3471,7 +3685,7 @@ msgstr "Rechercher des entreprises..."
 
 #. Placeholder for company search in modal
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:217
+#: src/components/watchlist/company-search-modal.tsx:220
 msgid "watchlists.companyModal.searchPlaceholder"
 msgstr "Rechercher des entreprises..."
 
@@ -3488,19 +3702,19 @@ msgstr "Recherchez des emplois dans des milliers d'entreprises, scrapés directe
 
 #. Placeholder for search input in all-languages modal
 #. js-lingui-explicit-id
-#: src/components/settings/JobLanguageModal.tsx:78
+#: src/components/settings/JobLanguageModal.tsx:81
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Rechercher des langues…"
 
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:288
+#: src/components/search/location-modal.tsx:291
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Rechercher des lieux…"
 
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:492
+#: src/components/search/location-search-modal.tsx:495
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Rechercher des lieux..."
 
@@ -3512,7 +3726,7 @@ msgstr "Résultats de recherche"
 
 #. Placeholder for search input in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:320
+#: src/components/search/occupation-modal.tsx:323
 msgid "search.occupationModal.searchPlaceholder"
 msgstr "Rechercher des rôles..."
 
@@ -3542,7 +3756,7 @@ msgstr "Visualise ton funnel, tes taux de conversion et ta heatmap d'activité p
 
 #. Title for the seniority level selection modal
 #. js-lingui-explicit-id
-#: src/components/search/seniority-modal.tsx:57
+#: src/components/search/seniority-modal.tsx:58
 msgid "search.seniorityModal.title"
 msgstr "Sélectionner le niveau"
 
@@ -3608,7 +3822,7 @@ msgstr "Envoi…"
 
 #. Add seniority filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:211
+#: src/components/watchlist/watchlist-filter-editor.tsx:214
 msgid "watchlists.filters.seniority"
 msgstr "Niveau d'expérience"
 
@@ -3654,16 +3868,16 @@ msgstr "Paramètres"
 msgid "home.features.s3.p3.title"
 msgstr "Partager avec tout le monde"
 
-#. Collapse location pill list
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:351
-msgid "company.page.showLess"
-msgstr "Afficher moins"
-
 #. Button to collapse location list
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:355
+#: src/components/search/job-detail-dialog.tsx:357
 msgid "search.detail.showLessLocations"
+msgstr "Afficher moins"
+
+#. Collapse location pill list
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:355
+msgid "company.page.showLess"
 msgstr "Afficher moins"
 
 #. Aria label to show password
@@ -3860,7 +4074,7 @@ msgstr "Statut"
 
 #. Status section heading
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:200
+#: src/components/my-jobs/my-job-detail-panel.tsx:201
 msgid "myJobs.detail.status"
 msgstr "Statut"
 
@@ -3936,21 +4150,21 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technique"
 
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:399
+msgid "search.detail.technologies"
+msgstr "Technologies"
+
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:765
 msgid "search.bar.technologies"
 msgstr "Technologies"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Technologies"
-
 #. Add technology filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:212
+#: src/components/watchlist/watchlist-filter-editor.tsx:215
 msgid "watchlists.filters.technology"
 msgstr "Technologie"
 
@@ -4134,7 +4348,7 @@ msgstr "Réessayer"
 
 #. Add employment type filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:213
+#: src/components/watchlist/watchlist-filter-editor.tsx:216
 msgid "watchlists.filters.employmentType"
 msgstr "Type"
 
@@ -4146,7 +4360,7 @@ msgstr "Type d'emploi"
 
 #. Placeholder for filter value input
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:377
+#: src/components/watchlist/watchlist-filter-editor.tsx:435
 msgid "watchlists.filters.inputPlaceholder"
 msgstr "Tapez le slug et appuyez sur Entrée"
 
@@ -4211,7 +4425,7 @@ msgstr "Mettre à jour le nom d'utilisateur"
 
 #. Upgrade button in modal
 #. js-lingui-explicit-id
-#: src/components/ui/upgrade-modal.tsx:74
+#: src/components/ui/upgrade-modal.tsx:77
 msgid "upgrade.modal.upgrade"
 msgstr "Mettre à niveau"
 
@@ -4294,7 +4508,7 @@ msgstr "Appel vidéo"
 
 #. Link to the original job posting
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:186
+#: src/components/search/job-detail-dialog.tsx:188
 msgid "search.detail.viewPosting"
 msgstr "Voir l'offre"
 
@@ -4508,13 +4722,13 @@ msgstr "Quelles langues Jobseek prend-il en charge ?"
 
 #. Add work-mode (onsite/hybrid/remote) filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:214
+#: src/components/watchlist/watchlist-filter-editor.tsx:217
 msgid "watchlists.filters.workMode"
 msgstr "Mode de travail"
 
 #. Title for the work-mode (onsite/hybrid/remote) selection modal
 #. js-lingui-explicit-id
-#: src/components/search/work-mode-modal.tsx:82
+#: src/components/search/work-mode-modal.tsx:83
 msgid "search.workModeModal.title"
 msgstr "Mode de travail"
 

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -53,7 +53,7 @@ msgstr "(apre in una nuova scheda)"
 #. Button to show remaining collapsed locations
 #. js-lingui-explicit-id
 #. placeholder {0}: locations.length - LOCATIONS_COLLAPSED
-#: src/components/search/job-detail-dialog.tsx:359
+#: src/components/search/job-detail-dialog.tsx:361
 msgid "search.detail.showMoreLocations"
 msgstr "{0} in più"
 
@@ -255,6 +255,12 @@ msgstr "Aggiungi aziende"
 msgid "watchlists.view.addDescription"
 msgstr "Aggiungi descrizione"
 
+#. Aria label for the checkmark button that confirms adding a filter
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:448
+msgid "watchlists.filters.confirmAdd"
+msgstr "Aggiungi filtro"
+
 #. Quick action tooltip: add interview round
 #. js-lingui-explicit-id
 #: src/components/my-jobs/quick-actions.tsx:19
@@ -281,7 +287,7 @@ msgstr "Aggiungi filtro per luogo o parola chiave…"
 
 #. Placeholder in the add location input
 #. js-lingui-explicit-id
-#: src/components/search/location-pills.tsx:176
+#: src/components/search/location-pills.tsx:174
 msgid "search.locations.addPlaceholder"
 msgstr "Aggiungi località..."
 
@@ -299,7 +305,7 @@ msgstr "Prompt dell'agente"
 
 #. Footer shown after all paged countries have been loaded into the location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:813
+#: src/components/search/location-search-modal.tsx:816
 msgid "search.locationModal.allLoaded"
 msgstr "Tutti i {totalCountries} paesi caricati"
 
@@ -311,7 +317,7 @@ msgstr "Tutti i dati sono crittografati in transito e a riposo."
 
 #. Option to show all industries
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:259
+#: src/components/watchlist/company-search-modal.tsx:262
 msgid "watchlists.companyModal.allIndustries"
 msgstr "Tutti i settori"
 
@@ -335,7 +341,7 @@ msgstr "Tutte le sedi"
 
 #. Button to open all-locations modal on company page
 #. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:342
+#: src/components/search/filter-bar.tsx:346
 msgid "company.page.allLocations"
 msgstr "Tutte le sedi"
 
@@ -400,7 +406,7 @@ msgstr "Statistiche candidature"
 
 #. Application tracker section heading in job detail
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:247
+#: src/components/search/job-detail-dialog.tsx:249
 msgid "search.detail.applicationTracker"
 msgstr "Monitoraggio candidatura"
 
@@ -424,7 +430,7 @@ msgstr "Candidato"
 
 #. Application tracker status: applied
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:449
+#: src/components/search/job-detail-dialog.tsx:451
 msgid "search.tracker.applied"
 msgstr "Candidato"
 
@@ -448,19 +454,19 @@ msgstr "Candidato"
 
 #. Apply salary filter
 #. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:320
+#: src/components/search/salary-modal.tsx:324
 msgid "search.salaryModal.apply"
 msgstr "Applica"
 
 #. Apply experience filter
 #. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:246
+#: src/components/search/experience-modal.tsx:249
 msgid "search.experienceModal.apply"
 msgstr "Applica"
 
 #. Apply button linking to original job posting
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:292
+#: src/components/my-jobs/my-job-detail-panel.tsx:293
 msgid "search.detail.apply"
 msgstr "Candidati"
 
@@ -500,16 +506,16 @@ msgstr "Ago"
 msgid "settings.account.username.available"
 msgstr "Disponibile"
 
-#. Link back to sign-in after failed verification
-#. js-lingui-explicit-id
-#: app/[lang]/verify-email/page.tsx:68
-msgid "auth.verify.error.backToSignIn"
-msgstr "Torna all'accesso"
-
 #. Link back to sign-in from reset password
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:42
 msgid "auth.resetPassword.backToSignIn"
+msgstr "Torna all'accesso"
+
+#. Link back to sign-in after failed verification
+#. js-lingui-explicit-id
+#: app/[lang]/verify-email/page.tsx:68
+msgid "auth.verify.error.backToSignIn"
 msgstr "Torna all'accesso"
 
 #. Link back to sign-in from forgot password
@@ -617,6 +623,14 @@ msgstr "Posso rifiutare l'indicizzazione della mia azienda da parte di Jobseek?"
 msgid "watchlists.delete.cancel"
 msgstr "Annulla"
 
+#. Aria label for the X button that cancels the inline add-filter UI
+#. Aria label for the X button that cancels the inline add-filter UI
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:420
+#: src/components/watchlist/watchlist-filter-editor.tsx:456
+msgid "watchlists.filters.cancel"
+msgstr "Annulla"
+
 #. Cancel delete button
 #. js-lingui-explicit-id
 #: src/components/settings/AccountSettings.tsx:532
@@ -711,7 +725,7 @@ msgstr "Scegli in quali lingue vuoi vedere le offerte di lavoro."
 #. Location type label for cities
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:35
-#: src/components/search/location-pills.tsx:33
+#: src/components/search/location-pills.tsx:31
 msgid "location.type.city"
 msgstr "Città"
 
@@ -730,8 +744,8 @@ msgstr "Rimuovi tutti"
 #. Button to clear all active search filters
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:624
-#: src/components/search/search-toolbar.tsx:337
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:645
+#: src/components/search/search-toolbar.tsx:367
 msgid "search.filters.clearAll"
 msgstr "Cancella tutto"
 
@@ -758,6 +772,90 @@ msgstr "Clicca per rinominare"
 #: src/components/HowWeIndexContent.tsx:119
 msgid "indexing.ingestion.s2.title"
 msgstr "API client come seconda opzione."
+
+#. Aria label for close button on add-companies modal
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-search-modal.tsx:201
+msgid "watchlists.companyModal.close"
+msgstr "Chiudi"
+
+#. Aria label for upgrade modal close button
+#. js-lingui-explicit-id
+#: src/components/ui/upgrade-modal.tsx:59
+msgid "upgrade.modal.close"
+msgstr "Chiudi"
+
+#. Aria label for the job-languages modal close button
+#. js-lingui-explicit-id
+#: src/components/settings/JobLanguageModal.tsx:66
+msgid "settings.jobLanguages.modal.close"
+msgstr "Chiudi"
+
+#. Aria label for the work-mode modal close button
+#. js-lingui-explicit-id
+#: src/components/search/work-mode-modal.tsx:90
+msgid "search.workModeModal.close"
+msgstr "Chiudi"
+
+#. Aria label for the technology modal close button
+#. js-lingui-explicit-id
+#: src/components/search/technology-modal.tsx:117
+msgid "search.technologyModal.close"
+msgstr "Chiudi"
+
+#. Aria label for the seniority modal close button
+#. js-lingui-explicit-id
+#: src/components/search/seniority-modal.tsx:65
+msgid "search.seniorityModal.close"
+msgstr "Chiudi"
+
+#. Aria label for the salary modal close button
+#. js-lingui-explicit-id
+#: src/components/search/salary-modal.tsx:254
+msgid "search.salaryModal.close"
+msgstr "Chiudi"
+
+#. Aria label for close button on the company-page all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:275
+msgid "company.locationModal.close"
+msgstr "Chiudi"
+
+#. Aria label for the employment-type modal close button
+#. js-lingui-explicit-id
+#: src/components/search/employment-type-modal.tsx:82
+msgid "search.employmentTypeModal.close"
+msgstr "Chiudi"
+
+#. Aria label for the location modal close button
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:479
+msgid "search.locationModal.close"
+msgstr "Chiudi"
+
+#. Aria label for the experience modal close button
+#. js-lingui-explicit-id
+#: src/components/search/experience-modal.tsx:193
+msgid "search.experienceModal.close"
+msgstr "Chiudi"
+
+#. Aria label for the occupation modal close button
+#. js-lingui-explicit-id
+#: src/components/search/occupation-modal.tsx:307
+msgid "search.occupationModal.close"
+msgstr "Chiudi"
+
+#. Aria label for job detail panel close button
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:92
+msgid "search.detail.close"
+msgstr "Chiudi i dettagli dell’offerta"
+
+#. Aria label for the my-jobs detail panel close button
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:173
+msgid "myJobs.detail.close"
+msgstr "Chiudi i dettagli dell’offerta"
 
 #. Aria label for close mobile menu button
 #. js-lingui-explicit-id
@@ -885,6 +983,12 @@ msgstr "Collega"
 msgid "settings.account.socials.title"
 msgstr "Account collegati"
 
+#. Footer link to contact email
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Contatti"
+
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:24
@@ -895,12 +999,6 @@ msgstr "Contatti"
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:95
 msgid "license.contact.title"
-msgstr "Contatti"
-
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
 msgstr "Contatti"
 
 #. Table of contents heading
@@ -985,7 +1083,7 @@ msgstr "Copia il prompt"
 #. Location type label for countries
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:33
-#: src/components/search/location-pills.tsx:31
+#: src/components/search/location-pills.tsx:29
 msgid "location.type.country"
 msgstr "Paese"
 
@@ -1165,7 +1263,7 @@ msgstr "Dettagli"
 
 #. Collapsible section heading for extracted job details
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:387
+#: src/components/search/job-detail-dialog.tsx:389
 msgid "search.detail.details"
 msgstr "Dettagli"
 
@@ -1274,7 +1372,7 @@ msgstr "Email verificata"
 
 #. Title for the employment type selection modal
 #. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:74
+#: src/components/search/employment-type-modal.tsx:75
 msgid "search.employmentTypeModal.title"
 msgstr "Tipo di impiego"
 
@@ -1453,7 +1551,7 @@ msgstr "Feb"
 
 #. Button to add a filter to watchlist
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:295
+#: src/components/watchlist/watchlist-filter-editor.tsx:352
 msgid "watchlists.filters.add"
 msgstr "Filtro"
 
@@ -1461,33 +1559,33 @@ msgstr "Filtro"
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. Tooltip prefix for clickable filter pills, followed by the value name
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:116
-#: src/components/search/job-detail-dialog.tsx:300
-#: src/components/search/job-detail-dialog.tsx:378
+#: src/components/search/job-detail-dialog.tsx:118
+#: src/components/search/job-detail-dialog.tsx:302
+#: src/components/search/job-detail-dialog.tsx:380
 msgid "search.detail.filterByPrefix"
 msgstr "Filtra per"
 
 #. Tooltip for salary filter pill
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:226
+#: src/components/search/job-detail-dialog.tsx:228
 msgid "search.detail.filterBySalary"
 msgstr "Filtra per questa fascia salariale"
 
 #. Placeholder for industry filter search
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:247
+#: src/components/watchlist/company-search-modal.tsx:250
 msgid "watchlists.companyModal.industrySearch"
 msgstr "Filtra settori..."
 
 #. Placeholder for search input in technology modal
 #. js-lingui-explicit-id
-#: src/components/search/technology-modal.tsx:130
+#: src/components/search/technology-modal.tsx:133
 msgid "search.technologyModal.searchPlaceholder"
 msgstr "Filtra tecnologie..."
 
 #. Section title for filters in watchlist view
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:221
+#: src/components/watchlist/watchlist-filter-editor.tsx:224
 msgid "watchlists.view.filters"
 msgstr "Filtri"
 
@@ -1663,7 +1761,7 @@ msgstr "Capito"
 
 #. Dismiss upgrade modal
 #. js-lingui-explicit-id
-#: src/components/ui/upgrade-modal.tsx:66
+#: src/components/ui/upgrade-modal.tsx:69
 msgid "upgrade.modal.dismiss"
 msgstr "Capito"
 
@@ -1759,9 +1857,9 @@ msgstr "Come indicizziamo"
 #. Work mode: hybrid (mixed onsite/remote)
 #. Work mode: hybrid (mixed onsite/remote)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:587
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:597
 #: src/components/search/search-bar.tsx:812
-#: src/components/search/search-toolbar.tsx:260
+#: src/components/search/search-toolbar.tsx:271
 #: src/components/search/work-mode-modal.tsx:27
 msgid "search.workMode.hybrid"
 msgstr "Ibrido"
@@ -1837,7 +1935,7 @@ msgstr "Politica di indicizzazione"
 
 #. Industry filter label
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:235
+#: src/components/watchlist/company-search-modal.tsx:238
 msgid "watchlists.companyModal.industry"
 msgstr "Settore"
 
@@ -1897,7 +1995,7 @@ msgstr "In colloquio"
 
 #. Application tracker status: interviewing
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:450
+#: src/components/search/job-detail-dialog.tsx:452
 msgid "search.tracker.interviewing"
 msgstr "In colloquio"
 
@@ -1972,7 +2070,7 @@ msgstr "Dati sugli annunci (CC BY-NC 4.0)"
 
 #. Job detail panel title
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:86
+#: src/components/search/job-detail-dialog.tsx:87
 msgid "search.detail.title"
 msgstr "Dettagli dell'offerta"
 
@@ -2100,7 +2198,7 @@ msgstr "Giu"
 
 #. Add keyword filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:208
+#: src/components/watchlist/watchlist-filter-editor.tsx:211
 msgid "watchlists.filters.keyword"
 msgstr "Parola chiave"
 
@@ -2220,7 +2318,7 @@ msgstr "Caricamento…"
 
 #. Add location filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:209
+#: src/components/watchlist/watchlist-filter-editor.tsx:212
 msgid "watchlists.filters.location"
 msgstr "Luogo"
 
@@ -2230,17 +2328,17 @@ msgstr "Luogo"
 msgid "search.advanced.location"
 msgstr "Luogo"
 
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:314
+msgid "search.detail.locations"
+msgstr "Località"
+
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:842
 msgid "search.bar.locations"
 msgstr "Sedi"
-
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:312
-msgid "search.detail.locations"
-msgstr "Località"
 
 #. Login button label
 #. Login button label
@@ -2318,7 +2416,7 @@ msgstr "Segna come rifiutato"
 
 #. Header for the server-side search-results cluster shown when the user types in the location modal search box
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:582
+#: src/components/search/location-search-modal.tsx:585
 msgid "search.locationModal.searchHitsHeader"
 msgstr "Risultati"
 
@@ -2409,7 +2507,7 @@ msgstr "Mensile"
 
 #. Expand location pill list to show all
 #. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:356
+#: src/components/search/filter-bar.tsx:360
 msgid "company.page.showMore"
 msgstr "altro"
 
@@ -2510,37 +2608,37 @@ msgstr "Nessuna ridistribuzione commerciale o rivendita senza autorizzazione."
 
 #. Empty state when no filters are set
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:407
+#: src/components/watchlist/watchlist-filter-editor.tsx:467
 msgid "watchlists.filters.empty"
 msgstr "Nessun filtro impostato. Aggiungi filtri per restringere i risultati."
 
 #. No industries match search
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:277
+#: src/components/watchlist/company-search-modal.tsx:280
 msgid "watchlists.companyModal.noIndustries"
 msgstr "Nessun settore trovato."
 
 #. Empty state when no jobs match the time range
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:207
+#: src/components/watchlist/watchlist-job-list.tsx:208
 msgid "watchlists.jobList.empty"
 msgstr "Nessuna offerta trovata."
 
 #. No languages match search in all-languages modal
 #. js-lingui-explicit-id
-#: src/components/settings/JobLanguageModal.tsx:92
+#: src/components/settings/JobLanguageModal.tsx:95
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Nessuna lingua corrisponde alla ricerca."
 
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:309
+#: src/components/search/location-modal.tsx:312
 msgid "company.locationModal.noResults"
 msgstr "Nessuna sede corrisponde alla tua ricerca."
 
 #. No locations match search in location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:513
+#: src/components/search/location-search-modal.tsx:516
 msgid "search.locationModal.noResults"
 msgstr "Nessun luogo corrisponde alla tua ricerca."
 
@@ -2570,19 +2668,19 @@ msgstr "Nessun risultato trovato per \"{query}\""
 
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:341
+#: src/components/search/occupation-modal.tsx:344
 msgid "search.occupationModal.noResults"
 msgstr "Nessun ruolo corrisponde alla tua ricerca."
 
 #. No seniority levels available
 #. js-lingui-explicit-id
-#: src/components/search/seniority-modal.tsx:76
+#: src/components/search/seniority-modal.tsx:80
 msgid "search.seniorityModal.noResults"
 msgstr "Nessun livello di anzianità disponibile."
 
 #. No technologies available or matching search
 #. js-lingui-explicit-id
-#: src/components/search/technology-modal.tsx:151
+#: src/components/search/technology-modal.tsx:154
 msgid "search.technologyModal.noResults"
 msgstr "Nessuna tecnologia trovata."
 
@@ -2622,7 +2720,7 @@ msgstr "No. Non vendiamo, affittiamo né condividiamo i tuoi dati a fini di mark
 
 #. Application tracker status: not applied
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:448
+#: src/components/search/job-detail-dialog.tsx:450
 msgid "search.tracker.notApplied"
 msgstr "Non candidato"
 
@@ -2646,7 +2744,7 @@ msgstr "Nov"
 
 #. Add occupation filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:210
+#: src/components/watchlist/watchlist-filter-editor.tsx:213
 msgid "watchlists.filters.occupation"
 msgstr "Professione"
 
@@ -2658,7 +2756,7 @@ msgstr "Ott"
 
 #. Application tracker status: offer
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:451
+#: src/components/search/job-detail-dialog.tsx:453
 msgid "search.tracker.offer"
 msgstr "Offerta"
 
@@ -2697,9 +2795,9 @@ msgstr "Ok"
 #. Work mode: onsite (in-office)
 #. Work mode: onsite (in-office)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:585
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:595
 #: src/components/search/search-bar.tsx:810
-#: src/components/search/search-toolbar.tsx:258
+#: src/components/search/search-toolbar.tsx:269
 #: src/components/search/work-mode-modal.tsx:26
 msgid "search.workMode.onsite"
 msgstr "In sede"
@@ -2777,13 +2875,13 @@ msgstr "Originale"
 
 #. Fallback label for a country header in the location modal when the city has no parent country in the hierarchy. Rare path.
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:635
+#: src/components/search/location-search-modal.tsx:638
 msgid "search.locationModal.otherCountry"
 msgstr "Altro"
 
 #. Fallback label for a region row in the location modal when the region has no display name (e.g. orphaned cities). Rare path; only shown when a city's parent region in the hierarchy has no localized name.
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:720
+#: src/components/search/location-search-modal.tsx:723
 msgid "search.locationModal.otherRegion"
 msgstr "Altro"
 
@@ -3013,13 +3111,13 @@ msgstr "Accedi per gestire le impostazioni di fatturazione."
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:101
+#: src/components/search/job-detail-dialog.tsx:103
 msgid "search.detail.notFound"
 msgstr "Offerta non trovata."
 
 #. Posting not found message
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:183
+#: src/components/my-jobs/my-job-detail-panel.tsx:184
 msgid "myJobs.detail.notFound"
 msgstr "Offerta non trovata."
 
@@ -3157,20 +3255,20 @@ msgstr "Ridistribuire le proprie modifiche, a condizione di includere l'avviso M
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:32
 #: src/components/search/filter-bar.tsx:34
+#: src/components/search/location-pills.tsx:28
 #: src/components/search/location-pills.tsx:30
-#: src/components/search/location-pills.tsx:32
 msgid "location.type.region"
 msgstr "Regione"
 
 #. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:319
+#: src/components/search/location-modal.tsx:322
 msgid "company.locationModal.regionsHeader"
 msgstr "Regioni"
 
 #. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:523
+#: src/components/search/location-search-modal.tsx:526
 msgid "search.locationModal.regionsHeader"
 msgstr "Regioni"
 
@@ -3182,7 +3280,7 @@ msgstr "Rifiutato"
 
 #. Application tracker status: rejected
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:452
+#: src/components/search/job-detail-dialog.tsx:454
 msgid "search.tracker.rejected"
 msgstr "Rifiutato"
 
@@ -3215,12 +3313,84 @@ msgstr "Rilasciato sotto licenza MIT. I dati sugli annunci sono CC BY-NC 4.0."
 #. Work mode: remote (work-from-home)
 #. Work mode: remote (work-from-home)
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:588
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:598
 #: src/components/search/search-bar.tsx:813
-#: src/components/search/search-toolbar.tsx:261
+#: src/components/search/search-toolbar.tsx:272
 #: src/components/search/work-mode-modal.tsx:28
 msgid "search.workMode.remote"
 msgstr "Remoto"
+
+#. Aria label for the X button that removes a company pill; {name} is the company name
+#. js-lingui-explicit-id
+#. placeholder {0}: company.name
+#: src/components/watchlist/company-pill.tsx:24
+msgid "watchlists.companyPill.remove"
+msgstr "Rimuovi {0}"
+
+#. Aria label for the X button that removes a filter pill; {name} is the filter value
+#. Aria label for the X button that removes a filter pill; {name} is the filter value
+#. js-lingui-explicit-id
+#. placeholder {0}: pill.filter.name
+#: src/components/search/filter-bar.tsx:279
+#: src/components/search/filter-bar.tsx:297
+msgid "company.page.removeFilter"
+msgstr "Rimuovi filtro {0}"
+
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. Aria label for remove-filter X button on a filter pill; {name} is the filter value
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:559
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:569
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:579
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:589
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:603
+#: src/components/search/search-toolbar.tsx:201
+#: src/components/search/search-toolbar.tsx:220
+#: src/components/search/search-toolbar.tsx:240
+#: src/components/search/search-toolbar.tsx:260
+#: src/components/search/search-toolbar.tsx:283
+msgid "search.filters.removeFilter"
+msgstr "Rimuovi filtro {name}"
+
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. Aria label for remove-filter X button on a watchlist pill; {name} is the filter value
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:240
+#: src/components/watchlist/watchlist-filter-editor.tsx:252
+#: src/components/watchlist/watchlist-filter-editor.tsx:264
+#: src/components/watchlist/watchlist-filter-editor.tsx:276
+#: src/components/watchlist/watchlist-filter-editor.tsx:288
+#: src/components/watchlist/watchlist-filter-editor.tsx:300
+#: src/components/watchlist/watchlist-filter-editor.tsx:312
+msgid "watchlists.filters.removeFilter"
+msgstr "Rimuovi filtro {name}"
+
+#. Aria label for the X button that clears the experience-range filter
+#. Aria label for the X button that clears the experience-range filter
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:622
+#: src/components/search/search-toolbar.tsx:318
+msgid "search.filters.removeExperience"
+msgstr "Rimuovi filtro esperienza"
+
+#. Aria label for the X button that clears the experience-range watchlist filter
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:339
+msgid "watchlists.filters.removeExperience"
+msgstr "Rimuovi filtro esperienza"
 
 #. Aria label for removing a keyword pill
 #. js-lingui-explicit-id
@@ -3228,11 +3398,55 @@ msgstr "Remoto"
 msgid "search.keywords.remove"
 msgstr "Rimuovi parola chiave"
 
+#. Aria label for the X button that removes a keyword filter pill; {name} is the keyword
+#. js-lingui-explicit-id
+#. placeholder {0}: pill.filter.value
+#: src/components/search/filter-bar.tsx:261
+msgid "company.page.removeKeyword"
+msgstr "Rimuovi parola chiave {0}"
+
+#. Aria label for remove-keyword X button; {name} is the keyword
+#. Aria label for remove-keyword X button; {name} is the keyword
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:630
+#: src/components/search/search-toolbar.tsx:335
+msgid "search.filters.removeKeyword"
+msgstr "Rimuovi parola chiave {name}"
+
 #. Aria label for removing a location pill
 #. js-lingui-explicit-id
-#: src/components/search/location-pills.tsx:201
+#: src/components/search/location-pills.tsx:199
 msgid "search.locations.remove"
 msgstr "Rimuovi località"
+
+#. Aria label for the X button that removes a location filter pill; {name} is the location label
+#. js-lingui-explicit-id
+#. placeholder {0}: pill.filter.name
+#: src/components/search/filter-bar.tsx:315
+msgid "company.page.removeLocation"
+msgstr "Rimuovi località {0}"
+
+#. Aria label for remove-location X button; {name} is the location label
+#. Aria label for remove-location X button; {name} is the location label
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:640
+#: src/components/search/search-toolbar.tsx:356
+msgid "search.filters.removeLocation"
+msgstr "Rimuovi località {name}"
+
+#. Aria label for the X button that clears the salary-range filter
+#. Aria label for the X button that clears the salary-range filter
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:613
+#: src/components/search/search-toolbar.tsx:301
+msgid "search.filters.removeSalary"
+msgstr "Rimuovi filtro stipendio"
+
+#. Aria label for the X button that clears the salary-range watchlist filter
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-filter-editor.tsx:326
+msgid "watchlists.filters.removeSalary"
+msgstr "Rimuovi filtro stipendio"
 
 #. Synthetic dropdown row that lets the user request a company that's not in the catalog
 #. js-lingui-explicit-id
@@ -3284,13 +3498,13 @@ msgstr "Reinvia email di verifica"
 
 #. Reset salary filter
 #. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:314
+#: src/components/search/salary-modal.tsx:318
 msgid "search.salaryModal.reset"
 msgstr "Reimposta"
 
 #. Reset experience filter
 #. js-lingui-explicit-id
-#: src/components/search/experience-modal.tsx:240
+#: src/components/search/experience-modal.tsx:243
 msgid "search.experienceModal.reset"
 msgstr "Reimposta"
 
@@ -3362,7 +3576,7 @@ msgstr "Visualizzazione stipendio"
 
 #. Title for salary filter modal
 #. js-lingui-explicit-id
-#: src/components/search/salary-modal.tsx:246
+#: src/components/search/salary-modal.tsx:247
 msgid "search.salaryModal.title"
 msgstr "Fascia salariale"
 
@@ -3471,7 +3685,7 @@ msgstr "Cerca aziende..."
 
 #. Placeholder for company search in modal
 #. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:217
+#: src/components/watchlist/company-search-modal.tsx:220
 msgid "watchlists.companyModal.searchPlaceholder"
 msgstr "Cerca aziende..."
 
@@ -3488,19 +3702,19 @@ msgstr "Cerca lavori in migliaia di aziende, scansionati direttamente dalle pagi
 
 #. Placeholder for search input in all-languages modal
 #. js-lingui-explicit-id
-#: src/components/settings/JobLanguageModal.tsx:78
+#: src/components/settings/JobLanguageModal.tsx:81
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Cerca lingue…"
 
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:288
+#: src/components/search/location-modal.tsx:291
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Cerca sedi…"
 
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:492
+#: src/components/search/location-search-modal.tsx:495
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Cerca luoghi..."
 
@@ -3512,7 +3726,7 @@ msgstr "Risultati della ricerca"
 
 #. Placeholder for search input in occupation modal
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:320
+#: src/components/search/occupation-modal.tsx:323
 msgid "search.occupationModal.searchPlaceholder"
 msgstr "Cerca ruoli..."
 
@@ -3542,7 +3756,7 @@ msgstr "Visualizza il tuo funnel, i tassi di conversione e la heatmap delle atti
 
 #. Title for the seniority level selection modal
 #. js-lingui-explicit-id
-#: src/components/search/seniority-modal.tsx:57
+#: src/components/search/seniority-modal.tsx:58
 msgid "search.seniorityModal.title"
 msgstr "Seleziona livello"
 
@@ -3608,7 +3822,7 @@ msgstr "Invio…"
 
 #. Add seniority filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:211
+#: src/components/watchlist/watchlist-filter-editor.tsx:214
 msgid "watchlists.filters.seniority"
 msgstr "Livello di esperienza"
 
@@ -3654,16 +3868,16 @@ msgstr "Impostazioni"
 msgid "home.features.s3.p3.title"
 msgstr "Condividi con chiunque"
 
-#. Collapse location pill list
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:351
-msgid "company.page.showLess"
-msgstr "Mostra meno"
-
 #. Button to collapse location list
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:355
+#: src/components/search/job-detail-dialog.tsx:357
 msgid "search.detail.showLessLocations"
+msgstr "Mostra meno"
+
+#. Collapse location pill list
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:355
+msgid "company.page.showLess"
 msgstr "Mostra meno"
 
 #. Aria label to show password
@@ -3860,7 +4074,7 @@ msgstr "Stato"
 
 #. Status section heading
 #. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:200
+#: src/components/my-jobs/my-job-detail-panel.tsx:201
 msgid "myJobs.detail.status"
 msgstr "Stato"
 
@@ -3936,21 +4150,21 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Tecnico"
 
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:399
+msgid "search.detail.technologies"
+msgstr "Tecnologie"
+
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:765
 msgid "search.bar.technologies"
 msgstr "Tecnologie"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:397
-msgid "search.detail.technologies"
-msgstr "Tecnologie"
-
 #. Add technology filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:212
+#: src/components/watchlist/watchlist-filter-editor.tsx:215
 msgid "watchlists.filters.technology"
 msgstr "Tecnologia"
 
@@ -4134,7 +4348,7 @@ msgstr "Riprova"
 
 #. Add employment type filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:213
+#: src/components/watchlist/watchlist-filter-editor.tsx:216
 msgid "watchlists.filters.employmentType"
 msgstr "Tipo"
 
@@ -4146,7 +4360,7 @@ msgstr "Tipo di impiego"
 
 #. Placeholder for filter value input
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:377
+#: src/components/watchlist/watchlist-filter-editor.tsx:435
 msgid "watchlists.filters.inputPlaceholder"
 msgstr "Digita lo slug e premi Invio"
 
@@ -4211,7 +4425,7 @@ msgstr "Aggiorna nome utente"
 
 #. Upgrade button in modal
 #. js-lingui-explicit-id
-#: src/components/ui/upgrade-modal.tsx:74
+#: src/components/ui/upgrade-modal.tsx:77
 msgid "upgrade.modal.upgrade"
 msgstr "Upgrade"
 
@@ -4294,7 +4508,7 @@ msgstr "Videochiamata"
 
 #. Link to the original job posting
 #. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:186
+#: src/components/search/job-detail-dialog.tsx:188
 msgid "search.detail.viewPosting"
 msgstr "Vedi offerta"
 
@@ -4508,13 +4722,13 @@ msgstr "Quali lingue supporta Jobseek?"
 
 #. Add work-mode (onsite/hybrid/remote) filter
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-filter-editor.tsx:214
+#: src/components/watchlist/watchlist-filter-editor.tsx:217
 msgid "watchlists.filters.workMode"
 msgstr "Modalità di lavoro"
 
 #. Title for the work-mode (onsite/hybrid/remote) selection modal
 #. js-lingui-explicit-id
-#: src/components/search/work-mode-modal.tsx:82
+#: src/components/search/work-mode-modal.tsx:83
 msgid "search.workModeModal.title"
 msgstr "Modalità di lavoro"
 

--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -136,16 +136,16 @@ export function AppHeader() {
           {/* Nav icons (desktop only) */}
           <nav className="hidden items-center gap-1 md:flex">
             <NavIcon href={appHref} label={exploreLabel}>
-              <Compass size={18} />
+              <Compass size={18} aria-hidden="true" />
             </NavIcon>
             <NavIcon href={lp("/watchlists")} label={watchlistsLabel}>
-              <Eye size={18} />
+              <Eye size={18} aria-hidden="true" />
             </NavIcon>
             <NavIcon href={lp("/my-jobs")} label={myJobsLabel}>
-              <Briefcase size={18} />
+              <Briefcase size={18} aria-hidden="true" />
             </NavIcon>
             <NavIcon href={lp(siteConfig.nav.settings.href)} label={settingsLabel}>
-              <Settings size={18} />
+              <Settings size={18} aria-hidden="true" />
             </NavIcon>
           </nav>
 

--- a/apps/web/src/components/Header.tsx
+++ b/apps/web/src/components/Header.tsx
@@ -88,7 +88,7 @@ export function Header({ onOpenMobileAction }: HeaderProps) {
           className="inline-flex items-center justify-center rounded-md p-1.5 text-foreground hover:bg-border-soft cursor-pointer lg:hidden"
           aria-label={t({ id: "common.header.openMenu", comment: "Aria label for mobile menu button", message: "Open main menu" })}
         >
-          <Menu size={20} />
+          <Menu size={20} aria-hidden="true" />
         </button>
       </div>
     </header>

--- a/apps/web/src/components/LocaleSwitcher.tsx
+++ b/apps/web/src/components/LocaleSwitcher.tsx
@@ -51,7 +51,7 @@ export function LocaleSwitcher({ className }: LocaleSwitcherProps) {
                 className={`inline-flex items-center justify-center rounded-md p-1.5 text-foreground hover:bg-border-soft transition-colors cursor-pointer ${className ?? ""}`}
                 aria-label={label}
               >
-                <Globe size={18} />
+                <Globe size={18} aria-hidden="true" />
               </button>
             </DropdownMenu.Trigger>
           </Tooltip.Trigger>

--- a/apps/web/src/components/MobileMenu.tsx
+++ b/apps/web/src/components/MobileMenu.tsx
@@ -65,7 +65,7 @@ export function MobileMenu({ open, onCloseAction }: MobileMenuProps) {
                     className="inline-flex items-center justify-center rounded-md p-1.5 text-foreground hover:bg-border-soft cursor-pointer"
                     aria-label={t({ id: "common.mobileMenu.close", comment: "Aria label for close mobile menu button", message: "Close menu" })}
                   >
-                    <X size={18} />
+                    <X size={18} aria-hidden="true" />
                   </button>
                 </Dialog.Close>
               </div>

--- a/apps/web/src/components/ThemeToggleButton.tsx
+++ b/apps/web/src/components/ThemeToggleButton.tsx
@@ -40,7 +40,7 @@ export function ThemeToggleButton({ className }: ThemeToggleButtonProps) {
             className={`inline-flex items-center justify-center rounded-md p-1.5 text-foreground hover:bg-border-soft transition-colors cursor-pointer ${className ?? ""}`}
             aria-label={label}
           >
-            {isDark ? <Sun size={18} /> : <Moon size={18} />}
+            {isDark ? <Sun size={18} aria-hidden="true" /> : <Moon size={18} aria-hidden="true" />}
           </button>
         </Tooltip.Trigger>
         <Tooltip.Portal>

--- a/apps/web/src/components/__tests__/aria-hidden-lucide-icons.test.tsx
+++ b/apps/web/src/components/__tests__/aria-hidden-lucide-icons.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+
+// `server-only` is a marker import that throws when loaded outside an
+// RSC context. Several transitive deps pull it in; stub here so the
+// component tree under test renders.
+vi.mock("server-only", () => ({}));
+
+// Stub the full Lingui surface used by Header/MobileMenu/search-toolbar
+// so the components render without an active I18nProvider.
+import "@/test-utils/lingui-mock";
+
+// `next/link` pulls in router internals; stub to a plain anchor so the
+// test renderer doesn't try to wire App Router hooks.
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ href, onClick, children, prefetch: _prefetch, ...rest }: {
+    href: string;
+    onClick?: (e: React.MouseEvent) => void;
+    children: React.ReactNode;
+    prefetch?: boolean;
+  }) => (
+    <a href={href} onClick={onClick} {...rest}>{children}</a>
+  ),
+}));
+
+// `usePathname` is used by Header and MobileMenu for the active-link
+// computation. Stub to a fixed value so the components render.
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/en",
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  useParams: () => ({ lang: "en" }),
+}));
+
+// SessionProvider is consumed indirectly via the Avatar in AppHeader,
+// but Header.tsx and MobileMenu.tsx don't reach for session. The
+// component itself doesn't import next-themes either. We still need
+// to stub `useLocalePath` so the Link `href` resolves.
+vi.mock("@/lib/useLocalePath", () => ({
+  useLocalePath: () => (p: string) => p,
+}));
+
+// Header reads from siteConfig — small, deterministic JSON; pulling the
+// real one is fine. ThemedImage doesn't require any provider.
+vi.mock("@/components/ThemeToggleButton", () => ({
+  ThemeToggleButton: () => null,
+}));
+vi.mock("@/components/LocaleSwitcher", () => ({
+  LocaleSwitcher: () => null,
+}));
+vi.mock("@/components/ThemedImage", () => ({
+  ThemedImage: ({ alt }: { alt: string }) => <span>{alt}</span>,
+}));
+
+import { Header } from "../Header";
+import { MobileMenu } from "../MobileMenu";
+import { SearchToolbar } from "../search/search-toolbar";
+
+describe("Lucide icon aria-hidden (regression for #3177)", () => {
+  it("Header hamburger icon is aria-hidden", () => {
+    const { container } = render(
+      <Header onOpenMobileAction={() => {}} />,
+    );
+    // The hamburger button's inner SVG should have aria-hidden="true"
+    // so screen readers announce only the button's aria-label.
+    const btn = container.querySelector('button[aria-label]');
+    expect(btn).not.toBeNull();
+    const svg = btn?.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("MobileMenu close icon is aria-hidden when open", () => {
+    const { container } = render(
+      <MobileMenu open={true} onCloseAction={() => {}} />,
+    );
+    // The Radix Dialog portal renders into document.body, so query off
+    // the global root rather than the container.
+    const closeBtn = document.querySelector(
+      'button[aria-label*="Close" i]',
+    );
+    expect(closeBtn).not.toBeNull();
+    const svg = closeBtn?.querySelector("svg");
+    expect(svg).not.toBeNull();
+    expect(svg?.getAttribute("aria-hidden")).toBe("true");
+    // Cleanup the portaled content to avoid leaking between tests.
+    container.remove();
+  });
+
+  it("search-toolbar pill X icons are aria-hidden", () => {
+    const { container } = render(
+      <SearchToolbar
+        locale="en"
+        keywords={["typescript"]}
+        locations={[]}
+        occupations={[
+          { id: 1, slug: "engineering", name: "Engineering" },
+        ]}
+        seniorities={[]}
+        jobLanguages={[]}
+        onRemoveKeyword={() => {}}
+        onAddLocation={() => {}}
+        onRemoveLocation={() => {}}
+        onAddOccupation={() => {}}
+        onRemoveOccupation={() => {}}
+        onAddSeniority={() => {}}
+        onRemoveSeniority={() => {}}
+        onClearAll={() => {}}
+        onSubmitSearch={() => {}}
+      />,
+    );
+
+    // Every remove-filter pill button now has aria-label, so collect
+    // them and assert their child SVG is aria-hidden.
+    const removeButtons = container.querySelectorAll(
+      'button[aria-label^="Remove"]',
+    );
+    // We rendered one occupation pill + one keyword pill -> at least 2
+    // remove buttons live in the DOM.
+    expect(removeButtons.length).toBeGreaterThanOrEqual(2);
+
+    for (const btn of Array.from(removeButtons)) {
+      const svg = btn.querySelector("svg");
+      expect(svg).not.toBeNull();
+      expect(svg?.getAttribute("aria-hidden")).toBe("true");
+    }
+  });
+});

--- a/apps/web/src/components/my-jobs/my-job-detail-panel.tsx
+++ b/apps/web/src/components/my-jobs/my-job-detail-panel.tsx
@@ -170,8 +170,9 @@ export function MyJobDetailPanel({
         <button
           onClick={onClose}
           className="cursor-pointer rounded p-1 text-muted hover:bg-border-soft hover:text-foreground"
+          aria-label={t({ id: "myJobs.detail.close", comment: "Aria label for the my-jobs detail panel close button", message: "Close job details" })}
         >
-          <X size={14} />
+          <X size={14} aria-hidden="true" />
         </button>
       </div>
 

--- a/apps/web/src/components/my-jobs/quick-actions.tsx
+++ b/apps/web/src/components/my-jobs/quick-actions.tsx
@@ -24,7 +24,7 @@ function useActionsByStatus(): Record<ApplicationStatus, Action[]> {
     saved: [
       {
         label: markApplied,
-        icon: <Check size={12} />,
+        icon: <Check size={12} aria-hidden="true" />,
         status: "applied",
         className: "text-blue-600 hover:bg-blue-100 dark:hover:bg-blue-900/40",
       },
@@ -32,14 +32,14 @@ function useActionsByStatus(): Record<ApplicationStatus, Action[]> {
     applied: [
       {
         label: addInterview,
-        icon: <Plus size={12} />,
+        icon: <Plus size={12} aria-hidden="true" />,
         status: "interviewing",
         className:
           "text-amber-600 hover:bg-amber-100 dark:hover:bg-amber-900/40",
       },
       {
         label: markRejected,
-        icon: <X size={12} />,
+        icon: <X size={12} aria-hidden="true" />,
         status: "rejected",
         className: "text-red-500 hover:bg-red-100 dark:hover:bg-red-900/40",
       },
@@ -47,21 +47,21 @@ function useActionsByStatus(): Record<ApplicationStatus, Action[]> {
     interviewing: [
       {
         label: addInterview,
-        icon: <Plus size={12} />,
+        icon: <Plus size={12} aria-hidden="true" />,
         status: "interviewing",
         className:
           "text-amber-600 hover:bg-amber-100 dark:hover:bg-amber-900/40",
       },
       {
         label: markOffer,
-        icon: <Star size={12} />,
+        icon: <Star size={12} aria-hidden="true" />,
         status: "offered",
         className:
           "text-green-600 hover:bg-green-100 dark:hover:bg-green-900/40",
       },
       {
         label: markRejected,
-        icon: <X size={12} />,
+        icon: <X size={12} aria-hidden="true" />,
         status: "rejected",
         className: "text-red-500 hover:bg-red-100 dark:hover:bg-red-900/40",
       },
@@ -69,7 +69,7 @@ function useActionsByStatus(): Record<ApplicationStatus, Action[]> {
     offered: [
       {
         label: markRejected,
-        icon: <X size={12} />,
+        icon: <X size={12} aria-hidden="true" />,
         status: "rejected",
         className: "text-red-500 hover:bg-red-100 dark:hover:bg-red-900/40",
       },
@@ -112,6 +112,7 @@ export function QuickActions({
                   onStatusChange(action.status);
                 }
               }}
+              aria-label={action.label}
               className={`inline-flex cursor-pointer items-center justify-center rounded p-1 transition-colors ${action.className}`}
             >
               {action.icon}

--- a/apps/web/src/components/search/employment-type-modal.tsx
+++ b/apps/web/src/components/search/employment-type-modal.tsx
@@ -42,6 +42,7 @@ export function EmploymentTypeModal({
   onToggle,
   filters,
 }: EmploymentTypeModalProps) {
+  const { t } = useLingui();
   const EMPLOYMENT_TYPES = useEmploymentTypes();
   const selectedSet = useMemo(() => new Set(selected), [selected]);
 
@@ -76,8 +77,11 @@ export function EmploymentTypeModal({
               </Trans>
             </Dialog.Title>
             <Dialog.Close asChild>
-              <button className="cursor-pointer rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground">
-                <X size={16} />
+              <button
+                className="cursor-pointer rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground"
+                aria-label={t({ id: "search.employmentTypeModal.close", comment: "Aria label for the employment-type modal close button", message: "Close" })}
+              >
+                <X size={16} aria-hidden="true" />
               </button>
             </Dialog.Close>
           </div>

--- a/apps/web/src/components/search/experience-modal.tsx
+++ b/apps/web/src/components/search/experience-modal.tsx
@@ -188,8 +188,11 @@ export function ExperienceModal({
               </Trans>
             </Dialog.Title>
             <Dialog.Close asChild>
-              <button className="rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer">
-                <X size={16} />
+              <button
+                className="rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer"
+                aria-label={t({ id: "search.experienceModal.close", comment: "Aria label for the experience modal close button", message: "Close" })}
+              >
+                <X size={16} aria-hidden="true" />
               </button>
             </Dialog.Close>
           </div>

--- a/apps/web/src/components/search/filter-bar.tsx
+++ b/apps/web/src/components/search/filter-bar.tsx
@@ -258,8 +258,9 @@ export function FilterBar({
                   <button
                     onClick={() => removeFilter(pill.filter)}
                     className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
+                    aria-label={t({ id: "company.page.removeKeyword", comment: "Aria label for the X button that removes a keyword filter pill; {name} is the keyword", message: `Remove keyword ${pill.filter.value}` })}
                   >
-                    <X size={12} />
+                    <X size={12} aria-hidden="true" />
                   </button>
                 </span>
               );
@@ -275,8 +276,9 @@ export function FilterBar({
                   <button
                     onClick={() => removeFilter(pill.filter)}
                     className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
+                    aria-label={t({ id: "company.page.removeFilter", comment: "Aria label for the X button that removes a filter pill; {name} is the filter value", message: `Remove ${pill.filter.name} filter` })}
                   >
-                    <X size={12} />
+                    <X size={12} aria-hidden="true" />
                   </button>
                 </span>
               );
@@ -292,8 +294,9 @@ export function FilterBar({
                   <button
                     onClick={() => removeFilter(pill.filter)}
                     className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
+                    aria-label={t({ id: "company.page.removeFilter", comment: "Aria label for the X button that removes a filter pill; {name} is the filter value", message: `Remove ${pill.filter.name} filter` })}
                   >
-                    <X size={12} />
+                    <X size={12} aria-hidden="true" />
                   </button>
                 </span>
               );
@@ -309,8 +312,9 @@ export function FilterBar({
                   <button
                     onClick={() => removeFilter(pill.filter)}
                     className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
+                    aria-label={t({ id: "company.page.removeLocation", comment: "Aria label for the X button that removes a location filter pill; {name} is the location label", message: `Remove location ${pill.filter.name}` })}
                   >
-                    <X size={12} />
+                    <X size={12} aria-hidden="true" />
                   </button>
                 </span>
               );

--- a/apps/web/src/components/search/job-detail-dialog.tsx
+++ b/apps/web/src/components/search/job-detail-dialog.tsx
@@ -30,6 +30,7 @@ interface JobDetailPanelProps {
 }
 
 export function JobDetailPanel({ postingId, onClose }: JobDetailPanelProps) {
+  const { t } = useLingui();
   const [detail, setDetail] = useState<PostingDetail | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(false);
@@ -88,8 +89,9 @@ export function JobDetailPanel({ postingId, onClose }: JobDetailPanelProps) {
         <button
           onClick={onClose}
           className="rounded p-1 text-muted hover:bg-border-soft hover:text-foreground"
+          aria-label={t({ id: "search.detail.close", comment: "Aria label for job detail panel close button", message: "Close job details" })}
         >
-          <X size={14} />
+          <X size={14} aria-hidden="true" />
         </button>
       </div>
 

--- a/apps/web/src/components/search/keyword-pills.tsx
+++ b/apps/web/src/components/search/keyword-pills.tsx
@@ -47,7 +47,7 @@ export function KeywordPills({ keywords, onAdd, onRemove }: KeywordPillsProps) {
               message: "Remove keyword",
             })}
           >
-            <X size={12} />
+            <X size={12} aria-hidden="true" />
           </button>
         </span>
       ))}

--- a/apps/web/src/components/search/location-modal.tsx
+++ b/apps/web/src/components/search/location-modal.tsx
@@ -270,8 +270,11 @@ export function LocationModal({
               </Trans>
             </Dialog.Title>
             <Dialog.Close asChild>
-              <button className="rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer">
-                <X size={16} />
+              <button
+                className="rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer"
+                aria-label={t({ id: "company.locationModal.close", comment: "Aria label for close button on the company-page all-locations modal", message: "Close" })}
+              >
+                <X size={16} aria-hidden="true" />
               </button>
             </Dialog.Close>
           </div>

--- a/apps/web/src/components/search/location-pills.tsx
+++ b/apps/web/src/components/search/location-pills.tsx
@@ -202,7 +202,7 @@ export function LocationPills({
               message: "Remove location",
             })}
           >
-            <X size={12} />
+            <X size={12} aria-hidden="true" />
           </button>
         </span>
       ))}

--- a/apps/web/src/components/search/location-search-modal.tsx
+++ b/apps/web/src/components/search/location-search-modal.tsx
@@ -474,8 +474,11 @@ export function LocationSearchModal({
               </Trans>
             </Dialog.Title>
             <Dialog.Close asChild>
-              <button className="rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer">
-                <X size={16} />
+              <button
+                className="rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer"
+                aria-label={t({ id: "search.locationModal.close", comment: "Aria label for the location modal close button", message: "Close" })}
+              >
+                <X size={16} aria-hidden="true" />
               </button>
             </Dialog.Close>
           </div>

--- a/apps/web/src/components/search/occupation-modal.tsx
+++ b/apps/web/src/components/search/occupation-modal.tsx
@@ -302,8 +302,11 @@ export function OccupationModal({
               </Trans>
             </Dialog.Title>
             <Dialog.Close asChild>
-              <button className="rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer">
-                <X size={16} />
+              <button
+                className="rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer"
+                aria-label={t({ id: "search.occupationModal.close", comment: "Aria label for the occupation modal close button", message: "Close" })}
+              >
+                <X size={16} aria-hidden="true" />
               </button>
             </Dialog.Close>
           </div>

--- a/apps/web/src/components/search/salary-modal.tsx
+++ b/apps/web/src/components/search/salary-modal.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { X, Loader2 } from "lucide-react";
-import { Trans } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import {
   getCurrencyRates,
   getSalaryHistogram,
@@ -155,6 +155,7 @@ export function SalaryModal({
   onApply,
   histogramFilters,
 }: SalaryModalProps) {
+  const { t } = useLingui();
   const salaryDisplay = useSalaryDisplay();
 
   // Data — prefer context rates, fetch only histogram
@@ -248,8 +249,11 @@ export function SalaryModal({
               </Trans>
             </Dialog.Title>
             <Dialog.Close asChild>
-              <button className="rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer">
-                <X size={16} />
+              <button
+                className="rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer"
+                aria-label={t({ id: "search.salaryModal.close", comment: "Aria label for the salary modal close button", message: "Close" })}
+              >
+                <X size={16} aria-hidden="true" />
               </button>
             </Dialog.Close>
           </div>

--- a/apps/web/src/components/search/save-button.tsx
+++ b/apps/web/src/components/search/save-button.tsx
@@ -43,7 +43,7 @@ export function SaveButton({ postingId }: { postingId: string }) {
             className="shrink-0 cursor-pointer text-muted transition-opacity hover:opacity-70 disabled:cursor-default disabled:opacity-50"
             aria-label={label}
           >
-            <Icon size={14} className={saved ? "fill-current" : ""} />
+            <Icon size={14} aria-hidden="true" className={saved ? "fill-current" : ""} />
           </button>
         </Tooltip.Trigger>
         <Tooltip.Portal>

--- a/apps/web/src/components/search/search-toolbar.tsx
+++ b/apps/web/src/components/search/search-toolbar.tsx
@@ -196,8 +196,9 @@ export function SearchToolbar({
               <button
                 onClick={() => onRemoveOccupation(occ.id)}
                 className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
+                aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${occ.name} filter` })}
               >
-                <X size={12} />
+                <X size={12} aria-hidden="true" />
               </button>
             </span>
           ))}
@@ -211,8 +212,9 @@ export function SearchToolbar({
               <button
                 onClick={() => onRemoveSeniority(sen.id)}
                 className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
+                aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${sen.name} filter` })}
               >
-                <X size={12} />
+                <X size={12} aria-hidden="true" />
               </button>
             </span>
           ))}
@@ -227,46 +229,55 @@ export function SearchToolbar({
                 <button
                   onClick={() => onRemoveTechnology(tech.id)}
                   className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
+                  aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${tech.name} filter` })}
                 >
-                  <X size={12} />
+                  <X size={12} aria-hidden="true" />
                 </button>
               )}
             </span>
           ))}
-          {onToggleEmploymentType && employmentTypes && employmentTypes.map((et) => (
-            <span
-              key={et}
-              className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm capitalize text-primary"
-            >
-              <CalendarDays size={12} className="shrink-0" />
-              {et.replace(/_/g, " ")}
-              <button
-                onClick={() => onToggleEmploymentType(et)}
-                className="ml-0.5 cursor-pointer rounded-full p-0.5 transition-colors hover:bg-primary/20"
+          {onToggleEmploymentType && employmentTypes && employmentTypes.map((et) => {
+            const etLabel = et.replace(/_/g, " ");
+            return (
+              <span
+                key={et}
+                className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm capitalize text-primary"
               >
-                <X size={12} />
-              </button>
-            </span>
-          ))}
-          {onToggleWorkMode && workMode && workMode.map((wm) => (
-            <span
-              key={`wm-${wm}`}
-              className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary"
-            >
-              <Home size={12} className="shrink-0" />
-              {wm === "onsite"
-                ? t({ id: "search.workMode.onsite", comment: "Work mode: onsite (in-office)", message: "On-site" })
-                : wm === "hybrid"
-                  ? t({ id: "search.workMode.hybrid", comment: "Work mode: hybrid (mixed onsite/remote)", message: "Hybrid" })
-                  : t({ id: "search.workMode.remote", comment: "Work mode: remote (work-from-home)", message: "Remote" })}
-              <button
-                onClick={() => onToggleWorkMode(wm)}
-                className="ml-0.5 cursor-pointer rounded-full p-0.5 transition-colors hover:bg-primary/20"
+                <CalendarDays size={12} className="shrink-0" />
+                {etLabel}
+                <button
+                  onClick={() => onToggleEmploymentType(et)}
+                  className="ml-0.5 cursor-pointer rounded-full p-0.5 transition-colors hover:bg-primary/20"
+                  aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${etLabel} filter` })}
+                >
+                  <X size={12} aria-hidden="true" />
+                </button>
+              </span>
+            );
+          })}
+          {onToggleWorkMode && workMode && workMode.map((wm) => {
+            const wmLabel = wm === "onsite"
+              ? t({ id: "search.workMode.onsite", comment: "Work mode: onsite (in-office)", message: "On-site" })
+              : wm === "hybrid"
+                ? t({ id: "search.workMode.hybrid", comment: "Work mode: hybrid (mixed onsite/remote)", message: "Hybrid" })
+                : t({ id: "search.workMode.remote", comment: "Work mode: remote (work-from-home)", message: "Remote" });
+            return (
+              <span
+                key={`wm-${wm}`}
+                className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary"
               >
-                <X size={12} />
-              </button>
-            </span>
-          ))}
+                <Home size={12} className="shrink-0" />
+                {wmLabel}
+                <button
+                  onClick={() => onToggleWorkMode(wm)}
+                  className="ml-0.5 cursor-pointer rounded-full p-0.5 transition-colors hover:bg-primary/20"
+                  aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${wmLabel} filter` })}
+                >
+                  <X size={12} aria-hidden="true" />
+                </button>
+              </span>
+            );
+          })}
           {onSalaryChange && (salaryMin != null || salaryMax != null) && (
             <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
               <DollarSign size={12} className="shrink-0" />
@@ -278,8 +289,9 @@ export function SearchToolbar({
               <button
                 onClick={() => onSalaryChange(salaryCurrency ?? "EUR", undefined, undefined)}
                 className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
+                aria-label={t({ id: "search.filters.removeSalary", comment: "Aria label for the X button that clears the salary-range filter", message: "Remove salary filter" })}
               >
-                <X size={12} />
+                <X size={12} aria-hidden="true" />
               </button>
             </span>
           )}
@@ -294,8 +306,9 @@ export function SearchToolbar({
               <button
                 onClick={() => onExperienceChange(undefined, undefined)}
                 className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
+                aria-label={t({ id: "search.filters.removeExperience", comment: "Aria label for the X button that clears the experience-range filter", message: "Remove experience filter" })}
               >
-                <X size={12} />
+                <X size={12} aria-hidden="true" />
               </button>
             </span>
           )}
@@ -308,28 +321,33 @@ export function SearchToolbar({
               <button
                 onClick={() => onRemoveKeyword(kw)}
                 className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
+                aria-label={t({ id: "search.filters.removeKeyword", comment: "Aria label for remove-keyword X button; {name} is the keyword", message: `Remove keyword ${kw}` })}
               >
-                <X size={12} />
+                <X size={12} aria-hidden="true" />
               </button>
             </span>
           ))}
-          {locations.map((loc) => (
-            <span
-              key={loc.id}
-              className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary"
-            >
-              <MapPin size={12} className="shrink-0" />
-              {loc.parentName && loc.type !== "country" && loc.type !== "macro"
-                ? `${loc.name}, ${loc.parentName}`
-                : loc.name}
-              <button
-                onClick={() => onRemoveLocation(loc.id)}
-                className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
+          {locations.map((loc) => {
+            const locLabel = loc.parentName && loc.type !== "country" && loc.type !== "macro"
+              ? `${loc.name}, ${loc.parentName}`
+              : loc.name;
+            return (
+              <span
+                key={loc.id}
+                className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary"
               >
-                <X size={12} />
-              </button>
-            </span>
-          ))}
+                <MapPin size={12} className="shrink-0" />
+                {locLabel}
+                <button
+                  onClick={() => onRemoveLocation(loc.id)}
+                  className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
+                  aria-label={t({ id: "search.filters.removeLocation", comment: "Aria label for remove-location X button; {name} is the location label", message: `Remove location ${locLabel}` })}
+                >
+                  <X size={12} aria-hidden="true" />
+                </button>
+              </span>
+            );
+          })}
           <button
             onClick={onClearAll}
             className="cursor-pointer text-xs text-muted transition-colors hover:text-foreground"

--- a/apps/web/src/components/search/search-toolbar.tsx
+++ b/apps/web/src/components/search/search-toolbar.tsx
@@ -186,69 +186,78 @@ export function SearchToolbar({
       </div>
       {hasFilters && (
         <div className="flex flex-wrap items-center gap-2">
-          {occupations.map((occ) => (
-            <span
-              key={`occ-${occ.id}`}
-              className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary"
-            >
-              <Briefcase size={12} className="shrink-0" />
-              {occ.name}
-              <button
-                onClick={() => onRemoveOccupation(occ.id)}
-                className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
-                aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${occ.name} filter` })}
+          {occupations.map((occ) => {
+            const name = occ.name;
+            return (
+              <span
+                key={`occ-${occ.id}`}
+                className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary"
               >
-                <X size={12} aria-hidden="true" />
-              </button>
-            </span>
-          ))}
-          {seniorities.map((sen) => (
-            <span
-              key={`sen-${sen.id}`}
-              className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary"
-            >
-              <BarChart3 size={12} className="shrink-0" />
-              {sen.name}
-              <button
-                onClick={() => onRemoveSeniority(sen.id)}
-                className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
-                aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${sen.name} filter` })}
-              >
-                <X size={12} aria-hidden="true" />
-              </button>
-            </span>
-          ))}
-          {(technologies ?? []).map((tech) => (
-            <span
-              key={`tech-${tech.id}`}
-              className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary"
-            >
-              <Code2 size={12} className="shrink-0" />
-              {tech.name}
-              {onRemoveTechnology && (
+                <Briefcase size={12} className="shrink-0" />
+                {name}
                 <button
-                  onClick={() => onRemoveTechnology(tech.id)}
+                  onClick={() => onRemoveOccupation(occ.id)}
                   className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
-                  aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${tech.name} filter` })}
+                  aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${name} filter` })}
                 >
                   <X size={12} aria-hidden="true" />
                 </button>
-              )}
-            </span>
-          ))}
+              </span>
+            );
+          })}
+          {seniorities.map((sen) => {
+            const name = sen.name;
+            return (
+              <span
+                key={`sen-${sen.id}`}
+                className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary"
+              >
+                <BarChart3 size={12} className="shrink-0" />
+                {name}
+                <button
+                  onClick={() => onRemoveSeniority(sen.id)}
+                  className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
+                  aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${name} filter` })}
+                >
+                  <X size={12} aria-hidden="true" />
+                </button>
+              </span>
+            );
+          })}
+          {(technologies ?? []).map((tech) => {
+            const name = tech.name;
+            return (
+              <span
+                key={`tech-${tech.id}`}
+                className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary"
+              >
+                <Code2 size={12} className="shrink-0" />
+                {name}
+                {onRemoveTechnology && (
+                  <button
+                    onClick={() => onRemoveTechnology(tech.id)}
+                    className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
+                    aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${name} filter` })}
+                  >
+                    <X size={12} aria-hidden="true" />
+                  </button>
+                )}
+              </span>
+            );
+          })}
           {onToggleEmploymentType && employmentTypes && employmentTypes.map((et) => {
-            const etLabel = et.replace(/_/g, " ");
+            const name = et.replace(/_/g, " ");
             return (
               <span
                 key={et}
                 className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm capitalize text-primary"
               >
                 <CalendarDays size={12} className="shrink-0" />
-                {etLabel}
+                {name}
                 <button
                   onClick={() => onToggleEmploymentType(et)}
                   className="ml-0.5 cursor-pointer rounded-full p-0.5 transition-colors hover:bg-primary/20"
-                  aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${etLabel} filter` })}
+                  aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${name} filter` })}
                 >
                   <X size={12} aria-hidden="true" />
                 </button>
@@ -256,7 +265,7 @@ export function SearchToolbar({
             );
           })}
           {onToggleWorkMode && workMode && workMode.map((wm) => {
-            const wmLabel = wm === "onsite"
+            const name = wm === "onsite"
               ? t({ id: "search.workMode.onsite", comment: "Work mode: onsite (in-office)", message: "On-site" })
               : wm === "hybrid"
                 ? t({ id: "search.workMode.hybrid", comment: "Work mode: hybrid (mixed onsite/remote)", message: "Hybrid" })
@@ -267,11 +276,11 @@ export function SearchToolbar({
                 className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary"
               >
                 <Home size={12} className="shrink-0" />
-                {wmLabel}
+                {name}
                 <button
                   onClick={() => onToggleWorkMode(wm)}
                   className="ml-0.5 cursor-pointer rounded-full p-0.5 transition-colors hover:bg-primary/20"
-                  aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${wmLabel} filter` })}
+                  aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${name} filter` })}
                 >
                   <X size={12} aria-hidden="true" />
                 </button>
@@ -312,23 +321,26 @@ export function SearchToolbar({
               </button>
             </span>
           )}
-          {keywords.map((kw) => (
-            <span
-              key={kw}
-              className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary"
-            >
-              {kw}
-              <button
-                onClick={() => onRemoveKeyword(kw)}
-                className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
-                aria-label={t({ id: "search.filters.removeKeyword", comment: "Aria label for remove-keyword X button; {name} is the keyword", message: `Remove keyword ${kw}` })}
+          {keywords.map((kw) => {
+            const name = kw;
+            return (
+              <span
+                key={kw}
+                className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary"
               >
-                <X size={12} aria-hidden="true" />
-              </button>
-            </span>
-          ))}
+                {name}
+                <button
+                  onClick={() => onRemoveKeyword(kw)}
+                  className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
+                  aria-label={t({ id: "search.filters.removeKeyword", comment: "Aria label for remove-keyword X button; {name} is the keyword", message: `Remove keyword ${name}` })}
+                >
+                  <X size={12} aria-hidden="true" />
+                </button>
+              </span>
+            );
+          })}
           {locations.map((loc) => {
-            const locLabel = loc.parentName && loc.type !== "country" && loc.type !== "macro"
+            const name = loc.parentName && loc.type !== "country" && loc.type !== "macro"
               ? `${loc.name}, ${loc.parentName}`
               : loc.name;
             return (
@@ -337,11 +349,11 @@ export function SearchToolbar({
                 className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary"
               >
                 <MapPin size={12} className="shrink-0" />
-                {locLabel}
+                {name}
                 <button
                   onClick={() => onRemoveLocation(loc.id)}
                   className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
-                  aria-label={t({ id: "search.filters.removeLocation", comment: "Aria label for remove-location X button; {name} is the location label", message: `Remove location ${locLabel}` })}
+                  aria-label={t({ id: "search.filters.removeLocation", comment: "Aria label for remove-location X button; {name} is the location label", message: `Remove location ${name}` })}
                 >
                   <X size={12} aria-hidden="true" />
                 </button>

--- a/apps/web/src/components/search/seniority-modal.tsx
+++ b/apps/web/src/components/search/seniority-modal.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useMemo, useRef } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { X, Loader2 } from "lucide-react";
-import { Trans } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { ScrollFade } from "@/components/ui/scroll-fade";
 import { getAllSeniorities } from "@/lib/actions/taxonomy";
 import type { SeniorityOption } from "@/lib/actions/taxonomy";
@@ -25,6 +25,7 @@ export function SeniorityModal({
   onToggle,
   filters,
 }: SeniorityModalProps) {
+  const { t } = useLingui();
   const [options, setOptions] = useState<SeniorityOption[] | null>(null);
   const [loading, setLoading] = useState(false);
 
@@ -59,8 +60,11 @@ export function SeniorityModal({
               </Trans>
             </Dialog.Title>
             <Dialog.Close asChild>
-              <button className="rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer">
-                <X size={16} />
+              <button
+                className="rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer"
+                aria-label={t({ id: "search.seniorityModal.close", comment: "Aria label for the seniority modal close button", message: "Close" })}
+              >
+                <X size={16} aria-hidden="true" />
               </button>
             </Dialog.Close>
           </div>

--- a/apps/web/src/components/search/star-button.tsx
+++ b/apps/web/src/components/search/star-button.tsx
@@ -40,6 +40,7 @@ export function StarButton({ companyId }: { companyId: string }) {
     >
       <Star
         size={18}
+        aria-hidden="true"
         className={starred ? "fill-accent text-accent" : "text-muted hover:text-accent"}
       />
     </button>

--- a/apps/web/src/components/search/technology-modal.tsx
+++ b/apps/web/src/components/search/technology-modal.tsx
@@ -112,8 +112,11 @@ export function TechnologyModal({
               </Trans>
             </Dialog.Title>
             <Dialog.Close asChild>
-              <button className="rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer">
-                <X size={16} />
+              <button
+                className="rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer"
+                aria-label={t({ id: "search.technologyModal.close", comment: "Aria label for the technology modal close button", message: "Close" })}
+              >
+                <X size={16} aria-hidden="true" />
               </button>
             </Dialog.Close>
           </div>

--- a/apps/web/src/components/search/work-mode-modal.tsx
+++ b/apps/web/src/components/search/work-mode-modal.tsx
@@ -50,6 +50,7 @@ export function WorkModeModal({
   onToggle,
   filters,
 }: WorkModeModalProps) {
+  const { t } = useLingui();
   const WORK_MODES = useWorkModes();
   const selectedSet = useMemo(() => new Set(selected), [selected]);
 
@@ -84,8 +85,11 @@ export function WorkModeModal({
               </Trans>
             </Dialog.Title>
             <Dialog.Close asChild>
-              <button className="cursor-pointer rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground">
-                <X size={16} />
+              <button
+                className="cursor-pointer rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground"
+                aria-label={t({ id: "search.workModeModal.close", comment: "Aria label for the work-mode modal close button", message: "Close" })}
+              >
+                <X size={16} aria-hidden="true" />
               </button>
             </Dialog.Close>
           </div>

--- a/apps/web/src/components/settings/JobLanguageModal.tsx
+++ b/apps/web/src/components/settings/JobLanguageModal.tsx
@@ -61,8 +61,11 @@ export function JobLanguageModal({
               </Trans>
             </Dialog.Title>
             <Dialog.Close asChild>
-              <button className="rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer">
-                <X size={16} />
+              <button
+                className="rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer"
+                aria-label={t({ id: "settings.jobLanguages.modal.close", comment: "Aria label for the job-languages modal close button", message: "Close" })}
+              >
+                <X size={16} aria-hidden="true" />
               </button>
             </Dialog.Close>
           </div>

--- a/apps/web/src/components/ui/FormField.tsx
+++ b/apps/web/src/components/ui/FormField.tsx
@@ -37,7 +37,7 @@ export function FormField({ label, className, type, ...inputProps }: FormFieldPr
             }
             tabIndex={-1}
           >
-            {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+            {showPassword ? <EyeOff size={16} aria-hidden="true" /> : <Eye size={16} aria-hidden="true" />}
           </button>
         )}
       </div>

--- a/apps/web/src/components/ui/back-to-top.tsx
+++ b/apps/web/src/components/ui/back-to-top.tsx
@@ -34,7 +34,7 @@ export function BackToTop() {
               })}
               className="flex size-10 items-center justify-center rounded-full border border-divider bg-surface-alpha shadow-lg backdrop-blur-md transition-colors hover:bg-border-soft"
             >
-              <ChevronUp size={20} />
+              <ChevronUp size={20} aria-hidden="true" />
             </button>
           </Tooltip.Trigger>
           <Tooltip.Portal>

--- a/apps/web/src/components/ui/upgrade-modal.tsx
+++ b/apps/web/src/components/ui/upgrade-modal.tsx
@@ -54,8 +54,11 @@ export function UpgradeModal({
               </p>
             </div>
             <Dialog.Close asChild>
-              <button className="rounded-md p-1 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer">
-                <X size={14} />
+              <button
+                className="rounded-md p-1 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer"
+                aria-label={t({ id: "upgrade.modal.close", comment: "Aria label for upgrade modal close button", message: "Close" })}
+              >
+                <X size={14} aria-hidden="true" />
               </button>
             </Dialog.Close>
           </div>

--- a/apps/web/src/components/watchlist/company-pill.tsx
+++ b/apps/web/src/components/watchlist/company-pill.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { X } from "lucide-react";
+import { useLingui } from "@lingui/react/macro";
 import { CompanyIcon } from "@/components/CompanyIcon";
 
 export function CompanyPill({
@@ -10,6 +11,7 @@ export function CompanyPill({
   company: { id: string; name: string; slug: string; icon: string | null };
   onRemove?: (id: string) => void;
 }) {
+  const { t } = useLingui();
   return (
     <span className="inline-flex items-center gap-1.5 rounded-full border border-border-soft px-2.5 py-1 text-sm">
       <CompanyIcon icon={company.icon} alt={company.name} size={16} />
@@ -19,8 +21,9 @@ export function CompanyPill({
           type="button"
           onClick={() => onRemove(company.id)}
           className="ml-0.5 rounded-full p-0.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer"
+          aria-label={t({ id: "watchlists.companyPill.remove", comment: "Aria label for the X button that removes a company pill; {name} is the company name", message: `Remove ${company.name}` })}
         >
-          <X size={12} />
+          <X size={12} aria-hidden="true" />
         </button>
       )}
     </span>

--- a/apps/web/src/components/watchlist/company-search-modal.tsx
+++ b/apps/web/src/components/watchlist/company-search-modal.tsx
@@ -196,8 +196,11 @@ export function CompanySearchModal({
                 </button>
               )}
               <Dialog.Close asChild>
-                <button className="rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer">
-                  <X size={16} />
+                <button
+                  className="rounded-md p-1.5 text-muted transition-colors hover:bg-border-soft hover:text-foreground cursor-pointer"
+                  aria-label={t({ id: "watchlists.companyModal.close", comment: "Aria label for close button on add-companies modal", message: "Close" })}
+                >
+                  <X size={16} aria-hidden="true" />
                 </button>
               </Dialog.Close>
             </div>

--- a/apps/web/src/components/watchlist/watchlist-action-bar.tsx
+++ b/apps/web/src/components/watchlist/watchlist-action-bar.tsx
@@ -168,7 +168,7 @@ export function WatchlistActionBar({
                   label={t({ id: "watchlists.actions.edit", comment: "Edit watchlist tooltip", message: "Edit" })}
                   onClick={onEdit}
                 >
-                  <Pencil size={16} />
+                  <Pencil size={16} aria-hidden="true" />
                 </ActionButton>
               )}
               <ActionButton
@@ -181,7 +181,7 @@ export function WatchlistActionBar({
                 disabled={!isPaidPlan && isPublic}
                 warning={!isPaidPlan && isPublic}
               >
-                {isPublic ? <Globe size={16} /> : <Lock size={16} />}
+                {isPublic ? <Globe size={16} aria-hidden="true" /> : <Lock size={16} aria-hidden="true" />}
               </ActionButton>
               <ActionButton
                 label={
@@ -193,7 +193,7 @@ export function WatchlistActionBar({
                 disabled={!isPaidPlan}
                 warning={!isPaidPlan}
               >
-                {alertsEnabled ? <BellOff size={16} /> : <Bell size={16} />}
+                {alertsEnabled ? <BellOff size={16} aria-hidden="true" /> : <Bell size={16} aria-hidden="true" />}
               </ActionButton>
               <ActionButton
                 label={t({ id: "watchlists.actions.mirror", comment: "Mirror watchlist tooltip", message: "Mirror" })}
@@ -201,7 +201,7 @@ export function WatchlistActionBar({
                 disabled={limitReached}
                 warning={limitReached}
               >
-                <Copy size={16} />
+                <Copy size={16} aria-hidden="true" />
               </ActionButton>
               <AlertDialog.Root open={deleteOpen} onOpenChange={setDeleteOpen}>
                 <AlertDialog.Trigger asChild>
@@ -210,7 +210,7 @@ export function WatchlistActionBar({
                       label={t({ id: "watchlists.actions.delete", comment: "Delete watchlist tooltip", message: "Delete" })}
                       onClick={() => setDeleteOpen(true)}
                     >
-                      <Trash2 size={16} />
+                      <Trash2 size={16} aria-hidden="true" />
                     </ActionButton>
                   </span>
                 </AlertDialog.Trigger>
@@ -261,7 +261,7 @@ export function WatchlistActionBar({
               disabled={isLoggedIn && limitReached}
               warning={isLoggedIn && limitReached}
             >
-              <Copy size={16} />
+              <Copy size={16} aria-hidden="true" />
             </ActionButton>
           )}
         </div>

--- a/apps/web/src/components/watchlist/watchlist-filter-editor.tsx
+++ b/apps/web/src/components/watchlist/watchlist-filter-editor.tsx
@@ -64,10 +64,12 @@ function FilterPill({
   icon,
   label,
   onRemove,
+  removeLabel,
 }: {
   icon?: React.ReactNode;
   label: string;
   onRemove: () => void;
+  removeLabel: string;
 }) {
   return (
     <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
@@ -77,8 +79,9 @@ function FilterPill({
         type="button"
         onClick={onRemove}
         className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
+        aria-label={removeLabel}
       >
-        <X size={12} />
+        <X size={12} aria-hidden="true" />
       </button>
     </span>
   );
@@ -228,36 +231,73 @@ export function WatchlistFilterEditor({
       {/* Existing filter pills */}
       <div className="flex flex-wrap items-center gap-2">
         {filters.keywords?.map((kw) => (
-          <FilterPill key={`kw-${kw}`} label={kw} onRemove={() => removeKeyword(kw)} />
+          <FilterPill
+            key={`kw-${kw}`}
+            label={kw}
+            onRemove={() => removeKeyword(kw)}
+            removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${kw} filter` })}
+          />
         ))}
         {filters.locationSlugs?.map((slug) => (
-          <FilterPill key={`loc-${slug}`} icon={<MapPin size={12} />} label={slug} onRemove={() => removeLocation(slug)} />
+          <FilterPill
+            key={`loc-${slug}`}
+            icon={<MapPin size={12} />}
+            label={slug}
+            onRemove={() => removeLocation(slug)}
+            removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${slug} filter` })}
+          />
         ))}
         {filters.occupationSlugs?.map((slug) => (
-          <FilterPill key={`occ-${slug}`} icon={<Briefcase size={12} />} label={slug} onRemove={() => removeOccupation(slug)} />
+          <FilterPill
+            key={`occ-${slug}`}
+            icon={<Briefcase size={12} />}
+            label={slug}
+            onRemove={() => removeOccupation(slug)}
+            removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${slug} filter` })}
+          />
         ))}
         {filters.senioritySlugs?.map((slug) => (
-          <FilterPill key={`sen-${slug}`} icon={<Award size={12} />} label={slug} onRemove={() => removeSeniority(slug)} />
+          <FilterPill
+            key={`sen-${slug}`}
+            icon={<Award size={12} />}
+            label={slug}
+            onRemove={() => removeSeniority(slug)}
+            removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${slug} filter` })}
+          />
         ))}
         {filters.technologySlugs?.map((slug) => (
-          <FilterPill key={`tech-${slug}`} icon={<Cpu size={12} />} label={slug} onRemove={() => removeTechnology(slug)} />
-        ))}
-        {filters.employmentType?.map((type) => (
           <FilterPill
-            key={`et-${type}`}
-            icon={<CalendarDays size={12} />}
-            label={employmentTypeLabel(t, type)}
-            onRemove={() => toggleEmploymentType(type)}
+            key={`tech-${slug}`}
+            icon={<Cpu size={12} />}
+            label={slug}
+            onRemove={() => removeTechnology(slug)}
+            removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${slug} filter` })}
           />
         ))}
-        {filters.workMode?.map((mode) => (
-          <FilterPill
-            key={`wm-${mode}`}
-            icon={<Home size={12} />}
-            label={workModeLabel(t, mode as WorkMode)}
-            onRemove={() => toggleWorkMode(mode as WorkMode)}
-          />
-        ))}
+        {filters.employmentType?.map((type) => {
+          const label = employmentTypeLabel(t, type);
+          return (
+            <FilterPill
+              key={`et-${type}`}
+              icon={<CalendarDays size={12} />}
+              label={label}
+              onRemove={() => toggleEmploymentType(type)}
+              removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${label} filter` })}
+            />
+          );
+        })}
+        {filters.workMode?.map((mode) => {
+          const label = workModeLabel(t, mode as WorkMode);
+          return (
+            <FilterPill
+              key={`wm-${mode}`}
+              icon={<Home size={12} />}
+              label={label}
+              onRemove={() => toggleWorkMode(mode as WorkMode)}
+              removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${label} filter` })}
+            />
+          );
+        })}
         {(filters.salaryMin != null || filters.salaryMax != null) && (
           <FilterPill
             icon={<DollarSign size={12} />}
@@ -268,6 +308,7 @@ export function WatchlistFilterEditor({
               filters.salaryCurrency ?? "",
             ].filter(Boolean).join(" ")}
             onRemove={removeSalary}
+            removeLabel={t({ id: "watchlists.filters.removeSalary", comment: "Aria label for the X button that clears the salary-range watchlist filter", message: "Remove salary filter" })}
           />
         )}
         {(filters.experienceMin != null || filters.experienceMax != null) && (
@@ -280,6 +321,7 @@ export function WatchlistFilterEditor({
               "yrs",
             ].filter(Boolean).join(" ")}
             onRemove={removeExperience}
+            removeLabel={t({ id: "watchlists.filters.removeExperience", comment: "Aria label for the X button that clears the experience-range watchlist filter", message: "Remove experience filter" })}
           />
         )}
 
@@ -360,8 +402,9 @@ export function WatchlistFilterEditor({
                 type="button"
                 onClick={() => { setAdding(null); setInputValue(""); }}
                 className="rounded-md p-1 text-muted transition-colors hover:text-foreground cursor-pointer"
+                aria-label={t({ id: "watchlists.filters.cancel", comment: "Aria label for the X button that cancels the inline add-filter UI", message: "Cancel" })}
               >
-                <X size={14} />
+                <X size={14} aria-hidden="true" />
               </button>
             </div>
           ) : (
@@ -387,15 +430,17 @@ export function WatchlistFilterEditor({
                 onClick={submitInput}
                 disabled={!inputValue.trim()}
                 className="rounded-md p-1 text-muted transition-colors hover:text-foreground disabled:opacity-40 cursor-pointer"
+                aria-label={t({ id: "watchlists.filters.confirmAdd", comment: "Aria label for the checkmark button that confirms adding a filter", message: "Add filter" })}
               >
-                <Check size={14} />
+                <Check size={14} aria-hidden="true" />
               </button>
               <button
                 type="button"
                 onClick={() => { setAdding(null); setInputValue(""); }}
                 className="rounded-md p-1 text-muted transition-colors hover:text-foreground cursor-pointer"
+                aria-label={t({ id: "watchlists.filters.cancel", comment: "Aria label for the X button that cancels the inline add-filter UI", message: "Cancel" })}
               >
-                <X size={14} />
+                <X size={14} aria-hidden="true" />
               </button>
             </div>
           )}

--- a/apps/web/src/components/watchlist/watchlist-filter-editor.tsx
+++ b/apps/web/src/components/watchlist/watchlist-filter-editor.tsx
@@ -230,71 +230,86 @@ export function WatchlistFilterEditor({
 
       {/* Existing filter pills */}
       <div className="flex flex-wrap items-center gap-2">
-        {filters.keywords?.map((kw) => (
-          <FilterPill
-            key={`kw-${kw}`}
-            label={kw}
-            onRemove={() => removeKeyword(kw)}
-            removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${kw} filter` })}
-          />
-        ))}
-        {filters.locationSlugs?.map((slug) => (
-          <FilterPill
-            key={`loc-${slug}`}
-            icon={<MapPin size={12} />}
-            label={slug}
-            onRemove={() => removeLocation(slug)}
-            removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${slug} filter` })}
-          />
-        ))}
-        {filters.occupationSlugs?.map((slug) => (
-          <FilterPill
-            key={`occ-${slug}`}
-            icon={<Briefcase size={12} />}
-            label={slug}
-            onRemove={() => removeOccupation(slug)}
-            removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${slug} filter` })}
-          />
-        ))}
-        {filters.senioritySlugs?.map((slug) => (
-          <FilterPill
-            key={`sen-${slug}`}
-            icon={<Award size={12} />}
-            label={slug}
-            onRemove={() => removeSeniority(slug)}
-            removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${slug} filter` })}
-          />
-        ))}
-        {filters.technologySlugs?.map((slug) => (
-          <FilterPill
-            key={`tech-${slug}`}
-            icon={<Cpu size={12} />}
-            label={slug}
-            onRemove={() => removeTechnology(slug)}
-            removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${slug} filter` })}
-          />
-        ))}
+        {filters.keywords?.map((kw) => {
+          const name = kw;
+          return (
+            <FilterPill
+              key={`kw-${kw}`}
+              label={name}
+              onRemove={() => removeKeyword(kw)}
+              removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${name} filter` })}
+            />
+          );
+        })}
+        {filters.locationSlugs?.map((slug) => {
+          const name = slug;
+          return (
+            <FilterPill
+              key={`loc-${slug}`}
+              icon={<MapPin size={12} />}
+              label={name}
+              onRemove={() => removeLocation(slug)}
+              removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${name} filter` })}
+            />
+          );
+        })}
+        {filters.occupationSlugs?.map((slug) => {
+          const name = slug;
+          return (
+            <FilterPill
+              key={`occ-${slug}`}
+              icon={<Briefcase size={12} />}
+              label={name}
+              onRemove={() => removeOccupation(slug)}
+              removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${name} filter` })}
+            />
+          );
+        })}
+        {filters.senioritySlugs?.map((slug) => {
+          const name = slug;
+          return (
+            <FilterPill
+              key={`sen-${slug}`}
+              icon={<Award size={12} />}
+              label={name}
+              onRemove={() => removeSeniority(slug)}
+              removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${name} filter` })}
+            />
+          );
+        })}
+        {filters.technologySlugs?.map((slug) => {
+          const name = slug;
+          return (
+            <FilterPill
+              key={`tech-${slug}`}
+              icon={<Cpu size={12} />}
+              label={name}
+              onRemove={() => removeTechnology(slug)}
+              removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${name} filter` })}
+            />
+          );
+        })}
         {filters.employmentType?.map((type) => {
-          const label = employmentTypeLabel(t, type);
+          const name = employmentTypeLabel(t, type);
           return (
             <FilterPill
               key={`et-${type}`}
               icon={<CalendarDays size={12} />}
-              label={label}
+              label={name}
               onRemove={() => toggleEmploymentType(type)}
-              removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${label} filter` })}
+              removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${name} filter` })}
             />
           );
         })}
         {filters.workMode?.map((mode) => {
-          const label = workModeLabel(t, mode as WorkMode);
+          const name = workModeLabel(t, mode as WorkMode);
           return (
             <FilterPill
               key={`wm-${mode}`}
               icon={<Home size={12} />}
-              label={label}
+              label={name}
               onRemove={() => toggleWorkMode(mode as WorkMode)}
-              removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${label} filter` })}
+              removeLabel={t({ id: "watchlists.filters.removeFilter", comment: "Aria label for remove-filter X button on a watchlist pill; {name} is the filter value", message: `Remove ${name} filter` })}
             />
           );
         })}

--- a/apps/web/src/components/watchlist/watchlist-job-list.tsx
+++ b/apps/web/src/components/watchlist/watchlist-job-list.tsx
@@ -171,6 +171,7 @@ export function WatchlistJobList({
         >
           <Bookmark
             size={14}
+            aria-hidden="true"
             className={isSaved(entry.id) ? "fill-current" : ""}
           />
         </span>


### PR DESCRIPTION
## Summary

Adds `aria-hidden=\"true\"` to ~50 decorative lucide-react icons inside icon-only buttons across the web app, plus the few `aria-label`s required so the icon-only buttons that previously lacked any accessible name still have one. Closes #3177.

Screen-reader users heard verbose \"graphic\" announcements after each button's accessible name (e.g. *\"Close button, x graphic\"*). Marking the SVG `aria-hidden` removes that redundancy.

## WCAG

- **1.3.1 Info and Relationships** (Level A) — decorative SVGs should not be announced.
- **4.1.2 Name, Role, Value** (Level A) — duplicate/conflicting accessible name + child SVG announcement.

## Scope

Files updated (33):

**Listed in the issue:**
- `src/components/Header.tsx`
- `src/components/MobileMenu.tsx`
- `src/components/AppHeader.tsx` (4 nav icons)
- `src/components/ThemeToggleButton.tsx`
- `src/components/LocaleSwitcher.tsx`
- `src/components/ui/upgrade-modal.tsx`
- `src/components/ui/back-to-top.tsx`
- `src/components/search/job-detail-dialog.tsx`
- `src/components/search/save-button.tsx`
- `src/components/search/star-button.tsx`
- `src/components/search/search-toolbar.tsx` (7 pill remove buttons)
- `src/components/watchlist/watchlist-filter-editor.tsx`

**Found during the sweep (same pattern):**
- All 9 search modals (location, location-search, occupation, seniority, technology, salary, experience, employment-type, work-mode close buttons)
- `src/components/settings/JobLanguageModal.tsx`
- `src/components/ui/FormField.tsx` (password show/hide eye)
- `src/components/search/keyword-pills.tsx`, `location-pills.tsx`, `filter-bar.tsx`
- `src/components/watchlist/watchlist-action-bar.tsx` (5 action icons), `watchlist-job-list.tsx`, `watchlist-filter-editor.tsx`, `company-pill.tsx`, `company-search-modal.tsx`
- `src/components/my-jobs/my-job-detail-panel.tsx`, `quick-actions.tsx`
- `app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx` (inline pills mirroring search-toolbar)

## Scope decisions

- **Decorative icons that sit next to visible text** (button has icon + label text) were left alone per the issue body's option A — visible text already provides the accessible name.
- **Icon-only buttons that previously lacked any `aria-label`** got both: the missing `aria-label` (translated, with explicit Lingui `id`+`comment`) AND `aria-hidden` on the icon. Adding only `aria-hidden` would have removed the only accessible name.
- **Filter-pill icons** inside spans (decorative, not in a button) were skipped — they're not the announcement-duplication source.
- **Listbox-row icons** (search-bar dropdown options) were skipped — the option already has descriptive text and no spurious announcement was reported.

## Tests

`src/components/__tests__/aria-hidden-lucide-icons.test.tsx` — 3 regression tests:
- `<Header>` hamburger icon has `aria-hidden=\"true\"`
- `<MobileMenu>` close icon has `aria-hidden=\"true\"`
- `<SearchToolbar>` filter pill remove buttons all have `aria-hidden=\"true\"` on their X icons

## Test plan

- [x] `pnpm test` (1078 tests pass, including 3 new ones)
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec eslint <changed files>` clean
- [x] Lingui translation coverage check passed (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)