### PR TITLE
Persist anonymous salary display preferences

### DIFF
--- a/apps/web/src/components/__tests__/SalaryDisplayProvider.test.tsx
+++ b/apps/web/src/components/__tests__/SalaryDisplayProvider.test.tsx
@@ -12,8 +12,9 @@
  *   3. consumers without a provider in scope still mount and receive
  *      a graceful empty table (no fallback fetch, no crash)
  */
+import { useState } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import "@/test-utils/lingui-mock";
 
 const getCurrencyRatesMock = vi.fn();
@@ -51,8 +52,69 @@ function FormatterProbe() {
   );
 }
 
+function PreferenceProbe() {
+  const salary = useSalaryDisplay();
+  return (
+    <>
+      <span data-testid="currency">{salary.displayCurrency ?? "none"}</span>
+      <span data-testid="period">{salary.displayPeriod ?? "original"}</span>
+      <button
+        type="button"
+        onClick={() =>
+          salary.update({ displayCurrency: "CHF", salaryPeriod: "hourly" })
+        }
+      >
+        Update salary display
+      </button>
+    </>
+  );
+}
+
+function BootstrapPreferenceHarness() {
+  const [preferences, setPreferences] = useState<{
+    currency: string | null;
+    period: string | null;
+  }>({ currency: null, period: null });
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setPreferences({ currency: "GBP", period: "yearly" })}
+      >
+        Load account preferences
+      </button>
+      <SalaryDisplayProvider
+        displayCurrency={preferences.currency}
+        salaryPeriod={preferences.period}
+      >
+        <PreferenceProbe />
+      </SalaryDisplayProvider>
+    </>
+  );
+}
+
 beforeEach(() => {
   getCurrencyRatesMock.mockReset();
+  const memory = new Map<string, string>();
+  const stub: Storage = {
+    get length() {
+      return memory.size;
+    },
+    clear: () => memory.clear(),
+    getItem: (key: string) => memory.get(key) ?? null,
+    key: (index: number) => Array.from(memory.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      memory.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      memory.set(key, value);
+    },
+  };
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: stub,
+  });
 });
 
 describe("SalaryDisplayProvider rate sharing (issue #3181)", () => {
@@ -91,5 +153,57 @@ describe("SalaryDisplayProvider rate sharing (issue #3181)", () => {
 
     expect(screen.getByTestId("orphan").textContent).toBe("");
     expect(getCurrencyRatesMock).toHaveBeenCalledTimes(0);
+  });
+});
+
+describe("SalaryDisplayProvider preference persistence (#6035)", () => {
+  it("rehydrates anonymous preferences and persists updates across remounts", async () => {
+    getCurrencyRatesMock.mockResolvedValue([]);
+    window.localStorage.setItem("pref-display-currency", "USD");
+    window.localStorage.setItem("pref-salary-period", "monthly");
+
+    const first = render(
+      <SalaryDisplayProvider>
+        <PreferenceProbe />
+      </SalaryDisplayProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("currency").textContent).toBe("USD");
+      expect(screen.getByTestId("period").textContent).toBe("monthly");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Update salary display" }));
+    expect(window.localStorage.getItem("pref-display-currency")).toBe("CHF");
+    expect(window.localStorage.getItem("pref-salary-period")).toBe("hourly");
+    first.unmount();
+
+    render(
+      <SalaryDisplayProvider>
+        <PreferenceProbe />
+      </SalaryDisplayProvider>,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("currency").textContent).toBe("CHF");
+      expect(screen.getByTestId("period").textContent).toBe("hourly");
+    });
+  });
+
+  it("lets asynchronously loaded account preferences override anonymous values", async () => {
+    getCurrencyRatesMock.mockResolvedValue([]);
+    window.localStorage.setItem("pref-display-currency", "USD");
+    window.localStorage.setItem("pref-salary-period", "monthly");
+
+    render(<BootstrapPreferenceHarness />);
+    await waitFor(() => {
+      expect(screen.getByTestId("currency").textContent).toBe("USD");
+      expect(screen.getByTestId("period").textContent).toBe("monthly");
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Load account preferences" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("currency").textContent).toBe("GBP");
+      expect(screen.getByTestId("period").textContent).toBe("yearly");
+    });
   });
 });

