### PR TITLE
Fix form error accessibility

### DIFF
--- a/apps/web/app/[lang]/(app)/companies/request/company-request-page-form.tsx
+++ b/apps/web/app/[lang]/(app)/companies/request/company-request-page-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActionState, useEffect, useRef, useState, useTransition } from "react";
+import { useActionState, useEffect, useId, useRef, useState, useTransition } from "react";
 import { useLingui } from "@lingui/react";
 import { msg } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
@@ -76,6 +76,7 @@ export function CompanyRequestPageForm({
   }, [state]);
 
   const errorMessage = state?.errorCode ? t(errorMessages[state.errorCode]) : "";
+  const errorId = useId();
 
   const initialValue = pickDefaultValue(defaultName, defaultWebsite);
 
@@ -122,6 +123,8 @@ export function CompanyRequestPageForm({
             }))}
             className="w-full rounded-md border border-divider bg-background px-3 py-1.5 text-sm text-foreground outline-none focus:border-primary"
             disabled={isPending}
+            aria-invalid={errorMessage ? true : undefined}
+            aria-describedby={errorMessage ? errorId : undefined}
           />
         </div>
         <Button type="submit" disabled={isPending} size="sm">
@@ -141,7 +144,7 @@ export function CompanyRequestPageForm({
             }}
           />
         )}
-        <ErrorAlert message={errorMessage} />
+        <ErrorAlert id={errorId} message={errorMessage} focusOnRender />
       </div>
     </div>
   );

--- a/apps/web/app/[lang]/(app)/explore/company-request-form.tsx
+++ b/apps/web/app/[lang]/(app)/explore/company-request-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActionState, useEffect, useRef, useState, useTransition } from "react";
+import { useActionState, useEffect, useId, useRef, useState, useTransition } from "react";
 import { useLingui } from "@lingui/react";
 import { msg } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
@@ -38,6 +38,7 @@ export function CompanyRequestForm({ locale }: { locale: string }) {
   }, [state]);
 
   const errorMessage = state?.errorCode ? t(errorMessages[state.errorCode]) : "";
+  const errorId = useId();
 
   function handleSubmit(formData: FormData) {
     setAgentRun(null);
@@ -84,6 +85,8 @@ export function CompanyRequestForm({ locale }: { locale: string }) {
             }))}
             className="w-full rounded-md border border-divider bg-background px-3 py-1.5 text-sm text-foreground outline-none focus:border-primary"
             disabled={isPending}
+            aria-invalid={errorMessage ? true : undefined}
+            aria-describedby={errorMessage ? errorId : undefined}
           />
         </div>
         <Button type="submit" disabled={isPending} size="sm">
@@ -103,7 +106,7 @@ export function CompanyRequestForm({ locale }: { locale: string }) {
             }}
           />
         )}
-        <ErrorAlert message={errorMessage} />
+        <ErrorAlert id={errorId} message={errorMessage} focusOnRender />
       </div>
     </div>
   );

--- a/apps/web/app/[lang]/(app)/progress/company-request-form.tsx
+++ b/apps/web/app/[lang]/(app)/progress/company-request-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActionState, useEffect, useRef, useState, useTransition } from "react";
+import { useActionState, useEffect, useId, useRef, useState, useTransition } from "react";
 import { useLingui } from "@lingui/react";
 import { msg } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
@@ -38,6 +38,7 @@ export function CompanyRequestForm({ locale }: { locale: string }) {
   }, [state]);
 
   const errorMessage = state?.errorCode ? t(errorMessages[state.errorCode]) : "";
+  const errorId = useId();
 
   function handleSubmit(formData: FormData) {
     setAgentRun(null);
@@ -84,6 +85,8 @@ export function CompanyRequestForm({ locale }: { locale: string }) {
             }))}
             className="w-full rounded-md border border-divider bg-background px-3 py-1.5 text-sm text-foreground outline-none focus:border-primary"
             disabled={isPending}
+            aria-invalid={errorMessage ? true : undefined}
+            aria-describedby={errorMessage ? errorId : undefined}
           />
         </div>
         <Button type="submit" disabled={isPending} size="sm">
@@ -103,7 +106,7 @@ export function CompanyRequestForm({ locale }: { locale: string }) {
             }}
           />
         )}
