### PR TITLE
Format filter facet counts by locale

### DIFF
--- a/apps/web/src/components/search/__tests__/employment-type-modal.test.tsx
+++ b/apps/web/src/components/search/__tests__/employment-type-modal.test.tsx
@@ -38,8 +38,8 @@ describe("EmploymentTypeModal — per-option counts (#3032)", () => {
 
     await waitFor(() => expect(getEmploymentTypeCountsMock).toHaveBeenCalled());
     // After data resolves, each option button shows its count alongside the label.
-    await waitFor(() => screen.getByText("(1234)"));
-    expect(screen.getByText("(1234)")).toBeTruthy();
+    await waitFor(() => screen.getByText("(1,234)"));
+    expect(screen.getByText("(1,234)")).toBeTruthy();
     expect(screen.getByText("(56)")).toBeTruthy();
     expect(screen.getByText("(78)")).toBeTruthy();
     expect(screen.getByText("(9)")).toBeTruthy();

--- a/apps/web/src/components/search/__tests__/facet-count.test.ts
+++ b/apps/web/src/components/search/__tests__/facet-count.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { formatFacetCount } from "../facet-count";
+
+describe("formatFacetCount", () => {
+  it.each([
+    ["en", "631,127"],
+    ["de", "631.127"],
+    ["fr", "631\u202f127"],
+    ["it", "631.127"],
+  ])("uses the %s locale grouping convention", (locale, expected) => {
+    expect(formatFacetCount(631127, locale)).toBe(expected);
+  });
+});

--- a/apps/web/src/components/search/disabled-filter-pill.tsx
+++ b/apps/web/src/components/search/disabled-filter-pill.tsx
@@ -3,6 +3,7 @@
 import * as Tooltip from "@radix-ui/react-tooltip";
 import { Trans } from "@lingui/react/macro";
 import { tooltipClass } from "@/components/ui/tooltip-styles";
+import { FacetCount } from "./facet-count";
 
 interface DisabledFilterPillProps {
   /** Display name (e.g. "Berlin"). */
@@ -22,8 +23,6 @@ interface DisabledFilterPillProps {
   variant?: "pill" | "parent" | "country" | "region" | "domain";
   /** Optional left-side icon (e.g. country flag). Only rendered for `country` variant. */
   leftAdornment?: React.ReactNode;
-  /** Auxiliary count rendered after the name (e.g. parent + children sum). */
-  auxText?: string;
 }
 
 /**
@@ -39,7 +38,6 @@ export function DisabledFilterPill({
   ancestorName,
   variant = "pill",
   leftAdornment,
-  auxText,
 }: DisabledFilterPillProps) {
   const baseClass = (() => {
     switch (variant) {
@@ -70,14 +68,14 @@ export function DisabledFilterPill({
           >
             {leftAdornment}
             <span>{name}</span>
-            {auxText && (
-              <span className="ml-1 text-xs font-normal text-muted">{auxText}</span>
-            )}
             {count != null && variant === "pill" && (
-              <span className="text-xs text-muted">({count})</span>
+              <FacetCount count={count} className="text-xs text-muted" />
+            )}
+            {count != null && variant === "parent" && (
+              <FacetCount count={count} className="ml-1 text-xs font-normal text-muted" />
             )}
             {count != null && (variant === "country" || variant === "region" || variant === "domain") && (
-              <span className="ml-1 text-[10px] font-normal normal-case text-muted">({count})</span>
+              <FacetCount count={count} className="ml-1 text-[10px] font-normal normal-case text-muted" />
             )}
           </button>
         </Tooltip.Trigger>

--- a/apps/web/src/components/search/employment-type-modal.tsx
+++ b/apps/web/src/components/search/employment-type-modal.tsx
@@ -6,6 +6,7 @@ import { Loader2, X } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { ScrollFade } from "@/components/ui/scroll-fade";
 import { getEmploymentTypeCounts } from "@/lib/actions/taxonomy";
+import { FacetCount } from "./facet-count";
 
 function useEmploymentTypes() {
   const { t } = useLingui();
@@ -108,9 +109,7 @@ export function EmploymentTypeModal({
                       }`}
                     >
                       <span>{opt.label}</span>
-                      <span className={`text-xs ${active ? "text-primary/70" : "text-muted"}`}>
-                        ({count})
-                      </span>
+                      <FacetCount count={count} className={`text-xs ${active ? "text-primary/70" : "text-muted"}`} />
                     </button>
                   );
                 })}

--- a/apps/web/src/components/search/facet-count.tsx
+++ b/apps/web/src/components/search/facet-count.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useLingui } from "@lingui/react";
+
+const formatters = new Map<string, Intl.NumberFormat>();
+
+export function formatFacetCount(count: number, locale: string): string {
+  let formatter = formatters.get(locale);
+  if (!formatter) {
+    formatter = new Intl.NumberFormat(locale);
+    formatters.set(locale, formatter);
+  }
+  return formatter.format(count);
+}
+
+interface FacetCountProps {
+  count: number;
+  className?: string;
+}
+
+/** Locale-aware count shared by every filter-facet rendering shape. */
+export function FacetCount({ count, className }: FacetCountProps) {
+  const { i18n } = useLingui();
+  return (
+    <span className={className}>
+      ({formatFacetCount(count, i18n.locale)})
+    </span>
+  );
+}

--- a/apps/web/src/components/search/location-modal.tsx
+++ b/apps/web/src/components/search/location-modal.tsx
@@ -17,6 +17,7 @@ import { findBestGuess } from "./best-guess";
 import { ScrollFade } from "@/components/ui/scroll-fade";
 import { useDisabledByAncestor } from "./use-disabled-by-ancestor";
 import { DisabledFilterPill } from "./disabled-filter-pill";
+import { FacetCount } from "./facet-count";
 
 /** Threshold: show region sub-headers when a country has more cities than this. */
 const REGION_THRESHOLD = 8;
@@ -356,9 +357,7 @@ export function LocationModal({
                             }`}
                           >
                             {macro.name}
-                            <span className={`text-xs ${active ? "text-primary/70" : "text-muted"}`}>
-                              ({macro.count})
-                            </span>
+                            <FacetCount count={macro.count} className={`text-xs ${active ? "text-primary/70" : "text-muted"}`} />
                           </button>
                         );
                       })}
@@ -399,9 +398,10 @@ export function LocationModal({
                             <CountryFlag iso={countryIso(country.countryId)} size={14} className="mr-1 inline-block align-middle" />
                             <span className={countryActive ? "underline" : ""}>{country.countryName}</span>
                             {country.countryCount > 0 && (
-                              <span className={`ml-1 text-[10px] font-normal normal-case ${countryActive ? "text-primary/70" : "text-muted"}`}>
-                                ({country.countryCount})
-                              </span>
+                              <FacetCount
+                                count={country.countryCount}
+                                className={`ml-1 text-[10px] font-normal normal-case ${countryActive ? "text-primary/70" : "text-muted"}`}
+                              />
                             )}
                           </button>
                         )
@@ -443,9 +443,10 @@ export function LocationModal({
                                     >
                                       <span className={regionActive ? "underline" : ""}>{region.regionName}</span>
                                       {region.regionCount > 0 && (
-                                        <span className={`ml-1 text-[10px] font-normal ${regionActive ? "text-primary/70" : "text-muted"}`}>
-                                          ({region.regionCount})
-                                        </span>
+                                        <FacetCount
+                                          count={region.regionCount}
+                                          className={`ml-1 text-[10px] font-normal ${regionActive ? "text-primary/70" : "text-muted"}`}
+                                        />
                                       )}
                                     </button>
                                   )
@@ -478,9 +479,7 @@ export function LocationModal({
                                         }`}
                                       >
                                         {loc.name}
-                                        <span className={`text-xs ${active ? "text-primary/70" : "text-muted"}`}>
-                                          ({loc.count})
-                                        </span>
+                                        <FacetCount count={loc.count} className={`text-xs ${active ? "text-primary/70" : "text-muted"}`} />
                                       </button>
                                     );
                                   })}
