### PR TITLE
fix(a11y): add aria-busy/aria-live to loading skeletons + infinite scroll (closes #3190)

### DIFF
--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -506,16 +506,16 @@ msgstr "Aug"
 msgid "settings.account.username.available"
 msgstr "Verfügbar"
 
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Zurück zur Anmeldung"
-
 #. Link back to sign-in after failed verification
 #. js-lingui-explicit-id
 #: app/[lang]/verify-email/page.tsx:68
 msgid "auth.verify.error.backToSignIn"
+msgstr "Zurück zur Anmeldung"
+
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
 msgstr "Zurück zur Anmeldung"
 
 #. Link back to sign-in from forgot password
@@ -544,6 +544,12 @@ msgstr "Nach oben"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Verhalten"
 
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:146
+msgid "blog.post.backToIndex"
+msgstr "Blog"
+
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:28
@@ -554,12 +560,6 @@ msgstr "Blog"
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:79
 msgid "blog.index.heading"
-msgstr "Blog"
-
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:146
-msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -673,17 +673,17 @@ msgstr "Ändere dein Passwort über einen sicheren E-Mail-Link."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Ändern…"
 
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "E-Mail prüfen"
-
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
 msgstr "E-Mail überprüfen"
+
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
+msgstr "E-Mail prüfen"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -815,16 +815,10 @@ msgstr "Schließen"
 msgid "search.salaryModal.close"
 msgstr "Schließen"
 
-#. Aria label for close button on the company-page all-locations modal
+#. Aria label for the occupation modal close button
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:275
-msgid "company.locationModal.close"
-msgstr "Schließen"
-
-#. Aria label for the employment-type modal close button
-#. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:82
-msgid "search.employmentTypeModal.close"
+#: src/components/search/occupation-modal.tsx:307
+msgid "search.occupationModal.close"
 msgstr "Schließen"
 
 #. Aria label for the location modal close button
@@ -833,16 +827,22 @@ msgstr "Schließen"
 msgid "search.locationModal.close"
 msgstr "Schließen"
 
+#. Aria label for close button on the company-page all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:275
+msgid "company.locationModal.close"
+msgstr "Schließen"
+
 #. Aria label for the experience modal close button
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:193
 msgid "search.experienceModal.close"
 msgstr "Schließen"
 
-#. Aria label for the occupation modal close button
+#. Aria label for the employment-type modal close button
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:307
-msgid "search.occupationModal.close"
+#: src/components/search/employment-type-modal.tsx:82
+msgid "search.employmentTypeModal.close"
 msgstr "Schließen"
 
 #. Aria label for job detail panel close button
@@ -1003,14 +1003,14 @@ msgstr "Kontakt"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:17
-msgid "license.toc.title"
+#: src/components/HowWeIndexContent.tsx:21
+msgid "indexing.toc.title"
 msgstr "Inhalt"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:21
-msgid "indexing.toc.title"
+#: src/components/LicenseContent.tsx:17
+msgid "license.toc.title"
 msgstr "Inhalt"
 
 #. Button to continue to app after verification
@@ -1462,7 +1462,7 @@ msgstr "Jobs entdecken"
 
 #. Hidden page H1 for /explore — screen-reader landmark
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/search-page.tsx:753
+#: app/[lang]/(app)/explore/search-page.tsx:754
 msgid "explore.h1"
 msgstr "Jobs entdecken"
 
@@ -2304,6 +2304,32 @@ msgstr "Lizenzierung von Job Seek — der Quellcode steht unter MIT-Lizenz, Stel
 msgid "settings.theme.light"
 msgstr "Hell"
 
+#. Screen-reader announcement while the company search modal is fetching results
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-search-modal.tsx:307
+msgid "watchlists.companyModal.loading"
+msgstr "Unternehmen werden geladen"
+
+#. Screen-reader announcement while the job detail panel is loading
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:512
+msgid "search.detail.loading"
+msgstr "Stellendetails werden geladen"
+
+#. Aria label and screen-reader announcement on the infinite-scroll sentinel that triggers fetching the next page of results
+#. Aria label and screen-reader announcement on the infinite-scroll sentinel that triggers fetching the next page of results
+#. js-lingui-explicit-id
+#: src/components/InfiniteScrollSentinel.tsx:44
+#: src/components/InfiniteScrollSentinel.tsx:68
+msgid "common.a11y.loadingMoreResults"
+msgstr "Weitere Ergebnisse werden geladen"
+
+#. Screen-reader announcement while a list of result cards is loading
+#. js-lingui-explicit-id
+#: src/components/search/skeleton-card.tsx:18
+msgid "common.a11y.loadingResults"
+msgstr "Ergebnisse werden geladen"
+
 #. Loading indicator
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:97
@@ -2328,16 +2354,16 @@ msgstr "Standort"
 msgid "search.advanced.location"
 msgstr "Standort"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:314
-msgid "search.detail.locations"
-msgstr "Standorte"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:842
 msgid "search.bar.locations"
+msgstr "Standorte"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:314
+msgid "search.detail.locations"
 msgstr "Standorte"
 
 #. Login button label
@@ -2630,17 +2656,17 @@ msgstr "Keine Jobs gefunden."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Keine Sprachen entsprechen deiner Suche."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:312
-msgid "company.locationModal.noResults"
-msgstr "Keine Standorte entsprechen Ihrer Suche."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:516
 msgid "search.locationModal.noResults"
 msgstr "Keine Standorte gefunden."
+
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:312
+msgid "company.locationModal.noResults"
+msgstr "Keine Standorte entsprechen Ihrer Suche."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2911,26 +2937,26 @@ msgstr "Unsere Haltung zur Automatisierung"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:21
-msgid "license.toc.overview"
-msgstr "Überblick"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:25
 msgid "indexing.toc.overview"
 msgstr "Überblick"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
-msgid "license.toc.ariaLabel"
-msgstr "Seiteninhalt"
+#: src/components/LicenseContent.tsx:21
+msgid "license.toc.overview"
+msgstr "Überblick"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:22
 msgid "indexing.toc.ariaLabel"
+msgstr "Seiteninhalt"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:18
+msgid "license.toc.ariaLabel"
 msgstr "Seiteninhalt"
 
 #. Heading shown on the 404 page
@@ -3260,16 +3286,16 @@ msgstr "Deine Änderungen weiterverbreiten, solange du den MIT-Hinweis beifügst
 msgid "location.type.region"
 msgstr "Region"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:322
-msgid "company.locationModal.regionsHeader"
-msgstr "Regionen"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:526
 msgid "search.locationModal.regionsHeader"
+msgstr "Regionen"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:322
+msgid "company.locationModal.regionsHeader"
 msgstr "Regionen"
 
 #. Status group heading: rejected
@@ -3706,17 +3732,17 @@ msgstr "Durchsuche Jobs bei Tausenden von Unternehmen, direkt von Karriereseiten
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Sprachen suchen…"
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:291
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Standorte suchen…"
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:495
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Standorte suchen..."
+
+#. Placeholder for search input in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:291
+msgid "company.locationModal.searchPlaceholder"
+msgstr "Standorte suchen…"
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3802,17 +3828,17 @@ msgstr "Link senden"
 msgid "settings.account.password.send"
 msgstr "Link senden"
 
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Wird gesendet..."
-
 #. Resend button while sending
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:96
 msgid "auth.verify.resending"
 msgstr "Wird gesendet…"
+
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
+msgstr "Wird gesendet..."
 
 #. Reset password button while loading
 #. js-lingui-explicit-id
@@ -4150,16 +4176,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technisch"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:399
-msgid "search.detail.technologies"
-msgstr "Technologien"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:765
 msgid "search.bar.technologies"
+msgstr "Technologien"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:399
+msgid "search.detail.technologies"
 msgstr "Technologien"
 
 #. Add technology filter

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -506,16 +506,16 @@ msgstr "Aug"
 msgid "settings.account.username.available"
 msgstr "Available"
 
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Back to sign in"
-
 #. Link back to sign-in after failed verification
 #. js-lingui-explicit-id
 #: app/[lang]/verify-email/page.tsx:68
 msgid "auth.verify.error.backToSignIn"
+msgstr "Back to sign in"
+
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
 msgstr "Back to sign in"
 
 #. Link back to sign-in from forgot password
@@ -544,6 +544,12 @@ msgstr "Back to top"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Behavioral"
 
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:146
+msgid "blog.post.backToIndex"
+msgstr "Blog"
+
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:28
@@ -554,12 +560,6 @@ msgstr "Blog"
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:79
 msgid "blog.index.heading"
-msgstr "Blog"
-
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:146
-msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -673,16 +673,16 @@ msgstr "Change your password via a secure email link."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Change..."
 
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "Check your email"
-
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
+msgstr "Check your email"
+
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
 msgstr "Check your email"
 
 #. Checking username availability
@@ -815,16 +815,10 @@ msgstr "Close"
 msgid "search.salaryModal.close"
 msgstr "Close"
 
-#. Aria label for close button on the company-page all-locations modal
+#. Aria label for the occupation modal close button
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:275
-msgid "company.locationModal.close"
-msgstr "Close"
-
-#. Aria label for the employment-type modal close button
-#. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:82
-msgid "search.employmentTypeModal.close"
+#: src/components/search/occupation-modal.tsx:307
+msgid "search.occupationModal.close"
 msgstr "Close"
 
 #. Aria label for the location modal close button
@@ -833,16 +827,22 @@ msgstr "Close"
 msgid "search.locationModal.close"
 msgstr "Close"
 
+#. Aria label for close button on the company-page all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:275
+msgid "company.locationModal.close"
+msgstr "Close"
+
 #. Aria label for the experience modal close button
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:193
 msgid "search.experienceModal.close"
 msgstr "Close"
 
-#. Aria label for the occupation modal close button
+#. Aria label for the employment-type modal close button
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:307
-msgid "search.occupationModal.close"
+#: src/components/search/employment-type-modal.tsx:82
+msgid "search.employmentTypeModal.close"
 msgstr "Close"
 
 #. Aria label for job detail panel close button
@@ -1003,14 +1003,14 @@ msgstr "Contact"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:17
-msgid "license.toc.title"
+#: src/components/HowWeIndexContent.tsx:21
+msgid "indexing.toc.title"
 msgstr "Contents"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:21
-msgid "indexing.toc.title"
+#: src/components/LicenseContent.tsx:17
+msgid "license.toc.title"
 msgstr "Contents"
 
 #. Button to continue to app after verification
@@ -1462,7 +1462,7 @@ msgstr "Explore Jobs"
 
 #. Hidden page H1 for /explore — screen-reader landmark
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/search-page.tsx:753
+#: app/[lang]/(app)/explore/search-page.tsx:754
 msgid "explore.h1"
 msgstr "Explore Jobs"
 
@@ -2304,6 +2304,32 @@ msgstr "Licensing for Job Seek — application source code is MIT-licensed, job 
 msgid "settings.theme.light"
 msgstr "Light"
 
+#. Screen-reader announcement while the company search modal is fetching results
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-search-modal.tsx:307
+msgid "watchlists.companyModal.loading"
+msgstr "Loading companies"
+
+#. Screen-reader announcement while the job detail panel is loading
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:512
+msgid "search.detail.loading"
+msgstr "Loading job details"
+
+#. Aria label and screen-reader announcement on the infinite-scroll sentinel that triggers fetching the next page of results
+#. Aria label and screen-reader announcement on the infinite-scroll sentinel that triggers fetching the next page of results
+#. js-lingui-explicit-id
+#: src/components/InfiniteScrollSentinel.tsx:44
+#: src/components/InfiniteScrollSentinel.tsx:68
+msgid "common.a11y.loadingMoreResults"
+msgstr "Loading more results"
+
+#. Screen-reader announcement while a list of result cards is loading
+#. js-lingui-explicit-id
+#: src/components/search/skeleton-card.tsx:18
+msgid "common.a11y.loadingResults"
+msgstr "Loading results"
+
 #. Loading indicator
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:97
@@ -2328,16 +2354,16 @@ msgstr "Location"
 msgid "search.advanced.location"
 msgstr "Location"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:314
-msgid "search.detail.locations"
-msgstr "Locations"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:842
 msgid "search.bar.locations"
+msgstr "Locations"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:314
+msgid "search.detail.locations"
 msgstr "Locations"
 
 #. Login button label
@@ -2630,16 +2656,16 @@ msgstr "No jobs found."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "No languages match your search."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:312
-msgid "company.locationModal.noResults"
-msgstr "No locations match your search."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:516
 msgid "search.locationModal.noResults"
+msgstr "No locations match your search."
+
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:312
+msgid "company.locationModal.noResults"
 msgstr "No locations match your search."
 
 #. No postings found message on company page
@@ -2911,26 +2937,26 @@ msgstr "Our stance on automation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:21
-msgid "license.toc.overview"
-msgstr "Overview"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:25
 msgid "indexing.toc.overview"
 msgstr "Overview"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
-msgid "license.toc.ariaLabel"
-msgstr "Page contents"
+#: src/components/LicenseContent.tsx:21
+msgid "license.toc.overview"
+msgstr "Overview"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:22
 msgid "indexing.toc.ariaLabel"
+msgstr "Page contents"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:18
+msgid "license.toc.ariaLabel"
 msgstr "Page contents"
 
 #. Heading shown on the 404 page
@@ -3260,16 +3286,16 @@ msgstr "Redistribute your changes, as long as you include the MIT notice."
 msgid "location.type.region"
 msgstr "Region"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:322
-msgid "company.locationModal.regionsHeader"
-msgstr "Regions"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:526
 msgid "search.locationModal.regionsHeader"
+msgstr "Regions"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:322
+msgid "company.locationModal.regionsHeader"
 msgstr "Regions"
 
 #. Status group heading: rejected
@@ -3706,16 +3732,16 @@ msgstr "Search jobs across thousands of companies scraped directly from career p
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Search languages..."
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:291
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Search locations..."
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:495
 msgid "search.locationModal.searchPlaceholder"
+msgstr "Search locations..."
+
+#. Placeholder for search input in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:291
+msgid "company.locationModal.searchPlaceholder"
 msgstr "Search locations..."
 
 #. Back-to-search link on company page header
@@ -3802,16 +3828,16 @@ msgstr "Send reset link"
 msgid "settings.account.password.send"
 msgstr "Send reset link"
 
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Sending..."
-
 #. Resend button while sending
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:96
 msgid "auth.verify.resending"
+msgstr "Sending..."
+
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
 msgstr "Sending..."
 
 #. Reset password button while loading
@@ -4150,16 +4176,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technical"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:399
-msgid "search.detail.technologies"
-msgstr "Technologies"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:765
 msgid "search.bar.technologies"
+msgstr "Technologies"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:399
+msgid "search.detail.technologies"
 msgstr "Technologies"
 
 #. Add technology filter

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -506,16 +506,16 @@ msgstr "Aoû"
 msgid "settings.account.username.available"
 msgstr "Disponible"
 
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Retour à la connexion"
-
 #. Link back to sign-in after failed verification
 #. js-lingui-explicit-id
 #: app/[lang]/verify-email/page.tsx:68
 msgid "auth.verify.error.backToSignIn"
+msgstr "Retour à la connexion"
+
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
 msgstr "Retour à la connexion"
 
 #. Link back to sign-in from forgot password
@@ -544,6 +544,12 @@ msgstr "Retour en haut"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Comportemental"
 
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:146
+msgid "blog.post.backToIndex"
+msgstr "Blog"
+
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:28
@@ -554,12 +560,6 @@ msgstr "Blog"
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:79
 msgid "blog.index.heading"
-msgstr "Blog"
-
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:146
-msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -673,17 +673,17 @@ msgstr "Modifie ton mot de passe via un lien e-mail sécurisé."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Changer…"
 
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "Vérifiez votre e-mail"
-
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
 msgstr "Vérifie ton e-mail"
+
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
+msgstr "Vérifiez votre e-mail"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -815,16 +815,10 @@ msgstr "Fermer"
 msgid "search.salaryModal.close"
 msgstr "Fermer"
 
-#. Aria label for close button on the company-page all-locations modal
+#. Aria label for the occupation modal close button
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:275
-msgid "company.locationModal.close"
-msgstr "Fermer"
-
-#. Aria label for the employment-type modal close button
-#. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:82
-msgid "search.employmentTypeModal.close"
+#: src/components/search/occupation-modal.tsx:307
+msgid "search.occupationModal.close"
 msgstr "Fermer"
 
 #. Aria label for the location modal close button
@@ -833,16 +827,22 @@ msgstr "Fermer"
 msgid "search.locationModal.close"
 msgstr "Fermer"
 
+#. Aria label for close button on the company-page all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:275
+msgid "company.locationModal.close"
+msgstr "Fermer"
+
 #. Aria label for the experience modal close button
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:193
 msgid "search.experienceModal.close"
 msgstr "Fermer"
 
-#. Aria label for the occupation modal close button
+#. Aria label for the employment-type modal close button
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:307
-msgid "search.occupationModal.close"
+#: src/components/search/employment-type-modal.tsx:82
+msgid "search.employmentTypeModal.close"
 msgstr "Fermer"
 
 #. Aria label for job detail panel close button
@@ -1003,14 +1003,14 @@ msgstr "Contact"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:17
-msgid "license.toc.title"
+#: src/components/HowWeIndexContent.tsx:21
+msgid "indexing.toc.title"
 msgstr "Sommaire"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:21
-msgid "indexing.toc.title"
+#: src/components/LicenseContent.tsx:17
+msgid "license.toc.title"
 msgstr "Sommaire"
 
 #. Button to continue to app after verification
@@ -1462,7 +1462,7 @@ msgstr "Explorer les emplois"
 
 #. Hidden page H1 for /explore — screen-reader landmark
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/search-page.tsx:753
+#: app/[lang]/(app)/explore/search-page.tsx:754
 msgid "explore.h1"
 msgstr "Explorer les emplois"
 
@@ -2304,6 +2304,32 @@ msgstr "Licences de Job Seek — le code source est sous licence MIT, les offres
 msgid "settings.theme.light"
 msgstr "Clair"
 
+#. Screen-reader announcement while the company search modal is fetching results
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-search-modal.tsx:307
+msgid "watchlists.companyModal.loading"
+msgstr "Chargement des entreprises"
+
+#. Screen-reader announcement while the job detail panel is loading
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:512
+msgid "search.detail.loading"
+msgstr "Chargement des détails de l'offre"
+
+#. Aria label and screen-reader announcement on the infinite-scroll sentinel that triggers fetching the next page of results
+#. Aria label and screen-reader announcement on the infinite-scroll sentinel that triggers fetching the next page of results
+#. js-lingui-explicit-id
+#: src/components/InfiniteScrollSentinel.tsx:44
+#: src/components/InfiniteScrollSentinel.tsx:68
+msgid "common.a11y.loadingMoreResults"
+msgstr "Chargement de résultats supplémentaires"
+
+#. Screen-reader announcement while a list of result cards is loading
+#. js-lingui-explicit-id
+#: src/components/search/skeleton-card.tsx:18
+msgid "common.a11y.loadingResults"
+msgstr "Chargement des résultats"
+
 #. Loading indicator
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:97
@@ -2328,16 +2354,16 @@ msgstr "Lieu"
 msgid "search.advanced.location"
 msgstr "Lieu"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:314
-msgid "search.detail.locations"
-msgstr "Lieux"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:842
 msgid "search.bar.locations"
+msgstr "Lieux"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:314
+msgid "search.detail.locations"
 msgstr "Lieux"
 
 #. Login button label
@@ -2630,16 +2656,16 @@ msgstr "Aucune offre trouvée."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Aucune langue ne correspond à votre recherche."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:312
-msgid "company.locationModal.noResults"
-msgstr "Aucun lieu ne correspond à votre recherche."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:516
 msgid "search.locationModal.noResults"
+msgstr "Aucun lieu ne correspond à votre recherche."
+
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:312
+msgid "company.locationModal.noResults"
 msgstr "Aucun lieu ne correspond à votre recherche."
 
 #. No postings found message on company page
@@ -2911,26 +2937,26 @@ msgstr "Notre position sur l'automatisation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:21
-msgid "license.toc.overview"
-msgstr "Aperçu"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:25
 msgid "indexing.toc.overview"
 msgstr "Aperçu"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
-msgid "license.toc.ariaLabel"
-msgstr "Sommaire de la page"
+#: src/components/LicenseContent.tsx:21
+msgid "license.toc.overview"
+msgstr "Aperçu"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:22
 msgid "indexing.toc.ariaLabel"
+msgstr "Sommaire de la page"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:18
+msgid "license.toc.ariaLabel"
 msgstr "Sommaire de la page"
 
 #. Heading shown on the 404 page
@@ -3260,16 +3286,16 @@ msgstr "Redistribue tes modifications, à condition d'inclure la mention MIT."
 msgid "location.type.region"
 msgstr "Région"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:322
-msgid "company.locationModal.regionsHeader"
-msgstr "Régions"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:526
 msgid "search.locationModal.regionsHeader"
+msgstr "Régions"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:322
+msgid "company.locationModal.regionsHeader"
 msgstr "Régions"
 
 #. Status group heading: rejected
@@ -3706,17 +3732,17 @@ msgstr "Recherchez des emplois dans des milliers d'entreprises, scrapés directe
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Rechercher des langues…"
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:291
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Rechercher des lieux…"
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:495
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Rechercher des lieux..."
+
+#. Placeholder for search input in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:291
+msgid "company.locationModal.searchPlaceholder"
+msgstr "Rechercher des lieux…"
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3802,16 +3828,16 @@ msgstr "Envoyer le lien"
 msgid "settings.account.password.send"
 msgstr "Envoyer le lien"
 
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Envoi en cours..."
-
 #. Resend button while sending
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:96
 msgid "auth.verify.resending"
+msgstr "Envoi en cours..."
+
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
 msgstr "Envoi en cours..."
 
 #. Reset password button while loading
@@ -4150,16 +4176,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Technique"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:399
-msgid "search.detail.technologies"
-msgstr "Technologies"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:765
 msgid "search.bar.technologies"
+msgstr "Technologies"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:399
+msgid "search.detail.technologies"
 msgstr "Technologies"
 
 #. Add technology filter

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -506,16 +506,16 @@ msgstr "Ago"
 msgid "settings.account.username.available"
 msgstr "Disponibile"
 
-#. Link back to sign-in from reset password
-#. js-lingui-explicit-id
-#: app/[lang]/reset-password/page.tsx:42
-msgid "auth.resetPassword.backToSignIn"
-msgstr "Torna all'accesso"
-
 #. Link back to sign-in after failed verification
 #. js-lingui-explicit-id
 #: app/[lang]/verify-email/page.tsx:68
 msgid "auth.verify.error.backToSignIn"
+msgstr "Torna all'accesso"
+
+#. Link back to sign-in from reset password
+#. js-lingui-explicit-id
+#: app/[lang]/reset-password/page.tsx:42
+msgid "auth.resetPassword.backToSignIn"
 msgstr "Torna all'accesso"
 
 #. Link back to sign-in from forgot password
@@ -544,6 +544,12 @@ msgstr "Torna su"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Comportamentale"
 
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:146
+msgid "blog.post.backToIndex"
+msgstr "Blog"
+
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:28
@@ -554,12 +560,6 @@ msgstr "Blog"
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:79
 msgid "blog.index.heading"
-msgstr "Blog"
-
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:146
-msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -673,17 +673,17 @@ msgstr "Cambia la tua password tramite un link email sicuro."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Cambia…"
 
-#. Heading after reset email is sent
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:58
-msgid "auth.forgotPassword.sent.title"
-msgstr "Controlla la tua e-mail"
-
 #. Heading after sign-up telling user to check email
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:80
 msgid "auth.verify.checkEmail.title"
 msgstr "Controlla la tua email"
+
+#. Heading after reset email is sent
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:58
+msgid "auth.forgotPassword.sent.title"
+msgstr "Controlla la tua e-mail"
 
 #. Checking username availability
 #. js-lingui-explicit-id
@@ -815,16 +815,10 @@ msgstr "Chiudi"
 msgid "search.salaryModal.close"
 msgstr "Chiudi"
 
-#. Aria label for close button on the company-page all-locations modal
+#. Aria label for the occupation modal close button
 #. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:275
-msgid "company.locationModal.close"
-msgstr "Chiudi"
-
-#. Aria label for the employment-type modal close button
-#. js-lingui-explicit-id
-#: src/components/search/employment-type-modal.tsx:82
-msgid "search.employmentTypeModal.close"
+#: src/components/search/occupation-modal.tsx:307
+msgid "search.occupationModal.close"
 msgstr "Chiudi"
 
 #. Aria label for the location modal close button
@@ -833,16 +827,22 @@ msgstr "Chiudi"
 msgid "search.locationModal.close"
 msgstr "Chiudi"
 
+#. Aria label for close button on the company-page all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:275
+msgid "company.locationModal.close"
+msgstr "Chiudi"
+
 #. Aria label for the experience modal close button
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:193
 msgid "search.experienceModal.close"
 msgstr "Chiudi"
 
-#. Aria label for the occupation modal close button
+#. Aria label for the employment-type modal close button
 #. js-lingui-explicit-id
-#: src/components/search/occupation-modal.tsx:307
-msgid "search.occupationModal.close"
+#: src/components/search/employment-type-modal.tsx:82
+msgid "search.employmentTypeModal.close"
 msgstr "Chiudi"
 
 #. Aria label for job detail panel close button
@@ -1003,14 +1003,14 @@ msgstr "Contatti"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:17
-msgid "license.toc.title"
+#: src/components/HowWeIndexContent.tsx:21
+msgid "indexing.toc.title"
 msgstr "Sommario"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:21
-msgid "indexing.toc.title"
+#: src/components/LicenseContent.tsx:17
+msgid "license.toc.title"
 msgstr "Sommario"
 
 #. Button to continue to app after verification
@@ -1462,7 +1462,7 @@ msgstr "Esplora lavori"
 
 #. Hidden page H1 for /explore — screen-reader landmark
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/search-page.tsx:753
+#: app/[lang]/(app)/explore/search-page.tsx:754
 msgid "explore.h1"
 msgstr "Esplora lavori"
 
@@ -2304,6 +2304,32 @@ msgstr "Licenze di Job Seek — il codice sorgente è sotto licenza MIT, le offe
 msgid "settings.theme.light"
 msgstr "Chiaro"
 
+#. Screen-reader announcement while the company search modal is fetching results
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-search-modal.tsx:307
+msgid "watchlists.companyModal.loading"
+msgstr "Caricamento delle aziende"
+
+#. Screen-reader announcement while the job detail panel is loading
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:512
+msgid "search.detail.loading"
+msgstr "Caricamento dei dettagli dell'offerta"
+
+#. Aria label and screen-reader announcement on the infinite-scroll sentinel that triggers fetching the next page of results
+#. Aria label and screen-reader announcement on the infinite-scroll sentinel that triggers fetching the next page of results
+#. js-lingui-explicit-id
+#: src/components/InfiniteScrollSentinel.tsx:44
+#: src/components/InfiniteScrollSentinel.tsx:68
+msgid "common.a11y.loadingMoreResults"
+msgstr "Caricamento di altri risultati"
+
+#. Screen-reader announcement while a list of result cards is loading
+#. js-lingui-explicit-id
+#: src/components/search/skeleton-card.tsx:18
+msgid "common.a11y.loadingResults"
+msgstr "Caricamento dei risultati"
+
 #. Loading indicator
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:97
@@ -2328,17 +2354,17 @@ msgstr "Luogo"
 msgid "search.advanced.location"
 msgstr "Luogo"
 
-#. Locations heading in job detail
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:314
-msgid "search.detail.locations"
-msgstr "Località"
-
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:842
 msgid "search.bar.locations"
 msgstr "Sedi"
+
+#. Locations heading in job detail
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:314
+msgid "search.detail.locations"
+msgstr "Località"
 
 #. Login button label
 #. Login button label
@@ -2630,17 +2656,17 @@ msgstr "Nessuna offerta trovata."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Nessuna lingua corrisponde alla ricerca."
 
-#. No locations match search in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:312
-msgid "company.locationModal.noResults"
-msgstr "Nessuna sede corrisponde alla tua ricerca."
-
 #. No locations match search in location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:516
 msgid "search.locationModal.noResults"
 msgstr "Nessun luogo corrisponde alla tua ricerca."
+
+#. No locations match search in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:312
+msgid "company.locationModal.noResults"
+msgstr "Nessuna sede corrisponde alla tua ricerca."
 
 #. No postings found message on company page
 #. js-lingui-explicit-id
@@ -2911,26 +2937,26 @@ msgstr "La nostra posizione sull'automazione"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:21
-msgid "license.toc.overview"
-msgstr "Panoramica"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:25
 msgid "indexing.toc.overview"
 msgstr "Panoramica"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
-msgid "license.toc.ariaLabel"
-msgstr "Contenuti della pagina"
+#: src/components/LicenseContent.tsx:21
+msgid "license.toc.overview"
+msgstr "Panoramica"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:22
 msgid "indexing.toc.ariaLabel"
+msgstr "Contenuti della pagina"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:18
+msgid "license.toc.ariaLabel"
 msgstr "Contenuti della pagina"
 
 #. Heading shown on the 404 page
@@ -3260,16 +3286,16 @@ msgstr "Ridistribuire le proprie modifiche, a condizione di includere l'avviso M
 msgid "location.type.region"
 msgstr "Regione"
 
-#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:322
-msgid "company.locationModal.regionsHeader"
-msgstr "Regioni"
-
 #. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:526
 msgid "search.locationModal.regionsHeader"
+msgstr "Regioni"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:322
+msgid "company.locationModal.regionsHeader"
 msgstr "Regioni"
 
 #. Status group heading: rejected
@@ -3706,17 +3732,17 @@ msgstr "Cerca lavori in migliaia di aziende, scansionati direttamente dalle pagi
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Cerca lingue…"
 
-#. Placeholder for search input in all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:291
-msgid "company.locationModal.searchPlaceholder"
-msgstr "Cerca sedi…"
-
 #. Placeholder for search input in global location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-search-modal.tsx:495
 msgid "search.locationModal.searchPlaceholder"
 msgstr "Cerca luoghi..."
+
+#. Placeholder for search input in all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:291
+msgid "company.locationModal.searchPlaceholder"
+msgstr "Cerca sedi…"
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3802,16 +3828,16 @@ msgstr "Invia link"
 msgid "settings.account.password.send"
 msgstr "Invia il link"
 
-#. Send reset link button while loading
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/forgot-password/page.tsx:103
-msgid "auth.forgotPassword.button.loading"
-msgstr "Invio in corso..."
-
 #. Resend button while sending
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/check-email/page.tsx:96
 msgid "auth.verify.resending"
+msgstr "Invio in corso..."
+
+#. Send reset link button while loading
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/forgot-password/page.tsx:103
+msgid "auth.forgotPassword.button.loading"
 msgstr "Invio in corso..."
 
 #. Reset password button while loading
@@ -4150,16 +4176,16 @@ msgstr "System Design"
 msgid "myJobs.interviewType.technical"
 msgstr "Tecnico"
 
-#. Technologies sub-heading in details section
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:399
-msgid "search.detail.technologies"
-msgstr "Tecnologie"
-
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
 #: src/components/search/search-bar.tsx:765
 msgid "search.bar.technologies"
+msgstr "Tecnologie"
+
+#. Technologies sub-heading in details section
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:399
+msgid "search.detail.technologies"
 msgstr "Tecnologie"
 
 #. Add technology filter

--- a/apps/web/src/components/InfiniteScrollSentinel.tsx
+++ b/apps/web/src/components/InfiniteScrollSentinel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Loader2 } from "lucide-react";
+import { Trans, useLingui } from "@lingui/react/macro";
 
 interface InfiniteScrollSentinelProps {
   // Accept any React ref shape — `useInfiniteScroll` returns a
@@ -19,12 +20,19 @@ interface InfiniteScrollSentinelProps {
   orientation?: "vertical" | "horizontal";
 }
 
+// WCAG 4.1.3 (status messages): the IntersectionObserver sentinel is
+// visually a spinner, but used to be silent to screen readers. We wrap it in
+// a polite live region so an SR announces "Loading more results" each time
+// the sentinel scrolls into view and a new page starts streaming. The
+// sentinel `<div>` itself carries an `aria-label` so the visual region has a
+// name even when no spinner is rendered (closes #3190).
 export function InfiniteScrollSentinel({
   sentinelRef,
   isLoading,
   size = "md",
   orientation = "vertical",
 }: InfiniteScrollSentinelProps) {
+  const { t } = useLingui();
   const axisSize =
     orientation === "horizontal"
       ? size === "sm"
@@ -33,17 +41,38 @@ export function InfiniteScrollSentinel({
       : size === "sm"
         ? "h-6"
         : "h-8";
+  const sentinelLabel = t({
+    id: "common.a11y.loadingMoreResults",
+    comment:
+      "Aria label and screen-reader announcement on the infinite-scroll sentinel that triggers fetching the next page of results",
+    message: "Loading more results",
+  });
   return (
     <div
       ref={sentinelRef}
+      role="status"
+      aria-live="polite"
+      aria-busy={isLoading}
+      aria-label={sentinelLabel}
       className={`flex items-center justify-center ${axisSize}`}
       style={{ overflowAnchor: "none" }}
     >
       {isLoading && (
-        <Loader2
-          size={size === "sm" ? 12 : 14}
-          className="animate-spin text-muted"
-        />
+        <>
+          <Loader2
+            aria-hidden="true"
+            size={size === "sm" ? 12 : 14}
+            className="animate-spin text-muted"
+          />
+          <span className="sr-only">
+            <Trans
+              id="common.a11y.loadingMoreResults"
+              comment="Aria label and screen-reader announcement on the infinite-scroll sentinel that triggers fetching the next page of results"
+            >
+              Loading more results
+            </Trans>
+          </span>
+        </>
       )}
     </div>
   );

--- a/apps/web/src/components/__tests__/InfiniteScrollSentinel.test.tsx
+++ b/apps/web/src/components/__tests__/InfiniteScrollSentinel.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+
+// Lingui shim — register before imports of Lingui-aware modules.
+import "@/test-utils/lingui-mock";
+
+import { InfiniteScrollSentinel } from "../InfiniteScrollSentinel";
+
+// Regression test for #3190: the infinite-scroll sentinel renders a spinner
+// when the next page is being fetched. Without role=status + aria-live the
+// SR stays silent and the user never learns more results are arriving.
+describe("InfiniteScrollSentinel — role=status + aria-live (#3190)", () => {
+  it("renders the sentinel with role=status, aria-live=polite and an aria-label", () => {
+    const { container } = render(
+      <InfiniteScrollSentinel sentinelRef={() => {}} isLoading={false} />,
+    );
+    const sentinel = container.firstElementChild as HTMLElement;
+    expect(sentinel).toBeTruthy();
+    expect(sentinel.getAttribute("role")).toBe("status");
+    expect(sentinel.getAttribute("aria-live")).toBe("polite");
+    expect(sentinel.getAttribute("aria-label")).toBe("Loading more results");
+  });
+
+  it("flips aria-busy from false to true while the next page is loading", () => {
+    const { container, rerender } = render(
+      <InfiniteScrollSentinel sentinelRef={() => {}} isLoading={false} />,
+    );
+    const sentinel = container.firstElementChild as HTMLElement;
+    expect(sentinel.getAttribute("aria-busy")).toBe("false");
+
+    rerender(
+      <InfiniteScrollSentinel sentinelRef={() => {}} isLoading={true} />,
+    );
+    expect(sentinel.getAttribute("aria-busy")).toBe("true");
+  });
+
+  it("includes a visually-hidden announcement while loading", () => {
+    const { container } = render(
+      <InfiniteScrollSentinel sentinelRef={() => {}} isLoading={true} />,
+    );
+    const srOnly = container.querySelector("span.sr-only");
+    expect(srOnly).toBeTruthy();
+    expect(srOnly?.textContent).toBe("Loading more results");
+  });
+
+  it("does not render the announcement when idle (no spurious polite hits)", () => {
+    const { container } = render(
+      <InfiniteScrollSentinel sentinelRef={() => {}} isLoading={false} />,
+    );
+    expect(container.querySelector("span.sr-only")).toBeNull();
+  });
+});

--- a/apps/web/src/components/search/__tests__/skeleton-card-aria.test.tsx
+++ b/apps/web/src/components/search/__tests__/skeleton-card-aria.test.tsx
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+
+// Lingui shim — register before imports of Lingui-aware modules.
+import "@/test-utils/lingui-mock";
+
+import { SkeletonCards } from "../skeleton-card";
+
+// Regression test for #3190: skeleton placeholders must surface as a polite
+// live region in a busy state so screen readers announce that content is
+// loading instead of staying silent on the visual pulse.
+describe("SkeletonCards — aria-busy/aria-live (#3190)", () => {
+  it("renders the outer container with aria-busy and aria-live=polite", () => {
+    const { container } = render(<SkeletonCards count={3} />);
+    const wrapper = container.firstElementChild as HTMLElement;
+    expect(wrapper).toBeTruthy();
+    expect(wrapper.getAttribute("aria-busy")).toBe("true");
+    expect(wrapper.getAttribute("aria-live")).toBe("polite");
+    expect(wrapper.getAttribute("role")).toBe("status");
+  });
+
+  it("includes a visually-hidden screen-reader announcement", () => {
+    const { container } = render(<SkeletonCards count={1} />);
+    const srOnly = container.querySelector("span.sr-only");
+    expect(srOnly).toBeTruthy();
+    expect(srOnly?.textContent).toBe("Loading results");
+  });
+});

--- a/apps/web/src/components/search/job-detail-dialog.tsx
+++ b/apps/web/src/components/search/job-detail-dialog.tsx
@@ -497,25 +497,42 @@ function formatExperience(min: number | null, max: number | null): string {
 }
 
 function DetailSkeleton() {
+  // WCAG 4.1.3 (status messages): the job-detail panel skeleton sits over the
+  // previous posting body until the new description streams in. Without an
+  // `aria-busy` / `aria-live` wrapper, an SR keeps reading the stale content
+  // (closes #3190).
   return (
-    <div className="animate-pulse space-y-4">
-      <div className="flex items-center gap-3">
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      className="animate-pulse space-y-4"
+    >
+      <span className="sr-only">
+        <Trans
+          id="search.detail.loading"
+          comment="Screen-reader announcement while the job detail panel is loading"
+        >
+          Loading job details
+        </Trans>
+      </span>
+      <div aria-hidden="true" className="flex items-center gap-3">
         <div className="size-9 rounded bg-border-soft" />
         <div className="h-4 w-28 rounded bg-border-soft" />
       </div>
-      <div className="h-5 w-3/4 rounded bg-border-soft" />
-      <div className="flex gap-3">
+      <div aria-hidden="true" className="h-5 w-3/4 rounded bg-border-soft" />
+      <div aria-hidden="true" className="flex gap-3">
         <div className="h-3 w-16 rounded bg-border-soft" />
         <div className="h-3 w-10 rounded bg-border-soft" />
       </div>
-      <div className="space-y-1">
+      <div aria-hidden="true" className="space-y-1">
         <div className="h-2.5 w-16 rounded bg-border-soft" />
         <div className="h-3.5 w-40 rounded bg-border-soft" />
         <div className="h-3.5 w-36 rounded bg-border-soft" />
       </div>
-      <div className="h-3 w-32 rounded bg-border-soft" />
-      <hr className="border-divider" />
-      <div className="space-y-2">
+      <div aria-hidden="true" className="h-3 w-32 rounded bg-border-soft" />
+      <hr aria-hidden="true" className="border-divider" />
+      <div aria-hidden="true" className="space-y-2">
         {Array.from({ length: 6 }, (_, i) => (
           <div key={i} className="h-3 rounded bg-border-soft" style={{ width: `${65 + Math.random() * 35}%` }} />
         ))}

--- a/apps/web/src/components/search/skeleton-card.tsx
+++ b/apps/web/src/components/search/skeleton-card.tsx
@@ -1,11 +1,31 @@
 "use client";
 
+import { Trans } from "@lingui/react/macro";
+
+// WCAG 4.1.3 (status messages): screen readers stay silent on visual-only
+// skeleton placeholders unless we mark the container as a polite live region
+// in a busy state. The visually-hidden child gives the SR an actual phrase
+// to announce when the skeleton mounts (closes #3190).
 export function SkeletonCards({ count = 3 }: { count?: number }) {
   return (
-    <div className="space-y-4">
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      className="space-y-4"
+    >
+      <span className="sr-only">
+        <Trans
+          id="common.a11y.loadingResults"
+          comment="Screen-reader announcement while a list of result cards is loading"
+        >
+          Loading results
+        </Trans>
+      </span>
       {Array.from({ length: count }, (_, i) => (
         <div
           key={i}
+          aria-hidden="true"
           className="animate-pulse rounded-md border border-divider bg-surface p-4"
         >
           <div className="flex items-center gap-3">

--- a/apps/web/src/components/watchlist/company-search-modal.tsx
+++ b/apps/web/src/components/watchlist/company-search-modal.tsx
@@ -292,8 +292,25 @@ export function CompanySearchModal({
           {/* Company list */}
           <div ref={scrollRef} className="flex-1 overflow-y-auto">
             {loading && companies.length === 0 ? (
-              <div className="flex items-center justify-center py-12">
-                <Loader2 size={20} className="animate-spin text-muted" />
+              <div
+                role="status"
+                aria-busy="true"
+                aria-live="polite"
+                className="flex items-center justify-center py-12"
+              >
+                <Loader2
+                  aria-hidden="true"
+                  size={20}
+                  className="animate-spin text-muted"
+                />
+                <span className="sr-only">
+                  <Trans
+                    id="watchlists.companyModal.loading"
+                    comment="Screen-reader announcement while the company search modal is fetching results"
+                  >
+                    Loading companies
+                  </Trans>
+                </span>
               </div>
             ) : visibleCompanies.length === 0 && !loading ? (
               <div className="px-5">


### PR DESCRIPTION
## Summary

Closes #3190. Screen-reader users heard silence on the explore skeleton, infinite-scroll loader, watchlist infinite scroll, company-search-modal initial load, and the job-detail panel skeleton — the previous content stayed read out and no announcement was made when new items arrived. WCAG **4.1.3 Status Messages** (Level AA) requires status to be programmatically determinable.

This PR wraps each loading affordance in a polite live region in a busy state:
- `SkeletonCards` (used by explore / watchlist / company `loading.tsx` and `<ExploreSkeleton>` / `<WatchlistSkeleton>` / `<CompanySkeleton>`) — `role=status` + `aria-busy=true` + `aria-live=polite` + visually-hidden \"Loading results\".
- `InfiniteScrollSentinel` (used by `SearchResults`, `WatchlistJobList`, `CompanySearchModal`) — `role=status` + `aria-live=polite`, an `aria-label=\"Loading more results\"` so the region has a name when idle, `aria-busy` reflects `isLoading`, and a visually-hidden \"Loading more results\" string mounts while loading so the polite announcement fires.
- `CompanySearchModal` initial-load spinner — wrapped in `role=status` + `aria-live=polite` + visually-hidden \"Loading companies\".
- `DetailSkeleton` in `job-detail-dialog.tsx` — `role=status` + `aria-busy=true` + `aria-live=polite` + visually-hidden \"Loading job details\".

All visual placeholder bars / spinner icons are marked `aria-hidden=\"true\"` so the SR only hears the polite announcement, not the decorative geometry.

## i18n

Four new keys, all with explicit `id` + `comment` per `apps/web/docs/i18n.md`:

- `common.a11y.loadingResults`
- `common.a11y.loadingMoreResults`
- `search.detail.loading`
- `watchlists.companyModal.loading`

Translations added to `en` / `de` / `fr` / `it` `.po` catalogs. `scripts/check-i18n-coverage.sh` is green.

## Scope decisions

- The issue listed `apps/web/src/components/search/company-search-modal.tsx`; the file actually lives at `apps/web/src/components/watchlist/company-search-modal.tsx`. Same component, just a path correction.
- The inline `<Loader2>` next to the search input in the modal (a re-search spinner while you type) was **not** wrapped — it's a visual hint that the existing list is being filtered, not a list-loading event, and the list itself is still readable.
- `ExploreSkeleton`, `WatchlistSkeleton`, `CompanySkeleton`, and `loading.tsx` wrappers were left untouched: they delegate to `SkeletonCards`, which now carries the polite region. Adding nested live regions would double-announce.
- No `git stash` was used at any point.

## Test plan

- [x] `pnpm test` — 120 files / 1106 tests pass, including 2 new files covering `SkeletonCards` and `InfiniteScrollSentinel` (#3190 regression tests for the new aria attributes and announcements)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec eslint <changed files>` — clean
- [x] `pnpm extract && pnpm compile` — all new keys extracted and compiled; check-i18n-coverage.sh green
- [ ] Manual SR smoke test (VoiceOver / NVDA) — recommended before promoting

🤖 Generated with [Claude Code](https://claude.com/claude-code)