### PR TITLE
Tolerate old company CI dispatch inputs

### DIFF
--- a/.github/scripts/dispatch-pr-checks.sh
+++ b/.github/scripts/dispatch-pr-checks.sh
@@ -38,4 +38,16 @@ if [[ "$branch" != add-company/* ]]; then
 fi
 
 echo "Dispatching path-aware CI for PR #$PR on $branch"
-gh workflow run ci.yml --repo "$REPO" --ref "$branch" -f "pr=$PR"
+output=$(gh workflow run ci.yml --repo "$REPO" --ref "$branch" -f "pr=$PR" 2>&1) && {
+  echo "$output"
+  exit 0
+}
+status=$?
+echo "$output"
+
+if grep -q 'Unexpected inputs provided: \["pr"\]' <<< "$output"; then
+  echo "::warning::Branch $branch does not yet include path-aware workflow_dispatch input; a later rebase retry will dispatch CI."
+  exit 0
+fi
+
+exit "$status"

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -137,6 +137,8 @@ test("bot-authored company branch updates dispatch path-aware CI", () => {
   assert.match(dispatchPrChecksScript, /gh workflow run ci\.yml --repo "\$REPO" --ref "\$branch" -f "pr=\$PR"/);
   assert.doesNotMatch(dispatchPrChecksScript, /codeql\.yml/);
   assert.match(dispatchPrChecksScript, /"\$branch" != add-company\/\*/);
+  assert.match(dispatchPrChecksScript, /Unexpected inputs provided: \\\["pr"\\\]/);
+  assert.match(dispatchPrChecksScript, /later rebase retry will dispatch CI/);
 
   assert.match(maybeAutoMergeWorkflow, /actions: write/);
   assert.match(maybeAutoMergeWorkflow, /dispatch-pr-checks\.sh/);


### PR DESCRIPTION
## Summary
- make dispatch-pr-checks tolerate old add-company branches whose CI workflow does not yet declare the `pr` workflow_dispatch input
- keep the workflow successful and let a later rebase retry dispatch path-aware CI from the updated workflow

## Why
#4996 was created before the new CI dispatch input landed. Its image upload did useful work, then failed because dispatching `ci.yml` with `pr=4996` hit GitHub's `Unexpected inputs provided: ["pr"]`. This should be a transitional warning, not a failed upload workflow.

## Validation
- bash -n .github/scripts/dispatch-pr-checks.sh .github/scripts/classify-pr-paths.sh .github/scripts/maybe-auto-merge-pr.sh .github/scripts/label-pr.sh
- node --test scripts/ci-workflow.test.mjs scripts/docs-index.test.mjs scripts/dealroom-company-requests.test.mjs
- git diff --check