### PR TITLE
Run pnpm Dependabot from the workspace root

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,14 +14,10 @@ updates:
           - "*"
 
   - package-ecosystem: "npm"
-    # Security alerts are reported against both workspace manifests and the
-    # shared lockfile. Keep them in one updater so fixes are generated as an
-    # atomic pnpm workspace change instead of one PR per manifest boundary.
-    directories:
-      - "/"
-      - "/apps/trace-viewer"
-      - "/apps/web"
-      - "/packages/mcp-server"
+    # pnpm owns workspace resolution and the shared lockfile at the repository
+    # root. Running Dependabot from member directories makes pnpm reject the
+    # update; the root updater still discovers and groups workspace manifests.
+    directory: "/"
     schedule:
       interval: "weekly"
       day: "monday"

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -812,21 +812,18 @@ test("CodeQL skips full analysis for non-code pull requests", () => {
   assert.match(analyzeJob, /Perform CodeQL Analysis[\s\S]*if: needs\.changes\.outputs\.codeql == 'true'/);
 });
 
-test("Dependabot groups npm security updates across pnpm workspace manifests", () => {
+test("Dependabot updates and groups the pnpm workspace from its root", () => {
   const npmConfig = dependabotConfig.match(
     /  - package-ecosystem: "npm"\n([\s\S]*?)(?=\n  - package-ecosystem:)/,
   )?.[1];
 
   assert.ok(npmConfig, "missing npm Dependabot configuration");
-  assert.doesNotMatch(npmConfig, /^    directory: "\/"$/m);
-  for (const directory of [
-    "/",
-    "/apps/trace-viewer",
-    "/apps/web",
-    "/packages/mcp-server",
-  ]) {
-    assert.match(npmConfig, new RegExp(`^      - "${directory}"$`, "m"));
-  }
+  assert.match(npmConfig, /^    directory: "\/"$/m);
+  assert.doesNotMatch(npmConfig, /^    directories:/m);
+  assert.match(
+    npmConfig,
+    /exclude-paths:\n      - "apps\/crawler\/murmur\/\*\*"\n      - "apps\/murmur-shim\/\*\*"/,
+  );
   assert.match(
     npmConfig,
     /security-updates:\n        applies-to: "security-updates"\n        patterns:\n          - "\*"/,


### PR DESCRIPTION
Closes #5855

## Summary

- run the npm Dependabot updater only from the pnpm workspace root
- retain the security, provider-family, test-tooling, and dependency-name grouping rules from #5836
- retain the Murmur exclusions/backburner policy
- replace the earlier multi-directory assertion with a regression test that rejects nested pnpm update roots

## Root cause

The first npm update after #5836 proved cross-workspace grouping works, but failed after creating PRs because the same update entry listed both `/` and pnpm workspace member directories. Dependabot then invoked pnpm as though each member directory owned dependency resolution. pnpm rejected those attempts because `pnpm-lock.yaml` and `pnpm-workspace.yaml` live in the parent repository root.

A root-only updater is the workspace-native configuration: pnpm discovers member manifests from `pnpm-workspace.yaml`, updates the shared lockfile atomically, and lets Dependabot apply the existing cross-workspace group rules without trying unsupported nested roots.

## Verification

- reproduced in Dependabot job 1472959136 / Actions run 29879480629
- YAML parse: passed
- `node --test scripts/ci-workflow.test.mjs`: 36 passed
- `git diff --check`: passed

After merge, the npm updater must be triggered and complete successfully before this issue is considered production-accepted.
