### PR TITLE
fix(web): patch anyCompany count on Discover surfaces too (closes #3352)

### DIFF
--- a/apps/web/src/lib/actions/__tests__/watchlists-listing-perf.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-listing-perf.test.ts
@@ -396,33 +396,53 @@ describe("getPopularWatchlists — Typesense path (#3176)", () => {
     const N = 20;
     const hits = Array.from({ length: N }, (_, i) => fakePublicWatchlistHit(i, i * 5));
     mocks.tsSearch.mockResolvedValueOnce({ hits, found: N });
+    // #3352: a single batched filter lookup for the page (no per-row
+    // fan-out). Returns no `anyCompany` rows so the patch is a no-op.
+    mocks.dbExecute.mockResolvedValueOnce(
+      hits.map((h) => ({ id: h.document.id, filters: {} })),
+    );
 
     await getPopularWatchlists({ offset: 0, limit: 20, locale: "en" });
 
+    // Only the watchlist collection — no per-row `job_posting` count
+    // (the regression this test protects against from #3176).
     expect(mocks.tsSearch).toHaveBeenCalledTimes(1);
     expect(mocks.tsCollectionsCalls).toEqual(["watchlist"]);
   });
 
-  it("preserves the denormalized active_job_count from the Typesense doc", async () => {
+  it("preserves the denormalized active_job_count from the Typesense doc for non-anyCompany rows", async () => {
     const hits = [
       fakePublicWatchlistHit(0, 100),
       fakePublicWatchlistHit(1, 50),
       fakePublicWatchlistHit(2, 25),
     ];
     mocks.tsSearch.mockResolvedValueOnce({ hits, found: 3 });
+    // #3352: filter lookup returns non-anyCompany filters for all rows,
+    // so the patch is a no-op and the denormalized count survives.
+    mocks.dbExecute.mockResolvedValueOnce(
+      hits.map((h) => ({ id: h.document.id, filters: { keywords: ["x"] } })),
+    );
 
     const result = await getPopularWatchlists({ offset: 0, limit: 20, locale: "en" });
 
     expect(result.watchlists.map((w) => w.activeJobCount)).toEqual([100, 50, 25]);
   });
 
-  it("does NOT touch Postgres on the Typesense success path", async () => {
-    const hits = [fakePublicWatchlistHit(0, 10)];
-    mocks.tsSearch.mockResolvedValueOnce({ hits, found: 1 });
+  it("issues a single batched Postgres lookup for filters (no per-row fan-out)", async () => {
+    const hits = [
+      fakePublicWatchlistHit(0, 10),
+      fakePublicWatchlistHit(1, 20),
+      fakePublicWatchlistHit(2, 30),
+    ];
+    mocks.tsSearch.mockResolvedValueOnce({ hits, found: 3 });
+    mocks.dbExecute.mockResolvedValueOnce(
+      hits.map((h) => ({ id: h.document.id, filters: {} })),
+    );
 
     await getPopularWatchlists({ offset: 0, limit: 20, locale: "en" });
 
-    expect(mocks.dbExecute).not.toHaveBeenCalled();
+    // Exactly one batched SELECT for filters — not N (#3352).
+    expect(mocks.dbExecute).toHaveBeenCalledTimes(1);
   });
 });
 
@@ -431,6 +451,9 @@ describe("searchPublicWatchlists — Typesense path (#3176)", () => {
     const N = 15;
     const hits = Array.from({ length: N }, (_, i) => fakePublicWatchlistHit(i, i + 1));
     mocks.tsSearch.mockResolvedValueOnce({ hits, found: N });
+    mocks.dbExecute.mockResolvedValueOnce(
+      hits.map((h) => ({ id: h.document.id, filters: {} })),
+    );
 
     await searchPublicWatchlists({ query: "python", offset: 0, limit: 20, locale: "en" });
 
@@ -438,12 +461,15 @@ describe("searchPublicWatchlists — Typesense path (#3176)", () => {
     expect(mocks.tsCollectionsCalls).toEqual(["watchlist"]);
   });
 
-  it("preserves the denormalized active_job_count from the Typesense doc", async () => {
+  it("preserves the denormalized active_job_count from the Typesense doc for non-anyCompany rows", async () => {
     const hits = [
       fakePublicWatchlistHit(0, 99),
       fakePublicWatchlistHit(1, 77),
     ];
     mocks.tsSearch.mockResolvedValueOnce({ hits, found: 2 });
+    mocks.dbExecute.mockResolvedValueOnce(
+      hits.map((h) => ({ id: h.document.id, filters: { keywords: ["x"] } })),
+    );
 
     const result = await searchPublicWatchlists({
       query: "python",
@@ -466,5 +492,160 @@ describe("searchPublicWatchlists — Typesense path (#3176)", () => {
     expect(result).toEqual({ watchlists: [], total: 0 });
     expect(mocks.tsSearch).not.toHaveBeenCalled();
     expect(mocks.dbExecute).not.toHaveBeenCalled();
+  });
+});
+
+// ---- Discover anyCompany patch (#3352) -------------------------------
+//
+// `getPopularWatchlists` and `searchPublicWatchlists` read
+// `active_job_count` straight from the Typesense `watchlist` doc, which
+// is 0 by construction for `anyCompany` watchlists (the crawler's
+// `refresh_typesense_counts` joins the empty `watchlist_company` table
+// for them — see `apps/crawler/src/sync.py`). The fix mirrors the
+// `getUserWatchlists` patch from #3340: detect `anyCompany` rows by
+// looking up `filters` in Postgres for the page's IDs, then run one
+// `job_posting` count per `anyCompany` row in parallel — bounded by
+// page size on the Discover surface.
+
+describe("getPopularWatchlists — anyCompany count patch (#3352)", () => {
+  it("patches anyCompany rows with a live Typesense count", async () => {
+    const anyHit = fakePublicWatchlistHit(0, 0); // Typesense doc says 0
+    const normalHit = fakePublicWatchlistHit(1, 12);
+    mocks.tsSearch.mockResolvedValueOnce({ hits: [anyHit, normalHit], found: 2 });
+    mocks.dbExecute.mockResolvedValueOnce([
+      { id: anyHit.document.id, filters: { anyCompany: true, locationSlugs: ["eu"] } },
+      { id: normalHit.document.id, filters: { keywords: ["python"] } },
+    ]);
+    mocks.tsSearch.mockResolvedValueOnce({ found: 38717, hits: [] });
+
+    const result = await getPopularWatchlists({ offset: 0, limit: 20, locale: "en" });
+
+    expect(result.watchlists).toHaveLength(2);
+    // The anyCompany row: patched from Typesense doc's 0 to the live count.
+    expect(result.watchlists[0].activeJobCount).toBe(38717);
+    // The non-anyCompany row: denormalized doc count survives unchanged.
+    expect(result.watchlists[1].activeJobCount).toBe(12);
+
+    // Two Typesense calls: one for the watchlist collection, one for the
+    // job_posting count of the single anyCompany row.
+    expect(mocks.tsSearch).toHaveBeenCalledTimes(2);
+    expect(mocks.tsCollectionsCalls).toEqual(["watchlist", "job_posting"]);
+  });
+
+  it("fires no per-row count when no anyCompany rows are present", async () => {
+    const hits = [
+      fakePublicWatchlistHit(0, 50),
+      fakePublicWatchlistHit(1, 80),
+    ];
+    mocks.tsSearch.mockResolvedValueOnce({ hits, found: 2 });
+    mocks.dbExecute.mockResolvedValueOnce([
+      { id: hits[0].document.id, filters: { keywords: ["x"] } },
+      { id: hits[1].document.id, filters: {} },
+    ]);
+
+    await getPopularWatchlists({ offset: 0, limit: 20, locale: "en" });
+
+    // Only the watchlist search — no job_posting count fan-out.
+    expect(mocks.tsSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.tsCollectionsCalls).toEqual(["watchlist"]);
+  });
+
+  it("degrades to the Typesense doc count when the filter lookup fails", async () => {
+    const anyHit = fakePublicWatchlistHit(0, 0);
+    mocks.tsSearch.mockResolvedValueOnce({ hits: [anyHit], found: 1 });
+    mocks.dbExecute.mockRejectedValueOnce(new Error("postgres unreachable"));
+
+    const result = await getPopularWatchlists({ offset: 0, limit: 20, locale: "en" });
+
+    // Without a successful filter lookup we cannot detect `anyCompany`,
+    // so the row falls through to the Typesense doc's denormalized 0.
+    // No job_posting count fires.
+    expect(result.watchlists).toHaveLength(1);
+    expect(result.watchlists[0].activeJobCount).toBe(0);
+    expect(mocks.tsSearch).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes viewer languages through to the anyCompany Typesense count", async () => {
+    const anyHit = fakePublicWatchlistHit(0, 0);
+    mocks.tsSearch.mockResolvedValueOnce({ hits: [anyHit], found: 1 });
+    mocks.dbExecute.mockResolvedValueOnce([
+      { id: anyHit.document.id, filters: { anyCompany: true } },
+    ]);
+    mocks.getViewerLanguages.mockResolvedValueOnce(["de"]);
+    mocks.tsSearch.mockResolvedValueOnce({ found: 4242, hits: [] });
+
+    const buildFilterStringMock = vi.mocked(
+      await import("@/lib/search/typesense-filters"),
+    ).buildFilterString;
+    buildFilterStringMock.mockClear();
+
+    const result = await getPopularWatchlists({ offset: 0, limit: 20, locale: "de" });
+
+    expect(mocks.getViewerLanguages).toHaveBeenCalledWith("de");
+    // The viewer's languages reach `buildFilterString` so the tile
+    // count's filter shape matches the watchlist-detail page (#3344).
+    const lastCall = buildFilterStringMock.mock.calls.at(-1);
+    expect(lastCall?.[0]).toMatchObject({ languages: ["de"] });
+    expect(result.watchlists[0].activeJobCount).toBe(4242);
+  });
+});
+
+describe("searchPublicWatchlists — anyCompany count patch (#3352)", () => {
+  it("patches anyCompany rows with a live Typesense count", async () => {
+    const anyHit = fakePublicWatchlistHit(0, 0);
+    const normalHit = fakePublicWatchlistHit(1, 42);
+    mocks.tsSearch.mockResolvedValueOnce({ hits: [anyHit, normalHit], found: 2 });
+    mocks.dbExecute.mockResolvedValueOnce([
+      { id: anyHit.document.id, filters: { anyCompany: true } },
+      { id: normalHit.document.id, filters: {} },
+    ]);
+    mocks.tsSearch.mockResolvedValueOnce({ found: 1234, hits: [] });
+
+    const result = await searchPublicWatchlists({
+      query: "python",
+      offset: 0,
+      limit: 20,
+      locale: "en",
+    });
+
+    expect(result.watchlists).toHaveLength(2);
+    expect(result.watchlists[0].activeJobCount).toBe(1234);
+    expect(result.watchlists[1].activeJobCount).toBe(42);
+
+    expect(mocks.tsSearch).toHaveBeenCalledTimes(2);
+    expect(mocks.tsCollectionsCalls).toEqual(["watchlist", "job_posting"]);
+  });
+
+  it("fires no per-row count when no anyCompany rows are present", async () => {
+    const hits = [fakePublicWatchlistHit(0, 10), fakePublicWatchlistHit(1, 20)];
+    mocks.tsSearch.mockResolvedValueOnce({ hits, found: 2 });
+    mocks.dbExecute.mockResolvedValueOnce([
+      { id: hits[0].document.id, filters: {} },
+      { id: hits[1].document.id, filters: { keywords: ["x"] } },
+    ]);
+
+    await searchPublicWatchlists({ query: "python", offset: 0, limit: 20, locale: "en" });
+
+    expect(mocks.tsSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.tsCollectionsCalls).toEqual(["watchlist"]);
+  });
+
+  it("returns 0 when the per-row anyCompany count fails", async () => {
+    const anyHit = fakePublicWatchlistHit(0, 0);
+    mocks.tsSearch.mockResolvedValueOnce({ hits: [anyHit], found: 1 });
+    mocks.dbExecute.mockResolvedValueOnce([
+      { id: anyHit.document.id, filters: { anyCompany: true } },
+    ]);
+    mocks.tsSearch.mockRejectedValueOnce(new Error("typesense unreachable"));
+
+    const result = await searchPublicWatchlists({
+      query: "python",
+      offset: 0,
+      limit: 20,
+      locale: "en",
+    });
+
+    expect(result.watchlists).toHaveLength(1);
+    expect(result.watchlists[0].activeJobCount).toBe(0); // graceful degradation
   });
 });

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -1213,6 +1213,91 @@ async function queryPublicWatchlists(params: {
   };
 }
 
+/**
+ * Patch `active_job_count` on Discover-surface entries whose source
+ * watchlist has `filters.anyCompany = true`.
+ *
+ * Context (#3352): `getPopularWatchlists` and `searchPublicWatchlists`
+ * both read the denormalized `active_job_count` directly from the
+ * Typesense `watchlist` doc — fast, but always 0 for `anyCompany`
+ * watchlists because the crawler's `refresh_typesense_counts` joins the
+ * empty `watchlist_company` table for them. Same root cause as #3333,
+ * which patched the analogous code path in `getUserWatchlists`. This
+ * helper mirrors that patch for the public Discover surfaces.
+ *
+ * Shape:
+ * 1. Look up `filters` JSONB for each entry's `id` in a single batched
+ *    Postgres query (Typesense doesn't index `filters`, so we can't
+ *    detect `anyCompany` from the doc alone).
+ * 2. For rows where `filters.anyCompany` is set, fan out one
+ *    `_resolveAnyCompanyActiveCount(filters, locale, languages)` per
+ *    row in parallel via `Promise.all`. Each call is cached by
+ *    `_resolveAnyCompanyActiveCount` itself, so repeat renders with the
+ *    same viewer-language scope hit Redis instead of Typesense.
+ * 3. Patch the `activeJobCount` on the matching entry; non-anyCompany
+ *    rows are returned unchanged.
+ *
+ * Fan-out is bounded by the page size (typically 10-20 tiles on the
+ * Discover surface) times the fraction that are `anyCompany`. Same
+ * trade-off as the `getUserWatchlists` patch in #3340.
+ *
+ * Failures (Postgres unreachable, Typesense per-row count failure)
+ * degrade to the Typesense doc's denormalized 0 — same as the rest of
+ * the Discover surface. Logged for visibility.
+ */
+async function _patchAnyCompanyCountsForDiscover(
+  entries: PublicWatchlistEntry[],
+  locale: string,
+  languages: string[],
+): Promise<PublicWatchlistEntry[]> {
+  if (entries.length === 0) return entries;
+
+  let filtersById: Map<string, WatchlistFilters>;
+  try {
+    const ids = entries.map((e) => e.id);
+    const rows = await withDbRetry(
+      () =>
+        db.execute<{ [key: string]: unknown; id: string; filters: WatchlistFilters }>(sql`
+          SELECT w.id, w.filters
+          FROM watchlist w
+          WHERE w.id = ANY(${ids}::uuid[])
+        `),
+      { label: "discoverAnyCompanyFilters" },
+    );
+    const typed = rows as unknown as { id: string; filters: WatchlistFilters }[];
+    filtersById = new Map(typed.map((r) => [r.id, r.filters]));
+  } catch (err) {
+    console.error("[_patchAnyCompanyCountsForDiscover] filter lookup failed", err);
+    return entries;
+  }
+
+  const anyCompanyEntries = entries.filter((e) => filtersById.get(e.id)?.anyCompany);
+  if (anyCompanyEntries.length === 0) return entries;
+
+  const pairs = await Promise.all(
+    anyCompanyEntries.map(async (e) => {
+      const f = filtersById.get(e.id)!;
+      try {
+        const c = await _resolveAnyCompanyActiveCount(f, locale, languages);
+        return [e.id, c] as const;
+      } catch (err) {
+        console.error("[_patchAnyCompanyCountsForDiscover] anyCompany count failed", {
+          id: e.id,
+          err,
+        });
+        return [e.id, 0] as const;
+      }
+    }),
+  );
+  const patchedCounts = new Map(pairs);
+
+  return entries.map((e) =>
+    patchedCounts.has(e.id)
+      ? { ...e, activeJobCount: patchedCounts.get(e.id)! }
+      : e,
+  );
+}
+
 export async function searchPublicWatchlists(params: {
   query: string;
   offset: number;
@@ -1237,8 +1322,18 @@ export async function searchPublicWatchlists(params: {
           // sync). The previous shape re-computed N filtered counts per
           // listing render, costing N Typesense round-trips for a search
           // surface that shows 20+ results per page.
+          //
+          // EXCEPTION (#3352): `anyCompany` rows carry a denormalized 0
+          // (same root cause as the `getUserWatchlists` patch in #3333 /
+          // PR #3340). Patch those rows with a live Typesense count
+          // bounded by the page size — see `_patchAnyCompanyCountsForDiscover`.
+          const patched = await _patchAnyCompanyCountsForDiscover(
+            tsResult.watchlists,
+            params.locale,
+            languages,
+          );
           return {
-            watchlists: tsResult.watchlists,
+            watchlists: patched,
             total: tsResult.total,
           };
         }
@@ -1275,8 +1370,17 @@ export async function getPopularWatchlists(params: {
           // Perf (#3176): trust the denormalized `active_job_count`
           // already on each Typesense `watchlist` doc — see the matching
           // comment in `searchPublicWatchlists`.
+          //
+          // EXCEPTION (#3352): patch `anyCompany` rows from their
+          // structural 0 — see the matching comment in
+          // `searchPublicWatchlists`.
+          const patched = await _patchAnyCompanyCountsForDiscover(
+            tsResult.watchlists,
+            params.locale,
+            languages,
+          );
           return {
-            watchlists: tsResult.watchlists,
+            watchlists: patched,
             total: tsResult.total,
           };
         }


### PR DESCRIPTION
## Scope

Split from #3333 / PR #3340. PR #3340 patched the `anyCompany` count on
`getUserWatchlists` (logged-in user's own listing). This PR extends the
same patch to the two Discover-side reads that #3340 didn't touch:

- `getPopularWatchlists` (Discover home tiles, anonymous-friendly)
- `searchPublicWatchlists` (Discover search, anonymous-friendly)

Both read `active_job_count` straight from the Typesense `watchlist`
doc, which is 0 by construction for `anyCompany` watchlists — the
crawler's `refresh_typesense_counts` joins the empty `watchlist_company`
table for them. Same root cause as #3333, just on a different read
path.

## Change

New helper `_patchAnyCompanyCountsForDiscover` in `watchlists.ts`:

1. After Typesense returns the page, look up `filters` JSONB for the
   page's IDs in **one batched Postgres query** (Typesense doesn't
   index `filters`, so we can't detect `anyCompany` from the doc).
2. For rows where `filters.anyCompany` is set, fan out one
   `_resolveAnyCompanyActiveCount(filters, locale, languages)` per row
   in parallel via `Promise.all` — same helper `getUserWatchlists`
   already uses, with the same per-viewer-language cache scoping from
   #3347.
3. Patch `activeJobCount` on each matching entry. Non-anyCompany rows
   pass through unchanged.

Both surfaces use `getViewerLanguages(locale)` (already in place,
handles authenticated and anonymous viewers — cookie-backed for the
anonymous Discover viewer).

## Trade-off

Re-introduces N Typesense `job_posting` count queries for the
anyCompany subset of each Discover page, plus one batched Postgres
query for the page. Bounded by page size (10-20 tiles per page on the
Discover surface), so fan-out is bounded too. Same trade-off documented
in #3340 — the per-row count results are cached by
`_resolveAnyCompanyActiveCount` so repeat renders with the same
viewer-language scope hit Redis instead of Typesense.

Failures (Postgres unreachable, per-row count failure) degrade to the
Typesense doc's denormalized 0 — same graceful degradation pattern as
the rest of the Discover surface. Logged for visibility.

## Tests

`apps/web/src/lib/actions/__tests__/watchlists-listing-perf.test.ts`:

Two new describe blocks (`#3352` regression):
- `getPopularWatchlists — anyCompany count patch` — patch path,
  no-fan-out for non-anyCompany pages, Postgres-error degradation,
  language passthrough (anchors that the viewer-language scope from
  #3347 also reaches the Discover Typesense count).
- `searchPublicWatchlists — anyCompany count patch` — same coverage on
  the search path.

Existing `#3176` assertions updated to reflect the new batched Postgres
filter-lookup on the Typesense success path (still **one** Typesense
watchlist-collection round-trip + **one** batched Postgres lookup per
page — no per-row fan-out for non-anyCompany rows).

## Gates

- `pnpm test` — 1197 / 1197 pass (130 files)
- `pnpm exec tsc --noEmit` — clean

## Test plan

- [ ] Open https://jseek.co/en/explore (or the Discover watchlists surface)
- [ ] Find an `anyCompany` watchlist tile (e.g. https://jseek.co/en/openclawwt/usa-software-engineer-entry-level-2yoe)
- [ ] Pre-fix: tile shows `0 jobs`. Post-fix: tile shows the same count as the detail page.
- [ ] Anonymous viewer + EN locale: tile count matches detail (locale-scoped) count.
- [ ] Logged-in viewer with a `jobLanguages` preference: tile count matches detail under the same language scope.

## Related

- #3333 (closed via #3340 — `getUserWatchlists` only)
- #3344 (closed via #3347 — added viewer-language scope to `_resolveAnyCompanyActiveCount`)
- #3262 (introduced denormalized `active_job_count`)
- #3176 (the original listing-perf cutover that made the denormalized read possible)

🤖 Generated with [Claude Code](https://claude.com/claude-code)