### PR TITLE
Opt workflows into Node 24 actions runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   changes:
     name: Detect changes

--- a/.github/workflows/deploy-crawler-browser.yml
+++ b/.github/workflows/deploy-crawler-browser.yml
@@ -7,6 +7,9 @@ on:
       - 'apps/crawler/**'
       - '.github/workflows/deploy-crawler-browser.yml'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-murmur-shim.yml
+++ b/.github/workflows/deploy-murmur-shim.yml
@@ -70,6 +70,9 @@ concurrency:
   group: deploy-murmur-shim
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/notify-blog-indexnow.yml
+++ b/.github/workflows/notify-blog-indexnow.yml
@@ -42,6 +42,9 @@ concurrency:
   group: notify-blog-indexnow-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   notify:
     name: Submit blog URLs to IndexNow

--- a/.github/workflows/publish-mcp-server.yml
+++ b/.github/workflows/publish-mcp-server.yml
@@ -8,6 +8,9 @@ on:
       - ".github/workflows/publish-mcp-server.yml"
       - "packages/mcp-server/package.json"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -18,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/resolve-company-requests.yml
+++ b/.github/workflows/resolve-company-requests.yml
@@ -11,6 +11,7 @@ concurrency:
 
 env:
   BUDGET_PER_5H: 5
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 permissions:
   contents: write       # push add-company/* branches
@@ -52,7 +53,7 @@ jobs:
         if: >
           steps.select.outputs.selected != '' &&
           steps.budget.outputs.remaining > 0
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: "22"
 


### PR DESCRIPTION
## Summary
- set `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` on workflows that use current Node 20 JavaScript actions (`docker/*` and `pnpm/action-setup`) so we exercise the June 16 runtime before GitHub flips the default
- update the two remaining `actions/setup-node@v4` SHA pins to the repo's existing `setup-node@v6` SHA

Closes #3410.

## Notes
- `docker/setup-buildx-action@v3`, `docker/login-action@v3`, and `docker/build-push-action@v6` are already pinned to the current major-tag SHAs; their action manifests still declare `runs.using: node20`, so there was no newer same-major SHA to take.
- latest `pnpm/action-setup@v4` also still declares `runs.using: node20`; the runtime opt-in is the meaningful compatibility check.

## Verification
- workflow YAML parse for all touched workflow files
- `git diff --check`
- verified no `actions/setup-node@v4` SHA pin remains in `.github/workflows`