### PR TITLE
Stabilize production Server Action keys

### DIFF
--- a/.github/scripts/classify-vercel-web-change.mjs
+++ b/.github/scripts/classify-vercel-web-change.mjs
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 
 const EXACT_WEB_INPUTS = new Set([
   ".github/scripts/classify-vercel-web-change.mjs",
+  ".github/scripts/verify-vercel-server-action-key.mjs",
   ".github/scripts/verify-vercel-promotion.mjs",
   ".github/workflows/deploy-web-production.yml",
   "package.json",

--- a/.github/scripts/verify-vercel-server-action-key.mjs
+++ b/.github/scripts/verify-vercel-server-action-key.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+export const SERVER_ACTION_KEY_NAME = "NEXT_SERVER_ACTIONS_ENCRYPTION_KEY";
+
+export function verifyServerActionKey(value) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(
+      `Production must define ${SERVER_ACTION_KEY_NAME} before building.`,
+    );
+  }
+
+  const decoded = Buffer.from(value, "base64");
+  const isCanonicalBase64 = /^[A-Za-z0-9+/]{43}=$/.test(value) &&
+    decoded.toString("base64") === value;
+
+  if (!isCanonicalBase64 || decoded.byteLength !== 32) {
+    throw new Error(
+      `${SERVER_ACTION_KEY_NAME} must be canonical base64 encoding exactly 32 bytes.`,
+    );
+  }
+}
+
+export function verifyServerActionEnvironment(environment) {
+  verifyServerActionKey(environment[SERVER_ACTION_KEY_NAME]);
+}
+
+function main() {
+  verifyServerActionEnvironment(process.env);
+  process.stdout.write("Stable production Server Action encryption is configured.\n");
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
           scripts/docs-index.test.mjs
           scripts/dealroom-company-requests.test.mjs
           scripts/vercel-web-deploy-paths.test.mjs
+          scripts/vercel-server-action-key.test.mjs
           scripts/vercel-production-sha.test.mjs
           scripts/vercel-promotion-identity.test.mjs
 

--- a/.github/workflows/deploy-web-production.yml
+++ b/.github/workflows/deploy-web-production.yml
@@ -75,8 +75,16 @@ jobs:
           --environment=production
           --token="$VERCEL_TOKEN"
 
+      - name: Require stable Server Action encryption
+        if: steps.paths.outputs.deploy == 'true'
+        env:
+          NEXT_SERVER_ACTIONS_ENCRYPTION_KEY: ${{ secrets.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY }}
+        run: node .github/scripts/verify-vercel-server-action-key.mjs
+
       - name: Build the production artifact
         if: steps.paths.outputs.deploy == 'true'
+        env:
+          NEXT_SERVER_ACTIONS_ENCRYPTION_KEY: ${{ secrets.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY }}
         run: >-
           pnpm dlx vercel@55.0.0 build
           --prod

--- a/docs/18-vercel-fluid-cpu.md
+++ b/docs/18-vercel-fluid-cpu.md
@@ -24,6 +24,27 @@ external-call, error, and functionality gates.
 The release target is at least a 50% reduction in visible Active CPU: no more
 than 138.5 seconds in a comparable 12-hour window.
 
+## Stable Server Action deployments
+
+Production must define `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` as the canonical
+base64 encoding of exactly 32 random bytes. Without a persistent key, a new
+Next.js build can rotate the encrypted Server Action metadata. Clients or
+automation retaining an older action ID then invoke Fluid only to receive a
+`Failed to find Server Action` response.
+
+Vercel Sensitive values are intentionally absent from the environment file
+downloaded by a prebuilt CI deployment. Store the same value in both the Vercel
+Production environment as Sensitive and the GitHub `Production` environment as
+an Actions secret. The production workflow injects the GitHub secret only into
+the validation and `vercel build --prod` steps. The check reports only validity
+and never prints the value.
+
+Generate a replacement only during an intentional incident rotation, and
+update both secret stores together; an ordinary deployment must keep the
+existing value. After a deliberate rotation, treat old-action traffic as
+deployment skew, mitigate confirmed obsolete IDs before Functions, and restart
+the 12-hour measurement window.
+
 ## Measurement protocol
 
 1. Record the production deployment SHA and its Vercel `Ready` timestamp.

--- a/scripts/vercel-server-action-key.test.mjs
+++ b/scripts/vercel-server-action-key.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  SERVER_ACTION_KEY_NAME,
+  verifyServerActionEnvironment,
+  verifyServerActionKey,
+} from "../.github/scripts/verify-vercel-server-action-key.mjs";
+
+const validKey = Buffer.alloc(32, 0x5a).toString("base64");
+
+test("accepts a canonical base64 32-byte Server Action key", () => {
+  assert.doesNotThrow(() => verifyServerActionKey(validKey));
+  assert.doesNotThrow(() => verifyServerActionEnvironment({
+    [SERVER_ACTION_KEY_NAME]: validKey,
+  }));
+});
+
+test("rejects an absent Server Action key", () => {
+  assert.throws(
+    () => verifyServerActionEnvironment({ OTHER_SETTING: "present" }),
+    new RegExp(`must define ${SERVER_ACTION_KEY_NAME}`),
+  );
+});
+
+test("rejects non-32-byte and non-canonical values without echoing them", () => {
+  for (const invalidKey of [
+    Buffer.alloc(16, 0x41).toString("base64"),
+    Buffer.alloc(24, 0x42).toString("base64"),
+    Buffer.alloc(33, 0x43).toString("base64"),
+    `${validKey} `,
+    "not-base64",
+  ]) {
+    assert.throws(
+      () => verifyServerActionKey(invalidKey),
+      (error) => {
+        assert.match(error.message, /canonical base64 encoding exactly 32 bytes/);
+        assert.doesNotMatch(error.message, new RegExp(invalidKey));
+        return true;
+      },
+    );
+  }
+});
+
+test("rejects a malformed injected key without exposing its content", () => {
+  const malformed = '"unterminated';
+  assert.throws(
+    () => verifyServerActionEnvironment({
+      [SERVER_ACTION_KEY_NAME]: malformed,
+    }),
+    (error) => {
+      assert.match(
+        error.message,
+        /canonical base64 encoding exactly 32 bytes/,
+      );
+      assert.doesNotMatch(error.message, /unterminated/);
+      return true;
+    },
+  );
+});