@@ -516,9 +515,7 @@ export function LocationModal({
                                   }`}
                                 >
                                   {loc.name}
-                                  <span className={`text-xs ${active ? "text-primary/70" : "text-muted"}`}>
-                                    ({loc.count})
-                                  </span>
+                                  <FacetCount count={loc.count} className={`text-xs ${active ? "text-primary/70" : "text-muted"}`} />
                                 </button>
                               );
                             }),

--- a/apps/web/src/components/search/location-search-modal.tsx
+++ b/apps/web/src/components/search/location-search-modal.tsx
@@ -26,6 +26,7 @@ import { findBestGuess } from "./best-guess";
 import { ScrollFade } from "@/components/ui/scroll-fade";
 import { useDisabledByAncestor, pruneRedundantDescendants } from "./use-disabled-by-ancestor";
 import { DisabledFilterPill } from "./disabled-filter-pill";
+import { FacetCount } from "./facet-count";
 
 /** Show region sub-headers when a country has more cities than this. */
 const REGION_THRESHOLD = 8;
@@ -573,9 +574,7 @@ export function LocationSearchModal({
                             }`}
                           >
                             {macro.name}
-                            <span className={`text-xs ${active ? "text-primary/70" : "text-muted"}`}>
-                              ({macro.count})
-                            </span>
+                            <FacetCount count={macro.count} className={`text-xs ${active ? "text-primary/70" : "text-muted"}`} />
                           </button>
                         );
                       })}
