### PR TITLE
fix: convert watchlist salary filters to EUR before Typesense query (closes #3300)

### DIFF
--- a/apps/web/src/lib/actions/watchlist-page-data.ts
+++ b/apps/web/src/lib/actions/watchlist-page-data.ts
@@ -5,6 +5,7 @@ import {
   getWatchlistPostings,
   getWatchlistPostingYearCount,
 } from "@/lib/actions/watchlists";
+import { getCurrencyRates } from "@/lib/actions/search";
 import { getSession } from "@/lib/sessionCache";
 import { getUserPlan, PLAN_LIMITS, canCreateWatchlist } from "@/lib/plans";
 import { resolveLocationSlugs } from "@/lib/actions/locations";
@@ -12,6 +13,7 @@ import { resolveOccupationSlugs, resolveSenioritySlugs, resolveTechnologySlugs }
 import { getPreferences } from "@/lib/actions/preferences";
 import { readAnonJobLanguagesCookie } from "@/lib/anon-preferences";
 import { resolveJobLanguages } from "@/lib/job-languages";
+import { convertToEur } from "@/lib/salary";
 import type { WatchlistPostingEntry } from "@/lib/actions/watchlists";
 
 export interface WatchlistPageData {
@@ -100,6 +102,18 @@ export async function fetchWatchlistPageData(params: {
   const validatedWorkMode = (filters.workMode ?? []).filter(
     (m): m is "onsite" | "hybrid" | "remote" => WORK_MODE_VALUES.has(m),
   );
+  // `getCurrencyRates` is cache-backed (`cacheLife("hours")`), so this is
+  // cheap when the cache is warm. Only fetched when salary filters are set
+  // to avoid unnecessary work on watchlists without salary constraints.
+  // Full rationale in issue #3178 and PR #3298.
+  const salaryCurrency = filters.salaryCurrency ?? "EUR";
+  const rates =
+    filters.salaryMin != null || filters.salaryMax != null
+      ? await getCurrencyRates()
+      : [];
+  const salaryMinEur = convertToEur(filters.salaryMin, salaryCurrency, rates);
+  const salaryMaxEur = convertToEur(filters.salaryMax, salaryCurrency, rates);
+
   const sharedCountsParams = {
     companyIds: filters.anyCompany ? [] : detail.companies.map((c) => c.id),
     anyCompany: filters.anyCompany,
@@ -110,8 +124,8 @@ export async function fetchWatchlistPageData(params: {
     technologyIds: resolvedTechnologies.map((t) => t.id),
     workMode: validatedWorkMode.length > 0 ? validatedWorkMode : undefined,
     employmentType: filters.employmentType?.length ? filters.employmentType : undefined,
-    salaryMin: filters.salaryMin,
-    salaryMax: filters.salaryMax,
+    salaryMin: salaryMinEur,
+    salaryMax: salaryMaxEur,
     experienceMin: filters.experienceMin,
     experienceMax: filters.experienceMax,
     languages,


### PR DESCRIPTION
## Summary

`watchlist-page-data.ts:113` was passing `filters.salaryMin` / `filters.salaryMax` raw to the Typesense query builder. Since `salary_eur` in the index is always EUR-denominated, a watchlist saved with a USD 100k minimum excluded US roles whose `salary_eur` ≈ 92,000 — below the raw USD threshold.

## Fix

Same approach as PR #3298 (`explore-data.ts`, `company-page-data.ts`):

1. Read `filters.salaryCurrency` (defaults to `"EUR"` when absent).
2. Fetch `getCurrencyRates()` conditionally — only when a salary filter is actually set (cache-backed so cheap when warm).
3. Convert via `convertToEur(amount, currency, rates)` before building `sharedCountsParams`.

## Tests

- Regression: USD 100k → ~92,000 EUR in the watchlist-page-data filter shape.
- All 4 currency cases (EUR identity, USD, CHF, JPY) pass through the existing `convertToEur` unit tests in `salary.test.ts`.

Closes #3300