--- a/scripts/vercel-web-deploy-paths.test.mjs
+++ b/scripts/vercel-web-deploy-paths.test.mjs
@@ -18,6 +18,7 @@ test("deploys web runtime and every current workspace input", () => {
     "turbo.json",
     ".github/workflows/deploy-web-production.yml",
     ".github/scripts/classify-vercel-web-change.mjs",
+    ".github/scripts/verify-vercel-server-action-key.mjs",
     ".github/scripts/verify-vercel-promotion.mjs",
   ]) {
     assert.equal(isVercelWebInput(path), true, path);
@@ -88,6 +89,10 @@ test("production workflow stages, verifies, then promotes exact main", () => {
   assert.doesNotMatch(workflow, /--cwd=apps\/web/);
   assert.doesNotMatch(workflow, /--git-branch/);
   assert.match(workflow, /environment: Production/);
+  assert.match(
+    workflow,
+    /vercel@55\.0\.0 pull[\s\S]{0,400}verify-vercel-server-action-key\.mjs[\s\S]{0,400}vercel@55\.0\.0 build/,
+  );
   assert.doesNotMatch(workflow, /environment:\n\s+name: Production\n\s+url:/);
   assert.doesNotMatch(workflow, /pull_request:/);
 });


### PR DESCRIPTION
## Summary

- require one persistent 32-byte base64 `NEXT_SERVER_ACTIONS_ENCRYPTION_KEY` for production prebuilt deployments
- inject the protected GitHub Production environment secret only into the validation and build steps
- fail before `vercel build --prod` if the key is missing or malformed, without printing its value
- classify the guard as a web deployment input and document synchronized Vercel/GitHub secret rotation

## Why

Production is receiving a sustained replay of obsolete `POST /en/explore` Server Actions. Deployment `dpl_3kuxDcQ5gDMJh5LRdkEKVa5t6EeV` logs at least 100 failures in 29.5 seconds for unknown action `7ffac6a500b0410a78dcf5f6a75ea0d2253b635222`. Each rejected request still reaches a Function and consumes Fluid CPU.

The project had no persistent Server Action encryption key, so separate Next.js builds could rotate action metadata. Vercel Skew Protection is unavailable on the project's Hobby plan. A synchronized key is now configured in the Vercel Production environment (Sensitive) and the GitHub `Production` environment (Actions secret); this PR makes the prebuilt deployment use and enforce it.

The exact obsolete ID still needs the staged firewall log-to-deny rollout tracked in #7189. This change prevents subsequent builds from creating new version-skew action IDs.

## Validation

- `node --test` across all 10 workflow/security test files: 98 passed
- direct valid-key CLI invocation: passed
- `git diff --check`: passed
- zizmor 1.26.1: no findings (61 ignored, 94 suppressed)
- actionlint will run in CI's provisioned Go environment; Go is not installed locally

Part of #7189
Part of #6616
