### PR TITLE
Move remaining web taxonomy reads to Typesense

### DIFF
--- a/apps/web/docs/edge-requests/special-routes.md
+++ b/apps/web/docs/edge-requests/special-routes.md
@@ -6,13 +6,16 @@ These routes don't render visible pages but generate edge requests when accessed
 
 | Request | Type | Notes |
 |---------|------|-------|
-| `GET /sitemap.xml` | Serverless function | Dynamic — queries DB for companies with active postings + public watchlists |
+| `GET /sitemap.xml` | Serverless function | Dynamic — queries the web-owned DB tables for qualifying public watchlists |
 
 Generated on every request (no caching header set by Next.js sitemap convention). Includes:
 - Static pages (7) x 4 locales = 28 URLs
 - Explore page x 4 locales = 4 URLs
-- All active company pages x 4 locales = N URLs
-- Public watchlists x 4 locales = N URLs
+- Qualifying public watchlists x 4 locales = N URLs
+- Translated blog posts (only locales with content)
+
+Company pages are `noindex,follow` and are intentionally excluded. The sitemap
+does not read crawler-mirror company, posting, location, or taxonomy tables.
 
 Each URL includes `<lastmod>` in W3C Datetime format and `<xhtml:link>` hreflang alternates.
 
@@ -106,7 +109,7 @@ The 6 permanent redirects configured in `next.config.ts` each generate 1 edge re
 
 | Route | DB queries | CPU work | Est. duration |
 |-------|-----------|----------|---------------|
-| `sitemap.xml` | 2 (companies + watchlists) | URL generation + XML serialization | 30-120ms |
+| `sitemap.xml` | 1 (watchlists) | URL generation + XML serialization | 30-120ms |
 | `robots.txt` | 0 | Template string | <5ms |
 | OG images (root) | 0 | Font read + Satori render + sharp PNG encode | 60-140ms |
 | OG images (company) | 1 (company lookup) | Font read + Satori + sharp + logo embed | 80-180ms |

--- a/apps/web/src/lib/actions/__tests__/company-macro.test.ts
+++ b/apps/web/src/lib/actions/__tests__/company-macro.test.ts
@@ -3,19 +3,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   cacheLife: vi.fn(),
   cacheTag: vi.fn(),
-  dbExecute: vi.fn(),
   search: vi.fn(),
