### PR TITLE
Fix company job detail navigation

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-content.test.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-content.test.tsx
@@ -244,7 +244,6 @@ describe("CompanyContent — server-render initial-data path (#3203)", () => {
       "sal",
       "salcur",
       "exp",
-      "show",
     ];
     for (const param of filterParams) {
       mockFetchCompanyPageData.mockClear();
@@ -260,6 +259,68 @@ describe("CompanyContent — server-render initial-data path (#3203)", () => {
       });
       unmount();
     }
+  });
+
+  it("does not refetch company results when only the selected posting changes", async () => {
+    setDocumentCookie("logged_in=1");
+    const initialData = makeInitialData({ activeCount: 5 });
+    const personalizedData = makeInitialData({ activeCount: 4 });
+    mockFetchCompanyPageData.mockResolvedValue(personalizedData);
+
+    const { queryByTestId, rerender } = render(
+      <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
+    );
+
+    await waitFor(() => {
+      expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(1);
+      expect(queryByTestId("company-page")?.getAttribute("data-active")).toBe(
+        "4",
+      );
+    });
+
+    currentSearchParams = new URLSearchParams("show=posting-1");
+    rerender(
+      <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
+    );
+    currentSearchParams = new URLSearchParams("show=posting-2");
+    rerender(
+      <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(1);
+    expect(queryByTestId("company-skeleton")).toBeNull();
+    expect(queryByTestId("company-page")?.getAttribute("data-active")).toBe(
+      "4",
+    );
+  });
+
+  it("keeps `show` out of filtered fetches and does not refetch when it changes", async () => {
+    currentSearchParams = new URLSearchParams("q=python&show=posting-1");
+    const initialData = makeInitialData();
+    const { rerender } = render(
+      <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
+    );
+
+    await waitFor(() => {
+      expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(1);
+    });
+    expect(mockFetchCompanyPageData.mock.calls[0]?.[0]).toMatchObject({
+      searchParams: { q: "python" },
+    });
+    expect(
+      (mockFetchCompanyPageData.mock.calls[0]?.[0] as {
+        searchParams: Record<string, string | undefined>;
+      }).searchParams.show,
+    ).toBeUndefined();
+
+    currentSearchParams = new URLSearchParams("q=python&show=posting-2");
+    rerender(
+      <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(1);
   });
 
   it("passes etype through when it triggers a personalized fetch", async () => {

--- a/apps/web/app/[lang]/(app)/company/[slug]/company-back-link.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-back-link.tsx
@@ -3,6 +3,7 @@
 import { useSearchParams } from "next/navigation";
 import { BackLink } from "@/components/BackLink";
 import type { Locale } from "@/lib/i18n";
+import { serializeSearchFilterParams } from "@/lib/search/query-params";
 
 type Props = {
   locale: Locale;
@@ -19,7 +20,7 @@ type Props = {
  */
 export function CompanyBackLink({ locale, label }: Props) {
   const sp = useSearchParams();
-  const qs = sp.toString();
+  const qs = serializeSearchFilterParams(sp);
   const href = `/${locale}/explore${qs ? `?${qs}` : ""}`;
   return <BackLink href={href}>{label}</BackLink>;
 }

--- a/apps/web/app/[lang]/(app)/company/[slug]/company-content.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-content.tsx
@@ -6,6 +6,10 @@ import { Trans } from "@lingui/react/macro";
 import { fetchCompanyPageData, type CompanyPageData } from "@/lib/actions/company-page-data";
 import { hasLoggedInHint, hasAnonJobLanguagesHint } from "@/lib/client-cookies";
 import { CompanySkeleton } from "@/components/search/company-skeleton";
+import {
+  hasSearchFilterParams,
+  serializeSearchFilterParams,
+} from "@/lib/search/query-params";
 import { CompanyPage } from "./company-page";
 
 type CompanyContentProps = {
@@ -28,22 +32,12 @@ type CompanyContentProps = {
  * these are present, the prerendered ``initialData`` doesn't reflect
  * the filters and we must re-fetch the personalized variant.
  *
- * Mirrors the list in `explore-content.tsx` (`FILTER_PARAMS`). Also
- * includes ``show`` — the deep-link param that opens a posting detail
- * panel — because it changes the rendered subtree even though it
- * doesn't affect the postings list itself. Better to refetch and keep
- * the panel responsive than to render with ``initialData`` and have
- * the panel pop in late.
+ * The shared result-bearing parameter list deliberately excludes the
+ * ``show`` deep-link param: it only selects a posting in ``CompanyPage``
+ * and ``JobDetailPanel`` fetches that posting independently. Treating it
+ * as a data input would unmount and refetch the entire company results
+ * view on every posting click (#5766).
  */
-const FILTER_PARAMS = ["q", "loc", "occ", "sen", "tech", "wm", "etype", "sal", "salcur", "exp", "show"];
-
-function hasAnyFilterParam(searchParams: URLSearchParams): boolean {
-  for (const key of FILTER_PARAMS) {
-    if (searchParams.has(key)) return true;
-  }
-  return false;
-}
-
 function CompanyNotFound() {
   return (
     <div className="flex flex-col items-center justify-center py-24 text-center">
@@ -69,7 +63,7 @@ function CompanyNotFound() {
 
 export function CompanyContent({ locale, slug, initialData }: CompanyContentProps) {
   const searchParams = useSearchParams();
-  const paramsKey = searchParams.toString();
+  const dataParamsKey = serializeSearchFilterParams(searchParams);
   const fetchIdRef = useRef(0);
   const [data, setData] = useState<CompanyPageData | null | "not-found">(initialData ?? null);
 
@@ -91,11 +85,11 @@ export function CompanyContent({ locale, slug, initialData }: CompanyContentProp
   // slug or locale navigation.
   useEffect(() => {
     const fetchId = ++fetchIdRef.current;
-    const params = new URLSearchParams(paramsKey);
+    const params = new URLSearchParams(dataParamsKey);
     const needsPersonalizedFetch =
       hasLoggedInHint() ||
       hasAnonJobLanguagesHint() ||
-      hasAnyFilterParam(params) ||
+      hasSearchFilterParams(params) ||
       initialData === undefined;
     if (!needsPersonalizedFetch) {
       setData(initialData ?? null);
@@ -120,7 +114,7 @@ export function CompanyContent({ locale, slug, initialData }: CompanyContentProp
       console.error("[company] fetchCompanyPageData failed", err);
       if (initialData) setData(initialData);
     });
-  }, [initialData, locale, paramsKey, slug]);
+  }, [dataParamsKey, initialData, locale, slug]);
 
   if (data === null) return <CompanySkeleton />;
   if (data === "not-found") return <CompanyNotFound />;

--- a/apps/web/app/[lang]/(app)/explore/explore-content.tsx
+++ b/apps/web/app/[lang]/(app)/explore/explore-content.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { fetchExplorePageData, type ExploreData } from "@/lib/actions/explore-page-data";
 import { hasLoggedInHint, hasAnonJobLanguagesHint } from "@/lib/client-cookies";
+import { hasSearchFilterParams } from "@/lib/search/query-params";
 import { ExploreSkeleton } from "@/components/search/explore-skeleton";
 import { SearchPage } from "./search-page";
 
@@ -46,20 +47,6 @@ type ExploreContentProps = {
   initialData?: ExploreData;
 };
 
-/**
- * URL searchParams that ``fetchExplorePageData`` consumes. If any of these
- * are present, the prerendered ``initialData`` doesn't reflect the
- * filters and we must re-fetch the personalized variant.
- */
-const FILTER_PARAMS = ["q", "loc", "occ", "sen", "tech", "wm", "etype", "sal", "salcur", "exp"];
-
-function hasAnyFilterParam(searchParams: URLSearchParams): boolean {
-  for (const key of FILTER_PARAMS) {
-    if (searchParams.has(key)) return true;
-  }
-  return false;
-}
-
 export function ExploreContent({ locale, initialData }: ExploreContentProps) {
   const searchParams = useSearchParams();
   const [data, setData] = useState<ExploreData | null>(initialData ?? null);
@@ -78,7 +65,7 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
     const needsPersonalizedFetch =
       hasLoggedInHint() ||
       hasAnonJobLanguagesHint() ||
-      hasAnyFilterParam(searchParams) ||
+      hasSearchFilterParams(searchParams) ||
       initialData === undefined;
     if (!needsPersonalizedFetch) return;
 

--- a/apps/web/src/components/company/similar-companies-strip.tsx
+++ b/apps/web/src/components/company/similar-companies-strip.tsx
@@ -11,6 +11,10 @@ import { useSession } from "@/components/providers/SessionProvider";
 import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
 import { getSimilarCompanies, type SimilarCompany } from "@/lib/actions/company";
 import type { Locale } from "@/lib/i18n";
+import {
+  searchFilterParamsToObject,
+  serializeSearchFilterParams,
+} from "@/lib/search/query-params";
 import { SimilarCompanyCard } from "./similar-company-card";
 
 type Props = {
@@ -35,10 +39,14 @@ export function SimilarCompaniesStrip({
 }: Props) {
   const { t } = useLingui();
   const searchParams = useSearchParams();
-  // URL query string → stable cache key for the effect + the card links.
-  // Empty string means no filters, matches SSR semantics.
-  const paramsKey = searchParams.toString();
-  const spObject = useMemo(() => _searchParamsToObject(searchParams), [paramsKey]);
+  // Result-bearing query string → stable cache key for the effect + card
+  // links. UI-only ``show`` changes must only replace the detail panel;
+  // they do not affect counts or belong on another company's URL (#5766).
+  const paramsKey = serializeSearchFilterParams(searchParams);
+  const spObject = useMemo(
+    () => searchFilterParamsToObject(new URLSearchParams(paramsKey)),
+    [paramsKey],
+  );
   // Suppress the inaugural fetch only when SSR already produced
   // cards. When the parent passes `initialCompanies=[]` (the page is
   // statically prerendered and hands off to the client to load), the
@@ -191,18 +199,3 @@ function SignInPromptCard() {
     </li>
   );
 }
-
-function _searchParamsToObject(
-  sp: URLSearchParams | ReadonlyURLSearchParams,
-): Record<string, string | string[]> {
-  const out: Record<string, string | string[]> = {};
-  for (const key of new Set(sp.keys())) {
-    const values = sp.getAll(key);
-    out[key] = values.length > 1 ? values : values[0];
-  }
-  return out;
-}
-
-// Re-export Next's readonly searchParams type narrowly so TS can infer
-// the intersection with the standard URLSearchParams iterator.
-type ReadonlyURLSearchParams = ReturnType<typeof useSearchParams>;

--- a/apps/web/src/lib/search/__tests__/query-params.test.ts
+++ b/apps/web/src/lib/search/__tests__/query-params.test.ts
@@ -4,6 +4,9 @@ import {
   parseWorkModeParam,
   buildFilterQuery,
   buildFilteredPath,
+  hasSearchFilterParams,
+  searchFilterParamsToObject,
+  serializeSearchFilterParams,
 } from "../query-params";
 
 // =====================================================================
@@ -137,5 +140,38 @@ describe("buildFilteredPath — workMode", () => {
     expect(
       buildFilteredPath("/en/explore", [], [], undefined, undefined, undefined, undefined, []),
     ).toBe("/en/explore");
+  });
+});
+
+describe("result-bearing search params (#5766)", () => {
+  it("serializes filters in canonical order and drops UI/tracking state", () => {
+    const params = new URLSearchParams();
+    params.set("show", "posting-1");
+    params.set("utm_source", "newsletter");
+    params.set("loc", "berlin");
+    params.set("q", "python");
+
+    expect(serializeSearchFilterParams(params)).toBe(
+      "q=python&loc=berlin",
+    );
+  });
+
+  it("preserves repeated filter values for server-action inputs", () => {
+    const params = new URLSearchParams("loc=berlin&loc=paris&show=posting-1");
+
+    expect(searchFilterParamsToObject(params)).toEqual({
+      loc: ["berlin", "paris"],
+    });
+  });
+
+  it("does not classify selected-posting or tracking state as filters", () => {
+    expect(
+      hasSearchFilterParams(
+        new URLSearchParams("show=posting-1&utm_source=newsletter"),
+      ),
+    ).toBe(false);
+    expect(hasSearchFilterParams(new URLSearchParams("etype=internship"))).toBe(
+      true,
+    );
   });
 });

--- a/apps/web/src/lib/search/query-params.ts
+++ b/apps/web/src/lib/search/query-params.ts
@@ -7,6 +7,69 @@
 
 import { isEmploymentType, isWorkMode, type EmploymentType, type WorkMode } from "./types";
 
+/**
+ * Query parameters that change the search result set. UI-only state such as
+ * ``show`` and attribution parameters are intentionally not included.
+ */
+export const SEARCH_FILTER_PARAM_KEYS = [
+  "q",
+  "loc",
+  "occ",
+  "sen",
+  "tech",
+  "wm",
+  "etype",
+  "sal",
+  "salcur",
+  "exp",
+] as const;
+
+type SearchParamsReader = {
+  getAll(name: string): string[];
+};
+
+/** Select only result-bearing search parameters in a stable order. */
+export function selectSearchFilterParams(
+  searchParams: SearchParamsReader,
+): URLSearchParams {
+  const selected = new URLSearchParams();
+  for (const key of SEARCH_FILTER_PARAM_KEYS) {
+    for (const value of searchParams.getAll(key)) {
+      selected.append(key, value);
+    }
+  }
+  return selected;
+}
+
+/** Serialize only result-bearing search parameters, without a leading ``?``. */
+export function serializeSearchFilterParams(
+  searchParams: SearchParamsReader,
+): string {
+  return selectSearchFilterParams(searchParams).toString();
+}
+
+/** Whether the URL contains at least one result-bearing search parameter. */
+export function hasSearchFilterParams(
+  searchParams: SearchParamsReader,
+): boolean {
+  return SEARCH_FILTER_PARAM_KEYS.some(
+    (key) => searchParams.getAll(key).length > 0,
+  );
+}
+
+/** Convert result-bearing search parameters to the server-action input shape. */
+export function searchFilterParamsToObject(
+  searchParams: SearchParamsReader,
+): Record<string, string | string[]> {
+  const out: Record<string, string | string[]> = {};
+  for (const key of SEARCH_FILTER_PARAM_KEYS) {
+    const values = searchParams.getAll(key);
+    if (values.length === 0) continue;
+    out[key] = values.length > 1 ? values : values[0];
+  }
+  return out;
+}
+
 export interface SerializableLocation {
   id: number;
   slug: string;


### PR DESCRIPTION
## Summary

- classify URL state centrally into result-bearing search filters versus UI-only state
- keep `show` changes inside the posting-detail panel instead of invalidating company results
- prevent redundant similar-company fetches and stop selected posting IDs leaking into back/peer-company links
- cover anonymous, personalized, filtered, repeated-param, and UI-only navigation cases

## Root cause

`CompanyContent` and `SimilarCompaniesStrip` keyed their data effects on the full query string. Next.js observes native History API updates, so replacing `?show=<posting>` made those outer boundaries clear/refetch even though `show` does not change any search result. The full query string was also forwarded to unrelated navigation links.

The fix establishes one shared result-bearing parameter list (`q`, `loc`, `occ`, `sen`, `tech`, `wm`, `etype`, `sal`, `salcur`, `exp`) and uses it for result effects, server-action inputs, and filter-preserving links. `show` remains available to `CompanyPage`/`JobDetailPanel` directly from the URL.

## Reproduction and verification

Before, production Amazon navigation showed `Loading results` with the job list absent 118 ms after a second job click, and the click settled in about 3.0 s.

After, local browser verification showed:
- `?show=` updated in about 0.2 s
- the company heading and full job list remained mounted
- only `getPostingDetail` ran; company-results and similar-company actions did not
- back and peer-company links contained only actual filters

Checks:
- `pnpm exec vitest run --pool=threads` (174 files, 1,388 tests)
- targeted ESLint
- `pnpm typecheck`
- `pnpm build`

Closes #5766
