### PR TITLE
Add virgin-atlantic

### DIFF
--- a/apps/crawler/data/companies.csv
+++ b/apps/crawler/data/companies.csv
@@ -4453,3 +4453,4 @@ zurich-insurance,Zurich Insurance,https://www.zurich.com,https://jobseek-assets.
 zus-health,Zus Health,https://zushealth.com,https://jobseek-assets.colophon-group.org/companies/zus-health/logo.png,https://jobseek-assets.colophon-group.org/companies/zus-health/icon.webp,wordmark+icon,,,,"{""sameAs"": [""https://www.facebook.com/ZusHealthHQ"", ""https://x.com/zushealthhq"", ""https://www.linkedin.com/company/zus-health/""]}"
 zwift,Zwift,https://www.zwift.com,https://jobseek-assets.colophon-group.org/companies/zwift/logo.jpg,https://jobseek-assets.colophon-group.org/companies/zwift/icon.webp,wordmark,1,,2014,"{""sameAs"": [""https://twitter.com/GoZwift""], ""wikidataId"": ""Q47461874""}"
 zynga,Zynga,https://www.zyngacareers.com,https://jobseek-assets.colophon-group.org/companies/zynga/logo.jpg,https://jobseek-assets.colophon-group.org/companies/zynga/icon.webp,wordmark,6,,,
+virgin-atlantic,,,,,,,,,


### PR DESCRIPTION
Closes #4760

## Virgin Atlantic
https://www.virginatlantic.com
logo_type: wordmark+icon

| Full Logo | Minified Logo |
|-----------|----------------|
| ![full-logo](https://raw.githubusercontent.com/colophon-group/jobseek/db339b6f2b84001aeb832a12492a58a0024fcd5f/apps/crawler/data/images/virgin-atlantic/logo.svg) | ![minified-logo](https://raw.githubusercontent.com/colophon-group/jobseek/db339b6f2b84001aeb832a12492a58a0024fcd5f/apps/crawler/data/images/virgin-atlantic/icon.png) |

|  | virgin-atlantic-careers |
|---|---|
| URL | https://careers.virginatlantic.com/search-and-apply |
| Monitor | `sitemap` *(configured)* |
| Scraper | `json-ld` |
| Jobs | 15 |
| Cost | ~0.88s/cycle |
| title | 10/10 (clean) |
| description | 10/10 (clean) |
| locations | 10/10 (clean) |
| employment_type | 0/10 (absent) |
| job_location_type | 0/10 (absent) |
| date_posted | 10/10 (clean) |
| base_salary | 0/10 (absent) |
| skills | 0/10 (absent) |
| qualifications | 0/10 (absent) |
| responsibilities | 0/10 (absent) |
| valid_through | 10/10 (clean) |
| **Verdict** | **good** — Sitemap monitor returns 15 filtered /search-and-apply/ job URLs, matching the official public count. JSON-LD scraper extracts real titles, locations, detailed HTML descriptions, date_posted, and valid_through for all 10 sampled jobs; employment type and job location type are not present in the JSON-LD. |

<details>
<summary>Configurations evaluated</summary>

#### `virgin-atlantic-careers`

| # | Config | Monitor | Scraper | Jobs | Cost | Status | Notes |
|---|--------|---------|---------|------|------|--------|-------|
| 1 | sitemap-test | `sitemap` | json-ld | 15 | ~0.88s | **selected** | good: Sitemap monitor returns 15 filtered /search-and-apply/ job URLs, matching the official public count. JSON-LD scraper extracts real titles, locations, detailed HTML descriptions, date_posted, and valid_through for all 10 sampled jobs; employment type and job location type are not present in the JSON-LD. |
| 2 | dom-test | `dom` | json-ld | 10 | ~0.76s | tested |  |

</details>
