### PR TITLE
Stop logging raw external client errors

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/company-content.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-content.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from "next/navigation";
 import { Trans } from "@lingui/react/macro";
 import { fetchCompanyPageData, type CompanyPageData } from "@/lib/actions/company-page-data";
 import { hasLoggedInHint, hasAnonJobLanguagesHint } from "@/lib/client-cookies";
+import { logExternalError } from "@/lib/safe-external-error";
 import { CompanySkeleton } from "@/components/search/company-skeleton";
 import {
   hasSearchFilterParams,
@@ -130,7 +131,7 @@ export function CompanyContent({ locale, slug, initialData }: CompanyContentProp
       setData(result ?? "not-found");
     }).catch((err) => {
       if (fetchIdRef.current !== fetchId) return;
-      console.error("[company] fetchCompanyPageData failed", err);
+      logExternalError("error", { service: "typesense", operation: "fetch_company_page" }, err);
       if (initialData) setData(initialData);
     });
   }, [dataParamsKey, initialData, locale, slug]);

--- a/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
+++ b/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
@@ -376,11 +376,16 @@ describe("ExploreContent — cold-start retry (#3008)", () => {
     await waitFor(() => {
       expect(console.error).toHaveBeenCalled();
     });
-    // The error log includes the marker so it can be filtered in
-    // observability.
-    const errorArg = (console.error as unknown as ReturnType<typeof vi.fn>).mock
-      .calls[0]?.[0] as string | undefined;
-    expect(errorArg).toMatch(/explore.*failed twice/i);
+    // The structured event and operation remain filterable without
+    // serializing the raw server-action error.
+    const [event, payload] = (console.error as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [string, Record<string, unknown>];
+    expect(event).toBe("external_client_error");
+    expect(payload).toMatchObject({
+      service: "typesense",
+      operation: "fetch_explore_page",
+      retry_count: 2,
+    });
   });
 
   it("does NOT retry on the happy path (single resolved call)", async () => {

--- a/apps/web/app/[lang]/(app)/explore/explore-content.tsx
+++ b/apps/web/app/[lang]/(app)/explore/explore-content.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { fetchExplorePageData, type ExploreData } from "@/lib/actions/explore-page-data";
 import { hasLoggedInHint, hasAnonJobLanguagesHint } from "@/lib/client-cookies";
+import { logExternalError } from "@/lib/safe-external-error";
 import { hasSearchFilterParams } from "@/lib/search/query-params";
 import { ExploreSkeleton } from "@/components/search/explore-skeleton";
 import { SearchPage } from "./search-page";
@@ -29,7 +30,11 @@ async function fetchExplorePageDataWithRetry(
   try {
     return await fetchExplorePageData(args);
   } catch (err) {
-    console.warn("[explore] fetchExplorePageData failed, retrying once", err);
+    logExternalError(
+      "warn",
+      { service: "typesense", operation: "fetch_explore_page_retry", retryCount: 1 },
+      err,
+    );
     await new Promise((resolve) => setTimeout(resolve, 250));
     return fetchExplorePageData(args);
   }
@@ -97,7 +102,11 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
         // toolbar because the prerender doesn't carry them, but that
         // matches the pre-#2746 cold-error behaviour and beats a
         // permanent skeleton.
-        console.error("[explore] fetchExplorePageData failed twice", err);
+        logExternalError(
+          "error",
+          { service: "typesense", operation: "fetch_explore_page", retryCount: 2 },
+          err,
+        );
         if (initialData) setData(initialData);
       });
     // Empty deps: the conditional-fetch decision is made once on

--- a/apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx
@@ -2,6 +2,7 @@ import { RefreshCw } from "lucide-react";
 import { Trans } from "@lingui/react/macro";
 import { getSession } from "@/lib/sessionCache";
 import { getUserWatchlistsWithLimit } from "@/lib/services/watchlists";
+import { logExternalError } from "@/lib/safe-external-error";
 import { WatchlistsPage } from "./watchlists-page";
 
 const WATCHLIST_LOAD_TIMEOUT_MS = 8_000;
@@ -43,7 +44,7 @@ export async function WatchlistsLoader({ locale }: { locale: string }) {
       />
     );
   } catch (err) {
-    console.error("[watchlists] server load failed", err);
+    logExternalError("error", { service: "database", operation: "load_watchlists" }, err);
     return (
       <div className="flex flex-col items-center justify-center gap-3 py-24 text-center">
         <p className="text-sm font-medium">

--- a/apps/web/app/api/auth/[...all]/__tests__/route.test.ts
+++ b/apps/web/app/api/auth/[...all]/__tests__/route.test.ts
@@ -249,8 +249,10 @@ describe("auth catch-all route — passwordResetLimiter wiring (#3223)", () => {
 
   // --- E2: Redis bypass is logged so the outage is queryable (#3175) ----
 
-  it("logs `[auth-rate-limit] redis bypass` when authLimiter throws (so a Redis outage is visible in Loki, not silent)", async () => {
-    limiterCalls.authLimit.mockRejectedValue(new Error("ECONNREFUSED"));
+  it("logs a safe auth rate-limit event when Redis throws", async () => {
+    limiterCalls.authLimit.mockRejectedValue(
+      Object.assign(new Error("SECRET_CANARY_AUTH_LIMIT"), { code: "ECONNREFUSED" }),
+    );
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const { POST } = await import("../route");
@@ -259,17 +261,23 @@ describe("auth catch-all route — passwordResetLimiter wiring (#3223)", () => {
     // Bypass behaviour preserved.
     expect(res.status).toBe(200);
     expect(betterAuthHandlers.POST).toHaveBeenCalledTimes(1);
-    // Stable event prefix so a sustained outage is queryable.
+    // Stable event and operation so a sustained outage is queryable.
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    const [message, errArg] = warnSpy.mock.calls[0];
-    expect(message).toBe("[auth-rate-limit] redis bypass");
-    expect(errArg).toBeInstanceOf(Error);
-    expect((errArg as Error).message).toBe("ECONNREFUSED");
+    const [event, payload] = warnSpy.mock.calls[0];
+    expect(event).toBe("external_client_error");
+    expect(payload).toMatchObject({
+      service: "redis",
+      operation: "auth_rate_limit",
+      code: "ECONNREFUSED",
+    });
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain("SECRET_CANARY_AUTH_LIMIT");
     warnSpy.mockRestore();
   });
 
-  it("logs `[auth-rate-limit] pw-reset redis bypass` when passwordResetLimiter throws on a reset path (email-bombing vector observability)", async () => {
-    limiterCalls.passwordResetLimit.mockRejectedValue(new Error("ECONNREFUSED"));
+  it("logs a safe password-reset rate-limit event when Redis throws", async () => {
+    limiterCalls.passwordResetLimit.mockRejectedValue(
+      Object.assign(new Error("SECRET_CANARY_PASSWORD_RESET"), { code: "ECONNREFUSED" }),
+    );
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const { POST } = await import("../route");
@@ -283,10 +291,14 @@ describe("auth catch-all route — passwordResetLimiter wiring (#3223)", () => {
     // Two-axis defence-in-depth means authLimiter still ran with no
     // throw, so only the pw-reset bypass log fires.
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    const [message, errArg] = warnSpy.mock.calls[0];
-    expect(message).toBe("[auth-rate-limit] pw-reset redis bypass");
-    expect(errArg).toBeInstanceOf(Error);
-    expect((errArg as Error).message).toBe("ECONNREFUSED");
+    const [event, payload] = warnSpy.mock.calls[0];
+    expect(event).toBe("external_client_error");
+    expect(payload).toMatchObject({
+      service: "redis",
+      operation: "password_reset_rate_limit",
+      code: "ECONNREFUSED",
+    });
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain("SECRET_CANARY_PASSWORD_RESET");
     warnSpy.mockRestore();
   });
 

--- a/apps/web/app/api/auth/[...all]/route.ts
+++ b/apps/web/app/api/auth/[...all]/route.ts
@@ -6,6 +6,7 @@ import {
   passwordResetLimiter,
 } from "@/lib/rate-limit";
 import { type NextRequest, NextResponse } from "next/server";
+import { logExternalError } from "@/lib/safe-external-error";
 
 const { GET: authGet, POST: authPost } = toNextJsHandler(auth);
 
@@ -67,9 +68,9 @@ async function applyAuthLimits(
     } catch (err) {
       // Redis unavailable — degrade open, mirroring authLimiter behaviour.
       // Log at warn so a Redis outage that disables the tight password-reset
-      // bucket (3/300s, the email-bombing vector) is queryable in Loki under
-      // `[auth-rate-limit] pw-reset redis bypass`. See #3175.
-      console.warn("[auth-rate-limit] pw-reset redis bypass", err);
+      // bucket (3/300s, the email-bombing vector) is queryable by the
+      // `password_reset_rate_limit` operation. See #3175.
+      logExternalError("warn", { service: "redis", operation: "password_reset_rate_limit" }, err);
     }
   }
 
@@ -79,8 +80,8 @@ async function applyAuthLimits(
   } catch (err) {
     // Redis unavailable — allow request through. Log at warn so a Redis
     // outage that silently disables the broader auth bucket (10/60s) is
-    // queryable in Loki under `[auth-rate-limit] redis bypass`. See #3175.
-    console.warn("[auth-rate-limit] redis bypass", err);
+    // queryable by the `auth_rate_limit` operation. See #3175.
+    logExternalError("warn", { service: "redis", operation: "auth_rate_limit" }, err);
   }
   return null;
 }

--- a/apps/web/app/api/internal/invalidate-typeahead/route.ts
+++ b/apps/web/app/api/internal/invalidate-typeahead/route.ts
@@ -4,6 +4,7 @@ import { revalidateTag } from "next/cache";
 import { NextResponse, type NextRequest } from "next/server";
 
 import { invalidatePattern } from "@/lib/cache";
+import { logExternalError } from "@/lib/safe-external-error";
 import {
   CACHE_PREFIXES_INVALIDATED_ON_SYNC,
   CACHE_TAGS_INVALIDATED_ON_SYNC,
@@ -80,11 +81,7 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
       // A revalidation hiccup must not fail the sweep — the legacy
       // Redis prefix loop below is the backstop for any straggler keys,
       // and the slot's 3600s TTL is the ultimate backstop.
-      console.warn(
-        "[invalidate-typeahead] revalidateTag failed",
-        tag,
-        err,
-      );
+      logExternalError("warn", { service: "external_http", operation: "revalidate_typeahead" }, err);
     }
   }
 

--- a/apps/web/app/api/v1/_shared.test.ts
+++ b/apps/web/app/api/v1/_shared.test.ts
@@ -11,8 +11,8 @@ import { NextRequest } from "next/server";
  *   1. When the limiter throws, the request still degrades open (the
  *      original behaviour — fail-closed would lock the public API down
  *      during a Redis incident).
- *   2. The catch handler emits a stable `[rate-limit] redis bypass`
- *      warning so a sustained bypass is queryable in Loki / Vercel logs.
+ *   2. The catch handler emits a stable structured warning so a sustained
+ *      bypass is queryable in Loki / Vercel logs without exposing Redis config.
  */
 
 vi.mock("server-only", () => ({}));
@@ -53,7 +53,9 @@ describe("checkRateLimit — Redis bypass observability (#3175)", () => {
   });
 
   it("logs a warn when the limiter throws (Redis outage) and still degrades open", async () => {
-    limiterCalls.apiLimit.mockRejectedValue(new Error("ECONNREFUSED"));
+    limiterCalls.apiLimit.mockRejectedValue(
+      Object.assign(new Error("SECRET_CANARY_PUBLIC_API"), { code: "ECONNREFUSED" }),
+    );
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const { checkRateLimit } = await import("./_shared");
@@ -61,12 +63,16 @@ describe("checkRateLimit — Redis bypass observability (#3175)", () => {
 
     // Bypass preserved: caller sees `null`, not a thrown error, not a 429.
     expect(result).toBeNull();
-    // Stable event prefix so Loki / Vercel queries can count bypasses.
+    // Stable event and operation so Loki / Vercel queries can count bypasses.
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    const [message, errArg] = warnSpy.mock.calls[0];
-    expect(message).toBe("[rate-limit] redis bypass");
-    expect(errArg).toBeInstanceOf(Error);
-    expect((errArg as Error).message).toBe("ECONNREFUSED");
+    const [event, payload] = warnSpy.mock.calls[0];
+    expect(event).toBe("external_client_error");
+    expect(payload).toMatchObject({
+      service: "redis",
+      operation: "public_api_rate_limit",
+      code: "ECONNREFUSED",
+    });
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain("SECRET_CANARY_PUBLIC_API");
   });
 
   it("does NOT log when the limiter succeeds (no false bypass signal)", async () => {

--- a/apps/web/app/api/v1/_shared.ts
+++ b/apps/web/app/api/v1/_shared.ts
@@ -2,6 +2,7 @@ import { type NextRequest, NextResponse } from "next/server";
 import { apiLimiter, getClientIp } from "@/lib/rate-limit";
 import { CACHE_TTL_MEDIUM } from "@/lib/cache-ttl";
 import { siteConfig } from "@/content/config";
+import { logExternalError } from "@/lib/safe-external-error";
 
 /** Rate-limit result to thread through to apiResponse(). */
 export type RateLimitInfo = { limit: number; remaining: number; reset: number };
@@ -35,8 +36,9 @@ export async function checkRateLimit(
     // outage (which silently disables rate-limiting on every public
     // `/api/v1/*` request) is visible in Vercel/Loki rather than looking
     // like normal "no-rate-limit-headers" traffic. See #3175.
-    // Stable event prefix `[rate-limit] redis bypass` is queryable in Loki.
-    console.warn("[rate-limit] redis bypass", err);
+    // The stable `external_client_error` event and `public_api_rate_limit`
+    // operation are queryable in Loki.
+    logExternalError("warn", { service: "redis", operation: "public_api_rate_limit" }, err);
   }
   return null;
 }

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -19,6 +19,95 @@ const appSourceIgnores = [
   "scripts/**",
 ];
 
+function memberName(node) {
+  if (!node || node.type !== "MemberExpression") return undefined;
+  if (!node.computed && node.property.type === "Identifier") return node.property.name;
+  if (node.computed && node.property.type === "Literal") return node.property.value;
+  return undefined;
+}
+
+const safeClientLoggingPlugin = {
+  rules: {
+    "no-raw-errors": {
+      meta: {
+        type: "problem",
+        docs: {
+          description: "Prevent SDK/client error objects from reaching application logs",
+        },
+        messages: {
+          rawError:
+            "Do not log raw errors or error-derived values. Use logExternalError() or safeExternalError().",
+        },
+        schema: [],
+      },
+      create(context) {
+        const sourceCode = context.sourceCode;
+        const caughtNames = new Map();
+
+        function addCaught(name) {
+          caughtNames.set(name, (caughtNames.get(name) ?? 0) + 1);
+        }
+
+        function removeCaught(name) {
+          const count = caughtNames.get(name) ?? 0;
+          if (count <= 1) caughtNames.delete(name);
+          else caughtNames.set(name, count - 1);
+        }
+
+        function isSafeSerializer(node) {
+          return (
+            node.type === "CallExpression" &&
+            node.callee.type === "Identifier" &&
+            (node.callee.name === "safeExternalError" || node.callee.name === "logExternalError")
+          );
+        }
+
+        function containsRawError(node) {
+          if (!node || typeof node !== "object" || isSafeSerializer(node)) return false;
+          if (node.type === "Identifier") {
+            return caughtNames.has(node.name) || /^(?:err|error|cause|lastErr|[A-Za-z]+Error)$/.test(node.name);
+          }
+          if (node.type === "MemberExpression" && memberName(node) === "error") return true;
+          if (node.type === "Property" && !node.computed) return containsRawError(node.value);
+
+          const keys = sourceCode.visitorKeys[node.type] ?? [];
+          return keys.some((key) => {
+            const child = node[key];
+            return Array.isArray(child)
+              ? child.some((entry) => containsRawError(entry))
+              : containsRawError(child);
+          });
+        }
+
+        function isApplicationLogger(node) {
+          if (node.type !== "MemberExpression") return false;
+          const method = memberName(node);
+          if (method !== "error" && method !== "warn") return false;
+          if (node.object.type === "Identifier") {
+            return ["console", "log", "logger"].includes(node.object.name);
+          }
+          return memberName(node.object) === "logger";
+        }
+
+        return {
+          CatchClause(node) {
+            if (node.param?.type === "Identifier") addCaught(node.param.name);
+          },
+          "CatchClause:exit"(node) {
+            if (node.param?.type === "Identifier") removeCaught(node.param.name);
+          },
+          CallExpression(node) {
+            if (!isApplicationLogger(node.callee)) return;
+            if (node.arguments.some((argument) => containsRawError(argument))) {
+              context.report({ node, messageId: "rawError" });
+            }
+          },
+        };
+      },
+    },
+  },
+};
+
 export default tseslint.config(
   {
     ignores: [".next/", "node_modules/", "src/locales/", "locales/", "next-env.d.ts"],
@@ -66,6 +155,24 @@ export default tseslint.config(
             "Pass an explicit locale for display sorting, or use deterministic < > comparison for canonical keys.",
         },
       ],
+    },
+  },
+  {
+    files: ["app/**/*.{ts,tsx}", "src/**/*.{ts,tsx}", "script/**/*.ts", "scripts/**/*.ts"],
+    ignores: [
+      "**/__tests__/**",
+      "**/*.test.{ts,tsx}",
+      "app/api/admin/murmur-demo/**",
+      "app/api/web/companies/request/**",
+      "app/api/stripe/**",
+      "src/lib/actions/request-company.ts",
+      "src/lib/stripe.ts",
+    ],
+    plugins: {
+      "safe-client-logging": safeClientLoggingPlugin,
+    },
+    rules: {
+      "safe-client-logging/no-raw-errors": "error",
     },
   },
   {

--- a/apps/web/script/capture-screenshots.ts
+++ b/apps/web/script/capture-screenshots.ts
@@ -22,6 +22,7 @@ import { mkdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { config } from "dotenv";
+import { logExternalError } from "../src/lib/safe-external-error";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 config({ path: join(__dirname, "..", ".env.local") });
@@ -208,7 +209,7 @@ async function run() {
           await page.screenshot({ path: outPath, type: "png" });
           captured++;
         } catch (err) {
-          console.error(`    FAILED: ${err instanceof Error ? err.message : err}`);
+          logExternalError("error", { service: "external_http", operation: "capture_screenshot" }, err);
         } finally {
           await page.close();
         }
@@ -221,6 +222,6 @@ async function run() {
 }
 
 run().catch((err) => {
-  console.error(err);
+  logExternalError("error", { service: "external_http", operation: "capture_screenshots" }, err);
   process.exit(1);
 });

--- a/apps/web/script/notify-blog-indexnow.ts
+++ b/apps/web/script/notify-blog-indexnow.ts
@@ -25,6 +25,7 @@
  */
 
 import { notifyIndexNow } from "../src/lib/indexnow";
+import { logExternalError } from "../src/lib/safe-external-error";
 import { listBlogPosts, getBlogPostLocales } from "../src/lib/blog";
 
 async function main(): Promise<void> {
@@ -83,6 +84,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  console.error("[notify-blog-indexnow] failed", err);
+  logExternalError("error", { service: "indexnow", operation: "notify_blog" }, err);
   process.exit(1);
 });

--- a/apps/web/script/prune-company-og-cache.ts
+++ b/apps/web/script/prune-company-og-cache.ts
@@ -19,6 +19,7 @@ import {
   S3Client,
   type _Object,
 } from "@aws-sdk/client-s3";
+import { logExternalError } from "../src/lib/safe-external-error";
 
 type Options = {
   prefix: string;
@@ -427,6 +428,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-  console.error("[company-og-prune] failed", err);
+  logExternalError("error", { service: "r2", operation: "prune_company_og" }, err);
   process.exit(1);
 });

--- a/apps/web/script/smoke-built-app.ts
+++ b/apps/web/script/smoke-built-app.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { chromium, type Browser } from "playwright";
+import { logExternalError } from "../src/lib/safe-external-error";
 
 const port = Number(process.env.SMOKE_PORT ?? "3100");
 const baseUrl = `http://127.0.0.1:${port}`;
@@ -124,6 +125,6 @@ async function main() {
 }
 
 main().catch((error: unknown) => {
-  console.error(error);
+  logExternalError("error", { service: "external_http", operation: "smoke_built_app" }, error);
   process.exit(1);
 });

--- a/apps/web/scripts/backfill-slugs.ts
+++ b/apps/web/scripts/backfill-slugs.ts
@@ -1,6 +1,7 @@
 import dotenv from "dotenv";
 dotenv.config({ path: ".env.local" });
 import postgres from "postgres";
+import { logExternalError } from "../src/lib/safe-external-error";
 
 const dryRun = process.argv.includes("--dry-run");
 const sql = postgres(process.env.DATABASE_URL_UNPOOLED ?? process.env.DATABASE_URL!, { max: 1 });
@@ -148,6 +149,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error("Failed:", err);
+  logExternalError("error", { service: "database", operation: "backfill_slugs" }, err);
   process.exit(1);
 });

--- a/apps/web/scripts/backfill-watchlist-descriptions.ts
+++ b/apps/web/scripts/backfill-watchlist-descriptions.ts
@@ -4,6 +4,7 @@ import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { eq } from "drizzle-orm";
 import { user, watchlist, watchlistCompany, company } from "../src/db/schema";
+import { logExternalError } from "../src/lib/safe-external-error";
 
 const url = process.env.DATABASE_URL_UNPOOLED ?? process.env.DATABASE_URL;
 if (!url) {
@@ -162,6 +163,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error(err);
+  logExternalError("error", { service: "database", operation: "backfill_watchlist_descriptions" }, err);
   process.exit(1);
 });

--- a/apps/web/scripts/grant-admin-subscription.ts
+++ b/apps/web/scripts/grant-admin-subscription.ts
@@ -4,6 +4,7 @@ import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { eq } from "drizzle-orm";
 import { user, subscription } from "../src/db/schema";
+import { logExternalError } from "../src/lib/safe-external-error";
 
 const url = process.env.DATABASE_URL_UNPOOLED ?? process.env.DATABASE_URL;
 if (!url) {
@@ -55,6 +56,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error(err);
+  logExternalError("error", { service: "database", operation: "grant_admin_subscription" }, err);
   process.exit(1);
 });

--- a/apps/web/scripts/verify-production-migration-baseline.ts
+++ b/apps/web/scripts/verify-production-migration-baseline.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 
 import dotenv from "dotenv";
 import postgres from "postgres";
+import { logExternalError } from "../src/lib/safe-external-error";
 
 dotenv.config({ path: ".env.local", quiet: true });
 
@@ -252,6 +253,6 @@ async function main() {
 }
 
 void main().catch((error: unknown) => {
-  console.error("Production migration verification failed:", error);
+  logExternalError("error", { service: "database", operation: "verify_migration_baseline" }, error);
   process.exitCode = 1;
 });

--- a/apps/web/scripts/verify-saved-job-contract.ts
+++ b/apps/web/scripts/verify-saved-job-contract.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 
 import dotenv from "dotenv";
 import postgres from "postgres";
+import { logExternalError } from "../src/lib/safe-external-error";
 
 import { isExactSavedJobTextCheck } from "./saved-job-contract-definition";
 
@@ -518,6 +519,6 @@ async function main() {
 }
 
 void main().catch((error: unknown) => {
-  console.error("Saved-job contract verification failed:", error);
+  logExternalError("error", { service: "database", operation: "verify_saved_job_contract" }, error);
   process.exitCode = 1;
 });

--- a/apps/web/scripts/verify-saved-job-expand.ts
+++ b/apps/web/scripts/verify-saved-job-expand.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path";
 
 import dotenv from "dotenv";
 import postgres from "postgres";
+import { logExternalError } from "../src/lib/safe-external-error";
 
 dotenv.config({ path: ".env.local", quiet: true });
 
@@ -262,6 +263,6 @@ async function main() {
 }
 
 void main().catch((error: unknown) => {
-  console.error("Saved-job expand verification failed:", error);
+  logExternalError("error", { service: "database", operation: "verify_saved_job_expand" }, error);
   process.exitCode = 1;
 });

--- a/apps/web/scripts/verify-saved-job-typesense-coverage.ts
+++ b/apps/web/scripts/verify-saved-job-typesense-coverage.ts
@@ -4,6 +4,7 @@ import { pathToFileURL } from "node:url";
 
 import dotenv from "dotenv";
 import postgres from "postgres";
+import { logExternalError } from "../src/lib/safe-external-error";
 
 type SavedPostingSource = {
   postingId: string;
@@ -264,7 +265,7 @@ async function main() {
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   void main().catch((error: unknown) => {
-    console.error("Saved-job Typesense coverage failed:", error);
+    logExternalError("error", { service: "typesense", operation: "verify_saved_job_coverage" }, error);
     process.exitCode = 1;
   });
 }

--- a/apps/web/src/components/UserAvatar.tsx
+++ b/apps/web/src/components/UserAvatar.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { clearStoredUserImage } from "@/lib/actions/preferences";
+import { logExternalError } from "@/lib/safe-external-error";
 
 /**
  * Compute the 1-2 char initials placeholder displayed when no avatar
@@ -171,7 +172,7 @@ export function UserAvatar({
     // failure is logged; nothing the UI can do about it.
     Promise.resolve((onBrokenImage ?? clearStoredUserImage)()).catch(
       (err) => {
-        console.warn("[UserAvatar] broken-image heal failed", err);
+        logExternalError("warn", { service: "database", operation: "heal_user_avatar" }, err);
       },
     );
   }

--- a/apps/web/src/components/watchlist/watchlist-job-list.tsx
+++ b/apps/web/src/components/watchlist/watchlist-job-list.tsx
@@ -25,6 +25,7 @@ import { PendingJobIcon } from "@/components/PendingJobWarning";
 import { LanguageStatsRow } from "@/components/search/language-stats-row";
 import { SearchUnavailable } from "@/components/search/search-unavailable";
 import { formatDateDivider, getDateKey } from "@/components/watchlist/format-date-divider";
+import { logExternalError } from "@/lib/safe-external-error";
 
 const BATCH = 20;
 
@@ -126,7 +127,7 @@ export function WatchlistJobList({
       if (cancelled) return;
       setYearTotal(next);
     }).catch((err) => {
-      console.error("[WatchlistJobList] year-count refetch failed", err);
+      logExternalError("error", { service: "typesense", operation: "watchlist_year_count" }, err);
     });
     return () => {
       cancelled = true;

--- a/apps/web/src/db/migrate.ts
+++ b/apps/web/src/db/migrate.ts
@@ -3,6 +3,7 @@ dotenv.config({ path: ".env.local", quiet: true });
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
+import { logExternalError } from "@/lib/safe-external-error";
 
 const unpooledUrl = process.env.DATABASE_URL_UNPOOLED;
 const url = unpooledUrl ?? process.env.DATABASE_URL;
@@ -95,6 +96,6 @@ async function main() {
 }
 
 void main().catch((err: unknown) => {
-  console.error("Migration failed:", err);
+  logExternalError("error", { service: "database", operation: "migrate" }, err);
   process.exitCode = 1;
 });

--- a/apps/web/src/db/seed.ts
+++ b/apps/web/src/db/seed.ts
@@ -3,6 +3,7 @@ dotenv.config({ path: ".env.local" });
 import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
 import { company, jobPosting } from "./schema";
+import { logExternalError } from "@/lib/safe-external-error";
 
 const url = process.env.DATABASE_URL_UNPOOLED ?? process.env.DATABASE_URL;
 if (!url) {
@@ -83,6 +84,6 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error("Seed failed:", err);
+  logExternalError("error", { service: "database", operation: "seed" }, err);
   process.exit(1);
 });

--- a/apps/web/src/lib/__tests__/db-retry.test.ts
+++ b/apps/web/src/lib/__tests__/db-retry.test.ts
@@ -216,9 +216,12 @@ describe("withDbRetry", () => {
 
     await withDbRetry(fn, { sleep, label: "companyBySlug[chevron]" });
 
-    const warnArg = (console.warn as unknown as ReturnType<typeof vi.fn>).mock
-      .calls[0][0] as string;
-    expect(warnArg).toContain("companyBySlug[chevron]");
-    expect(warnArg).toContain("ECONNRESET");
+    const [event, payload] = (console.warn as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [string, Record<string, unknown>];
+    expect(event).toBe("external_client_error");
+    expect(payload).toMatchObject({
+      operation: "company_by_slug_chevron_retry",
+      code: "ECONNRESET",
+    });
   });
 });

--- a/apps/web/src/lib/__tests__/indexnow-observability.test.ts
+++ b/apps/web/src/lib/__tests__/indexnow-observability.test.ts
@@ -86,8 +86,11 @@ describe("logIndexNowResult", () => {
     });
   });
 
-  it("emits console.warn with the error message (not the raw object) for errored results", () => {
-    const networkErr = new Error("ECONNRESET");
+  it("emits console.warn with a safe error envelope for errored results", () => {
+    const networkErr = Object.assign(new Error("secret-bearing message"), {
+      code: "ECONNRESET",
+      config: { headers: { Authorization: "SECRET_CANARY_INDEXNOW" } },
+    });
     const result: NotifyIndexNowResult = {
       kind: "errored",
       error: networkErr,
@@ -101,12 +104,20 @@ describe("logIndexNowResult", () => {
     expect(payload).toMatchObject({
       label: "deleteWatchlist",
       kind: "errored",
-      error: "ECONNRESET",
+      error: {
+        event: "external_client_error",
+        service: "indexnow",
+        operation: "submit_urls",
+        kind: "network",
+        timeout: false,
+        code: "ECONNRESET",
+      },
       urlCount: 4,
     });
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain("SECRET_CANARY_INDEXNOW");
   });
 
-  it("stringifies non-Error errored values defensively", () => {
+  it("does not stringify non-Error errored values", () => {
     // `notifyIndexNow` types `error` as `unknown`. A non-Error throw
     // (string, number, AbortSignal timeout's DOMException-ish object)
     // must still serialise cleanly to a log line.
@@ -118,8 +129,13 @@ describe("logIndexNowResult", () => {
     logIndexNowResult("copyWatchlist", result);
 
     expect(warnSpy).toHaveBeenCalledOnce();
-    const payload = warnSpy.mock.calls[0][1] as { error: string };
-    expect(payload.error).toBe("raw string thrown");
+    const payload = warnSpy.mock.calls[0][1] as { error: Record<string, unknown> };
+    expect(payload.error).toMatchObject({
+      event: "external_client_error",
+      service: "indexnow",
+      kind: "unknown",
+    });
+    expect(JSON.stringify(payload)).not.toContain("raw string thrown");
   });
 
   it("emits console.debug (minimal output) for skipped results — preview deploys without INDEXNOW_KEY", () => {

--- a/apps/web/src/lib/__tests__/safe-external-error.test.ts
+++ b/apps/web/src/lib/__tests__/safe-external-error.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  EXTERNAL_CLIENT_LOG_EVENT,
+  logExternalError,
+  safeExternalError,
+} from "@/lib/safe-external-error";
+
+const CANARIES = [
+  "SECRET_CANARY_HEADER_6123",
+  "SECRET_CANARY_AUTH_6123",
+  "SECRET_CANARY_BODY_6123",
+  "SECRET_CANARY_CAUSE_6123",
+  "SECRET_CANARY_QUERY_6123",
+  "SECRET_CANARY_STACK_6123",
+];
+
+function credentialedAxiosError(): unknown {
+  const error = new Error(`request failed ${CANARIES[5]}`) as Error & Record<string, unknown>;
+  error.stack = `stack ${CANARIES[5]}`;
+  error.code = "ECONNABORTED";
+  error.config = {
+    auth: { username: "admin", password: CANARIES[1] },
+    headers: {
+      Authorization: `Bearer ${CANARIES[0]}`,
+      "X-TYPESENSE-API-KEY": CANARIES[0],
+    },
+    baseURL: "https://admin:password@typesense.example.com",
+    url: `/collections/${CANARIES[0]}/documents?x-typesense-api-key=${CANARIES[4]}`,
+    data: { token: CANARIES[2] },
+  };
+  error.response = {
+    status: 504,
+    headers: {
+      "x-request-id": "req-safe-123",
+      authorization: CANARIES[0],
+    },
+    data: { secret: CANARIES[2] },
+  };
+  error.cause = {
+    message: CANARIES[3],
+    headers: { cookie: CANARIES[3] },
+    body: CANARIES[2],
+  };
+  return error;
+}
+
+describe("safeExternalError", () => {
+  it("retains only allowlisted operational fields", () => {
+    expect(
+      safeExternalError(credentialedAxiosError(), {
+        service: "typesense",
+        operation: "search_jobs",
+        retryCount: 2,
+      }),
+    ).toEqual({
+      event: EXTERNAL_CLIENT_LOG_EVENT,
+      service: "typesense",
+      operation: "search_jobs",
+      kind: "timeout",
+      timeout: true,
+      status: 504,
+      code: "ECONNABORTED",
+      retry_count: 2,
+      request_id: "req-safe-123",
+      host: "typesense.example.com",
+      path: "/collections/[redacted]/documents",
+    });
+  });
+
+  it("never serializes secrets from nested SDK error shapes", () => {
+    const serialized = JSON.stringify(
+      safeExternalError(credentialedAxiosError(), {
+        service: "typesense",
+        operation: "search_jobs",
+      }),
+    );
+
+    for (const canary of CANARIES) expect(serialized).not.toContain(canary);
+    expect(serialized).not.toMatch(/authorization|api[-_]?key|password|bearer/i);
+  });
+
+  it("does not trust arbitrary codes, request IDs, operations, or throwing getters", () => {
+    const hostile = Object.create(null, {
+      code: { get: () => "SECRET_CODE" },
+      status: { get: () => 401 },
+      message: { get: () => { throw new Error("SECRET_GETTER"); } },
+      headers: { value: { "x-request-id": "SECRET_TOKEN_VALUE" } },
+    });
+
+    expect(
+      safeExternalError(hostile, {
+        service: "github",
+        operation: "bad operation with secrets",
+      }),
+    ).toEqual({
+      event: EXTERNAL_CLIENT_LOG_EVENT,
+      service: "github",
+      operation: "unknown",
+      kind: "auth",
+      timeout: false,
+      status: 401,
+    });
+  });
+
+  it("logs only the sanitized envelope", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    logExternalError(
+      "error",
+      { service: "redis", operation: "session_cache_scan" },
+      credentialedAxiosError(),
+    );
+
+    expect(spy).toHaveBeenCalledWith(
+      EXTERNAL_CLIENT_LOG_EVENT,
+      expect.objectContaining({ service: "redis", operation: "session_cache_scan" }),
+    );
+    expect(JSON.stringify(spy.mock.calls)).not.toContain("SECRET_CANARY");
+    spy.mockRestore();
+  });
+});

--- a/apps/web/src/lib/actions/__tests__/watchlist-year-count-fallback.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlist-year-count-fallback.test.ts
@@ -263,8 +263,12 @@ describe("getWatchlistPostingYearCount fallback (#3056)", () => {
     expect(mocks.withDbRetry).toHaveBeenCalledTimes(1);
     expect(mocks.dbExecute).toHaveBeenCalledTimes(1);
     expect(consoleError).toHaveBeenCalledWith(
-      "[getWatchlistPostingYearCount] Typesense failed, falling back to Postgres",
-      typesenseError,
+      "external_client_error",
+      expect.objectContaining({
+        service: "typesense",
+        operation: "watchlist_posting_year_count",
+        code: "ECONNRESET",
+      }),
     );
 
     const query = mocks.dbExecute.mock.calls[0]?.[0] as {

--- a/apps/web/src/lib/actions/my-jobs.ts
+++ b/apps/web/src/lib/actions/my-jobs.ts
@@ -6,6 +6,7 @@ import { savedJob, applicationInterview } from "@/db/schema";
 import { getSessionUserId } from "@/lib/sessionCache";
 import { decodeSavedJobSnapshot } from "@/lib/saved-job-snapshot";
 import { fetchIndexedPostingStates } from "@/lib/search/typesense-posting-detail";
+import { logExternalError } from "@/lib/safe-external-error";
 import {
   type ApplicationStatus,
   type InterviewType,
@@ -465,9 +466,10 @@ export async function addInterview(
     // Exhausted the retry budget without a successful insert. Surface as
     // a soft error so the caller can decide (the UI shows a toast). The
     // server log path picks up the underlying postgres error.
-    console.warn(
-      "[addInterview] failed to assign unique round after retries",
-      { savedJobId, type, lastErr },
+    logExternalError(
+      "warn",
+      { service: "database", operation: "assign_interview_round", retryCount: MAX_ATTEMPTS },
+      lastErr,
     );
     return { ok: false, error: "interview_round_failed" };
   }

--- a/apps/web/src/lib/actions/preferences.ts
+++ b/apps/web/src/lib/actions/preferences.ts
@@ -21,6 +21,7 @@ import { updateWatchlistField as tsUpdateWatchlistField } from "@/lib/search/typ
 import { isReservedUsername } from "@/lib/username";
 import { isTrivialWatchlist } from "@/lib/watchlist-utils";
 import { notifyIndexNow } from "@/lib/indexnow";
+import { logExternalError } from "@/lib/safe-external-error";
 import type { WatchlistFilters } from "@/lib/actions/watchlists";
 
 const PASSWORD_RESET_COOLDOWN_SECONDS = 60;
@@ -84,7 +85,7 @@ function invalidateJobLanguageDependentPages(): void {
       // locale/parameter combination represented by each pattern.
       revalidatePath(path, "page");
     } catch (err) {
-      console.warn("[preferences] revalidatePath failed for", path, err);
+      logExternalError("warn", { service: "external_http", operation: "revalidate_preferences" }, err);
     }
   }
 }
@@ -296,7 +297,7 @@ export async function clearStoredUserImage(): Promise<void> {
       .set({ image: null, updatedAt: new Date() })
       .where(eq(user.id, userId));
   } catch (err) {
-    console.warn("[clearStoredUserImage] db write failed", err);
+    logExternalError("warn", { service: "database", operation: "clear_user_image" }, err);
     return;
   }
 
@@ -552,8 +553,9 @@ export async function renameUsername(
       try {
         await invalidateRedis(`public-watchlist:${oldSlug}:${wl.slug}`);
       } catch (err) {
-        console.error(
-          "[renameUsername] redis public-watchlist invalidate failed",
+        logExternalError(
+          "error",
+          { service: "redis", operation: "rename_user_watchlist_invalidate" },
           err,
         );
       }
@@ -583,7 +585,7 @@ export async function renameUsername(
   try {
     await invalidateRedis("sitemap:watchlists");
   } catch (err) {
-    console.error("[renameUsername] sitemap invalidate failed", err);
+    logExternalError("error", { service: "redis", operation: "rename_user_sitemap_invalidate" }, err);
   }
 
   // Bust the Redis-cached `getSession()` blob for every device the user
@@ -618,7 +620,7 @@ export async function renameUsername(
     try {
       await notifyIndexNow(urls);
     } catch (err) {
-      console.error("[renameUsername] indexnow failed", err);
+      logExternalError("error", { service: "indexnow", operation: "rename_user_urls" }, err);
     }
   });
 

--- a/apps/web/src/lib/db-retry.ts
+++ b/apps/web/src/lib/db-retry.ts
@@ -21,13 +21,15 @@
  *   - Retry only on transient connection errors (see `isRetryable`)
  *   - Non-retryable errors (syntax, constraint, business logic) propagate
  *     immediately so callers see the real failure
- *   - `console.warn` on every retry so observability picks it up
+ *   - Structured `external_client_error` warning on every retry
  *
  * Scope of this PR: wraps `_fetchCompanyBySlugFromPostgres` only. Other
  * build-critical Postgres call sites (sitemap, related-posts, company
  * directory) are likely to want the same protection — flagged as a
  * follow-up rather than expanded mechanically here.
  */
+
+import { logExternalError } from "@/lib/safe-external-error";
 
 const RETRYABLE_ERROR_CODES = new Set([
   "ECONNRESET",
@@ -123,13 +125,14 @@ export async function withDbRetry<T>(
       const baseDelay = baseDelays[attempt - 1] ?? baseDelays[baseDelays.length - 1] ?? 200;
       const jitter = Math.floor(Math.random() * (maxJitter + 1));
       const delay = baseDelay + jitter;
-      const code = (err as { code?: unknown }).code;
-      const message = (err as { message?: unknown }).message;
-      console.warn(
-        `[${label}] transient error on attempt ${attempt}/${attempts}, ` +
-          `retrying in ${delay}ms ` +
-          `(code=${typeof code === "string" ? code : "n/a"}, ` +
-          `message=${typeof message === "string" ? message.slice(0, 200) : "n/a"})`,
+      logExternalError(
+        "warn",
+        {
+          service: "database",
+          operation: `${label}_retry`,
+          retryCount: attempt,
+        },
+        err,
       );
       await sleep(delay);
     }

--- a/apps/web/src/lib/indexnow.ts
+++ b/apps/web/src/lib/indexnow.ts
@@ -1,5 +1,6 @@
 import { siteConfig } from "@/content/config";
 import { type Locale, locales } from "@/lib/i18n";
+import { logExternalError, safeExternalError } from "@/lib/safe-external-error";
 
 const INDEXNOW_ENDPOINT = "https://api.indexnow.org/indexnow";
 
@@ -102,7 +103,7 @@ export async function notifyIndexNow(
     }
     return { kind: "submitted", status: res.status, urlCount: unique.length };
   } catch (err) {
-    console.error("[indexnow] submission failed", err);
+    logExternalError("error", { service: "indexnow", operation: "submit_urls" }, err);
     return { kind: "errored", error: err, urlCount: unique.length };
   }
 }
@@ -200,7 +201,10 @@ export function logIndexNowResult(
       console.warn(INDEXNOW_LOG_EVENT, {
         label,
         kind: "errored",
-        error: result.error instanceof Error ? result.error.message : String(result.error),
+        error: safeExternalError(result.error, {
+          service: "indexnow",
+          operation: "submit_urls",
+        }),
         urlCount: result.urlCount,
       });
       return;

--- a/apps/web/src/lib/og/company-og-cache.ts
+++ b/apps/web/src/lib/og/company-og-cache.ts
@@ -5,6 +5,7 @@ import {
   PutObjectCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
+import { logExternalError } from "@/lib/safe-external-error";
 
 const CONTENT_TYPE = "image/png";
 const CACHE_CONTROL = "public, max-age=31536000, immutable";
@@ -104,7 +105,7 @@ export async function readCompanyOgCache(key: string): Promise<Uint8Array | null
     return bodyToBytes(response.Body);
   } catch (error) {
     if (isMissingObjectError(error)) return null;
-    console.warn("[company-og-cache] read failed", error);
+    logExternalError("warn", { service: "r2", operation: "read_company_og" }, error);
     return null;
   }
 }
@@ -125,6 +126,6 @@ export async function writeCompanyOgCache(
       CacheControl: CACHE_CONTROL,
     }));
   } catch (error) {
-    console.warn("[company-og-cache] write failed", error);
+    logExternalError("warn", { service: "r2", operation: "write_company_og" }, error);
   }
 }

--- a/apps/web/src/lib/safe-external-error.ts
+++ b/apps/web/src/lib/safe-external-error.ts
@@ -1,0 +1,285 @@
+/**
+ * A deliberately lossy serializer for errors from credentialed clients.
+ *
+ * SDK errors commonly retain request headers, auth config, response bodies,
+ * credential-bearing URLs, and nested causes. Logging the raw object (or its
+ * message/stack) can therefore disclose secrets. This module emits only a
+ * small allowlist of operational fields and never copies arbitrary strings
+ * from an error.
+ */
+
+export const EXTERNAL_CLIENT_LOG_EVENT = "external_client_error";
+
+const SERVICES = new Set([
+  "auth",
+  "database",
+  "github",
+  "indexnow",
+  "r2",
+  "redis",
+  "typesense",
+  "external_http",
+]);
+
+const SAFE_CODES = new Set([
+  "EAI_AGAIN",
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EPIPE",
+  "ENETUNREACH",
+  "ENOTFOUND",
+  "ETIMEDOUT",
+  "ERR_CANCELED",
+  "ERR_NETWORK",
+  "UND_ERR_CONNECT_TIMEOUT",
+]);
+
+const REQUEST_ID_HEADERS = [
+  "cf-ray",
+  "request-id",
+  "traceparent",
+  "x-amz-request-id",
+  "x-request-id",
+] as const;
+
+const SENSITIVE_TEXT = /(api[-_]?key|authorization|bearer|credential|password|secret|session|token)/i;
+const SENSITIVE_OPERATION = /(api[-_]?key|authorization|bearer|credential|secret)/i;
+const SAFE_REQUEST_ID = /^[A-Za-z0-9._:/=-]{1,128}$/;
+const HIGH_ENTROPY_SEGMENT = /^[A-Za-z0-9_-]{24,}$/;
+
+export type ExternalService =
+  | "auth"
+  | "database"
+  | "github"
+  | "indexnow"
+  | "r2"
+  | "redis"
+  | "typesense"
+  | "external_http";
+
+export type ExternalErrorKind =
+  | "auth"
+  | "canceled"
+  | "invalid_request"
+  | "network"
+  | "not_found"
+  | "rate_limited"
+  | "timeout"
+  | "unknown"
+  | "upstream";
+
+export interface ExternalErrorContext {
+  service: ExternalService;
+  operation: string;
+  retryCount?: number;
+}
+
+export interface SafeExternalError {
+  event: typeof EXTERNAL_CLIENT_LOG_EVENT;
+  service: ExternalService | "unknown";
+  operation: string;
+  kind: ExternalErrorKind;
+  timeout: boolean;
+  status?: number;
+  code?: string;
+  retry_count?: number;
+  request_id?: string;
+  host?: string;
+  path?: string;
+}
+
+function safeGet(value: unknown, key: PropertyKey): unknown {
+  if ((typeof value !== "object" || value === null) && typeof value !== "function") {
+    return undefined;
+  }
+  try {
+    return Reflect.get(value, key);
+  } catch {
+    return undefined;
+  }
+}
+
+function errorNodes(error: unknown): unknown[] {
+  const nodes: unknown[] = [];
+  const queue: unknown[] = [error];
+  const seen = new Set<unknown>();
+
+  while (queue.length > 0 && nodes.length < 6) {
+    const node = queue.shift();
+    if ((typeof node !== "object" || node === null) && typeof node !== "function") continue;
+    if (seen.has(node)) continue;
+    seen.add(node);
+    nodes.push(node);
+
+    for (const key of ["cause", "originalError", "response"] as const) {
+      const nested = safeGet(node, key);
+      if (nested !== undefined && nested !== node) queue.push(nested);
+    }
+  }
+  return nodes;
+}
+
+function firstNumber(nodes: readonly unknown[], keys: readonly string[]): number | undefined {
+  for (const node of nodes) {
+    for (const key of keys) {
+      const candidate = safeGet(node, key);
+      if (typeof candidate === "number" && Number.isInteger(candidate)) return candidate;
+    }
+  }
+  return undefined;
+}
+
+function extractStatus(nodes: readonly unknown[]): number | undefined {
+  const status = firstNumber(nodes, ["httpStatus", "status", "statusCode"]);
+  return status !== undefined && status >= 100 && status <= 599 ? status : undefined;
+}
+
+function extractCode(nodes: readonly unknown[]): string | undefined {
+  for (const node of nodes) {
+    const code = safeGet(node, "code");
+    if (typeof code === "string" && SAFE_CODES.has(code)) return code;
+  }
+  return undefined;
+}
+
+function headerValue(headers: unknown, name: string): unknown {
+  const get = safeGet(headers, "get");
+  if (typeof get === "function") {
+    try {
+      return Reflect.apply(get, headers, [name]);
+    } catch {
+      return undefined;
+    }
+  }
+  return safeGet(headers, name) ?? safeGet(headers, name.toLowerCase());
+}
+
+function extractRequestId(nodes: readonly unknown[]): string | undefined {
+  for (const node of nodes) {
+    const headers = safeGet(node, "headers");
+    for (const name of REQUEST_ID_HEADERS) {
+      const value = headerValue(headers, name);
+      const candidate = Array.isArray(value) ? value[0] : value;
+      if (
+        typeof candidate === "string" &&
+        SAFE_REQUEST_ID.test(candidate) &&
+        !SENSITIVE_TEXT.test(candidate)
+      ) {
+        return candidate;
+      }
+    }
+  }
+  return undefined;
+}
+
+function redactUrlPart(value: string): string {
+  if (!value || value.length > 64 || SENSITIVE_TEXT.test(value) || HIGH_ENTROPY_SEGMENT.test(value)) {
+    return "[redacted]";
+  }
+  return value.replace(/[^A-Za-z0-9._~-]/g, "_");
+}
+
+function sanitizeOperation(value: string): string {
+  if (!value || value.length > 256 || SENSITIVE_OPERATION.test(value)) return "unknown";
+  const normalized = value
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^[_\-.]+|[_\-.]+$/g, "")
+    .slice(0, 64);
+  return /^[a-z][a-z0-9_.-]{0,63}$/.test(normalized) ? normalized : "unknown";
+}
+
+function sanitizeUrl(rawUrl: unknown, baseUrl?: unknown): { host?: string; path?: string } {
+  if (typeof rawUrl !== "string" || rawUrl.length === 0 || rawUrl.length > 2_048) return {};
+  try {
+    const base = typeof baseUrl === "string" ? baseUrl : "https://external.invalid";
+    const parsed = new URL(rawUrl, base);
+    const host = parsed.hostname
+      .split(".")
+      .map(redactUrlPart)
+      .join(".");
+    const pathSegments = parsed.pathname.split("/").filter(Boolean).map(redactUrlPart);
+    return {
+      ...(parsed.hostname !== "external.invalid" && host ? { host } : {}),
+      path: pathSegments.length > 0 ? `/${pathSegments.join("/")}` : "/",
+    };
+  } catch {
+    return {};
+  }
+}
+
+function extractUrl(nodes: readonly unknown[]): { host?: string; path?: string } {
+  for (const node of nodes) {
+    const config = safeGet(node, "config");
+    const fromConfig = sanitizeUrl(safeGet(config, "url"), safeGet(config, "baseURL"));
+    if (fromConfig.host || fromConfig.path) return fromConfig;
+
+    const direct = sanitizeUrl(safeGet(node, "url"));
+    if (direct.host || direct.path) return direct;
+
+    const request = safeGet(node, "request");
+    const fromRequest = sanitizeUrl(safeGet(request, "responseURL"));
+    if (fromRequest.host || fromRequest.path) return fromRequest;
+  }
+  return {};
+}
+
+function classify(status: number | undefined, code: string | undefined): ExternalErrorKind {
+  if (code === "ETIMEDOUT" || code === "ECONNABORTED" || code === "UND_ERR_CONNECT_TIMEOUT") {
+    return "timeout";
+  }
+  if (code === "ERR_CANCELED") return "canceled";
+  if (code) return "network";
+  if (status === 401 || status === 403) return "auth";
+  if (status === 404) return "not_found";
+  if (status === 408 || status === 504) return "timeout";
+  if (status === 429) return "rate_limited";
+  if (status !== undefined && status >= 400 && status < 500) return "invalid_request";
+  if (status !== undefined && status >= 500) return "upstream";
+  return "unknown";
+}
+
+export function safeExternalError(
+  error: unknown,
+  context: ExternalErrorContext,
+): SafeExternalError {
+  const nodes = errorNodes(error);
+  const status = extractStatus(nodes);
+  const code = extractCode(nodes);
+  const requestId = extractRequestId(nodes);
+  const url = extractUrl(nodes);
+  const service = SERVICES.has(context.service) ? context.service : "unknown";
+  const operation = sanitizeOperation(context.operation);
+  const retryCount = context.retryCount;
+
+  return {
+    event: EXTERNAL_CLIENT_LOG_EVENT,
+    service,
+    operation,
+    kind: classify(status, code),
+    timeout:
+      code === "ETIMEDOUT" ||
+      code === "ECONNABORTED" ||
+      code === "UND_ERR_CONNECT_TIMEOUT" ||
+      status === 408 ||
+      status === 504,
+    ...(status !== undefined ? { status } : {}),
+    ...(code !== undefined ? { code } : {}),
+    ...(typeof retryCount === "number" && Number.isInteger(retryCount) && retryCount >= 0
+      ? { retry_count: retryCount }
+      : {}),
+    ...(requestId ? { request_id: requestId } : {}),
+    ...url,
+  };
+}
+
+export function logExternalError(
+  level: "error" | "warn",
+  context: ExternalErrorContext,
+  error: unknown,
+): void {
+  console[level](EXTERNAL_CLIENT_LOG_EVENT, safeExternalError(error, context));
+}

--- a/apps/web/src/lib/search/__tests__/typesense-retry.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense-retry.test.ts
@@ -254,9 +254,9 @@ describe("withTypesenseRetry", () => {
 
     await withTypesenseRetry(fn, { sleep, label: "search" });
 
-    const warnArg = (console.warn as unknown as ReturnType<typeof vi.fn>).mock
-      .calls[0][0] as string;
-    expect(warnArg).toContain("search");
-    expect(warnArg).toContain("ECONNRESET");
+    const [event, payload] = (console.warn as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [string, Record<string, unknown>];
+    expect(event).toBe("external_client_error");
+    expect(payload).toMatchObject({ operation: "search_retry", code: "ECONNRESET" });
   });
 });

--- a/apps/web/src/lib/search/search-runner.ts
+++ b/apps/web/src/lib/search/search-runner.ts
@@ -20,6 +20,7 @@ import {
   ANON_MAX_POSTINGS,
   ANON_MAX_WATCHLIST_POSTINGS,
 } from "./constants";
+import { logExternalError } from "@/lib/safe-external-error";
 
 type SearchInput = SearchFilters & { keywords: string[]; offset: number; limit: number };
 type ListInput = SearchFilters & { offset: number; limit: number };
@@ -71,7 +72,7 @@ export async function runSearchJobs(
       const result = await provider.search(params);
       if (!result.degraded) return applyAnonCap(result, params.offset, isLoggedIn);
     } catch (err) {
-      console.error("[search-runner] browser searchJobs failed, falling back", err);
+      logExternalError("error", { service: "typesense", operation: "browser_search_jobs" }, err);
     }
   }
   return serverSearchJobs(params);
@@ -90,7 +91,11 @@ export async function runListTopCompanies(
       const result = await provider.listTopCompanies(params);
       if (!result.degraded) return applyAnonCap(result, params.offset, isLoggedIn);
     } catch (err) {
-      console.error("[search-runner] browser listTopCompanies failed, falling back", err);
+      logExternalError(
+        "error",
+        { service: "typesense", operation: "browser_list_top_companies" },
+        err,
+      );
     }
   }
   return serverListTopCompanies(params);
@@ -134,7 +139,11 @@ export async function runGetWatchlistPostings(
           : undefined;
       return truncated ? { ...result, truncated } : result;
     } catch (err) {
-      console.error("[search-runner] browser getWatchlistPostings failed, falling back", err);
+      logExternalError(
+        "error",
+        { service: "typesense", operation: "browser_watchlist_postings" },
+        err,
+      );
     }
   }
   return serverGetWatchlistPostings(params);
@@ -172,7 +181,11 @@ export async function runGetCompanyPostings(
       }
       return result;
     } catch (err) {
-      console.error("[search-runner] browser getCompanyPostings failed, falling back", err);
+      logExternalError(
+        "error",
+        { service: "typesense", operation: "browser_company_postings" },
+        err,
+      );
     }
   }
   return serverGetCompanyPostings(params);

