### PR TITLE
Fix watchlist company search for filtered watchlists

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,12 +161,10 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-    # `Production` environment exposes DATABASE_URL + TYPESENSE_* secrets.
-    # The build needs DATABASE_URL because the blog `MdxMentions` server
-    # action (rendered for every per-post path during static generation)
-    # reads from Supabase — empirically validated in #2900 (replacing it
-    # with a stub DSN reproduces a Failed query / ECONNREFUSED prerender
-    # error on `/[lang]/blog/how-we-index-job-postings`).
+    # `Production` environment exposes DATABASE_URL + TYPESENSE_* secrets for
+    # trusted same-repo runs. Fork PRs deliberately receive no secrets; blog
+    # `MdxMentions` company lookups must degrade to their missing-mention
+    # fallback instead of reaching Postgres when DATABASE_URL is absent.
     environment: Production
     # Job-level env: declared once, applied to every step in the job.
     # Real secrets come from the `Production` environment above; the
@@ -176,8 +174,9 @@ jobs:
     # search/write keys are only consumed at runtime by request handlers,
     # which the build does not exercise.
     env:
-      # Required: blog `<Mention>` MDX components fetch company tooltips
-      # at build time. Without a real DSN the per-post prerender fails.
+      # Trusted runs use the real DSN so blog `<Mention>` MDX components can
+      # render company tooltips at build time. Fork runs leave this empty and
+      # exercise the secretless fallback path.
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
       DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}
       # Build-time-readable Typesense client config. Present as Production

--- a/apps/web/src/lib/actions/__tests__/company.test.ts
+++ b/apps/web/src/lib/actions/__tests__/company.test.ts
@@ -180,6 +180,9 @@ describe("searchCompaniesForWatchlist", () => {
         hits: [{ document: _hit({ active_posting_count: 0 }) }],
       })
       .mockResolvedValueOnce({
+        facet_counts: [{ counts: [], stats: { total_values: 0 } }],
+      })
+      .mockResolvedValueOnce({
         hits: [{ document: _hit({ active_posting_count: 0 }) }],
       });
 
