### PR TITLE
fix(a11y): add global :focus-visible outline (closes #3170)

### DIFF
--- a/apps/web/app/__tests__/globals-focus-visible.test.ts
+++ b/apps/web/app/__tests__/globals-focus-visible.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression guard for #3170 (WCAG 2.4.7 — Focus Visible).
+ *
+ * Tailwind v4 strips the browser-default focus outline. Before this fix
+ * only ~5 components in the codebase declared their own `:focus-visible`
+ * styling, leaving every other interactive element (the `Button`
+ * primitive, icon buttons, filter chips, close buttons, watchlist cards,
+ * locale + theme toggles, cookie banner, etc.) with no visible focus
+ * indicator for keyboard users. The fix is a global `:focus-visible` rule
+ * in `globals.css` scoped via `:where()` so per-component overrides keep
+ * winning by specificity.
+ *
+ * Unit-asserting the compiled selector behaviour requires a browser; a
+ * cheaper guard that catches the regression (the rule getting deleted
+ * during a refactor) is to assert the literal CSS source still contains
+ * the global selector + the `var(--primary)` outline.
+ */
+describe("globals.css :focus-visible (a11y, #3170)", () => {
+  const cssPath = join(__dirname, "..", "globals.css");
+  const css = readFileSync(cssPath, "utf8");
+
+  it("declares a global :focus-visible rule", () => {
+    expect(css).toMatch(/:focus-visible\s*\{/);
+  });
+
+  it("scopes the rule via :where() to keep specificity at 0", () => {
+    // `:where()` selector wraps the element list so per-component focus
+    // utilities (e.g. `focus:outline-none focus:ring-2` on the
+    // agent-prompt-card copy buttons) still win without `!important`.
+    expect(css).toMatch(/:where\([^)]*\):focus-visible/);
+  });
+
+  it("draws the outline from the --primary design token", () => {
+    // Theme-aware: --primary inverts in `.dark` so the ring stays visible
+    // in both light and dark mode without a second selector.
+    const match = css.match(/:where\([^)]*\):focus-visible\s*\{[^}]*\}/);
+    expect(match).not.toBeNull();
+    expect(match![0]).toContain("outline");
+    expect(match![0]).toContain("var(--primary)");
+  });
+
+  it("covers the primary interactive element types", () => {
+    const match = css.match(/:where\(([^)]*)\):focus-visible/);
+    expect(match).not.toBeNull();
+    const selectorList = match![1];
+    // Must cover plain links + buttons (the bulk of the codebase's
+    // interactive elements) plus form fields and ARIA-roled custom widgets.
+    for (const required of ["a", "button", "input", "[role=\"button\"]", "[tabindex]"]) {
+      expect(selectorList).toContain(required);
+    }
+  });
+});

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -340,4 +340,47 @@
     background: var(--code-bg);
     border: 1px solid var(--code-border);
   }
+
+  /* ── Global keyboard focus indicator (WCAG 2.4.7, #3170) ──
+   *
+   * Tailwind v4 normalises away the browser default 2px focus outline. The
+   * codebase only has a handful of explicit focus rings (see
+   * `similar-companies-strip.tsx`, `similar-company-card.tsx`, the three
+   * `agent-prompt-card.tsx` sites). Every other interactive element — the
+   * `Button` primitive, icon buttons in headers/modals, filter chips, the
+   * watchlist cards, the bookmark/star buttons, the locale + theme toggles,
+   * the cookie banner, the close `X` buttons — has no visible focus
+   * indicator, leaving keyboard-only users with no way to track focus.
+   *
+   * The `:where()` wrapper keeps specificity at 0 so any per-component
+   * focus utility (e.g. the existing `focus-visible:outline-primary` sites,
+   * or `focus:outline-none focus:ring-2` on the agent-prompt-card copy
+   * buttons) still wins. Form inputs in `FormField.tsx` use
+   * `focus:border-primary` for their indicator — the global outline layers
+   * on top without disturbing the border colour.
+   *
+   * Uses `outline-offset: 2px` so the ring sits clear of rounded buttons
+   * (the `Button` primitive ships `rounded-full`) and `--primary` so it
+   * inverts cleanly between light and dark themes.
+   */
+  :where(
+    a,
+    button,
+    input,
+    select,
+    textarea,
+    summary,
+    [role="button"],
+    [role="link"],
+    [role="checkbox"],
+    [role="radio"],
+    [role="menuitem"],
+    [role="tab"],
+    [role="switch"],
+    [tabindex]
+  ):focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+    border-radius: 4px;
+  }
 }


