### PR TITLE
Fix pnpm config for pnpm 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - run: node scripts/verify-pnpm-config.mjs
+
       - run: pnpm lint
 
   i18n-coverage:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: web-lint
         name: ESLint (web)
         language: system
-        entry: pnpm --dir apps/web lint
+        entry: node scripts/pnpm-pinned.mjs --dir apps/web lint
         files: ^apps/web/.*\.(js|jsx|ts|tsx)$
         pass_filenames: false
         stages: [pre-commit]

--- a/package.json
+++ b/package.json
@@ -12,39 +12,5 @@
   "devDependencies": {
     "turbo": "^2.9.18"
   },
-  "packageManager": "pnpm@10.30.0",
-  "pnpm": {
-    "overrides": {
-      "@hono/node-server": ">=1.19.13",
-      "@babel/core": ">=7.29.6",
-      "axios": ">=1.15.2",
-      "basic-ftp": ">=5.3.1",
-      "defu": ">=6.1.5",
-      "brace-expansion": "5.0.6",
-      "esbuild": "0.28.1",
-      "fast-uri": ">=3.1.2",
-      "fast-xml-builder": ">=1.1.7",
-      "fast-xml-parser": ">=5.7.0",
-      "flatted": ">=3.4.2",
-      "follow-redirects": ">=1.16.0",
-      "form-data": ">=4.0.6",
-      "hono": "4.12.25",
-      "ip-address": ">=10.1.1",
-      "js-yaml": ">=4.2.0",
-      "kysely": "0.29.2",
-      "lodash": "4.18.1",
-      "minimatch": ">=10.2.3",
-      "path-to-regexp": ">=8.4.0",
-      "postcss": ">=8.5.10",
-      "qs": "6.15.2",
-      "undici": "7.28.0",
-      "uuid": "11.1.1",
-      "ws@>=7.0.0 <7.5.11": "7.5.11",
-      "ws@>=8.0.0 <8.21.0": "8.21.0"
-    },
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "sharp"
-    ]
-  }
+  "packageManager": "pnpm@10.30.0"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,39 @@ packages:
   - "apps/*"
   - "apps/crawler/murmur"
   - "packages/*"
+
+overrides:
+  "@hono/node-server": ">=1.19.13"
+  "@babel/core": ">=7.29.6"
+  axios: ">=1.15.2"
+  basic-ftp: ">=5.3.1"
+  defu: ">=6.1.5"
+  brace-expansion: 5.0.6
+  esbuild: 0.28.1
+  fast-uri: ">=3.1.2"
+  fast-xml-builder: ">=1.1.7"
+  fast-xml-parser: ">=5.7.0"
+  flatted: ">=3.4.2"
+  follow-redirects: ">=1.16.0"
+  form-data: ">=4.0.6"
+  hono: 4.12.25
+  ip-address: ">=10.1.1"
+  js-yaml: ">=4.2.0"
+  kysely: 0.29.2
+  lodash: 4.18.1
+  minimatch: ">=10.2.3"
+  path-to-regexp: ">=8.4.0"
+  postcss: ">=8.5.10"
+  qs: 6.15.2
+  undici: 7.28.0
+  uuid: 11.1.1
+  "ws@>=7.0.0 <7.5.11": 7.5.11
+  "ws@>=8.0.0 <8.21.0": 8.21.0
+
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
+
+allowBuilds:
+  esbuild: true
+  sharp: true

--- a/scripts/pnpm-pinned.mjs
+++ b/scripts/pnpm-pinned.mjs
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(scriptDir, "..");
+const rootPackage = JSON.parse(readFileSync(resolve(rootDir, "package.json"), "utf8"));
+const packageManager = rootPackage.packageManager;
+
+const match = /^pnpm@(.+)$/.exec(packageManager ?? "");
+if (!match) {
+  console.error("package.json must declare packageManager as pnpm@<version>");
+  process.exit(1);
+}
+
+const result = spawnSync("npx", ["-y", `pnpm@${match[1]}`, ...process.argv.slice(2)], {
+  cwd: rootDir,
+  stdio: "inherit",
+});
+
+if (result.error) {
+  console.error(result.error.message);
+  process.exit(1);
+}
+
+process.exit(result.status ?? 1);

--- a/scripts/verify-pnpm-config.mjs
+++ b/scripts/verify-pnpm-config.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+
+const packageJson = JSON.parse(readFileSync("package.json", "utf8"));
+const workspaceYaml = readFileSync("pnpm-workspace.yaml", "utf8");
+const preCommitConfig = readFileSync(".pre-commit-config.yaml", "utf8");
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+assert(packageJson.packageManager === "pnpm@10.30.0", "packageManager must pin pnpm@10.30.0");
+assert(!("pnpm" in packageJson), "pnpm settings must live in pnpm-workspace.yaml, not package.json");
+assert(workspaceYaml.includes("\noverrides:\n"), "pnpm-workspace.yaml must define overrides");
+assert(
+  workspaceYaml.includes("\nonlyBuiltDependencies:\n"),
+  "pnpm-workspace.yaml must define onlyBuiltDependencies",
+);
+assert(
+  workspaceYaml.includes("brace-expansion: 5.0.6"),
+  "pnpm-workspace.yaml must carry security override entries",
+);
+assert(
+  workspaceYaml.includes("  - esbuild") && workspaceYaml.includes("  - sharp"),
+  "pnpm-workspace.yaml must allow required native build dependencies",
+);
+assert(
+  workspaceYaml.includes("\nallowBuilds:\n") &&
+    workspaceYaml.includes("  esbuild: true") &&
+    workspaceYaml.includes("  sharp: true"),
+  "pnpm-workspace.yaml must explicitly approve pnpm 11 native builds",
+);
+assert(
+  preCommitConfig.includes("node scripts/pnpm-pinned.mjs --dir apps/web lint"),
+  "web-lint pre-commit hook must use the pinned pnpm wrapper",
+);


### PR DESCRIPTION
Fixes #3480.

## Summary
- move pnpm overrides and build-script allowlists from `package.json#pnpm` to `pnpm-workspace.yaml`, where pnpm 11 reads them
- explicitly approve pnpm 11 native builds for `esbuild` and `sharp`
- route the web pre-commit lint hook through a small wrapper that reads the repo `packageManager` pin and invokes that pnpm version
- add `scripts/verify-pnpm-config.mjs` and run it in CI so the config location/hook path cannot drift back

## Reproduction
Before the fix, plain global pnpm 11 failed in a clean worktree:

```text
[WARN] The "pnpm" field in package.json is no longer read by pnpm...
[ERR_PNPM_LOCKFILE_CONFIG_MISMATCH] Cannot proceed with the frozen installation.
```

## Verification
- `node scripts/verify-pnpm-config.mjs`
- `pnpm install --frozen-lockfile` with PATH pnpm 11.7.0: exit 0, no config mismatch, no ignored build scripts
- `npx pnpm@10.30.0 install --frozen-lockfile`: exit 0
- `node scripts/pnpm-pinned.mjs --version`: `10.30.0`
- `pre-commit run web-lint --all-files`
- `npx pnpm@10.30.0 lint`
- `npx pnpm@10.30.0 typecheck`
- prod-backed `NEXT_TELEMETRY_DISABLED=1 npx pnpm@10.30.0 --filter @jobseek/web build`: 0 Typesense 429/fallback lines, 174 static pages

## Counts
- before `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`: 1
- after pnpm 11 config mismatch: 0
- after pnpm 11 ignored builds: 0
- pre-commit failures: 0