### PR TITLE
Make crawler dependency PRs release-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
         run: >
           node --test
           scripts/ci-workflow.test.mjs
+          scripts/crawler-version.test.mjs
           scripts/crawler-host-hygiene.test.mjs
           scripts/docs-index.test.mjs
           scripts/dealroom-company-requests.test.mjs
@@ -641,28 +642,34 @@ jobs:
     needs: changes
     if: needs.changes.outputs.is_pr == 'true' && needs.changes.outputs.crawler_code == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
-      - name: Check VERSION increased
+      - name: Resolve trusted PR context
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr }}
         run: |
-          PR_VERSION=$(cat apps/crawler/VERSION | tr -d '[:space:]')
-          MAIN_VERSION=$(git show origin/main:apps/crawler/VERSION | tr -d '[:space:]')
+          set -euo pipefail
+          pr=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER")
+          {
+            echo "base_sha=$(jq -r '.base.sha' <<< "$pr")"
+            echo "head_sha=$(jq -r '.head.sha' <<< "$pr")"
+            echo "author=$(jq -r '.user.login' <<< "$pr")"
+          } >> "$GITHUB_OUTPUT"
 
-          IFS='.' read -r pr_major pr_minor pr_patch <<< "$PR_VERSION"
-          IFS='.' read -r main_major main_minor main_patch <<< "$MAIN_VERSION"
-
-          pr_num=$((pr_major * 1000000 + pr_minor * 1000 + pr_patch))
-          main_num=$((main_major * 1000000 + main_minor * 1000 + main_patch))
-
-          if [ "$pr_num" -gt "$main_num" ]; then
-            echo "VERSION bumped: ${MAIN_VERSION} → ${PR_VERSION}"
-          else
-            echo "::error::apps/crawler/VERSION must be bumped for crawler code changes (main: ${MAIN_VERSION}, PR: ${PR_VERSION})"
-            exit 1
-          fi
+      - name: Enforce crawler release policy
+        run: >-
+          node scripts/check-crawler-version.mjs
+          --base "${{ steps.pr.outputs.base_sha }}"
+          --head "${{ steps.pr.outputs.head_sha }}"
+          --author "${{ steps.pr.outputs.author }}"
 
   probe-new-boards:
     name: Probe new/changed boards

--- a/.github/workflows/deploy-crawler-browser.yml
+++ b/.github/workflows/deploy-crawler-browser.yml
@@ -7,6 +7,7 @@ on:
       - 'apps/crawler/**'
       - '!apps/crawler/data/**'
       - '!apps/crawler/traces/**'
+      - '!apps/crawler/ws-package/**'
       - '!apps/crawler/*.md'
       - '!apps/crawler/**/*.md'
       - '.github/workflows/deploy-crawler-browser.yml'
@@ -28,10 +29,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
 
-      - name: Read VERSION
+      - name: Derive immutable build version
         id: version
