### PR TITLE
Prevent Codex deploy starvation

### DIFF
--- a/.github/workflows/deploy-codex-runner.yml
+++ b/.github/workflows/deploy-codex-runner.yml
@@ -21,7 +21,8 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
-  JOBSEEK_CODEX_DEPLOY_LOCK_TIMEOUT_S: "900"
+  # Covers the governor service's four-hour maximum plus lock-release headroom.
+  JOBSEEK_CODEX_DEPLOY_LOCK_TIMEOUT_S: "15000"
 
 concurrency:
   group: codex-runner-production-sync
@@ -57,9 +58,9 @@ jobs:
           username: root
           key: ${{ secrets.HETZNER_SSH_KEY }}
           envs: GITHUB_SHA,JOBSEEK_CODEX_DEPLOY_LOCK_TIMEOUT_S
-          # Allow the 15-minute runner-lock wait to finish, then leave another
-          # 15 minutes for checkout, runtime sync, verification, and reporting.
-          command_timeout: 30m
+          # Allow the full resolver window to finish, then leave 50 minutes for
+          # checkout, runtime sync, verification, and reporting.
+          command_timeout: 5h
           script: |
             set -euo pipefail
             export JOBSEEK_CODEX_BRANCH=main

--- a/docs/18-codex-automation-deployment.md
+++ b/docs/18-codex-automation-deployment.md
@@ -330,15 +330,22 @@ timers for boot persistence. It intentionally sets
 `JOBSEEK_CODEX_START_TIMERS=0`, so it does not start a company resolver,
 annotation run, or error review from GitHub Actions.
 
-The deploy never interrupts a live Codex routine. It waits up to 15 minutes
-for the shared runner lock, and the SSH command has a 30-minute envelope so
-that a successful lock wait still leaves 15 minutes for checkout, runtime
-sync, verification, and the retention report. If the lock remains occupied
-for the full wait, the deploy fails before changing the checkout or units;
-the live routine continues normally, and the deployment can be retried with
-`workflow_dispatch` after the routine releases the lock. Workflow concurrency
-also uses `cancel-in-progress: false`, so queued deployments are not canceled
-by a newer push.
+The deploy never interrupts a live Codex routine. Before waiting for the shared
+runner lock, it records which Codex timers are active and stops those timer
+units only. A service that already holds the lock continues normally, while no
+new resolver or daily routine can jump ahead of the pending deploy. An exit
+trap restores the previously active timers on both success and failure; the
+workflow's `JOBSEEK_CODEX_START_TIMERS=0` therefore means "restore existing
+timer state", not "leave production paused".
+
+The lock wait is bounded at 15,000 seconds: the governor's four-hour service
+limit plus lock-release headroom. The SSH command has a five-hour envelope so
+that a full wait still leaves 50 minutes for checkout, runtime sync,
+verification, and reporting. A longer daily routine can still make the deploy
+fail before changing the checkout or units, but continuous resolver work can
+no longer starve it by reacquiring the lock between retries. Workflow
+concurrency also uses `cancel-in-progress: false`, so queued deployments are
+not canceled by a newer push.
 
 Initial service limits:
 

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -295,6 +295,75 @@ test("Codex deploy transport outlives the runner lock wait", () => {
   assert.match(deployCodexRunnerWorkflow, /cancel-in-progress: false/);
 });
 
