### PR TITLE
Add Fluid CPU regression gate

### DIFF
--- a/.github/workflows/fluid-cpu-regression-gate.yml
+++ b/.github/workflows/fluid-cpu-regression-gate.yml
@@ -1,0 +1,36 @@
+name: Fluid CPU regression gate
+
+on:
+  workflow_dispatch:
+    inputs:
+      metrics_json:
+        description: "JSON report copied from the clean post-deploy Vercel observation window"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  evaluate:
+    name: Evaluate route CPU budgets
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      FLUID_CPU_REPORT_JSON: ${{ inputs.metrics_json }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Evaluate clean-window budgets
+        run: pnpm --filter @jobseek/web cpu:gate | tee -a "$GITHUB_STEP_SUMMARY"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "db:check": "drizzle-kit check",
     "analyze": "ANALYZE=true next build",
     "check:bundle": "tsx script/check-bundle-budget.ts",
+    "cpu:gate": "tsx script/check-fluid-cpu-budget.ts",
     "optimize:svg": "svgo public/*.svg --multipass",
     "og:prewarm": "tsx script/prewarm-company-og-cache.ts",
     "og:prune": "tsx script/prune-company-og-cache.ts",

--- a/apps/web/script/check-fluid-cpu-budget.ts
+++ b/apps/web/script/check-fluid-cpu-budget.ts
@@ -1,0 +1,357 @@
+/** Evaluate a clean post-deployment Vercel Fluid CPU observation window. */
+import { readFileSync } from "node:fs";
+
+export const FLUID_CPU_BASELINE = {
+  windowHours: 12,
+  visibleActiveCpuSeconds: 277,
+  activeCpuP75Ms: 308,
+  cpuThrottleP75Pct: 7.6,
+  invocations: 1_500,
+  routes: {
+    companyOg: 120,
+    companyPages: 91,
+    publicWatchlists: 39,
+    explore: 10,
+    other: 17,
+  },
+} as const;
+
+export const FLUID_CPU_BUDGET = {
+  minimumWindowHours: 12,
+  visibleActiveCpuSeconds: 138.5,
+  activeCpuP75Ms: 308,
+  cpuThrottleP75Pct: 7.6,
+  errorRatePct: 0.5,
+  timeoutRatePct: 0.1,
+  typesenseCallsPerInvocation: 2.5,
+  upstashCallsPerInvocation: 1.5,
+  companyOgR2HitRatePct: 95,
+  pprShellHitRatePct: 35,
+  minimumRecognizedBotRequests: 1,
+  minimumLongTailUniqueKeys: 20,
+  routes: {
+    companyOg: 24,
+    companyPages: 60,
+    publicWatchlists: 25,
+    explore: 10,
+    other: 19.5,
+  },
+} as const;
+
+const REQUIRED_ROUTES = [
+  "companyOg",
+  "companyPages",
+  "publicWatchlists",
+  "explore",
+  "other",
+] as const;
+
+const REQUIRED_FUNCTIONALITY = [
+  "home",
+  "explore",
+  "companyPage",
+  "companyOg",
+  "publicWatchlist",
+  "authentication",
+] as const;
+
+type Check = {
+  name: string;
+  actual: string;
+  budget: string;
+  passed: boolean;
+};
+
+export type FluidCpuGateResult = {
+  checks: Check[];
+  markdown: string;
+  passed: boolean;
+};
+
+function record(value: unknown, name: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${name} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function finiteNumber(value: unknown, name: string): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative finite number`);
+  }
+  return value;
+}
+
+function requiredString(value: unknown, name: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function requiredBoolean(value: unknown, name: string): boolean {
+  if (typeof value !== "boolean") throw new Error(`${name} must be a boolean`);
+  return value;
+}
+
+function timestamp(value: unknown, name: string): number {
+  const raw = requiredString(value, name);
+  const parsed = Date.parse(raw);
+  if (!Number.isFinite(parsed)) throw new Error(`${name} must be an ISO timestamp`);
+  return parsed;
+}
+
+function format(value: number, digits = 1): string {
+  return value.toFixed(digits).replace(/\.0$/, "");
+}
+
+function ratioPercent(numerator: number, denominator: number): number {
+  return denominator === 0 ? 0 : (numerator / denominator) * 100;
+}
+
+function addMaximum(
+  checks: Check[],
+  name: string,
+  actual: number,
+  budget: number,
+  unit: string,
+) {
+  checks.push({
+    name,
+    actual: `${format(actual)}${unit}`,
+    budget: `≤ ${format(budget)}${unit}`,
+    passed: actual <= budget,
+  });
+}
+
+function addMinimum(
+  checks: Check[],
+  name: string,
+  actual: number,
+  budget: number,
+  unit: string,
+) {
+  checks.push({
+    name,
+    actual: `${format(actual)}${unit}`,
+    budget: `≥ ${format(budget)}${unit}`,
+    passed: actual >= budget,
+  });
+}
+
+export function evaluateFluidCpuReport(input: unknown): FluidCpuGateResult {
+  const report = record(input, "report");
+  if (report.schemaVersion !== 1) throw new Error("schemaVersion must be 1");
+
+  const deployment = record(report.deployment, "deployment");
+  const sha = requiredString(deployment.sha, "deployment.sha");
+  if (!/^[a-f0-9]{7,40}$/i.test(sha)) throw new Error("deployment.sha is invalid");
+  const readyAt = timestamp(deployment.readyAt, "deployment.readyAt");
+
+  const window = record(report.window, "window");
+  const windowStart = timestamp(window.start, "window.start");
+  const windowEnd = timestamp(window.end, "window.end");
+  if (windowEnd <= windowStart) throw new Error("window.end must be after window.start");
+  const windowHours = (windowEnd - windowStart) / 3_600_000;
+
+  const totals = record(report.totals, "totals");
+  const invocations = finiteNumber(totals.invocations, "totals.invocations");
+  if (invocations < 1) throw new Error("totals.invocations must be at least 1");
+  const visibleCpu = finiteNumber(
+    totals.visibleActiveCpuSeconds,
+    "totals.visibleActiveCpuSeconds",
+  );
+  const activeCpuP75 = finiteNumber(totals.activeCpuP75Ms, "totals.activeCpuP75Ms");
+  const throttleP75 = finiteNumber(
+    totals.cpuThrottleP75Pct,
+    "totals.cpuThrottleP75Pct",
+  );
+  const errorRate = finiteNumber(totals.errorRatePct, "totals.errorRatePct");
+  const timeoutRate = finiteNumber(totals.timeoutRatePct, "totals.timeoutRatePct");
+  const typesenseCalls = finiteNumber(totals.typesenseCalls, "totals.typesenseCalls");
+  const upstashCalls = finiteNumber(totals.upstashCalls, "totals.upstashCalls");
+
+  const routes = record(report.routes, "routes");
+  const routeCpu = {} as Record<(typeof REQUIRED_ROUTES)[number], number>;
+  for (const routeName of REQUIRED_ROUTES) {
+    const metric = record(routes[routeName], `routes.${routeName}`);
+    finiteNumber(metric.invocations, `routes.${routeName}.invocations`);
+    routeCpu[routeName] = finiteNumber(
+      metric.activeCpuSeconds,
+      `routes.${routeName}.activeCpuSeconds`,
+    );
+  }
+
+  const cache = record(report.cache, "cache");
+  const companyOgR2Hits = finiteNumber(cache.companyOgR2Hits, "cache.companyOgR2Hits");
+  const companyOgR2Misses = finiteNumber(
+    cache.companyOgR2Misses,
+    "cache.companyOgR2Misses",
+  );
+  const pprShellHits = finiteNumber(cache.pprShellHits, "cache.pprShellHits");
+  const pprShellMisses = finiteNumber(cache.pprShellMisses, "cache.pprShellMisses");
+
+  const traffic = record(report.traffic, "traffic");
+  const recognizedBotRequests = finiteNumber(
+    traffic.recognizedBotRequests,
+    "traffic.recognizedBotRequests",
+  );
+  const longTailUniqueKeys = finiteNumber(
+    traffic.longTailUniqueKeys,
+    "traffic.longTailUniqueKeys",
+  );
+  const sourceIncludesAllTraffic = requiredBoolean(
+    traffic.sourceIncludesAllTraffic,
+    "traffic.sourceIncludesAllTraffic",
+  );
+
+  const functionality = record(report.functionality, "functionality");
+  const functionalityChecks = REQUIRED_FUNCTIONALITY.map((name) => ({
+    name,
+    passed: requiredBoolean(functionality[name], `functionality.${name}`),
+  }));
+
+  const checks: Check[] = [];
+  checks.push({
+    name: "Window starts after deployment ready",
+    actual: new Date(windowStart).toISOString(),
+    budget: `≥ ${new Date(readyAt).toISOString()}`,
+    passed: windowStart >= readyAt,
+  });
+  addMinimum(checks, "Clean window duration", windowHours, FLUID_CPU_BUDGET.minimumWindowHours, "h");
+  addMaximum(checks, "Visible Active CPU", visibleCpu, FLUID_CPU_BUDGET.visibleActiveCpuSeconds, "s");
+  addMaximum(checks, "Active CPU P75", activeCpuP75, FLUID_CPU_BUDGET.activeCpuP75Ms, "ms");
+  addMaximum(checks, "CPU throttle P75", throttleP75, FLUID_CPU_BUDGET.cpuThrottleP75Pct, "%");
+  addMaximum(checks, "Error rate", errorRate, FLUID_CPU_BUDGET.errorRatePct, "%");
+  addMaximum(checks, "Timeout rate", timeoutRate, FLUID_CPU_BUDGET.timeoutRatePct, "%");
+  addMaximum(
+    checks,
+    "Typesense calls / invocation",
+    typesenseCalls / invocations,
+    FLUID_CPU_BUDGET.typesenseCallsPerInvocation,
+    "",
+  );
+  addMaximum(
+    checks,
+    "Upstash calls / invocation",
+    upstashCalls / invocations,
+    FLUID_CPU_BUDGET.upstashCallsPerInvocation,
+    "",
+  );
+
+  for (const routeName of REQUIRED_ROUTES) {
+    addMaximum(
+      checks,
+      `${routeName} Active CPU`,
+      routeCpu[routeName],
+      FLUID_CPU_BUDGET.routes[routeName],
+      "s",
+    );
+  }
+
+  const routeCpuSum = Object.values(routeCpu).reduce((sum, value) => sum + value, 0);
+  checks.push({
+    name: "Route CPU reconciliation",
+    actual: `${format(Math.abs(routeCpuSum - visibleCpu))}s difference`,
+    budget: "≤ 0.5s difference",
+    passed: Math.abs(routeCpuSum - visibleCpu) <= 0.5,
+  });
+
+  addMinimum(
+    checks,
+    "Company OG R2 hit rate",
+    ratioPercent(companyOgR2Hits, companyOgR2Hits + companyOgR2Misses),
+    FLUID_CPU_BUDGET.companyOgR2HitRatePct,
+    "%",
+  );
+  addMinimum(
+    checks,
+    "PPR shell hit rate",
+    ratioPercent(pprShellHits, pprShellHits + pprShellMisses),
+    FLUID_CPU_BUDGET.pprShellHitRatePct,
+    "%",
+  );
+  addMinimum(
+    checks,
+    "Recognized bot requests represented",
+    recognizedBotRequests,
+    FLUID_CPU_BUDGET.minimumRecognizedBotRequests,
+    "",
+  );
+  addMinimum(
+    checks,
+    "Long-tail unique keys represented",
+    longTailUniqueKeys,
+    FLUID_CPU_BUDGET.minimumLongTailUniqueKeys,
+    "",
+  );
+  checks.push({
+    name: "Traffic source includes all requests",
+    actual: String(sourceIncludesAllTraffic),
+    budget: "true",
+    passed: sourceIncludesAllTraffic,
+  });
+
+  for (const functionalityCheck of functionalityChecks) {
+    checks.push({
+      name: `Functionality: ${functionalityCheck.name}`,
+      actual: String(functionalityCheck.passed),
+      budget: "true",
+      passed: functionalityCheck.passed,
+    });
+  }
+
+  const passed = checks.every((check) => check.passed);
+  const markdown = [
+    `# Vercel Fluid CPU gate: ${passed ? "PASS" : "FAIL"}`,
+    "",
+    `Deployment: \`${sha}\``,
+    `Window: ${new Date(windowStart).toISOString()} → ${new Date(windowEnd).toISOString()} (${format(windowHours, 2)}h)`,
+    "",
+    "| Check | Actual | Budget | Result |",
+    "|---|---:|---:|:---:|",
+    ...checks.map((check) =>
+      `| ${check.name} | ${check.actual} | ${check.budget} | ${check.passed ? "PASS" : "FAIL"} |`,
+    ),
+    "",
+    `Visible CPU reduction vs baseline: ${format((1 - visibleCpu / FLUID_CPU_BASELINE.visibleActiveCpuSeconds) * 100)}%`,
+  ].join("\n");
+
+  return { checks, markdown, passed };
+}
+
+function parseArguments(argv: string[]): { inputPath: string | null } {
+  let inputPath: string | null = null;
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--") continue;
+    if (argument === "--input") {
+      inputPath = argv[++index] ?? null;
+      if (!inputPath) throw new Error("--input requires a path");
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  return { inputPath };
+}
+
+function main() {
+  const { inputPath } = parseArguments(process.argv.slice(2));
+  const raw = inputPath
+    ? readFileSync(inputPath, "utf8")
+    : process.env.FLUID_CPU_REPORT_JSON;
+  if (!raw) throw new Error("Provide --input or FLUID_CPU_REPORT_JSON");
+  const result = evaluateFluidCpuReport(JSON.parse(raw));
+  console.log(result.markdown);
+  if (!result.passed) process.exitCode = 1;
+}
+
+const entrypoint = process.argv[1] ?? "";
+if (/check-fluid-cpu-budget\.(?:ts|js|mjs|cjs)$/.test(entrypoint)) {
+  try {
+    main();
+  } catch {
+    console.error("fluid_cpu_budget_report_invalid");
+    process.exitCode = 1;
+  }
+}

--- a/apps/web/src/lib/__tests__/fluid-cpu-budget.test.ts
+++ b/apps/web/src/lib/__tests__/fluid-cpu-budget.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateFluidCpuReport,
+  FLUID_CPU_BUDGET,
+} from "../../../script/check-fluid-cpu-budget";
+
+function passingReport() {
+  return {
+    schemaVersion: 1,
+    deployment: {
+      sha: "1234567890abcdef",
+      readyAt: "2026-08-11T00:00:00.000Z",
+    },
+    window: {
+      start: "2026-08-11T00:05:00.000Z",
+      end: "2026-08-11T12:05:00.000Z",
+    },
+    totals: {
+      invocations: 1_000,
+      visibleActiveCpuSeconds: 130,
+      activeCpuP75Ms: 240,
+      cpuThrottleP75Pct: 5,
+      errorRatePct: 0,
+      timeoutRatePct: 0,
+      typesenseCalls: 2_000,
+      upstashCalls: 1_000,
+    },
+    routes: {
+      companyOg: { invocations: 200, activeCpuSeconds: 20 },
+      companyPages: { invocations: 300, activeCpuSeconds: 58 },
+      publicWatchlists: { invocations: 150, activeCpuSeconds: 24 },
+      explore: { invocations: 100, activeCpuSeconds: 9 },
+      other: { invocations: 250, activeCpuSeconds: 19 },
+    },
+    cache: {
+      companyOgR2Hits: 195,
+      companyOgR2Misses: 5,
+      pprShellHits: 400,
+      pprShellMisses: 600,
+    },
+    traffic: {
+      recognizedBotRequests: 250,
+      longTailUniqueKeys: 300,
+      sourceIncludesAllTraffic: true,
+    },
+    functionality: {
+      home: true,
+      explore: true,
+      companyPage: true,
+      companyOg: true,
+      publicWatchlist: true,
+      authentication: true,
+    },
+  };
+}
+
+describe("Fluid CPU regression gate", () => {
+  it("passes a clean 12-hour report inside every budget", () => {
+    const result = evaluateFluidCpuReport(passingReport());
+
+    expect(result.passed).toBe(true);
+    expect(result.markdown).toContain("Vercel Fluid CPU gate: PASS");
+  });
+
+  it("fails the 50% total CPU target even when route functionality passes", () => {
+    const report = passingReport();
+    report.totals.visibleActiveCpuSeconds = FLUID_CPU_BUDGET.visibleActiveCpuSeconds + 1;
+    report.routes.other.activeCpuSeconds += 9.5;
+
+    const result = evaluateFluidCpuReport(report);
+
+    expect(result.passed).toBe(false);
+    expect(result.checks.find((check) => check.name === "Visible Active CPU"))
+      .toMatchObject({ passed: false });
+  });
+
+  it("rejects windows containing pre-deployment traffic", () => {
+    const report = passingReport();
+    report.window.start = "2026-08-10T23:59:00.000Z";
+
+    const result = evaluateFluidCpuReport(report);
+
+    expect(result.passed).toBe(false);
+    expect(result.checks[0]).toMatchObject({
+      name: "Window starts after deployment ready",
+      passed: false,
+    });
+  });
+
+  it("fails when a live production functionality check fails", () => {
+    const report = passingReport();
+    report.functionality.companyOg = false;
+
+    const result = evaluateFluidCpuReport(report);
+
+    expect(result.passed).toBe(false);
+    expect(result.checks.find((check) => check.name === "Functionality: companyOg"))
+      .toMatchObject({ passed: false });
+  });
+
+  it("fails hot-key-only samples without bot and long-tail representation", () => {
+    const report = passingReport();
+    report.traffic.recognizedBotRequests = 0;
+    report.traffic.longTailUniqueKeys = 1;
+
+    const result = evaluateFluidCpuReport(report);
+
+    expect(result.passed).toBe(false);
+    expect(result.checks.filter((check) => !check.passed).map((check) => check.name))
+      .toEqual(expect.arrayContaining([
+        "Recognized bot requests represented",
+        "Long-tail unique keys represented",
+      ]));
+  });
+});

