### PR TITLE
fix(web): allow zero-posting companies in watchlists

### DIFF
--- a/apps/web/src/lib/actions/__tests__/company.test.ts
+++ b/apps/web/src/lib/actions/__tests__/company.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   cacheTag: vi.fn(),
   search: vi.fn(),
   dbExecute: vi.fn(),
+  buildFilterString: vi.fn(() => ""),
 }));
 
 vi.mock("server-only", () => ({}));
@@ -54,7 +55,10 @@ vi.mock("@/lib/search/constants", () => ({
   ANON_MAX_COMPANIES: 5,
   ANON_MAX_POSTINGS: 10,
 }));
-vi.mock("@/lib/search/typesense-filters", () => ({ buildFilterString: vi.fn() }));
+vi.mock("@/lib/search/typesense-filters", () => ({
+  POSTING_BASE_FILTER: "is_active:true && has_content:!=false",
+  buildFilterString: mocks.buildFilterString,
+}));
 vi.mock("@/lib/search/pg-filters", () => ({ localesOrNoneClause: vi.fn() }));
 vi.mock("@/lib/actions/search-input", () => ({ parseSearchFilters: vi.fn() }));
 vi.mock("@/lib/search/params", () => ({
@@ -63,12 +67,13 @@ vi.mock("@/lib/search/params", () => ({
   parseRangeParam: vi.fn(),
 }));
 
-import { getCompanyBySlug } from "../company";
+import { getCompanyBySlug, searchCompaniesForWatchlist } from "../company";
 
 const searchMock = mocks.search;
 const dbExecuteMock = mocks.dbExecute;
 const cacheLifeMock = mocks.cacheLife;
 const cacheTagMock = mocks.cacheTag;
+const buildFilterStringMock = mocks.buildFilterString;
 
 const _hit = (overrides: Record<string, unknown> = {}) => ({
   id: "co-1",
@@ -95,6 +100,102 @@ beforeEach(() => {
   vi.clearAllMocks();
   searchMock.mockReset();
   dbExecuteMock.mockReset();
+  buildFilterStringMock.mockReset();
+  buildFilterStringMock.mockReturnValue("");
+});
+
+describe("searchCompaniesForWatchlist", () => {
+  it("includes companies with zero active postings in unfiltered search", async () => {
+    searchMock.mockResolvedValue({
+      found: 1,
+      hits: [{ document: _hit({ active_posting_count: 0 }) }],
+    });
+
+    const out = await searchCompaniesForWatchlist({
+      query: "Acme",
+      locale: "en",
+      offset: 0,
+      limit: 20,
+    });
+
+    expect(out.companies).toHaveLength(1);
+    expect(out.companies[0].activeMatches).toBe(0);
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({ filter_by: expect.stringContaining("active_posting_count") }),
+    );
+  });
+
+  it("does not exclude zero-posting companies when filtering by industry", async () => {
+    searchMock.mockResolvedValue({
+      found: 1,
+      hits: [{ document: _hit({ active_posting_count: 0 }) }],
+    });
+
+    await searchCompaniesForWatchlist({
+      industryId: 7,
+      locale: "en",
+      offset: 0,
+      limit: 20,
+    });
+
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ filter_by: "industry_id:=7" }),
+    );
+  });
+
+  it("keeps starred ordering without requiring active postings", async () => {
+    searchMock
+      .mockResolvedValueOnce({
+        found: 1,
+        hits: [{ document: _hit({ active_posting_count: 0 }) }],
+      })
+      .mockResolvedValueOnce({ found: 0, hits: [] });
+
+    const out = await searchCompaniesForWatchlist({
+      locale: "en",
+      offset: 0,
+      limit: 20,
+      starredCompanyIds: ["co-1"],
+    });
+
+    expect(out.companies).toHaveLength(1);
+    expect(searchMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ filter_by: "id:[co-1]" }),
+    );
+    expect(searchMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ filter_by: "id:!=[co-1]" }),
+    );
+  });
+
+  it("includes a searched zero-posting company when the watchlist has filters", async () => {
+    buildFilterStringMock.mockReturnValue("location_ids:=[42]");
+    searchMock
+      .mockResolvedValueOnce({
+        facet_counts: [{ counts: [], stats: { total_values: 0 } }],
+      })
+      .mockResolvedValueOnce({
+        found: 1,
+        hits: [{ document: _hit({ active_posting_count: 0 }) }],
+      })
+      .mockResolvedValueOnce({
+        hits: [{ document: _hit({ active_posting_count: 0 }) }],
+      });
+
+    const out = await searchCompaniesForWatchlist({
+      query: "Acme",
+      locale: "en",
+      offset: 0,
+      limit: 20,
+      locationIds: [42],
+    });
+
+    expect(out).toMatchObject({
+      total: 1,
+      companies: [{ id: "co-1", activeMatches: 0 }],
+    });
+  });
 });
 
 describe("getCompanyBySlug — Typesense path", () => {

--- a/apps/web/src/lib/actions/company.ts
+++ b/apps/web/src/lib/actions/company.ts
@@ -217,26 +217,36 @@ async function _searchCompaniesForWatchlistTypesense(params: {
 
     if (hasQuery || params.industryId != null) {
       // Query company collection to get matching company IDs, then intersect
-      const companyFilterParts: string[] = ["active_posting_count:>0"];
+      const companyFilterParts: string[] = [];
       if (params.industryId != null) companyFilterParts.push(`industry_id:=${params.industryId}`);
 
       const companyResult = await client.collections("company").documents().search({
         q: hasQuery ? q! : "*",
         query_by: "name",
-        filter_by: companyFilterParts.join(" && "),
+        ...(companyFilterParts.length > 0
+          ? { filter_by: companyFilterParts.join(" && ") }
+          : {}),
         per_page: 250, // generous limit to intersect with facets
         prefix: true,
         num_typos: 1,
       });
 
+      const companyHits = companyResult.hits ?? [];
       const companyNameSet = new Set(
-        (companyResult.hits ?? []).map((h) => (h.document as Record<string, unknown>).id as string),
+        companyHits.map((h) => (h.document as Record<string, unknown>).id as string),
       );
 
-      // Intersect: only companies that appear in both name search and facet results
-      filteredCompanyIds = facetCounts
+      // Positive matches retain facet-count ordering. A company with no active
+      // postings cannot appear in the posting facets at all, so append those
+      // matching company documents explicitly to keep them selectable (#3383).
+      const positiveMatchIds = facetCounts
         .filter((fc) => companyNameSet.has(fc.value))
         .map((fc) => fc.value);
+      const zeroPostingIds = companyHits
+        .map((hit) => hit.document as Record<string, unknown>)
+        .filter((doc) => (doc.active_posting_count as number) === 0)
+        .map((doc) => doc.id as string);
+      filteredCompanyIds = [...positiveMatchIds, ...zeroPostingIds];
       total = filteredCompanyIds.length;
     } else {
       filteredCompanyIds = facetCounts.map((fc) => fc.value);
@@ -288,17 +298,21 @@ async function _searchCompaniesForWatchlistTypesense(params: {
     };
   }
 
-  // NO WATCHLIST FILTERS: query company collection directly by active_posting_count.
-  // Much simpler — every active company is relevant.
+  // NO WATCHLIST FILTERS: query the full company collection. Companies with
+  // no active postings are still valid watchlist targets (#3383).
 
   if (wantStarredBoost) {
     // Two queries: starred first, then remaining
-    const companyFilterParts: string[] = ["active_posting_count:>0"];
+    const companyFilterParts: string[] = [];
     if (params.industryId != null) companyFilterParts.push(`industry_id:=${params.industryId}`);
     const baseFilter = companyFilterParts.join(" && ");
 
-    const starredFilter = `${baseFilter} && id:[${starredIds!.join(",")}]`;
-    const remainingFilter = `${baseFilter} && id:!=[${starredIds!.join(",")}]`;
+    const starredFilter = [baseFilter, `id:[${starredIds!.join(",")}]`]
+      .filter(Boolean)
+      .join(" && ");
+    const remainingFilter = [baseFilter, `id:!=[${starredIds!.join(",")}]`]
+      .filter(Boolean)
+      .join(" && ");
 
     const [starredResult, remainingResult] = await Promise.all([
       client.collections("company").documents().search({
@@ -346,13 +360,15 @@ async function _searchCompaniesForWatchlistTypesense(params: {
   }
 
   // Simple case: no starred, no watchlist filters, maybe text query
-  const companyFilterParts: string[] = ["active_posting_count:>0"];
+  const companyFilterParts: string[] = [];
   if (params.industryId != null) companyFilterParts.push(`industry_id:=${params.industryId}`);
 
   const result = await client.collections("company").documents().search({
     q: hasQuery ? q! : "*",
     query_by: "name",
-    filter_by: companyFilterParts.join(" && "),
+    ...(companyFilterParts.length > 0
+      ? { filter_by: companyFilterParts.join(" && ") }
+      : {}),
     sort_by: hasQuery ? "_text_match:desc,active_posting_count:desc" : "active_posting_count:desc",
     per_page: params.limit,
     page: Math.floor(params.offset / params.limit) + 1,
@@ -1874,4 +1890,3 @@ async function _fetchLocationsGrouped(
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────
-


### PR DESCRIPTION
## Summary
- include companies with zero active postings in the watchlist company search
- preserve starred and industry ordering without an active-posting eligibility gate
- include explicitly searched zero-posting companies when the watchlist itself has posting filters
- add regression coverage for unfiltered, industry, starred, and filtered-watchlist paths

## Verification
- `pnpm exec vitest run src/lib/actions/__tests__/company.test.ts` (30 passed)
- `pnpm exec eslint src/lib/actions/company.ts src/lib/actions/__tests__/company.test.ts`
- `pnpm --dir apps/web typecheck`

Closes #3383