### PR TITLE
Reject obsolete Explore action at proxy

### DIFF
--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -17,6 +17,9 @@ const COOKIE_NAME = "NEXT_LOCALE";
 const LOGGED_IN_HINT_COOKIE = "logged_in";
 const COMPANY_REQUEST_PATH = /^\/(en|de|fr|it)\/companies\/request$/;
 const LOCALIZED_EXPLORE_PATH = /^\/(?:en|de|fr|it)\/explore$/;
+const OBSOLETE_EXPLORE_ACTION_IDS = new Set([
+  "7ffac6a500b0410a78dcf5f6a75ea0d2253b635222",
+]);
 const LOCALIZED_COMPANY_PATH = /^\/(en|de|fr|it)\/company\/([^/]+)$/;
 const LOCALIZED_WATCHLIST_PATH =
   /^\/(en|de|fr|it)\/([^/]+)\/([^/]+)$/;
@@ -150,6 +153,29 @@ async function resolveLocalizedResourceRequest(
 }
 
 export async function proxy(request: NextRequest): Promise<NextResponse> {
+  // A sustained client is replaying this action ID after its deployment was
+  // retired. Next rejects it as unknown, but only after invoking the full page
+  // Function. Keep this exact deployment-skew signature at the lightweight
+  // proxy boundary as defense in depth behind the zero-Function WAF rule.
+  // Current and future action IDs intentionally continue straight to Next.
+  if (
+    request.method === "POST" &&
+    LOCALIZED_EXPLORE_PATH.test(request.nextUrl.pathname) &&
+    OBSOLETE_EXPLORE_ACTION_IDS.has(
+      request.headers.get("next-action") ?? "",
+    )
+  ) {
+    return new NextResponse("Not Found", {
+      status: 404,
+      headers: {
+        "Cache-Control": "private, no-store",
+        "Content-Type": "text/plain; charset=utf-8",
+        "X-Content-Type-Options": "nosniff",
+        "X-Robots-Tag": "noindex",
+      },
+    });
+  }
+
   // Stop common exploit-probe shapes at the network boundary. Without this,
   // Cache Components can stream the public-watchlist PPR shell with HTTP 200
   // before the route-level notFound() guard runs, consuming a Fluid function
@@ -272,6 +298,16 @@ export const config = {
     "/:lang(en|de|fr|it)/companies/request",
     "/:lang(en|de|fr|it)/company/:slug",
     "/:lang(en|de|fr|it)/:userSlug/:watchlistSlug",
+    {
+      source: "/:lang(en|de|fr|it)/explore",
+      has: [
+        {
+          type: "header",
+          key: "next-action",
+          value: "7ffac6a500b0410a78dcf5f6a75ea0d2253b635222",
+        },
+      ],
+    },
     {
       source: "/:lang(en|de|fr|it)/explore",
       has: [

--- a/apps/web/src/lib/__tests__/proxy.test.ts
+++ b/apps/web/src/lib/__tests__/proxy.test.ts
@@ -460,6 +460,8 @@ describe("missing-resource HTTP boundary", () => {
 });
 
 describe("Explore PPR shell normalization", () => {
+  const obsoleteActionId = "7ffac6a500b0410a78dcf5f6a75ea0d2253b635222";
+
   it("rewrites query-bearing HTML documents to the locale shell", async () => {
     const request = new NextRequest(
       "http://localhost/en/explore?q=python&wm=remote",
@@ -508,6 +510,26 @@ describe("Explore PPR shell normalization", () => {
     expect(response.headers.get("x-middleware-rewrite")).toBeNull();
     expect(response.headers.get("x-middleware-next")).toBe("1");
   });
+
+  it.each(["en", "de", "fr", "it"])(
+    "rejects the confirmed obsolete %s Explore action before the page Function",
+    async (locale) => {
+      const response = await proxy(
+        new NextRequest(`http://localhost/${locale}/explore?q=python`, {
+          method: "POST",
+          headers: {
+            accept: "text/x-component",
+            "next-action": obsoleteActionId,
+          },
+        }),
+      );
+
+      expect(response.status).toBe(404);
+      await expect(response.text()).resolves.toBe("Not Found");
+      expect(response.headers.get("cache-control")).toBe("private, no-store");
+      expect(response.headers.get("x-middleware-next")).toBeNull();
+    },
+  );
 });
 
 describe("scanner path boundary", () => {
@@ -550,7 +572,7 @@ describe("proxy config", () => {
     ).toBe(true);
   });
 
-  it("excludes Explore RSC and Server Action traffic before proxy compute", () => {
+  it("excludes Explore RSC and current Server Action traffic before proxy compute", () => {
     expect(
       unstable_doesMiddlewareMatch({
         config,
@@ -571,6 +593,23 @@ describe("proxy config", () => {
       }),
     ).toBe(false);
   });
+
+  it.each(["en", "de", "fr", "it"])(
+    "matches only the confirmed obsolete %s Explore action at the proxy boundary",
+    (locale) => {
+      expect(
+        unstable_doesMiddlewareMatch({
+          config,
+          nextConfig: {},
+          url: `/${locale}/explore?q=python`,
+          headers: {
+            accept: "text/x-component",
+            "next-action": "7ffac6a500b0410a78dcf5f6a75ea0d2253b635222",
+          },
+        }),
+      ).toBe(true);
+    },
+  );
 
   it.each([
     "/en/wp-admin/install.php",


### PR DESCRIPTION
## Summary

- match only the confirmed obsolete Explore `Next-Action` ID at the existing localized proxy boundary
- return the same 404 semantics before the full Next.js page/action Function runs
- keep all current and future Server Action IDs excluded from proxy compute
- cover exact matching and all four locales with proxy behavior/config tests

## Production evidence

After the persistent-key deployment `dpl_8PRdmJcvws1yy8X419sQ8Z815qc7` reached production, runtime logs contained 478 failures for the same obsolete action in 48.8 seconds (about 9.8/second):

`7ffac6a500b0410a78dcf5f6a75ea0d2253b635222`

The new deployment still correctly reports that ID as unknown. This fail-safe prevents the replay from reaching the heavier page Function while the exact Vercel WAF rule goes through its required log-first publish/review/deny sequence.

Routing Middleware is itself Fluid Compute, so the WAF remains the final zero-Function mitigation. This PR is defense in depth, not a replacement for firewall enforcement.

## Functionality boundary

- only `POST /{en,de,fr,it}/explore` with the exact known-invalid ID is rejected
- normal Server Actions, RSC navigation, document loads, deep links, and browser-direct Typesense remain unchanged
- response remains HTTP 404 with private/no-store semantics

## Validation

- targeted proxy suite: 74 passed
- web ESLint: passed
- web typecheck / Next route typegen: passed
- pre-commit web lint and translation coverage: passed
- `git diff --check`: passed

Part of #7189
Part of #6616
