### PR TITLE
Add recovery actions to missing-company pages

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-not-found.test.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-not-found.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CompanyNotFoundState } from "../company-not-found";
+
+describe("CompanyNotFoundState", () => {
+  it("offers localized recovery routes and prefills the missing slug", () => {
+    render(
+      <CompanyNotFoundState
+        locale="de"
+        slug="acme-inc"
+        title="Unternehmen nicht gefunden"
+        message="Das Unternehmen existiert nicht."
+        exploreLabel="Entdecken"
+        requestLabel="Dieses Unternehmen anfragen"
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: "Entdecken" }).getAttribute("href"))
+      .toBe("/de/explore");
+    expect(
+      screen
+        .getByRole("link", { name: "Dieses Unternehmen anfragen" })
+        .getAttribute("href"),
+    ).toBe("/de/companies/request?name=acme%20inc");
+  });
+});

--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-route-suspense.test.ts
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-route-suspense.test.ts
@@ -25,4 +25,18 @@ describe("company route partial prerendering", () => {
     expect(source.match(/getCompanyRouteSnapshot\(slug, locale\)/g)).toHaveLength(2);
     expect(source).not.toContain("getCompanyBySlug(slug, locale)");
   });
+
+  it("renders the missing-company fallback with the requested locale and slug", () => {
+    const source = readFileSync(
+      "app/[lang]/(app)/company/[slug]/page.tsx",
+      "utf8",
+    );
+
+    expect(source).toContain("async function CompanyNotFound({ locale, slug }");
+    expect(source).toContain("const { i18n } = await loadCatalog(locale);");
+    expect(source).toContain(
+      "return <CompanyNotFound locale={locale} slug={slug} />;",
+    );
+    expect(source).not.toContain("loadCatalog(defaultLocale);");
+  });
 });

--- a/apps/web/app/[lang]/(app)/company/[slug]/company-content.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-content.tsx
@@ -11,6 +11,7 @@ import {
   serializeSearchFilterParams,
 } from "@/lib/search/query-params";
 import { CompanyPage } from "./company-page";
