### PR TITLE
fix(a11y): un-nest interactive elements in watchlist/company-card (closes #3166)

### DIFF
--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -239,7 +239,7 @@ msgstr "aktiv"
 
 #. Active matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:120
+#: src/components/search/company-card.tsx:121
 msgid "search.card.active"
 msgstr "aktiv"
 
@@ -333,16 +333,16 @@ msgstr "Alle Sprachen"
 msgid "settings.general.jobLanguages.all"
 msgstr "Alle Sprachen"
 
-#. Title for the all-locations modal on company page
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:268
-msgid "company.locationModal.title"
-msgstr "Alle Standorte"
-
 #. Button to open all-locations modal on company page
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:346
 msgid "company.page.allLocations"
+msgstr "Alle Standorte"
+
+#. Title for the all-locations modal on company page
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:268
+msgid "company.locationModal.title"
 msgstr "Alle Standorte"
 
 #. Link to sign-in page from sign-up
@@ -434,12 +434,6 @@ msgstr "Beworben"
 msgid "search.tracker.applied"
 msgstr "Beworben"
 
-#. Applied status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:20
-msgid "myJobs.status.applied"
-msgstr "Beworben"
-
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
@@ -450,6 +444,12 @@ msgstr "Beworben"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.applied"
+msgstr "Beworben"
+
+#. Applied status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:20
+msgid "myJobs.status.applied"
 msgstr "Beworben"
 
 #. Apply salary filter
@@ -544,12 +544,6 @@ msgstr "Nach oben"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Verhalten"
 
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:146
-msgid "blog.post.backToIndex"
-msgstr "Blog"
-
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:28
@@ -560,6 +554,12 @@ msgstr "Blog"
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:79
 msgid "blog.index.heading"
+msgstr "Blog"
+
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:146
+msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -791,12 +791,6 @@ msgstr "Schließen"
 msgid "settings.jobLanguages.modal.close"
 msgstr "Schließen"
 
-#. Aria label for the work-mode modal close button
-#. js-lingui-explicit-id
-#: src/components/search/work-mode-modal.tsx:90
-msgid "search.workModeModal.close"
-msgstr "Schließen"
-
 #. Aria label for the technology modal close button
 #. js-lingui-explicit-id
 #: src/components/search/technology-modal.tsx:117
@@ -807,6 +801,12 @@ msgstr "Schließen"
 #. js-lingui-explicit-id
 #: src/components/search/seniority-modal.tsx:65
 msgid "search.seniorityModal.close"
+msgstr "Schließen"
+
+#. Aria label for the work-mode modal close button
+#. js-lingui-explicit-id
+#: src/components/search/work-mode-modal.tsx:90
+msgid "search.workModeModal.close"
 msgstr "Schließen"
 
 #. Aria label for the salary modal close button
@@ -827,12 +827,6 @@ msgstr "Schließen"
 msgid "search.locationModal.close"
 msgstr "Schließen"
 
-#. Aria label for close button on the company-page all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:275
-msgid "company.locationModal.close"
-msgstr "Schließen"
-
 #. Aria label for the experience modal close button
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:193
@@ -843,6 +837,12 @@ msgstr "Schließen"
 #. js-lingui-explicit-id
 #: src/components/search/employment-type-modal.tsx:82
 msgid "search.employmentTypeModal.close"
+msgstr "Schließen"
+
+#. Aria label for close button on the company-page all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:275
+msgid "company.locationModal.close"
 msgstr "Schließen"
 
 #. Aria label for job detail panel close button
@@ -871,7 +871,7 @@ msgstr "Geschlossen"
 
 #. Label for inactive/closed job postings on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:143
+#: src/components/search/company-card.tsx:159
 msgid "search.card.closed"
 msgstr "Geschlossen"
 
@@ -983,12 +983,6 @@ msgstr "Verbinden"
 msgid "settings.account.socials.title"
 msgstr "Verknüpfte Konten"
 
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Kontakt"
-
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:24
@@ -1001,16 +995,22 @@ msgstr "Kontakt"
 msgid "license.contact.title"
 msgstr "Kontakt"
 
-#. Table of contents heading
+#. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:21
-msgid "indexing.toc.title"
-msgstr "Inhalt"
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Kontakt"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:17
 msgid "license.toc.title"
+msgstr "Inhalt"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:21
+msgid "indexing.toc.title"
 msgstr "Inhalt"
 
 #. Button to continue to app after verification
@@ -1911,7 +1911,7 @@ msgstr "im letzten Jahr"
 
 #. Yearly matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:122
+#: src/components/search/company-card.tsx:123
 msgid "search.card.yearCount"
 msgstr "im letzten Jahr"
 
@@ -1999,16 +1999,16 @@ msgstr "Im Interview"
 msgid "search.tracker.interviewing"
 msgstr "Im Interview"
 
-#. Interviewing status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:21
-msgid "myJobs.status.interviewing"
-msgstr "Im Interview"
-
 #. Status option in dropdown: interviewing
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:37
 msgid "myJobs.statusOption.interviewing"
+msgstr "Im Interview"
+
+#. Interviewing status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:21
+msgid "myJobs.status.interviewing"
 msgstr "Im Interview"
 
 #. Interviews section heading
@@ -2050,16 +2050,16 @@ msgstr "Gibt es ein Limit, wie viele Jobs ich verfolgen kann?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:31
-msgid "watchlists.card.jobSingular"
-msgstr "Job"
-
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:121
 msgid "watchlists.explore.jobSingular"
+msgstr "Job"
+
+#. Singular job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:31
+msgid "watchlists.card.jobSingular"
 msgstr "Job"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -2162,16 +2162,16 @@ msgstr "Die Codebasis von Job Seek ist Open Source unter MIT. Die von uns gesamm
 msgid "watchlist.meta.fallback"
 msgstr "Job-Watchlist von @{owner}"
 
-#. Plural job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:32
-msgid "watchlists.card.jobPlural"
-msgstr "Jobs"
-
 #. Plural job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:122
 msgid "watchlists.explore.jobPlural"
+msgstr "Jobs"
+
+#. Plural job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:32
+msgid "watchlists.card.jobPlural"
 msgstr "Jobs"
 
 #. js-lingui-explicit-id
@@ -2646,7 +2646,7 @@ msgstr "Keine Branchen gefunden."
 
 #. Empty state when no jobs match the time range
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:208
+#: src/components/watchlist/watchlist-job-list.tsx:230
 msgid "watchlists.jobList.empty"
 msgstr "Keine Jobs gefunden."
 
@@ -2852,6 +2852,18 @@ msgstr "Nur Kleinbuchstaben, Zahlen und Bindestriche (nicht am Anfang/Ende)"
 msgid "myJobs.interviewType.onsite"
 msgstr "Vor Ort"
 
+#. Aria label for the row open-posting button when the posting title is missing
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-job-list.tsx:158
+msgid "watchlists.jobList.openPosting"
+msgstr "Stellenausschreibung öffnen"
+
+#. Aria label for opening a job posting from a company card row when the posting title is missing
+#. js-lingui-explicit-id
+#: src/components/search/company-card.tsx:147
+msgid "search.card.openPosting"
+msgstr "Stellenausschreibung öffnen"
+
 #. Aria label for mobile menu button
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:89
@@ -2937,26 +2949,26 @@ msgstr "Unsere Haltung zur Automatisierung"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:25
-msgid "indexing.toc.overview"
-msgstr "Überblick"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:21
 msgid "license.toc.overview"
 msgstr "Überblick"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:22
-msgid "indexing.toc.ariaLabel"
-msgstr "Seiteninhalt"
+#: src/components/HowWeIndexContent.tsx:25
+msgid "indexing.toc.overview"
+msgstr "Überblick"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.ariaLabel"
+msgstr "Seiteninhalt"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:22
+msgid "indexing.toc.ariaLabel"
 msgstr "Seiteninhalt"
 
 #. Heading shown on the 404 page
@@ -3310,12 +3322,6 @@ msgstr "Abgelehnt"
 msgid "search.tracker.rejected"
 msgstr "Abgelehnt"
 
-#. Rejected status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:23
-msgid "myJobs.status.rejected"
-msgstr "Abgelehnt"
-
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
@@ -3326,6 +3332,12 @@ msgstr "Abgelehnt"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:39
 msgid "myJobs.statusOption.rejected"
+msgstr "Abgelehnt"
+
+#. Rejected status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:23
+msgid "myJobs.status.rejected"
 msgstr "Abgelehnt"
 
 #. Footer license summary text
@@ -3620,7 +3632,7 @@ msgstr "Speichere jede Suche als Watchlist und erhalte E-Mail-Benachrichtigungen
 
 #. Save job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:169
+#: src/components/watchlist/watchlist-job-list.tsx:191
 msgid "watchlists.jobList.save"
 msgstr "Job speichern"
 
@@ -3654,12 +3666,6 @@ msgstr "Diese Suche speichern"
 msgid "myJobs.group.saved"
 msgstr "Gespeichert"
 
-#. Saved status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:19
-msgid "myJobs.status.saved"
-msgstr "Gespeichert"
-
 #. Sankey funnel node: saved jobs
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:41
@@ -3670,6 +3676,12 @@ msgstr "Gespeichert"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:35
 msgid "myJobs.statusOption.saved"
+msgstr "Gespeichert"
+
+#. Saved status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:19
+msgid "myJobs.status.saved"
 msgstr "Gespeichert"
 
 #. Username save button while loading
@@ -3894,16 +3906,16 @@ msgstr "Einstellungen"
 msgid "home.features.s3.p3.title"
 msgstr "Mit jedem teilen"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:357
-msgid "search.detail.showLessLocations"
-msgstr "Weniger anzeigen"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:355
 msgid "company.page.showLess"
+msgstr "Weniger anzeigen"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:357
+msgid "search.detail.showLessLocations"
 msgstr "Weniger anzeigen"
 
 #. Aria label to show password
@@ -4421,7 +4433,7 @@ msgstr "Unbegrenzte Watchlists, E-Mail-Benachrichtigungen bei neuen Treffern"
 
 #. Unsave job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:168
+#: src/components/watchlist/watchlist-job-list.tsx:190
 msgid "watchlists.jobList.unsave"
 msgstr "Job entfernen"
 

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -239,7 +239,7 @@ msgstr "active"
 
 #. Active matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:120
+#: src/components/search/company-card.tsx:121
 msgid "search.card.active"
 msgstr "active"
 
@@ -333,16 +333,16 @@ msgstr "All languages"
 msgid "settings.general.jobLanguages.all"
 msgstr "All languages"
 
-#. Title for the all-locations modal on company page
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:268
-msgid "company.locationModal.title"
-msgstr "All locations"
-
 #. Button to open all-locations modal on company page
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:346
 msgid "company.page.allLocations"
+msgstr "All locations"
+
+#. Title for the all-locations modal on company page
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:268
+msgid "company.locationModal.title"
 msgstr "All locations"
 
 #. Link to sign-in page from sign-up
@@ -434,12 +434,6 @@ msgstr "Applied"
 msgid "search.tracker.applied"
 msgstr "Applied"
 
-#. Applied status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:20
-msgid "myJobs.status.applied"
-msgstr "Applied"
-
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
@@ -450,6 +444,12 @@ msgstr "Applied"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.applied"
+msgstr "Applied"
+
+#. Applied status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:20
+msgid "myJobs.status.applied"
 msgstr "Applied"
 
 #. Apply salary filter
@@ -544,12 +544,6 @@ msgstr "Back to top"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Behavioral"
 
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:146
-msgid "blog.post.backToIndex"
-msgstr "Blog"
-
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:28
@@ -560,6 +554,12 @@ msgstr "Blog"
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:79
 msgid "blog.index.heading"
+msgstr "Blog"
+
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:146
+msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -791,12 +791,6 @@ msgstr "Close"
 msgid "settings.jobLanguages.modal.close"
 msgstr "Close"
 
-#. Aria label for the work-mode modal close button
-#. js-lingui-explicit-id
-#: src/components/search/work-mode-modal.tsx:90
-msgid "search.workModeModal.close"
-msgstr "Close"
-
 #. Aria label for the technology modal close button
 #. js-lingui-explicit-id
 #: src/components/search/technology-modal.tsx:117
@@ -807,6 +801,12 @@ msgstr "Close"
 #. js-lingui-explicit-id
 #: src/components/search/seniority-modal.tsx:65
 msgid "search.seniorityModal.close"
+msgstr "Close"
+
+#. Aria label for the work-mode modal close button
+#. js-lingui-explicit-id
+#: src/components/search/work-mode-modal.tsx:90
+msgid "search.workModeModal.close"
 msgstr "Close"
 
 #. Aria label for the salary modal close button
@@ -827,12 +827,6 @@ msgstr "Close"
 msgid "search.locationModal.close"
 msgstr "Close"
 
-#. Aria label for close button on the company-page all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:275
-msgid "company.locationModal.close"
-msgstr "Close"
-
 #. Aria label for the experience modal close button
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:193
@@ -843,6 +837,12 @@ msgstr "Close"
 #. js-lingui-explicit-id
 #: src/components/search/employment-type-modal.tsx:82
 msgid "search.employmentTypeModal.close"
+msgstr "Close"
+
+#. Aria label for close button on the company-page all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:275
+msgid "company.locationModal.close"
 msgstr "Close"
 
 #. Aria label for job detail panel close button
@@ -871,7 +871,7 @@ msgstr "Closed"
 
 #. Label for inactive/closed job postings on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:143
+#: src/components/search/company-card.tsx:159
 msgid "search.card.closed"
 msgstr "Closed"
 
@@ -983,12 +983,6 @@ msgstr "Connect"
 msgid "settings.account.socials.title"
 msgstr "Connected accounts"
 
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Contact"
-
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:24
@@ -1001,16 +995,22 @@ msgstr "Contact"
 msgid "license.contact.title"
 msgstr "Contact"
 
-#. Table of contents heading
+#. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:21
-msgid "indexing.toc.title"
-msgstr "Contents"
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Contact"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:17
 msgid "license.toc.title"
+msgstr "Contents"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:21
+msgid "indexing.toc.title"
 msgstr "Contents"
 
 #. Button to continue to app after verification
@@ -1911,7 +1911,7 @@ msgstr "in the last year"
 
 #. Yearly matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:122
+#: src/components/search/company-card.tsx:123
 msgid "search.card.yearCount"
 msgstr "in the last year"
 
@@ -1999,16 +1999,16 @@ msgstr "Interviewing"
 msgid "search.tracker.interviewing"
 msgstr "Interviewing"
 
-#. Interviewing status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:21
-msgid "myJobs.status.interviewing"
-msgstr "Interviewing"
-
 #. Status option in dropdown: interviewing
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:37
 msgid "myJobs.statusOption.interviewing"
+msgstr "Interviewing"
+
+#. Interviewing status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:21
+msgid "myJobs.status.interviewing"
 msgstr "Interviewing"
 
 #. Interviews section heading
@@ -2050,16 +2050,16 @@ msgstr "Is there a limit to how many jobs I can track?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:31
-msgid "watchlists.card.jobSingular"
-msgstr "job"
-
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:121
 msgid "watchlists.explore.jobSingular"
+msgstr "job"
+
+#. Singular job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:31
+msgid "watchlists.card.jobSingular"
 msgstr "job"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -2162,16 +2162,16 @@ msgstr "Job Seek's codebase is open source under MIT. The job data we collect an
 msgid "watchlist.meta.fallback"
 msgstr "Job watchlist by @{owner}"
 
-#. Plural job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:32
-msgid "watchlists.card.jobPlural"
-msgstr "jobs"
-
 #. Plural job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:122
 msgid "watchlists.explore.jobPlural"
+msgstr "jobs"
+
+#. Plural job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:32
+msgid "watchlists.card.jobPlural"
 msgstr "jobs"
 
 #. js-lingui-explicit-id
@@ -2646,7 +2646,7 @@ msgstr "No industries found."
 
 #. Empty state when no jobs match the time range
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:208
+#: src/components/watchlist/watchlist-job-list.tsx:230
 msgid "watchlists.jobList.empty"
 msgstr "No jobs found."
 
@@ -2852,6 +2852,18 @@ msgstr "Only lowercase letters, numbers, and hyphens (cannot start/end with hyph
 msgid "myJobs.interviewType.onsite"
 msgstr "Onsite"
 
+#. Aria label for the row open-posting button when the posting title is missing
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-job-list.tsx:158
+msgid "watchlists.jobList.openPosting"
+msgstr "Open job posting"
+
+#. Aria label for opening a job posting from a company card row when the posting title is missing
+#. js-lingui-explicit-id
+#: src/components/search/company-card.tsx:147
+msgid "search.card.openPosting"
+msgstr "Open job posting"
+
 #. Aria label for mobile menu button
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:89
@@ -2937,26 +2949,26 @@ msgstr "Our stance on automation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:25
-msgid "indexing.toc.overview"
-msgstr "Overview"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:21
 msgid "license.toc.overview"
 msgstr "Overview"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:22
-msgid "indexing.toc.ariaLabel"
-msgstr "Page contents"
+#: src/components/HowWeIndexContent.tsx:25
+msgid "indexing.toc.overview"
+msgstr "Overview"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.ariaLabel"
+msgstr "Page contents"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:22
+msgid "indexing.toc.ariaLabel"
 msgstr "Page contents"
 
 #. Heading shown on the 404 page
@@ -3310,12 +3322,6 @@ msgstr "Rejected"
 msgid "search.tracker.rejected"
 msgstr "Rejected"
 
-#. Rejected status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:23
-msgid "myJobs.status.rejected"
-msgstr "Rejected"
-
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
@@ -3326,6 +3332,12 @@ msgstr "Rejected"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:39
 msgid "myJobs.statusOption.rejected"
+msgstr "Rejected"
+
+#. Rejected status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:23
+msgid "myJobs.status.rejected"
 msgstr "Rejected"
 
 #. Footer license summary text
@@ -3620,7 +3632,7 @@ msgstr "Save any search as a watchlist and get email alerts when new roles match
 
 #. Save job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:169
+#: src/components/watchlist/watchlist-job-list.tsx:191
 msgid "watchlists.jobList.save"
 msgstr "Save job"
 
@@ -3654,12 +3666,6 @@ msgstr "Save this search"
 msgid "myJobs.group.saved"
 msgstr "Saved"
 
-#. Saved status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:19
-msgid "myJobs.status.saved"
-msgstr "Saved"
-
 #. Sankey funnel node: saved jobs
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:41
@@ -3670,6 +3676,12 @@ msgstr "Saved"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:35
 msgid "myJobs.statusOption.saved"
+msgstr "Saved"
+
+#. Saved status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:19
+msgid "myJobs.status.saved"
 msgstr "Saved"
 
 #. Username save button while loading
@@ -3894,16 +3906,16 @@ msgstr "Settings"
 msgid "home.features.s3.p3.title"
 msgstr "Share with anyone"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:357
-msgid "search.detail.showLessLocations"
-msgstr "Show less"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:355
 msgid "company.page.showLess"
+msgstr "Show less"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:357
+msgid "search.detail.showLessLocations"
 msgstr "Show less"
 
 #. Aria label to show password
@@ -4421,7 +4433,7 @@ msgstr "Unlimited watchlists, email alerts on new matches"
 
 #. Unsave job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:168
+#: src/components/watchlist/watchlist-job-list.tsx:190
 msgid "watchlists.jobList.unsave"
 msgstr "Unsave job"
 

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -239,7 +239,7 @@ msgstr "actifs"
 
 #. Active matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:120
+#: src/components/search/company-card.tsx:121
 msgid "search.card.active"
 msgstr "actif"
 
@@ -333,16 +333,16 @@ msgstr "Toutes les langues"
 msgid "settings.general.jobLanguages.all"
 msgstr "Toutes les langues"
 
-#. Title for the all-locations modal on company page
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:268
-msgid "company.locationModal.title"
-msgstr "Tous les lieux"
-
 #. Button to open all-locations modal on company page
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:346
 msgid "company.page.allLocations"
+msgstr "Tous les lieux"
+
+#. Title for the all-locations modal on company page
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:268
+msgid "company.locationModal.title"
 msgstr "Tous les lieux"
 
 #. Link to sign-in page from sign-up
@@ -434,12 +434,6 @@ msgstr "Postulé"
 msgid "search.tracker.applied"
 msgstr "Postulé"
 
-#. Applied status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:20
-msgid "myJobs.status.applied"
-msgstr "Postulé"
-
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
@@ -450,6 +444,12 @@ msgstr "Postulé"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.applied"
+msgstr "Postulé"
+
+#. Applied status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:20
+msgid "myJobs.status.applied"
 msgstr "Postulé"
 
 #. Apply salary filter
@@ -544,12 +544,6 @@ msgstr "Retour en haut"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Comportemental"
 
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:146
-msgid "blog.post.backToIndex"
-msgstr "Blog"
-
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:28
@@ -560,6 +554,12 @@ msgstr "Blog"
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:79
 msgid "blog.index.heading"
+msgstr "Blog"
+
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:146
+msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -791,12 +791,6 @@ msgstr "Fermer"
 msgid "settings.jobLanguages.modal.close"
 msgstr "Fermer"
 
-#. Aria label for the work-mode modal close button
-#. js-lingui-explicit-id
-#: src/components/search/work-mode-modal.tsx:90
-msgid "search.workModeModal.close"
-msgstr "Fermer"
-
 #. Aria label for the technology modal close button
 #. js-lingui-explicit-id
 #: src/components/search/technology-modal.tsx:117
@@ -807,6 +801,12 @@ msgstr "Fermer"
 #. js-lingui-explicit-id
 #: src/components/search/seniority-modal.tsx:65
 msgid "search.seniorityModal.close"
+msgstr "Fermer"
+
+#. Aria label for the work-mode modal close button
+#. js-lingui-explicit-id
+#: src/components/search/work-mode-modal.tsx:90
+msgid "search.workModeModal.close"
 msgstr "Fermer"
 
 #. Aria label for the salary modal close button
@@ -827,12 +827,6 @@ msgstr "Fermer"
 msgid "search.locationModal.close"
 msgstr "Fermer"
 
-#. Aria label for close button on the company-page all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:275
-msgid "company.locationModal.close"
-msgstr "Fermer"
-
 #. Aria label for the experience modal close button
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:193
@@ -843,6 +837,12 @@ msgstr "Fermer"
 #. js-lingui-explicit-id
 #: src/components/search/employment-type-modal.tsx:82
 msgid "search.employmentTypeModal.close"
+msgstr "Fermer"
+
+#. Aria label for close button on the company-page all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:275
+msgid "company.locationModal.close"
 msgstr "Fermer"
 
 #. Aria label for job detail panel close button
@@ -871,7 +871,7 @@ msgstr "Fermé"
 
 #. Label for inactive/closed job postings on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:143
+#: src/components/search/company-card.tsx:159
 msgid "search.card.closed"
 msgstr "Fermé"
 
@@ -983,12 +983,6 @@ msgstr "Connecter"
 msgid "settings.account.socials.title"
 msgstr "Comptes connectés"
 
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Contact"
-
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:24
@@ -1001,16 +995,22 @@ msgstr "Contact"
 msgid "license.contact.title"
 msgstr "Contact"
 
-#. Table of contents heading
+#. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:21
-msgid "indexing.toc.title"
-msgstr "Sommaire"
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Contact"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:17
 msgid "license.toc.title"
+msgstr "Sommaire"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:21
+msgid "indexing.toc.title"
 msgstr "Sommaire"
 
 #. Button to continue to app after verification
@@ -1911,7 +1911,7 @@ msgstr "sur la dernière année"
 
 #. Yearly matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:122
+#: src/components/search/company-card.tsx:123
 msgid "search.card.yearCount"
 msgstr "au cours de la dernière année"
 
@@ -1999,16 +1999,16 @@ msgstr "En entretien"
 msgid "search.tracker.interviewing"
 msgstr "En entretien"
 
-#. Interviewing status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:21
-msgid "myJobs.status.interviewing"
-msgstr "En entretien"
-
 #. Status option in dropdown: interviewing
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:37
 msgid "myJobs.statusOption.interviewing"
+msgstr "En entretien"
+
+#. Interviewing status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:21
+msgid "myJobs.status.interviewing"
 msgstr "En entretien"
 
 #. Interviews section heading
@@ -2050,16 +2050,16 @@ msgstr "Y a-t-il une limite au nombre d'offres que je peux suivre ?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:31
-msgid "watchlists.card.jobSingular"
-msgstr "offre"
-
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:121
 msgid "watchlists.explore.jobSingular"
+msgstr "offre"
+
+#. Singular job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:31
+msgid "watchlists.card.jobSingular"
 msgstr "offre"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -2162,16 +2162,16 @@ msgstr "Le code source de Job Seek est ouvert sous licence MIT. Les données d'e
 msgid "watchlist.meta.fallback"
 msgstr "Liste d'emplois de @{owner}"
 
-#. Plural job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:32
-msgid "watchlists.card.jobPlural"
-msgstr "offres"
-
 #. Plural job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:122
 msgid "watchlists.explore.jobPlural"
+msgstr "offres"
+
+#. Plural job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:32
+msgid "watchlists.card.jobPlural"
 msgstr "offres"
 
 #. js-lingui-explicit-id
@@ -2646,7 +2646,7 @@ msgstr "Aucun secteur trouvé."
 
 #. Empty state when no jobs match the time range
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:208
+#: src/components/watchlist/watchlist-job-list.tsx:230
 msgid "watchlists.jobList.empty"
 msgstr "Aucune offre trouvée."
 
@@ -2852,6 +2852,18 @@ msgstr "Uniquement des lettres minuscules, des chiffres et des tirets (pas au d�
 msgid "myJobs.interviewType.onsite"
 msgstr "Sur site"
 
+#. Aria label for the row open-posting button when the posting title is missing
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-job-list.tsx:158
+msgid "watchlists.jobList.openPosting"
+msgstr "Ouvrir l'offre d'emploi"
+
+#. Aria label for opening a job posting from a company card row when the posting title is missing
+#. js-lingui-explicit-id
+#: src/components/search/company-card.tsx:147
+msgid "search.card.openPosting"
+msgstr "Ouvrir l'offre d'emploi"
+
 #. Aria label for mobile menu button
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:89
@@ -2937,26 +2949,26 @@ msgstr "Notre position sur l'automatisation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:25
-msgid "indexing.toc.overview"
-msgstr "Aperçu"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:21
 msgid "license.toc.overview"
 msgstr "Aperçu"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:22
-msgid "indexing.toc.ariaLabel"
-msgstr "Sommaire de la page"
+#: src/components/HowWeIndexContent.tsx:25
+msgid "indexing.toc.overview"
+msgstr "Aperçu"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.ariaLabel"
+msgstr "Sommaire de la page"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:22
+msgid "indexing.toc.ariaLabel"
 msgstr "Sommaire de la page"
 
 #. Heading shown on the 404 page
@@ -3310,12 +3322,6 @@ msgstr "Refusé"
 msgid "search.tracker.rejected"
 msgstr "Refusé"
 
-#. Rejected status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:23
-msgid "myJobs.status.rejected"
-msgstr "Refusé"
-
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
@@ -3326,6 +3332,12 @@ msgstr "Refusé"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:39
 msgid "myJobs.statusOption.rejected"
+msgstr "Refusé"
+
+#. Rejected status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:23
+msgid "myJobs.status.rejected"
 msgstr "Refusé"
 
 #. Footer license summary text
@@ -3620,7 +3632,7 @@ msgstr "Enregistre n'importe quelle recherche en watchlist et reçois des alerte
 
 #. Save job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:169
+#: src/components/watchlist/watchlist-job-list.tsx:191
 msgid "watchlists.jobList.save"
 msgstr "Sauvegarder l'offre"
 
@@ -3654,12 +3666,6 @@ msgstr "Enregistrer cette recherche"
 msgid "myJobs.group.saved"
 msgstr "Enregistré"
 
-#. Saved status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:19
-msgid "myJobs.status.saved"
-msgstr "Enregistré"
-
 #. Sankey funnel node: saved jobs
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:41
@@ -3670,6 +3676,12 @@ msgstr "Enregistré"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:35
 msgid "myJobs.statusOption.saved"
+msgstr "Enregistré"
+
+#. Saved status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:19
+msgid "myJobs.status.saved"
 msgstr "Enregistré"
 
 #. Username save button while loading
@@ -3894,16 +3906,16 @@ msgstr "Paramètres"
 msgid "home.features.s3.p3.title"
 msgstr "Partager avec tout le monde"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:357
-msgid "search.detail.showLessLocations"
-msgstr "Afficher moins"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:355
 msgid "company.page.showLess"
+msgstr "Afficher moins"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:357
+msgid "search.detail.showLessLocations"
 msgstr "Afficher moins"
 
 #. Aria label to show password
@@ -4421,7 +4433,7 @@ msgstr "Listes de suivi illimitées, alertes email sur les nouveaux résultats"
 
 #. Unsave job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:168
+#: src/components/watchlist/watchlist-job-list.tsx:190
 msgid "watchlists.jobList.unsave"
 msgstr "Retirer l'offre"
 

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -239,7 +239,7 @@ msgstr "attivi"
 
 #. Active matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:120
+#: src/components/search/company-card.tsx:121
 msgid "search.card.active"
 msgstr "attivo"
 
@@ -333,16 +333,16 @@ msgstr "Tutte le lingue"
 msgid "settings.general.jobLanguages.all"
 msgstr "Tutte le lingue"
 
-#. Title for the all-locations modal on company page
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:268
-msgid "company.locationModal.title"
-msgstr "Tutte le sedi"
-
 #. Button to open all-locations modal on company page
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:346
 msgid "company.page.allLocations"
+msgstr "Tutte le sedi"
+
+#. Title for the all-locations modal on company page
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:268
+msgid "company.locationModal.title"
 msgstr "Tutte le sedi"
 
 #. Link to sign-in page from sign-up
@@ -434,12 +434,6 @@ msgstr "Candidato"
 msgid "search.tracker.applied"
 msgstr "Candidato"
 
-#. Applied status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:20
-msgid "myJobs.status.applied"
-msgstr "Candidato"
-
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
@@ -450,6 +444,12 @@ msgstr "Candidato"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.applied"
+msgstr "Candidato"
+
+#. Applied status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:20
+msgid "myJobs.status.applied"
 msgstr "Candidato"
 
 #. Apply salary filter
@@ -544,12 +544,6 @@ msgstr "Torna su"
 msgid "myJobs.interviewType.behavioral"
 msgstr "Comportamentale"
 
-#. Back-to-index link at the top of a blog post (rendered as '← {label}')
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/blog/[slug]/page.tsx:146
-msgid "blog.post.backToIndex"
-msgstr "Blog"
-
 #. Document title (<title>) for the blog index page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:28
@@ -560,6 +554,12 @@ msgstr "Blog"
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:79
 msgid "blog.index.heading"
+msgstr "Blog"
+
+#. Back-to-index link at the top of a blog post (rendered as '← {label}')
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/blog/[slug]/page.tsx:146
+msgid "blog.post.backToIndex"
 msgstr "Blog"
 
 #. Nav link: Blog
@@ -791,12 +791,6 @@ msgstr "Chiudi"
 msgid "settings.jobLanguages.modal.close"
 msgstr "Chiudi"
 
-#. Aria label for the work-mode modal close button
-#. js-lingui-explicit-id
-#: src/components/search/work-mode-modal.tsx:90
-msgid "search.workModeModal.close"
-msgstr "Chiudi"
-
 #. Aria label for the technology modal close button
 #. js-lingui-explicit-id
 #: src/components/search/technology-modal.tsx:117
@@ -807,6 +801,12 @@ msgstr "Chiudi"
 #. js-lingui-explicit-id
 #: src/components/search/seniority-modal.tsx:65
 msgid "search.seniorityModal.close"
+msgstr "Chiudi"
+
+#. Aria label for the work-mode modal close button
+#. js-lingui-explicit-id
+#: src/components/search/work-mode-modal.tsx:90
+msgid "search.workModeModal.close"
 msgstr "Chiudi"
 
 #. Aria label for the salary modal close button
@@ -827,12 +827,6 @@ msgstr "Chiudi"
 msgid "search.locationModal.close"
 msgstr "Chiudi"
 
-#. Aria label for close button on the company-page all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:275
-msgid "company.locationModal.close"
-msgstr "Chiudi"
-
 #. Aria label for the experience modal close button
 #. js-lingui-explicit-id
 #: src/components/search/experience-modal.tsx:193
@@ -843,6 +837,12 @@ msgstr "Chiudi"
 #. js-lingui-explicit-id
 #: src/components/search/employment-type-modal.tsx:82
 msgid "search.employmentTypeModal.close"
+msgstr "Chiudi"
+
+#. Aria label for close button on the company-page all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:275
+msgid "company.locationModal.close"
 msgstr "Chiudi"
 
 #. Aria label for job detail panel close button
@@ -871,7 +871,7 @@ msgstr "Chiuso"
 
 #. Label for inactive/closed job postings on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:143
+#: src/components/search/company-card.tsx:159
 msgid "search.card.closed"
 msgstr "Chiuso"
 
@@ -983,12 +983,6 @@ msgstr "Collega"
 msgid "settings.account.socials.title"
 msgstr "Account collegati"
 
-#. Footer link to contact email
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Contatti"
-
 #. TOC: Contact
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:24
@@ -1001,16 +995,22 @@ msgstr "Contatti"
 msgid "license.contact.title"
 msgstr "Contatti"
 
-#. Table of contents heading
+#. Footer link to contact email
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:21
-msgid "indexing.toc.title"
-msgstr "Sommario"
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Contatti"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:17
 msgid "license.toc.title"
+msgstr "Sommario"
+
+#. Table of contents heading
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:21
+msgid "indexing.toc.title"
 msgstr "Sommario"
 
 #. Button to continue to app after verification
@@ -1911,7 +1911,7 @@ msgstr "nell'ultimo anno"
 
 #. Yearly matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:122
+#: src/components/search/company-card.tsx:123
 msgid "search.card.yearCount"
 msgstr "nell'ultimo anno"
 
@@ -1999,16 +1999,16 @@ msgstr "In colloquio"
 msgid "search.tracker.interviewing"
 msgstr "In colloquio"
 
-#. Interviewing status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:21
-msgid "myJobs.status.interviewing"
-msgstr "In colloquio"
-
 #. Status option in dropdown: interviewing
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:37
 msgid "myJobs.statusOption.interviewing"
+msgstr "In colloquio"
+
+#. Interviewing status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:21
+msgid "myJobs.status.interviewing"
 msgstr "In colloquio"
 
 #. Interviews section heading
@@ -2050,16 +2050,16 @@ msgstr "C'è un limite al numero di offerte che posso tracciare?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Gen"
 
-#. Singular job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:31
-msgid "watchlists.card.jobSingular"
-msgstr "offerta"
-
 #. Singular job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:121
 msgid "watchlists.explore.jobSingular"
+msgstr "offerta"
+
+#. Singular job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:31
+msgid "watchlists.card.jobSingular"
 msgstr "offerta"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -2162,16 +2162,16 @@ msgstr "Il codice sorgente di Job Seek è open source sotto licenza MIT. I dati 
 msgid "watchlist.meta.fallback"
 msgstr "Lista lavori di @{owner}"
 
-#. Plural job count on watchlist card
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-card.tsx:32
-msgid "watchlists.card.jobPlural"
-msgstr "offerte"
-
 #. Plural job count in public watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/public-watchlist-search.tsx:122
 msgid "watchlists.explore.jobPlural"
+msgstr "offerte"
+
+#. Plural job count on watchlist card
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:32
+msgid "watchlists.card.jobPlural"
 msgstr "offerte"
 
 #. js-lingui-explicit-id
@@ -2646,7 +2646,7 @@ msgstr "Nessun settore trovato."
 
 #. Empty state when no jobs match the time range
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:208
+#: src/components/watchlist/watchlist-job-list.tsx:230
 msgid "watchlists.jobList.empty"
 msgstr "Nessuna offerta trovata."
 
@@ -2852,6 +2852,18 @@ msgstr "Solo lettere minuscole, numeri e trattini (non all'inizio/fine)"
 msgid "myJobs.interviewType.onsite"
 msgstr "In sede"
 
+#. Aria label for the row open-posting button when the posting title is missing
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-job-list.tsx:158
+msgid "watchlists.jobList.openPosting"
+msgstr "Apri offerta di lavoro"
+
+#. Aria label for opening a job posting from a company card row when the posting title is missing
+#. js-lingui-explicit-id
+#: src/components/search/company-card.tsx:147
+msgid "search.card.openPosting"
+msgstr "Apri offerta di lavoro"
+
 #. Aria label for mobile menu button
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:89
@@ -2937,26 +2949,26 @@ msgstr "La nostra posizione sull'automazione"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:25
-msgid "indexing.toc.overview"
-msgstr "Panoramica"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:21
 msgid "license.toc.overview"
 msgstr "Panoramica"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:22
-msgid "indexing.toc.ariaLabel"
-msgstr "Contenuti della pagina"
+#: src/components/HowWeIndexContent.tsx:25
+msgid "indexing.toc.overview"
+msgstr "Panoramica"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:18
 msgid "license.toc.ariaLabel"
+msgstr "Contenuti della pagina"
+
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/HowWeIndexContent.tsx:22
+msgid "indexing.toc.ariaLabel"
 msgstr "Contenuti della pagina"
 
 #. Heading shown on the 404 page
@@ -3310,12 +3322,6 @@ msgstr "Rifiutato"
 msgid "search.tracker.rejected"
 msgstr "Rifiutato"
 
-#. Rejected status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:23
-msgid "myJobs.status.rejected"
-msgstr "Rifiutato"
-
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
@@ -3326,6 +3332,12 @@ msgstr "Rifiutato"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:39
 msgid "myJobs.statusOption.rejected"
+msgstr "Rifiutato"
+
+#. Rejected status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:23
+msgid "myJobs.status.rejected"
 msgstr "Rifiutato"
 
 #. Footer license summary text
@@ -3620,7 +3632,7 @@ msgstr "Salva qualsiasi ricerca come watchlist e ricevi avvisi via email quando 
 
 #. Save job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:169
+#: src/components/watchlist/watchlist-job-list.tsx:191
 msgid "watchlists.jobList.save"
 msgstr "Salva offerta"
 
@@ -3654,12 +3666,6 @@ msgstr "Salva questa ricerca"
 msgid "myJobs.group.saved"
 msgstr "Salvato"
 
-#. Saved status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:19
-msgid "myJobs.status.saved"
-msgstr "Salvato"
-
 #. Sankey funnel node: saved jobs
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:41
@@ -3670,6 +3676,12 @@ msgstr "Salvato"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:35
 msgid "myJobs.statusOption.saved"
+msgstr "Salvato"
+
+#. Saved status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:19
+msgid "myJobs.status.saved"
 msgstr "Salvato"
 
 #. Username save button while loading
@@ -3894,16 +3906,16 @@ msgstr "Impostazioni"
 msgid "home.features.s3.p3.title"
 msgstr "Condividi con chiunque"
 
-#. Button to collapse location list
-#. js-lingui-explicit-id
-#: src/components/search/job-detail-dialog.tsx:357
-msgid "search.detail.showLessLocations"
-msgstr "Mostra meno"
-
 #. Collapse location pill list
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:355
 msgid "company.page.showLess"
+msgstr "Mostra meno"
+
+#. Button to collapse location list
+#. js-lingui-explicit-id
+#: src/components/search/job-detail-dialog.tsx:357
+msgid "search.detail.showLessLocations"
 msgstr "Mostra meno"
 
 #. Aria label to show password
@@ -4421,7 +4433,7 @@ msgstr "Watchlist illimitate, avvisi email sui nuovi risultati"
 
 #. Unsave job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:168
+#: src/components/watchlist/watchlist-job-list.tsx:190
 msgid "watchlists.jobList.unsave"
 msgstr "Rimuovi offerta"
 

--- a/apps/web/src/components/search/__tests__/company-card-nested-buttons.test.tsx
+++ b/apps/web/src/components/search/__tests__/company-card-nested-buttons.test.tsx
@@ -1,0 +1,255 @@
+/**
+ * Regression tests for issue #3166 — un-nesting interactive elements
+ * in the search company-card posting list.
+ *
+ * Before the fix, each posting row was a `<div role="button" tabIndex=
+ * "0">` containing a real `<SaveButton>` (`<button>`). The outer was
+ * keyboard-reachable but the WCAG 4.1.2 violation (button inside
+ * button) remained, and screen readers conflated the two controls.
+ *
+ * The fix restructures the row into a `relative` wrapper containing
+ * two sibling `<button>` elements:
+ *   - an "Open posting" overlay (`absolute inset-0`),
+ *   - the existing SaveButton wrapped in a `relative z-10` span so it
+ *     overlays the open-overlay and stays keyboard-reachable.
+ *
+ * Assertions here mirror the watchlist tests:
+ *   1. No `<button>` (or [role=button]) is nested inside another.
+ *   2. Both row-level controls are real buttons and keyboard-reachable.
+ *   3. Clicking SaveButton does NOT trigger `onShowPosting`.
+ *   4. Clicking the row open-overlay DOES trigger `onShowPosting`.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@/test-utils/lingui-mock";
+
+// --- Mocks ------------------------------------------------------------------
+// Keep the heavy subtree light, but render SaveButton as a REAL <button>
+// so we can verify the nested-button invariant on the rendered DOM.
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ lang: "en" }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, prefetch: _prefetch, ...props }: Record<string, unknown>) => (
+    <a href={href as string} {...props}>{children as React.ReactNode}</a>
+  ),
+}));
+
+vi.mock("@/components/CompanyIcon", () => ({
+  CompanyIcon: ({ alt }: { alt: string }) => <span data-testid="company-icon">{alt}</span>,
+}));
+
+vi.mock("@/components/InfiniteScrollSentinel", () => ({
+  InfiniteScrollSentinel: () => null,
+}));
+
+vi.mock("@/components/TruncationPrompt", () => ({
+  TruncationPrompt: () => null,
+}));
+
+vi.mock("@/components/TrackingDot", () => ({
+  TrackingDot: () => <span data-testid="tracking-dot" />,
+}));
+
+vi.mock("@/components/PendingJobWarning", () => ({
+  PendingJobIcon: () => <span data-testid="pending-job-icon" />,
+}));
+
+const saveClickMock = vi.fn();
+// IMPORTANT: render the SaveButton as a real <button> so the
+// "no nested <button>" assertion has teeth.
+vi.mock("@/components/search/save-button", () => ({
+  SaveButton: ({ postingId }: { postingId: string }) => (
+    <button
+      type="button"
+      data-testid={`save-button-${postingId}`}
+      aria-label={`Save job ${postingId}`}
+      onClick={(e) => {
+        // Preserve the original stopPropagation guard.
+        e.stopPropagation();
+        saveClickMock(postingId);
+      }}
+    >
+      save
+    </button>
+  ),
+}));
+
+vi.mock("@/components/search/star-button", () => ({
+  StarButton: () => null,
+}));
+
+vi.mock("@/components/ui/scroll-fade", () => ({
+  ScrollFade: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/use-infinite-scroll", () => ({
+  useInfiniteScroll: () => ({ sentinelRef: { current: null }, isLoading: false }),
+}));
+
+vi.mock("@/lib/actions/search", () => ({
+  loadMorePostings: vi.fn(),
+}));
+
+vi.mock("@/lib/time", () => ({
+  timeAgoShort: () => "1d",
+}));
+
+vi.mock("@/lib/search/query-params", () => ({
+  buildFilteredPath: () => "/en/company/acme",
+}));
+
+// Import AFTER mocks.
+import { CompanyCard } from "../company-card";
+import type { SearchResultCompany } from "@/lib/search";
+
+function makeResult(): SearchResultCompany {
+  return {
+    company: { id: "c1", name: "ACME", slug: "acme", icon: null },
+    activeMatches: 2,
+    yearMatches: 2,
+    postings: [
+      {
+        id: "p1",
+        title: "Senior Engineer",
+        firstSeenAt: "2026-05-01T00:00:00Z",
+        relevanceScore: 1,
+        locations: [],
+        isActive: true,
+      },
+      {
+        id: "p2",
+        title: "Junior Engineer",
+        firstSeenAt: "2026-05-02T00:00:00Z",
+        relevanceScore: 1,
+        locations: [],
+        isActive: true,
+      },
+    ],
+  };
+}
+
+describe("CompanyCard row a11y (issue #3166)", () => {
+  beforeEach(() => {
+    saveClickMock.mockClear();
+  });
+
+  it("does NOT nest a <button> (or [role=button]) inside another <button>", () => {
+    const onShow = vi.fn();
+    const { container } = render(
+      <CompanyCard
+        result={makeResult()}
+        keywords={[]}
+        locationIds={[]}
+        locations={[]}
+        occupations={[]}
+        seniorities={[]}
+        technologies={[]}
+        employmentTypes={[]}
+        workMode={[]}
+        languages={["en"]}
+        onShowPosting={onShow}
+        selectedPostingId={null}
+      />,
+    );
+
+    const buttons = container.querySelectorAll("button");
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const btn of buttons) {
+      const nested = btn.querySelector('button, [role="button"]');
+      expect(
+        nested,
+        `nested interactive inside <button>: ${btn.outerHTML.slice(0, 200)}`,
+      ).toBeNull();
+    }
+
+    // Also: there must be no `[role="button"]` elements at all in the
+    // posting rows — those were the original violation surface.
+    const roleButtons = container.querySelectorAll('[role="button"]');
+    expect(roleButtons.length).toBe(0);
+  });
+
+  it("renders posting rows with real keyboard-reachable open buttons", () => {
+    render(
+      <CompanyCard
+        result={makeResult()}
+        keywords={[]}
+        locationIds={[]}
+        locations={[]}
+        occupations={[]}
+        seniorities={[]}
+        technologies={[]}
+        employmentTypes={[]}
+        workMode={[]}
+        languages={["en"]}
+        onShowPosting={vi.fn()}
+        selectedPostingId={null}
+      />,
+    );
+
+    // Two postings => two open-row buttons. The aria-label uses the
+    // posting title (per the new implementation).
+    const seniorBtn = screen.getByRole("button", { name: "Senior Engineer" });
+    const juniorBtn = screen.getByRole("button", { name: "Junior Engineer" });
+    expect(seniorBtn.tagName).toBe("BUTTON");
+    expect(juniorBtn.tagName).toBe("BUTTON");
+    expect(seniorBtn.getAttribute("tabindex")).not.toBe("-1");
+    expect(juniorBtn.getAttribute("tabindex")).not.toBe("-1");
+  });
+
+  it("clicking SaveButton does NOT call onShowPosting (sibling, not nested)", () => {
+    const onShow = vi.fn();
+    render(
+      <CompanyCard
+        result={makeResult()}
+        keywords={[]}
+        locationIds={[]}
+        locations={[]}
+        occupations={[]}
+        seniorities={[]}
+        technologies={[]}
+        employmentTypes={[]}
+        workMode={[]}
+        languages={["en"]}
+        onShowPosting={onShow}
+        selectedPostingId={null}
+      />,
+    );
+
+    const saveBtn = screen.getByTestId("save-button-p1");
+    fireEvent.click(saveBtn);
+
+    expect(saveClickMock).toHaveBeenCalledTimes(1);
+    expect(saveClickMock).toHaveBeenCalledWith("p1");
+    expect(onShow).not.toHaveBeenCalled();
+  });
+
+  it("clicking the row's open button DOES call onShowPosting", () => {
+    const onShow = vi.fn();
+    render(
+      <CompanyCard
+        result={makeResult()}
+        keywords={[]}
+        locationIds={[]}
+        locations={[]}
+        occupations={[]}
+        seniorities={[]}
+        technologies={[]}
+        employmentTypes={[]}
+        workMode={[]}
+        languages={["en"]}
+        onShowPosting={onShow}
+        selectedPostingId={null}
+      />,
+    );
+
+    const seniorBtn = screen.getByRole("button", { name: "Senior Engineer" });
+    fireEvent.click(seniorBtn);
+
+    expect(onShow).toHaveBeenCalledTimes(1);
+    expect(onShow).toHaveBeenCalledWith("p1");
+    expect(saveClickMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/search/company-card.tsx
+++ b/apps/web/src/components/search/company-card.tsx
@@ -2,7 +2,7 @@
 
 import { memo, useState, useRef, useMemo } from "react";
 import Link from "next/link";
-import { Trans } from "@lingui/react/macro";
+import { Trans, useLingui } from "@lingui/react/macro";
 import { CompanyIcon } from "@/components/CompanyIcon";
 import { useParams } from "next/navigation";
 import { timeAgoShort } from "@/lib/time";
@@ -43,6 +43,7 @@ interface CompanyCardProps {
 function CompanyCardImpl({ result, keywords, locationIds, locations, occupations, seniorities, technologies, employmentTypes, workMode, salaryMinEur, salaryMaxEur, experienceMin, experienceMax, languages, onShowPosting, selectedPostingId }: CompanyCardProps) {
   const params = useParams();
   const locale = (params.lang as string) ?? "en";
+  const { t } = useLingui();
   const { company, activeMatches, yearMatches } = result;
 
   const companyHref = buildFilteredPath(
@@ -128,14 +129,29 @@ function CompanyCardImpl({ result, keywords, locationIds, locations, occupations
       {/* Scrollable posting list */}
       <ScrollFade className="max-h-[184px]" scrollRef={scrollRef} deps={[allPostings.length]}>
           {allPostings.map((posting) => (
+          // Un-nested layout (issue #3166): the row "open posting" button
+          // and the SaveButton are siblings under a `relative` wrapper —
+          // not a div[role=button] containing a nested <button>. The open
+          // button is a positioned overlay covering the row's click area;
+          // SaveButton sits in normal flex flow with `relative z-10` so
+          // it stacks above the overlay and stays keyboard-reachable.
           <div
             key={posting.id}
-            role="button"
-            tabIndex={0}
-            onClick={() => onShowPosting?.(posting.id)}
-            onKeyDown={(e) => { if (e.key === "Enter") onShowPosting?.(posting.id); }}
-            className={`flex cursor-pointer items-center gap-2 rounded px-1 py-1.5 transition-colors ${posting.id === selectedPostingId ? "bg-primary/10" : "hover:bg-border-soft"} ${posting.isActive === false ? "opacity-50" : ""}`}
+            className={`relative flex items-center gap-2 rounded px-1 py-1.5 transition-colors ${posting.id === selectedPostingId ? "bg-primary/10" : "hover:bg-border-soft"} ${posting.isActive === false ? "opacity-50" : ""}`}
           >
+            <button
+              type="button"
+              onClick={() => onShowPosting?.(posting.id)}
+              aria-label={
+                posting.title ??
+                t({
+                  id: "search.card.openPosting",
+                  comment: "Aria label for opening a job posting from a company card row when the posting title is missing",
+                  message: "Open job posting",
+                })
+              }
+              className="absolute inset-0 z-0 cursor-pointer rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+            />
             <TrackingDot postingId={posting.id} />
             <span className="min-w-0 flex-1 truncate text-sm">{posting.title ?? "—"}</span>
             {posting.isActive === false && (
@@ -151,8 +167,16 @@ function CompanyCardImpl({ result, keywords, locationIds, locations, occupations
                 {posting.locations.length > 1 && ` +${posting.locations.length - 1}`}
               </span>
             )}
-            {!posting.title && <PendingJobIcon />}
-            <SaveButton postingId={posting.id} />
+            {!posting.title && (
+              // `relative z-10` so the warning icon's tooltip trigger
+              // remains above the absolute overlay button.
+              <span className="relative z-10 inline-flex shrink-0">
+                <PendingJobIcon />
+              </span>
+            )}
+            <span className="relative z-10 shrink-0">
+              <SaveButton postingId={posting.id} />
+            </span>
             <span suppressHydrationWarning className="w-8 shrink-0 text-left text-[10px] tabular-nums text-muted">
               {timeAgoShort(posting.firstSeenAt)}
             </span>

--- a/apps/web/src/components/watchlist/__tests__/watchlist-job-list-nested-buttons.test.tsx
+++ b/apps/web/src/components/watchlist/__tests__/watchlist-job-list-nested-buttons.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * Regression tests for issue #3166 — nested interactive elements in the
+ * watchlist row.
+ *
+ * Before the fix, each row was a `<button>` with a nested `<span role=
+ * "button">` for the save toggle. That violates WCAG 4.1.2 (nested
+ * interactive widgets) and left the inner span unreachable by keyboard
+ * (no `tabIndex={0}` and no `onKeyDown`).
+ *
+ * The fix restructures the row into a `relative` wrapper containing two
+ * sibling `<button>` elements:
+ *   - an "Open posting" overlay (`absolute inset-0`) that captures
+ *     clicks anywhere on the row,
+ *   - a real Save `<button>` (`relative z-10`) that overlays the row
+ *     visually and intercepts its own clicks.
+ *
+ * These tests assert:
+ *   1. The DOM no longer contains a `<button>` inside a `<button>`
+ *      (the WCAG violation).
+ *   2. Both buttons are real `<button>` elements, keyboard-reachable
+ *      via natural Tab order.
+ *   3. Clicking the save button does NOT trigger the open-posting
+ *      handler (the original `e.stopPropagation()` invariant).
+ *   4. Clicking elsewhere on the row DOES open the posting.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@/test-utils/lingui-mock";
+
+// --- Mocks ------------------------------------------------------------------
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/components/CompanyIcon", () => ({
+  CompanyIcon: ({ alt }: { alt: string }) => <span data-testid="company-icon">{alt}</span>,
+}));
+
+vi.mock("@/lib/time", () => ({
+  timeAgoShort: () => "1d",
+}));
+
+vi.mock("@/lib/search/search-runner", () => ({
+  runGetWatchlistPostings: vi.fn().mockResolvedValue({
+    postings: [],
+    total: 0,
+  }),
+}));
+
+vi.mock("@/lib/search/use-clear-typesense-on-auth-change", () => ({
+  useClearTypesenseOnAuthChange: () => {},
+}));
+
+const toggleMock = vi.fn();
+vi.mock("@/components/SessionProvider", () => ({
+  useSession: () => ({ isLoggedIn: true, isPending: false }),
+}));
+vi.mock("@/components/SavedJobsProvider", () => ({
+  useSavedJobs: () => ({
+    isSaved: () => false,
+    toggle: toggleMock,
+    isToggling: () => false,
+    getStatus: () => null,
+    getSavedJobId: () => null,
+    setStatus: () => {},
+    onStatusChange: () => () => {},
+  }),
+}));
+
+vi.mock("@/components/search/job-detail-dialog", () => ({
+  JobDetailPanel: () => <div data-testid="job-detail-panel" />,
+}));
+
+vi.mock("@/lib/use-infinite-scroll", () => ({
+  useInfiniteScroll: () => ({ sentinelRef: { current: null }, isLoading: false }),
+}));
+
+vi.mock("@/lib/use-paginated-load-more", () => ({
+  usePaginatedLoadMore: ({ initialItems, initialTotal }: {
+    initialItems: unknown[];
+    initialTotal: number;
+  }) => ({
+    items: initialItems,
+    total: initialTotal,
+    truncated: false,
+    hasMore: false,
+    loadMore: () => {},
+  }),
+}));
+
+vi.mock("@/components/InfiniteScrollSentinel", () => ({
+  InfiniteScrollSentinel: () => null,
+}));
+
+vi.mock("@/components/TruncationPrompt", () => ({
+  TruncationPrompt: () => null,
+}));
+
+vi.mock("@/components/TrackingDot", () => ({
+  TrackingDot: () => <span data-testid="tracking-dot" />,
+}));
+
+vi.mock("@/components/PendingJobWarning", () => ({
+  PendingJobIcon: () => <span data-testid="pending-job-icon" />,
+}));
+
+vi.mock("@/components/search/language-stats-row", () => ({
+  LanguageStatsRow: () => null,
+}));
+
+vi.mock("@/components/watchlist/format-date-divider", () => ({
+  formatDateDivider: () => "Today",
+  getDateKey: (s: string) => s,
+}));
+
+// Stub window.history APIs the row's open handler invokes.
+beforeEach(() => {
+  toggleMock.mockClear();
+  // happy-dom provides history; nothing more needed.
+});
+
+// Import AFTER mocks so vi.mock hoisting is honored.
+import { WatchlistJobList } from "../watchlist-job-list";
+import type { WatchlistPostingEntry } from "@/lib/actions/watchlists";
+
+function entry(id: string, title: string | null = `Job ${id}`): WatchlistPostingEntry {
+  return {
+    id,
+    title,
+    sourceUrl: `https://example.com/${id}`,
+    firstSeenAt: "2026-05-13T00:00:00Z",
+    isActive: true,
+    company: {
+      id: `c-${id}`,
+      name: `Company ${id}`,
+      slug: `company-${id}`,
+      icon: null,
+    },
+  };
+}
+
+function renderList(postings: WatchlistPostingEntry[]) {
+  return render(
+    <WatchlistJobList
+      filters={{ companyIds: ["c-1"] }}
+      initialPostings={postings}
+      initialTotal={postings.length}
+      yearTotal={postings.length}
+      jobLanguages={["en"]}
+      locale="en"
+    />,
+  );
+}
+
+describe("WatchlistJobList row a11y (issue #3166)", () => {
+  it("does NOT nest a <button> (or [role=button]) inside another <button>", () => {
+    const { container } = renderList([entry("1"), entry("2")]);
+
+    // Find every real <button>; assert none has a button-like descendant.
+    const buttons = container.querySelectorAll("button");
+    expect(buttons.length).toBeGreaterThan(0);
+    for (const btn of buttons) {
+      const nested = btn.querySelector('button, [role="button"]');
+      expect(
+        nested,
+        `nested interactive element found inside <button>: ${btn.outerHTML.slice(0, 200)}`,
+      ).toBeNull();
+    }
+  });
+
+  it("renders two real <button>s per row — Open posting + Save job — both keyboard-reachable", () => {
+    renderList([entry("1")]);
+
+    // Both buttons must be real <button> elements (not [role=button] spans).
+    const openBtn = screen.getByRole("button", { name: /Company 1 — Job 1|open job posting/i });
+    const saveBtn = screen.getByRole("button", { name: /save job/i });
+    expect(openBtn.tagName).toBe("BUTTON");
+    expect(saveBtn.tagName).toBe("BUTTON");
+
+    // Real <button>s are tab-focusable by default. The browser puts
+    // tabIndex=0 implicitly; explicit tabIndex=-1 would opt them out.
+    expect(openBtn.getAttribute("tabindex")).not.toBe("-1");
+    expect(saveBtn.getAttribute("tabindex")).not.toBe("-1");
+  });
+
+  it("Tab order across two rows is: row1.open, row1.save, row2.open, row2.save", () => {
+    const { container } = renderList([entry("1"), entry("2")]);
+
+    // Take all <button>s in DOM order; they must be the four expected
+    // ones in the expected sequence. Open buttons use the row title
+    // (e.g. `Company 1 — Job 1`); save buttons use "Save job".
+    const buttons = Array.from(container.querySelectorAll("button"));
+    const labels = buttons.map((b) => b.getAttribute("aria-label") ?? "");
+
+    // Classify each label as `open` or `save`. Anything else (e.g. date
+    // dividers shouldn't add buttons, but be defensive) is ignored.
+    const classified = labels
+      .map((l) => {
+        if (/save job/i.test(l)) return "save" as const;
+        if (/^Company \d+ — Job \d+$/.test(l)) return "open" as const;
+        if (/open job posting/i.test(l)) return "open" as const;
+        return null;
+      })
+      .filter((x): x is "open" | "save" => x !== null);
+
+    expect(classified).toEqual(["open", "save", "open", "save"]);
+  });
+
+  it("clicking the save button does NOT trigger the open-posting handler", () => {
+    renderList([entry("1")]);
+
+    const saveBtn = screen.getByRole("button", { name: /save job/i });
+    fireEvent.click(saveBtn);
+
+    // toggle was called exactly once with the entry id.
+    expect(toggleMock).toHaveBeenCalledTimes(1);
+    expect(toggleMock).toHaveBeenCalledWith("1");
+
+    // The detail panel must NOT have appeared (open handler never fired).
+    expect(screen.queryByTestId("job-detail-panel")).toBeNull();
+  });
+
+  it("clicking the row (open button) opens the posting; save handler not called", () => {
+    renderList([entry("1")]);
+
+    // Before click: the JobDetailPanel mock has not been rendered.
+    expect(screen.queryAllByTestId("job-detail-panel")).toHaveLength(0);
+
+    const openBtn = screen.getByRole("button", { name: /Company 1 — Job 1|open job posting/i });
+    fireEvent.click(openBtn);
+
+    // After click: the detail panel renders (there are two panes — a
+    // sticky desktop one and a mobile drawer — both render under the
+    // current breakpoint-agnostic layout).
+    expect(
+      screen.queryAllByTestId("job-detail-panel").length,
+    ).toBeGreaterThan(0);
+    expect(toggleMock).not.toHaveBeenCalled();
+  });
+});
+

--- a/apps/web/src/components/watchlist/watchlist-job-list.tsx
+++ b/apps/web/src/components/watchlist/watchlist-job-list.tsx
@@ -135,15 +135,34 @@ export function WatchlistJobList({
       );
     }
 
+    // Un-nested layout (issue #3166): row open button + save button are
+    // siblings in a `relative` container, not nested. The open button is
+    // a positioned overlay covering the row's click area; the save
+    // button sits in normal flex flow with `relative z-10` so it stacks
+    // above the overlay AND receives its own click. Tab order: row open
+    // first, then save (DOM order). No `e.stopPropagation()` needed —
+    // the buttons are siblings, not nested.
     rows.push(
-      <button
+      <div
         key={entry.id}
-        type="button"
-        onClick={() => handleOpenPosting(entry.id)}
-        className={`flex w-full cursor-pointer items-center gap-3 rounded-md px-2 py-2 text-left transition-colors hover:bg-border-soft ${
+        className={`relative flex w-full items-center gap-3 rounded-md px-2 py-2 text-left transition-colors hover:bg-border-soft ${
           showPostingId === entry.id ? "bg-border-soft" : ""
         }`}
       >
+        <button
+          type="button"
+          onClick={() => handleOpenPosting(entry.id)}
+          aria-label={
+            entry.title
+              ? `${entry.company.name} — ${entry.title}`
+              : t({
+                  id: "watchlists.jobList.openPosting",
+                  comment: "Aria label for the row open-posting button when the posting title is missing",
+                  message: "Open job posting",
+                })
+          }
+          className="absolute inset-0 z-0 cursor-pointer rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+        />
         <TrackingDot postingId={entry.id} />
         <CompanyIcon icon={entry.company.icon} alt={entry.company.name} size={24} />
 
@@ -155,14 +174,17 @@ export function WatchlistJobList({
           {entry.title ?? "—"}
         </span>
 
-        {!entry.title && <PendingJobIcon />}
-        <span
-          role="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            toggle(entry.id);
-          }}
-          className="shrink-0 cursor-pointer text-muted transition-opacity hover:opacity-70"
+        {!entry.title && (
+          // `relative z-10` so the warning icon's tooltip trigger remains
+          // above the absolute overlay button and still receives hover.
+          <span className="relative z-10 inline-flex shrink-0">
+            <PendingJobIcon />
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={() => toggle(entry.id)}
+          className="relative z-10 shrink-0 cursor-pointer text-muted transition-opacity hover:opacity-70 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
           aria-label={
             isSaved(entry.id)
               ? t({ id: "watchlists.jobList.unsave", comment: "Unsave job aria label", message: "Unsave job" })
@@ -174,7 +196,7 @@ export function WatchlistJobList({
             aria-hidden="true"
             className={isSaved(entry.id) ? "fill-current" : ""}
           />
-        </span>
+        </button>
 
         <span
           suppressHydrationWarning
@@ -182,7 +204,7 @@ export function WatchlistJobList({
         >
           {timeAgoShort(entry.firstSeenAt)}
         </span>
-      </button>,
+      </div>,
     );
   }
 


### PR DESCRIPTION
## Summary

Fixes a WCAG 4.1.2 violation in two job-list surfaces — the watchlist
job list and the search company-card posting list — and a real
keyboard-only failure where the inner save toggle was completely
unreachable in the watchlist.

### What was wrong

**`apps/web/src/components/watchlist/watchlist-job-list.tsx`** — each
row was a real `<button>` containing a nested `<span role=\"button\">`
for the save toggle. That violates WCAG 4.1.2 (no nested interactive
elements), and the inner span had no \`tabIndex={0}\` and no
\`onKeyDown\` — **a keyboard-only user could not save/unsave from the
watchlist list at all**.

**`apps/web/src/components/search/company-card.tsx`** — each posting row
was a \`<div role=\"button\" tabIndex=\"0\">\` wrapping a real
\`<SaveButton>\` (\`<button>\`). The inner button was reachable, but
nested-button-in-button is still 4.1.2 territory, and screen readers
treat the row as a single ambiguous control.

### What changed (two threads)

Both files now use the same un-nested layout. Each row is a `relative`
wrapper containing two SIBLING real \`<button>\` elements:

  - an **\"Open posting\"** overlay (\`absolute inset-0 z-0\`) covering
    the row's click area,
  - the **Save** action (\`relative z-10\`) in normal flex flow,
    stacking above the overlay and intercepting its own clicks.

Both buttons are real \`<button>\`s, keyboard-reachable in natural Tab
order (row open first, then save). Visible focus rings via
\`focus-visible:ring-2\` align with #3170. The \`<PendingJobIcon>\`
tooltip trigger is wrapped in a \`relative z-10 inline-flex\` span so
hover still reaches it above the overlay.

Visual layout is preserved — only DOM structure + a11y semantics
change. The mouse interaction model (clicks on the row open the
posting; clicks on the save bookmark don't navigate) is preserved by
the sibling-not-nested wiring instead of by \`e.stopPropagation()\`.

### Tests added

- \`watchlist-job-list-nested-buttons.test.tsx\` (5 tests)
- \`company-card-nested-buttons.test.tsx\` (4 tests)

Both files assert:
  - no \`<button>\` (or \`[role=\"button\"]\`) is nested inside another \`<button>\`,
  - both row controls are real \`<button>\` elements, keyboard-reachable,
  - clicking the save button does NOT trigger the open-posting handler,
  - clicking the row open-overlay DOES trigger it.
  - (watchlist) Tab order across two rows is row1.open, row1.save, row2.open, row2.save.

### Out of scope

The issue also mentions \`search/job-detail-dialog.tsx:316-336\` —
location pill as a span-button — as a third, less severe site. Per the
implementer brief (no scope creep) this PR fixes only the two called-out
sites. The third site warrants a follow-up.

## Test plan

- [x] \`pnpm test\` — 1115 / 1115 pass (9 new across the two new files)
- [x] \`pnpm exec tsc --noEmit\` — clean
- [x] \`pnpm exec eslint <changed files>\` — clean
- [ ] Keyboard-only smoke: open \`/watchlists/<slug>\` and \`/search\`,
  Tab through several rows, confirm the save bookmark is focusable and
  Enter/Space toggles it; confirm clicking row text opens the posting,
  clicking save toggles without opening.
- [ ] Screen-reader spot-check (VoiceOver / NVDA): confirm each row
  exposes two distinct buttons (open + save), not one ambiguous
  \"Job title, Save job\" control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)