### PR TITLE
fix(web): align watchlist count surfaces + refetch year count on filter change (closes #3344)

### DIFF
--- a/apps/web/src/components/watchlist/__tests__/watchlist-job-list-year-count-refetch.test.tsx
+++ b/apps/web/src/components/watchlist/__tests__/watchlist-job-list-year-count-refetch.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * Regression test for issue #3344 — `yearTotal` ("in the last year")
+ * went stale on filter change.
+ *
+ * Before this fix, the active count refetched on every filter change
+ * (driven by `usePaginatedLoadMore`'s `resetKey`) but the year count
+ * was rendered as a static prop from SSR. Editing a filter inline
+ * updated the active badge but left the year badge unchanged until a
+ * full page reload — visible divergence on the same row.
+ *
+ * The fix runs a parallel year-count refetch keyed on the same
+ * `filtersKey` so both badges stay in lockstep.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, render } from "@testing-library/react";
+import "@/test-utils/lingui-mock";
+
+const runGetWatchlistPostings = vi.fn().mockResolvedValue({
+  postings: [],
+  total: 0,
+});
+const runGetWatchlistPostingYearCount = vi.fn().mockResolvedValue(0);
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/lib/search/search-runner", () => ({
+  runGetWatchlistPostings: (...args: unknown[]) =>
+    runGetWatchlistPostings(...args),
+  runGetWatchlistPostingYearCount: (...args: unknown[]) =>
+    runGetWatchlistPostingYearCount(...args),
+}));
+
+vi.mock("@/components/CompanyIcon", () => ({
+  CompanyIcon: () => null,
+}));
+vi.mock("@/lib/time", () => ({ timeAgoShort: () => "" }));
+vi.mock("@/lib/search/use-clear-typesense-on-auth-change", () => ({
+  useClearTypesenseOnAuthChange: () => {},
+}));
+vi.mock("@/components/SessionProvider", () => ({
+  useSession: () => ({ isLoggedIn: true, isPending: false }),
+}));
+vi.mock("@/components/SavedJobsProvider", () => ({
+  useSavedJobs: () => ({
+    isSaved: () => false,
+    toggle: () => {},
+    isToggling: () => false,
+    getStatus: () => null,
+    getSavedJobId: () => null,
+    setStatus: () => {},
+    onStatusChange: () => () => {},
+  }),
+}));
+vi.mock("@/components/search/job-detail-dialog", () => ({
+  JobDetailPanel: () => null,
+}));
+vi.mock("@/lib/use-infinite-scroll", () => ({
+  useInfiniteScroll: () => ({ sentinelRef: { current: null }, isLoading: false }),
+}));
+vi.mock("@/lib/use-paginated-load-more", () => ({
+  usePaginatedLoadMore: ({ initialItems, initialTotal }: {
+    initialItems: unknown[];
+    initialTotal: number;
+  }) => ({
+    items: initialItems,
+    total: initialTotal,
+    truncated: false,
+    hasMore: false,
+    loadMore: () => {},
+  }),
+}));
+vi.mock("@/components/InfiniteScrollSentinel", () => ({
+  InfiniteScrollSentinel: () => null,
+}));
+vi.mock("@/components/TruncationPrompt", () => ({
+  TruncationPrompt: () => null,
+}));
+vi.mock("@/components/TrackingDot", () => ({ TrackingDot: () => null }));
+vi.mock("@/components/PendingJobWarning", () => ({
+  PendingJobIcon: () => null,
+}));
+
+// Render the year-count value as a stable test surface.
+vi.mock("@/components/search/language-stats-row", () => ({
+  LanguageStatsRow: ({ yearCount }: { yearCount: number }) => (
+    <div data-testid="year-count">{yearCount}</div>
+  ),
+}));
+
+vi.mock("@/components/watchlist/format-date-divider", () => ({
+  formatDateDivider: () => "",
+  getDateKey: (s: string) => s,
+}));
+
+beforeEach(() => {
+  runGetWatchlistPostings.mockClear();
+  runGetWatchlistPostingYearCount.mockClear();
+  runGetWatchlistPostingYearCount.mockResolvedValue(0);
+});
+
+import { WatchlistJobList } from "../watchlist-job-list";
+
+const baseProps = {
+  initialPostings: [],
+  initialTotal: 0,
+  jobLanguages: ["en"],
+  locale: "en",
+};
+
+describe("WatchlistJobList — year-count refetch on filter change (#3344)", () => {
+  it("does NOT refire the year-count fetch on initial mount (SSR yearTotal already covers it)", async () => {
+    render(
+      <WatchlistJobList
+        filters={{ companyIds: ["c-1"] }}
+        yearTotal={88343}
+        {...baseProps}
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(runGetWatchlistPostingYearCount).not.toHaveBeenCalled();
+  });
+
+  it("refires the year-count fetch when filters change, and updates the rendered badge", async () => {
+    const { rerender, getByTestId } = render(
+      <WatchlistJobList
+        filters={{ companyIds: ["c-1"] }}
+        yearTotal={88343}
+        {...baseProps}
+      />,
+    );
+
+    expect(getByTestId("year-count").textContent).toBe("88343");
+
+    runGetWatchlistPostingYearCount.mockResolvedValueOnce(12345);
+    rerender(
+      <WatchlistJobList
+        filters={{ companyIds: ["c-1"], keywords: ["engineer"] }}
+        yearTotal={88343}
+        {...baseProps}
+      />,
+    );
+
+    // Drain the effect's microtask + the resolved fetch.
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(runGetWatchlistPostingYearCount).toHaveBeenCalledTimes(1);
+    expect(getByTestId("year-count").textContent).toBe("12345");
+  });
+
+  it("ignores a stale result if filters change again before the previous fetch resolves", async () => {
+    let resolveFirst: ((n: number) => void) | undefined;
+    runGetWatchlistPostingYearCount.mockImplementationOnce(
+      () => new Promise<number>((res) => { resolveFirst = res; }),
+    );
+    runGetWatchlistPostingYearCount.mockResolvedValueOnce(7777);
+
+    const { rerender, getByTestId } = render(
+      <WatchlistJobList
+        filters={{ companyIds: ["c-1"] }}
+        yearTotal={1000}
+        {...baseProps}
+      />,
+    );
+
+    rerender(
+      <WatchlistJobList
+        filters={{ companyIds: ["c-1"], keywords: ["alpha"] }}
+        yearTotal={1000}
+        {...baseProps}
+      />,
+    );
+    rerender(
+      <WatchlistJobList
+        filters={{ companyIds: ["c-1"], keywords: ["beta"] }}
+        yearTotal={1000}
+        {...baseProps}
+      />,
+    );
+
+    // Resolve the first (now-stale) fetch.
+    resolveFirst?.(1);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // The second (latest) fetch wins.
+    expect(getByTestId("year-count").textContent).toBe("7777");
+  });
+});

--- a/apps/web/src/components/watchlist/watchlist-job-list.tsx
+++ b/apps/web/src/components/watchlist/watchlist-job-list.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import { useState, useRef } from "react";
+import { useEffect, useState, useRef } from "react";
 import { useSearchParams } from "next/navigation";
 import { Bookmark } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { CompanyIcon } from "@/components/CompanyIcon";
 import { timeAgoShort } from "@/lib/time";
 import { type WatchlistPostingEntry } from "@/lib/actions/watchlists";
-import { runGetWatchlistPostings } from "@/lib/search/search-runner";
+import {
+  runGetWatchlistPostings,
+  runGetWatchlistPostingYearCount,
+} from "@/lib/search/search-runner";
 import { useClearTypesenseOnAuthChange } from "@/lib/search/use-clear-typesense-on-auth-change";
 import { useSession } from "@/components/SessionProvider";
 import { useSavedJobs } from "@/components/SavedJobsProvider";
@@ -93,6 +96,34 @@ export function WatchlistJobList({
         isLoggedInRef.current,
       ),
   });
