### PR TITLE
Fix anonymous company request redirect

### DIFF
--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -4,6 +4,8 @@ import Negotiator from "negotiator";
 import { defaultLocale, locales, isLocale } from "@/lib/i18n";
 
 const COOKIE_NAME = "NEXT_LOCALE";
+const LOGGED_IN_HINT_COOKIE = "logged_in";
+const COMPANY_REQUEST_PATH = /^\/(en|de|fr|it)\/companies\/request$/;
 
 function getLocale(request: NextRequest): string {
   // 1. Explicit cookie from a previous locale switch
@@ -31,6 +33,28 @@ export function proxy(request: NextRequest) {
     request.nextUrl.pathname === `/${indexNowKey}.txt`
   ) {
     return NextResponse.next();
+  }
+
+  const companyRequestMatch = request.nextUrl.pathname.match(
+    COMPANY_REQUEST_PATH,
+  );
+  if (companyRequestMatch) {
+    // Decide the anonymous continuation before the Cache Components app shell
+    // can hydrate. Otherwise SalaryDisplayProvider starts getCurrencyRates(),
+    // the page redirect redirects that Server Action response, and Next falls
+    // back to a blank full-document navigation (#6043). The page still checks
+    // the real httpOnly session for hinted visitors; this cookie is only the
+    // same non-sensitive fast-path hint used by AppBootstrapProvider.
+    if (request.cookies.has(LOGGED_IN_HINT_COOKIE)) {
+      return NextResponse.next();
+    }
+
+    const returnPath = `${request.nextUrl.pathname}${request.nextUrl.search}`;
+    const signInUrl = request.nextUrl.clone();
+    signInUrl.pathname = `/${companyRequestMatch[1]}/sign-in`;
+    signInUrl.search = "";
+    signInUrl.searchParams.set("next", returnPath);
+    return NextResponse.redirect(signInUrl);
   }
 
   const cookieLocale = request.cookies.get(COOKIE_NAME)?.value;
@@ -71,5 +95,6 @@ export const config = {
   // and 404. See #2835 critic round 1.
   matcher: [
     "/((?!_next|api|mcp|flags|fonts|publicdomain|screenshots|\\.well-known|favicon\\.ico$|favicon-16x16\\.png$|favicon-32x32\\.png$|apple-touch-icon\\.png$|apple-touch-icon-[^/]+\\.png$|android-chrome-192x192\\.png$|android-chrome-512x512\\.png$|site\\.webmanifest$|BingSiteAuth\\.xml$|js_[^/]+\\.svg$|js_missing_screenshot_black\\.png$|js_missing_screenshot_white\\.png$|logo-dark\\.svg$|logo-light\\.svg$|opengraph-image|indexnow-key\\.txt$|llms\\.txt$|openapi\\.json$|openapi\\.yaml$|robots\\.txt$|sitemap\\.xml$|en|de|fr|it).*)",
+    "/:lang(en|de|fr|it)/companies/request",
   ],
 };

--- a/apps/web/src/lib/__tests__/proxy.test.ts
+++ b/apps/web/src/lib/__tests__/proxy.test.ts
@@ -17,6 +17,7 @@ function createRequest(
   pathname: string,
   acceptLanguage?: string,
   cookieLocale?: string,
+  loggedIn = false,
 ): NextRequest {
   const url = new URL(`http://localhost${pathname}`);
   const headers: Record<string, string> = {};
@@ -24,6 +25,7 @@ function createRequest(
 
   const request = new NextRequest(url, { headers });
   if (cookieLocale) request.cookies.set("NEXT_LOCALE", cookieLocale);
+  if (loggedIn) request.cookies.set("logged_in", "1");
   return request;
 }
 
@@ -89,7 +91,7 @@ describe("proxy", () => {
       createRequest("/indexnow-verification-token.txt"),
     );
 
-    expect(redirectSpy).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
     expect(response.headers.get("x-middleware-next")).toBe("1");
   });
 
@@ -133,10 +135,53 @@ describe("proxy caching", () => {
   });
 });
 
+describe("company request auth boundary", () => {
+  it("redirects anonymous visitors before the app shell and preserves prefills", () => {
+    const response = proxy(
+      createRequest(
+        "/de/companies/request?name=MissingCo&website=https%3A%2F%2Fexample.com%2Fcareers",
+      ),
+    );
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get("location")!);
+    expect(location.pathname).toBe("/de/sign-in");
+    expect(location.searchParams.get("next")).toBe(
+      "/de/companies/request?name=MissingCo&website=https%3A%2F%2Fexample.com%2Fcareers",
+    );
+  });
+
+  it("lets hinted visitors reach the server-verified request page", () => {
+    const response = proxy(
+      createRequest("/en/companies/request?name=Acme", undefined, undefined, true),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+  });
+});
+
 describe("proxy config", () => {
   it("has a matcher pattern", () => {
     expect(config.matcher).toBeDefined();
     expect(config.matcher.length).toBeGreaterThan(0);
+  });
+
+  it("matches the localized company-request auth boundary only", () => {
+    expect(
+      unstable_doesMiddlewareMatch({
+        config,
+        nextConfig: {},
+        url: "/en/companies/request?name=Acme",
+      }),
+    ).toBe(true);
+    expect(
+      unstable_doesMiddlewareMatch({
+        config,
+        nextConfig: {},
+        url: "/en/explore",
+      }),
+    ).toBe(false);
   });
 
   it.each([


### PR DESCRIPTION
## Summary

- redirect anonymous localized company-request visits at the proxy boundary, before the Cache Components app shell can hydrate and start unrelated Server Actions
- preserve the complete localized request path and prefill query in the sign-in `next` parameter
- let visitors carrying the existing non-sensitive `logged_in` hint reach the page, where the real httpOnly session remains authoritative
- add focused auth-boundary and matcher regression coverage

Closes #6043.

## Root cause

The protected company-request page redirected from inside the partially prerendered `(app)` tree. Before that redirect completed, `SalaryDisplayProvider` mounted and started `getCurrencyRates`. The page redirect then transformed that Server Action response into a sign-in redirect instead of the expected action/RSC payload, causing Next.js to throw and recover through a visibly blank full-document navigation.

## Validation

- `pnpm test` — 207 files, 1,522 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build` — 184/184 pages generated
- local Chrome: an anonymous German prefilled request URL produced one clean navigation to localized sign-in, preserved `next`, emitted no page exception, and sent no `Next-Action` request

## Production verification plan

- repeat the timed anonymous redirect on the exact production deployment and confirm the first committed page is sign-in, with no empty app-shell/blank filmstrip frame, page exception, or `Next-Action` request
- verify the complete localized prefill path survives in `next`
- sign in with the test account and verify a hinted, authenticated visitor still reaches the company-request form without submitting it
- inspect exact deployment logs before merging the audit item as verified
