### PR TITLE
Fix Vercel smoke curl options

### DIFF
--- a/.github/workflows/deploy-web-production.yml
+++ b/.github/workflows/deploy-web-production.yml
@@ -117,12 +117,12 @@ jobs:
             /en/sign-in; do
             status="$(pnpm dlx vercel@55.0.0 curl "$path" \
               --deployment="$DEPLOYMENT_URL" \
-              -- --silent --show-error --output=/dev/null --write-out='%{http_code}')"
+              -- --silent --show-error --output /dev/null --write-out '%{http_code}')"
             [[ "$status" == "200" ]]
           done
           scanner_status="$(pnpm dlx vercel@55.0.0 curl /wp-admin/setup-config.php \
             --deployment="$DEPLOYMENT_URL" \
-            -- --silent --show-error --output=/dev/null --write-out='%{http_code}')"
+            -- --silent --show-error --output /dev/null --write-out '%{http_code}')"
           [[ "$scanner_status" == "404" ]]
 
       - name: Promote only if this SHA is still main

--- a/scripts/vercel-web-deploy-paths.test.mjs
+++ b/scripts/vercel-web-deploy-paths.test.mjs
@@ -60,6 +60,12 @@ test("production workflow stages, verifies, then promotes exact main", () => {
   for (const line of curlLines) {
     assert.doesNotMatch(line, /--token/);
   }
+  assert.equal(
+    [...workflow.matchAll(/--output \/dev\/null --write-out '%\{http_code\}'/g)]
+      .length,
+    2,
+  );
+  assert.doesNotMatch(workflow, /--(?:output|write-out)=/);
   assert.doesNotMatch(workflow, /--cwd=apps\/web/);
   assert.doesNotMatch(workflow, /--git-branch/);
   assert.match(workflow, /environment: Production/);


### PR DESCRIPTION
## Summary

- pass native curl `--output` and `--write-out` values as separate arguments
- preserve environment-backed Vercel authentication and staged deployment targeting
- add regression coverage forbidding unsupported equals-form native options

## Root cause

Run 31513950259 confirmed Vercel environment authentication works: the prior `--token` forwarding error disappeared. The staged deployment `dpl_3Q3zp4mtz38ARe3rgpfdYpsdwqki` reached Ready. Native Ubuntu curl then rejected `--output=/dev/null`; curl long options that consume values require separate arguments in this environment. Promotion was safely blocked and no production domain changed.

The same correction is applied proactively to `--write-out`.

## Verification

- exact command through `pnpm dlx vercel@55.0.0 curl https://jseek.co/en/sign-in -- --silent --show-error --output /dev/null --write-out %{http_code}` returned 200
- standalone long-form curl command returned 200
- `node --test scripts/vercel-web-deploy-paths.test.mjs` — 4 passed
- `actionlint .github/workflows/deploy-web-production.yml` — passed
- `uvx zizmor .github/workflows/deploy-web-production.yml` — no findings
- `git diff --check` — passed

## Follow-up

After merge, current main will be staged via tgz, smoke-tested on its isolated URL, revalidated as current main, and promoted only on success.

Related: #6855, #6833, #6802, #6655, #6612