### PR TITLE
Retry company auto-merge after image uploads

### DIFF
--- a/.github/scripts/maybe-auto-merge-pr.sh
+++ b/.github/scripts/maybe-auto-merge-pr.sh
@@ -54,6 +54,48 @@ if [[ ",$labels," != *",auto-merge,"* ]]; then
   exit 0
 fi
 
+required_ci_state() {
+  gh pr view "$PR" --repo "$REPO" --json statusCheckRollup --jq '
+    [
+      .statusCheckRollup[]
+      | select(
+          (.__typename == "StatusContext" and .context == "Required CI")
+          or (.__typename == "CheckRun" and .name == "Required CI")
+        )
+      | if .__typename == "StatusContext" then .state else .conclusion end
+    ]
+    | last // ""
+  '
+}
+
+wait_for_required_ci() {
+  for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24; do
+    state=$(required_ci_state)
+
+    case "$state" in
+      SUCCESS|success)
+        echo "PR #$PR Required CI is successful"
+        return 0
+        ;;
+      FAILURE|ERROR|CANCELLED|TIMED_OUT|ACTION_REQUIRED|failure|cancelled|timed_out|action_required)
+        echo "PR #$PR Required CI is $state; not auto-merging"
+        return 1
+        ;;
+      "")
+        echo "PR #$PR is waiting for Required CI to be reported (attempt $attempt/24)"
+        ;;
+      *)
+        echo "PR #$PR Required CI is $state; waiting (attempt $attempt/24)"
+        ;;
+    esac
+
+    sleep 10
+  done
+
+  echo "PR #$PR Required CI did not become successful in time"
+  return 1
+}
+
 git config user.name "github-actions[bot]"
 git config user.email "github-actions[bot]@users.noreply.github.com"
 
@@ -110,6 +152,11 @@ else
   git push --force-with-lease origin "$branch"
   "$SCRIPTS_DIR/dispatch-pr-checks.sh"
   echo "PR #$PR branch updated; dispatched checks before merge"
+fi
+
+if ! wait_for_required_ci; then
+  echo "PR #$PR is not mergeable yet; scheduled/workflow_run retries will revisit it"
+  exit 0
 fi
 
 for attempt in 1 2 3; do

--- a/.github/workflows/maybe-auto-merge.yml
+++ b/.github/workflows/maybe-auto-merge.yml
@@ -65,15 +65,16 @@ jobs:
           if [[ "$EVENT_NAME" == "pull_request_target" ]]; then
             jq -r '.pull_request.number' "$GITHUB_EVENT_PATH" >> "$prs_file"
           elif [[ "$EVENT_NAME" == "workflow_run" ]]; then
