### PR TITLE
Restore compiled interview translations

### DIFF
--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -5041,49 +5041,73 @@ msgid "myJobs.stats.toDate"
 msgstr "Bis"
 
 #. Button label while an interview round is being added
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.detail.addingInterview"
 msgstr "Wird hinzugefügt…"
 
 #. Screen-reader confirmation after adding an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.added"
 msgstr "Interview hinzugefügt."
 
 #. Error shown when an interview round cannot be added
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.addError"
 msgstr "Das Interview konnte nicht hinzugefügt werden. Bitte erneut versuchen."
 
 #. Screen-reader confirmation after updating an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.updated"
 msgstr "Interview aktualisiert."
 
 #. Error shown when an interview round cannot be updated
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.updateError"
 msgstr "Das Interview konnte nicht aktualisiert werden. Bitte erneut versuchen."
 
 #. Delete interview confirmation title
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteTitle"
 msgstr "Interview löschen?"
 
 #. Delete interview confirmation description
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteDescription"
 msgstr "Diese Interviewrunde wird dauerhaft gelöscht. Wenn es die letzte Runde ist, wird die Bewerbung auf „Beworben“ zurückgesetzt."
 
 #. Cancel deleting an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteCancel"
 msgstr "Abbrechen"
 
 #. Confirm deleting an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteConfirm"
 msgstr "Löschen"
 
 #. Delete interview button while deletion is pending
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleting"
 msgstr "Löschen…"
 
 #. Screen-reader confirmation after deleting an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleted"
 msgstr "Interview gelöscht."
 
 #. Error shown when an interview round cannot be deleted
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteError"
 msgstr "Das Interview konnte nicht gelöscht werden. Bitte erneut versuchen."

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -5041,49 +5041,73 @@ msgid "myJobs.stats.toDate"
 msgstr "To"
 
 #. Button label while an interview round is being added
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.detail.addingInterview"
 msgstr "Adding…"
 
 #. Screen-reader confirmation after adding an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.added"
 msgstr "Interview added."
 
 #. Error shown when an interview round cannot be added
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.addError"
 msgstr "Couldn't add the interview. Try again."
 
 #. Screen-reader confirmation after updating an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.updated"
 msgstr "Interview updated."
 
 #. Error shown when an interview round cannot be updated
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.updateError"
 msgstr "Couldn't update the interview. Try again."
 
 #. Delete interview confirmation title
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteTitle"
 msgstr "Delete interview?"
 
 #. Delete interview confirmation description
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteDescription"
 msgstr "This permanently deletes this interview round. If it is the last round, the application moves back to Applied."
 
 #. Cancel deleting an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteCancel"
 msgstr "Cancel"
 
 #. Confirm deleting an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteConfirm"
 msgstr "Delete"
 
 #. Delete interview button while deletion is pending
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleting"
 msgstr "Deleting…"
 
 #. Screen-reader confirmation after deleting an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleted"
 msgstr "Interview deleted."
 
 #. Error shown when an interview round cannot be deleted
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteError"
 msgstr "Couldn't delete the interview. Try again."

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -5041,49 +5041,73 @@ msgid "myJobs.stats.toDate"
 msgstr "Au"
 
 #. Button label while an interview round is being added
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.detail.addingInterview"
 msgstr "Ajout…"
 
 #. Screen-reader confirmation after adding an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.added"
 msgstr "Entretien ajouté."
 
 #. Error shown when an interview round cannot be added
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.addError"
 msgstr "Impossible d’ajouter l’entretien. Réessayez."
 
 #. Screen-reader confirmation after updating an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.updated"
 msgstr "Entretien mis à jour."
 
 #. Error shown when an interview round cannot be updated
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.updateError"
 msgstr "Impossible de mettre à jour l’entretien. Réessayez."
 
 #. Delete interview confirmation title
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteTitle"
 msgstr "Supprimer l’entretien ?"
 
 #. Delete interview confirmation description
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteDescription"
 msgstr "Cet entretien sera supprimé définitivement. S’il s’agit du dernier, la candidature repassera à l’état « Postulé »."
 
 #. Cancel deleting an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteCancel"
 msgstr "Annuler"
 
 #. Confirm deleting an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteConfirm"
 msgstr "Supprimer"
 
 #. Delete interview button while deletion is pending
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleting"
 msgstr "Suppression…"
 
 #. Screen-reader confirmation after deleting an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleted"
 msgstr "Entretien supprimé."
 
 #. Error shown when an interview round cannot be deleted
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteError"
 msgstr "Impossible de supprimer l’entretien. Réessayez."

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -5041,49 +5041,73 @@ msgid "myJobs.stats.toDate"
 msgstr "Al"
 
 #. Button label while an interview round is being added
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.detail.addingInterview"
 msgstr "Aggiunta…"
 
 #. Screen-reader confirmation after adding an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.added"
 msgstr "Colloquio aggiunto."
 
 #. Error shown when an interview round cannot be added
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.addError"
 msgstr "Impossibile aggiungere il colloquio. Riprova."
 
 #. Screen-reader confirmation after updating an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.updated"
 msgstr "Colloquio aggiornato."
 
 #. Error shown when an interview round cannot be updated
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.updateError"
 msgstr "Impossibile aggiornare il colloquio. Riprova."
 
 #. Delete interview confirmation title
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteTitle"
 msgstr "Eliminare il colloquio?"
 
 #. Delete interview confirmation description
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteDescription"
 msgstr "Questo colloquio verrà eliminato definitivamente. Se è l’ultimo, la candidatura tornerà allo stato « Candidato »."
 
 #. Cancel deleting an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteCancel"
 msgstr "Annulla"
 
 #. Confirm deleting an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteConfirm"
 msgstr "Elimina"
 
 #. Delete interview button while deletion is pending
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleting"
 msgstr "Eliminazione…"
 
 #. Screen-reader confirmation after deleting an interview round
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleted"
 msgstr "Colloquio eliminato."
 
 #. Error shown when an interview round cannot be deleted
