### PR TITLE
Refactor company action tests around service behavior

### DIFF
--- a/apps/web/src/lib/actions/__tests__/company.test.ts
+++ b/apps/web/src/lib/actions/__tests__/company.test.ts
@@ -1,568 +1,64 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { setTestEnv, withTestEnv } from "@/test-utils/env";
 
-// `vi.mock` hoists to the top of the file so its factories cannot close
-// over module-scope variables. Use `vi.hoisted` to share mocks between
-// the factory and the test bodies.
-const mocks = vi.hoisted(() => ({
-  cacheLife: vi.fn(),
-  cacheTag: vi.fn(),
-  cached: vi.fn(
-    (_key: string, fetcher: () => Promise<unknown>, _options: unknown) => fetcher(),
-  ),
-  search: vi.fn(),
-  dbExecute: vi.fn(),
-  buildFilterString: vi.fn(() => ""),
+const service = vi.hoisted(() => ({
+  suggestCompanies: vi.fn(),
+  searchCompaniesForWatchlist: vi.fn(),
+  suggestIndustries: vi.fn(),
+  getCompanyBySlug: vi.fn(),
+  getSimilarCompanies: vi.fn(),
+  getCompanyPostings: vi.fn(),
+  getCompanyPostingsAnonymous: vi.fn(),
+  getCompanyTopLocations: vi.fn(),
+  getCompanyLocationsGrouped: vi.fn(),
+  getCompanyLocationsGroupedWithMacros: vi.fn(),
 }));
 
-vi.mock("server-only", () => ({}));
+vi.mock("@/lib/services/company", () => service);
 
-// `cacheLife` / `cacheTag` are no-ops outside a Cache Components-enabled
-// runtime — vitest doesn't load `next.config.ts`, so calling the real
-// implementations throws "cacheLife() is only available with the
-// cacheComponents config". Mock them to silent no-ops; the `'use cache'`
-// directive itself is removed by the test transform pipeline (Babel +
-// esbuild treat it as a no-op string-statement). Tests exercise the
-// underlying Typesense + Postgres branching directly. See #2884 bucket
-// 4 — `getCompanyBySlug` migrated from Redis-backed `cached()` to
-// `'use cache'` here.
-vi.mock("next/cache", () => ({
-  cacheLife: mocks.cacheLife,
-  cacheTag: mocks.cacheTag,
-}));
-vi.mock("@/lib/cache", () => ({
-  cached: mocks.cached,
-}));
+import * as actions from "../company";
 
-vi.mock("@/lib/search/typesense-client", () => ({
-  getSearchClient: () => ({
-    collections: () => ({ documents: () => ({ search: mocks.search }) }),
-  }),
-}));
+type CompanyActionName = keyof typeof service & keyof typeof actions;
 
-vi.mock("@/db", () => ({ db: { execute: mocks.dbExecute } }));
-
-// Drag in the side-effect-bearing transitive imports as no-ops so the
-// "use server" module loads cleanly in vitest.
-vi.mock("drizzle-orm", () => ({
-  sql: (strings: TemplateStringsArray, ..._values: unknown[]) =>
-    strings.join("?"),
-}));
-vi.mock("@/lib/sessionCache", () => ({ getSessionUserId: vi.fn() }));
-vi.mock("@/lib/services/locations", () => ({
-  expandLocationIds: vi.fn(),
-  expandLocationIdsBatch: vi.fn().mockResolvedValue([]),
-}));
-vi.mock("@/lib/services/taxonomy", () => ({
-  expandOccupationIds: vi.fn(),
-  expandOccupationIdsBatch: vi.fn().mockResolvedValue([]),
-}));
-vi.mock("@/lib/search", () => ({ getSearchProvider: vi.fn() }));
-vi.mock("@/lib/search/constants", () => ({
-  ANON_MAX_COMPANIES: 5,
-  ANON_MAX_POSTINGS: 10,
-}));
-vi.mock("@/lib/search/typesense-filters", () => ({
-  POSTING_BASE_FILTER: "is_active:true && has_content:!=false",
-  buildFilterString: mocks.buildFilterString,
-}));
-vi.mock("@/lib/search/typesense-retry", () => ({
-  isRetryableError: (err: unknown) =>
-    typeof err === "object" &&
-    err !== null &&
-    "code" in err &&
-    (err as { code?: unknown }).code === "ECONNRESET",
-  isTypesenseRateLimitError: (err: unknown) =>
-    typeof err === "object" &&
-    err !== null &&
-    (
-      ("httpStatus" in err && (err as { httpStatus?: unknown }).httpStatus === 429) ||
-      ("message" in err &&
-        typeof (err as { message?: unknown }).message === "string" &&
-        (err as { message: string }).message.includes("HTTP code 429"))
-    ),
-  isTypesenseUnavailableError: (err: unknown) =>
-    typeof err === "object" &&
-    err !== null &&
-    (
-      ("code" in err && (err as { code?: unknown }).code === "ECONNRESET") ||
-      ("message" in err &&
-        typeof (err as { message?: unknown }).message === "string" &&
-        (err as { message: string }).message.includes("TYPESENSE_SEARCH_KEY"))
-    ),
-  withTypesenseRetry: (fn: () => Promise<unknown>) => fn(),
-}));
-vi.mock("@/lib/search/pg-filters", () => ({ localesOrNoneClause: vi.fn() }));
-vi.mock("@/lib/services/search-input", () => ({ parseSearchFilters: vi.fn() }));
-vi.mock("@/lib/search/params", () => ({
-  firstOf: vi.fn(),
-  idsOrUndefined: vi.fn(),
-  parseRangeParam: vi.fn(),
-}));
-
-import { getCompanyBySlug, searchCompaniesForWatchlist } from "../company";
-
-const searchMock = mocks.search;
-const dbExecuteMock = mocks.dbExecute;
-const cachedMock = mocks.cached;
-const buildFilterStringMock = mocks.buildFilterString;
-const TEST_ENV = {
-  DATABASE_URL:
-    process.env.DATABASE_URL ?? "postgresql://test:test@localhost:5432/test",
-  TYPESENSE_HOST: process.env.TYPESENSE_HOST,
-  TYPESENSE_PORT: process.env.TYPESENSE_PORT,
-  TYPESENSE_PROTOCOL: process.env.TYPESENSE_PROTOCOL,
-  TYPESENSE_SEARCH_KEY: process.env.TYPESENSE_SEARCH_KEY,
-};
-
-const _hit = (overrides: Record<string, unknown> = {}) => ({
-  id: "co-1",
-  name: "Acme Corp",
-  slug: "acme",
-  icon: "https://cdn.x/icon.png",
-  logo: null,
-  website: "https://acme.example",
-  description: "We build things in English.",
-  description_de: "Wir bauen Dinge.",
-  industry_id: 7,
-  industry_name: "Software",
-  industry_name_de: "Software",
-  employee_count_range: 3,
-  founded_year: 2015,
-  active_posting_count: 42,
-  ...overrides,
-});
-
-const _typesenseResponse = (hit: Record<string, unknown> | null) =>
-  hit ? { hits: [{ document: hit }] } : { hits: [] };
-
-withTestEnv(TEST_ENV);
+const cases: Array<{
+  name: CompanyActionName;
+  args: unknown[];
+  result: unknown;
+}> = [
+  { name: "suggestCompanies", args: [{ query: "ac" }], result: [{ id: "co-1" }] },
+  {
+    name: "searchCompaniesForWatchlist",
+    args: [{ locale: "en", offset: 0, limit: 10 }],
+    result: { companies: [], total: 0 },
+  },
+  { name: "suggestIndustries", args: [{ query: "soft", locale: "en" }], result: [] },
+  { name: "getCompanyBySlug", args: ["acme", "en"], result: { slug: "acme" } },
+  {
+    name: "getSimilarCompanies",
+    args: ["co-1", 7, { locale: "en" }],
+    result: { companies: [], hasMore: false },
+  },
+  { name: "getCompanyPostings", args: [{ companyId: "co-1", locale: "en" }], result: [] },
+  {
+    name: "getCompanyPostingsAnonymous",
+    args: [{ companyId: "co-1", locale: "en" }],
+    result: { postings: [], hasMore: false },
+  },
+  { name: "getCompanyTopLocations", args: ["co-1", "en"], result: [] },
+  { name: "getCompanyLocationsGrouped", args: ["co-1", "en"], result: [] },
+  { name: "getCompanyLocationsGroupedWithMacros", args: ["co-1", "en"], result: [] },
+];
 
 beforeEach(() => {
   vi.clearAllMocks();
-  cachedMock.mockImplementation(
-    (_key: string, fetcher: () => Promise<unknown>, _options: unknown) => fetcher(),
-  );
-  searchMock.mockReset();
-  dbExecuteMock.mockReset();
-  buildFilterStringMock.mockReset();
-  buildFilterStringMock.mockReturnValue("");
 });
 
-describe("searchCompaniesForWatchlist", () => {
-  it("includes companies with zero active postings in unfiltered search", async () => {
-    searchMock.mockResolvedValue({
-      found: 1,
-      hits: [{ document: _hit({ active_posting_count: 0 }) }],
-    });
+describe("company server actions", () => {
+  it.each(cases)("delegates $name to the company service", async ({ name, args, result }) => {
+    service[name].mockResolvedValue(result);
 
-    const out = await searchCompaniesForWatchlist({
-      query: "Acme",
-      locale: "en",
-      offset: 0,
-      limit: 20,
-    });
+    const out = await actions[name](...(args as never[]));
 
-    expect(out.companies).toHaveLength(1);
-    expect(out.companies[0].activeMatches).toBe(0);
-    expect(searchMock).toHaveBeenCalledWith(
-      expect.not.objectContaining({ filter_by: expect.stringContaining("active_posting_count") }),
-    );
-  });
-
-  it("does not exclude zero-posting companies when filtering by industry", async () => {
-    searchMock.mockResolvedValue({
-      found: 1,
-      hits: [{ document: _hit({ active_posting_count: 0 }) }],
-    });
-
-    await searchCompaniesForWatchlist({
-      industryId: 7,
-      locale: "en",
-      offset: 0,
-      limit: 20,
-    });
-
-    expect(searchMock).toHaveBeenCalledWith(
-      expect.objectContaining({ filter_by: "industry_id:=7" }),
-    );
-  });
-
-  it("keeps starred ordering without requiring active postings", async () => {
-    searchMock
-      .mockResolvedValueOnce({
-        found: 1,
-        hits: [{ document: _hit({ active_posting_count: 0 }) }],
-      })
-      .mockResolvedValueOnce({ found: 0, hits: [] });
-
-    const out = await searchCompaniesForWatchlist({
-      locale: "en",
-      offset: 0,
-      limit: 20,
-      starredCompanyIds: ["co-1"],
-    });
-
-    expect(out.companies).toHaveLength(1);
-    expect(searchMock).toHaveBeenNthCalledWith(
-      1,
-      expect.objectContaining({ filter_by: "id:[co-1]" }),
-    );
-    expect(searchMock).toHaveBeenNthCalledWith(
-      2,
-      expect.objectContaining({ filter_by: "id:!=[co-1]" }),
-    );
-  });
-
-  it("includes a searched zero-posting company when the watchlist has filters", async () => {
-    buildFilterStringMock.mockReturnValue("location_ids:=[42]");
-    searchMock
-      .mockResolvedValueOnce({
-        facet_counts: [{ counts: [], stats: { total_values: 0 } }],
-      })
-      .mockResolvedValueOnce({
-        found: 1,
-        hits: [{ document: _hit({ active_posting_count: 0 }) }],
-      })
-      .mockResolvedValueOnce({
-        facet_counts: [{ counts: [], stats: { total_values: 0 } }],
-      })
-      .mockResolvedValueOnce({
-        hits: [{ document: _hit({ active_posting_count: 0 }) }],
-      });
-
-    const out = await searchCompaniesForWatchlist({
-      query: "Acme",
-      locale: "en",
-      offset: 0,
-      limit: 20,
-      locationIds: [42],
-    });
-
-    expect(out).toMatchObject({
-      total: 1,
-      companies: [{ id: "co-1", activeMatches: 0 }],
-    });
-  });
-
-  it("includes a searched active company with zero matches for the current watchlist filters", async () => {
-    buildFilterStringMock.mockReturnValue("technology_ids:=[99]");
-    searchMock
-      .mockResolvedValueOnce({
-        facet_counts: [{ counts: [], stats: { total_values: 0 } }],
-      })
-      .mockResolvedValueOnce({
-        found: 1,
-        hits: [{ document: _hit({ active_posting_count: 42 }) }],
-      })
-      .mockResolvedValueOnce({
-        facet_counts: [{ counts: [], stats: { total_values: 0 } }],
-      })
-      .mockResolvedValueOnce({
-        hits: [{ document: _hit({ active_posting_count: 42 }) }],
-      });
-
-    const out = await searchCompaniesForWatchlist({
-      query: "Acme",
-      locale: "en",
-      offset: 0,
-      limit: 20,
-      technologyIds: [99],
-    });
-
-    expect(out).toMatchObject({
-      total: 1,
-      companies: [{ id: "co-1", activeMatches: 0 }],
-    });
-  });
-});
-
-describe("getCompanyBySlug — Typesense path", () => {
-  it("returns the Typesense hit mapped to CompanyDetail", async () => {
-    searchMock.mockResolvedValue(_typesenseResponse(_hit()));
-
-    const out = await getCompanyBySlug("acme", "en");
-
-    expect(out).toEqual({
-      id: "co-1",
-      name: "Acme Corp",
-      slug: "acme",
-      icon: "https://cdn.x/icon.png",
-      logo: null,
-      website: "https://acme.example",
-      description: "We build things in English.",
-      industryId: 7,
-      industryName: "Software",
-      employeeCountRange: 3,
-      foundedYear: 2015,
-      activeJobCount: 42,
-    });
-    expect(searchMock).toHaveBeenCalledWith({
-      q: "*",
-      filter_by: "slug:=acme",
-      per_page: 1,
-    });
-    expect(dbExecuteMock).not.toHaveBeenCalled();
-  });
-
-  it("prefers the locale-specific description when present", async () => {
-    searchMock.mockResolvedValue(_typesenseResponse(_hit()));
-    const out = await getCompanyBySlug("acme", "de");
-    expect(out?.description).toBe("Wir bauen Dinge.");
-    expect(out?.industryName).toBe("Software");
-  });
-
-  it("falls back to base English description when locale variant is missing", async () => {
-    searchMock.mockResolvedValue(
-      _typesenseResponse(_hit({ description_fr: undefined })),
-    );
-    const out = await getCompanyBySlug("acme", "fr");
-    expect(out?.description).toBe("We build things in English.");
-  });
-
-  it("returns null description when both locale and base are missing", async () => {
-    searchMock.mockResolvedValue(
-      _typesenseResponse(
-        _hit({ description: undefined, description_de: undefined }),
-      ),
-    );
-    const out = await getCompanyBySlug("acme", "de");
-    expect(out?.description).toBeNull();
-  });
-
-  it("returns null description when locale value is empty string", async () => {
-    /** Empty string must be treated as missing so the en fallback fires —
-     * otherwise a half-translated company shows the empty string verbatim. */
-    searchMock.mockResolvedValue(_typesenseResponse(_hit({ description_de: "" })));
-    const out = await getCompanyBySlug("acme", "de");
-    expect(out?.description).toBe("We build things in English.");
-  });
-});
-
-describe("getCompanyBySlug — slug shape guard", () => {
-  /** SLUG_SHAPE rejection short-circuits the Typesense call so attacker input
-   * never reaches the raw-interpolated `filter_by`. Postgres still runs
-   * (drizzle parameterizes; injection-safe) and returns null naturally. */
-  it.each([
-    "acme corp", // space
-    "acme&&filter:=evil", // injection attempt
-    "ACME", // uppercase
-    "acme--double", // double hyphen
-    "-acme", // leading hyphen
-    "acme-", // trailing hyphen
-    "acme/path", // slash
-    "", // empty
-  ])(
-    "rejects malformed slug %j without calling Typesense (Postgres still queried, returns null)",
-    async (slug) => {
-      dbExecuteMock.mockResolvedValue([]);
-      const out = await getCompanyBySlug(slug, "en");
-      expect(out).toBeNull();
-      expect(searchMock).not.toHaveBeenCalled();
-      expect(dbExecuteMock).toHaveBeenCalled();
-    },
-  );
-
-  it.each(["acme", "1-800-flowers", "deutsche-bank", "abc123-xyz"])(
-    "accepts well-formed slug %j",
-    async (slug) => {
-      searchMock.mockResolvedValue(_typesenseResponse(_hit({ slug })));
-      const out = await getCompanyBySlug(slug, "en");
-      expect(out?.slug).toBe(slug);
-    },
-  );
-});
-
-describe("getCompanyBySlug — Postgres fallback", () => {
-  const _pgRow = {
-    id: "co-1",
-    name: "Acme Corp",
-    slug: "acme",
-    icon: null,
-    logo: null,
-    website: null,
-    description: "From Postgres",
-    industry_id: 7,
-    industry_name: "Software",
-    employee_count_range: 3,
-    founded_year: 2015,
-  };
-
-  it("falls through to Postgres when Typesense is unavailable", async () => {
-    searchMock.mockRejectedValue(new Error("TYPESENSE_SEARCH_KEY is not set"));
-    dbExecuteMock.mockResolvedValue([_pgRow]);
-
-    const out = await getCompanyBySlug("acme", "en");
-
-    expect(out?.description).toBe("From Postgres");
-    expect(out?.activeJobCount).toBe(0); // PG path doesn't compute this
-    expect(dbExecuteMock).toHaveBeenCalled();
-  });
-
-  it("logs `[company] Typesense failed, falling back to Postgres` when Typesense is unavailable (so fallback rate is queryable per #3175)", async () => {
-    /** Issue colophon-group/jobseek#3175 — the silent `} catch {}` made a
-     * Cloudflare-tunnel outage indistinguishable from healthy traffic in
-     * the logs. Matches the precedent set by `searchCompaniesForWatchlist`
-     * and `_fetchSimilarUnfiltered` in the same file. */
-    searchMock.mockRejectedValue(new Error("TYPESENSE_SEARCH_KEY is not set"));
-    dbExecuteMock.mockResolvedValue([_pgRow]);
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
-    const out = await getCompanyBySlug("acme", "en");
-
-    // Fallback behaviour preserved — Postgres still serves the request.
-    expect(out?.description).toBe("From Postgres");
-    // Stable event prefix so the fallback rate is queryable in Loki.
-    const fallbackCalls = errorSpy.mock.calls.filter(
-      (call) => call[0] === "[company] Typesense failed, falling back to Postgres",
-    );
-    expect(fallbackCalls).toHaveLength(1);
-    expect(fallbackCalls[0][1]).toBeInstanceOf(Error);
-    expect((fallbackCalls[0][1] as Error).message).toBe("TYPESENSE_SEARCH_KEY is not set");
-    errorSpy.mockRestore();
-  });
-
-  it("does not fall through to Postgres when Typesense returns HTTP 429", async () => {
-    const rateLimitError = Object.assign(new Error("Request failed with HTTP code 429"), {
-      httpStatus: 429,
-    });
-    searchMock.mockRejectedValue(rateLimitError);
-
-    await expect(getCompanyBySlug("acme", "en")).rejects.toBe(rateLimitError);
-    expect(dbExecuteMock).not.toHaveBeenCalled();
-  });
-
-  it("does NOT log the fallback event when Typesense returns 0 hits (only thrown errors signal an outage)", async () => {
-    /** Zero hits is the brand-new-company path, not a Typesense outage —
-     * silencing it here keeps the fallback-rate metric an accurate
-     * signal of Typesense health, not company-freshness noise. */
-    searchMock.mockResolvedValue(_typesenseResponse(null));
-    dbExecuteMock.mockResolvedValue([_pgRow]);
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
-    const out = await getCompanyBySlug("acme", "en");
-
-    expect(out?.description).toBe("From Postgres");
-    const fallbackCalls = errorSpy.mock.calls.filter(
-      (call) => call[0] === "[company] Typesense failed, falling back to Postgres",
-    );
-    expect(fallbackCalls).toHaveLength(0);
-    errorSpy.mockRestore();
-  });
-
-  it("falls through to Postgres when Typesense returns 0 hits", async () => {
-    searchMock.mockResolvedValue(_typesenseResponse(null));
-    dbExecuteMock.mockResolvedValue([_pgRow]);
-
-    const out = await getCompanyBySlug("acme", "en");
-
-    expect(out?.description).toBe("From Postgres");
-    expect(dbExecuteMock).toHaveBeenCalled();
-  });
-
-  it("returns null when both Typesense and Postgres miss", async () => {
-    searchMock.mockResolvedValue(_typesenseResponse(null));
-    dbExecuteMock.mockResolvedValue([]);
-
-    const out = await getCompanyBySlug("acme", "en");
-    expect(out).toBeNull();
-  });
-
-  it("returns null outside the cache boundary when lookup env is not configured", async () => {
-    searchMock.mockResolvedValue(_typesenseResponse(null));
-    setTestEnv({
-      DATABASE_URL: undefined,
-      TYPESENSE_HOST: undefined,
-      TYPESENSE_PORT: undefined,
-      TYPESENSE_PROTOCOL: undefined,
-      TYPESENSE_SEARCH_KEY: undefined,
-    });
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-    const out = await getCompanyBySlug("acme", "en");
-
-    expect(out).toBeNull();
-    expect(searchMock).not.toHaveBeenCalled();
-    expect(dbExecuteMock).not.toHaveBeenCalled();
-    expect(warnSpy).toHaveBeenCalledWith(
-      "[company] lookup skipped because Typesense and DATABASE_URL are not configured",
-    );
-    warnSpy.mockRestore();
-  });
-
-  it("retries the Postgres query on transient ECONNRESET (#2918 follow-up)", async () => {
-    /** The 2026-05-09 Vercel build died on a single `read ECONNRESET`
-     * during this exact code path (OG-image prerender →
-     * `_fetchCompanyBySlugFromPostgres`). The next build 2 min later
-     * succeeded — a flake, not a structural break. The retry helper
-     * must turn this single transient error into a successful query
-     * so the prerender finishes. */
-    searchMock.mockRejectedValue(new Error("TYPESENSE_SEARCH_KEY is not set"));
-    const econn = new Error("read ECONNRESET") as Error & { code: string };
-    econn.code = "ECONNRESET";
-    dbExecuteMock
-      .mockRejectedValueOnce(econn)
-      .mockResolvedValueOnce([_pgRow]);
-    const warnSpy = vi
-      .spyOn(console, "warn")
-      .mockImplementation(() => {});
-
-    const out = await getCompanyBySlug("acme", "en");
-
-    expect(out?.description).toBe("From Postgres");
-    expect(dbExecuteMock).toHaveBeenCalledTimes(2);
-    expect(warnSpy).toHaveBeenCalled();
-    warnSpy.mockRestore();
-  });
-});
-
-describe("getCompanyBySlug — caching contract", () => {
-  it("uses the shared company-slug cache with skip-null semantics on a hit", async () => {
-    /** #3603 regression: company slug misses must not throw sentinel
-     * errors from a `'use cache'` boundary, because Next serializes the
-     * caught throw into the RSC payload. Redis `cached()` keeps the old
-     * skip-null contract without leaking an error digest. */
-    searchMock.mockResolvedValue(_typesenseResponse(_hit()));
-
-    const out = await getCompanyBySlug("acme", "en");
-
-    expect(out?.id).toBe("co-1");
-    expect(cachedMock).toHaveBeenCalledTimes(1);
-    const [key, _fetcher, options] = cachedMock.mock.calls[0] as [
-      string,
-      () => Promise<unknown>,
-      { ttl: number; skipIf: (data: unknown) => boolean },
-    ];
-    expect(key).toBe("company-slug:acme:en");
-    expect(options.ttl).toBe(600);
-    expect(options.skipIf(null)).toBe(true);
-    expect(options.skipIf(out)).toBe(false);
-  });
-
-  it("returns null on miss without throwing a cache-boundary sentinel", async () => {
-    /** The returned null is not cached by Redis because the skipIf
-     * predicate above treats null as a miss. That preserves retry-on-
-     * next-request behavior for brand-new slugs without throwing. */
-    searchMock.mockResolvedValue(_typesenseResponse(null));
-    dbExecuteMock.mockResolvedValue([]);
-
-    const out = await getCompanyBySlug("ghost-slug", "en");
-    expect(out).toBeNull();
-    const options = cachedMock.mock.calls[0][2] as {
-      skipIf: (data: unknown) => boolean;
-    };
-    expect(options.skipIf(out)).toBe(true);
-  });
-
-  it("re-throws unexpected errors past the wrapper", async () => {
-    /** A genuine downstream failure (DB pool exhausted, Drizzle parse
-     * error, etc.) MUST propagate so Suspense / error boundaries
-     * trigger; silently nulling here would surface as a 404 instead of
-     * a 5xx and hide the outage. */
-    searchMock.mockRejectedValue(new Error("TYPESENSE_SEARCH_KEY is not set"));
-    const boom = new Error("postgres pool exhausted");
-    dbExecuteMock.mockRejectedValue(boom);
-
-    await expect(getCompanyBySlug("acme", "en")).rejects.toBe(boom);
+    expect(out).toBe(result);
+    expect(service[name]).toHaveBeenCalledWith(...args);
   });
 });

--- a/apps/web/src/lib/actions/__tests__/similar-companies-salary-currency.test.ts
+++ b/apps/web/src/lib/actions/__tests__/similar-companies-salary-currency.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // `vi.mock` hoists to the top of the file so its factories cannot close
 // over module-scope variables. Use `vi.hoisted` to share mocks between
 // the factory and the test bodies. Mirrors the pattern in
-// `company.test.ts` and `explore-page-data-salary-currency.test.ts`.
+// `company-detail.test.ts` and `explore-page-data-salary-currency.test.ts`.
 const mocks = vi.hoisted(() => ({
   cacheLife: vi.fn(),
   cacheTag: vi.fn(),
@@ -18,7 +18,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("server-only", () => ({}));
 
 // `cacheLife` / `cacheTag` are no-ops outside a Cache Components-enabled
-// runtime — see `company.test.ts` for the full rationale. The `'use cache'`
+// runtime — see `company-detail.test.ts` for the full rationale. The `'use cache'`
 // directive itself is removed by the test transform pipeline.
 vi.mock("next/cache", () => ({
   cacheLife: mocks.cacheLife,

--- a/apps/web/src/lib/actions/__tests__/watchlists-invalidation.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-invalidation.test.ts
@@ -11,7 +11,7 @@ vi.mock("server-only", () => ({}));
  * Shared mocks must live in `vi.hoisted` because `vi.mock` hoists to the
  * top of the file; closure references against module-scope variables
  * become `undefined` at the time the factory runs. (Same pattern used
- * in apps/web/src/lib/actions/__tests__/company.test.ts.)
+ * in apps/web/src/lib/services/__tests__/company-detail.test.ts.)
  */
 const mocks = vi.hoisted(() => ({
   // Drizzle fluent-API surface used by mutators. Each call returns the

--- a/apps/web/src/lib/services/__tests__/company-detail-lookup.test.ts
+++ b/apps/web/src/lib/services/__tests__/company-detail-lookup.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  canResolveCompanyBySlugFromEnv,
+  isSafeCompanySlug,
+  mapPostgresCompanyRowToDetail,
+  mapTypesenseCompanyHitToDetail,
+  resolveCompanyBySlug,
+  type CompanyDetail,
+  type PostgresCompanyRow,
+} from "../company-detail-lookup";
+
+const detail = (overrides: Partial<CompanyDetail> = {}): CompanyDetail => ({
+  id: "co-1",
+  name: "Acme Corp",
+  slug: "acme",
+  icon: "https://cdn.example/icon.png",
+  logo: null,
+  website: "https://acme.example",
+  description: "We build things.",
+  industryId: 7,
+  industryName: "Software",
+  employeeCountRange: 3,
+  foundedYear: 2015,
+  activeJobCount: 42,
+  ...overrides,
+});
+
+const hit = (overrides: Record<string, unknown> = {}) => ({
+  id: "co-1",
+  name: "Acme Corp",
+  slug: "acme",
+  icon: "https://cdn.example/icon.png",
+  logo: null,
+  website: "https://acme.example",
+  description: "We build things.",
+  description_de: "Wir bauen Dinge.",
+  industry_id: 7,
+  industry_name: "Software",
+  industry_name_de: "Software DE",
+  employee_count_range: 3,
+  founded_year: 2015,
+  active_posting_count: 42,
+  ...overrides,
+});
+
+const pgRow = (overrides: Partial<PostgresCompanyRow> = {}): PostgresCompanyRow => ({
+  id: "co-1",
+  name: "Acme Corp",
+  slug: "acme",
+  icon: null,
+  logo: null,
+  website: null,
+  description: "From Postgres",
+  industry_id: 7,
+  industry_name: "Software",
+  employee_count_range: 3,
+  founded_year: 2015,
+  ...overrides,
+});
+
+const unavailable = (err: unknown): boolean =>
+  err instanceof Error && err.message.includes("TYPESENSE_SEARCH_KEY");
+
+describe("company detail mapping", () => {
+  it("maps a Typesense hit into CompanyDetail values", () => {
+    expect(mapTypesenseCompanyHitToDetail(hit(), "fallback-slug", "en")).toEqual(
+      detail(),
+    );
+  });
+
+  it("prefers non-empty localized Typesense fields and falls back to English", () => {
+    const localized = mapTypesenseCompanyHitToDetail(hit(), "acme", "de");
+    expect(localized.description).toBe("Wir bauen Dinge.");
+    expect(localized.industryName).toBe("Software DE");
+
+    const fallback = mapTypesenseCompanyHitToDetail(
+      hit({ description_fr: "", industry_name_fr: undefined }),
+      "acme",
+      "fr",
+    );
+    expect(fallback.description).toBe("We build things.");
+    expect(fallback.industryName).toBe("Software");
+
+    const missing = mapTypesenseCompanyHitToDetail(
+      hit({ description: undefined, description_it: undefined }),
+      "acme",
+      "it",
+    );
+    expect(missing.description).toBeNull();
+  });
+
+  it("maps a Postgres fallback row and leaves active count at zero", () => {
+    expect(mapPostgresCompanyRowToDetail(pgRow())).toEqual(
+      detail({
+        icon: null,
+        website: null,
+        description: "From Postgres",
+        activeJobCount: 0,
+      }),
+    );
+  });
+});
+
+describe("company slug lookup resolver", () => {
+  it("detects safe slugs and configured lookup environments", () => {
+    expect(isSafeCompanySlug("acme")).toBe(true);
+    expect(isSafeCompanySlug("1-800-flowers")).toBe(true);
+    expect(isSafeCompanySlug("acme corp")).toBe(false);
+    expect(isSafeCompanySlug("acme&&filter:=evil")).toBe(false);
+    expect(isSafeCompanySlug("ACME")).toBe(false);
+    expect(canResolveCompanyBySlugFromEnv({ DATABASE_URL: "postgres://test" })).toBe(true);
+    expect(
+      canResolveCompanyBySlugFromEnv({
+        TYPESENSE_HOST: "localhost",
+        TYPESENSE_PORT: "8108",
+        TYPESENSE_PROTOCOL: "http",
+        TYPESENSE_SEARCH_KEY: "xyz",
+      }),
+    ).toBe(true);
+    expect(canResolveCompanyBySlugFromEnv({ TYPESENSE_HOST: "localhost" })).toBe(false);
+  });
+
+  it("returns the Typesense result without querying Postgres", async () => {
+    const fetchFromTypesense = vi.fn().mockResolvedValue(detail());
+    const fetchFromPostgres = vi.fn().mockResolvedValue(detail({ description: "pg" }));
+
+    const out = await resolveCompanyBySlug("acme", "en", {
+      fetchFromTypesense,
+      fetchFromPostgres,
+      hasPostgresConfig: () => true,
+      isTypesenseUnavailableError: unavailable,
+    });
+
+    expect(out).toEqual(detail());
+    expect(fetchFromTypesense).toHaveBeenCalledWith("acme", "en");
+    expect(fetchFromPostgres).not.toHaveBeenCalled();
+  });
+
+  it("does not send malformed slugs to Typesense and lets Postgres miss naturally", async () => {
+    const fetchFromTypesense = vi.fn().mockRejectedValue(new Error("should not run"));
+    const fetchFromPostgres = vi.fn().mockResolvedValue(null);
+
+    const out = await resolveCompanyBySlug("acme&&filter:=evil", "en", {
+      fetchFromTypesense,
+      fetchFromPostgres,
+      hasPostgresConfig: () => true,
+      isTypesenseUnavailableError: unavailable,
+    });
+
+    expect(out).toBeNull();
+    expect(fetchFromTypesense).not.toHaveBeenCalled();
+    expect(fetchFromPostgres).toHaveBeenCalledWith("acme&&filter:=evil", "en");
+  });
+
+  it("falls back to Postgres and logs when Typesense is unavailable", async () => {
+    const error = new Error("TYPESENSE_SEARCH_KEY is not set");
+    const logger = { error: vi.fn(), warn: vi.fn() };
+    const fetchFromTypesense = vi.fn().mockRejectedValue(error);
+    const fetchFromPostgres = vi.fn().mockResolvedValue(detail({ description: "pg" }));
+
+    const out = await resolveCompanyBySlug("acme", "en", {
+      fetchFromTypesense,
+      fetchFromPostgres,
+      hasPostgresConfig: () => true,
+      isTypesenseUnavailableError: unavailable,
+      logger,
+    });
+
+    expect(out?.description).toBe("pg");
+    expect(fetchFromPostgres).toHaveBeenCalledWith("acme", "en");
+    expect(logger.error).toHaveBeenCalledWith(
+      "[company] Typesense failed, falling back to Postgres",
+      error,
+    );
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it("rethrows non-unavailable Typesense errors without querying Postgres", async () => {
+    const rateLimitError = Object.assign(new Error("Request failed with HTTP code 429"), {
+      httpStatus: 429,
+    });
+    const fetchFromPostgres = vi.fn();
+
+    await expect(
+      resolveCompanyBySlug("acme", "en", {
+        fetchFromTypesense: vi.fn().mockRejectedValue(rateLimitError),
+        fetchFromPostgres,
+        hasPostgresConfig: () => true,
+        isTypesenseUnavailableError: unavailable,
+      }),
+    ).rejects.toBe(rateLimitError);
+    expect(fetchFromPostgres).not.toHaveBeenCalled();
+  });
+
+  it("returns null and warns when neither backend can return a company", async () => {
+    const logger = { error: vi.fn(), warn: vi.fn() };
+    const out = await resolveCompanyBySlug("ghost-slug", "en", {
+      fetchFromTypesense: vi.fn().mockResolvedValue(null),
+      fetchFromPostgres: vi.fn().mockResolvedValue(detail()),
+      hasPostgresConfig: () => false,
+      isTypesenseUnavailableError: unavailable,
+      logger,
+    });
+
+    expect(out).toBeNull();
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[company] Postgres fallback skipped because DATABASE_URL is not configured",
+    );
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/services/__tests__/company-detail.test.ts
+++ b/apps/web/src/lib/services/__tests__/company-detail.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setTestEnv, withTestEnv } from "@/test-utils/env";
+
+const mocks = vi.hoisted(() => ({
+  cached: vi.fn(
+    (_key: string, fetcher: () => Promise<unknown>, _options: unknown) => fetcher(),
+  ),
+  search: vi.fn(),
+  dbExecute: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/cache", () => ({
+  cached: mocks.cached,
+}));
+vi.mock("@/lib/search/typesense-client", () => ({
+  getSearchClient: () => ({
+    collections: () => ({ documents: () => ({ search: mocks.search }) }),
+  }),
+}));
+vi.mock("@/db", () => ({ db: { execute: mocks.dbExecute } }));
+vi.mock("drizzle-orm", () => ({
+  sql: (strings: TemplateStringsArray, ..._values: unknown[]) =>
+    strings.join("?"),
+}));
+vi.mock("@/lib/search/typesense-retry", () => ({
+  isRetryableError: (err: unknown) =>
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: unknown }).code === "ECONNRESET",
+  isTypesenseRateLimitError: (err: unknown) =>
+    typeof err === "object" &&
+    err !== null &&
+    (
+      ("httpStatus" in err && (err as { httpStatus?: unknown }).httpStatus === 429) ||
+      ("message" in err &&
+        typeof (err as { message?: unknown }).message === "string" &&
+        (err as { message: string }).message.includes("HTTP code 429"))
+    ),
+  isTypesenseUnavailableError: (err: unknown) =>
+    typeof err === "object" &&
+    err !== null &&
+    (
+      ("code" in err && (err as { code?: unknown }).code === "ECONNRESET") ||
+      ("message" in err &&
+        typeof (err as { message?: unknown }).message === "string" &&
+        (err as { message: string }).message.includes("TYPESENSE_SEARCH_KEY"))
+    ),
+  withTypesenseRetry: (fn: () => Promise<unknown>) => fn(),
+}));
+
+import { getCompanyBySlug } from "../company-detail";
+
+const searchMock = mocks.search;
+const dbExecuteMock = mocks.dbExecute;
+const cachedMock = mocks.cached;
+const TEST_ENV = {
+  DATABASE_URL:
+    process.env.DATABASE_URL ?? "postgresql://test:test@localhost:5432/test",
+  TYPESENSE_HOST: process.env.TYPESENSE_HOST ?? "localhost",
+  TYPESENSE_PORT: process.env.TYPESENSE_PORT ?? "8108",
+  TYPESENSE_PROTOCOL: process.env.TYPESENSE_PROTOCOL ?? "http",
+  TYPESENSE_SEARCH_KEY: process.env.TYPESENSE_SEARCH_KEY ?? "test-key",
+};
+
+const hit = (overrides: Record<string, unknown> = {}) => ({
+  id: "co-1",
+  name: "Acme Corp",
+  slug: "acme",
+  icon: "https://cdn.x/icon.png",
+  logo: null,
+  website: "https://acme.example",
+  description: "We build things in English.",
+  industry_id: 7,
+  industry_name: "Software",
+  employee_count_range: 3,
+  founded_year: 2015,
+  active_posting_count: 42,
+  ...overrides,
+});
+
+const pgRow = {
+  id: "co-1",
+  name: "Acme Corp",
+  slug: "acme",
+  icon: null,
+  logo: null,
+  website: null,
+  description: "From Postgres",
+  industry_id: 7,
+  industry_name: "Software",
+  employee_count_range: 3,
+  founded_year: 2015,
+};
+
+withTestEnv(TEST_ENV);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  cachedMock.mockImplementation(
+    (_key: string, fetcher: () => Promise<unknown>, _options: unknown) => fetcher(),
+  );
+  searchMock.mockReset();
+  dbExecuteMock.mockReset();
+});
+
+describe("getCompanyBySlug", () => {
+  it("uses the shared company-slug cache with skip-null semantics on a hit", async () => {
+    searchMock.mockResolvedValue({ hits: [{ document: hit() }] });
+
+    const out = await getCompanyBySlug("acme", "en");
+
+    expect(out?.id).toBe("co-1");
+    expect(cachedMock).toHaveBeenCalledTimes(1);
+    const [key, _fetcher, options] = cachedMock.mock.calls[0] as [
+      string,
+      () => Promise<unknown>,
+      { ttl: number; skipIf: (data: unknown) => boolean },
+    ];
+    expect(key).toBe("company-slug:acme:en");
+    expect(options.ttl).toBe(600);
+    expect(options.skipIf(null)).toBe(true);
+    expect(options.skipIf(out)).toBe(false);
+  });
+
+  it("returns null on miss without throwing a cache-boundary sentinel", async () => {
+    searchMock.mockResolvedValue({ hits: [] });
+    dbExecuteMock.mockResolvedValue([]);
+
+    const out = await getCompanyBySlug("ghost-slug", "en");
+
+    expect(out).toBeNull();
+    const options = cachedMock.mock.calls[0][2] as {
+      skipIf: (data: unknown) => boolean;
+    };
+    expect(options.skipIf(out)).toBe(true);
+  });
+
+  it("returns null outside the cache boundary when lookup env is not configured", async () => {
+    setTestEnv({
+      DATABASE_URL: undefined,
+      TYPESENSE_HOST: undefined,
+      TYPESENSE_PORT: undefined,
+      TYPESENSE_PROTOCOL: undefined,
+      TYPESENSE_SEARCH_KEY: undefined,
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const out = await getCompanyBySlug("acme", "en");
+
+    expect(out).toBeNull();
+    expect(cachedMock).not.toHaveBeenCalled();
+    expect(searchMock).not.toHaveBeenCalled();
+    expect(dbExecuteMock).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[company] lookup skipped because Typesense and DATABASE_URL are not configured",
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("retries the Postgres query on transient ECONNRESET", async () => {
+    searchMock.mockRejectedValue(new Error("TYPESENSE_SEARCH_KEY is not set"));
+    const econn = new Error("read ECONNRESET") as Error & { code: string };
+    econn.code = "ECONNRESET";
+    dbExecuteMock
+      .mockRejectedValueOnce(econn)
+      .mockResolvedValueOnce([pgRow]);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const out = await getCompanyBySlug("acme", "en");
+
+    expect(out?.description).toBe("From Postgres");
+    expect(dbExecuteMock).toHaveBeenCalledTimes(2);
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});

--- a/apps/web/src/lib/services/__tests__/company-watchlist-search.test.ts
+++ b/apps/web/src/lib/services/__tests__/company-watchlist-search.test.ts
@@ -1,0 +1,251 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withTestEnv } from "@/test-utils/env";
+
+const mocks = vi.hoisted(() => ({
+  cacheLife: vi.fn(),
+  cacheTag: vi.fn(),
+  cached: vi.fn(
+    (_key: string, fetcher: () => Promise<unknown>, _options: unknown) => fetcher(),
+  ),
+  search: vi.fn(),
+  dbExecute: vi.fn(),
+  buildFilterString: vi.fn(() => ""),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/cache", () => ({
+  cacheLife: mocks.cacheLife,
+  cacheTag: mocks.cacheTag,
+}));
+vi.mock("@/lib/cache", () => ({
+  cached: mocks.cached,
+}));
+vi.mock("@/lib/search/typesense-client", () => ({
+  getSearchClient: () => ({
+    collections: () => ({ documents: () => ({ search: mocks.search }) }),
+  }),
+}));
+vi.mock("@/db", () => ({ db: { execute: mocks.dbExecute } }));
+vi.mock("drizzle-orm", () => ({
+  sql: (strings: TemplateStringsArray, ..._values: unknown[]) =>
+    strings.join("?"),
+}));
+vi.mock("@/lib/sessionCache", () => ({ getSessionUserId: vi.fn() }));
+vi.mock("@/lib/services/locations", () => ({
+  expandLocationIds: vi.fn(),
+  expandLocationIdsBatch: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("@/lib/services/taxonomy", () => ({
+  expandOccupationIds: vi.fn(),
+  expandOccupationIdsBatch: vi.fn().mockResolvedValue([]),
+}));
+vi.mock("@/lib/search", () => ({ getSearchProvider: vi.fn() }));
+vi.mock("@/lib/search/constants", () => ({
+  ANON_MAX_COMPANIES: 5,
+  ANON_MAX_POSTINGS: 10,
+}));
+vi.mock("@/lib/search/typesense-filters", () => ({
+  POSTING_BASE_FILTER: "is_active:true && has_content:!=false",
+  buildFilterString: mocks.buildFilterString,
+}));
+vi.mock("@/lib/search/typesense-retry", () => ({
+  isRetryableError: (err: unknown) =>
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code?: unknown }).code === "ECONNRESET",
+  isTypesenseRateLimitError: (err: unknown) =>
+    typeof err === "object" &&
+    err !== null &&
+    (
+      ("httpStatus" in err && (err as { httpStatus?: unknown }).httpStatus === 429) ||
+      ("message" in err &&
+        typeof (err as { message?: unknown }).message === "string" &&
+        (err as { message: string }).message.includes("HTTP code 429"))
+    ),
+  isTypesenseUnavailableError: (err: unknown) =>
+    typeof err === "object" &&
+    err !== null &&
+    (
+      ("code" in err && (err as { code?: unknown }).code === "ECONNRESET") ||
+      ("message" in err &&
+        typeof (err as { message?: unknown }).message === "string" &&
+        (err as { message: string }).message.includes("TYPESENSE_SEARCH_KEY"))
+    ),
+  withTypesenseRetry: (fn: () => Promise<unknown>) => fn(),
+}));
+vi.mock("@/lib/search/pg-filters", () => ({ localesOrNoneClause: vi.fn() }));
+vi.mock("@/lib/services/search-input", () => ({ parseSearchFilters: vi.fn() }));
+vi.mock("@/lib/search/params", () => ({
+  firstOf: vi.fn(),
+  idsOrUndefined: vi.fn(),
+  parseRangeParam: vi.fn(),
+}));
+
+import { searchCompaniesForWatchlist } from "../company";
+
+const searchMock = mocks.search;
+const buildFilterStringMock = mocks.buildFilterString;
+const TEST_ENV = {
+  DATABASE_URL:
+    process.env.DATABASE_URL ?? "postgresql://test:test@localhost:5432/test",
+  TYPESENSE_HOST: process.env.TYPESENSE_HOST,
+  TYPESENSE_PORT: process.env.TYPESENSE_PORT,
+  TYPESENSE_PROTOCOL: process.env.TYPESENSE_PROTOCOL,
+  TYPESENSE_SEARCH_KEY: process.env.TYPESENSE_SEARCH_KEY,
+};
+
+const companyHit = (overrides: Record<string, unknown> = {}) => ({
+  id: "co-1",
+  name: "Acme Corp",
+  slug: "acme",
+  icon: "https://cdn.x/icon.png",
+  logo: null,
+  website: "https://acme.example",
+  description: "We build things in English.",
+  description_de: "Wir bauen Dinge.",
+  industry_id: 7,
+  industry_name: "Software",
+  industry_name_de: "Software",
+  employee_count_range: 3,
+  founded_year: 2015,
+  active_posting_count: 42,
+  ...overrides,
+});
+
+withTestEnv(TEST_ENV);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  searchMock.mockReset();
+  buildFilterStringMock.mockReset();
+  buildFilterStringMock.mockReturnValue("");
+});
+
+describe("searchCompaniesForWatchlist", () => {
+  it("includes companies with zero active postings in unfiltered search", async () => {
+    searchMock.mockResolvedValue({
+      found: 1,
+      hits: [{ document: companyHit({ active_posting_count: 0 }) }],
+    });
+
+    const out = await searchCompaniesForWatchlist({
+      query: "Acme",
+      locale: "en",
+      offset: 0,
+      limit: 20,
+    });
+
+    expect(out.companies).toHaveLength(1);
+    expect(out.companies[0].activeMatches).toBe(0);
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.not.objectContaining({ filter_by: expect.stringContaining("active_posting_count") }),
+    );
+  });
+
+  it("does not exclude zero-posting companies when filtering by industry", async () => {
+    searchMock.mockResolvedValue({
+      found: 1,
+      hits: [{ document: companyHit({ active_posting_count: 0 }) }],
+    });
+
+    await searchCompaniesForWatchlist({
+      industryId: 7,
+      locale: "en",
+      offset: 0,
+      limit: 20,
+    });
+
+    expect(searchMock).toHaveBeenCalledWith(
+      expect.objectContaining({ filter_by: "industry_id:=7" }),
+    );
+  });
+
+  it("keeps starred ordering without requiring active postings", async () => {
+    searchMock
+      .mockResolvedValueOnce({
+        found: 1,
+        hits: [{ document: companyHit({ active_posting_count: 0 }) }],
+      })
+      .mockResolvedValueOnce({ found: 0, hits: [] });
+
+    const out = await searchCompaniesForWatchlist({
+      locale: "en",
+      offset: 0,
+      limit: 20,
+      starredCompanyIds: ["co-1"],
+    });
+
+    expect(out.companies).toHaveLength(1);
+    expect(searchMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ filter_by: "id:[co-1]" }),
+    );
+    expect(searchMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ filter_by: "id:!=[co-1]" }),
+    );
+  });
+
+  it("includes a searched zero-posting company when the watchlist has filters", async () => {
+    buildFilterStringMock.mockReturnValue("location_ids:=[42]");
+    searchMock
+      .mockResolvedValueOnce({
+        facet_counts: [{ counts: [], stats: { total_values: 0 } }],
+      })
+      .mockResolvedValueOnce({
+        found: 1,
+        hits: [{ document: companyHit({ active_posting_count: 0 }) }],
+      })
+      .mockResolvedValueOnce({
+        facet_counts: [{ counts: [], stats: { total_values: 0 } }],
+      })
+      .mockResolvedValueOnce({
+        hits: [{ document: companyHit({ active_posting_count: 0 }) }],
+      });
+
+    const out = await searchCompaniesForWatchlist({
+      query: "Acme",
+      locale: "en",
+      offset: 0,
+      limit: 20,
+      locationIds: [42],
+    });
+
+    expect(out).toMatchObject({
+      total: 1,
+      companies: [{ id: "co-1", activeMatches: 0 }],
+    });
+  });
+
+  it("includes a searched active company with zero matches for the current watchlist filters", async () => {
+    buildFilterStringMock.mockReturnValue("technology_ids:=[99]");
+    searchMock
+      .mockResolvedValueOnce({
+        facet_counts: [{ counts: [], stats: { total_values: 0 } }],
+      })
+      .mockResolvedValueOnce({
+        found: 1,
+        hits: [{ document: companyHit({ active_posting_count: 42 }) }],
+      })
+      .mockResolvedValueOnce({
+        facet_counts: [{ counts: [], stats: { total_values: 0 } }],
+      })
+      .mockResolvedValueOnce({
+        hits: [{ document: companyHit({ active_posting_count: 42 }) }],
+      });
+
+    const out = await searchCompaniesForWatchlist({
+      query: "Acme",
+      locale: "en",
+      offset: 0,
+      limit: 20,
+      technologyIds: [99],
+    });
+
+    expect(out).toMatchObject({
+      total: 1,
+      companies: [{ id: "co-1", activeMatches: 0 }],
+    });
+  });
+});

--- a/apps/web/src/lib/services/company-detail-lookup.ts
+++ b/apps/web/src/lib/services/company-detail-lookup.ts
@@ -1,0 +1,158 @@
+export interface CompanyDetail {
+  id: string;
+  name: string;
+  slug: string;
+  icon: string | null;
+  logo: string | null;
+  website: string | null;
+  description: string | null;
+  industryId: number | null;
+  industryName: string | null;
+  employeeCountRange: number | null;
+  foundedYear: number | null;
+  activeJobCount: number;
+}
+
+export interface CompanyLookupEnv {
+  [key: string]: string | undefined;
+  DATABASE_URL?: string;
+  TYPESENSE_HOST?: string;
+  TYPESENSE_PORT?: string;
+  TYPESENSE_PROTOCOL?: string;
+  TYPESENSE_SEARCH_KEY?: string;
+}
+
+export interface ResolveCompanyBySlugDeps {
+  fetchFromTypesense: (slug: string, locale: string) => Promise<CompanyDetail | null>;
+  fetchFromPostgres: (slug: string, locale: string) => Promise<CompanyDetail | null>;
+  hasPostgresConfig: () => boolean;
+  isTypesenseUnavailableError: (err: unknown) => boolean;
+  logger?: Pick<typeof console, "error" | "warn">;
+}
+
+// Canonical company-slug shape: lowercase alphanumeric segments separated
+// by single hyphens (mirrors apps/crawler SLUG_RE). The slug reaches here
+// from a URL path segment, so a hostile caller could craft a string that
+// escapes the Typesense filter clause when raw-interpolated. Reject
+// non-conforming slugs up front; null falls through to a regular 404.
+const SLUG_SHAPE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+export function isSafeCompanySlug(slug: string): boolean {
+  return SLUG_SHAPE.test(slug);
+}
+
+export function canResolveCompanyBySlugFromEnv(env: CompanyLookupEnv): boolean {
+  return Boolean(
+    env.DATABASE_URL ||
+      (
+        env.TYPESENSE_HOST &&
+        env.TYPESENSE_PORT &&
+        env.TYPESENSE_PROTOCOL &&
+        env.TYPESENSE_SEARCH_KEY
+      ),
+  );
+}
+
+export async function resolveCompanyBySlug(
+  slug: string,
+  locale: string,
+  deps: ResolveCompanyBySlugDeps,
+): Promise<CompanyDetail | null> {
+  const logger = deps.logger ?? console;
+  let typesenseError: unknown;
+
+  // Primary path: Typesense. Falls back to Postgres on either error or 0 hits
+  // so brand-new companies (whose Typesense upsert lagged the latest sync)
+  // still render. Bot traffic to nonexistent slugs pays the Postgres cost
+  // (a cheap PK lookup on company.slug); cache layer above prevents
+  // poisoning by not storing nulls.
+  if (isSafeCompanySlug(slug)) {
+    try {
+      const fromTypesense = await deps.fetchFromTypesense(slug, locale);
+      if (fromTypesense) return fromTypesense;
+    } catch (err) {
+      typesenseError = err;
+    }
+  }
+
+  if (typesenseError && !deps.isTypesenseUnavailableError(typesenseError)) {
+    throw typesenseError;
+  }
+  if (!deps.hasPostgresConfig()) {
+    if (typesenseError) {
+      logger.error("[company] Typesense failed and Postgres fallback is unavailable", typesenseError);
+    }
+    logger.warn("[company] Postgres fallback skipped because DATABASE_URL is not configured");
+    return null;
+  }
+  if (typesenseError) {
+    logger.error("[company] Typesense failed, falling back to Postgres", typesenseError);
+  }
+  return deps.fetchFromPostgres(slug, locale);
+}
+
+export function mapTypesenseCompanyHitToDetail(
+  hit: Record<string, unknown>,
+  slug: string,
+  locale: string,
+): CompanyDetail {
+  const localeKey = (loc: string, base: string): string =>
+    loc === "en" ? base : `${base}_${loc}`;
+  const pickLocalized = (base: string): string | null => {
+    const localized = hit[localeKey(locale, base)];
+    if (typeof localized === "string" && localized.length > 0) return localized;
+    const en = hit[base];
+    return typeof en === "string" && en.length > 0 ? en : null;
+  };
+
+  return {
+    id: String(hit.id),
+    name: String(hit.name ?? ""),
+    slug: String(hit.slug ?? slug),
+    icon: typeof hit.icon === "string" ? hit.icon : null,
+    logo: typeof hit.logo === "string" ? hit.logo : null,
+    website: typeof hit.website === "string" ? hit.website : null,
+    description: pickLocalized("description"),
+    industryId: typeof hit.industry_id === "number" ? hit.industry_id : null,
+    industryName: pickLocalized("industry_name"),
+    employeeCountRange:
+      typeof hit.employee_count_range === "number" ? hit.employee_count_range : null,
+    foundedYear: typeof hit.founded_year === "number" ? hit.founded_year : null,
+    activeJobCount: typeof hit.active_posting_count === "number" ? hit.active_posting_count : 0,
+  };
+}
+
+export interface PostgresCompanyRow {
+  id: string;
+  name: string;
+  slug: string;
+  icon: string | null;
+  logo: string | null;
+  website: string | null;
+  description: string | null;
+  industry_id: number | null;
+  industry_name: string | null;
+  employee_count_range: number | null;
+  founded_year: number | null;
+}
+
+export function mapPostgresCompanyRowToDetail(row: PostgresCompanyRow): CompanyDetail {
+  return {
+    id: row.id,
+    name: row.name,
+    slug: row.slug,
+    icon: row.icon,
+    logo: row.logo,
+    website: row.website,
+    description: row.description,
+    industryId: row.industry_id,
+    industryName: row.industry_name,
+    employeeCountRange: row.employee_count_range,
+    foundedYear: row.founded_year,
+    // Postgres fallback skips the active count (the only Typesense-only fact).
+    // Effect on the page: header strip shows "0 open positions" until Typesense
+    // recovers; the postings list itself comes from a separate Typesense call
+    // and already degrades independently.
+    activeJobCount: 0,
+  };
+}

--- a/apps/web/src/lib/services/company-detail.ts
+++ b/apps/web/src/lib/services/company-detail.ts
@@ -1,0 +1,132 @@
+import "server-only";
+
+import { sql } from "drizzle-orm";
+import { db } from "@/db";
+import { CACHE_TTL_DETAIL } from "@/lib/cache-ttl";
+import { cached } from "@/lib/cache";
+import { withDbRetry } from "@/lib/db-retry";
+import { getSearchClient } from "@/lib/search/typesense-client";
+import {
+  isRetryableError as isRetryableTypesenseError,
+  isTypesenseRateLimitError,
+  isTypesenseUnavailableError,
+  withTypesenseRetry,
+} from "@/lib/search/typesense-retry";
+import {
+  canResolveCompanyBySlugFromEnv,
+  isSafeCompanySlug,
+  mapPostgresCompanyRowToDetail,
+  mapTypesenseCompanyHitToDetail,
+  resolveCompanyBySlug,
+  type CompanyDetail,
+  type PostgresCompanyRow,
+} from "@/lib/services/company-detail-lookup";
+
+export type { CompanyDetail } from "@/lib/services/company-detail-lookup";
+
+export async function getCompanyBySlug(
+  slug: string,
+  locale: string,
+): Promise<CompanyDetail | null> {
+  if (!canResolveCompanyBySlugFromEnv(process.env)) {
+    console.warn("[company] lookup skipped because Typesense and DATABASE_URL are not configured");
+    return null;
+  }
+  const key = `company-slug:${slug}:${locale}`;
+  // Empty-result skipping is load-bearing here: a not-yet-indexed company
+  // should be retried on the next request, but throwing a sentinel from a
+  // `'use cache'` boundary leaks that error into the RSC payload (#3603).
+  return cached(key, () => fetchCompanyBySlug(slug, locale), {
+    ttl: CACHE_TTL_DETAIL,
+    skipIf: (data) => data === null,
+  });
+}
+
+async function fetchCompanyBySlug(slug: string, locale: string): Promise<CompanyDetail | null> {
+  return resolveCompanyBySlug(slug, locale, {
+    fetchFromTypesense: fetchCompanyBySlugFromTypesense,
+    fetchFromPostgres: fetchCompanyBySlugFromPostgres,
+    hasPostgresConfig: () => Boolean(process.env.DATABASE_URL),
+    isTypesenseUnavailableError,
+    logger: console,
+  });
+}
+
+function shouldRetryCompanyTypesenseRead(err: unknown): boolean {
+  return isRetryableTypesenseError(err) || isTypesenseRateLimitError(err);
+}
+
+async function fetchCompanyBySlugFromTypesense(
+  slug: string,
+  locale: string,
+): Promise<CompanyDetail | null> {
+  if (!isSafeCompanySlug(slug)) return null;
+  const client = getSearchClient();
+  const result = await withTypesenseRetry(
+    () =>
+      client.collections("company").documents().search({
+        q: "*",
+        filter_by: `slug:=${slug}`,
+        per_page: 1,
+      }),
+    {
+      attempts: 5,
+      baseDelaysMs: [250, 500, 1000, 2000],
+      isRetryable: shouldRetryCompanyTypesenseRead,
+      label: `companyBySlug[${slug}]`,
+    },
+  );
+  const hit = result.hits?.[0]?.document as Record<string, unknown> | undefined;
+  return hit ? mapTypesenseCompanyHitToDetail(hit, slug, locale) : null;
+}
+
+async function fetchCompanyBySlugFromPostgres(
+  slug: string,
+  locale: string,
+): Promise<CompanyDetail | null> {
+  // Retry on transient connection-class errors (#2918): the build that
+  // killed prerender at 2026-05-09T15:41:49Z hit `read ECONNRESET` from
+  // the Supabase pooler on this exact query. The next build 2 min later
+  // succeeded, a flake, not structural break. `withDbRetry` only retries
+  // ECONNRESET / ETIMEDOUT / ECONNREFUSED / EPIPE / "Connection
+  // terminated"-class messages; syntax / constraint / business errors
+  // propagate immediately so the original signal is preserved.
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        id: string;
+        name: string;
+        slug: string;
+        icon: string | null;
+        logo: string | null;
+        website: string | null;
+        description: string | null;
+        industry_id: number | null;
+        industry_name: string | null;
+        employee_count_range: number | null;
+        founded_year: number | null;
+      }>(sql`
+        SELECT c.id, c.name, c.slug, c.icon, c.logo, c.website,
+          COALESCE(cd.description, c.description) AS description,
+          c.industry AS industry_id,
+          COALESCE(ind_name.name, i.name) AS industry_name,
+          c.employee_count_range,
+          c.founded_year
+        FROM company c
+        LEFT JOIN industry i ON i.id = c.industry
+        LEFT JOIN company_description cd
+          ON cd.company_id = c.id AND cd.locale = ${locale}
+        LEFT JOIN LATERAL (
+          SELECT name FROM industry_name
+          WHERE industry_id = c.industry AND locale IN (${locale}, 'en') AND is_display = true
+          ORDER BY (locale = ${locale})::int DESC LIMIT 1
+        ) ind_name ON c.industry IS NOT NULL
+        WHERE c.slug = ${slug}
+      `),
+    { label: `companyBySlug[${slug}]` },
+  );
+
+  const row = (rows as unknown as PostgresCompanyRow[])[0];
+  return row ? mapPostgresCompanyRowToDetail(row) : null;
+}

--- a/apps/web/src/lib/services/company.ts
+++ b/apps/web/src/lib/services/company.ts
@@ -3,8 +3,7 @@ import "server-only";
 import { sql } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
 import { db } from "@/db";
-import { CACHE_TTL_MEDIUM, CACHE_TTL_LONG, CACHE_TTL_DETAIL } from "@/lib/cache-ttl";
-import { cached } from "@/lib/cache";
+import { CACHE_TTL_MEDIUM, CACHE_TTL_LONG } from "@/lib/cache-ttl";
 import { withDbRetry } from "@/lib/db-retry";
 import { getSearchProvider } from "@/lib/search";
 import type { SearchResultPosting, WorkMode } from "@/lib/search";
@@ -19,12 +18,7 @@ import { expandOccupationIdsBatch } from "@/lib/services/taxonomy";
 import { ANON_MAX_COMPANIES, ANON_MAX_POSTINGS } from "@/lib/search/constants";
 import { getSearchClient } from "@/lib/search/typesense-client";
 import { buildFilterString, POSTING_BASE_FILTER } from "@/lib/search/typesense-filters";
-import {
-  isRetryableError as isRetryableTypesenseError,
-  isTypesenseRateLimitError,
-  isTypesenseUnavailableError,
-  withTypesenseRetry,
-} from "@/lib/search/typesense-retry";
+import { isTypesenseUnavailableError } from "@/lib/search/typesense-retry";
 import { localesOrNoneClause } from "@/lib/search/pg-filters";
 import { parseSearchFilters } from "@/lib/services/search-input";
 import { getCurrencyRates } from "@/lib/services/search";
@@ -32,9 +26,8 @@ import { firstOf, idsOrUndefined, parseRangeParam } from "@/lib/search/params";
 import { convertToEur } from "@/lib/salary";
 import { canonicalStringCompare } from "@/lib/sort";
 
-function shouldRetryCompanyTypesenseRead(err: unknown): boolean {
-  return isRetryableTypesenseError(err) || isTypesenseRateLimitError(err);
-}
+export { getCompanyBySlug } from "@/lib/services/company-detail";
+export type { CompanyDetail } from "@/lib/services/company-detail";
 
 // ── Company suggestions (search bar autocomplete) ───────────────────
 
@@ -618,219 +611,6 @@ export async function suggestIndustries(params: {
 
   type Row = { id: number; name: string };
   return (rows as unknown as Row[]).map((r) => ({ id: r.id, name: r.name }));
-}
-
-// ── Company detail ──────────────────────────────────────────────────
-
-export interface CompanyDetail {
-  id: string;
-  name: string;
-  slug: string;
-  icon: string | null;
-  logo: string | null;
-  website: string | null;
-  description: string | null;
-  industryId: number | null;
-  industryName: string | null;
-  employeeCountRange: number | null;
-  foundedYear: number | null;
-  activeJobCount: number;
-}
-
-export async function getCompanyBySlug(
-  slug: string,
-  locale: string,
-): Promise<CompanyDetail | null> {
-  if (!canResolveCompanyBySlug()) {
-    console.warn("[company] lookup skipped because Typesense and DATABASE_URL are not configured");
-    return null;
-  }
-  const key = `company-slug:${slug}:${locale}`;
-  // Empty-result skipping is load-bearing here: a not-yet-indexed company
-  // should be retried on the next request, but throwing a sentinel from a
-  // `'use cache'` boundary leaks that error into the RSC payload (#3603).
-  return cached(key, () => _fetchCompanyBySlug(slug, locale), {
-    ttl: CACHE_TTL_DETAIL,
-    skipIf: (data) => data === null,
-  });
-}
-
-async function _fetchCompanyBySlug(slug: string, locale: string): Promise<CompanyDetail | null> {
-  // Primary path: Typesense. Falls back to Postgres on either error or 0 hits
-  // so brand-new companies (whose Typesense upsert lagged the latest sync)
-  // still render. Bot traffic to nonexistent slugs pays the Postgres cost
-  // (a cheap PK lookup on company.slug); cache layer above prevents
-  // poisoning by not storing nulls.
-  let typesenseError: unknown;
-  try {
-    const fromTypesense = await _fetchCompanyBySlugFromTypesense(slug, locale);
-    if (fromTypesense) return fromTypesense;
-  } catch (err) {
-    typesenseError = err;
-  }
-  if (typesenseError && !isTypesenseUnavailableError(typesenseError)) {
-    throw typesenseError;
-  }
-  if (!process.env.DATABASE_URL) {
-    if (typesenseError) {
-      console.error("[company] Typesense failed and Postgres fallback is unavailable", typesenseError);
-    }
-    console.warn("[company] Postgres fallback skipped because DATABASE_URL is not configured");
-    return null;
-  }
-  if (typesenseError) {
-    // Typesense unreachable — fall through to Postgres. Log at error so the
-    // fallback rate is queryable (e.g. Cloudflare-tunnel blip pushing 100%
-    // of company-page traffic to Supabase). Matches the precedent set by
-    // `searchCompaniesForWatchlist` / `_fetchSimilarUnfiltered` /
-    // `_fetchSimilarFiltered` in this same file. See #3175.
-    console.error("[company] Typesense failed, falling back to Postgres", typesenseError);
-  }
-  return _fetchCompanyBySlugFromPostgres(slug, locale);
-}
-
-function canResolveCompanyBySlug(): boolean {
-  return Boolean(
-    process.env.DATABASE_URL ||
-      (
-        process.env.TYPESENSE_HOST &&
-        process.env.TYPESENSE_PORT &&
-        process.env.TYPESENSE_PROTOCOL &&
-        process.env.TYPESENSE_SEARCH_KEY
-      ),
-  );
-}
-
-// Canonical company-slug shape: lowercase alphanumeric segments separated
-// by single hyphens (mirrors apps/crawler SLUG_RE). The slug reaches here
-// from a URL path segment, so a hostile caller could craft a string that
-// escapes the Typesense filter clause when raw-interpolated. Reject
-// non-conforming slugs up front; null falls through to a regular 404.
-const SLUG_SHAPE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
-
-async function _fetchCompanyBySlugFromTypesense(
-  slug: string,
-  locale: string,
-): Promise<CompanyDetail | null> {
-  if (!SLUG_SHAPE.test(slug)) return null;
-  const client = getSearchClient();
-  const result = await withTypesenseRetry(
-    () =>
-      client.collections("company").documents().search({
-        q: "*",
-        filter_by: `slug:=${slug}`,
-        per_page: 1,
-      }),
-    {
-      attempts: 5,
-      baseDelaysMs: [250, 500, 1000, 2000],
-      isRetryable: shouldRetryCompanyTypesenseRead,
-      label: `companyBySlug[${slug}]`,
-    },
-  );
-  const hit = result.hits?.[0]?.document as Record<string, unknown> | undefined;
-  if (!hit) return null;
-
-  const localeKey = (loc: string, base: string): string =>
-    loc === "en" ? base : `${base}_${loc}`;
-  const pickLocalized = (base: string): string | null => {
-    const localized = hit[localeKey(locale, base)];
-    if (typeof localized === "string" && localized.length > 0) return localized;
-    const en = hit[base];
-    return typeof en === "string" && en.length > 0 ? en : null;
-  };
-
-  return {
-    id: String(hit.id),
-    name: String(hit.name ?? ""),
-    slug: String(hit.slug ?? slug),
-    icon: typeof hit.icon === "string" ? hit.icon : null,
-    logo: typeof hit.logo === "string" ? hit.logo : null,
-    website: typeof hit.website === "string" ? hit.website : null,
-    description: pickLocalized("description"),
-    industryId: typeof hit.industry_id === "number" ? hit.industry_id : null,
-    industryName: pickLocalized("industry_name"),
-    employeeCountRange:
-      typeof hit.employee_count_range === "number" ? hit.employee_count_range : null,
-    foundedYear: typeof hit.founded_year === "number" ? hit.founded_year : null,
-    activeJobCount: typeof hit.active_posting_count === "number" ? hit.active_posting_count : 0,
-  };
-}
-
-async function _fetchCompanyBySlugFromPostgres(
-  slug: string,
-  locale: string,
-): Promise<CompanyDetail | null> {
-  // Retry on transient connection-class errors (#2918): the build that
-  // killed prerender at 2026-05-09T15:41:49Z hit `read ECONNRESET` from
-  // the Supabase pooler on this exact query. The next build 2 min later
-  // succeeded → flake, not structural break. `withDbRetry` only retries
-  // ECONNRESET / ETIMEDOUT / ECONNREFUSED / EPIPE / "Connection
-  // terminated"-class messages; syntax / constraint / business errors
-  // propagate immediately so the original signal is preserved.
-  const rows = await withDbRetry(
-    () =>
-      db.execute<{
-        [key: string]: unknown;
-        id: string;
-        name: string;
-        slug: string;
-        icon: string | null;
-        logo: string | null;
-        website: string | null;
-        description: string | null;
-        industry_id: number | null;
-        industry_name: string | null;
-        employee_count_range: number | null;
-        founded_year: number | null;
-      }>(sql`
-        SELECT c.id, c.name, c.slug, c.icon, c.logo, c.website,
-          COALESCE(cd.description, c.description) AS description,
-          c.industry AS industry_id,
-          COALESCE(ind_name.name, i.name) AS industry_name,
-          c.employee_count_range,
-          c.founded_year
-        FROM company c
-        LEFT JOIN industry i ON i.id = c.industry
-        LEFT JOIN company_description cd
-          ON cd.company_id = c.id AND cd.locale = ${locale}
-        LEFT JOIN LATERAL (
-          SELECT name FROM industry_name
-          WHERE industry_id = c.industry AND locale IN (${locale}, 'en') AND is_display = true
-          ORDER BY (locale = ${locale})::int DESC LIMIT 1
-        ) ind_name ON c.industry IS NOT NULL
-        WHERE c.slug = ${slug}
-      `),
-    { label: `companyBySlug[${slug}]` },
-  );
-
-  type Row = {
-    id: string; name: string; slug: string; icon: string | null;
-    logo: string | null; website: string | null; description: string | null;
-    industry_id: number | null; industry_name: string | null;
-    employee_count_range: number | null; founded_year: number | null;
-  };
-  const row = (rows as unknown as Row[])[0];
-  if (!row) return null;
-
-  return {
-    id: row.id,
-    name: row.name,
-    slug: row.slug,
-    icon: row.icon,
-    logo: row.logo,
-    website: row.website,
-    description: row.description,
-    industryId: row.industry_id,
-    industryName: row.industry_name,
-    employeeCountRange: row.employee_count_range,
-    foundedYear: row.founded_year,
-    // Postgres fallback skips the active count (the only Typesense-only fact).
-    // Effect on the page: header strip shows "0 open positions" until Typesense
-    // recovers; the postings list itself comes from a separate Typesense call
-    // (getCompanyPostings) so its rendering is unaffected by this path.
-    activeJobCount: 0,
-  };
 }
 
 // ── Similar companies (same industry, active, excluding self) ───────


### PR DESCRIPTION
## Summary
- split company slug lookup into a narrow detail service plus a pure lookup helper
- move backend behavior coverage out of the server-action test and into focused service tests
- reduce `apps/web/src/lib/actions/__tests__/company.test.ts` from 17 `vi.mock` calls to one service mock while preserving action-wrapper coverage

## Reproduction
- `grep -c "vi.mock" apps/web/src/lib/actions/__tests__/company.test.ts` returned `17` on `origin/main`
- focused baseline company test passed, confirming the issue was test structure rather than a current failing behavior

## Validation
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm --dir apps/web test src/lib/actions/__tests__/company.test.ts src/lib/services/__tests__/company-watchlist-search.test.ts src/lib/services/__tests__/company-detail-lookup.test.ts src/lib/services/__tests__/company-detail.test.ts`
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm --dir apps/web exec eslint src/lib/actions/__tests__/company.test.ts src/lib/actions/__tests__/similar-companies-salary-currency.test.ts src/lib/actions/__tests__/watchlists-invalidation.test.ts src/lib/services/company.ts src/lib/services/company-detail.ts src/lib/services/company-detail-lookup.ts src/lib/services/__tests__/company-watchlist-search.test.ts src/lib/services/__tests__/company-detail-lookup.test.ts src/lib/services/__tests__/company-detail.test.ts`
- `git diff --check`
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm --dir apps/web typecheck`
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm --dir apps/web build` (passes with existing missing-local-env warnings)
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm --dir apps/web test` (`161` files / `1324` tests)

Production probing is not applicable for this test/service-structure refactor; no production writes or Supabase writes were performed.

Closes #3133
