### PR TITLE
Add comments to i18n descriptors

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
@@ -61,12 +61,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       if (detail.companies.length > 3) {
         names.push(i18n._({
           id: "watchlist.meta.moreCompanies",
+          comment: "SEO metadata suffix when a watchlist includes more companies than can be listed by name.",
           message: "{count} more",
           values: { count: detail.companies.length - 3 },
         }));
       }
       parts.push(i18n._({
         id: "watchlist.meta.jobsAt",
+        comment: "SEO metadata phrase listing companies tracked by a public watchlist.",
         message: "Jobs at {names}",
         values: { names: names.join(", ") },
       }));
@@ -77,6 +79,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     if (detail.filters.locationSlugs?.length) {
       parts.push(i18n._({
         id: "watchlist.meta.inLocations",
+        comment: "SEO metadata phrase listing locations filtered by a public watchlist.",
         message: "in {locations}",
         values: { locations: detail.filters.locationSlugs.slice(0, 2).map((s) => s.replace(/-/g, " ")).join(", ") },
       }));
@@ -85,6 +88,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       ? parts.join(" · ")
       : i18n._({
           id: "watchlist.meta.fallback",
+          comment: "Fallback SEO description for a public watchlist with no description or filters.",
           message: "Job watchlist by @{owner}",
           values: { owner: ownerLabel },
         });
@@ -103,6 +107,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   if (companyCount > 0) {
     description = i18n._({
       id: "watchlist.meta.tracking",
+      comment: "SEO description prefix for a public watchlist; {description} is the existing watchlist summary.",
       message: "{count, plural, one {Tracking # company} other {Tracking # companies}}. {description}",
       values: { count: companyCount, description },
     });

--- a/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
@@ -33,6 +33,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const title = i18n._({
     id: "company.meta.title",
+    comment: "SEO title for a company detail page; {name} is the company name.",
     message: "Jobs at {name}",
     values: { name: company.name },
   });
@@ -40,18 +41,25 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const countText = count > 0
     ? i18n._({
         id: "company.meta.positionCount",
+        comment: "SEO metadata count text for a company page; {count} is the active job count.",
         message: "{count, plural, one {# open position} other {# open positions}}",
         values: { count },
       })
-    : i18n._({ id: "company.meta.openPositions", message: "Open positions" });
+    : i18n._({
+        id: "company.meta.openPositions",
+        comment: "Fallback SEO metadata count text for a company with no active jobs.",
+        message: "Open positions",
+      });
   const description = company.description
     ? i18n._({
         id: "company.meta.descriptionWithInfo",
+        comment: "SEO description for a company page; includes job count, company name, and company summary.",
         message: "{countText} at {name}. {description}",
         values: { countText, name: company.name, description: company.description },
       })
     : i18n._({
         id: "company.meta.descriptionBasic",
+        comment: "SEO description for a company page when no company summary is available.",
         message: "{countText} at {name}",
         values: { countText, name: company.name },
       });

--- a/apps/web/app/[lang]/(app)/explore/page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/page.tsx
@@ -36,9 +36,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const locale = isLocale(lang) ? lang : defaultLocale;
   const { i18n } = await loadCatalog(locale);
 
-  const title = i18n._({ id: "explore.meta.title", message: "Explore Jobs" });
+  const title = i18n._({
+    id: "explore.meta.title",
+    comment: "SEO title for the Explore jobs page.",
+    message: "Explore Jobs",
+  });
   const description = i18n._({
     id: "explore.meta.description",
+    comment: "SEO description for the Explore jobs page.",
     message: "Search jobs across thousands of companies scraped directly from career pages. Filter by seniority, tech stack, salary, and location — then save watchlists and get alerts.",
   });
 

--- a/apps/web/app/[lang]/(public)/about/page.tsx
+++ b/apps/web/app/[lang]/(public)/about/page.tsx
@@ -14,9 +14,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const locale = isLocale(lang) ? lang : defaultLocale;
   const { i18n } = await loadCatalog(locale);
 
-  const title = i18n._({ id: "about.meta.title", message: "About" });
+  const title = i18n._({
+    id: "about.meta.title",
+    comment: "SEO title for the public About page.",
+    message: "About",
+  });
   const description = i18n._({
     id: "about.meta.description",
+    comment: "SEO description for the public About page.",
     message: "Job Seek helps you track the companies you want to work at — watchlists, email alerts, and postings sourced directly from company career pages. Built by Colophon Group, a small developer studio in Switzerland.",
   });
 
@@ -43,8 +48,16 @@ export default async function AboutPage({ params }: Props) {
       <JsonLd data={{
         "@context": "https://schema.org",
         "@type": "WebPage",
-        name: i18n._({ id: "about.meta.title", message: "About" }),
-        description: i18n._({ id: "about.meta.description", message: "Job Seek helps you track the companies you want to work at — watchlists, email alerts, and postings sourced directly from company career pages. Built by Colophon Group, a small developer studio in Switzerland." }),
+        name: i18n._({
+          id: "about.meta.title",
+          comment: "JSON-LD page name for the public About page.",
+          message: "About",
+        }),
+        description: i18n._({
+          id: "about.meta.description",
+          comment: "JSON-LD page description for the public About page.",
+          message: "Job Seek helps you track the companies you want to work at — watchlists, email alerts, and postings sourced directly from company career pages. Built by Colophon Group, a small developer studio in Switzerland.",
+        }),
         url: `${siteConfig.url}/${locale}/about`,
         inLanguage: locale,
         isPartOf: { "@type": "WebSite", url: siteConfig.url },

--- a/apps/web/app/[lang]/(public)/faq/page.tsx
+++ b/apps/web/app/[lang]/(public)/faq/page.tsx
@@ -14,9 +14,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const locale = isLocale(lang) ? lang : defaultLocale;
   const { i18n } = await loadCatalog(locale);
 
-  const title = i18n._({ id: "faq.meta.title", message: "FAQ" });
+  const title = i18n._({
+    id: "faq.meta.title",
+    comment: "SEO title for the public FAQ page.",
+    message: "FAQ",
+  });
   const description = i18n._({
     id: "faq.meta.description",
+    comment: "SEO description for the public FAQ page.",
     message: "Answers to common questions about Job Seek — how we crawl career pages, what the free and Pro plans include, how we handle your data, and how to opt out.",
   });
 
@@ -41,56 +46,56 @@ export default async function FaqPage({ params }: Props) {
 
   const faqItems = [
     {
-      q: i18n._({ id: "faq.q.whatIsJobseek", message: "What is Job Seek?" }),
-      a: i18n._({ id: "faq.a.whatIsJobseek", message: "Job Seek helps you track the companies you actually want to work at. Build a watchlist, get email alerts when new roles open up, and track applications in one place. Postings come straight from company career pages, so you see them within hours of going live — typically before LinkedIn or Indeed cross-post them." }),
+      q: i18n._({ id: "faq.q.whatIsJobseek", comment: "FAQ question asking for a short product definition.", message: "What is Job Seek?" }),
+      a: i18n._({ id: "faq.a.whatIsJobseek", comment: "FAQ answer explaining what Job Seek does for targeted job seekers.", message: "Job Seek helps you track the companies you actually want to work at. Build a watchlist, get email alerts when new roles open up, and track applications in one place. Postings come straight from company career pages, so you see them within hours of going live — typically before LinkedIn or Indeed cross-post them." }),
     },
     {
-      q: i18n._({ id: "faq.q.targetedSeeker", message: "Is Job Seek for me if I already know which companies I want to work for?" }),
-      a: i18n._({ id: "faq.a.targetedSeeker", message: "Yes — that's the use case we built around. Add the companies you care about to a watchlist, set your filters (role, location, seniority, salary), and Job Seek monitors their career pages and alerts you the moment new roles match. You don't have to keep checking each company's site by hand or fight LinkedIn's algorithm." }),
+      q: i18n._({ id: "faq.q.targetedSeeker", comment: "FAQ question about whether the product suits company-targeted job seekers.", message: "Is Job Seek for me if I already know which companies I want to work for?" }),
+      a: i18n._({ id: "faq.a.targetedSeeker", comment: "FAQ answer explaining the company watchlist use case.", message: "Yes — that's the use case we built around. Add the companies you care about to a watchlist, set your filters (role, location, seniority, salary), and Job Seek monitors their career pages and alerts you the moment new roles match. You don't have to keep checking each company's site by hand or fight LinkedIn's algorithm." }),
     },
     {
-      q: i18n._({ id: "faq.q.howOftenUpdated", message: "How often are job listings updated?" }),
-      a: i18n._({ id: "faq.a.howOftenUpdated", message: "The crawler discovers new postings on an hourly cycle and refreshes job details daily. Most roles appear within hours of being published on a company's careers page." }),
+      q: i18n._({ id: "faq.q.howOftenUpdated", comment: "FAQ question about job listing refresh cadence.", message: "How often are job listings updated?" }),
+      a: i18n._({ id: "faq.a.howOftenUpdated", comment: "FAQ answer explaining crawler discovery and refresh frequency.", message: "The crawler discovers new postings on an hourly cycle and refreshes job details daily. Most roles appear within hours of being published on a company's careers page." }),
     },
     {
-      q: i18n._({ id: "faq.q.differentiation", message: "What makes Job Seek different from LinkedIn or Indeed?" }),
-      a: i18n._({ id: "faq.a.differentiation", message: "We index company career pages directly, not third-party feeds. No recruiter spam, no reposted ghost jobs, and we re-check companies frequently — so most roles show up here within hours of being published. We're built for users who already know which companies they want to work at, not broad 'find me any job' searches." }),
+      q: i18n._({ id: "faq.q.differentiation", comment: "FAQ question comparing Job Seek with general job boards.", message: "What makes Job Seek different from LinkedIn or Indeed?" }),
+      a: i18n._({ id: "faq.a.differentiation", comment: "FAQ answer explaining direct career-page indexing and no recruiter spam.", message: "We index company career pages directly, not third-party feeds. No recruiter spam, no reposted ghost jobs, and we re-check companies frequently — so most roles show up here within hours of being published. We're built for users who already know which companies they want to work at, not broad 'find me any job' searches." }),
     },
     {
-      q: i18n._({ id: "faq.q.requestCompany", message: "How do I request a company that isn't listed?" }),
-      a: i18n._({ id: "faq.a.requestCompany", message: "Use the request form on the explore page — paste a careers page URL or company name and we'll start indexing it. You can track progress via the issue number we return." }),
+      q: i18n._({ id: "faq.q.requestCompany", comment: "FAQ question about requesting a missing company.", message: "How do I request a company that isn't listed?" }),
+      a: i18n._({ id: "faq.a.requestCompany", comment: "FAQ answer explaining how to request a missing company from the Explore page.", message: "Use the request form on the explore page — paste a careers page URL or company name and we'll start indexing it. You can track progress via the issue number we return." }),
     },
     {
-      q: i18n._({ id: "faq.q.freeVsPro", message: "What's the difference between Free and Pro?" }),
-      a: i18n._({ id: "faq.a.freeVsPro", message: "Free gives you full search across all companies, one watchlist, and the application tracker with interview logging. Pro adds unlimited watchlists and email alerts when new roles match your criteria." }),
+      q: i18n._({ id: "faq.q.freeVsPro", comment: "FAQ question comparing the Free and Pro plans.", message: "What's the difference between Free and Pro?" }),
+      a: i18n._({ id: "faq.a.freeVsPro", comment: "FAQ answer summarizing Free and Pro plan differences.", message: "Free gives you full search across all companies, one watchlist, and the application tracker with interview logging. Pro adds unlimited watchlists and email alerts when new roles match your criteria." }),
     },
     {
-      q: i18n._({ id: "faq.q.whatIsWatchlist", message: "What is a watchlist?" }),
-      a: i18n._({ id: "faq.a.whatIsWatchlist", message: "A watchlist is a saved search with optional company filtering. Pick the companies you care about, set your filters (role, location, seniority, salary), and get a live feed of matching jobs. You can share watchlists publicly or keep them private." }),
+      q: i18n._({ id: "faq.q.whatIsWatchlist", comment: "FAQ question defining a watchlist.", message: "What is a watchlist?" }),
+      a: i18n._({ id: "faq.a.whatIsWatchlist", comment: "FAQ answer explaining saved-search watchlists and sharing options.", message: "A watchlist is a saved search with optional company filtering. Pick the companies you care about, set your filters (role, location, seniority, salary), and get a live feed of matching jobs. You can share watchlists publicly or keep them private." }),
     },
     {
-      q: i18n._({ id: "faq.q.trackerLimit", message: "Is there a limit to how many jobs I can track?" }),
-      a: i18n._({ id: "faq.a.trackerLimit", message: "No. The application tracker has no hard limit — save as many jobs as you want and move them through your pipeline." }),
+      q: i18n._({ id: "faq.q.trackerLimit", comment: "FAQ question about application tracker limits.", message: "Is there a limit to how many jobs I can track?" }),
+      a: i18n._({ id: "faq.a.trackerLimit", comment: "FAQ answer explaining that the application tracker has no hard limit.", message: "No. The application tracker has no hard limit — save as many jobs as you want and move them through your pipeline." }),
     },
     {
-      q: i18n._({ id: "faq.q.crawlingPolicy", message: "How does the crawler behave on my company's website?" }),
-      a: i18n._({ id: "faq.a.crawlingPolicy", message: "We respect robots.txt and TDM-Reservation headers, limit requests to one per site per minute, and use exponential backoff. All requests identify themselves via User-Agent. See our Job Indexing page for full details." }),
+      q: i18n._({ id: "faq.q.crawlingPolicy", comment: "FAQ question for company operators about crawler behavior.", message: "How does the crawler behave on my company's website?" }),
+      a: i18n._({ id: "faq.a.crawlingPolicy", comment: "FAQ answer summarizing crawler politeness, rate limits, and policy compliance.", message: "We respect robots.txt and TDM-Reservation headers, limit requests to one per site per minute, and use exponential backoff. All requests identify themselves via User-Agent. See our Job Indexing page for full details." }),
     },
     {
-      q: i18n._({ id: "faq.q.optOut", message: "Can I opt out of Jobseek indexing my company?" }),
-      a: i18n._({ id: "faq.a.optOut", message: "Yes. Email us and we'll stop crawling your careers site immediately and remove your postings from the index." }),
+      q: i18n._({ id: "faq.q.optOut", comment: "FAQ question about company opt-out from indexing.", message: "Can I opt out of Jobseek indexing my company?" }),
+      a: i18n._({ id: "faq.a.optOut", comment: "FAQ answer explaining how companies can opt out of indexing.", message: "Yes. Email us and we'll stop crawling your careers site immediately and remove your postings from the index." }),
     },
     {
-      q: i18n._({ id: "faq.q.openSource", message: "Is the crawler open source?" }),
-      a: i18n._({ id: "faq.a.openSource", message: "Yes. The crawler and extraction pipeline are fully open source on GitHub. The application code is MIT licensed; job data is CC BY-NC 4.0." }),
+      q: i18n._({ id: "faq.q.openSource", comment: "FAQ question about open-source availability.", message: "Is the crawler open source?" }),
+      a: i18n._({ id: "faq.a.openSource", comment: "FAQ answer explaining crawler source availability and data licensing.", message: "Yes. The crawler and extraction pipeline are fully open source on GitHub. The application code is MIT licensed; job data is CC BY-NC 4.0." }),
     },
     {
-      q: i18n._({ id: "faq.q.dataPrivacy", message: "Does Jobseek sell my data?" }),
-      a: i18n._({ id: "faq.a.dataPrivacy", message: "No. We don't sell, rent, or share your data for marketing. Cookies are session-only with no ads or tracking. You can delete your account and all data is wiped within 30 days." }),
+      q: i18n._({ id: "faq.q.dataPrivacy", comment: "FAQ question about whether user data is sold.", message: "Does Jobseek sell my data?" }),
+      a: i18n._({ id: "faq.a.dataPrivacy", comment: "FAQ answer explaining data privacy, cookies, and account deletion.", message: "No. We don't sell, rent, or share your data for marketing. Cookies are session-only with no ads or tracking. You can delete your account and all data is wiped within 30 days." }),
     },
     {
-      q: i18n._({ id: "faq.q.languages", message: "Which languages does Jobseek support?" }),
-      a: i18n._({ id: "faq.a.languages", message: "The interface is available in English, German, French, and Italian. You can also filter job postings by the language they were written in." }),
+      q: i18n._({ id: "faq.q.languages", comment: "FAQ question about supported interface and job-posting languages.", message: "Which languages does Jobseek support?" }),
+      a: i18n._({ id: "faq.a.languages", comment: "FAQ answer listing interface languages and posting-language filtering.", message: "The interface is available in English, German, French, and Italian. You can also filter job postings by the language they were written in." }),
     },
   ];
 

--- a/apps/web/app/[lang]/(public)/how-we-index/page.tsx
+++ b/apps/web/app/[lang]/(public)/how-we-index/page.tsx
@@ -14,9 +14,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const locale = isLocale(lang) ? lang : defaultLocale;
   const { i18n } = await loadCatalog(locale);
 
-  const title = i18n._({ id: "indexing.meta.title", message: "How We Index" });
+  const title = i18n._({
+    id: "indexing.meta.title",
+    comment: "SEO title for the public Job Indexing methodology page.",
+    message: "How We Index",
+  });
   const description = i18n._({
     id: "indexing.meta.description",
+    comment: "SEO description for the public Job Indexing methodology page.",
     message: "How Job Seek discovers and indexes job postings: our sourcing approach, crawl frequency, rate limits, robots.txt and TDM-Reservation compliance, and how to opt out.",
   });
 
@@ -46,8 +51,16 @@ export default async function HowWeIndexPage({ params }: Props) {
       <JsonLd data={{
         "@context": "https://schema.org",
         "@type": "WebPage",
-        name: i18n._({ id: "indexing.meta.title", message: "How We Index" }),
-        description: i18n._({ id: "indexing.meta.description", message: "How Job Seek discovers and indexes job postings: our sourcing approach, crawl frequency, rate limits, robots.txt and TDM-Reservation compliance, and how to opt out." }),
+        name: i18n._({
+          id: "indexing.meta.title",
+          comment: "JSON-LD page name for the public Job Indexing methodology page.",
+          message: "How We Index",
+        }),
+        description: i18n._({
+          id: "indexing.meta.description",
+          comment: "JSON-LD page description for the public Job Indexing methodology page.",
+          message: "How Job Seek discovers and indexes job postings: our sourcing approach, crawl frequency, rate limits, robots.txt and TDM-Reservation compliance, and how to opt out.",
+        }),
         url: `${siteConfig.url}/${locale}/how-we-index`,
         inLanguage: locale,
         isPartOf: { "@type": "WebSite", url: siteConfig.url },

--- a/apps/web/app/[lang]/(public)/license/page.tsx
+++ b/apps/web/app/[lang]/(public)/license/page.tsx
@@ -14,9 +14,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const locale = isLocale(lang) ? lang : defaultLocale;
   const { i18n } = await loadCatalog(locale);
 
-  const title = i18n._({ id: "license.meta.title", message: "License" });
+  const title = i18n._({
+    id: "license.meta.title",
+    comment: "SEO title for the public License page.",
+    message: "License",
+  });
   const description = i18n._({
     id: "license.meta.description",
+    comment: "SEO description for the public License page.",
     message: "Licensing for Job Seek — application source code is MIT-licensed, job posting data is CC BY-NC 4.0. Learn what you can and cannot do with our code and data.",
   });
 
@@ -48,8 +53,16 @@ export default async function LicensePage({ params }: Props) {
       <JsonLd data={{
         "@context": "https://schema.org",
         "@type": "WebPage",
-        name: i18n._({ id: "license.meta.title", message: "License" }),
-        description: i18n._({ id: "license.meta.description", message: "Licensing for Job Seek — application source code is MIT-licensed, job posting data is CC BY-NC 4.0. Learn what you can and cannot do with our code and data." }),
+        name: i18n._({
+          id: "license.meta.title",
+          comment: "JSON-LD page name for the public License page.",
+          message: "License",
+        }),
+        description: i18n._({
+          id: "license.meta.description",
+          comment: "JSON-LD page description for the public License page.",
+          message: "Licensing for Job Seek — application source code is MIT-licensed, job posting data is CC BY-NC 4.0. Learn what you can and cannot do with our code and data.",
+        }),
         url: `${siteConfig.url}/${locale}/license`,
         inLanguage: locale,
         isPartOf: { "@type": "WebSite", url: siteConfig.url },

--- a/apps/web/app/[lang]/(public)/page.tsx
+++ b/apps/web/app/[lang]/(public)/page.tsx
@@ -17,9 +17,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const locale = isLocale(lang) ? lang : defaultLocale;
   const { i18n } = await loadCatalog(locale);
 
-  const title = i18n._({ id: "home.meta.title", message: "Track the companies you want to work at — Job Seek" });
+  const title = i18n._({
+    id: "home.meta.title",
+    comment: "SEO title for the public homepage.",
+    message: "Track the companies you want to work at — Job Seek",
+  });
   const description = i18n._({
     id: "home.meta.description",
+    comment: "SEO description for the public homepage.",
     message: "Build watchlists of the companies you care about, get email alerts when new roles open up, and track applications in one place. Postings come direct from company career pages, within hours of going live — no recruiter spam, no reposted listings.",
   });
 
@@ -49,8 +54,16 @@ export default async function HomePage({ params }: Props) {
       <JsonLd data={{
         "@context": "https://schema.org",
         "@type": "WebPage",
-        name: i18n._({ id: "home.meta.title", message: "Track the companies you want to work at — Job Seek" }),
-        description: i18n._({ id: "home.meta.description", message: "Build watchlists of the companies you care about, get email alerts when new roles open up, and track applications in one place. Postings come direct from company career pages, within hours of going live — no recruiter spam, no reposted listings." }),
+        name: i18n._({
+          id: "home.meta.title",
+          comment: "JSON-LD page name for the public homepage.",
+          message: "Track the companies you want to work at — Job Seek",
+        }),
+        description: i18n._({
+          id: "home.meta.description",
+          comment: "JSON-LD page description for the public homepage.",
+          message: "Build watchlists of the companies you care about, get email alerts when new roles open up, and track applications in one place. Postings come direct from company career pages, within hours of going live — no recruiter spam, no reposted listings.",
+        }),
         url: `${siteConfig.url}/${locale}`,
         inLanguage: locale,
         isPartOf: { "@type": "WebSite", url: siteConfig.url },

--- a/apps/web/app/[lang]/(public)/privacy-policy/page.tsx
+++ b/apps/web/app/[lang]/(public)/privacy-policy/page.tsx
@@ -14,9 +14,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const locale = isLocale(lang) ? lang : defaultLocale;
   const { i18n } = await loadCatalog(locale);
 
-  const title = i18n._({ id: "privacy.meta.title", message: "Privacy Policy" });
+  const title = i18n._({
+    id: "privacy.meta.title",
+    comment: "SEO title for the public Privacy Policy page.",
+    message: "Privacy Policy",
+  });
   const description = i18n._({
     id: "privacy.meta.description",
+    comment: "SEO description for the public Privacy Policy page.",
     message: "Job Seek privacy policy — what personal data we collect, how we use it, your GDPR rights, cookie policy, and how to request deletion of your account and data.",
   });
 
@@ -47,8 +52,16 @@ export default async function PrivacyPolicyPage({ params }: Props) {
       <JsonLd data={{
         "@context": "https://schema.org",
         "@type": "WebPage",
-        name: i18n._({ id: "privacy.meta.title", message: "Privacy Policy" }),
-        description: i18n._({ id: "privacy.meta.description", message: "Job Seek privacy policy — what personal data we collect, how we use it, your GDPR rights, cookie policy, and how to request deletion of your account and data." }),
+        name: i18n._({
+          id: "privacy.meta.title",
+          comment: "JSON-LD page name for the public Privacy Policy page.",
+          message: "Privacy Policy",
+        }),
+        description: i18n._({
+          id: "privacy.meta.description",
+          comment: "JSON-LD page description for the public Privacy Policy page.",
+          message: "Job Seek privacy policy — what personal data we collect, how we use it, your GDPR rights, cookie policy, and how to request deletion of your account and data.",
+        }),
         url: `${siteConfig.url}/${locale}/privacy-policy`,
         inLanguage: locale,
         isPartOf: { "@type": "WebSite", url: siteConfig.url },

--- a/apps/web/app/[lang]/(public)/terms/page.tsx
+++ b/apps/web/app/[lang]/(public)/terms/page.tsx
@@ -14,9 +14,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const locale = isLocale(lang) ? lang : defaultLocale;
   const { i18n } = await loadCatalog(locale);
 
-  const title = i18n._({ id: "terms.meta.title", message: "Terms of Service" });
+  const title = i18n._({
+    id: "terms.meta.title",
+    comment: "SEO title for the public Terms of Service page.",
+    message: "Terms of Service",
+  });
   const description = i18n._({
     id: "terms.meta.description",
+    comment: "SEO description for the public Terms of Service page.",
     message: "Terms of Service for Job Seek — usage rules, intellectual property, account responsibilities, limitation of liability, and governing law for the job search platform.",
   });
 
@@ -47,8 +52,16 @@ export default async function TermsPage({ params }: Props) {
       <JsonLd data={{
         "@context": "https://schema.org",
         "@type": "WebPage",
-        name: i18n._({ id: "terms.meta.title", message: "Terms of Service" }),
-        description: i18n._({ id: "terms.meta.description", message: "Terms of Service for Job Seek — usage rules, intellectual property, account responsibilities, limitation of liability, and governing law for the job search platform." }),
+        name: i18n._({
+          id: "terms.meta.title",
+          comment: "JSON-LD page name for the public Terms of Service page.",
+          message: "Terms of Service",
+        }),
+        description: i18n._({
+          id: "terms.meta.description",
+          comment: "JSON-LD page description for the public Terms of Service page.",
+          message: "Terms of Service for Job Seek — usage rules, intellectual property, account responsibilities, limitation of liability, and governing law for the job search platform.",
+        }),
         url: `${siteConfig.url}/${locale}/terms`,
         inLanguage: locale,
         isPartOf: { "@type": "WebSite", url: siteConfig.url },

--- a/apps/web/app/[lang]/layout.tsx
+++ b/apps/web/app/[lang]/layout.tsx
@@ -84,6 +84,7 @@ export default async function LocaleLayout({ children, params }: Props) {
               logo: `${siteConfig.url}${siteConfig.logo.src}`,
               description: i18n._({
                 id: "app.schema.org.description",
+                comment: "Organization JSON-LD description for Job Seek and Colophon Group.",
                 message: "Company-tracking tool for targeted job seekers — watchlists, email alerts, and postings sourced directly from company career pages. Built by Colophon Group, a small developer studio in Switzerland.",
               }),
               foundingDate: "2025",
@@ -119,6 +120,7 @@ export default async function LocaleLayout({ children, params }: Props) {
               inLanguage: locale,
               description: i18n._({
                 id: "app.schema.description",
+                comment: "WebApplication JSON-LD description for Job Seek.",
                 message: "Company-tracking tool for job seekers who already know which companies they want to work at. Build watchlists, get email alerts when new roles open up, and track applications in one place — postings sourced directly from company career pages.",
               }),
               offers: [
@@ -127,7 +129,11 @@ export default async function LocaleLayout({ children, params }: Props) {
                   name: "Free",
                   price: "0",
                   priceCurrency: "USD",
-                  description: i18n._({ id: "app.schema.offer.free", message: "Full search, 1 watchlist, application tracker" }),
+                  description: i18n._({
+                    id: "app.schema.offer.free",
+                    comment: "WebApplication JSON-LD offer description for the Free plan.",
+                    message: "Full search, 1 watchlist, application tracker",
+                  }),
                 },
                 {
                   "@type": "Offer",
@@ -135,14 +141,34 @@ export default async function LocaleLayout({ children, params }: Props) {
                   price: "10",
                   priceCurrency: "USD",
                   billingPeriod: "P1M",
-                  description: i18n._({ id: "app.schema.offer.pro", message: "Unlimited watchlists, email alerts on new matches" }),
+                  description: i18n._({
+                    id: "app.schema.offer.pro",
+                    comment: "WebApplication JSON-LD offer description for the Pro plan.",
+                    message: "Unlimited watchlists, email alerts on new matches",
+                  }),
                 },
               ],
               featureList: [
-                i18n._({ id: "app.schema.feature.monitor", message: "Monitor company career pages" }),
-                i18n._({ id: "app.schema.feature.alerts", message: "Real-time job posting alerts" }),
-                i18n._({ id: "app.schema.feature.languages", message: "Multi-language support" }),
-                i18n._({ id: "app.schema.feature.watchlists", message: "Watchlists and application tracking" }),
+                i18n._({
+                  id: "app.schema.feature.monitor",
+                  comment: "WebApplication JSON-LD feature list item about career-page monitoring.",
+                  message: "Monitor company career pages",
+                }),
+                i18n._({
+                  id: "app.schema.feature.alerts",
+                  comment: "WebApplication JSON-LD feature list item about job alert notifications.",
+                  message: "Real-time job posting alerts",
+                }),
+                i18n._({
+                  id: "app.schema.feature.languages",
+                  comment: "WebApplication JSON-LD feature list item about supported interface languages.",
+                  message: "Multi-language support",
+                }),
+                i18n._({
+                  id: "app.schema.feature.watchlists",
+                  comment: "WebApplication JSON-LD feature list item about watchlists and application tracking.",
+                  message: "Watchlists and application tracking",
+                }),
               ],
             }} />
             {children}

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -57,8 +57,9 @@ msgstr "(öffnet in neuem Tab)"
 msgid "search.detail.showMoreLocations"
 msgstr "{0} weitere"
 
+#. SEO metadata count text for a company page; {count} is the active job count.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:41
+#: app/[lang]/(app)/company/[slug]/page.tsx:42
 msgid "company.meta.positionCount"
 msgstr "{count, plural, one {# offene Stelle} other {# offene Stellen}}"
 
@@ -86,8 +87,9 @@ msgstr "{count, plural, one {offene Stelle} other {offene Stellen}}"
 msgid "blog.mention.watchlist.companiesLabel"
 msgstr "{count, plural, one {Unternehmen} other {Unternehmen}}"
 
+#. SEO description prefix for a public watchlist; {description} is the existing watchlist summary.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:104
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:108
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {# Unternehmen beobachtet} other {# Unternehmen beobachtet}}. {description}"
 
@@ -97,18 +99,21 @@ msgstr "{count, plural, one {# Unternehmen beobachtet} other {# Unternehmen beob
 msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} Bewerbungen am {date}"
 
+#. SEO metadata suffix when a watchlist includes more companies than can be listed by name.
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:62
 msgid "watchlist.meta.moreCompanies"
 msgstr "{count} weitere"
 
+#. SEO description for a company page when no company summary is available.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:53
+#: app/[lang]/(app)/company/[slug]/page.tsx:60
 msgid "company.meta.descriptionBasic"
 msgstr "{countText} bei {name}"
 
+#. SEO description for a company page; includes job count, company name, and company summary.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:48
+#: app/[lang]/(app)/company/[slug]/page.tsx:54
 msgid "company.meta.descriptionWithInfo"
 msgstr "{countText} bei {name}. {description}"
 
@@ -178,14 +183,17 @@ msgstr "1. MCP installieren"
 msgid "app.home.request.agent.run_heading"
 msgstr "2. Prompt ausführen"
 
+#. FAQ answer explaining saved-search watchlists and sharing options.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:69
+#: app/[lang]/(public)/faq/page.tsx:74
 msgid "faq.a.whatIsWatchlist"
 msgstr "Eine Watchlist ist eine gespeicherte Suche mit optionaler Unternehmensfilterung. Wähle die Unternehmen, die dich interessieren, setze deine Filter (Rolle, Standort, Seniorität, Gehalt) und erhalte einen Live-Feed passender Stellen. Du kannst Watchlists öffentlich teilen oder privat halten."
 
+#. JSON-LD page name for the public About page.
+#. SEO title for the public About page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/page.tsx:17
-#: app/[lang]/(public)/about/page.tsx:46
+#: app/[lang]/(public)/about/page.tsx:51
 msgid "about.meta.title"
 msgstr "Über uns"
 
@@ -224,8 +232,8 @@ msgstr "Kontomenü"
 #. Active postings count on company page
 #. Active postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:561
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:571
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:572
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:582
 msgid "company.page.active"
 msgstr "aktiv"
 
@@ -239,7 +247,7 @@ msgstr "aktiv"
 
 #. Active matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:121
+#: src/components/search/company-card.tsx:122
 msgid "search.card.active"
 msgstr "aktiv"
 
@@ -287,7 +295,7 @@ msgstr "Standort- oder Stichwortfilter hinzufügen…"
 
 #. Placeholder in the add location input
 #. js-lingui-explicit-id
-#: src/components/search/location-pills.tsx:174
+#: src/components/search/location-pills.tsx:170
 msgid "search.locations.addPlaceholder"
 msgstr "Standort hinzufügen..."
 
@@ -305,7 +313,7 @@ msgstr "Agent-Prompt"
 
 #. Footer shown after all paged countries have been loaded into the location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:816
+#: src/components/search/location-search-modal.tsx:825
 msgid "search.locationModal.allLoaded"
 msgstr "Alle {totalCountries} Länder geladen"
 
@@ -333,16 +341,16 @@ msgstr "Alle Sprachen"
 msgid "settings.general.jobLanguages.all"
 msgstr "Alle Sprachen"
 
-#. Button to open all-locations modal on company page
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:346
-msgid "company.page.allLocations"
-msgstr "Alle Standorte"
-
 #. Title for the all-locations modal on company page
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:268
 msgid "company.locationModal.title"
+msgstr "Alle Standorte"
+
+#. Button to open all-locations modal on company page
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:346
+msgid "company.page.allLocations"
 msgstr "Alle Standorte"
 
 #. Link to sign-in page from sign-up
@@ -353,12 +361,13 @@ msgstr "Bereits ein Konto? <0>Anmelden</0>"
 
 #. Username is taken
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:292
+#: src/components/settings/AccountSettings.tsx:298
 msgid "settings.account.username.taken"
 msgstr "Bereits vergeben"
 
+#. SEO description for the public FAQ page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:18
+#: app/[lang]/(public)/faq/page.tsx:22
 msgid "faq.meta.description"
 msgstr "Antworten auf häufige Fragen zu Job Seek — wie wir Karriereseiten crawlen, was die Tarife enthalten, wie wir mit deinen Daten umgehen und wie du dich abmelden kannst."
 
@@ -434,6 +443,12 @@ msgstr "Beworben"
 msgid "search.tracker.applied"
 msgstr "Beworben"
 
+#. Applied status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:20
+msgid "myJobs.status.applied"
+msgstr "Beworben"
+
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
@@ -444,12 +459,6 @@ msgstr "Beworben"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.applied"
-msgstr "Beworben"
-
-#. Applied status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:20
-msgid "myJobs.status.applied"
 msgstr "Beworben"
 
 #. Apply salary filter
@@ -484,13 +493,13 @@ msgstr "Als letztes Mittel parsen wir die Karriereseiten selbst, bevorzugen dabe
 
 #. Username too short hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:280
+#: src/components/settings/AccountSettings.tsx:286
 msgid "settings.account.username.tooShort"
 msgstr "Mindestens 3 Zeichen"
 
 #. Username too long hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:282
+#: src/components/settings/AccountSettings.tsx:288
 msgid "settings.account.username.tooLong"
 msgstr "Maximal 30 Zeichen"
 
@@ -502,7 +511,7 @@ msgstr "Aug"
 
 #. Username is available
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:290
+#: src/components/settings/AccountSettings.tsx:296
 msgid "settings.account.username.available"
 msgstr "Verfügbar"
 
@@ -562,18 +571,18 @@ msgstr "Blog"
 msgid "blog.post.backToIndex"
 msgstr "Blog"
 
+#. Footer link to /blog index page
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:52
+msgid "common.footer.blog"
+msgstr "Blog"
+
 #. Nav link: Blog
 #. Nav link: Blog
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:74
 #: src/components/MobileMenu.tsx:98
 msgid "common.nav.blog"
-msgstr "Blog"
-
-#. Footer link to /blog index page
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
-msgid "common.footer.blog"
 msgstr "Blog"
 
 #. Subtitle on the sign-in CTA card shown to anonymous users at the end of the similar-companies strip
@@ -588,9 +597,11 @@ msgstr "Alle Mitbewerber durchsuchen"
 msgid "indexing.oss.browseRepo"
 msgstr "Repository ansehen unter"
 
+#. JSON-LD page description for the public homepage.
+#. SEO description for the public homepage.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:21
-#: app/[lang]/(public)/page.tsx:53
+#: app/[lang]/(public)/page.tsx:25
+#: app/[lang]/(public)/page.tsx:62
 msgid "home.meta.description"
 msgstr "Erstelle Watchlists mit den Unternehmen, die dich interessieren, lasse dich per E-Mail benachrichtigen, wenn neue Stellen geöffnet werden, und verfolge Bewerbungen an einem Ort. Stellen kommen direkt von den Karriereseiten der Unternehmen, innerhalb weniger Stunden nach Veröffentlichung — kein Recruiter-Spam, keine wiederveröffentlichten Listings."
 
@@ -612,8 +623,9 @@ msgstr "Von Jobsuchenden entwickelt, für Jobsuchende"
 msgid "terms.hero.description"
 msgstr "Mit der Nutzung von Job Seek stimmst du diesen Bedingungen zu. Hier eine verständliche Zusammenfassung."
 
+#. FAQ question about company opt-out from indexing.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:80
+#: app/[lang]/(public)/faq/page.tsx:85
 msgid "faq.q.optOut"
 msgstr "Kann ich die Indexierung meines Unternehmens durch Jobseek ablehnen?"
 
@@ -633,7 +645,7 @@ msgstr "Abbrechen"
 
 #. Cancel delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:532
+#: src/components/settings/AccountSettings.tsx:538
 msgid "settings.account.delete.cancel"
 msgstr "Abbrechen"
 
@@ -645,7 +657,7 @@ msgstr "ändern"
 
 #. Change email section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:370
+#: src/components/settings/AccountSettings.tsx:376
 msgid "settings.account.email.title"
 msgstr "E-Mail ändern"
 
@@ -673,21 +685,21 @@ msgstr "Ändere dein Passwort über einen sicheren E-Mail-Link."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Ändern…"
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "E-Mail überprüfen"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
 msgstr "E-Mail prüfen"
 
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
+msgstr "E-Mail überprüfen"
+
 #. Checking username availability
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:288
+#: src/components/settings/AccountSettings.tsx:294
 msgid "settings.account.username.checking"
 msgstr "Verfügbarkeit wird geprüft..."
 
@@ -725,7 +737,7 @@ msgstr "Wähle aus, in welchen Sprachen du Stellenanzeigen sehen möchtest."
 #. Location type label for cities
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:35
-#: src/components/search/location-pills.tsx:31
+#: src/components/search/location-pills.tsx:32
 msgid "location.type.city"
 msgstr "Stadt"
 
@@ -745,7 +757,7 @@ msgstr "Alle entfernen"
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:645
-#: src/components/search/search-toolbar.tsx:367
+#: src/components/search/search-toolbar.tsx:368
 msgid "search.filters.clearAll"
 msgstr "Alle löschen"
 
@@ -773,12 +785,6 @@ msgstr "Klicken zum Umbenennen"
 msgid "indexing.ingestion.s2.title"
 msgstr "Client-APIs als Zweites."
 
-#. Aria label for close button on add-companies modal
-#. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:201
-msgid "watchlists.companyModal.close"
-msgstr "Schließen"
-
 #. Aria label for upgrade modal close button
 #. js-lingui-explicit-id
 #: src/components/ui/upgrade-modal.tsx:59
@@ -791,16 +797,16 @@ msgstr "Schließen"
 msgid "settings.jobLanguages.modal.close"
 msgstr "Schließen"
 
+#. Aria label for close button on add-companies modal
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-search-modal.tsx:201
+msgid "watchlists.companyModal.close"
+msgstr "Schließen"
+
 #. Aria label for the technology modal close button
 #. js-lingui-explicit-id
 #: src/components/search/technology-modal.tsx:117
 msgid "search.technologyModal.close"
-msgstr "Schließen"
-
-#. Aria label for the seniority modal close button
-#. js-lingui-explicit-id
-#: src/components/search/seniority-modal.tsx:65
-msgid "search.seniorityModal.close"
 msgstr "Schließen"
 
 #. Aria label for the work-mode modal close button
@@ -809,10 +815,22 @@ msgstr "Schließen"
 msgid "search.workModeModal.close"
 msgstr "Schließen"
 
+#. Aria label for the seniority modal close button
+#. js-lingui-explicit-id
+#: src/components/search/seniority-modal.tsx:65
+msgid "search.seniorityModal.close"
+msgstr "Schließen"
+
 #. Aria label for the salary modal close button
 #. js-lingui-explicit-id
 #: src/components/search/salary-modal.tsx:254
 msgid "search.salaryModal.close"
+msgstr "Schließen"
+
+#. Aria label for close button on the company-page all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:275
+msgid "company.locationModal.close"
 msgstr "Schließen"
 
 #. Aria label for the occupation modal close button
@@ -823,7 +841,7 @@ msgstr "Schließen"
 
 #. Aria label for the location modal close button
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:479
+#: src/components/search/location-search-modal.tsx:488
 msgid "search.locationModal.close"
 msgstr "Schließen"
 
@@ -837,12 +855,6 @@ msgstr "Schließen"
 #. js-lingui-explicit-id
 #: src/components/search/employment-type-modal.tsx:82
 msgid "search.employmentTypeModal.close"
-msgstr "Schließen"
-
-#. Aria label for close button on the company-page all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:275
-msgid "company.locationModal.close"
 msgstr "Schließen"
 
 #. Aria label for job detail panel close button
@@ -865,13 +877,13 @@ msgstr "Menü schließen"
 
 #. Label for inactive/closed job postings on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:663
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:676
 msgid "company.page.closed"
 msgstr "Geschlossen"
 
 #. Label for inactive/closed job postings on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:159
+#: src/components/search/company-card.tsx:171
 msgid "search.card.closed"
 msgstr "Geschlossen"
 
@@ -907,7 +919,7 @@ msgstr "Demnächst verfügbar"
 
 #. Section header for company suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:882
+#: src/components/search/search-bar.tsx:878
 msgid "search.bar.companies"
 msgstr "Unternehmen"
 
@@ -945,15 +957,17 @@ msgstr "Unternehmen"
 #. Heading shown when the company URL slug doesn't resolve to a known company
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/company/[slug]/company-content.tsx:51
-#: app/[lang]/(app)/company/[slug]/page.tsx:89
+#: app/[lang]/(app)/company/[slug]/page.tsx:97
 msgid "company.notFound.title"
 msgstr "Unternehmen nicht gefunden"
 
+#. WebApplication JSON-LD description for Job Seek.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:120
+#: app/[lang]/layout.tsx:121
 msgid "app.schema.description"
 msgstr "Unternehmens-Tracking-Tool für Jobsuchende, die schon wissen, bei welchen Unternehmen sie arbeiten möchten. Erstelle Watchlists, erhalte E-Mail-Benachrichtigungen, sobald neue Stellen frei werden, und verfolge Bewerbungen an einem Ort — Stellenanzeigen direkt von den Karriereseiten der Unternehmen."
 
+#. Organization JSON-LD description for Job Seek and Colophon Group.
 #. js-lingui-explicit-id
 #: app/[lang]/layout.tsx:85
 msgid "app.schema.org.description"
@@ -961,7 +975,7 @@ msgstr "Unternehmens-Tracking-Tool für gezielte Jobsuchende — Watchlists, E-M
 
 #. Confirm delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:525
+#: src/components/settings/AccountSettings.tsx:531
 msgid "settings.account.delete.confirm"
 msgstr "Löschen bestätigen"
 
@@ -973,15 +987,21 @@ msgstr "Passwort bestätigen"
 
 #. Connect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:475
+#: src/components/settings/AccountSettings.tsx:481
 msgid "settings.account.socials.connect"
 msgstr "Verbinden"
 
 #. Connected accounts section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:450
+#: src/components/settings/AccountSettings.tsx:456
 msgid "settings.account.socials.title"
 msgstr "Verknüpfte Konten"
+
+#. Footer link to contact email
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Kontakt"
 
 #. TOC: Contact
 #. js-lingui-explicit-id
@@ -995,22 +1015,16 @@ msgstr "Kontakt"
 msgid "license.contact.title"
 msgstr "Kontakt"
 
-#. Footer link to contact email
+#. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Kontakt"
+#: src/components/HowWeIndexContent.tsx:21
+msgid "indexing.toc.title"
+msgstr "Inhalt"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:17
 msgid "license.toc.title"
-msgstr "Inhalt"
-
-#. Table of contents heading
-#. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:21
-msgid "indexing.toc.title"
 msgstr "Inhalt"
 
 #. Button to continue to app after verification
@@ -1083,7 +1097,7 @@ msgstr "Prompt kopieren"
 #. Location type label for countries
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:33
-#: src/components/search/location-pills.tsx:29
+#: src/components/search/location-pills.tsx:30
 msgid "location.type.country"
 msgstr "Land"
 
@@ -1119,7 +1133,7 @@ msgstr "Erstellen Sie ein kostenloses Konto, um alle Ergebnisse zu durchsuchen, 
 
 #. Tooltip explaining save search creates a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:117
+#: src/components/search/save-search-button.tsx:120
 msgid "search.saveSearch.tooltip"
 msgstr "Erstelle eine Watchlist aus deinen aktuellen Filtern"
 
@@ -1227,13 +1241,13 @@ msgstr "Löschen"
 
 #. Delete account section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:508
+#: src/components/settings/AccountSettings.tsx:514
 msgid "settings.account.delete.title"
 msgstr "Konto löschen"
 
 #. Delete account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:518
+#: src/components/settings/AccountSettings.tsx:524
 msgid "settings.account.delete.button"
 msgstr "Mein Konto löschen"
 
@@ -1245,7 +1259,7 @@ msgstr "Watchlist löschen?"
 
 #. Delete button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:524
+#: src/components/settings/AccountSettings.tsx:530
 msgid "settings.account.delete.deleting"
 msgstr "Löschen…"
 
@@ -1287,7 +1301,7 @@ msgstr "Benachrichtigungen deaktivieren"
 
 #. Disconnect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:474
+#: src/components/settings/AccountSettings.tsx:480
 msgid "settings.account.socials.disconnect"
 msgstr "Trennen"
 
@@ -1297,8 +1311,9 @@ msgstr "Trennen"
 msgid "watchlists.explore.publicTitle"
 msgstr "Öffentliche Watchlists entdecken"
 
+#. FAQ question about whether user data is sold.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:88
+#: app/[lang]/(public)/faq/page.tsx:93
 msgid "faq.q.dataPrivacy"
 msgstr "Verkauft Jobseek meine Daten?"
 
@@ -1455,40 +1470,41 @@ msgstr "Entdecken"
 msgid "app.header.nav.explore"
 msgstr "Entdecken"
 
+#. SEO title for the Explore jobs page.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:32
+#: app/[lang]/(app)/explore/page.tsx:39
 msgid "explore.meta.title"
 msgstr "Jobs entdecken"
 
 #. Hidden page H1 for /explore — screen-reader landmark
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/search-page.tsx:754
+#: app/[lang]/(app)/explore/search-page.tsx:811
 msgid "explore.h1"
 msgstr "Jobs entdecken"
 
 #. Generic email change error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:360
+#: src/components/settings/AccountSettings.tsx:366
 msgid "settings.account.email.error"
 msgstr "E-Mail-Änderung fehlgeschlagen"
 
 #. Error when linking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:426
+#: src/components/settings/AccountSettings.tsx:432
 msgid "settings.account.socials.connectError"
 msgstr "Konto konnte nicht verbunden werden"
 
 #. Generic account deletion error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:499
+#: src/components/settings/AccountSettings.tsx:505
 msgid "settings.account.delete.error"
 msgstr "Konto konnte nicht gelöscht werden"
 
 #. Error when unlinking social account fails
 #. Error when unlinking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:437
-#: src/components/settings/AccountSettings.tsx:442
+#: src/components/settings/AccountSettings.tsx:443
+#: src/components/settings/AccountSettings.tsx:448
 msgid "settings.account.socials.disconnectError"
 msgstr "Konto konnte nicht getrennt werden"
 
@@ -1518,10 +1534,11 @@ msgstr "Passwort konnte nicht gesetzt werden"
 
 #. Generic username update error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:261
+#: src/components/settings/AccountSettings.tsx:267
 msgid "settings.account.username.error"
 msgstr "Benutzername konnte nicht aktualisiert werden"
 
+#. SEO title for the public FAQ page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/faq/page.tsx:17
 msgid "faq.meta.title"
@@ -1667,8 +1684,9 @@ msgstr "Kostenlos"
 msgid "settings.billing.plan.free"
 msgstr "Kostenlos"
 
+#. FAQ answer summarizing Free and Pro plan differences.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:65
+#: app/[lang]/(public)/faq/page.tsx:70
 msgid "faq.a.freeVsPro"
 msgstr "Kostenlos bietet dir vollständige Suche über alle Unternehmen, eine Watchlist und den Bewerbungstracker mit Interview-Protokollierung. Pro fügt unbegrenzte Watchlists und E-Mail-Benachrichtigungen hinzu, wenn neue Stellen deinen Kriterien entsprechen."
 
@@ -1696,8 +1714,9 @@ msgstr "Von der gespeicherten Stelle zum unterschriebenen Angebot — alles an e
 msgid "settings.billing.free.f2"
 msgstr "Vollständige Jobsuche"
 
+#. WebApplication JSON-LD offer description for the Free plan.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:130
+#: app/[lang]/layout.tsx:132
 msgid "app.schema.offer.free"
 msgstr "Vollständige Suche, 1 Watchlist, Bewerbungstracker"
 
@@ -1807,24 +1826,29 @@ msgstr "Stündlich"
 msgid "myJobs.salary.hourly"
 msgstr "Stündlich"
 
+#. FAQ question about requesting a missing company.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:60
+#: app/[lang]/(public)/faq/page.tsx:65
 msgid "faq.q.requestCompany"
 msgstr "Wie kann ich ein nicht gelistetes Unternehmen anfragen?"
 
+#. FAQ question for company operators about crawler behavior.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:76
+#: app/[lang]/(public)/faq/page.tsx:81
 msgid "faq.q.crawlingPolicy"
 msgstr "Wie verhält sich der Crawler auf der Website meines Unternehmens?"
 
+#. JSON-LD page description for the public Job Indexing methodology page.
+#. SEO description for the public Job Indexing methodology page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:18
-#: app/[lang]/(public)/how-we-index/page.tsx:50
+#: app/[lang]/(public)/how-we-index/page.tsx:22
+#: app/[lang]/(public)/how-we-index/page.tsx:59
 msgid "indexing.meta.description"
 msgstr "Wie Job Seek Stellenanzeigen entdeckt und indexiert: unser Sourcing-Ansatz, Crawl-Frequenz, Rate-Limits, robots.txt- und TDM-Reservation-Konformität und wie du dich abmeldest."
 
+#. FAQ question about job listing refresh cadence.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:52
+#: app/[lang]/(public)/faq/page.tsx:57
 msgid "faq.q.howOftenUpdated"
 msgstr "Wie oft werden Stellenanzeigen aktualisiert?"
 
@@ -1846,9 +1870,11 @@ msgstr "Wie Stellenanzeigen in den Index gelangen"
 msgid "indexing.hero.title"
 msgstr "Wie wir Stellenanzeigen finden und verarbeiten"
 
+#. JSON-LD page name for the public Job Indexing methodology page.
+#. SEO title for the public Job Indexing methodology page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/how-we-index/page.tsx:17
-#: app/[lang]/(public)/how-we-index/page.tsx:49
+#: app/[lang]/(public)/how-we-index/page.tsx:54
 msgid "indexing.meta.title"
 msgstr "So indexieren wir"
 
@@ -1858,8 +1884,8 @@ msgstr "So indexieren wir"
 #. Work mode: hybrid (mixed onsite/remote)
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:597
-#: src/components/search/search-bar.tsx:812
-#: src/components/search/search-toolbar.tsx:271
+#: src/components/search/search-bar.tsx:808
+#: src/components/search/search-toolbar.tsx:272
 #: src/components/search/work-mode-modal.tsx:27
 msgid "search.workMode.hybrid"
 msgstr "Hybrid"
@@ -1888,16 +1914,17 @@ msgstr "Wenn du unerwartete Aktivitäten unseres Crawlers bemerkst oder es vorzi
 msgid "indexing.outreach.body"
 msgstr "Wenn du ungewöhnliches Crawler-Verhalten bemerkst, es vorziehst, dass wir deine Inhalte nicht indexieren, oder Vorschläge zur Verbesserung unserer Schutzmaßnahmen hast, kontaktiere uns bitte."
 
+#. SEO metadata phrase listing locations filtered by a public watchlist.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:78
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:80
 msgid "watchlist.meta.inLocations"
 msgstr "in {locations}"
 
 #. Year postings count on company page
 #. Year postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:563
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:575
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:574
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:586
 msgid "company.page.yearCount"
 msgstr "im letzten Jahr"
 
@@ -1911,7 +1938,7 @@ msgstr "im letzten Jahr"
 
 #. Yearly matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:123
+#: src/components/search/company-card.tsx:124
 msgid "search.card.yearCount"
 msgstr "im letzten Jahr"
 
@@ -1999,16 +2026,16 @@ msgstr "Im Interview"
 msgid "search.tracker.interviewing"
 msgstr "Im Interview"
 
-#. Status option in dropdown: interviewing
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:37
-msgid "myJobs.statusOption.interviewing"
-msgstr "Im Interview"
-
 #. Interviewing status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:21
 msgid "myJobs.status.interviewing"
+msgstr "Im Interview"
+
+#. Status option in dropdown: interviewing
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:37
+msgid "myJobs.statusOption.interviewing"
 msgstr "Im Interview"
 
 #. Interviews section heading
@@ -2029,18 +2056,21 @@ msgstr "Ungültiger Link"
 msgid "auth.verify.error.invalidLink"
 msgstr "Ungültiger Bestätigungslink"
 
+#. FAQ question about whether the product suits company-targeted job seekers.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:48
+#: app/[lang]/(public)/faq/page.tsx:53
 msgid "faq.q.targetedSeeker"
 msgstr "Ist Job Seek das Richtige für mich, wenn ich schon weiß, bei welchen Unternehmen ich arbeiten möchte?"
 
+#. FAQ question about open-source availability.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:84
+#: app/[lang]/(public)/faq/page.tsx:89
 msgid "faq.q.openSource"
 msgstr "Ist der Crawler Open Source?"
 
+#. FAQ question about application tracker limits.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:72
+#: app/[lang]/(public)/faq/page.tsx:77
 msgid "faq.q.trackerLimit"
 msgstr "Gibt es ein Limit, wie viele Jobs ich verfolgen kann?"
 
@@ -2050,16 +2080,16 @@ msgstr "Gibt es ein Limit, wie viele Jobs ich verfolgen kann?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:121
-msgid "watchlists.explore.jobSingular"
-msgstr "Job"
-
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31
 msgid "watchlists.card.jobSingular"
+msgstr "Job"
+
+#. Singular job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:121
+msgid "watchlists.explore.jobSingular"
 msgstr "Job"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -2104,14 +2134,17 @@ msgstr "Stellenanzeigen"
 msgid "home.features.s2.screenshot.alt"
 msgstr "Job Seek Bewerbungs-Tracker mit gespeicherten Stellen und Interview-Details"
 
+#. FAQ answer explaining what Job Seek does for targeted job seekers.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:45
+#: app/[lang]/(public)/faq/page.tsx:50
 msgid "faq.a.whatIsJobseek"
 msgstr "Job Seek hilft dir dabei, die Unternehmen zu verfolgen, bei denen du wirklich arbeiten möchtest. Erstelle eine Watchlist, lasse dich per E-Mail benachrichtigen, wenn neue Stellen geöffnet werden, und verfolge Bewerbungen an einem Ort. Stellen kommen direkt von den Karriereseiten der Unternehmen, sodass du sie innerhalb weniger Stunden nach Veröffentlichung siehst — typischerweise bevor LinkedIn oder Indeed sie übernehmen."
 
+#. JSON-LD page description for the public About page.
+#. SEO description for the public About page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/about/page.tsx:18
-#: app/[lang]/(public)/about/page.tsx:47
+#: app/[lang]/(public)/about/page.tsx:22
+#: app/[lang]/(public)/about/page.tsx:56
 msgid "about.meta.description"
 msgstr "Job Seek hilft dir dabei, die Unternehmen zu verfolgen, bei denen du arbeiten möchtest — Watchlists, E-Mail-Benachrichtigungen und Stellen direkt von den Karriereseiten der Unternehmen. Entwickelt von Colophon Group, einem kleinen Entwicklerstudio in der Schweiz."
 
@@ -2133,9 +2166,11 @@ msgstr "Job Seek wird aktiv entwickelt. Bleib dran für Updates!"
 msgid "about.p1"
 msgstr "Job Seek wird von der Colophon Group entwickelt, einem kleinen Entwicklerteam in der Schweiz. Wir haben es gestartet, weil wir das gleiche Problem satt hatten, das jeder Jobsuchende kennt: Dutzende Browser-Tabs jonglieren, neue Stellen verpassen, weil ein Aggregator zu langsam war, und in algorithmischem Rauschen untergehen, das auf Klicks statt auf Relevanz optimiert."
 
+#. JSON-LD page description for the public Privacy Policy page.
+#. SEO description for the public Privacy Policy page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:18
-#: app/[lang]/(public)/privacy-policy/page.tsx:51
+#: app/[lang]/(public)/privacy-policy/page.tsx:22
+#: app/[lang]/(public)/privacy-policy/page.tsx:60
 msgid "privacy.meta.description"
 msgstr "Datenschutzrichtlinie von Job Seek — welche personenbezogenen Daten wir erheben, wie wir sie verwenden, deine DSGVO-Rechte, Cookie-Richtlinie und Kontolöschung."
 
@@ -2157,16 +2192,11 @@ msgstr "Job Seek Watchlist mit kuratierten Robotik-Ingenieurstellen in Zürich"
 msgid "license.hero.description"
 msgstr "Die Codebasis von Job Seek ist Open Source unter MIT. Die von uns gesammelten und aufbereiteten Stellendaten stehen unter Creative Commons BY-NC 4.0. Nachfolgend eine verständliche Zusammenfassung — bitte lies die vollständigen Lizenzen für die genauen Bedingungen."
 
+#. Fallback SEO description for a public watchlist with no description or filters.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:86
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:89
 msgid "watchlist.meta.fallback"
 msgstr "Job-Watchlist von @{owner}"
-
-#. Plural job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:122
-msgid "watchlists.explore.jobPlural"
-msgstr "Jobs"
 
 #. Plural job count on watchlist card
 #. js-lingui-explicit-id
@@ -2174,13 +2204,21 @@ msgstr "Jobs"
 msgid "watchlists.card.jobPlural"
 msgstr "Jobs"
 
+#. Plural job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:122
+msgid "watchlists.explore.jobPlural"
+msgstr "Jobs"
+
+#. SEO title for a company detail page; {name} is the company name.
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/company/[slug]/page.tsx:34
 msgid "company.meta.title"
 msgstr "Jobs bei {name}"
 
+#. SEO metadata phrase listing companies tracked by a public watchlist.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:68
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:69
 msgid "watchlist.meta.jobsAt"
 msgstr "Jobs bei {names}"
 
@@ -2228,14 +2266,14 @@ msgstr "Letzte Stunde"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:27
-msgid "terms.hero.lastUpdated"
+#: src/components/PrivacyPolicyContent.tsx:27
+msgid "privacy.hero.lastUpdated"
 msgstr "Zuletzt aktualisiert:"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:27
-msgid "privacy.hero.lastUpdated"
+#: src/components/TermsContent.tsx:27
+msgid "terms.hero.lastUpdated"
 msgstr "Zuletzt aktualisiert:"
 
 #. Time range option: last week
@@ -2252,7 +2290,7 @@ msgstr "Mehr erfahren"
 
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:730
+#: src/components/search/search-bar.tsx:726
 msgid "search.bar.level"
 msgstr "Stufe"
 
@@ -2262,16 +2300,18 @@ msgstr "Stufe"
 msgid "search.advanced.level"
 msgstr "Stufe"
 
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:17
-#: app/[lang]/(public)/license/page.tsx:51
-msgid "license.meta.title"
-msgstr "Lizenz"
-
 #. Link to license page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:70
 msgid "about.link.license"
+msgstr "Lizenz"
+
+#. JSON-LD page name for the public License page.
+#. SEO title for the public License page.
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/license/page.tsx:17
+#: app/[lang]/(public)/license/page.tsx:56
+msgid "license.meta.title"
 msgstr "Lizenz"
 
 #. Footer link to license page
@@ -2292,9 +2332,11 @@ msgstr "Lizenz von Job Seek"
 msgid "license.hero.eyebrow"
 msgstr "Lizenzierung"
 
+#. JSON-LD page description for the public License page.
+#. SEO description for the public License page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:18
-#: app/[lang]/(public)/license/page.tsx:52
+#: app/[lang]/(public)/license/page.tsx:22
+#: app/[lang]/(public)/license/page.tsx:61
 msgid "license.meta.description"
 msgstr "Lizenzierung von Job Seek — der Quellcode steht unter MIT-Lizenz, Stellenanzeigen unter CC BY-NC 4.0. Erfahre, was du mit unserem Code und unseren Daten tun darfst."
 
@@ -2356,7 +2398,7 @@ msgstr "Standort"
 
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:842
+#: src/components/search/search-bar.tsx:838
 msgid "search.bar.locations"
 msgstr "Standorte"
 
@@ -2382,7 +2424,7 @@ msgstr "Anmelden"
 
 #. Tooltip when user needs to log in to save search
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:122
+#: src/components/search/save-search-button.tsx:125
 msgid "search.saveSearch.tooltipLogin"
 msgstr "Melde dich an, um diese Suche als Watchlist zu speichern"
 
@@ -2412,7 +2454,7 @@ msgstr "Abo verwalten"
 
 #. Connected accounts section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:453
+#: src/components/settings/AccountSettings.tsx:459
 msgid "settings.account.socials.description"
 msgstr "Verwalte deine verknüpften Social-Media-Konten."
 
@@ -2442,7 +2484,7 @@ msgstr "Als abgelehnt markieren"
 
 #. Header for the server-side search-results cluster shown when the user types in the location modal search box
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:585
+#: src/components/search/location-search-modal.tsx:594
 msgid "search.locationModal.searchHitsHeader"
 msgstr "Treffer"
 
@@ -2508,8 +2550,9 @@ msgstr "Ein Unternehmen fehlt? Füge die Karriereseiten-URL ein und wir beginnen
 msgid "myJobs.heatmap.day.mon"
 msgstr "Mo"
 
+#. WebApplication JSON-LD feature list item about career-page monitoring.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:142
+#: app/[lang]/layout.tsx:152
 msgid "app.schema.feature.monitor"
 msgstr "Karriereseiten von Unternehmen überwachen"
 
@@ -2549,8 +2592,9 @@ msgstr "Verschiebe jede Stelle von gespeichert zu beworben, im Interview, im Ang
 msgid "home.features.s1.p2.title"
 msgstr "Mehrdimensionale Filter"
 
+#. WebApplication JSON-LD feature list item about supported interface languages.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:144
+#: app/[lang]/layout.tsx:162
 msgid "app.schema.feature.languages"
 msgstr "Mehrsprachige Unterstützung"
 
@@ -2560,22 +2604,22 @@ msgstr "Mehrsprachige Unterstützung"
 #. Warning when Enter is pressed but multiple items match
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:247
-#: src/components/search/location-search-modal.tsx:430
+#: src/components/search/location-search-modal.tsx:439
 #: src/components/search/occupation-modal.tsx:180
 #: src/components/search/technology-modal.tsx:88
 msgid "search.bestGuess.ambiguous"
 msgstr "Mehrere Treffer — wähle einen aus"
 
-#. Back link to my jobs
-#. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:40
-msgid "myJobs.stats.back"
-msgstr "Meine Jobs"
-
 #. Title of the My Jobs page
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:252
 msgid "myJobs.title"
+msgstr "Meine Jobs"
+
+#. Back link to my jobs
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:40
+msgid "myJobs.stats.back"
 msgstr "Meine Jobs"
 
 #. My Jobs nav icon tooltip
@@ -2604,7 +2648,7 @@ msgstr "Kontakt aufnehmen?"
 
 #. New email input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:382
+#: src/components/settings/AccountSettings.tsx:388
 msgid "settings.account.email.label"
 msgstr "Neue E-Mail"
 
@@ -2646,7 +2690,7 @@ msgstr "Keine Branchen gefunden."
 
 #. Empty state when no jobs match the time range
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:230
+#: src/components/watchlist/watchlist-job-list.tsx:282
 msgid "watchlists.jobList.empty"
 msgstr "Keine Jobs gefunden."
 
@@ -2656,21 +2700,21 @@ msgstr "Keine Jobs gefunden."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Keine Sprachen entsprechen deiner Suche."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:516
-msgid "search.locationModal.noResults"
-msgstr "Keine Standorte gefunden."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:312
 msgid "company.locationModal.noResults"
 msgstr "Keine Standorte entsprechen Ihrer Suche."
 
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:525
+msgid "search.locationModal.noResults"
+msgstr "Keine Standorte gefunden."
+
 #. No postings found message on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:644
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:657
 msgid "company.page.noResults"
 msgstr "Keine passenden Stellenanzeigen gefunden."
 
@@ -2691,18 +2735,6 @@ msgstr "Keine Antwort"
 #: src/components/search/zero-results.tsx:14
 msgid "search.zero.heading"
 msgstr "Keine Ergebnisse für „{query}\" gefunden"
-
-#. Heading shown when a search surface returns an impossible empty result set
-#. js-lingui-explicit-id
-#: src/components/search/search-unavailable.tsx:9
-msgid "search.unavailable.heading"
-msgstr "Hoppla, etwas ist schiefgelaufen."
-
-#. Body shown when a search surface returns an impossible empty result set
-#. js-lingui-explicit-id
-#: src/components/search/search-unavailable.tsx:14
-msgid "search.unavailable.body"
-msgstr "Versuchen Sie, die Seite neu zu laden."
 
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
@@ -2746,13 +2778,15 @@ msgstr "Keine Watchlists gefunden."
 msgid "watchlists.page.empty"
 msgstr "Noch keine Watchlists. Erstelle eine, um Jobs von deinen Lieblingsunternehmen zu verfolgen."
 
+#. FAQ answer explaining that the application tracker has no hard limit.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:73
+#: app/[lang]/(public)/faq/page.tsx:78
 msgid "faq.a.trackerLimit"
 msgstr "Nein. Der Bewerbungstracker hat kein festes Limit — speichere so viele Jobs, wie du möchtest, und verschiebe sie durch deine Pipeline."
 
+#. FAQ answer explaining data privacy, cookies, and account deletion.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:89
+#: app/[lang]/(public)/faq/page.tsx:94
 msgid "faq.a.dataPrivacy"
 msgstr "Nein. Wir verkaufen, vermieten oder teilen deine Daten nicht zu Marketingzwecken. Cookies sind nur sitzungsbasiert, ohne Werbung oder Tracking. Du kannst dein Konto löschen und alle Daten werden innerhalb von 30 Tagen entfernt."
 
@@ -2834,8 +2868,8 @@ msgstr "Ok"
 #. Work mode: onsite (in-office)
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:595
-#: src/components/search/search-bar.tsx:810
-#: src/components/search/search-toolbar.tsx:269
+#: src/components/search/search-bar.tsx:806
+#: src/components/search/search-toolbar.tsx:270
 #: src/components/search/work-mode-modal.tsx:26
 msgid "search.workMode.onsite"
 msgstr "Vor Ort"
@@ -2854,7 +2888,7 @@ msgstr "Eine Seite pro Minute."
 
 #. Username invalid characters hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:284
+#: src/components/settings/AccountSettings.tsx:290
 msgid "settings.account.username.invalidChars"
 msgstr "Nur Kleinbuchstaben, Zahlen und Bindestriche (nicht am Anfang/Ende)"
 
@@ -2864,15 +2898,21 @@ msgstr "Nur Kleinbuchstaben, Zahlen und Bindestriche (nicht am Anfang/Ende)"
 msgid "myJobs.interviewType.onsite"
 msgstr "Vor Ort"
 
+#. Heading shown when a search surface returns an impossible empty result set
+#. js-lingui-explicit-id
+#: src/components/search/search-unavailable.tsx:9
+msgid "search.unavailable.heading"
+msgstr "Hoppla, etwas ist schiefgelaufen."
+
 #. Aria label for the row open-posting button when the posting title is missing
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:158
+#: src/components/watchlist/watchlist-job-list.tsx:199
 msgid "watchlists.jobList.openPosting"
 msgstr "Stellenausschreibung öffnen"
 
 #. Aria label for opening a job posting from a company card row when the posting title is missing
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:147
+#: src/components/search/company-card.tsx:159
 msgid "search.card.openPosting"
 msgstr "Stellenausschreibung öffnen"
 
@@ -2882,8 +2922,9 @@ msgstr "Stellenausschreibung öffnen"
 msgid "common.header.openMenu"
 msgstr "Hauptmenü öffnen"
 
+#. Fallback SEO metadata count text for a company with no active jobs.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:46
+#: app/[lang]/(app)/company/[slug]/page.tsx:48
 msgid "company.meta.openPositions"
 msgstr "Offene Stellen"
 
@@ -2925,13 +2966,13 @@ msgstr "Original"
 
 #. Fallback label for a country header in the location modal when the city has no parent country in the hierarchy. Rare path.
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:638
+#: src/components/search/location-search-modal.tsx:647
 msgid "search.locationModal.otherCountry"
 msgstr "Sonstige"
 
 #. Fallback label for a region row in the location modal when the region has no display name (e.g. orphaned cities). Rare path; only shown when a city's parent region in the hierarchy has no localized name.
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:723
+#: src/components/search/location-search-modal.tsx:732
 msgid "search.locationModal.otherRegion"
 msgstr "Sonstige"
 
@@ -2961,21 +3002,15 @@ msgstr "Unsere Haltung zur Automatisierung"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:21
-msgid "license.toc.overview"
-msgstr "Überblick"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:25
 msgid "indexing.toc.overview"
 msgstr "Überblick"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
-msgid "license.toc.ariaLabel"
-msgstr "Seiteninhalt"
+#: src/components/LicenseContent.tsx:21
+msgid "license.toc.overview"
+msgstr "Überblick"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
@@ -2983,9 +3018,17 @@ msgstr "Seiteninhalt"
 msgid "indexing.toc.ariaLabel"
 msgstr "Seiteninhalt"
 
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:18
+msgid "license.toc.ariaLabel"
+msgstr "Seiteninhalt"
+
+#. Heading shown on the 404 page
 #. Heading shown on the 404 page
 #. js-lingui-explicit-id
 #: app/[lang]/not-found-content.tsx:12
+#: app/[lang]/not-found.tsx:21
 msgid "notFound.title"
 msgstr "Seite nicht gefunden"
 
@@ -3071,7 +3114,7 @@ msgstr "Zeitraum"
 
 #. Delete account section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:511
+#: src/components/settings/AccountSettings.tsx:517
 msgid "settings.account.delete.description"
 msgstr "Lösche dein Konto und alle zugehörigen Daten dauerhaft. Diese Aktion kann nicht rückgängig gemacht werden."
 
@@ -3107,7 +3150,7 @@ msgstr "Bitte geben Sie einen Firmennamen oder eine URL ein."
 
 #. Error when email field is empty
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:350
+#: src/components/settings/AccountSettings.tsx:356
 msgid "settings.account.email.required"
 msgstr "Bitte gib eine neue E-Mail-Adresse ein"
 
@@ -3203,9 +3246,11 @@ msgstr "Datenschutz"
 msgid "privacy.hero.title"
 msgstr "Datenschutz bei Job Seek"
 
+#. JSON-LD page name for the public Privacy Policy page.
+#. SEO title for the public Privacy Policy page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/privacy-policy/page.tsx:17
-#: app/[lang]/(public)/privacy-policy/page.tsx:50
+#: app/[lang]/(public)/privacy-policy/page.tsx:55
 msgid "privacy.meta.title"
 msgstr "Datenschutzrichtlinie"
 
@@ -3239,16 +3284,16 @@ msgstr "Gemeinfrei"
 msgid "license.contactCta"
 msgstr "Fragen zur Lizenzierung oder kommerziellen Nutzung? Schreib uns eine E-Mail."
 
-#. Terms contact call to action
-#. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:53
-msgid "terms.contact.description"
-msgstr "Fragen? Schreib uns eine E-Mail."
-
 #. Privacy contact call to action
 #. js-lingui-explicit-id
 #: src/components/PrivacyPolicyContent.tsx:65
 msgid "privacy.contact.description"
+msgstr "Fragen? Schreib uns eine E-Mail."
+
+#. Terms contact call to action
+#. js-lingui-explicit-id
+#: src/components/TermsContent.tsx:53
+msgid "terms.contact.description"
 msgstr "Fragen? Schreib uns eine E-Mail."
 
 #. Link to full CC license
@@ -3275,8 +3320,9 @@ msgstr "Vollständige Datenschutzrichtlinie lesen"
 msgid "terms.fullTermsLink"
 msgstr "Vollständige Nutzungsbedingungen lesen"
 
+#. WebApplication JSON-LD feature list item about job alert notifications.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:143
+#: app/[lang]/layout.tsx:157
 msgid "app.schema.feature.alerts"
 msgstr "Echtzeit-Benachrichtigungen über neue Stellen"
 
@@ -3305,21 +3351,21 @@ msgstr "Deine Änderungen weiterverbreiten, solange du den MIT-Hinweis beifügst
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:32
 #: src/components/search/filter-bar.tsx:34
-#: src/components/search/location-pills.tsx:28
-#: src/components/search/location-pills.tsx:30
+#: src/components/search/location-pills.tsx:29
+#: src/components/search/location-pills.tsx:31
 msgid "location.type.region"
 msgstr "Region"
-
-#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:526
-msgid "search.locationModal.regionsHeader"
-msgstr "Regionen"
 
 #. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:322
 msgid "company.locationModal.regionsHeader"
+msgstr "Regionen"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:535
+msgid "search.locationModal.regionsHeader"
 msgstr "Regionen"
 
 #. Status group heading: rejected
@@ -3334,6 +3380,12 @@ msgstr "Abgelehnt"
 msgid "search.tracker.rejected"
 msgstr "Abgelehnt"
 
+#. Rejected status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:23
+msgid "myJobs.status.rejected"
+msgstr "Abgelehnt"
+
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
@@ -3344,12 +3396,6 @@ msgstr "Abgelehnt"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:39
 msgid "myJobs.statusOption.rejected"
-msgstr "Abgelehnt"
-
-#. Rejected status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:23
-msgid "myJobs.status.rejected"
 msgstr "Abgelehnt"
 
 #. Footer license summary text
@@ -3364,8 +3410,8 @@ msgstr "Veröffentlicht unter der MIT-Lizenz. Stellendaten sind CC BY-NC 4.0."
 #. Work mode: remote (work-from-home)
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:598
-#: src/components/search/search-bar.tsx:813
-#: src/components/search/search-toolbar.tsx:272
+#: src/components/search/search-bar.tsx:809
+#: src/components/search/search-toolbar.tsx:273
 #: src/components/search/work-mode-modal.tsx:28
 msgid "search.workMode.remote"
 msgstr "Remote"
@@ -3402,11 +3448,11 @@ msgstr "Filter {0} entfernen"
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:579
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:589
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:603
-#: src/components/search/search-toolbar.tsx:201
-#: src/components/search/search-toolbar.tsx:220
-#: src/components/search/search-toolbar.tsx:240
-#: src/components/search/search-toolbar.tsx:260
-#: src/components/search/search-toolbar.tsx:283
+#: src/components/search/search-toolbar.tsx:202
+#: src/components/search/search-toolbar.tsx:221
+#: src/components/search/search-toolbar.tsx:241
+#: src/components/search/search-toolbar.tsx:261
+#: src/components/search/search-toolbar.tsx:284
 msgid "search.filters.removeFilter"
 msgstr "Filter {name} entfernen"
 
@@ -3432,7 +3478,7 @@ msgstr "Filter {name} entfernen"
 #. Aria label for the X button that clears the experience-range filter
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:622
-#: src/components/search/search-toolbar.tsx:318
+#: src/components/search/search-toolbar.tsx:319
 msgid "search.filters.removeExperience"
 msgstr "Erfahrungsfilter entfernen"
 
@@ -3459,13 +3505,13 @@ msgstr "Stichwort {0} entfernen"
 #. Aria label for remove-keyword X button; {name} is the keyword
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:630
-#: src/components/search/search-toolbar.tsx:335
+#: src/components/search/search-toolbar.tsx:336
 msgid "search.filters.removeKeyword"
 msgstr "Stichwort {name} entfernen"
 
 #. Aria label for removing a location pill
 #. js-lingui-explicit-id
-#: src/components/search/location-pills.tsx:199
+#: src/components/search/location-pills.tsx:195
 msgid "search.locations.remove"
 msgstr "Standort entfernen"
 
@@ -3480,7 +3526,7 @@ msgstr "Standort {0} entfernen"
 #. Aria label for remove-location X button; {name} is the location label
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:640
-#: src/components/search/search-toolbar.tsx:356
+#: src/components/search/search-toolbar.tsx:357
 msgid "search.filters.removeLocation"
 msgstr "Standort {name} entfernen"
 
@@ -3488,7 +3534,7 @@ msgstr "Standort {name} entfernen"
 #. Aria label for the X button that clears the salary-range filter
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:613
-#: src/components/search/search-toolbar.tsx:301
+#: src/components/search/search-toolbar.tsx:302
 msgid "search.filters.removeSalary"
 msgstr "Gehaltsfilter entfernen"
 
@@ -3500,7 +3546,7 @@ msgstr "Gehaltsfilter entfernen"
 
 #. Synthetic dropdown row that lets the user request a company that's not in the catalog
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:934
+#: src/components/search/search-bar.tsx:930
 msgid "search.bar.request"
 msgstr "„{trimmedInput}\" anfragen"
 
@@ -3590,7 +3636,7 @@ msgstr "Beruf"
 
 #. Section header for occupation suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:695
+#: src/components/search/search-bar.tsx:691
 msgid "search.bar.roles"
 msgstr "Berufe"
 
@@ -3644,7 +3690,7 @@ msgstr "Speichere jede Suche als Watchlist und erhalte E-Mail-Benachrichtigungen
 
 #. Save job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:191
+#: src/components/watchlist/watchlist-job-list.tsx:232
 msgid "watchlists.jobList.save"
 msgstr "Job speichern"
 
@@ -3668,7 +3714,7 @@ msgstr "Speichern Sie Jobs und verfolgen Sie Ihre Bewerbungen, um hier Statistik
 
 #. Button label to save current search as a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:110
+#: src/components/search/save-search-button.tsx:113
 msgid "search.saveSearch.label"
 msgstr "Diese Suche speichern"
 
@@ -3676,6 +3722,12 @@ msgstr "Diese Suche speichern"
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:28
 msgid "myJobs.group.saved"
+msgstr "Gespeichert"
+
+#. Saved status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:19
+msgid "myJobs.status.saved"
 msgstr "Gespeichert"
 
 #. Sankey funnel node: saved jobs
@@ -3690,21 +3742,15 @@ msgstr "Gespeichert"
 msgid "myJobs.statusOption.saved"
 msgstr "Gespeichert"
 
-#. Saved status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:19
-msgid "myJobs.status.saved"
-msgstr "Gespeichert"
-
 #. Username save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:320
+#: src/components/settings/AccountSettings.tsx:326
 msgid "settings.account.username.saving"
 msgstr "Speichern..."
 
 #. Email save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:392
+#: src/components/settings/AccountSettings.tsx:398
 msgid "settings.account.email.saving"
 msgstr "Speichern…"
 
@@ -3723,7 +3769,7 @@ msgstr "Suche über tausende Unternehmen hinweg, direkt von ihren Karriereseiten
 #. Placeholder for search bar when on company page
 #. js-lingui-explicit-id
 #. placeholder {0}: company.name
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:161
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:169
 msgid "company.page.searchPlaceholder"
 msgstr "Suchen bei {0}..."
 
@@ -3741,12 +3787,13 @@ msgstr "Unternehmen suchen..."
 
 #. Option to search by title keyword in dropdown
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:683
+#: src/components/search/search-bar.tsx:679
 msgid "search.bar.keyword"
 msgstr "Nach \"{trimmedInput}\" in Jobtiteln suchen"
 
+#. SEO description for the Explore jobs page.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:33
+#: app/[lang]/(app)/explore/page.tsx:44
 msgid "explore.meta.description"
 msgstr "Durchsuche Jobs bei Tausenden von Unternehmen, direkt von Karriereseiten gecrawlt. Filtere nach Erfahrungsstufe, Tech-Stack, Gehalt und Standort — erstelle Watchlists und erhalte Benachrichtigungen."
 
@@ -3756,17 +3803,17 @@ msgstr "Durchsuche Jobs bei Tausenden von Unternehmen, direkt von Karriereseiten
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Sprachen suchen…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:495
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Standorte suchen..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:291
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Standorte suchen…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:504
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Standorte suchen..."
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3794,7 +3841,7 @@ msgstr "Suche mit Präzision"
 
 #. Placeholder for the main search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:608
+#: src/components/search/search-bar.tsx:604
 msgid "search.bar.placeholder"
 msgstr "Suchen…"
 
@@ -3812,7 +3859,7 @@ msgstr "Stufe auswählen"
 
 #. Title for the global location selection modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:472
+#: src/components/search/location-search-modal.tsx:481
 msgid "search.locationModal.title"
 msgstr "Standort auswählen"
 
@@ -3852,17 +3899,17 @@ msgstr "Link senden"
 msgid "settings.account.password.send"
 msgstr "Link senden"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Wird gesendet…"
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
 msgstr "Wird gesendet..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
+msgstr "Wird gesendet…"
 
 #. Reset password button while loading
 #. js-lingui-explicit-id
@@ -4052,7 +4099,7 @@ msgstr "Zuerst die Sitemap."
 
 #. Skip to main content link for keyboard users
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/layout.tsx:25
+#: src/components/SkipToContentLink.tsx:11
 msgid "common.a11y.skipToContent"
 msgstr "Zum Inhalt springen"
 
@@ -4202,7 +4249,7 @@ msgstr "Technisch"
 
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:765
+#: src/components/search/search-bar.tsx:761
 msgid "search.bar.technologies"
 msgstr "Technologien"
 
@@ -4248,9 +4295,11 @@ msgstr "Nutzungsbedingungen"
 msgid "common.footer.termsLink"
 msgstr "AGB"
 
+#. JSON-LD page name for the public Terms of Service page.
+#. SEO title for the public Terms of Service page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/terms/page.tsx:17
-#: app/[lang]/(public)/terms/page.tsx:50
+#: app/[lang]/(public)/terms/page.tsx:55
 msgid "terms.meta.title"
 msgstr "Nutzungsbedingungen"
 
@@ -4260,15 +4309,17 @@ msgstr "Nutzungsbedingungen"
 msgid "terms.hero.title"
 msgstr "Nutzungsbedingungen"
 
+#. JSON-LD page description for the public Terms of Service page.
+#. SEO description for the public Terms of Service page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:18
-#: app/[lang]/(public)/terms/page.tsx:51
+#: app/[lang]/(public)/terms/page.tsx:22
+#: app/[lang]/(public)/terms/page.tsx:60
 msgid "terms.meta.description"
 msgstr "Nutzungsbedingungen von Job Seek — Nutzungsregeln, geistiges Eigentum, Kontoverantwortung, Haftungsbeschränkung und geltendes Recht der Jobsuchplattform."
 
 #. Body text shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:94
+#: app/[lang]/(app)/company/[slug]/page.tsx:102
 msgid "company.notFound.message"
 msgstr "Das gesuchte Unternehmen existiert nicht oder wurde entfernt."
 
@@ -4284,13 +4335,15 @@ msgstr "Das gesuchte Unternehmen existiert nicht oder wurde entfernt."
 msgid "about.transparency.p1"
 msgstr "Der Crawler-Code ist Open Source, damit jeder prüfen kann, wie wir Daten sammeln. Wir respektieren robots.txt, beachten TDM-Reservation-Header und beschränken uns auf eine Anfrage pro Seite pro Minute. Jeder ausgehende Link enthält utm_source=jobseek, damit Arbeitgeber wissen, woher ihr Traffic kommt."
 
+#. FAQ answer explaining crawler discovery and refresh frequency.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:53
+#: app/[lang]/(public)/faq/page.tsx:58
 msgid "faq.a.howOftenUpdated"
 msgstr "Der Crawler entdeckt neue Stellenanzeigen in einem stündlichen Zyklus und aktualisiert Stellendetails täglich. Die meisten Stellen erscheinen innerhalb weniger Stunden nach ihrer Veröffentlichung auf der Karriereseite eines Unternehmens."
 
+#. FAQ answer listing interface languages and posting-language filtering.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:93
+#: app/[lang]/(public)/faq/page.tsx:98
 msgid "faq.a.languages"
 msgstr "Die Benutzeroberfläche ist auf Englisch, Deutsch, Französisch und Italienisch verfügbar. Du kannst Stellenanzeigen auch nach der Sprache filtern, in der sie verfasst wurden."
 
@@ -4308,14 +4361,14 @@ msgstr "Der Service wird ohne Gewährleistung bereitgestellt."
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:39
-msgid "terms.short.title"
+#: src/components/PrivacyPolicyContent.tsx:39
+msgid "privacy.short.title"
 msgstr "Die Kurzfassung"
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:39
-msgid "privacy.short.title"
+#: src/components/TermsContent.tsx:39
+msgid "terms.short.title"
 msgstr "Die Kurzfassung"
 
 #. Theme settings section heading
@@ -4338,7 +4391,7 @@ msgstr "Diese Seite verwendet Cookies ausschließlich für Authentifizierung und
 
 #. Username is reserved hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:286
+#: src/components/settings/AccountSettings.tsx:292
 msgid "settings.account.username.reserved"
 msgstr "Dieser Benutzername ist reserviert"
 
@@ -4356,7 +4409,7 @@ msgstr "Diese Watchlist und alle zugehörigen Einstellungen werden dauerhaft gel
 
 #. Date divider label for today
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:71
+#: src/components/watchlist/watchlist-job-list.tsx:75
 msgid "watchlists.jobList.today"
 msgstr "Heute"
 
@@ -4366,9 +4419,11 @@ msgstr "Heute"
 msgid "home.hero.title"
 msgstr "Verfolge die Unternehmen, bei denen du wirklich arbeiten willst."
 
+#. JSON-LD page name for the public homepage.
+#. SEO title for the public homepage.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/page.tsx:20
-#: app/[lang]/(public)/page.tsx:52
+#: app/[lang]/(public)/page.tsx:57
 msgid "home.meta.title"
 msgstr "Verfolge die Unternehmen, bei denen du arbeiten willst — Job Seek"
 
@@ -4395,6 +4450,12 @@ msgstr "Standardmässig transparent"
 #: app/[lang]/error.tsx:23
 msgid "error.retryButton"
 msgstr "Erneut versuchen"
+
+#. Body shown when a search surface returns an impossible empty result set
+#. js-lingui-explicit-id
+#: src/components/search/search-unavailable.tsx:14
+msgid "search.unavailable.body"
+msgstr "Versuchen Sie, die Seite neu zu laden."
 
 #. Add employment type filter
 #. js-lingui-explicit-id
@@ -4438,14 +4499,15 @@ msgstr "Unbegrenzte Watchlists"
 msgid "home.pricing.pro.description"
 msgstr "Unbegrenzte Watchlists mit E-Mail-Benachrichtigungen, damit du keine Stelle verpasst."
 
+#. WebApplication JSON-LD offer description for the Pro plan.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:138
+#: app/[lang]/layout.tsx:144
 msgid "app.schema.offer.pro"
 msgstr "Unbegrenzte Watchlists, E-Mail-Benachrichtigungen bei neuen Treffern"
 
 #. Unsave job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:190
+#: src/components/watchlist/watchlist-job-list.tsx:231
 msgid "watchlists.jobList.unsave"
 msgstr "Job entfernen"
 
@@ -4457,19 +4519,19 @@ msgstr "Job entfernen"
 
 #. Email save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:393
+#: src/components/settings/AccountSettings.tsx:399
 msgid "settings.account.email.save"
 msgstr "E-Mail aktualisieren"
 
 #. Change email section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:373
+#: src/components/settings/AccountSettings.tsx:379
 msgid "settings.account.email.description"
 msgstr "Aktualisiere die mit deinem Konto verknüpfte E-Mail-Adresse."
 
 #. Username save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:321
+#: src/components/settings/AccountSettings.tsx:327
 msgid "settings.account.username.save"
 msgstr "Benutzername aktualisieren"
 
@@ -4497,8 +4559,9 @@ msgstr "Auf Pro upgraden"
 msgid "settings.billing.upgrading"
 msgstr "Upgrade l\\u00e4uft\\u2026"
 
+#. FAQ answer explaining how to request a missing company from the Explore page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:61
+#: app/[lang]/(public)/faq/page.tsx:66
 msgid "faq.a.requestCompany"
 msgstr "Nutze das Anfrageformular auf der Entdecken-Seite — füge eine Karriereseiten-URL oder einen Firmennamen ein und wir beginnen mit der Indexierung. Du kannst den Fortschritt über die Issue-Nummer verfolgen, die wir zurückgeben."
 
@@ -4510,25 +4573,25 @@ msgstr "Nutzer"
 
 #. Username section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:298
+#: src/components/settings/AccountSettings.tsx:304
 msgid "settings.account.username.title"
 msgstr "Benutzername"
 
 #. Username input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:310
+#: src/components/settings/AccountSettings.tsx:316
 msgid "settings.account.username.label"
 msgstr "Benutzername"
 
 #. Username updated success message
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:273
+#: src/components/settings/AccountSettings.tsx:279
 msgid "settings.account.username.success"
 msgstr "Benutzername aktualisiert."
 
 #. Success message after email change request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:362
+#: src/components/settings/AccountSettings.tsx:368
 msgid "settings.account.email.success"
 msgstr "Bestätigungs-E-Mail gesendet. Bitte überprüfe dein Postfach. Es kann einige Minuten dauern, bis die E-Mail ankommt."
 
@@ -4616,8 +4679,9 @@ msgstr "Watchlists"
 msgid "home.features.s1.p3.title"
 msgstr "Watchlists und Benachrichtigungen"
 
+#. WebApplication JSON-LD feature list item about watchlists and application tracking.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:145
+#: app/[lang]/layout.tsx:167
 msgid "app.schema.feature.watchlists"
 msgstr "Watchlists und Bewerbungstracking"
 
@@ -4645,8 +4709,9 @@ msgstr "Wir erheben nur, was wir brauchen, wir verkaufen deine Daten nicht, und 
 msgid "privacy.short.r2"
 msgstr "Wir verkaufen, vermieten oder teilen deine Daten nicht für Marketingzwecke."
 
+#. FAQ answer explaining direct career-page indexing and no recruiter spam.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:57
+#: app/[lang]/(public)/faq/page.tsx:62
 msgid "faq.a.differentiation"
 msgstr "Wir indexieren Karriereseiten von Unternehmen direkt, nicht Drittanbieter-Feeds. Kein Recruiter-Spam, keine wiederveröffentlichten Ghost-Jobs, und wir prüfen Unternehmen häufig erneut — die meisten Stellen erscheinen hier also innerhalb weniger Stunden nach Veröffentlichung. Wir sind für Nutzer gemacht, die schon wissen, bei welchen Unternehmen sie arbeiten möchten, nicht für allgemeine Suchen nach irgendeinem Job."
 
@@ -4686,8 +4751,9 @@ msgstr "Wir haben festgestellt, dass diese Stelle kürzlich hinzugefügt wurde. 
 msgid "indexing.automation.body"
 msgstr "Wir lehnen es ab, Einstellungs- oder Jobsuch-Entscheidungen an undurchsichtige Automatisierung zu übergeben — ob auf Arbeitgeber- oder Bewerberseite. Jeder ausgehende Link enthält <0>utm_source=jobseek</0>, damit Recruiter den Traffic erkennen, und wir überprüfen kontinuierlich Nutzungsmuster und setzen Hürden ein, um automatisierte Bewerbungen zu verhindern."
 
+#. FAQ answer summarizing crawler politeness, rate limits, and policy compliance.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:77
+#: app/[lang]/(public)/faq/page.tsx:82
 msgid "faq.a.crawlingPolicy"
 msgstr "Wir respektieren robots.txt und TDM-Reservation-Header, beschränken Anfragen auf eine pro Seite pro Minute und verwenden exponentielles Backoff. Alle Anfragen identifizieren sich über den User-Agent. Weitere Details findest du auf unserer Indexierungsseite."
 
@@ -4717,7 +4783,7 @@ msgstr "Wir nutzen eine Handvoll Drittanbieter für Anmeldung, Hosting und Speic
 
 #. Secondary line under the Request <query> dropdown row
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:941
+#: src/components/search/search-bar.tsx:937
 msgid "search.bar.request.subtext"
 msgstr "Wir fangen an, sie zu verfolgen"
 
@@ -4739,23 +4805,27 @@ msgstr "Mi"
 msgid "auth.signIn.subtitle"
 msgstr "Willkommen zurück"
 
+#. FAQ question defining a watchlist.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:68
+#: app/[lang]/(public)/faq/page.tsx:73
 msgid "faq.q.whatIsWatchlist"
 msgstr "Was ist eine Watchlist?"
 
+#. FAQ question asking for a short product definition.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:44
+#: app/[lang]/(public)/faq/page.tsx:49
 msgid "faq.q.whatIsJobseek"
 msgstr "Was ist Job Seek?"
 
+#. FAQ question comparing Job Seek with general job boards.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:56
+#: app/[lang]/(public)/faq/page.tsx:61
 msgid "faq.q.differentiation"
 msgstr "Was unterscheidet Job Seek von LinkedIn oder Indeed?"
 
+#. FAQ question comparing the Free and Pro plans.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:64
+#: app/[lang]/(public)/faq/page.tsx:69
 msgid "faq.q.freeVsPro"
 msgstr "Was ist der Unterschied zwischen Kostenlos und Pro?"
 
@@ -4765,8 +4835,9 @@ msgstr "Was ist der Unterschied zwischen Kostenlos und Pro?"
 msgid "app.home.request.heading"
 msgstr "Welches Unternehmen sollen wir verfolgen?"
 
+#. FAQ question about supported interface and job-posting languages.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:92
+#: app/[lang]/(public)/faq/page.tsx:97
 msgid "faq.q.languages"
 msgstr "Welche Sprachen unterstützt Jobseek?"
 
@@ -4784,7 +4855,7 @@ msgstr "Arbeitsweise"
 
 #. Section header for work-mode (onsite/hybrid/remote) suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:800
+#: src/components/search/search-bar.tsx:796
 msgid "search.bar.workMode"
 msgstr "Arbeitsweise"
 
@@ -4822,24 +4893,27 @@ msgstr "Jährlich"
 msgid "search.experienceModal.years"
 msgstr "Jahre"
 
+#. FAQ answer explaining the company watchlist use case.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:49
+#: app/[lang]/(public)/faq/page.tsx:54
 msgid "faq.a.targetedSeeker"
 msgstr "Ja — genau dafür haben wir Job Seek entwickelt. Füge die Unternehmen, die dich interessieren, zu einer Watchlist hinzu, setze deine Filter (Rolle, Standort, Seniorität, Gehalt), und Job Seek überwacht ihre Karriereseiten und benachrichtigt dich, sobald neue passende Stellen erscheinen. Du musst nicht jede Unternehmenswebsite manuell prüfen oder gegen den LinkedIn-Algorithmus kämpfen."
 
+#. FAQ answer explaining how companies can opt out of indexing.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:81
+#: app/[lang]/(public)/faq/page.tsx:86
 msgid "faq.a.optOut"
 msgstr "Ja. Schreib uns eine E-Mail und wir stellen das Crawlen deiner Karriereseite sofort ein und entfernen deine Stellenanzeigen aus dem Index."
 
+#. FAQ answer explaining crawler source availability and data licensing.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:85
+#: app/[lang]/(public)/faq/page.tsx:90
 msgid "faq.a.openSource"
 msgstr "Ja. Der Crawler und die Extraktions-Pipeline sind vollständig Open Source auf GitHub. Der Anwendungscode ist MIT-lizenziert; die Stellendaten sind CC BY-NC 4.0."
 
 #. Date divider label for yesterday
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:72
+#: src/components/watchlist/watchlist-job-list.tsx:76
 msgid "watchlists.jobList.yesterday"
 msgstr "Gestern"
 
@@ -4931,7 +5005,7 @@ msgstr "Du hast dein Watchlist-Limit erreicht. Upgrade deinen Plan, um weitere W
 
 #. Reason shown in upgrade modal when saving a search hits the watchlist limit
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:93
+#: src/components/search/save-search-button.tsx:96
 msgid "upgrade.reason.saveSearch"
 msgstr "Du hast dein Watchlist-Limit erreicht. Upgrade deinen Plan, um weitere Suchen als Watchlist zu speichern."
 
@@ -4961,6 +5035,6 @@ msgstr "Deine Rechte"
 
 #. Username section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:301
+#: src/components/settings/AccountSettings.tsx:307
 msgid "settings.account.username.description"
 msgstr "Dein eindeutiger Name für deine öffentliche Profil-URL."

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -57,8 +57,9 @@ msgstr "(opens in new tab)"
 msgid "search.detail.showMoreLocations"
 msgstr "{0} more"
 
+#. SEO metadata count text for a company page; {count} is the active job count.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:41
+#: app/[lang]/(app)/company/[slug]/page.tsx:42
 msgid "company.meta.positionCount"
 msgstr "{count, plural, one {# open position} other {# open positions}}"
 
@@ -86,8 +87,9 @@ msgstr "{count, plural, one {active posting} other {active postings}}"
 msgid "blog.mention.watchlist.companiesLabel"
 msgstr "{count, plural, one {company} other {companies}}"
 
+#. SEO description prefix for a public watchlist; {description} is the existing watchlist summary.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:104
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:108
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {Tracking # company} other {Tracking # companies}}. {description}"
 
@@ -97,18 +99,21 @@ msgstr "{count, plural, one {Tracking # company} other {Tracking # companies}}. 
 msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} applications on {date}"
 
+#. SEO metadata suffix when a watchlist includes more companies than can be listed by name.
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:62
 msgid "watchlist.meta.moreCompanies"
 msgstr "{count} more"
 
+#. SEO description for a company page when no company summary is available.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:53
+#: app/[lang]/(app)/company/[slug]/page.tsx:60
 msgid "company.meta.descriptionBasic"
 msgstr "{countText} at {name}"
 
+#. SEO description for a company page; includes job count, company name, and company summary.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:48
+#: app/[lang]/(app)/company/[slug]/page.tsx:54
 msgid "company.meta.descriptionWithInfo"
 msgstr "{countText} at {name}. {description}"
 
@@ -178,14 +183,17 @@ msgstr "1. Install MCP"
 msgid "app.home.request.agent.run_heading"
 msgstr "2. Run the prompt"
 
+#. FAQ answer explaining saved-search watchlists and sharing options.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:69
+#: app/[lang]/(public)/faq/page.tsx:74
 msgid "faq.a.whatIsWatchlist"
 msgstr "A watchlist is a saved search with optional company filtering. Pick the companies you care about, set your filters (role, location, seniority, salary), and get a live feed of matching jobs. You can share watchlists publicly or keep them private."
 
+#. JSON-LD page name for the public About page.
+#. SEO title for the public About page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/page.tsx:17
-#: app/[lang]/(public)/about/page.tsx:46
+#: app/[lang]/(public)/about/page.tsx:51
 msgid "about.meta.title"
 msgstr "About"
 
@@ -224,8 +232,8 @@ msgstr "Account menu"
 #. Active postings count on company page
 #. Active postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:561
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:571
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:572
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:582
 msgid "company.page.active"
 msgstr "active"
 
@@ -239,7 +247,7 @@ msgstr "active"
 
 #. Active matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:121
+#: src/components/search/company-card.tsx:122
 msgid "search.card.active"
 msgstr "active"
 
@@ -287,7 +295,7 @@ msgstr "Add location or keyword filter..."
 
 #. Placeholder in the add location input
 #. js-lingui-explicit-id
-#: src/components/search/location-pills.tsx:174
+#: src/components/search/location-pills.tsx:170
 msgid "search.locations.addPlaceholder"
 msgstr "Add location..."
 
@@ -305,7 +313,7 @@ msgstr "Agent prompt"
 
 #. Footer shown after all paged countries have been loaded into the location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:816
+#: src/components/search/location-search-modal.tsx:825
 msgid "search.locationModal.allLoaded"
 msgstr "All {totalCountries} countries loaded"
 
@@ -333,16 +341,16 @@ msgstr "All languages"
 msgid "settings.general.jobLanguages.all"
 msgstr "All languages"
 
-#. Button to open all-locations modal on company page
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:346
-msgid "company.page.allLocations"
-msgstr "All locations"
-
 #. Title for the all-locations modal on company page
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:268
 msgid "company.locationModal.title"
+msgstr "All locations"
+
+#. Button to open all-locations modal on company page
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:346
+msgid "company.page.allLocations"
 msgstr "All locations"
 
 #. Link to sign-in page from sign-up
@@ -353,12 +361,13 @@ msgstr "Already have an account? <0>Sign in</0>"
 
 #. Username is taken
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:292
+#: src/components/settings/AccountSettings.tsx:298
 msgid "settings.account.username.taken"
 msgstr "Already taken"
 
+#. SEO description for the public FAQ page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:18
+#: app/[lang]/(public)/faq/page.tsx:22
 msgid "faq.meta.description"
 msgstr "Answers to common questions about Job Seek — how we crawl career pages, what the free and Pro plans include, how we handle your data, and how to opt out."
 
@@ -434,6 +443,12 @@ msgstr "Applied"
 msgid "search.tracker.applied"
 msgstr "Applied"
 
+#. Applied status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:20
+msgid "myJobs.status.applied"
+msgstr "Applied"
+
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
@@ -444,12 +459,6 @@ msgstr "Applied"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.applied"
-msgstr "Applied"
-
-#. Applied status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:20
-msgid "myJobs.status.applied"
 msgstr "Applied"
 
 #. Apply salary filter
@@ -484,13 +493,13 @@ msgstr "As a last resort we parse the careers pages themselves, preferring newes
 
 #. Username too short hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:280
+#: src/components/settings/AccountSettings.tsx:286
 msgid "settings.account.username.tooShort"
 msgstr "At least 3 characters"
 
 #. Username too long hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:282
+#: src/components/settings/AccountSettings.tsx:288
 msgid "settings.account.username.tooLong"
 msgstr "At most 30 characters"
 
@@ -502,7 +511,7 @@ msgstr "Aug"
 
 #. Username is available
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:290
+#: src/components/settings/AccountSettings.tsx:296
 msgid "settings.account.username.available"
 msgstr "Available"
 
@@ -562,18 +571,18 @@ msgstr "Blog"
 msgid "blog.post.backToIndex"
 msgstr "Blog"
 
+#. Footer link to /blog index page
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:52
+msgid "common.footer.blog"
+msgstr "Blog"
+
 #. Nav link: Blog
 #. Nav link: Blog
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:74
 #: src/components/MobileMenu.tsx:98
 msgid "common.nav.blog"
-msgstr "Blog"
-
-#. Footer link to /blog index page
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
-msgid "common.footer.blog"
 msgstr "Blog"
 
 #. Subtitle on the sign-in CTA card shown to anonymous users at the end of the similar-companies strip
@@ -588,9 +597,11 @@ msgstr "Browse every peer company"
 msgid "indexing.oss.browseRepo"
 msgstr "Browse the repository at"
 
+#. JSON-LD page description for the public homepage.
+#. SEO description for the public homepage.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:21
-#: app/[lang]/(public)/page.tsx:53
+#: app/[lang]/(public)/page.tsx:25
+#: app/[lang]/(public)/page.tsx:62
 msgid "home.meta.description"
 msgstr "Build watchlists of the companies you care about, get email alerts when new roles open up, and track applications in one place. Postings come direct from company career pages, within hours of going live — no recruiter spam, no reposted listings."
 
@@ -612,8 +623,9 @@ msgstr "Built by job seekers, for job seekers"
 msgid "terms.hero.description"
 msgstr "By using Job Seek you agree to these terms. Here’s a plain-language overview."
 
+#. FAQ question about company opt-out from indexing.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:80
+#: app/[lang]/(public)/faq/page.tsx:85
 msgid "faq.q.optOut"
 msgstr "Can I opt out of Jobseek indexing my company?"
 
@@ -633,7 +645,7 @@ msgstr "Cancel"
 
 #. Cancel delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:532
+#: src/components/settings/AccountSettings.tsx:538
 msgid "settings.account.delete.cancel"
 msgstr "Cancel"
 
@@ -645,7 +657,7 @@ msgstr "change"
 
 #. Change email section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:370
+#: src/components/settings/AccountSettings.tsx:376
 msgid "settings.account.email.title"
 msgstr "Change email"
 
@@ -673,21 +685,21 @@ msgstr "Change your password via a secure email link."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Change..."
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "Check your email"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
 msgstr "Check your email"
 
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
+msgstr "Check your email"
+
 #. Checking username availability
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:288
+#: src/components/settings/AccountSettings.tsx:294
 msgid "settings.account.username.checking"
 msgstr "Checking availability..."
 
@@ -725,7 +737,7 @@ msgstr "Choose which languages you want to see job postings in."
 #. Location type label for cities
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:35
-#: src/components/search/location-pills.tsx:31
+#: src/components/search/location-pills.tsx:32
 msgid "location.type.city"
 msgstr "City"
 
@@ -745,7 +757,7 @@ msgstr "Clear all"
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:645
-#: src/components/search/search-toolbar.tsx:367
+#: src/components/search/search-toolbar.tsx:368
 msgid "search.filters.clearAll"
 msgstr "Clear all"
 
@@ -773,12 +785,6 @@ msgstr "Click to rename"
 msgid "indexing.ingestion.s2.title"
 msgstr "Client APIs second."
 
-#. Aria label for close button on add-companies modal
-#. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:201
-msgid "watchlists.companyModal.close"
-msgstr "Close"
-
 #. Aria label for upgrade modal close button
 #. js-lingui-explicit-id
 #: src/components/ui/upgrade-modal.tsx:59
@@ -791,16 +797,16 @@ msgstr "Close"
 msgid "settings.jobLanguages.modal.close"
 msgstr "Close"
 
+#. Aria label for close button on add-companies modal
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-search-modal.tsx:201
+msgid "watchlists.companyModal.close"
+msgstr "Close"
+
 #. Aria label for the technology modal close button
 #. js-lingui-explicit-id
 #: src/components/search/technology-modal.tsx:117
 msgid "search.technologyModal.close"
-msgstr "Close"
-
-#. Aria label for the seniority modal close button
-#. js-lingui-explicit-id
-#: src/components/search/seniority-modal.tsx:65
-msgid "search.seniorityModal.close"
 msgstr "Close"
 
 #. Aria label for the work-mode modal close button
@@ -809,10 +815,22 @@ msgstr "Close"
 msgid "search.workModeModal.close"
 msgstr "Close"
 
+#. Aria label for the seniority modal close button
+#. js-lingui-explicit-id
+#: src/components/search/seniority-modal.tsx:65
+msgid "search.seniorityModal.close"
+msgstr "Close"
+
 #. Aria label for the salary modal close button
 #. js-lingui-explicit-id
 #: src/components/search/salary-modal.tsx:254
 msgid "search.salaryModal.close"
+msgstr "Close"
+
+#. Aria label for close button on the company-page all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:275
+msgid "company.locationModal.close"
 msgstr "Close"
 
 #. Aria label for the occupation modal close button
@@ -823,7 +841,7 @@ msgstr "Close"
 
 #. Aria label for the location modal close button
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:479
+#: src/components/search/location-search-modal.tsx:488
 msgid "search.locationModal.close"
 msgstr "Close"
 
@@ -837,12 +855,6 @@ msgstr "Close"
 #. js-lingui-explicit-id
 #: src/components/search/employment-type-modal.tsx:82
 msgid "search.employmentTypeModal.close"
-msgstr "Close"
-
-#. Aria label for close button on the company-page all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:275
-msgid "company.locationModal.close"
 msgstr "Close"
 
 #. Aria label for job detail panel close button
@@ -865,13 +877,13 @@ msgstr "Close menu"
 
 #. Label for inactive/closed job postings on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:663
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:676
 msgid "company.page.closed"
 msgstr "Closed"
 
 #. Label for inactive/closed job postings on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:159
+#: src/components/search/company-card.tsx:171
 msgid "search.card.closed"
 msgstr "Closed"
 
@@ -907,7 +919,7 @@ msgstr "Coming soon"
 
 #. Section header for company suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:882
+#: src/components/search/search-bar.tsx:878
 msgid "search.bar.companies"
 msgstr "Companies"
 
@@ -945,15 +957,17 @@ msgstr "Company"
 #. Heading shown when the company URL slug doesn't resolve to a known company
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/company/[slug]/company-content.tsx:51
-#: app/[lang]/(app)/company/[slug]/page.tsx:89
+#: app/[lang]/(app)/company/[slug]/page.tsx:97
 msgid "company.notFound.title"
 msgstr "Company not found"
 
+#. WebApplication JSON-LD description for Job Seek.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:120
+#: app/[lang]/layout.tsx:121
 msgid "app.schema.description"
 msgstr "Company-tracking tool for job seekers who already know which companies they want to work at. Build watchlists, get email alerts when new roles open up, and track applications in one place — postings sourced directly from company career pages."
 
+#. Organization JSON-LD description for Job Seek and Colophon Group.
 #. js-lingui-explicit-id
 #: app/[lang]/layout.tsx:85
 msgid "app.schema.org.description"
@@ -961,7 +975,7 @@ msgstr "Company-tracking tool for targeted job seekers — watchlists, email ale
 
 #. Confirm delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:525
+#: src/components/settings/AccountSettings.tsx:531
 msgid "settings.account.delete.confirm"
 msgstr "Confirm deletion"
 
@@ -973,15 +987,21 @@ msgstr "Confirm password"
 
 #. Connect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:475
+#: src/components/settings/AccountSettings.tsx:481
 msgid "settings.account.socials.connect"
 msgstr "Connect"
 
 #. Connected accounts section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:450
+#: src/components/settings/AccountSettings.tsx:456
 msgid "settings.account.socials.title"
 msgstr "Connected accounts"
+
+#. Footer link to contact email
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Contact"
 
 #. TOC: Contact
 #. js-lingui-explicit-id
@@ -995,22 +1015,16 @@ msgstr "Contact"
 msgid "license.contact.title"
 msgstr "Contact"
 
-#. Footer link to contact email
+#. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Contact"
+#: src/components/HowWeIndexContent.tsx:21
+msgid "indexing.toc.title"
+msgstr "Contents"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:17
 msgid "license.toc.title"
-msgstr "Contents"
-
-#. Table of contents heading
-#. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:21
-msgid "indexing.toc.title"
 msgstr "Contents"
 
 #. Button to continue to app after verification
@@ -1083,7 +1097,7 @@ msgstr "Copy prompt"
 #. Location type label for countries
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:33
-#: src/components/search/location-pills.tsx:29
+#: src/components/search/location-pills.tsx:30
 msgid "location.type.country"
 msgstr "Country"
 
@@ -1119,7 +1133,7 @@ msgstr "Create a free account to browse all results, save jobs, track applicatio
 
 #. Tooltip explaining save search creates a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:117
+#: src/components/search/save-search-button.tsx:120
 msgid "search.saveSearch.tooltip"
 msgstr "Create a watchlist from your current filters"
 
@@ -1227,13 +1241,13 @@ msgstr "Delete"
 
 #. Delete account section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:508
+#: src/components/settings/AccountSettings.tsx:514
 msgid "settings.account.delete.title"
 msgstr "Delete account"
 
 #. Delete account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:518
+#: src/components/settings/AccountSettings.tsx:524
 msgid "settings.account.delete.button"
 msgstr "Delete my account"
 
@@ -1245,7 +1259,7 @@ msgstr "Delete watchlist?"
 
 #. Delete button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:524
+#: src/components/settings/AccountSettings.tsx:530
 msgid "settings.account.delete.deleting"
 msgstr "Deleting..."
 
@@ -1287,7 +1301,7 @@ msgstr "Disable alerts"
 
 #. Disconnect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:474
+#: src/components/settings/AccountSettings.tsx:480
 msgid "settings.account.socials.disconnect"
 msgstr "Disconnect"
 
@@ -1297,8 +1311,9 @@ msgstr "Disconnect"
 msgid "watchlists.explore.publicTitle"
 msgstr "Discover public watchlists"
 
+#. FAQ question about whether user data is sold.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:88
+#: app/[lang]/(public)/faq/page.tsx:93
 msgid "faq.q.dataPrivacy"
 msgstr "Does Jobseek sell my data?"
 
@@ -1455,40 +1470,41 @@ msgstr "Explore"
 msgid "app.header.nav.explore"
 msgstr "Explore"
 
+#. SEO title for the Explore jobs page.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:32
+#: app/[lang]/(app)/explore/page.tsx:39
 msgid "explore.meta.title"
 msgstr "Explore Jobs"
 
 #. Hidden page H1 for /explore — screen-reader landmark
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/search-page.tsx:754
+#: app/[lang]/(app)/explore/search-page.tsx:811
 msgid "explore.h1"
 msgstr "Explore Jobs"
 
 #. Generic email change error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:360
+#: src/components/settings/AccountSettings.tsx:366
 msgid "settings.account.email.error"
 msgstr "Failed to change email"
 
 #. Error when linking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:426
+#: src/components/settings/AccountSettings.tsx:432
 msgid "settings.account.socials.connectError"
 msgstr "Failed to connect account"
 
 #. Generic account deletion error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:499
+#: src/components/settings/AccountSettings.tsx:505
 msgid "settings.account.delete.error"
 msgstr "Failed to delete account"
 
 #. Error when unlinking social account fails
 #. Error when unlinking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:437
-#: src/components/settings/AccountSettings.tsx:442
+#: src/components/settings/AccountSettings.tsx:443
+#: src/components/settings/AccountSettings.tsx:448
 msgid "settings.account.socials.disconnectError"
 msgstr "Failed to disconnect account"
 
@@ -1518,10 +1534,11 @@ msgstr "Failed to set password"
 
 #. Generic username update error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:261
+#: src/components/settings/AccountSettings.tsx:267
 msgid "settings.account.username.error"
 msgstr "Failed to update username"
 
+#. SEO title for the public FAQ page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/faq/page.tsx:17
 msgid "faq.meta.title"
@@ -1667,8 +1684,9 @@ msgstr "Free"
 msgid "settings.billing.plan.free"
 msgstr "Free"
 
+#. FAQ answer summarizing Free and Pro plan differences.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:65
+#: app/[lang]/(public)/faq/page.tsx:70
 msgid "faq.a.freeVsPro"
 msgstr "Free gives you full search across all companies, one watchlist, and the application tracker with interview logging. Pro adds unlimited watchlists and email alerts when new roles match your criteria."
 
@@ -1696,8 +1714,9 @@ msgstr "From saved role to signed offer, all in one place"
 msgid "settings.billing.free.f2"
 msgstr "Full job search"
 
+#. WebApplication JSON-LD offer description for the Free plan.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:130
+#: app/[lang]/layout.tsx:132
 msgid "app.schema.offer.free"
 msgstr "Full search, 1 watchlist, application tracker"
 
@@ -1807,24 +1826,29 @@ msgstr "Hourly"
 msgid "myJobs.salary.hourly"
 msgstr "Hourly"
 
+#. FAQ question about requesting a missing company.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:60
+#: app/[lang]/(public)/faq/page.tsx:65
 msgid "faq.q.requestCompany"
 msgstr "How do I request a company that isn't listed?"
 
+#. FAQ question for company operators about crawler behavior.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:76
+#: app/[lang]/(public)/faq/page.tsx:81
 msgid "faq.q.crawlingPolicy"
 msgstr "How does the crawler behave on my company's website?"
 
+#. JSON-LD page description for the public Job Indexing methodology page.
+#. SEO description for the public Job Indexing methodology page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:18
-#: app/[lang]/(public)/how-we-index/page.tsx:50
+#: app/[lang]/(public)/how-we-index/page.tsx:22
+#: app/[lang]/(public)/how-we-index/page.tsx:59
 msgid "indexing.meta.description"
 msgstr "How Job Seek discovers and indexes job postings: our sourcing approach, crawl frequency, rate limits, robots.txt and TDM-Reservation compliance, and how to opt out."
 
+#. FAQ question about job listing refresh cadence.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:52
+#: app/[lang]/(public)/faq/page.tsx:57
 msgid "faq.q.howOftenUpdated"
 msgstr "How often are job listings updated?"
 
@@ -1846,9 +1870,11 @@ msgstr "How postings enter the index"
 msgid "indexing.hero.title"
 msgstr "How we find and process job postings"
 
+#. JSON-LD page name for the public Job Indexing methodology page.
+#. SEO title for the public Job Indexing methodology page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/how-we-index/page.tsx:17
-#: app/[lang]/(public)/how-we-index/page.tsx:49
+#: app/[lang]/(public)/how-we-index/page.tsx:54
 msgid "indexing.meta.title"
 msgstr "How We Index"
 
@@ -1858,8 +1884,8 @@ msgstr "How We Index"
 #. Work mode: hybrid (mixed onsite/remote)
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:597
-#: src/components/search/search-bar.tsx:812
-#: src/components/search/search-toolbar.tsx:271
+#: src/components/search/search-bar.tsx:808
+#: src/components/search/search-toolbar.tsx:272
 #: src/components/search/work-mode-modal.tsx:27
 msgid "search.workMode.hybrid"
 msgstr "Hybrid"
@@ -1888,16 +1914,17 @@ msgstr "If you notice unexpected activity from our crawler or prefer that your c
 msgid "indexing.outreach.body"
 msgstr "If you notice unusual crawler behaviour, prefer that we do not index your content, or have suggestions on how to improve our safeguards, please reach out."
 
+#. SEO metadata phrase listing locations filtered by a public watchlist.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:78
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:80
 msgid "watchlist.meta.inLocations"
 msgstr "in {locations}"
 
 #. Year postings count on company page
 #. Year postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:563
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:575
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:574
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:586
 msgid "company.page.yearCount"
 msgstr "in the last year"
 
@@ -1911,7 +1938,7 @@ msgstr "in the last year"
 
 #. Yearly matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:123
+#: src/components/search/company-card.tsx:124
 msgid "search.card.yearCount"
 msgstr "in the last year"
 
@@ -1999,16 +2026,16 @@ msgstr "Interviewing"
 msgid "search.tracker.interviewing"
 msgstr "Interviewing"
 
-#. Status option in dropdown: interviewing
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:37
-msgid "myJobs.statusOption.interviewing"
-msgstr "Interviewing"
-
 #. Interviewing status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:21
 msgid "myJobs.status.interviewing"
+msgstr "Interviewing"
+
+#. Status option in dropdown: interviewing
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:37
+msgid "myJobs.statusOption.interviewing"
 msgstr "Interviewing"
 
 #. Interviews section heading
@@ -2029,18 +2056,21 @@ msgstr "Invalid reset link"
 msgid "auth.verify.error.invalidLink"
 msgstr "Invalid verification link"
 
+#. FAQ question about whether the product suits company-targeted job seekers.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:48
+#: app/[lang]/(public)/faq/page.tsx:53
 msgid "faq.q.targetedSeeker"
 msgstr "Is Job Seek for me if I already know which companies I want to work for?"
 
+#. FAQ question about open-source availability.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:84
+#: app/[lang]/(public)/faq/page.tsx:89
 msgid "faq.q.openSource"
 msgstr "Is the crawler open source?"
 
+#. FAQ question about application tracker limits.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:72
+#: app/[lang]/(public)/faq/page.tsx:77
 msgid "faq.q.trackerLimit"
 msgstr "Is there a limit to how many jobs I can track?"
 
@@ -2050,16 +2080,16 @@ msgstr "Is there a limit to how many jobs I can track?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:121
-msgid "watchlists.explore.jobSingular"
-msgstr "job"
-
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31
 msgid "watchlists.card.jobSingular"
+msgstr "job"
+
+#. Singular job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:121
+msgid "watchlists.explore.jobSingular"
 msgstr "job"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -2104,14 +2134,17 @@ msgstr "Job Postings"
 msgid "home.features.s2.screenshot.alt"
 msgstr "Job Seek application tracker showing saved jobs and interview details"
 
+#. FAQ answer explaining what Job Seek does for targeted job seekers.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:45
+#: app/[lang]/(public)/faq/page.tsx:50
 msgid "faq.a.whatIsJobseek"
 msgstr "Job Seek helps you track the companies you actually want to work at. Build a watchlist, get email alerts when new roles open up, and track applications in one place. Postings come straight from company career pages, so you see them within hours of going live — typically before LinkedIn or Indeed cross-post them."
 
+#. JSON-LD page description for the public About page.
+#. SEO description for the public About page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/about/page.tsx:18
-#: app/[lang]/(public)/about/page.tsx:47
+#: app/[lang]/(public)/about/page.tsx:22
+#: app/[lang]/(public)/about/page.tsx:56
 msgid "about.meta.description"
 msgstr "Job Seek helps you track the companies you want to work at — watchlists, email alerts, and postings sourced directly from company career pages. Built by Colophon Group, a small developer studio in Switzerland."
 
@@ -2133,9 +2166,11 @@ msgstr "Job Seek is being actively built. Stay tuned for updates!"
 msgid "about.p1"
 msgstr "Job Seek is built by Colophon Group, a small team of developers based in Switzerland. We started it because we were tired of the same problem every job seeker faces: juggling dozens of browser tabs, missing new postings because an aggregator was slow to pick them up, and drowning in algorithmic noise that optimizes for clicks rather than relevance."
 
+#. JSON-LD page description for the public Privacy Policy page.
+#. SEO description for the public Privacy Policy page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:18
-#: app/[lang]/(public)/privacy-policy/page.tsx:51
+#: app/[lang]/(public)/privacy-policy/page.tsx:22
+#: app/[lang]/(public)/privacy-policy/page.tsx:60
 msgid "privacy.meta.description"
 msgstr "Job Seek privacy policy — what personal data we collect, how we use it, your GDPR rights, cookie policy, and how to request deletion of your account and data."
 
@@ -2157,16 +2192,11 @@ msgstr "Job Seek watchlist showing curated robotics engineering roles in Zurich"
 msgid "license.hero.description"
 msgstr "Job Seek's codebase is open source under MIT. The job data we collect and enrich is Creative Commons BY-NC 4.0. Below is the plain-language summary — please read the full licenses for exact terms."
 
+#. Fallback SEO description for a public watchlist with no description or filters.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:86
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:89
 msgid "watchlist.meta.fallback"
 msgstr "Job watchlist by @{owner}"
-
-#. Plural job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:122
-msgid "watchlists.explore.jobPlural"
-msgstr "jobs"
 
 #. Plural job count on watchlist card
 #. js-lingui-explicit-id
@@ -2174,13 +2204,21 @@ msgstr "jobs"
 msgid "watchlists.card.jobPlural"
 msgstr "jobs"
 
+#. Plural job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:122
+msgid "watchlists.explore.jobPlural"
+msgstr "jobs"
+
+#. SEO title for a company detail page; {name} is the company name.
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/company/[slug]/page.tsx:34
 msgid "company.meta.title"
 msgstr "Jobs at {name}"
 
+#. SEO metadata phrase listing companies tracked by a public watchlist.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:68
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:69
 msgid "watchlist.meta.jobsAt"
 msgstr "Jobs at {names}"
 
@@ -2228,14 +2266,14 @@ msgstr "Last hour"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:27
-msgid "terms.hero.lastUpdated"
+#: src/components/PrivacyPolicyContent.tsx:27
+msgid "privacy.hero.lastUpdated"
 msgstr "Last updated:"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:27
-msgid "privacy.hero.lastUpdated"
+#: src/components/TermsContent.tsx:27
+msgid "terms.hero.lastUpdated"
 msgstr "Last updated:"
 
 #. Time range option: last week
@@ -2252,7 +2290,7 @@ msgstr "Learn more"
 
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:730
+#: src/components/search/search-bar.tsx:726
 msgid "search.bar.level"
 msgstr "Level"
 
@@ -2262,16 +2300,18 @@ msgstr "Level"
 msgid "search.advanced.level"
 msgstr "Level"
 
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:17
-#: app/[lang]/(public)/license/page.tsx:51
-msgid "license.meta.title"
-msgstr "License"
-
 #. Link to license page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:70
 msgid "about.link.license"
+msgstr "License"
+
+#. JSON-LD page name for the public License page.
+#. SEO title for the public License page.
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/license/page.tsx:17
+#: app/[lang]/(public)/license/page.tsx:56
+msgid "license.meta.title"
 msgstr "License"
 
 #. Footer link to license page
@@ -2292,9 +2332,11 @@ msgstr "License of Job Seek"
 msgid "license.hero.eyebrow"
 msgstr "Licensing"
 
+#. JSON-LD page description for the public License page.
+#. SEO description for the public License page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:18
-#: app/[lang]/(public)/license/page.tsx:52
+#: app/[lang]/(public)/license/page.tsx:22
+#: app/[lang]/(public)/license/page.tsx:61
 msgid "license.meta.description"
 msgstr "Licensing for Job Seek — application source code is MIT-licensed, job posting data is CC BY-NC 4.0. Learn what you can and cannot do with our code and data."
 
@@ -2356,7 +2398,7 @@ msgstr "Location"
 
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:842
+#: src/components/search/search-bar.tsx:838
 msgid "search.bar.locations"
 msgstr "Locations"
 
@@ -2382,7 +2424,7 @@ msgstr "Log in"
 
 #. Tooltip when user needs to log in to save search
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:122
+#: src/components/search/save-search-button.tsx:125
 msgid "search.saveSearch.tooltipLogin"
 msgstr "Log in to save this search as a watchlist"
 
@@ -2412,7 +2454,7 @@ msgstr "Manage subscription"
 
 #. Connected accounts section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:453
+#: src/components/settings/AccountSettings.tsx:459
 msgid "settings.account.socials.description"
 msgstr "Manage your linked social accounts."
 
@@ -2442,7 +2484,7 @@ msgstr "Mark rejected"
 
 #. Header for the server-side search-results cluster shown when the user types in the location modal search box
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:585
+#: src/components/search/location-search-modal.tsx:594
 msgid "search.locationModal.searchHitsHeader"
 msgstr "Matches"
 
@@ -2508,8 +2550,9 @@ msgstr "Missing a company? Paste its careers page URL and we start indexing it f
 msgid "myJobs.heatmap.day.mon"
 msgstr "Mon"
 
+#. WebApplication JSON-LD feature list item about career-page monitoring.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:142
+#: app/[lang]/layout.tsx:152
 msgid "app.schema.feature.monitor"
 msgstr "Monitor company career pages"
 
@@ -2549,8 +2592,9 @@ msgstr "Move each role from saved to applied, interviewing, offered, or rejected
 msgid "home.features.s1.p2.title"
 msgstr "Multi-dimensional filters"
 
+#. WebApplication JSON-LD feature list item about supported interface languages.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:144
+#: app/[lang]/layout.tsx:162
 msgid "app.schema.feature.languages"
 msgstr "Multi-language support"
 
@@ -2560,22 +2604,22 @@ msgstr "Multi-language support"
 #. Warning when Enter is pressed but multiple items match
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:247
-#: src/components/search/location-search-modal.tsx:430
+#: src/components/search/location-search-modal.tsx:439
 #: src/components/search/occupation-modal.tsx:180
 #: src/components/search/technology-modal.tsx:88
 msgid "search.bestGuess.ambiguous"
 msgstr "Multiple matches — select one below"
 
-#. Back link to my jobs
-#. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:40
-msgid "myJobs.stats.back"
-msgstr "My Jobs"
-
 #. Title of the My Jobs page
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:252
 msgid "myJobs.title"
+msgstr "My Jobs"
+
+#. Back link to my jobs
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:40
+msgid "myJobs.stats.back"
 msgstr "My Jobs"
 
 #. My Jobs nav icon tooltip
@@ -2604,7 +2648,7 @@ msgstr "Need to reach us?"
 
 #. New email input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:382
+#: src/components/settings/AccountSettings.tsx:388
 msgid "settings.account.email.label"
 msgstr "New email"
 
@@ -2646,7 +2690,7 @@ msgstr "No industries found."
 
 #. Empty state when no jobs match the time range
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:230
+#: src/components/watchlist/watchlist-job-list.tsx:282
 msgid "watchlists.jobList.empty"
 msgstr "No jobs found."
 
@@ -2656,21 +2700,21 @@ msgstr "No jobs found."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "No languages match your search."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:516
-msgid "search.locationModal.noResults"
-msgstr "No locations match your search."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:312
 msgid "company.locationModal.noResults"
 msgstr "No locations match your search."
 
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:525
+msgid "search.locationModal.noResults"
+msgstr "No locations match your search."
+
 #. No postings found message on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:644
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:657
 msgid "company.page.noResults"
 msgstr "No matching postings found."
 
@@ -2691,18 +2735,6 @@ msgstr "No response"
 #: src/components/search/zero-results.tsx:14
 msgid "search.zero.heading"
 msgstr "No results found for “{query}”"
-
-#. Heading shown when a search surface returns an impossible empty result set
-#. js-lingui-explicit-id
-#: src/components/search/search-unavailable.tsx:9
-msgid "search.unavailable.heading"
-msgstr "Oops, something went wrong."
-
-#. Body shown when a search surface returns an impossible empty result set
-#. js-lingui-explicit-id
-#: src/components/search/search-unavailable.tsx:14
-msgid "search.unavailable.body"
-msgstr "Try refreshing the page."
 
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
@@ -2746,13 +2778,15 @@ msgstr "No watchlists found."
 msgid "watchlists.page.empty"
 msgstr "No watchlists yet. Create one to track jobs from your favorite companies."
 
+#. FAQ answer explaining that the application tracker has no hard limit.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:73
+#: app/[lang]/(public)/faq/page.tsx:78
 msgid "faq.a.trackerLimit"
 msgstr "No. The application tracker has no hard limit — save as many jobs as you want and move them through your pipeline."
 
+#. FAQ answer explaining data privacy, cookies, and account deletion.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:89
+#: app/[lang]/(public)/faq/page.tsx:94
 msgid "faq.a.dataPrivacy"
 msgstr "No. We don't sell, rent, or share your data for marketing. Cookies are session-only with no ads or tracking. You can delete your account and all data is wiped within 30 days."
 
@@ -2834,8 +2868,8 @@ msgstr "Ok"
 #. Work mode: onsite (in-office)
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:595
-#: src/components/search/search-bar.tsx:810
-#: src/components/search/search-toolbar.tsx:269
+#: src/components/search/search-bar.tsx:806
+#: src/components/search/search-toolbar.tsx:270
 #: src/components/search/work-mode-modal.tsx:26
 msgid "search.workMode.onsite"
 msgstr "On-site"
@@ -2854,7 +2888,7 @@ msgstr "One page per minute."
 
 #. Username invalid characters hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:284
+#: src/components/settings/AccountSettings.tsx:290
 msgid "settings.account.username.invalidChars"
 msgstr "Only lowercase letters, numbers, and hyphens (cannot start/end with hyphen)"
 
@@ -2864,15 +2898,21 @@ msgstr "Only lowercase letters, numbers, and hyphens (cannot start/end with hyph
 msgid "myJobs.interviewType.onsite"
 msgstr "Onsite"
 
+#. Heading shown when a search surface returns an impossible empty result set
+#. js-lingui-explicit-id
+#: src/components/search/search-unavailable.tsx:9
+msgid "search.unavailable.heading"
+msgstr "Oops, something went wrong."
+
 #. Aria label for the row open-posting button when the posting title is missing
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:158
+#: src/components/watchlist/watchlist-job-list.tsx:199
 msgid "watchlists.jobList.openPosting"
 msgstr "Open job posting"
 
 #. Aria label for opening a job posting from a company card row when the posting title is missing
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:147
+#: src/components/search/company-card.tsx:159
 msgid "search.card.openPosting"
 msgstr "Open job posting"
 
@@ -2882,8 +2922,9 @@ msgstr "Open job posting"
 msgid "common.header.openMenu"
 msgstr "Open main menu"
 
+#. Fallback SEO metadata count text for a company with no active jobs.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:46
+#: app/[lang]/(app)/company/[slug]/page.tsx:48
 msgid "company.meta.openPositions"
 msgstr "Open positions"
 
@@ -2925,13 +2966,13 @@ msgstr "Original"
 
 #. Fallback label for a country header in the location modal when the city has no parent country in the hierarchy. Rare path.
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:638
+#: src/components/search/location-search-modal.tsx:647
 msgid "search.locationModal.otherCountry"
 msgstr "Other"
 
 #. Fallback label for a region row in the location modal when the region has no display name (e.g. orphaned cities). Rare path; only shown when a city's parent region in the hierarchy has no localized name.
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:723
+#: src/components/search/location-search-modal.tsx:732
 msgid "search.locationModal.otherRegion"
 msgstr "Other"
 
@@ -2961,21 +3002,15 @@ msgstr "Our stance on automation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:21
-msgid "license.toc.overview"
-msgstr "Overview"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:25
 msgid "indexing.toc.overview"
 msgstr "Overview"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
-msgid "license.toc.ariaLabel"
-msgstr "Page contents"
+#: src/components/LicenseContent.tsx:21
+msgid "license.toc.overview"
+msgstr "Overview"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
@@ -2983,9 +3018,17 @@ msgstr "Page contents"
 msgid "indexing.toc.ariaLabel"
 msgstr "Page contents"
 
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:18
+msgid "license.toc.ariaLabel"
+msgstr "Page contents"
+
+#. Heading shown on the 404 page
 #. Heading shown on the 404 page
 #. js-lingui-explicit-id
 #: app/[lang]/not-found-content.tsx:12
+#: app/[lang]/not-found.tsx:21
 msgid "notFound.title"
 msgstr "Page not found"
 
@@ -3071,7 +3114,7 @@ msgstr "Period"
 
 #. Delete account section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:511
+#: src/components/settings/AccountSettings.tsx:517
 msgid "settings.account.delete.description"
 msgstr "Permanently delete your account and all associated data. This action cannot be undone."
 
@@ -3107,7 +3150,7 @@ msgstr "Please enter a company name or URL."
 
 #. Error when email field is empty
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:350
+#: src/components/settings/AccountSettings.tsx:356
 msgid "settings.account.email.required"
 msgstr "Please enter a new email address"
 
@@ -3203,9 +3246,11 @@ msgstr "Privacy"
 msgid "privacy.hero.title"
 msgstr "Privacy at Job Seek"
 
+#. JSON-LD page name for the public Privacy Policy page.
+#. SEO title for the public Privacy Policy page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/privacy-policy/page.tsx:17
-#: app/[lang]/(public)/privacy-policy/page.tsx:50
+#: app/[lang]/(public)/privacy-policy/page.tsx:55
 msgid "privacy.meta.title"
 msgstr "Privacy Policy"
 
@@ -3239,16 +3284,16 @@ msgstr "Public Domain"
 msgid "license.contactCta"
 msgstr "Questions about licensing or commercial use? Email us."
 
-#. Terms contact call to action
-#. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:53
-msgid "terms.contact.description"
-msgstr "Questions? Email us."
-
 #. Privacy contact call to action
 #. js-lingui-explicit-id
 #: src/components/PrivacyPolicyContent.tsx:65
 msgid "privacy.contact.description"
+msgstr "Questions? Email us."
+
+#. Terms contact call to action
+#. js-lingui-explicit-id
+#: src/components/TermsContent.tsx:53
+msgid "terms.contact.description"
 msgstr "Questions? Email us."
 
 #. Link to full CC license
@@ -3275,8 +3320,9 @@ msgstr "Read the full Privacy Policy"
 msgid "terms.fullTermsLink"
 msgstr "Read the full Terms of Service"
 
+#. WebApplication JSON-LD feature list item about job alert notifications.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:143
+#: app/[lang]/layout.tsx:157
 msgid "app.schema.feature.alerts"
 msgstr "Real-time job posting alerts"
 
@@ -3305,21 +3351,21 @@ msgstr "Redistribute your changes, as long as you include the MIT notice."
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:32
 #: src/components/search/filter-bar.tsx:34
-#: src/components/search/location-pills.tsx:28
-#: src/components/search/location-pills.tsx:30
+#: src/components/search/location-pills.tsx:29
+#: src/components/search/location-pills.tsx:31
 msgid "location.type.region"
 msgstr "Region"
-
-#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:526
-msgid "search.locationModal.regionsHeader"
-msgstr "Regions"
 
 #. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:322
 msgid "company.locationModal.regionsHeader"
+msgstr "Regions"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:535
+msgid "search.locationModal.regionsHeader"
 msgstr "Regions"
 
 #. Status group heading: rejected
@@ -3334,6 +3380,12 @@ msgstr "Rejected"
 msgid "search.tracker.rejected"
 msgstr "Rejected"
 
+#. Rejected status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:23
+msgid "myJobs.status.rejected"
+msgstr "Rejected"
+
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
@@ -3344,12 +3396,6 @@ msgstr "Rejected"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:39
 msgid "myJobs.statusOption.rejected"
-msgstr "Rejected"
-
-#. Rejected status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:23
-msgid "myJobs.status.rejected"
 msgstr "Rejected"
 
 #. Footer license summary text
@@ -3364,8 +3410,8 @@ msgstr "Released under the MIT License. Job data is CC BY-NC 4.0."
 #. Work mode: remote (work-from-home)
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:598
-#: src/components/search/search-bar.tsx:813
-#: src/components/search/search-toolbar.tsx:272
+#: src/components/search/search-bar.tsx:809
+#: src/components/search/search-toolbar.tsx:273
 #: src/components/search/work-mode-modal.tsx:28
 msgid "search.workMode.remote"
 msgstr "Remote"
@@ -3402,11 +3448,11 @@ msgstr "Remove {0} filter"
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:579
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:589
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:603
-#: src/components/search/search-toolbar.tsx:201
-#: src/components/search/search-toolbar.tsx:220
-#: src/components/search/search-toolbar.tsx:240
-#: src/components/search/search-toolbar.tsx:260
-#: src/components/search/search-toolbar.tsx:283
+#: src/components/search/search-toolbar.tsx:202
+#: src/components/search/search-toolbar.tsx:221
+#: src/components/search/search-toolbar.tsx:241
+#: src/components/search/search-toolbar.tsx:261
+#: src/components/search/search-toolbar.tsx:284
 msgid "search.filters.removeFilter"
 msgstr "Remove {name} filter"
 
@@ -3432,7 +3478,7 @@ msgstr "Remove {name} filter"
 #. Aria label for the X button that clears the experience-range filter
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:622
-#: src/components/search/search-toolbar.tsx:318
+#: src/components/search/search-toolbar.tsx:319
 msgid "search.filters.removeExperience"
 msgstr "Remove experience filter"
 
@@ -3459,13 +3505,13 @@ msgstr "Remove keyword {0}"
 #. Aria label for remove-keyword X button; {name} is the keyword
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:630
-#: src/components/search/search-toolbar.tsx:335
+#: src/components/search/search-toolbar.tsx:336
 msgid "search.filters.removeKeyword"
 msgstr "Remove keyword {name}"
 
 #. Aria label for removing a location pill
 #. js-lingui-explicit-id
-#: src/components/search/location-pills.tsx:199
+#: src/components/search/location-pills.tsx:195
 msgid "search.locations.remove"
 msgstr "Remove location"
 
@@ -3480,7 +3526,7 @@ msgstr "Remove location {0}"
 #. Aria label for remove-location X button; {name} is the location label
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:640
-#: src/components/search/search-toolbar.tsx:356
+#: src/components/search/search-toolbar.tsx:357
 msgid "search.filters.removeLocation"
 msgstr "Remove location {name}"
 
@@ -3488,7 +3534,7 @@ msgstr "Remove location {name}"
 #. Aria label for the X button that clears the salary-range filter
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:613
-#: src/components/search/search-toolbar.tsx:301
+#: src/components/search/search-toolbar.tsx:302
 msgid "search.filters.removeSalary"
 msgstr "Remove salary filter"
 
@@ -3500,7 +3546,7 @@ msgstr "Remove salary filter"
 
 #. Synthetic dropdown row that lets the user request a company that's not in the catalog
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:934
+#: src/components/search/search-bar.tsx:930
 msgid "search.bar.request"
 msgstr "Request \"{trimmedInput}\""
 
@@ -3590,7 +3636,7 @@ msgstr "Role"
 
 #. Section header for occupation suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:695
+#: src/components/search/search-bar.tsx:691
 msgid "search.bar.roles"
 msgstr "Roles"
 
@@ -3644,7 +3690,7 @@ msgstr "Save any search as a watchlist and get email alerts when new roles match
 
 #. Save job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:191
+#: src/components/watchlist/watchlist-job-list.tsx:232
 msgid "watchlists.jobList.save"
 msgstr "Save job"
 
@@ -3668,7 +3714,7 @@ msgstr "Save some jobs and track your applications to see stats here."
 
 #. Button label to save current search as a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:110
+#: src/components/search/save-search-button.tsx:113
 msgid "search.saveSearch.label"
 msgstr "Save this search"
 
@@ -3676,6 +3722,12 @@ msgstr "Save this search"
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:28
 msgid "myJobs.group.saved"
+msgstr "Saved"
+
+#. Saved status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:19
+msgid "myJobs.status.saved"
 msgstr "Saved"
 
 #. Sankey funnel node: saved jobs
@@ -3690,21 +3742,15 @@ msgstr "Saved"
 msgid "myJobs.statusOption.saved"
 msgstr "Saved"
 
-#. Saved status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:19
-msgid "myJobs.status.saved"
-msgstr "Saved"
-
 #. Username save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:320
+#: src/components/settings/AccountSettings.tsx:326
 msgid "settings.account.username.saving"
 msgstr "Saving..."
 
 #. Email save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:392
+#: src/components/settings/AccountSettings.tsx:398
 msgid "settings.account.email.saving"
 msgstr "Saving..."
 
@@ -3723,7 +3769,7 @@ msgstr "Search across thousands of companies scraped directly from their career 
 #. Placeholder for search bar when on company page
 #. js-lingui-explicit-id
 #. placeholder {0}: company.name
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:161
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:169
 msgid "company.page.searchPlaceholder"
 msgstr "Search at {0}..."
 
@@ -3741,12 +3787,13 @@ msgstr "Search companies..."
 
 #. Option to search by title keyword in dropdown
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:683
+#: src/components/search/search-bar.tsx:679
 msgid "search.bar.keyword"
 msgstr "Search for \"{trimmedInput}\" in job titles"
 
+#. SEO description for the Explore jobs page.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:33
+#: app/[lang]/(app)/explore/page.tsx:44
 msgid "explore.meta.description"
 msgstr "Search jobs across thousands of companies scraped directly from career pages. Filter by seniority, tech stack, salary, and location — then save watchlists and get alerts."
 
@@ -3756,16 +3803,16 @@ msgstr "Search jobs across thousands of companies scraped directly from career p
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Search languages..."
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:495
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Search locations..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:291
 msgid "company.locationModal.searchPlaceholder"
+msgstr "Search locations..."
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:504
+msgid "search.locationModal.searchPlaceholder"
 msgstr "Search locations..."
 
 #. Back-to-search link on company page header
@@ -3794,7 +3841,7 @@ msgstr "Search with precision"
 
 #. Placeholder for the main search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:608
+#: src/components/search/search-bar.tsx:604
 msgid "search.bar.placeholder"
 msgstr "Search..."
 
@@ -3812,7 +3859,7 @@ msgstr "Select level"
 
 #. Title for the global location selection modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:472
+#: src/components/search/location-search-modal.tsx:481
 msgid "search.locationModal.title"
 msgstr "Select location"
 
@@ -3852,16 +3899,16 @@ msgstr "Send reset link"
 msgid "settings.account.password.send"
 msgstr "Send reset link"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Sending..."
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
+msgstr "Sending..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
 msgstr "Sending..."
 
 #. Reset password button while loading
@@ -4052,7 +4099,7 @@ msgstr "Sitemap first."
 
 #. Skip to main content link for keyboard users
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/layout.tsx:25
+#: src/components/SkipToContentLink.tsx:11
 msgid "common.a11y.skipToContent"
 msgstr "Skip to content"
 
@@ -4202,7 +4249,7 @@ msgstr "Technical"
 
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:765
+#: src/components/search/search-bar.tsx:761
 msgid "search.bar.technologies"
 msgstr "Technologies"
 
@@ -4248,9 +4295,11 @@ msgstr "Terms"
 msgid "common.footer.termsLink"
 msgstr "Terms"
 
+#. JSON-LD page name for the public Terms of Service page.
+#. SEO title for the public Terms of Service page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/terms/page.tsx:17
-#: app/[lang]/(public)/terms/page.tsx:50
+#: app/[lang]/(public)/terms/page.tsx:55
 msgid "terms.meta.title"
 msgstr "Terms of Service"
 
@@ -4260,15 +4309,17 @@ msgstr "Terms of Service"
 msgid "terms.hero.title"
 msgstr "Terms of Service"
 
+#. JSON-LD page description for the public Terms of Service page.
+#. SEO description for the public Terms of Service page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:18
-#: app/[lang]/(public)/terms/page.tsx:51
+#: app/[lang]/(public)/terms/page.tsx:22
+#: app/[lang]/(public)/terms/page.tsx:60
 msgid "terms.meta.description"
 msgstr "Terms of Service for Job Seek — usage rules, intellectual property, account responsibilities, limitation of liability, and governing law for the job search platform."
 
 #. Body text shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:94
+#: app/[lang]/(app)/company/[slug]/page.tsx:102
 msgid "company.notFound.message"
 msgstr "The company you are looking for does not exist or has been removed."
 
@@ -4284,13 +4335,15 @@ msgstr "The company you are looking for does not exist or has been removed."
 msgid "about.transparency.p1"
 msgstr "The crawler code is open source so anyone can audit how we collect data. We respect robots.txt, honor TDM-Reservation headers, and limit ourselves to one request per site per minute. Every outbound link includes utm_source=jobseek so employers know where their traffic comes from."
 
+#. FAQ answer explaining crawler discovery and refresh frequency.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:53
+#: app/[lang]/(public)/faq/page.tsx:58
 msgid "faq.a.howOftenUpdated"
 msgstr "The crawler discovers new postings on an hourly cycle and refreshes job details daily. Most roles appear within hours of being published on a company's careers page."
 
+#. FAQ answer listing interface languages and posting-language filtering.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:93
+#: app/[lang]/(public)/faq/page.tsx:98
 msgid "faq.a.languages"
 msgstr "The interface is available in English, German, French, and Italian. You can also filter job postings by the language they were written in."
 
@@ -4308,14 +4361,14 @@ msgstr "The service is provided as-is — no warranties."
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:39
-msgid "terms.short.title"
+#: src/components/PrivacyPolicyContent.tsx:39
+msgid "privacy.short.title"
 msgstr "The short version"
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:39
-msgid "privacy.short.title"
+#: src/components/TermsContent.tsx:39
+msgid "terms.short.title"
 msgstr "The short version"
 
 #. Theme settings section heading
@@ -4338,7 +4391,7 @@ msgstr "This site uses cookies only for authentication and essential functionali
 
 #. Username is reserved hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:286
+#: src/components/settings/AccountSettings.tsx:292
 msgid "settings.account.username.reserved"
 msgstr "This username is reserved"
 
@@ -4356,7 +4409,7 @@ msgstr "This will permanently delete this watchlist and all its settings. This a
 
 #. Date divider label for today
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:71
+#: src/components/watchlist/watchlist-job-list.tsx:75
 msgid "watchlists.jobList.today"
 msgstr "Today"
 
@@ -4366,9 +4419,11 @@ msgstr "Today"
 msgid "home.hero.title"
 msgstr "Track the companies you actually want to work at."
 
+#. JSON-LD page name for the public homepage.
+#. SEO title for the public homepage.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/page.tsx:20
-#: app/[lang]/(public)/page.tsx:52
+#: app/[lang]/(public)/page.tsx:57
 msgid "home.meta.title"
 msgstr "Track the companies you want to work at — Job Seek"
 
@@ -4395,6 +4450,12 @@ msgstr "Transparent by default"
 #: app/[lang]/error.tsx:23
 msgid "error.retryButton"
 msgstr "Try again"
+
+#. Body shown when a search surface returns an impossible empty result set
+#. js-lingui-explicit-id
+#: src/components/search/search-unavailable.tsx:14
+msgid "search.unavailable.body"
+msgstr "Try refreshing the page."
 
 #. Add employment type filter
 #. js-lingui-explicit-id
@@ -4438,14 +4499,15 @@ msgstr "Unlimited watchlists"
 msgid "home.pricing.pro.description"
 msgstr "Unlimited watchlists with email alerts so you never miss an opening."
 
+#. WebApplication JSON-LD offer description for the Pro plan.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:138
+#: app/[lang]/layout.tsx:144
 msgid "app.schema.offer.pro"
 msgstr "Unlimited watchlists, email alerts on new matches"
 
 #. Unsave job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:190
+#: src/components/watchlist/watchlist-job-list.tsx:231
 msgid "watchlists.jobList.unsave"
 msgstr "Unsave job"
 
@@ -4457,19 +4519,19 @@ msgstr "Unsave job"
 
 #. Email save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:393
+#: src/components/settings/AccountSettings.tsx:399
 msgid "settings.account.email.save"
 msgstr "Update email"
 
 #. Change email section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:373
+#: src/components/settings/AccountSettings.tsx:379
 msgid "settings.account.email.description"
 msgstr "Update the email address associated with your account."
 
 #. Username save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:321
+#: src/components/settings/AccountSettings.tsx:327
 msgid "settings.account.username.save"
 msgstr "Update username"
 
@@ -4497,8 +4559,9 @@ msgstr "Upgrade to Pro"
 msgid "settings.billing.upgrading"
 msgstr "Upgrading…"
 
+#. FAQ answer explaining how to request a missing company from the Explore page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:61
+#: app/[lang]/(public)/faq/page.tsx:66
 msgid "faq.a.requestCompany"
 msgstr "Use the request form on the explore page — paste a careers page URL or company name and we'll start indexing it. You can track progress via the issue number we return."
 
@@ -4510,25 +4573,25 @@ msgstr "user"
 
 #. Username section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:298
+#: src/components/settings/AccountSettings.tsx:304
 msgid "settings.account.username.title"
 msgstr "Username"
 
 #. Username input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:310
+#: src/components/settings/AccountSettings.tsx:316
 msgid "settings.account.username.label"
 msgstr "Username"
 
 #. Username updated success message
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:273
+#: src/components/settings/AccountSettings.tsx:279
 msgid "settings.account.username.success"
 msgstr "Username updated."
 
 #. Success message after email change request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:362
+#: src/components/settings/AccountSettings.tsx:368
 msgid "settings.account.email.success"
 msgstr "Verification email sent. Please check your inbox. It may take a few minutes to arrive."
 
@@ -4616,8 +4679,9 @@ msgstr "Watchlists"
 msgid "home.features.s1.p3.title"
 msgstr "Watchlists and alerts"
 
+#. WebApplication JSON-LD feature list item about watchlists and application tracking.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:145
+#: app/[lang]/layout.tsx:167
 msgid "app.schema.feature.watchlists"
 msgstr "Watchlists and application tracking"
 
@@ -4645,8 +4709,9 @@ msgstr "We collect only what we need, we don’t sell your data, and you can del
 msgid "privacy.short.r2"
 msgstr "We don’t sell, rent, or share your data for marketing."
 
+#. FAQ answer explaining direct career-page indexing and no recruiter spam.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:57
+#: app/[lang]/(public)/faq/page.tsx:62
 msgid "faq.a.differentiation"
 msgstr "We index company career pages directly, not third-party feeds. No recruiter spam, no reposted ghost jobs, and we re-check companies frequently — so most roles show up here within hours of being published. We're built for users who already know which companies they want to work at, not broad 'find me any job' searches."
 
@@ -4686,8 +4751,9 @@ msgstr "We noticed this job was recently added. Some details may still be proces
 msgid "indexing.automation.body"
 msgstr "We oppose handing hiring or job-search decisions over to black-box automation — whether on the employer or applicant side. Every outbound link we share includes <0>utm_source=jobseek</0> so recruiters recognise the traffic, and we continuously review usage patterns plus enforce friction to deter scripted applications."
 
+#. FAQ answer summarizing crawler politeness, rate limits, and policy compliance.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:77
+#: app/[lang]/(public)/faq/page.tsx:82
 msgid "faq.a.crawlingPolicy"
 msgstr "We respect robots.txt and TDM-Reservation headers, limit requests to one per site per minute, and use exponential backoff. All requests identify themselves via User-Agent. See our Job Indexing page for full details."
 
@@ -4717,7 +4783,7 @@ msgstr "We use a handful of third-party services for sign-in, hosting, and stora
 
 #. Secondary line under the Request <query> dropdown row
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:941
+#: src/components/search/search-bar.tsx:937
 msgid "search.bar.request.subtext"
 msgstr "We'll start tracking it"
 
@@ -4739,23 +4805,27 @@ msgstr "Wed"
 msgid "auth.signIn.subtitle"
 msgstr "Welcome back"
 
+#. FAQ question defining a watchlist.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:68
+#: app/[lang]/(public)/faq/page.tsx:73
 msgid "faq.q.whatIsWatchlist"
 msgstr "What is a watchlist?"
 
+#. FAQ question asking for a short product definition.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:44
+#: app/[lang]/(public)/faq/page.tsx:49
 msgid "faq.q.whatIsJobseek"
 msgstr "What is Job Seek?"
 
+#. FAQ question comparing Job Seek with general job boards.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:56
+#: app/[lang]/(public)/faq/page.tsx:61
 msgid "faq.q.differentiation"
 msgstr "What makes Job Seek different from LinkedIn or Indeed?"
 
+#. FAQ question comparing the Free and Pro plans.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:64
+#: app/[lang]/(public)/faq/page.tsx:69
 msgid "faq.q.freeVsPro"
 msgstr "What's the difference between Free and Pro?"
 
@@ -4765,8 +4835,9 @@ msgstr "What's the difference between Free and Pro?"
 msgid "app.home.request.heading"
 msgstr "Which company should we track?"
 
+#. FAQ question about supported interface and job-posting languages.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:92
+#: app/[lang]/(public)/faq/page.tsx:97
 msgid "faq.q.languages"
 msgstr "Which languages does Jobseek support?"
 
@@ -4784,7 +4855,7 @@ msgstr "Work mode"
 
 #. Section header for work-mode (onsite/hybrid/remote) suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:800
+#: src/components/search/search-bar.tsx:796
 msgid "search.bar.workMode"
 msgstr "Work mode"
 
@@ -4822,24 +4893,27 @@ msgstr "Yearly"
 msgid "search.experienceModal.years"
 msgstr "years"
 
+#. FAQ answer explaining the company watchlist use case.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:49
+#: app/[lang]/(public)/faq/page.tsx:54
 msgid "faq.a.targetedSeeker"
 msgstr "Yes — that's the use case we built around. Add the companies you care about to a watchlist, set your filters (role, location, seniority, salary), and Job Seek monitors their career pages and alerts you the moment new roles match. You don't have to keep checking each company's site by hand or fight LinkedIn's algorithm."
 
+#. FAQ answer explaining how companies can opt out of indexing.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:81
+#: app/[lang]/(public)/faq/page.tsx:86
 msgid "faq.a.optOut"
 msgstr "Yes. Email us and we'll stop crawling your careers site immediately and remove your postings from the index."
 
+#. FAQ answer explaining crawler source availability and data licensing.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:85
+#: app/[lang]/(public)/faq/page.tsx:90
 msgid "faq.a.openSource"
 msgstr "Yes. The crawler and extraction pipeline are fully open source on GitHub. The application code is MIT licensed; job data is CC BY-NC 4.0."
 
 #. Date divider label for yesterday
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:72
+#: src/components/watchlist/watchlist-job-list.tsx:76
 msgid "watchlists.jobList.yesterday"
 msgstr "Yesterday"
 
@@ -4931,7 +5005,7 @@ msgstr "You've reached your watchlist limit. Upgrade your plan to mirror more wa
 
 #. Reason shown in upgrade modal when saving a search hits the watchlist limit
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:93
+#: src/components/search/save-search-button.tsx:96
 msgid "upgrade.reason.saveSearch"
 msgstr "You've reached your watchlist limit. Upgrade your plan to save more searches as watchlists."
 
@@ -4961,6 +5035,6 @@ msgstr "Your rights"
 
 #. Username section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:301
+#: src/components/settings/AccountSettings.tsx:307
 msgid "settings.account.username.description"
 msgstr "Your unique handle used in your public profile URL."

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -57,8 +57,9 @@ msgstr "(ouvre dans un nouvel onglet)"
 msgid "search.detail.showMoreLocations"
 msgstr "{0} de plus"
 
+#. SEO metadata count text for a company page; {count} is the active job count.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:41
+#: app/[lang]/(app)/company/[slug]/page.tsx:42
 msgid "company.meta.positionCount"
 msgstr "{count, plural, one {# poste ouvert} other {# postes ouverts}}"
 
@@ -86,8 +87,9 @@ msgstr "{count, plural, one {offre active} other {offres actives}}"
 msgid "blog.mention.watchlist.companiesLabel"
 msgstr "{count, plural, one {entreprise} other {entreprises}}"
 
+#. SEO description prefix for a public watchlist; {description} is the existing watchlist summary.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:104
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:108
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {# entreprise suivie} other {# entreprises suivies}}. {description}"
 
@@ -97,18 +99,21 @@ msgstr "{count, plural, one {# entreprise suivie} other {# entreprises suivies}}
 msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} candidatures le {date}"
 
+#. SEO metadata suffix when a watchlist includes more companies than can be listed by name.
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:62
 msgid "watchlist.meta.moreCompanies"
 msgstr "{count} de plus"
 
+#. SEO description for a company page when no company summary is available.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:53
+#: app/[lang]/(app)/company/[slug]/page.tsx:60
 msgid "company.meta.descriptionBasic"
 msgstr "{countText} chez {name}"
 
+#. SEO description for a company page; includes job count, company name, and company summary.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:48
+#: app/[lang]/(app)/company/[slug]/page.tsx:54
 msgid "company.meta.descriptionWithInfo"
 msgstr "{countText} chez {name}. {description}"
 
@@ -178,14 +183,17 @@ msgstr "1. Installer MCP"
 msgid "app.home.request.agent.run_heading"
 msgstr "2. Exécuter le prompt"
 
+#. FAQ answer explaining saved-search watchlists and sharing options.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:69
+#: app/[lang]/(public)/faq/page.tsx:74
 msgid "faq.a.whatIsWatchlist"
 msgstr "Une liste de suivi est une recherche enregistrée avec filtrage optionnel par entreprise. Choisissez les entreprises qui vous intéressent, définissez vos filtres (poste, lieu, séniorité, salaire) et obtenez un flux en direct des offres correspondantes. Vous pouvez partager vos listes publiquement ou les garder privées."
 
+#. JSON-LD page name for the public About page.
+#. SEO title for the public About page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/page.tsx:17
-#: app/[lang]/(public)/about/page.tsx:46
+#: app/[lang]/(public)/about/page.tsx:51
 msgid "about.meta.title"
 msgstr "À propos"
 
@@ -224,8 +232,8 @@ msgstr "Menu du compte"
 #. Active postings count on company page
 #. Active postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:561
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:571
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:572
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:582
 msgid "company.page.active"
 msgstr "actif"
 
@@ -239,7 +247,7 @@ msgstr "actifs"
 
 #. Active matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:121
+#: src/components/search/company-card.tsx:122
 msgid "search.card.active"
 msgstr "actif"
 
@@ -287,7 +295,7 @@ msgstr "Ajouter un filtre de lieu ou mot-clé…"
 
 #. Placeholder in the add location input
 #. js-lingui-explicit-id
-#: src/components/search/location-pills.tsx:174
+#: src/components/search/location-pills.tsx:170
 msgid "search.locations.addPlaceholder"
 msgstr "Ajouter un lieu..."
 
@@ -305,7 +313,7 @@ msgstr "Prompt de l'agent"
 
 #. Footer shown after all paged countries have been loaded into the location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:816
+#: src/components/search/location-search-modal.tsx:825
 msgid "search.locationModal.allLoaded"
 msgstr "Tous les {totalCountries} pays chargés"
 
@@ -333,16 +341,16 @@ msgstr "Toutes les langues"
 msgid "settings.general.jobLanguages.all"
 msgstr "Toutes les langues"
 
-#. Button to open all-locations modal on company page
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:346
-msgid "company.page.allLocations"
-msgstr "Tous les lieux"
-
 #. Title for the all-locations modal on company page
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:268
 msgid "company.locationModal.title"
+msgstr "Tous les lieux"
+
+#. Button to open all-locations modal on company page
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:346
+msgid "company.page.allLocations"
 msgstr "Tous les lieux"
 
 #. Link to sign-in page from sign-up
@@ -353,12 +361,13 @@ msgstr "Déjà un compte ? <0>Se connecter</0>"
 
 #. Username is taken
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:292
+#: src/components/settings/AccountSettings.tsx:298
 msgid "settings.account.username.taken"
 msgstr "Déjà pris"
 
+#. SEO description for the public FAQ page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:18
+#: app/[lang]/(public)/faq/page.tsx:22
 msgid "faq.meta.description"
 msgstr "Réponses aux questions fréquentes sur Job Seek — comment nous scrapons les pages carrières, ce que contiennent les forfaits, la gestion de vos données et comment se désinscrire."
 
@@ -434,6 +443,12 @@ msgstr "Postulé"
 msgid "search.tracker.applied"
 msgstr "Postulé"
 
+#. Applied status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:20
+msgid "myJobs.status.applied"
+msgstr "Postulé"
+
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
@@ -444,12 +459,6 @@ msgstr "Postulé"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.applied"
-msgstr "Postulé"
-
-#. Applied status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:20
-msgid "myJobs.status.applied"
 msgstr "Postulé"
 
 #. Apply salary filter
@@ -484,13 +493,13 @@ msgstr "En dernier recours, nous analysons directement les pages carrières, en 
 
 #. Username too short hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:280
+#: src/components/settings/AccountSettings.tsx:286
 msgid "settings.account.username.tooShort"
 msgstr "3 caractères minimum"
 
 #. Username too long hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:282
+#: src/components/settings/AccountSettings.tsx:288
 msgid "settings.account.username.tooLong"
 msgstr "30 caractères maximum"
 
@@ -502,7 +511,7 @@ msgstr "Aoû"
 
 #. Username is available
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:290
+#: src/components/settings/AccountSettings.tsx:296
 msgid "settings.account.username.available"
 msgstr "Disponible"
 
@@ -562,18 +571,18 @@ msgstr "Blog"
 msgid "blog.post.backToIndex"
 msgstr "Blog"
 
+#. Footer link to /blog index page
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:52
+msgid "common.footer.blog"
+msgstr "Blog"
+
 #. Nav link: Blog
 #. Nav link: Blog
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:74
 #: src/components/MobileMenu.tsx:98
 msgid "common.nav.blog"
-msgstr "Blog"
-
-#. Footer link to /blog index page
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
-msgid "common.footer.blog"
 msgstr "Blog"
 
 #. Subtitle on the sign-in CTA card shown to anonymous users at the end of the similar-companies strip
@@ -588,9 +597,11 @@ msgstr "Parcourir toutes les entreprises similaires"
 msgid "indexing.oss.browseRepo"
 msgstr "Parcourir le dépôt sur"
 
+#. JSON-LD page description for the public homepage.
+#. SEO description for the public homepage.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:21
-#: app/[lang]/(public)/page.tsx:53
+#: app/[lang]/(public)/page.tsx:25
+#: app/[lang]/(public)/page.tsx:62
 msgid "home.meta.description"
 msgstr "Crée des watchlists des entreprises qui t'intéressent, reçois des alertes par e-mail dès qu'un nouveau poste s'ouvre, et suis tes candidatures en un seul endroit. Les offres viennent directement des pages carrières des entreprises, dans les heures suivant leur publication — pas de spam de recruteurs, pas d'annonces republiées."
 
@@ -612,8 +623,9 @@ msgstr "Créé par des chercheurs d'emploi, pour des chercheurs d'emploi"
 msgid "terms.hero.description"
 msgstr "En utilisant Job Seek, tu acceptes ces conditions. Voici un résumé en langage clair."
 
+#. FAQ question about company opt-out from indexing.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:80
+#: app/[lang]/(public)/faq/page.tsx:85
 msgid "faq.q.optOut"
 msgstr "Puis-je refuser l'indexation de mon entreprise par Jobseek ?"
 
@@ -633,7 +645,7 @@ msgstr "Annuler"
 
 #. Cancel delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:532
+#: src/components/settings/AccountSettings.tsx:538
 msgid "settings.account.delete.cancel"
 msgstr "Annuler"
 
@@ -645,7 +657,7 @@ msgstr "modifier"
 
 #. Change email section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:370
+#: src/components/settings/AccountSettings.tsx:376
 msgid "settings.account.email.title"
 msgstr "Changer l'e-mail"
 
@@ -673,21 +685,21 @@ msgstr "Modifie ton mot de passe via un lien e-mail sécurisé."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Changer…"
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "Vérifie ton e-mail"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
 msgstr "Vérifiez votre e-mail"
 
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
+msgstr "Vérifie ton e-mail"
+
 #. Checking username availability
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:288
+#: src/components/settings/AccountSettings.tsx:294
 msgid "settings.account.username.checking"
 msgstr "Vérification de la disponibilité..."
 
@@ -725,7 +737,7 @@ msgstr "Choisissez les langues dans lesquelles vous souhaitez voir les offres d'
 #. Location type label for cities
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:35
-#: src/components/search/location-pills.tsx:31
+#: src/components/search/location-pills.tsx:32
 msgid "location.type.city"
 msgstr "Ville"
 
@@ -745,7 +757,7 @@ msgstr "Tout effacer"
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:645
-#: src/components/search/search-toolbar.tsx:367
+#: src/components/search/search-toolbar.tsx:368
 msgid "search.filters.clearAll"
 msgstr "Tout effacer"
 
@@ -773,12 +785,6 @@ msgstr "Cliquer pour renommer"
 msgid "indexing.ingestion.s2.title"
 msgstr "API clientes en second."
 
-#. Aria label for close button on add-companies modal
-#. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:201
-msgid "watchlists.companyModal.close"
-msgstr "Fermer"
-
 #. Aria label for upgrade modal close button
 #. js-lingui-explicit-id
 #: src/components/ui/upgrade-modal.tsx:59
@@ -791,16 +797,16 @@ msgstr "Fermer"
 msgid "settings.jobLanguages.modal.close"
 msgstr "Fermer"
 
+#. Aria label for close button on add-companies modal
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-search-modal.tsx:201
+msgid "watchlists.companyModal.close"
+msgstr "Fermer"
+
 #. Aria label for the technology modal close button
 #. js-lingui-explicit-id
 #: src/components/search/technology-modal.tsx:117
 msgid "search.technologyModal.close"
-msgstr "Fermer"
-
-#. Aria label for the seniority modal close button
-#. js-lingui-explicit-id
-#: src/components/search/seniority-modal.tsx:65
-msgid "search.seniorityModal.close"
 msgstr "Fermer"
 
 #. Aria label for the work-mode modal close button
@@ -809,10 +815,22 @@ msgstr "Fermer"
 msgid "search.workModeModal.close"
 msgstr "Fermer"
 
+#. Aria label for the seniority modal close button
+#. js-lingui-explicit-id
+#: src/components/search/seniority-modal.tsx:65
+msgid "search.seniorityModal.close"
+msgstr "Fermer"
+
 #. Aria label for the salary modal close button
 #. js-lingui-explicit-id
 #: src/components/search/salary-modal.tsx:254
 msgid "search.salaryModal.close"
+msgstr "Fermer"
+
+#. Aria label for close button on the company-page all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:275
+msgid "company.locationModal.close"
 msgstr "Fermer"
 
 #. Aria label for the occupation modal close button
@@ -823,7 +841,7 @@ msgstr "Fermer"
 
 #. Aria label for the location modal close button
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:479
+#: src/components/search/location-search-modal.tsx:488
 msgid "search.locationModal.close"
 msgstr "Fermer"
 
@@ -837,12 +855,6 @@ msgstr "Fermer"
 #. js-lingui-explicit-id
 #: src/components/search/employment-type-modal.tsx:82
 msgid "search.employmentTypeModal.close"
-msgstr "Fermer"
-
-#. Aria label for close button on the company-page all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:275
-msgid "company.locationModal.close"
 msgstr "Fermer"
 
 #. Aria label for job detail panel close button
@@ -865,13 +877,13 @@ msgstr "Fermer le menu"
 
 #. Label for inactive/closed job postings on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:663
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:676
 msgid "company.page.closed"
 msgstr "Fermé"
 
 #. Label for inactive/closed job postings on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:159
+#: src/components/search/company-card.tsx:171
 msgid "search.card.closed"
 msgstr "Fermé"
 
@@ -907,7 +919,7 @@ msgstr "Bientôt disponible"
 
 #. Section header for company suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:882
+#: src/components/search/search-bar.tsx:878
 msgid "search.bar.companies"
 msgstr "Entreprises"
 
@@ -945,15 +957,17 @@ msgstr "Entreprise"
 #. Heading shown when the company URL slug doesn't resolve to a known company
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/company/[slug]/company-content.tsx:51
-#: app/[lang]/(app)/company/[slug]/page.tsx:89
+#: app/[lang]/(app)/company/[slug]/page.tsx:97
 msgid "company.notFound.title"
 msgstr "Entreprise introuvable"
 
+#. WebApplication JSON-LD description for Job Seek.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:120
+#: app/[lang]/layout.tsx:121
 msgid "app.schema.description"
 msgstr "Outil de suivi d'entreprises pour les candidats qui savent déjà dans quelles entreprises ils veulent travailler. Crée des watchlists, reçois des alertes par e-mail dès qu'un nouveau poste s'ouvre, et suis tes candidatures en un seul endroit — les offres viennent directement des pages carrières des entreprises."
 
+#. Organization JSON-LD description for Job Seek and Colophon Group.
 #. js-lingui-explicit-id
 #: app/[lang]/layout.tsx:85
 msgid "app.schema.org.description"
@@ -961,7 +975,7 @@ msgstr "Outil de suivi d'entreprises pour les candidats ciblés — watchlists, 
 
 #. Confirm delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:525
+#: src/components/settings/AccountSettings.tsx:531
 msgid "settings.account.delete.confirm"
 msgstr "Confirmer la suppression"
 
@@ -973,15 +987,21 @@ msgstr "Confirmer le mot de passe"
 
 #. Connect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:475
+#: src/components/settings/AccountSettings.tsx:481
 msgid "settings.account.socials.connect"
 msgstr "Connecter"
 
 #. Connected accounts section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:450
+#: src/components/settings/AccountSettings.tsx:456
 msgid "settings.account.socials.title"
 msgstr "Comptes connectés"
+
+#. Footer link to contact email
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Contact"
 
 #. TOC: Contact
 #. js-lingui-explicit-id
@@ -995,22 +1015,16 @@ msgstr "Contact"
 msgid "license.contact.title"
 msgstr "Contact"
 
-#. Footer link to contact email
+#. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Contact"
+#: src/components/HowWeIndexContent.tsx:21
+msgid "indexing.toc.title"
+msgstr "Sommaire"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:17
 msgid "license.toc.title"
-msgstr "Sommaire"
-
-#. Table of contents heading
-#. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:21
-msgid "indexing.toc.title"
 msgstr "Sommaire"
 
 #. Button to continue to app after verification
@@ -1083,7 +1097,7 @@ msgstr "Copier le prompt"
 #. Location type label for countries
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:33
-#: src/components/search/location-pills.tsx:29
+#: src/components/search/location-pills.tsx:30
 msgid "location.type.country"
 msgstr "Pays"
 
@@ -1119,7 +1133,7 @@ msgstr "Créez un compte gratuit pour parcourir tous les résultats, enregistrer
 
 #. Tooltip explaining save search creates a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:117
+#: src/components/search/save-search-button.tsx:120
 msgid "search.saveSearch.tooltip"
 msgstr "Créer une liste de suivi à partir de vos filtres actuels"
 
@@ -1227,13 +1241,13 @@ msgstr "Supprimer"
 
 #. Delete account section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:508
+#: src/components/settings/AccountSettings.tsx:514
 msgid "settings.account.delete.title"
 msgstr "Supprimer le compte"
 
 #. Delete account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:518
+#: src/components/settings/AccountSettings.tsx:524
 msgid "settings.account.delete.button"
 msgstr "Supprimer mon compte"
 
@@ -1245,7 +1259,7 @@ msgstr "Supprimer la liste de suivi ?"
 
 #. Delete button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:524
+#: src/components/settings/AccountSettings.tsx:530
 msgid "settings.account.delete.deleting"
 msgstr "Suppression…"
 
@@ -1287,7 +1301,7 @@ msgstr "Désactiver les alertes"
 
 #. Disconnect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:474
+#: src/components/settings/AccountSettings.tsx:480
 msgid "settings.account.socials.disconnect"
 msgstr "Déconnecter"
 
@@ -1297,8 +1311,9 @@ msgstr "Déconnecter"
 msgid "watchlists.explore.publicTitle"
 msgstr "Découvrir des listes publiques"
 
+#. FAQ question about whether user data is sold.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:88
+#: app/[lang]/(public)/faq/page.tsx:93
 msgid "faq.q.dataPrivacy"
 msgstr "Jobseek vend-il mes données ?"
 
@@ -1455,40 +1470,41 @@ msgstr "Explorer"
 msgid "app.header.nav.explore"
 msgstr "Explorer"
 
+#. SEO title for the Explore jobs page.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:32
+#: app/[lang]/(app)/explore/page.tsx:39
 msgid "explore.meta.title"
 msgstr "Explorer les emplois"
 
 #. Hidden page H1 for /explore — screen-reader landmark
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/search-page.tsx:754
+#: app/[lang]/(app)/explore/search-page.tsx:811
 msgid "explore.h1"
 msgstr "Explorer les emplois"
 
 #. Generic email change error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:360
+#: src/components/settings/AccountSettings.tsx:366
 msgid "settings.account.email.error"
 msgstr "Échec du changement d'e-mail"
 
 #. Error when linking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:426
+#: src/components/settings/AccountSettings.tsx:432
 msgid "settings.account.socials.connectError"
 msgstr "Échec de la connexion du compte"
 
 #. Generic account deletion error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:499
+#: src/components/settings/AccountSettings.tsx:505
 msgid "settings.account.delete.error"
 msgstr "Échec de la suppression du compte"
 
 #. Error when unlinking social account fails
 #. Error when unlinking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:437
-#: src/components/settings/AccountSettings.tsx:442
+#: src/components/settings/AccountSettings.tsx:443
+#: src/components/settings/AccountSettings.tsx:448
 msgid "settings.account.socials.disconnectError"
 msgstr "Échec de la déconnexion du compte"
 
@@ -1518,10 +1534,11 @@ msgstr "Échec de la définition du mot de passe"
 
 #. Generic username update error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:261
+#: src/components/settings/AccountSettings.tsx:267
 msgid "settings.account.username.error"
 msgstr "Échec de la mise à jour du nom d'utilisateur"
 
+#. SEO title for the public FAQ page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/faq/page.tsx:17
 msgid "faq.meta.title"
@@ -1667,8 +1684,9 @@ msgstr "Gratuit"
 msgid "settings.billing.plan.free"
 msgstr "Gratuit"
 
+#. FAQ answer summarizing Free and Pro plan differences.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:65
+#: app/[lang]/(public)/faq/page.tsx:70
 msgid "faq.a.freeVsPro"
 msgstr "La version gratuite vous offre une recherche complète sur toutes les entreprises, une liste de suivi et le suivi des candidatures avec journal des entretiens. Pro ajoute des listes de suivi illimitées et des alertes email lorsque de nouvelles offres correspondent à vos critères."
 
@@ -1696,8 +1714,9 @@ msgstr "Du poste sauvegardé à l'offre signée, tout au même endroit"
 msgid "settings.billing.free.f2"
 msgstr "Recherche d'emploi complète"
 
+#. WebApplication JSON-LD offer description for the Free plan.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:130
+#: app/[lang]/layout.tsx:132
 msgid "app.schema.offer.free"
 msgstr "Recherche complète, 1 liste de suivi, suivi des candidatures"
 
@@ -1807,24 +1826,29 @@ msgstr "Horaire"
 msgid "myJobs.salary.hourly"
 msgstr "Horaire"
 
+#. FAQ question about requesting a missing company.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:60
+#: app/[lang]/(public)/faq/page.tsx:65
 msgid "faq.q.requestCompany"
 msgstr "Comment demander l'ajout d'une entreprise non répertoriée ?"
 
+#. FAQ question for company operators about crawler behavior.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:76
+#: app/[lang]/(public)/faq/page.tsx:81
 msgid "faq.q.crawlingPolicy"
 msgstr "Comment le crawler se comporte-t-il sur le site de mon entreprise ?"
 
+#. JSON-LD page description for the public Job Indexing methodology page.
+#. SEO description for the public Job Indexing methodology page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:18
-#: app/[lang]/(public)/how-we-index/page.tsx:50
+#: app/[lang]/(public)/how-we-index/page.tsx:22
+#: app/[lang]/(public)/how-we-index/page.tsx:59
 msgid "indexing.meta.description"
 msgstr "Comment Job Seek découvre et indexe les offres d'emploi : notre approche de sourcing, fréquence de crawl, limites de débit, conformité robots.txt et TDM-Reservation, et comment se désinscrire."
 
+#. FAQ question about job listing refresh cadence.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:52
+#: app/[lang]/(public)/faq/page.tsx:57
 msgid "faq.q.howOftenUpdated"
 msgstr "À quelle fréquence les offres d'emploi sont-elles mises à jour ?"
 
@@ -1846,9 +1870,11 @@ msgstr "Comment les offres entrent dans l'index"
 msgid "indexing.hero.title"
 msgstr "Comment nous trouvons et traitons les offres d'emploi"
 
+#. JSON-LD page name for the public Job Indexing methodology page.
+#. SEO title for the public Job Indexing methodology page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/how-we-index/page.tsx:17
-#: app/[lang]/(public)/how-we-index/page.tsx:49
+#: app/[lang]/(public)/how-we-index/page.tsx:54
 msgid "indexing.meta.title"
 msgstr "Comment nous indexons"
 
@@ -1858,8 +1884,8 @@ msgstr "Comment nous indexons"
 #. Work mode: hybrid (mixed onsite/remote)
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:597
-#: src/components/search/search-bar.tsx:812
-#: src/components/search/search-toolbar.tsx:271
+#: src/components/search/search-bar.tsx:808
+#: src/components/search/search-toolbar.tsx:272
 #: src/components/search/work-mode-modal.tsx:27
 msgid "search.workMode.hybrid"
 msgstr "Hybride"
@@ -1888,16 +1914,17 @@ msgstr "Si tu constates une activité inattendue de notre robot d'indexation ou 
 msgid "indexing.outreach.body"
 msgstr "Si tu remarques un comportement inhabituel de notre robot, préfères que nous n'indexions pas ton contenu, ou as des suggestions pour améliorer nos mesures de protection, n'hésite pas à nous contacter."
 
+#. SEO metadata phrase listing locations filtered by a public watchlist.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:78
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:80
 msgid "watchlist.meta.inLocations"
 msgstr "à {locations}"
 
 #. Year postings count on company page
 #. Year postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:563
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:575
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:574
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:586
 msgid "company.page.yearCount"
 msgstr "au cours de la dernière année"
 
@@ -1911,7 +1938,7 @@ msgstr "sur la dernière année"
 
 #. Yearly matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:123
+#: src/components/search/company-card.tsx:124
 msgid "search.card.yearCount"
 msgstr "au cours de la dernière année"
 
@@ -1999,16 +2026,16 @@ msgstr "En entretien"
 msgid "search.tracker.interviewing"
 msgstr "En entretien"
 
-#. Status option in dropdown: interviewing
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:37
-msgid "myJobs.statusOption.interviewing"
-msgstr "En entretien"
-
 #. Interviewing status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:21
 msgid "myJobs.status.interviewing"
+msgstr "En entretien"
+
+#. Status option in dropdown: interviewing
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:37
+msgid "myJobs.statusOption.interviewing"
 msgstr "En entretien"
 
 #. Interviews section heading
@@ -2029,18 +2056,21 @@ msgstr "Lien invalide"
 msgid "auth.verify.error.invalidLink"
 msgstr "Lien de vérification invalide"
 
+#. FAQ question about whether the product suits company-targeted job seekers.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:48
+#: app/[lang]/(public)/faq/page.tsx:53
 msgid "faq.q.targetedSeeker"
 msgstr "Job Seek est-il fait pour moi si je sais déjà dans quelles entreprises je veux travailler ?"
 
+#. FAQ question about open-source availability.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:84
+#: app/[lang]/(public)/faq/page.tsx:89
 msgid "faq.q.openSource"
 msgstr "Le crawler est-il open source ?"
 
+#. FAQ question about application tracker limits.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:72
+#: app/[lang]/(public)/faq/page.tsx:77
 msgid "faq.q.trackerLimit"
 msgstr "Y a-t-il une limite au nombre d'offres que je peux suivre ?"
 
@@ -2050,16 +2080,16 @@ msgstr "Y a-t-il une limite au nombre d'offres que je peux suivre ?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Jan"
 
-#. Singular job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:121
-msgid "watchlists.explore.jobSingular"
-msgstr "offre"
-
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31
 msgid "watchlists.card.jobSingular"
+msgstr "offre"
+
+#. Singular job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:121
+msgid "watchlists.explore.jobSingular"
 msgstr "offre"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -2104,14 +2134,17 @@ msgstr "Offres d'emploi"
 msgid "home.features.s2.screenshot.alt"
 msgstr "Suivi de candidatures Job Seek montrant les postes sauvegardés et les détails d'entretien"
 
+#. FAQ answer explaining what Job Seek does for targeted job seekers.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:45
+#: app/[lang]/(public)/faq/page.tsx:50
 msgid "faq.a.whatIsJobseek"
 msgstr "Job Seek t'aide à suivre les entreprises pour lesquelles tu veux vraiment travailler. Crée une watchlist, reçois des alertes par e-mail dès qu'un nouveau poste s'ouvre, et suis tes candidatures en un seul endroit. Les offres viennent directement des pages carrières des entreprises, donc tu les vois dans les heures suivant leur publication — généralement avant que LinkedIn ou Indeed ne les relaient."
 
+#. JSON-LD page description for the public About page.
+#. SEO description for the public About page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/about/page.tsx:18
-#: app/[lang]/(public)/about/page.tsx:47
+#: app/[lang]/(public)/about/page.tsx:22
+#: app/[lang]/(public)/about/page.tsx:56
 msgid "about.meta.description"
 msgstr "Job Seek t'aide à suivre les entreprises pour lesquelles tu veux travailler — watchlists, alertes par e-mail et offres directement issues des pages carrières. Créé par Colophon Group, un petit studio de développeurs en Suisse."
 
@@ -2133,9 +2166,11 @@ msgstr "Job Seek est en cours de développement. Restez à l'écoute pour les mi
 msgid "about.p1"
 msgstr "Job Seek est développé par Colophon Group, une petite équipe de développeurs basée en Suisse. Nous l'avons créé parce que nous en avions assez du même problème que rencontre chaque chercheur d'emploi : jongler entre des dizaines d'onglets, rater des offres parce qu'un agrégateur était trop lent, et se noyer dans du bruit algorithmique optimisé pour les clics plutôt que pour la pertinence."
 
+#. JSON-LD page description for the public Privacy Policy page.
+#. SEO description for the public Privacy Policy page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:18
-#: app/[lang]/(public)/privacy-policy/page.tsx:51
+#: app/[lang]/(public)/privacy-policy/page.tsx:22
+#: app/[lang]/(public)/privacy-policy/page.tsx:60
 msgid "privacy.meta.description"
 msgstr "Politique de confidentialité de Job Seek — données collectées, utilisation, droits RGPD, politique de cookies et suppression de compte et de données."
 
@@ -2157,16 +2192,11 @@ msgstr "Liste de suivi Job Seek montrant des postes sélectionnés en ingénieri
 msgid "license.hero.description"
 msgstr "Le code source de Job Seek est ouvert sous licence MIT. Les données d'emploi que nous collectons et enrichissons sont sous Creative Commons BY-NC 4.0. Tu trouveras ci-dessous un résumé en langage clair — consulte les licences complètes pour les termes exacts."
 
+#. Fallback SEO description for a public watchlist with no description or filters.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:86
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:89
 msgid "watchlist.meta.fallback"
 msgstr "Liste d'emplois de @{owner}"
-
-#. Plural job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:122
-msgid "watchlists.explore.jobPlural"
-msgstr "offres"
 
 #. Plural job count on watchlist card
 #. js-lingui-explicit-id
@@ -2174,13 +2204,21 @@ msgstr "offres"
 msgid "watchlists.card.jobPlural"
 msgstr "offres"
 
+#. Plural job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:122
+msgid "watchlists.explore.jobPlural"
+msgstr "offres"
+
+#. SEO title for a company detail page; {name} is the company name.
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/company/[slug]/page.tsx:34
 msgid "company.meta.title"
 msgstr "Emplois chez {name}"
 
+#. SEO metadata phrase listing companies tracked by a public watchlist.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:68
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:69
 msgid "watchlist.meta.jobsAt"
 msgstr "Emplois chez {names}"
 
@@ -2228,14 +2266,14 @@ msgstr "Dernière heure"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:27
-msgid "terms.hero.lastUpdated"
+#: src/components/PrivacyPolicyContent.tsx:27
+msgid "privacy.hero.lastUpdated"
 msgstr "Dernière mise à jour :"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:27
-msgid "privacy.hero.lastUpdated"
+#: src/components/TermsContent.tsx:27
+msgid "terms.hero.lastUpdated"
 msgstr "Dernière mise à jour :"
 
 #. Time range option: last week
@@ -2252,7 +2290,7 @@ msgstr "En savoir plus"
 
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:730
+#: src/components/search/search-bar.tsx:726
 msgid "search.bar.level"
 msgstr "Niveau"
 
@@ -2262,16 +2300,18 @@ msgstr "Niveau"
 msgid "search.advanced.level"
 msgstr "Niveau"
 
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:17
-#: app/[lang]/(public)/license/page.tsx:51
-msgid "license.meta.title"
-msgstr "Licence"
-
 #. Link to license page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:70
 msgid "about.link.license"
+msgstr "Licence"
+
+#. JSON-LD page name for the public License page.
+#. SEO title for the public License page.
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/license/page.tsx:17
+#: app/[lang]/(public)/license/page.tsx:56
+msgid "license.meta.title"
 msgstr "Licence"
 
 #. Footer link to license page
@@ -2292,9 +2332,11 @@ msgstr "Licence de Job Seek"
 msgid "license.hero.eyebrow"
 msgstr "Licences"
 
+#. JSON-LD page description for the public License page.
+#. SEO description for the public License page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:18
-#: app/[lang]/(public)/license/page.tsx:52
+#: app/[lang]/(public)/license/page.tsx:22
+#: app/[lang]/(public)/license/page.tsx:61
 msgid "license.meta.description"
 msgstr "Licences de Job Seek — le code source est sous licence MIT, les offres d'emploi sous CC BY-NC 4.0. Découvrez ce que vous pouvez faire avec notre code et nos données."
 
@@ -2356,7 +2398,7 @@ msgstr "Lieu"
 
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:842
+#: src/components/search/search-bar.tsx:838
 msgid "search.bar.locations"
 msgstr "Lieux"
 
@@ -2382,7 +2424,7 @@ msgstr "Se connecter"
 
 #. Tooltip when user needs to log in to save search
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:122
+#: src/components/search/save-search-button.tsx:125
 msgid "search.saveSearch.tooltipLogin"
 msgstr "Connectez-vous pour enregistrer cette recherche comme liste de suivi"
 
@@ -2412,7 +2454,7 @@ msgstr "Gérer l'abonnement"
 
 #. Connected accounts section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:453
+#: src/components/settings/AccountSettings.tsx:459
 msgid "settings.account.socials.description"
 msgstr "Gère tes comptes sociaux liés."
 
@@ -2442,7 +2484,7 @@ msgstr "Marquer comme refusé"
 
 #. Header for the server-side search-results cluster shown when the user types in the location modal search box
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:585
+#: src/components/search/location-search-modal.tsx:594
 msgid "search.locationModal.searchHitsHeader"
 msgstr "Correspondances"
 
@@ -2508,8 +2550,9 @@ msgstr "Une entreprise manque ? Colle l'URL de sa page carrières et nous commen
 msgid "myJobs.heatmap.day.mon"
 msgstr "Lun"
 
+#. WebApplication JSON-LD feature list item about career-page monitoring.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:142
+#: app/[lang]/layout.tsx:152
 msgid "app.schema.feature.monitor"
 msgstr "Surveiller les pages carrières des entreprises"
 
@@ -2549,8 +2592,9 @@ msgstr "Fais passer chaque poste de sauvegardé à candidaté, en entretien, off
 msgid "home.features.s1.p2.title"
 msgstr "Filtres multi-dimensionnels"
 
+#. WebApplication JSON-LD feature list item about supported interface languages.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:144
+#: app/[lang]/layout.tsx:162
 msgid "app.schema.feature.languages"
 msgstr "Support multilingue"
 
@@ -2560,22 +2604,22 @@ msgstr "Support multilingue"
 #. Warning when Enter is pressed but multiple items match
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:247
-#: src/components/search/location-search-modal.tsx:430
+#: src/components/search/location-search-modal.tsx:439
 #: src/components/search/occupation-modal.tsx:180
 #: src/components/search/technology-modal.tsx:88
 msgid "search.bestGuess.ambiguous"
 msgstr "Plusieurs résultats — sélectionnez-en un ci-dessous"
 
-#. Back link to my jobs
-#. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:40
-msgid "myJobs.stats.back"
-msgstr "Mes emplois"
-
 #. Title of the My Jobs page
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:252
 msgid "myJobs.title"
+msgstr "Mes emplois"
+
+#. Back link to my jobs
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:40
+msgid "myJobs.stats.back"
 msgstr "Mes emplois"
 
 #. My Jobs nav icon tooltip
@@ -2604,7 +2648,7 @@ msgstr "Besoin de nous contacter ?"
 
 #. New email input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:382
+#: src/components/settings/AccountSettings.tsx:388
 msgid "settings.account.email.label"
 msgstr "Nouvel e-mail"
 
@@ -2646,7 +2690,7 @@ msgstr "Aucun secteur trouvé."
 
 #. Empty state when no jobs match the time range
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:230
+#: src/components/watchlist/watchlist-job-list.tsx:282
 msgid "watchlists.jobList.empty"
 msgstr "Aucune offre trouvée."
 
@@ -2656,21 +2700,21 @@ msgstr "Aucune offre trouvée."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Aucune langue ne correspond à votre recherche."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:516
-msgid "search.locationModal.noResults"
-msgstr "Aucun lieu ne correspond à votre recherche."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:312
 msgid "company.locationModal.noResults"
 msgstr "Aucun lieu ne correspond à votre recherche."
 
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:525
+msgid "search.locationModal.noResults"
+msgstr "Aucun lieu ne correspond à votre recherche."
+
 #. No postings found message on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:644
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:657
 msgid "company.page.noResults"
 msgstr "Aucune offre correspondante trouvée."
 
@@ -2691,18 +2735,6 @@ msgstr "Sans réponse"
 #: src/components/search/zero-results.tsx:14
 msgid "search.zero.heading"
 msgstr "Aucun résultat trouvé pour « {query} »"
-
-#. Heading shown when a search surface returns an impossible empty result set
-#. js-lingui-explicit-id
-#: src/components/search/search-unavailable.tsx:9
-msgid "search.unavailable.heading"
-msgstr "Oups, une erreur s'est produite."
-
-#. Body shown when a search surface returns an impossible empty result set
-#. js-lingui-explicit-id
-#: src/components/search/search-unavailable.tsx:14
-msgid "search.unavailable.body"
-msgstr "Essayez d'actualiser la page."
 
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
@@ -2746,13 +2778,15 @@ msgstr "Aucune liste de suivi trouvée."
 msgid "watchlists.page.empty"
 msgstr "Aucune liste de suivi pour l'instant. Créez-en une pour suivre les offres de vos entreprises préférées."
 
+#. FAQ answer explaining that the application tracker has no hard limit.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:73
+#: app/[lang]/(public)/faq/page.tsx:78
 msgid "faq.a.trackerLimit"
 msgstr "Non. Le suivi des candidatures n'a pas de limite — enregistrez autant d'offres que vous voulez et faites-les avancer dans votre pipeline."
 
+#. FAQ answer explaining data privacy, cookies, and account deletion.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:89
+#: app/[lang]/(public)/faq/page.tsx:94
 msgid "faq.a.dataPrivacy"
 msgstr "Non. Nous ne vendons, ne louons ni ne partageons vos données à des fins marketing. Les cookies sont uniquement de session, sans publicité ni tracking. Vous pouvez supprimer votre compte et toutes les données seront effacées sous 30 jours."
 
@@ -2834,8 +2868,8 @@ msgstr "Ok"
 #. Work mode: onsite (in-office)
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:595
-#: src/components/search/search-bar.tsx:810
-#: src/components/search/search-toolbar.tsx:269
+#: src/components/search/search-bar.tsx:806
+#: src/components/search/search-toolbar.tsx:270
 #: src/components/search/work-mode-modal.tsx:26
 msgid "search.workMode.onsite"
 msgstr "Sur site"
@@ -2854,7 +2888,7 @@ msgstr "Une page par minute."
 
 #. Username invalid characters hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:284
+#: src/components/settings/AccountSettings.tsx:290
 msgid "settings.account.username.invalidChars"
 msgstr "Uniquement des lettres minuscules, des chiffres et des tirets (pas au début/fin)"
 
@@ -2864,15 +2898,21 @@ msgstr "Uniquement des lettres minuscules, des chiffres et des tirets (pas au d�
 msgid "myJobs.interviewType.onsite"
 msgstr "Sur site"
 
+#. Heading shown when a search surface returns an impossible empty result set
+#. js-lingui-explicit-id
+#: src/components/search/search-unavailable.tsx:9
+msgid "search.unavailable.heading"
+msgstr "Oups, une erreur s'est produite."
+
 #. Aria label for the row open-posting button when the posting title is missing
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:158
+#: src/components/watchlist/watchlist-job-list.tsx:199
 msgid "watchlists.jobList.openPosting"
 msgstr "Ouvrir l'offre d'emploi"
 
 #. Aria label for opening a job posting from a company card row when the posting title is missing
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:147
+#: src/components/search/company-card.tsx:159
 msgid "search.card.openPosting"
 msgstr "Ouvrir l'offre d'emploi"
 
@@ -2882,8 +2922,9 @@ msgstr "Ouvrir l'offre d'emploi"
 msgid "common.header.openMenu"
 msgstr "Ouvrir le menu principal"
 
+#. Fallback SEO metadata count text for a company with no active jobs.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:46
+#: app/[lang]/(app)/company/[slug]/page.tsx:48
 msgid "company.meta.openPositions"
 msgstr "Postes ouverts"
 
@@ -2925,13 +2966,13 @@ msgstr "Original"
 
 #. Fallback label for a country header in the location modal when the city has no parent country in the hierarchy. Rare path.
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:638
+#: src/components/search/location-search-modal.tsx:647
 msgid "search.locationModal.otherCountry"
 msgstr "Autre"
 
 #. Fallback label for a region row in the location modal when the region has no display name (e.g. orphaned cities). Rare path; only shown when a city's parent region in the hierarchy has no localized name.
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:723
+#: src/components/search/location-search-modal.tsx:732
 msgid "search.locationModal.otherRegion"
 msgstr "Autre"
 
@@ -2961,21 +3002,15 @@ msgstr "Notre position sur l'automatisation"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:21
-msgid "license.toc.overview"
-msgstr "Aperçu"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:25
 msgid "indexing.toc.overview"
 msgstr "Aperçu"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
-msgid "license.toc.ariaLabel"
-msgstr "Sommaire de la page"
+#: src/components/LicenseContent.tsx:21
+msgid "license.toc.overview"
+msgstr "Aperçu"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
@@ -2983,9 +3018,17 @@ msgstr "Sommaire de la page"
 msgid "indexing.toc.ariaLabel"
 msgstr "Sommaire de la page"
 
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:18
+msgid "license.toc.ariaLabel"
+msgstr "Sommaire de la page"
+
+#. Heading shown on the 404 page
 #. Heading shown on the 404 page
 #. js-lingui-explicit-id
 #: app/[lang]/not-found-content.tsx:12
+#: app/[lang]/not-found.tsx:21
 msgid "notFound.title"
 msgstr "Page introuvable"
 
@@ -3071,7 +3114,7 @@ msgstr "Période"
 
 #. Delete account section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:511
+#: src/components/settings/AccountSettings.tsx:517
 msgid "settings.account.delete.description"
 msgstr "Supprime définitivement ton compte et toutes les données associées. Cette action est irréversible."
 
@@ -3107,7 +3150,7 @@ msgstr "Veuillez entrer un nom d'entreprise ou une URL."
 
 #. Error when email field is empty
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:350
+#: src/components/settings/AccountSettings.tsx:356
 msgid "settings.account.email.required"
 msgstr "Saisis une nouvelle adresse e-mail"
 
@@ -3203,9 +3246,11 @@ msgstr "Confidentialité"
 msgid "privacy.hero.title"
 msgstr "Confidentialité chez Job Seek"
 
+#. JSON-LD page name for the public Privacy Policy page.
+#. SEO title for the public Privacy Policy page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/privacy-policy/page.tsx:17
-#: app/[lang]/(public)/privacy-policy/page.tsx:50
+#: app/[lang]/(public)/privacy-policy/page.tsx:55
 msgid "privacy.meta.title"
 msgstr "Politique de confidentialité"
 
@@ -3239,16 +3284,16 @@ msgstr "Domaine public"
 msgid "license.contactCta"
 msgstr "Des questions sur les licences ou l'utilisation commerciale ? Écris-nous."
 
-#. Terms contact call to action
-#. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:53
-msgid "terms.contact.description"
-msgstr "Des questions ? Écris-nous."
-
 #. Privacy contact call to action
 #. js-lingui-explicit-id
 #: src/components/PrivacyPolicyContent.tsx:65
 msgid "privacy.contact.description"
+msgstr "Des questions ? Écris-nous."
+
+#. Terms contact call to action
+#. js-lingui-explicit-id
+#: src/components/TermsContent.tsx:53
+msgid "terms.contact.description"
 msgstr "Des questions ? Écris-nous."
 
 #. Link to full CC license
@@ -3275,8 +3320,9 @@ msgstr "Lire la politique de confidentialité complète"
 msgid "terms.fullTermsLink"
 msgstr "Lire les conditions d'utilisation complètes"
 
+#. WebApplication JSON-LD feature list item about job alert notifications.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:143
+#: app/[lang]/layout.tsx:157
 msgid "app.schema.feature.alerts"
 msgstr "Alertes en temps réel sur les nouvelles offres"
 
@@ -3305,21 +3351,21 @@ msgstr "Redistribue tes modifications, à condition d'inclure la mention MIT."
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:32
 #: src/components/search/filter-bar.tsx:34
-#: src/components/search/location-pills.tsx:28
-#: src/components/search/location-pills.tsx:30
+#: src/components/search/location-pills.tsx:29
+#: src/components/search/location-pills.tsx:31
 msgid "location.type.region"
 msgstr "Région"
-
-#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:526
-msgid "search.locationModal.regionsHeader"
-msgstr "Régions"
 
 #. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:322
 msgid "company.locationModal.regionsHeader"
+msgstr "Régions"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:535
+msgid "search.locationModal.regionsHeader"
 msgstr "Régions"
 
 #. Status group heading: rejected
@@ -3334,6 +3380,12 @@ msgstr "Refusé"
 msgid "search.tracker.rejected"
 msgstr "Refusé"
 
+#. Rejected status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:23
+msgid "myJobs.status.rejected"
+msgstr "Refusé"
+
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
@@ -3344,12 +3396,6 @@ msgstr "Refusé"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:39
 msgid "myJobs.statusOption.rejected"
-msgstr "Refusé"
-
-#. Rejected status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:23
-msgid "myJobs.status.rejected"
 msgstr "Refusé"
 
 #. Footer license summary text
@@ -3364,8 +3410,8 @@ msgstr "Publié sous licence MIT. Les données d'emploi sont sous CC BY-NC 4.0."
 #. Work mode: remote (work-from-home)
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:598
-#: src/components/search/search-bar.tsx:813
-#: src/components/search/search-toolbar.tsx:272
+#: src/components/search/search-bar.tsx:809
+#: src/components/search/search-toolbar.tsx:273
 #: src/components/search/work-mode-modal.tsx:28
 msgid "search.workMode.remote"
 msgstr "À distance"
@@ -3402,11 +3448,11 @@ msgstr "Supprimer le filtre {0}"
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:579
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:589
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:603
-#: src/components/search/search-toolbar.tsx:201
-#: src/components/search/search-toolbar.tsx:220
-#: src/components/search/search-toolbar.tsx:240
-#: src/components/search/search-toolbar.tsx:260
-#: src/components/search/search-toolbar.tsx:283
+#: src/components/search/search-toolbar.tsx:202
+#: src/components/search/search-toolbar.tsx:221
+#: src/components/search/search-toolbar.tsx:241
+#: src/components/search/search-toolbar.tsx:261
+#: src/components/search/search-toolbar.tsx:284
 msgid "search.filters.removeFilter"
 msgstr "Supprimer le filtre {name}"
 
@@ -3432,7 +3478,7 @@ msgstr "Supprimer le filtre {name}"
 #. Aria label for the X button that clears the experience-range filter
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:622
-#: src/components/search/search-toolbar.tsx:318
+#: src/components/search/search-toolbar.tsx:319
 msgid "search.filters.removeExperience"
 msgstr "Supprimer le filtre d’expérience"
 
@@ -3459,13 +3505,13 @@ msgstr "Supprimer le mot-clé {0}"
 #. Aria label for remove-keyword X button; {name} is the keyword
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:630
-#: src/components/search/search-toolbar.tsx:335
+#: src/components/search/search-toolbar.tsx:336
 msgid "search.filters.removeKeyword"
 msgstr "Supprimer le mot-clé {name}"
 
 #. Aria label for removing a location pill
 #. js-lingui-explicit-id
-#: src/components/search/location-pills.tsx:199
+#: src/components/search/location-pills.tsx:195
 msgid "search.locations.remove"
 msgstr "Supprimer le lieu"
 
@@ -3480,7 +3526,7 @@ msgstr "Supprimer le lieu {0}"
 #. Aria label for remove-location X button; {name} is the location label
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:640
-#: src/components/search/search-toolbar.tsx:356
+#: src/components/search/search-toolbar.tsx:357
 msgid "search.filters.removeLocation"
 msgstr "Supprimer le lieu {name}"
 
@@ -3488,7 +3534,7 @@ msgstr "Supprimer le lieu {name}"
 #. Aria label for the X button that clears the salary-range filter
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:613
-#: src/components/search/search-toolbar.tsx:301
+#: src/components/search/search-toolbar.tsx:302
 msgid "search.filters.removeSalary"
 msgstr "Supprimer le filtre de salaire"
 
@@ -3500,7 +3546,7 @@ msgstr "Supprimer le filtre de salaire"
 
 #. Synthetic dropdown row that lets the user request a company that's not in the catalog
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:934
+#: src/components/search/search-bar.tsx:930
 msgid "search.bar.request"
 msgstr "Demander \\\"{trimmedInput}\\\""
 
@@ -3590,7 +3636,7 @@ msgstr "Rôle"
 
 #. Section header for occupation suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:695
+#: src/components/search/search-bar.tsx:691
 msgid "search.bar.roles"
 msgstr "Rôles"
 
@@ -3644,7 +3690,7 @@ msgstr "Enregistre n'importe quelle recherche en watchlist et reçois des alerte
 
 #. Save job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:191
+#: src/components/watchlist/watchlist-job-list.tsx:232
 msgid "watchlists.jobList.save"
 msgstr "Sauvegarder l'offre"
 
@@ -3668,7 +3714,7 @@ msgstr "Enregistrez des offres et suivez vos candidatures pour voir des statisti
 
 #. Button label to save current search as a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:110
+#: src/components/search/save-search-button.tsx:113
 msgid "search.saveSearch.label"
 msgstr "Enregistrer cette recherche"
 
@@ -3676,6 +3722,12 @@ msgstr "Enregistrer cette recherche"
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:28
 msgid "myJobs.group.saved"
+msgstr "Enregistré"
+
+#. Saved status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:19
+msgid "myJobs.status.saved"
 msgstr "Enregistré"
 
 #. Sankey funnel node: saved jobs
@@ -3690,21 +3742,15 @@ msgstr "Enregistré"
 msgid "myJobs.statusOption.saved"
 msgstr "Enregistré"
 
-#. Saved status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:19
-msgid "myJobs.status.saved"
-msgstr "Enregistré"
-
 #. Username save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:320
+#: src/components/settings/AccountSettings.tsx:326
 msgid "settings.account.username.saving"
 msgstr "Enregistrement..."
 
 #. Email save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:392
+#: src/components/settings/AccountSettings.tsx:398
 msgid "settings.account.email.saving"
 msgstr "Enregistrement…"
 
@@ -3723,7 +3769,7 @@ msgstr "Cherche parmi des milliers d'entreprises scrapées directement depuis le
 #. Placeholder for search bar when on company page
 #. js-lingui-explicit-id
 #. placeholder {0}: company.name
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:161
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:169
 msgid "company.page.searchPlaceholder"
 msgstr "Rechercher chez {0}..."
 
@@ -3741,12 +3787,13 @@ msgstr "Rechercher des entreprises..."
 
 #. Option to search by title keyword in dropdown
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:683
+#: src/components/search/search-bar.tsx:679
 msgid "search.bar.keyword"
 msgstr "Rechercher \"{trimmedInput}\" dans les titres de postes"
 
+#. SEO description for the Explore jobs page.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:33
+#: app/[lang]/(app)/explore/page.tsx:44
 msgid "explore.meta.description"
 msgstr "Recherchez des emplois dans des milliers d'entreprises, scrapés directement des pages carrières. Filtrez par niveau, stack technique, salaire et localisation — créez des watchlists et recevez des alertes."
 
@@ -3756,17 +3803,17 @@ msgstr "Recherchez des emplois dans des milliers d'entreprises, scrapés directe
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Rechercher des langues…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:495
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Rechercher des lieux..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:291
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Rechercher des lieux…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:504
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Rechercher des lieux..."
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3794,7 +3841,7 @@ msgstr "Recherche précise"
 
 #. Placeholder for the main search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:608
+#: src/components/search/search-bar.tsx:604
 msgid "search.bar.placeholder"
 msgstr "Rechercher…"
 
@@ -3812,7 +3859,7 @@ msgstr "Sélectionner le niveau"
 
 #. Title for the global location selection modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:472
+#: src/components/search/location-search-modal.tsx:481
 msgid "search.locationModal.title"
 msgstr "Sélectionner le lieu"
 
@@ -3852,16 +3899,16 @@ msgstr "Envoyer le lien"
 msgid "settings.account.password.send"
 msgstr "Envoyer le lien"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Envoi en cours..."
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
+msgstr "Envoi en cours..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
 msgstr "Envoi en cours..."
 
 #. Reset password button while loading
@@ -4052,7 +4099,7 @@ msgstr "Sitemap d'abord."
 
 #. Skip to main content link for keyboard users
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/layout.tsx:25
+#: src/components/SkipToContentLink.tsx:11
 msgid "common.a11y.skipToContent"
 msgstr "Aller au contenu"
 
@@ -4202,7 +4249,7 @@ msgstr "Technique"
 
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:765
+#: src/components/search/search-bar.tsx:761
 msgid "search.bar.technologies"
 msgstr "Technologies"
 
@@ -4248,9 +4295,11 @@ msgstr "Conditions d'utilisation"
 msgid "common.footer.termsLink"
 msgstr "CGU"
 
+#. JSON-LD page name for the public Terms of Service page.
+#. SEO title for the public Terms of Service page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/terms/page.tsx:17
-#: app/[lang]/(public)/terms/page.tsx:50
+#: app/[lang]/(public)/terms/page.tsx:55
 msgid "terms.meta.title"
 msgstr "Conditions d'utilisation"
 
@@ -4260,15 +4309,17 @@ msgstr "Conditions d'utilisation"
 msgid "terms.hero.title"
 msgstr "Conditions d'utilisation"
 
+#. JSON-LD page description for the public Terms of Service page.
+#. SEO description for the public Terms of Service page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:18
-#: app/[lang]/(public)/terms/page.tsx:51
+#: app/[lang]/(public)/terms/page.tsx:22
+#: app/[lang]/(public)/terms/page.tsx:60
 msgid "terms.meta.description"
 msgstr "Conditions d'utilisation de Job Seek — règles d'usage, propriété intellectuelle, responsabilités du compte, limitation de responsabilité et droit applicable."
 
 #. Body text shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:94
+#: app/[lang]/(app)/company/[slug]/page.tsx:102
 msgid "company.notFound.message"
 msgstr "L'entreprise que vous recherchez n'existe pas ou a été supprimée."
 
@@ -4284,13 +4335,15 @@ msgstr "L'entreprise que vous recherchez n'existe pas ou a été supprimée."
 msgid "about.transparency.p1"
 msgstr "Le code du crawler est open source pour que tout le monde puisse vérifier comment nous collectons les données. Nous respectons robots.txt, honorons les en-têtes TDM-Reservation et nous limitons à une requête par site par minute. Chaque lien sortant inclut utm_source=jobseek pour que les employeurs sachent d'où vient leur trafic."
 
+#. FAQ answer explaining crawler discovery and refresh frequency.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:53
+#: app/[lang]/(public)/faq/page.tsx:58
 msgid "faq.a.howOftenUpdated"
 msgstr "Le crawler découvre de nouvelles offres selon un cycle horaire et actualise les détails quotidiennement. La plupart des postes apparaissent dans les heures suivant leur publication sur la page carrières d'une entreprise."
 
+#. FAQ answer listing interface languages and posting-language filtering.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:93
+#: app/[lang]/(public)/faq/page.tsx:98
 msgid "faq.a.languages"
 msgstr "L'interface est disponible en anglais, allemand, français et italien. Vous pouvez également filtrer les offres d'emploi par la langue dans laquelle elles ont été rédigées."
 
@@ -4308,14 +4361,14 @@ msgstr "Le service est fourni tel quel, sans garantie."
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:39
-msgid "terms.short.title"
+#: src/components/PrivacyPolicyContent.tsx:39
+msgid "privacy.short.title"
 msgstr "En bref"
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:39
-msgid "privacy.short.title"
+#: src/components/TermsContent.tsx:39
+msgid "terms.short.title"
 msgstr "En bref"
 
 #. Theme settings section heading
@@ -4338,7 +4391,7 @@ msgstr "Ce site utilise des cookies uniquement pour l'authentification et les fo
 
 #. Username is reserved hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:286
+#: src/components/settings/AccountSettings.tsx:292
 msgid "settings.account.username.reserved"
 msgstr "Ce nom d'utilisateur est réservé"
 
@@ -4356,7 +4409,7 @@ msgstr "Cette liste de suivi et tous ses paramètres seront définitivement supp
 
 #. Date divider label for today
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:71
+#: src/components/watchlist/watchlist-job-list.tsx:75
 msgid "watchlists.jobList.today"
 msgstr "Aujourd'hui"
 
@@ -4366,9 +4419,11 @@ msgstr "Aujourd'hui"
 msgid "home.hero.title"
 msgstr "Suis les entreprises pour lesquelles tu veux vraiment travailler."
 
+#. JSON-LD page name for the public homepage.
+#. SEO title for the public homepage.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/page.tsx:20
-#: app/[lang]/(public)/page.tsx:52
+#: app/[lang]/(public)/page.tsx:57
 msgid "home.meta.title"
 msgstr "Suis les entreprises pour lesquelles tu veux travailler — Job Seek"
 
@@ -4395,6 +4450,12 @@ msgstr "Transparent par défaut"
 #: app/[lang]/error.tsx:23
 msgid "error.retryButton"
 msgstr "Réessayer"
+
+#. Body shown when a search surface returns an impossible empty result set
+#. js-lingui-explicit-id
+#: src/components/search/search-unavailable.tsx:14
+msgid "search.unavailable.body"
+msgstr "Essayez d'actualiser la page."
 
 #. Add employment type filter
 #. js-lingui-explicit-id
@@ -4438,14 +4499,15 @@ msgstr "Watchlists illimitées"
 msgid "home.pricing.pro.description"
 msgstr "Watchlists illimitées avec alertes par e-mail pour ne jamais rater une ouverture."
 
+#. WebApplication JSON-LD offer description for the Pro plan.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:138
+#: app/[lang]/layout.tsx:144
 msgid "app.schema.offer.pro"
 msgstr "Listes de suivi illimitées, alertes email sur les nouveaux résultats"
 
 #. Unsave job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:190
+#: src/components/watchlist/watchlist-job-list.tsx:231
 msgid "watchlists.jobList.unsave"
 msgstr "Retirer l'offre"
 
@@ -4457,19 +4519,19 @@ msgstr "Retirer l'offre"
 
 #. Email save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:393
+#: src/components/settings/AccountSettings.tsx:399
 msgid "settings.account.email.save"
 msgstr "Mettre à jour l'e-mail"
 
 #. Change email section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:373
+#: src/components/settings/AccountSettings.tsx:379
 msgid "settings.account.email.description"
 msgstr "Mets à jour l'adresse e-mail associée à ton compte."
 
 #. Username save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:321
+#: src/components/settings/AccountSettings.tsx:327
 msgid "settings.account.username.save"
 msgstr "Mettre à jour le nom d'utilisateur"
 
@@ -4497,8 +4559,9 @@ msgstr "Passer à Pro"
 msgid "settings.billing.upgrading"
 msgstr "Mise à jour…"
 
+#. FAQ answer explaining how to request a missing company from the Explore page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:61
+#: app/[lang]/(public)/faq/page.tsx:66
 msgid "faq.a.requestCompany"
 msgstr "Utilisez le formulaire de demande sur la page Explorer — collez l'URL d'une page carrières ou un nom d'entreprise et nous lancerons l'indexation. Vous pouvez suivre la progression via le numéro d'issue que nous vous renvoyons."
 
@@ -4510,25 +4573,25 @@ msgstr "utilisateur"
 
 #. Username section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:298
+#: src/components/settings/AccountSettings.tsx:304
 msgid "settings.account.username.title"
 msgstr "Nom d'utilisateur"
 
 #. Username input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:310
+#: src/components/settings/AccountSettings.tsx:316
 msgid "settings.account.username.label"
 msgstr "Nom d'utilisateur"
 
 #. Username updated success message
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:273
+#: src/components/settings/AccountSettings.tsx:279
 msgid "settings.account.username.success"
 msgstr "Nom d'utilisateur mis à jour."
 
 #. Success message after email change request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:362
+#: src/components/settings/AccountSettings.tsx:368
 msgid "settings.account.email.success"
 msgstr "E-mail de vérification envoyé. Vérifie ta boîte de réception. La réception peut prendre quelques minutes."
 
@@ -4616,8 +4679,9 @@ msgstr "Listes de suivi"
 msgid "home.features.s1.p3.title"
 msgstr "Watchlists et alertes"
 
+#. WebApplication JSON-LD feature list item about watchlists and application tracking.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:145
+#: app/[lang]/layout.tsx:167
 msgid "app.schema.feature.watchlists"
 msgstr "Listes de suivi et suivi des candidatures"
 
@@ -4645,8 +4709,9 @@ msgstr "Nous ne collectons que le nécessaire, nous ne vendons pas tes données,
 msgid "privacy.short.r2"
 msgstr "Nous ne vendons, ne louons et ne partageons pas tes données à des fins marketing."
 
+#. FAQ answer explaining direct career-page indexing and no recruiter spam.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:57
+#: app/[lang]/(public)/faq/page.tsx:62
 msgid "faq.a.differentiation"
 msgstr "Nous indexons les pages carrières des entreprises directement, pas des flux tiers. Pas de spam de recruteurs, pas d'annonces fantômes republiées, et nous revérifions les entreprises fréquemment — la plupart des postes apparaissent donc ici dans les heures suivant leur publication. Nous sommes conçus pour les utilisateurs qui savent déjà dans quelles entreprises ils veulent travailler, pas pour des recherches générales du type « trouve-moi n'importe quel job »."
 
@@ -4686,8 +4751,9 @@ msgstr "Nous avons remarqué que cette offre a été ajoutée récemment. Certai
 msgid "indexing.automation.body"
 msgstr "Nous nous opposons à ce que les décisions de recrutement ou de recherche d'emploi soient confiées à une automatisation opaque — que ce soit côté employeur ou côté candidat. Chaque lien sortant que nous partageons inclut <0>utm_source=jobseek</0> afin que les recruteurs identifient le trafic, et nous examinons en permanence les schémas d'utilisation tout en imposant des frictions pour dissuader les candidatures automatisées."
 
+#. FAQ answer summarizing crawler politeness, rate limits, and policy compliance.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:77
+#: app/[lang]/(public)/faq/page.tsx:82
 msgid "faq.a.crawlingPolicy"
 msgstr "Nous respectons robots.txt et les en-têtes TDM-Reservation, limitons les requêtes à une par site par minute et utilisons un backoff exponentiel. Toutes les requêtes s'identifient via le User-Agent. Consultez notre page d'indexation pour tous les détails."
 
@@ -4717,7 +4783,7 @@ msgstr "Nous utilisons quelques services tiers pour la connexion, l’hébergeme
 
 #. Secondary line under the Request <query> dropdown row
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:941
+#: src/components/search/search-bar.tsx:937
 msgid "search.bar.request.subtext"
 msgstr "Nous commencerons à la suivre"
 
@@ -4739,23 +4805,27 @@ msgstr "Mer"
 msgid "auth.signIn.subtitle"
 msgstr "Content de te revoir"
 
+#. FAQ question defining a watchlist.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:68
+#: app/[lang]/(public)/faq/page.tsx:73
 msgid "faq.q.whatIsWatchlist"
 msgstr "Qu'est-ce qu'une liste de suivi ?"
 
+#. FAQ question asking for a short product definition.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:44
+#: app/[lang]/(public)/faq/page.tsx:49
 msgid "faq.q.whatIsJobseek"
 msgstr "Qu'est-ce que Job Seek ?"
 
+#. FAQ question comparing Job Seek with general job boards.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:56
+#: app/[lang]/(public)/faq/page.tsx:61
 msgid "faq.q.differentiation"
 msgstr "Qu'est-ce qui distingue Job Seek de LinkedIn ou Indeed ?"
 
+#. FAQ question comparing the Free and Pro plans.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:64
+#: app/[lang]/(public)/faq/page.tsx:69
 msgid "faq.q.freeVsPro"
 msgstr "Quelle est la différence entre Gratuit et Pro ?"
 
@@ -4765,8 +4835,9 @@ msgstr "Quelle est la différence entre Gratuit et Pro ?"
 msgid "app.home.request.heading"
 msgstr "Quelle entreprise devons-nous suivre ?"
 
+#. FAQ question about supported interface and job-posting languages.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:92
+#: app/[lang]/(public)/faq/page.tsx:97
 msgid "faq.q.languages"
 msgstr "Quelles langues Jobseek prend-il en charge ?"
 
@@ -4784,7 +4855,7 @@ msgstr "Mode de travail"
 
 #. Section header for work-mode (onsite/hybrid/remote) suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:800
+#: src/components/search/search-bar.tsx:796
 msgid "search.bar.workMode"
 msgstr "Mode de travail"
 
@@ -4822,24 +4893,27 @@ msgstr "Annuel"
 msgid "search.experienceModal.years"
 msgstr "ans"
 
+#. FAQ answer explaining the company watchlist use case.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:49
+#: app/[lang]/(public)/faq/page.tsx:54
 msgid "faq.a.targetedSeeker"
 msgstr "Oui — c'est précisément le cas d'usage pour lequel nous l'avons conçu. Ajoute les entreprises qui t'intéressent à une watchlist, définis tes filtres (poste, lieu, séniorité, salaire), et Job Seek surveille leurs pages carrières et te prévient dès qu'un nouveau poste correspond. Plus besoin de vérifier chaque site d'entreprise à la main ni de combattre l'algorithme de LinkedIn."
 
+#. FAQ answer explaining how companies can opt out of indexing.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:81
+#: app/[lang]/(public)/faq/page.tsx:86
 msgid "faq.a.optOut"
 msgstr "Oui. Envoyez-nous un email et nous cesserons immédiatement de crawler votre site carrières et retirerons vos offres de l'index."
 
+#. FAQ answer explaining crawler source availability and data licensing.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:85
+#: app/[lang]/(public)/faq/page.tsx:90
 msgid "faq.a.openSource"
 msgstr "Oui. Le crawler et le pipeline d'extraction sont entièrement open source sur GitHub. Le code de l'application est sous licence MIT ; les données d'emploi sont sous CC BY-NC 4.0."
 
 #. Date divider label for yesterday
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:72
+#: src/components/watchlist/watchlist-job-list.tsx:76
 msgid "watchlists.jobList.yesterday"
 msgstr "Hier"
 
@@ -4931,7 +5005,7 @@ msgstr "Vous avez atteint la limite de vos listes de suivi. Passez à un plan su
 
 #. Reason shown in upgrade modal when saving a search hits the watchlist limit
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:93
+#: src/components/search/save-search-button.tsx:96
 msgid "upgrade.reason.saveSearch"
 msgstr "Vous avez atteint la limite de vos listes de suivi. Passez à un plan supérieur pour enregistrer davantage de recherches."
 
@@ -4961,6 +5035,6 @@ msgstr "Tes droits"
 
 #. Username section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:301
+#: src/components/settings/AccountSettings.tsx:307
 msgid "settings.account.username.description"
 msgstr "Votre identifiant unique utilisé dans l'URL de votre profil public."

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -57,8 +57,9 @@ msgstr "(apre in una nuova scheda)"
 msgid "search.detail.showMoreLocations"
 msgstr "{0} in più"
 
+#. SEO metadata count text for a company page; {count} is the active job count.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:41
+#: app/[lang]/(app)/company/[slug]/page.tsx:42
 msgid "company.meta.positionCount"
 msgstr "{count, plural, one {# posizione aperta} other {# posizioni aperte}}"
 
@@ -86,8 +87,9 @@ msgstr "{count, plural, one {offerta attiva} other {offerte attive}}"
 msgid "blog.mention.watchlist.companiesLabel"
 msgstr "{count, plural, one {azienda} other {aziende}}"
 
+#. SEO description prefix for a public watchlist; {description} is the existing watchlist summary.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:104
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:108
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {# azienda monitorata} other {# aziende monitorate}}. {description}"
 
@@ -97,18 +99,21 @@ msgstr "{count, plural, one {# azienda monitorata} other {# aziende monitorate}}
 msgid "myJobs.heatmap.tooltipMultiple"
 msgstr "{count} candidature il {date}"
 
+#. SEO metadata suffix when a watchlist includes more companies than can be listed by name.
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:62
 msgid "watchlist.meta.moreCompanies"
 msgstr "altre {count}"
 
+#. SEO description for a company page when no company summary is available.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:53
+#: app/[lang]/(app)/company/[slug]/page.tsx:60
 msgid "company.meta.descriptionBasic"
 msgstr "{countText} presso {name}"
 
+#. SEO description for a company page; includes job count, company name, and company summary.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:48
+#: app/[lang]/(app)/company/[slug]/page.tsx:54
 msgid "company.meta.descriptionWithInfo"
 msgstr "{countText} presso {name}. {description}"
 
@@ -178,14 +183,17 @@ msgstr "1. Installa MCP"
 msgid "app.home.request.agent.run_heading"
 msgstr "2. Esegui il prompt"
 
+#. FAQ answer explaining saved-search watchlists and sharing options.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:69
+#: app/[lang]/(public)/faq/page.tsx:74
 msgid "faq.a.whatIsWatchlist"
 msgstr "Una watchlist è una ricerca salvata con filtro opzionale per azienda. Scegli le aziende che ti interessano, imposta i filtri (ruolo, località, seniority, stipendio) e ottieni un feed in tempo reale delle offerte corrispondenti. Puoi condividere le watchlist pubblicamente o mantenerle private."
 
+#. JSON-LD page name for the public About page.
+#. SEO title for the public About page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/page.tsx:17
-#: app/[lang]/(public)/about/page.tsx:46
+#: app/[lang]/(public)/about/page.tsx:51
 msgid "about.meta.title"
 msgstr "Chi siamo"
 
@@ -224,8 +232,8 @@ msgstr "Menu account"
 #. Active postings count on company page
 #. Active postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:561
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:571
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:572
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:582
 msgid "company.page.active"
 msgstr "attivo"
 
@@ -239,7 +247,7 @@ msgstr "attivi"
 
 #. Active matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:121
+#: src/components/search/company-card.tsx:122
 msgid "search.card.active"
 msgstr "attivo"
 
@@ -287,7 +295,7 @@ msgstr "Aggiungi filtro per luogo o parola chiave…"
 
 #. Placeholder in the add location input
 #. js-lingui-explicit-id
-#: src/components/search/location-pills.tsx:174
+#: src/components/search/location-pills.tsx:170
 msgid "search.locations.addPlaceholder"
 msgstr "Aggiungi località..."
 
@@ -305,7 +313,7 @@ msgstr "Prompt dell'agente"
 
 #. Footer shown after all paged countries have been loaded into the location modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:816
+#: src/components/search/location-search-modal.tsx:825
 msgid "search.locationModal.allLoaded"
 msgstr "Tutti i {totalCountries} paesi caricati"
 
@@ -333,16 +341,16 @@ msgstr "Tutte le lingue"
 msgid "settings.general.jobLanguages.all"
 msgstr "Tutte le lingue"
 
-#. Button to open all-locations modal on company page
-#. js-lingui-explicit-id
-#: src/components/search/filter-bar.tsx:346
-msgid "company.page.allLocations"
-msgstr "Tutte le sedi"
-
 #. Title for the all-locations modal on company page
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:268
 msgid "company.locationModal.title"
+msgstr "Tutte le sedi"
+
+#. Button to open all-locations modal on company page
+#. js-lingui-explicit-id
+#: src/components/search/filter-bar.tsx:346
+msgid "company.page.allLocations"
 msgstr "Tutte le sedi"
 
 #. Link to sign-in page from sign-up
@@ -353,12 +361,13 @@ msgstr "Hai già un account? <0>Accedi</0>"
 
 #. Username is taken
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:292
+#: src/components/settings/AccountSettings.tsx:298
 msgid "settings.account.username.taken"
 msgstr "Già in uso"
 
+#. SEO description for the public FAQ page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:18
+#: app/[lang]/(public)/faq/page.tsx:22
 msgid "faq.meta.description"
 msgstr "Risposte alle domande frequenti su Job Seek — come scansioniamo le pagine carriere, cosa includono i piani, come gestiamo i tuoi dati e come disiscriversi."
 
@@ -434,6 +443,12 @@ msgstr "Candidato"
 msgid "search.tracker.applied"
 msgstr "Candidato"
 
+#. Applied status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:20
+msgid "myJobs.status.applied"
+msgstr "Candidato"
+
 #. Sankey funnel node: applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:42
@@ -444,12 +459,6 @@ msgstr "Candidato"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:36
 msgid "myJobs.statusOption.applied"
-msgstr "Candidato"
-
-#. Applied status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:20
-msgid "myJobs.status.applied"
 msgstr "Candidato"
 
 #. Apply salary filter
@@ -484,13 +493,13 @@ msgstr "Come ultima risorsa analizziamo le pagine carriere stesse, preferendo l'
 
 #. Username too short hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:280
+#: src/components/settings/AccountSettings.tsx:286
 msgid "settings.account.username.tooShort"
 msgstr "Minimo 3 caratteri"
 
 #. Username too long hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:282
+#: src/components/settings/AccountSettings.tsx:288
 msgid "settings.account.username.tooLong"
 msgstr "Massimo 30 caratteri"
 
@@ -502,7 +511,7 @@ msgstr "Ago"
 
 #. Username is available
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:290
+#: src/components/settings/AccountSettings.tsx:296
 msgid "settings.account.username.available"
 msgstr "Disponibile"
 
@@ -562,18 +571,18 @@ msgstr "Blog"
 msgid "blog.post.backToIndex"
 msgstr "Blog"
 
+#. Footer link to /blog index page
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:52
+msgid "common.footer.blog"
+msgstr "Blog"
+
 #. Nav link: Blog
 #. Nav link: Blog
 #. js-lingui-explicit-id
 #: src/components/Header.tsx:74
 #: src/components/MobileMenu.tsx:98
 msgid "common.nav.blog"
-msgstr "Blog"
-
-#. Footer link to /blog index page
-#. js-lingui-explicit-id
-#: src/components/Footer.tsx:52
-msgid "common.footer.blog"
 msgstr "Blog"
 
 #. Subtitle on the sign-in CTA card shown to anonymous users at the end of the similar-companies strip
@@ -588,9 +597,11 @@ msgstr "Sfoglia tutte le aziende simili"
 msgid "indexing.oss.browseRepo"
 msgstr "Consulta il repository su"
 
+#. JSON-LD page description for the public homepage.
+#. SEO description for the public homepage.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/page.tsx:21
-#: app/[lang]/(public)/page.tsx:53
+#: app/[lang]/(public)/page.tsx:25
+#: app/[lang]/(public)/page.tsx:62
 msgid "home.meta.description"
 msgstr "Crea watchlist delle aziende che ti interessano, ricevi avvisi via email quando si aprono nuove posizioni, e monitora le candidature in un unico posto. Le offerte arrivano direttamente dalle pagine carriere delle aziende, entro poche ore dalla pubblicazione — niente spam dei recruiter, nessun annuncio ripubblicato."
 
@@ -612,8 +623,9 @@ msgstr "Creato da chi cerca lavoro, per chi cerca lavoro"
 msgid "terms.hero.description"
 msgstr "Utilizzando Job Seek accetti questi termini. Ecco un riassunto in parole semplici."
 
+#. FAQ question about company opt-out from indexing.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:80
+#: app/[lang]/(public)/faq/page.tsx:85
 msgid "faq.q.optOut"
 msgstr "Posso rifiutare l'indicizzazione della mia azienda da parte di Jobseek?"
 
@@ -633,7 +645,7 @@ msgstr "Annulla"
 
 #. Cancel delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:532
+#: src/components/settings/AccountSettings.tsx:538
 msgid "settings.account.delete.cancel"
 msgstr "Annulla"
 
@@ -645,7 +657,7 @@ msgstr "modifica"
 
 #. Change email section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:370
+#: src/components/settings/AccountSettings.tsx:376
 msgid "settings.account.email.title"
 msgstr "Cambia email"
 
@@ -673,21 +685,21 @@ msgstr "Cambia la tua password tramite un link email sicuro."
 msgid "myJobs.detail.changePlaceholder"
 msgstr "Cambia…"
 
-#. Heading after sign-up telling user to check email
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:80
-msgid "auth.verify.checkEmail.title"
-msgstr "Controlla la tua email"
-
 #. Heading after reset email is sent
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:58
 msgid "auth.forgotPassword.sent.title"
 msgstr "Controlla la tua e-mail"
 
+#. Heading after sign-up telling user to check email
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:80
+msgid "auth.verify.checkEmail.title"
+msgstr "Controlla la tua email"
+
 #. Checking username availability
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:288
+#: src/components/settings/AccountSettings.tsx:294
 msgid "settings.account.username.checking"
 msgstr "Verifica disponibilità..."
 
@@ -725,7 +737,7 @@ msgstr "Scegli in quali lingue vuoi vedere le offerte di lavoro."
 #. Location type label for cities
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:35
-#: src/components/search/location-pills.tsx:31
+#: src/components/search/location-pills.tsx:32
 msgid "location.type.city"
 msgstr "Città"
 
@@ -745,7 +757,7 @@ msgstr "Rimuovi tutti"
 #. Button to clear all active search filters
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:645
-#: src/components/search/search-toolbar.tsx:367
+#: src/components/search/search-toolbar.tsx:368
 msgid "search.filters.clearAll"
 msgstr "Cancella tutto"
 
@@ -773,12 +785,6 @@ msgstr "Clicca per rinominare"
 msgid "indexing.ingestion.s2.title"
 msgstr "API client come seconda opzione."
 
-#. Aria label for close button on add-companies modal
-#. js-lingui-explicit-id
-#: src/components/watchlist/company-search-modal.tsx:201
-msgid "watchlists.companyModal.close"
-msgstr "Chiudi"
-
 #. Aria label for upgrade modal close button
 #. js-lingui-explicit-id
 #: src/components/ui/upgrade-modal.tsx:59
@@ -791,16 +797,16 @@ msgstr "Chiudi"
 msgid "settings.jobLanguages.modal.close"
 msgstr "Chiudi"
 
+#. Aria label for close button on add-companies modal
+#. js-lingui-explicit-id
+#: src/components/watchlist/company-search-modal.tsx:201
+msgid "watchlists.companyModal.close"
+msgstr "Chiudi"
+
 #. Aria label for the technology modal close button
 #. js-lingui-explicit-id
 #: src/components/search/technology-modal.tsx:117
 msgid "search.technologyModal.close"
-msgstr "Chiudi"
-
-#. Aria label for the seniority modal close button
-#. js-lingui-explicit-id
-#: src/components/search/seniority-modal.tsx:65
-msgid "search.seniorityModal.close"
 msgstr "Chiudi"
 
 #. Aria label for the work-mode modal close button
@@ -809,10 +815,22 @@ msgstr "Chiudi"
 msgid "search.workModeModal.close"
 msgstr "Chiudi"
 
+#. Aria label for the seniority modal close button
+#. js-lingui-explicit-id
+#: src/components/search/seniority-modal.tsx:65
+msgid "search.seniorityModal.close"
+msgstr "Chiudi"
+
 #. Aria label for the salary modal close button
 #. js-lingui-explicit-id
 #: src/components/search/salary-modal.tsx:254
 msgid "search.salaryModal.close"
+msgstr "Chiudi"
+
+#. Aria label for close button on the company-page all-locations modal
+#. js-lingui-explicit-id
+#: src/components/search/location-modal.tsx:275
+msgid "company.locationModal.close"
 msgstr "Chiudi"
 
 #. Aria label for the occupation modal close button
@@ -823,7 +841,7 @@ msgstr "Chiudi"
 
 #. Aria label for the location modal close button
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:479
+#: src/components/search/location-search-modal.tsx:488
 msgid "search.locationModal.close"
 msgstr "Chiudi"
 
@@ -837,12 +855,6 @@ msgstr "Chiudi"
 #. js-lingui-explicit-id
 #: src/components/search/employment-type-modal.tsx:82
 msgid "search.employmentTypeModal.close"
-msgstr "Chiudi"
-
-#. Aria label for close button on the company-page all-locations modal
-#. js-lingui-explicit-id
-#: src/components/search/location-modal.tsx:275
-msgid "company.locationModal.close"
 msgstr "Chiudi"
 
 #. Aria label for job detail panel close button
@@ -865,13 +877,13 @@ msgstr "Chiudi menu"
 
 #. Label for inactive/closed job postings on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:663
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:676
 msgid "company.page.closed"
 msgstr "Chiuso"
 
 #. Label for inactive/closed job postings on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:159
+#: src/components/search/company-card.tsx:171
 msgid "search.card.closed"
 msgstr "Chiuso"
 
@@ -907,7 +919,7 @@ msgstr "In arrivo"
 
 #. Section header for company suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:882
+#: src/components/search/search-bar.tsx:878
 msgid "search.bar.companies"
 msgstr "Aziende"
 
@@ -945,15 +957,17 @@ msgstr "Azienda"
 #. Heading shown when the company URL slug doesn't resolve to a known company
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/company/[slug]/company-content.tsx:51
-#: app/[lang]/(app)/company/[slug]/page.tsx:89
+#: app/[lang]/(app)/company/[slug]/page.tsx:97
 msgid "company.notFound.title"
 msgstr "Azienda non trovata"
 
+#. WebApplication JSON-LD description for Job Seek.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:120
+#: app/[lang]/layout.tsx:121
 msgid "app.schema.description"
 msgstr "Strumento di tracciamento aziende per chi cerca lavoro e sa già in quali aziende vuole lavorare. Crea watchlist, ricevi avvisi via email quando si aprono nuove posizioni e monitora le candidature in un unico posto — annunci direttamente dalle pagine carriere delle aziende."
 
+#. Organization JSON-LD description for Job Seek and Colophon Group.
 #. js-lingui-explicit-id
 #: app/[lang]/layout.tsx:85
 msgid "app.schema.org.description"
@@ -961,7 +975,7 @@ msgstr "Strumento di tracciamento aziende per chi cerca lavoro in modo mirato �
 
 #. Confirm delete button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:525
+#: src/components/settings/AccountSettings.tsx:531
 msgid "settings.account.delete.confirm"
 msgstr "Conferma eliminazione"
 
@@ -973,15 +987,21 @@ msgstr "Conferma password"
 
 #. Connect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:475
+#: src/components/settings/AccountSettings.tsx:481
 msgid "settings.account.socials.connect"
 msgstr "Collega"
 
 #. Connected accounts section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:450
+#: src/components/settings/AccountSettings.tsx:456
 msgid "settings.account.socials.title"
 msgstr "Account collegati"
+
+#. Footer link to contact email
+#. js-lingui-explicit-id
+#: src/components/Footer.tsx:46
+msgid "common.footer.contact"
+msgstr "Contatti"
 
 #. TOC: Contact
 #. js-lingui-explicit-id
@@ -995,22 +1015,16 @@ msgstr "Contatti"
 msgid "license.contact.title"
 msgstr "Contatti"
 
-#. Footer link to contact email
+#. Table of contents heading
 #. js-lingui-explicit-id
-#: src/components/Footer.tsx:46
-msgid "common.footer.contact"
-msgstr "Contatti"
+#: src/components/HowWeIndexContent.tsx:21
+msgid "indexing.toc.title"
+msgstr "Sommario"
 
 #. Table of contents heading
 #. js-lingui-explicit-id
 #: src/components/LicenseContent.tsx:17
 msgid "license.toc.title"
-msgstr "Sommario"
-
-#. Table of contents heading
-#. js-lingui-explicit-id
-#: src/components/HowWeIndexContent.tsx:21
-msgid "indexing.toc.title"
 msgstr "Sommario"
 
 #. Button to continue to app after verification
@@ -1083,7 +1097,7 @@ msgstr "Copia il prompt"
 #. Location type label for countries
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:33
-#: src/components/search/location-pills.tsx:29
+#: src/components/search/location-pills.tsx:30
 msgid "location.type.country"
 msgstr "Paese"
 
@@ -1119,7 +1133,7 @@ msgstr "Crea un account gratuito per consultare tutti i risultati, salvare offer
 
 #. Tooltip explaining save search creates a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:117
+#: src/components/search/save-search-button.tsx:120
 msgid "search.saveSearch.tooltip"
 msgstr "Crea una watchlist dai tuoi filtri attuali"
 
@@ -1227,13 +1241,13 @@ msgstr "Elimina"
 
 #. Delete account section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:508
+#: src/components/settings/AccountSettings.tsx:514
 msgid "settings.account.delete.title"
 msgstr "Elimina account"
 
 #. Delete account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:518
+#: src/components/settings/AccountSettings.tsx:524
 msgid "settings.account.delete.button"
 msgstr "Elimina il mio account"
 
@@ -1245,7 +1259,7 @@ msgstr "Eliminare la lista di osservazione?"
 
 #. Delete button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:524
+#: src/components/settings/AccountSettings.tsx:530
 msgid "settings.account.delete.deleting"
 msgstr "Eliminazione…"
 
@@ -1287,7 +1301,7 @@ msgstr "Disattiva notifiche"
 
 #. Disconnect social account button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:474
+#: src/components/settings/AccountSettings.tsx:480
 msgid "settings.account.socials.disconnect"
 msgstr "Scollega"
 
@@ -1297,8 +1311,9 @@ msgstr "Scollega"
 msgid "watchlists.explore.publicTitle"
 msgstr "Scopri liste pubbliche"
 
+#. FAQ question about whether user data is sold.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:88
+#: app/[lang]/(public)/faq/page.tsx:93
 msgid "faq.q.dataPrivacy"
 msgstr "Jobseek vende i miei dati?"
 
@@ -1455,40 +1470,41 @@ msgstr "Esplora"
 msgid "app.header.nav.explore"
 msgstr "Esplora"
 
+#. SEO title for the Explore jobs page.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:32
+#: app/[lang]/(app)/explore/page.tsx:39
 msgid "explore.meta.title"
 msgstr "Esplora lavori"
 
 #. Hidden page H1 for /explore — screen-reader landmark
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/search-page.tsx:754
+#: app/[lang]/(app)/explore/search-page.tsx:811
 msgid "explore.h1"
 msgstr "Esplora lavori"
 
 #. Generic email change error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:360
+#: src/components/settings/AccountSettings.tsx:366
 msgid "settings.account.email.error"
 msgstr "Impossibile cambiare l'email"
 
 #. Error when linking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:426
+#: src/components/settings/AccountSettings.tsx:432
 msgid "settings.account.socials.connectError"
 msgstr "Impossibile collegare l'account"
 
 #. Generic account deletion error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:499
+#: src/components/settings/AccountSettings.tsx:505
 msgid "settings.account.delete.error"
 msgstr "Impossibile eliminare l'account"
 
 #. Error when unlinking social account fails
 #. Error when unlinking social account fails
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:437
-#: src/components/settings/AccountSettings.tsx:442
+#: src/components/settings/AccountSettings.tsx:443
+#: src/components/settings/AccountSettings.tsx:448
 msgid "settings.account.socials.disconnectError"
 msgstr "Impossibile scollegare l'account"
 
@@ -1518,10 +1534,11 @@ msgstr "Impossibile impostare la password"
 
 #. Generic username update error
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:261
+#: src/components/settings/AccountSettings.tsx:267
 msgid "settings.account.username.error"
 msgstr "Impossibile aggiornare il nome utente"
 
+#. SEO title for the public FAQ page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/faq/page.tsx:17
 msgid "faq.meta.title"
@@ -1667,8 +1684,9 @@ msgstr "Gratis"
 msgid "settings.billing.plan.free"
 msgstr "Gratuito"
 
+#. FAQ answer summarizing Free and Pro plan differences.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:65
+#: app/[lang]/(public)/faq/page.tsx:70
 msgid "faq.a.freeVsPro"
 msgstr "La versione gratuita offre ricerca completa su tutte le aziende, una watchlist e il tracker delle candidature con registro dei colloqui. Pro aggiunge watchlist illimitate e avvisi email quando nuove offerte corrispondono ai tuoi criteri."
 
@@ -1696,8 +1714,9 @@ msgstr "Dalla posizione salvata all'offerta firmata, tutto in un unico posto"
 msgid "settings.billing.free.f2"
 msgstr "Ricerca lavoro completa"
 
+#. WebApplication JSON-LD offer description for the Free plan.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:130
+#: app/[lang]/layout.tsx:132
 msgid "app.schema.offer.free"
 msgstr "Ricerca completa, 1 watchlist, tracker delle candidature"
 
@@ -1807,24 +1826,29 @@ msgstr "Orario"
 msgid "myJobs.salary.hourly"
 msgstr "Orario"
 
+#. FAQ question about requesting a missing company.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:60
+#: app/[lang]/(public)/faq/page.tsx:65
 msgid "faq.q.requestCompany"
 msgstr "Come posso richiedere un'azienda non presente nell'elenco?"
 
+#. FAQ question for company operators about crawler behavior.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:76
+#: app/[lang]/(public)/faq/page.tsx:81
 msgid "faq.q.crawlingPolicy"
 msgstr "Come si comporta il crawler sul sito della mia azienda?"
 
+#. JSON-LD page description for the public Job Indexing methodology page.
+#. SEO description for the public Job Indexing methodology page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/how-we-index/page.tsx:18
-#: app/[lang]/(public)/how-we-index/page.tsx:50
+#: app/[lang]/(public)/how-we-index/page.tsx:22
+#: app/[lang]/(public)/how-we-index/page.tsx:59
 msgid "indexing.meta.description"
 msgstr "Come Job Seek scopre e indicizza le offerte di lavoro: il nostro approccio di sourcing, frequenza di crawl, limiti di frequenza, conformità a robots.txt e TDM-Reservation, e come disattivare."
 
+#. FAQ question about job listing refresh cadence.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:52
+#: app/[lang]/(public)/faq/page.tsx:57
 msgid "faq.q.howOftenUpdated"
 msgstr "Con quale frequenza vengono aggiornate le offerte di lavoro?"
 
@@ -1846,9 +1870,11 @@ msgstr "Come gli annunci entrano nell'indice"
 msgid "indexing.hero.title"
 msgstr "Come troviamo e processiamo gli annunci di lavoro"
 
+#. JSON-LD page name for the public Job Indexing methodology page.
+#. SEO title for the public Job Indexing methodology page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/how-we-index/page.tsx:17
-#: app/[lang]/(public)/how-we-index/page.tsx:49
+#: app/[lang]/(public)/how-we-index/page.tsx:54
 msgid "indexing.meta.title"
 msgstr "Come indicizziamo"
 
@@ -1858,8 +1884,8 @@ msgstr "Come indicizziamo"
 #. Work mode: hybrid (mixed onsite/remote)
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:597
-#: src/components/search/search-bar.tsx:812
-#: src/components/search/search-toolbar.tsx:271
+#: src/components/search/search-bar.tsx:808
+#: src/components/search/search-toolbar.tsx:272
 #: src/components/search/work-mode-modal.tsx:27
 msgid "search.workMode.hybrid"
 msgstr "Ibrido"
@@ -1888,16 +1914,17 @@ msgstr "Se noti attività impreviste del nostro crawler o preferisci che il tuo 
 msgid "indexing.outreach.body"
 msgstr "Se noti un comportamento anomalo del crawler, preferisci che non indicizziamo i tuoi contenuti o hai suggerimenti su come migliorare le nostre misure di sicurezza, contattaci."
 
+#. SEO metadata phrase listing locations filtered by a public watchlist.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:78
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:80
 msgid "watchlist.meta.inLocations"
 msgstr "a {locations}"
 
 #. Year postings count on company page
 #. Year postings count on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:563
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:575
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:574
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:586
 msgid "company.page.yearCount"
 msgstr "nell'ultimo anno"
 
@@ -1911,7 +1938,7 @@ msgstr "nell'ultimo anno"
 
 #. Yearly matches label on company card
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:123
+#: src/components/search/company-card.tsx:124
 msgid "search.card.yearCount"
 msgstr "nell'ultimo anno"
 
@@ -1999,16 +2026,16 @@ msgstr "In colloquio"
 msgid "search.tracker.interviewing"
 msgstr "In colloquio"
 
-#. Status option in dropdown: interviewing
-#. js-lingui-explicit-id
-#: src/components/my-jobs/my-job-detail-panel.tsx:37
-msgid "myJobs.statusOption.interviewing"
-msgstr "In colloquio"
-
 #. Interviewing status badge label
 #. js-lingui-explicit-id
 #: src/components/my-jobs/status-badge.tsx:21
 msgid "myJobs.status.interviewing"
+msgstr "In colloquio"
+
+#. Status option in dropdown: interviewing
+#. js-lingui-explicit-id
+#: src/components/my-jobs/my-job-detail-panel.tsx:37
+msgid "myJobs.statusOption.interviewing"
 msgstr "In colloquio"
 
 #. Interviews section heading
@@ -2029,18 +2056,21 @@ msgstr "Link non valido"
 msgid "auth.verify.error.invalidLink"
 msgstr "Link di verifica non valido"
 
+#. FAQ question about whether the product suits company-targeted job seekers.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:48
+#: app/[lang]/(public)/faq/page.tsx:53
 msgid "faq.q.targetedSeeker"
 msgstr "Job Seek fa per me se so già in quali aziende voglio lavorare?"
 
+#. FAQ question about open-source availability.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:84
+#: app/[lang]/(public)/faq/page.tsx:89
 msgid "faq.q.openSource"
 msgstr "Il crawler è open source?"
 
+#. FAQ question about application tracker limits.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:72
+#: app/[lang]/(public)/faq/page.tsx:77
 msgid "faq.q.trackerLimit"
 msgstr "C'è un limite al numero di offerte che posso tracciare?"
 
@@ -2050,16 +2080,16 @@ msgstr "C'è un limite al numero di offerte che posso tracciare?"
 msgid "myJobs.heatmap.month.jan"
 msgstr "Gen"
 
-#. Singular job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:121
-msgid "watchlists.explore.jobSingular"
-msgstr "offerta"
-
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31
 msgid "watchlists.card.jobSingular"
+msgstr "offerta"
+
+#. Singular job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:121
+msgid "watchlists.explore.jobSingular"
 msgstr "offerta"
 
 #. TOC: Job data (CC BY-NC 4.0)
@@ -2104,14 +2134,17 @@ msgstr "Offerte di lavoro"
 msgid "home.features.s2.screenshot.alt"
 msgstr "Tracker delle candidature Job Seek che mostra le offerte salvate e i dettagli dei colloqui"
 
+#. FAQ answer explaining what Job Seek does for targeted job seekers.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:45
+#: app/[lang]/(public)/faq/page.tsx:50
 msgid "faq.a.whatIsJobseek"
 msgstr "Job Seek ti aiuta a monitorare le aziende per cui vuoi davvero lavorare. Crea una watchlist, ricevi avvisi via email quando si aprono nuove posizioni, e monitora le candidature in un unico posto. Le offerte arrivano direttamente dalle pagine carriere delle aziende, così le vedi entro poche ore dalla pubblicazione — tipicamente prima che LinkedIn o Indeed le ripubblichino."
 
+#. JSON-LD page description for the public About page.
+#. SEO description for the public About page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/about/page.tsx:18
-#: app/[lang]/(public)/about/page.tsx:47
+#: app/[lang]/(public)/about/page.tsx:22
+#: app/[lang]/(public)/about/page.tsx:56
 msgid "about.meta.description"
 msgstr "Job Seek ti aiuta a monitorare le aziende per cui vuoi lavorare — watchlist, avvisi via email e offerte direttamente dalle pagine carriere delle aziende. Creato da Colophon Group, un piccolo studio di sviluppatori in Svizzera."
 
@@ -2133,9 +2166,11 @@ msgstr "Job Seek è in fase di sviluppo attivo. Resta aggiornato per le novità!
 msgid "about.p1"
 msgstr "Job Seek è sviluppato da Colophon Group, un piccolo team di sviluppatori con sede in Svizzera. L'abbiamo creato perché eravamo stanchi dello stesso problema che ogni persona in cerca di lavoro conosce: destreggiarsi tra decine di schede del browser, perdere nuove offerte perché un aggregatore era troppo lento, e annegare nel rumore algoritmico ottimizzato per i clic anziché per la rilevanza."
 
+#. JSON-LD page description for the public Privacy Policy page.
+#. SEO description for the public Privacy Policy page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/privacy-policy/page.tsx:18
-#: app/[lang]/(public)/privacy-policy/page.tsx:51
+#: app/[lang]/(public)/privacy-policy/page.tsx:22
+#: app/[lang]/(public)/privacy-policy/page.tsx:60
 msgid "privacy.meta.description"
 msgstr "Informativa sulla privacy di Job Seek — dati personali raccolti, utilizzo, diritti GDPR, politica sui cookie e come richiedere la cancellazione dell'account."
 
@@ -2157,16 +2192,11 @@ msgstr "Watchlist di Job Seek con posizioni selezionate in ingegneria robotica a
 msgid "license.hero.description"
 msgstr "Il codice sorgente di Job Seek è open source sotto licenza MIT. I dati sugli annunci che raccogliamo e arricchiamo sono Creative Commons BY-NC 4.0. Di seguito il riepilogo in linguaggio semplice — si prega di leggere le licenze complete per i termini esatti."
 
+#. Fallback SEO description for a public watchlist with no description or filters.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:86
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:89
 msgid "watchlist.meta.fallback"
 msgstr "Lista lavori di @{owner}"
-
-#. Plural job count in public watchlist
-#. js-lingui-explicit-id
-#: src/components/watchlist/public-watchlist-search.tsx:122
-msgid "watchlists.explore.jobPlural"
-msgstr "offerte"
 
 #. Plural job count on watchlist card
 #. js-lingui-explicit-id
@@ -2174,13 +2204,21 @@ msgstr "offerte"
 msgid "watchlists.card.jobPlural"
 msgstr "offerte"
 
+#. Plural job count in public watchlist
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx:122
+msgid "watchlists.explore.jobPlural"
+msgstr "offerte"
+
+#. SEO title for a company detail page; {name} is the company name.
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/company/[slug]/page.tsx:34
 msgid "company.meta.title"
 msgstr "Lavori presso {name}"
 
+#. SEO metadata phrase listing companies tracked by a public watchlist.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:68
+#: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:69
 msgid "watchlist.meta.jobsAt"
 msgstr "Lavori presso {names}"
 
@@ -2228,14 +2266,14 @@ msgstr "Ultima ora"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:27
-msgid "terms.hero.lastUpdated"
+#: src/components/PrivacyPolicyContent.tsx:27
+msgid "privacy.hero.lastUpdated"
 msgstr "Ultimo aggiornamento:"
 
 #. Last updated date label
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:27
-msgid "privacy.hero.lastUpdated"
+#: src/components/TermsContent.tsx:27
+msgid "terms.hero.lastUpdated"
 msgstr "Ultimo aggiornamento:"
 
 #. Time range option: last week
@@ -2252,7 +2290,7 @@ msgstr "Scopri di più"
 
 #. Section header for seniority suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:730
+#: src/components/search/search-bar.tsx:726
 msgid "search.bar.level"
 msgstr "Livello"
 
@@ -2262,16 +2300,18 @@ msgstr "Livello"
 msgid "search.advanced.level"
 msgstr "Livello"
 
-#. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:17
-#: app/[lang]/(public)/license/page.tsx:51
-msgid "license.meta.title"
-msgstr "Licenza"
-
 #. Link to license page
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:70
 msgid "about.link.license"
+msgstr "Licenza"
+
+#. JSON-LD page name for the public License page.
+#. SEO title for the public License page.
+#. js-lingui-explicit-id
+#: app/[lang]/(public)/license/page.tsx:17
+#: app/[lang]/(public)/license/page.tsx:56
+msgid "license.meta.title"
 msgstr "Licenza"
 
 #. Footer link to license page
@@ -2292,9 +2332,11 @@ msgstr "Licenza di Job Seek"
 msgid "license.hero.eyebrow"
 msgstr "Licenze"
 
+#. JSON-LD page description for the public License page.
+#. SEO description for the public License page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/license/page.tsx:18
-#: app/[lang]/(public)/license/page.tsx:52
+#: app/[lang]/(public)/license/page.tsx:22
+#: app/[lang]/(public)/license/page.tsx:61
 msgid "license.meta.description"
 msgstr "Licenze di Job Seek — il codice sorgente è sotto licenza MIT, le offerte di lavoro sotto CC BY-NC 4.0. Scopri cosa puoi fare con il nostro codice e i nostri dati."
 
@@ -2356,7 +2398,7 @@ msgstr "Luogo"
 
 #. Section header for location suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:842
+#: src/components/search/search-bar.tsx:838
 msgid "search.bar.locations"
 msgstr "Sedi"
 
@@ -2382,7 +2424,7 @@ msgstr "Accedi"
 
 #. Tooltip when user needs to log in to save search
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:122
+#: src/components/search/save-search-button.tsx:125
 msgid "search.saveSearch.tooltipLogin"
 msgstr "Accedi per salvare questa ricerca come watchlist"
 
@@ -2412,7 +2454,7 @@ msgstr "Gestisci abbonamento"
 
 #. Connected accounts section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:453
+#: src/components/settings/AccountSettings.tsx:459
 msgid "settings.account.socials.description"
 msgstr "Gestisci i tuoi account social collegati."
 
@@ -2442,7 +2484,7 @@ msgstr "Segna come rifiutato"
 
 #. Header for the server-side search-results cluster shown when the user types in the location modal search box
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:585
+#: src/components/search/location-search-modal.tsx:594
 msgid "search.locationModal.searchHitsHeader"
 msgstr "Risultati"
 
@@ -2508,8 +2550,9 @@ msgstr "Manca un'azienda? Incolla l'URL della sua pagina carriere e iniziamo a i
 msgid "myJobs.heatmap.day.mon"
 msgstr "Lun"
 
+#. WebApplication JSON-LD feature list item about career-page monitoring.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:142
+#: app/[lang]/layout.tsx:152
 msgid "app.schema.feature.monitor"
 msgstr "Monitorare le pagine carriere delle aziende"
 
@@ -2549,8 +2592,9 @@ msgstr "Sposta ogni posizione da salvata a candidata, in colloquio, offerta rice
 msgid "home.features.s1.p2.title"
 msgstr "Filtri multidimensionali"
 
+#. WebApplication JSON-LD feature list item about supported interface languages.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:144
+#: app/[lang]/layout.tsx:162
 msgid "app.schema.feature.languages"
 msgstr "Supporto multilingue"
 
@@ -2560,22 +2604,22 @@ msgstr "Supporto multilingue"
 #. Warning when Enter is pressed but multiple items match
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:247
-#: src/components/search/location-search-modal.tsx:430
+#: src/components/search/location-search-modal.tsx:439
 #: src/components/search/occupation-modal.tsx:180
 #: src/components/search/technology-modal.tsx:88
 msgid "search.bestGuess.ambiguous"
 msgstr "Risultati multipli — selezionane uno qui sotto"
 
-#. Back link to my jobs
-#. js-lingui-explicit-id
-#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:40
-msgid "myJobs.stats.back"
-msgstr "I miei lavori"
-
 #. Title of the My Jobs page
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:252
 msgid "myJobs.title"
+msgstr "I miei lavori"
+
+#. Back link to my jobs
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx:40
+msgid "myJobs.stats.back"
 msgstr "I miei lavori"
 
 #. My Jobs nav icon tooltip
@@ -2604,7 +2648,7 @@ msgstr "Vuoi contattarci?"
 
 #. New email input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:382
+#: src/components/settings/AccountSettings.tsx:388
 msgid "settings.account.email.label"
 msgstr "Nuova email"
 
@@ -2646,7 +2690,7 @@ msgstr "Nessun settore trovato."
 
 #. Empty state when no jobs match the time range
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:230
+#: src/components/watchlist/watchlist-job-list.tsx:282
 msgid "watchlists.jobList.empty"
 msgstr "Nessuna offerta trovata."
 
@@ -2656,21 +2700,21 @@ msgstr "Nessuna offerta trovata."
 msgid "settings.jobLanguages.modal.noResults"
 msgstr "Nessuna lingua corrisponde alla ricerca."
 
-#. No locations match search in location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:516
-msgid "search.locationModal.noResults"
-msgstr "Nessun luogo corrisponde alla tua ricerca."
-
 #. No locations match search in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:312
 msgid "company.locationModal.noResults"
 msgstr "Nessuna sede corrisponde alla tua ricerca."
 
+#. No locations match search in location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:525
+msgid "search.locationModal.noResults"
+msgstr "Nessun luogo corrisponde alla tua ricerca."
+
 #. No postings found message on company page
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:644
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:657
 msgid "company.page.noResults"
 msgstr "Nessun annuncio corrispondente trovato."
 
@@ -2691,18 +2735,6 @@ msgstr "Nessuna risposta"
 #: src/components/search/zero-results.tsx:14
 msgid "search.zero.heading"
 msgstr "Nessun risultato trovato per \"{query}\""
-
-#. Heading shown when a search surface returns an impossible empty result set
-#. js-lingui-explicit-id
-#: src/components/search/search-unavailable.tsx:9
-msgid "search.unavailable.heading"
-msgstr "Ops, qualcosa è andato storto."
-
-#. Body shown when a search surface returns an impossible empty result set
-#. js-lingui-explicit-id
-#: src/components/search/search-unavailable.tsx:14
-msgid "search.unavailable.body"
-msgstr "Prova ad aggiornare la pagina."
 
 #. No occupations match search in occupation modal
 #. js-lingui-explicit-id
@@ -2746,13 +2778,15 @@ msgstr "Nessuna lista trovata."
 msgid "watchlists.page.empty"
 msgstr "Nessuna lista di osservazione. Creane una per seguire le offerte delle tue aziende preferite."
 
+#. FAQ answer explaining that the application tracker has no hard limit.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:73
+#: app/[lang]/(public)/faq/page.tsx:78
 msgid "faq.a.trackerLimit"
 msgstr "No. Il tracker delle candidature non ha limiti — salva quante offerte vuoi e spostale nella tua pipeline."
 
+#. FAQ answer explaining data privacy, cookies, and account deletion.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:89
+#: app/[lang]/(public)/faq/page.tsx:94
 msgid "faq.a.dataPrivacy"
 msgstr "No. Non vendiamo, affittiamo né condividiamo i tuoi dati a fini di marketing. I cookie sono solo di sessione, senza pubblicità né tracciamento. Puoi eliminare il tuo account e tutti i dati verranno cancellati entro 30 giorni."
 
@@ -2834,8 +2868,8 @@ msgstr "Ok"
 #. Work mode: onsite (in-office)
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:595
-#: src/components/search/search-bar.tsx:810
-#: src/components/search/search-toolbar.tsx:269
+#: src/components/search/search-bar.tsx:806
+#: src/components/search/search-toolbar.tsx:270
 #: src/components/search/work-mode-modal.tsx:26
 msgid "search.workMode.onsite"
 msgstr "In sede"
@@ -2854,7 +2888,7 @@ msgstr "Una pagina al minuto."
 
 #. Username invalid characters hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:284
+#: src/components/settings/AccountSettings.tsx:290
 msgid "settings.account.username.invalidChars"
 msgstr "Solo lettere minuscole, numeri e trattini (non all'inizio/fine)"
 
@@ -2864,15 +2898,21 @@ msgstr "Solo lettere minuscole, numeri e trattini (non all'inizio/fine)"
 msgid "myJobs.interviewType.onsite"
 msgstr "In sede"
 
+#. Heading shown when a search surface returns an impossible empty result set
+#. js-lingui-explicit-id
+#: src/components/search/search-unavailable.tsx:9
+msgid "search.unavailable.heading"
+msgstr "Ops, qualcosa è andato storto."
+
 #. Aria label for the row open-posting button when the posting title is missing
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:158
+#: src/components/watchlist/watchlist-job-list.tsx:199
 msgid "watchlists.jobList.openPosting"
 msgstr "Apri offerta di lavoro"
 
 #. Aria label for opening a job posting from a company card row when the posting title is missing
 #. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:147
+#: src/components/search/company-card.tsx:159
 msgid "search.card.openPosting"
 msgstr "Apri offerta di lavoro"
 
@@ -2882,8 +2922,9 @@ msgstr "Apri offerta di lavoro"
 msgid "common.header.openMenu"
 msgstr "Apri menu principale"
 
+#. Fallback SEO metadata count text for a company with no active jobs.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:46
+#: app/[lang]/(app)/company/[slug]/page.tsx:48
 msgid "company.meta.openPositions"
 msgstr "Posizioni aperte"
 
@@ -2925,13 +2966,13 @@ msgstr "Originale"
 
 #. Fallback label for a country header in the location modal when the city has no parent country in the hierarchy. Rare path.
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:638
+#: src/components/search/location-search-modal.tsx:647
 msgid "search.locationModal.otherCountry"
 msgstr "Altro"
 
 #. Fallback label for a region row in the location modal when the region has no display name (e.g. orphaned cities). Rare path; only shown when a city's parent region in the hierarchy has no localized name.
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:723
+#: src/components/search/location-search-modal.tsx:732
 msgid "search.locationModal.otherRegion"
 msgstr "Altro"
 
@@ -2961,21 +3002,15 @@ msgstr "La nostra posizione sull'automazione"
 
 #. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:21
-msgid "license.toc.overview"
-msgstr "Panoramica"
-
-#. TOC: Overview
-#. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:25
 msgid "indexing.toc.overview"
 msgstr "Panoramica"
 
-#. Table of contents aria label
+#. TOC: Overview
 #. js-lingui-explicit-id
-#: src/components/LicenseContent.tsx:18
-msgid "license.toc.ariaLabel"
-msgstr "Contenuti della pagina"
+#: src/components/LicenseContent.tsx:21
+msgid "license.toc.overview"
+msgstr "Panoramica"
 
 #. Table of contents aria label
 #. js-lingui-explicit-id
@@ -2983,9 +3018,17 @@ msgstr "Contenuti della pagina"
 msgid "indexing.toc.ariaLabel"
 msgstr "Contenuti della pagina"
 
+#. Table of contents aria label
+#. js-lingui-explicit-id
+#: src/components/LicenseContent.tsx:18
+msgid "license.toc.ariaLabel"
+msgstr "Contenuti della pagina"
+
+#. Heading shown on the 404 page
 #. Heading shown on the 404 page
 #. js-lingui-explicit-id
 #: app/[lang]/not-found-content.tsx:12
+#: app/[lang]/not-found.tsx:21
 msgid "notFound.title"
 msgstr "Pagina non trovata"
 
@@ -3071,7 +3114,7 @@ msgstr "Periodo"
 
 #. Delete account section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:511
+#: src/components/settings/AccountSettings.tsx:517
 msgid "settings.account.delete.description"
 msgstr "Elimina definitivamente il tuo account e tutti i dati associati. Questa azione non può essere annullata."
 
@@ -3107,7 +3150,7 @@ msgstr "Inserisci un nome di azienda o un URL."
 
 #. Error when email field is empty
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:350
+#: src/components/settings/AccountSettings.tsx:356
 msgid "settings.account.email.required"
 msgstr "Inserisci un nuovo indirizzo email"
 
@@ -3203,9 +3246,11 @@ msgstr "Privacy"
 msgid "privacy.hero.title"
 msgstr "Privacy su Job Seek"
 
+#. JSON-LD page name for the public Privacy Policy page.
+#. SEO title for the public Privacy Policy page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/privacy-policy/page.tsx:17
-#: app/[lang]/(public)/privacy-policy/page.tsx:50
+#: app/[lang]/(public)/privacy-policy/page.tsx:55
 msgid "privacy.meta.title"
 msgstr "Informativa sulla privacy"
 
@@ -3239,16 +3284,16 @@ msgstr "Pubblico dominio"
 msgid "license.contactCta"
 msgstr "Domande sulle licenze o sull'uso commerciale? Scrivici via email."
 
-#. Terms contact call to action
-#. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:53
-msgid "terms.contact.description"
-msgstr "Domande? Scrivici."
-
 #. Privacy contact call to action
 #. js-lingui-explicit-id
 #: src/components/PrivacyPolicyContent.tsx:65
 msgid "privacy.contact.description"
+msgstr "Domande? Scrivici."
+
+#. Terms contact call to action
+#. js-lingui-explicit-id
+#: src/components/TermsContent.tsx:53
+msgid "terms.contact.description"
 msgstr "Domande? Scrivici."
 
 #. Link to full CC license
@@ -3275,8 +3320,9 @@ msgstr "Leggi l'informativa sulla privacy completa"
 msgid "terms.fullTermsLink"
 msgstr "Leggi i termini di servizio completi"
 
+#. WebApplication JSON-LD feature list item about job alert notifications.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:143
+#: app/[lang]/layout.tsx:157
 msgid "app.schema.feature.alerts"
 msgstr "Avvisi in tempo reale sulle nuove offerte"
 
@@ -3305,21 +3351,21 @@ msgstr "Ridistribuire le proprie modifiche, a condizione di includere l'avviso M
 #. js-lingui-explicit-id
 #: src/components/search/filter-bar.tsx:32
 #: src/components/search/filter-bar.tsx:34
-#: src/components/search/location-pills.tsx:28
-#: src/components/search/location-pills.tsx:30
+#: src/components/search/location-pills.tsx:29
+#: src/components/search/location-pills.tsx:31
 msgid "location.type.region"
 msgstr "Regione"
-
-#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:526
-msgid "search.locationModal.regionsHeader"
-msgstr "Regioni"
 
 #. Header for the macro-region cluster (EU, EMEA, DACH) in company-page location modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:322
 msgid "company.locationModal.regionsHeader"
+msgstr "Regioni"
+
+#. Header for the macro-region cluster (EU, EMEA, DACH) at the top of the location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:535
+msgid "search.locationModal.regionsHeader"
 msgstr "Regioni"
 
 #. Status group heading: rejected
@@ -3334,6 +3380,12 @@ msgstr "Rifiutato"
 msgid "search.tracker.rejected"
 msgstr "Rifiutato"
 
+#. Rejected status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:23
+msgid "myJobs.status.rejected"
+msgstr "Rifiutato"
+
 #. Sankey funnel node label prefix: rejected
 #. js-lingui-explicit-id
 #: src/components/my-jobs/sankey-funnel.tsx:45
@@ -3344,12 +3396,6 @@ msgstr "Rifiutato"
 #. js-lingui-explicit-id
 #: src/components/my-jobs/my-job-detail-panel.tsx:39
 msgid "myJobs.statusOption.rejected"
-msgstr "Rifiutato"
-
-#. Rejected status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:23
-msgid "myJobs.status.rejected"
 msgstr "Rifiutato"
 
 #. Footer license summary text
@@ -3364,8 +3410,8 @@ msgstr "Rilasciato sotto licenza MIT. I dati sugli annunci sono CC BY-NC 4.0."
 #. Work mode: remote (work-from-home)
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:598
-#: src/components/search/search-bar.tsx:813
-#: src/components/search/search-toolbar.tsx:272
+#: src/components/search/search-bar.tsx:809
+#: src/components/search/search-toolbar.tsx:273
 #: src/components/search/work-mode-modal.tsx:28
 msgid "search.workMode.remote"
 msgstr "Remoto"
@@ -3402,11 +3448,11 @@ msgstr "Rimuovi filtro {0}"
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:579
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:589
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:603
-#: src/components/search/search-toolbar.tsx:201
-#: src/components/search/search-toolbar.tsx:220
-#: src/components/search/search-toolbar.tsx:240
-#: src/components/search/search-toolbar.tsx:260
-#: src/components/search/search-toolbar.tsx:283
+#: src/components/search/search-toolbar.tsx:202
+#: src/components/search/search-toolbar.tsx:221
+#: src/components/search/search-toolbar.tsx:241
+#: src/components/search/search-toolbar.tsx:261
+#: src/components/search/search-toolbar.tsx:284
 msgid "search.filters.removeFilter"
 msgstr "Rimuovi filtro {name}"
 
@@ -3432,7 +3478,7 @@ msgstr "Rimuovi filtro {name}"
 #. Aria label for the X button that clears the experience-range filter
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:622
-#: src/components/search/search-toolbar.tsx:318
+#: src/components/search/search-toolbar.tsx:319
 msgid "search.filters.removeExperience"
 msgstr "Rimuovi filtro esperienza"
 
@@ -3459,13 +3505,13 @@ msgstr "Rimuovi parola chiave {0}"
 #. Aria label for remove-keyword X button; {name} is the keyword
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:630
-#: src/components/search/search-toolbar.tsx:335
+#: src/components/search/search-toolbar.tsx:336
 msgid "search.filters.removeKeyword"
 msgstr "Rimuovi parola chiave {name}"
 
 #. Aria label for removing a location pill
 #. js-lingui-explicit-id
-#: src/components/search/location-pills.tsx:199
+#: src/components/search/location-pills.tsx:195
 msgid "search.locations.remove"
 msgstr "Rimuovi località"
 
@@ -3480,7 +3526,7 @@ msgstr "Rimuovi località {0}"
 #. Aria label for remove-location X button; {name} is the location label
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:640
-#: src/components/search/search-toolbar.tsx:356
+#: src/components/search/search-toolbar.tsx:357
 msgid "search.filters.removeLocation"
 msgstr "Rimuovi località {name}"
 
@@ -3488,7 +3534,7 @@ msgstr "Rimuovi località {name}"
 #. Aria label for the X button that clears the salary-range filter
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx:613
-#: src/components/search/search-toolbar.tsx:301
+#: src/components/search/search-toolbar.tsx:302
 msgid "search.filters.removeSalary"
 msgstr "Rimuovi filtro stipendio"
 
@@ -3500,7 +3546,7 @@ msgstr "Rimuovi filtro stipendio"
 
 #. Synthetic dropdown row that lets the user request a company that's not in the catalog
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:934
+#: src/components/search/search-bar.tsx:930
 msgid "search.bar.request"
 msgstr "Richiedi \\\"{trimmedInput}\\\""
 
@@ -3590,7 +3636,7 @@ msgstr "Ruolo"
 
 #. Section header for occupation suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:695
+#: src/components/search/search-bar.tsx:691
 msgid "search.bar.roles"
 msgstr "Ruoli"
 
@@ -3644,7 +3690,7 @@ msgstr "Salva qualsiasi ricerca come watchlist e ricevi avvisi via email quando 
 
 #. Save job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:191
+#: src/components/watchlist/watchlist-job-list.tsx:232
 msgid "watchlists.jobList.save"
 msgstr "Salva offerta"
 
@@ -3668,7 +3714,7 @@ msgstr "Salva offerte e monitora le tue candidature per vedere le statistiche qu
 
 #. Button label to save current search as a watchlist
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:110
+#: src/components/search/save-search-button.tsx:113
 msgid "search.saveSearch.label"
 msgstr "Salva questa ricerca"
 
@@ -3676,6 +3722,12 @@ msgstr "Salva questa ricerca"
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/my-jobs/my-jobs-page.tsx:28
 msgid "myJobs.group.saved"
+msgstr "Salvato"
+
+#. Saved status badge label
+#. js-lingui-explicit-id
+#: src/components/my-jobs/status-badge.tsx:19
+msgid "myJobs.status.saved"
 msgstr "Salvato"
 
 #. Sankey funnel node: saved jobs
@@ -3690,21 +3742,15 @@ msgstr "Salvato"
 msgid "myJobs.statusOption.saved"
 msgstr "Salvato"
 
-#. Saved status badge label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/status-badge.tsx:19
-msgid "myJobs.status.saved"
-msgstr "Salvato"
-
 #. Username save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:320
+#: src/components/settings/AccountSettings.tsx:326
 msgid "settings.account.username.saving"
 msgstr "Salvataggio..."
 
 #. Email save button while loading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:392
+#: src/components/settings/AccountSettings.tsx:398
 msgid "settings.account.email.saving"
 msgstr "Salvataggio…"
 
@@ -3723,7 +3769,7 @@ msgstr "Cerca tra migliaia di aziende prese direttamente dalle loro pagine carri
 #. Placeholder for search bar when on company page
 #. js-lingui-explicit-id
 #. placeholder {0}: company.name
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:161
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:169
 msgid "company.page.searchPlaceholder"
 msgstr "Cerca in {0}..."
 
@@ -3741,12 +3787,13 @@ msgstr "Cerca aziende..."
 
 #. Option to search by title keyword in dropdown
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:683
+#: src/components/search/search-bar.tsx:679
 msgid "search.bar.keyword"
 msgstr "Cerca \"{trimmedInput}\" nei titoli di lavoro"
 
+#. SEO description for the Explore jobs page.
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/explore/page.tsx:33
+#: app/[lang]/(app)/explore/page.tsx:44
 msgid "explore.meta.description"
 msgstr "Cerca lavori in migliaia di aziende, scansionati direttamente dalle pagine carriere. Filtra per livello, stack tecnologico, stipendio e località — crea watchlist e ricevi notifiche."
 
@@ -3756,17 +3803,17 @@ msgstr "Cerca lavori in migliaia di aziende, scansionati direttamente dalle pagi
 msgid "settings.jobLanguages.modal.searchPlaceholder"
 msgstr "Cerca lingue…"
 
-#. Placeholder for search input in global location modal
-#. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:495
-msgid "search.locationModal.searchPlaceholder"
-msgstr "Cerca luoghi..."
-
 #. Placeholder for search input in all-locations modal
 #. js-lingui-explicit-id
 #: src/components/search/location-modal.tsx:291
 msgid "company.locationModal.searchPlaceholder"
 msgstr "Cerca sedi…"
+
+#. Placeholder for search input in global location modal
+#. js-lingui-explicit-id
+#: src/components/search/location-search-modal.tsx:504
+msgid "search.locationModal.searchPlaceholder"
+msgstr "Cerca luoghi..."
 
 #. Back-to-search link on company page header
 #. js-lingui-explicit-id
@@ -3794,7 +3841,7 @@ msgstr "Cerca con precisione"
 
 #. Placeholder for the main search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:608
+#: src/components/search/search-bar.tsx:604
 msgid "search.bar.placeholder"
 msgstr "Cerca…"
 
@@ -3812,7 +3859,7 @@ msgstr "Seleziona livello"
 
 #. Title for the global location selection modal
 #. js-lingui-explicit-id
-#: src/components/search/location-search-modal.tsx:472
+#: src/components/search/location-search-modal.tsx:481
 msgid "search.locationModal.title"
 msgstr "Seleziona luogo"
 
@@ -3852,16 +3899,16 @@ msgstr "Invia link"
 msgid "settings.account.password.send"
 msgstr "Invia il link"
 
-#. Resend button while sending
-#. js-lingui-explicit-id
-#: app/[lang]/(auth)/check-email/page.tsx:96
-msgid "auth.verify.resending"
-msgstr "Invio in corso..."
-
 #. Send reset link button while loading
 #. js-lingui-explicit-id
 #: app/[lang]/(auth)/forgot-password/page.tsx:103
 msgid "auth.forgotPassword.button.loading"
+msgstr "Invio in corso..."
+
+#. Resend button while sending
+#. js-lingui-explicit-id
+#: app/[lang]/(auth)/check-email/page.tsx:96
+msgid "auth.verify.resending"
 msgstr "Invio in corso..."
 
 #. Reset password button while loading
@@ -4052,7 +4099,7 @@ msgstr "Prima la sitemap."
 
 #. Skip to main content link for keyboard users
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/layout.tsx:25
+#: src/components/SkipToContentLink.tsx:11
 msgid "common.a11y.skipToContent"
 msgstr "Vai al contenuto"
 
@@ -4202,7 +4249,7 @@ msgstr "Tecnico"
 
 #. Section header for technology suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:765
+#: src/components/search/search-bar.tsx:761
 msgid "search.bar.technologies"
 msgstr "Tecnologie"
 
@@ -4248,9 +4295,11 @@ msgstr "Termini di servizio"
 msgid "common.footer.termsLink"
 msgstr "Termini"
 
+#. JSON-LD page name for the public Terms of Service page.
+#. SEO title for the public Terms of Service page.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/terms/page.tsx:17
-#: app/[lang]/(public)/terms/page.tsx:50
+#: app/[lang]/(public)/terms/page.tsx:55
 msgid "terms.meta.title"
 msgstr "Termini di servizio"
 
@@ -4260,15 +4309,17 @@ msgstr "Termini di servizio"
 msgid "terms.hero.title"
 msgstr "Termini di servizio"
 
+#. JSON-LD page description for the public Terms of Service page.
+#. SEO description for the public Terms of Service page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/terms/page.tsx:18
-#: app/[lang]/(public)/terms/page.tsx:51
+#: app/[lang]/(public)/terms/page.tsx:22
+#: app/[lang]/(public)/terms/page.tsx:60
 msgid "terms.meta.description"
 msgstr "Termini di servizio di Job Seek — regole d'uso, proprietà intellettuale, responsabilità dell'account, limitazione di responsabilità e legge applicabile."
 
 #. Body text shown when a company page slug does not exist
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/page.tsx:94
+#: app/[lang]/(app)/company/[slug]/page.tsx:102
 msgid "company.notFound.message"
 msgstr "L'azienda che stai cercando non esiste o è stata rimossa."
 
@@ -4284,13 +4335,15 @@ msgstr "L'azienda che stai cercando non esiste o è stata rimossa."
 msgid "about.transparency.p1"
 msgstr "Il codice del crawler è open source, così chiunque può verificare come raccogliamo i dati. Rispettiamo robots.txt, onoriamo gli header TDM-Reservation e ci limitiamo a una richiesta per sito al minuto. Ogni link in uscita include utm_source=jobseek, così i datori di lavoro sanno da dove arriva il traffico."
 
+#. FAQ answer explaining crawler discovery and refresh frequency.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:53
+#: app/[lang]/(public)/faq/page.tsx:58
 msgid "faq.a.howOftenUpdated"
 msgstr "Il crawler scopre nuove offerte con un ciclo orario e aggiorna i dettagli quotidianamente. La maggior parte delle posizioni appare entro poche ore dalla pubblicazione sulla pagina carriere di un'azienda."
 
+#. FAQ answer listing interface languages and posting-language filtering.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:93
+#: app/[lang]/(public)/faq/page.tsx:98
 msgid "faq.a.languages"
 msgstr "L'interfaccia è disponibile in inglese, tedesco, francese e italiano. Puoi anche filtrare le offerte di lavoro per la lingua in cui sono state scritte."
 
@@ -4308,14 +4361,14 @@ msgstr "Il servizio è fornito così com'è, senza garanzie."
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: src/components/TermsContent.tsx:39
-msgid "terms.short.title"
+#: src/components/PrivacyPolicyContent.tsx:39
+msgid "privacy.short.title"
 msgstr "In breve"
 
 #. Short version section title
 #. js-lingui-explicit-id
-#: src/components/PrivacyPolicyContent.tsx:39
-msgid "privacy.short.title"
+#: src/components/TermsContent.tsx:39
+msgid "terms.short.title"
 msgstr "In breve"
 
 #. Theme settings section heading
@@ -4338,7 +4391,7 @@ msgstr "Questo sito utilizza i cookie solo per l'autenticazione e le funzionalit
 
 #. Username is reserved hint
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:286
+#: src/components/settings/AccountSettings.tsx:292
 msgid "settings.account.username.reserved"
 msgstr "Questo nome utente è riservato"
 
@@ -4356,7 +4409,7 @@ msgstr "Questa lista di osservazione e tutte le sue impostazioni verranno elimin
 
 #. Date divider label for today
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:71
+#: src/components/watchlist/watchlist-job-list.tsx:75
 msgid "watchlists.jobList.today"
 msgstr "Oggi"
 
@@ -4366,9 +4419,11 @@ msgstr "Oggi"
 msgid "home.hero.title"
 msgstr "Monitora le aziende per cui vuoi davvero lavorare."
 
+#. JSON-LD page name for the public homepage.
+#. SEO title for the public homepage.
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/page.tsx:20
-#: app/[lang]/(public)/page.tsx:52
+#: app/[lang]/(public)/page.tsx:57
 msgid "home.meta.title"
 msgstr "Monitora le aziende per cui vuoi lavorare — Job Seek"
 
@@ -4395,6 +4450,12 @@ msgstr "Trasparente per impostazione predefinita"
 #: app/[lang]/error.tsx:23
 msgid "error.retryButton"
 msgstr "Riprova"
+
+#. Body shown when a search surface returns an impossible empty result set
+#. js-lingui-explicit-id
+#: src/components/search/search-unavailable.tsx:14
+msgid "search.unavailable.body"
+msgstr "Prova ad aggiornare la pagina."
 
 #. Add employment type filter
 #. js-lingui-explicit-id
@@ -4438,14 +4499,15 @@ msgstr "Watchlist illimitate"
 msgid "home.pricing.pro.description"
 msgstr "Watchlist illimitate con avvisi via email così non perdi mai un'apertura."
 
+#. WebApplication JSON-LD offer description for the Pro plan.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:138
+#: app/[lang]/layout.tsx:144
 msgid "app.schema.offer.pro"
 msgstr "Watchlist illimitate, avvisi email sui nuovi risultati"
 
 #. Unsave job aria label
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:190
+#: src/components/watchlist/watchlist-job-list.tsx:231
 msgid "watchlists.jobList.unsave"
 msgstr "Rimuovi offerta"
 
@@ -4457,19 +4519,19 @@ msgstr "Rimuovi offerta"
 
 #. Email save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:393
+#: src/components/settings/AccountSettings.tsx:399
 msgid "settings.account.email.save"
 msgstr "Aggiorna email"
 
 #. Change email section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:373
+#: src/components/settings/AccountSettings.tsx:379
 msgid "settings.account.email.description"
 msgstr "Aggiorna l'indirizzo email associato al tuo account."
 
 #. Username save button
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:321
+#: src/components/settings/AccountSettings.tsx:327
 msgid "settings.account.username.save"
 msgstr "Aggiorna nome utente"
 
@@ -4497,8 +4559,9 @@ msgstr "Passa a Pro"
 msgid "settings.billing.upgrading"
 msgstr "Aggiornamento…"
 
+#. FAQ answer explaining how to request a missing company from the Explore page.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:61
+#: app/[lang]/(public)/faq/page.tsx:66
 msgid "faq.a.requestCompany"
 msgstr "Usa il modulo di richiesta nella pagina Esplora — incolla l'URL di una pagina carriere o il nome dell'azienda e inizieremo l'indicizzazione. Puoi seguire i progressi tramite il numero di issue che ti restituiamo."
 
@@ -4510,25 +4573,25 @@ msgstr "utente"
 
 #. Username section heading
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:298
+#: src/components/settings/AccountSettings.tsx:304
 msgid "settings.account.username.title"
 msgstr "Nome utente"
 
 #. Username input label
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:310
+#: src/components/settings/AccountSettings.tsx:316
 msgid "settings.account.username.label"
 msgstr "Nome utente"
 
 #. Username updated success message
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:273
+#: src/components/settings/AccountSettings.tsx:279
 msgid "settings.account.username.success"
 msgstr "Nome utente aggiornato."
 
 #. Success message after email change request
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:362
+#: src/components/settings/AccountSettings.tsx:368
 msgid "settings.account.email.success"
 msgstr "Email di verifica inviata. Controlla la tua casella di posta. Potrebbe volerci qualche minuto per l'arrivo."
 
@@ -4616,8 +4679,9 @@ msgstr "Liste di osservazione"
 msgid "home.features.s1.p3.title"
 msgstr "Watchlist e avvisi"
 
+#. WebApplication JSON-LD feature list item about watchlists and application tracking.
 #. js-lingui-explicit-id
-#: app/[lang]/layout.tsx:145
+#: app/[lang]/layout.tsx:167
 msgid "app.schema.feature.watchlists"
 msgstr "Watchlist e tracciamento delle candidature"
 
@@ -4645,8 +4709,9 @@ msgstr "Raccogliamo solo il necessario, non vendiamo i tuoi dati e puoi cancella
 msgid "privacy.short.r2"
 msgstr "Non vendiamo, affittiamo o condividiamo i tuoi dati per scopi di marketing."
 
+#. FAQ answer explaining direct career-page indexing and no recruiter spam.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:57
+#: app/[lang]/(public)/faq/page.tsx:62
 msgid "faq.a.differentiation"
 msgstr "Indicizziamo le pagine carriere delle aziende direttamente, non feed di terze parti. Niente spam dei recruiter, nessun annuncio fantasma ripubblicato, e ricontrolliamo le aziende frequentemente — così la maggior parte delle posizioni appare qui entro poche ore dalla pubblicazione. Siamo costruiti per chi sa già in quali aziende vuole lavorare, non per ricerche generiche del tipo «trovami un lavoro qualsiasi»."
 
@@ -4686,8 +4751,9 @@ msgstr "Abbiamo notato che questa offerta è stata aggiunta di recente. Alcuni d
 msgid "indexing.automation.body"
 msgstr "Ci opponiamo a delegare le decisioni di assunzione o di ricerca lavoro ad automazioni opache — sia dal lato dei datori di lavoro che dei candidati. Ogni link in uscita che condividiamo include <0>utm_source=jobseek</0> affinché i recruiter riconoscano il traffico, e monitoriamo continuamente i pattern di utilizzo applicando frizioni per scoraggiare le candidature automatizzate."
 
+#. FAQ answer summarizing crawler politeness, rate limits, and policy compliance.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:77
+#: app/[lang]/(public)/faq/page.tsx:82
 msgid "faq.a.crawlingPolicy"
 msgstr "Rispettiamo robots.txt e gli header TDM-Reservation, limitiamo le richieste a una per sito al minuto e utilizziamo il backoff esponenziale. Tutte le richieste si identificano tramite User-Agent. Consulta la nostra pagina sull'indicizzazione per tutti i dettagli."
 
@@ -4717,7 +4783,7 @@ msgstr "Utilizziamo pochi servizi terzi per accesso, hosting e archiviazione —
 
 #. Secondary line under the Request <query> dropdown row
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:941
+#: src/components/search/search-bar.tsx:937
 msgid "search.bar.request.subtext"
 msgstr "Inizieremo a monitorarla"
 
@@ -4739,23 +4805,27 @@ msgstr "Mer"
 msgid "auth.signIn.subtitle"
 msgstr "Bentornato"
 
+#. FAQ question defining a watchlist.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:68
+#: app/[lang]/(public)/faq/page.tsx:73
 msgid "faq.q.whatIsWatchlist"
 msgstr "Cos'è una watchlist?"
 
+#. FAQ question asking for a short product definition.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:44
+#: app/[lang]/(public)/faq/page.tsx:49
 msgid "faq.q.whatIsJobseek"
 msgstr "Cos'è Job Seek?"
 
+#. FAQ question comparing Job Seek with general job boards.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:56
+#: app/[lang]/(public)/faq/page.tsx:61
 msgid "faq.q.differentiation"
 msgstr "Cosa rende Job Seek diverso da LinkedIn o Indeed?"
 
+#. FAQ question comparing the Free and Pro plans.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:64
+#: app/[lang]/(public)/faq/page.tsx:69
 msgid "faq.q.freeVsPro"
 msgstr "Qual è la differenza tra Gratuito e Pro?"
 
@@ -4765,8 +4835,9 @@ msgstr "Qual è la differenza tra Gratuito e Pro?"
 msgid "app.home.request.heading"
 msgstr "Quale azienda dobbiamo monitorare?"
 
+#. FAQ question about supported interface and job-posting languages.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:92
+#: app/[lang]/(public)/faq/page.tsx:97
 msgid "faq.q.languages"
 msgstr "Quali lingue supporta Jobseek?"
 
@@ -4784,7 +4855,7 @@ msgstr "Modalità di lavoro"
 
 #. Section header for work-mode (onsite/hybrid/remote) suggestions in search bar
 #. js-lingui-explicit-id
-#: src/components/search/search-bar.tsx:800
+#: src/components/search/search-bar.tsx:796
 msgid "search.bar.workMode"
 msgstr "Modalità di lavoro"
 
@@ -4822,24 +4893,27 @@ msgstr "Annuale"
 msgid "search.experienceModal.years"
 msgstr "anni"
 
+#. FAQ answer explaining the company watchlist use case.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:49
+#: app/[lang]/(public)/faq/page.tsx:54
 msgid "faq.a.targetedSeeker"
 msgstr "Sì — è esattamente il caso d'uso per cui l'abbiamo costruito. Aggiungi le aziende che ti interessano a una watchlist, imposta i tuoi filtri (ruolo, località, seniority, stipendio) e Job Seek monitora le loro pagine carriere e ti avvisa nel momento in cui appaiono nuove posizioni che corrispondono. Non devi più controllare ogni sito a mano né combattere contro l'algoritmo di LinkedIn."
 
+#. FAQ answer explaining how companies can opt out of indexing.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:81
+#: app/[lang]/(public)/faq/page.tsx:86
 msgid "faq.a.optOut"
 msgstr "Sì. Inviaci un'email e smetteremo immediatamente di analizzare il tuo sito carriere e rimuoveremo le tue offerte dall'indice."
 
+#. FAQ answer explaining crawler source availability and data licensing.
 #. js-lingui-explicit-id
-#: app/[lang]/(public)/faq/page.tsx:85
+#: app/[lang]/(public)/faq/page.tsx:90
 msgid "faq.a.openSource"
 msgstr "Sì. Il crawler e la pipeline di estrazione sono completamente open source su GitHub. Il codice dell'applicazione è sotto licenza MIT; i dati sulle offerte sono CC BY-NC 4.0."
 
 #. Date divider label for yesterday
 #. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-job-list.tsx:72
+#: src/components/watchlist/watchlist-job-list.tsx:76
 msgid "watchlists.jobList.yesterday"
 msgstr "Ieri"
 
@@ -4931,7 +5005,7 @@ msgstr "Hai raggiunto il limite delle tue liste di osservazione. Effettua l'upgr
 
 #. Reason shown in upgrade modal when saving a search hits the watchlist limit
 #. js-lingui-explicit-id
-#: src/components/search/save-search-button.tsx:93
+#: src/components/search/save-search-button.tsx:96
 msgid "upgrade.reason.saveSearch"
 msgstr "Hai raggiunto il limite delle tue liste di osservazione. Effettua l'upgrade per salvare altre ricerche."
 
@@ -4961,6 +5035,6 @@ msgstr "I tuoi diritti"
 
 #. Username section description
 #. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:301
+#: src/components/settings/AccountSettings.tsx:307
 msgid "settings.account.username.description"
 msgstr "Il tuo identificativo unico utilizzato nell'URL del tuo profilo pubblico."

--- a/scripts/check-i18n-comments.mjs
+++ b/scripts/check-i18n-comments.mjs
@@ -1,0 +1,170 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, extname, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const require = createRequire(import.meta.url);
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const defaultRepoRoot = resolve(scriptDir, "..");
+const dependencyRoot = resolve(process.argv[2] ?? defaultRepoRoot);
+const ts = require(
+  require.resolve("typescript", {
+    paths: [join(dependencyRoot, "apps/web"), dependencyRoot],
+  }),
+);
+
+const SOURCE_DIRS = ["apps/web/app", "apps/web/src"];
+const SOURCE_EXTENSIONS = new Set([".ts", ".tsx", ".js", ".jsx"]);
+
+function normalizePath(path) {
+  return path.split(sep).join("/");
+}
+
+function isTestPath(path) {
+  const normalized = normalizePath(path);
+  return (
+    normalized.includes("/__tests__/") ||
+    /\.(test|spec)\.[cm]?[jt]sx?$/.test(normalized)
+  );
+}
+
+function listSourceFiles(repoRoot) {
+  const files = [];
+
+  function walk(dir) {
+    if (!existsSync(dir)) {
+      return;
+    }
+
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name !== "node_modules" && entry.name !== ".next") {
+          walk(path);
+        }
+        continue;
+      }
+
+      if (SOURCE_EXTENSIONS.has(extname(entry.name)) && !isTestPath(path)) {
+        files.push(path);
+      }
+    }
+  }
+
+  for (const sourceDir of SOURCE_DIRS) {
+    walk(join(repoRoot, sourceDir));
+  }
+
+  return files.sort();
+}
+
+function getPropertyName(property) {
+  if (
+    ts.isPropertyAssignment(property) ||
+    ts.isShorthandPropertyAssignment(property) ||
+    ts.isMethodDeclaration(property)
+  ) {
+    const name = property.name;
+    if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+      return name.text;
+    }
+  }
+
+  return null;
+}
+
+function hasProperty(objectLiteral, propertyName) {
+  return objectLiteral.properties.some((property) => getPropertyName(property) === propertyName);
+}
+
+function getStringProperty(objectLiteral, propertyName) {
+  for (const property of objectLiteral.properties) {
+    if (!ts.isPropertyAssignment(property) || getPropertyName(property) !== propertyName) {
+      continue;
+    }
+
+    const initializer = property.initializer;
+    if (ts.isStringLiteral(initializer) || ts.isNoSubstitutionTemplateLiteral(initializer)) {
+      return initializer.text;
+    }
+  }
+
+  return null;
+}
+
+function isI18nUnderscoreCall(node) {
+  if (!ts.isCallExpression(node) || !ts.isPropertyAccessExpression(node.expression)) {
+    return false;
+  }
+
+  return (
+    node.expression.name.text === "_" &&
+    ts.isIdentifier(node.expression.expression) &&
+    node.expression.expression.text === "i18n"
+  );
+}
+
+function createSourceFile(filePath, sourceText) {
+  const scriptKind = filePath.endsWith("x") ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
+  return ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true, scriptKind);
+}
+
+export function findI18nCommentViolationsInSource(sourceText, filePath) {
+  const sourceFile = createSourceFile(filePath, sourceText);
+  const violations = [];
+
+  function visit(node) {
+    if (isI18nUnderscoreCall(node)) {
+      const [descriptor] = node.arguments;
+      if (descriptor && ts.isObjectLiteralExpression(descriptor) && hasProperty(descriptor, "id")) {
+        if (!hasProperty(descriptor, "comment")) {
+          const location = sourceFile.getLineAndCharacterOfPosition(descriptor.getStart(sourceFile));
+          violations.push({
+            file: filePath,
+            line: location.line + 1,
+            column: location.character + 1,
+            id: getStringProperty(descriptor, "id"),
+            message: getStringProperty(descriptor, "message"),
+          });
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return violations;
+}
+
+export function findI18nCommentViolations(repoRoot = process.cwd()) {
+  const absoluteRoot = resolve(repoRoot);
+  return listSourceFiles(absoluteRoot).flatMap((filePath) => {
+    const sourceText = readFileSync(filePath, "utf8");
+    const relativePath = normalizePath(relative(absoluteRoot, filePath));
+    return findI18nCommentViolationsInSource(sourceText, relativePath);
+  });
+}
+
+function formatViolation(violation) {
+  const suffix = violation.id ? ` (${violation.id})` : "";
+  return `${violation.file}:${violation.line}:${violation.column}${suffix}`;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const repoRoot = process.argv[2] ?? defaultRepoRoot;
+  const violations = findI18nCommentViolations(repoRoot);
+
+  if (violations.length > 0) {
+    console.error("");
+    console.error(`❌ i18n._ descriptors missing translator comments (${violations.length}):`);
+    for (const violation of violations) {
+      console.error(`   ${formatViolation(violation)}`);
+    }
+    console.error("");
+    console.error("Add a `comment` field that explains where the string appears or how to translate it.");
+    process.exit(1);
+  }
+
+  console.log("i18n-comments: all i18n._ descriptors include translator comments ✓");
+}

--- a/scripts/check-i18n-comments.test.mjs
+++ b/scripts/check-i18n-comments.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { findI18nCommentViolationsInSource } from "./check-i18n-comments.mjs";
+
+test("flags i18n._ descriptors with ids but no translator comment", () => {
+  const violations = findI18nCommentViolationsInSource(
+    `
+      const title = i18n._({
+        id: "home.meta.title",
+        message: "Track companies",
+      });
+    `,
+    "apps/web/app/[lang]/page.tsx",
+  );
+
+  assert.deepEqual(violations, [
+    {
+      file: "apps/web/app/[lang]/page.tsx",
+      line: 2,
+      column: 28,
+      id: "home.meta.title",
+      message: "Track companies",
+    },
+  ]);
+});
+
+test("allows i18n._ descriptors with translator comments", () => {
+  const violations = findI18nCommentViolationsInSource(
+    `
+      const title = i18n._({
+        id: "home.meta.title",
+        comment: "Metadata title for the public landing page.",
+        message: "Track companies",
+      });
+    `,
+    "apps/web/app/[lang]/page.tsx",
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test("ignores non-i18n descriptor objects and non-descriptor overloads", () => {
+  const violations = findI18nCommentViolationsInSource(
+    `
+      const descriptor = { id: "plain.object", message: "Plain object" };
+      const macro = t({ id: "macro.title", message: "Macro title" });
+      const raw = i18n._("common.raw");
+    `,
+    "apps/web/src/example.ts",
+  );
+
+  assert.deepEqual(violations, []);
+});
+
+test("reports each missing comment in multiline JSON-LD arrays", () => {
+  const violations = findI18nCommentViolationsInSource(
+    `
+      const features = [
+        i18n._({ id: "app.schema.feature.monitor", message: "Monitor company career pages" }),
+        i18n._({
+          id: "app.schema.feature.alerts",
+          message: "Real-time job posting alerts",
+        }),
+      ];
+    `,
+    "apps/web/app/[lang]/layout.tsx",
+  );
+
+  assert.deepEqual(
+    violations.map(({ file, line, column, id }) => ({ file, line, column, id })),
+    [
+      {
+        file: "apps/web/app/[lang]/layout.tsx",
+        line: 3,
+        column: 16,
+        id: "app.schema.feature.monitor",
+      },
+      {
+        file: "apps/web/app/[lang]/layout.tsx",
+        line: 4,
+        column: 16,
+        id: "app.schema.feature.alerts",
+      },
+    ],
+  );
+});

--- a/scripts/check-i18n-coverage.sh
+++ b/scripts/check-i18n-coverage.sh
@@ -10,7 +10,12 @@
 #      `msgstr ""` in any of de/fr/it. The PO file header is
 #      `msgid ""\nmsgstr ""` and is excluded by the `[^"]` filter.
 #
-#   2. **Stale catalog** — runs `pnpm --dir apps/web extract` in a
+#   2. **Missing translator comments** — every `i18n._({ id, ... })`
+#      descriptor under `apps/web/app` and `apps/web/src` must include
+#      a `comment` field, matching the project convention documented
+#      in `apps/web/docs/i18n.md`.
+#
+#   3. **Stale catalog** — runs `pnpm --dir apps/web extract` in a
 #      sandboxed temp copy of the catalogs and diffs against the
 #      committed ones. Any non-trivial diff means the user added or
 #      removed a macro call without running extract, so the catalogs
@@ -80,7 +85,26 @@ for locale in "${NON_SOURCE_LOCALES[@]}"; do
   fi
 done
 
-# ── Check 2: catalogs stale vs source (#3031) ───────────────────────
+# ── Check 2: translator comments on imperative i18n calls ───────────
+#
+# Lingui extracts `i18n._({ id, message })` descriptors from metadata and
+# JSON-LD code, but those sites used to miss the translator context that
+# `<Trans>` / `t({ ... })` call sites already carry. Use the TypeScript
+# parser instead of grep so multi-line object literals are checked
+# correctly. This check is skipped only in dependency-stripped local
+# sandboxes, mirroring the stale-catalog check below.
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "i18n-coverage: node not found — skipping i18n comment check"
+elif [[ ! -d "$REPO_ROOT/apps/web/node_modules" ]]; then
+  echo "i18n-coverage: apps/web/node_modules missing — skipping i18n comment check"
+elif [[ ! -d "$REPO_ROOT/node_modules" ]]; then
+  echo "i18n-coverage: repo node_modules missing — skipping i18n comment check"
+elif ! node "$REPO_ROOT/scripts/check-i18n-comments.mjs" "$REPO_ROOT"; then
+  failed=1
+fi
+
+# ── Check 3: catalogs stale vs source (#3031) ───────────────────────
 #
 # Run `pnpm extract` in a worktree-local sandbox so we don't mutate the
 # committed catalogs, then diff against them on normalized content. The


### PR DESCRIPTION
Closes #3139.\n\n## Summary\n- add translator comments to the remaining i18n._ descriptors used by metadata, JSON-LD, and FAQ content\n- refresh Lingui catalogs so the comments are visible in the .po files\n- add an AST-based i18n comment guard to scripts/check-i18n-coverage.sh with node:test coverage\n\n## Reproduction\n- reproduced on current main with the new guard before the fix: 72 i18n._ descriptors under apps/web/app lacked comment fields\n- production probing is not applicable; this is translator metadata/catalog hygiene with no runtime data path\n\n## Validation\n- node --test scripts/check-i18n-comments.test.mjs\n- node scripts/check-i18n-comments.mjs\n- pnpm --dir apps/web extract\n- bash scripts/check-i18n-coverage.sh\n- pnpm --dir apps/web lint\n- pnpm --filter @jobseek/web typecheck\n- git diff --check