### PR TITLE
Resolve production UX audit findings

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-route-suspense.test.ts
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-route-suspense.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+describe("company route partial prerendering", () => {
+  it("places every useSearchParams client subtree behind an explicit Suspense boundary", () => {
+    const source = readFileSync(
+      "app/[lang]/(app)/company/[slug]/page.tsx",
+      "utf8",
+    );
+
+    expect(source).toContain("<Suspense fallback={null}>");
+    expect(source).toContain("<SimilarSection");
+    expect(source).toContain("<Suspense fallback={<CompanySkeleton />}>");
+    expect(source).toContain("<CompanyContent");
+  });
+});

--- a/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
@@ -262,12 +262,13 @@ export function CompanyPage({
         updateUrl();
         runSearch();
       },
-      submitSearch: (nextKeywords, nextLocations, nextOccupations, nextSeniorities, nextTechnologies) => {
+      submitSearch: (nextKeywords, nextLocations, nextOccupations, nextSeniorities, nextTechnologies, nextWorkMode) => {
         setKeywords(nextKeywords);
         setLocations(nextLocations);
         if (nextOccupations) { setOccupations(nextOccupations); }
         if (nextSeniorities) { setSeniorities(nextSeniorities); }
         if (nextTechnologies) { setTechnologies(nextTechnologies); }
+        if (nextWorkMode) { setWorkMode(nextWorkMode); }
         setShowPostingId(null);
         updateUrl();
         runSearch();

--- a/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import { cacheLife, cacheTag } from "next/cache";
 import { isLocale, defaultLocale, loadCatalog, initI18nForPage, ogLocale, ogAlternateLocales } from "@/lib/i18n";
 import { companyCacheTag } from "@/lib/cache-tags";
@@ -10,6 +11,7 @@ import { buildAlternates } from "@/lib/seo";
 import { CompanyHead } from "./company-head";
 import { CompanyContent } from "./company-content";
 import { SimilarSection } from "./similar-section";
+import { CompanySkeleton } from "@/components/search/company-skeleton";
 
 type Props = {
   params: Promise<{ lang: string; slug: string }>;
@@ -142,12 +144,16 @@ export default async function CompanyPageRoute({ params }: Props) {
   return (
     <div className="space-y-4">
       <CompanyHead company={company} locale={locale} />
-      <SimilarSection
-        companyId={company.id}
-        industryId={company.industryId}
-        locale={locale}
-      />
-      <CompanyContent locale={locale} slug={slug} initialData={initialData} />
+      <Suspense fallback={null}>
+        <SimilarSection
+          companyId={company.id}
+          industryId={company.industryId}
+          locale={locale}
+        />
+      </Suspense>
+      <Suspense fallback={<CompanySkeleton />}>
+        <CompanyContent locale={locale} slug={slug} initialData={initialData} />
+      </Suspense>
     </div>
   );
 }

--- a/apps/web/app/[lang]/(app)/explore/search-page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/search-page.tsx
@@ -351,12 +351,13 @@ export function SearchPage({
         updateUrl();
         runSearch();
       },
-      submitSearch: (nextKeywords, nextLocations, nextOccupations, nextSeniorities, nextTechnologies) => {
+      submitSearch: (nextKeywords, nextLocations, nextOccupations, nextSeniorities, nextTechnologies, nextWorkMode) => {
         setKeywords(nextKeywords);
         setLocations(nextLocations);
         if (nextOccupations) { setOccupations(nextOccupations); }
         if (nextSeniorities) { setSeniorities(nextSeniorities); }
         if (nextTechnologies) { setTechnologies(nextTechnologies); }
+        if (nextWorkMode) { setWorkMode(nextWorkMode); }
         setShowPostingId(null);
         updateUrl();
         runSearch();

--- a/apps/web/app/[lang]/(app)/watchlists/__tests__/watchlists-loader.test.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/__tests__/watchlists-loader.test.tsx
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import "@/test-utils/lingui-mock";
+
+const mocks = vi.hoisted(() => ({
+  load: vi.fn(),
+  session: {
+    user: { id: "user-1", username: "alice" } as {
+      id: string;
+      username: string | null;
+    } | null,
+    isPending: false,
+  },
+}));
+
+vi.mock("@/lib/actions/watchlists", () => ({
+  getUserWatchlistsWithLimit: (...args: unknown[]) => mocks.load(...args),
+}));
+
+vi.mock("@/components/providers/SessionProvider", () => ({
+  useSession: () => mocks.session,
+}));
+
+vi.mock("../watchlists-page", () => ({
+  WatchlistsPage: ({
+    initialWatchlists,
+    username,
+  }: {
+    initialWatchlists: unknown[];
+    username: string | null;
+  }) => (
+    <div
+      data-testid="watchlists-page"
+      data-count={initialWatchlists.length}
+      data-username={username ?? ""}
+    />
+  ),
+}));
+
+import { WatchlistsLoader } from "../watchlists-loader";
+
+describe("WatchlistsLoader recovery (#5896)", () => {
+  beforeEach(() => {
+    mocks.load.mockReset();
+    mocks.session.user = { id: "user-1", username: "alice" };
+    mocks.session.isPending = false;
+  });
+
+  it("retries one transient failure and renders the recovered data", async () => {
+    mocks.load
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+      .mockResolvedValueOnce({
+        watchlists: [{ id: "wl-1" }],
+        limitReached: false,
+      });
+
+    render(<WatchlistsLoader locale="en" />);
+
+    const page = await screen.findByTestId("watchlists-page");
+    expect(page.getAttribute("data-count")).toBe("1");
+    expect(page.getAttribute("data-username")).toBe("alice");
+    expect(mocks.load).toHaveBeenCalledTimes(2);
+  });
+
+  it("replaces the permanent spinner with an error and a working retry", async () => {
+    mocks.load
+      .mockRejectedValueOnce(new Error("cold failure"))
+      .mockRejectedValueOnce(new Error("retry failure"));
+
+    render(<WatchlistsLoader locale="en" />);
+
+    const retry = await screen.findByRole("button", { name: /try again/i });
+    expect(screen.getByText(/couldn't load your watchlists/i)).toBeTruthy();
+
+    mocks.load.mockResolvedValueOnce({ watchlists: [], limitReached: false });
+    fireEvent.click(retry);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("watchlists-page")).toBeTruthy();
+    });
+    expect(mocks.load).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { RefreshCw } from "lucide-react";
+import { Trans } from "@lingui/react/macro";
 import { getUserWatchlistsWithLimit, type WatchlistSummary } from "@/lib/actions/watchlists";
 import { useSession } from "@/components/providers/SessionProvider";
 import { WatchlistsPage } from "./watchlists-page";
@@ -11,13 +13,50 @@ type WatchlistsData = {
   limitReached: boolean;
 };
 
+const WATCHLIST_LOAD_TIMEOUT_MS = 8_000;
+
+async function loadWatchlistsWithRetry(locale: string) {
+  async function attempt() {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        getUserWatchlistsWithLimit(locale),
+        new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(
+            () => reject(new Error("Watchlists request timed out")),
+            WATCHLIST_LOAD_TIMEOUT_MS,
+          );
+        }),
+      ]);
+    } finally {
+      if (timeoutId) clearTimeout(timeoutId);
+    }
+  }
+
+  try {
+    return await attempt();
+  } catch (err) {
+    console.warn("[watchlists] initial load failed, retrying once", err);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    return attempt();
+  }
+}
+
 export function WatchlistsLoader({ locale }: { locale: string }) {
   const { user, isPending } = useSession();
   const [data, setData] = useState<WatchlistsData | null>(null);
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [retryKey, setRetryKey] = useState(0);
+  const userId = user?.id;
+  const username = user?.username ?? null;
 
   useEffect(() => {
+    let cancelled = false;
     if (isPending) return;
-    if (!user) {
+    setLoadFailed(false);
+    setData(null);
+
+    if (!userId) {
       setData({ watchlists: [], username: null, limitReached: true });
       return;
     }
@@ -25,14 +64,46 @@ export function WatchlistsLoader({ locale }: { locale: string }) {
     // which left ``CreateWatchlistCard`` permanently enabled even for
     // users at the plan limit. Server now returns both so the card
     // surfaces its disabled state + upgrade modal correctly.
-    getUserWatchlistsWithLimit(locale).then(({ watchlists, limitReached }) => {
-      setData({
-        watchlists,
-        username: user.username ?? null,
-        limitReached,
+    loadWatchlistsWithRetry(locale)
+      .then(({ watchlists, limitReached }) => {
+        if (cancelled) return;
+        setData({
+          watchlists,
+          username,
+          limitReached,
+        });
+      })
+      .catch((err) => {
+        console.error("[watchlists] load failed twice", err);
+        if (!cancelled) setLoadFailed(true);
       });
-    });
-  }, [user, isPending, locale]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, username, isPending, locale, retryKey]);
+
+  if (loadFailed) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 py-24 text-center">
+        <p className="text-sm font-medium">
+          <Trans id="watchlists.load.error" comment="Error shown when the watchlists overview cannot load after a retry">
+            We couldn&apos;t load your watchlists.
+          </Trans>
+        </p>
+        <button
+          type="button"
+          onClick={() => setRetryKey((value) => value + 1)}
+          className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-border-soft px-3 py-2 text-sm font-medium transition-colors hover:bg-border-soft"
+        >
+          <RefreshCw size={14} aria-hidden="true" />
+          <Trans id="watchlists.load.retry" comment="Button to retry loading the watchlists overview">
+            Try again
+          </Trans>
+        </button>
+      </div>
+    );
+  }
 
   if (!data) {
     return (

--- a/apps/web/app/[lang]/(app)/watchlists/watchlists-page.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/watchlists-page.tsx
@@ -55,6 +55,7 @@ export function WatchlistsPage({
         description: prefill?.description,
         companyIds: [],
         filters: prefill?.filters,
+        isPublic: false,
       });
       if ("error" in result) {
         // Server-side race: client thought limit wasn't reached, but a

--- a/apps/web/app/[lang]/(auth)/layout.tsx
+++ b/apps/web/app/[lang]/(auth)/layout.tsx
@@ -10,17 +10,17 @@ type Props = {
   children: ReactNode;
 };
 
-// Under cacheComponents, the static AuthShell + form prerender.
-// `RedirectIfSignedIn` is the only dynamic piece — it streams a session
-// lookup and redirects if the visitor is already signed in. Returns null
-// otherwise, so there's no visual placeholder to flash.
+// Under cacheComponents, AuthShell prerenders while request-aware auth
+// subtrees stream. `RedirectIfSignedIn` reads the session; AuthForm reads a
+// validated `next` search param so save/sign-in flows can return to their
+// original context. Both need explicit, stable Suspense boundaries.
 export default function AuthLayout({ params, children }: Props) {
   return (
     <AuthShell>
       <Suspense fallback={null}>
         <RedirectIfSignedIn params={params} />
       </Suspense>
-      {children}
+      <Suspense fallback={null}>{children}</Suspense>
     </AuthShell>
   );
 }

--- a/apps/web/drizzle/0081_private_watchlists_and_general_interviews.sql
+++ b/apps/web/drizzle/0081_private_watchlists_and_general_interviews.sql
@@ -1,0 +1,31 @@
+BEGIN;
+
+-- The UI's default "Add interview" action uses the general
+-- `interview` type. The application schema already includes it, but the
+-- original database CHECK constraint predates that option.
+ALTER TABLE application_interview
+  DROP CONSTRAINT IF EXISTS application_interview_type_check;
+
+ALTER TABLE application_interview
+  ADD CONSTRAINT application_interview_type_check
+  CHECK (
+    type IN (
+      'interview',
+      'phone_screen',
+      'video_call',
+      'technical',
+      'coding',
+      'system_design',
+      'behavioral',
+      'onsite',
+      'panel',
+      'hiring_manager',
+      'other'
+    )
+  );
+
+-- Privacy is the safe default for every newly created or mirrored
+-- watchlist. Existing rows keep their current visibility.
+ALTER TABLE watchlist ALTER COLUMN is_public SET DEFAULT false;
+
+COMMIT;

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -505,6 +505,13 @@
       "when": 1783335141000,
       "tag": "0080_experience_decimal_years",
       "breakpoints": true
+    },
+    {
+      "idx": 72,
+      "version": "7",
+      "when": 1784720400000,
+      "tag": "0081_private_watchlists_and_general_interviews",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -1502,12 +1502,6 @@ msgstr "Passwort konnte nicht zurückgesetzt werden. Der Link ist möglicherweis
 msgid "settings.account.password.error"
 msgstr "Zurücksetzungs-E-Mail konnte nicht gesendet werden"
 
-#. Generic set password error
-#. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:78
-msgid "settings.account.password.setError"
-msgstr "Passwort konnte nicht gesetzt werden"
-
 #. Generic username update error
 #. js-lingui-explicit-id
 #: src/components/settings/AccountSettings.tsx:267
@@ -3163,12 +3157,6 @@ msgstr "Datenschutz bei Job Seek"
 #: app/[lang]/(public)/privacy-policy/page.tsx:55
 msgid "privacy.meta.title"
 msgstr "Datenschutzrichtlinie"
-
-#. Reason shown in upgrade modal when trying to make watchlist private
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-action-bar.tsx:125
-msgid "upgrade.reason.makePrivate"
-msgstr "Private Watchlists sind eine kostenpflichtige Funktion. Upgrade, um deine Watchlists vor anderen zu verbergen."
 
 #. Pro tier name
 #. js-lingui-explicit-id
@@ -5014,3 +5002,21 @@ msgstr "Diese Statusänderung ist nicht erlaubt."
 #: src/lib/action-error-messages.ts
 msgid "actions.error.interviewRoundFailed"
 msgstr "Interviewrunde konnte nicht zugewiesen werden."
+
+#. Accessible label for the mobile application funnel summary
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx
+msgid "myJobs.funnel.mobileLabel"
+msgstr "Bewerbungsprozess"
+
+#. Error shown when the watchlists overview cannot load after a retry
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/watchlists/watchlists-loader.tsx
+msgid "watchlists.load.error"
+msgstr "Deine Watchlists konnten nicht geladen werden."
+
+#. Button to retry loading the watchlists overview
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/watchlists/watchlists-loader.tsx
+msgid "watchlists.load.retry"
+msgstr "Erneut versuchen"

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -1502,12 +1502,6 @@ msgstr "Failed to reset password. The link may have expired."
 msgid "settings.account.password.error"
 msgstr "Failed to send reset email"
 
-#. Generic set password error
-#. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:78
-msgid "settings.account.password.setError"
-msgstr "Failed to set password"
-
 #. Generic username update error
 #. js-lingui-explicit-id
 #: src/components/settings/AccountSettings.tsx:267
@@ -3163,12 +3157,6 @@ msgstr "Privacy at Job Seek"
 #: app/[lang]/(public)/privacy-policy/page.tsx:55
 msgid "privacy.meta.title"
 msgstr "Privacy Policy"
-
-#. Reason shown in upgrade modal when trying to make watchlist private
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-action-bar.tsx:125
-msgid "upgrade.reason.makePrivate"
-msgstr "Private watchlists are a paid feature. Upgrade to hide your watchlists from others."
 
 #. Pro tier name
 #. js-lingui-explicit-id
@@ -5014,3 +5002,21 @@ msgstr "That status change is not allowed."
 #: src/lib/action-error-messages.ts
 msgid "actions.error.interviewRoundFailed"
 msgstr "Could not assign interview round."
+
+#. Accessible label for the mobile application funnel summary
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx
+msgid "myJobs.funnel.mobileLabel"
+msgstr "Application funnel"
+
+#. Error shown when the watchlists overview cannot load after a retry
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/watchlists/watchlists-loader.tsx
+msgid "watchlists.load.error"
+msgstr "We couldn't load your watchlists."
+
+#. Button to retry loading the watchlists overview
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/watchlists/watchlists-loader.tsx
+msgid "watchlists.load.retry"
+msgstr "Try again"

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -1502,12 +1502,6 @@ msgstr "Impossible de réinitialiser le mot de passe. Le lien a peut-être expir
 msgid "settings.account.password.error"
 msgstr "Échec de l'envoi de l'e-mail de réinitialisation"
 
-#. Generic set password error
-#. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:78
-msgid "settings.account.password.setError"
-msgstr "Échec de la définition du mot de passe"
-
 #. Generic username update error
 #. js-lingui-explicit-id
 #: src/components/settings/AccountSettings.tsx:267
@@ -3163,12 +3157,6 @@ msgstr "Confidentialité chez Job Seek"
 #: app/[lang]/(public)/privacy-policy/page.tsx:55
 msgid "privacy.meta.title"
 msgstr "Politique de confidentialité"
-
-#. Reason shown in upgrade modal when trying to make watchlist private
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-action-bar.tsx:125
-msgid "upgrade.reason.makePrivate"
-msgstr "Les listes de suivi privées sont une fonctionnalité payante. Passez à un plan supérieur pour masquer vos listes."
 
 #. Pro tier name
 #. js-lingui-explicit-id
@@ -5014,3 +5002,21 @@ msgstr "Ce changement de statut n'est pas autorisé."
 #: src/lib/action-error-messages.ts
 msgid "actions.error.interviewRoundFailed"
 msgstr "Impossible d'attribuer l'entretien."
+
+#. Accessible label for the mobile application funnel summary
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx
+msgid "myJobs.funnel.mobileLabel"
+msgstr "Parcours de candidature"
+
+#. Error shown when the watchlists overview cannot load after a retry
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/watchlists/watchlists-loader.tsx
+msgid "watchlists.load.error"
+msgstr "Impossible de charger vos listes de suivi."
+
+#. Button to retry loading the watchlists overview
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/watchlists/watchlists-loader.tsx
+msgid "watchlists.load.retry"
+msgstr "Réessayer"

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -1502,12 +1502,6 @@ msgstr "Impossibile reimpostare la password. Il link potrebbe essere scaduto."
 msgid "settings.account.password.error"
 msgstr "Impossibile inviare l'email di reimpostazione"
 
-#. Generic set password error
-#. js-lingui-explicit-id
-#: src/components/settings/AccountSettings.tsx:78
-msgid "settings.account.password.setError"
-msgstr "Impossibile impostare la password"
-
 #. Generic username update error
 #. js-lingui-explicit-id
 #: src/components/settings/AccountSettings.tsx:267
@@ -3163,12 +3157,6 @@ msgstr "Privacy su Job Seek"
 #: app/[lang]/(public)/privacy-policy/page.tsx:55
 msgid "privacy.meta.title"
 msgstr "Informativa sulla privacy"
-
-#. Reason shown in upgrade modal when trying to make watchlist private
-#. js-lingui-explicit-id
-#: src/components/watchlist/watchlist-action-bar.tsx:125
-msgid "upgrade.reason.makePrivate"
-msgstr "Le liste private sono una funzionalità a pagamento. Effettua l'upgrade per nascondere le tue liste agli altri."
 
 #. Pro tier name
 #. js-lingui-explicit-id
@@ -5014,3 +5002,21 @@ msgstr "Questa modifica dello stato non è consentita."
 #: src/lib/action-error-messages.ts
 msgid "actions.error.interviewRoundFailed"
 msgstr "Impossibile assegnare il colloquio."
+
+#. Accessible label for the mobile application funnel summary
+#. js-lingui-explicit-id
+#: src/components/my-jobs/sankey-funnel.tsx
+msgid "myJobs.funnel.mobileLabel"
+msgstr "Percorso di candidatura"
+
+#. Error shown when the watchlists overview cannot load after a retry
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/watchlists/watchlists-loader.tsx
+msgid "watchlists.load.error"
+msgstr "Impossibile caricare le tue liste di osservazione."
+
+#. Button to retry loading the watchlists overview
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/watchlists/watchlists-loader.tsx
+msgid "watchlists.load.retry"
+msgstr "Riprova"

--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -38,9 +38,9 @@ function NavIcon({ href, label, children }: { href: string; label: string; child
 
 function BottomBarLink({ href, label, children }: { href: string; label: string; children: React.ReactNode }) {
   return (
-    <Link href={href} prefetch={false} className="flex flex-1 flex-col items-center gap-0.5 py-1.5 text-foreground transition-colors hover:text-muted">
+    <Link href={href} prefetch={false} className="flex h-full min-w-0 flex-1 flex-col items-center justify-center gap-0.5 px-0.5 py-1 text-foreground transition-colors hover:text-muted">
       {children}
-      <span className="text-[10px] leading-tight">{label}</span>
+      <span className="line-clamp-2 min-h-5 max-w-full text-center text-[9px] leading-[10px]">{label}</span>
     </Link>
   );
 }
@@ -173,7 +173,7 @@ export function AppHeader() {
       </header>
 
       {/* ── Mobile bottom bar ── */}
-      <nav className="fixed bottom-0 left-0 right-0 z-50 flex items-center border-t border-divider bg-surface-alpha backdrop-blur-md md:hidden">
+      <nav className="fixed bottom-0 left-0 right-0 z-50 flex h-14 items-center border-t border-divider bg-surface-alpha backdrop-blur-md md:hidden">
         <BottomBarLink href={appHref} label={exploreLabel}>
           <Compass size={20} />
         </BottomBarLink>
@@ -186,16 +186,16 @@ export function AppHeader() {
         <BottomBarLink href={lp(siteConfig.nav.settings.href)} label={settingsLabel}>
           <Settings size={20} />
         </BottomBarLink>
-        <span className="flex flex-1">
+        <span className="flex h-full min-w-0 flex-1">
           {isPending ? (
-            <span className="flex flex-1 flex-col items-center gap-0.5 py-1.5">
+            <span className="flex min-w-0 flex-1 flex-col items-center justify-center gap-0.5 py-1">
               <span className="size-6 rounded-full bg-muted/30 animate-pulse" />
               <span className="h-3 w-10 rounded bg-muted/30 animate-pulse" />
             </span>
           ) : isLoggedIn && user ? (
             <DropdownMenu.Root>
               <DropdownMenu.Trigger asChild>
-                <button className="flex flex-1 flex-col items-center gap-0.5 py-1.5 transition-colors cursor-pointer">
+                <button className="flex h-full min-w-0 flex-1 flex-col items-center justify-center gap-0.5 px-0.5 py-1 transition-colors cursor-pointer">
                   <UserAvatar
                     image={user.image}
                     name={user.name}
@@ -203,7 +203,7 @@ export function AppHeader() {
                     size={24}
                     initialsTextClass="text-[10px]"
                   />
-                  <span className="text-[10px] leading-tight text-foreground">
+                  <span className="line-clamp-2 min-h-5 max-w-full text-center text-[9px] leading-[10px] text-foreground">
                     {t({ id: "app.header.nav.account", comment: "Account bottom bar label", message: "Account" })}
                   </span>
                 </button>
@@ -213,9 +213,9 @@ export function AppHeader() {
               </DropdownMenu.Portal>
             </DropdownMenu.Root>
           ) : (
-            <Link href={lp(siteConfig.nav.login.href)} prefetch={false} className="flex flex-1 flex-col items-center gap-0.5 py-1.5 text-foreground transition-colors hover:text-muted">
+            <Link href={lp(siteConfig.nav.login.href)} prefetch={false} className="flex h-full min-w-0 flex-1 flex-col items-center justify-center gap-0.5 px-0.5 py-1 text-foreground transition-colors hover:text-muted">
               <LogIn size={20} />
-              <span className="text-[10px] leading-tight">
+              <span className="line-clamp-2 min-h-5 max-w-full text-center text-[9px] leading-[10px]">
                 {t({ id: "common.auth.login", comment: "Login button label", message: "Log in" })}
               </span>
             </Link>

--- a/apps/web/src/components/AuthForm.tsx
+++ b/apps/web/src/components/AuthForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { Trans } from "@lingui/react/macro";
 import { useLingui } from "@lingui/react/macro";
 import { authClient } from "@/lib/auth-client";
@@ -14,6 +14,11 @@ import { Button } from "@/components/ui/Button";
 import { FormField } from "@/components/ui/FormField";
 import { ErrorAlert } from "@/components/ui/ErrorAlert";
 import { OAuthButtons } from "@/components/ui/OAuthButtons";
+import {
+  localizeAuthReturnPath,
+  normalizeAuthReturnPath,
+  withAuthReturnPath,
+} from "@/lib/auth-return";
 
 type AuthFormProps = {
   mode: "sign-in" | "sign-up";
@@ -21,6 +26,7 @@ type AuthFormProps = {
 
 export function AuthForm({ mode }: AuthFormProps) {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { t } = useLingui();
   const lp = useLocalePath();
   const [name, setName] = useState("");
@@ -31,7 +37,10 @@ export function AuthForm({ mode }: AuthFormProps) {
   const [loading, setLoading] = useState(false);
 
   const isSignUp = mode === "sign-up";
-  const dashboardUrl = lp("/explore");
+  const requestedReturnPath = normalizeAuthReturnPath(searchParams.get("next"));
+  const dashboardUrl = requestedReturnPath ?? lp("/explore");
+  const signInUrl = withAuthReturnPath(lp("/sign-in"), requestedReturnPath);
+  const signUpUrl = withAuthReturnPath(lp("/sign-up"), requestedReturnPath);
 
   function goToCheckEmail() {
     sessionStorage.setItem("verify-email", email);
@@ -135,7 +144,11 @@ export function AuthForm({ mode }: AuthFormProps) {
         }
 
         if (targetLocale && !dashboardUrl.startsWith(`/${targetLocale}/`)) {
-          router.push(`/${targetLocale}/explore`);
+          router.push(
+            requestedReturnPath
+              ? localizeAuthReturnPath(requestedReturnPath, targetLocale)
+              : `/${targetLocale}/explore`,
+          );
         } else {
           router.push(dashboardUrl);
         }
@@ -234,14 +247,14 @@ export function AuthForm({ mode }: AuthFormProps) {
         {isSignUp ? (
           <Trans id="auth.signUp.hasAccount" comment="Link to sign-in page from sign-up">
             Already have an account?{" "}
-            <Link href={lp("/sign-in")} prefetch={false} className="font-semibold transition-colors hover:text-muted">
+            <Link href={signInUrl} prefetch={false} className="font-semibold transition-colors hover:text-muted">
               Sign in
             </Link>
           </Trans>
         ) : (
           <Trans id="auth.signIn.noAccount" comment="Link to sign-up page from sign-in">
             Don&apos;t have an account?{" "}
-            <Link href={lp("/sign-up")} prefetch={false} className="font-semibold transition-colors hover:text-muted">
+            <Link href={signUpUrl} prefetch={false} className="font-semibold transition-colors hover:text-muted">
               Sign up
             </Link>
           </Trans>

--- a/apps/web/src/components/CookieBanner.tsx
+++ b/apps/web/src/components/CookieBanner.tsx
@@ -39,7 +39,7 @@ export function CookieBanner({ aboveBottomBar, serverConsent }: CookieBannerProp
 
   return (
     <div className={aboveBottomBar
-      ? "fixed bottom-[52px] left-0 right-0 z-50 border-t border-info-border bg-info-bg dark:bg-[rgba(147,187,253,0.15)] backdrop-blur-sm md:fixed md:top-12 md:bottom-auto md:z-40 md:border-b md:border-t-0"
+      ? "fixed bottom-14 left-0 right-0 z-50 border-t border-info-border bg-info-bg dark:bg-[rgba(147,187,253,0.15)] backdrop-blur-sm md:static md:z-auto md:border-b md:border-t-0"
       : "border-b border-info-border bg-info-bg dark:bg-[rgba(147,187,253,0.15)] backdrop-blur-sm"
     }>
       <div className="mx-auto flex max-w-[1200px] flex-col gap-2 px-4 py-2 text-sm text-info sm:flex-row sm:items-center sm:gap-3">

--- a/apps/web/src/components/__tests__/AuthForm-a11y.test.tsx
+++ b/apps/web/src/components/__tests__/AuthForm-a11y.test.tsx
@@ -6,6 +6,7 @@ import "@/test-utils/lingui-mock";
 
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
+  searchParams: new URLSearchParams(),
   signInEmail: vi.fn(),
   signInUsername: vi.fn(),
   signUpEmail: vi.fn(),
@@ -15,6 +16,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mocks.push }),
+  useSearchParams: () => mocks.searchParams,
 }));
 
 vi.mock("@/lib/useLocalePath", () => ({
@@ -51,6 +53,7 @@ import { AuthForm } from "../AuthForm";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.searchParams.delete("next");
 });
 
 describe("AuthForm accessibility", () => {
@@ -75,5 +78,25 @@ describe("AuthForm accessibility", () => {
     expect(password.getAttribute("aria-describedby")).toBeTruthy();
     expect(mocks.signInEmail).not.toHaveBeenCalled();
     expect(mocks.signInUsername).not.toHaveBeenCalled();
+  });
+
+  it("uses a safe next path for the auth callback and post-sign-in navigation", async () => {
+    const user = userEvent.setup();
+    mocks.searchParams.set("next", "/en/company/acme?q=safety&show=post-1");
+    mocks.signInEmail.mockResolvedValue({ error: null });
+    mocks.getPreferences.mockResolvedValue(null);
+
+    render(<AuthForm mode="sign-in" />);
+
+    await user.type(screen.getByLabelText("Email or username"), "person@example.com");
+    await user.type(screen.getByLabelText("Password", { selector: "input" }), "password");
+    await user.click(screen.getByRole("button", { name: "Sign in" }));
+
+    await waitFor(() => {
+      expect(mocks.signInEmail).toHaveBeenCalledWith(expect.objectContaining({
+        callbackURL: "/en/company/acme?q=safety&show=post-1",
+      }));
+      expect(mocks.push).toHaveBeenCalledWith("/en/company/acme?q=safety&show=post-1");
+    });
   });
 });

--- a/apps/web/src/components/__tests__/responsive-app-chrome.test.ts
+++ b/apps/web/src/components/__tests__/responsive-app-chrome.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+describe("responsive app chrome", () => {
+  it("keeps informational banners in document flow on desktop", () => {
+    for (const path of [
+      "src/components/CookieBanner.tsx",
+      "src/components/watchlist/watchlist-tip-banner.tsx",
+    ]) {
+      const source = readFileSync(path, "utf8");
+      expect(source).toContain("bottom-14");
+      expect(source).toContain("md:static");
+      expect(source).not.toContain("md:fixed md:top-12");
+    }
+  });
+
+  it("gives every mobile navigation item a bounded two-line label", () => {
+    const source = readFileSync("src/components/AppHeader.tsx", "utf8");
+
+    expect(source).toContain("h-14 items-center");
+    expect(source).toContain("line-clamp-2 min-h-5 max-w-full text-center");
+    expect(source).toContain("h-full min-w-0 flex-1");
+  });
+});

--- a/apps/web/src/components/my-jobs/__tests__/activity-heatmap.test.tsx
+++ b/apps/web/src/components/my-jobs/__tests__/activity-heatmap.test.tsx
@@ -208,7 +208,24 @@ describe("ActivityHeatmap — locale labels and plural tooltip (#3150)", () => {
     expect(labels).toContain(new Intl.DateTimeFormat("de", { weekday: "short" }).format(new Date(2026, 0, 5)));
     expect(labels).toContain(new Intl.DateTimeFormat("de", { weekday: "short" }).format(new Date(2026, 0, 7)));
     expect(labels).toContain(new Intl.DateTimeFormat("de", { weekday: "short" }).format(new Date(2026, 0, 9)));
-    expect(labels).toContain(new Intl.DateTimeFormat("de", { month: "short" }).format(new Date(2026, 6, 1)));
+    expect(labels).toContain(new Intl.DateTimeFormat("de", { month: "short" }).format(new Date(2026, 7, 1)));
+  });
+
+  it("omits a partial first-month label when it would collide with the next month", () => {
+    vi.setSystemTime(new Date(2026, 6, 22, 12, 0, 0, 0));
+
+    const { container } = render(<ActivityHeatmap data={[]} />);
+    const monthLabels = Array.from(
+      container.querySelectorAll<SVGTextElement>("text[data-month-column]"),
+    );
+
+    expect(monthLabels[0]?.textContent).toBe(
+      new Intl.DateTimeFormat("en", { month: "short" }).format(new Date(2026, 7, 1)),
+    );
+    const columns = monthLabels.map((label) => Number(label.dataset.monthColumn));
+    for (let index = 1; index < columns.length; index++) {
+      expect(columns[index] - columns[index - 1]).toBeGreaterThanOrEqual(3);
+    }
   });
 
   const tooltipCases: Array<[number, string]> = [

--- a/apps/web/src/components/my-jobs/__tests__/sankey-funnel-mobile.test.tsx
+++ b/apps/web/src/components/my-jobs/__tests__/sankey-funnel-mobile.test.tsx
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import type { FunnelData } from "@/lib/actions/my-jobs-stats";
+import { SankeyFunnel } from "../sankey-funnel";
+
+vi.mock("@lingui/react/macro", () => ({
+  useLingui: () => ({
+    t: ({ message }: { message?: string }) => message ?? "",
+  }),
+}));
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ resolvedTheme: "light" }),
+}));
+
+vi.mock("@nivo/sankey", () => ({
+  ResponsiveSankey: () => <div data-testid="sankey-chart" />,
+}));
+
+const data: FunnelData = {
+  saved: 10,
+  applied: 5,
+  offered: 1,
+  offeredWithoutInterview: 0,
+  rejectedAtSaved: 2,
+  rejectedAtApplied: 1,
+  noResponseAtSaved: 3,
+  noResponseAtApplied: 1,
+  interviewRounds: [{ round: 1, count: 3 }],
+  rejectedAtRound: [{ round: 1, count: 1 }],
+  noResponseAtRound: [],
+  offeredAtRound: [{ round: 1, count: 1 }],
+};
+
+describe("SankeyFunnel mobile summary", () => {
+  beforeEach(() => {
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      value: vi.fn(() => ({
+        matches: true,
+        media: "(max-width: 640px)",
+        onchange: null,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  it("renders readable stage rows instead of a vertically labelled chart", async () => {
+    const { container, getByTestId } = render(<SankeyFunnel data={data} />);
+
+    await waitFor(() => expect(getByTestId("mobile-funnel")).toBeTruthy());
+
+    expect(container.querySelector('[data-testid="sankey-chart"]')).toBeNull();
+    expect(container.textContent).toContain("Saved");
+    expect(container.textContent).toContain("Applied");
+    expect(container.textContent).toContain("Round 1");
+    expect(container.textContent).toContain("Offered");
+    expect(container.textContent).toContain("Rejected: 2");
+  });
+});

--- a/apps/web/src/components/my-jobs/activity-heatmap.tsx
+++ b/apps/web/src/components/my-jobs/activity-heatmap.tsx
@@ -18,6 +18,7 @@ const DAYS = 7;
 const CELL = 10;
 const GAP = 2;
 const STEP = CELL + GAP;
+const MIN_MONTH_LABEL_COLUMNS = 3;
 
 const LEVELS = [
   "var(--color-border-soft, #e7e5e4)",
@@ -100,7 +101,29 @@ export function ActivityHeatmap({ data }: { data: ActivityDay[] }) {
       columns.push(col);
     }
 
-    return { grid: columns, monthHeaders };
+    // A partial first month can occupy only one or two columns. Its label
+    // then collides with the next full month (for example Jul/Aug). Prefer
+    // the full month and keep every subsequent label at least three columns
+    // apart, which fits localized three-letter month abbreviations.
+    const visibleMonthHeaders: typeof monthHeaders = [];
+    for (let index = 0; index < monthHeaders.length; index++) {
+      const header = monthHeaders[index];
+      const next = monthHeaders[index + 1];
+      if (
+        index === 0
+        && next
+        && next.col - header.col < MIN_MONTH_LABEL_COLUMNS
+      ) {
+        continue;
+      }
+      const previous = visibleMonthHeaders.at(-1);
+      if (previous && header.col - previous.col < MIN_MONTH_LABEL_COLUMNS) {
+        continue;
+      }
+      visibleMonthHeaders.push(header);
+    }
+
+    return { grid: columns, monthHeaders: visibleMonthHeaders };
   }, [data, MONTHS]);
 
   const labelW = 26;
@@ -162,6 +185,7 @@ export function ActivityHeatmap({ data }: { data: ActivityDay[] }) {
         {monthHeaders.map((m) => (
           <text
             key={`month-${m.col}`}
+            data-month-column={m.col}
             x={labelW + m.col * STEP}
             y={11}
             className="fill-muted"

--- a/apps/web/src/components/my-jobs/sankey-funnel.tsx
+++ b/apps/web/src/components/my-jobs/sankey-funnel.tsx
@@ -36,6 +36,7 @@ export function SankeyFunnel({ data }: { data: FunnelData }) {
   const { resolvedTheme } = useTheme();
   const isDark = resolvedTheme === "dark";
   const { t } = useLingui();
+  const isSmall = useIsSmallScreen();
 
   const l = {
     saved: t({ id: "myJobs.funnel.saved", comment: "Sankey funnel node: saved jobs", message: "Saved" }),
@@ -143,21 +144,93 @@ export function SankeyFunnel({ data }: { data: FunnelData }) {
 
   if (links.length === 0) return null;
 
+  if (isSmall) {
+    const stages = [
+      {
+        key: "saved",
+        label: l.saved,
+        count: data.saved,
+        outcomes: [
+          { label: l.rejected, count: data.rejectedAtSaved },
+          { label: l.notApplied, count: data.noResponseAtSaved },
+        ],
+      },
+      {
+        key: "applied",
+        label: l.applied,
+        count: data.applied,
+        outcomes: [
+          { label: l.rejected, count: data.rejectedAtApplied },
+          { label: l.noResponse, count: data.noResponseAtApplied },
+        ],
+      },
+      ...data.interviewRounds.map((round) => ({
+        key: `round-${round.round}`,
+        label: `${l.round} ${round.round}`,
+        count: round.count,
+        outcomes: [
+          {
+            label: l.rejected,
+            count: data.rejectedAtRound.find((item) => item.round === round.round)?.count ?? 0,
+          },
+          {
+            label: l.noResponse,
+            count: data.noResponseAtRound.find((item) => item.round === round.round)?.count ?? 0,
+          },
+        ],
+      })),
+      {
+        key: "offered",
+        label: l.offered,
+        count: data.offered,
+        outcomes: [],
+      },
+    ].filter((stage) => stage.count > 0);
+
+    return (
+      <ol data-testid="mobile-funnel" className="space-y-2" aria-label={t({
+        id: "myJobs.funnel.mobileLabel",
+        comment: "Accessible label for the mobile application funnel summary",
+        message: "Application funnel",
+      })}>
+        {stages.map((stage, index) => {
+          const outcomes = stage.outcomes.filter((outcome) => outcome.count > 0);
+          return (
+            <li key={stage.key} className="relative rounded-lg border border-border-soft bg-surface px-3 py-2.5">
+              {index > 0 && (
+                <span aria-hidden="true" className="absolute -top-2.5 left-6 h-2.5 border-l border-border-soft" />
+              )}
+              <div className="flex items-center justify-between gap-3">
+                <span className="min-w-0 font-medium">{stage.label}</span>
+                <span className="shrink-0 rounded-full bg-border-soft px-2 py-0.5 font-mono text-sm tabular-nums">
+                  {stage.count}
+                </span>
+              </div>
+              {outcomes.length > 0 && (
+                <ul className="mt-1.5 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted">
+                  {outcomes.map((outcome) => (
+                    <li key={outcome.label}>
+                      {outcome.label}: <span className="font-mono tabular-nums">{outcome.count}</span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    );
+  }
+
   const sankeyData = { nodes: filteredNodes, links };
-  const isSmall = useIsSmallScreen();
-  const layout = isSmall ? "vertical" : "horizontal";
-  const height = isSmall
-    ? Math.max(400, 250 + nodes.length * 20)
-    : Math.max(300, 200 + nodes.length * 16);
-  const margin = isSmall
-    ? { top: 0, right: 20, bottom: 120, left: 20 }
-    : { top: 20, right: 180, bottom: 20, left: 10 };
+  const height = Math.max(300, 200 + nodes.length * 16);
+  const margin = { top: 20, right: 180, bottom: 20, left: 10 };
 
   return (
     <div style={{ height }}>
       <ResponsiveSankey
         data={sankeyData}
-        layout={layout}
+        layout="horizontal"
         margin={margin}
         align="start"
         colors={(node) => getColor(node.id as string)}
@@ -174,7 +247,7 @@ export function SankeyFunnel({ data }: { data: FunnelData }) {
         enableLinkGradient={false}
         label={(node) => labelMap.get(node.id as string) ?? (node.id as string)}
         labelPosition="outside"
-        labelOrientation={isSmall ? "vertical" : "horizontal"}
+        labelOrientation="horizontal"
         labelPadding={12}
         labelTextColor={isDark ? "#e7e5e4" : "#1c1917"}
         theme={{

--- a/apps/web/src/components/providers/SearchStateProvider.tsx
+++ b/apps/web/src/components/providers/SearchStateProvider.tsx
@@ -158,6 +158,7 @@ export interface SearchPageActions {
     occupations?: { id: number; slug: string; name: string }[],
     seniorities?: { id: number; slug: string; name: string }[],
     technologies?: { id: number; slug: string; name: string }[],
+    workMode?: WorkMode[],
   ) => void;
   getLocations: () => SelectedLocation[];
   getKeywords: () => string[];

--- a/apps/web/src/components/search/__tests__/save-button-auth-return.test.ts
+++ b/apps/web/src/components/search/__tests__/save-button-auth-return.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+describe("SaveButton anonymous auth handoff", () => {
+  it("includes the current path, filters, and open job in the sign-in URL", () => {
+    const source = readFileSync("src/components/search/save-button.tsx", "utf8");
+
+    expect(source).toContain("window.location.pathname");
+    expect(source).toContain("window.location.search");
+    expect(source).toContain("window.location.hash");
+    expect(source).toContain("withAuthReturnPath");
+  });
+});

--- a/apps/web/src/components/search/__tests__/save-search-button.test.tsx
+++ b/apps/web/src/components/search/__tests__/save-search-button.test.tsx
@@ -80,6 +80,9 @@ describe("SaveSearchButton (issue #3036)", () => {
     fireEvent.click(screen.getByRole("button", { name: /save this search/i }));
 
     await waitFor(() => expect(pushMock).toHaveBeenCalledWith("/en/alice/my-search"));
+    expect(createWatchlistMock.mock.calls[0]?.[0]).toMatchObject({
+      isPublic: false,
+    });
   });
 
   it("includes employment type filters when saving the search", async () => {

--- a/apps/web/src/components/search/__tests__/search-bar-company-scope.test.tsx
+++ b/apps/web/src/components/search/__tests__/search-bar-company-scope.test.tsx
@@ -1,0 +1,94 @@
+import { useEffect } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import "@/test-utils/lingui-mock";
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  submitSearch: vi.fn(),
+  parseSearchFilters: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.push }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/en/company/acme",
+  useParams: () => ({ lang: "en" }),
+}));
+
+vi.mock("@/lib/actions/company", () => ({
+  suggestCompanies: vi.fn(async () => []),
+}));
+
+vi.mock("@/lib/search/typeahead-runner", () => ({
+  runSuggestLocations: vi.fn(async () => []),
+  runSuggestOccupations: vi.fn(async () => []),
+  runSuggestSeniorities: vi.fn(async () => []),
+  runSuggestTechnologies: vi.fn(async () => []),
+}));
+
+vi.mock("@/lib/actions/search-input", () => ({
+  parseSearchFilters: (...args: unknown[]) => mocks.parseSearchFilters(...args),
+}));
+
+vi.mock("server-only", () => ({}));
+
+import { SearchBar } from "../search-bar";
+import {
+  SearchStateProvider,
+  useSearchStateStore,
+} from "@/components/providers/SearchStateProvider";
+
+function CompanySearchHarness() {
+  const { setPageActions } = useSearchStateStore();
+
+  useEffect(() => {
+    setPageActions({
+      addLocation: vi.fn(),
+      addOccupation: vi.fn(),
+      addSeniority: vi.fn(),
+      submitSearch: mocks.submitSearch,
+      getLocations: () => [],
+      getKeywords: () => [],
+      getOccupations: () => [],
+      getSeniorities: () => [],
+      getTechnologies: () => [],
+      placeholder: "Search at Acme...",
+    });
+    return () => setPageActions(null);
+  }, [setPageActions]);
+
+  return <SearchBar />;
+}
+
+describe("SearchBar company scope", () => {
+  it("submits free text through the company page instead of navigating to Explore", async () => {
+    mocks.parseSearchFilters.mockResolvedValue({
+      keywords: ["safety"],
+      locations: [],
+      occupations: [],
+      seniorities: [],
+      technologies: [],
+      workMode: [],
+    });
+
+    render(
+      <SearchStateProvider>
+        <CompanySearchHarness />
+      </SearchStateProvider>,
+    );
+
+    const input = screen.getByRole("combobox");
+    expect(input.getAttribute("placeholder")).toBe("Search at Acme...");
+    await userEvent.type(input, "safety{Enter}");
+
+    await waitFor(() => {
+      expect(mocks.submitSearch).toHaveBeenCalledWith(
+        ["safety"], [], [], [], [], [],
+      );
+    });
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/search/filter-pills-readonly.tsx
+++ b/apps/web/src/components/search/filter-pills-readonly.tsx
@@ -90,44 +90,63 @@ export function FilterPillsReadOnly({
 }) {
   const { t } = useLingui();
   const pills: FilterPill[] = [];
+  const removeFilterLabel = (name: string) => t({
+    id: "search.filters.removeFilter",
+    comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value",
+    message: `Remove ${name} filter`,
+  });
 
   if (filters.keywords?.length) {
     for (const kw of filters.keywords) {
+      const name = kw;
       pills.push({
         key: `kw-${kw}`,
         icon: null,
         label: kw,
         onRemove: onRemoveKeyword ? () => onRemoveKeyword(kw) : undefined,
         removeLabel: onRemoveKeyword
-          ? t({ id: "search.filters.removeKeyword", comment: "Aria label for remove-keyword X button; {name} is the keyword", message: `Remove keyword ${kw}` })
+          ? t({
+              id: "search.filters.removeKeyword",
+              comment: "Aria label for remove-keyword X button; {name} is the keyword",
+              message: `Remove keyword ${name}`,
+            })
           : undefined,
       });
     }
   }
   if (locations && locations.length > 0) {
     for (const loc of locations) {
-      const label = loc.parentName && loc.type !== "country" && loc.type !== "macro"
+      const name = loc.parentName && loc.type !== "country" && loc.type !== "macro"
         ? `${loc.name}, ${loc.parentName}`
         : loc.name;
       pills.push({
         key: `loc-${loc.id}`,
         icon: <MapPin size={12} />,
-        label,
+        label: name,
         onRemove: onRemoveLocation ? () => onRemoveLocation(loc) : undefined,
         removeLabel: onRemoveLocation
-          ? t({ id: "search.filters.removeLocation", comment: "Aria label for remove-location X button; {name} is the location label", message: `Remove location ${label}` })
+          ? t({
+              id: "search.filters.removeLocation",
+              comment: "Aria label for remove-location X button; {name} is the location label",
+              message: `Remove location ${name}`,
+            })
           : undefined,
       });
     }
   } else if (filters.locationSlugs?.length) {
     for (const slug of filters.locationSlugs) {
+      const name = slug;
       pills.push({
         key: `loc-${slug}`,
         icon: <MapPin size={12} />,
         label: slug,
         onRemove: onRemoveLocationSlug ? () => onRemoveLocationSlug(slug) : undefined,
         removeLabel: onRemoveLocationSlug
-          ? t({ id: "search.filters.removeLocation", comment: "Aria label for remove-location X button; {name} is the location label", message: `Remove location ${slug}` })
+          ? t({
+              id: "search.filters.removeLocation",
+              comment: "Aria label for remove-location X button; {name} is the location label",
+              message: `Remove location ${name}`,
+            })
           : undefined,
       });
     }
@@ -140,7 +159,7 @@ export function FilterPillsReadOnly({
         label: occ.name,
         onRemove: onRemoveOccupation ? () => onRemoveOccupation(occ) : undefined,
         removeLabel: onRemoveOccupation
-          ? t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${occ.name} filter` })
+          ? removeFilterLabel(occ.name)
           : undefined,
       });
     }
@@ -152,7 +171,7 @@ export function FilterPillsReadOnly({
         label: slug,
         onRemove: onRemoveOccupationSlug ? () => onRemoveOccupationSlug(slug) : undefined,
         removeLabel: onRemoveOccupationSlug
-          ? t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${slug} filter` })
+          ? removeFilterLabel(slug)
           : undefined,
       });
     }
@@ -165,7 +184,7 @@ export function FilterPillsReadOnly({
         label: sen.name,
         onRemove: onRemoveSeniority ? () => onRemoveSeniority(sen) : undefined,
         removeLabel: onRemoveSeniority
-          ? t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${sen.name} filter` })
+          ? removeFilterLabel(sen.name)
           : undefined,
       });
     }
@@ -177,7 +196,7 @@ export function FilterPillsReadOnly({
         label: slug,
         onRemove: onRemoveSenioritySlug ? () => onRemoveSenioritySlug(slug) : undefined,
         removeLabel: onRemoveSenioritySlug
-          ? t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${slug} filter` })
+          ? removeFilterLabel(slug)
           : undefined,
       });
     }
@@ -190,7 +209,7 @@ export function FilterPillsReadOnly({
         label: tech.name,
         onRemove: onRemoveTechnology ? () => onRemoveTechnology(tech) : undefined,
         removeLabel: onRemoveTechnology
-          ? t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${tech.name} filter` })
+          ? removeFilterLabel(tech.name)
           : undefined,
       });
     }
@@ -202,7 +221,7 @@ export function FilterPillsReadOnly({
         label: slug,
         onRemove: onRemoveTechnologySlug ? () => onRemoveTechnologySlug(slug) : undefined,
         removeLabel: onRemoveTechnologySlug
-          ? t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${slug} filter` })
+          ? removeFilterLabel(slug)
           : undefined,
       });
     }
@@ -221,7 +240,7 @@ export function FilterPillsReadOnly({
         labelClassName: "capitalize",
         onRemove: onToggleEmploymentType ? () => onToggleEmploymentType(et) : undefined,
         removeLabel: onToggleEmploymentType
-          ? t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${et.replace(/_/g, " ")} filter` })
+          ? removeFilterLabel(et.replace(/_/g, " "))
           : undefined,
       });
     }
@@ -235,7 +254,7 @@ export function FilterPillsReadOnly({
         label,
         onRemove: onToggleWorkMode ? () => onToggleWorkMode(mode) : undefined,
         removeLabel: onToggleWorkMode
-          ? t({ id: "search.filters.removeFilter", comment: "Aria label for remove-filter X button on a filter pill; {name} is the filter value", message: `Remove ${label} filter` })
+          ? removeFilterLabel(label)
           : undefined,
       });
     }

--- a/apps/web/src/components/search/save-button.tsx
+++ b/apps/web/src/components/search/save-button.tsx
@@ -7,6 +7,7 @@ import { useSession } from "@/components/providers/SessionProvider";
 import { useLocalePath } from "@/lib/useLocalePath";
 import { useSavedJobs } from "@/components/providers/SavedJobsProvider";
 import { tooltipClass } from "@/components/ui/tooltip-styles";
+import { withAuthReturnPath } from "@/lib/auth-return";
 
 export function SaveButton({ postingId }: { postingId: string }) {
   const { t } = useLingui();
@@ -25,7 +26,8 @@ export function SaveButton({ postingId }: { postingId: string }) {
     e.stopPropagation();
     if (isPending) return;
     if (!isLoggedIn) {
-      window.location.href = lp("/sign-in");
+      const returnPath = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+      window.location.href = withAuthReturnPath(lp("/sign-in"), returnPath);
       return;
     }
     toggle(postingId);

--- a/apps/web/src/components/search/save-search-button.tsx
+++ b/apps/web/src/components/search/save-search-button.tsx
@@ -84,6 +84,7 @@ export function SaveSearchButton({
         title,
         companyIds: [],
         filters,
+        isPublic: false,
       });
 
       if ("error" in result) {

--- a/apps/web/src/components/search/search-bar.tsx
+++ b/apps/web/src/components/search/search-bar.tsx
@@ -84,7 +84,7 @@ export function SearchBar({
   onAddSeniority,
   onAddTechnology,
   onAddWorkMode,
-  onSubmitSearch: _onSubmitSearch,
+  onSubmitSearch,
   locale: localeProp,
   keywords: keywordsProp,
   locations: locationsProp,
@@ -404,14 +404,26 @@ export function SearchBar({
         const wmSet = new Set(existingWm);
         const mergedWm = [...existingWm, ...(parsed.workMode ?? []).filter((m) => !wmSet.has(m))];
 
-        router.push(buildFilteredPath(lp("/explore"), mergedKw, mergedLocs, undefined, mergedOccs, mergedSens, mergedTechs, mergedWm));
+        if (onSubmitSearch) {
+          onSubmitSearch(mergedKw, mergedLocs, mergedOccs, mergedSens, mergedTechs, mergedWm);
+        } else if (pageActions) {
+          pageActions.submitSearch(mergedKw, mergedLocs, mergedOccs, mergedSens, mergedTechs, mergedWm);
+        } else {
+          router.push(buildFilteredPath(lp("/explore"), mergedKw, mergedLocs, undefined, mergedOccs, mergedSens, mergedTechs, mergedWm));
+        }
       })
       .catch(() => {
         // Fallback: treat raw input as a keyword and navigate
         const mergedKw = [...existingKw, input];
-        router.push(buildFilteredPath(lp("/explore"), mergedKw, existingLocs, undefined, existingOccs, existingSens, existingTechs, existingWm));
+        if (onSubmitSearch) {
+          onSubmitSearch(mergedKw, existingLocs, existingOccs, existingSens, existingTechs, existingWm);
+        } else if (pageActions) {
+          pageActions.submitSearch(mergedKw, existingLocs, existingOccs, existingSens, existingTechs, existingWm);
+        } else {
+          router.push(buildFilteredPath(lp("/explore"), mergedKw, existingLocs, undefined, existingOccs, existingSens, existingTechs, existingWm));
+        }
       });
-  }, [inputValue, lang, userLat, userLng, getPageActions, router, lp, searchParams, keywordsProp, locationsProp, occupationsProp, senioritiesProp, technologiesProp, workModeProp, currentKeywords, clearResults]);
+  }, [inputValue, lang, userLat, userLng, getPageActions, onSubmitSearch, router, lp, searchParams, keywordsProp, locationsProp, occupationsProp, senioritiesProp, technologiesProp, workModeProp, currentKeywords, clearResults]);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "ArrowDown") {

--- a/apps/web/src/components/watchlist/watchlist-action-bar.tsx
+++ b/apps/web/src/components/watchlist/watchlist-action-bar.tsx
@@ -121,14 +121,6 @@ export function WatchlistActionBar({
   }
 
   function handleToggleVisibility() {
-    if (!isPaidPlan && isPublic) {
-      upgrade.show(t({
-        id: "upgrade.reason.makePrivate",
-        comment: "Reason shown in upgrade modal when trying to make watchlist private",
-        message: "Private watchlists are a paid feature. Upgrade to hide your watchlists from others.",
-      }));
-      return;
-    }
     const next = !isPublic;
     setIsPublic(next);
     updateWatchlist({ watchlistId, isPublic: next });
@@ -178,8 +170,6 @@ export function WatchlistActionBar({
                     : t({ id: "watchlists.actions.makePublic", comment: "Make watchlist public tooltip", message: "Make public" })
                 }
                 onClick={handleToggleVisibility}
-                disabled={!isPaidPlan && isPublic}
-                warning={!isPaidPlan && isPublic}
               >
                 {isPublic ? <Globe size={16} aria-hidden="true" /> : <Lock size={16} aria-hidden="true" />}
               </ActionButton>

--- a/apps/web/src/components/watchlist/watchlist-tip-banner.tsx
+++ b/apps/web/src/components/watchlist/watchlist-tip-banner.tsx
@@ -39,7 +39,7 @@ export function WatchlistTipBanner({ aboveBottomBar }: { aboveBottomBar?: boolea
 
   return (
     <div className={aboveBottomBar
-      ? "fixed bottom-[52px] left-0 right-0 z-50 border-t border-info-border bg-info-bg dark:bg-[rgba(147,187,253,0.15)] backdrop-blur-sm md:fixed md:top-12 md:bottom-auto md:z-40 md:border-b md:border-t-0"
+      ? "fixed bottom-14 left-0 right-0 z-50 border-t border-info-border bg-info-bg dark:bg-[rgba(147,187,253,0.15)] backdrop-blur-sm md:static md:z-auto md:border-b md:border-t-0"
       : "border-b border-info-border bg-info-bg dark:bg-[rgba(147,187,253,0.15)] backdrop-blur-sm"
     }>
       <div className="mx-auto flex max-w-[1200px] flex-col gap-2 px-4 py-2 text-sm text-info sm:flex-row sm:items-center sm:gap-3">

--- a/apps/web/src/db/__tests__/watchlist-privacy-interview-migration.test.ts
+++ b/apps/web/src/db/__tests__/watchlist-privacy-interview-migration.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+import { getTableColumns } from "drizzle-orm";
+
+import { watchlist } from "@/db/schema";
+
+const migrationPath = join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "drizzle",
+  "0081_private_watchlists_and_general_interviews.sql",
+);
+const migrationSql = readFileSync(migrationPath, "utf8");
+
+describe("0081 private-watchlist and general-interview migration", () => {
+  it("aligns the database interview CHECK with the general UI option", () => {
+    expect(migrationSql).toMatch(
+      /ADD CONSTRAINT application_interview_type_check[\s\S]*?'interview'/,
+    );
+  });
+
+  it("makes private the database and Drizzle default", () => {
+    expect(migrationSql).toMatch(
+      /ALTER TABLE watchlist ALTER COLUMN is_public SET DEFAULT false/,
+    );
+    expect(getTableColumns(watchlist).isPublic.default).toBe(false);
+  });
+
+  it("is registered in drizzle's migration journal", () => {
+    const journalPath = join(
+      __dirname,
+      "..",
+      "..",
+      "..",
+      "drizzle",
+      "meta",
+      "_journal.json",
+    );
+    const journal = JSON.parse(readFileSync(journalPath, "utf8")) as {
+      entries: { tag: string }[];
+    };
+    expect(journal.entries.map((entry) => entry.tag)).toContain(
+      "0081_private_watchlists_and_general_interviews",
+    );
+  });
+});

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -784,7 +784,7 @@ export const watchlist = pgTable(
     slug: text("slug").notNull(),
     title: text("title").notNull(),
     description: text("description"),
-    isPublic: boolean("is_public").default(true).notNull(),
+    isPublic: boolean("is_public").default(false).notNull(),
     alertsEnabled: boolean("alerts_enabled").default(false).notNull(),
     filters: jsonb("filters").default({}).notNull(),
     sourceWatchlistId: uuid("source_watchlist_id").references((): AnyPgColumn => watchlist.id, {

--- a/apps/web/src/lib/__tests__/action-error-messages.test.ts
+++ b/apps/web/src/lib/__tests__/action-error-messages.test.ts
@@ -1,4 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@lingui/core/macro", () => ({
+  msg: (descriptor: unknown) => descriptor,
+}));
+
 import { translateActionError, type ActionErrorCode } from "@/lib/action-error-messages";
 
 const t = ((descriptor: { message?: string; id?: string }) =>

--- a/apps/web/src/lib/__tests__/auth-return.test.ts
+++ b/apps/web/src/lib/__tests__/auth-return.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  localizeAuthReturnPath,
+  normalizeAuthReturnPath,
+  withAuthReturnPath,
+} from "../auth-return";
+
+describe("auth return paths", () => {
+  it("preserves a same-origin path, query, and selected job hash", () => {
+    const path = "/en/company/acme?q=safety&show=post-1#details";
+    expect(normalizeAuthReturnPath(path)).toBe(path);
+    expect(withAuthReturnPath("/en/sign-in", path)).toBe(
+      "/en/sign-in?next=%2Fen%2Fcompany%2Facme%3Fq%3Dsafety%26show%3Dpost-1%23details",
+    );
+  });
+
+  it.each([
+    "https://example.com/steal",
+    "//example.com/steal",
+    "/\\example.com/steal",
+    "javascript:alert(1)",
+  ])("rejects unsafe redirect target %s", (target) => {
+    expect(normalizeAuthReturnPath(target)).toBeNull();
+  });
+
+  it("updates only a supported locale prefix", () => {
+    expect(localizeAuthReturnPath("/en/company/acme?show=1", "de")).toBe(
+      "/de/company/acme?show=1",
+    );
+    expect(localizeAuthReturnPath("/company/acme", "de")).toBe("/company/acme");
+  });
+});

--- a/apps/web/src/lib/__tests__/db-conflict.test.ts
+++ b/apps/web/src/lib/__tests__/db-conflict.test.ts
@@ -40,6 +40,24 @@ describe("isUniqueViolation", () => {
     expect(isUniqueViolation(e, "idx_sj_user_posting")).toBe(false);
   });
 
+  it("matches the postgres error nested inside Drizzle's query-error cause", () => {
+    const cause = new Error(
+      'duplicate key value violates unique constraint "idx_sj_user_posting"',
+    ) as Error & { code: string; constraint_name: string };
+    cause.code = "23505";
+    cause.constraint_name = "idx_sj_user_posting";
+
+    const wrapper = new Error("Failed query", { cause });
+    expect(isUniqueViolation(wrapper, "idx_sj_user_posting")).toBe(true);
+    expect(isUniqueViolation(wrapper, "idx_fc_user_company")).toBe(false);
+  });
+
+  it("handles cyclic cause chains without looping", () => {
+    const wrapper = new Error("Failed query") as Error & { cause?: unknown };
+    wrapper.cause = wrapper;
+    expect(isUniqueViolation(wrapper, "idx_sj_user_posting")).toBe(false);
+  });
+
   it("rejects null / undefined / non-object errors", () => {
     expect(isUniqueViolation(null, "x")).toBe(false);
     expect(isUniqueViolation(undefined, "x")).toBe(false);

--- a/apps/web/src/lib/action-error-messages.ts
+++ b/apps/web/src/lib/action-error-messages.ts
@@ -1,4 +1,6 @@
 import type { useLingui } from "@lingui/react/macro";
+import { msg } from "@lingui/core/macro";
+import type { MessageDescriptor } from "@lingui/core";
 import type { BillingActionErrorCode } from "@/lib/actions/billing";
 import type { MyJobsActionErrorCode } from "@/lib/actions/my-jobs";
 import type { PreferencesActionErrorCode } from "@/lib/actions/preferences";
@@ -10,33 +12,22 @@ export type ActionErrorCode =
   | MyJobsActionErrorCode
   | PreferencesActionErrorCode;
 
+const actionErrorMessages = {
+  not_authenticated: msg({ id: "actions.error.notAuthenticated", comment: "Generic server-action error shown when a user is not logged in", message: "Please log in and try again." }),
+  not_found: msg({ id: "actions.error.notFound", comment: "Generic server-action error shown when an item cannot be found", message: "Not found." }),
+  payments_unavailable: msg({ id: "actions.error.paymentsUnavailable", comment: "Billing error when checkout is not configured yet", message: "Payments are not available yet." }),
+  billing_account_not_found: msg({ id: "actions.error.billingAccountNotFound", comment: "Billing error when the user has no billing account", message: "No billing account found." }),
+  billing_portal_unavailable: msg({ id: "actions.error.billingPortalUnavailable", comment: "Billing error when the portal is not configured yet", message: "Billing portal is not available yet." }),
+  password_set_failed: msg({ id: "actions.error.passwordSetFailed", comment: "Generic error when setting an account password fails", message: "Failed to set password." }),
+  username_length: msg({ id: "actions.error.usernameLength", comment: "Username validation error for length", message: "Username must be 3-30 characters." }),
+  username_invalid_characters: msg({ id: "actions.error.usernameInvalidCharacters", comment: "Username validation error for unsupported characters", message: "Username can only use lowercase letters, numbers, and hyphens, and cannot start or end with a hyphen." }),
+  username_reserved: msg({ id: "actions.error.usernameReserved", comment: "Username validation error when a reserved username is requested", message: "This username is reserved." }),
+  username_update_failed: msg({ id: "actions.error.usernameUpdateFailed", comment: "Generic error when updating an account username fails", message: "Could not update username." }),
+  user_not_found: msg({ id: "actions.error.userNotFound", comment: "Generic account error when the current user row is missing", message: "User not found." }),
+  invalid_status_transition: msg({ id: "actions.error.invalidStatusTransition", comment: "My Jobs error when an application status transition is not allowed", message: "That status change is not allowed." }),
+  interview_round_failed: msg({ id: "actions.error.interviewRoundFailed", comment: "My Jobs error when assigning an interview round fails", message: "Could not assign interview round." }),
+} satisfies Record<ActionErrorCode, MessageDescriptor>;
+
 export function translateActionError(t: TFn, code: ActionErrorCode): string {
-  switch (code) {
-    case "not_authenticated":
-      return t({ id: "actions.error.notAuthenticated", comment: "Generic server-action error shown when a user is not logged in", message: "Please log in and try again." });
-    case "not_found":
-      return t({ id: "actions.error.notFound", comment: "Generic server-action error shown when an item cannot be found", message: "Not found." });
-    case "payments_unavailable":
-      return t({ id: "actions.error.paymentsUnavailable", comment: "Billing error when checkout is not configured yet", message: "Payments are not available yet." });
-    case "billing_account_not_found":
-      return t({ id: "actions.error.billingAccountNotFound", comment: "Billing error when the user has no billing account", message: "No billing account found." });
-    case "billing_portal_unavailable":
-      return t({ id: "actions.error.billingPortalUnavailable", comment: "Billing error when the portal is not configured yet", message: "Billing portal is not available yet." });
-    case "password_set_failed":
-      return t({ id: "actions.error.passwordSetFailed", comment: "Generic error when setting an account password fails", message: "Failed to set password." });
-    case "username_length":
-      return t({ id: "actions.error.usernameLength", comment: "Username validation error for length", message: "Username must be 3-30 characters." });
-    case "username_invalid_characters":
-      return t({ id: "actions.error.usernameInvalidCharacters", comment: "Username validation error for unsupported characters", message: "Username can only use lowercase letters, numbers, and hyphens, and cannot start or end with a hyphen." });
-    case "username_reserved":
-      return t({ id: "actions.error.usernameReserved", comment: "Username validation error when a reserved username is requested", message: "This username is reserved." });
-    case "username_update_failed":
-      return t({ id: "actions.error.usernameUpdateFailed", comment: "Generic error when updating an account username fails", message: "Could not update username." });
-    case "user_not_found":
-      return t({ id: "actions.error.userNotFound", comment: "Generic account error when the current user row is missing", message: "User not found." });
-    case "invalid_status_transition":
-      return t({ id: "actions.error.invalidStatusTransition", comment: "My Jobs error when an application status transition is not allowed", message: "That status change is not allowed." });
-    case "interview_round_failed":
-      return t({ id: "actions.error.interviewRoundFailed", comment: "My Jobs error when assigning an interview round fails", message: "Could not assign interview round." });
-  }
+  return t(actionErrorMessages[code]);
 }

--- a/apps/web/src/lib/actions/__tests__/locations-macro.test.ts
+++ b/apps/web/src/lib/actions/__tests__/locations-macro.test.ts
@@ -103,6 +103,9 @@ describe("getGlobalLocationsGrouped — Regions cluster (#2940)", () => {
           {
             field_name: "location_ids",
             counts: [
+              // The broad facet can include macro ancestors as well as the
+              // country/city rows. It must not duplicate EU under "Other".
+              { value: "4", count: 146 },
               { value: "100", count: 50 },
               { value: "200", count: 25 },
             ],
@@ -145,6 +148,10 @@ describe("getGlobalLocationsGrouped — Regions cluster (#2940)", () => {
     // Country tier still works
     expect(out.countries.length).toBeGreaterThan(0);
     expect(out.countries[0].countryName).toBe("Germany");
+    const hierarchyLocationIds = out.countries.flatMap((country) =>
+      country.regions.flatMap((region) => region.locations.map((location) => location.id)),
+    );
+    expect(hierarchyLocationIds).not.toContain(4);
   });
 
   /**

--- a/apps/web/src/lib/auth-return.ts
+++ b/apps/web/src/lib/auth-return.ts
@@ -1,0 +1,29 @@
+const LOCALE_PREFIX = /^\/(?:en|de|fr|it)(?=\/|$)/;
+
+/** Accept only same-origin path/query/hash values for post-auth navigation. */
+export function normalizeAuthReturnPath(value: string | null | undefined): string | null {
+  if (!value || !value.startsWith("/") || value.startsWith("//") || value.includes("\\")) {
+    return null;
+  }
+
+  try {
+    const url = new URL(value, "https://jseek.invalid");
+    if (url.origin !== "https://jseek.invalid") return null;
+    return `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return null;
+  }
+}
+
+export function withAuthReturnPath(authPath: string, returnPath: string | null): string {
+  if (!returnPath) return authPath;
+  const params = new URLSearchParams({ next: returnPath });
+  return `${authPath}?${params.toString()}`;
+}
+
+/** Keep the requested surface while honoring the user's stored UI locale. */
+export function localizeAuthReturnPath(returnPath: string, locale: string): string {
+  return LOCALE_PREFIX.test(returnPath)
+    ? returnPath.replace(LOCALE_PREFIX, `/${locale}`)
+    : returnPath;
+}

--- a/apps/web/src/lib/db-conflict.ts
+++ b/apps/web/src/lib/db-conflict.ts
@@ -34,14 +34,39 @@ export function isUniqueViolation(
   err: unknown,
   constraintName: string,
 ): boolean {
-  if (!err || typeof err !== "object") return false;
-  const e = err as { code?: unknown; constraint_name?: unknown };
-  if (e.code !== "23505") return false;
-  if (typeof e.constraint_name === "string") {
-    return e.constraint_name === constraintName;
+  // Drizzle wraps postgres.js errors in a query error whose `cause`
+  // carries the SQLSTATE and constraint metadata. Production therefore
+  // sees `{ cause: { code: "23505", constraint_name: ... } }`, while the
+  // unit-test and direct-driver shapes expose those fields at the top
+  // level. Walk a short, cycle-safe cause chain so both shapes are
+  // recognized without treating unrelated nested errors as conflicts.
+  let current: unknown = err;
+  const seen = new Set<object>();
+
+  for (let depth = 0; depth < 5; depth++) {
+    if (!current || typeof current !== "object" || seen.has(current)) {
+      return false;
+    }
+    seen.add(current);
+
+    const e = current as {
+      code?: unknown;
+      constraint_name?: unknown;
+      message?: unknown;
+      cause?: unknown;
+    };
+
+    if (e.code === "23505") {
+      if (typeof e.constraint_name === "string") {
+        return e.constraint_name === constraintName;
+      }
+      if (typeof e.message === "string" && e.message.includes(constraintName)) {
+        return true;
+      }
+    }
+
+    current = e.cause;
   }
-  const message = (err as { message?: unknown }).message;
-  return (
-    typeof message === "string" && message.includes(constraintName)
-  );
+
+  return false;
 }

--- a/apps/web/src/lib/services/locations.ts
+++ b/apps/web/src/lib/services/locations.ts
@@ -798,6 +798,11 @@ async function _fetchGlobalLocationsGrouped(
       const loc = hierarchy.get(locationId);
       if (!loc) continue;
 
+      // Macro regions render in the dedicated Regions cluster above. They
+      // have no country parent, so letting them fall through the hierarchy
+      // builder also adds them to the synthetic "Other" country group.
+      if (loc.type === "macro") continue;
+
       // Find region and country for this location
       let regionId: number | null = null;
       let countryId: number | null = null;

--- a/apps/web/src/lib/services/watchlists.ts
+++ b/apps/web/src/lib/services/watchlists.ts
@@ -242,7 +242,7 @@ export async function createWatchlist(params: {
           slug: candidate,
           title: params.title,
           description: params.description ?? null,
-          isPublic: params.isPublic ?? true,
+          isPublic: params.isPublic ?? false,
           filters: { anyCompany: true, ...params.filters },
         })
         .returning({ id: watchlist.id });
@@ -264,7 +264,7 @@ export async function createWatchlist(params: {
   // request scope — calling notifyIndexNow from a detached .then()
   // chain (the previous shape) silently broke because next/server's
   // after() requires a live request context to attach work.
-  const isPublic = params.isPublic ?? true;
+  const isPublic = params.isPublic ?? false;
   const mergedFilters = { anyCompany: true, ...params.filters };
   const trivial = isTrivialWatchlist(mergedFilters, params.companyIds.length);
 
@@ -552,7 +552,7 @@ export async function copyWatchlist(
           slug: candidate,
           title: source.title,
           description: source.description,
-          isPublic: true,
+          isPublic: false,
           filters: sourceFilters,
           sourceWatchlistId: watchlistId,
         })
@@ -583,7 +583,7 @@ export async function copyWatchlist(
     slug_before: null,
     slug_after: slug,
     is_public_before: null,
-    is_public_after: true,
+    is_public_after: false,
     company_count_delta: companies.length,
   });
 
@@ -591,7 +591,7 @@ export async function copyWatchlist(
   // in the request scope; the previous detached .then() pattern broke
   // notifyIndexNow because the inner after() lost its request context
   // by the time the chain resolved.
-  // Cache invalidation runs unconditionally (even if trivial) — same
+  // Cache invalidation runs unconditionally (even if private/trivial) — same
   // reasoning as `createWatchlist`: a stale null-detail render in the
   // page-level cache needs busting whether or not the watchlist will
   // be sitemap-indexed.
@@ -603,24 +603,8 @@ export async function copyWatchlist(
     }
   });
 
-  if (!isTrivialWatchlist(sourceFilters, companies.length)) {
-    // 1. Upsert the new copy (copies are always public) — unless trivial.
-    after(async () => {
-      try {
-        await _reindexPublicWatchlist(userId, {
-          id: row.id,
-          slug,
-          title: source.title,
-          description: source.description,
-          company_count: companies.length,
-          filters: sourceFilters,
-          logLabel: "copyWatchlist",
-        });
-      } catch (err) {
-        console.error("[copyWatchlist] Typesense upsert hook failed", err);
-      }
-    });
-  }
+  // Copies now default to private, so they must not enter Typesense,
+  // sitemaps, or IndexNow until the owner explicitly makes them public.
 
   // 2. Update source watchlist's mirror_count (increment). No IndexNow
   // here — the source URL hasn't changed visible content.


### PR DESCRIPTION
## Summary

Resolves the confirmed, actionable findings from the production UX audit:

- keeps cookie/watchlist banners clear of navigation and makes the Italian mobile bar readable
- removes duplicate macro-region filters, preserves company-scoped searches, and restores post-login Save context
- replaces permanent watchlist loading with bounded retry/error recovery
- makes new and copied watchlists private by default while allowing privacy controls on every plan
- fixes Add interview by aligning the production database constraint with the existing general interview type
- treats nested Drizzle/Postgres unique violations as idempotent save/star conflicts
- replaces the unreadable mobile Sankey chart with an accessible funnel summary and prevents heatmap month-label collisions
- adds explicit Suspense boundaries for request-aware auth/company subtrees under Cache Components
- repairs Lingui extraction by normalizing dynamic placeholders and making action-error descriptors statically extractable

## Root causes

The findings were a mix of stale defaults/constraints, fixed-position mobile chrome that did not share a height contract, navigation fallbacks that ignored page-local search actions, server-action errors wrapped in Drizzle's `cause` chain, and request-aware client subtrees lacking explicit PPR boundaries. The catalog failure encountered during remediation came from multiple runtime interpolation names for the same message IDs and descriptors hidden inside a switch.

## Validation

- `pnpm test` — 182 files, 1,410 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `bash scripts/check-i18n-coverage.sh`
- `pnpm build` — Next.js 16.2.11, 183/183 static pages generated
- local built company-page smoke test confirmed the scoped search and resume-mismatch fix

Closes #5893
Closes #5894
Closes #5896
Closes #5897
Closes #5898
Closes #5900
Closes #5901
Closes #5902
Closes #5903
Closes #5904
Closes #5905
Closes #5906
Closes #5911
Closes #5931
