### PR TITLE
Fix Supabase retirement run-name validation

### DIFF
--- a/apps/web/src/db/__tests__/production-migration-safety.test.ts
+++ b/apps/web/src/db/__tests__/production-migration-safety.test.ts
@@ -109,6 +109,14 @@ describe("production migration safety", () => {
     expect(evidenceValidator).toContain('git/ref/heads/main');
     expect(evidenceValidator).toContain('test "$main_sha" = "$CURRENT_SHA"');
     expect(evidenceValidator).toContain("Crawler maintenance: backfill-typesense @");
+    expect(
+      evidenceValidator
+        .split("\n")
+        .filter((line) => line.trim() === '"$backfill_title" \\'),
+    ).toHaveLength(2);
+    expect(evidenceValidator).not.toContain(
+      "'Crawler scheduled maintenance' \\",
+    );
     expect(evidenceValidator).toContain("apps/crawler \\");
     expect(workflow).toContain('cancel-in-progress: false');
     expect(workflow).toContain(

--- a/scripts/validate-supabase-retirement-evidence.sh
+++ b/scripts/validate-supabase-retirement-evidence.sh
@@ -123,7 +123,7 @@ backfill_title="Crawler maintenance: backfill-typesense @ ${crawler_sha}"
 backfill_sha="$(validate_run \
   "$TYPESENSE_BACKFILL_RUN_ID" \
   '.github/workflows/crawler-scheduled-maintenance.yml' \
-  'Crawler scheduled maintenance' \
+  "$backfill_title" \
   "$backfill_title" \
   workflow_dispatch \
   14400 \


### PR DESCRIPTION
## Summary
- accept GitHub Actions `run-name` semantics for the exact Typesense backfill evidence record
- continue requiring the exact expected dynamic name in both `name` and `display_title`
- add a regression assertion so the validator cannot drift back to the static workflow name

## Verification
- `pnpm --filter @jobseek/web exec vitest run src/db/__tests__/production-migration-safety.test.ts` (4 passed)
- `bash -n scripts/validate-supabase-retirement-evidence.sh`
- `git diff --check`

Production migration run 30953149268 failed closed before approval on this API-field mismatch; no database write occurred.