### PR TITLE
Add recovery action to missing-watchlist pages

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-content.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-content.tsx
@@ -5,6 +5,7 @@ import { Trans } from "@lingui/react/macro";
 import { fetchWatchlistPageData, type WatchlistPageData } from "@/lib/actions/watchlist-page-data";
 import { WatchlistSkeleton } from "@/components/search/watchlist-skeleton";
 import { WatchlistViewPage } from "./watchlist-view-page";
+import { WatchlistNotFoundState } from "./watchlist-not-found";
 
 type WatchlistContentProps = {
   lang: string;
@@ -12,26 +13,35 @@ type WatchlistContentProps = {
   watchlistSlug: string;
 };
 
-function WatchlistNotFound() {
+function WatchlistNotFound({ lang }: { lang: string }) {
   return (
-    <div className="flex flex-col items-center justify-center py-24 text-center">
-      <h1 className="text-2xl font-bold">
+    <WatchlistNotFoundState
+      lang={lang}
+      title={
         <Trans
           id="watchlist.notFound.title"
           comment="Heading shown when the watchlist URL doesn't resolve to a public watchlist"
         >
           Watchlist not found
         </Trans>
-      </h1>
-      <p className="mt-2 text-muted">
+      }
+      message={
         <Trans
           id="watchlist.notFound.body"
           comment="Body text for the watchlist-not-found page; explains the watchlist is either gone or private"
         >
           This watchlist does not exist or is not public.
         </Trans>
-      </p>
-    </div>
+      }
+      browseLabel={
+        <Trans
+          id="watchlist.notFound.browse"
+          comment="Recovery action on the watchlist-not-found page"
+        >
+          Browse watchlists
+        </Trans>
+      }
+    />
   );
 }
 
@@ -47,7 +57,7 @@ export function WatchlistContent({ lang, userSlug, watchlistSlug }: WatchlistCon
   }, [lang, userSlug, watchlistSlug]);
 
   if (data === null) return <WatchlistSkeleton />;
-  if (data === "not-found") return <WatchlistNotFound />;
+  if (data === "not-found") return <WatchlistNotFound lang={lang} />;
 
   return (
     <WatchlistViewPage

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-not-found.test.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-not-found.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { WatchlistNotFoundState } from "./watchlist-not-found";
+
+describe("WatchlistNotFoundState", () => {
+  it("offers a locale-preserving route back to the watchlist browser", () => {
+    render(
+      <WatchlistNotFoundState
+        lang="fr"
+        title="Watchlist introuvable"
+        message="Cette watchlist n’existe pas."
+        browseLabel="Parcourir les watchlists"
+      />,
+    );
+
+    expect(
+      screen
+        .getByRole("link", { name: "Parcourir les watchlists" })
+        .getAttribute("href"),
+    ).toBe("/fr/watchlists");
+  });
+});

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-not-found.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-not-found.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+import { Button } from "@/components/ui/Button";
+
+type WatchlistNotFoundStateProps = {
+  lang: string;
+  title: ReactNode;
+  message: ReactNode;
+  browseLabel: ReactNode;
+};
+
+export function WatchlistNotFoundState({
+  lang,
+  title,
+  message,
+  browseLabel,
+}: WatchlistNotFoundStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-24 text-center">
+      <h1 className="text-2xl font-bold">{title}</h1>
+      <p className="mt-2 text-muted">{message}</p>
+      <Button href={`/${lang}/watchlists`} className="mt-6">
+        {browseLabel}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -4543,6 +4543,11 @@ msgstr "Watchlist-Limit erreicht"
 msgid "watchlist.notFound.title"
 msgstr "Beobachtungsliste nicht gefunden"
 
+#. Recovery action on the watchlist-not-found page
+#. js-lingui-explicit-id
+msgid "watchlist.notFound.browse"
+msgstr "Watchlists entdecken"
+
 #. Title of the watchlists exploration page
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/watchlists/watchlists-page.tsx:127

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -4543,6 +4543,11 @@ msgstr "Watchlist limit reached"
 msgid "watchlist.notFound.title"
 msgstr "Watchlist not found"
 
+#. Recovery action on the watchlist-not-found page
+#. js-lingui-explicit-id
+msgid "watchlist.notFound.browse"
+msgstr "Browse watchlists"
+
 #. Title of the watchlists exploration page
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/watchlists/watchlists-page.tsx:127

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -4543,6 +4543,11 @@ msgstr "Limite de listes atteinte"
 msgid "watchlist.notFound.title"
 msgstr "Liste de surveillance introuvable"
 
+#. Recovery action on the watchlist-not-found page
+#. js-lingui-explicit-id
+msgid "watchlist.notFound.browse"
+msgstr "Parcourir les watchlists"
+
 #. Title of the watchlists exploration page
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/watchlists/watchlists-page.tsx:127

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -4543,6 +4543,11 @@ msgstr "Limite liste raggiunto"
 msgid "watchlist.notFound.title"
 msgstr "Watchlist non trovata"
 
+#. Recovery action on the watchlist-not-found page
+#. js-lingui-explicit-id
+msgid "watchlist.notFound.browse"
+msgstr "Esplora le watchlist"
+
 #. Title of the watchlists exploration page
 #. js-lingui-explicit-id
 #: app/[lang]/(app)/watchlists/watchlists-page.tsx:127


### PR DESCRIPTION
## Summary
- add a locale-preserving Browse watchlists action to the public watchlist not-found state
- keep the presentation small and reusable
- translate the recovery action in English, German, French, and Italian
- add link-level regression coverage

## Validation
- pnpm --dir apps/web test -- --run (195 files, 1,446 tests)
- pnpm --dir apps/web typecheck
- pnpm --dir apps/web lint
- pnpm --dir apps/web build
- bash scripts/check-i18n-coverage.sh

Fixes #5977