--- a/apps/web/src/lib/search/typesense-browser.ts
+++ b/apps/web/src/lib/search/typesense-browser.ts
@@ -15,6 +15,7 @@ import type {
   ExperienceBucket,
 } from "./types";
 import { normalizePostingTitle } from "@/lib/posting-title";
+import { logExternalError } from "@/lib/safe-external-error";
 
 interface JobPostingDoc {
   id: string;
@@ -226,7 +227,7 @@ export class TypesenseBrowserProvider implements SearchProvider {
 
       return { companies, totalCompanies };
     } catch (err) {
-      console.error("[typesense-browser] search error", err);
+      logExternalError("error", { service: "typesense", operation: "browser_search_jobs" }, err);
       return emptyResponse();
     }
   }
@@ -243,7 +244,11 @@ export class TypesenseBrowserProvider implements SearchProvider {
       }
       return await this.filtered(cfg, filterStr, offset, limit, locationIds);
     } catch (err) {
-      console.error("[typesense-browser] listTopCompanies error", err);
+      logExternalError(
+        "error",
+        { service: "typesense", operation: "browser_list_top_companies" },
+        err,
+      );
       return emptyResponse();
     }
   }
@@ -390,7 +395,7 @@ export class TypesenseBrowserProvider implements SearchProvider {
       });
       return (r.hits ?? []).map((h) => mapHitToPosting(h, locationIds));
     } catch (err) {
-      console.error("[typesense-browser] loadPostings error", err);
+      logExternalError("error", { service: "typesense", operation: "browser_load_postings" }, err);
       return [];
     }
   }
