### PR TITLE
Localize server action error codes

### DIFF
--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -4936,3 +4936,81 @@ msgstr "Deine Rechte"
 #: src/components/settings/AccountSettings.tsx:307
 msgid "settings.account.username.description"
 msgstr "Dein eindeutiger Name für deine öffentliche Profil-URL."
+
+#. Generic server-action error shown when a user is not logged in
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.notAuthenticated"
+msgstr "Bitte melde dich an und versuche es erneut."
+
+#. Generic server-action error shown when an item cannot be found
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.notFound"
+msgstr "Nicht gefunden."
+
+#. Billing error when checkout is not configured yet
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.paymentsUnavailable"
+msgstr "Zahlungen sind noch nicht verfügbar."
+
+#. Billing error when the user has no billing account
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.billingAccountNotFound"
+msgstr "Kein Abrechnungskonto gefunden."
+
+#. Billing error when the portal is not configured yet
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.billingPortalUnavailable"
+msgstr "Das Abrechnungsportal ist noch nicht verfügbar."
+
+#. Generic error when setting an account password fails
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.passwordSetFailed"
+msgstr "Passwort konnte nicht gesetzt werden."
+
+#. Username validation error for length
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.usernameLength"
+msgstr "Der Benutzername muss 3-30 Zeichen lang sein."
+
+#. Username validation error for unsupported characters
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.usernameInvalidCharacters"
+msgstr "Der Benutzername darf nur Kleinbuchstaben, Zahlen und Bindestriche enthalten und nicht mit einem Bindestrich beginnen oder enden."
+
+#. Username validation error when a reserved username is requested
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.usernameReserved"
+msgstr "Dieser Benutzername ist reserviert."
+
+#. Generic error when updating an account username fails
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.usernameUpdateFailed"
+msgstr "Benutzername konnte nicht aktualisiert werden."
+
+#. Generic account error when the current user row is missing
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.userNotFound"
+msgstr "Benutzer nicht gefunden."
+
+#. My Jobs error when an application status transition is not allowed
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.invalidStatusTransition"
+msgstr "Diese Statusänderung ist nicht erlaubt."
+
+#. My Jobs error when assigning an interview round fails
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.interviewRoundFailed"
+msgstr "Interviewrunde konnte nicht zugewiesen werden."

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -4936,3 +4936,81 @@ msgstr "Your rights"
 #: src/components/settings/AccountSettings.tsx:307
 msgid "settings.account.username.description"
 msgstr "Your unique handle used in your public profile URL."
+
+#. Generic server-action error shown when a user is not logged in
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.notAuthenticated"
+msgstr "Please log in and try again."
+
+#. Generic server-action error shown when an item cannot be found
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.notFound"
+msgstr "Not found."
+
+#. Billing error when checkout is not configured yet
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.paymentsUnavailable"
+msgstr "Payments are not available yet."
+
+#. Billing error when the user has no billing account
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.billingAccountNotFound"
+msgstr "No billing account found."
+
+#. Billing error when the portal is not configured yet
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.billingPortalUnavailable"
+msgstr "Billing portal is not available yet."
+
+#. Generic error when setting an account password fails
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.passwordSetFailed"
+msgstr "Failed to set password."
+
+#. Username validation error for length
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.usernameLength"
+msgstr "Username must be 3-30 characters."
+
+#. Username validation error for unsupported characters
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.usernameInvalidCharacters"
+msgstr "Username can only use lowercase letters, numbers, and hyphens, and cannot start or end with a hyphen."
+
+#. Username validation error when a reserved username is requested
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.usernameReserved"
+msgstr "This username is reserved."
+
+#. Generic error when updating an account username fails
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.usernameUpdateFailed"
+msgstr "Could not update username."
+
+#. Generic account error when the current user row is missing
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.userNotFound"
+msgstr "User not found."
+
+#. My Jobs error when an application status transition is not allowed
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.invalidStatusTransition"
+msgstr "That status change is not allowed."
+
+#. My Jobs error when assigning an interview round fails
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.interviewRoundFailed"
+msgstr "Could not assign interview round."

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -4936,3 +4936,81 @@ msgstr "Tes droits"
 #: src/components/settings/AccountSettings.tsx:307
 msgid "settings.account.username.description"
 msgstr "Votre identifiant unique utilisé dans l'URL de votre profil public."
