### PR TITLE
Localize posting counts and relative times

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
@@ -26,6 +26,7 @@ import { useLatest, useLatestState } from "@/lib/use-latest";
 import type { SearchResultPosting, HistogramFilters, WorkMode } from "@/lib/search";
 import type { SelectedLocation } from "@/lib/search/types";
 import { useSearchStateStore } from "@/components/providers/SearchStateProvider";
+import { ActivePostingCount, YearPostingCount } from "@/components/search/posting-count-labels";
 
 const PAGE_SIZE = 20;
 
@@ -546,21 +547,19 @@ export function CompanyPage({
   // left/right.
   const statsSlot = (
     <p className="hidden whitespace-nowrap text-xs text-muted md:block">
-      {activeCount} <Trans id="company.page.active" comment="Active postings count on company page">active</Trans>
+      <ActivePostingCount count={activeCount} />
       {" · "}
-      {yearCount} <Trans id="company.page.yearCount" comment="Year postings count on company page">in the last year</Trans>
+      <YearPostingCount count={yearCount} />
     </p>
   );
   // Mobile: dedicated row. Active left, year right.
   const statsRowMobile = (
     <div className="flex items-center justify-between text-xs text-muted md:hidden">
       <span>
-        {activeCount}{" "}
-        <Trans id="company.page.active" comment="Active postings count on company page">active</Trans>
+        <ActivePostingCount count={activeCount} />
       </span>
       <span>
-        {yearCount}{" "}
-        <Trans id="company.page.yearCount" comment="Year postings count on company page">in the last year</Trans>
+        <YearPostingCount count={yearCount} />
       </span>
     </div>
   );
@@ -670,7 +669,7 @@ export function CompanyPage({
               {!posting.title && <PendingJobIcon />}
               <SaveButton postingId={posting.id} />
               <span suppressHydrationWarning className="w-8 shrink-0 text-left text-[10px] tabular-nums text-muted">
-                {timeAgoShort(posting.firstSeenAt)}
+                {timeAgoShort(posting.firstSeenAt, uiLocale)}
               </span>
             </div>
           ))}

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -223,27 +223,17 @@ msgstr "Konto"
 msgid "app.header.avatar.label"
 msgstr "Kontomenü"
 
-#. Active postings count on company page
-#. Active postings count on company page
+#. Locale-formatted active posting count
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:572
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:582
-msgid "company.page.active"
-msgstr "aktiv"
+#: src/components/search/posting-count-labels.tsx
+msgid "common.stats.activeCount"
+msgstr "{count, plural, one {# aktive Stelle} other {# aktive Stellen}}"
 
-#. Active postings count
-#. Active postings count
+#. Locale-formatted postings seen in the last year count
 #. js-lingui-explicit-id
-#: src/components/search/language-stats-row.tsx:36
-#: src/components/search/language-stats-row.tsx:47
-msgid "common.stats.active"
-msgstr "aktiv"
-
-#. Active matches label on company card
-#. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:122
-msgid "search.card.active"
-msgstr "aktiv"
+#: src/components/search/posting-count-labels.tsx
+msgid "common.stats.yearCountWithValue"
+msgstr "{count, plural, one {# im letzten Jahr} other {# im letzten Jahr}}"
 
 #. Title for add companies modal
 #. js-lingui-explicit-id
@@ -1877,28 +1867,6 @@ msgstr "Wenn du ungewöhnliches Crawler-Verhalten bemerkst, es vorziehst, dass w
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:80
 msgid "watchlist.meta.inLocations"
 msgstr "in {locations}"
-
-#. Year postings count on company page
-#. Year postings count on company page
-#. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:574
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:586
-msgid "company.page.yearCount"
-msgstr "im letzten Jahr"
-
-#. Postings seen in the last year count
-#. Postings seen in the last year count
-#. js-lingui-explicit-id
-#: src/components/search/language-stats-row.tsx:39
-#: src/components/search/language-stats-row.tsx:51
-msgid "common.stats.yearCount"
-msgstr "im letzten Jahr"
-
-#. Yearly matches label on company card
-#. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:124
-msgid "search.card.yearCount"
-msgstr "im letzten Jahr"
 
 #. Stat label on a WatchlistCard mention card — 'in the past year' (year-to-date jobs counted by the watchlist filters)
 #. js-lingui-explicit-id

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -223,27 +223,17 @@ msgstr "Account"
 msgid "app.header.avatar.label"
 msgstr "Account menu"
 
-#. Active postings count on company page
-#. Active postings count on company page
+#. Locale-formatted active posting count
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:572
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:582
-msgid "company.page.active"
-msgstr "active"
+#: src/components/search/posting-count-labels.tsx
+msgid "common.stats.activeCount"
+msgstr "{count, plural, one {# active job} other {# active jobs}}"
 
-#. Active postings count
-#. Active postings count
+#. Locale-formatted postings seen in the last year count
 #. js-lingui-explicit-id
-#: src/components/search/language-stats-row.tsx:36
-#: src/components/search/language-stats-row.tsx:47
-msgid "common.stats.active"
-msgstr "active"
-
-#. Active matches label on company card
-#. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:122
-msgid "search.card.active"
-msgstr "active"
+#: src/components/search/posting-count-labels.tsx
+msgid "common.stats.yearCountWithValue"
+msgstr "{count, plural, one {# in the last year} other {# in the last year}}"
 
 #. Title for add companies modal
 #. js-lingui-explicit-id
@@ -1877,28 +1867,6 @@ msgstr "If you notice unusual crawler behaviour, prefer that we do not index you
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:80
 msgid "watchlist.meta.inLocations"
 msgstr "in {locations}"
-
-#. Year postings count on company page
-#. Year postings count on company page
-#. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:574
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:586
-msgid "company.page.yearCount"
-msgstr "in the last year"
-
-#. Postings seen in the last year count
-#. Postings seen in the last year count
-#. js-lingui-explicit-id
-#: src/components/search/language-stats-row.tsx:39
-#: src/components/search/language-stats-row.tsx:51
-msgid "common.stats.yearCount"
-msgstr "in the last year"
-
-#. Yearly matches label on company card
-#. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:124
-msgid "search.card.yearCount"
-msgstr "in the last year"
 
 #. Stat label on a WatchlistCard mention card — 'in the past year' (year-to-date jobs counted by the watchlist filters)
 #. js-lingui-explicit-id

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -223,27 +223,17 @@ msgstr "Compte"
 msgid "app.header.avatar.label"
 msgstr "Menu du compte"
 
-#. Active postings count on company page
-#. Active postings count on company page
+#. Locale-formatted active posting count
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:572
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:582
-msgid "company.page.active"
-msgstr "actif"
+#: src/components/search/posting-count-labels.tsx
+msgid "common.stats.activeCount"
+msgstr "{count, plural, =0 {# offres actives} one {# offre active} other {# offres actives}}"
 
-#. Active postings count
-#. Active postings count
+#. Locale-formatted postings seen in the last year count
 #. js-lingui-explicit-id
-#: src/components/search/language-stats-row.tsx:36
-#: src/components/search/language-stats-row.tsx:47
-msgid "common.stats.active"
-msgstr "actifs"
-
-#. Active matches label on company card
-#. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:122
-msgid "search.card.active"
-msgstr "actif"
+#: src/components/search/posting-count-labels.tsx
+msgid "common.stats.yearCountWithValue"
+msgstr "{count, plural, one {# au cours de la dernière année} other {# au cours de la dernière année}}"
 
 #. Title for add companies modal
 #. js-lingui-explicit-id
@@ -1877,28 +1867,6 @@ msgstr "Si tu remarques un comportement inhabituel de notre robot, préfères qu
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:80
 msgid "watchlist.meta.inLocations"
 msgstr "à {locations}"
-
-#. Year postings count on company page
-#. Year postings count on company page
-#. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:574
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:586
-msgid "company.page.yearCount"
-msgstr "au cours de la dernière année"
-
-#. Postings seen in the last year count
-#. Postings seen in the last year count
-#. js-lingui-explicit-id
-#: src/components/search/language-stats-row.tsx:39
-#: src/components/search/language-stats-row.tsx:51
-msgid "common.stats.yearCount"
-msgstr "sur la dernière année"
-
-#. Yearly matches label on company card
-#. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:124
-msgid "search.card.yearCount"
-msgstr "au cours de la dernière année"
 
 #. Stat label on a WatchlistCard mention card — 'in the past year' (year-to-date jobs counted by the watchlist filters)
 #. js-lingui-explicit-id

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -223,27 +223,17 @@ msgstr "Account"
 msgid "app.header.avatar.label"
 msgstr "Menu account"
 
-#. Active postings count on company page
-#. Active postings count on company page
+#. Locale-formatted active posting count
 #. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:572
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:582
-msgid "company.page.active"
-msgstr "attivo"
+#: src/components/search/posting-count-labels.tsx
+msgid "common.stats.activeCount"
+msgstr "{count, plural, one {# offerta attiva} other {# offerte attive}}"
 
-#. Active postings count
-#. Active postings count
+#. Locale-formatted postings seen in the last year count
 #. js-lingui-explicit-id
-#: src/components/search/language-stats-row.tsx:36
-#: src/components/search/language-stats-row.tsx:47
-msgid "common.stats.active"
-msgstr "attivi"
-
-#. Active matches label on company card
-#. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:122
-msgid "search.card.active"
-msgstr "attivo"
+#: src/components/search/posting-count-labels.tsx
+msgid "common.stats.yearCountWithValue"
+msgstr "{count, plural, one {# nell'ultimo anno} other {# nell'ultimo anno}}"
 
 #. Title for add companies modal
 #. js-lingui-explicit-id
@@ -1877,28 +1867,6 @@ msgstr "Se noti un comportamento anomalo del crawler, preferisci che non indiciz
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:80
 msgid "watchlist.meta.inLocations"
 msgstr "a {locations}"
-
-#. Year postings count on company page
-#. Year postings count on company page
-#. js-lingui-explicit-id
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:574
-#: app/[lang]/(app)/company/[slug]/company-page.tsx:586
-msgid "company.page.yearCount"
-msgstr "nell'ultimo anno"
-
-#. Postings seen in the last year count
-#. Postings seen in the last year count
-#. js-lingui-explicit-id
-#: src/components/search/language-stats-row.tsx:39
-#: src/components/search/language-stats-row.tsx:51
-msgid "common.stats.yearCount"
-msgstr "nell'ultimo anno"
-
-#. Yearly matches label on company card
-#. js-lingui-explicit-id
-#: src/components/search/company-card.tsx:124
-msgid "search.card.yearCount"
-msgstr "nell'ultimo anno"
 
 #. Stat label on a WatchlistCard mention card — 'in the past year' (year-to-date jobs counted by the watchlist filters)
 #. js-lingui-explicit-id

--- a/apps/web/src/components/my-jobs/my-job-detail-panel.tsx
+++ b/apps/web/src/components/my-jobs/my-job-detail-panel.tsx
@@ -269,6 +269,7 @@ export function MyJobDetailPanel({
 function PostingContent({ detail }: { detail: PostingDetail }) {
   const { company } = detail;
   const lp = useLocalePath();
+  const { i18n } = useLingui();
 
   return (
     <>
@@ -309,7 +310,7 @@ function PostingContent({ detail }: { detail: PostingDetail }) {
           </span>
         )}
         <span suppressHydrationWarning>
-          {timeAgoShort(detail.firstSeenAt)}
+          {timeAgoShort(detail.firstSeenAt, i18n.locale)}
         </span>
         <SaveButton postingId={detail.id} />
       </div>

--- a/apps/web/src/components/my-jobs/my-job-row.tsx
+++ b/apps/web/src/components/my-jobs/my-job-row.tsx
@@ -5,6 +5,7 @@ import { timeAgoShort } from "@/lib/time";
 import { TrackingDot } from "@/components/TrackingDot";
 import { PendingJobIcon } from "@/components/PendingJobWarning";
 import type { MyJobEntry } from "@/lib/actions/my-jobs";
+import { useLingui } from "@lingui/react/macro";
 
 interface MyJobRowProps {
   entry: MyJobEntry;
@@ -17,6 +18,8 @@ export function MyJobRow({
   isSelected,
   onSelect,
 }: MyJobRowProps) {
+  const { i18n } = useLingui();
+
   return (
     <div
       role="button"
@@ -45,7 +48,7 @@ export function MyJobRow({
         suppressHydrationWarning
         className="w-8 shrink-0 text-right text-[10px] tabular-nums text-muted"
       >
-        {timeAgoShort(entry.statusChangedAt)}
+        {timeAgoShort(entry.statusChangedAt, i18n.locale)}
       </span>
 
       <TrackingDot postingId={entry.posting.id} />

--- a/apps/web/src/components/search/__tests__/posting-count-labels.test.tsx
+++ b/apps/web/src/components/search/__tests__/posting-count-labels.test.tsx
@@ -1,0 +1,25 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import "@/test-utils/lingui-mock";
+import { ActivePostingCount, YearPostingCount } from "../posting-count-labels";
+
+function renderCounts(active: number, year: number) {
+  const { container } = render(
+    <p>
+      <ActivePostingCount count={active} />
+      {" · "}
+      <YearPostingCount count={year} />
+    </p>,
+  );
+  return container.textContent;
+}
+
+describe("posting count labels", () => {
+  it("selects the singular fallback", () => {
+    expect(renderCounts(1, 1)).toBe("1 active job · 1 in the last year");
+  });
+
+  it("selects the plural fallback", () => {
+    expect(renderCounts(3333, 8698)).toBe("3333 active jobs · 8698 in the last year");
+  });
+});

--- a/apps/web/src/components/search/company-card.tsx
+++ b/apps/web/src/components/search/company-card.tsx
@@ -16,6 +16,7 @@ import { PendingJobIcon } from "@/components/PendingJobWarning";
 import { SaveButton } from "@/components/search/save-button";
 import { StarButton } from "@/components/search/star-button";
 import { ScrollFade } from "@/components/ui/scroll-fade";
+import { ActivePostingCount, YearPostingCount } from "@/components/search/posting-count-labels";
 import { buildFilteredPath } from "@/lib/search/query-params";
 import type { SerializableLocation, SerializableOccupation, SerializableSeniority, SerializableTechnology } from "@/lib/search/query-params";
 import type { SearchResultCompany, SearchResultPosting, WorkMode } from "@/lib/search";
@@ -140,9 +141,9 @@ function CompanyCardImpl({ result, keywords, locationIds, locations, occupations
 
       {/* Stats */}
       <p className="mt-2 text-xs text-muted">
-        {activeMatches} <Trans id="search.card.active" comment="Active matches label on company card">active</Trans>
+        <ActivePostingCount count={activeMatches} />
         {" · "}
-        {yearMatches} <Trans id="search.card.yearCount" comment="Yearly matches label on company card">in the last year</Trans>
+        <YearPostingCount count={yearMatches} />
       </p>
 
       {/* Divider */}
@@ -211,7 +212,7 @@ function CompanyCardImpl({ result, keywords, locationIds, locations, occupations
               <SaveButton postingId={posting.id} />
             </span>
             <span suppressHydrationWarning className="w-8 shrink-0 text-left text-[10px] tabular-nums text-muted">
-              {timeAgoShort(posting.firstSeenAt)}
+              {timeAgoShort(posting.firstSeenAt, locale)}
             </span>
           </div>
         ))}

--- a/apps/web/src/components/search/job-detail-dialog.tsx
+++ b/apps/web/src/components/search/job-detail-dialog.tsx
@@ -80,7 +80,7 @@ function DetailContent({ detail, descriptionLoaded }: { detail: PostingDetail; d
   const lp = useLocalePath();
   const pageActions = usePageActions();
   const salary = useSalaryDisplay();
-  const { t } = useLingui();
+  const { t, i18n } = useLingui();
   const filterByPrefix = t({ id: "search.detail.filterByPrefix", comment: "Tooltip prefix for clickable filter pills, followed by the value name", message: "Filter by" });
   const { getStatus, getSavedJobId, setStatus: setTrackingStatus } = useSavedJobs();
   const trackingStatus = getStatus(detail.id);
@@ -143,7 +143,7 @@ function DetailContent({ detail, descriptionLoaded }: { detail: PostingDetail; d
           <span className="text-sm font-semibold">{company.name}</span>
         </Link>
         <div className="ml-auto flex shrink-0 items-center gap-2">
-          <span suppressHydrationWarning className="text-[10px] tabular-nums text-muted">{timeAgoShort(detail.firstSeenAt)}</span>
+          <span suppressHydrationWarning className="text-[10px] tabular-nums text-muted">{timeAgoShort(detail.firstSeenAt, i18n.locale)}</span>
           <SaveButton postingId={detail.id} />
           <a
             href={withUtmSource(detail.sourceUrl)}

--- a/apps/web/src/components/search/language-stats-row.tsx
+++ b/apps/web/src/components/search/language-stats-row.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Trans } from "@lingui/react/macro";
 import { LanguageNote } from "@/components/search/language-note";
+import { ActivePostingCount, YearPostingCount } from "@/components/search/posting-count-labels";
 
 type Props = {
   jobLanguages: string[];
@@ -21,36 +21,26 @@ type Props = {
  *        the two high-signal numbers mirror the page's own left/right
  *        reading flow).
  *
- * Numbers are locale-formatted (`toLocaleString`) so the thousands
- * separator follows the page locale.
+ * Counts are rendered through ICU plurals so both number formatting and
+ * grammar follow the active locale.
  */
 export function LanguageStatsRow({ jobLanguages, locale, activeCount, yearCount }: Props) {
-  const active = activeCount.toLocaleString(locale);
-  const year = yearCount.toLocaleString(locale);
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between gap-4">
         <LanguageNote jobLanguages={jobLanguages} locale={locale} />
         <p className="hidden whitespace-nowrap text-xs text-muted md:block">
-          {active}{" "}
-          <Trans id="common.stats.active" comment="Active postings count">active</Trans>
+          <ActivePostingCount count={activeCount} />
           {" · "}
-          {year}{" "}
-          <Trans id="common.stats.yearCount" comment="Postings seen in the last year count">
-            in the last year
-          </Trans>
+          <YearPostingCount count={yearCount} />
         </p>
       </div>
       <div className="flex items-center justify-between text-xs text-muted md:hidden">
         <span>
-          {active}{" "}
-          <Trans id="common.stats.active" comment="Active postings count">active</Trans>
+          <ActivePostingCount count={activeCount} />
         </span>
         <span>
-          {year}{" "}
-          <Trans id="common.stats.yearCount" comment="Postings seen in the last year count">
-            in the last year
-          </Trans>
+          <YearPostingCount count={yearCount} />
         </span>
       </div>
     </div>

--- a/apps/web/src/components/search/posting-count-labels.tsx
+++ b/apps/web/src/components/search/posting-count-labels.tsx
@@ -1,0 +1,25 @@
+import { Plural } from "@lingui/react/macro";
+
+export function ActivePostingCount({ count }: { count: number }) {
+  return (
+    <Plural
+      id="common.stats.activeCount"
+      comment="Locale-formatted active posting count"
+      value={count}
+      one="# active job"
+      other="# active jobs"
+    />
+  );
+}
+
+export function YearPostingCount({ count }: { count: number }) {
+  return (
+    <Plural
+      id="common.stats.yearCountWithValue"
+      comment="Locale-formatted postings seen in the last year count"
+      value={count}
+      one="# in the last year"
+      other="# in the last year"
+    />
+  );
+}

--- a/apps/web/src/components/watchlist/company-search-modal.tsx
+++ b/apps/web/src/components/watchlist/company-search-modal.tsx
@@ -15,6 +15,7 @@ import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
 import { InfiniteScrollSentinel } from "@/components/InfiniteScrollSentinel";
 import { RequestCompanyPrompt } from "@/components/search/request-company";
 import { useStarredCompanies } from "@/components/providers/StarredCompaniesProvider";
+import { ActivePostingCount, YearPostingCount } from "@/components/search/posting-count-labels";
 
 type SelectedCompany = { id: string; name: string; slug: string; icon: string | null };
 
@@ -337,7 +338,9 @@ export function CompanySearchModal({
                             {c.name}
                           </span>
                           <span className="text-xs text-muted">
-                            {c.activeMatches} active · {c.yearMatches} in the last year
+                            <ActivePostingCount count={c.activeMatches} />
+                            {" · "}
+                            <YearPostingCount count={c.yearMatches} />
                           </span>
                         </div>
                         {c.description && (

--- a/apps/web/src/components/watchlist/watchlist-job-list.tsx
+++ b/apps/web/src/components/watchlist/watchlist-job-list.tsx
@@ -256,7 +256,7 @@ export function WatchlistJobList({
           suppressHydrationWarning
           className="w-8 shrink-0 text-left text-[10px] tabular-nums text-muted"
         >
-          {timeAgoShort(entry.firstSeenAt)}
+          {timeAgoShort(entry.firstSeenAt, locale)}
         </span>
       </div>,
     );

--- a/apps/web/src/lib/__tests__/time.test.ts
+++ b/apps/web/src/lib/__tests__/time.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { timeAgoShort } from "../time";
+
+const NOW = new Date("2026-07-22T12:00:00Z");
+
+describe("timeAgoShort", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("preserves the compact English labels", () => {
+    expect(timeAgoShort(new Date(NOW.getTime() - 51 * 60_000))).toBe("51m");
+    expect(timeAgoShort(new Date(NOW.getTime() - 3 * 60 * 60_000))).toBe("3h");
+    expect(timeAgoShort(new Date(NOW.getTime() - 2 * DAY_MS))).toBe("2d");
+    expect(timeAgoShort(new Date(NOW.getTime() - 21 * DAY_MS))).toBe("3w");
+    expect(timeAgoShort(new Date(NOW.getTime() - 90 * DAY_MS))).toBe("3mo");
+    expect(timeAgoShort(new Date(NOW.getTime() - 730 * DAY_MS))).toBe("2y");
+  });
+
+  it("uses locale-aware narrow units", () => {
+    const minutesAgo = new Date(NOW.getTime() - 51 * 60_000);
+    const monthsAgo = new Date(NOW.getTime() - 90 * DAY_MS);
+
+    expect(timeAgoShort(minutesAgo, "de")).toBe("51 Min.");
+    expect(timeAgoShort(monthsAgo, "de")).toBe("3 M");
+    expect(timeAgoShort(minutesAgo, "fr")).toBe("51min");
+    expect(timeAgoShort(monthsAgo, "fr")).toBe("3m.");
+    expect(timeAgoShort(minutesAgo, "it")).toBe("51min");
+    expect(timeAgoShort(monthsAgo, "it")).toBe("3 mesi");
+  });
+});
+
+const DAY_MS = 24 * 60 * 60 * 1000;

--- a/apps/web/src/lib/time.ts
+++ b/apps/web/src/lib/time.ts
@@ -1,18 +1,48 @@
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-export function timeAgoShort(date: Date | string): string {
+type RelativeUnit = "year" | "month" | "week" | "day" | "hour" | "minute";
+
+const unitFormatters = new Map<string, Intl.NumberFormat>();
+
+function formatShortUnit(value: number, unit: RelativeUnit, locale: string): string {
+  // CLDR's English narrow month symbol is "m", which is indistinguishable
+  // from minutes. Preserve the established unambiguous English "mo" label.
+  if (unit === "month" && locale.toLowerCase().startsWith("en")) {
+    const key = `${locale}:month-token`;
+    let formatter = unitFormatters.get(key);
+    if (!formatter) {
+      formatter = new Intl.NumberFormat(locale);
+      unitFormatters.set(key, formatter);
+    }
+    return `${formatter.format(value)}mo`;
+  }
+
+  const key = `${locale}:${unit}`;
+  let formatter = unitFormatters.get(key);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(locale, {
+      style: "unit",
+      unit,
+      unitDisplay: "narrow",
+    });
+    unitFormatters.set(key, formatter);
+  }
+  return formatter.format(value);
+}
+
+export function timeAgoShort(date: Date | string, locale = "en"): string {
   const d = typeof date === "string" ? new Date(date) : date;
   const diffMs = Date.now() - d.getTime();
   const days = Math.floor(diffMs / DAY_MS);
 
-  if (days >= 365) return `${Math.floor(days / 365)}y`;
-  if (days >= 30) return `${Math.floor(days / 30)}mo`;
-  if (days >= 7) return `${Math.floor(days / 7)}w`;
-  if (days > 0) return `${days}d`;
+  if (days >= 365) return formatShortUnit(Math.floor(days / 365), "year", locale);
+  if (days >= 30) return formatShortUnit(Math.floor(days / 30), "month", locale);
+  if (days >= 7) return formatShortUnit(Math.floor(days / 7), "week", locale);
+  if (days > 0) return formatShortUnit(days, "day", locale);
 
   const hours = Math.floor(diffMs / (60 * 60 * 1000));
-  if (hours > 0) return `${hours}h`;
+  if (hours > 0) return formatShortUnit(hours, "hour", locale);
 
   const minutes = Math.max(1, Math.floor(diffMs / (60 * 1000)));
-  return `${minutes}m`;
+  return formatShortUnit(minutes, "minute", locale);
 }

--- a/apps/web/src/test-utils/lingui-mock.ts
+++ b/apps/web/src/test-utils/lingui-mock.ts
@@ -28,12 +28,14 @@ const fromMessage = (input: MessageLike): string =>
   typeof input === "string" ? input : (input.message ?? input.id ?? "");
 
 vi.mock("@lingui/react", () => ({
-  useLingui: () => ({ _: fromMessage }),
+  useLingui: () => ({ _: fromMessage, i18n: { locale: "en" } }),
 }));
 
 vi.mock("@lingui/react/macro", () => ({
-  useLingui: () => ({ t: fromMessage }),
+  useLingui: () => ({ t: fromMessage, i18n: { locale: "en" } }),
   Trans: ({ children }: { children: ReactNode }) => children,
+  Plural: ({ value, one, other }: { value: number; one: string; other: string }) =>
+    (value === 1 ? one : other).replace("#", String(value)),
 }));
 
 vi.mock("@lingui/core/macro", () => ({


### PR DESCRIPTION
Fixes #5965
Fixes #5966

## Summary
- format compact relative-time units with cached locale-aware `Intl.NumberFormat` instances across Explore, company pages, watchlists, job details, and My Jobs
- render active/year posting counts through shared ICU plurals so numbers group correctly and French/Italian grammar agrees with the count
- localize the previously hard-coded company-count row in the watchlist company picker
- add regression coverage for time thresholds and shared singular/plural count rendering

## Validation
- `pnpm --filter @jobseek/web test` — 191 files / 1437 tests
- `pnpm --filter @jobseek/web compile`
- `pnpm --filter @jobseek/web typecheck`
- `pnpm --filter @jobseek/web lint`
- `pnpm --filter @jobseek/web build`
- `bash scripts/check-i18n-coverage.sh`