### PR TITLE
Remove unused trace viewer load state

### DIFF
--- a/apps/trace-viewer/src/App.tsx
+++ b/apps/trace-viewer/src/App.tsx
@@ -30,7 +30,6 @@ function App() {
     activeBundle,
     activeHeader,
     activateBundle,
-    serverLoaded,
     serverAttempted,
   } = useTrace()
 


### PR DESCRIPTION
## Summary
- stop destructuring the unused serverLoaded value in the trace viewer App component

## Verification
- Baseline before edit: pnpm --filter @jobseek/trace-viewer typecheck
- Baseline before edit: pnpm --filter @jobseek/trace-viewer build
- pnpm --filter @jobseek/trace-viewer typecheck
- pnpm --filter @jobseek/trace-viewer build
- git diff --check

Targets GitHub Code Quality finding #44 (js/unused-local-variable).