### PR TITLE
Prefer exact maintenance overlap during correlation

### DIFF
--- a/docs/14-error-review-routine.md
+++ b/docs/14-error-review-routine.md
@@ -79,6 +79,9 @@ classifying instability:
 
 - A single validated maintenance window owns only service pauses that overlap
   it or its bounded two-minute correlation edge.
+- A single exact-overlap candidate takes precedence over windows that reach
+  the pause only through that edge. Multiple exact candidates or multiple
+  padding-only provenance contracts remain ambiguous.
 - Service-pause correlation is limited to the eight monitored long-running
   crawler services: Redis, three HTTP workers, the browser worker, exporter,
   drain, and Alloy. Transient Compose init services cannot stretch a crawler

--- a/scripts/jobseek-maintenance.py
+++ b/scripts/jobseek-maintenance.py
@@ -33,6 +33,7 @@ from jobseek_maintenance_provenance import (  # noqa: E402
     OPERATION_RE,
     REVISION_LABEL,
     REVISION_RE,
+    correlate_events,
     docker_label_arguments,
 )
 
@@ -464,6 +465,83 @@ def _self_test() -> None:
             pass
         with _mutation_lock(0, lock_path=Path(temp_dir) / "created.lock"):
             pass
+
+    deploy_provenance = {
+        "operation": "crawler-deploy",
+        "issue": 3409,
+        "revision": "a" * 40,
+        "budget_seconds": 1800,
+    }
+    adjacent_provenance = {
+        "operation": "maintenance-provenance-acceptance",
+        "issue": 6067,
+        "revision": "b" * 40,
+        "budget_seconds": 120,
+    }
+    correlation = correlate_events(
+        [
+            {
+                "source": "docker_event",
+                "event_at": "2026-07-23T05:00:00+00:00",
+                "action": "start",
+                "container_generation": "deploy-marker",
+                "compose_service": "maintenance-window",
+                "compose_oneoff": "True",
+                "maintenance_provenance": deploy_provenance,
+            },
+            {
+                "source": "docker_event",
+                "event_at": "2026-07-23T05:00:40+00:00",
+                "action": "stop",
+                "container_generation": "worker-generation",
+                "compose_service": "worker-1",
+                "compose_oneoff": "False",
+            },
+            {
+                "source": "docker_event",
+                "event_at": "2026-07-23T05:00:50+00:00",
+                "action": "start",
+                "container_generation": "worker-generation",
+                "compose_service": "worker-1",
+                "compose_oneoff": "False",
+            },
+            {
+                "source": "docker_event",
+                "event_at": "2026-07-23T05:01:00+00:00",
+                "action": "die",
+                "container_generation": "deploy-marker",
+                "compose_service": "maintenance-window",
+                "compose_oneoff": "True",
+                "event_exit_code": "137",
+                "maintenance_provenance": deploy_provenance,
+            },
+            {
+                "source": "docker_event",
+                "event_at": "2026-07-23T05:02:49+00:00",
+                "action": "start",
+                "container_generation": "adjacent-marker",
+                "compose_service": "maintenance-window",
+                "compose_oneoff": "True",
+                "maintenance_provenance": adjacent_provenance,
+            },
+            {
+                "source": "docker_event",
+                "event_at": "2026-07-23T05:02:50+00:00",
+                "action": "die",
+                "container_generation": "adjacent-marker",
+                "compose_service": "maintenance-window",
+                "compose_oneoff": "True",
+                "event_exit_code": "137",
+                "maintenance_provenance": adjacent_provenance,
+            },
+        ]
+    )
+    assert correlation["unattributed_service_pauses"] == []
+    windows = {window["operation"]: window for window in correlation["maintenance_windows"]}
+    assert [pause["service"] for pause in windows["crawler-deploy"]["service_pauses"]] == [
+        "worker-1"
+    ]
+    assert windows["maintenance-provenance-acceptance"]["service_pauses"] == []
 
 
 def _add_provenance_arguments(parser: argparse.ArgumentParser) -> None:

--- a/scripts/jobseek_maintenance_provenance.py
+++ b/scripts/jobseek_maintenance_provenance.py
@@ -519,9 +519,16 @@ def correlate_events(events: Iterable[dict[str, Any]]) -> dict[str, object]:
     unattributed: list[dict[str, object]] = []
     for pause in _service_pauses(parsed):
         candidates = _candidate_windows(pause, windows)
-        provenance_keys = {candidate["provenance_key"] for candidate in candidates}
+        exact_candidates = [
+            candidate for candidate in candidates if _window_distance(pause, candidate) == 0
+        ]
+        preferred_candidates = exact_candidates or candidates
+        provenance_keys = {candidate["provenance_key"] for candidate in preferred_candidates}
         if len(provenance_keys) == 1:
-            selected = min(candidates, key=lambda item: _window_distance(pause, item))
+            selected = min(
+                preferred_candidates,
+                key=lambda item: _window_distance(pause, item),
+            )
             selected["service_pauses"].append(pause)
             continue
         public_pause = _public_pause(pause)


### PR DESCRIPTION
## Summary

- prefer a unique exact-overlap maintenance window over provenance candidates that reach a service pause only through the two-minute correlation edge
- preserve fail-closed ambiguity for multiple exact-overlap contracts and for multiple padding-only contracts
- extend the installed maintenance self-test with the exact production boundary case and document the precedence rule

## Root cause

After #6074 deployed, the 19:41:28–19:41:29 Alloy pause sat directly inside the 19:37:48–19:41:48 crawler-deploy window. The acceptance canary started at 19:43:25, only 116 seconds later. The correlator weighted exact overlap and padding-only adjacency equally, so the restored Alloy pause became ambiguous despite stronger direct evidence.

## Verification

- `uv run pytest tests/ -q`: 5,964 passed, 43 skipped
- `uv run pyright`: 0 errors
- `node --test scripts/ci-workflow.test.mjs`: 45 passed
- installed maintenance self-test, Ruff, byte-compilation, and diff checks pass
- root-only production candidate collection against the real two-hour journal:
  - crawler deploy `85c23b20…`: `completed`, seven service pauses, five successful one-offs, no actionable reason
  - #6067 acceptance canary `85c23b20…`: `completed`, no service pauses, one successful one-off
  - invalid provenance: zero; unattributed service pauses: zero

Only the Codex collector/runbook deployment paths change. There is no crawler version bump, crawler deployment, or Typesense change.

Refs #6067.
