### PR TITLE
Verify Vercel promotion identity

### DIFF
--- a/.github/scripts/classify-vercel-web-change.mjs
+++ b/.github/scripts/classify-vercel-web-change.mjs
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 
 const EXACT_WEB_INPUTS = new Set([
   ".github/scripts/classify-vercel-web-change.mjs",
+  ".github/scripts/verify-vercel-promotion.mjs",
   ".github/workflows/deploy-web-production.yml",
   "package.json",
   "pnpm-lock.yaml",

--- a/.github/scripts/verify-vercel-promotion.mjs
+++ b/.github/scripts/verify-vercel-promotion.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+
+import { execFile } from "node:child_process";
+import { appendFile } from "node:fs/promises";
+import { promisify } from "node:util";
+import { pathToFileURL } from "node:url";
+
+const execFileAsync = promisify(execFile);
+const SHA_RE = /^[0-9a-f]{40}$/;
+const DEPLOYMENT_ID_RE = /^dpl_[A-Za-z0-9]+$/;
+const ALIAS_RE = /^[A-Za-z0-9](?:[A-Za-z0-9.-]*[A-Za-z0-9])?$/;
+const VERCEL_URL_RE = /^https:\/\/[A-Za-z0-9.-]+\.vercel\.app\/?$/;
+
+export class PromotionVerificationError extends Error {
+  constructor(message, observation) {
+    super(message);
+    this.name = "PromotionVerificationError";
+    this.observation = observation;
+  }
+}
+
+function requireMatch(value, pattern, name) {
+  if (typeof value !== "string" || !pattern.test(value)) {
+    throw new TypeError(`Invalid ${name}`);
+  }
+  return value;
+}
+
+function requirePositiveInteger(value, name) {
+  if (!Number.isSafeInteger(value) || value < 1) {
+    throw new TypeError(`Invalid ${name}`);
+  }
+  return value;
+}
+
+function safeValue(value) {
+  if (typeof value !== "string") return "unavailable";
+  return value.replace(/[^A-Za-z0-9._:/-]/g, "?").slice(0, 200) || "unavailable";
+}
+
+export function parseProductionDeployment(raw) {
+  let deployment;
+  try {
+    deployment = JSON.parse(raw);
+  } catch {
+    throw new TypeError("Vercel returned malformed JSON");
+  }
+  if (!deployment || Array.isArray(deployment) || typeof deployment !== "object") {
+    throw new TypeError("Vercel returned an invalid deployment object");
+  }
+
+  const sha = deployment.gitSource?.sha ?? deployment.meta?.githubCommitSha;
+  const id = deployment.id;
+  const rawUrl = deployment.url;
+  const url = typeof rawUrl === "string" && rawUrl.startsWith("https://")
+    ? rawUrl
+    : `https://${rawUrl ?? ""}`;
+
+  return {
+    sha: requireMatch(sha, SHA_RE, "deployment SHA"),
+    id: requireMatch(id, DEPLOYMENT_ID_RE, "deployment ID"),
+    url: requireMatch(url, VERCEL_URL_RE, "deployment URL"),
+  };
+}
+
+export async function verifyPromotion({
+  expectedSha,
+  expectedId,
+  expectedUrl,
+  alias,
+  attempts = 12,
+  delayMs = 5_000,
+  fetchProduction,
+  sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+}) {
+  requireMatch(expectedSha, SHA_RE, "EXPECTED_SHA");
+  requireMatch(expectedId, DEPLOYMENT_ID_RE, "EXPECTED_DEPLOYMENT_ID");
+  requireMatch(expectedUrl, VERCEL_URL_RE, "EXPECTED_DEPLOYMENT_URL");
+  requireMatch(alias, ALIAS_RE, "PRODUCTION_ALIAS");
+  requirePositiveInteger(attempts, "attempts");
+  if (!Number.isSafeInteger(delayMs) || delayMs < 0) {
+    throw new TypeError("Invalid delayMs");
+  }
+  if (typeof fetchProduction !== "function") {
+    throw new TypeError("fetchProduction is required");
+  }
+
+  let observation = { sha: "unavailable", id: "unavailable", url: "unavailable" };
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      observation = parseProductionDeployment(await fetchProduction());
+      if (observation.sha === expectedSha && observation.id === expectedId) {
+        return { ...observation, attempt };
+      }
+    } catch {
+      observation = {
+        sha: "unavailable",
+        id: "unavailable",
+        url: "error:Vercel_API_unavailable",
+      };
+    }
+    if (attempt < attempts) await sleep(delayMs);
+  }
+
+  throw new PromotionVerificationError(
+    `Production alias ${alias} did not resolve to the promoted deployment after ${attempts} attempts`,
+    observation,
+  );
+}
+
+async function writeFailureSummary(error, expected) {
+  if (!process.env.GITHUB_STEP_SUMMARY) return;
+  const observed = error instanceof PromotionVerificationError
+    ? error.observation
+    : { sha: "unavailable", id: "unavailable", url: "unavailable" };
+  await appendFile(
+    process.env.GITHUB_STEP_SUMMARY,
+    [
+      "## Vercel promotion identity mismatch",
+      "",
+      `- Expected SHA: \`${safeValue(expected.sha)}\``,
+      `- Expected deployment: \`${safeValue(expected.id)}\` (${safeValue(expected.url)})`,
+      `- Observed SHA: \`${safeValue(observed.sha)}\``,
+      `- Observed deployment: \`${safeValue(observed.id)}\` (${safeValue(observed.url)})`,
+      "",
+      "The production alias did not converge to the deployment that this workflow promoted.",
+      "",
+    ].join("\n"),
+  );
+}
+
+async function main() {
+  const expected = {
+    sha: process.env.EXPECTED_SHA,
+    id: process.env.EXPECTED_DEPLOYMENT_ID,
+    url: process.env.EXPECTED_DEPLOYMENT_URL,
+  };
+  const alias = process.env.PRODUCTION_ALIAS;
+  const orgId = process.env.VERCEL_ORG_ID;
+  const token = process.env.VERCEL_TOKEN;
+  requireMatch(orgId, /^[A-Za-z0-9_-]+$/, "VERCEL_ORG_ID");
+  if (typeof token !== "string" || token.length === 0) {
+    throw new TypeError("Invalid VERCEL_TOKEN");
+  }
+
+  try {
+    const result = await verifyPromotion({
+      expectedSha: expected.sha,
+      expectedId: expected.id,
+      expectedUrl: expected.url,
+      alias,
+      fetchProduction: async () => {
+        const { stdout } = await execFileAsync(
+          "pnpm",
+          [
+            "dlx",
+            "vercel@55.0.0",
+            "api",
+            `/v13/deployments/${alias}?teamId=${orgId}`,
+            "--raw",
+            `--token=${token}`,
+          ],
+          { encoding: "utf8", maxBuffer: 1_000_000 },
+        );
+        return stdout;
+      },
+    });
+    process.stdout.write(`${JSON.stringify({
+      event: "vercel_promotion_verified",
+      expectedSha: expected.sha,
+      deploymentId: expected.id,
+      deploymentUrl: expected.url,
+      productionUrl: result.url,
+      attempt: result.attempt,
+    })}\n`);
+  } catch (error) {
+    await writeFailureSummary(error, expected);
+    const observed = error instanceof PromotionVerificationError
+      ? error.observation
+      : { sha: "unavailable", id: "unavailable", url: "unavailable" };
+    const message = error instanceof Error ? error.message : String(error);
+    process.stdout.write(
+      `::error title=Vercel promotion identity mismatch::${safeValue(message)}. ` +
+      `Expected ${safeValue(expected.sha)} / ${safeValue(expected.id)} at ${safeValue(expected.url)}; ` +
+      `observed ${safeValue(observed.sha)} / ${safeValue(observed.id)} at ${safeValue(observed.url)}\n`,
+    );
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main().catch((error) => {
+    process.stderr.write(`${safeValue(error instanceof Error ? error.message : String(error))}\n`);
+    process.exitCode = 2;
+  });
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
           scripts/dealroom-company-requests.test.mjs
           scripts/vercel-web-deploy-paths.test.mjs
           scripts/vercel-production-sha.test.mjs
+          scripts/vercel-promotion-identity.test.mjs
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/deploy-web-production.yml
+++ b/.github/workflows/deploy-web-production.yml
@@ -135,10 +135,12 @@ jobs:
 
       - name: Promote only if this SHA is still main
         if: steps.paths.outputs.deploy == 'true'
+        id: promote
         env:
           DEPLOYMENT_URL: ${{ steps.stage.outputs.url }}
           EXPECTED_SHA: ${{ steps.paths.outputs.current_sha }}
         run: |
+          echo "promoted=false" >> "$GITHUB_OUTPUT"
           current_main="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')"
           if [[ "$current_main" != "$EXPECTED_SHA" ]]; then
             echo "Skipping stale staged deployment: expected $EXPECTED_SHA, main is $current_main"
@@ -146,3 +148,34 @@ jobs:
           fi
           pnpm dlx vercel@55.0.0 promote "$DEPLOYMENT_URL" \
             --yes --timeout=3m --token="$VERCEL_TOKEN"
+          echo "promoted=true" >> "$GITHUB_OUTPUT"
+
+      - name: Verify the promoted deployment owns production
+        if: steps.promote.outputs.promoted == 'true'
+        env:
+          EXPECTED_SHA: ${{ steps.paths.outputs.current_sha }}
+          EXPECTED_DEPLOYMENT_ID: ${{ steps.stage.outputs.id }}
+          EXPECTED_DEPLOYMENT_URL: ${{ steps.stage.outputs.url }}
+        run: |
+          node .github/scripts/verify-vercel-promotion.mjs
+
+          current_main="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')"
+          git fetch --no-tags origin "$current_main"
+          result="$(node .github/scripts/classify-vercel-web-change.mjs \
+            "$EXPECTED_SHA" "$current_main")"
+          deploy="$(jq -r '.deploy' <<<"$result")"
+          relevant="$(jq -r '.relevant | join(", ")' <<<"$result")"
+          if [[ "$deploy" == "true" ]]; then
+            message="Promoted $EXPECTED_SHA ($EXPECTED_DEPLOYMENT_ID), but main $current_main now contains web inputs: $relevant"
+            echo "::error title=Web change landed during Vercel promotion::$message. Staged URL: $EXPECTED_DEPLOYMENT_URL"
+            {
+              echo "## Web change landed during Vercel promotion"
+              echo
+              echo "- Promoted SHA: \`$EXPECTED_SHA\`"
+              echo "- Current main SHA: \`$current_main\`"
+              echo "- Deployment: \`$EXPECTED_DEPLOYMENT_ID\` ($EXPECTED_DEPLOYMENT_URL)"
+              echo "- New web inputs: \`$relevant\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+          echo "Production remains current for web inputs at main $current_main"

--- a/docs/18-vercel-fluid-cpu.md
+++ b/docs/18-vercel-fluid-cpu.md
@@ -44,17 +44,18 @@ than 138.5 seconds in a comparable 12-hour window.
 ## Production deployment identity
 
 Do not start a measurement window until the deployment holding the production
-aliases is the current GitHub `main` SHA. Vercel completed two 2026-08-11 main
-deployments out of order and let an older parent commit reacquire `jseek.co`,
-temporarily undoing the company-OG cutover.
+aliases is the most recent web-relevant GitHub `main` SHA. Production can
+legitimately lag crawler-, data-, documentation-, or ops-only commits. Vercel
+completed two 2026-08-11 main deployments out of order and let an older parent
+commit reacquire `jseek.co`, temporarily undoing the company-OG cutover.
 
-The `Guard Vercel production order` workflow checks every successful Vercel
-Production deployment status against the live default-branch SHA. A mismatch
-fails with both SHAs and the deployment URL. Treat that failure as a production
-incident: inspect the Ready deployment for current main, run the functionality
-checks below against its protected URL, and only then use `vercel promote` to
-restore the aliases. The guard detects stale production; issue #6655 tracks a
-future staged-promotion flow that can correct it automatically.
+The `Guard Vercel production order` workflow remains a secondary check for
+successful Vercel Production deployment-status events. It compares such an
+event with the live default-branch SHA, but owned CLI promotions do not
+reliably emit a matching event and an exact-main comparison is intentionally
+stricter than the web-relevant invariant. Treat a guard failure as a signal to
+inspect the deployment and cumulative web delta, not as the primary promotion
+assertion.
 
 `apps/web/vercel.json` disables connected-Git production deployments for
 `main`. The `Deploy web production` workflow owns that path instead: it runs on
@@ -62,12 +63,17 @@ every main push and deterministically classifies the entire delta from the
 currently promoted Vercel SHA to live `main`. This cumulative comparison means
 a newer queued ops-only push cannot hide an earlier web change. The workflow
 stages an exact-SHA production artifact with no domains, smoke-tests it,
-rechecks the live main SHA, and only then promotes it. If main moves during the
-build, the staged artifact is not promoted and the latest serialized run
-re-evaluates the cumulative delta. PR branches remain on the Vercel Git
-integration. Web inputs are `apps/web/**`, `packages/mcp-server/**`, root pnpm
-and Turbo configuration, and dependency patches. Crawler code, crawler board
-configuration, documentation, and company CSV changes do not deploy the web.
+rechecks the live main SHA, and only then promotes it. After promotion, a
+bounded API poll must prove that `jseek.co` resolves to both the staged
+deployment ID and SHA. The workflow then refetches main and fails with both
+SHAs, the deployment identity, and relevant paths if a web change landed during
+promotion. If main moves earlier during the build, the staged artifact is not
+promoted and the latest serialized run re-evaluates the cumulative delta. PR
+branches remain on the Vercel Git integration. Web inputs are `apps/web/**`,
+`packages/mcp-server/**`, the production deployment workflow and helpers, root
+pnpm and Turbo configuration, and dependency patches. Crawler code, crawler
+board configuration, documentation, and company CSV changes do not deploy the
+web.
 
 Company CSV changes are safe to exclude because the external OG prewarm job
 publishes `og/company/<renderer>/_complete/current.json` only after the full

--- a/scripts/vercel-promotion-identity.test.mjs
+++ b/scripts/vercel-promotion-identity.test.mjs
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  PromotionVerificationError,
+  parseProductionDeployment,
+  verifyPromotion,
+} from "../.github/scripts/verify-vercel-promotion.mjs";
+
+const expectedSha = "a".repeat(40);
+const staleSha = "b".repeat(40);
+const expectedId = "dpl_Expected123";
+const staleId = "dpl_Stale456";
+const expectedUrl = "https://jobseek-expected.vercel.app";
+
+function deployment({
+  sha = expectedSha,
+  id = expectedId,
+  url = "jobseek-expected.vercel.app",
+} = {}) {
+  return JSON.stringify({ gitSource: { sha }, id, url });
+}
+
+function options(fetchProduction) {
+  return {
+    expectedSha,
+    expectedId,
+    expectedUrl,
+    alias: "jseek.co",
+    fetchProduction,
+    delayMs: 0,
+    sleep: async () => {},
+  };
+}
+
+test("accepts only the exact promoted deployment identity", async () => {
+  let calls = 0;
+  const result = await verifyPromotion(options(async () => {
+    calls += 1;
+    return deployment();
+  }));
+
+  assert.deepEqual(result, {
+    sha: expectedSha,
+    id: expectedId,
+    url: expectedUrl,
+    attempt: 1,
+  });
+  assert.equal(calls, 1);
+});
+
+test("polls through stale alias propagation before accepting exact identity", async () => {
+  const responses = [
+    deployment({ sha: staleSha, id: staleId, url: "jobseek-stale.vercel.app" }),
+    deployment(),
+  ];
+  const result = await verifyPromotion({
+    ...options(async () => responses.shift()),
+    attempts: 2,
+  });
+
+  assert.equal(result.attempt, 2);
+  assert.equal(responses.length, 0);
+});
+
+test("fails after a bounded number of permanent mismatches", async () => {
+  let calls = 0;
+  await assert.rejects(
+    verifyPromotion({
+      ...options(async () => {
+        calls += 1;
+        return deployment({ sha: staleSha, id: staleId });
+      }),
+      attempts: 3,
+    }),
+    (error) => {
+      assert.ok(error instanceof PromotionVerificationError);
+      assert.match(error.message, /after 3 attempts/);
+      assert.deepEqual(error.observation, {
+        sha: staleSha,
+        id: staleId,
+        url: expectedUrl,
+      });
+      return true;
+    },
+  );
+  assert.equal(calls, 3);
+});
+
+test("reports malformed API responses without preserving control syntax", async () => {
+  await assert.rejects(
+    verifyPromotion({
+      ...options(async () => "not-json\n::error secret"),
+      attempts: 1,
+    }),
+    (error) => {
+      assert.ok(error instanceof PromotionVerificationError);
+      assert.equal(error.observation.sha, "unavailable");
+      assert.doesNotMatch(error.observation.url, /\s|::/);
+      assert.match(error.observation.url, /^error:Vercel/);
+      return true;
+    },
+  );
+});
+
+test("does not expose Vercel command failures", async () => {
+  await assert.rejects(
+    verifyPromotion({
+      ...options(async () => {
+        throw new Error("command failed with --token=do-not-print");
+      }),
+      attempts: 1,
+    }),
+    (error) => {
+      assert.ok(error instanceof PromotionVerificationError);
+      assert.equal(error.observation.url, "error:Vercel_API_unavailable");
+      assert.doesNotMatch(JSON.stringify(error), /do-not-print/);
+      return true;
+    },
+  );
+});
+
+test("parses the legacy metadata SHA and an absolute deployment URL", () => {
+  assert.deepEqual(parseProductionDeployment(JSON.stringify({
+    meta: { githubCommitSha: expectedSha },
+    id: expectedId,
+    url: expectedUrl,
+  })), {
+    sha: expectedSha,
+    id: expectedId,
+    url: expectedUrl,
+  });
+});

--- a/scripts/vercel-web-deploy-paths.test.mjs
+++ b/scripts/vercel-web-deploy-paths.test.mjs
@@ -18,6 +18,7 @@ test("deploys web runtime and every current workspace input", () => {
     "turbo.json",
     ".github/workflows/deploy-web-production.yml",
     ".github/scripts/classify-vercel-web-change.mjs",
+    ".github/scripts/verify-vercel-promotion.mjs",
   ]) {
     assert.equal(isVercelWebInput(path), true, path);
   }
@@ -49,6 +50,18 @@ test("production workflow stages, verifies, then promotes exact main", () => {
   assert.match(workflow, /production_sha.*current_sha/);
   assert.match(workflow, /current_main=.*commits\/main/);
   assert.match(workflow, /vercel@55\.0\.0 promote/);
+  assert.match(workflow, /id: promote/);
+  assert.match(workflow, /promoted=true/);
+  assert.match(
+    workflow,
+    /if: steps\.promote\.outputs\.promoted == 'true'/,
+  );
+  assert.match(workflow, /verify-vercel-promotion\.mjs/);
+  assert.match(
+    workflow,
+    /classify-vercel-web-change\.mjs[\s\S]{0,160}\$EXPECTED_SHA[\s\S]{0,80}\$current_main/,
+  );
+  assert.match(workflow, /Web change landed during Vercel promotion/);
   assert.match(
     workflow,
     /VERCEL_TOKEN: \$\{\{ secrets\.VERCEL_TOKEN \}\}/,


### PR DESCRIPTION
## Summary

- poll the production alias after an owned Vercel promotion and require the exact staged deployment ID and Git SHA
- recheck the cumulative promoted-to-main delta and fail only when a web-relevant change landed during promotion
- keep path-aware crawler/data/docs skips, add deterministic regressions, and document the operative production invariant

## Verification

- `node --test` repository workflow-script suite: 93 passed
- `actionlint`: clean
- `zizmor --persona regular --min-severity medium --min-confidence high .github/workflows`: no findings
- `git diff --check`
- independent adversarial review: no blockers

Closes #6655