### PR TITLE
Harden Dealroom company issue creation

### DIFF
--- a/scripts/dealroom-company-requests.mjs
+++ b/scripts/dealroom-company-requests.mjs
@@ -247,6 +247,10 @@ export function buildIssueTitle(company) {
   return `Add company: ${company.name}`;
 }
 
+export function issueTitleKey(title) {
+  return String(title ?? "").trim().toLowerCase();
+}
+
 export function buildIssueBody(company, { parentIssue = DEFAULT_PARENT_ISSUE } = {}) {
   const listLines = company.lists
     .slice()
@@ -426,21 +430,68 @@ function fetchExistingCompanyRequestIssues() {
   const issues = new Map();
   for (const line of stdout.split("\n").filter(Boolean)) {
     const issue = JSON.parse(line);
-    issues.set(issue.title.toLowerCase(), issue.number);
+    const titleKey = issueTitleKey(issue.title);
+    if (titleKey && !issues.has(titleKey)) {
+      issues.set(titleKey, issue.number);
+    }
   }
   return issues;
+}
+
+export function parseCreatedIssueResponse(stdout, expectedTitle) {
+  let issue;
+  try {
+    issue = JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(
+      `Could not parse GitHub issue create response for ${expectedTitle}: ${error.message}`,
+    );
+  }
+
+  if (!issue || typeof issue !== "object") {
+    throw new Error(`GitHub issue create response for ${expectedTitle} was not an object`);
+  }
+  if (!Number.isInteger(issue.number)) {
+    throw new Error(`GitHub issue create response for ${expectedTitle} did not include a number`);
+  }
+  if (typeof issue.html_url !== "string" || issue.html_url.trim() === "") {
+    throw new Error(`GitHub issue create response for ${expectedTitle} did not include html_url`);
+  }
+  if (issue.title && issueTitleKey(issue.title) !== issueTitleKey(expectedTitle)) {
+    throw new Error(
+      `GitHub issue create response title mismatch: expected ${expectedTitle}, got ${issue.title}`,
+    );
+  }
+
+  return {
+    number: issue.number,
+    title: issue.title || expectedTitle,
+    url: issue.html_url,
+  };
 }
 
 function createIssue(title, body) {
   const result = spawnSync(
     "gh",
-    ["issue", "create", "--title", title, "--body", body, "--label", "company-request"],
-    { encoding: "utf8" },
+    [
+      "api",
+      "--method",
+      "POST",
+      "repos/colophon-group/jobseek/issues",
+      "--header",
+      "Content-Type: application/json",
+      "--input",
+      "-",
+    ],
+    {
+      input: JSON.stringify({ title, body, labels: ["company-request"] }),
+      encoding: "utf8",
+    },
   );
   if (result.status !== 0) {
     throw new Error(result.stderr || result.stdout || `gh issue create failed for ${title}`);
   }
-  return result.stdout.trim();
+  return parseCreatedIssueResponse(result.stdout, title);
 }
 
 async function main() {
@@ -474,16 +525,25 @@ async function main() {
   if (!args.createIssues) return;
 
   const existing = fetchExistingCompanyRequestIssues();
+  const plannedTitles = new Set();
   for (const company of limitedMissing) {
     const title = buildIssueTitle(company);
-    const existingNumber = existing.get(title.toLowerCase());
+    const titleKey = issueTitleKey(title);
+    if (plannedTitles.has(titleKey)) {
+      console.log(`SKIP duplicate title in Dealroom audit: ${title}`);
+      continue;
+    }
+    plannedTitles.add(titleKey);
+
+    const existingNumber = existing.get(titleKey);
     if (existingNumber) {
       console.log(`SKIP existing #${existingNumber}: ${title}`);
       continue;
     }
 
-    const url = createIssue(title, buildIssueBody(company, { parentIssue: args.parentIssue }));
-    console.log(`CREATED ${title}: ${url}`);
+    const issue = createIssue(title, buildIssueBody(company, { parentIssue: args.parentIssue }));
+    existing.set(issueTitleKey(issue.title), issue.number);
+    console.log(`CREATED #${issue.number} ${title}: ${issue.url}`);
     if (args.delayMs > 0) {
       await sleep(args.delayMs);
     }

--- a/scripts/dealroom-company-requests.test.mjs
+++ b/scripts/dealroom-company-requests.test.mjs
@@ -7,8 +7,10 @@ import {
   buildIssueTitle,
   buildRegistryIndex,
   extractDealroomCompaniesFromHtml,
+  issueTitleKey,
   normalizeHost,
   normalizeName,
+  parseCreatedIssueResponse,
   parseCsvRows,
   parseListSitemapXml,
   slugify,
@@ -185,4 +187,48 @@ test("builds company-request issue title and body with parent evidence", () => {
   assert.match(body, /Company name:\*\* ICEYE/);
   assert.match(body, /Space startups in Europe #2/);
   assert.match(body, /Parent tracking issue: #3570/);
+});
+
+test("normalizes issue titles for idempotent company-request dedupe", () => {
+  assert.equal(issueTitleKey(" Add company: ICEYE "), "add company: iceye");
+  assert.equal(issueTitleKey(null), "");
+});
+
+test("parses and validates GitHub issue create responses", () => {
+  assert.deepEqual(
+    parseCreatedIssueResponse(
+      JSON.stringify({
+        number: 123,
+        title: "Add company: ICEYE",
+        html_url: "https://github.com/colophon-group/jobseek/issues/123",
+      }),
+      "Add company: ICEYE",
+    ),
+    {
+      number: 123,
+      title: "Add company: ICEYE",
+      url: "https://github.com/colophon-group/jobseek/issues/123",
+    },
+  );
+
+  assert.throws(
+    () => parseCreatedIssueResponse("", "Add company: ICEYE"),
+    /Could not parse GitHub issue create response/,
+  );
+  assert.throws(
+    () => parseCreatedIssueResponse(JSON.stringify({ number: 123 }), "Add company: ICEYE"),
+    /did not include html_url/,
+  );
+  assert.throws(
+    () =>
+      parseCreatedIssueResponse(
+        JSON.stringify({
+          number: 123,
+          title: "Add company: Different",
+          html_url: "https://github.com/colophon-group/jobseek/issues/123",
+        }),
+        "Add company: ICEYE",
+      ),
+    /title mismatch/,
+  );
 });


### PR DESCRIPTION
Fixes #4145.
Refs #3643.

## Summary
- switch Dealroom child issue creation from `gh issue create` to parsed REST API responses
- validate created issue number/title/html_url before logging success
- dedupe duplicate titles inside the planned batch and remember each successful create immediately

## Validation
- `node --test scripts/ci-workflow.test.mjs scripts/dealroom-company-requests.test.mjs`
- `node scripts/dealroom-company-requests.mjs --limit 5`
- `git diff --check origin/main...HEAD`

## Operational note
The existing #3643 batch is currently partially complete and needs reconciliation of duplicate child issues before remaining company requests are created.