### PR TITLE
Run PR-only gates for workflow-dispatched CI

### DIFF
--- a/.github/scripts/classify-pr-paths.sh
+++ b/.github/scripts/classify-pr-paths.sh
@@ -70,7 +70,15 @@ emit() {
   fi
 }
 
+base_ref=$(gh api "repos/$REPO/pulls/$PR" --jq '.base.ref')
+if [[ -z "$base_ref" || "$base_ref" == "null" ]]; then
+  echo "PR #$PR has no base branch" >&2
+  exit 1
+fi
+
 emit "code" "$code"
 emit "crawler_code" "$crawler_code"
 emit "boards_csv" "$boards_csv"
 emit "codeql" "$code"
+emit "is_pr" "true"
+emit "base_ref" "$base_ref"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,8 @@ jobs:
       code: ${{ steps.manual-default.outputs.code || steps.manual-pr.outputs.code || steps.filter.outputs.code }}
       crawler_code: ${{ steps.manual-default.outputs.crawler_code || steps.manual-pr.outputs.crawler_code || steps.filter.outputs.crawler_code }}
       boards_csv: ${{ steps.manual-default.outputs.boards_csv || steps.manual-pr.outputs.boards_csv || steps.filter.outputs.boards_csv }}
+      is_pr: ${{ steps.manual-default.outputs.is_pr || steps.manual-pr.outputs.is_pr || steps.pull-request.outputs.is_pr }}
+      base_ref: ${{ steps.manual-default.outputs.base_ref || steps.manual-pr.outputs.base_ref || steps.pull-request.outputs.base_ref }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
         with:
@@ -92,6 +94,8 @@ jobs:
             echo "code=true"
             echo "crawler_code=false"
             echo "boards_csv=false"
+            echo "is_pr=false"
+            echo "base_ref="
           } >> "$GITHUB_OUTPUT"
 
       - name: Classify manually dispatched PR paths
@@ -102,6 +106,17 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           PR: ${{ github.event.inputs.pr }}
+
+      - name: Record pull request context
+        id: pull-request
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          {
+            echo "is_pr=true"
+            echo "base_ref=$BASE_REF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Detect changed paths
         id: filter
@@ -665,7 +680,7 @@ jobs:
   version-check:
     name: Version bump check
     needs: changes
-    if: github.event_name == 'pull_request' && needs.changes.outputs.crawler_code == 'true'
+    if: needs.changes.outputs.is_pr == 'true' && needs.changes.outputs.crawler_code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
@@ -693,7 +708,7 @@ jobs:
   probe-new-boards:
     name: Probe new/changed boards
     needs: changes
-    if: github.event_name == 'pull_request' && needs.changes.outputs.boards_csv == 'true'
+    if: needs.changes.outputs.is_pr == 'true' && needs.changes.outputs.boards_csv == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
@@ -714,13 +729,13 @@ jobs:
 
       - name: Fetch base ref
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_REF: ${{ needs.changes.outputs.base_ref }}
         run: git fetch --depth=1 origin "$BASE_REF"
 
       - name: Probe added/changed boards
         working-directory: apps/crawler
         env:
-          BASE_REF: ${{ github.base_ref }}
+          BASE_REF: ${{ needs.changes.outputs.base_ref }}
         run: uv run python ../../scripts/probe-new-boards.py --base-ref "origin/$BASE_REF"
 
   required-ci:
@@ -768,6 +783,7 @@ jobs:
           const code = needs.changes?.outputs?.code === "true";
           const crawlerCode = needs.changes?.outputs?.crawler_code === "true";
           const boardsCsv = needs.changes?.outputs?.boards_csv === "true";
+          const isPr = needs.changes?.outputs?.is_pr === "true";
 
           const failures = [];
 
@@ -809,8 +825,8 @@ jobs:
           }
 
           requireSuccess("ws-package-smoke", crawlerCode);
-          requireSuccess("version-check", eventName === "pull_request" && crawlerCode);
-          requireSuccess("probe-new-boards", eventName === "pull_request" && boardsCsv);
+          requireSuccess("version-check", isPr && crawlerCode);
+          requireSuccess("probe-new-boards", isPr && boardsCsv);
 
           if (failures.length > 0) {
             console.error("Required CI failed:");

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -110,6 +110,46 @@ printf '%s\\n' "$*" >> "$MOCK_GH_LOG"
   return { ...result, calls };
 }
 
