### PR TITLE
Sort company card postings by freshness

### DIFF
--- a/apps/web/src/components/search/__tests__/company-card-posting-order.test.tsx
+++ b/apps/web/src/components/search/__tests__/company-card-posting-order.test.tsx
@@ -1,0 +1,173 @@
+import { act, render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@/test-utils/lingui-mock";
+import type { SearchResultCompany, SearchResultPosting } from "@/lib/search";
+
+const mocks = vi.hoisted(() => ({
+  loadMorePostings: vi.fn(),
+  load: undefined as undefined | (() => Promise<void>),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ lang: "en" }),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, prefetch: _prefetch, ...props }: Record<string, unknown>) => (
+    <a href={href as string} {...props}>{children as React.ReactNode}</a>
+  ),
+}));
+
+vi.mock("@/components/CompanyIcon", () => ({
+  CompanyIcon: ({ alt }: { alt: string }) => <span data-testid="company-icon">{alt}</span>,
+}));
+
+vi.mock("@/components/InfiniteScrollSentinel", () => ({
+  InfiniteScrollSentinel: () => null,
+}));
+
+vi.mock("@/components/TruncationPrompt", () => ({
+  TruncationPrompt: () => null,
+}));
+
+vi.mock("@/components/TrackingDot", () => ({
+  TrackingDot: () => <span data-testid="tracking-dot" />,
+}));
+
+vi.mock("@/components/PendingJobWarning", () => ({
+  PendingJobIcon: () => <span data-testid="pending-job-icon" />,
+}));
+
+vi.mock("@/components/search/save-button", () => ({
+  SaveButton: ({ postingId }: { postingId: string }) => (
+    <button type="button" aria-label={`Save job ${postingId}`}>save</button>
+  ),
+}));
+
+vi.mock("@/components/search/star-button", () => ({
+  StarButton: () => null,
+}));
+
+vi.mock("@/components/ui/scroll-fade", () => ({
+  ScrollFade: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/use-infinite-scroll", () => ({
+  useInfiniteScroll: ({ load }: { load: () => Promise<void> }) => {
+    mocks.load = load;
+    return { sentinelRef: { current: null }, isLoading: false };
+  },
+}));
+
+vi.mock("@/lib/actions/search", () => ({
+  loadMorePostings: mocks.loadMorePostings,
+}));
+
+vi.mock("@/lib/time", () => ({
+  timeAgoShort: () => "1m",
+}));
+
+vi.mock("@/lib/search/query-params", () => ({
+  buildFilteredPath: () => "/en/company/acme",
+}));
+
+import { CompanyCard, sortPostingsByFreshness } from "../company-card";
+
+function posting(
+  id: string,
+  title: string,
+  firstSeenAt: string,
+): SearchResultPosting {
+  return {
+    id,
+    title,
+    firstSeenAt,
+    relevanceScore: 1,
+    locations: [],
+    isActive: true,
+  };
+}
+
+function result(postings: SearchResultPosting[]): SearchResultCompany {
+  return {
+    company: { id: "company-1", name: "High Churn Co", slug: "high-churn", icon: null },
+    activeMatches: 100,
+    yearMatches: 100,
+    postings,
+  };
+}
+
+function renderCard(postings: SearchResultPosting[]) {
+  return render(
+    <CompanyCard
+      result={result(postings)}
+      keywords={[]}
+      locationIds={[]}
+      locations={[]}
+      occupations={[]}
+      seniorities={[]}
+      technologies={[]}
+      employmentTypes={[]}
+      workMode={[]}
+      languages={["en"]}
+      onShowPosting={vi.fn()}
+      selectedPostingId={null}
+    />,
+  );
+}
+
+function visiblePostingIds(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll("[data-posting-id]")).map(
+    (node) => node.getAttribute("data-posting-id") ?? "",
+  );
+}
+
+describe("CompanyCard posting order", () => {
+  beforeEach(() => {
+    mocks.load = undefined;
+    mocks.loadMorePostings.mockReset();
+  });
+
+  it("sorts initial postings by newest first before rendering", () => {
+    const { container } = renderCard([
+      posting("old", "Old role", "2026-06-22T11:20:00.000Z"),
+      posting("fresh", "Fresh role", "2026-06-22T11:50:00.000Z"),
+      posting("middle", "Middle role", "2026-06-22T11:40:00.000Z"),
+    ]);
+
+    expect(visiblePostingIds(container)).toEqual(["fresh", "middle", "old"]);
+  });
+
+  it("resorts after load-more appends fresher postings from high-churn companies", async () => {
+    const { container } = renderCard([
+      posting("visible-older", "Visible older role", "2026-06-22T11:30:00.000Z"),
+      posting("visible-oldest", "Visible oldest role", "2026-06-22T11:20:00.000Z"),
+    ]);
+
+    mocks.loadMorePostings.mockResolvedValueOnce({
+      postings: [
+        posting("loaded-fresh", "Loaded fresh role", "2026-06-22T11:55:00.000Z"),
+      ],
+      truncated: false,
+    });
+
+    await act(async () => {
+      await mocks.load?.();
+    });
+
+    expect(visiblePostingIds(container)).toEqual([
+      "loaded-fresh",
+      "visible-older",
+      "visible-oldest",
+    ]);
+  });
+
+  it("uses posting id as deterministic tie-breaker", () => {
+    expect(
+      sortPostingsByFreshness([
+        posting("b", "B", "2026-06-22T11:55:00.000Z"),
+        posting("a", "A", "2026-06-22T11:55:00.000Z"),
+      ]).map((p) => p.id),
+    ).toEqual(["a", "b"]);
+  });
+});

