### PR TITLE
Queue watchlist access touch with after

### DIFF
--- a/apps/web/src/lib/actions/__tests__/watchlists-detail-perf.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-detail-perf.test.ts
@@ -47,17 +47,18 @@ const mocks = vi.hoisted(() => ({
   // fire from these loaders — the read path is now pure raw-SQL.
   dbSelect: vi.fn(),
   // `update(...)`/`delete(...)` chains are still allowed (the owner
-  // path fires `db.update(watchlist).set({ lastAccessedAt: … })` as a
-  // detached side-effect). The test ignores them; the assertion is on
-  // `dbExecute` round-trips, which is the user-visible serial latency.
+  // path queues `db.update(watchlist).set({ lastAccessedAt: … })` in
+  // `after`). The assertion is on `dbExecute` round-trips, which is the
+  // user-visible serial latency.
   dbUpdate: vi.fn(),
+  after: vi.fn((cb: () => unknown) => cb()),
 
   getSessionUserId: vi.fn(),
   cached: vi.fn(),
   withDbRetry: vi.fn(),
 }));
 
-vi.mock("next/server", () => ({ after: (cb: () => unknown) => cb() }));
+vi.mock("next/server", () => ({ after: mocks.after }));
 vi.mock("next/cache", () => ({ updateTag: vi.fn() }));
 
 vi.mock("@/lib/cache", () => ({
@@ -188,10 +189,6 @@ function makeUpdateChain() {
   }
   chain.then = (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) =>
     Promise.resolve(undefined).then(resolve, reject);
-  // Drizzle's update chain also supports `.catch(...)` for the
-  // fire-and-forget owner-touch — the production code path uses
-  // `.catch(() => {})` directly on the chain (not after `await`).
-  chain.catch = () => Promise.resolve(undefined);
   return chain;
 }
 
@@ -274,6 +271,15 @@ describe("getWatchlistByUserAndSlug — single-query fold (#3211)", () => {
     // Asserting that `db.select` is NOT touched pins that the companies
     // array now arrives via the same `db.execute` round-trip.
     expect(mocks.dbSelect).not.toHaveBeenCalled();
+  });
+
+  it("queues the owner lastAccessedAt touch through next/server after()", async () => {
+    mocks.dbExecute.mockResolvedValueOnce([fakeWatchlistRow()]);
+
+    await getWatchlistByUserAndSlug("alice", "my-watchlist");
+
+    expect(mocks.after).toHaveBeenCalledTimes(1);
+    expect(mocks.dbUpdate).toHaveBeenCalledTimes(1);
   });
 
   it("returns the full WatchlistDetail shape callers consume", async () => {

--- a/apps/web/src/lib/actions/__tests__/watchlists-invalidation.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-invalidation.test.ts
@@ -641,7 +641,7 @@ const EXPECTED_NON_INVALIDATING = new Set<string>([
   // alertsEnabled is a private field — never rendered on the public page,
   // so no public cache key is affected by toggling it.
   "toggleWatchlistAlerts",
-  // lastAccessedAt is a private "fire-and-forget" analytics touch on the
+  // lastAccessedAt is a private after-queued analytics touch on the
   // owner's read path; it never appears in any public render.
   "getWatchlistByUserAndSlug",
 ]);
@@ -845,5 +845,10 @@ describe("invalidation registry guard", () => {
     );
     const callSites = (withoutDef.match(/_invalidateWatchlistCaches\s*\(/g) || []).length;
     expect(callSites).toBe(EXPECTED_INVALIDATING_MUTATORS.size);
+  });
+
+  it("does not use silent detached promise catches for watchlist side effects", () => {
+    const source = readFileSync(SOURCE_PATH, "utf-8");
+    expect(source).not.toMatch(/\.catch\(\s*\(\)\s*=>\s*\{\s*\}\s*\)/);
   });
 });

--- a/apps/web/src/lib/services/watchlists.ts
+++ b/apps/web/src/lib/services/watchlists.ts
@@ -1022,12 +1022,19 @@ export async function getWatchlistByUserAndSlug(
   // Access check: public or owner
   if (!row.is_public && row.user_id !== sessionUserId) return null;
 
-  // Touch lastAccessedAt (fire-and-forget — doesn't affect response)
+  // Touch lastAccessedAt after the response; it is private analytics state
+  // and should not affect the watchlist detail read path.
   if (row.user_id === sessionUserId) {
-    db.update(watchlist)
-      .set({ lastAccessedAt: new Date() })
-      .where(eq(watchlist.id, row.wl_id))
-      .catch(() => {});
+    after(async () => {
+      try {
+        await db
+          .update(watchlist)
+          .set({ lastAccessedAt: new Date() })
+          .where(eq(watchlist.id, row.wl_id));
+      } catch (err) {
+        console.error("[getWatchlistByUserAndSlug] lastAccessedAt touch failed", err);
+      }
+    });
   }
 
   return {


### PR DESCRIPTION
Fixes #3109

## Summary
- move the owner `lastAccessedAt` touch in `getWatchlistByUserAndSlug` from a detached `db.update(...).catch(() => {})` chain into a request-bound `after(...)` callback
- log owner-touch failures instead of silently swallowing them
- update watchlist detail/invalidation tests and add a source guard against silent empty catches in the watchlist service

## Reproduction / production baseline
- on current `main`, the add/clear/remove public-watchlist Typesense hooks are already inside `after(...)`, but `getWatchlistByUserAndSlug` still used `db.update(...).catch(() => {})` for `lastAccessedAt`
- read-only production baseline: `https://jseek.co/en/watchlists` returned HTTP 200 with no `application-error` or digest markers; recent deployment error logs were empty
- no mutating production action was invoked

## Validation
- `npx -y pnpm@10.30.0 install --frozen-lockfile`
- `npx -y pnpm@10.30.0 --filter @jobseek/web exec vitest run src/lib/actions/__tests__/watchlists-detail-perf.test.ts src/lib/actions/__tests__/watchlists-invalidation.test.ts`
- source guard search for detached watchlist side effects
- `git diff --check`
- `npx -y pnpm@10.30.0 --filter @jobseek/web exec eslint src/lib/services/watchlists.ts src/lib/actions/__tests__/watchlists-detail-perf.test.ts src/lib/actions/__tests__/watchlists-invalidation.test.ts`
- `npx -y pnpm@10.30.0 --filter @jobseek/web run typecheck`
- `npx -y pnpm@10.30.0 --filter @jobseek/web test`
- `npx -y pnpm@10.30.0 --filter @jobseek/web run build` (passed with existing missing-local-env warnings)