--- a/docs/18-vercel-fluid-cpu.md
+++ b/docs/18-vercel-fluid-cpu.md
@@ -1,0 +1,130 @@
+# Vercel Fluid CPU regression gate
+
+This runbook prevents a hot-key benchmark from being mistaken for a real
+production improvement. A Fluid CPU intervention is successful only after a
+clean, fully post-deployment 12-hour window passes route, cache, traffic,
+external-call, error, and functionality gates.
+
+## 2026-08-11 baseline
+
+| Metric | Clean 12h baseline |
+|---|---:|
+| Invocations | 1,500 |
+| Visible Active CPU | 277s |
+| Active CPU P75 | 308ms |
+| CPU throttle P75 | 7.6% |
+| Company OG | 120s / 271 invocations |
+| Company pages | 91s |
+| Public watchlists | 39s |
+| Explore | 10s |
+| Typesense calls | 5,900 |
+| Upstash calls | 2,900 |
+| Errors / timeouts | 0% / 0% |
+
+The release target is at least a 50% reduction in visible Active CPU: no more
+than 138.5 seconds in a comparable 12-hour window.
+
+## Measurement protocol
+
+1. Record the production deployment SHA and its Vercel `Ready` timestamp.
+2. Let at least 12 hours of production traffic accumulate after that timestamp.
+   Never include traffic from the previous deployment.
+3. In Vercel Observability, select Production and the exact absolute start/end
+   timestamps. Do not use a moving “Past 12 hours” window while transcribing.
+4. Record overall invocations, visible Active CPU, CPU P75, throttle P75,
+   errors, timeouts, Typesense calls, and Upstash calls.
+5. Record invocations and Active CPU for these exhaustive route groups:
+   `companyOg`, `companyPages`, `publicWatchlists`, `explore`, and `other`.
+   The sum must reconcile to overall visible CPU within 0.5 seconds.
+6. Record company-OG R2 hits/misses and PPR shell hits/misses.
+7. Confirm the window includes recognized bots and at least 20 distinct
+   long-tail route keys. Synthetic repeated requests do not satisfy this gate.
+8. Run the live checks below from production, then evaluate the JSON report.
+
+## Live functionality checks
+
+All checks are mandatory:
+
+- Home page returns a successful localized document.
+- Explore renders initial results and filter interaction still works.
+- A known company page renders its company data and postings.
+- That company page's `og:image` returns a valid PNG.
+- A known public watchlist renders, while scanner-shaped paths return non-200.
+- Sign-in loads and an existing authenticated session remains usable.
+
+Set the corresponding `functionality` fields to `true` only after observing the
+production behavior. CPU gains never override a failed functionality check.
+
+## Report format
+
+```json
+{
+  "schemaVersion": 1,
+  "deployment": {
+    "sha": "0123456789abcdef",
+    "readyAt": "2026-08-11T13:00:00.000Z"
+  },
+  "window": {
+    "start": "2026-08-11T13:05:00.000Z",
+    "end": "2026-08-12T01:05:00.000Z"
+  },
+  "totals": {
+    "invocations": 1000,
+    "visibleActiveCpuSeconds": 130,
+    "activeCpuP75Ms": 240,
+    "cpuThrottleP75Pct": 5,
+    "errorRatePct": 0,
+    "timeoutRatePct": 0,
+    "typesenseCalls": 2000,
+    "upstashCalls": 1000
+  },
+  "routes": {
+    "companyOg": { "invocations": 200, "activeCpuSeconds": 20 },
+    "companyPages": { "invocations": 300, "activeCpuSeconds": 58 },
+    "publicWatchlists": { "invocations": 150, "activeCpuSeconds": 24 },
+    "explore": { "invocations": 100, "activeCpuSeconds": 9 },
+    "other": { "invocations": 250, "activeCpuSeconds": 19 }
+  },
+  "cache": {
+    "companyOgR2Hits": 195,
+    "companyOgR2Misses": 5,
+    "pprShellHits": 400,
+    "pprShellMisses": 600
+  },
+  "traffic": {
+    "recognizedBotRequests": 250,
+    "longTailUniqueKeys": 300,
+    "sourceIncludesAllTraffic": true
+  },
+  "functionality": {
+    "home": true,
+    "explore": true,
+    "companyPage": true,
+    "companyOg": true,
+    "publicWatchlist": true,
+    "authentication": true
+  }
+}
+```
+
+Run locally:
+
+```bash
+pnpm --filter @jobseek/web cpu:gate -- --input /absolute/path/report.json
+```
+
+Or dispatch the `Fluid CPU regression gate` workflow and paste the same JSON
+into `metrics_json`. The workflow writes the complete gate table to its job
+summary and fails when any budget or functionality check fails.
+
+## Rollback and escalation
+
+- Roll back immediately for production functionality loss, authentication
+  failure, data corruption, new timeouts, or a sustained error rate above 0.5%.
+- Investigate before declaring success when total CPU improves but any route
+  exceeds its budget, external calls per invocation regress, or cache hit rates
+  miss their thresholds.
+- Continue remediation when visible Active CPU is above 138.5 seconds, even if
+  P75 improves. Total CPU is the bottleneck and the release gate.
+- Preserve the failed report in issue #6616 with the deployment SHA and exact
+  timestamps so subsequent comparisons use the same traffic definition.

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,9 @@ Status tags:
   `[routine]` - gold-dataset sampling, labelling, validation, and upload.
 - [16 - Hetzner Maintenance](16-hetzner-maintenance.md) `[runbook]` -
   disk/headroom checks and Docker cleanup on Hetzner hosts.
+- [18 - Vercel Fluid CPU Regression Gate](18-vercel-fluid-cpu.md) `[runbook]` -
+  clean-window measurement protocol, route budgets, functionality checks, and
+  rollback criteria for web CPU interventions.
 - [19 - Hetzner Data Backup and Recovery](19-data-backup-recovery.md)
   `[runbook]` - encrypted PostgreSQL and Typesense backups, restore drills,
   retention, scheduling, and replacement gates for legacy server backups.


### PR DESCRIPTION
## Summary
- codify the clean 12-hour production baseline and a 50% total Fluid CPU reduction target
- fail on route-level CPU, cache, external-call, traffic-mix, error, timeout, or functionality regressions
- add a manually dispatched GitHub workflow and operator runbook for exact post-deploy measurements

## Validation
- ESLint on the new evaluator and tests
- five focused Vitest cases
- web typecheck
- zizmor workflow audit
- git diff --check

Refs #6616

The issue remains open until a real clean post-deployment 12-hour window passes every gate.