### PR TITLE
Use repository data for company OG prewarm

### DIFF
--- a/.github/workflows/prewarm-company-og-cache.yml
+++ b/.github/workflows/prewarm-company-og-cache.yml
@@ -6,6 +6,8 @@ on:
     paths:
       - ".github/workflows/prewarm-company-og-cache.yml"
       - "apps/crawler/data/companies.csv"
+      - "apps/crawler/data/company_descriptions.csv"
+      - "apps/crawler/data/industries.csv"
       - "apps/web/public/fonts/JetBrainsMono-Bold.ttf"
       - "apps/web/src/lib/og/company-og-card.tsx"
       - "apps/web/src/lib/og/company-og-key.ts"
@@ -46,18 +48,19 @@ jobs:
     env:
       PREWARM_CONCURRENCY: ${{ inputs.concurrency || '4' }}
       PREWARM_MAX_COMPANIES: ${{ inputs.max_companies || '' }}
-      PREWARM_FORCE: ${{ inputs.force || false }}
+      # Source or renderer pushes must replace existing cards in the stable
+      # renderer namespace. Scheduled reconciliation still skips existing
+      # objects; manual dispatch honors its explicit force input.
+      PREWARM_FORCE: ${{ github.event_name == 'push' || inputs.force || false }}
       COMPANY_OG_RENDERER_VERSION_SALT: ${{ vars.COMPANY_OG_RENDERER_VERSION_SALT || '' }}
       R2_ENDPOINT_URL: ${{ secrets.R2_ENDPOINT_URL }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
       R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
       R2_BUCKET: ${{ secrets.R2_BUCKET || vars.R2_BUCKET }}
-      TYPESENSE_HOST: ${{ secrets.TYPESENSE_HOST }}
-      TYPESENSE_PORT: ${{ secrets.TYPESENSE_PORT }}
-      TYPESENSE_PROTOCOL: ${{ secrets.TYPESENSE_PROTOCOL }}
-      TYPESENSE_SEARCH_KEY: ${{ secrets.TYPESENSE_SEARCH_KEY }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
 

--- a/apps/web/docs/company-og-cache.md
+++ b/apps/web/docs/company-og-cache.md
@@ -30,15 +30,16 @@ reusing the same objects.
 `.github/workflows/prewarm-company-og-cache.yml` runs on renderer/font changes,
 company registry changes, weekly reconciliation, and manual dispatch. It:
 
-1. Reads all company documents from Typesense in bounded pages.
+1. Reads companies, localized descriptions, and industries from the same
+   versioned CSV sources that feed production.
 2. Lists the current R2 namespace once and skips existing locale/slug objects.
 3. Renders the same `ImageResponse` card on a GitHub runner.
 4. Uploads missing PNGs to R2 with bounded concurrency and retries.
 5. Fails the run if any card cannot be rendered or uploaded.
 
-The production GitHub environment supplies the scoped Typesense search key and
-R2 write credentials. No request is sent through the deployed OG route, so a
-prewarm consumes no Vercel Fluid CPU.
+The production GitHub environment supplies R2 write credentials. The job has
+no dependency on the public Typesense tunnel and sends no request through the
+deployed OG route, so a prewarm consumes no Vercel Fluid CPU.
 
 Run a bounded canary before a forced/full reconciliation:
 
@@ -90,10 +91,6 @@ Vercel runtime/build:
 GitHub Production environment:
 
 - the same R2 connection values
-- `TYPESENSE_HOST`
-- `TYPESENSE_PORT`
-- `TYPESENSE_PROTOCOL`
-- `TYPESENSE_SEARCH_KEY`
 - optional `COMPANY_OG_RENDERER_VERSION_SALT` variable
 
 Vercel project env vars are not automatically visible inside `pnpm turbo run
@@ -149,7 +146,8 @@ an unbounded number of objects.
 
 ## Tradeoff
 
-The cache key is renderer-versioned, not company-data-versioned. Company name,
-logo, description, and count changes can leave an existing OG image stale until
-the renderer version changes or a force control is used. That matches the
-existing cache policy while moving the expensive render work off Vercel.
+The cache key is renderer-versioned, not company-data-versioned. Push-triggered
+prewarms therefore force-replace the current namespace when a company source
+changes; scheduled reconciliation skips existing objects. Route-level CDN
+responses can remain cached until their existing cache policy expires, while
+new requests read the updated R2 object without using Vercel CPU to render it.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -50,6 +50,7 @@
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^2.0.0",
     "better-auth": "^1.6.26",
+    "csv-parse": "^6.1.0",
     "dompurify": "^3.4.13",
     "drizzle-orm": "^0.45.2",
     "entities": "^8.0.0",

--- a/apps/web/script/prewarm-company-og-cache.ts
+++ b/apps/web/script/prewarm-company-og-cache.ts
@@ -1,7 +1,7 @@
 /**
  * Pre-render company Open Graph cards outside Vercel Functions.
  *
- * The script pages through the production Typesense company collection once,
+ * The script reads the versioned company sources that feed production,
  * renders the exact same Satori card used by the Next.js fallback route, and
  * uploads only missing objects in the current renderer-version namespace.
  */
@@ -10,8 +10,10 @@ import {
   PutObjectCommand,
   S3Client,
 } from "@aws-sdk/client-s3";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
-import { Client as TypesenseClient } from "typesense";
+import { parse } from "csv-parse/sync";
 import {
   logExternalError,
   safeExternalError,
@@ -26,8 +28,8 @@ import { computeCompanyOgRendererVersion } from "@/lib/og/company-og-renderer-ve
 const ALL_LOCALES = ["en", "de", "fr", "it"] as const;
 const CONTENT_TYPE = "image/png";
 const CACHE_CONTROL = "public, max-age=31536000, immutable";
-const TYPESENSE_PAGE_SIZE = 250;
-export const TYPESENSE_BATCH_TIMEOUT_SECONDS = 30;
+const COMPANY_SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const COMPANY_DATA_DIR = resolve(process.cwd(), "../crawler/data");
 
 class PrewarmExternalError extends Error {
   constructor(
@@ -142,56 +144,132 @@ function createR2Client(): { client: S3Client; bucket: string } {
   };
 }
 
-function createPrewarmTypesenseClient(): TypesenseClient {
-  const host = requiredEnvironment("TYPESENSE_HOST");
-  const port = Number.parseInt(requiredEnvironment("TYPESENSE_PORT"), 10);
-  const protocol = requiredEnvironment("TYPESENSE_PROTOCOL");
-  const apiKey = requiredEnvironment("TYPESENSE_SEARCH_KEY");
-  if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) {
-    throw new Error("TYPESENSE_PORT must be a valid TCP port");
-  }
-
-  // Batch jobs traverse the public Cloudflare tunnel from a GitHub runner and
-  // need a wider timeout than latency-sensitive production requests. Keep
-  // this isolated from getSearchClient(), whose five-second budget is correct
-  // for interactive web traffic.
-  return new TypesenseClient({
-    nodes: [{ host, port, protocol }],
-    apiKey,
-    connectionTimeoutSeconds: TYPESENSE_BATCH_TIMEOUT_SECONDS,
-    numRetries: 1,
-    retryIntervalSeconds: 1,
-  });
+function parseCsv(source: string, label: string): Record<string, string>[] {
+  const rows = parse(source, {
+    bom: true,
+    columns: true,
+    relax_column_count: false,
+    skip_empty_lines: true,
+  }) as Record<string, string>[];
+  if (rows.length === 0) throw new Error(`${label} must contain at least one row`);
+  return rows;
 }
 
-async function listCompanies(
-  client: TypesenseClient,
-  maxCompanies: number | null,
-) {
-  const companies: Record<string, unknown>[] = [];
-  let page = 1;
+function value(row: Record<string, string>, field: string): string | null {
+  const candidate = row[field]?.trim();
+  return candidate ? candidate : null;
+}
 
-  while (true) {
-    const result = await withRetry(
-      () => client.collections<Record<string, unknown>>("company")
-        .documents()
-        .search({
-          q: "*",
-          per_page: TYPESENSE_PAGE_SIZE,
-          page,
-        }),
-      1_000,
-    );
-    const hits = result.hits ?? [];
-    for (const hit of hits) {
-      companies.push(hit.document);
-      if (maxCompanies && companies.length >= maxCompanies) return companies;
+function optionalInteger(
+  row: Record<string, string>,
+  field: string,
+  context: string,
+): number | null {
+  const candidate = value(row, field);
+  if (!candidate) return null;
+  const parsed = Number.parseInt(candidate, 10);
+  if (!Number.isSafeInteger(parsed) || String(parsed) !== candidate) {
+    throw new Error(`${context}.${field} must be an integer`);
+  }
+  return parsed;
+}
+
+/** Build the Typesense-compatible records consumed by the shared card mapper. */
+export function buildCompanyDocuments(
+  companiesSource: string,
+  descriptionsSource: string,
+  industriesSource: string,
+  maxCompanies: number | null,
+): Record<string, unknown>[] {
+  const companyRows = parseCsv(companiesSource, "companies.csv");
+  const descriptionRows = parseCsv(descriptionsSource, "company_descriptions.csv");
+  const industryRows = parseCsv(industriesSource, "industries.csv");
+
+  const industries = new Map<number, string>();
+  for (const row of industryRows) {
+    const id = optionalInteger(row, "id", "industry");
+    const name = value(row, "en") ?? value(row, "name");
+    if (id === null || id < 1 || !name) {
+      throw new Error("Every industry must have a positive id and a name");
     }
-    if (hits.length < TYPESENSE_PAGE_SIZE || companies.length >= result.found) break;
-    page += 1;
+    if (industries.has(id)) throw new Error(`Duplicate industry id: ${id}`);
+    industries.set(id, name);
   }
 
-  return companies;
+  const descriptions = new Map<string, Record<string, string>>();
+  for (const row of descriptionRows) {
+    const slug = value(row, "slug");
+    if (!slug || !COMPANY_SLUG.test(slug)) {
+      throw new Error("Every company description must have a valid slug");
+    }
+    if (descriptions.has(slug)) {
+      throw new Error(`Duplicate company description slug: ${slug}`);
+    }
+    descriptions.set(slug, row);
+  }
+
+  const seenSlugs = new Set<string>();
+  const documents = companyRows.map((row) => {
+    const slug = value(row, "slug");
+    const name = value(row, "name");
+    if (!slug || !COMPANY_SLUG.test(slug) || !name) {
+      throw new Error("Every company must have a valid slug and name");
+    }
+    if (seenSlugs.has(slug)) throw new Error(`Duplicate company slug: ${slug}`);
+    seenSlugs.add(slug);
+
+    const industryId = optionalInteger(row, "industry", `company.${slug}`);
+    const industryName = industryId === null ? null : industries.get(industryId);
+    if (industryId !== null && !industryName) {
+      throw new Error(`company.${slug}.industry references missing id ${industryId}`);
+    }
+
+    const document: Record<string, unknown> = {
+      id: slug,
+      name,
+      slug,
+      active_posting_count: 0,
+    };
+    const directFields = [
+      ["icon", "icon_url"],
+      ["logo", "logo_url"],
+      ["website", "website"],
+    ] as const;
+    for (const [target, source] of directFields) {
+      const fieldValue = value(row, source);
+      if (fieldValue) document[target] = fieldValue;
+    }
+
+    if (industryId !== null) document.industry_id = industryId;
+    if (industryName) document.industry_name = industryName;
+    for (const field of ["employee_count_range", "founded_year"] as const) {
+      const fieldValue = optionalInteger(row, field, `company.${slug}`);
+      if (fieldValue !== null) document[field] = fieldValue;
+    }
+
+    const localizedDescriptions = descriptions.get(slug);
+    for (const locale of ALL_LOCALES) {
+      const description = localizedDescriptions
+        ? value(localizedDescriptions, locale)
+        : null;
+      if (!description) continue;
+      document[locale === "en" ? "description" : `description_${locale}`] =
+        description;
+    }
+
+    return document;
+  });
+
+  return maxCompanies ? documents.slice(0, maxCompanies) : documents;
+}
+
+function listCompanies(maxCompanies: number | null): Record<string, unknown>[] {
+  return buildCompanyDocuments(
+    readFileSync(resolve(COMPANY_DATA_DIR, "companies.csv"), "utf8"),
+    readFileSync(resolve(COMPANY_DATA_DIR, "company_descriptions.csv"), "utf8"),
+    readFileSync(resolve(COMPANY_DATA_DIR, "industries.csv"), "utf8"),
+    maxCompanies,
+  );
 }
 
 async function listExistingKeys(
@@ -285,37 +363,26 @@ export async function main() {
   const options = parseOptions(process.argv.slice(2));
   if (!options.yes) throw new Error(`R2 writes require --yes.\n\n${usage()}`);
 
-  // Validate Typesense configuration before any R2 writes begin.
-  const typesenseClient = createPrewarmTypesenseClient();
-
   const rendererVersion = options.rendererVersion ??
     computeCompanyOgRendererVersion(process.cwd());
   const prefix = `og/company/${rendererVersion}/`;
   const { client, bucket } = createR2Client();
-  const [companies, existingKeys] = await Promise.all([
-    listCompanies(typesenseClient, options.maxCompanies).catch((error) => {
-      throw new PrewarmExternalError(
-        "typesense",
-        "list_company_og_source",
-        error,
-      );
-    }),
-    options.force
-      ? Promise.resolve(new Set<string>())
-      : listExistingKeys(client, bucket, prefix).catch((error) => {
-          throw new PrewarmExternalError(
-            "r2",
-            "list_company_og_cache",
-            error,
-          );
-        }),
-  ]);
+  const companies = listCompanies(options.maxCompanies);
+  const existingKeys = options.force
+    ? new Set<string>()
+    : await listExistingKeys(client, bucket, prefix).catch((error) => {
+        throw new PrewarmExternalError(
+          "r2",
+          "list_company_og_cache",
+          error,
+        );
+      });
 
   const tasks: RenderTask[] = [];
   let skipped = 0;
   for (const company of companies) {
     const slug = typeof company.slug === "string" ? company.slug : "";
-    if (!slug) throw new Error(`Typesense company document ${String(company.id)} has no slug`);
+    if (!slug) throw new Error(`Company document ${String(company.id)} has no slug`);
     for (const locale of options.locales) {
       const key = companyOgCacheKeyForVersion(rendererVersion, locale, slug);
       if (existingKeys.has(key)) {

--- a/apps/web/src/lib/og/__tests__/company-og-cache.test.ts
+++ b/apps/web/src/lib/og/__tests__/company-og-cache.test.ts
@@ -114,15 +114,18 @@ describe("company OG cache", () => {
     expect(mocks.s3Send).not.toHaveBeenCalled();
   });
 
-  it("treats a public R2 404 as a cache miss without loading the AWS SDK", async () => {
+  it("falls back to a signed read when the public CDN has a stale 404", async () => {
     setTestEnv({ R2_DOMAIN_URL: "https://assets.example.test" });
+    configureR2Env();
     mockPublicResponse(404);
+    const transformToByteArray = vi.fn().mockResolvedValue(new Uint8Array([3, 2, 1]));
+    mocks.s3Send.mockResolvedValueOnce({ Body: { transformToByteArray } });
     const { readCompanyOgCache } = await import("../company-og-cache");
 
-    await expect(
-      readCompanyOgCache("og/company/x/en/missing.png"),
-    ).resolves.toBeNull();
-    expect(mocks.s3Send).not.toHaveBeenCalled();
+    const bytes = await readCompanyOgCache("og/company/x/en/prewarmed.png");
+
+    expect(Array.from(bytes ?? [])).toEqual([3, 2, 1]);
+    expect(mocks.s3Send).toHaveBeenCalledOnce();
   });
 
   it("soft-disables reads and writes when R2 is not configured", async () => {

--- a/apps/web/src/lib/og/__tests__/company-og-prewarm.test.ts
+++ b/apps/web/src/lib/og/__tests__/company-og-prewarm.test.ts
@@ -1,13 +1,60 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildCompanyDocuments,
   parseOptions,
-  TYPESENSE_BATCH_TIMEOUT_SECONDS,
   withRetry,
 } from "../../../../script/prewarm-company-og-cache";
 
 describe("company OG prewarm CLI", () => {
-  it("uses a batch-only Typesense timeout without changing the web client", () => {
-    expect(TYPESENSE_BATCH_TIMEOUT_SECONDS).toBe(30);
+  it("builds localized card data from the repository sources", () => {
+    const documents = buildCompanyDocuments(
+      [
+        "slug,name,website,logo_url,icon_url,logo_type,industry,employee_count_range,founded_year,extras",
+        "acme,Acme,https://acme.test,,https://assets.test/acme.png,icon,1,3,1999,",
+      ].join("\n"),
+      [
+        "slug,en,de,fr,it",
+        "acme,English description,Deutsche Beschreibung,,",
+      ].join("\n"),
+      ["id,name,keywords", "1,Technology,software"].join("\n"),
+      null,
+    );
+
+    expect(documents).toEqual([{
+      id: "acme",
+      name: "Acme",
+      slug: "acme",
+      active_posting_count: 0,
+      icon: "https://assets.test/acme.png",
+      website: "https://acme.test",
+      industry_id: 1,
+      industry_name: "Technology",
+      employee_count_range: 3,
+      founded_year: 1999,
+      description: "English description",
+      description_de: "Deutsche Beschreibung",
+    }]);
+  });
+
+  it("loads and validates every production company source row", async () => {
+    const { readFile } = await import("node:fs/promises");
+    const companies = await readFile("../crawler/data/companies.csv", "utf8");
+    const descriptions = await readFile(
+      "../crawler/data/company_descriptions.csv",
+      "utf8",
+    );
+    const industries = await readFile("../crawler/data/industries.csv", "utf8");
+
+    const documents = buildCompanyDocuments(
+      companies,
+      descriptions,
+      industries,
+      null,
+    );
+
+    expect(documents.length).toBeGreaterThan(5_000);
+    expect(new Set(documents.map((company) => company.slug)).size)
+      .toBe(documents.length);
   });
 
   it("parses bounded canary options passed through pnpm", () => {

--- a/apps/web/src/lib/og/company-og-cache.ts
+++ b/apps/web/src/lib/og/company-og-cache.ts
@@ -137,7 +137,6 @@ export async function readCompanyOgCache(
     try {
       const result = await readPublicObject(publicUrl);
       if (result.bytes) return result.bytes;
-      if (result.status === 404) return null;
     } catch (error) {
       logExternalError(
         "warn",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,6 +225,9 @@ importers:
       better-auth:
         specifier: ^1.6.26
         version: 1.6.26(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@neondatabase/serverless@1.0.2)(@opentelemetry/api@1.9.0)(@types/pg@8.16.0)(@upstash/redis@1.38.2)(kysely@0.29.2)(postgres@3.4.9))(next@16.2.11(patch_hash=104a5ec79255d25fa9722b3db1a6c8f6b0f5aa0f742ac82bff2e6fdb6b54c6c6)(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vitest@4.1.10)
+      csv-parse:
+        specifier: ^6.1.0
+        version: 6.2.1
       dompurify:
         specifier: ^3.4.13
         version: 3.4.13
@@ -2892,6 +2895,9 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  csv-parse@6.2.1:
+    resolution: {integrity: sha512-LRLMV+UCyfMokp8Wb411duBf1gaBKJfOfBWU9eHMJ+b+cJYZsNu3AFmjJf3+yPGd59Exz1TsMjaSFyxnYB9+IQ==}
 
   d3-array@2.12.1:
     resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
@@ -7754,6 +7760,8 @@ snapshots:
       css-tree: 2.2.1
 
   csstype@3.2.3: {}
+
+  csv-parse@6.2.1: {}
 
   d3-array@2.12.1:
     dependencies:


### PR DESCRIPTION
## Summary
- remove the unreachable public Typesense tunnel from the GitHub OG prewarm path
- build exact localized card documents from the versioned companies, descriptions, and industries CSV sources
- force-replace stable-namespace cards on source pushes while keeping scheduled reconciliation incremental
- fall through to signed R2 reads when a public CDN 404 is stale, avoiding repeat ImageResponse rendering

## Validation
- all 5,000+ production company source rows parsed and validated in a focused test
- 14 OG prewarm/cache tests
- focused ESLint
- web typecheck
- zizmor workflow audit
- git diff --check

Refs #6613

This supersedes the failed Typesense timeout retries in #6647 without changing production company-page reads.