### PR TITLE
Fix MCP server bin link warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,8 @@ jobs:
       # turbo run typecheck has dependsOn: ["^build"], so @jseek/mcp-server
       # is built once and all consumers (apps/web) typecheck against the
       # built declarations. Covers every TS workspace in the monorepo.
+      - run: pnpm --filter @jseek/mcp-server test
+
       - run: pnpm typecheck
 
   test-web:

--- a/.github/workflows/publish-mcp-server.yml
+++ b/.github/workflows/publish-mcp-server.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - ".github/workflows/publish-mcp-server.yml"
       - "packages/mcp-server/package.json"
+      - "packages/mcp-server/server.json"
+      - "packages/mcp-server/src/**"
+      - "packages/mcp-server/scripts/**"
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@jseek/mcp-server",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "mcpName": "io.github.colophon-group/jobseek",
   "description": "MCP server for Job Seek — search jobs, companies, and watchlists on jseek.co",
   "license": "MIT",
   "type": "module",
   "bin": {
-    "jobseek-mcp": "dist/index.js"
+    "jobseek-mcp": "src/bin/jobseek-mcp.js"
   },
   "main": "./dist/index.js",
   "exports": {
@@ -15,7 +15,8 @@
     "./handler": "./dist/handler.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "src/bin/jobseek-mcp.js"
   ],
   "scripts": {
     "build": "tsc",
@@ -23,6 +24,7 @@
     "prepare": "tsc",
     "start": "node dist/index.js",
     "start:http": "node dist/http.js",
+    "test": "node scripts/verify-package.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/mcp-server/scripts/verify-package.mjs
+++ b/packages/mcp-server/scripts/verify-package.mjs
@@ -1,0 +1,42 @@
+import { access, readFile } from "node:fs/promises";
+
+const packageJson = JSON.parse(await readFile("package.json", "utf8"));
+const serverJson = JSON.parse(await readFile("server.json", "utf8"));
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const binTarget = packageJson.bin?.["jobseek-mcp"];
+
+assert(typeof binTarget === "string", "package.json must define bin.jobseek-mcp");
+assert(
+  binTarget !== "dist/index.js",
+  "bin.jobseek-mcp must target a checked-in launcher, not generated dist/index.js",
+);
+
+await access(binTarget);
+
+const files = packageJson.files ?? [];
+assert(files.includes("dist"), 'package.json files must include "dist"');
+assert(
+  files.includes(binTarget),
+  `package.json files must include the bin target (${binTarget})`,
+);
+
+const launcher = await readFile(binTarget, "utf8");
+assert(
+  launcher.includes("dist/index.js"),
+  "bin launcher must delegate to the built dist/index.js entrypoint",
+);
+
+assert(
+  serverJson.version === packageJson.version,
+  "server.json version must match package.json version",
+);
+assert(
+  serverJson.packages?.[0]?.version === packageJson.version,
+  "server.json package version must match package.json version",
+);

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/colophon-group/jobseek",
     "source": "github"
   },
-  "version": "0.1.1",
+  "version": "0.1.3",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@jseek/mcp-server",
-      "version": "0.1.1",
+      "version": "0.1.3",
       "transport": {
         "type": "stdio"
       }

--- a/packages/mcp-server/src/bin/jobseek-mcp.js
+++ b/packages/mcp-server/src/bin/jobseek-mcp.js
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+// Checked-in launcher: pnpm links workspace bins before `prepare` builds dist.
+import "../../dist/index.js";


### PR DESCRIPTION
Fixes #3415.

## Summary
- point `jobseek-mcp` at a checked-in launcher so pnpm can link the workspace bin before `prepare` builds `dist/`
- keep the published CLI executing the built `dist/index.js` entrypoint
- add a lightweight MCP package guard in CI to keep the bin target checked in and packaged
- bump `@jseek/mcp-server` / `server.json` to 0.1.3 and broaden the publish workflow paths so this package change publishes

## Reproduction
- clean pinned install before the fix: `npx pnpm@10.30.0 install --frozen-lockfile` emitted `Failed to create bin ... jobseek-mcp ... packages/mcp-server/dist/index.js` before `prepare` built dist

## Verification
- clean checkout-style install after deleting node_modules and `packages/mcp-server/dist`: `npx pnpm@10.30.0 install --frozen-lockfile`
- warning count went from 1 before to 0 after
- package-dir install: `cd packages/mcp-server && npx pnpm@10.30.0 install --frozen-lockfile`
- `npx pnpm@10.30.0 --filter @jseek/mcp-server test`
- `npx pnpm@10.30.0 --filter @jseek/mcp-server typecheck`
- `npx pnpm@10.30.0 typecheck`
- `npx pnpm@10.30.0 --filter @jseek/mcp-server pack --pack-destination /tmp/jobseek-3415-pack-final`
- tarball includes executable `package/src/bin/jobseek-mcp.js` and built `package/dist/index.js`
- prod-backed `NEXT_TELEMETRY_DISABLED=1 npx pnpm@10.30.0 --filter @jobseek/web build` completed with 0 Typesense 429/fallback lines

## Notes
- Local Docker daemon is unavailable (`Cannot connect to the Docker daemon`), so I could not run Docker builds locally. The launcher lives under `packages/mcp-server/src/`, which the murmur-shim Dockerfile already copies before its filtered install.