### PR TITLE
Migrate Mistral board to Ashby

### DIFF
--- a/apps/crawler/data/boards.csv
+++ b/apps/crawler/data/boards.csv
@@ -3250,7 +3250,7 @@ mirum-pharmaceuticals,mirum-pharmaceuticals-greenhouse,https://job-boards.greenh
 misfits-market,misfits-market-greenhouse,https://job-boards.greenhouse.io/misfitsmarket,greenhouse,"{""token"": ""misfitsmarket""}",skip,
 miso,miso-ashby,https://jobs.ashbyhq.com/miso,ashby,"{""token"": ""miso""}",skip,
 mission-lane,mission-lane-greenhouse,https://job-boards.greenhouse.io/missionlane,greenhouse,"{""token"": ""missionlane""}",skip,
-mistral-ai,mistral-ai-careers,https://jobs.lever.co/mistral,lever,"{""token"": ""mistral""}",skip,
+mistral-ai,mistral-ai-careers,https://jobs.ashbyhq.com/mistral.ai,ashby,"{""token"": ""mistral.ai""}",skip,
 mithril,mithril-greenhouse,https://job-boards.greenhouse.io/mithril,greenhouse,"{""token"": ""mithril""}",skip,
 mithrl,mithrl-ashby,https://jobs.ashbyhq.com/mithrl,ashby,"{""token"": ""mithrl""}",skip,
 mitigram,mitigram-careers,https://careers.mitigram.com/,rss,"{""preset"": ""teamtailor"", ""feed_url"": ""https://careers.mitigram.com/jobs.rss""}",skip,


### PR DESCRIPTION
## Summary
- preserve the stable `mistral-ai` company and `mistral-ai-careers` board identities
- replace the retired, empty Lever source with Mistral's active Ashby board
- let the existing slug-stable sync path realign the production row rather than creating a duplicate board

## Root cause
The CSV source of truth still selected Mistral's legacy Lever tenant after active recruiting moved to Ashby. The old endpoint remains reachable but returns an empty board, so re-enabling that row would only reproduce the symptom.

## Verification
- legacy Lever monitor: 0 jobs
- patched CSV Ashby monitor: 171 rich jobs; all 171 have title, description, and location
- `python3 scripts/validate_data_csv.py`
- `uv run python ../../scripts/probe-new-boards.py --base-ref origin/main`
- `uv run pytest tests/test_probe_boards.py tests/test_sync.py -q` (91 passed)

Production CLI dry-run and export verification will follow the normal CSV sync after merge.

Refs #6021