### PR TITLE
Use shared pagination for watchlist and company cards

### DIFF
--- a/apps/web/src/components/search/__tests__/company-card-posting-order.test.tsx
+++ b/apps/web/src/components/search/__tests__/company-card-posting-order.test.tsx
@@ -1,4 +1,4 @@
-import { act, render } from "@testing-library/react";
+import { act, render, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "@/test-utils/lingui-mock";
 import type { SearchResultCompany, SearchResultPosting } from "@/lib/search";
@@ -6,6 +6,7 @@ import type { SearchResultCompany, SearchResultPosting } from "@/lib/search";
 const mocks = vi.hoisted(() => ({
   getMorePostings: vi.fn(),
   load: undefined as undefined | (() => Promise<void>),
+  hasMore: undefined as boolean | undefined,
 }));
 
 vi.mock("next/navigation", () => ({
@@ -53,8 +54,9 @@ vi.mock("@/components/ui/scroll-fade", () => ({
 }));
 
 vi.mock("@/lib/use-infinite-scroll", () => ({
-  useInfiniteScroll: ({ load }: { load: () => Promise<void> }) => {
+  useInfiniteScroll: ({ hasMore, load }: { hasMore: boolean; load: () => Promise<void> }) => {
     mocks.load = load;
+    mocks.hasMore = hasMore;
     return { sentinelRef: { current: null }, isLoading: false };
   },
 }));
@@ -125,6 +127,7 @@ function visiblePostingIds(container: HTMLElement): string[] {
 describe("CompanyCard posting order", () => {
   beforeEach(() => {
     mocks.load = undefined;
+    mocks.hasMore = undefined;
     mocks.getMorePostings.mockReset();
   });
 
@@ -160,6 +163,36 @@ describe("CompanyCard posting order", () => {
       "visible-older",
       "visible-oldest",
     ]);
+  });
+
+  it("stops infinite scroll when a full loaded page contains only duplicate posting ids", async () => {
+    const initialPostings = Array.from({ length: 20 }, (_, index) =>
+      posting(
+        `visible-${index}`,
+        `Visible role ${index}`,
+        `2026-06-22T11:${String(59 - index).padStart(2, "0")}:00.000Z`,
+      ),
+    );
+    const { container } = renderCard(initialPostings);
+
+    mocks.getMorePostings.mockResolvedValueOnce({
+      postings: initialPostings,
+      truncated: false,
+    });
+
+    expect(mocks.hasMore).toBe(true);
+
+    await act(async () => {
+      await mocks.load?.();
+    });
+
+    expect(mocks.getMorePostings).toHaveBeenLastCalledWith(
+      expect.objectContaining({ offset: 20, limit: 20 }),
+    );
+    expect(visiblePostingIds(container)).toEqual(initialPostings.map((p) => p.id));
+    await waitFor(() => {
+      expect(mocks.hasMore).toBe(false);
+    });
   });
 
   it("uses posting id as deterministic tie-breaker", () => {

--- a/apps/web/src/components/search/company-card.tsx
+++ b/apps/web/src/components/search/company-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useState, useRef, useMemo } from "react";
+import { memo, useEffect, useRef, useMemo } from "react";
 import Link from "next/link";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { CompanyIcon } from "@/components/CompanyIcon";
@@ -8,6 +8,7 @@ import { useParams } from "next/navigation";
 import { timeAgoShort } from "@/lib/time";
 import { getMorePostings } from "@/lib/actions/search";
 import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
+import { usePaginatedLoadMore } from "@/lib/use-paginated-load-more";
 import { InfiniteScrollSentinel } from "@/components/InfiniteScrollSentinel";
 import { TruncationPrompt } from "@/components/TruncationPrompt";
 import { TrackingDot } from "@/components/TrackingDot";
@@ -57,54 +58,74 @@ function CompanyCardImpl({ result, keywords, locationIds, locations, occupations
     workMode,
   );
 
-  const [extraPostings, setExtraPostings] = useState<SearchResultPosting[]>([]);
-  const [exhausted, setExhausted] = useState(false);
-  const [isTruncated, setIsTruncated] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const initialPostingsKey = useMemo(
+    () => result.postings.map((posting) => posting.id).join("\u0000"),
+    [result.postings],
+  );
+
+  const {
+    items: postings,
+    hasMore,
+    truncated: isTruncated,
+    loadMore,
+    setItems,
+    setTotal,
+    setExhausted,
+    setTruncated,
+  } = usePaginatedLoadMore<SearchResultPosting>({
+    initialItems: result.postings,
+    initialTotal: activeMatches,
+    batchSize: POSTINGS_BATCH,
+    itemKey: (posting) => posting.id,
+    fetcher: async ({ offset, limit }) => {
+      const result = await getMorePostings({
+        companyId: company.id,
+        keywords,
+        locationIds,
+        occupationIds: occupations?.map((o) => o.id),
+        seniorityIds: seniorities?.map((s) => s.id),
+        technologyIds: technologies?.map((t) => t.id),
+        employmentTypes,
+        workMode,
+        salaryMinEur,
+        salaryMaxEur,
+        experienceMin,
+        experienceMax,
+        languages: languages ?? [locale],
+        locale,
+        offset,
+        limit,
+      });
+
+      return {
+        postings: result.postings,
+        total: activeMatches,
+        truncated: result.truncated,
+      };
+    },
+  });
+
+  useEffect(() => {
+    setItems(result.postings);
+    setTotal(activeMatches);
+    setExhausted(result.postings.length >= activeMatches);
+    setTruncated(false);
+  }, [
+    activeMatches,
+    initialPostingsKey,
+    result.postings,
+    setExhausted,
+    setItems,
+    setTotal,
+    setTruncated,
+  ]);
 
   const allPostings = useMemo(() => {
-    const seen = new Set<string>();
-    const deduped = [...result.postings, ...extraPostings].filter((p) => {
-      if (seen.has(p.id)) return false;
-      seen.add(p.id);
-      return true;
-    });
-    return sortPostingsByFreshness(deduped);
-  }, [result.postings, extraPostings]);
+    return sortPostingsByFreshness(postings);
+  }, [postings]);
 
-  const hasMore = !exhausted && !isTruncated && allPostings.length < activeMatches;
-  const offsetRef = useRef(result.postings.length);
-
-  async function handleLoadMore() {
-    const result = await getMorePostings({
-      companyId: company.id,
-      keywords,
-      locationIds,
-      occupationIds: occupations?.map((o) => o.id),
-      seniorityIds: seniorities?.map((s) => s.id),
-      technologyIds: technologies?.map((t) => t.id),
-      employmentTypes,
-      workMode,
-      salaryMinEur,
-      salaryMaxEur,
-      experienceMin,
-      experienceMax,
-      languages: languages ?? [locale],
-      locale,
-      offset: offsetRef.current,
-      limit: POSTINGS_BATCH,
-    });
-    if (result.truncated) setIsTruncated(true);
-    offsetRef.current += result.postings.length;
-    if (result.postings.length > 0) {
-      setExtraPostings((prev) => [...prev, ...result.postings]);
-    }
-    if (result.postings.length < POSTINGS_BATCH) {
-      setExhausted(true);
-    }
-  }
-
-  const { sentinelRef, isLoading } = useInfiniteScroll({ hasMore, load: handleLoadMore, root: scrollRef, rootMargin: "50px" });
+  const { sentinelRef, isLoading } = useInfiniteScroll({ hasMore, load: loadMore, root: scrollRef, rootMargin: "50px" });
 
   return (
     <div className="rounded-md border border-divider bg-surface p-4">

--- a/apps/web/src/components/watchlist/__tests__/public-watchlist-search.test.tsx
+++ b/apps/web/src/components/watchlist/__tests__/public-watchlist-search.test.tsx
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import "@/test-utils/lingui-mock";
+
+const infiniteScrollMock = vi.hoisted(() => ({
+  latest: undefined as
+    | { hasMore: boolean; load: () => Promise<void> }
+    | undefined,
+}));
 
 vi.mock("next/link", () => ({
   default: ({ children, href, prefetch: _prefetch, ...props }: Record<string, unknown>) => (
@@ -17,7 +23,10 @@ vi.mock("@/lib/useLocalePath", () => ({
 }));
 
 vi.mock("@/lib/use-infinite-scroll", () => ({
-  useInfiniteScroll: () => ({ sentinelRef: { current: null }, isLoading: false }),
+  useInfiniteScroll: (options: { hasMore: boolean; load: () => Promise<void> }) => {
+    infiniteScrollMock.latest = options;
+    return { sentinelRef: { current: null }, isLoading: false };
+  },
 }));
 
 vi.mock("@/lib/actions/watchlists", () => ({
@@ -31,26 +40,34 @@ import { PublicWatchlistSearch } from "../public-watchlist-search";
 const getPopularWatchlistsMock = vi.mocked(getPopularWatchlists);
 const searchPublicWatchlistsMock = vi.mocked(searchPublicWatchlists);
 
+function makeWatchlists(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `public-watchlist-${index}`,
+    slug: `watchlist-${index}`,
+    title: `Watchlist ${index}`,
+    description: "Big tech and AI jobs",
+    isPublic: true,
+    alertsEnabled: false,
+    companyCount: 12,
+    activeJobCount: 45,
+    lastAccessedAt: "2026-07-06T00:00:00.000Z",
+    createdAt: "2026-07-06T00:00:00.000Z",
+    ownerName: "Colophon",
+    ownerUsername: "colophongroup",
+    mirrorCount: 2,
+  }));
+}
+
 beforeEach(() => {
   vi.restoreAllMocks();
+  infiniteScrollMock.latest = undefined;
   getPopularWatchlistsMock.mockResolvedValue({
-    watchlists: [
-      {
-        id: "public-watchlist-1",
-        slug: "maangplus",
-        title: "MAANG+",
-        description: "Big tech and AI jobs",
-        isPublic: true,
-        alertsEnabled: false,
-        companyCount: 12,
-        activeJobCount: 45,
-        lastAccessedAt: "2026-07-06T00:00:00.000Z",
-        createdAt: "2026-07-06T00:00:00.000Z",
-        ownerName: "Colophon",
-        ownerUsername: "colophongroup",
-        mirrorCount: 2,
-      },
-    ],
+    watchlists: [{
+      ...makeWatchlists(1)[0],
+      id: "public-watchlist-1",
+      slug: "maangplus",
+      title: "MAANG+",
+    }],
     total: 1,
   });
   searchPublicWatchlistsMock.mockResolvedValue({ watchlists: [], total: 0 });
@@ -67,5 +84,30 @@ describe("PublicWatchlistSearch navigation", () => {
 
     expect(link.getAttribute("href")).toBe("/en/colophongroup/maangplus");
     expect(scrollTo).toHaveBeenCalledWith({ top: 0, left: 0, behavior: "instant" });
+  });
+
+  it("stops infinite scroll when the next full public-watchlist page contains only duplicate ids", async () => {
+    const firstPage = makeWatchlists(10);
+    getPopularWatchlistsMock
+      .mockResolvedValueOnce({ watchlists: firstPage, total: 20 })
+      .mockResolvedValueOnce({ watchlists: firstPage, total: 20 });
+
+    render(<PublicWatchlistSearch />);
+
+    await screen.findByText("Watchlist 0");
+    expect(infiniteScrollMock.latest?.hasMore).toBe(true);
+
+    await act(async () => {
+      await infiniteScrollMock.latest?.load();
+    });
+
+    expect(getPopularWatchlistsMock).toHaveBeenLastCalledWith({
+      offset: 10,
+      limit: 10,
+      locale: "en",
+    });
+    await waitFor(() => {
+      expect(infiniteScrollMock.latest?.hasMore).toBe(false);
+    });
   });
 });

--- a/apps/web/src/components/watchlist/public-watchlist-search.tsx
+++ b/apps/web/src/components/watchlist/public-watchlist-search.tsx
@@ -7,6 +7,7 @@ import { Search, Loader2, Copy } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useLocalePath } from "@/lib/useLocalePath";
 import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
+import { usePaginatedLoadMore } from "@/lib/use-paginated-load-more";
 import { scrollToTopOnNav } from "@/lib/scroll-on-nav";
 import { InfiniteScrollSentinel } from "@/components/InfiniteScrollSentinel";
 import {
@@ -23,61 +24,53 @@ export function PublicWatchlistSearch() {
   const { t } = useLingui();
   const lp = useLocalePath();
   const [query, setQuery] = useState("");
-  const [results, setResults] = useState<PublicWatchlistEntry[]>([]);
+  const [debouncedQuery, setDebouncedQuery] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
-  const [total, setTotal] = useState(0);
-  const [exhausted, setExhausted] = useState(false);
-  const [mode, setMode] = useState<"popular" | "search">("popular");
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-  const queryRef = useRef(query);
-  queryRef.current = query;
 
-  const fetchPage = useCallback(async (q: string, offset: number, append: boolean) => {
+  const fetchPage = useCallback(async (q: string, offset: number, limit: number) => {
     const fetcher = q.length >= 2
-      ? () => searchPublicWatchlists({ query: q, offset, limit: PAGE_SIZE, locale })
-      : () => getPopularWatchlists({ offset, limit: PAGE_SIZE, locale });
-
-    const newMode = q.length >= 2 ? "search" : "popular";
+      ? () => searchPublicWatchlists({ query: q, offset, limit, locale })
+      : () => getPopularWatchlists({ offset, limit, locale });
 
     try {
       const { watchlists, total: t } = await fetcher();
-      if (append) {
-        setResults((prev) => {
-          const seen = new Set(prev.map((w) => w.id));
-          return [...prev, ...watchlists.filter((w) => !seen.has(w.id))];
-        });
-      } else {
-        setResults(watchlists);
-      }
-      setTotal(t);
-      setMode(newMode);
-      if (watchlists.length < PAGE_SIZE) setExhausted(true);
+      return { postings: watchlists, total: t };
     } finally {
       setLoading(false);
     }
   }, [locale]);
+
+  const activeQuery = debouncedQuery ?? "";
+  const {
+    items: results,
+    hasMore,
+    loadMore,
+  } = usePaginatedLoadMore<PublicWatchlistEntry>({
+    initialItems: [],
+    initialTotal: 0,
+    batchSize: PAGE_SIZE,
+    itemKey: (watchlist) => watchlist.id,
+    resetKey: `${locale}:${debouncedQuery ?? "__pending__"}`,
+    fetcher: ({ offset, limit }) => fetchPage(activeQuery, offset, limit),
+  });
 
   // Initial load + search on query change
   useEffect(() => {
     clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
       setLoading(true);
-      setExhausted(false);
-      fetchPage(query, 0, false);
+      setDebouncedQuery(query);
     }, query.length > 0 ? 300 : 0);
     return () => clearTimeout(timerRef.current);
-  }, [query, fetchPage]);
-
-  const hasMore = !exhausted && results.length < total;
-
-  async function handleLoadMore() {
-    await fetchPage(queryRef.current, results.length, true);
-  }
+  }, [query]);
 
   const { sentinelRef, isLoading: loadingMore } = useInfiniteScroll({
     hasMore,
-    load: handleLoadMore,
+    load: loadMore,
   });
+
+  const mode: "popular" | "search" = activeQuery.length >= 2 ? "search" : "popular";
 
   return (
     <div>


### PR DESCRIPTION
Fixes #3060.

## Summary
- Migrate `PublicWatchlistSearch` to `usePaginatedLoadMore` for page merging, offsets, and terminal conditions.
- Migrate `CompanyCard` posting pagination to the shared hook while preserving freshness sorting and anon truncation behavior.
- Add regressions for full duplicate pages so both surfaces stop loading when dedup yields no fresh rows.

## Reproduction
- Added focused tests that simulate a full next page containing only duplicate ids.
- On current main, both tests failed because `hasMore` stayed true after dedup added zero fresh rows.
- Read-only production baseline: `/en/watchlists` and `/en/explore` both returned HTTP 200 with no `application-error`, `NEXT_HTTP_ERROR_FALLBACK`, or digest markers. No production writes and no Supabase mutations.

## Validation
- Red before fix: `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm exec vitest run src/components/watchlist/__tests__/public-watchlist-search.test.tsx -t "duplicate ids"`.
- Red before fix: `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm exec vitest run src/components/search/__tests__/company-card-posting-order.test.tsx -t "duplicate posting ids"`.
- Green after fix: focused duplicate-page tests.
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm exec vitest run src/components/watchlist/__tests__/public-watchlist-search.test.tsx src/components/search/__tests__/company-card-posting-order.test.tsx src/components/search/__tests__/company-card.test.tsx src/components/search/__tests__/company-card-nested-buttons.test.tsx src/components/search/__tests__/company-card-scroll-stability.test.tsx` (26 passed).
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm exec eslint src/components/watchlist/public-watchlist-search.tsx src/components/search/company-card.tsx src/components/watchlist/__tests__/public-watchlist-search.test.tsx src/components/search/__tests__/company-card-posting-order.test.tsx`.
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm typecheck`.
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm test` (174 files / 1379 tests passed).
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm build` passed with the existing local missing-env warnings for Redis/Auth/Typesense during static generation.
- `git diff --check origin/main...HEAD`.

Note: local pnpm commands used `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0` because the current lockfile trips the local pnpm minimum-release-age policy for already-locked packages; no lockfile changes were made.