### PR TITLE
Fix stale anonymous explore defaults

### DIFF
--- a/apps/web/app/[lang]/(app)/explore/page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/page.tsx
@@ -7,6 +7,12 @@ import { buildAlternates } from "@/lib/seo";
 import { fetchExploreDefaults } from "@/lib/actions/explore-data";
 import { ExploreContent } from "./explore-content";
 
+const EXPLORE_DEFAULTS_CACHE_LIFE = {
+  stale: CACHE_TTL_SHORT,
+  revalidate: CACHE_TTL_SHORT,
+  expire: CACHE_TTL_SHORT * 5,
+} as const;
+
 // Cached for 60s. The anonymous, no-filter explore page is rendered
 // server-side via `fetchExploreDefaults` and embedded as `initialData`.
 // `ExploreContent` is a client component that re-fetches a personalized
@@ -53,7 +59,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
 export default async function AppPage({ params }: Props) {
   "use cache";
-  cacheLife({ revalidate: CACHE_TTL_SHORT });
+  cacheLife(EXPLORE_DEFAULTS_CACHE_LIFE);
   const { lang } = await params;
   const locale = isLocale(lang) ? lang : defaultLocale;
   const initialData = await fetchExploreDefaults({ locale });

--- a/apps/web/src/lib/search/__tests__/typesense.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense.test.ts
@@ -36,14 +36,15 @@ function postingHit(
   companyId: string,
   companyName: string,
   firstSeenAt: number,
+  title = `${companyName} role`,
 ) {
   return {
     document: {
-      id: `${companyId}-posting`,
+      id: `${companyId}-${firstSeenAt}`,
       company_id: companyId,
       company_name: companyName,
       company_slug: companyId,
-      title: `${companyName} role`,
+      title,
       is_active: true,
       location_ids: [],
       location_names: [],
@@ -76,6 +77,8 @@ function companyHit(
 
 const freshPosting = postingHit("fresh-co", "Fresh Co", NOW);
 const stalePosting = postingHit("stale-bigco", "Stale BigCo", NOW - 16 * DAY);
+const olderRole = postingHit("mixed-co", "Mixed Co", NOW - 3 * DAY, "Older role");
+const freshRole = postingHit("mixed-co", "Mixed Co", NOW - DAY, "Fresh role");
 
 function freshnessGroupedResponse() {
   return {
@@ -97,6 +100,29 @@ function companyResponse() {
       companyHit("stale-bigco", "Stale BigCo", 50_000, 50_000),
       companyHit("fresh-co", "Fresh Co", 1, 1),
     ],
+  };
+}
+
+function outOfOrderPostingsResponse() {
+  return {
+    grouped_hits: [
+      {
+        group_key: ["mixed-co"],
+        found: 2,
+        // Reproduces the screenshot class: an older posting appears above a
+        // fresher one inside the same anonymous company card.
+        hits: [olderRole, freshRole],
+      },
+    ],
+    facet_counts: [
+      { field_name: "company_id", counts: [], stats: { total_values: 1 } },
+    ],
+  };
+}
+
+function mixedCompanyResponse() {
+  return {
+    hits: [companyHit("mixed-co", "Mixed Co", 2, 2)],
   };
 }
 
@@ -154,6 +180,28 @@ describe("TypesenseSearchProvider.listTopCompanies", () => {
         per_page: 2,
       },
     });
+  });
+
+  it("orders postings inside anonymous default company cards by freshness", async () => {
+    const provider = new TypesenseSearchProvider();
+
+    mocks.search.mockImplementation(async (collection: string) => {
+      if (collection === "job_posting") return outOfOrderPostingsResponse();
+      if (collection === "company") return mixedCompanyResponse();
+      throw new Error(`unexpected collection: ${collection}`);
+    });
+
+    const result = await provider.listTopCompanies({
+      languages: [],
+      locale: "en",
+      offset: 0,
+      limit: 1,
+    });
+
+    expect(result.companies[0].postings.map((p) => p.title)).toEqual([
+      "Fresh role",
+      "Older role",
+    ]);
   });
 });
 
@@ -219,5 +267,43 @@ describe("TypesenseBrowserProvider.listTopCompanies", () => {
         per_page: "2",
       },
     });
