### PR TITLE
[supabase downgrade] Expand saved-job snapshots without dropping the FK

### DIFF
--- a/.github/workflows/web-database-migrations.yml
+++ b/.github/workflows/web-database-migrations.yml
@@ -14,7 +14,7 @@ on:
           - verify
           - apply
       confirmation:
-        description: "For apply, enter APPLY-0083"
+        description: "For apply, enter APPLY-0084"
         required: false
         type: string
 
@@ -52,6 +52,7 @@ jobs:
         working-directory: apps/web
         run: >-
           pnpm exec vitest run
+          src/db/__tests__/saved-job-snapshot-expand-migration.test.ts
           src/db/__tests__/active-job-company-index-migration.test.ts
           src/db/__tests__/watchlist-privacy-interview-migration.test.ts
           src/db/__tests__/timestamptz-coverage.test.ts
@@ -78,7 +79,7 @@ jobs:
           set -euo pipefail
           test "$EVENT_NAME" = "workflow_dispatch"
           test "$GIT_REF" = "refs/heads/main"
-          test "$DISPATCH_CONFIRMATION" = "APPLY-0083"
+          test "$DISPATCH_CONFIRMATION" = "APPLY-0084"
           test -n "$DATABASE_URL_UNPOOLED"
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -97,7 +98,7 @@ jobs:
 
       - name: Verify audited preflight
         run: >-
-          pnpm --filter @jobseek/web db:migrate:verify --
+          pnpm --filter @jobseek/web db:migrate:verify-expand --
           preflight "$RUNNER_TEMP/web-database-preflight.json"
 
       - name: Apply reviewed migrations
@@ -106,7 +107,7 @@ jobs:
 
       - name: Verify exact postflight
         run: >-
-          pnpm --filter @jobseek/web db:migrate:verify --
+          pnpm --filter @jobseek/web db:migrate:verify-expand --
           postflight "$RUNNER_TEMP/web-database-postflight.json"
 
       - name: Publish non-sensitive evidence
@@ -152,7 +153,7 @@ jobs:
 
       - name: Check for production baseline drift
         run: >-
-          pnpm --filter @jobseek/web db:migrate:verify --
+          pnpm --filter @jobseek/web db:migrate:verify-expand --
           drift "$RUNNER_TEMP/web-database-drift.json"
 
       - name: Publish non-sensitive evidence

--- a/apps/web/drizzle/0084_saved_job_snapshot_expand.sql
+++ b/apps/web/drizzle/0084_saved_job_snapshot_expand.sql
@@ -18,6 +18,40 @@ ALTER TABLE public.saved_job ADD COLUMN company_name text;--> statement-breakpoi
 ALTER TABLE public.saved_job ADD COLUMN company_slug text;--> statement-breakpoint
 ALTER TABLE public.saved_job ADD COLUMN company_icon text;--> statement-breakpoint
 
+DO $snapshot$
+DECLARE
+  posting_fk record;
+BEGIN
+  SELECT conname, convalidated, confdeltype
+  INTO posting_fk
+  FROM pg_constraint
+  WHERE conrelid = 'public.saved_job'::regclass
+    AND confrelid = 'public.job_posting'::regclass
+    AND contype = 'f';
+
+  IF posting_fk.conname IS DISTINCT FROM
+       'saved_job_job_posting_id_job_posting_id_fk'
+     OR posting_fk.convalidated IS DISTINCT FROM true
+     OR posting_fk.confdeltype IS DISTINCT FROM 'c'
+  THEN
+    RAISE EXCEPTION
+      'Saved-job expand expected the validated cascading posting FK, got %',
+      row_to_json(posting_fk);
+  END IF;
+END
+$snapshot$;--> statement-breakpoint
+
+-- Prevent a crawler-side posting/company deletion from cascading into user
+-- application history while the compatibility FK still exists.
+ALTER TABLE public.saved_job
+  DROP CONSTRAINT saved_job_job_posting_id_job_posting_id_fk;--> statement-breakpoint
+ALTER TABLE public.saved_job
+  ADD CONSTRAINT saved_job_job_posting_id_job_posting_id_fk
+  FOREIGN KEY (job_posting_id)
+  REFERENCES public.job_posting(id)
+  ON DELETE RESTRICT
+  ON UPDATE NO ACTION;--> statement-breakpoint
+
 CREATE FUNCTION public.saved_job_snapshot_from_mirror()
 RETURNS trigger
 LANGUAGE plpgsql
@@ -133,6 +167,20 @@ FROM public.job_posting AS jp
 JOIN public.company AS c ON c.id = jp.company_id
 WHERE sj.job_posting_id = jp.id;--> statement-breakpoint
 
+-- Columns remain physically nullable for a rolling app deploy, but every old
+-- and new row must already satisfy the future contract.
+ALTER TABLE public.saved_job
+  ADD CONSTRAINT saved_job_required_snapshot_check
+  CHECK (
+    NULLIF(btrim(posting_title), '') IS NOT NULL
+    AND NULLIF(btrim(posting_source_url), '') IS NOT NULL
+    AND posting_first_seen_at IS NOT NULL
+    AND posting_is_active IS NOT NULL
+    AND company_id IS NOT NULL
+    AND NULLIF(btrim(company_name), '') IS NOT NULL
+    AND NULLIF(btrim(company_slug), '') IS NOT NULL
+  );--> statement-breakpoint
+
 DO $snapshot$
 DECLARE
   saved_job_count bigint;