--- a/apps/web/src/components/providers/AppBootstrapProvider.tsx
+++ b/apps/web/src/components/providers/AppBootstrapProvider.tsx
@@ -59,6 +59,7 @@ export function AppBootstrapProvider({ children }: { children: ReactNode }) {
           <SalaryDisplayProvider
             displayCurrency={prefs?.displayCurrency ?? null}
             salaryPeriod={prefs?.salaryPeriod ?? null}
+            persistLocally={!isPending && user === null}
           >
             <BannerProvider serverDismissed={prefs?.dismissedBanners}>
               {prefs && (

--- a/apps/web/src/components/providers/SalaryDisplayProvider.tsx
+++ b/apps/web/src/components/providers/SalaryDisplayProvider.tsx
@@ -4,6 +4,24 @@ import { createContext, useContext, useEffect, useState, useMemo, useCallback, t
 import { useLingui } from "@lingui/react/macro";
 import { getCurrencyRates, type CurrencyRate } from "@/lib/actions/search";
 import { formatSalary, type PeriodLabel, type SalaryPeriod } from "@/lib/salary";
+import { localPrefs } from "@/lib/preference-timestamps";
+
+const SALARY_PERIODS = new Set<SalaryPeriod>([
+  "yearly",
+  "monthly",
+  "daily",
+  "hourly",
+]);
+
+function validLocalCurrency(value: string | null): string | null {
+  return value && /^[A-Z]{3}$/.test(value) ? value : null;
+}
+
+function validLocalPeriod(value: string | null): SalaryPeriod | null {
+  return value && SALARY_PERIODS.has(value as SalaryPeriod)
+    ? (value as SalaryPeriod)
+    : null;
+}
 
 interface SalaryDisplayContextValue {
   displayCurrency: string | null;
@@ -25,10 +43,12 @@ const SalaryDisplayContext = createContext<SalaryDisplayContextValue>({
 export function SalaryDisplayProvider({
   displayCurrency: initialCurrency = null,
   salaryPeriod: initialPeriod = null,
+  persistLocally = true,
   children,
 }: {
   displayCurrency?: string | null;
   salaryPeriod?: string | null;
+  persistLocally?: boolean;
   children: ReactNode;
 }) {
   const { t } = useLingui();
@@ -40,12 +60,39 @@ export function SalaryDisplayProvider({
     getCurrencyRates().then(setRates);
   }, []);
 
+  useEffect(() => {
+    if (initialCurrency !== null) {
+      // Authenticated bootstrap preferences are authoritative. This effect
+      // also handles the async null -> DB-preference transition after mount.
+      setDisplayCurrency(initialCurrency);
+      setSalaryPeriod(initialPeriod);
+      return;
+    }
+
+    if (!persistLocally) {
+      setDisplayCurrency(null);
+      setSalaryPeriod(null);
+      return;
+    }
+
+    // Anonymous viewers have no bootstrap preference row. Rehydrate the
+    // client-owned values so formatting and Settings survive remounts/reloads.
+    setDisplayCurrency(validLocalCurrency(localPrefs.displayCurrency.get()));
+    setSalaryPeriod(validLocalPeriod(localPrefs.salaryPeriod.get()));
+  }, [initialCurrency, initialPeriod, persistLocally]);
+
   const displayPeriod = (salaryPeriod as SalaryPeriod | null) ?? null;
 
   const update = useCallback((opts: { displayCurrency?: string | null; salaryPeriod?: string | null }) => {
-    if (opts.displayCurrency !== undefined) setDisplayCurrency(opts.displayCurrency);
-    if (opts.salaryPeriod !== undefined) setSalaryPeriod(opts.salaryPeriod);
-  }, []);
+    if (opts.displayCurrency !== undefined) {
+      setDisplayCurrency(opts.displayCurrency);
+      if (persistLocally) localPrefs.displayCurrency.set(opts.displayCurrency);
+    }
+    if (opts.salaryPeriod !== undefined) {
+      setSalaryPeriod(opts.salaryPeriod);
+      if (persistLocally) localPrefs.salaryPeriod.set(opts.salaryPeriod);
+    }
+  }, [persistLocally]);
 
   // Locale-aware period suffix used when the salary is shown as
   // "<amount> <CCY> / <period>" on posting cards and detail pages.

--- a/apps/web/src/components/settings/GeneralSettings.tsx
+++ b/apps/web/src/components/settings/GeneralSettings.tsx
@@ -50,6 +50,11 @@ export function GeneralSettings({ savedJobLanguages, savedDisplayCurrency, saved
   const [displayCurrency, setDisplayCurrency] = useState(savedDisplayCurrency);
   const [salaryPeriod, setSalaryPeriod] = useState(savedSalaryPeriod ?? "");
   const salaryDisplay = useSalaryDisplay();
+  useEffect(() => {
+    if (salaryDisplay.displayCurrency === null) return;
+    setDisplayCurrency(salaryDisplay.displayCurrency);
+    setSalaryPeriod(salaryDisplay.displayPeriod ?? "");
+  }, [salaryDisplay.displayCurrency, salaryDisplay.displayPeriod]);
 
   const isAllLanguages = jobLanguages.includes("*");
   const isDefault = jobLanguages.length === 0;

--- a/apps/web/src/components/settings/__tests__/GeneralSettings-locale-switch.test.tsx
+++ b/apps/web/src/components/settings/__tests__/GeneralSettings-locale-switch.test.tsx
@@ -53,14 +53,17 @@ vi.mock("@/lib/actions/preferences", () => ({
 // `server-only` is imported transitively via the preferences action.
 vi.mock("server-only", () => ({}));
 
-// SalaryDisplayProvider context — minimal stub so the component renders.
+// SalaryDisplayProvider context — mutable so salary hydration can be covered.
+let salaryDisplayCurrency: string | null = "EUR";
+let salaryDisplayPeriod: "yearly" | "monthly" | "daily" | "hourly" | null = null;
+const salaryDisplayUpdateMock = vi.fn();
 vi.mock("@/components/providers/SalaryDisplayProvider", () => ({
   useSalaryDisplay: () => ({
-    displayCurrency: "EUR",
-    displayPeriod: null,
+    displayCurrency: salaryDisplayCurrency,
+    displayPeriod: salaryDisplayPeriod,
     rates: [],
     format: () => "",
-    update: vi.fn(),
+    update: salaryDisplayUpdateMock,
   }),
 }));
 
@@ -73,6 +76,9 @@ beforeEach(() => {
   pushMock.mockReset();
   refreshMock.mockReset();
   updatePreferencesMock.mockReset().mockResolvedValue(null);
+  salaryDisplayCurrency = "EUR";
+  salaryDisplayPeriod = null;
+  salaryDisplayUpdateMock.mockReset();
   currentPathname = "/en/settings";
   cookieValue = "";
   cookieWrites = [];
@@ -272,5 +278,34 @@ describe("GeneralSettings overflow languages (#6027)", () => {
           !preferences.jobLanguages.includes("*"),
       ),
     ).toEqual([[{ jobLanguages: ["sv"] }]]);
+  });
+});
+
+describe("GeneralSettings salary preference hydration (#6035)", () => {
+  it("reflects the provider's rehydrated anonymous salary preferences", async () => {
+    salaryDisplayCurrency = "USD";
+    salaryDisplayPeriod = "monthly";
+
+    render(
+      <GeneralSettings
+        savedJobLanguages={[]}
+        savedDisplayCurrency="EUR"
+        savedSalaryPeriod={null}
+        availableCurrencies={["EUR", "USD"]}
+        availableLanguages={[]}
+        locale="en"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        (screen.getByRole("combobox", { name: "Currency" }) as HTMLSelectElement)
+          .value,
+      ).toBe("USD");
+      expect(
+        (screen.getByRole("combobox", { name: "Pay period" }) as HTMLSelectElement)
+          .value,
+      ).toBe("monthly");
+    });
   });
 });

--- a/apps/web/src/lib/preference-timestamps.ts
+++ b/apps/web/src/lib/preference-timestamps.ts
@@ -1,6 +1,8 @@
 const THEME_TS_KEY = "pref-theme-updated-at";
 const LOCALE_TS_KEY = "pref-locale-updated-at";
 const LOCALE_KEY = "pref-locale";
+const DISPLAY_CURRENCY_KEY = "pref-display-currency";
+const SALARY_PERIOD_KEY = "pref-salary-period";
 
 export const localPrefs = {
   themeTimestamp: {
@@ -14,5 +16,19 @@ export const localPrefs = {
   locale: {
     get: (): string | null => localStorage.getItem(LOCALE_KEY),
     set: (locale: string) => localStorage.setItem(LOCALE_KEY, locale),
+  },
+  displayCurrency: {
+    get: (): string | null => localStorage.getItem(DISPLAY_CURRENCY_KEY),
+    set: (currency: string | null) => {
+      if (currency === null) localStorage.removeItem(DISPLAY_CURRENCY_KEY);
+      else localStorage.setItem(DISPLAY_CURRENCY_KEY, currency);
+    },
+  },
+  salaryPeriod: {
+    get: (): string | null => localStorage.getItem(SALARY_PERIOD_KEY),
+    set: (period: string | null) => {
+      if (period === null) localStorage.removeItem(SALARY_PERIOD_KEY);
+      else localStorage.setItem(SALARY_PERIOD_KEY, period);
+    },
   },
 };


### PR DESCRIPTION
Closes #6035.

## Summary

- persist anonymous display currency and salary period in the existing local-preference store
- rehydrate the shared salary-formatting provider after anonymous remounts/reloads and synchronize the Settings controls from that source
- keep pending/authenticated bootstrap isolated from local values; database preferences remain authoritative when they arrive
- validate stored currency/period values before using them
- add provider remount, async account-precedence, bootstrap, and Settings hydration regression coverage

## Verification

- focused provider/bootstrap/Settings tests: 14/14
- full web suite: 206 files, 1,516 tests
- TypeScript typecheck
- ESLint
- React/Next component quality checklist
- production build: 184/184 routes
- commit hooks: ESLint and Lingui coverage
