### PR TITLE
Fix watchlist Typesense filter batching

### DIFF
--- a/apps/web/src/lib/actions/__tests__/watchlist-year-count-fallback.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlist-year-count-fallback.test.ts
@@ -191,6 +191,11 @@ import {
   getWatchlistPostingYearCount,
   getWatchlistPostings,
 } from "../watchlists";
+import { typesenseQueryStringLength } from "@/lib/search/typesense-query-size";
+
+function makeUuid(index: number): string {
+  return `00000000-0000-0000-0000-${String(index).padStart(12, "0")}`;
+}
 
 describe("getWatchlistPostingYearCount fallback (#3056)", () => {
   beforeEach(() => {
@@ -310,6 +315,46 @@ describe("getWatchlistPostingYearCount fallback (#3056)", () => {
 
     expect(mocks.withTypesenseRetry).toHaveBeenCalledTimes(1);
     expect(mocks.isTypesenseUnavailableError).toHaveBeenCalledWith(rateLimitError);
+    expect(mocks.dbExecute).not.toHaveBeenCalled();
+  });
+
+  it("batches active posting queries before the Typesense GET limit (#3477)", async () => {
+    const companyIds = Array.from({ length: 99 }, (_, i) => makeUuid(i + 1));
+    mocks.tsSearch.mockResolvedValue({ found: 0, hits: [] });
+
+    const result = await getWatchlistPostings({
+      companyIds,
+      offset: 0,
+      limit: 20,
+    });
+
+    expect(result).toEqual({ postings: [], total: 0 });
+    expect(mocks.tsSearch.mock.calls.length).toBeGreaterThan(1);
+    for (const [params] of mocks.tsSearch.mock.calls) {
+      expect(typesenseQueryStringLength(params)).toBeLessThan(4000);
+      const filter = (params as { filter_by?: string }).filter_by ?? "";
+      const idsInFilter = filter.match(/[0-9a-f-]{36}/g) ?? [];
+      expect(idsInFilter.length).toBeLessThan(companyIds.length);
+    }
+    expect(mocks.dbExecute).not.toHaveBeenCalled();
+  });
+
+  it("batches year-count queries instead of returning zero for large watchlists (#3477)", async () => {
+    const companyIds = Array.from({ length: 99 }, (_, i) => makeUuid(i + 1));
+    mocks.tsSearch.mockResolvedValue({ found: 5, hits: [] });
+
+    const count = await getWatchlistPostingYearCount({
+      companyIds,
+    });
+
+    expect(mocks.tsSearch.mock.calls.length).toBeGreaterThan(1);
+    expect(count).toBe(mocks.tsSearch.mock.calls.length * 5);
+    for (const [params] of mocks.tsSearch.mock.calls) {
+      expect(typesenseQueryStringLength(params)).toBeLessThan(4000);
+      const filter = (params as { filter_by?: string }).filter_by ?? "";
+      const idsInFilter = filter.match(/[0-9a-f-]{36}/g) ?? [];
+      expect(idsInFilter.length).toBeLessThan(companyIds.length);
+    }
     expect(mocks.dbExecute).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -32,6 +32,10 @@ import {
   isTypesenseUnavailableError,
   withTypesenseRetry,
 } from "@/lib/search/typesense-retry";
+import {
+  isTypesenseQueryStringSafe,
+  splitValuesForTypesenseQuery,
+} from "@/lib/search/typesense-query-size";
 import { localesOrNoneClause } from "@/lib/search/pg-filters";
 import {
   upsertWatchlist as tsUpsertWatchlist,
@@ -1491,27 +1495,28 @@ export async function getWatchlistPostingYearCount(
     const hasKeywords = params.keywords && params.keywords.length > 0;
     const keywordsQ = hasKeywords ? params.keywords!.join(" ") : "*";
     const oneYearAgo = Math.floor((Date.now() - 365 * 24 * 3600 * 1000) / 1000);
-    const parts = [POSTING_FLOW_FILTER, `first_seen_at:>${oneYearAgo}`];
-    if (params.companyIds.length > 0 && params.companyIds.length <= COMPANY_BATCH_SIZE) {
-      parts.push(`company_id:[${params.companyIds.join(",")}]`);
-    } else if (params.companyIds.length > COMPANY_BATCH_SIZE) {
-      // Oversized company list: fall back to the batched helper's
-      // activeTotal flavour — conservatively skip year count instead
-      // of running N Typesense queries just for a stats number.
-      return 0;
-    }
-    if (filterStr) parts.push(filterStr);
-    const result = await withTypesenseRetry(
-      () =>
-        client.collections("job_posting").documents().search({
-          q: keywordsQ,
-          query_by: "title",
-          filter_by: parts.join(" && "),
-          per_page: 0,
-        }),
-      { label: "getWatchlistPostingYearCount" },
+    const baseParts = [POSTING_FLOW_FILTER, `first_seen_at:>${oneYearAgo}`];
+    const buildSearchParams = (companyIds: readonly string[]) => ({
+      q: keywordsQ,
+      query_by: "title",
+      filter_by: buildWatchlistPostingFilter(baseParts, companyIds, filterStr),
+      per_page: 0,
+    });
+    const batches = params.companyIds.length > 0
+      ? splitValuesForTypesenseQuery(params.companyIds, buildSearchParams, COMPANY_BATCH_SIZE)
+      : [[]];
+    const results = await Promise.all(
+      batches.map((batch) =>
+        withTypesenseRetry(
+          () =>
+            client.collections("job_posting").documents().search(
+              buildSearchParams(batch),
+            ),
+          { label: "getWatchlistPostingYearCount" },
+        ),
+      ),
     );
-    return result.found ?? 0;
+    return results.reduce((sum, result) => sum + (result.found ?? 0), 0);
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
     console.error("[getWatchlistPostingYearCount] Typesense failed, falling back to Postgres", err);
@@ -1572,41 +1577,41 @@ export async function getWatchlistPostingDisplayCounts(
   const hasKeywords = f.keywords && f.keywords.length > 0;
   const q = hasKeywords ? f.keywords!.join(" ") : "*";
 
-  const companyClause = !isAny && companyIds.length > 0 && companyIds.length <= COMPANY_BATCH_SIZE
-    ? `company_id:[${companyIds.join(",")}]`
-    : null;
-  // Oversized company list (>COMPANY_BATCH_SIZE) would need fan-out
-  // batching to count correctly. The card is decorative, not load-
-  // bearing — fall back to "skip the stats" rather than running 10+
-  // Typesense queries for a number on a blog embed.
-  if (!isAny && companyIds.length > COMPANY_BATCH_SIZE) {
-    return { activeJobs: 0, yearJobs: 0 };
-  }
-
-  const baseFilterParts = (extra: string[]): string =>
-    [...extra, ...(companyClause ? [companyClause] : []), ...(filterStr ? [filterStr] : [])].join(" && ");
-
   const oneYearAgo = Math.floor((Date.now() - 365 * 24 * 3600 * 1000) / 1000);
-  const activeFilter = baseFilterParts([POSTING_BASE_FILTER]);
-  // Mirror `POSTING_FLOW_FILTER` (#2965) on the year filter so the
-  // year-count stays content-quality-consistent with the active filter
-  // (which already includes `has_content:!=false` via POSTING_BASE_FILTER).
-  // See issue #3029.
-  const yearFilter = baseFilterParts([POSTING_FLOW_FILTER, `first_seen_at:>${oneYearAgo}`]);
 
   try {
     const client = getSearchClient();
-    const [activeRes, yearRes] = await Promise.all([
-      client.collections("job_posting").documents().search({
-        q, query_by: "title", filter_by: activeFilter, per_page: 0,
-      }),
-      client.collections("job_posting").documents().search({
-        q, query_by: "title", filter_by: yearFilter, per_page: 0,
-      }),
+    const searchCount = async (baseParts: string[], label: string): Promise<number> => {
+      const buildSearchParams = (batch: readonly string[]) => ({
+        q,
+        query_by: "title",
+        filter_by: buildWatchlistPostingFilter(baseParts, !isAny ? batch : [], filterStr),
+        per_page: 0,
+      });
+      const batches = !isAny && companyIds.length > 0
+        ? splitValuesForTypesenseQuery(companyIds, buildSearchParams, COMPANY_BATCH_SIZE)
+        : [[]];
+      const results = await Promise.all(
+        batches.map((batch) =>
+          withTypesenseRetry(
+            () => client.collections("job_posting").documents().search(buildSearchParams(batch)),
+            { label },
+          ),
+        ),
+      );
+      return results.reduce((sum, result) => sum + (result.found ?? 0), 0);
+    };
+    // Mirror `POSTING_FLOW_FILTER` (#2965) on the year filter so the
+    // year-count stays content-quality-consistent with the active filter
+    // (which already includes `has_content:!=false` via POSTING_BASE_FILTER).
+    // See issue #3029.
+    const [activeJobs, yearJobs] = await Promise.all([
+      searchCount([POSTING_BASE_FILTER], "getWatchlistPostingDisplayCounts.active"),
+      searchCount([POSTING_FLOW_FILTER, `first_seen_at:>${oneYearAgo}`], "getWatchlistPostingDisplayCounts.year"),
     ]);
     return {
-      activeJobs: activeRes.found ?? 0,
-      yearJobs: yearRes.found ?? 0,
+      activeJobs,
+      yearJobs,
     };
   } catch (err) {
     console.error("[getWatchlistPostingDisplayCounts] Typesense failed", err);
@@ -1795,7 +1800,17 @@ function _mapWatchlistDoc(doc: Record<string, unknown>): PublicWatchlistEntry {
   };
 }
 
-/** Max company IDs per Typesense filter string batch (~7KB ≈ 200 UUIDs). */
+function buildWatchlistPostingFilter(
+  baseParts: readonly string[],
+  companyIds: readonly string[],
+  filterStr: string,
+): string {
+  return [
+    ...baseParts,
+    companyIds.length > 0 ? `company_id:[${companyIds.join(",")}]` : "",
+    filterStr,
+  ].filter(Boolean).join(" && ");
+}
 
 async function _getWatchlistPostingsTypesense(
   params: WatchlistPostingQueryParams,
@@ -1824,31 +1839,31 @@ async function _getWatchlistPostingsTypesense(
   const keywordsQ = hasKeywords ? params.keywords!.join(" ") : "*";
 
   // Build company_id filter — omit for "any company" mode
-  let companyFilter = "";
-  if (params.companyIds.length > 0) {
-    if (params.companyIds.length > COMPANY_BATCH_SIZE) {
-      // Large watchlist: batch queries and merge
-      return _getWatchlistPostingsBatched(params, userId);
-    }
-    companyFilter = `company_id:[${params.companyIds.join(",")}]`;
-  }
+  const fullFilter = buildWatchlistPostingFilter(
+    [POSTING_BASE_FILTER],
+    params.companyIds,
+    filterStr,
+  );
+  const searchParams = {
+    q: keywordsQ,
+    query_by: "title",
+    filter_by: fullFilter,
+    sort_by: hasKeywords ? "_text_match:desc,first_seen_at:desc" : "first_seen_at:desc",
+    per_page: params.limit === 0 ? 0 : params.limit,
+    page: params.limit === 0 ? 1 : Math.floor(params.offset / params.limit) + 1,
+  };
 
-  // Combine all filter parts
-  const filterParts = [POSTING_BASE_FILTER];
-  if (companyFilter) filterParts.push(companyFilter);
-  if (filterStr) filterParts.push(filterStr);
-  const fullFilter = filterParts.join(" && ");
+  if (
+    params.companyIds.length > 0 &&
+    (params.companyIds.length > COMPANY_BATCH_SIZE ||
+      !isTypesenseQueryStringSafe(searchParams))
+  ) {
+    return _getWatchlistPostingsBatched(params, userId);
+  }
 
   const result = await withTypesenseRetry(
     () =>
-      client.collections("job_posting").documents().search({
-        q: keywordsQ,
-        query_by: "title",
-        filter_by: fullFilter,
-        sort_by: hasKeywords ? "_text_match:desc,first_seen_at:desc" : "first_seen_at:desc",
-        per_page: params.limit === 0 ? 0 : params.limit,
-        page: params.limit === 0 ? 1 : Math.floor(params.offset / params.limit) + 1,
-      }),
+      client.collections("job_posting").documents().search(searchParams),
     { label: "getWatchlistPostings" },
   );
 
@@ -1879,7 +1894,7 @@ async function _getWatchlistPostingsTypesense(
   };
 }
 
-/** Batched version for large watchlists (200+ companies). */
+/** Batched version for large watchlists or large serialized filters. */
 async function _getWatchlistPostingsBatched(
   params: WatchlistPostingQueryParams,
   userId: string | null,
@@ -1903,26 +1918,39 @@ async function _getWatchlistPostingsBatched(
 
   const hasKeywords = params.keywords && params.keywords.length > 0;
   const keywordsQ = hasKeywords ? params.keywords!.join(" ") : "*";
+  const sortBy = hasKeywords ? "_text_match:desc,first_seen_at:desc" : "first_seen_at:desc";
+  const needed = params.offset + params.limit;
+  const buildFilter = (batch: readonly string[]) =>
+    buildWatchlistPostingFilter([POSTING_BASE_FILTER], batch, filterStr);
+  const buildCountSearchParams = (batch: readonly string[]) => ({
+    q: keywordsQ,
+    query_by: "title",
+    filter_by: buildFilter(batch),
+    per_page: 0,
+  });
+  const buildRowsSearchParams = (batch: readonly string[]) => ({
+    q: keywordsQ,
+    query_by: "title",
+    filter_by: buildFilter(batch),
+    sort_by: sortBy,
+    per_page: needed,
+    page: 1,
+  });
 
-  // Split company IDs into batches
-  const batches: string[][] = [];
-  for (let i = 0; i < params.companyIds.length; i += COMPANY_BATCH_SIZE) {
-    batches.push(params.companyIds.slice(i, i + COMPANY_BATCH_SIZE));
-  }
+  const batches = splitValuesForTypesenseQuery(
+    params.companyIds,
+    buildRowsSearchParams,
+    COMPANY_BATCH_SIZE,
+  );
 
   // Query each batch for total count (per_page: 0)
   const countResults = await Promise.all(
     batches.map((batch) => {
-      const filterParts = [POSTING_BASE_FILTER, `company_id:[${batch.join(",")}]`];
-      if (filterStr) filterParts.push(filterStr);
       return withTypesenseRetry(
         () =>
-          client.collections("job_posting").documents().search({
-            q: keywordsQ,
-            query_by: "title",
-            filter_by: filterParts.join(" && "),
-            per_page: 0,
-          }),
+          client.collections("job_posting").documents().search(
+            buildCountSearchParams(batch),
+          ),
         { label: "getWatchlistPostings.batched.count" },
       );
     }),
@@ -1933,21 +1961,13 @@ async function _getWatchlistPostingsBatched(
 
   // For actual postings, query all batches with enough per_page to cover offset+limit,
   // then merge and sort by first_seen_at desc, slice to desired page.
-  const needed = params.offset + params.limit;
   const postingsResults = await Promise.all(
     batches.map((batch) => {
-      const filterParts = [POSTING_BASE_FILTER, `company_id:[${batch.join(",")}]`];
-      if (filterStr) filterParts.push(filterStr);
       return withTypesenseRetry(
         () =>
-          client.collections("job_posting").documents().search({
-            q: keywordsQ,
-            query_by: "title",
-            filter_by: filterParts.join(" && "),
-            sort_by: hasKeywords ? "_text_match:desc,first_seen_at:desc" : "first_seen_at:desc",
-            per_page: needed,
-            page: 1,
-          }),
+          client.collections("job_posting").documents().search(
+            buildRowsSearchParams(batch),
+          ),
         { label: "getWatchlistPostings.batched.rows" },
       );
     }),

--- a/apps/web/src/lib/search/__tests__/typesense-browser-watchlist.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense-browser-watchlist.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getTypesenseBrowserConfig: vi.fn(async () => ({
+    apiKey: "test-key",
+    host: "typesense.test",
+    port: 443,
+    protocol: "https",
+    expiresAt: Date.now() + 60_000,
+  })),
+}));
+
+vi.mock("../typesense-browser-key", () => ({
+  getTypesenseBrowserConfig: mocks.getTypesenseBrowserConfig,
+}));
+
+import { getWatchlistPostingsBrowser } from "../typesense-browser-watchlist";
+
+function makeUuid(index: number): string {
+  return `00000000-0000-0000-0000-${String(index).padStart(12, "0")}`;
+}
+
+describe("getWatchlistPostingsBrowser (#3477)", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it("falls back before sending an oversized company-id filter", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      getWatchlistPostingsBrowser({
+        companyIds: Array.from({ length: 99 }, (_, i) => makeUuid(i + 1)),
+        offset: 0,
+        limit: 20,
+      }),
+    ).rejects.toThrow("watchlist Typesense query exceeds GET limit");
+
+    expect(mocks.getTypesenseBrowserConfig).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/search/typesense-browser-watchlist.ts
+++ b/apps/web/src/lib/search/typesense-browser-watchlist.ts
@@ -1,6 +1,7 @@
 import { getTypesenseBrowserConfig, type TypesenseBrowserConfig } from "./typesense-browser-key";
 import { buildFilterString, POSTING_BASE_FILTER } from "./typesense-filters";
 import { COMPANY_BATCH_SIZE } from "./constants";
+import { isTypesenseQueryStringSafe } from "./typesense-query-size";
 import type { WatchlistPostingEntry } from "@/lib/actions/watchlists";
 
 interface JobPostingDoc {
@@ -81,12 +82,12 @@ export interface WatchlistPostingsParams {
 }
 
 /**
- * Browser-side watchlist postings fetch. Mirrors the server-side
- * `_getWatchlistPostingsTypesense` for ≤COMPANY_BATCH_SIZE companies.
+ * Browser-side watchlist postings fetch. Mirrors the server-side single-query
+ * path when the request fits Typesense's GET query-string limit.
  *
- * For watchlists tracking >COMPANY_BATCH_SIZE companies, throws so the
- * runner falls back to the server action (which has a batched/merge
- * implementation we don't need to duplicate browser-side).
+ * For larger requests, throws so the runner falls back to the server action
+ * (which has a batched/merge implementation we don't need to duplicate
+ * browser-side).
  */
 export async function getWatchlistPostingsBrowser(
   params: WatchlistPostingsParams,
@@ -98,7 +99,6 @@ export async function getWatchlistPostingsBrowser(
     throw new Error("watchlist exceeds COMPANY_BATCH_SIZE — falling back");
   }
 
-  const cfg = await getTypesenseBrowserConfig();
   const filterStr = buildFilterString({
     locationIds: params.locationIds,
     occupationIds: params.occupationIds,
@@ -121,14 +121,20 @@ export async function getWatchlistPostingsBrowser(
   }
   if (filterStr) filterParts.push(filterStr);
 
-  const result = await searchOne<JobPostingDoc>(cfg, "job_posting", {
+  const searchParams = {
     q,
     query_by: "title",
     filter_by: filterParts.join(" && "),
     sort_by: hasKeywords ? "_text_match:desc,first_seen_at:desc" : "first_seen_at:desc",
     per_page: params.limit === 0 ? 0 : params.limit,
     page: params.limit === 0 ? 1 : Math.floor(params.offset / params.limit) + 1,
-  });
+  };
+  if (!isTypesenseQueryStringSafe(searchParams)) {
+    throw new Error("watchlist Typesense query exceeds GET limit — falling back");
+  }
+
+  const cfg = await getTypesenseBrowserConfig();
+  const result = await searchOne<JobPostingDoc>(cfg, "job_posting", searchParams);
 
   const total = result.found ?? 0;
   if (total === 0 || params.limit === 0) return { postings: [], total };

--- a/apps/web/src/lib/search/typesense-query-size.ts
+++ b/apps/web/src/lib/search/typesense-query-size.ts
@@ -1,0 +1,47 @@
+export type TypesenseQueryParamValue = string | number | boolean | null | undefined;
+
+export type TypesenseQueryParams = Record<string, TypesenseQueryParamValue>;
+
+// Typesense rejects GET search query strings above 4000 bytes.
+// Keep headroom for SDK/browser serialization details and future params.
+export const TYPESENSE_SAFE_QUERY_STRING_LENGTH = 3500;
+
+export function typesenseQueryStringLength(params: TypesenseQueryParams): number {
+  const query = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value === undefined || value === null) continue;
+    query.set(key, String(value));
+  }
+  return query.toString().length;
+}
+
+export function isTypesenseQueryStringSafe(params: TypesenseQueryParams): boolean {
+  return typesenseQueryStringLength(params) <= TYPESENSE_SAFE_QUERY_STRING_LENGTH;
+}
+
+export function splitValuesForTypesenseQuery(
+  values: readonly string[],
+  buildParams: (batch: readonly string[]) => TypesenseQueryParams,
+  maxValuesPerBatch: number,
+): string[][] {
+  const batches: string[][] = [];
+  let batch: string[] = [];
+
+  for (const value of values) {
+    if (batch.length >= maxValuesPerBatch) {
+      batches.push(batch);
+      batch = [];
+    }
+
+    const candidate = [...batch, value];
+    if (batch.length > 0 && !isTypesenseQueryStringSafe(buildParams(candidate))) {
+      batches.push(batch);
+      batch = [value];
+    } else {
+      batch = candidate;
+    }
+  }
+
+  if (batch.length > 0) batches.push(batch);
+  return batches;
+}


### PR DESCRIPTION
## Summary

Closes #3477.

Large watchlists were still sending a single `company_id:[...]` filter until `companyIds.length > COMPANY_BATCH_SIZE` (`100`). Production Typesense rejects GET search URLs above 4000 bytes, so a UUID-heavy watchlist can fail around 98-100 companies before the old count-based batch switch ever runs.

This PR changes the watchlist postings path to batch by the actual serialized Typesense query size, not just company count. It also applies the same safe batching to the watchlist year-count/display-count queries so `fetchWatchlistPageData` cannot reject from the parallel count path after active postings are fixed. The direct browser Typesense path now detects an oversized request and falls back to the server action before requesting a scoped browser key or sending the failing GET.

## Production reproduction / proof

Using production Typesense (`typesense.colophon-group.org`) with real `job_posting` company IDs:

- single 98-ID query: HTTP 200
- single 99-ID query: HTTP 400, `Query string exceeds max allowed length of 4000. Use the /multi_search end-point for larger payloads.`
- new batching rule for the same 99 IDs: split into 85 + 14 IDs, both HTTP 200

## Testing

- `npx -y pnpm@10.30.0 --dir apps/web test src/lib/actions/__tests__/watchlist-year-count-fallback.test.ts src/lib/search/__tests__/typesense-browser-watchlist.test.ts`
- `npx -y pnpm@10.30.0 --dir apps/web lint`
- `cd apps/web && ./node_modules/.bin/tsc --noEmit --pretty false`
- `git diff --check`
- pre-commit Lingui translation coverage hook passed
- live production Typesense sanity check described above
