### PR TITLE
fix(web): prevent watchlist scroll jitter via reserved-space placeholders (closes #3345)

### DIFF
--- a/apps/web/src/components/search/__tests__/company-card-scroll-stability.test.tsx
+++ b/apps/web/src/components/search/__tests__/company-card-scroll-stability.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Regression tests for issue #3345 — preventing scroll jitter in the
+ * CompanyCard posting list (mirrors the watchlist-job-list fix).
+ *
+ * The CompanyCard renders its posting list inside a local ScrollFade
+ * scroll container, so it does NOT need the wider `overflow-anchor:
+ * none` opt-out that the watchlist surface uses. But each posting row
+ * needs the same defensive height + layout-containment so a re-render
+ * cannot push neighbouring rows around.
+ *
+ *   - `min-h-7` (= 28px) reserves the row's natural height.
+ *   - `[contain:layout]` isolates layout calculations per row.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render } from "@testing-library/react";
+import "@/test-utils/lingui-mock";
+
+// --- Mocks (mirror company-card-nested-buttons.test.tsx) -------------------
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ lang: "en" }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, prefetch: _prefetch, ...props }: Record<string, unknown>) => (
+    <a href={href as string} {...props}>{children as React.ReactNode}</a>
+  ),
+}));
+
+vi.mock("@/components/CompanyIcon", () => ({
+  CompanyIcon: ({ alt }: { alt: string }) => <span data-testid="company-icon">{alt}</span>,
+}));
+
+vi.mock("@/components/InfiniteScrollSentinel", () => ({
+  InfiniteScrollSentinel: () => null,
+}));
+
+vi.mock("@/components/TruncationPrompt", () => ({
+  TruncationPrompt: () => null,
+}));
+
+vi.mock("@/components/TrackingDot", () => ({
+  TrackingDot: () => <span data-testid="tracking-dot" />,
+}));
+
+vi.mock("@/components/PendingJobWarning", () => ({
+  PendingJobIcon: () => <span data-testid="pending-job-icon" />,
+}));
+
+vi.mock("@/components/search/save-button", () => ({
+  SaveButton: ({ postingId }: { postingId: string }) => (
+    <button type="button" aria-label={`Save job ${postingId}`}>save</button>
+  ),
+}));
+
+vi.mock("@/components/search/star-button", () => ({
+  StarButton: () => null,
+}));
+
+vi.mock("@/components/ui/scroll-fade", () => ({
+  ScrollFade: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/use-infinite-scroll", () => ({
+  useInfiniteScroll: () => ({ sentinelRef: { current: null }, isLoading: false }),
+}));
+
+vi.mock("@/lib/actions/search", () => ({
+  loadMorePostings: vi.fn(),
+}));
+
+vi.mock("@/lib/time", () => ({
+  timeAgoShort: () => "1d",
+}));
+
+vi.mock("@/lib/search/query-params", () => ({
+  buildFilteredPath: () => "/en/company/acme",
+}));
+
+// Import AFTER mocks.
+import { CompanyCard } from "../company-card";
+import type { SearchResultCompany } from "@/lib/search";
+
+function makeResult(): SearchResultCompany {
+  return {
+    company: { id: "c1", name: "ACME", slug: "acme", icon: null },
+    activeMatches: 2,
+    yearMatches: 2,
+    postings: [
+      {
+        id: "p1",
+        title: "Senior Engineer",
+        firstSeenAt: "2026-05-01T00:00:00Z",
+        relevanceScore: 1,
+        locations: [],
+        isActive: true,
+      },
+      {
+        id: "p2",
+        title: "Junior Engineer",
+        firstSeenAt: "2026-05-02T00:00:00Z",
+        relevanceScore: 1,
+        locations: [],
+        isActive: true,
+      },
+    ],
+  };
+}
+
+describe("CompanyCard — scroll stability (issue #3345)", () => {
+  it("each posting row reserves vertical space with `min-h-7` and `contain: layout`", () => {
+    const { container } = render(
+      <CompanyCard
+        result={makeResult()}
+        keywords={[]}
+        locationIds={[]}
+        locations={[]}
+        occupations={[]}
+        seniorities={[]}
+        technologies={[]}
+        employmentTypes={[]}
+        workMode={[]}
+        languages={["en"]}
+        onShowPosting={vi.fn()}
+        selectedPostingId={null}
+      />,
+    );
+
+    // Two postings → two rows. Each row carries both `min-h-7` (locks
+    // vertical extent at the current 28px natural height) and
+    // `[contain:layout]` (Tailwind arbitrary syntax compiles to
+    // `contain: layout`).
+    const rows = container.querySelectorAll('div.relative.flex.min-h-7.\\[contain\\:layout\\]');
+    expect(
+      rows.length,
+      "every CompanyCard posting row must carry `min-h-7` and `[contain:layout]` to prevent scroll jitter",
+    ).toBe(2);
+  });
+});

