### PR TITLE
Cut saved jobs over to durable snapshots

### DIFF
--- a/apps/web/src/db/__tests__/supabase-posting-read-cutover.test.ts
+++ b/apps/web/src/db/__tests__/supabase-posting-read-cutover.test.ts
@@ -1,0 +1,38 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const source = (path: string) => readFileSync(join(root, path), "utf8");
+
+describe("Supabase posting read cutover", () => {
+  it.each([
+    "src/lib/actions/saved-jobs.ts",
+    "src/lib/actions/my-jobs.ts",
+  ])("%s reads only saved-job-owned display fields", (path) => {
+    const contents = source(path);
+    const readSection = path.endsWith("my-jobs.ts")
+      ? contents.slice(
+          contents.indexOf("export async function getMyJobs"),
+          contents.indexOf("export async function updateJobStatus"),
+        )
+      : contents.slice(contents.indexOf("export async function getSavedJobs"));
+    const schemaImport =
+      contents.match(/import\s+\{([^}]*)\}\s+from\s+"@\/db\/schema"/)?.[1] ?? "";
+
+    expect(schemaImport).not.toMatch(/\b(jobPosting|company)\b/);
+    expect(readSection).not.toContain(".innerJoin(");
+  });
+
+  it("posting detail delegates to Typesense without crawler-table SQL", () => {
+    const contents = source("src/lib/services/search.ts");
+    const detailSection = contents.slice(
+      contents.indexOf("export async function getPostingDetail"),
+      contents.indexOf("export async function searchJobs"),
+    );
+
+    expect(detailSection).toContain("fetchIndexedPostingDetail");
+    expect(detailSection).not.toContain("db.execute");
+    expect(detailSection).not.toMatch(/FROM\s+(job_posting|company|location)/i);
+  });
+});

--- a/apps/web/src/lib/actions/__tests__/my-jobs-interview-count-batch.test.ts
+++ b/apps/web/src/lib/actions/__tests__/my-jobs-interview-count-batch.test.ts
@@ -16,7 +16,7 @@
  * `idx_ai_saved_job_round`), but cold pool burns ~50–150 ms.
  *
  * Post-fix shape:
- *   1. Outer SELECT joins savedJob + jobPosting + company, projecting
+ *   1. Outer SELECT reads the savedJob-owned display snapshot, projecting
  *      everything EXCEPT interviewCount. Up to `limit` rows.
  *   2. Single `SELECT saved_job_id, count(*) … WHERE saved_job_id =
  *      ANY($1) GROUP BY saved_job_id` over the page's ids. Postgres
@@ -56,6 +56,7 @@ const mocks = vi.hoisted(() => {
   };
   return {
     getSessionUserId: vi.fn(),
+    fetchIndexedPostingStates: vi.fn(),
     // Queue of select-result rows in declaration order. Each entry is
     // one `db.select(...).from(...)…` chain. The chain captures which
     // table was hit and resolves with `rows`.
@@ -76,6 +77,10 @@ const mocks = vi.hoisted(() => {
 
 vi.mock("@/lib/sessionCache", () => ({
   getSessionUserId: mocks.getSessionUserId,
+}));
+
+vi.mock("@/lib/search/typesense-posting-detail", () => ({
+  fetchIndexedPostingStates: mocks.fetchIndexedPostingStates,
 }));
 
 vi.mock("@/db/schema", () => ({
@@ -233,6 +238,7 @@ beforeEach(() => {
   mocks.selectQueue = [];
   mocks.selectCalls = [];
   mocks.getSessionUserId.mockResolvedValue(USER_ID);
+  mocks.fetchIndexedPostingStates.mockResolvedValue(new Map());
 });
 
 afterEach(() => {
@@ -321,6 +327,36 @@ describe("#3172 — getMyJobs batches interviewCount via GROUP BY", () => {
       { id: "sj-3", ic: 2 },
       { id: "sj-4", ic: 3 },
       { id: "sj-5", ic: 0 },
+    ]);
+  });
+
+  it("uses live indexed active state and snapshot fallback for a missing hit", async () => {
+    const pageRows = [
+      { ...fakeOuterRow({ id: "sj-1" }), postingIsActive: true },
+      { ...fakeOuterRow({ id: "sj-2" }), postingIsActive: false },
+      { ...fakeOuterRow({ id: "sj-3" }), postingIsActive: false },
+    ];
+    mocks.selectQueue.push({ rows: [{ count: 3 }] });
+    mocks.selectQueue.push({ rows: pageRows });
+    mocks.selectQueue.push({ rows: [] });
+    mocks.fetchIndexedPostingStates.mockResolvedValue(
+      new Map([
+        ["posting-sj-1", { isActive: false }],
+        ["posting-sj-2", { isActive: true }],
+      ]),
+    );
+
+    const { jobs } = await getMyJobs({ offset: 0, limit: 20 });
+
+    expect(jobs.map((job) => job.posting.isActive)).toEqual([
+      false,
+      true,
+      false,
+    ]);
+    expect(mocks.fetchIndexedPostingStates).toHaveBeenCalledWith([
+      "posting-sj-1",
+      "posting-sj-2",
+      "posting-sj-3",
     ]);
   });
 

--- a/apps/web/src/lib/actions/__tests__/saved-jobs-snapshot.test.ts
+++ b/apps/web/src/lib/actions/__tests__/saved-jobs-snapshot.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  getSessionUserId: vi.fn(),
+  fetchIndexedPostingStates: vi.fn(),
+  selectQueue: [] as unknown[][],
+}));
+
+vi.mock("@/lib/sessionCache", () => ({
+  getSessionUserId: mocks.getSessionUserId,
+}));
+
+vi.mock("@/lib/search/typesense-posting-detail", () => ({
+  fetchIndexedPostingSnapshot: vi.fn(),
+  fetchIndexedPostingStates: mocks.fetchIndexedPostingStates,
+}));
+
+vi.mock("@/db/schema", () => {
+  const column = (name: string) => ({ name });
+  return {
+    savedJob: {
+      id: column("id"),
+      userId: column("user_id"),
+      jobPostingId: column("job_posting_id"),
+      savedAt: column("saved_at"),
+      status: column("status"),
+      postingTitle: column("posting_title"),
+      postingSourceUrl: column("posting_source_url"),
+      postingFirstSeenAt: column("posting_first_seen_at"),
+      postingIsActive: column("posting_is_active"),
+      companyId: column("company_id"),
+      companyName: column("company_name"),
+      companySlug: column("company_slug"),
+      companyIcon: column("company_icon"),
+    },
+  };
+});
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn(),
+  and: vi.fn(),
+  desc: vi.fn(),
+  count: vi.fn(),
+}));
+
+vi.mock("@/db", () => {
+  const selectChain = () => {
+    const chain: Record<string, unknown> = {};
+    for (const method of ["from", "where", "orderBy", "offset", "limit"]) {
+      chain[method] = () => chain;
+    }
+    chain.then = (
+      resolve: (value: unknown[]) => unknown,
+      reject?: (error: unknown) => unknown,
+    ) => {
+      const rows = mocks.selectQueue.shift();
+      if (!rows) {
+        return Promise.reject(new Error("select queue empty")).then(
+          resolve,
+          reject,
+        );
+      }
+      return Promise.resolve(rows).then(resolve, reject);
+    };
+    return chain;
+  };
+  return { db: { select: () => selectChain() } };
+});
+
+import { getSavedJobs } from "../saved-jobs";
+
+const savedAt = new Date("2026-07-01T12:00:00Z");
+const snapshotRow = {
+  id: "saved-1",
+  savedAt,
+  postingId: "posting-1",
+  postingTitle: "Archived role",
+  postingSourceUrl: "https://example.com/archived",
+  postingFirstSeenAt: new Date("2026-01-01T12:00:00Z"),
+  postingIsActive: false,
+  companyId: "company-1",
+  companyName: "Snapshot Company",
+  companySlug: "snapshot-company",
+  companyIcon: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.selectQueue = [];
+  mocks.getSessionUserId.mockResolvedValue("user-1");
+  mocks.fetchIndexedPostingStates.mockResolvedValue(new Map());
+});
+
+describe("saved-job snapshot reads", () => {
+  it("keeps a missing-index inactive posting visible from its snapshot", async () => {
+    mocks.selectQueue.push([{ count: 1 }], [snapshotRow]);
+
+    const result = await getSavedJobs({ offset: 0, limit: 20 });
+
+    expect(result.jobs).toHaveLength(1);
+    expect(result.jobs[0]).toMatchObject({
+      posting: {
+        id: "posting-1",
+        title: "Archived role",
+        isActive: false,
+      },
+      company: {
+        id: "company-1",
+        name: "Snapshot Company",
+        slug: "snapshot-company",
+      },
+    });
+  });
+
+  it("uses live active state when available and snapshot state on an outage", async () => {
+    mocks.selectQueue.push([{ count: 1 }], [snapshotRow]);
+    mocks.fetchIndexedPostingStates.mockResolvedValueOnce(
+      new Map([["posting-1", { isActive: true }]]),
+    );
+
+    const live = await getSavedJobs({ offset: 0, limit: 20 });
+    expect(live.jobs[0].posting.isActive).toBe(true);
+
+    mocks.selectQueue.push([{ count: 1 }], [snapshotRow]);
+    mocks.fetchIndexedPostingStates.mockResolvedValueOnce(new Map());
+    const degraded = await getSavedJobs({ offset: 0, limit: 20 });
+    expect(degraded.jobs[0].posting.isActive).toBe(false);
+  });
+
+  it("surfaces an incomplete persisted snapshot instead of fabricating links", async () => {
+    mocks.selectQueue.push(
+      [{ count: 1 }],
+      [{ ...snapshotRow, companySlug: null }],
+    );
+
+    await expect(getSavedJobs({ offset: 0, limit: 20 })).rejects.toThrow(
+      "incomplete company_slug",
+    );
+  });
+});

