### PR TITLE
Keep overflow language picker reachable

### DIFF
--- a/apps/web/src/components/settings/GeneralSettings.tsx
+++ b/apps/web/src/components/settings/GeneralSettings.tsx
@@ -296,12 +296,7 @@ export function GeneralSettings({ savedJobLanguages, savedDisplayCurrency, saved
           {hasOverflow && (
             <button
               onClick={() => setLangModalOpen(true)}
-              disabled={isAllLanguages}
-              className={`inline-flex items-center gap-1.5 rounded-full border px-4 py-1 text-sm transition-colors cursor-pointer ${
-                isAllLanguages
-                  ? "border-border-soft text-muted opacity-50"
-                  : "border-dashed border-divider bg-surface hover:bg-border-soft text-muted hover:text-foreground"
-              }`}
+              className="inline-flex cursor-pointer items-center gap-1.5 rounded-full border border-dashed border-divider bg-surface px-4 py-1 text-sm text-muted transition-colors hover:bg-border-soft hover:text-foreground"
             >
               <Search size={13} className="shrink-0" />
               <Trans id="settings.general.jobLanguages.findMore" comment="Button to open modal with all languages">

--- a/apps/web/src/components/settings/GeneralSettings.tsx
+++ b/apps/web/src/components/settings/GeneralSettings.tsx
@@ -267,9 +267,7 @@ export function GeneralSettings({ savedJobLanguages, savedDisplayCurrency, saved
                 className={`inline-flex cursor-pointer items-center gap-1.5 rounded-full px-3 py-1 text-sm transition-colors ${
                   active
                     ? "bg-primary/10 text-primary font-medium"
-                    : isAllLanguages
-                      ? "border border-border-soft text-muted opacity-50"
-                      : "border border-border-soft text-muted hover:border-primary/30 hover:text-foreground"
+                    : "border border-border-soft text-muted hover:border-primary/30 hover:text-foreground"
                 }`}
               >
                 {lang.flag && <CountryFlag iso={lang.flag} size={16} className="shrink-0 rounded-[2px]" />}

--- a/apps/web/src/components/settings/__tests__/GeneralSettings-locale-switch.test.tsx
+++ b/apps/web/src/components/settings/__tests__/GeneralSettings-locale-switch.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, render, screen } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import "@/test-utils/lingui-mock";
@@ -213,5 +213,64 @@ describe("GeneralSettings locale switch (#2988)", () => {
 
     expect(cookieWrites).toEqual([]);
     expect(pushMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("GeneralSettings overflow languages (#6027)", () => {
+  it("opens Find more from all-language mode and selects an overflow language directly", async () => {
+    const user = userEvent.setup();
+    act(() => {
+      render(
+        <GeneralSettings
+          savedJobLanguages={["*"]}
+          savedDisplayCurrency="EUR"
+          savedSalaryPeriod={null}
+          availableCurrencies={["EUR"]}
+          availableLanguages={[
+            { code: "en", count: 1000 },
+            { code: "de", count: 900 },
+            { code: "fr", count: 800 },
+            { code: "es", count: 700 },
+            { code: "pt", count: 600 },
+            { code: "ja", count: 500 },
+            { code: "it", count: 400 },
+            { code: "nl", count: 300 },
+            { code: "pl", count: 200 },
+            { code: "ko", count: 100 },
+            { code: "cs", count: 90 },
+            { code: "zh", count: 80 },
+            { code: "sv", count: 70 },
+          ]}
+          locale="en"
+        />,
+      );
+    });
+
+    const allLanguages = screen.getByRole("button", { name: "All languages" });
+    const findMore = screen.getByRole("button", { name: "Find more" });
+    expect(allLanguages.getAttribute("aria-pressed")).toBe("true");
+    expect((findMore as HTMLButtonElement).disabled).toBe(false);
+    updatePreferencesMock.mockClear();
+
+    await user.click(findMore);
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    await user.click(screen.getByRole("button", { name: "svenska" }));
+
+    expect(allLanguages.getAttribute("aria-pressed")).toBe("false");
+    await waitFor(() => {
+      expect(updatePreferencesMock).toHaveBeenCalledWith({
+        jobLanguages: ["sv"],
+      });
+    });
+    expect(
+      updatePreferencesMock.mock.calls.filter(
+        ([preferences]) =>
+          typeof preferences === "object" &&
+          preferences !== null &&
+          "jobLanguages" in preferences &&
+          Array.isArray(preferences.jobLanguages) &&
+          !preferences.jobLanguages.includes("*"),
+      ),
+    ).toEqual([[{ jobLanguages: ["sv"] }]]);
   });
 });


### PR DESCRIPTION
Closes #6027.

## Summary

- keep **Find more** enabled while **All languages** is selected
- keep every clickable specific-language chip visibly actionable instead of applying disabled-looking opacity
- reuse the existing direct transition from the `*` sentinel to the requested inline or overflow language
- add a regression test that opens the real modal and selects the 13th language without an arbitrary intermediate preference

## Verification

- focused settings tests: 4/4
- full web suite: 205 files, 1,512 tests
- TypeScript typecheck
- ESLint (rerun after the final affordance change)
- production build: 184/184 routes
- commit hooks: ESLint and Lingui coverage