### PR TITLE
fix(web): include 'wm' in /explore FILTER_PARAMS (closes #3275)

### DIFF
--- a/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
+++ b/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
@@ -147,7 +147,12 @@ describe("ExploreContent — server-render initial-data path (#2640)", () => {
   });
 
   it("recognises every documented filter searchParam as a refetch trigger", async () => {
-    const filterParams = ["q", "loc", "occ", "sen", "tech", "sal", "salcur", "exp"];
+    // Mirrors `FILTER_PARAMS` in `../explore-content.tsx`. Adding a new
+    // filter param to that array MUST also add it here so the regression
+    // surface stays explicit (e.g. #3275 — `wm` was added to the live
+    // code in #2987 but the test list lagged behind, leaving the
+    // refetch-trigger contract unguarded).
+    const filterParams = ["q", "loc", "occ", "sen", "tech", "wm", "sal", "salcur", "exp"];
     for (const param of filterParams) {
       mockFetchExploreData.mockClear();
       currentSearchParams = new URLSearchParams(`${param}=x`);
@@ -162,6 +167,60 @@ describe("ExploreContent — server-render initial-data path (#2640)", () => {
       });
       unmount();
     }
+  });
+
+  // Regression coverage for #3275. The `wm` (workMode) searchParam was
+  // added to `FILTER_PARAMS` in #2987 alongside the work-mode filter
+  // feature, but no test pinned the behaviour. A future revert/refactor
+  // that drops `wm` would silently re-introduce the stale-data bug
+  // (anonymous deep-link to `/explore?wm=remote` paints the unfiltered
+  // homepage `initialData` and never refetches). These tests lock that
+  // contract in place.
+  describe("wm (workMode) filter-param refetch trigger (#3275)", () => {
+    it("triggers refetch when ?wm=remote is in the URL", async () => {
+      currentSearchParams = new URLSearchParams("wm=remote");
+
+      render(
+        <ExploreContent locale="en" initialData={makeInitialData()} />,
+      );
+
+      await waitFor(() => {
+        expect(mockFetchExploreData).toHaveBeenCalledTimes(1);
+      });
+      const callArgs = mockFetchExploreData.mock.calls[0]?.[0] as {
+        searchParams: Record<string, string | undefined>;
+      };
+      expect(callArgs.searchParams.wm).toBe("remote");
+    });
+
+    it("triggers refetch when ?wm=hybrid is in the URL", async () => {
+      currentSearchParams = new URLSearchParams("wm=hybrid");
+
+      render(
+        <ExploreContent locale="en" initialData={makeInitialData()} />,
+      );
+
+      await waitFor(() => {
+        expect(mockFetchExploreData).toHaveBeenCalledTimes(1);
+      });
+      const callArgs = mockFetchExploreData.mock.calls[0]?.[0] as {
+        searchParams: Record<string, string | undefined>;
+      };
+      expect(callArgs.searchParams.wm).toBe("hybrid");
+    });
+
+    it("does NOT trigger refetch when the wm param is absent", async () => {
+      // Sanity: a no-wm anonymous visit must still hit the prerendered
+      // initialData path so #2640's zero-invocation guarantee holds.
+      currentSearchParams = new URLSearchParams();
+
+      render(
+        <ExploreContent locale="en" initialData={makeInitialData()} />,
+      );
+
+      await new Promise((r) => setTimeout(r, 0));
+      expect(mockFetchExploreData).not.toHaveBeenCalled();
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Issue #3275 flagged that `/explore`'s `FILTER_PARAMS` check might be missing `wm` (workMode), letting anonymous deep-links like `/explore?wm=remote` skip the personalized refetch and paint the prerendered unfiltered homepage `initialData`.

**Empirical check**: `wm` was already added to `FILTER_PARAMS` in #2987 (work-mode filter feature, 2026-05-10) alongside the `location_types` Typesense clause — the production fix is already in `main`. What's missing is regression test coverage: `explore-content.test.tsx`'s param-list test hardcoded the original 8 params and never grew to include `wm`, leaving the contract unguarded against a future revert.

This PR locks the contract in place via tests only — no production code changes.

## Stale-data scenario (the bug #3275 was tracking)

1. Anonymous user opens `/explore?wm=remote`.
2. SSR returns the prerendered unfiltered-homepage `initialData`.
3. Client mounts `ExploreContent` and calls `hasAnyFilterParam(searchParams)`.
4. If `wm` is **not** in `FILTER_PARAMS`, the check returns false → no refetch → user sees the unfiltered homepage with their `wm=remote` URL filter silently ignored.

Already mitigated in #2987; this PR pins it.

## Changes

`apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx` (test-only):
1. Existing `recognises every documented filter searchParam` loop — added `"wm"` to the local `filterParams` array so it stays in sync with the production list.
2. New `describe("wm (workMode) filter-param refetch trigger (#3275)")` block:
   - `?wm=remote` triggers refetch (positive case)
   - `?wm=hybrid` triggers refetch (positive case)
   - No `wm` param does NOT trigger refetch (negative case, preserves the #2640 zero-invocation guarantee)

## Verification

Failing-on-main empirical check:
- Removed `wm` from `FILTER_PARAMS` in `explore-content.tsx` → the 3 new positive-case tests fail with `expected to be called 1 times, but got 0 times`.
- Restored `wm` → all 12 tests pass (was 9 before this PR).

## Scope decisions

The issue's task list includes `?wm=` (empty value) does NOT trigger refetch. Current `hasAnyFilterParam` uses `URLSearchParams.has()`, which returns `true` for empty values — same as `?q=`, `?loc=`, etc. Asserting "empty does NOT trigger refetch" would require changing `hasAnyFilterParam` to do value-non-empty checks, which the orchestrator brief explicitly excluded as scope creep (\"Don't refactor surrounding logic\"). This PR therefore covers the present-but-non-empty and absent cases only.

## Test plan

- [x] `pnpm test` (apps/web) — 1129/1129 passing
- [x] `pnpm exec tsc --noEmit` (apps/web) — clean
- [x] Verified new tests fail when `wm` is removed from `FILTER_PARAMS`
- [x] No production code changes

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)