### PR TITLE
Make blog mention builds deterministic

### DIFF
--- a/.github/actions/setup-web-build-env/action.yml
+++ b/.github/actions/setup-web-build-env/action.yml
@@ -15,9 +15,9 @@ runs:
         APP_URL: ${{ inputs.app-url }}
       run: |
         {
-          # Backing services are intentionally absent. Company and watchlist
-          # lookups then exercise their supported build-time fallback instead
-          # of reaching production or treating an invalid placeholder as a DSN.
+          # Backing services are intentionally absent. Blog company/watchlist
+          # mentions use their reviewed repository snapshot and have a zero-call
+          # build budget; other routes exercise their supported build fallback.
           echo 'DATABASE_URL='
           echo 'DATABASE_URL_UNPOOLED='
           echo 'TYPESENSE_HOST='

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,6 +332,9 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Enforce zero-call blog mention build budget
+        run: pnpm --filter @jobseek/web blog-mentions:check
+
       - run: >
           pnpm --filter @jobseek/web exec vitest run
           --exclude src/lib/search/__tests__/typesense.e2e.test.ts

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -69,12 +69,6 @@ msgstr "{count, plural, one {# offene Stelle} other {# offene Stellen}}"
 msgid "company.similar.positionCount"
 msgstr "{count, plural, one {# offene Stelle} other {# offene Stellen}}"
 
-#. Stat label on a WatchlistCard mention card — pluralized 'active job' / 'active jobs'. {count} is the integer count.
-#. js-lingui-explicit-id
-#: src/components/blog/MdxMentions.tsx:358
-msgid "blog.mention.watchlist.activeJobsLabel"
-msgstr "{count, plural, one {offene Stelle} other {offene Stellen}}"
-
 #. Stat label on a CompanyCard mention card — pluralized 'active posting' / 'active postings'. {count} is the integer count.
 #. js-lingui-explicit-id
 #: src/components/blog/MdxMentions.tsx:290
@@ -1889,12 +1883,6 @@ msgstr "Wenn du ungewöhnliches Crawler-Verhalten bemerkst, es vorziehst, dass w
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:80
 msgid "watchlist.meta.inLocations"
 msgstr "in {locations}"
-
-#. Stat label on a WatchlistCard mention card — 'in the past year' (year-to-date jobs counted by the watchlist filters)
-#. js-lingui-explicit-id
-#: src/components/blog/MdxMentions.tsx:369
-msgid "blog.mention.watchlist.yearJobsLabel"
-msgstr "im letzten Jahr"
 
 #. Tooltip on a disabled filter pill explaining the row is implied by an already-selected ancestor (e.g. 'Included in European Union' when EU is selected).
 #. js-lingui-explicit-id

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -69,12 +69,6 @@ msgstr "{count, plural, one {# open position} other {# open positions}}"
 msgid "company.similar.positionCount"
 msgstr "{count, plural, one {# open position} other {# open positions}}"
 
-#. Stat label on a WatchlistCard mention card — pluralized 'active job' / 'active jobs'. {count} is the integer count.
-#. js-lingui-explicit-id
-#: src/components/blog/MdxMentions.tsx:358
-msgid "blog.mention.watchlist.activeJobsLabel"
-msgstr "{count, plural, one {active job} other {active jobs}}"
-
 #. Stat label on a CompanyCard mention card — pluralized 'active posting' / 'active postings'. {count} is the integer count.
 #. js-lingui-explicit-id
 #: src/components/blog/MdxMentions.tsx:290
@@ -1889,12 +1883,6 @@ msgstr "If you notice unusual crawler behaviour, prefer that we do not index you
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:80
 msgid "watchlist.meta.inLocations"
 msgstr "in {locations}"
-
-#. Stat label on a WatchlistCard mention card — 'in the past year' (year-to-date jobs counted by the watchlist filters)
-#. js-lingui-explicit-id
-#: src/components/blog/MdxMentions.tsx:369
-msgid "blog.mention.watchlist.yearJobsLabel"
-msgstr "in the past year"
 
 #. Tooltip on a disabled filter pill explaining the row is implied by an already-selected ancestor (e.g. 'Included in European Union' when EU is selected).
 #. js-lingui-explicit-id

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -69,12 +69,6 @@ msgstr "{count, plural, one {# poste ouvert} other {# postes ouverts}}"
 msgid "company.similar.positionCount"
 msgstr "{count, plural, one {# poste ouvert} other {# postes ouverts}}"
 
-#. Stat label on a WatchlistCard mention card — pluralized 'active job' / 'active jobs'. {count} is the integer count.
-#. js-lingui-explicit-id
-#: src/components/blog/MdxMentions.tsx:358
-msgid "blog.mention.watchlist.activeJobsLabel"
-msgstr "{count, plural, one {offre active} other {offres actives}}"
-
 #. Stat label on a CompanyCard mention card — pluralized 'active posting' / 'active postings'. {count} is the integer count.
 #. js-lingui-explicit-id
 #: src/components/blog/MdxMentions.tsx:290
@@ -1889,12 +1883,6 @@ msgstr "Si tu remarques un comportement inhabituel de notre robot, préfères qu
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:80
 msgid "watchlist.meta.inLocations"
 msgstr "à {locations}"
-
-#. Stat label on a WatchlistCard mention card — 'in the past year' (year-to-date jobs counted by the watchlist filters)
-#. js-lingui-explicit-id
-#: src/components/blog/MdxMentions.tsx:369
-msgid "blog.mention.watchlist.yearJobsLabel"
-msgstr "au cours de la dernière année"
 
 #. Tooltip on a disabled filter pill explaining the row is implied by an already-selected ancestor (e.g. 'Included in European Union' when EU is selected).
 #. js-lingui-explicit-id

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -69,12 +69,6 @@ msgstr "{count, plural, one {# posizione aperta} other {# posizioni aperte}}"
 msgid "company.similar.positionCount"
 msgstr "{count, plural, one {# posizione aperta} other {# posizioni aperte}}"
 
-#. Stat label on a WatchlistCard mention card — pluralized 'active job' / 'active jobs'. {count} is the integer count.
-#. js-lingui-explicit-id
-#: src/components/blog/MdxMentions.tsx:358
-msgid "blog.mention.watchlist.activeJobsLabel"
-msgstr "{count, plural, one {offerta attiva} other {offerte attive}}"
-
 #. Stat label on a CompanyCard mention card — pluralized 'active posting' / 'active postings'. {count} is the integer count.
 #. js-lingui-explicit-id
 #: src/components/blog/MdxMentions.tsx:290
@@ -1889,12 +1883,6 @@ msgstr "Se noti un comportamento anomalo del crawler, preferisci che non indiciz
 #: app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx:80
 msgid "watchlist.meta.inLocations"
 msgstr "a {locations}"
-
-#. Stat label on a WatchlistCard mention card — 'in the past year' (year-to-date jobs counted by the watchlist filters)
-#. js-lingui-explicit-id
-#: src/components/blog/MdxMentions.tsx:369
-msgid "blog.mention.watchlist.yearJobsLabel"
-msgstr "nell'ultimo anno"
 
 #. Tooltip on a disabled filter pill explaining the row is implied by an already-selected ancestor (e.g. 'Included in European Union' when EU is selected).
 #. js-lingui-explicit-id

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "lingui compile && next build",
+    "build": "pnpm blog-mentions:check && lingui compile && next build",
     "start": "next start",
     "lint": "eslint .",
     "extract": "lingui extract",
@@ -24,6 +24,8 @@
     "screenshots": "tsx script/capture-screenshots.ts",
     "smoke": "tsx script/smoke-built-app.ts",
     "notify-blog-indexnow": "tsx script/notify-blog-indexnow.ts",
+    "blog-mentions:check": "tsx script/check-blog-mention-snapshot.ts",
+    "blog-mentions:update": "tsx script/check-blog-mention-snapshot.ts --write",
     "test": "vitest run",
     "test:coverage": "vitest run --config vitest.coverage.config.ts",
     "test:watch": "vitest",

--- a/apps/web/script/check-blog-mention-snapshot.ts
+++ b/apps/web/script/check-blog-mention-snapshot.ts
@@ -1,0 +1,326 @@
+/**
+ * Validate/regenerate the repository-owned MDX mention snapshot.
+ *
+ * Default mode is a CI/build gate. `--write` is the explicit author action
+ * after adding a company mention or changing one of the approved CSV rows.
+ * Watchlist metadata is editorial and is therefore preserved from the
+ * reviewed snapshot; a newly mentioned watchlist must be added there first.
+ */
+import { existsSync } from "node:fs";
+import { readFile, readdir, writeFile } from "node:fs/promises";
+import { dirname, extname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse } from "csv-parse/sync";
+import ts from "typescript";
+
+const WEB_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const BLOG_DIR = resolve(WEB_ROOT, "src/content/blog");
+const SNAPSHOT_PATH = resolve(BLOG_DIR, "mention-snapshot.json");
+const COMPANY_DATA_DIR = resolve(WEB_ROOT, "../crawler/data");
+const MENTION_COMPONENT_PATH = resolve(
+  WEB_ROOT,
+  "src/components/blog/MdxMentions.tsx",
+);
+const LOCALES = ["en", "de", "fr", "it"] as const;
+const SLUG = /^[a-z0-9]+(?:-[a-z0-9]+)*$/u;
+const EXTERNAL_CALL_BUDGET = 0;
+
+type CsvRow = Record<string, string>;
+type CompanySnapshot = {
+  slug: string;
+  name: string;
+  icon: string | null;
+  industryName: string | null;
+  employeeCountRange: number | null;
+  foundedYear: number | null;
+  descriptions: Record<(typeof LOCALES)[number], string | null>;
+};
+type WatchlistSnapshot = {
+  owner: string;
+  ownerLabel: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  companyCount: number | null;
+};
+type MentionSnapshot = {
+  schemaVersion: 1;
+  companies: CompanySnapshot[];
+  watchlists: WatchlistSnapshot[];
+};
+type MentionRefs = {
+  companies: Set<string>;
+  watchlists: Set<string>;
+};
+
+function csv(source: string, label: string): CsvRow[] {
+  const rows = parse(source, {
+    bom: true,
+    columns: true,
+    relax_column_count: false,
+    skip_empty_lines: true,
+  }) as CsvRow[];
+  if (rows.length === 0) throw new Error(`${label} must not be empty`);
+  return rows;
+}
+
+function value(row: CsvRow, field: string): string | null {
+  const candidate = row[field]?.trim();
+  return candidate ? candidate : null;
+}
+
+function optionalInteger(row: CsvRow, field: string, context: string): number | null {
+  const candidate = value(row, field);
+  if (candidate === null) return null;
+  const parsed = Number.parseInt(candidate, 10);
+  if (!Number.isSafeInteger(parsed) || String(parsed) !== candidate) {
+    throw new Error(`${context}.${field} must be an integer`);
+  }
+  return parsed;
+}
+
+function uniqueRows(rows: CsvRow[], key: string, label: string): Map<string, CsvRow> {
+  const result = new Map<string, CsvRow>();
+  for (const row of rows) {
+    const id = value(row, key);
+    if (!id) throw new Error(`${label} row is missing ${key}`);
+    if (result.has(id)) throw new Error(`${label} has duplicate ${key}: ${id}`);
+    result.set(id, row);
+  }
+  return result;
+}
+
+function attributes(source: string): Map<string, string> {
+  const result = new Map<string, string>();
+  for (const match of source.matchAll(/([A-Za-z][\w-]*)\s*=\s*(["'])(.*?)\2/gu)) {
+    result.set(match[1], match[3]);
+  }
+  return result;
+}
+
+export function collectMentionRefs(sources: readonly string[]): MentionRefs {
+  const refs: MentionRefs = { companies: new Set(), watchlists: new Set() };
+  const tag = /<(Company|CompanyCard|Watchlist|WatchlistCard)\b([^>]*)\/?\s*>/gu;
+  for (const source of sources) {
+    for (const match of source.matchAll(tag)) {
+      const name = match[1];
+      const attrs = attributes(match[2]);
+      const slug = attrs.get("slug");
+      if (!slug || !SLUG.test(slug)) {
+        throw new Error(`<${name}> must have a canonical literal slug`);
+      }
+      if (name === "Company" || name === "CompanyCard") {
+        refs.companies.add(slug);
+        continue;
+      }
+      const owner = attrs.get("owner");
+      if (!owner || !SLUG.test(owner)) {
+        throw new Error(`<${name}> must have a canonical literal owner`);
+      }
+      refs.watchlists.add(`${owner}/${slug}`);
+    }
+  }
+  return refs;
+}
+
+function compareKeys(actual: readonly string[], expected: Set<string>, label: string): void {
+  const duplicates = actual.filter((key, index) => actual.indexOf(key) !== index);
+  if (duplicates.length > 0) {
+    throw new Error(`${label} snapshot contains duplicates: ${[...new Set(duplicates)].join(", ")}`);
+  }
+  const actualSet = new Set(actual);
+  const missing = [...expected].filter((key) => !actualSet.has(key));
+  const stale = [...actualSet].filter((key) => !expected.has(key));
+  if (missing.length || stale.length) {
+    throw new Error(
+      `${label} snapshot coverage mismatch; missing=[${missing.join(", ")}], stale=[${stale.join(", ")}]`,
+    );
+  }
+}
+
+export function buildExpectedSnapshot(
+  refs: MentionRefs,
+  companiesSource: string,
+  descriptionsSource: string,
+  industriesSource: string,
+  current: MentionSnapshot,
+): MentionSnapshot {
+  const companies = uniqueRows(csv(companiesSource, "companies.csv"), "slug", "companies.csv");
+  const descriptions = uniqueRows(
+    csv(descriptionsSource, "company_descriptions.csv"),
+    "slug",
+    "company_descriptions.csv",
+  );
+  const industries = uniqueRows(csv(industriesSource, "industries.csv"), "id", "industries.csv");
+
+  compareKeys(
+    current.watchlists.map((watchlist) => `${watchlist.owner}/${watchlist.slug}`),
+    refs.watchlists,
+    "watchlist",
+  );
+
+  const expectedCompanies = [...refs.companies].sort().map((slug): CompanySnapshot => {
+    const row = companies.get(slug);
+    if (!row) throw new Error(`Company mention is absent from companies.csv: ${slug}`);
+    const name = value(row, "name");
+    if (!name) throw new Error(`Company mention has no name in companies.csv: ${slug}`);
+    const industryId = value(row, "industry");
+    const descriptionRow = descriptions.get(slug);
+    return {
+      slug,
+      name,
+      icon: value(row, "icon_url"),
+      industryName: industryId ? value(industries.get(industryId) ?? {}, "name") : null,
+      employeeCountRange: optionalInteger(row, "employee_count_range", slug),
+      foundedYear: optionalInteger(row, "founded_year", slug),
+      descriptions: Object.fromEntries(
+        LOCALES.map((locale) => [
+          locale,
+          descriptionRow ? value(descriptionRow, locale) : null,
+        ]),
+      ) as CompanySnapshot["descriptions"],
+    };
+  });
+
+  const expectedWatchlists = [...current.watchlists]
+    .sort((a, b) => `${a.owner}/${a.slug}`.localeCompare(`${b.owner}/${b.slug}`));
+
+  return {
+    schemaVersion: 1,
+    companies: expectedCompanies,
+    watchlists: expectedWatchlists,
+  };
+}
+
+function stableJson(snapshot: MentionSnapshot): string {
+  return `${JSON.stringify(snapshot, null, 2)}\n`;
+}
+
+function localImportPath(fromPath: string, specifier: string): string | null {
+  let base: string;
+  if (specifier.startsWith("@/")) {
+    base = resolve(WEB_ROOT, "src", specifier.slice(2));
+  } else if (specifier.startsWith(".")) {
+    base = resolve(dirname(fromPath), specifier);
+  } else {
+    return null;
+  }
+  if (extname(base)) return base;
+  for (const extension of [".ts", ".tsx", ".json"]) {
+    const candidate = `${base}${extension}`;
+    if (existsSync(candidate)) return candidate;
+  }
+  return base;
+}
+
+const FORBIDDEN_LOCAL_BOUNDARIES = [
+  "/src/db/",
+  "/src/lib/actions/",
+  "/src/lib/search/",
+  "/src/lib/services/",
+] as const;
+const ALLOWED_EXTERNAL_PACKAGES = new Set([
+  "@lingui/core",
+  "@lingui/react/server",
+  "lucide-react",
+  "next/image",
+  "next/link",
+  "react",
+]);
+
+/** Ensure the entire local import graph reachable from MDX mentions is offline. */
+export async function assertOfflineImportGraph(entryPath: string): Promise<void> {
+  const pending = [entryPath];
+  const visited = new Set<string>();
+
+  while (pending.length > 0) {
+    const path = pending.pop()!;
+    if (visited.has(path) || path.endsWith(".json")) continue;
+    visited.add(path);
+    if (FORBIDDEN_LOCAL_BOUNDARIES.some((segment) => path.includes(segment))) {
+      throw new Error(`Blog mention import graph crosses external-data boundary: ${path}`);
+    }
+
+    const source = await readFile(path, "utf8");
+    const file = ts.createSourceFile(path, source, ts.ScriptTarget.Latest, true);
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "fetch"
+      ) {
+        throw new Error(`Blog mention import graph calls fetch(): ${path}`);
+      }
+
+      let specifier: string | null = null;
+      if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+        specifier = node.moduleSpecifier.text;
+      } else if (
+        ts.isExportDeclaration(node) &&
+        node.moduleSpecifier &&
+        ts.isStringLiteral(node.moduleSpecifier)
+      ) {
+        specifier = node.moduleSpecifier.text;
+      }
+      if (specifier) {
+        const local = localImportPath(path, specifier);
+        if (local) {
+          pending.push(local);
+        } else if (!ALLOWED_EXTERNAL_PACKAGES.has(specifier)) {
+          throw new Error(`Blog mention import graph imports unapproved package ${specifier}: ${path}`);
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(file);
+  }
+}
+
+async function main(): Promise<void> {
+  const write = process.argv.slice(2).includes("--write");
+  const filenames = (await readdir(BLOG_DIR)).filter((name) => name.endsWith(".mdx"));
+  const sources = await Promise.all(
+    filenames.map((name) => readFile(resolve(BLOG_DIR, name), "utf8")),
+  );
+  const refs = collectMentionRefs(sources);
+  const current = JSON.parse(await readFile(SNAPSHOT_PATH, "utf8")) as MentionSnapshot;
+  if (current.schemaVersion !== 1) throw new Error("Unsupported blog mention snapshot schema");
+
+  const [companiesSource, descriptionsSource, industriesSource] = await Promise.all([
+    readFile(resolve(COMPANY_DATA_DIR, "companies.csv"), "utf8"),
+    readFile(resolve(COMPANY_DATA_DIR, "company_descriptions.csv"), "utf8"),
+    readFile(resolve(COMPANY_DATA_DIR, "industries.csv"), "utf8"),
+  ]);
+  const expected = buildExpectedSnapshot(
+    refs,
+    companiesSource,
+    descriptionsSource,
+    industriesSource,
+    current,
+  );
+  if (write) {
+    await writeFile(SNAPSHOT_PATH, stableJson(expected), "utf8");
+  } else {
+    compareKeys(current.companies.map((company) => company.slug), refs.companies, "company");
+    if (stableJson(current) !== stableJson(expected)) {
+      throw new Error(
+        "Blog mention snapshot is stale. Run `pnpm blog-mentions:update` and review the diff.",
+      );
+    }
+  }
+
+  await assertOfflineImportGraph(MENTION_COMPONENT_PATH);
+  console.log(
+    `[blog-mentions] ${refs.companies.size + refs.watchlists.size} unique entities across ${LOCALES.length} locales; external-call budget=${EXTERNAL_CALL_BUDGET}`,
+  );
+}
+
+const entrypoint = process.argv[1] ?? "";
+if (/check-blog-mention-snapshot\.(?:ts|js|mjs|cjs)$/u.test(entrypoint)) {
+  void main().catch(() => {
+    // Never echo an error-derived value: CI/build environments can contain
+    // client configuration and credentials that do not belong in logs.
+    console.error("Blog mention snapshot validation failed");
+    process.exitCode = 1;
+  });
+}

--- a/apps/web/src/components/blog/MdxMentions.tsx
+++ b/apps/web/src/components/blog/MdxMentions.tsx
@@ -15,33 +15,31 @@
  *    when the mention IS the content — a featured spotlight, a "see
  *    also" reference, or a stat anchor.
  *
- * All variants resolve their entity at server-render time so the post
- * body reflects current state. Missing references fall back to
- * `<code>{Type ...}</code>` so broken links are visible during review.
+ * All variants resolve from the reviewed, repository-owned blog mention
+ * snapshot. Prerendering therefore has a zero external-call budget and does
+ * not turn a four-locale build into a retry fan-out against Typesense.
+ * Missing references fall back to `<code>{Type ...}</code>` so broken links
+ * remain visible during review.
  *
  * Iconography follows `apps/web/docs/icons.md` — `Building2` for
  * companies (avatar fallback), `Eye` for watchlists (matches the
  * watchlists nav slot in `AppHeader`). Don't introduce new icons
  * without adding rows to `icons.md` first.
  *
- * To add a new mention type: write the inline + card pair, fetch the
- * entity via an ISR-safe action (must NOT read session/cookies/headers
- * — see `app/__tests__/isr-routes.test.ts`'s `TAINTED_HELPERS`),
- * register both variants in `buildMdxComponents()`. Mention components
- * run inside the post page's `compileMDX` call which is itself
- * ISR-cached at revalidate=86400.
+ * To add a new mention type: write the inline + card pair, add the
+ * entity to the checked-in snapshot, then register both variants in
+ * `buildMdxComponents()`. Do not add request-time or build-time data clients
+ * here; `pnpm blog-mentions:check` enforces that boundary.
  */
 
-import { cache } from "react";
 import { Eye, Briefcase } from "lucide-react";
 import { CompanyIcon } from "@/components/CompanyIcon";
 import { NavLink } from "@/components/NavLink";
 import { loadCatalog, isLocale, defaultLocale, type Locale } from "@/lib/i18n";
-import { getCompanyBySlug } from "@/lib/actions/company";
 import {
-  getPublicWatchlistByUserAndSlug,
-  getWatchlistPostingDisplayCounts,
-} from "@/lib/actions/watchlists";
+  resolveBlogCompanyMention,
+  resolveBlogWatchlistMention,
+} from "@/lib/blog-mention-snapshot";
 
 /**
  * Helper: load the Lingui catalog for a string locale, normalizing
@@ -169,14 +167,6 @@ function MentionCard({
   );
 }
 
-// ── Data resolvers ─────────────────────────────────────────────────
-
-// React-cache wrappers so the same entity referenced multiple times
-// in one post is fetched once per render. Falls back to a fresh fetch
-// on the next ISR regen (revalidate=86400 on the post page).
-const cachedCompany = cache(getCompanyBySlug);
-const cachedWatchlist = cache(getPublicWatchlistByUserAndSlug);
-
 function companyIcon(
   icon: string | null | undefined,
   size: 16 | 24,
@@ -187,14 +177,14 @@ function companyIcon(
 
 // ── Inline mentions ────────────────────────────────────────────────
 
-export async function CompanyMention({
+export function CompanyMention({
   slug,
   locale,
 }: {
   slug: string;
   locale: string;
 }) {
-  const company = await cachedCompany(slug, locale);
+  const company = resolveBlogCompanyMention(slug, locale);
   if (!company) return <MissingMention raw={`{Company ${slug}}`} />;
   return (
     <MentionPill
@@ -205,7 +195,7 @@ export async function CompanyMention({
   );
 }
 
-export async function WatchlistMention({
+export function WatchlistMention({
   owner,
   slug,
   locale,
@@ -214,17 +204,15 @@ export async function WatchlistMention({
   slug: string;
   locale: string;
 }) {
-  const detail = await cachedWatchlist(owner, slug);
+  const detail = resolveBlogWatchlistMention(owner, slug);
   if (!detail) return <MissingMention raw={`{Watchlist ${owner}/${slug}}`} />;
-  const ownerLabel =
-    detail.owner.displayUsername ?? detail.owner.username ?? detail.owner.name;
   return (
     <MentionPill
       href={`/${locale}/${owner}/${slug}`}
       // `Eye` matches the watchlists nav slot in AppHeader (see icons.md).
       icon={<Eye size={14} aria-hidden="true" />}
       label={detail.title}
-      meta={`@${ownerLabel}`}
+      meta={`@${detail.ownerLabel}`}
     />
   );
 }
@@ -255,7 +243,7 @@ export async function CompanyCard({
   slug: string;
   locale: string;
 }) {
-  const company = await cachedCompany(slug, locale);
+  const company = resolveBlogCompanyMention(slug, locale);
   if (!company) return <MissingMention raw={`{CompanyCard ${slug}}`} />;
 
   const { i18n } = await loadLocaleCatalog(locale);
@@ -325,53 +313,24 @@ export async function WatchlistCard({
   slug: string;
   locale: string;
 }) {
-  const detail = await cachedWatchlist(owner, slug);
+  const detail = resolveBlogWatchlistMention(owner, slug);
   if (!detail) return <MissingMention raw={`{WatchlistCard ${owner}/${slug}}`} />;
 
   const { i18n } = await loadLocaleCatalog(locale);
 
-  // Posting counts mirror the in-app "N active · M in the last year"
-  // stats row so the card embed reads consistently with the watchlist
-  // detail view. ISR-safe (session-free Typesense queries).
-  const counts = await getWatchlistPostingDisplayCounts(detail);
-
-  const ownerLabel =
-    detail.owner.displayUsername ?? detail.owner.username ?? detail.owner.name;
-
   const stats: { label: string; value: string }[] = [];
-  // Skip the company-count stat for `anyCompany` watchlists — the
-  // numbers in `detail.companies` are leftover noise, not what the
-  // watchlist tracks (same caveat as in PR #2833).
-  if (!detail.filters.anyCompany) {
+  // Volatile active/year counts never enter the build snapshot. Render a
+  // company count only when an author explicitly approved that editorial
+  // point-in-time value (for example, the stable five-company MAANG set).
+  if (typeof detail.companyCount === "number") {
     stats.push({
       label: i18n._({
         id: "blog.mention.watchlist.companiesLabel",
         comment: "Stat label on a WatchlistCard mention card — pluralized 'company' / 'companies'. {count} is the integer count.",
         message: "{count, plural, one {company} other {companies}}",
-        values: { count: detail.companies.length },
+        values: { count: detail.companyCount },
       }),
-      value: String(detail.companies.length),
-    });
-  }
-  if (counts.activeJobs > 0) {
-    stats.push({
-      label: i18n._({
-        id: "blog.mention.watchlist.activeJobsLabel",
-        comment: "Stat label on a WatchlistCard mention card — pluralized 'active job' / 'active jobs'. {count} is the integer count.",
-        message: "{count, plural, one {active job} other {active jobs}}",
-        values: { count: counts.activeJobs },
-      }),
-      value: String(counts.activeJobs),
-    });
-  }
-  if (counts.yearJobs > 0) {
-    stats.push({
-      label: i18n._({
-        id: "blog.mention.watchlist.yearJobsLabel",
-        comment: "Stat label on a WatchlistCard mention card — 'in the past year' (year-to-date jobs counted by the watchlist filters)",
-        message: "in the past year",
-      }),
-      value: String(counts.yearJobs),
+      value: String(detail.companyCount),
     });
   }
 
@@ -387,7 +346,7 @@ export async function WatchlistCard({
       eyebrow={eyebrow}
       icon={<Eye size={14} aria-hidden="true" />}
       title={detail.title}
-      meta={`@${ownerLabel}`}
+      meta={`@${detail.ownerLabel}`}
       description={detail.description ?? undefined}
       stats={stats.length > 0 ? stats : undefined}
     />
@@ -401,8 +360,9 @@ export const __FUTURE_JOB_ICON_HINT = Briefcase;
 
 /**
  * Build the `components` map passed to `compileMDX` from the post page.
- * Each entry is a partially-applied async component — locale is bound
- * at the call site so MDX authors don't need to pass it through.
+ * Each entry is a partially-applied component — locale is bound at the call
+ * site so MDX authors don't need to pass it through. Cards stay async only to
+ * load their Lingui catalog; entity resolution itself is synchronous.
  *
  * To register a new mention type:
  *

--- a/apps/web/src/components/blog/__tests__/MdxMentions.test.tsx
+++ b/apps/web/src/components/blog/__tests__/MdxMentions.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import snapshot from "@/content/blog/mention-snapshot.json";
+import {
+  CompanyMention,
+  WatchlistCard,
+} from "@/components/blog/MdxMentions";
+import {
+  BLOG_MENTION_EXTERNAL_CALL_BUDGET,
+  resolveBlogCompanyMention,
+  resolveBlogWatchlistMention,
+} from "@/lib/blog-mention-snapshot";
+import { withTestEnv } from "@/test-utils/env";
+
+const locales = ["en", "de", "fr", "it"] as const;
+const SEARCH_KEY_CANARY = "blog-mention-search-key-must-not-appear";
+
+withTestEnv({
+  TYPESENSE_HOST: "production-typesense-canary.invalid",
+  TYPESENSE_PORT: "443",
+  TYPESENSE_PROTOCOL: "https",
+  TYPESENSE_SEARCH_KEY: SEARCH_KEY_CANARY,
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("MDX mention snapshot", () => {
+  it("resolves localized company fields with the English fallback", () => {
+    const german = resolveBlogCompanyMention("anthropic", "de");
+    expect(german).toMatchObject({
+      name: "Anthropic",
+      description:
+        "KI-Sicherheitsunternehmen, das zuverlässige, interpretierbare und steuerbare Systeme künstlicher Intelligenz entwickelt.",
+    });
+
+    const fallback = resolveBlogCompanyMention("anthropic", "unsupported");
+    expect(fallback?.description).toBe(
+      "AI safety company building reliable, interpretable, and steerable artificial intelligence systems.",
+    );
+
+    render(CompanyMention({ slug: "anthropic", locale: "de" }));
+    expect(screen.getByRole("link", { name: "Anthropic" }).getAttribute("href"))
+      .toBe("/de/company/anthropic");
+  });
+
+  it("keeps unknown references author-visible", async () => {
+    render(CompanyMention({ slug: "not-in-the-approved-snapshot", locale: "en" }));
+    expect(screen.getByText("{Company not-in-the-approved-snapshot}")).toBeTruthy();
+
+    const missingCard = await WatchlistCard({
+      owner: "colophongroup",
+      slug: "not-in-the-approved-snapshot",
+      locale: "en",
+    });
+    render(missingCard);
+    expect(
+      screen.getByText("{WatchlistCard colophongroup/not-in-the-approved-snapshot}"),
+    ).toBeTruthy();
+  });
+
+  it("uses one approved record per unique mention", () => {
+    expect(new Set(snapshot.companies.map((company) => company.slug)).size)
+      .toBe(snapshot.companies.length);
+    expect(
+      new Set(snapshot.watchlists.map((watchlist) => `${watchlist.owner}/${watchlist.slug}`)).size,
+    ).toBe(snapshot.watchlists.length);
+    expect(resolveBlogWatchlistMention("colophongroup", "maang"))
+      .toMatchObject({ title: "MAANG", companyCount: 5 });
+  });
+
+  it("makes zero search-plane calls across the full four-locale company set", () => {
+    const searchPlane503 = Object.assign(new Error("simulated Typesense 503"), {
+      httpStatus: 503,
+    });
+    const searchPlane429 = Object.assign(new Error("simulated Typesense 429"), {
+      httpStatus: 429,
+    });
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(searchPlane503)
+      .mockRejectedValue(searchPlane429);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const resolved = locales.flatMap((locale) =>
+      snapshot.companies.map((company) =>
+        resolveBlogCompanyMention(company.slug, locale),
+      ),
+    );
+
+    expect(resolved).toHaveLength(locales.length * snapshot.companies.length);
+    expect(resolved.every(Boolean)).toBe(true);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(JSON.stringify(resolved)).not.toContain(SEARCH_KEY_CANARY);
+    expect(BLOG_MENTION_EXTERNAL_CALL_BUDGET).toBe(0);
+  });
+});

--- a/apps/web/src/content/blog/README.md
+++ b/apps/web/src/content/blog/README.md
@@ -96,7 +96,28 @@ Currently `relatedCompanies` and `relatedWatchlists` are advisory frontmatter �
 
 ## MDX components catalogue
 
-Components are server-rendered, fetch their entity at compile time, and fall back to `<code>{Type slug}</code>` if the entity is missing — so a broken reference is visible during draft review.
+Components are server-rendered from `mention-snapshot.json` and fall back to `<code>{Type slug}</code>` if the entity is missing — so a broken reference is visible during draft review. They never fetch an entity while `next build` prerenders the four locale variants.
+
+### Build-time data and call budget
+
+The complete `en` / `de` / `fr` / `it` blog build has an external-call budget of **zero** for MDX mentions. Production Typesense, Postgres, Redis, and their credentials are not inputs to this path. A 503 or 429 from the search plane therefore cannot trigger per-component retry amplification or change the rendered post.
+
+`mention-snapshot.json` is the only approved build input:
+
+- Company rows are generated from the versioned `apps/crawler/data/companies.csv`, `company_descriptions.csv`, and `industries.csv` sources. The snapshot contains one row per unique company slug used across all locale MDX files; localized descriptions are selected from that single row with English fallback.
+- Watchlist rows are reviewed editorial snapshots. Volatile active/year posting counts are deliberately excluded. Include a company count only when the post author explicitly approves it as point-in-time editorial content.
+
+Every production build runs `pnpm blog-mentions:check`. The gate scans every MDX file, requires exactly one snapshot row for each unique company/watchlist reference, verifies generated company fields against the repository CSVs, and walks the mention component's local import graph. Imports of database/search service layers, Typesense/Postgres/network clients, or a direct `fetch()` fail the build. This both asserts the zero-call budget in CI and prevents a production-host fallback from being introduced behind the snapshot.
+
+After adding or changing a mention:
+
+```bash
+cd apps/web
+pnpm blog-mentions:update  # regenerate company rows; preserve reviewed watchlists
+pnpm blog-mentions:check   # same zero-call gate run by CI and `pnpm build`
+```
+
+Review the snapshot diff. A newly referenced watchlist has no repository CSV source, so add its stable title/description to `mention-snapshot.json` before running the update command.
 
 ### `<Company slug="..." />`
 
@@ -106,7 +127,7 @@ Inline pill linking to `/{locale}/company/{slug}`. Renders the company's icon (o
 The shift was led by <Company slug="stripe" /> and <Company slug="openai" />.
 ```
 
-Source: `MdxMentions.tsx::CompanyMention`. Resolves via the ISR-safe `getCompanyBySlug`.
+Source: `MdxMentions.tsx::CompanyMention`. Resolves synchronously from the approved snapshot; no search-plane client is in its import graph.
 
 ### `<Watchlist owner="..." slug="..." />`
 
@@ -116,17 +137,17 @@ Inline pill linking to `/{locale}/{owner}/{slug}`. Renders a checklist glyph + t
 For the curated set, see <Watchlist owner="colophongroup" slug="big-tech-jobs-in-switzerland" />.
 ```
 
-Source: `MdxMentions.tsx::WatchlistMention`. Resolves via the ISR-safe `getPublicWatchlistByUserAndSlug`.
+Source: `MdxMentions.tsx::WatchlistMention`. Resolves synchronously from the approved snapshot.
 
 ### Adding a new mention type
 
 The future-mention candidates flagged in #2828 are `<Job id="..." />`, `<Occupation slug="..." />`, `<Location slug="..." />`, `<Author slug="..." />`. To add one:
 
-1. **Pick an ISR-safe data action.** It must NOT read session/cookies/headers (see `app/__tests__/isr-routes.test.ts::TAINTED_HELPERS`). The blog post page is `revalidate=86400`; tainted helpers would silently break that.
-2. **Add a server component to `MdxMentions.tsx`** following the `CompanyMention` shape: `cache()`-wrap the data action, `MentionPill` for the visual, `MissingMention` for the fallback.
+1. **Add a reviewed repository snapshot source.** Build-time and request-time data actions are forbidden in the MDX mention import graph.
+2. **Add a server component to `MdxMentions.tsx`** following the `CompanyMention` shape: synchronous snapshot lookup, `MentionPill` for the visual, `MissingMention` for the fallback.
 3. **Register in `buildMdxComponents()`** with a TitleCase MDX tag.
 4. **Document here** with one usage example.
-5. **Test rendering** in dev — the live data should resolve, and an intentionally bad reference should fall through to `{Type ...}`.
+5. **Test rendering** in dev — the snapshot data should resolve, and an intentionally bad reference should fall through to `{Type ...}`.
 
 The `MentionPill` skeleton is shared so a new type inherits the visual treatment for free; only the `icon`, `label`, and (optional) `meta` differ.
 
@@ -154,10 +175,10 @@ behavior.
 
 ```bash
 cd apps/web
-pnpm install            # if first time in the worktree
-pnpm dev                # starts Next.js at localhost:3000
-                        # ensure .env.local exists — DB-backed mention
-                        # components throw without DATABASE_URL
+pnpm install                 # if first time in the worktree
+pnpm blog-mentions:check     # validate exact snapshot coverage + zero-call boundary
+pnpm dev                     # starts Next.js at localhost:3000
+                             # blog mentions do not require service credentials
 ```
 
 Author MDX, save, browser hot-reloads.

--- a/apps/web/src/content/blog/mention-snapshot.json
+++ b/apps/web/src/content/blog/mention-snapshot.json
@@ -1,0 +1,419 @@
+{
+  "schemaVersion": 1,
+  "companies": [
+    {
+      "slug": "accenture",
+      "name": "Accenture",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/accenture/icon.webp",
+      "industryName": "Professional Services",
+      "employeeCountRange": 8,
+      "foundedYear": 1989,
+      "descriptions": {
+        "en": "Accenture is a global professional services company specializing in strategy, consulting, technology, and operations services.",
+        "de": "Accenture ist ein globales Unternehmen für professionelle Dienstleistungen, das sich auf Strategie, Beratung, Technologie und operative Prozesse spezialisiert hat.",
+        "fr": "Accenture est une entreprise mondiale de services professionnels spécialisée dans la stratégie, le conseil, la technologie et les services opérationnels.",
+        "it": "Accenture è un'azienda globale di servizi professionali specializzata in strategia, consulenza, tecnologia e servizi operativi."
+      }
+    },
+    {
+      "slug": "affirm",
+      "name": "Affirm",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/affirm/icon.webp",
+      "industryName": "Financial Services",
+      "employeeCountRange": null,
+      "foundedYear": 2012,
+      "descriptions": {
+        "en": "Buy-now-pay-later fintech offering transparent installment plans with no hidden fees, using advanced analytics beyond traditional credit scores.",
+        "de": "Fintech für Ratenzahlung mit transparenten Zahlungsplänen ohne versteckte Gebühren, basierend auf fortschrittlicher Analytik jenseits klassischer Bonitätsbewertungen.",
+        "fr": "Fintech de paiement fractionné proposant des plans de versement transparents sans frais cachés, grâce à des analyses avancées au-delà des scores de crédit traditionnels.",
+        "it": "Fintech buy-now-pay-later che offre piani di pagamento rateali trasparenti senza costi nascosti, utilizzando analisi avanzate oltre i tradizionali punteggi di credito."
+      }
+    },
+    {
+      "slug": "amazon",
+      "name": "Amazon",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/amazon/icon.png",
+      "industryName": "Technology",
+      "employeeCountRange": 8,
+      "foundedYear": 1994,
+      "descriptions": {
+        "en": "Global technology company offering e-commerce, cloud computing, and AI services",
+        "de": "Globales Technologieunternehmen für E-Commerce, Cloud Computing und KI-Dienste",
+        "fr": "Entreprise technologique mondiale proposant e-commerce, cloud computing et services d'IA",
+        "it": "Azienda tecnologica globale che offre e-commerce, cloud computing e servizi di IA"
+      }
+    },
+    {
+      "slug": "anthropic",
+      "name": "Anthropic",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/anthropic/icon.webp",
+      "industryName": "Technology",
+      "employeeCountRange": 5,
+      "foundedYear": 2021,
+      "descriptions": {
+        "en": "AI safety company building reliable, interpretable, and steerable artificial intelligence systems.",
+        "de": "KI-Sicherheitsunternehmen, das zuverlässige, interpretierbare und steuerbare Systeme künstlicher Intelligenz entwickelt.",
+        "fr": "Entreprise de sécurité de l'IA développant des systèmes d'intelligence artificielle fiables, interprétables et contrôlables.",
+        "it": "Azienda di sicurezza dell'IA che sviluppa sistemi di intelligenza artificiale affidabili, interpretabili e controllabili."
+      }
+    },
+    {
+      "slug": "clickhouse",
+      "name": "ClickHouse",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/clickhouse/icon.webp",
+      "industryName": "Technology",
+      "employeeCountRange": null,
+      "foundedYear": 2016,
+      "descriptions": {
+        "en": "Open-source columnar database management system optimized for real-time analytical queries on large datasets using SQL.",
+        "de": "Open-Source-Spaltendatenbank, optimiert für analytische Echtzeitabfragen auf grossen Datenmengen mittels SQL.",
+        "fr": "Système de gestion de base de données colonnaire open source optimisé pour les requêtes analytiques en temps réel sur de grands volumes de données.",
+        "it": "Database colonnare open source ottimizzato per query analitiche in tempo reale su grandi volumi di dati tramite SQL."
+      }
+    },
+    {
+      "slug": "clickup",
+      "name": "Clickup",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/clickup/icon.webp",
+      "industryName": "Technology",
+      "employeeCountRange": 5,
+      "foundedYear": 2016,
+      "descriptions": {
+        "en": "ClickUp is a productivity platform that consolidates tasks, docs, goals, whiteboards, and chat into a single workspace for teams of any size.",
+        "de": "ClickUp ist eine Produktivitatsplattform, die Aufgaben, Dokumente, Ziele, Whiteboards und Chat in einem einzigen Arbeitsbereich fur Teams jeder Grosse vereint.",
+        "fr": "ClickUp est une plateforme de productivite qui regroupe taches, documents, objectifs, tableaux blancs et messagerie dans un espace de travail unique pour les equipes de toute taille.",
+        "it": "ClickUp e una piattaforma di produttivita che riunisce attivita, documenti, obiettivi, lavagne e chat in un unico spazio di lavoro per team di qualsiasi dimensione."
+      }
+    },
+    {
+      "slug": "cresta",
+      "name": "Cresta",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/cresta/icon.webp",
+      "industryName": "Technology",
+      "employeeCountRange": null,
+      "foundedYear": null,
+      "descriptions": {
+        "en": "AI platform for enterprise contact centers that coaches agents in real time, automates quality management, and deploys virtual agents to transform customer interactions.",
+        "de": "KI-Plattform für Unternehmens-Kontaktcenter, die Agenten in Echtzeit coacht, Qualitätsmanagement automatisiert und virtuelle Agenten für bessere Kundeninteraktionen einsetzt.",
+        "fr": "Plateforme d'IA pour centres de contact d'entreprise qui accompagne les agents en temps réel, automatise la gestion de la qualité et déploie des agents virtuels pour transformer les interactions client.",
+        "it": "Piattaforma di IA per contact center aziendali che assiste gli agenti in tempo reale, automatizza la gestione della qualità e utilizza agenti virtuali per trasformare le interazioni con i clienti."
+      }
+    },
+    {
+      "slug": "disney",
+      "name": "Disney",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/disney/icon.webp",
+      "industryName": "Media & Entertainment",
+      "employeeCountRange": 8,
+      "foundedYear": 1923,
+      "descriptions": {
+        "en": "Global entertainment and media conglomerate operating theme parks, film studios, and streaming services",
+        "de": "Globaler Unterhaltungs- und Medienkonzern mit Freizeitparks, Filmstudios und Streaming-Diensten",
+        "fr": "Conglomérat mondial du divertissement et des médias exploitant des parcs à thèmes, des studios de cinéma et des services de streaming",
+        "it": "Conglomerato globale dell'intrattenimento e dei media con parchi tematici, studi cinematografici e servizi di streaming"
+      }
+    },
+    {
+      "slug": "gitlab",
+      "name": "GitLab",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/gitlab/icon.webp",
+      "industryName": "Technology",
+      "employeeCountRange": null,
+      "foundedYear": 2011,
+      "descriptions": {
+        "en": "Comprehensive AI-powered DevSecOps platform that unifies source code management, CI/CD, and security scanning to accelerate software delivery and reduce compliance risk.",
+        "de": "Umfassende KI-gestützte DevSecOps-Plattform, die Quellcodeverwaltung, CI/CD und Sicherheitsscans vereint, um die Softwarebereitstellung zu beschleunigen und Compliance-Risiken zu reduzieren.",
+        "fr": "Plateforme DevSecOps complète alimentée par l'IA qui unifie la gestion du code source, le CI/CD et l'analyse de sécurité pour accélérer la livraison logicielle et réduire les risques de conformité.",
+        "it": "Piattaforma DevSecOps completa basata sull'IA che unifica la gestione del codice sorgente, CI/CD e scansioni di sicurezza per accelerare la distribuzione del software e ridurre i rischi di conformità."
+      }
+    },
+    {
+      "slug": "goldman-sachs",
+      "name": "Goldman Sachs",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/goldman-sachs/icon.webp",
+      "industryName": "Financial Services",
+      "employeeCountRange": 8,
+      "foundedYear": 1869,
+      "descriptions": {
+        "en": "Goldman Sachs is a global investment banking, securities, and investment management firm. It provides a wide range of financial services including advisory, underwriting, lending, and asset management to corporations, governments, and individuals worldwide.",
+        "de": "Goldman Sachs ist ein weltweit tätiges Investmentbanking-, Wertpapier- und Vermögensverwaltungsunternehmen. Es bietet Unternehmen, Regierungen und Privatpersonen umfassende Finanzdienstleistungen wie Beratung, Kapitalbeschaffung, Kreditvergabe und Vermögensverwaltung an.",
+        "fr": "Goldman Sachs est une société mondiale de banque d'investissement, de valeurs mobilières et de gestion d'actifs. Elle fournit une large gamme de services financiers, notamment le conseil, la souscription, le crédit et la gestion de patrimoine, aux entreprises, gouvernements et particuliers du monde entier.",
+        "it": "Goldman Sachs è una società globale di investment banking, titoli e gestione degli investimenti. Offre un'ampia gamma di servizi finanziari tra cui consulenza, sottoscrizione, prestiti e gestione patrimoniale a imprese, governi e privati in tutto il mondo."
+      }
+    },
+    {
+      "slug": "grafana-labs",
+      "name": "Grafana Labs",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/grafana-labs/icon.webp",
+      "industryName": "Technology",
+      "employeeCountRange": null,
+      "foundedYear": null,
+      "descriptions": {
+        "en": "Creator of Grafana, the open-source analytics and monitoring platform, along with Loki, Tempo, and Mimir for unified observability of metrics, logs, and traces.",
+        "de": "Entwickler von Grafana, der Open-Source-Plattform für Analytik und Monitoring, sowie Loki, Tempo und Mimir für einheitliche Observability von Metriken, Logs und Traces.",
+        "fr": "Createur de Grafana, la plateforme open source d'analyse et de monitoring, ainsi que de Loki, Tempo et Mimir pour une observabilite unifiee des metriques, logs et traces.",
+        "it": "Creatore di Grafana, la piattaforma open source di analisi e monitoraggio, insieme a Loki, Tempo e Mimir per un'osservabilita unificata di metriche, log e tracce."
+      }
+    },
+    {
+      "slug": "instacart",
+      "name": "Instacart",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/instacart/icon.webp",
+      "industryName": null,
+      "employeeCountRange": null,
+      "foundedYear": 2012,
+      "descriptions": {
+        "en": "Order same-day delivery or pickup from more than 300 retailers and grocers. Download the Instacart app or start shopping online now with Instacart to get groceries, alcohol, home essentials, and more delivered to you <b>in as fast as 1 hour</b> or select curbside pickup from your favorite local stores.",
+        "de": "Instacart ist ein amerikanisches Technologieunternehmen, das einen Online-Liefer- und Abholservice für Lebensmittel betreibt. Kunden können Lebensmittel und Haushaltsartikel bei lokalen Einzelhändlern bestellen und sich nach Hause liefern lassen.",
+        "fr": "Instacart est une entreprise technologique américaine qui exploite un service de livraison et de retrait de courses en ligne, permettant aux clients de commander des produits alimentaires et ménagers auprès de détaillants locaux et de se les faire livrer à domicile.",
+        "it": "Instacart è un'azienda tecnologica americana che gestisce un servizio di consegna e ritiro di generi alimentari online, consentendo ai clienti di ordinare prodotti alimentari e per la casa dai rivenditori locali e riceverli direttamente a domicilio."
+      }
+    },
+    {
+      "slug": "jpmorgan",
+      "name": "JPMorgan Chase & Co.",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/jpmorgan/icon.webp",
+      "industryName": "Financial Services",
+      "employeeCountRange": 8,
+      "foundedYear": 2000,
+      "descriptions": {
+        "en": "JPMorgan Chase & Co. is a global financial services firm and one of the largest banking institutions in the world, offering investment banking, asset management, commercial banking, and consumer financial services.",
+        "de": "JPMorgan Chase & Co. ist ein globales Finanzdienstleistungsunternehmen und eines der grössten Bankinstitute der Welt. Es bietet Investmentbanking, Vermögensverwaltung, Firmenkundengeschäft und Finanzdienstleistungen für Privatkunden an.",
+        "fr": "JPMorgan Chase & Co. est une société mondiale de services financiers et l'un des plus grands établissements bancaires au monde, proposant des services de banque d'investissement, de gestion d'actifs, de banque commerciale et de services financiers aux particuliers.",
+        "it": "JPMorgan Chase & Co. è una società globale di servizi finanziari e uno dei più grandi istituti bancari al mondo, che offre servizi di investment banking, gestione patrimoniale, banca commerciale e servizi finanziari per i privati."
+      }
+    },
+    {
+      "slug": "keeper-security",
+      "name": "Keeper Security",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/keeper-security/icon.webp",
+      "industryName": "Cybersecurity",
+      "employeeCountRange": null,
+      "foundedYear": null,
+      "descriptions": {
+        "en": "Password management and privileged access management platform protecting individuals and businesses from credential-based cyberattacks.",
+        "de": "Passwort- und Zugriffsverwaltungsplattform, die Privatpersonen und Unternehmen vor Cyberangriffen auf Zugangsdaten schützt.",
+        "fr": "Plateforme de gestion des mots de passe et des accès à privilèges protégeant les particuliers et les entreprises contre les cyberattaques basées sur les identifiants.",
+        "it": "Piattaforma di gestione password e accessi privilegiati che protegge privati e aziende dagli attacchi informatici basati sulle credenziali."
+      }
+    },
+    {
+      "slug": "kraken",
+      "name": "Kraken",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/kraken/icon.png",
+      "industryName": "Financial Services",
+      "employeeCountRange": 6,
+      "foundedYear": 2011,
+      "descriptions": {
+        "en": "Cryptocurrency exchange platform for trading digital assets",
+        "de": "Kryptowährungsbörse für den Handel mit digitalen Vermögenswerten",
+        "fr": "Plateforme d'échange de cryptomonnaies pour le trading d'actifs numériques",
+        "it": "Piattaforma di scambio di criptovalute per il trading di asset digitali"
+      }
+    },
+    {
+      "slug": "microsoft",
+      "name": "Microsoft",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/microsoft/icon.webp",
+      "industryName": "Technology",
+      "employeeCountRange": 8,
+      "foundedYear": 1975,
+      "descriptions": {
+        "en": "Microsoft is a global technology company that develops software, hardware, and cloud services, known for products like Windows, Office, Azure, and Xbox.",
+        "de": "Microsoft ist ein globales Technologieunternehmen, das Software, Hardware und Cloud-Dienste entwickelt und für Produkte wie Windows, Office, Azure und Xbox bekannt ist.",
+        "fr": "Microsoft est une entreprise technologique mondiale qui développe des logiciels, du matériel et des services cloud, connue pour des produits tels que Windows, Office, Azure et Xbox.",
+        "it": "Microsoft è un'azienda tecnologica globale che sviluppa software, hardware e servizi cloud, nota per prodotti come Windows, Office, Azure e Xbox."
+      }
+    },
+    {
+      "slug": "netflix",
+      "name": "Netflix",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/netflix/icon.webp",
+      "industryName": "Media & Entertainment",
+      "employeeCountRange": 8,
+      "foundedYear": 1997,
+      "descriptions": {
+        "en": "Global streaming entertainment service offering a wide library of films, series, documentaries, and games across 190+ countries.",
+        "de": "Globaler Streaming-Unterhaltungsdienst mit einer umfangreichen Bibliothek an Filmen, Serien, Dokumentationen und Spielen in über 190 Ländern.",
+        "fr": "Service mondial de divertissement en streaming proposant une vaste bibliothèque de films, séries, documentaires et jeux dans plus de 190 pays.",
+        "it": "Servizio globale di intrattenimento in streaming che offre un'ampia libreria di film, serie, documentari e giochi in oltre 190 paesi."
+      }
+    },
+    {
+      "slug": "nvidia",
+      "name": "NVIDIA",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/nvidia/icon.webp",
+      "industryName": "Technology",
+      "employeeCountRange": 8,
+      "foundedYear": 1993,
+      "descriptions": {
+        "en": "Semiconductor company designing GPUs and accelerated computing platforms for gaming, AI, and data centers",
+        "de": "Halbleiterhersteller für Grafikprozessoren und Plattformen für beschleunigtes Rechnen in den Bereichen Gaming, KI und Rechenzentren",
+        "fr": "Fabricant de semiconducteurs concevant des GPU et des plateformes de calcul accéléré pour le gaming, l'IA et les centres de données",
+        "it": "Produttore di semiconduttori che progetta GPU e piattaforme di calcolo accelerato per gaming, intelligenza artificiale e data center"
+      }
+    },
+    {
+      "slug": "oliver-wyman",
+      "name": "Oliver Wyman",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/oliver-wyman/icon.webp",
+      "industryName": null,
+      "employeeCountRange": 7,
+      "foundedYear": 1984,
+      "descriptions": {
+        "en": "Oliver Wyman is a global management consulting firm specializing in strategy, operations, risk management, and organizational transformation. A business of Marsh McLennan, it serves clients across industries with a strong focus on financial services.",
+        "de": "Oliver Wyman ist eine globale Managementberatung, die sich auf Strategie, Operations, Risikomanagement und organisatorische Transformation spezialisiert. Als Teil von Marsh McLennan berät das Unternehmen Kunden branchenübergreifend mit besonderem Fokus auf Finanzdienstleistungen.",
+        "fr": "Oliver Wyman est un cabinet de conseil en management international spécialisé dans la stratégie, les opérations, la gestion des risques et la transformation organisationnelle. Filiale de Marsh McLennan, il accompagne ses clients dans tous les secteurs avec une forte expertise en services financiers.",
+        "it": "Oliver Wyman è una società di consulenza gestionale globale specializzata in strategia, operations, gestione del rischio e trasformazione organizzativa. Parte di Marsh McLennan, opera in diversi settori con una forte competenza nei servizi finanziari."
+      }
+    },
+    {
+      "slug": "pinterest",
+      "name": "Pinterest",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/pinterest/icon.webp",
+      "industryName": "Technology",
+      "employeeCountRange": 5,
+      "foundedYear": 2010,
+      "descriptions": {
+        "en": "Visual discovery and bookmarking platform for finding and saving creative ideas and inspiration.",
+        "de": "Visuelle Entdeckungs- und Lesezeichen-Plattform zum Finden und Speichern kreativer Ideen und Inspirationen.",
+        "fr": "Plateforme visuelle de découverte et de partage pour trouver et sauvegarder des idées créatives et de l'inspiration.",
+        "it": "Piattaforma visiva di scoperta e raccolta per trovare e salvare idee creative e ispirazione."
+      }
+    },
+    {
+      "slug": "reddit",
+      "name": "Reddit",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/reddit/icon.webp",
+      "industryName": "Technology",
+      "employeeCountRange": null,
+      "foundedYear": 2005,
+      "descriptions": {
+        "en": "Reddit is a social media platform where millions of people gather in communities to share, discuss, and vote on content across a wide range of topics.",
+        "de": "Reddit ist eine Social-Media-Plattform, auf der Millionen von Menschen in Communities zusammenkommen, um Inhalte zu einer Vielzahl von Themen zu teilen, zu diskutieren und darüber abzustimmen.",
+        "fr": "Reddit est une plateforme de médias sociaux où des millions de personnes se rassemblent en communautés pour partager, discuter et voter sur des contenus couvrant un large éventail de sujets.",
+        "it": "Reddit è una piattaforma di social media dove milioni di persone si riuniscono in comunità per condividere, discutere e votare contenuti su una vasta gamma di argomenti."
+      }
+    },
+    {
+      "slug": "samsara",
+      "name": "Samsara",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/samsara/icon.webp",
+      "industryName": "Technology",
+      "employeeCountRange": null,
+      "foundedYear": null,
+      "descriptions": {
+        "en": "Connected operations platform providing IoT sensors, vehicle telematics, and fleet management solutions for physical operations.",
+        "de": "Plattform fuer vernetzte Betriebsprozesse mit IoT-Sensoren, Fahrzeugtelematik und Flottenmanagement fuer physische Ablaeufe.",
+        "fr": "Plateforme d'operations connectees proposant des capteurs IoT, de la telematique vehicule et des solutions de gestion de flotte pour les operations physiques.",
+        "it": "Piattaforma per operazioni connesse che offre sensori IoT, telematica veicolare e soluzioni di gestione flotte per le operazioni fisiche."
+      }
+    },
+    {
+      "slug": "sezzle",
+      "name": "Sezzle",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/sezzle/icon.webp",
+      "industryName": "Financial Services",
+      "employeeCountRange": null,
+      "foundedYear": 2016,
+      "descriptions": {
+        "en": "Buy-now-pay-later platform that lets shoppers split purchases into four interest-free installments while building credit history through on-time payments.",
+        "de": "Buy-Now-Pay-Later-Plattform, mit der Kaufer ihre Einkaufe in vier zinsfreie Raten aufteilen und gleichzeitig ihre Kreditwurdigkeit durch punktliche Zahlungen aufbauen.",
+        "fr": "Plateforme d'achat fractionne permettant de repartir ses achats en quatre versements sans interet tout en construisant son historique de credit grace aux paiements ponctuels.",
+        "it": "Piattaforma di pagamento rateale che consente di suddividere gli acquisti in quattro rate senza interessi, costruendo al contempo la propria storia creditizia con pagamenti puntuali."
+      }
+    },
+    {
+      "slug": "tether",
+      "name": "Tether",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/tether/icon.webp",
+      "industryName": "Financial Services",
+      "employeeCountRange": 4,
+      "foundedYear": 2014,
+      "descriptions": {
+        "en": "Cryptocurrency company behind the USDT stablecoin, providing blockchain infrastructure and digital asset technology for the global financial ecosystem.",
+        "de": "Kryptowährungsunternehmen hinter dem Stablecoin USDT, das Blockchain-Infrastruktur und digitale Vermögenswert-Technologie für das globale Finanzsystem bereitstellt.",
+        "fr": "Entreprise de cryptomonnaie, createur du stablecoin USDT, fournissant une infrastructure blockchain et des technologies pour le systeme financier mondial.",
+        "it": "Azienda di criptovalute creatrice dello stablecoin USDT, che fornisce infrastruttura blockchain e tecnologie per gli asset digitali nel sistema finanziario globale."
+      }
+    },
+    {
+      "slug": "twilio",
+      "name": "Twilio",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/twilio/icon.webp",
+      "industryName": "Technology",
+      "employeeCountRange": null,
+      "foundedYear": 2008,
+      "descriptions": {
+        "en": "Cloud communications platform providing APIs for SMS, voice, video, and authentication that developers embed directly into their applications.",
+        "de": "Cloud-Kommunikationsplattform mit APIs für SMS, Sprache, Video und Authentifizierung, die Entwickler direkt in ihre Anwendungen integrieren.",
+        "fr": "Plateforme de communication cloud fournissant des API pour SMS, voix, video et authentification, que les developpeurs integrent directement dans leurs applications.",
+        "it": "Piattaforma di comunicazione cloud che fornisce API per SMS, voce, video e autenticazione, integrate direttamente dagli sviluppatori nelle proprie applicazioni."
+      }
+    },
+    {
+      "slug": "veeva",
+      "name": "Veeva",
+      "icon": "https://jobseek-assets.colophon-group.org/companies/veeva/icon.webp",
+      "industryName": "Technology",
+      "employeeCountRange": null,
+      "foundedYear": 2007,
+      "descriptions": {
+        "en": "Veeva Systems delivers cloud-based software for the global life sciences industry, serving over 1000 pharmaceutical and biotech customers.",
+        "de": "Veeva Systems bietet cloudbasierte Software fuer die globale Life-Sciences-Branche und bedient ueber 1000 Pharma- und Biotech-Kunden.",
+        "fr": "Veeva Systems fournit des logiciels cloud pour l'industrie mondiale des sciences de la vie, au service de plus de 1000 clients pharmaceutiques et biotechnologiques.",
+        "it": "Veeva Systems fornisce software cloud per l'industria globale delle scienze della vita, servendo oltre 1000 clienti farmaceutici e biotecnologici."
+      }
+    }
+  ],
+  "watchlists": [
+    {
+      "owner": "colophongroup",
+      "ownerLabel": "colophongroup",
+      "slug": "big-tech-jobs-in-germany",
+      "title": "Big Tech Jobs in Germany",
+      "description": "Discover open positions at the leading global tech companies hiring in Germany. This watchlist tracks Big Tech employers — Magnificent 7 (Google, Microsoft, Apple, Amazon, Meta, NVIDIA, Tesla) plus Adobe, Salesforce, Oracle, IBM, SAP, ServiceNow — alongside major regional tech firms with engineering hubs across Berlin, Munich, Hamburg, and Frankfurt. Filter results by occupation, seniority, and salary to find your next role at Germany's top tech employers. Updated daily as new positions are posted.",
+      "companyCount": null
+    },
+    {
+      "owner": "colophongroup",
+      "ownerLabel": "colophongroup",
+      "slug": "big-tech-jobs-in-spain",
+      "title": "Big Tech Jobs in Spain",
+      "description": "Discover open positions at the leading global tech companies hiring in Spain. This watchlist tracks Big Tech employers — Magnificent 7 (Google, Microsoft, Apple, Amazon, Meta, NVIDIA, Tesla) plus Adobe, Salesforce, Oracle, IBM, SAP, ServiceNow — alongside major regional tech firms with engineering hubs across Madrid, Barcelona, Málaga, and Valencia. Filter results by occupation, seniority, and salary to find your next role at Spain's top tech employers. Updated daily as new positions are posted.",
+      "companyCount": null
+    },
+    {
+      "owner": "colophongroup",
+      "ownerLabel": "colophongroup",
+      "slug": "big-tech-jobs-in-switzerland",
+      "title": "Big Tech Jobs in Switzerland",
+      "description": "Discover open positions at the leading global tech companies hiring in Switzerland. This watchlist tracks Big Tech employers — Magnificent 7 (Google, Microsoft, Apple, Amazon, Meta, NVIDIA, Tesla) plus Adobe, Salesforce, Oracle, IBM, SAP, ServiceNow — alongside major regional tech firms with engineering hubs across Zürich, Lausanne, Geneva, and Basel. Filter results by occupation, seniority, and salary to find your next role at Switzerland's top tech employers. Updated daily as new positions are posted.",
+      "companyCount": null
+    },
+    {
+      "owner": "colophongroup",
+      "ownerLabel": "colophongroup",
+      "slug": "big-tech-jobs-in-united-kingdom",
+      "title": "Big Tech Jobs in United Kingdom",
+      "description": "Discover open positions at the leading global tech companies hiring in United Kingdom. This watchlist tracks Big Tech employers — Magnificent 7 (Google, Microsoft, Apple, Amazon, Meta, NVIDIA, Tesla) plus Adobe, Salesforce, Oracle, IBM, SAP, ServiceNow — alongside major regional tech firms with engineering hubs across London, Cambridge, Manchester, and Edinburgh. Filter results by occupation, seniority, and salary to find your next role at United Kingdom's top tech employers. Updated daily as new positions are posted.",
+      "companyCount": null
+    },
+    {
+      "owner": "colophongroup",
+      "ownerLabel": "colophongroup",
+      "slug": "enterprise-sales-in-switzerland",
+      "title": "Enterprise Sales in Switzerland",
+      "description": "Enterprise Sales Roles throughout Switzerland",
+      "companyCount": null
+    },
+    {
+      "owner": "colophongroup",
+      "ownerLabel": "colophongroup",
+      "slug": "maang",
+      "title": "MAANG",
+      "description": "Meta, Amazon, Apple, Google, and Netflix — the classic five.",
+      "companyCount": 5
+    }
+  ]
+}

--- a/apps/web/src/lib/__tests__/blog-mention-snapshot-gate.test.ts
+++ b/apps/web/src/lib/__tests__/blog-mention-snapshot-gate.test.ts
@@ -1,0 +1,61 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  assertOfflineImportGraph,
+  collectMentionRefs,
+} from "../../../script/check-blog-mention-snapshot";
+
+let temporaryDirectory: string | null = null;
+
+afterEach(async () => {
+  if (temporaryDirectory) {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+    temporaryDirectory = null;
+  }
+});
+async function temporaryModule(source: string): Promise<string> {
+  temporaryDirectory ??= await mkdtemp(join(tmpdir(), "blog-mention-gate-"));
+  const path = join(temporaryDirectory, "entry.ts");
+  await writeFile(path, source, "utf8");
+  return path;
+}
+
+describe("blog mention build gate", () => {
+  it("deduplicates identical entity references across locale sources", () => {
+    const refs = collectMentionRefs([
+      '<Company slug="anthropic" /> <WatchlistCard owner="team" slug="ai" />',
+      '<CompanyCard slug="anthropic" /> <Watchlist owner="team" slug="ai" />',
+    ]);
+
+    expect([...refs.companies]).toEqual(["anthropic"]);
+    expect([...refs.watchlists]).toEqual(["team/ai"]);
+  });
+
+  it("rejects non-literal or malformed mention identifiers", () => {
+    expect(() => collectMentionRefs(['<Company slug="Not Canonical" />']))
+      .toThrow("canonical literal slug");
+    expect(() => collectMentionRefs(['<Watchlist owner="Team" slug="ai" />']))
+      .toThrow("canonical literal owner");
+  });
+
+  it("blocks a direct fetch fallback", async () => {
+    const entry = await temporaryModule(
+      'export async function resolve() { return fetch("https://production.invalid"); }',
+    );
+    await expect(assertOfflineImportGraph(entry)).rejects.toThrow("calls fetch()");
+  });
+
+  it("blocks unapproved client packages anywhere in the local import graph", async () => {
+    temporaryDirectory = await mkdtemp(join(tmpdir(), "blog-mention-gate-"));
+    const entry = join(temporaryDirectory, "entry.ts");
+    const nested = join(temporaryDirectory, "nested.ts");
+    await writeFile(entry, 'export { resolve } from "./nested";', "utf8");
+    await writeFile(nested, 'import Client from "typesense"; export const resolve = Client;', "utf8");
+
+    await expect(assertOfflineImportGraph(entry)).rejects.toThrow(
+      "imports unapproved package typesense",
+    );
+  });
+});

--- a/apps/web/src/lib/blog-mention-snapshot.ts
+++ b/apps/web/src/lib/blog-mention-snapshot.ts
@@ -1,0 +1,98 @@
+import snapshot from "@/content/blog/mention-snapshot.json";
+import { defaultLocale, isLocale, type Locale } from "@/lib/i18n";
+
+/**
+ * Repository-owned data used by MDX entity mentions.
+ *
+ * This module is deliberately synchronous and side-effect free. In particular,
+ * it must never grow a database, Typesense, Redis, HTTP, or `fetch` fallback:
+ * blog pages are prerendered for four locales and their build-time external-call
+ * budget is zero. `pnpm blog-mentions:check` validates both the snapshot and this
+ * import boundary before every production build.
+ */
+
+type CompanySnapshotEntry = (typeof snapshot.companies)[number];
+type WatchlistSnapshotEntry = (typeof snapshot.watchlists)[number];
+
+export type BlogCompanyMention = {
+  slug: string;
+  name: string;
+  icon: string | null;
+  description: string | null;
+  industryName: string | null;
+  employeeCountRange: number | null;
+  foundedYear: number | null;
+  /** Volatile posting counts are intentionally absent from the snapshot. */
+  activeJobCount: null;
+};
+
+export type BlogWatchlistMention = {
+  owner: string;
+  ownerLabel: string;
+  slug: string;
+  title: string;
+  description: string | null;
+  /** Optional only when an author approves a point-in-time editorial value. */
+  companyCount: number | null;
+};
+
+const companiesBySlug = new Map(
+  snapshot.companies.map((company) => [company.slug, company] as const),
+);
+const watchlistsByKey = new Map(
+  snapshot.watchlists.map((watchlist) => [
+    `${watchlist.owner}/${watchlist.slug}`,
+    watchlist,
+  ] as const),
+);
+
+function normalizedLocale(locale: string): Locale {
+  return isLocale(locale) ? locale : defaultLocale;
+}
+
+function localizedDescription(
+  company: CompanySnapshotEntry,
+  locale: Locale,
+): string | null {
+  return company.descriptions[locale] ?? company.descriptions.en ?? null;
+}
+
+export function resolveBlogCompanyMention(
+  slug: string,
+  locale: string,
+): BlogCompanyMention | null {
+  const company = companiesBySlug.get(slug);
+  if (!company) return null;
+
+  return {
+    slug: company.slug,
+    name: company.name,
+    icon: company.icon,
+    description: localizedDescription(company, normalizedLocale(locale)),
+    industryName: company.industryName,
+    employeeCountRange: company.employeeCountRange,
+    foundedYear: company.foundedYear,
+    activeJobCount: null,
+  };
+}
+
+export function resolveBlogWatchlistMention(
+  owner: string,
+  slug: string,
+): BlogWatchlistMention | null {
+  const watchlist: WatchlistSnapshotEntry | undefined = watchlistsByKey.get(
+    `${owner}/${slug}`,
+  );
+  if (!watchlist) return null;
+
+  return {
+    owner: watchlist.owner,
+    ownerLabel: watchlist.ownerLabel,
+    slug: watchlist.slug,
+    title: watchlist.title,
+    description: watchlist.description,
+    companyCount: watchlist.companyCount,
+  };
+}
+
+export const BLOG_MENTION_EXTERNAL_CALL_BUDGET = 0;


### PR DESCRIPTION
## Summary

- resolve all company and watchlist MDX mentions from one reviewed static snapshot
- gate snapshot completeness, locale coverage, and import boundaries in CI
- remove build-time Typesense reads and retry amplification from mention rendering
- retain explicit missing-mention rendering without publishing transient authoritative zeros

## Verification

- snapshot gate: 32 unique entities across 4 locales; external-call budget=0
- focused Vitest: 2 files, 8 tests
- changed-file ESLint
- Next route type generation and TypeScript
- previously recorded production-shaped build completed all routes with the zero-call gate
- git diff --check

## Post-deploy acceptance

Inspect one production deployment log to confirm blog prerendering performs no search-plane calls, then sample company, watchlist, localized, and missing-mention output.

Closes #6131