+import { CompanyNotFoundState } from "./company-not-found";
 
 type CompanyContentProps = {
   locale: string;
@@ -38,26 +39,44 @@ type CompanyContentProps = {
  * as a data input would unmount and refetch the entire company results
  * view on every posting click (#5766).
  */
-function CompanyNotFound() {
+function CompanyNotFound({ locale, slug }: { locale: string; slug: string }) {
   return (
-    <div className="flex flex-col items-center justify-center py-24 text-center">
-      <h1 className="text-2xl font-bold">
+    <CompanyNotFoundState
+      locale={locale}
+      slug={slug}
+      title={
         <Trans
           id="company.notFound.title"
           comment="Heading shown when the company URL slug doesn't resolve to a known company"
         >
           Company not found
         </Trans>
-      </h1>
-      <p className="mt-2 text-muted">
+      }
+      message={
         <Trans
           id="company.notFound.body"
           comment="Body text for the company-not-found page; explains the company is either gone or never existed"
         >
           The company you are looking for does not exist or has been removed.
         </Trans>
-      </p>
-    </div>
+      }
+      exploreLabel={
+        <Trans
+          id="company.notFound.explore"
+          comment="Primary recovery action on the company-not-found page"
+        >
+          Explore companies
+        </Trans>
+      }
+      requestLabel={
+        <Trans
+          id="company.notFound.request"
+          comment="Secondary action on the company-not-found page to request that company"
+        >
+          Request this company
+        </Trans>
+      }
+    />
   );
 }
 
@@ -117,7 +136,7 @@ export function CompanyContent({ locale, slug, initialData }: CompanyContentProp
   }, [dataParamsKey, initialData, locale, slug]);
 
   if (data === null) return <CompanySkeleton />;
-  if (data === "not-found") return <CompanyNotFound />;
+  if (data === "not-found") return <CompanyNotFound locale={locale} slug={slug} />;
 
   return (
     <CompanyPage

--- a/apps/web/app/[lang]/(app)/company/[slug]/company-not-found.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-not-found.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/Button";
+
+type CompanyNotFoundStateProps = {
+  locale: string;
+  slug: string;
+  title: ReactNode;
+  message: ReactNode;
+  exploreLabel: ReactNode;
+  requestLabel: ReactNode;
+};
+
+/** Shared presentation for both the cached server fallback and client refetch. */
+export function CompanyNotFoundState({
+  locale,
+  slug,
+  title,
+  message,
+  exploreLabel,
+  requestLabel,
+}: CompanyNotFoundStateProps) {
+  const suggestedName = slug.replaceAll("-", " ");
+  const requestHref = `/${locale}/companies/request?name=${encodeURIComponent(suggestedName)}`;
+
+  return (
+    <div className="flex flex-col items-center justify-center py-24 text-center">
+      <h1 className="text-2xl font-bold">{title}</h1>
+      <p className="mt-2 text-muted">{message}</p>
+      <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+        <Button href={`/${locale}/explore`}>{exploreLabel}</Button>
+        <Button href={requestHref} variant="outline">
+          {requestLabel}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
@@ -10,6 +10,7 @@ import { siteConfig } from "@/content/config";
 import { buildAlternates } from "@/lib/seo";
 import { CompanyHead } from "./company-head";
 import { CompanyContent } from "./company-content";
+import { CompanyNotFoundState } from "./company-not-found";
 import { SimilarSection } from "./similar-section";
 import { CompanySkeleton } from "@/components/search/company-skeleton";
 
@@ -110,8 +111,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-async function CompanyNotFound() {
-  const { i18n } = await loadCatalog(defaultLocale);
+async function CompanyNotFound({ locale, slug }: { locale: Locale; slug: string }) {
+  const { i18n } = await loadCatalog(locale);
   const title = i18n._({
     id: "company.notFound.title",
     comment: "Heading shown when a company page slug does not exist",
@@ -122,11 +123,25 @@ async function CompanyNotFound() {
     comment: "Body text shown when a company page slug does not exist",
     message: "The company you are looking for does not exist or has been removed.",
   });
+  const exploreLabel = i18n._({
+    id: "company.notFound.explore",
+    comment: "Primary recovery action on the company-not-found page",
+    message: "Explore companies",
+  });
+  const requestLabel = i18n._({
+    id: "company.notFound.request",
+    comment: "Secondary action on the company-not-found page to request that company",
+    message: "Request this company",
+  });
   return (
-    <div className="flex flex-col items-center justify-center py-24 text-center">
-      <h1 className="text-2xl font-bold">{title}</h1>
-      <p className="mt-2 text-muted">{message}</p>
-    </div>
+    <CompanyNotFoundState
+      locale={locale}
+      slug={slug}
+      title={title}
+      message={message}
+      exploreLabel={exploreLabel}
+      requestLabel={requestLabel}
+    />
   );
 }
 
@@ -146,7 +161,7 @@ export default async function CompanyPageRoute({ params }: Props) {
   // variant via ``fetchCompanyPageData`` when filters or auth-related
   // hint cookies are present.
   const initialData = await getCompanyRouteSnapshot(slug, locale);
-  if (!initialData) return <CompanyNotFound />;
+  if (!initialData) return <CompanyNotFound locale={locale} slug={slug} />;
   const { company } = initialData;
 
   // The page body is `'use cache'`-wrapped (10-minute revalidate) so the

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -933,6 +933,16 @@ msgstr "Unternehmen"
 msgid "company.notFound.title"
 msgstr "Unternehmen nicht gefunden"
 
+#. Primary recovery action on the company-not-found page
+#. js-lingui-explicit-id
+msgid "company.notFound.explore"
+msgstr "Unternehmen entdecken"
+
+#. Secondary action on the company-not-found page to request that company
+#. js-lingui-explicit-id
+msgid "company.notFound.request"
+msgstr "Dieses Unternehmen anfragen"
+
 #. WebApplication JSON-LD description for Job Seek.
 #. js-lingui-explicit-id
 #: app/[lang]/layout.tsx:121

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -933,6 +933,16 @@ msgstr "Company"
 msgid "company.notFound.title"
 msgstr "Company not found"
 
+#. Primary recovery action on the company-not-found page
+#. js-lingui-explicit-id
+msgid "company.notFound.explore"
+msgstr "Explore companies"
+
+#. Secondary action on the company-not-found page to request that company
+#. js-lingui-explicit-id
+msgid "company.notFound.request"
+msgstr "Request this company"
+
 #. WebApplication JSON-LD description for Job Seek.
 #. js-lingui-explicit-id
 #: app/[lang]/layout.tsx:121

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -933,6 +933,16 @@ msgstr "Entreprise"
 msgid "company.notFound.title"
 msgstr "Entreprise introuvable"
 
+#. Primary recovery action on the company-not-found page
+#. js-lingui-explicit-id
+msgid "company.notFound.explore"
+msgstr "Découvrir les entreprises"
+
+#. Secondary action on the company-not-found page to request that company
+#. js-lingui-explicit-id
+msgid "company.notFound.request"
+msgstr "Demander cette entreprise"
+
 #. WebApplication JSON-LD description for Job Seek.
 #. js-lingui-explicit-id
 #: app/[lang]/layout.tsx:121

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -933,6 +933,16 @@ msgstr "Azienda"
 msgid "company.notFound.title"
 msgstr "Azienda non trovata"
 
+#. Primary recovery action on the company-not-found page
+#. js-lingui-explicit-id
+msgid "company.notFound.explore"
+msgstr "Scopri le aziende"
+
+#. Secondary action on the company-not-found page to request that company
+#. js-lingui-explicit-id
+msgid "company.notFound.request"
+msgstr "Richiedi questa azienda"
+
 #. WebApplication JSON-LD description for Job Seek.
 #. js-lingui-explicit-id
 #: app/[lang]/layout.tsx:121


### PR DESCRIPTION
## Summary
- render missing-company copy from the requested route locale on both server and client paths
- add localized Explore companies and Request this company actions
- prefill the request form from the missing URL slug
- share one responsive empty-state presentation between cached and personalized paths
- add route and link regression coverage

## Validation
- pnpm --dir apps/web test -- --run (194 files, 1,445 tests)
- pnpm --dir apps/web typecheck
- pnpm --dir apps/web lint
- pnpm --dir apps/web build
- bash scripts/check-i18n-coverage.sh

Fixes #5973
Fixes #5974