### PR TITLE
Keep public watchlist snapshots session-free

### DIFF
--- a/apps/web/src/lib/actions/__tests__/watchlist-year-count-fallback.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlist-year-count-fallback.test.ts
@@ -195,6 +195,7 @@ vi.mock("@/lib/watchlist-utils", () => ({
 }));
 
 import {
+  getPublicWatchlistPostings,
   getWatchlistPostingYearCount,
   getWatchlistPostings,
 } from "../watchlists";
@@ -323,6 +324,20 @@ describe("getWatchlistPostingYearCount fallback (#3056)", () => {
     expect(mocks.withTypesenseRetry).toHaveBeenCalledTimes(1);
     expect(mocks.isTypesenseUnavailableError).toHaveBeenCalledWith(rateLimitError);
     expect(mocks.dbExecute).not.toHaveBeenCalled();
+  });
+
+  it("keeps cached public posting snapshots session-free (#5980)", async () => {
+    mocks.tsSearch.mockResolvedValue({ found: 0, hits: [] });
+
+    const result = await getPublicWatchlistPostings({
+      companyIds: ["11111111-1111-1111-1111-111111111111"],
+      offset: 0,
+      limit: 20,
+    });
+
+    expect(result).toEqual({ postings: [], total: 0 });
+    expect(mocks.getSessionUserId).not.toHaveBeenCalled();
+    expect(mocks.tsSearch).toHaveBeenCalledTimes(1);
   });
 
   it("batches active posting queries before the Typesense GET limit (#3477)", async () => {

--- a/apps/web/src/lib/actions/watchlist-page-data.ts
+++ b/apps/web/src/lib/actions/watchlist-page-data.ts
@@ -2,6 +2,7 @@
 
 import {
   getWatchlistByUserAndSlug,
+  getPublicWatchlistPostings,
   getWatchlistPostings,
   getWatchlistPostingYearCount,
 } from "@/lib/actions/watchlists";
@@ -44,6 +45,7 @@ async function buildWatchlistPageData(params: {
   isPaidPlan: boolean;
   limitReached: boolean;
   jobLanguages: string[];
+  publicSnapshot: boolean;
 }): Promise<WatchlistPageData> {
   const {
     detail,
@@ -52,6 +54,7 @@ async function buildWatchlistPageData(params: {
     isPaidPlan,
     limitReached,
     jobLanguages,
+    publicSnapshot,
   } = params;
   const languages = resolveJobLanguages(jobLanguages, locale);
   const filters = detail.filters;
@@ -124,7 +127,11 @@ async function buildWatchlistPageData(params: {
     languages,
   };
   const [{ postings, total }, yearTotal] = await Promise.all([
-    getWatchlistPostings({ ...sharedCountsParams, offset: 0, limit: 20 }),
+    (publicSnapshot ? getPublicWatchlistPostings : getWatchlistPostings)({
+      ...sharedCountsParams,
+      offset: 0,
+      limit: 20,
+    }),
     getWatchlistPostingYearCount(sharedCountsParams),
   ]);
 
@@ -157,6 +164,7 @@ export async function fetchPublicWatchlistPageData(params: {
     isPaidPlan: false,
     limitReached: true,
     jobLanguages: [],
+    publicSnapshot: true,
   });
 }
 
@@ -193,5 +201,6 @@ export async function fetchWatchlistPageData(params: {
     limitReached,
     locale,
     jobLanguages,
+    publicSnapshot: false,
   });
 }

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -99,6 +99,12 @@ export async function getWatchlistPostings(
   return service.getWatchlistPostings(...args);
 }
 
+export async function getPublicWatchlistPostings(
+  ...args: Parameters<typeof service.getPublicWatchlistPostings>
+): ReturnType<typeof service.getPublicWatchlistPostings> {
+  return service.getPublicWatchlistPostings(...args);
+}
+
 export async function getWatchlistPostingYearCount(
   ...args: Parameters<typeof service.getWatchlistPostingYearCount>
 ): ReturnType<typeof service.getWatchlistPostingYearCount> {

--- a/apps/web/src/lib/services/watchlists.ts
+++ b/apps/web/src/lib/services/watchlists.ts
@@ -1760,6 +1760,37 @@ export async function getWatchlistPostings(
 }
 
 /**
+ * Session-free counterpart used by cached public-watchlist snapshots.
+ *
+ * `getWatchlistPostings` reads `getSessionUserId()` to apply saved-job state
+ * and anonymous truncation. That request API is intentionally forbidden
+ * inside a shared `"use cache"` boundary, so the public route must pass the
+ * known-anonymous viewer explicitly instead of consulting `headers()`.
+ */
+export async function getPublicWatchlistPostings(
+  params: WatchlistPostingQueryParams,
+): Promise<{ postings: WatchlistPostingEntry[]; total: number; truncated?: boolean }> {
+  if (!params.anyCompany && params.companyIds.length === 0) {
+    return { postings: [], total: 0 };
+  }
+
+  if (params.offset >= ANON_MAX_WATCHLIST_POSTINGS) {
+    return { postings: [], total: 0, truncated: true };
+  }
+
+  try {
+    return await _getWatchlistPostingsTypesense(params, null);
+  } catch (err) {
+    if (!isTypesenseUnavailableError(err)) throw err;
+    console.error(
+      "[getPublicWatchlistPostings] Typesense failed, falling back to Postgres",
+      err,
+    );
+    return _getWatchlistPostingsPostgres(params, null);
+  }
+}
+
+/**
  * Year-window posting count for a watchlist's current filter set.
  *
  * Counterpart to `getWatchlistPostings`: same filters, but drops


### PR DESCRIPTION
## Summary

- add a session-free public posting reader for cached anonymous watchlist snapshots
- preserve anonymous truncation, Typesense batching, and Postgres fallback without consulting request headers
- route only the cache-safe public snapshot through that reader; personalized and private views keep the existing session-aware path
- add regression coverage proving the public reader never calls `getSessionUserId()`

## Production incident

Production verification of #5981 exposed `headers()` inside `"use cache"` on real public watchlists (`Error ID: 402298860@E833`). `jseek.co` was immediately rolled back to known-good deployment `dpl_FQXaAbJCNjcxp5ZNLuuUEnfd9BWx` while this hotfix was prepared.

## Verification

- local anonymous render of the real Big Tech watchlist against configured production data/services
- `pnpm --dir apps/web test` (196 files, 1,452 tests)
- `pnpm --dir apps/web typecheck`
- targeted public/session regression test
- ESLint
- Lingui translation coverage
- `pnpm --dir apps/web build`

Closes #5980