### PR TITLE
Share watchlist filter pill renderer

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
-import { X, Loader2, MapPin, Briefcase, BarChart3, Code2, DollarSign, Clock, Building2, Pencil, CalendarDays, Home } from "lucide-react";
+import { Loader2, Building2, Pencil } from "lucide-react";
 import { BackLink } from "@/components/BackLink";
 import { useLingui } from "@lingui/react/macro";
 import { useLocalePath } from "@/lib/useLocalePath";
@@ -548,104 +548,25 @@ export function WatchlistViewPage({
               onExperienceChange={onExperienceChange}
               histogramFilters={histogramFilters}
             />
-            {hasFilters && (
-              <div className="flex flex-wrap items-center gap-2">
-                {occupations.map((occ) => {
-                  const name = occ.name;
-                  return (
-                    <span key={`occ-${occ.id}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
-                      <Briefcase size={12} className="shrink-0" />
-                      {name}
-                      <button onClick={() => onRemoveOccupation(occ.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${name} filter` })}><X size={12} aria-hidden="true" /></button>
-                    </span>
-                  );
-                })}
-                {seniorities.map((sen) => {
-                  const name = sen.name;
-                  return (
-                    <span key={`sen-${sen.id}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
-                      <BarChart3 size={12} className="shrink-0" />
-                      {name}
-                      <button onClick={() => onRemoveSeniority(sen.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${name} filter` })}><X size={12} aria-hidden="true" /></button>
-                    </span>
-                  );
-                })}
-                {technologies.map((tech) => {
-                  const name = tech.name;
-                  return (
-                    <span key={`tech-${tech.id}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
-                      <Code2 size={12} className="shrink-0" />
-                      {name}
-                      <button onClick={() => onRemoveTechnology(tech.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${name} filter` })}><X size={12} aria-hidden="true" /></button>
-                    </span>
-                  );
-                })}
-                {employmentTypes.map((et) => {
-                  const name = et.replace(/_/g, " ");
-                  return (
-                    <span key={`et-${et}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm capitalize text-primary">
-                      <CalendarDays size={12} className="shrink-0" />
-                      {name}
-                      <button onClick={() => onToggleEmploymentType(et)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${name} filter` })}><X size={12} aria-hidden="true" /></button>
-                    </span>
-                  );
-                })}
-                {workMode.map((wm) => {
-                  const name = wm === "onsite"
-                    ? t({ id: "search.workMode.onsite", comment: "Work mode: onsite (in-office)", message: "On-site" })
-                    : wm === "hybrid"
-                      ? t({ id: "search.workMode.hybrid", comment: "Work mode: hybrid (mixed onsite/remote)", message: "Hybrid" })
-                      : t({ id: "search.workMode.remote", comment: "Work mode: remote (work-from-home)", message: "Remote" });
-                  return (
-                    <span key={`wm-${wm}`} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
-                      <Home size={12} className="shrink-0" />
-                      {name}
-                      <button onClick={() => onToggleWorkMode(wm)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${name} filter` })}><X size={12} aria-hidden="true" /></button>
-                    </span>
-                  );
-                })}
-                {(salaryMin != null || salaryMax != null) && (
-                  <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
-                    <DollarSign size={12} className="shrink-0" />
-                    {salaryMin != null && salaryMax != null
-                      ? `${salaryCurrency} ${Math.round(salaryMin / 1000)}K – ${Math.round(salaryMax / 1000)}K`
-                      : salaryMin != null ? `${salaryCurrency} ${Math.round(salaryMin / 1000)}K+` : `${salaryCurrency} ≤${Math.round(salaryMax! / 1000)}K`}
-                    <button onClick={() => onSalaryChange(salaryCurrency, undefined, undefined)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeSalary", comment: "Aria label for the X button that clears the salary-range filter", message: "Remove salary filter" })}><X size={12} aria-hidden="true" /></button>
-                  </span>
-                )}
-                {(experienceMin != null || experienceMax != null) && (
-                  <span className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
-                    <Clock size={12} className="shrink-0" />
-                    {experienceMin != null && experienceMax != null
-                      ? `${experienceMin}–${experienceMax}y`
-                      : experienceMin != null ? `${experienceMin}y+` : `≤${experienceMax}y`}
-                    <button onClick={() => onExperienceChange(undefined, undefined)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeExperience", comment: "Aria label for the X button that clears the experience-range filter", message: "Remove experience filter" })}><X size={12} aria-hidden="true" /></button>
-                  </span>
-                )}
-                {keywords.map((kw) => {
-                  const name = kw;
-                  return (
-                    <span key={kw} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
-                      {name}
-                      <button onClick={() => onRemoveKeyword(kw)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeKeyword", comment: "Aria label for remove-keyword X button; {name} is the keyword", message: `Remove keyword ${name}` })}><X size={12} aria-hidden="true" /></button>
-                    </span>
-                  );
-                })}
-                {locations.map((loc) => {
-                  const name = loc.parentName && loc.type !== "country" && loc.type !== "macro" ? `${loc.name}, ${loc.parentName}` : loc.name;
-                  return (
-                    <span key={loc.id} className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary">
-                      <MapPin size={12} className="shrink-0" />
-                      {name}
-                      <button onClick={() => onRemoveLocation(loc.id)} className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer" aria-label={t({ id: "search.filters.removeLocation", comment: "Aria label for remove-location X button; {name} is the location label", message: `Remove location ${name}` })}><X size={12} aria-hidden="true" /></button>
-                    </span>
-                  );
-                })}
-                <button onClick={onClearAll} className="cursor-pointer text-xs text-muted transition-colors hover:text-foreground">
-                  {t({ id: "search.filters.clearAll", comment: "Button to clear all active search filters", message: "Clear all" })}
-                </button>
-              </div>
-            )}
+            <FilterPillsReadOnly
+              filters={buildFilters()}
+              locations={locations}
+              occupations={occupations}
+              seniorities={seniorities}
+              technologies={technologies}
+              workMode={workMode}
+              employmentType={employmentTypes}
+              onRemoveKeyword={onRemoveKeyword}
+              onRemoveLocation={(loc) => onRemoveLocation(loc.id)}
+              onRemoveOccupation={(occ) => onRemoveOccupation(occ.id)}
+              onRemoveSeniority={(sen) => onRemoveSeniority(sen.id)}
+              onRemoveTechnology={(tech) => onRemoveTechnology(tech.id)}
+              onToggleEmploymentType={onToggleEmploymentType}
+              onToggleWorkMode={onToggleWorkMode}
+              onRemoveSalary={() => onSalaryChange(salaryCurrency, undefined, undefined)}
+              onRemoveExperience={() => onExperienceChange(undefined, undefined)}
+              onClearAll={hasFilters ? onClearAll : undefined}
+            />
           </div>
         ) : (
           <FilterPillsReadOnly

--- a/apps/web/src/components/__tests__/filter-pill-remove-labels.test.tsx
+++ b/apps/web/src/components/__tests__/filter-pill-remove-labels.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 
 vi.mock("server-only", () => ({}));
 
@@ -37,6 +37,7 @@ vi.mock("@/lib/useLocalePath", () => ({
 }));
 
 import { SearchToolbar } from "../search/search-toolbar";
+import { FilterPillsReadOnly } from "../search/filter-pills-readonly";
 import { WatchlistFilterEditor } from "../watchlist/watchlist-filter-editor";
 
 describe("filter pill remove buttons", () => {
@@ -124,5 +125,92 @@ describe("filter pill remove buttons", () => {
     ]) {
       expect(screen.queryByRole("button", { name })).not.toBeNull();
     }
+  });
+
+  it("renders shared watchlist pills read-only when removal callbacks are absent", () => {
+    render(
+      <FilterPillsReadOnly
+        filters={{
+          keywords: ["backend"],
+          salaryCurrency: "CHF",
+          salaryMin: 120000,
+        }}
+        locations={[{ id: 1, slug: "zurich", name: "Zurich", type: "city", parentName: "Switzerland" }]}
+      />,
+    );
+
+    expect(screen.queryByText("backend")).not.toBeNull();
+    expect(screen.queryByText("Zurich, Switzerland")).not.toBeNull();
+    expect(screen.queryByText("CHF 120K+")).not.toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("renders shared watchlist pills with owner removal callbacks", () => {
+    const onRemoveKeyword = vi.fn();
+    const onRemoveLocation = vi.fn();
+    const onRemoveOccupation = vi.fn();
+    const onRemoveSeniority = vi.fn();
+    const onRemoveTechnology = vi.fn();
+    const onToggleEmploymentType = vi.fn();
+    const onToggleWorkMode = vi.fn();
+    const onRemoveSalary = vi.fn();
+    const onRemoveExperience = vi.fn();
+    const onClearAll = vi.fn();
+
+    render(
+      <FilterPillsReadOnly
+        filters={{
+          keywords: ["backend"],
+          salaryCurrency: "CHF",
+          salaryMin: 120000,
+          salaryMax: 180000,
+          experienceMin: 4,
+          experienceMax: 8,
+        }}
+        locations={[{ id: 1, slug: "zurich", name: "Zurich", type: "city", parentName: "Switzerland" }]}
+        occupations={[{ id: 2, slug: "software-engineer", name: "Software Engineer" }]}
+        seniorities={[{ id: 3, slug: "senior", name: "Senior" }]}
+        technologies={[{ id: 4, slug: "python", name: "Python" }]}
+        employmentType={["full_time"]}
+        workMode={["hybrid"]}
+        onRemoveKeyword={onRemoveKeyword}
+        onRemoveLocation={onRemoveLocation}
+        onRemoveOccupation={onRemoveOccupation}
+        onRemoveSeniority={onRemoveSeniority}
+        onRemoveTechnology={onRemoveTechnology}
+        onToggleEmploymentType={onToggleEmploymentType}
+        onToggleWorkMode={onToggleWorkMode}
+        onRemoveSalary={onRemoveSalary}
+        onRemoveExperience={onRemoveExperience}
+        onClearAll={onClearAll}
+      />,
+    );
+
+    for (const name of [
+      "Remove keyword backend",
+      "Remove location Zurich, Switzerland",
+      "Remove Software Engineer filter",
+      "Remove Senior filter",
+      "Remove Python filter",
+      "Remove full time filter",
+      "Remove Hybrid filter",
+      "Remove salary filter",
+      "Remove experience filter",
+      "Clear all",
+    ]) {
+      expect(screen.queryByRole("button", { name })).not.toBeNull();
+    }
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove keyword backend" }));
+    expect(onRemoveKeyword).toHaveBeenCalledWith("backend");
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove location Zurich, Switzerland" }));
+    expect(onRemoveLocation).toHaveBeenCalledWith(expect.objectContaining({ id: 1 }));
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove salary filter" }));
+    expect(onRemoveSalary).toHaveBeenCalledOnce();
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear all" }));
+    expect(onClearAll).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/components/search/filter-pills-readonly.tsx
+++ b/apps/web/src/components/search/filter-pills-readonly.tsx
@@ -1,16 +1,33 @@
 "use client";
 
-import { MapPin, Briefcase, BarChart3, Code2, DollarSign, Clock, Home, CalendarDays } from "lucide-react";
+import type { ReactNode } from "react";
+import { MapPin, Briefcase, BarChart3, Code2, DollarSign, Clock, Home, CalendarDays, X } from "lucide-react";
+import { useLingui } from "@lingui/react/macro";
 import type { WatchlistFilters } from "@/lib/actions/watchlists";
 import type { SelectedLocation } from "@/lib/search/types";
 import type { WorkMode } from "@/lib/search/types";
 
 type TaxonomyItem = { id: number; slug: string; name: string };
+type TFn = ReturnType<typeof useLingui>["t"];
 
-const WORK_MODE_LABEL: Record<WorkMode, string> = {
-  onsite: "On-site",
-  hybrid: "Hybrid",
-  remote: "Remote",
+function workModeLabel(t: TFn, value: WorkMode): string {
+  switch (value) {
+    case "onsite":
+      return t({ id: "search.workMode.onsite", comment: "Work mode: onsite (in-office)", message: "On-site" });
+    case "hybrid":
+      return t({ id: "search.workMode.hybrid", comment: "Work mode: hybrid (mixed onsite/remote)", message: "Hybrid" });
+    case "remote":
+      return t({ id: "search.workMode.remote", comment: "Work mode: remote (work-from-home)", message: "Remote" });
+  }
+}
+
+type FilterPill = {
+  key: string;
+  icon: ReactNode;
+  label: string;
+  labelClassName?: string;
+  onRemove?: () => void;
+  removeLabel?: string;
 };
 
 export function FilterPillsReadOnly({
@@ -21,6 +38,20 @@ export function FilterPillsReadOnly({
   technologies,
   workMode,
   employmentType,
+  onRemoveKeyword,
+  onRemoveLocation,
+  onRemoveLocationSlug,
+  onRemoveOccupation,
+  onRemoveOccupationSlug,
+  onRemoveSeniority,
+  onRemoveSenioritySlug,
+  onRemoveTechnology,
+  onRemoveTechnologySlug,
+  onToggleEmploymentType,
+  onToggleWorkMode,
+  onRemoveSalary,
+  onRemoveExperience,
+  onClearAll,
 }: {
   filters: WatchlistFilters;
   locations?: SelectedLocation[];
@@ -42,12 +73,35 @@ export function FilterPillsReadOnly({
    * fall back to `filters.employmentType`.
    */
   employmentType?: string[];
+  onRemoveKeyword?: (keyword: string) => void;
+  onRemoveLocation?: (location: SelectedLocation) => void;
+  onRemoveLocationSlug?: (slug: string) => void;
+  onRemoveOccupation?: (occupation: TaxonomyItem) => void;
+  onRemoveOccupationSlug?: (slug: string) => void;
+  onRemoveSeniority?: (seniority: TaxonomyItem) => void;
+  onRemoveSenioritySlug?: (slug: string) => void;
+  onRemoveTechnology?: (technology: TaxonomyItem) => void;
+  onRemoveTechnologySlug?: (slug: string) => void;
+  onToggleEmploymentType?: (employmentType: string) => void;
+  onToggleWorkMode?: (workMode: WorkMode) => void;
+  onRemoveSalary?: () => void;
+  onRemoveExperience?: () => void;
+  onClearAll?: () => void;
 }) {
-  const pills: { key: string; icon: React.ReactNode; label: string }[] = [];
+  const { t } = useLingui();
+  const pills: FilterPill[] = [];
 
   if (filters.keywords?.length) {
     for (const kw of filters.keywords) {
-      pills.push({ key: `kw-${kw}`, icon: null, label: kw });
+      pills.push({
+        key: `kw-${kw}`,
+        icon: null,
+        label: kw,
+        onRemove: onRemoveKeyword ? () => onRemoveKeyword(kw) : undefined,
+        removeLabel: onRemoveKeyword
+          ? t({ id: "search.filters.removeKeyword", comment: "Aria label for remove-keyword X button; {name} is the keyword", message: `Remove keyword ${kw}` })
+          : undefined,
+      });
     }
   }
   if (locations && locations.length > 0) {
@@ -55,38 +109,102 @@ export function FilterPillsReadOnly({
       const label = loc.parentName && loc.type !== "country" && loc.type !== "macro"
         ? `${loc.name}, ${loc.parentName}`
         : loc.name;
-      pills.push({ key: `loc-${loc.id}`, icon: <MapPin size={12} />, label });
+      pills.push({
+        key: `loc-${loc.id}`,
+        icon: <MapPin size={12} />,
+        label,
+        onRemove: onRemoveLocation ? () => onRemoveLocation(loc) : undefined,
+        removeLabel: onRemoveLocation
+          ? t({ id: "search.filters.removeLocation", comment: "Aria label for remove-location X button; {name} is the location label", message: `Remove location ${label}` })
+          : undefined,
+      });
     }
   } else if (filters.locationSlugs?.length) {
     for (const slug of filters.locationSlugs) {
-      pills.push({ key: `loc-${slug}`, icon: <MapPin size={12} />, label: slug });
+      pills.push({
+        key: `loc-${slug}`,
+        icon: <MapPin size={12} />,
+        label: slug,
+        onRemove: onRemoveLocationSlug ? () => onRemoveLocationSlug(slug) : undefined,
+        removeLabel: onRemoveLocationSlug
+          ? t({ id: "search.filters.removeLocation", comment: "Aria label for remove-location X button; {name} is the location label", message: `Remove location ${slug}` })
+          : undefined,
+      });
     }
   }
   if (occupations && occupations.length > 0) {
     for (const occ of occupations) {
-      pills.push({ key: `occ-${occ.id}`, icon: <Briefcase size={12} />, label: occ.name });
+      pills.push({
+        key: `occ-${occ.id}`,
+        icon: <Briefcase size={12} />,
+        label: occ.name,
+        onRemove: onRemoveOccupation ? () => onRemoveOccupation(occ) : undefined,
+        removeLabel: onRemoveOccupation
+          ? t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${occ.name} filter` })
+          : undefined,
+      });
     }
   } else if (filters.occupationSlugs?.length) {
     for (const slug of filters.occupationSlugs) {
-      pills.push({ key: `occ-${slug}`, icon: <Briefcase size={12} />, label: slug });
+      pills.push({
+        key: `occ-${slug}`,
+        icon: <Briefcase size={12} />,
+        label: slug,
+        onRemove: onRemoveOccupationSlug ? () => onRemoveOccupationSlug(slug) : undefined,
+        removeLabel: onRemoveOccupationSlug
+          ? t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${slug} filter` })
+          : undefined,
+      });
     }
   }
   if (seniorities && seniorities.length > 0) {
     for (const sen of seniorities) {
-      pills.push({ key: `sen-${sen.id}`, icon: <BarChart3 size={12} />, label: sen.name });
+      pills.push({
+        key: `sen-${sen.id}`,
+        icon: <BarChart3 size={12} />,
+        label: sen.name,
+        onRemove: onRemoveSeniority ? () => onRemoveSeniority(sen) : undefined,
+        removeLabel: onRemoveSeniority
+          ? t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${sen.name} filter` })
+          : undefined,
+      });
     }
   } else if (filters.senioritySlugs?.length) {
     for (const slug of filters.senioritySlugs) {
-      pills.push({ key: `sen-${slug}`, icon: <BarChart3 size={12} />, label: slug });
+      pills.push({
+        key: `sen-${slug}`,
+        icon: <BarChart3 size={12} />,
+        label: slug,
+        onRemove: onRemoveSenioritySlug ? () => onRemoveSenioritySlug(slug) : undefined,
+        removeLabel: onRemoveSenioritySlug
+          ? t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${slug} filter` })
+          : undefined,
+      });
     }
   }
   if (technologies && technologies.length > 0) {
     for (const tech of technologies) {
-      pills.push({ key: `tech-${tech.id}`, icon: <Code2 size={12} />, label: tech.name });
+      pills.push({
+        key: `tech-${tech.id}`,
+        icon: <Code2 size={12} />,
+        label: tech.name,
+        onRemove: onRemoveTechnology ? () => onRemoveTechnology(tech) : undefined,
+        removeLabel: onRemoveTechnology
+          ? t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${tech.name} filter` })
+          : undefined,
+      });
     }
   } else if (filters.technologySlugs?.length) {
     for (const slug of filters.technologySlugs) {
-      pills.push({ key: `tech-${slug}`, icon: <Code2 size={12} />, label: slug });
+      pills.push({
+        key: `tech-${slug}`,
+        icon: <Code2 size={12} />,
+        label: slug,
+        onRemove: onRemoveTechnologySlug ? () => onRemoveTechnologySlug(slug) : undefined,
+        removeLabel: onRemoveTechnologySlug
+          ? t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${slug} filter` })
+          : undefined,
+      });
     }
   }
   const effectiveEmploymentType = employmentType ?? filters.employmentType;
@@ -100,12 +218,26 @@ export function FilterPillsReadOnly({
         // keep it lowercase here to match the unfiltered text rendering
         // and avoid mismatches with the localised labels in the modal.
         label: et.replace(/_/g, " "),
+        labelClassName: "capitalize",
+        onRemove: onToggleEmploymentType ? () => onToggleEmploymentType(et) : undefined,
+        removeLabel: onToggleEmploymentType
+          ? t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${et.replace(/_/g, " ")} filter` })
+          : undefined,
       });
     }
   }
   if (workMode && workMode.length > 0) {
     for (const mode of workMode) {
-      pills.push({ key: `wm-${mode}`, icon: <Home size={12} />, label: WORK_MODE_LABEL[mode] });
+      const label = workModeLabel(t, mode);
+      pills.push({
+        key: `wm-${mode}`,
+        icon: <Home size={12} />,
+        label,
+        onRemove: onToggleWorkMode ? () => onToggleWorkMode(mode) : undefined,
+        removeLabel: onToggleWorkMode
+          ? t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${label} filter` })
+          : undefined,
+      });
     }
   }
   if (filters.salaryMin != null || filters.salaryMax != null) {
@@ -118,7 +250,15 @@ export function FilterPillsReadOnly({
     } else {
       label = `${cur} ≤${Math.round(filters.salaryMax! / 1000)}K`;
     }
-    pills.push({ key: "salary", icon: <DollarSign size={12} />, label });
+    pills.push({
+      key: "salary",
+      icon: <DollarSign size={12} />,
+      label,
+      onRemove: onRemoveSalary,
+      removeLabel: onRemoveSalary
+        ? t({ id: "search.filters.removeSalary", comment: "Aria label for the X button that clears the salary-range filter", message: "Remove salary filter" })
+        : undefined,
+    });
   }
   if (filters.experienceMin != null || filters.experienceMax != null) {
     let label: string;
@@ -129,7 +269,15 @@ export function FilterPillsReadOnly({
     } else {
       label = `≤${filters.experienceMax}y`;
     }
-    pills.push({ key: "exp", icon: <Clock size={12} />, label });
+    pills.push({
+      key: "exp",
+      icon: <Clock size={12} />,
+      label,
+      onRemove: onRemoveExperience,
+      removeLabel: onRemoveExperience
+        ? t({ id: "search.filters.removeExperience", comment: "Aria label for the X button that clears the experience-range filter", message: "Remove experience filter" })
+        : undefined,
+    });
   }
 
   if (pills.length === 0) return null;
@@ -142,9 +290,28 @@ export function FilterPillsReadOnly({
           className="inline-flex items-center gap-1 rounded-full bg-primary/10 px-3 py-1 text-sm text-primary"
         >
           {pill.icon && <span className="shrink-0">{pill.icon}</span>}
-          {pill.label}
+          <span className={pill.labelClassName}>{pill.label}</span>
+          {pill.onRemove && pill.removeLabel && (
+            <button
+              type="button"
+              onClick={pill.onRemove}
+              className="ml-0.5 rounded-full p-0.5 transition-colors hover:bg-primary/20 cursor-pointer"
+              aria-label={pill.removeLabel}
+            >
+              <X size={12} aria-hidden="true" />
+            </button>
+          )}
         </span>
       ))}
+      {onClearAll && (
+        <button
+          type="button"
+          onClick={onClearAll}
+          className="cursor-pointer text-xs text-muted transition-colors hover:text-foreground"
+        >
+          {t({ id: "search.filters.clearAll", comment: "Button to clear all active search filters", message: "Clear all" })}
+        </button>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Extend `FilterPillsReadOnly` with optional removal callbacks while preserving read-only rendering when callbacks are absent.
- Replace the owner-only inline removable pill block in `WatchlistViewPage` with the shared renderer.
- Add focused tests for shared read-only pills and owner removable pills/callbacks.

Closes #3111

## Reproduction
- Source-level repro on current `origin/main`: `WatchlistViewPage` contained repeated inline removable filter-pill JSX for occupation, seniority, technology, employment type, work mode, salary, experience, keyword, and location while the read-only branch already used `FilterPillsReadOnly`.
- Read-only production baseline: `https://jseek.co/en/colophongroup/big-tech-jobs-in-switzerland` returned HTTP 200.

## Validation
After rebasing onto `e3893920b`:
- `../../node_modules/.pnpm/node_modules/.bin/vitest run src/components/__tests__/filter-pill-remove-labels.test.tsx`
- `../../node_modules/.pnpm/node_modules/.bin/eslint 'app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx' src/components/search/filter-pills-readonly.tsx src/components/__tests__/filter-pill-remove-labels.test.tsx`
- `../../node_modules/.pnpm/node_modules/.bin/next typegen && ../../node_modules/.pnpm/node_modules/.bin/tsc`
- `git diff --check`

Note: this worktree used ignored dependency symlinks and direct workspace binaries to avoid changing package policy while current main's local `pnpm exec` path is affected by the inherited minimum-release-age setup.
