### PR TITLE
Keep image cleanup commits data-only

### DIFF
--- a/.github/workflows/upload-company-images.yml
+++ b/.github/workflows/upload-company-images.yml
@@ -96,7 +96,10 @@ jobs:
 
             # The workflow has production R2 secrets. Keep PR-controlled data,
             # but run only trusted crawler code and dependency metadata.
-            git restore --source="$trusted_ref" --staged --worktree -- \
+            # Keep trusted executable code in the working tree only. Staging
+            # it here would make the later data commit absorb every source
+            # difference between the PR branch and main.
+            git restore --source="$trusted_ref" --worktree -- \
               apps/crawler/src \
               apps/crawler/pyproject.toml \
               apps/crawler/uv.lock
@@ -109,6 +112,16 @@ jobs:
             fi
 
             git add apps/crawler/data/
+            unexpected_staged="$(
+              git diff --cached --name-only \
+                | grep -v '^apps/crawler/data/' \
+                || true
+            )"
+            if [[ -n "$unexpected_staged" ]]; then
+              echo "Refusing to commit paths outside apps/crawler/data:" >&2
+              printf '%s\n' "$unexpected_staged" >&2
+              exit 1
+            fi
             git commit -m "Upload images to R2"
 
             if git push --force-with-lease origin "HEAD:$BRANCH"; then

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -157,6 +157,26 @@ test("bot-authored company branch updates dispatch path-aware CI", () => {
   assert.match(uploadCompanyImagesWorkflow, /TRUSTED_SCRIPTS_DIR: \$\{\{ runner\.temp \}\}\/trusted-scripts/);
 });
 
+test("company image cleanup commits cannot absorb trusted source changes", () => {
+  assert.match(
+    uploadCompanyImagesWorkflow,
+    /git restore --source="\$trusted_ref" --worktree -- \\\n+              apps\/crawler\/src/,
+  );
+  assert.doesNotMatch(
+    uploadCompanyImagesWorkflow,
+    /git restore --source="\$trusted_ref" --staged/,
+  );
+  assert.match(uploadCompanyImagesWorkflow, /git add apps\/crawler\/data\//);
+  assert.match(
+    uploadCompanyImagesWorkflow,
+    /git diff --cached --name-only[\s\S]*grep -v '\^apps\/crawler\/data\/'/,
+  );
+  assert.match(
+    uploadCompanyImagesWorkflow,
+    /Refusing to commit paths outside apps\/crawler\/data/,
+  );
+});
+
 test("company PR label script applies decision labels idempotently", () => {
   assert.match(labelPrScript, /gh pr view "\$PR" --repo "\$REPO" --json labels/);
   assert.match(labelPrScript, /DESIRED_LABELS=",\$LABELS,"/);


### PR DESCRIPTION
Closes #5730

## Summary
- restore trusted crawler code into the image job working tree without staging it
- fail closed if any non-data path reaches the image cleanup commit index
- add a workflow-security regression contract for the allowed commit scope

## Verification
- node --test scripts/ci-workflow.test.mjs (18 passed)
- git diff --check