### PR TITLE
Fix mobile job detail dialog accessibility

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
@@ -8,6 +8,7 @@ import { timeAgoShort } from "@/lib/time";
 import { SaveButton } from "@/components/search/save-button";
 import { SearchUnavailable } from "@/components/search/search-unavailable";
 import { JobDetailPanel } from "@/components/search/job-detail-dialog";
+import { MobileJobDetailDialog } from "@/components/search/mobile-job-detail-dialog";
 import { SearchToolbar } from "@/components/search/search-toolbar";
 import { runGetCompanyPostings } from "@/lib/search/search-runner";
 import { useClearTypesenseOnAuthChange } from "@/lib/search/use-clear-typesense-on-auth-change";
@@ -680,17 +681,7 @@ export function CompanyPage({
           <div className="sticky top-[4.5rem] z-40 hidden h-[calc(100vh-5.5rem)] w-[420px] shrink-0 lg:block">
             <JobDetailPanel postingId={showPostingId} onClose={handleClosePosting} />
           </div>
-          {/* Small screens: full-height slide-out overlay with dim
-              backdrop. Matches explore / my-jobs / watchlist patterns
-              so the job detail card behaves identically across pages. */}
-          <div className="fixed inset-0 z-50 bg-black/40 lg:hidden" onClick={handleClosePosting}>
-            <div
-              className="absolute inset-y-0 right-0 w-full max-w-lg bg-surface shadow-xl"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <JobDetailPanel postingId={showPostingId} onClose={handleClosePosting} />
-            </div>
-          </div>
+          <MobileJobDetailDialog postingId={showPostingId} onClose={handleClosePosting} />
         </>
       )}
     </div>

--- a/apps/web/app/[lang]/(app)/explore/search-page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/search-page.tsx
@@ -10,6 +10,7 @@ import { SearchUnavailable } from "@/components/search/search-unavailable";
 import { ZeroResults } from "@/components/search/zero-results";
 import { SkeletonCards } from "@/components/search/skeleton-card";
 import { JobDetailPanel } from "@/components/search/job-detail-dialog";
+import { MobileJobDetailDialog } from "@/components/search/mobile-job-detail-dialog";
 import { SearchToolbar } from "@/components/search/search-toolbar";
 import { useSalaryRates } from "@/components/providers/SalaryDisplayProvider";
 import { runSearchJobs, runListTopCompanies } from "@/lib/search/search-runner";
@@ -886,15 +887,7 @@ export function SearchPage({
           >
             <JobDetailPanel postingId={showPostingId} onClose={handleClosePosting} />
           </div>
-          {/* On small screens, show as an overlay */}
-          <div className="fixed inset-0 z-50 bg-black/40 lg:hidden" onClick={handleClosePosting}>
-            <div
-              className="absolute inset-y-0 right-0 w-full max-w-lg bg-surface shadow-xl"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <JobDetailPanel postingId={showPostingId} onClose={handleClosePosting} />
-            </div>
-          </div>
+          <MobileJobDetailDialog postingId={showPostingId} onClose={handleClosePosting} />
         </>
       )}
     </div>

--- a/apps/web/app/[lang]/(app)/my-jobs/my-jobs-page.tsx
+++ b/apps/web/app/[lang]/(app)/my-jobs/my-jobs-page.tsx
@@ -17,6 +17,7 @@ import { InfiniteScrollSentinel } from "@/components/InfiniteScrollSentinel";
 import { SortFilterBar, type SortBy, type GroupBy } from "@/components/my-jobs/sort-filter-bar";
 import { MyJobRow } from "@/components/my-jobs/my-job-row";
 import { JobDetailPanel } from "@/components/search/job-detail-dialog";
+import { MobileJobDetailDialog } from "@/components/search/mobile-job-detail-dialog";
 import { useSavedJobs } from "@/components/providers/SavedJobsProvider";
 
 const BATCH = 20;
@@ -349,20 +350,10 @@ export function MyJobsPage({
               onClose={handleCloseDetail}
             />
           </div>
-          <div
-            className="fixed inset-0 z-50 bg-black/40 lg:hidden"
-            onClick={handleCloseDetail}
-          >
-            <div
-              className="absolute inset-y-0 right-0 w-full max-w-lg bg-surface shadow-xl"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <JobDetailPanel
-                postingId={selectedJob.postingId}
-                onClose={handleCloseDetail}
-              />
-            </div>
-          </div>
+          <MobileJobDetailDialog
+            postingId={selectedJob.postingId}
+            onClose={handleCloseDetail}
+          />
         </>
       )}
     </div>

