### PR TITLE
Fix cross-owner maintenance locking

### DIFF
--- a/docs/16-hetzner-maintenance.md
+++ b/docs/16-hetzner-maintenance.md
@@ -759,6 +759,12 @@ Use the installed `/usr/local/sbin/jobseek-maintenance` contract. It:
   window, so service stops and restoration are correlated to the operation
   even when the inner repair has several containers.
 
+The lock inode is shared by root-run operator work and deploy-user workflows.
+The wrapper opens an existing lock read-only before applying `flock`; it never
+creates/truncates that inode merely to acquire it. If root must create a
+missing post-reboot lock, ownership is handed to `deploy` so later workflows
+continue to serialize on the same inode.
+
 The revision must be the reviewed commit that defines the repair. Keep
 credentials in a root/deploy-only environment file; never put them in the
 wrapper or Docker command arguments.

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -562,6 +562,20 @@ test("Codex deploy installs the maintenance contract without granting runner Doc
   );
 });
 
+test("maintenance wrapper self-test covers the cross-owner lock path", () => {
+  const result = spawnSync(
+    "python3",
+    ["scripts/jobseek-maintenance.py", "--self-test"],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    },
+  );
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /maintenance provenance self-test passed/);
+});
+
 test("Codex deploy restores prior timer state after failure", () => {
   const dir = mkdtempSync(join(tmpdir(), "codex-deploy-timers-"));
   const log = join(dir, "systemctl.log");

--- a/scripts/jobseek-maintenance.py
+++ b/scripts/jobseek-maintenance.py
@@ -6,10 +6,12 @@ from __future__ import annotations
 import argparse
 import fcntl
 import os
+import pwd
 import re
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from collections.abc import Sequence
 from contextlib import contextmanager, suppress
@@ -161,12 +163,47 @@ def _run_capture(command: Sequence[str], *, timeout: int = 30) -> subprocess.Com
         raise MaintenanceError(f"Docker control command failed: {type(exc).__name__}") from exc
 
 
-@contextmanager
-def _mutation_lock(timeout_seconds: int):
+def _open_mutation_lock(lock_path: Path):
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    created = False
     try:
-        lock_file = MUTATION_LOCK.open("a+", encoding="utf-8")
+        try:
+            descriptor = os.open(lock_path, flags)
+        except FileNotFoundError:
+            try:
+                descriptor = os.open(
+                    lock_path,
+                    flags | os.O_CREAT | os.O_EXCL,
+                    0o600,
+                )
+                created = True
+            except FileExistsError:
+                descriptor = os.open(lock_path, flags)
     except OSError as exc:
         raise MaintenanceError(f"maintenance lock unavailable: {type(exc).__name__}") from exc
+    if created and os.geteuid() == 0:
+        try:
+            deploy_account = pwd.getpwnam("deploy")
+        except KeyError:
+            pass
+        else:
+            try:
+                os.fchown(descriptor, deploy_account.pw_uid, deploy_account.pw_gid)
+            except OSError as exc:
+                os.close(descriptor)
+                raise MaintenanceError(
+                    f"maintenance lock ownership failed: {type(exc).__name__}"
+                ) from exc
+    try:
+        return os.fdopen(descriptor, "r", encoding="utf-8")
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+@contextmanager
+def _mutation_lock(timeout_seconds: int, *, lock_path: Path | None = None):
+    lock_file = _open_mutation_lock(lock_path or MUTATION_LOCK)
     deadline = time.monotonic() + timeout_seconds
     try:
         while True:
@@ -420,6 +457,13 @@ def _self_test() -> None:
     for label in (OPERATION_LABEL, ISSUE_LABEL, REVISION_LABEL, BUDGET_LABEL):
         assert joined.count(label) == 1
     assert "secret" not in joined.lower()
+    with tempfile.TemporaryDirectory(prefix="jobseek-maintenance-self-test-") as temp_dir:
+        existing_lock = Path(temp_dir) / "existing.lock"
+        existing_lock.touch(mode=0o444)
+        with _mutation_lock(0, lock_path=existing_lock):
+            pass
+        with _mutation_lock(0, lock_path=Path(temp_dir) / "created.lock"):
+            pass
 
 
 def _add_provenance_arguments(parser: argparse.ArgumentParser) -> None:


### PR DESCRIPTION
Refs #6067

## Production finding

The #6072 acceptance canary failed safely before Docker access. `/run/lock/jobseek-crawler-mutation.lock` is deploy-owned, and Linux protected-regular-file policy rejects root reopening an existing sticky-directory file with `O_CREAT`. The wrapper therefore could not serve both documented callers even though both use the same lock inode.

No canary container was created. All crawler services remained healthy with restart 0 and OOM false.

## Root fix

- open an existing shared lock read-only before applying the exclusive `flock`, avoiding create/truncate semantics entirely
- create with `O_EXCL` only when the inode is genuinely absent
- when root creates a missing post-reboot inode, hand ownership to `deploy` so later workflows keep using the same inode
- extend the deploy-time self-test to cover both a read-only existing inode and a missing inode
- execute that self-test in the repository workflow-security suite and document the cross-owner invariant

The new helper acquired the actual deploy-owned production lock as root before this PR was opened; it did not invoke Docker or change service state.

## Validation

- `python3 scripts/jobseek-maintenance.py --self-test`
- `uv run ruff check scripts/jobseek-maintenance.py`
- `python3 -m py_compile scripts/jobseek-maintenance.py`
- `node --test scripts/ci-workflow.test.mjs` — 45 passed
- exact production lock acquisition with the patched helper — passed

After merge I will retry the harmless labelled canary and the sanitized bundle assertions before closing #6067.