+test("Codex deploy reserves the next runner-lock handoff", () => {
+  const pauseCall = deployCodexRunnerHostScript.indexOf(
+    "  pause_timer_activations\n",
+  );
+  const lockWait = deployCodexRunnerHostScript.indexOf(
+    '  if ! flock -w "${LOCK_TIMEOUT_S}" 9; then',
+  );
+
+  assert.ok(pauseCall >= 0, "deployment must pause timer activations");
+  assert.ok(lockWait > pauseCall, "timers must pause before waiting for the lock");
+  assert.match(
+    deployCodexRunnerHostScript,
+    /systemctl is-active --quiet "\$\{timer\}"[\s\S]*systemctl stop "\$\{ACTIVE_TIMERS_BEFORE_DEPLOY\[@\]\}"/,
+  );
+  assert.match(
+    deployCodexRunnerHostScript,
+    /trap restore_timers_on_exit EXIT/,
+  );
+  assert.match(
+    deployCodexRunnerHostScript,
+    /systemctl start "\$\{ACTIVE_TIMERS_BEFORE_DEPLOY\[@\]\}"/,
+  );
+  assert.doesNotMatch(
+    deployCodexRunnerHostScript,
+    /systemctl stop "\$\{UNITS\[@\]\}"/,
+    "deployment must not interrupt an active service",
+  );
+});
+
+test("Codex deploy restores prior timer state after failure", () => {
+  const dir = mkdtempSync(join(tmpdir(), "codex-deploy-timers-"));
+  const log = join(dir, "systemctl.log");
+  const result = spawnSync(
+    "bash",
+    [
+      "-c",
+      `set -euo pipefail
+source scripts/deploy-codex-runner-host.sh
+TIMERS=(alpha.timer beta.timer)
+START_TIMERS=0
+systemctl() {
+  printf '%s\\n' "$*" >> "$MOCK_SYSTEMCTL_LOG"
+  if [[ "$1" == "is-active" ]]; then
+    [[ "$3" == "alpha.timer" ]]
+    return
+  fi
+  return 0
+}
+pause_timer_activations
+exit 23
+`,
+    ],
+    {
+      cwd: process.cwd(),
+      env: { ...process.env, MOCK_SYSTEMCTL_LOG: log },
+      encoding: "utf8",
+    },
+  );
+  const calls = readFileSync(log, "utf8");
+  rmSync(dir, { recursive: true, force: true });
+
+  assert.equal(result.status, 23, result.stderr);
+  assert.match(calls, /^is-active --quiet alpha\.timer$/m);
+  assert.match(calls, /^is-active --quiet beta\.timer$/m);
+  assert.match(calls, /^stop alpha\.timer$/m);
+  assert.match(calls, /^start alpha\.timer$/m);
+  assert.doesNotMatch(calls, /^start beta\.timer$/m);
+});
+
 test("scheduled maintenance always reports host hygiene independently", () => {
   assert.match(crawlerHostHygieneScript, /from datetime import datetime, timezone/);
   assert.match(crawlerHostHygieneScript, /UTC = timezone\.utc/);

--- a/scripts/deploy-codex-runner-host.sh
+++ b/scripts/deploy-codex-runner-host.sh
@@ -11,7 +11,7 @@ REPO_DIR="${JOBSEEK_CODEX_REPO_DIR:-${ROOT_DIR}/repo}"
 REPO_URL="${JOBSEEK_CODEX_REPO_URL:-https://github.com/colophon-group/jobseek.git}"
 BRANCH="${JOBSEEK_CODEX_BRANCH:-main}"
 EXPECTED_SHA="${JOBSEEK_CODEX_EXPECTED_SHA:-}"
-LOCK_TIMEOUT_S="${JOBSEEK_CODEX_DEPLOY_LOCK_TIMEOUT_S:-900}"
+LOCK_TIMEOUT_S="${JOBSEEK_CODEX_DEPLOY_LOCK_TIMEOUT_S:-15000}"
 START_TIMERS="${JOBSEEK_CODEX_START_TIMERS:-0}"
 
 LOCK_FILE="${ROOT_DIR}/state/codex-runner.lock"
@@ -30,6 +30,9 @@ TIMERS=(
   jobseek-codex-daily-annotations.timer
   jobseek-codex-daily-error-review.timer
 )
+
+ACTIVE_TIMERS_BEFORE_DEPLOY=()
+TIMER_RESTORE_ARMED=0
 
 log() {
   printf '==> %s\n' "$*"
@@ -172,16 +175,51 @@ report_trace_retention() {
     "${REPO_DIR}/scripts/codex-trace-backfill.py" --report
 }
 
-maybe_start_timers() {
-  if [[ "${START_TIMERS}" == "1" ]]; then
-    systemctl start "${TIMERS[@]}"
+pause_timer_activations() {
+  local timer
+  for timer in "${TIMERS[@]}"; do
+    if systemctl is-active --quiet "${timer}"; then
+      ACTIVE_TIMERS_BEFORE_DEPLOY+=("${timer}")
+    fi
+  done
+
+  TIMER_RESTORE_ARMED=1
+  trap restore_timers_on_exit EXIT
+
+  if ((${#ACTIVE_TIMERS_BEFORE_DEPLOY[@]} > 0)); then
+    log "pausing new Codex timer activations while deployment waits"
+    systemctl stop "${ACTIVE_TIMERS_BEFORE_DEPLOY[@]}"
   fi
+}
+
+restore_timers_on_exit() {
+  local deploy_status=$?
+  local restore_status=0
+  trap - EXIT
+  set +e
+
+  if [[ "${TIMER_RESTORE_ARMED}" == "1" ]]; then
+    if [[ "${START_TIMERS}" == "1" ]]; then
+      systemctl start "${TIMERS[@]}"
+      restore_status=$?
+    elif ((${#ACTIVE_TIMERS_BEFORE_DEPLOY[@]} > 0)); then
+      systemctl start "${ACTIVE_TIMERS_BEFORE_DEPLOY[@]}"
+      restore_status=$?
+    fi
+  fi
+
+  systemctl list-timers --all 'jobseek-codex*' --no-pager
+  if [[ "${deploy_status}" -eq 0 && "${restore_status}" -ne 0 ]]; then
+    deploy_status="${restore_status}"
+  fi
+  exit "${deploy_status}"
 }
 
 main() {
   require_root
   ensure_layout
   require_runtime_config
+  pause_timer_activations
 
   log "waiting for Codex runner lock: ${LOCK_FILE}"
   exec 9>"${LOCK_FILE}"
@@ -195,8 +233,8 @@ main() {
   verify_entrypoints
   reconcile_codex_worktrees
   report_trace_retention
-  maybe_start_timers
-  systemctl list-timers --all 'jobseek-codex*' --no-pager
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
## Root cause

Deploys waited on the same runner lock as the company resolver, but left the one-minute governor timer active. With a non-empty company-request backlog, the timer could start a new resolver between a lock release and a deploy retry, so retrying the 15-minute wait did not guarantee progress.

## Solution

- snapshot and pause active Codex timer units before waiting for the shared lock
- leave an already-running resolver or daily service untouched
- restore the prior timer state from an EXIT trap on success and failure
- cover the governor’s full four-hour service window plus lock-release headroom
- keep the outer SSH timeout longer than the host-side wait
- add static ordering checks and an executable failure-path timer restoration test

## Verification

- `bash -n scripts/deploy-codex-runner-host.sh`
- `node --test scripts/ci-workflow.test.mjs` (27 passed)
- `git diff --check`

Closes #5755