### PR TITLE
Index active postings for watchlist counts

### DIFF
--- a/apps/web/drizzle/0082_add_active_job_company_index.sql
+++ b/apps/web/drizzle/0082_add_active_job_company_index.sql
@@ -1,0 +1,6 @@
+-- Watchlist summaries count active postings for every tracked company.
+-- The existing company index still scans inactive history before applying
+-- `is_active`, which makes the overview query time out for larger lists.
+CREATE INDEX IF NOT EXISTS idx_jp_active_company
+  ON job_posting (company_id)
+  WHERE is_active = true;

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -512,6 +512,13 @@
       "when": 1784720400000,
       "tag": "0081_private_watchlists_and_general_interviews",
       "breakpoints": true
+    },
+    {
+      "idx": 73,
+      "version": "7",
+      "when": 1784727570000,
+      "tag": "0082_add_active_job_company_index",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/db/__tests__/active-job-company-index-migration.test.ts
+++ b/apps/web/src/db/__tests__/active-job-company-index-migration.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { getTableConfig } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+
+import { jobPosting } from "@/db/schema";
+
+const migrationSql = readFileSync(
+  resolve(process.cwd(), "drizzle/0082_add_active_job_company_index.sql"),
+  "utf8",
+);
+
+describe("active job company index migration", () => {
+  it("adds the partial index used by watchlist active-job counts", () => {
+    expect(migrationSql).toMatch(
+      /CREATE INDEX IF NOT EXISTS idx_jp_active_company\s+ON job_posting \(company_id\)\s+WHERE is_active = true/i,
+    );
+
+    const index = getTableConfig(jobPosting).indexes.find(
+      (candidate) => candidate.config.name === "idx_jp_active_company",
+    );
+
+    expect(index).toBeDefined();
+    expect(index?.config.where).toBeDefined();
+  });
+});

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -528,6 +528,9 @@ export const jobPosting = pgTable(
   },
   (table) => [
     index("idx_jp_company").on(table.companyId),
+    index("idx_jp_active_company")
+      .on(table.companyId)
+      .where(sql`is_active = true`),
     index("idx_jp_board_url").on(table.boardId, table.sourceUrl),
     index("idx_jp_active").on(table.isActive).where(sql`is_active = true`),
     index("idx_jp_location_ids").using("gin", table.locationIds),


### PR DESCRIPTION
## What

- add a partial job_posting(company_id) index for active rows
- register migration 0082 and keep the Drizzle schema in sync
- add a regression test covering both the migration SQL and schema index

## Why

Production verification after #5955 showed that the watchlists loader presentation was fixed but the authenticated workflow still failed. Vercel logged an 8-second server timeout. A read-only production profile reproduced the summary SQL timing out after 15 seconds.

The query plan estimates 488,499 total cost for the test user: 16 watchlists and 448 company edges repeatedly use idx_jp_company, then filter historical postings by is_active. The new partial index lets the same query read active rows directly.

## Validation

- 184 web test files / 1,418 tests pass
- production build passes, including TypeScript and 183 generated routes
- focused ESLint passes
- drizzle-kit check passes
- pre-commit ESLint and Lingui coverage hooks pass

## Production rollout

After CI and merge, build the index concurrently to avoid blocking crawler writes, run the idempotent migration to record 0082, and re-profile plus retest /en/watchlists before closing the issue.

Closes #5896