### PR TITLE
Align Codex deploy timeout with lock wait

### DIFF
--- a/.github/workflows/deploy-codex-runner.yml
+++ b/.github/workflows/deploy-codex-runner.yml
@@ -21,6 +21,7 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  JOBSEEK_CODEX_DEPLOY_LOCK_TIMEOUT_S: "900"
 
 concurrency:
   group: codex-runner-production-sync
@@ -55,7 +56,10 @@ jobs:
           host: ${{ secrets.HETZNER_HOST }}
           username: root
           key: ${{ secrets.HETZNER_SSH_KEY }}
-          envs: GITHUB_SHA
+          envs: GITHUB_SHA,JOBSEEK_CODEX_DEPLOY_LOCK_TIMEOUT_S
+          # Allow the 15-minute runner-lock wait to finish, then leave another
+          # 15 minutes for checkout, runtime sync, verification, and reporting.
+          command_timeout: 30m
           script: |
             set -euo pipefail
             export JOBSEEK_CODEX_BRANCH=main

--- a/docs/18-codex-automation-deployment.md
+++ b/docs/18-codex-automation-deployment.md
@@ -330,6 +330,16 @@ timers for boot persistence. It intentionally sets
 `JOBSEEK_CODEX_START_TIMERS=0`, so it does not start a company resolver,
 annotation run, or error review from GitHub Actions.
 
+The deploy never interrupts a live Codex routine. It waits up to 15 minutes
+for the shared runner lock, and the SSH command has a 30-minute envelope so
+that a successful lock wait still leaves 15 minutes for checkout, runtime
+sync, verification, and the retention report. If the lock remains occupied
+for the full wait, the deploy fails before changing the checkout or units;
+the live routine continues normally, and the deployment can be retried with
+`workflow_dispatch` after the routine releases the lock. Workflow concurrency
+also uses `cancel-in-progress: false`, so queued deployments are not canceled
+by a newer push.
+
 Initial service limits:
 
 ```ini

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -38,6 +38,14 @@ const publishMcpServerWorkflow = readFileSync(
   ".github/workflows/publish-mcp-server.yml",
   "utf8",
 );
+const deployCodexRunnerWorkflow = readFileSync(
+  ".github/workflows/deploy-codex-runner.yml",
+  "utf8",
+);
+const deployCodexRunnerHostScript = readFileSync(
+  "scripts/deploy-codex-runner-host.sh",
+  "utf8",
+);
 const mainStrictGateRuleset = JSON.parse(
   readFileSync(".github/rulesets/main-strict-gate.json", "utf8"),
 );
@@ -118,6 +126,13 @@ function workflowJobBlock(workflowSource, jobId) {
   return match[0];
 }
 
+function durationSeconds(value) {
+  const match = value.match(/^(\d+)([smh])$/);
+  assert.ok(match, `unsupported duration ${value}`);
+  const unitSeconds = { s: 1, m: 60, h: 3600 };
+  return Number(match[1]) * unitSeconds[match[2]];
+}
+
 test("CI change detection uses the pinned paths-filter action", () => {
   assert.match(
     workflow,
@@ -170,6 +185,32 @@ test("workflow-security runs repository script tests", () => {
   assert.match(workflow, /scripts\/ci-workflow\.test\.mjs/);
   assert.match(workflow, /scripts\/docs-index\.test\.mjs/);
   assert.match(workflow, /scripts\/dealroom-company-requests\.test\.mjs/);
+});
+
+test("Codex deploy transport outlives the runner lock wait", () => {
+  const workflowLockTimeout = deployCodexRunnerWorkflow.match(
+    /^  JOBSEEK_CODEX_DEPLOY_LOCK_TIMEOUT_S: "(\d+)"$/m,
+  );
+  const hostLockTimeout = deployCodexRunnerHostScript.match(
+    /LOCK_TIMEOUT_S="\$\{JOBSEEK_CODEX_DEPLOY_LOCK_TIMEOUT_S:-(\d+)\}"/,
+  );
+  const commandTimeout = deployCodexRunnerWorkflow.match(
+    /^          command_timeout: (\d+[smh])$/m,
+  );
+
+  assert.ok(workflowLockTimeout, "missing workflow runner-lock timeout");
+  assert.ok(hostLockTimeout, "missing host runner-lock timeout default");
+  assert.ok(commandTimeout, "missing SSH command timeout");
+  assert.equal(workflowLockTimeout[1], hostLockTimeout[1]);
+  assert.match(
+    deployCodexRunnerWorkflow,
+    /envs: GITHUB_SHA,JOBSEEK_CODEX_DEPLOY_LOCK_TIMEOUT_S/,
+  );
+  assert.ok(
+    durationSeconds(commandTimeout[1]) >= Number(workflowLockTimeout[1]) + 900,
+    "SSH command timeout must include the lock wait plus 15 minutes for deployment",
+  );
+  assert.match(deployCodexRunnerWorkflow, /cancel-in-progress: false/);
 });
 
 test("maybe-auto-merge wakes without manual retries", () => {


### PR DESCRIPTION
Closes #5738

## Root cause
The production SSH action used its 10-minute default while the host-side safety lock intentionally waits up to 15 minutes. The outer transport could therefore kill a valid wait before the host policy reached its own bounded decision.

## Solution
- pass the explicit 900-second lock timeout from the workflow to the host deploy
- give the SSH command 30 minutes: 15 for the lock plus 15 for checkout, runtime sync, verification, and reporting
- add a repository regression that compares workflow, host, and transport timeouts and preserves non-canceling concurrency
- document safe failure and retry behavior; live routines are never interrupted

## Verification
- `actionlint .github/workflows/deploy-codex-runner.yml`
- `bash -n scripts/deploy-codex-runner-host.sh`
- `node --test scripts/ci-workflow.test.mjs scripts/docs-index.test.mjs` (25 passed)
- `git diff --check`

Related to #5120 and #5726.