### PR TITLE
Add docs index and architecture ADRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         run: >
           node --test
           scripts/ci-workflow.test.mjs
+          scripts/docs-index.test.mjs
           scripts/dealroom-company-requests.test.mjs
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -88,6 +88,9 @@ The crawler runs continuously on Hetzner. `sync.py` loads CSV configs into local
 
 ## Related Documents
 
+For the full documentation index, including routines, runbooks, historical
+plans, and ADRs, start with [docs/README.md](./README.md).
+
 - [01 -- Agent Workflow](./01-agent-workflow.md): How agents resolve company requests
 - [02 -- Data Schema](./02-data-schema.md): CSV schemas, DB sync, config format
 - [03 -- Crawler Architecture](./03-crawler-architecture.md): Redis pipeline, workers, exporter

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,99 @@
+# Jobseek Documentation
+
+This directory is the project documentation index. The numeric prefixes are
+historical and have gaps, so use this page rather than filename order when
+looking for the current reference.
+
+Status tags:
+
+- `[reference]` - maintained architecture, data, or implementation reference.
+- `[routine]` - repeatable operating process.
+- `[runbook]` - incident, migration, or one-off operational guide.
+- `[historical]` - preserved background that may not describe the current
+  implementation.
+- `[adr]` - architectural decision record.
+
+## Start Here
+
+- [00 - System Overview](00-overview.md) `[reference]` - project map, main
+  pipelines, and high-level design decisions.
+- [agents.md](agents.md) `[reference]` - reasoning guidance for developer
+  agents working in this repository.
+- [07 - System Design](07-system-design.md) `[reference]` - infrastructure,
+  data paths, runtime components, and web/crawler subsystem details.
+- [02 - Data Schema](02-data-schema.md) `[reference]` - company and board CSV
+  schemas, sync behavior, and validation commands.
+
+## Crawler And Data
+
+- [03 - Crawler Architecture](03-crawler-architecture.md) `[reference]` -
+  Redis queues, crawler workers, local Postgres, exporter CDC, and failure
+  handling.
+- [04 - Monitors and Scrapers](04-monitors-and-scrapers.md) `[reference]` -
+  monitor/scraper types, configuration examples, and extraction rules.
+- [08 - Job Data Fields](08-job-data-fields.md) `[reference]` - normalized job
+  fields and source mappings.
+- [09 - Enrichment](09-enrichment.md) `[reference]` - enrichment pipeline
+  shape, provider boundaries, and rollout constraints.
+- [10 - Parallel Agent Pipeline](10-parallel-agent-pipeline.md) `[historical]`
+  - earlier multi-agent company onboarding design and backlog notes.
+
+## Search, SEO, And Web Read Paths
+
+- [11 - Typesense](11-typesense.md) `[reference]` - Typesense deployment,
+  schemas, aliases, indexing, web read paths, and reconciliation.
+- [12 - Typesense Benchmarks](12-typesense-benchmarks.md) `[reference]` -
+  measured Typesense query performance.
+- [13 - SEO and IndexNow](13-seo-and-indexnow.md) `[reference]` - company page
+  indexing policy, active IndexNow paths, and current observability limits.
+
+## Agent And Automation Workflows
+
+- [01 - Agent Workflow](01-agent-workflow.md) `[reference]` - company-request
+  resolver workflow and `ws` usage.
+- [05 - Auto-Merge](05-auto-merge.md) `[reference]` - low-risk config PR merge
+  policy.
+- [16 - Murmur Codex MCP Transition](16-murmur-codex-mcp-transition.md)
+  `[runbook]` - Codex-accessible Murmur MCP transition plan and guardrails.
+- [17 - Codex Migration Verification Runbook](17-codex-migration-verification-runbook.md)
+  `[runbook]` - pilot checks and rollback criteria for Codex migration
+  surfaces.
+
+## Operations And Routines
+
+- [14 - Daily Error Review Routine](14-error-review-routine.md) `[routine]` -
+  crawler error review workflow.
+- [15 - Daily Labelled-Postings Routine](15-data-sampling-routine.md)
+  `[routine]` - gold-dataset sampling, labelling, validation, and upload.
+- [16 - Hetzner Maintenance](16-hetzner-maintenance.md) `[runbook]` -
+  disk/headroom checks and Docker cleanup on Hetzner hosts.
+- [Didi Reactivation Runbook](runbook-didi-reactivate-2026-05-10.md)
+  `[runbook]` - historical Didi reactivation notes.
+
+## Historical Plans
+
+- [Multi-Language Job Postings](multi-language-job-postings.md) `[historical]`
+  - the original multilingual posting migration checklist. The implemented
+  decision is captured in
+  [ADR-001](adr/001-multi-language-job-postings.md).
+
+## Architectural Decisions
+
+- [ADR-001 - Multi-Language Job Postings](adr/001-multi-language-job-postings.md)
+  `[adr]` - implemented language metadata and detection model.
+- [ADR-002 - Local Postgres for Crawler Runtime Source of Truth](adr/002-local-postgres-runtime-sot.md)
+  `[adr]` - local Postgres is authoritative for crawler-owned runtime data.
+- [ADR-003 - CSV Configuration Source of Truth](adr/003-csv-configuration-source-of-truth.md)
+  `[adr]` - company and board configuration remain CSV-backed until a future
+  migration explicitly supersedes the contract.
+- [ADR-004 - Better Auth for Web Authentication](adr/004-better-auth-web-authentication.md)
+  `[adr]` - Better Auth remains the web authentication boundary.
+- [ADR-005 - Lingui Babel Macro Pipeline](adr/005-lingui-babel-macro-pipeline.md)
+  `[adr]` - Lingui macros are transformed through Babel rather than an
+  SWC-only build path.
+- [ADR-006 - Crawler Deploy Quiescence and Rollback](adr/006-crawler-deploy-quiescence-and-rollback.md)
+  `[adr]` - crawler deploys intentionally quiesce processors and rely on
+  rollback/readiness gates.
+- [ADR-007 - IndexNow Observability Boundary](adr/007-indexnow-observability-boundary.md)
+  `[adr]` - active IndexNow observability uses structured logs until the web
+  metrics surface exists.

