### PR TITLE
Stop rebasing image company-request PRs

### DIFF
--- a/.github/workflows/maybe-auto-merge.yml
+++ b/.github/workflows/maybe-auto-merge.yml
@@ -57,8 +57,8 @@ jobs:
       - name: Rebase and resolve CSV conflicts
         id: rebase
         if: >-
-          steps.images.outputs.pending == 'true'
-          || contains(steps.label.outputs.labels, 'auto-merge')
+          steps.images.outputs.pending == 'false'
+          && contains(steps.label.outputs.labels, 'auto-merge')
         env:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -8,6 +8,10 @@ const uploadCompanyImagesWorkflow = readFileSync(
   ".github/workflows/upload-company-images.yml",
   "utf8",
 );
+const maybeAutoMergeWorkflow = readFileSync(
+  ".github/workflows/maybe-auto-merge.yml",
+  "utf8",
+);
 const publishMcpServerWorkflow = readFileSync(
   ".github/workflows/publish-mcp-server.yml",
   "utf8",
@@ -76,6 +80,24 @@ test("workflow-security runs repository script tests", () => {
   assert.match(workflow, /scripts\/ci-workflow\.test\.mjs/);
   assert.match(workflow, /scripts\/docs-index\.test\.mjs/);
   assert.match(workflow, /scripts\/dealroom-company-requests\.test\.mjs/);
+});
+
+test("maybe-auto-merge hands image PRs to the image upload workflow without rebasing", () => {
+  const job = workflowJobBlock(maybeAutoMergeWorkflow, "label-and-merge");
+  const rebaseStep = job.match(
+    /- name: Rebase and resolve CSV conflicts[\s\S]*?(?=\n      - name: Merge)/,
+  );
+  const labelStep = job.match(
+    /- name: Label PR[\s\S]*?(?=\n      - name: Rebase and resolve CSV conflicts)/,
+  );
+
+  assert.ok(rebaseStep, "missing rebase step");
+  assert.ok(labelStep, "missing label step");
+  assert.match(job, /name: Check for pending images/);
+  assert.match(labelStep[0], /if: steps\.images\.outputs\.pending == 'false'/);
+  assert.match(rebaseStep[0], /steps\.images\.outputs\.pending == 'false'/);
+  assert.match(rebaseStep[0], /contains\(steps\.label\.outputs\.labels, 'auto-merge'\)/);
+  assert.doesNotMatch(rebaseStep[0], /steps\.images\.outputs\.pending == 'true'/);
 });
 
 test("CodeQL skips full analysis for non-code pull requests", () => {


### PR DESCRIPTION
## Summary

Refs #3534.

Stops `maybe-auto-merge` from rebasing `add-company/*` PRs while staged images are still present. Those PRs are owned by `upload-company-images.yml`, which already uploads the images, updates the branch, labels the PR, and handles merge/issue cleanup. Letting `maybe-auto-merge` rebase first creates a bot force-push with no useful content change and triggers extra `pull_request` CI/CodeQL runs.

## Actual examples

- #4967 (`add-company/vicarius`) touched company data plus staged image SVGs. `maybe-auto-merge` run 28893231909 rebased it, then CI 28893253600 and CodeQL 28893253514 were created as `action_required` zero-job runs on the bot-pushed SHA. The concurrent image upload run 28893231623 failed because the branch moved underneath it.
- #4936 (`add-company/wavenet`) followed the same pattern: `maybe-auto-merge` run 28874444127 rebased before image upload cleanup, then CI 28874592222 and CodeQL 28874592028 were created as `action_required` zero-job runs.
- #4962 (`add-company/viktor`) also had the pending-image rebase path: `maybe-auto-merge` run 28889455957 rebased, followed by CI 28889483261 and CodeQL 28889483018 `action_required` zero-job runs.

GitHub documents that `pull_request` updates made with `GITHUB_TOKEN` create workflow runs requiring approval, so the fix is to avoid the unnecessary bot push in the first place.

## Verification

- `node --test scripts/ci-workflow.test.mjs`
- `node --test scripts/ci-workflow.test.mjs scripts/docs-index.test.mjs scripts/dealroom-company-requests.test.mjs`
- `uvx --from zizmor==1.26.1 zizmor --persona regular --min-severity medium --min-confidence high .github/workflows`
- `git diff --check`

Could not run `actionlint` locally because `go` is not installed in this environment.
