### PR TITLE
Fix API discovery 404 probes

### DIFF
--- a/apps/web/app/__tests__/api-discovery-routes.test.ts
+++ b/apps/web/app/__tests__/api-discovery-routes.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { GET as apiGet, HEAD as apiHead } from "../api/route";
+import { GET as apiDocsGet, HEAD as apiDocsHead } from "../api-docs/route";
+import {
+  GET as apiReferenceGet,
+  HEAD as apiReferenceHead,
+} from "../api-reference/route";
+import { GET as developerGet, HEAD as developerHead } from "../developer/route";
+import { GET as developersGet, HEAD as developersHead } from "../developers/route";
+import { GET as llmsGet, HEAD as llmsHead } from "../llms.txt/route";
+import { GET as mcpJsonGet, HEAD as mcpJsonHead } from "../mcp.json/route";
+import { GET as openApiJsonGet, HEAD as openApiJsonHead } from "../openapi.json/route";
+import { GET as openApiYamlGet, HEAD as openApiYamlHead } from "../openapi.yaml/route";
+
+const notFoundRoutes = [
+  ["/api", apiGet, apiHead],
+  ["/api-docs", apiDocsGet, apiDocsHead],
+  ["/api-reference", apiReferenceGet, apiReferenceHead],
+  ["/developer", developerGet, developerHead],
+  ["/developers", developersGet, developersHead],
+  ["/mcp.json", mcpJsonGet, mcpJsonHead],
+  ["/openapi.yaml", openApiYamlGet, openApiYamlHead],
+] as const;
+
+const redirectRoutes = [
+  ["/llms.txt", "/.well-known/llms.txt", llmsGet, llmsHead],
+  ["/openapi.json", "/api/openapi.json", openApiJsonGet, openApiJsonHead],
+] as const;
+
+describe("API discovery probe routes", () => {
+  it.each(notFoundRoutes)("%s returns a raw 404 for GET and HEAD", async (_, get, head) => {
+    const getResponse = await get();
+    expect(getResponse.status).toBe(404);
+    expect(getResponse.headers.get("content-type")).toBe("text/plain; charset=utf-8");
+    expect(getResponse.headers.get("x-robots-tag")).toBe("noindex");
+
+    const headResponse = await head();
+    expect(headResponse.status).toBe(404);
+    expect(await headResponse.text()).toBe("");
+  });
+
+  it.each(redirectRoutes)("%s redirects to its canonical endpoint", async (_, location, get, head) => {
+    const getResponse = await get();
+    expect(getResponse.status).toBe(308);
+    expect(getResponse.headers.get("location")).toBe(location);
+    expect(getResponse.headers.get("x-robots-tag")).toBe("noindex");
+
+    const headResponse = await head();
+    expect(headResponse.status).toBe(308);
+    expect(headResponse.headers.get("location")).toBe(location);
+  });
+});
+

--- a/apps/web/app/api-docs/route.ts
+++ b/apps/web/app/api-docs/route.ts
@@ -1,0 +1,10 @@
+import { discoveryNotFound, discoveryNotFoundHead } from "@/lib/discovery-responses";
+
+export function GET() {
+  return discoveryNotFound();
+}
+
+export function HEAD() {
+  return discoveryNotFoundHead();
+}
+

--- a/apps/web/app/api-reference/route.ts
+++ b/apps/web/app/api-reference/route.ts
@@ -1,0 +1,10 @@
+import { discoveryNotFound, discoveryNotFoundHead } from "@/lib/discovery-responses";
+
+export function GET() {
+  return discoveryNotFound();
+}
+
+export function HEAD() {
+  return discoveryNotFoundHead();
+}
+

--- a/apps/web/app/api/route.ts
+++ b/apps/web/app/api/route.ts
@@ -1,0 +1,10 @@
+import { discoveryNotFound, discoveryNotFoundHead } from "@/lib/discovery-responses";
+
+export function GET() {
+  return discoveryNotFound();
+}
+
+export function HEAD() {
+  return discoveryNotFoundHead();
+}
+

--- a/apps/web/app/developer/route.ts
+++ b/apps/web/app/developer/route.ts
@@ -1,0 +1,10 @@
+import { discoveryNotFound, discoveryNotFoundHead } from "@/lib/discovery-responses";
+
+export function GET() {
+  return discoveryNotFound();
+}
+
+export function HEAD() {
+  return discoveryNotFoundHead();
+}
+

--- a/apps/web/app/developers/route.ts
+++ b/apps/web/app/developers/route.ts
@@ -1,0 +1,10 @@
+import { discoveryNotFound, discoveryNotFoundHead } from "@/lib/discovery-responses";
+
+export function GET() {
+  return discoveryNotFound();
+}
+
+export function HEAD() {
+  return discoveryNotFoundHead();
+}
+

--- a/apps/web/app/llms.txt/route.ts
+++ b/apps/web/app/llms.txt/route.ts
@@ -1,0 +1,12 @@
+import {
+  discoveryRedirect,
+  discoveryRedirectHead,
+} from "@/lib/discovery-responses";
+
+export function GET() {
+  return discoveryRedirect("/.well-known/llms.txt");
+}
+
+export function HEAD() {
+  return discoveryRedirectHead("/.well-known/llms.txt");
+}

--- a/apps/web/app/mcp.json/route.ts
+++ b/apps/web/app/mcp.json/route.ts
@@ -1,0 +1,10 @@
+import { discoveryNotFound, discoveryNotFoundHead } from "@/lib/discovery-responses";
+
+export function GET() {
+  return discoveryNotFound();
+}
+
+export function HEAD() {
+  return discoveryNotFoundHead();
+}
+

