### PR TITLE
Fix explore mount scroll reset

### DIFF
--- a/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
+++ b/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
@@ -108,6 +108,19 @@ describe("ExploreContent — server-render initial-data path (#2640)", () => {
     expect(mockFetchExploreData).not.toHaveBeenCalled();
   });
 
+  it("does NOT reset scroll on the prerendered initial-data mount", async () => {
+    const scrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+
+    try {
+      render(<ExploreContent locale="en" initialData={makeInitialData()} />);
+
+      await flushQueuedEffects();
+      expect(scrollTo).not.toHaveBeenCalled();
+    } finally {
+      scrollTo.mockRestore();
+    }
+  });
+
   it("calls fetchExplorePageData when the `logged_in` hint cookie is present even without filters", async () => {
     setDocumentCookie("logged_in=1");
 

--- a/apps/web/app/[lang]/(app)/explore/explore-content.tsx
+++ b/apps/web/app/[lang]/(app)/explore/explore-content.tsx
@@ -75,7 +75,6 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
   // with zero function invocations — the bulk of organic traffic per
   // #2640.
   useEffect(() => {
-    window.scrollTo(0, 0);
     const needsPersonalizedFetch =
       hasLoggedInHint() ||
       hasAnonJobLanguagesHint() ||


### PR DESCRIPTION
## Summary
- Remove the redundant `window.scrollTo(0, 0)` mount effect from ExploreContent.
- Add a regression proving the prerendered initial-data mount does not call `window.scrollTo`.

Closes #3061

## Reproduction
- Production read-only probe on `https://jseek.co/en/explore` did not reach the exact unauthenticated job-detail remount path: a center click on a scrolled job row stayed on Explore, while an action-side click went to sign-in.
- Component-boundary reproduction did confirm the bug: the new regression failed before the fix because `ExploreContent` called `window.scrollTo(0, 0)` on prerendered initial-data mount.

## Validation
- Failed before the fix: `../../node_modules/.pnpm/node_modules/.bin/vitest run 'app/[lang]/(app)/explore/__tests__/explore-content.test.tsx'` with the new regression expecting no `window.scrollTo` call.
- Passed after the fix, including after rebasing onto `5d5505cf1`:
  - `../../node_modules/.pnpm/node_modules/.bin/vitest run 'app/[lang]/(app)/explore/__tests__/explore-content.test.tsx'`
  - `../../node_modules/.pnpm/node_modules/.bin/eslint .`
  - `../../node_modules/.pnpm/node_modules/.bin/next typegen && ../../node_modules/.pnpm/node_modules/.bin/tsc`
  - `git diff --check`

Note: local `pnpm exec` remains blocked by the inherited minimum-release-age policy on current main, so validation used ignored dependency symlinks and direct workspace binaries without changing the policy.
