### PR TITLE
Restore watchlist delete focus

### DIFF
--- a/apps/web/src/components/watchlist/__tests__/watchlist-action-bar-focus.test.tsx
+++ b/apps/web/src/components/watchlist/__tests__/watchlist-action-bar-focus.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import "@/test-utils/lingui-mock";
+
+const mocks = vi.hoisted(() => ({
+  deleteWatchlist: vi.fn(),
+  push: vi.fn(),
+  refresh: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.push, refresh: mocks.refresh }),
+}));
+
+vi.mock("@/lib/useLocalePath", () => ({
+  useLocalePath: () => (path: string) => `/en${path}`,
+}));
+
+vi.mock("@/components/providers/SessionProvider", () => ({
+  useSession: () => ({
+    user: { username: "test-user" },
+    isLoggedIn: true,
+  }),
+}));
+
+vi.mock("@/lib/actions/watchlists", () => ({
+  copyWatchlist: vi.fn(),
+  deleteWatchlist: mocks.deleteWatchlist,
+  toggleWatchlistAlerts: vi.fn(),
+  updateWatchlist: vi.fn(),
+}));
+
+vi.mock("@/components/ui/upgrade-modal", () => ({
+  UpgradeModal: () => null,
+  useUpgradeModal: () => ({
+    open: false,
+    setOpen: vi.fn(),
+    reason: "",
+    show: vi.fn(),
+  }),
+}));
+
+import { WatchlistActionBar } from "../watchlist-action-bar";
+
+function renderActionBar() {
+  return render(
+    <WatchlistActionBar
+      watchlistId="watchlist-1"
+      isOwner
+      isPublic={false}
+      alertsEnabled={false}
+      isPaidPlan
+      limitReached={false}
+    />,
+  );
+}
+
+async function openDeleteDialog(user: ReturnType<typeof userEvent.setup>) {
+  const trigger = screen.getByRole("button", { name: "Delete" });
+  await user.click(trigger);
+  const dialog = await screen.findByRole("alertdialog", {
+    name: "Delete watchlist?",
+  });
+  return { dialog, trigger };
+}
+
+describe("WatchlistActionBar delete focus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.deleteWatchlist.mockResolvedValue({ ok: true });
+  });
+
+  it("restores focus to Delete after Cancel", async () => {
+    const user = userEvent.setup();
+    renderActionBar();
+
+    const { dialog, trigger } = await openDeleteDialog(user);
+    const cancel = within(dialog).getByRole("button", { name: "Cancel" });
+    await waitFor(() => expect(document.activeElement).toBe(cancel));
+
+    await user.click(cancel);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alertdialog")).toBeNull();
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+
+  it("restores focus to Delete after Escape", async () => {
+    const user = userEvent.setup();
+    renderActionBar();
+
+    const { trigger } = await openDeleteDialog(user);
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alertdialog")).toBeNull();
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+
+  it("still deletes and navigates back to Watchlists", async () => {
+    const user = userEvent.setup();
+    renderActionBar();
+
+    const { dialog } = await openDeleteDialog(user);
+    await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(mocks.deleteWatchlist).toHaveBeenCalledWith("watchlist-1");
+      expect(mocks.push).toHaveBeenCalledWith("/en/watchlists");
+    });
+  });
+});

--- a/apps/web/src/components/watchlist/watchlist-action-bar.tsx
+++ b/apps/web/src/components/watchlist/watchlist-action-bar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Bell, BellOff, Trash2, Pencil, Copy, Loader2, Globe, Lock, AlertTriangle } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
@@ -25,18 +25,21 @@ function ActionButton({
   onClick,
   disabled,
   warning,
+  buttonRef,
   children,
 }: {
   label: string;
   onClick: () => void;
   disabled?: boolean;
   warning?: boolean;
+  buttonRef?: React.Ref<HTMLButtonElement>;
   children: React.ReactNode;
 }) {
   return (
     <Tooltip.Root>
       <Tooltip.Trigger asChild>
         <button
+          ref={buttonRef}
           type="button"
           onClick={onClick}
           className={`${iconBtnClass} ${disabled ? "opacity-40" : ""}`}
@@ -82,6 +85,7 @@ export function WatchlistActionBar({
   const [busy, setBusy] = useState(false);
   const [isPublic, setIsPublic] = useState(initialIsPublic);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const deleteButtonRef = useRef<HTMLButtonElement>(null);
   const upgrade = useUpgradeModal();
 
   async function handleCopy() {
@@ -194,19 +198,22 @@ export function WatchlistActionBar({
                 <Copy size={16} aria-hidden="true" />
               </ActionButton>
               <AlertDialog.Root open={deleteOpen} onOpenChange={setDeleteOpen}>
-                <AlertDialog.Trigger asChild>
-                  <span>
-                    <ActionButton
-                      label={t({ id: "watchlists.actions.delete", comment: "Delete watchlist tooltip", message: "Delete" })}
-                      onClick={() => setDeleteOpen(true)}
-                    >
-                      <Trash2 size={16} aria-hidden="true" />
-                    </ActionButton>
-                  </span>
-                </AlertDialog.Trigger>
+                <ActionButton
+                  label={t({ id: "watchlists.actions.delete", comment: "Delete watchlist tooltip", message: "Delete" })}
+                  onClick={() => setDeleteOpen(true)}
+                  buttonRef={deleteButtonRef}
+                >
+                  <Trash2 size={16} aria-hidden="true" />
+                </ActionButton>
                 <AlertDialog.Portal>
                   <AlertDialog.Overlay className="fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=open]:fade-in-0" />
-                  <AlertDialog.Content className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border-soft bg-surface p-6 shadow-xl data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95">
+                  <AlertDialog.Content
+                    className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border-soft bg-surface p-6 shadow-xl data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+                    onCloseAutoFocus={(event) => {
+                      event.preventDefault();
+                      deleteButtonRef.current?.focus();
+                    }}
+                  >
                     <AlertDialog.Title className="text-base font-semibold">
                       <Trans id="watchlists.delete.title" comment="Delete watchlist confirmation title">
                         Delete watchlist?


### PR DESCRIPTION
## Summary

- replace the non-focusable AlertDialog trigger wrapper with a ref to the real Delete button
- use Radix's close-autofocus hook to restore that trigger after Cancel or Escape
- retain confirmed deletion and Watchlists navigation
- add interaction coverage for both focus-restoration paths and successful deletion

## Verification

- targeted action-bar tests: 3 passed
- `pnpm test` — 201 files / 1,488 tests passed
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- production reproduction and before/after screenshots are embedded in #5999
- temporary production watchlists and their mirrored copy were deleted; the Discover cache no longer contains them

Fixes #5999
