### PR TITLE
Fix Dependabot health alert access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,8 @@ jobs:
           cache-dependency-glob: "apps/crawler/uv.lock"
 
       - name: actionlint
-        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -ignore 'SC(2002|2086|2129)'
+        # GitHub added vulnerability-alerts in 2026; actionlint support is pending upstream.
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -ignore 'SC(2002|2086|2129)|unknown permission scope "vulnerability-alerts"'
 
       - name: zizmor
         run: uvx --from zizmor==1.26.1 zizmor --persona regular --min-severity medium --min-confidence high .github/workflows

--- a/.github/workflows/dependabot-health.yml
+++ b/.github/workflows/dependabot-health.yml
@@ -25,7 +25,7 @@ permissions:
   # Detect open and stale Dependabot pull requests.
   pull-requests: read
   # Read repository Dependabot alerts; the workflow never dismisses alerts.
-  security-events: read
+  vulnerability-alerts: read
 
 jobs:
   check:

--- a/scripts/dependabot-health.test.mjs
+++ b/scripts/dependabot-health.test.mjs
@@ -174,7 +174,8 @@ test("health workflow uses least-privilege read access plus issue reporting", ()
   assert.match(workflow, /actions: read/);
   assert.match(workflow, /contents: read/);
   assert.match(workflow, /pull-requests: read/);
-  assert.match(workflow, /security-events: read/);
+  assert.match(workflow, /vulnerability-alerts: read/);
+  assert.doesNotMatch(workflow, /security-events:/);
   assert.match(workflow, /issues: write/);
   assert.doesNotMatch(workflow, /contents: write/);
   assert.match(workflow, /cron: "15 8 \* \* \*"/);


### PR DESCRIPTION
## Summary
- grant the scheduled Dependabot health monitor the dedicated `vulnerability-alerts: read` permission required by the Dependabot alerts API
- update its least-privilege regression test
- narrowly ignore actionlint’s known false positive until upstream support for the 2026 permission lands

## Root cause
The monitor used `security-events: read`, which only covers code-scanning alerts. Its real workflow token therefore received a 403 from the Dependabot alerts endpoint even though administrator/API checks confirmed zero open alerts.

## Verification
- `node --test scripts/dependabot-health.test.mjs scripts/ci-workflow.test.mjs` (53/53)
- `actionlint -ignore 'SC(2002|2086|2129)|unknown permission scope "vulnerability-alerts"'`\n- `uvx --from zizmor==1.26.1 zizmor --persona regular --min-severity medium --min-confidence high .github/workflows`\n- `git diff --check`\n\nAfter merge I will dispatch the live health workflow and require success, then confirm its incident issue closes.