### PR TITLE
Group AWS SDK Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,9 @@ updates:
       typesense:
         patterns:
           - "typesense"
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
       test-tooling:
         dependency-type: "development"
         patterns:


### PR DESCRIPTION
## Summary
- group `@aws-sdk/*` root npm updates under the explicit Dependabot config
- keep AWS SDK updates covered while avoiding a failing ungrouped root update path

## Reproduction / monitoring
- Post-merge Dependabot Updates run 28815403744 failed while updating `@aws-sdk/client-s3` because its latest release briefly resolved to an unavailable `@aws-sdk/core` version.
- The registry metadata later resolved, but Dependabot update runs cannot be rerun directly; grouping the package family gives this config a fresh validation path without disabling AWS SDK updates.

## Validation
- YAML parse and shape check for `.github/dependabot.yml`
- structural manifest/directory check for every Dependabot entry, including the `aws-sdk` npm group
- `git diff --check`

Follow-up for #3089.