--- a/docs/adr/002-local-postgres-runtime-sot.md
+++ b/docs/adr/002-local-postgres-runtime-sot.md
@@ -1,0 +1,56 @@
+# ADR-002: Local Postgres for Crawler Runtime Source of Truth
+
+Status: implemented
+
+Date: 2026-07-07
+
+## Context
+
+The crawler runs on Hetzner close to a dedicated local Postgres instance.
+Workers, processors, the exporter, reconciliation, and Typesense indexing all
+depend on low-latency reads and writes of crawler-owned job data. Supabase is
+still the web-facing Postgres service for user-owned tables such as auth,
+sessions, watchlists, and posting detail fallbacks.
+
+Historically, "just write to Supabase" looked tempting because the web app
+already uses Supabase. That loses the crawler's operational separation and
+creates split-brain risk between the worker pipeline, exporter CDC, Typesense,
+and read-side fallbacks.
+
+## Decision
+
+Local Postgres is the authoritative store for crawler-owned runtime data,
+including job postings, crawler state, board processing state, taxonomy lookup
+inputs, and aggregation sources used for Typesense indexing.
+
+For crawler-owned job data:
+
+- Workers and processing code write local Postgres.
+- Reprocessing and repair commands write local Postgres first.
+- The exporter is the path that copies changed job data to Supabase.
+- Typesense indexing and denormalization read from local Postgres.
+- Supabase is treated as a read-side mirror for crawler-owned job data, not as
+  the place to patch crawler truth directly.
+
+This does not make Supabase read-only for the whole product. Web-owned auth,
+session, preference, watchlist, subscription, and other user-facing tables are
+still owned by the web app's Supabase/Drizzle layer.
+
+## Consequences
+
+- Production fixes to crawler-owned data should target local Postgres and let
+  CDC/export/reconciliation catch Supabase up.
+- Direct Supabase writes to crawler-owned job data need an explicit exception
+  and a reconciliation plan.
+- Supabase outages pause web mirror freshness but do not stop crawler workers
+  from maintaining local truth.
+- Typesense fallback and denormalization bugs should be debugged from local
+  Postgres first, then exporter cursor state, then Supabase.
+
+## References
+
+- [Crawler architecture](../03-crawler-architecture.md)
+- [System design](../07-system-design.md)
+- [Typesense deployment state](../11-typesense.md)
+- [`apps/crawler/src/exporter.py`](../../apps/crawler/src/exporter.py)
+- [`apps/crawler/src/sync.py`](../../apps/crawler/src/sync.py)

