### PR TITLE
Codify server action naming

### DIFF
--- a/apps/web/__tests__/build-output.test.ts
+++ b/apps/web/__tests__/build-output.test.ts
@@ -241,7 +241,7 @@ function driftDiagnostic(route: string, expected: Classification, actual: Classi
       "render path reads runtime APIs (`cookies()`, `headers()`, `searchParams`",
       "without `await`-then-passing-into-a-cache-fn). Helpers that internally",
       "read request state — `getSession`, `getSessionUserId`, `getViewerLanguages`,",
-      "`getGeoFromHeaders`, `getPreferences`, `fetchExploreData`, `listTopCompanies` —",
+      "`getGeoFromHeaders`, `getPreferences`, `fetchExplorePageData`, `listTopCompanies` —",
       "must move into a `<Suspense>`-wrapped child or a server action fired",
       "from the client. See `apps/web/docs/cache-components.md` and #2243.",
     );

--- a/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
+++ b/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
@@ -1,20 +1,20 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { act, render, waitFor } from "@testing-library/react";
-import type { ExploreData } from "@/lib/actions/explore-data";
+import type { ExploreData } from "@/lib/actions/explore-page-data";
 
-// `@/lib/actions/explore-data` is a server action that transitively imports
+// `@/lib/actions/explore-page-data` is a server action that transitively imports
 // `server-only`, which throws when loaded in a non-Next runtime. Neutralise
 // the gate, then swap the action itself for a spy.
 vi.mock("server-only", () => ({}));
 const mockFetchExploreData = vi.fn();
