### PR TITLE
Detect stale unmanaged crawler host resources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
         run: >
           node --test
           scripts/ci-workflow.test.mjs
+          scripts/crawler-host-hygiene.test.mjs
           scripts/docs-index.test.mjs
           scripts/dealroom-company-requests.test.mjs
 

--- a/.github/workflows/crawler-scheduled-maintenance.yml
+++ b/.github/workflows/crawler-scheduled-maintenance.yml
@@ -41,13 +41,29 @@ concurrency:
   group: crawler-scheduled-maintenance
   cancel-in-progress: false
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   run:
     runs-on: ubuntu-latest
     environment: production
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
+
+      - name: Validate host hygiene check
+        run: python3 -m py_compile scripts/crawler-host-hygiene.py
+
+      - name: Copy host hygiene check
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
+        with:
+          host: ${{ secrets.HETZNER_HOST }}
+          username: deploy
+          key: ${{ secrets.HETZNER_SSH_KEY }}
+          source: scripts/crawler-host-hygiene.py
+          target: /tmp/jobseek-crawler-maintenance/${{ github.sha }}
+          strip_components: 1
+
       - name: Resolve task
         id: task
         run: |
@@ -63,6 +79,7 @@ jobs:
           host: ${{ secrets.HETZNER_HOST }}
           username: deploy
           key: ${{ secrets.HETZNER_SSH_KEY }}
+          envs: GITHUB_SHA
           script: |
             set -euo pipefail
             TASK="${{ steps.task.outputs.task }}"
@@ -75,3 +92,4 @@ jobs:
               --network host \
               "ghcr.io/colophon-group/jobseek-crawler:${tag}" \
               uv run --no-sync crawler "$TASK"
+            python3 "/tmp/jobseek-crawler-maintenance/${GITHUB_SHA}/crawler-host-hygiene.py"

--- a/docs/16-hetzner-maintenance.md
+++ b/docs/16-hetzner-maintenance.md
@@ -80,6 +80,31 @@ Current policy:
 The crawler-specific rule matters because repeated versioned deploys can
 consume tens of GiB before a normal age-based prune would trigger.
 