@@ -475,7 +480,7 @@ export class TypesenseBrowserProvider implements SearchProvider {
       buckets.sort((a, b) => a.min - b.min);
       return buckets;
     } catch (err) {
-      console.error("[typesense-browser] salary histogram error", err);
+      logExternalError("error", { service: "typesense", operation: "browser_salary_histogram" }, err);
       return [];
     }
   }
@@ -505,7 +510,11 @@ export class TypesenseBrowserProvider implements SearchProvider {
       buckets.sort((a, b) => a.years - b.years);
       return buckets;
     } catch (err) {
-      console.error("[typesense-browser] experience histogram error", err);
+      logExternalError(
+        "error",
+        { service: "typesense", operation: "browser_experience_histogram" },
+        err,
+      );
       return [];
     }
   }

--- a/apps/web/src/lib/search/typesense-posting-detail.ts
+++ b/apps/web/src/lib/search/typesense-posting-detail.ts
@@ -1,6 +1,7 @@
 import "server-only";
 
 import { normalizePostingTitle } from "@/lib/posting-title";
+import { logExternalError } from "@/lib/safe-external-error";
 import { getSearchClient } from "./typesense-client";
 import { withTypesenseRetry } from "./typesense-retry";
 
@@ -149,7 +150,7 @@ async function retrieveOptionalDocument<T extends Record<string, unknown>>(
   try {
     return await retrieveDocument<T>(collection, id, label);
   } catch (error) {
-    console.warn(`[typesense-posting-detail] ${label} unavailable`, error);
+    logExternalError("warn", { service: "typesense", operation: label }, error);
     return null;
   }
 }
