### PR TITLE
Fix homepage screenshot routing

### DIFF
--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -70,6 +70,6 @@ export const config = {
   // for non-(public) pages 308-redirect to `/<locale>/opengraph-image-<hash>`
   // and 404. See #2835 critic round 1.
   matcher: [
-    "/((?!_next|api|mcp|flags|fonts|publicdomain|\\.well-known|favicon\\.ico$|favicon-16x16\\.png$|favicon-32x32\\.png$|apple-touch-icon\\.png$|apple-touch-icon-[^/]+\\.png$|android-chrome-192x192\\.png$|android-chrome-512x512\\.png$|site\\.webmanifest$|BingSiteAuth\\.xml$|js_[^/]+\\.svg$|js_missing_screenshot_black\\.png$|js_missing_screenshot_white\\.png$|logo-dark\\.svg$|logo-light\\.svg$|opengraph-image|indexnow-key\\.txt$|llms\\.txt$|openapi\\.json$|openapi\\.yaml$|robots\\.txt$|sitemap\\.xml$|en|de|fr|it).*)",
+    "/((?!_next|api|mcp|flags|fonts|publicdomain|screenshots|\\.well-known|favicon\\.ico$|favicon-16x16\\.png$|favicon-32x32\\.png$|apple-touch-icon\\.png$|apple-touch-icon-[^/]+\\.png$|android-chrome-192x192\\.png$|android-chrome-512x512\\.png$|site\\.webmanifest$|BingSiteAuth\\.xml$|js_[^/]+\\.svg$|js_missing_screenshot_black\\.png$|js_missing_screenshot_white\\.png$|logo-dark\\.svg$|logo-light\\.svg$|opengraph-image|indexnow-key\\.txt$|llms\\.txt$|openapi\\.json$|openapi\\.yaml$|robots\\.txt$|sitemap\\.xml$|en|de|fr|it).*)",
   ],
 };

--- a/apps/web/src/lib/__tests__/proxy.test.ts
+++ b/apps/web/src/lib/__tests__/proxy.test.ts
@@ -167,6 +167,7 @@ describe("proxy config", () => {
     "/sitemap.xml",
     "/flags/ch.svg",
     "/fonts/JetBrainsMono-Regular.woff2",
+    "/screenshots/en/feature1-dark.png",
   ])("bypasses known static or discovery route %s", (url) => {
     expect(
       unstable_doesMiddlewareMatch({ config, nextConfig: {}, url }),


### PR DESCRIPTION
## Summary

- exclude the marketing screenshot directory from locale-proxy redirects so Next Image can resolve root-relative feature media
- regression-test the screenshot path alongside other known static-asset directories

Closes #6039.

## Validation

- `pnpm exec vitest run src/lib/__tests__/proxy.test.ts` (35/35)
- `pnpm test -- --run` (206 files, 1,517 tests)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build` (184/184 static pages)
- local Chrome dark-theme homepage: all three visible feature screenshots completed at 1200×630 natural dimensions with no 4xx responses or console errors
