### PR TITLE
Extract shared posting detail hook

### DIFF
--- a/apps/web/src/components/my-jobs/my-job-detail-panel.tsx
+++ b/apps/web/src/components/my-jobs/my-job-detail-panel.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { X } from "lucide-react";
 import { CompanyIcon } from "@/components/CompanyIcon";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useLocalePath } from "@/lib/useLocalePath";
-import { getPostingDetail } from "@/lib/actions/search";
 import type { PostingDetail } from "@/lib/actions/search";
 import {
   getMyJobDetail,
@@ -28,6 +27,7 @@ import { InterviewList } from "./interview-list";
 import { timeAgoShort } from "@/lib/time";
 import { SaveButton } from "@/components/search/save-button";
 import { ScrollFade } from "@/components/ui/scroll-fade";
+import { usePostingDetail } from "@/lib/use-posting-detail";
 
 function useStatusOptionLabels(): Record<ApplicationStatus, string> {
   const { t } = useLingui();
@@ -53,58 +53,55 @@ export function MyJobDetailPanel({
   onClose,
   onStatusChanged,
 }: MyJobDetailPanelProps) {
-  const [postingDetail, setPostingDetail] = useState<PostingDetail | null>(
-    null,
-  );
+  const {
+    detail: postingDetail,
+    loading: postingLoading,
+    error: postingError,
+    descriptionLoaded,
+  } = usePostingDetail(postingId);
   const [jobDetail, setJobDetail] = useState<MyJobDetail | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
+  const [jobLoading, setJobLoading] = useState(true);
+  const [jobError, setJobError] = useState(false);
+  const jobDetailRequestIdRef = useRef(0);
   const { t } = useLingui();
   const statusOptionLabels = useStatusOptionLabels();
   const changePlaceholder = t({ id: "myJobs.detail.changePlaceholder", comment: "Placeholder in status change dropdown", message: "Change..." });
 
-  const loadData = useCallback(async () => {
-    setLoading(true);
-    setError(false);
-    const locale = document.documentElement.lang || "en";
-
-    try {
-      const [posting, detail] = await Promise.all([
-        getPostingDetail({ postingId, locale }),
-        getMyJobDetail(savedJobId),
-      ]);
-
-      if (!posting || !detail) {
-        setError(true);
-        return;
-      }
-
-      // Show structured data immediately
-      setPostingDetail(posting);
-      setJobDetail(detail);
-      setLoading(false);
-
-      // Fetch description in background
-      if (posting.descriptionUrl && !posting.descriptionHtml) {
-        fetch(posting.descriptionUrl)
-          .then((r) => r.ok ? r.text() : null)
-          .then((html) => {
-            if (!html) return;
-            setPostingDetail((prev) => prev ? { ...prev, descriptionHtml: html } : prev);
-          })
-          .catch(() => {});
-      }
-      return;
-    } catch {
-      setError(true);
-    } finally {
-      setLoading(false);
-    }
-  }, [postingId, savedJobId]);
-
   useEffect(() => {
-    loadData();
-  }, [loadData]);
+    const requestId = ++jobDetailRequestIdRef.current;
+    setJobDetail(null);
+    setJobLoading(true);
+    setJobError(false);
+
+    getMyJobDetail(savedJobId)
+      .then((detail) => {
+        if (jobDetailRequestIdRef.current !== requestId) return;
+        if (!detail) {
+          setJobError(true);
+          return;
+        }
+        setJobDetail(detail);
+      })
+      .catch(() => {
+        if (jobDetailRequestIdRef.current === requestId) {
+          setJobError(true);
+        }
+      })
+      .finally(() => {
+        if (jobDetailRequestIdRef.current === requestId) {
+          setJobLoading(false);
+        }
+      });
+
+    return () => {
+      if (jobDetailRequestIdRef.current === requestId) {
+        jobDetailRequestIdRef.current += 1;
+      }
+    };
+  }, [savedJobId]);
+
+  const loading = postingLoading || jobLoading;
+  const error = !loading && (postingError || jobError);
 
   async function handleStatusChange(newStatus: ApplicationStatus) {
     if (!jobDetail) return;
@@ -255,7 +252,7 @@ export function MyJobDetailPanel({
                   }}
                 />
               </>
-            ) : postingDetail.descriptionUrl ? (
+            ) : !descriptionLoaded && postingDetail.descriptionUrl ? (
               <div className="space-y-2 py-4">
                 <div className="h-3 w-full animate-pulse rounded bg-border-soft" />
                 <div className="h-3 w-5/6 animate-pulse rounded bg-border-soft" />

--- a/apps/web/src/components/search/job-detail-dialog.tsx
+++ b/apps/web/src/components/search/job-detail-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { BarChart3, CalendarDays, ChevronDown, ChevronUp, Clock, Code2, DollarSign, MapPin, X } from "lucide-react";
 import { CompanyIcon } from "@/components/CompanyIcon";
@@ -8,7 +8,6 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { tooltipClass } from "@/components/ui/tooltip-styles";
 import { useLocalePath } from "@/lib/useLocalePath";
-import { getPostingDetail } from "@/lib/actions/search";
 import type { PostingDetail } from "@/lib/actions/search";
 import { SaveButton } from "@/components/search/save-button";
 import { useSavedJobs } from "@/components/providers/SavedJobsProvider";
@@ -16,6 +15,7 @@ import { PendingJobBanner } from "@/components/PendingJobWarning";
 import { sanitizeJobHtml } from "@/lib/sanitize";
 import { withUtmSource } from "@/lib/utm";
 import { ScrollFade } from "@/components/ui/scroll-fade";
+import { usePostingDetail } from "@/lib/use-posting-detail";
 
 import { InterviewList } from "@/components/my-jobs/interview-list";
 import { updateJobStatus, getMyJobDetail, addInterview, updateInterview, deleteInterview } from "@/lib/actions/my-jobs";
@@ -41,51 +41,7 @@ interface JobDetailPanelProps {
 
 export function JobDetailPanel({ postingId, onClose }: JobDetailPanelProps) {
   const { t } = useLingui();
-  const [detail, setDetail] = useState<PostingDetail | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(false);
-  const [descriptionLoaded, setDescriptionLoaded] = useState(false);
-  const fetchIdRef = useRef(0);
-
-  useEffect(() => {
-    setDetail(null);
-    setDescriptionLoaded(false);
-    if (!postingId) return;
-
-    const id = ++fetchIdRef.current;
-    setLoading(true);
-    setError(false);
-    const locale = document.documentElement.lang || "en";
-
-    getPostingDetail({ postingId, locale })
-      .then((d) => {
-        if (fetchIdRef.current !== id) return;
-        if (!d) { setError(true); setLoading(false); return; }
-        // Show structured data immediately
-        setDetail(d);
-        setLoading(false);
-        // Fetch description in background
-        if (d.descriptionUrl && !d.descriptionHtml) {
-          fetch(d.descriptionUrl)
-            .then((r) => r.ok ? r.text() : null)
-            .then((html) => {
-              if (fetchIdRef.current !== id) return;
-              if (html) setDetail((prev) => prev ? { ...prev, descriptionHtml: html } : prev);
-              setDescriptionLoaded(true);
-            })
-            .catch(() => {
-              if (fetchIdRef.current === id) setDescriptionLoaded(true);
-            });
-        } else {
-          setDescriptionLoaded(true);
-        }
-      })
-      .catch(() => {
-        if (fetchIdRef.current !== id) return;
-        setError(true);
-        setLoading(false);
-      });
-  }, [postingId]);
+  const { detail, loading, error, descriptionLoaded } = usePostingDetail(postingId);
 
   if (!postingId) return null;
 
@@ -592,4 +548,3 @@ function FilterPill({
     </Tooltip.Root>
   );
 }
-

--- a/apps/web/src/lib/__tests__/use-posting-detail.test.tsx
+++ b/apps/web/src/lib/__tests__/use-posting-detail.test.tsx
@@ -1,0 +1,178 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { getPostingDetail } from "@/lib/actions/search";
+import type { PostingDetail } from "@/lib/actions/search";
+import { usePostingDetail } from "@/lib/use-posting-detail";
+
+vi.mock("@/lib/actions/search", () => ({
+  getPostingDetail: vi.fn(),
+}));
+
+const getPostingDetailMock = vi.mocked(getPostingDetail);
+
+function makePostingDetail(overrides: Partial<PostingDetail> = {}): PostingDetail {
+  return {
+    id: "posting-1",
+    title: "Product Engineer",
+    company: {
+      id: "company-1",
+      name: "Example",
+      slug: "example",
+      logo: null,
+      icon: null,
+    },
+    locations: [],
+    employmentType: null,
+    experienceMin: null,
+    experienceMax: null,
+    technologies: [],
+    salaryMin: null,
+    salaryMax: null,
+    salaryCurrency: null,
+    salaryPeriod: null,
+    seniority: null,
+    sourceUrl: "https://example.com/jobs/posting-1",
+    firstSeenAt: "2026-01-01T00:00:00.000Z",
+    descriptionHtml: null,
+    descriptionUrl: null,
+    ...overrides,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function HookHarness({ postingId }: { postingId: string | null }) {
+  const { detail, loading, error, descriptionLoaded } =
+    usePostingDetail(postingId);
+
+  return (
+    <dl>
+      <dt>loading</dt>
+      <dd data-testid="loading">{String(loading)}</dd>
+      <dt>error</dt>
+      <dd data-testid="error">{String(error)}</dd>
+      <dt>descriptionLoaded</dt>
+      <dd data-testid="description-loaded">{String(descriptionLoaded)}</dd>
+      <dt>title</dt>
+      <dd data-testid="title">{detail?.title ?? ""}</dd>
+      <dt>description</dt>
+      <dd data-testid="description">{detail?.descriptionHtml ?? ""}</dd>
+    </dl>
+  );
+}
+
+function expectTestIdText(testId: string, text: string) {
+  expect(screen.getByTestId(testId).textContent).toBe(text);
+}
+
+describe("usePostingDetail", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    document.documentElement.lang = "";
+  });
+
+  it("loads posting detail using the document locale and fetches deferred description HTML", async () => {
+    document.documentElement.lang = "fr";
+    getPostingDetailMock.mockResolvedValue(
+      makePostingDetail({
+        descriptionUrl: "https://r2.example/job/posting-1/fr/latest.html",
+      }),
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        text: vi.fn().mockResolvedValue("<p>Bonjour</p>"),
+      }),
+    );
+
+    render(<HookHarness postingId="posting-1" />);
+
+    await waitFor(() =>
+      expect(getPostingDetailMock).toHaveBeenCalledWith({
+        postingId: "posting-1",
+        locale: "fr",
+      }),
+    );
+    await waitFor(() => expectTestIdText("description", "<p>Bonjour</p>"));
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://r2.example/job/posting-1/fr/latest.html",
+    );
+    expectTestIdText("loading", "false");
+    expectTestIdText("error", "false");
+    expectTestIdText("description-loaded", "true");
+  });
+
+  it("ignores stale posting-detail responses after the posting id changes", async () => {
+    const oldRequest = deferred<PostingDetail | null>();
+    getPostingDetailMock.mockImplementation(({ postingId }) => {
+      if (postingId === "old-posting") return oldRequest.promise;
+      return Promise.resolve(
+        makePostingDetail({
+          id: "new-posting",
+          title: "New posting",
+          descriptionHtml: "<p>Fresh</p>",
+        }),
+      );
+    });
+
+    const { rerender } = render(<HookHarness postingId="old-posting" />);
+
+    rerender(<HookHarness postingId="new-posting" />);
+    await act(async () => {
+      oldRequest.resolve(
+        makePostingDetail({
+          id: "old-posting",
+          title: "Old posting",
+          descriptionHtml: "<p>Stale</p>",
+        }),
+      );
+      await oldRequest.promise;
+    });
+
+    await waitFor(() => expectTestIdText("title", "New posting"));
+    expectTestIdText("description", "<p>Fresh</p>");
+    expect(screen.getByTestId("description").textContent).not.toContain(
+      "Stale",
+    );
+  });
+
+  it("marks the description as loaded when the deferred description fetch fails", async () => {
+    getPostingDetailMock.mockResolvedValue(
+      makePostingDetail({
+        descriptionUrl: "https://r2.example/job/posting-1/en/latest.html",
+      }),
+    );
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("R2 down")));
+
+    render(<HookHarness postingId="posting-1" />);
+
+    await waitFor(() => expectTestIdText("title", "Product Engineer"));
+    await waitFor(() =>
+      expectTestIdText("description-loaded", "true"),
+    );
+
+    expectTestIdText("loading", "false");
+    expectTestIdText("error", "false");
+    expectTestIdText("description", "");
+  });
+
+  it("resets without fetching when there is no posting id", () => {
+    render(<HookHarness postingId={null} />);
+
+    expect(getPostingDetailMock).not.toHaveBeenCalled();
+    expectTestIdText("loading", "false");
+    expectTestIdText("error", "false");
+    expectTestIdText("description-loaded", "false");
+  });
+});

