### PR TITLE
Expose safe web PostgreSQL backup failure evidence

### DIFF
--- a/apps/crawler/tests/test_web_postgresql_backup_operations.py
+++ b/apps/crawler/tests/test_web_postgresql_backup_operations.py
@@ -28,6 +28,21 @@ def bypass_deployment_lock(monkeypatch: pytest.MonkeyPatch, operations: ModuleTy
     monkeypatch.setattr(operations, "deployment_identity_lock", lambda: nullcontext(41))
 
 
+def failed_backup_status(**updates: object) -> dict[str, object]:
+    status: dict[str, object] = {
+        "schema_version": 1,
+        "service": "web-postgresql",
+        "attempt_at": "1970-01-01T00:16:40+00:00",
+        "attempt_unix": 1_000,
+        "success": False,
+        "finished_at": "1970-01-01T00:16:41+00:00",
+        "duration_seconds": 1.25,
+        "error": "pg_dump exited 1: connection refused",
+    }
+    status.update(updates)
+    return status
+
+
 def test_identity_requires_exact_deployed_revision_and_every_artifact(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -57,6 +72,125 @@ def test_identity_requires_exact_deployed_revision_and_every_artifact(
     artifacts["restore_drill"].write_text("tampered\n", encoding="utf-8")
     with pytest.raises(operations.OperationError, match="restore_drill"):
         operations.validate_identity(expected)
+
+
+def test_failed_backup_emits_only_fresh_aggregate_evidence_and_preserves_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    operations = load_operations()
+    expected = operations.ExpectedIdentity("a" * 40, {})
+    status_path = tmp_path / "web-postgresql.json"
+    original_failure = operations.OperationError("systemctl operation failed")
+    monkeypatch.setattr(operations, "BACKUP_STATUS_PATH", status_path)
+    monkeypatch.setattr(operations, "EVIDENCE_PATH", tmp_path / "activation.json")
+    monkeypatch.setattr(operations, "validate_host_readiness", lambda _expected: None)
+    monkeypatch.setattr(operations, "validate_identity", lambda _expected: {})
+    monkeypatch.setattr(operations, "timer_state", lambda: ("disabled", "inactive"))
+    monkeypatch.setattr(operations.time, "time", lambda: 1_000)
+
+    def fail_start(argv: list[str], **_kwargs: object) -> str:
+        if argv == ["systemctl", "start", operations.BACKUP_UNIT]:
+            status_path.write_text(
+                json.dumps(
+                    failed_backup_status(
+                        row_count=99,
+                        database_url="postgresql://must-not-appear",
+                        environment={"PASSWORD": "must-not-appear"},
+                    )
+                ),
+                encoding="utf-8",
+            )
+            raise original_failure
+        return ""
+
+    monkeypatch.setattr(operations, "run_checked", fail_start)
+
+    with pytest.raises(operations.OperationError) as raised:
+        operations.run_backup_locked(expected)
+
+    assert raised.value is original_failure
+    prefix = "Backup failure evidence: "
+    diagnostic_line = capsys.readouterr().err.strip()
+    assert diagnostic_line.startswith(prefix)
+    assert json.loads(diagnostic_line.removeprefix(prefix)) == {
+        "attempt_at": "1970-01-01T00:16:40+00:00",
+        "duration_seconds": 1.25,
+        "error": "pg_dump exited 1: connection refused",
+    }
+    assert "row_count" not in diagnostic_line
+    assert "database_url" not in diagnostic_line
+    assert "environment" not in diagnostic_line
+
+
+def test_backup_failure_diagnostic_redacts_uris_and_credentials() -> None:
+    operations = load_operations()
+    diagnostic = operations.backup_failure_diagnostic(
+        failed_backup_status(
+            error=(
+                "pg_dump postgresql://db-user:db-password@db.example/jobs failed; "
+                "password=plain-secret token:opaque-secret api_key api-secret "
+                "Authorization: Bearer bearer-secret "
+                "https://user:web-password@example.test/path?token=query-secret"
+            )
+        ),
+        started=1_000,
+    )
+
+    assert len(diagnostic) <= operations.BACKUP_FAILURE_DIAGNOSTIC_LIMIT
+    assert "db-user" not in diagnostic
+    assert "db-password" not in diagnostic
+    assert "plain-secret" not in diagnostic
+    assert "opaque-secret" not in diagnostic
+    assert "api-secret" not in diagnostic
+    assert "bearer-secret" not in diagnostic
+    assert "web-password" not in diagnostic
+    assert "query-secret" not in diagnostic
+    assert "<redacted-uri>" in diagnostic
+    assert "password=<redacted>" in diagnostic
+    assert "token=<redacted>" in diagnostic
+    assert "api_key=<redacted>" in diagnostic
+    assert "authorization=<redacted>" in diagnostic
+
+
+@pytest.mark.parametrize(
+    "status_content",
+    (None, "{", json.dumps(failed_backup_status(attempt_unix=999))),
+)
+def test_failed_backup_without_fresh_valid_evidence_preserves_original_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    status_content: str | None,
+) -> None:
+    operations = load_operations()
+    expected = operations.ExpectedIdentity("a" * 40, {})
+    status_path = tmp_path / "web-postgresql.json"
+    original_failure = operations.OperationError("systemctl operation failed")
+    if status_content is not None:
+        status_path.write_text(status_content, encoding="utf-8")
+    monkeypatch.setattr(operations, "BACKUP_STATUS_PATH", status_path)
+    monkeypatch.setattr(operations, "EVIDENCE_PATH", tmp_path / "activation.json")
+    monkeypatch.setattr(operations, "validate_host_readiness", lambda _expected: None)
+    monkeypatch.setattr(operations, "validate_identity", lambda _expected: {})
+    monkeypatch.setattr(operations, "timer_state", lambda: ("disabled", "inactive"))
+    monkeypatch.setattr(operations.time, "time", lambda: 1_000)
+    monkeypatch.setattr(
+        operations,
+        "run_checked",
+        lambda argv, **_kwargs: (
+            (_ for _ in ()).throw(original_failure)
+            if argv == ["systemctl", "start", operations.BACKUP_UNIT]
+            else ""
+        ),
+    )
+
+    with pytest.raises(operations.OperationError) as raised:
+        operations.run_backup_locked(expected)
+
+    assert raised.value is original_failure
+    assert capsys.readouterr().err == ""
 
 
 def test_root_artifact_boundary_rejects_nonroot_or_writable_files(

--- a/deploy/backups/web-postgresql/operations.py
+++ b/deploy/backups/web-postgresql/operations.py
@@ -7,6 +7,7 @@ import argparse
 import fcntl
 import hashlib
 import json
+import math
 import os
 import re
 import secrets
@@ -41,6 +42,18 @@ DATABASE_CREDENTIAL_PATH = Path("/etc/jobseek-backup/web-postgresql.database-url
 RESTORE_IMAGE = (
     "postgres:17-alpine@sha256:742f40ea20b9ff2ff31db5458d127452988a2164df9e17441e191f3b72252193"
 )
+BACKUP_FAILURE_ERROR_LIMIT = 512
+BACKUP_FAILURE_DIAGNOSTIC_LIMIT = 768
+_BACKUP_FAILURE_URI = re.compile(r"(?i)\b[a-z][a-z0-9+.-]*://[^\s'\"<>]+")
+_BACKUP_FAILURE_AUTHORITY = re.compile(r"(?i)\b[^\s:@/]+:[^\s@/]+@[a-z0-9.-]+")
+_BACKUP_FAILURE_AUTHORIZATION = re.compile(
+    r"(?i)\b(?:authorization|proxy-authorization)\s*:\s*(?:bearer|basic)\s+[^\s,;]+"
+)
+_BACKUP_FAILURE_SECRET = re.compile(
+    r"(?i)\b(?P<name>api[-_ ]?key|credential|password|passwd|secret|token)"
+    r"(?:\s*(?:=|:)\s*|\s+)(?P<value>[^\s,;]+)"
+)
+_BACKUP_FAILURE_CONTROL = re.compile(r"[\x00-\x1f\x7f]+")
 ARTIFACT_PATHS = {
     "data_backup": Path("/usr/local/sbin/jobseek-data-backup"),
     "operations": Path("/usr/local/sbin/jobseek-web-postgresql-operations"),
@@ -471,6 +484,86 @@ def required_int(value: object, field: str) -> int:
     return value
 
 
+def redact_backup_failure_error(value: object) -> str:
+    if not isinstance(value, str) or not value or len(value) > 1200:
+        raise OperationError("fresh failed web PostgreSQL backup error is invalid")
+    text = _BACKUP_FAILURE_URI.sub("<redacted-uri>", value)
+    text = _BACKUP_FAILURE_AUTHORITY.sub("<redacted-authority>", text)
+    text = _BACKUP_FAILURE_AUTHORIZATION.sub("authorization=<redacted>", text)
+    text = _BACKUP_FAILURE_SECRET.sub(
+        lambda match: f"{match.group('name')}=<redacted>",
+        text,
+    )
+    text = " ".join(_BACKUP_FAILURE_CONTROL.sub(" ", text).split())
+    if not text:
+        raise OperationError("fresh failed web PostgreSQL backup error is invalid")
+    if len(text) > BACKUP_FAILURE_ERROR_LIMIT:
+        suffix = " <truncated>"
+        prefix = text[: BACKUP_FAILURE_ERROR_LIMIT - len(suffix)]
+        boundary = prefix.rfind(" ")
+        text = (
+            prefix[:boundary] + suffix
+            if boundary >= BACKUP_FAILURE_ERROR_LIMIT // 2
+            else "backup failure detail exceeded the safe diagnostic limit"
+        )
+    if (
+        len(text) > BACKUP_FAILURE_ERROR_LIMIT
+        or _BACKUP_FAILURE_URI.search(text)
+        or _BACKUP_FAILURE_AUTHORITY.search(text)
+        or _BACKUP_FAILURE_AUTHORIZATION.search(text)
+        or any(
+            match.group("value") != "<redacted>" for match in _BACKUP_FAILURE_SECRET.finditer(text)
+        )
+    ):
+        raise OperationError("backup failure detail violated the nonsecret contract")
+    return text
+
+
+def backup_failure_diagnostic(status: dict[str, Any], *, started: int) -> str:
+    attempt = required_int(status.get("attempt_unix"), "attempt_unix")
+    attempt_at = status.get("attempt_at")
+    finished_at = status.get("finished_at")
+    duration = status.get("duration_seconds")
+    if (
+        status.get("schema_version") != 1
+        or status.get("service") != "web-postgresql"
+        or status.get("success") is not False
+        or attempt < started
+        or not isinstance(attempt_at, str)
+        or len(attempt_at) > 64
+        or parse_timestamp(attempt_at) < started
+        or not isinstance(finished_at, str)
+        or len(finished_at) > 64
+        or parse_timestamp(finished_at) < attempt
+        or isinstance(duration, bool)
+        or not isinstance(duration, (int, float))
+        or not math.isfinite(duration)
+        or duration < 0
+        or duration > 2 * 60 * 60 + 300
+    ):
+        raise OperationError("fresh failed web PostgreSQL backup evidence is invalid")
+    diagnostic = json.dumps(
+        {
+            "attempt_at": attempt_at,
+            "duration_seconds": duration,
+            "error": redact_backup_failure_error(status.get("error")),
+        },
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    if len(diagnostic) > BACKUP_FAILURE_DIAGNOSTIC_LIMIT:
+        raise OperationError("backup failure diagnostic exceeded its safe size contract")
+    return diagnostic
+
+
+def emit_backup_failure_diagnostic(*, started: int) -> None:
+    status = read_json(BACKUP_STATUS_PATH)
+    print(
+        "Backup failure evidence: " + backup_failure_diagnostic(status, started=started),
+        file=sys.stderr,
+    )
+
+
 def validate_identity(expected: ExpectedIdentity) -> dict[str, str]:
     if not re.fullmatch(r"[0-9a-f]{40}", expected.deploy_sha):
         raise OperationError("expected deployment revision is invalid")
@@ -678,7 +771,12 @@ def run_backup_locked(expected: ExpectedIdentity) -> None:
     before = timer_state()
     started = int(time.time())
     run_checked(["systemctl", "reset-failed", BACKUP_UNIT])
-    run_checked(["systemctl", "start", BACKUP_UNIT], timeout=2 * 60 * 60 + 300)
+    try:
+        run_checked(["systemctl", "start", BACKUP_UNIT], timeout=2 * 60 * 60 + 300)
+    except (OperationError, OSError, subprocess.TimeoutExpired):
+        with suppress(OperationError, OSError):
+            emit_backup_failure_diagnostic(started=started)
+        raise
     if timer_state() != before:
         raise OperationError("backup operation changed the timer state")
     artifact_hashes = validate_identity(expected)


### PR DESCRIPTION
## Summary
- validate the fresh atomic failed backup status when the protected systemd start returns an error
- emit only attempt time, duration, and a bounded independently redacted error
- fail closed on missing or malformed evidence while preserving the original service-start exception
- cover useful diagnostics, credential and URI redaction, and stale or absent evidence

## Verification
- uv run pytest tests/test_web_postgresql_backup_operations.py tests/test_web_postgresql_backup_operations_workflow.py -q (31 passed, 1 skipped)
- uv run ruff check src/ tests/ ../../deploy/backups/web-postgresql/operations.py
- uv run ruff format --check src/ tests/ ../../deploy/backups/web-postgresql/operations.py
- uv run pyright --level error
- python3 -m py_compile deploy/backups/web-postgresql/operations.py
- node --test scripts/crawler-version.test.mjs (13 passed)
- full crawler suite: 7233 passed, 53 skipped, 12 unrelated failures in shared-state Codex runner tests and unavailable optional google-genai/anthropic provider packages

## Release coordination
Crawler version 0.13.247 is intentionally reserved for #6285. This commit should be consolidated there so both workflow-test and backup-diagnostic changes ship in the same release. The standalone version gate is therefore expected to request a bump until consolidation.