### PR TITLE
Use environment auth for Vercel smoke tests

### DIFF
--- a/.github/workflows/deploy-web-production.yml
+++ b/.github/workflows/deploy-web-production.yml
@@ -115,12 +115,12 @@ jobs:
             /en/explore?wm=remote\&q=python \
             /en/company/securitas-ag \
             /en/sign-in; do
-            status="$(pnpm dlx vercel@55.0.0 --token="$VERCEL_TOKEN" curl "$path" \
+            status="$(pnpm dlx vercel@55.0.0 curl "$path" \
               --deployment="$DEPLOYMENT_URL" \
               -- --silent --show-error --output=/dev/null --write-out='%{http_code}')"
             [[ "$status" == "200" ]]
           done
-          scanner_status="$(pnpm dlx vercel@55.0.0 --token="$VERCEL_TOKEN" curl /wp-admin/setup-config.php \
+          scanner_status="$(pnpm dlx vercel@55.0.0 curl /wp-admin/setup-config.php \
             --deployment="$DEPLOYMENT_URL" \
             -- --silent --show-error --output=/dev/null --write-out='%{http_code}')"
           [[ "$scanner_status" == "404" ]]

--- a/scripts/vercel-web-deploy-paths.test.mjs
+++ b/scripts/vercel-web-deploy-paths.test.mjs
@@ -49,12 +49,17 @@ test("production workflow stages, verifies, then promotes exact main", () => {
   assert.match(workflow, /production_sha.*current_sha/);
   assert.match(workflow, /current_main=.*commits\/main/);
   assert.match(workflow, /vercel@55\.0\.0 promote/);
-  assert.equal(
-    [...workflow.matchAll(/vercel@55\.0\.0 --token="\$VERCEL_TOKEN" curl/g)]
-      .length,
-    2,
+  assert.match(
+    workflow,
+    /VERCEL_TOKEN: \$\{\{ secrets\.VERCEL_TOKEN \}\}/,
   );
-  assert.doesNotMatch(workflow, /vercel@55\.0\.0 curl/);
+  const curlLines = workflow
+    .split("\n")
+    .filter((line) => line.includes("vercel@55.0.0") && line.includes("curl"));
+  assert.equal(curlLines.length, 2);
+  for (const line of curlLines) {
+    assert.doesNotMatch(line, /--token/);
+  }
   assert.doesNotMatch(workflow, /--cwd=apps\/web/);
   assert.doesNotMatch(workflow, /--git-branch/);
   assert.match(workflow, /environment: Production/);


### PR DESCRIPTION
## Summary

- rely on the job-level `VERCEL_TOKEN` environment variable for Vercel CLI authentication during staged curl checks
- omit the unsupported global `--token` argument from the beta curl subcommand
- verify both smoke invocation lines remain token-flag-free while the secret-backed environment is configured

## Root cause

Run 31513012312 proved that moving `--token` before `curl` was insufficient. Vercel CLI 55 beta still forwarded it to native curl and promotion was safely blocked.

Inspection of Vercel CLI 55.0.0 bundled source showed two decisive details:

1. top-level auth resolves `process.env.VERCEL_TOKEN` when no explicit flag is supplied;
2. the curl-specific parser only recognizes `--deployment`, `--protection-bypass`, `--yes`, `--help`, `--trace`, and `--json`, forwarding every other argument to native curl.

The workflow already exposes `secrets.VERCEL_TOKEN` as the job-level `VERCEL_TOKEN`, so removing the explicit flag is the narrow supported path.

The staged deployment `dpl_EmXwgNU73zf9rgZN5Ar8V6qBhiwy` reached Ready. No production alias or domain changed.

## Verification

- `node --test scripts/vercel-web-deploy-paths.test.mjs` — 4 passed
- `actionlint .github/workflows/deploy-web-production.yml` — passed
- `uvx zizmor .github/workflows/deploy-web-production.yml` — no findings
- `git diff --check` — passed
- Vercel CLI 55.0.0 source confirms environment-token fallback and curl flag whitelist

## Follow-up

After merge, the workflow will stage current main with `--archive=tgz`, smoke-test the isolated deployment with environment-backed authentication, recheck main, and promote only on success.

Related: #6833, #6802, #6655, #6612