### PR TITLE
Render public watchlists from server data

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
@@ -1,8 +1,16 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import { cacheLife, cacheTag } from "next/cache";
-import { isLocale, defaultLocale, loadCatalog, ogLocale, ogAlternateLocales } from "@/lib/i18n";
+import {
+  isLocale,
+  defaultLocale,
+  loadCatalog,
+  ogLocale,
+  ogAlternateLocales,
+  type Locale,
+} from "@/lib/i18n";
 import { watchlistCacheTag } from "@/lib/cache-tags";
-import { CACHE_TTL_LONG } from "@/lib/cache-ttl";
+import { CACHE_TTL_LONG, CACHE_TTL_SHORT } from "@/lib/cache-ttl";
 import {
   getPublicWatchlistByUserAndSlug,
   getWatchlistMatchingCompanyCount,
@@ -10,18 +18,24 @@ import {
 import { isQualifyingWatchlist } from "@/lib/watchlist-utils";
 import { siteConfig } from "@/content/config";
 import { buildAlternates, buildWatchlistItemListJsonLd, JsonLd } from "@/lib/seo";
+import {
+  fetchPublicWatchlistPageData,
+  fetchWatchlistPageData,
+} from "@/lib/actions/watchlist-page-data";
 import { WatchlistContent } from "./watchlist-content";
 
-// 1-hour cache for both the metadata and the page body. Each is its
-// own `'use cache'` boundary — under cacheComponents they run in
+// Metadata is cached for an hour; the page body uses the short tier so
+// its posting list stays reasonably fresh. Each is its own `'use cache'`
+// boundary — under cacheComponents they run in
 // separate clean AsyncLocalStorage snapshots, so React's `cache()`
 // wouldn't dedupe the watchlist lookup across them. Cross-boundary
 // dedup lives one level down: `getPublicWatchlistByUserAndSlug` is
 // wrapped in Redis `cached()` (60s TTL) so the two callers share a
 // single SQL roundtrip. Watchlist metadata is shared via the CDN, so
-// per-viewer freshness comes from the client-hydrated body — search
+// the anonymous page body is also rendered at this boundary, while
+// viewers with personalization hints refresh it client-side. Search
 // engines re-crawl on a much slower cadence than an hour anyway. See
-// issue #2648.
+// issues #2648 and #5980.
 
 type Props = {
   params: Promise<{ lang: string; userSlug: string; watchlistSlug: string }>;
@@ -36,7 +50,8 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const [detail, { i18n }] = await Promise.all([
     // Public-only fetch: never reads session, so the page stays
     // statically prerenderable. The session-aware variant is only used
-    // by the client-fired server action that hydrates the page body.
+    // when viewer-specific data is needed, either in the runtime
+    // missing/private boundary or by the public page's client refresh.
     // See issue #2244. The Redis `cached()` wrapper inside
     // `getPublicWatchlistByUserAndSlug` shares this lookup with the
     // page-render call below.
@@ -144,21 +159,26 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
   };
 }
 
-export default async function WatchlistRoute({ params }: Props) {
+async function getWatchlistRouteSnapshot(
+  locale: Locale,
+  userSlug: string,
+  watchlistSlug: string,
+) {
   "use cache";
-  cacheLife({ revalidate: CACHE_TTL_LONG });
-  const { lang, userSlug, watchlistSlug } = await params;
+  cacheLife({ revalidate: CACHE_TTL_SHORT });
   cacheTag(watchlistCacheTag(userSlug, watchlistSlug));
-  const locale = isLocale(lang) ? lang : defaultLocale;
 
   // Re-fetch the watchlist detail. The Redis `cached()` layer inside
   // `getPublicWatchlistByUserAndSlug` shares the result with the
   // `generateMetadata` call above (single SQL per cold cache fill).
-  // The body is client-rendered via WatchlistContent, but the
-  // structured data must reach non-JS consumers (AI retrievers,
-  // search-engine crawlers that don't execute JS) — emitting it
-  // server-side is the only path.
+  // The body and its structured data must reach non-JS consumers (AI
+  // retrievers and search-engine crawlers that don't execute JS), so
+  // render the anonymous snapshot here. Viewers with personalization
+  // hints replace it through WatchlistContent's server action.
   const detail = await getPublicWatchlistByUserAndSlug(userSlug, watchlistSlug);
+  if (!detail) return null;
+
+  const initialData = await fetchPublicWatchlistPageData({ detail, locale });
 
   // For `anyCompany` watchlists, `detail.companies` is unrelated to
   // what the watchlist actually tracks (it holds leftover rows from
@@ -166,17 +186,72 @@ export default async function WatchlistRoute({ params }: Props) {
   // Emitting `Organization` references for that noise would mislead
   // schema consumers. Skip JSON-LD entirely for those; the page
   // metadata description still describes the watchlist correctly.
-  const itemListJsonLd = detail && !detail.filters.anyCompany
+  const itemListJsonLd = !detail.filters.anyCompany
     ? buildWatchlistItemListJsonLd(
         { title: detail.title, companies: detail.companies },
         locale,
       )
     : null;
 
+  return { initialData, itemListJsonLd };
+}
+
+async function WatchlistRuntimeContent({
+  locale,
+  userSlug,
+  watchlistSlug,
+}: {
+  locale: Locale;
+  userSlug: string;
+  watchlistSlug: string;
+}) {
+  const initialData = await fetchWatchlistPageData({
+    userSlug,
+    watchlistSlug,
+    locale,
+  });
+
+  return (
+    <WatchlistContent
+      lang={locale}
+      userSlug={userSlug}
+      watchlistSlug={watchlistSlug}
+      initialData={initialData}
+      viewerResolved
+    />
+  );
+}
+
+export default async function WatchlistRoute({ params }: Props) {
+  const { lang, userSlug, watchlistSlug } = await params;
+  const locale = isLocale(lang) ? lang : defaultLocale;
+  const snapshot = await getWatchlistRouteSnapshot(
+    locale,
+    userSlug,
+    watchlistSlug,
+  );
+
+  if (!snapshot) {
+    return (
+      <Suspense fallback={null}>
+        <WatchlistRuntimeContent
+          locale={locale}
+          userSlug={userSlug}
+          watchlistSlug={watchlistSlug}
+        />
+      </Suspense>
+    );
+  }
+
   return (
     <>
-      {itemListJsonLd && <JsonLd data={itemListJsonLd} />}
-      <WatchlistContent lang={lang} userSlug={userSlug} watchlistSlug={watchlistSlug} />
+      {snapshot.itemListJsonLd && <JsonLd data={snapshot.itemListJsonLd} />}
+      <WatchlistContent
+        lang={locale}
+        userSlug={userSlug}
+        watchlistSlug={watchlistSlug}
+        initialData={snapshot.initialData}
+      />
     </>
   );
 }

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-content.test.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-content.test.tsx
@@ -1,0 +1,170 @@
+import { render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { WatchlistPageData } from "@/lib/actions/watchlist-page-data";
+
+const mockFetchWatchlistPageData = vi.fn();
+const mockHasLoggedInHint = vi.fn();
+const mockHasAnonJobLanguagesHint = vi.fn();
+
+vi.mock("@/lib/actions/watchlist-page-data", () => ({
+  fetchWatchlistPageData: (...args: unknown[]) =>
+    mockFetchWatchlistPageData(...args),
+}));
+
+vi.mock("@/lib/client-cookies", () => ({
+  hasLoggedInHint: () => mockHasLoggedInHint(),
+  hasAnonJobLanguagesHint: () => mockHasAnonJobLanguagesHint(),
+}));
+
+vi.mock("@/components/search/watchlist-skeleton", () => ({
+  WatchlistSkeleton: () => <div data-testid="watchlist-skeleton" />,
+}));
+
+vi.mock("./watchlist-view-page", () => ({
+  WatchlistViewPage: ({ isOwner }: { isOwner: boolean }) => (
+    <div data-testid="watchlist-view" data-owner={String(isOwner)} />
+  ),
+}));
+
+vi.mock("./watchlist-not-found", () => ({
+  WatchlistNotFoundState: () => <div data-testid="watchlist-not-found" />,
+}));
+
+import { WatchlistContent } from "./watchlist-content";
+
+function makeData(isOwner = false): WatchlistPageData {
+  return {
+    detail: {
+      id: "watchlist-1",
+      slug: "public-list",
+      title: "Public list",
+      description: null,
+      isPublic: true,
+      alertsEnabled: false,
+      filters: {},
+      sourceWatchlistId: null,
+      createdAt: "2026-07-22T00:00:00.000Z",
+      owner: {
+        id: "user-1",
+        username: "owner",
+        displayUsername: "owner",
+        name: "Owner",
+      },
+      companies: [],
+    },
+    isOwner,
+    isPaidPlan: false,
+    limitReached: true,
+    postings: [],
+    total: 0,
+    yearTotal: 0,
+    resolvedLocations: [],
+    resolvedOccupations: [],
+    resolvedSeniorities: [],
+    resolvedTechnologies: [],
+    jobLanguages: [],
+    languages: ["en"],
+  };
+}
+
+beforeEach(() => {
+  mockFetchWatchlistPageData.mockReset();
+  mockHasLoggedInHint.mockReset().mockReturnValue(false);
+  mockHasAnonJobLanguagesHint.mockReset().mockReturnValue(false);
+  vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("WatchlistContent initial data", () => {
+  it("renders anonymous public data immediately without a mount fetch", async () => {
+    const { getByTestId, queryByTestId } = render(
+      <WatchlistContent
+        lang="en"
+        userSlug="owner"
+        watchlistSlug="public-list"
+        initialData={makeData()}
+      />,
+    );
+
+    expect(getByTestId("watchlist-view")).toBeTruthy();
+    expect(queryByTestId("watchlist-skeleton")).toBeNull();
+    await waitFor(() => expect(mockFetchWatchlistPageData).not.toHaveBeenCalled());
+  });
+
+  it("refetches when the logged-in hint requires viewer-specific data", async () => {
+    mockHasLoggedInHint.mockReturnValue(true);
+    mockFetchWatchlistPageData.mockResolvedValue(makeData(true));
+
+    const { getByTestId } = render(
+      <WatchlistContent
+        lang="en"
+        userSlug="owner"
+        watchlistSlug="public-list"
+        initialData={makeData()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockFetchWatchlistPageData).toHaveBeenCalledWith({
+        userSlug: "owner",
+        watchlistSlug: "public-list",
+        locale: "en",
+      });
+      expect(getByTestId("watchlist-view").getAttribute("data-owner")).toBe(
+        "true",
+      );
+    });
+  });
+
+  it("uses viewer-resolved server data without another authenticated fetch", async () => {
+    mockHasLoggedInHint.mockReturnValue(true);
+
+    const { getByTestId } = render(
+      <WatchlistContent
+        lang="en"
+        userSlug="owner"
+        watchlistSlug="private-list"
+        initialData={makeData(true)}
+        viewerResolved
+      />,
+    );
+
+    expect(getByTestId("watchlist-view").getAttribute("data-owner")).toBe(
+      "true",
+    );
+    await waitFor(() => expect(mockFetchWatchlistPageData).not.toHaveBeenCalled());
+  });
+
+  it("renders a definitive server not-found result without a client lookup", async () => {
+    const { getByTestId, queryByTestId } = render(
+      <WatchlistContent
+        lang="en"
+        userSlug="missing"
+        watchlistSlug="missing"
+        initialData={null}
+        viewerResolved
+      />,
+    );
+
+    expect(getByTestId("watchlist-not-found")).toBeTruthy();
+    expect(queryByTestId("watchlist-skeleton")).toBeNull();
+    await waitFor(() => expect(mockFetchWatchlistPageData).not.toHaveBeenCalled());
+  });
+
+  it("keeps the legacy fetch path when no public initial data exists", async () => {
+    mockFetchWatchlistPageData.mockResolvedValue(null);
+
+    render(
+      <WatchlistContent
+        lang="en"
+        userSlug="missing"
+        watchlistSlug="missing"
+      />,
+    );
+
+    await waitFor(() => expect(mockFetchWatchlistPageData).toHaveBeenCalledTimes(1));
+  });
+});

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-content.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-content.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { Trans } from "@lingui/react/macro";
 import { fetchWatchlistPageData, type WatchlistPageData } from "@/lib/actions/watchlist-page-data";
+import { hasAnonJobLanguagesHint, hasLoggedInHint } from "@/lib/client-cookies";
 import { WatchlistSkeleton } from "@/components/search/watchlist-skeleton";
 import { WatchlistViewPage } from "./watchlist-view-page";
 import { WatchlistNotFoundState } from "./watchlist-not-found";
@@ -11,6 +12,10 @@ type WatchlistContentProps = {
   lang: string;
   userSlug: string;
   watchlistSlug: string;
+  /** Cache-safe anonymous data, or null when the server confirmed no access. */
+  initialData?: WatchlistPageData | null;
+  /** The server already resolved this specific viewer, so no mount fetch is needed. */
+  viewerResolved?: boolean;
 };
 
 function WatchlistNotFound({ lang }: { lang: string }) {
@@ -45,16 +50,38 @@ function WatchlistNotFound({ lang }: { lang: string }) {
   );
 }
 
-export function WatchlistContent({ lang, userSlug, watchlistSlug }: WatchlistContentProps) {
-  const [data, setData] = useState<WatchlistPageData | null | "not-found">(null);
+export function WatchlistContent({
+  lang,
+  userSlug,
+  watchlistSlug,
+  initialData,
+  viewerResolved = false,
+}: WatchlistContentProps) {
+  const [data, setData] = useState<WatchlistPageData | null | "not-found">(
+    initialData === null ? "not-found" : (initialData ?? null),
+  );
 
   useEffect(() => {
-    setData(null);
     window.scrollTo(0, 0);
+    if (viewerResolved) {
+      setData(initialData ?? "not-found");
+      return;
+    }
+
+    const needsPersonalizedFetch =
+      hasLoggedInHint() ||
+      hasAnonJobLanguagesHint() ||
+      initialData === undefined;
+    if (!needsPersonalizedFetch) {
+      setData(initialData);
+      return;
+    }
+
+    setData(null);
     fetchWatchlistPageData({ userSlug, watchlistSlug, locale: lang }).then((result) => {
       setData(result ?? "not-found");
     });
-  }, [lang, userSlug, watchlistSlug]);
+  }, [initialData, lang, userSlug, viewerResolved, watchlistSlug]);
 
   if (data === null) return <WatchlistSkeleton />;
   if (data === "not-found") return <WatchlistNotFound lang={lang} />;

--- a/apps/web/src/lib/actions/watchlist-page-data.ts
+++ b/apps/web/src/lib/actions/watchlist-page-data.ts
@@ -16,8 +16,12 @@ import { resolveJobLanguages } from "@/lib/job-languages";
 import { convertToEur } from "@/lib/salary";
 import type { WatchlistPostingEntry } from "@/lib/actions/watchlists";
 
+type WatchlistDetail = NonNullable<
+  Awaited<ReturnType<typeof getWatchlistByUserAndSlug>>
+>;
+
 export interface WatchlistPageData {
-  detail: NonNullable<Awaited<ReturnType<typeof getWatchlistByUserAndSlug>>>;
+  detail: WatchlistDetail;
   isOwner: boolean;
   isPaidPlan: boolean;
   limitReached: boolean;
@@ -33,34 +37,23 @@ export interface WatchlistPageData {
   languages: string[];
 }
 
-export async function fetchWatchlistPageData(params: {
-  userSlug: string;
-  watchlistSlug: string;
+async function buildWatchlistPageData(params: {
+  detail: WatchlistDetail;
   locale: string;
-}): Promise<WatchlistPageData | null> {
-  const { userSlug, watchlistSlug, locale } = params;
-
-  const detail = await getWatchlistByUserAndSlug(userSlug, watchlistSlug);
-  if (!detail) return null;
-
-  const session = await getSession();
-  const isOwner = session?.user?.id === detail.owner.id;
-
-  // Auth users persist `jobLanguages` in `user_preferences`; anon
-  // users mirror it into a cookie (issue #2850 + `anon-preferences.ts`).
-  // Read whichever applies so the watchlist body filters consistently.
-  const [plan, limit, prefs, anonJobLangs] = await Promise.all([
-    session ? getUserPlan(session.user.id) : ("free" as const),
-    session ? canCreateWatchlist(session.user.id) : { allowed: false, current: 0, max: 0 },
-    session ? getPreferences() : Promise.resolve(null),
-    session ? Promise.resolve(null) : readAnonJobLanguagesCookie(),
-  ]);
-  const isPaidPlan = PLAN_LIMITS[plan].canReceiveAlerts;
-  const limitReached = !limit.allowed;
-
-  const jobLanguages = prefs?.jobLanguages ?? anonJobLangs ?? [];
+  isOwner: boolean;
+  isPaidPlan: boolean;
+  limitReached: boolean;
+  jobLanguages: string[];
+}): Promise<WatchlistPageData> {
+  const {
+    detail,
+    locale,
+    isOwner,
+    isPaidPlan,
+    limitReached,
+    jobLanguages,
+  } = params;
   const languages = resolveJobLanguages(jobLanguages, locale);
-
   const filters = detail.filters;
 
   const [locMap, occMap, senMap, techMap] = await Promise.all([
@@ -150,4 +143,55 @@ export async function fetchWatchlistPageData(params: {
     jobLanguages,
     languages,
   };
+}
+
+/** Anonymous, cache-safe initial data for a known public watchlist. */
+export async function fetchPublicWatchlistPageData(params: {
+  detail: WatchlistDetail;
+  locale: string;
+}): Promise<WatchlistPageData> {
+  return buildWatchlistPageData({
+    detail: params.detail,
+    locale: params.locale,
+    isOwner: false,
+    isPaidPlan: false,
+    limitReached: true,
+    jobLanguages: [],
+  });
+}
+
+export async function fetchWatchlistPageData(params: {
+  userSlug: string;
+  watchlistSlug: string;
+  locale: string;
+}): Promise<WatchlistPageData | null> {
+  const { userSlug, watchlistSlug, locale } = params;
+
+  const detail = await getWatchlistByUserAndSlug(userSlug, watchlistSlug);
+  if (!detail) return null;
+
+  const session = await getSession();
+  const isOwner = session?.user?.id === detail.owner.id;
+
+  // Auth users persist `jobLanguages` in `user_preferences`; anon
+  // users mirror it into a cookie (issue #2850 + `anon-preferences.ts`).
+  // Read whichever applies so the watchlist body filters consistently.
+  const [plan, limit, prefs, anonJobLangs] = await Promise.all([
+    session ? getUserPlan(session.user.id) : ("free" as const),
+    session ? canCreateWatchlist(session.user.id) : { allowed: false, current: 0, max: 0 },
+    session ? getPreferences() : Promise.resolve(null),
+    session ? Promise.resolve(null) : readAnonJobLanguagesCookie(),
+  ]);
+  const isPaidPlan = PLAN_LIMITS[plan].canReceiveAlerts;
+  const limitReached = !limit.allowed;
+
+  const jobLanguages = prefs?.jobLanguages ?? anonJobLangs ?? [];
+  return buildWatchlistPageData({
+    detail,
+    isOwner,
+    isPaidPlan,
+    limitReached,
+    locale,
+    jobLanguages,
+  });
 }


### PR DESCRIPTION
## Summary

- render cache-safe anonymous public-watchlist data in the server response instead of painting a skeleton and calling a second server action on mount
- keep the public posting snapshot on the 60-second cache tier so initial results stay reasonably fresh
- resolve public misses in a request-time server boundary, giving anonymous visitors a definitive not-found state while preserving private-owner access
- refetch only when a cached public page has logged-in or anonymous-language personalization hints

## Verification

- `pnpm --dir apps/web test` (196 files, 1,451 tests)
- `pnpm --dir apps/web typecheck`
- focused Vitest coverage for anonymous, personalized, private-owner, and definitive-not-found paths
- ESLint
- Lingui translation coverage
- `pnpm --dir apps/web build`

Closes #5980