### PR TITLE
Record verified backup deployment state

### DIFF
--- a/docs/19-data-backup-recovery.md
+++ b/docs/19-data-backup-recovery.md
@@ -76,10 +76,19 @@ the last successful backup so a failed and a stale backup remain distinct.
 | Typesense | Snapshot API produced 1,348,345,503 bytes; encrypted Restic upload, prune, and check completed in about 164 seconds without restarting Typesense | verified Restic restore returned all 1,348,345,503 bytes in 13 seconds; an isolated Typesense 27.1 node became healthy, loaded all seven collections and aliases, matched stable collection counts, served representative reads, and returned live search results |
 
 Temporary restore containers, data, keys and drill credentials were removed.
-The PostgreSQL pre-cutover container remains stopped only as a short-lived
-rollback target until the reviewed revision is merged and redeployed. Legacy
-server backups remain until scheduling and daily error-review alert delivery
-also pass the removal gate below.
+The reviewed revision was deployed from `main` to both hosts, and its exact
+service units completed fresh production backups. PostgreSQL then completed a
+19.1 GB differential scope with a 4.27 GB encrypted repository delta in 140
+seconds; Typesense completed a 1,362,668,187-byte snapshot, encrypted upload,
+prune, and repository check in 78 seconds. Both emitted successful atomic JSON
+and Prometheus freshness records. PostgreSQL remained ready with zero archive
+failures and Typesense remained healthy without a restart.
+
+Both timers are enabled and their next jittered runs are visible. Delete and
+rebuild protection is enabled on both data servers, delete protection is
+enabled on the PostgreSQL Volume, and the validated pre-cutover PostgreSQL
+container has been removed. Legacy server backups remain until daily
+error-review alert delivery passes the removal gate below.
 
 ## Installation and scheduling
 
@@ -110,7 +119,10 @@ disabling an existing timer. Deployment uses the same per-service lock as the
 backup job and fails safely instead of replacing code during an active
 backup. The production environment variables
 `HETZNER_POSTGRES_HOST` and `HETZNER_TYPESENSE_HOST` select the two hosts; the
-workflow reuses the existing Hetzner SSH deployment credential.
+workflow reuses the existing Hetzner SSH deployment credential. These are
+environment-scoped variables, so the workflow resolves them inside runtime
+steps after the protected `production` environment is attached; do not embed
+their values in `strategy.matrix`, which GitHub expands earlier.
 
 Confirm the effective schedule:
 
@@ -282,6 +294,12 @@ are true for both services:
 - failure and freshness status is included in the daily Codex error-review
   evidence and can create or update an actionable GitHub issue;
 - recovery evidence and measured recovery time are recorded in the audit.
+
+Current gate state as of 2026-07-22: off-host backups, repository validation,
+isolated restores, measured recovery evidence, enabled schedules, and visible
+next runs have passed. Daily Codex failure/freshness evidence and proven GitHub
+issue delivery remain pending. Therefore the legacy server backups must remain
+enabled even though the replacement data protection is operating normally.
 
 After the gate passes, disable server backups and delete the residual server
 backup images for PostgreSQL and Typesense. Preserve the independent Storage

--- a/docs/audits/2026-07-22-hetzner-systems.md
+++ b/docs/audits/2026-07-22-hetzner-systems.md
@@ -45,11 +45,27 @@ pass.
   heap and B-tree parent verification across all 384 relations and 2,147,497
   pages. The restored database exposed 2,447,190 postings with zero rows
   failing the structural-null probe. Temporary drill state was removed. The
-  exact old container remains stopped as a rollback target until the reviewed
-  revision is merged and redeployed.
-- The PostgreSQL and Typesense timers and the legacy Hetzner OS backups remain
-  unchanged until both restore evidence and daily error-review alert evidence
-  satisfy the removal gate in `docs/19-data-backup-recovery.md`.
+  reviewed revision was then merged and deployed from `main` to both data
+  hosts. A workflow evaluation bug was reproduced and fixed: protected
+  environment variables cannot be resolved while GitHub expands a job matrix,
+  so host selection now occurs only inside runtime steps after the production
+  environment is attached.
+- The exact deployed PostgreSQL service completed a fresh differential backup
+  covering 19.1 GB with a 4.27 GB encrypted repository delta in 140 seconds.
+  The exact deployed Typesense service completed a 1,362,668,187-byte
+  consistent snapshot, encrypted upload, retention prune, and repository check
+  in 78 seconds. Both atomic status files and Prometheus textfiles report
+  success. PostgreSQL stayed ready with zero archive failures; Typesense stayed
+  healthy with its original start time, and neither container restarted or was
+  OOM-killed.
+- Both backup timers are enabled with their next jittered runs visible. Delete
+  and rebuild protection is enabled on the PostgreSQL and Typesense servers,
+  and delete protection is enabled on the PostgreSQL Volume. The stopped
+  pre-cutover PostgreSQL container was removed after these gates passed.
+- The legacy Hetzner OS backups remain unchanged. Their final removal is gated
+  only on proving that backup failure/freshness evidence reaches the daily
+  Codex error-review workflow and can create or update an actionable GitHub
+  issue, as required by `docs/19-data-backup-recovery.md`.
 
 ## Inventory and ownership
 
@@ -214,11 +230,16 @@ Observed project inventory for the in-scope systems: three running servers, one 
 ## Remaining evidence gaps
 
 - Name and verify accountable human owners/on-call escalation paths; the Cloud project API does not expose project membership or billing ownership.
-- Create application-consistent PostgreSQL and Typesense backups in independent storage, verify isolated restores and RPO/RTO, then remove the mistaken Hetzner OS backups.
+- Prove database/search backup failure and freshness evidence in the daily
+  Codex issue-delivery path, then remove the mistaken Hetzner OS backups.
 - Add explicit historical metrics coverage to the root-produced Codex error-review evidence boundary without exposing production or write credentials.
 - Verify the documented Cloudflare per-IP rate-limit rule and notification routing in the Cloudflare control plane.
 - Verify notification delivery rather than rule evaluation only; the false `ExporterStale` alerts show that firing state alone is not useful evidence.
 
 ## Remediation state
 
-No service was restarted, deployed, reconfigured, resized, patched, or mutated during this audit. Database queries and external probes were read-only. Issue creation is organizational only; remediation remains paused.
+The baseline audit phase was read-only. Subsequent operator-approved changes
+are recorded only in the verified remediation change log above so the original
+observations remain reproducible. Replacement database/search backups,
+restores, scheduling, capacity expansion, and resource protections are now
+verified; legacy OS-backup removal remains gated on daily alert-delivery proof.


### PR DESCRIPTION
## Summary
- record exact-revision PostgreSQL and Typesense backup evidence
- document enabled schedules and Hetzner deletion protections
- record PostgreSQL rollback finalization and the workflow host-resolution root cause
- keep legacy OS backups explicitly gated on daily Codex alert-delivery proof

## Verification
- pre-commit run --all-files
- git diff --check
- production evidence was collected read-only after the approved mutations

Documentation follow-up for #5927; this does not close the issue because the alert-delivery gate remains pending.