### PR TITLE
Add altilium-metals

### DIFF
--- a/apps/crawler/data/companies.csv
+++ b/apps/crawler/data/companies.csv
@@ -4564,3 +4564,4 @@ zurich-insurance,Zurich Insurance,https://www.zurich.com,https://jobseek-assets.
 zus-health,Zus Health,https://zushealth.com,https://jobseek-assets.colophon-group.org/companies/zus-health/logo.png,https://jobseek-assets.colophon-group.org/companies/zus-health/icon.webp,wordmark+icon,,,,"{""sameAs"": [""https://www.facebook.com/ZusHealthHQ"", ""https://x.com/zushealthhq"", ""https://www.linkedin.com/company/zus-health/""]}"
 zwift,Zwift,https://www.zwift.com,https://jobseek-assets.colophon-group.org/companies/zwift/logo.jpg,https://jobseek-assets.colophon-group.org/companies/zwift/icon.webp,wordmark,1,,2014,"{""sameAs"": [""https://twitter.com/GoZwift""], ""wikidataId"": ""Q47461874""}"
 zynga,Zynga,https://www.zyngacareers.com,https://jobseek-assets.colophon-group.org/companies/zynga/logo.jpg,https://jobseek-assets.colophon-group.org/companies/zynga/icon.webp,wordmark,6,,,
+altilium-metals,,,,,,,,,


### PR DESCRIPTION
Closes #3795

## Altilium
https://altilium.tech/
logo_type: wordmark+icon

| Full Logo | Minified Logo |
|-----------|----------------|
| ![full-logo](https://raw.githubusercontent.com/colophon-group/jobseek/b36b14021b150be3bc1d18839bda60e22d3a04bf/apps/crawler/data/images/altilium/logo.png) | ![minified-logo](https://raw.githubusercontent.com/colophon-group/jobseek/b36b14021b150be3bc1d18839bda60e22d3a04bf/apps/crawler/data/images/altilium/icon.png) |

|  | altilium-careers |
|---|---|
| URL | https://altilium.tech/careers/ |
| Monitor | `api_sniffer` *(configured)* |
| Scraper | `dom` *(configured)* |
| Jobs | 0 |
| Cost | ~0.68s/cycle |
| title | 5/5 (clean) |
| description | 5/5 (clean) |
| locations | 5/5 (clean) |
| employment_type | 0/5 (absent) |
| job_location_type | 0/5 (absent) |
| date_posted | 0/5 (absent) |
| base_salary | 0/5 (absent) |
| skills | 0/5 (absent) |
| qualifications | 0/5 (absent) |
| responsibilities | 0/5 (absent) |
| valid_through | 0/5 (absent) |
| **Verdict** | **good** — Direct WP Job Openings REST endpoint currently returns 0 active roles, matching careers page. DOM scraper validated on 5 archived first-party /jobs/ pages: 5/5 clean titles, descriptions, and locations; explicit labels are extracted, with Devon, UK fallback only when source omits location, verified against the company's Plymouth/Tavistock operating footprint. Rejected unrelated Pinpoint demo tenant false positive. |

<details>
<summary>Configurations evaluated</summary>

#### `altilium-careers`

| # | Config | Monitor | Scraper | Jobs | Cost | Status | Notes |
|---|--------|---------|---------|------|------|--------|-------|
| 1 | pinpoint-test | `pinpoint` | skip | 4 | ~0.36s | rejected | False-positive Pinpoint tenant; returned unrelated demo roles |
| 2 | wp-api | `api_sniffer` | dom | 0 | ~0.68s | **selected** | good: Direct WP Job Openings REST endpoint currently returns 0 active roles, matching careers page. DOM scraper validated on 5 archived first-party /jobs/ pages: 5/5 clean titles, descriptions, and locations; explicit labels are extracted, with Devon, UK fallback only when source omits location, verified against the company's Plymouth/Tavistock operating footprint. Rejected unrelated Pinpoint demo tenant false positive. |

</details>