--- a/docs/adr/003-csv-configuration-source-of-truth.md
+++ b/docs/adr/003-csv-configuration-source-of-truth.md
@@ -1,0 +1,52 @@
+# ADR-003: CSV Configuration Source of Truth
+
+Status: implemented
+
+Date: 2026-07-07
+
+## Context
+
+Company and board configuration is stored in
+`apps/crawler/data/companies.csv` and `apps/crawler/data/boards.csv`. The `ws`
+tool stages company onboarding work and submit flows create normal Git PRs
+that change those CSV files. Deploy-time sync then derives local Postgres,
+Supabase display subsets, Redis schedules, and Typesense taxonomy/company docs
+from those committed files.
+
+Murmur pipeline definitions and MCP access are being introduced as an
+orchestration surface, but current transition docs explicitly keep `ws`, CSVs,
+prompts, schema validation, and persistence rules outside provider-specific MCP
+code.
+
+## Decision
+
+CSV files remain the source of truth for company and board configuration until
+a future migration explicitly supersedes this ADR.
+
+Runtime databases contain derived configuration state. They are not the
+authoritative editing surface for company onboarding or board reconfiguration.
+Murmur and workspace YAML may guide agents through the workflow, but accepted
+changes must still land as reviewed CSV diffs.
+
+A future DB-as-source-of-truth migration must add its own ADR before changing
+this contract. That ADR must define ownership, audit history, delete/disable
+semantics, rollback, sync cutover, and how agents review changes without losing
+the current Git diff workflow.
+
+## Consequences
+
+- PRs that change companies or boards should include the CSV diff.
+- Local Postgres and Supabase config rows can be regenerated from CSV sync.
+- Ad hoc DB edits to company/board configuration are temporary operational
+  repairs unless they are backported to CSV.
+- Murmur MCP tooling must not silently create a second source of truth.
+- Reviewers should reject changes that bypass CSV without an explicit migration
+  plan.
+
+## References
+
+- [Data schema](../02-data-schema.md)
+- [Agent workflow](../01-agent-workflow.md)
+- [Murmur Codex MCP transition](../16-murmur-codex-mcp-transition.md)
+- [`apps/crawler/src/sync.py`](../../apps/crawler/src/sync.py)
+- [`apps/crawler/src/workspace`](../../apps/crawler/src/workspace)

