### PR TITLE
Harden pull_request_target automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+.github/CODEOWNERS @viktor-shcherb
+.github/workflows/** @viktor-shcherb
+.github/scripts/** @viktor-shcherb

--- a/.github/scripts/label-pr.sh
+++ b/.github/scripts/label-pr.sh
@@ -16,9 +16,6 @@ set -euo pipefail
 : "${PR:?PR is required}"
 : "${REPO:?REPO is required}"
 
-SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd -- "$SCRIPT_DIR/../.." && pwd)"
-
 # Only label add-company/* branches — developer branches are reviewed manually
 BRANCH=$(gh pr view "$PR" --repo "$REPO" --json headRefName -q .headRefName)
 if [[ "$BRANCH" != add-company/* ]]; then
@@ -28,32 +25,10 @@ if [[ "$BRANCH" != add-company/* ]]; then
 fi
 
 ALLOWED_FILES="apps/crawler/data/companies.csv apps/crawler/data/boards.csv apps/crawler/data/company_descriptions.csv apps/crawler/VERSION"
-VALID_MONITOR_TYPES="$(
-python3 - "$REPO_ROOT" <<'PY'
-import sys
-from pathlib import Path
-
-repo_root = Path(sys.argv[1])
-sys.path.insert(0, str(repo_root / "apps/crawler"))
-
-from src.workspace._compat import all_monitor_types
-
-print("|".join(sorted(all_monitor_types())))
-PY
-)"
-VALID_SCRAPER_TYPES="$(
-python3 - "$REPO_ROOT" <<'PY'
-import sys
-from pathlib import Path
-
-repo_root = Path(sys.argv[1])
-sys.path.insert(0, str(repo_root / "apps/crawler"))
-
-from src.workspace._compat import all_scraper_types
-
-print("|".join(sorted(all_scraper_types())))
-PY
-)"
+# Keep these static: this script runs with pull_request_target write
+# permissions and must not import PR-controllable Python.
+VALID_MONITOR_TYPES='accenture|almacareer|amazon|api_sniffer|ashby|bite|breezy|deel|dom|dvinci|eightfold|gem|greenhouse|hireology|inline|jobylon|join|lever|mokahr|nextdata|notion|oracle_hcm|personio|phenom|pinpoint|recruitee|recruiter_co_kr|rippling|rss|sitemap|smartrecruiters|softgarden|talentbrew|traffit|umantis|workable|workday|ycombinator'
+VALID_SCRAPER_TYPES='api_sniffer|bite|dom|eightfold|embedded|json-ld|mokahr|nextdata|notion|oracle_hcm|pdf|rippling|skip|smartrecruiters|workable|workday'
 SLUG_RE='^[a-z0-9]+(-[a-z0-9]+)*$'
 URL_RE='^https?://'
 # --- Check changed files ---

--- a/.github/workflows/maybe-auto-merge.yml
+++ b/.github/workflows/maybe-auto-merge.yml
@@ -21,6 +21,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Capture trusted scripts
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/trusted-scripts"
+          cp .github/scripts/label-pr.sh "$RUNNER_TEMP/trusted-scripts/label-pr.sh"
+          cp .github/scripts/close-linked-company-request-issues.sh "$RUNNER_TEMP/trusted-scripts/close-linked-company-request-issues.sh"
+          chmod +x "$RUNNER_TEMP/trusted-scripts/"*.sh
+
       - name: Check for pending images
         id: images
         run: |
@@ -40,7 +48,7 @@ jobs:
       - name: Label PR
         id: label
         if: steps.images.outputs.pending == 'false'
-        run: .github/scripts/label-pr.sh
+        run: "$RUNNER_TEMP/trusted-scripts/label-pr.sh"
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
@@ -133,7 +141,7 @@ jobs:
 
       - name: Close linked company-request issues
         if: steps.rebase.outputs.rebased == 'true' && steps.images.outputs.pending == 'false'
-        run: .github/scripts/close-linked-company-request-issues.sh
+        run: "$RUNNER_TEMP/trusted-scripts/close-linked-company-request-issues.sh"
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}

--- a/.github/workflows/upload-company-images.yml
+++ b/.github/workflows/upload-company-images.yml
@@ -31,9 +31,34 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.head_ref || github.ref }}
           token: ${{ github.token }}
           fetch-depth: 0
+
+      - name: Prepare trusted scripts and PR branch
+        if: github.event_name != 'workflow_dispatch'
+        env:
+          BRANCH: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+
+          mkdir -p "$RUNNER_TEMP/trusted-scripts"
+          cp .github/scripts/label-pr.sh "$RUNNER_TEMP/trusted-scripts/label-pr.sh"
+          cp .github/scripts/close-linked-company-request-issues.sh "$RUNNER_TEMP/trusted-scripts/close-linked-company-request-issues.sh"
+          chmod +x "$RUNNER_TEMP/trusted-scripts/"*.sh
+
+          git fetch origin main "$BRANCH"
+          # The workflow has production R2 secrets. Before running Python,
+          # keep code from main and check out only PR-controlled data inputs.
+          git checkout "origin/$BRANCH" -- apps/crawler/data
+
+      - name: Capture trusted scripts
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/trusted-scripts"
+          cp .github/scripts/label-pr.sh "$RUNNER_TEMP/trusted-scripts/label-pr.sh"
+          cp .github/scripts/close-linked-company-request-issues.sh "$RUNNER_TEMP/trusted-scripts/close-linked-company-request-issues.sh"
+          chmod +x "$RUNNER_TEMP/trusted-scripts/"*.sh
 
       - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
 
@@ -62,13 +87,19 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add apps/crawler/data/
 
-          if git diff --cached --quiet; then
+          if git diff --quiet -- apps/crawler/data; then
             echo "No R2 URL or image cleanup changes to commit"
             exit 0
           fi
 
+          if [ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]; then
+            git diff --binary -- apps/crawler/data > "$RUNNER_TEMP/image-sync.patch"
+            git checkout -B "$BRANCH" "origin/$BRANCH"
+            git apply "$RUNNER_TEMP/image-sync.patch"
+          fi
+
+          git add apps/crawler/data/
           git commit -m "Upload images to R2"
 
           # maybe-auto-merge can rebase/force-push the same PR branch in parallel.
@@ -159,7 +190,7 @@ jobs:
       - name: Label PR
         id: label
         if: github.event_name != 'workflow_dispatch'
-        run: .github/scripts/label-pr.sh
+        run: "$RUNNER_TEMP/trusted-scripts/label-pr.sh"
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
@@ -201,7 +232,7 @@ jobs:
 
       - name: Close linked company-request issues
         if: github.event_name != 'workflow_dispatch' && steps.merge.outputs.merged == 'true'
-        run: .github/scripts/close-linked-company-request-issues.sh
+        run: "$RUNNER_TEMP/trusted-scripts/close-linked-company-request-issues.sh"
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Closes #3232.\n\nSummary:\n- Stop label-pr.sh from importing repo Python while running under pull_request_target write permissions; monitor/scraper allow-lists are static and verified against _compat.py.\n- Run maybe-auto-merge follow-up scripts from trusted copies captured before any PR branch checkout.\n- Rework upload-company-images so the R2-secret Python step runs main-branch code against PR data files only; it switches to the PR branch only after generating the data patch to commit.\n- Add CODEOWNERS for workflow and script paths.\n\nVerification:\n- bash -n .github/scripts/label-pr.sh .github/scripts/close-linked-company-request-issues.sh\n- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/upload-company-images.yml .github/workflows/maybe-auto-merge.yml\n- Static allow-list comparison against apps/crawler/src/workspace/_compat.py\n- rg check for removed repo-Python imports and direct .github/scripts workflow runs