### PR TITLE
Fix skip-link focus navigation

### DIFF
--- a/apps/web/app/[lang]/(app)/layout.tsx
+++ b/apps/web/app/[lang]/(app)/layout.tsx
@@ -29,7 +29,8 @@ export default async function AppLayout({ children }: Props) {
             <WatchlistTipBanner aboveBottomBar />
             <main
               id="main-content"
-              className="mx-auto w-full max-w-[1200px] px-4 py-8 pb-20 md:pb-8"
+              tabIndex={-1}
+              className="mx-auto w-full max-w-[1200px] scroll-mt-12 px-4 py-8 pb-20 md:pb-8"
             >
               {children}
             </main>

--- a/apps/web/app/[lang]/(public)/layout.tsx
+++ b/apps/web/app/[lang]/(public)/layout.tsx
@@ -22,7 +22,9 @@ export default async function PublicLayout({ children, params }: Props) {
       <div className="fixed top-0 right-0 left-0 z-50">
         <HeaderShell />
       </div>
-      <div id="main-content" className="pt-12">{children}</div>
+      <div id="main-content" tabIndex={-1} className="scroll-mt-12 pt-12">
+        {children}
+      </div>
       <Footer lang={locale} />
     </>
   );

--- a/apps/web/src/components/SkipToContentLink.tsx
+++ b/apps/web/src/components/SkipToContentLink.tsx
@@ -1,13 +1,43 @@
 "use client";
 
 import { Trans } from "@lingui/react/macro";
+import type { MouseEvent } from "react";
 
 const SKIP_LINK_CLASS =
-  "sr-only focus:not-sr-only fixed top-2 left-2 z-[100] rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-contrast focus:outline-none";
+  "fixed top-2 left-2 z-[100] -translate-y-16 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-contrast focus:translate-y-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary";
+
+function focusVisibleMain(event: MouseEvent<HTMLAnchorElement>) {
+  const target = Array.from(
+    document.querySelectorAll<HTMLElement>("#main-content"),
+  ).find((candidate) => candidate.getClientRects().length > 0);
+
+  // Keep the native fragment fallback when the streamed page has not exposed
+  // a visible target yet. Once hydrated, select the rendered copy explicitly:
+  // React/Next may retain an earlier duplicate inside a display:none Suspense
+  // container, which native fragment navigation otherwise resolves first.
+  if (!target) return;
+
+  event.preventDefault();
+  if (!target.hasAttribute("tabindex")) target.tabIndex = -1;
+  target.focus({ preventScroll: true });
+  target.scrollIntoView({ block: "start" });
+
+  const url = new URL(window.location.href);
+  url.hash = "main-content";
+  if (window.location.hash === url.hash) {
+    window.history.replaceState(null, "", url);
+  } else {
+    window.history.pushState(null, "", url);
+  }
+}
 
 export function SkipToContentLink() {
   return (
-    <a href="#main-content" className={SKIP_LINK_CLASS}>
+    <a
+      href="#main-content"
+      className={SKIP_LINK_CLASS}
+      onClick={focusVisibleMain}
+    >
       <Trans id="common.a11y.skipToContent" comment="Skip to main content link for keyboard users">
         Skip to content
       </Trans>

--- a/apps/web/src/components/__tests__/SkipToContentLink.test.tsx
+++ b/apps/web/src/components/__tests__/SkipToContentLink.test.tsx
@@ -1,0 +1,59 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import "@/test-utils/lingui-mock";
+
+import { SkipToContentLink } from "../SkipToContentLink";
+
+function visibleClientRects(): DOMRectList {
+  return { length: 1 } as DOMRectList;
+}
+
+describe("SkipToContentLink", () => {
+  it("renders above fixed chrome when focused", () => {
+    render(<SkipToContentLink />);
+
+    const link = screen.getByRole("link", { name: "Skip to content" });
+    expect(link.className).toContain("fixed");
+    expect(link.className).toContain("z-[100]");
+    expect(link.className).toContain("-translate-y-16");
+    expect(link.className).toContain("focus:translate-y-0");
+    expect(link.className).not.toContain("sr-only");
+  });
+
+  it("focuses the visible target when a hidden streamed duplicate comes first", async () => {
+    const scrollIntoView = vi.fn();
+
+    render(
+      <>
+        <SkipToContentLink />
+        <div id="main-content" data-testid="hidden-main" tabIndex={-1} />
+        <main id="main-content" data-testid="visible-main">
+          <button type="button">First main action</button>
+        </main>
+      </>,
+    );
+
+    const hiddenTarget = screen.getByTestId("hidden-main");
+    const visibleTarget = screen.getByTestId("visible-main");
+    vi.spyOn(hiddenTarget, "getClientRects").mockReturnValue({ length: 0 } as DOMRectList);
+    vi.spyOn(visibleTarget, "getClientRects").mockImplementation(visibleClientRects);
+    Object.defineProperty(visibleTarget, "scrollIntoView", {
+      configurable: true,
+      value: scrollIntoView,
+    });
+
+    fireEvent.click(screen.getByRole("link", { name: "Skip to content" }));
+
+    expect(document.activeElement).toBe(visibleTarget);
+    expect(visibleTarget.getAttribute("tabindex")).toBe("-1");
+    expect(scrollIntoView).toHaveBeenCalledWith({ block: "start" });
+    expect(window.location.hash).toBe("#main-content");
+
+    await userEvent.setup().tab();
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "First main action" }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- keep the skip link physically fixed above the public/app headers and reveal it with a focus transform instead of conflicting `sr-only` utilities
- explicitly select, focus, and scroll the visible `#main-content` target when Next/React retains a hidden streamed duplicate
- make both layout targets programmatically focusable with fixed-header scroll margin
- cover the hidden-duplicate focus contract and the following Tab destination

Closes #3163.

## Validation

- `pnpm exec vitest run src/components/__tests__/SkipToContentLink.test.tsx` (2/2)
- `pnpm test -- --run` (207 files, 1,518 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build` (184/184 static pages)
- local Chrome keyboard proof on `/en`, `/en/explore`, and `/en/how-we-index`: first Tab renders the link at 8×8 above the header; Enter focuses the visible target; the next Tab reaches the first main-region control/link
