### PR TITLE
Fix screenshot storage event dispatch

### DIFF
--- a/apps/web/script/capture-screenshots.ts
+++ b/apps/web/script/capture-screenshots.ts
@@ -97,7 +97,7 @@ async function setTheme(page: Page, theme: "light" | "dark") {
     localStorage.setItem("theme", t);
     document.documentElement.classList.remove("light", "dark");
     document.documentElement.classList.add(t);
-    window.dispatchEvent(new StorageEvent("storage", { key: "theme", newValue: t }));
+    window.dispatchEvent(new Event("storage"));
   }, theme);
   await page.waitForTimeout(300);
 }


### PR DESCRIPTION
## Summary
- replace the screenshot helper's `StorageEvent` constructor call with a plain `storage` event dispatch
- keep the theme localStorage write and DOM class update unchanged

## Code Quality
- Resolves finding #40 (`js/superfluous-trailing-arguments`) in `apps/web/script/capture-screenshots.ts`

## Verification
- `pnpm --filter @jobseek/web exec eslint script/capture-screenshots.ts`
- `pnpm --filter @jobseek/web typecheck`
- `pnpm --filter @jobseek/web exec tsc --noEmit --pretty false`
- pre-commit web ESLint hook passed
