### PR TITLE
Fix watchlist navigation scroll reset

### DIFF
--- a/apps/web/src/components/watchlist/__tests__/public-watchlist-search.test.tsx
+++ b/apps/web/src/components/watchlist/__tests__/public-watchlist-search.test.tsx
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import "@/test-utils/lingui-mock";
+
+vi.mock("next/link", () => ({
+  default: ({ children, href, prefetch: _prefetch, ...props }: Record<string, unknown>) => (
+    <a href={href as string} {...props}>{children as React.ReactNode}</a>
+  ),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ lang: "en" }),
+}));
+
+vi.mock("@/lib/useLocalePath", () => ({
+  useLocalePath: () => (p: string) => `/en${p}`,
+}));
+
+vi.mock("@/lib/use-infinite-scroll", () => ({
+  useInfiniteScroll: () => ({ sentinelRef: { current: null }, isLoading: false }),
+}));
+
+vi.mock("@/lib/actions/watchlists", () => ({
+  getPopularWatchlists: vi.fn(),
+  searchPublicWatchlists: vi.fn(),
+}));
+
+import { getPopularWatchlists, searchPublicWatchlists } from "@/lib/actions/watchlists";
+import { PublicWatchlistSearch } from "../public-watchlist-search";
+
+const getPopularWatchlistsMock = vi.mocked(getPopularWatchlists);
+const searchPublicWatchlistsMock = vi.mocked(searchPublicWatchlists);
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  getPopularWatchlistsMock.mockResolvedValue({
+    watchlists: [
+      {
+        id: "public-watchlist-1",
+        slug: "maangplus",
+        title: "MAANG+",
+        description: "Big tech and AI jobs",
+        isPublic: true,
+        alertsEnabled: false,
+        companyCount: 12,
+        activeJobCount: 45,
+        lastAccessedAt: "2026-07-06T00:00:00.000Z",
+        createdAt: "2026-07-06T00:00:00.000Z",
+        ownerName: "Colophon",
+        ownerUsername: "colophongroup",
+        mirrorCount: 2,
+      },
+    ],
+    total: 1,
+  });
+  searchPublicWatchlistsMock.mockResolvedValue({ watchlists: [], total: 0 });
+});
+
+describe("PublicWatchlistSearch navigation", () => {
+  it("scrolls to top synchronously when opening a public watchlist result", async () => {
+    const scrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+
+    render(<PublicWatchlistSearch />);
+
+    const link = await screen.findByRole("link", { name: /maang\+/i });
+    fireEvent.click(link);
+
+    expect(link.getAttribute("href")).toBe("/en/colophongroup/maangplus");
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, left: 0, behavior: "instant" });
+  });
+});

--- a/apps/web/src/components/watchlist/__tests__/watchlist-card.test.tsx
+++ b/apps/web/src/components/watchlist/__tests__/watchlist-card.test.tsx
@@ -7,12 +7,12 @@
  *   3. open the upgrade modal instead, telling the user why nothing
  *      happened
  */
