### PR TITLE
Fix company bot commit CI handoff

### DIFF
--- a/.github/rulesets/main-strict-gate.json
+++ b/.github/rulesets/main-strict-gate.json
@@ -19,18 +19,6 @@
           {
             "context": "Required CI",
             "integration_id": 15368
-          },
-          {
-            "context": "Analyze (actions)",
-            "integration_id": 15368
-          },
-          {
-            "context": "Analyze (javascript-typescript)",
-            "integration_id": 15368
-          },
-          {
-            "context": "Analyze (python)",
-            "integration_id": 15368
           }
         ]
       }

--- a/.github/scripts/classify-pr-paths.sh
+++ b/.github/scripts/classify-pr-paths.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${REPO:?REPO is required}"
+: "${PR:?PR is required}"
+
+is_non_code_path() {
+  local file="$1"
+
+  case "$file" in
+    *.md | \
+      docs/* | \
+      .github/dependabot.yml | \
+      .github/dependabot.yaml | \
+      .github/ISSUE_TEMPLATE/* | \
+      .github/DISCUSSION_TEMPLATE/* | \
+      apps/crawler/data/* | \
+      apps/crawler/traces/* | \
+      apps/crawler/VERSION)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+is_crawler_code_path() {
+  local file="$1"
+
+  [[ "$file" == apps/crawler/* ]] || return 1
+
+  case "$file" in
+    *.md | apps/crawler/data/* | apps/crawler/traces/* | apps/crawler/VERSION)
+      return 1
+      ;;
+  esac
+
+  return 0
+}
+
+code=false
+crawler_code=false
+boards_csv=false
+
+while IFS= read -r file; do
+  [[ -n "$file" ]] || continue
+
+  if ! is_non_code_path "$file"; then
+    code=true
+  fi
+
+  if is_crawler_code_path "$file"; then
+    crawler_code=true
+  fi
+
+  if [[ "$file" == "apps/crawler/data/boards.csv" ]]; then
+    boards_csv=true
+  fi
+done < <(gh api --paginate "repos/$REPO/pulls/$PR/files" --jq '.[].filename')
+
+emit() {
+  local name="$1"
+  local value="$2"
+
+  echo "$name=$value"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "$name=$value" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+emit "code" "$code"
+emit "crawler_code" "$crawler_code"
+emit "boards_csv" "$boards_csv"
+emit "codeql" "$code"

--- a/.github/scripts/dispatch-pr-checks.sh
+++ b/.github/scripts/dispatch-pr-checks.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${REPO:?REPO is required}"
+: "${PR:?PR is required}"
+
+OWNER="${REPO%%/*}"
+
+pr_json=$(gh pr view "$PR" --repo "$REPO" \
+  --json state,isDraft,headRefName,headRepositoryOwner \
+  --jq '{state,isDraft,headRefName,headRepositoryOwner}')
+
+state=$(jq -r '.state' <<< "$pr_json")
+draft=$(jq -r '.isDraft' <<< "$pr_json")
+branch="${BRANCH:-$(jq -r '.headRefName' <<< "$pr_json")}"
+head_owner=$(jq -r '.headRepositoryOwner.login' <<< "$pr_json")
+
+if [[ "$state" != "OPEN" ]]; then
+  echo "PR #$PR is $state; not dispatching checks"
+  exit 0
+fi
+
+if [[ "$draft" == "true" ]]; then
+  echo "PR #$PR is draft; not dispatching checks"
+  exit 0
+fi
+
+if [[ "$head_owner" != "$OWNER" ]]; then
+  echo "PR #$PR is from $head_owner, not $OWNER; not dispatching checks"
+  exit 0
+fi
+
+if [[ "$branch" != add-company/* ]]; then
+  echo "PR #$PR branch is $branch, not add-company/*; not dispatching checks"
+  exit 0
+fi
+
+echo "Dispatching path-aware CI for PR #$PR on $branch"
+gh workflow run ci.yml --repo "$REPO" --ref "$branch" -f "pr=$PR"

--- a/.github/scripts/maybe-auto-merge-pr.sh
+++ b/.github/scripts/maybe-auto-merge-pr.sh
@@ -108,7 +108,8 @@ else
   fi
 
   git push --force-with-lease origin "$branch"
-  echo "PR #$PR branch updated; checks will run before merge"
+  "$SCRIPTS_DIR/dispatch-pr-checks.sh"
+  echo "PR #$PR branch updated; dispatched checks before merge"
 fi
 
 for attempt in 1 2 3; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main, murmur-demo]
   workflow_dispatch:
+    inputs:
+      pr:
+        description: "Optional PR number for path-aware bot retry"
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -70,23 +75,32 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      code: ${{ steps.manual.outputs.code || steps.filter.outputs.code }}
-      crawler_code: ${{ steps.manual.outputs.crawler_code || steps.filter.outputs.crawler_code }}
-      boards_csv: ${{ steps.manual.outputs.boards_csv || steps.filter.outputs.boards_csv }}
+      code: ${{ steps.manual-default.outputs.code || steps.manual-pr.outputs.code || steps.filter.outputs.code }}
+      crawler_code: ${{ steps.manual-default.outputs.crawler_code || steps.manual-pr.outputs.crawler_code || steps.filter.outputs.crawler_code }}
+      boards_csv: ${{ steps.manual-default.outputs.boards_csv || steps.manual-pr.outputs.boards_csv || steps.filter.outputs.boards_csv }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
           fetch-depth: 0
 
       - name: Manual dispatch defaults
-        id: manual
-        if: github.event_name == 'workflow_dispatch'
+        id: manual-default
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.pr == ''
         run: |
           {
             echo "code=true"
             echo "crawler_code=false"
             echo "boards_csv=false"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Classify manually dispatched PR paths
+        id: manual-pr
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.pr != ''
+        run: .github/scripts/classify-pr-paths.sh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.inputs.pr }}
 
       - name: Detect changed paths
         id: filter

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,9 +5,24 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+      - ".github/dependabot.yml"
+      - ".github/dependabot.yaml"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/DISCUSSION_TEMPLATE/**"
+      - "apps/crawler/data/**"
+      - "apps/crawler/traces/**"
+      - "apps/crawler/VERSION"
   schedule:
     - cron: "17 3 * * 1"
   workflow_dispatch:
+    inputs:
+      pr:
+        description: "Optional PR number for path-aware bot retry"
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,7 +39,7 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      codeql: ${{ steps.default.outputs.codeql || steps.filter.outputs.codeql }}
+      codeql: ${{ steps.default.outputs.codeql || steps.manual-pr.outputs.codeql || steps.filter.outputs.codeql }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
@@ -32,8 +47,17 @@ jobs:
 
       - name: Non-PR CodeQL default
         id: default
-        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || github.event.inputs.pr == '')
         run: echo "codeql=true" >> "$GITHUB_OUTPUT"
+
+      - name: Classify manually dispatched PR paths
+        id: manual-pr
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.pr != ''
+        run: .github/scripts/classify-pr-paths.sh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.inputs.pr }}
 
       - name: Detect changed paths
         id: filter

--- a/.github/workflows/maybe-auto-merge.yml
+++ b/.github/workflows/maybe-auto-merge.yml
@@ -20,6 +20,7 @@ jobs:
   label-and-merge:
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       contents: write
       issues: write
       pull-requests: write
@@ -36,6 +37,7 @@ jobs:
           cp .github/scripts/label-pr.sh "$RUNNER_TEMP/trusted-scripts/label-pr.sh"
           cp .github/scripts/close-linked-company-request-issues.sh "$RUNNER_TEMP/trusted-scripts/close-linked-company-request-issues.sh"
           cp .github/scripts/maybe-auto-merge-pr.sh "$RUNNER_TEMP/trusted-scripts/maybe-auto-merge-pr.sh"
+          cp .github/scripts/dispatch-pr-checks.sh "$RUNNER_TEMP/trusted-scripts/dispatch-pr-checks.sh"
           chmod +x "$RUNNER_TEMP/trusted-scripts/"*.sh
 
       - name: Select PRs

--- a/.github/workflows/upload-company-images.yml
+++ b/.github/workflows/upload-company-images.yml
@@ -14,6 +14,7 @@ on:
         type: string
 
 permissions:
+  actions: write
   contents: write
   issues: write
   pull-requests: write
@@ -52,6 +53,7 @@ jobs:
           mkdir -p "$RUNNER_TEMP/trusted-scripts"
           cp .github/scripts/label-pr.sh "$RUNNER_TEMP/trusted-scripts/label-pr.sh"
           cp .github/scripts/close-linked-company-request-issues.sh "$RUNNER_TEMP/trusted-scripts/close-linked-company-request-issues.sh"
+          cp .github/scripts/dispatch-pr-checks.sh "$RUNNER_TEMP/trusted-scripts/dispatch-pr-checks.sh"
           chmod +x "$RUNNER_TEMP/trusted-scripts/"*.sh
 
       - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
@@ -67,6 +69,7 @@ jobs:
         working-directory: apps/crawler
 
       - name: Upload images to R2 and push cleanup
+        id: image-sync
         env:
           BRANCH: ${{ github.event.pull_request.head.ref || inputs.branch || github.ref_name }}
           R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
@@ -77,6 +80,7 @@ jobs:
         run: |
           set -euo pipefail
 
+          echo "pushed=false" >> "$GITHUB_OUTPUT"
           git check-ref-format --branch "$BRANCH" >/dev/null
           trusted_ref="$(git rev-parse HEAD)"
 
@@ -107,6 +111,7 @@ jobs:
             git commit -m "Upload images to R2"
 
             if git push --force-with-lease origin "HEAD:$BRANCH"; then
+              echo "pushed=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
 
@@ -117,6 +122,16 @@ jobs:
 
           echo "Unable to commit image upload after 3 attempts" >&2
           exit 1
+
+      - name: Dispatch checks for image commit
+        if: github.event_name != 'workflow_dispatch' && steps.image-sync.outputs.pushed == 'true'
+        run: |
+          "$RUNNER_TEMP/trusted-scripts/dispatch-pr-checks.sh"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
 
       - name: Post image preview comment
         if: github.event_name != 'workflow_dispatch'
@@ -225,6 +240,12 @@ jobs:
             gh pr checks "$PR" --repo "$REPO" --watch --fail-fast || true
             gh pr merge "$PR" --repo "$REPO" --rebase
             echo "merged=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if echo "$output" | grep -q "Auto merge is not allowed for this repository"; then
+            echo "Repository auto-merge is disabled; maybe-auto-merge will retry after checks pass."
+            echo "merged=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -16,6 +16,14 @@ const maybeAutoMergeScript = readFileSync(
   ".github/scripts/maybe-auto-merge-pr.sh",
   "utf8",
 );
+const classifyPrPathsScript = readFileSync(
+  ".github/scripts/classify-pr-paths.sh",
+  "utf8",
+);
+const dispatchPrChecksScript = readFileSync(
+  ".github/scripts/dispatch-pr-checks.sh",
+  "utf8",
+);
 const labelPrScript = readFileSync(".github/scripts/label-pr.sh", "utf8");
 const publishMcpServerWorkflow = readFileSync(
   ".github/workflows/publish-mcp-server.yml",
@@ -83,6 +91,19 @@ test("CI no longer shells out to custom diff classification", () => {
   assert.equal(workflow.includes("git diff-tree"), false);
 });
 
+test("manual CI dispatch can classify a PR without full code checks", () => {
+  const changesJob = jobBlock("changes");
+  assert.match(workflow, /workflow_dispatch:\n    inputs:\n      pr:/);
+  assert.match(changesJob, /id: manual-default/);
+  assert.match(changesJob, /id: manual-pr/);
+  assert.match(changesJob, /\.github\/scripts\/classify-pr-paths\.sh/);
+  assert.match(classifyPrPathsScript, /gh api --paginate "repos\/\$REPO\/pulls\/\$PR\/files"/);
+  assert.match(classifyPrPathsScript, /emit "code" "\$code"/);
+  assert.match(classifyPrPathsScript, /emit "crawler_code" "\$crawler_code"/);
+  assert.match(classifyPrPathsScript, /emit "boards_csv" "\$boards_csv"/);
+  assert.match(classifyPrPathsScript, /emit "codeql" "\$code"/);
+});
+
 test("workflow-security runs repository script tests", () => {
   assert.match(workflow, /node --test/);
   assert.match(workflow, /scripts\/ci-workflow\.test\.mjs/);
@@ -107,8 +128,24 @@ test("maybe-auto-merge script skips image PRs and retries pending merges", () =>
   assert.match(maybeAutoMergeScript, /upload-company-images will handle it/);
   assert.match(maybeAutoMergeScript, /label-pr\.sh/);
   assert.match(maybeAutoMergeScript, /git rebase origin\/main/);
+  assert.match(maybeAutoMergeScript, /dispatch-pr-checks\.sh/);
   assert.match(maybeAutoMergeScript, /gh pr merge "\$PR" --repo "\$REPO" --rebase/);
   assert.match(maybeAutoMergeScript, /scheduled\/workflow_run retries will revisit it/);
+});
+
+test("bot-authored company branch updates dispatch path-aware CI", () => {
+  assert.match(dispatchPrChecksScript, /gh workflow run ci\.yml --repo "\$REPO" --ref "\$branch" -f "pr=\$PR"/);
+  assert.doesNotMatch(dispatchPrChecksScript, /codeql\.yml/);
+  assert.match(dispatchPrChecksScript, /"\$branch" != add-company\/\*/);
+
+  assert.match(maybeAutoMergeWorkflow, /actions: write/);
+  assert.match(maybeAutoMergeWorkflow, /dispatch-pr-checks\.sh/);
+
+  assert.match(uploadCompanyImagesWorkflow, /actions: write/);
+  assert.match(uploadCompanyImagesWorkflow, /id: image-sync/);
+  assert.match(uploadCompanyImagesWorkflow, /steps\.image-sync\.outputs\.pushed == 'true'/);
+  assert.match(uploadCompanyImagesWorkflow, /Dispatch checks for image commit/);
+  assert.match(uploadCompanyImagesWorkflow, /Auto merge is not allowed for this repository/);
 });
 
 test("company PR label script applies decision labels idempotently", () => {
@@ -126,7 +163,10 @@ test("company PR label script applies decision labels idempotently", () => {
 
 test("CodeQL skips full analysis for non-code pull requests", () => {
   const changesJob = workflowJobBlock(codeqlWorkflow, "changes");
+  assert.match(codeqlWorkflow, /pull_request:\n    branches: \[main\]\n    paths-ignore:/);
   assert.match(changesJob, /name: Detect CodeQL changes/);
+  assert.match(changesJob, /id: manual-pr/);
+  assert.match(changesJob, /\.github\/scripts\/classify-pr-paths\.sh/);
   assert.match(changesJob, /uses: dorny\/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3/);
   assert.match(changesJob, /predicate-quantifier: every/);
   assert.match(changesJob, /codeql:\n(?:              - .+\n)+/);
@@ -170,14 +210,7 @@ test("main branch ruleset does not require non-path-aware code scanning", () => 
     (check) => check.context,
   );
 
-  for (const context of [
-    "Required CI",
-    "Analyze (actions)",
-    "Analyze (javascript-typescript)",
-    "Analyze (python)",
-  ]) {
-    assert.ok(contexts.includes(context), `missing required check ${context}`);
-  }
+  assert.deepEqual(contexts, ["Required CI"]);
 });
 
 test("CI runs Typesense E2E suites against a service container", () => {


### PR DESCRIPTION
## Summary
- stop requiring CodeQL status contexts in the main ruleset snapshot so data-only company PRs only need Required CI
- make CodeQL ignore non-code PR paths at the trigger level
- add a PR path classifier for workflow_dispatch CI retries
- dispatch path-aware CI after image-upload and auto-merge bot pushes so GitHub's suppressed pull_request runs do not block company PRs
- keep image upload successful when repository auto-merge is disabled and leave merging to maybe-auto-merge

## Why
#4991 was data-only, but the R2 image uploader pushed a github-actions bot commit. GitHub then created zero-job action_required CI/CodeQL runs for the new head SHA, while a dynamic CodeQL scan still ran. Because the ruleset still required CodeQL contexts, the PR looked like code checks were required for CSV-only changes and could not merge hands-off.

## Validation
- bash -n .github/scripts/classify-pr-paths.sh .github/scripts/dispatch-pr-checks.sh .github/scripts/maybe-auto-merge-pr.sh .github/scripts/label-pr.sh
- node --test scripts/ci-workflow.test.mjs scripts/docs-index.test.mjs scripts/dealroom-company-requests.test.mjs
- actionlint .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/maybe-auto-merge.yml .github/workflows/upload-company-images.yml
- uvx --from zizmor==1.26.1 zizmor --persona regular --min-severity medium --min-confidence high .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/maybe-auto-merge.yml .github/workflows/upload-company-images.yml
- jq empty .github/rulesets/main-strict-gate.json
- git diff --check