### PR TITLE
Always report crawler host hygiene

### DIFF
--- a/.github/workflows/crawler-scheduled-maintenance.yml
+++ b/.github/workflows/crawler-scheduled-maintenance.yml
@@ -86,10 +86,23 @@ jobs:
             NAME="crawler-${TASK}-$(date -u +%Y%m%dT%H%M%SZ)"
             tag="$(grep -E '^CRAWLER_IMAGE_TAG=' /home/deploy/.env 2>/dev/null | tail -n1 | cut -d= -f2- || true)"
             tag="${tag:-latest}"
+            maintenance_status=0
             docker run --rm \
               --name "$NAME" \
               --env-file /home/deploy/.env \
               --network host \
               "ghcr.io/colophon-group/jobseek-crawler:${tag}" \
-              uv run --no-sync crawler "$TASK"
-            python3 "/tmp/jobseek-crawler-maintenance/${GITHUB_SHA}/crawler-host-hygiene.py"
+              uv run --no-sync crawler "$TASK" || maintenance_status=$?
+
+            hygiene_status=0
+            python3 "/tmp/jobseek-crawler-maintenance/${GITHUB_SHA}/crawler-host-hygiene.py" || hygiene_status=$?
+
+            if (( maintenance_status != 0 )); then
+              echo "Maintenance task failed with status ${maintenance_status}" >&2
+            fi
+            if (( hygiene_status != 0 )); then
+              echo "Host hygiene check failed with status ${hygiene_status}" >&2
+            fi
+            if (( maintenance_status != 0 || hygiene_status != 0 )); then
+              exit 1
+            fi

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -46,6 +46,14 @@ const deployCodexRunnerHostScript = readFileSync(
   "scripts/deploy-codex-runner-host.sh",
   "utf8",
 );
+const crawlerScheduledMaintenanceWorkflow = readFileSync(
+  ".github/workflows/crawler-scheduled-maintenance.yml",
+  "utf8",
+);
+const crawlerHostHygieneScript = readFileSync(
+  "scripts/crawler-host-hygiene.py",
+  "utf8",
+);
 const mainStrictGateRuleset = JSON.parse(
   readFileSync(".github/rulesets/main-strict-gate.json", "utf8"),
 );
@@ -212,6 +220,20 @@ test("Codex deploy transport outlives the runner lock wait", () => {
     "SSH command timeout must include the lock wait plus 15 minutes for deployment",
   );
   assert.match(deployCodexRunnerWorkflow, /cancel-in-progress: false/);
+});
+
+test("scheduled maintenance always reports host hygiene independently", () => {
+  assert.match(crawlerHostHygieneScript, /from datetime import datetime, timezone/);
+  assert.match(crawlerHostHygieneScript, /UTC = timezone\.utc/);
+  assert.doesNotMatch(crawlerHostHygieneScript, /from datetime import UTC/);
+  assert.match(
+    crawlerScheduledMaintenanceWorkflow,
+    /docker run --rm[\s\S]*\|\| maintenance_status=\$\?[\s\S]*crawler-host-hygiene\.py" \|\| hygiene_status=\$\?/,
+  );
+  assert.match(
+    crawlerScheduledMaintenanceWorkflow,
+    /maintenance_status != 0 \|\| hygiene_status != 0/,
+  );
 });
 
 test("maybe-auto-merge wakes without manual retries", () => {

--- a/scripts/crawler-host-hygiene.py
+++ b/scripts/crawler-host-hygiene.py
@@ -5,14 +5,16 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import shlex
 import subprocess
 import sys
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 COMPOSE_PROJECT_LABEL = "com.docker.compose.project"
+UTC = timezone.utc
 
 
 class HygieneError(RuntimeError):
@@ -37,8 +39,12 @@ def _run(command: list[str]) -> str:
 
 
 def _parse_started_at(value: str) -> datetime:
+    normalized = value.replace("Z", "+00:00")
+    # Docker emits nanoseconds, while the host's Python 3.10 ISO parser accepts
+    # at most six fractional digits.
+    normalized = re.sub(r"(\.\d{6})\d+([+-]\d{2}:\d{2})$", r"\1\2", normalized)
     try:
-        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(normalized)
     except ValueError as exc:
         raise HygieneError(f"invalid Docker StartedAt timestamp: {value!r}") from exc
     if parsed.tzinfo is None:

--- a/scripts/crawler-host-hygiene.test.mjs
+++ b/scripts/crawler-host-hygiene.test.mjs
@@ -94,7 +94,7 @@ test("host hygiene reports only stale unmanaged resources", () => {
       container({
         id: "stale-container-id",
         name: "tesla-debug",
-        startedAt: "2026-07-18T10:00:00Z",
+        startedAt: "2026-07-18T10:00:00.123456789Z",
       }),
       container({
         id: "compose-container-id",


### PR DESCRIPTION
Related to #4943 and follow-up to #5741.

## Production reproduction
The first post-merge maintenance run (#29748232301) hit the existing #4947 Typesense timeout before reaching the hygiene command. Direct execution of the copied checker then exposed two compatibility/ordering bugs:

- host Python is 3.10, so `datetime.UTC` was unavailable and nanosecond Docker timestamps exceeded its ISO parser
- `set -e` let any maintenance failure skip hygiene entirely

## Root-cause fix
- use Python 3.10-compatible `timezone.utc` and normalize Docker nanoseconds to microseconds
- capture maintenance and hygiene exit statuses independently, always execute both, report both, and fail once at the end
- add regression coverage for host compatibility and independent workflow execution

## Production proof
Piping this revision read-only to the crawler host reports exactly four stale resources: three 89-day non-Compose Tesla containers and the 102-day `starbucks-backfill.service` transient unit. No cleanup has been performed yet; that will happen only after this PR is green and merged.

## Verification
- repository Node tests: 36 passed (full), 25 passed after compatibility update
- `actionlint .github/workflows/crawler-scheduled-maintenance.yml .github/workflows/ci.yml`
- ruff check/format
- Python byte compilation
- live read-only execution under host Python 3.10
- `git diff --check`