### PR TITLE
Return 400 for missing API v1 params

### DIFF
--- a/apps/web/app/api/v1/_shared.test.ts
+++ b/apps/web/app/api/v1/_shared.test.ts
@@ -104,3 +104,12 @@ describe("checkRateLimit — Redis bypass observability (#3175)", () => {
     expect(result && "status" in result && result.status).toBe(429);
   });
 });
+
+describe("apiResponse status contract (#3213)", () => {
+  it("uses 200 by default but honors explicit non-2xx status codes", async () => {
+    const { apiResponse } = await import("./_shared");
+
+    expect(apiResponse({ ok: true }).status).toBe(200);
+    expect(apiResponse({ error: "Bad request" }, { status: 400 }).status).toBe(400);
+  });
+});

--- a/apps/web/app/api/v1/_shared.ts
+++ b/apps/web/app/api/v1/_shared.ts
@@ -41,10 +41,19 @@ export async function checkRateLimit(
   return null;
 }
 
-/** Build a JSON response with standard headers. */
+/** Build a JSON response with standard API headers.
+ *
+ * Public `/api/v1/*` contract errors should pass an explicit non-2xx status
+ * so standard `response.ok` callers do not treat malformed requests as
+ * successful empty payloads.
+ */
 export function apiResponse(
   data: unknown,
-  options?: { maxAge?: number; rateLimit?: RateLimitInfo | null },
+  options?: {
+    maxAge?: number;
+    rateLimit?: RateLimitInfo | null;
+    status?: number;
+  },
 ): NextResponse {
   const maxAge = options?.maxAge ?? CACHE_TTL_MEDIUM;
   const headers: Record<string, string> = {
@@ -57,7 +66,7 @@ export function apiResponse(
     headers["X-RateLimit-Remaining"] = String(options.rateLimit.remaining);
     headers["X-RateLimit-Reset"] = String(options.rateLimit.reset);
   }
-  return NextResponse.json(data, { headers });
+  return NextResponse.json(data, { headers, status: options?.status });
 }
 
 /** Build the full URL to the site for a given path. */

--- a/apps/web/app/api/v1/companies/route.test.ts
+++ b/apps/web/app/api/v1/companies/route.test.ts
@@ -36,6 +36,15 @@ describe("GET /api/v1/companies service boundary (#3331)", () => {
     mocks.suggestCompanies.mockReset();
   });
 
+  it("returns 400 when the required `q` param is missing (#3213)", async () => {
+    const res = await GET(makeReq("?locale=en"));
+    const body = (await res.json()) as { error?: string };
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/Missing required 'q' param/);
+    expect(mocks.suggestCompanies).not.toHaveBeenCalled();
+  });
+
   it("resolves company suggestions through the service tier", async () => {
     mocks.suggestCompanies.mockResolvedValue([
       {

--- a/apps/web/app/api/v1/companies/route.ts
+++ b/apps/web/app/api/v1/companies/route.ts
@@ -19,7 +19,7 @@ export async function GET(request: NextRequest) {
   if (!q) {
     return apiResponse(
       { error: "Missing required 'q' param (company name query)" },
-      { maxAge: 0 },
+      { maxAge: 0, status: 400 },
     );
   }
 

--- a/apps/web/app/api/v1/job/route.test.ts
+++ b/apps/web/app/api/v1/job/route.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  apiLimiter: {
+    limit: vi.fn(async () => {
+      throw new Error("no redis in unit tests");
+    }),
+  },
+  getClientIp: () => "test-ip",
+}));
+
+const mocks = vi.hoisted(() => ({
+  getPostingDetail: vi.fn(),
+}));
+
+vi.mock("@/lib/services/search", () => ({
+  getPostingDetail: mocks.getPostingDetail,
+}));
+
+import { GET } from "./route";
+
+function makeReq(qs: string): NextRequest {
+  return new NextRequest(`http://localhost/api/v1/job${qs}`);
+}
+
+async function callRoute(qs: string) {
+  const res = await GET(makeReq(qs));
+  const body = (await res.json()) as { error?: string };
+  return { res, body };
+}
+
+describe("GET /api/v1/job status contract (#3213)", () => {
+  beforeEach(() => {
+    mocks.getPostingDetail.mockReset();
+  });
+
+  it("returns 400 when the required `id` param is missing", async () => {
+    const { res, body } = await callRoute("?locale=en");
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Missing required parameter: id");
+    expect(mocks.getPostingDetail).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when the requested posting is not found", async () => {
+    mocks.getPostingDetail.mockResolvedValue(null);
+
+    const { res, body } = await callRoute("?id=missing&locale=de");
+
+    expect(res.status).toBe(404);
+    expect(body.error).toBe("Job posting not found");
+    expect(mocks.getPostingDetail).toHaveBeenCalledWith({
+      postingId: "missing",
+      locale: "de",
+    });
+  });
+});

--- a/apps/web/app/api/v1/job/route.ts
+++ b/apps/web/app/api/v1/job/route.ts
@@ -12,18 +12,18 @@ export async function GET(request: NextRequest) {
   const locale = sp.get("locale") ?? "en";
 
   if (!id) {
-    return NextResponse.json(
+    return apiResponse(
       { error: "Missing required parameter: id" },
-      { status: 400 },
+      { maxAge: 0, status: 400 },
     );
   }
 
   const detail = await getPostingDetail({ postingId: id, locale });
 
   if (!detail) {
-    return NextResponse.json(
+    return apiResponse(
       { error: "Job posting not found" },
-      { status: 404 },
+      { maxAge: 0, status: 404 },
     );
   }
 

--- a/apps/web/app/api/v1/resolve/route.test.ts
+++ b/apps/web/app/api/v1/resolve/route.test.ts
@@ -82,6 +82,22 @@ describe("GET /api/v1/resolve?type=industries (issue #3228)", () => {
     mocks.suggestIndustries.mockReset();
   });
 
+  it("returns 400 when the required `type` param is missing (#3213)", async () => {
+    const { res, body } = await call("?q=tech");
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/Missing or invalid 'type' param/);
+    expect(mocks.suggestIndustries).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when the required `q` param is missing or too short (#3213)", async () => {
+    const { res, body } = await call("?type=industries&q=t");
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Missing or too short 'q' param (min 2 chars)");
+    expect(mocks.suggestIndustries).not.toHaveBeenCalled();
+  });
+
   it("emits a slug-shaped string for each industry, NOT the stringified id", async () => {
     mocks.suggestIndustries.mockResolvedValue([
       { id: 3, name: "Technology" },

--- a/apps/web/app/api/v1/resolve/route.ts
+++ b/apps/web/app/api/v1/resolve/route.ts
@@ -37,14 +37,14 @@ export async function GET(request: NextRequest) {
       {
         error: `Missing or invalid 'type' param. Valid: ${VALID_TYPES.join(", ")}`,
       },
-      { maxAge: 0 },
+      { maxAge: 0, status: 400 },
     );
   }
 
   if (!q || q.trim().length < 2) {
     return apiResponse(
       { error: "Missing or too short 'q' param (min 2 chars)" },
-      { maxAge: 0 },
+      { maxAge: 0, status: 400 },
     );
   }
 

--- a/apps/web/app/api/v1/taxonomies/route.test.ts
+++ b/apps/web/app/api/v1/taxonomies/route.test.ts
@@ -44,6 +44,18 @@ describe("GET /api/v1/taxonomies industries service boundary (#3331)", () => {
     vi.clearAllMocks();
   });
 
+  it("returns 400 when the required `type` param is missing (#3213)", async () => {
+    const res = await GET(makeReq("?locale=en"));
+    const body = (await res.json()) as { error?: string };
+
+    expect(res.status).toBe(400);
+    expect(body.error).toMatch(/Missing or invalid 'type' param/);
+    expect(mocks.suggestIndustries).not.toHaveBeenCalled();
+    expect(mocks.getAllSeniorities).not.toHaveBeenCalled();
+    expect(mocks.getAllOccupationsGrouped).not.toHaveBeenCalled();
+    expect(mocks.getAllTechnologiesGrouped).not.toHaveBeenCalled();
+  });
+
   it("resolves industries through the company service tier", async () => {
     mocks.suggestIndustries.mockResolvedValue([
       { id: 3, name: "Technology" },

--- a/apps/web/app/api/v1/taxonomies/route.ts
+++ b/apps/web/app/api/v1/taxonomies/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest) {
   if (!type || !VALID_TYPES.includes(type)) {
     return apiResponse(
       { error: `Missing or invalid 'type' param. Valid: ${VALID_TYPES.join(", ")}` },
-      { maxAge: 0 },
+      { maxAge: 0, status: 400 },
     );
   }
 

--- a/apps/web/app/api/v1/watchlist/create/route.test.ts
+++ b/apps/web/app/api/v1/watchlist/create/route.test.ts
@@ -60,6 +60,16 @@ describe("GET /api/v1/watchlist/create — filter params", () => {
     mocks.listTopCompanies.mockResolvedValue(emptyResult);
   });
 
+  it("returns 400 when the required `title` param is missing (#3213)", async () => {
+    const { res, body } = await callRoute("?locale=en");
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe("Missing required 'title' param");
+    expect(mocks.parseSearchFilters).not.toHaveBeenCalled();
+    expect(mocks.searchJobs).not.toHaveBeenCalled();
+    expect(mocks.listTopCompanies).not.toHaveBeenCalled();
+  });
+
   it("forwards `etype=` to the parser, preview search, and create URL", async () => {
     mocks.parseSearchFilters.mockResolvedValue({
       ...emptyParsed,

--- a/apps/web/app/api/v1/watchlist/create/route.ts
+++ b/apps/web/app/api/v1/watchlist/create/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
   if (!title) {
     return apiResponse(
       { error: "Missing required 'title' param" },
-      { maxAge: 0 },
+      { maxAge: 0, status: 400 },
     );
   }
 


### PR DESCRIPTION
## Summary
- extend `apiResponse` with an explicit `status` option for public API contract errors
- return 400 for missing required params in `/api/v1/companies`, `/api/v1/taxonomies`, `/api/v1/resolve`, and `/api/v1/watchlist/create`
- route `/api/v1/job` 400/404 errors through the shared helper and add route regressions

Fixes #3213

## Reproduction
Read-only production probes before the fix showed inconsistent status handling:
- `/api/v1/job?locale=en` -> 400
- `/api/v1/companies?locale=en` -> 200 error body
- `/api/v1/taxonomies?locale=en` -> 200 error body
- `/api/v1/resolve?q=tech&locale=en` -> 200 error body
- `/api/v1/resolve?type=industries&locale=en` -> 200 error body
- `/api/v1/watchlist/create?locale=en` -> 200 error body

## Validation
- `pnpm --filter @jobseek/web exec vitest run app/api/v1/_shared.test.ts app/api/v1/job/route.test.ts app/api/v1/companies/route.test.ts app/api/v1/taxonomies/route.test.ts app/api/v1/resolve/route.test.ts app/api/v1/watchlist/create/route.test.ts --reporter=dot`
- `pnpm --filter @jobseek/web lint`
- `pnpm --filter @jobseek/web typecheck`
- `pnpm --filter @jobseek/web test`
- `pnpm --filter @jobseek/web build`
- `git diff --check`