### PR TITLE
Keep saved-search navigation visibly loading

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
@@ -23,6 +23,7 @@ import {
   fetchWatchlistPageData,
 } from "@/lib/actions/watchlist-page-data";
 import { WatchlistContent } from "./watchlist-content";
+import { WatchlistRuntimeFallback } from "./watchlist-runtime-fallback";
 
 // Metadata is cached for an hour; the page body uses the short tier so
 // its posting list stays reasonably fresh. Each is its own `'use cache'`
@@ -233,7 +234,7 @@ export default async function WatchlistRoute({ params }: Props) {
 
   if (!snapshot) {
     return (
-      <Suspense fallback={null}>
+      <Suspense fallback={<WatchlistRuntimeFallback />}>
         <WatchlistRuntimeContent
           locale={locale}
           userSlug={userSlug}

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-runtime-fallback.test.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-runtime-fallback.test.tsx
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import "@/test-utils/lingui-mock";
+import { WatchlistRuntimeFallback } from "./watchlist-runtime-fallback";
+
+describe("WatchlistRuntimeFallback", () => {
+  it("exposes a visible, polite busy status while viewer data resolves", () => {
+    render(<WatchlistRuntimeFallback />);
+
+    const status = screen.getByRole("status");
+    expect(status.getAttribute("aria-busy")).toBe("true");
+    expect(status.getAttribute("aria-live")).toBe("polite");
+    expect(status.textContent).toContain("Loading…");
+  });
+
+  it("guards the session-aware route boundary from an empty fallback", () => {
+    const source = readFileSync(join(__dirname, "page.tsx"), "utf8");
+
+    expect(source).toContain(
+      "<Suspense fallback={<WatchlistRuntimeFallback />}>",
+    );
+    expect(source).not.toContain("<Suspense fallback={null}>");
+  });
+});

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-runtime-fallback.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-runtime-fallback.tsx
@@ -1,0 +1,18 @@
+import { Loader2 } from "lucide-react";
+import { Trans } from "@lingui/react/macro";
+
+export function WatchlistRuntimeFallback() {
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      className="flex min-h-64 flex-col items-center justify-center gap-3 text-sm text-muted"
+    >
+      <Loader2 className="size-5 animate-spin" aria-hidden="true" />
+      <Trans id="myJobs.stats.loading" comment="Loading indicator">
+        Loading…
+      </Trans>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #6003

## Summary
- replace the private/missing watchlist runtime `Suspense` null fallback with a neutral localized loading status
- keep the session-aware privacy boundary and avoid reintroducing the misleading results skeleton fixed in #5980
- expose polite `role=status` / `aria-busy` semantics while viewer data resolves
- add a component and route-boundary regression test

## Validation
- pnpm exec vitest run app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-runtime-fallback.test.tsx --reporter=dot
- pnpm test (202 files, 1,490 tests before rebasing the unrelated #6002 merge)
- pnpm lint
- pnpm typecheck
- pnpm build