### PR TITLE
Keep skip target on visible PPR landmark

### DIFF
--- a/apps/web/app/[lang]/__tests__/entry-route-semantics.test.tsx
+++ b/apps/web/app/[lang]/__tests__/entry-route-semantics.test.tsx
@@ -97,6 +97,10 @@ function expectSinglePageOutline() {
   expect(main.tabIndex).toBe(-1);
   expect(main.contains(heading)).toBe(true);
   expect(heading.textContent?.trim()).not.toBe("");
+  expect(screen.getAllByRole("link", { name: "Skip to content" })).toHaveLength(1);
+  expect(
+    screen.getByRole("link", { name: "Skip to content" }).getAttribute("href"),
+  ).toBe("#main-content");
 }
 
 function renderAuthRoute(page: ReactElement, ownsShell = false) {
@@ -120,8 +124,6 @@ describe("entry-route page semantics", () => {
     render(layout);
 
     expectSinglePageOutline();
-    expect(screen.getByRole("link", { name: "Skip to content" }).getAttribute("href"))
-      .toBe("#main-content");
   });
 
   it.each([

--- a/apps/web/src/components/AuthShell.tsx
+++ b/apps/web/src/components/AuthShell.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { ThemeToggleButton } from "@/components/ThemeToggleButton";
 import { LocaleSwitcher } from "@/components/LocaleSwitcher";
+import { SkipToContentLink } from "@/components/SkipToContentLink";
 import { ThemedImage } from "@/components/ThemedImage";
 import { useLocalePath } from "@/lib/useLocalePath";
 import type { ReactNode } from "react";
@@ -11,31 +12,34 @@ export function AuthShell({ children }: { children: ReactNode }) {
   const lp = useLocalePath();
 
   return (
-    <main
-      id="main-content"
-      tabIndex={-1}
-      className="mx-auto w-full max-w-lg px-4 scroll-mt-12 sm:w-fit sm:min-w-[24rem]"
-    >
-      <div className="flex min-h-screen flex-col items-center justify-center py-8">
-        <Link href={lp("/explore")} prefetch={false} className="mb-6 block h-9 w-36">
-          <ThemedImage
-            lightSrc="/js_wide_logo_black.svg"
-            darkSrc="/js_wide_logo_white.svg"
-            alt="Job Seek"
-            width={144}
-            height={36}
-            loading="eager"
-            fetchPriority="high"
-          />
-        </Link>
-        <div className="w-full rounded-lg border border-border-soft bg-surface p-6 sm:p-8">
-          {children}
+    <>
+      <SkipToContentLink />
+      <main
+        id="main-content"
+        tabIndex={-1}
+        className="mx-auto w-full max-w-lg px-4 scroll-mt-12 sm:w-fit sm:min-w-[24rem]"
+      >
+        <div className="flex min-h-screen flex-col items-center justify-center py-8">
+          <Link href={lp("/explore")} prefetch={false} className="mb-6 block h-9 w-36">
+            <ThemedImage
+              lightSrc="/js_wide_logo_black.svg"
+              darkSrc="/js_wide_logo_white.svg"
+              alt="Job Seek"
+              width={144}
+              height={36}
+              loading="eager"
+              fetchPriority="high"
+            />
+          </Link>
+          <div className="w-full rounded-lg border border-border-soft bg-surface p-6 sm:p-8">
+            {children}
+          </div>
+          <div className="mt-4 flex gap-1">
+            <ThemeToggleButton />
+            <LocaleSwitcher />
+          </div>
         </div>
-        <div className="mt-4 flex gap-1">
-          <ThemeToggleButton />
-          <LocaleSwitcher />
-        </div>
-      </div>
-    </main>
+      </main>
+    </>
   );
 }

--- a/apps/web/src/components/SkipToContentLink.tsx
+++ b/apps/web/src/components/SkipToContentLink.tsx
@@ -1,15 +1,96 @@
 "use client";
 
 import { Trans } from "@lingui/react/macro";
-import type { MouseEvent } from "react";
+import { type MouseEvent, useEffect } from "react";
 
 const SKIP_LINK_CLASS =
   "fixed top-2 left-2 z-[100] -translate-y-16 rounded-md bg-primary px-4 py-2 text-sm font-semibold text-primary-contrast focus:translate-y-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary";
+const MAIN_CONTENT_ID = "main-content";
+const MAIN_CONTENT_CANDIDATE_ATTRIBUTE = "data-main-content-candidate";
+const MAIN_CONTENT_CANDIDATE_SELECTOR =
+  `#${MAIN_CONTENT_ID},[${MAIN_CONTENT_CANDIDATE_ATTRIBUTE}]`;
+
+function isAccessibilityHidden(candidate: HTMLElement) {
+  let current: Element | null = candidate;
+
+  while (current) {
+    if (
+      current.hasAttribute("hidden") ||
+      current.hasAttribute("inert") ||
+      current.getAttribute("aria-hidden")?.toLowerCase() === "true"
+    ) {
+      return true;
+    }
+    current = current.parentElement;
+  }
+
+  return false;
+}
+
+function reconcileMainContentTarget() {
+  const candidates = Array.from(
+    document.querySelectorAll<HTMLElement>(MAIN_CONTENT_CANDIDATE_SELECTOR),
+  );
+
+  // Remember every copy independently of the canonical id. If Next later
+  // promotes a hidden PPR tree, React may not restore an id removed outside
+  // its render cycle because the JSX prop itself did not change.
+  for (const candidate of candidates) {
+    candidate.setAttribute(MAIN_CONTENT_CANDIDATE_ATTRIBUTE, "");
+  }
+
+  const target = candidates.find(
+    (candidate) =>
+      !isAccessibilityHidden(candidate) &&
+      candidate.getClientRects().length > 0,
+  );
+
+  if (!target) return null;
+
+  // A streamed Next.js route can retain its prerendered copy inside a hidden
+  // Suspense container after the visible copy has hydrated. React renders the
+  // same fragment id into both copies, so native `#main-content` lookup would
+  // otherwise resolve the hidden one. Keep the visible landmark authoritative
+  // without removing the fallback before a rendered target exists.
+  for (const candidate of candidates) {
+    if (candidate === target) {
+      if (candidate.id !== MAIN_CONTENT_ID) candidate.id = MAIN_CONTENT_ID;
+    } else if (candidate.id === MAIN_CONTENT_ID) {
+      candidate.removeAttribute("id");
+    }
+  }
+
+  return target;
+}
+
+function containsMainContentTarget(node: Node) {
+  return (
+    node instanceof Element &&
+    (node.matches(MAIN_CONTENT_CANDIDATE_SELECTOR) ||
+      node.querySelector(MAIN_CONTENT_CANDIDATE_SELECTOR) !== null)
+  );
+}
+
+function mainContentTargetMayHaveChanged(mutations: MutationRecord[]) {
+  return mutations.some((mutation) => {
+    if (mutation.type === "attributes") {
+      if (!(mutation.target instanceof Element)) return false;
+
+      if (mutation.attributeName === "id") {
+        return mutation.target.matches(MAIN_CONTENT_CANDIDATE_SELECTOR);
+      }
+
+      return containsMainContentTarget(mutation.target);
+    }
+
+    return [...mutation.addedNodes, ...mutation.removedNodes].some(
+      containsMainContentTarget,
+    );
+  });
+}
 
 function focusVisibleMain(event: MouseEvent<HTMLAnchorElement>) {
-  const target = Array.from(
-    document.querySelectorAll<HTMLElement>("#main-content"),
-  ).find((candidate) => candidate.getClientRects().length > 0);
+  const target = reconcileMainContentTarget();
 
   // Keep the native fragment fallback when the streamed page has not exposed
   // a visible target yet. Once hydrated, select the rendered copy explicitly:
@@ -23,7 +104,7 @@ function focusVisibleMain(event: MouseEvent<HTMLAnchorElement>) {
   target.scrollIntoView({ block: "start" });
 
   const url = new URL(window.location.href);
-  url.hash = "main-content";
+  url.hash = MAIN_CONTENT_ID;
   if (window.location.hash === url.hash) {
     window.history.replaceState(null, "", url);
   } else {
@@ -32,6 +113,31 @@ function focusVisibleMain(event: MouseEvent<HTMLAnchorElement>) {
 }
 
 export function SkipToContentLink() {
+  useEffect(() => {
+    reconcileMainContentTarget();
+
+    // Public/app layouts persist across client navigation while Next streams
+    // replacement route segments underneath them. Reconcile additions and
+    // hidden-state transitions so a later route cannot reintroduce a hidden
+    // duplicate fragment target.
+    const observer = new MutationObserver((mutations) => {
+      // Search results and other dynamic app surfaces mutate frequently. Only
+      // run the geometry check when a mutation can actually affect the skip
+      // target instead of forcing layout for every subtree update.
+      if (mainContentTargetMayHaveChanged(mutations)) {
+        reconcileMainContentTarget();
+      }
+    });
+    observer.observe(document.body, {
+      attributes: true,
+      attributeFilter: ["aria-hidden", "hidden", "id", "inert"],
+      childList: true,
+      subtree: true,
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <a
       href="#main-content"

--- a/apps/web/src/components/__tests__/SkipToContentLink.test.tsx
+++ b/apps/web/src/components/__tests__/SkipToContentLink.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -8,6 +8,10 @@ import { SkipToContentLink } from "../SkipToContentLink";
 
 function visibleClientRects(): DOMRectList {
   return { length: 1 } as DOMRectList;
+}
+
+function hiddenClientRects(): DOMRectList {
+  return { length: 0 } as DOMRectList;
 }
 
 describe("SkipToContentLink", () => {
@@ -28,7 +32,9 @@ describe("SkipToContentLink", () => {
     render(
       <>
         <SkipToContentLink />
-        <div id="main-content" data-testid="hidden-main" tabIndex={-1} />
+        <div hidden>
+          <main id="main-content" data-testid="hidden-main" tabIndex={-1} />
+        </div>
         <main id="main-content" data-testid="visible-main">
           <button type="button">First main action</button>
         </main>
@@ -44,6 +50,12 @@ describe("SkipToContentLink", () => {
       value: scrollIntoView,
     });
 
+    await waitFor(() => {
+      expect(document.querySelectorAll("#main-content")).toHaveLength(1);
+    });
+    expect(hiddenTarget.getAttribute("id")).toBeNull();
+    expect(document.querySelector("#main-content")).toBe(visibleTarget);
+
     fireEvent.click(screen.getByRole("link", { name: "Skip to content" }));
 
     expect(document.activeElement).toBe(visibleTarget);
@@ -55,5 +67,169 @@ describe("SkipToContentLink", () => {
     expect(document.activeElement).toBe(
       screen.getByRole("button", { name: "First main action" }),
     );
+  });
+
+  it("reconciles a hidden duplicate streamed after hydration", async () => {
+    render(
+      <>
+        <SkipToContentLink />
+        <main id="main-content" data-testid="visible-main" />
+      </>,
+    );
+
+    const visibleTarget = screen.getByTestId("visible-main");
+    vi.spyOn(visibleTarget, "getClientRects").mockImplementation(visibleClientRects);
+
+    const streamedFallback = document.createElement("div");
+    streamedFallback.hidden = true;
+    streamedFallback.innerHTML = '<main id="main-content">Fallback</main>';
+    document.body.append(streamedFallback);
+
+    await waitFor(() => {
+      expect(document.querySelectorAll("#main-content")).toHaveLength(1);
+    });
+    expect(document.querySelector("#main-content")).toBe(visibleTarget);
+    streamedFallback.remove();
+  });
+
+  it("moves the canonical id when Next promotes the hidden PPR tree", async () => {
+    render(
+      <>
+        <SkipToContentLink />
+        <div data-testid="staged-container" hidden>
+          <main id="main-content" data-testid="staged-main" />
+        </div>
+        <div data-testid="current-container">
+          <main id="main-content" data-testid="current-main" />
+        </div>
+      </>,
+    );
+
+    const stagedContainer = screen.getByTestId("staged-container");
+    const currentContainer = screen.getByTestId("current-container");
+    const stagedTarget = screen.getByTestId("staged-main");
+    const currentTarget = screen.getByTestId("current-main");
+    vi.spyOn(stagedTarget, "getClientRects").mockImplementation(() =>
+      stagedContainer.hidden ? hiddenClientRects() : visibleClientRects(),
+    );
+    vi.spyOn(currentTarget, "getClientRects").mockImplementation(() =>
+      currentContainer.hidden ? hiddenClientRects() : visibleClientRects(),
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector("#main-content")).toBe(currentTarget);
+    });
+    expect(stagedTarget.getAttribute("id")).toBeNull();
+
+    currentContainer.hidden = true;
+    stagedContainer.hidden = false;
+
+    await waitFor(() => {
+      expect(document.querySelectorAll("#main-content")).toHaveLength(1);
+      expect(document.querySelector("#main-content")).toBe(stagedTarget);
+    });
+    expect(currentTarget.getAttribute("id")).toBeNull();
+  });
+
+  it.each(["aria-hidden", "inert"] as const)(
+    "moves the canonical id when Next promotes a tree hidden by %s",
+    async (hiddenAttribute) => {
+      render(
+        <>
+          <SkipToContentLink />
+          <div
+            data-testid="staged-container"
+            aria-hidden={hiddenAttribute === "aria-hidden" ? "true" : undefined}
+            inert={hiddenAttribute === "inert" ? true : undefined}
+          >
+            <main id="main-content" data-testid="staged-main" />
+          </div>
+          <div data-testid="current-container">
+            <main id="main-content" data-testid="current-main" />
+          </div>
+        </>,
+      );
+
+      const stagedContainer = screen.getByTestId("staged-container");
+      const currentContainer = screen.getByTestId("current-container");
+      const stagedTarget = screen.getByTestId("staged-main");
+      const currentTarget = screen.getByTestId("current-main");
+      vi.spyOn(stagedTarget, "getClientRects").mockImplementation(
+        visibleClientRects,
+      );
+      vi.spyOn(currentTarget, "getClientRects").mockImplementation(
+        visibleClientRects,
+      );
+
+      await waitFor(() => {
+        expect(document.querySelector("#main-content")).toBe(currentTarget);
+      });
+      expect(stagedTarget.getAttribute("id")).toBeNull();
+
+      currentContainer.setAttribute(hiddenAttribute, "true");
+      stagedContainer.removeAttribute(hiddenAttribute);
+
+      await waitFor(() => {
+        expect(document.querySelectorAll("#main-content")).toHaveLength(1);
+        expect(document.querySelector("#main-content")).toBe(stagedTarget);
+      });
+      expect(currentTarget.getAttribute("id")).toBeNull();
+    },
+  );
+
+  it("reassigns the canonical id when the selected tree is removed", async () => {
+    render(<SkipToContentLink />);
+
+    const currentContainer = document.createElement("div");
+    const currentTarget = document.createElement("main");
+    const remainingTarget = document.createElement("main");
+    currentTarget.id = "main-content";
+    remainingTarget.id = "main-content";
+    currentContainer.append(currentTarget);
+    vi.spyOn(currentTarget, "getClientRects").mockImplementation(
+      visibleClientRects,
+    );
+    vi.spyOn(remainingTarget, "getClientRects").mockImplementation(
+      visibleClientRects,
+    );
+    document.body.append(currentContainer, remainingTarget);
+
+    await waitFor(() => {
+      expect(document.querySelector("#main-content")).toBe(currentTarget);
+    });
+
+    currentContainer.remove();
+
+    await waitFor(() => {
+      expect(document.querySelectorAll("#main-content")).toHaveLength(1);
+      expect(document.querySelector("#main-content")).toBe(remainingTarget);
+    });
+    remainingTarget.remove();
+  });
+
+  it("does not remeasure the main target for unrelated subtree updates", async () => {
+    render(
+      <>
+        <SkipToContentLink />
+        <main id="main-content" data-testid="visible-main" />
+      </>,
+    );
+
+    const visibleTarget = screen.getByTestId("visible-main");
+    const getClientRects = vi
+      .spyOn(visibleTarget, "getClientRects")
+      .mockImplementation(visibleClientRects);
+    visibleTarget.setAttribute("id", "main-content");
+
+    await waitFor(() => expect(getClientRects).toHaveBeenCalled());
+    getClientRects.mockClear();
+
+    const unrelated = document.createElement("div");
+    unrelated.textContent = "Unrelated search result";
+    document.body.append(unrelated);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(getClientRects).not.toHaveBeenCalled();
+    unrelated.remove();
   });
 });


### PR DESCRIPTION
## Summary

- reconcile streamed PPR copies so only the visible, accessibility-exposed main landmark retains `#main-content`
- preserve candidate identity across hidden-tree promotion, removal, `aria-hidden`, and `inert` transitions
- run reconciliation at hydration and only on target-relevant streamed DOM changes
- mount exactly one shared skip link in anonymous auth shells, including direct verify/reset routes
- add regressions for fallback insertion, PPR promotion/removal, accessibility-hidden trees, unrelated DOM churn, and all six auth route outlines

## Verification

- focused Vitest: 3 files, 18 tests
- changed-file ESLint
- TypeScript (`tsc --noEmit`)
- production Next build: 183 routes
- `git diff --check`

## Post-deploy acceptance

On `/en` and the six anonymous auth entry routes after hydration, verify one accessible main/H1/skip link, exactly one `#main-content` element, and that activating the skip link focuses the visible main landmark.

Addresses #6642