### PR TITLE
Fix filtered watchlist listing counts

### DIFF
--- a/apps/web/src/lib/actions/__tests__/watchlists-listing-perf.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-listing-perf.test.ts
@@ -3,7 +3,9 @@
  *
  * Asserts that the watchlist listing surfaces — `getUserWatchlists`,
  * `getPopularWatchlists`, and `searchPublicWatchlists` — do NOT fan out
- * per-watchlist Typesense `job_posting` count queries.
+ * per-watchlist Typesense `job_posting` count queries. Filtered rows
+ * may request precise counts, but they must do it in a single
+ * `multi_search` batch per listing render (#3261).
  *
  * Pre-fix:
  *   `getUserWatchlists(locale)` loaded N watchlist rows from Postgres,
@@ -16,10 +18,11 @@
  *   Typesense `watchlist` collection (1 round-trip), then re-ran the
  *   same N-fanout via `_enrichWatchlistsWithRealCounts`.
  *
- * Post-fix:
+ * #3176 post-fix:
  *   - `getUserWatchlists`  one SQL query against Postgres with the
  *     active count denormalized via a `watchlist_company JOIN
- *     job_posting WHERE is_active` subquery. Zero Typesense round-trips.
+ *     job_posting WHERE is_active` subquery. Zero Typesense round-trips
+ *     for unfiltered company-scoped rows.
  *   - `searchPublicWatchlists` / `getPopularWatchlists`  one Typesense
  *     `watchlist` collection search whose returned docs already carry
  *     `active_job_count` for company-scoped watchlists. `anyCompany`
@@ -27,12 +30,10 @@
  *     hit and run a bounded live `job_posting` count without Postgres
  *     hydration.
  *
- * The trade-off: non-anyCompany listing counts ignore the per-watchlist
- * filters (keywords, locations, work_mode, …) and the viewer's language
- * preference. The watchlist-detail page still surfaces the precise
- * filter-applied count via `getWatchlistPostingDisplayCounts`. The
- * follow-up issue (#3261) tracks restoring per-viewer / per-filter
- * accuracy via a batched `multi_search` if the UX warrants it.
+ * #3261 post-fix:
+ *   filtered rows patch the denormalized count through one batched
+ *   `multi_search`, using viewer languages and the same filter shape as
+ *   the watchlist-detail active count.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -88,9 +89,14 @@ const mocks = vi.hoisted(() => {
     // routes through this one mock so we can assert call count + which
     // collection was hit.
     tsSearch: vi.fn(),
+    tsMultiSearch: vi.fn(),
     tsCollectionsCalls: [] as string[],
 
     getViewerLanguages: vi.fn().mockResolvedValue(["en"]),
+    resolveLocationSlugs: vi.fn(),
+    resolveOccupationSlugs: vi.fn(),
+    resolveSenioritySlugs: vi.fn(),
+    resolveTechnologySlugs: vi.fn(),
     canCreateWatchlist: vi.fn().mockResolvedValue({ allowed: true }),
     notifyIndexNow: vi.fn(),
     tsUpsertWatchlist: vi.fn(),
@@ -176,6 +182,9 @@ vi.mock("@/lib/watchlist-slug", () => ({
 // assert which collections were hit and how often.
 vi.mock("@/lib/search/typesense-client", () => ({
   getSearchClient: () => ({
+    multiSearch: {
+      perform: mocks.tsMultiSearch,
+    },
     collections: (name: string) => {
       mocks.tsCollectionsCalls.push(name);
       return {
@@ -188,7 +197,26 @@ vi.mock("@/lib/search/typesense-client", () => ({
 }));
 
 vi.mock("@/lib/search/typesense-filters", () => ({
-  buildFilterString: vi.fn(() => ""),
+  buildFilterString: vi.fn((filters?: Record<string, unknown> | null) => {
+    if (!filters) return "";
+    const parts: string[] = [];
+    if (Array.isArray(filters.locationIds) && filters.locationIds.length) {
+      parts.push(`location_ids:[${filters.locationIds.join(",")}]`);
+    }
+    if (Array.isArray(filters.occupationIds) && filters.occupationIds.length) {
+      parts.push(`occupation_ids:[${filters.occupationIds.join(",")}]`);
+    }
+    if (Array.isArray(filters.seniorityIds) && filters.seniorityIds.length) {
+      parts.push(`seniority_id:[${filters.seniorityIds.join(",")}]`);
+    }
+    if (Array.isArray(filters.technologyIds) && filters.technologyIds.length) {
+      parts.push(`technology_ids:[${filters.technologyIds.join(",")}]`);
+    }
+    if (Array.isArray(filters.languages) && filters.languages.length) {
+      parts.push(`locales:[${[...filters.languages, "_none"].join(",")}]`);
+    }
+    return parts.join(" && ");
+  }),
   POSTING_BASE_FILTER: "is_active:true",
   POSTING_FLOW_FILTER: "has_content:!=false",
 }));
@@ -205,23 +233,23 @@ vi.mock("@/lib/search/constants", () => ({
 vi.mock("@/lib/actions/locations", () => ({
   expandLocationIds: vi.fn().mockResolvedValue([]),
   expandLocationIdsBatch: vi.fn().mockResolvedValue([]),
-  resolveLocationSlugs: vi.fn().mockResolvedValue(new Map()),
+  resolveLocationSlugs: mocks.resolveLocationSlugs,
 }));
 
 vi.mock("@/lib/actions/taxonomy", () => ({
   expandOccupationIds: vi.fn().mockResolvedValue([]),
   expandOccupationIdsBatch: vi.fn().mockResolvedValue([]),
-  resolveOccupationSlugs: vi.fn().mockResolvedValue(new Map()),
-  resolveSenioritySlugs: vi.fn().mockResolvedValue(new Map()),
-  resolveTechnologySlugs: vi.fn().mockResolvedValue(new Map()),
+  resolveOccupationSlugs: mocks.resolveOccupationSlugs,
+  resolveSenioritySlugs: mocks.resolveSenioritySlugs,
+  resolveTechnologySlugs: mocks.resolveTechnologySlugs,
 }));
 
 vi.mock("@/lib/services/taxonomy", () => ({
   expandOccupationIds: vi.fn().mockResolvedValue([]),
   expandOccupationIdsBatch: vi.fn().mockResolvedValue([]),
-  resolveOccupationSlugs: vi.fn().mockResolvedValue(new Map()),
-  resolveSenioritySlugs: vi.fn().mockResolvedValue(new Map()),
-  resolveTechnologySlugs: vi.fn().mockResolvedValue(new Map()),
+  resolveOccupationSlugs: mocks.resolveOccupationSlugs,
+  resolveSenioritySlugs: mocks.resolveSenioritySlugs,
+  resolveTechnologySlugs: mocks.resolveTechnologySlugs,
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -257,6 +285,15 @@ beforeEach(() => {
   mocks.getSessionUserId.mockResolvedValue(USER_ID);
   mocks.canCreateWatchlist.mockResolvedValue({ allowed: true });
   mocks.getViewerLanguages.mockResolvedValue(["en"]);
+  mocks.resolveLocationSlugs.mockResolvedValue(new Map([
+    ["zurich", { id: 2657896, slug: "zurich", name: "Zurich" }],
+    ["switzerland", { id: 2658434, slug: "switzerland", name: "Switzerland" }],
+  ]));
+  mocks.resolveOccupationSlugs.mockResolvedValue(new Map([
+    ["software-engineer", { id: 1, slug: "software-engineer", name: "Software Engineer" }],
+  ]));
+  mocks.resolveSenioritySlugs.mockResolvedValue(new Map());
+  mocks.resolveTechnologySlugs.mockResolvedValue(new Map());
 });
 
 afterEach(() => {
@@ -265,7 +302,15 @@ afterEach(() => {
 
 // ---- helpers ----------------------------------------------------------
 
-function fakeUserWatchlistRow(i: number, activeJobCount: number) {
+function fakeUserWatchlistRow(
+  i: number,
+  activeJobCount: number,
+  overrides: Partial<{
+    filters: Record<string, unknown>;
+    company_ids: string[];
+    company_count: number;
+  }> = {},
+) {
   return {
     id: `wl-${i}`,
     slug: `slug-${i}`,
@@ -273,15 +318,12 @@ function fakeUserWatchlistRow(i: number, activeJobCount: number) {
     description: null,
     is_public: i % 2 === 0,
     alerts_enabled: false,
-    filters: {
-      keywords: ["python", "remote"],
-      locationSlugs: ["zurich"],
-      workMode: ["remote"],
-    },
+    filters: overrides.filters ?? {},
     last_accessed_at: new Date("2026-05-14T00:00:00Z"),
     created_at: new Date("2026-05-01T00:00:00Z"),
-    company_count: 3,
+    company_count: overrides.company_count ?? 3,
     active_job_count: activeJobCount,
+    company_ids: overrides.company_ids ?? [`company-${i}-a`, `company-${i}-b`],
   };
 }
 
@@ -352,6 +394,60 @@ describe("getUserWatchlists — listing fan-out fix (#3176)", () => {
     expect(result.map((w) => w.activeJobCount)).toEqual([42, 7, 0]);
   });
 
+  it("patches filtered company-scoped rows with one batched Typesense multi_search (#3261)", async () => {
+    const rows = [
+      fakeUserWatchlistRow(0, 108, {
+        filters: {
+          locationSlugs: ["switzerland"],
+          occupationSlugs: ["software-engineer"],
+        },
+        company_ids: ["company-a", "company-b"],
+      }),
+      fakeUserWatchlistRow(1, 44, {
+        filters: {
+          keywords: ["python"],
+        },
+        company_ids: ["company-c"],
+      }),
+      fakeUserWatchlistRow(2, 12),
+    ];
+    mocks.dbExecute.mockResolvedValueOnce(rows);
+    mocks.tsMultiSearch.mockResolvedValueOnce({
+      results: [
+        { found: 6, hits: [] },
+        { found: 3, hits: [] },
+      ],
+    });
+
+    const result = await getUserWatchlists("en");
+
+    expect(result.map((w) => w.activeJobCount)).toEqual([6, 3, 12]);
+    expect(mocks.tsSearch).not.toHaveBeenCalled();
+    expect(mocks.tsMultiSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.tsMultiSearch.mock.calls[0]?.[0]).toMatchObject({
+      searches: [
+        {
+          collection: "job_posting",
+          q: "*",
+          query_by: "title",
+          per_page: 0,
+        },
+        {
+          collection: "job_posting",
+          q: "python",
+          query_by: "title",
+          per_page: 0,
+        },
+      ],
+    });
+    const searches = mocks.tsMultiSearch.mock.calls[0]?.[0].searches;
+    expect(searches[0].filter_by).toContain("company_id:[company-a,company-b]");
+    expect(searches[0].filter_by).toContain("location_ids:[2658434]");
+    expect(searches[0].filter_by).toContain("occupation_ids:[1]");
+    expect(searches[0].filter_by).toContain("locales:[en,_none]");
+    expect(searches[1].filter_by).toContain("company_id:[company-c]");
+  });
+
   it("returns [] without touching the database when unauthenticated", async () => {
     mocks.getSessionUserId.mockResolvedValueOnce(null);
 
@@ -373,7 +469,10 @@ describe("getUserWatchlists — listing fan-out fix (#3176)", () => {
     };
     const normalRow = fakeUserWatchlistRow(1, 12);
     mocks.dbExecute.mockResolvedValueOnce([anyRow, normalRow]);
-    mocks.tsSearch.mockResolvedValueOnce({ found: 38717, hits: [] });
+    mocks.resolveLocationSlugs.mockResolvedValueOnce(new Map([
+      ["eu", { id: 6255148, slug: "eu", name: "European Union" }],
+    ]));
+    mocks.tsMultiSearch.mockResolvedValueOnce({ results: [{ found: 38717, hits: [] }] });
 
     const result = await getUserWatchlists("en");
 
@@ -386,8 +485,9 @@ describe("getUserWatchlists — listing fan-out fix (#3176)", () => {
 
     // Exactly one Typesense call (the anyCompany count). The normal
     // row goes straight from SQL.
-    expect(mocks.tsSearch).toHaveBeenCalledTimes(1);
-    expect(mocks.tsCollectionsCalls).toEqual(["job_posting"]);
+    expect(mocks.tsSearch).not.toHaveBeenCalled();
+    expect(mocks.tsMultiSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.tsCollectionsCalls).toEqual([]);
   });
 
   it("returns 0 (not the SQL 0 either) when the anyCompany Typesense count fails", async () => {
@@ -396,7 +496,10 @@ describe("getUserWatchlists — listing fan-out fix (#3176)", () => {
       filters: { anyCompany: true, locationSlugs: ["eu"] },
     };
     mocks.dbExecute.mockResolvedValueOnce([anyRow]);
-    mocks.tsSearch.mockRejectedValueOnce(new Error("typesense unreachable"));
+    mocks.resolveLocationSlugs.mockResolvedValueOnce(new Map([
+      ["eu", { id: 6255148, slug: "eu", name: "European Union" }],
+    ]));
+    mocks.tsMultiSearch.mockRejectedValueOnce(new Error("typesense unreachable"));
 
     const result = await getUserWatchlists("en");
 
@@ -416,9 +519,9 @@ describe("getUserWatchlists — listing fan-out fix (#3176)", () => {
   // Regression for #3344. The `anyCompany` Typesense patch previously
   // omitted the viewer-language scope, so the tile count diverged from
   // the watchlist-detail page (which DOES scope by `locales:[lang,
-  // _none]` via `_getWatchlistPostingsTypesense`). The fix threads the
-  // viewer's resolved languages through `_resolveAnyCompanyActiveCount`
-  // so both surfaces issue the same Typesense filter shape.
+  // _none]` via `_getWatchlistPostingsTypesense`). The batched listing
+  // count path must keep forwarding the viewer's resolved languages so
+  // both surfaces issue the same Typesense filter shape.
   it("passes viewer languages through to the anyCompany Typesense count (#3344)", async () => {
     const anyRow = {
       ...fakeUserWatchlistRow(0, 0),
@@ -426,7 +529,10 @@ describe("getUserWatchlists — listing fan-out fix (#3176)", () => {
     };
     mocks.dbExecute.mockResolvedValueOnce([anyRow]);
     mocks.getViewerLanguages.mockResolvedValueOnce(["en"]);
-    mocks.tsSearch.mockResolvedValueOnce({ found: 39126, hits: [] });
+    mocks.resolveLocationSlugs.mockResolvedValueOnce(new Map([
+      ["eu", { id: 6255148, slug: "eu", name: "European Union" }],
+    ]));
+    mocks.tsMultiSearch.mockResolvedValueOnce({ results: [{ found: 39126, hits: [] }] });
 
     const buildFilterStringMock = vi.mocked(
       await import("@/lib/search/typesense-filters"),
@@ -573,7 +679,7 @@ describe("getPopularWatchlists — anyCompany count patch (#3352)", () => {
     }); // Typesense doc says 0
     const normalHit = fakePublicWatchlistHit(1, 12);
     mocks.tsSearch.mockResolvedValueOnce({ hits: [anyHit, normalHit], found: 2 });
-    mocks.tsSearch.mockResolvedValueOnce({ found: 38717, hits: [] });
+    mocks.tsMultiSearch.mockResolvedValueOnce({ results: [{ found: 38717, hits: [] }] });
 
     const result = await getPopularWatchlists({ offset: 0, limit: 20, locale: "en" });
 
@@ -583,11 +689,39 @@ describe("getPopularWatchlists — anyCompany count patch (#3352)", () => {
     // The non-anyCompany row: denormalized doc count survives unchanged.
     expect(result.watchlists[1].activeJobCount).toBe(12);
 
-    // Two Typesense calls: one for the watchlist collection, one for the
-    // job_posting count of the single anyCompany row.
-    expect(mocks.tsSearch).toHaveBeenCalledTimes(2);
-    expect(mocks.tsCollectionsCalls).toEqual(["watchlist", "job_posting"]);
+    // One watchlist search plus one batched job_posting multi_search.
+    expect(mocks.tsSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.tsMultiSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.tsCollectionsCalls).toEqual(["watchlist"]);
     expect(mocks.dbExecute).not.toHaveBeenCalled();
+  });
+
+  it("patches filtered company-scoped rows with one company-id query and one multi_search (#3261)", async () => {
+    const filteredHit = fakePublicWatchlistHit(0, 1000, {
+      locationSlugs: ["switzerland"],
+      locationIds: [2658434],
+      occupationSlugs: ["software-engineer"],
+      occupationIds: [1],
+    });
+    const unfilteredHit = fakePublicWatchlistHit(1, 12);
+    mocks.tsSearch.mockResolvedValueOnce({ hits: [filteredHit, unfilteredHit], found: 2 });
+    mocks.dbExecute.mockResolvedValueOnce([
+      { watchlist_id: "wl-0", company_ids: ["company-a", "company-b"] },
+    ]);
+    mocks.tsMultiSearch.mockResolvedValueOnce({ results: [{ found: 14, hits: [] }] });
+
+    const result = await getPopularWatchlists({ offset: 0, limit: 20, locale: "en" });
+
+    expect(result.watchlists.map((w) => w.activeJobCount)).toEqual([14, 12]);
+    expect(mocks.tsSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.dbExecute).toHaveBeenCalledTimes(1);
+    expect(mocks.tsMultiSearch).toHaveBeenCalledTimes(1);
+    const searches = mocks.tsMultiSearch.mock.calls[0]?.[0].searches;
+    expect(searches).toHaveLength(1);
+    expect(searches[0].filter_by).toContain("company_id:[company-a,company-b]");
+    expect(searches[0].filter_by).toContain("location_ids:[2658434]");
+    expect(searches[0].filter_by).toContain("occupation_ids:[1]");
+    expect(searches[0].filter_by).toContain("locales:[en,_none]");
   });
 
   it("fires no per-row count when no anyCompany rows are present", async () => {
@@ -601,6 +735,7 @@ describe("getPopularWatchlists — anyCompany count patch (#3352)", () => {
 
     // Only the watchlist search — no job_posting count fan-out.
     expect(mocks.tsSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.tsMultiSearch).not.toHaveBeenCalled();
     expect(mocks.tsCollectionsCalls).toEqual(["watchlist"]);
     expect(mocks.dbExecute).not.toHaveBeenCalled();
   });
@@ -617,6 +752,7 @@ describe("getPopularWatchlists — anyCompany count patch (#3352)", () => {
     expect(result.watchlists).toHaveLength(1);
     expect(result.watchlists[0].activeJobCount).toBe(0);
     expect(mocks.tsSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.tsMultiSearch).not.toHaveBeenCalled();
     expect(mocks.dbExecute).not.toHaveBeenCalled();
   });
 
@@ -631,6 +767,7 @@ describe("getPopularWatchlists — anyCompany count patch (#3352)", () => {
 
     expect(result.watchlists[0].activeJobCount).toBe(0);
     expect(mocks.tsSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.tsMultiSearch).not.toHaveBeenCalled();
     expect(mocks.tsCollectionsCalls).toEqual(["watchlist"]);
   });
 
@@ -638,7 +775,7 @@ describe("getPopularWatchlists — anyCompany count patch (#3352)", () => {
     const anyHit = fakePublicWatchlistHit(0, 0, { anyCompany: true });
     mocks.tsSearch.mockResolvedValueOnce({ hits: [anyHit], found: 1 });
     mocks.getViewerLanguages.mockResolvedValueOnce(["de"]);
-    mocks.tsSearch.mockResolvedValueOnce({ found: 4242, hits: [] });
+    mocks.tsMultiSearch.mockResolvedValueOnce({ results: [{ found: 4242, hits: [] }] });
 
     const buildFilterStringMock = vi.mocked(
       await import("@/lib/search/typesense-filters"),
@@ -662,7 +799,7 @@ describe("searchPublicWatchlists — anyCompany count patch (#3352)", () => {
     const anyHit = fakePublicWatchlistHit(0, 0, { anyCompany: true });
     const normalHit = fakePublicWatchlistHit(1, 42);
     mocks.tsSearch.mockResolvedValueOnce({ hits: [anyHit, normalHit], found: 2 });
-    mocks.tsSearch.mockResolvedValueOnce({ found: 1234, hits: [] });
+    mocks.tsMultiSearch.mockResolvedValueOnce({ results: [{ found: 1234, hits: [] }] });
 
     const result = await searchPublicWatchlists({
       query: "python",
@@ -675,9 +812,46 @@ describe("searchPublicWatchlists — anyCompany count patch (#3352)", () => {
     expect(result.watchlists[0].activeJobCount).toBe(1234);
     expect(result.watchlists[1].activeJobCount).toBe(42);
 
-    expect(mocks.tsSearch).toHaveBeenCalledTimes(2);
-    expect(mocks.tsCollectionsCalls).toEqual(["watchlist", "job_posting"]);
+    expect(mocks.tsSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.tsMultiSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.tsCollectionsCalls).toEqual(["watchlist"]);
     expect(mocks.dbExecute).not.toHaveBeenCalled();
+  });
+
+  it("patches filtered company-scoped rows with one multi_search (#3261)", async () => {
+    const filteredHit = fakePublicWatchlistHit(0, 250, {
+      keywords: ["python"],
+      locationSlugs: ["zurich"],
+      locationIds: [2657896],
+    });
+    const unfilteredHit = fakePublicWatchlistHit(1, 42);
+    mocks.tsSearch.mockResolvedValueOnce({ hits: [filteredHit, unfilteredHit], found: 2 });
+    mocks.dbExecute.mockResolvedValueOnce([
+      { watchlist_id: "wl-0", company_ids: ["company-a"] },
+    ]);
+    mocks.tsMultiSearch.mockResolvedValueOnce({ results: [{ found: 8, hits: [] }] });
+
+    const result = await searchPublicWatchlists({
+      query: "python",
+      offset: 0,
+      limit: 20,
+      locale: "en",
+    });
+
+    expect(result.watchlists.map((w) => w.activeJobCount)).toEqual([8, 42]);
+    expect(mocks.tsSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.dbExecute).toHaveBeenCalledTimes(1);
+    expect(mocks.tsMultiSearch).toHaveBeenCalledTimes(1);
+    const searches = mocks.tsMultiSearch.mock.calls[0]?.[0].searches;
+    expect(searches).toHaveLength(1);
+    expect(searches[0]).toMatchObject({
+      collection: "job_posting",
+      q: "python",
+      query_by: "title",
+      per_page: 0,
+    });
+    expect(searches[0].filter_by).toContain("company_id:[company-a]");
+    expect(searches[0].filter_by).toContain("location_ids:[2657896]");
   });
 
   it("fires no per-row count when no anyCompany rows are present", async () => {
@@ -687,6 +861,7 @@ describe("searchPublicWatchlists — anyCompany count patch (#3352)", () => {
     await searchPublicWatchlists({ query: "python", offset: 0, limit: 20, locale: "en" });
 
     expect(mocks.tsSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.tsMultiSearch).not.toHaveBeenCalled();
     expect(mocks.tsCollectionsCalls).toEqual(["watchlist"]);
     expect(mocks.dbExecute).not.toHaveBeenCalled();
   });
@@ -694,7 +869,7 @@ describe("searchPublicWatchlists — anyCompany count patch (#3352)", () => {
   it("returns 0 when the per-row anyCompany count fails", async () => {
     const anyHit = fakePublicWatchlistHit(0, 0, { anyCompany: true });
     mocks.tsSearch.mockResolvedValueOnce({ hits: [anyHit], found: 1 });
-    mocks.tsSearch.mockRejectedValueOnce(new Error("typesense unreachable"));
+    mocks.tsMultiSearch.mockRejectedValueOnce(new Error("typesense unreachable"));
 
     const result = await searchPublicWatchlists({
       query: "python",

--- a/apps/web/src/lib/services/watchlists.ts
+++ b/apps/web/src/lib/services/watchlists.ts
@@ -663,14 +663,12 @@ export async function getUserWatchlists(locale: string): Promise<WatchlistSummar
   const userId = await getSessionUserId();
   if (!userId) return [];
 
-  // Viewer language preference — used to scope the `anyCompany`
-  // Typesense-backed patch below so the tile count matches the
-  // watchlist-detail page's locale-filtered count. The SQL fast path
-  // for non-`anyCompany` rows still uses the locale-blind denormalized
-  // `active_job_count` (per the trade-off in #3176 — see block comment
-  // below), but the patched `anyCompany` count is exactly what the
-  // detail page renders, so they must share the same filter shape.
-  // See issue #3344.
+  // Viewer language preference — used by the batched Typesense count
+  // patch below so filtered listing counts match the watchlist-detail
+  // page's locale-filtered count. The SQL fast path for unfiltered
+  // company-scoped rows still uses the denormalized `active_job_count`;
+  // issue #3261 only pays the Typesense round-trip when a row has
+  // filters that make that approximation visibly wrong.
   const languages = await getViewerLanguages(locale);
 
   // Perf (#3176): compute the active job count via a denormalized SQL
@@ -687,13 +685,10 @@ export async function getUserWatchlists(locale: string): Promise<WatchlistSummar
   // server-side at request time so it is fresh, and so it works for
   // private watchlists too (which never reach Typesense).
   //
-  // Trade-off: this count ignores the per-watchlist filters
-  // (keywords, locations, work_mode, …) and the viewer's language
-  // preference. Both the listing badge and the public Discover surface
-  // accept this approximation — the watchlist detail page still shows
-  // the precise filter-applied count via `getWatchlistPostingDisplayCounts`.
-  // The follow-up issue (#3261) tracks restoring per-viewer / per-filter
-  // accuracy via a batched `multi_search` when the listing UX requires it.
+  // Follow-up (#3261): rows with any real watchlist filters are patched
+  // after this query via one Typesense `multi_search`. Rows without
+  // filters keep this SQL count, preserving the zero-Typesense fast path
+  // for the common "these companies, no filter clauses" watchlist.
   //
   // EXCEPTION (#3333): `anyCompany` watchlists have NO `watchlist_company`
   // rows (the editor toggle disables the company picker, and copies
@@ -702,11 +697,8 @@ export async function getUserWatchlists(locale: string): Promise<WatchlistSummar
   // The denormalized Typesense `active_job_count` field is also 0 for
   // these (the crawler's `refresh_typesense_counts` joins the same
   // empty `watchlist_company` table — see `apps/crawler/src/sync.py`).
-  // Fall back to a per-watchlist live Typesense count for those rows
-  // only, so the listing badge reflects reality. A user can have at
-  // most PLAN_LIMITS.maxWatchlists.maxPaid (50) watchlists; the fan-out
-  // is bounded by however many of those have `anyCompany` set, which
-  // is rare in practice.
+  // They are included in the same #3261 multi_search patch; when
+  // Typesense is unavailable they degrade to SQL's structural 0.
   const rows = await withDbRetry(
     () =>
       db.execute<{
@@ -721,10 +713,16 @@ export async function getUserWatchlists(locale: string): Promise<WatchlistSummar
         created_at: Date;
         company_count: number;
         active_job_count: number;
+        company_ids: string[];
       }>(sql`
         SELECT w.id, w.slug, w.title, w.description, w.is_public, w.alerts_enabled, w.filters,
                w.last_accessed_at, w.created_at,
                (SELECT count(*)::int FROM watchlist_company wc WHERE wc.watchlist_id = w.id) AS company_count,
+               (
+                 SELECT COALESCE(array_agg(wc.company_id::text ORDER BY wc.company_id::text), ARRAY[]::text[])
+                 FROM watchlist_company wc
+                 WHERE wc.watchlist_id = w.id
+               ) AS company_ids,
                (
                  SELECT count(*)::int
                  FROM watchlist_company wc
@@ -741,33 +739,12 @@ export async function getUserWatchlists(locale: string): Promise<WatchlistSummar
   type Row = {
     id: string; slug: string; title: string; description: string | null; is_public: boolean;
     alerts_enabled: boolean; filters: WatchlistFilters; last_accessed_at: Date; created_at: Date;
-    company_count: number; active_job_count: number;
+    company_count: number; active_job_count: number; company_ids: string[];
   };
 
   const typed = rows as unknown as Row[];
 
-  // Patch `anyCompany` rows with a live Typesense count (see comment
-  // above the SELECT). Fan-out is bounded by the user's
-  // `anyCompany`-watchlist count (typically 0-2); each call is cached
-  // by `_resolveAnyCompanyActiveCount` so an immediately-following
-  // render hits Redis instead of Typesense. Failures degrade to the
-  // SQL 0 — same as the rest of the listing surface.
-  const anyCompanyRows = typed.filter((r) => r.filters?.anyCompany);
-  let anyCompanyCounts: Map<string, number> = new Map();
-  if (anyCompanyRows.length > 0) {
-    const pairs = await Promise.all(
-      anyCompanyRows.map(async (r) => {
-        try {
-          const c = await _resolveAnyCompanyActiveCount(r.filters, locale, languages);
-          return [r.id, c] as const;
-        } catch (err) {
-          console.error("[getUserWatchlists] anyCompany count failed", { id: r.id, err });
-          return [r.id, 0] as const;
-        }
-      }),
-    );
-    anyCompanyCounts = new Map(pairs);
-  }
+  const preciseCounts = await _resolveUserListingCounts(typed, locale, languages);
 
   return typed.map((r) => ({
     id: r.id,
@@ -777,128 +754,188 @@ export async function getUserWatchlists(locale: string): Promise<WatchlistSummar
     isPublic: r.is_public,
     alertsEnabled: r.alerts_enabled,
     companyCount: r.company_count,
-    activeJobCount: r.filters?.anyCompany
-      ? (anyCompanyCounts.get(r.id) ?? 0)
-      : r.active_job_count,
+    activeJobCount: preciseCounts.get(r.id) ?? r.active_job_count,
     lastAccessedAt: new Date(r.last_accessed_at).toISOString(),
     createdAt: new Date(r.created_at).toISOString(),
   }));
 }
 
-/**
- * Compute the live "active jobs matching this watchlist's filters"
- * count against Typesense, for the `anyCompany=true` case where the
- * denormalized SQL JOIN and the Typesense `watchlist.active_job_count`
- * doc field both return 0 by construction.
- *
- * Mirrors the Typesense shape used by `_getWatchlistPostingsTypesense`
- * (POSTING_BASE_FILTER + slug-resolved filter ids + keywords +
- * viewer-language scope) but runs `per_page: 0` so we pay only for the
- * count. Cached by `buildFilterCacheKey(filters, [])` + the viewer's
- * resolved languages so two consecutive page renders with the same
- * filters and the same viewer share a single Typesense round-trip, but
- * an `en` viewer and a `de` viewer get distinct cache slots.
- *
- * Filter shape MUST match `_getWatchlistPostingsTypesense` exactly —
- * the tile count and the detail page's "active" count read the same
- * watchlist, and any divergence (e.g. omitting the locales filter)
- * shows up as a P1 count mismatch. Issue #3344 (originally allowed an
- * unscoped, broadest count here per #3262's listing trade-off; rolled
- * back when the user-visible divergence outweighed the per-viewer
- * cache fragmentation cost).
- *
- * Returns 0 on any Typesense error so the listing badge degrades to
- * the same value as the company-scope fast path.
- */
-async function _resolveAnyCompanyActiveCount(
-  filters: WatchlistFilters,
+async function _resolveUserListingCounts(
+  rows: Array<{
+    id: string;
+    filters: WatchlistFilters | null;
+    company_ids: string[] | null;
+    active_job_count: number;
+  }>,
   locale: string,
   languages: string[],
-): Promise<number> {
-  const langKey = languagesCacheKey(languages);
-  const key = `wl-any-active:${buildFilterCacheKey(filters, [])}:${langKey}`;
-  return cached(key, async () => {
-    const [locMap, occMap, senMap, techMap] = await Promise.all([
-      filters.locationSlugs?.length ? resolveLocationSlugs(filters.locationSlugs, locale) : Promise.resolve(new Map()),
-      filters.occupationSlugs?.length ? resolveOccupationSlugs(filters.occupationSlugs, locale) : Promise.resolve(new Map()),
-      filters.senioritySlugs?.length ? resolveSenioritySlugs(filters.senioritySlugs, locale) : Promise.resolve(new Map()),
-      filters.technologySlugs?.length ? resolveTechnologySlugs(filters.technologySlugs) : Promise.resolve(new Map()),
-    ]);
+): Promise<Map<string, number>> {
+  const filteredRows = rows.filter((r) => hasPreciseListingCountFilters(r.filters));
+  if (filteredRows.length === 0) return new Map();
 
-    const filterStr = buildFilterString({
-      locationIds: locMap.size > 0 ? [...locMap.values()].map((l) => l.id) : undefined,
-      occupationIds: occMap.size > 0 ? [...occMap.values()].map((o) => o.id) : undefined,
-      seniorityIds: senMap.size > 0 ? [...senMap.values()].map((s) => s.id) : undefined,
-      technologyIds: techMap.size > 0 ? [...techMap.values()].map((t) => t.id) : undefined,
-      workMode: filters.workMode?.length ? filters.workMode : undefined,
-      employmentTypes: filters.employmentType?.length ? filters.employmentType : undefined,
-      salaryMinEur: filters.salaryMin,
-      salaryMaxEur: filters.salaryMax,
-      experienceMin: filters.experienceMin,
-      experienceMax: filters.experienceMax,
-      languages: languages.length > 0 ? languages : undefined,
+  let indexedById: Map<string, IndexedWatchlistFilters | null>;
+  try {
+    indexedById = await buildIndexedFiltersForUserRows(filteredRows, locale);
+  } catch (err) {
+    console.error("[getUserWatchlists] filter id resolution failed", err);
+    return new Map();
+  }
+
+  const candidates: ListingCountCandidate[] = [];
+  for (const row of filteredRows) {
+    const filters = indexedById.get(row.id);
+    if (!filters || hasUnresolvedIndexedTaxonomy(filters)) continue;
+    candidates.push({
+      id: row.id,
+      filters,
+      companyIds: row.company_ids ?? [],
+      fallbackCount: row.active_job_count,
     });
+  }
 
-    const fullFilter = `${POSTING_BASE_FILTER}${filterStr ? " && " + filterStr : ""}`;
-    const hasKeywords = filters.keywords && filters.keywords.length > 0;
-    const q = hasKeywords ? filters.keywords!.join(" ") : "*";
-
-    try {
-      const client = getSearchClient();
-      const result = await client.collections("job_posting").documents().search({
-        q,
-        query_by: "title",
-        filter_by: fullFilter,
-        per_page: 0,
-      });
-      return result.found ?? 0;
-    } catch (err) {
-      console.error("[_resolveAnyCompanyActiveCount] Typesense failed", err);
-      return 0;
-    }
-  }, { ttl: CACHE_TTL_SHORT });
+  return resolvePreciseListingCounts(candidates, languages, "getUserWatchlists");
 }
 
-async function _resolveIndexedAnyCompanyActiveCount(
-  filters: IndexedWatchlistFilters,
-  filterCacheKey: string,
+async function buildIndexedFiltersForUserRows(
+  rows: Array<{ id: string; filters: WatchlistFilters | null }>,
+  locale: string,
+): Promise<Map<string, IndexedWatchlistFilters | null>> {
+  const locationSlugs = new Set<string>();
+  const occupationSlugs = new Set<string>();
+  const senioritySlugs = new Set<string>();
+  const technologySlugs = new Set<string>();
+
+  for (const row of rows) {
+    const f = row.filters ?? {};
+    f.locationSlugs?.forEach((slug) => locationSlugs.add(slug));
+    f.occupationSlugs?.forEach((slug) => occupationSlugs.add(slug));
+    f.senioritySlugs?.forEach((slug) => senioritySlugs.add(slug));
+    f.technologySlugs?.forEach((slug) => technologySlugs.add(slug));
+  }
+
+  const [locMap, occMap, senMap, techMap] = await Promise.all([
+    locationSlugs.size > 0 ? resolveLocationSlugs([...locationSlugs], locale) : Promise.resolve(new Map()),
+    occupationSlugs.size > 0 ? resolveOccupationSlugs([...occupationSlugs], locale) : Promise.resolve(new Map()),
+    senioritySlugs.size > 0 ? resolveSenioritySlugs([...senioritySlugs], locale) : Promise.resolve(new Map()),
+    technologySlugs.size > 0 ? resolveTechnologySlugs([...technologySlugs]) : Promise.resolve(new Map()),
+  ]);
+
+  const result = new Map<string, IndexedWatchlistFilters | null>();
+  for (const row of rows) {
+    const filters = row.filters ?? {};
+    const resolvedIds = {
+      locationIds: idsForSlugs(filters.locationSlugs, locMap),
+      occupationIds: idsForSlugs(filters.occupationSlugs, occMap),
+      seniorityIds: idsForSlugs(filters.senioritySlugs, senMap),
+      technologyIds: idsForSlugs(filters.technologySlugs, techMap),
+    };
+    const payload = buildIndexedWatchlistFiltersPayload(filters, resolvedIds);
+    result.set(row.id, payload);
+  }
+  return result;
+}
+
+function idsForSlugs<T extends { id: number }>(
+  slugs: string[] | undefined,
+  resolved: Map<string, T>,
+): number[] | undefined {
+  if (!slugs?.length) return undefined;
+  const ids: number[] = [];
+  for (const slug of slugs) {
+    const match = resolved.get(slug);
+    if (!match) return undefined;
+    ids.push(match.id);
+  }
+  return ids;
+}
+
+function hasPreciseListingCountFilters(
+  filters: WatchlistFilters | IndexedWatchlistFilters | null | undefined,
+): boolean {
+  if (!filters) return false;
+  return Boolean(
+    filters.anyCompany ||
+      filters.keywords?.length ||
+      filters.locationSlugs?.length ||
+      filters.occupationSlugs?.length ||
+      filters.senioritySlugs?.length ||
+      filters.technologySlugs?.length ||
+      filters.workMode?.length ||
+      filters.employmentType?.length ||
+      filters.salaryMin != null ||
+      filters.salaryMax != null ||
+      filters.experienceMin != null ||
+      filters.experienceMax != null,
+  );
+}
+
+async function resolvePreciseListingCounts(
+  candidates: ListingCountCandidate[],
   languages: string[],
-): Promise<number> {
-  const langKey = languagesCacheKey(languages);
-  const key = `wl-any-active-indexed:${filterCacheKey}:${langKey}`;
-  return cached(key, async () => {
-    const filterStr = buildFilterString({
-      locationIds: filters.locationIds?.length ? filters.locationIds : undefined,
-      occupationIds: filters.occupationIds?.length ? filters.occupationIds : undefined,
-      seniorityIds: filters.seniorityIds?.length ? filters.seniorityIds : undefined,
-      technologyIds: filters.technologyIds?.length ? filters.technologyIds : undefined,
-      workMode: filters.workMode?.length ? filters.workMode : undefined,
-      employmentTypes: filters.employmentType?.length ? filters.employmentType : undefined,
-      salaryMinEur: filters.salaryMin,
-      salaryMaxEur: filters.salaryMax,
-      experienceMin: filters.experienceMin,
-      experienceMax: filters.experienceMax,
-      languages: languages.length > 0 ? languages : undefined,
-    });
+  label: string,
+): Promise<Map<string, number>> {
+  if (candidates.length === 0) return new Map();
 
-    const fullFilter = `${POSTING_BASE_FILTER}${filterStr ? " && " + filterStr : ""}`;
-    const hasKeywords = filters.keywords && filters.keywords.length > 0;
-    const q = hasKeywords ? filters.keywords!.join(" ") : "*";
-
-    try {
-      const client = getSearchClient();
-      const result = await client.collections("job_posting").documents().search({
-        q,
-        query_by: "title",
-        filter_by: fullFilter,
-        per_page: 0,
-      });
-      return result.found ?? 0;
-    } catch (err) {
-      console.error("[_resolveIndexedAnyCompanyActiveCount] Typesense failed", err);
-      return 0;
+  const counts = new Map<string, number>();
+  const searchable: ListingCountCandidate[] = [];
+  for (const candidate of candidates) {
+    if (!candidate.filters.anyCompany && candidate.companyIds.length === 0) {
+      counts.set(candidate.id, 0);
+    } else {
+      searchable.push(candidate);
     }
-  }, { ttl: CACHE_TTL_SHORT });
+  }
+  if (searchable.length === 0) return counts;
+
+  const searches = searchable.map((candidate) =>
+    buildListingCountSearch(candidate.filters, candidate.companyIds, languages),
+  );
+
+  try {
+    const client = getSearchClient();
+    const result = await client.multiSearch.perform({ searches });
+    const results = (result as { results?: Array<{ found?: number }> }).results ?? [];
+    searchable.forEach((candidate, index) => {
+      counts.set(candidate.id, results[index]?.found ?? candidate.fallbackCount);
+    });
+  } catch (err) {
+    console.error(`[${label}] precise listing count multi_search failed`, err);
+    for (const candidate of searchable) counts.set(candidate.id, candidate.fallbackCount);
+  }
+
+  return counts;
+}
+
+function buildListingCountSearch(
+  filters: IndexedWatchlistFilters,
+  companyIds: string[],
+  languages: string[],
+): ListingCountSearch {
+  const filterStr = buildFilterString({
+    locationIds: filters.locationIds?.length ? filters.locationIds : undefined,
+    occupationIds: filters.occupationIds?.length ? filters.occupationIds : undefined,
+    seniorityIds: filters.seniorityIds?.length ? filters.seniorityIds : undefined,
+    technologyIds: filters.technologyIds?.length ? filters.technologyIds : undefined,
+    workMode: filters.workMode?.length ? filters.workMode : undefined,
+    employmentTypes: filters.employmentType?.length ? filters.employmentType : undefined,
+    salaryMinEur: filters.salaryMin,
+    salaryMaxEur: filters.salaryMax,
+    experienceMin: filters.experienceMin,
+    experienceMax: filters.experienceMax,
+    languages: languages.length > 0 ? languages : undefined,
+  });
+  const q = filters.keywords?.length ? filters.keywords.join(" ") : "*";
+  return {
+    collection: "job_posting",
+    q,
+    query_by: "title",
+    filter_by: buildWatchlistPostingFilter(
+      [POSTING_BASE_FILTER],
+      filters.anyCompany ? [] : companyIds,
+      filterStr,
+    ),
+    per_page: 0,
+  };
 }
 
 export async function getWatchlistByUserAndSlug(
@@ -1135,6 +1172,22 @@ export type PublicWatchlistEntry = WatchlistSummary & {
 type InternalPublicWatchlistEntry = PublicWatchlistEntry & {
   indexedFilters: IndexedWatchlistFilters | null;
   indexedFilterCacheKey: string | null;
+  companyIds: string[] | null;
+};
+
+type ListingCountCandidate = {
+  id: string;
+  filters: IndexedWatchlistFilters;
+  companyIds: string[];
+  fallbackCount: number;
+};
+
+type ListingCountSearch = {
+  collection: "job_posting";
+  q: string;
+  query_by: "title";
+  filter_by: string;
+  per_page: 0;
 };
 
 /** Stable cache-key fragment for a viewer's language filter. */
@@ -1277,11 +1330,18 @@ function parseIndexedWatchlistFilters(raw: unknown): IndexedWatchlistFilters | n
 
 function hasUnresolvedIndexedTaxonomy(filters: IndexedWatchlistFilters): boolean {
   return Boolean(
-    (filters.locationSlugs?.length && !filters.locationIds?.length) ||
-      (filters.occupationSlugs?.length && !filters.occupationIds?.length) ||
-      (filters.senioritySlugs?.length && !filters.seniorityIds?.length) ||
-      (filters.technologySlugs?.length && !filters.technologyIds?.length),
+    (filters.locationSlugs?.length && (filters.locationIds?.length ?? 0) < filters.locationSlugs.length) ||
+      (filters.occupationSlugs?.length && (filters.occupationIds?.length ?? 0) < filters.occupationSlugs.length) ||
+      (filters.senioritySlugs?.length && (filters.seniorityIds?.length ?? 0) < filters.senioritySlugs.length) ||
+      (filters.technologySlugs?.length && (filters.technologyIds?.length ?? 0) < filters.technologySlugs.length),
   );
+}
+
+function pgTextArrayLiteral(values: string[]): string {
+  const escaped = values.map((value) =>
+    `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`,
+  );
+  return `{${escaped.join(",")}}`;
 }
 
 /**
@@ -1377,6 +1437,7 @@ async function queryPublicWatchlists(params: {
   orderClause: ReturnType<typeof sql>;
   offset: number;
   limit: number;
+  locale: string;
   /**
    * Currently unused — the Postgres fallback returns the same
    * "company-scope" active count the Typesense path returns
@@ -1406,13 +1467,18 @@ async function queryPublicWatchlists(params: {
         alerts_enabled: boolean; filters: WatchlistFilters;
         last_accessed_at: Date; created_at: Date;
         owner_name: string; owner_username: string | null;
-        company_count: number; active_job_count: number;
+        company_count: number; active_job_count: number; company_ids: string[];
         mirror_count: number;
       }>(sql`
         SELECT w.id, w.slug, w.title, w.description, w.is_public, w.alerts_enabled, w.filters,
                w.last_accessed_at, w.created_at,
                u.name AS owner_name, u.username AS owner_username,
                (SELECT count(*)::int FROM watchlist_company wc WHERE wc.watchlist_id = w.id) AS company_count,
+               (
+                 SELECT COALESCE(array_agg(wc.company_id::text ORDER BY wc.company_id::text), ARRAY[]::text[])
+                 FROM watchlist_company wc
+                 WHERE wc.watchlist_id = w.id
+               ) AS company_ids,
                (
                  SELECT count(*)::int
                  FROM watchlist_company wc
@@ -1435,101 +1501,135 @@ async function queryPublicWatchlists(params: {
     alerts_enabled: boolean; filters: WatchlistFilters;
     last_accessed_at: Date; created_at: Date;
     owner_name: string; owner_username: string | null;
-    company_count: number; active_job_count: number;
+    company_count: number; active_job_count: number; company_ids: string[];
     mirror_count: number;
   };
 
   const typed = rows as unknown as Row[];
+  let indexedById: Map<string, IndexedWatchlistFilters | null> = new Map();
+  const filteredRows = typed.filter((r) => hasPreciseListingCountFilters(r.filters));
+  if (filteredRows.length > 0) {
+    try {
+      indexedById = await buildIndexedFiltersForUserRows(filteredRows, params.locale);
+    } catch (err) {
+      console.error("[queryPublicWatchlists] filter id resolution failed", err);
+    }
+  }
+
+  const entries: InternalPublicWatchlistEntry[] = typed.map((r) => ({
+    id: r.id,
+    slug: r.slug,
+    title: r.title,
+    description: r.description,
+    isPublic: r.is_public,
+    alertsEnabled: r.alerts_enabled,
+    companyCount: r.company_count,
+    activeJobCount: r.active_job_count,
+    lastAccessedAt: new Date(r.last_accessed_at).toISOString(),
+    createdAt: new Date(r.created_at).toISOString(),
+    ownerName: r.owner_name,
+    ownerUsername: r.owner_username,
+    mirrorCount: r.mirror_count,
+    indexedFilters: indexedById.get(r.id) ?? null,
+    indexedFilterCacheKey: null,
+    companyIds: r.company_ids ?? [],
+  }));
+
+  const patched = await _patchPreciseCountsForDiscover(entries, params.languages ?? []);
 
   return {
-    watchlists: typed.map((r) => ({
-      id: r.id,
-      slug: r.slug,
-      title: r.title,
-      description: r.description,
-      isPublic: r.is_public,
-      alertsEnabled: r.alerts_enabled,
-      companyCount: r.company_count,
-      activeJobCount: r.active_job_count,
-      lastAccessedAt: new Date(r.last_accessed_at).toISOString(),
-      createdAt: new Date(r.created_at).toISOString(),
-      ownerName: r.owner_name,
-      ownerUsername: r.owner_username,
-      mirrorCount: r.mirror_count,
-    })),
+    watchlists: stripIndexedWatchlistFields(patched),
     total,
   };
 }
 
 /**
- * Patch `active_job_count` on Discover-surface entries whose source
- * watchlist has `filters.anyCompany = true`.
+ * Patch `active_job_count` on Discover-surface entries whose filters make
+ * the denormalized company-scope count inaccurate (#3261).
  *
- * Context (#3352): `getPopularWatchlists` and `searchPublicWatchlists`
- * both read the denormalized `active_job_count` directly from the
- * Typesense `watchlist` doc — fast, but always 0 for `anyCompany`
- * watchlists because the crawler's `refresh_typesense_counts` joins the
- * empty `watchlist_company` table for them. Same root cause as #3333,
- * which patched the analogous code path in `getUserWatchlists`. This
- * helper mirrors that patch for the public Discover surfaces.
+ * Typesense watchlist hits carry sanitized `filters_json` with resolved
+ * taxonomy IDs. They do not carry company IDs, so filtered company-scoped
+ * rows hydrate only those IDs from Postgres in one batch before issuing a
+ * single `job_posting` multi_search. Any-company rows need no company
+ * hydration. Unfiltered company-scoped rows keep the denormalized doc
+ * count and pay no extra I/O.
  *
- * Shape:
- * 1. Read the self-contained, sanitized `filters_json` payload from each
- *    Typesense `watchlist` hit. It carries both the public filter fields
- *    and pre-resolved taxonomy IDs, so the card path does not hydrate
- *    `watchlist.filters` from Postgres.
- * 2. For rows where `filters_json.anyCompany` is set, fan out one live
- *    `job_posting` Typesense count per row in parallel via `Promise.all`.
- *    Each call is cached by the indexed payload + viewer-language scope.
- * 3. Patch `activeJobCount` on the matching entry; non-anyCompany rows
- *    are returned unchanged.
- *
- * Fan-out is bounded by the page size (typically 10-20 tiles on the
- * Discover surface) times the fraction that are `anyCompany`. Same
- * trade-off as the `getUserWatchlists` patch in #3340.
- *
- * Failures or missing resolved taxonomy IDs degrade to the Typesense
- * doc's denormalized count. Missing IDs are not broadened into a less
+ * Failures or missing resolved taxonomy IDs degrade to the existing
+ * denormalized count; missing IDs are never broadened into a less
  * selective query.
  */
-async function _patchAnyCompanyCountsForDiscover(
+async function _patchPreciseCountsForDiscover(
   entries: InternalPublicWatchlistEntry[],
   languages: string[],
 ): Promise<InternalPublicWatchlistEntry[]> {
   if (entries.length === 0) return entries;
 
-  const anyCompanyEntries = entries.filter((e) =>
-    e.indexedFilters?.anyCompany &&
-    !hasUnresolvedIndexedTaxonomy(e.indexedFilters) &&
-    e.indexedFilterCacheKey,
+  const filteredEntries = entries.filter((e) =>
+    e.indexedFilters &&
+    hasPreciseListingCountFilters(e.indexedFilters) &&
+    !hasUnresolvedIndexedTaxonomy(e.indexedFilters),
   );
-  if (anyCompanyEntries.length === 0) return entries;
+  if (filteredEntries.length === 0) return entries;
 
-  const pairs = await Promise.all(
-    anyCompanyEntries.map(async (e) => {
-      try {
-        const c = await _resolveIndexedAnyCompanyActiveCount(
-          e.indexedFilters!,
-          e.indexedFilterCacheKey!,
-          languages,
-        );
-        return [e.id, c] as const;
-      } catch (err) {
-        console.error("[_patchAnyCompanyCountsForDiscover] anyCompany count failed", {
-          id: e.id,
-          err,
-        });
-        return [e.id, 0] as const;
-      }
-    }),
+  const companyScopedEntries = filteredEntries.filter((e) =>
+    !e.indexedFilters!.anyCompany &&
+    e.companyIds === null,
   );
-  const patchedCounts = new Map(pairs);
+  let hydratedCompanyIds = new Map<string, string[]>();
+  if (companyScopedEntries.length > 0) {
+    try {
+      hydratedCompanyIds = await _fetchWatchlistCompanyIds(companyScopedEntries.map((e) => e.id));
+    } catch (err) {
+      console.error("[_patchPreciseCountsForDiscover] company id hydration failed", err);
+      return entries;
+    }
+  }
+
+  const candidates: ListingCountCandidate[] = filteredEntries.map((entry) => ({
+    id: entry.id,
+    filters: entry.indexedFilters!,
+    companyIds: entry.indexedFilters!.anyCompany
+      ? []
+      : (entry.companyIds ?? hydratedCompanyIds.get(entry.id) ?? []),
+    fallbackCount: entry.activeJobCount,
+  }));
+  const patchedCounts = await resolvePreciseListingCounts(
+    candidates,
+    languages,
+    "_patchPreciseCountsForDiscover",
+  );
 
   return entries.map((e) =>
     patchedCounts.has(e.id)
       ? { ...e, activeJobCount: patchedCounts.get(e.id)! }
       : e,
   );
+}
+
+async function _fetchWatchlistCompanyIds(watchlistIds: string[]): Promise<Map<string, string[]>> {
+  if (watchlistIds.length === 0) return new Map();
+  const pgArray = pgTextArrayLiteral([...new Set(watchlistIds)]);
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{
+        [key: string]: unknown;
+        watchlist_id: string;
+        company_ids: string[];
+      }>(sql`
+        SELECT wc.watchlist_id::text AS watchlist_id,
+               COALESCE(array_agg(wc.company_id::text ORDER BY wc.company_id::text), ARRAY[]::text[]) AS company_ids
+        FROM watchlist_company wc
+        WHERE wc.watchlist_id = ANY(${pgArray}::uuid[])
+        GROUP BY wc.watchlist_id
+      `),
+    { label: "watchlistCompanyIdsForListingCounts" },
+  );
+
+  const result = new Map<string, string[]>();
+  for (const row of rows as unknown as { watchlist_id: string; company_ids: string[] }[]) {
+    result.set(row.watchlist_id, row.company_ids ?? []);
+  }
+  return result;
 }
 
 export async function searchPublicWatchlists(params: {
@@ -1550,17 +1650,13 @@ export async function searchPublicWatchlists(params: {
       try {
         const tsResult = await _searchPublicWatchlistsTypesense(q, params.offset, params.limit);
         if (tsResult.watchlists.length > 0) {
-          // Perf (#3176/#3492): company-scoped cards trust the
-          // denormalized `active_job_count` carried on each Typesense
-          // `watchlist` doc. `anyCompany` cards use the doc's
-          // self-contained `filters_json` payload for a live count, with
-          // no Postgres filter hydration.
-          //
-          // EXCEPTION (#3352): `anyCompany` rows carry a denormalized 0
-          // (same root cause as the `getUserWatchlists` patch in #3333 /
-          // PR #3340). Patch those rows with a live Typesense count
-          // bounded by the page size — see `_patchAnyCompanyCountsForDiscover`.
-          const patched = await _patchAnyCompanyCountsForDiscover(tsResult.watchlists, languages);
+          // Perf (#3176/#3492): unfiltered company-scoped cards trust
+          // the denormalized `active_job_count` carried on each
+          // Typesense `watchlist` doc. Filtered or `anyCompany` cards
+          // use the self-contained `filters_json` payload plus one
+          // batched `job_posting` multi_search for precise counts
+          // (#3261).
+          const patched = await _patchPreciseCountsForDiscover(tsResult.watchlists, languages);
           return {
             watchlists: stripIndexedWatchlistFields(patched),
             total: tsResult.total,
@@ -1575,6 +1671,7 @@ export async function searchPublicWatchlists(params: {
         orderClause: sql`w.created_at DESC`,
         offset: params.offset,
         limit: params.limit,
+        locale: params.locale,
         languages,
       });
     },
@@ -1596,13 +1693,10 @@ export async function getPopularWatchlists(params: {
       try {
         const tsResult = await _getPopularWatchlistsTypesense(params.offset, params.limit);
         if (tsResult.watchlists.length > 0) {
-          // Perf (#3176/#3492): use the same count semantics as
-          // `searchPublicWatchlists`.
-          //
-          // EXCEPTION (#3352): patch `anyCompany` rows from their
-          // structural 0 — see the matching comment in
-          // `searchPublicWatchlists`.
-          const patched = await _patchAnyCompanyCountsForDiscover(tsResult.watchlists, languages);
+          // Use the same count semantics as `searchPublicWatchlists`:
+          // denormalized for unfiltered company-scoped rows, batched
+          // precise counts for filtered or `anyCompany` rows (#3261).
+          const patched = await _patchPreciseCountsForDiscover(tsResult.watchlists, languages);
           return {
             watchlists: stripIndexedWatchlistFields(patched),
             total: tsResult.total,
@@ -1617,6 +1711,7 @@ export async function getPopularWatchlists(params: {
         orderClause: sql`(u.username = 'colophongroup')::int DESC, (SELECT count(*)::int FROM watchlist w2 WHERE w2.source_watchlist_id = w.id) DESC, (w.description IS NOT NULL AND w.description != '')::int DESC, w.created_at DESC`,
         offset: params.offset,
         limit: params.limit,
+        locale: params.locale,
         languages,
       });
     },
@@ -1993,13 +2088,19 @@ function _mapWatchlistDoc(doc: Record<string, unknown>): InternalPublicWatchlist
     indexedFilterCacheKey: typeof rawFiltersJson === "string" && rawFiltersJson.length > 0
       ? rawFiltersJson
       : null,
+    companyIds: null,
   };
 }
 
 function stripIndexedWatchlistFields(
   entries: InternalPublicWatchlistEntry[],
 ): PublicWatchlistEntry[] {
-  return entries.map(({ indexedFilters: _indexedFilters, indexedFilterCacheKey: _key, ...entry }) => entry);
+  return entries.map(({
+    indexedFilters: _indexedFilters,
+    indexedFilterCacheKey: _key,
+    companyIds: _companyIds,
+    ...entry
+  }) => entry);
 }
 
 function buildWatchlistPostingFilter(


### PR DESCRIPTION
## Summary

Closes #3261.

- Keep the existing denormalized active-count fast path for unfiltered company-scoped watchlists.
- Patch filtered listing rows through one `job_posting` Typesense `multi_search` batch per render.
- Resolve user-watchlist slug filters once per listing page, and hydrate public Typesense watchlist company IDs only for filtered company-scoped rows in one Postgres read.
- Preserve graceful degradation to the existing denormalized count on Typesense/company-ID hydration failures.

## Reproduction / production read-only probe

- Current source path trusted `active_job_count` for non-`anyCompany` listing rows even when `filters`/`filters_json` contained location, occupation, keyword, or other clauses.
- Read-only production Typesense probe using the main-tree web search credentials found public filtered watchlist docs with `filters_json` plus broad denormalized counts. Example: `Big Tech Jobs in Switzerland` has `locationSlugs=["switzerland"]`, `company_count=50`, and `active_job_count=73765` on the watchlist doc.
- No Supabase writes or destructive production actions were performed.

## Validation

- `node node_modules/vitest/vitest.mjs run src/lib/actions/__tests__/watchlists-listing-perf.test.ts` (`26 passed`)
- `node node_modules/eslint/bin/eslint.js src/lib/services/watchlists.ts src/lib/actions/__tests__/watchlists-listing-perf.test.ts`
- `node packages/mcp-server/node_modules/typescript/bin/tsc -p packages/mcp-server/tsconfig.json` (builds local MCP package needed by web typecheck in a fresh worktree)
- `node node_modules/typescript/bin/tsc --noEmit --project apps/web/tsconfig.json` from `apps/web`
- `git diff --check`

Note: `pnpm --dir apps/web exec vitest ...` and the commit hook's `pnpm lint` path were blocked by the current inherited minimum-release-age/local `.bin` install state in this fresh worktree; direct Vitest/ESLint/TypeScript entrypoints were used instead.
