### PR TITLE
Restore entry-page landmarks and headings

### DIFF
--- a/apps/web/app/[lang]/(auth)/check-email/page.tsx
+++ b/apps/web/app/[lang]/(auth)/check-email/page.tsx
@@ -71,33 +71,35 @@ export default function CheckEmailPage() {
     setCooldown(COOLDOWN_SECONDS);
   }, [email, lp, t]);
 
-  if (!email) return null;
-
   return (
     <div className="text-center">
       <Mail className="mx-auto mb-4 size-10 text-muted" />
-      <h2 className="text-xl font-bold">
+      <h1 className="text-xl font-bold">
         <Trans id="auth.verify.checkEmail.title" comment="Heading after sign-up telling user to check email">
           Check your email
         </Trans>
-      </h2>
-      <p className="mt-2 text-sm text-muted">
-        <Trans id="auth.verify.checkEmail.description" comment="Description telling user a verification link was sent">
-          We sent a verification link to <strong>{email}</strong>. Click the link to verify your account. It may take a few minutes to arrive.
-        </Trans>
-      </p>
-      <button
-        type="button"
-        onClick={handleResend}
-        disabled={resending || cooldown > 0}
-        className="mt-4 text-sm font-semibold transition-colors hover:text-muted disabled:opacity-50 cursor-pointer"
-      >
-        {resending
-          ? t({ id: "auth.verify.resending", comment: "Resend button while sending", message: "Sending..." })
-          : cooldown > 0
-            ? t({ id: "auth.verify.cooldown", comment: "Resend button during cooldown with seconds remaining", message: `Resend in ${cooldown}s` })
-            : t({ id: "auth.verify.resend", comment: "Button to resend verification email", message: "Resend verification email" })}
-      </button>
+      </h1>
+      {email && (
+        <>
+          <p className="mt-2 text-sm text-muted">
+            <Trans id="auth.verify.checkEmail.description" comment="Description telling user a verification link was sent">
+              We sent a verification link to <strong>{email}</strong>. Click the link to verify your account. It may take a few minutes to arrive.
+            </Trans>
+          </p>
+          <button
+            type="button"
+            onClick={handleResend}
+            disabled={resending || cooldown > 0}
+            className="mt-4 cursor-pointer text-sm font-semibold transition-colors hover:text-muted disabled:opacity-50"
+          >
+            {resending
+              ? t({ id: "auth.verify.resending", comment: "Resend button while sending", message: "Sending..." })
+              : cooldown > 0
+                ? t({ id: "auth.verify.cooldown", comment: "Resend button during cooldown with seconds remaining", message: `Resend in ${cooldown}s` })
+                : t({ id: "auth.verify.resend", comment: "Button to resend verification email", message: "Resend verification email" })}
+          </button>
+        </>
+      )}
       <ErrorAlert message={error} focusOnRender />
     </div>
   );

