### PR TITLE
Reduce CI for non-code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,8 @@ env:
 jobs:
   dependency-review:
     name: Dependency Review
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -67,41 +68,44 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Test change classifier
+        run: node scripts/ci-classify-changes.test.mjs
+
       - name: Check for code changes
         id: filter
+        shell: bash
         run: |
+          set -euo pipefail
+
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "code=true" >> "$GITHUB_OUTPUT"
             echo "crawler_code=false" >> "$GITHUB_OUTPUT"
             echo "boards_csv=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
           if [ "${{ github.event_name }}" = "push" ]; then
-            FILES=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || echo "force")
+            BEFORE="${{ github.event.before }}"
+            AFTER="${{ github.sha }}"
+            ZERO_SHA="0000000000000000000000000000000000000000"
+
+            if [ -n "$BEFORE" ] && [ "$BEFORE" != "$ZERO_SHA" ]; then
+              if ! FILES=$(git diff --name-only "$BEFORE" "$AFTER" 2>/dev/null); then
+                FILES=force
+              fi
+            elif ! FILES=$(git diff-tree --no-commit-id --name-only -r "$AFTER" 2>/dev/null); then
+              FILES=force
+            fi
           else
             # Use paginated files API — gh pr diff fails on large diffs (>20k lines)
-            FILES=$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --jq '.[].filename' 2>/dev/null || echo "force")
+            if ! FILES=$(gh api --paginate "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" --jq '.[].filename' 2>/dev/null); then
+              FILES=force
+            fi
           fi
-          CODE=false
-          CRAWLER_CODE=false
-          BOARDS_CSV=false
-          while IFS= read -r f; do
-            [ -z "$f" ] && continue
-            case "$f" in
-              force) CODE=true; CRAWLER_CODE=true ;;
-              apps/crawler/data/boards.csv) BOARDS_CSV=true ;;
-              apps/crawler/data/*) ;;
-              apps/crawler/traces/*) ;;
-              apps/crawler/VERSION) ;;
-              *.md) ;;
-              apps/crawler/*) CODE=true; CRAWLER_CODE=true ;;
-              *) CODE=true ;;
-            esac
-          done <<< "$FILES"
-          echo "code=$CODE" >> "$GITHUB_OUTPUT"
-          echo "crawler_code=$CRAWLER_CODE" >> "$GITHUB_OUTPUT"
-          echo "boards_csv=$BOARDS_CSV" >> "$GITHUB_OUTPUT"
-          echo "Code changes detected: $CODE (crawler: $CRAWLER_CODE, boards.csv: $BOARDS_CSV)"
+
+          RESULTS="$(printf '%s\n' "$FILES" | node scripts/ci-classify-changes.mjs)"
+          printf '%s\n' "$RESULTS" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$RESULTS"
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -642,7 +646,7 @@ jobs:
           requireSuccess("workflow-security");
           requireSuccess("changes");
           requireSuccess("data-validation");
-          requireSuccess("dependency-review", eventName === "pull_request");
+          requireSuccess("dependency-review", eventName === "pull_request" && code);
 
           for (const job of [
             "lint-web",

--- a/.github/workflows/deploy-crawler-browser.yml
+++ b/.github/workflows/deploy-crawler-browser.yml
@@ -6,6 +6,9 @@ on:
     paths:
       - 'apps/crawler/**'
       - '!apps/crawler/data/**'
+      - '!apps/crawler/traces/**'
+      - '!apps/crawler/*.md'
+      - '!apps/crawler/**/*.md'
       - '.github/workflows/deploy-crawler-browser.yml'
 
 env:

