### PR TITLE
Fix company OG build prerender burst

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/opengraph-image-prebake.test.ts
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/opengraph-image-prebake.test.ts
@@ -1,15 +1,17 @@
 /**
- * Tests for the OG prebake's `generateStaticParams` fail-loud condition
- * (issue #2891 / PR #2888 round-3 critic ask).
+ * Tests for the OG prebake's `generateStaticParams` opt-in and fail-loud
+ * conditions (issues #2891 and #3422).
  *
  * The module under test exports `generateStaticParams`, which dynamically
  * imports `@/lib/search/typesense-client` so the dependency can be mocked
  * here without touching the surrounding `ImageResponse` handler.
  *
- * The fail-loud gate: `isProductionBuild && hasTypesenseConfig`. When both
- * are true and Typesense throws, we re-throw to fail the Vercel deploy
- * (silently shipping zero prerender hides a real outage). All three other
- * quadrants soft-fail with a console.warn and an empty array.
+ * The prebake is disabled unless `COMPANY_OG_PRERENDER_TOP_N` is explicitly
+ * positive. Once enabled, the fail-loud gate remains
+ * `isProductionBuild && hasTypesenseConfig`. When both are true and Typesense
+ * throws, we re-throw to fail the Vercel deploy (silently shipping a partial
+ * prebake hides a real outage). All three other quadrants soft-fail with a
+ * console.warn and an empty array.
  */
 import {
   afterEach,
@@ -84,6 +86,7 @@ describe("opengraph-image generateStaticParams", () => {
     async () => {
       process.env.VERCEL_ENV = "production";
       process.env.TYPESENSE_HOST = "typesense.example.com";
+      process.env.COMPANY_OG_PRERENDER_TOP_N = "200";
       const err = new Error("connection refused");
       searchMock.mockRejectedValue(err);
 
@@ -99,6 +102,7 @@ describe("opengraph-image generateStaticParams", () => {
     async () => {
       process.env.VERCEL_ENV = "production";
       process.env.TYPESENSE_HOST = "typesense.example.com";
+      process.env.COMPANY_OG_PRERENDER_TOP_N = "200";
       searchMock.mockResolvedValue({ hits: [] });
 
       const result = await generateStaticParams();
@@ -115,6 +119,7 @@ describe("opengraph-image generateStaticParams", () => {
     "preview env + Typesense throws -> warns and returns []",
     async () => {
       process.env.VERCEL_ENV = "preview";
+      process.env.COMPANY_OG_PRERENDER_TOP_N = "200";
       // TYPESENSE_HOST may or may not be set on previews; clear it
       // to exercise the "not configured" branch alongside non-prod
       // env. Either way this quadrant must NOT throw.
@@ -136,12 +141,28 @@ describe("opengraph-image generateStaticParams", () => {
     async () => {
       delete process.env.VERCEL_ENV;
       delete process.env.TYPESENSE_HOST;
+      process.env.COMPANY_OG_PRERENDER_TOP_N = "200";
       searchMock.mockRejectedValue(new Error("invalid request"));
 
       const result = await generateStaticParams();
 
       expect(result).toEqual([]);
       expect(warnSpy).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it(
+    "unset COMPANY_OG_PRERENDER_TOP_N skips Typesense prebake by default",
+    async () => {
+      process.env.VERCEL_ENV = "production";
+      process.env.TYPESENSE_HOST = "typesense.example.com";
+      delete process.env.COMPANY_OG_PRERENDER_TOP_N;
+
+      const result = await generateStaticParams();
+
+      expect(result).toEqual([]);
+      expect(searchMock).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
     },
   );
 
@@ -165,6 +186,7 @@ describe("opengraph-image generateStaticParams", () => {
     async () => {
       process.env.VERCEL_ENV = "production";
       process.env.TYPESENSE_HOST = "typesense.example.com";
+      process.env.COMPANY_OG_PRERENDER_TOP_N = "2";
       searchMock.mockResolvedValue({
         hits: [{ document: { slug: "stripe" } }, { document: { slug: "airbnb" } }],
       });
@@ -178,6 +200,9 @@ describe("opengraph-image generateStaticParams", () => {
         .map((entry) => entry.lang)
         .sort();
       expect(stripeLocales).toEqual(["de", "en", "fr", "it"]);
+      expect(searchMock).toHaveBeenCalledWith(
+        expect.objectContaining({ per_page: 2 }),
+      );
       expect(warnSpy).not.toHaveBeenCalled();
     },
   );

--- a/apps/web/app/[lang]/(app)/company/[slug]/opengraph-image.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/opengraph-image.tsx
@@ -24,22 +24,21 @@ import { join } from "node:path";
 
 /**
  * How many top companies (by active posting count) to prerender at build
- * time, across every supported locale. The actual count of cells baked
- * into the build is `getCompanyOgPrerenderTopN() × locales.length` (4 today). At
- * ~50 KB per PNG that's a ~40 MB increase to the build artifact for N=200.
+ * time, across every supported locale. This is opt-in: the default is 0
+ * because each company slug fans out across every locale and each generated
+ * image may need a company-detail read. At N=200 that is 800 route renders.
  *
  * Long-tail companies still generate on first request and then live in
- * Vercel's CDN for the `revalidate` window. Prebaking the top tier
- * absorbs Twitter/LinkedIn/Slack crawl spikes that otherwise cold-start
- * a function per (slug, locale).
+ * Vercel's CDN for the `revalidate` window. Operators can prebake a bounded
+ * top tier for a specific deploy by setting `COMPANY_OG_PRERENDER_TOP_N`.
  *
- * See issue #2645.
+ * See issues #2645 and #3422.
  */
 function getCompanyOgPrerenderTopN(): number {
   const raw = process.env.COMPANY_OG_PRERENDER_TOP_N;
-  if (!raw) return 200;
+  if (!raw) return 0;
   const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed)) return 200;
+  if (!Number.isFinite(parsed)) return 0;
   return Math.max(0, Math.min(parsed, 500));
 }
 

--- a/apps/web/docs/company-og-cache.md
+++ b/apps/web/docs/company-og-cache.md
@@ -77,12 +77,13 @@ environment variables are set on your Vercel project, but missing from "turbo.js
 ## Force Controls
 
 Use `COMPANY_OG_PRERENDER_TOP_N` to adjust how many high-traffic company
-cards are rendered during `next build`. It defaults to `200`; set it to `0`
-only for build-classification CI lanes that must not depend on external
-company data:
+cards are rendered during `next build`. It defaults to `0` and is therefore
+explicit opt-in. Leave it unset for routine builds that must not fan out live
+Typesense company-detail reads; set it to a bounded positive value only for
+an intentional prebake:
 
 ```bash
-COMPANY_OG_PRERENDER_TOP_N=0 pnpm --filter @jobseek/web build
+COMPANY_OG_PRERENDER_TOP_N=25 pnpm --filter @jobseek/web build
 ```
 
 Use `COMPANY_OG_RENDERER_VERSION_SALT` to force a new namespace at build time:
@@ -114,15 +115,19 @@ pnpm --filter @jobseek/web build
 
 ## Build Behavior
 
-`generateStaticParams` still fetches the top company slugs from Typesense so
-popular cards are prebaked. During the actual OG render step, cache hits come
-from R2 and do not call `getCompanyBySlug`. That keeps routine builds from
-issuing hundreds of company detail reads and prevents Typesense 429s from
-cascading into Postgres fallback load.
+When `COMPANY_OG_PRERENDER_TOP_N` is unset or `0`, `generateStaticParams`
+returns no company-card paths and the build performs no company OG prebake.
+Long-tail cards still render on first request and then cache in R2/CDN.
+
+When `COMPANY_OG_PRERENDER_TOP_N` is a positive integer, `generateStaticParams`
+fetches that many top company slugs from Typesense so popular cards are
+prebaked. During the actual OG render step, cache hits come from R2 and do not
+call `getCompanyBySlug`. Keep the number small enough that slug count times
+locale count does not burst Typesense or the R2 cache.
 
 If Typesense rate-limits the top-slug query, the query retries in place. If it
 still fails in production with Typesense configured, the build fails loud
-instead of silently shipping a zero-prebake deploy.
+instead of silently shipping a partial-prebake deploy.
 
 ## Retention
 


### PR DESCRIPTION
Fixes #3422.

## Summary
- make company OG prebake explicit opt-in by defaulting `COMPANY_OG_PRERENDER_TOP_N` to 0
- keep the fail-loud behavior for an explicitly enabled production prebake
- update the OG cache docs to describe the opt-in behavior and safe bounded usage

## Reproduction
- prod-backed `pnpm --filter @jobseek/web build` before the fix failed while prerendering `/de/company/accenture-federal-services/opengraph-image-y6bp13`
- captured 198 `HTTP code 429` / `httpStatus=429` lines from repeated `companyBySlug[...]` retries

## Verification
- `npx pnpm@10.30.0 --filter @jobseek/web test -- 'app/[lang]/(app)/company/[slug]/__tests__/opengraph-image-prebake.test.ts'`
- `npx pnpm@10.30.0 --filter @jobseek/web lint`
- prod-backed `NEXT_TELEMETRY_DISABLED=1 npx pnpm@10.30.0 --filter @jobseek/web build`
- after build: 0 `HTTP code 429` / `httpStatus=429` lines, 0 Typesense fallback lines, 174 static pages instead of 974

## Note
- The local pre-commit hook currently invokes global pnpm 11 and fails on the existing lockfile/config mismatch before running ESLint. The same web lint was run manually with the repo-pinned pnpm 10.30.0.