### PR TITLE
Reuse Explore PPR shells across filter URLs

### DIFF
--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -6,6 +6,7 @@ import { defaultLocale, locales, isLocale } from "@/lib/i18n";
 const COOKIE_NAME = "NEXT_LOCALE";
 const LOGGED_IN_HINT_COOKIE = "logged_in";
 const COMPANY_REQUEST_PATH = /^\/(en|de|fr|it)\/companies\/request$/;
+const LOCALIZED_EXPLORE_PATH = /^\/(?:en|de|fr|it)\/explore$/;
 const LOCALIZED_SCANNER_PATH =
   /^\/(?:en|de|fr|it)\/(?:(?:adminer|cgi-bin|phpmyadmin|wp-admin|wp-content|wp-includes|wp-json|xmlrpc|\.env|\.git)(?:\/|$)|[^/]+\/(?:\.env|\.git)(?:\/|$))/i;
 
@@ -35,6 +36,32 @@ export function proxy(request: NextRequest) {
       status: 404,
       headers: { "Cache-Control": "public, max-age=86400, s-maxage=86400" },
     });
+  }
+
+  // The Explore RSC shell does not read search params: filters are restored
+  // from the browser URL by ExploreContent after hydration. Normalize only
+  // full HTML document requests to the queryless internal URL so long-tail
+  // filter links share one PPR shell per locale instead of generating a new
+  // Fluid invocation for every query-string permutation.
+  //
+  // RSC navigations and Server Actions intentionally bypass this rewrite.
+  // Their framework query/header state is part of the request protocol and
+  // must reach Next unchanged.
+  if (
+    LOCALIZED_EXPLORE_PATH.test(request.nextUrl.pathname) &&
+    request.nextUrl.search &&
+    (request.method === "GET" || request.method === "HEAD") &&
+    request.headers.get("accept")?.includes("text/html") &&
+    request.headers.get("rsc") !== "1" &&
+    !request.headers.has("next-action")
+  ) {
+    const shellUrl = request.nextUrl.clone();
+    shellUrl.search = "";
+    return NextResponse.rewrite(shellUrl);
+  }
+
+  if (LOCALIZED_EXPLORE_PATH.test(request.nextUrl.pathname)) {
+    return NextResponse.next();
   }
 
   // The public IndexNow proof filename is derived from a secret at runtime and
@@ -109,6 +136,16 @@ export const config = {
   matcher: [
     "/((?!_next|api|mcp|flags|fonts|publicdomain|screenshots|\\.well-known|favicon\\.ico$|favicon-16x16\\.png$|favicon-32x32\\.png$|apple-touch-icon\\.png$|apple-touch-icon-[^/]+\\.png$|android-chrome-192x192\\.png$|android-chrome-512x512\\.png$|site\\.webmanifest$|BingSiteAuth\\.xml$|js_[^/]+\\.svg$|js_missing_screenshot_black\\.png$|js_missing_screenshot_white\\.png$|logo-dark\\.svg$|logo-light\\.svg$|opengraph-image|indexnow-key\\.txt$|llms\\.txt$|openapi\\.json$|openapi\\.yaml$|robots\\.txt$|sitemap\\.xml$|en|de|fr|it).*)",
     "/:lang(en|de|fr|it)/companies/request",
+    {
+      source: "/:lang(en|de|fr|it)/explore",
+      has: [
+        { type: "header", key: "accept", value: ".*text/html.*" },
+      ],
+      missing: [
+        { type: "header", key: "rsc", value: "1" },
+        { type: "header", key: "next-action" },
+      ],
+    },
     "/:lang(en|de|fr|it)/:probe(adminer|cgi-bin|phpmyadmin|wp-admin|wp-content|wp-includes|wp-json|xmlrpc|\\.env|\\.git)/:path*",
     "/:lang(en|de|fr|it)/:user/:probe(\\.env|\\.git)/:path*",
   ],

--- a/apps/web/src/lib/__tests__/proxy.test.ts
+++ b/apps/web/src/lib/__tests__/proxy.test.ts
@@ -161,6 +161,57 @@ describe("company request auth boundary", () => {
   });
 });
 
