### PR TITLE
Fix job language modal focus

### DIFF
--- a/apps/web/src/components/settings/JobLanguageModal.tsx
+++ b/apps/web/src/components/settings/JobLanguageModal.tsx
@@ -7,6 +7,7 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import { allLanguages } from "@/lib/job-languages";
 import { CountryFlag } from "@/components/country-flag";
 import { ScrollFade } from "@/components/ui/scroll-fade";
+import { useSearchableDialogFocus } from "@/components/search/use-searchable-dialog-focus";
 
 interface JobLanguageModalProps {
   open: boolean;
@@ -26,6 +27,16 @@ export function JobLanguageModal({
 }: JobLanguageModalProps) {
   const { t } = useLingui();
   const [search, setSearch] = useState("");
+  const {
+    searchInputRef,
+    focusSearchInputOnOpen,
+    restoreTriggerFocusOnClose,
+  } = useSearchableDialogFocus();
+  const searchLabel = t({
+    id: "settings.jobLanguages.modal.searchPlaceholder",
+    comment: "Placeholder for search input in all-languages modal",
+    message: "Search languages...",
+  });
 
   const available = useMemo(
     () => allLanguages.filter((l) => availableCodes.has(l.code)),
@@ -49,6 +60,8 @@ export function JobLanguageModal({
         <Dialog.Content
           className="fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-[calc(100%-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 flex-col rounded-xl border border-border-soft bg-surface shadow-xl data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
           aria-describedby={undefined}
+          onOpenAutoFocus={focusSearchInputOnOpen}
+          onCloseAutoFocus={restoreTriggerFocusOnClose}
         >
           {/* Header */}
           <div className="flex items-center justify-between border-b border-divider px-5 py-4">
@@ -75,14 +88,12 @@ export function JobLanguageModal({
             <div className="flex items-center gap-2 rounded-md border border-border-soft px-3 py-2">
               <Search size={14} className="shrink-0 text-muted" />
               <input
+                ref={searchInputRef}
                 type="text"
                 value={search}
                 onChange={(e) => setSearch(e.target.value)}
-                placeholder={t({
-                  id: "settings.jobLanguages.modal.searchPlaceholder",
-                  comment: "Placeholder for search input in all-languages modal",
-                  message: "Search languages...",
-                })}
+                aria-label={searchLabel}
+                placeholder={searchLabel}
                 className="w-full min-w-0 bg-transparent text-sm outline-none placeholder:text-muted"
               />
             </div>

--- a/apps/web/src/components/settings/JobLanguageModal.tsx
+++ b/apps/web/src/components/settings/JobLanguageModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useEffect, useState, useMemo } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { X, Search } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
@@ -52,6 +52,10 @@ export function JobLanguageModal({
         lang.code.toLowerCase().includes(q),
     );
   }, [available, search]);
+
+  useEffect(() => {
+    if (!open) setSearch("");
+  }, [open]);
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>

--- a/apps/web/src/components/settings/JobLanguageModal.tsx
+++ b/apps/web/src/components/settings/JobLanguageModal.tsx
@@ -122,6 +122,7 @@ export function JobLanguageModal({
                     <button
                       key={lang.code}
                       onClick={() => onToggle(lang.code)}
+                      aria-pressed={active}
                       className={`inline-flex cursor-pointer items-center gap-1.5 rounded-full px-3 py-1 text-sm transition-colors ${
                         active
                           ? "bg-primary/10 text-primary font-medium"

--- a/apps/web/src/components/settings/__tests__/JobLanguageModal-focus.test.tsx
+++ b/apps/web/src/components/settings/__tests__/JobLanguageModal-focus.test.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import "@/test-utils/lingui-mock";
+import { JobLanguageModal } from "../JobLanguageModal";
+
+const selectedLanguages = new Set<string>();
+const availableLanguages = new Set(["de", "en"]);
+const toggleLanguage = vi.fn();
+
+function JobLanguageModalHarness() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Find more
+      </button>
+      <JobLanguageModal
+        open={open}
+        onOpenChange={setOpen}
+        selected={selectedLanguages}
+        onToggle={toggleLanguage}
+        availableCodes={availableLanguages}
+      />
+    </>
+  );
+}
+
+describe("JobLanguageModal focus lifecycle (#5990)", () => {
+  it("supports immediate typing and restores the external trigger after Escape", async () => {
+    const user = userEvent.setup();
+    render(<JobLanguageModalHarness />);
+
+    const trigger = screen.getByRole("button", { name: "Find more" });
+    await user.click(trigger);
+
+    const search = screen.getByRole("textbox", {
+      name: "Search languages...",
+    });
+    await waitFor(() => expect(document.activeElement).toBe(search));
+
+    await user.keyboard("de");
+    expect((search as HTMLInputElement).value).toBe("de");
+
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    await waitFor(() => expect(document.activeElement).toBe(trigger));
+  });
+});

--- a/apps/web/src/components/settings/__tests__/JobLanguageModal-focus.test.tsx
+++ b/apps/web/src/components/settings/__tests__/JobLanguageModal-focus.test.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import "@/test-utils/lingui-mock";
 import { JobLanguageModal } from "../JobLanguageModal";
 
-const selectedLanguages = new Set<string>();
+const selectedLanguages = new Set(["en"]);
 const availableLanguages = new Set(["de", "en"]);
 const toggleLanguage = vi.fn();
 
@@ -41,6 +41,18 @@ describe("JobLanguageModal focus lifecycle (#5990)", () => {
       name: "Search languages...",
     });
     await waitFor(() => expect(document.activeElement).toBe(search));
+
+    const dialog = screen.getByRole("dialog");
+    expect(
+      within(dialog)
+        .getByRole("button", { name: "English" })
+        .getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(
+      within(dialog)
+        .getByRole("button", { name: "Deutsch" })
+        .getAttribute("aria-pressed"),
+    ).toBe("false");
 
     await user.keyboard("de");
     expect((search as HTMLInputElement).value).toBe("de");

--- a/apps/web/src/components/settings/__tests__/JobLanguageModal-focus.test.tsx
+++ b/apps/web/src/components/settings/__tests__/JobLanguageModal-focus.test.tsx
@@ -48,5 +48,12 @@ describe("JobLanguageModal focus lifecycle (#5990)", () => {
     await user.keyboard("{Escape}");
     await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
     await waitFor(() => expect(document.activeElement).toBe(trigger));
+
+    await user.click(trigger);
+    const reopenedSearch = screen.getByRole("textbox", {
+      name: "Search languages...",
+    });
+    await waitFor(() => expect(document.activeElement).toBe(reopenedSearch));
+    expect((reopenedSearch as HTMLInputElement).value).toBe("");
   });
 });


### PR DESCRIPTION
Closes #5953.
Closes #5990.
Closes #6030.

## Summary

- wire the Settings job-language modal into the same tested searchable-dialog focus contract used by the Explore/company filters
- expose each modal language button's selected state with `aria-pressed`
- focus the search field on open and restore the external **Find more** trigger on Escape/close
- give the search field a real localized accessible name instead of relying on placeholder heuristics
- reset the transient search on close so a new modal session starts with the complete language list
- add component-level coverage for selected/unselected state, clean reopen state, immediate typing, Escape, and external-trigger restoration

## Verification

- focused modal + shared-hook tests: 2/2
- full web suite: 206 files, 1,512 tests
- TypeScript typecheck (rerun after the selected-state follow-up)
- ESLint (rerun after the selected-state follow-up)
- production build: 184/184 routes
- commit hooks: ESLint and Lingui coverage
