### PR TITLE
Update DOMPurify security dependency

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -44,7 +44,7 @@
     "@vercel/speed-insights": "^1.3.1",
     "apify-client": "^2",
     "better-auth": "^1.6.18",
-    "dompurify": "^3.4.0",
+    "dompurify": "^3.4.10",
     "drizzle-orm": "^0.45.2",
     "gray-matter": "^4.0.3",
     "isomorphic-dompurify": "^3.12.0",

--- a/apps/web/src/lib/sanitize.ts
+++ b/apps/web/src/lib/sanitize.ts
@@ -5,7 +5,7 @@
  * (see apps/crawler/src/shared/html_normalize.py), but we re-sanitize on the
  * read path to guard against R2 tampering or crawler bypass.
  */
-import DOMPurify from "dompurify";
+import DOMPurify from "isomorphic-dompurify";
 
 /** Must match _ALLOWED_TAGS in apps/crawler/src/shared/html_normalize.py */
 const ALLOWED_TAGS = [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,8 +216,8 @@ importers:
         specifier: ^1.6.18
         version: 1.6.18(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.9)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.3)(kysely@0.29.2)(postgres@3.4.8))(next@16.2.6(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(babel-plugin-macros@3.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.9)
       dompurify:
-        specifier: ^3.4.0
-        version: 3.4.0
+        specifier: ^3.4.10
+        version: 3.4.10
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.36.3)(kysely@0.29.2)(postgres@3.4.8)
@@ -3405,11 +3405,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.0:
-    resolution: {integrity: sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==}
-
-  dompurify@3.4.3:
-    resolution: {integrity: sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==}
+  dompurify@3.4.10:
+    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -9091,11 +9088,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.0:
-    optionalDependencies:
-      '@types/trusted-types': 2.0.7
-
-  dompurify@3.4.3:
+  dompurify@3.4.10:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -9775,7 +9768,7 @@ snapshots:
 
   isomorphic-dompurify@3.12.0(@noble/hashes@2.0.1):
     dependencies:
-      dompurify: 3.4.3
+      dompurify: 3.4.10
       jsdom: 29.1.1(@noble/hashes@2.0.1)
     transitivePeerDependencies:
       - '@noble/hashes'


### PR DESCRIPTION
## Summary
- bump the web DOMPurify dependency and lockfile to `3.4.10`, resolving the newly opened DOMPurify advisory range (`<= 3.4.7`)
- collapse the direct and `isomorphic-dompurify` transitive lockfile entries to one `dompurify@3.4.10`
- route `sanitizeJobHtml` through `isomorphic-dompurify` so Node tests use jsdom instead of the unsafe DOMPurify + happy-dom combination that left `<script>` intact under 3.4.10

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm audit`
- `pnpm --filter @jobseek/web exec vitest run src/lib/__tests__/sanitize.test.ts`
- `pnpm --filter @jobseek/web lint`
- `pnpm --filter @jobseek/web typecheck`
- `pnpm --filter @jobseek/web test`
- `pnpm --filter @jobseek/web test:isr`
- `git diff --check`

Dependabot alerts expected to close after merge: #147-#152 (`dompurify`).