@@ -253,7 +254,7 @@ export async function fetchIndexedPostingStates(
       ]),
     );
   } catch (error) {
-    console.warn("[typesense-posting-detail] saved-job states unavailable", error);
+    logExternalError("warn", { service: "typesense", operation: "saved_job_states" }, error);
     return new Map();
   }
 }
@@ -360,7 +361,7 @@ export async function fetchIndexedPostingDetail(
       descriptionLocale,
     };
   } catch (error) {
-    console.error("[typesense-posting-detail] posting detail unavailable", error);
+    logExternalError("error", { service: "typesense", operation: "posting_detail" }, error);
     return null;
   }
 }

--- a/apps/web/src/lib/search/typesense-retry.ts
+++ b/apps/web/src/lib/search/typesense-retry.ts
@@ -29,8 +29,10 @@
  *   - Non-retryable errors (4xx auth, 400 schema, syntax) propagate
  *     immediately so the upstream `try/catch` returns `emptyResponse()`
  *     without burning the budget
- *   - `console.warn` on every retry so observability picks it up
+ *   - Structured `external_client_error` warning on every retry
  */
+
+import { logExternalError } from "@/lib/safe-external-error";
 
 const RETRYABLE_NODE_CODES = new Set([
   "ECONNRESET",
@@ -204,15 +206,14 @@ export async function withTypesenseRetry<T>(
         baseDelays[attempt - 1] ?? baseDelays[baseDelays.length - 1] ?? 200;
       const jitter = Math.floor(Math.random() * (maxJitter + 1));
       const delay = baseDelay + jitter;
-      const code = (err as { code?: unknown }).code;
-      const httpStatus = (err as { httpStatus?: unknown }).httpStatus;
-      const message = (err as { message?: unknown }).message;
-      console.warn(
-        `[${label}] transient error on attempt ${attempt}/${attempts}, ` +
-          `retrying in ${delay}ms ` +
-          `(code=${typeof code === "string" ? code : "n/a"}, ` +
-          `httpStatus=${typeof httpStatus === "number" ? httpStatus : "n/a"}, ` +
-          `message=${typeof message === "string" ? message.slice(0, 200) : "n/a"})`,
+      logExternalError(
+        "warn",
+        {
+          service: "typesense",
+          operation: `${label}_retry`,
+          retryCount: attempt,
+        },
+        err,
       );
       await sleep(delay);
     }

--- a/apps/web/src/lib/search/typesense-watchlist.ts
+++ b/apps/web/src/lib/search/typesense-watchlist.ts
@@ -9,6 +9,7 @@
  */
 
 import { getWriteClient } from "@/lib/search/typesense-client";
+import { logExternalError } from "@/lib/safe-external-error";
 
 export interface WatchlistDoc {
   id: string;
@@ -36,7 +37,7 @@ export function upsertWatchlist(doc: WatchlistDoc): void {
     .documents()
     .upsert(doc)
     .catch((err) => {
-      console.error("[typesense] failed to upsert watchlist", doc.id, err);
+      logExternalError("error", { service: "typesense", operation: "upsert_watchlist" }, err);
     });
 }
 
@@ -51,7 +52,7 @@ export function deleteWatchlist(watchlistId: string): void {
     .catch((err) => {
       // 404 is fine — the doc may not exist (e.g., was never public)
       if (err?.httpStatus === 404) return;
-      console.error("[typesense] failed to delete watchlist", watchlistId, err);
+      logExternalError("error", { service: "typesense", operation: "delete_watchlist" }, err);
     });
 }
 
@@ -69,6 +70,6 @@ export function updateWatchlistField(
     .catch((err) => {
       // 404 is fine — the doc may not exist yet
       if (err?.httpStatus === 404) return;
-      console.error("[typesense] failed to update watchlist", watchlistId, err);
+      logExternalError("error", { service: "typesense", operation: "update_watchlist" }, err);
     });
 }

--- a/apps/web/src/lib/search/typesense.ts
+++ b/apps/web/src/lib/search/typesense.ts
@@ -18,6 +18,7 @@ import type {
   ExperienceBucket,
 } from "./types";
 import { normalizePostingTitle } from "@/lib/posting-title";
+import { logExternalError } from "@/lib/safe-external-error";
 
 // ── Typesense document shapes ──────────────────────────────────────
 
@@ -283,7 +284,7 @@ export class TypesenseSearchProvider implements SearchProvider {
 
       return mapGroupedHits(groupedHits, totalCompanies, yearCountMap, locationIds);
     } catch (err) {
-      console.error("[typesense] search error", err);
+      logExternalError("error", { service: "typesense", operation: "search_jobs" }, err);
       return emptyResponse();
     }
   }
@@ -309,7 +310,7 @@ export class TypesenseSearchProvider implements SearchProvider {
         locationIds,
       );
     } catch (err) {
-      console.error("[typesense] search error", err);
+      logExternalError("error", { service: "typesense", operation: "list_top_companies" }, err);
       return emptyResponse();
     }
   }
@@ -524,7 +525,7 @@ export class TypesenseSearchProvider implements SearchProvider {
         mapHitToPosting(hit, locationIds),
       );
     } catch (err) {
-      console.error("[typesense] search error", err);
+      logExternalError("error", { service: "typesense", operation: "load_postings" }, err);
       return [];
     }
   }
