### PR TITLE
Preserve MCP package compatibility

### DIFF
--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jseek/mcp-server",
-  "version": "0.2.0",
+  "version": "0.1.2",
   "mcpName": "io.github.colophon-group/jobseek",
   "description": "MCP server for Job Seek — search jobs, companies, and watchlists on jseek.co",
   "license": "MIT",
@@ -36,6 +36,6 @@
     "typescript": "^5.7.0"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   }
 }

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/colophon-group/jobseek",
     "source": "github"
   },
-  "version": "0.2.0",
+  "version": "0.1.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@jseek/mcp-server",
-      "version": "0.2.0",
+      "version": "0.1.2",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

- restore the published MCP package metadata to its existing 0.1.2 release
- preserve the public Node >=18 compatibility contract
- keep the repository-level Hono security overrides and explicit Node TypeScript environment from #5910

## Root cause

#5910 correctly patches the repository's installed Hono graph through pnpm workspace overrides. Those overrides are root-project policy and are not part of the published MCP package, whose source uses the Web Standard and stdio transports rather than the affected Hono Node adapter.

Advancing the MCP package to 0.2.0 and declaring Node >=20 would therefore have imposed an unnecessary, misleading interface break. The post-merge publication attempt also exposed that the repository npm token cannot currently publish, returning a registry 404 after the artifact built and provenance was signed.

Restoring the existing package version makes the publish workflow compare equal to npm's 0.1.2 release and skip an unnecessary publication. The root application remains on patched `@hono/node-server@2.0.10`, `hono@4.12.27`, and `fast-uri@3.1.4`.

## Validation

- `pnpm --filter @jseek/mcp-server test`
- `pnpm --filter @jseek/mcp-server build`
- `pnpm --filter @jobseek/web typecheck`
- `pnpm audit --prod --audit-level=moderate` — zero known vulnerabilities