+## Unmanaged Resource Hygiene
+
+The scheduled crawler maintenance workflow runs the read-only
+[`crawler-host-hygiene.py`](../scripts/crawler-host-hygiene.py) check after
+its normal maintenance command. It fails visibly when either of these has
+survived for more than 24 hours:
+
+- a running Docker container without a Compose project label
+- a transient systemd service that remains `active (exited)`
+
+This catches forgotten debug containers, one-off test commands, and completed
+transient units without deleting anything automatically. Run the same check
+manually with:
+
+```bash
+python3 /tmp/jobseek-crawler-maintenance/<deployed-sha>/crawler-host-hygiene.py
+```
+
+Before applying a printed cleanup command, inspect the resource and confirm
+that it is not active production work. Removing a stale container uses
+`docker rm -f -- <name>`. Stopping an `active (exited)` transient unit with
+`systemctl stop <unit>` also lets watcher loops waiting on `is-active` exit;
+verify the watcher is gone and run `systemctl reset-failed <unit>` only if a
+failed unit state remains.
+
 ## Codex Runner Timers
 
 The recurring company-request resolver and daily Codex routines run on the

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -183,6 +183,7 @@ test("manual CI dispatch can classify a PR without full code checks", () => {
 test("workflow-security runs repository script tests", () => {
   assert.match(workflow, /node --test/);
   assert.match(workflow, /scripts\/ci-workflow\.test\.mjs/);
+  assert.match(workflow, /scripts\/crawler-host-hygiene\.test\.mjs/);
   assert.match(workflow, /scripts\/docs-index\.test\.mjs/);
   assert.match(workflow, /scripts\/dealroom-company-requests\.test\.mjs/);
 });

--- a/scripts/crawler-host-hygiene.py
+++ b/scripts/crawler-host-hygiene.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Detect stale resources created outside the crawler's managed services."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+COMPOSE_PROJECT_LABEL = "com.docker.compose.project"
+
+
+class HygieneError(RuntimeError):
+    """Raised when host inventory cannot be inspected safely."""
+
+
+@dataclass(frozen=True)
+class Finding:
+    kind: str
+    name: str
+    age_seconds: float
+    detail: str
+    cleanup: str
+
+
+def _run(command: list[str]) -> str:
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no output"
+        raise HygieneError(f"{' '.join(command)} failed: {detail}")
+    return result.stdout
+
+
+def _parse_started_at(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise HygieneError(f"invalid Docker StartedAt timestamp: {value!r}") from exc
+    if parsed.tzinfo is None:
+        raise HygieneError(f"Docker StartedAt timestamp lacks a timezone: {value!r}")
+    return parsed.astimezone(UTC)
+
+
+def _container_findings(now: datetime, max_age_seconds: float) -> list[Finding]:
+    ids = _run(["docker", "ps", "-q"]).split()
+    if not ids:
+        return []
+
+    try:
+        containers = json.loads(_run(["docker", "inspect", *ids]))
+    except json.JSONDecodeError as exc:
+        raise HygieneError("docker inspect returned invalid JSON") from exc
+
+    findings: list[Finding] = []
+    for container in containers:
+        config = container.get("Config") or {}
+        labels = config.get("Labels") or {}
+        if labels.get(COMPOSE_PROJECT_LABEL):
+            continue
+
+        state = container.get("State") or {}
+        started_at = _parse_started_at(str(state.get("StartedAt", "")))
+        age_seconds = max(0.0, (now - started_at).total_seconds())
+        if age_seconds < max_age_seconds:
+            continue
+
+        container_id = str(container.get("Id", ""))[:12] or "unknown"
+        name = str(container.get("Name", "")).lstrip("/") or container_id
+        image = str(config.get("Image", "")) or "unknown"
+        findings.append(
+            Finding(
+                kind="unmanaged container",
+                name=name,
+                age_seconds=age_seconds,
+                detail=f"id={container_id} image={image}",
+                cleanup=f"docker rm -f -- {shlex.quote(name)}",
+            )
+        )
+    return findings
+
+
+def _properties(output: str) -> dict[str, str]:
+    return dict(line.split("=", 1) for line in output.splitlines() if "=" in line)
+
+
+def _transient_unit_findings(
+    *, max_age_seconds: float, uptime_seconds: float
+) -> list[Finding]:
+    output = _run(
+        [
+            "systemctl",
+            "list-units",
+            "--type=service",
+            "--state=active",
+            "--no-legend",
+            "--plain",
+        ]
+    )
+    findings: list[Finding] = []
+    for line in output.splitlines():
+        fields = line.split(None, 4)
+        if len(fields) < 4 or fields[2:4] != ["active", "exited"]:
+            continue
+
+        unit = fields[0]
+        props = _properties(
+            _run(
+                [
+                    "systemctl",
+                    "show",
+                    unit,
+                    "--property=FragmentPath",
+                    "--property=ActiveEnterTimestampMonotonic",
+                    "--no-pager",
+                ]
+            )
+        )
+        fragment = props.get("FragmentPath", "")
+        if not fragment.startswith("/run/systemd/transient/"):
+            continue
+
+        try:
+            active_at = int(props.get("ActiveEnterTimestampMonotonic", "0")) / 1_000_000
+        except ValueError as exc:
+            raise HygieneError(f"invalid monotonic timestamp for {unit}") from exc
+        age_seconds = max(0.0, uptime_seconds - active_at)
+        if age_seconds < max_age_seconds:
+            continue
+
+        findings.append(
+            Finding(
+                kind="active-exited transient service",
+                name=unit,
+                age_seconds=age_seconds,
+                detail=f"fragment={fragment}",
+                cleanup=f"systemctl stop {shlex.quote(unit)}",
+            )
+        )
+    return findings
+
+
+def _format_age(seconds: float) -> str:
+    hours = int(seconds // 3600)
+    days, remainder = divmod(hours, 24)
+    return f"{days}d{remainder:02d}h" if days else f"{hours}h"
+
+
+def _parse_now(value: str | None) -> datetime:
+    if value is None:
+        return datetime.now(tz=UTC)
+    parsed = _parse_started_at(value)
+    return parsed.astimezone(UTC)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--max-age-hours", type=float, default=24.0)
+    parser.add_argument("--now", help=argparse.SUPPRESS)
+    parser.add_argument("--proc-uptime", type=Path, default=Path("/proc/uptime"))
+    args = parser.parse_args(argv)
+
+    if args.max_age_hours <= 0:
+        parser.error("--max-age-hours must be positive")
+
+    try:
+        uptime_seconds = float(args.proc_uptime.read_text().split()[0])
+        max_age_seconds = args.max_age_hours * 3600
+        findings = [
+            *_container_findings(_parse_now(args.now), max_age_seconds),
+            *_transient_unit_findings(
+                max_age_seconds=max_age_seconds,
+                uptime_seconds=uptime_seconds,
+            ),
+        ]
+    except (OSError, ValueError, HygieneError) as exc:
+        print(f"host hygiene inspection failed: {exc}", file=sys.stderr)
+        return 2
+
+    if not findings:
+        print(
+            "host hygiene clean: no unmanaged containers or active-exited "
+            f"transient services older than {args.max_age_hours:g}h"
+        )
+        return 0
+
+    print(
+        f"host hygiene found {len(findings)} stale resource(s) older than "
+        f"{args.max_age_hours:g}h:",
+        file=sys.stderr,
+    )
+    for finding in findings:
+        print(
+            f"- {finding.kind}: {finding.name} age={_format_age(finding.age_seconds)} "
+            f"{finding.detail}",
+            file=sys.stderr,
+        )
+        print(f"  cleanup after verification: {finding.cleanup}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/crawler-host-hygiene.test.mjs
+++ b/scripts/crawler-host-hygiene.test.mjs
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import {
+  chmodSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import test from "node:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+function mockExecutable(path, source) {
+  writeFileSync(path, `#!/usr/bin/env node\n${source}`);
+  chmodSync(path, 0o755);
+}
+
+function runHygiene({ containers = [], units = {} }) {
+  const dir = mkdtempSync(join(tmpdir(), "crawler-host-hygiene-"));
+  const uptime = join(dir, "uptime");
+  writeFileSync(uptime, "1000000.00 0.00\n");
+
+  mockExecutable(
+    join(dir, "docker"),
+    `const containers = JSON.parse(process.env.MOCK_CONTAINERS);
+const command = process.argv[2];
+if (command === "ps") {
+  process.stdout.write(containers.map((item) => item.Id).join("\\n"));
+} else if (command === "inspect") {
+  process.stdout.write(JSON.stringify(containers));
+} else {
+  process.exit(2);
+}
+`,
+  );
+  mockExecutable(
+    join(dir, "systemctl"),
+    `const units = JSON.parse(process.env.MOCK_UNITS);
+const command = process.argv[2];
+if (command === "list-units") {
+  process.stdout.write(Object.entries(units).map(([name, item]) =>
+    \`${"${name}"} loaded active ${"${item.subState}"} fixture\`
+  ).join("\\n"));
+} else if (command === "show") {
+  const item = units[process.argv[3]];
+  process.stdout.write(\`FragmentPath=${"${item.fragment}"}\\nActiveEnterTimestampMonotonic=${"${item.activeAtMicros}"}\\n\`);
+} else {
+  process.exit(2);
+}
+`,
+  );
+
+  const result = spawnSync(
+    "python3",
+    [
+      "scripts/crawler-host-hygiene.py",
+      "--now",
+      "2026-07-20T12:00:00Z",
+      "--proc-uptime",
+      uptime,
+    ],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        PATH: `${dir}:${process.env.PATH}`,
+        MOCK_CONTAINERS: JSON.stringify(containers),
+        MOCK_UNITS: JSON.stringify(units),
+      },
+      encoding: "utf8",
+    },
+  );
+  rmSync(dir, { recursive: true, force: true });
+  return result;
+}
+
+function container({ id, name, startedAt, composeProject = "" }) {
+  return {
+    Id: id,
+    Name: `/${name}`,
+    Config: {
+      Image: "crawler-full:test",
+      Labels: composeProject
+        ? { "com.docker.compose.project": composeProject }
+        : {},
+    },
+    State: { StartedAt: startedAt },
+  };
+}
+
+test("host hygiene reports only stale unmanaged resources", () => {
+  const result = runHygiene({
+    containers: [
+      container({
+        id: "stale-container-id",
+        name: "tesla-debug",
+        startedAt: "2026-07-18T10:00:00Z",
+      }),
+      container({
+        id: "compose-container-id",
+        name: "worker",
+        startedAt: "2026-07-10T10:00:00Z",
+        composeProject: "deploy",
+      }),
+      container({
+        id: "recent-container-id",
+        name: "crawler-refresh-typesense",
+        startedAt: "2026-07-20T11:30:00Z",
+      }),
+    ],
+    units: {
+      "starbucks-backfill.service": {
+        subState: "exited",
+        fragment: "/run/systemd/transient/starbucks-backfill.service",
+        activeAtMicros: 500_000_000_000,
+      },
+      "recent-debug.service": {
+        subState: "exited",
+        fragment: "/run/systemd/transient/recent-debug.service",
+        activeAtMicros: 999_000_000_000,
+      },
+      "managed.service": {
+        subState: "exited",
+        fragment: "/etc/systemd/system/managed.service",
+        activeAtMicros: 100_000_000_000,
+      },
+      "running.service": {
+        subState: "running",
+        fragment: "/run/systemd/transient/running.service",
+        activeAtMicros: 100_000_000_000,
+      },
+    },
+  });
+
+  assert.equal(result.status, 1, result.stderr);
+  assert.match(result.stderr, /found 2 stale resource/);
+  assert.match(result.stderr, /tesla-debug/);
+  assert.match(result.stderr, /docker rm -f -- tesla-debug/);
+  assert.match(result.stderr, /starbucks-backfill\.service/);
+  assert.match(result.stderr, /systemctl stop starbucks-backfill\.service/);
+  assert.doesNotMatch(result.stderr, /worker/);
+  assert.doesNotMatch(result.stderr, /crawler-refresh-typesense/);
+  assert.doesNotMatch(result.stderr, /recent-debug/);
+  assert.doesNotMatch(result.stderr, /managed\.service/);
+  assert.doesNotMatch(result.stderr, /running\.service/);
+});
+
+test("host hygiene succeeds when old resources are managed", () => {
+  const result = runHygiene({
+    containers: [
+      container({
+        id: "compose-container-id",
+        name: "worker",
+        startedAt: "2026-07-10T10:00:00Z",
+        composeProject: "deploy",
+      }),
+    ],
+    units: {
+      "managed.service": {
+        subState: "exited",
+        fragment: "/etc/systemd/system/managed.service",
+        activeAtMicros: 100_000_000_000,
+      },
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /host hygiene clean/);
+});


### PR DESCRIPTION
Related to #4943. The issue will be closed only after the existing production residue is removed and the new check is verified clean.

## Reproduction
Read-only inspection on 2026-07-20 confirmed the original residue still exists: three non-Compose Tesla debug containers have run since April, and `starbucks-backfill.service` is a transient `active (exited)` unit with its watcher still alive.

## Root cause
The hourly Docker GC only removes unused images and builder cache. The scheduled maintenance path had no age-aware inventory for running resources outside Compose or completed transient services, so debug artifacts were invisible indefinitely.

## Solution
- add a read-only host hygiene checker for unmanaged running containers and `active (exited)` transient services older than 24 hours
- print exact cleanup plans but never delete automatically
- run the gate after every four-hour crawler maintenance command
- add deterministic executable tests covering stale, recent, Compose-managed, persistent-unit, and running-unit cases
- document inspection and safe cleanup behavior

## Verification
- `node --test scripts/crawler-host-hygiene.test.mjs scripts/ci-workflow.test.mjs scripts/docs-index.test.mjs scripts/dealroom-company-requests.test.mjs` (35 passed)
- `actionlint .github/workflows/crawler-scheduled-maintenance.yml .github/workflows/ci.yml`
- `uv run --project apps/crawler ruff check scripts/crawler-host-hygiene.py`
- `uv run --project apps/crawler ruff format --check scripts/crawler-host-hygiene.py`
- `python3 -m py_compile scripts/crawler-host-hygiene.py`
- `git diff --check`