### PR TITLE
Handle root asset fallback requests

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -159,6 +159,11 @@ const nextConfig: NextConfig = {
     return key ? [{ source: `/${key}.txt`, destination: "/indexnow-key.txt" }] : [];
   },
   redirects: async () => [
+    {
+      source: "/apple-touch-icon-:variant.png",
+      destination: "/apple-touch-icon.png",
+      permanent: true,
+    },
     { source: "/:lang(en|de|fr|it)/app", destination: "/:lang/explore", permanent: true },
     { source: "/:lang(en|de|fr|it)/app/saved", destination: "/:lang/my-jobs", permanent: true },
     { source: "/:lang(en|de|fr|it)/saved", destination: "/:lang/my-jobs", permanent: true },

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -22,6 +22,17 @@ function getLocale(request: NextRequest): string {
 }
 
 export function proxy(request: NextRequest) {
+  // The public IndexNow proof filename is derived from a secret at runtime and
+  // therefore cannot be listed in the static matcher below. Let that one
+  // configured dotted root path continue to the rewrite in next.config.ts.
+  const indexNowKey = process.env.INDEXNOW_KEY;
+  if (
+    indexNowKey &&
+    request.nextUrl.pathname === `/${indexNowKey}.txt`
+  ) {
+    return NextResponse.next();
+  }
+
   const cookieLocale = request.cookies.get(COOKIE_NAME)?.value;
   const locale = getLocale(request);
   const url = request.nextUrl.clone();
@@ -46,14 +57,19 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  // Only match paths that do NOT start with a locale prefix, static assets,
-  // API routes, or Next.js internals.  Locale-prefixed paths (e.g. /en/…)
-  // skip the proxy entirely — no edge invocation needed.
+  // Only match paths that do NOT start with a locale prefix, a known static
+  // asset/discovery route, an API route, or Next.js internals. Unknown dotted
+  // root paths must still pass through the proxy: otherwise `[lang]` treats
+  // the filename as an invalid locale and the dynamic root layout turns its
+  // intended 404 into a 500. Redirecting to `/<locale>/<path>` reaches the
+  // localized 404 surface correctly.
   //
   // `opengraph-image*` is excluded so `og:image` URLs that the Metadata
   // API generates against the root `app/opengraph-image.tsx` reach the
   // handler directly. Without this, Twitter / LinkedIn / Slack OG fetches
   // for non-(public) pages 308-redirect to `/<locale>/opengraph-image-<hash>`
   // and 404. See #2835 critic round 1.
-  matcher: ["/((?!_next|api|mcp|flags|fonts|publicdomain|favicon\\.ico|opengraph-image|en|de|fr|it|.*\\..*).*)" ],
+  matcher: [
+    "/((?!_next|api|mcp|flags|fonts|publicdomain|\\.well-known|favicon\\.ico$|favicon-16x16\\.png$|favicon-32x32\\.png$|apple-touch-icon\\.png$|apple-touch-icon-[^/]+\\.png$|android-chrome-192x192\\.png$|android-chrome-512x512\\.png$|site\\.webmanifest$|BingSiteAuth\\.xml$|js_[^/]+\\.svg$|js_missing_screenshot_black\\.png$|js_missing_screenshot_white\\.png$|logo-dark\\.svg$|logo-light\\.svg$|opengraph-image|indexnow-key\\.txt$|llms\\.txt$|openapi\\.json$|openapi\\.yaml$|robots\\.txt$|sitemap\\.xml$|en|de|fr|it).*)",
+  ],
 };

--- a/apps/web/src/lib/__tests__/next-config-redirects.test.ts
+++ b/apps/web/src/lib/__tests__/next-config-redirects.test.ts
@@ -1,0 +1,32 @@
+import type { NextConfig } from "next";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import nextConfig from "../../../next.config";
+
+describe("root asset redirects", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("canonicalizes browser-generated Apple icon variants", async () => {
+    expect(typeof nextConfig).toBe("object");
+
+    const redirects = await (nextConfig as NextConfig).redirects?.();
+
+    expect(redirects).toContainEqual({
+      source: "/apple-touch-icon-:variant.png",
+      destination: "/apple-touch-icon.png",
+      permanent: true,
+    });
+  });
+
+  it("retains the runtime-configured IndexNow proof rewrite", async () => {
+    vi.stubEnv("INDEXNOW_KEY", "indexnow-verification-token");
+
+    const rewrites = await (nextConfig as NextConfig).rewrites?.();
+
+    expect(rewrites).toContainEqual({
+      source: "/indexnow-verification-token.txt",
+      destination: "/indexnow-key.txt",
+    });
+  });
+});

