### PR TITLE
Submit title searches on Enter

### DIFF
--- a/apps/web/src/components/search/__tests__/search-bar-company-scope.test.tsx
+++ b/apps/web/src/components/search/__tests__/search-bar-company-scope.test.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   push: vi.fn(),
   submitSearch: vi.fn(),
   parseSearchFilters: vi.fn(),
+  suggestLocations: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -23,7 +24,7 @@ vi.mock("@/lib/actions/company", () => ({
 }));
 
 vi.mock("@/lib/search/typeahead-runner", () => ({
-  runSuggestLocations: vi.fn(async () => []),
+  runSuggestLocations: (...args: unknown[]) => mocks.suggestLocations(...args),
   runSuggestOccupations: vi.fn(async () => []),
   runSuggestSeniorities: vi.fn(async () => []),
   runSuggestTechnologies: vi.fn(async () => []),
@@ -40,6 +41,13 @@ import {
   SearchStateProvider,
   useSearchStateStore,
 } from "@/components/providers/SearchStateProvider";
+
+beforeEach(() => {
+  mocks.push.mockReset();
+  mocks.submitSearch.mockReset();
+  mocks.parseSearchFilters.mockReset();
+  mocks.suggestLocations.mockReset();
+});
 
 function CompanySearchHarness() {
   const { setPageActions } = useSearchStateStore();
@@ -64,7 +72,46 @@ function CompanySearchHarness() {
 }
 
 describe("SearchBar company scope", () => {
+  it("submits free text on Enter after additional suggestions arrive", async () => {
+    mocks.suggestLocations.mockResolvedValue([
+      {
+        id: 10,
+        slug: "merced-california",
+        name: "Merced",
+        type: "city",
+        parentName: "California",
+      },
+    ]);
+    mocks.parseSearchFilters.mockResolvedValue({
+      keywords: ["merck"],
+      locations: [],
+      occupations: [],
+      seniorities: [],
+      technologies: [],
+      workMode: [],
+    });
+
+    render(
+      <SearchStateProvider>
+        <CompanySearchHarness />
+      </SearchStateProvider>,
+    );
+
+    const input = screen.getByRole("combobox");
+    await userEvent.type(input, "merck");
+    expect(await screen.findByText("Merced")).toBeTruthy();
+    await userEvent.type(input, "{Enter}");
+
+    await waitFor(() => {
+      expect(mocks.submitSearch).toHaveBeenCalledWith(
+        ["merck"], [], [], [], [], [],
+      );
+    });
+    expect(mocks.push).not.toHaveBeenCalled();
+  });
+
   it("submits free text through the company page instead of navigating to Explore", async () => {
+    mocks.suggestLocations.mockResolvedValue([]);
     mocks.parseSearchFilters.mockResolvedValue({
       keywords: ["safety"],
       locations: [],

--- a/apps/web/src/components/search/search-bar.tsx
+++ b/apps/web/src/components/search/search-bar.tsx
@@ -444,11 +444,13 @@ export function SearchBar({
       e.preventDefault();
       if (activeIndex >= 0 && activeIndex < allSuggestions.length) {
         selectItem(allSuggestions[activeIndex]);
-      } else if (allSuggestions.length === 1 && allSuggestions[0].kind === "keyword") {
-        // Auto-select when keyword is the only option
-        selectItem(allSuggestions[0]);
+      } else if (trimmedInput.length >= 2) {
+        // The title-search row is always the first option. Enter should
+        // submit it even after asynchronous taxonomy/company suggestions
+        // arrive; requiring ArrowDown first makes an ordinary search input
+        // appear unresponsive (#5985).
+        submitFreeTextSearch();
       }
-      // Otherwise no action — user must select from dropdown
     } else if (e.key === "Escape") {
       setIsOpen(false);
       setActiveIndex(-1);


### PR DESCRIPTION
## Summary

- submit the visible title-search action when Enter is pressed without an active suggestion
- preserve Arrow-key selection and Enter activation for highlighted taxonomy/company/request suggestions
- cover the production regression where asynchronous location suggestions made Enter a no-op

Closes #5985

## Verification

- `pnpm exec vitest run src/components/search/__tests__/search-bar-company-scope.test.tsx src/components/search/__tests__/search-bar-request.test.tsx src/components/search/__tests__/search-bar-structured-suggestions.test.tsx`
- `pnpm exec eslint src/components/search/search-bar.tsx src/components/search/__tests__/search-bar-company-scope.test.tsx`
- `pnpm exec tsc --noEmit`
- `pnpm test` — 196 files, 1,453 tests
- `pnpm build`
