### PR TITLE
Add explicit Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,101 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:00"
+      timezone: "Etc/UTC"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "04:30"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 10
+    exclude-paths:
+      - "apps/crawler/murmur/**"
+      - "apps/murmur-shim/**"
+    groups:
+      next-react:
+        patterns:
+          - "next"
+          - "@next/*"
+          - "react"
+          - "react-dom"
+      lingui:
+        patterns:
+          - "@lingui/*"
+      typesense:
+        patterns:
+          - "typesense"
+      test-tooling:
+        dependency-type: "development"
+        patterns:
+          - "@testing-library/*"
+          - "@vitest/*"
+          - "vitest"
+
+  - package-ecosystem: "uv"
+    directory: "/apps/crawler"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:00"
+      timezone: "Etc/UTC"
+
+  - package-ecosystem: "uv"
+    directory: "/apps/crawler/ws-package"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:15"
+      timezone: "Etc/UTC"
+
+  - package-ecosystem: "uv"
+    directory: "/apps/web/script"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "05:30"
+      timezone: "Etc/UTC"
+
+  - package-ecosystem: "docker"
+    directory: "/apps/web"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+
+  - package-ecosystem: "docker"
+    directory: "/apps/crawler"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:15"
+      timezone: "Etc/UTC"
+
+  - package-ecosystem: "docker-compose"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "Etc/UTC"
+
+  - package-ecosystem: "docker-compose"
+    directory: "/apps/crawler"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:45"
+      timezone: "Etc/UTC"


### PR DESCRIPTION
## Summary
- fixes #3089 by adding checked-in `.github/dependabot.yml`
- schedules weekly version updates for GitHub Actions, the root pnpm workspace, uv lockfiles, Dockerfiles, and Docker Compose files
- groups high-churn npm families (`next`/React, Lingui, Typesense, test tooling) and excludes Murmur-specific npm workspace paths while Murmur work is on hold

## Reproduction / probe
- `find .github -name dependabot.yml -o -name dependabot.yaml` returned no checked-in config.
- `gh api repos/colophon-group/jobseek/actions/workflows --jq '.workflows[] | select(.name | test("Dependabot"; "i")) | {name, state, path}'` showed an active dynamic `Dependabot Updates` workflow.
- No production write/probe is relevant for this repo config-only issue.

## Validation
- `ruby -e "require 'yaml'; data = YAML.load_file('.github/dependabot.yml'); abort 'bad version' unless data['version'] == 2; abort 'missing updates' unless data['updates'].is_a?(Array) && data['updates'].size == 9; puts 'dependabot YAML ok'"`
- structural Ruby check that every configured ecosystem/directory points at existing manifests or lockfiles
- `git diff --check`
