### PR TITLE
Share browser geolocation hook

### DIFF
--- a/apps/web/src/components/search/location-pills.tsx
+++ b/apps/web/src/components/search/location-pills.tsx
@@ -7,7 +7,7 @@ import type { LocationSuggestion } from "@/lib/actions/locations";
 import { runSuggestLocations as suggestLocations } from "@/lib/search/typeahead-runner";
 import type { SelectedLocation } from "@/lib/search/types";
 import { ScrollFade } from "@/components/ui/scroll-fade";
-import { getBrowserCoordinatesOnce } from "@/lib/search/browser-geolocation";
+import { useBrowserCoordinates } from "@/lib/search/browser-geolocation";
 
 interface LocationPillsProps {
   locations: SelectedLocation[];
@@ -42,32 +42,17 @@ export function LocationPills({
   const [suggestions, setSuggestions] = useState<LocationSuggestion[]>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
-  const [browserGeo, setBrowserGeo] = useState<{ lat: number; lng: number } | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLUListElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
   const isKeyboardNav = useRef(false);
 
-  // Resolve effective coordinates: server (Vercel IP) → browser geolocation
+  const browserGeo = useBrowserCoordinates(serverLat);
+
+  // Resolve effective coordinates: server (Vercel IP) -> browser geolocation
   const userLat = serverLat ?? browserGeo?.lat;
   const userLng = serverLng ?? browserGeo?.lng;
-
-  // Request browser geolocation once per page load if server didn't provide coords.
-  useEffect(() => {
-    if (serverLat != null) return;
-    let cancelled = false;
-
-    void getBrowserCoordinatesOnce().then((geo) => {
-      if (!cancelled && geo) {
-        setBrowserGeo(geo);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [serverLat]);
 
   const fetchSuggestions = useCallback(
     (query: string) => {

--- a/apps/web/src/components/search/search-bar.tsx
+++ b/apps/web/src/components/search/search-bar.tsx
@@ -22,7 +22,7 @@ import type { WorkMode } from "@/lib/search/types";
 import { useSearchStateStore, usePageActions } from "@/components/providers/SearchStateProvider";
 import { useLocalePath } from "@/lib/useLocalePath";
 import { ScrollFade } from "@/components/ui/scroll-fade";
-import { getBrowserCoordinatesOnce } from "@/lib/search/browser-geolocation";
+import { useBrowserCoordinates } from "@/lib/search/browser-geolocation";
 
 /**
  * Work-mode autocomplete entries — fixed three values, matched
@@ -151,32 +151,15 @@ export function SearchBar({
   const [technologyResults, setTechnologyResults] = useState<TaxonomySuggestion[]>([]);
   const [isOpen, setIsOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState(-1);
-  const [browserGeo, setBrowserGeo] = useState<{ lat: number; lng: number } | null>(null);
-
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const debounceRef = useRef<ReturnType<typeof setTimeout>>(null);
   const isKeyboardNav = useRef(false);
 
+  const browserGeo = useBrowserCoordinates(serverLat);
   const userLat = serverLat ?? browserGeo?.lat;
   const userLng = serverLng ?? browserGeo?.lng;
-
-  // Request browser geolocation once per page load if server didn't provide coords.
-  useEffect(() => {
-    if (serverLat != null) return;
-    let cancelled = false;
-
-    void getBrowserCoordinatesOnce().then((geo) => {
-      if (!cancelled && geo) {
-        setBrowserGeo(geo);
-      }
-    });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [serverLat]);
 
   // Current filter state: from props if available, otherwise derive from URL
   const currentKeywords = keywordsProp ?? (searchParams.get("q")?.split(",").filter(Boolean) ?? []);

--- a/apps/web/src/lib/search/__tests__/browser-geolocation.test.tsx
+++ b/apps/web/src/lib/search/__tests__/browser-geolocation.test.tsx
@@ -1,0 +1,87 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type BrowserCoordinates,
+  useBrowserCoordinates,
+} from "../browser-geolocation";
+
+type SuccessCallback = (position: GeolocationPosition) => void;
+
+function Harness({
+  serverLat,
+  onValue,
+}: {
+  serverLat?: number;
+  onValue: (value: BrowserCoordinates | null) => void;
+}) {
+  const coordinates = useBrowserCoordinates(serverLat);
+
+  useEffect(() => {
+    onValue(coordinates);
+  }, [coordinates, onValue]);
+
+  return null;
+}
+
+function geolocationPosition(lat: number, lng: number): GeolocationPosition {
+  return {
+    coords: {
+      latitude: lat,
+      longitude: lng,
+    },
+  } as GeolocationPosition;
+}
+
+describe("useBrowserCoordinates", () => {
+  const successes: SuccessCallback[] = [];
+  const getCurrentPosition = vi.fn((success: SuccessCallback) => {
+    successes.push(success);
+  });
+
+  beforeEach(() => {
+    successes.length = 0;
+    getCurrentPosition.mockClear();
+    Object.defineProperty(globalThis.navigator, "geolocation", {
+      configurable: true,
+      value: { getCurrentPosition },
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not request browser geolocation when server coordinates are already available", () => {
+    const values: Array<BrowserCoordinates | null> = [];
+
+    render(<Harness serverLat={47.37} onValue={(value) => values.push(value)} />);
+
+    expect(getCurrentPosition).not.toHaveBeenCalled();
+    expect(values).toEqual([null]);
+  });
+
+  it("shares one browser geolocation request across multiple hook consumers", async () => {
+    const firstValues: Array<BrowserCoordinates | null> = [];
+    const secondValues: Array<BrowserCoordinates | null> = [];
+
+    render(
+      <>
+        <Harness onValue={(value) => firstValues.push(value)} />
+        <Harness onValue={(value) => secondValues.push(value)} />
+      </>,
+    );
+
+    expect(getCurrentPosition).toHaveBeenCalledTimes(1);
+    expect(successes).toHaveLength(1);
+
+    await act(async () => {
+      successes[0](geolocationPosition(47.37, 8.54));
+    });
+
+    await waitFor(() => {
+      expect(firstValues.at(-1)).toEqual({ lat: 47.37, lng: 8.54 });
+      expect(secondValues.at(-1)).toEqual({ lat: 47.37, lng: 8.54 });
+    });
+  });
+});

--- a/apps/web/src/lib/search/browser-geolocation.ts
+++ b/apps/web/src/lib/search/browser-geolocation.ts
@@ -1,3 +1,5 @@
+import { useEffect, useState } from "react";
+
 export type BrowserCoordinates = {
   lat: number;
   lng: number;
@@ -21,4 +23,31 @@ export function getBrowserCoordinatesOnce(): Promise<BrowserCoordinates | null> 
   });
 
   return browserCoordinatesRequest;
+}
+
+export function useBrowserCoordinates(
+  serverLat: number | null | undefined,
+): BrowserCoordinates | null {
+  const [coordinates, setCoordinates] = useState<BrowserCoordinates | null>(null);
+
+  useEffect(() => {
+    if (serverLat != null) {
+      setCoordinates(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    void getBrowserCoordinatesOnce().then((geo) => {
+      if (!cancelled) {
+        setCoordinates(geo);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [serverLat]);
+
+  return coordinates;
 }


### PR DESCRIPTION
## Summary
- add a shared `useBrowserCoordinates` hook around the existing single-flight browser geolocation request helper
- replace the duplicated `browserGeo` state/effect wrappers in `SearchBar` and `LocationPills`
- add focused hook regression coverage for server-coordinate short-circuiting and shared in-flight requests

## Reproduction
- confirmed current `main` no longer has the original inline sessionStorage block, but still reproduces the remaining duplication: both `search-bar.tsx` and `location-pills.tsx` own local `browserGeo` state plus the same `getBrowserCoordinatesOnce().then(...)` cancellation effect
- read-only production baseline: `https://jseek.co/en` and `/en/explore` returned HTTP 200 with no `application-error`, `NEXT_HTTP_ERROR_FALLBACK`, or `digest` markers

## Validation
- `../../node_modules/.pnpm/node_modules/.bin/vitest run src/lib/search/__tests__/browser-geolocation.test.tsx --config vitest.config.ts`
- `../../node_modules/.pnpm/node_modules/.bin/vitest run src/components/search/__tests__/search-bar-request.test.tsx src/components/search/__tests__/location-search-modal.test.tsx --config vitest.config.ts`
- `../../node_modules/.pnpm/node_modules/.bin/eslint src/lib/search/browser-geolocation.ts src/lib/search/__tests__/browser-geolocation.test.tsx src/components/search/search-bar.tsx src/components/search/location-pills.tsx`
- `../../node_modules/.pnpm/node_modules/.bin/tsc` in `packages/mcp-server`, then `next typegen && tsc` in `apps/web`
- `git diff --check`

Note: direct binaries were used because this fresh worktree hits the current inherited pnpm minimum-release-age policy gate on newly published Lingui/Vitest packages before script execution.

Closes #3119