### PR TITLE
Restore filter trigger focus after close

### DIFF
--- a/apps/web/src/components/search/__tests__/use-searchable-dialog-focus.test.tsx
+++ b/apps/web/src/components/search/__tests__/use-searchable-dialog-focus.test.tsx
@@ -7,26 +7,32 @@ import { useSearchableDialogFocus } from "../use-searchable-dialog-focus";
 
 function SearchableDialogHarness() {
   const [open, setOpen] = useState(false);
-  const { searchInputRef, focusSearchInputOnOpen } = useSearchableDialogFocus();
+  const {
+    searchInputRef,
+    focusSearchInputOnOpen,
+    restoreTriggerFocusOnClose,
+  } = useSearchableDialogFocus();
 
   return (
-    <Dialog.Root open={open} onOpenChange={setOpen}>
-      <Dialog.Trigger asChild>
-        <button type="button">Open filters</button>
-      </Dialog.Trigger>
-      <Dialog.Portal>
-        <Dialog.Content
-          aria-describedby={undefined}
-          onOpenAutoFocus={focusSearchInputOnOpen}
-        >
-          <Dialog.Title>Search filters</Dialog.Title>
-          <Dialog.Close asChild>
-            <button type="button">Close</button>
-          </Dialog.Close>
-          <input ref={searchInputRef} aria-label="Search options" />
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+    <>
+      {/* Production filter buttons control dialog state without Dialog.Trigger. */}
+      <button type="button" onClick={() => setOpen(true)}>Open filters</button>
+      <Dialog.Root open={open} onOpenChange={setOpen}>
+        <Dialog.Portal>
+          <Dialog.Content
+            aria-describedby={undefined}
+            onOpenAutoFocus={focusSearchInputOnOpen}
+            onCloseAutoFocus={restoreTriggerFocusOnClose}
+          >
+            <Dialog.Title>Search filters</Dialog.Title>
+            <Dialog.Close asChild>
+              <button type="button">Close</button>
+            </Dialog.Close>
+            <input ref={searchInputRef} aria-label="Search options" />
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </>
   );
 }
 