--- a/scripts/ci-classify-changes.mjs
+++ b/scripts/ci-classify-changes.mjs
@@ -1,0 +1,102 @@
+import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const FORCE_SENTINEL = "force";
+
+function isUnder(path, prefix) {
+  return path === prefix || path.startsWith(`${prefix}/`);
+}
+
+export function isNonCodePath(path) {
+  if (path.endsWith(".md")) {
+    return true;
+  }
+
+  if (isUnder(path, "docs")) {
+    return true;
+  }
+
+  if (path === ".github/dependabot.yml" || path === ".github/dependabot.yaml") {
+    return true;
+  }
+
+  if (isUnder(path, ".github/ISSUE_TEMPLATE")) {
+    return true;
+  }
+
+  if (isUnder(path, ".github/DISCUSSION_TEMPLATE")) {
+    return true;
+  }
+
+  if (isUnder(path, "apps/crawler/data")) {
+    return true;
+  }
+
+  if (isUnder(path, "apps/crawler/traces")) {
+    return true;
+  }
+
+  if (path === "apps/crawler/VERSION") {
+    return true;
+  }
+
+  return false;
+}
+
+export function classifyChanges(files) {
+  const result = {
+    code: false,
+    crawler_code: false,
+    boards_csv: false,
+  };
+
+  for (const rawFile of files) {
+    const file = rawFile.trim();
+    if (!file) {
+      continue;
+    }
+
+    if (file === FORCE_SENTINEL) {
+      result.code = true;
+      result.crawler_code = true;
+      continue;
+    }
+
+    if (file === "apps/crawler/data/boards.csv") {
+      result.boards_csv = true;
+      continue;
+    }
+
+    if (isNonCodePath(file)) {
+      continue;
+    }
+
+    if (isUnder(file, "apps/crawler")) {
+      result.code = true;
+      result.crawler_code = true;
+      continue;
+    }
+
+    result.code = true;
+  }
+
+  return result;
+}
+
+function readInputFiles() {
+  if (process.argv.length > 2) {
+    return process.argv.slice(2);
+  }
+
+  return readFileSync(0, "utf8").split(/\r?\n/);
+}
+
+function printOutput(result) {
+  for (const [key, value] of Object.entries(result)) {
+    console.log(`${key}=${value ? "true" : "false"}`);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  printOutput(classifyChanges(readInputFiles()));
+}

--- a/scripts/ci-classify-changes.test.mjs
+++ b/scripts/ci-classify-changes.test.mjs
@@ -1,0 +1,107 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { classifyChanges, isNonCodePath } from "./ci-classify-changes.mjs";
+
+test("classifies Markdown-only and docs-only changes as non-code", () => {
+  assert.deepEqual(
+    classifyChanges([
+      "README.md",
+      "apps/crawler/AGENTS.md",
+      "docs/16-hetzner-maintenance.md",
+      "docs/images/diagram.png",
+    ]),
+    {
+      code: false,
+      crawler_code: false,
+      boards_csv: false,
+    },
+  );
+});
+
+test("classifies Dependabot and issue template metadata as non-code", () => {
+  assert.deepEqual(
+    classifyChanges([
+      ".github/dependabot.yml",
+      ".github/dependabot.yaml",
+      ".github/ISSUE_TEMPLATE/bug.yml",
+      ".github/DISCUSSION_TEMPLATE/idea.yml",
+    ]),
+    {
+      code: false,
+      crawler_code: false,
+      boards_csv: false,
+    },
+  );
+});
+
+test("keeps workflow and script changes in the code lane", () => {
+  assert.deepEqual(
+    classifyChanges([
+      ".github/workflows/ci.yml",
+      ".github/scripts/close-linked-company-request-issues.sh",
+      "scripts/ci-classify-changes.mjs",
+    ]),
+    {
+      code: true,
+      crawler_code: false,
+      boards_csv: false,
+    },
+  );
+});
+
+test("marks crawler source changes as crawler code", () => {
+  assert.deepEqual(classifyChanges(["apps/crawler/src/cli.py"]), {
+    code: true,
+    crawler_code: true,
+    boards_csv: false,
+  });
+});
+
+test("keeps crawler data and traces out of the code lane", () => {
+  assert.deepEqual(
+    classifyChanges([
+      "apps/crawler/data/companies.csv",
+      "apps/crawler/data/images/acme.png",
+      "apps/crawler/traces/acme/raw.html",
+    ]),
+    {
+      code: false,
+      crawler_code: false,
+      boards_csv: false,
+    },
+  );
+});
+
+test("flags boards.csv for targeted board probes without full code CI", () => {
+  assert.deepEqual(classifyChanges(["apps/crawler/data/boards.csv"]), {
+    code: false,
+    crawler_code: false,
+    boards_csv: true,
+  });
+});
+
+test("uses the force sentinel when file discovery fails", () => {
+  assert.deepEqual(classifyChanges(["force"]), {
+    code: true,
+    crawler_code: true,
+    boards_csv: false,
+  });
+});
+
+test("does not let non-code files hide code in mixed changes", () => {
+  assert.deepEqual(
+    classifyChanges(["docs/runbook.md", "apps/web/src/app/page.tsx"]),
+    {
+      code: true,
+      crawler_code: false,
+      boards_csv: false,
+    },
+  );
+});
+
+test("documents individual non-code path predicates", () => {
+  assert.equal(isNonCodePath(".github/dependabot.yml"), true);
+  assert.equal(isNonCodePath("apps/crawler/data/boards.csv"), true);
+  assert.equal(isNonCodePath(".github/workflows/ci.yml"), false);
+});


### PR DESCRIPTION
## Summary
- add a tested CI change classifier and use it from the CI workflow
- skip heavy CI and dependency review for conservative non-code paths such as docs, crawler traces/data, issue templates, and Dependabot config
- compare push event before..after SHAs instead of only HEAD~1..HEAD so multi-commit pushes are classified by the full pushed range
- stop Deploy Crawler from running for crawler Markdown/traces while preserving deploys for crawler code and deploy workflow edits

## Reproduction
- #3533 changed only apps/crawler/AGENTS.md and docs/16-hetzner-maintenance.md; main CI skipped the heavy matrix, but Deploy Crawler still ran for ~5.5 minutes and CodeQL ran.
- #3539 changed only .github/dependabot.yml; the current classifier treated it as code and started the heavy CI matrix. CodeQL also ran, but I left CodeQL triggers untouched because ruleset main-strict-gate explicitly requires Analyze (actions), Analyze (javascript-typescript), and Analyze (python).

## Validation
- node scripts/ci-classify-changes.test.mjs
- direct classifier probes for #3533 and #3539 file sets
- git diff --check
- node --check scripts/ci-classify-changes.mjs && node --check scripts/ci-classify-changes.test.mjs
- actionlint v1.7.12 on edited workflows
- uvx --from zizmor==1.26.1 zizmor --persona regular --min-severity medium --min-confidence high .github/workflows/ci.yml .github/workflows/deploy-crawler-browser.yml

Closes #3534