### PR TITLE
perf(web): single getCurrencyRates fetch via SalaryDisplayProvider (closes #3181)

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
@@ -16,7 +16,7 @@ import { InfiniteScrollSentinel } from "@/components/InfiniteScrollSentinel";
 import { TruncationPrompt } from "@/components/TruncationPrompt";
 import { TrackingDot } from "@/components/TrackingDot";
 import { PendingJobIcon } from "@/components/PendingJobWarning";
-import { getCurrencyRates, type CurrencyRate } from "@/lib/actions/search";
+import { useSalaryRates } from "@/components/SalaryDisplayProvider";
 import type { CompanyDetail } from "@/lib/actions/company";
 import { buildFilteredPath } from "@/lib/search/query-params";
 import type { SearchResultPosting, HistogramFilters, WorkMode } from "@/lib/search";
@@ -113,11 +113,11 @@ export function CompanyPage({
   const [exhausted, setExhausted] = useState(initialPostings.length < PAGE_SIZE);
   const [isTruncated, setIsTruncated] = useState(initialTruncated ?? false);
 
-  // Currency rates for EUR conversion (fetched lazily)
-  const [currencyRates, setCurrencyRates] = useState<CurrencyRate[]>([]);
-  useEffect(() => {
-    getCurrencyRates().then(setCurrencyRates);
-  }, []);
+  // Currency rates for EUR conversion — shared via `SalaryDisplayProvider`
+  // which fetches once at the (app) layout root. Previously this page
+  // fired a third `getCurrencyRates()` per view (alongside the provider
+  // and the salary modal); see #3181.
+  const currencyRates = useSalaryRates();
 
   // Refs for all filter state — single source of truth for updateUrl/runSearch
   const keywordsRef = useRef(keywords);

--- a/apps/web/app/[lang]/(app)/explore/search-page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/search-page.tsx
@@ -10,7 +10,7 @@ import { ZeroResults } from "@/components/search/zero-results";
 import { SkeletonCards } from "@/components/search/skeleton-card";
 import { JobDetailPanel } from "@/components/search/job-detail-dialog";
 import { SearchToolbar } from "@/components/search/search-toolbar";
-import { getCurrencyRates, type CurrencyRate } from "@/lib/actions/search";
+import { useSalaryRates } from "@/components/SalaryDisplayProvider";
 import { runSearchJobs, runListTopCompanies } from "@/lib/search/search-runner";
 import { useClearTypesenseOnAuthChange } from "@/lib/search/use-clear-typesense-on-auth-change";
 import { useSession } from "@/components/SessionProvider";
@@ -136,11 +136,12 @@ export function SearchPage({
     shouldRestore ? cached.workMode : initialWorkMode,
   );
 
-  // Currency rates for EUR conversion (fetched lazily)
-  const [currencyRates, setCurrencyRates] = useState<CurrencyRate[]>([]);
-  useEffect(() => {
-    getCurrencyRates().then(setCurrencyRates);
-  }, []);
+  // Currency rates for EUR conversion — read from `SalaryDisplayProvider`
+  // which fetches once on mount and shares the table with every consumer
+  // on this layout (search page, salary modal, salary cells). Previously
+  // each consumer fired its own `getCurrencyRates()`, producing 3 server
+  // actions per `/explore` view; see #3181.
+  const currencyRates = useSalaryRates();
 
   useClearTypesenseOnAuthChange(isLoggedIn);
 

--- a/apps/web/src/components/SalaryDisplayProvider.tsx
+++ b/apps/web/src/components/SalaryDisplayProvider.tsx
@@ -86,3 +86,24 @@ export function SalaryDisplayProvider({
 export function useSalaryDisplay() {
   return useContext(SalaryDisplayContext);
 }
+
+/**
+ * Returns the cached currency-rate table fetched once by
+ * `SalaryDisplayProvider` on mount.
+ *
+ * Consumers (search page, company page, salary modal) historically each
+ * fired their own `getCurrencyRates()` server action on mount, producing
+ * three identical round-trips per `/explore` or `/company/<slug>` view
+ * (~90–240ms of serial latency before salary filters were interactive —
+ * see #3181). Reading the rates from context collapses that to a single
+ * fetch.
+ *
+ * Returns `[]` when no provider is in scope (the context default), so
+ * callers can treat the result as a graceful empty list. The salary
+ * conversion helpers (`toEur`, `fromEur`) already fall back to an
+ * identity transform on an empty rate table, so an unmounted provider
+ * is non-fatal.
+ */
+export function useSalaryRates(): CurrencyRate[] {
+  return useContext(SalaryDisplayContext).rates;
+}

--- a/apps/web/src/components/__tests__/SalaryDisplayProvider.test.tsx
+++ b/apps/web/src/components/__tests__/SalaryDisplayProvider.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Tests for SalaryDisplayProvider — issue #3181.
+ *
+ * The `/explore` and `/company/<slug>` pages historically fired
+ * `getCurrencyRates()` three times per view (SalaryDisplayProvider +
+ * SearchPage/CompanyPage + SalaryModal). The fix hoists the fetch into
+ * the provider and exposes the table via a new `useSalaryRates()` hook.
+ * These tests pin that contract:
+ *
+ *   1. mounting the provider triggers exactly one fetch
+ *   2. multiple consumers reading via the hook share the same fetch
+ *   3. consumers without a provider in scope still mount and receive
+ *      a graceful empty table (no fallback fetch, no crash)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@/test-utils/lingui-mock";
+
+const getCurrencyRatesMock = vi.fn();
+
+// The real `@/lib/actions/search` is a server action that transitively
+// imports `server-only`, which throws when loaded outside a Next runtime.
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/actions/search", () => ({
+  getCurrencyRates: (...args: unknown[]) => getCurrencyRatesMock(...args),
+}));
+
+// Import after the mock is installed so the provider closes over the
+// mocked module.
+import {
+  SalaryDisplayProvider,
+  useSalaryRates,
+  useSalaryDisplay,
+} from "../SalaryDisplayProvider";
+
+function RatesProbe({ testId }: { testId: string }) {
+  const rates = useSalaryRates();
+  return (
+    <span data-testid={testId}>
+      {rates.map((r) => `${r.currency}:${r.toEur}`).join(",")}
+    </span>
+  );
+}
+
+function FormatterProbe() {
+  const { rates } = useSalaryDisplay();
+  // Consume rates through the legacy `useSalaryDisplay()` API as well —
+  // it must read from the same context value, not double-fetch.
+  return (
+    <span data-testid="formatter-rates">{rates.length}</span>
+  );
+}
+
+beforeEach(() => {
+  getCurrencyRatesMock.mockReset();
+});
+
+describe("SalaryDisplayProvider rate sharing (issue #3181)", () => {
+  it("fetches currency rates exactly once when multiple consumers mount", async () => {
+    getCurrencyRatesMock.mockResolvedValue([
+      { currency: "EUR", toEur: 1 },
+      { currency: "USD", toEur: 0.92 },
+    ]);
+
+    render(
+      <SalaryDisplayProvider>
+        <RatesProbe testId="probe-a" />
+        <RatesProbe testId="probe-b" />
+        <RatesProbe testId="probe-c" />
+        <FormatterProbe />
+      </SalaryDisplayProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("probe-a").textContent).toContain("EUR:1");
+    });
+
+    // All consumers see the same payload — and we only paid for one
+    // round-trip to do it.
+    expect(getCurrencyRatesMock).toHaveBeenCalledTimes(1);
+    expect(screen.getByTestId("probe-b").textContent).toBe("EUR:1,USD:0.92");
+    expect(screen.getByTestId("probe-c").textContent).toBe("EUR:1,USD:0.92");
+    expect(screen.getByTestId("formatter-rates").textContent).toBe("2");
+  });
+
+  it("returns an empty rate list when no provider is in scope (no fallback fetch, no crash)", () => {
+    // No mock setup: if the hook fell through to its own fetch, the
+    // assertion below would still pass (mock returns undefined), but
+    // `getCurrencyRatesMock.toHaveBeenCalledTimes(0)` would catch it.
+    render(<RatesProbe testId="orphan" />);
+
+    expect(screen.getByTestId("orphan").textContent).toBe("");
+    expect(getCurrencyRatesMock).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
## Summary
- `/explore` and `/company/<slug>` previously fired `getCurrencyRates()` **3 times** per view (provider mount + page mount + first salary-modal open) — 3 serial server-action round-trips, ~90-240 ms before the salary filter became interactive
- Hoist the fetch into `SalaryDisplayProvider` (which already owns the rate table for salary formatting) and expose it via a new `useSalaryRates()` hook
- `SearchPage` and `CompanyPage` drop their own `useEffect` + `getCurrencyRates()` calls; `SalaryModal` already preferred context rates with a fallback on race, so it was left as-is

## Rationale: hook vs. bootstrap payload
The issue mentioned two paths — adding `currencyRates` to `fetchAppBootstrap()` or hoisting into `SalaryDisplayProvider`. The bootstrap path doesn't help anonymous users: `AppBootstrapProvider` short-circuits the RPC when the `logged_in` hint cookie is absent (per #2246), so anonymous `/explore` visitors would still pay for a separate rates fetch. `SalaryDisplayProvider` mounts unconditionally, so hoisting there cuts the count to 1 regardless of auth state.

## Test plan
- [x] `pnpm test` — 116 files / 1091 tests, all pass (new tests in `SalaryDisplayProvider.test.tsx`)
  - Mount provider once, render 3 `RatesProbe` consumers + 1 `useSalaryDisplay` consumer → `getCurrencyRates` called exactly once
  - Orphan consumer (no provider in scope) → empty rate list, no fallback fetch, no crash
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec eslint <changed files>` — clean
- [ ] Manual: load `/explore` anonymous & logged-in, watch network for `getCurrencyRates` action calls (should see 1, was 3)

Closes #3181

🤖 Generated with [Claude Code](https://claude.com/claude-code)