--- a/apps/web/src/components/search/company-card.tsx
+++ b/apps/web/src/components/search/company-card.tsx
@@ -64,11 +64,12 @@ function CompanyCardImpl({ result, keywords, locationIds, locations, occupations
 
   const allPostings = useMemo(() => {
     const seen = new Set<string>();
-    return [...result.postings, ...extraPostings].filter((p) => {
+    const deduped = [...result.postings, ...extraPostings].filter((p) => {
       if (seen.has(p.id)) return false;
       seen.add(p.id);
       return true;
     });
+    return sortPostingsByFreshness(deduped);
   }, [result.postings, extraPostings]);
 
   const hasMore = !exhausted && !isTruncated && allPostings.length < activeMatches;
@@ -142,6 +143,12 @@ function CompanyCardImpl({ result, keywords, locationIds, locations, occupations
           // re-render of one row cannot reflow neighbouring rows.
           <div
             key={posting.id}
+            data-posting-id={posting.id}
+            data-first-seen-at={
+              typeof posting.firstSeenAt === "string"
+                ? posting.firstSeenAt
+                : posting.firstSeenAt.toISOString()
+            }
             className={`relative flex min-h-7 items-center gap-2 rounded px-1 py-1.5 transition-colors [contain:layout] ${posting.id === selectedPostingId ? "bg-primary/10" : "hover:bg-border-soft"} ${posting.isActive === false ? "opacity-50" : ""}`}
           >
             <button
@@ -192,6 +199,25 @@ function CompanyCardImpl({ result, keywords, locationIds, locations, occupations
       </ScrollFade>
     </div>
   );
+}
+
+function firstSeenAtMs(posting: SearchResultPosting): number {
+  const value =
+    typeof posting.firstSeenAt === "string"
+      ? Date.parse(posting.firstSeenAt)
+      : posting.firstSeenAt.getTime();
+  return Number.isFinite(value) ? value : 0;
+}
+
+export function sortPostingsByFreshness(
+  postings: SearchResultPosting[],
+): SearchResultPosting[] {
+  if (postings.length <= 1) return postings;
+  return [...postings].sort((a, b) => {
+    const byTime = firstSeenAtMs(b) - firstSeenAtMs(a);
+    if (byTime !== 0) return byTime;
+    return a.id.localeCompare(b.id);
+  });
 }
 
 // --- Memoization (issue #3198) -----------------------------------------------


### PR DESCRIPTION
## Summary
- sort each company card's combined initial + load-more postings by firstSeenAt before rendering
- add data-first-seen-at / data-posting-id attributes for DOM-level QA inspection
- add component regressions for out-of-order initial data and fresher rows arriving after load-more

## Why
After scrolling, high-churn companies like Amazon/NHS can receive load-more batches whose postings are fresher than rows already visible. Rendering `[initial, ...loaded]` preserves arrival order and can show 23m/51m rows above 3m/9m rows. The card should enforce newest-first at the final render boundary regardless of whether data came from server initialData, restored state, browser Typesense, or load-more.

## Performance notes
- no extra network calls
- sorting happens inside the existing useMemo after dedupe
- single-row cards return immediately
- card posting lists are capped/bounded in this UI, so sort cost is local and small

## Verification
- pnpm --filter @jobseek/web test src/components/search/__tests__/company-card-posting-order.test.tsx src/components/search/__tests__/company-card.test.tsx src/components/search/__tests__/company-card-scroll-stability.test.tsx
- pnpm --filter @jobseek/web lint
- pnpm --filter @jobseek/web typecheck
