### PR TITLE
Expose application activity to screen readers

### DIFF
--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -93,11 +93,23 @@ msgstr "{count, plural, one {Unternehmen} other {Unternehmen}}"
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {# Unternehmen beobachtet} other {# Unternehmen beobachtet}}. {description}"
 
-#. Heatmap tooltip shown when hovering an application-activity day; {date} is a YYYY-MM-DD date and {count} is the number of applications that day.
+#. Heatmap tooltip and accessible summary for an application-activity day; {date} is a localized date and {count} is the number of applications that day.
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:117
+#: src/components/my-jobs/activity-heatmap.tsx:158
 msgid "myJobs.heatmap.tooltip"
 msgstr "{count, plural, =0 {Keine Bewerbungen am {date}} one {# Bewerbung am {date}} other {# Bewerbungen am {date}}}"
+
+#. Accessible label for the application activity heatmap
+#. js-lingui-explicit-id
+#: src/components/my-jobs/activity-heatmap.tsx:209
+msgid "myJobs.heatmap.label"
+msgstr "Bewerbungsaktivität"
+
+#. Accessible summary when the application activity heatmap has no non-zero days
+#. js-lingui-explicit-id
+#: src/components/my-jobs/activity-heatmap.tsx:222
+msgid "myJobs.heatmap.emptySummary"
+msgstr "Keine Bewerbungsaktivität im angezeigten Jahr."
 
 #. SEO metadata suffix when a watchlist includes more companies than can be listed by name.
 #. js-lingui-explicit-id

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -93,11 +93,23 @@ msgstr "{count, plural, one {company} other {companies}}"
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {Tracking # company} other {Tracking # companies}}. {description}"
 
-#. Heatmap tooltip shown when hovering an application-activity day; {date} is a YYYY-MM-DD date and {count} is the number of applications that day.
+#. Heatmap tooltip and accessible summary for an application-activity day; {date} is a localized date and {count} is the number of applications that day.
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:117
+#: src/components/my-jobs/activity-heatmap.tsx:158
 msgid "myJobs.heatmap.tooltip"
 msgstr "{count, plural, =0 {No applications on {date}} one {# application on {date}} other {# applications on {date}}}"
+
+#. Accessible label for the application activity heatmap
+#. js-lingui-explicit-id
+#: src/components/my-jobs/activity-heatmap.tsx:209
+msgid "myJobs.heatmap.label"
+msgstr "Application activity"
+
+#. Accessible summary when the application activity heatmap has no non-zero days
+#. js-lingui-explicit-id
+#: src/components/my-jobs/activity-heatmap.tsx:222
+msgid "myJobs.heatmap.emptySummary"
+msgstr "No application activity in the displayed year."
 
 #. SEO metadata suffix when a watchlist includes more companies than can be listed by name.
 #. js-lingui-explicit-id

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -93,11 +93,23 @@ msgstr "{count, plural, one {entreprise} other {entreprises}}"
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {# entreprise suivie} other {# entreprises suivies}}. {description}"
 
-#. Heatmap tooltip shown when hovering an application-activity day; {date} is a YYYY-MM-DD date and {count} is the number of applications that day.
+#. Heatmap tooltip and accessible summary for an application-activity day; {date} is a localized date and {count} is the number of applications that day.
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:117
+#: src/components/my-jobs/activity-heatmap.tsx:158
 msgid "myJobs.heatmap.tooltip"
 msgstr "{count, plural, =0 {Aucune candidature le {date}} one {# candidature le {date}} other {# candidatures le {date}}}"
+
+#. Accessible label for the application activity heatmap
+#. js-lingui-explicit-id
+#: src/components/my-jobs/activity-heatmap.tsx:209
+msgid "myJobs.heatmap.label"
+msgstr "Activité de candidature"
+
+#. Accessible summary when the application activity heatmap has no non-zero days
+#. js-lingui-explicit-id
+#: src/components/my-jobs/activity-heatmap.tsx:222
+msgid "myJobs.heatmap.emptySummary"
+msgstr "Aucune activité de candidature pendant l’année affichée."
 
 #. SEO metadata suffix when a watchlist includes more companies than can be listed by name.
 #. js-lingui-explicit-id

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -93,11 +93,23 @@ msgstr "{count, plural, one {azienda} other {aziende}}"
 msgid "watchlist.meta.tracking"
 msgstr "{count, plural, one {# azienda monitorata} other {# aziende monitorate}}. {description}"
 
-#. Heatmap tooltip shown when hovering an application-activity day; {date} is a YYYY-MM-DD date and {count} is the number of applications that day.
+#. Heatmap tooltip and accessible summary for an application-activity day; {date} is a localized date and {count} is the number of applications that day.
 #. js-lingui-explicit-id
-#: src/components/my-jobs/activity-heatmap.tsx:117
+#: src/components/my-jobs/activity-heatmap.tsx:158
 msgid "myJobs.heatmap.tooltip"
 msgstr "{count, plural, =0 {Nessuna candidatura il {date}} one {# candidatura il {date}} other {# candidature il {date}}}"
+
+#. Accessible label for the application activity heatmap
+#. js-lingui-explicit-id
+#: src/components/my-jobs/activity-heatmap.tsx:209
+msgid "myJobs.heatmap.label"
+msgstr "Attività di candidatura"
+
+#. Accessible summary when the application activity heatmap has no non-zero days
+#. js-lingui-explicit-id
+#: src/components/my-jobs/activity-heatmap.tsx:222
+msgid "myJobs.heatmap.emptySummary"
+msgstr "Nessuna attività di candidatura nell’anno visualizzato."
 
 #. SEO metadata suffix when a watchlist includes more companies than can be listed by name.
 #. js-lingui-explicit-id

--- a/apps/web/src/components/my-jobs/__tests__/activity-heatmap.test.tsx
+++ b/apps/web/src/components/my-jobs/__tests__/activity-heatmap.test.tsx
@@ -35,9 +35,24 @@ const translateDescriptor = vi.hoisted(() => (
       message?: string;
       values?: Record<string, unknown>;
     }) {
+      if (id === "myJobs.heatmap.label") {
+        return linguiState.locale === "de"
+          ? "Bewerbungsaktivität"
+          : "Application activity";
+      }
+      if (id === "myJobs.heatmap.emptySummary") {
+        return linguiState.locale === "de"
+          ? "Keine Bewerbungsaktivität im angezeigten Jahr."
+          : "No application activity in the displayed year.";
+      }
       if (id === "myJobs.heatmap.tooltip") {
         const count = Number(values.count ?? 0);
         const date = String(values.date ?? "");
+        if (linguiState.locale === "de") {
+          if (count === 0) return `Keine Bewerbungen am ${date}`;
+          if (count === 1) return `1 Bewerbung am ${date}`;
+          return `${count} Bewerbungen am ${date}`;
+        }
         if (count === 0) return `No applications on ${date}`;
         if (count === 1) return `1 application on ${date}`;
         return `${count} applications on ${date}`;
@@ -248,6 +263,77 @@ describe("ActivityHeatmap — locale labels and plural tooltip (#3150)", () => {
     expect(todayCell).toBeDefined();
     fireEvent.mouseEnter(todayCell!);
 
-    expect(container.textContent).toContain(`${prefix} on ${todayKey}`);
+    const localizedDate = new Intl.DateTimeFormat("en", {
+      dateStyle: "long",
+    }).format(now);
+    expect(container.textContent).toContain(`${prefix} on ${localizedDate}`);
+  });
+});
+
+describe("ActivityHeatmap — accessible summary (#6024)", () => {
+  beforeEach(() => {
+    linguiState.locale = "en";
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("exposes every non-zero displayed day and hides decorative SVG cells", () => {
+    const now = new Date(2026, 6, 22, 12, 0, 0, 0);
+    vi.setSystemTime(now);
+    const yesterday = new Date(now);
+    yesterday.setDate(yesterday.getDate() - 1);
+
+    const { container, getByRole, getByTestId } = render(
+      <ActivityHeatmap
+        data={[
+          { date: formatLocal(yesterday), count: 2 },
+          { date: formatLocal(now), count: 1 },
+        ]}
+      />,
+    );
+
+    const region = getByRole("region", { name: "Application activity" });
+    const summary = getByTestId("heatmap-summary");
+    expect(region.contains(summary)).toBe(true);
+    expect(summary.textContent).toContain(
+      `2 applications on ${new Intl.DateTimeFormat("en", { dateStyle: "long" }).format(yesterday)}`,
+    );
+    expect(summary.textContent).toContain(
+      `1 application on ${new Intl.DateTimeFormat("en", { dateStyle: "long" }).format(now)}`,
+    );
+    expect(summary.querySelectorAll("li")).toHaveLength(2);
+    expect(container.querySelector("svg")?.closest('[aria-hidden="true"]')).not.toBeNull();
+  });
+
+  it("exposes a localized empty summary", () => {
+    linguiState.locale = "de";
+    vi.setSystemTime(new Date(2026, 6, 22, 12, 0, 0, 0));
+
+    const { getByRole, getByTestId } = render(<ActivityHeatmap data={[]} />);
+
+    expect(getByRole("region", { name: "Bewerbungsaktivität" })).toBeTruthy();
+    expect(getByTestId("heatmap-summary").textContent).toBe(
+      "Keine Bewerbungsaktivität im angezeigten Jahr.",
+    );
+  });
+
+  it("formats non-English activity dates with the active locale", () => {
+    linguiState.locale = "de";
+    const now = new Date(2026, 6, 22, 12, 0, 0, 0);
+    vi.setSystemTime(now);
+
+    const { getByTestId } = render(
+      <ActivityHeatmap data={[{ date: formatLocal(now), count: 1 }]} />,
+    );
+
+    const localizedDate = new Intl.DateTimeFormat("de", {
+      dateStyle: "long",
+    }).format(now);
+    expect(getByTestId("heatmap-summary").textContent).toContain(
+      `1 Bewerbung am ${localizedDate}`,
+    );
   });
 });

--- a/apps/web/src/components/my-jobs/activity-heatmap.tsx
+++ b/apps/web/src/components/my-jobs/activity-heatmap.tsx
@@ -13,6 +13,11 @@ function formatLocal(d: Date): string {
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
+function parseLocalDate(date: string): Date {
+  const [year, month, day] = date.split("-").map(Number);
+  return new Date(year, month - 1, day);
+}
+
 const WEEKS = 52;
 const DAYS = 7;
 const CELL = 10;
@@ -67,6 +72,10 @@ export function ActivityHeatmap({ data }: { data: ActivityDay[] }) {
   const { i18n } = useLingui();
   const DAY_LABELS = useDayLabels(i18n.locale);
   const MONTHS = useMonthLabels(i18n.locale);
+  const activityDateFormatter = useMemo(
+    () => new Intl.DateTimeFormat(i18n.locale, { dateStyle: "long" }),
+    [i18n.locale],
+  );
 
   const { grid, monthHeaders } = useMemo(() => {
     const map = new Map(data.map((d) => [d.date, d.count]));
@@ -133,17 +142,38 @@ export function ActivityHeatmap({ data }: { data: ActivityDay[] }) {
   const svgW = labelW + gridW;
   const svgH = monthH + gridH;
 
+  const activityDays = useMemo(
+    () =>
+      grid.flatMap((column) =>
+        column.filter(
+          (cell): cell is { date: string; count: number } =>
+            cell !== null && cell.count > 0,
+        ),
+      ),
+    [grid],
+  );
+
+  function formatActivity(cell: { date: string; count: number }): string {
+    return i18n._({
+      id: "myJobs.heatmap.tooltip",
+      comment: "Heatmap tooltip and accessible summary for an application-activity day; {date} is a localized date and {count} is the number of applications that day.",
+      message: "{count, plural, =0 {No applications on {date}} one {# application on {date}} other {# applications on {date}}}",
+      values: {
+        count: cell.count,
+        date: activityDateFormatter.format(parseLocalDate(cell.date)),
+      },
+    });
+  }
+
   function handleMouseEnter(e: React.MouseEvent, cell: { date: string; count: number }) {
     const rect = (e.target as SVGElement).getBoundingClientRect();
     const container = containerRef.current?.getBoundingClientRect();
     if (!container) return;
-    const text = i18n._({
-      id: "myJobs.heatmap.tooltip",
-      comment: "Heatmap tooltip shown when hovering an application-activity day; {date} is a YYYY-MM-DD date and {count} is the number of applications that day.",
-      message: "{count, plural, =0 {No applications on {date}} one {# application on {date}} other {# applications on {date}}}",
-      values: { count: cell.count, date: cell.date },
+    setTooltip({
+      x: rect.left - container.left + CELL / 2,
+      y: rect.top - container.top - 4,
+      text: formatActivity(cell),
     });
-    setTooltip({ x: rect.left - container.left + CELL / 2, y: rect.top - container.top - 4, text });
   }
 
   function renderCells(levels: string[]) {
@@ -174,64 +204,96 @@ export function ActivityHeatmap({ data }: { data: ActivityDay[] }) {
   }
 
   return (
-    <div ref={containerRef} className="relative">
-      <div className="overflow-x-auto">
-      <svg
-        viewBox={`0 0 ${svgW} ${svgH}`}
-        width={svgW}
-        height={svgH}
-      >
-        {/* Month labels */}
-        {monthHeaders.map((m) => (
-          <text
-            key={`month-${m.col}`}
-            data-month-column={m.col}
-            x={labelW + m.col * STEP}
-            y={11}
-            className="fill-muted"
-            style={{ fontSize: 9, fontFamily: "'JetBrains Mono', monospace" }}
-          >
-            {m.label}
-          </text>
-        ))}
-
-        {/* Day labels */}
-        {DAY_LABELS.map((label, day) =>
-          label ? (
-            <text
-              key={`day-${day}`}
-              x={0}
-              y={monthH + day * STEP + CELL - 1}
-              className="fill-muted"
-              style={{ fontSize: 8, fontFamily: "'JetBrains Mono', monospace" }}
-            >
-              {label}
-            </text>
-          ) : null,
+    <section
+      aria-label={i18n._({
+        id: "myJobs.heatmap.label",
+        comment: "Accessible label for the application activity heatmap",
+        message: "Application activity",
+      })}
+    >
+      <ul data-testid="heatmap-summary" className="sr-only">
+        {activityDays.length > 0 ? (
+          activityDays.map((cell) => (
+            <li key={cell.date}>{formatActivity(cell)}</li>
+          ))
+        ) : (
+          <li>
+            {i18n._({
+              id: "myJobs.heatmap.emptySummary",
+              comment: "Accessible summary when the application activity heatmap has no non-zero days",
+              message: "No application activity in the displayed year.",
+            })}
+          </li>
         )}
+      </ul>
 
-        {/* Light mode cells */}
-        <g className="dark:hidden">{renderCells(LEVELS)}</g>
+      <div ref={containerRef} className="relative" aria-hidden="true">
+        <div className="overflow-x-auto">
+          <svg
+            viewBox={`0 0 ${svgW} ${svgH}`}
+            width={svgW}
+            height={svgH}
+          >
+            {/* Month labels */}
+            {monthHeaders.map((m) => (
+              <text
+                key={`month-${m.col}`}
+                data-month-column={m.col}
+                x={labelW + m.col * STEP}
+                y={11}
+                className="fill-muted"
+                style={{
+                  fontSize: 9,
+                  fontFamily: "'JetBrains Mono', monospace",
+                }}
+              >
+                {m.label}
+              </text>
+            ))}
 
-        {/* Dark mode cells */}
-        <g className="hidden dark:block">{renderCells(LEVELS_DARK)}</g>
-      </svg>
-      </div>
+            {/* Day labels */}
+            {DAY_LABELS.map((label, day) =>
+              label ? (
+                <text
+                  key={`day-${day}`}
+                  x={0}
+                  y={monthH + day * STEP + CELL - 1}
+                  className="fill-muted"
+                  style={{
+                    fontSize: 8,
+                    fontFamily: "'JetBrains Mono', monospace",
+                  }}
+                >
+                  {label}
+                </text>
+              ) : null,
+            )}
 
-      {/* Tooltip */}
-      {tooltip && (
-        <div
-          className="pointer-events-none absolute z-50 rounded-md border border-border-soft bg-surface px-2 py-1 text-[10px] shadow-md"
-          style={{
-            left: tooltip.x,
-            top: tooltip.y,
-            transform: "translate(-50%, -100%)",
-            fontFamily: "'JetBrains Mono', monospace",
-          }}
-        >
-          {tooltip.text}
+            {/* Light mode cells */}
+            <g className="dark:hidden">{renderCells(LEVELS)}</g>
+
+            {/* Dark mode cells */}
+            <g className="hidden dark:block">
+              {renderCells(LEVELS_DARK)}
+            </g>
+          </svg>
         </div>
-      )}
-    </div>
+
+        {/* Tooltip */}
+        {tooltip && (
+          <div
+            className="pointer-events-none absolute z-50 rounded-md border border-border-soft bg-surface px-2 py-1 text-[10px] shadow-md"
+            style={{
+              left: tooltip.x,
+              top: tooltip.y,
+              transform: "translate(-50%, -100%)",
+              fontFamily: "'JetBrains Mono', monospace",
+            }}
+          >
+            {tooltip.text}
+          </div>
+        )}
+      </div>
+    </section>
   );
 }


### PR DESCRIPTION
Closes #6024.

## Summary

- add a localized semantic region and screen-reader-only activity summary
- list every non-zero day currently displayed with a localized long date and application count
- provide a localized empty-state summary
- hide the duplicate light/dark SVG chart trees from assistive technology
- localize the existing visual hover tooltip date without changing the visible layout

## Verification

- focused activity heatmap tests: 13/13
- full web suite: 205 files, 1,510 tests
- TypeScript typecheck
- ESLint
- Lingui comment, compiled-ID, translation-completeness, and catalog-sync gates
- production build: 184/184 routes
- commit hooks: ESLint and Lingui coverage