--- a/apps/web/src/components/search/location-modal.tsx
+++ b/apps/web/src/components/search/location-modal.tsx
@@ -46,7 +46,11 @@ export function LocationModal({
   const [search, setSearch] = useState("");
   const [warning, setWarning] = useState("");
   const warningTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-  const { searchInputRef, focusSearchInputOnOpen } = useSearchableDialogFocus();
+  const {
+    searchInputRef,
+    focusSearchInputOnOpen,
+    restoreTriggerFocusOnClose,
+  } = useSearchableDialogFocus();
 
   const activeLocationIds = useMemo(
     () => new Set(filters.filter((f) => f.kind === "location").map((f) => f.id)),
@@ -265,6 +269,7 @@ export function LocationModal({
           className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 flex-col rounded-xl border border-border-soft bg-surface shadow-xl data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
           aria-describedby={undefined}
           onOpenAutoFocus={focusSearchInputOnOpen}
+          onCloseAutoFocus={restoreTriggerFocusOnClose}
         >
           {/* Header */}
           <div className="flex items-center justify-between border-b border-divider px-5 py-4">

--- a/apps/web/src/components/search/location-search-modal.tsx
+++ b/apps/web/src/components/search/location-search-modal.tsx
@@ -71,7 +71,11 @@ export function LocationSearchModal({
   const [search, setSearch] = useState("");
   const [warning, setWarning] = useState("");
   const warningTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-  const { searchInputRef, focusSearchInputOnOpen } = useSearchableDialogFocus();
+  const {
+    searchInputRef,
+    focusSearchInputOnOpen,
+    restoreTriggerFocusOnClose,
+  } = useSearchableDialogFocus();
   // Scroll container — observed by both ScrollFade (gradient overlay) and
   // the bottom IntersectionObserver that triggers loadMore.
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -477,6 +481,7 @@ export function LocationSearchModal({
           className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 flex-col rounded-xl border border-border-soft bg-surface shadow-xl data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
           aria-describedby={undefined}
           onOpenAutoFocus={focusSearchInputOnOpen}
+          onCloseAutoFocus={restoreTriggerFocusOnClose}
         >
           {/* Header */}
           <div className="flex items-center justify-between border-b border-divider px-5 py-4">

--- a/apps/web/src/components/search/occupation-modal.tsx
+++ b/apps/web/src/components/search/occupation-modal.tsx
@@ -36,7 +36,11 @@ export function OccupationModal({
   const [search, setSearch] = useState("");
   const [warning, setWarning] = useState("");
   const warningTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-  const { searchInputRef, focusSearchInputOnOpen } = useSearchableDialogFocus();
+  const {
+    searchInputRef,
+    focusSearchInputOnOpen,
+    restoreTriggerFocusOnClose,
+  } = useSearchableDialogFocus();
 
   const selectedIds = useMemo(() => new Set(selected.map((s) => s.id)), [selected]);
 
@@ -295,6 +299,7 @@ export function OccupationModal({
           className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 flex-col rounded-xl border border-border-soft bg-surface shadow-xl data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
           aria-describedby={undefined}
           onOpenAutoFocus={focusSearchInputOnOpen}
+          onCloseAutoFocus={restoreTriggerFocusOnClose}
         >
           {/* Header */}
           <div className="flex items-center justify-between border-b border-divider px-5 py-4">

--- a/apps/web/src/components/search/technology-modal.tsx
+++ b/apps/web/src/components/search/technology-modal.tsx
@@ -32,7 +32,11 @@ export function TechnologyModal({
   const [search, setSearch] = useState("");
   const [warning, setWarning] = useState("");
   const warningTimer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-  const { searchInputRef, focusSearchInputOnOpen } = useSearchableDialogFocus();
+  const {
+    searchInputRef,
+    focusSearchInputOnOpen,
+    restoreTriggerFocusOnClose,
+  } = useSearchableDialogFocus();
 
   const selectedIds = useMemo(() => new Set(selected.map((s) => s.id)), [selected]);
 
@@ -106,6 +110,7 @@ export function TechnologyModal({
           className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 flex-col rounded-xl border border-border-soft bg-surface shadow-xl data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
           aria-describedby={undefined}
           onOpenAutoFocus={focusSearchInputOnOpen}
+          onCloseAutoFocus={restoreTriggerFocusOnClose}
         >
           {/* Header */}
           <div className="flex items-center justify-between border-b border-divider px-5 py-4">

--- a/apps/web/src/components/search/use-searchable-dialog-focus.ts
+++ b/apps/web/src/components/search/use-searchable-dialog-focus.ts
@@ -5,13 +5,35 @@ import { useCallback, useRef } from "react";
 /** Focus the primary search input when a searchable Radix dialog opens. */
 export function useSearchableDialogFocus() {
   const searchInputRef = useRef<HTMLInputElement>(null);
+  const restoreFocusElementRef = useRef<HTMLElement | null>(null);
 
   const focusSearchInputOnOpen = useCallback((event: Event) => {
+    if (typeof document !== "undefined") {
+      const activeElement = document.activeElement;
+      restoreFocusElementRef.current =
+        activeElement instanceof HTMLElement && activeElement !== document.body
+          ? activeElement
+          : null;
+    }
+
     const input = searchInputRef.current;
     if (!input) return;
     event.preventDefault();
     input.focus();
   }, []);
 
-  return { searchInputRef, focusSearchInputOnOpen };
+  const restoreTriggerFocusOnClose = useCallback((event: Event) => {
+    const restoreTarget = restoreFocusElementRef.current;
+    restoreFocusElementRef.current = null;
+    if (!restoreTarget?.isConnected) return;
+
+    event.preventDefault();
+    restoreTarget.focus();
+  }, []);
+
+  return {
+    searchInputRef,
+    focusSearchInputOnOpen,
+    restoreTriggerFocusOnClose,
+  };
 }


### PR DESCRIPTION
## Summary

- remember the external toolbar control that opened each searchable filter dialog
- restore focus to that control after the dialog closes
- cover the production controlled-dialog shape, where the opener is not a Radix `Dialog.Trigger`

PR #5991 fixed initial focus by moving it to the filter search input, but the production verification exposed that focus was lost after closing. The toolbar buttons control dialog state externally, so Radix does not have a trigger element to restore automatically. This follow-up preserves the opener during the dialog's open autofocus event and restores it during close autofocus, while leaving Radix's default behavior intact when no valid opener exists.

Fixes #5990

## Verification

- `pnpm --filter @jobseek/web test -- --run src/components/search/__tests__/use-searchable-dialog-focus.test.tsx src/components/search/__tests__/location-search-modal.test.tsx src/components/search/__tests__/location-modal.test.tsx`
- `pnpm --filter @jobseek/web exec eslint src/components/search/__tests__/use-searchable-dialog-focus.test.tsx src/components/search/location-modal.tsx src/components/search/location-search-modal.tsx src/components/search/occupation-modal.tsx src/components/search/technology-modal.tsx src/components/search/use-searchable-dialog-focus.ts`
- `pnpm --filter @jobseek/web typecheck`
- `pnpm --filter @jobseek/web test -- --run` (198 files, 1,458 tests)
- `pnpm --filter @jobseek/web build`

