### PR TITLE
Make watchlist loading fallback RSC safe

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
@@ -234,7 +234,7 @@ export default async function WatchlistRoute({ params }: Props) {
 
   if (!snapshot) {
     return (
-      <Suspense fallback={<WatchlistRuntimeFallback />}>
+      <Suspense fallback={<WatchlistRuntimeFallback locale={locale} />}>
         <WatchlistRuntimeContent
           locale={locale}
           userSlug={userSlug}

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-runtime-fallback.test.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-runtime-fallback.test.tsx
@@ -8,7 +8,7 @@ import { WatchlistRuntimeFallback } from "./watchlist-runtime-fallback";
 
 describe("WatchlistRuntimeFallback", () => {
   it("exposes a visible, polite busy status while viewer data resolves", () => {
-    render(<WatchlistRuntimeFallback />);
+    render(<WatchlistRuntimeFallback locale="en" />);
 
     const status = screen.getByRole("status");
     expect(status.getAttribute("aria-busy")).toBe("true");
@@ -16,11 +16,29 @@ describe("WatchlistRuntimeFallback", () => {
     expect(status.textContent).toContain("Loading…");
   });
 
+  it("renders locale-safe copy without an RSC i18n context", () => {
+    const { rerender } = render(<WatchlistRuntimeFallback locale="de" />);
+    expect(screen.getByRole("status").textContent).toContain("Laden…");
+
+    rerender(<WatchlistRuntimeFallback locale="fr" />);
+    expect(screen.getByRole("status").textContent).toContain("Chargement…");
+
+    rerender(<WatchlistRuntimeFallback locale="it" />);
+    expect(screen.getByRole("status").textContent).toContain("Caricamento…");
+
+    const source = readFileSync(
+      join(__dirname, "watchlist-runtime-fallback.tsx"),
+      "utf8",
+    );
+    expect(source).not.toContain("@lingui");
+    expect(source).not.toContain("<Trans");
+  });
+
   it("guards the session-aware route boundary from an empty fallback", () => {
     const source = readFileSync(join(__dirname, "page.tsx"), "utf8");
 
     expect(source).toContain(
-      "<Suspense fallback={<WatchlistRuntimeFallback />}>",
+      "<Suspense fallback={<WatchlistRuntimeFallback locale={locale} />}>",
     );
     expect(source).not.toContain("<Suspense fallback={null}>");
   });

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-runtime-fallback.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-runtime-fallback.tsx
@@ -1,7 +1,14 @@
 import { Loader2 } from "lucide-react";
-import { Trans } from "@lingui/react/macro";
+import type { Locale } from "@/lib/i18n";
 
-export function WatchlistRuntimeFallback() {
+const loadingLabels: Record<Locale, string> = {
+  en: "Loading…",
+  de: "Laden…",
+  fr: "Chargement…",
+  it: "Caricamento…",
+};
+
+export function WatchlistRuntimeFallback({ locale }: { locale: Locale }) {
   return (
     <div
       role="status"
@@ -10,9 +17,7 @@ export function WatchlistRuntimeFallback() {
       className="flex min-h-64 flex-col items-center justify-center gap-3 text-sm text-muted"
     >
       <Loader2 className="size-5 animate-spin" aria-hidden="true" />
-      <Trans id="myJobs.stats.loading" comment="Loading indicator">
-        Loading…
-      </Trans>
+      {loadingLabels[locale]}
     </div>
   );
 }


### PR DESCRIPTION
Closes #6003

## Regression addressed
Production verification of #6005 exposed Error ID `3674871692`: the Suspense fallback rendered Lingui `Trans` without an initialized RSC i18n instance. Production was immediately rolled back to the preceding Ready deployment and the temporary watchlist was deleted.

## Summary
- pass the already-resolved route locale into the neutral fallback
- render a small explicit EN/DE/FR/IT label map without Lingui runtime context
- preserve `role=status`, `aria-busy`, and `aria-live` semantics
- add regression assertions that the fallback does not import or render Lingui `Trans`

## Validation
- targeted fallback suite: 3 tests
- pnpm test: 203 files, 1,495 tests
- pnpm lint
- pnpm typecheck
- pnpm build