### PR TITLE
Harden trace viewer Markdown links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,6 +334,10 @@ jobs:
           pnpm --filter @jobseek/web exec vitest run
           --exclude src/lib/search/__tests__/typesense.e2e.test.ts
 
+      - run: pnpm --filter @jobseek/trace-viewer test
+
+      - run: pnpm --filter @jobseek/trace-viewer build
+
   test-web-typesense-e2e:
     name: Test Web Typesense E2E
     needs: changes

--- a/apps/trace-viewer/package.json
+++ b/apps/trace-viewer/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "dompurify": "^3.4.13",
+    "entities": "^8.0.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "lucide-react": "^1.30.0"

--- a/apps/trace-viewer/package.json
+++ b/apps/trace-viewer/package.json
@@ -4,10 +4,12 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && node script/verify-build-security.mjs",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "dompurify": "^3.4.13",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "lucide-react": "^1.30.0"
@@ -16,9 +18,11 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^6.0.5",
+    "jsdom": "^30.0.1",
     "typescript": "^5.7.0",
     "vite": "^8.2.1",
     "tailwindcss": "^4.3.3",
-    "@tailwindcss/vite": "^4.3.3"
+    "@tailwindcss/vite": "^4.3.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/trace-viewer/script/verify-build-security.mjs
+++ b/apps/trace-viewer/script/verify-build-security.mjs
@@ -1,21 +1,19 @@
 import assert from 'node:assert/strict'
 import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
+import { JSDOM } from 'jsdom'
 
 const indexPath = fileURLToPath(new URL('../dist/index.html', import.meta.url))
 const html = readFileSync(indexPath, 'utf8')
+const document = new JSDOM(html).window.document
 
