### PR TITLE
Embed currency rates in the app shell

### DIFF
--- a/apps/web/app/[lang]/(app)/layout.tsx
+++ b/apps/web/app/[lang]/(app)/layout.tsx
@@ -8,6 +8,7 @@ import { UpgradeBanner } from "@/components/UpgradeBanner";
 import { WatchlistTipBanner } from "@/components/watchlist/watchlist-tip-banner";
 import { BackToTop } from "@/components/ui/back-to-top";
 import { SkipToContentLink } from "@/components/SkipToContentLink";
+import { getCurrencyRates } from "@/lib/services/search";
 
 type Props = {
   children: ReactNode;
@@ -17,8 +18,13 @@ type Props = {
 // setI18n + <LinguiClientProvider>); this layout no longer redoes that work.
 // See #2883.
 export default async function AppLayout({ children }: Props) {
+  // Resolve the hours-cached table as part of the shared server shell. Passing
+  // it into the client provider removes one uncached Server Action POST from
+  // every app-page mount while retaining the same EUR fallback behavior.
+  const currencyRates = await getCurrencyRates();
+
   return (
-    <AppBootstrapProvider>
+    <AppBootstrapProvider initialCurrencyRates={currencyRates}>
       <SearchStateProvider>
         <SkipToContentLink />
         <div className="flex min-h-dvh flex-col">

--- a/apps/web/src/components/__tests__/AppBootstrapProvider.test.tsx
+++ b/apps/web/src/components/__tests__/AppBootstrapProvider.test.tsx
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, act } from "@testing-library/react";
-// SalaryDisplayProvider (mounted via AppBootstrapProvider) now calls
-// `useLingui()` for the period-suffix label (#3144). Stub the Lingui
-// surface so the provider hierarchy can render without an I18n setup.
+// SalaryDisplayProvider (mounted via AppBootstrapProvider) calls `useLingui()`
+// for the period-suffix label (#3144). Stub the Lingui surface so the provider
+// hierarchy can render without an I18n setup.
 import "@/test-utils/lingui-mock";
 import { useSession } from "../providers/SessionProvider";
 
@@ -43,6 +43,12 @@ if (typeof window !== "undefined") {
 
 // Import after the mock is installed.
 import { AppBootstrapProvider } from "../providers/AppBootstrapProvider";
+import { useSalaryRates } from "../providers/SalaryDisplayProvider";
+
+const initialCurrencyRates = [
+  { currency: "EUR", toEur: 1 },
+  { currency: "CHF", toEur: 1.04 },
+];
 
 function SessionProbe() {
   const { user, isLoggedIn, isPending } = useSession();
@@ -52,6 +58,15 @@ function SessionProbe() {
       <span data-testid="logged-in">{String(isLoggedIn)}</span>
       <span data-testid="user-name">{user?.name ?? "none"}</span>
     </>
+  );
+}
+
+function RatesProbe() {
+  const rates = useSalaryRates();
+  return (
+    <span data-testid="rates">
+      {rates.map((rate) => rate.currency).join(",")}
+    </span>
   );
 }
 
@@ -81,8 +96,9 @@ describe("AppBootstrapProvider", () => {
     });
 
     render(
-      <AppBootstrapProvider>
+      <AppBootstrapProvider initialCurrencyRates={initialCurrencyRates}>
         <SessionProbe />
+        <RatesProbe />
       </AppBootstrapProvider>,
     );
 
@@ -94,6 +110,7 @@ describe("AppBootstrapProvider", () => {
     expect(mockBootstrap).not.toHaveBeenCalled();
     expect(screen.getByTestId("logged-in").textContent).toBe("false");
     expect(screen.getByTestId("user-name").textContent).toBe("none");
+    expect(screen.getByTestId("rates").textContent).toBe("EUR,CHF");
   });
 
   it("calls fetchAppBootstrap and propagates user state when the hint cookie is present", async () => {
@@ -111,7 +128,7 @@ describe("AppBootstrapProvider", () => {
     });
 
     render(
-      <AppBootstrapProvider>
+      <AppBootstrapProvider initialCurrencyRates={initialCurrencyRates}>
         <SessionProbe />
       </AppBootstrapProvider>,
     );
@@ -133,7 +150,7 @@ describe("AppBootstrapProvider", () => {
     );
 
     render(
-      <AppBootstrapProvider>
+      <AppBootstrapProvider initialCurrencyRates={initialCurrencyRates}>
         <SessionProbe />
       </AppBootstrapProvider>,
     );
@@ -190,7 +207,7 @@ describe("AppBootstrapProvider", () => {
     }
 
     render(
-      <AppBootstrapProvider>
+      <AppBootstrapProvider initialCurrencyRates={initialCurrencyRates}>
         <SessionProbe />
         <RefreshProbe />
       </AppBootstrapProvider>,
@@ -251,7 +268,7 @@ describe("AppBootstrapProvider", () => {
     });
 
     render(
-      <AppBootstrapProvider>
+      <AppBootstrapProvider initialCurrencyRates={initialCurrencyRates}>
         <SessionProbe />
       </AppBootstrapProvider>,
     );

--- a/apps/web/src/components/__tests__/SalaryDisplayProvider.test.tsx
+++ b/apps/web/src/components/__tests__/SalaryDisplayProvider.test.tsx
@@ -3,31 +3,20 @@
  *
  * The `/explore` and `/company/<slug>` pages historically fired
  * `getCurrencyRates()` three times per view (SalaryDisplayProvider +
- * SearchPage/CompanyPage + SalaryModal). The fix hoists the fetch into
- * the provider and exposes the table via a new `useSalaryRates()` hook.
- * These tests pin that contract:
+ * SearchPage/CompanyPage + SalaryModal). #3181 hoisted that to one provider
+ * RPC; #7197 resolves the hours-cached table in the shared server layout and
+ * injects it into the provider. These tests pin the final contract:
  *
- *   1. mounting the provider triggers exactly one fetch
- *   2. multiple consumers reading via the hook share the same fetch
+ *   1. multiple consumers receive the same server-supplied table immediately
+ *   2. mounting the provider triggers no browser Server Action
  *   3. consumers without a provider in scope still mount and receive
  *      a graceful empty table (no fallback fetch, no crash)
  */
 import { useState } from "react";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import "@/test-utils/lingui-mock";
 
-const getCurrencyRatesMock = vi.fn();
-
-// The real `@/lib/actions/search` is a server action that transitively
-// imports `server-only`, which throws when loaded outside a Next runtime.
-vi.mock("server-only", () => ({}));
-vi.mock("@/lib/actions/search", () => ({
-  getCurrencyRates: (...args: unknown[]) => getCurrencyRatesMock(...args),
-}));
-
-// Import after the mock is installed so the provider closes over the
-// mocked module.
 import {
   SalaryDisplayProvider,
   useSalaryRates,
@@ -85,6 +74,7 @@ function BootstrapPreferenceHarness() {
         Load account preferences
       </button>
       <SalaryDisplayProvider
+        initialRates={[]}
         displayCurrency={preferences.currency}
         salaryPeriod={preferences.period}
       >
@@ -95,7 +85,6 @@ function BootstrapPreferenceHarness() {
 }
 
 beforeEach(() => {
-  getCurrencyRatesMock.mockReset();
   const memory = new Map<string, string>();
   const stub: Storage = {
     get length() {
@@ -117,15 +106,15 @@ beforeEach(() => {
   });
 });
 
-describe("SalaryDisplayProvider rate sharing (issue #3181)", () => {
-  it("fetches currency rates exactly once when multiple consumers mount", async () => {
-    getCurrencyRatesMock.mockResolvedValue([
+describe("SalaryDisplayProvider rate sharing (#3181, #7197)", () => {
+  it("shares the injected currency rates when multiple consumers mount", () => {
+    const initialRates = [
       { currency: "EUR", toEur: 1 },
       { currency: "USD", toEur: 0.92 },
-    ]);
+    ];
 
     render(
-      <SalaryDisplayProvider>
+      <SalaryDisplayProvider initialRates={initialRates}>
         <RatesProbe testId="probe-a" />
         <RatesProbe testId="probe-b" />
         <RatesProbe testId="probe-c" />
@@ -133,37 +122,28 @@ describe("SalaryDisplayProvider rate sharing (issue #3181)", () => {
       </SalaryDisplayProvider>,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId("probe-a").textContent).toContain("EUR:1");
-    });
-
-    // All consumers see the same payload — and we only paid for one
-    // round-trip to do it.
-    expect(getCurrencyRatesMock).toHaveBeenCalledTimes(1);
+    // All consumers synchronously see the same server-shell payload. No client
+    // action is imported or fired by the provider.
+    expect(screen.getByTestId("probe-a").textContent).toContain("EUR:1");
     expect(screen.getByTestId("probe-b").textContent).toBe("EUR:1,USD:0.92");
     expect(screen.getByTestId("probe-c").textContent).toBe("EUR:1,USD:0.92");
     expect(screen.getByTestId("formatter-rates").textContent).toBe("2");
   });
 
   it("returns an empty rate list when no provider is in scope (no fallback fetch, no crash)", () => {
-    // No mock setup: if the hook fell through to its own fetch, the
-    // assertion below would still pass (mock returns undefined), but
-    // `getCurrencyRatesMock.toHaveBeenCalledTimes(0)` would catch it.
     render(<RatesProbe testId="orphan" />);
 
     expect(screen.getByTestId("orphan").textContent).toBe("");
-    expect(getCurrencyRatesMock).toHaveBeenCalledTimes(0);
   });
 });
 
 describe("SalaryDisplayProvider preference persistence (#6035)", () => {
   it("rehydrates anonymous preferences and persists updates across remounts", async () => {
-    getCurrencyRatesMock.mockResolvedValue([]);
     window.localStorage.setItem("pref-display-currency", "USD");
     window.localStorage.setItem("pref-salary-period", "monthly");
 
     const first = render(
-      <SalaryDisplayProvider>
+      <SalaryDisplayProvider initialRates={[]}>
         <PreferenceProbe />
       </SalaryDisplayProvider>,
     );
@@ -179,7 +159,7 @@ describe("SalaryDisplayProvider preference persistence (#6035)", () => {
     first.unmount();
 
     render(
-      <SalaryDisplayProvider>
+      <SalaryDisplayProvider initialRates={[]}>
         <PreferenceProbe />
       </SalaryDisplayProvider>,
     );
@@ -190,7 +170,6 @@ describe("SalaryDisplayProvider preference persistence (#6035)", () => {
   });
 
   it("lets asynchronously loaded account preferences override anonymous values", async () => {
-    getCurrencyRatesMock.mockResolvedValue([]);
     window.localStorage.setItem("pref-display-currency", "USD");
     window.localStorage.setItem("pref-salary-period", "monthly");
 

--- a/apps/web/src/components/providers/AppBootstrapProvider.tsx
+++ b/apps/web/src/components/providers/AppBootstrapProvider.tsx
@@ -9,6 +9,7 @@ import { SalaryDisplayProvider } from "@/components/providers/SalaryDisplayProvi
 import { BannerProvider } from "@/components/providers/BannerProvider";
 import { PreferencesInitializer } from "@/components/providers/PreferencesInitializer";
 import { clearLoggedInHint, hasLoggedInHint } from "@/lib/client-cookies";
+import type { CurrencyRate } from "@/lib/actions/search";
 
 const ANON_BOOTSTRAP: AppBootstrapData = {
   user: null,
@@ -17,7 +18,13 @@ const ANON_BOOTSTRAP: AppBootstrapData = {
   starredIds: [],
 };
 
-export function AppBootstrapProvider({ children }: { children: ReactNode }) {
+export function AppBootstrapProvider({
+  children,
+  initialCurrencyRates,
+}: {
+  children: ReactNode;
+  initialCurrencyRates: CurrencyRate[];
+}) {
   const [data, setData] = useState<AppBootstrapData | null>(null);
 
   // Re-fetch the bootstrap payload and replace state in place. Used by
@@ -57,6 +64,7 @@ export function AppBootstrapProvider({ children }: { children: ReactNode }) {
       <SavedJobsProvider initialStatuses={data?.savedStatuses}>
         <StarredCompaniesProvider initialIds={data?.starredIds}>
           <SalaryDisplayProvider
+            initialRates={initialCurrencyRates}
             displayCurrency={prefs?.displayCurrency ?? null}
             salaryPeriod={prefs?.salaryPeriod ?? null}
             persistLocally={!isPending && user === null}

--- a/apps/web/src/components/providers/SalaryDisplayProvider.tsx
+++ b/apps/web/src/components/providers/SalaryDisplayProvider.tsx
@@ -2,7 +2,7 @@
 
 import { createContext, useContext, useEffect, useState, useMemo, useCallback, type ReactNode } from "react";
 import { useLingui } from "@lingui/react/macro";
-import { getCurrencyRates, type CurrencyRate } from "@/lib/actions/search";
+import type { CurrencyRate } from "@/lib/actions/search";
 import { formatSalary, type PeriodLabel, type SalaryPeriod } from "@/lib/salary";
 import { localPrefs } from "@/lib/preference-timestamps";
 
@@ -41,24 +41,22 @@ const SalaryDisplayContext = createContext<SalaryDisplayContextValue>({
 });
 
 export function SalaryDisplayProvider({
+  initialRates,
   displayCurrency: initialCurrency = null,
   salaryPeriod: initialPeriod = null,
   persistLocally = true,
   children,
 }: {
+  initialRates: CurrencyRate[];
   displayCurrency?: string | null;
   salaryPeriod?: string | null;
   persistLocally?: boolean;
   children: ReactNode;
 }) {
   const { t } = useLingui();
-  const [rates, setRates] = useState<CurrencyRate[]>([]);
+  const rates = initialRates;
   const [displayCurrency, setDisplayCurrency] = useState(initialCurrency);
   const [salaryPeriod, setSalaryPeriod] = useState(initialPeriod);
-
-  useEffect(() => {
-    getCurrencyRates().then(setRates);
-  }, []);
 
   useEffect(() => {
     if (initialCurrency !== null) {
@@ -135,15 +133,15 @@ export function useSalaryDisplay() {
 }
 
 /**
- * Returns the cached currency-rate table fetched once by
- * `SalaryDisplayProvider` on mount.
+ * Returns the hours-cached currency-rate table embedded by the shared server
+ * layout and supplied through `SalaryDisplayProvider`.
  *
  * Consumers (search page, company page, salary modal) historically each
  * fired their own `getCurrencyRates()` server action on mount, producing
  * three identical round-trips per `/explore` or `/company/<slug>` view
- * (~90–240ms of serial latency before salary filters were interactive —
- * see #3181). Reading the rates from context collapses that to a single
- * fetch.
+ * (~90–240ms of serial latency before salary filters were interactive — see
+ * #3181). The first fix collapsed those to one provider RPC; #7197 removes the
+ * last browser RPC by resolving the cache once in the server shell.
  *
  * Returns `[]` when no provider is in scope (the context default), so
  * callers can treat the result as a graceful empty list. The salary

--- a/apps/web/src/lib/actions/__tests__/db-retry-coverage.test.ts
+++ b/apps/web/src/lib/actions/__tests__/db-retry-coverage.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { withTestEnv } from "@/test-utils/env";
+import { setTestEnv, withTestEnv } from "@/test-utils/env";
 
 /**
  * Issue #2930: extends `withDbRetry` (#2929 / #2918) to additional
@@ -212,6 +212,21 @@ describe("issue #2930 — withDbRetry covers additional call sites", () => {
 
     expect(rates.find((r) => r.currency === "USD")?.toEur).toBeCloseTo(0.92);
     expect(dbExecuteMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns the EUR fallback without entering the cache when the database is absent", async () => {
+    const configuredUrl = process.env.DATABASE_URL;
+    setTestEnv({ DATABASE_URL: undefined });
+    try {
+      const { getCurrencyRates } = await import("@/lib/actions/search");
+      await expect(getCurrencyRates()).resolves.toEqual([
+        { currency: "EUR", toEur: 1 },
+      ]);
+    } finally {
+      setTestEnv({ DATABASE_URL: configuredUrl });
+    }
+
+    expect(dbExecuteMock).not.toHaveBeenCalled();
   });
 
   it("propagates non-retryable errors (syntax) without retrying", async () => {

--- a/apps/web/src/lib/services/search.ts
+++ b/apps/web/src/lib/services/search.ts
@@ -257,6 +257,13 @@ async function _fetchCurrencyRates(): Promise<CurrencyRate[]> {
 }
 
 export async function getCurrencyRates(): Promise<CurrencyRate[]> {
+  // Secretless CI and local production builds prerender the shared app layout.
+  // Avoid entering the cached database boundary when no database exists: Next
+  // surfaces that build-time cache error outside ordinary userland catches.
+  // Runtime deployments have DATABASE_URL and retain the hours-cached table.
+  if (!process.env.DATABASE_URL) {
+    return [{ currency: "EUR", toEur: 1 }];
+  }
   try {
     return await _fetchCurrencyRates();
   } catch {


### PR DESCRIPTION
## Summary

- resolve the hours-cached currency table in the shared server `(app)` layout
- inject rates through `AppBootstrapProvider` into `SalaryDisplayProvider`
- remove the provider's unconditional mount-time Server Action and make the server-supplied prop required
- preserve the existing EUR fallback before entering the cache in secretless builds

## Fluid CPU impact

Every app-page browser mount currently fires `getCurrencyRates()` as an uncached Server Action. The underlying database table is cached for hours, but the RPC still invokes Fluid once per anonymous or authenticated page view. This removes that browser POST entirely and pays only the shared server/cache read embedded in the PPR shell.

Issue #3181 previously reduced three identical rate RPCs per Explore/company view to one provider RPC. This removes the remaining one without changing `useSalaryRates()` or `useSalaryDisplay().rates` consumers.

## Functionality

- rates are available immediately instead of after hydration
- authenticated and anonymous display-currency/salary-period behavior is unchanged
- salary conversion/filter consumers receive the identical serialized table
- missing-database CI/local builds retain the existing EUR-only fallback
- the provider cannot be mounted in production without an explicit table because the prop is type-required

## Validation

- provider/bootstrap/DB fallback tests: 14 passed
- web ESLint: passed
- Next route typegen + TypeScript: passed
- complete secretless production build: passed, all 183 static pages generated
- PPR/static/dynamic route classifications unchanged
- pre-commit web lint and translation coverage: passed
- React review: removes a client waterfall and derived state; serialized payload is a small shared rate table

Closes #7197
Part of #6616