+
+  // Year-count refetch on filter change. The SSR-prerendered
+  // `yearTotal` only reflects the watchlist's stored filters at page
+  // load — when the owner edits filters in-place the active count
+  // updates (via `usePaginatedLoadMore`'s reset-on-filtersKey) but the
+  // year count went stale until a full reload. Mirror that reset by
+  // keying a `useEffect` on the same `filtersKey` so both badges stay
+  // in lockstep. Issue #3344.
+  //
+  // `initialFiltersKeyRef` skips the first fetch on mount — the SSR
+  // `yearTotal` already covers it. Cancel-on-stale guards a race
+  // between rapid filter changes (we only commit the latest
+  // in-flight result).
+  const [yearTotal_, setYearTotal] = useState(yearTotal);
+  const initialFiltersKeyRef = useRef(filtersKey);
+  useEffect(() => {
+    if (filtersKey === initialFiltersKeyRef.current) return;
+    let cancelled = false;
+    runGetWatchlistPostingYearCount(filtersRef.current).then((next) => {
+      if (cancelled) return;
+      setYearTotal(next);
+    }).catch((err) => {
+      console.error("[WatchlistJobList] year-count refetch failed", err);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [filtersKey]);
 
   const { sentinelRef, isLoading } = useInfiniteScroll({ hasMore, load: loadMore });
 
@@ -220,7 +251,7 @@ export function WatchlistJobList({
         jobLanguages={jobLanguages}
         locale={locale}
         activeCount={total}
-        yearCount={yearTotal}
+        yearCount={yearTotal_}
       />
       <div>
         {rows}

--- a/apps/web/src/lib/actions/__tests__/watchlists-listing-perf.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-listing-perf.test.ts
@@ -356,6 +356,37 @@ describe("getUserWatchlists — listing fan-out fix (#3176)", () => {
 
     expect(mocks.tsSearch).not.toHaveBeenCalled();
   });
+
+  // Regression for #3344. The `anyCompany` Typesense patch previously
+  // omitted the viewer-language scope, so the tile count diverged from
+  // the watchlist-detail page (which DOES scope by `locales:[lang,
+  // _none]` via `_getWatchlistPostingsTypesense`). The fix threads the
+  // viewer's resolved languages through `_resolveAnyCompanyActiveCount`
+  // so both surfaces issue the same Typesense filter shape.
+  it("passes viewer languages through to the anyCompany Typesense count (#3344)", async () => {
+    const anyRow = {
+      ...fakeUserWatchlistRow(0, 0),
+      filters: { anyCompany: true, locationSlugs: ["eu"] },
+    };
+    mocks.dbExecute.mockResolvedValueOnce([anyRow]);
+    mocks.getViewerLanguages.mockResolvedValueOnce(["en"]);
+    mocks.tsSearch.mockResolvedValueOnce({ found: 39126, hits: [] });
+
+    const buildFilterStringMock = vi.mocked(
+      await import("@/lib/search/typesense-filters"),
+    ).buildFilterString;
+    buildFilterStringMock.mockClear();
+
+    await getUserWatchlists("en");
+
+    // `getViewerLanguages` was called once with the page locale.
+    expect(mocks.getViewerLanguages).toHaveBeenCalledWith("en");
+    // The viewer's languages were forwarded into `buildFilterString` so
+    // the Typesense filter for the tile matches the detail page's
+    // shape (locales:[en,_none] in the rendered filter_by string).
+    const lastCall = buildFilterStringMock.mock.calls.at(-1);
+    expect(lastCall?.[0]).toMatchObject({ languages: ["en"] });
+  });
 });
 
 // ---- public Discover surfaces (Typesense path) -------------------------

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -603,9 +603,19 @@ export async function getUserWatchlistsWithLimit(
   return { watchlists, limitReached: !limit.allowed };
 }
 
-export async function getUserWatchlists(_locale: string): Promise<WatchlistSummary[]> {
+export async function getUserWatchlists(locale: string): Promise<WatchlistSummary[]> {
   const userId = await getSessionUserId();
   if (!userId) return [];
+
+  // Viewer language preference — used to scope the `anyCompany`
+  // Typesense-backed patch below so the tile count matches the
+  // watchlist-detail page's locale-filtered count. The SQL fast path
+  // for non-`anyCompany` rows still uses the locale-blind denormalized
+  // `active_job_count` (per the trade-off in #3176 — see block comment
+  // below), but the patched `anyCompany` count is exactly what the
+  // detail page renders, so they must share the same filter shape.
+  // See issue #3344.
+  const languages = await getViewerLanguages(locale);
 
   // Perf (#3176): compute the active job count via a denormalized SQL
   // aggregation in the same query that loads the watchlist rows. The
@@ -692,7 +702,7 @@ export async function getUserWatchlists(_locale: string): Promise<WatchlistSumma
     const pairs = await Promise.all(
       anyCompanyRows.map(async (r) => {
         try {
-          const c = await _resolveAnyCompanyActiveCount(r.filters);
+          const c = await _resolveAnyCompanyActiveCount(r.filters, locale, languages);
           return [r.id, c] as const;
         } catch (err) {
           console.error("[getUserWatchlists] anyCompany count failed", { id: r.id, err });
@@ -726,24 +736,32 @@ export async function getUserWatchlists(_locale: string): Promise<WatchlistSumma
  * doc field both return 0 by construction.
  *
  * Mirrors the Typesense shape used by `_getWatchlistPostingsTypesense`
- * (POSTING_BASE_FILTER + slug-resolved filter ids + keywords) but
- * runs `per_page: 0` so we pay only for the count. Cached by
- * `buildFilterCacheKey(filters, [])` so two consecutive page renders
- * with the same filters share a single Typesense round-trip.
+ * (POSTING_BASE_FILTER + slug-resolved filter ids + keywords +
+ * viewer-language scope) but runs `per_page: 0` so we pay only for the
+ * count. Cached by `buildFilterCacheKey(filters, [])` + the viewer's
+ * resolved languages so two consecutive page renders with the same
+ * filters and the same viewer share a single Typesense round-trip, but
+ * an `en` viewer and a `de` viewer get distinct cache slots.
  *
- * The viewer's language preference is NOT scoped here — the listing
- * badge shows the same broadest count to all viewers, matching the
- * documented trade-off in #3262.
+ * Filter shape MUST match `_getWatchlistPostingsTypesense` exactly —
+ * the tile count and the detail page's "active" count read the same
+ * watchlist, and any divergence (e.g. omitting the locales filter)
+ * shows up as a P1 count mismatch. Issue #3344 (originally allowed an
+ * unscoped, broadest count here per #3262's listing trade-off; rolled
+ * back when the user-visible divergence outweighed the per-viewer
+ * cache fragmentation cost).
  *
  * Returns 0 on any Typesense error so the listing badge degrades to
  * the same value as the company-scope fast path.
  */
 async function _resolveAnyCompanyActiveCount(
   filters: WatchlistFilters,
+  locale: string,
+  languages: string[],
 ): Promise<number> {
-  const key = `wl-any-active:${buildFilterCacheKey(filters, [])}`;
+  const langKey = languagesCacheKey(languages);
+  const key = `wl-any-active:${buildFilterCacheKey(filters, [])}:${langKey}`;
   return cached(key, async () => {
-    const locale = "en";
     const [locMap, occMap, senMap, techMap] = await Promise.all([
       filters.locationSlugs?.length ? resolveLocationSlugs(filters.locationSlugs, locale) : Promise.resolve(new Map()),
       filters.occupationSlugs?.length ? resolveOccupationSlugs(filters.occupationSlugs, locale) : Promise.resolve(new Map()),
@@ -762,6 +780,7 @@ async function _resolveAnyCompanyActiveCount(
       salaryMaxEur: filters.salaryMax,
       experienceMin: filters.experienceMin,
       experienceMax: filters.experienceMax,
+      languages: languages.length > 0 ? languages : undefined,
     });
 
     const fullFilter = `${POSTING_BASE_FILTER}${filterStr ? " && " + filterStr : ""}`;

--- a/apps/web/src/lib/search/search-runner.ts
+++ b/apps/web/src/lib/search/search-runner.ts
@@ -7,6 +7,7 @@ import {
 import { getCompanyPostings as serverGetCompanyPostings } from "@/lib/actions/company";
 import {
   getWatchlistPostings as serverGetWatchlistPostings,
+  getWatchlistPostingYearCount as serverGetWatchlistPostingYearCount,
   type WatchlistPostingEntry,
 } from "@/lib/actions/watchlists";
 import type {
@@ -137,6 +138,22 @@ export async function runGetWatchlistPostings(
     }
   }
   return serverGetWatchlistPostings(params);
+}
+
+/**
+ * Client runner for the watchlist "in the last year" count. Mirrors
+ * the active-count fetch shape so the two badges on the watchlist
+ * detail page can refetch in lockstep when filters change.
+ *
+ * Issue #3344 — before this, `yearTotal` was rendered as a static SSR
+ * prop and went stale until the next full page reload. The active
+ * count next to it kept updating via `runGetWatchlistPostings`, which
+ * produced visible "active changes but year doesn't" divergence.
+ */
+export async function runGetWatchlistPostingYearCount(
+  params: Omit<WatchlistPostingsInput, "offset" | "limit">,
+): Promise<number> {
+  return serverGetWatchlistPostingYearCount(params);
 }
 
 export async function runGetCompanyPostings(


### PR DESCRIPTION
## Summary

Closes #3344. Two distinct count divergences on the watchlist surfaces, fixed together.

### Bug 1 — listing tile count != detail \"active\" count for the same watchlist

\`_resolveAnyCompanyActiveCount\` (added in #3340 to patch \`anyCompany\` watchlists, whose SQL \`watchlist_company JOIN\` returns 0 by construction) issued the Typesense \`per_page: 0\` count with \`POSTING_BASE_FILTER\` + slug-resolved filters, but **intentionally omitted the viewer's language scope** (\`locales:[en,_none]\`). The detail-page count via \`_getWatchlistPostingsTypesense\` always applies that scope, so the two surfaces returned different numbers for the same watchlist viewed by the same user.

**Empirical reproduction** on viktor's \`viktoroo-sch/my-search\` (filters: \`anyCompany: true, locationSlugs: [\"eu\"]\`) — Typesense queried directly with each surface's exact filter shape:

| Surface | Filter | Typesense \`found\` |
|---|---|---|
| Tile (post-#3340) | \`is_active:true && has_content:!=false && location_ids:[4]\` | **63,643** |
| Detail \"active\" | \`... && locales:[en,_none]\` | **39,218** |
| Detail \"in the last year\" | \`has_content:!=false && first_seen_at:>1y && location_ids:[4] && locales:[en,_none]\` | **88,405** |

The ~24k delta between tile and detail is exactly the locales filter — matching the 62,884 vs 39,126 the issue reports.

**Root cause**: implementer comment in #3340 (preserved before this PR):

> The viewer's language preference is NOT scoped here — the listing badge shows the same broadest count to all viewers, matching the documented trade-off in #3262.

The trade-off in #3262 is for the SQL fast path (denormalized count, no viewer scope, no filter scope). The new Typesense patch for \`anyCompany\` rows had no such constraint and should have matched the detail page's filter shape from day one.

**Fix**: thread the viewer's resolved \`languages\` (via \`getViewerLanguages(locale)\`) through to \`_resolveAnyCompanyActiveCount\`. Cache key gets a \`:lang\` suffix so per-viewer slots stay distinct.

### Bug 2 — detail page \"in the last year\" count stale on filter change

\`yearTotal\` was rendered as a static SSR prop and only refreshed on a full page reload. The active count, by contrast, refetches on every filter change via \`usePaginatedLoadMore\`'s reset-on-\`filtersKey\`. Editing a filter inline (e.g. adding a keyword, removing the location pill) updated the active badge but not the year badge — they diverged until the next reload.

**Fix**: track \`yearTotal\` in component state, refire \`runGetWatchlistPostingYearCount\` from a \`useEffect\` keyed on the same \`filtersKey\` the active count uses. Cancel-on-stale guards rapid filter changes (we only commit the latest in-flight result). New \`runGetWatchlistPostingYearCount\` runner in \`search-runner.ts\` mirrors the existing watchlist-postings runner.

This is pattern (A) from the issue: single source of truth for both counts, refetched together on filter change.

## Verification (Playwright)

Run against viktor's \`my-search\` watchlist on a local dev server.

| Surface | Value | Screenshot |
|---|---|---|
| Listing tile | **My search · 39,593 jobs** | \`01b-listing-tile-crop.png\` |
| Detail initial | **39,593 active · 88,791 in the last year** | \`02-detail-initial.png\` |
| Detail after removing the EU location filter | **644,811 active · 1,318,513 in the last year** | \`03-detail-after-filter.png\` |

**Bug 1**: tile count (39,593) == detail \"active\" count (39,593) — exact match. (Pre-fix, the tile would have shown ~63k.)

**Bug 2**: removing the EU location filter on the detail page updated BOTH counts in lockstep without a page reload (39,593 → 644,811 active, 88,791 → 1,318,513 year).

Screenshots saved at \`/tmp/issue-3344-screenshots/\` (full + cropped variants of each step).

## Tests

- New regression test in \`watchlists-listing-perf.test.ts\`: asserts the viewer's languages reach \`buildFilterString\` for the \`anyCompany\` Typesense count (Bug 1).
- New file \`watchlist-job-list-year-count-refetch.test.tsx\` with three tests (Bug 2):
  - SSR-mount no-op (year fetch does not fire on initial mount)
  - Refetch on filter change updates the rendered year badge
  - Stale-result cancellation when filters change again before the previous fetch resolves

## Test plan

- [x] \`pnpm test\` — all 1,185 tests pass
- [x] \`pnpm exec tsc --noEmit\` — clean
- [x] Playwright verification with screenshots — tile/detail counts aligned, filter change updates both counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)