-const cspTag = html.match(
-  /<meta\b[^>]*http-equiv=["']Content-Security-Policy["'][^>]*>/i,
+const cspTag = [...document.querySelectorAll('meta[http-equiv]')].find(
+  (meta) => meta.getAttribute('http-equiv')?.toLowerCase() === 'content-security-policy',
 )
 assert.ok(cspTag, 'built index.html must contain a Content Security Policy')
 
-const encodedCsp = cspTag[0].match(/\bcontent="([^"]+)"/i)?.[1]
-assert.ok(encodedCsp, 'built CSP meta tag must have content')
-const csp = encodedCsp
-  .replace(/&#(?:39|x27);/gi, "'")
-  .replace(/&apos;/gi, "'")
-  .replace(/&amp;/gi, '&')
+const csp = cspTag.getAttribute('content')
+assert.ok(csp, 'built CSP meta tag must have content')
 assert.match(csp, /(?:^|;)\s*script-src 'self'(?:;|$)/)
 assert.match(csp, /(?:^|;)\s*object-src 'none'(?:;|$)/)
 assert.match(csp, /(?:^|;)\s*base-uri 'none'(?:;|$)/)
@@ -23,9 +21,9 @@ const scriptSrc = csp.match(/(?:^|;)\s*(script-src[^;]*)/)?.[1]
 assert.ok(scriptSrc, 'built CSP must define script-src')
 assert.doesNotMatch(scriptSrc, /'unsafe-inline'|'unsafe-eval'/)
 
-for (const script of html.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/gi)) {
-  assert.match(script[1], /\bsrc=/i, 'built scripts must load from external files')
-  assert.equal(script[2].trim(), '', 'built index.html must not depend on inline script')
+for (const script of document.querySelectorAll('script')) {
+  assert.ok(script.hasAttribute('src'), 'built scripts must load from external files')
+  assert.equal(script.textContent?.trim(), '', 'built index.html must not depend on inline script')
 }
 
 console.log('trace-viewer build security: CSP and external scripts verified')

--- a/apps/trace-viewer/script/verify-build-security.mjs
+++ b/apps/trace-viewer/script/verify-build-security.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const indexPath = fileURLToPath(new URL('../dist/index.html', import.meta.url))
+const html = readFileSync(indexPath, 'utf8')
+
+const cspTag = html.match(
+  /<meta\b[^>]*http-equiv=["']Content-Security-Policy["'][^>]*>/i,
+)
+assert.ok(cspTag, 'built index.html must contain a Content Security Policy')
+
+const encodedCsp = cspTag[0].match(/\bcontent="([^"]+)"/i)?.[1]
+assert.ok(encodedCsp, 'built CSP meta tag must have content')
+const csp = encodedCsp
+  .replace(/&#(?:39|x27);/gi, "'")
+  .replace(/&apos;/gi, "'")
+  .replace(/&amp;/gi, '&')
+assert.match(csp, /(?:^|;)\s*script-src 'self'(?:;|$)/)
+assert.match(csp, /(?:^|;)\s*object-src 'none'(?:;|$)/)
+assert.match(csp, /(?:^|;)\s*base-uri 'none'(?:;|$)/)
+const scriptSrc = csp.match(/(?:^|;)\s*(script-src[^;]*)/)?.[1]
+assert.ok(scriptSrc, 'built CSP must define script-src')
+assert.doesNotMatch(scriptSrc, /'unsafe-inline'|'unsafe-eval'/)
+
+for (const script of html.matchAll(/<script\b([^>]*)>([\s\S]*?)<\/script>/gi)) {
+  assert.match(script[1], /\bsrc=/i, 'built scripts must load from external files')
+  assert.equal(script[2].trim(), '', 'built index.html must not depend on inline script')
+}
+
+console.log('trace-viewer build security: CSP and external scripts verified')

--- a/apps/trace-viewer/src/components/DetailPanel.test.tsx
+++ b/apps/trace-viewer/src/components/DetailPanel.test.tsx
@@ -1,0 +1,44 @@
+/** @vitest-environment jsdom */
+
+import { flushSync } from 'react-dom'
+import { createRoot } from 'react-dom/client'
+import { describe, expect, it } from 'vitest'
+import type { TimelineEvent, TimelineEventKind } from '../types'
+import DetailPanel from './DetailPanel'
+
+function maliciousEvent(kind: TimelineEventKind): TimelineEvent {
+  return {
+    id: 1,
+    kind,
+    timestamp: new Date('2026-08-11T00:00:00Z'),
+    elapsedMs: 0,
+    text: 'click',
+    fullText:
+      '[click](java&#x0a;script:alert&#40;document.domain&#41;) '
+      + '<img src=x onerror=alert(1)><script>alert(1)</script>',
+    isSubagent: false,
+    rawRecord: {
+      type: 'system',
+      uuid: 'malicious-record',
+      timestamp: '2026-08-11T00:00:00Z',
+    },
+  }
+}
+
+describe('DetailPanel trace content security', () => {
+  it.each(['user-prompt', 'assistant-text'] as const)(
+    'renders a crafted %s trace without executable content',
+    (kind) => {
+      const container = document.createElement('div')
+      const root = createRoot(container)
+
+      flushSync(() => root.render(<DetailPanel event={maliciousEvent(kind)} />))
+
+      expect(container.querySelector('a, img, script, [onclick], [onerror]')).toBeNull()
+      expect(container.textContent).toContain('click')
+      expect(container.textContent).toContain('<img src=x onerror=alert(1)>')
+
+      root.unmount()
+    },
+  )
+})

--- a/apps/trace-viewer/src/lib/markdown.test.ts
+++ b/apps/trace-viewer/src/lib/markdown.test.ts
@@ -1,0 +1,77 @@
+/** @vitest-environment jsdom */
+
+import { describe, expect, it } from 'vitest'
+import { markdownToHtml } from './markdown'
+
+function render(markdown: string): HTMLDivElement {
+  const container = document.createElement('div')
+  container.innerHTML = markdownToHtml(markdown)
+  return container
+}
+
+describe('markdownToHtml link security', () => {
+  it('keeps HTTPS links and isolates them from the viewer origin', () => {
+    const container = render('[safe](https://example.com/jobs?a=1&b=2)')
+    const link = container.querySelector('a')
+
+    expect(link?.getAttribute('href')).toBe('https://example.com/jobs?a=1&b=2')
+    expect(link?.getAttribute('target')).toBe('_blank')
+    expect(link?.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+
+  it.each([
+    '#event-1',
+    '/traces/today',
+    './next-trace',
+    '../previous-trace',
+    'trace/123?view=detail',
+  ])('keeps safe relative destination %s in the same context', (href) => {
+    const link = render(`[safe](${href})`).querySelector('a')
+
+    expect(link?.getAttribute('href')).toBe(href)
+    expect(link?.hasAttribute('target')).toBe(false)
+    expect(link?.hasAttribute('rel')).toBe(false)
+  })
+
+  it.each([
+    'javascript:alert(1)',
+    'JaVaScRiPt:alert(1)',
+    'java\tscript:alert(1)',
+    'java&#x0a;script:alert(1)',
+    'java&Tab;script:alert(1)',
+    'java&#x73;cript:alert(1)',
+    '%6a%61%76%61%73%63%72%69%70%74%3aalert(1)',
+    '%256a%2561%2576%2561%2573%2563%2572%2569%2570%2574%253aalert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'vbscript:msgbox(1)',
+    '//evil.example/payload',
+    '\\\\evil.example/payload',
+    '%2f%2fevil.example/payload',
+    '&sol;&sol;evil.example/payload',
+  ])('renders unsafe destination %s as inert text', (href) => {
+    const container = render(`[click](${href})`)
+
+    expect(container.querySelector('a')).toBeNull()
+    expect(container.textContent).toContain('click')
+  })
+
+  it('cannot create tags or event handlers through raw HTML or a link attribute', () => {
+    const container = render(
+      '[click](https://example.com&quot; onclick=&quot;alert(1)) '
+      + '<img src=x onerror=alert(1)><script>alert(1)</script>',
+    )
+
+    expect(container.querySelector('a')).toBeNull()
+    expect(container.querySelector('img, script, [onclick], [onerror]')).toBeNull()
+    expect(container.textContent).toContain('<img src=x onerror=alert(1)>')
+  })
+
+  it('preserves normal markdown formatting through the final sanitizer', () => {
+    const container = render('# Header\n\n**bold** and `code`\n\n- one\n- two')
+
+    expect(container.querySelector('h1')?.textContent).toBe('Header')
+    expect(container.querySelector('strong')?.textContent).toBe('bold')
+    expect(container.querySelector('code')?.textContent).toBe('code')
+    expect(container.querySelectorAll('li')).toHaveLength(2)
+  })
+})

--- a/apps/trace-viewer/src/lib/markdown.ts
+++ b/apps/trace-viewer/src/lib/markdown.ts
@@ -1,8 +1,42 @@
 /**
  * Lightweight markdown-to-HTML converter for trace viewer.
  * Handles: headers, bold, italic, code blocks, inline code, links, lists.
- * No external dependencies.
+ * Trace text is untrusted: uploads and fetched traces both contain user/model
+ * content. Escape it before formatting, validate every link destination, then
+ * sanitize the generated HTML through a fixed DOMPurify allowlist.
  */
+
+import DOMPurify, { type Config } from 'dompurify'
+
+const URL_VALIDATION_BASE = new URL('https://trace-viewer.invalid/')
+const DECODE_PASSES = 5
+const RAW_WHITESPACE_OR_CONTROL = /[\u0000-\u0020\u007f]/
+const UNSAFE_URL_CHARACTERS = /["'<>`]/
+
+const MARKDOWN_SANITIZER_CONFIG: Config = {
+  ALLOWED_TAGS: [
+    'a',
+    'br',
+    'code',
+    'em',
+    'h1',
+    'h2',
+    'h3',
+    'h4',
+    'h5',
+    'h6',
+    'li',
+    'p',
+    'pre',
+    'strong',
+    'ul',
+  ],
+  ALLOWED_ATTR: ['class', 'href', 'rel', 'target'],
+  ALLOW_ARIA_ATTR: false,
+  ALLOW_DATA_ATTR: false,
+  FORBID_ATTR: ['style'],
+  FORBID_TAGS: ['script', 'style'],
+}
 
 function escapeHtml(s: string): string {
   return s
@@ -102,7 +136,77 @@ export function markdownToHtml(text: string): string {
     out.push('</ul>')
   }
 
-  return out.join('\n')
+  return DOMPurify.sanitize(out.join('\n'), MARKDOWN_SANITIZER_CONFIG)
+}
+
+function undoInputEscaping(value: string): string {
+  return value
+    .replace(/&quot;/g, '"')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+}
+
+function decodeHtmlEntities(value: string): string {
+  const textarea = document.createElement('textarea')
+  let decoded = value
+  for (let pass = 0; pass < DECODE_PASSES; pass++) {
+    textarea.innerHTML = decoded
+    const next = textarea.value
+    if (next === decoded) break
+    decoded = next
+  }
+  return decoded
+}
+
+function decodePercentEncoding(value: string): string | null {
+  let decoded = value
+  for (let pass = 0; pass < DECODE_PASSES; pass++) {
+    try {
+      const next = decodeURIComponent(decoded)
+      if (next === decoded) break
+      decoded = next
+    } catch {
+      return null
+    }
+  }
+  return decoded
+}
+
+type SafeMarkdownHref = {
+  href: string
+  external: boolean
+}
+
+function sanitizeMarkdownHref(escapedHref: string): SafeMarkdownHref | null {
+  const rawHref = undoInputEscaping(escapedHref)
+  if (!rawHref || RAW_WHITESPACE_OR_CONTROL.test(rawHref)) return null
+
+  const entityDecoded = decodeHtmlEntities(rawHref)
+  const canonical = decodePercentEncoding(entityDecoded)
+  if (!canonical || UNSAFE_URL_CHARACTERS.test(canonical)) return null
+
+  // Browsers ignore ASCII whitespace/control characters inside scheme names.
+  // Collapse them for policy evaluation so `java\tscript:` is rejected even
+  // when the original bytes reached us through an entity/percent encoding.
+  const compact = canonical.replace(/[\u0000-\u0020\u007f]/g, '')
+  const slashNormalized = compact.replace(/\\/g, '/')
+  if (slashNormalized.startsWith('//')) return null
+
+  let parsed: URL
+  try {
+    parsed = new URL(compact, URL_VALIDATION_BASE)
+  } catch {
+    return null
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null
+
+  const explicitScheme = /^[a-z][a-z0-9+.-]*:/i.test(compact)
+  return {
+    href: escapeHtml(rawHref),
+    external: explicitScheme || parsed.origin !== URL_VALIDATION_BASE.origin,
+  }
 }
 
 function inlineFormat(text: string): string {
@@ -116,6 +220,13 @@ function inlineFormat(text: string): string {
   // Italic
   s = s.replace(/\*(.+?)\*/g, '<em>$1</em>')
   // Links
-  s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2" class="md-link">$1</a>')
+  s = s.replace(/\[([^\]]+)\]\(([^)]+)\)/g, (_match, label: string, href: string) => {
+    const safe = sanitizeMarkdownHref(href)
+    if (!safe) return label
+    const externalAttrs = safe.external
+      ? ' target="_blank" rel="noopener noreferrer"'
+      : ''
+    return `<a href="${safe.href}" class="md-link"${externalAttrs}>${label}</a>`
+  })
   return s
 }

--- a/apps/trace-viewer/src/lib/markdown.ts
+++ b/apps/trace-viewer/src/lib/markdown.ts
@@ -7,6 +7,7 @@
  */
 
 import DOMPurify, { type Config } from 'dompurify'
+import { decodeHTML } from 'entities'
 
 const URL_VALIDATION_BASE = new URL('https://trace-viewer.invalid/')
 const DECODE_PASSES = 5
@@ -148,11 +149,9 @@ function undoInputEscaping(value: string): string {
 }
 
 function decodeHtmlEntities(value: string): string {
-  const textarea = document.createElement('textarea')
   let decoded = value
   for (let pass = 0; pass < DECODE_PASSES; pass++) {
-    textarea.innerHTML = decoded
-    const next = textarea.value
+    const next = decodeHTML(decoded)
     if (next === decoded) break
     decoded = next
   }

--- a/apps/trace-viewer/vite.config.ts
+++ b/apps/trace-viewer/vite.config.ts
@@ -1,7 +1,39 @@
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
+const PRODUCTION_CSP = [
+  "default-src 'none'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "connect-src 'self' https://huggingface.co https://*.huggingface.co https://*.hf.co",
+  "img-src 'self' data:",
+  "font-src 'self'",
+  "base-uri 'none'",
+  "form-action 'none'",
+  "object-src 'none'",
+  "frame-src 'none'",
+  "worker-src 'none'",
+].join('; ')
+
+const productionCspPlugin: Plugin = {
+  name: 'trace-viewer-production-csp',
+  apply: 'build',
+  transformIndexHtml: {
+    order: 'post',
+    handler() {
+      return [{
+        tag: 'meta',
+        attrs: {
+          'http-equiv': 'Content-Security-Policy',
+          content: PRODUCTION_CSP,
+        },
+        injectTo: 'head-prepend',
+      }]
+    },
+  },
+}
+
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), productionCspPlugin],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       dompurify:
         specifier: ^3.4.13
         version: 3.4.13
+      entities:
+        specifier: ^8.0.0
+        version: 8.0.0
       lucide-react:
         specifier: ^1.30.0
         version: 1.30.0(react@19.2.8)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
 
   apps/trace-viewer:
     dependencies:
+      dompurify:
+        specifier: ^3.4.13
+        version: 3.4.13
       lucide-react:
         specifier: ^1.30.0
         version: 1.30.0(react@19.2.8)
@@ -153,6 +156,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.5
         version: 6.0.5(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.23.11)(yaml@2.9.0))
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1(@noble/hashes@2.0.1)
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -162,6 +168,9 @@ importers:
       vite:
         specifier: ^8.2.1
         version: 8.2.1(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.23.11)(yaml@2.9.0)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(happy-dom@20.11.2)(jsdom@30.0.1(@noble/hashes@2.0.1))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.47.1)(tsx@4.23.11)(yaml@2.9.0))
 
   apps/web:
     dependencies:

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -1220,6 +1220,8 @@ test("broad CI test jobs exclude service-backed Typesense E2E suites", () => {
     webJob,
     /pnpm --filter @jobseek\/web exec vitest run[\s\S]*--exclude src\/lib\/search\/__tests__\/typesense\.e2e\.test\.ts/,
   );
+  assert.match(webJob, /pnpm --filter @jobseek\/trace-viewer test/);
+  assert.match(webJob, /pnpm --filter @jobseek\/trace-viewer build/);
 
   const crawlerJob = jobBlock("test-crawler");
   assert.match(crawlerJob, /uv run pytest tests\/ -v --ignore=tests\/e2e\/test_typesense_indexing\.py/);


### PR DESCRIPTION
## Summary

- validate Markdown destinations after iterative entity and percent decoding, allowing only HTTP(S) and non-network relative links
- sanitize generated markup through an explicit DOMPurify tag and attribute allowlist, with safe external-link attributes
- ship a production CSP and verify the built artifact uses external scripts
- run trace-viewer exploit and build checks in CI

## Recon

Uploaded JSON/JSONL traces and Hugging Face trace content both reach the two Markdown-backed DetailPanel sinks. Raw HTML was already escaped, but link destinations were interpolated without a scheme policy, making the reported executable-URL path valid. The fix is scoped to that reachable boundary.

## Verification

- pnpm --filter @jobseek/trace-viewer test
- pnpm --filter @jobseek/trace-viewer build
- node --test scripts/ci-workflow.test.mjs
- pnpm typecheck
- pnpm lint

Closes #6122