### PR TITLE
Add vivo-defence-services

### DIFF
--- a/apps/crawler/data/companies.csv
+++ b/apps/crawler/data/companies.csv
@@ -4451,3 +4451,4 @@ zurich-insurance,Zurich Insurance,https://www.zurich.com,https://jobseek-assets.
 zus-health,Zus Health,https://zushealth.com,https://jobseek-assets.colophon-group.org/companies/zus-health/logo.png,https://jobseek-assets.colophon-group.org/companies/zus-health/icon.webp,wordmark+icon,,,,"{""sameAs"": [""https://www.facebook.com/ZusHealthHQ"", ""https://x.com/zushealthhq"", ""https://www.linkedin.com/company/zus-health/""]}"
 zwift,Zwift,https://www.zwift.com,https://jobseek-assets.colophon-group.org/companies/zwift/logo.jpg,https://jobseek-assets.colophon-group.org/companies/zwift/icon.webp,wordmark,1,,2014,"{""sameAs"": [""https://twitter.com/GoZwift""], ""wikidataId"": ""Q47461874""}"
 zynga,Zynga,https://www.zyngacareers.com,https://jobseek-assets.colophon-group.org/companies/zynga/logo.jpg,https://jobseek-assets.colophon-group.org/companies/zynga/icon.webp,wordmark,6,,,
+vivo-defence-services,,,,,,,,,


### PR DESCRIPTION
Closes #4761

## VIVO Defence Services
https://www.vivodefence.com
logo_type: wordmark

| Full Logo | Minified Logo |
|-----------|----------------|
| ![full-logo](https://raw.githubusercontent.com/colophon-group/jobseek/5fc177f70c089ccebb36e69eb7b292d144d2a485/apps/crawler/data/images/vivo-defence-services/logo.png) | ![minified-logo](https://raw.githubusercontent.com/colophon-group/jobseek/5fc177f70c089ccebb36e69eb7b292d144d2a485/apps/crawler/data/images/vivo-defence-services/icon.png) |

|  | vivo-defence-services-careers |
|---|---|
| URL | https://apply-now.serco.com/VIVO |
| Monitor | `rss` *(configured)* |
| Scraper | *(auto)* |
| Jobs | 61 |
| Cost | ~21.74s/cycle |
| title | 61/61 (clean) |
| description | 61/61 (clean) |
| locations | 61/61 (clean) |
| employment_type | 0/61 (absent) |
| job_location_type | 0/61 (absent) |
| date_posted | 0/61 (absent) |
| base_salary | 0/61 (absent) |
| skills | 0/61 (absent) |
| qualifications | 0/61 (absent) |
| responsibilities | 0/61 (absent) |
| valid_through | 0/61 (absent) |
| **Verdict** | **good** — SuccessFactors RSS feed filtered to VIVO job URLs (/VIVO/job/) keeps 61 VIVO roles and removes 695 non-VIVO Serco roles; rich RSS data provides clean titles, locations, and full descriptions, so scraper is skipped. |