+function runClassifyPrPaths({ files = [], baseRef = "main" } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "classify-pr-paths-"));
+  const output = join(dir, "github-output");
+  const gh = join(dir, "gh");
+  writeFileSync(
+    gh,
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" == *"/files"* ]]; then
+  printf '%s\\n' "$MOCK_FILES"
+else
+  printf '%s\\n' "$MOCK_BASE_REF"
+fi
+`,
+  );
+  chmodSync(gh, 0o755);
+  const result = spawnSync("bash", [".github/scripts/classify-pr-paths.sh"], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      PATH: `${dir}:${process.env.PATH}`,
+      GH_TOKEN: "test-token",
+      REPO: "colophon-group/jobseek",
+      PR: "123",
+      GITHUB_OUTPUT: output,
+      MOCK_FILES: files.join("\n"),
+      MOCK_BASE_REF: baseRef,
+    },
+    encoding: "utf8",
+  });
+  let outputs = "";
+  try {
+    outputs = readFileSync(output, "utf8");
+  } catch {
+    // Failed classifications may stop before writing outputs.
+  }
+  rmSync(dir, { recursive: true, force: true });
+  return { ...result, outputs };
+}
+
 function setupUvBlocks(workflowSource) {
   return [
     ...workflowSource.matchAll(
@@ -186,6 +226,39 @@ test("manual CI dispatch can classify a PR without full code checks", () => {
   assert.match(classifyPrPathsScript, /emit "crawler_code" "\$crawler_code"/);
   assert.match(classifyPrPathsScript, /emit "boards_csv" "\$boards_csv"/);
   assert.match(classifyPrPathsScript, /emit "codeql" "\$code"/);
+});
+
+test("manual PR classification exports the validated PR base context", () => {
+  const result = runClassifyPrPaths({
+    files: ["apps/crawler/src/core/monitor.py", "apps/crawler/data/boards.csv"],
+    baseRef: "main",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.outputs, /^code=true$/m);
+  assert.match(result.outputs, /^crawler_code=true$/m);
+  assert.match(result.outputs, /^boards_csv=true$/m);
+  assert.match(result.outputs, /^is_pr=true$/m);
+  assert.match(result.outputs, /^base_ref=main$/m);
+});
+
+test("PR-only CI gates cover pull requests and dispatched PRs", () => {
+  const changesJob = jobBlock("changes");
+  const versionJob = jobBlock("version-check");
+  const probeJob = jobBlock("probe-new-boards");
+  const requiredCiJob = jobBlock("required-ci");
+
+  assert.match(changesJob, /echo "is_pr=false"/);
+  assert.match(changesJob, /id: manual-pr[\s\S]*classify-pr-paths\.sh/);
+  assert.match(changesJob, /id: pull-request[\s\S]*echo "is_pr=true"/);
+  assert.match(changesJob, /echo "base_ref=\$BASE_REF"/);
+  assert.match(versionJob, /if: needs\.changes\.outputs\.is_pr == 'true'/);
+  assert.match(probeJob, /if: needs\.changes\.outputs\.is_pr == 'true'/);
+  assert.match(probeJob, /BASE_REF: \$\{\{ needs\.changes\.outputs\.base_ref \}\}/);
+  assert.match(requiredCiJob, /const isPr = needs\.changes\?\.outputs\?\.is_pr === "true"/);
+  assert.match(requiredCiJob, /requireSuccess\("version-check", isPr && crawlerCode\)/);
+  assert.match(requiredCiJob, /requireSuccess\("probe-new-boards", isPr && boardsCsv\)/);
+  assert.doesNotMatch(versionJob, /github\.event_name == 'pull_request'/);
+  assert.doesNotMatch(probeJob, /github\.event_name == 'pull_request'/);
 });
 
 test("workflow-security runs repository script tests", () => {


### PR DESCRIPTION
Closes #5742

## Root cause

The CI workflow keyed PR-only gates off `github.event_name == pull_request`. Image-cleanup validation deliberately reuses CI through `workflow_dispatch` with a PR number, so dispatched validation skipped crawler version and board probe checks even though it classified the PR diff.

## Fix

- have the path classifier resolve and emit the PR base branch
- carry explicit PR context through both pull-request and dispatched runs
- gate version and live-board validation on PR context, not trigger name
- enforce those results in Required CI for dispatched PR validation
- add executable workflow regression coverage for classification and gate wiring

## Verification

- `bash -n .github/scripts/classify-pr-paths.sh`
- `node --test scripts/ci-workflow.test.mjs` (38 passing)
- `actionlint .github/workflows/ci.yml`
- `git diff --check`