### PR TITLE
Update OG pruner pnpm action

### DIFF
--- a/.github/workflows/prune-company-og-cache.yml
+++ b/.github/workflows/prune-company-og-cache.yml
@@ -26,9 +26,6 @@ concurrency:
   group: prune-company-og-cache
   cancel-in-progress: false
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-
 jobs:
   prune:
     name: Prune stale company OG versions
@@ -45,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:


### PR DESCRIPTION
## Summary
- update the company OG pruning workflow to pnpm/action-setup v6.0.9 by pinned commit
- remove the temporary Node 24 force env because v6.0.9 declares runs: node24

## Verification
- git diff --check
- resolved pnpm/action-setup v6.0.9 to verified commit 0ebf47130e4866e96fce0953f49152a61190b271
- confirmed action.yml declares runs: using node24