+  locationDocs: [] as Array<Record<string, unknown>>,
 }));
 
 vi.mock("server-only", () => ({}));
 vi.mock("next/cache", () => ({
   cacheLife: mocks.cacheLife,
   cacheTag: mocks.cacheTag,
-}));
-vi.mock("@/db", () => ({ db: { execute: mocks.dbExecute } }));
-vi.mock("drizzle-orm", () => ({
-  sql: (strings: TemplateStringsArray, ..._values: unknown[]) =>
-    strings.join("?"),
 }));
 vi.mock("@/lib/sessionCache", () => ({ getSessionUserId: vi.fn() }));
 vi.mock("@/lib/actions/locations", () => ({
@@ -32,11 +27,21 @@ vi.mock("@/lib/search/typesense-client", () => ({
     collections: () => ({ documents: () => ({ search: mocks.search }) }),
   }),
 }));
+vi.mock("@/lib/search/typesense-taxonomy", () => ({
+  fetchLocationMacroDocuments: () =>
+    mocks.locationDocs.filter((doc) => doc.type === "macro"),
+  fetchLocationDocumentsWithAncestors: () => mocks.locationDocs,
+  fetchLocationDocumentsByIds: (ids: number[]) =>
+    mocks.locationDocs.filter((doc) => ids.includes(doc.location_id as number)),
+}));
 vi.mock("@/lib/search/constants", () => ({
   ANON_MAX_COMPANIES: 5,
   ANON_MAX_POSTINGS: 10,
 }));
-vi.mock("@/lib/search/typesense-filters", () => ({ buildFilterString: vi.fn() }));
+vi.mock("@/lib/search/typesense-filters", () => ({
+  buildFilterString: vi.fn(),
+  POSTING_BASE_FILTER: "is_active:true",
+}));
 vi.mock("@/lib/search/pg-filters", () => ({ localesOrNoneClause: vi.fn() }));
 vi.mock("@/lib/actions/search-input", () => ({ parseSearchFilters: vi.fn() }));
 vi.mock("@/lib/search/params", () => ({
@@ -45,70 +50,40 @@ vi.mock("@/lib/search/params", () => ({
   parseRangeParam: vi.fn(),
 }));
 
-import { getCompanyLocationsGroupedWithMacros } from "../company";
+import { getCompanyLocationsGroupedWithMacros, suggestIndustries } from "../company";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.locationDocs = [];
 });
 
 describe("getCompanyLocationsGroupedWithMacros — Regions cluster gate (#2940)", () => {
-  /**
-   * Order of dbExecute calls inside `getCompanyLocationsGroupedWithMacros`:
-   *   1. `_fetchLocationsGrouped` posting-locations join (countries, regions, cities)
-   *   2. `_fetchLocationsGrouped` aliasMap fetch (location_name)
-   *   3. `_fetchCompanyMacroCluster` main macro_postings + member_country_count CTE
-   *   4. `_fetchCompanyMacroCluster` member-name fetch
-   *
-   * Because `_fetchLocationsGrouped` and `_fetchCompanyMacroCluster` run
-   * concurrently via Promise.all, the call order across the two helpers is
-   * not guaranteed. We use `mockImplementation` keyed on SQL substrings so
-   * the test passes regardless of interleaving.
-   */
-  function setupMocks(opts: { macros: Array<{ id: number; slug: string | null; name: string; postingCount: number; memberCountryCount: number }>; members: Array<{ macro_id: number; country_id: number; country_name: string }>; }) {
-    mocks.dbExecute.mockImplementation((arg: unknown) => {
-      const sql = String(arg);
-      if (sql.includes("WITH active_locs AS") && sql.includes("hierarchy")) {
-        // _fetchLocationsGrouped main query — return one country with one city
-        return Promise.resolve([
-          {
-            location_id: 200, loc_slug: "berlin", loc_type: "city", loc_name: "Berlin", cnt: 5,
-            region_id: null, region_slug: null, region_name: null,
-            country_id: 100, country_slug: "germany", country_name: "Germany",
-          },
-        ]);
-      }
-      if (sql.includes("FROM location_name") && sql.includes("ANY") && !sql.includes("location_macro_member")) {
-        // _fetchLocationsGrouped alias map
-        return Promise.resolve([]);
-      }
-      if (sql.includes("WITH company_postings AS") && sql.includes("macro_postings")) {
-        // _fetchCompanyMacroCluster main query
-        return Promise.resolve(opts.macros.map((m) => ({
-          macro_id: m.id,
-          macro_slug: m.slug,
-          macro_name: m.name,
-          posting_count: m.postingCount,
-          member_country_count: m.memberCountryCount,
-        })));
-      }
-      if (sql.includes("location_macro_member") && sql.includes("country_name")) {
-        return Promise.resolve(opts.members);
-      }
-      return Promise.resolve([]);
-    });
+  /** Configure the direct-location and ancestor-expanded company facets. */
+  function setupMocks(memberCounts: Array<{ id: number; count: number }>) {
+    mocks.locationDocs = [
+      { id: "4", location_id: 4, slug: "eu", name_en: "EU", type: "macro", member_country_ids: [100, 101] },
+      { id: "100", location_id: 100, slug: "germany", name_en: "Germany", type: "country" },
+      { id: "101", location_id: 101, slug: "france", name_en: "France", type: "country" },
+      { id: "200", location_id: 200, slug: "berlin", name_en: "Berlin", type: "city", parent_id: 100 },
+    ];
+    mocks.search.mockImplementation((args: { facet_by?: string }) =>
+      Promise.resolve({
+        facet_counts: [{
+          field_name: args.facet_by,
+          counts: args.facet_by === "location_direct_ids"
+            ? [{ value: "200", count: 5 }]
+            : [
+                { value: "4", count: 100 },
+                ...memberCounts.map((entry) => ({ value: String(entry.id), count: entry.count })),
+              ],
+          stats: { total_values: args.facet_by === "location_direct_ids" ? 1 : 3 },
+        }],
+      }),
+    );
   }
 
   it("returns macros where the company has postings spanning >=2 member countries", async () => {
-    setupMocks({
-      macros: [
-        // EU: 2 member countries with hits — passes the gate
-        { id: 4, slug: null, name: "EU", postingCount: 100, memberCountryCount: 2 },
-      ],
-      members: [
-        { macro_id: 4, country_id: 100, country_name: "Germany" },
-        { macro_id: 4, country_id: 101, country_name: "France" },
-      ],
-    });
+    setupMocks([{ id: 100, count: 70 }, { id: 101, count: 30 }]);
     const out = await getCompanyLocationsGroupedWithMacros("co-1", "en");
     expect(out.macros).toHaveLength(1);
     expect(out.macros[0]).toEqual({
@@ -117,21 +92,51 @@ describe("getCompanyLocationsGroupedWithMacros — Regions cluster gate (#2940)"
       name: "European Union",
       abbreviation: "EU",
       count: 100,
-      memberCountryNames: ["Germany", "France"],
-      memberCountryIds: [100, 101],
+      memberCountryNames: ["France", "Germany"],
+      memberCountryIds: [101, 100],
     });
   });
 
-  /**
-   * Gate enforcement: a company with all postings in a single member country
-   * doesn't see the Regions cluster (the SQL HAVING clause filters
-   * `member_country_count >= 2`). The fixture simulates the SQL having
-   * already filtered out the macro — the action should return an empty
-   * macros array.
-   */
-  it("excludes macros when SQL gate yields zero rows (single-country company)", async () => {
-    setupMocks({ macros: [], members: [] });
+  /** A company with postings in one member country does not see the region. */
+  it("excludes macros when only one member country has matching postings", async () => {
+    setupMocks([{ id: 100, count: 100 }]);
     const out = await getCompanyLocationsGroupedWithMacros("co-2", "en");
     expect(out.macros).toEqual([]);
+  });
+
+  it("returns an empty optional surface during a Typesense outage", async () => {
+    mocks.search.mockRejectedValue(
+      Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+    );
+
+    await expect(
+      getCompanyLocationsGroupedWithMacros("co-3", "en"),
+    ).resolves.toEqual({ countries: [], macros: [] });
+  });
+
+  it("propagates unexpected Typesense errors", async () => {
+    mocks.search.mockRejectedValue(
+      Object.assign(new Error("Request failed with HTTP code 429"), {
+        httpStatus: 429,
+      }),
+    );
+
+    await expect(
+      getCompanyLocationsGroupedWithMacros("co-4", "en"),
+    ).rejects.toThrow("429");
+  });
+
+  it("applies the same outage policy to industry suggestions", async () => {
+    mocks.search.mockRejectedValueOnce(
+      Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+    );
+    await expect(suggestIndustries({ query: "tech", locale: "en" })).resolves.toEqual([]);
+
+    mocks.search.mockRejectedValueOnce(
+      Object.assign(new Error("Request failed with HTTP code 429"), {
+        httpStatus: 429,
+      }),
+    );
+    await expect(suggestIndustries({ query: "tech", locale: "en" })).rejects.toThrow("429");
   });
 });

--- a/apps/web/src/lib/actions/__tests__/db-retry-coverage.test.ts
+++ b/apps/web/src/lib/actions/__tests__/db-retry-coverage.test.ts
@@ -22,8 +22,6 @@ import { withTestEnv } from "@/test-utils/env";
  *     build-critical (the route handler runs at every sitemap fetch).
  *   - `getCurrencyRates` (via `_fetchCurrencyRates`) — runtime-hot;
  *     used by /explore, /company/<slug>, settings, and salary modal.
- *   - `getCompanyTopLocations` (via `_fetchTopLocations`) — explicitly
- *     called out in the #2918 follow-up bullet list.
  *
  * Each spec mocks `db.execute` to throw an ECONNRESET on the first
  * call and resolve normally on the second. Asserting `toHaveBeenCalledTimes(2)`
@@ -213,28 +211,6 @@ describe("issue #2930 — withDbRetry covers additional call sites", () => {
     const rates = await getCurrencyRates();
 
     expect(rates.find((r) => r.currency === "USD")?.toEur).toBeCloseTo(0.92);
-    expect(dbExecuteMock).toHaveBeenCalledTimes(2);
-  });
-
-  it("retries getCompanyTopLocations after ECONNRESET", async () => {
-    dbExecuteMock
-      .mockRejectedValueOnce(econnreset())
-      .mockResolvedValueOnce([
-        {
-          location_id: 1,
-          loc_slug: "berlin",
-          loc_type: "city",
-          loc_name: "Berlin",
-          cnt: 5,
-          total_locations: 1,
-        },
-      ]);
-
-    const { getCompanyTopLocations } = await import("@/lib/actions/company");
-    const result = await getCompanyTopLocations("c-1", "en");
-
-    expect(result.locations).toHaveLength(1);
-    expect(result.locations[0]?.slug).toBe("berlin");
     expect(dbExecuteMock).toHaveBeenCalledTimes(2);
   });
 

--- a/apps/web/src/lib/actions/__tests__/expand-batch.test.ts
+++ b/apps/web/src/lib/actions/__tests__/expand-batch.test.ts
@@ -1,29 +1,10 @@
-/**
- * Perf regression test (issue #3186).
- *
- * The Postgres fallback paths in `_getWatchlistPostingsPostgres` and
- * `_searchCompaniesForWatchlistPostgres` previously dispatched one
- * `expandLocationIds(id)` / `expandOccupationIds(id)` per seed via
- * `Promise.all(ids.map(expand))`, firing L separate recursive CTE queries
- * against `location` / `occupation` and L extra Redis round-trips even
- * on warm cache. A 5-location + 5-occupation watchlist filter cost
- * ~50–150ms of avoidable work on cold cache.
- *
- * `expandLocationIdsBatch` and `expandOccupationIdsBatch` collapse that
- * to a single recursive CTE per taxonomy that accepts an `int[]` seed
- * and returns the deduplicated union (`SELECT DISTINCT id FROM
- * descendants`). These tests pin:
- *
- *   - call count (regression guard: 1 `db.execute`, not L)
- *   - returned union semantics (functional guard: merged + deduped)
- *   - empty input short-circuit (no DB call at all)
- */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   cacheLife: vi.fn(),
   cacheTag: vi.fn(),
-  dbExecute: vi.fn(),
+  fetchLocationDescendants: vi.fn(),
+  fetchOccupationDocuments: vi.fn(),
 }));
 
 vi.mock("server-only", () => ({}));
@@ -41,13 +22,18 @@ vi.mock("@/lib/cache", () => ({
   cached: vi.fn((_key: string, fn: () => unknown) => fn()),
 }));
 vi.mock("@/lib/cache-ttl", () => ({ CACHE_TTL_LONG: 3600 }));
-vi.mock("@/lib/db-retry", () => ({
-  withDbRetry: vi.fn((fn: () => Promise<unknown>) => fn()),
+vi.mock("@/lib/search/typesense-taxonomy", () => ({
+  fetchLocationDescendants: mocks.fetchLocationDescendants,
+  fetchOccupationDocuments: mocks.fetchOccupationDocuments,
+  fetchLocationDocumentsByIds: vi.fn(),
+  fetchLocationDocumentsBySlugs: vi.fn(),
+  fetchLocationDocumentsWithAncestors: vi.fn(),
+  fetchLocationMacroDocuments: vi.fn(),
+  fetchSeniorityDocuments: vi.fn(),
+  fetchTechnologyDocuments: vi.fn(),
 }));
 vi.mock("@/lib/search/typesense-client", () => ({
-  getTypesenseClient: () => ({
-    collections: () => ({ documents: () => ({ search: vi.fn() }) }),
-  }),
+  getTypesenseClient: vi.fn(),
 }));
 vi.mock("@/lib/search/typesense-filters", () => ({
   buildFilterString: () => "",
@@ -55,17 +41,6 @@ vi.mock("@/lib/search/typesense-filters", () => ({
 }));
 vi.mock("@/lib/search/typeahead-boost", () => ({
   boostByFilterMatches: (xs: unknown) => xs,
-}));
-vi.mock("@/lib/search/canonicalize-filters", () => ({
-  canonicalizeFilters: (x: unknown) => x,
-}));
-vi.mock("@/lib/search/location-paging", () => ({
-  LOCATION_PAGE_SIZE: 20,
-}));
-vi.mock("@/db", () => ({ db: { execute: mocks.dbExecute } }));
-vi.mock("drizzle-orm", () => ({
-  sql: (strings: TemplateStringsArray, ..._values: unknown[]) =>
-    strings.join("?"),
 }));
 
 import { expandLocationIdsBatch } from "../locations";
@@ -75,102 +50,43 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-// ── expandLocationIdsBatch ───────────────────────────────────────────
-
-describe("expandLocationIdsBatch (#3186)", () => {
-  it("issues exactly ONE db.execute round-trip for N seed IDs (not N)", async () => {
-    // Three seeds. Pre-fix this would fire 3 parallel recursive CTEs.
-    mocks.dbExecute.mockResolvedValueOnce([
-      { id: 1 },
-      { id: 2 },
-      { id: 3 },
-      { id: 100 },
-      { id: 200 },
+describe("expandLocationIdsBatch", () => {
+  it("uses one Typesense descendant lookup with sorted, deduplicated seeds", async () => {
+    mocks.fetchLocationDescendants.mockResolvedValue([
+      { location_id: 20 },
+      { location_id: 1 },
+      { location_id: 10 },
     ]);
 
-    await expandLocationIdsBatch([1, 2, 3]);
-
-    expect(mocks.dbExecute).toHaveBeenCalledTimes(1);
+    await expect(expandLocationIdsBatch([10, 1, 10])).resolves.toEqual([1, 10, 20]);
+    expect(mocks.fetchLocationDescendants).toHaveBeenCalledOnce();
+    expect(mocks.fetchLocationDescendants).toHaveBeenCalledWith([1, 10]);
   });
 
-  it("returns the deduplicated union of all descendant IDs", async () => {
-    // Simulate Postgres returning the seeds + descendants for each.
-    // Postgres `SELECT DISTINCT` already dedupes — the wrapper just
-    // maps rows to numbers; the union+dedup semantics are pinned by
-    // the SQL and the assertion below confirms the wrapper preserves
-    // them.
-    mocks.dbExecute.mockResolvedValueOnce([
-      { id: 1 }, // seed
-      { id: 10 }, // descendant of 1
-      { id: 11 }, // descendant of 1
-      { id: 2 }, // seed
-      { id: 20 }, // descendant of 2
-    ]);
-
-    const result = await expandLocationIdsBatch([1, 2]);
-
-    expect(result).toEqual([1, 10, 11, 2, 20]);
-    // Set semantics: no duplicates in the returned array.
-    expect(new Set(result).size).toBe(result.length);
-  });
-
-  it("returns [] for empty input WITHOUT touching the DB", async () => {
-    const result = await expandLocationIdsBatch([]);
-
-    expect(result).toEqual([]);
-    // Short-circuits before the cache + DB boundary.
-    expect(mocks.dbExecute).not.toHaveBeenCalled();
-  });
-
-  it("dedupes the seed array so [a,a,b] and [a,b] share a cache slot", async () => {
-    mocks.dbExecute.mockResolvedValueOnce([{ id: 1 }, { id: 2 }]);
-
-    await expandLocationIdsBatch([1, 1, 2, 2]);
-
-    expect(mocks.dbExecute).toHaveBeenCalledTimes(1);
-    // Implementation detail: the wrapper sorts + dedupes BEFORE the
-    // `'use cache'` boundary. We don't assert on the SQL string shape
-    // (Drizzle's `sql` tag is mocked to a join), but if the wrapper
-    // dropped the dedup step, the dbExecute call count would still
-    // be 1 — so this test pins the "no extra work for duplicates"
-    // contract by way of result correctness (no duplicate output IDs).
+  it("short-circuits empty input", async () => {
+    await expect(expandLocationIdsBatch([])).resolves.toEqual([]);
+    expect(mocks.fetchLocationDescendants).not.toHaveBeenCalled();
   });
 });
 
-// ── expandOccupationIdsBatch ─────────────────────────────────────────
-
-describe("expandOccupationIdsBatch (#3186)", () => {
-  it("issues exactly ONE db.execute round-trip for N seed IDs (not N)", async () => {
-    mocks.dbExecute.mockResolvedValueOnce([
-      { id: 1 },
-      { id: 2 },
-      { id: 3 },
-      { id: 100 },
+describe("expandOccupationIdsBatch", () => {
+  it("derives the transitive descendant union from Typesense parent metadata", async () => {
+    mocks.fetchOccupationDocuments.mockResolvedValue([
+      { occupation_id: 1 },
+      { occupation_id: 10, parent_id: 1 },
+      { occupation_id: 11, parent_id: 10 },
+      { occupation_id: 2 },
     ]);
 
-    await expandOccupationIdsBatch([1, 2, 3]);
-
-    expect(mocks.dbExecute).toHaveBeenCalledTimes(1);
+    await expect(expandOccupationIdsBatch([1, 2, 1])).resolves.toEqual([1, 2, 10, 11]);
+    expect(mocks.fetchOccupationDocuments).toHaveBeenCalledOnce();
+    expect(mocks.fetchOccupationDocuments).toHaveBeenCalledWith("en");
   });
 
-  it("returns the deduplicated union of all descendant IDs", async () => {
-    mocks.dbExecute.mockResolvedValueOnce([
-      { id: 5 }, // seed
-      { id: 50 }, // descendant
-      { id: 51 }, // descendant
-      { id: 6 }, // seed
-    ]);
-
-    const result = await expandOccupationIdsBatch([5, 6]);
-
-    expect(result).toEqual([5, 50, 51, 6]);
-    expect(new Set(result).size).toBe(result.length);
-  });
-
-  it("returns [] for empty input WITHOUT touching the DB", async () => {
-    const result = await expandOccupationIdsBatch([]);
-
-    expect(result).toEqual([]);
-    expect(mocks.dbExecute).not.toHaveBeenCalled();
+  it("drops unknown seeds and short-circuits empty input", async () => {
+    mocks.fetchOccupationDocuments.mockResolvedValue([{ occupation_id: 1 }]);
+    await expect(expandOccupationIdsBatch([999])).resolves.toEqual([]);
+    await expect(expandOccupationIdsBatch([])).resolves.toEqual([]);
+    expect(mocks.fetchOccupationDocuments).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/lib/actions/__tests__/locations-hierarchical-counts.test.ts
+++ b/apps/web/src/lib/actions/__tests__/locations-hierarchical-counts.test.ts
@@ -27,7 +27,7 @@ const mocks = vi.hoisted(() => ({
   cacheLife: vi.fn(),
   cacheTag: vi.fn(),
   search: vi.fn(),
-  dbExecute: vi.fn(),
+  locationDocs: [] as Array<Record<string, unknown>>,
   cached: vi.fn((_key: string, fn: () => unknown) => fn()),
 }));
 
@@ -43,10 +43,14 @@ vi.mock("@/lib/search/typesense-client", () => ({
     collections: () => ({ documents: () => ({ search: mocks.search }) }),
   }),
 }));
-vi.mock("@/db", () => ({ db: { execute: mocks.dbExecute } }));
-vi.mock("drizzle-orm", () => ({
-  sql: (strings: TemplateStringsArray, ..._values: unknown[]) =>
-    strings.join("?"),
+vi.mock("@/lib/search/typesense-taxonomy", () => ({
+  fetchLocationMacroDocuments: () =>
+    mocks.locationDocs.filter((doc) => doc.type === "macro"),
+  fetchLocationDocumentsWithAncestors: () => mocks.locationDocs,
+  fetchLocationDocumentsByIds: (ids: number[]) =>
+    mocks.locationDocs.filter((doc) => ids.includes(doc.location_id as number)),
+  fetchLocationDocumentsBySlugs: () => [],
+  fetchLocationDescendants: () => [],
 }));
 vi.mock("@/lib/search/typesense-filters", () => ({
   buildFilterString: () => "",
@@ -60,6 +64,7 @@ import { getGlobalLocationsGrouped } from "../locations";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.locationDocs = [];
 });
 
 /**
@@ -70,23 +75,13 @@ beforeEach(() => {
  * no city.
  */
 function chileSetup() {
-  mocks.dbExecute
-    .mockResolvedValueOnce([
-      // Locations: country, region, two cities + a macro for completeness
-      { id: 100, slug: "americas", type: "macro", parent_id: null },
-      { id: 200, slug: "chile", type: "country", parent_id: null },
-      { id: 210, slug: "santiago-region", type: "region", parent_id: 200 },
-      { id: 220, slug: "santiago", type: "city", parent_id: 210 },
-      { id: 230, slug: "valparaiso", type: "city", parent_id: 200 },
-    ])
-    .mockResolvedValueOnce([
-      { location_id: 100, locale: "en", name: "Americas" },
-      { location_id: 200, locale: "en", name: "Chile" },
-      { location_id: 210, locale: "en", name: "Santiago Region" },
-      { location_id: 220, locale: "en", name: "Santiago" },
-      { location_id: 230, locale: "en", name: "Valparaíso" },
-    ])
-    .mockResolvedValueOnce([]); // empty macro members
+  mocks.locationDocs = [
+    { id: "100", location_id: 100, slug: "americas", type: "macro", name_en: "Americas" },
+    { id: "200", location_id: 200, slug: "chile", type: "country", name_en: "Chile" },
+    { id: "210", location_id: 210, slug: "santiago-region", type: "region", name_en: "Santiago Region", parent_id: 200 },
+    { id: "220", location_id: 220, slug: "santiago", type: "city", name_en: "Santiago", parent_id: 210 },
+    { id: "230", location_id: 230, slug: "valparaiso", type: "city", name_en: "Valparaíso", parent_id: 200 },
+  ];
 
   mocks.search.mockImplementation((args: { filter_by?: string }) => {
     const isMacroQuery = (args.filter_by ?? "").includes("location_ids:[");
@@ -159,14 +154,9 @@ describe("getGlobalLocationsGrouped — hierarchical counts (#3033)", () => {
    * `g.regions.some((r) => r.locations.length > 0)` dropped these.
    */
   it("keeps countries that have direct facet counts but no city facet entries", async () => {
-    mocks.dbExecute
-      .mockResolvedValueOnce([
-        { id: 300, slug: "lichtenstein", type: "country", parent_id: null },
-      ])
-      .mockResolvedValueOnce([
-        { location_id: 300, locale: "en", name: "Liechtenstein" },
-      ])
-      .mockResolvedValueOnce([]);
+    mocks.locationDocs = [
+      { id: "300", location_id: 300, slug: "lichtenstein", type: "country", name_en: "Liechtenstein" },
+    ];
 
     mocks.search.mockImplementation((args: { filter_by?: string }) => {
       const isMacroQuery = (args.filter_by ?? "").includes("location_ids:[");

--- a/apps/web/src/lib/actions/__tests__/locations-locale-sort.test.ts
+++ b/apps/web/src/lib/actions/__tests__/locations-locale-sort.test.ts
@@ -4,7 +4,7 @@ const mocks = vi.hoisted(() => ({
   cacheLife: vi.fn(),
   cacheTag: vi.fn(),
   search: vi.fn(),
-  dbExecute: vi.fn(),
+  locationDocs: [] as Array<Record<string, unknown>>,
   cached: vi.fn((_key: string, fn: () => unknown) => fn()),
 }));
 
@@ -20,10 +20,12 @@ vi.mock("@/lib/search/typesense-client", () => ({
     collections: () => ({ documents: () => ({ search: mocks.search }) }),
   }),
 }));
-vi.mock("@/db", () => ({ db: { execute: mocks.dbExecute } }));
-vi.mock("drizzle-orm", () => ({
-  sql: (strings: TemplateStringsArray, ..._values: unknown[]) =>
-    strings.join("?"),
+vi.mock("@/lib/search/typesense-taxonomy", () => ({
+  fetchLocationMacroDocuments: () => [],
+  fetchLocationDocumentsWithAncestors: () => mocks.locationDocs,
+  fetchLocationDocumentsByIds: () => mocks.locationDocs,
+  fetchLocationDocumentsBySlugs: () => [],
+  fetchLocationDescendants: () => [],
 }));
 vi.mock("@/lib/search/typesense-filters", () => ({
   buildFilterString: () => "",
@@ -37,21 +39,16 @@ import { getGlobalLocationsGrouped } from "../locations";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.locationDocs = [];
 });
 
 describe("getGlobalLocationsGrouped — locale-aware display sorting", () => {
   it("sorts country names with the caller locale", async () => {
-    mocks.dbExecute
-      .mockResolvedValueOnce([
-        { id: 100, slug: "austria", type: "country", parent_id: null },
-        { id: 200, slug: "switzerland", type: "country", parent_id: null },
-        { id: 300, slug: "zambia", type: "country", parent_id: null },
-      ])
-      .mockResolvedValueOnce([
-        { location_id: 100, locale: "sv", name: "Österreich" },
-        { location_id: 200, locale: "sv", name: "Schweiz" },
-        { location_id: 300, locale: "sv", name: "Zambia" },
-      ]);
+    mocks.locationDocs = [
+      { id: "100", location_id: 100, slug: "austria", type: "country", name_en: "Austria", name_de: "Österreich" },
+      { id: "200", location_id: 200, slug: "switzerland", type: "country", name_en: "Switzerland", name_de: "Schweiz" },
+      { id: "300", location_id: 300, slug: "zambia", type: "country", name_en: "Zambia", name_de: "Sambia" },
+    ];
 
     mocks.search.mockResolvedValue({
       facet_counts: [
@@ -66,12 +63,12 @@ describe("getGlobalLocationsGrouped — locale-aware display sorting", () => {
       ],
     });
 
-    const out = await getGlobalLocationsGrouped("sv");
+    const out = await getGlobalLocationsGrouped("de");
 
     expect(out.countries.map((c) => c.countryName)).toEqual([
-      "Schweiz",
-      "Zambia",
       "Österreich",
+      "Sambia",
+      "Schweiz",
     ]);
   });
 });

--- a/apps/web/src/lib/actions/__tests__/locations-macro.test.ts
+++ b/apps/web/src/lib/actions/__tests__/locations-macro.test.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
   cacheLife: vi.fn(),
   cacheTag: vi.fn(),
   search: vi.fn(),
-  dbExecute: vi.fn(),
+  locationDocs: [] as Array<Record<string, unknown>>,
   cached: vi.fn((_key: string, fn: () => unknown) => fn()),
 }));
 
@@ -21,10 +21,14 @@ vi.mock("@/lib/search/typesense-client", () => ({
     collections: () => ({ documents: () => ({ search: mocks.search }) }),
   }),
 }));
-vi.mock("@/db", () => ({ db: { execute: mocks.dbExecute } }));
-vi.mock("drizzle-orm", () => ({
-  sql: (strings: TemplateStringsArray, ..._values: unknown[]) =>
-    strings.join("?"),
+vi.mock("@/lib/search/typesense-taxonomy", () => ({
+  fetchLocationMacroDocuments: () =>
+    mocks.locationDocs.filter((doc) => doc.type === "macro"),
+  fetchLocationDocumentsWithAncestors: () => mocks.locationDocs,
+  fetchLocationDocumentsByIds: (ids: number[]) =>
+    mocks.locationDocs.filter((doc) => ids.includes(doc.location_id as number)),
+  fetchLocationDocumentsBySlugs: () => [],
+  fetchLocationDescendants: () => [],
 }));
 vi.mock("@/lib/search/typesense-filters", () => ({
   buildFilterString: () => "",
@@ -38,6 +42,7 @@ import { getGlobalLocationsGrouped } from "../locations";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.locationDocs = [];
 });
 
 describe("getGlobalLocationsGrouped — Regions cluster (#2940)", () => {
@@ -48,33 +53,18 @@ describe("getGlobalLocationsGrouped — Regions cluster (#2940)", () => {
    * rendering uses the consistent label called for in the issue test plan.
    */
   it("includes macros with active postings, sorted by count, with canonical names", async () => {
-    // Order of dbExecute calls in `_fetchGlobalLocationsGrouped`:
-    //   1. SELECT id, slug, type, parent_id FROM location  (hierarchy)
-    //   2. SELECT location_id, locale, name FROM location_name  (display names)
-    //   3. SELECT macro_id, country_name FROM location_macro_member ...
-    //      (only when there are macros with non-zero counts)
-    mocks.dbExecute
-      .mockResolvedValueOnce([
-        { id: 4, slug: null, type: "macro", parent_id: null },
-        { id: 1, slug: null, type: "macro", parent_id: null },
-        { id: 5, slug: null, type: "macro", parent_id: null },
-        { id: 100, slug: "germany", type: "country", parent_id: null },
-        { id: 200, slug: "berlin", type: "city", parent_id: 100 },
-      ])
-      .mockResolvedValueOnce([
-        { location_id: 4, locale: "en", name: "EU" },
-        { location_id: 1, locale: "en", name: "EMEA" },
-        { location_id: 5, locale: "en", name: "DACH" },
-        { location_id: 100, locale: "en", name: "Germany" },
-        { location_id: 200, locale: "en", name: "Berlin" },
-      ])
-      .mockResolvedValueOnce([
-        { macro_id: 4, country_id: 100, country_name: "Germany" },
-        { macro_id: 4, country_id: 101, country_name: "France" },
-        { macro_id: 5, country_id: 100, country_name: "Germany" },
-        { macro_id: 5, country_id: 102, country_name: "Austria" },
-        { macro_id: 5, country_id: 103, country_name: "Switzerland" },
-      ]);
+    // Location hierarchy and membership come from the taxonomy collection;
+    // only posting counts require the two Typesense facet searches below.
+    mocks.locationDocs = [
+      { id: "4", location_id: 4, slug: "eu", type: "macro", name_en: "EU", member_country_ids: [100, 101] },
+      { id: "1", location_id: 1, slug: "emea", type: "macro", name_en: "EMEA" },
+      { id: "5", location_id: 5, slug: "dach", type: "macro", name_en: "DACH", member_country_ids: [100, 102, 103] },
+      { id: "100", location_id: 100, slug: "germany", type: "country", name_en: "Germany" },
+      { id: "101", location_id: 101, slug: "france", type: "country", name_en: "France" },
+      { id: "102", location_id: 102, slug: "austria", type: "country", name_en: "Austria" },
+      { id: "103", location_id: 103, slug: "switzerland", type: "country", name_en: "Switzerland" },
+      { id: "200", location_id: 200, slug: "berlin", type: "city", name_en: "Berlin", parent_id: 100 },
+    ];
 
     // Two parallel Typesense calls: country-tier facet (top-500) AND a
     // dedicated macro-only facet. Country-tier truncation can drop low-
@@ -133,8 +123,8 @@ describe("getGlobalLocationsGrouped — Regions cluster (#2940)", () => {
       name: "European Union",
       abbreviation: "EU",
       count: 146,
-      memberCountryNames: ["Germany", "France"],
-      memberCountryIds: [100, 101],
+      memberCountryNames: ["France", "Germany"],
+      memberCountryIds: [101, 100],
     });
     expect(out.macros[2]).toEqual({
       id: 5,
@@ -142,8 +132,8 @@ describe("getGlobalLocationsGrouped — Regions cluster (#2940)", () => {
       name: "DACH (Germany, Austria, Switzerland)",
       abbreviation: "DACH",
       count: 6,
-      memberCountryNames: ["Germany", "Austria", "Switzerland"],
-      memberCountryIds: [100, 102, 103],
+      memberCountryNames: ["Austria", "Germany", "Switzerland"],
+      memberCountryIds: [102, 100, 103],
     });
     // Country tier still works
     expect(out.countries.length).toBeGreaterThan(0);
@@ -159,18 +149,11 @@ describe("getGlobalLocationsGrouped — Regions cluster (#2940)", () => {
    * — the cluster only ever shows actionable filters.
    */
   it("drops macros that have zero active-posting facet count", async () => {
-    mocks.dbExecute
-      .mockResolvedValueOnce([
-        { id: 4, slug: null, type: "macro", parent_id: null },
-        { id: 9, slug: null, type: "macro", parent_id: null },
-        { id: 100, slug: "germany", type: "country", parent_id: null },
-      ])
-      .mockResolvedValueOnce([
-        { location_id: 4, locale: "en", name: "EU" },
-        { location_id: 9, locale: "en", name: "Worldwide" },
-        { location_id: 100, locale: "en", name: "Germany" },
-      ])
-      .mockResolvedValueOnce([]); // empty member table — should not break
+    mocks.locationDocs = [
+      { id: "4", location_id: 4, slug: "eu", type: "macro", name_en: "EU" },
+      { id: "9", location_id: 9, slug: "worldwide", type: "macro", name_en: "Worldwide" },
+      { id: "100", location_id: 100, slug: "germany", type: "country", name_en: "Germany" },
+    ];
 
     mocks.search.mockImplementation((args: { filter_by?: string }) => {
       const isMacroQuery = (args.filter_by ?? "").includes("location_ids:[");
@@ -205,8 +188,18 @@ describe("getGlobalLocationsGrouped — Regions cluster (#2940)", () => {
    * propagating. The modal renders the empty-state message in this case.
    */
   it("returns empty shape when Typesense is unreachable", async () => {
-    mocks.search.mockRejectedValue(new Error("Typesense down"));
+    mocks.search.mockRejectedValue(Object.assign(new Error("Typesense down"), { code: "ECONNRESET" }));
     const out = await getGlobalLocationsGrouped("en");
     expect(out).toEqual({ macros: [], countries: [] });
+  });
+
+  it("propagates unexpected Typesense errors", async () => {
+    mocks.search.mockRejectedValue(
+      Object.assign(new Error("Request failed with HTTP code 429"), {
+        httpStatus: 429,
+      }),
+    );
+
+    await expect(getGlobalLocationsGrouped("en")).rejects.toThrow("429");
   });
 });

--- a/apps/web/src/lib/actions/__tests__/resolve-slugs-canonical-sort.test.ts
+++ b/apps/web/src/lib/actions/__tests__/resolve-slugs-canonical-sort.test.ts
@@ -1,29 +1,13 @@
-/**
- * Regression tests for #3276 — `resolveLocationSlugs`,
- * `resolveOccupationSlugs`, `resolveSenioritySlugs`,
- * `resolveTechnologySlugs` previously called `[...slugs].sort()` before
- * forwarding to a `'use cache'` inner. Bare `.sort()` uses UTF-16 code
- * unit order, where `"ü"` (U+00FC) sorts *after* `"z"` — so two callers
- * passing the same logical slug set in different orders hashed to
- * different cache slots, splitting the cache for accented slugs.
- *
- * After the fix every site uses `canonicalStringCompare` (locale-
- * independent `Intl.Collator("en", { sensitivity: "base" })`) so
- * permutations collapse to the same slot.
- *
- * Strategy: mock the cache layer and `db.execute`, then verify that the
- * SQL placeholder array passed to the cached inner is identical
- * regardless of input permutation / case.
- */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   cacheLife: vi.fn(),
   cacheTag: vi.fn(),
-  // Captures the substituted SQL parameter values for the most recent
-  // `db.execute` call so each test can assert the array shape.
-  capturedSql: [] as unknown[][],
-  dbExecute: vi.fn(),
+  fetchLocationDocumentsBySlugs: vi.fn(),
+  fetchLocationDocumentsByIds: vi.fn(),
+  fetchOccupationDocuments: vi.fn(),
+  fetchSeniorityDocuments: vi.fn(),
+  fetchTechnologyDocuments: vi.fn(),
 }));
 
 vi.mock("server-only", () => ({}));
@@ -41,13 +25,18 @@ vi.mock("@/lib/cache", () => ({
   cached: vi.fn((_key: string, fn: () => unknown) => fn()),
 }));
 vi.mock("@/lib/cache-ttl", () => ({ CACHE_TTL_LONG: 3600 }));
-vi.mock("@/lib/db-retry", () => ({
-  withDbRetry: vi.fn((fn: () => Promise<unknown>) => fn()),
+vi.mock("@/lib/search/typesense-taxonomy", () => ({
+  fetchLocationDocumentsBySlugs: mocks.fetchLocationDocumentsBySlugs,
+  fetchLocationDocumentsByIds: mocks.fetchLocationDocumentsByIds,
+  fetchOccupationDocuments: mocks.fetchOccupationDocuments,
+  fetchSeniorityDocuments: mocks.fetchSeniorityDocuments,
+  fetchTechnologyDocuments: mocks.fetchTechnologyDocuments,
+  fetchLocationDescendants: vi.fn(),
+  fetchLocationDocumentsWithAncestors: vi.fn(),
+  fetchLocationMacroDocuments: vi.fn(),
 }));
 vi.mock("@/lib/search/typesense-client", () => ({
-  getTypesenseClient: () => ({
-    collections: () => ({ documents: () => ({ search: vi.fn() }) }),
-  }),
+  getTypesenseClient: vi.fn(),
 }));
 vi.mock("@/lib/search/typesense-filters", () => ({
   buildFilterString: () => "",
@@ -55,22 +44,6 @@ vi.mock("@/lib/search/typesense-filters", () => ({
 }));
 vi.mock("@/lib/search/typeahead-boost", () => ({
   boostByFilterMatches: (xs: unknown) => xs,
-}));
-vi.mock("@/lib/search/canonicalize-filters", () => ({
-  canonicalizeFilters: (x: unknown) => x,
-}));
-vi.mock("@/lib/search/location-paging", () => ({
-  LOCATION_PAGE_SIZE: 20,
-}));
-vi.mock("@/db", () => ({ db: { execute: mocks.dbExecute } }));
-vi.mock("drizzle-orm", () => ({
-  // Snapshot the substituted values so each test can assert what got
-  // interpolated. `sortedSlugs.join(",")` flows in as a single string
-  // value through the `pgArray` template literal.
-  sql: (_strings: TemplateStringsArray, ...values: unknown[]) => {
-    mocks.capturedSql.push(values);
-    return { __sql: true } as unknown;
-  },
 }));
 
 import { resolveLocationSlugs } from "../locations";
@@ -82,106 +55,71 @@ import {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.capturedSql = [];
-  mocks.dbExecute.mockResolvedValue([]);
+  mocks.fetchLocationDocumentsByIds.mockResolvedValue([]);
 });
 
-// Helpers ───────────────────────────────────────────────────────────
+describe("Typesense taxonomy slug resolvers", () => {
+  it("resolves localized location and parent labels exactly by slug", async () => {
+    mocks.fetchLocationDocumentsBySlugs.mockResolvedValue([
+      {
+        location_id: 10,
+        slug: "zürich",
+        type: "city",
+        name_en: "Zurich",
+        name_de: "Zürich",
+        parent_id: 20,
+      },
+    ]);
+    mocks.fetchLocationDocumentsByIds.mockResolvedValue([
+      {
+        location_id: 20,
+        slug: "zurich-canton",
+        type: "region",
+        name_en: "Canton of Zurich",
+        name_de: "Kanton Zürich",
+      },
+    ]);
 
-// The `pgArray` literal sent through to Postgres is the substituted
-// value. `db.execute(sql\`... ${pgArray} ...\`)` records the values as
-// the first SQL invocation; the array is the only substitution.
-function lastPgArrayValue(): string {
-  // The last captured `sql\`\`` call is the one that ran inside the
-  // cached inner. The substituted values include the pgArray and
-  // (depending on the call) a locale string. We pluck the one that
-  // starts with `{` (pg-array literal).
-  const flat = mocks.capturedSql.flat();
-  const pg = flat.find((v) => typeof v === "string" && v.startsWith("{"));
-  return pg as string;
-}
-
-// ── resolveOccupationSlugs ──────────────────────────────────────────
-
-describe("resolveOccupationSlugs — canonical sort (#3276)", () => {
-  it("permutes input → same Postgres parameter array", async () => {
-    await resolveOccupationSlugs(["b-eng", "a-eng"], "en");
-    const first = lastPgArrayValue();
-    mocks.capturedSql = [];
-    await resolveOccupationSlugs(["a-eng", "b-eng"], "en");
-    const second = lastPgArrayValue();
-    expect(first).toBe(second);
+    const resolved = await resolveLocationSlugs(["zürich"], "de");
+    expect(resolved.get("zürich")).toEqual({
+      id: 10,
+      slug: "zürich",
+      name: "Zürich",
+      type: "city",
+      parentName: "Kanton Zürich",
+    });
   });
 
-  it("case-folded `Apple` and `apple` produce the same canonical order", async () => {
-    // Base-sensitivity means `"Apple"` and `"apple"` collate to the
-    // same slot; the secondary identity comparator breaks the tie
-    // deterministically. We assert that two callers passing the same
-    // logical content (one upper, one lower) produce the same array
-    // shape modulo case.
-    await resolveOccupationSlugs(["Apple", "banana"], "en");
-    const upper = lastPgArrayValue();
-    mocks.capturedSql = [];
-    await resolveOccupationSlugs(["apple", "Banana"], "en");
-    const lower = lastPgArrayValue();
-    // The ordering matches: both place the a-group first.
-    const upperFirst = upper.slice(1).split(",")[0].toLowerCase();
-    const lowerFirst = lower.slice(1).split(",")[0].toLowerCase();
-    expect(upperFirst).toBe("apple");
-    expect(lowerFirst).toBe("apple");
-  });
-});
+  it("selects only requested occupation, seniority and technology slugs", async () => {
+    mocks.fetchOccupationDocuments.mockResolvedValue([
+      { occupation_id: 1, slug: "software-engineer", name: "Software Engineer" },
+      { occupation_id: 2, slug: "designer", name: "Designer" },
+    ]);
+    mocks.fetchSeniorityDocuments.mockResolvedValue([
+      { seniority_id: 3, slug: "senior", name: "Senior" },
+      { seniority_id: 4, slug: "junior", name: "Junior" },
+    ]);
+    mocks.fetchTechnologyDocuments.mockResolvedValue([
+      { technology_id: 5, slug: "rust", name: "Rust" },
+      { technology_id: 6, slug: "go", name: "Go" },
+    ]);
 
-// ── resolveSenioritySlugs ───────────────────────────────────────────
-
-describe("resolveSenioritySlugs — canonical sort (#3276)", () => {
-  it("permutes input → same Postgres parameter array", async () => {
-    await resolveSenioritySlugs(["senior", "junior"], "en");
-    const first = lastPgArrayValue();
-    mocks.capturedSql = [];
-    await resolveSenioritySlugs(["junior", "senior"], "en");
-    const second = lastPgArrayValue();
-    expect(first).toBe(second);
-  });
-});
-
-// ── resolveTechnologySlugs ──────────────────────────────────────────
-
-describe("resolveTechnologySlugs — canonical sort (#3276)", () => {
-  it("permutes input → same Postgres parameter array", async () => {
-    await resolveTechnologySlugs(["rust", "go"]);
-    const first = lastPgArrayValue();
-    mocks.capturedSql = [];
-    await resolveTechnologySlugs(["go", "rust"]);
-    const second = lastPgArrayValue();
-    expect(first).toBe(second);
-  });
-});
-
-// ── resolveLocationSlugs ────────────────────────────────────────────
-
-describe("resolveLocationSlugs — canonical sort (#3276)", () => {
-  it("permutes input → same Postgres parameter array", async () => {
-    await resolveLocationSlugs(["zurich", "berlin"], "en");
-    const first = lastPgArrayValue();
-    mocks.capturedSql = [];
-    await resolveLocationSlugs(["berlin", "zurich"], "en");
-    const second = lastPgArrayValue();
-    expect(first).toBe(second);
+    const [occupations, seniorities, technologies] = await Promise.all([
+      resolveOccupationSlugs(["designer"], "en"),
+      resolveSenioritySlugs(["senior"], "en"),
+      resolveTechnologySlugs(["go"]),
+    ]);
+    expect([...occupations.keys()]).toEqual(["designer"]);
+    expect([...seniorities.keys()]).toEqual(["senior"]);
+    expect([...technologies.keys()]).toEqual(["go"]);
   });
 
-  it("regression: accented slugs collapse via canonical (`zürich` next to `z`-group)", async () => {
-    // Bare `.sort()` would put `"zürich"` after `"zoom"` in UTF-16
-    // order. With `canonicalStringCompare`, the u-base of `ü` sorts
-    // before `o` — wait, actually the canonical collator is
-    // base-sensitivity in "en" locale. For German ä/ö/ü, the base is
-    // a/o/u, so `"zürich"` will sort by the `z` first letter. The key
-    // test is: input permutation collapses regardless.
+  it("keeps canonical sorting before the location cache boundary", async () => {
+    mocks.fetchLocationDocumentsBySlugs.mockResolvedValue([]);
     await resolveLocationSlugs(["zürich", "berlin"], "en");
-    const first = lastPgArrayValue();
-    mocks.capturedSql = [];
-    await resolveLocationSlugs(["berlin", "zürich"], "en");
-    const second = lastPgArrayValue();
-    expect(first).toBe(second);
+    expect(mocks.fetchLocationDocumentsBySlugs).toHaveBeenCalledWith([
+      "berlin",
+      "zürich",
+    ]);
   });
 });

--- a/apps/web/src/lib/search/__tests__/typesense-taxonomy.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense-taxonomy.test.ts
@@ -1,0 +1,115 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ search: vi.fn() }));
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/lib/search/typesense-client", () => ({
+  getTypesenseClient: () => ({
+    collections: () => ({ documents: () => ({ search: mocks.search }) }),
+  }),
+}));
+
+import {
+  fetchLocationDocumentsBySlugs,
+  fetchLocationDocumentsWithAncestors,
+  fetchOccupationDocuments,
+  fetchTechnologyDocuments,
+} from "../typesense-taxonomy";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("Typesense taxonomy provider", () => {
+  it("escapes exact slug literals", async () => {
+    mocks.search.mockResolvedValue({ found: 0, hits: [] });
+
+    await fetchLocationDocumentsBySlugs(["cote`d\\azur"]);
+
+    expect(mocks.search).toHaveBeenCalledWith(
+      expect.objectContaining({
+        filter_by: "slug:[`cote\\`d\\\\azur`]",
+      }),
+    );
+  });
+
+  it("paginates complete taxonomy snapshots", async () => {
+    const firstPage = Array.from({ length: 250 }, (_, index) => ({
+      document: {
+        id: String(index),
+        technology_id: index,
+        slug: `technology-${index}`,
+        name: `Technology ${index}`,
+      },
+    }));
+    mocks.search
+      .mockResolvedValueOnce({ found: 251, hits: firstPage })
+      .mockResolvedValueOnce({
+        found: 251,
+        hits: [
+          {
+            document: {
+              id: "250",
+              technology_id: 250,
+              slug: "technology-250",
+              name: "Technology 250",
+            },
+          },
+        ],
+      });
+
+    const documents = await fetchTechnologyDocuments();
+
+    expect(documents).toHaveLength(251);
+    expect(mocks.search).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ page: 1, per_page: 250 }),
+    );
+    expect(mocks.search).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ page: 2, per_page: 250 }),
+    );
+  });
+
+  it("prefers the requested locale and falls back per occupation", async () => {
+    mocks.search.mockResolvedValue({
+      found: 3,
+      hits: [
+        { document: { id: "1-en", occupation_id: 1, slug: "developer", name: "Developer", locale: "en" } },
+        { document: { id: "1-de", occupation_id: 1, slug: "developer", name: "Entwickler", locale: "de" } },
+        { document: { id: "2-en", occupation_id: 2, slug: "designer", name: "Designer", locale: "en" } },
+      ],
+    });
+
+    const documents = await fetchOccupationDocuments("de");
+
+    expect(documents.map(({ occupation_id, name }) => [occupation_id, name])).toEqual([
+      [1, "Entwickler"],
+      [2, "Designer"],
+    ]);
+    expect(mocks.search).toHaveBeenCalledWith(
+      expect.objectContaining({ filter_by: "locale:[de,en]" }),
+    );
+  });
+
+  it("walks missing geographic parents without a database read", async () => {
+    mocks.search
+      .mockResolvedValueOnce({
+        found: 1,
+        hits: [{ document: { id: "10", location_id: 10, slug: "zurich", name_en: "Zurich", type: "city", parent_id: 20 } }],
+      })
+      .mockResolvedValueOnce({
+        found: 1,
+        hits: [{ document: { id: "20", location_id: 20, slug: "zurich-canton", name_en: "Zurich", type: "region", parent_id: 30 } }],
+      })
+      .mockResolvedValueOnce({
+        found: 1,
+        hits: [{ document: { id: "30", location_id: 30, slug: "switzerland", name_en: "Switzerland", type: "country" } }],
+      });
+
+    const documents = await fetchLocationDocumentsWithAncestors([10]);
+
+    expect(documents.map((document) => document.location_id)).toEqual([10, 20, 30]);
+    expect(mocks.search).toHaveBeenCalledTimes(3);
+  });
+});

--- a/apps/web/src/lib/search/typesense-taxonomy.ts
+++ b/apps/web/src/lib/search/typesense-taxonomy.ts
@@ -1,0 +1,221 @@
+import "server-only";
+
+import { getTypesenseClient, type TypesenseHit } from "@/lib/search/typesense-client";
+
+const PAGE_SIZE = 250;
+const FILTER_BATCH_SIZE = 100;
+
+type SearchParams = Record<string, string | number | boolean>;
+
+export type TypesenseLocationDocument = {
+  id: string;
+  location_id: number;
+  slug: string;
+  name_en: string;
+  name_de?: string;
+  name_fr?: string;
+  name_it?: string;
+  aliases?: string[];
+  parent_id?: number;
+  parent_name?: string;
+  ancestor_ids?: number[];
+  member_country_ids?: number[];
+  type: string;
+  active_posting_count: number;
+};
+
+export type TypesenseOccupationDocument = {
+  id: string;
+  occupation_id: number;
+  slug: string;
+  name: string;
+  parent_id?: number;
+  domain_id?: number;
+  domain_slug?: string;
+  domain_name?: string;
+  locale: string;
+};
+
+export type TypesenseSeniorityDocument = {
+  id: string;
+  seniority_id: number;
+  slug: string;
+  name: string;
+  locale: string;
+};
+
+export type TypesenseTechnologyDocument = {
+  id: string;
+  technology_id: number;
+  slug: string;
+  name: string;
+  category?: string;
+};
+
+function chunks<T>(values: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < values.length; i += size) out.push(values.slice(i, i + size));
+  return out;
+}
+
+function filterLiteral(value: string): string {
+  return `\`${value.replace(/\\/g, "\\\\").replace(/`/g, "\\`")}\``;
+}
+
+async function searchAll<T>(
+  collection: string,
+  params: SearchParams,
+): Promise<T[]> {
+  const client = getTypesenseClient();
+  const documents: T[] = [];
+
+  for (let page = 1; ; page += 1) {
+    const response = await client.collections(collection).documents().search({
+      ...params,
+      page,
+      per_page: PAGE_SIZE,
+    });
+    const hits = (response.hits ?? []) as unknown as TypesenseHit[];
+    documents.push(...hits.map((hit) => hit.document as T));
+    if (hits.length < PAGE_SIZE || documents.length >= (response.found ?? 0)) break;
+  }
+
+  return documents;
+}
+
+export async function fetchLocationDocumentsByIds(
+  ids: number[],
+): Promise<TypesenseLocationDocument[]> {
+  const unique = [...new Set(ids)].filter(Number.isInteger);
+  const results = await Promise.all(
+    chunks(unique, FILTER_BATCH_SIZE).map((batch) =>
+      searchAll<TypesenseLocationDocument>("location", {
+        q: "*",
+        query_by: "name_en",
+        filter_by: `id:[${batch.join(",")}]`,
+      }),
+    ),
+  );
+  return results.flat();
+}
+
+export async function fetchLocationDocumentsWithAncestors(
+  ids: number[],
+): Promise<TypesenseLocationDocument[]> {
+  const byId = new Map<number, TypesenseLocationDocument>();
+  let pending = [...new Set(ids)].sort((a, b) => a - b);
+  while (pending.length > 0) {
+    const rows = await fetchLocationDocumentsByIds(pending);
+    for (const row of rows) byId.set(row.location_id, row);
+    pending = [
+      ...new Set(
+        rows.flatMap((row) =>
+          row.parent_id != null && !byId.has(row.parent_id) ? [row.parent_id] : [],
+        ),
+      ),
+    ].sort((a, b) => a - b);
+  }
+  return [...byId.values()];
+}
+
+export async function fetchLocationDocumentsBySlugs(
+  slugs: string[],
+): Promise<TypesenseLocationDocument[]> {
+  const unique = [...new Set(slugs)];
+  const results = await Promise.all(
+    chunks(unique, FILTER_BATCH_SIZE).map((batch) =>
+      searchAll<TypesenseLocationDocument>("location", {
+        q: "*",
+        query_by: "name_en",
+        filter_by: `slug:[${batch.map(filterLiteral).join(",")}]`,
+      }),
+    ),
+  );
+  return results.flat();
+}
+
+export function fetchLocationMacroDocuments(): Promise<TypesenseLocationDocument[]> {
+  return searchAll<TypesenseLocationDocument>("location", {
+    q: "*",
+    query_by: "name_en",
+    filter_by: "type:=macro",
+  });
+}
+
+export async function fetchLocationDescendants(
+  ancestorIds: number[],
+): Promise<TypesenseLocationDocument[]> {
+  const unique = [...new Set(ancestorIds)].filter(Number.isInteger);
+  const results = await Promise.all(
+    chunks(unique, FILTER_BATCH_SIZE).map((batch) =>
+      searchAll<TypesenseLocationDocument>("location", {
+        q: "*",
+        query_by: "name_en",
+        filter_by: `ancestor_ids:[${batch.join(",")}]`,
+      }),
+    ),
+  );
+  const byId = new Map<number, TypesenseLocationDocument>();
+  for (const doc of results.flat()) byId.set(doc.location_id, doc);
+  return [...byId.values()];
+}
+
+function safeLocale(locale: string): string {
+  return /^[a-z]{2}$/i.test(locale) ? locale.toLowerCase() : "en";
+}
+
+async function fetchLocalizedDocuments<T extends { locale: string }>(
+  collection: "occupation" | "seniority",
+  locale: string,
+): Promise<T[]> {
+  const preferred = safeLocale(locale);
+  const localeFilter = preferred === "en" ? "locale:=en" : `locale:[${preferred},en]`;
+  return searchAll<T>(collection, {
+    q: "*",
+    query_by: "name",
+    filter_by: localeFilter,
+  });
+}
+
+function preferLocale<T extends { locale: string }>(
+  documents: T[],
+  locale: string,
+  id: (document: T) => number,
+): T[] {
+  const preferred = safeLocale(locale);
+  const byId = new Map<number, T>();
+  for (const document of documents) {
+    const current = byId.get(id(document));
+    if (!current || (document.locale === preferred && current.locale !== preferred)) {
+      byId.set(id(document), document);
+    }
+  }
+  return [...byId.values()];
+}
+
+export async function fetchOccupationDocuments(
+  locale: string,
+): Promise<TypesenseOccupationDocument[]> {
+  const documents = await fetchLocalizedDocuments<TypesenseOccupationDocument>(
+    "occupation",
+    locale,
+  );
+  return preferLocale(documents, locale, (document) => document.occupation_id);
+}
+
+export async function fetchSeniorityDocuments(
+  locale: string,
+): Promise<TypesenseSeniorityDocument[]> {
+  const documents = await fetchLocalizedDocuments<TypesenseSeniorityDocument>(
+    "seniority",
+    locale,
+  );
+  return preferLocale(documents, locale, (document) => document.seniority_id);
+}
+
+export function fetchTechnologyDocuments(): Promise<TypesenseTechnologyDocument[]> {
+  return searchAll<TypesenseTechnologyDocument>("technology", {
+    q: "*",
+    query_by: "name",
+  });
+}

--- a/apps/web/src/lib/services/__tests__/supabase-taxonomy-read-cutover.test.ts
+++ b/apps/web/src/lib/services/__tests__/supabase-taxonomy-read-cutover.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const read = (path: string): string =>
+  readFileSync(resolve(process.cwd(), path), "utf8");
+
+describe("Supabase location and taxonomy read cutover", () => {
+  it("keeps public location, taxonomy, and company-location providers on Typesense", () => {
+    for (const path of [
+      "src/lib/services/locations.ts",
+      "src/lib/services/taxonomy.ts",
+      "src/lib/services/company.ts",
+    ]) {
+      const source = read(path);
+      expect(source).not.toContain('from "@/db"');
+      expect(source).not.toContain('from "@/db/schema"');
+      expect(source).not.toContain('from "drizzle-orm"');
+      expect(source).not.toMatch(/\bdb\.(execute|select)\b/);
+      expect(source).not.toMatch(/\bsql`/);
+    }
+
+    const provider = read("src/lib/search/typesense-taxonomy.ts");
+    expect(provider).toContain("getTypesenseClient");
+    expect(provider).not.toContain("DATABASE_URL");
+    expect(provider).not.toContain('from "@/db"');
+  });
+
+  it("limits sitemap SQL to durable web-owned watchlist tables", () => {
+    const source = read("src/lib/sitemap.ts");
+    const sqlBlocks = [...source.matchAll(/sql`([\s\S]*?)`/g)].map((match) => match[1]);
+    const tables = sqlBlocks.flatMap((block) =>
+      [...block.matchAll(/\b(?:FROM|JOIN)\s+("[^"]+"|[a-z_]+)/gi)].map(
+        (match) => match[1].replaceAll('"', ""),
+      ),
+    );
+
+    expect(new Set(tables)).toEqual(
+      new Set(["watchlist", "user", "watchlist_company"]),
+    );
+    expect(source).not.toMatch(/\b(?:FROM|JOIN)\s+(?:job_posting|location|occupation|seniority|technology|industry|company)\b/i);
+  });
+});

--- a/apps/web/src/lib/services/__tests__/taxonomy-outage.test.ts
+++ b/apps/web/src/lib/services/__tests__/taxonomy-outage.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  cached: vi.fn((_key: string, fetcher: () => unknown) => fetcher()),
+  search: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("next/cache", () => ({ cacheLife: vi.fn(), cacheTag: vi.fn() }));
+vi.mock("@/lib/cache", () => ({ cached: mocks.cached }));
+vi.mock("@/lib/cache-tags", () => ({
+  typeaheadOccupationsCacheTag: () => "occupations",
+  typeaheadSenioritiesCacheTag: () => "seniorities",
+  typeaheadTechnologiesCacheTag: () => "technologies",
+}));
+vi.mock("@/lib/search/typesense-client", () => ({
+  getTypesenseClient: () => ({
+    collections: () => ({ documents: () => ({ search: mocks.search }) }),
+  }),
+}));
+vi.mock("@/lib/search/typesense-taxonomy", () => ({
+  fetchOccupationDocuments: () => [],
+  fetchSeniorityDocuments: () => [
+    { id: "1-en", seniority_id: 1, slug: "senior", name: "Senior", locale: "en" },
+  ],
+  fetchTechnologyDocuments: () => [],
+}));
+vi.mock("@/lib/search/typesense-filters", () => ({
+  buildFilterString: () => "",
+  POSTING_BASE_FILTER: "is_active:true",
+}));
+vi.mock("@/lib/search/typeahead-boost", () => ({
+  boostByFilterMatches: (values: unknown) => values,
+}));
+
+import { getAllSeniorities } from "../taxonomy";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+describe("taxonomy outage policy", () => {
+  it("degrades an optional taxonomy surface only for availability failures", async () => {
+    mocks.search.mockRejectedValue(
+      Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }),
+    );
+
+    await expect(getAllSeniorities("en")).resolves.toEqual([]);
+    expect(mocks.cached).toHaveBeenCalledTimes(1);
+  });
+
+  it("propagates rate limits and other unexpected errors", async () => {
+    mocks.search.mockRejectedValue(
+      Object.assign(new Error("Request failed with HTTP code 429"), {
+        httpStatus: 429,
+      }),
+    );
+
+    await expect(getAllSeniorities("en")).rejects.toThrow("429");
+  });
+});

--- a/apps/web/src/lib/services/company.ts
+++ b/apps/web/src/lib/services/company.ts
@@ -1,10 +1,7 @@
 import "server-only";
 
-import { sql } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
-import { db } from "@/db";
 import { CACHE_TTL_MEDIUM, CACHE_TTL_LONG } from "@/lib/cache-ttl";
-import { withDbRetry } from "@/lib/db-retry";
 import { getSearchProvider } from "@/lib/search";
 import type { SearchResultPosting, WorkMode } from "@/lib/search";
 import {
@@ -17,11 +14,17 @@ import { ANON_MAX_COMPANIES, ANON_MAX_POSTINGS } from "@/lib/search/constants";
 import { getSearchClient } from "@/lib/search/typesense-client";
 import { buildFilterString, POSTING_BASE_FILTER } from "@/lib/search/typesense-filters";
 import { isTypesenseUnavailableError } from "@/lib/search/typesense-retry";
+import {
+  fetchLocationDocumentsByIds,
+  fetchLocationDocumentsWithAncestors,
+  fetchLocationMacroDocuments,
+  type TypesenseLocationDocument,
+} from "@/lib/search/typesense-taxonomy";
 import { parseSearchFilters } from "@/lib/services/search-input";
 import { getCurrencyRates } from "@/lib/services/search";
 import { firstOf, idsOrUndefined, parseRangeParam } from "@/lib/search/params";
 import { convertToEur } from "@/lib/salary";
-import { canonicalStringCompare } from "@/lib/sort";
+import { canonicalStringCompare, makeDisplayStringCompare } from "@/lib/sort";
 import { logExternalError } from "@/lib/safe-external-error";
 
 export { getCompanyBySlug } from "@/lib/services/company-detail";
@@ -403,35 +406,47 @@ export async function suggestIndustries(params: {
   query?: string;
   locale: string;
 }): Promise<IndustrySuggestion[]> {
+  try {
+    return await _suggestIndustries(params);
+  } catch (err) {
+    if (!isTypesenseUnavailableError(err)) throw err;
+    console.error(
+      "[suggestIndustries] Typesense unavailable; returning no industries",
+      err,
+    );
+    return [];
+  }
+}
+
+async function _suggestIndustries(params: {
+  query?: string;
+  locale: string;
+}): Promise<IndustrySuggestion[]> {
   const q = params.query?.trim().toLowerCase();
   const hasQuery = q && q.length >= 1;
+  const localeField = ["de", "fr", "it"].includes(params.locale)
+    ? `industry_name_${params.locale}`
+    : "industry_name";
+  const result = await getSearchClient().collections("company").documents().search({
+    q: hasQuery ? q : "*",
+    query_by: "industry_name,industry_name_de,industry_name_fr,industry_name_it",
+    filter_by: "industry_id:>=0",
+    group_by: "industry_id",
+    group_limit: 1,
+    per_page: 100,
+    prefix: true,
+    num_typos: 0,
+    include_fields: [...new Set(["industry_id", "industry_name", localeField])].join(","),
+  });
 
-  const rows = await withDbRetry(
-    () =>
-      db.execute<{
-        [key: string]: unknown;
-        id: number;
-        name: string;
-      }>(sql`
-        SELECT i.id,
-               COALESCE(
-                 (SELECT idn.name FROM industry_name idn
-                  WHERE idn.industry_id = i.id AND idn.locale = ${params.locale} AND idn.is_display = true
-                  LIMIT 1),
-                 i.name
-               ) AS name
-        FROM industry i
-        ${hasQuery ? sql`WHERE lower(i.name) LIKE ${q + "%"} OR EXISTS (
-          SELECT 1 FROM industry_name idn
-          WHERE idn.industry_id = i.id AND lower(idn.name) LIKE ${q + "%"}
-        )` : sql``}
-        ORDER BY i.name
-      `),
-    { label: "suggestIndustries" },
-  );
-
-  type Row = { id: number; name: string };
-  return (rows as unknown as Row[]).map((r) => ({ id: r.id, name: r.name }));
+  const suggestions = (result.grouped_hits ?? []).flatMap((group) => {
+    const doc = group.hits[0]?.document as Record<string, unknown> | undefined;
+    if (!doc || typeof doc.industry_id !== "number") return [];
+    const name = String(doc[localeField] ?? doc.industry_name ?? "");
+    return name ? [{ id: doc.industry_id, name }] : [];
+  });
+  return suggestions
+    .sort((a, b) => canonicalStringCompare(a.name, b.name));
 }
 
 // ── Similar companies (same industry, active, excluding self) ───────
@@ -1019,6 +1034,22 @@ export async function getCompanyTopLocations(
   companyId: string,
   locale: string,
 ): Promise<{ locations: CompanyLocation[]; totalCount: number }> {
+  try {
+    return await _getCompanyTopLocationsCached(companyId, locale);
+  } catch (err) {
+    if (!isTypesenseUnavailableError(err)) throw err;
+    console.error(
+      "[getCompanyTopLocations] Typesense unavailable; returning no locations",
+      err,
+    );
+    return { locations: [], totalCount: 0 };
+  }
+}
+
+async function _getCompanyTopLocationsCached(
+  companyId: string,
+  locale: string,
+): Promise<{ locations: CompanyLocation[]; totalCount: number }> {
   "use cache";
   cacheLife("hours");
   cacheTag(companyByIdCacheTag(companyId));
@@ -1029,59 +1060,22 @@ async function _fetchTopLocations(
   companyId: string,
   locale: string,
 ): Promise<{ locations: CompanyLocation[]; totalCount: number }> {
-  const rows = await withDbRetry(
-    () =>
-      db.execute<{
-        [key: string]: unknown;
-        location_id: number;
-        loc_slug: string;
-        loc_type: string;
-        loc_name: string;
-        cnt: number;
-        total_locations: number;
-      }>(sql`
-        WITH active_locs AS (
-          SELECT unnest(jp.location_ids) AS location_id
-          FROM job_posting jp
-          WHERE jp.company_id = ${companyId}
-            AND jp.is_active = true
-            AND jp.location_ids IS NOT NULL
-        ),
-        grouped AS (
-          SELECT
-            al.location_id,
-            l.slug AS loc_slug,
-            l.type::text AS loc_type,
-            ln.name AS loc_name,
-            COUNT(*)::int AS cnt
-          FROM active_locs al
-          JOIN location l ON l.id = al.location_id
-          JOIN LATERAL (
-            SELECT name FROM location_name
-            WHERE location_id = al.location_id AND locale IN (${locale}, 'en') AND is_display = true
-            ORDER BY (locale = ${locale})::int DESC LIMIT 1
-          ) ln ON true
-          GROUP BY al.location_id, l.slug, l.type, ln.name
-        )
-        SELECT *, COUNT(*) OVER ()::int AS total_locations
-        FROM grouped
-        ORDER BY cnt DESC
-        LIMIT 15
-      `),
-    { label: `companyTopLocations[${companyId}]` },
-  );
-
-  type Row = { location_id: number; loc_slug: string; loc_type: string; loc_name: string; cnt: number; total_locations: number };
-  const all = rows as unknown as Row[];
+  const facet = await _fetchCompanyLocationFacet(companyId, "location_direct_ids", 15);
+  const documents = await fetchLocationDocumentsByIds(facet.counts.map((entry) => entry.id));
+  const byId = new Map(documents.map((document) => [document.location_id, document]));
   return {
-    locations: all.map((r) => ({
-      id: r.location_id,
-      slug: r.loc_slug,
-      name: r.loc_name,
-      type: r.loc_type,
-      count: r.cnt,
-    })),
-    totalCount: all[0]?.total_locations ?? 0,
+    locations: facet.counts.flatMap(({ id, count }) => {
+      const document = byId.get(id);
+      if (!document) return [];
+      return [{
+        id,
+        slug: document.slug,
+        name: _companyLocationName(document, locale),
+        type: document.type,
+        count,
+      }];
+    }),
+    totalCount: facet.totalValues,
   };
 }
 
@@ -1159,6 +1153,22 @@ export async function getCompanyLocationsGrouped(
   companyId: string,
   locale: string,
 ): Promise<GroupedCompanyLocations[]> {
+  try {
+    return await _getCompanyLocationsGroupedCached(companyId, locale);
+  } catch (err) {
+    if (!isTypesenseUnavailableError(err)) throw err;
+    console.error(
+      "[getCompanyLocationsGrouped] Typesense unavailable; returning no locations",
+      err,
+    );
+    return [];
+  }
+}
+
+async function _getCompanyLocationsGroupedCached(
+  companyId: string,
+  locale: string,
+): Promise<GroupedCompanyLocations[]> {
   "use cache";
   cacheLife("hours");
   cacheTag(companyByIdCacheTag(companyId));
@@ -1176,6 +1186,22 @@ export async function getCompanyLocationsGroupedWithMacros(
   companyId: string,
   locale: string,
 ): Promise<CompanyLocationsResponse> {
+  try {
+    return await _getCompanyLocationsGroupedWithMacrosCached(companyId, locale);
+  } catch (err) {
+    if (!isTypesenseUnavailableError(err)) throw err;
+    console.error(
+      "[getCompanyLocationsGroupedWithMacros] Typesense unavailable; returning no locations",
+      err,
+    );
+    return { countries: [], macros: [] };
+  }
+}
+
+async function _getCompanyLocationsGroupedWithMacrosCached(
+  companyId: string,
+  locale: string,
+): Promise<CompanyLocationsResponse> {
   "use cache";
   cacheLife("hours");
   cacheTag(companyByIdCacheTag(companyId));
@@ -1190,10 +1216,10 @@ export async function getCompanyLocationsGroupedWithMacros(
  * Fetch macro regions that have ≥2 member countries with postings for
  * `companyId`. Returns the macro `count` (total active postings whose
  * `location_ids` ancestor includes this macro) and the localized member
- * country names. The ≥2-member gate is enforced via `HAVING` on the
- * member-country count, not the posting count — a company with 50
- * postings in only Germany doesn't see DACH; a company with one posting
- * in Germany and one in Austria does.
+ * country names. The ≥2-member gate is evaluated from the macro document's
+ * member-country IDs and the company facet counts, not the posting count.
+ * A company with 50 postings in only Germany doesn't see DACH; a company
+ * with one posting in Germany and one in Austria does.
  */
 async function _fetchCompanyMacroCluster(
   companyId: string,
@@ -1215,232 +1241,51 @@ async function _fetchCompanyMacroCluster(
     worldwide: "Worldwide",
   };
 
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    macro_id: number;
-    macro_slug: string | null;
-    macro_name: string;
-    posting_count: number;
-    member_country_count: number;
-  }>(sql`
-    WITH company_postings AS (
-      SELECT id, location_ids
-      FROM job_posting
-      WHERE company_id = ${companyId}
-        AND is_active = true
-        AND location_ids IS NOT NULL
-    ),
-    macro_postings AS (
-      -- Each macro that appears as an ancestor on any of this company's postings
-      SELECT m.id AS macro_id, m.slug AS macro_slug,
-             COUNT(DISTINCT cp.id)::int AS posting_count
-      FROM company_postings cp
-      JOIN location m ON m.id = ANY(cp.location_ids) AND m.type::text = 'macro'
-      GROUP BY m.id, m.slug
-    ),
-    macro_member_hits AS (
-      -- For each macro, count distinct member countries that have at least
-      -- one posting for this company. Joins via location_macro_member.
-      SELECT lmm.macro_id, COUNT(DISTINCT lmm.country_id)::int AS member_country_count
-      FROM location_macro_member lmm
-      JOIN company_postings cp ON lmm.country_id = ANY(cp.location_ids)
-      GROUP BY lmm.macro_id
-    )
-    SELECT mp.macro_id, mp.macro_slug,
-           ln.name AS macro_name,
-           mp.posting_count,
-           COALESCE(mmh.member_country_count, 0)::int AS member_country_count
-    FROM macro_postings mp
-    LEFT JOIN macro_member_hits mmh ON mmh.macro_id = mp.macro_id
-    JOIN LATERAL (
-      SELECT name FROM location_name
-      WHERE location_id = mp.macro_id
-        AND locale IN (${locale}, 'en')
-        AND is_display = true
-      ORDER BY (locale = ${locale})::int DESC LIMIT 1
-    ) ln ON true
-    WHERE COALESCE(mmh.member_country_count, 0) >= 2
-    ORDER BY mp.posting_count DESC
-  `);
+  const [facet, macros] = await Promise.all([
+    _fetchCompanyLocationFacet(companyId, "location_ids", 5000),
+    fetchLocationMacroDocuments(),
+  ]);
+  const counts = new Map(facet.counts.map((entry) => [entry.id, entry.count]));
+  const eligible = macros.filter((macro) =>
+    (macro.member_country_ids ?? []).filter((id) => (counts.get(id) ?? 0) > 0).length >= 2,
+  );
+  const memberIds = eligible.flatMap((macro) => macro.member_country_ids ?? []);
+  const members = await fetchLocationDocumentsByIds(memberIds);
+  const membersById = new Map(members.map((member) => [member.location_id, member]));
+  const compareNames = makeDisplayStringCompare(locale);
 
-  type Row = {
-    macro_id: number;
-    macro_slug: string | null;
-    macro_name: string;
-    posting_count: number;
-    member_country_count: number;
-  };
-  const macroRows = rows as unknown as Row[];
-  if (macroRows.length === 0) return [];
-
-  // Fetch member country names + IDs for each macro. The IDs power the
-  // hierarchical-disable hook (#2978) and stay aligned with names because
-  // they share the same row order.
-  const macroIds = macroRows.map((r) => r.macro_id);
-  const pgArray = `{${macroIds.join(",")}}`;
-  const memberRows = await db.execute<{
-    [key: string]: unknown;
-    macro_id: number;
-    country_id: number;
-    country_name: string;
-  }>(sql`
-    SELECT lmm.macro_id, lmm.country_id, ln.name AS country_name
-    FROM location_macro_member lmm
-    JOIN LATERAL (
-      SELECT name FROM location_name
-      WHERE location_id = lmm.country_id
-        AND locale IN (${locale}, 'en')
-        AND is_display = true
-      ORDER BY (locale = ${locale})::int DESC LIMIT 1
-    ) ln ON true
-    WHERE lmm.macro_id = ANY(${pgArray}::integer[])
-    ORDER BY lmm.macro_id, ln.name
-  `);
-  const memberMap = new Map<number, { countryNames: string[]; countryIds: number[] }>();
-  for (const r of memberRows as unknown as { macro_id: number; country_id: number; country_name: string }[]) {
-    let entry = memberMap.get(r.macro_id);
-    if (!entry) { entry = { countryNames: [], countryIds: [] }; memberMap.set(r.macro_id, entry); }
-    entry.countryNames.push(r.country_name);
-    entry.countryIds.push(r.country_id);
-  }
-
-  return macroRows.map((r) => {
-    const slugKey = (r.macro_slug ?? "").toLowerCase()
-      || r.macro_name.toLowerCase().replace(/\s+/g, "-");
+  return eligible.map((macro) => {
+    const abbreviation = _companyLocationName(macro, locale);
+    const slugKey = macro.slug.toLowerCase()
+      || abbreviation.toLowerCase().replace(/\s+/g, "-");
     const canonical = MACRO_DISPLAY_NAMES[slugKey];
-    const members = memberMap.get(r.macro_id);
+    const memberRows = (macro.member_country_ids ?? [])
+      .flatMap((id) => {
+        const member = membersById.get(id);
+        return member ? [{ id, name: _companyLocationName(member, locale) }] : [];
+      })
+      .sort((a, b) => compareNames(a.name, b.name));
     return {
-      id: r.macro_id,
-      slug: r.macro_slug ?? slugKey,
-      name: canonical ?? r.macro_name,
-      abbreviation: r.macro_name,
-      count: r.posting_count,
-      memberCountryNames: members?.countryNames ?? [],
-      memberCountryIds: members?.countryIds ?? [],
+      id: macro.location_id,
+      slug: macro.slug || slugKey,
+      name: canonical ?? abbreviation,
+      abbreviation,
+      count: counts.get(macro.location_id) ?? 0,
+      memberCountryNames: memberRows.map((member) => member.name),
+      memberCountryIds: memberRows.map((member) => member.id),
     };
-  });
+  }).sort((a, b) => b.count - a.count);
 }
 
 async function _fetchLocationsGrouped(
   companyId: string,
   locale: string,
 ): Promise<GroupedCompanyLocations[]> {
-  const rows = await withDbRetry(
-    () =>
-      db.execute<{
-        [key: string]: unknown;
-        location_id: number;
-        loc_slug: string;
-        loc_type: string;
-        loc_name: string;
-        cnt: number;
-        region_id: number | null;
-        region_slug: string | null;
-        region_name: string | null;
-        country_id: number | null;
-        country_slug: string | null;
-        country_name: string | null;
-      }>(sql`
-    WITH active_locs AS (
-      SELECT unnest(jp.location_ids) AS location_id
-      FROM job_posting jp
-      WHERE jp.company_id = ${companyId}
-        AND jp.is_active = true
-        AND jp.location_ids IS NOT NULL
-    ),
-    loc_counts AS (
-      SELECT al.location_id, COUNT(*)::int AS cnt
-      FROM active_locs al GROUP BY al.location_id
-    ),
-    hierarchy AS (
-      SELECT lc.location_id, lc.cnt,
-        l.type::text AS loc_type, l.slug AS loc_slug,
-        CASE
-          WHEN l.type = 'region' THEN l.id
-          WHEN l.type = 'city' AND p.type = 'region' THEN p.id
-          ELSE NULL
-        END AS region_id,
-        CASE
-          WHEN l.type = 'country' THEN l.id
-          WHEN p.type = 'country' THEN p.id
-          WHEN gp.type = 'country' THEN gp.id
-          ELSE NULL
-        END AS country_id
-      FROM loc_counts lc
-      JOIN location l ON l.id = lc.location_id
-      LEFT JOIN location p ON p.id = l.parent_id
-      LEFT JOIN location gp ON gp.id = p.parent_id
-    )
-    SELECT
-      h.location_id, h.loc_slug, h.loc_type, h.cnt,
-      ln.name AS loc_name,
-      h.region_id,
-      rl.slug AS region_slug,
-      rn.name AS region_name,
-      h.country_id,
-      cl.slug AS country_slug,
-      cn.name AS country_name
-    FROM hierarchy h
-    JOIN LATERAL (
-      SELECT name FROM location_name
-      WHERE location_id = h.location_id AND locale IN (${locale}, 'en') AND is_display = true
-      ORDER BY (locale = ${locale})::int DESC LIMIT 1
-    ) ln ON true
-    LEFT JOIN location rl ON rl.id = h.region_id
-    LEFT JOIN LATERAL (
-      SELECT name FROM location_name
-      WHERE location_id = h.region_id AND locale IN (${locale}, 'en') AND is_display = true
-      ORDER BY (locale = ${locale})::int DESC LIMIT 1
-    ) rn ON true
-    LEFT JOIN location cl ON cl.id = h.country_id
-    LEFT JOIN LATERAL (
-      SELECT name FROM location_name
-      WHERE location_id = h.country_id AND locale IN (${locale}, 'en') AND is_display = true
-      ORDER BY (locale = ${locale})::int DESC LIMIT 1
-    ) cn ON true
-    ORDER BY cn.name NULLS LAST, rn.name NULLS LAST, h.cnt DESC
-  `),
-    { label: `companyLocationsGrouped[${companyId}]` },
+  const facet = await _fetchCompanyLocationFacet(companyId, "location_direct_ids", 5000);
+  const documents = await fetchLocationDocumentsWithAncestors(
+    facet.counts.map((entry) => entry.id),
   );
-
-  type Row = {
-    location_id: number; loc_slug: string; loc_type: string; loc_name: string; cnt: number;
-    region_id: number | null; region_slug: string | null; region_name: string | null;
-    country_id: number | null; country_slug: string | null; country_name: string | null;
-  };
-
-  // Collect all location IDs for alias lookup
-  const allLocIds = new Set<number>();
-  for (const r of rows as unknown as Row[]) {
-    allLocIds.add(r.location_id);
-    if (r.region_id) allLocIds.add(r.region_id);
-    if (r.country_id) allLocIds.add(r.country_id);
-  }
-
-  // Fetch name aliases (user locale + en)
-  const aliasMap = new Map<number, string[]>();
-  if (allLocIds.size > 0) {
-    const pgArray = `{${[...allLocIds].join(",")}}`;
-    const aliasRows = await withDbRetry(
-      () =>
-        db.execute<{
-          [key: string]: unknown;
-          location_id: number;
-          name: string;
-        }>(sql`
-          SELECT location_id, lower(name) AS name
-          FROM location_name
-          WHERE location_id = ANY(${pgArray}::integer[])
-            AND locale IN (${locale}, 'en')
-        `),
-      { label: `companyLocationsGrouped.aliases[${companyId}]` },
-    );
-    for (const a of aliasRows as unknown as { location_id: number; name: string }[]) {
-      let arr = aliasMap.get(a.location_id);
-      if (!arr) { arr = []; aliasMap.set(a.location_id, arr); }
-      if (!arr.includes(a.name)) arr.push(a.name);
-    }
-  }
+  const byId = new Map(documents.map((document) => [document.location_id, document]));
 
   // Build country → region → city hierarchy
   const countries = new Map<number, GroupedCompanyLocations>();
@@ -1448,52 +1293,68 @@ async function _fetchLocationsGrouped(
   const directCountryCount = new Map<number, number>();
   const directRegionCount = new Map<number, number>();
 
-  for (const r of rows as unknown as Row[]) {
-    const cid = r.country_id ?? 0;
+  for (const { id, count } of facet.counts) {
+    const location = byId.get(id);
+    if (!location || location.type === "macro") continue;
+    const parent = location.parent_id == null ? undefined : byId.get(location.parent_id);
+    const grandparent = parent?.parent_id == null ? undefined : byId.get(parent.parent_id);
+    const region = location.type === "region"
+      ? location
+      : location.type === "city" && parent?.type === "region"
+        ? parent
+        : undefined;
+    const countryMeta = location.type === "country"
+      ? location
+      : parent?.type === "country"
+        ? parent
+        : grandparent?.type === "country"
+          ? grandparent
+          : undefined;
+    const cid = countryMeta?.location_id ?? 0;
     let country = countries.get(cid);
     if (!country) {
       country = {
         countryId: cid,
-        countrySlug: r.country_slug ?? "",
-        countryName: r.country_name ?? "Other",
+        countrySlug: countryMeta?.slug ?? "",
+        countryName: countryMeta ? _companyLocationName(countryMeta, locale) : "Other",
         countryCount: 0,
-        countryAliases: aliasMap.get(cid) ?? [],
+        countryAliases: countryMeta ? _companyLocationAliases(countryMeta, locale) : [],
         regions: [],
       };
       countries.set(cid, country);
     }
 
-    if (r.loc_type === "country") {
-      directCountryCount.set(cid, r.cnt);
+    if (location.type === "country") {
+      directCountryCount.set(cid, count);
       continue;
     }
-    if (r.loc_type === "region") {
-      directRegionCount.set(r.location_id, r.cnt);
+    if (location.type === "region") {
+      directRegionCount.set(location.location_id, count);
       continue;
     }
 
     // City: find or create region group
-    const rid = r.region_id ?? 0;
-    let region = country.regions.find((rg) => rg.regionId === rid);
-    if (!region) {
-      region = {
+    const rid = region?.location_id ?? 0;
+    let regionGroup = country.regions.find((candidate) => candidate.regionId === rid);
+    if (!regionGroup) {
+      regionGroup = {
         regionId: rid,
-        regionSlug: r.region_slug ?? "",
-        regionName: r.region_name ?? "",
+        regionSlug: region?.slug ?? "",
+        regionName: region ? _companyLocationName(region, locale) : "",
         regionCount: 0,
-        regionAliases: rid > 0 ? (aliasMap.get(rid) ?? []) : [],
+        regionAliases: region ? _companyLocationAliases(region, locale) : [],
         locations: [],
       };
-      country.regions.push(region);
+      country.regions.push(regionGroup);
     }
 
-    region.locations.push({
-      id: r.location_id,
-      slug: r.loc_slug,
-      name: r.loc_name,
-      type: r.loc_type,
-      count: r.cnt,
-      aliases: aliasMap.get(r.location_id) ?? [],
+    regionGroup.locations.push({
+      id: location.location_id,
+      slug: location.slug,
+      name: _companyLocationName(location, locale),
+      type: location.type,
+      count,
+      aliases: _companyLocationAliases(location, locale),
     });
   }
 
@@ -1504,13 +1365,63 @@ async function _fetchLocationsGrouped(
       const cityTotal = region.locations.reduce((sum, l) => sum + l.count, 0);
       region.regionCount = cityTotal + (directRegionCount.get(region.regionId) ?? 0);
       countryTotal += region.regionCount;
+      region.locations.sort((a, b) => b.count - a.count);
     }
     country.countryCount = countryTotal;
     // Sort regions by count desc
     country.regions.sort((a, b) => b.regionCount - a.regionCount);
   }
 
-  return [...countries.values()].filter((g) => g.regions.some((r) => r.locations.length > 0));
+  const compareNames = makeDisplayStringCompare(locale);
+  return [...countries.values()]
+    .filter((group) => group.regions.some((region) => region.locations.length > 0))
+    .sort((a, b) => compareNames(a.countryName, b.countryName));
+}
+
+async function _fetchCompanyLocationFacet(
+  companyId: string,
+  field: "location_ids" | "location_direct_ids",
+  maxFacetValues: number,
+): Promise<{
+  counts: Array<{ id: number; count: number }>;
+  totalValues: number;
+}> {
+  const result = await getSearchClient().collections("job_posting").documents().search({
+    q: "*",
+    query_by: "title",
+    filter_by: `${POSTING_BASE_FILTER} && company_id:=${companyId}`,
+    facet_by: field,
+    facet_strategy: "exhaustive",
+    max_facet_values: maxFacetValues,
+    per_page: 0,
+  });
+  const facet = result.facet_counts?.find((entry) => entry.field_name === field);
+  return {
+    counts: (facet?.counts ?? []).map((entry) => ({
+      id: Number(entry.value),
+      count: entry.count,
+    })),
+    totalValues: facet?.stats?.total_values ?? facet?.counts.length ?? 0,
+  };
+}
+
+function _companyLocationName(
+  document: TypesenseLocationDocument,
+  locale: string,
+): string {
+  const localized = document[`name_${locale}` as "name_de" | "name_fr" | "name_it"];
+  return localized ?? document.name_en ?? document.slug;
+}
+
+function _companyLocationAliases(
+  document: TypesenseLocationDocument,
+  locale: string,
+): string[] {
+  return [...new Set([
+    document.name_en,
+    _companyLocationName(document, locale),
+    ...(document.aliases ?? []),
+  ].filter(Boolean).map((name) => name.toLowerCase()))];
 }
 
 // ── Helpers ─────────────────────────────────────────────────────────

--- a/apps/web/src/lib/services/company.ts
+++ b/apps/web/src/lib/services/company.ts
@@ -410,10 +410,7 @@ export async function suggestIndustries(params: {
     return await _suggestIndustries(params);
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
-    console.error(
-      "[suggestIndustries] Typesense unavailable; returning no industries",
-      err,
-    );
+    logExternalError("error", { service: "typesense", operation: "suggest_industries" }, err);
     return [];
   }
 }
@@ -1038,8 +1035,9 @@ export async function getCompanyTopLocations(
     return await _getCompanyTopLocationsCached(companyId, locale);
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
-    console.error(
-      "[getCompanyTopLocations] Typesense unavailable; returning no locations",
+    logExternalError(
+      "error",
+      { service: "typesense", operation: "company_top_locations" },
       err,
     );
     return { locations: [], totalCount: 0 };
@@ -1157,8 +1155,9 @@ export async function getCompanyLocationsGrouped(
     return await _getCompanyLocationsGroupedCached(companyId, locale);
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
-    console.error(
-      "[getCompanyLocationsGrouped] Typesense unavailable; returning no locations",
+    logExternalError(
+      "error",
+      { service: "typesense", operation: "company_locations_grouped" },
       err,
     );
     return [];
@@ -1190,8 +1189,9 @@ export async function getCompanyLocationsGroupedWithMacros(
     return await _getCompanyLocationsGroupedWithMacrosCached(companyId, locale);
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
-    console.error(
-      "[getCompanyLocationsGroupedWithMacros] Typesense unavailable; returning no locations",
+    logExternalError(
+      "error",
+      { service: "typesense", operation: "company_locations_grouped_with_macros" },
       err,
     );
     return { countries: [], macros: [] };

--- a/apps/web/src/lib/services/locations.ts
+++ b/apps/web/src/lib/services/locations.ts
@@ -20,6 +20,7 @@ import { canonicalizeFilters } from "@/lib/search/canonicalize-filters";
 import { canonicalStringCompare, makeDisplayStringCompare } from "@/lib/sort";
 import { LOCATION_PAGE_SIZE } from "@/lib/search/location-paging";
 import type { LocationType } from "@/lib/search/types";
+import { logExternalError } from "@/lib/safe-external-error";
 
 export interface LocationSuggestion {
   id: number;
@@ -349,8 +350,9 @@ export async function getGlobalLocationsGrouped(
     });
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
-    console.error(
-      "[getGlobalLocationsGrouped] Typesense unavailable; returning no locations",
+    logExternalError(
+      "error",
+      { service: "typesense", operation: "global_locations_grouped" },
       err,
     );
     return { macros: [], countries: [] };
@@ -493,8 +495,9 @@ export async function searchGlobalLocations(
     });
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
-    console.error(
-      "[searchGlobalLocations] Typesense unavailable; returning no matches",
+    logExternalError(
+      "error",
+      { service: "typesense", operation: "search_global_locations" },
       err,
     );
     return [];

--- a/apps/web/src/lib/services/locations.ts
+++ b/apps/web/src/lib/services/locations.ts
@@ -1,13 +1,19 @@
 import "server-only";
 
-import { sql } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
-import { db } from "@/db";
 import { cached } from "@/lib/cache";
 import { CACHE_TTL_LONG } from "@/lib/cache-ttl";
-import { withDbRetry } from "@/lib/db-retry";
 import { typeaheadLocationsCacheTag } from "@/lib/cache-tags";
 import { getTypesenseClient, type TypesenseHit } from "@/lib/search/typesense-client";
+import { isTypesenseUnavailableError } from "@/lib/search/typesense-retry";
+import {
+  fetchLocationDescendants,
+  fetchLocationDocumentsByIds,
+  fetchLocationDocumentsBySlugs,
+  fetchLocationDocumentsWithAncestors,
+  fetchLocationMacroDocuments,
+  type TypesenseLocationDocument,
+} from "@/lib/search/typesense-taxonomy";
 import { buildFilterString, POSTING_BASE_FILTER } from "@/lib/search/typesense-filters";
 import { boostByFilterMatches, type TypeaheadBoostFilters } from "@/lib/search/typeahead-boost";
 import { canonicalizeFilters } from "@/lib/search/canonicalize-filters";
@@ -160,49 +166,16 @@ function _mapLocationHit(hit: TypesenseHit, locale: string): LocationSuggestion 
  * hierarchy changes (macro region members in particular).
  *
  * Prefer {@link expandLocationIdsBatch} when callers have multiple seed
- * IDs — a single recursive CTE per batch beats L parallel CTEs. See
- * #3186.
+ * IDs so one taxonomy filter request can resolve the union.
  */
 export async function expandLocationIds(locationId: number): Promise<number[]> {
-  "use cache";
-  cacheLife("days");
-  cacheTag(typeaheadLocationsCacheTag());
-
-  const rows = await withDbRetry(
-    () =>
-      db.execute<{ [key: string]: unknown; id: number }>(sql`
-        WITH RECURSIVE seeds AS (
-          -- The location itself
-          SELECT id FROM location WHERE id = ${locationId}
-          UNION
-          -- If it's a macro region, include its member countries
-          SELECT lm.country_id AS id
-          FROM location_macro_member lm
-          WHERE lm.macro_id = ${locationId}
-        ),
-        descendants AS (
-          SELECT id FROM seeds
-          UNION ALL
-          SELECT l.id FROM location l JOIN descendants d ON l.parent_id = d.id
-        )
-        SELECT id FROM descendants
-      `),
-    { label: `expandLocationIds[${locationId}]` },
-  );
-  return (rows as unknown as { id: number }[]).map((r) => r.id);
+  return expandLocationIdsBatch([locationId]);
 }
 
 /**
  * Batch variant of {@link expandLocationIds} — takes an array of seed
- * location IDs and returns the deduplicated union of all descendant IDs
- * in a single recursive CTE round-trip (issue #3186).
- *
- * Postgres fallback paths in `_getWatchlistPostingsPostgres` and
- * `_searchCompaniesForWatchlistPostgres` previously dispatched one
- * `expandLocationIds(id)` per seed via `Promise.all(...)`, which fires L
- * separate recursive CTE queries (and L Redis round-trips even on warm
- * cache) — a 10x amplifier on the exact path that runs when Typesense is
- * degraded. The batched query collapses that to one CTE regardless of L.
+ * location IDs and returns the deduplicated union of all matching documents
+ * whose indexed `ancestor_ids` contains any seed (issue #3186).
  *
  * Cache-key shape under `'use cache'`: the wrapper sorts the ID array so
  * `[a,b]` and `[b,a]` hit the same slot. Empty input short-circuits
@@ -224,29 +197,8 @@ async function _expandLocationIdsBatchCached(
   cacheLife("days");
   cacheTag(typeaheadLocationsCacheTag());
 
-  const pgArray = `{${sortedIds.join(",")}}`;
-  const rows = await withDbRetry(
-    () =>
-      db.execute<{ [key: string]: unknown; id: number }>(sql`
-        WITH RECURSIVE seeds AS (
-          -- The seed locations themselves
-          SELECT id FROM location WHERE id = ANY(${pgArray}::integer[])
-          UNION
-          -- If any seed is a macro region, include its member countries
-          SELECT lm.country_id AS id
-          FROM location_macro_member lm
-          WHERE lm.macro_id = ANY(${pgArray}::integer[])
-        ),
-        descendants AS (
-          SELECT id FROM seeds
-          UNION
-          SELECT l.id FROM location l JOIN descendants d ON l.parent_id = d.id
-        )
-        SELECT DISTINCT id FROM descendants
-      `),
-    { label: "expandLocationIdsBatch" },
-  );
-  return (rows as unknown as { id: number }[]).map((r) => r.id);
+  const documents = await fetchLocationDescendants(sortedIds);
+  return documents.map((document) => document.location_id).sort((a, b) => a - b);
 }
 
 export interface ResolvedLocation {
@@ -289,43 +241,19 @@ async function _resolveLocationSlugsCached(
   cacheLife("days");
   cacheTag(typeaheadLocationsCacheTag());
 
-  const pgArray = `{${sortedSlugs.join(",")}}`;
-  const rows = await withDbRetry(
-    () =>
-      db.execute<{
-        [key: string]: unknown;
-        id: number;
-        slug: string;
-        type: string;
-        name: string;
-        parent_name: string | null;
-      }>(sql`
-        SELECT l.id, l.slug, l.type::text AS type,
-          ln.name,
-          pln.name AS parent_name
-        FROM location l
-        JOIN LATERAL (
-          SELECT name FROM location_name
-          WHERE location_id = l.id AND locale IN (${locale}, 'en') AND is_display = true
-          ORDER BY (locale = ${locale})::int DESC LIMIT 1
-        ) ln ON true
-        LEFT JOIN LATERAL (
-          SELECT name FROM location_name
-          WHERE location_id = l.parent_id AND locale IN (${locale}, 'en') AND is_display = true
-          ORDER BY (locale = ${locale})::int DESC LIMIT 1
-        ) pln ON true
-        WHERE l.slug = ANY(${pgArray}::text[])
-      `),
-    { label: "resolveLocationSlugs" },
-  );
+  const rows = await fetchLocationDocumentsBySlugs(sortedSlugs);
+  const parentIds = rows.flatMap((row) => row.parent_id == null ? [] : [row.parent_id]);
+  const parents = await fetchLocationDocumentsByIds(parentIds);
+  const parentsById = new Map(parents.map((parent) => [parent.location_id, parent]));
   const result: Record<string, ResolvedLocation> = {};
-  for (const r of rows as unknown as { id: number; slug: string; type: LocationType; name: string; parent_name: string | null }[]) {
-    result[r.slug] = {
-      id: r.id,
-      slug: r.slug,
-      name: r.name,
-      type: r.type,
-      parentName: r.parent_name,
+  for (const row of rows) {
+    const parent = row.parent_id == null ? undefined : parentsById.get(row.parent_id);
+    result[row.slug] = {
+      id: row.location_id,
+      slug: row.slug,
+      name: _getTypesenseLocationName(row, locale),
+      type: row.type as LocationType,
+      parentName: parent ? _getTypesenseLocationName(parent, locale) : row.parent_name ?? null,
     };
   }
   return result;
@@ -369,7 +297,7 @@ export interface GlobalMacroRegion {
    */
   abbreviation: string;
   count: number;
-  /** Member country names (English) — for the chip's hover tooltip. */
+  /** Localized member country names — for the chip's hover tooltip. */
   memberCountryNames: string[];
   /**
    * Member country IDs — used by the hierarchical-disable hook so that
@@ -414,8 +342,19 @@ export async function getGlobalLocationsGrouped(
   // facet query). Old v1/v2 entries cached the array shape and would
   // otherwise be deserialized into the new wrapper object via the
   // run-time JSON path, then fail to render the macro tier.
-  const key = `global-locs-grouped-v4:${locale}:${fKey}`;
-  return cached(key, () => _fetchGlobalLocationsGrouped(locale, filters), { ttl: CACHE_TTL_LONG });
+  const key = `global-locs-grouped-v5:${locale}:${fKey}`;
+  try {
+    return await cached(key, () => _fetchGlobalLocationsGrouped(locale, filters), {
+      ttl: CACHE_TTL_LONG,
+    });
+  } catch (err) {
+    if (!isTypesenseUnavailableError(err)) throw err;
+    console.error(
+      "[getGlobalLocationsGrouped] Typesense unavailable; returning no locations",
+      err,
+    );
+    return { macros: [], countries: [] };
+  }
 }
 
 // ── Paged variant for fast modal TTFB (#2982) ─────────────────────────
@@ -456,12 +395,12 @@ export interface GlobalLocationsPage {
  * countries; subsequent pages are fetched on-scroll and append to the
  * rendered list.
  *
- * The underlying Typesense + DB fetch is still one round-trip (cached
- * via the shared {@link cached} slot for 3600s) — the perf win comes
+ * The underlying Typesense facet + taxonomy fetch is cached via the shared
+ * {@link cached} slot for 3600s. The perf win comes
  * from React mounting fewer DOM nodes on first paint, plus the
  * subsequent pages hitting the same cache slot without re-running the
  * Typesense facet. TTFB for cursor=0 equals the unpaged action's TTFB;
- * TTFB for cursor>0 is dominated by Redis round-trip + JSON parse
+ * TTFB for cursor>0 is dominated by the cache round-trip + JSON parse
  * (typically <30ms).
  *
  * `macros` are always returned on cursor=0 only — they're bounded
@@ -552,16 +491,21 @@ export async function searchGlobalLocations(
         count: (doc.active_posting_count as number) ?? 0,
       };
     });
-  } catch {
+  } catch (err) {
+    if (!isTypesenseUnavailableError(err)) throw err;
+    console.error(
+      "[searchGlobalLocations] Typesense unavailable; returning no matches",
+      err,
+    );
     return [];
   }
 }
 
 /**
- * Canonical display labels for macro regions. Stored DB names are short
+ * Canonical display labels for macro regions. Indexed taxonomy names are short
  * abbreviations ("EU", "DACH", "EMEA") which read as alphabet-soup in chip
  * UI; this map expands the most-common ones to their full names. The slug
- * is used as the lookup key — falls back to the localized DB name when the
+ * is used as the lookup key — falls back to the localized indexed name when the
  * slug isn't in the map (e.g. NULL slug or a future addition).
  *
  * In the en/de/fr/it fall-through case we still pass the abbreviation
@@ -581,14 +525,15 @@ const MACRO_DISPLAY_NAMES: Record<string, string> = {
   worldwide: "Worldwide",
 };
 
-// ── Location hierarchy cache (from Supabase Postgres, long TTL) ──────
+// ── Location hierarchy cache (from Typesense, long TTL) ─────────────
 
 interface LocationMeta {
   id: number;
   slug: string;
   type: LocationType;
   parentId: number | null;
-  names: Record<string, string>; // locale -> display name
+  names: Record<string, string>;
+  memberCountryIds: number[];
 }
 
 // Per-region in-memory `'use cache'` (cacheLife('days')). Build ID is
@@ -597,56 +542,57 @@ interface LocationMeta {
 // Returns a plain `Record` (serializable); the wrapper converts to `Map`
 // for O(1) lookup ergonomics. Migrated from Redis-backed `cached()` in
 // #2884 (hierarchy-cache slice). See `apps/web/docs/cache-components.md`.
-async function _fetchLocationHierarchyData(): Promise<Record<string, LocationMeta>> {
+async function _fetchLocationHierarchyData(
+  sortedIds: number[],
+): Promise<Record<string, LocationMeta>> {
   "use cache";
   cacheLife("days");
+  cacheTag(typeaheadLocationsCacheTag());
 
-  const rows = await withDbRetry(
-    () =>
-      db.execute<{
-        [key: string]: unknown;
-        id: number;
-        slug: string;
-        type: string;
-        parent_id: number | null;
-      }>(sql`SELECT id, slug, type::text AS type, parent_id FROM location`),
-    { label: "locationHierarchy.locations" },
-  );
-
-  const nameRows = await withDbRetry(
-    () =>
-      db.execute<{
-        [key: string]: unknown;
-        location_id: number;
-        locale: string;
-        name: string;
-      }>(sql`SELECT location_id, locale, name FROM location_name WHERE is_display = true`),
-    { label: "locationHierarchy.names" },
-  );
-
-  const nameMap = new Map<number, Record<string, string>>();
-  for (const nr of nameRows as unknown as { location_id: number; locale: string; name: string }[]) {
-    let names = nameMap.get(nr.location_id);
-    if (!names) { names = {}; nameMap.set(nr.location_id, names); }
-    names[nr.locale] = nr.name;
-  }
+  const rows = await fetchLocationDocumentsWithAncestors(sortedIds);
 
   const result: Record<string, LocationMeta> = {};
-  for (const r of rows as unknown as { id: number; slug: string; type: LocationType; parent_id: number | null }[]) {
-    result[String(r.id)] = {
-      id: r.id,
-      slug: r.slug,
-      type: r.type,
-      parentId: r.parent_id,
-      names: nameMap.get(r.id) ?? {},
+  for (const row of rows) {
+    result[String(row.location_id)] = {
+      id: row.location_id,
+      slug: row.slug,
+      type: row.type as LocationType,
+      parentId: row.parent_id ?? null,
+      names: _locationNames(row),
+      memberCountryIds: row.member_country_ids ?? [],
     };
   }
   return result;
 }
 
-async function _getLocationHierarchyCache(): Promise<Map<number, LocationMeta>> {
-  const record = await _fetchLocationHierarchyData();
+async function _getLocationHierarchyCache(
+  ids: number[],
+): Promise<Map<number, LocationMeta>> {
+  const sorted = [...new Set(ids)].sort((a, b) => a - b);
+  const record = await _fetchLocationHierarchyData(sorted);
   return new Map(Object.entries(record).map(([k, v]) => [Number(k), v]));
+}
+
+async function _fetchMacroLocationData(): Promise<TypesenseLocationDocument[]> {
+  "use cache";
+  cacheLife("days");
+  cacheTag(typeaheadLocationsCacheTag());
+  return fetchLocationMacroDocuments();
+}
+
+function _locationNames(document: TypesenseLocationDocument): Record<string, string> {
+  const names: Record<string, string> = { en: document.name_en };
+  if (document.name_de) names.de = document.name_de;
+  if (document.name_fr) names.fr = document.name_fr;
+  if (document.name_it) names.it = document.name_it;
+  return names;
+}
+
+function _getTypesenseLocationName(
+  document: TypesenseLocationDocument,
+  locale: string,
+): string {
+  return _locationNames(document)[locale] ?? document.name_en ?? document.slug;
 }
 
 function _getLocaleName(meta: LocationMeta, locale: string): string {
@@ -657,8 +603,7 @@ async function _fetchGlobalLocationsGrouped(
   locale: string,
   filters?: { companyId?: string; keywords?: string[]; occupationIds?: number[]; seniorityIds?: number[]; technologyIds?: number[]; languages?: string[] },
 ): Promise<GlobalLocationsResponse> {
-  try {
-    const client = getTypesenseClient();
+  const client = getTypesenseClient();
 
     // Build filter string for the facet query (excludes location filter itself)
     const filterStr = buildFilterString(filters);
@@ -670,11 +615,8 @@ async function _fetchGlobalLocationsGrouped(
     // Load hierarchy metadata up-front so we know which IDs are macros
     // (used both for the dedicated macro facet query below AND for the
     // country-tier hierarchy walk further down).
-    const hierarchy = await _getLocationHierarchyCache();
-    const allMacroIds: number[] = [];
-    for (const meta of hierarchy.values()) {
-      if (meta.type === "macro") allMacroIds.push(meta.id);
-    }
+    const macroDocuments = await _fetchMacroLocationData();
+    const allMacroIds = macroDocuments.map((document) => document.location_id);
 
     // Run the country-tier facet query AND a dedicated macro-only facet
     // query in parallel. Reason for separating them: even with
@@ -707,15 +649,10 @@ async function _fetchGlobalLocationsGrouped(
       per_page: 0,
     };
 
-    // #3031: parallelize the macro-members DB lookup with the Typesense
-    // facet queries. Macro members depend only on the hierarchy (already
-    // cached), not on the Typesense result — we fetch members for *all*
-    // macros up-front and filter post-hoc by the macros that actually
-    // have a non-zero facet count. There are at most ~9 macros so the
-    // wasted work is negligible (most rows are kept anyway), and the
-    // saved sequential round-trip (~300 ms cold) shows up directly on
-    // the modal's first-paint TTFB.
-    const [result, macroResult, allMacroMembers] = await Promise.all([
+    // Run both facet requests together. Macro membership is already carried
+    // by the location documents loaded above, so this path has no crawler-
+    // mirror database round-trip.
+    const [result, macroResult] = await Promise.all([
       client.collections("job_posting").documents().search(baseSearchParams),
       macroFilterClause
         ? client.collections("job_posting").documents().search({
@@ -723,9 +660,6 @@ async function _fetchGlobalLocationsGrouped(
             filter_by: `${baseSearchParams.filter_by} && ${macroFilterClause}`,
           })
         : Promise.resolve(null),
-      allMacroIds.length > 0
-        ? _fetchGlobalMacroMembers(allMacroIds, locale)
-        : Promise.resolve(new Map<number, MacroMembers>()),
     ]);
 
     // Extract facet counts: location_id -> count
@@ -755,18 +689,20 @@ async function _fetchGlobalLocationsGrouped(
       return { macros: [], countries: [] };
     }
 
+    const hierarchy = await _getLocationHierarchyCache([
+      ...facetCounts.keys(),
+      ...allMacroIds,
+      ...macroDocuments.flatMap((document) => document.member_country_ids ?? []),
+    ]);
+
     // Build macro-region cluster from the dedicated macro-only facet
     // result (NOT the truncated top-500 country-tier facet). Ancestor
     // expansion in `exporter.py` already promotes macro IDs onto each
     // posting's `location_ids`, so the facet count for a macro reflects
     // every posting whose country (transitively) belongs to it. See
-    // `_fetchGlobalMacroMembers` for the per-macro member country names
-    // used as the chip's hover tooltip.
+    // The location document's `member_country_ids` supplies the per-macro
+    // country names used as the chip's hover tooltip.
     const macroIdsWithCounts = allMacroIds.filter((id) => (macroFacetCounts.get(id) ?? 0) > 0);
-    // Subset the pre-fetched macro members down to the macros with counts.
-    // Macros with zero matching postings won't render so we don't need
-    // their member lists past this point.
-    const macroMembers = allMacroMembers;
     const macros: GlobalMacroRegion[] = macroIdsWithCounts
       .map((id) => {
         const meta = hierarchy.get(id);
@@ -775,15 +711,19 @@ async function _fetchGlobalLocationsGrouped(
         const slugKey = (meta.slug ?? "").toLowerCase()
           || abbreviation.toLowerCase().replace(/\s+/g, "-");
         const canonical = MACRO_DISPLAY_NAMES[slugKey];
-        const members = macroMembers.get(id);
+        const members = meta.memberCountryIds
+          .map((countryId) => hierarchy.get(countryId))
+          .filter((country): country is LocationMeta => country != null)
+          .map((country) => ({ id: country.id, name: _getLocaleName(country, locale) }))
+          .sort((a, b) => makeDisplayStringCompare(locale)(a.name, b.name));
         return {
           id,
           slug: meta.slug ?? slugKey,
           name: canonical ?? abbreviation,
           abbreviation,
           count: macroFacetCounts.get(id) ?? 0,
-          memberCountryNames: members?.countryNames ?? [],
-          memberCountryIds: members?.countryIds ?? [],
+          memberCountryNames: members.map((member) => member.name),
+          memberCountryIds: members.map((member) => member.id),
         } satisfies GlobalMacroRegion;
       })
       .filter((m): m is GlobalMacroRegion => m !== null && m.count > 0)
@@ -944,65 +884,6 @@ async function _fetchGlobalLocationsGrouped(
       });
 
     return { macros, countries: sortedCountries };
-  } catch {
-    // Typesense unavailable — return empty
-    return { macros: [], countries: [] };
-  }
-}
-
-/**
- * For each macro region, fetch the names of its member countries (in the
- * caller's locale, falling back to English). Used to populate the chip's
- * hover tooltip in {@link LocationSearchModal}.
- *
- * NOTE: in production today `location_macro_member` may be sparsely
- * populated — macros are still useful (ancestor expansion in
- * `exporter.py` promotes the macro ID onto each posting via the
- * `country_id -> [macro_ids]` map, even when that map is empty in the
- * particular DB snapshot we read from). When the table is empty we return
- * an empty member list and the modal renders the chip without a tooltip.
- */
-interface MacroMembers {
-  countryNames: string[];
-  countryIds: number[];
-}
-
-async function _fetchGlobalMacroMembers(
-  macroIds: number[],
-  locale: string,
-): Promise<Map<number, MacroMembers>> {
-  if (macroIds.length === 0) return new Map();
-  const pgArray = `{${macroIds.join(",")}}`;
-  // Project `country_id` alongside `country_name` so the hierarchical
-  // disable hook (#2978) can walk macro -> member-country links without
-  // a second round-trip. Names and IDs stay aligned because they share
-  // the same row order.
-  const rows = await db.execute<{
-    [key: string]: unknown;
-    macro_id: number;
-    country_id: number;
-    country_name: string;
-  }>(sql`
-    SELECT lmm.macro_id, lmm.country_id, ln.name AS country_name
-    FROM location_macro_member lmm
-    JOIN LATERAL (
-      SELECT name FROM location_name
-      WHERE location_id = lmm.country_id
-        AND locale IN (${locale}, 'en')
-        AND is_display = true
-      ORDER BY (locale = ${locale})::int DESC LIMIT 1
-    ) ln ON true
-    WHERE lmm.macro_id = ANY(${pgArray}::integer[])
-    ORDER BY lmm.macro_id, ln.name
-  `);
-  const map = new Map<number, MacroMembers>();
-  for (const r of rows as unknown as { macro_id: number; country_id: number; country_name: string }[]) {
-    let entry = map.get(r.macro_id);
-    if (!entry) { entry = { countryNames: [], countryIds: [] }; map.set(r.macro_id, entry); }
-    entry.countryNames.push(r.country_name);
-    entry.countryIds.push(r.country_id);
-  }
-  return map;
 }
 
 function _ensureCountryGroup(

--- a/apps/web/src/lib/services/taxonomy.ts
+++ b/apps/web/src/lib/services/taxonomy.ts
@@ -1,17 +1,20 @@
 import "server-only";
 
-import { sql } from "drizzle-orm";
 import { cacheLife, cacheTag } from "next/cache";
-import { db } from "@/db";
 import { cached } from "@/lib/cache";
 import { CACHE_TTL_LONG } from "@/lib/cache-ttl";
-import { withDbRetry } from "@/lib/db-retry";
 import {
   typeaheadOccupationsCacheTag,
   typeaheadSenioritiesCacheTag,
   typeaheadTechnologiesCacheTag,
 } from "@/lib/cache-tags";
 import { getTypesenseClient, type TypesenseHit } from "@/lib/search/typesense-client";
+import { isTypesenseUnavailableError } from "@/lib/search/typesense-retry";
+import {
+  fetchOccupationDocuments,
+  fetchSeniorityDocuments,
+  fetchTechnologyDocuments,
+} from "@/lib/search/typesense-taxonomy";
 import { buildFilterString, POSTING_BASE_FILTER } from "@/lib/search/typesense-filters";
 import { boostByFilterMatches, type TypeaheadBoostFilters } from "@/lib/search/typeahead-boost";
 import { canonicalizeFilters } from "@/lib/search/canonicalize-filters";
@@ -345,29 +348,16 @@ async function _resolveOccupationSlugsCached(
   cacheLife("days");
   cacheTag(typeaheadOccupationsCacheTag());
 
-  const pgArray = `{${sortedSlugs.join(",")}}`;
-  const rows = await withDbRetry(
-    () =>
-      db.execute<{
-        [key: string]: unknown;
-        id: number;
-        slug: string;
-        name: string;
-      }>(sql`
-        SELECT o.id, o.slug, dn.name
-        FROM occupation o
-        JOIN LATERAL (
-          SELECT name FROM occupation_name
-          WHERE occupation_id = o.id AND locale IN (${locale}, 'en') AND is_display = true
-          ORDER BY (locale = ${locale})::int DESC LIMIT 1
-        ) dn ON true
-        WHERE o.slug = ANY(${pgArray}::text[])
-      `),
-    { label: "resolveOccupationSlugs" },
-  );
+  const rows = await fetchOccupationDocuments(locale);
+  const wanted = new Set(sortedSlugs);
   const result: Record<string, TaxonomySuggestion> = {};
-  for (const r of rows as unknown as { id: number; slug: string; name: string }[]) {
-    result[r.slug] = { id: r.id, slug: r.slug, name: r.name };
+  for (const row of rows) {
+    if (!wanted.has(row.slug)) continue;
+    result[row.slug] = {
+      id: row.occupation_id,
+      slug: row.slug,
+      name: row.name,
+    };
   }
   return result;
 }
@@ -391,29 +381,16 @@ async function _resolveSenioritySlugsCached(
   cacheLife("days");
   cacheTag(typeaheadSenioritiesCacheTag());
 
-  const pgArray = `{${sortedSlugs.join(",")}}`;
-  const rows = await withDbRetry(
-    () =>
-      db.execute<{
-        [key: string]: unknown;
-        id: number;
-        slug: string;
-        name: string;
-      }>(sql`
-        SELECT s.id, s.slug, dn.name
-        FROM seniority s
-        JOIN LATERAL (
-          SELECT name FROM seniority_name
-          WHERE seniority_id = s.id AND locale IN (${locale}, 'en') AND is_display = true
-          ORDER BY (locale = ${locale})::int DESC LIMIT 1
-        ) dn ON true
-        WHERE s.slug = ANY(${pgArray}::text[])
-      `),
-    { label: "resolveSenioritySlugs" },
-  );
+  const rows = await fetchSeniorityDocuments(locale);
+  const wanted = new Set(sortedSlugs);
   const result: Record<string, TaxonomySuggestion> = {};
-  for (const r of rows as unknown as { id: number; slug: string; name: string }[]) {
-    result[r.slug] = { id: r.id, slug: r.slug, name: r.name };
+  for (const row of rows) {
+    if (!wanted.has(row.slug)) continue;
+    result[row.slug] = {
+      id: row.seniority_id,
+      slug: row.slug,
+      name: row.name,
+    };
   }
   return result;
 }
@@ -428,40 +405,16 @@ async function _resolveSenioritySlugsCached(
  * drops the slot when the occupation hierarchy changes.
  *
  * Prefer {@link expandOccupationIdsBatch} when callers have multiple seed
- * IDs — a single recursive CTE per batch beats L parallel CTEs. See
- * #3186.
+ * IDs so one cached taxonomy snapshot resolves the union.
  */
 export async function expandOccupationIds(occupationId: number): Promise<number[]> {
-  "use cache";
-  cacheLife("days");
-  cacheTag(typeaheadOccupationsCacheTag());
-
-  const rows = await withDbRetry(
-    () =>
-      db.execute<{ [key: string]: unknown; id: number }>(sql`
-        WITH RECURSIVE descendants AS (
-          SELECT id FROM occupation WHERE id = ${occupationId}
-          UNION ALL
-          SELECT o.id FROM occupation o JOIN descendants d ON o.parent_id = d.id
-        )
-        SELECT id FROM descendants
-      `),
-    { label: `expandOccupationIds[${occupationId}]` },
-  );
-  return (rows as unknown as { id: number }[]).map((r) => r.id);
+  return expandOccupationIdsBatch([occupationId]);
 }
 
 /**
  * Batch variant of {@link expandOccupationIds} — takes an array of seed
- * occupation IDs and returns the deduplicated union of all descendant IDs
- * in a single recursive CTE round-trip (issue #3186).
- *
- * Postgres fallback paths in `_getWatchlistPostingsPostgres` and
- * `_searchCompaniesForWatchlistPostgres` previously dispatched one
- * `expandOccupationIds(id)` per seed via `Promise.all(...)`, which fires
- * L separate recursive CTE queries (and L Redis round-trips even on
- * warm cache). The batched query collapses that to one CTE regardless
- * of L.
+ * occupation IDs and walks the indexed `parent_id` metadata in memory to
+ * return the deduplicated descendant union (issue #3186).
  *
  * Cache-key shape under `'use cache'`: the wrapper sorts the ID array
  * so `[a,b]` and `[b,a]` hit the same slot. Empty input short-circuits
@@ -482,20 +435,24 @@ async function _expandOccupationIdsBatchCached(
   cacheLife("days");
   cacheTag(typeaheadOccupationsCacheTag());
 
-  const pgArray = `{${sortedIds.join(",")}}`;
-  const rows = await withDbRetry(
-    () =>
-      db.execute<{ [key: string]: unknown; id: number }>(sql`
-        WITH RECURSIVE descendants AS (
-          SELECT id FROM occupation WHERE id = ANY(${pgArray}::integer[])
-          UNION
-          SELECT o.id FROM occupation o JOIN descendants d ON o.parent_id = d.id
-        )
-        SELECT DISTINCT id FROM descendants
-      `),
-    { label: "expandOccupationIdsBatch" },
-  );
-  return (rows as unknown as { id: number }[]).map((r) => r.id);
+  const documents = await fetchOccupationDocuments("en");
+  const descendants = new Set(sortedIds);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const document of documents) {
+      if (
+        document.parent_id != null &&
+        descendants.has(document.parent_id) &&
+        !descendants.has(document.occupation_id)
+      ) {
+        descendants.add(document.occupation_id);
+        changed = true;
+      }
+    }
+  }
+  const known = new Set(documents.map((document) => document.occupation_id));
+  return [...descendants].filter((id) => known.has(id)).sort((a, b) => a - b);
 }
 
 export async function resolveTechnologySlugs(
@@ -515,21 +472,16 @@ async function _resolveTechnologySlugsCached(
   cacheLife("days");
   cacheTag(typeaheadTechnologiesCacheTag());
 
-  const pgArray = `{${sortedSlugs.join(",")}}`;
-  const rows = await withDbRetry(
-    () =>
-      db.execute<{
-        [key: string]: unknown; id: number; slug: string; name: string;
-      }>(sql`
-        SELECT t.id, t.slug, COALESCE(t.name, t.slug) AS name
-        FROM technology t
-        WHERE t.slug = ANY(${pgArray}::text[])
-      `),
-    { label: "resolveTechnologySlugs" },
-  );
+  const rows = await fetchTechnologyDocuments();
+  const wanted = new Set(sortedSlugs);
   const result: Record<string, TaxonomySuggestion> = {};
-  for (const r of rows as unknown as { id: number; slug: string; name: string }[]) {
-    result[r.slug] = { id: r.id, slug: r.slug, name: r.name };
+  for (const row of rows) {
+    if (!wanted.has(row.slug)) continue;
+    result[row.slug] = {
+      id: row.technology_id,
+      slug: row.slug,
+      name: row.name ?? row.slug,
+    };
   }
   return result;
 }
@@ -584,8 +536,19 @@ export async function getAllOccupationsGrouped(
   // counts directly; sub-group/domain totals dropped the
   // sum-children-and-add-parent hack). Old v1 entries cached the buggy
   // summed counts.
-  const key = `occ-all-grouped-v2:${locale}:${fKey}`;
-  return cached(key, () => _fetchAllOccupationsGrouped(locale, filters), { ttl: CACHE_TTL_LONG });
+  const key = `occ-all-grouped-v3:${locale}:${fKey}`;
+  try {
+    return await cached(key, () => _fetchAllOccupationsGrouped(locale, filters), {
+      ttl: CACHE_TTL_LONG,
+    });
+  } catch (err) {
+    if (!isTypesenseUnavailableError(err)) throw err;
+    console.error(
+      "[getAllOccupationsGrouped] Typesense unavailable; returning no occupations",
+      err,
+    );
+    return [];
+  }
 }
 
 // ── Occupation hierarchy cache ───────────────────────────────────────
@@ -617,84 +580,26 @@ async function _fetchOccupationHierarchyData(): Promise<{
   "use cache";
   cacheLife("days");
 
-  // Fetch occupations
-  const occRows = await withDbRetry(
-    () =>
-      db.execute<{
-        [key: string]: unknown;
-        id: number;
-        slug: string;
-        parent_id: number | null;
-        domain_id: number | null;
-      }>(sql`SELECT id, slug, parent_id, domain_id FROM occupation`),
-    { label: "occupationHierarchy.occupations" },
-  );
-
-  const occNameRows = await withDbRetry(
-    () =>
-      db.execute<{
-        [key: string]: unknown;
-        occupation_id: number;
-        locale: string;
-        name: string;
-      }>(sql`SELECT occupation_id, locale, name FROM occupation_name WHERE is_display = true`),
-    { label: "occupationHierarchy.names" },
-  );
-
-  const occNameMap = new Map<number, Record<string, string>>();
-  for (const nr of occNameRows as unknown as { occupation_id: number; locale: string; name: string }[]) {
-    let names = occNameMap.get(nr.occupation_id);
-    if (!names) { names = {}; occNameMap.set(nr.occupation_id, names); }
-    names[nr.locale] = nr.name;
-  }
+  cacheTag(typeaheadOccupationsCacheTag());
+  const occRows = await fetchOccupationDocuments("en");
 
   const occupations: Record<string, OccupationMeta> = {};
-  for (const r of occRows as unknown as { id: number; slug: string; parent_id: number | null; domain_id: number | null }[]) {
-    occupations[String(r.id)] = {
-      id: r.id,
-      slug: r.slug,
-      parentId: r.parent_id,
-      domainId: r.domain_id,
-      names: occNameMap.get(r.id) ?? {},
-    };
-  }
-
-  // Fetch domains
-  const domainRows = await withDbRetry(
-    () =>
-      db.execute<{
-        [key: string]: unknown;
-        id: number;
-        slug: string;
-      }>(sql`SELECT id, slug FROM occupation_domain`),
-    { label: "occupationHierarchy.domains" },
-  );
-
-  const domainNameRows = await withDbRetry(
-    () =>
-      db.execute<{
-        [key: string]: unknown;
-        domain_id: number;
-        locale: string;
-        name: string;
-      }>(sql`SELECT domain_id, locale, name FROM occupation_domain_name WHERE is_display = true`),
-    { label: "occupationHierarchy.domainNames" },
-  );
-
-  const domainNameMap = new Map<number, Record<string, string>>();
-  for (const nr of domainNameRows as unknown as { domain_id: number; locale: string; name: string }[]) {
-    let names = domainNameMap.get(nr.domain_id);
-    if (!names) { names = {}; domainNameMap.set(nr.domain_id, names); }
-    names[nr.locale] = nr.name;
-  }
-
   const domains: Record<string, OccupationDomainMeta> = {};
-  for (const r of domainRows as unknown as { id: number; slug: string }[]) {
-    domains[String(r.id)] = {
-      id: r.id,
-      slug: r.slug,
-      names: domainNameMap.get(r.id) ?? {},
+  for (const row of occRows) {
+    occupations[String(row.occupation_id)] = {
+      id: row.occupation_id,
+      slug: row.slug,
+      parentId: row.parent_id ?? null,
+      domainId: row.domain_id ?? null,
+      names: { en: row.name },
     };
+    if (row.domain_id != null && row.domain_slug) {
+      domains[String(row.domain_id)] = {
+        id: row.domain_id,
+        slug: row.domain_slug,
+        names: { en: row.domain_name ?? row.domain_slug },
+      };
+    }
   }
 
   return { occupations, domains };
@@ -711,6 +616,33 @@ async function _getOccupationHierarchyCache(): Promise<{
   };
 }
 
+async function _getLocalizedOccupationHierarchyCache(locale: string): Promise<{
+  occupations: Map<number, OccupationMeta>;
+  domains: Map<number, OccupationDomainMeta>;
+}> {
+  if (locale === "en") return _getOccupationHierarchyCache();
+  const rows = await fetchOccupationDocuments(locale);
+  const occupations = new Map<number, OccupationMeta>();
+  const domains = new Map<number, OccupationDomainMeta>();
+  for (const row of rows) {
+    occupations.set(row.occupation_id, {
+      id: row.occupation_id,
+      slug: row.slug,
+      parentId: row.parent_id ?? null,
+      domainId: row.domain_id ?? null,
+      names: { [locale]: row.name },
+    });
+    if (row.domain_id != null && row.domain_slug) {
+      domains.set(row.domain_id, {
+        id: row.domain_id,
+        slug: row.domain_slug,
+        names: { [locale]: row.domain_name ?? row.domain_slug },
+      });
+    }
+  }
+  return { occupations, domains };
+}
+
 function _getLocaleName(names: Record<string, string>, locale: string, fallback: string): string {
   return names[locale] ?? names.en ?? fallback;
 }
@@ -719,8 +651,7 @@ async function _fetchAllOccupationsGrouped(
   locale: string,
   filters?: { companyId?: string; keywords?: string[]; locationIds?: number[]; seniorityIds?: number[]; technologyIds?: number[]; languages?: string[] },
 ): Promise<OccupationGroup[]> {
-  try {
-    const client = getTypesenseClient();
+  const client = getTypesenseClient();
     const filterStr = buildFilterString(filters);
 
     const hasKeywords = filters?.keywords && filters.keywords.length > 0;
@@ -762,11 +693,11 @@ async function _fetchAllOccupationsGrouped(
     if (facetCounts.size === 0) return [];
 
     // Load hierarchy metadata
-    const { occupations, domains } = await _getOccupationHierarchyCache();
+    const { occupations, domains } = await _getLocalizedOccupationHierarchyCache(locale);
 
     // Build items with counts from facet data. Every facet value is an
-    // occupation id; occupation-domain ids come from a separate database
-    // sequence and must not be interpreted in this namespace (#3027).
+    // occupation id; occupation-domain ids remain a separate identifier
+    // namespace and must not be interpreted as occupation ids (#3027).
     type OccRow = { id: number; slug: string; name: string; cnt: number; parentId: number | null; domainId: number | null };
     const items: OccRow[] = [];
 
@@ -937,9 +868,6 @@ async function _fetchAllOccupationsGrouped(
 
     groupedResult.sort((a, b) => b.domain.count - a.domain.count);
     return [...groupedResult, ...ungrouped];
-  } catch {
-    return [];
-  }
 }
 
 // ── All seniorities (Typesense facets) ──────────────────────────────
@@ -957,8 +885,19 @@ export async function getAllSeniorities(
 ): Promise<SeniorityOption[]> {
   // Stable cache key across array permutations — see #3187.
   const fKey = filters ? JSON.stringify(canonicalizeFilters(filters)) : "";
-  const key = `sen-all:${locale}:${fKey}`;
-  return cached(key, () => _fetchAllSeniorities(locale, filters), { ttl: CACHE_TTL_LONG });
+  const key = `sen-all-v2:${locale}:${fKey}`;
+  try {
+    return await cached(key, () => _fetchAllSeniorities(locale, filters), {
+      ttl: CACHE_TTL_LONG,
+    });
+  } catch (err) {
+    if (!isTypesenseUnavailableError(err)) throw err;
+    console.error(
+      "[getAllSeniorities] Typesense unavailable; returning no seniorities",
+      err,
+    );
+    return [];
+  }
 }
 
 // ── Seniority metadata cache ─────────────────────────────────────────
@@ -972,51 +911,27 @@ interface SeniorityMeta {
 // Per-region in-memory `'use cache'` (cacheLife('days')). See note on
 // `_fetchOccupationHierarchyData` above. Migrated from Redis-backed
 // `cached()` in #2884 (hierarchy-cache slice).
-async function _fetchSeniorityHierarchyData(): Promise<Record<string, SeniorityMeta>> {
+async function _fetchSeniorityHierarchyData(
+  locale: string,
+): Promise<Record<string, SeniorityMeta>> {
   "use cache";
   cacheLife("days");
-
-  const rows = await withDbRetry(
-    () =>
-      db.execute<{
-        [key: string]: unknown;
-        id: number;
-        slug: string;
-      }>(sql`SELECT id, slug FROM seniority`),
-    { label: "seniorityHierarchy.seniorities" },
-  );
-
-  const nameRows = await withDbRetry(
-    () =>
-      db.execute<{
-        [key: string]: unknown;
-        seniority_id: number;
-        locale: string;
-        name: string;
-      }>(sql`SELECT seniority_id, locale, name FROM seniority_name WHERE is_display = true`),
-    { label: "seniorityHierarchy.names" },
-  );
-
-  const nameMap = new Map<number, Record<string, string>>();
-  for (const nr of nameRows as unknown as { seniority_id: number; locale: string; name: string }[]) {
-    let names = nameMap.get(nr.seniority_id);
-    if (!names) { names = {}; nameMap.set(nr.seniority_id, names); }
-    names[nr.locale] = nr.name;
-  }
+  cacheTag(typeaheadSenioritiesCacheTag());
+  const rows = await fetchSeniorityDocuments(locale);
 
   const result: Record<string, SeniorityMeta> = {};
-  for (const r of rows as unknown as { id: number; slug: string }[]) {
-    result[String(r.id)] = {
-      id: r.id,
-      slug: r.slug,
-      names: nameMap.get(r.id) ?? {},
+  for (const row of rows) {
+    result[String(row.seniority_id)] = {
+      id: row.seniority_id,
+      slug: row.slug,
+      names: { [locale]: row.name },
     };
   }
   return result;
 }
 
-async function _getSeniorityCache(): Promise<Map<number, SeniorityMeta>> {
-  const record = await _fetchSeniorityHierarchyData();
+async function _getSeniorityCache(locale: string): Promise<Map<number, SeniorityMeta>> {
+  const record = await _fetchSeniorityHierarchyData(locale);
   return new Map(Object.entries(record).map(([k, v]) => [Number(k), v]));
 }
 
@@ -1024,8 +939,7 @@ async function _fetchAllSeniorities(
   locale: string,
   filters?: { companyId?: string; keywords?: string[]; locationIds?: number[]; occupationIds?: number[]; technologyIds?: number[]; languages?: string[] },
 ): Promise<SeniorityOption[]> {
-  try {
-    const client = getTypesenseClient();
+  const client = getTypesenseClient();
     const filterStr = buildFilterString(filters);
 
     const hasKeywords = filters?.keywords && filters.keywords.length > 0;
@@ -1046,7 +960,7 @@ async function _fetchAllSeniorities(
     );
     if (!senFacet) return [];
 
-    const senCache = await _getSeniorityCache();
+    const senCache = await _getSeniorityCache(locale);
 
     const options: SeniorityOption[] = [];
     for (const fc of (senFacet as { counts: Array<{ value: string; count: number }> }).counts) {
@@ -1064,9 +978,6 @@ async function _fetchAllSeniorities(
     // Sort by seniority id (preserve logical order)
     options.sort((a, b) => a.id - b.id);
     return options;
-  } catch {
-    return [];
-  }
 }
 
 // ── All technologies grouped by category (Typesense facets) ──────────
@@ -1088,8 +999,19 @@ export async function getAllTechnologiesGrouped(
 ): Promise<TechnologyGroup[]> {
   // Stable cache key across array permutations — see #3187.
   const fKey = filters ? JSON.stringify(canonicalizeFilters(filters)) : "";
-  const key = `tech-all-grouped:${fKey}`;
-  return cached(key, () => _fetchAllTechnologiesGrouped(filters), { ttl: CACHE_TTL_LONG });
+  const key = `tech-all-grouped-v2:${fKey}`;
+  try {
+    return await cached(key, () => _fetchAllTechnologiesGrouped(filters), {
+      ttl: CACHE_TTL_LONG,
+    });
+  } catch (err) {
+    if (!isTypesenseUnavailableError(err)) throw err;
+    console.error(
+      "[getAllTechnologiesGrouped] Typesense unavailable; returning no technologies",
+      err,
+    );
+    return [];
+  }
 }
 
 // ── Technology metadata cache ────────────────────────────────────────
@@ -1115,25 +1037,15 @@ async function _fetchTechnologyHierarchyData(): Promise<Record<string, Technolog
   // matching the typeahead slot's invalidation.
   cacheTag(typeaheadTechnologiesCacheTag());
 
-  const rows = await withDbRetry(
-    () =>
-      db.execute<{
-        [key: string]: unknown;
-        id: number;
-        slug: string;
-        name: string | null;
-        category: string | null;
-      }>(sql`SELECT id, slug, name, category FROM technology`),
-    { label: "technologyHierarchy" },
-  );
+  const rows = await fetchTechnologyDocuments();
 
   const result: Record<string, TechnologyMeta> = {};
-  for (const r of rows as unknown as { id: number; slug: string; name: string | null; category: string | null }[]) {
-    result[String(r.id)] = {
-      id: r.id,
-      slug: r.slug,
-      name: r.name ?? r.slug,
-      category: r.category ?? "other",
+  for (const row of rows) {
+    result[String(row.technology_id)] = {
+      id: row.technology_id,
+      slug: row.slug,
+      name: row.name ?? row.slug,
+      category: row.category ?? "other",
     };
   }
   return result;
@@ -1147,8 +1059,7 @@ async function _getTechnologyCache(): Promise<Map<number, TechnologyMeta>> {
 async function _fetchAllTechnologiesGrouped(
   filters?: { companyId?: string; keywords?: string[]; locationIds?: number[]; occupationIds?: number[]; seniorityIds?: number[]; languages?: string[] },
 ): Promise<TechnologyGroup[]> {
-  try {
-    const client = getTypesenseClient();
+  const client = getTypesenseClient();
     const filterStr = buildFilterString(filters);
 
     const hasKeywords = filters?.keywords && filters.keywords.length > 0;
@@ -1198,9 +1109,6 @@ async function _fetchAllTechnologiesGrouped(
         const bTotal = b.technologies.reduce((s, t) => s + t.count, 0);
         return bTotal - aTotal;
       });
-  } catch {
-    return [];
-  }
 }
 
 // ── Facet-count helpers for fixed-option modals ──────────────────────

--- a/apps/web/src/lib/services/taxonomy.ts
+++ b/apps/web/src/lib/services/taxonomy.ts
@@ -19,6 +19,7 @@ import { buildFilterString, POSTING_BASE_FILTER } from "@/lib/search/typesense-f
 import { boostByFilterMatches, type TypeaheadBoostFilters } from "@/lib/search/typeahead-boost";
 import { canonicalizeFilters } from "@/lib/search/canonicalize-filters";
 import { canonicalStringCompare } from "@/lib/sort";
+import { logExternalError } from "@/lib/safe-external-error";
 
 export interface TaxonomySuggestion {
   id: number;
@@ -543,8 +544,9 @@ export async function getAllOccupationsGrouped(
     });
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
-    console.error(
-      "[getAllOccupationsGrouped] Typesense unavailable; returning no occupations",
+    logExternalError(
+      "error",
+      { service: "typesense", operation: "all_occupations_grouped" },
       err,
     );
     return [];
@@ -892,10 +894,7 @@ export async function getAllSeniorities(
     });
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
-    console.error(
-      "[getAllSeniorities] Typesense unavailable; returning no seniorities",
-      err,
-    );
+    logExternalError("error", { service: "typesense", operation: "all_seniorities" }, err);
     return [];
   }
 }
@@ -1006,8 +1005,9 @@ export async function getAllTechnologiesGrouped(
     });
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
-    console.error(
-      "[getAllTechnologiesGrouped] Typesense unavailable; returning no technologies",
+    logExternalError(
+      "error",
+      { service: "typesense", operation: "all_technologies_grouped" },
       err,
     );
     return [];

--- a/docs/11-typesense.md
+++ b/docs/11-typesense.md
@@ -319,8 +319,20 @@ downtime is required.
 - All search, typeahead, browse-all modals, and watchlist search go through Typesense
 - **Posting detail**: `getPostingDetail` retrieves the posting plus company/location/seniority documents from Typesense and builds the R2 description URL. Original salary amount, currency, and period are denormalized onto the posting document for this reader.
 - **Saved jobs**: `saved_job` owns an immutable posting/company snapshot. The snapshot is populated from Typesense for new saves and backfilled by migration for existing saves, so application history survives later removal of the Supabase `job_posting` mirror. List/detail readers refresh current `is_active` in one bounded Typesense query and retain the snapshot value for missing hits or outages.
-- **Watchlist posting reads**: public watchlist discovery and watchlist posting lists/counts read the Typesense `watchlist` / `job_posting` collections. Together with the posting-detail path above, these named paths do not fall back to the Supabase crawler mirror. Authenticated watchlist metadata, company membership, and mutations remain in the web database
-- **Graceful degradation**: public watchlist discovery and watchlist posting lists return empty results when Typesense is unavailable, while watchlist posting counts return zero. These outages are logged, outage-shaped public discovery results are not cached, and non-availability errors still propagate. This guarantee is scoped to the watchlist and posting-detail paths; the deferred `company.ts` location/taxonomy readers described below remain a deployment blocker
+- **Company- and watchlist-facing reads**: company autocomplete, watchlist company search, public watchlist discovery, watchlist posting lists/counts, the progress-page company/posting counters, and `getCompanyBySlug` read Typesense. They do not fall back to the Supabase crawler mirror. Authenticated watchlist metadata, company membership, and mutations remain in the web database
+- **Location/taxonomy reads**: filter-chip slug resolution, descendant
+  expansion, browse-all location/occupation/seniority/technology metadata,
+  industry suggestions, and company location summaries read the taxonomy,
+  company, and posting collections. They do not read the Supabase crawler
+  mirror.
+- **Graceful degradation**: optional company/location/taxonomy browse surfaces
+  return their empty shape only when Typesense is unavailable, and the catch is
+  outside the cache boundary so an outage-shaped empty is not stored. Exact
+  slug resolvers and unexpected errors (including rate limits and schema/query
+  errors) propagate. Company detail degrades to not found and logs an actual
+  outage. Public watchlist discovery and posting lists return empty results and
+  posting counts return zero during a confirmed Typesense outage. No live
+  fallback returns crawler data from Supabase.
 - **Caching**: no Redis cache on main search (Typesense is fast enough). Cached for unfiltered homepage (60s) and popular watchlists (120s). `getCompanyBySlug` is wrapped with a Redis cache (`ttl: 600`, key `company-slug:{slug}:{locale}`) that skips storing nulls so brand-new slugs aren't poisoned
 - **Server-side client**: `typesense-js` in the web app, connecting to `typesense.colophon-group.org` (Cloudflare tunnel) with the search/read key
 
@@ -344,7 +356,8 @@ The web app can bypass the Vercel server-action proxy and call Typesense directl
 - Salary/experience histograms (`getSalaryHistogram`/`getExperienceHistogram`, kept on server actions for the 3600 s cache)
 - `getCompanyBySlug` (server-rendered and cached; unavailable Typesense degrades to not found)
 - `getSimilarCompanies` (filtered path requires Postgres slug→id resolution)
-- Browse-all modals (`getGlobalLocationsGrouped`, `getAllOccupationsGrouped`, etc. — need Postgres taxonomy hierarchy)
+- Browse-all modals (`getGlobalLocationsGrouped`, `getAllOccupationsGrouped`,
+  etc. -- server-side Typesense taxonomy snapshots and facets)
 - Watchlist postings for >100 companies (uses batched-merge logic that's only worth maintaining server-side)
 
 **Infrastructure:**
@@ -363,7 +376,7 @@ Three data tiers, three read paths:
 |------|------|-------|
 | Local Postgres (Hetzner) | Source of truth for `job_posting`, taxonomies, companies | Crawler workers, exporter, `refresh-typesense` count aggregations, watchlist active-posting counts (via crawler) |
 | Web-owned Postgres | **Only home** for user-facing tables (`user`, `session`, `watchlist`, `watchlist_company`, `saved_job`, ...) | Auth, watchlist mutations, saved-job snapshots, and watchlist company-pair lookups |
-| Typesense | In-memory search + denormalized read layer | Job search and posting detail, all typeaheads, browse-all modals, watchlist company search/discovery/posting lists/counts, company autocomplete/detail, public site stats, similar-company strip |
+| Typesense | In-memory search + denormalized read layer | Job search and posting detail, all typeaheads and taxonomy resolvers, browse-all modals, watchlist search/discovery/posting lists/counts, company autocomplete/detail/location/industry reads, public site stats, similar-company strip |
 
 Aggregation queries against `job_posting` are deliberately kept on local Postgres, not Supabase, to keep Supabase compute reserved for user-facing CRUD. Notable examples:
 


### PR DESCRIPTION
Closes the remaining web read-plane portion of #6167.

## What changes

- Moves location, occupation, seniority, technology, industry, and company-location readers from the former Supabase crawler mirror to Typesense.
- Adds bounded taxonomy helpers, deterministic locale sorting, outage behavior, and an anti-Supabase-read contract.
- Keeps durable auth, saved-job, watchlist metadata, membership, and mutations in the web-owned database.

## Rollout evidence

- Restacked onto exact `main` base `42277b17c886bb7eb5ff01eb68f831136890451e`; PR head is `5d860c1f6e309ba240a3e1c66bd7489baeb6bdf4`.
- The producer in #6256 has completed production verification, and the backup/restore/timer prerequisites are complete.
- The protected `job_posting` retirement remains a separate follow-up after this consumer is deployed and its read guard is green.
- The final branch changes no crawler or release path. It inherits crawler `0.13.257` from `main`, so no additional crawler version bump is required.

## Validation

- Focused taxonomy/company/modal/API/boundary suite: 13 files, 58 tests passed on the final head.
- Full web unit suite (excluding the separately exercised Typesense E2E): 218 files, 1,562 tests passed.
- Typesense 27.1 E2E: 1 file, 32 tests passed against an isolated local container.
- ISR suite: 1 file, 15 tests passed.
- Web ESLint, TypeScript typecheck, production build, and `git diff --check` passed.
- `main` advanced once during validation only in crawler/ATS deployment paths; the validated and final `apps/web` tree hashes are identical (`b0c014e1bb17eddca635c782dc0467b2d788a5a3`).