--- a/apps/web/src/lib/__tests__/proxy.test.ts
+++ b/apps/web/src/lib/__tests__/proxy.test.ts
@@ -1,4 +1,13 @@
-import { describe, it, expect, vi, beforeEach, afterAll } from "vitest";
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeEach,
+  afterEach,
+  afterAll,
+} from "vitest";
+import { unstable_doesMiddlewareMatch } from "next/experimental/testing/server";
 import { NextRequest, NextResponse } from "next/server";
 import { proxy, config } from "../../../proxy";
 
@@ -27,6 +36,10 @@ function redirectedPathname(): string {
 describe("proxy", () => {
   beforeEach(() => {
     redirectSpy.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   afterAll(() => {
@@ -62,6 +75,22 @@ describe("proxy", () => {
   it("handles root path", () => {
     proxy(createRequest("/"));
     expect(redirectedPathname()).toBe("/en");
+  });
+
+  it("preserves an unknown dotted path when adding the locale", () => {
+    proxy(createRequest("/does-not-exist.png"));
+    expect(redirectedPathname()).toBe("/en/does-not-exist.png");
+  });
+
+  it("passes the configured IndexNow proof path through to its rewrite", () => {
+    vi.stubEnv("INDEXNOW_KEY", "indexnow-verification-token");
+
+    const response = proxy(
+      createRequest("/indexnow-verification-token.txt"),
+    );
+
+    expect(redirectSpy).not.toHaveBeenCalled();
+    expect(response.headers.get("x-middleware-next")).toBe("1");
   });
 
   it("uses the cookie locale when present", () => {
@@ -108,5 +137,39 @@ describe("proxy config", () => {
   it("has a matcher pattern", () => {
     expect(config.matcher).toBeDefined();
     expect(config.matcher.length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    "/does-not-exist.png",
+    "/robots-nope.txt",
+    "/random.html",
+    "/favicon-missing.png",
+    "/apple-touch-icon-missing.jpg",
+    "/logo-missing.svg",
+    "/indexnow-verification-token.txt",
+  ])("matches unknown dotted root path %s", (url) => {
+    expect(
+      unstable_doesMiddlewareMatch({ config, nextConfig: {}, url }),
+    ).toBe(true);
+  });
+
+  it.each([
+    "/apple-touch-icon.png",
+    "/apple-touch-icon-120x120.png",
+    "/favicon-32x32.png",
+    "/android-chrome-192x192.png",
+    "/site.webmanifest",
+    "/BingSiteAuth.xml",
+    "/.well-known/ai-plugin.json",
+    "/openapi.json",
+    "/llms.txt",
+    "/robots.txt",
+    "/sitemap.xml",
+    "/flags/ch.svg",
+    "/fonts/JetBrainsMono-Regular.woff2",
+  ])("bypasses known static or discovery route %s", (url) => {
+    expect(
+      unstable_doesMiddlewareMatch({ config, nextConfig: {}, url }),
+    ).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- route unknown dotted root paths through the locale proxy so they reach the working localized 404 instead of being interpreted as an invalid `[lang]`
- redirect common Apple touch-icon probes to the canonical icon
- preserve all known public/discovery assets and the runtime-configured IndexNow proof path
- add matcher, redirect, and IndexNow regression coverage

## Root cause

The proxy matcher excluded every path containing a dot. A missing root asset therefore skipped locale routing and matched the dynamic `[lang]` segment as an invalid locale. Its `notFound()` could not be composed through the app's dynamic-only root layout and surfaced as a server-component 500.

## Verification

- `pnpm test` — 200 files / 1,485 tests passed
- `pnpm lint`
- `pnpm typecheck`
- `INDEXNOW_KEY=indexnow-verification-token pnpm build`
- production-mode HTTP matrix:
  - Apple icon aliases: `308` to canonical icon, then `200 image/png`
  - arbitrary missing dotted roots and asset lookalikes: locale redirect, then `404 text/html`
  - canonical icons, robots, `.well-known`, and IndexNow proof path: `200`
  - no server errors emitted during the final matrix

Fixes #5996
