### PR TITLE
Expire browser Typesense scoped keys

### DIFF
--- a/apps/web/app/api/typesense-key/route.test.ts
+++ b/apps/web/app/api/typesense-key/route.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { setTestEnv, withTestEnv } from "@/test-utils/env";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  getSessionUserId: vi.fn<() => Promise<string | null>>(),
+}));
+
+vi.mock("@/lib/sessionCache", () => ({
+  getSessionUserId: mocks.getSessionUserId,
+}));
+
+import { GET } from "./route";
+
+const NOW_SECONDS = 2_000_000_000;
+const PARENT_KEY = "test-parent-key-abcdef0123456789";
+
+withTestEnv({
+  TYPESENSE_BROWSER_PARENT_KEY: PARENT_KEY,
+  TYPESENSE_HOST: "typesense.example",
+  TYPESENSE_PORT: "443",
+  TYPESENSE_PROTOCOL: "https",
+});
+
+function decodeEmbed(apiKey: string): Record<string, unknown> {
+  const decoded = Buffer.from(apiKey, "base64").toString("utf-8");
+  return JSON.parse(decoded.slice(48)) as Record<string, unknown>;
+}
+
+describe("GET /api/typesense-key", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_SECONDS * 1000 + 789);
+    mocks.getSessionUserId.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("signs anonymous expiry and derives metadata from the same timestamp", async () => {
+    mocks.getSessionUserId.mockResolvedValue(null);
+
+    const response = await GET();
+    const body = (await response.json()) as { apiKey: string; expiresAt: number };
+
+    expect(response.status).toBe(200);
+    expect(decodeEmbed(body.apiKey)).toEqual({
+      use_cache: true,
+      expires_at: NOW_SECONDS + 300,
+    });
+    expect(body.expiresAt).toBe((NOW_SECONDS + 300) * 1000);
+    expect(response.headers.get("cache-control")).toBe(
+      "public, s-maxage=150, max-age=0",
+    );
+  });
+
+  it("signs authenticated expiry beyond the private response cache", async () => {
+    mocks.getSessionUserId.mockResolvedValue("user-1");
+
+    const response = await GET();
+    const body = (await response.json()) as { apiKey: string; expiresAt: number };
+
+    expect(decodeEmbed(body.apiKey)).toEqual({
+      use_cache: true,
+      expires_at: NOW_SECONDS + 600,
+    });
+    expect(body.expiresAt).toBe((NOW_SECONDS + 600) * 1000);
+    expect(response.headers.get("cache-control")).toBe("private, max-age=300");
+  });
+
+  it("does not mint a key when the browser parent is unavailable", async () => {
+    mocks.getSessionUserId.mockResolvedValue(null);
+    setTestEnv({ TYPESENSE_BROWSER_PARENT_KEY: undefined });
+
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+    await expect(response.json()).resolves.toEqual({
+      error: "search not configured",
+    });
+  });
+});

