### PR TITLE
Fix anonymous explore freshness ranking

### DIFF
--- a/apps/web/src/lib/search/__tests__/typesense.e2e.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense.e2e.test.ts
@@ -699,7 +699,7 @@ describe("search()", () => {
 // =====================================================================
 
 describe("listTopCompanies()", () => {
-  it("unfiltered returns companies sorted by posting count", async () => {
+  it("unfiltered returns companies sorted by freshest posting", async () => {
     if (skipIfUnavailable()) return;
 
     const result = await provider.listTopCompanies({
@@ -711,10 +711,16 @@ describe("listTopCompanies()", () => {
     expect(result.companies.length).toBeGreaterThan(0);
     expect(result.totalCompanies).toBeGreaterThan(0);
 
-    // Companies should be sorted by activeMatches descending
+    // Companies should be sorted by each company's newest visible posting.
     for (let i = 1; i < result.companies.length; i++) {
-      expect(result.companies[i - 1].activeMatches).toBeGreaterThanOrEqual(
-        result.companies[i].activeMatches,
+      const previousNewest = new Date(
+        result.companies[i - 1].postings[0].firstSeenAt,
+      ).getTime();
+      const currentNewest = new Date(
+        result.companies[i].postings[0].firstSeenAt,
+      ).getTime();
+      expect(previousNewest).toBeGreaterThanOrEqual(
+        currentNewest,
       );
     }
   });

--- a/apps/web/src/lib/search/__tests__/typesense.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+type SearchCall = {
+  collection: string;
+  params: Record<string, unknown>;
+};
+
+const mocks = vi.hoisted(() => ({
+  calls: [] as SearchCall[],
+  browserCalls: [] as SearchCall[],
+  search: vi.fn(),
+}));
+
+vi.mock("../typesense-client", () => ({
+  getSearchClient: () => ({
+    collections: (collection: string) => ({
+      documents: () => ({
+        search: (params: Record<string, unknown>) => {
+          mocks.calls.push({ collection, params });
+          return mocks.search(collection, params);
+        },
+      }),
+    }),
+  }),
+}));
+
+import { TypesenseBrowserProvider } from "../typesense-browser";
+import { clearTypesenseBrowserConfig } from "../typesense-browser-key";
+import { POSTING_BASE_FILTER } from "../typesense-filters";
+import { TypesenseSearchProvider } from "../typesense";
+
+const NOW = Math.floor(Date.UTC(2026, 5, 19) / 1000);
+const DAY = 86_400;
+
+function postingHit(
+  companyId: string,
+  companyName: string,
+  firstSeenAt: number,
+) {
+  return {
+    document: {
+      id: `${companyId}-posting`,
+      company_id: companyId,
+      company_name: companyName,
+      company_slug: companyId,
+      title: `${companyName} role`,
+      is_active: true,
+      location_ids: [],
+      location_names: [],
+      location_types: [],
+      location_geo_types: [],
+      technology_ids: [],
+      experience_min: -1,
+      locales: ["en"],
+      first_seen_at: firstSeenAt,
+    },
+  };
+}
+
+function companyHit(
+  id: string,
+  name: string,
+  activePostingCount: number,
+  yearPostingCount: number,
+) {
+  return {
+    document: {
+      id,
+      name,
+      slug: id,
+      active_posting_count: activePostingCount,
+      year_posting_count: yearPostingCount,
+    },
+  };
+}
+
+const freshPosting = postingHit("fresh-co", "Fresh Co", NOW);
+const stalePosting = postingHit("stale-bigco", "Stale BigCo", NOW - 16 * DAY);
+
+function freshnessGroupedResponse() {
+  return {
+    grouped_hits: [
+      { group_key: ["fresh-co"], found: 1, hits: [freshPosting] },
+      { group_key: ["stale-bigco"], found: 50_000, hits: [stalePosting] },
+    ],
+    facet_counts: [
+      { field_name: "company_id", counts: [], stats: { total_values: 2 } },
+    ],
+  };
+}
+
+function companyResponse() {
+  return {
+    // Deliberately return company docs in active-count order. Providers must
+    // preserve the freshness order from grouped postings.
+    hits: [
+      companyHit("stale-bigco", "Stale BigCo", 50_000, 50_000),
+      companyHit("fresh-co", "Fresh Co", 1, 1),
+    ],
+  };
+}
+
+beforeEach(() => {
+  mocks.calls.length = 0;
+  mocks.browserCalls.length = 0;
+  mocks.search.mockReset();
+  clearTypesenseBrowserConfig();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("TypesenseSearchProvider.listTopCompanies", () => {
+  it("ranks the anonymous default surface by freshest active posting, not company size", async () => {
+    const provider = new TypesenseSearchProvider();
+
+    mocks.search.mockImplementation(async (collection: string) => {
+      if (collection === "job_posting") return freshnessGroupedResponse();
+      if (collection === "company") return companyResponse();
+      throw new Error(`unexpected collection: ${collection}`);
+    });
+
+    const result = await provider.listTopCompanies({
+      languages: [],
+      locale: "en",
+      offset: 0,
+      limit: 2,
+    });
+
+    expect(result.companies.map((c) => c.company.id)).toEqual([
+      "fresh-co",
+      "stale-bigco",
+    ]);
+    expect(result.companies.map((c) => c.activeMatches)).toEqual([1, 50_000]);
+    expect(result.totalCompanies).toBe(2);
+    expect(mocks.calls[0]).toMatchObject({
+      collection: "job_posting",
+      params: {
+        q: "*",
+        filter_by: POSTING_BASE_FILTER,
+        group_by: "company_id",
+        group_limit: 10,
+        sort_by: "first_seen_at:desc",
+        per_page: 2,
+        page: 1,
+      },
+    });
+    expect(mocks.calls[1]).toMatchObject({
+      collection: "company",
+      params: {
+        q: "*",
+        filter_by: "id:[fresh-co,stale-bigco]",
+        per_page: 2,
+      },
+    });
+  });
+});
+
+describe("TypesenseBrowserProvider.listTopCompanies", () => {
+  it("uses the same freshness ranking as the server provider", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url === "/api/typesense-key") {
+          return Response.json({
+            apiKey: "browser-key",
+            host: "typesense.example",
+            port: 443,
+            protocol: "https",
+            expiresAt: Date.now() + 60_000,
+          });
+        }
+
+        const parsed = new URL(url);
+        const collection = parsed.pathname.match(/\/collections\/([^/]+)/)?.[1];
+        if (!collection) throw new Error(`unexpected URL: ${url}`);
+        mocks.browserCalls.push({
+          collection,
+          params: Object.fromEntries(parsed.searchParams.entries()),
+        });
+        if (collection === "job_posting") return Response.json(freshnessGroupedResponse());
+        if (collection === "company") return Response.json(companyResponse());
+        throw new Error(`unexpected collection: ${collection}`);
+      }),
+    );
+
+    const provider = new TypesenseBrowserProvider();
+    const result = await provider.listTopCompanies({
+      languages: [],
+      locale: "en",
+      offset: 0,
+      limit: 2,
+    });
+
+    expect(result.companies.map((c) => c.company.id)).toEqual([
+      "fresh-co",
+      "stale-bigco",
+    ]);
+    expect(result.totalCompanies).toBe(2);
+    expect(mocks.browserCalls[0]).toMatchObject({
+      collection: "job_posting",
+      params: {
+        q: "*",
+        filter_by: POSTING_BASE_FILTER,
+        group_by: "company_id",
+        group_limit: "10",
+        sort_by: "first_seen_at:desc",
+        per_page: "2",
+        page: "1",
+      },
+    });
+    expect(mocks.browserCalls[1]).toMatchObject({
+      collection: "company",
+      params: {
+        q: "*",
+        filter_by: "id:[fresh-co,stale-bigco]",
+        per_page: "2",
+      },
+    });
+  });
+});

--- a/apps/web/src/lib/search/typesense-browser.ts
+++ b/apps/web/src/lib/search/typesense-browser.ts
@@ -297,47 +297,51 @@ export class TypesenseBrowserProvider implements SearchProvider {
     offset: number,
     limit: number,
   ): Promise<SearchResponse> {
-    const companyResults = await searchOne<CompanyDoc>(cfg, "company", {
-      q: "*",
-      filter_by: "active_posting_count:>0",
-      sort_by: "active_posting_count:desc",
-      per_page: limit,
-      page: Math.floor(offset / limit) + 1,
-    });
-    const totalCompanies = companyResults.found;
-    const hits = companyResults.hits ?? [];
-    if (hits.length === 0) return { companies: [], totalCompanies };
-
-    const companyIds = hits.map((h) => h.document.id);
-    const compMap = new Map<string, CompanyDoc>(hits.map((h) => [h.document.id, h.document]));
     const postingResults = await searchOne<JobPostingDoc>(cfg, "job_posting", {
       q: "*",
-      filter_by: `company_id:[${companyIds.join(",")}] && ${POSTING_BASE_FILTER}`,
+      filter_by: POSTING_BASE_FILTER,
       group_by: "company_id",
       group_limit: 10,
       sort_by: "first_seen_at:desc",
+      per_page: limit,
+      page: Math.floor(offset / limit) + 1,
+      facet_by: "company_id",
+      facet_strategy: "exhaustive",
+      max_facet_values: 1,
+    });
+    const groupedHits = (postingResults.grouped_hits ?? []) as GroupedHit<JobPostingDoc>[];
+    const totalCompanies =
+      postingResults.facet_counts?.[0]?.stats?.total_values ?? groupedHits.length;
+    if (groupedHits.length === 0) return { companies: [], totalCompanies };
+
+    const companyIds = groupedHits.map((g) => g.hits[0].document.company_id);
+    const companyResults = await searchOne<CompanyDoc>(cfg, "company", {
+      q: "*",
+      filter_by: `id:[${companyIds.join(",")}]`,
       per_page: companyIds.length,
     });
-
-    const groupMap = new Map<string, GroupedHit<JobPostingDoc>>(
-      (postingResults.grouped_hits ?? []).map(
-        (g) => [g.hits[0].document.company_id, g] as [string, GroupedHit<JobPostingDoc>],
-      ),
+    const compMap = new Map<string, CompanyDoc>(
+      (companyResults.hits ?? []).map((h) => [h.document.id, h.document]),
     );
 
-    const companies: SearchResultCompany[] = companyIds
-      .map((cid) => {
+    const companies: SearchResultCompany[] = groupedHits
+      .map((g) => {
+        const first = g.hits[0].document;
+        const cid = first.company_id;
         const compDoc = compMap.get(cid);
-        const g = groupMap.get(cid);
-        if (!compDoc) return null;
         return {
-          company: { id: cid, name: compDoc.name, slug: compDoc.slug, icon: compDoc.icon ?? null },
-          activeMatches: compDoc.active_posting_count,
-          yearMatches: compDoc.year_posting_count,
-          postings: g ? g.hits.map((h) => mapHitToPosting(h)) : [],
+          company: {
+            id: cid,
+            name: compDoc?.name ?? first.company_name,
+            slug: compDoc?.slug ?? first.company_slug,
+            icon: compDoc?.icon ?? first.company_icon ?? null,
+          },
+          activeMatches: compDoc?.active_posting_count ?? g.found ?? g.hits.length,
+          yearMatches: compDoc?.year_posting_count ?? 0,
+          postings: g.hits.map((h) => mapHitToPosting(h)),
         } satisfies SearchResultCompany;
       })
-      .filter((c): c is SearchResultCompany => c !== null);
+      .filter((c) => c.postings.length > 0);
 
     return { companies, totalCompanies };
   }

--- a/apps/web/src/lib/search/typesense.ts
+++ b/apps/web/src/lib/search/typesense.ts
@@ -400,39 +400,6 @@ export class TypesenseSearchProvider implements SearchProvider {
   ): Promise<SearchResponse> {
     const client = getSearchClient();
 
-    // Query company collection sorted by active_posting_count
-    const companyResults: TsSearchResponse<CompanyDoc> = await withTypesenseRetry(
-      () =>
-        client
-          .collections<CompanyDoc>("company")
-          .documents()
-          .search({
-            q: "*",
-            filter_by: "active_posting_count:>0",
-            sort_by: "active_posting_count:desc",
-            per_page: limit,
-            page: Math.floor(offset / limit) + 1,
-          }),
-      { label: "topCompaniesUnfiltered" },
-    );
-
-    const totalCompanies = companyResults.found;
-    const companyHits = companyResults.hits ?? [];
-    if (companyHits.length === 0) {
-      return { companies: [], totalCompanies };
-    }
-
-    const companyIds = companyHits.map(
-      (h: SearchResponseHit<CompanyDoc>) => h.document.id,
-    );
-    const companyMap = new Map<string, CompanyDoc>(
-      companyHits.map(
-        (h: SearchResponseHit<CompanyDoc>) =>
-          [h.document.id, h.document] as [string, CompanyDoc],
-      ),
-    );
-
-    // Fetch postings for these companies
     const postingResults: TsSearchResponse<JobPostingDoc> = await withTypesenseRetry(
       () =>
         client
@@ -440,43 +407,67 @@ export class TypesenseSearchProvider implements SearchProvider {
           .documents()
           .search({
             q: "*",
-            filter_by: `company_id:[${companyIds.join(",")}] && ${POSTING_BASE_FILTER}`,
+            filter_by: POSTING_BASE_FILTER,
             group_by: "company_id",
             group_limit: 10,
             sort_by: "first_seen_at:desc",
-            per_page: companyIds.length,
+            per_page: limit,
+            page: Math.floor(offset / limit) + 1,
+            facet_by: "company_id",
+            facet_strategy: "exhaustive",
+            max_facet_values: 1,
           }),
-      { label: "topCompaniesUnfilteredPostings" },
+      { label: "topCompaniesUnfiltered" },
     );
 
     const groupedHits = (postingResults.grouped_hits ?? []) as GroupedHit[];
-    const groupMap = new Map<string, GroupedHit>(
-      groupedHits.map(
-        (g: GroupedHit) =>
-          [g.hits[0].document.company_id, g] as [string, GroupedHit],
+    const totalCompanies =
+      postingResults.facet_counts?.[0]?.stats?.total_values ?? groupedHits.length;
+    if (groupedHits.length === 0) {
+      return { companies: [], totalCompanies };
+    }
+
+    const companyIds = groupedHits.map(
+      (g: GroupedHit) => g.hits[0].document.company_id,
+    );
+    const companyResults: TsSearchResponse<CompanyDoc> = await withTypesenseRetry(
+      () =>
+        client
+          .collections<CompanyDoc>("company")
+          .documents()
+          .search({
+            q: "*",
+            filter_by: `id:[${companyIds.join(",")}]`,
+            per_page: companyIds.length,
+          }),
+      { label: "topCompaniesUnfilteredCompanies" },
+    );
+
+    const companyMap = new Map<string, CompanyDoc>(
+      (companyResults.hits ?? []).map(
+        (h: SearchResponseHit<CompanyDoc>) =>
+          [h.document.id, h.document] as [string, CompanyDoc],
       ),
     );
 
-    const companies: SearchResultCompany[] = companyIds
-      .map((companyId: string) => {
+    const companies: SearchResultCompany[] = groupedHits
+      .map((group: GroupedHit) => {
+        const firstHit = group.hits[0].document;
+        const companyId = firstHit.company_id;
         const compDoc = companyMap.get(companyId);
-        const group = groupMap.get(companyId);
-        if (!compDoc) return null;
         return {
           company: {
             id: companyId,
-            name: compDoc.name,
-            slug: compDoc.slug,
-            icon: compDoc.icon ?? null,
+            name: compDoc?.name ?? firstHit.company_name,
+            slug: compDoc?.slug ?? firstHit.company_slug,
+            icon: compDoc?.icon ?? firstHit.company_icon ?? null,
           },
-          activeMatches: compDoc.active_posting_count,
-          yearMatches: compDoc.year_posting_count,
-          postings: group
-            ? group.hits.map((hit: JobPostingHit) => mapHitToPosting(hit))
-            : [],
+          activeMatches: compDoc?.active_posting_count ?? group.found ?? group.hits.length,
+          yearMatches: compDoc?.year_posting_count ?? 0,
+          postings: group.hits.map((hit: JobPostingHit) => mapHitToPosting(hit)),
         };
       })
-      .filter((c): c is SearchResultCompany => c !== null);
+      .filter((c) => c.postings.length > 0);
 
     return { companies, totalCompanies };
   }


### PR DESCRIPTION
## Summary
- rank the anonymous unfiltered explore surface by each company’s freshest visible active posting instead of active posting count
- keep active/year counts hydrated from the company collection after selecting the freshness-ordered company page
- add deterministic regression tests for both server and browser-direct Typesense providers

## Reproduction
Live Typesense showed the old anonymous default order putting Starbucks third with newest posting 2026-06-03 while many 2026-06-19 companies were lower or absent. The fixed grouped job_posting query returns 2026-06-19 companies first.

Closes #3430.

## Verification
- pnpm --filter @jobseek/web exec vitest run src/lib/search/__tests__/typesense.test.ts
- pnpm --filter @jobseek/web exec vitest run src/lib/search/__tests__/typesense.e2e.test.ts src/lib/search/__tests__/typesense.test.ts
- pnpm --filter @jobseek/web typecheck
- pnpm --filter @jobseek/web exec eslint src/lib/search/typesense.ts src/lib/search/typesense-browser.ts src/lib/search/__tests__/typesense.test.ts src/lib/search/__tests__/typesense.e2e.test.ts
- git diff --check

Note: full web Vitest suite in the fresh worktree had 2 unrelated failures in src/lib/actions/__tests__/password-reset-race.test.ts with missing Redis/Auth env warnings; the new Typesense tests passed inside that run.