### PR TITLE
Guard production against stale Vercel deployments

### DIFF
--- a/.github/scripts/verify-vercel-production-sha.sh
+++ b/.github/scripts/verify-vercel-production-sha.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${REPO:?REPO is required}"
+: "${DEFAULT_BRANCH:?DEFAULT_BRANCH is required}"
+: "${DEPLOYED_SHA:?DEPLOYED_SHA is required}"
+: "${DEPLOYMENT_URL:?DEPLOYMENT_URL is required}"
+
+if [[ ! "$REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+  printf 'Invalid REPO: %s\n' "$REPO" >&2
+  exit 2
+fi
+if [[ ! "$DEFAULT_BRANCH" =~ ^[A-Za-z0-9._/-]+$ ]]; then
+  printf 'Invalid DEFAULT_BRANCH: %s\n' "$DEFAULT_BRANCH" >&2
+  exit 2
+fi
+if [[ ! "$DEPLOYED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+  printf 'Invalid DEPLOYED_SHA: %s\n' "$DEPLOYED_SHA" >&2
+  exit 2
+fi
+if [[ ! "$DEPLOYMENT_URL" =~ ^https://[A-Za-z0-9.-]+\.vercel\.app/?$ ]]; then
+  printf 'Invalid DEPLOYMENT_URL: %s\n' "$DEPLOYMENT_URL" >&2
+  exit 2
+fi
+
+main_sha=$(gh api "repos/$REPO/commits/$DEFAULT_BRANCH" --jq .sha)
+if [[ ! "$main_sha" =~ ^[0-9a-f]{40}$ ]]; then
+  printf 'GitHub returned an invalid main SHA: %s\n' "$main_sha" >&2
+  exit 2
+fi
+
+if [[ "$DEPLOYED_SHA" == "$main_sha" ]]; then
+  printf '{"event":"vercel_production_sha_verified","sha":"%s","deploymentUrl":"%s"}\n' \
+    "$DEPLOYED_SHA" "$DEPLOYMENT_URL"
+  exit 0
+fi
+
+message="Vercel Production deployed $DEPLOYED_SHA, but $DEFAULT_BRANCH is $main_sha"
+printf '::error title=Stale Vercel Production deployment::%s. Inspect %s and promote the Ready main deployment only after smoke checks.\n' \
+  "$message" "$DEPLOYMENT_URL"
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    printf '## Stale Vercel Production deployment\n\n'
+    printf -- '- Deployment: `%s`\n' "$DEPLOYMENT_URL"
+    printf -- '- Deployed SHA: `%s`\n' "$DEPLOYED_SHA"
+    printf -- '- Current `%s` SHA: `%s`\n\n' "$DEFAULT_BRANCH" "$main_sha"
+    printf 'Smoke-test the Ready deployment for the current main SHA, then use `vercel promote <deployment>` to restore production.\n'
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
           scripts/crawler-host-hygiene.test.mjs
           scripts/docs-index.test.mjs
           scripts/dealroom-company-requests.test.mjs
+          scripts/vercel-production-sha.test.mjs
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/guard-vercel-production-order.yml
+++ b/.github/workflows/guard-vercel-production-order.yml
@@ -1,0 +1,33 @@
+name: Guard Vercel production order
+
+on:
+  deployment_status:
+
+permissions:
+  contents: read
+
+jobs:
+  verify-production-sha:
+    name: Verify Vercel production SHA
+    if: >-
+      github.event.deployment.environment == 'Production' &&
+      github.event.deployment_status.state == 'success' &&
+      contains(github.event.deployment_status.environment_url, '.vercel.app')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+      DEPLOYED_SHA: ${{ github.event.deployment.sha }}
+      DEPLOYMENT_URL: ${{ github.event.deployment_status.environment_url }}
+    steps:
+      # Always use the current guard implementation. The deployment event may
+      # point at an older commit that predates this workflow or its script.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Compare the successful deployment with main
+        run: bash .github/scripts/verify-vercel-production-sha.sh

--- a/docs/18-vercel-fluid-cpu.md
+++ b/docs/18-vercel-fluid-cpu.md
@@ -41,6 +41,21 @@ than 138.5 seconds in a comparable 12-hour window.
    long-tail route keys. Synthetic repeated requests do not satisfy this gate.
 8. Run the live checks below from production, then evaluate the JSON report.
 
+## Production deployment identity
+
+Do not start a measurement window until the deployment holding the production
+aliases is the current GitHub `main` SHA. Vercel completed two 2026-08-11 main
+deployments out of order and let an older parent commit reacquire `jseek.co`,
+temporarily undoing the company-OG cutover.
+
+The `Guard Vercel production order` workflow checks every successful Vercel
+Production deployment status against the live default-branch SHA. A mismatch
+fails with both SHAs and the deployment URL. Treat that failure as a production
+incident: inspect the Ready deployment for current main, run the functionality
+checks below against its protected URL, and only then use `vercel promote` to
+restore the aliases. The guard detects stale production; issue #6655 tracks a
+future staged-promotion flow that can correct it automatically.
+
 ## Live functionality checks
 
 All checks are mandatory:

--- a/scripts/vercel-production-sha.test.mjs
+++ b/scripts/vercel-production-sha.test.mjs
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import test from "node:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const deployedSha = "a".repeat(40);
+const currentMainSha = "b".repeat(40);
+
+function runGuard({
+  deployed = deployedSha,
+  main = deployedSha,
+  deploymentUrl = "https://jobseek-example.vercel.app",
+} = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "vercel-production-sha-"));
+  const gh = join(dir, "gh");
+  const summary = join(dir, "summary.md");
+  writeFileSync(
+    gh,
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$1" == "api" ]]; then
+  printf '%s\\n' "$MOCK_MAIN_SHA"
+  exit 0
+fi
+exit 64
+`,
+  );
+  chmodSync(gh, 0o755);
+
+  const result = spawnSync(
+    "bash",
+    [".github/scripts/verify-vercel-production-sha.sh"],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        PATH: `${dir}:${process.env.PATH}`,
+        GH_TOKEN: "test-token",
+        LANG: "C",
+        LC_ALL: "C",
+        REPO: "colophon-group/jobseek",
+        DEFAULT_BRANCH: "main",
+        DEPLOYED_SHA: deployed,
+        DEPLOYMENT_URL: deploymentUrl,
+        GITHUB_STEP_SUMMARY: summary,
+        MOCK_MAIN_SHA: main,
+      },
+      encoding: "utf8",
+    },
+  );
+
+  let summaryText = "";
+  try {
+    summaryText = readFileSync(summary, "utf8");
+  } catch {
+    // Successful checks do not need a job summary.
+  }
+  rmSync(dir, { recursive: true, force: true });
+  return { ...result, summaryText };
+}
+
+test("accepts a Vercel Production deployment at the current main SHA", () => {
+  const result = runGuard();
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /vercel_production_sha_verified/);
+  assert.equal(result.stderr, "");
+  assert.equal(result.summaryText, "");
+});
+
+test("fails visibly when a stale main ancestor reaches production", () => {
+  const result = runGuard({ main: currentMainSha });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /::error title=Stale Vercel Production deployment/);
+  assert.match(result.stdout, new RegExp(deployedSha));
+  assert.match(result.stdout, new RegExp(currentMainSha));
+  assert.match(result.summaryText, /vercel promote <deployment>/);
+});
+
+test("rejects malformed deployment input before calling GitHub", () => {
+  const result = runGuard({ deployed: "not-a-sha" });
+
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /Invalid DEPLOYED_SHA/);
+});


### PR DESCRIPTION
Partially addresses #6655.

## Why

During the company-OG rollout, Vercel let the Ready deployment for older parent `480eb88bf` reacquire `jseek.co` after newer main `a25a3f447` was already Ready. That silently undid the direct-R2 metadata cutover and continued spending Fluid CPU. Official Vercel build-queue behavior says same-branch builds should remain sequential and skip older queued commits, so production needs an independent invariant check.

## What changed

- Add a `deployment_status` workflow for successful Vercel Production deployments only.
- Check the event's deployed SHA against the live default-branch SHA through GitHub's API.
- Fail with both SHAs, the deployment URL, and the smoke-test/`vercel promote` recovery procedure when production is stale.
- Always check out the current default branch so a stale deployment cannot select an old or missing guard implementation.
- Validate repository, branch, SHA, and `.vercel.app` inputs before using them.
- Document the deployment-identity gate in the Fluid CPU runbook.

This is detection and safe operator guidance; #6655 remains open for staged/automatic correction.

## Verification

- `bash -n` passes.
- 3 guard tests pass: current main accepted, stale ancestor rejected with job summary, malformed SHA rejected before GitHub access.
- All 48 existing CI workflow/script tests pass.
- `zizmor 1.26.1` reports no medium/high-confidence findings.
- The repository's pinned actionlint command will run in required CI (Go is not installed in this local environment).
- Live post-#6654 production identity was separately verified: deployment `jobseek-bm32ue3qw...` reports `githubCommitSha=717feedbf7548e9dad38a101c06ed196fc9edc82`, matching current main.
