### PR TITLE
Defer watchlist job counts

### DIFF
--- a/apps/web/app/[lang]/(app)/watchlists/__tests__/watchlists-loader.test.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/__tests__/watchlists-loader.test.tsx
@@ -21,16 +21,19 @@ vi.mock("../watchlists-page", () => ({
     initialWatchlists,
     username,
     limitReached,
+    locale,
   }: {
     initialWatchlists: unknown[];
     username: string | null;
     limitReached: boolean;
+    locale: string;
   }) => (
     <div
       data-testid="watchlists-page"
       data-count={initialWatchlists.length}
       data-username={username ?? ""}
       data-limit-reached={String(limitReached)}
+      data-locale={locale}
     />
   ),
 }));
@@ -57,6 +60,7 @@ describe("WatchlistsLoader server read (#5896)", () => {
     expect(page.getAttribute("data-count")).toBe("1");
     expect(page.getAttribute("data-username")).toBe("alice");
     expect(page.getAttribute("data-limit-reached")).toBe("false");
+    expect(page.getAttribute("data-locale")).toBe("en");
     expect(mocks.load).toHaveBeenCalledOnce();
     expect(mocks.load).toHaveBeenCalledWith("en");
   });

--- a/apps/web/app/[lang]/(app)/watchlists/__tests__/watchlists-page.test.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/__tests__/watchlists-page.test.tsx
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@/test-utils/lingui-mock";
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  refresh: vi.fn(),
+  createWatchlist: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.push, refresh: mocks.refresh }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/lib/useLocalePath", () => ({
+  useLocalePath: () => (path: string) => `/en${path}`,
+}));
+
+vi.mock("@/components/providers/SessionProvider", () => ({
+  useSession: () => ({
+    user: { username: "alice" },
+    isLoggedIn: true,
+  }),
+}));
+
+vi.mock("@/lib/actions/watchlists", () => ({
+  createWatchlist: mocks.createWatchlist,
+}));
+
+vi.mock("@/components/watchlist/watchlist-card", () => ({
+  WatchlistCard: ({ watchlist }: { watchlist: { id: string; companyCount: number; activeJobCount: number | null } }) => (
+    <div data-testid={`watchlist-${watchlist.id}`}>
+      {watchlist.activeJobCount == null
+        ? `${watchlist.companyCount} companies`
+        : `${watchlist.activeJobCount} jobs`}
+    </div>
+  ),
+  CreateWatchlistCard: () => <button type="button">Create</button>,
+}));
+
+vi.mock("@/components/watchlist/public-watchlist-search", () => ({
+  PublicWatchlistSearch: () => null,
+}));
+
+vi.mock("@/components/ui/upgrade-modal", () => ({
+  UpgradeModal: () => null,
+  useUpgradeModal: () => ({
+    open: false,
+    setOpen: vi.fn(),
+    reason: "",
+    show: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/ui/Button", () => ({
+  Button: ({ children }: { children: React.ReactNode }) => <button type="button">{children}</button>,
+}));
+
+import { WatchlistsPage } from "../watchlists-page";
+
+const overview = [{
+  id: "watchlist-1",
+  slug: "engineering",
+  title: "Engineering",
+  description: null,
+  isPublic: false,
+  alertsEnabled: false,
+  companyCount: 3,
+  activeJobCount: null,
+  lastAccessedAt: "2026-07-22T00:00:00.000Z",
+  createdAt: "2026-07-22T00:00:00.000Z",
+}];
+
+describe("WatchlistsPage deferred counts (#5896)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("renders useful cards before the count request settles", () => {
+    vi.stubGlobal("fetch", vi.fn(() => new Promise(() => {})));
+
+    render(
+      <WatchlistsPage
+        initialWatchlists={overview}
+        username="alice"
+        limitReached={false}
+        locale="en"
+      />,
+    );
+
+    expect(screen.getByTestId("watchlist-watchlist-1").textContent).toBe(
+      "3 companies",
+    );
+  });
+
+  it("replaces the fallback with the live active-job count", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ counts: { "watchlist-1": 42 } }),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <WatchlistsPage
+        initialWatchlists={overview}
+        username="alice"
+        limitReached={false}
+        locale="de"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("watchlist-watchlist-1").textContent).toBe(
+        "42 jobs",
+      );
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/web/watchlists/counts?locale=de",
+      expect.objectContaining({ cache: "no-store" }),
+    );
+  });
+});

--- a/apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx
@@ -39,6 +39,7 @@ export async function WatchlistsLoader({ locale }: { locale: string }) {
         initialWatchlists={watchlists}
         username={session?.user.username ?? null}
         limitReached={limitReached}
+        locale={locale}
       />
     );
   } catch (err) {

--- a/apps/web/app/[lang]/(app)/watchlists/watchlists-page.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/watchlists-page.tsx
@@ -6,7 +6,7 @@ import { Eye, Loader2, LogIn } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useLocalePath } from "@/lib/useLocalePath";
 import { useSession } from "@/components/providers/SessionProvider";