-        <ErrorAlert message={errorMessage} />
+        <ErrorAlert id={errorId} message={errorMessage} focusOnRender />
       </div>
     </div>
   );

--- a/apps/web/app/[lang]/(auth)/check-email/page.tsx
+++ b/apps/web/app/[lang]/(auth)/check-email/page.tsx
@@ -98,7 +98,7 @@ export default function CheckEmailPage() {
             ? t({ id: "auth.verify.cooldown", comment: "Resend button during cooldown with seconds remaining", message: `Resend in ${cooldown}s` })
             : t({ id: "auth.verify.resend", comment: "Button to resend verification email", message: "Resend verification email" })}
       </button>
-      <ErrorAlert message={error} />
+      <ErrorAlert message={error} focusOnRender />
     </div>
   );
 }

--- a/apps/web/app/[lang]/(auth)/forgot-password/page.tsx
+++ b/apps/web/app/[lang]/(auth)/forgot-password/page.tsx
@@ -16,19 +16,23 @@ export default function ForgotPasswordPage() {
   const lp = useLocalePath();
   const [email, setEmail] = useState("");
   const [error, setError] = useState("");
+  const [emailError, setEmailError] = useState("");
   const [loading, setLoading] = useState(false);
   const [sent, setSent] = useState(false);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError("");
+    setEmailError("");
 
     if (!email) {
-      setError(t({
+      const message = t({
         id: "auth.forgotPassword.error.required",
         comment: "Error when email field is empty",
         message: "Please enter your email address",
-      }));
+      });
+      setEmailError(message);
+      setError(message);
       return;
     }
 
@@ -40,6 +44,7 @@ export default function ForgotPasswordPage() {
     setLoading(false);
 
     if (error) {
+      setEmailError("");
       setError(error.message ?? t({
         id: "auth.forgotPassword.error.generic",
         comment: "Generic forgot password error",
@@ -86,7 +91,7 @@ export default function ForgotPasswordPage() {
         </Trans>
       </p>
 
-      <ErrorAlert message={error} />
+      <ErrorAlert message={error} focusOnRender />
 
       <form onSubmit={handleSubmit} noValidate>
         <FormField
@@ -95,8 +100,12 @@ export default function ForgotPasswordPage() {
           required
           autoComplete="email"
           value={email}
-          onChange={(e) => setEmail(e.target.value)}
+          onChange={(e) => {
+            setEmail(e.target.value);
+            setEmailError("");
+          }}
           className="mb-6"
+          error={emailError}
         />
         <Button type="submit" disabled={loading} className="w-full">
           {loading

--- a/apps/web/app/[lang]/reset-password/page.tsx
+++ b/apps/web/app/[lang]/reset-password/page.tsx
@@ -21,6 +21,8 @@ export default function ResetPasswordPage() {
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState("");
+  const [passwordError, setPasswordError] = useState("");
+  const [confirmPasswordError, setConfirmPasswordError] = useState("");
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
 
@@ -76,22 +78,28 @@ export default function ResetPasswordPage() {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError("");
+    setPasswordError("");
+    setConfirmPasswordError("");
 
     if (!password) {
-      setError(t({
+      const message = t({
         id: "auth.resetPassword.error.required",
         comment: "Error when new password is empty",
         message: "Please enter a new password",
-      }));
+      });
+      setPasswordError(message);
+      setError(message);
       return;
     }
 
     if (password !== confirmPassword) {
-      setError(t({
+      const message = t({
         id: "auth.resetPassword.error.mismatch",
         comment: "Error when passwords do not match",
         message: "Passwords do not match",
-      }));
+      });
+      setConfirmPasswordError(message);
+      setError(message);
       return;
     }
 
@@ -103,6 +111,8 @@ export default function ResetPasswordPage() {
     setLoading(false);
 
     if (error) {
+      setPasswordError("");
+      setConfirmPasswordError("");
       setError(error.message ?? t({
         id: "auth.resetPassword.error.generic",
         comment: "Generic reset password error",
@@ -126,7 +136,7 @@ export default function ResetPasswordPage() {
         </Trans>
       </p>
 
-      <ErrorAlert message={error} />
+      <ErrorAlert message={error} focusOnRender />
 
       <form onSubmit={handleSubmit} noValidate>
         <FormField
@@ -135,8 +145,12 @@ export default function ResetPasswordPage() {
           required
           autoComplete="new-password"
           value={password}
-          onChange={(e) => setPassword(e.target.value)}
+          onChange={(e) => {
+            setPassword(e.target.value);
+            setPasswordError("");
+          }}
           className="mb-4"
+          error={passwordError}
         />
         <FormField
           label={t({ id: "auth.resetPassword.confirmPassword", comment: "Confirm password input label", message: "Confirm password" })}
@@ -144,8 +158,12 @@ export default function ResetPasswordPage() {
           required
           autoComplete="new-password"
           value={confirmPassword}
-          onChange={(e) => setConfirmPassword(e.target.value)}
+          onChange={(e) => {
+            setConfirmPassword(e.target.value);
+            setConfirmPasswordError("");
+          }}
           className="mb-6"
+          error={confirmPasswordError}
         />
         <Button type="submit" disabled={loading} className="w-full">
           {loading

--- a/apps/web/app/[lang]/verify-email/page.tsx
+++ b/apps/web/app/[lang]/verify-email/page.tsx
@@ -63,7 +63,7 @@ export default function VerifyEmailPage() {
               Verification failed
             </Trans>
           </h2>
-          <ErrorAlert message={error} />
+          <ErrorAlert message={error} focusOnRender />
           <Button href={lp("/sign-in")} prefetch={false} className="mt-4">
             <Trans id="auth.verify.error.backToSignIn" comment="Link back to sign-in after failed verification">
               Back to sign in

--- a/apps/web/src/components/AuthForm.tsx
+++ b/apps/web/src/components/AuthForm.tsx
@@ -27,6 +27,7 @@ export function AuthForm({ mode }: AuthFormProps) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
+  const [fieldErrors, setFieldErrors] = useState<{ name?: string; email?: string; password?: string }>({});
   const [loading, setLoading] = useState(false);
 
   const isSignUp = mode === "sign-up";
@@ -40,14 +41,21 @@ export function AuthForm({ mode }: AuthFormProps) {
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError("");
+    setFieldErrors({});
 
     // Client-side validation
     if (!email || !password || (isSignUp && !name)) {
-      setError(t({
+      const message = t({
         id: "auth.error.fieldsRequired",
         comment: "Error when required fields are empty",
         message: "Please fill in all fields",
-      }));
+      });
+      setFieldErrors({
+        name: isSignUp && !name ? message : undefined,
+        email: !email ? message : undefined,
+        password: !password ? message : undefined,
+      });
+      setError(message);
       return;
     }
 
@@ -62,6 +70,7 @@ export function AuthForm({ mode }: AuthFormProps) {
         callbackURL: dashboardUrl,
       });
       if (error) {
+        setFieldErrors({});
         setError(error.message ?? t({
           id: "auth.signUp.error.generic",
           comment: "Generic sign-up error fallback",
@@ -88,6 +97,7 @@ export function AuthForm({ mode }: AuthFormProps) {
           goToCheckEmail();
           return;
         }
+        setFieldErrors({});
         setError(error.message ?? t({
           id: "auth.signIn.error.generic",
           comment: "Generic sign-in error fallback",
@@ -155,7 +165,7 @@ export function AuthForm({ mode }: AuthFormProps) {
           : <Trans id="auth.signIn.subtitle" comment="Sign-in page subtitle">Welcome back</Trans>}
       </p>
 
-      <ErrorAlert message={error} />
+      <ErrorAlert message={error} focusOnRender />
 
       <form onSubmit={handleSubmit} noValidate>
         {isSignUp && (
@@ -164,8 +174,12 @@ export function AuthForm({ mode }: AuthFormProps) {
             required
             autoComplete="name"
             value={name}
-            onChange={(e) => setName(e.target.value)}
+            onChange={(e) => {
+              setName(e.target.value);
+              setFieldErrors((current) => ({ ...current, name: undefined }));
+            }}
             className="mb-4"
+            error={fieldErrors.name}
           />
         )}
         <FormField
@@ -176,8 +190,12 @@ export function AuthForm({ mode }: AuthFormProps) {
           required
           autoComplete={isSignUp ? "email" : "username email"}
           value={email}
-          onChange={(e) => setEmail(e.target.value)}
+          onChange={(e) => {
+            setEmail(e.target.value);
+            setFieldErrors((current) => ({ ...current, email: undefined }));
+          }}
           className="mb-4"
+          error={fieldErrors.email}
         />
         <FormField
           label={t({ id: "auth.field.password", comment: "Password input label", message: "Password" })}
@@ -185,8 +203,12 @@ export function AuthForm({ mode }: AuthFormProps) {
           required
           autoComplete={isSignUp ? "new-password" : "current-password"}
           value={password}
-          onChange={(e) => setPassword(e.target.value)}
+          onChange={(e) => {
+            setPassword(e.target.value);
+            setFieldErrors((current) => ({ ...current, password: undefined }));
+          }}
           className={isSignUp ? "mb-6" : "mb-2"}
+          error={fieldErrors.password}
         />
         {!isSignUp && (
           <div className="mb-6 text-right">

--- a/apps/web/src/components/__tests__/AuthForm-a11y.test.tsx
+++ b/apps/web/src/components/__tests__/AuthForm-a11y.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import "@/test-utils/lingui-mock";
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  signInEmail: vi.fn(),
+  signInUsername: vi.fn(),
+  signUpEmail: vi.fn(),
+  getPreferences: vi.fn(),
+  updatePreferences: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.push }),
+}));
+
+vi.mock("@/lib/useLocalePath", () => ({
+  useLocalePath: () => (path: string) => `/en${path}`,
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    signIn: {
+      email: mocks.signInEmail,
+      username: mocks.signInUsername,
+      social: vi.fn(),
+    },
+    signUp: {
+      email: mocks.signUpEmail,
+    },
+  },
+}));
+
+vi.mock("@/lib/actions/preferences", () => ({
+  getPreferences: mocks.getPreferences,
+  updatePreferences: mocks.updatePreferences,
+}));
+
+vi.mock("@/lib/preference-timestamps", () => ({
+  localPrefs: {
+    themeTimestamp: { get: vi.fn(), set: vi.fn() },
+    localeTimestamp: { get: vi.fn(), set: vi.fn() },
+    locale: { get: vi.fn(), set: vi.fn() },
+  },
+}));
+
+import { AuthForm } from "../AuthForm";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AuthForm accessibility", () => {
+  it("focuses the error banner and marks missing fields invalid", async () => {
+    const user = userEvent.setup();
+    render(<AuthForm mode="sign-in" />);
+
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+
+    const alert = await screen.findByRole("alert");
+    await waitFor(() => {
+      expect(document.activeElement).toBe(alert);
+    });
+
+    const email = screen.getByLabelText("Email or username") as HTMLInputElement;
+    const password = screen.getByLabelText("Password", { selector: "input" }) as HTMLInputElement;
+
+    expect(alert.textContent).toBe("Please fill in all fields");
+    expect(email.getAttribute("aria-invalid")).toBe("true");
+    expect(password.getAttribute("aria-invalid")).toBe("true");
+    expect(email.getAttribute("aria-describedby")).toBeTruthy();
+    expect(password.getAttribute("aria-describedby")).toBeTruthy();
+    expect(mocks.signInEmail).not.toHaveBeenCalled();
+    expect(mocks.signInUsername).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/search/request-company.tsx
+++ b/apps/web/src/components/search/request-company.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActionState, useEffect, useRef, useState, useTransition } from "react";
+import { useActionState, useEffect, useId, useRef, useState, useTransition } from "react";
 import { useLingui } from "@lingui/react";
 import { msg } from "@lingui/core/macro";
 import { Trans } from "@lingui/react/macro";
@@ -41,6 +41,7 @@ export function RequestCompanyPrompt() {
   }, [state]);
 
   const errorMessage = state?.errorCode ? t(errorMessages[state.errorCode]) : "";
+  const errorId = useId();
 
   function handleSubmit(formData: FormData) {
     // Clear previous agent-run state so old success cards don't linger.
@@ -99,6 +100,8 @@ export function RequestCompanyPrompt() {
               }))}
               className="w-full rounded-md border border-divider bg-background px-3 py-1.5 text-sm text-foreground outline-none focus:border-primary"
               disabled={isPending}
+              aria-invalid={errorMessage ? true : undefined}
+              aria-describedby={errorMessage ? errorId : undefined}
             />
           </div>
           <Button type="submit" disabled={isPending} size="sm">
@@ -118,7 +121,7 @@ export function RequestCompanyPrompt() {
               }}
             />
           )}
-          <ErrorAlert message={errorMessage} />
+          <ErrorAlert id={errorId} message={errorMessage} focusOnRender />
         </div>
       </div>
     </div>

--- a/apps/web/src/components/settings/AccountSettings.tsx
+++ b/apps/web/src/components/settings/AccountSettings.tsx
@@ -61,20 +61,25 @@ function SetPasswordFlow({ onSuccess }: { onSuccess: () => void }) {
   const [newPassword, setNewPassword] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [newPasswordError, setNewPasswordError] = useState("");
   const [success, setSuccess] = useState("");
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError("");
+    setNewPasswordError("");
     setSuccess("");
     if (!newPassword) {
-      setError(t({ id: "settings.account.password.newRequired", comment: "Error when new password is empty", message: "Please enter a password" }));
+      const message = t({ id: "settings.account.password.newRequired", comment: "Error when new password is empty", message: "Please enter a password" });
+      setNewPasswordError(message);
+      setError(message);
       return;
     }
     setLoading(true);
     const result = await setPasswordAction(newPassword);
     setLoading(false);
     if (result.error) {
+      setNewPasswordError("");
       setError(result.error ?? t({ id: "settings.account.password.setError", comment: "Generic set password error", message: "Failed to set password" }));
     } else {
       setSuccess(t({ id: "settings.account.password.setSuccess", comment: "Success message after setting password", message: "Password set successfully." }));
@@ -93,7 +98,7 @@ function SetPasswordFlow({ onSuccess }: { onSuccess: () => void }) {
           You signed in with a social account. Set a password to enable email changes and additional security.
         </Trans>
       </p>
-      <ErrorAlert message={error} />
+      <ErrorAlert message={error} focusOnRender />
       <SuccessAlert message={success} />
       <form onSubmit={handleSubmit} className="flex flex-col gap-4 min-[480px]:flex-row min-[480px]:items-end">
         <input type="hidden" name="username" autoComplete="username" value={user?.email ?? ""} />
@@ -104,7 +109,11 @@ function SetPasswordFlow({ onSuccess }: { onSuccess: () => void }) {
             required
             autoComplete="new-password"
             value={newPassword}
-            onChange={(e) => setNewPassword(e.target.value)}
+            onChange={(e) => {
+              setNewPassword(e.target.value);
+              setNewPasswordError("");
+            }}
+            error={newPasswordError}
           />
         </div>
         <Button type="submit" disabled={loading} size="sm">
@@ -178,7 +187,7 @@ function ResetPasswordFlow({ initialCooldown }: { initialCooldown: number }) {
           Change your password via a secure email link.
         </Trans>
       </p>
-      <ErrorAlert message={error} />
+      <ErrorAlert message={error} focusOnRender />
       <SuccessAlert message={success} />
       <Button onClick={handleReset} disabled={loading || cooldown > 0} size="sm">
         {loading
@@ -297,6 +306,13 @@ function UsernameSection({ currentUsername }: { currentUsername: string }) {
               : available === false
                 ? t({ id: "settings.account.username.taken", comment: "Username is taken", message: "Already taken" })
                 : null;
+  const usernameValidationInvalid = !unchanged && (tooShort || tooLong || invalidChars || reserved || available === false);
+  const usernameInvalid = usernameValidationInvalid || !!error;
+  const hintClassName = available === true
+    ? "mt-1 text-xs text-green-600 dark:text-green-400"
+    : usernameInvalid
+      ? "mt-1 text-xs text-error"
+      : "mt-1 text-xs text-muted";
 
   return (
     <section>
@@ -308,7 +324,7 @@ function UsernameSection({ currentUsername }: { currentUsername: string }) {
           Your unique handle used in your public profile URL.
         </Trans>
       </p>
-      <ErrorAlert message={error} />
+      <ErrorAlert message={error} focusOnRender />
       <form onSubmit={handleSubmit}>
         <div className="flex flex-col gap-4 min-[480px]:flex-row min-[480px]:items-end">
           <div className="flex-1">
@@ -319,6 +335,10 @@ function UsernameSection({ currentUsername }: { currentUsername: string }) {
               value={value}
               onChange={(e) => handleChange(e.target.value)}
               maxLength={30}
+              hint={hint}
+              hintClassName={hintClassName}
+              error={error}
+              aria-invalid={usernameInvalid || undefined}
             />
           </div>
           <Button type="submit" disabled={loading || unchanged || tooShort || tooLong || invalidChars || reserved || available === false || checking} size="sm">
@@ -327,11 +347,6 @@ function UsernameSection({ currentUsername }: { currentUsername: string }) {
               : t({ id: "settings.account.username.save", comment: "Username save button", message: "Update username" })}
           </Button>
         </div>
-        {hint && (
-          <p className={`mt-1 text-xs ${available === true ? "text-green-600 dark:text-green-400" : available === false || invalidChars || tooShort || tooLong || reserved ? "text-error" : "text-muted"}`}>
-            {hint}
-          </p>
-        )}
         {success && <div className="mt-3"><SuccessAlert message={success} /></div>}
       </form>
     </section>
@@ -346,14 +361,18 @@ function ChangeEmailSection() {
   const [newEmail, setNewEmail] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [emailError, setEmailError] = useState("");
   const [success, setSuccess] = useState("");
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError("");
+    setEmailError("");
     setSuccess("");
     if (!newEmail) {
-      setError(t({ id: "settings.account.email.required", comment: "Error when email field is empty", message: "Please enter a new email address" }));
+      const message = t({ id: "settings.account.email.required", comment: "Error when email field is empty", message: "Please enter a new email address" });
+      setEmailError(message);
+      setError(message);
       return;
     }
     setLoading(true);
@@ -363,6 +382,7 @@ function ChangeEmailSection() {
     });
     setLoading(false);
     if (error) {
+      setEmailError("");
       setError(error.message ?? t({ id: "settings.account.email.error", comment: "Generic email change error", message: "Failed to change email" }));
     } else {
       setSuccess(t({ id: "settings.account.email.success", comment: "Success message after email change request", message: "Verification email sent. Please check your inbox. It may take a few minutes to arrive." }));
@@ -380,7 +400,7 @@ function ChangeEmailSection() {
           Update the email address associated with your account.
         </Trans>
       </p>
-      <ErrorAlert message={error} />
+      <ErrorAlert message={error} focusOnRender />
       <SuccessAlert message={success} />
       <form onSubmit={handleSubmit} className="flex flex-col gap-4 min-[480px]:flex-row min-[480px]:items-end">
         <div className="flex-1">
@@ -390,7 +410,11 @@ function ChangeEmailSection() {
             required
             autoComplete="email"
             value={newEmail}
-            onChange={(e) => setNewEmail(e.target.value)}
+            onChange={(e) => {
+              setNewEmail(e.target.value);
+              setEmailError("");
+            }}
+            error={emailError}
           />
         </div>
         <Button type="submit" disabled={loading} size="sm">
@@ -460,7 +484,7 @@ function ConnectedAccountsSection({ accounts, onDisconnect }: { accounts: Connec
           Manage your linked social accounts.
         </Trans>
       </p>
-      <ErrorAlert message={error} />
+      <ErrorAlert message={error} focusOnRender />
       <div className="space-y-2">
         {socialProviders.map((p) => {
           const connected = isConnected(p.id);
@@ -518,7 +542,7 @@ function DeleteAccountSection() {
           Permanently delete your account and all associated data. This action cannot be undone.
         </Trans>
       </p>
-      <ErrorAlert message={error} />
+      <ErrorAlert message={error} focusOnRender />
       {!showConfirm ? (
         <Button onClick={() => setShowConfirm(true)} variant="danger" size="sm">
           {t({ id: "settings.account.delete.button", comment: "Delete account button", message: "Delete my account" })}

--- a/apps/web/src/components/settings/BillingSettings.tsx
+++ b/apps/web/src/components/settings/BillingSettings.tsx
@@ -156,7 +156,7 @@ export function BillingSettings({ planInfo }: { planInfo: PlanInfo }) {
           />
         </div>
 
-        {error && <div className="mt-4"><ErrorAlert message={error} /></div>}
+        {error && <div className="mt-4"><ErrorAlert message={error} focusOnRender /></div>}
 
         <div className="mt-4">
           {isFree ? (

--- a/apps/web/src/components/settings/__tests__/AccountSettings-username-error.test.tsx
+++ b/apps/web/src/components/settings/__tests__/AccountSettings-username-error.test.tsx
@@ -112,6 +112,11 @@ describe("AccountSettings username errors", () => {
 
     const alert = await screen.findByRole("alert");
     expect(alert.textContent).toBe("Username already taken");
+    expect(document.activeElement).toBe(alert);
+
+    const username = screen.getByLabelText("Username");
+    expect(username.getAttribute("aria-invalid")).toBe("true");
+    expect(username.getAttribute("aria-describedby")).toBeTruthy();
     expect(mocks.sessionRefresh).not.toHaveBeenCalled();
     expect(mocks.routerRefresh).not.toHaveBeenCalled();
   });
@@ -128,7 +133,23 @@ describe("AccountSettings username errors", () => {
 
     const alert = await screen.findByRole("alert");
     expect(alert.textContent).toBe("Failed to update username");
+    expect(document.activeElement).toBe(alert);
     expect(mocks.sessionRefresh).not.toHaveBeenCalled();
     expect(mocks.routerRefresh).not.toHaveBeenCalled();
+  });
+
+  it("links the username availability hint to the input", async () => {
+    mocks.isUsernameAvailable.mockResolvedValueOnce({ data: { available: false } });
+    const user = userEvent.setup();
+
+    render(<AccountSettings initialData={{ ...initialData }} />);
+
+    const username = screen.getByLabelText("Username");
+    await user.clear(username);
+    await user.type(username, "taken-name");
+
+    const hint = await screen.findByText("Already taken");
+    expect(username.getAttribute("aria-invalid")).toBe("true");
+    expect(username.getAttribute("aria-describedby")?.split(" ")).toContain(hint.id);
   });
 });

--- a/apps/web/src/components/ui/ErrorAlert.tsx
+++ b/apps/web/src/components/ui/ErrorAlert.tsx
@@ -1,11 +1,35 @@
+"use client";
+
+import { useEffect, useRef, type HTMLAttributes } from "react";
+
 type ErrorAlertProps = {
   message: string;
-};
+  focusOnRender?: boolean;
+} & HTMLAttributes<HTMLDivElement>;
 
-export function ErrorAlert({ message }: ErrorAlertProps) {
+export function ErrorAlert({
+  message,
+  focusOnRender = false,
+  className,
+  tabIndex,
+  ...props
+}: ErrorAlertProps) {
+  const localRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!message || !focusOnRender) return;
+    localRef.current?.focus();
+  }, [message, focusOnRender]);
+
   if (!message) return null;
   return (
-    <div role="alert" className="mb-4 rounded-md border border-error-border bg-error-bg px-4 py-3 text-sm text-error">
+    <div
+      ref={localRef}
+      role="alert"
+      tabIndex={focusOnRender ? (tabIndex ?? -1) : tabIndex}
+      className={`mb-4 rounded-md border border-error-border bg-error-bg px-4 py-3 text-sm text-error${className ? ` ${className}` : ""}`}
+      {...props}
+    >
       {message}
     </div>
   );

--- a/apps/web/src/components/ui/FormField.tsx
+++ b/apps/web/src/components/ui/FormField.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, type InputHTMLAttributes } from "react";
+import { forwardRef, useId, useState, type InputHTMLAttributes } from "react";
 import { useLingui } from "@lingui/react/macro";
 import { Eye, EyeOff } from "lucide-react";
 
@@ -10,20 +10,44 @@ const inputClass =
 type FormFieldProps = {
   label: string;
   className?: string;
+  error?: string | null;
+  hint?: string | null;
+  hintClassName?: string;
 } & InputHTMLAttributes<HTMLInputElement>;
 
-export function FormField({ label, className, type, ...inputProps }: FormFieldProps) {
+export const FormField = forwardRef<HTMLInputElement, FormFieldProps>(function FormField({
+  label,
+  className,
+  type,
+  id,
+  error,
+  hint,
+  hintClassName,
+  "aria-describedby": ariaDescribedBy,
+  "aria-invalid": ariaInvalid,
+  ...inputProps
+}, ref) {
   const { t } = useLingui();
+  const generatedId = useId();
   const isPassword = type === "password";
   const [showPassword, setShowPassword] = useState(false);
+  const inputId = id ?? generatedId;
+  const hintId = hint ? `${inputId}-hint` : undefined;
+  const errorId = error ? `${inputId}-error` : undefined;
+  const describedBy = [ariaDescribedBy, hintId, errorId].filter(Boolean).join(" ") || undefined;
+  const invalid = error ? true : ariaInvalid;
 
   return (
-    <label className={`block ${className ?? ""}`}>
-      <span className="mb-1 block text-sm font-medium">{label}</span>
+    <div className={`block ${className ?? ""}`}>
+      <label htmlFor={inputId} className="mb-1 block text-sm font-medium">{label}</label>
       <div className="relative">
         <input
+          id={inputId}
+          ref={ref}
           className={`${inputClass}${isPassword ? " pr-9" : ""}`}
           type={isPassword && showPassword ? "text" : type}
+          aria-describedby={describedBy}
+          aria-invalid={invalid}
           {...inputProps}
         />
         {isPassword && (
@@ -41,6 +65,16 @@ export function FormField({ label, className, type, ...inputProps }: FormFieldPr
           </button>
         )}
       </div>
-    </label>
+      {hint && (
+        <p id={hintId} className={hintClassName ?? "mt-1 text-xs text-muted"}>
+          {hint}
+        </p>
+      )}
+      {error && (
+        <p id={errorId} className="mt-1 text-xs text-error">
+          {error}
+        </p>
+      )}
+    </div>
   );
-}
+});

--- a/apps/web/src/components/ui/__tests__/ErrorAlert.test.tsx
+++ b/apps/web/src/components/ui/__tests__/ErrorAlert.test.tsx
@@ -13,6 +13,11 @@ describe("ErrorAlert", () => {
     render(<ErrorAlert message="Something went wrong" />);
     expect(screen.getByRole("alert").textContent).toBe("Something went wrong");
   });
+
+  it("can move focus to the alert when requested", () => {
+    render(<ErrorAlert message="Something went wrong" focusOnRender />);
+    expect(document.activeElement).toBe(screen.getByRole("alert"));
+  });
 });
 
 describe("SuccessAlert", () => {

--- a/apps/web/src/components/ui/__tests__/FormField.test.tsx
+++ b/apps/web/src/components/ui/__tests__/FormField.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import "@/test-utils/lingui-mock";
+
+import { FormField } from "../FormField";
+
+describe("FormField", () => {
+  it("associates hint and error text with the input", () => {
+    render(
+      <FormField
+        label="Email"
+        hint="Use your work email"
+        error="Email is required"
+      />,
+    );
+
+    const input = screen.getByLabelText("Email");
+    const describedBy = input.getAttribute("aria-describedby");
+
+    expect(input.getAttribute("aria-invalid")).toBe("true");
+    expect(describedBy).toBeTruthy();
+
+    const descriptions = describedBy
+      ?.split(" ")
+      .map((id) => document.getElementById(id)?.textContent);
+
+    expect(descriptions).toEqual(["Use your work email", "Email is required"]);
+  });
+});


### PR DESCRIPTION
Closes #3207

## Summary
- focus the top form error alert when submit validation or server-action errors are shown
- mark invalid fields with `aria-invalid` and associate field-level hints/errors with `aria-describedby`
- extend the shared form/error primitives and add regressions for auth, settings, and company-request forms

## Production reproduction
Read-only production probe on `https://jseek.co/en/sign-in` before the fix, submitting the empty sign-in form:

```json
{
  "active": { "tag": "BUTTON", "text": "Sign in", "type": "submit", "ariaInvalid": null },
  "email": { "ariaInvalid": null, "describedBy": null },
  "password": { "ariaInvalid": null, "describedBy": null },
  "alert": "Please fill in all fields"
}
```

## Validation
- `pnpm --filter @jobseek/web exec vitest run src/components/ui/__tests__/ErrorAlert.test.tsx src/components/ui/__tests__/FormField.test.tsx src/components/__tests__/AuthForm-a11y.test.tsx src/components/settings/__tests__/AccountSettings-username-error.test.tsx 'app/[lang]/(app)/companies/request/__tests__/company-request-page-form.test.tsx' --reporter=dot`\n- `pnpm --filter @jobseek/web lint`\n- `pnpm --filter @jobseek/web typecheck`\n- `git diff --check`\n\nAdditional pre-rebase local coverage also passed: full `pnpm --filter @jobseek/web test` and `pnpm --filter @jobseek/web build` with the existing missing-local-env warnings.