### PR TITLE
Resolve backup deploy hosts at runtime

### DIFF
--- a/.github/workflows/deploy-data-backups.yml
+++ b/.github/workflows/deploy-data-backups.yml
@@ -30,11 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - service: postgresql
-            host: ${{ vars.HETZNER_POSTGRES_HOST }}
-          - service: typesense
-            host: ${{ vars.HETZNER_TYPESENSE_HOST }}
+        service: [postgresql, typesense]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -51,13 +47,15 @@ jobs:
 
       - name: Require configured production host
         env:
-          TARGET_HOST: ${{ matrix.host }}
+          # Environment-scoped variables are unavailable while GitHub expands
+          # the job matrix, so resolve the host only after production is attached.
+          TARGET_HOST: ${{ matrix.service == 'postgresql' && vars.HETZNER_POSTGRES_HOST || vars.HETZNER_TYPESENSE_HOST }}
         run: test -n "$TARGET_HOST"
 
       - name: Copy backup deployment artifacts
         uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
         with:
-          host: ${{ matrix.host }}
+          host: ${{ matrix.service == 'postgresql' && vars.HETZNER_POSTGRES_HOST || vars.HETZNER_TYPESENSE_HOST }}
           username: root
           key: ${{ secrets.HETZNER_SSH_KEY }}
           source: scripts/jobseek-data-backup.py,deploy/backups,deploy/systemd/jobseek-postgresql-backup.service,deploy/systemd/jobseek-postgresql-backup.timer,deploy/systemd/jobseek-postgresql-backup-repository.service,deploy/systemd/jobseek-typesense-backup.service,deploy/systemd/jobseek-typesense-backup.timer,docs/19-data-backup-recovery.md,docs/16-hetzner-maintenance.md
@@ -70,7 +68,7 @@ jobs:
           JOBSEEK_BACKUP_DEPLOY_SHA: ${{ github.sha }}
           JOBSEEK_BACKUP_SERVICE: ${{ matrix.service }}
         with:
-          host: ${{ matrix.host }}
+          host: ${{ matrix.service == 'postgresql' && vars.HETZNER_POSTGRES_HOST || vars.HETZNER_TYPESENSE_HOST }}
           username: root
           key: ${{ secrets.HETZNER_SSH_KEY }}
           envs: JOBSEEK_BACKUP_DEPLOY_SHA,JOBSEEK_BACKUP_SERVICE


### PR DESCRIPTION
## Summary
- keep the backup matrix limited to service names
- resolve production-environment host variables inside runtime steps
- preserve the fail-closed missing-host check

## Root cause
GitHub expands the strategy matrix before attaching the protected production environment, so environment-scoped variables embedded in the matrix were empty. The merged deployment therefore stopped safely before connecting to either host.

## Verification
- actionlint .github/workflows/deploy-data-backups.yml
- pre-commit run --all-files
- git diff --check

Follow-up for #5927.