@@ -625,9 +624,7 @@ export function LocationSearchModal({
                             }`}
                           >
                             {hit.name}
-                            <span className={`text-xs ${active ? "text-primary/70" : "text-muted"}`}>
-                              ({hit.count})
-                            </span>
+                            <FacetCount count={hit.count} className={`text-xs ${active ? "text-primary/70" : "text-muted"}`} />
                           </button>
                         );
                       })}
@@ -680,9 +677,10 @@ export function LocationSearchModal({
                           <CountryFlag iso={countryIso(country.countryId)} size={14} className="mr-1 inline-block align-middle" />
                           <span className={countryActive ? "underline" : ""}>{countryDisplayName}</span>
                           {country.countryCount > 0 && (
-                            <span className={`ml-1 text-[10px] font-normal normal-case ${countryActive ? "text-primary/70" : "text-muted"}`}>
-                              ({country.countryCount})
-                            </span>
+                            <FacetCount
+                              count={country.countryCount}
+                              className={`ml-1 text-[10px] font-normal normal-case ${countryActive ? "text-primary/70" : "text-muted"}`}
+                            />
                           )}
                         </button>
                       )}
@@ -720,9 +718,10 @@ export function LocationSearchModal({
                                     >
                                       <span className={regionActive ? "underline" : ""}>{region.regionName}</span>
                                       {region.regionCount > 0 && (
-                                        <span className={`ml-1 text-[10px] font-normal ${regionActive ? "text-primary/70" : "text-muted"}`}>
-                                          ({region.regionCount})
-                                        </span>
+                                        <FacetCount
+                                          count={region.regionCount}
+                                          className={`ml-1 text-[10px] font-normal ${regionActive ? "text-primary/70" : "text-muted"}`}
+                                        />
                                       )}
                                     </button>
                                   )
@@ -759,9 +758,7 @@ export function LocationSearchModal({
                                         }`}
                                       >
                                         {loc.name}
-                                        <span className={`text-xs ${active ? "text-primary/70" : "text-muted"}`}>
-                                          ({loc.count})
-                                        </span>
+                                        <FacetCount count={loc.count} className={`text-xs ${active ? "text-primary/70" : "text-muted"}`} />
                                       </button>
                                     );
                                   })}
@@ -796,9 +793,7 @@ export function LocationSearchModal({
                                   }`}
                                 >
                                   {loc.name}
-                                  <span className={`text-xs ${active ? "text-primary/70" : "text-muted"}`}>
-                                    ({loc.count})
-                                  </span>
+                                  <FacetCount count={loc.count} className={`text-xs ${active ? "text-primary/70" : "text-muted"}`} />
                                 </button>
                               );
                             }),

--- a/apps/web/src/components/search/occupation-modal.tsx
+++ b/apps/web/src/components/search/occupation-modal.tsx
@@ -10,6 +10,7 @@ import { findBestGuess } from "./best-guess";
 import { ScrollFade } from "@/components/ui/scroll-fade";
 import { useDisabledByAncestor } from "./use-disabled-by-ancestor";
 import { DisabledFilterPill } from "./disabled-filter-pill";
+import { FacetCount } from "./facet-count";
 
 interface OccupationModalProps {
   open: boolean;
@@ -279,9 +280,7 @@ export function OccupationModal({
         }`}
       >
         {item.name}
-        <span className={`text-xs ${active ? "text-primary/70" : "text-muted"}`}>
-          ({item.count})
-        </span>
+        <FacetCount count={item.count} className={`text-xs ${active ? "text-primary/70" : "text-muted"}`} />
       </button>
     );
   }
@@ -367,9 +366,10 @@ export function OccupationModal({
                           }`}
                         >
                           {group.domain.name}
-                          <span className={`ml-1 text-[10px] font-normal normal-case ${allSelected ? "text-primary/70" : "text-muted"}`}>
-                            ({group.domain.count})
-                          </span>
+                          <FacetCount
+                            count={group.domain.count}
+                            className={`ml-1 text-[10px] font-normal normal-case ${allSelected ? "text-primary/70" : "text-muted"}`}
+                          />
                         </button>
                         <div className="h-px flex-1 bg-divider" />
                       </div>
@@ -392,9 +392,9 @@ export function OccupationModal({
                             {parentDisabled ? (
                               <DisabledFilterPill
                                 name={sg.parent.name}
+                                count={totalCount}
                                 ancestorName={ancestorNameOf(sg.parent.id)}
                                 variant="parent"
-                                auxText={`(${totalCount})`}
                               />
                             ) : (
                               <button
@@ -404,9 +404,10 @@ export function OccupationModal({
                                 }`}
                               >
                                 <span className={parentActive ? "underline" : "group-hover/parent:underline"}>{sg.parent.name}</span>
