### PR TITLE
Centralize sync cache invalidation registry

### DIFF
--- a/apps/web/app/api/internal/invalidate-typeahead/route.test.ts
+++ b/apps/web/app/api/internal/invalidate-typeahead/route.test.ts
@@ -78,7 +78,7 @@ describe("POST /api/internal/invalidate-typeahead", () => {
     expect(body.revalidatedTags).toEqual(tags);
   });
 
-  it("invokes invalidatePattern for every typeahead prefix", async () => {
+  it("invokes invalidatePattern for every crawler-sync Redis prefix", async () => {
     mocks.invalidatePattern.mockImplementation(async (prefix: string) =>
       prefix === "loc-suggest:" ? 5 : prefix === "company-suggest:" ? 2 : 0,
     );
@@ -131,8 +131,8 @@ describe("POST /api/internal/invalidate-typeahead", () => {
 
   it("does not accept arbitrary prefixes from the caller", async () => {
     /** Defense-in-depth: even an authenticated caller cannot direct the
-     * sweep at, say, `cache:session:*` — the prefix list is owned by
-     * this route, not the request body. */
+     * sweep at, say, `cache:session:*` — the synced-prefix registry, not
+     * the request body, owns the sweep scope. */
     const res = await POST(
       new Request("http://localhost/api/internal/invalidate-typeahead", {
         method: "POST",

--- a/apps/web/app/api/internal/invalidate-typeahead/route.ts
+++ b/apps/web/app/api/internal/invalidate-typeahead/route.ts
@@ -5,13 +5,9 @@ import { NextResponse, type NextRequest } from "next/server";
 
 import { invalidatePattern } from "@/lib/cache";
 import {
-  companyCsvDataCacheTag,
-  typeaheadCompaniesCacheTag,
-  typeaheadLocationsCacheTag,
-  typeaheadOccupationsCacheTag,
-  typeaheadSenioritiesCacheTag,
-  typeaheadTechnologiesCacheTag,
-} from "@/lib/cache-tags";
+  CACHE_PREFIXES_INVALIDATED_ON_SYNC,
+  CACHE_TAGS_INVALIDATED_ON_SYNC,
+} from "@/lib/cache-registry";
 
 function _safeBearerEqual(presented: string | null, expected: string): boolean {
   if (presented === null) return false;
@@ -23,28 +19,6 @@ function _safeBearerEqual(presented: string | null, expected: string): boolean {
   if (a.length !== b.length) return false;
   return timingSafeEqual(a, b);
 }
-
-// Closed list — every cache key prefix that would go stale after a
-// `crawler sync` mutation (taxonomy renames, company CSV edits). Defined
-// here (not in the caller) so the crawler can't accidentally request a
-// sweep of an unrelated namespace. Mirrors the keys built in
-// apps/web/src/lib/actions/{locations,taxonomy,company}.ts.
-//
-// company-slug: + company-similar: were added in #2715 — a company
-// rename / industry change otherwise leaves /company/<slug> stale up to
-// the 10-minute company-slug TTL. The posting-derived caches
-// (company-top-locs:, company-locs-grouped:, company-postings:) key off
-// job_posting data, which a CSV sync doesn't touch, so they're left to
-// their TTLs.
-const TYPEAHEAD_PREFIXES = [
-  "loc-suggest:",
-  "occ-suggest:",
-  "sen-suggest:",
-  "tech-suggest:",
-  "company-suggest:",
-  "company-slug:",
-  "company-similar:",
-] as const;
 
 // `'use cache'` tags for the 5 typeahead slots migrated in #2907 plus
 // the CSV-driven per-company tag covering `getCompanyBySlug` and
@@ -61,22 +35,14 @@ const TYPEAHEAD_PREFIXES = [
 // `revalidateTag(companyCacheTag(slug))` calls. The per-slug
 // `companyCacheTag(slug)` is reserved for future targeted invalidation
 // (e.g., a server action that mutates a single company).
-const INVALIDATE_TAGS = [
-  typeaheadLocationsCacheTag(),
-  typeaheadOccupationsCacheTag(),
-  typeaheadSenioritiesCacheTag(),
-  typeaheadTechnologiesCacheTag(),
-  typeaheadCompaniesCacheTag(),
-  companyCsvDataCacheTag(),
-] as const;
-
 /**
  * POST /api/internal/invalidate-typeahead
  *
  * Called by the crawler after `sync_typesense` to drop stale typeahead
  * suggestions and company-detail caches across all locales (see the
- * `TYPEAHEAD_PREFIXES` list for the full scope — kept under the original
- * route name so the crawler caller doesn't need a URL change).
+ * `CACHE_PREFIXES_INVALIDATED_ON_SYNC` registry for the full legacy Redis
+ * sweep scope — kept under the original route name so the crawler caller
+ * doesn't need a URL change).
  * Authenticated via a bearer token shared out-of-band
  * (`INTERNAL_REVALIDATE_TOKEN` env var on both sides).
  *
@@ -106,7 +72,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   // expire — the tag is fired once per `crawler sync` and the slot
   // must drop until the next call refills it.
   const revalidatedTags: string[] = [];
-  for (const tag of INVALIDATE_TAGS) {
+  for (const tag of CACHE_TAGS_INVALIDATED_ON_SYNC) {
     try {
       revalidateTag(tag, "max");
       revalidatedTags.push(tag);
@@ -129,7 +95,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
   // path under one of these prefixes). Each call resolves to 0 deletes
   // in the steady state.
   const deleted: Record<string, number> = {};
-  for (const prefix of TYPEAHEAD_PREFIXES) {
+  for (const prefix of CACHE_PREFIXES_INVALIDATED_ON_SYNC) {
     deleted[prefix] = await invalidatePattern(prefix);
   }
   const total = Object.values(deleted).reduce((a, b) => a + b, 0);

--- a/apps/web/src/lib/__tests__/cache-registry.test.ts
+++ b/apps/web/src/lib/__tests__/cache-registry.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  CACHE_NAMESPACE,
+  CACHE_PREFIXES_INVALIDATED_ON_SYNC,
+  CACHE_TAGS_INVALIDATED_ON_SYNC,
+  buildCacheKey,
+  cachePrefix,
+  companyDetailCacheKey,
+} from "@/lib/cache-registry";
+
+describe("cache registry", () => {
+  it("declares the crawler-sync Redis prefix sweep in one place", () => {
+    expect(CACHE_PREFIXES_INVALIDATED_ON_SYNC).toEqual([
+      "loc-suggest:",
+      "occ-suggest:",
+      "sen-suggest:",
+      "tech-suggest:",
+      "company-suggest:",
+      "company-slug:",
+      "company-similar:",
+    ]);
+  });
+
+  it("declares the crawler-sync use-cache tag sweep in one place", () => {
+    expect(CACHE_TAGS_INVALIDATED_ON_SYNC).toEqual([
+      "typeahead:locations",
+      "typeahead:occupations",
+      "typeahead:seniorities",
+      "typeahead:technologies",
+      "typeahead:companies",
+      "company-csv-data",
+    ]);
+  });
+
+  it("builds cache keys from shared namespaces", () => {
+    expect(cachePrefix(CACHE_NAMESPACE.COMPANY_DETAIL)).toBe("company-slug:");
+    expect(buildCacheKey(CACHE_NAMESPACE.COMPANY_DETAIL, "acme", "en")).toBe(
+      "company-slug:acme:en",
+    );
+    expect(companyDetailCacheKey("acme", "en")).toBe("company-slug:acme:en");
+  });
+
+  it("keeps the route as a consumer instead of the prefix owner", () => {
+    const routeSource = readFileSync(
+      join(process.cwd(), "app/api/internal/invalidate-typeahead/route.ts"),
+      "utf8",
+    );
+    expect(routeSource).toContain("CACHE_PREFIXES_INVALIDATED_ON_SYNC");
+    expect(routeSource).not.toContain("const TYPEAHEAD_PREFIXES");
+    expect(routeSource).not.toContain('"loc-suggest:"');
+  });
+});

--- a/apps/web/src/lib/cache-registry.ts
+++ b/apps/web/src/lib/cache-registry.ts
@@ -1,0 +1,58 @@
+import {
+  companyCsvDataCacheTag,
+  typeaheadCompaniesCacheTag,
+  typeaheadLocationsCacheTag,
+  typeaheadOccupationsCacheTag,
+  typeaheadSenioritiesCacheTag,
+  typeaheadTechnologiesCacheTag,
+} from "@/lib/cache-tags";
+
+export const CACHE_NAMESPACE = {
+  LOCATION_SUGGESTIONS: "loc-suggest",
+  OCCUPATION_SUGGESTIONS: "occ-suggest",
+  SENIORITY_SUGGESTIONS: "sen-suggest",
+  TECHNOLOGY_SUGGESTIONS: "tech-suggest",
+  COMPANY_SUGGESTIONS: "company-suggest",
+  COMPANY_DETAIL: "company-slug",
+  COMPANY_SIMILAR: "company-similar",
+} as const;
+
+export type CacheNamespace = (typeof CACHE_NAMESPACE)[keyof typeof CACHE_NAMESPACE];
+
+export function cachePrefix(namespace: CacheNamespace): string {
+  return `${namespace}:`;
+}
+
+export function buildCacheKey(
+  namespace: CacheNamespace,
+  ...parts: readonly (string | number)[]
+): string {
+  return [namespace, ...parts].join(":");
+}
+
+export function companyDetailCacheKey(slug: string, locale: string): string {
+  return buildCacheKey(CACHE_NAMESPACE.COMPANY_DETAIL, slug, locale);
+}
+
+// Legacy Redis prefixes to sweep after crawler CSV/taxonomy sync. These
+// prefixes mirror the cache namespaces that used to be minted by Redis
+// `cached()` callers and remain as a rollout-window backstop for migrated
+// `'use cache'` slots.
+export const CACHE_PREFIXES_INVALIDATED_ON_SYNC = [
+  cachePrefix(CACHE_NAMESPACE.LOCATION_SUGGESTIONS),
+  cachePrefix(CACHE_NAMESPACE.OCCUPATION_SUGGESTIONS),
+  cachePrefix(CACHE_NAMESPACE.SENIORITY_SUGGESTIONS),
+  cachePrefix(CACHE_NAMESPACE.TECHNOLOGY_SUGGESTIONS),
+  cachePrefix(CACHE_NAMESPACE.COMPANY_SUGGESTIONS),
+  cachePrefix(CACHE_NAMESPACE.COMPANY_DETAIL),
+  cachePrefix(CACHE_NAMESPACE.COMPANY_SIMILAR),
+] as const;
+
+export const CACHE_TAGS_INVALIDATED_ON_SYNC = [
+  typeaheadLocationsCacheTag(),
+  typeaheadOccupationsCacheTag(),
+  typeaheadSenioritiesCacheTag(),
+  typeaheadTechnologiesCacheTag(),
+  typeaheadCompaniesCacheTag(),
+  companyCsvDataCacheTag(),
+] as const;

--- a/apps/web/src/lib/services/company-detail.ts
+++ b/apps/web/src/lib/services/company-detail.ts
@@ -4,6 +4,7 @@ import { sql } from "drizzle-orm";
 import { db } from "@/db";
 import { CACHE_TTL_DETAIL } from "@/lib/cache-ttl";
 import { cached } from "@/lib/cache";
+import { companyDetailCacheKey } from "@/lib/cache-registry";
 import { withDbRetry } from "@/lib/db-retry";
 import { getSearchClient } from "@/lib/search/typesense-client";
 import {
@@ -32,7 +33,7 @@ export async function getCompanyBySlug(
     console.warn("[company] lookup skipped because Typesense and DATABASE_URL are not configured");
     return null;
   }
-  const key = `company-slug:${slug}:${locale}`;
+  const key = companyDetailCacheKey(slug, locale);
   // Empty-result skipping is load-bearing here: a not-yet-indexed company
   // should be retried on the next request, but throwing a sentinel from a
   // `'use cache'` boundary leaks that error into the RSC payload (#3603).

--- a/apps/web/src/lib/services/company.ts
+++ b/apps/web/src/lib/services/company.ts
@@ -731,8 +731,8 @@ async function _fetchSimilarFilteredCached(
   // CSV-driven sweep — an industry move (changing `industry_id` on a
   // company row) changes the candidate pool for every other company in
   // the source AND target industry. Conservative: drop on every CSV
-  // sync. Mirrors the legacy `company-similar:` Redis-prefix sweep
-  // (#2715). See #2884.
+  // sync. Mirrors the legacy company-similar Redis namespace from the
+  // cache invalidation registry (#2715). See #2884.
   cacheTag(companyCsvDataCacheTag());
   return _fetchSimilarFiltered(companyId, industryId, limit, filters);
 }


### PR DESCRIPTION
## Summary
- centralize crawler-sync Redis cache prefixes and Next cache tags in `cache-registry`
- make the internal invalidate route consume the shared registry instead of owning hardcoded prefixes
- route the company-detail cache key through the shared namespace helper and add registry regression coverage

Fixes #3099

## Reproduction / prod probe
- confirmed production internal endpoint exists and rejects non-mutating GET probe: `GET https://jseek.co/api/internal/invalidate-typeahead` -> `405`
- added source regression proving the route consumes `CACHE_PREFIXES_INVALIDATED_ON_SYNC` and no longer declares `TYPEAHEAD_PREFIXES`

## Validation
- `pnpm install --frozen-lockfile --trust-lockfile`
- `./node_modules/.bin/vitest run app/api/internal/invalidate-typeahead/route.test.ts src/lib/__tests__/cache-registry.test.ts src/lib/services/__tests__/company-detail.test.ts`
- `./node_modules/.bin/eslint app/api/internal/invalidate-typeahead/route.ts app/api/internal/invalidate-typeahead/route.test.ts src/lib/cache-registry.ts src/lib/__tests__/cache-registry.test.ts src/lib/services/company-detail.ts src/lib/services/company.ts`
- `pnpm --filter @jobseek/web typecheck`