### PR TITLE
Fix backup evidence log selection

### DIFF
--- a/apps/web/src/db/__tests__/production-migration-safety.test.ts
+++ b/apps/web/src/db/__tests__/production-migration-safety.test.ts
@@ -99,8 +99,9 @@ describe("production migration safety", () => {
       'actions/runs/${run_id}/logs',
     );
     expect(evidenceValidator).toContain(
-      "'preauthorize/*.txt'",
+      "'*_preauthorize.txt'",
     );
+    expect(evidenceValidator).not.toContain("'preauthorize/*.txt'");
     expect(evidenceValidator).toContain("DISPATCH_MODE:");
     expect(evidenceValidator).toContain("- restore)");
     expect(evidenceValidator).not.toContain(

--- a/scripts/validate-supabase-retirement-evidence.sh
+++ b/scripts/validate-supabase-retirement-evidence.sh
@@ -44,7 +44,7 @@ validate_workflow_dispatch_input() {
     gh api "repos/${REPO}/actions/runs/${run_id}/logs" > "$archive"
   fi
   actual_modes="$(
-    unzip -p "$archive" 'preauthorize/*.txt' \
+    unzip -p "$archive" '*_preauthorize.txt' \
       | sed -n 's/^[0-9T:.+-]*Z   DISPATCH_MODE: \([^[:space:]]*\)\r*$/\1/p' \
       | sort -u
   )"


### PR DESCRIPTION
## Summary
- read the actual GitHub Actions job log entry (`*_preauthorize.txt`) from backup run archives
- keep parsing the logged `DISPATCH_MODE` value to distinguish restore evidence from backup evidence
- add a regression assertion for the archive entry shape

## Verification
- confirmed run 30936056898 contains `DISPATCH_MODE: restore` in `2_preauthorize.txt`
- confirmed run 30935836712 contains `DISPATCH_MODE: backup` in `2_preauthorize.txt`
- `pnpm --filter @jobseek/web exec vitest run src/db/__tests__/production-migration-safety.test.ts` (4 passed)
- `bash -n scripts/validate-supabase-retirement-evidence.sh`
- `git diff --check`

Migration runs failed closed before approval; no production database write occurred.