### PR TITLE
Add explicit accessible names to search controls

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
@@ -153,6 +153,11 @@ export function CompanyPage({
     comment: "Placeholder for search bar when on company page",
     message: `Search at ${company.name}...`,
   });
+  const searchAccessibleLabel = t({
+    id: "company.page.searchLabel",
+    comment: "Accessible label for job search scoped to one company",
+    message: `Search jobs at ${company.name}`,
+  });
 
   /** Update only the `show` query param without touching filter state. */
   function updateShowParam(postingId: string | null) {
@@ -365,9 +370,10 @@ export function CompanyPage({
         runSearch();
       },
       placeholder: searchPlaceholder,
+      accessibleLabel: searchAccessibleLabel,
     });
     return () => setPageActions(null);
-  }, [setPageActions, searchPlaceholder]);
+  }, [setPageActions, searchAccessibleLabel, searchPlaceholder]);
 
   const handleRemoveKeyword = useCallback(
     (keyword: string) => {
@@ -671,6 +677,7 @@ export function CompanyPage({
         onClearAll={handleClearAll}
         onSubmitSearch={handleSubmitSearch}
         searchPlaceholder={searchPlaceholder}
+        searchAccessibleLabel={searchAccessibleLabel}
         statsSlot={statsSlot}
       />
 

--- a/apps/web/locales/de.po
+++ b/apps/web/locales/de.po
@@ -14,6 +14,25 @@ msgstr ""
 "Plural-Forms: \n"
 "X-Generator: @lingui/cli\n"
 
+#. Accessible label for job search scoped to one company
+#. js-lingui-explicit-id
+#. placeholder {0}: company.name
+#: app/[lang]/(app)/company/[slug]/company-page.tsx
+msgid "company.page.searchLabel"
+msgstr "Jobs bei {0} suchen"
+
+#. Accessible label for the main job search input
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx
+msgid "search.bar.label"
+msgstr "Jobs suchen"
+
+#. Accessible label for public watchlist search input
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx
+msgid "watchlists.explore.searchLabel"
+msgstr "Öffentliche Watchlists suchen"
+
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/faq/page.tsx:47
 #~ msgid "faq.a.whichAts"

--- a/apps/web/locales/en.po
+++ b/apps/web/locales/en.po
@@ -14,6 +14,25 @@ msgstr ""
 "Plural-Forms: \n"
 "X-Generator: @lingui/cli\n"
 
+#. Accessible label for job search scoped to one company
+#. js-lingui-explicit-id
+#. placeholder {0}: company.name
+#: app/[lang]/(app)/company/[slug]/company-page.tsx
+msgid "company.page.searchLabel"
+msgstr "Search jobs at {0}"
+
+#. Accessible label for the main job search input
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx
+msgid "search.bar.label"
+msgstr "Search jobs"
+
+#. Accessible label for public watchlist search input
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx
+msgid "watchlists.explore.searchLabel"
+msgstr "Search public watchlists"
+
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/faq/page.tsx:47
 #~ msgid "faq.a.whichAts"

--- a/apps/web/locales/fr.po
+++ b/apps/web/locales/fr.po
@@ -14,6 +14,25 @@ msgstr ""
 "Plural-Forms: \n"
 "X-Generator: @lingui/cli\n"
 
+#. Accessible label for job search scoped to one company
+#. js-lingui-explicit-id
+#. placeholder {0}: company.name
+#: app/[lang]/(app)/company/[slug]/company-page.tsx
+msgid "company.page.searchLabel"
+msgstr "Rechercher des offres chez {0}"
+
+#. Accessible label for the main job search input
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx
+msgid "search.bar.label"
+msgstr "Rechercher des offres"
+
+#. Accessible label for public watchlist search input
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx
+msgid "watchlists.explore.searchLabel"
+msgstr "Rechercher des listes publiques"
+
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/faq/page.tsx:47
 #~ msgid "faq.a.whichAts"

--- a/apps/web/locales/it.po
+++ b/apps/web/locales/it.po
@@ -14,6 +14,25 @@ msgstr ""
 "Plural-Forms: \n"
 "X-Generator: @lingui/cli\n"
 
+#. Accessible label for job search scoped to one company
+#. js-lingui-explicit-id
+#. placeholder {0}: company.name
+#: app/[lang]/(app)/company/[slug]/company-page.tsx
+msgid "company.page.searchLabel"
+msgstr "Cerca offerte di lavoro presso {0}"
+
+#. Accessible label for the main job search input
+#. js-lingui-explicit-id
+#: src/components/search/search-bar.tsx
+msgid "search.bar.label"
+msgstr "Cerca offerte di lavoro"
+
+#. Accessible label for public watchlist search input
+#. js-lingui-explicit-id
+#: src/components/watchlist/public-watchlist-search.tsx
+msgid "watchlists.explore.searchLabel"
+msgstr "Cerca liste pubbliche"
+
 #. js-lingui-explicit-id
 #: app/[lang]/(public)/faq/page.tsx:47
 #~ msgid "faq.a.whichAts"

--- a/apps/web/src/components/providers/SearchStateProvider.tsx
+++ b/apps/web/src/components/providers/SearchStateProvider.tsx
@@ -167,6 +167,8 @@ export interface SearchPageActions {
   getTechnologies?: () => { id: number; slug: string; name: string }[];
   /** Custom placeholder for the header SearchBar (e.g. "Search at Google...") */
   placeholder?: string;
+  /** Stable accessible name for the header SearchBar's current scope. */
+  accessibleLabel?: string;
 }
 
 type SearchStateStore = {

--- a/apps/web/src/components/search/__tests__/search-bar-accessibility.test.tsx
+++ b/apps/web/src/components/search/__tests__/search-bar-accessibility.test.tsx
@@ -1,0 +1,169 @@
+import { useEffect } from "react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import "@/test-utils/lingui-mock";
+
+let currentPathname = "/en";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => currentPathname,
+  useParams: () => ({ lang: "en" }),
+}));
+
+vi.mock("@/lib/actions/search-input", () => ({
+  parseSearchFilters: vi.fn(),
+}));
+
+vi.mock("@/components/search/search-bar-typeahead", () => ({
+  matchWorkModes: () => [],
+  useSearchBarTypeahead: ({
+    onOpen,
+  }: {
+    onOpen: () => void;
+  }) => ({
+    locationResults: [],
+    companyResults: [],
+    occupationResults: [],
+    seniorityResults: [],
+    technologyResults: [],
+    clearResults: vi.fn(),
+    fetchSuggestions: onOpen,
+  }),
+}));
+
+import {
+  SearchStateProvider,
+  useSearchStateStore,
+  type SearchPageActions,
+} from "@/components/providers/SearchStateProvider";
+import { SearchBar } from "../search-bar";
+
+const noOpPageActions: Omit<SearchPageActions, "accessibleLabel" | "placeholder"> = {
+  addLocation: vi.fn(),
+  addOccupation: vi.fn(),
+  addSeniority: vi.fn(),
+  submitSearch: vi.fn(),
+  getLocations: () => [],
+  getKeywords: () => [],
+  getOccupations: () => [],
+  getSeniorities: () => [],
+};
+
+function CompanyHeaderSearch() {
+  const { setPageActions } = useSearchStateStore();
+
+  useEffect(() => {
+    setPageActions({
+      ...noOpPageActions,
+      placeholder: "Search at Acme...",
+      accessibleLabel: "Search jobs at Acme",
+    });
+    return () => setPageActions(null);
+  }, [setPageActions]);
+
+  return <SearchBar />;
+}
+
+async function expectOwnedListbox(input: HTMLElement) {
+  expect(input.getAttribute("aria-expanded")).toBe("false");
+  expect(input.getAttribute("aria-controls")).toBeNull();
+
+  await userEvent.type(input, "engineer");
+
+  expect(input.getAttribute("aria-expanded")).toBe("true");
+  const controls = input.getAttribute("aria-controls");
+  expect(controls).toBeTruthy();
+
+  const listbox = document.getElementById(controls!);
+  expect(listbox).toBe(screen.getByRole("listbox"));
+  expect(within(listbox!).getAllByRole("option").length).toBeGreaterThan(0);
+
+  await userEvent.type(input, "{ArrowDown}");
+  const activeDescendant = input.getAttribute("aria-activedescendant");
+  expect(activeDescendant).toBeTruthy();
+  expect(document.getElementById(activeDescendant!)?.getAttribute("role")).toBe(
+    "option",
+  );
+
+  await userEvent.type(input, "{Escape}");
+  expect(input.getAttribute("aria-expanded")).toBe("false");
+  expect(input.getAttribute("aria-controls")).toBeNull();
+  expect(input.getAttribute("aria-activedescendant")).toBeNull();
+}
+
+describe("SearchBar accessibility contract", () => {
+  beforeEach(() => {
+    currentPathname = "/en";
+  });
+
+  it.each([
+    "/en",
+    "/en/alice/engineering",
+    "/en/companies/request",
+    "/en/explore",
+    "/en/my-jobs",
+    "/en/my-jobs/stats",
+    "/en/progress",
+    "/en/settings",
+    "/en/settings/account",
+    "/en/settings/billing",
+    "/en/watchlists",
+  ])(
+    "gives the shared search on %s a stable job-search name and owned popup",
+    async (pathname) => {
+      currentPathname = pathname;
+      render(<SearchBar />);
+
+      const input = screen.getByRole("combobox", { name: "Search jobs" });
+      await expectOwnedListbox(input);
+    },
+  );
+
+  it("reactively gives the company header search its localized company scope", async () => {
+    currentPathname = "/en/company/acme";
+    render(
+      <SearchStateProvider>
+        <CompanyHeaderSearch />
+      </SearchStateProvider>,
+    );
+
+    const input = await screen.findByRole("combobox", {
+      name: "Search jobs at Acme",
+    });
+    expect(input.getAttribute("placeholder")).toBe("Search at Acme...");
+    await expectOwnedListbox(input);
+  });
+
+  it("keeps popup and option IDs unique when desktop and mobile searches coexist", async () => {
+    render(
+      <>
+        <SearchBar accessibleLabel="Search jobs" />
+        <SearchBar accessibleLabel="Search jobs at Acme" companyId="acme" />
+      </>,
+    );
+
+    const globalInput = screen.getByRole("combobox", { name: "Search jobs" });
+    const companyInput = screen.getByRole("combobox", {
+      name: "Search jobs at Acme",
+    });
+    // Change both inputs without pointer focus transitions so both responsive
+    // variants stay expanded in the DOM at once. A real pointer interaction
+    // intentionally closes the other instance through its outside-click hook.
+    fireEvent.change(globalInput, { target: { value: "engineer" } });
+    fireEvent.change(companyInput, { target: { value: "designer" } });
+
+    const globalControls = globalInput.getAttribute("aria-controls");
+    const companyControls = companyInput.getAttribute("aria-controls");
+    expect(globalControls).toBeTruthy();
+    expect(companyControls).toBeTruthy();
+    expect(globalControls).not.toBe(companyControls);
+
+    const optionIds = screen
+      .getAllByRole("option")
+      .map((option) => option.id);
+    expect(new Set(optionIds).size).toBe(optionIds.length);
+  });
+});

--- a/apps/web/src/components/search/search-bar-suggestion-section.tsx
+++ b/apps/web/src/components/search/search-bar-suggestion-section.tsx
@@ -5,6 +5,7 @@ import type { ReactNode } from "react";
 export function SearchBarSuggestionSection<T>({
   items,
   header,
+  optionIdPrefix,
   startIndex,
   activeIndex,
   hasDivider,
@@ -18,6 +19,7 @@ export function SearchBarSuggestionSection<T>({
 }: {
   items: readonly T[];
   header: string;
+  optionIdPrefix: string;
   startIndex: number;
   activeIndex: number;
   hasDivider: boolean;
@@ -45,7 +47,7 @@ export function SearchBarSuggestionSection<T>({
         return (
           <div
             key={getKey(item)}
-            id={`search-option-${flatIndex}`}
+            id={`${optionIdPrefix}-${flatIndex}`}
             role="option"
             aria-selected={flatIndex === activeIndex}
             data-suggestion

--- a/apps/web/src/components/search/search-bar.tsx
+++ b/apps/web/src/components/search/search-bar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback, useMemo } from "react";
+import { useState, useRef, useEffect, useCallback, useId, useMemo } from "react";
 import { useParams, usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   Search,
@@ -76,6 +76,8 @@ interface SearchBarProps {
   userLng?: number;
   className?: string;
   placeholder?: string;
+  /** Stable accessible name for the search scope. */
+  accessibleLabel?: string;
 }
 
 export function SearchBar({
@@ -98,6 +100,7 @@ export function SearchBar({
   userLng: serverLng,
   className,
   placeholder: placeholderProp,
+  accessibleLabel: accessibleLabelProp,
 }: SearchBarProps) {
   const { t } = useLingui();
   const router = useRouter();
@@ -123,6 +126,7 @@ export function SearchBar({
   const listRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const isKeyboardNav = useRef(false);
+  const listboxId = useId();
 
   const browserGeo = useBrowserCoordinates(serverLat);
   const userLat = serverLat ?? browserGeo?.lat;
@@ -484,6 +488,16 @@ export function SearchBar({
     comment: "Placeholder for the main search bar",
     message: "Search...",
   });
+  const accessibleLabel =
+    accessibleLabelProp ??
+    reactivePageActions?.accessibleLabel ??
+    t({
+      id: "search.bar.label",
+      comment: "Accessible label for the main job search input",
+      message: "Search jobs",
+    });
+  const listboxVisible = isOpen && allSuggestions.length > 0;
+  const optionIdPrefix = `${listboxId}-option`;
 
   // Compute flat indices for each section (keyword → occupations → seniorities → technologies → workMode → locations → companies → request)
   let flatIdx = 0;
@@ -544,16 +558,21 @@ export function SearchBar({
           placeholder={placeholder}
           className="w-full bg-transparent text-sm outline-none placeholder:text-muted"
           role="combobox"
-          aria-expanded={isOpen}
+          aria-label={accessibleLabel}
+          aria-expanded={listboxVisible}
           aria-autocomplete="list"
+          aria-controls={listboxVisible ? listboxId : undefined}
           aria-activedescendant={
-            activeIndex >= 0 ? `search-option-${activeIndex}` : undefined
+            listboxVisible && activeIndex >= 0
+              ? `${optionIdPrefix}-${activeIndex}`
+              : undefined
           }
         />
       </div>
 
-      {isOpen && allSuggestions.length > 0 && (
+      {listboxVisible && (
         <div
+          id={listboxId}
           ref={listRef}
           role="listbox"
           className="absolute left-0 top-full z-50 mt-1 w-full min-w-64 rounded-lg border border-border-soft bg-surface shadow-lg"
@@ -561,7 +580,7 @@ export function SearchBar({
         <ScrollFade className="max-h-[366px]" deps={[allSuggestions.length]}>
           {trimmedInput.length >= 2 && (
             <div
-              id={`search-option-${keywordIndex}`}
+              id={`${optionIdPrefix}-${keywordIndex}`}
               role="option"
               aria-selected={keywordIndex === activeIndex}
               data-suggestion
@@ -592,6 +611,7 @@ export function SearchBar({
               comment: "Section header for occupation suggestions in search bar",
               message: "Roles",
             })}
+            optionIdPrefix={optionIdPrefix}
             startIndex={occStartIndex}
             activeIndex={activeIndex}
             hasDivider={trimmedInput.length >= 2}
@@ -609,6 +629,7 @@ export function SearchBar({
               comment: "Section header for seniority suggestions in search bar",
               message: "Level",
             })}
+            optionIdPrefix={optionIdPrefix}
             startIndex={senStartIndex}
             activeIndex={activeIndex}
             hasDivider={occupationResults.length > 0}
@@ -626,6 +647,7 @@ export function SearchBar({
               comment: "Section header for technology suggestions in search bar",
               message: "Technologies",
             })}
+            optionIdPrefix={optionIdPrefix}
             startIndex={techStartIndex}
             activeIndex={activeIndex}
             hasDivider={occupationResults.length > 0 || seniorityResults.length > 0}
@@ -643,6 +665,7 @@ export function SearchBar({
               comment: "Section header for work-mode (onsite/hybrid/remote) suggestions in search bar",
               message: "Work mode",
             })}
+            optionIdPrefix={optionIdPrefix}
             startIndex={wmStartIndex}
             activeIndex={activeIndex}
             hasDivider={occupationResults.length > 0 || seniorityResults.length > 0 || technologyResults.length > 0}
@@ -661,6 +684,7 @@ export function SearchBar({
               comment: "Section header for location suggestions in search bar",
               message: "Locations",
             })}
+            optionIdPrefix={optionIdPrefix}
             startIndex={locStartIndex}
             activeIndex={activeIndex}
             hasDivider={occupationResults.length > 0 || seniorityResults.length > 0 || technologyResults.length > 0 || workModeResults.length > 0}
@@ -685,6 +709,7 @@ export function SearchBar({
               comment: "Section header for company suggestions in search bar",
               message: "Companies",
             })}
+            optionIdPrefix={optionIdPrefix}
             startIndex={companyStartIndex}
             activeIndex={activeIndex}
             hasDivider={occupationResults.length > 0 || seniorityResults.length > 0 || technologyResults.length > 0 || workModeResults.length > 0 || locationResults.length > 0}
@@ -698,7 +723,7 @@ export function SearchBar({
 
           {showRequestItem && (
             <div
-              id={`search-option-${requestIndex}`}
+              id={`${optionIdPrefix}-${requestIndex}`}
               role="option"
               aria-selected={requestIndex === activeIndex}
               data-suggestion

--- a/apps/web/src/components/search/search-toolbar.tsx
+++ b/apps/web/src/components/search/search-toolbar.tsx
@@ -56,6 +56,8 @@ interface SearchToolbarProps {
   ) => void;
   /** Placeholder for the mobile search bar */
   searchPlaceholder?: string;
+  /** Accessible name for the mobile search bar's current scope. */
+  searchAccessibleLabel?: string;
   /**
    * Optional element rendered on the right of the language-note row
    * (next to SaveSearchButton when filters are active). Used by the
@@ -98,6 +100,7 @@ export function SearchToolbar({
   onClearAll,
   onSubmitSearch,
   searchPlaceholder,
+  searchAccessibleLabel,
   statsSlot,
 }: SearchToolbarProps) {
   const { t } = useLingui();
@@ -136,6 +139,7 @@ export function SearchToolbar({
           userLat={userLat}
           userLng={userLng}
           placeholder={searchPlaceholder}
+          accessibleLabel={searchAccessibleLabel}
         />
       </div>
       <div className="flex items-start justify-between gap-4">

--- a/apps/web/src/components/watchlist/__tests__/public-watchlist-search.test.tsx
+++ b/apps/web/src/components/watchlist/__tests__/public-watchlist-search.test.tsx
@@ -74,6 +74,17 @@ beforeEach(() => {
 });
 
 describe("PublicWatchlistSearch navigation", () => {
+  it("exposes a stable public-watchlist searchbox name", () => {
+    render(<PublicWatchlistSearch />);
+
+    const input = screen.getByRole("searchbox", {
+      name: "Search public watchlists",
+    });
+    expect(input.getAttribute("placeholder")).toBe("Search watchlists...");
+    expect(input.getAttribute("aria-expanded")).toBeNull();
+    expect(input.getAttribute("aria-controls")).toBeNull();
+  });
+
   it("scrolls to top synchronously when opening a public watchlist result", async () => {
     const scrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
 

--- a/apps/web/src/components/watchlist/public-watchlist-search.tsx
+++ b/apps/web/src/components/watchlist/public-watchlist-search.tsx
@@ -83,9 +83,14 @@ export function PublicWatchlistSearch() {
       <div className="mb-4 flex items-center gap-2 rounded-md border border-border-soft px-3 py-2">
         <Search size={14} className="shrink-0 text-muted" />
         <input
-          type="text"
+          type="search"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
+          aria-label={t({
+            id: "watchlists.explore.searchLabel",
+            comment: "Accessible label for public watchlist search input",
+            message: "Search public watchlists",
+          })}
           placeholder={t({
             id: "watchlists.explore.searchPlaceholder",
             comment: "Placeholder for public watchlist search input",


### PR DESCRIPTION
## Summary

- give shared and public-watchlist search controls stable localized accessible names
- connect expanded comboboxes to stable, instance-unique listbox IDs
- preserve route-specific search scope and keyboard behavior

## Verification

- focused Vitest: 2 files, 16 tests covering names, roles, expanded state, controls, and duplicate instances
- changed-file ESLint
- Next route type generation and TypeScript
- git diff --check

## Post-deploy acceptance

Repeat keyboard navigation and inspect the Chromium accessibility tree on Explore, company, and public-watchlist routes.

Addresses #6641