+
+#. Generic server-action error shown when a user is not logged in
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.notAuthenticated"
+msgstr "Veuillez vous connecter puis réessayer."
+
+#. Generic server-action error shown when an item cannot be found
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.notFound"
+msgstr "Introuvable."
+
+#. Billing error when checkout is not configured yet
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.paymentsUnavailable"
+msgstr "Les paiements ne sont pas encore disponibles."
+
+#. Billing error when the user has no billing account
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.billingAccountNotFound"
+msgstr "Aucun compte de facturation trouvé."
+
+#. Billing error when the portal is not configured yet
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.billingPortalUnavailable"
+msgstr "Le portail de facturation n'est pas encore disponible."
+
+#. Generic error when setting an account password fails
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.passwordSetFailed"
+msgstr "Impossible de définir le mot de passe."
+
+#. Username validation error for length
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.usernameLength"
+msgstr "Le nom d'utilisateur doit contenir 3 à 30 caractères."
+
+#. Username validation error for unsupported characters
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.usernameInvalidCharacters"
+msgstr "Le nom d'utilisateur ne peut contenir que des lettres minuscules, des chiffres et des traits d'union, et ne peut pas commencer ou finir par un trait d'union."
+
+#. Username validation error when a reserved username is requested
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.usernameReserved"
+msgstr "Ce nom d'utilisateur est réservé."
+
+#. Generic error when updating an account username fails
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.usernameUpdateFailed"
+msgstr "Impossible de mettre à jour le nom d'utilisateur."
+
+#. Generic account error when the current user row is missing
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.userNotFound"
+msgstr "Utilisateur introuvable."
+
+#. My Jobs error when an application status transition is not allowed
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.invalidStatusTransition"
+msgstr "Ce changement de statut n'est pas autorisé."
+
+#. My Jobs error when assigning an interview round fails
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.interviewRoundFailed"
+msgstr "Impossible d'attribuer l'entretien."

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -4936,3 +4936,81 @@ msgstr "I tuoi diritti"
 #: src/components/settings/AccountSettings.tsx:307
 msgid "settings.account.username.description"
 msgstr "Il tuo identificativo unico utilizzato nell'URL del tuo profilo pubblico."
+
+#. Generic server-action error shown when a user is not logged in
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.notAuthenticated"
+msgstr "Accedi e riprova."
+
+#. Generic server-action error shown when an item cannot be found
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.notFound"
+msgstr "Non trovato."
+
+#. Billing error when checkout is not configured yet
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.paymentsUnavailable"
+msgstr "I pagamenti non sono ancora disponibili."
+
+#. Billing error when the user has no billing account
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.billingAccountNotFound"
+msgstr "Nessun account di fatturazione trovato."
+
+#. Billing error when the portal is not configured yet
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.billingPortalUnavailable"
+msgstr "Il portale di fatturazione non è ancora disponibile."
+
+#. Generic error when setting an account password fails
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.passwordSetFailed"
+msgstr "Impossibile impostare la password."
+
+#. Username validation error for length
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.usernameLength"
+msgstr "Il nome utente deve avere 3-30 caratteri."
+
+#. Username validation error for unsupported characters
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.usernameInvalidCharacters"
+msgstr "Il nome utente può usare solo lettere minuscole, numeri e trattini e non può iniziare o finire con un trattino."
+
+#. Username validation error when a reserved username is requested
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.usernameReserved"
+msgstr "Questo nome utente è riservato."
+
+#. Generic error when updating an account username fails
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.usernameUpdateFailed"
+msgstr "Impossibile aggiornare il nome utente."
+
+#. Generic account error when the current user row is missing
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.userNotFound"
+msgstr "Utente non trovato."
+
+#. My Jobs error when an application status transition is not allowed
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.invalidStatusTransition"
+msgstr "Questa modifica dello stato non è consentita."
+
+#. My Jobs error when assigning an interview round fails
+#. js-lingui-explicit-id
+#: src/lib/action-error-messages.ts
+msgid "actions.error.interviewRoundFailed"
+msgstr "Impossibile assegnare il colloquio."

--- a/apps/web/src/components/settings/BillingSettings.tsx
+++ b/apps/web/src/components/settings/BillingSettings.tsx
@@ -7,6 +7,7 @@ import { Check, Crown } from "lucide-react";
 import { useSession } from "@/components/providers/SessionProvider";
 import { useLocalePath } from "@/lib/useLocalePath";
 import { createCheckoutSession, createPortalSession } from "@/lib/actions/billing";
+import { translateActionError } from "@/lib/action-error-messages";
 import { Button } from "@/components/ui/Button";
 import { ErrorAlert } from "@/components/ui/ErrorAlert";
 import type { PlanId } from "@/lib/plans";
