### PR TITLE
Fix company image upload races

### DIFF
--- a/.github/workflows/deploy-crawler-browser.yml
+++ b/.github/workflows/deploy-crawler-browser.yml
@@ -5,10 +5,15 @@ on:
     branches: [main]
     paths:
       - 'apps/crawler/**'
+      - '!apps/crawler/data/**'
       - '.github/workflows/deploy-crawler-browser.yml'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+concurrency:
+  group: crawler-production-sync
+  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/.github/workflows/sync-data.yml
+++ b/.github/workflows/sync-data.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches: [main]
     paths:
-      - 'apps/crawler/data/companies.csv'
-      - 'apps/crawler/data/boards.csv'
-      - 'apps/crawler/data/company_descriptions.csv'
+      - 'apps/crawler/data/*.csv'
   workflow_dispatch:
+
+concurrency:
+  group: crawler-production-sync
+  cancel-in-progress: false
 
 jobs:
   sync:

--- a/.github/workflows/upload-company-images.yml
+++ b/.github/workflows/upload-company-images.yml
@@ -7,6 +7,11 @@ on:
     paths:
       - "apps/crawler/data/images/**"
   workflow_dispatch:
+    inputs:
+      branch:
+        description: "Same-repo branch to update, e.g. add-company/intuit"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -14,8 +19,8 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: upload-images-${{ github.head_ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.ref || inputs.branch || github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
   upload:
@@ -31,30 +36,19 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          ref: main
           token: ${{ github.token }}
           fetch-depth: 0
 
-      - name: Prepare trusted scripts and PR branch
-        if: github.event_name != 'workflow_dispatch'
+      - name: Prepare trusted scripts and target branch
         env:
-          BRANCH: ${{ github.head_ref }}
+          BRANCH: ${{ github.event.pull_request.head.ref || inputs.branch || github.ref_name }}
         run: |
           set -euo pipefail
 
-          mkdir -p "$RUNNER_TEMP/trusted-scripts"
-          cp .github/scripts/label-pr.sh "$RUNNER_TEMP/trusted-scripts/label-pr.sh"
-          cp .github/scripts/close-linked-company-request-issues.sh "$RUNNER_TEMP/trusted-scripts/close-linked-company-request-issues.sh"
-          chmod +x "$RUNNER_TEMP/trusted-scripts/"*.sh
+          git check-ref-format --branch "$BRANCH" >/dev/null
+          git fetch --no-tags origin "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
 
-          git fetch origin main "$BRANCH"
-          # The workflow has production R2 secrets. Before running Python,
-          # keep code from main and check out only PR-controlled data inputs.
-          git checkout "origin/$BRANCH" -- apps/crawler/data
-
-      - name: Capture trusted scripts
-        if: github.event_name == 'workflow_dispatch'
-        run: |
-          set -euo pipefail
           mkdir -p "$RUNNER_TEMP/trusted-scripts"
           cp .github/scripts/label-pr.sh "$RUNNER_TEMP/trusted-scripts/label-pr.sh"
           cp .github/scripts/close-linked-company-request-issues.sh "$RUNNER_TEMP/trusted-scripts/close-linked-company-request-issues.sh"
@@ -69,50 +63,57 @@ jobs:
       - run: uv sync
         working-directory: apps/crawler
 
-      - name: Upload images to R2
-        working-directory: apps/crawler
-        run: uv run python -m src.image_sync
+      - name: Upload images to R2 and push cleanup
         env:
+          BRANCH: ${{ github.event.pull_request.head.ref || inputs.branch || github.ref_name }}
           R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_BUCKET: ${{ vars.R2_BUCKET }}
           R2_DOMAIN_URL: ${{ vars.R2_DOMAIN_URL }}
-
-      - name: Commit R2 URLs and image cleanup
-        env:
-          BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
           set -euo pipefail
+
+          git check-ref-format --branch "$BRANCH" >/dev/null
+          trusted_ref="$(git rev-parse HEAD)"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          if git diff --quiet -- apps/crawler/data; then
-            echo "No R2 URL or image cleanup changes to commit"
-            exit 0
-          fi
+          for attempt in 1 2 3; do
+            echo "Image upload commit attempt $attempt"
 
-          if [ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]; then
-            git diff --binary -- apps/crawler/data > "$RUNNER_TEMP/image-sync.patch"
-            git checkout -B "$BRANCH" "origin/$BRANCH"
-            git apply "$RUNNER_TEMP/image-sync.patch"
-          fi
+            git fetch --no-tags origin "refs/heads/$BRANCH:refs/remotes/origin/$BRANCH"
+            git checkout -f -B "$BRANCH" "refs/remotes/origin/$BRANCH"
 
-          git add apps/crawler/data/
-          git commit -m "Upload images to R2"
+            # The workflow has production R2 secrets. Keep PR-controlled data,
+            # but run only trusted crawler code and dependency metadata.
+            git restore --source="$trusted_ref" --staged --worktree -- \
+              apps/crawler/src \
+              apps/crawler/pyproject.toml \
+              apps/crawler/uv.lock
 
-          # maybe-auto-merge can rebase/force-push the same PR branch in parallel.
-          # Rebase this commit on top of the latest remote branch before pushing.
-          git fetch origin "$BRANCH"
-          git rebase "origin/$BRANCH"
+            (cd apps/crawler && uv run python -m src.image_sync)
 
-          # Retry once in case branch moved again between fetch and push.
-          git push --force-with-lease origin "HEAD:$BRANCH" || {
-            git fetch origin "$BRANCH"
-            git rebase "origin/$BRANCH"
-            git push --force-with-lease origin "HEAD:$BRANCH"
-          }
+            if git diff --quiet -- apps/crawler/data; then
+              echo "No R2 URL or image cleanup changes to commit"
+              exit 0
+            fi
+
+            git add apps/crawler/data/
+            git commit -m "Upload images to R2"
+
+            if git push --force-with-lease origin "HEAD:$BRANCH"; then
+              exit 0
+            fi
+
+            echo "Branch moved while uploading images; retrying against latest branch"
+            git reset --hard
+            sleep "$attempt"
+          done
+
+          echo "Unable to commit image upload after 3 attempts" >&2
+          exit 1
 
       - name: Post image preview comment
         if: github.event_name != 'workflow_dispatch'
@@ -190,7 +191,8 @@ jobs:
       - name: Label PR
         id: label
         if: github.event_name != 'workflow_dispatch'
-        run: "$RUNNER_TEMP/trusted-scripts/label-pr.sh"
+        run: |
+          "$RUNNER_TEMP/trusted-scripts/label-pr.sh"
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
@@ -232,7 +234,8 @@ jobs:
 
       - name: Close linked company-request issues
         if: github.event_name != 'workflow_dispatch' && steps.merge.outputs.merged == 'true'
-        run: "$RUNNER_TEMP/trusted-scripts/close-linked-company-request-issues.sh"
+        run: |
+          "$RUNNER_TEMP/trusted-scripts/close-linked-company-request-issues.sh"
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Fixes #3475.

- makes `upload-company-images.yml` serialize per target branch for both PR and manual runs, without cancelling in-progress uploads after R2 side effects have started
- changes manual image upload reruns to use a required `branch` input, so operators can run the trusted workflow from `main` with `gh workflow run upload-company-images.yml --ref main -f branch=add-company/<slug>`
- removes the stale `git diff --binary | git apply` replay path; each retry now refetches the latest target branch, restores trusted crawler code/dependency metadata from `main`, reruns `image_sync`, and pushes with `--force-with-lease`
- prevents data-only company/taxonomy CSV merges from triggering a full crawler deploy, and serializes `sync-data` with crawler deploys under one production concurrency group

## Main failure diagnosis

The latest `ci.yml` run on `main` is green. The red main runs I found were operational workflows after rapid company merges:

- `Sync CSV data` run `28506313257` failed in `crawler sync`
- earlier `Deploy Crawler (Hetzner)`/`Sync CSV data` failures had the same root error
- logs show `asyncpg.exceptions.LockNotAvailableError: canceling statement due to lock timeout` at `sync_occupation_domains`, during the taxonomy-name upsert

Root cause: data-only company merges were starting both the lightweight CSV sync and the full crawler deploy, and both run `crawler sync` against Supabase. Rapid sequential merges made overlapping sync processes contend on the same taxonomy tables. The workflow changes in this PR address that by routing data-only changes to `sync-data.yml` and queueing deploy/sync production mutations.

## Verification

- `actionlint .github/workflows/upload-company-images.yml .github/workflows/sync-data.yml .github/workflows/deploy-crawler-browser.yml`
- `ruby -e 'require "yaml"; ARGV.each { |p| YAML.load_file(p); puts "parsed #{p}" }' .github/workflows/upload-company-images.yml .github/workflows/sync-data.yml .github/workflows/deploy-crawler-browser.yml`
- `git diff --check`
