### PR TITLE
Make Dependabot web CI secretless

### DIFF
--- a/.github/actions/setup-web-build-env/action.yml
+++ b/.github/actions/setup-web-build-env/action.yml
@@ -1,0 +1,43 @@
+name: Set up deterministic web build environment
+description: Export secretless build-time configuration for web CI jobs.
+
+inputs:
+  app-url:
+    description: Local URL used by Better Auth while the test server is running.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Export build-time configuration
+      shell: bash
+      env:
+        APP_URL: ${{ inputs.app-url }}
+      run: |
+        {
+          # Backing services are intentionally absent. Company and watchlist
+          # lookups then exercise their supported build-time fallback instead
+          # of reaching production or treating an invalid placeholder as a DSN.
+          echo 'DATABASE_URL='
+          echo 'DATABASE_URL_UNPOOLED='
+          echo 'TYPESENSE_HOST='
+          echo 'TYPESENSE_PORT='
+          echo 'TYPESENSE_PROTOCOL='
+
+          # These values satisfy module-level configuration reads only. They
+          # cannot authenticate to any external service.
+          echo 'BETTER_AUTH_SECRET=ci-stub-better-auth-secret-not-used-at-build-time'
+          echo "BETTER_AUTH_URL=$APP_URL"
+          echo 'TYPESENSE_SEARCH_KEY=ci-stub-not-used-at-build-time'
+          echo 'TYPESENSE_WRITE_KEY=ci-stub-not-used-at-build-time'
+          echo 'GITHUB_CLIENT_ID=ci-stub'
+          echo 'GITHUB_CLIENT_SECRET=ci-stub'
+          echo 'GOOGLE_CLIENT_ID=ci-stub'
+          echo 'GOOGLE_CLIENT_SECRET=ci-stub'
+          echo 'LINKEDIN_CLIENT_ID=ci-stub'
+          echo 'LINKEDIN_CLIENT_SECRET=ci-stub'
+          echo 'RESEND_API_KEY=ci-stub'
+          echo 'UPSTASH_REDIS_REST_URL=https://stub.invalid'
+          echo 'UPSTASH_REDIS_REST_TOKEN=ci-stub'
+          echo 'COMPANY_OG_PRERENDER_TOP_N=0'
+        } >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,50 +349,12 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-    # `Production` environment exposes DATABASE_URL + TYPESENSE_* secrets for
-    # trusted same-repo runs. Fork PRs deliberately receive no secrets; blog
-    # `MdxMentions` company lookups must degrade to their missing-mention
-    # fallback instead of reaching Postgres when DATABASE_URL is absent.
-    environment: Production
-    # Job-level env: declared once, applied to every step in the job.
-    # Real secrets come from the `Production` environment above; the
-    # `ci-stub-*` literals are build-time-only placeholders that satisfy
-    # module-top-level env reads (e.g. better-auth's OAuth provider
-    # config) without authenticating to any real service — auth/SSO and
-    # search/write keys are only consumed at runtime by request handlers,
-    # which the build does not exercise.
-    env:
-      # Trusted runs use the real DSN so blog `<Mention>` MDX components can
-      # render company tooltips at build time. Fork runs leave this empty and
-      # exercise the secretless fallback path.
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}
-      # This job classifies route cacheability. It must not depend on
-      # external Typesense availability or latency; trusted runs still have
-      # DATABASE_URL for blog company mentions, and fork/secretless runs
-      # exercise the missing-mention fallback path.
-      TYPESENSE_HOST: ""
-      TYPESENSE_PORT: ""
-      TYPESENSE_PROTOCOL: ""
-      # Build-time-only stubs (see job-level comment above).
-      BETTER_AUTH_SECRET: ci-stub-better-auth-secret-not-used-at-build-time
-      BETTER_AUTH_URL: http://localhost:3000
-      TYPESENSE_SEARCH_KEY: ci-stub-not-used-at-build-time
-      TYPESENSE_WRITE_KEY: ci-stub-not-used-at-build-time
-      GITHUB_CLIENT_ID: ci-stub
-      GITHUB_CLIENT_SECRET: ci-stub
-      GOOGLE_CLIENT_ID: ci-stub
-      GOOGLE_CLIENT_SECRET: ci-stub
-      LINKEDIN_CLIENT_ID: ci-stub
-      LINKEDIN_CLIENT_SECRET: ci-stub
-      RESEND_API_KEY: ci-stub
-      UPSTASH_REDIS_REST_URL: https://stub.invalid
-      UPSTASH_REDIS_REST_TOKEN: ci-stub
-      # It should also not spend build time rendering hundreds of company
-      # OG PNGs; unit tests cover the OG prebake query and renderer.
-      COMPANY_OG_PRERENDER_TOP_N: "0"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: ./.github/actions/setup-web-build-env
+        with:
+          app-url: http://localhost:3000
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 
@@ -618,29 +580,12 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
-    environment: Production
-    env:
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}
-      TYPESENSE_HOST: ""
-      TYPESENSE_PORT: ""
-      TYPESENSE_PROTOCOL: ""
-      BETTER_AUTH_SECRET: ci-stub-better-auth-secret-not-used-at-build-time
-      BETTER_AUTH_URL: http://127.0.0.1:3100
-      TYPESENSE_SEARCH_KEY: ci-stub-not-used-at-build-time
-      TYPESENSE_WRITE_KEY: ci-stub-not-used-at-build-time
-      GITHUB_CLIENT_ID: ci-stub
-      GITHUB_CLIENT_SECRET: ci-stub
-      GOOGLE_CLIENT_ID: ci-stub
-      GOOGLE_CLIENT_SECRET: ci-stub
-      LINKEDIN_CLIENT_ID: ci-stub
-      LINKEDIN_CLIENT_SECRET: ci-stub
-      RESEND_API_KEY: ci-stub
-      UPSTASH_REDIS_REST_URL: https://stub.invalid
-      UPSTASH_REDIS_REST_TOKEN: ci-stub
-      COMPANY_OG_PRERENDER_TOP_N: "0"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: ./.github/actions/setup-web-build-env
+        with:
+          app-url: http://127.0.0.1:3100
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
 

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -13,6 +13,10 @@ import { join } from "node:path";
 import { spawnSync } from "node:child_process";
 
 const workflow = readFileSync(".github/workflows/ci.yml", "utf8");
