### PR TITLE
Avoid unnecessary MCP package publish

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jseek/mcp-server",
-  "version": "0.1.3",
+  "version": "0.1.2",
   "mcpName": "io.github.colophon-group/jobseek",
   "description": "MCP server for Job Seek — search jobs, companies, and watchlists on jseek.co",
   "license": "MIT",

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/colophon-group/jobseek",
     "source": "github"
   },
-  "version": "0.1.3",
+  "version": "0.1.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@jseek/mcp-server",
-      "version": "0.1.3",
+      "version": "0.1.2",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
Follow-up to #3481 / #3415.

## Summary
- keep the workspace-bin fix from #3481, but restore `@jseek/mcp-server` to the already-published npm version `0.1.2`
- align `server.json` with `0.1.2` instead of the unnecessary `0.1.3` bump
- this lets the `Publish MCP server` workflow run its version gate and skip npm publish (`changed=false`)

## Why
The #3415 fix only affects workspace installs: pnpm links workspace bins before `prepare` builds `dist`. Published npm packages already contain `dist/index.js`, so npm consumers do not need a new release for this fix. The attempted 0.1.3 publish exposed a separate npm token/scope issue in the publish workflow.

## Verification
- `npx pnpm@10.30.0 install --frozen-lockfile` -> 0 `Failed to create bin ... jobseek-mcp` warnings
- `npx pnpm@10.30.0 --filter @jseek/mcp-server test`
- simulated publish version gate: local `0.1.2`, remote `0.1.2`, `changed=false`