### PR TITLE
Use explicit locale formatting

### DIFF
--- a/apps/web/app/[lang]/(app)/progress/progress-loader.tsx
+++ b/apps/web/app/[lang]/(app)/progress/progress-loader.tsx
@@ -9,7 +9,7 @@ import { CompanyRequestForm } from "./company-request-form";
 
 type StatsData = { companyCount: number; jobPostingCount: number };
 
-export function ProgressLoader({ locale: _locale, lang }: { locale: string; lang: string }) {
+export function ProgressLoader({ locale, lang }: { locale: string; lang: string }) {
   const [stats, setStats] = useState<StatsData | null>(null);
 
   useEffect(() => {
@@ -33,7 +33,7 @@ export function ProgressLoader({ locale: _locale, lang }: { locale: string; lang
       <div className="mt-10 flex gap-6">
         <div className="flex flex-col items-center rounded-md border border-divider bg-surface px-8 py-6">
           <Building2 className="mb-2 h-6 w-6 text-muted" />
-          <span className="text-3xl font-bold">{stats ? stats.companyCount.toLocaleString() : "—"}</span>
+          <span className="text-3xl font-bold">{stats ? stats.companyCount.toLocaleString(locale) : "—"}</span>
           <span className="mt-1 text-sm text-muted">
             <Trans id="app.home.stats.companies" comment="Label for the company counter on the app home page">
               Companies Tracked
@@ -42,7 +42,7 @@ export function ProgressLoader({ locale: _locale, lang }: { locale: string; lang
         </div>
         <div className="flex flex-col items-center rounded-md border border-divider bg-surface px-8 py-6">
           <Briefcase className="mb-2 h-6 w-6 text-muted" />
-          <span className="text-3xl font-bold">{stats ? stats.jobPostingCount.toLocaleString() : "—"}</span>
+          <span className="text-3xl font-bold">{stats ? stats.jobPostingCount.toLocaleString(locale) : "—"}</span>
           <span className="mt-1 text-sm text-muted">
             <Trans id="app.home.stats.jobPostings" comment="Label for the job postings counter on the app home page">
               Job Postings

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -10,6 +10,14 @@ const typedSourceIgnores = [
   "**/*.test.{ts,tsx}",
   "src/test-utils/**",
 ];
+const appSourceFiles = ["app/**/*.{ts,tsx}", "src/**/*.{ts,tsx}"];
+const appSourceIgnores = [
+  "**/__tests__/**",
+  "**/*.test.{ts,tsx}",
+  "src/test-utils/**",
+  "script/**",
+  "scripts/**",
+];
 
 export default tseslint.config(
   {
@@ -30,6 +38,33 @@ export default tseslint.config(
       "@typescript-eslint/no-misused-promises": [
         "error",
         { checksVoidReturn: { attributes: false } },
+      ],
+    },
+  },
+  {
+    files: appSourceFiles,
+    ignores: appSourceIgnores,
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "CallExpression[callee.property.name='toLocaleString'][arguments.length=0]",
+          message:
+            "Pass the app locale to toLocaleString(); browser defaults can differ from the selected UI language.",
+        },
+        {
+          selector:
+            "CallExpression[callee.property.name='toLocaleDateString'][arguments.length=0]",
+          message:
+            "Pass the app locale to toLocaleDateString(); browser defaults can differ from the selected UI language.",
+        },
+        {
+          selector:
+            "CallExpression[callee.property.name='localeCompare'][arguments.length=1]",
+          message:
+            "Pass an explicit locale for display sorting, or use deterministic < > comparison for canonical keys.",
+        },
       ],
     },
   },

--- a/apps/web/src/components/my-jobs/__tests__/salary-override.test.tsx
+++ b/apps/web/src/components/my-jobs/__tests__/salary-override.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { SalaryOverride } from "../salary-override";
+
+vi.mock("@lingui/react/macro", () => ({
+  useLingui: () => ({
+    i18n: { locale: "de-DE" },
+    t: ({ message }: { message?: string }) => message ?? "",
+  }),
+  Trans: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+describe("SalaryOverride", () => {
+  it("formats crawler salary placeholders with the active UI locale", () => {
+    render(
+      <SalaryOverride
+        crawlerSalary={{
+          min: 1234567,
+          max: 2345678,
+          currency: "EUR",
+          period: "yearly",
+        }}
+        override={{
+          min: null,
+          max: null,
+          currency: null,
+          period: null,
+        }}
+        onSave={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByPlaceholderText("1.234.567")).toBeTruthy();
+    expect(screen.getByPlaceholderText("2.345.678")).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/my-jobs/salary-override.tsx
+++ b/apps/web/src/components/my-jobs/salary-override.tsx
@@ -38,7 +38,7 @@ export function SalaryOverride({
     override.period ?? crawlerSalary.period ?? "yearly",
   );
   const saveTimeout = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const { t } = useLingui();
+  const { t, i18n } = useLingui();
   const minLabel = t({ id: "myJobs.salary.min", comment: "Minimum salary label", message: "Min" });
   const maxLabel = t({ id: "myJobs.salary.max", comment: "Maximum salary label", message: "Max" });
   const yearlyLabel = t({ id: "myJobs.salary.yearly", comment: "Yearly salary period option", message: "Yearly" });
@@ -87,7 +87,7 @@ export function SalaryOverride({
             type="number"
             value={min}
             onChange={(e) => handleChange("min", e.target.value)}
-            placeholder={crawlerSalary.min?.toLocaleString() ?? "—"}
+            placeholder={crawlerSalary.min?.toLocaleString(i18n.locale) ?? "—"}
             className="w-full rounded border border-border-soft bg-surface px-2 py-1 text-xs placeholder:text-muted/50"
           />
         </div>
@@ -97,7 +97,7 @@ export function SalaryOverride({
             type="number"
             value={max}
             onChange={(e) => handleChange("max", e.target.value)}
-            placeholder={crawlerSalary.max?.toLocaleString() ?? "—"}
+            placeholder={crawlerSalary.max?.toLocaleString(i18n.locale) ?? "—"}
             className="w-full rounded border border-border-soft bg-surface px-2 py-1 text-xs placeholder:text-muted/50"
           />
         </div>

--- a/apps/web/src/components/search/company-card.tsx
+++ b/apps/web/src/components/search/company-card.tsx
@@ -216,7 +216,8 @@ export function sortPostingsByFreshness(
   return [...postings].sort((a, b) => {
     const byTime = firstSeenAtMs(b) - firstSeenAtMs(a);
     if (byTime !== 0) return byTime;
-    return a.id.localeCompare(b.id);
+    if (a.id === b.id) return 0;
+    return a.id < b.id ? -1 : 1;
   });
 }
 

--- a/apps/web/src/lib/actions/__tests__/locations-locale-sort.test.ts
+++ b/apps/web/src/lib/actions/__tests__/locations-locale-sort.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
+  search: vi.fn(),
+  dbExecute: vi.fn(),
+  cached: vi.fn((_key: string, fn: () => unknown) => fn()),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/cache", () => ({
+  cacheLife: mocks.cacheLife,
+  cacheTag: mocks.cacheTag,
+}));
+vi.mock("@/lib/cache", () => ({ cached: mocks.cached }));
+vi.mock("@/lib/cache-tags", () => ({ typeaheadLocationsCacheTag: () => "tag" }));
+vi.mock("@/lib/search/typesense-client", () => ({
+  getTypesenseClient: () => ({
+    collections: () => ({ documents: () => ({ search: mocks.search }) }),
+  }),
+}));
+vi.mock("@/db", () => ({ db: { execute: mocks.dbExecute } }));
+vi.mock("drizzle-orm", () => ({
+  sql: (strings: TemplateStringsArray, ..._values: unknown[]) =>
+    strings.join("?"),
+}));
+vi.mock("@/lib/search/typesense-filters", () => ({
+  buildFilterString: () => "",
+  POSTING_BASE_FILTER: "is_active:true",
+}));
+vi.mock("@/lib/search/typeahead-boost", () => ({
+  boostByFilterMatches: (xs: unknown) => xs,
+}));
+
+import { getGlobalLocationsGrouped } from "../locations";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("getGlobalLocationsGrouped — locale-aware display sorting", () => {
+  it("sorts country names with the caller locale", async () => {
+    mocks.dbExecute
+      .mockResolvedValueOnce([
+        { id: 100, slug: "austria", type: "country", parent_id: null },
+        { id: 200, slug: "switzerland", type: "country", parent_id: null },
+        { id: 300, slug: "zambia", type: "country", parent_id: null },
+      ])
+      .mockResolvedValueOnce([
+        { location_id: 100, locale: "sv", name: "Österreich" },
+        { location_id: 200, locale: "sv", name: "Schweiz" },
+        { location_id: 300, locale: "sv", name: "Zambia" },
+      ]);
+
+    mocks.search.mockResolvedValue({
+      facet_counts: [
+        {
+          field_name: "location_ids",
+          counts: [
+            { value: "100", count: 1 },
+            { value: "200", count: 1 },
+            { value: "300", count: 1 },
+          ],
+        },
+      ],
+    });
+
+    const out = await getGlobalLocationsGrouped("sv");
+
+    expect(out.countries.map((c) => c.countryName)).toEqual([
+      "Schweiz",
+      "Zambia",
+      "Österreich",
+    ]);
+  });
+});

--- a/apps/web/src/lib/actions/locations.ts
+++ b/apps/web/src/lib/actions/locations.ts
@@ -11,7 +11,7 @@ import { getTypesenseClient, type TypesenseHit } from "@/lib/search/typesense-cl
 import { buildFilterString, POSTING_BASE_FILTER } from "@/lib/search/typesense-filters";
 import { boostByFilterMatches, type TypeaheadBoostFilters } from "@/lib/search/typeahead-boost";
 import { canonicalizeFilters } from "@/lib/search/canonicalize-filters";
-import { canonicalStringCompare } from "@/lib/sort";
+import { canonicalStringCompare, makeDisplayStringCompare } from "@/lib/sort";
 import { LOCATION_PAGE_SIZE } from "@/lib/search/location-paging";
 
 export interface LocationSuggestion {
@@ -929,11 +929,12 @@ async function _fetchGlobalLocationsGrouped(
     // city" filter dropped countries whose postings are tagged purely at
     // the country level — a regression introduced alongside #3033's
     // sum-of-children count.
+    const compareCountryNames = makeDisplayStringCompare(locale);
     const sortedCountries = [...countries.values()]
       .filter((g) => g.countryCount > 0 || g.regions.some((r) => r.locations.length > 0))
       .sort((a, b) => {
         // Sort by country name alphabetically
-        return a.countryName.localeCompare(b.countryName);
+        return compareCountryNames(a.countryName, b.countryName);
       });
 
     return { macros, countries: sortedCountries };

--- a/apps/web/src/lib/blog.ts
+++ b/apps/web/src/lib/blog.ts
@@ -202,7 +202,12 @@ export async function listBlogPosts(locale?: Locale): Promise<BlogPostSummary[]>
     // but the type system needs a fallthrough.
     throw new Error(`[blog] post '${slug}' disappeared between listdir and read`);
   }));
-  return posts.sort((a, b) => b.datePublished.localeCompare(a.datePublished));
+  return posts.sort((a, b) => compareIsoDateDesc(a.datePublished, b.datePublished));
+}
+
+function compareIsoDateDesc(a: string, b: string): number {
+  if (a === b) return 0;
+  return a < b ? 1 : -1;
 }
 
 /**
@@ -333,7 +338,7 @@ export function selectRelatedPosts(
       .filter(({ overlap }) => overlap > 0)
       .sort((a, b) => {
         if (b.overlap !== a.overlap) return b.overlap - a.overlap;
-        return b.post.datePublished.localeCompare(a.post.datePublished);
+        return compareIsoDateDesc(a.post.datePublished, b.post.datePublished);
       });
     for (const { post } of scored) {
       picked.push(post);
@@ -344,7 +349,7 @@ export function selectRelatedPosts(
   // 3. Recency fallback.
   const remaining = others
     .filter((p) => !picked.some((q) => q.slug === p.slug))
-    .sort((a, b) => b.datePublished.localeCompare(a.datePublished));
+    .sort((a, b) => compareIsoDateDesc(a.datePublished, b.datePublished));
   for (const post of remaining) {
     picked.push(post);
     if (picked.length >= max) return picked;


### PR DESCRIPTION
## Summary
- Pass the active UI locale to remaining display number formatting call sites.
- Sort location country names with the caller locale, and replace canonical date/id `localeCompare` tie-breaks with deterministic comparisons.
- Add focused regression tests plus an ESLint guard for future implicit locale formatting.

## Reproduction
- Audited open issue #3146 against current `origin/main` and found the interview/watchlist paths already fixed, but remaining no-locale number formatting and one-argument `localeCompare` call sites still existed in app/web source.
- Production probing was not relevant for this code-path audit; no production writes or Supabase writes were performed.

## Validation
- `pnpm exec vitest run src/components/my-jobs/__tests__/salary-override.test.tsx src/lib/actions/__tests__/locations-locale-sort.test.ts src/lib/actions/__tests__/locations-hierarchical-counts.test.ts --reporter=dot`
- `pnpm --filter @jobseek/web lint`
- `pnpm --filter @jobseek/web typecheck`
- `git diff --check`

Closes #3146
