### PR TITLE
Deploy Codex runner host from CI

### DIFF
--- a/.github/workflows/deploy-codex-runner.yml
+++ b/.github/workflows/deploy-codex-runner.yml
@@ -1,0 +1,64 @@
+name: Deploy Codex Runner (Hetzner)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.agents/**'
+      - 'AGENTS.md'
+      - 'apps/crawler/AGENTS.md'
+      - 'apps/crawler/src/labeller/**'
+      - 'apps/crawler/src/workspace/**'
+      - 'deploy/systemd/jobseek-codex-*'
+      - 'docs/14-error-review-routine.md'
+      - 'docs/15-data-sampling-routine.md'
+      - 'docs/16-hetzner-maintenance.md'
+      - 'docs/17-codex-migration-verification-runbook.md'
+      - 'docs/18-codex-automation-deployment.md'
+      - 'scripts/codex-*.py'
+      - '.github/workflows/deploy-codex-runner.yml'
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+concurrency:
+  group: codex-runner-production-sync
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Validate deploy script
+        run: bash -n scripts/deploy-codex-runner-host.sh
+
+      - name: Copy Codex runner deploy script
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
+        with:
+          host: ${{ secrets.HETZNER_HOST }}
+          username: root
+          key: ${{ secrets.HETZNER_SSH_KEY }}
+          source: scripts/deploy-codex-runner-host.sh
+          target: /tmp/jobseek-codex-runner-deploy/${{ github.sha }}
+          strip_components: 1
+
+      - name: Deploy Codex runner host surface
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
+        with:
+          host: ${{ secrets.HETZNER_HOST }}
+          username: root
+          key: ${{ secrets.HETZNER_SSH_KEY }}
+          envs: GITHUB_SHA
+          script: |
+            set -euo pipefail
+            export JOBSEEK_CODEX_BRANCH=main
+            export JOBSEEK_CODEX_EXPECTED_SHA="${GITHUB_SHA}"
+            export JOBSEEK_CODEX_START_TIMERS=0
+            bash "/tmp/jobseek-codex-runner-deploy/${GITHUB_SHA}/deploy-codex-runner-host.sh"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,8 +85,9 @@ uv run labeller upload --date <date>
 
 Scheduled ops routines are documented as repo runbooks and skills. Prefer
 the Hetzner local Codex runner or local Codex CLI so routine execution stays
-subscription-backed; do not add GitHub Actions for these Hetzner-owned
-automations. `codex exec --json` is the traceable noninteractive surface for
+subscription-backed; do not add GitHub Actions that execute these
+Hetzner-owned automations. CI/CD may still deploy the Hetzner runner host
+surface. `codex exec --json` is the traceable noninteractive surface for
 manual fallback and agent trace collection. Legacy
 Claude Code slash commands remain compatibility fallbacks where present.
 Deployment and maintenance rules live in

--- a/apps/crawler/AGENTS.md
+++ b/apps/crawler/AGENTS.md
@@ -359,8 +359,9 @@ Codex is the preferred new automation surface. Use repo skills from
 scheduled routines, and `codex exec --json` for traceable noninteractive
 fallback.
 Claude-compatible prompts may remain as alternate paths, but do not describe
-GitHub Actions automation as ChatGPT subscription billed and do not re-add
-GitHub Actions for automations now owned by the Hetzner runner.
+GitHub Actions automation execution as ChatGPT subscription billed and do not
+re-add GitHub Actions that run automations now owned by the Hetzner runner.
+GitHub Actions may still deploy the Hetzner runner host surface.
 
 ## Decision Mindset
 

--- a/docs/16-hetzner-maintenance.md
+++ b/docs/16-hetzner-maintenance.md
@@ -87,6 +87,10 @@ crawler host as `codex-runner`, outside Docker and outside the production
 crawler environment. Deployment templates live in
 [`18-codex-automation-deployment.md`](18-codex-automation-deployment.md) and
 [`../deploy/systemd/`](../deploy/systemd/).
+Host-surface deployment is CI/CD-owned by
+[`deploy-codex-runner.yml`](../.github/workflows/deploy-codex-runner.yml).
+That workflow updates the checked-out repo and systemd units; it does not run
+`codex exec`, select issues, upload labels, or perform error reviews.
 
 The local Codex desktop automation records for these three routines should be
 `PAUSED` after Hetzner cutover. They are retained only as local app state, not
@@ -96,9 +100,25 @@ as the production scheduler:
 - `jobseek-daily-classifications`
 - `jobseek-daily-error-review`
 
-Do not add or restore GitHub Actions for these routines. Manual recovery uses
-the same local Codex CLI path from a throwaway worktree, with `CODEX_EXEC_JSONL`
-set for trace capture.
+Do not add or restore GitHub Actions that execute these routines. Manual
+recovery uses the same local Codex CLI path from a throwaway worktree, with
+`CODEX_EXEC_JSONL` set for trace capture.
+
+Check the last CI/CD host deploy:
+
+```bash
+gh run list --workflow deploy-codex-runner.yml --branch main --limit 5
+```
+
+Manual host deploy, when CI/CD is unavailable, runs as root with the same
+script and should not start a timer:
+
+```bash
+git -C /srv/jobseek-codex/repo fetch origin main
+JOBSEEK_CODEX_EXPECTED_SHA="$(git -C /srv/jobseek-codex/repo rev-parse origin/main)" \
+JOBSEEK_CODEX_START_TIMERS=0 \
+bash /srv/jobseek-codex/repo/scripts/deploy-codex-runner-host.sh
+```
 
 Check the runner isolation:
 

--- a/docs/18-codex-automation-deployment.md
+++ b/docs/18-codex-automation-deployment.md
@@ -16,6 +16,10 @@ as source of truth and do not commit local Codex app state.
 The recurring company resolver and daily routines must not be triggered by
 GitHub Actions. They run on the Hetzner crawler host through local Codex CLI
 auth so they can use the subscription-backed Codex surface where possible.
+GitHub Actions may still deploy the Hetzner runner host surface. The
+[`deploy-codex-runner.yml`](../.github/workflows/deploy-codex-runner.yml)
+workflow updates `/srv/jobseek-codex/repo`, installs/verifies systemd units,
+and leaves actual Codex execution to the Hetzner timers.
 
 ## Harness Invariants
 
@@ -27,9 +31,9 @@ Codex CLI, the Hetzner governor, or a future Codex scheduler.
 - The repo docs and skills above are the behavioral source of truth. Update
   them first, then update the deployed automation prompt or runner prompt.
 - Do not install or invoke Claude Code from Codex automations. Do not add
-  Codex GitHub Actions for these Hetzner-owned routines.
-- Do not add a GitHub Actions trigger for the recurring company resolver or
-  daily Codex routines.
+  GitHub Actions that execute these Hetzner-owned routines.
+- GitHub Actions may deploy runner code and units, but must not select issues,
+  run `ws`, call `codex exec`, upload labels, or perform error reviews.
 - Run Hetzner Codex routines under a dedicated local user with no sudo,
   no Docker group, no production crawler environment, and no read access to
   crawler `.env` files.
@@ -76,6 +80,11 @@ runner prompt:
    routine has two clean production runs.
 7. Confirm the durable output: HuggingFace date rows, daily error report and
    issue updates, or company resolver PR.
+8. For Hetzner runner changes, let CI deploy the host surface through
+   [`deploy-codex-runner.yml`](../.github/workflows/deploy-codex-runner.yml).
+   That workflow runs
+   [`deploy-codex-runner-host.sh`](../scripts/deploy-codex-runner-host.sh)
+   with `JOBSEEK_CODEX_START_TIMERS=0`, so it does not start a Codex run.
 
 Do not hand-edit local Codex automation TOML unless recovering from a broken
 app state. If hand recovery is necessary, copy the final settings back into
@@ -286,6 +295,18 @@ systemctl enable --now jobseek-codex-daily-annotations.timer
 systemctl enable --now jobseek-codex-daily-error-review.timer
 ```
 
+After bootstrap, production updates are CI/CD-owned. Pushes to `main` that
+touch runner code, prompts, skills, docs, or systemd units trigger
+[`deploy-codex-runner.yml`](../.github/workflows/deploy-codex-runner.yml).
+The workflow copies
+[`deploy-codex-runner-host.sh`](../scripts/deploy-codex-runner-host.sh) to
+Hetzner, runs it as root, acquires
+`/srv/jobseek-codex/state/codex-runner.lock`, updates the normal checked-out
+clone at `/srv/jobseek-codex/repo`, installs and verifies units, and enables
+timers for boot persistence. It intentionally sets
+`JOBSEEK_CODEX_START_TIMERS=0`, so it does not start a company resolver,
+annotation run, or error review from GitHub Actions.
+
 Initial service limits:
 
 ```ini
@@ -310,7 +331,8 @@ block private and local service ranges by default, especially
 Redis/Postgres/Typesense private addresses and the Docker socket. Allow public
 internet access needed for GitHub, OpenAI/ChatGPT, npm/pypi package
 installation during setup, and HuggingFace trace upload if enabled. Do not
-replace the local Hetzner timer with a GitHub Actions schedule.
+replace the local Hetzner timer with a GitHub Actions schedule or workflow
+that executes a Codex routine.
 
 ### Phase 3 - governor decision loop
 

--- a/scripts/deploy-codex-runner-host.sh
+++ b/scripts/deploy-codex-runner-host.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Deploy the Hetzner-local Codex runner host surface.
+#
+# This is deployment-only: it updates the checked-out repo and systemd units.
+# It does not start any Codex operational service directly.
+
+set -euo pipefail
+
+ROOT_DIR="${JOBSEEK_CODEX_ROOT:-/srv/jobseek-codex}"
+REPO_DIR="${JOBSEEK_CODEX_REPO_DIR:-${ROOT_DIR}/repo}"
+REPO_URL="${JOBSEEK_CODEX_REPO_URL:-https://github.com/colophon-group/jobseek.git}"
+BRANCH="${JOBSEEK_CODEX_BRANCH:-main}"
+EXPECTED_SHA="${JOBSEEK_CODEX_EXPECTED_SHA:-}"
+LOCK_TIMEOUT_S="${JOBSEEK_CODEX_DEPLOY_LOCK_TIMEOUT_S:-900}"
+START_TIMERS="${JOBSEEK_CODEX_START_TIMERS:-0}"
+
+LOCK_FILE="${ROOT_DIR}/state/codex-runner.lock"
+
+UNITS=(
+  jobseek-codex-governor.service
+  jobseek-codex-governor.timer
+  jobseek-codex-daily-annotations.service
+  jobseek-codex-daily-annotations.timer
+  jobseek-codex-daily-error-review.service
+  jobseek-codex-daily-error-review.timer
+)
+
+TIMERS=(
+  jobseek-codex-governor.timer
+  jobseek-codex-daily-annotations.timer
+  jobseek-codex-daily-error-review.timer
+)
+
+log() {
+  printf '==> %s\n' "$*"
+}
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+as_runner() {
+  runuser -u codex-runner -- "$@"
+}
+
+require_root() {
+  if [[ "$(id -u)" -ne 0 ]]; then
+    fail "must run as root"
+  fi
+}
+
+ensure_layout() {
+  if ! id -u codex-runner >/dev/null 2>&1; then
+    useradd --system --user-group --create-home \
+      --home-dir /home/codex-runner --shell /bin/bash codex-runner
+  fi
+
+  if getent group docker >/dev/null 2>&1 && id -nG codex-runner | tr ' ' '\n' | grep -qx docker; then
+    gpasswd --delete codex-runner docker
+  fi
+
+  install -d -o codex-runner -g codex-runner -m 0750 "${ROOT_DIR}"
+  install -d -o codex-runner -g codex-runner -m 0700 \
+    "${ROOT_DIR}/worktrees" \
+    "${ROOT_DIR}/traces" \
+    "${ROOT_DIR}/state" \
+    "${ROOT_DIR}/logs" \
+    "${ROOT_DIR}/data/postings-labelled"
+  install -d -o root -g codex-runner -m 0750 "${ROOT_DIR}/inputs" /etc/jobseek-codex
+
+  touch "${LOCK_FILE}"
+  chown codex-runner:codex-runner "${LOCK_FILE}"
+  chmod 0600 "${LOCK_FILE}"
+}
+
+require_runtime_config() {
+  [[ -r /etc/jobseek-codex/governor.env ]] || fail "missing /etc/jobseek-codex/governor.env"
+  [[ -r /etc/jobseek-codex/labeller.env ]] || fail "missing /etc/jobseek-codex/labeller.env"
+  as_runner test -r /etc/jobseek-codex/governor.env ||
+    fail "codex-runner cannot read governor.env"
+  as_runner test -r /etc/jobseek-codex/labeller.env ||
+    fail "codex-runner cannot read labeller.env"
+}
+
+update_repo() {
+  if [[ -d "${REPO_DIR}/.git" ]]; then
+    if ! as_runner git -C "${REPO_DIR}" diff --quiet ||
+      ! as_runner git -C "${REPO_DIR}" diff --cached --quiet; then
+      fail "${REPO_DIR} has tracked local changes; refusing to overwrite"
+    fi
+    as_runner git -C "${REPO_DIR}" remote set-url origin "${REPO_URL}"
+    as_runner git -C "${REPO_DIR}" fetch --prune origin "${BRANCH}"
+  else
+    rm -rf "${REPO_DIR}"
+    install -d -o codex-runner -g codex-runner -m 0750 "$(dirname "${REPO_DIR}")"
+    as_runner git clone --branch "${BRANCH}" "${REPO_URL}" "${REPO_DIR}"
+    as_runner git -C "${REPO_DIR}" fetch --prune origin "${BRANCH}"
+  fi
+
+  local checkout_ref="origin/${BRANCH}"
+  if [[ -n "${EXPECTED_SHA}" ]]; then
+    if ! as_runner git -C "${REPO_DIR}" cat-file -e "${EXPECTED_SHA}^{commit}" 2>/dev/null; then
+      as_runner git -C "${REPO_DIR}" fetch origin "${EXPECTED_SHA}"
+    fi
+    checkout_ref="${EXPECTED_SHA}"
+  fi
+
+  as_runner git -C "${REPO_DIR}" checkout -B "${BRANCH}" "${checkout_ref}"
+  as_runner git -C "${REPO_DIR}" branch --set-upstream-to="origin/${BRANCH}" "${BRANCH}" >/dev/null
+  local actual_sha
+  actual_sha="$(as_runner git -C "${REPO_DIR}" rev-parse HEAD)"
+  log "repo ${REPO_DIR} at ${actual_sha}"
+
+  if [[ -n "${EXPECTED_SHA}" && "${actual_sha}" != "${EXPECTED_SHA}" ]]; then
+    fail "expected ${EXPECTED_SHA}, deployed ${actual_sha}"
+  fi
+}
+
+install_units() {
+  local unit
+  for unit in "${UNITS[@]}"; do
+    install -o root -g root -m 0644 \
+      "${REPO_DIR}/deploy/systemd/${unit}" \
+      "/etc/systemd/system/${unit}"
+  done
+
+  systemctl daemon-reload
+  systemd-analyze verify "${UNITS[@]/#//etc/systemd/system/}"
+  systemctl enable "${TIMERS[@]}"
+}
+
+verify_entrypoints() {
+  as_runner python3 -m py_compile \
+    "${REPO_DIR}/scripts/codex-company-resolver-governor.py" \
+    "${REPO_DIR}/scripts/codex-daily-routine-runner.py" \
+    "${REPO_DIR}/scripts/codex-error-review-bundle.py" \
+    "${REPO_DIR}/scripts/codex-usage-probe.py" \
+    "${REPO_DIR}/apps/crawler/src/workspace/codex_runner.py" \
+    "${REPO_DIR}/apps/crawler/src/workspace/codex_routine_runner.py"
+  as_runner env PYTHONPATH="${REPO_DIR}/apps/crawler" python3 -c \
+    'import src.workspace.codex_runner; import src.workspace.codex_routine_runner'
+  python3 "${REPO_DIR}/scripts/codex-error-review-bundle.py" --help >/dev/null
+}
+
+maybe_start_timers() {
+  if [[ "${START_TIMERS}" == "1" ]]; then
+    systemctl start "${TIMERS[@]}"
+  fi
+}
+
+main() {
+  require_root
+  ensure_layout
+  require_runtime_config
+
+  log "waiting for Codex runner lock: ${LOCK_FILE}"
+  exec 9>"${LOCK_FILE}"
+  if ! flock -w "${LOCK_TIMEOUT_S}" 9; then
+    fail "could not acquire ${LOCK_FILE} within ${LOCK_TIMEOUT_S}s"
+  fi
+
+  update_repo
+  install_units
+  verify_entrypoints
+  maybe_start_timers
+  systemctl list-timers --all 'jobseek-codex*' --no-pager
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a deploy-only GitHub Actions workflow for the Hetzner Codex runner host surface
- add a root-run deploy script that updates /srv/jobseek-codex/repo, verifies systemd units, and does not start Codex jobs unless explicitly requested
- clarify docs/AGENTS wording: Actions may deploy the runner, but must not execute automations

## Verification
- bash -n scripts/deploy-codex-runner-host.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy-codex-runner.yml")'
- git diff --check
- remote dry deploy on Hetzner with JOBSEEK_CODEX_START_TIMERS=0 against 8d02bf74b8dd41a7063eafc8d6b2d51dd1a1d5c3