+describe("Explore PPR shell normalization", () => {
+  it("rewrites query-bearing HTML documents to the locale shell", () => {
+    const request = new NextRequest(
+      "http://localhost/en/explore?q=python&wm=remote",
+      { headers: { accept: "text/html,application/xhtml+xml" } },
+    );
+
+    const response = proxy(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-middleware-rewrite")).toBe(
+      "http://localhost/en/explore",
+    );
+    expect(request.nextUrl.search).toBe("?q=python&wm=remote");
+  });
+
+  it("does not rewrite queryless Explore documents", () => {
+    const response = proxy(
+      new NextRequest("http://localhost/en/explore", {
+        headers: { accept: "text/html" },
+      }),
+    );
+
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("preserves RSC navigation queries", () => {
+    const response = proxy(
+      new NextRequest("http://localhost/en/explore?q=python&_rsc=abc123", {
+        headers: { accept: "text/x-component", rsc: "1" },
+      }),
+    );
+
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("preserves Server Action queries", () => {
+    const response = proxy(
+      new NextRequest("http://localhost/en/explore?q=python", {
+        method: "POST",
+        headers: { accept: "text/x-component", "next-action": "action-id" },
+      }),
+    );
+
+    expect(response.headers.get("x-middleware-rewrite")).toBeNull();
+    expect(response.headers.get("x-middleware-next")).toBe("1");
+  });
+});
+
 describe("scanner path boundary", () => {
   it.each([
     "/en/wp-admin/install.php",
@@ -183,7 +234,7 @@ describe("proxy config", () => {
     expect(config.matcher.length).toBeGreaterThan(0);
   });
 
-  it("matches the localized company-request auth boundary only", () => {
+  it("matches localized proxy boundaries", () => {
     expect(
       unstable_doesMiddlewareMatch({
         config,
@@ -195,7 +246,30 @@ describe("proxy config", () => {
       unstable_doesMiddlewareMatch({
         config,
         nextConfig: {},
-        url: "/en/explore",
+        url: "/en/explore?q=python",
+        headers: { accept: "text/html,application/xhtml+xml" },
+      }),
+    ).toBe(true);
+  });
+
+  it("excludes Explore RSC and Server Action traffic before proxy compute", () => {
+    expect(
+      unstable_doesMiddlewareMatch({
+        config,
+        nextConfig: {},
+        url: "/en/explore?q=python&_rsc=abc123",
+        headers: { accept: "text/x-component", rsc: "1" },
+      }),
+    ).toBe(false);
+    expect(
+      unstable_doesMiddlewareMatch({
+        config,
+        nextConfig: {},
+        url: "/en/explore?q=python",
+        headers: {
+          accept: "text/x-component",
+          "next-action": "action-id",
+        },
       }),
     ).toBe(false);
   });
@@ -214,7 +288,6 @@ describe("proxy config", () => {
   it.each([
     "/en/alice/jobs",
     "/de/companies/acme",
-    "/fr/explore",
   ])("does not add proxy work to valid localized path %s", (url) => {
     expect(
       unstable_doesMiddlewareMatch({ config, nextConfig: {}, url }),


### PR DESCRIPTION
Closes #6653

## Why

Vercel's 15-minute route sample showed `/en/explore` serving roughly 50 dynamic PPR requests with only a 1.8–1.9% shell hit rate. The server page intentionally ignores `searchParams`; filters are hydrated by `ExploreContent` from the visible browser URL. Despite that, each long-tail query-string permutation was reaching the PPR route as a distinct document request and consuming Fluid CPU.

## What changed

- Route full HTML document requests for localized Explore URLs through the existing Next.js proxy.
- Internally rewrite query-bearing documents to the queryless locale shell while preserving the visible browser URL.
- Keep queryless documents unchanged.
- Exclude RSC navigations and Server Actions at the matcher boundary so they never start proxy compute and their protocol state remains untouched.
- Add handler and matcher regression coverage for document, queryless, RSC, and Server Action paths.

## Fluid CPU trade-off

Vercel Routing Middleware is itself billed on Fluid compute. This change therefore limits proxy matching to HTML documents and uses only local URL/header checks. Query-bearing documents should replace a full 45–200 ms page execution with a tiny rewrite plus a shared PPR hit; RSC and Server Action traffic does not invoke the proxy. Production rollout should compare both route CPU and proxy CPU before keeping the change.

## Verification

- 69 focused proxy/Explore tests pass.
- Web lint and typecheck pass.
- Production Next.js build passes and still classifies `/[lang]/explore` as a 10-minute Partial Prerender.
- Three local production-server requests (queryless and two distinct filter URLs) returned byte-identical 95,588-byte HTML with the same ETag and `x-nextjs-cache: HIT`; filter URLs exposed `x-middleware-rewrite: /en/explore`.
- An actual browser retained `/en/explore?q=python&wm=remote`, hydrated the Python and Remote filters, loaded live Typesense results, and cleared back to queryless Explore successfully.
- The one unrelated Similar Companies timing failure seen during a heavily concurrent full-suite run passed immediately in isolation; required CI remains the merge gate.
