### PR TITLE
Sweep company PRs after main checks

### DIFF
--- a/.github/workflows/maybe-auto-merge.yml
+++ b/.github/workflows/maybe-auto-merge.yml
@@ -45,12 +45,20 @@ jobs:
           REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
           INPUT_PR: ${{ github.event.inputs.pr || '' }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
 
           prs_file="$RUNNER_TEMP/company-prs.txt"
           : > "$prs_file"
           owner="${REPO%%/*}"
+          default_branch="${DEFAULT_BRANCH:-main}"
+
+          select_open_company_prs() {
+            gh pr list --repo "$REPO" --state open --limit 100 \
+              --json number,isDraft,headRefName,headRepositoryOwner \
+              --jq ".[] | select(.isDraft == false and .headRepositoryOwner.login == \"$owner\" and (.headRefName | startswith(\"add-company/\"))) | .number"
+          }
 
           if [[ "$EVENT_NAME" == "pull_request_target" ]]; then
             jq -r '.pull_request.number' "$GITHUB_EVENT_PATH" >> "$prs_file"
@@ -62,15 +70,14 @@ jobs:
               if [[ "$head_repo" == "$REPO" && "$branch" == add-company/* ]]; then
                 gh pr list --repo "$REPO" --state open --head "$branch" \
                   --json number --jq '.[].number' >> "$prs_file"
+              elif [[ "$head_repo" == "$REPO" && "$branch" == "$default_branch" ]]; then
+                select_open_company_prs >> "$prs_file"
               fi
             fi
           elif [[ -n "$INPUT_PR" ]]; then
             echo "$INPUT_PR" >> "$prs_file"
           else
-            gh pr list --repo "$REPO" --state open --limit 100 \
-              --json number,isDraft,headRefName,headRepositoryOwner \
-              --jq ".[] | select(.isDraft == false and .headRepositoryOwner.login == \"$owner\" and (.headRefName | startswith(\"add-company/\"))) | .number" \
-              >> "$prs_file"
+            select_open_company_prs >> "$prs_file"
           fi
 
           sort -nu "$prs_file" > "$RUNNER_TEMP/company-prs.sorted.txt"

--- a/docs/05-auto-merge.md
+++ b/docs/05-auto-merge.md
@@ -16,8 +16,10 @@ PRs that add company configs can be auto-merged or require human review, based o
 1. The agent estimates job count and crawl time during the test crawl step
 2. The agent includes these estimates in the PR body
 3. The agent applies the appropriate label based on the thresholds
-4. The `auto-merge-config.yml` workflow watches for the `auto-merge` label
-5. If CI passes and the PR only touches `data/*.csv`, it merges automatically
+4. The `maybe-auto-merge.yml` workflow wakes on PR updates and CI/CodeQL
+   completion
+5. If CI passes and the PR only touches allowed company-request files, it
+   merges automatically
 
 ## Examples
 
@@ -40,7 +42,9 @@ The agent gets estimates from the test crawl via `ws run monitor`, which reports
 The `maybe-auto-merge.yml` workflow:
 
 1. Wakes on company PR changes, CI/CodeQL completion, a 15 minute schedule,
-   and manual dispatch
+   and manual dispatch. CI/CodeQL completion on `main` sweeps all eligible
+   open same-repo `add-company/*` PRs, so branches made stale by other merges
+   do not wait for operator action.
 2. Labels internal non-draft `add-company/*` PRs from trusted scripts
 3. Skips PRs with pending image files so `upload-company-images.yml` can handle
    the R2 upload path

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -96,6 +96,8 @@ test("maybe-auto-merge wakes without manual retries", () => {
   assert.match(maybeAutoMergeWorkflow, /schedule:\n    - cron: "\*\/15 \* \* \* \*"/);
   assert.match(maybeAutoMergeWorkflow, /workflow_dispatch:/);
   assert.match(job, /name: Select PRs/);
+  assert.match(job, /select_open_company_prs\(\)/);
+  assert.match(job, /\$branch" == "\$default_branch"/);
   assert.match(job, /name: Label, rebase, and merge/);
   assert.match(job, /maybe-auto-merge-pr\.sh/);
 });


### PR DESCRIPTION
## Summary
- Make `workflow_run` wakeups on the default branch sweep all eligible same-repo `add-company/*` PRs
- Keep add-company branch workflow_run handling for targeted retries after CI/CodeQL
- Update docs and regression tests for the no-manual-housekeeping path

## Context
After #4984 landed, workflow_run wakeups on `main` were successful no-ops. That still leaves stale ready company PRs such as #4980 dependent on cron timing. This change makes every main CI/CodeQL completion act as a queue sweep, so normal merges to `main` immediately retry stale company requests.

## Tests
- `node --test scripts/ci-workflow.test.mjs scripts/docs-index.test.mjs scripts/dealroom-company-requests.test.mjs`
- `actionlint .github/workflows/maybe-auto-merge.yml`
- `uvx --from zizmor==1.26.1 zizmor --persona regular --min-severity medium --min-confidence high .github/workflows/maybe-auto-merge.yml`
- `git diff --check`