### PR TITLE
Reduce Vercel Fluid CPU consumption

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/opengraph-image-cache.test.ts
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/opengraph-image-cache.test.ts
@@ -2,25 +2,13 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   companyOgCacheKey: vi.fn(() => "og/company/test/en/acme.png"),
-  getCompanyBySlug: vi.fn(),
   readCompanyOgCache: vi.fn(),
+  renderCompanyOgImage: vi.fn(),
   shouldBypassCompanyOgCache: vi.fn(),
   writeCompanyOgCache: vi.fn(),
 }));
 
 vi.mock("server-only", () => ({}));
-
-vi.mock("next/og", () => ({
-  ImageResponse: class extends Response {
-    constructor(_element: unknown, init: ResponseInit = {}) {
-      super(new Uint8Array([9, 8, 7]), init);
-    }
-  },
-}));
-
-vi.mock("@/lib/actions/company", () => ({
-  getCompanyBySlug: mocks.getCompanyBySlug,
-}));
 
 vi.mock("@/lib/og/company-og-cache", () => ({
   companyOgCacheKey: mocks.companyOgCacheKey,
@@ -29,33 +17,25 @@ vi.mock("@/lib/og/company-og-cache", () => ({
   writeCompanyOgCache: mocks.writeCompanyOgCache,
 }));
 
-import OgImage from "../opengraph-image";
+vi.mock("@/lib/og/render-company-og", () => ({
+  renderCompanyOgImage: mocks.renderCompanyOgImage,
+}));
 
-const company = {
-  id: "co-1",
-  name: "Acme",
-  slug: "acme",
-  icon: null,
-  logo: null,
-  website: "https://acme.example",
-  description: "A company.",
-  industryId: 1,
-  industryName: "Software",
-  employeeCountRange: null,
-  foundedYear: null,
-  activeJobCount: 12,
-};
+import OgImage from "../opengraph-image";
 
 describe("company opengraph image cache", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.companyOgCacheKey.mockReturnValue("og/company/test/en/acme.png");
-    mocks.getCompanyBySlug.mockResolvedValue(company);
     mocks.readCompanyOgCache.mockResolvedValue(null);
+    mocks.renderCompanyOgImage.mockResolvedValue({
+      response: new Response(new Uint8Array([9, 8, 7])),
+      cacheable: true,
+    });
     mocks.shouldBypassCompanyOgCache.mockReturnValue(false);
   });
 
-  it("returns R2 bytes on cache hit without loading company data", async () => {
+  it("returns R2 bytes without loading the renderer", async () => {
     mocks.readCompanyOgCache.mockResolvedValue(new Uint8Array([1, 2, 3]));
 
     const response = await OgImage({
@@ -64,22 +44,35 @@ describe("company opengraph image cache", () => {
 
     expect(mocks.companyOgCacheKey).toHaveBeenCalledWith("en", "acme");
     expect(mocks.readCompanyOgCache).toHaveBeenCalledWith("og/company/test/en/acme.png");
-    expect(mocks.getCompanyBySlug).not.toHaveBeenCalled();
+    expect(mocks.renderCompanyOgImage).not.toHaveBeenCalled();
     expect(mocks.writeCompanyOgCache).not.toHaveBeenCalled();
     expect(new Uint8Array(await response.arrayBuffer())).toEqual(new Uint8Array([1, 2, 3]));
   });
 
-  it("renders and writes to R2 on cache miss", async () => {
+  it("lazy-renders and writes to R2 on cache miss", async () => {
     const response = await OgImage({
       params: Promise.resolve({ lang: "en", slug: "acme" }),
     });
 
-    expect(mocks.getCompanyBySlug).toHaveBeenCalledWith("acme", "en");
+    expect(mocks.renderCompanyOgImage).toHaveBeenCalledWith("acme", "en");
     expect(mocks.writeCompanyOgCache).toHaveBeenCalledWith(
       "og/company/test/en/acme.png",
       new Uint8Array([9, 8, 7]),
     );
     expect(new Uint8Array(await response.arrayBuffer())).toEqual(new Uint8Array([9, 8, 7]));
+  });
+
+  it("does not cache the not-found card", async () => {
+    mocks.renderCompanyOgImage.mockResolvedValue({
+      response: new Response(new Uint8Array([9, 8, 7])),
+      cacheable: false,
+    });
+
+    await OgImage({
+      params: Promise.resolve({ lang: "en", slug: "missing" }),
+    });
+
+    expect(mocks.writeCompanyOgCache).not.toHaveBeenCalled();
   });
 
   it("bypasses the R2 read when forced and overwrites the current key", async () => {
@@ -90,7 +83,7 @@ describe("company opengraph image cache", () => {
     });
 
     expect(mocks.readCompanyOgCache).not.toHaveBeenCalled();
-    expect(mocks.getCompanyBySlug).toHaveBeenCalledWith("acme", "en");
+    expect(mocks.renderCompanyOgImage).toHaveBeenCalledWith("acme", "en");
     expect(mocks.writeCompanyOgCache).toHaveBeenCalledWith(
       "og/company/test/en/acme.png",
       new Uint8Array([9, 8, 7]),

--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/opengraph-image-prebake.test.ts
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/opengraph-image-prebake.test.ts
@@ -1,4 +1,8 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getCompanyBySlug: vi.fn(),
+}));
 
 vi.mock("server-only", () => ({}));
 
@@ -10,8 +14,12 @@ vi.mock("next/og", () => ({
   },
 }));
 
-vi.mock("@/lib/actions/company", () => ({
-  getCompanyBySlug: vi.fn(),
+vi.mock("next/cache", () => ({
+  cacheLife: vi.fn(),
+}));
+
+vi.mock("@/lib/services/company", () => ({
+  getCompanyBySlug: mocks.getCompanyBySlug,
 }));
 
 vi.mock("@/lib/og/company-og-cache", () => ({
@@ -22,6 +30,11 @@ vi.mock("@/lib/og/company-og-cache", () => ({
 }));
 
 import * as ogImage from "../opengraph-image";
+import * as renderer from "@/lib/og/render-company-og";
+
+beforeEach(() => {
+  mocks.getCompanyBySlug.mockReset();
+});
 
 describe("company opengraph image route rendering mode", () => {
   it("is dynamic because request-time R2 cache IO is intentional", () => {
@@ -33,44 +46,44 @@ describe("company opengraph image route rendering mode", () => {
 describe("company opengraph image icon rendering", () => {
   it("only passes known raster icon URLs to next/og", () => {
     expect(
-      ogImage.getRenderableCompanyOgIconUrl(
+      renderer.getRenderableCompanyOgIconUrl(
         "https://jobseek-assets.colophon-group.org/companies/acme/icon.png",
       ),
     ).toBe("https://jobseek-assets.colophon-group.org/companies/acme/icon.png");
     expect(
-      ogImage.getRenderableCompanyOgIconUrl(
+      renderer.getRenderableCompanyOgIconUrl(
         "https://jobseek-assets.colophon-group.org/companies/acme/icon.jpg?version=1",
       ),
     ).toBe("https://jobseek-assets.colophon-group.org/companies/acme/icon.jpg?version=1");
     expect(
-      ogImage.getRenderableCompanyOgIconUrl(
+      renderer.getRenderableCompanyOgIconUrl(
         "https://jobseek-assets.colophon-group.org/companies/acme/icon.jpeg",
       ),
     ).toBe("https://jobseek-assets.colophon-group.org/companies/acme/icon.jpeg");
 
     expect(
-      ogImage.getRenderableCompanyOgIconUrl(
+      renderer.getRenderableCompanyOgIconUrl(
         "https://jobseek-assets.colophon-group.org/companies/graphcore/icon.svg",
       ),
     ).toBeNull();
     expect(
-      ogImage.getRenderableCompanyOgIconUrl(
+      renderer.getRenderableCompanyOgIconUrl(
         "https://jobseek-assets.colophon-group.org/companies/acme/icon.webp",
       ),
     ).toBeNull();
-    expect(ogImage.getRenderableCompanyOgIconUrl("/local/icon.png")).toBeNull();
+    expect(renderer.getRenderableCompanyOgIconUrl("/local/icon.png")).toBeNull();
   });
 
   it("uses a deterministic fallback mark for unsupported remote icons", () => {
     expect(
-      ogImage.getCompanyOgIconRenderModel({
+      renderer.getCompanyOgIconRenderModel({
         name: "Graphcore",
         icon: "https://jobseek-assets.colophon-group.org/companies/graphcore/icon.svg",
       }),
     ).toEqual({ kind: "fallback", label: "GR" });
 
     expect(
-      ogImage.getCompanyOgIconRenderModel({
+      renderer.getCompanyOgIconRenderModel({
         name: "Acme Labs",
         icon: "https://jobseek-assets.colophon-group.org/companies/acme/icon.png",
       }),
@@ -80,10 +93,45 @@ describe("company opengraph image icon rendering", () => {
     });
 
     expect(
-      ogImage.getCompanyOgIconRenderModel({
+      renderer.getCompanyOgIconRenderModel({
         name: "Acme Labs",
         icon: null,
       }),
     ).toEqual({ kind: "none" });
+  });
+
+  it("preserves the existing PNG renderer on a durable-cache miss", async () => {
+    mocks.getCompanyBySlug.mockResolvedValue({
+      id: "co-1",
+      name: "Acme Labs",
+      slug: "acme",
+      icon: null,
+      logo: null,
+      website: "https://acme.example",
+      description: "A company.",
+      industryId: 1,
+      industryName: "Software",
+      employeeCountRange: null,
+      foundedYear: null,
+      activeJobCount: 12,
+    });
+
+    const result = await renderer.renderCompanyOgImage("acme", "en");
+
+    expect(result.cacheable).toBe(true);
+    expect(new Uint8Array(await result.response.arrayBuffer())).toEqual(
+      new Uint8Array([9, 8, 7]),
+    );
+  });
+
+  it("keeps unknown-company cards out of the durable cache", async () => {
+    mocks.getCompanyBySlug.mockResolvedValue(null);
+
+    const result = await renderer.renderCompanyOgImage("missing", "en");
+
+    expect(result.cacheable).toBe(false);
+    expect(new Uint8Array(await result.response.arrayBuffer())).toEqual(
+      new Uint8Array([9, 8, 7]),
+    );
   });
 });

--- a/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useTransition, useEffect, useMemo } from "react";
+import { useState, useCallback, useTransition, useEffect, useMemo, useRef } from "react";
 import { Loader2 } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useParams, usePathname, useSearchParams } from "next/navigation";
@@ -9,7 +9,10 @@ import { getCompanyPostingListState } from "./company-posting-state";
 import { JobDetailPanel } from "@/components/search/job-detail-dialog";
 import { MobileJobDetailDialog } from "@/components/search/mobile-job-detail-dialog";
 import { SearchToolbar } from "@/components/search/search-toolbar";
-import { runGetCompanyPostings } from "@/lib/search/search-runner";
+import {
+  runGetCompanyPostings,
+  tryGetCompanyPostingsDirect,
+} from "@/lib/search/search-runner";
 import { useClearTypesenseOnAuthChange } from "@/lib/search/use-clear-typesense-on-auth-change";
 import { useSession } from "@/components/providers/SessionProvider";
 import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
@@ -115,6 +118,8 @@ export function CompanyPage({
   const [isSearching, startSearch] = useTransition();
   const [exhausted, setExhausted] = useState(initialPostings.length < PAGE_SIZE);
   const [isTruncated, setIsTruncated] = useState(initialTruncated ?? false);
+  const searchGenerationRef = useRef(0);
+  const initialDirectRefreshKeyRef = useRef<string | null>(null);
 
   // Currency rates for EUR conversion — shared via `SalaryDisplayProvider`
   // which fetches once at the (app) layout root. Previously this page
@@ -202,6 +207,7 @@ export function CompanyPage({
     const salMaxEur = toEur(salaryMaxRef.current);
     const expMin = experienceMinRef.current;
     const expMax = experienceMaxRef.current;
+    const generation = ++searchGenerationRef.current;
     startSearch(async () => {
       const result = await runGetCompanyPostings(
         {
@@ -224,6 +230,7 @@ export function CompanyPage({
         },
         isLoggedInRef.current,
       );
+      if (searchGenerationRef.current !== generation) return;
       setPostings(result.postings);
       setActiveCount(result.activeCount);
       setYearCount(result.yearCount);
@@ -231,6 +238,55 @@ export function CompanyPage({
       setIsTruncated(result.truncated ?? false);
     });
   }
+
+  // Keep the anonymous shell cacheable for an hour, then revalidate the
+  // visible default postings directly from Typesense after hydration. This
+  // path never falls back to a Server Action, so it preserves freshness
+  // without converting page views back into Fluid CPU.
+  const directRefreshLanguagesKey = languages.join(",");
+  useEffect(() => {
+    if (hasFilters) return;
+
+    const refreshKey = [company.id, uiLocale, directRefreshLanguagesKey].join("|");
+    if (initialDirectRefreshKeyRef.current === refreshKey) return;
+    initialDirectRefreshKeyRef.current = refreshKey;
+
+    const generation = ++searchGenerationRef.current;
+    void tryGetCompanyPostingsDirect(
+      {
+        companyId: company.id,
+        keywords: [],
+        locationIds: undefined,
+        occupationIds: undefined,
+        seniorityIds: undefined,
+        technologyIds: undefined,
+        employmentTypes: undefined,
+        workMode: undefined,
+        salaryMinEur: undefined,
+        salaryMaxEur: undefined,
+        experienceMin: undefined,
+        experienceMax: undefined,
+        languages,
+        locale: uiLocale,
+        offset: 0,
+        limit: PAGE_SIZE,
+      },
+      isLoggedInRef.current,
+    ).then((result) => {
+      if (!result || searchGenerationRef.current !== generation) return;
+      setPostings(result.postings);
+      setActiveCount(result.activeCount);
+      setYearCount(result.yearCount);
+      setExhausted(result.postings.length < PAGE_SIZE);
+      setIsTruncated(result.truncated ?? false);
+    });
+
+    return () => {
+      if (searchGenerationRef.current === generation) {
+        searchGenerationRef.current += 1;
+      }
+    };
+  }, [company.id, directRefreshLanguagesKey, hasFilters, uiLocale]);
 
   // Register pageActions so the header SearchBar can interact directly
   useEffect(() => {
@@ -468,6 +524,7 @@ export function CompanyPage({
   }, [displayCurrency]);
 
   async function handleLoadMore() {
+    const generation = ++searchGenerationRef.current;
     const locationIds = locations.map((l) => l.id);
     const occupationIds = occupations.length > 0 ? occupations.map((o) => o.id) : undefined;
     const seniorityIds = seniorities.length > 0 ? seniorities.map((s) => s.id) : undefined;
@@ -498,6 +555,7 @@ export function CompanyPage({
       },
       isLoggedInRef.current,
     );
+    if (searchGenerationRef.current !== generation) return;
     if (result.truncated) setIsTruncated(true);
     if (result.postings.length > 0) {
       setPostings((prev) => {

--- a/apps/web/app/[lang]/(app)/company/[slug]/opengraph-image.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/opengraph-image.tsx
@@ -1,6 +1,3 @@
-import { ImageResponse } from "next/og";
-import { unstable_cache } from "next/cache";
-import { getCompanyBySlug, type CompanyDetail } from "@/lib/actions/company";
 import {
   companyOgCacheKey,
   readCompanyOgCache,
@@ -11,253 +8,21 @@ import {
 export const alt = "Company jobs";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
+
+// Request-time R2 IO is intentional. Making this route static caused
+// DYNAMIC_SERVER_USAGE failures in production under Cache Components.
 export const dynamic = "force-dynamic";
-// Long-cache via explicit headers. The durable cache key includes a
-// renderer hash, so unchanged deploys reuse R2 PNGs and renderer changes
-// naturally move to a new key.
-const CACHE_HEADERS = {
+
+const CACHE_CONTROL = "public, max-age=2592000, s-maxage=2592000, immutable";
+const PNG_HEADERS = {
   "Content-Type": contentType,
-  "Cache-Control": "public, max-age=2592000, s-maxage=2592000, immutable",
+  "Cache-Control": CACHE_CONTROL,
 };
-
-import { readFileSync } from "node:fs";
-import { join } from "node:path";
-
-const COMPANY_OG_CACHE_TTL_SECONDS = 2592000;
-
-const getCachedOgCompany = unstable_cache(
-  async (slug: string, lang: string) => getCompanyBySlug(slug, lang),
-  ["company-opengraph"],
-  { revalidate: COMPANY_OG_CACHE_TTL_SECONDS },
-);
-
-async function getOgCompany(slug: string, lang: string): Promise<CompanyDetail | null> {
-  try {
-    return await getCachedOgCompany(slug, lang);
-  } catch (error) {
-    if (
-      error instanceof Error &&
-      error.message.includes("incrementalCache missing")
-    ) {
-      return getCompanyBySlug(slug, lang);
-    }
-    throw error;
-  }
-}
-
-// Satori only supports TTF/OTF, not woff2. Keep this synchronous at module
-// load so the static renderer does not see uncached async filesystem IO.
-const fontData = readFileSync(
-  join(process.cwd(), "public/fonts/JetBrainsMono-Bold.ttf"),
-);
 
 function asPngResponse(bytes: Uint8Array): Response {
   const body = new Uint8Array(bytes.byteLength);
   body.set(bytes);
-  return new Response(body.buffer, { headers: CACHE_HEADERS });
-}
-
-async function imageResponseToBytes(response: Response): Promise<Uint8Array> {
-  return new Uint8Array(await response.arrayBuffer());
-}
-
-function renderNotFound(fontData: Buffer): ImageResponse {
-  return new ImageResponse(
-    <div
-      style={{
-        width: "100%",
-        height: "100%",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        backgroundColor: "#0a0a0a",
-        color: "#fafafa",
-        fontSize: 48,
-        fontFamily: "JetBrains Mono",
-      }}
-    >
-      Not Found
-    </div>,
-    {
-      ...size,
-      headers: CACHE_HEADERS,
-      fonts: [{ name: "JetBrains Mono", data: fontData, weight: 700, style: "normal" }],
-    },
-  );
-}
-
-const RENDERABLE_COMPANY_OG_ICON_EXTENSIONS = new Set([".png", ".jpg", ".jpeg"]);
-
-type CompanyOgIconRenderModel =
-  | { kind: "image"; src: string }
-  | { kind: "fallback"; label: string }
-  | { kind: "none" };
-
-function parseHttpUrl(value: string | null | undefined): URL | null {
-  if (!value) return null;
-  try {
-    const url = new URL(value);
-    return url.protocol === "http:" || url.protocol === "https:" ? url : null;
-  } catch {
-    return null;
-  }
-}
-
-export function getRenderableCompanyOgIconUrl(
-  icon: string | null | undefined,
-): string | null {
-  const url = parseHttpUrl(icon);
-  if (!url) return null;
-
-  const pathname = url.pathname.toLowerCase();
-  for (const extension of RENDERABLE_COMPANY_OG_ICON_EXTENSIONS) {
-    if (pathname.endsWith(extension)) return icon!;
-  }
-  return null;
-}
-
-export function getCompanyOgFallbackInitials(name: string): string {
-  const parts = name.trim().split(/\s+/).filter(Boolean);
-  if (parts.length >= 2) {
-    return parts
-      .slice(0, 2)
-      .map((part) => Array.from(part)[0])
-      .join("")
-      .toUpperCase();
-  }
-
-  const firstPart = parts[0] ?? "";
-  return Array.from(firstPart).slice(0, 2).join("").toUpperCase() || "?";
-}
-
-export function getCompanyOgIconRenderModel(
-  company: Pick<CompanyDetail, "icon" | "name">,
-): CompanyOgIconRenderModel {
-  const src = getRenderableCompanyOgIconUrl(company.icon);
-  if (src) return { kind: "image", src };
-
-  // `next/og` logs noisy parse errors for some valid-but-unsupported SVGs
-  // and does not support WebP reliably in this renderer path. Keep the card
-  // stable with a deterministic mark instead of handing those URLs to Satori.
-  if (parseHttpUrl(company.icon)) {
-    return { kind: "fallback", label: getCompanyOgFallbackInitials(company.name) };
-  }
-
-  return { kind: "none" };
-}
-
-function renderCompanyImage(company: CompanyDetail, fontData: Buffer): ImageResponse {
-  const icon = getCompanyOgIconRenderModel(company);
-
-  return new ImageResponse(
-    <div
-      style={{
-        width: "100%",
-        height: "100%",
-        display: "flex",
-        flexDirection: "column",
-        backgroundColor: "#0a0a0a",
-        color: "#fafafa",
-        fontFamily: "JetBrains Mono",
-        padding: "60px 80px",
-      }}
-    >
-      {/* Top: company icon + name */}
-      <div style={{ display: "flex", alignItems: "center", gap: "24px" }}>
-        {icon.kind === "image" && (
-          <img
-            src={icon.src}
-            width={72}
-            height={72}
-            style={{ borderRadius: 12 }}
-          />
-        )}
-        {icon.kind === "fallback" && (
-          <div
-            style={{
-              width: 72,
-              height: 72,
-              borderRadius: 12,
-              backgroundColor: "#18181b",
-              border: "1px solid #27272a",
-              color: "#fafafa",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              fontSize: 28,
-              fontWeight: 700,
-              lineHeight: 1,
-            }}
-          >
-            {icon.label}
-          </div>
-        )}
-        <span style={{ fontSize: 52, fontWeight: 700 }}>{company.name}</span>
-      </div>
-
-      {/* Middle: description */}
-      {company.description && (
-        <div
-          style={{
-            fontSize: 28,
-            color: "#a1a1aa",
-            marginTop: 32,
-            lineHeight: 1.4,
-            overflow: "hidden",
-            display: "flex",
-            maxHeight: "160px",
-          }}
-        >
-          {company.description.length > 200
-            ? company.description.slice(0, 200) + "…"
-            : company.description}
-        </div>
-      )}
-
-      {/* Bottom: meta chips */}
-      <div
-        style={{
-          display: "flex",
-          gap: "16px",
-          marginTop: "auto",
-          fontSize: 22,
-          color: "#71717a",
-        }}
-      >
-        {company.industryName && <span>{company.industryName}</span>}
-        {company.industryName && company.website && <span>·</span>}
-        {company.website && (
-          <span>{company.website.replace(/^https?:\/\//, "").replace(/\/$/, "")}</span>
-        )}
-      </div>
-
-      {/* Branding */}
-      <div
-        style={{
-          position: "absolute",
-          bottom: 40,
-          right: 80,
-          fontSize: 20,
-          color: "#52525b",
-          display: "flex",
-        }}
-      >
-        jseek.co
-      </div>
-    </div>,
-    {
-      ...size,
-      headers: CACHE_HEADERS,
-      fonts: [
-        {
-          name: "JetBrains Mono",
-          data: fontData,
-          weight: 700,
-          style: "normal",
-        },
-      ],
-    },
-  );
+  return new Response(body.buffer, { headers: PNG_HEADERS });
 }
 
 export default async function OgImage({
@@ -267,18 +32,21 @@ export default async function OgImage({
 }) {
   const { slug, lang } = await params;
   const key = companyOgCacheKey(lang, slug);
+
   if (!shouldBypassCompanyOgCache()) {
     const cached = await readCompanyOgCache(key);
     if (cached) return asPngResponse(cached);
   }
 
-  const company = await getOgCompany(slug, lang);
-  if (!company) {
-    return renderNotFound(fontData);
-  }
+  // Keep next/og, the font, company services, and the AWS SDK out of the hot
+  // cache-hit module path. They are evaluated only when this renderer version
+  // has never produced the requested card.
+  const { renderCompanyOgImage } = await import("@/lib/og/render-company-og");
+  const rendered = await renderCompanyOgImage(slug, lang);
+  const bytes = new Uint8Array(await rendered.response.arrayBuffer());
 
-  const rendered = renderCompanyImage(company, fontData);
-  const bytes = await imageResponseToBytes(rendered);
-  await writeCompanyOgCache(key, bytes);
+  if (rendered.cacheable) {
+    await writeCompanyOgCache(key, bytes);
+  }
   return asPngResponse(bytes);
 }

--- a/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { Suspense } from "react";
 import { cacheLife, cacheTag } from "next/cache";
 import { isLocale, defaultLocale, loadCatalog, initI18nForPage, ogLocale, ogAlternateLocales } from "@/lib/i18n";
 import { companyCacheTag } from "@/lib/cache-tags";
-import { CACHE_TTL_DETAIL } from "@/lib/cache-ttl";
+import { CACHE_TTL_COMPANY_SHELL } from "@/lib/cache-ttl";
 import { fetchCompanyPageDefaults } from "@/lib/actions/company-page-data";
 import type { Locale } from "@/lib/i18n";
 import { siteConfig } from "@/content/config";
@@ -28,14 +28,14 @@ type Props = {
  */
 async function getCompanyRouteSnapshot(slug: string, locale: Locale) {
   "use cache";
-  cacheLife({ revalidate: CACHE_TTL_DETAIL });
+  cacheLife({ revalidate: CACHE_TTL_COMPANY_SHELL });
   cacheTag(companyCacheTag(slug));
   return fetchCompanyPageDefaults({ slug, locale });
 }
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   "use cache";
-  cacheLife({ revalidate: CACHE_TTL_DETAIL });
+  cacheLife({ revalidate: CACHE_TTL_COMPANY_SHELL });
   const { slug, lang } = await params;
   cacheTag(companyCacheTag(slug));
   const locale = isLocale(lang) ? lang : defaultLocale;
@@ -147,7 +147,7 @@ async function CompanyNotFound({ locale, slug }: { locale: Locale; slug: string 
 
 export default async function CompanyPageRoute({ params }: Props) {
   "use cache";
-  cacheLife({ revalidate: CACHE_TTL_DETAIL });
+  cacheLife({ revalidate: CACHE_TTL_COMPANY_SHELL });
   const locale = await initI18nForPage(params);
   const { slug } = await params;
   cacheTag(companyCacheTag(slug));
@@ -164,10 +164,12 @@ export default async function CompanyPageRoute({ params }: Props) {
   if (!initialData) return <CompanyNotFound locale={locale} slug={slug} />;
   const { company } = initialData;
 
-  // The page body is `'use cache'`-wrapped (10-minute revalidate) so the
+  // The page body is `'use cache'`-wrapped (1-hour revalidate) so the
   // anonymous static shell ships from the per-region cache without
   // invoking a function on every request. Anything that reads
-  // `searchParams`, `headers()`, `cookies()`, or session state inside
+  // `CompanyPage` refreshes anonymous postings directly from Typesense after
+  // hydration, preserving visible freshness. `searchParams`, `headers()`,
+  // `cookies()`, or session state inside
   // this function would either fail the build or kill the cache. The
   // back-link (filter-aware) and similar-companies strip live in client
   // subtrees that read `useSearchParams()` so the shell here stays

--- a/apps/web/app/[lang]/(app)/explore/__tests__/search-page-heading.test.tsx
+++ b/apps/web/app/[lang]/(app)/explore/__tests__/search-page-heading.test.tsx
@@ -65,6 +65,7 @@ vi.mock("@/lib/actions/search", () => ({
 vi.mock("@/lib/search/search-runner", () => ({
   runSearchJobs: vi.fn().mockResolvedValue({ companies: [], totalCompanies: 0, truncated: false }),
   runListTopCompanies: vi.fn().mockResolvedValue({ companies: [], totalCompanies: 0, truncated: false }),
+  tryListTopCompaniesDirect: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock("@/lib/search/use-clear-typesense-on-auth-change", () => ({

--- a/apps/web/app/[lang]/(app)/explore/page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/page.tsx
@@ -1,25 +1,24 @@
 import type { Metadata } from "next";
 import { cacheLife } from "next/cache";
 import { isLocale, defaultLocale, loadCatalog, ogLocale, ogAlternateLocales } from "@/lib/i18n";
-import { CACHE_TTL_SHORT } from "@/lib/cache-ttl";
+import { CACHE_TTL_EXPLORE_SHELL } from "@/lib/cache-ttl";
 import { siteConfig } from "@/content/config";
 import { buildAlternates } from "@/lib/seo";
 import { fetchExplorePageDefaults } from "@/lib/actions/explore-page-data";
 import { ExploreContent } from "./explore-content";
 
 const EXPLORE_DEFAULTS_CACHE_LIFE = {
-  stale: CACHE_TTL_SHORT,
-  revalidate: CACHE_TTL_SHORT,
-  expire: CACHE_TTL_SHORT * 5,
+  stale: CACHE_TTL_EXPLORE_SHELL,
+  revalidate: CACHE_TTL_EXPLORE_SHELL,
+  expire: CACHE_TTL_EXPLORE_SHELL * 5,
 } as const;
 const EXPLORE_DEFAULTS_PAYLOAD_VERSION = "v3";
 
-// Cached for 60s. The anonymous, no-filter explore payload is rendered
+// Cached for 10 minutes. The anonymous, no-filter explore payload is rendered
 // server-side via `fetchExplorePageDefaults` and embedded as `initialData`.
-// `ExploreContent` is a client component that re-fetches a personalized
-// variant only when the `logged_in` hint cookie or a filter searchParam
-// is present, so anonymous no-filter visitors hit the static prerender
-// without triggering a Vercel function invocation. See #2640 + #2243.
+// `SearchPage` refreshes the default result directly from Typesense after
+// hydration, so the longer CDN lifetime removes background regenerations
+// without making the visible job inventory stale. See #2640 + #2243.
 //
 // Do NOT add `searchParams` to Props or read `headers()`/`cookies()`
 // here — that would force the page out of the cached path on every
@@ -31,7 +30,7 @@ type Props = {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   "use cache";
-  cacheLife({ revalidate: CACHE_TTL_SHORT });
+  cacheLife({ revalidate: CACHE_TTL_EXPLORE_SHELL });
   const { lang } = await params;
   const locale = isLocale(lang) ? lang : defaultLocale;
   const { i18n } = await loadCatalog(locale);

--- a/apps/web/app/[lang]/(app)/explore/search-page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/search-page.tsx
@@ -13,7 +13,11 @@ import { JobDetailPanel } from "@/components/search/job-detail-dialog";
 import { MobileJobDetailDialog } from "@/components/search/mobile-job-detail-dialog";
 import { SearchToolbar } from "@/components/search/search-toolbar";
 import { useSalaryRates } from "@/components/providers/SalaryDisplayProvider";
-import { runSearchJobs, runListTopCompanies } from "@/lib/search/search-runner";
+import {
+  runSearchJobs,
+  runListTopCompanies,
+  tryListTopCompaniesDirect,
+} from "@/lib/search/search-runner";
 import { useClearTypesenseOnAuthChange } from "@/lib/search/use-clear-typesense-on-auth-change";
 import { useSession } from "@/components/providers/SessionProvider";
 import { parseSearchFilters } from "@/lib/actions/search-input";
@@ -175,6 +179,7 @@ export function SearchPage({
   );
   const [isSearching, setIsSearching] = useState(false);
   const searchCounterRef = useRef(0);
+  const initialDirectRefreshKeyRef = useRef<string | null>(null);
   const [isTruncated, setIsTruncated] = useState(initialTruncated ?? false);
   const [isDegraded, setIsDegraded, isDegradedRef] = useLatestState(
     shouldRestore ? (cached.degraded ?? false) : (initialDegraded ?? false),
@@ -572,6 +577,63 @@ export function SearchPage({
     })();
   };
   function runSearch() { runSearchRef.current(); }
+
+  // The server payload is deliberately cached longer to avoid continuous ISR
+  // regeneration. Refresh the default inventory from browser-direct Typesense
+  // after hydration, without a Server Action fallback, so visitors still see
+  // current results and the refresh cannot add Fluid CPU.
+  const directRefreshLanguagesKey = languages.join(",");
+  useEffect(() => {
+    if (shouldRestore || hasFilters) return;
+
+    const refreshKey = [
+      locale,
+      directRefreshLanguagesKey,
+      userLat ?? "",
+      userLng ?? "",
+    ].join("|");
+    if (initialDirectRefreshKeyRef.current === refreshKey) return;
+    initialDirectRefreshKeyRef.current = refreshKey;
+
+    const id = ++searchCounterRef.current;
+    void tryListTopCompaniesDirect(
+      {
+        locationIds: undefined,
+        occupationIds: undefined,
+        seniorityIds: undefined,
+        technologyIds: undefined,
+        employmentTypes: undefined,
+        workMode: undefined,
+        salaryMinEur: undefined,
+        salaryMaxEur: undefined,
+        experienceMin: undefined,
+        experienceMax: undefined,
+        languages,
+        locale,
+        offset: 0,
+        limit: PAGE_SIZE,
+      },
+      isLoggedInRef.current,
+    ).then((result) => {
+      if (!result || searchCounterRef.current !== id) return;
+      setCompanies(result.companies);
+      serverOffsetRef.current = result.companies.length;
+      setTotalCompanies(result.totalCompanies);
+      setIsTruncated(result.truncated ?? false);
+      setIsDegraded(false);
+    });
+
+    return () => {
+      if (searchCounterRef.current === id) searchCounterRef.current += 1;
+    };
+  }, [
+    directRefreshLanguagesKey,
+    hasFilters,
+    locale,
+    shouldRestore,
+    userLat,
+    userLng,
+  ]);
 
   const handleRemoveKeyword = useCallback(
     (keyword: string) => {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -9,11 +9,10 @@ import path from "node:path";
  *
  * The company OG route stores rendered PNGs in R2 under
  * `og/company/<renderer-version>/<locale>/<slug>.png`. The version is a
- * conservative content hash of files that can plausibly affect the PNG.
- * That deliberately creates some false invalidations: changing nearby
- * company route code may rerender images even when the pixels stay the
- * same. The tradeoff is intentional because under-invalidation leaves
- * stale social cards until a manual purge.
+ * content hash of the renderer and its font. Keep this input set narrow:
+ * every new version invalidates every company/locale object, and broad
+ * inputs previously caused thousands of identical cards to be regenerated
+ * after unrelated deploys.
  *
  * Force controls:
  * - `COMPANY_OG_RENDERER_VERSION_SALT=<ticket/date>`: included in the
@@ -24,20 +23,11 @@ import path from "node:path";
  *   bad objects under the current hash; pair with a redeploy for CDN
  *   freshness.
  */
-const COMPANY_OG_HASH_VERSION = "company-og-v1";
+const COMPANY_OG_HASH_VERSION = "company-og-v2";
 
 const COMPANY_OG_HASH_INPUTS = [
-  "app/[lang]/(app)/company/[slug]",
-  "src/lib/actions/company.ts",
-  "src/lib/actions/company-page-data.ts",
-  "src/lib/cache-tags.ts",
-  "src/lib/cache-ttl.ts",
-  "src/lib/i18n.ts",
-  "src/lib/og",
+  "src/lib/og/render-company-og.tsx",
   "public/fonts/JetBrainsMono-Bold.ttf",
-  "package.json",
-  "next.config.ts",
-  "../../pnpm-lock.yaml",
 ];
 
 const HASHED_EXTENSIONS = new Set([

--- a/apps/web/src/lib/cache-ttl.ts
+++ b/apps/web/src/lib/cache-ttl.ts
@@ -18,10 +18,14 @@
  * | `CACHE_TTL_MEDIUM`  |  300    | Moderate churn (posting detail, company      |
  * |                     |         | postings, filtered watchlist counts,         |
  * |                     |         | default API `maxAge`)                        |
- * | `CACHE_TTL_DETAIL`  |  600    | Company detail page                          |
- * | `CACHE_TTL_LONG`    | 3600    | Semi-static taxonomies, locations, similar   |
- * |                     |         | companies, sitemap, watchlist matching count |
- * | `CACHE_TTL_DAY`     |86400    | Very static / rare-change (blog pages)       |
+ * | `CACHE_TTL_DETAIL`        |   600   | Company detail page                          |
+ * | `CACHE_TTL_EXPLORE_SHELL` |   600   | Anonymous explore prerender; browser         |
+ * |                           |         | Typesense refreshes it after hydration       |
+ * | `CACHE_TTL_LONG`          |  3600   | Semi-static taxonomies, locations, similar   |
+ * |                           |         | companies, sitemap, watchlist matching count |
+ * | `CACHE_TTL_COMPANY_SHELL` |  3600   | Anonymous company prerender; browser         |
+ * |                           |         | Typesense refreshes postings after hydration |
+ * | `CACHE_TTL_DAY`           | 86400   | Very static / rare-change (blog pages)       |
  *
  * Notes:
  * - Built-in Next.js `cacheLife()` profile names (`'hours'`, `'days'`,
@@ -43,8 +47,14 @@ export const CACHE_TTL_MEDIUM = 300;
 /** 600 seconds (10 min) — company detail page (cross-`'use cache'`-boundary dedup). */
 export const CACHE_TTL_DETAIL = 600;
 
+/** 10 minutes — anonymous explore shell; hydrated results refresh from Typesense. */
+export const CACHE_TTL_EXPLORE_SHELL = 600;
+
 /** 3600 seconds (1 hour) — semi-static taxonomies, locations, sitemap, similar companies. */
 export const CACHE_TTL_LONG = 3600;
+
+/** 1 hour — anonymous company shell; hydrated postings refresh from Typesense. */
+export const CACHE_TTL_COMPANY_SHELL = 3600;
 
 /** 86400 seconds (1 day) — very static / rare-change (blog pages). */
 export const CACHE_TTL_DAY = 86400;

--- a/apps/web/src/lib/og/__tests__/company-og-cache.test.ts
+++ b/apps/web/src/lib/og/__tests__/company-og-cache.test.ts
@@ -1,10 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Readable } from "node:stream";
 import { setTestEnv, withTestEnv } from "@/test-utils/env";
 
 vi.mock("server-only", () => ({}));
 
-const s3Mock = vi.hoisted(() => ({
-  send: vi.fn(),
+const mocks = vi.hoisted(() => ({
+  httpsRequest: vi.fn(),
+  s3Send: vi.fn(),
+}));
+
+vi.mock("node:https", () => ({
+  default: { request: mocks.httpsRequest },
 }));
 
 vi.mock("@aws-sdk/client-s3", () => {
@@ -25,7 +31,7 @@ vi.mock("@aws-sdk/client-s3", () => {
   }
 
   class MockS3Client {
-    send = s3Mock.send;
+    send = mocks.s3Send;
   }
 
   return {
@@ -44,10 +50,27 @@ function configureR2Env() {
   });
 }
 
+function mockPublicResponse(statusCode: number, bytes: Uint8Array = new Uint8Array()) {
+  mocks.httpsRequest.mockImplementation(
+    (_url: string, _options: unknown, callback: (response: unknown) => void) => {
+      const response = Readable.from(bytes.length > 0 ? [bytes] : []);
+      Object.assign(response, { statusCode });
+      callback(response);
+      return {
+        destroy: vi.fn(),
+        end: vi.fn(),
+        on: vi.fn(),
+        setTimeout: vi.fn(),
+      };
+    },
+  );
+}
+
 describe("company OG cache", () => {
   withTestEnv({
     COMPANY_OG_RENDERER_VERSION: "renderer123",
     COMPANY_OG_CACHE_BYPASS: undefined,
+    R2_DOMAIN_URL: undefined,
     R2_ENDPOINT_URL: undefined,
     R2_ACCESS_KEY_ID: undefined,
     R2_SECRET_ACCESS_KEY: undefined,
@@ -56,7 +79,8 @@ describe("company OG cache", () => {
 
   beforeEach(() => {
     vi.resetModules();
-    s3Mock.send.mockReset();
+    mocks.httpsRequest.mockReset();
+    mocks.s3Send.mockReset();
   });
 
   it("uses the renderer version in sanitized object keys", async () => {
@@ -74,6 +98,33 @@ describe("company OG cache", () => {
     expect(shouldBypassCompanyOgCache()).toBe(true);
   });
 
+  it("reads public R2 bytes with lightweight built-in HTTPS", async () => {
+    setTestEnv({ R2_DOMAIN_URL: "https://assets.example.test" });
+    mockPublicResponse(200, new Uint8Array([7, 8, 9]));
+    const { readCompanyOgCache } = await import("../company-og-cache");
+
+    const bytes = await readCompanyOgCache("og/company/x/en/acme labs.png");
+
+    expect(Array.from(bytes ?? [])).toEqual([7, 8, 9]);
+    expect(mocks.httpsRequest).toHaveBeenCalledWith(
+      "https://assets.example.test/og/company/x/en/acme%20labs.png",
+      { method: "GET" },
+      expect.any(Function),
+    );
+    expect(mocks.s3Send).not.toHaveBeenCalled();
+  });
+
+  it("treats a public R2 404 as a cache miss without loading the AWS SDK", async () => {
+    setTestEnv({ R2_DOMAIN_URL: "https://assets.example.test" });
+    mockPublicResponse(404);
+    const { readCompanyOgCache } = await import("../company-og-cache");
+
+    await expect(
+      readCompanyOgCache("og/company/x/en/missing.png"),
+    ).resolves.toBeNull();
+    expect(mocks.s3Send).not.toHaveBeenCalled();
+  });
+
   it("soft-disables reads and writes when R2 is not configured", async () => {
     const { readCompanyOgCache, writeCompanyOgCache } = await import("../company-og-cache");
 
@@ -83,17 +134,17 @@ describe("company OG cache", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("reads R2 bodies with transformToByteArray", async () => {
+  it("falls back to a signed R2 read when no public domain is configured", async () => {
     configureR2Env();
     const transformToByteArray = vi.fn().mockResolvedValue(new Uint8Array([4, 5, 6]));
-    s3Mock.send.mockResolvedValueOnce({ Body: { transformToByteArray } });
+    mocks.s3Send.mockResolvedValueOnce({ Body: { transformToByteArray } });
     const { readCompanyOgCache } = await import("../company-og-cache");
 
     const bytes = await readCompanyOgCache("og/company/x/en/acme.png");
 
     expect(Array.from(bytes ?? [])).toEqual([4, 5, 6]);
     expect(transformToByteArray).toHaveBeenCalledOnce();
-    expect(s3Mock.send).toHaveBeenCalledOnce();
+    expect(mocks.s3Send).toHaveBeenCalledOnce();
   });
 
   it("reads iterable R2 bodies", async () => {
@@ -102,12 +153,25 @@ describe("company OG cache", () => {
       yield new Uint8Array([1, 2]);
       yield new Uint8Array([3]);
     }
-    s3Mock.send.mockResolvedValueOnce({ Body: chunks() });
+    mocks.s3Send.mockResolvedValueOnce({ Body: chunks() });
     const { readCompanyOgCache } = await import("../company-og-cache");
 
     const bytes = await readCompanyOgCache("og/company/x/en/acme.png");
 
     expect(Array.from(bytes ?? [])).toEqual([1, 2, 3]);
-    expect(s3Mock.send).toHaveBeenCalledOnce();
+    expect(mocks.s3Send).toHaveBeenCalledOnce();
+  });
+
+  it("lazy-loads the AWS SDK for cache writes", async () => {
+    configureR2Env();
+    mocks.s3Send.mockResolvedValueOnce({});
+    const { writeCompanyOgCache } = await import("../company-og-cache");
+
+    await writeCompanyOgCache(
+      "og/company/x/en/acme.png",
+      new Uint8Array([1, 2, 3]),
+    );
+
+    expect(mocks.s3Send).toHaveBeenCalledOnce();
   });
 });

--- a/apps/web/src/lib/og/company-og-cache.ts
+++ b/apps/web/src/lib/og/company-og-cache.ts
@@ -1,10 +1,7 @@
 import "server-only";
 
-import {
-  GetObjectCommand,
-  PutObjectCommand,
-  S3Client,
-} from "@aws-sdk/client-s3";
+import https from "node:https";
+import type { S3Client } from "@aws-sdk/client-s3";
 import { logExternalError } from "@/lib/safe-external-error";
 
 const CONTENT_TYPE = "image/png";
@@ -53,8 +50,11 @@ function getR2Config():
   return { endpoint, accessKeyId, secretAccessKey, bucket };
 }
 
-function getClient(config: NonNullable<ReturnType<typeof getR2Config>>): S3Client {
+async function getClient(
+  config: NonNullable<ReturnType<typeof getR2Config>>,
+): Promise<S3Client> {
   if (client) return client;
+  const { S3Client } = await import("@aws-sdk/client-s3");
   client = new S3Client({
     endpoint: config.endpoint,
     region: "auto",
@@ -65,6 +65,43 @@ function getClient(config: NonNullable<ReturnType<typeof getR2Config>>): S3Clien
     },
   });
   return client;
+}
+
+function getPublicObjectUrl(key: string): string | null {
+  const domain = process.env.R2_DOMAIN_URL;
+  if (!domain) return null;
+
+  try {
+    const base = new URL(domain.endsWith("/") ? domain : `${domain}/`);
+    if (base.protocol !== "https:") return null;
+    return new URL(key.split("/").map(encodeURIComponent).join("/"), base).toString();
+  } catch {
+    return null;
+  }
+}
+
+async function readPublicObject(
+  url: string,
+): Promise<{ status: number; bytes: Uint8Array | null }> {
+  return new Promise((resolve, reject) => {
+    const request = https.request(url, { method: "GET" }, (response) => {
+      const status = response.statusCode ?? 0;
+      if (status < 200 || status >= 300) {
+        response.resume();
+        resolve({ status, bytes: null });
+        return;
+      }
+
+      void bodyToBytes(response)
+        .then((bytes) => resolve({ status, bytes }))
+        .catch(reject);
+    });
+    request.setTimeout(3000, () => {
+      request.destroy(new Error("R2 public cache probe timed out"));
+    });
+    request.on("error", reject);
+    request.end();
+  });
 }
 
 async function bodyToBytes(body: unknown): Promise<Uint8Array | null> {
@@ -93,12 +130,13 @@ function isMissingObjectError(error: unknown): boolean {
   return name === "NoSuchKey" || name === "NotFound" || code === 404;
 }
 
-export async function readCompanyOgCache(key: string): Promise<Uint8Array | null> {
+async function readCompanyOgCacheSigned(key: string): Promise<Uint8Array | null> {
   const config = getR2Config();
   if (!config) return null;
 
   try {
-    const response = await getClient(config).send(new GetObjectCommand({
+    const { GetObjectCommand } = await import("@aws-sdk/client-s3");
+    const response = await (await getClient(config)).send(new GetObjectCommand({
       Bucket: config.bucket,
       Key: key,
     }));
@@ -110,6 +148,27 @@ export async function readCompanyOgCache(key: string): Promise<Uint8Array | null
   }
 }
 
+export async function readCompanyOgCache(
+  key: string,
+): Promise<Uint8Array | null> {
+  const publicUrl = getPublicObjectUrl(key);
+  if (publicUrl) {
+    try {
+      const result = await readPublicObject(publicUrl);
+      if (result.bytes) return result.bytes;
+      if (result.status === 404) return null;
+    } catch (error) {
+      logExternalError(
+        "warn",
+        { service: "r2", operation: "probe_public_company_og" },
+        error,
+      );
+    }
+  }
+
+  return readCompanyOgCacheSigned(key);
+}
+
 export async function writeCompanyOgCache(
   key: string,
   body: Uint8Array,
@@ -118,7 +177,8 @@ export async function writeCompanyOgCache(
   if (!config) return;
 
   try {
-    await getClient(config).send(new PutObjectCommand({
+    const { PutObjectCommand } = await import("@aws-sdk/client-s3");
+    await (await getClient(config)).send(new PutObjectCommand({
       Bucket: config.bucket,
       Key: key,
       Body: body,

--- a/apps/web/src/lib/og/render-company-og.tsx
+++ b/apps/web/src/lib/og/render-company-og.tsx
@@ -1,0 +1,242 @@
+import "server-only";
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { cacheLife } from "next/cache";
+import { ImageResponse } from "next/og";
+import {
+  getCompanyBySlug,
+  type CompanyDetail,
+} from "@/lib/services/company";
+
+const COMPANY_OG_CACHE_TTL_SECONDS = 2592000;
+const CACHE_HEADERS = {
+  "Content-Type": "image/png",
+  "Cache-Control": "public, max-age=2592000, s-maxage=2592000, immutable",
+};
+const size = { width: 1200, height: 630 };
+
+async function getCachedOgCompany(
+  slug: string,
+  lang: string,
+): Promise<CompanyDetail | null> {
+  "use cache";
+  cacheLife({ revalidate: COMPANY_OG_CACHE_TTL_SECONDS });
+  return getCompanyBySlug(slug, lang);
+}
+
+// Satori only supports TTF/OTF, not woff2. This module is lazy-loaded only on
+// a durable-cache miss, so the synchronous read is absent from the hot path.
+const fontData = readFileSync(
+  join(process.cwd(), "public/fonts/JetBrainsMono-Bold.ttf"),
+);
+
+function renderNotFound(): ImageResponse {
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        backgroundColor: "#0a0a0a",
+        color: "#fafafa",
+        fontSize: 48,
+        fontFamily: "JetBrains Mono",
+      }}
+    >
+      Not Found
+    </div>,
+    {
+      ...size,
+      headers: CACHE_HEADERS,
+      fonts: [
+        { name: "JetBrains Mono", data: fontData, weight: 700, style: "normal" },
+      ],
+    },
+  );
+}
+
+const RENDERABLE_COMPANY_OG_ICON_EXTENSIONS = new Set([".png", ".jpg", ".jpeg"]);
+
+type CompanyOgIconRenderModel =
+  | { kind: "image"; src: string }
+  | { kind: "fallback"; label: string }
+  | { kind: "none" };
+
+function parseHttpUrl(value: string | null | undefined): URL | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:" ? url : null;
+  } catch {
+    return null;
+  }
+}
+
+export function getRenderableCompanyOgIconUrl(
+  icon: string | null | undefined,
+): string | null {
+  const url = parseHttpUrl(icon);
+  if (!url) return null;
+
+  const pathname = url.pathname.toLowerCase();
+  for (const extension of RENDERABLE_COMPANY_OG_ICON_EXTENSIONS) {
+    if (pathname.endsWith(extension)) return icon!;
+  }
+  return null;
+}
+
+export function getCompanyOgFallbackInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length >= 2) {
+    return parts
+      .slice(0, 2)
+      .map((part) => Array.from(part)[0])
+      .join("")
+      .toUpperCase();
+  }
+
+  const firstPart = parts[0] ?? "";
+  return Array.from(firstPart).slice(0, 2).join("").toUpperCase() || "?";
+}
+
+export function getCompanyOgIconRenderModel(
+  company: Pick<CompanyDetail, "icon" | "name">,
+): CompanyOgIconRenderModel {
+  const src = getRenderableCompanyOgIconUrl(company.icon);
+  if (src) return { kind: "image", src };
+
+  // next/og logs noisy parse errors for unsupported SVG/WebP inputs. Keep the
+  // card deterministic instead of handing those URLs to Satori.
+  if (parseHttpUrl(company.icon)) {
+    return { kind: "fallback", label: getCompanyOgFallbackInitials(company.name) };
+  }
+
+  return { kind: "none" };
+}
+
+function renderCompanyImage(company: CompanyDetail): ImageResponse {
+  const icon = getCompanyOgIconRenderModel(company);
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        backgroundColor: "#0a0a0a",
+        color: "#fafafa",
+        fontFamily: "JetBrains Mono",
+        padding: "60px 80px",
+      }}
+    >
+      <div style={{ display: "flex", alignItems: "center", gap: "24px" }}>
+        {icon.kind === "image" && (
+          // next/image cannot render inside next/og's Satori tree.
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={icon.src}
+            width={72}
+            height={72}
+            style={{ borderRadius: 12 }}
+          />
+        )}
+        {icon.kind === "fallback" && (
+          <div
+            style={{
+              width: 72,
+              height: 72,
+              borderRadius: 12,
+              backgroundColor: "#18181b",
+              border: "1px solid #27272a",
+              color: "#fafafa",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              fontSize: 28,
+              fontWeight: 700,
+              lineHeight: 1,
+            }}
+          >
+            {icon.label}
+          </div>
+        )}
+        <span style={{ fontSize: 52, fontWeight: 700 }}>{company.name}</span>
+      </div>
+
+      {company.description && (
+        <div
+          style={{
+            fontSize: 28,
+            color: "#a1a1aa",
+            marginTop: 32,
+            lineHeight: 1.4,
+            overflow: "hidden",
+            display: "flex",
+            maxHeight: "160px",
+          }}
+        >
+          {company.description.length > 200
+            ? company.description.slice(0, 200) + "…"
+            : company.description}
+        </div>
+      )}
+
+      <div
+        style={{
+          display: "flex",
+          gap: "16px",
+          marginTop: "auto",
+          fontSize: 22,
+          color: "#71717a",
+        }}
+      >
+        {company.industryName && <span>{company.industryName}</span>}
+        {company.industryName && company.website && <span>·</span>}
+        {company.website && (
+          <span>{company.website.replace(/^https?:\/\//, "").replace(/\/$/, "")}</span>
+        )}
+      </div>
+
+      <div
+        style={{
+          position: "absolute",
+          bottom: 40,
+          right: 80,
+          fontSize: 20,
+          color: "#52525b",
+          display: "flex",
+        }}
+      >
+        jseek.co
+      </div>
+    </div>,
+    {
+      ...size,
+      headers: CACHE_HEADERS,
+      fonts: [
+        {
+          name: "JetBrains Mono",
+          data: fontData,
+          weight: 700,
+          style: "normal",
+        },
+      ],
+    },
+  );
+}
+
+export async function renderCompanyOgImage(
+  slug: string,
+  lang: string,
+): Promise<{ response: Response; cacheable: boolean }> {
+  const company = await getCachedOgCompany(slug, lang);
+  if (!company) {
+    return { response: renderNotFound(), cacheable: false };
+  }
+
+  return { response: renderCompanyImage(company), cacheable: true };
+}

--- a/apps/web/src/lib/search/__tests__/search-runner-direct-refresh.test.ts
+++ b/apps/web/src/lib/search/__tests__/search-runner-direct-refresh.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setTestEnv, withTestEnv } from "@/test-utils/env";
+
+const mocks = vi.hoisted(() => ({
+  browserListTopCompanies: vi.fn(),
+  browserLoadCompanyPostings: vi.fn(),
+  serverListTopCompanies: vi.fn(),
+  serverSearchJobs: vi.fn(),
+  serverGetCompanyPostings: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/search", () => ({
+  listTopCompanies: mocks.serverListTopCompanies,
+  searchJobs: mocks.serverSearchJobs,
+}));
+
+vi.mock("@/lib/actions/company", () => ({
+  getCompanyPostings: mocks.serverGetCompanyPostings,
+}));
+
+vi.mock("@/lib/actions/watchlists", () => ({
+  getWatchlistPostings: vi.fn(),
+  getWatchlistPostingYearCount: vi.fn(),
+}));
+
+vi.mock("../typesense-browser", () => ({
+  getBrowserSearchProvider: () => ({
+    listTopCompanies: mocks.browserListTopCompanies,
+    loadPostingsWithCounts: mocks.browserLoadCompanyPostings,
+  }),
+}));
+
+describe("browser-direct shell refreshes", () => {
+  withTestEnv({ NEXT_PUBLIC_TYPESENSE_DIRECT: "1" });
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    setTestEnv({ NEXT_PUBLIC_TYPESENSE_DIRECT: "1" });
+  });
+
+  it("refreshes explore data without invoking the server fallback", async () => {
+    const browserResult = {
+      companies: [],
+      totalCompanies: 42,
+      truncated: false,
+    };
+    mocks.browserListTopCompanies.mockResolvedValue(browserResult);
+    const { tryListTopCompaniesDirect } = await import("../search-runner");
+
+    await expect(
+      tryListTopCompaniesDirect(
+        { languages: ["en"], locale: "en", offset: 0, limit: 10 },
+        false,
+      ),
+    ).resolves.toEqual(browserResult);
+    expect(mocks.serverListTopCompanies).not.toHaveBeenCalled();
+  });
+
+  it("returns null on a degraded browser result instead of consuming Fluid CPU", async () => {
+    mocks.browserListTopCompanies.mockResolvedValue({
+      companies: [],
+      totalCompanies: 0,
+      degraded: true,
+    });
+    const { tryListTopCompaniesDirect } = await import("../search-runner");
+
+    await expect(
+      tryListTopCompaniesDirect(
+        { languages: ["en"], locale: "en", offset: 0, limit: 10 },
+        false,
+      ),
+    ).resolves.toBeNull();
+    expect(mocks.serverListTopCompanies).not.toHaveBeenCalled();
+  });
+
+  it("refreshes company postings without invoking the server fallback", async () => {
+    const browserResult = {
+      postings: [],
+      activeCount: 7,
+      yearCount: 11,
+    };
+    mocks.browserLoadCompanyPostings.mockResolvedValue(browserResult);
+    const { tryGetCompanyPostingsDirect } = await import("../search-runner");
+
+    await expect(
+      tryGetCompanyPostingsDirect(
+        {
+          companyId: "company-1",
+          keywords: [],
+          languages: ["en"],
+          locale: "en",
+          offset: 0,
+          limit: 20,
+        },
+        false,
+      ),
+    ).resolves.toEqual(browserResult);
+    expect(mocks.serverGetCompanyPostings).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when browser-direct search is disabled", async () => {
+    setTestEnv({ NEXT_PUBLIC_TYPESENSE_DIRECT: "0" });
+    vi.resetModules();
+    const {
+      tryGetCompanyPostingsDirect,
+      tryListTopCompaniesDirect,
+    } = await import("../search-runner");
+
+    await expect(
+      tryListTopCompaniesDirect(
+        { languages: ["en"], locale: "en", offset: 0, limit: 10 },
+        false,
+      ),
+    ).resolves.toBeNull();
+    await expect(
+      tryGetCompanyPostingsDirect(
+        {
+          companyId: "company-1",
+          keywords: [],
+          languages: ["en"],
+          locale: "en",
+          offset: 0,
+          limit: 20,
+        },
+        false,
+      ),
+    ).resolves.toBeNull();
+    expect(mocks.browserListTopCompanies).not.toHaveBeenCalled();
+    expect(mocks.browserLoadCompanyPostings).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/search/search-runner.ts
+++ b/apps/web/src/lib/search/search-runner.ts
@@ -82,23 +82,36 @@ export async function runListTopCompanies(
   params: ListInput,
   isLoggedIn: boolean,
 ): Promise<SearchResponse> {
-  if (directEnabled) {
-    if (!isLoggedIn && params.offset >= ANON_MAX_COMPANIES) {
-      return { companies: [], totalCompanies: 0, truncated: true };
-    }
-    try {
-      const provider = await tryBrowserProvider();
-      const result = await provider.listTopCompanies(params);
-      if (!result.degraded) return applyAnonCap(result, params.offset, isLoggedIn);
-    } catch (err) {
-      logExternalError(
-        "error",
-        { service: "typesense", operation: "browser_list_top_companies" },
-        err,
-      );
-    }
-  }
+  const direct = await tryListTopCompaniesDirect(params, isLoggedIn);
+  if (direct) return direct;
   return serverListTopCompanies(params);
+}
+
+/**
+ * Revalidate a server-prerendered explore shell directly against Typesense.
+ * Returns null when browser-direct search is disabled or degraded so mount-time
+ * refreshes never create a duplicate Vercel Server Action invocation.
+ */
+export async function tryListTopCompaniesDirect(
+  params: ListInput,
+  isLoggedIn: boolean,
+): Promise<SearchResponse | null> {
+  if (!directEnabled) return null;
+  if (!isLoggedIn && params.offset >= ANON_MAX_COMPANIES) {
+    return { companies: [], totalCompanies: 0, truncated: true };
+  }
+  try {
+    const provider = await tryBrowserProvider();
+    const result = await provider.listTopCompanies(params);
+    if (!result.degraded) return applyAnonCap(result, params.offset, isLoggedIn);
+  } catch (err) {
+    logExternalError(
+      "error",
+      { service: "typesense", operation: "browser_list_top_companies" },
+      err,
+    );
+  }
+  return null;
 }
 
 type WatchlistPostingsInput = {
@@ -169,24 +182,37 @@ export async function runGetCompanyPostings(
   params: CompanyPostingsInput,
   isLoggedIn: boolean,
 ): Promise<CompanyPostingsResult> {
-  if (directEnabled) {
-    if (!isLoggedIn && params.offset >= ANON_MAX_POSTINGS) {
-      return { postings: [], activeCount: 0, yearCount: 0, truncated: true };
-    }
-    try {
-      const provider = await tryBrowserProvider();
-      const result = await provider.loadPostingsWithCounts(params);
-      if (!isLoggedIn && params.offset + result.postings.length >= ANON_MAX_POSTINGS) {
-        return { ...result, truncated: true };
-      }
-      return result;
-    } catch (err) {
-      logExternalError(
-        "error",
-        { service: "typesense", operation: "browser_company_postings" },
-        err,
-      );
-    }
-  }
+  const direct = await tryGetCompanyPostingsDirect(params, isLoggedIn);
+  if (direct) return direct;
   return serverGetCompanyPostings(params);
+}
+
+/**
+ * Revalidate a server-prerendered company shell directly against Typesense.
+ * The null result is deliberate: callers that are merely refreshing hydrated
+ * data must keep the rendered snapshot instead of falling back to Fluid CPU.
+ */
+export async function tryGetCompanyPostingsDirect(
+  params: CompanyPostingsInput,
+  isLoggedIn: boolean,
+): Promise<CompanyPostingsResult | null> {
+  if (!directEnabled) return null;
+  if (!isLoggedIn && params.offset >= ANON_MAX_POSTINGS) {
+    return { postings: [], activeCount: 0, yearCount: 0, truncated: true };
+  }
+  try {
+    const provider = await tryBrowserProvider();
+    const result = await provider.loadPostingsWithCounts(params);
+    if (!isLoggedIn && params.offset + result.postings.length >= ANON_MAX_POSTINGS) {
+      return { ...result, truncated: true };
+    }
+    return result;
+  } catch (err) {
+    logExternalError(
+      "error",
+      { service: "typesense", operation: "browser_company_postings" },
+      err,
+    );
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary

Reduce Vercel Fluid CPU consumption on the three dominant production surfaces without removing or degrading production behavior.

The earlier intervention from today never reached production: it was left as uncommitted, unpushed worktree changes. Current production observability over the last 12 hours showed approximately:

- Company Open Graph route: 1 minute Active CPU
- Explore route: 35 seconds Active CPU
- Company page routes across locales: 74 seconds Active CPU
- These surfaces account for about 169 of 204 visible Active CPU seconds

## Root cause

1. Company OG cache hits still evaluated the expensive image renderer, font load, company service graph, and AWS S3 client.
2. The OG renderer hash included broad route/config/dependency inputs. Unrelated deploys produced 37 renderer namespaces and caused thousands of identical PNG regenerations.
3. The default explore shell regenerated every 60 seconds.
4. Company snapshots regenerated every 10 minutes even though their visible job inventory can refresh directly from Typesense after hydration.

## Changes

- Make the company OG route a lightweight durable-cache reader.
  - Read immutable PNGs through the public R2 domain first.
  - Lazy-load the AWS SDK only for signed fallback or writes.
  - Lazy-load `next/og`, the font, company services, and renderer only on a durable miss.
  - Preserve signed R2 fallback and miss rendering behavior.
- Narrow the OG renderer version hash to the renderer source and font.
- Cache the anonymous explore shell for 10 minutes.
- Cache company snapshots for one hour.
- Refresh default explore and company results directly from browser Typesense after hydration.
  - Mount-time refreshes never fall back to a Server Action.
  - Interactive searches retain the existing server fallback.
  - Generation guards prevent stale refreshes from overwriting user searches or infinite-scroll results.

## Expected impact

Based on the production route distribution and the previous measured OG path reduction from roughly 416 ms to 26 ms, the forecast is:

- About 88% less CPU across the targeted surfaces
- About 73% less Fluid CPU across the currently visible function total

These are estimates until the deployment has accumulated a comparable Vercel observation window.

## Functional verification

- Explore rendered current production Typesense results in the built app.
- Bosch company detail rendered company metadata and 364 active postings.
- Company OG returned the same valid 1200x630 PNG.
- Explore response: `x-nextjs-cache: HIT`, `s-maxage=600`.
- OG response: `200 image/png`, 30-day immutable cache header.
- Emitted route inspection confirmed the renderer is a separate miss-only chunk and the eager cache-hit chunk excludes the AWS S3 client and renderer.

## Checks

- `pnpm typecheck`
- Full Vitest suite: 223 files, 1,615 tests passed
- ESLint pre-commit hook
- Lingui translation coverage pre-commit hook
- Production build without local service credentials
- Environment-backed production build
- Local built-app browser and HTTP verification

## Post-deploy verification

Compare the same Vercel Functions view after 12 and 24 hours. In particular, verify that the company OG, explore, and localized company routes fall in line with the forecast while request success rates and visible data freshness remain unchanged.
