### PR TITLE
Fix company PR label classification

### DIFF
--- a/.github/scripts/label-pr.sh
+++ b/.github/scripts/label-pr.sh
@@ -16,6 +16,8 @@ set -euo pipefail
 : "${PR:?PR is required}"
 : "${REPO:?REPO is required}"
 
+SCRIPTS_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+
 # Only label add-company/* branches — developer branches are reviewed manually
 BRANCH=$(gh pr view "$PR" --repo "$REPO" --json headRefName -q .headRefName)
 if [[ "$BRANCH" != add-company/* ]]; then
@@ -27,8 +29,8 @@ fi
 ALLOWED_FILES="apps/crawler/data/companies.csv apps/crawler/data/boards.csv apps/crawler/data/company_descriptions.csv apps/crawler/VERSION"
 # Keep these static: this script runs with pull_request_target write
 # permissions and must not import PR-controllable Python.
-VALID_MONITOR_TYPES='accenture|almacareer|amazon|api_sniffer|ashby|bite|breezy|deel|dom|dvinci|eightfold|gem|greenhouse|hireology|inline|jobylon|join|lever|mokahr|nextdata|notion|oracle_hcm|personio|phenom|pinpoint|recruitee|recruiter_co_kr|rippling|rss|sitemap|smartrecruiters|softgarden|talentbrew|traffit|umantis|workable|workday|ycombinator'
-VALID_SCRAPER_TYPES='api_sniffer|bite|dom|eightfold|embedded|json-ld|mokahr|nextdata|notion|oracle_hcm|pdf|rippling|skip|smartrecruiters|workable|workday'
+VALID_MONITOR_TYPES='accenture|almacareer|amazon|api_sniffer|ashby|bite|breezy|comeet|deel|dom|dvinci|eightfold|gem|greenhouse|hireology|inline|jobylon|join|lever|mokahr|nextdata|notion|oracle_hcm|paylocity|personio|phenom|pinpoint|recruitee|recruiter_co_kr|rippling|rss|sitemap|smartrecruiters|softgarden|talentbrew|traffit|umantis|workable|workday|ycombinator'
+VALID_SCRAPER_TYPES='api_sniffer|bite|dom|eightfold|embedded|json-ld|mokahr|nextdata|notion|oracle_hcm|paylocity|pdf|rippling|skip|smartrecruiters|workable|workday'
 SLUG_RE='^[a-z0-9]+(-[a-z0-9]+)*$'
 URL_RE='^https?://'
 # --- Check changed files ---
@@ -64,26 +66,20 @@ done <<< "$FILES"
 # --- Check diff size and content ---
 
 DIFF=$(gh pr diff "$PR" --repo "$REPO")
-# Count/validate only CSV hunks so non-CSV assets (e.g. KB markdown) don't affect CSV checks.
-CSV_DIFF=$(echo "$DIFF" | awk '
-  BEGIN { in_csv = 0 }
-  /^diff --git / {
-    in_csv = ($0 ~ /^diff --git a\/apps\/crawler\/data\/(companies|boards|company_descriptions)\.csv b\/apps\/crawler\/data\/(companies|boards|company_descriptions)\.csv$/)
-  }
-  in_csv { print }
-')
-RAW_ADDED=$(echo "$CSV_DIFF" | grep -c '^+[^+]' || true)
-RAW_REMOVED=$(echo "$CSV_DIFF" | grep -c '^-[^-]' || true)
-ADDED_LINES=$((RAW_ADDED - RAW_REMOVED))
-[ "$ADDED_LINES" -lt 0 ] && ADDED_LINES=0
+# Validate only semantic CSV additions. Stale company branches commonly move
+# already-merged rows while restoring sort order; treating the added half of a
+# remove/add pair as new made unrelated historical monitor types affect the
+# current PR's decision (#5764).
+CSV_ADDITIONS=$(printf '%s\n' "$DIFF" | python3 "$SCRIPTS_DIR/label_pr_csv_diff.py")
+ADDED_LINES=$(grep -c '.' <<< "$CSV_ADDITIONS" || true)
 
 # Dynamic limit: 1 company + 1 description + N boards + 1 margin.
-# Count added board rows (7-field CSV lines in boards.csv hunk).
-BOARD_ROWS=$(echo "$CSV_DIFF" | grep '^+[^+]' | python3 -c "
+# Count net-new board rows (7-field CSV lines).
+BOARD_ROWS=$(printf '%s\n' "$CSV_ADDITIONS" | python3 -c "
 import csv, io, sys
 n = 0
 for line in sys.stdin:
-    line = line.lstrip('+').strip()
+    line = line.strip()
     if not line or line.startswith('company_slug,'):
         continue
     try:
@@ -114,10 +110,9 @@ for row in csv.reader([sys.argv[1]]):
 " "$1"
 }
 
-# Validate each added line in the diff (skip diff headers)
+# Validate each net-new CSV row.
 while IFS= read -r line; do
-  # Strip the leading "+"
-  content="${line:1}"
+  content="$line"
 
   # Skip empty lines and CSV headers
   [ -z "$content" ] && continue
@@ -178,7 +173,7 @@ while IFS= read -r line; do
       DIFF_OK=false
     fi
   fi
-done < <(echo "$CSV_DIFF" | grep '^+[^+]' || true)
+done <<< "$CSV_ADDITIONS"
 
 # --- Check PR completeness (full file inspection) ---
 

--- a/.github/scripts/label_pr_csv_diff.py
+++ b/.github/scripts/label_pr_csv_diff.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Return semantic CSV additions from a unified company-PR diff.
+
+CSV sort/rebase churn can show an unchanged row once as removed and once as
+added. Those rows are moves, not PR-authored configuration, so the trusted
+classifier must cancel them before validating monitor/scraper types.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from collections import Counter
+
+CSV_PATHS = frozenset(
+    {
+        "apps/crawler/data/boards.csv",
+        "apps/crawler/data/companies.csv",
+        "apps/crawler/data/company_descriptions.csv",
+    }
+)
+_DIFF_HEADER = re.compile(r"^diff --git a/(.+) b/(.+)$")
+
+
+def net_added_csv_rows(diff: str) -> list[str]:
+    """Return added rows after identical removals in the same file cancel."""
+    current_path: str | None = None
+    added: Counter[tuple[str, str]] = Counter()
+    removed: Counter[tuple[str, str]] = Counter()
+    addition_order: list[tuple[str, str]] = []
+
+    for line in diff.splitlines():
+        header = _DIFF_HEADER.match(line)
+        if header:
+            before, after = header.groups()
+            current_path = after if before == after and after in CSV_PATHS else None
+            continue
+        if current_path is None or len(line) < 2:
+            continue
+        if line.startswith("+++") or line.startswith("---"):
+            continue
+        key = (current_path, line[1:])
+        if line.startswith("+"):
+            added[key] += 1
+            addition_order.append(key)
+        elif line.startswith("-"):
+            removed[key] += 1
+
+    remaining = added.copy()
+    for key, count in removed.items():
+        remaining[key] = max(0, remaining[key] - count)
+
+    rows: list[str] = []
+    for key in addition_order:
+        if remaining[key] <= 0:
+            continue
+        rows.append(key[1])
+        remaining[key] -= 1
+    return rows
+
+
+def main() -> None:
+    rows = net_added_csv_rows(sys.stdin.read())
+    if rows:
+        sys.stdout.write("\n".join(rows) + "\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/maybe-auto-merge.yml
+++ b/.github/workflows/maybe-auto-merge.yml
@@ -35,6 +35,7 @@ jobs:
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/trusted-scripts"
           cp .github/scripts/label-pr.sh "$RUNNER_TEMP/trusted-scripts/label-pr.sh"
+          cp .github/scripts/label_pr_csv_diff.py "$RUNNER_TEMP/trusted-scripts/label_pr_csv_diff.py"
           cp .github/scripts/close-linked-company-request-issues.sh "$RUNNER_TEMP/trusted-scripts/close-linked-company-request-issues.sh"
           cp .github/scripts/maybe-auto-merge-pr.sh "$RUNNER_TEMP/trusted-scripts/maybe-auto-merge-pr.sh"
           cp .github/scripts/dispatch-pr-checks.sh "$RUNNER_TEMP/trusted-scripts/dispatch-pr-checks.sh"

--- a/.github/workflows/upload-company-images.yml
+++ b/.github/workflows/upload-company-images.yml
@@ -52,6 +52,7 @@ jobs:
 
           mkdir -p "$RUNNER_TEMP/trusted-scripts"
           cp .github/scripts/label-pr.sh "$RUNNER_TEMP/trusted-scripts/label-pr.sh"
+          cp .github/scripts/label_pr_csv_diff.py "$RUNNER_TEMP/trusted-scripts/label_pr_csv_diff.py"
           cp .github/scripts/close-linked-company-request-issues.sh "$RUNNER_TEMP/trusted-scripts/close-linked-company-request-issues.sh"
           cp .github/scripts/dispatch-pr-checks.sh "$RUNNER_TEMP/trusted-scripts/dispatch-pr-checks.sh"
           cp .github/scripts/maybe-auto-merge-pr.sh "$RUNNER_TEMP/trusted-scripts/maybe-auto-merge-pr.sh"

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import {
   chmodSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -34,6 +35,7 @@ const dispatchPrChecksScript = readFileSync(
   "utf8",
 );
 const labelPrScript = readFileSync(".github/scripts/label-pr.sh", "utf8");
+const labelPrCsvDiffHelper = ".github/scripts/label_pr_csv_diff.py";
 const publishMcpServerWorkflow = readFileSync(
   ".github/workflows/publish-mcp-server.yml",
   "utf8",
@@ -148,6 +150,68 @@ fi
   }
   rmSync(dir, { recursive: true, force: true });
   return { ...result, outputs };
+}
+
+function runCompanyPrLabeler(diff) {
+  const dir = mkdtempSync(join(tmpdir(), "label-company-pr-"));
+  const output = join(dir, "github-output");
+  const log = join(dir, "gh.log");
+  const gh = join(dir, "gh");
+  writeFileSync(
+    gh,
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1 $2" == "pr view" && "$*" == *"headRefName"* ]]; then
+  printf '%s\n' 'add-company/example'
+elif [[ "$1 $2" == "pr view" && "$*" == *"labels"* ]]; then
+  printf '%s\n' 'review-code'
+elif [[ "$1 $2" == "pr diff" && "$*" == *"--name-only"* ]]; then
+  printf '%s\n' 'apps/crawler/data/boards.csv' 'apps/crawler/data/companies.csv' 'apps/crawler/data/company_descriptions.csv'
+elif [[ "$1 $2" == "pr diff" ]]; then
+  printf '%s' "$MOCK_DIFF"
+elif [[ "$1" == "api" && "$*" == *"/comments"* ]]; then
+  printf '%s\n' '<!-- crawl-stats {"jobs": 10, "monitor_time": 1.0} -->'
+elif [[ "$1" == "api" && "$*" == *"/contents/"* ]]; then
+  exit 0
+elif [[ "$1 $2" == "label create" ]]; then
+  exit 0
+elif [[ "$1 $2" == "pr edit" ]]; then
+  printf '%s\n' "$*" >> "$MOCK_GH_LOG"
+else
+  printf 'unexpected gh call: %s\n' "$*" >&2
+  exit 2
+fi
+`,
+  );
+  chmodSync(gh, 0o755);
+  const result = spawnSync("bash", [".github/scripts/label-pr.sh"], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      PATH: `${dir}:${process.env.PATH}`,
+      GH_TOKEN: "test-token",
+      REPO: "colophon-group/jobseek",
+      PR: "123",
+      GITHUB_OUTPUT: output,
+      MOCK_DIFF: diff,
+      MOCK_GH_LOG: log,
+    },
+    encoding: "utf8",
+  });
+  let outputs = "";
+  let calls = "";
+  try {
+    outputs = readFileSync(output, "utf8");
+  } catch {
+    // A failed classifier may stop before publishing outputs.
+  }
+  try {
+    calls = readFileSync(log, "utf8");
+  } catch {
+    // No label mutations means the mock call log is absent.
+  }
+  rmSync(dir, { recursive: true, force: true });
+  return { ...result, outputs, calls };
 }
 
 function setupUvBlocks(workflowSource) {
@@ -488,6 +552,127 @@ test("company PR label script applies decision labels idempotently", () => {
     labelPrScript,
     /for L in \$ALL_DECISION_LABELS; do\s+gh pr edit "\$PR" --repo "\$REPO" --remove-label "\$L"/,
   );
+});
+
+function shellAllowlist(name) {
+  const match = labelPrScript.match(new RegExp(`^${name}='([^']*)'$`, "m"));
+  assert.ok(match, `missing shell allowlist: ${name}`);
+  return new Set(match[1].split("|"));
+}
+
+function registeredTypes(directory) {
+  const types = new Set();
+  for (const filename of readdirSync(directory)) {
+    if (!filename.endsWith(".py")) continue;
+    const source = readFileSync(join(directory, filename), "utf8");
+    for (const match of source.matchAll(/\bregister\(\s*["']([^"']+)/g)) {
+      types.add(match[1]);
+    }
+  }
+  return types;
+}
+
+function netAddedCsvRows(diff) {
+  const result = spawnSync("python3", [labelPrCsvDiffHelper], {
+    cwd: process.cwd(),
+    input: diff,
+    encoding: "utf8",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  return result.stdout.trim() ? result.stdout.trim().split("\n") : [];
+}
+
+test("company PR static type allowlists match runtime registrations", () => {
+  assert.deepEqual(
+    shellAllowlist("VALID_MONITOR_TYPES"),
+    registeredTypes("apps/crawler/src/core/monitors"),
+  );
+  assert.deepEqual(
+    shellAllowlist("VALID_SCRAPER_TYPES"),
+    registeredTypes("apps/crawler/src/core/scrapers"),
+  );
+});
+
+test("company PR workflows capture the semantic diff helper as trusted code", () => {
+  for (const source of [maybeAutoMergeWorkflow, uploadCompanyImagesWorkflow]) {
+    assert.match(
+      source,
+      /cp \.github\/scripts\/label_pr_csv_diff\.py "\$RUNNER_TEMP\/trusted-scripts\/label_pr_csv_diff\.py"/,
+    );
+  }
+});
+
+test("company PR classifier cancels CSV row moves", () => {
+  const moved = "old,same,row";
+  const added = "company,board,https://example.com,sitemap,,skip,";
+  const diff = `diff --git a/apps/crawler/data/boards.csv b/apps/crawler/data/boards.csv
+--- a/apps/crawler/data/boards.csv
++++ b/apps/crawler/data/boards.csv
+@@ -1,2 +1,2 @@
+-${moved}
++${added}
+ ${moved}
+@@ -10,1 +10,1 @@
+-${added}
++${moved}
+`;
+
+  assert.deepEqual(netAddedCsvRows(diff), []);
+});
+
+test("company PR classifier retains only net-new CSV rows in order", () => {
+  const moved = "existing,Existing,https://existing.example,,,,,,";
+  const company = "new-company,New Company,https://new.example,,,,,,,";
+  const board = "new-company,careers,https://new.example/jobs,comeet,{},skip,";
+  const diff = `diff --git a/apps/crawler/data/companies.csv b/apps/crawler/data/companies.csv
+--- a/apps/crawler/data/companies.csv
++++ b/apps/crawler/data/companies.csv
+@@ -1 +1,2 @@
+-${moved}
++${company}
++${moved}
+diff --git a/apps/crawler/data/boards.csv b/apps/crawler/data/boards.csv
+--- a/apps/crawler/data/boards.csv
++++ b/apps/crawler/data/boards.csv
+@@ -1 +1 @@
++${board}
+`;
+
+  assert.deepEqual(netAddedCsvRows(diff), [company, board]);
+});
+
+test("company PR labeler auto-merges valid config despite moved historical rows", () => {
+  const moved =
+    "old-company,careers,https://old.example/jobs,paylocity,,paylocity,";
+  const board =
+    "new-company,careers,https://new.example/jobs,comeet,{},skip,";
+  const company = "new-company,New Company,https://new.example,,,,,,,";
+  const description = "new-company,English,German,French,Italian";
+  const diff = `diff --git a/apps/crawler/data/boards.csv b/apps/crawler/data/boards.csv
+--- a/apps/crawler/data/boards.csv
++++ b/apps/crawler/data/boards.csv
+@@ -1 +1,2 @@
+-${moved}
++${board}
++${moved}
+diff --git a/apps/crawler/data/companies.csv b/apps/crawler/data/companies.csv
+--- a/apps/crawler/data/companies.csv
++++ b/apps/crawler/data/companies.csv
+@@ -1 +1 @@
++${company}
+diff --git a/apps/crawler/data/company_descriptions.csv b/apps/crawler/data/company_descriptions.csv
+--- a/apps/crawler/data/company_descriptions.csv
++++ b/apps/crawler/data/company_descriptions.csv
+@@ -1 +1 @@
++${description}
+`;
+  const result = runCompanyPrLabeler(diff);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Applied labels: auto-merge/);
+  assert.match(result.outputs, /^labels=auto-merge$/m);
+  assert.match(result.calls, /--remove-label review-code/);
+  assert.match(result.calls, /--add-label auto-merge/);
 });
 
 test("CodeQL skips full analysis for non-code pull requests", () => {


### PR DESCRIPTION
## Root cause

Valid data-only company PRs such as #5761 and #5759 were labeled `review-code` for two independent classifier defects:

1. the trusted static monitor/scraper allowlists had drifted behind the runtime registries, so valid `comeet` and `paylocity` configurations were rejected;
2. stale-branch CSV sorting can represent an unchanged historical row as one removal plus one addition. The size calculation canceled those moves, but content validation still inspected every added half, letting unrelated historical rows affect the current PR.

## Solution

- add the currently registered `comeet` and `paylocity` types to the trusted allowlists
- add a trusted Python helper that cancels identical removed/added rows per CSV file before validation
- copy that helper into the trusted-script directory in both write-capable workflows
- add a CI contract that source-scans every literal runtime registration and requires exact allowlist equality
- add helper unit tests and an end-to-end mocked labeler test covering moved historical rows plus a valid new Comeet board

The allowlists remain static in the trusted base-branch script; no pull-request-controlled Python is imported by the `pull_request_target` workflows.

## Reproduction and verification

- production workflow log for #5761 showed valid moved `paylocity`/`comeet` rows causing `review-code`
- semantic diffing of #5761 now yields only its Bank of Ireland board/company/description rows
- semantic diffing of #5759 now yields only its Arbe Robotics board/company/description rows
- end-to-end mocked labeler changes the reproduced decision from `review-code` to `auto-merge`
- all 45 repository script tests pass
- helper ruff and format checks pass
- `bash -n .github/scripts/label-pr.sh`
- zizmor reports no findings

Closes #5764