### PR TITLE
Localize activity heatmap labels

### DIFF
--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -93,11 +93,11 @@ msgstr "{count, plural, one {Unternehmen} other {Unternehmen}}"
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {# Unternehmen beobachtet} other {# Unternehmen beobachtet}}. {description}"
 
-#. Heatmap tooltip for multiple applications
+#. Heatmap tooltip shown when hovering an application-activity day; {date} is a YYYY-MM-DD date and {count} is the number of applications that day.
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:85
-msgid "myJobs.heatmap.tooltipMultiple"
-msgstr "{count} Bewerbungen am {date}"
+#: src/components/my-jobs/activity-heatmap.tsx:117
+msgid "myJobs.heatmap.tooltip"
+msgstr "{count, plural, =0 {Keine Bewerbungen am {date}} one {# Bewerbung am {date}} other {# Bewerbungen am {date}}}"
 
 #. SEO metadata suffix when a watchlist includes more companies than can be listed by name.
 #. js-lingui-explicit-id
@@ -158,12 +158,6 @@ msgstr "10 $"
 #: src/components/settings/BillingSettings.tsx:152
 msgid "settings.billing.plan.proPrice"
 msgstr "10 $ / Monat"
-
-#. Heatmap tooltip for 1 application
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:84
-msgid "myJobs.heatmap.tooltipOne"
-msgstr "1 Bewerbung am {date}"
 
 #. Free feature: one watchlist
 #. js-lingui-explicit-id
@@ -479,12 +473,6 @@ msgstr "Anwenden"
 msgid "search.detail.apply"
 msgstr "Bewerben"
 
-#. Short April label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:65
-msgid "myJobs.heatmap.month.apr"
-msgstr "Apr"
-
 #. Step 3 body
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:129
@@ -502,12 +490,6 @@ msgstr "Mindestens 3 Zeichen"
 #: src/components/settings/AccountSettings.tsx:288
 msgid "settings.account.username.tooLong"
 msgstr "Maximal 30 Zeichen"
-
-#. Short August label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:69
-msgid "myJobs.heatmap.month.aug"
-msgstr "Aug"
 
 #. Username is available
 #. js-lingui-explicit-id
@@ -1215,12 +1197,6 @@ msgstr "Datenanalysen, Nachrichten und Zusammenfassungen von Branchenberichten u
 msgid "myJobs.sort.dateSaved"
 msgstr "Speicherdatum"
 
-#. Short December label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:73
-msgid "myJobs.heatmap.month.dec"
-msgstr "Dez"
-
 #. Delete watchlist tooltip
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-action-bar.tsx:210
@@ -1560,12 +1536,6 @@ msgstr "FAQ"
 msgid "common.nav.features"
 msgstr "Funktionen"
 
-#. Short February label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:63
-msgid "myJobs.heatmap.month.feb"
-msgstr "Feb"
-
 #. Button to add a filter to watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-filter-editor.tsx:352
@@ -1695,12 +1665,6 @@ msgstr "Kostenlos bietet dir vollständige Suche über alle Unternehmen, eine Wa
 #: app/[lang]/(public)/faq/faq-content.tsx:39
 msgid "faq.title"
 msgstr "Häufig gestellte Fragen"
-
-#. Short Friday label for heatmap
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:54
-msgid "myJobs.heatmap.day.fri"
-msgstr "Fr"
 
 #. Feature section 2 heading
 #. js-lingui-explicit-id
@@ -2074,12 +2038,6 @@ msgstr "Ist der Crawler Open Source?"
 msgid "faq.q.trackerLimit"
 msgstr "Gibt es ein Limit, wie viele Jobs ich verfolgen kann?"
 
-#. Short January label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:62
-msgid "myJobs.heatmap.month.jan"
-msgstr "Jan"
-
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31
@@ -2221,18 +2179,6 @@ msgstr "Jobs bei {name}"
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:69
 msgid "watchlist.meta.jobsAt"
 msgstr "Jobs bei {names}"
-
-#. Short July label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:68
-msgid "myJobs.heatmap.month.jul"
-msgstr "Jul"
-
-#. Short June label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:67
-msgid "myJobs.heatmap.month.jun"
-msgstr "Jun"
 
 #. Add keyword filter
 #. js-lingui-explicit-id
@@ -2458,12 +2404,6 @@ msgstr "Abo verwalten"
 msgid "settings.account.socials.description"
 msgstr "Verwalte deine verknüpften Social-Media-Konten."
 
-#. Short March label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:64
-msgid "myJobs.heatmap.month.mar"
-msgstr "Mär"
-
 #. Quick action tooltip: mark job as applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/quick-actions.tsx:18
@@ -2493,12 +2433,6 @@ msgstr "Treffer"
 #: src/components/my-jobs/salary-override.tsx:43
 msgid "myJobs.salary.max"
 msgstr "Max"
-
-#. Short May label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:66
-msgid "myJobs.heatmap.month.may"
-msgstr "Mai"
 
 #. Aria label for the region containing the MCP install one-liner
 #. js-lingui-explicit-id
@@ -2543,12 +2477,6 @@ msgstr "Kopien"
 #: src/components/Features.tsx:308
 msgid "home.features.s3.p2.description"
 msgstr "Ein Unternehmen fehlt? Füge die Karriereseiten-URL ein und wir beginnen, es für dich zu indexieren."
-
-#. Short Monday label for heatmap
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:50
-msgid "myJobs.heatmap.day.mon"
-msgstr "Mo"
 
 #. WebApplication JSON-LD feature list item about career-page monitoring.
 #. js-lingui-explicit-id
@@ -2663,12 +2591,6 @@ msgstr "Neues Passwort"
 #: src/components/settings/AccountSettings.tsx:102
 msgid "settings.account.password.newLabel"
 msgstr "Neues Passwort"
-
-#. Heatmap tooltip when no applications on a date
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:83
-msgid "myJobs.heatmap.tooltipNone"
-msgstr "Keine Bewerbungen am {date}"
 
 #. CC right 2
 #. js-lingui-explicit-id
@@ -2808,23 +2730,11 @@ msgstr "Nicht beworben"
 msgid "app.home.request.issueWarning"
 msgstr "Hinweis: Wir konnten kein Tracking-Issue erstellen, aber Ihre Anfrage wurde gespeichert."
 
-#. Short November label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:72
-msgid "myJobs.heatmap.month.nov"
-msgstr "Nov"
-
 #. Add occupation filter
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-filter-editor.tsx:213
 msgid "watchlists.filters.occupation"
 msgstr "Berufsfeld"
-
-#. Short October label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:71
-msgid "myJobs.heatmap.month.oct"
-msgstr "Okt"
 
 #. Application tracker status: offer
 #. js-lingui-explicit-id
@@ -3923,12 +3833,6 @@ msgstr "Senden…"
 msgid "watchlists.filters.seniority"
 msgstr "Erfahrungsstufe"
 
-#. Short September label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:70
-msgid "myJobs.heatmap.month.sep"
-msgstr "Sep"
-
 #. Reset password page heading
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:119
@@ -4792,12 +4696,6 @@ msgstr "Wir fangen an, sie zu verfolgen"
 #: src/components/search/request-company-success.tsx:90
 msgid "app.home.request.agent.headingPrefix"
 msgstr "Wir arbeiten am Hinzufügen von"
-
-#. Short Wednesday label for heatmap
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:52
-msgid "myJobs.heatmap.day.wed"
-msgstr "Mi"
 
 #. Sign-in page subtitle
 #. js-lingui-explicit-id

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -93,11 +93,11 @@ msgstr "{count, plural, one {company} other {companies}}"
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {Tracking # company} other {Tracking # companies}}. {description}"
 
-#. Heatmap tooltip for multiple applications
+#. Heatmap tooltip shown when hovering an application-activity day; {date} is a YYYY-MM-DD date and {count} is the number of applications that day.
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:85
-msgid "myJobs.heatmap.tooltipMultiple"
-msgstr "{count} applications on {date}"
+#: src/components/my-jobs/activity-heatmap.tsx:117
+msgid "myJobs.heatmap.tooltip"
+msgstr "{count, plural, =0 {No applications on {date}} one {# application on {date}} other {# applications on {date}}}"
 
 #. SEO metadata suffix when a watchlist includes more companies than can be listed by name.
 #. js-lingui-explicit-id
@@ -158,12 +158,6 @@ msgstr "$10"
 #: src/components/settings/BillingSettings.tsx:152
 msgid "settings.billing.plan.proPrice"
 msgstr "$10 / month"
-
-#. Heatmap tooltip for 1 application
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:84
-msgid "myJobs.heatmap.tooltipOne"
-msgstr "1 application on {date}"
 
 #. Free feature: one watchlist
 #. js-lingui-explicit-id
@@ -479,12 +473,6 @@ msgstr "Apply"
 msgid "search.detail.apply"
 msgstr "Apply"
 
-#. Short April label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:65
-msgid "myJobs.heatmap.month.apr"
-msgstr "Apr"
-
 #. Step 3 body
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:129
@@ -502,12 +490,6 @@ msgstr "At least 3 characters"
 #: src/components/settings/AccountSettings.tsx:288
 msgid "settings.account.username.tooLong"
 msgstr "At most 30 characters"
-
-#. Short August label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:69
-msgid "myJobs.heatmap.month.aug"
-msgstr "Aug"
 
 #. Username is available
 #. js-lingui-explicit-id
@@ -1215,12 +1197,6 @@ msgstr "Data analyses, news, and breakdowns of industry reports and papers — d
 msgid "myJobs.sort.dateSaved"
 msgstr "Date saved"
 
-#. Short December label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:73
-msgid "myJobs.heatmap.month.dec"
-msgstr "Dec"
-
 #. Delete watchlist tooltip
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-action-bar.tsx:210
@@ -1560,12 +1536,6 @@ msgstr "FAQ"
 msgid "common.nav.features"
 msgstr "Features"
 
-#. Short February label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:63
-msgid "myJobs.heatmap.month.feb"
-msgstr "Feb"
-
 #. Button to add a filter to watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-filter-editor.tsx:352
@@ -1695,12 +1665,6 @@ msgstr "Free gives you full search across all companies, one watchlist, and the 
 #: app/[lang]/(public)/faq/faq-content.tsx:39
 msgid "faq.title"
 msgstr "Frequently asked questions"
-
-#. Short Friday label for heatmap
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:54
-msgid "myJobs.heatmap.day.fri"
-msgstr "Fri"
 
 #. Feature section 2 heading
 #. js-lingui-explicit-id
@@ -2074,12 +2038,6 @@ msgstr "Is the crawler open source?"
 msgid "faq.q.trackerLimit"
 msgstr "Is there a limit to how many jobs I can track?"
 
-#. Short January label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:62
-msgid "myJobs.heatmap.month.jan"
-msgstr "Jan"
-
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31
@@ -2221,18 +2179,6 @@ msgstr "Jobs at {name}"
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:69
 msgid "watchlist.meta.jobsAt"
 msgstr "Jobs at {names}"
-
-#. Short July label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:68
-msgid "myJobs.heatmap.month.jul"
-msgstr "Jul"
-
-#. Short June label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:67
-msgid "myJobs.heatmap.month.jun"
-msgstr "Jun"
 
 #. Add keyword filter
 #. js-lingui-explicit-id
@@ -2458,12 +2404,6 @@ msgstr "Manage subscription"
 msgid "settings.account.socials.description"
 msgstr "Manage your linked social accounts."
 
-#. Short March label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:64
-msgid "myJobs.heatmap.month.mar"
-msgstr "Mar"
-
 #. Quick action tooltip: mark job as applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/quick-actions.tsx:18
@@ -2493,12 +2433,6 @@ msgstr "Matches"
 #: src/components/my-jobs/salary-override.tsx:43
 msgid "myJobs.salary.max"
 msgstr "Max"
-
-#. Short May label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:66
-msgid "myJobs.heatmap.month.may"
-msgstr "May"
 
 #. Aria label for the region containing the MCP install one-liner
 #. js-lingui-explicit-id
@@ -2543,12 +2477,6 @@ msgstr "mirrors"
 #: src/components/Features.tsx:308
 msgid "home.features.s3.p2.description"
 msgstr "Missing a company? Paste its careers page URL and we start indexing it for you."
-
-#. Short Monday label for heatmap
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:50
-msgid "myJobs.heatmap.day.mon"
-msgstr "Mon"
 
 #. WebApplication JSON-LD feature list item about career-page monitoring.
 #. js-lingui-explicit-id
@@ -2663,12 +2591,6 @@ msgstr "New password"
 #: src/components/settings/AccountSettings.tsx:102
 msgid "settings.account.password.newLabel"
 msgstr "New password"
-
-#. Heatmap tooltip when no applications on a date
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:83
-msgid "myJobs.heatmap.tooltipNone"
-msgstr "No applications on {date}"
 
 #. CC right 2
 #. js-lingui-explicit-id
@@ -2808,23 +2730,11 @@ msgstr "Not applied"
 msgid "app.home.request.issueWarning"
 msgstr "Note: We couldn't create a tracking issue, but your request was saved."
 
-#. Short November label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:72
-msgid "myJobs.heatmap.month.nov"
-msgstr "Nov"
-
 #. Add occupation filter
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-filter-editor.tsx:213
 msgid "watchlists.filters.occupation"
 msgstr "Occupation"
-
-#. Short October label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:71
-msgid "myJobs.heatmap.month.oct"
-msgstr "Oct"
 
 #. Application tracker status: offer
 #. js-lingui-explicit-id
@@ -3923,12 +3833,6 @@ msgstr "Sending..."
 msgid "watchlists.filters.seniority"
 msgstr "Seniority"
 
-#. Short September label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:70
-msgid "myJobs.heatmap.month.sep"
-msgstr "Sep"
-
 #. Reset password page heading
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:119
@@ -4792,12 +4696,6 @@ msgstr "We'll start tracking it"
 #: src/components/search/request-company-success.tsx:90
 msgid "app.home.request.agent.headingPrefix"
 msgstr "We're working on adding"
-
-#. Short Wednesday label for heatmap
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:52
-msgid "myJobs.heatmap.day.wed"
-msgstr "Wed"
 
 #. Sign-in page subtitle
 #. js-lingui-explicit-id

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -93,11 +93,11 @@ msgstr "{count, plural, one {entreprise} other {entreprises}}"
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {# entreprise suivie} other {# entreprises suivies}}. {description}"
 
-#. Heatmap tooltip for multiple applications
+#. Heatmap tooltip shown when hovering an application-activity day; {date} is a YYYY-MM-DD date and {count} is the number of applications that day.
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:85
-msgid "myJobs.heatmap.tooltipMultiple"
-msgstr "{count} candidatures le {date}"
+#: src/components/my-jobs/activity-heatmap.tsx:117
+msgid "myJobs.heatmap.tooltip"
+msgstr "{count, plural, =0 {Aucune candidature le {date}} one {# candidature le {date}} other {# candidatures le {date}}}"
 
 #. SEO metadata suffix when a watchlist includes more companies than can be listed by name.
 #. js-lingui-explicit-id
@@ -158,12 +158,6 @@ msgstr "10 $"
 #: src/components/settings/BillingSettings.tsx:152
 msgid "settings.billing.plan.proPrice"
 msgstr "10 $ / mois"
-
-#. Heatmap tooltip for 1 application
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:84
-msgid "myJobs.heatmap.tooltipOne"
-msgstr "1 candidature le {date}"
 
 #. Free feature: one watchlist
 #. js-lingui-explicit-id
@@ -479,12 +473,6 @@ msgstr "Appliquer"
 msgid "search.detail.apply"
 msgstr "Postuler"
 
-#. Short April label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:65
-msgid "myJobs.heatmap.month.apr"
-msgstr "Avr"
-
 #. Step 3 body
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:129
@@ -502,12 +490,6 @@ msgstr "3 caractères minimum"
 #: src/components/settings/AccountSettings.tsx:288
 msgid "settings.account.username.tooLong"
 msgstr "30 caractères maximum"
-
-#. Short August label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:69
-msgid "myJobs.heatmap.month.aug"
-msgstr "Aoû"
 
 #. Username is available
 #. js-lingui-explicit-id
@@ -1215,12 +1197,6 @@ msgstr "Analyses de données, actualités et résumés de rapports sectoriels et
 msgid "myJobs.sort.dateSaved"
 msgstr "Date d'enregistrement"
 
-#. Short December label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:73
-msgid "myJobs.heatmap.month.dec"
-msgstr "Déc"
-
 #. Delete watchlist tooltip
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-action-bar.tsx:210
@@ -1560,12 +1536,6 @@ msgstr "FAQ"
 msgid "common.nav.features"
 msgstr "Fonctionnalités"
 
-#. Short February label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:63
-msgid "myJobs.heatmap.month.feb"
-msgstr "Fév"
-
 #. Button to add a filter to watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-filter-editor.tsx:352
@@ -1695,12 +1665,6 @@ msgstr "La version gratuite vous offre une recherche complète sur toutes les en
 #: app/[lang]/(public)/faq/faq-content.tsx:39
 msgid "faq.title"
 msgstr "Questions fréquentes"
-
-#. Short Friday label for heatmap
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:54
-msgid "myJobs.heatmap.day.fri"
-msgstr "Ven"
 
 #. Feature section 2 heading
 #. js-lingui-explicit-id
@@ -2074,12 +2038,6 @@ msgstr "Le crawler est-il open source ?"
 msgid "faq.q.trackerLimit"
 msgstr "Y a-t-il une limite au nombre d'offres que je peux suivre ?"
 
-#. Short January label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:62
-msgid "myJobs.heatmap.month.jan"
-msgstr "Jan"
-
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31
@@ -2221,18 +2179,6 @@ msgstr "Emplois chez {name}"
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:69
 msgid "watchlist.meta.jobsAt"
 msgstr "Emplois chez {names}"
-
-#. Short July label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:68
-msgid "myJobs.heatmap.month.jul"
-msgstr "Jul"
-
-#. Short June label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:67
-msgid "myJobs.heatmap.month.jun"
-msgstr "Jun"
 
 #. Add keyword filter
 #. js-lingui-explicit-id
@@ -2458,12 +2404,6 @@ msgstr "Gérer l'abonnement"
 msgid "settings.account.socials.description"
 msgstr "Gère tes comptes sociaux liés."
 
-#. Short March label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:64
-msgid "myJobs.heatmap.month.mar"
-msgstr "Mar"
-
 #. Quick action tooltip: mark job as applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/quick-actions.tsx:18
@@ -2493,12 +2433,6 @@ msgstr "Correspondances"
 #: src/components/my-jobs/salary-override.tsx:43
 msgid "myJobs.salary.max"
 msgstr "Max"
-
-#. Short May label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:66
-msgid "myJobs.heatmap.month.may"
-msgstr "Mai"
 
 #. Aria label for the region containing the MCP install one-liner
 #. js-lingui-explicit-id
@@ -2543,12 +2477,6 @@ msgstr "copies"
 #: src/components/Features.tsx:308
 msgid "home.features.s3.p2.description"
 msgstr "Une entreprise manque ? Colle l'URL de sa page carrières et nous commençons à l'indexer pour toi."
-
-#. Short Monday label for heatmap
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:50
-msgid "myJobs.heatmap.day.mon"
-msgstr "Lun"
 
 #. WebApplication JSON-LD feature list item about career-page monitoring.
 #. js-lingui-explicit-id
@@ -2663,12 +2591,6 @@ msgstr "Nouveau mot de passe"
 #: src/components/settings/AccountSettings.tsx:102
 msgid "settings.account.password.newLabel"
 msgstr "Nouveau mot de passe"
-
-#. Heatmap tooltip when no applications on a date
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:83
-msgid "myJobs.heatmap.tooltipNone"
-msgstr "Aucune candidature le {date}"
 
 #. CC right 2
 #. js-lingui-explicit-id
@@ -2808,23 +2730,11 @@ msgstr "Non postulé"
 msgid "app.home.request.issueWarning"
 msgstr "Remarque : Nous n'avons pas pu créer un ticket de suivi, mais votre demande a été enregistrée."
 
-#. Short November label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:72
-msgid "myJobs.heatmap.month.nov"
-msgstr "Nov"
-
 #. Add occupation filter
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-filter-editor.tsx:213
 msgid "watchlists.filters.occupation"
 msgstr "Métier"
-
-#. Short October label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:71
-msgid "myJobs.heatmap.month.oct"
-msgstr "Oct"
 
 #. Application tracker status: offer
 #. js-lingui-explicit-id
@@ -3923,12 +3833,6 @@ msgstr "Envoi…"
 msgid "watchlists.filters.seniority"
 msgstr "Niveau d'expérience"
 
-#. Short September label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:70
-msgid "myJobs.heatmap.month.sep"
-msgstr "Sep"
-
 #. Reset password page heading
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:119
@@ -4792,12 +4696,6 @@ msgstr "Nous commencerons à la suivre"
 #: src/components/search/request-company-success.tsx:90
 msgid "app.home.request.agent.headingPrefix"
 msgstr "Nous travaillons à ajouter"
-
-#. Short Wednesday label for heatmap
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:52
-msgid "myJobs.heatmap.day.wed"
-msgstr "Mer"
 
 #. Sign-in page subtitle
 #. js-lingui-explicit-id

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -93,11 +93,11 @@ msgstr "{count, plural, one {azienda} other {aziende}}"
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {# azienda monitorata} other {# aziende monitorate}}. {description}"
 
-#. Heatmap tooltip for multiple applications
+#. Heatmap tooltip shown when hovering an application-activity day; {date} is a YYYY-MM-DD date and {count} is the number of applications that day.
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:85
-msgid "myJobs.heatmap.tooltipMultiple"
-msgstr "{count} candidature il {date}"
+#: src/components/my-jobs/activity-heatmap.tsx:117
+msgid "myJobs.heatmap.tooltip"
+msgstr "{count, plural, =0 {Nessuna candidatura il {date}} one {# candidatura il {date}} other {# candidature il {date}}}"
 
 #. SEO metadata suffix when a watchlist includes more companies than can be listed by name.
 #. js-lingui-explicit-id
@@ -158,12 +158,6 @@ msgstr "10 $"
 #: src/components/settings/BillingSettings.tsx:152
 msgid "settings.billing.plan.proPrice"
 msgstr "10 $ / mese"
-
-#. Heatmap tooltip for 1 application
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:84
-msgid "myJobs.heatmap.tooltipOne"
-msgstr "1 candidatura il {date}"
 
 #. Free feature: one watchlist
 #. js-lingui-explicit-id
@@ -479,12 +473,6 @@ msgstr "Applica"
 msgid "search.detail.apply"
 msgstr "Candidati"
 
-#. Short April label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:65
-msgid "myJobs.heatmap.month.apr"
-msgstr "Apr"
-
 #. Step 3 body
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:129
@@ -502,12 +490,6 @@ msgstr "Minimo 3 caratteri"
 #: src/components/settings/AccountSettings.tsx:288
 msgid "settings.account.username.tooLong"
 msgstr "Massimo 30 caratteri"
-
-#. Short August label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:69
-msgid "myJobs.heatmap.month.aug"
-msgstr "Ago"
 
 #. Username is available
 #. js-lingui-explicit-id
@@ -1215,12 +1197,6 @@ msgstr "Analisi dei dati, novità e riepiloghi di report e studi di settore — 
 msgid "myJobs.sort.dateSaved"
 msgstr "Data di salvataggio"
 
-#. Short December label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:73
-msgid "myJobs.heatmap.month.dec"
-msgstr "Dic"
-
 #. Delete watchlist tooltip
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-action-bar.tsx:210
@@ -1560,12 +1536,6 @@ msgstr "FAQ"
 msgid "common.nav.features"
 msgstr "Funzionalità"
 
-#. Short February label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:63
-msgid "myJobs.heatmap.month.feb"
-msgstr "Feb"
-
 #. Button to add a filter to watchlist
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-filter-editor.tsx:352
@@ -1695,12 +1665,6 @@ msgstr "La versione gratuita offre ricerca completa su tutte le aziende, una wat
 #: app/[lang]/(public)/faq/faq-content.tsx:39
 msgid "faq.title"
 msgstr "Domande frequenti"
-
-#. Short Friday label for heatmap
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:54
-msgid "myJobs.heatmap.day.fri"
-msgstr "Ven"
 
 #. Feature section 2 heading
 #. js-lingui-explicit-id
@@ -2074,12 +2038,6 @@ msgstr "Il crawler è open source?"
 msgid "faq.q.trackerLimit"
 msgstr "C'è un limite al numero di offerte che posso tracciare?"
 
-#. Short January label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:62
-msgid "myJobs.heatmap.month.jan"
-msgstr "Gen"
-
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31
@@ -2221,18 +2179,6 @@ msgstr "Lavori presso {name}"
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:69
 msgid "watchlist.meta.jobsAt"
 msgstr "Lavori presso {names}"
-
-#. Short July label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:68
-msgid "myJobs.heatmap.month.jul"
-msgstr "Lug"
-
-#. Short June label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:67
-msgid "myJobs.heatmap.month.jun"
-msgstr "Giu"
 
 #. Add keyword filter
 #. js-lingui-explicit-id
@@ -2458,12 +2404,6 @@ msgstr "Gestisci abbonamento"
 msgid "settings.account.socials.description"
 msgstr "Gestisci i tuoi account social collegati."
 
-#. Short March label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:64
-msgid "myJobs.heatmap.month.mar"
-msgstr "Mar"
-
 #. Quick action tooltip: mark job as applied
 #. js-lingui-explicit-id
 #: src/components/my-jobs/quick-actions.tsx:18
@@ -2493,12 +2433,6 @@ msgstr "Risultati"
 #: src/components/my-jobs/salary-override.tsx:43
 msgid "myJobs.salary.max"
 msgstr "Max"
-
-#. Short May label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:66
-msgid "myJobs.heatmap.month.may"
-msgstr "Mag"
 
 #. Aria label for the region containing the MCP install one-liner
 #. js-lingui-explicit-id
@@ -2543,12 +2477,6 @@ msgstr "copie"
 #: src/components/Features.tsx:308
 msgid "home.features.s3.p2.description"
 msgstr "Manca un'azienda? Incolla l'URL della sua pagina carriere e iniziamo a indicizzarla per te."
-
-#. Short Monday label for heatmap
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:50
-msgid "myJobs.heatmap.day.mon"
-msgstr "Lun"
 
 #. WebApplication JSON-LD feature list item about career-page monitoring.
 #. js-lingui-explicit-id
@@ -2663,12 +2591,6 @@ msgstr "Nuova password"
 #: src/components/settings/AccountSettings.tsx:102
 msgid "settings.account.password.newLabel"
 msgstr "Nuova password"
-
-#. Heatmap tooltip when no applications on a date
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:83
-msgid "myJobs.heatmap.tooltipNone"
-msgstr "Nessuna candidatura il {date}"
 
 #. CC right 2
 #. js-lingui-explicit-id
@@ -2808,23 +2730,11 @@ msgstr "Non candidato"
 msgid "app.home.request.issueWarning"
 msgstr "Nota: Non siamo riusciti a creare un ticket di monitoraggio, ma la tua richiesta è stata salvata."
 
-#. Short November label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:72
-msgid "myJobs.heatmap.month.nov"
-msgstr "Nov"
-
 #. Add occupation filter
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-filter-editor.tsx:213
 msgid "watchlists.filters.occupation"
 msgstr "Professione"
-
-#. Short October label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:71
-msgid "myJobs.heatmap.month.oct"
-msgstr "Ott"
 
 #. Application tracker status: offer
 #. js-lingui-explicit-id
@@ -3923,12 +3833,6 @@ msgstr "Invio…"
 msgid "watchlists.filters.seniority"
 msgstr "Livello di esperienza"
 
-#. Short September label
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:70
-msgid "myJobs.heatmap.month.sep"
-msgstr "Set"
-
 #. Reset password page heading
 #. js-lingui-explicit-id
 #: app/[lang]/reset-password/page.tsx:119
@@ -4792,12 +4696,6 @@ msgstr "Inizieremo a monitorarla"
 #: src/components/search/request-company-success.tsx:90
 msgid "app.home.request.agent.headingPrefix"
 msgstr "Stiamo lavorando per aggiungere"
-
-#. Short Wednesday label for heatmap
-#. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:52
-msgid "myJobs.heatmap.day.wed"
-msgstr "Mer"
 
 #. Sign-in page subtitle
 #. js-lingui-explicit-id

--- a/apps/web/src/components/my-jobs/__tests__/activity-heatmap.test.tsx
+++ b/apps/web/src/components/my-jobs/__tests__/activity-heatmap.test.tsx
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render } from "@testing-library/react";
+import { fireEvent, render } from "@testing-library/react";
+import { readFileSync } from "node:fs";
 import { ActivityHeatmap } from "../activity-heatmap";
 
 /**
@@ -22,10 +23,35 @@ import { ActivityHeatmap } from "../activity-heatmap";
  *     same component to prove the alignment matters.
  */
 
+const linguiState = vi.hoisted(() => ({ locale: "en" }));
+const translateDescriptor = vi.hoisted(() => (
+  {
+    format({
+      id,
+      message,
+      values = {},
+    }: {
+      id?: string;
+      message?: string;
+      values?: Record<string, unknown>;
+    }) {
+      if (id === "myJobs.heatmap.tooltip") {
+        const count = Number(values.count ?? 0);
+        const date = String(values.date ?? "");
+        if (count === 0) return `No applications on ${date}`;
+        if (count === 1) return `1 application on ${date}`;
+        return `${count} applications on ${date}`;
+      }
+      return (message ?? "").replace(/\{(\w+)\}/g, (_, key: string) => String(values[key] ?? ""));
+    },
+  }
+));
+
 // Lingui hook is required by the component for label rendering; stub it.
 vi.mock("@lingui/react/macro", () => ({
   useLingui: () => ({
-    t: ({ message }: { message?: string }) => message ?? "",
+    i18n: { locale: linguiState.locale, _: translateDescriptor.format },
+    t: translateDescriptor.format,
   }),
 }));
 
@@ -51,6 +77,7 @@ function findCellByDate(
 
 describe("ActivityHeatmap — TZ-aligned cell rendering (#3199)", () => {
   beforeEach(() => {
+    linguiState.locale = "en";
     vi.useFakeTimers();
   });
   afterEach(() => {
@@ -143,5 +170,67 @@ describe("ActivityHeatmap — TZ-aligned cell rendering (#3199)", () => {
     for (const cell of cells) {
       expect(cell.getAttribute("data-count")).toBe("0");
     }
+  });
+});
+
+describe("ActivityHeatmap — locale labels and plural tooltip (#3150)", () => {
+  beforeEach(() => {
+    linguiState.locale = "en";
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("uses a single ICU tooltip key and browser Intl labels instead of catalog-backed month/day keys", () => {
+    const source = readFileSync("src/components/my-jobs/activity-heatmap.tsx", "utf8");
+
+    expect(source).toContain('id: "myJobs.heatmap.tooltip"');
+    expect(source).toContain("{count, plural, =0");
+    expect(source).toContain("Intl.DateTimeFormat");
+    expect(source).not.toContain("myJobs.heatmap.tooltipNone");
+    expect(source).not.toContain("myJobs.heatmap.tooltipOne");
+    expect(source).not.toContain("myJobs.heatmap.tooltipMultiple");
+    expect(source).not.toContain("myJobs.heatmap.month.");
+    expect(source).not.toContain("myJobs.heatmap.day.");
+  });
+
+  it("renders weekday and month labels from the active locale", () => {
+    linguiState.locale = "de";
+    vi.setSystemTime(new Date(2026, 6, 15, 12, 0, 0, 0));
+
+    const { container } = render(<ActivityHeatmap data={[]} />);
+    const labels = Array.from(container.querySelectorAll("text"))
+      .map((el) => el.textContent)
+      .filter(Boolean);
+
+    expect(labels).toContain(new Intl.DateTimeFormat("de", { weekday: "short" }).format(new Date(2026, 0, 5)));
+    expect(labels).toContain(new Intl.DateTimeFormat("de", { weekday: "short" }).format(new Date(2026, 0, 7)));
+    expect(labels).toContain(new Intl.DateTimeFormat("de", { weekday: "short" }).format(new Date(2026, 0, 9)));
+    expect(labels).toContain(new Intl.DateTimeFormat("de", { month: "short" }).format(new Date(2026, 6, 1)));
+  });
+
+  const tooltipCases: Array<[number, string]> = [
+    [0, "No applications"],
+    [1, "1 application"],
+    [4, "4 applications"],
+  ];
+
+  it.each(tooltipCases)("renders tooltip plural branch for count %i", (count, prefix) => {
+    const now = new Date();
+    now.setHours(12, 0, 0, 0);
+    vi.setSystemTime(now);
+
+    const todayKey = formatLocal(now);
+    const { container } = render(
+      <ActivityHeatmap data={count > 0 ? [{ date: todayKey, count }] : []} />,
+    );
+
+    const todayCell = findCellByDate(container, todayKey);
+    expect(todayCell).toBeDefined();
+    fireEvent.mouseEnter(todayCell!);
+
+    expect(container.textContent).toContain(`${prefix} on ${todayKey}`);
   });
 });

--- a/apps/web/src/components/my-jobs/activity-heatmap.tsx
+++ b/apps/web/src/components/my-jobs/activity-heatmap.tsx
@@ -43,46 +43,29 @@ function getLevel(count: number): number {
   return 4;
 }
 
-function useDayLabels(): string[] {
-  const { t } = useLingui();
-  return [
-    "",
-    t({ id: "myJobs.heatmap.day.mon", comment: "Short Monday label for heatmap", message: "Mon" }),
-    "",
-    t({ id: "myJobs.heatmap.day.wed", comment: "Short Wednesday label for heatmap", message: "Wed" }),
-    "",
-    t({ id: "myJobs.heatmap.day.fri", comment: "Short Friday label for heatmap", message: "Fri" }),
-    "",
-  ];
+function useDayLabels(locale: string): string[] {
+  return useMemo(() => {
+    const formatter = new Intl.DateTimeFormat(locale, { weekday: "short" });
+    return Array.from({ length: DAYS }, (_, day) => {
+      if (day % 2 === 0) return "";
+      return formatter.format(new Date(2026, 0, 5 + (day - 1)));
+    });
+  }, [locale]);
 }
 
-function useMonthLabels(): string[] {
-  const { t } = useLingui();
-  return [
-    t({ id: "myJobs.heatmap.month.jan", comment: "Short January label", message: "Jan" }),
-    t({ id: "myJobs.heatmap.month.feb", comment: "Short February label", message: "Feb" }),
-    t({ id: "myJobs.heatmap.month.mar", comment: "Short March label", message: "Mar" }),
-    t({ id: "myJobs.heatmap.month.apr", comment: "Short April label", message: "Apr" }),
-    t({ id: "myJobs.heatmap.month.may", comment: "Short May label", message: "May" }),
-    t({ id: "myJobs.heatmap.month.jun", comment: "Short June label", message: "Jun" }),
-    t({ id: "myJobs.heatmap.month.jul", comment: "Short July label", message: "Jul" }),
-    t({ id: "myJobs.heatmap.month.aug", comment: "Short August label", message: "Aug" }),
-    t({ id: "myJobs.heatmap.month.sep", comment: "Short September label", message: "Sep" }),
-    t({ id: "myJobs.heatmap.month.oct", comment: "Short October label", message: "Oct" }),
-    t({ id: "myJobs.heatmap.month.nov", comment: "Short November label", message: "Nov" }),
-    t({ id: "myJobs.heatmap.month.dec", comment: "Short December label", message: "Dec" }),
-  ];
+function useMonthLabels(locale: string): string[] {
+  return useMemo(() => {
+    const formatter = new Intl.DateTimeFormat(locale, { month: "short" });
+    return Array.from({ length: 12 }, (_, month) => formatter.format(new Date(2026, month, 1)));
+  }, [locale]);
 }
 
 export function ActivityHeatmap({ data }: { data: ActivityDay[] }) {
   const [tooltip, setTooltip] = useState<{ x: number; y: number; text: string } | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const DAY_LABELS = useDayLabels();
-  const MONTHS = useMonthLabels();
-  const { t } = useLingui();
-  const noApplications = t({ id: "myJobs.heatmap.tooltipNone", comment: "Heatmap tooltip when no applications on a date", message: "No applications on {date}" });
-  const oneApplication = t({ id: "myJobs.heatmap.tooltipOne", comment: "Heatmap tooltip for 1 application", message: "1 application on {date}" });
-  const multipleApplications = t({ id: "myJobs.heatmap.tooltipMultiple", comment: "Heatmap tooltip for multiple applications", message: "{count} applications on {date}" });
+  const { i18n } = useLingui();
+  const DAY_LABELS = useDayLabels(i18n.locale);
+  const MONTHS = useMonthLabels(i18n.locale);
 
   const { grid, monthHeaders } = useMemo(() => {
     const map = new Map(data.map((d) => [d.date, d.count]));
@@ -118,7 +101,7 @@ export function ActivityHeatmap({ data }: { data: ActivityDay[] }) {
     }
 
     return { grid: columns, monthHeaders };
-  }, [data]);
+  }, [data, MONTHS]);
 
   const labelW = 26;
   const monthH = 15;
@@ -131,11 +114,12 @@ export function ActivityHeatmap({ data }: { data: ActivityDay[] }) {
     const rect = (e.target as SVGElement).getBoundingClientRect();
     const container = containerRef.current?.getBoundingClientRect();
     if (!container) return;
-    const text = cell.count === 0
-      ? noApplications.replace("{date}", cell.date)
-      : cell.count === 1
-        ? oneApplication.replace("{date}", cell.date)
-        : multipleApplications.replace("{count}", String(cell.count)).replace("{date}", cell.date);
+    const text = i18n._({
+      id: "myJobs.heatmap.tooltip",
+      comment: "Heatmap tooltip shown when hovering an application-activity day; {date} is a YYYY-MM-DD date and {count} is the number of applications that day.",
+      message: "{count, plural, =0 {No applications on {date}} one {# application on {date}} other {# applications on {date}}}",
+      values: { count: cell.count, date: cell.date },
+    });
     setTooltip({ x: rect.left - container.left + CELL / 2, y: rect.top - container.top - 4, text });
   }
 


### PR DESCRIPTION
## Summary
- replace activity heatmap weekday/month translation keys with locale-aware `Intl.DateTimeFormat(i18n.locale, ...)`
- collapse split none/one/multiple heatmap tooltip keys into one ICU plural descriptor with `=0`, `one`, and `other`
- remove obsolete heatmap day/month/tooltip catalog entries and add focused source/behavior regression coverage

## Reproduction / production probe
- Source/catalog audit reproduced the issue: `activity-heatmap.tsx` used 3 tooltip keys plus 3 weekday and 12 month catalog labels.
- Read-only production probe for `https://jseek.co/de/my-jobs/stats` returned HTTP 200 for the prerendered/auth shell and exposed localized heatmap strings; the actionable defect is source-level i18n structure rather than a public data mutation path.

## Validation
- `git diff --check`
- Source/catalog `rg` guard confirmed no obsolete `myJobs.heatmap.tooltipNone`, `tooltipOne`, `tooltipMultiple`, `month.*`, or `day.*` IDs remain in the component/catalogs
- Locale-entry inspection confirmed `myJobs.heatmap.tooltip` exists in en/de/fr/it with ICU plural forms
- `pnpm exec vitest run src/components/my-jobs/__tests__/activity-heatmap.test.tsx` could not run locally because current `origin/main` lockfile entries from the Dependabot update trip the active minimum-release-age policy before tests start (`@lingui/*@6.5.0`, `@vitest/*@4.1.10`, etc.). The failed install also left no workspace `eslint`/Vitest links, so the commit hook ESLint step could not execute locally. CI should run the normal workspace validation.

Closes #3150