### PR TITLE
Cache CI dependency installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,9 @@ jobs:
           cache: false
 
       - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "apps/crawler/uv.lock"
 
       - name: actionlint
         run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -ignore 'SC(2002|2086|2129)'
@@ -160,6 +163,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "apps/crawler/uv.lock"
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
@@ -183,6 +189,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "apps/crawler/uv.lock"
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
@@ -346,6 +355,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "apps/crawler/uv.lock"
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
@@ -366,6 +378,9 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
       - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "apps/crawler/uv.lock"
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
@@ -574,6 +589,9 @@ jobs:
           fetch-depth: 0
 
       - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "apps/crawler/uv.lock"
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:

--- a/.github/workflows/publish-mcp-server.yml
+++ b/.github/workflows/publish-mcp-server.yml
@@ -24,12 +24,14 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
 
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
-
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
         working-directory: packages/mcp-server

--- a/.github/workflows/upload-company-images.yml
+++ b/.github/workflows/upload-company-images.yml
@@ -55,6 +55,9 @@ jobs:
           chmod +x "$RUNNER_TEMP/trusted-scripts/"*.sh
 
       - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "apps/crawler/uv.lock"
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -3,6 +3,22 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 const workflow = readFileSync(".github/workflows/ci.yml", "utf8");
+const uploadCompanyImagesWorkflow = readFileSync(
+  ".github/workflows/upload-company-images.yml",
+  "utf8",
+);
+const publishMcpServerWorkflow = readFileSync(
+  ".github/workflows/publish-mcp-server.yml",
+  "utf8",
+);
+
+function setupUvBlocks(workflowSource) {
+  return [
+    ...workflowSource.matchAll(
+      /- uses: astral-sh\/setup-uv@[^\n]+[\s\S]*?(?=\n      - |\n  [a-zA-Z0-9_-]+:|\n$)/g,
+    ),
+  ].map((match) => match[0]);
+}
 
 test("CI change detection uses the pinned paths-filter action", () => {
   assert.match(
@@ -43,4 +59,30 @@ test("workflow-security runs repository script tests", () => {
     workflow,
     /node --test\n          scripts\/ci-workflow\.test\.mjs\n          scripts\/dealroom-company-requests\.test\.mjs/,
   );
+});
+
+test("setup-uv steps cache uv downloads by crawler lockfile", () => {
+  const checkedWorkflows = {
+    ci: workflow,
+    "upload-company-images": uploadCompanyImagesWorkflow,
+  };
+
+  for (const [name, source] of Object.entries(checkedWorkflows)) {
+    const blocks = setupUvBlocks(source);
+    assert.ok(blocks.length > 0, `${name} should use setup-uv`);
+
+    for (const block of blocks) {
+      assert.match(block, /enable-cache: true/);
+      assert.match(block, /cache-dependency-glob: "apps\/crawler\/uv\.lock"/);
+    }
+  }
+});
+
+test("MCP publish workflow caches the pnpm store", () => {
+  assert.match(
+    publishMcpServerWorkflow,
+    /pnpm\/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6\.0\.9[\s\S]*actions\/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6/,
+  );
+  assert.match(publishMcpServerWorkflow, /cache: pnpm/);
+  assert.match(publishMcpServerWorkflow, /cache-dependency-path: pnpm-lock\.yaml/);
 });


### PR DESCRIPTION
## Summary
- Enable `astral-sh/setup-uv` cache on CI and company-image upload workflows, keyed by `apps/crawler/uv.lock`.
- Add the missing pnpm store cache to the MCP publish workflow.
- Extend the repository workflow-shape test so uv and pnpm cache config does not regress.

## Reproduction
- Current main already had `setup-node` pnpm store caching in most CI jobs, but every `astral-sh/setup-uv` step lacked `enable-cache` and `cache-dependency-glob`.
- `publish-mcp-server.yml` still installed pnpm dependencies without `setup-node` pnpm cache enabled.

## Validation
- `node --test scripts/ci-workflow.test.mjs`
- `git diff --check`
- `actionlint -ignore 'SC(2002|2086|2129)' .github/workflows/ci.yml .github/workflows/upload-company-images.yml .github/workflows/publish-mcp-server.yml`
- `uvx --from zizmor==1.26.1 zizmor --persona regular --min-severity medium --min-confidence high .github/workflows/ci.yml .github/workflows/upload-company-images.yml .github/workflows/publish-mcp-server.yml`

Production probing is not applicable for this CI-only change; no Supabase access or writes.

Closes #3079