-import type { WatchlistSummary, WatchlistFilters } from "@/lib/actions/watchlists";
+import type { UserWatchlistOverview, WatchlistFilters } from "@/lib/actions/watchlists";
 import { createWatchlist } from "@/lib/actions/watchlists";
 import { WatchlistCard, CreateWatchlistCard } from "@/components/watchlist/watchlist-card";
 import { PublicWatchlistSearch } from "@/components/watchlist/public-watchlist-search";
@@ -17,10 +17,12 @@ export function WatchlistsPage({
   initialWatchlists,
   username,
   limitReached,
+  locale,
 }: {
-  initialWatchlists: WatchlistSummary[];
+  initialWatchlists: UserWatchlistOverview[];
   username: string | null;
   limitReached: boolean;
+  locale: string;
 }) {
   const { t } = useLingui();
   const router = useRouter();
@@ -28,7 +30,49 @@ export function WatchlistsPage({
   const { user, isLoggedIn } = useSession();
   const searchParams = useSearchParams();
   const [creating, setCreating] = useState(false);
+  const [watchlists, setWatchlists] = useState(initialWatchlists);
   const upgrade = useUpgradeModal();
+
+  useEffect(() => {
+    setWatchlists(initialWatchlists);
+    if (!isLoggedIn || initialWatchlists.length === 0) return;
+
+    const controller = new AbortController();
+    let disposed = false;
+    const timeoutId = setTimeout(() => controller.abort(), 12_000);
+
+    void fetch(`/api/web/watchlists/counts?locale=${encodeURIComponent(locale)}`, {
+      cache: "no-store",
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`Watchlist counts failed: ${response.status}`);
+        return response.json() as Promise<{ counts?: Record<string, unknown> }>;
+      })
+      .then(({ counts }) => {
+        if (!counts || disposed) return;
+        setWatchlists((current) =>
+          current.map((watchlist) => {
+            const count = counts[watchlist.id];
+            return {
+              ...watchlist,
+              activeJobCount:
+                typeof count === "number" ? count : watchlist.activeJobCount,
+            };
+          }),
+        );
+      })
+      .catch(() => {
+        // Company counts remain visible when the optional live count fails.
+      })
+      .finally(() => clearTimeout(timeoutId));
+
+    return () => {
+      disposed = true;
+      clearTimeout(timeoutId);
+      controller.abort();
+    };
+  }, [initialWatchlists, isLoggedIn, locale]);
 
   function showLimitUpgrade() {
     upgrade.show(t({
@@ -149,7 +193,7 @@ export function WatchlistsPage({
               {t({ id: "common.auth.login", comment: "Login button label", message: "Log in" })}
             </Button>
           </div>
-        ) : initialWatchlists.length === 0 ? (
+        ) : watchlists.length === 0 ? (
           <div className="flex flex-col items-center gap-3 py-8 text-center text-muted">
             <Eye size={32} />
             <p className="text-sm">
@@ -175,7 +219,7 @@ export function WatchlistsPage({
           </div>
         ) : (
           <div className="flex gap-3 overflow-x-auto pb-2 scrollbar-hide">
-            {initialWatchlists.map((wl) => (
+            {watchlists.map((wl) => (
               <WatchlistCard
                 key={wl.id}
                 watchlist={wl}

--- a/apps/web/app/api/web/watchlists/counts/__tests__/route.test.ts
+++ b/apps/web/app/api/web/watchlists/counts/__tests__/route.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getSessionUserId: vi.fn(),
+  getUserWatchlistCounts: vi.fn(),
+}));
+
+vi.mock("@/lib/sessionCache", () => ({
+  getSessionUserId: mocks.getSessionUserId,
+}));
+
+vi.mock("@/lib/services/watchlists", () => ({
+  getUserWatchlistCounts: mocks.getUserWatchlistCounts,
+}));
+
+import { GET } from "../route";
+
+describe("GET /api/web/watchlists/counts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getSessionUserId.mockResolvedValue("user-1");
+    mocks.getUserWatchlistCounts.mockResolvedValue({ "watchlist-1": 42 });
+  });
+
+  it("requires an authenticated session", async () => {
+    mocks.getSessionUserId.mockResolvedValueOnce(null);
+
+    const response = await GET(
+      new Request("https://jseek.co/api/web/watchlists/counts?locale=en"),
+    );
+
+    expect(response.status).toBe(401);
+    expect(mocks.getUserWatchlistCounts).not.toHaveBeenCalled();
+  });
+
+  it("returns private no-store counts in a supported locale", async () => {
+    const response = await GET(
+      new Request("https://jseek.co/api/web/watchlists/counts?locale=de"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("private, no-store");
+    expect(await response.json()).toEqual({ counts: { "watchlist-1": 42 } });
+    expect(mocks.getUserWatchlistCounts).toHaveBeenCalledWith("de");
+  });
+
+  it("falls back to English for an unsupported locale", async () => {
+    await GET(new Request("https://jseek.co/api/web/watchlists/counts?locale=xx"));
+
+    expect(mocks.getUserWatchlistCounts).toHaveBeenCalledWith("en");
+  });
+});

--- a/apps/web/app/api/web/watchlists/counts/route.ts
+++ b/apps/web/app/api/web/watchlists/counts/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+
+import { locales } from "@/lib/i18n";
+import { getSessionUserId } from "@/lib/sessionCache";
+import { getUserWatchlistCounts } from "@/lib/services/watchlists";
+
+export async function GET(request: Request) {
+  if (!(await getSessionUserId())) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  const requestedLocale = new URL(request.url).searchParams.get("locale");
+  const locale = requestedLocale && locales.includes(requestedLocale as (typeof locales)[number])
+    ? requestedLocale
+    : "en";
+  const counts = await getUserWatchlistCounts(locale);
+
+  return NextResponse.json(
+    { counts },
+    { headers: { "Cache-Control": "private, no-store" } },
+  );
+}

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -2032,6 +2032,18 @@ msgstr "Ist der Crawler Open Source?"
 msgid "faq.q.trackerLimit"
 msgstr "Gibt es ein Limit, wie viele Jobs ich verfolgen kann?"
 
+#. Singular company count shown while a watchlist job count loads
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:36
+msgid "watchlists.card.companySingular"
+msgstr "Unternehmen"
+
+#. Plural company count shown while a watchlist job count loads
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:37
+msgid "watchlists.card.companyPlural"
+msgstr "Unternehmen"
+
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -2032,6 +2032,18 @@ msgstr "Is the crawler open source?"
 msgid "faq.q.trackerLimit"
 msgstr "Is there a limit to how many jobs I can track?"
 
+#. Singular company count shown while a watchlist job count loads
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:36
+msgid "watchlists.card.companySingular"
+msgstr "company"
+
+#. Plural company count shown while a watchlist job count loads
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:37
+msgid "watchlists.card.companyPlural"
+msgstr "companies"
+
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -2032,6 +2032,18 @@ msgstr "Le crawler est-il open source ?"
 msgid "faq.q.trackerLimit"
 msgstr "Y a-t-il une limite au nombre d'offres que je peux suivre ?"
 
+#. Singular company count shown while a watchlist job count loads
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:36
+msgid "watchlists.card.companySingular"
+msgstr "entreprise"
+
+#. Plural company count shown while a watchlist job count loads
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:37
+msgid "watchlists.card.companyPlural"
+msgstr "entreprises"
+
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -2032,6 +2032,18 @@ msgstr "Il crawler è open source?"
 msgid "faq.q.trackerLimit"
 msgstr "C'è un limite al numero di offerte che posso tracciare?"
 
+#. Singular company count shown while a watchlist job count loads
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:36
+msgid "watchlists.card.companySingular"
+msgstr "azienda"
+
+#. Plural company count shown while a watchlist job count loads
+#. js-lingui-explicit-id
+#: src/components/watchlist/watchlist-card.tsx:37
+msgid "watchlists.card.companyPlural"
+msgstr "aziende"
+
 #. Singular job count on watchlist card
 #. js-lingui-explicit-id
 #: src/components/watchlist/watchlist-card.tsx:31

--- a/apps/web/src/components/watchlist/__tests__/watchlist-card.test.tsx
+++ b/apps/web/src/components/watchlist/__tests__/watchlist-card.test.tsx
@@ -53,6 +53,28 @@ describe("WatchlistCard navigation", () => {
 
     expect(scrollTo).toHaveBeenCalledWith({ top: 0, left: 0, behavior: "instant" });
   });
+
+  it("shows a useful company count until the live job count arrives", () => {
+    render(
+      <WatchlistCard
+        ownerUsername="colophongroup"
+        watchlist={{
+          id: "watchlist-1",
+          slug: "maangplus",
+          title: "MAANG+",
+          description: null,
+          isPublic: true,
+          alertsEnabled: false,
+          companyCount: 12,
+          activeJobCount: null,
+          lastAccessedAt: "2026-07-06T00:00:00.000Z",
+          createdAt: "2026-07-06T00:00:00.000Z",
+        }}
+      />,
+    );
+
+    expect(screen.getByText("12 companies")).toBeTruthy();
+  });
 });
 
 describe("CreateWatchlistCard (issue #3036)", () => {

--- a/apps/web/src/components/watchlist/watchlist-card.tsx
+++ b/apps/web/src/components/watchlist/watchlist-card.tsx
@@ -6,11 +6,11 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { useLocalePath } from "@/lib/useLocalePath";
 import { scrollToTopOnNav } from "@/lib/scroll-on-nav";
-import type { WatchlistSummary } from "@/lib/actions/watchlists";
+import type { UserWatchlistOverview } from "@/lib/actions/watchlists";
 import { UpgradeModal, useUpgradeModal } from "@/components/ui/upgrade-modal";
 import { tooltipWarningClass } from "@/components/ui/tooltip-styles";
 
-export function WatchlistCard({ watchlist, ownerUsername }: { watchlist: WatchlistSummary; ownerUsername: string | null }) {
+export function WatchlistCard({ watchlist, ownerUsername }: { watchlist: UserWatchlistOverview; ownerUsername: string | null }) {
   const { t } = useLingui();
   const lp = useLocalePath();
   const href = ownerUsername ? lp(`/${ownerUsername}/${watchlist.slug}`) : "#";
@@ -28,10 +28,20 @@ export function WatchlistCard({ watchlist, ownerUsername }: { watchlist: Watchli
       <span className="line-clamp-2 text-xs font-medium leading-tight">
         {watchlist.title}
       </span>
-      <span className="text-[10px] text-muted">
-        {watchlist.activeJobCount} {watchlist.activeJobCount === 1
-          ? t({ id: "watchlists.card.jobSingular", comment: "Singular job count on watchlist card", message: "job" })
-          : t({ id: "watchlists.card.jobPlural", comment: "Plural job count on watchlist card", message: "jobs" })}
+      <span className="text-[10px] text-muted" aria-live="polite">
+        {watchlist.activeJobCount == null ? (
+          <>
+            {watchlist.companyCount} {watchlist.companyCount === 1
+              ? t({ id: "watchlists.card.companySingular", comment: "Singular company count shown while a watchlist job count loads", message: "company" })
+              : t({ id: "watchlists.card.companyPlural", comment: "Plural company count shown while a watchlist job count loads", message: "companies" })}
+          </>
+        ) : (
+          <>
+            {watchlist.activeJobCount} {watchlist.activeJobCount === 1
+              ? t({ id: "watchlists.card.jobSingular", comment: "Singular job count on watchlist card", message: "job" })
+              : t({ id: "watchlists.card.jobPlural", comment: "Plural job count on watchlist card", message: "jobs" })}
+          </>
+        )}
       </span>
     </Link>
   );

--- a/apps/web/src/lib/actions/__tests__/watchlists-listing-perf.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-listing-perf.test.ts
@@ -18,11 +18,11 @@
  *   Typesense `watchlist` collection (1 round-trip), then re-ran the
  *   same N-fanout via `_enrichWatchlistsWithRealCounts`.
  *
- * #3176 post-fix:
- *   - `getUserWatchlists`  one SQL query against Postgres with the
- *     active count denormalized via a `watchlist_company JOIN
- *     job_posting WHERE is_active` subquery. Zero Typesense round-trips
- *     for unfiltered company-scoped rows.
+ * #5896 follow-up:
+ *   - `getUserWatchlists` runs one bounded metadata query against
+ *     Postgres, then one Typesense `multi_search` for all active counts.
+ *     This avoids both the original N-round-trip fan-out and an expensive
+ *     per-watchlist join against the full Postgres posting history.
  *   - `searchPublicWatchlists` / `getPopularWatchlists`  one Typesense
  *     `watchlist` collection search whose returned docs already carry
  *     `active_job_count` for company-scoped watchlists. `anyCompany`
@@ -273,6 +273,7 @@ vi.mock("@/db", () => ({
 // Module under test must be imported AFTER all vi.mock factories.
 import {
   getUserWatchlists,
+  getUserWatchlistsWithLimit,
   getPopularWatchlists,
   searchPublicWatchlists,
 } from "../../services/watchlists";
@@ -285,6 +286,7 @@ beforeEach(() => {
   mocks.getSessionUserId.mockResolvedValue(USER_ID);
   mocks.canCreateWatchlist.mockResolvedValue({ allowed: true });
   mocks.getViewerLanguages.mockResolvedValue(["en"]);
+  mocks.tsMultiSearch.mockResolvedValue({ results: [] });
   mocks.resolveLocationSlugs.mockResolvedValue(new Map([
     ["zurich", { id: 2657896, slug: "zurich", name: "Zurich" }],
     ["switzerland", { id: 2658434, slug: "switzerland", name: "Switzerland" }],
@@ -355,14 +357,34 @@ function fakePublicWatchlistHit(
 // ---- getUserWatchlists (user's own listing page) -----------------------
 
 describe("getUserWatchlists — listing fan-out fix (#3176)", () => {
-  it("fires ZERO Typesense queries when loading N watchlists", async () => {
+  it("keeps the initial overview independent from active-count aggregation (#5896)", async () => {
+    const rows = [fakeUserWatchlistRow(0, 42), fakeUserWatchlistRow(1, 7)];
+    mocks.dbExecute.mockResolvedValueOnce(rows);
+
+    const result = await getUserWatchlistsWithLimit("en");
+
+    expect(result.watchlists.map((watchlist) => watchlist.activeJobCount)).toEqual([
+      null,
+      null,
+    ]);
+    expect(mocks.tsMultiSearch).not.toHaveBeenCalled();
+    expect(mocks.getViewerLanguages).not.toHaveBeenCalled();
+    expect(mocks.dbExecute).toHaveBeenCalledTimes(1);
+  });
+
+  it("batches N watchlist counts into one Typesense multi_search", async () => {
     const N = 50; // paid-tier user, worst-case
     const rows = Array.from({ length: N }, (_, i) => fakeUserWatchlistRow(i, i * 3));
     mocks.dbExecute.mockResolvedValueOnce(rows);
+    mocks.tsMultiSearch.mockResolvedValueOnce({
+      results: rows.map((row) => ({ found: row.active_job_count, hits: [] })),
+    });
 
     await getUserWatchlists("en");
 
     expect(mocks.tsSearch).not.toHaveBeenCalled();
+    expect(mocks.tsMultiSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.tsMultiSearch.mock.calls[0]?.[0].searches).toHaveLength(N);
     expect(mocks.tsCollectionsCalls).toEqual([]);
   });
 
@@ -373,20 +395,25 @@ describe("getUserWatchlists — listing fan-out fix (#3176)", () => {
 
     await getUserWatchlists("en");
 
-    // Only the single SELECT that loads watchlists + their denormalized
-    // active_job_count. Pre-fix this would have been 1 (rows) plus up
-    // to 4N (taxonomy lookups for resolveFilteredJobCount) plus N
-    // (Typesense count).
+    // Only the single bounded metadata SELECT. Counts are handled by one
+    // batched Typesense request rather than SQL joins or N round-trips.
     expect(mocks.dbExecute).toHaveBeenCalledTimes(1);
   });
 
-  it("returns the denormalized active_job_count straight from SQL", async () => {
+  it("returns active counts from the batched Typesense response", async () => {
     const rows = [
       fakeUserWatchlistRow(0, 42),
       fakeUserWatchlistRow(1, 7),
       fakeUserWatchlistRow(2, 0),
     ];
     mocks.dbExecute.mockResolvedValueOnce(rows);
+    mocks.tsMultiSearch.mockResolvedValueOnce({
+      results: [
+        { found: 42, hits: [] },
+        { found: 7, hits: [] },
+        { found: 0, hits: [] },
+      ],
+    });
 
     const result = await getUserWatchlists("en");
 
@@ -416,6 +443,7 @@ describe("getUserWatchlists — listing fan-out fix (#3176)", () => {
       results: [
         { found: 6, hits: [] },
         { found: 3, hits: [] },
+        { found: 12, hits: [] },
       ],
     });
 
@@ -435,6 +463,12 @@ describe("getUserWatchlists — listing fan-out fix (#3176)", () => {
         {
           collection: "job_posting",
           q: "python",
+          query_by: "title",
+          per_page: 0,
+        },
+        {
+          collection: "job_posting",
+          q: "*",
           query_by: "title",
           per_page: 0,
         },
@@ -472,19 +506,22 @@ describe("getUserWatchlists — listing fan-out fix (#3176)", () => {
     mocks.resolveLocationSlugs.mockResolvedValueOnce(new Map([
       ["eu", { id: 6255148, slug: "eu", name: "European Union" }],
     ]));
-    mocks.tsMultiSearch.mockResolvedValueOnce({ results: [{ found: 38717, hits: [] }] });
+    mocks.tsMultiSearch.mockResolvedValueOnce({
+      results: [
+        { found: 38717, hits: [] },
+        { found: 12, hits: [] },
+      ],
+    });
 
     const result = await getUserWatchlists("en");
 
     expect(result).toHaveLength(2);
     // Patched from SQL's 0 to the Typesense count.
     expect(result[0].activeJobCount).toBe(38717);
-    // Non-anyCompany row keeps the SQL count untouched — no extra
-    // round-trip fires for it.
+    // The normal row is resolved in the same batch.
     expect(result[1].activeJobCount).toBe(12);
 
-    // Exactly one Typesense call (the anyCompany count). The normal
-    // row goes straight from SQL.
+    // Exactly one Typesense call covers both rows.
     expect(mocks.tsSearch).not.toHaveBeenCalled();
     expect(mocks.tsMultiSearch).toHaveBeenCalledTimes(1);
     expect(mocks.tsCollectionsCalls).toEqual([]);
@@ -507,13 +544,15 @@ describe("getUserWatchlists — listing fan-out fix (#3176)", () => {
     expect(result[0].activeJobCount).toBe(0); // graceful degradation
   });
 
-  it("fires no Typesense queries when there are zero anyCompany rows", async () => {
+  it("batches unfiltered company-scoped rows without per-row requests", async () => {
     const rows = Array.from({ length: 10 }, (_, i) => fakeUserWatchlistRow(i, i * 3));
     mocks.dbExecute.mockResolvedValueOnce(rows);
 
     await getUserWatchlists("en");
 
     expect(mocks.tsSearch).not.toHaveBeenCalled();
+    expect(mocks.tsMultiSearch).toHaveBeenCalledTimes(1);
+    expect(mocks.tsMultiSearch.mock.calls[0]?.[0].searches).toHaveLength(10);
   });
 
   // Regression for #3344. The `anyCompany` Typesense patch previously

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -57,6 +57,12 @@ export async function getUserWatchlists(
   return service.getUserWatchlists(...args);
 }
 
+export async function getUserWatchlistCounts(
+  ...args: Parameters<typeof service.getUserWatchlistCounts>
+): ReturnType<typeof service.getUserWatchlistCounts> {
+  return service.getUserWatchlistCounts(...args);
+}
+
 export async function getWatchlistByUserAndSlug(
   ...args: Parameters<typeof service.getWatchlistByUserAndSlug>
 ): ReturnType<typeof service.getWatchlistByUserAndSlug> {
@@ -126,6 +132,7 @@ export async function removeCompanyFromWatchlist(
 export type {
   WatchlistFilters,
   WatchlistSummary,
+  UserWatchlistOverview,
   WatchlistDetail,
   WatchlistPostingEntry,
   PublicWatchlistEntry,

--- a/apps/web/src/lib/services/watchlists.ts
+++ b/apps/web/src/lib/services/watchlists.ts
@@ -107,6 +107,11 @@ export type WatchlistSummary = {
   createdAt: string;
 };
 
+export type UserWatchlistOverview = Omit<WatchlistSummary, "activeJobCount"> & {
+  /** Loaded after the overview renders so count aggregation cannot block navigation. */
+  activeJobCount: number | null;
+};
+
 export type WatchlistDetail = {
   id: string;
   slug: string;
@@ -661,74 +666,46 @@ export async function toggleWatchlistAlerts(
  * value server-side so the gating UX matches the watchlist-detail page.
  */
 export async function getUserWatchlistsWithLimit(
-  locale: string,
-): Promise<{ watchlists: WatchlistSummary[]; limitReached: boolean }> {
+  _locale: string,
+): Promise<{ watchlists: UserWatchlistOverview[]; limitReached: boolean }> {
   const userId = await getSessionUserId();
   if (!userId) return { watchlists: [], limitReached: true };
 
-  const [watchlists, limit] = await Promise.all([
-    getUserWatchlists(locale),
+  const [rows, limit] = await Promise.all([
+    _getUserWatchlistRows(userId),
     canCreateWatchlist(userId),
   ]);
-  return { watchlists, limitReached: !limit.allowed };
+  return {
+    watchlists: rows.map((row) => _toUserWatchlistSummary(row, null)),
+    limitReached: !limit.allowed,
+  };
 }
 
-export async function getUserWatchlists(locale: string): Promise<WatchlistSummary[]> {
-  const userId = await getSessionUserId();
-  if (!userId) return [];
+type UserWatchlistRow = {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  is_public: boolean;
+  alerts_enabled: boolean;
+  filters: WatchlistFilters;
+  last_accessed_at: Date;
+  created_at: Date;
+  company_count: number;
+  company_ids: string[];
+};
 
-  // Viewer language preference — used by the batched Typesense count
-  // patch below so filtered listing counts match the watchlist-detail
-  // page's locale-filtered count. The SQL fast path for unfiltered
-  // company-scoped rows still uses the denormalized `active_job_count`;
-  // issue #3261 only pays the Typesense round-trip when a row has
-  // filters that make that approximation visibly wrong.
-  const languages = await getViewerLanguages(locale);
-
-  // Perf (#3176): compute the active job count via a denormalized SQL
-  // aggregation in the same query that loads the watchlist rows. The
-  // previous shape ran N parallel `resolveFilteredJobCount` calls — one
-  // Typesense round-trip per watchlist — which cost ~150-250ms for free
-  // users (5 watchlists) and 1.5-2.5s for paid users (50 watchlists) on
-  // every `/watchlists` load.
+async function _getUserWatchlistRows(userId: string): Promise<UserWatchlistRow[]> {
+  // Keep the database portion bounded to watchlist metadata and company
+  // membership. Counting active postings here used to join every tracked
+  // company against the full `job_posting` history for every watchlist;
+  // production users with larger lists exceeded a 15-second statement
+  // timeout even with an active-company index (#5896).
   //
-  // The new shape returns the "company-scope" active count: SUM over
-  // (watchlist's companies) of (active job_posting rows). This is the
-  // same denominator the crawler's `refresh-typesense` cron writes into
-  // the Typesense `watchlist.active_job_count` field — but computed
-  // server-side at request time so it is fresh, and so it works for
-  // private watchlists too (which never reach Typesense).
-  //
-  // Follow-up (#3261): rows with any real watchlist filters are patched
-  // after this query via one Typesense `multi_search`. Rows without
-  // filters keep this SQL count, preserving the zero-Typesense fast path
-  // for the common "these companies, no filter clauses" watchlist.
-  //
-  // EXCEPTION (#3333): `anyCompany` watchlists have NO `watchlist_company`
-  // rows (the editor toggle disables the company picker, and copies
-  // already strip the rows on save), so the SQL JOIN above returns 0
-  // for them — even when the filters match thousands of active postings.
-  // The denormalized Typesense `active_job_count` field is also 0 for
-  // these (the crawler's `refresh_typesense_counts` joins the same
-  // empty `watchlist_company` table — see `apps/crawler/src/sync.py`).
-  // They are included in the same #3261 multi_search patch; when
-  // Typesense is unavailable they degrade to SQL's structural 0.
+  // Active counts are intentionally resolved outside the initial page load.
   const rows = await withDbRetry(
     () =>
-      db.execute<{
-        [key: string]: unknown;
-        id: string;
-        slug: string;
-        title: string;
-        is_public: boolean;
-        alerts_enabled: boolean;
-        filters: WatchlistFilters;
-        last_accessed_at: Date;
-        created_at: Date;
-        company_count: number;
-        active_job_count: number;
-        company_ids: string[];
-      }>(sql`
+      db.execute<UserWatchlistRow & { [key: string]: unknown }>(sql`
         SELECT w.id, w.slug, w.title, w.description, w.is_public, w.alerts_enabled, w.filters,
                w.last_accessed_at, w.created_at,
                (SELECT count(*)::int FROM watchlist_company wc WHERE wc.watchlist_id = w.id) AS company_count,
@@ -736,13 +713,7 @@ export async function getUserWatchlists(locale: string): Promise<WatchlistSummar
                  SELECT COALESCE(array_agg(wc.company_id::text ORDER BY wc.company_id::text), ARRAY[]::text[])
                  FROM watchlist_company wc
                  WHERE wc.watchlist_id = w.id
-               ) AS company_ids,
-               (
-                 SELECT count(*)::int
-                 FROM watchlist_company wc
-                 JOIN job_posting jp ON jp.company_id = wc.company_id AND jp.is_active
-                 WHERE wc.watchlist_id = w.id
-               ) AS active_job_count
+               ) AS company_ids
         FROM watchlist w
         WHERE w.user_id = ${userId}
         ORDER BY w.last_accessed_at DESC
@@ -750,28 +721,50 @@ export async function getUserWatchlists(locale: string): Promise<WatchlistSummar
     { label: "userWatchlists" },
   );
 
-  type Row = {
-    id: string; slug: string; title: string; description: string | null; is_public: boolean;
-    alerts_enabled: boolean; filters: WatchlistFilters; last_accessed_at: Date; created_at: Date;
-    company_count: number; active_job_count: number; company_ids: string[];
+  return rows as unknown as UserWatchlistRow[];
+}
+
+function _toUserWatchlistSummary(
+  row: UserWatchlistRow,
+  activeJobCount: number | null,
+): UserWatchlistOverview {
+  return {
+    id: row.id,
+    slug: row.slug,
+    title: row.title,
+    description: row.description,
+    isPublic: row.is_public,
+    alertsEnabled: row.alerts_enabled,
+    companyCount: row.company_count,
+    activeJobCount,
+    lastAccessedAt: new Date(row.last_accessed_at).toISOString(),
+    createdAt: new Date(row.created_at).toISOString(),
   };
+}
 
-  const typed = rows as unknown as Row[];
+export async function getUserWatchlists(locale: string): Promise<WatchlistSummary[]> {
+  const userId = await getSessionUserId();
+  if (!userId) return [];
 
-  const preciseCounts = await _resolveUserListingCounts(typed, locale, languages);
+  // Viewer language preference is used by the batched Typesense count so
+  // listing counts match the watchlist-detail page.
+  const [rows, languages] = await Promise.all([
+    _getUserWatchlistRows(userId),
+    getViewerLanguages(locale),
+  ]);
 
-  return typed.map((r) => ({
-    id: r.id,
-    slug: r.slug,
-    title: r.title,
-    description: r.description,
-    isPublic: r.is_public,
-    alertsEnabled: r.alerts_enabled,
-    companyCount: r.company_count,
-    activeJobCount: preciseCounts.get(r.id) ?? r.active_job_count,
-    lastAccessedAt: new Date(r.last_accessed_at).toISOString(),
-    createdAt: new Date(r.created_at).toISOString(),
+  const preciseCounts = await _resolveUserListingCounts(rows, locale, languages);
+  return rows.map((row) => ({
+    ..._toUserWatchlistSummary(row, preciseCounts.get(row.id) ?? 0),
+    activeJobCount: preciseCounts.get(row.id) ?? 0,
   }));
+}
+
+export async function getUserWatchlistCounts(locale: string): Promise<Record<string, number>> {
+  const watchlists = await getUserWatchlists(locale);
+  return Object.fromEntries(
+    watchlists.map((watchlist) => [watchlist.id, watchlist.activeJobCount]),
+  );
 }
 
 async function _resolveUserListingCounts(
@@ -779,31 +772,33 @@ async function _resolveUserListingCounts(
     id: string;
     filters: WatchlistFilters | null;
     company_ids: string[] | null;
-    active_job_count: number;
   }>,
   locale: string,
   languages: string[],
 ): Promise<Map<string, number>> {
   const filteredRows = rows.filter((r) => hasPreciseListingCountFilters(r.filters));
-  if (filteredRows.length === 0) return new Map();
 
-  let indexedById: Map<string, IndexedWatchlistFilters | null>;
-  try {
-    indexedById = await buildIndexedFiltersForUserRows(filteredRows, locale);
-  } catch (err) {
-    console.error("[getUserWatchlists] filter id resolution failed", err);
-    return new Map();
+  let indexedById = new Map<string, IndexedWatchlistFilters | null>();
+  if (filteredRows.length > 0) {
+    try {
+      indexedById = await buildIndexedFiltersForUserRows(filteredRows, locale);
+    } catch (err) {
+      console.error("[getUserWatchlists] filter id resolution failed", err);
+    }
   }
 
   const candidates: ListingCountCandidate[] = [];
-  for (const row of filteredRows) {
-    const filters = indexedById.get(row.id);
+  for (const row of rows) {
+    const needsResolvedIds = hasPreciseListingCountFilters(row.filters);
+    const filters = needsResolvedIds
+      ? indexedById.get(row.id)
+      : buildIndexedWatchlistFiltersPayload(row.filters);
     if (!filters || hasUnresolvedIndexedTaxonomy(filters)) continue;
     candidates.push({
       id: row.id,
       filters,
       companyIds: row.company_ids ?? [],
-      fallbackCount: row.active_job_count,
+      fallbackCount: 0,
     });
   }
 


### PR DESCRIPTION
Closes #5896.

## Why

The signed-in watchlists page still failed after the server-loader fix because its initial query counted active postings for every company in every watchlist. For the production test user:

- 16 watchlists / 448 company edges
- the original SQL exceeded the 15-second statement timeout
- a partial active-company index reduced the plan cost but did not bring the query below 15 seconds
- the bounded watchlist metadata query completes in about 234 ms
- the exact 16-watchlist Typesense `multi_search` takes about 6.6 seconds

Exact job counts are useful, but they should not hold the entire page hostage.

## What changed

- Render watchlist metadata immediately without joining the posting history
- Show company counts as a useful initial fallback
- Fetch exact active-job counts after render through an authenticated, private, no-store endpoint
- Abort the optional count request after 12 seconds and keep the usable fallback
- Announce count replacements with `aria-live="polite"`
- Add English, German, French, and Italian company-count strings
- Cover the service/action boundary, endpoint auth/locale/cache behavior, immediate fallback rendering, async replacement, and loader locale propagation

## Verification

- `pnpm exec vitest run src/lib/services/__tests__/watchlists-tier.test.ts`
- `pnpm test` — 186 files / 1,425 tests
- `pnpm typecheck`
- focused ESLint
- `pnpm compile`
- `pnpm build`

The production screenshot and diagnostic notes remain private/untracked as requested; issue #5896 contains the user-visible evidence.