--- a/apps/web/src/lib/use-posting-detail.ts
+++ b/apps/web/src/lib/use-posting-detail.ts
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { getPostingDetail } from "@/lib/actions/search";
+import type { PostingDetail } from "@/lib/actions/search";
+
+interface PostingDetailState {
+  detail: PostingDetail | null;
+  loading: boolean;
+  error: boolean;
+  descriptionLoaded: boolean;
+}
+
+const EMPTY_STATE: PostingDetailState = {
+  detail: null,
+  loading: false,
+  error: false,
+  descriptionLoaded: false,
+};
+
+export function usePostingDetail(postingId: string | null): PostingDetailState {
+  const [state, setState] = useState<PostingDetailState>(EMPTY_STATE);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    const requestId = ++requestIdRef.current;
+
+    setState({
+      detail: null,
+      loading: Boolean(postingId),
+      error: false,
+      descriptionLoaded: false,
+    });
+
+    if (!postingId) return;
+
+    const locale = document.documentElement.lang || "en";
+
+    getPostingDetail({ postingId, locale })
+      .then((detail) => {
+        if (requestIdRef.current !== requestId) return;
+        if (!detail) {
+          setState({
+            detail: null,
+            loading: false,
+            error: true,
+            descriptionLoaded: false,
+          });
+          return;
+        }
+
+        const needsDescriptionFetch =
+          Boolean(detail.descriptionUrl) && !detail.descriptionHtml;
+
+        setState({
+          detail,
+          loading: false,
+          error: false,
+          descriptionLoaded: !needsDescriptionFetch,
+        });
+
+        if (!needsDescriptionFetch || !detail.descriptionUrl) return;
+
+        fetch(detail.descriptionUrl)
+          .then((response) => (response.ok ? response.text() : null))
+          .then((html) => {
+            if (requestIdRef.current !== requestId) return;
+            setState((previous) => ({
+              ...previous,
+              detail:
+                html && previous.detail
+                  ? { ...previous.detail, descriptionHtml: html }
+                  : previous.detail,
+              descriptionLoaded: true,
+            }));
+          })
+          .catch(() => {
+            if (requestIdRef.current !== requestId) return;
+            setState((previous) => ({
+              ...previous,
+              descriptionLoaded: true,
+            }));
+          });
+      })
+      .catch(() => {
+        if (requestIdRef.current !== requestId) return;
+        setState({
+          detail: null,
+          loading: false,
+          error: true,
+          descriptionLoaded: false,
+        });
+      });
+
+    return () => {
+      if (requestIdRef.current === requestId) {
+        requestIdRef.current += 1;
+      }
+    };
+  }, [postingId]);
+
+  return state;
+}


