### PR TITLE
Sunset Codex desktop automation guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Jobseek monitors company career pages for new job postings. Companies are config
 │   ├── 15-data-sampling-routine.md # Daily labelled-postings routine spec
 │   ├── 16-murmur-codex-mcp-transition.md # Murmur Codex MCP transition plan
 │   ├── 17-codex-migration-verification-runbook.md # Codex pilot verification
-│   └── 18-codex-automation-deployment.md # Codex automation deployment + maintenance
+│   └── 18-codex-automation-deployment.md # Hetzner Codex runner deployment + maintenance
 └── .github/workflows/       # CI + agent automation
 ```
 
@@ -110,9 +110,10 @@ Deployment and maintenance rules live in
 - `docs/17-codex-migration-verification-runbook.md` — central pilot
   verification checklist for Codex migration surfaces, including agent trace
   collection and local fallback guardrails.
-- `docs/18-codex-automation-deployment.md` — active automation registry,
-  Hetzner company resolver plan, harness-invariant contracts, deployment
-  procedure, and maintenance checks.
+- `docs/18-codex-automation-deployment.md` — production Hetzner runner
+  inventory, company resolver plan, harness-invariant contracts, deployment
+  procedure, and maintenance checks. Codex desktop schedules are sunset and
+  must not be recreated.
 
 Web app (from `apps/web/`):
 

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -116,4 +116,4 @@ plans, and ADRs, start with [docs/README.md](./README.md).
 - [09 -- Enrichment](./09-enrichment.md): LLM-based enrichment pipeline
 - [16 -- Murmur Codex MCP Transition](./16-murmur-codex-mcp-transition.md): Codex-first Murmur MCP plan
 - [17 -- Codex Migration Verification Runbook](./17-codex-migration-verification-runbook.md): Pilot checklist and rollback criteria
-- [18 -- Codex Automation Deployment](./18-codex-automation-deployment.md): Automation registry, deployment, and maintenance
+- [18 -- Hetzner Codex Runner Deployment](./18-codex-automation-deployment.md): Production runner inventory, deployment, maintenance, and desktop-scheduler sunset boundary

--- a/docs/01-agent-workflow.md
+++ b/docs/01-agent-workflow.md
@@ -140,7 +140,7 @@ The CSV config for the company should be included in the same PR alongside the c
 ## Company Resolver Automation
 
 The primary recurring path is the Hetzner-hosted local Codex runner documented
-in [18 - Codex Automation Deployment](18-codex-automation-deployment.md). It
+in [18 - Hetzner Codex Runner Deployment](18-codex-automation-deployment.md). It
 checks the backlog every 15-30 minutes, self-regulates against Codex usage and
 host capacity, selects at most one open `company-request` issue per accepted
 run, claims it with the shared `ws` claim protocol, and runs

--- a/docs/16-hetzner-maintenance.md
+++ b/docs/16-hetzner-maintenance.md
@@ -1226,17 +1226,18 @@ Host-surface deployment is CI/CD-owned by
 That workflow updates the checked-out repo and systemd units; it does not run
 `codex exec`, select issues, upload labels, or perform error reviews.
 
-The local Codex desktop automation records for these three routines should be
-`PAUSED` after Hetzner cutover. They are retained only as local app state, not
-as the production scheduler:
+The former desktop scheduler names below must remain absent after Hetzner
+cutover. They are identifiers for duplicate-scheduler detection only, not
+deployable or retained fallback state:
 
 - `jobseek-company-request-resolver`
 - `jobseek-daily-classifications`
 - `jobseek-daily-error-review`
 
-Do not add or restore GitHub Actions that execute these routines. Manual
-recovery uses the same local Codex CLI path from a throwaway worktree, with
-`CODEX_EXEC_JSONL` set for trace capture.
+Do not recreate those desktop schedules or add/restore GitHub Actions that
+execute the routines. Manual recovery uses the same committed Codex CLI path
+from a throwaway worktree, with the Hetzner ledger, shared lock, and `ws`
+claims checked first. Keep `CODEX_EXEC_JSONL` set for trace capture.
 
 Check the last CI/CD host deploy:
 

--- a/docs/18-codex-automation-deployment.md
+++ b/docs/18-codex-automation-deployment.md
@@ -1,17 +1,18 @@
-# Codex Automation Deployment
+# Hetzner Codex Runner Deployment
 
 This document is the repo-owned deployment and maintenance spec for recurring
-Codex runs. Codex app automation records, local app TOML files, Hetzner
-systemd units, and governor state are deployment artifacts; do not treat them
-as source of truth and do not commit local Codex app state.
+Codex runs. The committed Hetzner systemd units and runner code are the only
+production scheduling surface. Host unit state and governor state are
+deployment artifacts; do not treat them as source of truth.
 
-## Automation Registry
+## Production Runner Inventory
 
-| automation | cadence | execution | source of truth | model policy |
+| systemd unit | cadence | execution | source of truth | model policy |
 |---|---:|---|---|---|
-| `jobseek-daily-classifications` | daily, 08:00 UTC | Hetzner crawler host, dedicated `codex-runner` user, local Codex CLI, isolated worktree per day | [15-data-sampling-routine.md](15-data-sampling-routine.md), [`.agents/skills/jobseek-label-daily/SKILL.md`](../.agents/skills/jobseek-label-daily/SKILL.md) | Sol/high orchestrator; Luna and Terra labeller subagents |
-| `jobseek-daily-error-review` | daily, 09:00 UTC | Hetzner crawler host, dedicated `codex-runner` user, local Codex CLI, root-collected redacted evidence bundle | [14-error-review-routine.md](14-error-review-routine.md), [`.agents/skills/jobseek-error-review/SKILL.md`](../.agents/skills/jobseek-error-review/SKILL.md) | Sol/high orchestrator; no default subagents |
-| `jobseek-company-request-resolver` | self-regulated, checked every 15-30 min | Hetzner crawler host, dedicated `codex-runner` user, local Codex CLI, isolated worktree per issue | [01-agent-workflow.md](01-agent-workflow.md), `apps/crawler/AGENTS.md`, `ws task --issue <N>` | Sol/high orchestrator; Terra and Luna `ws` subagents |
+| `jobseek-codex-daily-annotations.timer` | daily, 08:00 UTC | Hetzner crawler host, dedicated `codex-runner` user, local Codex CLI, isolated worktree per day | [15-data-sampling-routine.md](15-data-sampling-routine.md), [`.agents/skills/jobseek-label-daily/SKILL.md`](../.agents/skills/jobseek-label-daily/SKILL.md) | Sol/high orchestrator; Luna and Terra labeller subagents |
+| `jobseek-codex-daily-error-review.timer` | daily, 09:00 UTC | Hetzner crawler host, dedicated `codex-runner` user, local Codex CLI, root-collected redacted evidence bundle | [14-error-review-routine.md](14-error-review-routine.md), [`.agents/skills/jobseek-error-review/SKILL.md`](../.agents/skills/jobseek-error-review/SKILL.md) | Sol/high orchestrator; no default subagents |
+| `jobseek-codex-governor.timer` | self-regulated, checked after each governor run | Hetzner crawler host, dedicated `codex-runner` user, local Codex CLI, isolated worktree per issue | [01-agent-workflow.md](01-agent-workflow.md), `apps/crawler/AGENTS.md`, `ws task --issue <N>` | Sol/high orchestrator; Terra and Luna `ws` subagents |
+| `jobseek-codex-docker-lifecycle.service` | continuous | root read-only event watcher producing allowlisted evidence for the isolated runner | this runbook and the committed unit/script | no model invocation |
 
 The recurring company resolver and daily routines must not be triggered by
 GitHub Actions. They run on the Hetzner crawler host through local Codex CLI
@@ -20,6 +21,20 @@ GitHub Actions may still deploy the Hetzner runner host surface. The
 [`deploy-codex-runner.yml`](../.github/workflows/deploy-codex-runner.yml)
 workflow updates `/srv/jobseek-codex/repo`, installs/verifies systemd units,
 and leaves actual Codex execution to the Hetzner timers.
+
+## Sunset Desktop Scheduler Names
+
+The former desktop-scheduled routine names are retained here only so duplicate
+schedulers can be recognized during an audit:
+
+- `jobseek-company-request-resolver`
+- `jobseek-daily-classifications`
+- `jobseek-daily-error-review`
+
+They must remain absent from Codex desktop schedules, local scheduler files,
+systemd, and cron. Do not recreate, pause-and-retain, or use them as a recovery
+path. Manual recovery runs the same committed runner entry point once from a
+throwaway worktree after checking the Hetzner ledger and shared lock.
 
 ## GPT-5.6 Model Policy
 
@@ -49,8 +64,8 @@ ambiguous evidence.
 
 ## Harness Invariants
 
-These rules must hold whether the run is launched by the Codex desktop app,
-Codex CLI, the Hetzner governor, or a future Codex scheduler.
+These rules must hold whether the run is launched manually by Codex CLI, by the
+Hetzner governor/timers, or by a future replacement for those host units.
 
 - The automation prompt must be self-contained. It cannot rely on the
   conversation that created or updated the automation.
@@ -95,8 +110,8 @@ Codex CLI, the Hetzner governor, or a future Codex scheduler.
 
 ## Deployment Procedure
 
-Use this process when creating or changing a Codex app automation or Hetzner
-runner prompt:
+Use this process when creating or changing a Hetzner runner unit, runner
+prompt, or routine source:
 
 1. Update the routine source doc or skill in this repo.
 2. Build a self-contained automation prompt that tells Codex to read the
@@ -118,9 +133,9 @@ runner prompt:
    [`deploy-codex-runner-host.sh`](../scripts/deploy-codex-runner-host.sh)
    with `JOBSEEK_CODEX_START_TIMERS=0`, so it does not start a Codex run.
 
-Do not hand-edit local Codex automation TOML unless recovering from a broken
-app state. If hand recovery is necessary, copy the final settings back into
-this document or the relevant routine source in the same PR.
+Desktop scheduling is not a recovery path. If a host timer is unavailable,
+repair the committed runner/unit configuration or perform one bounded manual
+CLI run using the same ledger, lock, prompt, and verification contracts.
 
 ## Hetzner Codex Runner Implementation Plan
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,10 +61,10 @@ Status tags:
 - [17 - Codex Migration Verification Runbook](17-codex-migration-verification-runbook.md)
   `[runbook]` - pilot checks and rollback criteria for Codex migration
   surfaces.
-- [18 - Codex Automation Deployment](18-codex-automation-deployment.md)
-  `[runbook]` - recurring Codex automation registry, Hetzner runner
-  implementation plan, deployment procedure, maintenance checks, and
-  harness-invariant contracts.
+- [18 - Hetzner Codex Runner Deployment](18-codex-automation-deployment.md)
+  `[runbook]` - production systemd runner inventory, deployment procedure,
+  maintenance checks, desktop-scheduler sunset boundary, and harness-invariant
+  contracts.
 
 ## Operations And Routines
 

--- a/scripts/docs-index.test.mjs
+++ b/scripts/docs-index.test.mjs
@@ -75,3 +75,55 @@ test("docs README and ADR relative markdown links resolve", () => {
     }
   }
 });
+
+test("production Codex guidance rejects sunset desktop scheduler deployment", () => {
+  const guidancePaths = [
+    "AGENTS.md",
+    "docs/00-overview.md",
+    "docs/01-agent-workflow.md",
+    "docs/16-hetzner-maintenance.md",
+    "docs/18-codex-automation-deployment.md",
+    "docs/README.md",
+  ];
+  const forbidden = [
+    /automation\.toml/i,
+    /Codex app automation/i,
+    /active automation registry/i,
+    /desktop automation records?[^.\n]*paused/i,
+  ];
+
+  for (const guidancePath of guidancePaths) {
+    const source = readFileSync(guidancePath, "utf8");
+    for (const pattern of forbidden) {
+      assert.doesNotMatch(
+        source,
+        pattern,
+        `${guidancePath} must not contain deployable desktop scheduler guidance`,
+      );
+    }
+  }
+
+  const runbook = readFileSync(
+    "docs/18-codex-automation-deployment.md",
+    "utf8",
+  );
+  for (const unit of [
+    "jobseek-codex-governor.timer",
+    "jobseek-codex-daily-annotations.timer",
+    "jobseek-codex-daily-error-review.timer",
+    "jobseek-codex-docker-lifecycle.service",
+  ]) {
+    assert.ok(runbook.includes(`\`${unit}\``), `runner inventory lists ${unit}`);
+  }
+  for (const legacyName of [
+    "jobseek-company-request-resolver",
+    "jobseek-daily-classifications",
+    "jobseek-daily-error-review",
+  ]) {
+    assert.ok(
+      runbook.includes(`\`${legacyName}\``),
+      `sunset note lists ${legacyName}`,
+    );
+  }
+  assert.match(runbook, /must remain absent/i);
+});


### PR DESCRIPTION
## Summary

- make Hetzner codex-runner systemd units the production source of truth
- remove deployable desktop automation and TOML recovery instructions
- retain legacy names only as a migration recognition list
- add a docs contract test that rejects restored desktop scheduler guidance

## Verification

- 4 documentation index and sunset-contract tests passed
- pre-push hook and diff check passed

## Runtime residual

This PR intentionally contains no scheduler mutation. The audit separately verified the legacy desktop definitions are absent and the dedicated Hetzner replacements remain enabled.

Closes #6629
