### PR TITLE
Embed similar companies in cached company snapshot

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-route-suspense.test.ts
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-route-suspense.test.ts
@@ -10,6 +10,7 @@ describe("company route partial prerendering", () => {
 
     expect(source).toContain("<Suspense fallback={null}>");
     expect(source).toContain("<SimilarSection");
+    expect(source).toContain("initialPage={initialData.similarCompanies}");
     expect(source).toContain("<Suspense fallback={<CompanySkeleton />}>");
     expect(source).toContain("<CompanyContent");
   });

--- a/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
@@ -181,6 +181,7 @@ export default async function CompanyPageRoute({ params }: Props) {
         <SimilarSection
           companyId={company.id}
           industryId={company.industryId}
+          initialPage={initialData.similarCompanies}
           locale={locale}
         />
       </Suspense>

--- a/apps/web/app/[lang]/(app)/company/[slug]/similar-section.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/similar-section.tsx
@@ -1,30 +1,38 @@
 "use client";
 
 import { SimilarCompaniesStrip } from "@/components/company/similar-companies-strip";
+import type { SimilarCompaniesPage } from "@/lib/actions/company";
 import type { Locale } from "@/lib/i18n";
 
 type Props = {
   companyId: string;
   industryId: number | null;
+  initialPage?: SimilarCompaniesPage;
   locale: Locale;
 };
 
 /**
- * Client wrapper that mounts the similar-companies strip with empty
- * initial state. The strip fetches page 0 on mount via a server
- * action; rendering it client-side keeps the parent company page
- * fully statically prerenderable (no `searchParams` / `headers()` /
- * `getSession()` reads on the server render path).
+ * Client wrapper for the filter-aware strip. Page zero arrives in the cached
+ * company route snapshot, so a no-filter visit does not need a mount-time
+ * Server Action. The client still owns URL filter changes and pagination,
+ * keeping `searchParams` / `headers()` / `getSession()` out of the cached
+ * route render path.
  */
-export function SimilarSection({ companyId, industryId, locale }: Props) {
+export function SimilarSection({
+  companyId,
+  industryId,
+  initialPage,
+  locale,
+}: Props) {
   if (industryId == null) return null;
   return (
     <SimilarCompaniesStrip
       companyId={companyId}
       industryId={industryId}
-      initialCompanies={[]}
-      initialHasMore={true}
-      initialTruncated={false}
+      initialCompanies={initialPage?.companies ?? []}
+      initialHasMore={initialPage?.hasMore ?? false}
+      initialTruncated={initialPage?.truncated ?? false}
+      initialPageLoaded={initialPage != null}
       locale={locale}
     />
   );

--- a/apps/web/src/components/company/__tests__/similar-companies-strip.test.tsx
+++ b/apps/web/src/components/company/__tests__/similar-companies-strip.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SimilarCompany } from "@/lib/actions/company";
+
+const mocks = vi.hoisted(() => ({
+  getSimilarCompanies: vi.fn(),
+}));
+
+let currentSearchParams = new URLSearchParams();
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ lang: "en" }),
+  useSearchParams: () => currentSearchParams,
+}));
+vi.mock("@lingui/react/macro", () => ({
+  Trans: ({ children }: { children: React.ReactNode }) => children,
+  useLingui: () => ({
+    t: ({ message }: { message: string }) => message,
+  }),
+}));
+vi.mock("@/lib/actions/company", () => ({
+  getSimilarCompanies: (...args: unknown[]) =>
+    mocks.getSimilarCompanies(...args),
+}));
+vi.mock("@/components/providers/SessionProvider", () => ({
+  useSession: () => ({ isPending: false }),
+}));
+vi.mock("@/lib/use-infinite-scroll", () => ({
+  useInfiniteScroll: () => ({ sentinelRef: vi.fn(), isLoading: false }),
+}));
+vi.mock("@/components/ui/scroll-fade", () => ({
+  ScrollFade: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+vi.mock("@/components/InfiniteScrollSentinel", () => ({
+  InfiniteScrollSentinel: () => <li data-testid="sentinel" />,
+}));
+vi.mock("../similar-company-card", () => ({
+  SimilarCompanyCard: ({ company }: { company: SimilarCompany }) => (
+    <li>{company.name}</li>
+  ),
+}));
+
+import { SimilarCompaniesStrip } from "../similar-companies-strip";
+
+const initialCompanies: SimilarCompany[] = [
+  {
+    id: "peer-1",
+    slug: "peer-one",
+    name: "Peer One",
+    icon: null,
+    activeJobCount: 4,
+  },
+];
+
+function renderStrip(overrides: Partial<React.ComponentProps<typeof SimilarCompaniesStrip>> = {}) {
+  return render(
+    <SimilarCompaniesStrip
+      companyId="company-1"
+      industryId={7}
+      initialCompanies={initialCompanies}
+      initialHasMore={false}
+      initialPageLoaded
+      locale="en"
+      {...overrides}
+    />,
+  );
+}
+
+beforeEach(() => {
+  currentSearchParams = new URLSearchParams();
+  mocks.getSimilarCompanies.mockReset();
+  mocks.getSimilarCompanies.mockResolvedValue({
+    companies: [
+      {
+        id: "filtered-peer",
+        slug: "filtered-peer",
+        name: "Filtered Peer",
+        icon: null,
+        activeJobCount: 2,
+      },
+    ],
+    hasMore: false,
+  });
+});
+
+describe("SimilarCompaniesStrip cached initial page", () => {
+  it("does not issue a mount-time Server Action for an unfiltered visit", async () => {
+    renderStrip();
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(screen.getByText("Peer One")).toBeTruthy();
+    expect(mocks.getSimilarCompanies).not.toHaveBeenCalled();
+  });
+
+  it("does not retry a cached empty result on mount", async () => {
+    const { container } = renderStrip({ initialCompanies: [] });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(container.innerHTML).toBe("");
+    expect(mocks.getSimilarCompanies).not.toHaveBeenCalled();
+  });
+
+  it("loads a filtered ranking when the entry URL has filters", async () => {
+    currentSearchParams = new URLSearchParams("q=python");
+    renderStrip();
+
+    await waitFor(() => {
+      expect(mocks.getSimilarCompanies).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.getSimilarCompanies).toHaveBeenCalledWith("company-1", 7, {
+      offset: 0,
+      limit: 10,
+      searchParams: { q: "python" },
+      locale: "en",
+    });
+    expect(screen.getByText("Filtered Peer")).toBeTruthy();
+  });
+
+  it("restores the cached unfiltered page when filters are cleared", async () => {
+    currentSearchParams = new URLSearchParams("q=python");
+    const view = renderStrip();
+
+    await waitFor(() => {
+      expect(screen.getByText("Filtered Peer")).toBeTruthy();
+    });
+
+    currentSearchParams = new URLSearchParams();
+    view.rerender(
+      <SimilarCompaniesStrip
+        companyId="company-1"
+        industryId={7}
+        initialCompanies={initialCompanies}
+        initialHasMore={false}
+        initialPageLoaded
+        locale="en"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Peer One")).toBeTruthy();
+    });
+    expect(mocks.getSimilarCompanies).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/company/similar-companies-strip.tsx
+++ b/apps/web/src/components/company/similar-companies-strip.tsx
@@ -24,6 +24,8 @@ type Props = {
   initialHasMore: boolean;
   /** True when anonymous-user pagination cap is already reached on page 0. */
   initialTruncated?: boolean;
+  /** True when the cached route snapshot already resolved unfiltered page 0. */
+  initialPageLoaded?: boolean;
   locale: Locale;
 };
 
@@ -35,6 +37,7 @@ export function SimilarCompaniesStrip({
   initialCompanies,
   initialHasMore,
   initialTruncated = false,
+  initialPageLoaded = false,
   locale,
 }: Props) {
   const { t } = useLingui();
@@ -47,11 +50,10 @@ export function SimilarCompaniesStrip({
     () => searchFilterParamsToObject(new URLSearchParams(paramsKey)),
     [paramsKey],
   );
-  // Suppress the inaugural fetch only when SSR already produced
-  // cards. When the parent passes `initialCompanies=[]` (the page is
-  // statically prerendered and hands off to the client to load), the
-  // first effect run must fire to actually populate the strip.
-  const skipNextFetch = useRef(initialCompanies.length > 0);
+  // The server snapshot is unfiltered. Suppress the inaugural read when it
+  // matches the current URL, including a legitimate empty result. A filtered
+  // entry URL still fetches its filtered ranking after hydration.
+  const skipNextFetch = useRef(initialPageLoaded && paramsKey === "");
 
   const [companies, setCompanies] = useState<SimilarCompany[]>(initialCompanies);
   const [hasMore, setHasMore] = useState(initialHasMore);
@@ -64,6 +66,15 @@ export function SimilarCompaniesStrip({
   useEffect(() => {
     if (skipNextFetch.current) {
       skipNextFetch.current = false;
+      return;
+    }
+    // When a user clears filters, restore the already-resolved unfiltered
+    // snapshot instead of creating another Server Action read.
+    if (initialPageLoaded && paramsKey === "") {
+      setCompanies(initialCompanies);
+      setHasMore(initialHasMore);
+      setTruncated(initialTruncated);
+      scrollRef.current?.scrollTo({ left: 0 });
       return;
     }
     let cancelled = false;
@@ -83,7 +94,17 @@ export function SimilarCompaniesStrip({
     return () => {
       cancelled = true;
     };
-  }, [paramsKey, companyId, industryId, locale, spObject]);
+  }, [
+    paramsKey,
+    companyId,
+    industryId,
+    initialCompanies,
+    initialHasMore,
+    initialPageLoaded,
+    initialTruncated,
+    locale,
+    spObject,
+  ]);
 
   const loadMore = useCallback(async () => {
     if (industryId == null) return;

--- a/apps/web/src/lib/actions/__tests__/company-page-data-defaults.test.ts
+++ b/apps/web/src/lib/actions/__tests__/company-page-data-defaults.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   getCompanyBySlug: vi.fn(),
   getCompanyPostings: vi.fn(),
   getCompanyPostingsAnonymous: vi.fn(),
+  getSimilarCompanies: vi.fn(),
   getSession: vi.fn(),
   getPreferences: vi.fn(),
   readAnonJobLanguagesCookie: vi.fn(),
@@ -22,6 +23,7 @@ vi.mock("@/lib/actions/company", () => ({
   getCompanyBySlug: mocks.getCompanyBySlug,
   getCompanyPostings: mocks.getCompanyPostings,
   getCompanyPostingsAnonymous: mocks.getCompanyPostingsAnonymous,
+  getSimilarCompanies: mocks.getSimilarCompanies,
 }));
 vi.mock("@/lib/actions/search", () => ({
   getCurrencyRates: mocks.getCurrencyRates,
@@ -58,8 +60,8 @@ function makeCompany(): CompanyDetail {
     logo: null,
     website: null,
     description: null,
-    industryId: null,
-    industryName: null,
+    industryId: 7,
+    industryName: "Software",
     employeeCountRange: null,
     foundedYear: null,
     activeJobCount: 7,
@@ -78,6 +80,18 @@ beforeEach(() => {
     postings: [],
     activeCount: 0,
     yearCount: 0,
+  });
+  mocks.getSimilarCompanies.mockResolvedValue({
+    companies: [
+      {
+        id: "company-2",
+        slug: "peer-company",
+        name: "Peer Company",
+        icon: null,
+        activeJobCount: 3,
+      },
+    ],
+    hasMore: true,
   });
   mocks.getSession.mockResolvedValue(null);
   mocks.getPreferences.mockResolvedValue(null);
@@ -132,6 +146,32 @@ describe("fetchCompanyPageDefaults — ISR-safe prerender variant (#3203)", () =
 
     expect(mocks.getCompanyPostingsAnonymous).toHaveBeenCalledTimes(1);
     expect(mocks.getCompanyPostings).not.toHaveBeenCalled();
+  });
+
+  it("embeds unfiltered similar companies in the cached page snapshot", async () => {
+    const result = await fetchCompanyPageDefaults({
+      slug: "test-company",
+      locale: "en",
+    });
+
+    expect(mocks.getSimilarCompanies).toHaveBeenCalledTimes(1);
+    expect(mocks.getSimilarCompanies).toHaveBeenCalledWith("company-1", 7, {
+      offset: 0,
+      limit: 10,
+      locale: "en",
+    });
+    expect(result?.similarCompanies).toEqual({
+      companies: [
+        {
+          id: "company-2",
+          slug: "peer-company",
+          name: "Peer Company",
+          icon: null,
+          activeJobCount: 3,
+        },
+      ],
+      hasMore: true,
+    });
   });
 
   it("returns anonymous defaults (EUR, no filters, locale-only language)", async () => {

--- a/apps/web/src/lib/actions/company-page-data.ts
+++ b/apps/web/src/lib/actions/company-page-data.ts
@@ -4,7 +4,9 @@ import {
   getCompanyBySlug,
   getCompanyPostings,
   getCompanyPostingsAnonymous,
+  getSimilarCompanies,
   type CompanyDetail,
+  type SimilarCompaniesPage,
 } from "@/lib/actions/company";
 import { getCurrencyRates } from "@/lib/actions/search";
 import { parseSearchFilters, type ParsedSearchFilters } from "@/lib/actions/search-input";
@@ -32,6 +34,12 @@ const EMPTY_PARSED_FILTERS: ParsedSearchFilters = {
 
 export interface CompanyPageData {
   company: CompanyDetail;
+  /**
+   * Unfiltered first page of same-industry companies embedded in the cached
+   * anonymous route snapshot. Personalized reads intentionally omit this: the
+   * strip owns filter changes after hydration.
+   */
+  similarCompanies?: SimilarCompaniesPage;
   postings: SearchResultPosting[];
   activeCount: number;
   yearCount: number;
@@ -187,17 +195,30 @@ export async function fetchCompanyPageDefaults(params: {
   // would silently downgrade the page to dynamic rendering, defeating
   // the ISR optimisation this function exists for. See the parallel
   // pattern in `explore-page-data.ts::fetchExplorePageDefaults` (#2640).
-  const postingsResult = await getCompanyPostingsAnonymous({
-    companyId: company.id,
-    keywords: [],
-    languages,
-    locale,
-    offset: 0,
-    limit: PAGE_SIZE,
-  });
+  // The first similar-company page is stable enough to share the route's
+  // cached snapshot. Fetch it alongside postings so the browser does not emit
+  // an uncached Server Action POST merely because the strip mounted (#6614).
+  // Page zero never reaches the anonymous pagination cap, so this call does
+  // not read session headers and remains safe inside the ISR snapshot.
+  const [postingsResult, similarCompanies] = await Promise.all([
+    getCompanyPostingsAnonymous({
+      companyId: company.id,
+      keywords: [],
+      languages,
+      locale,
+      offset: 0,
+      limit: PAGE_SIZE,
+    }),
+    getSimilarCompanies(company.id, company.industryId, {
+      offset: 0,
+      limit: 10,
+      locale,
+    }),
+  ]);
 
   return {
     company,
+    similarCompanies,
     postings: postingsResult.postings,
     activeCount: postingsResult.activeCount,
     yearCount: postingsResult.yearCount,


### PR DESCRIPTION
## Summary

- embed the unfiltered first similar-companies page in the cached company route snapshot
- avoid the mount-time Server Action POST for unfiltered company visits, including empty results
- preserve filtered entry URLs, pagination, and restore the cached page when filters are cleared
- add regression coverage for cached, empty, filtered, and filter-clear behavior

## Why

Production logs showed JS-capable crawlers triggering an extra Function invocation and multiple Typesense/Upstash calls on company-page mount. This moves that stable read into the existing one-hour cached snapshot without adding request-scoped APIs to the prerender path.

Closes #6614

## Verification

- focused Vitest suite: 17 tests passed
- Next.js type generation and TypeScript check passed
- production Next.js build passed
- web ESLint pre-commit hook passed