### PR TITLE
Add i18n coverage CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,25 @@ jobs:
 
       - run: pnpm lint
 
+  i18n-coverage:
+    name: i18n Coverage Web
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: bash scripts/check-i18n-coverage.sh
+
   lint-crawler:
     name: Lint Crawler
     needs: changes


### PR DESCRIPTION
Closes #3152.

## Summary
- add a dedicated CI job that runs `scripts/check-i18n-coverage.sh` for code-changing PRs and pushes
- mirror the existing web Node/pnpm setup so the stale-catalog check has `pnpm` and `node_modules` available

## Verification
- `pnpm install --frozen-lockfile`
- `bash scripts/check-i18n-coverage.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml parsed"'`\n- `git diff --check`