### PR TITLE
Harden public search filter inputs

### DIFF
--- a/apps/web/app/api/v1/search/route.test.ts
+++ b/apps/web/app/api/v1/search/route.test.ts
@@ -156,6 +156,35 @@ describe("GET /api/v1/search — lang= param (issue #3230)", () => {
     expect(url.searchParams.get("q")).toBe("engineer");
   });
 
+  it("rejects malformed `sal=` instead of forwarding NaN", async () => {
+    const { body } = await callRoute("?locale=en&sal=abc-def");
+    expect(body.error).toMatch(/Invalid 'sal' param/);
+    expect(mocks.listTopCompanies).not.toHaveBeenCalled();
+    expect(mocks.searchJobs).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed `exp=` instead of building an invalid Typesense filter", async () => {
+    const { body } = await callRoute("?locale=en&exp=3-nope");
+    expect(body.error).toMatch(/Invalid 'exp' param/);
+    expect(mocks.listTopCompanies).not.toHaveBeenCalled();
+    expect(mocks.searchJobs).not.toHaveBeenCalled();
+  });
+
+  it("rejects reversed numeric ranges", async () => {
+    const { body } = await callRoute("?locale=en&sal=200000-100000");
+    expect(body.error).toMatch(/min cannot be greater than max/);
+    expect(mocks.listTopCompanies).not.toHaveBeenCalled();
+  });
+
+  it("forwards valid `sal=` and `exp=` ranges as numbers", async () => {
+    await callRoute("?locale=en&sal=90000-140000&exp=3-7");
+    const call = mocks.listTopCompanies.mock.calls[0][0];
+    expect(call.salaryMinEur).toBe(90000);
+    expect(call.salaryMaxEur).toBe(140000);
+    expect(call.experienceMin).toBe(3);
+    expect(call.experienceMax).toBe(7);
+  });
+
   it("forwards `wm=remote` into `moreAt` (regression for lost work-mode param)", async () => {
     // The API already accepted `wm` and forwarded it to searchJobs, but
     // the moreAt-URL builder was dropping it (#3230 audit). After this

--- a/apps/web/app/api/v1/search/route.ts
+++ b/apps/web/app/api/v1/search/route.ts
@@ -58,6 +58,50 @@ function parseLangParam(raw: string | null): {
   return { ok: true, langs: Array.from(new Set(parts)) };
 }
 
+function parseIntegerRangeParam(
+  name: "sal" | "exp",
+  raw: string | undefined,
+): {
+  ok: true;
+  min: number | undefined;
+  max: number | undefined;
+} | {
+  ok: false;
+  error: string;
+} {
+  if (!raw) return { ok: true, min: undefined, max: undefined };
+
+  const parts = raw.split("-");
+  if (parts.length > 2) {
+    return { ok: false, error: `Invalid '${name}' param: expected min-max` };
+  }
+
+  const parseBound = (value: string): number | undefined => {
+    const trimmed = value.trim();
+    if (trimmed === "") return undefined;
+    if (!/^\d+$/.test(trimmed)) return Number.NaN;
+    return Number.parseInt(trimmed, 10);
+  };
+
+  const min = parseBound(parts[0] ?? "");
+  const max = parseBound(parts[1] ?? "");
+  if (Number.isNaN(min) || Number.isNaN(max)) {
+    return {
+      ok: false,
+      error: `Invalid '${name}' param: bounds must be positive integers`,
+    };
+  }
+
+  if (min !== undefined && max !== undefined && min > max) {
+    return {
+      ok: false,
+      error: `Invalid '${name}' param: min cannot be greater than max`,
+    };
+  }
+
+  return { ok: true, min, max };
+}
+
 export async function GET(request: NextRequest) {
   const rl = await checkRateLimit(request);
   if (rl instanceof NextResponse) return rl;
@@ -99,20 +143,14 @@ export async function GET(request: NextRequest) {
       ? parsed.technologies.map((t) => t.id)
       : undefined;
 
-  let salaryMinEur: number | undefined;
-  let salaryMaxEur: number | undefined;
-  if (sal) {
-    const [minStr, maxStr] = sal.split("-");
-    salaryMinEur = minStr ? parseInt(minStr, 10) : undefined;
-    salaryMaxEur = maxStr ? parseInt(maxStr, 10) : undefined;
+  const salaryRange = parseIntegerRangeParam("sal", sal);
+  if (!salaryRange.ok) {
+    return apiResponse({ error: salaryRange.error }, { maxAge: 0 });
   }
 
-  let experienceMin: number | undefined;
-  let experienceMax: number | undefined;
-  if (exp) {
-    const [minStr, maxStr] = exp.split("-");
-    experienceMin = minStr ? parseInt(minStr, 10) : undefined;
-    experienceMax = maxStr ? parseInt(maxStr, 10) : undefined;
+  const experienceRange = parseIntegerRangeParam("exp", exp);
+  if (!experienceRange.ok) {
+    return apiResponse({ error: experienceRange.error }, { maxAge: 0 });
   }
 
   const searchParams = {
@@ -121,10 +159,10 @@ export async function GET(request: NextRequest) {
     seniorityIds,
     technologyIds,
     workMode: parsed.workMode.length > 0 ? parsed.workMode : undefined,
-    salaryMinEur,
-    salaryMaxEur,
-    experienceMin,
-    experienceMax,
+    salaryMinEur: salaryRange.min,
+    salaryMaxEur: salaryRange.max,
+    experienceMin: experienceRange.min,
+    experienceMax: experienceRange.max,
     languages,
     locale,
     offset: 0,

--- a/apps/web/src/lib/search/__tests__/typesense-filters.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense-filters.test.ts
@@ -98,6 +98,41 @@ describe("buildFilterString — workMode (#2983)", () => {
     expect(buildFilterString({ workMode: undefined })).toBe("");
     expect(buildFilterString({ workMode: [] })).toBe("");
   });
+
+  it("drops unknown workMode tokens before interpolation", () => {
+    expect(buildFilterString({ workMode: ["remote", "x) || is_active:true"] })).toBe(
+      "location_types:[remote]",
+    );
+  });
+});
+
+describe("buildFilterString — input hardening", () => {
+  it("drops non-numeric array entries instead of interpolating them", () => {
+    const out = buildFilterString({
+      locationIds: [101, "102) || is_active:true"],
+      technologyIds: [10, Number.NaN, -1, 11],
+    });
+    expect(out).toBe("location_ids:[101] && technology_ids:[10,11]");
+  });
+
+  it("drops invalid token-list values", () => {
+    const out = buildFilterString({
+      employmentTypes: ["full-time", "contract] || is_active:true"],
+      languages: ["en", "fr,remote"],
+    });
+    expect(out).toBe("employment_type:[full-time] && locales:[en,_none]");
+  });
+
+  it("does not emit NaN numeric ranges", () => {
+    expect(
+      buildFilterString({
+        salaryMinEur: Number.NaN,
+        salaryMaxEur: Number.NaN,
+        experienceMin: Number.NaN,
+        experienceMax: Number.NaN,
+      }),
+    ).toBe("");
+  });
 });
 
 // =====================================================================

--- a/apps/web/src/lib/search/typesense-filters.ts
+++ b/apps/web/src/lib/search/typesense-filters.ts
@@ -42,6 +42,44 @@ export const POSTING_BASE_FILTER = "is_active:true && has_content:!=false";
  */
 export const POSTING_FLOW_FILTER = "has_content:!=false";
 
+export type TypesenseFilterInput = {
+  companyId?: unknown;
+  locationIds?: unknown;
+  occupationIds?: unknown;
+  seniorityIds?: unknown;
+  technologyIds?: unknown;
+  employmentTypes?: unknown;
+  workMode?: unknown;
+  salaryMinEur?: unknown;
+  salaryMaxEur?: unknown;
+  experienceMin?: unknown;
+  experienceMax?: unknown;
+  languages?: unknown;
+};
+
+const WORK_MODES = new Set(["remote", "hybrid", "onsite"]);
+
+function numericList(value: unknown): number[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(
+    (item): item is number =>
+      typeof item === "number" && Number.isInteger(item) && item >= 0,
+  );
+}
+
+function tokenList(value: unknown, allowed?: Set<string>): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is string => {
+    if (typeof item !== "string") return false;
+    if (!/^[a-z0-9_-]+$/i.test(item)) return false;
+    return allowed ? allowed.has(item) : true;
+  });
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
 /**
  * Build a Typesense filter_by string from user-specified filter dimensions.
  *
@@ -49,10 +87,7 @@ export const POSTING_FLOW_FILTER = "has_content:!=false";
  * {@link POSTING_BASE_FILTER} (or its parts) explicitly. Returns an empty
  * string when no filters are active.
  */
-export function buildFilterString(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  filters: any,
-): string {
+export function buildFilterString(filters?: TypesenseFilterInput | null): string {
   if (!filters) return "";
   const parts: string[] = [];
 
@@ -60,28 +95,36 @@ export function buildFilterString(
   // directly with arbitrary strings. Shape-validate before raw interpolation
   // so a hostile caller can't break out of the filter clause. Bad input is
   // dropped silently — a missing company scope is safer than an injection.
-  if (filters.companyId && /^[0-9a-z_-]{8,64}$/i.test(filters.companyId)) {
+  if (
+    typeof filters.companyId === "string" &&
+    /^[0-9a-z_-]{8,64}$/i.test(filters.companyId)
+  ) {
     parts.push(`company_id:=${filters.companyId}`);
   }
 
-  if (filters.locationIds?.length) {
-    parts.push(`location_ids:[${filters.locationIds.join(",")}]`);
+  const locationIds = numericList(filters.locationIds);
+  if (locationIds.length) {
+    parts.push(`location_ids:[${locationIds.join(",")}]`);
   }
 
-  if (filters.occupationIds?.length) {
-    parts.push(`occupation_ids:[${filters.occupationIds.join(",")}]`);
+  const occupationIds = numericList(filters.occupationIds);
+  if (occupationIds.length) {
+    parts.push(`occupation_ids:[${occupationIds.join(",")}]`);
   }
 
-  if (filters.seniorityIds?.length) {
-    parts.push(`seniority_id:[${filters.seniorityIds.join(",")}]`);
+  const seniorityIds = numericList(filters.seniorityIds);
+  if (seniorityIds.length) {
+    parts.push(`seniority_id:[${seniorityIds.join(",")}]`);
   }
 
-  if (filters.technologyIds?.length) {
-    parts.push(`technology_ids:[${filters.technologyIds.join(",")}]`);
+  const technologyIds = numericList(filters.technologyIds);
+  if (technologyIds.length) {
+    parts.push(`technology_ids:[${technologyIds.join(",")}]`);
   }
 
-  if (filters.employmentTypes?.length) {
-    parts.push(`employment_type:[${filters.employmentTypes.join(",")}]`);
+  const employmentTypes = tokenList(filters.employmentTypes);
+  if (employmentTypes.length) {
+    parts.push(`employment_type:[${employmentTypes.join(",")}]`);
   }
 
   // Work-mode filter (issue #2983). Reuses the existing `location_types`
@@ -91,17 +134,20 @@ export function buildFilterString(
   // active postings on 2026-05-09) drop out silently when this filter
   // is active — no sentinel-OR; treating unknown as bookable would
   // produce too many false positives (per issue Q4).
-  if (filters.workMode?.length) {
-    parts.push(`location_types:[${filters.workMode.join(",")}]`);
+  const workMode = tokenList(filters.workMode, WORK_MODES);
+  if (workMode.length) {
+    parts.push(`location_types:[${workMode.join(",")}]`);
   }
 
   // salary_eur is optional — only apply when user has set a meaningful salary filter (> 0)
+  const salaryMinEur = finiteNumber(filters.salaryMinEur);
+  const salaryMaxEur = finiteNumber(filters.salaryMaxEur);
   const hasSalaryFilter =
-    (filters.salaryMinEur != null && filters.salaryMinEur > 0) ||
-    (filters.salaryMaxEur != null && filters.salaryMaxEur > 0);
+    (salaryMinEur != null && salaryMinEur > 0) ||
+    (salaryMaxEur != null && salaryMaxEur > 0);
   if (hasSalaryFilter) {
-    const min = filters.salaryMinEur ?? 0;
-    const max = filters.salaryMaxEur ?? 999999;
+    const min = salaryMinEur ?? 0;
+    const max = salaryMaxEur ?? 999999;
     parts.push(`salary_eur:[${min}..${max}]`);
   }
 
@@ -120,28 +166,31 @@ export function buildFilterString(
   // `&&`, and Typesense's `&&` binds tighter than `||`. Without wrapping the
   // whole OR, a downstream `... && location_ids:[...]` would mis-parse and
   // the sentinel branch would match ALL -1 docs regardless of other filters.
-  if (filters.experienceMin != null && filters.experienceMax != null) {
+  const experienceMin = finiteNumber(filters.experienceMin);
+  const experienceMax = finiteNumber(filters.experienceMax);
+  if (experienceMin != null && experienceMax != null) {
     parts.push(
-      `((experience_min:<=${filters.experienceMax} && experience_max:>=${filters.experienceMin}) || experience_min:=-1)`,
+      `((experience_min:<=${experienceMax} && experience_max:>=${experienceMin}) || experience_min:=-1)`,
     );
-  } else if (filters.experienceMin != null) {
+  } else if (experienceMin != null) {
     // No upper bound from the user → range is `[min, ∞)`. The row's
     // experience_max must reach the user's lower bound (or above).
     parts.push(
-      `(experience_max:>=${filters.experienceMin} || experience_min:=-1)`,
+      `(experience_max:>=${experienceMin} || experience_min:=-1)`,
     );
-  } else if (filters.experienceMax != null) {
+  } else if (experienceMax != null) {
     // No lower bound → range is `[0, max]`. The row's experience_min must
     // sit at or below the user's upper bound.
     parts.push(
-      `(experience_min:<=${filters.experienceMax} || experience_min:=-1)`,
+      `(experience_min:<=${experienceMax} || experience_min:=-1)`,
     );
   }
 
   // locales uses sentinel "_none" for jobs with no detected language.
   // Include it so those jobs match any language filter.
-  if (filters.languages?.length) {
-    parts.push(`locales:[${[...filters.languages, "_none"].join(",")}]`);
+  const languages = tokenList(filters.languages);
+  if (languages.length) {
+    parts.push(`locales:[${[...languages, "_none"].join(",")}]`);
   }
 
   return parts.join(" && ");


### PR DESCRIPTION
## What
- Reject malformed `sal` / `exp` ranges before they reach search.
- Remove `any` from `buildFilterString`.
- Drop invalid array/token values before composing Typesense filters.

## Checks
- `corepack pnpm --filter @jobseek/web test -- app/api/v1/search/route.test.ts src/lib/search/__tests__/typesense-filters.test.ts src/lib/search/__tests__/typesense-filters-experience.test.ts`
- `corepack pnpm --filter @jobseek/web typecheck`