### PR TITLE
Fix translated skip link in app layout

### DIFF
--- a/apps/web/app/[lang]/(app)/layout.tsx
+++ b/apps/web/app/[lang]/(app)/layout.tsx
@@ -7,6 +7,7 @@ import { SearchStateProvider } from "@/components/SearchStateProvider";
 import { UpgradeBanner } from "@/components/UpgradeBanner";
 import { WatchlistTipBanner } from "@/components/watchlist/watchlist-tip-banner";
 import { BackToTop } from "@/components/ui/back-to-top";
+import { SkipToContentLink } from "@/components/SkipToContentLink";
 
 type Props = {
   children: ReactNode;
@@ -19,12 +20,7 @@ export default async function AppLayout({ children }: Props) {
   return (
     <AppBootstrapProvider>
       <SearchStateProvider>
-        <a
-          href="#main-content"
-          className="sr-only focus:not-sr-only fixed top-2 left-2 z-[100] rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-contrast focus:outline-none"
-        >
-          Skip to content
-        </a>
+        <SkipToContentLink />
         <div className="flex min-h-dvh flex-col">
           <AppHeader />
           <div className="flex min-h-0 flex-1 flex-col md:pt-12">

--- a/apps/web/app/[lang]/(public)/layout.tsx
+++ b/apps/web/app/[lang]/(public)/layout.tsx
@@ -1,8 +1,8 @@
 import type { ReactNode } from "react";
-import { Trans } from "@lingui/react/macro";
 import { defaultLocale, isLocale, type Locale } from "@/lib/i18n";
 import { HeaderShell } from "@/components/HeaderShell";
 import { Footer } from "@/components/Footer";
+import { SkipToContentLink } from "@/components/SkipToContentLink";
 
 type Props = {
   children: ReactNode;
@@ -18,12 +18,7 @@ export default async function PublicLayout({ children, params }: Props) {
 
   return (
     <>
-      <a
-        href="#main-content"
-        className="sr-only focus:not-sr-only fixed top-2 left-2 z-[100] rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-contrast focus:outline-none"
-      >
-        <Trans id="common.a11y.skipToContent" comment="Skip to main content link for keyboard users">Skip to content</Trans>
-      </a>
+      <SkipToContentLink />
       <div className="fixed top-0 right-0 left-0 z-50">
         <HeaderShell />
       </div>

--- a/apps/web/src/components/SkipToContentLink.tsx
+++ b/apps/web/src/components/SkipToContentLink.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { Trans } from "@lingui/react/macro";
+
+const SKIP_LINK_CLASS =
+  "sr-only focus:not-sr-only fixed top-2 left-2 z-[100] rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-contrast focus:outline-none";
+
+export function SkipToContentLink() {
+  return (
+    <a href="#main-content" className={SKIP_LINK_CLASS}>
+      <Trans id="common.a11y.skipToContent" comment="Skip to main content link for keyboard users">
+        Skip to content
+      </Trans>
+    </a>
+  );
+}


### PR DESCRIPTION
Closes #3265.\n\nSummary:\n- Move the translated skip-to-content link into a client component.\n- Reuse the component from both app and public layouts.\n- Avoid rendering Lingui's Trans macro directly inside the nested server app layout, which still crashes the ISR build path.\n\nVerification:\n- Reproduced the failure on current origin/main by adding Trans directly to apps/web/app/[lang]/(app)/layout.tsx; pnpm --filter @jobseek/web test:isr failed with 'Trans in Server Component, but i18n instance for RSC has not been setup'.\n- pnpm --filter @jobseek/web test:isr\n- pnpm --filter @jobseek/web lint\n- pnpm --filter @jobseek/web compile\n- pnpm --filter @jobseek/web typecheck