### PR TITLE
Fix company not-found cache miss handling

### DIFF
--- a/apps/web/src/lib/actions/__tests__/company.test.ts
+++ b/apps/web/src/lib/actions/__tests__/company.test.ts
@@ -7,6 +7,9 @@ import { setTestEnv, withTestEnv } from "@/test-utils/env";
 const mocks = vi.hoisted(() => ({
   cacheLife: vi.fn(),
   cacheTag: vi.fn(),
+  cached: vi.fn(
+    (_key: string, fetcher: () => Promise<unknown>, _options: unknown) => fetcher(),
+  ),
   search: vi.fn(),
   dbExecute: vi.fn(),
   buildFilterString: vi.fn(() => ""),
@@ -26,6 +29,9 @@ vi.mock("server-only", () => ({}));
 vi.mock("next/cache", () => ({
   cacheLife: mocks.cacheLife,
   cacheTag: mocks.cacheTag,
+}));
+vi.mock("@/lib/cache", () => ({
+  cached: mocks.cached,
 }));
 
 vi.mock("@/lib/search/typesense-client", () => ({
@@ -98,8 +104,7 @@ import { getCompanyBySlug, searchCompaniesForWatchlist } from "../company";
 
 const searchMock = mocks.search;
 const dbExecuteMock = mocks.dbExecute;
-const cacheLifeMock = mocks.cacheLife;
-const cacheTagMock = mocks.cacheTag;
+const cachedMock = mocks.cached;
 const buildFilterStringMock = mocks.buildFilterString;
 const TEST_ENV = {
   DATABASE_URL:
@@ -135,6 +140,9 @@ withTestEnv(TEST_ENV);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  cachedMock.mockImplementation(
+    (_key: string, fetcher: () => Promise<unknown>, _options: unknown) => fetcher(),
+  );
   searchMock.mockReset();
   dbExecuteMock.mockReset();
   buildFilterStringMock.mockReset();
@@ -509,47 +517,48 @@ describe("getCompanyBySlug — Postgres fallback", () => {
 });
 
 describe("getCompanyBySlug — caching contract", () => {
-  it("calls cacheLife('hours') + cacheTag(company:slug) + cacheTag(company-csv-data) on a hit", async () => {
-    /** #2884 bucket 4 footgun migration: under `'use cache'` a
-     * `null` return would pin a brand-new slug for the cacheLife
-     * window. The wrapper throws `CompanyNotFoundError` past the
-     * cache boundary on null and the outer catches → returns null,
-     * keeping the slot empty. The contract this test asserts is the
-     * tagging surface (so the page-level `revalidateTag` and the
-     * `/api/internal/invalidate-typeahead` CSV-driven sweep both
-     * still drop the slot when needed). The null-handling itself is
-     * covered by the Postgres-fallback `returns null` test above. */
+  it("uses the shared company-slug cache with skip-null semantics on a hit", async () => {
+    /** #3603 regression: company slug misses must not throw sentinel
+     * errors from a `'use cache'` boundary, because Next serializes the
+     * caught throw into the RSC payload. Redis `cached()` keeps the old
+     * skip-null contract without leaking an error digest. */
     searchMock.mockResolvedValue(_typesenseResponse(_hit()));
 
     const out = await getCompanyBySlug("acme", "en");
 
     expect(out?.id).toBe("co-1");
-    expect(cacheLifeMock).toHaveBeenCalledWith("hours");
-    const tags = cacheTagMock.mock.calls.map((c) => c[0]);
-    expect(tags).toContain("company:acme");
-    expect(tags).toContain("company-csv-data");
+    expect(cachedMock).toHaveBeenCalledTimes(1);
+    const [key, _fetcher, options] = cachedMock.mock.calls[0] as [
+      string,
+      () => Promise<unknown>,
+      { ttl: number; skipIf: (data: unknown) => boolean },
+    ];
+    expect(key).toBe("company-slug:acme:en");
+    expect(options.ttl).toBe(600);
+    expect(options.skipIf(null)).toBe(true);
+    expect(options.skipIf(out)).toBe(false);
   });
 
-  it("returns null without re-throwing CompanyNotFoundError on miss", async () => {
-    /** Regression for the throw-and-catch wrapper: the inner
-     * `_fetchCompanyBySlugCached` throws `CompanyNotFoundError` so
-     * the `'use cache'` slot stays empty for the next attempt. The
-     * outer `getCompanyBySlug` MUST swallow that one error class
-     * and return null — leaking the throw would 500 the route. */
+  it("returns null on miss without throwing a cache-boundary sentinel", async () => {
+    /** The returned null is not cached by Redis because the skipIf
+     * predicate above treats null as a miss. That preserves retry-on-
+     * next-request behavior for brand-new slugs without throwing. */
     searchMock.mockResolvedValue(_typesenseResponse(null));
     dbExecuteMock.mockResolvedValue([]);
 
     const out = await getCompanyBySlug("ghost-slug", "en");
     expect(out).toBeNull();
+    const options = cachedMock.mock.calls[0][2] as {
+      skipIf: (data: unknown) => boolean;
+    };
+    expect(options.skipIf(out)).toBe(true);
   });
 
   it("re-throws unexpected errors past the wrapper", async () => {
-    /** Empirical guard for #2884 bucket 4: the catch-and-null path is
-     * scoped to `CompanyNotFoundError` only. A genuine downstream
-     * failure (DB pool exhausted, Drizzle parse error, …) MUST
-     * propagate so Suspense / error boundaries trigger; silently
-     * nulling here would surface as a 404 instead of a 5xx and hide
-     * the outage. */
+    /** A genuine downstream failure (DB pool exhausted, Drizzle parse
+     * error, etc.) MUST propagate so Suspense / error boundaries
+     * trigger; silently nulling here would surface as a 404 instead of
+     * a 5xx and hide the outage. */
     searchMock.mockRejectedValue(new Error("TYPESENSE_SEARCH_KEY is not set"));
     const boom = new Error("postgres pool exhausted");
     dbExecuteMock.mockRejectedValue(boom);

--- a/apps/web/src/lib/services/company.ts
+++ b/apps/web/src/lib/services/company.ts
@@ -3,13 +3,13 @@ import "server-only";
 import { sql } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 import { db } from "@/db";
-import { CACHE_TTL_MEDIUM, CACHE_TTL_LONG } from "@/lib/cache-ttl";
+import { CACHE_TTL_MEDIUM, CACHE_TTL_LONG, CACHE_TTL_DETAIL } from "@/lib/cache-ttl";
+import { cached } from "@/lib/cache";
 import { withDbRetry } from "@/lib/db-retry";
 import { getSearchProvider } from "@/lib/search";
 import type { SearchResultPosting, WorkMode } from "@/lib/search";
 import {
   companyByIdCacheTag,
-  companyCacheTag,
   companyCsvDataCacheTag,
   typeaheadCompaniesCacheTag,
 } from "@/lib/cache-tags";
@@ -637,19 +637,6 @@ export interface CompanyDetail {
   activeJobCount: number;
 }
 
-// Sentinel to signal "no company found" out of `_fetchCompanyBySlugCached`
-// without letting `null` reach the `'use cache'` boundary. Returning null
-// would pin the slot for the cacheLife window and lock a brand-new slug
-// out of being seen for up to that long. Throwing past the cache boundary
-// (caught by `getCompanyBySlug`) keeps the slot empty and lets the next
-// request retry. See #2884 footgun.
-class CompanyNotFoundError extends Error {
-  constructor() {
-    super("company-not-found");
-    this.name = "CompanyNotFoundError";
-  }
-}
-
 export async function getCompanyBySlug(
   slug: string,
   locale: string,
@@ -658,42 +645,14 @@ export async function getCompanyBySlug(
     console.warn("[company] lookup skipped because Typesense and DATABASE_URL are not configured");
     return null;
   }
-  // Throw-and-catch around the `'use cache'` inner. The previous
-  // `skipIf: d === null` semantics aren't available under `'use cache'` —
-  // the inner fetcher throws `CompanyNotFoundError` on null so the cache
-  // slot stays empty for not-yet-seen slugs (avoids 600s of poisoned
-  // null), and the wrapper returns null to the caller. Migrated from
-  // Redis-backed `cached()` in #2884 (bucket 4 footgun).
-  try {
-    return await _fetchCompanyBySlugCached(slug, locale);
-  } catch (err) {
-    if (err instanceof CompanyNotFoundError) return null;
-    // Any other error is unexpected — re-throw so the caller / Suspense
-    // boundary handles it (matches the original `cached()` behaviour
-    // where unexpected errors propagated past the cache layer).
-    throw err;
-  }
-}
-
-async function _fetchCompanyBySlugCached(
-  slug: string,
-  locale: string,
-): Promise<CompanyDetail> {
-  "use cache";
-  cacheLife("hours");
-  // Tag the slot so the page route's `revalidateTag(companyCacheTag(slug))`
-  // (already used in `app/[lang]/(app)/company/[slug]/page.tsx` and
-  // `generateMetadata`) drops THIS slot too — keeping the data layer's
-  // cached entry in sync with the page-level cache. See #2884.
-  cacheTag(companyCacheTag(slug));
-  // Also drop on a CSV-driven sweep — covers rename / industry change.
-  // Mirrors the legacy `company-slug:` Redis-prefix sweep at the
-  // `/api/internal/invalidate-typeahead` route. See #2715 + #2884.
-  cacheTag(companyCsvDataCacheTag());
-
-  const data = await _fetchCompanyBySlug(slug, locale);
-  if (data === null) throw new CompanyNotFoundError();
-  return data;
+  const key = `company-slug:${slug}:${locale}`;
+  // Empty-result skipping is load-bearing here: a not-yet-indexed company
+  // should be retried on the next request, but throwing a sentinel from a
+  // `'use cache'` boundary leaks that error into the RSC payload (#3603).
+  return cached(key, () => _fetchCompanyBySlug(slug, locale), {
+    ttl: CACHE_TTL_DETAIL,
+    skipIf: (data) => data === null,
+  });
 }
 
 async function _fetchCompanyBySlug(slug: string, locale: string): Promise<CompanyDetail | null> {


### PR DESCRIPTION
## Summary
- replace the thrown `CompanyNotFoundError` sentinel under the company slug `use cache` lookup with the existing Redis `cached()` helper
- preserve the `company-slug:${slug}:${locale}` cache key and skip-null behavior so unknown/new slugs are retried without serializing an error into the RSC payload
- update the company action regression test to assert the skip-null cache contract

## Reproduction
- production fresh missing slug returned HTTP 200 with localized `Entreprise introuvable` but embedded `company-not-found`/digest markers
- valid `/fr/company/apple` control rendered normally

## Validation
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm --dir apps/web test src/lib/actions/__tests__/company.test.ts`
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm --dir apps/web exec eslint src/lib/services/company.ts src/lib/actions/__tests__/company.test.ts`
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm --dir apps/web typecheck`
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm --dir apps/web build`
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm --dir apps/web test`
- `git diff --check`
- local built-server probe using main-tree web env read-only: fresh missing slug returned localized not-found copy with zero `CompanyNotFoundError` / `company-not-found` / digest markers

Closes #3603