### PR DESCRIPTION
## Summary

Closes #3170. Adds a global `:focus-visible` outline so keyboard users can see which interactive element has focus — Tailwind v4's reset stripped the browser default 2px blue ring, and only 5 sites in the codebase shipped an explicit replacement, so every `Button`, icon button, filter chip, close `X`, watchlist card, bookmark, locale switcher, theme toggle, cookie banner action, etc. was invisibly focused.

## WCAG rationale

- **2.4.7 Focus Visible** (Level AA) — "Any keyboard operable user interface has a mode of operation where the keyboard focus indicator is visible."
- Related: 2.4.11 (Focus Not Obscured, WCAG 2.2 / Level AA).

## Tailwind v4 reset

Tailwind v4's preflight normalises away the browser default `outline` on focus — intentional, since the default blue ring clashes with most design systems. The expectation is that you re-add a focus indicator in your own design tokens. That step was never done here.

## Approach

Global selector inside `@layer base` in `apps/web/app/globals.css`, wrapped in `:where(...)` so its specificity is 0:

```css
:where(
  a, button, input, select, textarea, summary,
  [role="button"], [role="link"], [role="checkbox"], [role="radio"],
  [role="menuitem"], [role="tab"], [role="switch"], [tabindex]
):focus-visible {
  outline: 2px solid var(--primary);
  outline-offset: 2px;
  border-radius: 4px;
}
```

- `var(--primary)` is the existing design token — `#111111` in light, `#f5f5f5` in dark. The same token used by the 2 existing `focus-visible:outline-primary` sites (`similar-companies-strip.tsx`, `similar-company-card.tsx`), so the look is consistent across the app.
- `outline-offset: 2px` keeps the ring clear of `rounded-full` chrome (the `Button` primitive ships `rounded-full`).

## Interaction with existing custom rings

`:where()` keeps the selector specificity at `(0,0,0)`, so anything specificity-stronger wins:

- `similar-companies-strip.tsx:169`, `similar-company-card.tsx:32` — already use `focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary`. Same visual outcome as the new global rule, just declared per-component; either rule paints the same ring.
- `agent-prompt-card.tsx:223,251,329` — use `focus:outline-none focus:ring-2 focus:ring-primary`. The `focus:outline-none` utility carries normal class specificity (0,1,0) and beats `:where(...)` (0,0,0), so the existing `ring` aesthetic is preserved.
- `app/[lang]/(app)/layout.tsx:24`, `app/[lang]/(public)/layout.tsx:23` — skip-to-content links use `focus:outline-none` because they paint their own full-bleed primary background on focus; specificity wins, no regression.

`FormField.tsx` uses `focus:border-primary` for its indicator (a border-only ring). The global `outline` layers on top without changing the border colour — additive, no override needed.

## Test plan

- [x] `pnpm test` — 1093/1093 pass, including 4 new assertions in `apps/web/app/__tests__/globals-focus-visible.test.ts` that pin the literal CSS rule (catches "someone deleted the rule in a refactor").
- [x] `pnpm exec tsc --noEmit` — clean.
- [x] `pnpm exec eslint <changed files>` — clean (CSS file ignored by config; new test file passes).
- [ ] Manual verification: from the URL bar press Tab repeatedly through `/explore`, `/watchlists`, `/my-jobs`, `/settings` — every interactive element shows a 2px outline in both light and dark themes.

Build deliberately not run per scope rules.

## Scope decisions

- Did not refactor `Button.tsx` or any other component. The global rule fixes the whole page in one place.
- Did not touch the 5 existing custom-ring sites. They already work; modifying them is unnecessary scope.
- Did not add `:focus-visible` styling to elements that already use `focus:outline-none` (the copy buttons + skip links). Their custom presentations are intentional and the specificity ordering preserves them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)