### PR TITLE
Add schema enum semicolon

### DIFF
--- a/apps/web/drizzle/schema.ts
+++ b/apps/web/drizzle/schema.ts
@@ -1,7 +1,7 @@
 import { pgTable, text, integer, uuid, timestamp, numeric, uniqueIndex, index, foreignKey, unique, serial, boolean, jsonb, smallint, real, check, bigint, primaryKey, pgEnum } from "drizzle-orm/pg-core"
 import { sql } from "drizzle-orm"
 
-export const locationType = pgEnum("location_type", ['macro', 'country', 'region', 'city'])
+export const locationType = pgEnum("location_type", ['macro', 'country', 'region', 'city']);
 
 
 export const enrichBatch = pgTable("enrich_batch", {


### PR DESCRIPTION
## Summary
- add the missing semicolon to the locationType Drizzle enum export

## Verification
- Baseline before edit: pnpm --filter @jobseek/web exec eslint drizzle/schema.ts
- Baseline before edit: pnpm --filter @jobseek/web exec tsc --noEmit --pretty false
- pnpm --filter @jobseek/web exec eslint drizzle/schema.ts
- pnpm --filter @jobseek/web exec tsc --noEmit --pretty false
- git diff --check

Targets GitHub Code Quality finding #43 (js/automatic-semicolon-insertion).