### PR TITLE
Embed public mount data in page responses

### DIFF
--- a/apps/web/app/[lang]/(app)/progress/__tests__/progress-page.test.tsx
+++ b/apps/web/app/[lang]/(app)/progress/__tests__/progress-page.test.tsx
@@ -1,0 +1,56 @@
+import { readFileSync } from "node:fs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@/test-utils/lingui-mock";
+
+const mocks = vi.hoisted(() => ({
+  getSiteStats: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/stats", () => ({
+  getSiteStats: () => mocks.getSiteStats(),
+}));
+
+vi.mock("../company-request-form", () => ({
+  CompanyRequestForm: () => null,
+}));
+
+import AppPage from "../page";
+
+describe("progress page server data", () => {
+  beforeEach(() => {
+    mocks.getSiteStats.mockReset();
+  });
+
+  it("includes cached site counters in the initial server render", async () => {
+    mocks.getSiteStats.mockResolvedValue({
+      companyCount: 1234,
+      jobPostingCount: 5678,
+    });
+
+    render(await AppPage({ params: Promise.resolve({ lang: "en" }) }));
+
+    expect(screen.getByText("1,234")).toBeTruthy();
+    expect(screen.getByText("5,678")).toBeTruthy();
+    expect(mocks.getSiteStats).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the placeholder fallback when the cached read fails", async () => {
+    mocks.getSiteStats.mockRejectedValue(new Error("typesense unavailable"));
+
+    render(await AppPage({ params: Promise.resolve({ lang: "de" }) }));
+
+    expect(screen.getAllByText("—")).toHaveLength(2);
+  });
+
+  it("keeps the presentation component free of mount-time actions", () => {
+    const source = readFileSync(
+      "app/[lang]/(app)/progress/progress-loader.tsx",
+      "utf8",
+    );
+
+    expect(source).not.toContain('"use client"');
+    expect(source).not.toContain("useEffect");
+    expect(source).not.toContain("getSiteStats");
+  });
+});

--- a/apps/web/app/[lang]/(app)/progress/page.tsx
+++ b/apps/web/app/[lang]/(app)/progress/page.tsx
@@ -1,4 +1,5 @@
 import { isLocale, defaultLocale } from "@/lib/i18n";
