### PR TITLE
Fix company request auto-merge gates

### DIFF
--- a/.github/rulesets/main-strict-gate.json
+++ b/.github/rulesets/main-strict-gate.json
@@ -1,0 +1,55 @@
+{
+  "name": "main-strict-gate",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": ["~DEFAULT_BRANCH"]
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": true,
+        "required_status_checks": [
+          {
+            "context": "Required CI",
+            "integration_id": 15368
+          },
+          {
+            "context": "Analyze (actions)",
+            "integration_id": 15368
+          },
+          {
+            "context": "Analyze (javascript-typescript)",
+            "integration_id": 15368
+          },
+          {
+            "context": "Analyze (python)",
+            "integration_id": 15368
+          }
+        ]
+      }
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "required_reviewers": [],
+        "require_code_owner_review": false,
+        "dismissal_restriction": {
+          "enabled": false,
+          "allowed_actors": []
+        },
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    }
+  ]
+}

--- a/.github/scripts/maybe-auto-merge-pr.sh
+++ b/.github/scripts/maybe-auto-merge-pr.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${REPO:?REPO is required}"
+: "${PR:?PR is required}"
+
+SCRIPTS_DIR="${TRUSTED_SCRIPTS_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+OWNER="${REPO%%/*}"
+
+pr_json=$(gh pr view "$PR" --repo "$REPO" \
+  --json state,isDraft,headRefName,headRepositoryOwner \
+  --jq '{state,isDraft,headRefName,headRepositoryOwner}')
+
+state=$(jq -r '.state' <<< "$pr_json")
+draft=$(jq -r '.isDraft' <<< "$pr_json")
+branch=$(jq -r '.headRefName' <<< "$pr_json")
+head_owner=$(jq -r '.headRepositoryOwner.login' <<< "$pr_json")
+
+if [[ "$state" != "OPEN" ]]; then
+  echo "PR #$PR is $state; skipping"
+  exit 0
+fi
+
+if [[ "$draft" == "true" ]]; then
+  echo "PR #$PR is draft; skipping"
+  exit 0
+fi
+
+if [[ "$head_owner" != "$OWNER" ]]; then
+  echo "PR #$PR is from $head_owner, not $OWNER; skipping"
+  exit 0
+fi
+
+if [[ "$branch" != add-company/* ]]; then
+  echo "PR #$PR branch is $branch, not add-company/*; skipping"
+  exit 0
+fi
+
+files=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename')
+if grep -q '^apps/crawler/data/images/' <<< "$files"; then
+  echo "PR #$PR has pending image files; upload-company-images will handle it"
+  exit 0
+fi
+
+label_output=$(mktemp)
+GITHUB_OUTPUT="$label_output" "$SCRIPTS_DIR/label-pr.sh"
+labels=$(grep '^labels=' "$label_output" | tail -1 | cut -d= -f2- || true)
+rm -f "$label_output"
+
+if [[ ",$labels," != *",auto-merge,"* ]]; then
+  echo "PR #$PR labels are '$labels'; not auto-merging"
+  exit 0
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+
+git fetch origin main "refs/heads/$branch:refs/remotes/origin/$branch"
+git checkout -B "$branch" "origin/$branch"
+
+if git merge-base --is-ancestor origin/main HEAD 2>/dev/null; then
+  echo "PR #$PR is already up to date"
+else
+  if git rebase origin/main 2>/dev/null; then
+    echo "PR #$PR rebased cleanly"
+  else
+    while true; do
+      conflicted=$(git diff --name-only --diff-filter=U)
+      [[ -z "$conflicted" ]] && break
+
+      for file in $conflicted; do
+        if [[ "$file" == "apps/crawler/VERSION" ]]; then
+          git checkout --ours "$file"
+          current=$(tr -d '[:space:]' < "$file")
+          IFS='.' read -r major minor patch <<< "$current"
+          echo "${major}.${minor}.$((patch + 1))" > "$file"
+        elif [[ "$file" == *.csv ]]; then
+          git checkout --ours "$file"
+          git show REBASE_HEAD:"$file" | while IFS= read -r line; do
+            if ! grep -qxF "$line" "$file"; then
+              echo "$line" >> "$file"
+            fi
+          done
+        else
+          echo "::warning::Unexpected conflict in $file; keeping base version"
+          git checkout --ours "$file"
+        fi
+        git add "$file"
+      done
+
+      if GIT_EDITOR=true git rebase --continue 2>/tmp/maybe-auto-merge-rebase.err; then
+        if [[ -d .git/rebase-merge || -d .git/rebase-apply ]]; then
+          continue
+        fi
+        break
+      fi
+
+      if [[ -z "$(git diff --name-only --diff-filter=U)" ]]; then
+        cat /tmp/maybe-auto-merge-rebase.err
+        git rebase --skip
+        if [[ ! -d .git/rebase-merge && ! -d .git/rebase-apply ]]; then
+          break
+        fi
+      fi
+    done
+  fi
+
+  git push --force-with-lease origin "$branch"
+  echo "PR #$PR branch updated; checks will run before merge"
+fi
+
+for attempt in 1 2 3; do
+  if gh pr merge "$PR" --repo "$REPO" --rebase 2>/tmp/maybe-auto-merge.err; then
+    echo "PR #$PR merged"
+    "$SCRIPTS_DIR/close-linked-company-request-issues.sh"
+    exit 0
+  fi
+
+  echo "PR #$PR merge attempt $attempt did not complete yet:"
+  cat /tmp/maybe-auto-merge.err
+  sleep 10
+done
+
+echo "PR #$PR is not mergeable yet; scheduled/workflow_run retries will revisit it"

--- a/.github/workflows/maybe-auto-merge.yml
+++ b/.github/workflows/maybe-auto-merge.yml
@@ -4,12 +4,20 @@ on:
   pull_request_target:
     branches: [main]
     types: [opened, reopened, synchronize, ready_for_review]
+  workflow_run:
+    workflows: ["CI", "CodeQL"]
+    types: [completed]
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "Optional PR number to retry"
+        required: false
+        type: string
 
 jobs:
   label-and-merge:
-    if: >-
-      github.event.pull_request.head.repo.full_name == github.repository
-      && github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -27,122 +35,61 @@ jobs:
           mkdir -p "$RUNNER_TEMP/trusted-scripts"
           cp .github/scripts/label-pr.sh "$RUNNER_TEMP/trusted-scripts/label-pr.sh"
           cp .github/scripts/close-linked-company-request-issues.sh "$RUNNER_TEMP/trusted-scripts/close-linked-company-request-issues.sh"
+          cp .github/scripts/maybe-auto-merge-pr.sh "$RUNNER_TEMP/trusted-scripts/maybe-auto-merge-pr.sh"
           chmod +x "$RUNNER_TEMP/trusted-scripts/"*.sh
 
-      - name: Check for pending images
-        id: images
-        run: |
-          # Use paginated files API — gh pr diff fails on large diffs (>20k lines)
-          FILES=$(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename')
-          if echo "$FILES" | grep -q '^apps/crawler/data/images/'; then
-            echo "pending=true" >> "$GITHUB_OUTPUT"
-            echo "Images pending — upload-company-images workflow will handle labeling"
-          else
-            echo "pending=false" >> "$GITHUB_OUTPUT"
-          fi
+      - name: Select PRs
+        id: prs
         env:
           GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
-
-      - name: Label PR
-        id: label
-        if: steps.images.outputs.pending == 'false'
-        run: "$RUNNER_TEMP/trusted-scripts/label-pr.sh"
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-
-      - name: Rebase and resolve CSV conflicts
-        id: rebase
-        if: >-
-          steps.images.outputs.pending == 'false'
-          && contains(steps.label.outputs.labels, 'auto-merge')
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PR: ${{ github.event.inputs.pr || '' }}
         run: |
           set -euo pipefail
 
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          prs_file="$RUNNER_TEMP/company-prs.txt"
+          : > "$prs_file"
+          owner="${REPO%%/*}"
 
-          BRANCH=$(gh pr view "$PR" --repo "$REPO" --json headRefName -q .headRefName)
-          git checkout "$BRANCH"
-
-          # Already up to date — nothing to do
-          if git merge-base --is-ancestor origin/main HEAD 2>/dev/null; then
-            echo "Already up to date"
-            echo "rebased=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Try clean rebase first
-          if git rebase origin/main 2>/dev/null; then
-            echo "Clean rebase"
-            git push --force-with-lease origin "$BRANCH"
-            echo "rebased=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Conflicts — resolve CSV files (the only kind possible for auto-merge PRs)
-          # Loop handles multi-commit rebases where successive commits conflict
-          while true; do
-            conflicted=$(git diff --name-only --diff-filter=U)
-            [ -z "$conflicted" ] && break
-
-            for file in $conflicted; do
-              if [[ "$file" == "apps/crawler/VERSION" ]]; then
-                # Take main's version and bump patch +1 so CI version check passes
-                git checkout --ours "$file"
-                current=$(cat "$file" | tr -d '[:space:]')
-                IFS='.' read -r major minor patch <<< "$current"
-                echo "${major}.${minor}.$((patch + 1))" > "$file"
-              elif [[ "$file" == *.csv ]]; then
-                # Union merge: take main's version, then apply PR's changes
-                git checkout --ours "$file"
-                git show REBASE_HEAD:"$file" | while IFS= read -r line; do
-                  if ! grep -qxF "$line" "$file"; then
-                    echo "$line" >> "$file"
-                  fi
-                done
-              else
-                git checkout --ours "$file"
+          if [[ "$EVENT_NAME" == "pull_request_target" ]]; then
+            jq -r '.pull_request.number' "$GITHUB_EVENT_PATH" >> "$prs_file"
+          elif [[ "$EVENT_NAME" == "workflow_run" ]]; then
+            jq -r '.workflow_run.pull_requests[]?.number' "$GITHUB_EVENT_PATH" >> "$prs_file"
+            if [[ ! -s "$prs_file" ]]; then
+              branch=$(jq -r '.workflow_run.head_branch // ""' "$GITHUB_EVENT_PATH")
+              head_repo=$(jq -r '.workflow_run.head_repository.full_name // ""' "$GITHUB_EVENT_PATH")
+              if [[ "$head_repo" == "$REPO" && "$branch" == add-company/* ]]; then
+                gh pr list --repo "$REPO" --state open --head "$branch" \
+                  --json number --jq '.[].number' >> "$prs_file"
               fi
-              git add "$file"
-            done
-
-            if GIT_EDITOR=true git rebase --continue 2>/dev/null; then
-              break
             fi
-          done
+          elif [[ -n "$INPUT_PR" ]]; then
+            echo "$INPUT_PR" >> "$prs_file"
+          else
+            gh pr list --repo "$REPO" --state open --limit 100 \
+              --json number,isDraft,headRefName,headRepositoryOwner \
+              --jq ".[] | select(.isDraft == false and .headRepositoryOwner.login == \"$owner\" and (.headRefName | startswith(\"add-company/\"))) | .number" \
+              >> "$prs_file"
+          fi
 
-          git push --force-with-lease origin "$BRANCH"
-          echo "rebased=true" >> "$GITHUB_OUTPUT"
+          sort -nu "$prs_file" > "$RUNNER_TEMP/company-prs.sorted.txt"
+          count=$(wc -l < "$RUNNER_TEMP/company-prs.sorted.txt" | tr -d ' ')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "file=$RUNNER_TEMP/company-prs.sorted.txt" >> "$GITHUB_OUTPUT"
+          cat "$RUNNER_TEMP/company-prs.sorted.txt"
 
-      - name: Merge
-        if: steps.rebase.outputs.rebased == 'true' && steps.images.outputs.pending == 'false'
+      - name: Label, rebase, and merge
+        if: steps.prs.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TRUSTED_SCRIPTS_DIR: ${{ runner.temp }}/trusted-scripts
         run: |
-          # Retry merge — GitHub needs time to update mergeability after force-push
-          for i in 1 2 3; do
-            if gh pr merge "$PR" --repo "$REPO" --rebase 2>/dev/null; then
-              exit 0
-            fi
-            echo "Merge attempt $i failed, waiting..."
-            sleep 5
-          done
-          gh pr merge "$PR" --repo "$REPO" --rebase
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-
-      - name: Close linked company-request issues
-        if: steps.rebase.outputs.rebased == 'true' && steps.images.outputs.pending == 'false'
-        run: "$RUNNER_TEMP/trusted-scripts/close-linked-company-request-issues.sh"
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
+          set -euo pipefail
+          while IFS= read -r pr; do
+            [[ -z "$pr" ]] && continue
+            echo "::group::Process PR #$pr"
+            PR="$pr" "$TRUSTED_SCRIPTS_DIR/maybe-auto-merge-pr.sh"
+            echo "::endgroup::"
+          done < "${{ steps.prs.outputs.file }}"

--- a/docs/05-auto-merge.md
+++ b/docs/05-auto-merge.md
@@ -37,22 +37,30 @@ The agent gets estimates from the test crawl via `ws run monitor`, which reports
 
 ## Auto-Merge Workflow
 
-The `auto-merge-config.yml` workflow:
+The `maybe-auto-merge.yml` workflow:
 
-1. Triggers on PRs labeled `auto-merge`
-2. Checks that the PR only modifies files in `data/`
-3. Waits for CI to pass
-4. Enables auto-merge via GitHub API
+1. Wakes on company PR changes, CI/CodeQL completion, a 15 minute schedule,
+   and manual dispatch
+2. Labels internal non-draft `add-company/*` PRs from trusted scripts
+3. Skips PRs with pending image files so `upload-company-images.yml` can handle
+   the R2 upload path
+4. Rebases CSV conflicts when possible and merges via GitHub API
+5. Exits cleanly when checks are still pending; the next workflow wake retries
+   without operator action
 
 ```yaml
 on:
-  pull_request:
-    types: [labeled]
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+  workflow_run:
+    workflows: ["CI", "CodeQL"]
+    types: [completed]
+  schedule:
+    - cron: "*/15 * * * *"
 
 jobs:
   auto-merge:
-    if: github.event.label.name == 'auto-merge'
-    # ... verify only data/ files changed, then enable auto-merge
+    # ... select eligible company PRs, label, rebase, and merge
 ```
 
 ## Code Change PRs
@@ -75,7 +83,11 @@ PRs from external contributors (forks) currently require human review regardless
 
 ## Safety Rails
 
-- Auto-merge only applies to CSV file changes in `data/`
+- Auto-merge only applies to CSV file changes in `apps/crawler/data/`
 - CI must pass (CSV validation, no broken references)
+- CodeQL is enforced by required `Analyze (...)` status checks, not by a
+  non-path-aware GitHub code-scanning ruleset. This lets data-only company
+  requests satisfy CodeQL through the workflow skip path while code changes
+  still run real CodeQL analysis.
 - The `auto-merge` label can only be applied by the agent or maintainers
 - Any PR touching source code always requires human review

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -12,9 +12,16 @@ const maybeAutoMergeWorkflow = readFileSync(
   ".github/workflows/maybe-auto-merge.yml",
   "utf8",
 );
+const maybeAutoMergeScript = readFileSync(
+  ".github/scripts/maybe-auto-merge-pr.sh",
+  "utf8",
+);
 const publishMcpServerWorkflow = readFileSync(
   ".github/workflows/publish-mcp-server.yml",
   "utf8",
+);
+const mainStrictGateRuleset = JSON.parse(
+  readFileSync(".github/rulesets/main-strict-gate.json", "utf8"),
 );
 
 function setupUvBlocks(workflowSource) {
@@ -82,22 +89,23 @@ test("workflow-security runs repository script tests", () => {
   assert.match(workflow, /scripts\/dealroom-company-requests\.test\.mjs/);
 });
 
-test("maybe-auto-merge hands image PRs to the image upload workflow without rebasing", () => {
+test("maybe-auto-merge wakes without manual retries", () => {
   const job = workflowJobBlock(maybeAutoMergeWorkflow, "label-and-merge");
-  const rebaseStep = job.match(
-    /- name: Rebase and resolve CSV conflicts[\s\S]*?(?=\n      - name: Merge)/,
-  );
-  const labelStep = job.match(
-    /- name: Label PR[\s\S]*?(?=\n      - name: Rebase and resolve CSV conflicts)/,
-  );
+  assert.match(maybeAutoMergeWorkflow, /workflow_run:\n    workflows: \["CI", "CodeQL"\]/);
+  assert.match(maybeAutoMergeWorkflow, /schedule:\n    - cron: "\*\/15 \* \* \* \*"/);
+  assert.match(maybeAutoMergeWorkflow, /workflow_dispatch:/);
+  assert.match(job, /name: Select PRs/);
+  assert.match(job, /name: Label, rebase, and merge/);
+  assert.match(job, /maybe-auto-merge-pr\.sh/);
+});
 
-  assert.ok(rebaseStep, "missing rebase step");
-  assert.ok(labelStep, "missing label step");
-  assert.match(job, /name: Check for pending images/);
-  assert.match(labelStep[0], /if: steps\.images\.outputs\.pending == 'false'/);
-  assert.match(rebaseStep[0], /steps\.images\.outputs\.pending == 'false'/);
-  assert.match(rebaseStep[0], /contains\(steps\.label\.outputs\.labels, 'auto-merge'\)/);
-  assert.doesNotMatch(rebaseStep[0], /steps\.images\.outputs\.pending == 'true'/);
+test("maybe-auto-merge script skips image PRs and retries pending merges", () => {
+  assert.match(maybeAutoMergeScript, /apps\/crawler\/data\/images\//);
+  assert.match(maybeAutoMergeScript, /upload-company-images will handle it/);
+  assert.match(maybeAutoMergeScript, /label-pr\.sh/);
+  assert.match(maybeAutoMergeScript, /git rebase origin\/main/);
+  assert.match(maybeAutoMergeScript, /gh pr merge "\$PR" --repo "\$REPO" --rebase/);
+  assert.match(maybeAutoMergeScript, /scheduled\/workflow_run retries will revisit it/);
 });
 
 test("CodeQL skips full analysis for non-code pull requests", () => {
@@ -129,6 +137,31 @@ test("CodeQL skips full analysis for non-code pull requests", () => {
   assert.match(analyzeJob, /if: needs\.changes\.outputs\.codeql != 'true'/);
   assert.match(analyzeJob, /Initialize CodeQL[\s\S]*if: needs\.changes\.outputs\.codeql == 'true'/);
   assert.match(analyzeJob, /Perform CodeQL Analysis[\s\S]*if: needs\.changes\.outputs\.codeql == 'true'/);
+});
+
+test("main branch ruleset does not require non-path-aware code scanning", () => {
+  assert.equal(mainStrictGateRuleset.name, "main-strict-gate");
+  assert.equal(
+    mainStrictGateRuleset.rules.some((rule) => rule.type === "code_scanning"),
+    false,
+  );
+
+  const statusRule = mainStrictGateRuleset.rules.find(
+    (rule) => rule.type === "required_status_checks",
+  );
+  assert.ok(statusRule, "main-strict-gate should require status checks");
+  const contexts = statusRule.parameters.required_status_checks.map(
+    (check) => check.context,
+  );
+
+  for (const context of [
+    "Required CI",
+    "Analyze (actions)",
+    "Analyze (javascript-typescript)",
+    "Analyze (python)",
+  ]) {
+    assert.ok(contexts.includes(context), `missing required check ${context}`);
+  }
 });
 
 test("CI runs Typesense E2E suites against a service container", () => {


### PR DESCRIPTION
## Summary\n- remove the non-path-aware CodeQL code-scanning ruleset requirement from the documented main branch ruleset shape\n- make maybe-auto-merge wake on CI/CodeQL completion and a 15-minute schedule so ready company PRs retry without manual dispatches\n- move per-PR auto-merge handling into a trusted script that skips image PRs, relabels, rebases CSV conflicts, and exits cleanly when checks are still pending\n\nLive setting already updated: main-strict-gate no longer has the CodeQL code_scanning rule; it still requires Required CI and Analyze (actions/javascript-typescript/python) status checks.\n\nCloses #4983\n\n## Tests\n- node --test scripts/ci-workflow.test.mjs scripts/docs-index.test.mjs scripts/dealroom-company-requests.test.mjs\n- bash -n .github/scripts/maybe-auto-merge-pr.sh\n- uvx --from zizmor==1.26.1 zizmor --persona regular --min-severity medium --min-confidence high .github/workflows/maybe-auto-merge.yml\n- git diff --check