### PR TITLE
Add watchlist mutation audit logs

### DIFF
--- a/apps/web/src/lib/actions/__tests__/watchlists-invalidation.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-invalidation.test.ts
@@ -247,6 +247,19 @@ function expectedInvalidateKeyPair(slug: string) {
   ];
 }
 
+function spyAuditLog() {
+  return vi.spyOn(console, "info").mockImplementation(() => {});
+}
+
+function expectSingleAuditPayload(
+  spy: ReturnType<typeof spyAuditLog>,
+): Record<string, unknown> {
+  expect(spy).toHaveBeenCalledTimes(1);
+  const [line] = spy.mock.calls[0];
+  expect(typeof line).toBe("string");
+  return JSON.parse(line as string) as Record<string, unknown>;
+}
+
 /**
  * Queue the `_getOwnerInfo` SQL response — `db.execute` is called with the
  * SELECT username/display_username query inside `_invalidateWatchlistCaches`.
@@ -524,6 +537,43 @@ describe("watchlist mutator cache invalidation", () => {
   });
 });
 
+describe("watchlist mutation audit logs", () => {
+  it("deleteWatchlist emits a privacy-safe audit log for successful deletes", async () => {
+    const audit = spyAuditLog();
+    queueOwnerInfo();
+    mocks.selectLimitResult.mockResolvedValue([
+      { userId: USER_ID, slug: SLUG, isPublic: true },
+    ]);
+
+    await deleteWatchlist(WATCHLIST_ID);
+    await flushAfterQueue();
+
+    const payload = expectSingleAuditPayload(audit);
+    expect(payload).toMatchObject({
+      event: "watchlist.audit",
+      action: "watchlist.delete",
+      watchlist_id: WATCHLIST_ID,
+      slug_before: SLUG,
+      slug_after: null,
+      is_public_before: true,
+      is_public_after: null,
+    });
+    expect(payload.user_ref).toMatch(/^[a-f0-9]{12}$/);
+    expect(JSON.stringify(payload)).not.toContain(USER_ID);
+    expect(Date.parse(payload.occurred_at as string)).not.toBeNaN();
+  });
+
+  it("does not emit an audit log when deleteWatchlist finds no owned row", async () => {
+    const audit = spyAuditLog();
+    mocks.selectLimitResult.mockResolvedValue([]);
+
+    await expect(deleteWatchlist(WATCHLIST_ID)).resolves.toEqual({ ok: false });
+    await flushAfterQueue();
+
+    expect(audit).not.toHaveBeenCalled();
+  });
+});
+
 // ---- Special-case behavior ------------------------------------------
 
 describe("updateWatchlist title rename", () => {
@@ -664,6 +714,17 @@ const EXPECTED_NON_INVALIDATING = new Set<string>([
   // lastAccessedAt is a private after-queued analytics touch on the
   // owner's read path; it never appears in any public render.
   "getWatchlistByUserAndSlug",
+]);
+
+/** Successful watchlist mutators that MUST emit a structured audit log. */
+const EXPECTED_AUDITING_MUTATORS = new Set<string>([
+  "createWatchlist",
+  "updateWatchlist",
+  "deleteWatchlist",
+  "copyWatchlist",
+  "addCompanyToWatchlist",
+  "clearWatchlistCompanies",
+  "removeCompanyFromWatchlist",
 ]);
 
 /**
@@ -846,6 +907,33 @@ describe("invalidation registry guard", () => {
       EXPECTED_NON_INVALIDATING.has(n),
     );
     expect(overlap).toEqual([]);
+  });
+
+  it("successful public/user watchlist mutators all emit audit logs", () => {
+    const source = readFileSync(SOURCE_PATH, "utf-8");
+    const matches = enumerateExportedAsyncFunctions(source);
+    const errors: string[] = [];
+
+    for (let i = 0; i < matches.length; i++) {
+      const { name } = matches[i];
+      if (!EXPECTED_AUDITING_MUTATORS.has(name)) continue;
+      const body = functionBody(source, matches, i);
+      if (!body.includes("_logWatchlistAudit(")) {
+        errors.push(`Function \`${name}\` is missing _logWatchlistAudit().`);
+      }
+    }
+
+    expect(errors).toEqual([]);
+  });
+
+  it("EXPECTED_AUDITING_MUTATORS members all exist as exported async functions", () => {
+    const source = readFileSync(SOURCE_PATH, "utf-8");
+    const exportedNames = new Set(
+      enumerateExportedAsyncFunctions(source).map((m) => m.name),
+    );
+    for (const name of EXPECTED_AUDITING_MUTATORS) {
+      expect(exportedNames.has(name), `${name} not found as exported async function`).toBe(true);
+    }
   });
 
   it("toggleWatchlistAlerts is in EXPECTED_NON_INVALIDATING (private-only field)", () => {

--- a/apps/web/src/lib/services/watchlists.ts
+++ b/apps/web/src/lib/services/watchlists.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { createHash } from "node:crypto";
 import { after } from "next/server";
 import { updateTag } from "next/cache";
 import { eq, and, sql, type SQL } from "drizzle-orm";
@@ -166,6 +167,49 @@ type WatchlistPostingQueryParams = WatchlistPostingFilterParams & {
   limit: number;
 };
 
+type WatchlistAuditAction =
+  | "watchlist.create"
+  | "watchlist.update"
+  | "watchlist.delete"
+  | "watchlist.copy"
+  | "watchlist.company.add"
+  | "watchlist.companies.clear"
+  | "watchlist.company.remove";
+
+type WatchlistAuditPayload = {
+  event: "watchlist.audit";
+  occurred_at: string;
+  action: WatchlistAuditAction;
+  user_ref: string;
+  watchlist_id: string;
+  slug_before?: string | null;
+  slug_after?: string | null;
+  is_public_before?: boolean | null;
+  is_public_after?: boolean | null;
+  company_count_delta?: number | null;
+};
+
+type WatchlistAuditInput = Omit<
+  WatchlistAuditPayload,
+  "event" | "occurred_at" | "user_ref"
+> & {
+  userId: string;
+};
+
+function _watchlistAuditUserRef(userId: string): string {
+  return createHash("sha256").update(userId).digest("hex").slice(0, 12);
+}
+
+function _logWatchlistAudit({ userId, ...entry }: WatchlistAuditInput): void {
+  const payload: WatchlistAuditPayload = {
+    event: "watchlist.audit",
+    occurred_at: new Date().toISOString(),
+    user_ref: _watchlistAuditUserRef(userId),
+    ...entry,
+  };
+  console.info(JSON.stringify(payload));
+}
+
 // ── Actions ─────────────────────────────────────────────────────────
 
 export async function createWatchlist(params: {
@@ -223,6 +267,17 @@ export async function createWatchlist(params: {
   const isPublic = params.isPublic ?? true;
   const mergedFilters = { anyCompany: true, ...params.filters };
   const trivial = isTrivialWatchlist(mergedFilters, params.companyIds.length);
+
+  _logWatchlistAudit({
+    action: "watchlist.create",
+    userId,
+    watchlist_id: row.id,
+    slug_before: null,
+    slug_after: slug,
+    is_public_before: null,
+    is_public_after: isPublic,
+    company_count_delta: params.companyIds.length,
+  });
 
   // Cache invalidation runs unconditionally for public watchlists
   // (even trivial ones): if the URL was visited before the watchlist
@@ -340,6 +395,21 @@ export async function updateWatchlist(params: {
   const newFilters = params.filters !== undefined
     ? params.filters
     : (wl.filters ?? {}) as WatchlistFilters;
+  const didUpdateWatchlist = Object.keys(updates).length > 0;
+  const didReplaceCompanies = params.companyIds !== undefined;
+
+  if (didUpdateWatchlist || didReplaceCompanies) {
+    _logWatchlistAudit({
+      action: "watchlist.update",
+      userId,
+      watchlist_id: params.watchlistId,
+      slug_before: wl.slug,
+      slug_after: newSlug,
+      is_public_before: wasPublic,
+      is_public_after: nowPublic,
+      company_count_delta: didReplaceCompanies ? null : undefined,
+    });
+  }
 
   after(async () => {
     try {
@@ -405,6 +475,17 @@ export async function deleteWatchlist(
   if (!wl || wl.userId !== userId) return { ok: false };
 
   await db.delete(watchlist).where(eq(watchlist.id, watchlistId));
+
+  _logWatchlistAudit({
+    action: "watchlist.delete",
+    userId,
+    watchlist_id: watchlistId,
+    slug_before: wl.slug,
+    slug_after: null,
+    is_public_before: wl.isPublic,
+    is_public_after: null,
+    company_count_delta: null,
+  });
 
   // Typesense delete + IndexNow re-crawl trigger + Next/Redis cache
   // invalidation. The page-level `'use cache'` keeps a 1-hour cached
@@ -494,6 +575,17 @@ export async function copyWatchlist(
       })),
     );
   }
+
+  _logWatchlistAudit({
+    action: "watchlist.copy",
+    userId,
+    watchlist_id: row.id,
+    slug_before: null,
+    slug_after: slug,
+    is_public_before: null,
+    is_public_after: true,
+    company_count_delta: companies.length,
+  });
 
   // Typesense + IndexNow hooks. Wrapped in after() so work registers
   // in the request scope; the previous detached .then() pattern broke
@@ -1867,6 +1959,17 @@ export async function addCompanyToWatchlist(
     .values({ watchlistId, companyId })
     .onConflictDoNothing();
 
+  _logWatchlistAudit({
+    action: "watchlist.company.add",
+    userId,
+    watchlist_id: watchlistId,
+    slug_before: wl.slug,
+    slug_after: wl.slug,
+    is_public_before: wl.isPublic,
+    is_public_after: wl.isPublic,
+    company_count_delta: 1,
+  });
+
   // The companies array drives the cached page's JSON-LD ItemList,
   // metadata description ("Jobs at X, Y, Z"), and OG image. Bust the
   // page cache + Redis layer so the change is visible on the next read.
@@ -1901,6 +2004,17 @@ export async function clearWatchlistCompanies(
   await db
     .delete(watchlistCompany)
     .where(eq(watchlistCompany.watchlistId, watchlistId));
+
+  _logWatchlistAudit({
+    action: "watchlist.companies.clear",
+    userId,
+    watchlist_id: watchlistId,
+    slug_before: wl.slug,
+    slug_after: wl.slug,
+    is_public_before: wl.isPublic,
+    is_public_after: wl.isPublic,
+    company_count_delta: null,
+  });
 
   if (wl.isPublic) {
     after(async () => {
@@ -1939,6 +2053,17 @@ export async function removeCompanyFromWatchlist(
         eq(watchlistCompany.companyId, companyId),
       ),
     );
+
+  _logWatchlistAudit({
+    action: "watchlist.company.remove",
+    userId,
+    watchlist_id: watchlistId,
+    slug_before: wl.slug,
+    slug_after: wl.slug,
+    is_public_before: wl.isPublic,
+    is_public_after: wl.isPublic,
+    company_count_delta: -1,
+  });
 
   if (wl.isPublic) {
     after(async () => {


### PR DESCRIPTION
## Summary
- emit one structured `watchlist.audit` JSON log for successful watchlist create/update/delete/copy/company mutations
- use a 12-character SHA-256 user reference instead of logging raw user ids
- add behavior and source-guard regressions so future watchlist mutators cannot skip audit logging silently

## Reproduction
- Source-level reproduction on current main: successful watchlist mutators in `apps/web/src/lib/services/watchlists.ts` only logged post-mutation hook failures; no successful `console.info` audit path existed.
- Red regression before fix: `deleteWatchlist emits a privacy-safe audit log for successful deletes` expected one audit payload and got zero; source guard reported all seven mutators missing `_logWatchlistAudit()`.
- Production read-only probe: `https://jseek.co/en/watchlists` returned HTTP 200 with no `application-error` / `NEXT_HTTP_ERROR_FALLBACK` / digest markers; `GET /api/v1/watchlists?locale=en` returned HTTP 200 with 10 watchlists; `vercel logs https://jseek.co --query watchlist.audit --since 24h` found no existing audit marker. No production writes and no Supabase mutations.

## Validation
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm exec vitest run src/lib/actions/__tests__/watchlists-invalidation.test.ts -t "audit logs|successful public/user watchlist mutators all emit audit logs|EXPECTED_AUDITING_MUTATORS"` (red before fix, green after)
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm exec vitest run src/lib/actions/__tests__/watchlists-invalidation.test.ts` (`24 passed`)
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm exec eslint src/lib/services/watchlists.ts src/lib/actions/__tests__/watchlists-invalidation.test.ts`
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm typecheck`
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm test` (`174 files / 1383 tests`)
- `PNPM_CONFIG_MINIMUM_RELEASE_AGE=0 pnpm build` (passed with existing local missing-env warnings for Redis/Auth/Typesense)
- `git diff --check`

Closes #3164
