### PR TITLE
Fix Vercel production project pull

### DIFF
--- a/.github/workflows/deploy-web-production.yml
+++ b/.github/workflows/deploy-web-production.yml
@@ -73,7 +73,6 @@ jobs:
           pnpm dlx vercel@55.0.0 pull
           --yes
           --environment=production
-          --git-branch=main
           --token="$VERCEL_TOKEN"
 
       - name: Build the production artifact

--- a/scripts/vercel-web-deploy-paths.test.mjs
+++ b/scripts/vercel-web-deploy-paths.test.mjs
@@ -50,6 +50,7 @@ test("production workflow stages, verifies, then promotes exact main", () => {
   assert.match(workflow, /current_main=.*commits\/main/);
   assert.match(workflow, /vercel@55\.0\.0 promote/);
   assert.doesNotMatch(workflow, /--cwd=apps\/web/);
+  assert.doesNotMatch(workflow, /--git-branch/);
   assert.match(workflow, /environment: Production/);
   assert.doesNotMatch(workflow, /environment:\n\s+name: Production\n\s+url:/);
   assert.doesNotMatch(workflow, /pull_request:/);


### PR DESCRIPTION
## Root cause

The first post-#6748 `Deploy web production` run failed before build or deployment. Vercel CLI returned:

> Invalid request: `target` must be "preview" when specifying a `gitBranch`

`vercel pull --environment=production` must not include `--git-branch`; branch-specific environment overrides are Preview-only.

## Fix

- Remove `--git-branch=main` from the production pull.
- Add a regression assertion that the production workflow never combines these options again.

## Scope and safety

No build was created and no domain was changed by the failed run. Authentication, project resolution, cumulative path classification, and the company OG pointer publication all succeeded. This PR changes only the rejected CLI argument and its test.

## Verification

- `node --test scripts/vercel-web-deploy-paths.test.mjs` — 4 passed
- zizmor workflow scan — no findings

Follow-up to #6748 and #6612.