@@ -603,7 +604,7 @@ export class TypesenseSearchProvider implements SearchProvider {
 
       return { postings, activeCount, yearCount };
     } catch (err) {
-      console.error("[typesense] search error", err);
+      logExternalError("error", { service: "typesense", operation: "load_postings_with_counts" }, err);
       return { postings: [], activeCount: 0, yearCount: 0 };
     }
   }
@@ -649,7 +650,7 @@ export class TypesenseSearchProvider implements SearchProvider {
       buckets.sort((a: SalaryBucket, b: SalaryBucket) => a.min - b.min);
       return buckets;
     } catch (err) {
-      console.error("[typesense] search error", err);
+      logExternalError("error", { service: "typesense", operation: "salary_histogram" }, err);
       return [];
     }
   }
@@ -697,7 +698,7 @@ export class TypesenseSearchProvider implements SearchProvider {
       );
       return buckets;
     } catch (err) {
-      console.error("[typesense] search error", err);
+      logExternalError("error", { service: "typesense", operation: "experience_histogram" }, err);
       return [];
     }
   }

--- a/apps/web/src/lib/seo.tsx
+++ b/apps/web/src/lib/seo.tsx
@@ -1,5 +1,6 @@
 import { siteConfig } from "@/content/config";
 import { locales, type Locale } from "@/lib/i18n";
