### PR TITLE
Separate company posting row actions

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-posting-row.test.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-posting-row.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@/test-utils/lingui-mock";
+
+const saveClickMock = vi.fn();
+
+vi.mock("@/components/TrackingDot", () => ({
+  TrackingDot: () => <span data-testid="tracking-dot" />,
+}));
+
+vi.mock("@/components/PendingJobWarning", () => ({
+  PendingJobIcon: () => <span data-testid="pending-job-icon" />,
+}));
+
+vi.mock("@/components/search/save-button", () => ({
+  SaveButton: ({ postingId }: { postingId: string }) => (
+    <button
+      type="button"
+      aria-label={`Save job ${postingId}`}
+      onClick={() => saveClickMock(postingId)}
+    >
+      Save
+    </button>
+  ),
+}));
+
+vi.mock("@/lib/time", () => ({
+  timeAgoShort: () => "1d",
+}));
+
+import { CompanyPostingRow } from "../company-posting-row";
+import type { SearchResultPosting } from "@/lib/search";
+
+const posting = {
+  id: "posting-1",
+  title: "Senior Engineer",
+  firstSeenAt: "2026-07-22T00:00:00Z",
+  relevanceScore: 1,
+  locations: [{ name: "Zurich", type: "location", geoType: "city" }],
+  isActive: true,
+} as SearchResultPosting;
+
+describe("CompanyPostingRow keyboard actions (issue #3166)", () => {
+  beforeEach(() => {
+    saveClickMock.mockClear();
+  });
+
+  it("renders Open and Save as sibling buttons without nested interactive roles", () => {
+    const { container } = render(
+      <CompanyPostingRow
+        posting={posting}
+        selected={false}
+        uiLocale="en"
+        onOpen={vi.fn()}
+      />,
+    );
+
+    expect(container.querySelector('[role="button"]')).toBeNull();
+    for (const button of container.querySelectorAll("button")) {
+      expect(button.querySelector('button, [role="button"]')).toBeNull();
+    }
+    expect(screen.getByRole("button", { name: "Senior Engineer" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Save job posting-1" })).toBeTruthy();
+  });
+
+  it("Enter on Save does not open the posting", async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+    render(
+      <CompanyPostingRow
+        posting={posting}
+        selected={false}
+        uiLocale="en"
+        onOpen={onOpen}
+      />,
+    );
+
+    screen.getByRole("button", { name: "Save job posting-1" }).focus();
+    await user.keyboard("{Enter}");
+
+    expect(saveClickMock).toHaveBeenCalledOnce();
+    expect(saveClickMock).toHaveBeenCalledWith("posting-1");
+    expect(onOpen).not.toHaveBeenCalled();
+  });
+
+  it("Enter on Open still opens the posting without saving", async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+    render(
+      <CompanyPostingRow
+        posting={posting}
+        selected={false}
+        uiLocale="en"
+        onOpen={onOpen}
+      />,
+    );
+
+    screen.getByRole("button", { name: "Senior Engineer" }).focus();
+    await user.keyboard("{Enter}");
+
+    expect(onOpen).toHaveBeenCalledOnce();
+    expect(onOpen).toHaveBeenCalledWith("posting-1");
+    expect(saveClickMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
@@ -4,8 +4,6 @@ import { useState, useCallback, useTransition, useEffect, useMemo } from "react"
 import { Loader2 } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useParams, usePathname, useSearchParams } from "next/navigation";
-import { timeAgoShort } from "@/lib/time";
-import { SaveButton } from "@/components/search/save-button";
 import { SearchUnavailable } from "@/components/search/search-unavailable";
 import { getCompanyPostingListState } from "./company-posting-state";
 import { JobDetailPanel } from "@/components/search/job-detail-dialog";
@@ -17,8 +15,6 @@ import { useSession } from "@/components/providers/SessionProvider";
 import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
 import { InfiniteScrollSentinel } from "@/components/InfiniteScrollSentinel";
 import { TruncationPrompt } from "@/components/TruncationPrompt";
-import { TrackingDot } from "@/components/TrackingDot";
-import { PendingJobIcon } from "@/components/PendingJobWarning";
 import { useSalaryRates } from "@/components/providers/SalaryDisplayProvider";
 import type { CompanyDetail } from "@/lib/actions/company";
 import { buildFilteredPath } from "@/lib/search/query-params";
@@ -27,6 +23,7 @@ import type { SearchResultPosting, HistogramFilters, WorkMode } from "@/lib/sear
 import type { SelectedLocation } from "@/lib/search/types";
 import { useSearchStateStore } from "@/components/providers/SearchStateProvider";
 import { ActivePostingCount, YearPostingCount } from "@/components/search/posting-count-labels";
+import { CompanyPostingRow } from "./company-posting-row";
 
 const PAGE_SIZE = 20;
 
@@ -643,35 +640,13 @@ export function CompanyPage({
       ) : (
         <div>
           {postings.map((posting) => (
-            <div
+            <CompanyPostingRow
               key={posting.id}
-              role="button"
-              tabIndex={0}
-              onClick={() => handleOpenPosting(posting.id)}
-              onKeyDown={(e) => { if (e.key === "Enter") handleOpenPosting(posting.id); }}
-              className={`flex cursor-pointer items-center gap-2 rounded px-1 py-1.5 transition-colors ${posting.id === showPostingId ? "bg-primary/10" : "hover:bg-border-soft"} ${posting.isActive === false ? "opacity-50" : ""}`}
-            >
-              <TrackingDot postingId={posting.id} />
-              <span className="min-w-0 flex-1 truncate text-sm">{posting.title ?? "—"}</span>
-              {posting.isActive === false && (
-                <span className="shrink-0 rounded bg-border-soft px-1 py-0.5 text-[10px] text-muted">
-                  <Trans id="company.page.closed" comment="Label for inactive/closed job postings on company page">
-                    Closed
-                  </Trans>
-                </span>
-              )}
-              {posting.locations.length > 0 && (
-                <span className={`shrink-0 text-xs text-muted ${posting.locations[0].geoType && posting.locations[0].geoType !== "city" ? "italic" : ""}`}>
-                  {posting.locations[0].name}
-                  {posting.locations.length > 1 && ` +${posting.locations.length - 1}`}
-                </span>
-              )}
-              {!posting.title && <PendingJobIcon />}
-              <SaveButton postingId={posting.id} />
-              <span suppressHydrationWarning className="w-8 shrink-0 text-left text-[10px] tabular-nums text-muted">
-                {timeAgoShort(posting.firstSeenAt, uiLocale)}
-              </span>
-            </div>
+              posting={posting}
+              selected={posting.id === showPostingId}
+              uiLocale={uiLocale}
+              onOpen={handleOpenPosting}
+            />
           ))}
           {hasMore && <InfiniteScrollSentinel sentinelRef={sentinelRef} isLoading={isLoadingMore} />}
           {!hasMore && isTruncated && <TruncationPrompt type="postings" />}

--- a/apps/web/app/[lang]/(app)/company/[slug]/company-posting-row.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-posting-row.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Trans, useLingui } from "@lingui/react/macro";
+import { PendingJobIcon } from "@/components/PendingJobWarning";
+import { TrackingDot } from "@/components/TrackingDot";
+import { SaveButton } from "@/components/search/save-button";
+import type { SearchResultPosting } from "@/lib/search";
+import { timeAgoShort } from "@/lib/time";
+
+interface CompanyPostingRowProps {
+  posting: SearchResultPosting;
+  selected: boolean;
+  uiLocale: string;
+  onOpen: (postingId: string) => void;
+}
+
+export function CompanyPostingRow({
+  posting,
+  selected,
+  uiLocale,
+  onOpen,
+}: CompanyPostingRowProps) {
+  const { t } = useLingui();
+
+  return (
+    <div
+      data-posting-id={posting.id}
+      className={`relative flex items-center gap-2 rounded px-1 py-1.5 transition-colors ${selected ? "bg-primary/10" : "hover:bg-border-soft"} ${posting.isActive === false ? "opacity-50" : ""}`}
+    >
+      <button
+        type="button"
+        onClick={() => onOpen(posting.id)}
+        aria-label={
+          posting.title ??
+          t({
+            id: "search.card.openPosting",
+            comment: "Aria label for opening a job posting from a company card row when the posting title is missing",
+            message: "Open job posting",
+          })
+        }
+        className="absolute inset-0 z-0 cursor-pointer rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+      />
+      <TrackingDot postingId={posting.id} />
+      <span className="min-w-0 flex-1 truncate text-sm">{posting.title ?? "—"}</span>
+      {posting.isActive === false && (
+        <span className="shrink-0 rounded bg-border-soft px-1 py-0.5 text-[10px] text-muted">
+          <Trans id="company.page.closed" comment="Label for inactive/closed job postings on company page">
+            Closed
+          </Trans>
+        </span>
+      )}
+      {posting.locations.length > 0 && (
+        <span className={`shrink-0 text-xs text-muted ${posting.locations[0].geoType && posting.locations[0].geoType !== "city" ? "italic" : ""}`}>
+          {posting.locations[0].name}
+          {posting.locations.length > 1 && ` +${posting.locations.length - 1}`}
+        </span>
+      )}
+      {!posting.title && (
+        <span className="relative z-10 inline-flex shrink-0">
+          <PendingJobIcon />
+        </span>
+      )}
+      <span className="relative z-10 shrink-0">
+        <SaveButton postingId={posting.id} />
+      </span>
+      <span suppressHydrationWarning className="w-8 shrink-0 text-left text-[10px] tabular-nums text-muted">
+        {timeAgoShort(posting.firstSeenAt, uiLocale)}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- replace the company-page posting row's nested interactive structure with a non-interactive row container
- expose the row-opening action and Save action as sibling buttons
- preserve the full-row pointer target, selected/closed styling, tracking state, location, pending indicator, and relative time
- add keyboard regression coverage proving Enter on Save cannot open the posting and Enter on Open cannot save it

The production company page wrapped its real Save button in a focusable `div[role=button]`. Enter on Save bubbled into the outer keyboard handler, opened the posting detail, and did not complete the intended save action. The row now has an absolute open-posting button beneath its content and an independently stacked Save button, with no nested interactive roles.

Fixes #3166

## Verification

- focused company-page tests (3 files, 14 tests)
- changed-file ESLint
- `pnpm --filter @jobseek/web typecheck`
- `pnpm --filter @jobseek/web test -- --run` (199 files, 1,461 tests)
- `pnpm --filter @jobseek/web build`
- pre-commit i18n coverage gate