@@ -189,6 +192,37 @@ describe("searchCompaniesForWatchlist", () => {
       offset: 0,
       limit: 20,
       locationIds: [42],
+    });
+
+    expect(out).toMatchObject({
+      total: 1,
+      companies: [{ id: "co-1", activeMatches: 0 }],
+    });
+  });
+
+  it("includes a searched active company with zero matches for the current watchlist filters", async () => {
+    buildFilterStringMock.mockReturnValue("technology_ids:=[99]");
+    searchMock
+      .mockResolvedValueOnce({
+        facet_counts: [{ counts: [], stats: { total_values: 0 } }],
+      })
+      .mockResolvedValueOnce({
+        found: 1,
+        hits: [{ document: _hit({ active_posting_count: 42 }) }],
+      })
+      .mockResolvedValueOnce({
+        facet_counts: [{ counts: [], stats: { total_values: 0 } }],
+      })
+      .mockResolvedValueOnce({
+        hits: [{ document: _hit({ active_posting_count: 42 }) }],
+      });
+
+    const out = await searchCompaniesForWatchlist({
+      query: "Acme",
+      locale: "en",
+      offset: 0,
+      limit: 20,
+      technologyIds: [99],
     });
 
     expect(out).toMatchObject({

--- a/apps/web/src/lib/actions/__tests__/company.test.ts
+++ b/apps/web/src/lib/actions/__tests__/company.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // `vi.mock` hoists to the top of the file so its factories cannot close
 // over module-scope variables. Use `vi.hoisted` to share mocks between
@@ -74,6 +74,11 @@ const dbExecuteMock = mocks.dbExecute;
 const cacheLifeMock = mocks.cacheLife;
 const cacheTagMock = mocks.cacheTag;
 const buildFilterStringMock = mocks.buildFilterString;
+const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+const ORIGINAL_TYPESENSE_HOST = process.env.TYPESENSE_HOST;
+const ORIGINAL_TYPESENSE_PORT = process.env.TYPESENSE_PORT;
+const ORIGINAL_TYPESENSE_PROTOCOL = process.env.TYPESENSE_PROTOCOL;
+const ORIGINAL_TYPESENSE_SEARCH_KEY = process.env.TYPESENSE_SEARCH_KEY;
 
 const _hit = (overrides: Record<string, unknown> = {}) => ({
   id: "co-1",
@@ -102,6 +107,36 @@ beforeEach(() => {
   dbExecuteMock.mockReset();
   buildFilterStringMock.mockReset();
   buildFilterStringMock.mockReturnValue("");
+  process.env.DATABASE_URL =
+    ORIGINAL_DATABASE_URL ?? "postgresql://test:test@localhost:5432/test";
+});
+
+afterEach(() => {
+  if (ORIGINAL_DATABASE_URL === undefined) {
+    delete process.env.DATABASE_URL;
+  } else {
+    process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+  }
+  if (ORIGINAL_TYPESENSE_HOST === undefined) {
+    delete process.env.TYPESENSE_HOST;
+  } else {
+    process.env.TYPESENSE_HOST = ORIGINAL_TYPESENSE_HOST;
+  }
+  if (ORIGINAL_TYPESENSE_PORT === undefined) {
+    delete process.env.TYPESENSE_PORT;
+  } else {
+    process.env.TYPESENSE_PORT = ORIGINAL_TYPESENSE_PORT;
+  }
+  if (ORIGINAL_TYPESENSE_PROTOCOL === undefined) {
+    delete process.env.TYPESENSE_PROTOCOL;
+  } else {
+    process.env.TYPESENSE_PROTOCOL = ORIGINAL_TYPESENSE_PROTOCOL;
+  }
+  if (ORIGINAL_TYPESENSE_SEARCH_KEY === undefined) {
+    delete process.env.TYPESENSE_SEARCH_KEY;
+  } else {
+    process.env.TYPESENSE_SEARCH_KEY = ORIGINAL_TYPESENSE_SEARCH_KEY;
+  }
 });
 
 describe("searchCompaniesForWatchlist", () => {
@@ -411,6 +446,26 @@ describe("getCompanyBySlug — Postgres fallback", () => {
 
     const out = await getCompanyBySlug("acme", "en");
     expect(out).toBeNull();
+  });
+
+  it("returns null outside the cache boundary when lookup env is not configured", async () => {
+    searchMock.mockResolvedValue(_typesenseResponse(null));
+    delete process.env.DATABASE_URL;
+    delete process.env.TYPESENSE_HOST;
+    delete process.env.TYPESENSE_PORT;
+    delete process.env.TYPESENSE_PROTOCOL;
+    delete process.env.TYPESENSE_SEARCH_KEY;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const out = await getCompanyBySlug("acme", "en");
+
+    expect(out).toBeNull();
+    expect(searchMock).not.toHaveBeenCalled();
+    expect(dbExecuteMock).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[company] lookup skipped because Typesense and DATABASE_URL are not configured",
+    );
+    warnSpy.mockRestore();
   });
 
   it("retries the Postgres query on transient ECONNRESET (#2918 follow-up)", async () => {

--- a/apps/web/src/lib/actions/__tests__/db-retry-coverage.test.ts
+++ b/apps/web/src/lib/actions/__tests__/db-retry-coverage.test.ts
@@ -131,15 +131,24 @@ const econnreset = (): Error => {
   return e;
 };
 
+const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+
 describe("issue #2930 — withDbRetry covers additional call sites", () => {
   beforeEach(() => {
     dbExecuteMock.mockReset();
     cachedMock.mockClear();
+    process.env.DATABASE_URL =
+      ORIGINAL_DATABASE_URL ?? "postgresql://test:test@localhost:5432/test";
     vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    if (ORIGINAL_DATABASE_URL === undefined) {
+      delete process.env.DATABASE_URL;
+    } else {
+      process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+    }
   });
 
   it("retries _fetchPublicWatchlistByUserAndSlug after ECONNRESET", async () => {

--- a/apps/web/src/lib/actions/__tests__/watchlists-detail-perf.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-detail-perf.test.ts
@@ -207,14 +207,22 @@ import {
 } from "../watchlists";
 
 const USER_ID = "user-1";
+const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
 
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.getSessionUserId.mockResolvedValue(USER_ID);
+  process.env.DATABASE_URL =
+    ORIGINAL_DATABASE_URL ?? "postgresql://test:test@localhost:5432/test";
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  if (ORIGINAL_DATABASE_URL === undefined) {
+    delete process.env.DATABASE_URL;
+  } else {
+    process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
+  }
 });
 
 // ---- helpers ----------------------------------------------------------
@@ -400,5 +408,20 @@ describe("getPublicWatchlistByUserAndSlug — single-query fold (#3211)", () => 
     expect(detail).toBeNull();
     expect(mocks.dbExecute).toHaveBeenCalledTimes(1);
     expect(mocks.dbSelect).not.toHaveBeenCalled();
+  });
+
+  it("returns null before the cache/DB path when DATABASE_URL is not configured", async () => {
+    delete process.env.DATABASE_URL;
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const detail = await getPublicWatchlistByUserAndSlug("alice", "my-watchlist");
+
+    expect(detail).toBeNull();
+    expect(mocks.cached).not.toHaveBeenCalled();
+    expect(mocks.dbExecute).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[watchlist] public lookup skipped because DATABASE_URL is not configured",
+    );
+    warnSpy.mockRestore();
   });
 });

--- a/apps/web/src/lib/actions/company.ts
+++ b/apps/web/src/lib/actions/company.ts
@@ -232,21 +232,35 @@ async function _searchCompaniesForWatchlistTypesense(params: {
       });
 
       const companyHits = companyResult.hits ?? [];
-      const companyNameSet = new Set(
-        companyHits.map((h) => (h.document as Record<string, unknown>).id as string),
-      );
+      const companyHitDocs = companyHits.map((hit) => hit.document as Record<string, unknown>);
+      const companyHitIds = companyHitDocs.map((doc) => doc.id as string);
 
-      // Positive matches retain facet-count ordering. A company with no active
-      // postings cannot appear in the posting facets at all, so append those
-      // matching company documents explicitly to keep them selectable (#3383).
-      const positiveMatchIds = facetCounts
-        .filter((fc) => companyNameSet.has(fc.value))
-        .map((fc) => fc.value);
-      const zeroPostingIds = companyHits
-        .map((hit) => hit.document as Record<string, unknown>)
-        .filter((doc) => (doc.active_posting_count as number) === 0)
-        .map((doc) => doc.id as string);
-      filteredCompanyIds = [...positiveMatchIds, ...zeroPostingIds];
+      if (companyHitIds.length > 0) {
+        const candidateFacetResult = await client.collections("job_posting").documents().search({
+          q: keywordsQ,
+          query_by: "title",
+          filter_by: `${activeFilter} && company_id:[${companyHitIds.join(",")}]`,
+          facet_by: "company_id",
+          facet_strategy: "exhaustive",
+          max_facet_values: companyHitIds.length,
+          per_page: 0,
+        });
+
+        for (const fc of candidateFacetResult.facet_counts?.[0]?.counts ?? []) {
+          activeMatchMap.set(fc.value, fc.count);
+        }
+      }
+
+      // Keep all company-name hits selectable. The first posting facet query
+      // only returns the top filtered companies, so exact company searches
+      // like "Google" or "Salesforce" could disappear when they had zero
+      // matches for the current watchlist filters, or when they simply were
+      // not in that first facet window.
+      const positiveMatchIds = companyHitIds
+        .filter((id) => (activeMatchMap.get(id) ?? 0) > 0)
+        .sort((a, b) => (activeMatchMap.get(b) ?? 0) - (activeMatchMap.get(a) ?? 0));
+      const zeroMatchIds = companyHitIds.filter((id) => !positiveMatchIds.includes(id));
+      filteredCompanyIds = [...positiveMatchIds, ...zeroMatchIds];
       total = filteredCompanyIds.length;
     } else {
       filteredCompanyIds = facetCounts.map((fc) => fc.value);

--- a/apps/web/src/lib/actions/company.ts
+++ b/apps/web/src/lib/actions/company.ts
@@ -643,6 +643,10 @@ export async function getCompanyBySlug(
   slug: string,
   locale: string,
 ): Promise<CompanyDetail | null> {
+  if (!canResolveCompanyBySlug()) {
+    console.warn("[company] lookup skipped because Typesense and DATABASE_URL are not configured");
+    return null;
+  }
   // Throw-and-catch around the `'use cache'` inner. The previous
   // `skipIf: d === null` semantics aren't available under `'use cache'` —
   // the inner fetcher throws `CompanyNotFoundError` on null so the cache
@@ -687,18 +691,41 @@ async function _fetchCompanyBySlug(slug: string, locale: string): Promise<Compan
   // still render. Bot traffic to nonexistent slugs pays the Postgres cost
   // (a cheap PK lookup on company.slug); cache layer above prevents
   // poisoning by not storing nulls.
+  let typesenseError: unknown;
   try {
     const fromTypesense = await _fetchCompanyBySlugFromTypesense(slug, locale);
     if (fromTypesense) return fromTypesense;
   } catch (err) {
+    typesenseError = err;
+  }
+  if (!process.env.DATABASE_URL) {
+    if (typesenseError) {
+      console.error("[company] Typesense failed and Postgres fallback is unavailable", typesenseError);
+    }
+    console.warn("[company] Postgres fallback skipped because DATABASE_URL is not configured");
+    return null;
+  }
+  if (typesenseError) {
     // Typesense unreachable — fall through to Postgres. Log at error so the
     // fallback rate is queryable (e.g. Cloudflare-tunnel blip pushing 100%
     // of company-page traffic to Supabase). Matches the precedent set by
     // `searchCompaniesForWatchlist` / `_fetchSimilarUnfiltered` /
     // `_fetchSimilarFiltered` in this same file. See #3175.
-    console.error("[company] Typesense failed, falling back to Postgres", err);
+    console.error("[company] Typesense failed, falling back to Postgres", typesenseError);
   }
   return _fetchCompanyBySlugFromPostgres(slug, locale);
+}
+
+function canResolveCompanyBySlug(): boolean {
+  return Boolean(
+    process.env.DATABASE_URL ||
+      (
+        process.env.TYPESENSE_HOST &&
+        process.env.TYPESENSE_PORT &&
+        process.env.TYPESENSE_PROTOCOL &&
+        process.env.TYPESENSE_SEARCH_KEY
+      ),
+  );
 }
 
 // Canonical company-slug shape: lowercase alphanumeric segments separated

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -935,6 +935,10 @@ export async function getPublicWatchlistByUserAndSlug(
   userSlug: string,
   watchlistSlug: string,
 ): Promise<WatchlistDetail | null> {
+  if (!process.env.DATABASE_URL) {
+    console.warn("[watchlist] public lookup skipped because DATABASE_URL is not configured");
+    return null;
+  }
   return cached(
     `public-watchlist:${userSlug}:${watchlistSlug}`,
     () => _fetchPublicWatchlistByUserAndSlug(userSlug, watchlistSlug),


### PR DESCRIPTION
## Summary

Fix watchlist company search so searched company-name hits remain selectable even when the current watchlist filters produce 0 matching postings.

## Related Issues

Closes #3390

## Changes

- In `searchCompaniesForWatchlist`, when watchlist filters are active and a company query/industry filter is used:
  - search the `company` collection for matching company candidates
  - run a scoped `job_posting` facet query for those candidate company IDs
  - keep all matching company candidates selectable
  - sort positive-match companies before zero-match companies
- Add regression coverage for an active company that has 0 matches under the current watchlist filters.
- Make company and public-watchlist ISR mention lookups degrade safely on fork PRs where production secrets are intentionally unavailable.

## Testing

- `pnpm --filter @jobseek/web exec eslint src/lib/actions/company.ts src/lib/actions/watchlists.ts src/lib/actions/__tests__/company.test.ts src/lib/actions/__tests__/watchlists-detail-perf.test.ts src/lib/actions/__tests__/db-retry-coverage.test.ts`
- `pnpm --filter @jobseek/web exec tsc --noEmit --pretty false --tsBuildInfoFile /tmp/jobseek-pr3391-web.tsbuildinfo`
- `pnpm --filter @jobseek/web exec vitest run src/lib/actions/__tests__/company.test.ts src/lib/actions/__tests__/watchlists-detail-perf.test.ts src/lib/actions/__tests__/db-retry-coverage.test.ts`
- `env -u DATABASE_URL -u DATABASE_URL_UNPOOLED -u TYPESENSE_HOST -u TYPESENSE_PORT -u TYPESENSE_PROTOCOL ... pnpm --filter @jobseek/web test:isr`