### PR TITLE
Fix narrow auth and public shells

### DIFF
--- a/apps/web/src/components/AuthShell.tsx
+++ b/apps/web/src/components/AuthShell.tsx
@@ -11,7 +11,7 @@ export function AuthShell({ children }: { children: ReactNode }) {
   const lp = useLocalePath();
 
   return (
-    <div className="mx-auto w-fit min-w-[24rem] max-w-lg px-4">
+    <div className="mx-auto w-full max-w-lg px-4 sm:w-fit sm:min-w-[24rem]">
       <div className="flex min-h-screen flex-col items-center justify-center py-8">
         <Link href={lp("/explore")} prefetch={false} className="mb-6 block h-9 w-36">
           <ThemedImage
@@ -20,6 +20,8 @@ export function AuthShell({ children }: { children: ReactNode }) {
             alt="Job Seek"
             width={144}
             height={36}
+            loading="eager"
+            fetchPriority="high"
           />
         </Link>
         <div className="w-full rounded-lg border border-border-soft bg-surface p-6 sm:p-8">

--- a/apps/web/src/components/Footer.tsx
+++ b/apps/web/src/components/Footer.tsx
@@ -34,7 +34,7 @@ export function Footer({ lang }: FooterProps) {
           </Trans>
         </p>
         <nav aria-label={i18n._(msg({ id: "common.footer.ariaLabel", comment: "Aria label for footer navigation", message: "Footer" }))} className="order-1 sm:order-2">
-          <ul className="flex list-none gap-4 p-0">
+          <ul className="flex flex-wrap list-none gap-x-4 gap-y-2 p-0">
             <li>
               <a className={linkClass} href={links.github.href} target="_blank" rel="noreferrer">
                 <Trans id="common.footer.github" comment="Footer link to GitHub repo">GitHub</Trans>

--- a/apps/web/src/components/ThemedImage.tsx
+++ b/apps/web/src/components/ThemedImage.tsx
@@ -14,6 +14,8 @@ type ThemedImageProps = {
   className?: string;
   style?: CSSProperties;
   sizes?: string;
+  loading?: "eager" | "lazy";
+  fetchPriority?: "high" | "low" | "auto";
 };
 
 /**
@@ -41,6 +43,8 @@ export function ThemedImage({
   className,
   style,
   sizes,
+  loading,
+  fetchPriority,
 }: ThemedImageProps) {
   const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
@@ -57,6 +61,8 @@ export function ThemedImage({
       className={className}
       style={style}
       sizes={sizes}
+      loading={loading}
+      fetchPriority={fetchPriority}
     />
   );
 }

--- a/apps/web/src/components/__tests__/responsive-shared-shells.test.ts
+++ b/apps/web/src/components/__tests__/responsive-shared-shells.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+
+describe("responsive shared shells", () => {
+  it("allows the auth shell to shrink below its desktop minimum", () => {
+    const source = readFileSync("src/components/AuthShell.tsx", "utf8");
+    const themedImageSource = readFileSync(
+      "src/components/ThemedImage.tsx",
+      "utf8",
+    );
+
+    expect(source).toContain("w-full max-w-lg px-4");
+    expect(source).toContain("sm:w-fit sm:min-w-[24rem]");
+    expect(source).toContain('loading="eager"');
+    expect(source).toContain('fetchPriority="high"');
+    expect(themedImageSource).toContain("loading={loading}");
+    expect(themedImageSource).toContain("fetchPriority={fetchPriority}");
+    expect(source).not.toContain("w-fit min-w-[24rem] max-w-lg");
+  });
+
+  it("wraps public footer links on narrow viewports", () => {
+    const source = readFileSync("src/components/Footer.tsx", "utf8");
+
+    expect(source).toContain(
+      "flex flex-wrap list-none gap-x-4 gap-y-2 p-0",
+    );
+    expect(source).not.toContain('className="flex list-none gap-4 p-0"');
+  });
+});


### PR DESCRIPTION
## Summary

- let the shared auth shell shrink to the full available width below `sm` while preserving its existing 384px desktop card width
- wrap the six-link public footer row with a compact vertical gap on narrow viewports
- expose image loading/fetch-priority hints through `ThemedImage` and mark the always-above-fold auth logo eager/high priority
- add regression coverage for all three shared boundaries

Closes #6045.
Closes #6046.
Closes #6047.

## Production roots

- `AuthShell` applied an unconditional `min-w-[24rem]`, making every auth route 384px wide inside a 320px viewport.
- `Footer` kept all six links in one non-wrapping flex row, making every sampled public route 419px wide at 320px.
- `ThemedImage` exposed no loading hints, so the auth logo rendered as `loading="lazy"`, started at Chrome priority `Low`, and replaced the earlier LCP 352ms later in an unthrottled production trace.

## Validation

- focused regression test: 2/2 passed
- full web suite: 208 files / 1,524 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`: 184/184 pages generated
- local Chrome at 320×568: 56 auth/public route-locale combinations across English, German, French, and Italian had `scrollWidth === clientWidth` and no page exception
- auth wrapper measured 320px at the narrow viewport and retained its previous 384px desktop width
- local CDP trace rendered `loading="eager" fetchpriority="high"`, reported Chrome `initialPriority = High`, and emitted no Next.js LCP warning
- React/Next review: no new state/effect work, client boundaries, or unnecessary render paths; loading hints remain opt-in so existing themed images retain lazy defaults

## Production verification plan

- repeat the 320px matrix on the exact production deployment, including all auth routes and public-footer consumers in all four locales
- confirm the document has zero horizontal overflow and capture after-state screenshots for #6045/#6046
- trace the production auth-logo request and LCP entry, confirming eager/high-priority markup and no delayed logo replacement for #6047
- inspect the exact deployment logs, then update all three issues and the UX audit epic
