### PR TITLE
Publish Required CI status for company retries

### DIFF
--- a/.github/rulesets/main-strict-gate.json
+++ b/.github/rulesets/main-strict-gate.json
@@ -13,12 +13,11 @@
     {
       "type": "required_status_checks",
       "parameters": {
-        "strict_required_status_checks_policy": true,
+        "strict_required_status_checks_policy": false,
         "do_not_enforce_on_create": true,
         "required_status_checks": [
           {
-            "context": "Required CI",
-            "integration_id": 15368
+            "context": "Required CI"
           }
         ]
       }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -750,12 +750,17 @@ jobs:
       - version-check
       - probe-new-boards
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - name: Check required job results
         env:
           NEEDS_JSON: ${{ toJson(needs) }}
           EVENT_NAME: ${{ github.event_name }}
+          INPUT_PR: ${{ github.event.inputs.pr || '' }}
+          GH_TOKEN: ${{ github.token }}
         run: |
+          set +e
           node <<'NODE'
           const needs = JSON.parse(process.env.NEEDS_JSON);
           const eventName = process.env.EVENT_NAME;
@@ -813,3 +818,23 @@ jobs:
           }
           console.log("Required CI passed");
           NODE
+          status=$?
+          set -e
+
+          if [[ "$EVENT_NAME" == "workflow_dispatch" && -n "$INPUT_PR" ]]; then
+            if [[ "$status" -eq 0 ]]; then
+              state=success
+              description="Required CI passed"
+            else
+              state=failure
+              description="Required CI failed"
+            fi
+
+            gh api -X POST "repos/$GITHUB_REPOSITORY/statuses/$GITHUB_SHA" \
+              -f state="$state" \
+              -f context="Required CI" \
+              -f description="$description" \
+              -f target_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          fi
+
+          exit "$status"

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -206,11 +206,26 @@ test("main branch ruleset does not require non-path-aware code scanning", () => 
     (rule) => rule.type === "required_status_checks",
   );
   assert.ok(statusRule, "main-strict-gate should require status checks");
+  assert.equal(statusRule.parameters.strict_required_status_checks_policy, false);
   const contexts = statusRule.parameters.required_status_checks.map(
     (check) => check.context,
   );
 
   assert.deepEqual(contexts, ["Required CI"]);
+  assert.equal(
+    Object.hasOwn(statusRule.parameters.required_status_checks[0], "integration_id"),
+    false,
+  );
+});
+
+test("workflow-dispatched CI publishes the Required CI status context", () => {
+  const requiredCiJob = jobBlock("required-ci");
+  assert.match(requiredCiJob, /permissions:\n      statuses: write/);
+  assert.match(requiredCiJob, /INPUT_PR: \$\{\{ github\.event\.inputs\.pr \|\| '' \}\}/);
+  assert.match(requiredCiJob, /if \[\[ "\$EVENT_NAME" == "workflow_dispatch" && -n "\$INPUT_PR" \]\]/);
+  assert.match(requiredCiJob, /repos\/\$GITHUB_REPOSITORY\/statuses\/\$GITHUB_SHA/);
+  assert.match(requiredCiJob, /-f context="Required CI"/);
+  assert.match(requiredCiJob, /exit "\$status"/);
 });
 
 test("CI runs Typesense E2E suites against a service container", () => {


### PR DESCRIPTION
## Summary
- publish a `Required CI` commit status when CI is run through the company PR workflow_dispatch retry path
- make the main ruleset snapshot accept that context without pinning to a GitHub Actions check-run integration
- turn off strict required-status mode so the bot-dispatched head status can satisfy the gate after auto-merge rebases company PRs

## Why
The #4991 fix proved that workflow_dispatch CI can pass on the branch head but still not appear in the PR status rollup as the required check. A commit status context does appear in the rollup and lets the company flow merge hands-off after the path-aware CI has passed.

## Validation
- bash -n .github/scripts/classify-pr-paths.sh .github/scripts/dispatch-pr-checks.sh .github/scripts/maybe-auto-merge-pr.sh .github/scripts/label-pr.sh
- node --test scripts/ci-workflow.test.mjs scripts/docs-index.test.mjs scripts/dealroom-company-requests.test.mjs
- actionlint .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/maybe-auto-merge.yml .github/workflows/upload-company-images.yml
- uvx --from zizmor==1.26.1 zizmor --persona regular --min-severity medium --min-confidence high .github/workflows/ci.yml
- jq empty .github/rulesets/main-strict-gate.json
- git diff --check