-            jq -r '.workflow_run.pull_requests[]?.number' "$GITHUB_EVENT_PATH" >> "$prs_file"
-            if [[ ! -s "$prs_file" ]]; then
-              branch=$(jq -r '.workflow_run.head_branch // ""' "$GITHUB_EVENT_PATH")
-              head_repo=$(jq -r '.workflow_run.head_repository.full_name // ""' "$GITHUB_EVENT_PATH")
-              if [[ "$head_repo" == "$REPO" && "$branch" == add-company/* ]]; then
+            branch=$(jq -r '.workflow_run.head_branch // ""' "$GITHUB_EVENT_PATH")
+            head_repo=$(jq -r '.workflow_run.head_repository.full_name // ""' "$GITHUB_EVENT_PATH")
+
+            if [[ "$head_repo" == "$REPO" && "$branch" == "$default_branch" ]]; then
+              select_open_company_prs >> "$prs_file"
+            else
+              jq -r '.workflow_run.pull_requests[]?.number' "$GITHUB_EVENT_PATH" >> "$prs_file"
+              if [[ ! -s "$prs_file" && "$head_repo" == "$REPO" && "$branch" == add-company/* ]]; then
                 gh pr list --repo "$REPO" --state open --head "$branch" \
                   --json number --jq '.[].number' >> "$prs_file"
-              elif [[ "$head_repo" == "$REPO" && "$branch" == "$default_branch" ]]; then
-                select_open_company_prs >> "$prs_file"
               fi
             fi
           elif [[ -n "$INPUT_PR" ]]; then

--- a/.github/workflows/upload-company-images.yml
+++ b/.github/workflows/upload-company-images.yml
@@ -54,6 +54,7 @@ jobs:
           cp .github/scripts/label-pr.sh "$RUNNER_TEMP/trusted-scripts/label-pr.sh"
           cp .github/scripts/close-linked-company-request-issues.sh "$RUNNER_TEMP/trusted-scripts/close-linked-company-request-issues.sh"
           cp .github/scripts/dispatch-pr-checks.sh "$RUNNER_TEMP/trusted-scripts/dispatch-pr-checks.sh"
+          cp .github/scripts/maybe-auto-merge-pr.sh "$RUNNER_TEMP/trusted-scripts/maybe-auto-merge-pr.sh"
           chmod +x "$RUNNER_TEMP/trusted-scripts/"*.sh
 
       - uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
@@ -264,3 +265,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+
+      - name: Retry trusted auto-merge
+        if: >-
+          github.event_name != 'workflow_dispatch'
+          && contains(steps.label.outputs.labels, 'auto-merge')
+          && steps.merge.outputs.merged != 'true'
+        run: |
+          "$RUNNER_TEMP/trusted-scripts/maybe-auto-merge-pr.sh"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          TRUSTED_SCRIPTS_DIR: ${{ runner.temp }}/trusted-scripts

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -119,6 +119,7 @@ test("maybe-auto-merge wakes without manual retries", () => {
   assert.match(job, /name: Select PRs/);
   assert.match(job, /select_open_company_prs\(\)/);
   assert.match(job, /\$branch" == "\$default_branch"/);
+  assert.match(job, /\$branch" == "\$default_branch"[\s\S]*select_open_company_prs >> "\$prs_file"/);
   assert.match(job, /name: Label, rebase, and merge/);
   assert.match(job, /maybe-auto-merge-pr\.sh/);
 });
@@ -129,6 +130,9 @@ test("maybe-auto-merge script skips image PRs and retries pending merges", () =>
   assert.match(maybeAutoMergeScript, /label-pr\.sh/);
   assert.match(maybeAutoMergeScript, /git rebase origin\/main/);
   assert.match(maybeAutoMergeScript, /dispatch-pr-checks\.sh/);
+  assert.match(maybeAutoMergeScript, /required_ci_state\(\)/);
+  assert.match(maybeAutoMergeScript, /wait_for_required_ci\(\)/);
+  assert.match(maybeAutoMergeScript, /Required CI is successful/);
   assert.match(maybeAutoMergeScript, /gh pr merge "\$PR" --repo "\$REPO" --rebase/);
   assert.match(maybeAutoMergeScript, /scheduled\/workflow_run retries will revisit it/);
 });
@@ -148,6 +152,9 @@ test("bot-authored company branch updates dispatch path-aware CI", () => {
   assert.match(uploadCompanyImagesWorkflow, /steps\.image-sync\.outputs\.pushed == 'true'/);
   assert.match(uploadCompanyImagesWorkflow, /Dispatch checks for image commit/);
   assert.match(uploadCompanyImagesWorkflow, /Auto merge is not allowed for this repository/);
+  assert.match(uploadCompanyImagesWorkflow, /maybe-auto-merge-pr\.sh/);
+  assert.match(uploadCompanyImagesWorkflow, /Retry trusted auto-merge/);
+  assert.match(uploadCompanyImagesWorkflow, /TRUSTED_SCRIPTS_DIR: \$\{\{ runner\.temp \}\}\/trusted-scripts/);
 });
 
 test("company PR label script applies decision labels idempotently", () => {


### PR DESCRIPTION
## Summary
- make `maybe-auto-merge` sweep all open company PRs after `main` workflow completions, even when the workflow payload names one closed PR
- wait for the `Required CI` status before giving up on trusted auto-merge attempts
- have `upload-company-images` invoke the trusted auto-merge script after image cleanup when repository auto-merge is disabled

## Root cause
`maybe-auto-merge` skipped PRs while staged image files were present. After `upload-company-images` removed those files and dispatched CI, the merge retry ran too early and gave up before `Required CI` was visible. Later `main` workflow completions did not sweep all company PRs if the event payload included a single merged PR, so ready `auto-merge` PRs such as #4998 and #5000 stayed open.

The extra CodeQL jobs on #4998/#5000 are GitHub Code Quality (`dynamic/github-code-scanning/codeql`), not the checked-in `.github/workflows/codeql.yml`; the repo workflow already has path filters.

## Validation
- `node --test scripts/ci-workflow.test.mjs`
- `bash -n .github/scripts/maybe-auto-merge-pr.sh`
- `git diff --check`