### PR TITLE
Fix unsupported company OG icons

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/opengraph-image-prebake.test.ts
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/opengraph-image-prebake.test.ts
@@ -29,3 +29,61 @@ describe("company opengraph image route rendering mode", () => {
     expect("generateStaticParams" in ogImage).toBe(false);
   });
 });
+
+describe("company opengraph image icon rendering", () => {
+  it("only passes known raster icon URLs to next/og", () => {
+    expect(
+      ogImage.getRenderableCompanyOgIconUrl(
+        "https://jobseek-assets.colophon-group.org/companies/acme/icon.png",
+      ),
+    ).toBe("https://jobseek-assets.colophon-group.org/companies/acme/icon.png");
+    expect(
+      ogImage.getRenderableCompanyOgIconUrl(
+        "https://jobseek-assets.colophon-group.org/companies/acme/icon.jpg?version=1",
+      ),
+    ).toBe("https://jobseek-assets.colophon-group.org/companies/acme/icon.jpg?version=1");
+    expect(
+      ogImage.getRenderableCompanyOgIconUrl(
+        "https://jobseek-assets.colophon-group.org/companies/acme/icon.jpeg",
+      ),
+    ).toBe("https://jobseek-assets.colophon-group.org/companies/acme/icon.jpeg");
+
+    expect(
+      ogImage.getRenderableCompanyOgIconUrl(
+        "https://jobseek-assets.colophon-group.org/companies/graphcore/icon.svg",
+      ),
+    ).toBeNull();
+    expect(
+      ogImage.getRenderableCompanyOgIconUrl(
+        "https://jobseek-assets.colophon-group.org/companies/acme/icon.webp",
+      ),
+    ).toBeNull();
+    expect(ogImage.getRenderableCompanyOgIconUrl("/local/icon.png")).toBeNull();
+  });
+
+  it("uses a deterministic fallback mark for unsupported remote icons", () => {
+    expect(
+      ogImage.getCompanyOgIconRenderModel({
+        name: "Graphcore",
+        icon: "https://jobseek-assets.colophon-group.org/companies/graphcore/icon.svg",
+      }),
+    ).toEqual({ kind: "fallback", label: "GR" });
+
+    expect(
+      ogImage.getCompanyOgIconRenderModel({
+        name: "Acme Labs",
+        icon: "https://jobseek-assets.colophon-group.org/companies/acme/icon.png",
+      }),
+    ).toEqual({
+      kind: "image",
+      src: "https://jobseek-assets.colophon-group.org/companies/acme/icon.png",
+    });
+
+    expect(
+      ogImage.getCompanyOgIconRenderModel({
+        name: "Acme Labs",
+        icon: null,
+      }),
+    ).toEqual({ kind: "none" });
+  });
+});

--- a/apps/web/app/[lang]/(app)/company/[slug]/opengraph-image.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/opengraph-image.tsx
@@ -86,11 +86,68 @@ function renderNotFound(fontData: Buffer): ImageResponse {
   );
 }
 
+const RENDERABLE_COMPANY_OG_ICON_EXTENSIONS = new Set([".png", ".jpg", ".jpeg"]);
+
+type CompanyOgIconRenderModel =
+  | { kind: "image"; src: string }
+  | { kind: "fallback"; label: string }
+  | { kind: "none" };
+
+function parseHttpUrl(value: string | null | undefined): URL | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:" ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getRenderableCompanyOgIconUrl(
+  icon: string | null | undefined,
+): string | null {
+  const url = parseHttpUrl(icon);
+  if (!url) return null;
+
+  const pathname = url.pathname.toLowerCase();
+  for (const extension of RENDERABLE_COMPANY_OG_ICON_EXTENSIONS) {
+    if (pathname.endsWith(extension)) return icon!;
+  }
+  return null;
+}
+
+export function getCompanyOgFallbackInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) {
+    return parts
+      .slice(0, 2)
+      .map((part) => Array.from(part)[0])
+      .join("")
+      .toUpperCase();
+  }
+
+  const firstPart = parts[0] ?? "";
+  return Array.from(firstPart).slice(0, 2).join("").toUpperCase() || "?";
+}
+
+export function getCompanyOgIconRenderModel(
+  company: Pick<CompanyDetail, "icon" | "name">,
+): CompanyOgIconRenderModel {
+  const src = getRenderableCompanyOgIconUrl(company.icon);
+  if (src) return { kind: "image", src };
+
+  // `next/og` logs noisy parse errors for some valid-but-unsupported SVGs
+  // and does not support WebP reliably in this renderer path. Keep the card
+  // stable with a deterministic mark instead of handing those URLs to Satori.
+  if (parseHttpUrl(company.icon)) {
+    return { kind: "fallback", label: getCompanyOgFallbackInitials(company.name) };
+  }
+
+  return { kind: "none" };
+}
+
 function renderCompanyImage(company: CompanyDetail, fontData: Buffer): ImageResponse {
-  const hasIcon =
-    company.icon &&
-    company.icon.startsWith("http") &&
-    !company.icon.toLowerCase().endsWith(".webp");
+  const icon = getCompanyOgIconRenderModel(company);
 
   return new ImageResponse(
     <div
@@ -107,13 +164,33 @@ function renderCompanyImage(company: CompanyDetail, fontData: Buffer): ImageResp
     >
       {/* Top: company icon + name */}
       <div style={{ display: "flex", alignItems: "center", gap: "24px" }}>
-        {hasIcon && (
+        {icon.kind === "image" && (
           <img
-            src={company.icon!}
+            src={icon.src}
             width={72}
             height={72}
             style={{ borderRadius: 12 }}
           />
+        )}
+        {icon.kind === "fallback" && (
+          <div
+            style={{
+              width: 72,
+              height: 72,
+              borderRadius: 12,
+              backgroundColor: "#18181b",
+              border: "1px solid #27272a",
+              color: "#fafafa",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 28,
+              fontWeight: 700,
+              lineHeight: 1,
+            }}
+          >
+            {icon.label}
+          </div>
         )}
         <span style={{ fontSize: 52, fontWeight: 700 }}>{company.name}</span>
       </div>


### PR DESCRIPTION
## Summary
- fixes #3525 by preventing unsupported remote SVG/WebP company icons from being handed to `next/og`
- keeps known raster company icons (`png`, `jpg`, `jpeg`) rendered as images
- adds a deterministic initials fallback for unsupported remote icons so OG cards remain stable without noisy renderer logs

## Reproduction / prod probe
- Production Vercel logs show Graphcore OG generation logging: `Failed to parse SVG image: Invalid character` while returning a 200 PNG.
- Direct Graphcore SVG asset returns `200 image/svg+xml` and validates as XML, so the issue is the `next/og` renderer path rather than the asset endpoint.
- Local `ImageResponse` reproduction with the Graphcore SVG logs the same parser error.

## Validation
- `pnpm --filter @jobseek/web exec vitest run 'app/[lang]/(app)/company/[slug]/__tests__/opengraph-image-prebake.test.ts' 'app/[lang]/(app)/company/[slug]/__tests__/opengraph-image-cache.test.ts'`
- `pnpm --filter @jobseek/web lint`
- `pnpm --filter @jobseek/web typecheck`
- `git diff --check`
