### PR TITLE
Fix job-language route revalidation

### DIFF
--- a/apps/web/src/lib/actions/__tests__/preferences-revalidation.test.ts
+++ b/apps/web/src/lib/actions/__tests__/preferences-revalidation.test.ts
@@ -106,7 +106,7 @@ describe("updatePreferences invalidates job-language-dependent pages (#2916)", (
     expect(mocks.writeAnonJobLanguagesCookie).toHaveBeenCalledWith(["fr"]);
     expect(mocks.revalidatePath).toHaveBeenCalledTimes(PATHS.length);
     for (const p of PATHS) {
-      expect(mocks.revalidatePath).toHaveBeenCalledWith(p);
+      expect(mocks.revalidatePath).toHaveBeenCalledWith(p, "page");
     }
   });
 
@@ -132,7 +132,7 @@ describe("updatePreferences invalidates job-language-dependent pages (#2916)", (
 
     expect(mocks.revalidatePath).toHaveBeenCalledTimes(PATHS.length);
     for (const p of PATHS) {
-      expect(mocks.revalidatePath).toHaveBeenCalledWith(p);
+      expect(mocks.revalidatePath).toHaveBeenCalledWith(p, "page");
     }
   });
 
@@ -160,7 +160,7 @@ describe("updatePreferences invalidates job-language-dependent pages (#2916)", (
 
     expect(mocks.revalidatePath).toHaveBeenCalledTimes(PATHS.length);
     for (const p of PATHS) {
-      expect(mocks.revalidatePath).toHaveBeenCalledWith(p);
+      expect(mocks.revalidatePath).toHaveBeenCalledWith(p, "page");
     }
   });
 

--- a/apps/web/src/lib/actions/preferences.ts
+++ b/apps/web/src/lib/actions/preferences.ts
@@ -79,13 +79,10 @@ const JOB_LANGUAGE_DEPENDENT_PATHS = [
 function invalidateJobLanguageDependentPages(): void {
   for (const path of JOB_LANGUAGE_DEPENDENT_PATHS) {
     try {
-      // Match the existing convention from
-      // `app/api/web/companies/request/[run_id]/status/route.ts` —
-      // single-arg call invalidates that page's cache entries across
-      // every locale. Passing the second `"page"` arg is also valid
-      // but the unspecified default is what the rest of the codebase
-      // uses for App-Router page paths.
-      revalidatePath(path);
+      // Dynamic route patterns require an explicit type; without it Next
+      // warns and skips invalidation entirely. "page" covers every concrete
+      // locale/parameter combination represented by each pattern.
+      revalidatePath(path, "page");
     } catch (err) {
       console.warn("[preferences] revalidatePath failed for", path, err);
     }


### PR DESCRIPTION
Closes #6031.

## Summary

- pass the required `"page"` type when the Job languages preference action invalidates its three dynamic route patterns
- replace the stale comment that incorrectly treated the one-argument call as effective
- strengthen anonymous, authenticated-update, and authenticated-insert regression coverage to assert the complete call signature
- keep the company-request/Murmur status route outside this production-UI fix

## Verification

- focused preference-revalidation tests: 16/16 across the focused files
- full web suite: 206 files, 1,513 tests
- TypeScript typecheck
- ESLint
- production build: 184/184 routes
- commit hooks: ESLint and Lingui coverage
