### PR TITLE
Follow scanner redirects in Vercel smoke tests

### DIFF
--- a/.github/workflows/deploy-web-production.yml
+++ b/.github/workflows/deploy-web-production.yml
@@ -118,12 +118,20 @@ jobs:
             status="$(pnpm dlx vercel@55.0.0 curl "$path" \
               --deployment="$DEPLOYMENT_URL" \
               -- --silent --show-error --output /dev/null --write-out '%{http_code}')"
-            [[ "$status" == "200" ]]
+            echo "Smoke $path -> HTTP $status"
+            if [[ "$status" != "200" ]]; then
+              echo "::error title=Staged smoke failed::$path returned HTTP $status"
+              exit 1
+            fi
           done
           scanner_status="$(pnpm dlx vercel@55.0.0 curl /wp-admin/setup-config.php \
             --deployment="$DEPLOYMENT_URL" \
-            -- --silent --show-error --output /dev/null --write-out '%{http_code}')"
-          [[ "$scanner_status" == "404" ]]
+            -- --location --silent --show-error --output /dev/null --write-out '%{http_code}')"
+          echo "Smoke /wp-admin/setup-config.php -> HTTP $scanner_status after redirects"
+          if [[ "$scanner_status" != "404" ]]; then
+            echo "::error title=Scanner path exposed::Expected HTTP 404 after redirects, got $scanner_status"
+            exit 1
+          fi
 
       - name: Promote only if this SHA is still main
         if: steps.paths.outputs.deploy == 'true'

--- a/scripts/vercel-web-deploy-paths.test.mjs
+++ b/scripts/vercel-web-deploy-paths.test.mjs
@@ -66,6 +66,12 @@ test("production workflow stages, verifies, then promotes exact main", () => {
     2,
   );
   assert.doesNotMatch(workflow, /--(?:output|write-out)=/);
+  assert.match(
+    workflow,
+    /scanner_status=[\s\S]{0,240}-- --location --silent/,
+  );
+  assert.match(workflow, /Smoke \$path -> HTTP \$status/);
+  assert.match(workflow, /Scanner path exposed/);
   assert.doesNotMatch(workflow, /--cwd=apps\/web/);
   assert.doesNotMatch(workflow, /--git-branch/);
   assert.match(workflow, /environment: Production/);


### PR DESCRIPTION
## Summary

- follow the intentional locale redirect for the scanner-path negative smoke probe
- continue requiring the final response to be HTTP 404
- emit every staged endpoint and observed status before asserting, with clear GitHub error annotations

## Root cause

Run 31514767057 proved all CLI/auth/native-curl mechanics are now correct. The three production-functionality probes completed successfully. The scanner probe then compared its first response to 404, but `/wp-admin/setup-config.php` intentionally returns HTTP 307 from locale routing before the localized destination returns 404.

Direct reproduction against staged deployment `dpl_D74jcandNWg9V5EDCgPjFPPPVkkp`:

- without redirects: 307
- with `--location`: 404

The production endpoint behaves the same way. Following the redirect preserves the actual security assertion: the scanner target must not resolve and its final response must remain 404.

No production alias or domain changed during the failed run.

## Verification

- exact Vercel CLI 55 command against the staged scanner path with `--location` returned 404
- `node --test scripts/vercel-web-deploy-paths.test.mjs` — 4 passed
- `actionlint .github/workflows/deploy-web-production.yml` — passed
- `uvx zizmor .github/workflows/deploy-web-production.yml` — no findings
- `git diff --check` — passed

## Follow-up

After merge, the production workflow will stage current main via tgz, verify three HTTP 200 application paths plus the final HTTP 404 scanner path, recheck current main, and promote only if every gate succeeds.

Related: #6876, #6855, #6833, #6802, #6655, #6612