### PR TITLE
Dispatch production sync after company auto-merges

### DIFF
--- a/.github/scripts/dispatch-company-production-sync.sh
+++ b/.github/scripts/dispatch-company-production-sync.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${REPO:?REPO is required}"
+
+default_branch="${DEFAULT_BRANCH:-main}"
+
+# Merges performed with GITHUB_TOKEN do not emit new workflow runs. Company
+# auto-merges are data-only, so explicitly hand the merged main revision to
+# the production CSV sync instead of relying on sync-data.yml's push trigger.
+gh workflow run sync-data.yml --repo "$REPO" --ref "$default_branch"
+
+echo "Dispatched production CSV sync for ${PR:+PR #$PR on }$default_branch"

--- a/.github/scripts/maybe-auto-merge-pr.sh
+++ b/.github/scripts/maybe-auto-merge-pr.sh
@@ -162,6 +162,7 @@ fi
 for attempt in 1 2 3; do
   if gh pr merge "$PR" --repo "$REPO" --rebase 2>/tmp/maybe-auto-merge.err; then
     echo "PR #$PR merged"
+    "$SCRIPTS_DIR/dispatch-company-production-sync.sh"
     "$SCRIPTS_DIR/close-linked-company-request-issues.sh"
     exit 0
   fi

--- a/.github/workflows/maybe-auto-merge.yml
+++ b/.github/workflows/maybe-auto-merge.yml
@@ -37,6 +37,7 @@ jobs:
           cp .github/scripts/label-pr.sh "$RUNNER_TEMP/trusted-scripts/label-pr.sh"
           cp .github/scripts/label_pr_csv_diff.py "$RUNNER_TEMP/trusted-scripts/label_pr_csv_diff.py"
           cp .github/scripts/close-linked-company-request-issues.sh "$RUNNER_TEMP/trusted-scripts/close-linked-company-request-issues.sh"
+          cp .github/scripts/dispatch-company-production-sync.sh "$RUNNER_TEMP/trusted-scripts/dispatch-company-production-sync.sh"
           cp .github/scripts/maybe-auto-merge-pr.sh "$RUNNER_TEMP/trusted-scripts/maybe-auto-merge-pr.sh"
           cp .github/scripts/dispatch-pr-checks.sh "$RUNNER_TEMP/trusted-scripts/dispatch-pr-checks.sh"
           chmod +x "$RUNNER_TEMP/trusted-scripts/"*.sh

--- a/.github/workflows/upload-company-images.yml
+++ b/.github/workflows/upload-company-images.yml
@@ -54,6 +54,7 @@ jobs:
           cp .github/scripts/label-pr.sh "$RUNNER_TEMP/trusted-scripts/label-pr.sh"
           cp .github/scripts/label_pr_csv_diff.py "$RUNNER_TEMP/trusted-scripts/label_pr_csv_diff.py"
           cp .github/scripts/close-linked-company-request-issues.sh "$RUNNER_TEMP/trusted-scripts/close-linked-company-request-issues.sh"
+          cp .github/scripts/dispatch-company-production-sync.sh "$RUNNER_TEMP/trusted-scripts/dispatch-company-production-sync.sh"
           cp .github/scripts/dispatch-pr-checks.sh "$RUNNER_TEMP/trusted-scripts/dispatch-pr-checks.sh"
           cp .github/scripts/maybe-auto-merge-pr.sh "$RUNNER_TEMP/trusted-scripts/maybe-auto-merge-pr.sh"
           chmod +x "$RUNNER_TEMP/trusted-scripts/"*.sh
@@ -270,6 +271,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+
+      - name: Dispatch production CSV sync
+        if: github.event_name != 'workflow_dispatch' && steps.merge.outputs.merged == 'true'
+        run: |
+          "$RUNNER_TEMP/trusted-scripts/dispatch-company-production-sync.sh"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
       - name: Close linked company-request issues
         if: github.event_name != 'workflow_dispatch' && steps.merge.outputs.merged == 'true'

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -26,6 +26,10 @@ const maybeAutoMergeScript = readFileSync(
   ".github/scripts/maybe-auto-merge-pr.sh",
   "utf8",
 );
+const dispatchCompanyProductionSyncScript = readFileSync(
+  ".github/scripts/dispatch-company-production-sync.sh",
+  "utf8",
+);
 const classifyPrPathsScript = readFileSync(
   ".github/scripts/classify-pr-paths.sh",
   "utf8",
@@ -108,6 +112,44 @@ printf '%s\\n' "$*" >> "$MOCK_GH_LOG"
   } catch {
     // A correctly skipped PR does not call `gh workflow run`.
   }
