### PR TITLE
fix(web): restore EU macro location filter on /explore (closes #3350)

### DIFF
--- a/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
+++ b/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
@@ -20,15 +20,19 @@ vi.mock("@/lib/actions/explore-data", async () => {
 
 // SearchPage has a heavy dependency tree (Lingui i18n, Typesense provider,
 // etc.). Stub it out — this suite is testing the conditional-fetch logic
-// in ExploreContent, not SearchPage's behaviour.
+// in ExploreContent, not SearchPage's behaviour. Renders a marker with the
+// initialTotalCompanies prop so the data-routing regression test in #3350
+// can assert which dataset the page mounted ``SearchPage`` with.
 vi.mock("../search-page", () => ({
-  SearchPage: () => null,
+  SearchPage: ({ initialTotalCompanies }: { initialTotalCompanies: number }) => (
+    <div data-testid="search-page" data-total={initialTotalCompanies} />
+  ),
 }));
 
-// Skeleton stub — we just need a deterministic render output to check
-// that the component falls back to it when no data is available.
+// Skeleton stub — a distinct marker so the #3350 regression test can
+// assert which branch (skeleton vs SearchPage) is currently rendered.
 vi.mock("@/components/search/explore-skeleton", () => ({
-  ExploreSkeleton: () => null,
+  ExploreSkeleton: () => <div data-testid="explore-skeleton" />,
 }));
 
 // `useSearchParams` from `next/navigation` returns a `URLSearchParams`-like
@@ -219,6 +223,78 @@ describe("ExploreContent — server-render initial-data path (#2640)", () => {
       );
 
       await new Promise((r) => setTimeout(r, 0));
+      expect(mockFetchExploreData).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("filter-param visits unmount SearchPage until refetch lands (#3350)", () => {
+    // Regression coverage for #3350. The #2746 prerender path embeds the
+    // ANONYMOUS, NO-FILTER ``ExploreData`` as ``initialData``. If
+    // ``ExploreContent`` mounted ``SearchPage`` with that stale dataset
+    // and only later swapped ``data`` once the personalised fetch
+    // returned, ``SearchPage``'s ``useState`` initialisers (companies,
+    // locations, totals…) would already be locked in on the unfiltered
+    // defaults — so the filtered result list would never appear. The fix
+    // is to render the skeleton between mount and fetch completion when
+    // a refetch is needed, so ``SearchPage`` mounts ONCE with the
+    // filtered data.
+    it("renders ExploreSkeleton — NOT SearchPage with stale initialData — between mount and the filtered fetch resolution", async () => {
+      currentSearchParams = new URLSearchParams("loc=eu");
+      const filteredData = makeInitialData({
+        result: { companies: [], totalCompanies: 1133, truncated: false } as unknown as ExploreData["result"],
+      });
+      const unfilteredInitial = makeInitialData({
+        result: { companies: [], totalCompanies: 3928, truncated: false } as unknown as ExploreData["result"],
+      });
+
+      // Use a never-resolving promise initially so we can observe the
+      // skeleton-while-pending state, then resolve to the filtered data.
+      let resolve: (v: ExploreData) => void = () => {};
+      mockFetchExploreData.mockReturnValueOnce(
+        new Promise<ExploreData>((r) => {
+          resolve = r;
+        }),
+      );
+
+      const { queryByTestId } = render(
+        <ExploreContent locale="en" initialData={unfilteredInitial} />,
+      );
+
+      // While the fetch is pending the skeleton must be on screen — the
+      // unfiltered ``initialTotalCompanies=3928`` MUST NOT have been
+      // handed to ``SearchPage``, otherwise the filter regression
+      // recurs.
+      await waitFor(() => {
+        expect(queryByTestId("explore-skeleton")).not.toBeNull();
+      });
+      expect(queryByTestId("search-page")).toBeNull();
+
+      resolve(filteredData);
+
+      await waitFor(() => {
+        expect(queryByTestId("search-page")).not.toBeNull();
+      });
+      expect(queryByTestId("explore-skeleton")).toBeNull();
+      expect(queryByTestId("search-page")?.getAttribute("data-total")).toBe(
+        "1133",
+      );
+    });
+
+    it("for an anonymous no-filter visit, SearchPage mounts directly with the prerendered initialData (#2640 ISR path preserved)", async () => {
+      const initialData = makeInitialData({
+        result: { companies: [], totalCompanies: 3928, truncated: false } as unknown as ExploreData["result"],
+      });
+      const { queryByTestId } = render(
+        <ExploreContent locale="en" initialData={initialData} />,
+      );
+
+      await waitFor(() => {
+        expect(queryByTestId("search-page")).not.toBeNull();
+      });
+      expect(queryByTestId("explore-skeleton")).toBeNull();
+      expect(queryByTestId("search-page")?.getAttribute("data-total")).toBe(
+        "3928",
+      );
       expect(mockFetchExploreData).not.toHaveBeenCalled();
     });
   });

--- a/apps/web/app/[lang]/(app)/explore/explore-content.tsx
+++ b/apps/web/app/[lang]/(app)/explore/explore-content.tsx
@@ -83,6 +83,20 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
       initialData === undefined;
     if (!needsPersonalizedFetch) return;
 
+    // Clear ``data`` BEFORE firing the personalised fetch so
+    // ``SearchPage`` doesn't mount with the stale prerendered
+    // ``initialData`` and lock its ``useState``-initialised filter /
+    // result state to the unfiltered defaults — the subsequent
+    // ``setData(filtered)`` would otherwise re-render ``ExploreContent``
+    // with new ``initialX`` props, but ``SearchPage``'s state
+    // initialisers only run on first mount, so the filtered companies
+    // would never appear in the UI. By unmounting ``SearchPage`` (via
+    // ``ExploreSkeleton``) while the filtered fetch is in flight, the
+    // remount on data arrival re-initialises every ``useState``
+    // initialiser with the filtered data. Issue #3350 (regression of
+    // the #2746 ISR-prerender path for filter-bearing URLs).
+    setData(null);
+
     const sp: Record<string, string | undefined> = {};
     searchParams.forEach((value, key) => {
       sp[key] = value;
@@ -90,10 +104,15 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
     fetchExploreDataWithRetry({ searchParams: sp, locale })
       .then(setData)
       .catch((err) => {
-        // Both attempts failed; keep the prerendered ``initialData``
-        // so the page doesn't go empty mid-render. Log so production
-        // observability picks up the cold-start spike (#3008).
+        // Both attempts failed. Fall back to the prerendered
+        // ``initialData`` so the page doesn't sit on the skeleton
+        // forever; the user can retry by clicking a filter or
+        // refreshing. Filters in the URL won't be visible in the
+        // toolbar because the prerender doesn't carry them, but that
+        // matches the pre-#2746 cold-error behaviour and beats a
+        // permanent skeleton.
         console.error("[explore] fetchExploreData failed twice", err);
+        if (initialData) setData(initialData);
       });
     // Empty deps: the conditional-fetch decision is made once on
     // mount. ``initialData`` is stable across re-renders (page


### PR DESCRIPTION
## Summary

\`/en/explore?loc=eu\` (and every other filter searchParam) ignored the filter — the UI showed global top companies (Accenture, McDonald's, Starbucks) instead of EU-only postings, and the filter pill never appeared in the toolbar.

## Root cause

The #2746 ISR-prerender path: \`page.tsx\` is fully cached and embeds an ANONYMOUS, NO-FILTER \`ExploreData\` as \`initialData\` for every visitor (the zero-function-cost CDN optimisation). \`ExploreContent\` then mounted \`SearchPage\` with that stale dataset and only later swapped \`data\` once the personalised \`fetchExploreData({searchParams:{loc:'eu'}})\` server action returned.

But every \`SearchPage\` filter / result piece of state is initialised via \`useState(initialX)\` — **those initialisers only run on first mount**. The subsequent \`setData(filtered)\` re-rendered \`ExploreContent\` with new \`initialX\` props, but \`SearchPage\` kept its already-locked unfiltered state. So:

- \`initialCompanies={filteredCompanies}\` → ignored (\`useState(initialCompanies)\` already ran)
- \`initialLocations={[{slug:'eu',...}]}\` → ignored (no EU pill)
- \`initialTotalCompanies={1133}\` → ignored (still showing 3,928)

The server action did its job. Direct Typesense verification confirms the right query was emitted: \`location_ids:[4] && locales:[en,_none]\` → 39,760 EU postings vs 644,804 global. The bug was purely client-side wiring.

## Fix (1-line core)

In \`ExploreContent.useEffect\`, set \`data = null\` immediately before firing the personalised fetch, so \`ExploreSkeleton\` renders during the in-flight window and \`SearchPage\` mounts ONCE — with the filtered data — when the fetch resolves.

The fix is scoped to the filter-param branch: anonymous, no-filter visits still get the prerendered \`initialData\` directly with zero function invocations (#2640 / #2746 contract preserved).

## Count alignment evidence

| Surface | Top company | activeMatches |
|---|---|---|
| Typesense direct (\`location_ids:[4]\`) | 0e0f84c9... | 1,449 |
| Typesense direct | 0d4794af... | 1,235 |
| Typesense direct | e383d2ed... | 1,111 |
| Typesense direct | 4ab0f9f6... | 1,032 |
| UI on \`/en/explore?loc=eu\` (after fix) | PwC | **1,449** |
| UI | Amazon | **1,235** |
| UI | EY | **1,111** |
| UI | Capgemini | **1,032** |

Postings rendered under each company are EU-only: Athens, Zagreb, Rome, Copenhagen, The Hague, Luxembourg, Venice, Dublin, Warsaw, Bratislava.

Unfiltered (\`/en/explore\`) unchanged: Accenture (54k+), McDonald's, Starbucks — global top, as expected.

## Screenshots

- Filtered: \`/tmp/eu-final-filtered.png\` shows the **EU pill in the toolbar** ("Save this search | EU | Clear all"), PwC as top company with 1,449 active, and EU-based postings.
- Unfiltered: \`/tmp/eu-final-unfiltered.png\` shows Accenture/McDonald's/Starbucks at the top with global counts — the ISR fast path is intact.

## Regression coverage

Two new tests in \`explore-content.test.tsx\`:

1. With \`?loc=eu\` and a pending \`fetchExploreData\` promise: \`ExploreSkeleton\` renders, \`SearchPage\` does NOT — proves the unfiltered \`initialTotalCompanies=3928\` never reaches \`SearchPage\`'s state initialisers. On resolve, \`SearchPage\` mounts with the filtered \`initialTotalCompanies=1133\`.
2. Anonymous no-filter visit: \`SearchPage\` mounts directly with the prerendered \`initialTotalCompanies=3928\`, no fetch issued — the #2640 ISR fast path stays intact.

The \`SearchPage\` mock now exposes \`data-total={initialTotalCompanies}\` and \`ExploreSkeleton\` exposes a \`data-testid\` so the tests can assert which branch is on screen.

## Test plan

- [x] \`pnpm exec vitest run\` — 1,181 passing (1,179 + 2 new); only pre-existing \`app/mcp/route.test.ts\` failure unrelated to this change
- [x] \`pnpm exec tsc --noEmit\` — clean
- [x] Playwright empirical reproduction: \`/en/explore?loc=eu\` shows EU pill + filtered companies (PwC, Amazon, EY) with counts matching direct Typesense
- [x] Playwright control: \`/en/explore\` unchanged (Accenture/McDonald's/Starbucks)
- [x] Filter pill, "Clear all" button, EU posting locations all visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)