### PR TITLE
Fix Typesense docs drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Jobseek monitors company career pages for new job postings. Companies are config
 │               ├── upload.py        # HuggingFace dataset push
 │               ├── prompts/tasks/*.md.j2  # per-task Jinja templates
 │               └── schemas/         # per-task + posting JSON Schemas
-├── scripts/
+├── scripts/                 # Monorepo-wide operator/dev scripts; app-local scripts live under apps/*/scripts/
 │   ├── typesense-setup.py       # Create/recreate Typesense collections + aliases
 │   └── typesense-backfill-local.py  # One-shot backfill from Postgres to Typesense
 ├── docs/                    # Architecture documentation
@@ -154,13 +154,14 @@ See [docs/11-typesense.md](docs/11-typesense.md) for full deployment details, in
 
 ### API Keys
 
-Three scoped keys (stored in `apps/crawler/.env.local`, GitHub secrets, and Vercel env vars):
+Four scoped keys (stored in `apps/crawler/.env.local`, GitHub secrets, and Vercel env vars):
 
 | Key | Scope | Used by |
 |-----|-------|---------|
-| `TYPESENSE_ADMIN_KEY` | Full access | Exporter, sync, backfill (crawler machine) |
-| `TYPESENSE_SEARCH_KEY` | `documents:search` on all collections | Web app (via Cloudflare tunnel) |
-| `TYPESENSE_WRITE_KEY` | `documents:upsert/delete/update` on `watchlist` only | Web app watchlist mutations |
+| `TYPESENSE_ADMIN_KEY` | Full access | Exporter, sync, backfill, setup scripts (crawler machine) |
+| `TYPESENSE_SEARCH_KEY` | `documents:search` + `documents:get` on all collections | Web app server-side search (via Cloudflare tunnel) |
+| `TYPESENSE_BROWSER_PARENT_KEY` | `documents:search` on all collections only | Web app `/api/typesense-key` route; mints scoped keys for direct browser -> Typesense calls |
+| `TYPESENSE_WRITE_KEY` | `documents:create/upsert/delete/update` on `watchlist` only | Web app watchlist mutations |
 
 ### Collections
 

--- a/docs/02-data-schema.md
+++ b/docs/02-data-schema.md
@@ -51,7 +51,7 @@ meta,meta-careers,https://www.metacareers.com/jobs,sitemap,"{""sitemap_url"":""h
 | `board_url` | Yes | The career page URL to monitor. |
 | `monitor_type` | Yes | How to discover listings. Use any registered monitor type from `ws help monitors` (for example `greenhouse`, `workday`, `dom`, `api_sniffer`, `sitemap`). |
 | `monitor_config` | No | JSON object with monitor-specific settings. |
-| `scraper_type` | No | How to extract job details. One of: `json-ld`, `dom`, `nextdata`, `embedded`, `api_sniffer`. Empty when API monitor provides full data. |
+| `scraper_type` | No | How to extract job details. One of: `json-ld`, `dom`, `nextdata`, `embedded`, `api_sniffer`, `skip`. Empty when an API/rich monitor provides full data; use `skip` only as an explicit no-scrape marker for rich monitor output. |
 | `scraper_config` | No | JSON object with scraper-specific settings. |
 
 ### Rules
@@ -60,7 +60,7 @@ meta,meta-careers,https://www.metacareers.com/jobs,sitemap,"{""sitemap_url"":""h
 - `board_slug` must be unique across all rows and match slug format
 - `board_url` must be unique across all rows
 - `monitor_config` and `scraper_config` are JSON strings (use `""` for quotes inside CSV)
-- **Rich monitors** (ashby, amazon, dvinci, gem, greenhouse, hireology, lever, pinpoint, recruitee, rss, traffit; also `api_sniffer`/`nextdata` with `fields`) return full job data — `scraper_type` is empty
+- **Rich monitors** (ashby, amazon, dvinci, gem, greenhouse, hireology, lever, pinpoint, recruitee, rss, traffit; also `api_sniffer`/`nextdata` with `fields`) return full job data — `scraper_type` is empty or `skip`
 - **URL-only monitors with auto-scraper** (bite, breezy, join, rippling, smartrecruiters, softgarden, workable, workday) return URLs only — `scraper_type` is auto-configured and can be left empty in the CSV
 - **URL-only monitors without auto-scraper** (`sitemap`, `dom`, `nextdata`, `api_sniffer` without `fields`) return URLs only — `scraper_type` must be set explicitly
 
@@ -68,8 +68,8 @@ meta,meta-careers,https://www.metacareers.com/jobs,sitemap,"{""sitemap_url"":""h
 
 | Monitor Type | Returns | Scraper Needed? | Typical Scraper |
 |-------------|---------|-----------------|-----------------|
-| Rich monitors (greenhouse, lever, ashby, etc.) | Full job data | No | *(empty)* |
-| `api_sniffer`/`nextdata` with `fields` | Full job data | No | *(empty)* |
+| Rich monitors (greenhouse, lever, ashby, etc.) | Full job data | No | *(empty or `skip`)* |
+| `api_sniffer`/`nextdata` with `fields` | Full job data | No | *(empty or `skip`)* |
 | URL-only with auto-scraper (workday, rippling, etc.) | URLs only | Auto-configured | *(empty or override)* |
 | `sitemap` | URLs only | Yes (manual) | `json-ld` or `dom` |
 | `nextdata` without `fields` | URLs only | Yes (manual) | `nextdata` or `json-ld` |