--- a/docs/adr/004-better-auth-web-authentication.md
+++ b/docs/adr/004-better-auth-web-authentication.md
@@ -1,0 +1,49 @@
+# ADR-004: Better Auth for Web Authentication
+
+Status: implemented
+
+Date: 2026-07-07
+
+## Context
+
+The Next.js web app owns authentication through Better Auth. The server-side
+configuration lives in `apps/web/src/lib/auth.ts`, the browser client in
+`apps/web/src/lib/auth-client.ts`, and the auth tables are declared in the
+web Drizzle schema. Session reads are integrated with the app's cache and
+cookie behavior.
+
+Hosted auth products such as Stack Auth can offer attractive defaults, but
+switching would move a load-bearing product boundary: user/session storage,
+OAuth callbacks, username handling, password flows, and server-action
+permission checks.
+
+## Decision
+
+Jobseek uses Better Auth as the web authentication boundary. Do not introduce
+Stack Auth or a second auth provider unless a new ADR and migration plan are
+accepted.
+
+Better Auth should remain integrated with:
+
+- the web Drizzle schema and Supabase user-owned tables;
+- the username plugin and account settings flows;
+- server-side session checks used by pages, API routes, and server actions;
+- existing session cookie and cache invalidation behavior.
+
+## Consequences
+
+- Auth-related refactors should keep `auth.api` and `authClient` as the
+  application boundary rather than bypassing Better Auth tables directly.
+- New auth features should extend the current Better Auth setup first.
+- A provider migration must account for existing users, sessions, usernames,
+  password reset, OAuth identity linking, web cache invalidation, and rollback.
+- Tests should mock the Better Auth boundary instead of replacing the auth
+  implementation with provider-specific assumptions.
+
+## References
+
+- [System design auth section](../07-system-design.md)
+- [`apps/web/src/lib/auth.ts`](../../apps/web/src/lib/auth.ts)
+- [`apps/web/src/lib/auth-client.ts`](../../apps/web/src/lib/auth-client.ts)
+- [`apps/web/src/db/schema.ts`](../../apps/web/src/db/schema.ts)
+- [`apps/web/src/lib/sessionCache.ts`](../../apps/web/src/lib/sessionCache.ts)

--- a/docs/adr/005-lingui-babel-macro-pipeline.md
+++ b/docs/adr/005-lingui-babel-macro-pipeline.md
@@ -1,0 +1,47 @@
+# ADR-005: Lingui Babel Macro Pipeline
+
+Status: implemented
+
+Date: 2026-07-07
+
+## Context
+
+The web app uses Lingui macros for localized UI copy. Translation quality rules
+require explicit IDs and translator comments, and CI/build workflows run Lingui
+extract/compile steps. Macro expansion is part of the build contract, not just
+developer ergonomics.
+
+Next.js uses SWC for most transforms, but the repo keeps a Babel config for
+Lingui macro handling:
+
+- `apps/web/babel.config.json` uses `next/babel`.
+- `apps/web/babel.config.json` installs
+  `@lingui/babel-plugin-lingui-macro`.
+- `apps/web/lingui.config.ts` defines the extraction catalog inputs.
+
+## Decision
+
+Keep Lingui macro transformation in the Babel pipeline. Do not replace it with
+an SWC-only build path unless a focused migration proves that extraction,
+compilation, server rendering, client rendering, and CI all preserve the same
+macro semantics.
+
+The Babel config is therefore intentional. Removing it to "simplify" the Next
+configuration is a behavior change.
+
+## Consequences
+
+- Next build upgrades must verify Lingui macro extraction and runtime rendering.
+- Babel config changes need focused i18n validation, not just TypeScript
+  success.
+- New UI copy should continue using Lingui macros with explicit IDs and
+  comments.
+- If Lingui ships a proven SWC-compatible macro path for this app's Next
+  version, replace this ADR with a migration ADR that records the evidence.
+
+## References
+
+- [Web i18n guidelines](../../apps/web/docs/i18n.md)
+- [`apps/web/babel.config.json`](../../apps/web/babel.config.json)
+- [`apps/web/lingui.config.ts`](../../apps/web/lingui.config.ts)
+- [`apps/web/src/components/providers/LinguiProvider.tsx`](../../apps/web/src/components/providers/LinguiProvider.tsx)

