### PR TITLE
Make company label delta portable

### DIFF
--- a/.github/scripts/label-pr.sh
+++ b/.github/scripts/label-pr.sh
@@ -314,29 +314,31 @@ fi
 
 ALL_DECISION_LABELS="auto-merge review-code review-size review-load incomplete"
 CURRENT_LABELS=$(gh pr view "$PR" --repo "$REPO" --json labels --jq '.labels[].name')
+DESIRED_LABELS=",$LABELS,"
 
 has_current_label() {
   local label="$1"
   grep -Fxq "$label" <<< "$CURRENT_LABELS"
 }
 
-declare -A desired_labels=()
+has_desired_label() {
+  local label="$1"
+  [[ "$DESIRED_LABELS" == *",$label,"* ]]
+}
 
-IFS=',' read -ra LABEL_ARR <<< "$LABELS"
-for L in "${LABEL_ARR[@]}"; do
+for L in ${LABELS//,/ }; do
   [ -z "$L" ] && continue
-  desired_labels["$L"]=1
   gh label create "$L" --repo "$REPO" 2>/dev/null || true
 done
 
 for L in $ALL_DECISION_LABELS; do
-  if [[ -z "${desired_labels[$L]+x}" ]] && has_current_label "$L"; then
+  if ! has_desired_label "$L" && has_current_label "$L"; then
     echo "Removing stale label: $L"
     gh pr edit "$PR" --repo "$REPO" --remove-label "$L"
   fi
 done
 
-for L in "${LABEL_ARR[@]}"; do
+for L in ${LABELS//,/ }; do
   [ -z "$L" ] && continue
   if ! has_current_label "$L"; then
     echo "Adding label: $L"

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -113,7 +113,9 @@ test("maybe-auto-merge script skips image PRs and retries pending merges", () =>
 
 test("company PR label script applies decision labels idempotently", () => {
   assert.match(labelPrScript, /gh pr view "\$PR" --repo "\$REPO" --json labels/);
-  assert.match(labelPrScript, /declare -A desired_labels=\(\)/);
+  assert.match(labelPrScript, /DESIRED_LABELS=",\$LABELS,"/);
+  assert.match(labelPrScript, /has_desired_label\(\)/);
+  assert.doesNotMatch(labelPrScript, /declare -A/);
   assert.match(labelPrScript, /Removing stale label:/);
   assert.match(labelPrScript, /Adding label:/);
   assert.doesNotMatch(


### PR DESCRIPTION
## Summary
- replace Bash 4 associative-array label tracking with exact string membership
- keep company PR decision label updates idempotent without timeline churn
- add a regression assertion that label-pr.sh does not use associative arrays

## Verification
- bash -n .github/scripts/label-pr.sh .github/scripts/maybe-auto-merge-pr.sh
- GH_TOKEN=... PR=4986 REPO=colophon-group/jobseek GITHUB_OUTPUT=... bash .github/scripts/label-pr.sh
- node --test scripts/ci-workflow.test.mjs scripts/docs-index.test.mjs scripts/dealroom-company-requests.test.mjs
- git diff --check