### PR TITLE
Fix Vercel staged smoke authentication

### DIFF
--- a/.github/workflows/deploy-web-production.yml
+++ b/.github/workflows/deploy-web-production.yml
@@ -115,16 +115,14 @@ jobs:
             /en/explore?wm=remote\&q=python \
             /en/company/securitas-ag \
             /en/sign-in; do
-            status="$(pnpm dlx vercel@55.0.0 curl "$path" \
+            status="$(pnpm dlx vercel@55.0.0 --token="$VERCEL_TOKEN" curl "$path" \
               --deployment="$DEPLOYMENT_URL" \
-              --token="$VERCEL_TOKEN" -- \
-              --silent --show-error --output=/dev/null --write-out='%{http_code}')"
+              -- --silent --show-error --output=/dev/null --write-out='%{http_code}')"
             [[ "$status" == "200" ]]
           done
-          scanner_status="$(pnpm dlx vercel@55.0.0 curl /wp-admin/setup-config.php \
+          scanner_status="$(pnpm dlx vercel@55.0.0 --token="$VERCEL_TOKEN" curl /wp-admin/setup-config.php \
             --deployment="$DEPLOYMENT_URL" \
-            --token="$VERCEL_TOKEN" -- \
-            --silent --show-error --output=/dev/null --write-out='%{http_code}')"
+            -- --silent --show-error --output=/dev/null --write-out='%{http_code}')"
           [[ "$scanner_status" == "404" ]]
 
       - name: Promote only if this SHA is still main

--- a/scripts/vercel-web-deploy-paths.test.mjs
+++ b/scripts/vercel-web-deploy-paths.test.mjs
@@ -49,6 +49,12 @@ test("production workflow stages, verifies, then promotes exact main", () => {
   assert.match(workflow, /production_sha.*current_sha/);
   assert.match(workflow, /current_main=.*commits\/main/);
   assert.match(workflow, /vercel@55\.0\.0 promote/);
+  assert.equal(
+    [...workflow.matchAll(/vercel@55\.0\.0 --token="\$VERCEL_TOKEN" curl/g)]
+      .length,
+    2,
+  );
+  assert.doesNotMatch(workflow, /vercel@55\.0\.0 curl/);
   assert.doesNotMatch(workflow, /--cwd=apps\/web/);
   assert.doesNotMatch(workflow, /--git-branch/);
   assert.match(workflow, /environment: Production/);


### PR DESCRIPTION
## Summary

- pass the Vercel token as a global CLI option before the beta `curl` subcommand
- retain deployment targeting and native curl status-code assertions
- add a regression assertion covering both staged smoke requests

## Root cause

Production deployment run 31512004793 successfully built and staged deployment `dpl_3V1LSrzW5d7aGzgU8QQkaHqEvvL6` with the new `--archive=tgz` upload. The deployment reached Ready, but the smoke step stopped promotion because Vercel CLI 55 beta forwarded `--token` to the underlying system curl when the flag followed the `curl` subcommand:

`curl: option --token=***: is unknown`

Vercel CLI help documents the token as a global option. Moving it before `curl` keeps it in the Vercel parser while arguments after `--` continue to reach native curl.

No production alias or domain changed during the failed run.

## Verification

- `node --test scripts/vercel-web-deploy-paths.test.mjs` — 4 passed
- `actionlint .github/workflows/deploy-web-production.yml` — passed
- `uvx zizmor .github/workflows/deploy-web-production.yml` — no findings
- `git diff --check` — passed

## Follow-up

After merge, the path-aware production workflow will rebuild current main, stage via tgz, smoke-test the isolated deployment, recheck the live main SHA, and promote only on success.

Related: #6802, #6655, #6612