--- a/docs/adr/006-crawler-deploy-quiescence-and-rollback.md
+++ b/docs/adr/006-crawler-deploy-quiescence-and-rollback.md
@@ -1,0 +1,50 @@
+# ADR-006: Crawler Deploy Quiescence and Rollback
+
+Status: implemented
+
+Date: 2026-07-07
+
+## Context
+
+Crawler deploys update long-running workers, browser workers, exporter, drain,
+Redis-backed schedules, Typesense schema state, and local Postgres migrations.
+The deploy cannot be treated as a pure zero-downtime process because `sync`
+must reseed Redis-backed schedules while processors are not claiming work.
+
+`apps/crawler/deploy.sh` therefore pulls and preflights while the old stack is
+still serving, then quiesces processors, runs sync, starts the full stack, and
+gates readiness. Earlier deploy incidents showed that failures in the middle of
+this sequence can create a dark window if rollback and monitoring are weak.
+
+## Decision
+
+Treat crawler deploys as a bounded quiescence window with explicit rollback and
+readiness gates, not as an atomic swap.
+
+The deploy script must:
+
+- validate required environment before stopping processors;
+- preserve a rollback copy of the env file;
+- pull images and run schema preflights before quiescing processors;
+- stop workers, browser worker, exporter, and drain before `crawler sync`;
+- start the full stack after sync;
+- wait for core services to be running or healthy;
+- restore the previous env and start compose services on failure.
+
+## Consequences
+
+- Deploy changes need failure-path review as much as happy-path review.
+- Monitoring should alert when crawler metrics disappear or exporter freshness
+  stalls after a deploy.
+- Operators should assume a mid-deploy failure may require checking compose
+  state, Redis, exporter freshness, and logs before retrying.
+- Future zero-downtime deploy work should preserve the Redis reseed invariant or
+  explicitly replace it with an equivalent safe handoff.
+
+## References
+
+- [`apps/crawler/deploy.sh`](../../apps/crawler/deploy.sh)
+- [Crawler architecture deploy notes](../03-crawler-architecture.md)
+- [Typesense deploy notes](../11-typesense.md)
+- [Crawler alert rules](../../apps/crawler/alerts.yaml)
+- [Crawler AGENTS operations notes](../../apps/crawler/AGENTS.md)

