### PR TITLE
Restore Explore heading in initial HTML

### DIFF
--- a/apps/web/app/[lang]/(app)/explore/__tests__/explore-loading-semantics.test.tsx
+++ b/apps/web/app/[lang]/(app)/explore/__tests__/explore-loading-semantics.test.tsx
@@ -1,0 +1,17 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import "@/test-utils/lingui-mock";
+import Loading from "../loading";
+
+describe("Explore initial document fallback", () => {
+  it("keeps one page heading while cached results resume", () => {
+    render(<Loading />);
+
+    expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+    expect(screen.getByRole("heading", { level: 1 }).textContent).toBe(
+      "Explore Jobs",
+    );
+    expect(screen.getByRole("status").getAttribute("aria-busy")).toBe("true");
+  });
+});

--- a/apps/web/src/components/search/explore-skeleton.tsx
+++ b/apps/web/src/components/search/explore-skeleton.tsx
@@ -1,8 +1,27 @@
+"use client";
+
+import { Trans } from "@lingui/react/macro";
 import { SkeletonCards } from "@/components/search/skeleton-card";
 
 export function ExploreSkeleton() {
   return (
     <div className="space-y-6">
+      {/*
+        Route-level loading.tsx is the cached Explore document's initial HTML
+        boundary. Keep the page heading inside that boundary so no-JavaScript
+        readers and assistive technology receive a localized document outline
+        before the cached result payload resumes. SearchPage renders the same
+        heading after Suspense replaces this fallback, so there is exactly one
+        H1 in either state.
+      */}
+      <h1 className="sr-only">
+        <Trans
+          id="explore.h1"
+          comment="Hidden page H1 for /explore — screen-reader landmark"
+        >
+          Explore Jobs
+        </Trans>
+      </h1>
       {/* Toolbar placeholder */}
       <div className="flex flex-wrap items-center gap-2">
         <div className="h-8 w-24 animate-pulse rounded-md bg-border-soft" />


### PR DESCRIPTION
## Summary

- put the localized Explore H1 inside the route loading boundary
- preserve exactly one page heading before and after cached results resume
- keep the busy status semantics for the initial document fallback

## Verification

- focused Vitest: 1 file, 1 test
- changed-file ESLint
- Next route type generation and TypeScript
- git diff --check

## Post-deploy acceptance

Inspect raw HTML for all four localized Explore routes and repeat anonymous filter-bearing hydration checks in production.

Addresses #2640