@@ -165,9 +213,23 @@ BEGIN
     WHERE conrelid = 'public.saved_job'::regclass
       AND confrelid = 'public.job_posting'::regclass
       AND contype = 'f'
+      AND convalidated
+      AND confdeltype = 'r'
   ) THEN
     RAISE EXCEPTION
-      'Saved-job expand failed: job_posting FK must remain until contract';
+      'Saved-job expand failed: restrictive job_posting FK must remain until contract';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.saved_job'::regclass
+      AND conname = 'saved_job_required_snapshot_check'
+      AND contype = 'c'
+      AND convalidated
+  ) THEN
+    RAISE EXCEPTION
+      'Saved-job expand failed: required snapshot CHECK is not validated';
   END IF;
 END
 $snapshot$;

--- a/apps/web/drizzle/0084_saved_job_snapshot_expand.sql
+++ b/apps/web/drizzle/0084_saved_job_snapshot_expand.sql
@@ -1,0 +1,173 @@
+-- Expand phase for removing saved_job's dependency on the crawler mirror.
+--
+-- The compatibility trigger is installed before the backfill so old web
+-- instances that know only job_posting_id cannot create a snapshot-less row.
+-- The outbound FK deliberately remains until the dual-write/read application
+-- release is proven and the separate 0085 contract migration is approved.
+
+ALTER TABLE public.saved_job ADD COLUMN posting_title text;--> statement-breakpoint
+ALTER TABLE public.saved_job ADD COLUMN posting_source_url text;--> statement-breakpoint
+ALTER TABLE public.saved_job ADD COLUMN posting_first_seen_at timestamp with time zone;--> statement-breakpoint
+ALTER TABLE public.saved_job ADD COLUMN posting_is_active boolean;--> statement-breakpoint
+ALTER TABLE public.saved_job ADD COLUMN posting_salary_min integer;--> statement-breakpoint
+ALTER TABLE public.saved_job ADD COLUMN posting_salary_max integer;--> statement-breakpoint
+ALTER TABLE public.saved_job ADD COLUMN posting_salary_currency text;--> statement-breakpoint
+ALTER TABLE public.saved_job ADD COLUMN posting_salary_period text;--> statement-breakpoint
+ALTER TABLE public.saved_job ADD COLUMN company_id uuid;--> statement-breakpoint
+ALTER TABLE public.saved_job ADD COLUMN company_name text;--> statement-breakpoint
+ALTER TABLE public.saved_job ADD COLUMN company_slug text;--> statement-breakpoint
+ALTER TABLE public.saved_job ADD COLUMN company_icon text;--> statement-breakpoint
+
+CREATE FUNCTION public.saved_job_snapshot_from_mirror()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = pg_catalog, public
+AS $snapshot$
+DECLARE
+  source_posting record;
+BEGIN
+  SELECT
+    jp.titles[1] AS title,
+    jp.source_url,
+    jp.first_seen_at,
+    jp.is_active,
+    jp.salary_min,
+    jp.salary_max,
+    jp.salary_currency,
+    jp.salary_period,
+    c.id AS company_id,
+    c.name AS company_name,
+    c.slug AS company_slug,
+    c.icon AS company_icon
+  INTO source_posting
+  FROM public.job_posting AS jp
+  JOIN public.company AS c ON c.id = jp.company_id
+  WHERE jp.id = NEW.job_posting_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION
+      'Cannot snapshot saved job: posting % is absent from the Supabase mirror',
+      NEW.job_posting_id;
+  END IF;
+
+  NEW.posting_title := COALESCE(
+    NULLIF(btrim(NEW.posting_title), ''),
+    source_posting.title
+  );
+  NEW.posting_source_url := COALESCE(
+    NULLIF(btrim(NEW.posting_source_url), ''),
+    source_posting.source_url
+  );
+  NEW.posting_first_seen_at := COALESCE(
+    NEW.posting_first_seen_at,
+    source_posting.first_seen_at
+  );
+  NEW.posting_is_active := COALESCE(
+    NEW.posting_is_active,
+    source_posting.is_active
+  );
+  NEW.posting_salary_min := COALESCE(
+    NEW.posting_salary_min,
+    source_posting.salary_min
+  );
+  NEW.posting_salary_max := COALESCE(
+    NEW.posting_salary_max,
+    source_posting.salary_max
+  );
+  NEW.posting_salary_currency := COALESCE(
+    NEW.posting_salary_currency,
+    source_posting.salary_currency
+  );
+  NEW.posting_salary_period := COALESCE(
+    NEW.posting_salary_period,
+    source_posting.salary_period
+  );
+  NEW.company_id := COALESCE(NEW.company_id, source_posting.company_id);
+  NEW.company_name := COALESCE(
+    NULLIF(btrim(NEW.company_name), ''),
+    source_posting.company_name
+  );
+  NEW.company_slug := COALESCE(
+    NULLIF(btrim(NEW.company_slug), ''),
+    source_posting.company_slug
+  );
+  NEW.company_icon := COALESCE(NEW.company_icon, source_posting.company_icon);
+
+  IF NULLIF(btrim(NEW.posting_title), '') IS NULL
+     OR NULLIF(btrim(NEW.posting_source_url), '') IS NULL
+     OR NEW.posting_first_seen_at IS NULL
+     OR NEW.posting_is_active IS NULL
+     OR NEW.company_id IS NULL
+     OR NULLIF(btrim(NEW.company_name), '') IS NULL
+     OR NULLIF(btrim(NEW.company_slug), '') IS NULL
+  THEN
+    RAISE EXCEPTION
+      'Cannot save posting % with an incomplete required snapshot',
+      NEW.job_posting_id;
+  END IF;
+
+  RETURN NEW;
+END
+$snapshot$;--> statement-breakpoint
+
+CREATE TRIGGER saved_job_snapshot_from_mirror_before_insert
+BEFORE INSERT ON public.saved_job
+FOR EACH ROW
+EXECUTE FUNCTION public.saved_job_snapshot_from_mirror();--> statement-breakpoint
+
+UPDATE public.saved_job AS sj
+SET
+  posting_title = jp.titles[1],
+  posting_source_url = jp.source_url,
+  posting_first_seen_at = jp.first_seen_at,
+  posting_is_active = jp.is_active,
+  posting_salary_min = jp.salary_min,
+  posting_salary_max = jp.salary_max,
+  posting_salary_currency = jp.salary_currency,
+  posting_salary_period = jp.salary_period,
+  company_id = c.id,
+  company_name = c.name,
+  company_slug = c.slug,
+  company_icon = c.icon
+FROM public.job_posting AS jp
+JOIN public.company AS c ON c.id = jp.company_id
+WHERE sj.job_posting_id = jp.id;--> statement-breakpoint
+
+DO $snapshot$
+DECLARE
+  saved_job_count bigint;
+  complete_snapshot_count bigint;
+BEGIN
+  SELECT
+    count(*),
+    count(*) FILTER (
+      WHERE NULLIF(btrim(posting_title), '') IS NOT NULL
+        AND NULLIF(btrim(posting_source_url), '') IS NOT NULL
+        AND posting_first_seen_at IS NOT NULL
+        AND posting_is_active IS NOT NULL
+        AND company_id IS NOT NULL
+        AND NULLIF(btrim(company_name), '') IS NOT NULL
+        AND NULLIF(btrim(company_slug), '') IS NOT NULL
+    )
+  INTO saved_job_count, complete_snapshot_count
+  FROM public.saved_job;
+
+  IF complete_snapshot_count <> saved_job_count THEN
+    RAISE EXCEPTION
+      'Saved-job expand failed: % of % required snapshots are complete',
+      complete_snapshot_count,
+      saved_job_count;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.saved_job'::regclass
+      AND confrelid = 'public.job_posting'::regclass
+      AND contype = 'f'
+  ) THEN
+    RAISE EXCEPTION
+      'Saved-job expand failed: job_posting FK must remain until contract';
+  END IF;
+END
+$snapshot$;

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -505,6 +505,13 @@
       "when": 1785750000000,
       "tag": "0083_reconcile_supabase_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 72,