--- a/apps/web/src/lib/actions/__tests__/toggle-race.test.ts
+++ b/apps/web/src/lib/actions/__tests__/toggle-race.test.ts
@@ -15,10 +15,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
  * un-handled Postgres `23505` from `idx_sj_user_posting`. The UNIQUE
  * index protected the data but the client saw a 500.
  *
- * Fix matches the #3268 retry-on-conflict shape: try INSERT first,
- * catch `23505` scoped to the specific UNIQUE constraint, and treat
- * the conflict as "toggle was ON, transition to OFF" — DELETE the
- * matching row and return `saved/starred: false`.
+ * The saved-job fix deletes first so an existing save can be removed
+ * even when Typesense is unavailable. If nothing was deleted, it fetches
+ * a durable snapshot and then uses the #3268 retry-on-conflict shape:
+ * catch `23505` scoped to the specific UNIQUE constraint, delete the
+ * racing winner, and return `saved: false`. Starred companies retain the
+ * insert-first implementation because they do not need an external snapshot.
  *
  * Test strategy
  * -------------
@@ -150,33 +152,43 @@ const mocks = vi.hoisted(() => {
     const isSavedJob = table === savedJobRef;
     const isFollowedCompany = table === followedCompanyRef;
     return {
-      where: async (clause: unknown) => {
-        await Promise.resolve();
-        const params = extractParams(clause);
-        const strs = params.filter((p): p is string => typeof p === "string");
-        if (isSavedJob) {
-          const [userId, postingId] = strs;
-          if (!userId || !postingId) return;
-          for (let i = savedJobTable.length - 1; i >= 0; i--) {
-            const r = savedJobTable[i];
-            if (r.user_id === userId && r.job_posting_id === postingId) {
-              savedJobTable.splice(i, 1);
+      where: (clause: unknown) => {
+        const exec = async (returningId: boolean): Promise<unknown[]> => {
+          await Promise.resolve();
+          const params = extractParams(clause);
+          const strs = params.filter((p): p is string => typeof p === "string");
+          if (isSavedJob) {
+            const [userId, postingId] = strs;
+            if (!userId || !postingId) return [];
+            const removed: SavedJobRow[] = [];
+            for (let i = savedJobTable.length - 1; i >= 0; i--) {
+              const r = savedJobTable[i];
+              if (r.user_id === userId && r.job_posting_id === postingId) {
+                removed.push(...savedJobTable.splice(i, 1));
+              }
             }
+            return returningId ? removed.map((row) => ({ id: row.id })) : [];
           }
-          return;
-        }
-        if (isFollowedCompany) {
-          const [userId, companyId] = strs;
-          if (!userId || !companyId) return;
-          for (let i = followedCompanyTable.length - 1; i >= 0; i--) {
-            const r = followedCompanyTable[i];
-            if (r.user_id === userId && r.company_id === companyId) {
-              followedCompanyTable.splice(i, 1);
+          if (isFollowedCompany) {
+            const [userId, companyId] = strs;
+            if (!userId || !companyId) return [];
+            for (let i = followedCompanyTable.length - 1; i >= 0; i--) {
+              const r = followedCompanyTable[i];
+              if (r.user_id === userId && r.company_id === companyId) {
+                followedCompanyTable.splice(i, 1);
+              }
             }
+            return [];
           }
-          return;
-        }
-        throw new Error("dbDelete mock: unknown table");
+          throw new Error("dbDelete mock: unknown table");
+        };
+        return {
+          returning: () => exec(true),
+          then: (
+            resolve: (value: unknown) => unknown,
+            reject?: (reason?: unknown) => unknown,
+          ) => exec(false).then(resolve, reject),
+        };
       },
     };
   };
@@ -243,6 +255,7 @@ const mocks = vi.hoisted(() => {
       followedCompanyRef = f;
     },
     getSessionUserId: vi.fn(),
+    fetchIndexedPostingSnapshot: vi.fn(),
     dbInsert,
     dbDelete,
     dbSelect,
@@ -295,6 +308,11 @@ vi.mock("@/lib/sessionCache", () => ({
   getSessionUserId: mocks.getSessionUserId,
 }));
 
+vi.mock("@/lib/search/typesense-posting-detail", () => ({
+  fetchIndexedPostingSnapshot: mocks.fetchIndexedPostingSnapshot,
+  fetchIndexedPostingStates: vi.fn().mockResolvedValue(new Map()),
+}));
+
 vi.mock("@/db", () => ({
   db: {
     select: () => mocks.dbSelect(),
@@ -308,10 +326,28 @@ vi.mock("@/db", () => ({
 // and `followedCompany` from `@/db/schema`; we grab the same module
 // objects here so dispatch by identity matches.
 beforeEach(async () => {
+  vi.clearAllMocks();
   const schema = await import("@/db/schema");
   mocks.setTableRefs(schema.savedJob, schema.followedCompany);
   mocks.reset();
   mocks.getSessionUserId.mockResolvedValue("user-1");
+  mocks.fetchIndexedPostingSnapshot.mockResolvedValue({
+    id: "posting-1",
+    title: "Engineer",
+    sourceUrl: "https://example.com/jobs/1",
+    firstSeenAt: "2026-01-01T00:00:00.000Z",
+    isActive: true,
+    salaryMin: null,
+    salaryMax: null,
+    salaryCurrency: null,
+    salaryPeriod: null,
+    company: {
+      id: "company-1",
+      name: "Example",
+      slug: "example",
+      icon: null,
+    },
+  });
 });
 
 afterEach(() => {
@@ -332,9 +368,11 @@ describe("#3179 — toggleSavedJob race", () => {
   it("second toggle (row exists) deletes and returns saved=false", async () => {
     const { toggleSavedJob } = await import("@/lib/actions/saved-jobs");
     await toggleSavedJob("posting-1");
+    mocks.fetchIndexedPostingSnapshot.mockClear();
     const r = await toggleSavedJob("posting-1");
     expect(r.saved).toBe(false);
     expect(mocks.savedJobTable.length).toBe(0);
+    expect(mocks.fetchIndexedPostingSnapshot).not.toHaveBeenCalled();
   });
 
   it("two concurrent toggles on empty state — one saved, one un-saved, no exception", async () => {
@@ -358,7 +396,7 @@ describe("#3179 — toggleSavedJob race", () => {
     expect(mocks.savedJobTable.length).toBe(0);
   });
 
-  it("two concurrent toggles on existing state — both delete, idempotent", async () => {
+  it("two concurrent toggles on existing state serialize to off then on", async () => {
     const { toggleSavedJob } = await import("@/lib/actions/saved-jobs");
     // Seed: row already exists.
     await toggleSavedJob("posting-1");
@@ -369,12 +407,32 @@ describe("#3179 — toggleSavedJob race", () => {
       toggleSavedJob("posting-1"),
     ]);
 
-    // Both INSERTs collide with the pre-existing row. Both fall
-    // through to DELETE — one removes the row, the other finds nothing
-    // to remove (silent no-op). Both return saved=false.
-    expect(a.saved).toBe(false);
-    expect(b.saved).toBe(false);
-    expect(mocks.savedJobTable.length).toBe(0);
+    // One caller removes the existing row. The other observes the now-empty
+    // state and creates a new snapshot row, matching two serialized toggles.
+    expect([a.saved, b.saved].sort()).toEqual([false, true]);
+    expect(mocks.savedJobTable.length).toBe(1);
+  });
+
+  it("can unsave an existing row while Typesense is unavailable", async () => {
+    const { toggleSavedJob } = await import("@/lib/actions/saved-jobs");
+    await toggleSavedJob("posting-1");
+    mocks.fetchIndexedPostingSnapshot.mockClear();
+    mocks.fetchIndexedPostingSnapshot.mockRejectedValue(
+      new Error("Typesense unavailable"),
+    );
+
+    await expect(toggleSavedJob("posting-1")).resolves.toEqual({ saved: false });
+    expect(mocks.savedJobTable).toHaveLength(0);
+    expect(mocks.fetchIndexedPostingSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("does not create a save when its Typesense snapshot is unavailable", async () => {
+    const { toggleSavedJob } = await import("@/lib/actions/saved-jobs");
+    const outage = new Error("Typesense unavailable");
+    mocks.fetchIndexedPostingSnapshot.mockRejectedValue(outage);
+
+    await expect(toggleSavedJob("posting-1")).rejects.toBe(outage);
+    expect(mocks.savedJobTable).toHaveLength(0);
   });
 
   it("propagates non-23505 errors unchanged", async () => {

--- a/apps/web/src/lib/actions/my-jobs.ts
+++ b/apps/web/src/lib/actions/my-jobs.ts
@@ -2,9 +2,10 @@
 
 import { eq, and, desc, asc, count, inArray, sql } from "drizzle-orm";
 import { db } from "@/db";
-import { savedJob, jobPosting, company, applicationInterview } from "@/db/schema";
+import { savedJob, applicationInterview } from "@/db/schema";
 import { getSessionUserId } from "@/lib/sessionCache";
-import { normalizePostingTitle } from "@/lib/posting-title";
+import { decodeSavedJobSnapshot } from "@/lib/saved-job-snapshot";
+import { fetchIndexedPostingStates } from "@/lib/search/typesense-posting-detail";
 import {
   type ApplicationStatus,
   type InterviewType,
@@ -95,14 +96,14 @@ export async function getMyJobs(params: {
     status_changed_at: savedJob.statusChangedAt,
     saved_at: savedJob.savedAt,
     status: savedJob.status,
-    company_name: company.name,
+    company_name: savedJob.companyName,
   }[sortBy];
 
   const dirFn = sortDir === "asc" ? asc : desc;
 
   const orderClauses = [];
   if (groupByCompany) {
-    orderClauses.push(asc(company.name));
+    orderClauses.push(asc(savedJob.companyName));
   }
   orderClauses.push(dirFn(sortCol));
 
@@ -118,23 +119,21 @@ export async function getMyJobs(params: {
       salaryMaxOverride: savedJob.salaryMaxOverride,
       salaryCurrencyOverride: savedJob.salaryCurrencyOverride,
       salaryPeriodOverride: savedJob.salaryPeriodOverride,
-      postingId: jobPosting.id,
-      postingTitle: sql<string | null>`${jobPosting.titles}[1]`,
-      postingSourceUrl: jobPosting.sourceUrl,
-      postingFirstSeenAt: jobPosting.firstSeenAt,
-      postingIsActive: jobPosting.isActive,
-      postingSalaryMin: jobPosting.salaryMin,
-      postingSalaryMax: jobPosting.salaryMax,
-      postingSalaryCurrency: jobPosting.salaryCurrency,
-      postingSalaryPeriod: jobPosting.salaryPeriod,
-      companyId: company.id,
-      companyName: company.name,
-      companySlug: company.slug,
-      companyIcon: company.icon,
+      postingId: savedJob.jobPostingId,
+      postingTitle: savedJob.postingTitle,
+      postingSourceUrl: savedJob.postingSourceUrl,
+      postingFirstSeenAt: savedJob.postingFirstSeenAt,
+      postingIsActive: savedJob.postingIsActive,
+      postingSalaryMin: savedJob.postingSalaryMin,
+      postingSalaryMax: savedJob.postingSalaryMax,
+      postingSalaryCurrency: savedJob.postingSalaryCurrency,
+      postingSalaryPeriod: savedJob.postingSalaryPeriod,
+      companyId: savedJob.companyId,
+      companyName: savedJob.companyName,
+      companySlug: savedJob.companySlug,
+      companyIcon: savedJob.companyIcon,
     })
     .from(savedJob)
-    .innerJoin(jobPosting, eq(savedJob.jobPostingId, jobPosting.id))
-    .innerJoin(company, eq(jobPosting.companyId, company.id))
     .where(where)
     .orderBy(...orderClauses)
     .offset(offset)
@@ -156,6 +155,9 @@ export async function getMyJobs(params: {
   // Saved jobs with zero interviews are absent from the result and
   // default to count = 0.
   const savedJobIds = rows.map((r) => r.id);
+  const postingStatesPromise = fetchIndexedPostingStates(
+    rows.map((row) => row.postingId),
+  );
   const interviewCounts = new Map<string, number>();
   if (savedJobIds.length > 0) {
     const countRows = await db
@@ -171,38 +173,32 @@ export async function getMyJobs(params: {
       interviewCounts.set(cr.savedJobId, cr.count);
     }
   }
+  const postingStates = await postingStatesPromise;
 
-  const jobs: MyJobEntry[] = rows.map((r) => ({
-    id: r.id,
-    savedAt: r.savedAt.toISOString(),
-    status: r.status as ApplicationStatus,
-    statusChangedAt: r.statusChangedAt.toISOString(),
-    appliedAt: r.appliedAt?.toISOString() ?? null,
-    interviewCount: interviewCounts.get(r.id) ?? 0,
-    posting: {
-      id: r.postingId,
-      title: normalizePostingTitle(r.postingTitle),
-      sourceUrl: r.postingSourceUrl,
-      firstSeenAt: r.postingFirstSeenAt.toISOString(),
-      isActive: r.postingIsActive,
-      salaryMin: r.postingSalaryMin,
-      salaryMax: r.postingSalaryMax,
-      salaryCurrency: r.postingSalaryCurrency,
-      salaryPeriod: r.postingSalaryPeriod,
-    },
-    company: {
-      id: r.companyId,
-      name: r.companyName,
-      slug: r.companySlug,
-      icon: r.companyIcon,
-    },
-    salaryOverride: {
-      min: r.salaryMinOverride,
-      max: r.salaryMaxOverride,
-      currency: r.salaryCurrencyOverride,
-      period: r.salaryPeriodOverride,
-    },
-  }));
+  const jobs: MyJobEntry[] = rows.map((r) => {
+    const snapshot = decodeSavedJobSnapshot(r);
+    return {
+      id: r.id,
+      savedAt: r.savedAt.toISOString(),
+      status: r.status as ApplicationStatus,
+      statusChangedAt: r.statusChangedAt.toISOString(),
+      appliedAt: r.appliedAt?.toISOString() ?? null,
+      interviewCount: interviewCounts.get(r.id) ?? 0,
+      posting: {
+        ...snapshot.posting,
+        firstSeenAt: snapshot.posting.firstSeenAt.toISOString(),
+        isActive:
+          postingStates.get(r.postingId)?.isActive ?? snapshot.posting.isActive,
+      },
+      company: snapshot.company,
+      salaryOverride: {
+        min: r.salaryMinOverride,
+        max: r.salaryMaxOverride,
+        currency: r.salaryCurrencyOverride,
+        period: r.salaryPeriodOverride,
+      },
+    };
+  });
 
   return { jobs, total };
 }
@@ -228,33 +224,34 @@ export async function getMyJobDetail(
       salaryMaxOverride: savedJob.salaryMaxOverride,
       salaryCurrencyOverride: savedJob.salaryCurrencyOverride,
       salaryPeriodOverride: savedJob.salaryPeriodOverride,
-      postingId: jobPosting.id,
-      postingTitle: sql<string | null>`${jobPosting.titles}[1]`,
-      postingSourceUrl: jobPosting.sourceUrl,
-      postingFirstSeenAt: jobPosting.firstSeenAt,
-      postingIsActive: jobPosting.isActive,
-      postingSalaryMin: jobPosting.salaryMin,
-      postingSalaryMax: jobPosting.salaryMax,
-      postingSalaryCurrency: jobPosting.salaryCurrency,
-      postingSalaryPeriod: jobPosting.salaryPeriod,
-      companyId: company.id,
-      companyName: company.name,
-      companySlug: company.slug,
-      companyIcon: company.icon,
+      postingId: savedJob.jobPostingId,
+      postingTitle: savedJob.postingTitle,
+      postingSourceUrl: savedJob.postingSourceUrl,
+      postingFirstSeenAt: savedJob.postingFirstSeenAt,
+      postingIsActive: savedJob.postingIsActive,
+      postingSalaryMin: savedJob.postingSalaryMin,
+      postingSalaryMax: savedJob.postingSalaryMax,
+      postingSalaryCurrency: savedJob.postingSalaryCurrency,
+      postingSalaryPeriod: savedJob.postingSalaryPeriod,
+      companyId: savedJob.companyId,
+      companyName: savedJob.companyName,
+      companySlug: savedJob.companySlug,
+      companyIcon: savedJob.companyIcon,
     })
     .from(savedJob)
-    .innerJoin(jobPosting, eq(savedJob.jobPostingId, jobPosting.id))
-    .innerJoin(company, eq(jobPosting.companyId, company.id))
     .where(and(eq(savedJob.id, savedJobId), eq(savedJob.userId, userId)))
     .limit(1);
 
   if (!row) return null;
 
-  const interviewRows = await db
-    .select()
-    .from(applicationInterview)
-    .where(eq(applicationInterview.savedJobId, savedJobId))
-    .orderBy(asc(applicationInterview.round));
+  const [interviewRows, postingStates] = await Promise.all([
+    db
+      .select()
+      .from(applicationInterview)
+      .where(eq(applicationInterview.savedJobId, savedJobId))
+      .orderBy(asc(applicationInterview.round)),
+    fetchIndexedPostingStates([row.postingId]),
+  ]);
 
   const interviews: InterviewEntry[] = interviewRows.map((r) => ({
     id: r.id,
@@ -265,6 +262,7 @@ export async function getMyJobDetail(
       : null,
     createdAt: serializeDatabaseTimestamp(r.createdAt),
   }));
+  const snapshot = decodeSavedJobSnapshot(row);
 
   return {
     id: row.id,
@@ -276,22 +274,12 @@ export async function getMyJobDetail(
     rejectedAt: row.rejectedAt?.toISOString() ?? null,
     interviewCount: interviews.length,
     posting: {
-      id: row.postingId,
-      title: normalizePostingTitle(row.postingTitle),
-      sourceUrl: row.postingSourceUrl,
-      firstSeenAt: row.postingFirstSeenAt.toISOString(),
-      isActive: row.postingIsActive,
-      salaryMin: row.postingSalaryMin,
-      salaryMax: row.postingSalaryMax,
-      salaryCurrency: row.postingSalaryCurrency,
-      salaryPeriod: row.postingSalaryPeriod,
+      ...snapshot.posting,
+      firstSeenAt: snapshot.posting.firstSeenAt.toISOString(),
+      isActive:
+        postingStates.get(row.postingId)?.isActive ?? snapshot.posting.isActive,
     },
-    company: {
-      id: row.companyId,
-      name: row.companyName,
-      slug: row.companySlug,
-      icon: row.companyIcon,
-    },
+    company: snapshot.company,
     salaryOverride: {
       min: row.salaryMinOverride,
       max: row.salaryMaxOverride,

--- a/apps/web/src/lib/actions/saved-jobs.ts
+++ b/apps/web/src/lib/actions/saved-jobs.ts
@@ -1,11 +1,15 @@
 "use server";
 
-import { eq, and, desc, count, sql } from "drizzle-orm";
+import { eq, and, desc, count } from "drizzle-orm";
 import { db } from "@/db";
-import { savedJob, jobPosting, company } from "@/db/schema";
+import { savedJob } from "@/db/schema";
 import { getSessionUserId } from "@/lib/sessionCache";
 import { isUniqueViolation } from "@/lib/db-conflict";
-import { normalizePostingTitle } from "@/lib/posting-title";
+import { decodeSavedJobSnapshot } from "@/lib/saved-job-snapshot";
+import {
+  fetchIndexedPostingSnapshot,
+  fetchIndexedPostingStates,
+} from "@/lib/search/typesense-posting-detail";
 
 export type SavedJobEntry = {
   id: string;
@@ -42,12 +46,10 @@ const SAVED_JOB_UNIQUE_CONSTRAINT = "idx_sj_user_posting";
  * present both observed an empty SELECT, both ran INSERT, and the
  * loser crashed with an un-handled `23505` from `idx_sj_user_posting`.
  *
- * Fix matches the #3268 retry-on-conflict shape: optimistically try
- * INSERT first; if it succeeds the toggle was OFF→ON. If the INSERT
- * trips the UNIQUE index, the row already exists (either pre-call or
- * landed by a racing winner), so the toggle is ON→OFF — DELETE and
- * return `saved=false`. The UNIQUE index is the source of truth; the
- * exception path serialises contention without leaking 500s.
+ * Delete first so unsaving never depends on Typesense. If no row existed, the
+ * action fetches a complete immutable snapshot and inserts. A concurrent
+ * winner can still trip the UNIQUE index; that path deletes the winner's row
+ * and returns `saved=false`, preserving two serialized toggle outcomes.
  *
  * The conflict catch is scoped narrowly to `code === "23505"` on
  * `idx_sj_user_posting`. Other unique violations propagate.
@@ -58,10 +60,41 @@ export async function toggleSavedJob(
   const userId = await getSessionUserId();
   if (!userId) throw new Error("Not authenticated");
 
+  // Delete first so an existing save can always be removed during a Typesense
+  // outage. For an absent row, the strict snapshot fetch below is the gate for
+  // creating durable application history.
+  const deleted = await db
+    .delete(savedJob)
+    .where(
+      and(
+        eq(savedJob.userId, userId),
+        eq(savedJob.jobPostingId, jobPostingId),
+      ),
+    )
+    .returning({ id: savedJob.id });
+  if (deleted.length > 0) return { saved: false };
+
+  const snapshot = await fetchIndexedPostingSnapshot(jobPostingId);
+
   try {
     const [row] = await db
       .insert(savedJob)
-      .values({ userId, jobPostingId })
+      .values({
+        userId,
+        jobPostingId,
+        postingTitle: snapshot.title,
+        postingSourceUrl: snapshot.sourceUrl,
+        postingFirstSeenAt: new Date(snapshot.firstSeenAt),
+        postingIsActive: snapshot.isActive,
+        postingSalaryMin: snapshot.salaryMin,
+        postingSalaryMax: snapshot.salaryMax,
+        postingSalaryCurrency: snapshot.salaryCurrency,
+        postingSalaryPeriod: snapshot.salaryPeriod,
+        companyId: snapshot.company.id,
+        companyName: snapshot.company.name,
+        companySlug: snapshot.company.slug,
+        companyIcon: snapshot.company.icon,
+      })
       .returning({ id: savedJob.id });
     // INSERT succeeded — the row didn't exist before this call.
     return { saved: true, savedJobId: row.id };
@@ -117,41 +150,41 @@ export async function getSavedJobs(params: {
     .select({
       id: savedJob.id,
       savedAt: savedJob.savedAt,
-      postingId: jobPosting.id,
-      postingTitle: sql<string | null>`${jobPosting.titles}[1]`,
-      postingSourceUrl: jobPosting.sourceUrl,
-      postingFirstSeenAt: jobPosting.firstSeenAt,
-      postingIsActive: jobPosting.isActive,
-      companyId: company.id,
-      companyName: company.name,
-      companySlug: company.slug,
-      companyIcon: company.icon,
+      postingId: savedJob.jobPostingId,
+      postingTitle: savedJob.postingTitle,
+      postingSourceUrl: savedJob.postingSourceUrl,
+      postingFirstSeenAt: savedJob.postingFirstSeenAt,
+      postingIsActive: savedJob.postingIsActive,
+      companyId: savedJob.companyId,
+      companyName: savedJob.companyName,
+      companySlug: savedJob.companySlug,
+      companyIcon: savedJob.companyIcon,
     })
     .from(savedJob)
-    .innerJoin(jobPosting, eq(savedJob.jobPostingId, jobPosting.id))
-    .innerJoin(company, eq(jobPosting.companyId, company.id))
     .where(eq(savedJob.userId, userId))
     .orderBy(desc(savedJob.savedAt))
     .offset(params.offset)
     .limit(params.limit);
+  const postingStates = await fetchIndexedPostingStates(
+    rows.map((row) => row.postingId),
+  );
 
-  const jobs: SavedJobEntry[] = rows.map((r) => ({
-    id: r.id,
-    savedAt: r.savedAt.toISOString(),
-    posting: {
-      id: r.postingId,
-      title: normalizePostingTitle(r.postingTitle),
-      sourceUrl: r.postingSourceUrl,
-      firstSeenAt: r.postingFirstSeenAt.toISOString(),
-      isActive: r.postingIsActive,
-    },
-    company: {
-      id: r.companyId,
-      name: r.companyName,
-      slug: r.companySlug,
-      icon: r.companyIcon,
-    },
-  }));
+  const jobs: SavedJobEntry[] = rows.map((r) => {
+    const snapshot = decodeSavedJobSnapshot(r);
+    return {
+      id: r.id,
+      savedAt: r.savedAt.toISOString(),
+      posting: {
+        id: snapshot.posting.id,
+        title: snapshot.posting.title,
+        sourceUrl: snapshot.posting.sourceUrl,
+        firstSeenAt: snapshot.posting.firstSeenAt.toISOString(),
+        isActive:
+          postingStates.get(r.postingId)?.isActive ?? snapshot.posting.isActive,
+      },
+      company: snapshot.company,
+    };
+  });
 
   return { jobs, total };
 }

--- a/apps/web/src/lib/saved-job-snapshot.ts
+++ b/apps/web/src/lib/saved-job-snapshot.ts
@@ -1,0 +1,74 @@
+import { normalizePostingTitle } from "@/lib/posting-title";
+
+export type SavedJobSnapshotRow = {
+  id: string;
+  postingId: string;
+  postingTitle: string | null;
+  postingSourceUrl: string | null;
+  postingFirstSeenAt: Date | null;
+  postingIsActive: boolean | null;
+  postingSalaryMin?: number | null;
+  postingSalaryMax?: number | null;
+  postingSalaryCurrency?: string | null;
+  postingSalaryPeriod?: string | null;
+  companyId: string | null;
+  companyName: string | null;
+  companySlug: string | null;
+  companyIcon: string | null;
+};
+
+function requiredText(
+  savedJobId: string,
+  field: string,
+  value: string | null,
+): string {
+  if (value == null || value.trim() === "") {
+    throw new Error(`Saved job ${savedJobId} has incomplete ${field}`);
+  }
+  return value;
+}
+
+/**
+ * Decode the transitional nullable columns as the required snapshot contract.
+ * 0084 backfills and checks these values; throwing here makes any later drift
+ * observable instead of fabricating broken links, slugs, or timestamps.
+ */
+export function decodeSavedJobSnapshot(row: SavedJobSnapshotRow) {
+  const title = normalizePostingTitle(
+    requiredText(row.id, "posting_title", row.postingTitle),
+  );
+  if (!title) throw new Error(`Saved job ${row.id} has incomplete posting_title`);
+  if (
+    !(row.postingFirstSeenAt instanceof Date) ||
+    Number.isNaN(row.postingFirstSeenAt.getTime())
+  ) {
+    throw new Error(`Saved job ${row.id} has incomplete posting_first_seen_at`);
+  }
+  if (typeof row.postingIsActive !== "boolean") {
+    throw new Error(`Saved job ${row.id} has incomplete posting_is_active`);
+  }
+
+  return {
+    posting: {
+      id: requiredText(row.id, "job_posting_id", row.postingId),
+      title,
+      sourceUrl: requiredText(
+        row.id,
+        "posting_source_url",
+        row.postingSourceUrl,
+      ),
+      firstSeenAt: row.postingFirstSeenAt,
+      isActive: row.postingIsActive,
+      salaryMin: row.postingSalaryMin ?? null,
+      salaryMax: row.postingSalaryMax ?? null,
+      salaryCurrency: row.postingSalaryCurrency ?? null,
+      salaryPeriod: row.postingSalaryPeriod ?? null,
+    },
+    company: {
+      id: requiredText(row.id, "company_id", row.companyId),
+      name: requiredText(row.id, "company_name", row.companyName),
+      slug: requiredText(row.id, "company_slug", row.companySlug),
+      icon: row.companyIcon,
+    },
+  };
+}

--- a/apps/web/src/lib/search/__tests__/typesense-posting-detail.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense-posting-detail.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  documents: new Map<string, unknown>(),
+  searchHits: [] as unknown[],
+  searchRequests: [] as Record<string, unknown>[],
+  getSearchClient: vi.fn(),
+}));
+
+vi.mock("../typesense-client", () => ({
+  getSearchClient: mocks.getSearchClient,
+}));
+
+vi.mock("../typesense-retry", () => ({
+  withTypesenseRetry: (fn: () => Promise<unknown>) => fn(),
+}));
+
+import {
+  fetchIndexedPostingDetail,
+  fetchIndexedPostingSnapshot,
+  fetchIndexedPostingStates,
+} from "../typesense-posting-detail";
+
+const posting = {
+  id: "posting-1",
+  company_id: "company-1",
+  company_name: "Embedded Company",
+  company_slug: "embedded-company",
+  company_icon: "embedded-icon.svg",
+  title: "  Senior Engineer  ",
+  is_active: false,
+  location_ids: [10, 20, 30],
+  location_names: ["Zurich"],
+  location_types: ["onsite"],
+  location_geo_types: ["city"],
+  seniority_id: 2,
+  seniority_name: "Senior",
+  technology_ids: [7, 8],
+  technology_names: ["TypeScript", "PostgreSQL"],
+  employment_type: "full-time",
+  salary_min: 120_000,
+  salary_max: 150_000,
+  salary_currency: "CHF",
+  salary_period: "year",
+  experience_min_years: 3.5,
+  experience_max_years: 99,
+  experience_min: 4,
+  experience_max: 99,
+  locales: ["de", "en"],
+  source_url: "https://example.com/jobs/1",
+  first_seen_at: 1_767_225_600,
+};
+
+beforeEach(() => {
+  mocks.documents.clear();
+  mocks.searchHits = [posting];
+  mocks.searchRequests = [];
+  mocks.documents.set("job_posting/posting-1", posting);
+  mocks.documents.set("company/company-1", {
+    id: "company-1",
+    name: "Canonical Company",
+    slug: "canonical-company",
+    logo: "logo.svg",
+    icon: "icon.svg",
+  });
+  mocks.documents.set("location/10", {
+    id: "10",
+    location_id: 10,
+    name_en: "Zurich",
+    name_de: "Zürich",
+    type: "city",
+    parent_name: "Switzerland",
+  });
+  mocks.documents.set("seniority/2-de", {
+    id: "2-de",
+    seniority_id: 2,
+    slug: "senior",
+    name: "Senior",
+    locale: "de",
+  });
+
+  mocks.getSearchClient.mockReturnValue({
+    collections: (collection: string) => ({
+      documents: (id?: string) =>
+        id
+          ? {
+              retrieve: async () => {
+                const key = `${collection}/${id}`;
+                if (!mocks.documents.has(key)) throw new Error(`missing ${key}`);
+                return mocks.documents.get(key);
+              },
+            }
+          : {
+              search: async (request: Record<string, unknown>) => {
+                mocks.searchRequests.push(request);
+                return {
+                  hits: mocks.searchHits.map((document) => ({ document })),
+                };
+              },
+            },
+    }),
+  });
+  vi.spyOn(console, "warn").mockImplementation(() => undefined);
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Typesense posting projection", () => {
+  it("maps an immutable saved-job snapshot", async () => {
+    const snapshot = await fetchIndexedPostingSnapshot("posting-1");
+
+    expect(snapshot).toMatchObject({
+      id: "posting-1",
+      title: "  Senior Engineer  ",
+      sourceUrl: "https://example.com/jobs/1",
+      isActive: false,
+      salaryMin: 120_000,
+      salaryMax: 150_000,
+      salaryCurrency: "CHF",
+      salaryPeriod: "year",
+      company: {
+        id: "company-1",
+        name: "Embedded Company",
+        slug: "embedded-company",
+        icon: "embedded-icon.svg",
+      },
+    });
+  });
+
+  it("hydrates localized detail and ignores ancestor-only location ids", async () => {
+    const detail = await fetchIndexedPostingDetail("posting-1", "de");
+
+    expect(detail).toMatchObject({
+      company: {
+        id: "company-1",
+        name: "Canonical Company",
+        slug: "canonical-company",
+        logo: "logo.svg",
+        icon: "icon.svg",
+      },
+      locations: [
+        {
+          id: 10,
+          name: "Zürich",
+          type: "onsite",
+          geoType: "city",
+          parentName: "Switzerland",
+        },
+      ],
+      experienceMin: 3.5,
+      experienceMax: null,
+      technologies: [
+        { id: 7, name: "TypeScript" },
+        { id: 8, name: "PostgreSQL" },
+      ],
+      seniority: { id: 2, slug: "senior", name: "Senior" },
+      descriptionLocale: "de",
+    });
+    expect(mocks.documents.has("location/20")).toBe(false);
+  });
+
+  it("returns null when the posting document is unavailable", async () => {
+    await expect(fetchIndexedPostingDetail("missing", "en")).resolves.toBeNull();
+    await expect(fetchIndexedPostingSnapshot("missing")).rejects.toThrow(
+      "missing job_posting/missing",
+    );
+  });
+
+  it.each([
+    ["source_url", { source_url: "" }],
+    ["company_name", { company_name: "" }],
+    ["company_slug", { company_slug: "" }],
+    ["first_seen_at", { first_seen_at: 0 }],
+    ["is_active", { is_active: "yes" }],
+    ["salary_currency", { salary_currency: 12 }],
+    ["company_icon", { company_icon: "" }],
+  ])("rejects an invalid required %s snapshot field", async (field, change) => {
+    mocks.documents.set("job_posting/posting-1", { ...posting, ...change });
+
+    await expect(fetchIndexedPostingSnapshot("posting-1")).rejects.toThrow(
+      field,
+    );
+  });
+
+  it("keeps absent salary and icon fields nullable", async () => {
+    const {
+      salary_min: _salaryMin,
+      salary_max: _salaryMax,
+      salary_currency: _salaryCurrency,
+      salary_period: _salaryPeriod,
+      company_icon: _companyIcon,
+      ...withoutOptionalFields
+    } = posting;
+    mocks.documents.set("job_posting/posting-1", withoutOptionalFields);
+
+    await expect(fetchIndexedPostingSnapshot("posting-1")).resolves.toMatchObject({
+      salaryMin: null,
+      salaryMax: null,
+      salaryCurrency: null,
+      salaryPeriod: null,
+      company: { icon: null },
+    });
+  });
+
+  it("resolves current saved-job state in one bounded search", async () => {
+    mocks.searchHits = [
+      posting,
+      { ...posting, id: "posting-2", is_active: true },
+    ];
+    const states = await fetchIndexedPostingStates([
+      "posting-1",
+      "posting-2",
+      "posting-1",
+      "bad:id",
+    ]);
+
+    expect(states.get("posting-1")).toEqual({ isActive: false });
+    expect(states.get("posting-2")).toEqual({ isActive: true });
+    expect(states.size).toBe(2);
+    expect(mocks.searchRequests[0]).toMatchObject({
+      include_fields: "id,is_active",
+      per_page: 2,
+    });
+  });
+
+  it("returns an empty state map when Typesense is unavailable", async () => {
+    mocks.getSearchClient.mockImplementationOnce(() => {
+      throw new Error("Typesense unavailable");
+    });
+
+    await expect(fetchIndexedPostingStates(["posting-1"])).resolves.toEqual(
+      new Map(),
+    );
+  });
+});

--- a/apps/web/src/lib/search/typesense-posting-detail.ts
+++ b/apps/web/src/lib/search/typesense-posting-detail.ts
@@ -1,0 +1,366 @@
+import "server-only";
+
+import { normalizePostingTitle } from "@/lib/posting-title";
+import { getSearchClient } from "./typesense-client";
+import { withTypesenseRetry } from "./typesense-retry";
+
+interface JobPostingDocument extends Record<string, unknown> {
+  id: string;
+  company_id: string;
+  company_name: string;
+  company_slug: string;
+  company_icon?: string;
+  title: string;
+  is_active: boolean;
+  location_ids: number[];
+  location_names: string[];
+  location_types: string[];
+  location_geo_types: string[];
+  seniority_id?: number;
+  seniority_name?: string;
+  technology_ids: number[];
+  technology_names: string[];
+  employment_type?: string;
+  salary_min?: number;
+  salary_max?: number;
+  salary_currency?: string;
+  salary_period?: string;
+  experience_min_years?: number;
+  experience_max_years?: number;
+  experience_min: number;
+  experience_max?: number;
+  locales: string[];
+  source_url?: string;
+  first_seen_at: number;
+}
+
+interface CompanyDocument extends Record<string, unknown> {
+  id: string;
+  name: string;
+  slug: string;
+  logo?: string;
+  icon?: string;
+}
+
+interface LocationDocument extends Record<string, unknown> {
+  id: string;
+  location_id: number;
+  name_en: string;
+  name_de?: string;
+  name_fr?: string;
+  name_it?: string;
+  type: string;
+  parent_name?: string;
+}
+
+interface SeniorityDocument extends Record<string, unknown> {
+  id: string;
+  seniority_id: number;
+  slug: string;
+  name: string;
+  locale: string;
+}
+
+export interface IndexedPostingSnapshot {
+  id: string;
+  title: string;
+  sourceUrl: string;
+  firstSeenAt: string;
+  isActive: boolean;
+  salaryMin: number | null;
+  salaryMax: number | null;
+  salaryCurrency: string | null;
+  salaryPeriod: string | null;
+  company: {
+    id: string;
+    name: string;
+    slug: string;
+    icon: string | null;
+  };
+}
+
+export interface IndexedPostingDetail extends IndexedPostingSnapshot {
+  company: IndexedPostingSnapshot["company"] & { logo: string | null };
+  locations: {
+    id: number;
+    name: string;
+    type: string;
+    geoType?: string;
+    parentName?: string;
+  }[];
+  employmentType: string | null;
+  experienceMin: number | null;
+  experienceMax: number | null;
+  technologies: { id: number; name: string }[];
+  seniority: { id: number; slug: string; name: string } | null;
+  descriptionLocale: string;
+}
+
+export interface IndexedPostingState {
+  isActive: boolean;
+}
+
+const SAFE_DOCUMENT_ID_RE = /^[A-Za-z0-9_-]+$/;
+const MAX_POSTING_STATE_BATCH = 250;
+
+function requiredString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Typesense posting snapshot has invalid ${field}`);
+  }
+  return value;
+}
+
+function optionalNumber(value: unknown, field: string): number | null {
+  if (value == null) return null;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`Typesense posting snapshot has invalid ${field}`);
+  }
+  return value;
+}
+
+function optionalString(value: unknown, field: string): string | null {
+  if (value == null) return null;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Typesense posting snapshot has invalid ${field}`);
+  }
+  return value;
+}
+
+async function retrieveDocument<T extends Record<string, unknown>>(
+  collection: string,
+  id: string,
+  label: string,
+): Promise<T> {
+  return withTypesenseRetry(
+    () =>
+      getSearchClient()
+        .collections<T>(collection)
+        .documents(id)
+        .retrieve(),
+    { label },
+  );
+}
+
+async function retrieveOptionalDocument<T extends Record<string, unknown>>(
+  collection: string,
+  id: string,
+  label: string,
+): Promise<T | null> {
+  try {
+    return await retrieveDocument<T>(collection, id, label);
+  } catch (error) {
+    console.warn(`[typesense-posting-detail] ${label} unavailable`, error);
+    return null;
+  }
+}
+
+function mapSnapshot(doc: JobPostingDocument): IndexedPostingSnapshot {
+  const id = requiredString(doc.id, "id");
+  if (!SAFE_DOCUMENT_ID_RE.test(id)) {
+    throw new Error("Typesense posting snapshot has an unsafe id");
+  }
+  const title = normalizePostingTitle(requiredString(doc.title, "title"));
+  if (!title) throw new Error("Typesense posting snapshot has an empty title");
+  if (typeof doc.is_active !== "boolean") {
+    throw new Error("Typesense posting snapshot has invalid is_active");
+  }
+  if (
+    typeof doc.first_seen_at !== "number" ||
+    !Number.isFinite(doc.first_seen_at) ||
+    doc.first_seen_at <= 0
+  ) {
+    throw new Error("Typesense posting snapshot has invalid first_seen_at");
+  }
+
+  return {
+    id,
+    title,
+    sourceUrl: requiredString(doc.source_url, "source_url"),
+    firstSeenAt: new Date(doc.first_seen_at * 1000).toISOString(),
+    isActive: doc.is_active,
+    salaryMin: optionalNumber(doc.salary_min, "salary_min"),
+    salaryMax: optionalNumber(doc.salary_max, "salary_max"),
+    salaryCurrency: optionalString(doc.salary_currency, "salary_currency"),
+    salaryPeriod: optionalString(doc.salary_period, "salary_period"),
+    company: {
+      id: requiredString(doc.company_id, "company_id"),
+      name: requiredString(doc.company_name, "company_name"),
+      slug: requiredString(doc.company_slug, "company_slug"),
+      icon: optionalString(doc.company_icon, "company_icon"),
+    },
+  };
+}
+
+function normalizeExperience(value: number | undefined, isMaximum: boolean): number | null {
+  if (value == null || value < 0) return null;
+  if (isMaximum && value === 99) return null;
+  return value;
+}
+
+function supportedLocale(locale: string): "en" | "de" | "fr" | "it" {
+  return locale === "de" || locale === "fr" || locale === "it" ? locale : "en";
+}
+
+/**
+ * Retrieve and validate the immutable fields copied onto a saved-job row.
+ * New saves fail closed when Typesense is unavailable or incomplete; otherwise
+ * the database would retain an application row that cannot survive mirror
+ * removal. Unsaving an existing row does not call this function.
+ */
+export async function fetchIndexedPostingSnapshot(
+  postingId: string,
+): Promise<IndexedPostingSnapshot> {
+  const doc = await retrieveDocument<JobPostingDocument>(
+    "job_posting",
+    postingId,
+    `savedJobSnapshot[${postingId}]`,
+  );
+  return mapSnapshot(doc);
+}
+
+/**
+ * Resolve the only saved-job field that intentionally stays live. A single
+ * Typesense search covers a page of posting ids; missing hits and outages are
+ * omitted so callers can retain their immutable snapshot values.
+ */
+export async function fetchIndexedPostingStates(
+  postingIds: string[],
+): Promise<Map<string, IndexedPostingState>> {
+  const ids = [...new Set(postingIds)]
+    .filter((id) => SAFE_DOCUMENT_ID_RE.test(id))
+    .slice(0, MAX_POSTING_STATE_BATCH);
+  if (ids.length === 0) return new Map();
+
+  try {
+    const result = await withTypesenseRetry(
+      () =>
+        getSearchClient()
+          .collections<JobPostingDocument>("job_posting")
+          .documents()
+          .search({
+            q: "*",
+            filter_by: `id:[${ids.join(",")}]`,
+            include_fields: "id,is_active",
+            per_page: ids.length,
+          }),
+      { label: `savedJobStates[${ids.length}]` },
+    );
+
+    return new Map(
+      (result.hits ?? []).map((hit) => [
+        hit.document.id,
+        { isActive: hit.document.is_active },
+      ]),
+    );
+  } catch (error) {
+    console.warn("[typesense-posting-detail] saved-job states unavailable", error);
+    return new Map();
+  }
+}
+
+/** Retrieve a complete posting-detail projection without Supabase joins. */
+export async function fetchIndexedPostingDetail(
+  postingId: string,
+  requestedLocale: string,
+): Promise<IndexedPostingDetail | null> {
+  try {
+    const doc = await retrieveDocument<JobPostingDocument>(
+      "job_posting",
+      postingId,
+      `postingDetail[${postingId}]`,
+    );
+    const locale = supportedLocale(requestedLocale);
+    const leafLocationIds = (doc.location_ids ?? []).slice(
+      0,
+      doc.location_names?.length ?? 0,
+    );
+
+    const companyPromise = retrieveOptionalDocument<CompanyDocument>(
+      "company",
+      doc.company_id,
+      `postingCompany[${doc.company_id}]`,
+    );
+    const locationPromises = leafLocationIds.map((locationId) =>
+      retrieveOptionalDocument<LocationDocument>(
+        "location",
+        String(locationId),
+        `postingLocation[${locationId}]`,
+      ),
+    );
+
+    let seniorityPromise: Promise<SeniorityDocument | null> = Promise.resolve(null);
+    if (doc.seniority_id != null) {
+      seniorityPromise = retrieveOptionalDocument<SeniorityDocument>(
+        "seniority",
+        `${doc.seniority_id}-${locale}`,
+        `postingSeniority[${doc.seniority_id}-${locale}]`,
+      ).then((localized) => {
+        if (localized || locale === "en") return localized;
+        return retrieveOptionalDocument<SeniorityDocument>(
+          "seniority",
+          `${doc.seniority_id}-en`,
+          `postingSeniority[${doc.seniority_id}-en]`,
+        );
+      });
+    }
+
+    const [company, locationDocs, seniority] = await Promise.all([
+      companyPromise,
+      Promise.all(locationPromises),
+      seniorityPromise,
+    ]);
+    const snapshot = mapSnapshot(doc);
+
+    const locations = leafLocationIds.map((id, index) => {
+      const location = locationDocs[index];
+      const localizedName = location?.[`name_${locale}`] as string | undefined;
+      return {
+        id,
+        name: localizedName || location?.name_en || doc.location_names[index] || "",
+        type: doc.location_types?.[index] ?? "onsite",
+        geoType: location?.type || doc.location_geo_types?.[index] || undefined,
+        parentName: location?.parent_name || undefined,
+      };
+    });
+
+    const technologies = (doc.technology_ids ?? []).map((id, index) => ({
+      id,
+      name: doc.technology_names?.[index] ?? "",
+    })).filter((technology) => technology.name !== "");
+
+    const descriptionLocale = doc.locales?.find((value) => value !== "_none") ?? "en";
+
+    return {
+      ...snapshot,
+      company: {
+        id: company?.id ?? snapshot.company.id,
+        name: company?.name ?? snapshot.company.name,
+        slug: company?.slug ?? snapshot.company.slug,
+        logo: company?.logo ?? null,
+        icon: company?.icon ?? snapshot.company.icon,
+      },
+      locations,
+      employmentType: doc.employment_type || null,
+      experienceMin: normalizeExperience(
+        doc.experience_min_years ?? doc.experience_min,
+        false,
+      ),
+      experienceMax: normalizeExperience(
+        doc.experience_max_years ?? doc.experience_max,
+        true,
+      ),
+      technologies,
+      seniority: doc.seniority_id != null
+        ? {
+            id: doc.seniority_id,
+            slug: seniority?.slug ?? "",
+            name: seniority?.name ?? doc.seniority_name ?? "",
+          }
+        : null,
+      descriptionLocale,
+    };
+  } catch (error) {
+    console.error("[typesense-posting-detail] posting detail unavailable", error);
+    return null;
+  }
+}

--- a/apps/web/src/lib/services/search.ts
+++ b/apps/web/src/lib/services/search.ts
@@ -12,7 +12,7 @@ import { getSessionUserId } from "@/lib/sessionCache";
 import { ANON_MAX_COMPANIES, ANON_MAX_CARD_POSTINGS } from "@/lib/search/constants";
 import { canonicalStringCompare } from "@/lib/sort";
 import { normalizeHistogramFilters, type NormalizedHistogramFilters } from "@/lib/search/histogram-filters";
-import { normalizePostingTitle } from "@/lib/posting-title";
+import { fetchIndexedPostingDetail } from "@/lib/search/typesense-posting-detail";
 
 // ── Posting detail ──────────────────────────────────────────────────
 
@@ -47,73 +47,6 @@ export async function getPostingDetail(params: {
   return _fetchPostingDetail(postingId, locale);
 }
 
-async function resolvePostingLocations(
-  locationIds: number[] | null,
-  locationTypes: string[] | null,
-  locale: string,
-): Promise<PostingDetail["locations"]> {
-  if (!locationIds || locationIds.length === 0) return [];
-  const pgArray = `{${locationIds.join(",")}}`;
-  const locRows = await withDbRetry(
-    () =>
-      db.execute<{
-        [key: string]: unknown;
-        location_id: number;
-        name: string;
-        type: string;
-        parent_name: string | null;
-      }>(sql`
-        SELECT DISTINCT ON (ln.location_id) ln.location_id, ln.name, l.type::text,
-          (SELECT pn.name FROM location_name pn
-           WHERE pn.location_id = l.parent_id
-             AND pn.locale IN (${locale}, 'en')
-             AND pn.is_display = true
-           ORDER BY (pn.locale = ${locale})::int DESC
-           LIMIT 1) AS parent_name
-        FROM location_name ln
-        JOIN location l ON l.id = ln.location_id
-        WHERE ln.location_id = ANY(${pgArray}::integer[])
-          AND ln.locale IN (${locale}, 'en')
-          AND ln.is_display = true
-        ORDER BY ln.location_id, (ln.locale = ${locale})::int DESC
-      `),
-    { label: "postingLocations" },
-  );
-  const nameMap = new Map<number, { name: string; geoType: string; parentName?: string }>();
-  for (const r of locRows as unknown as { location_id: number; name: string; type: string; parent_name: string | null }[]) {
-    nameMap.set(r.location_id, { name: r.name, geoType: r.type, parentName: r.parent_name ?? undefined });
-  }
-  return locationIds
-    .map((id, i) => {
-      const resolved = nameMap.get(id);
-      return {
-        id,
-        name: resolved?.name ?? "",
-        type: locationTypes?.[i] ?? "onsite",
-        geoType: resolved?.geoType,
-        parentName: resolved?.parentName,
-      };
-    })
-    .filter((l) => l.name !== "");
-}
-
-async function resolvePostingTechnologies(
-  technologyIds: number[] | null,
-): Promise<{ id: number; name: string }[]> {
-  if (!technologyIds || technologyIds.length === 0) return [];
-  const techArray = `{${technologyIds.join(",")}}`;
-  const techRows = await withDbRetry(
-    () =>
-      db.execute<{ [key: string]: unknown; id: number; name: string | null }>(
-        sql`SELECT id, name FROM technology WHERE id = ANY(${techArray}::integer[]) ORDER BY name`,
-      ),
-    { label: "postingTechnologies" },
-  );
-  return (techRows as unknown as { id: number; name: string | null }[])
-    .filter((t) => t.name)
-    .map((t) => ({ id: t.id, name: t.name! }));
-}
-
 // Per-region in-memory `'use cache'` (cacheLife({ revalidate: 300 })).
 // Build ID is part of the key, so each deploy re-fetches. Migrated from
 // Redis-backed `cached(..., { ttl: 300 })` in #2884 (bucket 5). Args
@@ -126,100 +59,34 @@ async function _fetchPostingDetail(
 ): Promise<PostingDetail | null> {
   "use cache";
   cacheLife({ revalidate: CACHE_TTL_MEDIUM });
-  const rows = await withDbRetry(
-    () =>
-      db.execute<{
-        [key: string]: unknown;
-        id: string;
-        title: string | null;
-        company_id: string;
-        company_name: string;
-        company_slug: string;
-        company_logo: string | null;
-        company_icon: string | null;
-        location_ids: number[] | null;
-        location_types: string[] | null;
-        employment_type: string | null;
-        source_url: string;
-        first_seen_at: Date;
-        locales: string[];
-      }>(sql`
-        SELECT jp.id, jp.titles[1] AS title,
-          c.id AS company_id, c.name AS company_name, c.slug AS company_slug,
-          c.logo AS company_logo, c.icon AS company_icon,
-          jp.location_ids, jp.location_types,
-          jp.employment_type, jp.source_url, jp.first_seen_at,
-          jp.locales,
-          jp.experience_min, jp.experience_max, jp.technology_ids,
-          jp.salary_min, jp.salary_max, jp.salary_currency, jp.salary_period,
-          jp.seniority_id, s.slug AS seniority_slug, sn.name AS seniority_name
-        FROM job_posting jp
-        JOIN company c ON c.id = jp.company_id
-        LEFT JOIN seniority s ON s.id = jp.seniority_id
-        LEFT JOIN LATERAL (
-          SELECT name FROM seniority_name
-          WHERE seniority_id = jp.seniority_id AND locale IN (${locale}, 'en') AND is_display = true
-          ORDER BY (locale = ${locale})::int DESC LIMIT 1
-        ) sn ON true
-        WHERE jp.id = ${postingId}
-      `),
-    { label: `postingDetail[${postingId}]` },
-  );
-
-  type Row = {
-    id: string; title: string | null;
-    company_id: string; company_name: string; company_slug: string;
-    company_logo: string | null; company_icon: string | null;
-    location_ids: number[] | null; location_types: string[] | null;
-    employment_type: string | null; source_url: string;
-    first_seen_at: Date; locales: string[];
-    experience_min: number | null; experience_max: number | null;
-    technology_ids: number[] | null;
-    salary_min: number | null; salary_max: number | null;
-    salary_currency: string | null; salary_period: string | null;
-    seniority_id: number | null; seniority_slug: string | null; seniority_name: string | null;
-  };
-  const row = (rows as unknown as Row[])[0];
-  if (!row) return null;
-
-  // Resolve location and technology names in parallel
-  const [locations, technologies] = await Promise.all([
-    resolvePostingLocations(row.location_ids, row.location_types, locale),
-    resolvePostingTechnologies(row.technology_ids),
-  ]);
+  const posting = await fetchIndexedPostingDetail(postingId, locale);
+  if (!posting) return null;
 
   // Build R2 description URL for client-side fetch
   const r2Domain = process.env.R2_DOMAIN_URL;
   let descriptionUrl: string | null = null;
   if (r2Domain) {
-    const descLocale = row.locales?.[0] ?? "en";
-    descriptionUrl = `${r2Domain.replace(/\/$/, "")}/job/${postingId}/${descLocale}/latest.html`;
+    descriptionUrl = `${r2Domain.replace(/\/$/, "")}/job/${postingId}/${posting.descriptionLocale}/latest.html`;
   }
 
   return {
-    id: row.id,
-    title: normalizePostingTitle(row.title),
-    company: {
-      id: row.company_id,
-      name: row.company_name,
-      slug: row.company_slug,
-      logo: row.company_logo,
-      icon: row.company_icon,
-    },
-    locations,
-    employmentType: row.employment_type,
-    experienceMin: row.experience_min,
-    experienceMax: row.experience_max,
-    technologies,
-    salaryMin: row.salary_min,
-    salaryMax: row.salary_max,
-    salaryCurrency: row.salary_currency,
-    salaryPeriod: row.salary_period,
-    seniority: row.seniority_id && row.seniority_slug && row.seniority_name
-      ? { id: row.seniority_id, slug: row.seniority_slug, name: row.seniority_name }
+    id: posting.id,
+    title: posting.title,
+    company: posting.company,
+    locations: posting.locations,
+    employmentType: posting.employmentType,
+    experienceMin: posting.experienceMin,
+    experienceMax: posting.experienceMax,
+    technologies: posting.technologies,
+    salaryMin: posting.salaryMin,
+    salaryMax: posting.salaryMax,
+    salaryCurrency: posting.salaryCurrency,
+    salaryPeriod: posting.salaryPeriod,
+    seniority: posting.seniority?.slug && posting.seniority.name
+      ? posting.seniority
       : null,
-    sourceUrl: row.source_url,
-    firstSeenAt: new Date(row.first_seen_at).toISOString(),
+    sourceUrl: posting.sourceUrl,
+    firstSeenAt: posting.firstSeenAt,
     descriptionHtml: null,
     descriptionUrl,
   };


### PR DESCRIPTION
## What changes

- new saves copy a complete immutable posting/company snapshot from Typesense;
- unsaving deletes first, so existing saves remain removable during a Typesense outage;
- incomplete or unavailable Typesense snapshots fail closed before insert;
- saved-job and My Jobs list/detail reads use saved_job-owned fields with a bounded live is_active refresh and snapshot fallback;
- posting detail reads from Typesense instead of Supabase crawler tables;
- runtime decoders surface incomplete persisted snapshots rather than fabricating URLs, slugs, titles, or timestamps;
- the existing scoped 23505 race recovery remains intact.

## Cleared release gates

1. Typesense full backfill completed under an exporter cursor fence: https://github.com/colophon-group/jobseek/actions/runs/30827402506.
2. Exact saved-job coverage passed for all 260 unique postings: 260 retrieved, 0 retrieval failures, 0 parity failures.
3. 0084 expand applied in protected production run: https://github.com/colophon-group/jobseek/actions/runs/30831666947.
4. 0084 exact postflight: ledger 74 rows; 262/262 saved rows complete; 12 snapshot columns; one validated ON DELETE RESTRICT posting FK; one required snapshot check; one compatibility trigger.
5. Required CI and CodeQL are green on head ca12f2e41.

## Next gate

Deploy this application phase, run authenticated save/list/detail/unsave and historical My Jobs production canaries, then observe before applying the separate 0085 contract migration. This PR does not drop the posting foreign key or any crawler mirror table.

## Verification

- focused saved-job and posting-detail suite: 5 files / 38 tests passed after final rebase;
- TypeScript and targeted ESLint passed locally;
- complete Required CI, web build smoke, web tests, Typesense E2E, migration drift, and CodeQL passed in GitHub.

## Failure behavior and rollback

Existing snapshot rows continue to render when Typesense state lookup fails. New saves reject rather than create incomplete history. Roll back the web deployment without rolling back 0084; its compatibility trigger preserves old-app inserts and its restrictive FK preserves application history.