@@ -104,7 +105,7 @@ export function BillingSettings({ planInfo }: { planInfo: PlanInfo }) {
     const result = await createCheckoutSession();
     setLoading(null);
     if (result.error) {
-      setError(result.error);
+      setError(translateActionError(t, result.error));
       return;
     }
     if (result.url) {
@@ -118,7 +119,7 @@ export function BillingSettings({ planInfo }: { planInfo: PlanInfo }) {
     const result = await createPortalSession();
     setLoading(null);
     if (result.error) {
-      setError(result.error);
+      setError(translateActionError(t, result.error));
       return;
     }
     if (result.url) {

--- a/apps/web/src/components/settings/__tests__/AccountSettings-username-error.test.tsx
+++ b/apps/web/src/components/settings/__tests__/AccountSettings-username-error.test.tsx
@@ -100,8 +100,8 @@ async function submitUsername(value: string) {
 }
 
 describe("AccountSettings username errors", () => {
-  it("renders the renameUsername error and does not refresh stale session data", async () => {
-    mocks.renameUsername.mockResolvedValueOnce({ error: "Username already taken" });
+  it("translates renameUsername error codes and does not refresh stale session data", async () => {
+    mocks.renameUsername.mockResolvedValueOnce({ error: "username_reserved" });
 
     render(<AccountSettings initialData={{ ...initialData }} />);
     await submitUsername("newname");
@@ -111,7 +111,7 @@ describe("AccountSettings username errors", () => {
     });
 
     const alert = await screen.findByRole("alert");
-    expect(alert.textContent).toBe("Username already taken");
+    expect(alert.textContent).toBe("This username is reserved.");
     expect(document.activeElement).toBe(alert);
 
     const username = screen.getByLabelText("Username");

--- a/apps/web/src/components/settings/__tests__/BillingSettings-error-codes.test.tsx
+++ b/apps/web/src/components/settings/__tests__/BillingSettings-error-codes.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import "@/test-utils/lingui-mock";
+
+const mocks = vi.hoisted(() => ({
+  createCheckoutSession: vi.fn(),
+  createPortalSession: vi.fn(),
+}));
+
+vi.mock("@/components/providers/SessionProvider", () => ({
+  useSession: () => ({
+    isLoggedIn: true,
+  }),
+}));
+
+vi.mock("@/lib/useLocalePath", () => ({
+  useLocalePath: () => (path: string) => `/en${path}`,
+}));
+
+vi.mock("@/lib/actions/billing", () => ({
+  createCheckoutSession: mocks.createCheckoutSession,
+  createPortalSession: mocks.createPortalSession,
+}));
+
+import { BillingSettings } from "../BillingSettings";
+
+describe("BillingSettings action errors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createCheckoutSession.mockResolvedValue({ url: null });
+    mocks.createPortalSession.mockResolvedValue({ url: null });
+  });
+
+  it("translates checkout error codes before rendering them", async () => {
+    mocks.createCheckoutSession.mockResolvedValueOnce({
+      url: null,
+      error: "payments_unavailable",
+    });
+
+    render(
+      <BillingSettings
+        planInfo={{ plan: "free", canReceiveAlerts: false }}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Upgrade to Pro" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toBe(
+        "Payments are not available yet.",
+      );
+    });
+  });
+
+  it("translates portal error codes before rendering them", async () => {
+    mocks.createPortalSession.mockResolvedValueOnce({
+      url: null,
+      error: "billing_account_not_found",
+    });
+
+    render(
+      <BillingSettings
+        planInfo={{ plan: "unlimited", canReceiveAlerts: true }}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "Manage subscription" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toBe(
+        "No billing account found.",
+      );
+    });
+  });
+});

--- a/apps/web/src/components/settings/account/PasswordSection.tsx
+++ b/apps/web/src/components/settings/account/PasswordSection.tsx
@@ -13,6 +13,7 @@ import {
   recordPasswordResetRequest,
   setPassword as setPasswordAction,
 } from "@/lib/actions/preferences";
+import { translateActionError } from "@/lib/action-error-messages";
 
 export function PasswordSection({
   hasPassword,
@@ -55,7 +56,7 @@ function SetPasswordFlow({ onSuccess }: { onSuccess: () => void }) {
 
     if (result.error) {
       setNewPasswordError("");
-      setError(result.error ?? t({ id: "settings.account.password.setError", comment: "Generic set password error", message: "Failed to set password" }));
+      setError(translateActionError(t, result.error));
       return;
     }
 
@@ -139,7 +140,7 @@ function ResetPasswordFlow({ initialCooldown }: { initialCooldown: number }) {
     }
 
     if (result.error) {
-      setError(result.error);
+      setError(translateActionError(t, result.error));
       setLoading(false);
       return;
     }

--- a/apps/web/src/components/settings/account/UsernameSection.tsx
+++ b/apps/web/src/components/settings/account/UsernameSection.tsx
@@ -11,6 +11,7 @@ import { FormField } from "@/components/ui/FormField";
 import { SuccessAlert } from "@/components/ui/SuccessAlert";
 import { authClient } from "@/lib/auth-client";
 import { renameUsername } from "@/lib/actions/preferences";
+import { translateActionError } from "@/lib/action-error-messages";
 import { isReservedUsername } from "@/lib/username";
 
 const USERNAME_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
@@ -81,7 +82,7 @@ export function UsernameSection({ currentUsername }: { currentUsername: string }
       const { error } = await renameUsername(normalized);
       if (error) {
         setLoading(false);
-        setError(error);
+        setError(translateActionError(t, error));
         return;
       }
     } catch {

--- a/apps/web/src/lib/__tests__/action-error-messages.test.ts
+++ b/apps/web/src/lib/__tests__/action-error-messages.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { translateActionError, type ActionErrorCode } from "@/lib/action-error-messages";
+
+const t = ((descriptor: { message?: string; id?: string }) =>
+  descriptor.message ?? descriptor.id ?? "") as Parameters<
+  typeof translateActionError
+>[0];
+
+describe("translateActionError", () => {
+  it.each([
+    ["not_authenticated", "Please log in and try again."],
+    ["not_found", "Not found."],
+    ["payments_unavailable", "Payments are not available yet."],
+    ["billing_account_not_found", "No billing account found."],
+    ["billing_portal_unavailable", "Billing portal is not available yet."],
+    ["password_set_failed", "Failed to set password."],
+    ["username_length", "Username must be 3-30 characters."],
+    [
+      "username_invalid_characters",
+      "Username can only use lowercase letters, numbers, and hyphens, and cannot start or end with a hyphen.",
+    ],
+    ["username_reserved", "This username is reserved."],
+    ["username_update_failed", "Could not update username."],
+    ["user_not_found", "User not found."],
+    ["invalid_status_transition", "That status change is not allowed."],
+    ["interview_round_failed", "Could not assign interview round."],
+  ] satisfies Array<[ActionErrorCode, string]>)(
+    "maps %s to a localized descriptor",
+    (code, message) => {
+      expect(translateActionError(t, code)).toBe(message);
+    },
+  );
+});

--- a/apps/web/src/lib/action-error-messages.ts
+++ b/apps/web/src/lib/action-error-messages.ts
@@ -1,0 +1,42 @@
+import type { useLingui } from "@lingui/react/macro";
+import type { BillingActionErrorCode } from "@/lib/actions/billing";
+import type { MyJobsActionErrorCode } from "@/lib/actions/my-jobs";
+import type { PreferencesActionErrorCode } from "@/lib/actions/preferences";
+
+type TFn = ReturnType<typeof useLingui>["t"];
+
+export type ActionErrorCode =
+  | BillingActionErrorCode
+  | MyJobsActionErrorCode
+  | PreferencesActionErrorCode;
+
+export function translateActionError(t: TFn, code: ActionErrorCode): string {
+  switch (code) {
+    case "not_authenticated":
+      return t({ id: "actions.error.notAuthenticated", comment: "Generic server-action error shown when a user is not logged in", message: "Please log in and try again." });
+    case "not_found":
+      return t({ id: "actions.error.notFound", comment: "Generic server-action error shown when an item cannot be found", message: "Not found." });
+    case "payments_unavailable":
+      return t({ id: "actions.error.paymentsUnavailable", comment: "Billing error when checkout is not configured yet", message: "Payments are not available yet." });
+    case "billing_account_not_found":
+      return t({ id: "actions.error.billingAccountNotFound", comment: "Billing error when the user has no billing account", message: "No billing account found." });
+    case "billing_portal_unavailable":
+      return t({ id: "actions.error.billingPortalUnavailable", comment: "Billing error when the portal is not configured yet", message: "Billing portal is not available yet." });
+    case "password_set_failed":
+      return t({ id: "actions.error.passwordSetFailed", comment: "Generic error when setting an account password fails", message: "Failed to set password." });
+    case "username_length":
+      return t({ id: "actions.error.usernameLength", comment: "Username validation error for length", message: "Username must be 3-30 characters." });
+    case "username_invalid_characters":
+      return t({ id: "actions.error.usernameInvalidCharacters", comment: "Username validation error for unsupported characters", message: "Username can only use lowercase letters, numbers, and hyphens, and cannot start or end with a hyphen." });
+    case "username_reserved":
+      return t({ id: "actions.error.usernameReserved", comment: "Username validation error when a reserved username is requested", message: "This username is reserved." });
+    case "username_update_failed":
+      return t({ id: "actions.error.usernameUpdateFailed", comment: "Generic error when updating an account username fails", message: "Could not update username." });
+    case "user_not_found":
+      return t({ id: "actions.error.userNotFound", comment: "Generic account error when the current user row is missing", message: "User not found." });
+    case "invalid_status_transition":
+      return t({ id: "actions.error.invalidStatusTransition", comment: "My Jobs error when an application status transition is not allowed", message: "That status change is not allowed." });
+    case "interview_round_failed":
+      return t({ id: "actions.error.interviewRoundFailed", comment: "My Jobs error when assigning an interview round fails", message: "Could not assign interview round." });
+  }
+}

--- a/apps/web/src/lib/actions/__tests__/password-reset-race.test.ts
+++ b/apps/web/src/lib/actions/__tests__/password-reset-race.test.ts
@@ -424,7 +424,7 @@ describe("#3165 — recordPasswordResetRequest TOCTOU", () => {
     );
 
     const r = await recordPasswordResetRequest();
-    expect(r.error).toBe("Not authenticated");
+    expect(r.error).toBe("not_authenticated");
     expect(mocks.userPreferencesTable).toHaveLength(0);
     expect(mocks.getUpsertWrites()).toBe(0);
   });

--- a/apps/web/src/lib/actions/__tests__/rename-username.test.ts
+++ b/apps/web/src/lib/actions/__tests__/rename-username.test.ts
@@ -152,7 +152,7 @@ describe("renameUsername", () => {
 
     const result = await renameUsername("newname");
 
-    expect(result).toEqual({ error: "Not authenticated" });
+    expect(result).toEqual({ error: "not_authenticated" });
     expect(mocks.updateUser).not.toHaveBeenCalled();
   });
 
@@ -161,11 +161,11 @@ describe("renameUsername", () => {
     const { renameUsername } = await import("../preferences");
 
     expect(await renameUsername("ab")).toEqual({
-      error: "Username must be 3-30 characters",
+      error: "username_length",
     });
     expect(
       await renameUsername("a".repeat(31)),
-    ).toEqual({ error: "Username must be 3-30 characters" });
+    ).toEqual({ error: "username_length" });
     expect(mocks.updateUser).not.toHaveBeenCalled();
   });
 
@@ -176,17 +176,17 @@ describe("renameUsername", () => {
     // Hyphen at the start / end is rejected by the regex (matches the
     // client-side check in `UsernameSection`).
     expect(await renameUsername("-leading-hyphen")).toEqual({
-      error: "Username has invalid characters",
+      error: "username_invalid_characters",
     });
     expect(await renameUsername("trailing-")).toEqual({
-      error: "Username has invalid characters",
+      error: "username_invalid_characters",
     });
     // Special chars that survive normalization but aren't [a-z0-9-].
     expect(await renameUsername("has space")).toEqual({
-      error: "Username has invalid characters",
+      error: "username_invalid_characters",
     });
     expect(await renameUsername("with.dot")).toEqual({
-      error: "Username has invalid characters",
+      error: "username_invalid_characters",
     });
     expect(mocks.updateUser).not.toHaveBeenCalled();
   });
@@ -196,7 +196,7 @@ describe("renameUsername", () => {
     const { renameUsername } = await import("../preferences");
 
     expect(await renameUsername("admin")).toEqual({
-      error: "Username is reserved",
+      error: "username_reserved",
     });
     expect(mocks.updateUser).not.toHaveBeenCalled();
   });
@@ -362,7 +362,7 @@ describe("renameUsername", () => {
     );
   });
 
-  it("surfaces Better Auth errors and does NOT run the fanout", async () => {
+  it("returns an opaque Better Auth error code and does NOT run the fanout", async () => {
     mocks.getSession.mockResolvedValue({ user: { id: "u4" } });
     mocks.selectQueue.push([{ username: "old", displayUsername: null }]);
     mocks.executeQueue.push([
@@ -378,7 +378,7 @@ describe("renameUsername", () => {
     const { renameUsername } = await import("../preferences");
 
     const result = await renameUsername("taken");
-    expect(result).toEqual({ error: "Username already taken" });
+    expect(result).toEqual({ error: "username_update_failed" });
     expect(mocks.updateTag).not.toHaveBeenCalled();
     expect(mocks.invalidateRedis).not.toHaveBeenCalled();
     expect(mocks.tsUpdateWatchlistField).not.toHaveBeenCalled();

--- a/apps/web/src/lib/actions/billing.ts
+++ b/apps/web/src/lib/actions/billing.ts
@@ -9,6 +9,12 @@ import { getUserPlan, PLAN_LIMITS, type PlanId } from "@/lib/plans";
 // import Stripe from "stripe";
 // const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
 
+export type BillingActionErrorCode =
+  | "not_authenticated"
+  | "payments_unavailable"
+  | "billing_account_not_found"
+  | "billing_portal_unavailable";
+
 export async function getPlanInfo(): Promise<{
   plan: PlanId;
   canReceiveAlerts: boolean;
@@ -26,10 +32,10 @@ export async function getPlanInfo(): Promise<{
 
 export async function createCheckoutSession(): Promise<{
   url: string | null;
-  error?: string;
+  error?: BillingActionErrorCode;
 }> {
   const userId = await getSessionUserId();
-  if (!userId) return { url: null, error: "Not authenticated" };
+  if (!userId) return { url: null, error: "not_authenticated" };
 
   // TODO: Uncomment when Stripe is configured
   //
@@ -44,15 +50,15 @@ export async function createCheckoutSession(): Promise<{
   //
   // return { url: session.url };
 
-  return { url: null, error: "Payments not yet available" };
+  return { url: null, error: "payments_unavailable" };
 }
 
 export async function createPortalSession(): Promise<{
   url: string | null;
-  error?: string;
+  error?: BillingActionErrorCode;
 }> {
   const userId = await getSessionUserId();
-  if (!userId) return { url: null, error: "Not authenticated" };
+  if (!userId) return { url: null, error: "not_authenticated" };
 
   const [sub] = await db
     .select({ stripeCustomerId: subscription.stripeCustomerId })
@@ -61,7 +67,7 @@ export async function createPortalSession(): Promise<{
     .limit(1);
 
   if (!sub?.stripeCustomerId) {
-    return { url: null, error: "No billing account found" };
+    return { url: null, error: "billing_account_not_found" };
   }
 
   // TODO: Uncomment when Stripe is configured
@@ -73,5 +79,5 @@ export async function createPortalSession(): Promise<{
   //
   // return { url: session.url };
 
-  return { url: null, error: "Billing portal not yet available" };
+  return { url: null, error: "billing_portal_unavailable" };
 }

--- a/apps/web/src/lib/actions/my-jobs.ts
+++ b/apps/web/src/lib/actions/my-jobs.ts
@@ -21,6 +21,12 @@ export type {
   InterviewEntry,
 } from "./my-jobs-types";
 
+export type MyJobsActionErrorCode =
+  | "not_authenticated"
+  | "not_found"
+  | "invalid_status_transition"
+  | "interview_round_failed";
+
 const LEGAL_TRANSITIONS: Record<ApplicationStatus, ApplicationStatus[]> = {
   saved: ["applied", "interviewing", "offered", "rejected"],
   applied: ["saved", "interviewing", "offered", "rejected"],
@@ -290,9 +296,9 @@ export async function getMyJobDetail(
 export async function updateJobStatus(
   savedJobId: string,
   newStatus: ApplicationStatus,
-): Promise<{ ok: boolean; error?: string }> {
+): Promise<{ ok: boolean; error?: MyJobsActionErrorCode }> {
   const userId = await getSessionUserId();
-  if (!userId) return { ok: false, error: "Not authenticated" };
+  if (!userId) return { ok: false, error: "not_authenticated" };
 
   const [row] = await db
     .select({ id: savedJob.id, status: savedJob.status })
@@ -300,14 +306,14 @@ export async function updateJobStatus(
     .where(and(eq(savedJob.id, savedJobId), eq(savedJob.userId, userId)))
     .limit(1);
 
-  if (!row) return { ok: false, error: "Not found" };
+  if (!row) return { ok: false, error: "not_found" };
 
   const currentStatus = row.status as ApplicationStatus;
   const allowed = LEGAL_TRANSITIONS[currentStatus];
   if (!allowed.includes(newStatus)) {
     return {
       ok: false,
-      error: `Cannot transition from ${currentStatus} to ${newStatus}`,
+      error: "invalid_status_transition",
     };
   }
 
@@ -356,9 +362,9 @@ export async function updateJobStatus(
 export async function addInterview(
   savedJobId: string,
   type: InterviewType,
-): Promise<{ ok: boolean; interview?: InterviewEntry; error?: string }> {
+): Promise<{ ok: boolean; interview?: InterviewEntry; error?: MyJobsActionErrorCode }> {
   const userId = await getSessionUserId();
-  if (!userId) return { ok: false, error: "Not authenticated" };
+  if (!userId) return { ok: false, error: "not_authenticated" };
 
   // Verify ownership
   const [row] = await db
@@ -367,7 +373,7 @@ export async function addInterview(
     .where(and(eq(savedJob.id, savedJobId), eq(savedJob.userId, userId)))
     .limit(1);
 
-  if (!row) return { ok: false, error: "Not found" };
+  if (!row) return { ok: false, error: "not_found" };
 
   // Atomic round-number assignment (#3160 / #3114).
   //
@@ -464,7 +470,7 @@ export async function addInterview(
       "[addInterview] failed to assign unique round after retries",
       { savedJobId, type, lastErr },
     );
-    return { ok: false, error: "Could not assign interview round" };
+    return { ok: false, error: "interview_round_failed" };
   }
 
   // Auto-transition to interviewing if currently applied
@@ -492,9 +498,9 @@ export async function addInterview(
 export async function updateInterview(
   interviewId: string,
   updates: { type?: InterviewType; scheduledAt?: string | null },
-): Promise<{ ok: boolean; error?: string }> {
+): Promise<{ ok: boolean; error?: MyJobsActionErrorCode }> {
   const userId = await getSessionUserId();
-  if (!userId) return { ok: false, error: "Not authenticated" };
+  if (!userId) return { ok: false, error: "not_authenticated" };
 
   // Verify ownership through saved_job
   const [row] = await db
@@ -504,7 +510,7 @@ export async function updateInterview(
     .where(eq(applicationInterview.id, interviewId))
     .limit(1);
 
-  if (!row || row.userId !== userId) return { ok: false, error: "Not found" };
+  if (!row || row.userId !== userId) return { ok: false, error: "not_found" };
 
   const setObj: Record<string, unknown> = {};
   if (updates.type !== undefined) setObj.type = updates.type;
@@ -528,9 +534,9 @@ export async function updateInterview(
 
 export async function deleteInterview(
   interviewId: string,
-): Promise<{ ok: boolean; error?: string }> {
+): Promise<{ ok: boolean; error?: MyJobsActionErrorCode }> {
   const userId = await getSessionUserId();
-  if (!userId) return { ok: false, error: "Not authenticated" };
+  if (!userId) return { ok: false, error: "not_authenticated" };
 
   // Get interview + saved_job info
   const [row] = await db
@@ -545,7 +551,7 @@ export async function deleteInterview(
     .where(eq(applicationInterview.id, interviewId))
     .limit(1);
 
-  if (!row || row.sjUserId !== userId) return { ok: false, error: "Not found" };
+  if (!row || row.sjUserId !== userId) return { ok: false, error: "not_found" };
 
   // Delete the interview
   await db
@@ -587,9 +593,9 @@ export async function updateSalaryOverride(
     currency?: string | null;
     period?: string | null;
   },
-): Promise<{ ok: boolean; error?: string }> {
+): Promise<{ ok: boolean; error?: MyJobsActionErrorCode }> {
   const userId = await getSessionUserId();
-  if (!userId) return { ok: false, error: "Not authenticated" };
+  if (!userId) return { ok: false, error: "not_authenticated" };
 
   const [row] = await db
     .select({ id: savedJob.id })
@@ -597,7 +603,7 @@ export async function updateSalaryOverride(
     .where(and(eq(savedJob.id, savedJobId), eq(savedJob.userId, userId)))
     .limit(1);
 
-  if (!row) return { ok: false, error: "Not found" };
+  if (!row) return { ok: false, error: "not_found" };
 
   await db
     .update(savedJob)

--- a/apps/web/src/lib/actions/preferences.ts
+++ b/apps/web/src/lib/actions/preferences.ts
@@ -25,6 +25,15 @@ import type { WatchlistFilters } from "@/lib/actions/watchlists";
 
 const PASSWORD_RESET_COOLDOWN_SECONDS = 60;
 
+export type PreferencesActionErrorCode =
+  | "not_authenticated"
+  | "password_set_failed"
+  | "username_length"
+  | "username_invalid_characters"
+  | "username_reserved"
+  | "username_update_failed"
+  | "user_not_found";
+
 /**
  * jobLanguages flows into Typesense `filter_by` strings and Postgres array
  * literals via raw interpolation, so we whitelist at the write boundary.
@@ -346,9 +355,9 @@ export async function getPasswordResetCooldown(): Promise<number> {
  * here, because doing so would re-open the same TOCTOU window the
  * single-statement upsert exists to close.
  */
-export async function recordPasswordResetRequest(): Promise<{ error?: string; cooldown?: number }> {
+export async function recordPasswordResetRequest(): Promise<{ error?: PreferencesActionErrorCode; cooldown?: number }> {
   const session = await getSession();
-  if (!session) return { error: "Not authenticated" };
+  if (!session) return { error: "not_authenticated" };
 
   // Single-statement upsert + cooldown gate. The `WHERE` clause on the
   // `DO UPDATE` branch is evaluated atomically inside the upsert; if it
@@ -382,9 +391,9 @@ export async function recordPasswordResetRequest(): Promise<{ error?: string; co
   return { cooldown: Math.max(1, remaining) };
 }
 
-export async function setPassword(newPassword: string): Promise<{ error?: string }> {
+export async function setPassword(newPassword: string): Promise<{ error?: PreferencesActionErrorCode }> {
   const session = await getSession();
-  if (!session) return { error: "Not authenticated" };
+  if (!session) return { error: "not_authenticated" };
 
   try {
     await auth.api.setPassword({
@@ -392,9 +401,8 @@ export async function setPassword(newPassword: string): Promise<{ error?: string
       headers: await headers(),
     });
     return {};
-  } catch (e: unknown) {
-    const message = e instanceof Error ? e.message : "Failed to set password";
-    return { error: message };
+  } catch {
+    return { error: "password_set_failed" };
   }
 }
 
@@ -435,22 +443,22 @@ const USERNAME_RE = /^[a-z0-9][a-z0-9-]*[a-z0-9]$/;
  */
 export async function renameUsername(
   newUsername: string,
-): Promise<{ error?: string }> {
+): Promise<{ error?: PreferencesActionErrorCode }> {
   const currentSession = await getSession();
-  if (!currentSession) return { error: "Not authenticated" };
+  if (!currentSession) return { error: "not_authenticated" };
   const userId = currentSession.user.id;
 
   // Mirror the client-side validation in `UsernameSection` so a stray
   // direct call to this server action can't bypass it.
   const normalized = newUsername.toLowerCase().trim();
   if (normalized.length < 3 || normalized.length > 30) {
-    return { error: "Username must be 3-30 characters" };
+    return { error: "username_length" };
   }
   if (!USERNAME_RE.test(normalized)) {
-    return { error: "Username has invalid characters" };
+    return { error: "username_invalid_characters" };
   }
   if (isReservedUsername(normalized)) {
-    return { error: "Username is reserved" };
+    return { error: "username_reserved" };
   }
 
   // Snapshot the pre-rename state BEFORE handing off to Better Auth.
@@ -466,7 +474,7 @@ export async function renameUsername(
     .from(user)
     .where(eq(user.id, userId))
     .limit(1);
-  if (!oldUserRow) return { error: "User not found" };
+  if (!oldUserRow) return { error: "user_not_found" };
 
   if (oldUserRow.username === normalized) return {}; // no-op rename
 
@@ -519,16 +527,14 @@ export async function renameUsername(
 
   // Delegate the actual DB write + cookie re-sign to Better Auth so the
   // username plugin's uniqueness check and the `usernameValidator`
-  // configured in `auth.ts` run authoritatively. Failures (taken, format,
-  // etc.) surface as APIErrors with messages we forward to the caller.
+  // configured in `auth.ts` run authoritatively.
   try {
     await auth.api.updateUser({
       body: { username: normalized },
       headers: await headers(),
     });
-  } catch (e: unknown) {
-    const message = e instanceof Error ? e.message : "Failed to update username";
-    return { error: message };
+  } catch {
+    return { error: "username_update_failed" };
   }
 
   // ── Fanout below this point — best-effort, never rollback the rename ──


### PR DESCRIPTION
## Summary
- replace user-facing English strings returned by billing, preferences, and my-jobs server actions with typed opaque error codes
- add a shared Lingui-backed `translateActionError` helper and wire settings callers to translate before rendering
- add focused coverage for the mapping plus billing/account action-error rendering, and update action tests to assert codes
- add localized catalog entries for the new action-error messages

Closes #3141

## Reproduction
- source probe on current main found raw English `error` returns in `apps/web/src/lib/actions/billing.ts`, `preferences.ts`, and `my-jobs.ts` that were rendered by settings client components
- read-only production baseline: `https://jseek.co/fr/settings/account` returned HTTP 200 with no `application-error`, `NEXT_HTTP_ERROR_FALLBACK`, or `digest` markers

## Validation
- `../../node_modules/.pnpm/node_modules/.bin/vitest run src/lib/__tests__/action-error-messages.test.ts src/components/settings/__tests__/BillingSettings-error-codes.test.tsx src/components/settings/__tests__/AccountSettings-username-error.test.tsx src/lib/actions/__tests__/rename-username.test.ts src/lib/actions/__tests__/password-reset-race.test.ts src/lib/actions/__tests__/my-jobs-interview-race.test.ts --config vitest.config.ts`
- `../../node_modules/.pnpm/node_modules/.bin/eslint src/lib/action-error-messages.ts src/lib/__tests__/action-error-messages.test.ts src/components/settings/BillingSettings.tsx src/components/settings/__tests__/BillingSettings-error-codes.test.tsx src/components/settings/account/PasswordSection.tsx src/components/settings/account/UsernameSection.tsx src/lib/actions/billing.ts src/lib/actions/preferences.ts src/lib/actions/my-jobs.ts src/lib/actions/__tests__/rename-username.test.ts src/lib/actions/__tests__/password-reset-race.test.ts src/components/settings/__tests__/AccountSettings-username-error.test.tsx`
- `../../node_modules/.pnpm/node_modules/.bin/next typegen && ../../node_modules/.pnpm/node_modules/.bin/tsc` in `apps/web`
- `../../node_modules/.pnpm/node_modules/.bin/tsc` in `packages/mcp-server`
- `bash scripts/check-i18n-coverage.sh`
- `../../node_modules/.pnpm/node_modules/.bin/lingui compile`
- `git diff --check`
- full web suite before final rebase: `../../node_modules/.pnpm/node_modules/.bin/vitest run --config vitest.config.ts` (167 files / 1355 tests)

## Notes
- `pnpm --dir apps/web extract` is currently blocked locally by the existing pnpm minimum-release-age policy on new Lingui/Vitest lockfile entries. Running the linked Lingui extractor directly also exposes an unrelated existing duplicate default translation for `search.filters.removeLocation` in `filter-pills-readonly.tsx`; this PR does not broaden into that issue.