--- a/docs/04-monitors-and-scrapers.md
+++ b/docs/04-monitors-and-scrapers.md
@@ -192,8 +192,9 @@ A scraper takes a job page URL and returns structured job data. Only needed when
 | `embedded` | Static | Extracts from embedded JSON/JS data in page source |
 | `dom` | Static or Playwright | Step-based extraction engine |
 | `api_sniffer` | Playwright | Captures XHR/fetch API responses |
+| `skip` | No fetch | Explicit no-scrape marker for rich monitors that already returned complete job data |
 
-> **Note:** API monitors (ashby, greenhouse, lever, etc.) return full job data directly — no scraper is needed. The `scraper_type` column is left empty for these.
+> **Note:** API monitors (ashby, greenhouse, lever, etc.) return full job data directly — no scraper is needed. The `scraper_type` column is left empty for these, or set to `skip` when an explicit no-scrape marker is useful.
 
 ### json-ld
 

--- a/docs/11-typesense.md
+++ b/docs/11-typesense.md
@@ -256,5 +256,6 @@ All IPs, API keys, and connection strings are in `apps/crawler/.env.local` on th
 | `TYPESENSE_PORT` | 8108 |
 | `TYPESENSE_PROTOCOL` | `http` (private network, no TLS) |
 | `TYPESENSE_ADMIN_KEY` | Admin API key |
-| `TYPESENSE_SEARCH_KEY` | Search-only key (web app, via tunnel uses `https`) |
+| `TYPESENSE_SEARCH_KEY` | Search/read key for web server-side Typesense calls (via tunnel uses `https`) |
+| `TYPESENSE_BROWSER_PARENT_KEY` | Search-only parent key for `/api/typesense-key` scoped browser keys |
 | `TYPESENSE_WRITE_KEY` | Watchlist write key (web app) |

--- a/docs/13-seo-and-indexnow.md
+++ b/docs/13-seo-and-indexnow.md
@@ -215,14 +215,18 @@ psql -c "SELECT url, last_submitted_at FROM indexnow_submission ORDER BY last_su
 ## Metrics
 
 The active web and blog IndexNow paths do not expose Prometheus metrics today;
-they rely on application logs and GitHub Actions logs.
+the broader web-app metrics gap is tracked in #3182. Watchlist-side submissions
+emit structured Vercel log lines through `logIndexNowResult()` with the stable
+`indexnow.result` event name (#3202), and blog submissions rely on GitHub
+Actions logs.
 
 The legacy `notify-indexnow` crawler subcommand starts a Prometheus metrics
 server on `METRICS_PORT=9099` only for the duration of a manual run. There is
 no production container loop anymore, so durable metrics + a Grafana dashboard
-remain a TODO if company-page submission is ever revived.
+should be added under #3182 if company-page submission is ever revived.
 
-Until then, observability is structured log events emitted by `indexnow.py`:
+Until then, legacy crawler observability is structured log events emitted by
+`indexnow.py`:
 
 | Event | Level | When |
 |-------|-------|------|


### PR DESCRIPTION
Fixes #3155

## Reproduction
- Compared the duplicated Typesense key tables in `AGENTS.md` and `docs/11-typesense.md`: root docs listed 3 keys while the Typesense doc and implementation use `TYPESENSE_BROWSER_PARENT_KEY` for `/api/typesense-key`.
- Verified implementation in `apps/web/app/api/typesense-key/route.ts` and confirmed Vercel production lists `TYPESENSE_BROWSER_PARENT_KEY` / `NEXT_PUBLIC_TYPESENSE_DIRECT` with `vercel env ls production` from the main development tree. No secret values were read.
- Confirmed `skip` is a real scraper type via `apps/crawler/src/workspace/_compat.py` and `apps/crawler/src/core/scrapers/skip.py`.
- Checked the IndexNow observability TODO against existing tracking: structured log coverage is in closed #3202 and broader web metrics are tracked in open #3182.

## Changes
- Update root `AGENTS.md` to document all four Typesense keys and clarify repo-root scripts vs app-local scripts.
- Add `TYPESENSE_BROWSER_PARENT_KEY` to the `docs/11-typesense.md` credentials reference.
- Add `skip` to scraper-type docs in `docs/02-data-schema.md` and `docs/04-monitors-and-scrapers.md`.
- Replace the naked IndexNow metrics TODO with references to #3182 / #3202.

## Validation
- `rg -n "Three scoped keys|TYPESENSE_BROWSER_PARENT_KEY|TYPESENSE_WRITE_KEY|documents:create/upsert/delete/update|documents:search \+ documents:get|Search/read key" AGENTS.md docs/11-typesense.md`
- `rg -n "One of:.*skip|empty or `skip`|\| `skip` \|" docs/02-data-schema.md docs/04-monitors-and-scrapers.md apps/crawler/data/README.md`
- `rg -n "TODO|#3182|#3202|indexnow.result|logIndexNowResult" docs/13-seo-and-indexnow.md`
- `git diff --check`