### PR TITLE
Fix public search range validation

### DIFF
--- a/apps/web/app/api/v1/_shared.test.ts
+++ b/apps/web/app/api/v1/_shared.test.ts
@@ -108,6 +108,13 @@ describe("checkRateLimit — Redis bypass observability (#3175)", () => {
     // Blocked requests return a NextResponse with status 429.
     expect(result).not.toBeNull();
     expect(result && "status" in result && result.status).toBe(429);
+    if (result && "headers" in result) {
+      expect(result.headers.get("Cache-Control")).toBe("no-store");
+      expect(result.headers.get("Access-Control-Allow-Origin")).toBe("*");
+      expect(result.headers.get("Access-Control-Allow-Methods")).toBe("GET");
+      expect(result.headers.get("X-RateLimit-Limit")).toBe("60");
+      expect(result.headers.get("X-RateLimit-Remaining")).toBe("0");
+    }
   });
 });
 

--- a/apps/web/app/api/v1/_shared.ts
+++ b/apps/web/app/api/v1/_shared.ts
@@ -26,6 +26,8 @@ export async function checkRateLimit(
             "X-RateLimit-Remaining": "0",
             "X-RateLimit-Reset": String(reset),
             "Cache-Control": "no-store",
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "GET",
           },
         },
       );