+  });
+
+  it("orders browser-fetched anonymous card postings by freshness", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url === "/api/typesense-key") {
+          return Response.json({
+            apiKey: "browser-key",
+            host: "typesense.example",
+            port: 443,
+            protocol: "https",
+            expiresAt: Date.now() + 60_000,
+          });
+        }
+
+        const parsed = new URL(url);
+        const collection = parsed.pathname.match(/\/collections\/([^/]+)/)?.[1];
+        if (!collection) throw new Error(`unexpected URL: ${url}`);
+        if (collection === "job_posting") return Response.json(outOfOrderPostingsResponse());
+        if (collection === "company") return Response.json(mixedCompanyResponse());
+        throw new Error(`unexpected collection: ${collection}`);
+      }),
+    );
+
+    const provider = new TypesenseBrowserProvider();
+    const result = await provider.listTopCompanies({
+      languages: [],
+      locale: "en",
+      offset: 0,
+      limit: 1,
+    });
+
+    expect(result.companies[0].postings.map((p) => p.title)).toEqual([
+      "Fresh role",
+      "Older role",
+    ]);
   });
 });

--- a/apps/web/src/lib/search/typesense-browser.ts
+++ b/apps/web/src/lib/search/typesense-browser.ts
@@ -134,6 +134,19 @@ function mapHitToPosting(
   };
 }
 
+function mapHitsToPostingsByFreshness(
+  hits: SearchHit<JobPostingDoc>[],
+  filteredLocationIds?: number[],
+): SearchResultPosting[] {
+  if (hits.length <= 1) {
+    return hits.map((hit) => mapHitToPosting(hit, filteredLocationIds));
+  }
+
+  return [...hits]
+    .sort((a, b) => b.document.first_seen_at - a.document.first_seen_at)
+    .map((hit) => mapHitToPosting(hit, filteredLocationIds));
+}
+
 function emptyResponse(): SearchResponse {
   return { companies: [], totalCompanies: 0, degraded: true };
 }
@@ -284,7 +297,7 @@ export class TypesenseBrowserProvider implements SearchProvider {
           company: { id: cid, name: first.company_name, slug: first.company_slug, icon: first.company_icon ?? null },
           activeMatches: activeMap.get(cid) ?? 0,
           yearMatches: yearMap.get(cid) ?? 0,
-          postings: g.hits.map((h) => mapHitToPosting(h, locationIds)),
+          postings: mapHitsToPostingsByFreshness(g.hits, locationIds),
         } satisfies SearchResultCompany;
       })
       .filter((c): c is SearchResultCompany => c !== null);
@@ -338,7 +351,7 @@ export class TypesenseBrowserProvider implements SearchProvider {
           },
           activeMatches: compDoc?.active_posting_count ?? g.found ?? g.hits.length,
           yearMatches: compDoc?.year_posting_count ?? 0,
-          postings: g.hits.map((h) => mapHitToPosting(h)),
+          postings: mapHitsToPostingsByFreshness(g.hits),
         } satisfies SearchResultCompany;
       })
       .filter((c) => c.postings.length > 0);

--- a/apps/web/src/lib/search/typesense.ts
+++ b/apps/web/src/lib/search/typesense.ts
@@ -118,6 +118,19 @@ function mapHitToPosting(
   };
 }
 
+function mapHitsToPostingsByFreshness(
+  hits: JobPostingHit[],
+  filteredLocationIds?: number[],
+): SearchResultPosting[] {
+  if (hits.length <= 1) {
+    return hits.map((hit) => mapHitToPosting(hit, filteredLocationIds));
+  }
+
+  return [...hits]
+    .sort((a, b) => b.document.first_seen_at - a.document.first_seen_at)
+    .map((hit) => mapHitToPosting(hit, filteredLocationIds));
+}
+
 /**
  * Map grouped search results to SearchResponse.
  */
@@ -384,9 +397,7 @@ export class TypesenseSearchProvider implements SearchProvider {
           },
           activeMatches: activeCountMap.get(companyId) ?? 0,
           yearMatches: yearCountMap.get(companyId) ?? 0,
-          postings: group.hits.map((hit: JobPostingHit) =>
-            mapHitToPosting(hit, locationIds),
-          ),
+          postings: mapHitsToPostingsByFreshness(group.hits, locationIds),
         };
       })
       .filter((c): c is SearchResultCompany => c !== null);
@@ -464,7 +475,7 @@ export class TypesenseSearchProvider implements SearchProvider {
           },
           activeMatches: compDoc?.active_posting_count ?? group.found ?? group.hits.length,
           yearMatches: compDoc?.year_posting_count ?? 0,
-          postings: group.hits.map((hit: JobPostingHit) => mapHitToPosting(hit)),
+          postings: mapHitsToPostingsByFreshness(group.hits),
         };
       })
       .filter((c) => c.postings.length > 0);