+import { getSiteStats } from "@/lib/actions/stats";
 import { ProgressLoader } from "./progress-loader";
 
 type Props = {
@@ -8,5 +9,6 @@ type Props = {
 export default async function AppPage({ params }: Props) {
   const { lang } = await params;
   const locale = isLocale(lang) ? lang : defaultLocale;
-  return <ProgressLoader locale={locale} lang={lang} />;
+  const stats = await getSiteStats().catch(() => null);
+  return <ProgressLoader locale={locale} lang={lang} stats={stats} />;
 }

--- a/apps/web/app/[lang]/(app)/progress/progress-loader.tsx
+++ b/apps/web/app/[lang]/(app)/progress/progress-loader.tsx
@@ -1,21 +1,19 @@
-"use client";
-
-import { useEffect, useState } from "react";
 import { Trans } from "@lingui/react/macro";
 import { Construction, Building2, Briefcase } from "lucide-react";
 import { siteConfig } from "@/content/config";
-import { getSiteStats } from "@/lib/actions/stats";
 import { CompanyRequestForm } from "./company-request-form";
 
 type StatsData = { companyCount: number; jobPostingCount: number };
 
-export function ProgressLoader({ locale, lang }: { locale: string; lang: string }) {
-  const [stats, setStats] = useState<StatsData | null>(null);
-
-  useEffect(() => {
-    getSiteStats().then(setStats).catch(() => setStats(null));
-  }, []);
-
+export function ProgressLoader({
+  locale,
+  lang,
+  stats,
+}: {
+  locale: string;
+  lang: string;
+  stats: StatsData | null;
+}) {
   return (
     <div className="flex flex-col items-center justify-center py-24 text-center">
       <Construction className="mb-6 h-16 w-16 text-muted" />

--- a/apps/web/app/[lang]/(app)/watchlists/__tests__/watchlists-loader.test.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/__tests__/watchlists-loader.test.tsx
@@ -5,11 +5,13 @@ import "@/test-utils/lingui-mock";
 
 const mocks = vi.hoisted(() => ({
   load: vi.fn(),
+  popular: vi.fn(),
   getSession: vi.fn(),
 }));
 
 vi.mock("@/lib/services/watchlists", () => ({
   getUserWatchlistsWithLimit: (...args: unknown[]) => mocks.load(...args),
+  getPopularWatchlists: (...args: unknown[]) => mocks.popular(...args),
 }));
 
 vi.mock("@/lib/sessionCache", () => ({
@@ -19,11 +21,15 @@ vi.mock("@/lib/sessionCache", () => ({
 vi.mock("../watchlists-page", () => ({
   WatchlistsPage: ({
     initialWatchlists,
+    initialPopularWatchlists,
+    initialPopularTotal,
     username,
     limitReached,
     locale,
   }: {
     initialWatchlists: unknown[];
+    initialPopularWatchlists: unknown[];
+    initialPopularTotal: number;
     username: string | null;
     limitReached: boolean;
     locale: string;
@@ -31,6 +37,8 @@ vi.mock("../watchlists-page", () => ({
     <div
       data-testid="watchlists-page"
       data-count={initialWatchlists.length}
+      data-popular-count={initialPopularWatchlists.length}
+      data-popular-total={String(initialPopularTotal)}
       data-username={username ?? ""}
       data-limit-reached={String(limitReached)}
       data-locale={locale}
@@ -44,8 +52,13 @@ describe("WatchlistsLoader server read (#5896)", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     mocks.load.mockReset();
+    mocks.popular.mockReset();
     mocks.getSession.mockReset();
     mocks.getSession.mockResolvedValue({ user: { username: "alice" } });
+    mocks.popular.mockResolvedValue({
+      watchlists: [{ id: "public-wl-1" }],
+      total: 12,
+    });
   });
 
   it("passes the server-loaded overview to the interactive page", async () => {
@@ -58,11 +71,18 @@ describe("WatchlistsLoader server read (#5896)", () => {
 
     const page = screen.getByTestId("watchlists-page");
     expect(page.getAttribute("data-count")).toBe("1");
+    expect(page.getAttribute("data-popular-count")).toBe("1");
+    expect(page.getAttribute("data-popular-total")).toBe("12");
     expect(page.getAttribute("data-username")).toBe("alice");
     expect(page.getAttribute("data-limit-reached")).toBe("false");
     expect(page.getAttribute("data-locale")).toBe("en");
     expect(mocks.load).toHaveBeenCalledOnce();
     expect(mocks.load).toHaveBeenCalledWith("en");
+    expect(mocks.popular).toHaveBeenCalledWith({
+      offset: 0,
+      limit: 10,
+      locale: "en",
+    });
   });
 
   it("renders the anonymous overview without a username", async () => {
@@ -87,6 +107,22 @@ describe("WatchlistsLoader server read (#5896)", () => {
       "/fr/watchlists",
     );
     expect(mocks.load).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the overview usable when popular-watchlist discovery is unavailable", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    mocks.load.mockResolvedValue({
+      watchlists: [{ id: "wl-1" }],
+      limitReached: false,
+    });
+    mocks.popular.mockRejectedValue(new Error("typesense unavailable"));
+
+    render(await WatchlistsLoader({ locale: "it" }));
+
+    const page = screen.getByTestId("watchlists-page");
+    expect(page.getAttribute("data-count")).toBe("1");
+    expect(page.getAttribute("data-popular-count")).toBe("0");
+    expect(page.getAttribute("data-popular-total")).toBe("0");
   });
 });
 

--- a/apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx
@@ -1,11 +1,16 @@
 import { RefreshCw } from "lucide-react";
 import { Trans } from "@lingui/react/macro";
 import { getSession } from "@/lib/sessionCache";
-import { getUserWatchlistsWithLimit } from "@/lib/services/watchlists";
+import {
+  getPopularWatchlists,
+  getUserWatchlistsWithLimit,
+} from "@/lib/services/watchlists";
 import { logExternalError } from "@/lib/safe-external-error";
 import { WatchlistsPage } from "./watchlists-page";
 
 const WATCHLIST_LOAD_TIMEOUT_MS = 8_000;
+const PUBLIC_WATCHLIST_LOAD_TIMEOUT_MS = 3_000;
+const PUBLIC_WATCHLIST_PAGE_SIZE = 10;
 
 async function loadWatchlists(locale: string) {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -24,6 +29,27 @@ async function loadWatchlists(locale: string) {
   }
 }
 
+async function loadPopularWatchlists(locale: string) {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      getPopularWatchlists({
+        offset: 0,
+        limit: PUBLIC_WATCHLIST_PAGE_SIZE,
+        locale,
+      }),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(
+          () => reject(new Error("Popular watchlists request timed out")),
+          PUBLIC_WATCHLIST_LOAD_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
 /**
  * Initial watchlist data is a read, so load it in the server tree instead
  * of calling a Server Action from a client effect. The latter left the
@@ -34,10 +60,22 @@ export async function WatchlistsLoader({ locale }: { locale: string }) {
   const session = await getSession();
 
   try {
-    const { watchlists, limitReached } = await loadWatchlists(locale);
+    const [{ watchlists, limitReached }, popular] = await Promise.all([
+      loadWatchlists(locale),
+      loadPopularWatchlists(locale).catch((err) => {
+        logExternalError(
+          "error",
+          { service: "typesense", operation: "load_popular_watchlists" },
+          err,
+        );
+        return { watchlists: [], total: 0 };
+      }),
+    ]);
     return (
       <WatchlistsPage
         initialWatchlists={watchlists}
+        initialPopularWatchlists={popular.watchlists}
+        initialPopularTotal={popular.total}
         username={session?.user.username ?? null}
         limitReached={limitReached}
         locale={locale}

--- a/apps/web/app/[lang]/(app)/watchlists/watchlists-page.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/watchlists-page.tsx
@@ -6,7 +6,11 @@ import { Eye, Loader2, LogIn } from "lucide-react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useLocalePath } from "@/lib/useLocalePath";
 import { useSession } from "@/components/providers/SessionProvider";
-import type { UserWatchlistOverview, WatchlistFilters } from "@/lib/actions/watchlists";
+import type {
+  PublicWatchlistEntry,
+  UserWatchlistOverview,
+  WatchlistFilters,
+} from "@/lib/actions/watchlists";
 import {
   createWatchlist,
   createWatchlistFromHandoff,
@@ -28,11 +32,15 @@ function commaSeparatedValues(value: string | null): string[] {
 
 export function WatchlistsPage({
   initialWatchlists,
+  initialPopularWatchlists = [],
+  initialPopularTotal = 0,
   username,
   limitReached,
   locale,
 }: {
   initialWatchlists: UserWatchlistOverview[];
+  initialPopularWatchlists?: PublicWatchlistEntry[];
+  initialPopularTotal?: number;
   username: string | null;
   limitReached: boolean;
   locale: string;
@@ -305,7 +313,10 @@ export function WatchlistsPage({
       </div>
 
       {/* Public search — always visible */}
-      <PublicWatchlistSearch />
+      <PublicWatchlistSearch
+        initialWatchlists={initialPopularWatchlists}
+        initialTotal={initialPopularTotal}
+      />
     </div>
     <UpgradeModal open={upgrade.open} onOpenChange={upgrade.setOpen} reason={upgrade.reason} />
     </>

--- a/apps/web/src/components/watchlist/__tests__/public-watchlist-search.test.tsx
+++ b/apps/web/src/components/watchlist/__tests__/public-watchlist-search.test.tsx
@@ -58,6 +58,11 @@ function makeWatchlists(count: number) {
   }));
 }
 
+const emptyInitialPage = {
+  initialWatchlists: [],
+  initialTotal: 0,
+};
+
 beforeEach(() => {
   vi.restoreAllMocks();
   infiniteScrollMock.latest = undefined;
@@ -74,8 +79,15 @@ beforeEach(() => {
 });
 
 describe("PublicWatchlistSearch navigation", () => {
+  it("does not issue a read action merely because the server-rendered panel mounted", () => {
+    render(<PublicWatchlistSearch {...emptyInitialPage} />);
+
+    expect(getPopularWatchlistsMock).not.toHaveBeenCalled();
+    expect(searchPublicWatchlistsMock).not.toHaveBeenCalled();
+  });
+
   it("exposes a stable public-watchlist searchbox name", () => {
-    render(<PublicWatchlistSearch />);
+    render(<PublicWatchlistSearch {...emptyInitialPage} />);
 
     const input = screen.getByRole("searchbox", {
       name: "Search public watchlists",
@@ -87,8 +99,19 @@ describe("PublicWatchlistSearch navigation", () => {
 
   it("scrolls to top synchronously when opening a public watchlist result", async () => {
     const scrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+    const initialWatchlists = [{
+      ...makeWatchlists(1)[0],
+      id: "public-watchlist-1",
+      slug: "maangplus",
+      title: "MAANG+",
+    }];
 
-    render(<PublicWatchlistSearch />);
+    render(
+      <PublicWatchlistSearch
+        initialWatchlists={initialWatchlists}
+        initialTotal={1}
+      />,
+    );
 
     const link = await screen.findByRole("link", { name: /maang\+/i });
     fireEvent.click(link);
@@ -100,10 +123,14 @@ describe("PublicWatchlistSearch navigation", () => {
   it("stops infinite scroll when the next full public-watchlist page contains only duplicate ids", async () => {
     const firstPage = makeWatchlists(10);
     getPopularWatchlistsMock
-      .mockResolvedValueOnce({ watchlists: firstPage, total: 20 })
       .mockResolvedValueOnce({ watchlists: firstPage, total: 20 });
 
-    render(<PublicWatchlistSearch />);
+    render(
+      <PublicWatchlistSearch
+        initialWatchlists={firstPage}
+        initialTotal={20}
+      />,
+    );
 
     await screen.findByText("Watchlist 0");
     expect(infiniteScrollMock.latest?.hasMore).toBe(true);
@@ -117,6 +144,7 @@ describe("PublicWatchlistSearch navigation", () => {
       limit: 10,
       locale: "en",
     });
+    expect(getPopularWatchlistsMock).toHaveBeenCalledTimes(1);
     await waitFor(() => {
       expect(infiniteScrollMock.latest?.hasMore).toBe(false);
     });

--- a/apps/web/src/components/watchlist/public-watchlist-search.tsx
+++ b/apps/web/src/components/watchlist/public-watchlist-search.tsx
@@ -18,15 +18,22 @@ import {
 
 const PAGE_SIZE = 10;
 
-export function PublicWatchlistSearch() {
+export function PublicWatchlistSearch({
+  initialWatchlists,
+  initialTotal,
+}: {
+  initialWatchlists: PublicWatchlistEntry[];
+  initialTotal: number;
+}) {
   const params = useParams();
   const locale = (params.lang as string) ?? "en";
   const { t } = useLingui();
   const lp = useLocalePath();
   const [query, setQuery] = useState("");
-  const [debouncedQuery, setDebouncedQuery] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+  const [loading, setLoading] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  const initialQueryEffect = useRef(true);
 
   const fetchPage = useCallback(async (q: string, offset: number, limit: number) => {
     const fetcher = q.length >= 2
@@ -47,16 +54,20 @@ export function PublicWatchlistSearch() {
     hasMore,
     loadMore,
   } = usePaginatedLoadMore<PublicWatchlistEntry>({
-    initialItems: [],
-    initialTotal: 0,
+    initialItems: initialWatchlists,
+    initialTotal,
     batchSize: PAGE_SIZE,
     itemKey: (watchlist) => watchlist.id,
-    resetKey: `${locale}:${debouncedQuery ?? "__pending__"}`,
+    resetKey: `${locale}:${debouncedQuery}`,
     fetcher: ({ offset, limit }) => fetchPage(activeQuery, offset, limit),
   });
 
   // Initial load + search on query change
   useEffect(() => {
+    if (initialQueryEffect.current) {
+      initialQueryEffect.current = false;
+      return;
+    }
     clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => {
       setLoading(true);

--- a/apps/web/src/lib/actions/__tests__/stats-no-octokit.test.ts
+++ b/apps/web/src/lib/actions/__tests__/stats-no-octokit.test.ts
@@ -53,12 +53,14 @@ vi.mock("@/lib/search/typesense-retry", () => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.stubEnv("TYPESENSE_SEARCH_KEY", "test-search-key");
   mocks.collections.mockImplementation(() => ({
     documents: () => ({ search: mocks.search }),
   }));
 });
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   vi.resetModules();
 });
 
@@ -91,5 +93,13 @@ describe("stats.ts no longer eagerly pulls octokit (#3193)", () => {
       filter_by: "is_active:true",
       per_page: 0,
     });
+  });
+
+  it("returns the placeholder state before entering the cache during secretless builds", async () => {
+    vi.stubEnv("TYPESENSE_SEARCH_KEY", "");
+    const { getSiteStats } = await import("../stats");
+
+    await expect(getSiteStats()).resolves.toBeNull();
+    expect(mocks.collections).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/actions/stats.ts
+++ b/apps/web/src/lib/actions/stats.ts
@@ -7,33 +7,51 @@ import { withTypesenseRetry } from "@/lib/search/typesense-retry";
 // Per-region in-memory `'use cache'` (cacheLife('hours')). Build ID is
 // included in the key automatically — every deploy re-fetches. Migrated
 // from Redis-backed `cached(..., { ttl: 21600 })` in #2884 (bucket 5).
-// Returns a plain serializable object; Number coercions stay inside the
-// cache boundary so the cached value is the final shape consumers see.
-export async function getSiteStats() {
+// Returns a plain serializable object (or null for the existing placeholder
+// UI); Number coercions stay inside the cache boundary so the cached value is
+// the final shape consumers see.
+type SiteStats = {
+  companyCount: number;
+  jobPostingCount: number;
+};
+
+async function getCachedSiteStats(): Promise<SiteStats | null> {
   "use cache";
   cacheLife("hours");
-  const client = getSearchClient();
-  const [companies, postings] = await Promise.all([
-    withTypesenseRetry(
-      () =>
-        client.collections("company").documents().search({
-          q: "*",
-          per_page: 0,
-        }),
-      { label: "siteStats.company" },
-    ),
-    withTypesenseRetry(
-      () =>
-        client.collections("job_posting").documents().search({
-          q: "*",
-          filter_by: "is_active:true",
-          per_page: 0,
-        }),
-      { label: "siteStats.jobPosting" },
-    ),
-  ]);
-  return {
-    companyCount: Number(companies.found ?? 0),
-    jobPostingCount: Number(postings.found ?? 0),
-  };
+  try {
+    const client = getSearchClient();
+    const [companies, postings] = await Promise.all([
+      withTypesenseRetry(
+        () =>
+          client.collections("company").documents().search({
+            q: "*",
+            per_page: 0,
+          }),
+        { label: "siteStats.company" },
+      ),
+      withTypesenseRetry(
+        () =>
+          client.collections("job_posting").documents().search({
+            q: "*",
+            filter_by: "is_active:true",
+            per_page: 0,
+          }),
+        { label: "siteStats.jobPosting" },
+      ),
+    ]);
+    return {
+      companyCount: Number(companies.found ?? 0),
+      jobPostingCount: Number(postings.found ?? 0),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function getSiteStats(): Promise<SiteStats | null> {
+  // A secretless build must not enter the cache boundary: Next surfaces
+  // missing-environment errors from cached functions as prerender failures
+  // before a page-level catch can provide the existing placeholder UI.
+  if (!process.env.TYPESENSE_SEARCH_KEY) return null;
+  return getCachedSiteStats();
 }


### PR DESCRIPTION
## Summary

- include the first popular-watchlists page in the existing server loader, in parallel with the user overview
- seed public-watchlist search/pagination from that server result so an ordinary mount no longer emits a `Next-Action` POST
- render cached progress counters in the initial server response instead of fetching them in a client effect
- preserve empty/error fallbacks and cap the nonessential popular-watchlist read at three seconds
- make the cached stats boundary safe for secretless prerendering and Typesense outages

## Fluid CPU impact

This removes one automatic Server Action invocation from every `/{locale}/watchlists` visit and one from every `/{locale}/progress` visit. Search, pagination, mutations, authenticated watchlist counts, and all displayed content remain available.

The pre-intervention attribution assigned roughly 39 seconds of visible CPU to public-watchlist traffic. This PR removes the redundant post-hydration read on that surface; the exact reduction will be measured only after all CPU interventions and the exact obsolete-action WAF deny are live.

## Verification

- 20 focused tests passed across public-watchlist search, watchlists loader/page, progress SSR, and stats caching
- targeted ESLint passed
- Next route type generation and TypeScript passed
- full secretless production build passed: 183 pages
- `/progress` and `/watchlists` retain Partial Prerendering classifications
- React performance review: independent server reads use `Promise.all`, serialized props contain only rendered listing fields, and no mount-only derived state remains

Closes #7199