+  rmSync(dir, { recursive: true, force: true });
+  return { ...result, calls };
+}
+
+function runDispatchCompanyProductionSync({
+  defaultBranch = "main",
+  includeDefaultBranch = true,
+} = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "dispatch-company-sync-"));
+  const log = join(dir, "gh.log");
+  const gh = join(dir, "gh");
+  writeFileSync(
+    gh,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$MOCK_GH_LOG"
+`,
+  );
+  chmodSync(gh, 0o755);
+  const env = {
+    ...process.env,
+    PATH: `${dir}:${process.env.PATH}`,
+    GH_TOKEN: "test-token",
+    REPO: "colophon-group/jobseek",
+    PR: "123",
+    MOCK_GH_LOG: log,
+  };
+  if (includeDefaultBranch) env.DEFAULT_BRANCH = defaultBranch;
+  const result = spawnSync(
+    "bash",
+    [".github/scripts/dispatch-company-production-sync.sh"],
+    {
+      cwd: process.cwd(),
+      env,
+      encoding: "utf8",
+    },
+  );
+  const calls = readFileSync(log, "utf8");
   rmSync(dir, { recursive: true, force: true });
   return { ...result, calls };
 }
@@ -488,7 +530,44 @@ test("maybe-auto-merge script skips image PRs and retries pending merges", () =>
   assert.match(maybeAutoMergeScript, /wait_for_required_ci\(\)/);
   assert.match(maybeAutoMergeScript, /Required CI is successful/);
   assert.match(maybeAutoMergeScript, /gh pr merge "\$PR" --repo "\$REPO" --rebase/);
+  assert.match(
+    maybeAutoMergeScript,
+    /gh pr merge "\$PR" --repo "\$REPO" --rebase[\s\S]*dispatch-company-production-sync\.sh[\s\S]*close-linked-company-request-issues\.sh/,
+  );
   assert.match(maybeAutoMergeScript, /scheduled\/workflow_run retries will revisit it/);
+});
+
+test("company auto-merges explicitly dispatch production CSV sync", () => {
+  for (const source of [maybeAutoMergeWorkflow, uploadCompanyImagesWorkflow]) {
+    assert.match(
+      source,
+      /cp \.github\/scripts\/dispatch-company-production-sync\.sh "\$RUNNER_TEMP\/trusted-scripts\/dispatch-company-production-sync\.sh"/,
+    );
+  }
+
+  assert.match(
+    uploadCompanyImagesWorkflow,
+    /name: Dispatch production CSV sync[\s\S]*steps\.merge\.outputs\.merged == 'true'[\s\S]*dispatch-company-production-sync\.sh/,
+  );
+  assert.match(
+    dispatchCompanyProductionSyncScript,
+    /gh workflow run sync-data\.yml --repo "\$REPO" --ref "\$default_branch"/,
+  );
+
+  for (const fixture of [
+    { defaultBranch: "main", includeDefaultBranch: false },
+    { defaultBranch: "release", includeDefaultBranch: true },
+  ]) {
+    const result = runDispatchCompanyProductionSync(fixture);
+    assert.equal(result.status, 0, result.stderr);
+    const expectedBranch = fixture.includeDefaultBranch
+      ? fixture.defaultBranch
+      : "main";
+    assert.equal(
+      result.calls,
+      `workflow run sync-data.yml --repo colophon-group/jobseek --ref ${expectedBranch}\n`,
+    );
+  }
 });
 
 test("bot-authored company branch updates dispatch path-aware CI", () => {


### PR DESCRIPTION
## Summary

- explicitly dispatch the production CSV sync after the trusted company auto-merger completes a merge
- cover the direct successful-merge path in the company image workflow
- share the handoff through a trusted helper script
- add execution and workflow-structure regression tests for both paths

## Root cause

Company PR #5828 reproduced a delivery gap: the `Maybe auto-merge` workflow merged the PR with `GITHUB_TOKEN`, which suppresses normal `push`-triggered workflow creation. The main commit therefore received no `Sync CSV data` run, leaving the merged company inactive until a manual workflow dispatch.

GitHub permits explicit `workflow_dispatch` events from `GITHUB_TOKEN`. The trusted merge paths now use that exception to start `sync-data.yml` after the merge succeeds. The handoff runs before linked company-request issues are closed.

## Validation

- reproduced on #5828 / main commit `1c0d68394`; no push-triggered CSV sync existed
- manual dispatch run `29875722593` proved the target workflow and production path
- `actionlint` on both changed workflows
- `bash -n` on both changed shell scripts
- `node --test scripts/ci-workflow.test.mjs` — 34/34 passed
- `git diff --check`

Closes #5829