+import { logExternalError } from "@/lib/safe-external-error";
 
 /**
  * Build hreflang alternates for Next.js Metadata API.
@@ -191,7 +192,7 @@ export function JsonLd({ data }: { data: Record<string, unknown> }) {
   try {
     json = JSON.stringify(data).replace(/</g, "\\u003c");
   } catch (err) {
-    console.error("[JsonLd] failed to serialise payload", err);
+    logExternalError("error", { service: "external_http", operation: "serialize_json_ld" }, err);
     return null;
   }
   return (

--- a/apps/web/src/lib/services/__tests__/company-detail-lookup.test.ts
+++ b/apps/web/src/lib/services/__tests__/company-detail-lookup.test.ts
@@ -170,7 +170,11 @@ describe("company slug lookup resolver", () => {
     expect(fetchFromPostgres).toHaveBeenCalledWith("acme", "en");
     expect(logger.error).toHaveBeenCalledWith(
       "[company] Typesense failed, falling back to Postgres",
-      error,
+      expect.objectContaining({
+        event: "external_client_error",
+        service: "typesense",
+        operation: "company_detail_lookup",
+      }),
     );
     expect(logger.warn).not.toHaveBeenCalled();
   });

--- a/apps/web/src/lib/services/company-detail-lookup.ts
+++ b/apps/web/src/lib/services/company-detail-lookup.ts
@@ -1,3 +1,5 @@
+import { safeExternalError } from "@/lib/safe-external-error";
+
 export interface CompanyDetail {
   id: string;
   name: string;
@@ -80,13 +82,25 @@ export async function resolveCompanyBySlug(
   }
   if (!deps.hasPostgresConfig()) {
     if (typesenseError) {
-      logger.error("[company] Typesense failed and Postgres fallback is unavailable", typesenseError);
+      logger.error(
+        "[company] Typesense failed and Postgres fallback is unavailable",
+        safeExternalError(typesenseError, {
+          service: "typesense",
+          operation: "company_detail_lookup",
+        }),
+      );
     }
     logger.warn("[company] Postgres fallback skipped because DATABASE_URL is not configured");
     return null;
   }
   if (typesenseError) {
-    logger.error("[company] Typesense failed, falling back to Postgres", typesenseError);
+    logger.error(
+      "[company] Typesense failed, falling back to Postgres",
+      safeExternalError(typesenseError, {
+        service: "typesense",
+        operation: "company_detail_lookup",
+      }),
+    );
   }
   return deps.fetchFromPostgres(slug, locale);
 }

--- a/apps/web/src/lib/services/company.ts
+++ b/apps/web/src/lib/services/company.ts
@@ -25,6 +25,7 @@ import { getCurrencyRates } from "@/lib/services/search";
 import { firstOf, idsOrUndefined, parseRangeParam } from "@/lib/search/params";
 import { convertToEur } from "@/lib/salary";
 import { canonicalStringCompare } from "@/lib/sort";
+import { logExternalError } from "@/lib/safe-external-error";
 
 export { getCompanyBySlug } from "@/lib/services/company-detail";
 export type { CompanyDetail } from "@/lib/services/company-detail";
@@ -142,7 +143,7 @@ export async function searchCompaniesForWatchlist(params: {
     return await _searchCompaniesForWatchlistTypesense(params);
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
-    console.error("[searchCompaniesForWatchlist] Typesense failed, falling back to Postgres", err);
+    logExternalError("error", { service: "typesense", operation: "search_companies_watchlist" }, err);
     return _searchCompaniesForWatchlistPostgres(params);
   }
 }
@@ -775,7 +776,7 @@ async function _fetchSimilarUnfiltered(
     const hasMore = offset + companies.length < found;
     return { companies, hasMore };
   } catch (err) {
-    console.error("[_fetchSimilarUnfiltered] Typesense failed, returning empty page", err);
+    logExternalError("error", { service: "typesense", operation: "similar_companies" }, err);
     return { companies: [], hasMore: false };
   }
 }
@@ -982,7 +983,7 @@ async function _fetchSimilarFiltered(
 
     return { companies, hasMore: false };
   } catch (err) {
-    console.error("[_fetchSimilarFiltered] Typesense failed, returning empty page", err);
+    logExternalError("error", { service: "typesense", operation: "similar_companies_filtered" }, err);
     return { companies: [], hasMore: false };
   }
 }

--- a/apps/web/src/lib/services/watchlists.ts
+++ b/apps/web/src/lib/services/watchlists.ts
@@ -29,6 +29,7 @@ import { expandLocationIdsBatch, resolveLocationSlugs } from "@/lib/actions/loca
 import { expandOccupationIdsBatch, resolveOccupationSlugs, resolveSenioritySlugs, resolveTechnologySlugs } from "@/lib/services/taxonomy";
 import { getSearchClient } from "@/lib/search/typesense-client";
 import { normalizePostingTitle } from "@/lib/posting-title";
+import { logExternalError } from "@/lib/safe-external-error";
 import { buildFilterString, POSTING_BASE_FILTER, POSTING_FLOW_FILTER } from "@/lib/search/typesense-filters";
 import {
   isTypesenseUnavailableError,
@@ -297,7 +298,7 @@ export async function createWatchlist(params: {
       try {
         await _invalidateWatchlistCaches(userId, [slug]);
       } catch (err) {
-        console.error("[createWatchlist] cache invalidate failed", err);
+        logExternalError("error", { service: "redis", operation: "create_watchlist_invalidate" }, err);
       }
     });
   }
@@ -315,7 +316,7 @@ export async function createWatchlist(params: {
           logLabel: "createWatchlist",
         });
       } catch (err) {
-        console.error("[createWatchlist] post-mutation hook failed", err);
+        logExternalError("error", { service: "external_http", operation: "create_watchlist_hook" }, err);
       }
     });
   }
@@ -461,7 +462,7 @@ export async function updateWatchlist(params: {
         );
       }
     } catch (err) {
-      console.error("[updateWatchlist] post-mutation hook failed", err);
+      logExternalError("error", { service: "external_http", operation: "update_watchlist_hook" }, err);
     }
   });
 
@@ -510,7 +511,7 @@ export async function deleteWatchlist(
         "deleteWatchlist",
       );
     } catch (err) {
-      console.error("[deleteWatchlist] post-mutation hook failed", err);
+      logExternalError("error", { service: "external_http", operation: "delete_watchlist_hook" }, err);
     }
   });
 
@@ -607,7 +608,7 @@ export async function copyWatchlist(
     try {
       await _invalidateWatchlistCaches(userId, [slug]);
     } catch (err) {
-      console.error("[copyWatchlist] cache invalidate failed", err);
+      logExternalError("error", { service: "redis", operation: "copy_watchlist_invalidate" }, err);
     }
   });
 
@@ -621,7 +622,7 @@ export async function copyWatchlist(
       const count = await _getWatchlistMirrorCount(watchlistId);
       tsUpdateWatchlistField(watchlistId, { mirror_count: count });
     } catch (err) {
-      console.error("[copyWatchlist] Typesense mirror_count hook failed", err);
+      logExternalError("error", { service: "typesense", operation: "copy_watchlist_mirror_count" }, err);
     }
   });
 
@@ -784,7 +785,7 @@ async function _resolveUserListingCounts(
     try {
       indexedById = await buildIndexedFiltersForUserRows(filteredRows, locale);
     } catch (err) {
-      console.error("[getUserWatchlists] filter id resolution failed", err);
+      logExternalError("error", { service: "typesense", operation: "user_watchlist_filter_ids" }, err);
     }
   }
 
@@ -882,7 +883,7 @@ function hasPreciseListingCountFilters(
 async function resolvePreciseListingCounts(
   candidates: ListingCountCandidate[],
   languages: string[],
-  label: string,
+  _label: string,
 ): Promise<Map<string, number>> {
   if (candidates.length === 0) return new Map();
 
@@ -909,7 +910,11 @@ async function resolvePreciseListingCounts(
       counts.set(candidate.id, results[index]?.found ?? candidate.fallbackCount);
     });
   } catch (err) {
-    console.error(`[${label}] precise listing count multi_search failed`, err);
+    logExternalError(
+      "error",
+      { service: "typesense", operation: "precise_listing_count" },
+      err,
+    );
     for (const candidate of searchable) counts.set(candidate.id, candidate.fallbackCount);
   }
 
@@ -1042,7 +1047,7 @@ export async function getWatchlistByUserAndSlug(
           .set({ lastAccessedAt: new Date() })
           .where(eq(watchlist.id, row.wl_id));
       } catch (err) {
-        console.error("[getWatchlistByUserAndSlug] lastAccessedAt touch failed", err);
+        logExternalError("error", { service: "database", operation: "touch_watchlist_access" }, err);
       }
     });
   }
@@ -1312,7 +1317,7 @@ async function buildIndexedWatchlistFiltersJson(filters: WatchlistFilters): Prom
       technologyIds: techMap.size > 0 ? [...techMap.values()].map((t) => t.id) : undefined,
     };
   } catch (err) {
-    console.error("[buildIndexedWatchlistFiltersJson] taxonomy resolve failed", err);
+    logExternalError("error", { service: "typesense", operation: "indexed_watchlist_taxonomy" }, err);
   }
 
   const payload = buildIndexedWatchlistFiltersPayload(filters, resolvedIds);
@@ -1322,12 +1327,12 @@ async function buildIndexedWatchlistFiltersJson(filters: WatchlistFilters): Prom
 
 async function safeBuildIndexedWatchlistFiltersJson(
   filters: WatchlistFilters,
-  label: string,
+  _label: string,
 ): Promise<string | undefined> {
   try {
     return await buildIndexedWatchlistFiltersJson(filters);
   } catch (err) {
-    console.error(`[${label}] indexed watchlist filters build failed`, err);
+    logExternalError("error", { service: "typesense", operation: "indexed_watchlist_filters" }, err);
     return undefined;
   }
 }
@@ -1440,7 +1445,7 @@ export async function getWatchlistMatchingCompanyCount(
       });
       return result.facet_counts?.[0]?.stats?.total_values ?? 0;
     } catch (err) {
-      console.error("[getWatchlistMatchingCompanyCount] Typesense failed", err);
+      logExternalError("error", { service: "typesense", operation: "watchlist_company_count" }, err);
       return 0;
     }
     // Aligned to the watchlist-detail ISR window (1h, see page.tsx). Bumped
@@ -1529,7 +1534,7 @@ async function queryPublicWatchlists(params: {
     try {
       indexedById = await buildIndexedFiltersForUserRows(filteredRows, params.locale);
     } catch (err) {
-      console.error("[queryPublicWatchlists] filter id resolution failed", err);
+      logExternalError("error", { service: "typesense", operation: "public_watchlist_filter_ids" }, err);
     }
   }
 
@@ -1597,7 +1602,7 @@ async function _patchPreciseCountsForDiscover(
     try {
       hydratedCompanyIds = await _fetchWatchlistCompanyIds(companyScopedEntries.map((e) => e.id));
     } catch (err) {
-      console.error("[_patchPreciseCountsForDiscover] company id hydration failed", err);
+      logExternalError("error", { service: "database", operation: "hydrate_watchlist_company_ids" }, err);
       return entries;
     }
   }
@@ -1680,7 +1685,7 @@ export async function searchPublicWatchlists(params: {
           };
         }
       } catch (err) {
-        console.error("[searchPublicWatchlists] Typesense failed, falling back to Postgres", err);
+        logExternalError("error", { service: "typesense", operation: "search_public_watchlists" }, err);
       }
       // Empty Typesense result or error — fall back to Postgres
       return queryPublicWatchlists({
@@ -1720,7 +1725,7 @@ export async function getPopularWatchlists(params: {
           };
         }
       } catch (err) {
-        console.error("[getPopularWatchlists] Typesense failed, falling back to Postgres", err);
+        logExternalError("error", { service: "typesense", operation: "popular_watchlists" }, err);
       }
       // Empty Typesense result or error — fall back to Postgres
       return queryPublicWatchlists({
@@ -1754,7 +1759,7 @@ export async function getWatchlistPostings(
     return await _getWatchlistPostingsTypesense(params, userId);
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
-    console.error("[getWatchlistPostings] Typesense failed, falling back to Postgres", err);
+    logExternalError("error", { service: "typesense", operation: "watchlist_postings" }, err);
     return _getWatchlistPostingsPostgres(params, userId);
   }
 }
@@ -1782,10 +1787,7 @@ export async function getPublicWatchlistPostings(
     return await _getWatchlistPostingsTypesense(params, null);
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
-    console.error(
-      "[getPublicWatchlistPostings] Typesense failed, falling back to Postgres",
-      err,
-    );
+    logExternalError("error", { service: "typesense", operation: "public_watchlist_postings" }, err);
     return _getWatchlistPostingsPostgres(params, null);
   }
 }
@@ -1852,7 +1854,7 @@ export async function getWatchlistPostingYearCount(
     return results.reduce((sum, result) => sum + (result.found ?? 0), 0);
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
-    console.error("[getWatchlistPostingYearCount] Typesense failed, falling back to Postgres", err);
+    logExternalError("error", { service: "typesense", operation: "watchlist_posting_year_count" }, err);
     return _getWatchlistPostingYearCountPostgres(params);
   }
 }
@@ -1947,7 +1949,7 @@ export async function getWatchlistPostingDisplayCounts(
       yearJobs,
     };
   } catch (err) {
-    console.error("[getWatchlistPostingDisplayCounts] Typesense failed", err);
+    logExternalError("error", { service: "typesense", operation: "watchlist_display_counts" }, err);
     return { activeJobs: 0, yearJobs: 0 };
   }
 }
@@ -1992,7 +1994,7 @@ export async function addCompanyToWatchlist(
         await _invalidateWatchlistCaches(userId, [wl.slug]);
         await _syncWatchlistCompanyCountToTypesense(watchlistId);
       } catch (err) {
-        console.error("[addCompanyToWatchlist] post-mutation hook failed", err);
+        logExternalError("error", { service: "typesense", operation: "add_watchlist_company_hook" }, err);
       }
     });
   }
@@ -2035,7 +2037,7 @@ export async function clearWatchlistCompanies(
         await _invalidateWatchlistCaches(userId, [wl.slug]);
         await _syncWatchlistCompanyCountToTypesense(watchlistId);
       } catch (err) {
-        console.error("[clearWatchlistCompanies] post-mutation hook failed", err);
+        logExternalError("error", { service: "typesense", operation: "clear_watchlist_companies_hook" }, err);
       }
     });
   }
@@ -2084,7 +2086,7 @@ export async function removeCompanyFromWatchlist(
         await _invalidateWatchlistCaches(userId, [wl.slug]);
         await _syncWatchlistCompanyCountToTypesense(watchlistId);
       } catch (err) {
-        console.error("[removeCompanyFromWatchlist] post-mutation hook failed", err);
+        logExternalError("error", { service: "typesense", operation: "remove_watchlist_company_hook" }, err);
       }
     });
   }
@@ -2721,7 +2723,7 @@ async function _invalidateWatchlistCaches(
       try {
         await invalidate(`public-watchlist:${userSlug}:${slug}`);
       } catch (err) {
-        console.error("[invalidateWatchlistCaches] redis invalidate failed", err);
+        logExternalError("error", { service: "redis", operation: "invalidate_watchlist_caches" }, err);
       }
     }
   }

--- a/apps/web/src/lib/sessionCache.ts
+++ b/apps/web/src/lib/sessionCache.ts
@@ -3,6 +3,7 @@ import { cache } from "react";
 import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
 import { kvDelete, kvGet, kvMget, kvScan, kvSet } from "@/lib/cache";
+import { logExternalError } from "@/lib/safe-external-error";
 
 const SESSION_TTL = 300; // 5 minutes
 
@@ -133,10 +134,7 @@ export async function invalidateAllUserSessionCacheEntries(
       }
     } while (String(cursor) !== "0");
   } catch (err) {
-    console.error(
-      "[invalidateAllUserSessionCacheEntries] redis scan failed",
-      err,
-    );
+    logExternalError("error", { service: "redis", operation: "scan_session_cache" }, err);
   }
   return deleted;
 }

--- a/apps/web/src/lib/sitemap.ts
+++ b/apps/web/src/lib/sitemap.ts
@@ -7,6 +7,7 @@ import { withDbRetry } from "@/lib/db-retry";
 import { siteConfig } from "@/content/config";
 import { locales } from "@/lib/i18n";
 import { listBlogPosts, getBlogPostLocales, type BlogPostSummary } from "@/lib/blog";
+import { logExternalError } from "@/lib/safe-external-error";
 
 /**
  * Sitemap data + entry builders backing `app/sitemap.xml/route.ts`.
@@ -218,10 +219,7 @@ export async function buildSitemap(): Promise<MetadataRoute.Sitemap> {
   try {
     watchlists = await cachedSitemapWatchlists();
   } catch (err) {
-    console.error(
-      "[sitemap] watchlist fetch failed; serving static entries only",
-      err,
-    );
+    logExternalError("error", { service: "database", operation: "sitemap_watchlists" }, err);
   }
   let blogEntries: MetadataRoute.Sitemap = [];
   try {
@@ -232,7 +230,7 @@ export async function buildSitemap(): Promise<MetadataRoute.Sitemap> {
     // frontmatter or a future change to `getBlogPostLocales` could
     // surface here. Degrade to "no blog entries" rather than tearing
     // down the whole urlset (which was the second half of #2694).
-    console.error("[sitemap] blog entries failed; skipping", err);
+    logExternalError("error", { service: "external_http", operation: "sitemap_blog_entries" }, err);
   }
   return [
     ...staticAndExploreEntries(),


### PR DESCRIPTION
## What changed

- add a deliberately lossy external-client error serializer that preserves only service, operation, normalized kind, status, timeout, retry count, request ID, and sanitized host/path
- route Typesense, Redis/Upstash, database, R2, IndexNow, page-loader, retry, and maintenance-script failures through the safe envelope
- add nested Axios/SDK secret-canary coverage, including auth and rate-limit paths
- add an ESLint policy that rejects raw caught errors or error-derived values passed to application loggers

## Root cause and impact

Typesense uses Axios internally, and several catch blocks passed the full SDK error object to `console.error`/`console.warn`. Axios errors retain request config and headers, so production build/runtime logs could serialize `X-TYPESENSE-API-KEY` and copy it into retained log sinks.

The new serializer never copies error messages, stacks, headers, config/auth objects, bodies, URL credentials, query strings, or arbitrary SDK fields. Existing fallback behavior is unchanged.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- focused safe-logging and affected regression suite: 121 tests passed
- full web suite: 1,567 tests passed; five legacy log-shape assertions were then updated and the affected files reran 30/30 green
- commit/push hooks: ESLint and Lingui coverage passed

Operational key rotation and retained-log handling will follow after this safe logger reaches production.

Related to #6123
