### PR TITLE
Force dynamic company OG images

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/opengraph-image-prebake.test.ts
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/opengraph-image-prebake.test.ts
@@ -1,209 +1,31 @@
-/**
- * Tests for the OG prebake's `generateStaticParams` opt-in and fail-loud
- * conditions (issues #2891 and #3422).
- *
- * The module under test exports `generateStaticParams`, which dynamically
- * imports `@/lib/search/typesense-client` so the dependency can be mocked
- * here without touching the surrounding `ImageResponse` handler.
- *
- * The prebake is disabled unless `COMPANY_OG_PRERENDER_TOP_N` is explicitly
- * positive. Once enabled, the fail-loud gate remains
- * `isProductionBuild && hasTypesenseConfig`. When both are true and Typesense
- * throws, we re-throw to fail the Vercel deploy (silently shipping a partial
- * prebake hides a real outage). All three other quadrants soft-fail with a
- * console.warn and an empty array.
- */
-import {
-  afterEach,
-  beforeEach,
-  describe,
-  expect,
-  it,
-  vi,
-  type MockInstance,
-} from "vitest";
-
-const { searchMock } = vi.hoisted(() => ({
-  searchMock: vi.fn(),
-}));
+import { describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
-vi.mock("@/lib/search/typesense-client", () => ({
-  getSearchClient: () => ({
-    collections: () => ({
-      documents: () => ({
-        search: searchMock,
-      }),
-    }),
-  }),
+vi.mock("next/og", () => ({
+  ImageResponse: class extends Response {
+    constructor(_element: unknown, init: ResponseInit = {}) {
+      super(new Uint8Array([9, 8, 7]), init);
+    }
+  },
 }));
 
-// `getCompanyBySlug` is only called by the default OG handler, which we
-// don't exercise here — mock it to a no-op so importing the module
-// doesn't pull in db / Typesense / cache transitive deps unnecessarily.
 vi.mock("@/lib/actions/company", () => ({
   getCompanyBySlug: vi.fn(),
 }));
 
-import { generateStaticParams } from "../opengraph-image";
+vi.mock("@/lib/og/company-og-cache", () => ({
+  companyOgCacheKey: vi.fn(() => "og/company/test/en/acme.png"),
+  readCompanyOgCache: vi.fn(),
+  shouldBypassCompanyOgCache: vi.fn(() => false),
+  writeCompanyOgCache: vi.fn(),
+}));
 
-describe("opengraph-image generateStaticParams", () => {
-  let warnSpy: MockInstance<typeof console.warn>;
-  const ORIGINAL_VERCEL_ENV = process.env.VERCEL_ENV;
-  const ORIGINAL_TYPESENSE_HOST = process.env.TYPESENSE_HOST;
-  const ORIGINAL_OG_PRERENDER_TOP_N = process.env.COMPANY_OG_PRERENDER_TOP_N;
+import * as ogImage from "../opengraph-image";
 
-  beforeEach(() => {
-    searchMock.mockReset();
-    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+describe("company opengraph image route rendering mode", () => {
+  it("is dynamic because request-time R2 cache IO is intentional", () => {
+    expect(ogImage.dynamic).toBe("force-dynamic");
+    expect("generateStaticParams" in ogImage).toBe(false);
   });
-
-  afterEach(() => {
-    warnSpy.mockRestore();
-    // Restore env to whatever the test runner set it to. Using delete
-    // when the original was undefined avoids leaking the literal string
-    // "undefined" into subsequent tests.
-    if (ORIGINAL_VERCEL_ENV === undefined) {
-      delete process.env.VERCEL_ENV;
-    } else {
-      process.env.VERCEL_ENV = ORIGINAL_VERCEL_ENV;
-    }
-    if (ORIGINAL_TYPESENSE_HOST === undefined) {
-      delete process.env.TYPESENSE_HOST;
-    } else {
-      process.env.TYPESENSE_HOST = ORIGINAL_TYPESENSE_HOST;
-    }
-    if (ORIGINAL_OG_PRERENDER_TOP_N === undefined) {
-      delete process.env.COMPANY_OG_PRERENDER_TOP_N;
-    } else {
-      process.env.COMPANY_OG_PRERENDER_TOP_N = ORIGINAL_OG_PRERENDER_TOP_N;
-    }
-  });
-
-  it(
-    "production + Typesense configured + Typesense throws -> re-throws (fail loud)",
-    async () => {
-      process.env.VERCEL_ENV = "production";
-      process.env.TYPESENSE_HOST = "typesense.example.com";
-      process.env.COMPANY_OG_PRERENDER_TOP_N = "200";
-      const err = new Error("connection refused");
-      searchMock.mockRejectedValue(err);
-
-      await expect(generateStaticParams()).rejects.toThrow("connection refused");
-      // Fail-loud path doesn't warn — it throws, surfacing in the
-      // Vercel build log directly.
-      expect(warnSpy).not.toHaveBeenCalled();
-    },
-  );
-
-  it(
-    "production + Typesense configured + zero hits -> warns and returns []",
-    async () => {
-      process.env.VERCEL_ENV = "production";
-      process.env.TYPESENSE_HOST = "typesense.example.com";
-      process.env.COMPANY_OG_PRERENDER_TOP_N = "200";
-      searchMock.mockResolvedValue({ hits: [] });
-
-      const result = await generateStaticParams();
-
-      expect(result).toEqual([]);
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-      const message = warnSpy.mock.calls[0]?.[0] as string;
-      expect(message).toContain("0 companies returned from");
-      expect(message).toContain("Typesense");
-    },
-  );
-
-  it(
-    "preview env + Typesense throws -> warns and returns []",
-    async () => {
-      process.env.VERCEL_ENV = "preview";
-      process.env.COMPANY_OG_PRERENDER_TOP_N = "200";
-      // TYPESENSE_HOST may or may not be set on previews; clear it
-      // to exercise the "not configured" branch alongside non-prod
-      // env. Either way this quadrant must NOT throw.
-      delete process.env.TYPESENSE_HOST;
-      searchMock.mockRejectedValue(new Error("dns failure"));
-
-      const result = await generateStaticParams();
-
-      expect(result).toEqual([]);
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-      expect(warnSpy.mock.calls[0]?.[0]).toContain(
-        "skipping prerender",
-      );
-    },
-  );
-
-  it(
-    "local build (no VERCEL_ENV, no TYPESENSE_HOST) + Typesense throws -> warns and returns []",
-    async () => {
-      delete process.env.VERCEL_ENV;
-      delete process.env.TYPESENSE_HOST;
-      process.env.COMPANY_OG_PRERENDER_TOP_N = "200";
-      searchMock.mockRejectedValue(new Error("invalid request"));
-
-      const result = await generateStaticParams();
-
-      expect(result).toEqual([]);
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-    },
-  );
-
-  it(
-    "unset COMPANY_OG_PRERENDER_TOP_N skips Typesense prebake by default",
-    async () => {
-      process.env.VERCEL_ENV = "production";
-      process.env.TYPESENSE_HOST = "typesense.example.com";
-      delete process.env.COMPANY_OG_PRERENDER_TOP_N;
-
-      const result = await generateStaticParams();
-
-      expect(result).toEqual([]);
-      expect(searchMock).not.toHaveBeenCalled();
-      expect(warnSpy).not.toHaveBeenCalled();
-    },
-  );
-
-  it(
-    "COMPANY_OG_PRERENDER_TOP_N=0 skips Typesense prebake",
-    async () => {
-      process.env.VERCEL_ENV = "production";
-      process.env.TYPESENSE_HOST = "typesense.example.com";
-      process.env.COMPANY_OG_PRERENDER_TOP_N = "0";
-
-      const result = await generateStaticParams();
-
-      expect(result).toEqual([]);
-      expect(searchMock).not.toHaveBeenCalled();
-      expect(warnSpy).not.toHaveBeenCalled();
-    },
-  );
-
-  it(
-    "happy path: returns slug × locale matrix (en/de/fr/it)",
-    async () => {
-      process.env.VERCEL_ENV = "production";
-      process.env.TYPESENSE_HOST = "typesense.example.com";
-      process.env.COMPANY_OG_PRERENDER_TOP_N = "2";
-      searchMock.mockResolvedValue({
-        hits: [{ document: { slug: "stripe" } }, { document: { slug: "airbnb" } }],
-      });
-
-      const result = await generateStaticParams();
-
-      // 2 slugs × 4 locales = 8 entries.
-      expect(result).toHaveLength(8);
-      const stripeLocales = result
-        .filter((entry) => entry.slug === "stripe")
-        .map((entry) => entry.lang)
-        .sort();
-      expect(stripeLocales).toEqual(["de", "en", "fr", "it"]);
-      expect(searchMock).toHaveBeenCalledWith(
-        expect.objectContaining({ per_page: 2 }),
-      );
-      expect(warnSpy).not.toHaveBeenCalled();
-    },
-  );
 });

--- a/apps/web/app/[lang]/(app)/company/[slug]/opengraph-image.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/opengraph-image.tsx
@@ -1,7 +1,6 @@
 import { ImageResponse } from "next/og";
 import { unstable_cache } from "next/cache";
 import { getCompanyBySlug, type CompanyDetail } from "@/lib/actions/company";
-import { locales } from "@/lib/i18n";
 import {
   companyOgCacheKey,
   readCompanyOgCache,
@@ -12,6 +11,7 @@ import {
 export const alt = "Company jobs";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
+export const dynamic = "force-dynamic";
 // Long-cache via explicit headers. The durable cache key includes a
 // renderer hash, so unchanged deploys reuse R2 PNGs and renderer changes
 // naturally move to a new key.
@@ -24,107 +24,6 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const COMPANY_OG_CACHE_TTL_SECONDS = 2592000;
-
-/**
- * How many top companies (by active posting count) to prerender at build
- * time, across every supported locale. This is opt-in: the default is 0
- * because each company slug fans out across every locale and each generated
- * image may need a company-detail read. At N=200 that is 800 route renders.
- *
- * Long-tail companies still generate on first request and then live in
- * Vercel's CDN for the `revalidate` window. Operators can prebake a bounded
- * top tier for a specific deploy by setting `COMPANY_OG_PRERENDER_TOP_N`.
- *
- * See issues #2645 and #3422.
- */
-function getCompanyOgPrerenderTopN(): number {
-  const raw = process.env.COMPANY_OG_PRERENDER_TOP_N;
-  if (!raw) return 0;
-  const parsed = Number.parseInt(raw, 10);
-  if (!Number.isFinite(parsed)) return 0;
-  return Math.max(0, Math.min(parsed, 500));
-}
-
-/**
- * Pick the top-N companies to prerender. Fails the build only when
- * Typesense is configured AND unreachable on a production build —
- * that's the failure mode where a silent zero-prerender translates
- * into every Twitter/LinkedIn/Slack crawl cold-starting a function.
- *
- * Soft-fails (returns `[]` + warn) in two other cases:
- *   1. Typesense isn't configured (preview deploys without secrets,
- *      local builds without `.env.local`).
- *   2. Typesense responded successfully but with 0 results — could be
- *      a legitimately empty index (during reindex / fresh deploy) or
- *      an `active_posting_count:>0` filter mismatch. Failing the
- *      production deploy on a transient empty-index state would couple
- *      Vercel deploy availability to a specific Typesense data shape.
- *
- * See #2835 critic rounds 2 and 3.
- */
-export async function generateStaticParams(): Promise<
-  { lang: string; slug: string }[]
-> {
-  const prerenderTopN = getCompanyOgPrerenderTopN();
-  if (prerenderTopN === 0) return [];
-
-  const isProductionBuild = process.env.VERCEL_ENV === "production";
-  const hasTypesenseConfig = !!process.env.TYPESENSE_HOST;
-  try {
-    const [{ getSearchClient }, {
-      isRetryableError,
-      isTypesenseRateLimitError,
-      withTypesenseRetry,
-    }] = await Promise.all([
-      import("@/lib/search/typesense-client"),
-      import("@/lib/search/typesense-retry"),
-    ]);
-    const client = getSearchClient();
-    const result = await withTypesenseRetry(
-      () =>
-        client.collections("company").documents().search({
-          q: "*",
-          query_by: "name",
-          filter_by: "active_posting_count:>0",
-          sort_by: "active_posting_count:desc",
-          per_page: prerenderTopN,
-          page: 1,
-          include_fields: "slug",
-        }),
-      {
-        attempts: 5,
-        baseDelaysMs: [250, 500, 1000, 2000],
-        isRetryable: (err) => isRetryableError(err) || isTypesenseRateLimitError(err),
-        label: "company-og.generateStaticParams",
-      },
-    );
-    const slugs = (result.hits ?? [])
-      .map((h) => (h.document as Record<string, unknown>).slug)
-      .filter((s): s is string => typeof s === "string");
-    if (slugs.length === 0) {
-      console.warn(
-        "[opengraph-image] generateStaticParams: 0 companies returned from " +
-          "Typesense — index empty or filter mismatch. Long-tail OG generation " +
-          "will fall back to per-request rendering.",
-      );
-    }
-    return slugs.flatMap((slug) => locales.map((lang) => ({ lang, slug })));
-  } catch (err) {
-    if (isProductionBuild && hasTypesenseConfig) {
-      // Typesense was configured but the call threw (network error,
-      // misconfigured secret, etc.) on a production build. Fail loud —
-      // silently shipping zero prerender hides a real outage.
-      throw err;
-    }
-    // Typesense not configured (preview without secrets) OR local build —
-    // log loudly but don't fail; dynamic OG rendering still works.
-    console.warn(
-      "[opengraph-image] generateStaticParams: skipping prerender",
-      err,
-    );
-    return [];
-  }
-}
 
 const getCachedOgCompany = unstable_cache(
   async (slug: string, lang: string) => getCompanyBySlug(slug, lang),


### PR DESCRIPTION
## Summary

- Force the company OpenGraph image route to render dynamically.
- Remove the `generateStaticParams` prebake path for this route because request-time R2 cache IO is intentional and was still triggering `DYNAMIC_SERVER_USAGE` on Vercel under Cache Components.
- Keep the R2 PNG cache and long cache headers as the OG route caching layer.

## Verification

- `npx --yes pnpm@10.30.0 --dir apps/web lint`
- `npx --yes pnpm@10.30.0 --dir apps/web exec vitest run src/lib/__tests__/sanitize.test.ts src/lib/og/__tests__/company-og-cache.test.ts app/'[lang]'/'(app)'/company/'[slug]'/__tests__/opengraph-image-cache.test.ts app/'[lang]'/'(app)'/company/'[slug]'/__tests__/opengraph-image-prebake.test.ts`
- `npx --yes pnpm@10.30.0 turbo run build --filter=@jobseek/web`
  - Build route table now shows `ƒ /[lang]/company/[slug]/opengraph-image-y6bp13` instead of `●` SSG.
- Local standalone production server with pulled Vercel production env returned:
  - `/en/company/accenture/opengraph-image-y6bp13` -> `200 image/png`
  - `/fr/company/d-matrix/opengraph-image-y6bp13` -> `200 image/png`
  - `/en/company/topkey` -> `200 text/html`

## Production context

Post-merge monitoring of #3490 showed the jsdom page-side error stopped on the new deployment, but company OG image requests still returned 500 with `DYNAMIC_SERVER_USAGE`. This PR addresses that remaining production failure.