-vi.mock("@/lib/actions/explore-data", async () => {
+vi.mock("@/lib/actions/explore-page-data", async () => {
   const actual =
-    await vi.importActual<typeof import("@/lib/actions/explore-data")>(
-      "@/lib/actions/explore-data",
+    await vi.importActual<typeof import("@/lib/actions/explore-page-data")>(
+      "@/lib/actions/explore-page-data",
     );
   return {
     ...actual,
-    fetchExploreData: (...args: unknown[]) => mockFetchExploreData(...args),
+    fetchExplorePageData: (...args: unknown[]) => mockFetchExploreData(...args),
   };
 });
 
@@ -100,7 +100,7 @@ afterEach(() => {
 });
 
 describe("ExploreContent — server-render initial-data path (#2640)", () => {
-  it("does NOT call fetchExploreData for an anonymous, no-filter visit with prerendered initialData", async () => {
+  it("does NOT call fetchExplorePageData for an anonymous, no-filter visit with prerendered initialData", async () => {
     const initialData = makeInitialData();
     render(<ExploreContent locale="en" initialData={initialData} />);
 
@@ -108,7 +108,7 @@ describe("ExploreContent — server-render initial-data path (#2640)", () => {
     expect(mockFetchExploreData).not.toHaveBeenCalled();
   });
 
-  it("calls fetchExploreData when the `logged_in` hint cookie is present even without filters", async () => {
+  it("calls fetchExplorePageData when the `logged_in` hint cookie is present even without filters", async () => {
     setDocumentCookie("logged_in=1");
 
     const initialData = makeInitialData();
@@ -119,7 +119,7 @@ describe("ExploreContent — server-render initial-data path (#2640)", () => {
     });
   });
 
-  it("calls fetchExploreData when a filter searchParam is present", async () => {
+  it("calls fetchExplorePageData when a filter searchParam is present", async () => {
     currentSearchParams = new URLSearchParams("q=python");
 
     const initialData = makeInitialData();
@@ -137,7 +137,7 @@ describe("ExploreContent — server-render initial-data path (#2640)", () => {
     expect(callArgs.searchParams.q).toBe("python");
   });
 
-  it("calls fetchExploreData when initialData is omitted (legacy path)", async () => {
+  it("calls fetchExplorePageData when initialData is omitted (legacy path)", async () => {
     render(<ExploreContent locale="en" />);
 
     await waitFor(() => {
@@ -145,7 +145,7 @@ describe("ExploreContent — server-render initial-data path (#2640)", () => {
     });
   });
 
-  it("does NOT call fetchExploreData when a non-filter searchParam is present (e.g. utm tracking)", async () => {
+  it("does NOT call fetchExplorePageData when a non-filter searchParam is present (e.g. utm tracking)", async () => {
     currentSearchParams = new URLSearchParams("utm_source=google");
 
     const initialData = makeInitialData();
@@ -333,7 +333,7 @@ describe("ExploreContent — cold-start retry (#3008)", () => {
     vi.restoreAllMocks();
   });
 
-  it("retries fetchExploreData once when the first call rejects (cold-start abort)", async () => {
+  it("retries fetchExplorePageData once when the first call rejects (cold-start abort)", async () => {
     setDocumentCookie("logged_in=1");
     const successData = makeInitialData();
     mockFetchExploreData

--- a/apps/web/app/[lang]/(app)/explore/explore-content.tsx
+++ b/apps/web/app/[lang]/(app)/explore/explore-content.tsx
@@ -2,13 +2,13 @@
 
 import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { fetchExploreData, type ExploreData } from "@/lib/actions/explore-data";
+import { fetchExplorePageData, type ExploreData } from "@/lib/actions/explore-page-data";
 import { hasLoggedInHint, hasAnonJobLanguagesHint } from "@/lib/client-cookies";
 import { ExploreSkeleton } from "@/components/search/explore-skeleton";
 import { SearchPage } from "./search-page";
 
 /**
- * Retry policy for the personalized `fetchExploreData` server action
+ * Retry policy for the personalized `fetchExplorePageData` server action
  * on cold-start. When the Vercel function instance is cold and
  * Typesense's first-request TLS handshake takes a few hundred ms, the
  * client-side fetch can be aborted (`net::ERR_ABORTED`) by the browser
@@ -22,15 +22,15 @@ import { SearchPage } from "./search-page";
  * function instance + warm Typesense connection). If both fail,
  * surface the error so the existing initialData stays.
  */
-async function fetchExploreDataWithRetry(
-  args: Parameters<typeof fetchExploreData>[0],
+async function fetchExplorePageDataWithRetry(
+  args: Parameters<typeof fetchExplorePageData>[0],
 ): Promise<ExploreData> {
   try {
-    return await fetchExploreData(args);
+    return await fetchExplorePageData(args);
   } catch (err) {
-    console.warn("[explore] fetchExploreData failed, retrying once", err);
+    console.warn("[explore] fetchExplorePageData failed, retrying once", err);
     await new Promise((resolve) => setTimeout(resolve, 250));
-    return fetchExploreData(args);
+    return fetchExplorePageData(args);
   }
 }
 
@@ -47,7 +47,7 @@ type ExploreContentProps = {
 };
 
 /**
- * URL searchParams that ``fetchExploreData`` consumes. If any of these
+ * URL searchParams that ``fetchExplorePageData`` consumes. If any of these
  * are present, the prerendered ``initialData`` doesn't reflect the
  * filters and we must re-fetch the personalized variant.
  */
@@ -70,7 +70,7 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
   // preferences / job-language filter / display currency would change
   // the result set), OR they have an anonymous job-language cookie
   // set (#2850 — anon viewers persist `jobLanguages` via a cookie
-  // that the server side reads in `fetchExploreData`). Anonymous, no-
+  // that the server side reads in `fetchExplorePageData`). Anonymous, no-
   // filter, no-job-lang-cookie visitors still get the prerendered data
   // with zero function invocations — the bulk of organic traffic per
   // #2640.
@@ -101,7 +101,7 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
     searchParams.forEach((value, key) => {
       sp[key] = value;
     });
-    fetchExploreDataWithRetry({ searchParams: sp, locale })
+    fetchExplorePageDataWithRetry({ searchParams: sp, locale })
       .then(setData)
       .catch((err) => {
         // Both attempts failed. Fall back to the prerendered
@@ -111,7 +111,7 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
         // toolbar because the prerender doesn't carry them, but that
         // matches the pre-#2746 cold-error behaviour and beats a
         // permanent skeleton.
-        console.error("[explore] fetchExploreData failed twice", err);
+        console.error("[explore] fetchExplorePageData failed twice", err);
         if (initialData) setData(initialData);
       });
     // Empty deps: the conditional-fetch decision is made once on

--- a/apps/web/app/[lang]/(app)/explore/page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/page.tsx
@@ -4,7 +4,7 @@ import { isLocale, defaultLocale, loadCatalog, ogLocale, ogAlternateLocales } fr
 import { CACHE_TTL_SHORT } from "@/lib/cache-ttl";
 import { siteConfig } from "@/content/config";
 import { buildAlternates } from "@/lib/seo";
-import { fetchExploreDefaults } from "@/lib/actions/explore-data";
+import { fetchExplorePageDefaults } from "@/lib/actions/explore-page-data";
 import { ExploreContent } from "./explore-content";
 
 const EXPLORE_DEFAULTS_CACHE_LIFE = {
@@ -15,7 +15,7 @@ const EXPLORE_DEFAULTS_CACHE_LIFE = {
 const EXPLORE_DEFAULTS_PAYLOAD_VERSION = "v3";
 
 // Cached for 60s. The anonymous, no-filter explore payload is rendered
-// server-side via `fetchExploreDefaults` and embedded as `initialData`.
+// server-side via `fetchExplorePageDefaults` and embedded as `initialData`.
 // `ExploreContent` is a client component that re-fetches a personalized
 // variant only when the `logged_in` hint cookie or a filter searchParam
 // is present, so anonymous no-filter visitors hit the static prerender
@@ -67,7 +67,7 @@ async function renderExploreContent(
   if (payloadVersion !== EXPLORE_DEFAULTS_PAYLOAD_VERSION) {
     throw new Error("Unexpected explore defaults cache version");
   }
-  const initialData = await fetchExploreDefaults({ locale });
+  const initialData = await fetchExplorePageDefaults({ locale });
 
   return <ExploreContent locale={locale} initialData={initialData} />;
 }

--- a/apps/web/app/[lang]/(app)/my-jobs/stats/stats-loader.tsx
+++ b/apps/web/app/[lang]/(app)/my-jobs/stats/stats-loader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { getStats, type StatsData } from "@/lib/actions/my-jobs-stats";
+import { getMyJobsStats, type StatsData } from "@/lib/actions/my-jobs-stats";
 import { getViewerTz } from "@/lib/viewer-tz";
 import { StatsPage } from "./stats-page";
 
@@ -12,7 +12,7 @@ export function StatsLoader({ locale: _locale }: { locale: string }) {
     // Pass the browser's resolved IANA timezone so server-side day
     // bucketing for the activity heatmap matches what the client
     // renders. See #3199.
-    getStats({ tz: getViewerTz() }).then(setData);
+    getMyJobsStats({ tz: getViewerTz() }).then(setData);
   }, []);
 
   if (!data) {

--- a/apps/web/app/[lang]/(app)/my-jobs/stats/stats-page.tsx
+++ b/apps/web/app/[lang]/(app)/my-jobs/stats/stats-page.tsx
@@ -6,7 +6,7 @@ import { useLocalePath } from "@/lib/useLocalePath";
 import { BackLink } from "@/components/BackLink";
 import { SankeyFunnel } from "@/components/my-jobs/sankey-funnel-lazy";
 import { ActivityHeatmap } from "@/components/my-jobs/activity-heatmap";
-import { getStats, type StatsData } from "@/lib/actions/my-jobs-stats";
+import { getMyJobsStats, type StatsData } from "@/lib/actions/my-jobs-stats";
 import { getViewerTz } from "@/lib/viewer-tz";
 
 export function StatsPage({ initial }: { initial: StatsData }) {
@@ -22,7 +22,7 @@ export function StatsPage({ initial }: { initial: StatsData }) {
       // Pass the viewer's resolved IANA timezone so day bucketing and
       // the `from`/`to` calendar-day filter both resolve at the user's
       // local midnight, not Postgres-server midnight. See #3199.
-      const result = await getStats({
+      const result = await getMyJobsStats({
         from: newFrom || undefined,
         to: newTo || undefined,
         tz: getViewerTz(),

--- a/apps/web/app/[lang]/(app)/progress/progress-loader.tsx
+++ b/apps/web/app/[lang]/(app)/progress/progress-loader.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { Trans } from "@lingui/react/macro";
 import { Construction, Building2, Briefcase } from "lucide-react";
 import { siteConfig } from "@/content/config";
-import { getStats } from "@/lib/actions/stats";
+import { getSiteStats } from "@/lib/actions/stats";
 import { CompanyRequestForm } from "./company-request-form";
 
 type StatsData = { companyCount: number; jobPostingCount: number };
@@ -13,7 +13,7 @@ export function ProgressLoader({ locale, lang }: { locale: string; lang: string 
   const [stats, setStats] = useState<StatsData | null>(null);
 
   useEffect(() => {
-    getStats().then(setStats);
+    getSiteStats().then(setStats);
   }, []);
 
   return (

--- a/apps/web/docs/cache-components.md
+++ b/apps/web/docs/cache-components.md
@@ -81,7 +81,7 @@ async function AuthAwareNav() {
 When you're writing a new server component (or porting an existing one), walk this in order and stop at the first match.
 
 1. **Does it read `cookies()`, `headers()`, `searchParams`, `connection()`, `draftMode()`, or call any helper that internally does?**
-   The canonical "tainted helpers" — server functions that internally read request state — are: `getSession`, `getSessionUserId`, `getViewerLanguages`, `getGeoFromHeaders`, `getPreferences`, `fetchExploreData`, `listTopCompanies`. Extend the list (and grep callers in PRs) whenever you add another helper that reads `headers()` / `cookies()` / `getSession()` under the hood.
+   The canonical "tainted helpers" — server functions that internally read request state — are: `getSession`, `getSessionUserId`, `getViewerLanguages`, `getGeoFromHeaders`, `getPreferences`, `fetchExplorePageData`, `listTopCompanies`. Extend the list (and grep callers in PRs) whenever you add another helper that reads `headers()` / `cookies()` / `getSession()` under the hood.
    - **Yes** → it's dynamic. Wrap the component (or its parent) in `<Suspense>`. Provide a meaningful fallback (we have `SearchSkeleton`, `WatchlistSkeleton`, `CompanySkeleton` already; reuse before inventing).
    - **No** → continue.
 

--- a/apps/web/docs/data-fetching.md
+++ b/apps/web/docs/data-fetching.md
@@ -53,6 +53,32 @@ Server actions were chosen for the UI because:
 Server actions called from client components are POST requests under the
 hood — functionally equivalent to API calls, but with better DX.
 
+## Server Action Naming
+
+Server action names are part of the UI data contract, so read-action verbs
+carry meaning:
+
+- **Granular reads** use `getX` when they return one independently useful
+  resource or aggregate (`getPostingDetail`, `getSiteStats`,
+  `getMyJobsStats`). Existing domain verbs such as `searchX`, `listX`,
+  `suggestX`, `resolveX`, and `expandX` remain valid when they describe the
+  operation more precisely than `get`.
+- **Composite page/bootstrap bundles** use `fetchX` and live in
+  `bootstrap.ts` or `*-page-data.ts`. These actions collect several granular
+  reads into the full shape a loader needs, so their names include the bundle
+  type: `fetchAppBootstrap`, `fetchExplorePageData`,
+  `fetchExplorePageDefaults`, `fetchCompanyPageData`,
+  `fetchCompanyPageDefaults`, and `fetchWatchlistPageData`.
+- **Cursor or infinite-scroll reads** are still reads; use `getX` or a
+  domain verb, not `loadX`. The company-card posting action is
+  `getMorePostings`.
+
+Exported server action function names must be unique across
+`src/lib/actions/*.ts`; add a domain qualifier when the noun would otherwise
+be ambiguous across modules. `src/lib/actions/__tests__/naming-conventions.test.ts`
+enforces the uniqueness rule, blocks `load*` exports, and keeps `fetch*`
+reserved for bootstrap/page-data bundlers.
+
 ## Anonymous Truncation
 
 Unauthenticated users see limited results to prevent data scraping while
@@ -72,7 +98,7 @@ Constants are in `src/lib/search/constants.ts`.
 ### Enforcement
 
 Truncation is **enforced server-side** in each server action
-(`searchJobs`, `listTopCompanies`, `loadMorePostings`,
+(`searchJobs`, `listTopCompanies`, `getMorePostings`,
 `getCompanyPostings`, `getWatchlistPostings`). Each checks
 `getSessionUserId()` — if null, caps results at the limit and sets
 `truncated: true` in the response.

--- a/apps/web/docs/edge-requests.md
+++ b/apps/web/docs/edge-requests.md
@@ -175,7 +175,7 @@ the `(app)` route group serves static shells from CDN, and most page data loads
 through client-fired server actions on mount. A few high-traffic anonymous paths
 embed cacheable defaults in the shell:
 
-- `/explore` embeds anonymous, no-filter defaults via `fetchExploreDefaults()`.
+- `/explore` embeds anonymous, no-filter defaults via `fetchExplorePageDefaults()`.
 - `/company/[slug]` embeds anonymous, no-filter defaults via
   `fetchCompanyPageDefaults()`.
 - Watchlist and company metadata use cached server reads for SEO, then hydrate
@@ -389,7 +389,7 @@ invoked.
 
 | Route | Shell behavior | Dynamic work | Pattern | Redis/cache | Est. duration |
 |-------|----------------|--------------|---------|-------------|---------------|
-| **Explore** | Cached anonymous defaults | Personalized `fetchExploreData()` / search actions when signed in or filtered | Mixed | Defaults 60s; search 5min | 30-250ms when invoked |
+| **Explore** | Cached anonymous defaults | Personalized `fetchExplorePageData()` / search actions when signed in or filtered | Mixed | Defaults 60s; search 5min | 30-250ms when invoked |
 | **Company** | Cached anonymous defaults + metadata | Personalized `fetchCompanyPageData()` when signed in, filtered, or language cookie present | Mixed | Company/detail caches | 30-200ms when invoked |
 | **Shared watchlist** | Cached metadata/body shell | `fetchWatchlistPageData()` after mount | Sequential + parallel | Watchlist lookup cached | 60-300ms |
 | **My Jobs** | Static shell | `getMyJobs()` after mount | Sequential | None | 20-100ms |
@@ -502,7 +502,7 @@ use Typesense `multi_search` if filter precision is required.
 Search results and posting details are already cached (5-min TTL). Extend this
 to:
 - `getWatchlistPostings()` — filter-keyed, short TTL
-- `getStats()` (my-jobs-stats) — user-keyed, invalidate on status change
+- `getMyJobsStats()` (my-jobs-stats) — user-keyed, invalidate on status change
 
 `getUserWatchlists()` is fast enough post-#3176 (single SQL query, ~12-38ms)
 that caching adds invalidation complexity without a meaningful win.

--- a/apps/web/docs/edge-requests/my-jobs-stats.md
+++ b/apps/web/docs/edge-requests/my-jobs-stats.md
@@ -20,7 +20,7 @@
 ## Server-side data fetching (during SSR)
 
 - App layout: `getSession()`, `getPreferences()`, `getSavedJobStatuses()`, `getStarredCompanyIds()`
-- `getStats()` — funnel data, conversion rates, activity heatmap
+- `getMyJobsStats()` — funnel data, conversion rates, activity heatmap
 
 ## Notes
 
@@ -38,8 +38,8 @@
 | `getPreferences()` | 1 | parallel | None | 10-30ms |
 | `getSavedJobStatuses()` | 1 | parallel | None | 10-30ms |
 | `getStarredCompanyIds()` | 1 | parallel | None | 10-30ms |
-| `getStats()` funnel | 1 | sequential | None | 15-40ms |
-| `getStats()` activity | 1 | sequential | None | 15-40ms |
+| `getMyJobsStats()` funnel | 1 | sequential | None | 15-40ms |
+| `getMyJobsStats()` activity | 1 | sequential | None | 15-40ms |
 
 **Total DB queries:** 6
 **Estimated function duration:** 50-150ms (warm instance)

--- a/apps/web/docs/edge-requests/progress.md
+++ b/apps/web/docs/edge-requests/progress.md
@@ -20,7 +20,7 @@
 ## Server-side data fetching (during SSR)
 
 - App layout: `getSession()`, `getPreferences()`, `getSavedJobStatuses()`, `getStarredCompanyIds()`
-- `getStats()` — company count and job posting count
+- `getSiteStats()` — company count and job posting count
 
 ## Client-side requests (user interaction)
 
@@ -44,7 +44,7 @@
 | `getPreferences()` | 1 | parallel | None | 10-30ms |
 | `getSavedJobStatuses()` | 1 | parallel | None | 10-30ms |
 | `getStarredCompanyIds()` | 1 | parallel | None | 10-30ms |
-| `getStats()` (public) | 2 | parallel | Redis 6h | 10-30ms |
+| `getSiteStats()` (public) | 2 | parallel | Redis 6h | 10-30ms |
 
 **Total DB queries:** 6 (4 if stats cached)
 **Estimated function duration:** 30-80ms (warm instance)

--- a/apps/web/src/components/my-jobs/activity-heatmap.tsx
+++ b/apps/web/src/components/my-jobs/activity-heatmap.tsx
@@ -7,7 +7,7 @@ import type { ActivityDay } from "@/lib/actions/my-jobs-stats";
 // Renders a YYYY-MM-DD key from a JS Date using the *browser's* TZ
 // (Date.getFullYear/Month/Date are local-TZ accessors). The server
 // side now buckets `saved_at` in the same IANA TZ passed by the
-// caller (see `getStats({ tz })`), so cell keys and data keys agree
+// caller (see `getMyJobsStats({ tz })`), so cell keys and data keys agree
 // even at the day boundary in the viewer's local time. See #3199.
 function formatLocal(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;

--- a/apps/web/src/components/search/__tests__/company-card-nested-buttons.test.tsx
+++ b/apps/web/src/components/search/__tests__/company-card-nested-buttons.test.tsx
@@ -90,7 +90,7 @@ vi.mock("@/lib/use-infinite-scroll", () => ({
 }));
 
 vi.mock("@/lib/actions/search", () => ({
-  loadMorePostings: vi.fn(),
+  getMorePostings: vi.fn(),
 }));
 
 vi.mock("@/lib/time", () => ({

--- a/apps/web/src/components/search/__tests__/company-card-posting-order.test.tsx
+++ b/apps/web/src/components/search/__tests__/company-card-posting-order.test.tsx
@@ -4,7 +4,7 @@ import "@/test-utils/lingui-mock";
 import type { SearchResultCompany, SearchResultPosting } from "@/lib/search";
 
 const mocks = vi.hoisted(() => ({
-  loadMorePostings: vi.fn(),
+  getMorePostings: vi.fn(),
   load: undefined as undefined | (() => Promise<void>),
 }));
 
@@ -60,7 +60,7 @@ vi.mock("@/lib/use-infinite-scroll", () => ({
 }));
 
 vi.mock("@/lib/actions/search", () => ({
-  loadMorePostings: mocks.loadMorePostings,
+  getMorePostings: mocks.getMorePostings,
 }));
 
 vi.mock("@/lib/time", () => ({
@@ -125,7 +125,7 @@ function visiblePostingIds(container: HTMLElement): string[] {
 describe("CompanyCard posting order", () => {
   beforeEach(() => {
     mocks.load = undefined;
-    mocks.loadMorePostings.mockReset();
+    mocks.getMorePostings.mockReset();
   });
 
   it("sorts initial postings by newest first before rendering", () => {
@@ -144,7 +144,7 @@ describe("CompanyCard posting order", () => {
       posting("visible-oldest", "Visible oldest role", "2026-06-22T11:20:00.000Z"),
     ]);
 
-    mocks.loadMorePostings.mockResolvedValueOnce({
+    mocks.getMorePostings.mockResolvedValueOnce({
       postings: [
         posting("loaded-fresh", "Loaded fresh role", "2026-06-22T11:55:00.000Z"),
       ],

--- a/apps/web/src/components/search/__tests__/company-card-scroll-stability.test.tsx
+++ b/apps/web/src/components/search/__tests__/company-card-scroll-stability.test.tsx
@@ -66,7 +66,7 @@ vi.mock("@/lib/use-infinite-scroll", () => ({
 }));
 
 vi.mock("@/lib/actions/search", () => ({
-  loadMorePostings: vi.fn(),
+  getMorePostings: vi.fn(),
 }));
 
 vi.mock("@/lib/time", () => ({

--- a/apps/web/src/components/search/__tests__/company-card.test.tsx
+++ b/apps/web/src/components/search/__tests__/company-card.test.tsx
@@ -91,7 +91,7 @@ vi.mock("@/lib/use-infinite-scroll", () => ({
 }));
 
 vi.mock("@/lib/actions/search", () => ({
-  loadMorePostings: vi.fn().mockResolvedValue({ postings: [], truncated: false }),
+  getMorePostings: vi.fn().mockResolvedValue({ postings: [], truncated: false }),
 }));
 
 vi.mock("@/lib/time", () => ({

--- a/apps/web/src/components/search/company-card.tsx
+++ b/apps/web/src/components/search/company-card.tsx
@@ -6,7 +6,7 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import { CompanyIcon } from "@/components/CompanyIcon";
 import { useParams } from "next/navigation";
 import { timeAgoShort } from "@/lib/time";
-import { loadMorePostings } from "@/lib/actions/search";
+import { getMorePostings } from "@/lib/actions/search";
 import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
 import { InfiniteScrollSentinel } from "@/components/InfiniteScrollSentinel";
 import { TruncationPrompt } from "@/components/TruncationPrompt";
@@ -76,7 +76,7 @@ function CompanyCardImpl({ result, keywords, locationIds, locations, occupations
   const offsetRef = useRef(result.postings.length);
 
   async function handleLoadMore() {
-    const result = await loadMorePostings({
+    const result = await getMorePostings({
       companyId: company.id,
       keywords,
       locationIds,

--- a/apps/web/src/lib/actions/__tests__/explore-page-data-salary-currency.test.ts
+++ b/apps/web/src/lib/actions/__tests__/explore-page-data-salary-currency.test.ts
@@ -41,7 +41,7 @@ vi.mock("@/lib/actions/search-input", () => ({
   parseSearchFilters: mocks.parseSearchFilters,
 }));
 
-import { fetchExploreData } from "../explore-data";
+import { fetchExplorePageData } from "../explore-page-data";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -77,7 +77,7 @@ beforeEach(() => {
   ]);
 });
 
-describe("fetchExploreData — salary EUR conversion (#3178)", () => {
+describe("fetchExplorePageData — salary EUR conversion (#3178)", () => {
   it("converts USD 100K filter to ~92000 EUR before calling Typesense (was 100000 pre-fix)", async () => {
     // The headline #3178 scenario: a US user with salcur=USD enters "$100K+".
     // Pre-fix, salaryMinEur was passed through as 100000, so the filter
@@ -85,7 +85,7 @@ describe("fetchExploreData — salary EUR conversion (#3178)", () => {
     // Post-fix, the converted EUR value is what reaches the Typesense query.
     mocks.parseRangeParam.mockReturnValueOnce({ min: 100000, max: undefined });
 
-    await fetchExploreData({
+    await fetchExplorePageData({
       searchParams: { sal: "100000-", salcur: "USD" },
       locale: "en",
     });
@@ -100,7 +100,7 @@ describe("fetchExploreData — salary EUR conversion (#3178)", () => {
   it("converts CHF 100K filter to ~95000 EUR", async () => {
     mocks.parseRangeParam.mockReturnValueOnce({ min: 100000, max: undefined });
 
-    await fetchExploreData({
+    await fetchExplorePageData({
       searchParams: { sal: "100000-", salcur: "CHF" },
       locale: "en",
     });
@@ -115,7 +115,7 @@ describe("fetchExploreData — salary EUR conversion (#3178)", () => {
     // which excludes every posting on the platform. Now: ~60000 EUR.
     mocks.parseRangeParam.mockReturnValueOnce({ min: 10_000_000, max: undefined });
 
-    await fetchExploreData({
+    await fetchExplorePageData({
       searchParams: { sal: "10000000-", salcur: "JPY" },
       locale: "en",
     });
@@ -127,7 +127,7 @@ describe("fetchExploreData — salary EUR conversion (#3178)", () => {
   it("leaves EUR 100K unchanged (identity branch — no rate lookup needed)", async () => {
     mocks.parseRangeParam.mockReturnValueOnce({ min: 100000, max: undefined });
 
-    await fetchExploreData({
+    await fetchExplorePageData({
       searchParams: { sal: "100000-", salcur: "EUR" },
       locale: "en",
     });
@@ -141,7 +141,7 @@ describe("fetchExploreData — salary EUR conversion (#3178)", () => {
     // renders where the user actually has a salary filter applied.
     mocks.parseRangeParam.mockReturnValueOnce({ min: undefined, max: undefined });
 
-    await fetchExploreData({
+    await fetchExplorePageData({
       searchParams: {},
       locale: "en",
     });
@@ -160,7 +160,7 @@ describe("fetchExploreData — salary EUR conversion (#3178)", () => {
     });
     mocks.parseRangeParam.mockReturnValueOnce({ min: 100000, max: undefined });
 
-    await fetchExploreData({
+    await fetchExplorePageData({
       searchParams: { sal: "100000-" },
       locale: "en",
     });
@@ -172,7 +172,7 @@ describe("fetchExploreData — salary EUR conversion (#3178)", () => {
   it("preserves both min and max conversion (range filter)", async () => {
     mocks.parseRangeParam.mockReturnValueOnce({ min: 50000, max: 150000 });
 
-    await fetchExploreData({
+    await fetchExplorePageData({
       searchParams: { sal: "50000-150000", salcur: "USD" },
       locale: "en",
     });

--- a/apps/web/src/lib/actions/__tests__/my-jobs-stats-tz.test.ts
+++ b/apps/web/src/lib/actions/__tests__/my-jobs-stats-tz.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 /**
  * #3199 — Activity-heatmap TZ bug.
  *
- * Before the fix, `getStats()` bucketed `saved_at` via
+ * Before the fix, `getMyJobsStats()` bucketed `saved_at` via
  * `to_char(saved_at, 'YYYY-MM-DD')` in Postgres's TZ (UTC on Supabase),
  * while the client built cell keys with `Date.getFullYear/Month/Date`
  * (browser TZ). A NYC user saving at 23:00 local time would see the
@@ -22,7 +22,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  * The cell grid on the client still uses browser-TZ `Date` accessors,
  * but with the server bucketing in the same TZ the day keys align.
  *
- * This spec asserts the SQL produced by `getStats({ tz })` reaches
+ * This spec asserts the SQL produced by `getMyJobsStats({ tz })` reaches
  * Postgres parameterised with the right TZ and the right shape, and
  * that malformed inputs are coerced to "UTC".
  */
@@ -122,7 +122,7 @@ function flatten(
   return { text: parts.join(""), params };
 }
 
-describe("#3199 — getStats TZ-aware day bucketing", () => {
+describe("#3199 — getMyJobsStats TZ-aware day bucketing", () => {
   beforeEach(() => {
     captured.sqlObjects = [];
   });
@@ -131,8 +131,8 @@ describe("#3199 — getStats TZ-aware day bucketing", () => {
   });
 
   it("buckets activity in the viewer-supplied IANA TZ", async () => {
-    const { getStats } = await import("@/lib/actions/my-jobs-stats");
-    await getStats({ tz: "America/New_York" });
+    const { getMyJobsStats } = await import("@/lib/actions/my-jobs-stats");
+    await getMyJobsStats({ tz: "America/New_York" });
 
     // Two queries: funnel + activity. The activity query is the one
     // that references `to_char(... 'YYYY-MM-DD')`.
@@ -152,8 +152,8 @@ describe("#3199 — getStats TZ-aware day bucketing", () => {
   });
 
   it("interprets from/to date filters at the viewer's local midnight", async () => {
-    const { getStats } = await import("@/lib/actions/my-jobs-stats");
-    await getStats({
+    const { getMyJobsStats } = await import("@/lib/actions/my-jobs-stats");
+    await getMyJobsStats({
       from: "2026-05-13",
       to: "2026-05-14",
       tz: "America/New_York",
@@ -181,8 +181,8 @@ describe("#3199 — getStats TZ-aware day bucketing", () => {
   });
 
   it("falls back to UTC when no tz is supplied (preserves legacy behaviour)", async () => {
-    const { getStats } = await import("@/lib/actions/my-jobs-stats");
-    await getStats({});
+    const { getMyJobsStats } = await import("@/lib/actions/my-jobs-stats");
+    await getMyJobsStats({});
 
     const activity = captured.sqlObjects
       .map(flatten)
@@ -192,7 +192,7 @@ describe("#3199 — getStats TZ-aware day bucketing", () => {
   });
 
   it("rejects malformed TZ inputs and falls back to UTC", async () => {
-    const { getStats } = await import("@/lib/actions/my-jobs-stats");
+    const { getMyJobsStats } = await import("@/lib/actions/my-jobs-stats");
 
     const malformed = [
       "'; DROP TABLE saved_job; --",
@@ -205,7 +205,7 @@ describe("#3199 — getStats TZ-aware day bucketing", () => {
 
     for (const tz of malformed) {
       captured.sqlObjects = [];
-      await getStats({ tz });
+      await getMyJobsStats({ tz });
       const activity = captured.sqlObjects
         .map(flatten)
         .find((q) => q.text.includes("to_char"));
@@ -218,7 +218,7 @@ describe("#3199 — getStats TZ-aware day bucketing", () => {
   });
 
   it("accepts canonical IANA names with subzones", async () => {
-    const { getStats } = await import("@/lib/actions/my-jobs-stats");
+    const { getMyJobsStats } = await import("@/lib/actions/my-jobs-stats");
 
     const valid = [
       "Europe/Zurich",
@@ -230,7 +230,7 @@ describe("#3199 — getStats TZ-aware day bucketing", () => {
 
     for (const tz of valid) {
       captured.sqlObjects = [];
-      await getStats({ tz });
+      await getMyJobsStats({ tz });
       const activity = captured.sqlObjects
         .map(flatten)
         .find((q) => q.text.includes("to_char"));

--- a/apps/web/src/lib/actions/__tests__/naming-conventions.test.ts
+++ b/apps/web/src/lib/actions/__tests__/naming-conventions.test.ts
@@ -1,0 +1,101 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+interface ExportedAction {
+  file: string;
+  name: string;
+}
+
+const ACTIONS_DIR = dirname(dirname(fileURLToPath(import.meta.url)));
+const FETCH_ACTION_FILES = new Set([
+  "bootstrap.ts",
+  "company-page-data.ts",
+  "explore-page-data.ts",
+  "watchlist-page-data.ts",
+]);
+const FETCH_ACTION_NAME =
+  /^fetch(?:AppBootstrap|[A-Z][A-Za-z0-9]*(?:PageData|PageDefaults))$/;
+
+function hasModifier(node: ts.Node, kind: ts.SyntaxKind): boolean {
+  return ts.canHaveModifiers(node)
+    ? (ts.getModifiers(node)?.some((modifier) => modifier.kind === kind) ?? false)
+    : false;
+}
+
+function actionFiles(): string[] {
+  return readdirSync(ACTIONS_DIR)
+    .map((entry) => join(ACTIONS_DIR, entry))
+    .filter((path) => statSync(path).isFile() && path.endsWith(".ts"))
+    .sort();
+}
+
+function exportedAsyncFunctions(file: string): ExportedAction[] {
+  const source = ts.createSourceFile(
+    file,
+    readFileSync(file, "utf8"),
+    ts.ScriptTarget.Latest,
+    true,
+  );
+
+  return source.statements.flatMap((statement): ExportedAction[] => {
+    if (!ts.isFunctionDeclaration(statement) || statement.name == null) {
+      return [];
+    }
+    if (!hasModifier(statement, ts.SyntaxKind.ExportKeyword)) {
+      return [];
+    }
+    if (!hasModifier(statement, ts.SyntaxKind.AsyncKeyword)) {
+      return [];
+    }
+    return [{ file: basename(file), name: statement.name.text }];
+  });
+}
+
+function exportedActions(): ExportedAction[] {
+  return actionFiles().flatMap(exportedAsyncFunctions);
+}
+
+describe("server action naming conventions", () => {
+  it("keeps exported action function names globally unique", () => {
+    const byName = new Map<string, string[]>();
+    for (const action of exportedActions()) {
+      byName.set(action.name, [...(byName.get(action.name) ?? []), action.file]);
+    }
+
+    const duplicates = Array.from(byName.entries())
+      .filter(([, files]) => files.length > 1)
+      .map(([name, files]) => `${name}: ${files.join(", ")}`)
+      .sort();
+
+    expect(duplicates).toEqual([]);
+  });
+
+  it("reserves fetch* for bootstrap and page-data bundlers", () => {
+    const violations: string[] = [];
+
+    for (const action of exportedActions()) {
+      const fileAllowsFetch = FETCH_ACTION_FILES.has(action.file);
+      const isFetch = action.name.startsWith("fetch");
+
+      if (action.name.startsWith("load")) {
+        violations.push(`${action.file}:${action.name} should use get* or a domain verb`);
+      }
+      if (isFetch && !fileAllowsFetch) {
+        violations.push(`${action.file}:${action.name} uses fetch* outside a bundle file`);
+      }
+      if (fileAllowsFetch && !isFetch) {
+        violations.push(`${action.file}:${action.name} should use fetch*`);
+      }
+      if (isFetch && !FETCH_ACTION_NAME.test(action.name)) {
+        violations.push(
+          `${action.file}:${action.name} should be fetchAppBootstrap, fetch*PageData, or fetch*PageDefaults`,
+        );
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/actions/__tests__/request-company.test.ts
+++ b/apps/web/src/lib/actions/__tests__/request-company.test.ts
@@ -3,10 +3,10 @@ import { setTestEnv, withTestEnv } from "@/test-utils/env";
 
 /**
  * #3193 — `requestCompany` was previously colocated in `stats.ts` together
- * with `getStats`, which forced `@octokit/rest` + `@octokit/auth-app`
+ * with `getSiteStats`, which forced `@octokit/rest` + `@octokit/auth-app`
  * (~500–700 KB raw, ~150 KB gzipped) to be eagerly loaded into the server
  * bundle of every route importing anything from `stats.ts`, including
- * `/progress` which only needs the octokit-free `getStats`.
+ * `/progress` which only needs the octokit-free `getSiteStats`.
  *
  * These specs lock in the split:
  *   1. Importing `stats.ts` must NOT pull octokit into the module graph

--- a/apps/web/src/lib/actions/__tests__/similar-companies-salary-currency.test.ts
+++ b/apps/web/src/lib/actions/__tests__/similar-companies-salary-currency.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // `vi.mock` hoists to the top of the file so its factories cannot close
 // over module-scope variables. Use `vi.hoisted` to share mocks between
 // the factory and the test bodies. Mirrors the pattern in
-// `company.test.ts` and `explore-data-salary-currency.test.ts`.
+// `company.test.ts` and `explore-page-data-salary-currency.test.ts`.
 const mocks = vi.hoisted(() => ({
   cacheLife: vi.fn(),
   cacheTag: vi.fn(),
@@ -229,7 +229,7 @@ describe("getSimilarCompanies — salary EUR conversion (#3178)", () => {
     // Defensive guard so the strip doesn't hit the rates cache on every
     // unfiltered render (e.g. when the user is only filtering by
     // location). Mirrors the same guard in
-    // `explore-data.ts::fetchExploreData` and
+    // `explore-page-data.ts::fetchExplorePageData` and
     // `company-page-data.ts::fetchCompanyPageData`.
     mocks.parseRangeParam.mockReturnValueOnce({
       min: undefined,

--- a/apps/web/src/lib/actions/__tests__/stats-no-octokit.test.ts
+++ b/apps/web/src/lib/actions/__tests__/stats-no-octokit.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 /**
  * #3193 — Regression guard.
  *
- * `getStats` (the cheap platform-counts query used on `/progress` and
+ * `getSiteStats` (the cheap platform-counts query used on `/progress` and
  * elsewhere) must NOT pull `@octokit/rest` / `@octokit/auth-app` into its
  * module graph. The two octokit packages add ~500–700 KB raw / ~150 KB
  * gzipped to any server bundle that ends up evaluating them, and adds
@@ -11,7 +11,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
  *
  * Strategy: register `vi.mock` factories for both octokit packages that
  * throw on first access, then import `stats.ts`. If anything in the
- * transitive graph of `getStats` touches `@octokit/rest` or
+ * transitive graph of `getSiteStats` touches `@octokit/rest` or
  * `@octokit/auth-app`, the import will throw and the spec will fail.
  */
 
@@ -66,6 +66,6 @@ describe("stats.ts no longer eagerly pulls octokit (#3193)", () => {
     // If `stats.ts` (or anything in its transitive graph) imports octokit,
     // the `vi.mock` factory above throws and this import will reject.
     const mod = await import("../stats");
-    expect(typeof mod.getStats).toBe("function");
+    expect(typeof mod.getSiteStats).toBe("function");
   });
 });

--- a/apps/web/src/lib/actions/company-page-data.ts
+++ b/apps/web/src/lib/actions/company-page-data.ts
@@ -97,7 +97,7 @@ export async function fetchCompanyPageData(params: {
 
   const salaryCurrencyParam = salcur ?? displayCurrency;
   const { min: salaryMinDisplay, max: salaryMaxDisplay } = parseRangeParam(sal);
-  // Convert user-currency filter amount to EUR — see explore-data.ts for the
+  // Convert user-currency filter amount to EUR — see explore-page-data.ts for the
   // full rationale (issue #3178). `getCurrencyRates` is cache-backed
   // (`cacheLife("hours")`), so this is not an extra DB round-trip in the
   // steady state.
@@ -153,7 +153,7 @@ export async function fetchCompanyPageData(params: {
  * Server-side prerender variant of :func:`fetchCompanyPageData` for the
  * anonymous, no-filter company-detail page case (#3203).
  *
- * Mirrors :func:`fetchExploreDefaults` (#2640). Critically does NOT
+ * Mirrors :func:`fetchExplorePageDefaults` (#2640). Critically does NOT
  * call :func:`getPreferences`/:func:`getSession`/:func:`readAnonJobLanguagesCookie`
  * (read ``cookies()``) or :func:`getGeoFromHeaders` (reads ``headers()``)
  * — those force dynamic rendering and would silently break the page's
@@ -186,7 +186,7 @@ export async function fetchCompanyPageDefaults(params: {
   // latter calls ``getSessionUserId`` which awaits ``headers()`` and
   // would silently downgrade the page to dynamic rendering, defeating
   // the ISR optimisation this function exists for. See the parallel
-  // pattern in `explore-data.ts::fetchExploreDefaults` (#2640).
+  // pattern in `explore-page-data.ts::fetchExplorePageDefaults` (#2640).
   const postingsResult = await getCompanyPostingsAnonymous({
     companyId: company.id,
     keywords: [],

--- a/apps/web/src/lib/actions/explore-page-data.ts
+++ b/apps/web/src/lib/actions/explore-page-data.ts
@@ -44,7 +44,7 @@ export interface ExploreData {
   experienceMax: number | undefined;
 }
 
-export async function fetchExploreData(params: {
+export async function fetchExplorePageData(params: {
   searchParams: Record<string, string | string[] | undefined>;
   locale: string;
 }): Promise<ExploreData> {
@@ -157,7 +157,7 @@ export async function fetchExploreData(params: {
 }
 
 /**
- * Server-side prerender variant of :func:`fetchExploreData` for the
+ * Server-side prerender variant of :func:`fetchExplorePageData` for the
  * unauthenticated, no-filter homepage case (#2640).
  *
  * Critically does NOT call :func:`getPreferences` (reads
@@ -166,17 +166,17 @@ export async function fetchExploreData(params: {
  * ISR eligibility. Returns the same ``ExploreData`` shape with
  * anonymous defaults: EUR currency, no job-language filter, no geo
  * proximity bias. The client component conditionally re-fetches the
- * personalized variant via :func:`fetchExploreData` when the
+ * personalized variant via :func:`fetchExplorePageData` when the
  * ``logged_in`` hint cookie or any filter searchParams are present.
  *
  * Net effect: anonymous visitors hitting ``/explore`` with no
  * filters get a CDN-cached prerendered page with embedded
  * ``initialData``, no Vercel function invocation. Logged-in users
  * still pay the function call (one fetch on mount, same as today).
- * Filter changes always go through ``fetchExploreData`` because the
+ * Filter changes always go through ``fetchExplorePageData`` because the
  * defaults can't reflect them.
  */
-export async function fetchExploreDefaults(params: {
+export async function fetchExplorePageDefaults(params: {
   locale: string;
 }): Promise<ExploreData> {
   const { locale } = params;

--- a/apps/web/src/lib/actions/my-jobs-stats.ts
+++ b/apps/web/src/lib/actions/my-jobs-stats.ts
@@ -46,7 +46,7 @@ export interface StatsData {
   activityTotal: number;
 }
 
-export async function getStats(params?: {
+export async function getMyJobsStats(params?: {
   from?: string;
   to?: string;
   /**

--- a/apps/web/src/lib/actions/search-input.ts
+++ b/apps/web/src/lib/actions/search-input.ts
@@ -17,7 +17,7 @@
 // implementation.
 //
 // Existing UI callers (search-bar, search-page, company-page-data,
-// explore-data, etc.) continue importing from this module so their
+// explore-page-data, etc.) continue importing from this module so their
 // invocation remains a server-action call. The public REST routes go
 // straight to `@/lib/services/search-input` so they don't pay the
 // server-action machinery cost.

--- a/apps/web/src/lib/actions/search.ts
+++ b/apps/web/src/lib/actions/search.ts
@@ -71,10 +71,10 @@ export async function getExperienceHistogram(
   return service.getExperienceHistogram(...args);
 }
 
-export async function loadMorePostings(
-  ...args: Parameters<typeof service.loadMorePostings>
-): ReturnType<typeof service.loadMorePostings> {
-  return service.loadMorePostings(...args);
+export async function getMorePostings(
+  ...args: Parameters<typeof service.getMorePostings>
+): ReturnType<typeof service.getMorePostings> {
+  return service.getMorePostings(...args);
 }
 
 export type {

--- a/apps/web/src/lib/actions/stats.ts
+++ b/apps/web/src/lib/actions/stats.ts
@@ -10,7 +10,7 @@ import { company, jobPosting } from "@/db/schema";
 // from Redis-backed `cached(..., { ttl: 21600 })` in #2884 (bucket 5).
 // Returns a plain serializable object; Number coercions stay inside the
 // cache boundary so the cached value is the final shape consumers see.
-export async function getStats() {
+export async function getSiteStats() {
   "use cache";
   cacheLife("hours");
   const [[companyRow], [jobRow]] = await Promise.all([

--- a/apps/web/src/lib/client-cookies.ts
+++ b/apps/web/src/lib/client-cookies.ts
@@ -11,7 +11,7 @@ export const LOGGED_IN_COOKIE = "logged_in";
  * Name of the non-httpOnly cookie that persists anonymous-viewer
  * `jobLanguages` preferences. The same cookie is the canonical source
  * of truth on the server (read by `viewer.ts::getViewerLanguages` and
- * `explore-data.ts::fetchExploreData`); the client only needs to know
+ * `explore-page-data.ts::fetchExplorePageData`); the client only needs to know
  * whether it's set so it can decide to re-fetch the personalised
  * `ExploreData` instead of using the anon-default static prerender
  * (#2850). MUST stay in sync with `lib/anon-preferences.ts`.

--- a/apps/web/src/lib/services/company.ts
+++ b/apps/web/src/lib/services/company.ts
@@ -1086,7 +1086,7 @@ async function _parseSimilarFilters(
   // threshold MUST be in EUR-equivalent units. Without this, "100K USD" was
   // compared against EUR-indexed values, silently excluding US roles paying
   // $100K (their `salary_eur` ≈ 92,000 < 100,000). Mirrors the fix in
-  // `explore-data.ts` / `company-page-data.ts` (issue #3178).
+  // `explore-page-data.ts` / `company-page-data.ts` (issue #3178).
   //
   // The strip is a client component that calls this server action with the
   // URL search params from `useSearchParams()`. The toolbar omits `salcur`

--- a/apps/web/src/lib/services/search.ts
+++ b/apps/web/src/lib/services/search.ts
@@ -452,7 +452,7 @@ export async function getExperienceHistogram(filters?: HistogramFilters): Promis
 
 // ── Load more postings ─────────────────────────────────────────────
 
-export async function loadMorePostings(params: {
+export async function getMorePostings(params: {
   companyId: string;
   keywords: string[];
   locationIds?: number[];

--- a/apps/web/src/lib/viewer-tz.ts
+++ b/apps/web/src/lib/viewer-tz.ts
@@ -8,7 +8,7 @@
  *    WebViews, exotic regex shenanigans, etc.)
  *
  * The fallback matches the server-side default in
- * `getStats({ tz })`, so the worst case is pre-#3199 behaviour
+ * `getMyJobsStats({ tz })`, so the worst case is pre-#3199 behaviour
  * (UTC-bucketed days) instead of a crash.
  */
 export function getViewerTz(): string {

--- a/apps/web/vitest.coverage.config.ts
+++ b/apps/web/vitest.coverage.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     environment: "happy-dom",
     globals: true,
     include: [
-      "src/lib/actions/__tests__/{bootstrap,company-page-data-defaults,explore-data-salary-currency,locations-hierarchical-counts,locations-macro,request-company}.test.ts",
+      "src/lib/actions/__tests__/{bootstrap,company-page-data-defaults,explore-page-data-salary-currency,locations-hierarchical-counts,locations-macro,request-company}.test.ts",
       "src/lib/search/**/*.test.{ts,tsx}",
       "src/lib/__tests__/{salary,sanitize}.test.ts",
       "app/api/v1/**/*.test.{ts,tsx}",
@@ -31,7 +31,7 @@ export default defineConfig({
         "app/api/v1/watchlist/create/route.ts",
         "src/lib/actions/bootstrap.ts",
         "src/lib/actions/company-page-data.ts",
-        "src/lib/actions/explore-data.ts",
+        "src/lib/actions/explore-page-data.ts",
         "src/lib/services/locations.ts",
         "src/lib/actions/request-company.ts",
         "src/lib/search/canonicalize-filters.ts",


### PR DESCRIPTION
## Summary
- document server-action naming tiers in `apps/web/docs/data-fetching.md`
- rename ambiguous/drifting read actions: `getSiteStats`, `getMyJobsStats`, `getMorePostings`, `fetchExplorePageData`, and `fetchExplorePageDefaults`
- add a Vitest architecture guard for globally unique action exports, no `load*` exports, and `fetch*` reserved for bootstrap/page-data bundles

## Reproduction / baseline
- repo scan reproduced duplicate exported `getStats` in `actions/stats.ts` and `actions/my-jobs-stats.ts`
- repo scan reproduced `loadMorePostings` under `actions/search.ts`
- repo scan reproduced page-data fetchers without `PageData` names/docs
- read-only production baseline returned 200 for `/en`, `/en/explore`, and `/en/progress`

## Validation
- `cd apps/web && pnpm exec vitest run src/lib/actions/__tests__/naming-conventions.test.ts src/lib/actions/__tests__/explore-page-data-salary-currency.test.ts src/lib/actions/__tests__/my-jobs-stats-tz.test.ts src/lib/actions/__tests__/stats-no-octokit.test.ts app/'[lang]'/'(app)'/explore/__tests__/explore-content.test.tsx src/components/search/__tests__/company-card.test.tsx src/components/search/__tests__/company-card-posting-order.test.tsx src/components/search/__tests__/company-card-scroll-stability.test.tsx src/components/search/__tests__/company-card-nested-buttons.test.tsx`
- `cd apps/web && pnpm lint`
- `cd apps/web && pnpm typecheck`
- `cd apps/web && pnpm test` (`152 files / 1304 tests`)
- `cd apps/web && pnpm build` (passed with existing missing-local-env warnings)
- stale-name grep for old action names returned no matches
- `git diff --check`

Closes #3237