--- a/apps/web/app/[lang]/(auth)/forgot-password/page.tsx
+++ b/apps/web/app/[lang]/(auth)/forgot-password/page.tsx
@@ -59,11 +59,11 @@ export default function ForgotPasswordPage() {
     return (
       <div className="text-center">
         <CircleCheck className="mx-auto mb-4 size-10 text-green-500" />
-        <h2 className="text-xl font-bold">
+        <h1 className="text-xl font-bold">
           <Trans id="auth.forgotPassword.sent.title" comment="Heading after reset email is sent">
             Check your email
           </Trans>
-        </h2>
+        </h1>
         <p className="mt-2 text-sm text-muted">
           <Trans id="auth.forgotPassword.sent.description" comment="Description after reset email is sent">
             If an account exists for that email, we sent a password reset link.
@@ -80,11 +80,11 @@ export default function ForgotPasswordPage() {
 
   return (
     <>
-      <h2 className="text-center text-xl font-bold">
+      <h1 className="text-center text-xl font-bold">
         <Trans id="auth.forgotPassword.title" comment="Forgot password page heading">
           Forgot password?
         </Trans>
-      </h2>
+      </h1>
       <p className="mb-6 text-center text-sm text-muted">
         <Trans id="auth.forgotPassword.subtitle" comment="Forgot password page subtitle">
           Enter your email and we&apos;ll send you a reset link.

--- a/apps/web/app/[lang]/(public)/about/about-content.tsx
+++ b/apps/web/app/[lang]/(public)/about/about-content.tsx
@@ -16,7 +16,7 @@ export function AboutContent({ contactEmail, ossRepoUrl }: AboutContentProps) {
   const lp = useLocalePath();
 
   return (
-    <main className="py-12 md:py-20">
+    <main id="main-content" tabIndex={-1} className="scroll-mt-12 py-12 md:py-20">
       <div className="mx-auto max-w-[900px] px-4">
         <div className="flex flex-col gap-12 md:gap-16">
           <div className="w-full max-w-[840px]">

--- a/apps/web/app/[lang]/(public)/blog/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(public)/blog/[slug]/page.tsx
@@ -158,7 +158,11 @@ export default async function BlogPostPage({ params }: Props) {
   return (
     <>
       <JsonLd data={buildArticleJsonLd(post, locale)} />
-      <main className="mx-auto max-w-2xl px-4 py-12">
+      <main
+        id="main-content"
+        tabIndex={-1}
+        className="mx-auto max-w-2xl scroll-mt-12 px-4 py-12"
+      >
         <nav className="mb-6 text-sm">
           <Link href={`/${locale}/blog`} className="text-muted hover:underline">
             ← {backLabel}

--- a/apps/web/app/[lang]/(public)/blog/page.tsx
+++ b/apps/web/app/[lang]/(public)/blog/page.tsx
@@ -93,7 +93,11 @@ export default async function BlogIndexPage({ params }: Props) {
   });
 
   return (
-    <main className="mx-auto max-w-3xl px-4 py-12">
+    <main
+      id="main-content"
+      tabIndex={-1}
+      className="mx-auto max-w-3xl scroll-mt-12 px-4 py-12"
+    >
       <h1 className="text-3xl font-bold">{heading}</h1>
       <p className="mt-2 text-muted">{tagline}</p>
 

--- a/apps/web/app/[lang]/(public)/faq/faq-content.tsx
+++ b/apps/web/app/[lang]/(public)/faq/faq-content.tsx
@@ -29,7 +29,7 @@ function FaqItem({ item }: { item: FaqItem }) {
 
 export function FaqContent({ items }: { items: FaqItem[] }) {
   return (
-    <main className="py-12 md:py-20">
+    <main id="main-content" tabIndex={-1} className="scroll-mt-12 py-12 md:py-20">
       <div className="mx-auto max-w-[720px] px-4">
         <div className="flex flex-col gap-4 text-center">
           <span className={eyebrowClass}>

--- a/apps/web/app/[lang]/(public)/layout.tsx
+++ b/apps/web/app/[lang]/(public)/layout.tsx
@@ -22,9 +22,7 @@ export default async function PublicLayout({ children, params }: Props) {
       <div className="fixed top-0 right-0 left-0 z-50">
         <HeaderShell />
       </div>
-      <div id="main-content" tabIndex={-1} className="scroll-mt-12 pt-12">
-        {children}
-      </div>
+      <div className="pt-12">{children}</div>
       <Footer lang={locale} />
     </>
   );

--- a/apps/web/app/[lang]/(public)/page.tsx
+++ b/apps/web/app/[lang]/(public)/page.tsx
@@ -68,23 +68,25 @@ export default async function HomePage({ params }: Props) {
         inLanguage: locale,
         isPartOf: { "@type": "WebSite", url: siteConfig.url },
       }} />
-      <Hero />
-      <Features />
-      <Pricing />
-      {afterPricingArt && (
-        <section className="py-20">
-          <div className="mx-auto max-w-[1200px] px-4">
-            <div className="mx-auto h-[360px] w-full max-w-[768px] sm:h-[460px] lg:h-[560px]">
-              <PublicDomainArt
-                asset={afterPricingArt}
-                focus={siteConfig.homepageArt.focus}
-                sizes="(min-width: 768px) 768px, 100vw"
-                className="h-full w-full"
-              />
+      <main id="main-content" tabIndex={-1} className="scroll-mt-12">
+        <Hero />
+        <Features />
+        <Pricing />
+        {afterPricingArt && (
+          <section className="py-20">
+            <div className="mx-auto max-w-[1200px] px-4">
+              <div className="mx-auto h-[360px] w-full max-w-[768px] sm:h-[460px] lg:h-[560px]">
+                <PublicDomainArt
+                  asset={afterPricingArt}
+                  focus={siteConfig.homepageArt.focus}
+                  sizes="(min-width: 768px) 768px, 100vw"
+                  className="h-full w-full"
+                />
+              </div>
             </div>
-          </div>
-        </section>
-      )}
+          </section>
+        )}
+      </main>
     </>
   );
 }

--- a/apps/web/app/[lang]/__tests__/entry-route-semantics.test.tsx
+++ b/apps/web/app/[lang]/__tests__/entry-route-semantics.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReactElement } from "react";
+
+import "@/test-utils/lingui-mock";
+
+const mocks = vi.hoisted(() => ({
+  push: vi.fn(),
+  replace: vi.fn(),
+  searchParams: new URLSearchParams(),
+  verifyEmail: vi.fn(() => new Promise(() => {})),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mocks.push, replace: mocks.replace }),
+  useSearchParams: () => mocks.searchParams,
+}));
+
+vi.mock("@lingui/react/server", () => ({
+  getI18n: () => ({
+    _: ({ message, id }: { message?: string; id?: string }) => message ?? id ?? "",
+  }),
+}));
+
+vi.mock("@/lib/i18n", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/i18n")>()),
+  initI18nForPage: vi.fn().mockResolvedValue("en"),
+}));
+
+vi.mock("@/lib/useLocalePath", () => ({
+  useLocalePath: () => (path: string) => `/en${path}`,
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    requestPasswordReset: vi.fn(),
+    resetPassword: vi.fn(),
+    sendVerificationEmail: vi.fn(),
+    verifyEmail: mocks.verifyEmail,
+    signIn: {
+      email: vi.fn(),
+      username: vi.fn(),
+      social: vi.fn(),
+    },
+    signUp: { email: vi.fn() },
+  },
+}));
+
+vi.mock("@/lib/actions/preferences", () => ({
+  getPreferences: vi.fn(),
+  updatePreferences: vi.fn(),
+}));
+
+vi.mock("@/lib/preference-timestamps", () => ({
+  localPrefs: {
+    themeTimestamp: { get: vi.fn(), set: vi.fn() },
+    localeTimestamp: { get: vi.fn(), set: vi.fn() },
+    locale: { get: vi.fn(), set: vi.fn() },
+  },
+}));
+
+vi.mock("@/components/HeaderShell", () => ({ HeaderShell: () => <header /> }));
+vi.mock("@/components/Footer", () => ({ Footer: () => <footer /> }));
+vi.mock("@/components/SkipToContentLink", () => ({
+  SkipToContentLink: () => <a href="#main-content">Skip to content</a>,
+}));
+vi.mock("@/components/Features", () => ({ Features: () => null }));
+vi.mock("@/components/Pricing", () => ({ Pricing: () => null }));
+vi.mock("@/components/PublicDomainArt", () => ({ PublicDomainArt: () => null }));
+vi.mock("@/components/ThemeToggleButton", () => ({ ThemeToggleButton: () => null }));
+vi.mock("@/components/LocaleSwitcher", () => ({ LocaleSwitcher: () => null }));
+vi.mock("@/components/ThemedImage", () => ({
+  ThemedImage: ({ alt }: { alt: string }) => <span aria-label={alt} />,
+}));
+vi.mock("@/lib/seo", () => ({
+  buildAlternates: vi.fn(),
+  JsonLd: () => null,
+}));
+
+import PublicLayout from "../(public)/layout";
+import HomePage from "../(public)/page";
+import ForgotPasswordPage from "../(auth)/forgot-password/page";
+import CheckEmailPage from "../(auth)/check-email/page";
+import SignInPage from "../(auth)/sign-in/page";
+import SignUpPage from "../(auth)/sign-up/page";
+import ResetPasswordPage from "../reset-password/page";
+import VerifyEmailPage from "../verify-email/page";
+import { AuthShell } from "@/components/AuthShell";
+
+function expectSinglePageOutline() {
+  const main = screen.getByRole("main");
+  const heading = screen.getByRole("heading", { level: 1 });
+
+  expect(screen.getAllByRole("main")).toHaveLength(1);
+  expect(screen.getAllByRole("heading", { level: 1 })).toHaveLength(1);
+  expect(main.id).toBe("main-content");
+  expect(main.tabIndex).toBe(-1);
+  expect(main.contains(heading)).toBe(true);
+  expect(heading.textContent?.trim()).not.toBe("");
+}
+
+function renderAuthRoute(page: ReactElement, ownsShell = false) {
+  render(ownsShell ? page : <AuthShell>{page}</AuthShell>);
+  expectSinglePageOutline();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sessionStorage.clear();
+  mocks.searchParams.delete("token");
+  mocks.searchParams.delete("next");
+});
+
+describe("entry-route page semantics", () => {
+  it("gives the homepage one focusable main landmark, one H1, and a matching skip target", async () => {
+    const params = Promise.resolve({ lang: "en" });
+    const page = await HomePage({ params });
+    const layout = await PublicLayout({ children: page, params });
+
+    render(layout);
+
+    expectSinglePageOutline();
+    expect(screen.getByRole("link", { name: "Skip to content" }).getAttribute("href"))
+      .toBe("#main-content");
+  });
+
+  it.each([
+    ["sign-in", <SignInPage />],
+    ["sign-up", <SignUpPage />],
+    ["forgot-password", <ForgotPasswordPage />],
+  ])("gives /en/%s one main landmark and one descriptive H1", (_route, page) => {
+    renderAuthRoute(page);
+  });
+
+  it("gives /en/check-email one main landmark and one descriptive H1", () => {
+    sessionStorage.setItem("verify-email", "person@example.com");
+    renderAuthRoute(<CheckEmailPage />);
+  });
+
+  it("gives /en/verify-email one main landmark and one descriptive H1 while loading", () => {
+    mocks.searchParams.set("token", "test-token");
+    renderAuthRoute(<VerifyEmailPage />, true);
+  });
+
+  it("gives /en/reset-password one main landmark and one descriptive H1", () => {
+    mocks.searchParams.set("token", "test-token");
+    renderAuthRoute(<ResetPasswordPage />, true);
+  });
+});

--- a/apps/web/app/[lang]/reset-password/page.tsx
+++ b/apps/web/app/[lang]/reset-password/page.tsx
@@ -30,11 +30,11 @@ export default function ResetPasswordPage() {
     return (
       <AuthShell>
         <div className="text-center">
-          <h2 className="text-xl font-bold">
+          <h1 className="text-xl font-bold">
             <Trans id="auth.resetPassword.error.title" comment="Heading when reset link is invalid">
               Invalid reset link
             </Trans>
-          </h2>
+          </h1>
           <p className="mt-2 text-sm text-muted">
             <Trans id="auth.resetPassword.error.noToken" comment="Message when reset token is missing">
               This password reset link is invalid or has expired. Please request a new one.
@@ -55,11 +55,11 @@ export default function ResetPasswordPage() {
       <AuthShell>
         <div className="text-center">
           <CircleCheck className="mx-auto mb-4 size-10 text-green-500" />
-          <h2 className="text-xl font-bold">
+          <h1 className="text-xl font-bold">
             <Trans id="auth.resetPassword.success.title" comment="Heading after password is successfully reset">
               Password updated
             </Trans>
-          </h2>
+          </h1>
           <p className="mt-2 text-sm text-muted">
             <Trans id="auth.resetPassword.success.description" comment="Description after successful password reset">
               Your password has been reset. You can now sign in with your new password.
@@ -125,11 +125,11 @@ export default function ResetPasswordPage() {
 
   return (
     <AuthShell>
-      <h2 className="text-center text-xl font-bold">
+      <h1 className="text-center text-xl font-bold">
         <Trans id="auth.resetPassword.title" comment="Reset password page heading">
           Set new password
         </Trans>
-      </h2>
+      </h1>
       <p className="mb-6 text-center text-sm text-muted">
         <Trans id="auth.resetPassword.subtitle" comment="Reset password page subtitle">
           Enter your new password below.

--- a/apps/web/app/[lang]/verify-email/page.tsx
+++ b/apps/web/app/[lang]/verify-email/page.tsx
@@ -44,11 +44,11 @@ export default function VerifyEmailPage() {
     return (
       <AuthShell>
         <div className="text-center">
-          <p className="text-sm text-muted">
+          <h1 className="text-xl font-bold">
             <Trans id="auth.verify.loading" comment="Shown while verifying email token">
               Verifying your email...
             </Trans>
-          </p>
+          </h1>
         </div>
       </AuthShell>
     );
@@ -58,11 +58,11 @@ export default function VerifyEmailPage() {
     return (
       <AuthShell>
         <div className="text-center">
-          <h2 className="text-xl font-bold">
+          <h1 className="text-xl font-bold">
             <Trans id="auth.verify.error.title" comment="Heading when email verification fails">
               Verification failed
             </Trans>
-          </h2>
+          </h1>
           <ErrorAlert message={error} focusOnRender />
           <Button href={lp("/sign-in")} prefetch={false} className="mt-4">
             <Trans id="auth.verify.error.backToSignIn" comment="Link back to sign-in after failed verification">
@@ -78,11 +78,11 @@ export default function VerifyEmailPage() {
     <AuthShell>
       <div className="text-center">
         <CircleCheck className="mx-auto mb-4 size-10 text-green-500" />
-        <h2 className="text-xl font-bold">
+        <h1 className="text-xl font-bold">
           <Trans id="auth.verify.success.title" comment="Heading when email is successfully verified">
             Email verified
           </Trans>
-        </h2>
+        </h1>
         <p className="mt-2 text-sm text-muted">
           <Trans id="auth.verify.success.description" comment="Description after successful email verification">
             Your email has been verified.

--- a/apps/web/src/components/AuthForm.tsx
+++ b/apps/web/src/components/AuthForm.tsx
@@ -167,11 +167,11 @@ export function AuthForm({ mode }: AuthFormProps) {
 
   return (
     <>
-      <h2 className="text-center text-xl font-bold">
+      <h1 className="text-center text-xl font-bold">
         {isSignUp
           ? <Trans id="auth.signUp.title" comment="Sign-up page heading">Create an account</Trans>
           : <Trans id="auth.signIn.title" comment="Sign-in page heading">Sign in</Trans>}
-      </h2>
+      </h1>
       <p className="mb-6 text-center text-sm text-muted">
         {isSignUp
           ? <Trans id="auth.signUp.subtitle" comment="Sign-up page subtitle">Get started with Job Seek</Trans>

--- a/apps/web/src/components/AuthShell.tsx
+++ b/apps/web/src/components/AuthShell.tsx
@@ -11,7 +11,11 @@ export function AuthShell({ children }: { children: ReactNode }) {
   const lp = useLocalePath();
 
   return (
-    <div className="mx-auto w-full max-w-lg px-4 sm:w-fit sm:min-w-[24rem]">
+    <main
+      id="main-content"
+      tabIndex={-1}
+      className="mx-auto w-full max-w-lg px-4 scroll-mt-12 sm:w-fit sm:min-w-[24rem]"
+    >
       <div className="flex min-h-screen flex-col items-center justify-center py-8">
         <Link href={lp("/explore")} prefetch={false} className="mb-6 block h-9 w-36">
           <ThemedImage
@@ -32,6 +36,6 @@ export function AuthShell({ children }: { children: ReactNode }) {
           <LocaleSwitcher />
         </div>
       </div>
-    </div>
+    </main>
   );
 }

--- a/apps/web/src/components/HowWeIndexContent.tsx
+++ b/apps/web/src/components/HowWeIndexContent.tsx
@@ -32,7 +32,7 @@ export function HowWeIndexContent() {
   ];
 
   return (
-    <main className="py-12 md:py-20">
+    <main id="main-content" tabIndex={-1} className="scroll-mt-12 py-12 md:py-20">
       <div className="mx-auto max-w-[1200px] px-4">
         <div className="flex flex-col items-start gap-12 lg:flex-row lg:gap-20">
           <div className="flex flex-1 flex-col gap-12 md:gap-16">

--- a/apps/web/src/components/LicenseContent.tsx
+++ b/apps/web/src/components/LicenseContent.tsx
@@ -25,7 +25,7 @@ export function LicenseContent() {
   ];
 
   return (
-    <main className="py-12 md:py-20">
+    <main id="main-content" tabIndex={-1} className="scroll-mt-12 py-12 md:py-20">
       <div className="mx-auto max-w-[1200px] px-4">
         <div className="flex flex-col items-start gap-12 lg:flex-row lg:gap-20">
           <div className="flex flex-1 flex-col gap-12 md:gap-16">

--- a/apps/web/src/components/PrivacyPolicyContent.tsx
+++ b/apps/web/src/components/PrivacyPolicyContent.tsx
@@ -11,7 +11,7 @@ export function PrivacyPolicyContent() {
   const fullPolicyLink = `${siteConfig.repoUrl}/blob/main/PRIVACY-POLICY`;
 
   return (
-    <main className="py-12 md:py-20">
+    <main id="main-content" tabIndex={-1} className="scroll-mt-12 py-12 md:py-20">
       <div className="mx-auto max-w-[900px] px-4">
         <div className="flex flex-col gap-12 md:gap-16">
           {/* Hero */}

--- a/apps/web/src/components/TermsContent.tsx
+++ b/apps/web/src/components/TermsContent.tsx
@@ -11,7 +11,7 @@ export function TermsContent() {
   const fullTermsLink = `${siteConfig.repoUrl}/blob/main/TERMS-OF-SERVICE`;
 
   return (
-    <main className="py-12 md:py-20">
+    <main id="main-content" tabIndex={-1} className="scroll-mt-12 py-12 md:py-20">
       <div className="mx-auto max-w-[900px] px-4">
         <div className="flex flex-col gap-12 md:gap-16">
           {/* Hero */}


### PR DESCRIPTION
## Summary

- make the public entry layout own the primary main landmark and skip target
- give homepage and all anonymous auth routes one descriptive H1
- avoid nested main landmarks on public content routes that already use the shared layout

## Verification

- focused Vitest: 1 file, 7 route-semantic tests
- changed-file ESLint
- Next route type generation and TypeScript
- git diff --check

## Post-deploy acceptance

Inspect homepage and every anonymous auth route at mobile and desktop widths for exactly one main landmark and one descriptive H1.

Addresses #6642