### PR TITLE
Fix interview timestamp serialization

### DIFF
--- a/apps/web/src/lib/actions/__tests__/my-jobs-interview-race.test.ts
+++ b/apps/web/src/lib/actions/__tests__/my-jobs-interview-race.test.ts
@@ -105,7 +105,11 @@ const mocks = vi.hoisted(() => {
       created_at: new Date(),
     };
     interviewTable.push(row);
-    return [row];
+
+    // postgres.js returns raw timestamp columns from db.execute() as
+    // strings in production, even though Drizzle's schema-level type is
+    // Date. Keep this mock faithful to that raw-query boundary.
+    return [{ ...row, created_at: row.created_at.toISOString() }];
   };
 
   // ---- db.insert(...).values(...).onConflictDoNothing/returning ----
@@ -327,6 +331,9 @@ describe("#3160 — addInterview round-number race", () => {
     const r = await addInterview("sj-1", "technical");
     expect(r.ok).toBe(true);
     expect(r.interview?.round).toBe(3);
+    expect(r.interview?.createdAt).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+    );
 
     const rounds = mocks.interviewTable
       .filter((r) => r.saved_job_id === "sj-1")

--- a/apps/web/src/lib/actions/my-jobs.ts
+++ b/apps/web/src/lib/actions/my-jobs.ts
@@ -38,6 +38,14 @@ const LEGAL_TRANSITIONS: Record<ApplicationStatus, ApplicationStatus[]> = {
 
 type SortBy = "status_changed_at" | "saved_at" | "status" | "company_name";
 
+type DatabaseTimestamp = Date | string;
+
+function serializeDatabaseTimestamp(value: DatabaseTimestamp): string {
+  return value instanceof Date
+    ? value.toISOString()
+    : new Date(value).toISOString();
+}
+
 // ── getMyJobs ────────────────────────────────────────────────────────
 
 export async function getMyJobs(params: {
@@ -252,8 +260,10 @@ export async function getMyJobDetail(
     id: r.id,
     round: r.round,
     type: r.type as InterviewType,
-    scheduledAt: r.scheduledAt?.toISOString() ?? null,
-    createdAt: r.createdAt.toISOString(),
+    scheduledAt: r.scheduledAt
+      ? serializeDatabaseTimestamp(r.scheduledAt)
+      : null,
+    createdAt: serializeDatabaseTimestamp(r.createdAt),
   }));
 
   return {
@@ -403,8 +413,8 @@ export async function addInterview(
         id: string;
         round: number;
         type: string;
-        scheduledAt: Date | null;
-        createdAt: Date;
+        scheduledAt: DatabaseTimestamp | null;
+        createdAt: DatabaseTimestamp;
       }
     | undefined;
   let lastErr: unknown;
@@ -415,8 +425,8 @@ export async function addInterview(
         id: string;
         round: number;
         type: string;
-        scheduled_at: Date | null;
-        created_at: Date;
+        scheduled_at: DatabaseTimestamp | null;
+        created_at: DatabaseTimestamp;
       }>(sql`
         INSERT INTO application_interview (saved_job_id, round, type)
         SELECT
@@ -432,8 +442,8 @@ export async function addInterview(
         id: string;
         round: number;
         type: string;
-        scheduled_at: Date | null;
-        created_at: Date;
+        scheduled_at: DatabaseTimestamp | null;
+        created_at: DatabaseTimestamp;
       }>)[0];
 
       if (!r) {
@@ -488,8 +498,10 @@ export async function addInterview(
       id: inserted.id,
       round: inserted.round,
       type: inserted.type as InterviewType,
-      scheduledAt: inserted.scheduledAt?.toISOString() ?? null,
-      createdAt: inserted.createdAt.toISOString(),
+      scheduledAt: inserted.scheduledAt
+        ? serializeDatabaseTimestamp(inserted.scheduledAt)
+        : null,
+      createdAt: serializeDatabaseTimestamp(inserted.createdAt),
     },
   };
 }


### PR DESCRIPTION
## Summary

- normalize database timestamps returned as either Date objects or raw SQL strings
- keep InterviewEntry values serialized as ISO strings
- make the add-interview race harness reproduce the production raw-query timestamp shape

## Verification

- focused interview race test: 4/4
- full web suite: 205 files, 1,507 tests
- pnpm typecheck
- pnpm lint
- pnpm build: 184/184 routes
- commit hooks: ESLint and Lingui coverage

Closes #6018