### PR TITLE
Localize not-found page metadata

### DIFF
--- a/apps/web/app/[lang]/__tests__/not-found-metadata.test.ts
+++ b/apps/web/app/[lang]/__tests__/not-found-metadata.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from "vitest";
+
+const titles = {
+  en: "Page not found",
+  de: "Seite nicht gefunden",
+  fr: "Page introuvable",
+  it: "Pagina non trovata",
+} as const;
+
+vi.mock("@/lib/i18n", () => ({
+  defaultLocale: "en",
+  isLocale: (value: string) => value in titles,
+  loadCatalog: async (locale: keyof typeof titles) => ({
+    i18n: {
+      _: ({ id, message }: { id: string; message: string }) => (
+        id === "notFound.title" ? titles[locale] : message
+      ),
+    },
+  }),
+}));
+
+import { generateMetadata } from "../not-found";
+
+describe("[lang]/not-found metadata", () => {
+  it.each([
+    ["en", "Page not found"],
+    ["de", "Seite nicht gefunden"],
+    ["fr", "Page introuvable"],
+    ["it", "Pagina non trovata"],
+    ["bogus", "Page not found"],
+  ])("localizes the 404 title for %s", async (lang, title) => {
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ lang }),
+    });
+
+    expect(metadata.title).toBe(title);
+    expect(metadata.robots).toEqual({ index: false, follow: false });
+  });
+});

--- a/apps/web/app/[lang]/not-found.tsx
+++ b/apps/web/app/[lang]/not-found.tsx
@@ -1,5 +1,10 @@
 import type { Metadata } from "next";
+import { defaultLocale, isLocale, loadCatalog } from "@/lib/i18n";
 import { NotFoundContent } from "./not-found-content";
+
+type Props = {
+  params: Promise<{ lang: string }>;
+};
 
 // Server wrapper so we can export `metadata` (client components can't).
 // Without this, the title would cascade from `[lang]/layout.tsx`'s
@@ -7,10 +12,20 @@ import { NotFoundContent } from "./not-found-content";
 // `<title>Job Seek</title>`. Robots is also explicitly `noindex, nofollow`
 // since the 404 surface itself shouldn't be indexed AND its only
 // outgoing link goes to "/" which crawlers already know.
-export const metadata: Metadata = {
-  title: "Page not found",
-  robots: { index: false, follow: false },
-};
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { lang } = await params;
+  const locale = isLocale(lang) ? lang : defaultLocale;
+  const { i18n } = await loadCatalog(locale);
+
+  return {
+    title: i18n._({
+      id: "notFound.title",
+      comment: "Heading shown on the 404 page",
+      message: "Page not found",
+    }),
+    robots: { index: false, follow: false },
+  };
+}
 
 export default function NotFound() {
   return <NotFoundContent />;


### PR DESCRIPTION
Fixes #3154.

Changes:
- Replace the static English `metadata` export in `app/[lang]/not-found.tsx` with locale-aware `generateMetadata`.
- Reuse the existing manually translated `notFound.title` catalog key for the browser title.
- Add a focused metadata regression test for `en`, `de`, `fr`, `it`, and invalid-locale fallback.

Verification:
- `pnpm --filter @jobseek/web compile`
- `pnpm --filter @jobseek/web exec vitest run 'app/[lang]/__tests__/not-found-metadata.test.ts'`
- `pnpm --filter @jobseek/web test`
- `pnpm --filter @jobseek/web lint`
- `pnpm --filter @jobseek/web typecheck`
- `pnpm --filter @jobseek/web test:isr`
- `git diff --check`