+const webBuildEnvAction = readFileSync(
+  ".github/actions/setup-web-build-env/action.yml",
+  "utf8",
+);
 const codeqlWorkflow = readFileSync(".github/workflows/codeql.yml", "utf8");
 const dependabotConfig = readFileSync(".github/dependabot.yml", "utf8");
 const uploadCompanyImagesWorkflow = readFileSync(
@@ -374,6 +378,29 @@ test("workflow-security runs repository script tests", () => {
   assert.match(workflow, /scripts\/crawler-host-hygiene\.test\.mjs/);
   assert.match(workflow, /scripts\/docs-index\.test\.mjs/);
   assert.match(workflow, /scripts\/dealroom-company-requests\.test\.mjs/);
+});
+
+test("web build jobs use one deterministic secretless environment", () => {
+  for (const jobId of ["test-web-isr", "web-smoke"]) {
+    const job = jobBlock(jobId);
+    assert.match(job, /uses: \.\/\.github\/actions\/setup-web-build-env/);
+    assert.doesNotMatch(job, /environment: Production/);
+    assert.doesNotMatch(job, /secrets\./);
+  }
+
+  for (const variable of [
+    "DATABASE_URL",
+    "DATABASE_URL_UNPOOLED",
+    "TYPESENSE_HOST",
+    "TYPESENSE_PORT",
+    "TYPESENSE_PROTOCOL",
+  ]) {
+    assert.match(webBuildEnvAction, new RegExp(`echo '${variable}='`));
+  }
+  assert.match(webBuildEnvAction, /BETTER_AUTH_URL=\$APP_URL/);
+  assert.match(webBuildEnvAction, /COMPANY_OG_PRERENDER_TOP_N=0/);
+  assert.doesNotMatch(webBuildEnvAction, /secrets\./);
+  assert.doesNotMatch(webBuildEnvAction, /postgres(?:ql)?:\/\//);
 });
 
 test("Codex deploy transport outlives the runner lock wait", () => {


### PR DESCRIPTION
## Summary

- run web build jobs with deterministic secretless configuration
- centralize build-only stubs in a reusable local action
- add workflow contract coverage for both jobs

## Root cause

Dependabot PRs cannot access the Production environment secrets, but GitHub still supplied non-empty unusable values for the database variables. The web build interpreted those values as configured DSNs and attempted Postgres instead of using its supported build-time fallback. This affected every dependency PR, including Python-only updates.

The jobs now explicitly leave Postgres and Typesense connection variables empty, so CI exercises the supported fallback path and never depends on production services.

## Verification

- node --test scripts/ci-workflow.test.mjs (37 tests)
- actionlint
- zizmor (no medium/high-confidence findings)
- pnpm install --frozen-lockfile
- secretless ISR suite (15 tests)
- secretless web production build
- web bundle budget check (657.6 KB gzip)

Closes #5867