--- a/apps/web/app/api/typesense-key/route.ts
+++ b/apps/web/app/api/typesense-key/route.ts
@@ -21,15 +21,21 @@ export async function GET() {
 
   const userId = await getSessionUserId();
   const ttl = userId ? AUTHED_TTL_SECONDS : ANON_TTL_SECONDS;
+  const expiresAtSeconds = Math.floor(Date.now() / 1000) + ttl;
 
   // limit_hits is intentionally omitted: it counts raw hits (not grouped rows),
   // so it would block normal anon traffic that uses group_by company_id with
   // group_limit 10. Anon truncation is enforced as a soft client-side cap; the
   // Cloudflare per-IP rate-limit on typesense.colophon-group.org is the real
   // abuse brake.
-  const apiKey = generateScopedSearchKey(parentKey, { use_cache: true });
+  const apiKey = generateScopedSearchKey(parentKey, {
+    use_cache: true,
+    expires_at: expiresAtSeconds,
+  });
 
-  const expiresAt = Date.now() + ttl * 1000;
+  // Keep browser metadata on the exact signed boundary. Typesense validates
+  // expires_at as Unix seconds while the browser cache consumes milliseconds.
+  const expiresAt = expiresAtSeconds * 1000;
   const cacheControl = userId
     ? `private, max-age=${Math.floor(ttl / 2)}`
     : `public, s-maxage=${Math.floor(ttl / 2)}, max-age=0`;

--- a/apps/web/src/lib/search/__tests__/scoped-key.test.ts
+++ b/apps/web/src/lib/search/__tests__/scoped-key.test.ts
@@ -3,6 +3,7 @@ import { Client } from "typesense";
 import { generateScopedSearchKey } from "../scoped-key";
 
 const PARENT = "test-parent-key-abcdef0123456789";
+const EXPIRES_AT = 2_000_000_000;
 
 describe("generateScopedSearchKey", () => {
   it("matches typesense-js Client.keys().generateScopedSearchKey output", () => {
@@ -10,25 +11,43 @@ describe("generateScopedSearchKey", () => {
       apiKey: PARENT,
       nodes: [{ host: "x", port: 1, protocol: "http" }],
     });
-    const ours = generateScopedSearchKey(PARENT, { use_cache: true });
-    const theirs = client.keys().generateScopedSearchKey(PARENT, { use_cache: true });
+    const ours = generateScopedSearchKey(PARENT, {
+      use_cache: true,
+      expires_at: EXPIRES_AT,
+    });
+    const theirs = client.keys().generateScopedSearchKey(PARENT, {
+      use_cache: true,
+      expires_at: EXPIRES_AT,
+    });
     expect(ours).toBe(theirs);
   });
 
   it("changes output when embed parameters change", () => {
-    const a = generateScopedSearchKey(PARENT, { use_cache: true });
-    const b = generateScopedSearchKey(PARENT, { use_cache: false });
+    const a = generateScopedSearchKey(PARENT, {
+      use_cache: true,
+      expires_at: EXPIRES_AT,
+    });
+    const b = generateScopedSearchKey(PARENT, {
+      use_cache: false,
+      expires_at: EXPIRES_AT,
+    });
     expect(a).not.toBe(b);
   });
 
   it("decodes to a valid Typesense scoped key envelope", () => {
-    const key = generateScopedSearchKey(PARENT, { filter_by: "is_active:true" });
+    const key = generateScopedSearchKey(PARENT, {
+      filter_by: "is_active:true",
+      expires_at: EXPIRES_AT,
+    });
     const decoded = Buffer.from(key, "base64").toString("utf-8");
     // Format: <44-char base64 hmac><4-char prefix><params json>
     expect(decoded.length).toBeGreaterThan(48);
     const prefix = decoded.slice(44, 48);
     expect(prefix).toBe(PARENT.slice(0, 4));
     const params = decoded.slice(48);
-    expect(JSON.parse(params)).toEqual({ filter_by: "is_active:true" });
+    expect(JSON.parse(params)).toEqual({
+      filter_by: "is_active:true",
+      expires_at: EXPIRES_AT,
+    });
   });
 });

--- a/apps/web/src/lib/search/__tests__/typesense-browser-key.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense-browser-key.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const NOW_MS = 2_000_000_000_000;
+
+describe("getTypesenseBrowserConfig", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW_MS);
+    vi.stubGlobal("BroadcastChannel", undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("refreshes a signed key before its server-enforced expiry", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(Response.json({
+        apiKey: "first-key",
+        host: "typesense.example",
+        port: 443,
+        protocol: "https",
+        expiresAt: NOW_MS + 60_000,
+      }))
+      .mockResolvedValueOnce(Response.json({
+        apiKey: "second-key",
+        host: "typesense.example",
+        port: 443,
+        protocol: "https",
+        expiresAt: NOW_MS + 120_000,
+      }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { getTypesenseBrowserConfig } = await import("../typesense-browser-key");
+
+    await expect(getTypesenseBrowserConfig()).resolves.toMatchObject({
+      apiKey: "first-key",
+    });
+    await expect(getTypesenseBrowserConfig()).resolves.toMatchObject({
+      apiKey: "first-key",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(31_000);
+
+    await expect(getTypesenseBrowserConfig()).resolves.toMatchObject({
+      apiKey: "second-key",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/lib/search/__tests__/typesense.e2e.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense.e2e.test.ts
@@ -19,6 +19,7 @@ import { Client } from "typesense";
 import { withTestEnvForAll } from "@/test-utils/env";
 import type { CollectionCreateSchema } from "typesense/lib/Typesense/Collections";
 import { TypesenseSearchProvider } from "../typesense";
+import { generateScopedSearchKey } from "../scoped-key";
 
 // ── Constants ───────────────────────────────────────────────────────
 
@@ -481,6 +482,43 @@ function skipIfUnavailable() {
   }
   return false;
 }
+
+describe("scoped search key expiry", () => {
+  it("accepts a live key and rejects a past expires_at on Typesense 27.1", async () => {
+    if (skipIfUnavailable()) return;
+
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const parent = await adminClient.keys().create({
+      actions: ["documents:search"],
+      collections: [JOB_POSTING_COLLECTION],
+      description: "scoped expiry E2E parent",
+      expires_at: nowSeconds + 3_600,
+    });
+    if (!parent.value) throw new Error("Typesense did not return the test parent key");
+
+    const search = (apiKey: string) =>
+      fetch(
+        `http://localhost:8108/collections/${JOB_POSTING_COLLECTION}/documents/search?q=*&query_by=title`,
+        { headers: { "x-typesense-api-key": apiKey } },
+      );
+
+    try {
+      const liveKey = generateScopedSearchKey(parent.value, {
+        use_cache: true,
+        expires_at: nowSeconds + 60,
+      });
+      const expiredKey = generateScopedSearchKey(parent.value, {
+        use_cache: true,
+        expires_at: nowSeconds - 1,
+      });
+
+      await expect(search(liveKey)).resolves.toMatchObject({ status: 200 });
+      await expect(search(expiredKey)).resolves.toMatchObject({ status: 401 });
+    } finally {
+      await adminClient.keys(parent.id).delete();
+    }
+  });
+});
 
 // =====================================================================
 // SearchProvider.search()

--- a/apps/web/src/lib/search/scoped-key.ts
+++ b/apps/web/src/lib/search/scoped-key.ts
@@ -1,6 +1,7 @@
 import { createHmac } from "node:crypto";
 
 export interface ScopedKeyEmbed {
+  expires_at: number;
   filter_by?: string;
   exclude_fields?: string;
   use_cache?: boolean;

--- a/docs/11-typesense.md
+++ b/docs/11-typesense.md
@@ -59,10 +59,36 @@ part of a Git branch.
 | `TYPESENSE_OPERATIONS_KEY` | Generated key: `collections:*`, `documents:*`, `aliases:*` on all collections, plus `metrics.json:list` | Exporter, sync, backfill, setup, reconciliation, health metrics | Private network (crawler -> Typesense) |
 | `TYPESENSE_BACKUP_KEY` | Generated, revocable wildcard key | Root-owned Typesense Snapshot API backup service only | Loopback on Typesense host |
 | `TYPESENSE_SEARCH_KEY` | `documents:search` + `documents:get` on all collections | Web app server-side search (server actions) | Cloudflare tunnel |
-| `TYPESENSE_BROWSER_PARENT_KEY` | `documents:search` on all collections (no other action) | Web app `/api/typesense-key` route handler -- mints scoped keys for direct browser->Typesense calls | Cloudflare tunnel (browser, scoped key) |
+| `TYPESENSE_BROWSER_PARENT_KEY` | `documents:search` only on `job_posting`, `company`, `location`, `occupation`, `seniority`, and `technology` | Web app `/api/typesense-key` route handler -- mints scoped keys for direct browser->Typesense calls | Cloudflare tunnel (browser, scoped key) |
 | `TYPESENSE_WRITE_KEY` | `documents:create/upsert/delete/update` on `watchlist` collection only | Web app watchlist mutations | Cloudflare tunnel |
 
 `TYPESENSE_BROWSER_PARENT_KEY` is a separate parent because Typesense rejects scoped keys derived from a parent that has any actions other than `documents:search` (the server returns `Forbidden - a valid x-typesense-api-key header must be sent.` when used with a multi-action parent).
+The six named collections are the complete direct-browser read set. In
+particular, the browser watchlist path searches `job_posting`; it does not read
+the `watchlist` collection. Do not grant the parent wildcard collection access.
+
+Browser scoped keys embed a server-enforced `expires_at` Unix timestamp: five
+minutes for anonymous sessions and ten minutes for authenticated sessions.
+`/api/typesense-key` returns that same boundary in milliseconds for the browser
+cache, which refreshes 30 seconds early. Its response cache max-age is half the
+credential lifetime, so a cached response cannot outlive the signed key.
+
+### Browser parent-key rotation
+
+Rotate `TYPESENSE_BROWSER_PARENT_KEY` after deploying an expiry-policy change
+and on the normal credential-rotation schedule:
+
+1. Create a generated parent with the sole action `documents:search`, exactly
+   the six collections above, and an expiry later than any scoped child expiry.
+2. Replace the protected Vercel `TYPESENSE_BROWSER_PARENT_KEY` value and deploy
+   the web app.
+3. Fetch `/api/typesense-key`, decode its scoped payload to confirm
+   `expires_at`, and perform a browser-path search with the new child key.
+4. Delete the old parent in Typesense. Confirm a child captured from the old
+   parent now receives HTTP 401; revoking a parent invalidates all children
+   derived from it.
+
+Never delete the old parent before the new web deployment is serving keys.
 
 Typesense 27.1 does not accept a generated key restricted to
 `operations:snapshot` or `operations:*` for `POST /operations/snapshot`; a
@@ -362,7 +388,7 @@ The web app can bypass the Vercel server-action proxy and call Typesense directl
 
 **Infrastructure:**
 
-- **Scoped key endpoint** (`GET /api/typesense-key`): mints a Typesense scoped search key (HMAC-SHA256 + base64) from `TYPESENSE_BROWSER_PARENT_KEY`. Embed is just `{ use_cache: true }`. `limit_hits` is intentionally **not** embedded because Typesense counts raw hits (not grouped rows) and would block normal anon traffic on `group_by company_id` with `group_limit 10`.
+- **Scoped key endpoint** (`GET /api/typesense-key`): mints a Typesense scoped search key (HMAC-SHA256 + base64) from `TYPESENSE_BROWSER_PARENT_KEY`. The embed is `{ use_cache: true, expires_at: <Unix seconds> }`. `limit_hits` is intentionally **not** embedded because Typesense counts raw hits (not grouped rows) and would block normal anon traffic on `group_by company_id` with `group_limit 10`.
 - **TTL**: 5 min for anon, 10 min for authed. Browser caches the key in memory and refreshes 30 s before expiry. The cache is cleared via `useClearTypesenseOnAuthChange(isLoggedIn)` (called from each client surface) so a sign-in/out doesn't keep the wrong key.
 - **Browser provider**: `apps/web/src/lib/search/typesense-browser.ts` (postings/companies), `typesense-browser-typeahead.ts` (taxonomy suggest), `typesense-browser-watchlist.ts`. All thin -- no `typesense-js` runtime dependency in the browser bundle.
 - **Anon truncation**: enforced as a soft client-side cap (`ANON_MAX_COMPANIES`, `ANON_MAX_POSTINGS`, `ANON_MAX_WATCHLIST_POSTINGS`) matching the current server-action behaviour. Real abuse protection is the Cloudflare per-IP rate-limit on the tunnel hostname.
@@ -427,5 +453,5 @@ environment variables:
 | `TYPESENSE_BOOTSTRAP_KEY` | Root-only server bootstrap key; protected deployment secret, never a crawler/web variable |
 | `TYPESENSE_BACKUP_KEY` | Root-only generated backup key; protected deployment secret |
 | `TYPESENSE_SEARCH_KEY` | Search/read key for web server-side Typesense calls (via tunnel uses `https`) |
-| `TYPESENSE_BROWSER_PARENT_KEY` | Search-only parent key for `/api/typesense-key` scoped browser keys |
+| `TYPESENSE_BROWSER_PARENT_KEY` | `documents:search`-only parent for scoped browser keys, limited to `job_posting`, `company`, `location`, `occupation`, `seniority`, and `technology` |
 | `TYPESENSE_WRITE_KEY` | Watchlist write key (web app) |


### PR DESCRIPTION
## Summary

- sign every browser scoped key with a Typesense-enforced expires_at timestamp and derive browser metadata from the same value
- preserve the 300/600-second anonymous/authenticated lifetimes with response caches limited to half that duration
- verify route behavior, pre-expiry client refresh, official-client key compatibility, and real Typesense 27.1 rejection of an expired key
- document the exact six-collection browser parent scope and safe rotation order

## Recon

The report is valid when direct browser search is enabled: the old endpoint signed only use_cache, while expiresAt was unsigned client metadata. A copied bearer therefore remained usable until parent revocation.

The direct browser readers use job_posting, company, location, occupation, seniority, and technology. They do not read the watchlist collection, so the replacement parent should be limited to those six and documents:search only.

## Verification

- 231 web test files / 1,644 tests passed
- focused route, scoped-key, browser refresh, and auth-change tests passed
- web typecheck passed
- web lint passed
- real Typesense 27.1 expiry test added to the existing required E2E job

## Operations required after deployment

This PR intentionally references rather than closes #6124. After the new endpoint is deployed, create and deploy the six-collection parent, verify a newly issued child, delete the old parent, and confirm an old child receives HTTP 401. The issue should close only after that production rotation is recorded.

Refs #6124