### PR TITLE
Avoid company PR label churn

### DIFF
--- a/.github/scripts/label-pr.sh
+++ b/.github/scripts/label-pr.sh
@@ -310,17 +310,38 @@ if [ "$STATS_FOUND" = "true" ]; then
   fi
 fi
 
-# --- Apply labels (remove stale ones first) ---
+# --- Apply labels (delta only, so repeated runs do not churn timeline events) ---
 
 ALL_DECISION_LABELS="auto-merge review-code review-size review-load incomplete"
-for L in $ALL_DECISION_LABELS; do
-  gh pr edit "$PR" --repo "$REPO" --remove-label "$L" 2>/dev/null || true
-done
+CURRENT_LABELS=$(gh pr view "$PR" --repo "$REPO" --json labels --jq '.labels[].name')
+
+has_current_label() {
+  local label="$1"
+  grep -Fxq "$label" <<< "$CURRENT_LABELS"
+}
+
+declare -A desired_labels=()
 
 IFS=',' read -ra LABEL_ARR <<< "$LABELS"
 for L in "${LABEL_ARR[@]}"; do
+  [ -z "$L" ] && continue
+  desired_labels["$L"]=1
   gh label create "$L" --repo "$REPO" 2>/dev/null || true
-  gh pr edit "$PR" --repo "$REPO" --add-label "$L"
+done
+
+for L in $ALL_DECISION_LABELS; do
+  if [[ -z "${desired_labels[$L]+x}" ]] && has_current_label "$L"; then
+    echo "Removing stale label: $L"
+    gh pr edit "$PR" --repo "$REPO" --remove-label "$L"
+  fi
+done
+
+for L in "${LABEL_ARR[@]}"; do
+  [ -z "$L" ] && continue
+  if ! has_current_label "$L"; then
+    echo "Adding label: $L"
+    gh pr edit "$PR" --repo "$REPO" --add-label "$L"
+  fi
 done
 
 echo "Applied labels: $LABELS"

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -16,6 +16,7 @@ const maybeAutoMergeScript = readFileSync(
   ".github/scripts/maybe-auto-merge-pr.sh",
   "utf8",
 );
+const labelPrScript = readFileSync(".github/scripts/label-pr.sh", "utf8");
 const publishMcpServerWorkflow = readFileSync(
   ".github/workflows/publish-mcp-server.yml",
   "utf8",
@@ -106,6 +107,17 @@ test("maybe-auto-merge script skips image PRs and retries pending merges", () =>
   assert.match(maybeAutoMergeScript, /git rebase origin\/main/);
   assert.match(maybeAutoMergeScript, /gh pr merge "\$PR" --repo "\$REPO" --rebase/);
   assert.match(maybeAutoMergeScript, /scheduled\/workflow_run retries will revisit it/);
+});
+
+test("company PR label script applies decision labels idempotently", () => {
+  assert.match(labelPrScript, /gh pr view "\$PR" --repo "\$REPO" --json labels/);
+  assert.match(labelPrScript, /declare -A desired_labels=\(\)/);
+  assert.match(labelPrScript, /Removing stale label:/);
+  assert.match(labelPrScript, /Adding label:/);
+  assert.doesNotMatch(
+    labelPrScript,
+    /for L in \$ALL_DECISION_LABELS; do\s+gh pr edit "\$PR" --repo "\$REPO" --remove-label "\$L"/,
+  );
 });
 
 test("CodeQL skips full analysis for non-code pull requests", () => {


### PR DESCRIPTION
## Summary
- Make `.github/scripts/label-pr.sh` apply decision labels by delta instead of removing every decision label before re-adding the desired labels
- Keep stale-label cleanup, but only for labels that are actually present and no longer desired
- Add workflow regression coverage so repeated runs stay idempotent

## Context
Observed on #4982: github-actions repeatedly removed and re-added `review-size` on every label run. This keeps the final label set correct without generating timeline churn or waking dependent automations unnecessarily.

## Tests
- `bash -n .github/scripts/label-pr.sh .github/scripts/maybe-auto-merge-pr.sh`
- `node --test scripts/ci-workflow.test.mjs`
- `node --test scripts/ci-workflow.test.mjs scripts/docs-index.test.mjs scripts/dealroom-company-requests.test.mjs`
- `git diff --check`