--- a/apps/web/src/lib/services/__tests__/search-cache-key.test.ts
+++ b/apps/web/src/lib/services/__tests__/search-cache-key.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const keys: string[] = [];
+  const provider = {
+    listTopCompanies: vi.fn(async () => ({ companies: [], totalCompanies: 0 })),
+  };
+  return {
+    keys,
+    provider,
+    cached: vi.fn(async (key: string, fetcher: () => Promise<unknown>) => {
+      keys.push(key);
+      return fetcher();
+    }),
+  };
+});
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/cache", () => ({
+  cacheLife: vi.fn(),
+}));
+vi.mock("@/db", () => ({ db: { execute: vi.fn() } }));
+vi.mock("drizzle-orm", () => ({ sql: vi.fn() }));
+vi.mock("@/lib/cache", () => ({ cached: mocks.cached }));
+vi.mock("@/lib/cache-ttl", () => ({
+  CACHE_TTL_SHORT: 60,
+  CACHE_TTL_MEDIUM: 300,
+}));
+vi.mock("@/lib/db-retry", () => ({
+  withDbRetry: vi.fn((fn: () => Promise<unknown>) => fn()),
+}));
+vi.mock("@/lib/search", () => ({
+  getSearchProvider: () => mocks.provider,
+}));
+vi.mock("@/lib/sessionCache", () => ({
+  getSessionUserId: vi.fn(async () => null),
+}));
+
+import { listTopCompaniesAnonymous } from "../search";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.keys.length = 0;
+});
+
+describe("search service cache keys", () => {
+  it("versions anonymous top-company defaults so old ranking payloads cannot be reused", async () => {
+    await listTopCompaniesAnonymous({
+      languages: ["en"],
+      locale: "en",
+      offset: 0,
+      limit: 10,
+    });
+
+    expect(mocks.keys).toEqual(["top-companies:v2:en:en:0:10"]);
+  });
+});

--- a/apps/web/src/lib/services/search.ts
+++ b/apps/web/src/lib/services/search.ts
@@ -276,6 +276,11 @@ type TopCompaniesParams = {
   limit: number;
 };
 
+// Bump when the default anonymous ordering semantics change. The explore
+// prerender embeds this payload, so old Redis values must be unreachable
+// after ranking fixes even if a page cache revalidates before Redis expires.
+const TOP_COMPANIES_DEFAULT_CACHE_VERSION = "v2";
+
 /**
  * Session-free implementation shared by :func:`listTopCompanies` (which
  * reads ``getSessionUserId`` to enforce the anonymous truncation cap)
@@ -320,7 +325,7 @@ async function _listTopCompaniesImpl(
   let result: SearchResponse;
   if (hasNoExplicitFilters) {
     result = await cached(
-      `top-companies:${params.locale}:${langKey}:${params.offset}:${params.limit}`,
+      `top-companies:${TOP_COMPANIES_DEFAULT_CACHE_VERSION}:${params.locale}:${langKey}:${params.offset}:${params.limit}`,
       fetch,
       { ttl: CACHE_TTL_SHORT, skipIf: (r: SearchResponse) => !!r.degraded },
     );


### PR DESCRIPTION
## Summary
- version the anonymous top-company default cache key so old pre-fix ranking payloads cannot be reused
- bound the cached explore initial-data payload to a 60s stale/revalidate window with 5-minute expiry
- defensively sort grouped top-company postings by first_seen_at on server and browser providers

## Reproduction
- live Typesense returned fresh anonymous grouped results first
- fresh curl of https://jseek.co/en/explore still contained stale server-rendered initialData with old ordering
- response headers showed prerender/cache stale behavior on the unauthenticated explore route

## QA coverage
- added provider regressions for older grouped postings appearing before fresher postings inside a company card
- added cache-key regression for the anonymous top-company defaults version

## Performance notes
- no extra Typesense or Redis calls added
- sorting is local and bounded by group_limit 10; single-posting cards skip the copy/sort
- route remains statically classified and cached for anonymous no-filter visitors, with bounded expiry to prevent days-old embedded payloads

## Verification
- pnpm --filter @jobseek/web test src/lib/search/__tests__/typesense.test.ts src/lib/services/__tests__/search-cache-key.test.ts
- pnpm --filter @jobseek/web lint
- pnpm --filter @jobseek/web typecheck
- pnpm --filter @jobseek/web test:isr
