### PR TITLE
Focus searchable filter inputs on open

### DIFF
--- a/apps/web/src/components/search/__tests__/use-searchable-dialog-focus.test.tsx
+++ b/apps/web/src/components/search/__tests__/use-searchable-dialog-focus.test.tsx
@@ -1,0 +1,51 @@
+import { useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { useSearchableDialogFocus } from "../use-searchable-dialog-focus";
+
+function SearchableDialogHarness() {
+  const [open, setOpen] = useState(false);
+  const { searchInputRef, focusSearchInputOnOpen } = useSearchableDialogFocus();
+
+  return (
+    <Dialog.Root open={open} onOpenChange={setOpen}>
+      <Dialog.Trigger asChild>
+        <button type="button">Open filters</button>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Content
+          aria-describedby={undefined}
+          onOpenAutoFocus={focusSearchInputOnOpen}
+        >
+          <Dialog.Title>Search filters</Dialog.Title>
+          <Dialog.Close asChild>
+            <button type="button">Close</button>
+          </Dialog.Close>
+          <input ref={searchInputRef} aria-label="Search options" />
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+
+describe("useSearchableDialogFocus", () => {
+  it("supports immediate typing and restores trigger focus after Escape", async () => {
+    const user = userEvent.setup();
+    render(<SearchableDialogHarness />);
+
+    const trigger = screen.getByRole("button", { name: "Open filters" });
+    await user.click(trigger);
+
+    const input = screen.getByRole("textbox", { name: "Search options" });
+    await waitFor(() => expect(document.activeElement).toBe(input));
+
+    await user.keyboard("engineer");
+    expect((input as HTMLInputElement).value).toBe("engineer");
+
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+});

--- a/apps/web/src/components/search/location-modal.tsx
+++ b/apps/web/src/components/search/location-modal.tsx
@@ -18,6 +18,7 @@ import { ScrollFade } from "@/components/ui/scroll-fade";
 import { useDisabledByAncestor } from "./use-disabled-by-ancestor";
 import { DisabledFilterPill } from "./disabled-filter-pill";
 import { FacetCount } from "./facet-count";
+import { useSearchableDialogFocus } from "./use-searchable-dialog-focus";
 
 /** Threshold: show region sub-headers when a country has more cities than this. */
 const REGION_THRESHOLD = 8;
@@ -45,6 +46,7 @@ export function LocationModal({
   const [search, setSearch] = useState("");
   const [warning, setWarning] = useState("");
   const warningTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const { searchInputRef, focusSearchInputOnOpen } = useSearchableDialogFocus();
 
   const activeLocationIds = useMemo(
     () => new Set(filters.filter((f) => f.kind === "location").map((f) => f.id)),
@@ -262,6 +264,7 @@ export function LocationModal({
         <Dialog.Content
           className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 flex-col rounded-xl border border-border-soft bg-surface shadow-xl data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
           aria-describedby={undefined}
+          onOpenAutoFocus={focusSearchInputOnOpen}
         >
           {/* Header */}
           <div className="flex items-center justify-between border-b border-divider px-5 py-4">
@@ -285,6 +288,7 @@ export function LocationModal({
             <div className="flex items-center gap-2 rounded-md border border-border-soft px-3 py-2">
               <Search size={14} className="shrink-0 text-muted" />
               <input
+                ref={searchInputRef}
                 type="text"
                 value={search}
                 onChange={(e) => { setSearch(e.target.value); setWarning(""); }}

--- a/apps/web/src/components/search/location-search-modal.tsx
+++ b/apps/web/src/components/search/location-search-modal.tsx
@@ -27,6 +27,7 @@ import { ScrollFade } from "@/components/ui/scroll-fade";
 import { useDisabledByAncestor, pruneRedundantDescendants } from "./use-disabled-by-ancestor";
 import { DisabledFilterPill } from "./disabled-filter-pill";
 import { FacetCount } from "./facet-count";
+import { useSearchableDialogFocus } from "./use-searchable-dialog-focus";
 
 /** Show region sub-headers when a country has more cities than this. */
 const REGION_THRESHOLD = 8;
@@ -70,6 +71,7 @@ export function LocationSearchModal({
   const [search, setSearch] = useState("");
   const [warning, setWarning] = useState("");
   const warningTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const { searchInputRef, focusSearchInputOnOpen } = useSearchableDialogFocus();
   // Scroll container — observed by both ScrollFade (gradient overlay) and
   // the bottom IntersectionObserver that triggers loadMore.
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -474,6 +476,7 @@ export function LocationSearchModal({
         <Dialog.Content
           className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 flex-col rounded-xl border border-border-soft bg-surface shadow-xl data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
           aria-describedby={undefined}
+          onOpenAutoFocus={focusSearchInputOnOpen}
         >
           {/* Header */}
           <div className="flex items-center justify-between border-b border-divider px-5 py-4">
@@ -497,6 +500,7 @@ export function LocationSearchModal({
             <div className="flex items-center gap-2 rounded-md border border-border-soft px-3 py-2">
               <Search size={14} className="shrink-0 text-muted" />
               <input
+                ref={searchInputRef}
                 type="text"
                 value={search}
                 onChange={(e) => { setSearch(e.target.value); setWarning(""); }}

--- a/apps/web/src/components/search/occupation-modal.tsx
+++ b/apps/web/src/components/search/occupation-modal.tsx
@@ -11,6 +11,7 @@ import { ScrollFade } from "@/components/ui/scroll-fade";
 import { useDisabledByAncestor } from "./use-disabled-by-ancestor";
 import { DisabledFilterPill } from "./disabled-filter-pill";
 import { FacetCount } from "./facet-count";
+import { useSearchableDialogFocus } from "./use-searchable-dialog-focus";
 
 interface OccupationModalProps {
   open: boolean;
@@ -35,6 +36,7 @@ export function OccupationModal({
   const [search, setSearch] = useState("");
   const [warning, setWarning] = useState("");
   const warningTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const { searchInputRef, focusSearchInputOnOpen } = useSearchableDialogFocus();
 
   const selectedIds = useMemo(() => new Set(selected.map((s) => s.id)), [selected]);
 
@@ -292,6 +294,7 @@ export function OccupationModal({
         <Dialog.Content
           className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 flex-col rounded-xl border border-border-soft bg-surface shadow-xl data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
           aria-describedby={undefined}
+          onOpenAutoFocus={focusSearchInputOnOpen}
         >
           {/* Header */}
           <div className="flex items-center justify-between border-b border-divider px-5 py-4">
@@ -315,6 +318,7 @@ export function OccupationModal({
             <div className="flex items-center gap-2 rounded-md border border-border-soft px-3 py-2">
               <Search size={14} className="shrink-0 text-muted" />
               <input
+                ref={searchInputRef}
                 type="text"
                 value={search}
                 onChange={(e) => { setSearch(e.target.value); setWarning(""); }}

--- a/apps/web/src/components/search/technology-modal.tsx
+++ b/apps/web/src/components/search/technology-modal.tsx
@@ -9,6 +9,7 @@ import type { TechnologyGroup } from "@/lib/actions/taxonomy";
 import { findBestGuess } from "./best-guess";
 import { ScrollFade } from "@/components/ui/scroll-fade";
 import { FacetCount } from "./facet-count";
+import { useSearchableDialogFocus } from "./use-searchable-dialog-focus";
 
 interface TechnologyModalProps {
   open: boolean;
@@ -31,6 +32,7 @@ export function TechnologyModal({
   const [search, setSearch] = useState("");
   const [warning, setWarning] = useState("");
   const warningTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const { searchInputRef, focusSearchInputOnOpen } = useSearchableDialogFocus();
 
   const selectedIds = useMemo(() => new Set(selected.map((s) => s.id)), [selected]);
 
@@ -103,6 +105,7 @@ export function TechnologyModal({
         <Dialog.Content
           className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 flex-col rounded-xl border border-border-soft bg-surface shadow-xl data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
           aria-describedby={undefined}
+          onOpenAutoFocus={focusSearchInputOnOpen}
         >
           {/* Header */}
           <div className="flex items-center justify-between border-b border-divider px-5 py-4">
@@ -127,6 +130,7 @@ export function TechnologyModal({
             <div className="relative">
               <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted" />
               <input
+                ref={searchInputRef}
                 type="text"
                 value={search}
                 onChange={(e) => { setSearch(e.target.value); setWarning(""); }}

--- a/apps/web/src/components/search/use-searchable-dialog-focus.ts
+++ b/apps/web/src/components/search/use-searchable-dialog-focus.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+
+/** Focus the primary search input when a searchable Radix dialog opens. */
+export function useSearchableDialogFocus() {
+  const searchInputRef = useRef<HTMLInputElement>(null);
+
+  const focusSearchInputOnOpen = useCallback((event: Event) => {
+    const input = searchInputRef.current;
+    if (!input) return;
+    event.preventDefault();
+    input.focus();
+  }, []);
+
+  return { searchInputRef, focusSearchInputOnOpen };
+}


### PR DESCRIPTION
Fixes #5990

## Summary

- add one shared Radix open-autofocus hook for searchable filter dialogs
- focus the search input in global Location, per-company Location, Role, and Technology dialogs
- prevent Radix's default focus only when the input ref is mounted, preserving a safe fallback
- cover immediate keyboard typing, Escape dismissal, and trigger-focus restoration in a focused Radix harness

## Validation

- targeted dialog tests: 3 files / 25 tests
- ESLint on all changed source and test files
- `pnpm --filter @jobseek/web typecheck`
- `pnpm --filter @jobseek/web test` — 198 files / 1,458 tests
- `pnpm --filter @jobseek/web build`

The local build completed successfully. Its warnings were the expected missing local Redis/Auth/Typesense/database configuration warnings.
