### PR TITLE
Fix production migration runner cleanup

### DIFF
--- a/.github/workflows/web-database-migrations.yml
+++ b/.github/workflows/web-database-migrations.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Apply reviewed migrations
         working-directory: apps/web
-        run: pnpm db:migrate
+        run: timeout --signal=TERM --kill-after=15s 12m pnpm db:migrate
 
       - name: Verify exact postflight
         run: >-

--- a/apps/web/src/db/__tests__/production-migration-safety.test.ts
+++ b/apps/web/src/db/__tests__/production-migration-safety.test.ts
@@ -40,7 +40,12 @@ describe("production migration safety", () => {
   it("reserves one physical session for the advisory lock", () => {
     const runner = readWeb("src/db/migrate.ts");
 
-    expect(runner).toContain("await sql.reserve()");
+    expect(runner).toContain("await lockSql.reserve()");
+    expect(runner).toContain("drizzle(migrationSql)");
+    expect(runner).not.toMatch(/drizzle\((?:reserved|lockConnection)\)/);
+    expect(runner).toContain("connect_timeout: 15");
+    expect(runner).toContain("lockSql.end({ timeout: 5 })");
+    expect(runner).toContain("migrationSql.end({ timeout: 5 })");
     expect(runner).toContain("pg_try_advisory_lock");
     expect(runner).toContain("pg_advisory_unlock");
     expect(runner).toContain("MIGRATION_REQUIRE_UNPOOLED");
@@ -62,5 +67,8 @@ describe("production migration safety", () => {
     );
     expect(workflow).toContain('test "$GIT_REF" = "refs/heads/main"');
     expect(workflow).toContain('cancel-in-progress: false');
+    expect(workflow).toContain(
+      "timeout --signal=TERM --kill-after=15s 12m pnpm db:migrate",
+    );
   });
 });

--- a/apps/web/src/db/migrate.ts
+++ b/apps/web/src/db/migrate.ts
@@ -23,19 +23,32 @@ if (
   throw new Error("Refusing to migrate through the Supabase transaction pooler");
 }
 
-const sql = postgres(url, {
+const lockSql = postgres(url, {
   max: 1,
   prepare: false,
+  connect_timeout: 15,
+  connection: { application_name: "jobseek-web-migration-lock" },
+});
+const migrationSql = postgres(url, {
+  max: 1,
+  prepare: false,
+  connect_timeout: 15,
   connection: { application_name: "jobseek-web-migrations" },
 });
 
 async function main() {
-  const reserved = await sql.reserve();
-  const db = drizzle(reserved);
+  let lockConnection:
+    | Awaited<ReturnType<typeof lockSql.reserve>>
+    | undefined;
   let advisoryLockHeld = false;
 
   try {
-    const [lock] = await reserved<{ acquired: boolean }[]>`
+    // Drizzle requires the root postgres.js client because migrations call
+    // client.begin(). A reserved client has neither begin() nor options and
+    // cannot be passed to drizzle(). Keep a separate reserved session solely
+    // for the advisory lock while the one-connection migration pool owns DDL.
+    lockConnection = await lockSql.reserve();
+    const [lock] = await lockConnection<{ acquired: boolean }[]>`
       SELECT pg_try_advisory_lock(
         hashtextextended('jobseek:web-schema-migrations', 0)
       ) AS acquired
@@ -45,17 +58,20 @@ async function main() {
       throw new Error("Another web schema migration is already running");
     }
 
-    await reserved`SET lock_timeout = '10s'`;
-    await reserved`SET statement_timeout = '10min'`;
-    await reserved`SET idle_in_transaction_session_timeout = '2min'`;
+    // migrationSql has max=1, so these session settings and the Drizzle
+    // transaction use the same physical connection.
+    await migrationSql`SET lock_timeout = '10s'`;
+    await migrationSql`SET statement_timeout = '10min'`;
+    await migrationSql`SET idle_in_transaction_session_timeout = '2min'`;
 
+    const db = drizzle(migrationSql);
     console.log("Running migrations with the web schema advisory lock...");
     await migrate(db, { migrationsFolder: "./drizzle" });
     console.log("Migrations complete.");
   } finally {
     try {
-      if (advisoryLockHeld) {
-        const [unlock] = await reserved<{ released: boolean }[]>`
+      if (lockConnection && advisoryLockHeld) {
+        const [unlock] = await lockConnection<{ released: boolean }[]>`
           SELECT pg_advisory_unlock(
             hashtextextended('jobseek:web-schema-migrations', 0)
           ) AS released
@@ -66,8 +82,14 @@ async function main() {
         }
       }
     } finally {
-      await reserved.release();
-      await sql.end();
+      try {
+        if (lockConnection) await lockConnection.release();
+      } finally {
+        await Promise.all([
+          lockSql.end({ timeout: 5 }),
+          migrationSql.end({ timeout: 5 }),
+        ]);
+      }
     }
   }
 }


### PR DESCRIPTION
## Incident

The first reviewer-approved 0083 run passed its exact production preflight, then failed before DDL with Cannot read properties of undefined reading parsers. Drizzle 0.45 requires the root postgres.js client, but the runner passed a reserved client that has neither options nor begin. Construction also occurred before try/finally, so the failed process leaked its connection until the workflow was cancelled.

Failed no-op run: https://github.com/colophon-group/jobseek/actions/runs/30819626136

Production remained at 72 migration rows, watchlist default true, and the audited 0079 tip. No advisory lock or transaction remained and no schema/data change occurred.

## Fix

- reserve one bounded client only for the session advisory lock;
- give Drizzle a separate max-one root client for its transaction;
- apply lock, statement, and idle-transaction timeouts on that migration session;
- place construction inside cleanup coverage and close both pools with five-second bounds;
- bound the workflow command itself to twelve minutes.

## Verification

- 43 migration safety and reconciliation tests passed;
- TypeScript, ESLint, translation coverage, and commit hooks passed;
- live non-DDL production proof acquired/released the advisory lock and confirmed 10s lock, 10min statement, and 2min idle-transaction settings on the separate migration client.

After merge, rerun the existing reviewer-gated APPLY-0083 workflow and retain exact preflight/postflight evidence.