### PR TITLE
Fix My Jobs interview interactions

### DIFF
--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -5039,3 +5039,51 @@ msgstr "Von"
 #: app/[lang]/(app)/my-jobs/stats/stats-page.tsx
 msgid "myJobs.stats.toDate"
 msgstr "Bis"
+
+#. Button label while an interview round is being added
+msgid "myJobs.detail.addingInterview"
+msgstr "Wird hinzugefügt…"
+
+#. Screen-reader confirmation after adding an interview round
+msgid "myJobs.interview.added"
+msgstr "Interview hinzugefügt."
+
+#. Error shown when an interview round cannot be added
+msgid "myJobs.interview.addError"
+msgstr "Das Interview konnte nicht hinzugefügt werden. Bitte erneut versuchen."
+
+#. Screen-reader confirmation after updating an interview round
+msgid "myJobs.interview.updated"
+msgstr "Interview aktualisiert."
+
+#. Error shown when an interview round cannot be updated
+msgid "myJobs.interview.updateError"
+msgstr "Das Interview konnte nicht aktualisiert werden. Bitte erneut versuchen."
+
+#. Delete interview confirmation title
+msgid "myJobs.interview.deleteTitle"
+msgstr "Interview löschen?"
+
+#. Delete interview confirmation description
+msgid "myJobs.interview.deleteDescription"
+msgstr "Diese Interviewrunde wird dauerhaft gelöscht. Wenn es die letzte Runde ist, wird die Bewerbung auf „Beworben“ zurückgesetzt."
+
+#. Cancel deleting an interview round
+msgid "myJobs.interview.deleteCancel"
+msgstr "Abbrechen"
+
+#. Confirm deleting an interview round
+msgid "myJobs.interview.deleteConfirm"
+msgstr "Löschen"
+
+#. Delete interview button while deletion is pending
+msgid "myJobs.interview.deleting"
+msgstr "Löschen…"
+
+#. Screen-reader confirmation after deleting an interview round
+msgid "myJobs.interview.deleted"
+msgstr "Interview gelöscht."
+
+#. Error shown when an interview round cannot be deleted
+msgid "myJobs.interview.deleteError"
+msgstr "Das Interview konnte nicht gelöscht werden. Bitte erneut versuchen."

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -5039,3 +5039,51 @@ msgstr "From"
 #: app/[lang]/(app)/my-jobs/stats/stats-page.tsx
 msgid "myJobs.stats.toDate"
 msgstr "To"
+
+#. Button label while an interview round is being added
+msgid "myJobs.detail.addingInterview"
+msgstr "Adding…"
+
+#. Screen-reader confirmation after adding an interview round
+msgid "myJobs.interview.added"
+msgstr "Interview added."
+
+#. Error shown when an interview round cannot be added
+msgid "myJobs.interview.addError"
+msgstr "Couldn't add the interview. Try again."
+
+#. Screen-reader confirmation after updating an interview round
+msgid "myJobs.interview.updated"
+msgstr "Interview updated."
+
+#. Error shown when an interview round cannot be updated
+msgid "myJobs.interview.updateError"
+msgstr "Couldn't update the interview. Try again."
+
+#. Delete interview confirmation title
+msgid "myJobs.interview.deleteTitle"
+msgstr "Delete interview?"
+
+#. Delete interview confirmation description
+msgid "myJobs.interview.deleteDescription"
+msgstr "This permanently deletes this interview round. If it is the last round, the application moves back to Applied."
+
+#. Cancel deleting an interview round
+msgid "myJobs.interview.deleteCancel"
+msgstr "Cancel"
+
+#. Confirm deleting an interview round
+msgid "myJobs.interview.deleteConfirm"
+msgstr "Delete"
+
+#. Delete interview button while deletion is pending
+msgid "myJobs.interview.deleting"
+msgstr "Deleting…"
+
+#. Screen-reader confirmation after deleting an interview round
+msgid "myJobs.interview.deleted"
+msgstr "Interview deleted."
+
+#. Error shown when an interview round cannot be deleted
+msgid "myJobs.interview.deleteError"
+msgstr "Couldn't delete the interview. Try again."

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -5039,3 +5039,51 @@ msgstr "Du"
 #: app/[lang]/(app)/my-jobs/stats/stats-page.tsx
 msgid "myJobs.stats.toDate"
 msgstr "Au"
+
+#. Button label while an interview round is being added
+msgid "myJobs.detail.addingInterview"
+msgstr "Ajout…"
+
+#. Screen-reader confirmation after adding an interview round
+msgid "myJobs.interview.added"
+msgstr "Entretien ajouté."
+
+#. Error shown when an interview round cannot be added
+msgid "myJobs.interview.addError"
+msgstr "Impossible d’ajouter l’entretien. Réessayez."
+
+#. Screen-reader confirmation after updating an interview round
+msgid "myJobs.interview.updated"
+msgstr "Entretien mis à jour."
+
+#. Error shown when an interview round cannot be updated
+msgid "myJobs.interview.updateError"
+msgstr "Impossible de mettre à jour l’entretien. Réessayez."
+
+#. Delete interview confirmation title
+msgid "myJobs.interview.deleteTitle"
+msgstr "Supprimer l’entretien ?"
+
+#. Delete interview confirmation description
+msgid "myJobs.interview.deleteDescription"
+msgstr "Cet entretien sera supprimé définitivement. S’il s’agit du dernier, la candidature repassera à l’état « Postulé »."
+
+#. Cancel deleting an interview round
+msgid "myJobs.interview.deleteCancel"
+msgstr "Annuler"
+
+#. Confirm deleting an interview round
+msgid "myJobs.interview.deleteConfirm"
+msgstr "Supprimer"
+
+#. Delete interview button while deletion is pending
+msgid "myJobs.interview.deleting"
+msgstr "Suppression…"
+
+#. Screen-reader confirmation after deleting an interview round
+msgid "myJobs.interview.deleted"
+msgstr "Entretien supprimé."
+
+#. Error shown when an interview round cannot be deleted
+msgid "myJobs.interview.deleteError"
+msgstr "Impossible de supprimer l’entretien. Réessayez."

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -5039,3 +5039,51 @@ msgstr "Dal"
 #: app/[lang]/(app)/my-jobs/stats/stats-page.tsx
 msgid "myJobs.stats.toDate"
 msgstr "Al"
