### PR TITLE
Resolve follow-up production UX issues

### DIFF
--- a/apps/web/app/[lang]/(app)/companies/request/__tests__/company-request-page-form.test.tsx
+++ b/apps/web/app/[lang]/(app)/companies/request/__tests__/company-request-page-form.test.tsx
@@ -50,6 +50,12 @@ afterEach(() => {
 });
 
 describe("CompanyRequestPageForm", () => {
+  it("gives the free-form input a persistent, descriptive label", () => {
+    render(<CompanyRequestPageForm locale="en" />);
+
+    expect(screen.getByLabelText("Company name or careers-page URL")).toBeTruthy();
+  });
+
   it("renders the input with `defaultName` when no website is provided", () => {
     render(<CompanyRequestPageForm locale="en" defaultName="Anthropic" />);
 

--- a/apps/web/app/[lang]/(app)/companies/request/company-request-page-form.tsx
+++ b/apps/web/app/[lang]/(app)/companies/request/company-request-page-form.tsx
@@ -76,6 +76,7 @@ export function CompanyRequestPageForm({
   }, [state]);
 
   const errorMessage = state?.errorCode ? t(errorMessages[state.errorCode]) : "";
+  const inputId = useId();
   const errorId = useId();
 
   const initialValue = pickDefaultValue(defaultName, defaultWebsite);
@@ -109,7 +110,19 @@ export function CompanyRequestPageForm({
       >
         <input type="hidden" name="locale" value={locale} />
         <div className="flex-1">
+          <label
+            htmlFor={inputId}
+            className="mb-1.5 block text-xs font-medium text-foreground"
+          >
+            <Trans
+              id="companies.request.inputLabel"
+              comment="Label for the company name or careers-page URL request field"
+            >
+              Company name or careers-page URL
+            </Trans>
+          </label>
           <input
+            id={inputId}
             name="input"
             type="text"
             required

--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-route-suspense.test.ts
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-route-suspense.test.ts
@@ -13,4 +13,16 @@ describe("company route partial prerendering", () => {
     expect(source).toContain("<Suspense fallback={<CompanySkeleton />}>");
     expect(source).toContain("<CompanyContent");
   });
+
+  it("shares one cache-stable company snapshot between metadata and the page body", () => {
+    const source = readFileSync(
+      "app/[lang]/(app)/company/[slug]/page.tsx",
+      "utf8",
+    );
+
+    expect(source).toContain("async function getCompanyRouteSnapshot");
+    expect(source).toContain('return fetchCompanyPageDefaults({ slug, locale });');
+    expect(source.match(/getCompanyRouteSnapshot\(slug, locale\)/g)).toHaveLength(2);
+    expect(source).not.toContain("getCompanyBySlug(slug, locale)");
+  });
 });

--- a/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
@@ -4,8 +4,8 @@ import { cacheLife, cacheTag } from "next/cache";
 import { isLocale, defaultLocale, loadCatalog, initI18nForPage, ogLocale, ogAlternateLocales } from "@/lib/i18n";
 import { companyCacheTag } from "@/lib/cache-tags";
 import { CACHE_TTL_DETAIL } from "@/lib/cache-ttl";
-import { getCompanyBySlug } from "@/lib/actions/company";
 import { fetchCompanyPageDefaults } from "@/lib/actions/company-page-data";
+import type { Locale } from "@/lib/i18n";
 import { siteConfig } from "@/content/config";
 import { buildAlternates } from "@/lib/seo";
 import { CompanyHead } from "./company-head";
@@ -17,21 +17,37 @@ type Props = {
   params: Promise<{ lang: string; slug: string }>;
 };
 
+/**
+ * Keep the dynamic route's metadata and body on one cache-stable data
+ * snapshot. Next.js currently has a Cache Components/PPR resume defect when
+ * async metadata and the page body independently resolve the same dynamic
+ * route data: the prerendered metadata wrapper can disagree with the runtime
+ * metadata boundary and React falls back to a client render. See #5911 and
+ * vercel/next.js#93401.
+ */
+async function getCompanyRouteSnapshot(slug: string, locale: Locale) {
+  "use cache";
+  cacheLife({ revalidate: CACHE_TTL_DETAIL });
+  cacheTag(companyCacheTag(slug));
+  return fetchCompanyPageDefaults({ slug, locale });
+}
+
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   "use cache";
   cacheLife({ revalidate: CACHE_TTL_DETAIL });
   const { slug, lang } = await params;
   cacheTag(companyCacheTag(slug));
   const locale = isLocale(lang) ? lang : defaultLocale;
-  const [company, { i18n }] = await Promise.all([
-    getCompanyBySlug(slug, locale),
+  const [snapshot, { i18n }] = await Promise.all([
+    getCompanyRouteSnapshot(slug, locale),
     loadCatalog(locale),
   ]);
   // No company = ghost slug (deleted, never existed, typo). Bare `{}`
   // would let `[lang]/layout.tsx`'s `metadata.title.default` ("Job
   // Seek") cascade and leave the URL indexable. Tag explicitly as
   // `noindex,follow` to mirror the watchlist null-detail handling.
-  if (!company) return { robots: { index: false, follow: true } };
+  if (!snapshot) return { robots: { index: false, follow: true } };
+  const { company } = snapshot;
 
   const title = i18n._({
     id: "company.meta.title",
@@ -129,7 +145,7 @@ export default async function CompanyPageRoute({ params }: Props) {
   // ISR-eligible — the client component re-fetches the personalised
   // variant via ``fetchCompanyPageData`` when filters or auth-related
   // hint cookies are present.
-  const initialData = await fetchCompanyPageDefaults({ slug, locale });
+  const initialData = await getCompanyRouteSnapshot(slug, locale);
   if (!initialData) return <CompanyNotFound />;
   const { company } = initialData;
 

--- a/apps/web/app/[lang]/(app)/my-jobs/stats/__tests__/stats-page-a11y.test.tsx
+++ b/apps/web/app/[lang]/(app)/my-jobs/stats/__tests__/stats-page-a11y.test.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { StatsPage } from "../stats-page";
+
+vi.mock("@lingui/react/macro", () => ({
+  Trans: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/lib/useLocalePath", () => ({
+  useLocalePath: () => (path: string) => path,
+}));
+
+vi.mock("@/components/BackLink", () => ({
+  BackLink: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/components/my-jobs/sankey-funnel-lazy", () => ({
+  SankeyFunnel: () => <div />,
+}));
+
+vi.mock("@/components/my-jobs/activity-heatmap", () => ({
+  ActivityHeatmap: () => <div />,
+}));
+
+vi.mock("@/lib/actions/my-jobs-stats", () => ({
+  getMyJobsStats: vi.fn(),
+}));
+
+vi.mock("@/lib/viewer-tz", () => ({
+  getViewerTz: () => "UTC",
+}));
+
+const initial = {
+  funnel: {
+    saved: 0,
+    applied: 0,
+    offered: 0,
+    offeredWithoutInterview: 0,
+    rejectedAtSaved: 0,
+    rejectedAtApplied: 0,
+    noResponseAtSaved: 0,
+    noResponseAtApplied: 0,
+    interviewRounds: [],
+    rejectedAtRound: [],
+    noResponseAtRound: [],
+    offeredAtRound: [],
+  },
+  activity: [],
+  activityTotal: 0,
+};
+
+describe("StatsPage period filter", () => {
+  it("gives both date boundaries visible, programmatic labels", () => {
+    render(<StatsPage initial={initial} />);
+
+    expect(screen.getByLabelText("From").getAttribute("type")).toBe("date");
+    expect(screen.getByLabelText("To").getAttribute("type")).toBe("date");
+  });
+});

--- a/apps/web/app/[lang]/(app)/my-jobs/stats/stats-page.tsx
+++ b/apps/web/app/[lang]/(app)/my-jobs/stats/stats-page.tsx
@@ -61,25 +61,34 @@ export function StatsPage({ initial }: { initial: StatsData }) {
           <span className="text-xs font-semibold">
             <Trans id="myJobs.stats.period" comment="Period filter heading">Period</Trans>
           </span>
-          <input
-            type="date"
-            value={from}
-            onChange={(e) => {
-              setFrom(e.target.value);
-              handleFilter(e.target.value, to);
-            }}
-            className="rounded-md border border-border-soft bg-surface px-2.5 py-1.5 text-xs"
-          />
-          <span className="text-xs text-muted">–</span>
-          <input
-            type="date"
-            value={to}
-            onChange={(e) => {
-              setTo(e.target.value);
-              handleFilter(from, e.target.value);
-            }}
-            className="rounded-md border border-border-soft bg-surface px-2.5 py-1.5 text-xs"
-          />
+          <label className="flex items-center gap-1.5 text-xs text-muted">
+            <span>
+              <Trans id="myJobs.stats.fromDate" comment="Label for the start date in the stats period filter">From</Trans>
+            </span>
+            <input
+              type="date"
+              value={from}
+              onChange={(e) => {
+                setFrom(e.target.value);
+                handleFilter(e.target.value, to);
+              }}
+              className="rounded-md border border-border-soft bg-surface px-2.5 py-1.5 text-xs text-foreground"
+            />
+          </label>
+          <label className="flex items-center gap-1.5 text-xs text-muted">
+            <span>
+              <Trans id="myJobs.stats.toDate" comment="Label for the end date in the stats period filter">To</Trans>
+            </span>
+            <input
+              type="date"
+              value={to}
+              onChange={(e) => {
+                setTo(e.target.value);
+                handleFilter(from, e.target.value);
+              }}
+              className="rounded-md border border-border-soft bg-surface px-2.5 py-1.5 text-xs text-foreground"
+            />
+          </label>
           {(from || to) && (
             <button
               onClick={() => {

--- a/apps/web/app/[lang]/(app)/watchlists/__tests__/watchlists-loader.test.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/__tests__/watchlists-loader.test.tsx
@@ -1,83 +1,99 @@
+import { readFileSync } from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import "@/test-utils/lingui-mock";
 
 const mocks = vi.hoisted(() => ({
   load: vi.fn(),
-  session: {
-    user: { id: "user-1", username: "alice" } as {
-      id: string;
-      username: string | null;
-    } | null,
-    isPending: false,
-  },
+  getSession: vi.fn(),
 }));
 
-vi.mock("@/lib/actions/watchlists", () => ({
+vi.mock("@/lib/services/watchlists", () => ({
   getUserWatchlistsWithLimit: (...args: unknown[]) => mocks.load(...args),
 }));
 
-vi.mock("@/components/providers/SessionProvider", () => ({
-  useSession: () => mocks.session,
+vi.mock("@/lib/sessionCache", () => ({
+  getSession: () => mocks.getSession(),
 }));
 
 vi.mock("../watchlists-page", () => ({
   WatchlistsPage: ({
     initialWatchlists,
     username,
+    limitReached,
   }: {
     initialWatchlists: unknown[];
     username: string | null;
+    limitReached: boolean;
   }) => (
     <div
       data-testid="watchlists-page"
       data-count={initialWatchlists.length}
       data-username={username ?? ""}
+      data-limit-reached={String(limitReached)}
     />
   ),
 }));
 
 import { WatchlistsLoader } from "../watchlists-loader";
 
-describe("WatchlistsLoader recovery (#5896)", () => {
+describe("WatchlistsLoader server read (#5896)", () => {
   beforeEach(() => {
+    vi.restoreAllMocks();
     mocks.load.mockReset();
-    mocks.session.user = { id: "user-1", username: "alice" };
-    mocks.session.isPending = false;
+    mocks.getSession.mockReset();
+    mocks.getSession.mockResolvedValue({ user: { username: "alice" } });
   });
 
-  it("retries one transient failure and renders the recovered data", async () => {
-    mocks.load
-      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
-      .mockResolvedValueOnce({
-        watchlists: [{ id: "wl-1" }],
-        limitReached: false,
-      });
+  it("passes the server-loaded overview to the interactive page", async () => {
+    mocks.load.mockResolvedValue({
+      watchlists: [{ id: "wl-1" }],
+      limitReached: false,
+    });
 
-    render(<WatchlistsLoader locale="en" />);
+    render(await WatchlistsLoader({ locale: "en" }));
 
-    const page = await screen.findByTestId("watchlists-page");
+    const page = screen.getByTestId("watchlists-page");
     expect(page.getAttribute("data-count")).toBe("1");
     expect(page.getAttribute("data-username")).toBe("alice");
-    expect(mocks.load).toHaveBeenCalledTimes(2);
+    expect(page.getAttribute("data-limit-reached")).toBe("false");
+    expect(mocks.load).toHaveBeenCalledOnce();
+    expect(mocks.load).toHaveBeenCalledWith("en");
   });
 
-  it("replaces the permanent spinner with an error and a working retry", async () => {
-    mocks.load
-      .mockRejectedValueOnce(new Error("cold failure"))
-      .mockRejectedValueOnce(new Error("retry failure"));
+  it("renders the anonymous overview without a username", async () => {
+    mocks.getSession.mockResolvedValue(null);
+    mocks.load.mockResolvedValue({ watchlists: [], limitReached: true });
 
-    render(<WatchlistsLoader locale="en" />);
+    render(await WatchlistsLoader({ locale: "de" }));
 
-    const retry = await screen.findByRole("button", { name: /try again/i });
+    const page = screen.getByTestId("watchlists-page");
+    expect(page.getAttribute("data-username")).toBe("");
+    expect(page.getAttribute("data-limit-reached")).toBe("true");
+  });
+
+  it("renders a localized hard-reload recovery link when the server read fails", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.load.mockRejectedValue(new Error("database unavailable"));
+
+    render(await WatchlistsLoader({ locale: "fr" }));
+
     expect(screen.getByText(/couldn't load your watchlists/i)).toBeTruthy();
+    expect(screen.getByRole("link", { name: /try again/i }).getAttribute("href")).toBe(
+      "/fr/watchlists",
+    );
+    expect(mocks.load).toHaveBeenCalledOnce();
+  });
+});
 
-    mocks.load.mockResolvedValueOnce({ watchlists: [], limitReached: false });
-    fireEvent.click(retry);
+describe("Watchlists route partial prerendering", () => {
+  it("places the session-scoped server loader behind Suspense", () => {
+    const source = readFileSync(
+      "app/[lang]/(app)/watchlists/page.tsx",
+      "utf8",
+    );
 
-    await waitFor(() => {
-      expect(screen.getByTestId("watchlists-page")).toBeTruthy();
-    });
-    expect(mocks.load).toHaveBeenCalledTimes(3);
+    expect(source).toContain("<Suspense fallback={<WatchlistsFallback />}>");
+    expect(source).toContain("<WatchlistsLoader locale={locale} />");
   });
 });

--- a/apps/web/app/[lang]/(app)/watchlists/page.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { isLocale, defaultLocale } from "@/lib/i18n";
 import { WatchlistsLoader } from "./watchlists-loader";
 
@@ -8,5 +9,17 @@ type Props = {
 export default async function WatchlistsRoute({ params }: Props) {
   const { lang } = await params;
   const locale = isLocale(lang) ? lang : defaultLocale;
-  return <WatchlistsLoader locale={locale} />;
+  return (
+    <Suspense fallback={<WatchlistsFallback />}>
+      <WatchlistsLoader locale={locale} />
+    </Suspense>
+  );
+}
+
+function WatchlistsFallback() {
+  return (
+    <div className="flex items-center justify-center py-24">
+      <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary" />
+    </div>
+  );
 }

--- a/apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx
@@ -1,89 +1,48 @@
-"use client";
-
-import { useEffect, useState } from "react";
 import { RefreshCw } from "lucide-react";
 import { Trans } from "@lingui/react/macro";
-import { getUserWatchlistsWithLimit, type WatchlistSummary } from "@/lib/actions/watchlists";
-import { useSession } from "@/components/providers/SessionProvider";
+import { getSession } from "@/lib/sessionCache";
+import { getUserWatchlistsWithLimit } from "@/lib/services/watchlists";
 import { WatchlistsPage } from "./watchlists-page";
-
-type WatchlistsData = {
-  watchlists: WatchlistSummary[];
-  username: string | null;
-  limitReached: boolean;
-};
 
 const WATCHLIST_LOAD_TIMEOUT_MS = 8_000;
 
-async function loadWatchlistsWithRetry(locale: string) {
-  async function attempt() {
-    let timeoutId: ReturnType<typeof setTimeout> | undefined;
-    try {
-      return await Promise.race([
-        getUserWatchlistsWithLimit(locale),
-        new Promise<never>((_, reject) => {
-          timeoutId = setTimeout(
-            () => reject(new Error("Watchlists request timed out")),
-            WATCHLIST_LOAD_TIMEOUT_MS,
-          );
-        }),
-      ]);
-    } finally {
-      if (timeoutId) clearTimeout(timeoutId);
-    }
-  }
-
+async function loadWatchlists(locale: string) {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
   try {
-    return await attempt();
-  } catch (err) {
-    console.warn("[watchlists] initial load failed, retrying once", err);
-    await new Promise((resolve) => setTimeout(resolve, 250));
-    return attempt();
+    return await Promise.race([
+      getUserWatchlistsWithLimit(locale),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error("Watchlists request timed out")),
+          WATCHLIST_LOAD_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
   }
 }
 
-export function WatchlistsLoader({ locale }: { locale: string }) {
-  const { user, isPending } = useSession();
-  const [data, setData] = useState<WatchlistsData | null>(null);
-  const [loadFailed, setLoadFailed] = useState(false);
-  const [retryKey, setRetryKey] = useState(0);
-  const userId = user?.id;
-  const username = user?.username ?? null;
+/**
+ * Initial watchlist data is a read, so load it in the server tree instead
+ * of calling a Server Action from a client effect. The latter left the
+ * action promise unsettled in production even though Vercel recorded 200
+ * responses, keeping this core page unusable after hydration (#5896).
+ */
+export async function WatchlistsLoader({ locale }: { locale: string }) {
+  const session = await getSession();
 
-  useEffect(() => {
-    let cancelled = false;
-    if (isPending) return;
-    setLoadFailed(false);
-    setData(null);
-
-    if (!userId) {
-      setData({ watchlists: [], username: null, limitReached: true });
-      return;
-    }
-    // Issue #3036: previously hardcoded ``limitReached: false`` here,
-    // which left ``CreateWatchlistCard`` permanently enabled even for
-    // users at the plan limit. Server now returns both so the card
-    // surfaces its disabled state + upgrade modal correctly.
-    loadWatchlistsWithRetry(locale)
-      .then(({ watchlists, limitReached }) => {
-        if (cancelled) return;
-        setData({
-          watchlists,
-          username,
-          limitReached,
-        });
-      })
-      .catch((err) => {
-        console.error("[watchlists] load failed twice", err);
-        if (!cancelled) setLoadFailed(true);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [userId, username, isPending, locale, retryKey]);
-
-  if (loadFailed) {
+  try {
+    const { watchlists, limitReached } = await loadWatchlists(locale);
+    return (
+      <WatchlistsPage
+        initialWatchlists={watchlists}
+        username={session?.user.username ?? null}
+        limitReached={limitReached}
+      />
+    );
+  } catch (err) {
+    console.error("[watchlists] server load failed", err);
     return (
       <div className="flex flex-col items-center justify-center gap-3 py-24 text-center">
         <p className="text-sm font-medium">
@@ -91,33 +50,16 @@ export function WatchlistsLoader({ locale }: { locale: string }) {
             We couldn&apos;t load your watchlists.
           </Trans>
         </p>
-        <button
-          type="button"
-          onClick={() => setRetryKey((value) => value + 1)}
+        <a
+          href={`/${locale}/watchlists`}
           className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-border-soft px-3 py-2 text-sm font-medium transition-colors hover:bg-border-soft"
         >
           <RefreshCw size={14} aria-hidden="true" />
           <Trans id="watchlists.load.retry" comment="Button to retry loading the watchlists overview">
             Try again
           </Trans>
-        </button>
+        </a>
       </div>
     );
   }
-
-  if (!data) {
-    return (
-      <div className="flex items-center justify-center py-24">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-muted border-t-primary" />
-      </div>
-    );
-  }
-
-  return (
-    <WatchlistsPage
-      initialWatchlists={data.watchlists}
-      username={data.username}
-      limitReached={data.limitReached}
-    />
-  );
 }

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -5020,3 +5020,21 @@ msgstr "Deine Watchlists konnten nicht geladen werden."
 #: app/[lang]/(app)/watchlists/watchlists-loader.tsx
 msgid "watchlists.load.retry"
 msgstr "Erneut versuchen"
+
+#. Label for the company name or careers-page URL request field
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx
+msgid "companies.request.inputLabel"
+msgstr "Unternehmensname oder URL der Karriereseite"
+
+#. Label for the start date in the stats period filter
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx
+msgid "myJobs.stats.fromDate"
+msgstr "Von"
+
+#. Label for the end date in the stats period filter
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx
+msgid "myJobs.stats.toDate"
+msgstr "Bis"

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -5020,3 +5020,21 @@ msgstr "We couldn't load your watchlists."
 #: app/[lang]/(app)/watchlists/watchlists-loader.tsx
 msgid "watchlists.load.retry"
 msgstr "Try again"
+
+#. Label for the company name or careers-page URL request field
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx
+msgid "companies.request.inputLabel"
+msgstr "Company name or careers-page URL"
+
+#. Label for the start date in the stats period filter
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx
+msgid "myJobs.stats.fromDate"
+msgstr "From"
+
+#. Label for the end date in the stats period filter
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx
+msgid "myJobs.stats.toDate"
+msgstr "To"

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -5020,3 +5020,21 @@ msgstr "Impossible de charger vos listes de suivi."
 #: app/[lang]/(app)/watchlists/watchlists-loader.tsx
 msgid "watchlists.load.retry"
 msgstr "Réessayer"
+
+#. Label for the company name or careers-page URL request field
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx
+msgid "companies.request.inputLabel"
+msgstr "Nom de l’entreprise ou URL de la page Carrières"
+
+#. Label for the start date in the stats period filter
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx
+msgid "myJobs.stats.fromDate"
+msgstr "Du"
+
+#. Label for the end date in the stats period filter
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx
+msgid "myJobs.stats.toDate"
+msgstr "Au"

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -5020,3 +5020,21 @@ msgstr "Impossibile caricare le tue liste di osservazione."
 #: app/[lang]/(app)/watchlists/watchlists-loader.tsx
 msgid "watchlists.load.retry"
 msgstr "Riprova"
+
+#. Label for the company name or careers-page URL request field
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/companies/request/company-request-page-form.tsx
+msgid "companies.request.inputLabel"
+msgstr "Nome dell’azienda o URL della pagina Lavora con noi"
+
+#. Label for the start date in the stats period filter
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx
+msgid "myJobs.stats.fromDate"
+msgstr "Dal"
+
+#. Label for the end date in the stats period filter
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/my-jobs/stats/stats-page.tsx
+msgid "myJobs.stats.toDate"
+msgstr "Al"

--- a/apps/web/src/components/settings/GeneralSettings.tsx
+++ b/apps/web/src/components/settings/GeneralSettings.tsx
@@ -182,6 +182,7 @@ export function GeneralSettings({ savedJobLanguages, savedDisplayCurrency, saved
           {themeOptions.map((opt) => (
             <button
               key={opt.value}
+              aria-pressed={mounted && theme === opt.value}
               onClick={() => {
                 const now = new Date().toISOString();
                 setTheme(opt.value);
@@ -214,6 +215,7 @@ export function GeneralSettings({ savedJobLanguages, savedDisplayCurrency, saved
             return (
               <button
                 key={locale}
+                aria-pressed={isActive}
                 onClick={() => handleLocaleSwitch(locale)}
                 className={`flex items-center gap-2 rounded-md border px-4 py-2.5 text-sm transition-colors cursor-pointer ${
                   isActive
@@ -243,6 +245,7 @@ export function GeneralSettings({ savedJobLanguages, savedDisplayCurrency, saved
         <div className="flex flex-wrap gap-2">
           {/* All languages toggle */}
           <button
+            aria-pressed={isAllLanguages}
             onClick={handleSelectAllLanguages}
             className={`rounded-full border px-4 py-1 text-sm transition-colors cursor-pointer ${
               isAllLanguages
@@ -259,6 +262,7 @@ export function GeneralSettings({ savedJobLanguages, savedDisplayCurrency, saved
             return (
               <button
                 key={lang.code}
+                aria-pressed={active}
                 onClick={() => handleToggleLanguage(lang.code)}
                 className={`inline-flex cursor-pointer items-center gap-1.5 rounded-full px-3 py-1 text-sm transition-colors ${
                   active
@@ -279,6 +283,7 @@ export function GeneralSettings({ savedJobLanguages, savedDisplayCurrency, saved
             extraSelected.map((lang) => (
               <button
                 key={lang.code}
+                aria-pressed={true}
                 onClick={() => handleToggleLanguage(lang.code)}
                 className="inline-flex cursor-pointer items-center gap-1.5 rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary transition-colors"
               >

--- a/apps/web/src/components/settings/__tests__/GeneralSettings-locale-switch.test.tsx
+++ b/apps/web/src/components/settings/__tests__/GeneralSettings-locale-switch.test.tsx
@@ -117,6 +117,32 @@ afterEach(() => {
 import { GeneralSettings } from "../GeneralSettings";
 
 describe("GeneralSettings locale switch (#2988)", () => {
+  it("exposes selected theme, locale, and job-language states", () => {
+    act(() => {
+      render(
+        <GeneralSettings
+          savedJobLanguages={[]}
+          savedDisplayCurrency="EUR"
+          savedSalaryPeriod={null}
+          availableCurrencies={["EUR"]}
+          availableLanguages={[
+            { code: "en", count: 1000 },
+            { code: "de", count: 500 },
+          ]}
+          locale="en"
+        />,
+      );
+    });
+
+    expect(screen.getByRole("button", { name: "Dark" }).getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("button", { name: "Light" }).getAttribute("aria-pressed")).toBe("false");
+
+    const englishButtons = screen.getAllByRole("button", { name: /English/ });
+    expect(englishButtons[0]?.getAttribute("aria-pressed")).toBe("true");
+    expect(englishButtons[1]?.getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByRole("button", { name: "All languages" }).getAttribute("aria-pressed")).toBe("false");
+  });
+
   it("writes NEXT_LOCALE cookie and pushes new-locale URL on Deutsch click", async () => {
     const user = userEvent.setup();
     act(() => {

--- a/apps/web/src/components/watchlist/__tests__/watchlist-job-list-nested-buttons.test.tsx
+++ b/apps/web/src/components/watchlist/__tests__/watchlist-job-list-nested-buttons.test.tsx
@@ -184,6 +184,20 @@ describe("WatchlistJobList row a11y (issue #3166)", () => {
     expect(saveBtn.getAttribute("tabindex")).not.toBe("-1");
   });
 
+  it("shows a compact location summary and includes it in the row name", () => {
+    const posting = entry("1");
+    posting.locationNames = ["Zurich", "Geneva", "Zurich"];
+
+    renderList([posting]);
+
+    expect(screen.getByText("Zurich +1")).toBeTruthy();
+    expect(
+      screen.getByRole("button", {
+        name: "Company 1 — Job 1 — Zurich +1",
+      }),
+    ).toBeTruthy();
+  });
+
   it("Tab order across two rows is: row1.open, row1.save, row2.open, row2.save", () => {
     const { container } = renderList([entry("1"), entry("2")]);
 

--- a/apps/web/src/components/watchlist/watchlist-job-list.tsx
+++ b/apps/web/src/components/watchlist/watchlist-job-list.tsx
@@ -28,6 +28,12 @@ import { formatDateDivider, getDateKey } from "@/components/watchlist/format-dat
 
 const BATCH = 20;
 
+function formatLocationSummary(locationNames: string[] | undefined): string {
+  const names = [...new Set((locationNames ?? []).filter(Boolean))];
+  if (names.length === 0) return "";
+  return names.length === 1 ? names[0]! : `${names[0]} +${names.length - 1}`;
+}
+
 export interface WatchlistJobListFilters {
   companyIds: string[];
   anyCompany?: boolean;
@@ -150,6 +156,7 @@ export function WatchlistJobList({
   const seenDividers = new Set<string>();
 
   for (const entry of postings) {
+    const locationSummary = formatLocationSummary(entry.locationNames);
     const dateKey = getDateKey(entry.firstSeenAt);
     if (dateKey !== lastDateKey && !seenDividers.has(dateKey)) {
       lastDateKey = dateKey;
@@ -196,7 +203,7 @@ export function WatchlistJobList({
           onClick={() => handleOpenPosting(entry.id)}
           aria-label={
             entry.title
-              ? `${entry.company.name} — ${entry.title}`
+              ? `${entry.company.name} — ${entry.title}${locationSummary ? ` — ${locationSummary}` : ""}`
               : t({
                   id: "watchlists.jobList.openPosting",
                   comment: "Aria label for the row open-posting button when the posting title is missing",
@@ -212,8 +219,13 @@ export function WatchlistJobList({
           {entry.company.name}
         </span>
 
-        <span className="min-w-0 flex-1 truncate text-sm">
-          {entry.title ?? "—"}
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-sm">{entry.title ?? "—"}</span>
+          {locationSummary && (
+            <span className="block truncate text-[10px] text-muted">
+              {locationSummary}
+            </span>
+          )}
         </span>
 
         {!entry.title && (

--- a/apps/web/src/lib/services/watchlists.ts
+++ b/apps/web/src/lib/services/watchlists.ts
@@ -134,6 +134,8 @@ export type WatchlistDetail = {
 export type WatchlistPostingEntry = {
   id: string;
   title: string | null;
+  /** Leaf location names, in source order, used to disambiguate repeated titles. */
+  locationNames?: string[];
   sourceUrl: string;
   firstSeenAt: string;
   isActive: boolean;
@@ -2228,6 +2230,9 @@ async function _getWatchlistPostingsTypesense(
     return {
       id: doc.id as string,
       title: (doc.title as string) ?? null,
+      locationNames: Array.isArray(doc.location_names)
+        ? doc.location_names.filter((name): name is string => typeof name === "string" && name.length > 0)
+        : [],
       sourceUrl: (doc.source_url as string) ?? "",
       firstSeenAt: new Date(((doc.first_seen_at as number) ?? 0) * 1000).toISOString(),
       isActive: (doc.is_active as boolean) ?? true,
@@ -2341,6 +2346,9 @@ async function _getWatchlistPostingsBatched(
     return {
       id: doc.id as string,
       title: (doc.title as string) ?? null,
+      locationNames: Array.isArray(doc.location_names)
+        ? doc.location_names.filter((name): name is string => typeof name === "string" && name.length > 0)
+        : [],
       sourceUrl: (doc.source_url as string) ?? "",
       firstSeenAt: new Date(((doc.first_seen_at as number) ?? 0) * 1000).toISOString(),
       isActive: (doc.is_active as boolean) ?? true,
@@ -2535,6 +2543,7 @@ async function _getWatchlistPostingsPostgres(
     postings: (rows as unknown as Row[]).map((r) => ({
       id: r.id,
       title: r.title,
+      locationNames: [],
       sourceUrl: r.source_url,
       firstSeenAt: new Date(r.first_seen_at).toISOString(),
       isActive: r.is_active,


### PR DESCRIPTION
## What changed

- Load the authenticated Watchlists overview directly in the server tree behind Suspense, removing the client-effect Server Action waterfall that timed out in production.
- Share one cache-stable company snapshot between route metadata and the company page body to mitigate the Next.js Cache Components/PPR resume mismatch.
- Add visible, localized From/To labels to the Application Stats date range.
- Add a persistent, localized label to the company-request field.
- Expose pressed state for theme, interface-language, and job-language setting buttons.
- Carry posting locations into watchlist rows, show a compact location summary, and include it in the row accessible name.

## Why

The follow-up production audit confirmed that #5896 and #5911 persisted after the first remediation batch, and found four additional actionable UX/accessibility defects (#5951–#5954). Screenshots are embedded in each linked issue; local evidence remains untracked.

The company-page error matches the open Next.js metadata-boundary defect vercel/next.js#93401. This PR applies its reported userland mitigation by eliminating independently resolved metadata/body data for the dynamic route.

## Validation

- 183 test files / 1,417 tests passed
- Focused ESLint passed on every touched TypeScript/TSX file
- Lingui translation coverage hook passed
- Production `pnpm build` passed (183 static/PPR pages)
- Branch rebased and revalidated against current `origin/main`

Closes #5896
Closes #5911
Closes #5951
Closes #5952
Closes #5953
Closes #5954
