### PR TITLE
fix(web): canonicalize sort in remaining cache-key sites (closes #3276)

### DIFF
--- a/apps/web/src/components/SearchStateProvider.tsx
+++ b/apps/web/src/components/SearchStateProvider.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import type { SelectedLocation } from "@/components/search/location-pills";
 import type { SearchResultCompany, WorkMode } from "@/lib/search";
+import { canonicalStringCompare } from "@/lib/sort";
 
 export interface SearchStateSnapshot {
   keywords: string[];
@@ -37,12 +38,19 @@ export function buildCacheKey(
   seniorityIds?: number[],
   technologyIds?: number[],
 ): string {
+  // String dimensions (keywords) sort with `canonicalStringCompare`
+  // (locale-independent `Intl.Collator("en", { sensitivity: "base" })`)
+  // so that `["python","übung"]` and `["übung","python"]` hash to the
+  // same in-memory snapshot key. Numeric dimensions sort numerically so
+  // `[10, 2]` doesn't coerce to `["10","2"]` and split the slot.
+  // See #3276 (follow-up to #3221/#3187).
+  const numCmp = (a: number, b: number) => a - b;
   const parts = [
-    [...keywords].sort().join(","),
-    [...locationIds].sort().join(","),
-    [...(occupationIds ?? [])].sort().join(","),
-    [...(seniorityIds ?? [])].sort().join(","),
-    [...(technologyIds ?? [])].sort().join(","),
+    [...keywords].sort(canonicalStringCompare).join(","),
+    [...locationIds].sort(numCmp).join(","),
+    [...(occupationIds ?? [])].sort(numCmp).join(","),
+    [...(seniorityIds ?? [])].sort(numCmp).join(","),
+    [...(technologyIds ?? [])].sort(numCmp).join(","),
   ];
   return parts.join("|");
 }

--- a/apps/web/src/components/__tests__/SearchStateProvider.test.tsx
+++ b/apps/web/src/components/__tests__/SearchStateProvider.test.tsx
@@ -62,6 +62,38 @@ describe("buildCacheKey", () => {
       buildCacheKey([], [], [], [], []),
     );
   });
+
+  // #3276 — keyword strings sort with `canonicalStringCompare` so accented
+  // entries don't fragment the snapshot key across input permutations.
+  it("collapses accented keyword permutations onto one key", () => {
+    const a = buildCacheKey(["python", "übung", "zoom"], [], [], [], []);
+    const b = buildCacheKey(["übung", "zoom", "python"], [], [], [], []);
+    const c = buildCacheKey(["zoom", "python", "übung"], [], [], [], []);
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+
+  it("base-sensitivity keeps `Apple` collating with the a-group (not bumped between b and c)", () => {
+    // `sensitivity: "base"` makes `"Apple"` and `"apple"` collation-equal
+    // but does NOT rewrite the surface string. Within a single case,
+    // every permutation collapses to one key.
+    const upperA = buildCacheKey(["Apple", "banana"], [], [], [], []);
+    const upperB = buildCacheKey(["banana", "Apple"], [], [], [], []);
+    expect(upperA).toBe(upperB);
+    const lowerA = buildCacheKey(["apple", "banana"], [], [], [], []);
+    const lowerB = buildCacheKey(["banana", "apple"], [], [], [], []);
+    expect(lowerA).toBe(lowerB);
+    expect(upperA.startsWith("Apple")).toBe(true);
+    expect(lowerA.startsWith("apple")).toBe(true);
+  });
+
+  it("sorts numeric ID arrays numerically — no string-coercion bug", () => {
+    // Bare `.sort()` on a number array stringifies first, so `[10, 2]`
+    // sorts to `[10, 2]` (not `[2, 10]`). The fix uses a numeric
+    // comparator.
+    const key = buildCacheKey([], [10, 2, 100, 1], [], [], []);
+    expect(key).toBe("|1,2,10,100|||");
+  });
 });
 
 describe("shouldRestoreSnapshot — #2989 regression", () => {

--- a/apps/web/src/lib/__tests__/watchlist-utils.test.ts
+++ b/apps/web/src/lib/__tests__/watchlist-utils.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { isTrivialWatchlist, isQualifyingWatchlist } from "../watchlist-utils";
+import {
+  buildFilterCacheKey,
+  isTrivialWatchlist,
+  isQualifyingWatchlist,
+} from "../watchlist-utils";
 import { buildWatchlistItemListJsonLd } from "../seo";
 import type { WatchlistFilters } from "../actions/watchlists";
 
@@ -236,6 +240,134 @@ describe("isQualifyingWatchlist (#2823)", () => {
         createdAt: "not-a-date",
       }),
     ).toBe(false);
+  });
+});
+
+describe("buildFilterCacheKey — canonical sort (#3276)", () => {
+  // Each slug-bearing dimension on a watchlist filter must be sorted with
+  // `canonicalStringCompare` so input permutations collapse to one cache
+  // slot. Numeric-looking `companyIds` keep raw `.sort()` (no accents).
+
+  it("permutes keywords to the same key", () => {
+    const ab = buildFilterCacheKey({ keywords: ["a", "b"] }, []);
+    const ba = buildFilterCacheKey({ keywords: ["b", "a"] }, []);
+    expect(ab).toBe(ba);
+  });
+
+  it("permutes locationSlugs to the same key", () => {
+    const ab = buildFilterCacheKey({ locationSlugs: ["zurich", "berlin"] }, []);
+    const ba = buildFilterCacheKey({ locationSlugs: ["berlin", "zurich"] }, []);
+    expect(ab).toBe(ba);
+  });
+
+  it("permutes occupationSlugs to the same key", () => {
+    const a = buildFilterCacheKey(
+      { occupationSlugs: ["software-engineer", "data-scientist"] },
+      [],
+    );
+    const b = buildFilterCacheKey(
+      { occupationSlugs: ["data-scientist", "software-engineer"] },
+      [],
+    );
+    expect(a).toBe(b);
+  });
+
+  it("permutes senioritySlugs to the same key", () => {
+    const a = buildFilterCacheKey({ senioritySlugs: ["senior", "junior"] }, []);
+    const b = buildFilterCacheKey({ senioritySlugs: ["junior", "senior"] }, []);
+    expect(a).toBe(b);
+  });
+
+  it("permutes technologySlugs to the same key", () => {
+    const a = buildFilterCacheKey({ technologySlugs: ["go", "rust"] }, []);
+    const b = buildFilterCacheKey({ technologySlugs: ["rust", "go"] }, []);
+    expect(a).toBe(b);
+  });
+
+  it("permutes workMode to the same key", () => {
+    const a = buildFilterCacheKey({ workMode: ["remote", "hybrid"] }, []);
+    const b = buildFilterCacheKey({ workMode: ["hybrid", "remote"] }, []);
+    expect(a).toBe(b);
+  });
+
+  it("permutes employmentType to the same key", () => {
+    const a = buildFilterCacheKey(
+      { employmentType: ["full_time", "contract"] },
+      [],
+    );
+    const b = buildFilterCacheKey(
+      { employmentType: ["contract", "full_time"] },
+      [],
+    );
+    expect(a).toBe(b);
+  });
+
+  // Accent / case sensitivity (the bug class from #3221 / #3276).
+  it("accent-folded keywords map to the same key as the base letter neighbour", () => {
+    // The regression: raw `.sort()` puts `"übung"` (U+00FC) after `"z"`
+    // in UTF-16 order, so `["python","übung","zoom"]` and any of its
+    // permutations produce different cache keys *after sorting*. With
+    // `canonicalStringCompare` (`sensitivity: "base"`), `"übung"` collates
+    // with the u-group, so every permutation collapses to the same key.
+    const orderings = [
+      ["python", "übung", "zoom"],
+      ["zoom", "python", "übung"],
+      ["übung", "zoom", "python"],
+      ["zoom", "übung", "python"],
+    ];
+    const keys = orderings.map((kw) => buildFilterCacheKey({ keywords: kw }, []));
+    expect(new Set(keys).size).toBe(1);
+  });
+
+  it("base-sensitivity case folding collates `Apple` next to `banana` (not between `b` and `c`)", () => {
+    // `sensitivity: "base"` folds case so `"Apple"` and `"apple"` are
+    // collation-equal. Sort *positions* are stable across case variants —
+    // both upper and lower forms place the `a`-group before `banana`. The
+    // strings themselves are unchanged (the comparator only reorders), so
+    // the literal cache key strings still differ — but every PERMUTATION
+    // of a same-case input collapses to one key.
+    const a = buildFilterCacheKey({ keywords: ["Apple", "banana"] }, []);
+    const b = buildFilterCacheKey({ keywords: ["banana", "Apple"] }, []);
+    expect(a).toBe(b);
+    const c = buildFilterCacheKey({ keywords: ["apple", "banana"] }, []);
+    const d = buildFilterCacheKey({ keywords: ["banana", "apple"] }, []);
+    expect(c).toBe(d);
+    // The two case variants share the same RELATIVE ordering (`a*` before
+    // `b*`), even though the surface strings differ.
+    expect(a.startsWith("kw:Apple")).toBe(true);
+    expect(c.startsWith("kw:apple")).toBe(true);
+  });
+
+  it("companyIds stay on raw sort (numeric-looking string IDs)", () => {
+    // Original issue carve-out: `companyIds` are numeric-looking strings.
+    // We don't expect accent permutations here, so the cheap raw sort is
+    // retained. Two permutations still collapse.
+    const a = buildFilterCacheKey({}, ["10", "2", "100"]);
+    const b = buildFilterCacheKey({}, ["100", "10", "2"]);
+    expect(a).toBe(b);
+  });
+
+  it("preserves the `anyCompany` and scalar fields verbatim", () => {
+    const key = buildFilterCacheKey(
+      {
+        anyCompany: true,
+        keywords: ["python"],
+        salaryMin: 100000,
+        salaryMax: 200000,
+        experienceMin: 3,
+        experienceMax: 10,
+      },
+      [],
+    );
+    expect(key).toContain("any");
+    expect(key).toContain("smin:100000");
+    expect(key).toContain("smax:200000");
+    expect(key).toContain("emin:3");
+    expect(key).toContain("emax:10");
+  });
+
+  it("empty filter produces an empty string", () => {
+    expect(buildFilterCacheKey({}, [])).toBe("");
   });
 });
 