+      "version": "7",
+      "when": 1785753600000,
+      "tag": "0084_saved_job_snapshot_expand",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx src/db/migrate.ts",
     "db:migrate:verify": "tsx scripts/verify-production-migration-baseline.ts",
+    "db:migrate:verify-expand": "tsx scripts/verify-saved-job-expand.ts",
     "db:verify-saved-job-typesense": "tsx scripts/verify-saved-job-typesense-coverage.ts",
     "db:seed": "tsx src/db/seed.ts",
     "db:push": "drizzle-kit push",

--- a/apps/web/scripts/verify-saved-job-expand.ts
+++ b/apps/web/scripts/verify-saved-job-expand.ts
@@ -1,0 +1,242 @@
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import dotenv from "dotenv";
+import postgres from "postgres";
+
+dotenv.config({ path: ".env.local", quiet: true });
+
+type Mode = "preflight" | "postflight" | "drift";
+
+const cliArgs = process.argv.slice(2).filter((argument) => argument !== "--");
+const mode = cliArgs[0] as Mode | undefined;
+const outputPath = cliArgs[1];
+if (mode !== "preflight" && mode !== "postflight" && mode !== "drift") {
+  throw new Error(
+    "Usage: tsx scripts/verify-saved-job-expand.ts <preflight|postflight|drift> [output.json]",
+  );
+}
+
+const databaseUrl = process.env.DATABASE_URL_UNPOOLED;
+if (!databaseUrl) {
+  throw new Error("DATABASE_URL_UNPOOLED must be set for production verification");
+}
+if (new URL(databaseUrl).port === "6543") {
+  throw new Error("Refusing production verification through the transaction pooler");
+}
+const verifiedDatabaseUrl = databaseUrl;
+
+const repairCreatedAt = 1_785_750_000_000;
+const expandCreatedAt = 1_785_753_600_000;
+const migrationHash = (filename: string) =>
+  createHash("sha256")
+    .update(readFileSync(resolve(process.cwd(), "drizzle", filename)))
+    .digest("hex");
+const repairHash = migrationHash("0083_reconcile_supabase_baseline.sql");
+const expandHash = migrationHash("0084_saved_job_snapshot_expand.sql");
+const verifiedLegacyLedger = {
+  rowCount: 72,
+  digest: "90545f8ccec9ae7a8cb21742c842e8d8",
+} as const;
+const snapshotColumns = [
+  "company_icon",
+  "company_id",
+  "company_name",
+  "company_slug",
+  "posting_first_seen_at",
+  "posting_is_active",
+  "posting_salary_currency",
+  "posting_salary_max",
+  "posting_salary_min",
+  "posting_salary_period",
+  "posting_source_url",
+  "posting_title",
+] as const;
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+async function main() {
+  const sql = postgres(verifiedDatabaseUrl, {
+    max: 1,
+    prepare: false,
+    connection: { application_name: `jobseek-saved-job-expand-${mode}` },
+  });
+
+  try {
+    const evidence = await sql.begin(async (tx) => {
+      await tx`SET TRANSACTION READ ONLY`;
+      await tx`SET LOCAL statement_timeout = '30s'`;
+
+      const [legacyLedger] = await tx<{ rowCount: number; digest: string }[]>`
+        SELECT
+          count(*)::integer AS "rowCount",
+          md5(
+            string_agg(
+              id::text || ':' || hash || ':' || created_at::text,
+              ',' ORDER BY id
+            )
+          ) AS digest
+        FROM drizzle.__drizzle_migrations
+        WHERE created_at <= 1779148800000
+      `;
+      const [ledger] = await tx<
+        { rowCount: number; latestCreatedAt: string; latestHash: string }[]
+      >`
+        SELECT
+          count(*)::integer AS "rowCount",
+          (array_agg(created_at::text ORDER BY created_at DESC, id DESC))[1]
+            AS "latestCreatedAt",
+          (array_agg(hash ORDER BY created_at DESC, id DESC))[1]
+            AS "latestHash"
+        FROM drizzle.__drizzle_migrations
+      `;
+      const [migrationRows] = await tx<
+        { repair: number; expand: number }[]
+      >`
+        SELECT
+          count(*) FILTER (
+            WHERE created_at = ${repairCreatedAt} AND hash = ${repairHash}
+          )::integer AS repair,
+          count(*) FILTER (
+            WHERE created_at = ${expandCreatedAt} AND hash = ${expandHash}
+          )::integer AS expand
+        FROM drizzle.__drizzle_migrations
+      `;
+      const columns = await tx<{ name: string }[]>`
+        SELECT attname AS name
+        FROM pg_attribute
+        WHERE attrelid = 'public.saved_job'::regclass
+          AND attname IN ${tx(snapshotColumns)}
+          AND NOT attisdropped
+        ORDER BY attname
+      `;
+      const [foreignKey] = await tx<{ count: number }[]>`
+        SELECT count(*)::integer AS count
+        FROM pg_constraint
+        WHERE conrelid = 'public.saved_job'::regclass
+          AND confrelid = 'public.job_posting'::regclass
+          AND contype = 'f'
+      `;
+      const [trigger] = await tx<{ count: number }[]>`
+        SELECT count(*)::integer AS count
+        FROM pg_trigger
+        WHERE tgrelid = 'public.saved_job'::regclass
+          AND tgname = 'saved_job_snapshot_from_mirror_before_insert'
+          AND tgenabled = 'O'
+          AND NOT tgisinternal
+      `;
+      const [source] = await tx<
+        { total: number; incompleteRequired: number }[]
+      >`
+        SELECT
+          count(*)::integer AS total,
+          count(*) FILTER (
+            WHERE NULLIF(btrim(jp.titles[1]), '') IS NULL
+               OR NULLIF(btrim(jp.source_url), '') IS NULL
+               OR jp.first_seen_at IS NULL
+               OR jp.is_active IS NULL
+               OR c.id IS NULL
+               OR NULLIF(btrim(c.name), '') IS NULL
+               OR NULLIF(btrim(c.slug), '') IS NULL
+          )::integer AS "incompleteRequired"
+        FROM public.saved_job AS sj
+        LEFT JOIN public.job_posting AS jp ON jp.id = sj.job_posting_id
+        LEFT JOIN public.company AS c ON c.id = jp.company_id
+      `;
+
+      const actualColumns = columns.map((column) => column.name);
+      const snapshots = actualColumns.length === snapshotColumns.length
+        ? (await tx<{ total: number; incompleteRequired: number }[]>`
+            SELECT
+              count(*)::integer AS total,
+              count(*) FILTER (
+                WHERE NULLIF(btrim(posting_title), '') IS NULL
+                   OR NULLIF(btrim(posting_source_url), '') IS NULL
+                   OR posting_first_seen_at IS NULL
+                   OR posting_is_active IS NULL
+                   OR company_id IS NULL
+                   OR NULLIF(btrim(company_name), '') IS NULL
+                   OR NULLIF(btrim(company_slug), '') IS NULL
+              )::integer AS "incompleteRequired"
+            FROM public.saved_job
+          `)[0]
+        : null;
+
+      assert(legacyLedger, "Could not read the legacy migration ledger");
+      assert(ledger, "Could not read the migration ledger");
+      assert(migrationRows, "Could not read reconciliation/expand ledger rows");
+      assert(foreignKey?.count === 1, "The saved_job → job_posting FK is not exact");
+      assert(source, "Could not audit saved-job sources");
+      assert(
+        legacyLedger.rowCount === verifiedLegacyLedger.rowCount &&
+          legacyLedger.digest === verifiedLegacyLedger.digest,
+        `Legacy migration ledger drifted: ${JSON.stringify(legacyLedger)}`,
+      );
+      assert(migrationRows.repair === 1, "The exact 0083 repair is not recorded once");
+      assert(
+        source.incompleteRequired === 0,
+        `${source.incompleteRequired} saved jobs lack required mirror source fields`,
+      );
+
+      if (mode === "preflight") {
+        assert(
+          ledger.rowCount === 73 &&
+            Number(ledger.latestCreatedAt) === repairCreatedAt &&
+            ledger.latestHash === repairHash,
+          `Expected the exact post-0083 ledger before expand: ${JSON.stringify(ledger)}`,
+        );
+        assert(migrationRows.expand === 0, "0084 is already recorded");
+        assert(actualColumns.length === 0, "Snapshot columns already exist before 0084");
+        assert(trigger?.count === 0, "Compatibility trigger exists before 0084");
+      } else {
+        assert(migrationRows.expand === 1, "The exact 0084 expand is not recorded once");
+        assert(
+          actualColumns.length === snapshotColumns.length &&
+            actualColumns.every((column, index) => column === snapshotColumns[index]),
+          `Saved-job snapshot columns differ: ${JSON.stringify(actualColumns)}`,
+        );
+        assert(trigger?.count === 1, "Compatibility trigger is not enabled exactly once");
+        assert(
+          snapshots?.total === source.total && snapshots.incompleteRequired === 0,
+          `Saved-job snapshots are incomplete: ${JSON.stringify(snapshots)}`,
+        );
+        if (mode === "postflight") {
+          assert(
+            ledger.rowCount === 74 &&
+              Number(ledger.latestCreatedAt) === expandCreatedAt &&
+              ledger.latestHash === expandHash,
+            `Unexpected immediate post-0084 ledger: ${JSON.stringify(ledger)}`,
+          );
+        }
+      }
+
+      return {
+        checkedAt: new Date().toISOString(),
+        mode,
+        legacyLedger,
+        ledger,
+        migrationRows,
+        expand: { createdAt: expandCreatedAt, hash: expandHash },
+        source,
+        snapshots,
+        snapshotColumns: actualColumns,
+        postingForeignKeys: foreignKey.count,
+        compatibilityTriggers: trigger?.count ?? 0,
+      };
+    });
+
+    const rendered = `${JSON.stringify(evidence, null, 2)}\n`;
+    if (outputPath) writeFileSync(outputPath, rendered, { mode: 0o600 });
+    process.stdout.write(rendered);
+  } finally {
+    await sql.end();
+  }
+}
+
+void main().catch((error: unknown) => {
+  console.error("Saved-job expand verification failed:", error);
+  process.exitCode = 1;
+});