+
+#. Button label while an interview round is being added
+msgid "myJobs.detail.addingInterview"
+msgstr "Aggiunta…"
+
+#. Screen-reader confirmation after adding an interview round
+msgid "myJobs.interview.added"
+msgstr "Colloquio aggiunto."
+
+#. Error shown when an interview round cannot be added
+msgid "myJobs.interview.addError"
+msgstr "Impossibile aggiungere il colloquio. Riprova."
+
+#. Screen-reader confirmation after updating an interview round
+msgid "myJobs.interview.updated"
+msgstr "Colloquio aggiornato."
+
+#. Error shown when an interview round cannot be updated
+msgid "myJobs.interview.updateError"
+msgstr "Impossibile aggiornare il colloquio. Riprova."
+
+#. Delete interview confirmation title
+msgid "myJobs.interview.deleteTitle"
+msgstr "Eliminare il colloquio?"
+
+#. Delete interview confirmation description
+msgid "myJobs.interview.deleteDescription"
+msgstr "Questo colloquio verrà eliminato definitivamente. Se è l’ultimo, la candidatura tornerà allo stato « Candidato »."
+
+#. Cancel deleting an interview round
+msgid "myJobs.interview.deleteCancel"
+msgstr "Annulla"
+
+#. Confirm deleting an interview round
+msgid "myJobs.interview.deleteConfirm"
+msgstr "Elimina"
+
+#. Delete interview button while deletion is pending
+msgid "myJobs.interview.deleting"
+msgstr "Eliminazione…"
+
+#. Screen-reader confirmation after deleting an interview round
+msgid "myJobs.interview.deleted"
+msgstr "Colloquio eliminato."
+
+#. Error shown when an interview round cannot be deleted
+msgid "myJobs.interview.deleteError"
+msgstr "Impossibile eliminare il colloquio. Riprova."

