### PR TITLE
Redact Hetzner hosts in workflow logs

### DIFF
--- a/.github/workflows/deploy-data-backups.yml
+++ b/.github/workflows/deploy-data-backups.yml
@@ -47,15 +47,15 @@ jobs:
 
       - name: Require configured production host
         env:
-          # Environment-scoped variables are unavailable while GitHub expands
+          # Environment-scoped secrets are unavailable while GitHub expands
           # the job matrix, so resolve the host only after production is attached.
-          TARGET_HOST: ${{ matrix.service == 'postgresql' && vars.HETZNER_POSTGRES_HOST || vars.HETZNER_TYPESENSE_HOST }}
+          TARGET_HOST: ${{ matrix.service == 'postgresql' && secrets.HETZNER_POSTGRES_HOST || secrets.HETZNER_TYPESENSE_HOST }}
         run: test -n "$TARGET_HOST"
 
       - name: Copy backup deployment artifacts
         uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
         with:
-          host: ${{ matrix.service == 'postgresql' && vars.HETZNER_POSTGRES_HOST || vars.HETZNER_TYPESENSE_HOST }}
+          host: ${{ matrix.service == 'postgresql' && secrets.HETZNER_POSTGRES_HOST || secrets.HETZNER_TYPESENSE_HOST }}
           username: root
           key: ${{ secrets.HETZNER_SSH_KEY }}
           source: scripts/jobseek-data-backup.py,deploy/backups,deploy/systemd/jobseek-postgresql-backup.service,deploy/systemd/jobseek-postgresql-backup.timer,deploy/systemd/jobseek-postgresql-backup-repository.service,deploy/systemd/jobseek-typesense-backup.service,deploy/systemd/jobseek-typesense-backup.timer,docs/19-data-backup-recovery.md,docs/16-hetzner-maintenance.md
@@ -68,7 +68,7 @@ jobs:
           JOBSEEK_BACKUP_DEPLOY_SHA: ${{ github.sha }}
           JOBSEEK_BACKUP_SERVICE: ${{ matrix.service }}
         with:
-          host: ${{ matrix.service == 'postgresql' && vars.HETZNER_POSTGRES_HOST || vars.HETZNER_TYPESENSE_HOST }}
+          host: ${{ matrix.service == 'postgresql' && secrets.HETZNER_POSTGRES_HOST || secrets.HETZNER_TYPESENSE_HOST }}
           username: root
           key: ${{ secrets.HETZNER_SSH_KEY }}
           envs: JOBSEEK_BACKUP_DEPLOY_SHA,JOBSEEK_BACKUP_SERVICE

--- a/.github/workflows/deploy-hetzner-ingress.yml
+++ b/.github/workflows/deploy-hetzner-ingress.yml
@@ -44,8 +44,8 @@ jobs:
     env:
       HETZNER_API_TOKEN: ${{ secrets.HETZNER_API_TOKEN }}
       HETZNER_CRAWLER_HOST: ${{ secrets.HETZNER_HOST }}