--- a/docs/adr/007-indexnow-observability-boundary.md
+++ b/docs/adr/007-indexnow-observability-boundary.md
@@ -1,0 +1,52 @@
+# ADR-007: IndexNow Observability Boundary
+
+Status: implemented
+
+Date: 2026-07-07
+
+## Context
+
+Company-page IndexNow submission was retired when company pages became
+`noindex,follow` and left the sitemap. Active IndexNow paths now live in the
+web/blog surfaces:
+
+- watchlist server actions call the web-side notifier for qualifying public
+  watchlists;
+- the blog workflow submits changed blog URLs after deploy settle time.
+
+The crawler still has a manual legacy `notify-indexnow` command, but there is
+no long-running crawler IndexNow container. The active web and blog paths do
+not expose Prometheus metrics today; they emit structured logs or GitHub
+Actions logs.
+
+## Decision
+
+Do not add a crawler-owned metrics loop for active IndexNow paths. Until the
+web app has a durable metrics surface, active IndexNow observability is:
+
+- structured Vercel logs from the web notifier;
+- GitHub Actions logs for blog submissions;
+- manual crawler command logs only when an operator deliberately runs the
+  legacy command.
+
+The broader web metrics gap is tracked separately and should be solved as a web
+observability feature rather than by reviving a crawler container for a retired
+company-page path.
+
+## Consequences
+
+- IndexNow production checks should query the relevant web deployment logs or
+  workflow logs, not crawler Prometheus.
+- Crawler deploys should not depend on IndexNow secrets or an IndexNow
+  container.
+- A future durable dashboard for active IndexNow paths should be implemented
+  with the web metrics surface.
+- If company-page IndexNow submission is revived, the revival must define its
+  own scheduler, metrics, and alerting contract.
+
+## References
+
+- [SEO and IndexNow](../13-seo-and-indexnow.md)
+- [`apps/web/src/lib/indexnow.ts`](../../apps/web/src/lib/indexnow.ts)
+- [Notify blog IndexNow workflow](../../.github/workflows/notify-blog-indexnow.yml)
+- [`apps/crawler/src/indexnow.py`](../../apps/crawler/src/indexnow.py)

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -57,7 +57,7 @@ test("CI no longer shells out to custom diff classification", () => {
 test("workflow-security runs repository script tests", () => {
   assert.match(
     workflow,
-    /node --test\n          scripts\/ci-workflow\.test\.mjs\n          scripts\/dealroom-company-requests\.test\.mjs/,
+    /node --test\n          scripts\/ci-workflow\.test\.mjs\n          scripts\/docs-index\.test\.mjs\n          scripts\/dealroom-company-requests\.test\.mjs/,
   );
 });
 

--- a/scripts/docs-index.test.mjs
+++ b/scripts/docs-index.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+const repoRoot = process.cwd();
+const docsDir = path.join(repoRoot, "docs");
+const readmePath = path.join(docsDir, "README.md");
+const readme = readFileSync(readmePath, "utf8");
+
+function relative(filePath) {
+  return path.relative(repoRoot, filePath);
+}
+
+function markdownFiles(dir) {
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".md"))
+    .map((entry) => path.join(dir, entry.name))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+test("docs README indexes every top-level docs markdown file", () => {
+  const docs = markdownFiles(docsDir)
+    .map((filePath) => path.basename(filePath))
+    .filter((name) => name !== "README.md");
+
+  for (const doc of docs) {
+    assert.ok(
+      readme.includes(`](${doc})`),
+      `docs/README.md should link to ${doc}`,
+    );
+  }
+});
+
+test("docs README indexes every ADR", () => {
+  const adrDir = path.join(docsDir, "adr");
+  const adrs = markdownFiles(adrDir).map((filePath) => path.basename(filePath));
+
+  for (const adr of adrs) {
+    assert.ok(
+      readme.includes(`](adr/${adr})`),
+      `docs/README.md should link to adr/${adr}`,
+    );
+  }
+});
+
+test("docs README and ADR relative markdown links resolve", () => {
+  const checkedFiles = [
+    readmePath,
+    path.join(docsDir, "00-overview.md"),
+    ...markdownFiles(path.join(docsDir, "adr")),
+  ];
+
+  for (const filePath of checkedFiles) {
+    const source = readFileSync(filePath, "utf8");
+    const linkPattern = /\[[^\]]+\]\(([^)]+)\)/g;
+
+    for (const match of source.matchAll(linkPattern)) {
+      const target = match[1].trim();
+      if (
+        target.startsWith("#") ||
+        /^[a-z][a-z0-9+.-]*:/i.test(target)
+      ) {
+        continue;
+      }
+
+      const [targetPath] = target.split("#");
+      if (!targetPath) continue;
+
+      const resolved = path.resolve(path.dirname(filePath), targetPath);
+      assert.ok(
+        existsSync(resolved),
+        `${relative(filePath)} links to missing target ${target}`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
## Summary
- add `docs/README.md` as a full top-level docs index with status tags
- add ADRs for local Postgres runtime ownership, CSV config ownership, Better Auth, Lingui/Babel, crawler deploy quiescence, and IndexNow observability
- link the overview to the new docs index and enforce index coverage in CI

Closes #3153.

## Reproduction
- Confirmed current `docs/` had no `README.md` while `docs/00-overview.md` only linked a subset of top-level docs.
- Confirmed `docs/adr/` existed but only contained the multilingual posting ADR, leaving the decisions named in #3153 uncaptured.
- Production probing is not relevant for this docs-only change; no Supabase writes.

## Validation
- `node --test scripts/ci-workflow.test.mjs scripts/docs-index.test.mjs scripts/dealroom-company-requests.test.mjs`
- `/opt/homebrew/bin/actionlint -ignore 'SC(2002|2086|2129)' .github/workflows/ci.yml`\n- `uvx --from zizmor==1.26.1 zizmor --persona regular --min-severity medium --min-confidence high .github/workflows/ci.yml`\n- `git diff --check`