### PR TITLE
Return 400 for invalid public search requests

### DIFF
--- a/apps/web/app/api/v1/search/route.test.ts
+++ b/apps/web/app/api/v1/search/route.test.ts
@@ -5,21 +5,24 @@ import { NextRequest } from "next/server";
 // the search actions. The admin-route tests use the same shim pattern.
 vi.mock("server-only", () => ({}));
 
-// Avoid touching Redis / Upstash from a unit test — `checkRateLimit`
-// degrades closed when the limiter throws.
-vi.mock("@/lib/rate-limit", () => ({
-  apiLimiter: {
-    limit: vi.fn(async () => {
-      throw new Error("no redis in unit tests");
-    }),
-  },
-  getClientIp: () => "test-ip",
-}));
-
 const mocks = vi.hoisted(() => ({
+  apiLimit: vi.fn(),
+  logExternalError: vi.fn(),
   parseSearchFilters: vi.fn(),
   searchJobs: vi.fn(),
   listTopCompanies: vi.fn(),
+}));
+
+// Avoid touching Redis / Upstash from a unit test. The default rejection
+// exercises the route's documented fail-open rate-limit behavior; individual
+// tests can override it to cover 429 responses.
+vi.mock("@/lib/rate-limit", () => ({
+  apiLimiter: { limit: mocks.apiLimit },
+  getClientIp: () => "test-ip",
+}));
+
+vi.mock("@/lib/safe-external-error", () => ({
+  logExternalError: mocks.logExternalError,
 }));
 
 // Route handler now imports from `@/lib/services/*` (issue #3231). The
@@ -58,8 +61,11 @@ async function callRoute(qs: string) {
   return { res, body };
 }
 
