### PR TITLE
Use Node 24 actions runtime for OG pruner

### DIFF
--- a/.github/workflows/prune-company-og-cache.yml
+++ b/.github/workflows/prune-company-og-cache.yml
@@ -26,6 +26,9 @@ concurrency:
   group: prune-company-og-cache
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   prune:
     name: Prune stale company OG versions


### PR DESCRIPTION
## Summary
- set FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 on the new company OG pruning workflow
- matches the existing mitigation used by CI and other Node-based workflows

## Verification
- git diff --check
- workflow-only change; the previous manual pruning run passed before this warning cleanup
