### PR TITLE
Allow derived versions for crawler deploy self-triggers

### DIFF
--- a/.github/workflows/deploy-crawler-browser.yml
+++ b/.github/workflows/deploy-crawler-browser.yml
@@ -10,6 +10,8 @@ on:
       - '!apps/crawler/ws-package/**'
       - '!apps/crawler/*.md'
       - '!apps/crawler/**/*.md'
+      # Keep the deploy workflow self-triggered so policy changes exercise the
+      # immutable-version and production rollout path they control (#5873).
       - '.github/workflows/deploy-crawler-browser.yml'
 
 env:

--- a/scripts/check-crawler-version.mjs
+++ b/scripts/check-crawler-version.mjs
@@ -4,6 +4,8 @@ import { execFileSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
 
 const DEPENDABOT_LOGIN = "dependabot[bot]";
+const CRAWLER_DEPLOY_WORKFLOW =
+  ".github/workflows/deploy-crawler-browser.yml";
 const DEPENDENCY_FILES = new Set([
   "apps/crawler/Dockerfile",
   "apps/crawler/docker-compose.yml",
@@ -33,6 +35,24 @@ export function isCrawlerDependencyOnly(files) {
   return (
     uniqueFiles.length > 0 &&
     uniqueFiles.every((file) => DEPENDENCY_FILES.has(file))
+  );
+}
+
+export function isCrawlerDeployInfrastructureCommit(files) {
+  const uniqueFiles = [...new Set(files)].sort();
+  return (
+    uniqueFiles.includes(CRAWLER_DEPLOY_WORKFLOW) &&
+    uniqueFiles.every(
+      (file) =>
+        !file.startsWith("apps/crawler/") || DEPENDENCY_FILES.has(file),
+    )
+  );
+}
+
+export function isCrawlerDerivedBuildEligible(files) {
+  return (
+    isCrawlerDependencyOnly(files) ||
+    isCrawlerDeployInfrastructureCommit(files)
   );
 }
 

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -390,6 +390,10 @@ test("workflow-security runs repository script tests", () => {
 
 test("crawler deploys derive immutable versions for unchanged releases", () => {
   assert.match(deployCrawlerWorkflow, /'!apps\/crawler\/ws-package\/\*\*'/);
+  assert.match(
+    deployCrawlerWorkflow,
+    /'\.github\/workflows\/deploy-crawler-browser\.yml'/,
+  );
   assert.match(deployCrawlerWorkflow, /fetch-depth: 0/);
   assert.match(
     deployCrawlerWorkflow,

--- a/scripts/crawler-version.test.mjs
+++ b/scripts/crawler-version.test.mjs
@@ -119,6 +119,47 @@ test("unchanged releases get deterministic commit-specific build versions", () =
   );
 });
 
+test("deploy-infrastructure self-triggers get deterministic build versions", () => {
+  assert.deepEqual(
+    deriveCrawlerBuildVersion({
+      sourceVersion: "0.13.152",
+      parentVersion: "0.13.152",
+      commitCount: "6202",
+      sha: "123456789abcdef0",
+      files: [
+        ".github/workflows/deploy-crawler-browser.yml",
+        "scripts/check-crawler-version.mjs",
+        "scripts/crawler-version.test.mjs",
+        "scripts/derive-crawler-build-version.mjs",
+      ],
+    }),
+    {
+      sourceVersion: "0.13.152",
+      packageVersion: "0.13.152+build.6202.g123456789abc",
+      imageTag: "v0.13.152-build.6202.g123456789abc",
+      derived: true,
+    },
+  );
+});
+
+test("deploy-infrastructure self-triggers cannot hide crawler source changes", () => {
+  assert.throws(
+    () =>
+      deriveCrawlerBuildVersion({
+        sourceVersion: "0.13.152",
+        parentVersion: "0.13.152",
+        commitCount: "6202",
+        sha: "123456789abcdef0",
+        files: [
+          ".github/workflows/deploy-crawler-browser.yml",
+          "scripts/derive-crawler-build-version.mjs",
+          "apps/crawler/src/cli.py",
+        ],
+      }),
+    /dependency-only or deploy-infrastructure main commit/,
+  );
+});
+
 test("deployment does not derive versions for arbitrary unchanged code", () => {
   assert.throws(
     () =>
@@ -129,7 +170,7 @@ test("deployment does not derive versions for arbitrary unchanged code", () => {
         sha: "abcdef1234567890",
         files: ["apps/crawler/src/cli.py"],
       }),
-    /dependency-only main commit/,
+    /dependency-only or deploy-infrastructure main commit/,
   );
 });
 

--- a/scripts/derive-crawler-build-version.mjs
+++ b/scripts/derive-crawler-build-version.mjs
@@ -4,7 +4,7 @@ import { execFileSync } from "node:child_process";
 import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
-import { isCrawlerDependencyOnly } from "./check-crawler-version.mjs";
+import { isCrawlerDerivedBuildEligible } from "./check-crawler-version.mjs";
 
 function parseVersion(value, label) {
   const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(value.trim());
@@ -49,9 +49,10 @@ export function deriveCrawlerBuildVersion({
     };
   }
 
-  if (!isCrawlerDependencyOnly(files)) {
+  if (!isCrawlerDerivedBuildEligible(files)) {
     throw new Error(
-      "Unchanged crawler VERSION is only valid for a dependency-only main commit",
+      "Unchanged crawler VERSION is only valid for a dependency-only or " +
+        "deploy-infrastructure main commit",
     );
   }
 


### PR DESCRIPTION
Closes #5873

Parent: #5866

## Root cause

Deployment-time version derivation recognized unchanged `apps/crawler/VERSION` only when every changed file was a crawler dependency file. A legitimate deployment-policy change necessarily includes `.github/workflows/deploy-crawler-browser.yml` and supporting scripts, so the workflow self-trigger failed before building an image even though no crawler source had changed.

## Fix

- keep the PR-time release gate unchanged and strict
- add a separate deploy-time eligibility classifier for commits containing the crawler deployment workflow
- allow supporting non-crawler files and existing dependency paths
- reject the classification if any non-dependency `apps/crawler/**` path is present
- keep the deploy workflow path explicitly self-triggered so this merge exercises the revised derivation in production

## Validation

- reproduced the old rejection with a regression test
- `node --test scripts/crawler-version.test.mjs scripts/ci-workflow.test.mjs` — 51 passed
- all otherwise-runnable repository script tests passed; the unrelated i18n test needs the root TypeScript dependency that CI installs
- `actionlint .github/workflows/deploy-crawler-browser.yml`
- `node --check scripts/check-crawler-version.mjs`
- `node --check scripts/derive-crawler-build-version.mjs`
- `git diff --check`
