### PR TITLE
fix(web): reject empty-companies no-filter snapshot (closes #3354)

### DIFF
--- a/apps/web/src/components/SearchStateProvider.tsx
+++ b/apps/web/src/components/SearchStateProvider.tsx
@@ -67,8 +67,21 @@ export function buildCacheKey(
  * ``ZeroResults`` even though the URL had no filters and the
  * prerendered ``initialData`` had ~10 top companies. See #2989.
  *
+ * Additional guard (#3354): never restore a snapshot whose
+ * ``companies`` is empty AND whose ``cacheKey`` represents the no-
+ * filter view (``||||``). The snapshot only serves the
+ * "return to the same view after a posting-detail dive" use case — but
+ * an empty unfiltered result is never a legitimate destination (the
+ * homepage always has top companies). The empty state arises only from
+ * transient Typesense / cache degradation poisoning the snapshot, and
+ * restoring it traps the user on a permanently empty page even after
+ * the back end recovers, because the fresh prerendered top-10 in
+ * ``initialCompanies`` is overridden by the empty snapshot.
+ *
  * Restoration semantics now:
- *   - Same URL filters (or both empty) → restore the snapshot.
+ *   - Same URL filters (or both empty), snapshot has results → restore.
+ *   - Same URL filters (or both empty), snapshot has empty companies
+ *     AND the no-filter cacheKey → ignore (#3354 poison guard).
  *   - Different URL filters → ignore the snapshot, render the fresh
  *     ``initialData`` from the server prerender / re-fetch.
  *
@@ -76,12 +89,28 @@ export function buildCacheKey(
  * to the same view after a posting-detail dive) without the poisoning
  * footgun.
  */
+const NO_FILTER_CACHE_KEY = "||||";
+
 export function shouldRestoreSnapshot(
   cached: SearchStateSnapshot | null,
   currentCacheKey: string,
 ): boolean {
   if (cached === null) return false;
-  return cached.cacheKey === currentCacheKey;
+  if (cached.cacheKey !== currentCacheKey) return false;
+  // #3354 poison guard: an unfiltered snapshot with 0 companies is
+  // always a degraded prior state (Typesense glitch / silent failure)
+  // and never a legitimate "saved view" worth restoring. Reject it so
+  // the fresh ``initialCompanies`` from the server prerender / refetch
+  // can render. Filtered empty snapshots stay restorable because a
+  // 0-result keyword search IS a legitimate destination the user may
+  // want to return to.
+  if (
+    cached.cacheKey === NO_FILTER_CACHE_KEY &&
+    cached.companies.length === 0
+  ) {
+    return false;
+  }
+  return true;
 }
 
 /** Live callbacks the search page registers so the header SearchBar can interact directly. */

--- a/apps/web/src/components/__tests__/SearchStateProvider-empty-snapshot-poison.test.tsx
+++ b/apps/web/src/components/__tests__/SearchStateProvider-empty-snapshot-poison.test.tsx
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import { render, act } from "@testing-library/react";
+import { useEffect } from "react";
+import {
+  SearchStateProvider,
+  useSearchStateStore,
+  shouldRestoreSnapshot,
+  buildCacheKey,
+} from "@/components/SearchStateProvider";
+import type { SearchResultCompany } from "@/lib/search";
+
+/**
+ * Regression test for #3354 — empty-snapshot poison.
+ *
+ * The #2989 strict cache-key match closed the "filtered snapshot leaks
+ * onto unfiltered URL" leg of snapshot poisoning. But the no-filter ↔
+ * no-filter leg (cacheKey ``||||`` on both sides) remained vulnerable:
+ * if the snapshot's ``companies`` was empty (because the prior visit
+ * hit a transient Typesense glitch / cached degraded prerender), every
+ * subsequent /explore visit restored it, trapping the user on
+ * "empty results AND no filters" even though the fresh
+ * ``initialCompanies`` carried the top-10. The added poison guard in
+ * ``shouldRestoreSnapshot`` rejects this exact shape.
+ */
+
+interface FakeSearchPageProps {
+  initialKeywords: string[];
+  initialCompanies: SearchResultCompany[];
+  onResolved: (state: { keywords: string[]; companies: SearchResultCompany[] }) => void;
+}
+
+function FakeSearchPage({
+  initialKeywords,
+  initialCompanies,
+  onResolved,
+}: FakeSearchPageProps) {
+  const { get, set } = useSearchStateStore();
+  const cached = get();
+  const currentCacheKey = buildCacheKey(initialKeywords, [], [], [], []);
+  const shouldRestore = shouldRestoreSnapshot(cached, currentCacheKey);
+
+  const resolvedKeywords = shouldRestore && cached ? cached.keywords : initialKeywords;
+  const resolvedCompanies = shouldRestore && cached ? cached.companies : initialCompanies;
+
+  useEffect(() => {
+    onResolved({ keywords: resolvedKeywords, companies: resolvedCompanies });
+  }, [onResolved, resolvedKeywords, resolvedCompanies]);
+
+  useEffect(() => {
+    return () => {
+      set({
+        keywords: resolvedKeywords,
+        locations: [],
+        occupations: [],
+        seniorities: [],
+        technologies: [],
+        workMode: [],
+        salaryMinEur: undefined,
+        salaryMaxEur: undefined,
+        salaryCurrency: "EUR",
+        experienceMin: undefined,
+        experienceMax: undefined,
+        companies: resolvedCompanies,
+        totalCompanies: resolvedCompanies.length,
+        showPostingId: null,
+        scrollY: 0,
+        cacheKey: buildCacheKey(resolvedKeywords, [], [], [], []),
+      });
+    };
+  }, [set, resolvedCompanies, resolvedKeywords]);
+
+  return null;
+}
+
+function makeCompany(id: string, name: string): SearchResultCompany {
+  return {
+    company: { id, name, slug: name.toLowerCase(), icon: null },
+    activeMatches: 1,
+    yearMatches: 1,
+    postings: [],
+  };
+}
+
+function ControlledHost({
+  phase,
+  onResolved,
+  freshCompanies,
+}: {
+  phase: 1 | "between" | 2;
+  onResolved: (state: { keywords: string[]; companies: SearchResultCompany[] }) => void;
+  freshCompanies: SearchResultCompany[];
+}) {
+  if (phase === 1) {
+    // Phase 1: SearchPage with NO filters AND 0 companies (simulating
+    // a glitched initialCompanies from the cached prerender). State
+    // initializes to companies=[], filters=[]. cacheKey="||||".
+    return (
+      <FakeSearchPage
+        key="poisoned"
+        initialKeywords={[]}
+        initialCompanies={[]}
+        onResolved={onResolved}
+      />
+    );
+  }
+  if (phase === 2) {
+    return (
+      <FakeSearchPage
+        key="fresh"
+        initialKeywords={[]}
+        initialCompanies={freshCompanies}
+        onResolved={onResolved}
+      />
+    );
+  }
+  return null;
+}
+
+describe("SearchStateProvider — #3354 empty-snapshot poison", () => {
+  it("does NOT restore an empty-companies no-filter snapshot onto a fresh /explore mount", async () => {
+    const observed: { keywords: string[]; companies: SearchResultCompany[] }[] = [];
+    const onResolved = (s: typeof observed[number]) => observed.push(s);
+
+    const top10 = Array.from({ length: 10 }, (_, i) =>
+      makeCompany(`c-${i}`, `Company ${i}`),
+    );
+
+    let view: ReturnType<typeof render>;
+
+    // Phase 1: FakeSearchPage mounts with EMPTY filters AND 0 companies,
+    // mirroring the state SearchPage would land in if its first
+    // ``initialCompanies`` were degraded — or if a ``runSearch`` returned
+    // a transient empty result. Snapshot is not yet written.
+    await act(async () => {
+      view = render(
+        <SearchStateProvider>
+          <ControlledHost
+            phase={1}
+            onResolved={onResolved}
+            freshCompanies={top10}
+          />
+        </SearchStateProvider>,
+      );
+    });
+    expect(observed.at(-1)).toEqual({
+      keywords: [],
+      companies: [],
+    });
+
+    // Phase "between": unmount. The cleanup writes the poisoned snapshot
+    // (cacheKey="||||", companies=[]). Without the intermediate phase
+    // the cleanup would race with the next mount's ``get()`` call.
+    await act(async () => {
+      view!.rerender(
+        <SearchStateProvider>
+          <ControlledHost
+            phase="between"
+            onResolved={onResolved}
+            freshCompanies={top10}
+          />
+        </SearchStateProvider>,
+      );
+    });
+
+    // Phase 2: fresh /explore visit — URL has no filters, prerendered
+    // ``initialCompanies`` has 10 top companies. With the poison guard
+    // the snapshot's empty companies are rejected and the fresh
+    // top-10 renders. Without it, the user would be trapped on
+    // "empty + no filters" (the symptom in #3354).
+    await act(async () => {
+      view!.rerender(
+        <SearchStateProvider>
+          <ControlledHost
+            phase={2}
+            onResolved={onResolved}
+            freshCompanies={top10}
+          />
+        </SearchStateProvider>,
+      );
+    });
+
+    const final = observed.at(-1);
+    expect(final?.keywords).toEqual([]);
+    expect(final?.companies).toHaveLength(10);
+  });
+});

--- a/apps/web/src/components/__tests__/SearchStateProvider.test.tsx
+++ b/apps/web/src/components/__tests__/SearchStateProvider.test.tsx
@@ -112,12 +112,45 @@ describe("shouldRestoreSnapshot — #2989 regression", () => {
     expect(shouldRestoreSnapshot(cached, currentKey)).toBe(true);
   });
 
-  it("returns true when both snapshot and URL have no filters", () => {
+  it("returns true when both snapshot and URL have no filters AND snapshot has results", () => {
+    // The legitimate restore case: user previously viewed /explore (no
+    // filters, top companies loaded), drilled into a posting, comes
+    // back. cacheKey "||||" on both sides, snapshot has the top
+    // companies it last saw, restoring preserves the scroll position
+    // and result list.
     const cached = makeSnapshot({
       cacheKey: buildCacheKey([], [], [], [], []),
+      companies: [
+        {
+          company: { id: "c1", name: "Acme", slug: "acme", icon: null },
+          activeMatches: 1,
+          yearMatches: 1,
+          postings: [],
+        },
+      ] as SearchResultCompany[],
+      totalCompanies: 1,
     });
     const currentKey = buildCacheKey([], [], [], [], []);
     expect(shouldRestoreSnapshot(cached, currentKey)).toBe(true);
+  });
+
+  /**
+   * #3354 poison guard: an unfiltered snapshot with 0 companies is a
+   * degraded state (Typesense glitch / cache miss) and must NEVER be
+   * restored — restoring it traps the user on a permanently empty page
+   * even though the fresh ``initialCompanies`` prerender carries the
+   * real top-10. The strict cache-key match alone wasn't enough
+   * because the no-filter cacheKey ``||||`` legitimately matches every
+   * fresh /explore visit.
+   */
+  it("does NOT restore an empty-companies snapshot when both have no filters (#3354)", () => {
+    const cached = makeSnapshot({
+      cacheKey: buildCacheKey([], [], [], [], []),
+      companies: [] as SearchResultCompany[],
+      totalCompanies: 0,
+    });
+    const currentKey = buildCacheKey([], [], [], [], []);
+    expect(shouldRestoreSnapshot(cached, currentKey)).toBe(false);
   });
 
   /**


### PR DESCRIPTION
## Summary
- `/en/explore` could load with **empty results AND no filters** after a series of watchlist-related navigations. Refresh recovered. Reported during the #3353 watchlist-scroll repro session.
- Root cause: the #2989 strict cache-key match closed the "filtered → unfiltered" snapshot leak, but the **unfiltered ↔ unfiltered** leg remained vulnerable. A poisoned snapshot (cacheKey `||||`, companies `[]`) restored on every `/explore` mount, with the fresh `initialCompanies` top-10 being overridden.

## How the poison persists
1. Some prior visit left SearchPage with `companies: []` AND empty filters (a transient Typesense glitch / degraded cached prerender propagating into the page-level `'use cache'`).
2. SearchPage unmounted → cleanup wrote that exact shape as snapshot.
3. Every subsequent `/explore` visit had `currentCacheKey === "||||"` (no URL filters), matched the snapshot's `cacheKey`, and restored the empty `companies`.
4. The restored empty state immediately became the next unmount state, re-writing the same poison. Snapshot was self-perpetuating.

## Fix
Add a poison guard in `shouldRestoreSnapshot`: when `cached.cacheKey === "||||"` AND `cached.companies.length === 0`, reject the restore. An unfiltered empty result is never a legitimate "return to where I was" destination — the homepage always has top companies. Filtered empty snapshots stay restorable (0-result keyword search IS a legitimate destination).

## Investigation method
- Read the issue + 3350 PR ancestry: confirmed #3357 (just-merged) fixes a different facet of the same root issue (filtered-URL ignored) but doesn't block snapshot poisoning of the unfiltered case.
- Cold-read the SearchPage / SearchStateProvider / ExploreContent lifecycle to identify the no-filter ↔ no-filter restoration path.
- Wrote a Vitest reproducer mirroring SearchPage's mount/unmount snapshot lifecycle. Test failed before fix, passes after.
- Ran Playwright through the exact navigation sequence from the issue on local dev — never hit the empty state, but the dev server doesn't expose the Typesense-glitch poisoning scenario (which is the real-world trigger).

## Test plan
- [x] `pnpm test` — 1206/1206 pass (132 files); new integration test covers the lifecycle, updated unit tests guard the predicate.
- [x] `pnpm exec tsc --noEmit` — clean.
- [x] `pnpm exec eslint <changed files>` — clean.
- [x] Playwright run of the issue's exact sequence (10 iterations) — `/explore` filter pill renders, no empty state observed.

Closes #3354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)