### PR TITLE
Fix deployment build failures

### DIFF
--- a/.github/workflows/deploy-crawler-browser.yml
+++ b/.github/workflows/deploy-crawler-browser.yml
@@ -43,7 +43,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/jobseek-crawler:latest
             ghcr.io/${{ github.repository_owner }}/jobseek-crawler:v${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=crawler-slim
-          cache-to: type=gha,mode=max,scope=crawler-slim
+          cache-to: type=gha,mode=max,scope=crawler-slim,ignore-error=true
 
       - name: Build and push browser image (full)
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
@@ -56,7 +56,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/jobseek-crawler-browser:latest
             ghcr.io/${{ github.repository_owner }}/jobseek-crawler-browser:v${{ steps.version.outputs.version }}
           cache-from: type=gha,scope=crawler-browser
-          cache-to: type=gha,mode=max,scope=crawler-browser
+          cache-to: type=gha,mode=max,scope=crawler-browser,ignore-error=true
 
       # Dry-run setup-typesense against an ephemeral Typesense before
       # touching prod. Running it twice is the key bit — the second run

--- a/.github/workflows/deploy-murmur-shim.yml
+++ b/.github/workflows/deploy-murmur-shim.yml
@@ -110,7 +110,7 @@ jobs:
             ghcr.io/colophon-group/jobseek-murmur-shim:latest
             ghcr.io/colophon-group/jobseek-murmur-shim:${{ github.sha }}
           cache-from: type=gha,scope=murmur-shim
-          cache-to: type=gha,mode=max,scope=murmur-shim
+          cache-to: type=gha,mode=max,scope=murmur-shim,ignore-error=true
 
   deploy:
     needs: build

--- a/apps/murmur-shim/Dockerfile
+++ b/apps/murmur-shim/Dockerfile
@@ -150,9 +150,21 @@ COPY apps/trace-viewer/package.json ./apps/trace-viewer/
 COPY apps/crawler/murmur/package.json ./apps/crawler/murmur/
 COPY packages/mcp-server/package.json ./packages/mcp-server/
 
-# Frozen install: fail fast on lockfile drift. `--prefer-offline`
-# reduces network round-trips on warm builds.
-RUN pnpm install --frozen-lockfile --prefer-offline
+# The shim imports apps/web/src/db/schema.ts. Node resolves that file's
+# dependencies from apps/web/node_modules, so install the web dependency
+# graph too. The web package depends on @jseek/mcp-server, whose prepare
+# script compiles with tsc during install; copy its compile inputs before
+# the filtered install so that lifecycle has a real project to build.
+COPY packages/mcp-server/tsconfig.json ./packages/mcp-server/tsconfig.json
+COPY packages/mcp-server/src/ ./packages/mcp-server/src/
+
+# Frozen install: fail fast on lockfile drift. The filters keep this
+# image independent from unrelated workspace package lifecycle scripts.
+# `--prefer-offline` reduces network round-trips on warm builds.
+RUN pnpm \
+    --filter @jobseek/murmur-shim... \
+    --filter @jobseek/web... \
+    install --frozen-lockfile --prefer-offline
 
 # Copy the rest of the workspace. Dockerfile.dockerignore filters out
 # .git, .next, coverage, *.test.ts, etc.


### PR DESCRIPTION
## Summary
- install only the murmur-shim and web dependency graphs in the shim Docker build
- copy MCP server compile inputs before install so its prepare script succeeds when pulled in by the web package
- ignore BuildKit GHA cache export errors in deploy workflows so post-build cache flakes do not fail deployments

## Validation
- pnpm --filter @jobseek/murmur-shim... --filter @jobseek/web... install --frozen-lockfile --prefer-offline
- pnpm --filter @jobseek/murmur-shim build
- git diff --check

Local Docker builder-stage validation was attempted, but the local Colima Docker daemon is not running.