--- a/apps/web/src/components/search/company-card.tsx
+++ b/apps/web/src/components/search/company-card.tsx
@@ -135,9 +135,14 @@ function CompanyCardImpl({ result, keywords, locationIds, locations, occupations
           // button is a positioned overlay covering the row's click area;
           // SaveButton sits in normal flex flow with `relative z-10` so
           // it stacks above the overlay and stays keyboard-reachable.
+          // `min-h-7` (= 28px = current natural row height with py-1.5
+          // + 14px text) locks vertical extent so the row can never cause
+          // a layout shift inside the inner scroll container (closes
+          // #3345). `[contain:layout]` isolates per-row layout so a
+          // re-render of one row cannot reflow neighbouring rows.
           <div
             key={posting.id}
-            className={`relative flex items-center gap-2 rounded px-1 py-1.5 transition-colors ${posting.id === selectedPostingId ? "bg-primary/10" : "hover:bg-border-soft"} ${posting.isActive === false ? "opacity-50" : ""}`}
+            className={`relative flex min-h-7 items-center gap-2 rounded px-1 py-1.5 transition-colors [contain:layout] ${posting.id === selectedPostingId ? "bg-primary/10" : "hover:bg-border-soft"} ${posting.isActive === false ? "opacity-50" : ""}`}
           >
             <button
               type="button"

--- a/apps/web/src/components/watchlist/__tests__/watchlist-job-list-scroll-stability.test.tsx
+++ b/apps/web/src/components/watchlist/__tests__/watchlist-job-list-scroll-stability.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * Regression tests for issue #3345 — watchlist job cards jump up and
+ * down on scroll.
+ *
+ * The user-reported jitter was tracked to the browser's automatic scroll
+ * anchoring picking arbitrary row elements as anchors during pagination,
+ * plus the risk of content-driven height variation in date dividers and
+ * postings rows. The fix:
+ *
+ *   1. The postings list container opts the whole subtree out of scroll
+ *      anchoring with `[overflow-anchor:none]` — no element in the list
+ *      can be picked by the anchoring heuristic mid-scroll.
+ *   2. Each posting row carries an explicit `min-h-10` (= 40px, the
+ *      current natural height) and `[contain:layout]` so per-row
+ *      reflows can't propagate.
+ *   3. Each date divider carries `min-h-7` (= 28px, the divider's
+ *      current natural height with `py-2 + ~12px text`).
+ *
+ * These tests assert the class hooks are present so the fix can't
+ * silently regress.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render } from "@testing-library/react";
+import "@/test-utils/lingui-mock";
+
+// --- Mocks ------------------------------------------------------------------
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/components/CompanyIcon", () => ({
+  CompanyIcon: ({ alt }: { alt: string }) => <span data-testid="company-icon">{alt}</span>,
+}));
+
+vi.mock("@/lib/time", () => ({
+  timeAgoShort: () => "1d",
+}));
+
+vi.mock("@/lib/search/search-runner", () => ({
+  runGetWatchlistPostings: vi.fn().mockResolvedValue({
+    postings: [],
+    total: 0,
+  }),
+}));
+
+vi.mock("@/lib/search/use-clear-typesense-on-auth-change", () => ({
+  useClearTypesenseOnAuthChange: () => {},
+}));
+
+vi.mock("@/components/SessionProvider", () => ({
+  useSession: () => ({ isLoggedIn: true, isPending: false }),
+}));
+vi.mock("@/components/SavedJobsProvider", () => ({
+  useSavedJobs: () => ({
+    isSaved: () => false,
+    toggle: () => {},
+    isToggling: () => false,
+    getStatus: () => null,
+    getSavedJobId: () => null,
+    setStatus: () => {},
+    onStatusChange: () => () => {},
+  }),
+}));
+
+vi.mock("@/components/search/job-detail-dialog", () => ({
+  JobDetailPanel: () => <div data-testid="job-detail-panel" />,
+}));
+
+vi.mock("@/lib/use-infinite-scroll", () => ({
+  useInfiniteScroll: () => ({ sentinelRef: { current: null }, isLoading: false }),
+}));
+
+vi.mock("@/lib/use-paginated-load-more", () => ({
+  usePaginatedLoadMore: ({
+    initialItems,
+    initialTotal,
+  }: {
+    initialItems: unknown[];
+    initialTotal: number;
+  }) => ({
+    items: initialItems,
+    total: initialTotal,
+    truncated: false,
+    hasMore: false,
+    loadMore: () => {},
+  }),
+}));
+
+vi.mock("@/components/InfiniteScrollSentinel", () => ({
+  InfiniteScrollSentinel: () => null,
+}));
+
+vi.mock("@/components/TruncationPrompt", () => ({
+  TruncationPrompt: () => null,
+}));
+
+vi.mock("@/components/TrackingDot", () => ({
+  TrackingDot: () => <span data-testid="tracking-dot" />,
+}));
+
+vi.mock("@/components/PendingJobWarning", () => ({
+  PendingJobIcon: () => <span data-testid="pending-job-icon" />,
+}));
+
+vi.mock("@/components/search/language-stats-row", () => ({
+  LanguageStatsRow: () => null,
+}));
+
+vi.mock("@/components/watchlist/format-date-divider", () => ({
+  formatDateDivider: () => "Today",
+  getDateKey: (s: string) => s,
+}));
+
+beforeEach(() => {
+  /* nothing */
+});
+
+// Import AFTER mocks so vi.mock hoisting is honored.
+import { WatchlistJobList } from "../watchlist-job-list";
+import type { WatchlistPostingEntry } from "@/lib/actions/watchlists";
+
+function entry(
+  id: string,
+  title: string | null = `Job ${id}`,
+  firstSeenAt = "2026-05-13T00:00:00Z",
+): WatchlistPostingEntry {
+  return {
+    id,
+    title,
+    sourceUrl: `https://example.com/${id}`,
+    firstSeenAt,
+    isActive: true,
+    company: {
+      id: `c-${id}`,
+      name: `Company ${id}`,
+      slug: `company-${id}`,
+      icon: null,
+    },
+  };
+}
+
+function renderList(postings: WatchlistPostingEntry[]) {
+  return render(
+    <WatchlistJobList
+      filters={{ companyIds: ["c-1"] }}
+      initialPostings={postings}
+      initialTotal={postings.length}
+      yearTotal={postings.length}
+      jobLanguages={["en"]}
+      locale="en"
+    />,
+  );
+}
+
+describe("WatchlistJobList — scroll stability (issue #3345)", () => {
+  it("the postings list container has `overflow-anchor: none`", () => {
+    const { container } = renderList([entry("1"), entry("2")]);
+
+    // The container must opt the whole list subtree out of the browser's
+    // automatic scroll-anchor selection. Without this, the anchoring
+    // heuristic can pick a row near the viewport edge during pagination
+    // and adjust scroll position, producing the user-visible jitter.
+    const anchored = container.querySelector("div.\\[overflow-anchor\\:none\\]");
+    expect(
+      anchored,
+      "list container must carry `[overflow-anchor:none]` so the anchoring heuristic cannot pick a row mid-scroll",
+    ).not.toBeNull();
+  });
+
+  it("each posting row reserves vertical space with `min-h-10`", () => {
+    const { container } = renderList([entry("1"), entry("2")]);
+
+    // Posting rows are the `<div>`s that contain the `Open job posting`
+    // / `Company X — Job X` button (the absolute overlay).
+    const rows = container.querySelectorAll("div.relative.flex.min-h-10");
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("each posting row isolates its layout with `contain: layout`", () => {
+    const { container } = renderList([entry("1"), entry("2")]);
+
+    // `[contain:layout]` prevents a re-render of one row from triggering
+    // a reflow of neighbouring rows. The Tailwind arbitrary-property
+    // class compiles to `contain: layout`.
+    const rows = container.querySelectorAll('div.\\[contain\\:layout\\]');
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("the date divider reserves vertical space with `min-h-7`", () => {
+    // Two postings from different days → one divider between them. The
+    // first entry's date is the same as the second's → only one divider
+    // at the top (today). To be safe we use two distinct dates.
+    const { container } = renderList([
+      entry("1", "Job 1", "2026-05-13T00:00:00Z"),
+      entry("2", "Job 2", "2026-05-12T00:00:00Z"),
+    ]);
+
+    const dividers = container.querySelectorAll("div.flex.min-h-7");
+    expect(
+      dividers.length,
+      "date dividers must carry `min-h-7` so a re-render cannot collapse their height",
+    ).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/web/src/components/watchlist/watchlist-job-list.tsx
+++ b/apps/web/src/components/watchlist/watchlist-job-list.tsx
@@ -120,10 +120,13 @@ export function WatchlistJobList({
     if (dateKey !== lastDateKey && !seenDividers.has(dateKey)) {
       lastDateKey = dateKey;
       seenDividers.add(dateKey);
+      // `min-h-7` (= 28px = the divider's natural rendered height with
+      // py-2 + ~12px text) locks vertical extent so the divider can never
+      // cause a layout shift during scroll (closes #3345).
       rows.push(
         <div
           key={`d-${dateKey}`}
-          className="flex items-center gap-3 px-2 py-2"
+          className="flex min-h-7 items-center gap-3 px-2 py-2"
           suppressHydrationWarning
         >
           <div className="h-px flex-1 bg-divider" />
@@ -143,9 +146,14 @@ export function WatchlistJobList({
     // first, then save (DOM order). No `e.stopPropagation()` needed —
     // the buttons are siblings, not nested.
     rows.push(
+      // `min-h-10` (= 40px = current natural row height) locks vertical
+      // extent so any rounding / content-driven variation never causes a
+      // layout shift during scroll or pagination (closes #3345).
+      // `[contain:layout]` isolates per-row layout calculations so a
+      // re-render of one row cannot reflow neighbouring rows.
       <div
         key={entry.id}
-        className={`relative flex w-full items-center gap-3 rounded-md px-2 py-2 text-left transition-colors hover:bg-border-soft ${
+        className={`relative flex min-h-10 w-full items-center gap-3 rounded-md px-2 py-2 text-left transition-colors [contain:layout] hover:bg-border-soft ${
           showPostingId === entry.id ? "bg-border-soft" : ""
         }`}
       >
@@ -222,7 +230,16 @@ export function WatchlistJobList({
         activeCount={total}
         yearCount={yearTotal}
       />
-      <div>
+      {/* `[overflow-anchor:none]` opts the whole postings list out of the
+          browser's automatic scroll-anchor selection. Without it, when
+          pagination appends new rows the anchoring heuristic can pick a
+          row near the viewport edge and adjust scroll position by a few
+          pixels, which the user perceives as cards "jumping up and down"
+          (closes #3345). The sentinel inside `InfiniteScrollSentinel`
+          already opts out for itself; this widens the opt-out to every
+          row + date divider so no element in the subtree can be picked
+          mid-scroll. */}
+      <div className="[overflow-anchor:none]">
         {rows}
 
         {postings.length === 0 && !isLoading && (


### PR DESCRIPTION
## Summary

User-reported P2: watchlist job cards visibly jump up and down on scroll at `/<lang>/<user>/<slug>` (e.g. `/en/viktoroo-sch/my-search`).

Empirical CLS measurement on the baseline page (Playwright, 20-step scroll on a 1280×800 viewport, anon flow) returns ~**0.0005** — well below Google's 0.1 threshold. The user-perceived jitter comes from the browser's automatic scroll-anchor heuristic picking arbitrary row elements during pagination and adjusting scroll position by a few sub-pixel amounts that CLS doesn't always catch.

The fix is **purely defensive** — no visual change, only reserved space + layout containment so no element in the postings subtree can cause a shift even theoretically. Per the issue constraint: "prevent it **without changing the layout**".

## What changed

`apps/web/src/components/watchlist/watchlist-job-list.tsx`:
1. **`[overflow-anchor:none]` on the postings list container** — opts the whole subtree out of scroll-anchor selection. The sentinel already opted itself out via inline style; this widens the opt-out to every row + date divider so the anchoring heuristic can't pick any of them mid-scroll.
2. **`min-h-10` (40px = current natural row height) + `[contain:layout]`** on every watchlist row — locks vertical extent so any content-driven height variation never shifts neighbouring rows, and `contain: layout` isolates per-row reflows.
3. **`min-h-7` on date dividers** (28px = current natural height).

`apps/web/src/components/search/company-card.tsx`:
4. **`min-h-7` + `[contain:layout]` on company-card posting rows** — same treatment, since #3320 restructured them with the same `<div>` + absolute-overlay-button pattern.

## CLS before/after

Same scroll script (20 × `window.scrollBy(0, 600)` + 500ms wait, on `/en/viktoroo-sch/my-search`):

| | Total CLS | Shift entries | Verdict |
|---|---:|---:|---|
| **baseline** (issue-reproduction method, full page paint observer) | 0.0005 | 1 (nav) | PASS (already <0.1) |
| **after-fix** (post-paint observer, scroll only) | **0.0000** | **0** | **PASS** |

Heavy pagination test (200 postings loaded in 9 fetch cycles, 30 scroll steps): row 0's document-Y position recorded across 32 snapshots — **one unique value (345.5), repeated**. Zero drift, zero CLS.

## Top shifting elements identified

None during scroll. The only shift detected on baseline (during initial paint, not scroll) was a 1px nav vertical drop — outside the issue's scope ("on scroll").

## Per-element fix applied

| Element | Before | After | Visual change |
|---|---|---|---|
| Watchlist row | `relative flex w-full items-center …` | `relative flex min-h-10 w-full items-center [contain:layout] …` | None (`min-h-10` = current natural height) |
| Date divider | `flex items-center gap-3 px-2 py-2` | `flex min-h-7 items-center gap-3 px-2 py-2` | None |
| Postings container | `<div>` | `<div className="[overflow-anchor:none]">` | None (visual = invisible CSS property) |
| Company-card row | `relative flex items-center gap-2 …` | `relative flex min-h-7 items-center gap-2 [contain:layout] …` | None |

## Tests

- `apps/web/src/components/watchlist/__tests__/watchlist-job-list-scroll-stability.test.tsx` (new) — 4 tests: asserts the `[overflow-anchor:none]` container, `min-h-10`+`[contain:layout]` rows, and `min-h-7` dividers are present.
- `apps/web/src/components/search/__tests__/company-card-scroll-stability.test.tsx` (new) — 1 test: asserts `min-h-7`+`[contain:layout]` rows are present.

## Test plan

- [x] `pnpm test --run` — 1186 tests pass (was 1181; +5 new tests above)
- [x] `pnpm exec tsc --noEmit` — clean
- [x] Playwright CLS measurement before fix — 0.0005 (PASS)
- [x] Playwright CLS measurement after fix — **0.0000 (PASS)**
- [x] Pagination test (200 postings, 9 fetches, 30 scroll steps) — row 0 doc-Y stable across 32 snapshots
- [x] Computed-style check: `overflow-anchor: none` applied to container, `min-height: 40px` + `contain: layout` on all 20 rows, `min-height: 28px` on date divider
- [x] Visual screenshot: layout identical to baseline (see `/tmp/3345-final-watchlist.png`)
- [x] Existing a11y / nested-buttons / infinite-scroll regression tests still pass