### PR TITLE
Fix stale company page effect deps

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-content.test.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-content.test.tsx
@@ -25,14 +25,17 @@ vi.mock("@/lib/actions/company-page-data", async () => {
 // stale-ISR-data regression test can assert which dataset mounted it.
 vi.mock("../company-page", () => ({
   CompanyPage: ({
+    company,
     initialActiveCount,
     initialEmploymentTypes,
   }: {
+    company: CompanyPageData["company"];
     initialActiveCount: number;
     initialEmploymentTypes: string[];
   }) => (
     <div
       data-testid="company-page"
+      data-company={company.slug}
       data-active={initialActiveCount}
       data-etypes={initialEmploymentTypes.join(",")}
     />
@@ -331,6 +334,66 @@ describe("CompanyContent — server-render initial-data path (#3203)", () => {
     );
     expect(queryByTestId("company-page")?.getAttribute("data-etypes")).toBe(
       "internship",
+    );
+  });
+
+  it("refetches on page identity changes and ignores stale responses", async () => {
+    let resolveAlpha: (v: CompanyPageData) => void = () => {};
+    let resolveBeta: (v: CompanyPageData) => void = () => {};
+    mockFetchCompanyPageData
+      .mockReturnValueOnce(
+        new Promise<CompanyPageData>((resolve) => {
+          resolveAlpha = resolve;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise<CompanyPageData>((resolve) => {
+          resolveBeta = resolve;
+        }),
+      );
+
+    const { queryByTestId, rerender } = render(
+      <CompanyContent locale="en" slug="alpha" />,
+    );
+
+    await waitFor(() => {
+      expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(1);
+    });
+    expect(mockFetchCompanyPageData.mock.calls[0]?.[0]).toMatchObject({
+      slug: "alpha",
+      locale: "en",
+    });
+
+    rerender(<CompanyContent locale="en" slug="beta" />);
+
+    await waitFor(() => {
+      expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(2);
+    });
+    expect(mockFetchCompanyPageData.mock.calls[1]?.[0]).toMatchObject({
+      slug: "beta",
+      locale: "en",
+    });
+
+    resolveAlpha(makeInitialData({
+      company: { ...makeCompany(), slug: "alpha" },
+      activeCount: 1,
+    }));
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(queryByTestId("company-page")).toBeNull();
+
+    resolveBeta(makeInitialData({
+      company: { ...makeCompany(), slug: "beta" },
+      activeCount: 2,
+    }));
+
+    await waitFor(() => {
+      expect(queryByTestId("company-page")?.getAttribute("data-company")).toBe(
+        "beta",
+      );
+    });
+    expect(queryByTestId("company-page")?.getAttribute("data-active")).toBe(
+      "2",
     );
   });
 

--- a/apps/web/app/[lang]/(app)/company/[slug]/company-content.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-content.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { Trans } from "@lingui/react/macro";
 import { fetchCompanyPageData, type CompanyPageData } from "@/lib/actions/company-page-data";
@@ -69,6 +69,8 @@ function CompanyNotFound() {
 
 export function CompanyContent({ locale, slug, initialData }: CompanyContentProps) {
   const searchParams = useSearchParams();
+  const paramsKey = searchParams.toString();
+  const fetchIdRef = useRef(0);
   const [data, setData] = useState<CompanyPageData | null | "not-found">(initialData ?? null);
 
   // Re-fetch on mount only when the prerendered ``initialData``
@@ -82,16 +84,23 @@ export function CompanyContent({ locale, slug, initialData }: CompanyContentProp
   // visitors still get the prerendered data with zero server-action
   // invocations — the bulk of organic traffic per #3203 + #2640.
   //
-  // After this effect, CompanyPage owns all filter changes and
-  // searches — URL sync via replaceState is for bookmarkability only
-  // and does not trigger a re-fetch here.
+  // After this effect, CompanyPage owns interactive filter changes and
+  // searches — URL sync via replaceState is for bookmarkability only.
+  // The deps below are the page identity/snapshot inputs that can
+  // change when App Router reuses this client boundary across company
+  // slug or locale navigation.
   useEffect(() => {
+    const fetchId = ++fetchIdRef.current;
+    const params = new URLSearchParams(paramsKey);
     const needsPersonalizedFetch =
       hasLoggedInHint() ||
       hasAnonJobLanguagesHint() ||
-      hasAnyFilterParam(searchParams) ||
+      hasAnyFilterParam(params) ||
       initialData === undefined;
-    if (!needsPersonalizedFetch) return;
+    if (!needsPersonalizedFetch) {
+      setData(initialData ?? null);
+      return;
+    }
 
     // Clear stale prerendered data before the personalised fetch so
     // CompanyPage unmounts. Its filters/postings are useState-initialised
@@ -100,21 +109,18 @@ export function CompanyContent({ locale, slug, initialData }: CompanyContentProp
     setData(null);
 
     const sp: Record<string, string | undefined> = {};
-    searchParams.forEach((value, key) => {
+    params.forEach((value, key) => {
       sp[key] = value;
     });
     fetchCompanyPageData({ slug, searchParams: sp, locale }).then((result) => {
+      if (fetchIdRef.current !== fetchId) return;
       setData(result ?? "not-found");
     }).catch((err) => {
+      if (fetchIdRef.current !== fetchId) return;
       console.error("[company] fetchCompanyPageData failed", err);
       if (initialData) setData(initialData);
     });
-    // Empty deps: the conditional-fetch decision is made once on
-    // mount. ``initialData`` is stable across re-renders (page
-    // identity), and ``CompanyPage`` owns subsequent filter changes
-    // via its own state — re-running this effect on ``searchParams``
-    // change would clobber the user's interactive filter selection.
-  }, []);
+  }, [initialData, locale, paramsKey, slug]);
 
   if (data === null) return <CompanySkeleton />;
   if (data === "not-found") return <CompanyNotFound />;

--- a/apps/web/app/[lang]/(app)/explore/search-page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/search-page.tsx
@@ -228,15 +228,24 @@ export function SearchPage({
     return filtered.toString();
   }
 
+  function buildExternalSearchKey(sp: URLSearchParams): string {
+    return [
+      locale,
+      userLat ?? "",
+      userLng ?? "",
+      buildSearchKey(sp),
+    ].join("|");
+  }
+
   // Track the last search key we've processed so we only react to genuine
   // external URL changes — not mount, StrictMode double-runs, or our own
   // replaceState calls.
-  const lastSearchKeyRef = useRef(buildSearchKey(searchParams));
+  const lastSearchKeyRef = useRef(buildExternalSearchKey(searchParams));
 
   // Detect external URL changes (e.g. header search bar → router.push)
   // and re-parse filters + search, without remounting the component.
   useEffect(() => {
-    const currentKey = buildSearchKey(searchParams);
+    const currentKey = buildExternalSearchKey(searchParams);
     if (internalUrlChangeRef.current) {
       internalUrlChangeRef.current = false;
       lastSearchKeyRef.current = currentKey;
@@ -286,7 +295,7 @@ export function SearchPage({
       setWorkMode(parsed.workMode); workModeRef.current = parsed.workMode;
       runSearch();
     });
-  }, [searchParams]);
+  }, [searchParams, locale, userLat, userLng]);
 
   /** Convert a salary amount from the user's display currency to EUR. */
   function toEur(amount: number | undefined): number | undefined {
@@ -419,7 +428,9 @@ export function SearchPage({
     });
   }, [setPageActions]);
 
-  // Restore scroll position and sync URL on mount when restoring from cache
+  // Restore scroll position and sync URL on mount when restoring from cache.
+  // This is intentionally snapshot-only: re-running after the user edits
+  // filters would overwrite the live URL and scroll state with stale cache.
   useEffect(() => {
     if (shouldRestore) {
       const extra: Record<string, string> = {};

--- a/apps/web/app/[lang]/(app)/watchlists/watchlists-page.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/watchlists-page.tsx
@@ -72,7 +72,10 @@ export function WatchlistsPage({
     }
   }
 
-  // Auto-create watchlist from URL params (e.g. from /api/v1/watchlist/create)
+  // Auto-create watchlist from URL params (e.g. from /api/v1/watchlist/create).
+  // Intentionally one-shot on mount: adding live deps here would retry
+  // the mutating create flow on unrelated session/limit/render changes.
+  // The login path returns to this page with the session already present.
   useEffect(() => {
     const title = searchParams.get("title");
     if (!title || !isLoggedIn) return;


### PR DESCRIPTION
## Summary
- key CompanyContent's personalized fetch effect by page identity/search snapshot instead of an empty dependency array
- ignore stale CompanyContent fetch responses when slug/locale/search params change before an older request resolves
- make Explore's external URL watcher include locale/geolocation context, and document intentional mount-only snapshot effects in Explore/Watchlists

## Reproduction
- Added a CompanyContent regression that fails on current main: rerendering from `slug="alpha"` to `slug="beta"` before the first personalized fetch resolves only performs the alpha fetch, leaving the beta view stuck on the stale request.
- Confirmed the new test failed before the fix with: `expected fetchCompanyPageData to be called 2 times, but got 1`.
- Read-only production baseline before the fix: `https://jseek.co/en/company/apple`, `/en/explore`, and `/en/watchlists` all returned 200.

## Validation
- `pnpm --config.minimum-release-age=0 --filter @jobseek/web exec vitest run 'app/[lang]/(app)/company/[slug]/__tests__/company-content.test.tsx'`
- `pnpm --config.minimum-release-age=0 --filter @jobseek/web exec vitest run 'app/[lang]/(app)/explore/__tests__/search-page-heading.test.tsx'`
- `pnpm --config.minimum-release-age=0 --filter @jobseek/web exec eslint 'app/[lang]/(app)/company/[slug]/company-content.tsx' 'app/[lang]/(app)/company/[slug]/__tests__/company-content.test.tsx' 'app/[lang]/(app)/explore/search-page.tsx' 'app/[lang]/(app)/watchlists/watchlists-page.tsx'`
- `pnpm --config.minimum-release-age=0 --filter @jobseek/web typecheck`
- `git diff --check`

Note: local pnpm commands require the release-age override because current `origin/main` includes Lingui/Vitest package versions that are still within the repo's configured minimum-release-age window on this machine. No package or lockfile changes were made.

Closes #3090