--- a/apps/web/scripts/verify-saved-job-expand.ts
+++ b/apps/web/scripts/verify-saved-job-expand.ts
@@ -113,12 +113,25 @@ async function main() {
           AND NOT attisdropped
         ORDER BY attname
       `;
-      const [foreignKey] = await tx<{ count: number }[]>`
-        SELECT count(*)::integer AS count
+      const [foreignKey] = await tx<
+        { count: number; deleteAction: string | null; validated: boolean | null }[]
+      >`
+        SELECT
+          count(*)::integer AS count,
+          min(confdeltype::text) AS "deleteAction",
+          bool_and(convalidated) AS validated
         FROM pg_constraint
         WHERE conrelid = 'public.saved_job'::regclass
           AND confrelid = 'public.job_posting'::regclass
           AND contype = 'f'
+      `;
+      const [requiredCheck] = await tx<{ count: number }[]>`
+        SELECT count(*)::integer AS count
+        FROM pg_constraint
+        WHERE conrelid = 'public.saved_job'::regclass
+          AND conname = 'saved_job_required_snapshot_check'
+          AND contype = 'c'
+          AND convalidated
       `;
       const [trigger] = await tx<{ count: number }[]>`
         SELECT count(*)::integer AS count
@@ -169,6 +182,7 @@ async function main() {
       assert(ledger, "Could not read the migration ledger");
       assert(migrationRows, "Could not read reconciliation/expand ledger rows");
       assert(foreignKey?.count === 1, "The saved_job → job_posting FK is not exact");
+      assert(requiredCheck, "Could not audit the required snapshot CHECK");
       assert(source, "Could not audit saved-job sources");
       assert(
         legacyLedger.rowCount === verifiedLegacyLedger.rowCount &&
@@ -191,6 +205,11 @@ async function main() {
         assert(migrationRows.expand === 0, "0084 is already recorded");
         assert(actualColumns.length === 0, "Snapshot columns already exist before 0084");
         assert(trigger?.count === 0, "Compatibility trigger exists before 0084");
+        assert(
+          foreignKey.deleteAction === "c" && foreignKey.validated === true,
+          `Expected the validated cascading pre-expand FK: ${JSON.stringify(foreignKey)}`,
+        );
+        assert(requiredCheck.count === 0, "Required snapshot CHECK exists before 0084");
       } else {
         assert(migrationRows.expand === 1, "The exact 0084 expand is not recorded once");
         assert(
@@ -199,6 +218,11 @@ async function main() {
           `Saved-job snapshot columns differ: ${JSON.stringify(actualColumns)}`,
         );
         assert(trigger?.count === 1, "Compatibility trigger is not enabled exactly once");
+        assert(
+          foreignKey.deleteAction === "r" && foreignKey.validated === true,
+          `Expected the validated restrictive expand FK: ${JSON.stringify(foreignKey)}`,
+        );
+        assert(requiredCheck.count === 1, "Required snapshot CHECK is not validated once");
         assert(
           snapshots?.total === source.total && snapshots.incompleteRequired === 0,
           `Saved-job snapshots are incomplete: ${JSON.stringify(snapshots)}`,
@@ -223,7 +247,8 @@ async function main() {
         source,
         snapshots,
         snapshotColumns: actualColumns,
-        postingForeignKeys: foreignKey.count,
+        postingForeignKey: foreignKey,
+        requiredSnapshotChecks: requiredCheck.count,
         compatibilityTriggers: trigger?.count ?? 0,
       };
     });

--- a/apps/web/scripts/verify-saved-job-typesense-coverage.ts
+++ b/apps/web/scripts/verify-saved-job-typesense-coverage.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
 
 import dotenv from "dotenv";
@@ -21,6 +22,13 @@ type SavedPostingSource = {
 };
 
 type TypesensePostingDocument = Record<string, unknown>;
+
+// Cloudflare protects the public Typesense endpoint with a per-minute request
+// budget. Keep this proof below that budget so a complete saved-job audit does
+// not turn healthy documents into verifier-induced HTTP 429 failures.
+const REQUEST_INTERVAL_MS = 400;
+const RATE_LIMIT_FALLBACK_MS = 65_000;
+const RETRIEVE_ATTEMPTS = 3;
 
 const REQUIRED_TEXT_FIELDS = [
   ["id", "postingId"],
@@ -119,14 +127,27 @@ async function retrievePosting(
     `/collections/job_posting/documents/${encodeURIComponent(postingId)}`,
     baseUrl,
   );
-  const response = await fetch(url, {
-    headers: { "X-TYPESENSE-API-KEY": apiKey },
-    signal: AbortSignal.timeout(10_000),
-  });
-  if (!response.ok) {
-    throw new Error(`Typesense retrieve returned HTTP ${response.status}`);
+  for (let attempt = 1; attempt <= RETRIEVE_ATTEMPTS; attempt += 1) {
+    const response = await fetch(url, {
+      headers: { "X-TYPESENSE-API-KEY": apiKey },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (response.ok) {
+      return (await response.json()) as TypesensePostingDocument;
+    }
+    if (response.status !== 429 || attempt === RETRIEVE_ATTEMPTS) {
+      throw new Error(`Typesense retrieve returned HTTP ${response.status}`);
+    }
+
+    const retryAfter = Number(response.headers.get("retry-after"));
+    await delay(
+      Number.isFinite(retryAfter) && retryAfter > 0
+        ? retryAfter * 1_000
+        : RATE_LIMIT_FALLBACK_MS,
+    );
   }
-  return (await response.json()) as TypesensePostingDocument;
+
+  throw new Error("Typesense retrieve exhausted retries");
 }
 
 async function main() {
@@ -190,33 +211,27 @@ async function main() {
       fields: string[];
     }[] = [];
     let retrieved = 0;
-    const batchSize = 20;
-    for (let offset = 0; offset < rows.length; offset += batchSize) {
-      const batch = rows.slice(offset, offset + batchSize);
-      const documents = await Promise.all(
-        batch.map(async (row) => {
-          try {
-            return await retrievePosting(baseUrl.toString(), apiKey, row.postingId);
-          } catch (error) {
-            failures.push({
-              postingId: row.postingId,
-              kind: "retrieve",
-              fields: [error instanceof Error ? error.message : "retrieve failed"],
-            });
-            return null;
-          }
-        }),
-      );
-
-      for (const [index, document] of documents.entries()) {
-        if (!document) continue;
+    for (const [index, row] of rows.entries()) {
+      try {
+        const document = await retrievePosting(
+          baseUrl.toString(),
+          apiKey,
+          row.postingId,
+        );
         retrieved += 1;
-        const row = batch[index];
         const fields = comparePostingSnapshot(row, document);
         if (fields.length > 0) {
           failures.push({ postingId: row.postingId, kind: "parity", fields });
         }
+      } catch (error) {
+        failures.push({
+          postingId: row.postingId,
+          kind: "retrieve",
+          fields: [error instanceof Error ? error.message : "retrieve failed"],
+        });
       }
+
+      if (index + 1 < rows.length) await delay(REQUEST_INTERVAL_MS);
     }
 
     const retrievalFailures = failures.filter(

--- a/apps/web/src/db/__tests__/production-migration-safety.test.ts
+++ b/apps/web/src/db/__tests__/production-migration-safety.test.ts
@@ -20,7 +20,7 @@ describe("production migration safety", () => {
       "0081_private_watchlists_and_general_interviews",
     );
     expect(tags).not.toContain("0082_add_active_job_company_index");
-    expect(tags.at(-1)).toBe("0083_reconcile_supabase_baseline");
+    expect(tags).toContain("0083_reconcile_supabase_baseline");
   });
 
   it("keeps transaction ownership with Drizzle", () => {

--- a/apps/web/src/db/__tests__/saved-job-snapshot-expand-migration.test.ts
+++ b/apps/web/src/db/__tests__/saved-job-snapshot-expand-migration.test.ts
@@ -39,18 +39,27 @@ describe("0084 saved-job snapshot expand", () => {
     expect(verification).not.toContain("company_icon");
   });
 
-  it("retains the outbound posting FK throughout the expand phase", () => {
-    expect(migration).not.toMatch(/DROP CONSTRAINT/i);
-    expect(migration).toContain("job_posting FK must remain until contract");
+  it("retains a restrictive outbound posting FK throughout expand", () => {
+    expect(migration).toContain(
+      "DROP CONSTRAINT saved_job_job_posting_id_job_posting_id_fk",
+    );
+    expect(migration).toContain("ON DELETE RESTRICT");
+    expect(migration).toContain(
+      "restrictive job_posting FK must remain until contract",
+    );
 
     const config = getTableConfig(savedJob);
     expect(config.foreignKeys).toHaveLength(2);
-    expect(
-      config.foreignKeys.some(
+    const postingForeignKey = config.foreignKeys.find(
         (foreignKey) =>
           getTableName(foreignKey.reference().foreignTable) === "job_posting",
-      ),
-    ).toBe(true);
+    );
+    expect(postingForeignKey?.onDelete).toBe("restrict");
+  });
+
+  it("validates a temporary required-snapshot check", () => {
+    expect(migration).toContain("saved_job_required_snapshot_check");
+    expect(migration).toContain("required snapshot CHECK is not validated");
   });
 
   it("registers only the expand migration after the baseline repair", () => {

--- a/apps/web/src/db/__tests__/saved-job-snapshot-expand-migration.test.ts
+++ b/apps/web/src/db/__tests__/saved-job-snapshot-expand-migration.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { getTableName } from "drizzle-orm";
+import { getTableConfig } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+
+import { savedJob } from "@/db/schema";
+
+const migration = readFileSync(
+  resolve(process.cwd(), "drizzle/0084_saved_job_snapshot_expand.sql"),
+  "utf8",
+);
+
+describe("0084 saved-job snapshot expand", () => {
+  it("protects old-app inserts before backfilling", () => {
+    const triggerPosition = migration.indexOf(
+      "CREATE TRIGGER saved_job_snapshot_from_mirror_before_insert",
+    );
+    const backfillPosition = migration.indexOf("UPDATE public.saved_job AS sj");
+
+    expect(triggerPosition).toBeGreaterThan(0);
+    expect(backfillPosition).toBeGreaterThan(triggerPosition);
+    expect(migration).toContain("BEFORE INSERT ON public.saved_job");
+    expect(migration).toContain("incomplete required snapshot");
+  });
+
+  it("treats salary and icon as optional but verifies required identity", () => {
+    const verification = migration.slice(migration.lastIndexOf("DO $snapshot$"));
+
+    expect(verification).toContain("posting_title");
+    expect(verification).toContain("posting_source_url");
+    expect(verification).toContain("posting_first_seen_at");
+    expect(verification).toContain("posting_is_active");
+    expect(verification).toContain("company_id");
+    expect(verification).toContain("company_name");
+    expect(verification).toContain("company_slug");
+    expect(verification).not.toContain("posting_salary_min");
+    expect(verification).not.toContain("company_icon");
+  });
+
+  it("retains the outbound posting FK throughout the expand phase", () => {
+    expect(migration).not.toMatch(/DROP CONSTRAINT/i);
+    expect(migration).toContain("job_posting FK must remain until contract");
+
+    const config = getTableConfig(savedJob);
+    expect(config.foreignKeys).toHaveLength(2);
+    expect(
+      config.foreignKeys.some(
+        (foreignKey) =>
+          getTableName(foreignKey.reference().foreignTable) === "job_posting",
+      ),
+    ).toBe(true);
+  });
+
+  it("registers only the expand migration after the baseline repair", () => {
+    const journal = JSON.parse(
+      readFileSync(resolve(process.cwd(), "drizzle/meta/_journal.json"), "utf8"),
+    ) as { entries: { tag: string }[] };
+    const tags = journal.entries.map((entry) => entry.tag);
+
+    expect(tags.at(-2)).toBe("0083_reconcile_supabase_baseline");
+    expect(tags.at(-1)).toBe("0084_saved_job_snapshot_expand");
+    expect(tags).not.toContain("0085_saved_job_snapshot_contract");
+  });
+});

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -579,6 +579,20 @@ export const savedJob = pgTable(
       .notNull()
       .references(() => jobPosting.id, { onDelete: "cascade" }),
     savedAt: timestamp("saved_at", { withTimezone: true }).defaultNow().notNull(),
+    // Nullable during the expand/app phases. 0085 makes the required snapshot
+    // fields NOT NULL only after dual-write/read has been proven in production.
+    postingTitle: text("posting_title"),
+    postingSourceUrl: text("posting_source_url"),
+    postingFirstSeenAt: timestamp("posting_first_seen_at", { withTimezone: true }),
+    postingIsActive: boolean("posting_is_active"),
+    postingSalaryMin: integer("posting_salary_min"),
+    postingSalaryMax: integer("posting_salary_max"),
+    postingSalaryCurrency: text("posting_salary_currency"),
+    postingSalaryPeriod: text("posting_salary_period"),
+    companyId: uuid("company_id"),
+    companyName: text("company_name"),
+    companySlug: text("company_slug"),
+    companyIcon: text("company_icon"),
 
     // ── Application tracker fields ──
     status: text("status", {

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -577,7 +577,7 @@ export const savedJob = pgTable(
       .references(() => user.id, { onDelete: "cascade" }),
     jobPostingId: uuid("job_posting_id")
       .notNull()
-      .references(() => jobPosting.id, { onDelete: "cascade" }),
+      .references(() => jobPosting.id, { onDelete: "restrict" }),
     savedAt: timestamp("saved_at", { withTimezone: true }).defaultNow().notNull(),
     // Nullable during the expand/app phases. 0085 makes the required snapshot
     // fields NOT NULL only after dual-write/read has been proven in production.

--- a/docs/19-data-backup-recovery.md
+++ b/docs/19-data-backup-recovery.md
@@ -396,8 +396,10 @@ logical dump of this exact boundary:
 `subscription` table, and all Murmur tables are excluded. Before dumping, the
 job queries PostgreSQL's FK catalog and refuses to run if any included table
 points to an excluded table. In particular, the first production run is gated
-on migration `0083_saved_job_snapshot`, which removes the current
-`saved_job -> job_posting` FK only after snapshotting every saved posting.
+on contract migration `0085_saved_job_snapshot_contract`. That migration runs
+only after the 0084 expand phase and snapshot-writing app release have been
+verified, then removes the remaining `saved_job -> job_posting` FK after
+catching up and asserting every required saved-posting snapshot.
 
 The job fingerprints every allowlisted table as a row count plus a deterministic
 aggregate hash and records the Drizzle migration sequence state. It runs the
@@ -518,11 +520,11 @@ The normal replacement gate for any future legacy backup retirement is:
 - recovery evidence and measured recovery time are recorded in the audit.
 
 For the Supabase Pro-to-Free downgrade, the web database gate additionally
-requires: migration `0083_saved_job_snapshot` deployed with every existing
-saved row populated; one successful `web-postgresql` backup; one clean restore
-with exact fingerprints and mutation smoke; the six-hour timer enabled with a
-visible next run; and live failure/freshness telemetry. Only then may #6170
-drop crawler-mirror data.
+requires: contract migration `0085_saved_job_snapshot_contract` deployed with
+every existing saved row populated and the posting FK removed; one successful
+`web-postgresql` backup; one clean restore with exact fingerprints and mutation
+smoke; the six-hour timer enabled with a visible next run; and live
+failure/freshness telemetry. Only then may #6170 drop crawler-mirror data.
 
 Current state as of 2026-07-23: off-host backups, repository validation,
 isolated restores, measured recovery evidence, enabled schedules, visible next

--- a/docs/20-supabase-free-downgrade.md
+++ b/docs/20-supabase-free-downgrade.md
@@ -69,3 +69,9 @@ sequence is:
 Salary and icon fields may remain nullable. Posting title, source URL,
 first-seen timestamp, active state, and company identity/name/slug must be
 complete before the contract phase.
+
+Production source evidence collected read-only on 2026-08-03 shows 262 saved
+jobs and zero missing required source fields. Salary is absent for 229 rows and
+therefore remains intentionally nullable. Migration 0084 installs the old-app
+compatibility trigger before its backfill and fails unless every required
+snapshot is complete and the outbound posting FK still exists.


### PR DESCRIPTION
## Summary

First rollout-safe phase of the saved-job cutover. The production migration baseline and Typesense snapshot prerequisites are now proven.

- adds nullable snapshot columns in `0084_saved_job_snapshot_expand`;
- installs a `BEFORE INSERT` compatibility trigger before backfill so old web instances cannot create snapshot-less rows;
- backfills from the still-live `job_posting` + `company` mirror;
- fails unless every required snapshot is complete;
- replaces the cascading `saved_job → job_posting` FK with validated `ON DELETE RESTRICT`;
- keeps salary and company icon nullable;
- adds exact pre/postflight/drift evidence for 0084;
- advances the reviewer-gated workflow confirmation to `APPLY-0084`;
- fixes the saved-posting verifier to respect the production Typesense edge rate limit;
- corrects the backup runbook so backup/restore remains gated on the later 0085 contract.

Refs #6181, #6169, #6165. Supersedes the unsafe combined migration in #6174.

## Production prerequisite evidence

- exact 0083 ledger repair applied and independent drift verification passed;
- crawler 0.13.206 deployed successfully: https://github.com/colophon-group/jobseek/actions/runs/30826883590;
- fenced full Typesense backfill completed 2,585,004 postings in 39 minutes with clean host hygiene: https://github.com/colophon-group/jobseek/actions/runs/30827402506;
- steady exporter resumed, drained the post-cutoff backlog to zero, and dual-wrote every catch-up batch without failures;
- read-only 0084 preflight on 2026-08-03: 73-row exact ledger, 262 saved jobs, zero incomplete source snapshots, one validated cascading FK, no premature columns/trigger/check;
- final saved-posting gate on 2026-08-03:
  - 262 saved jobs;
  - 260 unique postings;
  - 260 documents retrieved;
  - 0 retrieval failures;
  - 0 parity failures;
  - posting-ID digest `12ab2feece45a872057b86abcb87be03e44b8fabe71ffd0670191d6fc140e6ad`.

Two historic Supabase mirror rows differed from authoritative local PostgreSQL after the backfill. Typesense matched local exactly; both mirror rows were repaired through the existing database-fenced, idempotent exporter upsert, then the complete 260-document gate passed. No user-owned table was changed.

## Compatibility contract

1. Merge this PR.
2. Dispatch **Web Database Migrations** from `main` with `apply` / `APPLY-0084` and approve `production-migrations`.
3. Prove the 0084 hash, 12 columns, enabled trigger, zero incomplete required snapshots, and one validated restrictive posting FK.
4. Deploy the separate snapshot-write/read app PR #6219 and run application canaries.
5. Only after production evidence, apply a separate 0085 contract migration to catch up, enforce required fields, remove the trigger, and drop the FK.
6. Only after 0085 may the encrypted web backup and isolated restore run.

## Verification

- expand/migration safety tests: 2 files / 9 tests passed;
- Typesense coverage verifier tests: 1 file / 2 tests passed;
- TypeScript: passed;
- targeted ESLint: passed;
- full Required CI: passed;
- pre-commit/pre-push hooks: passed.