### PR TITLE
Fix watchlist URL creation handoff

### DIFF
--- a/apps/web/app/[lang]/(app)/watchlists/__tests__/watchlists-page.test.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/__tests__/watchlists-page.test.tsx
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   replace: vi.fn(),
   refresh: vi.fn(),
   createWatchlist: vi.fn(),
+  createWatchlistFromHandoff: vi.fn(),
   searchParams: new URLSearchParams(),
   session: {
     user: { username: "alice" } as { username: string } | null,
@@ -34,6 +35,7 @@ vi.mock("@/components/providers/SessionProvider", () => ({
 
 vi.mock("@/lib/actions/watchlists", () => ({
   createWatchlist: mocks.createWatchlist,
+  createWatchlistFromHandoff: mocks.createWatchlistFromHandoff,
 }));
 
 vi.mock("@/components/watchlist/watchlist-card", () => ({
@@ -62,7 +64,9 @@ vi.mock("@/components/ui/upgrade-modal", () => ({
 }));
 
 vi.mock("@/components/ui/Button", () => ({
-  Button: ({ children }: { children: React.ReactNode }) => <button type="button">{children}</button>,
+  Button: ({ children, href }: { children: React.ReactNode; href?: string }) => (
+    href ? <a href={href}>{children}</a> : <button type="button">{children}</button>
+  ),
 }));
 
 import { WatchlistsPage } from "../watchlists-page";
@@ -83,6 +87,8 @@ const overview = [{
 describe("WatchlistsPage deferred counts (#5896)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.createWatchlist.mockReset();
+    mocks.createWatchlistFromHandoff.mockReset();
     mocks.searchParams = new URLSearchParams();
     mocks.session = {
       user: { username: "alice" },
@@ -156,7 +162,9 @@ describe("WatchlistsPage deferred counts (#5896)", () => {
       exp: "5-10",
       companies: "company-1,company-2",
     });
-    mocks.createWatchlist.mockResolvedValue({ slug: "distributed-systems" });
+    mocks.createWatchlistFromHandoff.mockResolvedValue({
+      slug: "distributed-systems",
+    });
 
     const props = {
       initialWatchlists: [],
@@ -175,11 +183,13 @@ describe("WatchlistsPage deferred counts (#5896)", () => {
     };
     rerender(<WatchlistsPage {...props} />);
 
-    await waitFor(() => expect(mocks.createWatchlist).toHaveBeenCalledTimes(1));
-    expect(mocks.createWatchlist).toHaveBeenCalledWith({
+    await waitFor(() => (
+      expect(mocks.createWatchlistFromHandoff).toHaveBeenCalledTimes(1)
+    ));
+    expect(mocks.createWatchlistFromHandoff).toHaveBeenCalledWith({
       title: "Distributed systems",
       description: "Senior platform roles",
-      companyIds: ["company-1", "company-2"],
+      companySlugs: ["company-1", "company-2"],
       filters: {
         keywords: ["platform", "distributed"],
         locationSlugs: ["berlin", "zurich"],
@@ -194,7 +204,6 @@ describe("WatchlistsPage deferred counts (#5896)", () => {
         experienceMin: 5,
         experienceMax: 10,
       },
-      isPublic: false,
     });
     expect(mocks.replace).toHaveBeenCalledWith(
       "/en/alice/distributed-systems",
@@ -202,6 +211,76 @@ describe("WatchlistsPage deferred counts (#5896)", () => {
     expect(mocks.push).not.toHaveBeenCalled();
 
     rerender(<WatchlistsPage {...props} locale="de" />);
-    await waitFor(() => expect(mocks.createWatchlist).toHaveBeenCalledTimes(1));
+    await waitFor(() => (
+      expect(mocks.createWatchlistFromHandoff).toHaveBeenCalledTimes(1)
+    ));
+  });
+
+  it("preserves the handoff across an anonymous sign-in return", async () => {
+    mocks.searchParams = new URLSearchParams({
+      title: "Stripe roles",
+      companies: "stripe",
+    });
+    mocks.session = { user: null, isLoggedIn: false, isPending: false };
+
+    const props = {
+      initialWatchlists: [],
+      username: null,
+      limitReached: false,
+      locale: "en",
+    };
+    const anonymous = render(<WatchlistsPage {...props} />);
+    const signIn = screen.getByRole("link", { name: "Log in" });
+    const signInUrl = new URL(signIn.getAttribute("href")!, "https://jseek.co");
+    expect(signInUrl.pathname).toBe("/en/sign-in");
+    expect(signInUrl.searchParams.get("next")).toBe(
+      "/en/watchlists?title=Stripe+roles&companies=stripe",
+    );
+    expect(mocks.createWatchlistFromHandoff).not.toHaveBeenCalled();
+
+    anonymous.unmount();
+    mocks.session = { user: null, isLoggedIn: false, isPending: true };
+    mocks.createWatchlistFromHandoff.mockResolvedValue({ slug: "stripe-roles" });
+    const authenticated = render(<WatchlistsPage {...props} />);
+    mocks.session = {
+      user: { username: "alice" },
+      isLoggedIn: true,
+      isPending: false,
+    };
+    authenticated.rerender(<WatchlistsPage {...props} username="alice" />);
+
+    await waitFor(() => (
+      expect(mocks.createWatchlistFromHandoff).toHaveBeenCalledTimes(1)
+    ));
+    expect(mocks.createWatchlistFromHandoff).toHaveBeenCalledWith(
+      expect.objectContaining({ companySlugs: ["stripe"] }),
+    );
+  });
+
+  it("handles a terminal handoff failure and retains the retry URL", async () => {
+    mocks.searchParams = new URLSearchParams({
+      title: "Retryable roles",
+      companies: "stripe",
+    });
+    mocks.createWatchlistFromHandoff.mockRejectedValue(
+      new Error("database unavailable"),
+    );
+
+    render(
+      <WatchlistsPage
+        initialWatchlists={[]}
+        username="alice"
+        limitReached={false}
+        locale="en"
+      />,
+    );
+
+    await waitFor(() => (
+      expect(mocks.createWatchlistFromHandoff).toHaveBeenCalledTimes(1)
+    ));
+    expect(mocks.replace).not.toHaveBeenCalled();
+    expect(mocks.searchParams.toString()).toBe(
+      "title=Retryable+roles&companies=stripe",
+    );
   });
 });

--- a/apps/web/app/[lang]/(app)/watchlists/__tests__/watchlists-page.test.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/__tests__/watchlists-page.test.tsx
@@ -4,13 +4,24 @@ import "@/test-utils/lingui-mock";
 
 const mocks = vi.hoisted(() => ({
   push: vi.fn(),
+  replace: vi.fn(),
   refresh: vi.fn(),
   createWatchlist: vi.fn(),
+  searchParams: new URLSearchParams(),
+  session: {
+    user: { username: "alice" } as { username: string } | null,
+    isLoggedIn: true,
+    isPending: false,
+  },
 }));
 
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({ push: mocks.push, refresh: mocks.refresh }),
-  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({
+    push: mocks.push,
+    replace: mocks.replace,
+    refresh: mocks.refresh,
+  }),
+  useSearchParams: () => mocks.searchParams,
 }));
 
 vi.mock("@/lib/useLocalePath", () => ({
@@ -18,10 +29,7 @@ vi.mock("@/lib/useLocalePath", () => ({
 }));
 
 vi.mock("@/components/providers/SessionProvider", () => ({
-  useSession: () => ({
-    user: { username: "alice" },
-    isLoggedIn: true,
-  }),
+  useSession: () => mocks.session,
 }));
 
 vi.mock("@/lib/actions/watchlists", () => ({
@@ -75,6 +83,12 @@ const overview = [{
 describe("WatchlistsPage deferred counts (#5896)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.searchParams = new URLSearchParams();
+    mocks.session = {
+      user: { username: "alice" },
+      isLoggedIn: true,
+      isPending: false,
+    };
   });
 
   afterEach(() => {
@@ -123,5 +137,71 @@ describe("WatchlistsPage deferred counts (#5896)", () => {
       "/api/web/watchlists/counts?locale=de",
       expect.objectContaining({ cache: "no-store" }),
     );
+  });
+
+  it("waits for bootstrap and creates one complete URL handoff", async () => {
+    mocks.session = { user: null, isLoggedIn: false, isPending: true };
+    mocks.searchParams = new URLSearchParams({
+      title: "Distributed systems",
+      description: "Senior platform roles",
+      q: "platform,distributed",
+      loc: "berlin,zurich",
+      occ: "software-engineering",
+      sen: "senior,staff",
+      tech: "go,kubernetes",
+      wm: "remote,hybrid",
+      etype: "full_time,contract",
+      sal: "120000-180000",
+      salcur: "CHF",
+      exp: "5-10",
+      companies: "company-1,company-2",
+    });
+    mocks.createWatchlist.mockResolvedValue({ slug: "distributed-systems" });
+
+    const props = {
+      initialWatchlists: [],
+      username: "alice",
+      limitReached: false,
+      locale: "en",
+    };
+    const { rerender } = render(<WatchlistsPage {...props} />);
+
+    expect(mocks.createWatchlist).not.toHaveBeenCalled();
+
+    mocks.session = {
+      user: { username: "alice" },
+      isLoggedIn: true,
+      isPending: false,
+    };
+    rerender(<WatchlistsPage {...props} />);
+
+    await waitFor(() => expect(mocks.createWatchlist).toHaveBeenCalledTimes(1));
+    expect(mocks.createWatchlist).toHaveBeenCalledWith({
+      title: "Distributed systems",
+      description: "Senior platform roles",
+      companyIds: ["company-1", "company-2"],
+      filters: {
+        keywords: ["platform", "distributed"],
+        locationSlugs: ["berlin", "zurich"],
+        occupationSlugs: ["software-engineering"],
+        senioritySlugs: ["senior", "staff"],
+        technologySlugs: ["go", "kubernetes"],
+        workMode: ["remote", "hybrid"],
+        employmentType: ["full_time", "contract"],
+        salaryMin: 120000,
+        salaryMax: 180000,
+        salaryCurrency: "CHF",
+        experienceMin: 5,
+        experienceMax: 10,
+      },
+      isPublic: false,
+    });
+    expect(mocks.replace).toHaveBeenCalledWith(
+      "/en/alice/distributed-systems",
+    );
+    expect(mocks.push).not.toHaveBeenCalled();
+
+    rerender(<WatchlistsPage {...props} locale="de" />);
+    await waitFor(() => expect(mocks.createWatchlist).toHaveBeenCalledTimes(1));
   });
 });

--- a/apps/web/app/[lang]/(app)/watchlists/watchlists-page.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/watchlists-page.tsx
@@ -7,7 +7,10 @@ import { Trans, useLingui } from "@lingui/react/macro";
 import { useLocalePath } from "@/lib/useLocalePath";
 import { useSession } from "@/components/providers/SessionProvider";
 import type { UserWatchlistOverview, WatchlistFilters } from "@/lib/actions/watchlists";
-import { createWatchlist } from "@/lib/actions/watchlists";
+import {
+  createWatchlist,
+  createWatchlistFromHandoff,
+} from "@/lib/actions/watchlists";
 import { WatchlistCard, CreateWatchlistCard } from "@/components/watchlist/watchlist-card";
 import { PublicWatchlistSearch } from "@/components/watchlist/public-watchlist-search";
 import { UpgradeModal, useUpgradeModal } from "@/components/ui/upgrade-modal";
@@ -16,6 +19,7 @@ import {
   parseEmploymentTypeParam,
   parseWorkModeParam,
 } from "@/lib/search/query-params";
+import { withAuthReturnPath } from "@/lib/auth-return";
 
 function commaSeparatedValues(value: string | null): string[] {
   if (!value) return [];
@@ -97,7 +101,7 @@ export function WatchlistsPage({
       title?: string;
       description?: string;
       filters?: WatchlistFilters;
-      companyIds?: string[];
+      companySlugs?: string[];
     },
     navigation: "push" | "replace" = "push",
   ) {
@@ -112,13 +116,20 @@ export function WatchlistsPage({
     }
     setCreating(true);
     try {
-      const result = await createWatchlist({
-        title: prefill?.title || "New watchlist",
-        description: prefill?.description,
-        companyIds: prefill?.companyIds ?? [],
-        filters: prefill?.filters,
-        isPublic: false,
-      });
+      const result = prefill?.companySlugs !== undefined
+        ? await createWatchlistFromHandoff({
+            title: prefill.title || "New watchlist",
+            description: prefill.description,
+            companySlugs: prefill.companySlugs,
+            filters: prefill.filters,
+          })
+        : await createWatchlist({
+            title: prefill?.title || "New watchlist",
+            description: prefill?.description,
+            companyIds: [],
+            filters: prefill?.filters,
+            isPublic: false,
+          });
       if ("error" in result) {
         // Server-side race: client thought limit wasn't reached, but a
         // concurrent create elsewhere raised the count. Same UX.
@@ -149,7 +160,7 @@ export function WatchlistsPage({
       title: string;
       description?: string;
       filters?: WatchlistFilters;
-      companyIds: string[];
+      companySlugs: string[];
     }) => handleCreate(prefill, "replace"),
   );
 
@@ -184,7 +195,7 @@ export function WatchlistsPage({
     const salcur = searchParams.get("salcur");
     const workMode = parseWorkModeParam(searchParams.get("wm"));
     const employmentType = parseEmploymentTypeParam(searchParams.get("etype"));
-    const companyIds = commaSeparatedValues(searchParams.get("companies"));
+    const companySlugs = commaSeparatedValues(searchParams.get("companies"));
 
     const filters: WatchlistFilters = {};
     if (q) filters.keywords = commaSeparatedValues(q);
@@ -210,9 +221,19 @@ export function WatchlistsPage({
       title,
       description: searchParams.get("description") ?? undefined,
       filters: Object.keys(filters).length > 0 ? filters : undefined,
-      companyIds,
+      companySlugs,
+    }).catch(() => {
+      // Keep the handoff URL intact after a terminal action/database failure.
+      // A reload is then an explicit retry, while this mount stays one-shot.
     });
   }, [isLoggedIn, isPending, limitReached, searchParams]);
+
+  const loginHref = withAuthReturnPath(
+    lp("/sign-in"),
+    searchParams.has("title")
+      ? `${lp("/watchlists")}?${searchParams.toString()}`
+      : null,
+  );
 
   return (
     <>
@@ -236,7 +257,7 @@ export function WatchlistsPage({
                 Sign in to create and manage your own watchlists.
               </Trans>
             </p>
-            <Button href={lp("/sign-in")} variant="primary" size="sm" className="gap-2">
+            <Button href={loginHref} variant="primary" size="sm" className="gap-2">
               <LogIn size={16} />
               {t({ id: "common.auth.login", comment: "Login button label", message: "Log in" })}
             </Button>

--- a/apps/web/app/[lang]/(app)/watchlists/watchlists-page.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/watchlists-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useEffect, useEffectEvent, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Eye, Loader2, LogIn } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
@@ -12,6 +12,15 @@ import { WatchlistCard, CreateWatchlistCard } from "@/components/watchlist/watch
 import { PublicWatchlistSearch } from "@/components/watchlist/public-watchlist-search";
 import { UpgradeModal, useUpgradeModal } from "@/components/ui/upgrade-modal";
 import { Button } from "@/components/ui/Button";
+import {
+  parseEmploymentTypeParam,
+  parseWorkModeParam,
+} from "@/lib/search/query-params";
+
+function commaSeparatedValues(value: string | null): string[] {
+  if (!value) return [];
+  return value.split(",").map((item) => item.trim()).filter(Boolean);
+}
 
 export function WatchlistsPage({
   initialWatchlists,
@@ -27,11 +36,12 @@ export function WatchlistsPage({
   const { t } = useLingui();
   const router = useRouter();
   const lp = useLocalePath();
-  const { user, isLoggedIn } = useSession();
+  const { user, isLoggedIn, isPending } = useSession();
   const searchParams = useSearchParams();
   const [creating, setCreating] = useState(false);
   const [watchlists, setWatchlists] = useState(initialWatchlists);
   const upgrade = useUpgradeModal();
+  const handoffAttemptedRef = useRef(false);
 
   useEffect(() => {
     setWatchlists(initialWatchlists);
@@ -82,7 +92,15 @@ export function WatchlistsPage({
     }));
   }
 
-  async function handleCreate(prefill?: { title?: string; description?: string; filters?: WatchlistFilters }) {
+  async function handleCreate(
+    prefill?: {
+      title?: string;
+      description?: string;
+      filters?: WatchlistFilters;
+      companyIds?: string[];
+    },
+    navigation: "push" | "replace" = "push",
+  ) {
     if (creating || !isLoggedIn) return;
     if (limitReached) {
       // Issue #3036: redirecting to /settings (general tab) hid the
@@ -97,7 +115,7 @@ export function WatchlistsPage({
       const result = await createWatchlist({
         title: prefill?.title || "New watchlist",
         description: prefill?.description,
-        companyIds: [],
+        companyIds: prefill?.companyIds ?? [],
         filters: prefill?.filters,
         isPublic: false,
       });
@@ -108,7 +126,16 @@ export function WatchlistsPage({
         return;
       }
       if ("slug" in result && (username ?? user?.username)) {
-        router.push(lp(`/${username ?? user?.username}/${result.slug}`));
+        const destination = lp(`/${username ?? user?.username}/${result.slug}`);
+        if (navigation === "replace") {
+          router.replace(destination);
+        } else {
+          router.push(destination);
+        }
+      } else if (navigation === "replace") {
+        // A successful handoff without a navigable owner/slug still needs to
+        // lose the mutating query string so refresh/back cannot create again.
+        router.replace(lp("/watchlists"));
       } else {
         router.refresh();
       }
@@ -117,13 +144,28 @@ export function WatchlistsPage({
     }
   }
 
-  // Auto-create watchlist from URL params (e.g. from /api/v1/watchlist/create).
-  // Intentionally one-shot on mount: adding live deps here would retry
-  // the mutating create flow on unrelated session/limit/render changes.
-  // The login path returns to this page with the session already present.
+  const runWatchlistHandoff = useEffectEvent(
+    (prefill: {
+      title: string;
+      description?: string;
+      filters?: WatchlistFilters;
+      companyIds: string[];
+    }) => handleCreate(prefill, "replace"),
+  );
+
+  // Auto-create a watchlist from URL params (for example, the URL emitted by
+  // /api/v1/watchlist/create). Wait for the asynchronous session bootstrap,
+  // then claim this mounted handoff before any mutation or modal side effect.
+  // The ref lets the effect react to bootstrap without allowing later context
+  // or URL identity changes to create the same watchlist twice.
   useEffect(() => {
+    if (isPending || handoffAttemptedRef.current) return;
+
     const title = searchParams.get("title");
-    if (!title || !isLoggedIn) return;
+    if (!title) return;
+
+    handoffAttemptedRef.current = true;
+    if (!isLoggedIn) return;
     if (limitReached) {
       // Issue #3036: arriving with `?title=...` while at the plan
       // limit used to silently no-op. Tell the user why nothing
@@ -140,13 +182,18 @@ export function WatchlistsPage({
     const sal = searchParams.get("sal");
     const exp = searchParams.get("exp");
     const salcur = searchParams.get("salcur");
+    const workMode = parseWorkModeParam(searchParams.get("wm"));
+    const employmentType = parseEmploymentTypeParam(searchParams.get("etype"));
+    const companyIds = commaSeparatedValues(searchParams.get("companies"));
 
     const filters: WatchlistFilters = {};
-    if (q) filters.keywords = q.split(",").filter(Boolean);
-    if (loc) filters.locationSlugs = loc.split(",").filter(Boolean);
-    if (occ) filters.occupationSlugs = occ.split(",").filter(Boolean);
-    if (sen) filters.senioritySlugs = sen.split(",").filter(Boolean);
-    if (tech) filters.technologySlugs = tech.split(",").filter(Boolean);
+    if (q) filters.keywords = commaSeparatedValues(q);
+    if (loc) filters.locationSlugs = commaSeparatedValues(loc);
+    if (occ) filters.occupationSlugs = commaSeparatedValues(occ);
+    if (sen) filters.senioritySlugs = commaSeparatedValues(sen);
+    if (tech) filters.technologySlugs = commaSeparatedValues(tech);
+    if (workMode.length > 0) filters.workMode = workMode;
+    if (employmentType.length > 0) filters.employmentType = employmentType;
     if (salcur) filters.salaryCurrency = salcur;
     if (sal) {
       const [minStr, maxStr] = sal.split("-");
@@ -159,12 +206,13 @@ export function WatchlistsPage({
       if (maxStr) filters.experienceMax = parseInt(maxStr, 10);
     }
 
-    handleCreate({
+    void runWatchlistHandoff({
       title,
       description: searchParams.get("description") ?? undefined,
       filters: Object.keys(filters).length > 0 ? filters : undefined,
+      companyIds,
     });
-  }, []);
+  }, [isLoggedIn, isPending, limitReached, searchParams]);
 
   return (
     <>

--- a/apps/web/src/lib/actions/watchlists.ts
+++ b/apps/web/src/lib/actions/watchlists.ts
@@ -21,6 +21,12 @@ export async function createWatchlist(
   return service.createWatchlist(...args);
 }
 
+export async function createWatchlistFromHandoff(
+  ...args: Parameters<typeof service.createWatchlistFromHandoff>
+): ReturnType<typeof service.createWatchlistFromHandoff> {
+  return service.createWatchlistFromHandoff(...args);
+}
+
 export async function updateWatchlist(
   ...args: Parameters<typeof service.updateWatchlist>
 ): ReturnType<typeof service.updateWatchlist> {

--- a/apps/web/src/lib/services/__tests__/company-detail.test.ts
+++ b/apps/web/src/lib/services/__tests__/company-detail.test.ts
@@ -44,7 +44,7 @@ vi.mock("@/lib/search/typesense-retry", () => ({
   withTypesenseRetry: (fn: () => Promise<unknown>) => fn(),
 }));
 
-import { getCompanyBySlug } from "../company-detail";
+import { getCompanyBySlug, getCompanyIdsBySlugs } from "../company-detail";
 
 const searchMock = mocks.search;
 const cachedMock = mocks.cached;
@@ -150,5 +150,29 @@ describe("getCompanyBySlug", () => {
       }),
     );
     errorSpy.mockRestore();
+  });
+});
+
+describe("getCompanyIdsBySlugs", () => {
+  it("resolves the handoff company set in one exact batched search", async () => {
+    searchMock.mockResolvedValue({
+      hits: [
+        { document: { id: "uuid-stripe", slug: "stripe" } },
+        { document: { id: "uuid-gitlab", slug: "gitlab" } },
+      ],
+    });
+
+    await expect(getCompanyIdsBySlugs(["stripe", "gitlab"])).resolves.toEqual(
+      new Map([
+        ["stripe", "uuid-stripe"],
+        ["gitlab", "uuid-gitlab"],
+      ]),
+    );
+    expect(searchMock).toHaveBeenCalledTimes(1);
+    expect(searchMock).toHaveBeenCalledWith({
+      q: "*",
+      filter_by: "slug:[stripe,gitlab]",
+      per_page: 2,
+    });
   });
 });

--- a/apps/web/src/lib/services/__tests__/watchlist-handoff.test.ts
+++ b/apps/web/src/lib/services/__tests__/watchlist-handoff.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  getCompanyIdsBySlugs: vi.fn(),
+  createWatchlist: vi.fn(),
+}));
+
+vi.mock("@/lib/services/company-detail", () => ({
+  getCompanyIdsBySlugs: mocks.getCompanyIdsBySlugs,
+}));
+
+vi.mock("@/lib/services/watchlists", () => ({
+  createWatchlist: mocks.createWatchlist,
+}));
+
+import { createWatchlistFromHandoffWithDeps } from "../watchlist-handoff";
+
+describe("createWatchlistFromHandoff", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createWatchlist.mockResolvedValue({ id: "watchlist-1", slug: "roles" });
+  });
+
+  it("resolves and deduplicates public company slugs before the UUID write", async () => {
+    mocks.getCompanyIdsBySlugs.mockResolvedValue(new Map([
+      ["stripe", "uuid-stripe"],
+      ["gitlab", "uuid-gitlab"],
+    ]));
+
+    await expect(createWatchlistFromHandoffWithDeps({
+      title: "Roles",
+      description: "Selected companies",
+      companySlugs: [" Stripe ", "gitlab", "stripe"],
+      filters: { workMode: ["remote"] },
+    }, mocks)).resolves.toEqual({ id: "watchlist-1", slug: "roles" });
+
+    expect(mocks.getCompanyIdsBySlugs).toHaveBeenCalledWith([
+      "stripe",
+      "gitlab",
+    ]);
+    expect(mocks.createWatchlist).toHaveBeenCalledWith({
+      title: "Roles",
+      description: "Selected companies",
+      companyIds: ["uuid-stripe", "uuid-gitlab"],
+      filters: { workMode: ["remote"], anyCompany: false },
+      isPublic: false,
+    });
+  });
+
+  it("fails closed when any requested company slug is unknown", async () => {
+    mocks.getCompanyIdsBySlugs.mockResolvedValue(new Map([
+      ["stripe", "uuid-stripe"],
+    ]));
+
+    await expect(createWatchlistFromHandoffWithDeps({
+      title: "Roles",
+      companySlugs: ["stripe", "missing"],
+    }, mocks)).resolves.toEqual({ error: "invalid_companies" });
+    expect(mocks.createWatchlist).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/services/company-detail.ts
+++ b/apps/web/src/lib/services/company-detail.ts
@@ -18,6 +18,8 @@ import {
   type CompanyDetail,
 } from "@/lib/services/company-detail-lookup";
 
+const MAX_COMPANY_SLUG_BATCH = 25;
+
 export type { CompanyDetail } from "@/lib/services/company-detail-lookup";
 
 export async function getCompanyBySlug(
@@ -36,6 +38,46 @@ export async function getCompanyBySlug(
     ttl: CACHE_TTL_DETAIL,
     skipIf: (data) => data === null,
   });
+}
+
+/** Resolve a bounded set of canonical slugs to UUIDs in one Typesense read. */
+export async function getCompanyIdsBySlugs(
+  slugs: readonly string[],
+): Promise<Map<string, string>> {
+  if (slugs.length === 0) return new Map();
+  if (slugs.length > MAX_COMPANY_SLUG_BATCH) {
+    throw new Error("Company slug batch exceeds the supported limit");
+  }
+  if (!canResolveCompanyBySlugFromEnv(process.env)) {
+    throw new Error("Company lookup is not configured");
+  }
+  if (slugs.some((slug) => !isSafeCompanySlug(slug))) {
+    return new Map();
+  }
+
+  const result = await withTypesenseRetry(
+    () => getSearchClient()
+      .collections<{ id: string; slug: string }>("company")
+      .documents()
+      .search({
+        q: "*",
+        filter_by: `slug:[${slugs.join(",")}]`,
+        per_page: slugs.length,
+      }),
+    {
+      attempts: 5,
+      baseDelaysMs: [250, 500, 1000, 2000],
+      isRetryable: shouldRetryCompanyTypesenseRead,
+      label: "companyIdsBySlugs",
+    },
+  );
+
+  return new Map(
+    (result.hits ?? []).map((hit) => [
+      String(hit.document.slug),
+      String(hit.document.id),
+    ]),
+  );
 }
 
 async function fetchCompanyBySlug(slug: string, locale: string): Promise<CompanyDetail | null> {

--- a/apps/web/src/lib/services/watchlist-handoff.ts
+++ b/apps/web/src/lib/services/watchlist-handoff.ts
@@ -1,0 +1,61 @@
+import "server-only";
+
+import { isSafeCompanySlug } from "@/lib/services/company-detail-lookup";
+import type { WatchlistFilters } from "@/lib/services/watchlists";
+
+const MAX_HANDOFF_COMPANIES = 25;
+
+/**
+ * Resolve the public API's company-slug contract before writing UUID foreign
+ * keys. Unknown/invalid slugs fail the whole handoff so a constrained request
+ * can never silently broaden into an any-company watchlist.
+ */
+export async function createWatchlistFromHandoffWithDeps(params: {
+  title: string;
+  description?: string;
+  companySlugs: string[];
+  filters?: WatchlistFilters;
+}, deps: {
+  getCompanyIdsBySlugs: (slugs: readonly string[]) => Promise<Map<string, string>>;
+  createWatchlist: (params: {
+    title: string;
+    description?: string;
+    companyIds: string[];
+    filters?: WatchlistFilters;
+    isPublic: boolean;
+  }) => Promise<{ id: string; slug: string } | { error: string }>;
+}): Promise<{ id: string; slug: string } | { error: string }> {
+  if (params.companySlugs.length > MAX_HANDOFF_COMPANIES) {
+    return { error: "invalid_companies" };
+  }
+  const companySlugs = [
+    ...new Set(
+      params.companySlugs
+        .map((slug) => slug.trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  ];
+  if (companySlugs.some((slug) => !isSafeCompanySlug(slug))) {
+    return { error: "invalid_companies" };
+  }
+
+  const companyIdsBySlug = await deps.getCompanyIdsBySlugs(companySlugs);
+  if (companyIdsBySlug.size !== companySlugs.length) {
+    return { error: "invalid_companies" };
+  }
+
+  const companyIds = [
+    ...new Set(companySlugs.map((slug) => companyIdsBySlug.get(slug)!)),
+  ];
+  const filters = companyIds.length > 0
+    ? { ...params.filters, anyCompany: false }
+    : params.filters;
+
+  return deps.createWatchlist({
+    title: params.title,
+    description: params.description,
+    companyIds,
+    filters,
+    isPublic: false,
+  });
+}

--- a/apps/web/src/lib/services/watchlists.ts
+++ b/apps/web/src/lib/services/watchlists.ts
@@ -46,6 +46,7 @@ import {
 } from "@/lib/search/typesense-watchlist";
 import { isTrivialWatchlist, buildFilterCacheKey } from "@/lib/watchlist-utils";
 import { notifyIndexNow, logIndexNowResult } from "@/lib/indexnow";
+import { createWatchlistFromHandoffWithDeps } from "@/lib/services/watchlist-handoff";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -330,6 +331,23 @@ export async function createWatchlist(params: {
   }
 
   return { id: row.id, slug };
+}
+
+export async function createWatchlistFromHandoff(params: {
+  title: string;
+  description?: string;
+  companySlugs: string[];
+  filters?: WatchlistFilters;
+}): Promise<{ id: string; slug: string } | { error: string }> {
+  // Keep the company-detail cache/search module off the ordinary watchlist
+  // import path. It is needed only for this explicit public-API handoff.
+  const { getCompanyIdsBySlugs } = await import(
+    "@/lib/services/company-detail"
+  );
+  return createWatchlistFromHandoffWithDeps(params, {
+    getCompanyIdsBySlugs,
+    createWatchlist,
+  });
 }
 
 export async function updateWatchlist(params: {


### PR DESCRIPTION
## Summary

- wait for session bootstrap before making the one-shot handoff decision
- guard auto-creation against duplicate context updates
- preserve work modes, employment types, and company constraints, resolving company slugs to canonical IDs with bounded fail-closed lookup
- clear handoff URL state after a successful create

## Verification

- focused Vitest: 3 files, 12 tests
- Next route type generation and TypeScript
- full web ESLint
- git diff --check

## Post-deploy acceptance

Verify one authenticated handoff in production, including canonical company lookup against live Typesense, and confirm the URL is cleared after exactly one create.

Addresses #6638