### PR TITLE
Fix remaining CodeQL workflow alerts

### DIFF
--- a/.github/workflows/crawler-scheduled-maintenance.yml
+++ b/.github/workflows/crawler-scheduled-maintenance.yml
@@ -41,6 +41,8 @@ concurrency:
   group: crawler-scheduled-maintenance
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   run:
     runs-on: ubuntu-latest

--- a/.github/workflows/label-rejected-requests.yml
+++ b/.github/workflows/label-rejected-requests.yml
@@ -14,12 +14,12 @@ jobs:
       - name: Extract reason and apply label
         env:
           GH_TOKEN: ${{ github.token }}
+          COMMENT_ID: ${{ github.event.comment.id }}
           ISSUE: ${{ github.event.issue.number }}
           REPO: ${{ github.repository }}
         run: |
-          # Fetch comment body via API to avoid shell injection from
-          # ${{ github.event.comment.body }} interpolation.
-          BODY=$(gh api "repos/$REPO/issues/comments/${{ github.event.comment.id }}" --jq '.body')
+          # Fetch comment body via API so user-provided text never enters this shell script through workflow expressions.
+          BODY=$(gh api "repos/$REPO/issues/comments/$COMMENT_ID" --jq '.body')
           REASON=$(echo "$BODY" | grep -oP '<!-- validation-failed: \K[a-z-]+')
           if [ -n "$REASON" ]; then
             gh issue edit "$ISSUE" -R "$REPO" --add-label "$REASON"


### PR DESCRIPTION
## Summary
- add explicit no-token permissions to the scheduled crawler maintenance workflow
- avoid workflow-expression interpolation inside the rejected-request shell script

## Validation
- ruby YAML parse for touched workflows
- actionlint for touched workflows