-      HETZNER_POSTGRES_HOST: ${{ vars.HETZNER_POSTGRES_HOST }}
-      HETZNER_TYPESENSE_HOST: ${{ vars.HETZNER_TYPESENSE_HOST }}
+      HETZNER_POSTGRES_HOST: ${{ secrets.HETZNER_POSTGRES_HOST }}
+      HETZNER_TYPESENSE_HOST: ${{ secrets.HETZNER_TYPESENSE_HOST }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Audit firewall and derive private inventory
@@ -69,9 +69,9 @@ jobs:
     env:
       HETZNER_API_TOKEN: ${{ secrets.HETZNER_API_TOKEN }}
       HETZNER_CRAWLER_HOST: ${{ secrets.HETZNER_HOST }}
-      HETZNER_POSTGRES_HOST: ${{ vars.HETZNER_POSTGRES_HOST }}
-      HETZNER_TYPESENSE_HOST: ${{ vars.HETZNER_TYPESENSE_HOST }}
-      TARGET_HOST: ${{ matrix.service == 'crawler' && secrets.HETZNER_HOST || matrix.service == 'postgresql' && vars.HETZNER_POSTGRES_HOST || vars.HETZNER_TYPESENSE_HOST }}
+      HETZNER_POSTGRES_HOST: ${{ secrets.HETZNER_POSTGRES_HOST }}
+      HETZNER_TYPESENSE_HOST: ${{ secrets.HETZNER_TYPESENSE_HOST }}
+      TARGET_HOST: ${{ matrix.service == 'crawler' && secrets.HETZNER_HOST || matrix.service == 'postgresql' && secrets.HETZNER_POSTGRES_HOST || secrets.HETZNER_TYPESENSE_HOST }}
       JOBSEEK_HOST_ROLE: ${{ matrix.service }}
       JOBSEEK_INGRESS_DEPLOY_SHA: ${{ github.sha }}
     steps:
@@ -81,7 +81,7 @@ jobs:
           set -euo pipefail
           python3 scripts/manage-hetzner-ingress.py audit \
             --state "${RUNNER_TEMP}/unused-firewall-state.json" \
-            --github-env "$GITHUB_ENV" >/dev/null
+            --github-env "$GITHUB_ENV"
       - name: Copy reviewed ingress tooling
         if: ${{ inputs.action == 'apply' }}
         uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
@@ -164,8 +164,8 @@ jobs:
     env:
       HETZNER_API_TOKEN: ${{ secrets.HETZNER_API_TOKEN }}
       HETZNER_CRAWLER_HOST: ${{ secrets.HETZNER_HOST }}
-      HETZNER_POSTGRES_HOST: ${{ vars.HETZNER_POSTGRES_HOST }}
-      HETZNER_TYPESENSE_HOST: ${{ vars.HETZNER_TYPESENSE_HOST }}
+      HETZNER_POSTGRES_HOST: ${{ secrets.HETZNER_POSTGRES_HOST }}
+      HETZNER_TYPESENSE_HOST: ${{ secrets.HETZNER_TYPESENSE_HOST }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Require exact provider policy and external port state
@@ -184,8 +184,8 @@ jobs:
     env:
       HETZNER_API_TOKEN: ${{ secrets.HETZNER_API_TOKEN }}
       HETZNER_CRAWLER_HOST: ${{ secrets.HETZNER_HOST }}
-      HETZNER_POSTGRES_HOST: ${{ vars.HETZNER_POSTGRES_HOST }}
-      HETZNER_TYPESENSE_HOST: ${{ vars.HETZNER_TYPESENSE_HOST }}
+      HETZNER_POSTGRES_HOST: ${{ secrets.HETZNER_POSTGRES_HOST }}
+      HETZNER_TYPESENSE_HOST: ${{ secrets.HETZNER_TYPESENSE_HOST }}
       JOBSEEK_INGRESS_DEPLOY_SHA: ${{ github.sha }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -194,7 +194,7 @@ jobs:
           set -euo pipefail
           python3 scripts/manage-hetzner-ingress.py audit \
             --state "${RUNNER_TEMP}/unused-firewall-state.json" \
-            --github-env "$GITHUB_ENV" >/dev/null
+            --github-env "$GITHUB_ENV"
       - name: Verify real crawler private paths over a fresh SSH session
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
         env:
@@ -224,9 +224,9 @@ jobs:
     env:
       HETZNER_API_TOKEN: ${{ secrets.HETZNER_API_TOKEN }}
       HETZNER_CRAWLER_HOST: ${{ secrets.HETZNER_HOST }}
-      HETZNER_POSTGRES_HOST: ${{ vars.HETZNER_POSTGRES_HOST }}
-      HETZNER_TYPESENSE_HOST: ${{ vars.HETZNER_TYPESENSE_HOST }}
-      TARGET_HOST: ${{ matrix.service == 'crawler' && secrets.HETZNER_HOST || matrix.service == 'postgresql' && vars.HETZNER_POSTGRES_HOST || vars.HETZNER_TYPESENSE_HOST }}
+      HETZNER_POSTGRES_HOST: ${{ secrets.HETZNER_POSTGRES_HOST }}
+      HETZNER_TYPESENSE_HOST: ${{ secrets.HETZNER_TYPESENSE_HOST }}
+      TARGET_HOST: ${{ matrix.service == 'crawler' && secrets.HETZNER_HOST || matrix.service == 'postgresql' && secrets.HETZNER_POSTGRES_HOST || secrets.HETZNER_TYPESENSE_HOST }}
       JOBSEEK_HOST_ROLE: ${{ matrix.service }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -235,7 +235,7 @@ jobs:
           set -euo pipefail
           python3 scripts/manage-hetzner-ingress.py audit \
             --state "${RUNNER_TEMP}/unused-firewall-state.json" \
-            --github-env "$GITHUB_ENV" >/dev/null
+            --github-env "$GITHUB_ENV"
       - name: Immediately roll back every staged host
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
         env:
@@ -270,9 +270,9 @@ jobs:
     env:
       HETZNER_API_TOKEN: ${{ secrets.HETZNER_API_TOKEN }}
       HETZNER_CRAWLER_HOST: ${{ secrets.HETZNER_HOST }}
-      HETZNER_POSTGRES_HOST: ${{ vars.HETZNER_POSTGRES_HOST }}
-      HETZNER_TYPESENSE_HOST: ${{ vars.HETZNER_TYPESENSE_HOST }}
-      TARGET_HOST: ${{ matrix.service == 'crawler' && secrets.HETZNER_HOST || matrix.service == 'postgresql' && vars.HETZNER_POSTGRES_HOST || vars.HETZNER_TYPESENSE_HOST }}
+      HETZNER_POSTGRES_HOST: ${{ secrets.HETZNER_POSTGRES_HOST }}
+      HETZNER_TYPESENSE_HOST: ${{ secrets.HETZNER_TYPESENSE_HOST }}
+      TARGET_HOST: ${{ matrix.service == 'crawler' && secrets.HETZNER_HOST || matrix.service == 'postgresql' && secrets.HETZNER_POSTGRES_HOST || secrets.HETZNER_TYPESENSE_HOST }}
       JOBSEEK_HOST_ROLE: ${{ matrix.service }}
       JOBSEEK_INGRESS_DEPLOY_SHA: ${{ github.sha }}
     steps:
@@ -282,7 +282,7 @@ jobs:
           set -euo pipefail
           python3 scripts/manage-hetzner-ingress.py audit \
             --state "${RUNNER_TEMP}/unused-firewall-state.json" \
-            --github-env "$GITHUB_ENV" >/dev/null
+            --github-env "$GITHUB_ENV"
       - name: Commit host policy after fresh-session and private-path proof
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
         env:
@@ -331,8 +331,8 @@ jobs:
     env:
       HETZNER_API_TOKEN: ${{ secrets.HETZNER_API_TOKEN }}
       HETZNER_CRAWLER_HOST: ${{ secrets.HETZNER_HOST }}
-      HETZNER_POSTGRES_HOST: ${{ vars.HETZNER_POSTGRES_HOST }}
-      HETZNER_TYPESENSE_HOST: ${{ vars.HETZNER_TYPESENSE_HOST }}
+      HETZNER_POSTGRES_HOST: ${{ secrets.HETZNER_POSTGRES_HOST }}
+      HETZNER_TYPESENSE_HOST: ${{ secrets.HETZNER_TYPESENSE_HOST }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Apply, verify, and transactionally retain the provider firewall

--- a/.github/workflows/deploy-hetzner-observability.yml
+++ b/.github/workflows/deploy-hetzner-observability.yml
@@ -57,13 +57,13 @@ jobs:
 
       - name: Resolve configured production host
         env:
-          TARGET_HOST: ${{ matrix.service == 'crawler' && secrets.HETZNER_HOST || matrix.service == 'postgresql' && vars.HETZNER_POSTGRES_HOST || vars.HETZNER_TYPESENSE_HOST }}
+          TARGET_HOST: ${{ matrix.service == 'crawler' && secrets.HETZNER_HOST || matrix.service == 'postgresql' && secrets.HETZNER_POSTGRES_HOST || secrets.HETZNER_TYPESENSE_HOST }}
         run: test -n "$TARGET_HOST"
 
       - name: Copy observability deployment artifacts
         uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
         with:
-          host: ${{ matrix.service == 'crawler' && secrets.HETZNER_HOST || matrix.service == 'postgresql' && vars.HETZNER_POSTGRES_HOST || vars.HETZNER_TYPESENSE_HOST }}
+          host: ${{ matrix.service == 'crawler' && secrets.HETZNER_HOST || matrix.service == 'postgresql' && secrets.HETZNER_POSTGRES_HOST || secrets.HETZNER_TYPESENSE_HOST }}
           username: root
           key: ${{ secrets.HETZNER_SSH_KEY }}
           source: scripts/jobseek-host-observability.py,deploy/observability,deploy/systemd/jobseek-alloy.service,deploy/systemd/jobseek-host-observability.service,deploy/systemd/jobseek-host-observability.timer,docs/16-hetzner-maintenance.md,docs/19-data-backup-recovery.md
@@ -82,7 +82,7 @@ jobs:
           GRAFANA_LOKI_USERNAME: ${{ secrets.GRAFANA_LOKI_USERNAME }}
           GRAFANA_LOKI_PASSWORD: ${{ secrets.GRAFANA_LOKI_PASSWORD }}
         with:
-          host: ${{ matrix.service == 'crawler' && secrets.HETZNER_HOST || matrix.service == 'postgresql' && vars.HETZNER_POSTGRES_HOST || vars.HETZNER_TYPESENSE_HOST }}
+          host: ${{ matrix.service == 'crawler' && secrets.HETZNER_HOST || matrix.service == 'postgresql' && secrets.HETZNER_POSTGRES_HOST || secrets.HETZNER_TYPESENSE_HOST }}
           username: root
           key: ${{ secrets.HETZNER_SSH_KEY }}
           envs: JOBSEEK_HOST_ROLE,JOBSEEK_OBSERVABILITY_DEPLOY_SHA,GRAFANA_PROM_URL,GRAFANA_PROM_USERNAME,GRAFANA_PROM_PASSWORD,GRAFANA_LOKI_URL,GRAFANA_LOKI_USERNAME,GRAFANA_LOKI_PASSWORD

--- a/docs/16-hetzner-maintenance.md
+++ b/docs/16-hetzner-maintenance.md
@@ -38,6 +38,14 @@ The repository-owned ingress source of truth is:
 - [`deploy-hetzner-ingress.yml`](../.github/workflows/deploy-hetzner-ingress.yml)
   for protected audit and apply operations.
 
+The protected `production` environment stores `HETZNER_API_TOKEN`,
+`HETZNER_HOST`, `HETZNER_POSTGRES_HOST`, `HETZNER_TYPESENSE_HOST`, and
+`HETZNER_SSH_KEY` as secrets. Host addresses are secrets for log-redaction
+purposes even though they are not authentication material. Do not convert them
+to GitHub variables: Actions prints ordinary variables in step environments.
+The inventory helper emits GitHub masking commands before exporting derived
+private addresses; suppressing that output would disable the masks.
+
 The public Hetzner firewall is default-deny inbound and allows only TCP 22 and
 ICMP over IPv4/IPv6. It has no outbound rules, so Hetzner's default outbound
 allow behavior remains in effect for backups, Grafana, crawler traffic, and

--- a/docs/19-data-backup-recovery.md
+++ b/docs/19-data-backup-recovery.md
@@ -124,12 +124,13 @@ main-branch artifacts to both hosts and runs the installer in preserve mode.
 It records the deployed commit without starting, stopping, enabling, or
 disabling an existing timer. Deployment uses the same per-service lock as the
 backup job and fails safely instead of replacing code during an active
-backup. The production environment variables
+backup. The production environment secrets
 `HETZNER_POSTGRES_HOST` and `HETZNER_TYPESENSE_HOST` select the two hosts; the
-workflow reuses the existing Hetzner SSH deployment credential. These are
-environment-scoped variables, so the workflow resolves them inside runtime
-steps after the protected `production` environment is attached; do not embed
-their values in `strategy.matrix`, which GitHub expands earlier.
+workflow reuses the existing Hetzner SSH deployment credential. Host addresses
+are secrets for log-redaction purposes even though they are not authentication
+material. These are environment-scoped secrets, so the workflow resolves them
+inside runtime steps after the protected `production` environment is attached;
+do not embed their values in `strategy.matrix`, which GitHub expands earlier.
 
 Confirm the effective schedule:
 


### PR DESCRIPTION
Follow-up to #6004 and #5923.

## Reproduction

The first read-only ingress audit correctly failed closed, but its failed-job log showed public and derived private host addresses. GitHub ordinary environment variables are printed in step metadata, and redirecting the inventory helper to `/dev/null` also discarded its `::add-mask::` workflow commands.

The affected run was deleted immediately. No credential or authentication material was exposed, and no production service/configuration mutation had occurred.

## Root-cause fix

- Promote the PostgreSQL and Typesense host selectors from protected environment variables to protected environment secrets.
- Use those secrets in ingress, observability, and data-backup workflows so every fleet deployment follows the same redaction contract.
- Preserve the inventory helper's stdout so GitHub processes the mask commands before derived private addresses enter later step environments.
- Document why host selectors are secrets for logging even though they are not credentials.

The protected secrets were provisioned from the existing environment variables over a direct stdin pipeline; values were never printed. Existing variables are retained until this PR deploys so rollback remains possible.

## Verification

- actionlint on all three affected workflows
- explicit negative checks for ordinary host-variable references and suppressed mask commands
- 39 repository CI-workflow tests
- `git diff --check`

Production ingress apply remains paused until this PR merges and a new read-only audit confirms that logs contain only masked addresses.
