### PR TITLE
Handle impossible empty search results

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
@@ -6,6 +6,7 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import { useParams, usePathname, useSearchParams } from "next/navigation";
 import { timeAgoShort } from "@/lib/time";
 import { SaveButton } from "@/components/search/save-button";
+import { SearchUnavailable } from "@/components/search/search-unavailable";
 import { JobDetailPanel } from "@/components/search/job-detail-dialog";
 import { SearchToolbar } from "@/components/search/search-toolbar";
 import { runGetCompanyPostings } from "@/lib/search/search-runner";
@@ -149,6 +150,11 @@ export function CompanyPage({
 
   const hasMore = !exhausted && !isTruncated && postings.length < yearCount;
   const hasFilters = keywords.length > 0 || locations.length > 0 || occupations.length > 0 || seniorities.length > 0 || technologies.length > 0 || employmentTypes.length > 0 || workMode.length > 0 || salaryMin != null || salaryMax != null || experienceMin != null || experienceMax != null;
+  const showUnavailable =
+    !isSearching &&
+    !hasFilters &&
+    postings.length === 0 &&
+    (isTruncated || activeCount > 0 || yearCount > 0);
 
   /** Convert a salary amount from the user's display currency to EUR. */
   function toEur(amount: number | undefined): number | undefined {
@@ -639,6 +645,8 @@ export function CompanyPage({
         <div className="flex items-center justify-center py-8">
           <Loader2 size={20} className="animate-spin text-muted" />
         </div>
+      ) : showUnavailable ? (
+        <SearchUnavailable />
       ) : postings.length === 0 && hasFilters ? (
         <p className="py-8 text-center text-sm text-muted">
           <Trans id="company.page.noResults" comment="No postings found message on company page">

--- a/apps/web/app/[lang]/(app)/explore/__tests__/search-page-heading.test.tsx
+++ b/apps/web/app/[lang]/(app)/explore/__tests__/search-page-heading.test.tsx
@@ -131,3 +131,80 @@ describe("SearchPage — heading landmark (#3196)", () => {
     expect(h1.className).toMatch(/\bsr-only\b/);
   });
 });
+
+describe("SearchPage — impossible empty search state (#3403)", () => {
+  it("shows a refresh prompt for an empty unfiltered result set", async () => {
+    await act(async () => {
+      render(
+        <SearchPage
+          initialCompanies={[]}
+          initialTotalCompanies={0}
+          initialKeywords={[]}
+          initialLocations={[]}
+          initialOccupations={[]}
+          initialSeniorities={[]}
+          initialTechnologies={[]}
+          initialWorkMode={[]}
+          locale="en"
+          displayCurrency="EUR"
+          jobLanguages={[]}
+          languages={[]}
+        />,
+      );
+    });
+
+    expect(screen.getByText(/oops, something went wrong/i)).toBeTruthy();
+    expect(screen.getByText(/try refreshing the page/i)).toBeTruthy();
+    expect(screen.queryByTestId("search-results-stub")).toBeNull();
+    expect(screen.queryByTestId("zero-results-stub")).toBeNull();
+  });
+
+  it("keeps the normal zero-results state for an empty filtered search", async () => {
+    await act(async () => {
+      render(
+        <SearchPage
+          initialCompanies={[]}
+          initialTotalCompanies={0}
+          initialKeywords={["python"]}
+          initialLocations={[]}
+          initialOccupations={[]}
+          initialSeniorities={[]}
+          initialTechnologies={[]}
+          initialWorkMode={[]}
+          locale="en"
+          displayCurrency="EUR"
+          jobLanguages={[]}
+          languages={[]}
+        />,
+      );
+    });
+
+    expect(screen.getByTestId("zero-results-stub")).toBeTruthy();
+    expect(screen.queryByText(/oops, something went wrong/i)).toBeNull();
+  });
+
+  it("shows a refresh prompt for degraded filtered results", async () => {
+    await act(async () => {
+      render(
+        <SearchPage
+          initialCompanies={[]}
+          initialTotalCompanies={0}
+          initialDegraded
+          initialKeywords={["python"]}
+          initialLocations={[]}
+          initialOccupations={[]}
+          initialSeniorities={[]}
+          initialTechnologies={[]}
+          initialWorkMode={[]}
+          locale="en"
+          displayCurrency="EUR"
+          jobLanguages={[]}
+          languages={[]}
+        />,
+      );
+    });
+
+    expect(screen.getByText(/oops, something went wrong/i)).toBeTruthy();
+    expect(screen.queryByTestId("zero-results-stub")).toBeNull();
+  });
+});

--- a/apps/web/app/[lang]/(app)/explore/explore-content.tsx
+++ b/apps/web/app/[lang]/(app)/explore/explore-content.tsx
@@ -130,6 +130,7 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
       initialCompanies={result.companies}
       initialTotalCompanies={result.totalCompanies}
       initialTruncated={result.truncated}
+      initialDegraded={result.degraded}
       initialKeywords={parsed.keywords}
       initialLocations={parsed.locations}
       initialOccupations={parsed.occupations}

--- a/apps/web/app/[lang]/(app)/explore/search-page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/search-page.tsx
@@ -6,6 +6,7 @@ import { Trans } from "@lingui/react/macro";
 
 import type { SelectedLocation } from "@/components/search/location-pills";
 import { SearchResults } from "@/components/search/search-results";
+import { SearchUnavailable } from "@/components/search/search-unavailable";
 import { ZeroResults } from "@/components/search/zero-results";
 import { SkeletonCards } from "@/components/search/skeleton-card";
 import { JobDetailPanel } from "@/components/search/job-detail-dialog";
@@ -31,6 +32,7 @@ interface SearchPageProps {
   initialCompanies: SearchResultCompany[];
   initialTotalCompanies: number;
   initialTruncated?: boolean;
+  initialDegraded?: boolean;
   initialKeywords: string[];
   initialLocations: SelectedLocation[];
   initialOccupations: TaxonomyItem[];
@@ -56,6 +58,7 @@ export function SearchPage({
   initialCompanies,
   initialTotalCompanies,
   initialTruncated,
+  initialDegraded,
   initialKeywords,
   initialLocations,
   initialOccupations,
@@ -157,6 +160,9 @@ export function SearchPage({
   const [isSearching, setIsSearching] = useState(false);
   const searchCounterRef = useRef(0);
   const [isTruncated, setIsTruncated] = useState(initialTruncated ?? false);
+  const [isDegraded, setIsDegraded] = useState(
+    shouldRestore ? (cached.degraded ?? false) : (initialDegraded ?? false),
+  );
   // Track server-side offset separately from deduped client list length.
   // Facet-based pagination can return overlapping companies between pages,
   // causing the deduped list to grow slower than the server offset.
@@ -178,6 +184,7 @@ export function SearchPage({
   const companiesRef = useRef(companies);
   const totalCompaniesRef = useRef(totalCompanies);
   const showPostingIdRef = useRef(showPostingId);
+  const isDegradedRef = useRef(isDegraded);
   keywordsRef.current = keywords;
   locationsRef.current = locations;
   occupationsRef.current = occupations;
@@ -193,6 +200,7 @@ export function SearchPage({
   companiesRef.current = companies;
   totalCompaniesRef.current = totalCompanies;
   showPostingIdRef.current = showPostingId;
+  isDegradedRef.current = isDegraded;
 
   // Flag to distinguish our own URL changes (replaceState) from external
   // navigation (router.push from header search bar, back/forward, etc.)
@@ -289,6 +297,7 @@ export function SearchPage({
         companies: companiesRef.current,
         totalCompanies: totalCompaniesRef.current,
         showPostingId: showPostingIdRef.current,
+        degraded: isDegradedRef.current,
         scrollY: window.scrollY,
         cacheKey: buildCacheKey(
           keywordsRef.current,
@@ -527,6 +536,7 @@ export function SearchPage({
         serverOffsetRef.current = result.companies.length;
         setTotalCompanies(result.totalCompanies);
         setIsTruncated(result.truncated ?? false);
+        setIsDegraded(result.degraded ?? false);
       } catch {
         // Keep existing results visible on error
       } finally {
@@ -711,6 +721,7 @@ export function SearchPage({
       : await runListTopCompanies({ locationIds, occupationIds, seniorityIds, technologyIds, employmentTypes: etypes, workMode: wm, salaryMinEur: salMinEur, salaryMaxEur: salMaxEur, experienceMin: expMin, experienceMax: expMax, languages, locale, offset, limit: PAGE_SIZE }, isLoggedInRef.current);
 
     if (result.truncated) setIsTruncated(true);
+    if (result.degraded) setIsDegraded(true);
     serverOffsetRef.current += result.companies.length;
 
     setCompanies((prev) => {
@@ -725,6 +736,7 @@ export function SearchPage({
   // the JSX rebuilt a fresh array on every render, defeating the custom
   // memo comparator's identity-first short-circuit on the array prop.
   const locationIds = useMemo(() => locations.map((l) => l.id), [locations]);
+  const showUnavailable = companies.length === 0 && !isSearching && (isDegraded || !hasFilters);
 
   const histogramFilters: HistogramFilters = useMemo(() => ({
     keywords: keywords.length > 0 ? keywords : undefined,
@@ -806,6 +818,8 @@ export function SearchPage({
 
       {companies.length === 0 && isSearching ? (
         <SkeletonCards count={3} />
+      ) : showUnavailable ? (
+        <SearchUnavailable />
       ) : companies.length === 0 && hasFilters ? (
         <ZeroResults query={[...keywords, ...locations.map((l) => l.name)].join(", ")} />
       ) : (

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -2692,6 +2692,18 @@ msgstr "Keine Antwort"
 msgid "search.zero.heading"
 msgstr "Keine Ergebnisse für „{query}\" gefunden"
 
+#. Heading shown when a search surface returns an impossible empty result set
+#. js-lingui-explicit-id
+#: src/components/search/search-unavailable.tsx:9
+msgid "search.unavailable.heading"
+msgstr "Hoppla, etwas ist schiefgelaufen."
+
+#. Body shown when a search surface returns an impossible empty result set
+#. js-lingui-explicit-id
+#: src/components/search/search-unavailable.tsx:14
+msgid "search.unavailable.body"
+msgstr "Versuchen Sie, die Seite neu zu laden."
+
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
 #: src/components/search/occupation-modal.tsx:344

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -2692,6 +2692,18 @@ msgstr "No response"
 msgid "search.zero.heading"
 msgstr "No results found for “{query}”"
 
+#. Heading shown when a search surface returns an impossible empty result set
+#. js-lingui-explicit-id
+#: src/components/search/search-unavailable.tsx:9
+msgid "search.unavailable.heading"
+msgstr "Oops, something went wrong."
+
+#. Body shown when a search surface returns an impossible empty result set
+#. js-lingui-explicit-id
+#: src/components/search/search-unavailable.tsx:14
+msgid "search.unavailable.body"
+msgstr "Try refreshing the page."
+
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
 #: src/components/search/occupation-modal.tsx:344

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -2692,6 +2692,18 @@ msgstr "Sans réponse"
 msgid "search.zero.heading"
 msgstr "Aucun résultat trouvé pour « {query} »"
 
+#. Heading shown when a search surface returns an impossible empty result set
+#. js-lingui-explicit-id
+#: src/components/search/search-unavailable.tsx:9
+msgid "search.unavailable.heading"
+msgstr "Oups, une erreur s'est produite."
+
+#. Body shown when a search surface returns an impossible empty result set
+#. js-lingui-explicit-id
+#: src/components/search/search-unavailable.tsx:14
+msgid "search.unavailable.body"
+msgstr "Essayez d'actualiser la page."
+
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
 #: src/components/search/occupation-modal.tsx:344

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -2692,6 +2692,18 @@ msgstr "Nessuna risposta"
 msgid "search.zero.heading"
 msgstr "Nessun risultato trovato per \"{query}\""
 
+#. Heading shown when a search surface returns an impossible empty result set
+#. js-lingui-explicit-id
+#: src/components/search/search-unavailable.tsx:9
+msgid "search.unavailable.heading"
+msgstr "Ops, qualcosa è andato storto."
+
+#. Body shown when a search surface returns an impossible empty result set
+#. js-lingui-explicit-id
+#: src/components/search/search-unavailable.tsx:14
+msgid "search.unavailable.body"
+msgstr "Prova ad aggiornare la pagina."
+
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
 #: src/components/search/occupation-modal.tsx:344

--- a/apps/web/src/components/SearchStateProvider.tsx
+++ b/apps/web/src/components/SearchStateProvider.tsx
@@ -26,6 +26,7 @@ export interface SearchStateSnapshot {
   experienceMax: number | undefined;
   companies: SearchResultCompany[];
   totalCompanies: number;
+  degraded?: boolean;
   showPostingId: string | null;
   scrollY: number;
   cacheKey: string;

--- a/apps/web/src/components/search/search-unavailable.tsx
+++ b/apps/web/src/components/search/search-unavailable.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { Trans } from "@lingui/react/macro";
+
+export function SearchUnavailable() {
+  return (
+    <div role="alert" className="flex flex-col items-center gap-2 py-12 text-center">
+      <p className="text-lg font-semibold">
+        <Trans id="search.unavailable.heading" comment="Heading shown when a search surface returns an impossible empty result set">
+          Oops, something went wrong.
+        </Trans>
+      </p>
+      <p className="text-sm text-muted">
+        <Trans id="search.unavailable.body" comment="Body shown when a search surface returns an impossible empty result set">
+          Try refreshing the page.
+        </Trans>
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/watchlist/__tests__/watchlist-job-list-nested-buttons.test.tsx
+++ b/apps/web/src/components/watchlist/__tests__/watchlist-job-list-nested-buttons.test.tsx
@@ -140,12 +140,12 @@ function entry(id: string, title: string | null = `Job ${id}`): WatchlistPosting
   };
 }
 
-function renderList(postings: WatchlistPostingEntry[]) {
+function renderList(postings: WatchlistPostingEntry[], total = postings.length) {
   return render(
     <WatchlistJobList
       filters={{ companyIds: ["c-1"] }}
       initialPostings={postings}
-      initialTotal={postings.length}
+      initialTotal={total}
       yearTotal={postings.length}
       jobLanguages={["en"]}
       locale="en"
@@ -238,5 +238,11 @@ describe("WatchlistJobList row a11y (issue #3166)", () => {
     ).toBeGreaterThan(0);
     expect(toggleMock).not.toHaveBeenCalled();
   });
-});
 
+  it("shows a refresh prompt when the watchlist count says jobs exist but the page is empty (#3403)", () => {
+    renderList([], 3);
+
+    expect(screen.getByRole("alert").textContent).toMatch(/oops, something went wrong/i);
+    expect(screen.queryByText(/no jobs found/i)).toBeNull();
+  });
+});

--- a/apps/web/src/components/watchlist/watchlist-job-list.tsx
+++ b/apps/web/src/components/watchlist/watchlist-job-list.tsx
@@ -22,6 +22,7 @@ import { TruncationPrompt } from "@/components/TruncationPrompt";
 import { TrackingDot } from "@/components/TrackingDot";
 import { PendingJobIcon } from "@/components/PendingJobWarning";
 import { LanguageStatsRow } from "@/components/search/language-stats-row";
+import { SearchUnavailable } from "@/components/search/search-unavailable";
 import { formatDateDivider, getDateKey } from "@/components/watchlist/format-date-divider";
 
 const BATCH = 20;
@@ -126,6 +127,7 @@ export function WatchlistJobList({
   }, [filtersKey]);
 
   const { sentinelRef, isLoading } = useInfiniteScroll({ hasMore, load: loadMore });
+  const showUnavailable = postings.length === 0 && !isLoading && total > 0;
 
   function handleOpenPosting(postingId: string) {
     setShowPostingId(postingId);
@@ -273,7 +275,9 @@ export function WatchlistJobList({
       <div className="[overflow-anchor:none]">
         {rows}
 
-        {postings.length === 0 && !isLoading && (
+        {showUnavailable ? (
+          <SearchUnavailable />
+        ) : postings.length === 0 && !isLoading && (
           <div className="py-12 text-center text-sm text-muted">
             <Trans id="watchlists.jobList.empty" comment="Empty state when no jobs match the time range">
               No jobs found.


### PR DESCRIPTION
Closes #3403.\n\nSummary:\n- Add a shared unavailable-search alert for impossible empty result sets.\n- Show it on /explore, company pages, and watchlist job lists where counts/degraded state prove the empty result is not a real zero-results state.\n- Add manual translations for en/de/fr/it and regression coverage.\n\nTests:\n- pnpm --filter @jobseek/web test -- 'app/[lang]/(app)/explore/__tests__/search-page-heading.test.tsx'\n- pnpm --filter @jobseek/web test -- src/components/watchlist/__tests__/watchlist-job-list-nested-buttons.test.tsx\n- pnpm --filter @jobseek/web compile\n- pnpm --filter @jobseek/web typecheck\n- pnpm --filter @jobseek/web lint