--- a/apps/web/src/components/my-jobs/__tests__/interview-list.test.tsx
+++ b/apps/web/src/components/my-jobs/__tests__/interview-list.test.tsx
@@ -1,0 +1,185 @@
+import { readFileSync } from "node:fs";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import "@/test-utils/lingui-mock";
+import type { InterviewEntry } from "@/lib/actions/my-jobs-types";
+import { InterviewList } from "../interview-list";
+
+const interview: InterviewEntry = {
+  id: "interview-1",
+  round: 1,
+  type: "interview",
+  scheduledAt: null,
+  createdAt: "2026-07-22T00:00:00.000Z",
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+function renderList(overrides: Partial<{
+  onAdd: (type: InterviewEntry["type"]) => Promise<boolean>;
+  onUpdate: (id: string, updates: { type?: InterviewEntry["type"]; scheduledAt?: string | null }) => Promise<boolean>;
+  onDelete: (id: string) => Promise<boolean>;
+}> = {}) {
+  const props = {
+    onAdd: vi.fn(async () => true),
+    onUpdate: vi.fn(async () => true),
+    onDelete: vi.fn(async () => true),
+    ...overrides,
+  };
+  render(<InterviewList interviews={[interview]} {...props} />);
+  return props;
+}
+
+async function openEditor(user: ReturnType<typeof userEvent.setup>) {
+  const trigger = screen.getByRole("button", { name: "#1 Interview" });
+  await user.click(trigger);
+  const menu = await screen.findByRole("menu");
+  return { trigger, menu };
+}
+
+async function openDeleteDialog(user: ReturnType<typeof userEvent.setup>) {
+  const { trigger, menu } = await openEditor(user);
+  await user.click(within(menu).getByRole("menuitem", { name: "Delete" }));
+  const dialog = await screen.findByRole("alertdialog", { name: "Delete interview?" });
+  return { trigger, dialog };
+}
+
+describe("InterviewList", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses a collision-aware semantic menu that closes on Escape and restores trigger focus", async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    const { trigger, menu } = await openEditor(user);
+    expect(trigger.getAttribute("aria-expanded")).toBe("true");
+    expect(within(menu).getByRole("menuitemradio", { name: "Other" })).toBeTruthy();
+    expect(menu.className).toContain("--radix-dropdown-menu-content-available-height");
+
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("menu")).toBeNull();
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+
+  it("does not retain the hand-rolled document mouse listener", () => {
+    const source = readFileSync("src/components/my-jobs/interview-list.tsx", "utf8");
+    expect(source).toContain("<DropdownMenu.Portal>");
+    expect(source).toContain("collisionPadding={12}");
+    expect(source).not.toContain('document.addEventListener("mousedown"');
+  });
+
+  it("guards Add interview while pending and announces success", async () => {
+    const user = userEvent.setup();
+    const pending = deferred<boolean>();
+    const onAdd = vi.fn(() => pending.promise);
+    renderList({ onAdd });
+
+    await user.click(screen.getByRole("button", { name: "Add interview" }));
+    const adding = screen.getByRole("button", { name: "Adding…" });
+    expect(adding).toHaveProperty("disabled", true);
+    await user.click(adding);
+    expect(onAdd).toHaveBeenCalledTimes(1);
+
+    pending.resolve(true);
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toBe("Interview added.");
+      expect(screen.getByRole("button", { name: "Add interview" })).toHaveProperty("disabled", false);
+    });
+  });
+
+  it("surfaces an actionable Add interview failure", async () => {
+    const user = userEvent.setup();
+    renderList({ onAdd: vi.fn(async () => false) });
+
+    await user.click(screen.getByRole("button", { name: "Add interview" }));
+
+    expect((await screen.findByRole("alert")).textContent).toBe("Couldn't add the interview. Try again.");
+  });
+
+  it("updates an interview type through the semantic radio menu", async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn(async () => true);
+    renderList({ onUpdate });
+
+    const { menu } = await openEditor(user);
+    await user.click(within(menu).getByRole("menuitemradio", { name: "Video Call" }));
+
+    await waitFor(() => {
+      expect(onUpdate).toHaveBeenCalledWith("interview-1", { type: "video_call" });
+      expect(screen.getByRole("status").textContent).toBe("Interview updated.");
+    });
+  });
+
+  it("opens a labelled delete confirmation with safe focus and restores the row on Cancel", async () => {
+    const user = userEvent.setup();
+    const props = renderList();
+
+    const { trigger, dialog } = await openDeleteDialog(user);
+    const cancel = within(dialog).getByRole("button", { name: "Cancel" });
+    await waitFor(() => expect(document.activeElement).toBe(cancel));
+
+    await user.click(cancel);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alertdialog")).toBeNull();
+      expect(document.activeElement).toBe(trigger);
+    });
+    expect(props.onDelete).not.toHaveBeenCalled();
+  });
+
+  it("restores the interview-row trigger after closing the confirmation with Escape", async () => {
+    const user = userEvent.setup();
+    renderList();
+
+    const { trigger } = await openDeleteDialog(user);
+    await user.keyboard("{Escape}");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alertdialog")).toBeNull();
+      expect(document.activeElement).toBe(trigger);
+    });
+  });
+
+  it("deletes only after explicit confirmation and announces success", async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn(async () => true);
+    renderList({ onDelete });
+
+    const { dialog } = await openDeleteDialog(user);
+    await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledWith("interview-1");
+      expect(screen.queryByRole("alertdialog")).toBeNull();
+      expect(screen.getByRole("status").textContent).toBe("Interview deleted.");
+    });
+  });
+
+  it("deletes only after confirmation and keeps failures inside the dialog", async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn(async () => false);
+    renderList({ onDelete });
+
+    const { dialog } = await openDeleteDialog(user);
+    await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledWith("interview-1");
+      expect(within(dialog).getByRole("alert").textContent).toBe("Couldn't delete the interview. Try again.");
+      expect(screen.getByRole("alertdialog", { name: "Delete interview?" })).toBeTruthy();
+    });
+  });
+});

--- a/apps/web/src/components/my-jobs/__tests__/reconcile-interview-mutation.test.ts
+++ b/apps/web/src/components/my-jobs/__tests__/reconcile-interview-mutation.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest";
+import type { InterviewEntry, MyJobDetail } from "@/lib/actions/my-jobs-types";
+import { reconcileInterviewMutation } from "../reconcile-interview-mutation";
+
+const firstInterview: InterviewEntry = {
+  id: "interview-1",
+  round: 1,
+  type: "interview",
+  scheduledAt: null,
+  createdAt: "2026-07-22T00:00:00.000Z",
+};
+
+function detail(interviews: InterviewEntry[]): MyJobDetail {
+  return {
+    id: "saved-job-1",
+    savedAt: "2026-07-22T00:00:00.000Z",
+    status: "interviewing",
+    statusChangedAt: "2026-07-22T00:00:00.000Z",
+    appliedAt: "2026-07-22T00:00:00.000Z",
+    offeredAt: null,
+    rejectedAt: null,
+    interviewCount: interviews.length,
+    posting: {
+      id: "posting-1",
+      title: "Engineer",
+      sourceUrl: "https://example.com/job",
+      firstSeenAt: "2026-07-22T00:00:00.000Z",
+      isActive: true,
+      salaryMin: null,
+      salaryMax: null,
+      salaryCurrency: null,
+      salaryPeriod: null,
+    },
+    company: {
+      id: "company-1",
+      name: "Example",
+      slug: "example",
+      icon: null,
+    },
+    salaryOverride: {
+      min: null,
+      max: null,
+      currency: null,
+      period: null,
+    },
+    interviews,
+  };
+}
+
+describe("reconcileInterviewMutation", () => {
+  it("recovers a committed mutation when the action response rejects", async () => {
+    const persisted = {
+      ...firstInterview,
+      id: "interview-2",
+      round: 2,
+    };
+    const applyDetail = vi.fn();
+
+    const ok = await reconcileInterviewMutation({
+      mutate: async () => {
+        throw new Error("response lost after commit");
+      },
+      refresh: async () => detail([firstInterview, persisted]),
+      applyDetail,
+      verify: (current) => current.interviews.some((interview) => interview.id === persisted.id),
+    });
+
+    expect(ok).toBe(true);
+    expect(applyDetail).toHaveBeenCalledWith(detail([firstInterview, persisted]));
+  });
+
+  it("reports failure when neither the action nor canonical state contains the change", async () => {
+    const ok = await reconcileInterviewMutation({
+      mutate: async () => ({ ok: false }),
+      refresh: async () => detail([firstInterview]),
+      applyDetail: vi.fn(),
+      verify: (current) => current.interviews.length === 2,
+    });
+
+    expect(ok).toBe(false);
+  });
+
+  it("uses the successful payload fallback when canonical refresh is unavailable", async () => {
+    const applyFallback = vi.fn(() => true);
+    const result = { ok: true, interview: firstInterview };
+
+    const ok = await reconcileInterviewMutation({
+      mutate: async () => result,
+      refresh: async () => {
+        throw new Error("read unavailable");
+      },
+      applyDetail: vi.fn(),
+      verify: () => false,
+      applyFallback,
+    });
+
+    expect(ok).toBe(true);
+    expect(applyFallback).toHaveBeenCalledWith(result);
+  });
+});