-import { describe, it, expect, vi } from "vitest";
+import { beforeEach, describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@/test-utils/lingui-mock";
 
 vi.mock("next/link", () => ({
-  default: ({ children, href, ...props }: Record<string, unknown>) => (
+  default: ({ children, href, prefetch: _prefetch, ...props }: Record<string, unknown>) => (
     <a href={href as string} {...props}>{children as React.ReactNode}</a>
   ),
 }));
@@ -21,7 +21,39 @@ vi.mock("@/lib/useLocalePath", () => ({
   useLocalePath: () => (p: string) => `/en${p}`,
 }));
 
-import { CreateWatchlistCard } from "../watchlist-card";
+import { CreateWatchlistCard, WatchlistCard } from "../watchlist-card";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("WatchlistCard navigation", () => {
+  it("scrolls to top synchronously when navigating to a watchlist", () => {
+    const scrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+
+    render(
+      <WatchlistCard
+        ownerUsername="colophongroup"
+        watchlist={{
+          id: "watchlist-1",
+          slug: "maangplus",
+          title: "MAANG+",
+          description: null,
+          isPublic: true,
+          alertsEnabled: false,
+          companyCount: 12,
+          activeJobCount: 34,
+          lastAccessedAt: "2026-07-06T00:00:00.000Z",
+          createdAt: "2026-07-06T00:00:00.000Z",
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: /maang\+/i }));
+
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, left: 0, behavior: "instant" });
+  });
+});
 
 describe("CreateWatchlistCard (issue #3036)", () => {
   it("applies dimmed styling when disabled", () => {

--- a/apps/web/src/components/watchlist/public-watchlist-search.tsx
+++ b/apps/web/src/components/watchlist/public-watchlist-search.tsx
@@ -7,6 +7,7 @@ import { Search, Loader2, Copy } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useLocalePath } from "@/lib/useLocalePath";
 import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
+import { scrollToTopOnNav } from "@/lib/scroll-on-nav";
 import { InfiniteScrollSentinel } from "@/components/InfiniteScrollSentinel";
 import {
   searchPublicWatchlists,
@@ -104,37 +105,42 @@ export function PublicWatchlistSearch() {
 
       {results.length > 0 && (
         <div className="space-y-2">
-          {results.map((wl) => (
-            <Link
-              key={wl.id}
-              href={wl.ownerUsername ? lp(`/${wl.ownerUsername}/${wl.slug}`) : "#"}
-              prefetch={false}
-              className="flex items-center gap-3 rounded-md border border-border-soft p-3 transition-colors hover:bg-border-soft"
-            >
-              <div className="min-w-0 flex-1">
-                <p className="truncate text-sm font-medium">{wl.title}</p>
-                {wl.description && (
-                  <p className="line-clamp-1 text-xs text-muted">{wl.description}</p>
-                )}
-                <p className="text-xs text-muted">
-                  @{wl.ownerUsername ?? t({ id: "watchlists.explore.unknownUser", comment: "Fallback username for watchlist owner", message: "user" })} · {wl.activeJobCount} {wl.activeJobCount === 1
-                    ? t({ id: "watchlists.explore.jobSingular", comment: "Singular job count in public watchlist", message: "job" })
-                    : t({ id: "watchlists.explore.jobPlural", comment: "Plural job count in public watchlist", message: "jobs" })}
-                  {wl.mirrorCount > 0 && (
-                    <>
-                      {" · "}
-                      <span className="inline-flex items-center gap-0.5">
-                        <Copy size={10} />
-                        {wl.mirrorCount} {wl.mirrorCount === 1
-                          ? t({ id: "watchlists.explore.mirrorSingular", comment: "Singular mirror count", message: "mirror" })
-                          : t({ id: "watchlists.explore.mirrorPlural", comment: "Plural mirror count", message: "mirrors" })}
-                      </span>
-                    </>
+          {results.map((wl) => {
+            const href = wl.ownerUsername ? lp(`/${wl.ownerUsername}/${wl.slug}`) : "#";
+
+            return (
+              <Link
+                key={wl.id}
+                href={href}
+                prefetch={false}
+                onClick={() => scrollToTopOnNav(href)}
+                className="flex items-center gap-3 rounded-md border border-border-soft p-3 transition-colors hover:bg-border-soft"
+              >
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium">{wl.title}</p>
+                  {wl.description && (
+                    <p className="line-clamp-1 text-xs text-muted">{wl.description}</p>
                   )}
-                </p>
-              </div>
-            </Link>
-          ))}
+                  <p className="text-xs text-muted">
+                    @{wl.ownerUsername ?? t({ id: "watchlists.explore.unknownUser", comment: "Fallback username for watchlist owner", message: "user" })} · {wl.activeJobCount} {wl.activeJobCount === 1
+                      ? t({ id: "watchlists.explore.jobSingular", comment: "Singular job count in public watchlist", message: "job" })
+                      : t({ id: "watchlists.explore.jobPlural", comment: "Plural job count in public watchlist", message: "jobs" })}
+                    {wl.mirrorCount > 0 && (
+                      <>
+                        {" · "}
+                        <span className="inline-flex items-center gap-0.5">
+                          <Copy size={10} />
+                          {wl.mirrorCount} {wl.mirrorCount === 1
+                            ? t({ id: "watchlists.explore.mirrorSingular", comment: "Singular mirror count", message: "mirror" })
+                            : t({ id: "watchlists.explore.mirrorPlural", comment: "Plural mirror count", message: "mirrors" })}
+                        </span>
+                      </>
+                    )}
+                  </p>
+                </div>
+              </Link>
+            );
+          })}
 
           {hasMore && <InfiniteScrollSentinel sentinelRef={sentinelRef} isLoading={loadingMore} size="sm" />}
         </div>

--- a/apps/web/src/components/watchlist/watchlist-card.tsx
+++ b/apps/web/src/components/watchlist/watchlist-card.tsx
@@ -5,6 +5,7 @@ import { Plus, Eye, Lock, Loader2, AlertTriangle } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { useLocalePath } from "@/lib/useLocalePath";
+import { scrollToTopOnNav } from "@/lib/scroll-on-nav";
 import type { WatchlistSummary } from "@/lib/actions/watchlists";
 import { UpgradeModal, useUpgradeModal } from "@/components/ui/upgrade-modal";
 import { tooltipWarningClass } from "@/components/ui/tooltip-styles";
@@ -18,6 +19,7 @@ export function WatchlistCard({ watchlist, ownerUsername }: { watchlist: Watchli
     <Link
       href={href}
       prefetch={false}
+      onClick={() => scrollToTopOnNav(href)}
       className="flex h-28 w-28 shrink-0 flex-col items-center justify-center gap-1.5 rounded-lg border border-border-soft bg-surface p-3 text-center transition-colors hover:border-primary/30 hover:bg-border-soft"
     >
       <div className="flex items-center gap-1 text-muted">


### PR DESCRIPTION
Closes #3064.

## Summary
- call `scrollToTopOnNav(href)` from owned watchlist cards and public watchlist search result links
- keep the destination watchlist-content mount scroll intact
- add focused regressions for both watchlist-card and public-search result navigation

## Reproduction
- Production pre-fix real-mouse probe on `/en/watchlists`: scrolled to `scrollY=1296`, clicked a public watchlist result via `page.mouse.click`, and recorded no `window.scrollTo` calls at click-time (`after-timeout` still `y=1296`, `calls=[]`) before the destination eventually landed at top.
- Local fixed real-mouse probe on `http://127.0.0.1:31064/en/watchlists`: scrolled to `scrollY=435`, clicked a public watchlist result via `page.mouse.click`, and recorded `window.scrollTo({ top: 0, left: 0, behavior: "instant" })` at click-time with `after-timeout` `y=0`.

## Validation
- `pnpm exec vitest run src/components/watchlist/__tests__/watchlist-card.test.tsx src/components/watchlist/__tests__/public-watchlist-search.test.tsx`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `pnpm exec vitest run src/lib/actions/__tests__/password-reset-race.test.ts` (reran after the full suite surfaced an order/env-only failure in that unrelated file)