--- a/apps/web/src/components/search/__tests__/mobile-job-detail-dialog.test.tsx
+++ b/apps/web/src/components/search/__tests__/mobile-job-detail-dialog.test.tsx
@@ -1,0 +1,152 @@
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { useState } from "react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import "@/test-utils/lingui-mock";
+
+vi.mock("@/components/search/job-detail-dialog", () => ({
+  JobDetailPanel: ({ onClose, postingId }: { onClose: () => void; postingId: string | null }) => (
+    <div data-testid="job-detail-panel" data-posting-id={postingId ?? ""}>
+      <button type="button" onClick={onClose}>
+        Close job details
+      </button>
+      <button type="button">Focusable detail action</button>
+    </div>
+  ),
+}));
+
+import { MobileJobDetailDialog } from "../mobile-job-detail-dialog";
+
+const webRoot = resolve(__dirname, "../../../..");
+
+const mobileOverlayCallsites = [
+  "app/[lang]/(app)/explore/search-page.tsx",
+  "app/[lang]/(app)/company/[slug]/company-page.tsx",
+  "src/components/watchlist/watchlist-job-list.tsx",
+  "app/[lang]/(app)/my-jobs/my-jobs-page.tsx",
+] as const;
+
+function installMatchMedia(matches: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    configurable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
+function DialogHarness() {
+  const [postingId, setPostingId] = useState<string | null>("posting-1");
+
+  return (
+    <MobileJobDetailDialog
+      postingId={postingId}
+      onClose={() => setPostingId(null)}
+    />
+  );
+}
+
+function TriggerHarness() {
+  const [postingId, setPostingId] = useState<string | null>(null);
+
+  return (
+    <>
+      <button type="button" onClick={() => setPostingId("posting-1")}>
+        Open posting
+      </button>
+      <button type="button">Outside action</button>
+      <MobileJobDetailDialog
+        postingId={postingId}
+        onClose={() => setPostingId(null)}
+      />
+    </>
+  );
+}
+
+describe("MobileJobDetailDialog", () => {
+  beforeEach(() => {
+    installMatchMedia(true);
+  });
+
+  it("renders the mobile job details as a named modal dialog", async () => {
+    render(<MobileJobDetailDialog postingId="posting-1" onClose={() => {}} />);
+
+    const dialog = await screen.findByRole("dialog", { name: /job details/i });
+    expect(dialog.getAttribute("aria-modal")).toBe("true");
+    expect(dialog.getAttribute("aria-labelledby")).toBeTruthy();
+    expect(screen.getByTestId("job-detail-panel").getAttribute("data-posting-id")).toBe("posting-1");
+  });
+
+  it("does not mount the modal shell outside the mobile breakpoint", async () => {
+    installMatchMedia(false);
+
+    render(<MobileJobDetailDialog postingId="posting-1" onClose={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(screen.queryByTestId("job-detail-panel")).toBeNull();
+  });
+
+  it("closes from Escape through Radix dialog behavior", async () => {
+    render(<DialogHarness />);
+
+    const dialog = await screen.findByRole("dialog", { name: /job details/i });
+    fireEvent.keyDown(dialog, { key: "Escape", code: "Escape" });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+  });
+
+  it("keeps tab focus inside the dialog and restores focus after Escape", async () => {
+    const user = userEvent.setup();
+    render(<TriggerHarness />);
+
+    const opener = screen.getByRole("button", { name: "Open posting" });
+    opener.focus();
+    expect(document.activeElement).toBe(opener);
+    await user.keyboard("{Enter}");
+
+    const dialog = await screen.findByRole("dialog", { name: /job details/i });
+    await waitFor(() => {
+      expect(dialog.contains(document.activeElement)).toBe(true);
+    });
+
+    await user.tab();
+    expect(dialog.contains(document.activeElement)).toBe(true);
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+    expect(document.activeElement).toBe(opener);
+  });
+});
+
+describe("mobile job-detail overlay source hygiene (#3161)", () => {
+  it("keeps all mobile job-detail call sites on the shared Radix wrapper", () => {
+    const sources = mobileOverlayCallsites.map((relPath) => readFileSync(join(webRoot, relPath), "utf8"));
+
+    for (const source of sources) {
+      expect(source).not.toContain("fixed inset-0 z-50 bg-black/40 lg:hidden");
+      expect(source).toContain("MobileJobDetailDialog");
+    }
+
+    expect(
+      sources.reduce((count, source) => count + (source.match(/<MobileJobDetailDialog\b/g)?.length ?? 0), 0),
+    ).toBe(4);
+  });
+});

--- a/apps/web/src/components/search/mobile-job-detail-dialog.tsx
+++ b/apps/web/src/components/search/mobile-job-detail-dialog.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Trans } from "@lingui/react/macro";
+import * as Dialog from "@radix-ui/react-dialog";
+
+import { JobDetailPanel } from "@/components/search/job-detail-dialog";
+
+interface MobileJobDetailDialogProps {
+  postingId: string | null;
+  onClose: () => void;
+}
+
+export function MobileJobDetailDialog({
+  postingId,
+  onClose,
+}: MobileJobDetailDialogProps) {
+  const isMobile = useMobileDetailBreakpoint();
+  const restoreFocusElementRef = useRef<HTMLElement | null>(null);
+
+  if (!postingId || !isMobile) return null;
+
+  return (
+    <Dialog.Root
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=open]:fade-in-0 lg:hidden" />
+        <Dialog.Content
+          aria-describedby={undefined}
+          aria-modal="true"
+          className="fixed inset-y-0 right-0 z-50 w-full max-w-lg bg-surface shadow-xl data-[state=open]:animate-in data-[state=open]:slide-in-from-right-4 lg:hidden"
+          onOpenAutoFocus={() => {
+            if (typeof document === "undefined") return;
+
+            const activeElement = document.activeElement;
+            restoreFocusElementRef.current = activeElement instanceof HTMLElement ? activeElement : null;
+          }}
+          onCloseAutoFocus={(event) => {
+            const restoreTarget = restoreFocusElementRef.current;
+            restoreFocusElementRef.current = null;
+
+            if (!restoreTarget?.isConnected) return;
+
+            event.preventDefault();
+            restoreTarget.focus();
+          }}
+        >
+          <Dialog.Title className="sr-only">
+            <Trans id="search.detail.title" comment="Job detail panel title">
+              Job Details
+            </Trans>
+          </Dialog.Title>
+          <JobDetailPanel postingId={postingId} onClose={onClose} />
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+function useMobileDetailBreakpoint() {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    if (!window.matchMedia) return;
+
+    const query = window.matchMedia("(max-width: 1023px)");
+    const update = () => setIsMobile(query.matches);
+    update();
+    query.addEventListener("change", update);
+    return () => query.removeEventListener("change", update);
+  }, []);
+
+  return isMobile;
+}

--- a/apps/web/src/components/watchlist/watchlist-job-list.tsx
+++ b/apps/web/src/components/watchlist/watchlist-job-list.tsx
@@ -15,6 +15,7 @@ import { useClearTypesenseOnAuthChange } from "@/lib/search/use-clear-typesense-
 import { useSession } from "@/components/providers/SessionProvider";
 import { useSavedJobs } from "@/components/providers/SavedJobsProvider";
 import { JobDetailPanel } from "@/components/search/job-detail-dialog";
+import { MobileJobDetailDialog } from "@/components/search/mobile-job-detail-dialog";
 import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
 import { usePaginatedLoadMore } from "@/lib/use-paginated-load-more";
 import { InfiniteScrollSentinel } from "@/components/InfiniteScrollSentinel";
@@ -301,14 +302,7 @@ export function WatchlistJobList({
           >
             <JobDetailPanel postingId={showPostingId} onClose={handleClosePosting} />
           </div>
-          <div className="fixed inset-0 z-50 bg-black/40 lg:hidden" onClick={handleClosePosting}>
-            <div
-              className="absolute inset-y-0 right-0 w-full max-w-lg bg-surface shadow-xl"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <JobDetailPanel postingId={showPostingId} onClose={handleClosePosting} />
-            </div>
-          </div>
+          <MobileJobDetailDialog postingId={showPostingId} onClose={handleClosePosting} />
         </>
       )}
     </div>


### PR DESCRIPTION
Closes #3161.

## Summary
- replace bespoke mobile job-detail overlays with a shared Radix Dialog wrapper
- keep desktop side panels unchanged
- cover the shared mobile dialog semantics, Escape close, focus trap/restoration, and source guard against raw overlay copies

## Reproduction
- Production mobile probe on `/en/colophongroup/big-tech-jobs-in-switzerland` opened a job row and found a fixed overlay with `dialogCount: 0`, no `aria-modal`, focus on `body`, and Escape left `?show=...` open.

## Validation
- `/Users/Viktor/jobseek/apps/web/node_modules/.bin/vitest run src/components/search/__tests__/mobile-job-detail-dialog.test.tsx`
- `/Users/Viktor/jobseek/apps/web/node_modules/.bin/vitest run src/components/watchlist/__tests__/watchlist-job-list-nested-buttons.test.tsx src/components/watchlist/__tests__/watchlist-job-list-scroll-stability.test.tsx`
- `/Users/Viktor/jobseek/apps/web/node_modules/.bin/vitest run app/[lang]/(app)/explore/__tests__/search-page-heading.test.tsx`
- edited-file ESLint
- `NEXT_TELEMETRY_DISABLED=1 /Users/Viktor/jobseek/apps/web/node_modules/.bin/next typegen && /Users/Viktor/jobseek/apps/web/node_modules/.bin/tsc --noEmit`
- `git diff --check`
- source guard: no raw `fixed inset-0 z-50 bg-black/40 lg:hidden` job-detail overlays remain outside tests

Note: a verifier subagent was spawned for the adjacent company-page copy, but the agent hit the account usage limit before work. The company page had the same comment-backed mirrored overlay pattern, so this PR updates it with the same shared wrapper instead of leaving a fourth copy behind.