### PR TITLE
Sync watchlist company counts from Postgres

### DIFF
--- a/apps/web/src/lib/actions/__tests__/watchlists-invalidation.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-invalidation.test.ts
@@ -483,6 +483,26 @@ describe("watchlist mutator cache invalidation", () => {
     );
   });
 
+  it("clearWatchlistCompanies patches Typesense with a fresh company count", async () => {
+    mocks.selectLimitResult.mockResolvedValue([
+      { userId: USER_ID, slug: SLUG, isPublic: true },
+    ]);
+    // Simulate another writer adding companies before the after-hook
+    // syncs Typesense. The hook must read Postgres, not assume zero.
+    mocks.dbExecute
+      .mockResolvedValueOnce([
+        { name: "Alice", username: USER_NAME, display_username: DISPLAY_USER_NAME },
+      ])
+      .mockResolvedValueOnce([{ cnt: 2 }]);
+
+    await clearWatchlistCompanies(WATCHLIST_ID);
+    await flushAfterQueue();
+
+    expect(mocks.tsUpdateWatchlistField).toHaveBeenCalledWith(WATCHLIST_ID, {
+      company_count: 2,
+    });
+  });
+
   it("removeCompanyFromWatchlist invalidates both slug variants for public watchlists", async () => {
     queueOwnerInfo();
     mocks.selectLimitResult.mockResolvedValue([

--- a/apps/web/src/lib/services/watchlists.ts
+++ b/apps/web/src/lib/services/watchlists.ts
@@ -1938,8 +1938,7 @@ export async function addCompanyToWatchlist(
     after(async () => {
       try {
         await _invalidateWatchlistCaches(userId, [wl.slug]);
-        const count = await _countWatchlistCompanies(watchlistId);
-        tsUpdateWatchlistField(watchlistId, { company_count: count });
+        await _syncWatchlistCompanyCountToTypesense(watchlistId);
       } catch (err) {
         console.error("[addCompanyToWatchlist] post-mutation hook failed", err);
       }
@@ -1971,7 +1970,7 @@ export async function clearWatchlistCompanies(
     after(async () => {
       try {
         await _invalidateWatchlistCaches(userId, [wl.slug]);
-        tsUpdateWatchlistField(watchlistId, { company_count: 0 });
+        await _syncWatchlistCompanyCountToTypesense(watchlistId);
       } catch (err) {
         console.error("[clearWatchlistCompanies] post-mutation hook failed", err);
       }
@@ -2009,8 +2008,7 @@ export async function removeCompanyFromWatchlist(
     after(async () => {
       try {
         await _invalidateWatchlistCaches(userId, [wl.slug]);
-        const count = await _countWatchlistCompanies(watchlistId);
-        tsUpdateWatchlistField(watchlistId, { company_count: count });
+        await _syncWatchlistCompanyCountToTypesense(watchlistId);
       } catch (err) {
         console.error("[removeCompanyFromWatchlist] post-mutation hook failed", err);
       }
@@ -2578,6 +2576,12 @@ async function _countWatchlistCompanies(watchlistId: string): Promise<number> {
     { label: `countWatchlistCompanies[${watchlistId}]` },
   );
   return (row as unknown as { cnt: number })?.cnt ?? 0;
+}
+
+/** Patch Typesense with the current Postgres company count. */
+async function _syncWatchlistCompanyCountToTypesense(watchlistId: string): Promise<void> {
+  const count = await _countWatchlistCompanies(watchlistId);
+  tsUpdateWatchlistField(watchlistId, { company_count: count });
 }
 
 /** Get the mirror count for a watchlist (number of copies). */


### PR DESCRIPTION
## Summary

- route add/clear/remove watchlist-company mutators through one after-queued Typesense company-count sync helper
- remove `clearWatchlistCompanies`' hard-coded `company_count: 0` patch
- add a regression where clear's after-hook must publish the freshly re-read Postgres count instead of assuming zero

Closes #3162.

## Reproduction / prod probe

- Source reproduction on current main showed `clearWatchlistCompanies` still wrote `tsUpdateWatchlistField(watchlistId, { company_count: 0 })` while add/remove re-counted Postgres.
- Read-only production probes only: public `/api/v1/watchlists?locale=en` returned 200, and an env-derived Typesense search-key probe for `SWE Zurich` returned public watchlist docs with `company_count: 5`, matching the public API sample. No production mutations were run.

## Validation

- `pnpm install --frozen-lockfile --trust-lockfile`
- red test before fix: new regression expected `company_count: 2` but current code wrote `company_count: 0`
- `pnpm --filter @jobseek/web test -- watchlists-invalidation` (170 files / 1353 tests)
- `pnpm exec vitest run src/lib/actions/__tests__/watchlists-invalidation.test.ts` (19 tests)
- `pnpm --filter @jobseek/web exec eslint src/lib/services/watchlists.ts src/lib/actions/__tests__/watchlists-invalidation.test.ts`
- `pnpm --filter @jobseek/web typecheck`
- `pnpm --filter @jobseek/web build` (passes with existing missing-local-env warnings for local Redis/Better Auth/DB/Typesense)
- `git diff --check`
