### PR TITLE
Make watchlist writes atomic

### DIFF
--- a/apps/web/src/lib/actions/__tests__/watchlists-invalidation.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-invalidation.test.ts
@@ -188,7 +188,7 @@ vi.mock("@/db/schema", () => ({
 function makeChain(leafResultFn: () => Promise<unknown>) {
   const chain: Record<string, unknown> = {};
   // Methods that just return the chain to keep fluency:
-  for (const m of ["from", "where", "set", "values", "onConflictDoNothing"]) {
+  for (const m of ["from", "where", "for", "set", "values", "onConflictDoNothing"]) {
     chain[m] = () => chain;
   }
   // Leaf-ish methods that resolve the chain when awaited.
@@ -201,15 +201,21 @@ function makeChain(leafResultFn: () => Promise<unknown>) {
   return chain;
 }
 
-vi.mock("@/db", () => ({
-  db: {
+vi.mock("@/db", () => {
+  const tx = {
     select: () => makeChain(() => Promise.resolve(mocks.selectLimitResult())),
     insert: () => makeChain(() => Promise.resolve(mocks.insertReturningResult())),
     update: () => makeChain(() => Promise.resolve(undefined)),
     delete: () => makeChain(() => Promise.resolve(undefined)),
     execute: (...args: unknown[]) => mocks.dbExecute(...args),
-  },
-}));
+  };
+  return {
+    db: {
+      ...tx,
+      transaction: async <T>(fn: (transaction: typeof tx) => Promise<T>) => fn(tx),
+    },
+  };
+});
 
 // ---- Module under test (must come AFTER vi.mock blocks) ------------
 
@@ -430,12 +436,18 @@ describe("watchlist mutator cache invalidation", () => {
 
   it("copyWatchlist invalidates new copy's slug for both variants", async () => {
     queueOwnerInfo();
-    // First select: source watchlist row; subsequent selects: copied
-    // companies (returns []).
+    // First select: source watchlist slug hint; second: the authoritative
+    // source snapshot inside the transaction; third: copied companies.
+    const source = {
+      title: "Source",
+      description: null,
+      filters: {},
+      isPublic: true,
+      userId: "other",
+    };
     mocks.selectLimitResult
-      .mockResolvedValueOnce([
-        { title: "Source", description: null, filters: {}, isPublic: true, userId: "other" },
-      ]);
+      .mockResolvedValueOnce([source])
+      .mockResolvedValueOnce([source]);
     // `db.select(... companyId).from(watchlistCompany).where(eq(...))`
     // resolves via the chain too (no `.limit`); make the chain
     // resolve on `.where` for the companies query.

--- a/apps/web/src/lib/actions/__tests__/watchlists-transactions.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-transactions.test.ts
@@ -1,0 +1,425 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => {
+  type WatchlistRow = {
+    id: string;
+    userId: string;
+    slug: string;
+    title: string;
+    description: string | null;
+    isPublic: boolean;
+    filters: Record<string, unknown>;
+  };
+  type CompanyRow = { watchlistId: string; companyId: string };
+  type State = { watchlists: WatchlistRow[]; companies: CompanyRow[] };
+
+  const watchlist = {
+    __table: "watchlist",
+    id: { __column: "watchlist.id" },
+    userId: { __column: "watchlist.userId" },
+    slug: { __column: "watchlist.slug" },
+    title: { __column: "watchlist.title" },
+    description: { __column: "watchlist.description" },
+    isPublic: { __column: "watchlist.isPublic" },
+    alertsEnabled: { __column: "watchlist.alertsEnabled" },
+    filters: { __column: "watchlist.filters" },
+  };
+  const watchlistCompany = {
+    __table: "watchlistCompany",
+    watchlistId: { __column: "watchlistCompany.watchlistId" },
+    companyId: { __column: "watchlistCompany.companyId" },
+  };
+
+  let committed: State = { watchlists: [], companies: [] };
+  let rootSelectRows: unknown[][] = [];
+  let failCompanyInsert = false;
+  let slugConflictsRemaining = 0;
+  let nextWatchlistId = "wl-new";
+
+  const calls = {
+    transactions: 0,
+    rollbacks: 0,
+  };
+  const afterFn = vi.fn();
+  const getSessionUserId = vi.fn();
+  const canCreateWatchlist = vi.fn();
+
+  const cloneState = (state: State): State => ({
+    watchlists: state.watchlists.map((row) => ({ ...row })),
+    companies: state.companies.map((row) => ({ ...row })),
+  });
+
+  const makeSelect = (state: State, useRootQueue: boolean) => {
+    let table: unknown;
+    const rows = () => {
+      if (useRootQueue) return rootSelectRows.shift() ?? [];
+      if (table === watchlistCompany) {
+        return state.companies.map(({ companyId }) => ({ companyId }));
+      }
+      return state.watchlists;
+    };
+    const chain: Record<string, unknown> = {};
+    chain.from = (nextTable: unknown) => {
+      table = nextTable;
+      return chain;
+    };
+    chain.where = () => chain;
+    chain.for = () => chain;
+    chain.limit = async () => rows();
+    chain.then = (
+      resolve: (value: unknown) => unknown,
+      reject?: (reason: unknown) => unknown,
+    ) => Promise.resolve(rows()).then(resolve, reject);
+    return chain;
+  };
+
+  const makeInsert = (state: State, table: unknown) => {
+    let insertedValues: Record<string, unknown>[] = [];
+    const chain: Record<string, unknown> = {};
+    chain.values = (values: Record<string, unknown> | Record<string, unknown>[]) => {
+      insertedValues = Array.isArray(values) ? values : [values];
+      return chain;
+    };
+
+    const apply = () => {
+      if (table === watchlistCompany) {
+        if (failCompanyInsert) throw new Error("forced watchlist_company insert failure");
+        state.companies.push(...insertedValues as CompanyRow[]);
+        return [];
+      }
+      if (table === watchlist) {
+        const value = insertedValues[0];
+        if (slugConflictsRemaining > 0) {
+          slugConflictsRemaining -= 1;
+          throw Object.assign(new Error("duplicate watchlist slug"), {
+            code: "23505",
+            constraint_name: "idx_wl_user_slug",
+          });
+        }
+        const row: WatchlistRow = {
+          id: nextWatchlistId,
+          userId: String(value.userId),
+          slug: String(value.slug),
+          title: String(value.title),
+          description: (value.description as string | null) ?? null,
+          isPublic: Boolean(value.isPublic),
+          filters: (value.filters as Record<string, unknown>) ?? {},
+        };
+        state.watchlists.push(row);
+        return [{ id: row.id }];
+      }
+      throw new Error("unexpected insert table");
+    };
+
+    chain.returning = async () => apply();
+    chain.then = (
+      resolve: (value: unknown) => unknown,
+      reject?: (reason: unknown) => unknown,
+    ) => Promise.resolve().then(apply).then(resolve, reject);
+    return chain;
+  };
+
+  const makeUpdate = (state: State, table: unknown) => {
+    let updates: Record<string, unknown> = {};
+    const chain: Record<string, unknown> = {};
+    chain.set = (values: Record<string, unknown>) => {
+      updates = values;
+      return chain;
+    };
+    chain.where = () => {
+      if (table !== watchlist) throw new Error("unexpected update table");
+      Object.assign(state.watchlists[0], updates);
+      return Promise.resolve([]);
+    };
+    return chain;
+  };
+
+  const makeDelete = (state: State, table: unknown) => {
+    const chain: Record<string, unknown> = {};
+    chain.where = async () => {
+      if (table !== watchlistCompany) throw new Error("unexpected delete table");
+      state.companies = [];
+      return [];
+    };
+    return chain;
+  };
+
+  const makeTx = (state: State) => ({
+    select: () => makeSelect(state, false),
+    insert: (table: unknown) => makeInsert(state, table),
+    update: (table: unknown) => makeUpdate(state, table),
+    delete: (table: unknown) => makeDelete(state, table),
+  });
+
+  const db = {
+    select: () => makeSelect(committed, true),
+    insert: () => {
+      throw new Error("mutation escaped transaction");
+    },
+    update: () => {
+      throw new Error("mutation escaped transaction");
+    },
+    delete: () => {
+      throw new Error("mutation escaped transaction");
+    },
+    transaction: async <T>(fn: (tx: ReturnType<typeof makeTx>) => Promise<T>) => {
+      calls.transactions += 1;
+      const draft = cloneState(committed);
+      try {
+        const result = await fn(makeTx(draft));
+        committed = draft;
+        return result;
+      } catch (error) {
+        calls.rollbacks += 1;
+        throw error;
+      }
+    },
+  };
+
+  const reset = () => {
+    committed = { watchlists: [], companies: [] };
+    rootSelectRows = [];
+    failCompanyInsert = false;
+    slugConflictsRemaining = 0;
+    nextWatchlistId = "wl-new";
+    calls.transactions = 0;
+    calls.rollbacks = 0;
+    afterFn.mockReset();
+    getSessionUserId.mockReset();
+    canCreateWatchlist.mockReset();
+  };
+
+  return {
+    watchlist,
+    watchlistCompany,
+    db,
+    calls,
+    afterFn,
+    getSessionUserId,
+    canCreateWatchlist,
+    reset,
+    snapshot: () => cloneState(committed),
+    setState: (state: State) => {
+      committed = cloneState(state);
+    },
+    queueRootSelect: (...rows: unknown[][]) => {
+      rootSelectRows.push(...rows);
+    },
+    failCompanyInserts: () => {
+      failCompanyInsert = true;
+    },
+    failSlugInserts: (count: number) => {
+      slugConflictsRemaining = count;
+    },
+    setNextWatchlistId: (id: string) => {
+      nextWatchlistId = id;
+    },
+  };
+});
+
+vi.mock("next/server", () => ({ after: mocks.afterFn }));
+vi.mock("next/cache", () => ({ updateTag: vi.fn() }));
+vi.mock("@/lib/sessionCache", () => ({
+  getSessionUserId: mocks.getSessionUserId,
+}));
+vi.mock("@/lib/plans", () => ({
+  canCreateWatchlist: mocks.canCreateWatchlist,
+  getUserPlan: vi.fn(),
+  PLAN_LIMITS: { free: {}, paid: {} },
+}));
+vi.mock("@/lib/watchlist-slug", async () =>
+  vi.importActual<typeof import("@/lib/watchlist-slug")>("@/lib/watchlist-slug"),
+);
+vi.mock("@/db/schema", () => ({
+  watchlist: mocks.watchlist,
+  watchlistCompany: mocks.watchlistCompany,
+  company: {},
+}));
+vi.mock("@/db", () => ({ db: mocks.db }));
+vi.mock("drizzle-orm", () => {
+  const sql = (strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values });
+  sql.join = (..._args: unknown[]) => ({ strings: [], values: [] });
+  return {
+    eq: (...args: unknown[]) => ({ kind: "eq", args }),
+    and: (...args: unknown[]) => ({ kind: "and", args }),
+    sql,
+  };
+});
+
+import {
+  copyWatchlist,
+  createWatchlist,
+  updateWatchlist,
+} from "@/lib/services/watchlists";
+
+const USER_ID = "user-1";
+const WATCHLIST_ID = "wl-existing";
+
+beforeEach(() => {
+  mocks.reset();
+  mocks.getSessionUserId.mockResolvedValue(USER_ID);
+  mocks.canCreateWatchlist.mockResolvedValue({ allowed: true });
+});
+
+describe("#3114 — watchlist multi-table writes are atomic", () => {
+  it("commits parent and company rows before registering post-commit work", async () => {
+    const audit = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      await expect(createWatchlist({
+        title: "New watchlist",
+        companyIds: ["company-1"],
+        isPublic: true,
+      })).resolves.toEqual({ id: "wl-new", slug: "new-watchlist" });
+
+      expect(mocks.snapshot()).toEqual({
+        watchlists: [expect.objectContaining({ id: "wl-new", title: "New watchlist" })],
+        companies: [{ watchlistId: "wl-new", companyId: "company-1" }],
+      });
+      expect(mocks.calls).toEqual({ transactions: 1, rollbacks: 0 });
+      expect(audit).toHaveBeenCalledTimes(1);
+      expect(mocks.afterFn).toHaveBeenCalledTimes(2);
+    } finally {
+      audit.mockRestore();
+    }
+  });
+
+  it("retries a slug conflict in a fresh transaction and emits hooks once", async () => {
+    const audit = vi.spyOn(console, "info").mockImplementation(() => {});
+    mocks.queueRootSelect([], [{ slug: "new-watchlist" }]);
+    mocks.failSlugInserts(1);
+
+    try {
+      await expect(createWatchlist({
+        title: "New watchlist",
+        companyIds: ["company-1"],
+        isPublic: true,
+      })).resolves.toEqual({ id: "wl-new", slug: "new-watchlist-2" });
+
+      expect(mocks.snapshot()).toEqual({
+        watchlists: [expect.objectContaining({ id: "wl-new", slug: "new-watchlist-2" })],
+        companies: [{ watchlistId: "wl-new", companyId: "company-1" }],
+      });
+      expect(mocks.calls).toEqual({ transactions: 2, rollbacks: 1 });
+      expect(audit).toHaveBeenCalledTimes(1);
+      expect(mocks.afterFn).toHaveBeenCalledTimes(2);
+    } finally {
+      audit.mockRestore();
+    }
+  });
+
+  it("rolls back create when a company-row insert fails", async () => {
+    mocks.failCompanyInserts();
+
+    await expect(createWatchlist({
+      title: "New watchlist",
+      companyIds: ["company-1"],
+    })).rejects.toThrow("forced watchlist_company insert failure");
+
+    expect(mocks.snapshot()).toEqual({ watchlists: [], companies: [] });
+    expect(mocks.calls).toEqual({ transactions: 1, rollbacks: 1 });
+    expect(mocks.afterFn).not.toHaveBeenCalled();
+  });
+
+  it("preserves metadata and company membership when replacement fails", async () => {
+    const originalState = {
+      watchlists: [{
+        id: WATCHLIST_ID,
+        userId: USER_ID,
+        slug: "existing",
+        title: "Existing",
+        description: "Original description",
+        isPublic: false,
+        filters: {},
+      }],
+      companies: [{ watchlistId: WATCHLIST_ID, companyId: "company-old" }],
+    };
+    mocks.setState(originalState);
+    mocks.queueRootSelect([{ ...originalState.watchlists[0] }]);
+    mocks.failCompanyInserts();
+
+    await expect(updateWatchlist({
+      watchlistId: WATCHLIST_ID,
+      description: "Changed description",
+      companyIds: ["company-new"],
+    })).rejects.toThrow("forced watchlist_company insert failure");
+
+    expect(mocks.snapshot()).toEqual(originalState);
+    expect(mocks.calls).toEqual({ transactions: 1, rollbacks: 1 });
+    expect(mocks.afterFn).not.toHaveBeenCalled();
+  });
+
+  it("rolls back the destination watchlist when copied company rows fail", async () => {
+    const originalState = {
+      watchlists: [{
+        id: WATCHLIST_ID,
+        userId: "source-owner",
+        slug: "source",
+        title: "Source",
+        description: null,
+        isPublic: true,
+        filters: {},
+      }],
+      companies: [{ watchlistId: WATCHLIST_ID, companyId: "company-1" }],
+    };
+    mocks.setState(originalState);
+    mocks.queueRootSelect([{ ...originalState.watchlists[0] }]);
+    mocks.setNextWatchlistId("wl-copy");
+    mocks.failCompanyInserts();
+
+    await expect(copyWatchlist(WATCHLIST_ID)).rejects.toThrow(
+      "forced watchlist_company insert failure",
+    );
+
+    expect(mocks.snapshot()).toEqual(originalState);
+    expect(mocks.calls).toEqual({ transactions: 1, rollbacks: 1 });
+    expect(mocks.afterFn).not.toHaveBeenCalled();
+  });
+
+  it("rechecks copy authorization inside the transaction", async () => {
+    mocks.queueRootSelect([{
+      id: WATCHLIST_ID,
+      userId: "source-owner",
+      slug: "source",
+      title: "Source",
+      description: null,
+      isPublic: true,
+      filters: {},
+    }]);
+
+    await expect(copyWatchlist(WATCHLIST_ID)).resolves.toEqual({ error: "not_found" });
+
+    expect(mocks.snapshot()).toEqual({ watchlists: [], companies: [] });
+    expect(mocks.calls).toEqual({ transactions: 1, rollbacks: 1 });
+    expect(mocks.afterFn).not.toHaveBeenCalled();
+  });
+
+  it("rejects a source that becomes private before the copy transaction", async () => {
+    mocks.setState({
+      watchlists: [{
+        id: WATCHLIST_ID,
+        userId: "source-owner",
+        slug: "source",
+        title: "Source",
+        description: null,
+        isPublic: false,
+        filters: {},
+      }],
+      companies: [],
+    });
+    mocks.queueRootSelect([{
+      userId: "source-owner",
+      title: "Source",
+      description: null,
+      isPublic: true,
+      filters: {},
+    }]);
+
+    await expect(copyWatchlist(WATCHLIST_ID)).resolves.toEqual({ error: "not_found" });
+
+    expect(mocks.snapshot().watchlists).toHaveLength(1);
+    expect(mocks.calls).toEqual({ transactions: 1, rollbacks: 1 });
+    expect(mocks.afterFn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/services/watchlists.ts
+++ b/apps/web/src/lib/services/watchlists.ts
@@ -218,6 +218,8 @@ function _logWatchlistAudit({ userId, ...entry }: WatchlistAuditInput): void {
   console.info(JSON.stringify(payload));
 }
 
+class WatchlistCopySourceUnavailableError extends Error {}
+
 // ── Actions ─────────────────────────────────────────────────────────
 
 export async function createWatchlist(params: {
@@ -239,33 +241,40 @@ export async function createWatchlist(params: {
   // double-fire of the Create button) used to crash one of the two
   // callers with an un-handled 23505 here; the helper catches the
   // violation, regenerates a fresh `-N` suffix, and retries.
+  //
+  // Keep the transaction *inside* the retry callback. A 23505 aborts
+  // its transaction in Postgres; allowing that transaction to reject
+  // before the helper retries gives every slug candidate a fresh
+  // transaction while keeping the parent + company rows atomic.
   const { row, slug } = await insertWatchlistWithUniqueSlug(
     userId,
     params.title,
-    async (candidate) => {
-      const [r] = await db
-        .insert(watchlist)
-        .values({
-          userId,
-          slug: candidate,
-          title: params.title,
-          description: params.description ?? null,
-          isPublic: params.isPublic ?? false,
-          filters: { anyCompany: true, ...params.filters },
-        })
-        .returning({ id: watchlist.id });
-      return r;
-    },
-  );
+    async (candidate) =>
+      db.transaction(async (tx) => {
+        const [r] = await tx
+          .insert(watchlist)
+          .values({
+            userId,
+            slug: candidate,
+            title: params.title,
+            description: params.description ?? null,
+            isPublic: params.isPublic ?? false,
+            filters: { anyCompany: true, ...params.filters },
+          })
+          .returning({ id: watchlist.id });
 
-  if (params.companyIds.length > 0) {
-    await db.insert(watchlistCompany).values(
-      params.companyIds.map((companyId) => ({
-        watchlistId: row.id,
-        companyId,
-      })),
-    );
-  }
+        if (params.companyIds.length > 0) {
+          await tx.insert(watchlistCompany).values(
+            params.companyIds.map((companyId) => ({
+              watchlistId: r.id,
+              companyId,
+            })),
+          );
+        }
+
+        return r;
+      }),
+  );
 
   // Typesense + IndexNow hook: upsert if public and non-trivial.
   // Wrapped in after() so the registration is synchronous in the
@@ -371,26 +380,30 @@ export async function updateWatchlist(params: {
   if (params.filters !== undefined) updates.filters = params.filters;
   if (params.isPublic !== undefined) updates.isPublic = params.isPublic;
 
-  if (Object.keys(updates).length > 0) {
-    await db
-      .update(watchlist)
-      .set(updates)
-      .where(eq(watchlist.id, params.watchlistId));
-  }
+  if (Object.keys(updates).length > 0 || params.companyIds !== undefined) {
+    await db.transaction(async (tx) => {
+      if (Object.keys(updates).length > 0) {
+        await tx
+          .update(watchlist)
+          .set(updates)
+          .where(eq(watchlist.id, params.watchlistId));
+      }
 
-  if (params.companyIds !== undefined) {
-    await db
-      .delete(watchlistCompany)
-      .where(eq(watchlistCompany.watchlistId, params.watchlistId));
+      if (params.companyIds !== undefined) {
+        await tx
+          .delete(watchlistCompany)
+          .where(eq(watchlistCompany.watchlistId, params.watchlistId));
 
-    if (params.companyIds.length > 0) {
-      await db.insert(watchlistCompany).values(
-        params.companyIds.map((companyId) => ({
-          watchlistId: params.watchlistId,
-          companyId,
-        })),
-      );
-    }
+        if (params.companyIds.length > 0) {
+          await tx.insert(watchlistCompany).values(
+            params.companyIds.map((companyId) => ({
+              watchlistId: params.watchlistId,
+              companyId,
+            })),
+          );
+        }
+      }
+    });
   }
 
   // Typesense + IndexNow hook. A doc is indexed when the watchlist is
@@ -543,46 +556,86 @@ export async function copyWatchlist(
     return { error: "not_found" };
   }
 
-  const sourceFilters = (source.filters ?? {}) as WatchlistFilters;
-
   // Same race shape as createWatchlist (#3201): two fast clicks of the
   // "Copy" button on a public watchlist used to race the SELECT-then-
   // INSERT slug pick and crash the loser. The helper retries on a
-  // `idx_wl_user_slug` 23505.
-  const { row, slug } = await insertWatchlistWithUniqueSlug(
-    userId,
-    source.title,
-    async (candidate) => {
-      const [r] = await db
-        .insert(watchlist)
-        .values({
-          userId,
-          slug: candidate,
-          title: source.title,
-          description: source.description,
-          isPublic: false,
-          filters: sourceFilters,
-          sourceWatchlistId: watchlistId,
-        })
-        .returning({ id: watchlist.id });
-      return r;
-    },
-  );
+  // `idx_wl_user_slug` 23505. As in create, each retry attempt owns a
+  // fresh transaction so a rejected candidate never poisons the next. Re-read
+  // and authorize the source inside that transaction too: the first read is
+  // only a slug-allocation hint, while the repeatable-read snapshot supplies
+  // every field and company row that is actually copied.
+  let inserted;
+  try {
+    inserted = await insertWatchlistWithUniqueSlug(
+      userId,
+      source.title,
+      async (candidate) =>
+        db.transaction(
+          async (tx) => {
+            const [currentSource] = await tx
+              .select({
+                title: watchlist.title,
+                description: watchlist.description,
+                filters: watchlist.filters,
+                isPublic: watchlist.isPublic,
+                userId: watchlist.userId,
+              })
+              .from(watchlist)
+              .where(eq(watchlist.id, watchlistId))
+              .for("share")
+              .limit(1);
 
-  // Copy companies (even in anyCompany mode, so toggling it off reveals them)
-  const companies = await db
-    .select({ companyId: watchlistCompany.companyId })
-    .from(watchlistCompany)
-    .where(eq(watchlistCompany.watchlistId, watchlistId));
+            if (
+              !currentSource
+              || (!currentSource.isPublic && currentSource.userId !== userId)
+            ) {
+              throw new WatchlistCopySourceUnavailableError();
+            }
 
-  if (companies.length > 0) {
-    await db.insert(watchlistCompany).values(
-      companies.map((c) => ({
-        watchlistId: row.id,
-        companyId: c.companyId,
-      })),
+            const [r] = await tx
+              .insert(watchlist)
+              .values({
+                userId,
+                slug: candidate,
+                title: currentSource.title,
+                description: currentSource.description,
+                isPublic: false,
+                filters: (currentSource.filters ?? {}) as WatchlistFilters,
+                sourceWatchlistId: watchlistId,
+              })
+              .returning({ id: watchlist.id });
+
+            // Copy companies (even in anyCompany mode, so toggling it off reveals them).
+            // The parent and child rows share a transaction so a malformed/stale
+            // company reference cannot leave behind an empty partial copy.
+            const companies = await tx
+              .select({ companyId: watchlistCompany.companyId })
+              .from(watchlistCompany)
+              .where(eq(watchlistCompany.watchlistId, watchlistId));
+
+            if (companies.length > 0) {
+              await tx.insert(watchlistCompany).values(
+                companies.map((c) => ({
+                  watchlistId: r.id,
+                  companyId: c.companyId,
+                })),
+              );
+            }
+
+            return { row: r, companies };
+          },
+          { isolationLevel: "repeatable read" },
+        ),
     );
+  } catch (error) {
+    if (error instanceof WatchlistCopySourceUnavailableError) {
+      return { error: "not_found" };
+    }
+    throw error;
   }
+
+  const { row: copyResult, slug } = inserted;
+  const { row, companies } = copyResult;
 
   _logWatchlistAudit({
     action: "watchlist.copy",


### PR DESCRIPTION
Closes #3114

## Summary
- commit watchlist parent and company rows atomically for create and copy
- commit watchlist metadata and company replacement atomically for update
- keep each slug-conflict retry in a fresh transaction so PostgreSQL 23505 failures do not poison the next attempt
- copy from one repeatable-read, share-locked authorization and data snapshot
- register audit, cache, Typesense, and IndexNow work only after a successful commit

## Recon and scope
The original issue bundled several historical my-jobs claims. Current main already has transactional interview deletion, a unique saved-job/round constraint, and conflict-safe interview creation. Delete-watchlist remains a single parent delete backed by database cascades. This PR therefore fixes only the still-reproducible watchlist multi-write risk.

## Verification
- full web Vitest suite: 225 files, 1631 tests passed
- focused watchlist transaction and invalidation suites: 31 tests passed after rebase
- watchlist slug-race suite: 10 tests passed
- full web ESLint passed
- TypeScript no-emit check passed
- pre-commit ESLint and Lingui gates passed
- independent re-review found no merge-blocking issues