### PR TITLE
Archive Vercel prebuilt deployments

### DIFF
--- a/.github/workflows/deploy-web-production.yml
+++ b/.github/workflows/deploy-web-production.yml
@@ -90,7 +90,7 @@ jobs:
           COMMIT_REF: main
         run: |
           deployment="$(pnpm dlx vercel@55.0.0 deploy \
-            --prebuilt --prod --skip-domain --format=json \
+            --prebuilt --prod --skip-domain --archive=tgz --format=json \
             --token="$VERCEL_TOKEN" \
             --meta githubCommitSha="$COMMIT_SHA" \
             --meta githubCommitRef="$COMMIT_REF" \

--- a/scripts/vercel-web-deploy-paths.test.mjs
+++ b/scripts/vercel-web-deploy-paths.test.mjs
@@ -44,7 +44,7 @@ test("production workflow stages, verifies, then promotes exact main", () => {
     ".github/workflows/deploy-web-production.yml",
     "utf8",
   );
-  assert.match(workflow, /--prod --skip-domain/);
+  assert.match(workflow, /--prod --skip-domain --archive=tgz/);
   assert.match(workflow, /v13\/deployments\/\$PRODUCTION_ALIAS/);
   assert.match(workflow, /production_sha.*current_sha/);
   assert.match(workflow, /current_main=.*commits\/main/);


### PR DESCRIPTION
## Root cause

The first corrected production workflow completed project pull and the full Vercel production build, then hit the Hobby API upload limit while uploading the prebuilt artifact file-by-file:

> Too many requests - try again in 24 hours (more than 5000, code: "api-upload-free")

No deployment was created and no domain was changed.

## Fix

Pass Vercel CLI `--archive=tgz` with the prebuilt staged deployment. This is the CLI-supported path for sending a large prebuilt output as an archive instead of thousands of individual API file uploads.

A regression test now requires the staged production command to combine `--skip-domain` and `--archive=tgz`.

## Verification

- `node --test scripts/vercel-web-deploy-paths.test.mjs` — 4 passed
- zizmor workflow scan — no findings
- prior workflow run proved production pull and production build succeed; failure was isolated to upload request cardinality

Follow-up to #6769, #6748, and #6612.
