### PR TITLE
Correct public crawler policy claims

### DIFF
--- a/apps/web/app/[lang]/(public)/about/about-content.tsx
+++ b/apps/web/app/[lang]/(public)/about/about-content.tsx
@@ -52,7 +52,7 @@ export function AboutContent({ contactEmail, ossRepoUrl }: AboutContentProps) {
               <div className="mt-4 flex flex-col gap-6 text-muted">
                 <p>
                   <Trans id="about.transparency.p1" comment="About transparency paragraph">
-                    The crawler code is open source so anyone can audit how we collect data. We respect robots.txt, honor TDM-Reservation headers, and limit ourselves to one request per site per minute. Every outbound link includes utm_source=jobseek so employers know where their traffic comes from.
+                    The crawler code is open source so anyone can audit how we collect data. We inspect robots.txt for sitemap discovery, honor TDM-Reservation headers, and pace requests per rate-limit domain. Every outbound link includes utm_source=jobseek so employers know where their traffic comes from.
                   </Trans>
                 </p>
               </div>

--- a/apps/web/app/[lang]/(public)/faq/page.tsx
+++ b/apps/web/app/[lang]/(public)/faq/page.tsx
@@ -79,7 +79,7 @@ export default async function FaqPage({ params }: Props) {
     },
     {
       q: i18n._({ id: "faq.q.crawlingPolicy", comment: "FAQ question for company operators about crawler behavior.", message: "How does the crawler behave on my company's website?" }),
-      a: i18n._({ id: "faq.a.crawlingPolicy", comment: "FAQ answer summarizing crawler politeness, rate limits, and policy compliance.", message: "We respect robots.txt and TDM-Reservation headers, limit requests to one per site per minute, and use exponential backoff. All requests identify themselves via User-Agent. See our Job Indexing page for full details." }),
+      a: i18n._({ id: "faq.a.crawlingPolicy", comment: "FAQ answer accurately summarizing robots handling, request identity, pacing, and TDM policy.", message: "We inspect robots.txt for sitemap discovery; Disallow enforcement is not yet active. We respect TDM-Reservation headers, pace requests per rate-limit domain, and use exponential backoff. Most requests use a stable browser-compatible User-Agent, while source-specific paths may use an identifying Job Seek UA. See our Job Indexing page for full details." }),
     },
     {
       q: i18n._({ id: "faq.q.optOut", comment: "FAQ question about company opt-out from indexing.", message: "Can I opt out of Jobseek indexing my company?" }),

--- a/apps/web/app/[lang]/(public)/how-we-index/page.tsx
+++ b/apps/web/app/[lang]/(public)/how-we-index/page.tsx
@@ -22,7 +22,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const description = i18n._({
     id: "indexing.meta.description",
     comment: "SEO description for the public Job Indexing methodology page.",
-    message: "How Job Seek discovers and indexes job postings: our sourcing approach, crawl frequency, rate limits, robots.txt and TDM-Reservation compliance, and how to opt out.",
+    message: "How Job Seek discovers and indexes job postings: sourcing, crawl frequency, rate limits, robots.txt discovery, TDM-Reservation handling, and how to opt out.",
   });
 
   return {
@@ -59,7 +59,7 @@ export default async function HowWeIndexPage({ params }: Props) {
         description: i18n._({
           id: "indexing.meta.description",
           comment: "JSON-LD page description for the public Job Indexing methodology page.",
-          message: "How Job Seek discovers and indexes job postings: our sourcing approach, crawl frequency, rate limits, robots.txt and TDM-Reservation compliance, and how to opt out.",
+          message: "How Job Seek discovers and indexes job postings: sourcing, crawl frequency, rate limits, robots.txt discovery, TDM-Reservation handling, and how to opt out.",
         }),
         url: `${siteConfig.url}/${locale}/how-we-index`,
         inLanguage: locale,

--- a/apps/web/app/__tests__/indexing-policy-copy.test.ts
+++ b/apps/web/app/__tests__/indexing-policy-copy.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const howWeIndex = readFileSync(
+  "src/components/HowWeIndexContent.tsx",
+  "utf8",
+);
+const faq = readFileSync("app/[lang]/(public)/faq/page.tsx", "utf8");
+const about = readFileSync(
+  "app/[lang]/(public)/about/about-content.tsx",
+  "utf8",
+);
+const crawlerConfig = readFileSync("../crawler/src/config.py", "utf8");
+
+describe("public indexing-policy copy", () => {
+  it("matches the crawler's configured per-domain pacing", () => {
+    expect(crawlerConfig).toContain("throttle_delay_default: float = 2.0");
+    expect(crawlerConfig).toContain("throttle_delay_ats: float = 0.5");
+    expect(howWeIndex).toContain("by 2 seconds by default and 0.5 seconds");
+    expect(howWeIndex).not.toContain("one request per site per minute");
+  });
+
+  it("describes current robots and User-Agent behavior without false guarantees", () => {
+    for (const source of [howWeIndex, faq, about]) {
+      expect(source).not.toContain("identifies itself via");
+      expect(source).not.toContain("All requests identify themselves");
+      expect(source).not.toContain("We respect robots.txt");
+    }
+
+    expect(howWeIndex).toContain("Disallow enforcement is not yet active");
+    expect(howWeIndex).toContain("stable browser-compatible");
+    expect(faq).toContain("Disallow enforcement is not yet active");
+  });
+
+  it("removes the fictional identifying UA from every translated blog post", () => {
+    for (const file of [
+      "src/content/blog/how-we-index-job-postings.mdx",
+      "src/content/blog/how-we-index-job-postings.de.mdx",
+      "src/content/blog/how-we-index-job-postings.fr.mdx",
+      "src/content/blog/how-we-index-job-postings.it.mdx",
+    ]) {
+      const post = readFileSync(file, "utf8");
+      expect(post).not.toContain("Job-Seek-Crawler/X.Y");
+      expect(post).toContain("issues/2841");
+    }
+  });
+});

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -1379,7 +1379,7 @@ msgstr "Gib unten dein neues Passwort ein."
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:78
 msgid "indexing.assurances.i3.body"
-msgstr "Auch nach der Entdeckung rufen wir Stellendetailseiten mit einem strikten Limit von einer Anfrage pro Seite pro Minute ab."
+msgstr "Die Queue hält zwischen Anfragen an dieselbe Rate-Limit-Domain standardmäßig 2 Sekunden und bei bekannten ATS-APIs 0,5 Sekunden Abstand. Der tatsächliche Traffic ist meist geringer, und Wiederholungen verwenden exponentielles Backoff."
 
 #. Feature section 1 heading
 #. js-lingui-explicit-id
@@ -1792,7 +1792,7 @@ msgstr "Wie verhält sich der Crawler auf der Website meines Unternehmens?"
 #: app/[lang]/(public)/how-we-index/page.tsx:22
 #: app/[lang]/(public)/how-we-index/page.tsx:59
 msgid "indexing.meta.description"
-msgstr "Wie Job Seek Stellenanzeigen entdeckt und indexiert: unser Sourcing-Ansatz, Crawl-Frequenz, Rate-Limits, robots.txt- und TDM-Reservation-Konformität und wie du dich abmeldest."
+msgstr "Wie Job Seek Stellenanzeigen entdeckt und indexiert: Quellen, Crawl-Frequenz, Rate-Limits, robots.txt-Erkennung, Umgang mit TDM-Reservation und Opt-out."
 
 #. FAQ question about job listing refresh cadence.
 #. js-lingui-explicit-id
@@ -2774,7 +2774,7 @@ msgstr "Sobald wir eine einzelne Stellenanzeige abrufen, speichern wir nur die s
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:77
 msgid "indexing.assurances.i3.title"
-msgstr "Eine Seite pro Minute."
+msgstr "Taktung pro Domain."
 
 #. Username invalid characters hint
 #. js-lingui-explicit-id
@@ -2876,7 +2876,7 @@ msgstr "Sonstige"
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:71
 msgid "indexing.assurances.i2.body"
-msgstr "Unser Crawler liest <0>robots.txt</0>, befolgt Disallow-Regeln, identifiziert sich über <1>User-Agent</1> und respektiert den W3C-<2>TDM-Reservation</2>-Header — wenn eine Seite Reservation signalisiert, überspringen wir sie."
+msgstr "Unser Crawler liest <0>robots.txt</0> zur Sitemap-Erkennung; die Durchsetzung von Disallow-Regeln ist noch nicht aktiv. Anfragen verwenden einen stabilen, browserkompatiblen <1>User-Agent</1>, wobei quellenspezifische Pfade einen identifizierenden Job-Seek-UA verwenden. Wir respektieren den W3C-<2>TDM-Reservation</2>-Header — wenn eine Seite eine Reservation signalisiert, überspringen wir sie."
 
 #. TOC: Our stance on automation
 #. js-lingui-explicit-id
@@ -3510,7 +3510,7 @@ msgstr "Respektvolles Tempo."
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:69
 msgid "indexing.assurances.i2.title"
-msgstr "Robots, Attribution und TDM-Reservation."
+msgstr "Robots-Erkennung, Anfrageidentität und TDM-Reservation."
 
 #. Label for role/occupation filter in advanced search
 #. js-lingui-explicit-id
@@ -4211,7 +4211,7 @@ msgstr "Das gesuchte Unternehmen existiert nicht oder wurde entfernt."
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:54
 msgid "about.transparency.p1"
-msgstr "Der Crawler-Code ist Open Source, damit jeder prüfen kann, wie wir Daten sammeln. Wir respektieren robots.txt, beachten TDM-Reservation-Header und beschränken uns auf eine Anfrage pro Seite pro Minute. Jeder ausgehende Link enthält utm_source=jobseek, damit Arbeitgeber wissen, woher ihr Traffic kommt."
+msgstr "Der Crawler-Code ist Open Source, damit jeder prüfen kann, wie wir Daten sammeln. Wir prüfen robots.txt zur Sitemap-Erkennung, beachten TDM-Reservation-Header und takten Anfragen pro Rate-Limit-Domain. Jeder ausgehende Link enthält utm_source=jobseek, damit Arbeitgeber wissen, woher ihr Traffic kommt."
 
 #. FAQ answer explaining crawler discovery and refresh frequency.
 #. js-lingui-explicit-id
@@ -4633,7 +4633,7 @@ msgstr "Wir lehnen es ab, Einstellungs- oder Jobsuch-Entscheidungen an undurchsi
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/faq/page.tsx:82
 msgid "faq.a.crawlingPolicy"
-msgstr "Wir respektieren robots.txt und TDM-Reservation-Header, beschränken Anfragen auf eine pro Seite pro Minute und verwenden exponentielles Backoff. Alle Anfragen identifizieren sich über den User-Agent. Weitere Details findest du auf unserer Indexierungsseite."
+msgstr "Wir prüfen robots.txt zur Sitemap-Erkennung; die Durchsetzung von Disallow-Regeln ist noch nicht aktiv. Wir beachten TDM-Reservation-Header, takten Anfragen pro Rate-Limit-Domain und verwenden exponentielles Backoff. Die meisten Anfragen nutzen einen stabilen, browserkompatiblen User-Agent; quellenspezifische Pfade können einen identifizierenden Job-Seek-UA verwenden. Weitere Details findest du auf unserer Indexierungsseite."
 
 #. Description telling user a verification link was sent
 #. js-lingui-explicit-id

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -1379,7 +1379,7 @@ msgstr "Enter your new password below."
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:78
 msgid "indexing.assurances.i3.body"
-msgstr "Even after discovery we retrieve job detail pages at a strict limit of one request per site per minute."
+msgstr "The queue spaces requests to the same rate-limit domain by 2 seconds by default and 0.5 seconds for known ATS APIs. Actual traffic is usually lower, and retries back off exponentially."
 
 #. Feature section 1 heading
 #. js-lingui-explicit-id
@@ -1792,7 +1792,7 @@ msgstr "How does the crawler behave on my company's website?"
 #: app/[lang]/(public)/how-we-index/page.tsx:22
 #: app/[lang]/(public)/how-we-index/page.tsx:59
 msgid "indexing.meta.description"
-msgstr "How Job Seek discovers and indexes job postings: our sourcing approach, crawl frequency, rate limits, robots.txt and TDM-Reservation compliance, and how to opt out."
+msgstr "How Job Seek discovers and indexes job postings: sourcing, crawl frequency, rate limits, robots.txt discovery, TDM-Reservation handling, and how to opt out."
 
 #. FAQ question about job listing refresh cadence.
 #. js-lingui-explicit-id
@@ -2774,7 +2774,7 @@ msgstr "Once we fetch an individual posting we store only the job-specific metad
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:77
 msgid "indexing.assurances.i3.title"
-msgstr "One page per minute."
+msgstr "Per-domain pacing."
 
 #. Username invalid characters hint
 #. js-lingui-explicit-id
@@ -2876,7 +2876,7 @@ msgstr "Other"
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:71
 msgid "indexing.assurances.i2.body"
-msgstr "Our crawler reads <0>robots.txt</0>, honours disallow rules, identifies itself via <1>User-Agent</1>, and respects the W3C <2>TDM-Reservation</2> header—if a page signals reservation, we skip it."
+msgstr "Our crawler reads <0>robots.txt</0> for sitemap discovery; Disallow enforcement is not yet active. Requests use a stable browser-compatible <1>User-Agent</1>, with an identifying Job Seek UA on source-specific paths. We respect the W3C <2>TDM-Reservation</2> header—if a page signals reservation, we skip it."
 
 #. TOC: Our stance on automation
 #. js-lingui-explicit-id
@@ -3510,7 +3510,7 @@ msgstr "Respectful pacing."
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:69
 msgid "indexing.assurances.i2.title"
-msgstr "Robots, attribution, and TDM reservation."
+msgstr "Robots discovery, request identity, and TDM reservation."
 
 #. Label for role/occupation filter in advanced search
 #. js-lingui-explicit-id
@@ -4211,7 +4211,7 @@ msgstr "The company you are looking for does not exist or has been removed."
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:54
 msgid "about.transparency.p1"
-msgstr "The crawler code is open source so anyone can audit how we collect data. We respect robots.txt, honor TDM-Reservation headers, and limit ourselves to one request per site per minute. Every outbound link includes utm_source=jobseek so employers know where their traffic comes from."
+msgstr "The crawler code is open source so anyone can audit how we collect data. We inspect robots.txt for sitemap discovery, honor TDM-Reservation headers, and pace requests per rate-limit domain. Every outbound link includes utm_source=jobseek so employers know where their traffic comes from."
 
 #. FAQ answer explaining crawler discovery and refresh frequency.
 #. js-lingui-explicit-id
@@ -4633,7 +4633,7 @@ msgstr "We oppose handing hiring or job-search decisions over to black-box autom
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/faq/page.tsx:82
 msgid "faq.a.crawlingPolicy"
-msgstr "We respect robots.txt and TDM-Reservation headers, limit requests to one per site per minute, and use exponential backoff. All requests identify themselves via User-Agent. See our Job Indexing page for full details."
+msgstr "We inspect robots.txt for sitemap discovery; Disallow enforcement is not yet active. We respect TDM-Reservation headers, pace requests per rate-limit domain, and use exponential backoff. Most requests use a stable browser-compatible User-Agent, while source-specific paths may use an identifying Job Seek UA. See our Job Indexing page for full details."
 
 #. Description telling user a verification link was sent
 #. js-lingui-explicit-id

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -1379,7 +1379,7 @@ msgstr "Entre ton nouveau mot de passe ci-dessous."
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:78
 msgid "indexing.assurances.i3.body"
-msgstr "Même après la découverte, nous récupérons les pages de détail des offres à un rythme strict d'une requête par site et par minute."
+msgstr "La file espace les requêtes vers un même domaine de limitation de 2 secondes par défaut et de 0,5 seconde pour les API ATS connues. Le trafic réel est généralement plus faible et les nouvelles tentatives utilisent un backoff exponentiel."
 
 #. Feature section 1 heading
 #. js-lingui-explicit-id
@@ -1792,7 +1792,7 @@ msgstr "Comment le crawler se comporte-t-il sur le site de mon entreprise ?"
 #: app/[lang]/(public)/how-we-index/page.tsx:22
 #: app/[lang]/(public)/how-we-index/page.tsx:59
 msgid "indexing.meta.description"
-msgstr "Comment Job Seek découvre et indexe les offres d'emploi : notre approche de sourcing, fréquence de crawl, limites de débit, conformité robots.txt et TDM-Reservation, et comment se désinscrire."
+msgstr "Comment Job Seek découvre et indexe les offres : sources, fréquence de crawl, limites de débit, découverte via robots.txt, gestion de TDM-Reservation et désinscription."
 
 #. FAQ question about job listing refresh cadence.
 #. js-lingui-explicit-id
@@ -2774,7 +2774,7 @@ msgstr "Une fois qu'une offre individuelle est récupérée, nous ne stockons qu
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:77
 msgid "indexing.assurances.i3.title"
-msgstr "Une page par minute."
+msgstr "Rythme par domaine."
 
 #. Username invalid characters hint
 #. js-lingui-explicit-id
@@ -2876,7 +2876,7 @@ msgstr "Autre"
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:71
 msgid "indexing.assurances.i2.body"
-msgstr "Notre robot lit le fichier <0>robots.txt</0>, respecte les règles d'interdiction, s'identifie via <1>User-Agent</1> et respecte l'en-tête W3C <2>TDM-Reservation</2> — si une page signale une réservation, nous la passons."
+msgstr "Notre robot lit <0>robots.txt</0> pour découvrir les sitemaps ; l'application des règles Disallow n'est pas encore active. Les requêtes utilisent un <1>User-Agent</1> stable et compatible avec les navigateurs, tandis que certains chemins propres à une source utilisent un UA Job Seek identifiable. Nous respectons l'en-tête W3C <2>TDM-Reservation</2> — si une page signale une réservation, nous la passons."
 
 #. TOC: Our stance on automation
 #. js-lingui-explicit-id
@@ -3510,7 +3510,7 @@ msgstr "Rythme respectueux."
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:69
 msgid "indexing.assurances.i2.title"
-msgstr "Robots, attribution et réservation TDM."
+msgstr "Découverte robots, identité des requêtes et réservation TDM."
 
 #. Label for role/occupation filter in advanced search
 #. js-lingui-explicit-id
@@ -4211,7 +4211,7 @@ msgstr "L'entreprise que vous recherchez n'existe pas ou a été supprimée."
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:54
 msgid "about.transparency.p1"
-msgstr "Le code du crawler est open source pour que tout le monde puisse vérifier comment nous collectons les données. Nous respectons robots.txt, honorons les en-têtes TDM-Reservation et nous limitons à une requête par site par minute. Chaque lien sortant inclut utm_source=jobseek pour que les employeurs sachent d'où vient leur trafic."
+msgstr "Le code du crawler est open source pour que tout le monde puisse vérifier comment nous collectons les données. Nous consultons robots.txt pour découvrir les sitemaps, respectons les en-têtes TDM-Reservation et espaçons les requêtes par domaine de limitation. Chaque lien sortant inclut utm_source=jobseek pour que les employeurs sachent d'où vient leur trafic."
 
 #. FAQ answer explaining crawler discovery and refresh frequency.
 #. js-lingui-explicit-id
@@ -4633,7 +4633,7 @@ msgstr "Nous nous opposons à ce que les décisions de recrutement ou de recherc
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/faq/page.tsx:82
 msgid "faq.a.crawlingPolicy"
-msgstr "Nous respectons robots.txt et les en-têtes TDM-Reservation, limitons les requêtes à une par site par minute et utilisons un backoff exponentiel. Toutes les requêtes s'identifient via le User-Agent. Consultez notre page d'indexation pour tous les détails."
+msgstr "Nous consultons robots.txt pour découvrir les sitemaps ; l'application des règles Disallow n'est pas encore active. Nous respectons les en-têtes TDM-Reservation, espaçons les requêtes par domaine de limitation et utilisons un backoff exponentiel. La plupart des requêtes utilisent un User-Agent stable et compatible avec les navigateurs ; certains chemins propres à une source peuvent utiliser un UA Job Seek identifiable. Consultez notre page d'indexation pour tous les détails."
 
 #. Description telling user a verification link was sent
 #. js-lingui-explicit-id

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -1379,7 +1379,7 @@ msgstr "Inserisci la tua nuova password qui sotto."
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:78
 msgid "indexing.assurances.i3.body"
-msgstr "Anche dopo la scoperta, recuperiamo le pagine di dettaglio degli annunci con un limite rigoroso di una richiesta per sito al minuto."
+msgstr "La coda distanzia le richieste allo stesso dominio di rate limit di 2 secondi per impostazione predefinita e di 0,5 secondi per le API ATS note. Il traffico reale è solitamente inferiore e i tentativi successivi usano il backoff esponenziale."
 
 #. Feature section 1 heading
 #. js-lingui-explicit-id
@@ -1792,7 +1792,7 @@ msgstr "Come si comporta il crawler sul sito della mia azienda?"
 #: app/[lang]/(public)/how-we-index/page.tsx:22
 #: app/[lang]/(public)/how-we-index/page.tsx:59
 msgid "indexing.meta.description"
-msgstr "Come Job Seek scopre e indicizza le offerte di lavoro: il nostro approccio di sourcing, frequenza di crawl, limiti di frequenza, conformità a robots.txt e TDM-Reservation, e come disattivare."
+msgstr "Come Job Seek scopre e indicizza le offerte: fonti, frequenza di crawl, limiti di frequenza, rilevamento tramite robots.txt, gestione di TDM-Reservation e opt-out."
 
 #. FAQ question about job listing refresh cadence.
 #. js-lingui-explicit-id
@@ -2774,7 +2774,7 @@ msgstr "Una volta recuperato un singolo annuncio, memorizziamo solo i metadati s
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:77
 msgid "indexing.assurances.i3.title"
-msgstr "Una pagina al minuto."
+msgstr "Ritmo per dominio."
 
 #. Username invalid characters hint
 #. js-lingui-explicit-id
@@ -2876,7 +2876,7 @@ msgstr "Altro"
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:71
 msgid "indexing.assurances.i2.body"
-msgstr "Il nostro crawler legge il file <0>robots.txt</0>, rispetta le regole di disallow, si identifica tramite <1>User-Agent</1> e rispetta l'header W3C <2>TDM-Reservation</2> — se una pagina segnala una riserva, la saltiamo."
+msgstr "Il nostro crawler legge <0>robots.txt</0> per rilevare le sitemap; l'applicazione delle regole Disallow non è ancora attiva. Le richieste usano uno <1>User-Agent</1> stabile e compatibile con i browser, mentre alcuni percorsi specifici per una fonte usano uno UA Job Seek identificabile. Rispettiamo l'header W3C <2>TDM-Reservation</2> — se una pagina segnala una riserva, la saltiamo."
 
 #. TOC: Our stance on automation
 #. js-lingui-explicit-id
@@ -3510,7 +3510,7 @@ msgstr "Ritmo rispettoso."
 #. js-lingui-explicit-id
 #: src/components/HowWeIndexContent.tsx:69
 msgid "indexing.assurances.i2.title"
-msgstr "Robot, attribuzione e riserva TDM."
+msgstr "Rilevamento robots, identità delle richieste e riserva TDM."
 
 #. Label for role/occupation filter in advanced search
 #. js-lingui-explicit-id
@@ -4211,7 +4211,7 @@ msgstr "L'azienda che stai cercando non esiste o è stata rimossa."
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/about/about-content.tsx:54
 msgid "about.transparency.p1"
-msgstr "Il codice del crawler è open source, così chiunque può verificare come raccogliamo i dati. Rispettiamo robots.txt, onoriamo gli header TDM-Reservation e ci limitiamo a una richiesta per sito al minuto. Ogni link in uscita include utm_source=jobseek, così i datori di lavoro sanno da dove arriva il traffico."
+msgstr "Il codice del crawler è open source, così chiunque può verificare come raccogliamo i dati. Controlliamo robots.txt per rilevare le sitemap, rispettiamo gli header TDM-Reservation e distanziamo le richieste per dominio di rate limit. Ogni link in uscita include utm_source=jobseek, così i datori di lavoro sanno da dove arriva il traffico."
 
 #. FAQ answer explaining crawler discovery and refresh frequency.
 #. js-lingui-explicit-id
@@ -4633,7 +4633,7 @@ msgstr "Ci opponiamo a delegare le decisioni di assunzione o di ricerca lavoro a
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/faq/page.tsx:82
 msgid "faq.a.crawlingPolicy"
-msgstr "Rispettiamo robots.txt e gli header TDM-Reservation, limitiamo le richieste a una per sito al minuto e utilizziamo il backoff esponenziale. Tutte le richieste si identificano tramite User-Agent. Consulta la nostra pagina sull'indicizzazione per tutti i dettagli."
+msgstr "Controlliamo robots.txt per rilevare le sitemap; l'applicazione delle regole Disallow non è ancora attiva. Rispettiamo gli header TDM-Reservation, distanziamo le richieste per dominio di rate limit e usiamo il backoff esponenziale. La maggior parte delle richieste usa uno User-Agent stabile e compatibile con i browser; alcuni percorsi specifici per una fonte possono usare uno UA Job Seek identificabile. Consulta la nostra pagina sull'indicizzazione per tutti i dettagli."
 
 #. Description telling user a verification link was sent
 #. js-lingui-explicit-id

--- a/apps/web/src/components/HowWeIndexContent.tsx
+++ b/apps/web/src/components/HowWeIndexContent.tsx
@@ -66,16 +66,16 @@ export function HowWeIndexContent() {
                       <p className="text-muted"><Trans id="indexing.assurances.i1.body" comment="Assurance 1 body">Every retry window uses exponential backoff so we never hammer an origin, and we bail if a host keeps timing out.</Trans></p>
                     </li>
                     <li>
-                      <p className="font-semibold"><Trans id="indexing.assurances.i2.title" comment="Assurance 2 title">Robots, attribution, and TDM reservation.</Trans></p>
+                      <p className="font-semibold"><Trans id="indexing.assurances.i2.title" comment="Assurance 2 title">Robots discovery, request identity, and TDM reservation.</Trans></p>
                       <p className="text-muted">
                         <Trans id="indexing.assurances.i2.body" comment="Assurance 2 body">
-                          Our crawler reads <code>robots.txt</code>, honours disallow rules, identifies itself via <code>User-Agent</code>, and respects the W3C <code>TDM-Reservation</code> header{"\u2014"}if a page signals reservation, we skip it.
+                          Our crawler reads <code>robots.txt</code> for sitemap discovery; Disallow enforcement is not yet active. Requests use a stable browser-compatible <code>User-Agent</code>, with an identifying Job Seek UA on source-specific paths. We respect the W3C <code>TDM-Reservation</code> header{"\u2014"}if a page signals reservation, we skip it.
                         </Trans>
                       </p>
                     </li>
                     <li>
-                      <p className="font-semibold"><Trans id="indexing.assurances.i3.title" comment="Assurance 3 title">One page per minute.</Trans></p>
-                      <p className="text-muted"><Trans id="indexing.assurances.i3.body" comment="Assurance 3 body">Even after discovery we retrieve job detail pages at a strict limit of one request per site per minute.</Trans></p>
+                      <p className="font-semibold"><Trans id="indexing.assurances.i3.title" comment="Assurance 3 title">Per-domain pacing.</Trans></p>
+                      <p className="text-muted"><Trans id="indexing.assurances.i3.body" comment="Assurance 3 body">The queue spaces requests to the same rate-limit domain by 2 seconds by default and 0.5 seconds for known ATS APIs. Actual traffic is usually lower, and retries back off exponentially.</Trans></p>
                     </li>
                   </ul>
                 </div>

--- a/apps/web/src/content/blog/how-we-index-job-postings.de.mdx
+++ b/apps/web/src/content/blog/how-we-index-job-postings.de.mdx
@@ -10,7 +10,7 @@ relatedWatchlists: ["colophongroup/big-tech-jobs-in-switzerland"]
 
 Eine neue Stelle erscheint um 10:14 Uhr morgens auf der Karriereseite von <Company slug="anthropic" />. Um 11:32 ist sie in unserem Index. Bei der nächsten Aktualisierung deiner Watchlist landet sie in deinem Feed.
 
-Wenn du die spezifikationsartige Zusammenfassung suchst — exakter User-Agent, Anfragerate pro Host, Retry-Policy, vollständige ATS-Liste — dann steht das auf der [Indexing-Policy-Seite](/de/how-we-index). Dieser Beitrag erzählt die Geschichte.
+Wenn du die spezifikationsartige Zusammenfassung suchst — aktuelles User-Agent-Verhalten, Anfrage-Taktung pro Host, Retry-Policy, vollständige ATS-Liste — dann steht das auf der [Indexing-Policy-Seite](/de/how-we-index). Dieser Beitrag erzählt die Geschichte.
 
 ## Schritt 1: ein 30-Sekunden-Handshake
 
@@ -25,7 +25,7 @@ Für Anthropic konkret — ein Greenhouse-Board — schickt der Monitor `https:/
 Zwei Regeln gelten für jede Anfrage des Crawlers:
 
 - **Ein paar Sekunden zwischen Anfragen an denselben Host.** Standard ist 2s, sinkt auf 0,5s für bekannte freundliche ATS-Domains. Ein vollständiger Board-Recheck läuft höchstens einmal pro Stunde. Selbst bei den größten Unternehmen unserer Liste sind wir nie der lauteste Besucher der Karriereseite. Concurrency-Budget pro IP, exponentielles Backoff bei Fehlern, automatische Deaktivierung nach 5 aufeinanderfolgenden Fehlschlägen, damit ein falsch konfiguriertes oder verschobenes Board laut statt still scheitert.
-- **`robots.txt` ist bindend.** Wenn die robots.txt eines Unternehmens das, was wir abrufen wollen, untersagt, hören wir auf. Außerdem respektieren wir den EU-TDM-Reservation-Header (Opt-out für Text und Data Mining) für alle Unternehmen, die ihn emittieren. Unser User-Agent identifiziert uns — `Job-Seek-Crawler/X.Y +https://jseek.co/how-we-index` — sodass jede:r, der/die Server-Logs liest, genau weiß, wer anfragt.
+- **`robots.txt` dient derzeit der Erkennung.** Wir lesen daraus Sitemap-Angaben; die Durchsetzung von Disallow-Regeln ist noch nicht aktiv und der Rollout wird [öffentlich verfolgt](https://github.com/colophon-group/jobseek/issues/2841). Wir respektieren den EU-TDM-Reservation-Header (Opt-out für Text und Data Mining) bei Unternehmen, die ihn senden. Die meisten Anfragen verwenden einen stabilen, browserkompatiblen User-Agent, weil manche ATS- und WAF-Pfade Bot-UAs ablehnen; quellenspezifische Pfade können einen identifizierenden Job-Seek-UA verwenden.
 
 Das ist keine Großzügigkeit, sondern wie man über Jahre willkommen bleibt. Die Zahl der Unternehmen, die uns gebeten haben, langsamer zu werden oder aufzuhören, ist klein — und das ist die einzige Kennzahl, die hier zählt.
 
@@ -45,7 +45,7 @@ Manche Karriereseiten wollen keine Bots aus Rechenzentren. Starbucks' eightfold-
 
 Der Kompromiss: Eine kleine, transparente Menge von Boards entscheidet sich für einen Residential-Proxy-Provider. Boards auf dem Proxy-Pfad werden noch aggressiver rate-limitiert. Wenn eine Proxy-IP von einer Origin geblockt wird, verlieren wir diese IP und diskutieren nicht.
 
-Wir geben uns nie als echte:r Nutzer:in aus. Der User-Agent bleibt ehrlich. Wir routen die Anfrage einfach über einen Residential-Exit, damit der IP-Reputations-Filter der Origin sie nicht ablehnt, bevor sie überhaupt ihren Inhaltsfilter erreicht.
+Der Kompatibilitätskompromiss ist transparent: Auch Pfade über Residential-Proxys verwenden den stabilen, browserkompatiblen User-Agent. Wir behaupten nicht, dass jede Anfrage sich selbst identifiziert; dieselbe Taktung, dieselben Retry-Budgets, TDM-Prüfungen und der Opt-out-Kanal gelten für beide Egress-Pfade.
 
 ## Schritt 5: von „in der Datenbank“ zu „in deinem Feed“
 

--- a/apps/web/src/content/blog/how-we-index-job-postings.fr.mdx
+++ b/apps/web/src/content/blog/how-we-index-job-postings.fr.mdx
@@ -10,7 +10,7 @@ relatedWatchlists: ["colophongroup/big-tech-jobs-in-switzerland"]
 
 Une nouvelle offre apparaît à 10h14 le matin sur la page carrière d'<Company slug="anthropic" />. À 11h32 elle est dans notre index. Au prochain rafraîchissement de votre watchlist, elle est dans votre flux.
 
-Si vous voulez le résumé façon spécifications — chaîne User-Agent exacte, fréquence des requêtes par hôte, politique de retry, liste complète des ATS — c'est sur la [page de politique d'indexation](/fr/how-we-index). Cet article raconte l'histoire.
+Si vous voulez le résumé façon spécifications — comportement actuel du User-Agent, rythme des requêtes par hôte, politique de retry, liste complète des ATS — c'est sur la [page de politique d'indexation](/fr/how-we-index). Cet article raconte l'histoire.
 
 ## Étape 1 : une poignée de main de trente secondes
 
@@ -25,7 +25,7 @@ Pour Anthropic précisément — un board Greenhouse — le moniteur appelle `ht
 Deux règles régissent chaque requête du crawler :
 
 - **Quelques secondes entre requêtes au même hôte.** 2s par défaut, descendant à 0,5s pour les domaines ATS connus pour être tolérants. Un re-check complet d'un board se déclenche au plus une fois par heure. Même chez les plus grandes entreprises de notre liste, nous ne sommes jamais le visiteur le plus bruyant de la page carrière. Budget de concurrence par IP, backoff exponentiel sur erreur, désactivation automatique après 5 échecs consécutifs, pour qu'un board mal configuré ou déplacé échoue bruyamment plutôt que silencieusement.
-- **`robots.txt` fait foi.** Si la robots.txt d'une entreprise interdit ce que nous tentons de récupérer, nous arrêtons. Nous respectons aussi l'en-tête TDM-Reservation européen (opt-out pour le text and data mining) pour toute entreprise qui l'émet. Notre User-Agent nous identifie — `Job-Seek-Crawler/X.Y +https://jseek.co/how-we-index` — pour que quiconque lit les logs du serveur sache exactement qui appelle.
+- **`robots.txt` sert actuellement à la découverte.** Nous y lisons les directives de sitemap ; l'application des règles Disallow n'est pas encore active et son déploiement est [suivi publiquement](https://github.com/colophon-group/jobseek/issues/2841). Nous respectons l'en-tête TDM-Reservation européen (opt-out pour le text and data mining) pour les entreprises qui l'émettent. La plupart des requêtes utilisent un User-Agent stable et compatible avec les navigateurs, car certains chemins ATS et WAF rejettent les UA de robots ; certains chemins propres à une source peuvent utiliser un UA Job Seek identifiable.
 
 Ce n'est pas de la générosité, c'est ainsi qu'on reste bienvenu sur la durée. Le nombre d'entreprises qui nous ont demandé de ralentir ou de cesser est faible — c'est la seule métrique qui compte ici.
 
@@ -45,7 +45,7 @@ Certaines pages carrière ne veulent pas de bots provenant de datacenters. Le bo
 
 Le compromis : un petit ensemble transparent de boards opte pour un fournisseur de proxy résidentiel. Les boards sur la voie proxy sont rate-limités encore plus strictement. Si une IP proxy se fait bloquer par une origine, nous perdons cette IP et nous ne discutons pas.
 
-Nous ne nous faisons jamais passer pour un vrai utilisateur. Le User-Agent reste honnête. Nous routons simplement la requête par une sortie résidentielle pour que le filtre de réputation IP de l'origine ne la rejette pas avant que son filtre de contenu ait une chance de voir qui appelle.
+Le compromis de compatibilité est explicite : les chemins passant par des proxys résidentiels utilisent eux aussi le User-Agent stable et compatible avec les navigateurs. Nous ne prétendons pas que chaque requête s'identifie ; le même rythme, les mêmes budgets de retry, contrôles TDM et canal d'opt-out s'appliquent aux deux chemins de sortie.
 
 ## Étape 5 : de « dans la base » à « dans votre flux »
 

--- a/apps/web/src/content/blog/how-we-index-job-postings.it.mdx
+++ b/apps/web/src/content/blog/how-we-index-job-postings.it.mdx
@@ -10,7 +10,7 @@ relatedWatchlists: ["colophongroup/big-tech-jobs-in-switzerland"]
 
 Un nuovo ruolo compare alle 10:14 del mattino sulla pagina carriere di <Company slug="anthropic" />. Alle 11:32 è nel nostro indice. Al successivo aggiornamento della tua watchlist, è nel tuo feed.
 
-Se cerchi il riassunto in stile specifica — stringa User-Agent esatta, frequenza delle richieste per host, retry policy, elenco ATS completo — quello sta sulla [pagina della policy di indicizzazione](/it/how-we-index). Questo articolo è la storia.
+Se cerchi il riassunto in stile specifica — comportamento attuale dello User-Agent, ritmo delle richieste per host, retry policy, elenco ATS completo — quello sta sulla [pagina della policy di indicizzazione](/it/how-we-index). Questo articolo è la storia.
 
 ## Passaggio 1: una stretta di mano di trenta secondi
 
@@ -25,7 +25,7 @@ Per Anthropic nello specifico — un board Greenhouse — il monitor chiama `htt
 Due regole governano ogni richiesta del crawler:
 
 - **Qualche secondo tra richieste allo stesso host.** Default 2s, scendendo a 0,5s per domini ATS noti come amichevoli. Un re-check completo di un board parte al massimo una volta l'ora. Anche presso le aziende più grandi della nostra lista, non siamo mai il visitatore più rumoroso della pagina carriere. Budget di concurrency per IP, backoff esponenziale sugli errori, disabilitazione automatica dopo 5 fallimenti consecutivi, perché un board mal configurato o spostato fallisca in modo rumoroso anziché silenzioso.
-- **`robots.txt` è vincolante.** Se la robots.txt di un'azienda vieta ciò che stiamo provando a recuperare, ci fermiamo. Rispettiamo anche l'header EU TDM-Reservation (opt-out per text and data mining) per le aziende che lo emettono. Il nostro User-Agent ci identifica — `Job-Seek-Crawler/X.Y +https://jseek.co/how-we-index` — così chi legge i log del server sa esattamente chi sta chiamando.
+- **`robots.txt` è attualmente una fonte di rilevamento.** Ne leggiamo le direttive sitemap; l'applicazione delle regole Disallow non è ancora attiva e il rollout è [tracciato pubblicamente](https://github.com/colophon-group/jobseek/issues/2841). Rispettiamo l'header EU TDM-Reservation (opt-out per text and data mining) per le aziende che lo emettono. La maggior parte delle richieste usa uno User-Agent stabile e compatibile con i browser, perché alcuni percorsi ATS e WAF rifiutano gli UA dei bot; percorsi specifici per una fonte possono usare uno UA Job Seek identificabile.
 
 Non è generosità: è come si resta benvenuti negli anni. Il numero di aziende che ci hanno chiesto di rallentare o di fermarci è piccolo — ed è l'unica metrica che conta qui.
 
@@ -45,7 +45,7 @@ Alcune pagine carriere non vogliono bot dai datacenter. Il board eightfold di St
 
 Il compromesso: un piccolo, trasparente insieme di board sceglie un provider di proxy residenziali. I board sul percorso proxy sono rate-limited ancora più aggressivamente. Se un IP proxy viene bloccato da un'origine, perdiamo quell'IP e non discutiamo.
 
-Non fingiamo mai di essere un utente vero. Lo User-Agent resta onesto. Instradiamo solo la richiesta tramite un'uscita residenziale, perché il filtro di reputazione IP dell'origine non la rifiuti prima che il suo filtro di contenuto abbia avuto modo di vedere chi chiama.
+Il compromesso di compatibilità è esplicito: anche i percorsi tramite proxy residenziali usano lo User-Agent stabile e compatibile con i browser. Non affermiamo che ogni richiesta si identifichi; lo stesso ritmo, gli stessi budget di retry, controlli TDM e canale di opt-out si applicano a entrambi i percorsi di uscita.
 
 ## Passaggio 5: da «nel database» a «nel tuo feed»
 

--- a/apps/web/src/content/blog/how-we-index-job-postings.mdx
+++ b/apps/web/src/content/blog/how-we-index-job-postings.mdx
@@ -10,7 +10,7 @@ relatedWatchlists: ["colophongroup/big-tech-jobs-in-switzerland"]
 
 A new role goes up on <Company slug="anthropic" />'s careers page at 10:14 in the morning. By 11:32 it's in our index. By the next time your watchlist refreshes, it's in your feed.
 
-If you want the spec-style summary — exact User-Agent string, request rate per host, retry policy, full ATS list — that's on the [indexing policy page](/en/how-we-index). This post is the story.
+If you want the spec-style summary — current User-Agent behavior, request pacing per host, retry policy, full ATS list — that's on the [indexing policy page](/en/how-we-index). This post is the story.
 
 ## Step 1: a thirty-second handshake
 
@@ -25,7 +25,7 @@ For Anthropic specifically — a Greenhouse board — the monitor hits `https://
 Two rules govern every request the crawler makes:
 
 - **A few seconds between requests to the same host.** Default is 2s, dropping to 0.5s for known-friendly ATS domains. A full board re-check fires at most once an hour. Even at the largest companies in our set, we're never the loudest visitor on the careers page. Concurrency budget per IP, exponential backoff on errors, automatic disable after 5 consecutive failures so a misconfigured or moved board fails loudly instead of silently.
-- **`robots.txt` is binding.** If a company's robots disallows what we're trying to fetch, we stop. We also respect the EU's TDM-Reservation (text and data mining opt-out) header for any companies that emit it. Our User-Agent identifies us — `Job-Seek-Crawler/X.Y +https://jseek.co/how-we-index` — so anyone reading server logs knows exactly who's calling.
+- **`robots.txt` is currently a discovery source.** We read sitemap directives from it; Disallow enforcement is not yet active and the rollout is [tracked publicly](https://github.com/colophon-group/jobseek/issues/2841). We respect the EU's TDM-Reservation (text and data mining opt-out) header for companies that emit it. Most requests use a stable browser-compatible User-Agent because some ATS and WAF paths reject bot UAs; source-specific paths may use an identifying Job Seek UA.
 
 This isn't generosity, it's how you stay welcome over years. The number of companies that have asked us to slow down or stop is small, which is the only metric here that matters.
 
@@ -45,7 +45,7 @@ Some careers pages don't want bots from datacenters. Starbucks's eightfold-hoste
 
 The compromise: a small, transparent set of boards opt into a residential-proxy provider. Boards on the proxy path get rate-limited even more aggressively. If a proxy IP gets blocked by an origin, we lose that IP and don't argue.
 
-We never pretend to be a real user. The User-Agent stays honest. We just route the request through a residential exit so the origin's IP-rep filter doesn't reject it before its content filter has a chance to see who's asking.
+The compatibility trade-off is explicit: residential-proxy paths still use the stable browser-compatible User-Agent. We do not claim that every request is self-identifying; the same pacing, retry budgets, TDM checks, and opt-out channel apply on either egress path.
 
 ## Step 5: from "in the database" to "in your feed"
 


### PR DESCRIPTION
## Summary
- align the public User-Agent description with the crawler’s current browser-compatible and source-specific behavior
- disclose that robots.txt is used for sitemap discovery while Disallow enforcement remains tracked in #2841
- document the configured 2-second default and 0.5-second known-ATS pacing
- update the policy page, FAQ, About page, SEO metadata, and EN/DE/FR/IT blog copy
- add regression coverage tied to crawler configuration

## Validation
- pnpm --dir apps/web test -- --run (193 files, 1,443 tests)
- pnpm --dir apps/web typecheck
- pnpm --dir apps/web lint
- pnpm --dir apps/web build
- pnpm --dir apps/web compile
- bash scripts/check-i18n-coverage.sh

Fixes #5963
Fixes #5970

#2841 intentionally remains open for crawler-side robots.txt Disallow enforcement.