### PR TITLE
Fix interview deletion renumbering

### DIFF
--- a/apps/web/src/lib/actions/__tests__/my-jobs-delete-interview-transaction.test.ts
+++ b/apps/web/src/lib/actions/__tests__/my-jobs-delete-interview-transaction.test.ts
@@ -1,0 +1,249 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * #3075 — `deleteInterview` used to delete the target row, select all
+ * remaining interviews, then issue one UPDATE per row to compact
+ * `round`.
+ *
+ * That shape is both slower (N sequential writes) and non-atomic: a
+ * failed mid-loop update could leave gaps, and the "last interview
+ * deleted" status downgrade happened after the renumber work.
+ *
+ * The fixed action does all writes in one `db.transaction`, compacts
+ * with a single row_number() CTE, and only updates saved_job.status
+ * after the same transaction has proven no interviews remain.
+ */
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => {
+  const savedJob = {
+    __t: "savedJob",
+    id: { __c: "savedJob.id" },
+    userId: { __c: "savedJob.userId" },
+    status: { __c: "savedJob.status" },
+    statusChangedAt: { __c: "savedJob.statusChangedAt" },
+  };
+  const applicationInterview = {
+    __t: "applicationInterview",
+    id: { __c: "applicationInterview.id" },
+    savedJobId: { __c: "applicationInterview.savedJobId" },
+    round: { __c: "applicationInterview.round" },
+    createdAt: { __c: "applicationInterview.createdAt" },
+  };
+
+  type OwnerRow = {
+    savedJobId: string;
+    sjUserId: string;
+    sjStatus: string;
+  };
+
+  let ownerRows: OwnerRow[] = [];
+  let remainingCount = 0;
+
+  const calls = {
+    transactions: 0,
+    deletes: [] as unknown[],
+    executes: [] as string[],
+    updates: [] as Array<{ table: unknown; values: Record<string, unknown> }>,
+  };
+
+  const getSessionUserId = vi.fn();
+
+  const reset = () => {
+    ownerRows = [];
+    remainingCount = 0;
+    calls.transactions = 0;
+    calls.deletes = [];
+    calls.executes = [];
+    calls.updates = [];
+    getSessionUserId.mockReset();
+  };
+
+  const select = () => {
+    const chain = {
+      from: () => chain,
+      innerJoin: () => chain,
+      where: () => chain,
+      limit: async () => ownerRows,
+    };
+    return chain;
+  };
+
+  const deleteFrom = (table: unknown) => {
+    const chain = {
+      where: async () => {
+        calls.deletes.push(table);
+      },
+    };
+    return chain;
+  };
+
+  const update = (table: unknown) => {
+    let values: Record<string, unknown> = {};
+    const chain = {
+      set: (nextValues: Record<string, unknown>) => {
+        values = nextValues;
+        return chain;
+      },
+      where: async () => {
+        calls.updates.push({ table, values });
+      },
+    };
+    return chain;
+  };
+
+  const execute = async (sqlObj: unknown) => {
+    const text = (sqlObj as { text?: string }).text ?? "";
+    calls.executes.push(text);
+    if (/remaining_count/i.test(text)) {
+      return [{ remaining_count: remainingCount }];
+    }
+    return [];
+  };
+
+  const tx = {
+    select,
+    delete: deleteFrom,
+    update,
+    execute,
+  };
+
+  return {
+    savedJob,
+    applicationInterview,
+    calls,
+    getSessionUserId,
+    reset,
+    setOwnerRow: (row: OwnerRow | null) => {
+      ownerRows = row ? [row] : [];
+    },
+    setRemainingCount: (count: number) => {
+      remainingCount = count;
+    },
+    db: {
+      transaction: async <T>(fn: (transaction: typeof tx) => Promise<T>) => {
+        calls.transactions += 1;
+        return fn(tx);
+      },
+    },
+  };
+});
+
+vi.mock("@/lib/sessionCache", () => ({
+  getSessionUserId: mocks.getSessionUserId,
+}));
+
+vi.mock("@/db/schema", () => ({
+  savedJob: mocks.savedJob,
+  applicationInterview: mocks.applicationInterview,
+  jobPosting: {},
+  company: {},
+}));
+
+vi.mock("@/db", () => ({
+  db: mocks.db,
+}));
+
+vi.mock("drizzle-orm", () => {
+  const sqlFn = (
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ): { text: string; values: unknown[] } => ({
+    text: Array.from(strings).join("?"),
+    values,
+  });
+  sqlFn.join = (..._args: unknown[]) => ({ text: "join", values: [] });
+
+  return {
+    eq: (..._args: unknown[]) => ({ _isEq: true }),
+    and: (..._args: unknown[]) => ({ _isAnd: true }),
+    asc: (..._args: unknown[]) => ({ _isAsc: true }),
+    desc: (..._args: unknown[]) => ({ _isDesc: true }),
+    count: (..._args: unknown[]) => ({ _isCount: true }),
+    inArray: (..._args: unknown[]) => ({ _isInArray: true }),
+    sql: sqlFn,
+  };
+});
+
+import { deleteInterview } from "../my-jobs";
+
+beforeEach(() => {
+  mocks.reset();
+  mocks.getSessionUserId.mockResolvedValue("user-1");
+});
+
+describe("#3075 — deleteInterview renumbers atomically", () => {
+  it("uses one transaction and a row_number CTE instead of per-row interview updates", async () => {
+    mocks.setOwnerRow({
+      savedJobId: "00000000-0000-0000-0000-000000000001",
+      sjUserId: "user-1",
+      sjStatus: "interviewing",
+    });
+    mocks.setRemainingCount(2);
+
+    const result = await deleteInterview(
+      "00000000-0000-0000-0000-000000000099",
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(mocks.calls.transactions).toBe(1);
+    expect(mocks.calls.deletes).toEqual([mocks.applicationInterview]);
+
+    const renumberSql = mocks.calls.executes.find((text) =>
+      /row_number\(\)/i.test(text),
+    );
+    expect(renumberSql).toMatch(/WITH ordered AS/i);
+    expect(renumberSql).toMatch(/UPDATE application_interview AS ai/i);
+    expect(renumberSql).toMatch(/remaining_count/i);
+
+    expect(
+      mocks.calls.updates.filter(
+        (call) => call.table === mocks.applicationInterview,
+      ),
+    ).toHaveLength(0);
+    expect(
+      mocks.calls.updates.filter((call) => call.table === mocks.savedJob),
+    ).toHaveLength(0);
+  });
+
+  it("downgrades an interviewing saved job when the deleted row was the last interview", async () => {
+    mocks.setOwnerRow({
+      savedJobId: "00000000-0000-0000-0000-000000000001",
+      sjUserId: "user-1",
+      sjStatus: "interviewing",
+    });
+    mocks.setRemainingCount(0);
+
+    const result = await deleteInterview(
+      "00000000-0000-0000-0000-000000000099",
+    );
+
+    expect(result).toEqual({ ok: true });
+    expect(mocks.calls.transactions).toBe(1);
+    expect(mocks.calls.updates).toHaveLength(1);
+    expect(mocks.calls.updates[0].table).toBe(mocks.savedJob);
+    expect(mocks.calls.updates[0].values).toMatchObject({
+      status: "applied",
+    });
+    expect(mocks.calls.updates[0].values.statusChangedAt).toBeInstanceOf(Date);
+  });
+
+  it("returns not_found without mutating when the interview is absent or owned by another user", async () => {
+    mocks.setOwnerRow({
+      savedJobId: "00000000-0000-0000-0000-000000000001",
+      sjUserId: "user-2",
+      sjStatus: "interviewing",
+    });
+
+    const result = await deleteInterview(
+      "00000000-0000-0000-0000-000000000099",
+    );
+
+    expect(result).toEqual({ ok: false, error: "not_found" });
+    expect(mocks.calls.transactions).toBe(1);
+    expect(mocks.calls.deletes).toHaveLength(0);
+    expect(mocks.calls.executes).toHaveLength(0);
+    expect(mocks.calls.updates).toHaveLength(0);
+  });
+});

--- a/apps/web/src/lib/actions/my-jobs.ts
+++ b/apps/web/src/lib/actions/my-jobs.ts
@@ -538,49 +538,69 @@ export async function deleteInterview(
   const userId = await getSessionUserId();
   if (!userId) return { ok: false, error: "not_authenticated" };
 
-  // Get interview + saved_job info
-  const [row] = await db
-    .select({
-      savedJobId: applicationInterview.savedJobId,
-      round: applicationInterview.round,
-      sjUserId: savedJob.userId,
-      sjStatus: savedJob.status,
-    })
-    .from(applicationInterview)
-    .innerJoin(savedJob, eq(applicationInterview.savedJobId, savedJob.id))
-    .where(eq(applicationInterview.id, interviewId))
-    .limit(1);
+  return db.transaction(async (tx) => {
+    const [row] = await tx
+      .select({
+        savedJobId: applicationInterview.savedJobId,
+        sjUserId: savedJob.userId,
+        sjStatus: savedJob.status,
+      })
+      .from(applicationInterview)
+      .innerJoin(savedJob, eq(applicationInterview.savedJobId, savedJob.id))
+      .where(eq(applicationInterview.id, interviewId))
+      .limit(1);
 
-  if (!row || row.sjUserId !== userId) return { ok: false, error: "not_found" };
+    if (!row || row.sjUserId !== userId) {
+      return { ok: false, error: "not_found" };
+    }
 
-  // Delete the interview
-  await db
-    .delete(applicationInterview)
-    .where(eq(applicationInterview.id, interviewId));
+    await tx
+      .delete(applicationInterview)
+      .where(eq(applicationInterview.id, interviewId));
 
-  // Renumber remaining rounds
-  const remaining = await db
-    .select({ id: applicationInterview.id })
-    .from(applicationInterview)
-    .where(eq(applicationInterview.savedJobId, row.savedJobId))
-    .orderBy(asc(applicationInterview.round));
+    // Avoid per-row UPDATEs and avoid transient collisions with the
+    // UNIQUE (saved_job_id, round) index while compacting rounds.
+    await tx.execute(sql`
+      UPDATE application_interview
+      SET round = -round
+      WHERE saved_job_id = ${row.savedJobId}::uuid
+    `);
 
-  for (let i = 0; i < remaining.length; i++) {
-    await db
-      .update(applicationInterview)
-      .set({ round: i + 1 })
-      .where(eq(applicationInterview.id, remaining[i].id));
-  }
+    const remainingRows = await tx.execute<{ remaining_count: number }>(sql`
+      WITH ordered AS (
+        SELECT
+          id,
+          (row_number() OVER (
+            ORDER BY abs(round) ASC, created_at ASC, id ASC
+          ))::smallint AS new_round
+        FROM application_interview
+        WHERE saved_job_id = ${row.savedJobId}::uuid
+      ),
+      renumbered AS (
+        UPDATE application_interview AS ai
+        SET round = ordered.new_round
+        FROM ordered
+        WHERE ai.id = ordered.id
+          AND ai.round IS DISTINCT FROM ordered.new_round
+        RETURNING ai.id
+      )
+      SELECT count(*)::int AS remaining_count
+      FROM ordered
+    `);
 
-  // If no interviews remain and status is interviewing, transition back
-  if (remaining.length === 0 && row.sjStatus === "interviewing") {
-    await db
-      .update(savedJob)
-      .set({ status: "applied", statusChangedAt: new Date() })
-      .where(eq(savedJob.id, row.savedJobId));
-  }
+    const remainingCount =
+      (remainingRows as unknown as ArrayLike<{ remaining_count: number }>)[0]
+        ?.remaining_count ?? 0;
 
-  return { ok: true };
+    if (remainingCount === 0 && row.sjStatus === "interviewing") {
+      await tx
+        .update(savedJob)
+        .set({ status: "applied", statusChangedAt: new Date() })
+        .where(eq(savedJob.id, row.savedJobId));
+    }
+
+    return { ok: true };
+  });
 }
 
 // ── updateSalaryOverride ─────────────────────────────────────────────


### PR DESCRIPTION
Fixes #3075

## Summary
- Wrap deleteInterview ownership check, delete, renumber, and status downgrade in one transaction
- Replace N sequential round UPDATEs with a unique-index-safe temporary shift plus row_number() CTE compaction
- Add focused regression coverage proving the action uses the transactional CTE path and does not update application_interview rows one-by-one

## Reproduction
- Source-level reproduction on current main: deleteInterview deleted the target row, selected all remaining interviews, looped over remaining rows issuing one UPDATE each, and downgraded saved_job.status outside a transaction
- Read-only production baseline: https://jseek.co/en/my-jobs returned HTTP 200 with expected unauthenticated UI and no app-error markers

## Validation
- Focused/neighboring my-jobs Vitest: 12 passed
- Edited-file ESLint
- Next typegen
- Web tsc after local MCP package build
- Full web Vitest: 174 files / 1376 tests passed
- git diff --check

## Notes
- Local pnpm script invocations are currently gated by the runtime minimum-release-age policy for recent lockfile entries; validation used a frozen worktree install with the release-age override and direct local binaries. No lockfile changes were made.