--- a/apps/web/src/lib/actions/__tests__/resolve-slugs-canonical-sort.test.ts
+++ b/apps/web/src/lib/actions/__tests__/resolve-slugs-canonical-sort.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Regression tests for #3276 — `resolveLocationSlugs`,
+ * `resolveOccupationSlugs`, `resolveSenioritySlugs`,
+ * `resolveTechnologySlugs` previously called `[...slugs].sort()` before
+ * forwarding to a `'use cache'` inner. Bare `.sort()` uses UTF-16 code
+ * unit order, where `"ü"` (U+00FC) sorts *after* `"z"` — so two callers
+ * passing the same logical slug set in different orders hashed to
+ * different cache slots, splitting the cache for accented slugs.
+ *
+ * After the fix every site uses `canonicalStringCompare` (locale-
+ * independent `Intl.Collator("en", { sensitivity: "base" })`) so
+ * permutations collapse to the same slot.
+ *
+ * Strategy: mock the cache layer and `db.execute`, then verify that the
+ * SQL placeholder array passed to the cached inner is identical
+ * regardless of input permutation / case.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
+  // Captures the substituted SQL parameter values for the most recent
+  // `db.execute` call so each test can assert the array shape.
+  capturedSql: [] as unknown[][],
+  dbExecute: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/cache", () => ({
+  cacheLife: mocks.cacheLife,
+  cacheTag: mocks.cacheTag,
+}));
+vi.mock("@/lib/cache-tags", () => ({
+  typeaheadLocationsCacheTag: () => "typeahead:locations",
+  typeaheadOccupationsCacheTag: () => "typeahead:occupations",
+  typeaheadSenioritiesCacheTag: () => "typeahead:seniorities",
+  typeaheadTechnologiesCacheTag: () => "typeahead:technologies",
+}));
+vi.mock("@/lib/cache", () => ({
+  cached: vi.fn((_key: string, fn: () => unknown) => fn()),
+}));
+vi.mock("@/lib/cache-ttl", () => ({ CACHE_TTL_LONG: 3600 }));
+vi.mock("@/lib/db-retry", () => ({
+  withDbRetry: vi.fn((fn: () => Promise<unknown>) => fn()),
+}));
+vi.mock("@/lib/search/typesense-client", () => ({
+  getTypesenseClient: () => ({
+    collections: () => ({ documents: () => ({ search: vi.fn() }) }),
+  }),
+}));
+vi.mock("@/lib/search/typesense-filters", () => ({
+  buildFilterString: () => "",
+  POSTING_BASE_FILTER: "is_active:true",
+}));
+vi.mock("@/lib/search/typeahead-boost", () => ({
+  boostByFilterMatches: (xs: unknown) => xs,
+}));
+vi.mock("@/lib/search/canonicalize-filters", () => ({
+  canonicalizeFilters: (x: unknown) => x,
+}));
+vi.mock("@/lib/search/location-paging", () => ({
+  LOCATION_PAGE_SIZE: 20,
+}));
+vi.mock("@/db", () => ({ db: { execute: mocks.dbExecute } }));
+vi.mock("drizzle-orm", () => ({
+  // Snapshot the substituted values so each test can assert what got
+  // interpolated. `sortedSlugs.join(",")` flows in as a single string
+  // value through the `pgArray` template literal.
+  sql: (_strings: TemplateStringsArray, ...values: unknown[]) => {
+    mocks.capturedSql.push(values);
+    return { __sql: true } as unknown;
+  },
+}));
+
+import { resolveLocationSlugs } from "../locations";
+import {
+  resolveOccupationSlugs,
+  resolveSenioritySlugs,
+  resolveTechnologySlugs,
+} from "../taxonomy";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.capturedSql = [];
+  mocks.dbExecute.mockResolvedValue([]);
+});
+
+// Helpers ───────────────────────────────────────────────────────────
+
+// The `pgArray` literal sent through to Postgres is the substituted
+// value. `db.execute(sql\`... ${pgArray} ...\`)` records the values as
+// the first SQL invocation; the array is the only substitution.
+function lastPgArrayValue(): string {
+  // The last captured `sql\`\`` call is the one that ran inside the
+  // cached inner. The substituted values include the pgArray and
+  // (depending on the call) a locale string. We pluck the one that
+  // starts with `{` (pg-array literal).
+  const flat = mocks.capturedSql.flat();
+  const pg = flat.find((v) => typeof v === "string" && v.startsWith("{"));
+  return pg as string;
+}
+
+// ── resolveOccupationSlugs ──────────────────────────────────────────
+
+describe("resolveOccupationSlugs — canonical sort (#3276)", () => {
+  it("permutes input → same Postgres parameter array", async () => {
+    await resolveOccupationSlugs(["b-eng", "a-eng"], "en");
+    const first = lastPgArrayValue();
+    mocks.capturedSql = [];
+    await resolveOccupationSlugs(["a-eng", "b-eng"], "en");
+    const second = lastPgArrayValue();
+    expect(first).toBe(second);
+  });
+
+  it("case-folded `Apple` and `apple` produce the same canonical order", async () => {
+    // Base-sensitivity means `"Apple"` and `"apple"` collate to the
+    // same slot; the secondary identity comparator breaks the tie
+    // deterministically. We assert that two callers passing the same
+    // logical content (one upper, one lower) produce the same array
+    // shape modulo case.
+    await resolveOccupationSlugs(["Apple", "banana"], "en");
+    const upper = lastPgArrayValue();
+    mocks.capturedSql = [];
+    await resolveOccupationSlugs(["apple", "Banana"], "en");
+    const lower = lastPgArrayValue();
+    // The ordering matches: both place the a-group first.
+    const upperFirst = upper.slice(1).split(",")[0].toLowerCase();
+    const lowerFirst = lower.slice(1).split(",")[0].toLowerCase();
+    expect(upperFirst).toBe("apple");
+    expect(lowerFirst).toBe("apple");
+  });
+});
+
+// ── resolveSenioritySlugs ───────────────────────────────────────────
+
+describe("resolveSenioritySlugs — canonical sort (#3276)", () => {
+  it("permutes input → same Postgres parameter array", async () => {
+    await resolveSenioritySlugs(["senior", "junior"], "en");
+    const first = lastPgArrayValue();
+    mocks.capturedSql = [];
+    await resolveSenioritySlugs(["junior", "senior"], "en");
+    const second = lastPgArrayValue();
+    expect(first).toBe(second);
+  });
+});
+
+// ── resolveTechnologySlugs ──────────────────────────────────────────
+
+describe("resolveTechnologySlugs — canonical sort (#3276)", () => {
+  it("permutes input → same Postgres parameter array", async () => {
+    await resolveTechnologySlugs(["rust", "go"]);
+    const first = lastPgArrayValue();
+    mocks.capturedSql = [];
+    await resolveTechnologySlugs(["go", "rust"]);
+    const second = lastPgArrayValue();
+    expect(first).toBe(second);
+  });
+});
+
+// ── resolveLocationSlugs ────────────────────────────────────────────
+
+describe("resolveLocationSlugs — canonical sort (#3276)", () => {
+  it("permutes input → same Postgres parameter array", async () => {
+    await resolveLocationSlugs(["zurich", "berlin"], "en");
+    const first = lastPgArrayValue();
+    mocks.capturedSql = [];
+    await resolveLocationSlugs(["berlin", "zurich"], "en");
+    const second = lastPgArrayValue();
+    expect(first).toBe(second);
+  });
+
+  it("regression: accented slugs collapse via canonical (`zürich` next to `z`-group)", async () => {
+    // Bare `.sort()` would put `"zürich"` after `"zoom"` in UTF-16
+    // order. With `canonicalStringCompare`, the u-base of `ü` sorts
+    // before `o` — wait, actually the canonical collator is
+    // base-sensitivity in "en" locale. For German ä/ö/ü, the base is
+    // a/o/u, so `"zürich"` will sort by the `z` first letter. The key
+    // test is: input permutation collapses regardless.
+    await resolveLocationSlugs(["zürich", "berlin"], "en");
+    const first = lastPgArrayValue();
+    mocks.capturedSql = [];
+    await resolveLocationSlugs(["berlin", "zürich"], "en");
+    const second = lastPgArrayValue();
+    expect(first).toBe(second);
+  });
+});

