### PR TITLE
Ignore crawler Pillow in Dependabot uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,6 +51,11 @@ updates:
       day: "monday"
       time: "05:00"
       timezone: "Etc/UTC"
+    ignore:
+      # Dependabot's uv updater currently errors with
+      # dependency_file_content_not_changed for this crawler entry before
+      # invoking uv; sibling uv projects still receive Pillow updates.
+      - dependency-name: "pillow"
 
   - package-ecosystem: "uv"
     directory: "/apps/crawler/ws-package"


### PR DESCRIPTION
## Summary
- add a scoped ignore for crawler Pillow updates in the explicit Dependabot uv config
- document the observed Dependabot updater failure from the post-merge #3089 run
- leave sibling uv projects eligible for Pillow updates

## Reproduction / monitoring
- Post-merge Dependabot Updates run 28810806897 failed for `uv in /apps/crawler` with `dependency_file_content_not_changed` on `pillow` before invoking `uv`.
- Local `uv lock --upgrade-package pillow==12.3.0` in `apps/crawler` produced a real lockfile diff, so this is scoped to Dependabot's updater behavior.

## Validation
- YAML parse and shape check for `.github/dependabot.yml`
- structural manifest/directory check for every Dependabot entry
- `git diff --check`

Follow-up for #3089.