--- a/apps/web/app/api/v1/search/route.test.ts
+++ b/apps/web/app/api/v1/search/route.test.ts
@@ -82,6 +82,10 @@ describe("GET /api/v1/search", () => {
     const call = mocks.listTopCompanies.mock.calls[0][0];
     expect(call.languages).toEqual([]);
     expect(call.locale).toBe("en");
+    expect(call.salaryMinEur).toBeUndefined();
+    expect(call.salaryMaxEur).toBeUndefined();
+    expect(call.experienceMin).toBeUndefined();
+    expect(call.experienceMax).toBeUndefined();
   });
 
   it("passes a single-value `lang=de` through as `languages: ['de']`", async () => {
@@ -135,12 +139,12 @@ describe("GET /api/v1/search", () => {
     {
       caseName: "malformed salary range",
       query: "?locale=en&sal=abc-def",
-      error: "Invalid 'sal' param: bounds must be positive integers",
+      error: "Invalid 'sal' param: bounds must be non-negative integers",
     },
     {
       caseName: "malformed experience range",
       query: "?locale=en&exp=3-nope",
-      error: "Invalid 'exp' param: bounds must be positive integers",
+      error: "Invalid 'exp' param: bounds must be non-negative integers",
     },
     {
       caseName: "reversed salary range",
@@ -150,7 +154,47 @@ describe("GET /api/v1/search", () => {
     {
       caseName: "unsafe integer bound",
       query: "?locale=en&exp=9007199254740992-",
-      error: "Invalid 'exp' param: bounds must be positive integers",
+      error: "Invalid 'exp' param: bounds must be non-negative integers",
+    },
+    {
+      caseName: "empty salary range",
+      query: "?locale=en&sal=",
+      error: "Invalid 'sal' param: expected min-max",
+    },
+    {
+      caseName: "salary range without either bound",
+      query: "?locale=en&sal=-",
+      error: "Invalid 'sal' param: at least one bound is required",
+    },
+    {
+      caseName: "salary range without a separator",
+      query: "?locale=en&sal=100000",
+      error: "Invalid 'sal' param: expected min-max",
+    },
+    {
+      caseName: "negative salary bound",
+      query: "?locale=en&sal=-1-100000",
+      error: "Invalid 'sal' param: expected min-max",
+    },
+    {
+      caseName: "empty experience range",
+      query: "?locale=en&exp=",
+      error: "Invalid 'exp' param: expected min-max",
+    },
+    {
+      caseName: "experience range without either bound",
+      query: "?locale=en&exp=-",
+      error: "Invalid 'exp' param: at least one bound is required",
+    },
+    {
+      caseName: "experience range without a separator",
+      query: "?locale=en&exp=3",
+      error: "Invalid 'exp' param: expected min-max",
+    },
+    {
+      caseName: "negative experience bound",
+      query: "?locale=en&exp=-1-5",
+      error: "Invalid 'exp' param: expected min-max",
     },
   ])("returns the documented 400 contract for $caseName", async ({ query, error }) => {
     const { res, body } = await callRoute(query);
@@ -162,6 +206,28 @@ describe("GET /api/v1/search", () => {
     expect(mocks.parseSearchFilters).not.toHaveBeenCalled();
     expect(mocks.listTopCompanies).not.toHaveBeenCalled();
     expect(mocks.searchJobs).not.toHaveBeenCalled();
+  });
+
+  it("preserves successful rate-limit metadata on validation errors", async () => {
+    const reset = Date.now() + 30_000;
+    mocks.apiLimit.mockResolvedValueOnce({
+      success: true,
+      limit: 30,
+      remaining: 29,
+      reset,
+    });
+
+    const { res, body } = await callRoute("?locale=en&sal=-");
+
+    expect(res.status).toBe(400);
+    expect(body).toEqual({
+      error: "Invalid 'sal' param: at least one bound is required",
+    });
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("30");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("29");
+    expect(res.headers.get("X-RateLimit-Reset")).toBe(String(reset));
   });
 
   it("uses the `searchJobs` path when `q=` is set, still forwarding `languages`", async () => {
@@ -194,14 +260,48 @@ describe("GET /api/v1/search", () => {
     expect(url.searchParams.get("q")).toBe("engineer");
   });
 
-  it("forwards valid `sal=` and `exp=` ranges as numbers", async () => {
-    await callRoute("?locale=en&sal=90000-140000&exp=3-7");
-    const call = mocks.listTopCompanies.mock.calls[0][0];
-    expect(call.salaryMinEur).toBe(90000);
-    expect(call.salaryMaxEur).toBe(140000);
-    expect(call.experienceMin).toBe(3);
-    expect(call.experienceMax).toBe(7);
-  });
+  it.each([
+    {
+      caseName: "closed ranges",
+      query: "?locale=en&sal=90000-140000&exp=3-7",
+      salaryMinEur: 90000,
+      salaryMaxEur: 140000,
+      experienceMin: 3,
+      experienceMax: 7,
+    },
+    {
+      caseName: "minimum-only open ranges",
+      query: "?locale=en&sal=90000-&exp=3-",
+      salaryMinEur: 90000,
+      salaryMaxEur: undefined,
+      experienceMin: 3,
+      experienceMax: undefined,
+    },
+    {
+      caseName: "maximum-only open ranges",
+      query: "?locale=en&sal=-140000&exp=-7",
+      salaryMinEur: undefined,
+      salaryMaxEur: 140000,
+      experienceMin: undefined,
+      experienceMax: 7,
+    },
+  ])(
+    "forwards valid $caseName as numbers",
+    async ({
+      query,
+      salaryMinEur,
+      salaryMaxEur,
+      experienceMin,
+      experienceMax,
+    }) => {
+      await callRoute(query);
+      const call = mocks.listTopCompanies.mock.calls[0][0];
+      expect(call.salaryMinEur).toBe(salaryMinEur);
+      expect(call.salaryMaxEur).toBe(salaryMaxEur);
+      expect(call.experienceMin).toBe(experienceMin);
+      expect(call.experienceMax).toBe(experienceMax);
+    },
+  );
 
   it("forwards `wm=remote` into `moreAt` (regression for lost work-mode param)", async () => {
     // The API already accepted `wm` and forwarded it to searchJobs, but
@@ -254,12 +354,23 @@ describe("GET /api/v1/search", () => {
     expect(res.status).toBe(429);
     expect(body).toEqual({ error: "Too many requests" });
     expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
     expect(res.headers.get("Retry-After")).not.toBeNull();
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("30");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("0");
+    expect(res.headers.get("X-RateLimit-Reset")).toBe(String(reset));
     expect(mocks.parseSearchFilters).not.toHaveBeenCalled();
     expect(mocks.listTopCompanies).not.toHaveBeenCalled();
   });
 
   it("returns a safe 500 body when the search provider fails", async () => {
+    const reset = Date.now() + 30_000;
+    mocks.apiLimit.mockResolvedValueOnce({
+      success: true,
+      limit: 30,
+      remaining: 28,
+      reset,
+    });
     const providerError = Object.assign(
       new Error("provider-internal-canary-do-not-expose"),
       { status: 503 },
@@ -272,6 +383,10 @@ describe("GET /api/v1/search", () => {
     expect(body).toEqual({ error: "Search service unavailable" });
     expect(JSON.stringify(body)).not.toContain("provider-internal-canary");
     expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("X-RateLimit-Limit")).toBe("30");
+    expect(res.headers.get("X-RateLimit-Remaining")).toBe("28");
+    expect(res.headers.get("X-RateLimit-Reset")).toBe(String(reset));
     expect(mocks.logExternalError).toHaveBeenCalledWith(
       "error",
       { service: "typesense", operation: "public_api_search" },

--- a/apps/web/app/api/v1/search/route.ts
+++ b/apps/web/app/api/v1/search/route.ts
@@ -9,13 +9,23 @@ import { searchJobs, listTopCompanies } from "@/lib/services/search";
 import { parseSearchFilters } from "@/lib/services/search-input";
 import { isLocale, locales } from "@/lib/i18n";
 import { logExternalError } from "@/lib/safe-external-error";
-import { checkRateLimit, apiResponse, siteUrl, exploreUrl } from "../_shared";
+import {
+  checkRateLimit,
+  apiResponse,
+  siteUrl,
+  exploreUrl,
+  type RateLimitInfo,
+} from "../_shared";
 
 const MAX_COMPANIES = 5;
 const MAX_POSTINGS_PER_COMPANY = 3;
 
-function searchErrorResponse(error: string, status: 400 | 500) {
-  const response = apiResponse({ error }, { maxAge: 0, status });
+function searchErrorResponse(
+  error: string,
+  status: 400 | 500,
+  rateLimit: RateLimitInfo | null,
+) {
+  const response = apiResponse({ error }, { maxAge: 0, rateLimit, status });
   // Search errors must never be stored by a browser or shared cache. This is
   // stricter than merely setting max-age=0 and keeps a transient provider
   // outage (or a malformed request) from becoming a cached API response.
@@ -79,10 +89,10 @@ function parseIntegerRangeParam(
   ok: false;
   error: string;
 } {
-  if (!raw) return { ok: true, min: undefined, max: undefined };
+  if (raw === undefined) return { ok: true, min: undefined, max: undefined };
 
   const parts = raw.split("-");
-  if (parts.length > 2) {
+  if (parts.length !== 2) {
     return { ok: false, error: `Invalid '${name}' param: expected min-max` };
   }
 
@@ -99,7 +109,14 @@ function parseIntegerRangeParam(
   if (Number.isNaN(min) || Number.isNaN(max)) {
     return {
       ok: false,
-      error: `Invalid '${name}' param: bounds must be positive integers`,
+      error: `Invalid '${name}' param: bounds must be non-negative integers`,
+    };
+  }
+
+  if (min === undefined && max === undefined) {
+    return {
+      ok: false,
+      error: `Invalid '${name}' param: at least one bound is required`,
     };
   }
 
@@ -133,12 +150,13 @@ export async function GET(request: NextRequest) {
     return searchErrorResponse(
       `Invalid 'locale' param. Supported: ${locales.join(", ")}`,
       400,
+      rl,
     );
   }
 
   const langParsed = parseLangParam(sp.get("lang"));
   if (!langParsed.ok) {
-    return searchErrorResponse(langParsed.error, 400);
+    return searchErrorResponse(langParsed.error, 400, rl);
   }
   // `searchJobs` / `listTopCompanies` treat `languages: []` as "no
   // filter" (see `apps/web/src/lib/search/typesense-filters.ts` —
@@ -147,12 +165,12 @@ export async function GET(request: NextRequest) {
 
   const salaryRange = parseIntegerRangeParam("sal", sal);
   if (!salaryRange.ok) {
-    return searchErrorResponse(salaryRange.error, 400);
+    return searchErrorResponse(salaryRange.error, 400, rl);
   }
 
   const experienceRange = parseIntegerRangeParam("exp", exp);
   if (!experienceRange.ok) {
-    return searchErrorResponse(experienceRange.error, 400);
+    return searchErrorResponse(experienceRange.error, 400, rl);
   }
 
   let parsed: Awaited<ReturnType<typeof parseSearchFilters>>;
@@ -164,7 +182,7 @@ export async function GET(request: NextRequest) {
       { service: "typesense", operation: "public_api_search" },
       error,
     );
-    return searchErrorResponse("Search service unavailable", 500);
+    return searchErrorResponse("Search service unavailable", 500, rl);
   }
 
   const locationIds =
@@ -212,7 +230,7 @@ export async function GET(request: NextRequest) {
       { service: "typesense", operation: "public_api_search" },
       error,
     );
-    return searchErrorResponse("Search service unavailable", 500);
+    return searchErrorResponse("Search service unavailable", 500, rl);
   }
 
   const companies = result.companies.slice(0, MAX_COMPANIES).map((c) => ({

--- a/apps/web/public/api/openapi.json
+++ b/apps/web/public/api/openapi.json
@@ -19,9 +19,9 @@
           { "name": "sen", "in": "query", "schema": { "type": "string" }, "description": "Seniority slugs, comma-separated (exact slugs only, use /resolve to look up)" },
           { "name": "tech", "in": "query", "schema": { "type": "string" }, "description": "Technology slugs, comma-separated (exact slugs only, use /resolve to look up)" },
           { "name": "wm", "in": "query", "schema": { "type": "string", "enum": ["onsite", "hybrid", "remote"] }, "description": "Work-mode filter (single value)" },
-          { "name": "sal", "in": "query", "schema": { "type": "string" }, "description": "Salary range in EUR, format: min-max (e.g. 80000-150000)" },
+          { "name": "sal", "in": "query", "schema": { "type": "string", "pattern": "^\\s*(?:\\d+\\s*-\\s*\\d+|\\d+\\s*-\\s*|-\\s*\\d+)\\s*$", "examples": ["80000-150000", "80000-", "-150000"] }, "description": "Salary range in EUR with non-negative integer bounds. Closed (min-max) and one-sided open ranges (min- or -max) are accepted; at least one bound is required. Omit the parameter for no salary bound." },
           { "name": "salcur", "in": "query", "schema": { "type": "string" }, "description": "Salary currency code (e.g. USD, EUR)" },
-          { "name": "exp", "in": "query", "schema": { "type": "string" }, "description": "Experience range in years, format: min-max (e.g. 3-10)" },
+          { "name": "exp", "in": "query", "schema": { "type": "string", "pattern": "^\\s*(?:\\d+\\s*-\\s*\\d+|\\d+\\s*-\\s*|-\\s*\\d+)\\s*$", "examples": ["3-10", "3-", "-10"] }, "description": "Experience range in years with non-negative integer bounds. Closed (min-max) and one-sided open ranges (min- or -max) are accepted; at least one bound is required. Omit the parameter for no experience bound." },
           { "name": "lang", "in": "query", "schema": { "type": "string" }, "description": "Job document language filter (comma-separated codes — en, de, fr, it). Distinct from ``locale`` (which controls response labels/currency formatting). Omit to return postings in any language; the API does not fall back to a cookie or to ``locale`` (public APIs are stateless)." },
           { "name": "locale", "in": "query", "schema": { "type": "string", "default": "en", "enum": ["en", "de", "fr", "it"] }, "description": "UI locale for response labels and currency formatting (en, de, fr, it). Does NOT filter postings by document language — use ``lang`` for that." }
         ],
@@ -71,6 +71,22 @@
               "Cache-Control": {
                 "description": "Always ``no-store`` for error responses.",
                 "schema": { "type": "string", "const": "no-store" }
+              },
+              "Access-Control-Allow-Origin": {
+                "description": "Cross-origin access is permitted for public API clients.",
+                "schema": { "type": "string", "const": "*" }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Request limit when the rate-limit backend is available.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Remaining requests when the rate-limit backend is available.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Reset": {
+                "description": "Rate-limit reset time in Unix milliseconds when the backend is available.",
+                "schema": { "type": "integer" }
               }
             },
             "content": {
@@ -85,6 +101,22 @@
               "Cache-Control": {
                 "description": "Always ``no-store`` for error responses.",
                 "schema": { "type": "string", "const": "no-store" }
+              },
+              "Access-Control-Allow-Origin": {
+                "description": "Cross-origin access is permitted for public API clients.",
+                "schema": { "type": "string", "const": "*" }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Request limit when the rate-limit backend is available.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Remaining requests when the rate-limit backend is available.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Reset": {
+                "description": "Rate-limit reset time in Unix milliseconds when the backend is available.",
+                "schema": { "type": "integer" }
               }
             },
             "content": {
@@ -94,7 +126,41 @@
               }
             }
           },
-          "429": { "description": "Rate limit exceeded" }
+          "429": {
+            "description": "Rate limit exceeded. The response is not cacheable.",
+            "headers": {
+              "Cache-Control": {
+                "description": "Always ``no-store`` for rate-limit responses.",
+                "schema": { "type": "string", "const": "no-store" }
+              },
+              "Access-Control-Allow-Origin": {
+                "description": "Cross-origin access is permitted for public API clients.",
+                "schema": { "type": "string", "const": "*" }
+              },
+              "Retry-After": {
+                "description": "Seconds until the client may retry.",
+                "schema": { "type": "integer", "minimum": 1 }
+              },
+              "X-RateLimit-Limit": {
+                "description": "Request limit for the current window.",
+                "schema": { "type": "integer" }
+              },
+              "X-RateLimit-Remaining": {
+                "description": "Remaining requests; always zero for this response.",
+                "schema": { "type": "integer", "const": 0 }
+              },
+              "X-RateLimit-Reset": {
+                "description": "Rate-limit reset time in Unix milliseconds.",
+                "schema": { "type": "integer" }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" },
+                "example": { "error": "Too many requests" }
+              }
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary

- reject present-but-empty, boundless, and separator-free salary/experience ranges while preserving valid open and closed forms
- preserve rate-limit metadata on search 400/500 responses and add public CORS headers to shared 429 responses
- align the OpenAPI range grammar and error-header contracts with runtime behavior

## Recon

Production already returned 400 for invalid language, non-numeric, and reversed ranges after #7018. It still returned cacheable 200 responses for `sal=`, `sal=-`, `exp=`, and `exp=-`, and validation errors omitted successful rate-limit metadata. Valid `min-`, `-max`, and `min-max` forms returned 200 and remain supported.

## Verification

- focused Vitest: 2 files, 36 tests
- full web Vitest suite
- Next route type generation + TypeScript
- changed-file ESLint
- OpenAPI JSON parse
- git diff check
- independent contract/diff review: no blocker

## Post-deploy acceptance

Probe invalid language/range forms plus valid open/closed ranges on production. Confirm 400 errors use `{ "error": string }`, `Cache-Control: no-store`, CORS, and rate-limit headers; valid forms remain 200; keep 429 distinct.

Fixes #6121