### PR TITLE
Clean up web test env mutations

### DIFF
--- a/apps/web/app/api/admin/meta/apify-import/route.test.ts
+++ b/apps/web/app/api/admin/meta/apify-import/route.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withTestEnv } from "@/test-utils/env";
 
 vi.mock("server-only", () => ({}));
 
@@ -17,8 +18,9 @@ import { importLatestMetaApifyRun } from "@/lib/admin/meta-apify-import";
 import { POST } from "./route";
 
 describe("POST /api/admin/meta/apify-import", () => {
+  withTestEnv({ ADMIN_SECRET: "secret-token" });
+
   beforeEach(() => {
-    process.env.ADMIN_SECRET = "secret-token";
     vi.mocked(importLatestMetaApifyRun).mockReset();
   });
 

--- a/apps/web/app/api/admin/murmur-demo/run/route.test.ts
+++ b/apps/web/app/api/admin/murmur-demo/run/route.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setTestEnv, withTestEnv } from "@/test-utils/env";
 
 vi.mock("server-only", () => ({}));
 
@@ -21,14 +22,13 @@ const ADMIN_SECRET = "secret-token";
 const URL_BASE = "http://localhost/api/admin/murmur-demo/run";
 
 describe("POST /api/admin/murmur-demo/run", () => {
-  beforeEach(() => {
-    process.env.ADMIN_SECRET = ADMIN_SECRET;
-    process.env.MURMUR_RUN_TRIGGER_ENABLED = "true";
-    vi.mocked(startRun).mockReset();
+  withTestEnv({
+    ADMIN_SECRET,
+    MURMUR_RUN_TRIGGER_ENABLED: "true",
   });
 
-  afterEach(() => {
-    delete process.env.MURMUR_RUN_TRIGGER_ENABLED;
+  beforeEach(() => {
+    vi.mocked(startRun).mockReset();
   });
 
   it("rejects requests without basic auth (401)", async () => {
@@ -46,7 +46,7 @@ describe("POST /api/admin/murmur-demo/run", () => {
   });
 
   it("returns 503 when the feature flag is not 'true'", async () => {
-    process.env.MURMUR_RUN_TRIGGER_ENABLED = "false";
+    setTestEnv({ MURMUR_RUN_TRIGGER_ENABLED: "false" });
     const res = await POST(
       new Request(URL_BASE, {
         method: "POST",

--- a/apps/web/app/api/internal/invalidate-typeahead/route.test.ts
+++ b/apps/web/app/api/internal/invalidate-typeahead/route.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setTestEnv, withTestEnv } from "@/test-utils/env";
 
 vi.mock("server-only", () => ({}));
 
@@ -12,19 +13,12 @@ vi.mock("next/cache", () => ({ revalidateTag: mocks.revalidateTag }));
 
 import { POST } from "./route";
 
-const _ORIGINAL_TOKEN = process.env.INTERNAL_REVALIDATE_TOKEN;
+withTestEnv({ INTERNAL_REVALIDATE_TOKEN: "secret-token" });
 
 beforeEach(() => {
   mocks.invalidatePattern.mockReset();
   mocks.invalidatePattern.mockResolvedValue(0);
   mocks.revalidateTag.mockReset();
-  process.env.INTERNAL_REVALIDATE_TOKEN = "secret-token";
-});
-
-afterEach(() => {
-  if (_ORIGINAL_TOKEN === undefined)
-    delete process.env.INTERNAL_REVALIDATE_TOKEN;
-  else process.env.INTERNAL_REVALIDATE_TOKEN = _ORIGINAL_TOKEN;
 });
 
 const _request = (auth?: string) =>
@@ -35,7 +29,7 @@ const _request = (auth?: string) =>
 
 describe("POST /api/internal/invalidate-typeahead", () => {
   it("returns 503 when INTERNAL_REVALIDATE_TOKEN is unset", async () => {
-    delete process.env.INTERNAL_REVALIDATE_TOKEN;
+    setTestEnv({ INTERNAL_REVALIDATE_TOKEN: undefined });
     const res = await POST(_request("Bearer secret-token") as never);
     expect(res.status).toBe(503);
     expect(mocks.invalidatePattern).not.toHaveBeenCalled();

--- a/apps/web/app/api/stripe/webhook/route.test.ts
+++ b/apps/web/app/api/stripe/webhook/route.test.ts
@@ -11,6 +11,7 @@
  * AND the fail-closed behaviour when a signature is missing or invalid.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setTestEnv, withTestEnv } from "@/test-utils/env";
 
 // We never touch the DB in these tests — the request must be rejected
 // before any handler logic runs. We still need to mock `@/db` because the
@@ -74,15 +75,17 @@ const FORGED_CHECKOUT_EVENT = {
 
 let warnSpy: ReturnType<typeof vi.spyOn>;
 
+withTestEnv({
+  STRIPE_WEBHOOK_SECRET: undefined,
+  STRIPE_SECRET_KEY: undefined,
+});
+
 beforeEach(() => {
   warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-  delete process.env.STRIPE_WEBHOOK_SECRET;
 });
 
 afterEach(() => {
   warnSpy.mockRestore();
-  delete process.env.STRIPE_WEBHOOK_SECRET;
-  delete process.env.STRIPE_SECRET_KEY;
 });
 
 describe("POST /api/stripe/webhook — fail-closed when STRIPE_WEBHOOK_SECRET unset", () => {
@@ -107,7 +110,7 @@ describe("POST /api/stripe/webhook — fail-closed when STRIPE_WEBHOOK_SECRET un
   });
 
   it("returns 503 when STRIPE_WEBHOOK_SECRET is the empty string", async () => {
-    process.env.STRIPE_WEBHOOK_SECRET = "";
+    setTestEnv({ STRIPE_WEBHOOK_SECRET: "" });
     const res = await POST(
       makeRequest(FORGED_CHECKOUT_EVENT, { signature: "t=1,v1=anything" }),
     );
@@ -125,8 +128,10 @@ describe("POST /api/stripe/webhook — fail-closed when STRIPE_WEBHOOK_SECRET un
 
 describe("POST /api/stripe/webhook — signature verification when STRIPE_WEBHOOK_SECRET set", () => {
   beforeEach(() => {
-    process.env.STRIPE_WEBHOOK_SECRET = "whsec_test_only_not_a_real_secret";
-    process.env.STRIPE_SECRET_KEY = "sk_test_unused";
+    setTestEnv({
+      STRIPE_WEBHOOK_SECRET: "whsec_test_only_not_a_real_secret",
+      STRIPE_SECRET_KEY: "sk_test_unused",
+    });
   });
 
   it("returns 400 when stripe-signature header is missing", async () => {

--- a/apps/web/app/api/web/companies/request/[run_id]/status/route.test.ts
+++ b/apps/web/app/api/web/companies/request/[run_id]/status/route.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setTestEnv, withTestEnv } from "@/test-utils/env";
 
 vi.mock("server-only", () => ({}));
 
@@ -63,10 +64,13 @@ function makeRequest(): Request {
 }
 
 describe("GET /api/web/companies/request/[run_id]/status", () => {
+  withTestEnv({
+    MURMUR_RUN_TRIGGER_ENABLED: "true",
+    MURMUR_URL: "https://murmur.example.com",
+    MURMUR_TOKEN: "tok-secret",
+  });
+
   beforeEach(() => {
-    process.env.MURMUR_RUN_TRIGGER_ENABLED = "true";
-    process.env.MURMUR_URL = "https://murmur.example.com";
-    process.env.MURMUR_TOKEN = "tok-secret";
     mockGetSessionUserId.mockReset();
     mockGetSessionUserId.mockResolvedValue(USER_ID);
     mockFetchMurmurRunStatus.mockReset();
@@ -74,12 +78,6 @@ describe("GET /api/web/companies/request/[run_id]/status", () => {
     mockLookup.mockResolvedValue(null);
     mockRevalidatePath.mockReset();
     mockRevalidateTag.mockReset();
-  });
-
-  afterEach(() => {
-    delete process.env.MURMUR_RUN_TRIGGER_ENABLED;
-    delete process.env.MURMUR_URL;
-    delete process.env.MURMUR_TOKEN;
   });
 
   it("rejects unauthenticated calls with 401", async () => {
@@ -97,7 +95,7 @@ describe("GET /api/web/companies/request/[run_id]/status", () => {
   });
 
   it("returns 503 when the feature flag is unset", async () => {
-    delete process.env.MURMUR_RUN_TRIGGER_ENABLED;
+    setTestEnv({ MURMUR_RUN_TRIGGER_ENABLED: undefined });
     const res = await GET(makeRequest() as never, makeContext("r_abc"));
     expect(res.status).toBe(503);
     await expect(res.json()).resolves.toEqual({

--- a/apps/web/app/api/web/companies/request/route.test.ts
+++ b/apps/web/app/api/web/companies/request/route.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setTestEnv, withTestEnv } from "@/test-utils/env";
 
 // `server-only` is a build-time guard the route imports transitively via
 // `@/lib/sessionCache`. The admin-route tests use the same shim.
@@ -45,16 +46,16 @@ function makeRequest(body: unknown, init?: RequestInit): Request {
 }
 
 describe("POST /api/web/companies/request", () => {
+  withTestEnv({
+    MURMUR_RUN_TRIGGER_ENABLED: "true",
+    MURMUR_TOKEN: undefined,
+  });
+
   beforeEach(() => {
-    process.env.MURMUR_RUN_TRIGGER_ENABLED = "true";
     vi.mocked(startRun).mockReset();
     mockGetSessionUserId.mockReset();
     mockGetSessionUserId.mockResolvedValue(USER_ID);
     __resetRateLimitForTests();
-  });
-
-  afterEach(() => {
-    delete process.env.MURMUR_RUN_TRIGGER_ENABLED;
   });
 
   it("rejects unauthenticated calls with 401", async () => {
@@ -71,7 +72,7 @@ describe("POST /api/web/companies/request", () => {
   });
 
   it("returns 503 when the feature flag is unset", async () => {
-    delete process.env.MURMUR_RUN_TRIGGER_ENABLED;
+    setTestEnv({ MURMUR_RUN_TRIGGER_ENABLED: undefined });
     const res = await POST(
       makeRequest({ company_name: "Stripe", website: "https://stripe.com" }),
     );
@@ -84,7 +85,7 @@ describe("POST /api/web/companies/request", () => {
   });
 
   it("returns 503 when the feature flag is set to a non-true value", async () => {
-    process.env.MURMUR_RUN_TRIGGER_ENABLED = "false";
+    setTestEnv({ MURMUR_RUN_TRIGGER_ENABLED: "false" });
     const res = await POST(
       makeRequest({ company_name: "Stripe", website: "https://stripe.com" }),
     );
@@ -182,7 +183,7 @@ describe("POST /api/web/companies/request", () => {
   });
 
   it("install_command carries the literal <token-from-jobseek-team> placeholder, never a real token", async () => {
-    process.env.MURMUR_TOKEN = "super_secret_token_42";
+    setTestEnv({ MURMUR_TOKEN: "super_secret_token_42" });
     vi.mocked(startRun).mockResolvedValue({ run_id: "r_x" });
     const res = await POST(
       makeRequest({ company_name: "Stripe", website: "https://stripe.com" }),
@@ -202,7 +203,6 @@ describe("POST /api/web/companies/request", () => {
       " " +
       body.data.agent_prompt.prompt_text;
     expect(joined).not.toContain("super_secret_token_42");
-    delete process.env.MURMUR_TOKEN;
   });
 
   it("trims whitespace on company_name and website before forwarding", async () => {
@@ -317,7 +317,7 @@ describe("POST /api/web/companies/request", () => {
   });
 
   it("does not echo the website value or env var values in error envelopes", async () => {
-    process.env.MURMUR_TOKEN = "super_secret_token_42";
+    setTestEnv({ MURMUR_TOKEN: "super_secret_token_42" });
     vi.mocked(startRun).mockRejectedValue(
       new StartRunError("network", "DNS failed for https://stripe.com"),
     );
@@ -331,7 +331,6 @@ describe("POST /api/web/companies/request", () => {
     const joined = body.errors.join(" ");
     expect(joined).not.toContain("https://stripe.com");
     expect(joined).not.toContain("super_secret_token_42");
-    delete process.env.MURMUR_TOKEN;
   });
 
   it("returns 401 (not 500) when the session lookup itself throws", async () => {

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -44,4 +44,24 @@ export default tseslint.config(
       "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     },
   },
+  {
+    files: ["**/*.{test,spec}.{ts,tsx}"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "AssignmentExpression[left.object.name='process'][left.property.name='env']",
+          message: "Use src/test-utils/env helpers instead of replacing process.env in tests.",
+        },
+        {
+          selector: "AssignmentExpression[left.object.object.name='process'][left.object.property.name='env']",
+          message: "Use src/test-utils/env helpers so test env changes are restored.",
+        },
+        {
+          selector: "UnaryExpression[operator='delete'][argument.object.object.name='process'][argument.object.property.name='env']",
+          message: "Use setTestEnv({ KEY: undefined }) so test env changes are restored.",
+        },
+      ],
+    },
+  },
 );

--- a/apps/web/src/lib/__tests__/indexnow.test.ts
+++ b/apps/web/src/lib/__tests__/indexnow.test.ts
@@ -3,10 +3,12 @@ import { join } from "node:path";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { setTestEnv, withTestEnv } from "@/test-utils/env";
 import { notifyIndexNow } from "../indexnow";
 
-const ORIGINAL_KEY = process.env.INDEXNOW_KEY;
 const fetchMock = vi.fn();
+
+withTestEnv({ INDEXNOW_KEY: undefined });
 
 beforeEach(() => {
   vi.stubGlobal("fetch", fetchMock);
@@ -16,28 +18,26 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
-  if (ORIGINAL_KEY === undefined) delete process.env.INDEXNOW_KEY;
-  else process.env.INDEXNOW_KEY = ORIGINAL_KEY;
   vi.restoreAllMocks();
 });
 
 describe("notifyIndexNow", () => {
   it("no-ops when INDEXNOW_KEY is unset", async () => {
-    delete process.env.INDEXNOW_KEY;
+    setTestEnv({ INDEXNOW_KEY: undefined });
     const result = await notifyIndexNow(["/foo"]);
     expect(result).toEqual({ kind: "skipped", reason: "no-key" });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("no-ops when paths is empty", async () => {
-    process.env.INDEXNOW_KEY = "test-key";
+    setTestEnv({ INDEXNOW_KEY: "test-key" });
     const result = await notifyIndexNow([]);
     expect(result).toEqual({ kind: "skipped", reason: "no-paths" });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
   it("expands one path to one URL per locale and posts a single batch", async () => {
-    process.env.INDEXNOW_KEY = "test-key";
+    setTestEnv({ INDEXNOW_KEY: "test-key" });
     await notifyIndexNow(["/u/wl"]);
 
     expect(fetchMock).toHaveBeenCalledOnce();
@@ -57,7 +57,7 @@ describe("notifyIndexNow", () => {
   });
 
   it("encodes path segments with spaces and unicode", async () => {
-    process.env.INDEXNOW_KEY = "test-key";
+    setTestEnv({ INDEXNOW_KEY: "test-key" });
     await notifyIndexNow(["/user name/lübeck-jobs"]);
     const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
     expect(body.urlList[0]).toBe(
@@ -66,7 +66,7 @@ describe("notifyIndexNow", () => {
   });
 
   it("dedupes URLs across paths and pins ordering", async () => {
-    process.env.INDEXNOW_KEY = "test-key";
+    setTestEnv({ INDEXNOW_KEY: "test-key" });
     await notifyIndexNow(["/foo", "/foo"]);
     const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
     expect(body.urlList).toEqual([
@@ -78,7 +78,7 @@ describe("notifyIndexNow", () => {
   });
 
   it("caps the batch at 10_000 URLs (IndexNow protocol limit)", async () => {
-    process.env.INDEXNOW_KEY = "test-key";
+    setTestEnv({ INDEXNOW_KEY: "test-key" });
     // 2_501 paths × 4 locales = 10_004 expanded URLs → must be trimmed.
     const paths = Array.from({ length: 2_501 }, (_, i) => `/p${i}`);
     await notifyIndexNow(paths);
@@ -88,14 +88,14 @@ describe("notifyIndexNow", () => {
   });
 
   it("does not log on a 200 response (success is silent)", async () => {
-    process.env.INDEXNOW_KEY = "test-key";
+    setTestEnv({ INDEXNOW_KEY: "test-key" });
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     await notifyIndexNow(["/foo"]);
     expect(errSpy).not.toHaveBeenCalled();
   });
 
   it("returns rejected (does not throw) when the endpoint rejects with 4xx", async () => {
-    process.env.INDEXNOW_KEY = "test-key";
+    setTestEnv({ INDEXNOW_KEY: "test-key" });
     fetchMock.mockResolvedValue(new Response("bad key", { status: 403 }));
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const result = await notifyIndexNow(["/foo"]);
@@ -105,7 +105,7 @@ describe("notifyIndexNow", () => {
   });
 
   it("returns errored (does not throw) on network errors", async () => {
-    process.env.INDEXNOW_KEY = "test-key";
+    setTestEnv({ INDEXNOW_KEY: "test-key" });
     const networkErr = new Error("ECONNRESET");
     fetchMock.mockRejectedValue(networkErr);
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -115,13 +115,13 @@ describe("notifyIndexNow", () => {
   });
 
   it("returns submitted with the URL count on a 200 response", async () => {
-    process.env.INDEXNOW_KEY = "test-key";
+    setTestEnv({ INDEXNOW_KEY: "test-key" });
     const result = await notifyIndexNow(["/foo"]);
     expect(result).toEqual({ kind: "submitted", status: 200, urlCount: 4 });
   });
 
   it("restricts locale fan-out when availableLocales is provided (#2843, blog)", async () => {
-    process.env.INDEXNOW_KEY = "test-key";
+    setTestEnv({ INDEXNOW_KEY: "test-key" });
     await notifyIndexNow(["/blog/welcome"], ["en", "de"]);
     const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
     expect(body.urlList).toEqual([
@@ -133,14 +133,14 @@ describe("notifyIndexNow", () => {
   });
 
   it("emits a single locale URL for an EN-only post", async () => {
-    process.env.INDEXNOW_KEY = "test-key";
+    setTestEnv({ INDEXNOW_KEY: "test-key" });
     await notifyIndexNow(["/blog/en-only"], ["en"]);
     const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
     expect(body.urlList).toEqual(["https://jseek.co/en/blog/en-only"]);
   });
 
   it("no-ops when availableLocales is an empty array (defensive)", async () => {
-    process.env.INDEXNOW_KEY = "test-key";
+    setTestEnv({ INDEXNOW_KEY: "test-key" });
     const result = await notifyIndexNow(["/blog/no-locales"], []);
     expect(result).toEqual({ kind: "skipped", reason: "no-locales" });
     expect(fetchMock).not.toHaveBeenCalled();
@@ -168,7 +168,7 @@ describe("notifyIndexNow", () => {
     // callers wrapped notifyIndexNow in a detached .then() chain. The
     // current contract is: notifyIndexNow awaits fetch directly and
     // the caller is responsible for invoking it inside after().
-    process.env.INDEXNOW_KEY = "test-key";
+    setTestEnv({ INDEXNOW_KEY: "test-key" });
     let resolved = false;
     let release!: () => void;
     const gate = new Promise<void>((r) => {

--- a/apps/web/src/lib/actions/__tests__/company.test.ts
+++ b/apps/web/src/lib/actions/__tests__/company.test.ts
@@ -1,4 +1,5 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setTestEnv, withTestEnv } from "@/test-utils/env";
 
 // `vi.mock` hoists to the top of the file so its factories cannot close
 // over module-scope variables. Use `vi.hoisted` to share mocks between
@@ -100,11 +101,14 @@ const dbExecuteMock = mocks.dbExecute;
 const cacheLifeMock = mocks.cacheLife;
 const cacheTagMock = mocks.cacheTag;
 const buildFilterStringMock = mocks.buildFilterString;
-const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
-const ORIGINAL_TYPESENSE_HOST = process.env.TYPESENSE_HOST;
-const ORIGINAL_TYPESENSE_PORT = process.env.TYPESENSE_PORT;
-const ORIGINAL_TYPESENSE_PROTOCOL = process.env.TYPESENSE_PROTOCOL;
-const ORIGINAL_TYPESENSE_SEARCH_KEY = process.env.TYPESENSE_SEARCH_KEY;
+const TEST_ENV = {
+  DATABASE_URL:
+    process.env.DATABASE_URL ?? "postgresql://test:test@localhost:5432/test",
+  TYPESENSE_HOST: process.env.TYPESENSE_HOST,
+  TYPESENSE_PORT: process.env.TYPESENSE_PORT,
+  TYPESENSE_PROTOCOL: process.env.TYPESENSE_PROTOCOL,
+  TYPESENSE_SEARCH_KEY: process.env.TYPESENSE_SEARCH_KEY,
+};
 
 const _hit = (overrides: Record<string, unknown> = {}) => ({
   id: "co-1",
@@ -127,42 +131,14 @@ const _hit = (overrides: Record<string, unknown> = {}) => ({
 const _typesenseResponse = (hit: Record<string, unknown> | null) =>
   hit ? { hits: [{ document: hit }] } : { hits: [] };
 
+withTestEnv(TEST_ENV);
+
 beforeEach(() => {
   vi.clearAllMocks();
   searchMock.mockReset();
   dbExecuteMock.mockReset();
   buildFilterStringMock.mockReset();
   buildFilterStringMock.mockReturnValue("");
-  process.env.DATABASE_URL =
-    ORIGINAL_DATABASE_URL ?? "postgresql://test:test@localhost:5432/test";
-});
-
-afterEach(() => {
-  if (ORIGINAL_DATABASE_URL === undefined) {
-    delete process.env.DATABASE_URL;
-  } else {
-    process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
-  }
-  if (ORIGINAL_TYPESENSE_HOST === undefined) {
-    delete process.env.TYPESENSE_HOST;
-  } else {
-    process.env.TYPESENSE_HOST = ORIGINAL_TYPESENSE_HOST;
-  }
-  if (ORIGINAL_TYPESENSE_PORT === undefined) {
-    delete process.env.TYPESENSE_PORT;
-  } else {
-    process.env.TYPESENSE_PORT = ORIGINAL_TYPESENSE_PORT;
-  }
-  if (ORIGINAL_TYPESENSE_PROTOCOL === undefined) {
-    delete process.env.TYPESENSE_PROTOCOL;
-  } else {
-    process.env.TYPESENSE_PROTOCOL = ORIGINAL_TYPESENSE_PROTOCOL;
-  }
-  if (ORIGINAL_TYPESENSE_SEARCH_KEY === undefined) {
-    delete process.env.TYPESENSE_SEARCH_KEY;
-  } else {
-    process.env.TYPESENSE_SEARCH_KEY = ORIGINAL_TYPESENSE_SEARCH_KEY;
-  }
 });
 
 describe("searchCompaniesForWatchlist", () => {
@@ -486,11 +462,13 @@ describe("getCompanyBySlug — Postgres fallback", () => {
 
   it("returns null outside the cache boundary when lookup env is not configured", async () => {
     searchMock.mockResolvedValue(_typesenseResponse(null));
-    delete process.env.DATABASE_URL;
-    delete process.env.TYPESENSE_HOST;
-    delete process.env.TYPESENSE_PORT;
-    delete process.env.TYPESENSE_PROTOCOL;
-    delete process.env.TYPESENSE_SEARCH_KEY;
+    setTestEnv({
+      DATABASE_URL: undefined,
+      TYPESENSE_HOST: undefined,
+      TYPESENSE_PORT: undefined,
+      TYPESENSE_PROTOCOL: undefined,
+      TYPESENSE_SEARCH_KEY: undefined,
+    });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const out = await getCompanyBySlug("acme", "en");

--- a/apps/web/src/lib/actions/__tests__/db-retry-coverage.test.ts
+++ b/apps/web/src/lib/actions/__tests__/db-retry-coverage.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withTestEnv } from "@/test-utils/env";
 
 /**
  * Issue #2930: extends `withDbRetry` (#2929 / #2918) to additional
@@ -131,24 +132,20 @@ const econnreset = (): Error => {
   return e;
 };
 
-const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+const TEST_DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgresql://test:test@localhost:5432/test";
 
 describe("issue #2930 — withDbRetry covers additional call sites", () => {
+  withTestEnv({ DATABASE_URL: TEST_DATABASE_URL });
+
   beforeEach(() => {
     dbExecuteMock.mockReset();
     cachedMock.mockClear();
-    process.env.DATABASE_URL =
-      ORIGINAL_DATABASE_URL ?? "postgresql://test:test@localhost:5432/test";
     vi.spyOn(console, "warn").mockImplementation(() => {});
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
-    if (ORIGINAL_DATABASE_URL === undefined) {
-      delete process.env.DATABASE_URL;
-    } else {
-      process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
-    }
   });
 
   it("retries _fetchPublicWatchlistByUserAndSlug after ECONNRESET", async () => {

--- a/apps/web/src/lib/actions/__tests__/request-company.test.ts
+++ b/apps/web/src/lib/actions/__tests__/request-company.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setTestEnv, withTestEnv } from "@/test-utils/env";
 
 /**
  * #3193 — `requestCompany` was previously colocated in `stats.ts` together
@@ -115,6 +116,12 @@ vi.mock("@/db/schema", () => ({
   },
 }));
 
+const GITHUB_APP_TEST_ENV = {
+  GITHUB_APP_ID: "12345",
+  GITHUB_APP_PRIVATE_KEY: "-----BEGIN KEY-----\nabc\n-----END KEY-----",
+  GITHUB_APP_INSTALLATION_ID: "67890",
+};
+
 /**
  * Build the headers a real Next-Action POST would carry. Always includes the
  * `next-action` magic header (issue #3235 Layer 3 — server-action header
@@ -126,7 +133,7 @@ function actionHeaders(extra: Record<string, string> = {}): Headers {
 }
 
 describe("requestCompany e2e (#3193) — GitHub issue shape preserved", () => {
-  const env = process.env;
+  withTestEnv(GITHUB_APP_TEST_ENV);
 
   beforeEach(() => {
     mocks.issuesCreate.mockReset();
@@ -141,13 +148,6 @@ describe("requestCompany e2e (#3193) — GitHub issue shape preserved", () => {
     mocks.rateLimit.mockReset();
     mocks.getClientIp.mockReset();
 
-    process.env = {
-      ...env,
-      GITHUB_APP_ID: "12345",
-      GITHUB_APP_PRIVATE_KEY: "-----BEGIN KEY-----\nabc\n-----END KEY-----",
-      GITHUB_APP_INSTALLATION_ID: "67890",
-    };
-
     // Default to "allow" so existing happy-path specs are unchanged.
     mocks.rateLimit.mockResolvedValue({ success: true, remaining: 4 });
     mocks.getClientIp.mockReturnValue("203.0.113.7");
@@ -155,7 +155,6 @@ describe("requestCompany e2e (#3193) — GitHub issue shape preserved", () => {
   });
 
   afterEach(() => {
-    process.env = env;
     vi.resetModules();
   });
 
@@ -204,10 +203,11 @@ describe("requestCompany e2e (#3193) — GitHub issue shape preserved", () => {
   });
 
   it("returns issueCreationFailed=true when GH credentials are missing", async () => {
-    process.env = { ...env };
-    delete process.env.GITHUB_APP_ID;
-    delete process.env.GITHUB_APP_PRIVATE_KEY;
-    delete process.env.GITHUB_APP_INSTALLATION_ID;
+    setTestEnv({
+      GITHUB_APP_ID: undefined,
+      GITHUB_APP_PRIVATE_KEY: undefined,
+      GITHUB_APP_INSTALLATION_ID: undefined,
+    });
 
     mocks.selectLimitResult.mockResolvedValue([]);
     mocks.insertReturningResult.mockResolvedValue([{ id: "row-1" }]);
@@ -267,7 +267,7 @@ describe("requestCompany e2e (#3193) — GitHub issue shape preserved", () => {
  *      rejected before any side effect.
  */
 describe("requestCompany security hardening (#3235)", () => {
-  const env = process.env;
+  withTestEnv(GITHUB_APP_TEST_ENV);
 
   beforeEach(() => {
     mocks.issuesCreate.mockReset();
@@ -282,20 +282,12 @@ describe("requestCompany security hardening (#3235)", () => {
     mocks.rateLimit.mockReset();
     mocks.getClientIp.mockReset();
 
-    process.env = {
-      ...env,
-      GITHUB_APP_ID: "12345",
-      GITHUB_APP_PRIVATE_KEY: "-----BEGIN KEY-----\nabc\n-----END KEY-----",
-      GITHUB_APP_INSTALLATION_ID: "67890",
-    };
-
     mocks.rateLimit.mockResolvedValue({ success: true, remaining: 4 });
     mocks.getClientIp.mockReturnValue("203.0.113.7");
     mocks.headers.mockResolvedValue(actionHeaders({ "cf-ipcountry": "CH" }));
   });
 
   afterEach(() => {
-    process.env = env;
     vi.resetModules();
   });
 

--- a/apps/web/src/lib/actions/__tests__/watchlists-detail-perf.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-detail-perf.test.ts
@@ -35,6 +35,7 @@
  *     hand the caller `[]`, not `null` or `undefined`).
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setTestEnv, withTestEnv } from "@/test-utils/env";
 
 vi.mock("server-only", () => ({}));
 
@@ -207,22 +208,18 @@ import {
 } from "../watchlists";
 
 const USER_ID = "user-1";
-const ORIGINAL_DATABASE_URL = process.env.DATABASE_URL;
+const TEST_DATABASE_URL =
+  process.env.DATABASE_URL ?? "postgresql://test:test@localhost:5432/test";
+
+withTestEnv({ DATABASE_URL: TEST_DATABASE_URL });
 
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.getSessionUserId.mockResolvedValue(USER_ID);
-  process.env.DATABASE_URL =
-    ORIGINAL_DATABASE_URL ?? "postgresql://test:test@localhost:5432/test";
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
-  if (ORIGINAL_DATABASE_URL === undefined) {
-    delete process.env.DATABASE_URL;
-  } else {
-    process.env.DATABASE_URL = ORIGINAL_DATABASE_URL;
-  }
 });
 
 // ---- helpers ----------------------------------------------------------
@@ -411,7 +408,7 @@ describe("getPublicWatchlistByUserAndSlug — single-query fold (#3211)", () => 
   });
 
   it("returns null before the cache/DB path when DATABASE_URL is not configured", async () => {
-    delete process.env.DATABASE_URL;
+    setTestEnv({ DATABASE_URL: undefined });
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const detail = await getPublicWatchlistByUserAndSlug("alice", "my-watchlist");

--- a/apps/web/src/lib/og/__tests__/company-og-cache.test.ts
+++ b/apps/web/src/lib/og/__tests__/company-og-cache.test.ts
@@ -1,56 +1,20 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setTestEnv, withTestEnv } from "@/test-utils/env";
 
 vi.mock("server-only", () => ({}));
 
-const ORIGINAL_RENDERER_VERSION = process.env.COMPANY_OG_RENDERER_VERSION;
-const ORIGINAL_CACHE_BYPASS = process.env.COMPANY_OG_CACHE_BYPASS;
-const ORIGINAL_R2_ENDPOINT_URL = process.env.R2_ENDPOINT_URL;
-const ORIGINAL_R2_ACCESS_KEY_ID = process.env.R2_ACCESS_KEY_ID;
-const ORIGINAL_R2_SECRET_ACCESS_KEY = process.env.R2_SECRET_ACCESS_KEY;
-const ORIGINAL_R2_BUCKET = process.env.R2_BUCKET;
-
 describe("company OG cache", () => {
-  beforeEach(() => {
-    vi.resetModules();
-    process.env.COMPANY_OG_RENDERER_VERSION = "renderer123";
-    delete process.env.COMPANY_OG_CACHE_BYPASS;
-    delete process.env.R2_ENDPOINT_URL;
-    delete process.env.R2_ACCESS_KEY_ID;
-    delete process.env.R2_SECRET_ACCESS_KEY;
-    delete process.env.R2_BUCKET;
+  withTestEnv({
+    COMPANY_OG_RENDERER_VERSION: "renderer123",
+    COMPANY_OG_CACHE_BYPASS: undefined,
+    R2_ENDPOINT_URL: undefined,
+    R2_ACCESS_KEY_ID: undefined,
+    R2_SECRET_ACCESS_KEY: undefined,
+    R2_BUCKET: undefined,
   });
 
-  afterEach(() => {
-    if (ORIGINAL_RENDERER_VERSION === undefined) {
-      delete process.env.COMPANY_OG_RENDERER_VERSION;
-    } else {
-      process.env.COMPANY_OG_RENDERER_VERSION = ORIGINAL_RENDERER_VERSION;
-    }
-    if (ORIGINAL_CACHE_BYPASS === undefined) {
-      delete process.env.COMPANY_OG_CACHE_BYPASS;
-    } else {
-      process.env.COMPANY_OG_CACHE_BYPASS = ORIGINAL_CACHE_BYPASS;
-    }
-    if (ORIGINAL_R2_ENDPOINT_URL === undefined) {
-      delete process.env.R2_ENDPOINT_URL;
-    } else {
-      process.env.R2_ENDPOINT_URL = ORIGINAL_R2_ENDPOINT_URL;
-    }
-    if (ORIGINAL_R2_ACCESS_KEY_ID === undefined) {
-      delete process.env.R2_ACCESS_KEY_ID;
-    } else {
-      process.env.R2_ACCESS_KEY_ID = ORIGINAL_R2_ACCESS_KEY_ID;
-    }
-    if (ORIGINAL_R2_SECRET_ACCESS_KEY === undefined) {
-      delete process.env.R2_SECRET_ACCESS_KEY;
-    } else {
-      process.env.R2_SECRET_ACCESS_KEY = ORIGINAL_R2_SECRET_ACCESS_KEY;
-    }
-    if (ORIGINAL_R2_BUCKET === undefined) {
-      delete process.env.R2_BUCKET;
-    } else {
-      process.env.R2_BUCKET = ORIGINAL_R2_BUCKET;
-    }
+  beforeEach(() => {
+    vi.resetModules();
   });
 
   it("uses the renderer version in sanitized object keys", async () => {
@@ -62,7 +26,7 @@ describe("company OG cache", () => {
   });
 
   it("exposes the explicit bypass knob", async () => {
-    process.env.COMPANY_OG_CACHE_BYPASS = "1";
+    setTestEnv({ COMPANY_OG_CACHE_BYPASS: "1" });
     const { shouldBypassCompanyOgCache } = await import("../company-og-cache");
 
     expect(shouldBypassCompanyOgCache()).toBe(true);

--- a/apps/web/src/lib/search/__tests__/typesense.e2e.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense.e2e.test.ts
@@ -14,14 +14,9 @@
  * @vitest-environment node
  */
 
-// Set env vars BEFORE any imports so the client factory picks them up.
-process.env.TYPESENSE_HOST = "localhost";
-process.env.TYPESENSE_PORT = "8108";
-process.env.TYPESENSE_PROTOCOL = "http";
-process.env.TYPESENSE_SEARCH_KEY = "local_dev_typesense_key";
-
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Client } from "typesense";
+import { withTestEnvForAll } from "@/test-utils/env";
 import type { CollectionCreateSchema } from "typesense/lib/Typesense/Collections";
 import { TypesenseSearchProvider } from "../typesense";
 
@@ -32,8 +27,15 @@ const COLLECTION_PREFIX = "e2e_test_";
 const JOB_POSTING_COLLECTION = `${COLLECTION_PREFIX}job_posting`;
 const COMPANY_COLLECTION = `${COLLECTION_PREFIX}company`;
 
+withTestEnvForAll({
+  TYPESENSE_HOST: "localhost",
+  TYPESENSE_PORT: "8108",
+  TYPESENSE_PROTOCOL: "http",
+  TYPESENSE_SEARCH_KEY: API_KEY,
+});
+
 // We use a direct admin client for seeding/cleanup. The provider uses the
-// search client singleton (getSearchClient), which reads env vars above.
+// search client singleton (getSearchClient), which reads env vars lazily.
 let adminClient: Client;
 let provider: TypesenseSearchProvider;
 let suiteSkipped = false;

--- a/apps/web/src/lib/search/__tests__/use-clear-typesense-on-auth-change.test.tsx
+++ b/apps/web/src/lib/search/__tests__/use-clear-typesense-on-auth-change.test.tsx
@@ -1,25 +1,21 @@
 /** @vitest-environment happy-dom */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
+import { setTestEnv, withTestEnv } from "@/test-utils/env";
 import { useClearTypesenseOnAuthChange } from "../use-clear-typesense-on-auth-change";
 import * as keyModule from "../typesense-browser-key";
 
 describe("useClearTypesenseOnAuthChange", () => {
   let clearSpy: ReturnType<typeof vi.spyOn>;
-  const ORIGINAL_FLAG = process.env.NEXT_PUBLIC_TYPESENSE_DIRECT;
+
+  withTestEnv({ NEXT_PUBLIC_TYPESENSE_DIRECT: "1" });
 
   beforeEach(() => {
-    process.env.NEXT_PUBLIC_TYPESENSE_DIRECT = "1";
     clearSpy = vi.spyOn(keyModule, "clearTypesenseBrowserConfig").mockImplementation(() => {});
   });
 
   afterEach(() => {
     clearSpy.mockRestore();
-    if (ORIGINAL_FLAG === undefined) {
-      delete process.env.NEXT_PUBLIC_TYPESENSE_DIRECT;
-    } else {
-      process.env.NEXT_PUBLIC_TYPESENSE_DIRECT = ORIGINAL_FLAG;
-    }
   });
 
   it("does NOT clear on first mount (would waste a key fetch on every soft nav)", () => {
@@ -61,7 +57,7 @@ describe("useClearTypesenseOnAuthChange", () => {
   });
 
   it("no-ops when feature flag is off, even on auth flip", () => {
-    process.env.NEXT_PUBLIC_TYPESENSE_DIRECT = "0";
+    setTestEnv({ NEXT_PUBLIC_TYPESENSE_DIRECT: "0" });
     const { rerender } = renderHook(
       (p: boolean) => useClearTypesenseOnAuthChange(p),
       { initialProps: false },

--- a/apps/web/src/test-utils/env.test.ts
+++ b/apps/web/src/test-utils/env.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+
+import { restoreTestEnv, setTestEnv, snapshotTestEnv } from "./env";
+
+describe("test env helpers", () => {
+  it("restores absent and present environment variables", () => {
+    const keys = [
+      "JOBSEEK_TEST_ENV_HELPER_PRESENT",
+      "JOBSEEK_TEST_ENV_HELPER_ABSENT",
+    ];
+    const outerSnapshot = snapshotTestEnv(keys);
+
+    try {
+      setTestEnv({
+        JOBSEEK_TEST_ENV_HELPER_PRESENT: "original",
+        JOBSEEK_TEST_ENV_HELPER_ABSENT: undefined,
+      });
+
+      const snapshot = snapshotTestEnv(keys);
+      setTestEnv({
+        JOBSEEK_TEST_ENV_HELPER_PRESENT: "changed",
+        JOBSEEK_TEST_ENV_HELPER_ABSENT: "created",
+      });
+
+      restoreTestEnv(snapshot);
+
+      expect(process.env.JOBSEEK_TEST_ENV_HELPER_PRESENT).toBe("original");
+      expect(process.env.JOBSEEK_TEST_ENV_HELPER_ABSENT).toBeUndefined();
+    } finally {
+      restoreTestEnv(outerSnapshot);
+    }
+  });
+});

--- a/apps/web/src/test-utils/env.ts
+++ b/apps/web/src/test-utils/env.ts
@@ -1,0 +1,58 @@
+import { afterAll, afterEach, beforeAll, beforeEach } from "vitest";
+
+export type TestEnvValue = string | undefined;
+export type TestEnvOverrides = Record<string, TestEnvValue>;
+
+export function snapshotTestEnv(keys: Iterable<string>): TestEnvOverrides {
+  const snapshot: TestEnvOverrides = {};
+  for (const key of keys) {
+    snapshot[key] = process.env[key];
+  }
+  return snapshot;
+}
+
+export function setTestEnv(overrides: TestEnvOverrides): void {
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+export function restoreTestEnv(snapshot: TestEnvOverrides): void {
+  setTestEnv(snapshot);
+}
+
+export function withTestEnv(overrides: TestEnvOverrides): void {
+  let original: TestEnvOverrides | undefined;
+
+  beforeEach(() => {
+    original = snapshotTestEnv(Object.keys(overrides));
+    setTestEnv(overrides);
+  });
+
+  afterEach(() => {
+    if (original !== undefined) {
+      restoreTestEnv(original);
+      original = undefined;
+    }
+  });
+}
+
+export function withTestEnvForAll(overrides: TestEnvOverrides): void {
+  let original: TestEnvOverrides | undefined;
+
+  beforeAll(() => {
+    original = snapshotTestEnv(Object.keys(overrides));
+    setTestEnv(overrides);
+  });
+
+  afterAll(() => {
+    if (original !== undefined) {
+      restoreTestEnv(original);
+      original = undefined;
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Add shared web test env helpers that snapshot and restore process env keys in Vitest lifecycle hooks
- Migrate web tests away from direct process.env writes/deletes and whole-object replacement
- Add an ESLint guard preventing direct process.env mutation in test/spec files

## Issue
Closes #3128

## Reproduction
- Confirmed the issue with a static scan: `rg -n "process\.env\s*=|process\.env\.[A-Z0-9_]+\s*=|delete process\.env\.[A-Z0-9_]+" apps/web --glob "*.{test,spec}.{ts,tsx}"` found direct writes/deletes including module-scope Typesense E2E env setup and admin route secrets.
- After the fix, the same scan returns no matches.
- Production probing is not relevant: this is test-only hygiene and does not change runtime behavior.

## Validation
- `pnpm --filter @jobseek/web exec vitest run src/test-utils/env.test.ts app/api/admin/meta/apify-import/route.test.ts app/api/admin/murmur-demo/run/route.test.ts app/api/stripe/webhook/route.test.ts app/api/internal/invalidate-typeahead/route.test.ts src/lib/search/__tests__/use-clear-typesense-on-auth-change.test.tsx src/lib/__tests__/indexnow.test.ts src/lib/og/__tests__/company-og-cache.test.ts src/lib/actions/__tests__/db-retry-coverage.test.ts src/lib/actions/__tests__/watchlists-detail-perf.test.ts src/lib/actions/__tests__/company.test.ts src/lib/actions/__tests__/request-company.test.ts app/api/web/companies/request/route.test.ts "app/api/web/companies/request/[run_id]/status/route.test.ts"`
- `pnpm --filter @jobseek/web lint`
- `pnpm --filter @jobseek/web typecheck`
- `pnpm --filter @jobseek/web test`
- `git diff --check`