--- a/apps/web/app/openapi.json/route.ts
+++ b/apps/web/app/openapi.json/route.ts
@@ -1,0 +1,12 @@
+import {
+  discoveryRedirect,
+  discoveryRedirectHead,
+} from "@/lib/discovery-responses";
+
+export function GET() {
+  return discoveryRedirect("/api/openapi.json");
+}
+
+export function HEAD() {
+  return discoveryRedirectHead("/api/openapi.json");
+}

--- a/apps/web/app/openapi.yaml/route.ts
+++ b/apps/web/app/openapi.yaml/route.ts
@@ -1,0 +1,10 @@
+import { discoveryNotFound, discoveryNotFoundHead } from "@/lib/discovery-responses";
+
+export function GET() {
+  return discoveryNotFound();
+}
+
+export function HEAD() {
+  return discoveryNotFoundHead();
+}
+

--- a/apps/web/script/smoke-built-app.ts
+++ b/apps/web/script/smoke-built-app.ts
@@ -7,6 +7,19 @@ import { chromium, type Browser } from "playwright";
 const port = Number(process.env.SMOKE_PORT ?? "3100");
 const baseUrl = `http://127.0.0.1:${port}`;
 const routes = ["/en", "/en/explore", "/en/companies/request"];
+const discoveryNotFoundRoutes = [
+  "/api",
+  "/api-docs",
+  "/api-reference",
+  "/developer",
+  "/developers",
+  "/mcp.json",
+  "/openapi.yaml",
+] as const;
+const discoveryRedirectRoutes = [
+  ["/llms.txt", "/.well-known/llms.txt"],
+  ["/openapi.json", "/api/openapi.json"],
+] as const;
 
 function delay(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -69,12 +82,38 @@ async function smoke(browser: Browser, route: string) {
   await page.close();
 }
 
+async function smokeDiscoveryRoute(route: string, expectedStatus: number) {
+  const response = await fetch(`${baseUrl}${route}`, { redirect: "manual" });
+  if (response.status !== expectedStatus) {
+    throw new Error(`${route} returned HTTP ${response.status}, expected ${expectedStatus}`);
+  }
+  console.log(`smoke ok ${route} ${expectedStatus}`);
+}
+
+async function smokeDiscoveryRedirect(route: string, location: string) {
+  const response = await fetch(`${baseUrl}${route}`, { redirect: "manual" });
+  if (response.status !== 308) {
+    throw new Error(`${route} returned HTTP ${response.status}, expected 308`);
+  }
+  const actualLocation = response.headers.get("location");
+  if (actualLocation !== location) {
+    throw new Error(`${route} redirected to ${actualLocation}, expected ${location}`);
+  }
+  console.log(`smoke ok ${route} 308 ${location}`);
+}
+
 async function main() {
   const server = startServer();
   let browser: Browser | undefined;
   try {
     await waitForServer();
     browser = await chromium.launch();
+    for (const route of discoveryNotFoundRoutes) {
+      await smokeDiscoveryRoute(route, 404);
+    }
+    for (const [route, location] of discoveryRedirectRoutes) {
+      await smokeDiscoveryRedirect(route, location);
+    }
     for (const route of routes) {
       await smoke(browser, route);
     }

--- a/apps/web/src/lib/discovery-responses.ts
+++ b/apps/web/src/lib/discovery-responses.ts
@@ -1,0 +1,42 @@
+const DISCOVERY_HEADERS = {
+  "Cache-Control": "public, max-age=0, must-revalidate",
+  "X-Robots-Tag": "noindex",
+} as const;
+
+export function discoveryNotFound(): Response {
+  return new Response("Not found\n", {
+    status: 404,
+    headers: {
+      ...DISCOVERY_HEADERS,
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}
+
+export function discoveryNotFoundHead(): Response {
+  return new Response(null, {
+    status: 404,
+    headers: DISCOVERY_HEADERS,
+  });
+}
+
+export function discoveryRedirect(pathname: string): Response {
+  return new Response("Redirecting\n", {
+    status: 308,
+    headers: {
+      ...DISCOVERY_HEADERS,
+      "Content-Type": "text/plain; charset=utf-8",
+      Location: pathname,
+    },
+  });
+}
+
+export function discoveryRedirectHead(pathname: string): Response {
+  return new Response(null, {
+    status: 308,
+    headers: {
+      ...DISCOVERY_HEADERS,
+      Location: pathname,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add explicit route handlers for API/doc discovery probes that were falling into Next's 404 render path as HTTP 500
- redirect useful aliases `/llms.txt` and `/openapi.json` to their canonical static endpoints
- extend built-app smoke coverage and add route-handler regression tests

Closes #3516

## Reproduction
- production probes for `/api`, `/api-docs`, `/api-reference`, `/developer`, `/developers`, `/mcp.json`, `/openapi.json`, `/openapi.yaml`, and `/llms.txt` returned HTTP 500 with `NEXT_HTTP_ERROR_FALLBACK;404`
- local `next build` + production server reproduced the same statuses before the fix

## Validation
- `pnpm --dir apps/web exec vitest run app/__tests__/api-discovery-routes.test.ts src/lib/__tests__/proxy.test.ts app/mcp/route.test.ts`
- `pnpm --dir apps/web exec eslint app/__tests__/api-discovery-routes.test.ts app/api/route.ts app/api-docs/route.ts app/api-reference/route.ts app/developer/route.ts app/developers/route.ts app/llms.txt/route.ts app/mcp.json/route.ts app/openapi.json/route.ts app/openapi.yaml/route.ts src/lib/discovery-responses.ts script/smoke-built-app.ts`
- `pnpm --filter @jobseek/web build`
- `pnpm --dir apps/web smoke`
- `git diff --check`