### PR TITLE
Skip CodeQL analysis for non-code PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,29 +13,76 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  actions: read
-  contents: read
-  packages: read
-  security-events: write
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
+  changes:
+    name: Detect CodeQL changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      codeql: ${{ steps.default.outputs.codeql || steps.filter.outputs.codeql }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        with:
+          fetch-depth: 0
+
+      - name: Non-PR CodeQL default
+        id: default
+        if: github.event_name != 'pull_request'
+        run: echo "codeql=true" >> "$GITHUB_OUTPUT"
+
+      - name: Detect changed paths
+        id: filter
+        if: github.event_name == 'pull_request'
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        with:
+          predicate-quantifier: every
+          filters: |
+            codeql:
+              - '**'
+              - '!**/*.md'
+              - '!docs/**'
+              - '!.github/dependabot.yml'
+              - '!.github/dependabot.yaml'
+              - '!.github/ISSUE_TEMPLATE/**'
+              - '!.github/DISCUSSION_TEMPLATE/**'
+              - '!apps/crawler/data/**'
+              - '!apps/crawler/traces/**'
+              - '!apps/crawler/VERSION'
+
   analyze:
     name: Analyze (${{ matrix.language }})
+    needs: changes
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
         language: [actions, javascript-typescript, python]
 
     steps:
+      - name: Skip CodeQL analysis for non-code PR
+        if: needs.changes.outputs.codeql != 'true'
+        run: echo "Only non-code paths changed; preserving the required CodeQL status without running analysis."
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+        if: needs.changes.outputs.codeql == 'true'
 
       - name: Initialize CodeQL
+        if: needs.changes.outputs.codeql == 'true'
         uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
+        if: needs.changes.outputs.codeql == 'true'
         uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -3,6 +3,7 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 const workflow = readFileSync(".github/workflows/ci.yml", "utf8");
+const codeqlWorkflow = readFileSync(".github/workflows/codeql.yml", "utf8");
 const uploadCompanyImagesWorkflow = readFileSync(
   ".github/workflows/upload-company-images.yml",
   "utf8",
@@ -22,6 +23,14 @@ function setupUvBlocks(workflowSource) {
 
 function jobBlock(jobId) {
   const match = workflow.match(
+    new RegExp(`\\n  ${jobId}:\\n[\\s\\S]*?(?=\\n  [a-zA-Z0-9_-]+:\\n|\\n$)`),
+  );
+  assert.ok(match, `missing workflow job ${jobId}`);
+  return match[0];
+}
+
+function workflowJobBlock(workflowSource, jobId) {
+  const match = workflowSource.match(
     new RegExp(`\\n  ${jobId}:\\n[\\s\\S]*?(?=\\n  [a-zA-Z0-9_-]+:\\n|\\n$)`),
   );
   assert.ok(match, `missing workflow job ${jobId}`);
@@ -67,6 +76,37 @@ test("workflow-security runs repository script tests", () => {
   assert.match(workflow, /scripts\/ci-workflow\.test\.mjs/);
   assert.match(workflow, /scripts\/docs-index\.test\.mjs/);
   assert.match(workflow, /scripts\/dealroom-company-requests\.test\.mjs/);
+});
+
+test("CodeQL skips full analysis for non-code pull requests", () => {
+  const changesJob = workflowJobBlock(codeqlWorkflow, "changes");
+  assert.match(changesJob, /name: Detect CodeQL changes/);
+  assert.match(changesJob, /uses: dorny\/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3/);
+  assert.match(changesJob, /predicate-quantifier: every/);
+  assert.match(changesJob, /codeql:\n(?:              - .+\n)+/);
+
+  for (const pattern of [
+    "'!**/*.md'",
+    "'!docs/**'",
+    "'!.github/dependabot.yml'",
+    "'!.github/dependabot.yaml'",
+    "'!.github/ISSUE_TEMPLATE/**'",
+    "'!.github/DISCUSSION_TEMPLATE/**'",
+    "'!apps/crawler/data/**'",
+    "'!apps/crawler/traces/**'",
+    "'!apps/crawler/VERSION'",
+  ]) {
+    assert.ok(changesJob.includes(pattern), `missing CodeQL filter pattern ${pattern}`);
+  }
+
+  const analyzeJob = workflowJobBlock(codeqlWorkflow, "analyze");
+  assert.match(analyzeJob, /name: Analyze \(\$\{\{ matrix\.language \}\}\)/);
+  assert.match(analyzeJob, /needs: changes/);
+  assert.doesNotMatch(analyzeJob, /\n    if: needs\.changes\.outputs\.codeql/);
+  assert.match(analyzeJob, /name: Skip CodeQL analysis for non-code PR/);
+  assert.match(analyzeJob, /if: needs\.changes\.outputs\.codeql != 'true'/);
+  assert.match(analyzeJob, /Initialize CodeQL[\s\S]*if: needs\.changes\.outputs\.codeql == 'true'/);
+  assert.match(analyzeJob, /Perform CodeQL Analysis[\s\S]*if: needs\.changes\.outputs\.codeql == 'true'/);
 });
 
 test("CI runs Typesense E2E suites against a service container", () => {


### PR DESCRIPTION
## Summary
- Keep the required CodeQL `Analyze (...)` status checks, but make them fast placeholders for pull requests that only touch non-code paths such as `apps/crawler/data/**`.
- Run full CodeQL analysis for code-changing PRs, pushes to `main`, scheduled runs, and manual runs.
- Add workflow regression coverage so company-data-only changes stay excluded from full CodeQL analysis.

## Reproduction
- PR #4146 currently changes only `apps/crawler/data/boards.csv`, `apps/crawler/data/companies.csv`, and `apps/crawler/data/company_descriptions.csv`.
- Its CI correctly skipped heavy code jobs, but CodeQL still ran `Analyze (actions)`, `Analyze (javascript-typescript)`, and `Analyze (python)`.
- The `main-strict-gate` ruleset requires those three contexts, so this preserves the contexts while skipping the expensive analysis steps for non-code PRs.

## Validation
- `node --test scripts/ci-workflow.test.mjs`
- `node --test scripts/ci-workflow.test.mjs scripts/docs-index.test.mjs scripts/dealroom-company-requests.test.mjs`
- `actionlint -ignore 'SC(2002|2086|2129)' .github/workflows/codeql.yml .github/workflows/ci.yml`\n- `uvx --from zizmor==1.26.1 zizmor --persona regular --min-severity medium --min-confidence high .github/workflows/codeql.yml`\n- `git diff --check`\n\nCloses #4149