### PR TITLE
Show an empty state for companies without active jobs

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-posting-state.test.ts
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-posting-state.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { getCompanyPostingListState } from "../company-posting-state";
+
+describe("getCompanyPostingListState", () => {
+  it("treats historical-only companies as a normal empty state", () => {
+    expect(
+      getCompanyPostingListState({
+        isSearching: false,
+        hasFilters: false,
+        postingCount: 0,
+        isTruncated: false,
+        activeCount: 0,
+      }),
+    ).toBe("no-active");
+  });
+
+  it("reports an unavailable search when active results disappear", () => {
+    expect(
+      getCompanyPostingListState({
+        isSearching: false,
+        hasFilters: false,
+        postingCount: 0,
+        isTruncated: false,
+        activeCount: 3,
+      }),
+    ).toBe("unavailable");
+  });
+
+  it("distinguishes filtered empty results from an empty company", () => {
+    expect(
+      getCompanyPostingListState({
+        isSearching: false,
+        hasFilters: true,
+        postingCount: 0,
+        isTruncated: false,
+        activeCount: 0,
+      }),
+    ).toBe("no-matches");
+  });
+});

--- a/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
@@ -7,6 +7,7 @@ import { useParams, usePathname, useSearchParams } from "next/navigation";
 import { timeAgoShort } from "@/lib/time";
 import { SaveButton } from "@/components/search/save-button";
 import { SearchUnavailable } from "@/components/search/search-unavailable";
+import { getCompanyPostingListState } from "./company-posting-state";
 import { JobDetailPanel } from "@/components/search/job-detail-dialog";
 import { MobileJobDetailDialog } from "@/components/search/mobile-job-detail-dialog";
 import { SearchToolbar } from "@/components/search/search-toolbar";
@@ -128,11 +129,13 @@ export function CompanyPage({
 
   const hasMore = !exhausted && !isTruncated && postings.length < yearCount;
   const hasFilters = keywords.length > 0 || locations.length > 0 || occupations.length > 0 || seniorities.length > 0 || technologies.length > 0 || employmentTypes.length > 0 || workMode.length > 0 || salaryMin != null || salaryMax != null || experienceMin != null || experienceMax != null;
-  const showUnavailable =
-    !isSearching &&
-    !hasFilters &&
-    postings.length === 0 &&
-    (isTruncated || activeCount > 0 || yearCount > 0);
+  const postingListState = getCompanyPostingListState({
+    isSearching,
+    hasFilters,
+    postingCount: postings.length,
+    isTruncated,
+    activeCount,
+  });
 
   /** Convert a salary amount from the user's display currency to EUR. */
   function toEur(amount: number | undefined): number | undefined {
@@ -620,16 +623,22 @@ export function CompanyPage({
       {statsRowMobile}
 
       {/* Posting list */}
-      {isSearching ? (
+      {postingListState === "loading" ? (
         <div className="flex items-center justify-center py-8">
           <Loader2 size={20} className="animate-spin text-muted" />
         </div>
-      ) : showUnavailable ? (
+      ) : postingListState === "unavailable" ? (
         <SearchUnavailable />
-      ) : postings.length === 0 && hasFilters ? (
+      ) : postingListState === "no-matches" ? (
         <p className="py-8 text-center text-sm text-muted">
           <Trans id="company.page.noResults" comment="No postings found message on company page">
             No matching postings found.
+          </Trans>
+        </p>
+      ) : postingListState === "no-active" ? (
+        <p className="py-8 text-center text-sm text-muted">
+          <Trans id="company.page.noActivePostings" comment="Empty-state message when a company has no active job postings">
+            No active postings right now.
           </Trans>
         </p>
       ) : (

--- a/apps/web/app/[lang]/(app)/company/[slug]/company-posting-state.ts
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-posting-state.ts
@@ -1,0 +1,28 @@
+export type CompanyPostingListState =
+  | "loading"
+  | "unavailable"
+  | "no-matches"
+  | "no-active"
+  | "results";
+
+interface CompanyPostingListStateInput {
+  isSearching: boolean;
+  hasFilters: boolean;
+  postingCount: number;
+  isTruncated: boolean;
+  activeCount: number;
+}
+
+export function getCompanyPostingListState({
+  isSearching,
+  hasFilters,
+  postingCount,
+  isTruncated,
+  activeCount,
+}: CompanyPostingListStateInput): CompanyPostingListState {
+  if (isSearching) return "loading";
+  if (postingCount > 0) return "results";
+  if (!hasFilters && (isTruncated || activeCount > 0)) return "unavailable";
+  if (hasFilters) return "no-matches";
+  return "no-active";
+}

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -2646,6 +2646,12 @@ msgstr "Keine Standorte gefunden."
 msgid "company.page.noResults"
 msgstr "Keine passenden Stellenanzeigen gefunden."
 
+#. Empty-state message when a company has no active job postings
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:640
+msgid "company.page.noActivePostings"
+msgstr "Derzeit keine aktiven Stellenanzeigen."
+
 #. Empty-state message shown when no blog posts have been published yet
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:89

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -2646,6 +2646,12 @@ msgstr "No locations match your search."
 msgid "company.page.noResults"
 msgstr "No matching postings found."
 
+#. Empty-state message when a company has no active job postings
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:640
+msgid "company.page.noActivePostings"
+msgstr "No active postings right now."
+
 #. Empty-state message shown when no blog posts have been published yet
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:89

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -2646,6 +2646,12 @@ msgstr "Aucun lieu ne correspond à votre recherche."
 msgid "company.page.noResults"
 msgstr "Aucune offre correspondante trouvée."
 
+#. Empty-state message when a company has no active job postings
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:640
+msgid "company.page.noActivePostings"
+msgstr "Aucune offre active pour le moment."
+
 #. Empty-state message shown when no blog posts have been published yet
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:89

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -2646,6 +2646,12 @@ msgstr "Nessun luogo corrisponde alla tua ricerca."
 msgid "company.page.noResults"
 msgstr "Nessun annuncio corrispondente trovato."
 
+#. Empty-state message when a company has no active job postings
+#. js-lingui-explicit-id
+#: app/[lang]/(app)/company/[slug]/company-page.tsx:640
+msgid "company.page.noActivePostings"
+msgstr "Nessuna offerta attiva al momento."
+
 #. Empty-state message shown when no blog posts have been published yet
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/blog/page.tsx:89


### PR DESCRIPTION
## Summary

- distinguish a valid zero-active company from provider/search unavailability
- show a localized “No active postings right now” state when historical postings exist but active results are empty
- keep provider unavailability and filtered-no-match states separate
- cover the result-state classifier with focused regression tests

## Validation

- `pnpm --filter @jobseek/web compile`
- `pnpm --filter @jobseek/web test --run` (188 files, 1429 tests)
- `pnpm --filter @jobseek/web typecheck`
- `pnpm --filter @jobseek/web lint`
- `pnpm --filter @jobseek/web build`

Fixes #5961