--- a/apps/web/src/lib/actions/locations.ts
+++ b/apps/web/src/lib/actions/locations.ts
@@ -11,6 +11,7 @@ import { getTypesenseClient, type TypesenseHit } from "@/lib/search/typesense-cl
 import { buildFilterString, POSTING_BASE_FILTER } from "@/lib/search/typesense-filters";
 import { boostByFilterMatches, type TypeaheadBoostFilters } from "@/lib/search/typeahead-boost";
 import { canonicalizeFilters } from "@/lib/search/canonicalize-filters";
+import { canonicalStringCompare } from "@/lib/sort";
 import { LOCATION_PAGE_SIZE } from "@/lib/search/location-paging";
 
 export interface LocationSuggestion {
@@ -260,7 +261,11 @@ export async function resolveLocationSlugs(
   locale: string,
 ): Promise<Map<string, ResolvedLocation>> {
   if (slugs.length === 0) return new Map();
-  const sorted = [...slugs].sort();
+  // `canonicalStringCompare` instead of raw `.sort()` so accented slugs
+  // (e.g. `zürich`) don't fragment the `'use cache'` slot between callers
+  // passing the same logical input in different orders. See #3276
+  // (follow-up to #3221).
+  const sorted = [...slugs].sort(canonicalStringCompare);
   // Plain `Record` survives the `'use cache'` boundary; Map is not
   // serializable, so the wrapper converts at the edge for caller ergonomics.
   const record = await _resolveLocationSlugsCached(sorted, locale);

--- a/apps/web/src/lib/actions/search.ts
+++ b/apps/web/src/lib/actions/search.ts
@@ -10,6 +10,8 @@ import { CACHE_TTL_SHORT, CACHE_TTL_MEDIUM } from "@/lib/cache-ttl";
 import { withDbRetry } from "@/lib/db-retry";
 import { getSessionUserId } from "@/lib/sessionCache";
 import { ANON_MAX_COMPANIES, ANON_MAX_CARD_POSTINGS } from "@/lib/search/constants";
+import { canonicalStringCompare } from "@/lib/sort";
+import { normalizeHistogramFilters, type NormalizedHistogramFilters } from "@/lib/search/histogram-filters";
 
 // ── Posting detail ──────────────────────────────────────────────────
 
@@ -309,7 +311,12 @@ async function _listTopCompaniesImpl(
 
   // Cache the default homepage (no user-specified filters). Include languages
   // in the key since different locales produce different language filters.
-  const langKey = [...(params.languages ?? [])].sort().join(",");
+  // `canonicalStringCompare` (locale-independent `Intl.Collator("en", {
+  // sensitivity: "base" })`) avoids the UTF-16-code-unit-order bug class
+  // from #3221 — for ASCII locale codes the orders coincide today, but the
+  // canonical comparator is forwards-compatible if future locale codes
+  // carry accented chars and keeps every cache-key call-site on one rule.
+  const langKey = [...(params.languages ?? [])].sort(canonicalStringCompare).join(",");
   let result: SearchResponse;
   if (hasNoExplicitFilters) {
     result = await cached(
@@ -397,28 +404,9 @@ import type { SalaryBucket, ExperienceBucket } from "@/lib/search/types";
 // failure). Returns plain arrays of `{ bucket, count }` shapes (already
 // serializable; no Maps/Sets/Dates).
 
-interface NormalizedHistogramFilters {
-  companyId: string;
-  keywords: string[];
-  locationIds: number[];
-  occupationIds: number[];
-  seniorityIds: number[];
-  technologyIds: number[];
-  languages: string[];
-}
-
-function normalizeHistogramFilters(filters?: HistogramFilters): NormalizedHistogramFilters {
-  const f = filters ?? {};
-  return {
-    companyId: f.companyId ?? "",
-    keywords: [...(f.keywords ?? [])].sort(),
-    locationIds: [...(f.locationIds ?? [])].sort((a, b) => a - b),
-    occupationIds: [...(f.occupationIds ?? [])].sort((a, b) => a - b),
-    seniorityIds: [...(f.seniorityIds ?? [])].sort((a, b) => a - b),
-    technologyIds: [...(f.technologyIds ?? [])].sort((a, b) => a - b),
-    languages: [...(f.languages ?? [])].sort(),
-  };
-}
+// `normalizeHistogramFilters` + `NormalizedHistogramFilters` extracted to
+// `@/lib/search/histogram-filters` so the sync helper is unit-testable
+// without booting the `"use server"` module surface. See #3276.
 
 async function _fetchSalaryHistogram(f: NormalizedHistogramFilters): Promise<SalaryBucket[]> {
   "use cache";

--- a/apps/web/src/lib/actions/taxonomy.ts
+++ b/apps/web/src/lib/actions/taxonomy.ts
@@ -15,6 +15,7 @@ import { getTypesenseClient, type TypesenseHit } from "@/lib/search/typesense-cl
 import { buildFilterString, POSTING_BASE_FILTER } from "@/lib/search/typesense-filters";
 import { boostByFilterMatches, type TypeaheadBoostFilters } from "@/lib/search/typeahead-boost";
 import { canonicalizeFilters } from "@/lib/search/canonicalize-filters";
+import { canonicalStringCompare } from "@/lib/sort";
 
 export interface TaxonomySuggestion {
   id: number;
@@ -327,7 +328,11 @@ export async function resolveOccupationSlugs(
   locale: string,
 ): Promise<Map<string, TaxonomySuggestion>> {
   if (slugs.length === 0) return new Map();
-  const sorted = [...slugs].sort();
+  // `canonicalStringCompare` instead of raw `.sort()` so accented slugs
+  // (e.g. a locale where occupation slugs include `é`) don't fragment the
+  // `'use cache'` slot between callers passing the same logical input in
+  // different orders. See #3276 (follow-up to #3221).
+  const sorted = [...slugs].sort(canonicalStringCompare);
   const record = await _resolveOccupationSlugsCached(sorted, locale);
   return new Map(Object.entries(record));
 }
@@ -372,7 +377,8 @@ export async function resolveSenioritySlugs(
   locale: string,
 ): Promise<Map<string, TaxonomySuggestion>> {
   if (slugs.length === 0) return new Map();
-  const sorted = [...slugs].sort();
+  // See `resolveOccupationSlugs` for the canonicalization rationale.
+  const sorted = [...slugs].sort(canonicalStringCompare);
   const record = await _resolveSenioritySlugsCached(sorted, locale);
   return new Map(Object.entries(record));
 }
@@ -496,7 +502,8 @@ export async function resolveTechnologySlugs(
   slugs: string[],
 ): Promise<Map<string, TaxonomySuggestion>> {
   if (slugs.length === 0) return new Map();
-  const sorted = [...slugs].sort();
+  // See `resolveOccupationSlugs` for the canonicalization rationale.
+  const sorted = [...slugs].sort(canonicalStringCompare);
   const record = await _resolveTechnologySlugsCached(sorted);
   return new Map(Object.entries(record));
 }

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -34,7 +34,7 @@ import {
   deleteWatchlist as tsDeleteWatchlist,
   updateWatchlistField as tsUpdateWatchlistField,
 } from "@/lib/search/typesense-watchlist";
-import { isTrivialWatchlist } from "@/lib/watchlist-utils";
+import { isTrivialWatchlist, buildFilterCacheKey } from "@/lib/watchlist-utils";
 import { notifyIndexNow, logIndexNowResult } from "@/lib/indexnow";
 
 // ── Types ───────────────────────────────────────────────────────────
@@ -937,23 +937,10 @@ const nonTrivialWatchlistPredicate = sql`(
   OR (w.filters ? 'experienceMax')
 )`;
 
-function buildFilterCacheKey(f: WatchlistFilters, companyIds: string[]): string {
-  const parts: string[] = [];
-  if (f.anyCompany) parts.push("any");
-  if (companyIds.length) parts.push(`c:${[...companyIds].sort().join(",")}`);
-  if (f.keywords?.length) parts.push(`kw:${[...f.keywords].sort().join(",")}`);
-  if (f.locationSlugs?.length) parts.push(`loc:${[...f.locationSlugs].sort().join(",")}`);
-  if (f.occupationSlugs?.length) parts.push(`occ:${[...f.occupationSlugs].sort().join(",")}`);
-  if (f.senioritySlugs?.length) parts.push(`sen:${[...f.senioritySlugs].sort().join(",")}`);
-  if (f.technologySlugs?.length) parts.push(`tech:${[...f.technologySlugs].sort().join(",")}`);
-  if (f.workMode?.length) parts.push(`wm:${[...f.workMode].sort().join(",")}`);
-  if (f.employmentType?.length) parts.push(`et:${[...f.employmentType].sort().join(",")}`);
-  if (f.salaryMin != null) parts.push(`smin:${f.salaryMin}`);
-  if (f.salaryMax != null) parts.push(`smax:${f.salaryMax}`);
-  if (f.experienceMin != null) parts.push(`emin:${f.experienceMin}`);
-  if (f.experienceMax != null) parts.push(`emax:${f.experienceMax}`);
-  return parts.join("|");
-}
+// `buildFilterCacheKey` lives in `@/lib/watchlist-utils` so it can be unit
+// tested without booting the `"use server"` module surface — `"use server"`
+// modules may only export async functions, which rules out exporting the
+// sync helper directly. See #3276 (follow-up to #3221).
 
 /**
  * Count distinct companies with currently-active postings matching the given

--- a/apps/web/src/lib/search/__tests__/histogram-filters.test.ts
+++ b/apps/web/src/lib/search/__tests__/histogram-filters.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { normalizeHistogramFilters } from "../histogram-filters";
+
+describe("normalizeHistogramFilters — stable `'use cache'` keys (#3276)", () => {
+  // The salary / experience histogram cache slot is keyed off the
+  // normalized filter shape. Same logical filter, different input
+  // ordering → must collapse to one slot, or the `'use cache'` boundary
+  // splits into n! permutations and the cache miss-rate collapses.
+
+  it("permutes keywords to the same cache shape", () => {
+    const ab = normalizeHistogramFilters({ keywords: ["python", "go"] });
+    const ba = normalizeHistogramFilters({ keywords: ["go", "python"] });
+    expect(JSON.stringify(ab)).toBe(JSON.stringify(ba));
+  });
+
+  it("regression: accented keywords no longer split the cache slot", () => {
+    // Bare `.sort()` puts `"übung"` after `"z"` in UTF-16 order. With
+    // `canonicalStringCompare`, the u-group collates next to itself, so
+    // every permutation collapses.
+    const a = normalizeHistogramFilters({ keywords: ["python", "übung", "zoom"] });
+    const b = normalizeHistogramFilters({ keywords: ["übung", "zoom", "python"] });
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it("base-sensitivity preserves relative ordering across case variants", () => {
+    // `sensitivity: "base"` collates `"Apple"` and `"apple"` as equal; the
+    // comparator just reorders, so the surface strings keep their case.
+    // Within a single case, every permutation collapses to one shape.
+    const upperA = normalizeHistogramFilters({ keywords: ["Apple", "banana"] });
+    const upperB = normalizeHistogramFilters({ keywords: ["banana", "Apple"] });
+    expect(JSON.stringify(upperA)).toBe(JSON.stringify(upperB));
+    const lowerA = normalizeHistogramFilters({ keywords: ["apple", "banana"] });
+    const lowerB = normalizeHistogramFilters({ keywords: ["banana", "apple"] });
+    expect(JSON.stringify(lowerA)).toBe(JSON.stringify(lowerB));
+    // The a-group sorts before the b-group regardless of case.
+    expect(upperA.keywords[0]).toBe("Apple");
+    expect(lowerA.keywords[0]).toBe("apple");
+  });
+
+  it("permutes languages to the same shape", () => {
+    const a = normalizeHistogramFilters({ languages: ["de", "en", "fr"] });
+    const b = normalizeHistogramFilters({ languages: ["fr", "de", "en"] });
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it("sorts numeric ID arrays numerically — no string coercion", () => {
+    // Bare `.sort()` coerces to string and would produce `[10, 2]`. The
+    // canonicalizer sorts as numbers: `[2, 10]`.
+    const out = normalizeHistogramFilters({ locationIds: [10, 2, 100, 1] });
+    expect(out.locationIds).toEqual([1, 2, 10, 100]);
+  });
+
+  it.each([
+    ["locationIds"],
+    ["occupationIds"],
+    ["seniorityIds"],
+    ["technologyIds"],
+  ] as const)("permutes %s to the same shape", (field) => {
+    const a = normalizeHistogramFilters({ [field]: [42, 7, 13] } as Record<string, number[]>);
+    const b = normalizeHistogramFilters({ [field]: [7, 13, 42] } as Record<string, number[]>);
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it("preserves the full normalized shape for empty input", () => {
+    const out = normalizeHistogramFilters();
+    expect(out).toEqual({
+      companyId: "",
+      keywords: [],
+      locationIds: [],
+      occupationIds: [],
+      seniorityIds: [],
+      technologyIds: [],
+      languages: [],
+    });
+  });
+
+  it("collapses combined permutations across every dimension", () => {
+    const a = normalizeHistogramFilters({
+      companyId: "acme",
+      keywords: ["zoom", "apple"],
+      locationIds: [42, 7],
+      occupationIds: [3, 1],
+      seniorityIds: [5, 2],
+      technologyIds: [10, 4],
+      languages: ["fr", "de"],
+    });
+    const b = normalizeHistogramFilters({
+      languages: ["de", "fr"],
+      technologyIds: [4, 10],
+      seniorityIds: [2, 5],
+      occupationIds: [1, 3],
+      locationIds: [7, 42],
+      keywords: ["apple", "zoom"],
+      companyId: "acme",
+    });
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+});

--- a/apps/web/src/lib/search/__tests__/location-prefetch.test.ts
+++ b/apps/web/src/lib/search/__tests__/location-prefetch.test.ts
@@ -87,6 +87,61 @@ describe("location-prefetch (#3031)", () => {
     expect(fetcher).toHaveBeenCalledTimes(1);
   });
 
+  // #3276 — keyword arrays sort with `canonicalStringCompare`, so accent
+  // permutations and case differences collapse to one cache slot. Numeric
+  // ID arrays sort numerically.
+  it("collapses accented keyword permutations onto the same cache key", async () => {
+    const fetcher = vi.fn(async () => _page({ totalCountries: 42 }));
+    await prefetchLocationsFirstPage(
+      "en",
+      { keywords: ["python", "übung", "zoom"] },
+      fetcher,
+    );
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    await prefetchLocationsFirstPage(
+      "en",
+      { keywords: ["zoom", "python", "übung"] },
+      fetcher,
+    );
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    await prefetchLocationsFirstPage(
+      "en",
+      { keywords: ["übung", "zoom", "python"] },
+      fetcher,
+    );
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("base-sensitivity preserves the slot under permutation of mixed-case inputs", async () => {
+    // The comparator collates `"Apple"` and `"apple"` as equal but does
+    // not rewrite the strings; surface text is preserved. Within a
+    // single-case input, every permutation hits the same slot.
+    const fetcher = vi.fn(async () => _page({ totalCountries: 1 }));
+    await prefetchLocationsFirstPage("en", { keywords: ["Apple", "banana"] }, fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    await prefetchLocationsFirstPage("en", { keywords: ["banana", "Apple"] }, fetcher);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("sorts numeric ID arrays numerically — `[10, 2]` and `[2, 10]` share a slot", async () => {
+    // Bare `.sort()` stringifies, so `[10, 2]` would canonicalize to
+    // `[10, 2]` not `[2, 10]`. Two callers passing the same logical
+    // numeric input in different orders must hit the same slot.
+    const fetcher = vi.fn(async () => _page({ totalCountries: 1 }));
+    await prefetchLocationsFirstPage(
+      "en",
+      { occupationIds: [10, 2] },
+      fetcher,
+    );
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    await prefetchLocationsFirstPage(
+      "en",
+      { occupationIds: [2, 10] },
+      fetcher,
+    );
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
   it("treats different filter shapes as different cache keys", async () => {
     const fetcher = vi.fn(async (_locale: string, _cursor: number, filters: unknown) => {
       const total = (filters as { keywords?: string[] } | undefined)?.keywords?.length ?? 0;

--- a/apps/web/src/lib/search/histogram-filters.ts
+++ b/apps/web/src/lib/search/histogram-filters.ts
@@ -1,0 +1,45 @@
+import type { HistogramFilters } from "@/lib/search/types";
+import { canonicalizeFilters } from "@/lib/search/canonicalize-filters";
+
+/**
+ * Shape produced by {@link normalizeHistogramFilters}. Each field is
+ * required (sentinel `""` / `[]` for missing inputs) so the `'use cache'`
+ * boundary in `_fetchSalaryHistogram` / `_fetchExperienceHistogram` keys
+ * off a stable object shape instead of a "field present" / "field
+ * undefined" discriminator.
+ */
+export interface NormalizedHistogramFilters {
+  companyId: string;
+  keywords: string[];
+  locationIds: number[];
+  occupationIds: number[];
+  seniorityIds: number[];
+  technologyIds: number[];
+  languages: string[];
+}
+
+/**
+ * Normalize a {@link HistogramFilters} into a stable cache-key shape for
+ * the salary / experience histogram `'use cache'` boundaries. Delegates
+ * the per-field sort to {@link canonicalizeFilters} so every cache-key
+ * site in the app stays on one canonicalization rule
+ * (locale-independent `Intl.Collator("en", { sensitivity: "base" })` for
+ * strings; numeric comparator for numeric IDs). See #3276 (follow-up to
+ * #3221/#3187).
+ *
+ * Lives in a sibling module (not in `actions/search.ts`) because
+ * `"use server"` modules may only export async functions — the sync
+ * helper must be importable by both the action file and its unit tests.
+ */
+export function normalizeHistogramFilters(filters?: HistogramFilters): NormalizedHistogramFilters {
+  const f = filters ?? {};
+  return canonicalizeFilters({
+    companyId: f.companyId ?? "",
+    keywords: f.keywords ?? [],
+    locationIds: f.locationIds ?? [],
+    occupationIds: f.occupationIds ?? [],
+    seniorityIds: f.seniorityIds ?? [],
+    technologyIds: f.technologyIds ?? [],
+    languages: f.languages ?? [],
+  }) as NormalizedHistogramFilters;
+}

--- a/apps/web/src/lib/search/location-prefetch.ts
+++ b/apps/web/src/lib/search/location-prefetch.ts
@@ -30,6 +30,7 @@
  */
 
 import type { GlobalLocationsPage } from "@/lib/actions/locations";
+import { canonicalStringCompare } from "@/lib/sort";
 
 /** Filter shape mirrors `LocationSearchModalProps['filters']`. */
 export type LocationModalFilters = {
@@ -73,6 +74,22 @@ type CacheEntry = ResolvedEntry | InflightEntry;
 
 const _cache = new Map<string, CacheEntry>();
 
+// Field-level canonicalization rule per name. Keeps the per-field sort in
+// one place so we don't have to inline a per-array `typeof` discriminator
+// in `_stableFilterKey`. String fields get `canonicalStringCompare`
+// (locale-independent `Intl.Collator("en", { sensitivity: "base" })`) so
+// accented values collate next to their base letter — `["a","übung"]` and
+// `["übung","a"]` collapse to the same key. Numeric fields sort
+// numerically so `[10,2]` doesn't string-coerce to `["10","2"]`. See
+// #3276 (follow-up to #3221/#3187).
+const _ARRAY_SORTERS: Record<string, ((a: unknown, b: unknown) => number) | undefined> = {
+  keywords: (a, b) => canonicalStringCompare(a as string, b as string),
+  languages: (a, b) => canonicalStringCompare(a as string, b as string),
+  occupationIds: (a, b) => (a as number) - (b as number),
+  seniorityIds: (a, b) => (a as number) - (b as number),
+  technologyIds: (a, b) => (a as number) - (b as number),
+};
+
 function _stableFilterKey(filters: LocationModalFilters | undefined): string {
   if (!filters) return "";
   // Sort keys so two callers passing the same logical filter with
@@ -83,8 +100,16 @@ function _stableFilterKey(filters: LocationModalFilters | undefined): string {
     const v = filters[k];
     if (v === undefined || v === null) continue;
     if (Array.isArray(v) && v.length === 0) continue;
-    // Sort array values too — e.g. [1,2] and [2,1] should share a slot.
-    normalized[k] = Array.isArray(v) ? [...v].sort() : v;
+    if (Array.isArray(v)) {
+      const cmp = _ARRAY_SORTERS[k];
+      // Field-aware sort: strings via `canonicalStringCompare`, numeric
+      // IDs numerically. Falls back to raw `.sort()` only for unknown
+      // fields, which the static type rules out today but defends against
+      // future field additions silently re-introducing the bug.
+      normalized[k] = cmp ? [...v].sort(cmp as (a: unknown, b: unknown) => number) : [...v].sort();
+    } else {
+      normalized[k] = v;
+    }
   }
   return JSON.stringify(normalized);
 }

--- a/apps/web/src/lib/watchlist-utils.ts
+++ b/apps/web/src/lib/watchlist-utils.ts
@@ -1,4 +1,5 @@
 import type { WatchlistFilters } from "@/lib/actions/watchlists";
+import { canonicalStringCompare } from "@/lib/sort";
 
 
 // A watchlist is "trivial" when it carries no meaningful filters and tracks
@@ -76,4 +77,41 @@ export function isQualifyingWatchlist(args: {
     (f.senioritySlugs?.length ?? 0) +
     (f.technologySlugs?.length ?? 0);
   return taxonomyCount >= 2;
+}
+
+/**
+ * Build the cache-key fragment used by `getWatchlistMatchingCompanyCount`
+ * (and friends) keyed off a watchlist's filter set.
+ *
+ * Slug-bearing dimensions sort with `canonicalStringCompare`
+ * (locale-independent `Intl.Collator("en", { sensitivity: "base" })`) so
+ * accented keywords / slugs (e.g. `"übung"`) collapse onto the same cache
+ * slot as their permutation siblings. Bare `.sort()` uses UTF-16 code unit
+ * order, where `"ü"` (U+00FC) sorts after `"z"` (U+007A) — that splits the
+ * cache for the same logical filter set. See #3276 (follow-up to #3221).
+ *
+ * `companyIds` are numeric-looking strings (no accents), so raw `.sort()`
+ * is fine and keeps the legacy lexicographic ordering — the same caveat
+ * noted in the original issue.
+ *
+ * Lives here (not in `actions/watchlists.ts`) because `"use server"`
+ * modules can only export async functions; co-located unit tests need a
+ * sync import. The action file re-uses this helper internally.
+ */
+export function buildFilterCacheKey(f: WatchlistFilters, companyIds: string[]): string {
+  const parts: string[] = [];
+  if (f.anyCompany) parts.push("any");
+  if (companyIds.length) parts.push(`c:${[...companyIds].sort().join(",")}`);
+  if (f.keywords?.length) parts.push(`kw:${[...f.keywords].sort(canonicalStringCompare).join(",")}`);
+  if (f.locationSlugs?.length) parts.push(`loc:${[...f.locationSlugs].sort(canonicalStringCompare).join(",")}`);
+  if (f.occupationSlugs?.length) parts.push(`occ:${[...f.occupationSlugs].sort(canonicalStringCompare).join(",")}`);
+  if (f.senioritySlugs?.length) parts.push(`sen:${[...f.senioritySlugs].sort(canonicalStringCompare).join(",")}`);
+  if (f.technologySlugs?.length) parts.push(`tech:${[...f.technologySlugs].sort(canonicalStringCompare).join(",")}`);
+  if (f.workMode?.length) parts.push(`wm:${[...f.workMode].sort(canonicalStringCompare).join(",")}`);
+  if (f.employmentType?.length) parts.push(`et:${[...f.employmentType].sort(canonicalStringCompare).join(",")}`);
+  if (f.salaryMin != null) parts.push(`smin:${f.salaryMin}`);
+  if (f.salaryMax != null) parts.push(`smax:${f.salaryMax}`);
+  if (f.experienceMin != null) parts.push(`emin:${f.experienceMin}`);
+  if (f.experienceMax != null) parts.push(`emax:${f.experienceMax}`);
+  return parts.join("|");
 }


### PR DESCRIPTION
## Summary

Sweep replaces raw `.sort()` on string arrays with `canonicalStringCompare` (locale-independent `Intl.Collator("en", { sensitivity: "base" })`) and raw `.sort()` on number arrays with `(a, b) => a - b` at every remaining cache-key site that inherited the #3221 bug class. Companion to #3221 (the original locale-aware sort fix narrowed to 6 sites) and #3187 (the `canonicalizeFilters` helper used by another batch). Closes #3276.

### Sites fixed

- `apps/web/src/lib/actions/watchlists.ts:buildFilterCacheKey` — the explicit deferral filed in #3276. Extracted into `@/lib/watchlist-utils.ts` so the sync helper is unit-testable (the `"use server"` module surface only exports async functions). `companyIds` keep raw `.sort()` per the issue carve-out (numeric-looking string IDs, no accents).
- `apps/web/src/lib/actions/search.ts` — `normalizeHistogramFilters` (feeds the `_fetchSalaryHistogram` / `_fetchExperienceHistogram` `'use cache'` boundaries) and the `langKey` for the homepage `top-companies` Redis slot. `normalizeHistogramFilters` extracted into `@/lib/search/histogram-filters.ts` and routed through the existing `canonicalizeFilters` helper.
- `apps/web/src/lib/actions/taxonomy.ts` — `resolveOccupationSlugs`, `resolveSenioritySlugs`, `resolveTechnologySlugs`.
- `apps/web/src/lib/actions/locations.ts` — `resolveLocationSlugs`.
- `apps/web/src/components/SearchStateProvider.tsx:buildCacheKey` — keyword strings + every numeric ID array (the previous code silently coerced IDs to strings, so `[10, 2]` and `[2, 10]` hit different slots).
- `apps/web/src/lib/search/location-prefetch.ts:_stableFilterKey` — per-field sorter map: `canonicalStringCompare` for string fields, numeric comparator for `*Ids` fields.

### Cache invalidation impact

All affected slots are ephemeral — Redis TTL on `top-companies` and `wl-match-companies`, `'use cache'` (cacheLife `hours`/`days`) on `normalizeHistogramFilters` / resolveXxxSlugs, and an in-process client `Map` for `location-prefetch`. No persistent hash invalidation; cache miss-rate improves immediately at the merge boundary.

### Tests added

- `apps/web/src/lib/__tests__/watchlist-utils.test.ts` — `buildFilterCacheKey` permutation tests on each slug-bearing dimension + accent + case-sensitivity collation.
- `apps/web/src/lib/search/__tests__/histogram-filters.test.ts` (new) — `normalizeHistogramFilters` permutation + accent tests, plus the numeric ID sort regression.
- `apps/web/src/lib/actions/__tests__/resolve-slugs-canonical-sort.test.ts` (new) — verifies that `resolve{Occupation,Seniority,Technology,Location}Slugs` forward the canonically-sorted slug array to Postgres regardless of input ordering.
- `apps/web/src/components/__tests__/SearchStateProvider.test.tsx` — `buildCacheKey` accent + numeric-ID regression tests.
- `apps/web/src/lib/search/__tests__/location-prefetch.test.ts` — accent + case + numeric-ID cache-slot tests.

### Scope hygiene

Per #3276's "ONLY the sites listed" instruction: a `git grep '.sort()'` sweep across `apps/web/src/` shows no other cache-key sites that weren't already covered by #3221 / #3187. No 7th occurrence found.

## Test plan

- [x] `pnpm test` — 1161/1161 passing across 125 files
- [x] `pnpm exec tsc --noEmit` — clean
- [ ] CI green

Generated with [Claude Code](https://claude.com/claude-code)