### PR TITLE
Bound and sequence typeahead requests

### DIFF
--- a/apps/web/src/components/search/__tests__/search-bar-company-scope.test.tsx
+++ b/apps/web/src/components/search/__tests__/search-bar-company-scope.test.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   submitSearch: vi.fn(),
   parseSearchFilters: vi.fn(),
   suggestLocations: vi.fn(),
+  suggestSearchBar: vi.fn(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -24,10 +25,7 @@ vi.mock("@/lib/actions/company", () => ({
 }));
 
 vi.mock("@/lib/search/typeahead-runner", () => ({
-  runSuggestLocations: (...args: unknown[]) => mocks.suggestLocations(...args),
-  runSuggestOccupations: vi.fn(async () => []),
-  runSuggestSeniorities: vi.fn(async () => []),
-  runSuggestTechnologies: vi.fn(async () => []),
+  runSearchBarTypeahead: (...args: unknown[]) => mocks.suggestSearchBar(...args),
 }));
 
 vi.mock("@/lib/actions/search-input", () => ({
@@ -47,6 +45,13 @@ beforeEach(() => {
   mocks.submitSearch.mockReset();
   mocks.parseSearchFilters.mockReset();
   mocks.suggestLocations.mockReset();
+  mocks.suggestSearchBar.mockImplementation(async (params: unknown) => ({
+    locations: await mocks.suggestLocations(params),
+    companies: [],
+    occupations: [],
+    seniorities: [],
+    technologies: [],
+  }));
 });
 
 function CompanySearchHarness() {
@@ -100,6 +105,9 @@ describe("SearchBar company scope", () => {
     const input = screen.getByRole("combobox");
     await userEvent.type(input, "merck");
     expect(await screen.findByText("Merced")).toBeTruthy();
+    expect(mocks.suggestSearchBar).toHaveBeenCalledWith(
+      expect.objectContaining({ includeCompanies: false }),
+    );
     await userEvent.type(input, "{Enter}");
 
     await waitFor(() => {

--- a/apps/web/src/components/search/__tests__/search-bar-request.test.tsx
+++ b/apps/web/src/components/search/__tests__/search-bar-request.test.tsx
@@ -25,6 +25,7 @@ vi.mock("next/navigation", () => ({
 
 // Server actions / typeahead runners — controlled per test.
 const suggestCompaniesMock = vi.fn();
+const suggestSearchBarMock = vi.fn();
 vi.mock("@/lib/actions/company", async () => {
   const actual =
     await vi.importActual<typeof import("@/lib/actions/company")>(
@@ -37,10 +38,7 @@ vi.mock("@/lib/actions/company", async () => {
 });
 
 vi.mock("@/lib/search/typeahead-runner", () => ({
-  runSuggestLocations: vi.fn(async () => []),
-  runSuggestOccupations: vi.fn(async () => []),
-  runSuggestSeniorities: vi.fn(async () => []),
-  runSuggestTechnologies: vi.fn(async () => []),
+  runSearchBarTypeahead: (...args: unknown[]) => suggestSearchBarMock(...args),
 }));
 
 // `parseSearchFilters` is a server action — only used on the keyword
@@ -64,6 +62,13 @@ import { SearchBar } from "../search-bar";
 beforeEach(() => {
   pushMock.mockReset();
   suggestCompaniesMock.mockReset();
+  suggestSearchBarMock.mockImplementation(async (params: { query: string }) => ({
+    locations: [],
+    companies: await suggestCompaniesMock({ query: params.query }),
+    occupations: [],
+    seniorities: [],
+    technologies: [],
+  }));
   currentPathname = "/en";
 });
 

--- a/apps/web/src/components/search/__tests__/search-bar-structure.test.ts
+++ b/apps/web/src/components/search/__tests__/search-bar-structure.test.ts
@@ -17,6 +17,6 @@ describe("SearchBar source structure (#3082)", () => {
     expect((searchBar.match(/data-suggestion/g) ?? []).length).toBeLessThanOrEqual(3);
     expect(searchBar).not.toContain("suggestCompanies({ query })");
     expect(typeahead).toContain("function useSearchBarTypeahead");
-    expect(typeahead).toContain("setFilteredResults");
+    expect(typeahead).toContain("requestGenerationRef");
   });
 });

--- a/apps/web/src/components/search/__tests__/search-bar-structured-suggestions.test.tsx
+++ b/apps/web/src/components/search/__tests__/search-bar-structured-suggestions.test.tsx
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import type { SearchBarTypeaheadResults } from "@/lib/search/typeahead-contract";
 
 import "@/test-utils/lingui-mock";
 
@@ -20,6 +21,7 @@ const suggestLocationsMock = vi.fn();
 const suggestOccupationsMock = vi.fn();
 const suggestSenioritiesMock = vi.fn();
 const suggestTechnologiesMock = vi.fn();
+const suggestSearchBarMock = vi.fn();
 
 vi.mock("@/lib/actions/company", async () => {
   const actual =
@@ -33,10 +35,7 @@ vi.mock("@/lib/actions/company", async () => {
 });
 
 vi.mock("@/lib/search/typeahead-runner", () => ({
-  runSuggestLocations: (...args: unknown[]) => suggestLocationsMock(...args),
-  runSuggestOccupations: (...args: unknown[]) => suggestOccupationsMock(...args),
-  runSuggestSeniorities: (...args: unknown[]) => suggestSenioritiesMock(...args),
-  runSuggestTechnologies: (...args: unknown[]) => suggestTechnologiesMock(...args),
+  runSearchBarTypeahead: (...args: unknown[]) => suggestSearchBarMock(...args),
 }));
 
 vi.mock("@/lib/actions/search-input", () => ({
@@ -56,11 +55,19 @@ import { SearchBar } from "../search-bar";
 beforeEach(() => {
   pushMock.mockReset();
   currentPathname = "/en";
+  suggestSearchBarMock.mockReset();
   suggestCompaniesMock.mockResolvedValue([]);
   suggestLocationsMock.mockResolvedValue([]);
   suggestOccupationsMock.mockResolvedValue([]);
   suggestSenioritiesMock.mockResolvedValue([]);
   suggestTechnologiesMock.mockResolvedValue([]);
+  suggestSearchBarMock.mockImplementation(async (params: { query: string }) => ({
+    locations: await suggestLocationsMock(params),
+    companies: await suggestCompaniesMock({ query: params.query }),
+    occupations: await suggestOccupationsMock(params),
+    seniorities: await suggestSenioritiesMock(params),
+    technologies: await suggestTechnologiesMock(params),
+  }));
 });
 
 afterEach(() => {
@@ -71,6 +78,33 @@ async function typeInBar(value: string) {
   const input = screen.getByRole("combobox");
   await userEvent.type(input, value);
   await new Promise((r) => setTimeout(r, 250));
+}
+
+function emptyTypeaheadResults(): SearchBarTypeaheadResults {
+  return {
+    locations: [],
+    companies: [],
+    occupations: [],
+    seniorities: [],
+    technologies: [],
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function changeQuery(value: string) {
+  fireEvent.change(screen.getByRole("combobox"), { target: { value } });
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 225));
+  });
 }
 
 describe("SearchBar structured suggestion sections (#3082)", () => {
@@ -139,5 +173,66 @@ describe("SearchBar structured suggestion sections (#3082)", () => {
     fireEvent.mouseDown(row);
 
     expect(onAddWorkMode).toHaveBeenCalledWith("remote");
+  });
+
+  it("ignores an older request that resolves after the latest query", async () => {
+    const oldRequest = deferred<SearchBarTypeaheadResults>();
+    const newRequest = deferred<SearchBarTypeaheadResults>();
+    suggestSearchBarMock.mockImplementation(({ query }: { query: string }) =>
+      query === "old" ? oldRequest.promise : newRequest.promise,
+    );
+    render(<SearchBar />);
+
+    await changeQuery("old");
+    await changeQuery("new");
+    expect(suggestSearchBarMock).toHaveBeenCalledTimes(2);
+
+    newRequest.resolve({
+      ...emptyTypeaheadResults(),
+      companies: [{ id: "new", name: "New Company", slug: "new", icon: null }],
+    });
+    expect(await screen.findByText("New Company")).toBeTruthy();
+
+    await act(async () => {
+      oldRequest.resolve({
+        ...emptyTypeaheadResults(),
+        companies: [{ id: "old", name: "Old Company", slug: "old", icon: null }],
+      });
+      await oldRequest.promise;
+    });
+
+    expect(screen.getByText("New Company")).toBeTruthy();
+    expect(screen.queryByText("Old Company")).toBeNull();
+  });
+
+  it("retains results while loading, then clears them after a caught terminal rejection", async () => {
+    const failedRequest = deferred<SearchBarTypeaheadResults>();
+    suggestSearchBarMock
+      .mockResolvedValueOnce({
+        ...emptyTypeaheadResults(),
+        companies: [{ id: "old", name: "Old Company", slug: "old", icon: null }],
+      })
+      .mockReturnValueOnce(failedRequest.promise);
+    render(<SearchBar />);
+
+    await changeQuery("old");
+    expect(await screen.findByText("Old Company")).toBeTruthy();
+
+    await changeQuery("new");
+    expect(screen.getByText("Old Company")).toBeTruthy();
+
+    await act(async () => {
+      failedRequest.reject(new Error("terminal fallback failed"));
+      try {
+        await failedRequest.promise;
+      } catch {
+        // The hook owns the rejection; awaiting here only flushes the test task.
+      }
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Old Company")).toBeNull();
+      expect(screen.getByRole("combobox").getAttribute("aria-expanded")).toBe("false");
+    });
   });
 });

--- a/apps/web/src/components/search/search-bar-typeahead.ts
+++ b/apps/web/src/components/search/search-bar-typeahead.ts
@@ -1,17 +1,11 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { suggestCompanies } from "@/lib/actions/company";
 import type { CompanySuggestion } from "@/lib/actions/company";
 import type { LocationSuggestion } from "@/lib/actions/locations";
 import type { TaxonomySuggestion } from "@/lib/actions/taxonomy";
 import type { WorkMode } from "@/lib/search/types";
-import {
-  runSuggestLocations as suggestLocations,
-  runSuggestOccupations as suggestOccupations,
-  runSuggestSeniorities as suggestSeniorities,
-  runSuggestTechnologies as suggestTechnologies,
-} from "@/lib/search/typeahead-runner";
+import { runSearchBarTypeahead } from "@/lib/search/typeahead-runner";
 
 /**
  * Work-mode autocomplete entries - fixed three values, matched
@@ -120,8 +114,9 @@ export function useSearchBarTypeahead({
   const [seniorityResults, setSeniorityResults] = useState<TaxonomySuggestion[]>([]);
   const [technologyResults, setTechnologyResults] = useState<TaxonomySuggestion[]>([]);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const requestGenerationRef = useRef(0);
 
-  const clearResults = useCallback(() => {
+  const clearResultState = useCallback(() => {
     setLocationResults([]);
     setCompanyResults([]);
     setOccupationResults([]);
@@ -129,9 +124,19 @@ export function useSearchBarTypeahead({
     setTechnologyResults([]);
   }, []);
 
+  const clearResults = useCallback(() => {
+    requestGenerationRef.current += 1;
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    clearResultState();
+  }, [clearResultState]);
+
   useEffect(() => {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
+      requestGenerationRef.current += 1;
     };
   }, []);
 
@@ -145,9 +150,16 @@ export function useSearchBarTypeahead({
         return;
       }
 
-      if (matchWorkModes(query, selectedWorkModes).length > 0) {
+      const hasWorkModeMatches = matchWorkModes(query, selectedWorkModes).length > 0;
+      if (hasWorkModeMatches) {
         onOpen();
       }
+
+      // Every accepted input owns a generation. Older promises may continue
+      // (server actions cannot be cancelled reliably), but their completion
+      // is ignored before any state or dropdown callbacks are touched.
+      const generation = requestGenerationRef.current + 1;
+      requestGenerationRef.current = generation;
 
       const baseFilters: TypeaheadFilters = {
         companyId,
@@ -164,73 +176,67 @@ export function useSearchBarTypeahead({
         const { [omit]: _omitted, ...rest } = baseFilters;
         return rest;
       };
-      const setFilteredResults = <T,>(
-        promise: Promise<T[]>,
-        filter: (items: T[]) => T[],
-        setResults: (items: T[]) => void,
-      ) => {
-        promise.then((items) => {
-          const filtered = filter(items);
-          setResults(filtered);
-          if (filtered.length > 0) onOpen();
-        });
-      };
 
       debounceRef.current = setTimeout(() => {
+        debounceRef.current = null;
         onResetActiveIndex();
 
-        if (scopedToCompany) {
-          setCompanyResults([]);
-        } else {
-          suggestCompanies({ query }).then((companies) => {
-            setCompanyResults(companies);
-            if (companies.length > 0 || query.trim().length >= 2) {
-              onOpen();
-            }
-          });
-        }
+        void runSearchBarTypeahead({
+          query,
+          locale: lang,
+          userLat,
+          userLng,
+          includeCompanies: !scopedToCompany,
+          locationFilters: filtersExcluding("locationIds"),
+          occupationFilters: filtersExcluding("occupationIds"),
+          seniorityFilters: filtersExcluding("seniorityIds"),
+          technologyFilters: filtersExcluding("technologyIds"),
+        })
+          .then((results) => {
+            if (requestGenerationRef.current !== generation) return;
 
-        setFilteredResults(
-          suggestLocations({
-            query,
-            locale: lang,
-            userLat,
-            userLng,
-            filters: filtersExcluding("locationIds"),
-          }),
-          (locs) =>
-            selectedLocationIds
-              ? locs.filter((r) => !selectedLocationIds.has(r.id))
-              : locs.filter((r) => !selectedLocationSlugs.has(r.slug)),
-          setLocationResults,
-        );
-        setFilteredResults(
-          suggestOccupations({
-            query,
-            locale: lang,
-            filters: filtersExcluding("occupationIds"),
-          }),
-          (occs) => occs.filter((r) => !selectedOccupationIds.has(r.id)),
-          setOccupationResults,
-        );
-        setFilteredResults(
-          suggestSeniorities({
-            query,
-            locale: lang,
-            filters: filtersExcluding("seniorityIds"),
-          }),
-          (sens) => sens.filter((r) => !selectedSeniorityIds.has(r.id)),
-          setSeniorityResults,
-        );
-        setFilteredResults(
-          suggestTechnologies({
-            query,
-            locale: lang,
-            filters: filtersExcluding("technologyIds"),
-          }),
-          (techs) => techs.filter((r) => !selectedTechnologyIds.has(r.id)),
-          setTechnologyResults,
-        );
+            const locations = selectedLocationIds
+              ? results.locations.filter((item) => !selectedLocationIds.has(item.id))
+              : results.locations.filter((item) => !selectedLocationSlugs.has(item.slug));
+            const occupations = results.occupations.filter(
+              (item) => !selectedOccupationIds.has(item.id),
+            );
+            const seniorities = results.seniorities.filter(
+              (item) => !selectedSeniorityIds.has(item.id),
+            );
+            const technologies = results.technologies.filter(
+              (item) => !selectedTechnologyIds.has(item.id),
+            );
+
+            setLocationResults(locations);
+            setCompanyResults(scopedToCompany ? [] : results.companies);
+            setOccupationResults(occupations);
+            setSeniorityResults(seniorities);
+            setTechnologyResults(technologies);
+
+            if (
+              !scopedToCompany ||
+              hasWorkModeMatches ||
+              locations.length > 0 ||
+              occupations.length > 0 ||
+              seniorities.length > 0 ||
+              technologies.length > 0
+            ) {
+              onOpen();
+            } else {
+              onClose();
+            }
+          })
+          .catch(() => {
+            if (requestGenerationRef.current !== generation) return;
+            // Explicit failure policy: retain prior results while a current
+            // query is loading, then clear them if every direct/server
+            // fallback path for that generation fails. Client-only work-mode
+            // matches remain visible because they need no network response.
+            clearResultState();
+            if (hasWorkModeMatches) onOpen();
+            else onClose();
+          });
       }, 200);
     },
     [
@@ -240,6 +246,7 @@ export function useSearchBarTypeahead({
       baseOccupationIds,
       baseSeniorityIds,
       baseTechnologyIds,
+      clearResultState,
       clearResults,
       companyId,
       lang,

--- a/apps/web/src/lib/actions/typeahead.ts
+++ b/apps/web/src/lib/actions/typeahead.ts
@@ -1,0 +1,53 @@
+"use server";
+
+import { suggestCompanies } from "@/lib/services/company";
+import { suggestLocations } from "@/lib/services/locations";
+import {
+  suggestOccupations,
+  suggestSeniorities,
+  suggestTechnologies,
+} from "@/lib/services/taxonomy";
+import type {
+  SearchBarTypeaheadParams,
+  SearchBarTypeaheadResults,
+} from "@/lib/search/typeahead-contract";
+
+/**
+ * One server-action boundary for a complete search-bar suggestion query.
+ * The service functions retain their independent cache slots while the
+ * browser pays for one action request instead of five.
+ */
+export async function suggestSearchBarTypeahead(
+  params: SearchBarTypeaheadParams,
+): Promise<SearchBarTypeaheadResults> {
+  const [locations, companies, occupations, seniorities, technologies] =
+    await Promise.all([
+      suggestLocations({
+        query: params.query,
+        locale: params.locale,
+        userLat: params.userLat,
+        userLng: params.userLng,
+        filters: params.locationFilters,
+      }),
+      params.includeCompanies
+        ? suggestCompanies({ query: params.query })
+        : Promise.resolve([]),
+      suggestOccupations({
+        query: params.query,
+        locale: params.locale,
+        filters: params.occupationFilters,
+      }),
+      suggestSeniorities({
+        query: params.query,
+        locale: params.locale,
+        filters: params.seniorityFilters,
+      }),
+      suggestTechnologies({
+        query: params.query,
+        locale: params.locale,
+        filters: params.technologyFilters,
+      }),
+    ]);
+
+  return { locations, companies, occupations, seniorities, technologies };
+}

--- a/apps/web/src/lib/search/__tests__/typeahead-request-budget.test.ts
+++ b/apps/web/src/lib/search/__tests__/typeahead-request-budget.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { setTestEnv, withTestEnv } from "@/test-utils/env";
+import {
+  SEARCH_BAR_TYPEAHEAD_MAX_DATA_REQUESTS,
+  SEARCH_BAR_TYPEAHEAD_MAX_MULTI_SEARCH_REQUESTS,
+  type SearchBarTypeaheadResults,
+} from "../typeahead-contract";
+import { clearTypesenseBrowserConfig } from "../typesense-browser-key";
+import { suggestSearchBarBrowser } from "../typesense-browser-typeahead";
+
+const mocks = vi.hoisted(() => ({ serverBatch: vi.fn() }));
+
+vi.mock("@/lib/actions/locations", () => ({ suggestLocations: vi.fn() }));
+vi.mock("@/lib/actions/taxonomy", () => ({
+  suggestOccupations: vi.fn(),
+  suggestSeniorities: vi.fn(),
+  suggestTechnologies: vi.fn(),
+}));
+vi.mock("@/lib/actions/typeahead", () => ({
+  suggestSearchBarTypeahead: mocks.serverBatch,
+}));
+
+type DataRequestKind = "key" | "candidate" | "fallback" | "boost";
+
+const emptyResults: SearchBarTypeaheadResults = {
+  locations: [],
+  companies: [],
+  occupations: [],
+  seniorities: [],
+  technologies: [],
+};
+
+function makeDataFetch(options: { failFallback?: boolean } = {}) {
+  const calls: DataRequestKind[] = [];
+  const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
+    if (String(input) === "/api/typesense-key") {
+      calls.push("key");
+      return new Response(
+        JSON.stringify({
+          apiKey: "test-key",
+          host: "typesense.test",
+          port: 443,
+          protocol: "https",
+          expiresAt: Date.now() + 600_000,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    const searches = (JSON.parse(String(init?.body)) as {
+      searches: Array<Record<string, unknown>>;
+    }).searches;
+    const isBoost = searches.every((search) => search.collection === "job_posting");
+    const isFallback = searches.every(
+      (search) =>
+        (search.collection === "occupation" || search.collection === "seniority") &&
+        search.filter_by === "has_active_postings:true && locale:en",
+    );
+    const kind: DataRequestKind = isBoost ? "boost" : isFallback ? "fallback" : "candidate";
+    calls.push(kind);
+    if (kind === "fallback" && options.failFallback) {
+      return new Response("fallback failed", { status: 503 });
+    }
+
+    const results = searches.map((search) => {
+      if (search.collection === "location") {
+        return {
+          hits: [
+            {
+              document: {
+                location_id: 100,
+                slug: "berlin",
+                type: "city",
+                name_en: "Berlin",
+                parent_name: "Germany",
+              },
+            },
+          ],
+        };
+      }
+      if (search.collection === "company") {
+        return {
+          hits: [{ document: { id: "acme", name: "Acme", slug: "acme", icon: null } }],
+        };
+      }
+      if (search.collection === "technology") {
+        return {
+          hits: [{ document: { technology_id: 40, slug: "react", name: "React" } }],
+        };
+      }
+      if (search.collection === "occupation") {
+        return search.filter_by === "has_active_postings:true && locale:en"
+          ? {
+              hits: [
+                { document: { occupation_id: 20, slug: "engineer", name: "Engineer" } },
+              ],
+            }
+          : { hits: [] };
+      }
+      if (search.collection === "seniority") {
+        return search.filter_by === "has_active_postings:true && locale:en"
+          ? {
+              hits: [{ document: { seniority_id: 30, slug: "senior", name: "Senior" } }],
+            }
+          : { hits: [] };
+      }
+      return {
+        facet_counts: [
+          {
+            field_name: search.facet_by,
+            counts: [{ value: "100", count: 1 }],
+          },
+        ],
+      };
+    });
+    return new Response(JSON.stringify({ results }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  });
+  return { calls, fetchMock };
+}
+
+describe("search-bar application-data request budget", () => {
+  const originalFetch = globalThis.fetch;
+  withTestEnv({ NEXT_PUBLIC_TYPESENSE_DIRECT: "1" });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearTypesenseBrowserConfig();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("enforces cold-key, warm-key, and warm-candidate direct budgets", async () => {
+    const { calls, fetchMock } = makeDataFetch();
+    globalThis.fetch = fetchMock;
+    const filters = { keywords: ["engineer"] };
+    const coldParams = {
+      query: "budget-cold-de-6639",
+      locale: "de",
+      includeCompanies: true,
+      locationFilters: filters,
+      occupationFilters: filters,
+      seniorityFilters: filters,
+      technologyFilters: filters,
+    };
+
+    await suggestSearchBarBrowser(coldParams);
+    expect(calls).toEqual(["key", "candidate", "fallback", "boost"]);
+    expect(calls).toHaveLength(SEARCH_BAR_TYPEAHEAD_MAX_DATA_REQUESTS);
+
+    const beforeWarmCandidates = calls.length;
+    await suggestSearchBarBrowser(coldParams);
+    expect(calls.slice(beforeWarmCandidates)).toEqual(["boost"]);
+
+    const beforeWarmKey = calls.length;
+    await suggestSearchBarBrowser({
+      ...coldParams,
+      query: "budget-warm-key-de-6639",
+    });
+    expect(calls.slice(beforeWarmKey)).toEqual(["candidate", "fallback", "boost"]);
+    expect(calls.length - beforeWarmKey).toBe(
+      SEARCH_BAR_TYPEAHEAD_MAX_MULTI_SEARCH_REQUESTS,
+    );
+  });
+
+  it("uses one application data request with direct mode disabled", async () => {
+    setTestEnv({ NEXT_PUBLIC_TYPESENSE_DIRECT: "0" });
+    vi.resetModules();
+    mocks.serverBatch.mockResolvedValue(emptyResults);
+    globalThis.fetch = vi.fn(() => {
+      throw new Error("direct fetch must not run");
+    });
+    const { runSearchBarTypeahead } = await import("../typeahead-runner");
+
+    await expect(
+      runSearchBarTypeahead({ query: "budget-direct-off-6639", locale: "en", includeCompanies: true }),
+    ).resolves.toBe(emptyResults);
+    expect(mocks.serverBatch).toHaveBeenCalledOnce();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("stops a failed fallback phase before adding one server-action request", async () => {
+    setTestEnv({ NEXT_PUBLIC_TYPESENSE_DIRECT: "1" });
+    vi.resetModules();
+    const { calls, fetchMock } = makeDataFetch({ failFallback: true });
+    globalThis.fetch = fetchMock;
+    mocks.serverBatch.mockResolvedValue(emptyResults);
+    const { runSearchBarTypeahead } = await import("../typeahead-runner");
+
+    await expect(
+      runSearchBarTypeahead({
+        query: "budget-fallback-failure-de-6639",
+        locale: "de",
+        includeCompanies: true,
+      }),
+    ).resolves.toBe(emptyResults);
+
+    expect(calls).toEqual(["key", "candidate", "fallback"]);
+    expect(mocks.serverBatch).toHaveBeenCalledOnce();
+    expect(calls.length + mocks.serverBatch.mock.calls.length).toBe(
+      SEARCH_BAR_TYPEAHEAD_MAX_DATA_REQUESTS,
+    );
+  });
+
+  it("documents the data-request scope and wire-level exclusions", () => {
+    const docs = readFileSync(resolve(process.cwd(), "../../docs/11-typesense.md"), "utf8");
+    expect(docs).toContain("application-initiated data requests");
+    expect(docs).toContain("dynamic-import chunks");
+    expect(docs).toContain("`OPTIONS` preflights");
+  });
+});

--- a/apps/web/src/lib/search/__tests__/typeahead-runner-batch.test.ts
+++ b/apps/web/src/lib/search/__tests__/typeahead-runner-batch.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setTestEnv, withTestEnv } from "@/test-utils/env";
+import type {
+  SearchBarTypeaheadParams,
+  SearchBarTypeaheadResults,
+} from "../typeahead-contract";
+
+const mocks = vi.hoisted(() => ({
+  browserBatch: vi.fn(),
+  serverBatch: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/locations", () => ({ suggestLocations: vi.fn() }));
+vi.mock("@/lib/actions/taxonomy", () => ({
+  suggestOccupations: vi.fn(),
+  suggestSeniorities: vi.fn(),
+  suggestTechnologies: vi.fn(),
+}));
+vi.mock("@/lib/actions/typeahead", () => ({
+  suggestSearchBarTypeahead: mocks.serverBatch,
+}));
+vi.mock("../typesense-browser-typeahead", () => ({
+  suggestSearchBarBrowser: mocks.browserBatch,
+}));
+
+const params: SearchBarTypeaheadParams = {
+  query: "engineer",
+  locale: "en",
+  includeCompanies: true,
+};
+const results: SearchBarTypeaheadResults = {
+  locations: [],
+  companies: [],
+  occupations: [],
+  seniorities: [],
+  technologies: [],
+};
+
+describe("runSearchBarTypeahead", () => {
+  withTestEnv({ NEXT_PUBLIC_TYPESENSE_DIRECT: "1" });
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    setTestEnv({ NEXT_PUBLIC_TYPESENSE_DIRECT: "1" });
+  });
+
+  it("returns a successful direct batch without a server action", async () => {
+    mocks.browserBatch.mockResolvedValue(results);
+    const { runSearchBarTypeahead } = await import("../typeahead-runner");
+
+    await expect(runSearchBarTypeahead(params)).resolves.toBe(results);
+    expect(mocks.browserBatch).toHaveBeenCalledOnce();
+    expect(mocks.serverBatch).not.toHaveBeenCalled();
+  });
+
+  it("falls back through exactly one batched server action", async () => {
+    mocks.browserBatch.mockRejectedValue(new Error("direct search unavailable"));
+    mocks.serverBatch.mockResolvedValue(results);
+    const { runSearchBarTypeahead } = await import("../typeahead-runner");
+
+    await expect(runSearchBarTypeahead(params)).resolves.toBe(results);
+    expect(mocks.browserBatch).toHaveBeenCalledOnce();
+    expect(mocks.serverBatch).toHaveBeenCalledOnce();
+  });
+
+  it("uses one server action when direct search is disabled", async () => {
+    setTestEnv({ NEXT_PUBLIC_TYPESENSE_DIRECT: "0" });
+    vi.resetModules();
+    mocks.serverBatch.mockResolvedValue(results);
+    const { runSearchBarTypeahead } = await import("../typeahead-runner");
+
+    await expect(runSearchBarTypeahead(params)).resolves.toBe(results);
+    expect(mocks.browserBatch).not.toHaveBeenCalled();
+    expect(mocks.serverBatch).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/lib/search/__tests__/typesense-browser-typeahead.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense-browser-typeahead.test.ts
@@ -21,7 +21,10 @@ vi.mock("../typesense-browser-key", () => ({
   })),
 }));
 
-import { suggestLocationsBrowser } from "../typesense-browser-typeahead";
+import {
+  suggestLocationsBrowser,
+  suggestSearchBarBrowser,
+} from "../typesense-browser-typeahead";
 
 const EU_DOC = {
   location_id: 4,
@@ -151,5 +154,146 @@ describe("suggestLocationsBrowser — macro region aliases (#2939)", () => {
       name: "Berlin",
       parentName: "Germany",
     });
+  });
+});
+
+describe("suggestSearchBarBrowser — bounded multi_search plan (#6639)", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("batches all uncached candidate collections into one request", async () => {
+    const calls: Array<{ url: string; searches: Array<Record<string, unknown>> }> = [];
+    globalThis.fetch = vi.fn(async (input, init) => {
+      const searches = (JSON.parse(String(init?.body)) as {
+        searches: Array<Record<string, unknown>>;
+      }).searches;
+      calls.push({ url: String(input), searches });
+      return new Response(
+        JSON.stringify({ results: searches.map(() => ({ hits: [] })) }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    const params = {
+      query: "batch-candidates-6639",
+      locale: "en",
+      includeCompanies: true,
+    };
+    await suggestSearchBarBrowser(params);
+    await suggestSearchBarBrowser(params);
+
+    // The second call is served entirely from the existing per-kind LRUs.
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toBe("https://typesense.test:443/multi_search");
+    expect(calls[0].searches.map((search) => search.collection)).toEqual([
+      "location",
+      "company",
+      "occupation",
+      "seniority",
+      "technology",
+    ]);
+  });
+
+  it("uses at most three multi_search phases for fallback and posting boosts", async () => {
+    const calls: Array<Array<Record<string, unknown>>> = [];
+    globalThis.fetch = vi.fn(async (_input, init) => {
+      const searches = (JSON.parse(String(init?.body)) as {
+        searches: Array<Record<string, unknown>>;
+      }).searches;
+      calls.push(searches);
+      const results = searches.map((search) => {
+        if (search.collection === "location") {
+          return { hits: [{ document: BERLIN_DOC }] };
+        }
+        if (search.collection === "company") {
+          return {
+            hits: [{ document: { id: "acme", name: "Acme", slug: "acme", icon: null } }],
+          };
+        }
+        if (search.collection === "technology") {
+          return {
+            hits: [
+              { document: { technology_id: 40, slug: "react", name: "React" } },
+              { document: { technology_id: 41, slug: "rust", name: "Rust" } },
+            ],
+          };
+        }
+        if (
+          search.collection === "occupation" &&
+          search.filter_by === "has_active_postings:true && locale:en"
+        ) {
+          return {
+            hits: [{ document: { occupation_id: 20, slug: "engineer", name: "Engineer" } }],
+          };
+        }
+        if (
+          search.collection === "seniority" &&
+          search.filter_by === "has_active_postings:true && locale:en"
+        ) {
+          return {
+            hits: [{ document: { seniority_id: 30, slug: "senior", name: "Senior" } }],
+          };
+        }
+        if (search.collection === "job_posting") {
+          const matchedId =
+            search.facet_by === "location_ids"
+              ? "100"
+              : search.facet_by === "occupation_id"
+                ? "20"
+                : search.facet_by === "seniority_id"
+                  ? "30"
+                  : "41";
+          return {
+            facet_counts: [
+              {
+                field_name: search.facet_by,
+                counts: [{ value: matchedId, count: 1 }],
+              },
+            ],
+          };
+        }
+        return { hits: [] };
+      });
+      return new Response(JSON.stringify({ results }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+
+    const filters = { keywords: ["engineer"] };
+    const result = await suggestSearchBarBrowser({
+      query: "cold-de-plan-6639",
+      locale: "de",
+      includeCompanies: true,
+      locationFilters: filters,
+      occupationFilters: filters,
+      seniorityFilters: filters,
+      technologyFilters: filters,
+    });
+
+    expect(calls).toHaveLength(3);
+    expect(calls[0].map((search) => search.collection)).toEqual([
+      "location",
+      "company",
+      "occupation",
+      "seniority",
+      "technology",
+    ]);
+    expect(calls[1].map((search) => search.collection)).toEqual([
+      "occupation",
+      "seniority",
+    ]);
+    expect(calls[2]).toHaveLength(4);
+    expect(calls[2].every((search) => search.collection === "job_posting")).toBe(true);
+    expect(result.companies[0].name).toBe("Acme");
+    expect(result.occupations[0].name).toBe("Engineer");
+    expect(result.seniorities[0].name).toBe("Senior");
+    expect(result.technologies.map((technology) => technology.name)).toEqual([
+      "Rust",
+      "React",
+    ]);
   });
 });

--- a/apps/web/src/lib/search/typeahead-contract.ts
+++ b/apps/web/src/lib/search/typeahead-contract.ts
@@ -1,0 +1,24 @@
+import type { CompanySuggestion } from "@/lib/services/company";
+import type { LocationSuggestion } from "@/lib/services/locations";
+import type { TaxonomySuggestion } from "@/lib/services/taxonomy";
+import type { TypeaheadBoostFilters } from "./typeahead-boost";
+
+export interface SearchBarTypeaheadParams {
+  query: string;
+  locale: string;
+  userLat?: number;
+  userLng?: number;
+  includeCompanies: boolean;
+  locationFilters?: TypeaheadBoostFilters;
+  occupationFilters?: TypeaheadBoostFilters;
+  seniorityFilters?: TypeaheadBoostFilters;
+  technologyFilters?: TypeaheadBoostFilters;
+}
+
+export interface SearchBarTypeaheadResults {
+  locations: LocationSuggestion[];
+  companies: CompanySuggestion[];
+  occupations: TaxonomySuggestion[];
+  seniorities: TaxonomySuggestion[];
+  technologies: TaxonomySuggestion[];
+}

--- a/apps/web/src/lib/search/typeahead-contract.ts
+++ b/apps/web/src/lib/search/typeahead-contract.ts
@@ -3,6 +3,10 @@ import type { LocationSuggestion } from "@/lib/services/locations";
 import type { TaxonomySuggestion } from "@/lib/services/taxonomy";
 import type { TypeaheadBoostFilters } from "./typeahead-boost";
 
+/** Application-initiated data fetches; excludes chunk loads and CORS OPTIONS. */
+export const SEARCH_BAR_TYPEAHEAD_MAX_DATA_REQUESTS = 4;
+export const SEARCH_BAR_TYPEAHEAD_MAX_MULTI_SEARCH_REQUESTS = 3;
+
 export interface SearchBarTypeaheadParams {
   query: string;
   locale: string;

--- a/apps/web/src/lib/search/typeahead-runner.ts
+++ b/apps/web/src/lib/search/typeahead-runner.ts
@@ -44,15 +44,20 @@ async function tryBrowser<T>(fn: () => Promise<T>): Promise<T | null> {
 /**
  * Executes one complete search-bar query through a bounded request plan.
  *
- * Request budget per debounced query:
+ * Application-data request budget per debounced query:
  * - direct disabled: exactly one server-action request;
  * - direct enabled, warm key: at most three Typesense `multi_search` requests
  *   (initial candidates, non-English fallback, posting-count boosts);
  * - direct enabled, cold key: the same plus one scoped-key request;
  * - if a direct candidate/fallback phase fails, one server-action fallback is
- *   added. Because a failure stops the direct plan, the absolute maximum is
- *   four browser network requests. Boost failures deliberately retain the
- *   unboosted candidates and do not trigger another request.
+ *   added. Because a failure stops the direct plan, the maximum is four
+ *   application-initiated data requests. Boost failures deliberately retain
+ *   the unboosted candidates and do not trigger another request.
+ *
+ * This budget does not count Next.js chunks loaded by the dynamic imports or
+ * browser-generated CORS OPTIONS preflights. Those are transport/cache work,
+ * not data requests initiated by this runner; docs/11-typesense.md records
+ * both exclusions so the bound is not mistaken for a wire-level ceiling.
  */
 export async function runSearchBarTypeahead(
   params: SearchBarTypeaheadParams,

--- a/apps/web/src/lib/search/typeahead-runner.ts
+++ b/apps/web/src/lib/search/typeahead-runner.ts
@@ -11,6 +11,10 @@ import {
   type TaxonomySuggestion,
 } from "@/lib/actions/taxonomy";
 import type { TypeaheadBoostFilters } from "./typeahead-boost";
+import type {
+  SearchBarTypeaheadParams,
+  SearchBarTypeaheadResults,
+} from "./typeahead-contract";
 
 const directEnabled = process.env.NEXT_PUBLIC_TYPESENSE_DIRECT === "1";
 
@@ -35,6 +39,32 @@ async function tryBrowser<T>(fn: () => Promise<T>): Promise<T | null> {
   } catch {
     return null;
   }
+}
+
+/**
+ * Executes one complete search-bar query through a bounded request plan.
+ *
+ * Request budget per debounced query:
+ * - direct disabled: exactly one server-action request;
+ * - direct enabled, warm key: at most three Typesense `multi_search` requests
+ *   (initial candidates, non-English fallback, posting-count boosts);
+ * - direct enabled, cold key: the same plus one scoped-key request;
+ * - if a direct candidate/fallback phase fails, one server-action fallback is
+ *   added. Because a failure stops the direct plan, the absolute maximum is
+ *   four browser network requests. Boost failures deliberately retain the
+ *   unboosted candidates and do not trigger another request.
+ */
+export async function runSearchBarTypeahead(
+  params: SearchBarTypeaheadParams,
+): Promise<SearchBarTypeaheadResults> {
+  const browser = await tryBrowser(async () => {
+    const m = await import("./typesense-browser-typeahead");
+    return m.suggestSearchBarBrowser(params);
+  });
+  if (browser !== null) return browser;
+
+  const m = await import("@/lib/actions/typeahead");
+  return m.suggestSearchBarTypeahead(params);
 }
 
 export async function runSuggestLocations(

--- a/apps/web/src/lib/search/typesense-browser-typeahead.ts
+++ b/apps/web/src/lib/search/typesense-browser-typeahead.ts
@@ -3,6 +3,11 @@ import { buildFilterString, POSTING_BASE_FILTER } from "./typesense-filters";
 import type { TypeaheadBoostFilters } from "./typeahead-boost";
 import type { LocationSuggestion } from "@/lib/actions/locations";
 import type { TaxonomySuggestion } from "@/lib/actions/taxonomy";
+import type { CompanySuggestion } from "@/lib/services/company";
+import type {
+  SearchBarTypeaheadParams,
+  SearchBarTypeaheadResults,
+} from "./typeahead-contract";
 
 export type { LocationSuggestion, TaxonomySuggestion };
 
@@ -56,6 +61,13 @@ interface RawSearchResponse<T> {
     field_name: string;
     counts: Array<{ value: string; count: number }>;
   }>;
+  error?: string;
+  code?: number;
+}
+
+interface MultiSearchRequest {
+  collection: string;
+  [key: string]: unknown;
 }
 
 async function searchOne<T>(
@@ -75,6 +87,30 @@ async function searchOne<T>(
   });
   if (!res.ok) throw new Error(`typesense ${collection} ${res.status}`);
   return res.json();
+}
+
+async function searchMany(
+  cfg: TypesenseBrowserConfig,
+  searches: MultiSearchRequest[],
+): Promise<RawSearchResponse<Record<string, unknown>>[]> {
+  if (searches.length === 0) return [];
+  const url = `${cfg.protocol}://${cfg.host}:${cfg.port}/multi_search`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-typesense-api-key": cfg.apiKey,
+    },
+    body: JSON.stringify({ searches }),
+  });
+  if (!res.ok) throw new Error(`typesense multi_search ${res.status}`);
+  const body = (await res.json()) as {
+    results?: RawSearchResponse<Record<string, unknown>>[];
+  };
+  if (!body.results || body.results.length !== searches.length) {
+    throw new Error("typesense multi_search returned an incomplete result set");
+  }
+  return body.results;
 }
 
 async function boost<T>(
@@ -225,6 +261,13 @@ interface TechnologyDoc {
   name?: string;
 }
 
+interface CompanyDoc {
+  id: string;
+  name: string;
+  slug: string;
+  icon?: string | null;
+}
+
 function mapAliasMatch(
   hit: SearchHit<unknown>,
   displayName: string,
@@ -232,6 +275,324 @@ function mapAliasMatch(
   const ah = hit.highlights?.find((h) => h.field === "aliases");
   const matched = ah?.snippets?.[0]?.replace(/<\/?mark>/g, "");
   return matched && matched !== displayName ? matched : undefined;
+}
+
+function requireSearchResult<T>(
+  result: RawSearchResponse<T>,
+  kind: string,
+): RawSearchResponse<T> {
+  if (result.error) {
+    throw new Error(`typesense ${kind}: ${result.error}`);
+  }
+  return result;
+}
+
+function makeBoostSearch<T extends { id: number }>(
+  candidates: T[],
+  facetField: string,
+  filters: TypeaheadBoostFilters | undefined,
+): MultiSearchRequest | null {
+  if (!filters || candidates.length === 0) return null;
+  const filterStr = buildFilterString(filters);
+  const hasKeywords = filters.keywords && filters.keywords.length > 0;
+  if (!filterStr && !hasKeywords) return null;
+
+  const ids = candidates.map((candidate) => candidate.id);
+  const filterParts = [POSTING_BASE_FILTER, `${facetField}:[${ids.join(",")}]`];
+  if (filterStr) filterParts.push(filterStr);
+  return {
+    collection: "job_posting",
+    q: hasKeywords ? filters.keywords!.join(" ") : "*",
+    query_by: "title",
+    filter_by: filterParts.join(" && "),
+    facet_by: facetField,
+    facet_strategy: "exhaustive",
+    max_facet_values: ids.length,
+    per_page: 0,
+  };
+}
+
+function applyBoostResult<T extends { id: number }>(
+  candidates: T[],
+  facetField: string,
+  result: RawSearchResponse<Record<string, unknown>>,
+): T[] {
+  // Boosting is an optional ranking refinement. Match the legacy direct
+  // path by retaining candidate order when this individual facet fails.
+  if (result.error) return candidates;
+  const facet = result.facet_counts?.find((entry) => entry.field_name === facetField);
+  if (!facet) return candidates;
+  const matched = new Set(
+    facet.counts.filter((entry) => entry.count > 0).map((entry) => entry.value),
+  );
+  return [
+    ...candidates.filter((candidate) => matched.has(String(candidate.id))),
+    ...candidates.filter((candidate) => !matched.has(String(candidate.id))),
+  ];
+}
+
+/**
+ * Batched direct-search implementation for the shared search bar.
+ *
+ * Candidate collections share one `multi_search`; non-English fallback
+ * collections share a second request only when needed; all posting-count
+ * ranking facets share a final request. The module-level LRUs remain the
+ * same slots used by the individual typeahead functions below.
+ */
+export async function suggestSearchBarBrowser(
+  params: SearchBarTypeaheadParams,
+): Promise<SearchBarTypeaheadResults> {
+  const q = params.query.trim();
+  if (q.length < 2) {
+    return {
+      locations: [],
+      companies: [],
+      occupations: [],
+      seniorities: [],
+      technologies: [],
+    };
+  }
+
+  const locationKey = suggestCacheKey(
+    "loc",
+    q,
+    params.locale,
+    params.userLat != null ? Math.round(params.userLat * 100) / 100 : undefined,
+    params.userLng != null ? Math.round(params.userLng * 100) / 100 : undefined,
+  );
+  const companyKey = suggestCacheKey("company", q);
+  const occupationKey = suggestCacheKey("occ", q, params.locale);
+  const seniorityKey = suggestCacheKey("sen", q, params.locale);
+  const technologyKey = suggestCacheKey("tech", q);
+
+  const cachedLocations = cacheGet<LocationSuggestion[]>(locationKey);
+  const cachedCompanies = params.includeCompanies
+    ? cacheGet<CompanySuggestion[]>(companyKey)
+    : [];
+  const cachedOccupations = cacheGet<TaxonomySuggestion[]>(occupationKey);
+  const cachedSeniorities = cacheGet<TaxonomySuggestion[]>(seniorityKey);
+  const cachedTechnologies = cacheGet<TaxonomySuggestion[]>(technologyKey);
+
+  let locations = cachedLocations;
+  let companies = cachedCompanies;
+  let occupations = cachedOccupations;
+  let seniorities = cachedSeniorities;
+  let technologies = cachedTechnologies;
+
+  const hasGeo = params.userLat != null && params.userLng != null;
+  const locationSort = hasGeo
+    ? `_text_match:desc,coordinates(${params.userLat},${params.userLng}, precision: 5km):asc,active_posting_count:desc`
+    : "_text_match:desc,active_posting_count:desc";
+  const locationQueryBy =
+    params.locale !== "en" ? `name_${params.locale},name_en,aliases` : "name_en,aliases";
+  const locationWeights = params.locale !== "en" ? "3,2,1" : "2,1";
+  const localeSearch = {
+    q,
+    query_by: "name,aliases",
+    filter_by: `has_active_postings:true && locale:${params.locale}`,
+    sort_by: "_text_match:desc,active_posting_count:desc",
+    per_page: 5,
+    prefix: "true",
+    num_typos: "1",
+  };
+
+  type CandidateKind = "location" | "company" | "occupation" | "seniority" | "technology";
+  const candidateKinds: CandidateKind[] = [];
+  const candidateSearches: MultiSearchRequest[] = [];
+  const addCandidate = (kind: CandidateKind, search: MultiSearchRequest) => {
+    candidateKinds.push(kind);
+    candidateSearches.push(search);
+  };
+
+  if (locations === null) {
+    addCandidate("location", {
+      collection: "location",
+      q,
+      query_by: locationQueryBy,
+      query_by_weights: locationWeights,
+      filter_by: "has_active_postings:true",
+      sort_by: locationSort,
+      per_page: 8,
+      prefix: "true",
+      num_typos: "1",
+      drop_tokens_threshold: 0,
+    });
+  }
+  if (params.includeCompanies && companies === null) {
+    addCandidate("company", {
+      collection: "company",
+      q,
+      query_by: "name",
+      filter_by: "active_posting_count:>0",
+      sort_by: "_text_match:desc,active_posting_count:desc",
+      per_page: 5,
+      prefix: true,
+      num_typos: 1,
+    });
+  }
+  if (occupations === null) {
+    addCandidate("occupation", { collection: "occupation", ...localeSearch });
+  }
+  if (seniorities === null) {
+    addCandidate("seniority", { collection: "seniority", ...localeSearch });
+  }
+  if (technologies === null) {
+    addCandidate("technology", {
+      collection: "technology",
+      q,
+      query_by: "name,slug",
+      filter_by: "has_active_postings:true",
+      sort_by: "_text_match:desc,active_posting_count:desc",
+      per_page: 5,
+      prefix: "true",
+      num_typos: "0",
+    });
+  }
+
+  let cfg: TypesenseBrowserConfig | null = null;
+  const getConfig = async () => {
+    cfg ??= await getTypesenseBrowserConfig();
+    return cfg;
+  };
+  const candidateResults = candidateSearches.length
+    ? await searchMany(await getConfig(), candidateSearches)
+    : [];
+  for (let index = 0; index < candidateKinds.length; index += 1) {
+    const kind = candidateKinds[index];
+    const result = requireSearchResult(candidateResults[index], kind);
+    if (kind === "location") {
+      locations = (result.hits ?? []).map((hit) => {
+        const doc = hit.document as unknown as LocationDoc;
+        return {
+          id: doc.location_id,
+          slug: doc.slug,
+          name: (doc[`name_${params.locale}`] ?? doc.name_en ?? doc.slug) as string,
+          type: doc.type as LocationSuggestion["type"],
+          parentName: doc.parent_name ?? null,
+        };
+      });
+      cacheSet(locationKey, locations);
+    } else if (kind === "company") {
+      companies = (result.hits ?? []).map((hit) => {
+        const doc = hit.document as unknown as CompanyDoc;
+        return {
+          id: String(doc.id),
+          name: String(doc.name ?? ""),
+          slug: String(doc.slug ?? ""),
+          icon: typeof doc.icon === "string" ? doc.icon : null,
+        };
+      });
+      cacheSet(companyKey, companies);
+    } else if (kind === "occupation" || kind === "seniority") {
+      const mapped = (result.hits ?? []).map((hit) => {
+        const doc = hit.document as unknown as OccupationDoc | SeniorityDoc;
+        return {
+          id: "occupation_id" in doc ? doc.occupation_id : doc.seniority_id,
+          slug: doc.slug,
+          name: doc.name,
+          matchedName: mapAliasMatch(hit as SearchHit<unknown>, doc.name),
+        };
+      });
+      if (kind === "occupation") occupations = mapped;
+      else seniorities = mapped;
+    } else {
+      technologies = (result.hits ?? []).map((hit) => {
+        const doc = hit.document as unknown as TechnologyDoc;
+        return {
+          id: doc.technology_id,
+          slug: doc.slug,
+          name: doc.name ?? doc.slug,
+        };
+      });
+      cacheSet(technologyKey, technologies);
+    }
+  }
+
+  // The locale-aware cache stores the final fallback result, not the empty
+  // first pass, so subsequent queries do not repeat the fallback phase.
+  type FallbackKind = "occupation" | "seniority";
+  const fallbackKinds: FallbackKind[] = [];
+  const fallbackSearches: MultiSearchRequest[] = [];
+  const englishFallback = {
+    ...localeSearch,
+    filter_by: "has_active_postings:true && locale:en",
+  };
+  if (cachedOccupations === null && occupations?.length === 0 && params.locale !== "en") {
+    fallbackKinds.push("occupation");
+    fallbackSearches.push({ collection: "occupation", ...englishFallback });
+  }
+  if (cachedSeniorities === null && seniorities?.length === 0 && params.locale !== "en") {
+    fallbackKinds.push("seniority");
+    fallbackSearches.push({ collection: "seniority", ...englishFallback });
+  }
+  const fallbackResults = fallbackSearches.length
+    ? await searchMany(await getConfig(), fallbackSearches)
+    : [];
+  for (let index = 0; index < fallbackKinds.length; index += 1) {
+    const kind = fallbackKinds[index];
+    const result = requireSearchResult(fallbackResults[index], `${kind} locale fallback`);
+    const mapped = (result.hits ?? []).map((hit) => {
+      const doc = hit.document as unknown as OccupationDoc | SeniorityDoc;
+      return {
+        id: "occupation_id" in doc ? doc.occupation_id : doc.seniority_id,
+        slug: doc.slug,
+        name: doc.name,
+        matchedName: mapAliasMatch(hit as SearchHit<unknown>, doc.name),
+      };
+    });
+    if (kind === "occupation") occupations = mapped;
+    else seniorities = mapped;
+  }
+  if (cachedOccupations === null) cacheSet(occupationKey, occupations ?? []);
+  if (cachedSeniorities === null) cacheSet(seniorityKey, seniorities ?? []);
+
+  type BoostKind = "location" | "occupation" | "seniority" | "technology";
+  const boostKinds: BoostKind[] = [];
+  const boostSearches: MultiSearchRequest[] = [];
+  const addBoost = (
+    kind: BoostKind,
+    candidates: Array<{ id: number }>,
+    facetField: string,
+    filters: TypeaheadBoostFilters | undefined,
+  ) => {
+    const search = makeBoostSearch(candidates, facetField, filters);
+    if (!search) return;
+    boostKinds.push(kind);
+    boostSearches.push(search);
+  };
+  addBoost("location", locations ?? [], "location_ids", params.locationFilters);
+  addBoost("occupation", occupations ?? [], "occupation_id", params.occupationFilters);
+  addBoost("seniority", seniorities ?? [], "seniority_id", params.seniorityFilters);
+  addBoost("technology", technologies ?? [], "technology_ids", params.technologyFilters);
+
+  try {
+    const boostResults = boostSearches.length
+      ? await searchMany(await getConfig(), boostSearches)
+      : [];
+    for (let index = 0; index < boostKinds.length; index += 1) {
+      const kind = boostKinds[index];
+      if (kind === "location") {
+        locations = applyBoostResult(locations ?? [], "location_ids", boostResults[index]);
+      } else if (kind === "occupation") {
+        occupations = applyBoostResult(occupations ?? [], "occupation_id", boostResults[index]);
+      } else if (kind === "seniority") {
+        seniorities = applyBoostResult(seniorities ?? [], "seniority_id", boostResults[index]);
+      } else {
+        technologies = applyBoostResult(technologies ?? [], "technology_ids", boostResults[index]);
+      }
+    }
+  } catch {
+    // Posting-count boosts are best-effort. Candidate relevance remains
+    // correct, so retain it rather than falling back and exceeding budget.
+  }
+
+  return {
+    locations: locations ?? [],
+    companies: companies ?? [],
+    occupations: occupations ?? [],
+    seniorities: seniorities ?? [],
+    technologies: technologies ?? [],
+  };
 }
 
 interface LocaleAwareDoc {

--- a/docs/11-typesense.md
+++ b/docs/11-typesense.md
@@ -398,15 +398,19 @@ The web app can bypass the Vercel server-action proxy and call Typesense directl
 - **Browser provider**: `apps/web/src/lib/search/typesense-browser.ts` (postings/companies), `typesense-browser-typeahead.ts` (taxonomy suggest), `typesense-browser-watchlist.ts`. All thin -- no `typesense-js` runtime dependency in the browser bundle.
 - **Anon truncation**: enforced as a soft client-side cap (`ANON_MAX_COMPANIES`, `ANON_MAX_POSTINGS`, `ANON_MAX_WATCHLIST_POSTINGS`) matching the current server-action behaviour. Real abuse protection is the Cloudflare per-IP rate-limit on the tunnel hostname.
 - **Fallback**: every runner falls back to the corresponding server action when the browser path errors, returns degraded, or hits a code-explicit fallback case (e.g. watchlist >100 companies).
-- **Search-bar request budget**: direct mode batches candidate collections,
-  non-English fallbacks, and posting-count boost facets into at most three
-  sequential `multi_search` requests. A cold scoped key adds one request. A
-  failed direct candidate/fallback phase stops that plan and adds one batched
-  server-action fallback, so the absolute ceiling is four browser network
-  requests per debounced query (also four on a successful cold direct query, one
-  with direct mode disabled). Best-effort boost failure retains the unboosted
-  order and never adds a retry. Query generations prevent any older completion
-  from updating the dropdown.
+- **Search-bar application-data request budget**: direct mode batches candidate
+  collections, non-English fallbacks, and posting-count boost facets into at
+  most three sequential `multi_search` requests. The strict ceiling is four
+  application-initiated data requests per debounced query: one scoped-key fetch
+  plus three searches on a successful cold worst case, or a stopped direct plan
+  plus one batched server-action fallback. Direct-disabled mode uses one action.
+  A warm key removes the key fetch; warm candidates remove the candidate and
+  locale-fallback searches (a filter-aware warm hit can still need one boost
+  search). Best-effort boost failure retains unboosted order and never retries.
+  This is deliberately not described as an absolute browser-wire count: cold
+  Next.js dynamic-import chunks and browser-generated cross-origin CORS
+  `OPTIONS` preflights are cache/transport requests outside the runner's data
+  budget. Query generations prevent older completions from updating the UI.
 
 ## Read paths summary
 

--- a/docs/11-typesense.md
+++ b/docs/11-typesense.md
@@ -375,7 +375,8 @@ The web app can bypass the Vercel server-action proxy and call Typesense directl
 | Surface | Runner export | Mirrors server action |
 |---------|---------------|----------------------|
 | `/explore` search loop (filter chip changes, load-more) | `runSearchJobs`, `runListTopCompanies` | `searchJobs`, `listTopCompanies` |
-| Header / modal typeahead (per keystroke) | `runSuggestLocations`, `runSuggestOccupations`, `runSuggestSeniorities`, `runSuggestTechnologies` | `suggestLocations`, `suggestOccupations`, `suggestSeniorities`, `suggestTechnologies` |
+| Shared header search-bar typeahead (per debounced query) | `runSearchBarTypeahead` | `suggestSearchBarTypeahead` (one action for company + four taxonomy caches) |
+| Location-only pill / modal typeahead | `runSuggestLocations` | `suggestLocations` |
 | Company detail postings list | `runGetCompanyPostings` | `getCompanyPostings` (calls `loadPostingsWithCounts`) |
 | Public watchlist postings (≤100 companies) | `runGetWatchlistPostings` | `getWatchlistPostings` (≤100 path; >100 falls back) |
 
@@ -397,6 +398,15 @@ The web app can bypass the Vercel server-action proxy and call Typesense directl
 - **Browser provider**: `apps/web/src/lib/search/typesense-browser.ts` (postings/companies), `typesense-browser-typeahead.ts` (taxonomy suggest), `typesense-browser-watchlist.ts`. All thin -- no `typesense-js` runtime dependency in the browser bundle.
 - **Anon truncation**: enforced as a soft client-side cap (`ANON_MAX_COMPANIES`, `ANON_MAX_POSTINGS`, `ANON_MAX_WATCHLIST_POSTINGS`) matching the current server-action behaviour. Real abuse protection is the Cloudflare per-IP rate-limit on the tunnel hostname.
 - **Fallback**: every runner falls back to the corresponding server action when the browser path errors, returns degraded, or hits a code-explicit fallback case (e.g. watchlist >100 companies).
+- **Search-bar request budget**: direct mode batches candidate collections,
+  non-English fallbacks, and posting-count boost facets into at most three
+  sequential `multi_search` requests. A cold scoped key adds one request. A
+  failed direct candidate/fallback phase stops that plan and adds one batched
+  server-action fallback, so the absolute ceiling is four browser network
+  requests per debounced query (also four on a successful cold direct query, one
+  with direct mode disabled). Best-effort boost failure retains the unboosted
+  order and never adds a retry. Query generations prevent any older completion
+  from updating the dropdown.
 
 ## Read paths summary
 


### PR DESCRIPTION
## Summary

- sequence debounced typeahead generations so stale completions cannot overwrite current results
- catch terminal failures and keep failure behavior deterministic
- batch direct facet lookups and cap each debounced query at four application data requests
- document the budget boundary, including excluded browser chunk loads and CORS preflight

## Verification

- focused Vitest: 7 files, 27 tests, including out-of-order, rejection, cold/warm cache, direct, and fallback matrices
- Next route type generation and TypeScript
- full web ESLint
- git diff --check

## Post-deploy acceptance

Capture one cold and one warm browser network trace in production, plus a forced fallback trace, to confirm the documented application-data request ceiling and absence of unhandled rejections.

Addresses #6639