-                                <span className={`ml-1 text-xs font-normal ${parentActive ? "text-primary/70" : "text-muted"}`}>
-                                  ({totalCount})
-                                </span>
+                                <FacetCount
+                                  count={totalCount}
+                                  className={`ml-1 text-xs font-normal ${parentActive ? "text-primary/70" : "text-muted"}`}
+                                />
                               </button>
                             )}
                             {/* Child pills */}

--- a/apps/web/src/components/search/seniority-modal.tsx
+++ b/apps/web/src/components/search/seniority-modal.tsx
@@ -7,6 +7,7 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import { ScrollFade } from "@/components/ui/scroll-fade";
 import { getAllSeniorities } from "@/lib/actions/taxonomy";
 import type { SeniorityOption } from "@/lib/actions/taxonomy";
+import { FacetCount } from "./facet-count";
 
 interface SeniorityModalProps {
   open: boolean;
@@ -96,9 +97,7 @@ export function SeniorityModal({
                       }`}
                     >
                       <span className="font-medium">{opt.name}</span>
-                      <span className={`text-xs ${active ? "text-primary/70" : "text-muted"}`}>
-                        ({opt.count})
-                      </span>
+                      <FacetCount count={opt.count} className={`text-xs ${active ? "text-primary/70" : "text-muted"}`} />
                     </button>
                   );
                 })}

--- a/apps/web/src/components/search/technology-modal.tsx
+++ b/apps/web/src/components/search/technology-modal.tsx
@@ -8,6 +8,7 @@ import { getAllTechnologiesGrouped } from "@/lib/actions/taxonomy";
 import type { TechnologyGroup } from "@/lib/actions/taxonomy";
 import { findBestGuess } from "./best-guess";
 import { ScrollFade } from "@/components/ui/scroll-fade";
+import { FacetCount } from "./facet-count";
 
 interface TechnologyModalProps {
   open: boolean;
@@ -176,9 +177,7 @@ export function TechnologyModal({
                             }`}
                           >
                             <span className="font-medium">{tech.name}</span>
-                            <span className={`text-xs ${active ? "text-primary/70" : "text-muted"}`}>
-                              ({tech.count})
-                            </span>
+                            <FacetCount count={tech.count} className={`text-xs ${active ? "text-primary/70" : "text-muted"}`} />
                           </button>
                         );
                       })}

--- a/apps/web/src/components/search/work-mode-modal.tsx
+++ b/apps/web/src/components/search/work-mode-modal.tsx
@@ -7,6 +7,7 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import { ScrollFade } from "@/components/ui/scroll-fade";
 import { getWorkModeCounts } from "@/lib/actions/taxonomy";
 import type { WorkMode } from "@/lib/search/types";
+import { FacetCount } from "./facet-count";
 
 /**
  * Work-mode (location_types) modal — mirrors employment-type-modal.tsx
@@ -116,9 +117,7 @@ export function WorkModeModal({
                       }`}
                     >
                       <span>{opt.label}</span>
-                      <span className={`text-xs ${active ? "text-primary/70" : "text-muted"}`}>
-                        ({count})
-                      </span>
+                      <FacetCount count={count} className={`text-xs ${active ? "text-primary/70" : "text-muted"}`} />
                     </button>
                   );
                 })}


### PR DESCRIPTION
Fixes #5987

## Summary

- add one locale-aware `FacetCount` component with a bounded `Intl.NumberFormat` cache
- use it across location, role, level, technology, employment-type, and work-mode dialogs
- keep ancestor-disabled hierarchy rows on the same formatting path
- cover English, German, French, and Italian grouping plus a rendered modal integration case

## Validation

- targeted filter tests: 5 files / 35 tests
- ESLint on all changed source and test files
- `pnpm --filter @jobseek/web typecheck`
- `pnpm --filter @jobseek/web test` — 197 files / 1,457 tests
- `pnpm --filter @jobseek/web build`

The local build completed successfully. Its warnings were the expected missing local Redis/Auth/Typesense/database configuration warnings.
