### PR TITLE
Patch Next PPR metadata resume

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/next-ppr-resume-patch.test.ts
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/next-ppr-resume-patch.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const appRenderSource = readFileSync(
+  join(
+    process.cwd(),
+    "node_modules/next/dist/server/app-render/app-render.js",
+  ),
+  "utf8",
+);
+
+describe("Next.js PPR metadata resume patch (#5911)", () => {
+  it("keeps streaming metadata enabled while a postponed shell resumes", () => {
+    expect(appRenderSource).toContain(
+      "typeof renderOpts.postponed === 'string'",
+    );
+    expect(
+      appRenderSource.match(
+        /serveStreamingMetadata = getServeStreamingMetadata\(ctx\.renderOpts\)/g,
+      ),
+    ).toHaveLength(3);
+  });
+});

--- a/patches/next@16.2.11.patch
+++ b/patches/next@16.2.11.patch
@@ -1,0 +1,50 @@
+diff --git a/dist/server/app-render/app-render.js b/dist/server/app-render/app-render.js
+index 5588d51e277c6098267be890b2fe973b1eefd29b..78d6d80584f3a695cb5869836adf4a34ca73c4bb 100644
+--- a/dist/server/app-render/app-render.js
++++ b/dist/server/app-render/app-render.js
+@@ -305,6 +305,18 @@ function NonIndex({ createElement, pagePath, statusCode, isPossibleServerAction
+     }
+     return null;
+ }
++/**
++ * A resumed PPR render must use the same metadata tree shape as the
++ * prerender that produced the postponed state. Prerenders always enable
++ * streaming metadata, so enabling it on resumes avoids a React tree mismatch
++ * for bot user agents. Backport of vercel/next.js#94630 for Next 16.2.11.
++ */
++function getServeStreamingMetadata(renderOpts) {
++    if (typeof renderOpts.postponed === 'string') {
++        return true;
++    }
++    return !!renderOpts.serveStreamingMetadata;
++}
+ /**
+  * This is used by server actions & client-side navigations to generate RSC data from a client-side request.
+  * This function is only called on "dynamic" requests (ie, there wasn't already a static response).
+@@ -318,7 +330,7 @@ function NonIndex({ createElement, pagePath, statusCode, isPossibleServerAction
+     // action reducer sees a falsy value, it'll simply resolve the action with no data.
+     let flightData = '';
+     const { componentMod: { routeModule: { userland: { loaderTree } }, createElement, createMetadataComponents, Fragment }, query, requestId, flightRouterState, workStore, url } = ctx;
+-    const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata;
++    const serveStreamingMetadata = getServeStreamingMetadata(ctx.renderOpts);
+     if (!(options == null ? void 0 : options.skipPageRendering)) {
+         var _ctx_renderOpts_prefetchHints;
+         const preloadCallbacks = [];
+@@ -976,7 +988,7 @@ async function getRSCPayload(tree, ctx, options) {
+     const { getDynamicParamFromSegment, query, appUsingSizeAdjustment, componentMod: { createMetadataComponents, createElement, Fragment }, url, workStore } = ctx;
+     const hints = ((_ctx_renderOpts_prefetchHints = ctx.renderOpts.prefetchHints) == null ? void 0 : _ctx_renderOpts_prefetchHints[ctx.pagePath]) ?? null;
+     const initialTree = await (0, _createflightrouterstatefromloadertree.createFlightRouterStateFromLoaderTree)(tree, hints, getDynamicParamFromSegment, query);
+-    const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata;
++    const serveStreamingMetadata = getServeStreamingMetadata(ctx.renderOpts);
+     const hasGlobalNotFound = !!tree[2]['global-not-found'];
+     const metadataIsRuntimePrefetchable = await (0, _instantconfig.anySegmentHasRuntimePrefetchEnabled)(tree);
+     const { Viewport, Metadata, MetadataOutlet } = createMetadataComponents({
+@@ -1089,7 +1101,7 @@ async function getRSCPayload(tree, ctx, options) {
+ async function getErrorRSCPayload(tree, ctx, ssrError, errorType) {
+     var _ctx_renderOpts_prefetchHints;
+     const { getDynamicParamFromSegment, query, componentMod: { createMetadataComponents, createElement, Fragment }, url, workStore } = ctx;
+-    const serveStreamingMetadata = !!ctx.renderOpts.serveStreamingMetadata;
++    const serveStreamingMetadata = getServeStreamingMetadata(ctx.renderOpts);
+     const metadataIsRuntimePrefetchable = await (0, _instantconfig.anySegmentHasRuntimePrefetchEnabled)(tree);
+     const { Viewport, Metadata } = createMetadataComponents({
+         tree,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,11 @@ overrides:
   ws@>=7.0.0 <7.5.11: 7.5.11
   ws@>=8.0.0 <8.21.0: 8.21.0
 
+patchedDependencies:
+  next@16.2.11:
+    hash: 2f397d24627f610a14d95115f9c6e21fe502802ebb586b2b42ee065826c62c1d
+    path: patches/next@16.2.11.patch
+
 importers:
 
   .:
@@ -212,16 +217,16 @@ importers:
         version: 1.38.0
       '@vercel/analytics':
         specifier: ^2.0.1
-        version: 2.0.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.1(next@16.2.11(patch_hash=2f397d24627f610a14d95115f9c6e21fe502802ebb586b2b42ee065826c62c1d)(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       '@vercel/speed-insights':
         specifier: ^2.0.0
-        version: 2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+        version: 2.0.0(next@16.2.11(patch_hash=2f397d24627f610a14d95115f9c6e21fe502802ebb586b2b42ee065826c62c1d)(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
       apify-client:
         specifier: ^2.23.4
         version: 2.23.4
       better-auth:
         specifier: ^1.6.23
-        version: 1.6.24(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(postgres@3.4.9))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
+        version: 1.6.24(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(postgres@3.4.9))(next@16.2.11(patch_hash=2f397d24627f610a14d95115f9c6e21fe502802ebb586b2b42ee065826c62c1d)(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
       dompurify:
         specifier: ^3.4.12
         version: 3.4.12
@@ -248,7 +253,7 @@ importers:
         version: 1.0.0
       next:
         specifier: ^16.2.11
-        version: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.2.11(patch_hash=2f397d24627f610a14d95115f9c6e21fe502802ebb586b2b42ee065826c62c1d)(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-mdx-remote:
         specifier: ^6.0.0
         version: 6.0.0(@types/react@19.2.17)(react@19.2.8)
@@ -7682,14 +7687,14 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@2.0.1(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@vercel/analytics@2.0.1(next@16.2.11(patch_hash=2f397d24627f610a14d95115f9c6e21fe502802ebb586b2b42ee065826c62c1d)(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     optionalDependencies:
-      next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.2.11(patch_hash=2f397d24627f610a14d95115f9c6e21fe502802ebb586b2b42ee065826c62c1d)(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
 
-  '@vercel/speed-insights@2.0.0(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+  '@vercel/speed-insights@2.0.0(next@16.2.11(patch_hash=2f397d24627f610a14d95115f9c6e21fe502802ebb586b2b42ee065826c62c1d)(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
     optionalDependencies:
-      next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.2.11(patch_hash=2f397d24627f610a14d95115f9c6e21fe502802ebb586b2b42ee065826c62c1d)(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
 
   '@vitejs/plugin-react@6.0.4(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.23.1)(yaml@2.8.3))':
@@ -8109,7 +8114,7 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.6.24(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(postgres@3.4.9))(next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10):
+  better-auth@1.6.24(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(postgres@3.4.9))(next@16.2.11(patch_hash=2f397d24627f610a14d95115f9c6e21fe502802ebb586b2b42ee065826c62c1d)(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10):
     dependencies:
       '@better-auth/core': 1.6.24(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/drizzle-adapter': 1.6.24(@better-auth/core@1.6.24(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.0)(better-call@1.3.7(zod@4.3.6))(jose@6.2.4)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(postgres@3.4.9))
@@ -8131,7 +8136,7 @@ snapshots:
     optionalDependencies:
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(postgres@3.4.9)
-      next: 16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      next: 16.2.11(patch_hash=2f397d24627f610a14d95115f9c6e21fe502802ebb586b2b42ee065826c62c1d)(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       vitest: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.0)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.1.5(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.23.1)(yaml@2.8.3))
@@ -9914,7 +9919,7 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  next@16.2.11(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@16.2.11(patch_hash=2f397d24627f610a14d95115f9c6e21fe502802ebb586b2b42ee065826c62c1d)(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.2.11
       '@swc/helpers': 0.5.15

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,6 +34,9 @@ overrides:
   "ws@>=7.0.0 <7.5.11": 7.5.11
   "ws@>=8.0.0 <8.21.0": 8.21.0
 
+patchedDependencies:
+  next@16.2.11: patches/next@16.2.11.patch
+
 onlyBuiltDependencies:
   - esbuild
   - sharp


### PR DESCRIPTION
Closes #5911.

## Why

Production company-page requests intermittently log React resume failures and fall back to client rendering:

```text
Expected the resume to render <div> in this slot but instead it rendered <__next_metadata_boundary__>
```

Two app-level attempts—adding explicit route Suspense boundaries and sharing one cached company snapshot between `generateMetadata()` and the page—did not remove the failure on READY production deployments.

This is the pinned Next.js 16.2.11 form of [vercel/next.js#93401](https://github.com/vercel/next.js/issues/93401). The upstream fix [vercel/next.js#94630](https://github.com/vercel/next.js/pull/94630) identifies the framework cause: Vercel resumes a PPR shell with a metadata tree shape that differs for bot user agents.

## What changed

- Backport the upstream `getServeStreamingMetadata` guard into `next@16.2.11`
- Use the resume-safe guard at all three metadata-render call sites
- Pin the patch through pnpm `patchedDependencies`
- Add a regression test against the actual installed Next.js runtime, ensuring all three call sites remain patched

The patch should be removed when Jobseek upgrades to a Next.js release containing upstream #94630.

## Verification

- `pnpm install --frozen-lockfile`
- focused company-route tests — 3 passed
- `pnpm typecheck`
- focused ESLint
- `pnpm test` — 187 files / 1,426 tests
- `pnpm build`

Production verification must inspect Vercel logs after deployment because the visual fallback masks the failure. Existing screenshot evidence remains private/untracked; #5911 already embeds the affected company surface.