-describe("GET /api/v1/search — lang= param (issue #3230)", () => {
+describe("GET /api/v1/search", () => {
   beforeEach(() => {
+    mocks.apiLimit.mockReset();
+    mocks.apiLimit.mockRejectedValue(new Error("no redis in unit tests"));
+    mocks.logExternalError.mockReset();
     mocks.parseSearchFilters.mockReset();
     mocks.parseSearchFilters.mockResolvedValue(emptyParsed);
     mocks.searchJobs.mockReset();
@@ -104,27 +110,58 @@ describe("GET /api/v1/search — lang= param (issue #3230)", () => {
     expect(call.languages).toEqual(["de", "fr"]);
   });
 
-  it("rejects `lang=xx` (unknown code) with an error response", async () => {
-    const { res, body } = await callRoute("?locale=en&lang=xx");
-    expect(res.status).toBe(200); // apiResponse always 200 with error body
-    expect(body.error).toMatch(/Invalid 'lang' value/);
-    expect(body.error).toContain("xx");
+  it.each([
+    {
+      caseName: "unsupported UI locale",
+      query: "?locale=es",
+      error: "Invalid 'locale' param. Supported: en, de, fr, it",
+    },
+    {
+      caseName: "unknown document language",
+      query: "?locale=en&lang=xx",
+      error: "Invalid 'lang' value(s): xx. Supported: en, de, fr, it",
+    },
+    {
+      caseName: "empty document-language array",
+      query: "?locale=en&lang=",
+      error:
+        "Invalid 'lang' param: must be a comma-separated list of language codes (en, de, fr, it)",
+    },
+    {
+      caseName: "mixed valid and invalid document-language array",
+      query: "?locale=en&lang=en,xx",
+      error: "Invalid 'lang' value(s): xx. Supported: en, de, fr, it",
+    },
+    {
+      caseName: "malformed salary range",
+      query: "?locale=en&sal=abc-def",
+      error: "Invalid 'sal' param: bounds must be positive integers",
+    },
+    {
+      caseName: "malformed experience range",
+      query: "?locale=en&exp=3-nope",
+      error: "Invalid 'exp' param: bounds must be positive integers",
+    },
+    {
+      caseName: "reversed salary range",
+      query: "?locale=en&sal=200000-100000",
+      error: "Invalid 'sal' param: min cannot be greater than max",
+    },
+    {
+      caseName: "unsafe integer bound",
+      query: "?locale=en&exp=9007199254740992-",
+      error: "Invalid 'exp' param: bounds must be positive integers",
+    },
+  ])("returns the documented 400 contract for $caseName", async ({ query, error }) => {
+    const { res, body } = await callRoute(query);
+
+    expect(res.status).toBe(400);
+    expect(body).toEqual({ error });
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(mocks.parseSearchFilters).not.toHaveBeenCalled();
     expect(mocks.listTopCompanies).not.toHaveBeenCalled();
     expect(mocks.searchJobs).not.toHaveBeenCalled();
-  });
-
-  it("rejects `lang=` (empty) with an error response", async () => {
-    const { res, body } = await callRoute("?locale=en&lang=");
-    expect(res.status).toBe(200);
-    expect(body.error).toMatch(/Invalid 'lang' param/);
-    expect(mocks.listTopCompanies).not.toHaveBeenCalled();
-  });
-
-  it("rejects a mixed-valid/invalid `lang=en,xx` with an error response", async () => {
-    const { body } = await callRoute("?locale=en&lang=en,xx");
-    expect(body.error).toMatch(/Invalid 'lang' value/);
-    expect(body.error).toContain("xx");
-    expect(mocks.listTopCompanies).not.toHaveBeenCalled();
   });
 
   it("uses the `searchJobs` path when `q=` is set, still forwarding `languages`", async () => {
@@ -155,26 +192,6 @@ describe("GET /api/v1/search — lang= param (issue #3230)", () => {
     const url = new URL(body.moreAt as string);
     expect(url.searchParams.has("lang")).toBe(false);
     expect(url.searchParams.get("q")).toBe("engineer");
-  });
-
-  it("rejects malformed `sal=` instead of forwarding NaN", async () => {
-    const { body } = await callRoute("?locale=en&sal=abc-def");
-    expect(body.error).toMatch(/Invalid 'sal' param/);
-    expect(mocks.listTopCompanies).not.toHaveBeenCalled();
-    expect(mocks.searchJobs).not.toHaveBeenCalled();
-  });
-
-  it("rejects malformed `exp=` instead of building an invalid Typesense filter", async () => {
-    const { body } = await callRoute("?locale=en&exp=3-nope");
-    expect(body.error).toMatch(/Invalid 'exp' param/);
-    expect(mocks.listTopCompanies).not.toHaveBeenCalled();
-    expect(mocks.searchJobs).not.toHaveBeenCalled();
-  });
-
-  it("rejects reversed numeric ranges", async () => {
-    const { body } = await callRoute("?locale=en&sal=200000-100000");
-    expect(body.error).toMatch(/min cannot be greater than max/);
-    expect(mocks.listTopCompanies).not.toHaveBeenCalled();
   });
 
   it("forwards valid `sal=` and `exp=` ranges as numbers", async () => {
@@ -221,5 +238,44 @@ describe("GET /api/v1/search — lang= param (issue #3230)", () => {
     const url = new URL(body.moreAt as string);
     expect(url.searchParams.get("etype")).toBe("full_time,internship");
     expect(url.searchParams.get("q")).toBe("designer");
+  });
+
+  it("keeps rate-limit failures distinct from validation failures", async () => {
+    const reset = Date.now() + 30_000;
+    mocks.apiLimit.mockResolvedValueOnce({
+      success: false,
+      limit: 30,
+      remaining: 0,
+      reset,
+    });
+
+    const { res, body } = await callRoute("?locale=en&lang=xx");
+
+    expect(res.status).toBe(429);
+    expect(body).toEqual({ error: "Too many requests" });
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Retry-After")).not.toBeNull();
+    expect(mocks.parseSearchFilters).not.toHaveBeenCalled();
+    expect(mocks.listTopCompanies).not.toHaveBeenCalled();
+  });
+
+  it("returns a safe 500 body when the search provider fails", async () => {
+    const providerError = Object.assign(
+      new Error("provider-internal-canary-do-not-expose"),
+      { status: 503 },
+    );
+    mocks.listTopCompanies.mockRejectedValueOnce(providerError);
+
+    const { res, body } = await callRoute("?locale=de");
+
+    expect(res.status).toBe(500);
+    expect(body).toEqual({ error: "Search service unavailable" });
+    expect(JSON.stringify(body)).not.toContain("provider-internal-canary");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(mocks.logExternalError).toHaveBeenCalledWith(
+      "error",
+      { service: "typesense", operation: "public_api_search" },
+      providerError,
+    );
   });
 });

--- a/apps/web/app/api/v1/search/route.ts
+++ b/apps/web/app/api/v1/search/route.ts
@@ -8,10 +8,20 @@ import { type NextRequest, NextResponse } from "next/server";
 import { searchJobs, listTopCompanies } from "@/lib/services/search";
 import { parseSearchFilters } from "@/lib/services/search-input";
 import { isLocale, locales } from "@/lib/i18n";
+import { logExternalError } from "@/lib/safe-external-error";
 import { checkRateLimit, apiResponse, siteUrl, exploreUrl } from "../_shared";
 
 const MAX_COMPANIES = 5;
 const MAX_POSTINGS_PER_COMPANY = 3;
+
+function searchErrorResponse(error: string, status: 400 | 500) {
+  const response = apiResponse({ error }, { maxAge: 0, status });
+  // Search errors must never be stored by a browser or shared cache. This is
+  // stricter than merely setting max-age=0 and keeps a transient provider
+  // outage (or a malformed request) from becoming a cached API response.
+  response.headers.set("Cache-Control", "no-store");
+  return response;
+}
 
 /**
  * Parse the optional `lang=` query param into a validated list of job
@@ -19,10 +29,10 @@ const MAX_POSTINGS_PER_COMPANY = 3;
  * + currency formatting) — ``lang`` filters by the language the posting
  * itself is written in (`job_posting.locales` in Typesense).
  *
- * - absent / empty → returns ``null`` (caller should pass ``[]`` to
- *   ``searchJobs`` / ``listTopCompanies`` so no language filter is
- *   applied — this is a public REST API, callers are stateless and
- *   should not be biased by the UI locale)
+ * - absent → returns ``null`` (caller should pass ``[]`` to ``searchJobs`` /
+ *   ``listTopCompanies`` so no language filter is applied — this is a public
+ *   REST API, callers are stateless and should not be biased by the UI locale)
+ * - present but empty → returns a ``400`` validation error
  * - comma-separated codes (e.g. ``de`` or ``de,fr``) → returns the
  *   validated subset. Unknown codes cause a ``400``.
  *
@@ -80,7 +90,8 @@ function parseIntegerRangeParam(
     const trimmed = value.trim();
     if (trimmed === "") return undefined;
     if (!/^\d+$/.test(trimmed)) return Number.NaN;
-    return Number.parseInt(trimmed, 10);
+    const parsed = Number.parseInt(trimmed, 10);
+    return Number.isSafeInteger(parsed) ? parsed : Number.NaN;
   };
 
   const min = parseBound(parts[0] ?? "");
@@ -118,16 +129,43 @@ export async function GET(request: NextRequest) {
   const exp = sp.get("exp") ?? undefined;
   const locale = sp.get("locale") ?? "en";
 
+  if (!isLocale(locale)) {
+    return searchErrorResponse(
+      `Invalid 'locale' param. Supported: ${locales.join(", ")}`,
+      400,
+    );
+  }
+
   const langParsed = parseLangParam(sp.get("lang"));
   if (!langParsed.ok) {
-    return apiResponse({ error: langParsed.error }, { maxAge: 0 });
+    return searchErrorResponse(langParsed.error, 400);
   }
   // `searchJobs` / `listTopCompanies` treat `languages: []` as "no
   // filter" (see `apps/web/src/lib/search/typesense-filters.ts` —
   // `filters.languages?.length` guards the locales clause).
   const languages = langParsed.langs ?? [];
 
-  const parsed = await parseSearchFilters({ q, loc, occ, sen, tech, wm, etype, locale });
+  const salaryRange = parseIntegerRangeParam("sal", sal);
+  if (!salaryRange.ok) {
+    return searchErrorResponse(salaryRange.error, 400);
+  }
+
+  const experienceRange = parseIntegerRangeParam("exp", exp);
+  if (!experienceRange.ok) {
+    return searchErrorResponse(experienceRange.error, 400);
+  }
+
+  let parsed: Awaited<ReturnType<typeof parseSearchFilters>>;
+  try {
+    parsed = await parseSearchFilters({ q, loc, occ, sen, tech, wm, etype, locale });
+  } catch (error) {
+    logExternalError(
+      "error",
+      { service: "typesense", operation: "public_api_search" },
+      error,
+    );
+    return searchErrorResponse("Search service unavailable", 500);
+  }
 
   const locationIds =
     parsed.locations.length > 0 ? parsed.locations.map((l) => l.id) : undefined;
@@ -143,16 +181,6 @@ export async function GET(request: NextRequest) {
     parsed.technologies.length > 0
       ? parsed.technologies.map((t) => t.id)
       : undefined;
-
-  const salaryRange = parseIntegerRangeParam("sal", sal);
-  if (!salaryRange.ok) {
-    return apiResponse({ error: salaryRange.error }, { maxAge: 0 });
-  }
-
-  const experienceRange = parseIntegerRangeParam("exp", exp);
-  if (!experienceRange.ok) {
-    return apiResponse({ error: experienceRange.error }, { maxAge: 0 });
-  }
 
   const searchParams = {
     locationIds,
@@ -172,10 +200,20 @@ export async function GET(request: NextRequest) {
     limit: MAX_COMPANIES,
   };
 
-  const result =
-    parsed.keywords.length > 0
-      ? await searchJobs({ keywords: parsed.keywords, ...searchParams })
-      : await listTopCompanies(searchParams);
+  let result: Awaited<ReturnType<typeof listTopCompanies>>;
+  try {
+    result =
+      parsed.keywords.length > 0
+        ? await searchJobs({ keywords: parsed.keywords, ...searchParams })
+        : await listTopCompanies(searchParams);
+  } catch (error) {
+    logExternalError(
+      "error",
+      { service: "typesense", operation: "public_api_search" },
+      error,
+    );
+    return searchErrorResponse("Search service unavailable", 500);
+  }
 
   const companies = result.companies.slice(0, MAX_COMPANIES).map((c) => ({
     name: c.company.name,

--- a/apps/web/public/api/openapi.json
+++ b/apps/web/public/api/openapi.json
@@ -11,7 +11,7 @@
       "get": {
         "operationId": "searchJobs",
         "summary": "Search jobs across companies",
-        "description": "Returns up to 5 companies with their top 3 job postings matching the filters. Only 'q' accepts freetext. All other filter params (loc, occ, sen, tech) require exact slugs — use /api/v1/resolve to convert freetext to slugs first.\n\nUI ``locale`` (response labels) is distinct from ``lang`` (job document language). Omitting ``lang`` returns postings in any language — pass ``lang=en`` (or a comma-separated list) to filter to specific posting languages.",
+        "description": "Returns up to 5 companies with their top 3 job postings matching the filters. Only 'q' accepts freetext. All other filter params (loc, occ, sen, tech) require exact slugs — use /api/v1/resolve to convert freetext to slugs first.\n\nUI ``locale`` (response labels) is distinct from ``lang`` (job document language). Omitting ``lang`` returns postings in any language — pass ``lang=en`` (or a comma-separated list) to filter to specific posting languages. Malformed or unsupported parameters return HTTP 400 with an ``{\"error\": string}`` body; provider failures use HTTP 500 and never include provider details.",
         "parameters": [
           { "name": "q", "in": "query", "schema": { "type": "string" }, "description": "Keywords (free text search)" },
           { "name": "loc", "in": "query", "schema": { "type": "string" }, "description": "Location slugs, comma-separated (exact slugs only, use /resolve to look up)" },
@@ -62,6 +62,35 @@
                     "moreAt": { "type": "string", "description": "Link to full results on jseek.co" }
                   }
                 }
+              }
+            }
+          },
+          "400": {
+            "description": "Malformed or unsupported search parameter. The response is not cacheable.",
+            "headers": {
+              "Cache-Control": {
+                "description": "Always ``no-store`` for error responses.",
+                "schema": { "type": "string", "const": "no-store" }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "500": {
+            "description": "Search provider failure. The message is user-safe and contains no provider detail.",
+            "headers": {
+              "Cache-Control": {
+                "description": "Always ``no-store`` for error responses.",
+                "schema": { "type": "string", "const": "no-store" }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" },
+                "example": { "error": "Search service unavailable" }
               }
             }
           },
@@ -343,6 +372,18 @@
               }
             }
           }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ErrorResponse": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["error"],
+        "properties": {
+          "error": { "type": "string" }
         }
       }
     }


### PR DESCRIPTION
## Summary

- return HTTP 400 for every invalid public search parameter class
- preserve distinct rate-limit and server-error statuses
- document the error contract in the public OpenAPI schema

## Verification

- focused Vitest: 1 file, 21 tests covering language, salary, experience, and range validation
- changed-file ESLint and OpenAPI JSON parse
- Next route type generation and TypeScript
- git diff --check

## Post-deploy acceptance

Probe each malformed request class against production and confirm response status/body while keeping 429 and server failures distinct.

Addresses #3213