### PR TITLE
Remove unused markdown code language state

### DIFF
--- a/apps/trace-viewer/src/lib/markdown.ts
+++ b/apps/trace-viewer/src/lib/markdown.ts
@@ -17,7 +17,6 @@ export function markdownToHtml(text: string): string {
   const out: string[] = []
   let inCodeBlock = false
   let codeLines: string[] = []
-  let codeLang = ''
   let inList = false
 
   for (const line of lines) {
@@ -35,7 +34,6 @@ export function markdownToHtml(text: string): string {
           inList = false
         }
         inCodeBlock = true
-        codeLang = line.trim().slice(3)
       }
       continue
     }


### PR DESCRIPTION
## Summary
- remove the unused markdown codeLang variable and assignment from the trace viewer markdown converter
- preserve current markdown output behavior; fenced language tags were already ignored

## Verification
- Baseline before edit: pnpm --filter @jobseek/trace-viewer typecheck
- Baseline before edit: pnpm --filter @jobseek/trace-viewer build
- pnpm --filter @jobseek/trace-viewer typecheck
- pnpm --filter @jobseek/trace-viewer build
- git diff --check

Targets GitHub Code Quality finding #45 (js/useless-assignment-to-local).