### PR DESCRIPTION
## Summary
- Extract shared `usePostingDetail` client hook for posting-detail loading and deferred description HTML fetches.
- Move `JobDetailPanel` and `MyJobDetailPanel` onto the shared hook while keeping saved-job detail loading local to My Jobs.
- Add hook regression coverage for locale propagation, deferred description fetch success/failure, and stale response cancellation.

Closes #3121

## Reproduction
- Source probe on current `main` found both `apps/web/src/components/search/job-detail-dialog.tsx` and `apps/web/src/components/my-jobs/my-job-detail-panel.tsx` had their own `getPostingDetail({ postingId, locale })`, `document.documentElement.lang`, `descriptionUrl`, and `fetch(...)` lazy-description paths.
- Read-only production baseline before changes: `https://jseek.co/en` and `https://jseek.co/en/my-jobs` returned HTTP 200 with no `application-error`, `NEXT_HTTP_ERROR_FALLBACK`, or `digest` markers.

## Validation
- `pnpm install --frozen-lockfile` linked dependencies but failed the inherited minimum-release-age policy on newly published Lingui/Vitest packages; validation used the linked direct binaries.
- `../../node_modules/.pnpm/node_modules/.bin/vitest run src/lib/__tests__/use-posting-detail.test.tsx --config vitest.config.ts`
- `../../node_modules/.pnpm/node_modules/.bin/eslint src/lib/use-posting-detail.ts src/lib/__tests__/use-posting-detail.test.tsx src/components/search/job-detail-dialog.tsx src/components/my-jobs/my-job-detail-panel.tsx`
- `../../node_modules/.pnpm/node_modules/.bin/tsc` in `packages/mcp-server`
- `../../node_modules/.pnpm/node_modules/.bin/next typegen && ../../node_modules/.pnpm/node_modules/.bin/tsc` in `apps/web`
- `git diff --check`