--- a/apps/web/src/components/my-jobs/interview-list.tsx
+++ b/apps/web/src/components/my-jobs/interview-list.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
-import { Plus, Trash2 } from "lucide-react";
+import { useRef, useState } from "react";
+import { Loader2, Plus, Trash2 } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
+import * as AlertDialog from "@radix-ui/react-alert-dialog";
+import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
+import { ErrorAlert } from "@/components/ui/ErrorAlert";
 import {
   INTERVIEW_TYPES,
   type InterviewEntry,
@@ -28,12 +31,12 @@ function useTypeLabels(): Record<InterviewType, string> {
 
 interface InterviewListProps {
   interviews: InterviewEntry[];
-  onAdd: (type: InterviewType) => void;
+  onAdd: (type: InterviewType) => Promise<boolean>;
   onUpdate: (
     id: string,
     updates: { type?: InterviewType; scheduledAt?: string | null },
-  ) => void;
-  onDelete: (id: string) => void;
+  ) => Promise<boolean>;
+  onDelete: (id: string) => Promise<boolean>;
 }
 
 export function InterviewList({
@@ -43,6 +46,43 @@ export function InterviewList({
   onDelete,
 }: InterviewListProps) {
   const typeLabels = useTypeLabels();
+  const { t } = useLingui();
+  const [adding, setAdding] = useState(false);
+  const [error, setError] = useState("");
+  const [feedback, setFeedback] = useState("");
+
+  function reportError(message: string) {
+    setFeedback("");
+    setError(message);
+  }
+
+  function reportSuccess(message: string) {
+    setError("");
+    setFeedback(message);
+  }
+
+  async function handleAdd() {
+    if (adding) return;
+    setAdding(true);
+    setError("");
+    setFeedback("");
+
+    let ok = false;
+    try {
+      ok = await onAdd("interview");
+    } catch {
+      ok = false;
+    } finally {
+      setAdding(false);
+    }
+
+    if (ok) {
+      reportSuccess(t({ id: "myJobs.interview.added", comment: "Screen-reader confirmation after adding an interview round", message: "Interview added." }));
+    } else {
+      reportError(t({ id: "myJobs.interview.addError", comment: "Error shown when an interview round cannot be added", message: "Couldn't add the interview. Try again." }));
+    }
+  }
+
   return (
     <div className="space-y-1">
       <h3 className="text-[10px] font-medium uppercase tracking-wider text-muted">
@@ -63,22 +103,41 @@ export function InterviewList({
               typeLabels={typeLabels}
               onUpdate={onUpdate}
               onDelete={onDelete}
+              onError={reportError}
+              onSuccess={reportSuccess}
             />
           ))}
         </ul>
       )}
 
+      <ErrorAlert
+        message={error}
+        focusOnRender
+        className="mb-1 px-2 py-1.5 text-xs"
+      />
+      <p role="status" aria-live="polite" className="sr-only">
+        {feedback}
+      </p>
       <button
-        onClick={() => onAdd("interview")}
-        className="inline-flex cursor-pointer items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-primary transition-colors hover:bg-primary/10"
+        type="button"
+        onClick={handleAdd}
+        disabled={adding}
+        aria-busy={adding}
+        className="inline-flex cursor-pointer items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-primary transition-colors hover:bg-primary/10 disabled:cursor-wait disabled:opacity-60"
       >
-        <Plus size={12} />
-        <Trans
-          id="myJobs.detail.addInterview"
-          comment="Button to add an interview round"
-        >
-          Add interview
-        </Trans>
+        {adding ? <Loader2 size={12} className="animate-spin" aria-hidden="true" /> : <Plus size={12} aria-hidden="true" />}
+        {adding ? (
+          <Trans id="myJobs.detail.addingInterview" comment="Button label while an interview round is being added">
+            Adding…
+          </Trans>
+        ) : (
+          <Trans
+            id="myJobs.detail.addInterview"
+            comment="Button to add an interview round"
+          >
+            Add interview
+          </Trans>
+        )}
       </button>
     </div>
   );
@@ -89,86 +148,197 @@ function InterviewRow({
   typeLabels,
   onUpdate,
   onDelete,
+  onError,
+  onSuccess,
 }: {
   interview: InterviewEntry;
   typeLabels: Record<InterviewType, string>;
   onUpdate: InterviewListProps["onUpdate"];
   onDelete: InterviewListProps["onDelete"];
+  onError: (message: string) => void;
+  onSuccess: (message: string) => void;
 }) {
   // `i18n.locale` is the viewer's active language. Without it,
   // `toLocaleDateString(undefined, ...)` renders the Node default
   // (en-US) on the server and the browser locale on the client,
   // producing a hydration mismatch for non-en viewers. See #3221.
-  const { i18n } = useLingui();
-  const [open, setOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
+  const { i18n, t } = useLingui();
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  const [updating, setUpdating] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState("");
 
-  // Close on outside click
-  useEffect(() => {
-    if (!open) return;
-    function handleClick(e: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
+  const updateError = t({ id: "myJobs.interview.updateError", comment: "Error shown when an interview round cannot be updated", message: "Couldn't update the interview. Try again." });
+  const deleteErrorMessage = t({ id: "myJobs.interview.deleteError", comment: "Error shown when an interview round cannot be deleted", message: "Couldn't delete the interview. Try again." });
+
+  async function handleTypeChange(type: InterviewType) {
+    if (type === interview.type || updating) return;
+    setUpdating(true);
+    let ok = false;
+    try {
+      ok = await onUpdate(interview.id, { type });
+    } catch {
+      ok = false;
+    } finally {
+      setUpdating(false);
     }
-    document.addEventListener("mousedown", handleClick);
-    return () => document.removeEventListener("mousedown", handleClick);
-  }, [open]);
+
+    if (ok) {
+      onSuccess(t({ id: "myJobs.interview.updated", comment: "Screen-reader confirmation after updating an interview round", message: "Interview updated." }));
+    } else {
+      onError(updateError);
+    }
+  }
+
+  async function handleDelete() {
+    if (deleting) return;
+    setDeleting(true);
+    setDeleteError("");
+    let ok = false;
+    try {
+      ok = await onDelete(interview.id);
+    } catch {
+      ok = false;
+    } finally {
+      setDeleting(false);
+    }
+
+    if (ok) {
+      setDeleteOpen(false);
+      onSuccess(t({ id: "myJobs.interview.deleted", comment: "Screen-reader confirmation after deleting an interview round", message: "Interview deleted." }));
+    } else {
+      setDeleteError(deleteErrorMessage);
+    }
+  }
+
+  function handleDeleteOpenChange(open: boolean) {
+    if (!open && deleting) return;
+    setDeleteOpen(open);
+    if (!open) setDeleteError("");
+  }
 
   return (
-    <li className="relative">
-      <button
-        onClick={() => setOpen((v) => !v)}
-        className="flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-left transition-colors hover:bg-border-soft/50"
-      >
-        <span className="text-[11px] font-medium text-muted">
-          #{interview.round}
-        </span>
-        <span className="text-xs">{typeLabels[interview.type]}</span>
-        {interview.scheduledAt && (
-          <span className="text-[11px] text-muted">
-            {new Date(interview.scheduledAt).toLocaleDateString(i18n.locale, {
-              month: "short",
-              day: "numeric",
-              hour: "2-digit",
-              minute: "2-digit",
-            })}
-          </span>
-        )}
-      </button>
-
-      {open && (
-        <div
-          ref={menuRef}
-          className="absolute left-0 z-20 mt-0.5 w-48 rounded-md border border-border-soft bg-surface py-1 shadow-lg"
-        >
-          {INTERVIEW_TYPES.map((t) => (
-            <button
-              key={t}
-              onClick={() => {
-                onUpdate(interview.id, { type: t });
-                setOpen(false);
-              }}
-              className={`flex w-full cursor-pointer items-center px-3 py-1.5 text-xs transition-colors hover:bg-border-soft ${
-                t === interview.type ? "font-medium text-primary" : "text-foreground"
-              }`}
-            >
-              {typeLabels[t]}
-            </button>
-          ))}
-          <hr className="my-1 border-divider" />
+    <li>
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger asChild>
           <button
-            onClick={() => {
-              onDelete(interview.id);
-              setOpen(false);
-            }}
-            className="flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-xs text-rose-500 transition-colors hover:bg-rose-50 dark:hover:bg-rose-900/20"
+            ref={triggerRef}
+            type="button"
+            disabled={updating}
+            className="flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1 text-left transition-colors hover:bg-border-soft/50 disabled:cursor-wait disabled:opacity-60"
           >
-            <Trash2 size={11} />
-            <Trans id="myJobs.interview.delete" comment="Delete interview button">Delete</Trans>
+            <span className="text-[11px] font-medium text-muted">
+              #{interview.round}
+            </span>
+            <span className="text-xs">{typeLabels[interview.type]}</span>
+            {interview.scheduledAt && (
+              <span className="text-[11px] text-muted">
+                {new Date(interview.scheduledAt).toLocaleDateString(i18n.locale, {
+                  month: "short",
+                  day: "numeric",
+                  hour: "2-digit",
+                  minute: "2-digit",
+                })}
+              </span>
+            )}
           </button>
-        </div>
-      )}
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            align="start"
+            sideOffset={4}
+            collisionPadding={12}
+            className="z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] w-48 overflow-y-auto rounded-md border border-border-soft bg-surface p-1 shadow-lg"
+          >
+            <DropdownMenu.RadioGroup
+              value={interview.type}
+              onValueChange={(value) => void handleTypeChange(value as InterviewType)}
+            >
+              {INTERVIEW_TYPES.map((type) => (
+                <DropdownMenu.RadioItem
+                  key={type}
+                  value={type}
+                  disabled={updating}
+                  className={`flex cursor-pointer items-center rounded-sm px-2 py-1.5 text-xs outline-none data-[highlighted]:bg-border-soft ${
+                    type === interview.type ? "font-medium text-primary" : "text-foreground"
+                  }`}
+                >
+                  {typeLabels[type]}
+                </DropdownMenu.RadioItem>
+              ))}
+            </DropdownMenu.RadioGroup>
+            <DropdownMenu.Separator className="my-1 h-px bg-divider" />
+            <DropdownMenu.Item
+              className="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-xs text-rose-500 outline-none data-[highlighted]:bg-rose-50 dark:data-[highlighted]:bg-rose-900/20"
+              onSelect={() => {
+                globalThis.setTimeout(() => setDeleteOpen(true), 0);
+              }}
+            >
+              <Trash2 size={11} aria-hidden="true" />
+              <Trans id="myJobs.interview.delete" comment="Delete interview button">Delete</Trans>
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
+
+      <AlertDialog.Root open={deleteOpen} onOpenChange={handleDeleteOpenChange}>
+        <AlertDialog.Portal>
+          <AlertDialog.Overlay className="fixed inset-0 z-50 bg-black/40 data-[state=open]:animate-in data-[state=open]:fade-in-0" />
+          <AlertDialog.Content
+            className="fixed left-1/2 top-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 rounded-xl border border-border-soft bg-surface p-6 shadow-xl data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+            onOpenAutoFocus={(event) => {
+              event.preventDefault();
+              cancelRef.current?.focus();
+            }}
+            onCloseAutoFocus={(event) => {
+              event.preventDefault();
+              triggerRef.current?.focus();
+            }}
+            onEscapeKeyDown={(event) => {
+              if (deleting) event.preventDefault();
+            }}
+          >
+            <AlertDialog.Title className="text-base font-semibold">
+              <Trans id="myJobs.interview.deleteTitle" comment="Delete interview confirmation title">Delete interview?</Trans>
+            </AlertDialog.Title>
+            <AlertDialog.Description className="mt-2 text-sm text-muted">
+              <Trans id="myJobs.interview.deleteDescription" comment="Delete interview confirmation description">
+                This permanently deletes this interview round. If it is the last round, the application moves back to Applied.
+              </Trans>
+            </AlertDialog.Description>
+            <div className="mt-4">
+              <ErrorAlert message={deleteError} focusOnRender />
+            </div>
+            <div className="mt-5 flex justify-end gap-2">
+              <AlertDialog.Cancel asChild>
+                <button
+                  ref={cancelRef}
+                  type="button"
+                  disabled={deleting}
+                  className="cursor-pointer rounded-md border border-border-soft px-4 py-2 text-sm font-medium transition-colors hover:bg-border-soft disabled:cursor-wait disabled:opacity-60"
+                >
+                  <Trans id="myJobs.interview.deleteCancel" comment="Cancel deleting an interview round">Cancel</Trans>
+                </button>
+              </AlertDialog.Cancel>
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={deleting}
+                className="inline-flex cursor-pointer items-center gap-2 rounded-md border border-warning-border bg-warning-bg px-4 py-2 text-sm font-medium text-warning transition-opacity hover:opacity-80 disabled:cursor-wait disabled:opacity-60"
+              >
+                {deleting && <Loader2 size={14} className="animate-spin" aria-hidden="true" />}
+                {deleting ? (
+                  <Trans id="myJobs.interview.deleting" comment="Delete interview button while deletion is pending">Deleting…</Trans>
+                ) : (
+                  <Trans id="myJobs.interview.deleteConfirm" comment="Confirm deleting an interview round">Delete</Trans>
+                )}
+              </button>
+            </div>
+          </AlertDialog.Content>
+        </AlertDialog.Portal>
+      </AlertDialog.Root>
     </li>
   );
 }

--- a/apps/web/src/components/my-jobs/my-job-detail-panel.tsx
+++ b/apps/web/src/components/my-jobs/my-job-detail-panel.tsx
@@ -24,6 +24,7 @@ import { StatusBadge } from "./status-badge";
 import { withUtmSource } from "@/lib/utm";
 import { sanitizeJobHtml } from "@/lib/sanitize";
 import { InterviewList } from "./interview-list";
+import { reconcileInterviewMutation } from "./reconcile-interview-mutation";
 import { timeAgoShort } from "@/lib/time";
 import { SaveButton } from "@/components/search/save-button";
 import { ScrollFade } from "@/components/ui/scroll-fade";
@@ -123,33 +124,77 @@ export function MyJobDetailPanel({
     }
   }
 
-  async function handleAddInterview(type: InterviewType) {
-    const result = await addInterview(savedJobId, type);
-    if (result.ok) {
-      const detail = await getMyJobDetail(savedJobId);
-      if (detail) {
-        setJobDetail(detail);
-        onStatusChanged?.(savedJobId, detail.status as ApplicationStatus);
-      }
-    }
+  function applyTrackedDetail(detail: MyJobDetail) {
+    setJobDetail(detail);
+    onStatusChanged?.(savedJobId, detail.status as ApplicationStatus);
+  }
+
+  async function handleAddInterview(type: InterviewType): Promise<boolean> {
+    const previousIds = new Set(jobDetail?.interviews.map((interview) => interview.id) ?? []);
+    return reconcileInterviewMutation({
+      mutate: () => addInterview(savedJobId, type),
+      refresh: () => getMyJobDetail(savedJobId),
+      applyDetail: applyTrackedDetail,
+      verify: (detail) => detail.interviews.some((interview) => !previousIds.has(interview.id)),
+      applyFallback: (result) => {
+        if (!result.interview) return false;
+        setJobDetail((previous) => previous ? {
+          ...previous,
+          status: previous.status === "applied" ? "interviewing" : previous.status,
+          interviews: previous.interviews.some((interview) => interview.id === result.interview!.id)
+            ? previous.interviews
+            : [...previous.interviews, result.interview!],
+        } : previous);
+        if (jobDetail?.status === "applied") {
+          onStatusChanged?.(savedJobId, "interviewing");
+        }
+        return true;
+      },
+    });
   }
 
   async function handleUpdateInterview(
     id: string,
     updates: { type?: InterviewType; scheduledAt?: string | null },
-  ) {
-    await updateInterview(id, updates);
-    const detail = await getMyJobDetail(savedJobId);
-    if (detail) setJobDetail(detail);
+  ): Promise<boolean> {
+    return reconcileInterviewMutation({
+      mutate: () => updateInterview(id, updates),
+      refresh: () => getMyJobDetail(savedJobId),
+      applyDetail: applyTrackedDetail,
+      verify: (detail) => {
+        const updated = detail.interviews.find((interview) => interview.id === id);
+        if (!updated) return false;
+        if (updates.type !== undefined && updated.type !== updates.type) return false;
+        if (updates.scheduledAt !== undefined && updated.scheduledAt !== updates.scheduledAt) return false;
+        return true;
+      },
+      applyFallback: () => {
+        setJobDetail((previous) => previous ? {
+          ...previous,
+          interviews: previous.interviews.map((interview) => interview.id === id ? { ...interview, ...updates } : interview),
+        } : previous);
+        return true;
+      },
+    });
   }
 
-  async function handleDeleteInterview(id: string) {
-    await deleteInterview(id);
-    const detail = await getMyJobDetail(savedJobId);
-    if (detail) {
-      setJobDetail(detail);
-      onStatusChanged?.(savedJobId, detail.status as ApplicationStatus);
-    }
+  async function handleDeleteInterview(id: string): Promise<boolean> {
+    return reconcileInterviewMutation({
+      mutate: () => deleteInterview(id),
+      refresh: () => getMyJobDetail(savedJobId),
+      applyDetail: applyTrackedDetail,
+      verify: (detail) => detail.interviews.every((interview) => interview.id !== id),
+      applyFallback: () => {
+        if (!jobDetail) return false;
+        const interviews = jobDetail.interviews.filter((interview) => interview.id !== id);
+        const status = interviews.length === 0 && jobDetail.status === "interviewing"
+          ? "applied"
+          : jobDetail.status;
+        setJobDetail({ ...jobDetail, interviews, status });
+        onStatusChanged?.(savedJobId, status as ApplicationStatus);
+        return true;
+      },
+    });
   }
 
   return (

--- a/apps/web/src/components/my-jobs/reconcile-interview-mutation.ts
+++ b/apps/web/src/components/my-jobs/reconcile-interview-mutation.ts
@@ -1,0 +1,43 @@
+import type { MyJobDetail } from "@/lib/actions/my-jobs-types";
+
+type MutationResult = { ok: boolean };
+
+/**
+ * Server actions can commit before their response reaches the client. Always
+ * read back the canonical tracker after a mutation so a committed row does not
+ * remain invisible when the action response rejects or is otherwise lost.
+ */
+export async function reconcileInterviewMutation<T extends MutationResult>({
+  mutate,
+  refresh,
+  applyDetail,
+  verify,
+  applyFallback,
+}: {
+  mutate: () => Promise<T>;
+  refresh: () => Promise<MyJobDetail | null>;
+  applyDetail: (detail: MyJobDetail) => void;
+  verify: (detail: MyJobDetail) => boolean;
+  applyFallback?: (result: T) => boolean;
+}): Promise<boolean> {
+  let result: T | undefined;
+
+  try {
+    result = await mutate();
+  } catch {
+    // A write may already have committed. The canonical read below decides.
+  }
+
+  try {
+    const detail = await refresh();
+    if (detail) {
+      applyDetail(detail);
+      return verify(detail);
+    }
+  } catch {
+    // Fall back to the successful action payload when the read-back fails.
+  }
+
+  if (!result?.ok) return false;
+  return applyFallback ? applyFallback(result) : true;
+}

--- a/apps/web/src/components/search/job-detail-dialog.tsx
+++ b/apps/web/src/components/search/job-detail-dialog.tsx
@@ -18,6 +18,7 @@ import { ScrollFade } from "@/components/ui/scroll-fade";
 import { usePostingDetail } from "@/lib/use-posting-detail";
 
 import { InterviewList } from "@/components/my-jobs/interview-list";
+import { reconcileInterviewMutation } from "@/components/my-jobs/reconcile-interview-mutation";
 import { updateJobStatus, getMyJobDetail, addInterview, updateInterview, deleteInterview } from "@/lib/actions/my-jobs";
 import type { ApplicationStatus, InterviewEntry, InterviewType } from "@/lib/actions/my-jobs-types";
 import { usePageActions } from "@/components/providers/SearchStateProvider";
@@ -98,37 +99,76 @@ function DetailContent({ detail, descriptionLoaded }: { detail: PostingDetail; d
     });
   }, [savedJobId, interviewsLoaded]);
 
+  function applyTrackedDetail(current: Awaited<ReturnType<typeof getMyJobDetail>>) {
+    if (!current) return;
+    setInterviews(current.interviews);
+    setTrackingStatus(detail.id, current.status as ApplicationStatus);
+  }
+
   async function handleStatusChange(newStatus: ApplicationStatus) {
     if (!savedJobId) return;
     setTrackingStatus(detail.id, newStatus);
     await updateJobStatus(savedJobId, newStatus);
   }
 
-  async function handleAddInterview(type: InterviewType) {
-    if (!savedJobId) return;
-    const result = await addInterview(savedJobId, type);
-    if (result.ok && result.interview) {
-      setInterviews((prev) => [...prev, result.interview!]);
-      // Server auto-transitions applied → interviewing
-      if (trackingStatus === "applied" || trackingStatus === "saved") {
-        setTrackingStatus(detail.id, "interviewing");
-      }
-    }
+  async function handleAddInterview(type: InterviewType): Promise<boolean> {
+    if (!savedJobId) return false;
+    const previousIds = new Set(interviews.map((interview) => interview.id));
+
+    return reconcileInterviewMutation({
+      mutate: () => addInterview(savedJobId, type),
+      refresh: () => getMyJobDetail(savedJobId),
+      applyDetail: applyTrackedDetail,
+      verify: (current) => current.interviews.some((interview) => !previousIds.has(interview.id)),
+      applyFallback: (result) => {
+        if (!result.interview) return false;
+        setInterviews((previous) => previous.some((interview) => interview.id === result.interview!.id)
+          ? previous
+          : [...previous, result.interview!]);
+        if (trackingStatus === "applied") {
+          setTrackingStatus(detail.id, "interviewing");
+        }
+        return true;
+      },
+    });
   }
 
-  async function handleUpdateInterview(id: string, updates: { type?: InterviewType; scheduledAt?: string | null }) {
-    await updateInterview(id, updates);
-    setInterviews((prev) => prev.map((i) => i.id === id ? { ...i, ...updates } : i));
+  async function handleUpdateInterview(id: string, updates: { type?: InterviewType; scheduledAt?: string | null }): Promise<boolean> {
+    if (!savedJobId) return false;
+    return reconcileInterviewMutation({
+      mutate: () => updateInterview(id, updates),
+      refresh: () => getMyJobDetail(savedJobId),
+      applyDetail: applyTrackedDetail,
+      verify: (current) => {
+        const updated = current.interviews.find((interview) => interview.id === id);
+        if (!updated) return false;
+        if (updates.type !== undefined && updated.type !== updates.type) return false;
+        if (updates.scheduledAt !== undefined && updated.scheduledAt !== updates.scheduledAt) return false;
+        return true;
+      },
+      applyFallback: () => {
+        setInterviews((previous) => previous.map((interview) => interview.id === id ? { ...interview, ...updates } : interview));
+        return true;
+      },
+    });
   }
 
-  async function handleDeleteInterview(id: string) {
-    await deleteInterview(id);
-    const remaining = interviews.filter((i) => i.id !== id);
-    setInterviews(remaining);
-    if (remaining.length === 0 && trackingStatus === "interviewing") {
-      setTrackingStatus(detail.id, "applied");
-      if (savedJobId) await updateJobStatus(savedJobId, "applied");
-    }
+  async function handleDeleteInterview(id: string): Promise<boolean> {
+    if (!savedJobId) return false;
+    const fallbackRemaining = interviews.filter((interview) => interview.id !== id);
+    return reconcileInterviewMutation({
+      mutate: () => deleteInterview(id),
+      refresh: () => getMyJobDetail(savedJobId),
+      applyDetail: applyTrackedDetail,
+      verify: (current) => current.interviews.every((interview) => interview.id !== id),
+      applyFallback: () => {
+        setInterviews(fallbackRemaining);
+        if (fallbackRemaining.length === 0 && trackingStatus === "interviewing") {
+          setTrackingStatus(detail.id, "applied");
+        }
+        return true;
+      },
+    });
   }
 
   return (


### PR DESCRIPTION
## Summary

- reconcile interview mutations against canonical tracker state so a committed write remains visible even if the server-action response is lost
- prevent duplicate Add interview submissions and provide pending, success, and actionable error feedback
- replace the clipped hand-rolled editor with a collision-aware semantic Radix menu that supports Escape and focus return
- require an accessible confirmation before deleting a round and keep failed deletions actionable
- add complete German, French, and Italian translations and focused regression coverage

## Validation

- pnpm test: 205 files, 1,507 tests passed
- pnpm typecheck
- pnpm lint
- pnpm build: 184/184 static pages generated
- bash scripts/check-i18n-coverage.sh
- pnpm compile

Closes #5898
Closes #6008
Closes #6009