+#. js-lingui-explicit-id
+#: src/components/my-jobs/interview-list.tsx
 msgid "myJobs.interview.deleteError"
 msgstr "Impossibile eliminare il colloquio. Riprova."

--- a/scripts/check-i18n-compiled.mjs
+++ b/scripts/check-i18n-compiled.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+const LOCALES = ["en", "de", "fr", "it"];
+
+export function extractCatalogIds(poSource) {
+  const ids = new Set();
+  const msgidPattern = /^msgid "((?:[^"\\]|\\.)+)"$/gm;
+
+  for (const match of poSource.matchAll(msgidPattern)) {
+    ids.add(JSON.parse(`"${match[1]}"`));
+  }
+
+  return [...ids].sort();
+}
+
+export function findMissingCompiledIds(ids, messages) {
+  return ids.filter((id) => !Object.hasOwn(messages, id));
+}
+
+async function main(repoRoot) {
+  const localesDir = path.join(repoRoot, "apps", "web", "locales");
+  let failed = false;
+
+  for (const locale of LOCALES) {
+    const poPath = path.join(localesDir, `${locale}.po`);
+    const compiledPath = path.join(localesDir, `${locale}.js`);
+    const poSource = await readFile(poPath, "utf8");
+    const compiledUrl = `${pathToFileURL(compiledPath).href}?coverage=${Date.now()}`;
+    const { messages } = await import(compiledUrl);
+    const missing = findMissingCompiledIds(extractCatalogIds(poSource), messages);
+
+    if (missing.length > 0) {
+      failed = true;
+      console.error(`\n❌ apps/web/locales/${locale}.js — ${missing.length} catalog IDs missing after compile:`);
+      for (const id of missing) console.error(`     ${id}`);
+    }
+  }
+
+  if (failed) process.exitCode = 1;
+  else console.log("i18n-compiled: every committed catalog ID is present after compile ✓");
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main(path.resolve(process.argv[2] ?? process.cwd()));
+}

--- a/scripts/check-i18n-coverage.sh
+++ b/scripts/check-i18n-coverage.sh
@@ -4,7 +4,7 @@
 # stale relative to the source tree (i.e. the user added a <Trans> or
 # t({…}) call but forgot to run `pnpm extract`).
 #
-# Two checks:
+# Four checks:
 #
 #   1. **Empty msgstr** — a `msgid "<key>"` immediately followed by
 #      `msgstr ""` in any of de/fr/it. The PO file header is
@@ -23,6 +23,12 @@
 #      msgid/msgstr content (stripping `#:` source-location comments
 #      that legitimately churn line-by-line), and fail only on real
 #      content differences. See #3031 for the rationale.
+#
+#   4. **Compiled catalog presence** — runs `lingui compile` and checks
+#      that every committed msgid is present under the same key in each
+#      generated catalog. This catches explicit-ID entries whose PO
+#      metadata was lost: Lingui otherwise compiles them under generated
+#      hashes and the production UI falls back to raw IDs. See #6014.
 #
 # When this fires (per check):
 #
@@ -197,6 +203,31 @@ else
   for locale in en "${NON_SOURCE_LOCALES[@]}"; do
     cp "$SNAPSHOT/$locale.po" "$LOCALES_DIR/$locale.po"
   done
+fi
+
+# ── Check 4: every committed ID survives compile (#6014) ────────────
+#
+# A PO entry can contain a complete translation and still be unusable at
+# runtime when the `js-lingui-explicit-id` extraction marker is missing.
+# Lingui then emits the translation under a generated hash rather than the
+# source ID. Compile the catalogs and compare their actual exported keys to
+# every committed msgid so the gate covers production behavior, not merely
+# PO-file contents.
+
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "i18n-coverage: pnpm not found — skipping compiled-catalog check"
+elif ! command -v node >/dev/null 2>&1; then
+  echo "i18n-coverage: node not found — skipping compiled-catalog check"
+elif [[ ! -d "$REPO_ROOT/apps/web/node_modules" ]]; then
+  echo "i18n-coverage: apps/web/node_modules missing — skipping compiled-catalog check"
+elif [[ ! -d "$REPO_ROOT/node_modules" ]]; then
+  echo "i18n-coverage: repo node_modules missing — skipping compiled-catalog check"
+elif ! pnpm --dir "$REPO_ROOT/apps/web" compile >/dev/null; then
+  echo ""
+  echo "❌ Lingui catalog compilation failed"
+  failed=1
+elif ! node "$REPO_ROOT/scripts/check-i18n-compiled.mjs" "$REPO_ROOT"; then
+  failed=1
 fi
 
 if [[ "$failed" -ne 0 ]]; then


### PR DESCRIPTION
## Summary

- restore Lingui explicit-ID metadata and source references for all 12 interview messages in English, German, French, and Italian
- add a compiled-catalog gate that verifies every committed msgid survives under the same runtime key
- catch the exact class of failure where PO translations exist but production falls back to raw IDs

## Regression proof

Before the metadata fix, the new gate failed with the same 12 missing IDs in all four compiled catalogs. After the fix it reports that every committed catalog ID is present. Spot checks return the expected localized pending and delete-title strings in en/de/fr/it.

## Validation

- bash scripts/check-i18n-coverage.sh
- pnpm --dir apps/web build: 184/184 static pages
- pnpm --dir apps/web lint
- pnpm --dir apps/web typecheck
- node --check scripts/check-i18n-compiled.mjs
- bash -n scripts/check-i18n-coverage.sh

Closes #6014