-        run: echo "version=$(cat apps/crawler/VERSION | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
+        run: >-
+          node scripts/derive-crawler-build-version.mjs
+          --write-version apps/crawler/VERSION
+          --github-output "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
@@ -51,7 +57,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/jobseek-crawler:v${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/jobseek-crawler:${{ steps.version.outputs.image_tag }}
           cache-from: type=gha,scope=crawler-slim
           cache-to: type=gha,mode=max,scope=crawler-slim,ignore-error=true
 
@@ -63,7 +69,7 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/jobseek-crawler-browser:v${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/jobseek-crawler-browser:${{ steps.version.outputs.image_tag }}
           cache-from: type=gha,scope=crawler-browser
           cache-to: type=gha,mode=max,scope=crawler-browser,ignore-error=true
 
@@ -74,7 +80,7 @@ jobs:
       # gates the SSH deploy on the image's idempotency.
       - name: Smoke-test setup-typesense (idempotency)
         env:
-          IMAGE: ghcr.io/${{ github.repository_owner }}/jobseek-crawler:v${{ steps.version.outputs.version }}
+          IMAGE: ghcr.io/${{ github.repository_owner }}/jobseek-crawler:${{ steps.version.outputs.image_tag }}
         run: |
           set -euo pipefail
           # Always tear down on exit, including on early failure, so a
@@ -134,7 +140,7 @@ jobs:
           script: bash /home/deploy/deploy.sh
         env:
           OWNER: ${{ github.repository_owner }}
-          CRAWLER_IMAGE_TAG: v${{ steps.version.outputs.version }}
+          CRAWLER_IMAGE_TAG: ${{ steps.version.outputs.image_tag }}
           DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}
           LOCAL_DATABASE_URL: ${{ secrets.LOCAL_DATABASE_URL }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
@@ -173,7 +179,7 @@ jobs:
       - name: Promote deployed images to latest
         run: |
           set -euo pipefail
-          version="v${{ steps.version.outputs.version }}"
+          version="${{ steps.version.outputs.image_tag }}"
           owner="${{ github.repository_owner }}"
           docker buildx imagetools create \
             -t "ghcr.io/${owner}/jobseek-crawler:latest" \

--- a/scripts/check-crawler-version.mjs
+++ b/scripts/check-crawler-version.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const DEPENDABOT_LOGIN = "dependabot[bot]";
+const DEPENDENCY_FILES = new Set([
+  "apps/crawler/Dockerfile",
+  "apps/crawler/docker-compose.yml",
+  "apps/crawler/pyproject.toml",
+  "apps/crawler/uv.lock",
+  "apps/crawler/ws-package/pyproject.toml",
+  "apps/crawler/ws-package/uv.lock",
+]);
+
+function parseVersion(value, label) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value.trim());
+  if (!match) {
+    throw new Error(`${label} must be a major.minor.patch version, got ${JSON.stringify(value.trim())}`);
+  }
+  return match.slice(1).map(Number);
+}
+
+function compareVersions(left, right) {
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return 0;
+}
+
+export function isCrawlerDependencyOnly(files) {
+  const uniqueFiles = [...new Set(files)].sort();
+  return (
+    uniqueFiles.length > 0 &&
+    uniqueFiles.every((file) => DEPENDENCY_FILES.has(file))
+  );
+}
+
+export function evaluateCrawlerVersion({
+  baseVersion,
+  prVersion,
+  author,
+  files,
+}) {
+  const base = parseVersion(baseVersion, "Base VERSION");
+  const pr = parseVersion(prVersion, "PR VERSION");
+  const comparison = compareVersions(pr, base);
+
+  if (comparison > 0) {
+    return {
+      kind: "release",
+      message: `VERSION bumped: ${baseVersion.trim()} → ${prVersion.trim()}`,
+    };
+  }
+  if (comparison < 0) {
+    throw new Error(
+      `apps/crawler/VERSION regressed: ${baseVersion.trim()} → ${prVersion.trim()}`,
+    );
+  }
+
+  const uniqueFiles = [...new Set(files)].sort();
+  const dependencyOnly = isCrawlerDependencyOnly(uniqueFiles);
+
+  if (author === DEPENDABOT_LOGIN && dependencyOnly) {
+    return {
+      kind: "dependabot-build",
+      message:
+        `Dependabot dependency-only update keeps ${prVersion.trim()}; ` +
+        "deployment will derive a commit-specific build version",
+    };
+  }
+
+  const detail =
+    author === DEPENDABOT_LOGIN
+      ? `Dependabot diff includes non-dependency paths: ${uniqueFiles.join(", ")}`
+      : `PR author is ${author || "unknown"}, not ${DEPENDABOT_LOGIN}`;
+  throw new Error(
+    `apps/crawler/VERSION must be bumped for crawler changes ` +
+      `(base: ${baseVersion.trim()}, PR: ${prVersion.trim()}). ${detail}`,
+  );
+}
+
+function git(...args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function argument(name) {
+  const index = process.argv.indexOf(name);
+  if (index === -1 || !process.argv[index + 1]) {
+    throw new Error(`Missing required argument ${name}`);
+  }
+  return process.argv[index + 1];
+}
+
+function main() {
+  const baseSha = argument("--base");
+  const headSha = argument("--head");
+  const author = argument("--author");
+  const versionPath = "apps/crawler/VERSION";
+  const baseVersion = git("show", `${baseSha}:${versionPath}`);
+  const prVersion = git("show", `${headSha}:${versionPath}`);
+  const files = git("diff", "--name-only", `${baseSha}...${headSha}`)
+    .split("\n")
+    .filter(Boolean);
+
+  const result = evaluateCrawlerVersion({
+    baseVersion,
+    prVersion,
+    author,
+    files,
+  });
+  console.log(result.message);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`::error::${error.message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -53,6 +53,10 @@ const deployCodexRunnerWorkflow = readFileSync(
   ".github/workflows/deploy-codex-runner.yml",
   "utf8",
 );
+const deployCrawlerWorkflow = readFileSync(
+  ".github/workflows/deploy-crawler-browser.yml",
+  "utf8",
+);
 const deployCodexRunnerHostScript = readFileSync(
   "scripts/deploy-codex-runner-host.sh",
   "utf8",
@@ -363,6 +367,9 @@ test("PR-only CI gates cover pull requests and dispatched PRs", () => {
   assert.match(changesJob, /id: pull-request[\s\S]*echo "is_pr=true"/);
   assert.match(changesJob, /echo "base_ref=\$BASE_REF"/);
   assert.match(versionJob, /if: needs\.changes\.outputs\.is_pr == 'true'/);
+  assert.match(versionJob, /gh api "repos\/\$GITHUB_REPOSITORY\/pulls\/\$PR_NUMBER"/);
+  assert.match(versionJob, /scripts\/check-crawler-version\.mjs/);
+  assert.match(versionJob, /\.user\.login/);
   assert.match(probeJob, /if: needs\.changes\.outputs\.is_pr == 'true'/);
   assert.match(probeJob, /BASE_REF: \$\{\{ needs\.changes\.outputs\.base_ref \}\}/);
   assert.match(requiredCiJob, /const isPr = needs\.changes\?\.outputs\?\.is_pr === "true"/);
@@ -375,9 +382,31 @@ test("PR-only CI gates cover pull requests and dispatched PRs", () => {
 test("workflow-security runs repository script tests", () => {
   assert.match(workflow, /node --test/);
   assert.match(workflow, /scripts\/ci-workflow\.test\.mjs/);
+  assert.match(workflow, /scripts\/crawler-version\.test\.mjs/);
   assert.match(workflow, /scripts\/crawler-host-hygiene\.test\.mjs/);
   assert.match(workflow, /scripts\/docs-index\.test\.mjs/);
   assert.match(workflow, /scripts\/dealroom-company-requests\.test\.mjs/);
+});
+
+test("crawler deploys derive immutable versions for unchanged releases", () => {
+  assert.match(deployCrawlerWorkflow, /'!apps\/crawler\/ws-package\/\*\*'/);
+  assert.match(deployCrawlerWorkflow, /fetch-depth: 0/);
+  assert.match(
+    deployCrawlerWorkflow,
+    /scripts\/derive-crawler-build-version\.mjs[\s\S]*--write-version apps\/crawler\/VERSION[\s\S]*--github-output "\$GITHUB_OUTPUT"/,
+  );
+  assert.match(
+    deployCrawlerWorkflow,
+    /jobseek-crawler:\$\{\{ steps\.version\.outputs\.image_tag \}\}/,
+  );
+  assert.match(
+    deployCrawlerWorkflow,
+    /CRAWLER_IMAGE_TAG: \$\{\{ steps\.version\.outputs\.image_tag \}\}/,
+  );
+  assert.doesNotMatch(
+    deployCrawlerWorkflow,
+    /steps\.version\.outputs\.version/,
+  );
 });
 
 test("web build jobs use one deterministic secretless environment", () => {

--- a/scripts/crawler-version.test.mjs
+++ b/scripts/crawler-version.test.mjs
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { evaluateCrawlerVersion } from "./check-crawler-version.mjs";
+import { deriveCrawlerBuildVersion } from "./derive-crawler-build-version.mjs";
+
+test("explicit crawler releases remain the default", () => {
+  const result = evaluateCrawlerVersion({
+    baseVersion: "0.13.152",
+    prVersion: "0.13.153",
+    author: "developer",
+    files: ["apps/crawler/src/cli.py", "apps/crawler/VERSION"],
+  });
+  assert.equal(result.kind, "release");
+});
+
+test("dependency-only Dependabot updates may keep the base version", () => {
+  const result = evaluateCrawlerVersion({
+    baseVersion: "0.13.152",
+    prVersion: "0.13.152",
+    author: "dependabot[bot]",
+    files: ["apps/crawler/pyproject.toml", "apps/crawler/uv.lock"],
+  });
+  assert.equal(result.kind, "dependabot-build");
+});
+
+test("transitive lockfile-only Dependabot updates are supported", () => {
+  const result = evaluateCrawlerVersion({
+    baseVersion: "0.13.152",
+    prVersion: "0.13.152",
+    author: "dependabot[bot]",
+    files: ["apps/crawler/uv.lock"],
+  });
+  assert.equal(result.kind, "dependabot-build");
+});
+
+test("ws-package lockfile updates use the dependency-only policy", () => {
+  const result = evaluateCrawlerVersion({
+    baseVersion: "0.13.152",
+    prVersion: "0.13.152",
+    author: "dependabot[bot]",
+    files: ["apps/crawler/ws-package/uv.lock"],
+  });
+  assert.equal(result.kind, "dependabot-build");
+});
+
+test("human-authored crawler changes still require a release bump", () => {
+  assert.throws(
+    () =>
+      evaluateCrawlerVersion({
+        baseVersion: "0.13.152",
+        prVersion: "0.13.152",
+        author: "developer",
+        files: ["apps/crawler/uv.lock"],
+      }),
+    /must be bumped/,
+  );
+});
+
+test("Dependabot cannot bypass the gate for crawler source changes", () => {
+  assert.throws(
+    () =>
+      evaluateCrawlerVersion({
+        baseVersion: "0.13.152",
+        prVersion: "0.13.152",
+        author: "dependabot[bot]",
+        files: ["apps/crawler/uv.lock", "apps/crawler/src/cli.py"],
+      }),
+    /non-dependency paths/,
+  );
+});
+
+test("crawler version regressions always fail", () => {
+  assert.throws(
+    () =>
+      evaluateCrawlerVersion({
+        baseVersion: "0.13.152",
+        prVersion: "0.13.151",
+        author: "dependabot[bot]",
+        files: ["apps/crawler/uv.lock"],
+      }),
+    /regressed/,
+  );
+});
+
+test("explicit release builds retain their clean version and tag", () => {
+  assert.deepEqual(
+    deriveCrawlerBuildVersion({
+      sourceVersion: "0.13.153",
+      parentVersion: "0.13.152",
+      commitCount: "6200",
+      sha: "abcdef1234567890",
+      files: ["apps/crawler/src/cli.py", "apps/crawler/VERSION"],
+    }),
+    {
+      sourceVersion: "0.13.153",
+      packageVersion: "0.13.153",
+      imageTag: "v0.13.153",
+      derived: false,
+    },
+  );
+});
+
+test("unchanged releases get deterministic commit-specific build versions", () => {
+  assert.deepEqual(
+    deriveCrawlerBuildVersion({
+      sourceVersion: "0.13.152",
+      parentVersion: "0.13.152",
+      commitCount: "6201",
+      sha: "ABCDEF1234567890",
+      files: ["apps/crawler/pyproject.toml", "apps/crawler/uv.lock"],
+    }),
+    {
+      sourceVersion: "0.13.152",
+      packageVersion: "0.13.152+build.6201.gabcdef123456",
+      imageTag: "v0.13.152-build.6201.gabcdef123456",
+      derived: true,
+    },
+  );
+});
+
+test("deployment does not derive versions for arbitrary unchanged code", () => {
+  assert.throws(
+    () =>
+      deriveCrawlerBuildVersion({
+        sourceVersion: "0.13.152",
+        parentVersion: "0.13.152",
+        commitCount: "6201",
+        sha: "abcdef1234567890",
+        files: ["apps/crawler/src/cli.py"],
+      }),
+    /dependency-only main commit/,
+  );
+});
+
+test("deployment refuses a source-version rollback", () => {
+  assert.throws(
+    () =>
+      deriveCrawlerBuildVersion({
+        sourceVersion: "0.13.151",
+        parentVersion: "0.13.152",
+        commitCount: "6201",
+        sha: "abcdef1234567890",
+        files: ["apps/crawler/uv.lock"],
+      }),
+    /regressed/,
+  );
+});

--- a/scripts/derive-crawler-build-version.mjs
+++ b/scripts/derive-crawler-build-version.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+import { isCrawlerDependencyOnly } from "./check-crawler-version.mjs";
+
+function parseVersion(value, label) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value.trim());
+  if (!match) {
+    throw new Error(`${label} must be a major.minor.patch version, got ${JSON.stringify(value.trim())}`);
+  }
+  return match.slice(1).map(Number);
+}
+
+function compareVersions(left, right) {
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) return left[index] - right[index];
+  }
+  return 0;
+}
+
+export function deriveCrawlerBuildVersion({
+  sourceVersion,
+  parentVersion,
+  commitCount,
+  sha,
+  files,
+}) {
+  const source = parseVersion(sourceVersion, "Source VERSION");
+  const parent = parentVersion
+    ? parseVersion(parentVersion, "Parent VERSION")
+    : null;
+
+  if (parent && compareVersions(source, parent) < 0) {
+    throw new Error(
+      `apps/crawler/VERSION regressed: ${parentVersion.trim()} → ${sourceVersion.trim()}`,
+    );
+  }
+
+  const cleanVersion = sourceVersion.trim();
+  if (!parent || compareVersions(source, parent) > 0) {
+    return {
+      sourceVersion: cleanVersion,
+      packageVersion: cleanVersion,
+      imageTag: `v${cleanVersion}`,
+      derived: false,
+    };
+  }
+
+  if (!isCrawlerDependencyOnly(files)) {
+    throw new Error(
+      "Unchanged crawler VERSION is only valid for a dependency-only main commit",
+    );
+  }
+
+  if (!/^\d+$/.test(String(commitCount)) || Number(commitCount) < 1) {
+    throw new Error(`Commit count must be a positive integer, got ${commitCount}`);
+  }
+  const shortSha = sha.trim().slice(0, 12);
+  if (!/^[0-9a-f]{7,12}$/i.test(shortSha)) {
+    throw new Error(`Commit SHA is invalid: ${JSON.stringify(sha.trim())}`);
+  }
+
+  const suffix = `build.${commitCount}.g${shortSha.toLowerCase()}`;
+  return {
+    sourceVersion: cleanVersion,
+    packageVersion: `${cleanVersion}+${suffix}`,
+    imageTag: `v${cleanVersion}-${suffix}`,
+    derived: true,
+  };
+}
+
+function git(...args) {
+  return execFileSync("git", args, { encoding: "utf8" }).trim();
+}
+
+function optionalArgument(name) {
+  const index = process.argv.indexOf(name);
+  return index === -1 ? null : process.argv[index + 1];
+}
+
+function main() {
+  const versionPath = optionalArgument("--write-version") ?? "apps/crawler/VERSION";
+  const githubOutput = optionalArgument("--github-output");
+  const sourceVersion = readFileSync(versionPath, "utf8").trim();
+  let parentVersion = null;
+  try {
+    parentVersion = git("show", `HEAD^:${versionPath}`);
+  } catch {
+    // The repository's first deployable commit has no parent to compare.
+  }
+  const result = deriveCrawlerBuildVersion({
+    sourceVersion,
+    parentVersion,
+    commitCount: git("rev-list", "--first-parent", "--count", "HEAD"),
+    sha: git("rev-parse", "HEAD"),
+    files: git("diff", "--name-only", "HEAD^", "HEAD")
+      .split("\n")
+      .filter(Boolean),
+  });
+
+  writeFileSync(versionPath, `${result.packageVersion}\n`);
+  const outputs = [
+    `source_version=${result.sourceVersion}`,
+    `package_version=${result.packageVersion}`,
+    `image_tag=${result.imageTag}`,
+    `derived=${result.derived}`,
+  ].join("\n");
+  if (githubOutput) appendFileSync(githubOutput, `${outputs}\n`);
+  console.log(
+    `Crawler build version: ${result.packageVersion} (${result.imageTag})`,
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`::error::${error.message}`);
+    process.exitCode = 1;
+  }
+}


### PR DESCRIPTION
## Summary

- preserve the crawler VERSION gate for ordinary code changes
- allow unchanged versions only for genuine Dependabot diffs restricted to managed dependency files
- derive deterministic PEP 440 build versions and immutable image tags for dependency-only crawler deployments
- stop ws-package-only changes from rebuilding an unrelated crawler image

## Root cause

The change classifier correctly treated crawler dependency updates as deployable changes, but the release gate assumed every PR author could also increment apps/crawler/VERSION. Dependabot only changes its managed manifest and lockfile, so every crawler dependency PR was permanently blocked. Simply skipping the gate would reuse a mutable image tag and make production report the wrong build.

CI now recognizes the author and exact diff from trusted GitHub PR metadata. Deployment independently revalidates the main-commit file set and, only for dependency-only commits whose source version stayed unchanged, bakes a deterministic local build version based on the first-parent commit count and SHA.

## Verification

- repository script suite: 61 passed
- crawler version policy suite: 11 passed
- actionlint
- zizmor: no medium/high-confidence findings
- real #5840 and #5837 diffs accepted by the new policy
- unchanged human-authored crawler change rejected
- dependency-only deploy smoke produced a unique tag and built a wheel carrying the derived version

Closes #5870