### PR TITLE
Align public API contracts

### DIFF
--- a/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
+++ b/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
@@ -7,6 +7,7 @@ import type { ExploreData } from "@/lib/actions/explore-page-data";
 // the gate, then swap the action itself for a spy.
 vi.mock("server-only", () => ({}));
 const mockFetchExploreData = vi.fn();
+const mockSearchPageProps = vi.fn();
 vi.mock("@/lib/actions/explore-page-data", async () => {
   const actual =
     await vi.importActual<typeof import("@/lib/actions/explore-page-data")>(
@@ -24,9 +25,14 @@ vi.mock("@/lib/actions/explore-page-data", async () => {
 // initialTotalCompanies prop so the data-routing regression test in #3350
 // can assert which dataset the page mounted ``SearchPage`` with.
 vi.mock("../search-page", () => ({
-  SearchPage: ({ initialTotalCompanies }: { initialTotalCompanies: number }) => (
-    <div data-testid="search-page" data-total={initialTotalCompanies} />
-  ),
+  SearchPage: (props: {
+    initialTotalCompanies: number;
+    initialRepositoryFallbackCompanies?: ExploreData["repositoryFallbackCompanies"];
+    initialLanguageOverride?: string[] | null;
+  }) => {
+    mockSearchPageProps(props);
+    return <div data-testid="search-page" data-total={props.initialTotalCompanies} />;
+  },
 }));
 
 // Skeleton stub — a distinct marker so the #3350 regression test can
@@ -85,6 +91,7 @@ async function flushQueuedEffects(): Promise<void> {
 
 beforeEach(() => {
   mockFetchExploreData.mockReset();
+  mockSearchPageProps.mockReset();
   mockFetchExploreData.mockResolvedValue(makeInitialData());
   setBrowserSearch();
   setDocumentCookie("");
@@ -115,6 +122,27 @@ describe("ExploreContent — server-render initial-data path (#2640)", () => {
     } finally {
       scrollTo.mockRestore();
     }
+  });
+
+  it("forwards repository fallback identities and an explicit language override together", async () => {
+    const repositoryFallbackCompanies = [{ name: "Acme", slug: "acme" }];
+    render(
+      <ExploreContent
+        locale="en"
+        initialData={makeInitialData({
+          repositoryFallbackCompanies,
+          languageOverride: [],
+        })}
+      />,
+    );
+
+    await flushQueuedEffects();
+    expect(mockSearchPageProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        initialRepositoryFallbackCompanies: repositoryFallbackCompanies,
+        initialLanguageOverride: [],
+      }),
+    );
   });
 
   it("calls fetchExplorePageData when the `logged_in` hint cookie is present even without filters", async () => {
@@ -170,7 +198,7 @@ describe("ExploreContent — server-render initial-data path (#2640)", () => {
     // surface stays explicit (e.g. #3275 — `wm` was added to the live
     // code in #2987 but the test list lagged behind, leaving the
     // refetch-trigger contract unguarded).
-    const filterParams = ["q", "loc", "occ", "sen", "tech", "wm", "etype", "sal", "salcur", "exp"];
+    const filterParams = ["q", "loc", "occ", "sen", "tech", "wm", "etype", "sal", "salcur", "exp", "lang"];
     for (const param of filterParams) {
       mockFetchExploreData.mockClear();
       setBrowserSearch(`${param}=x`);

--- a/apps/web/app/[lang]/(app)/explore/explore-content.tsx
+++ b/apps/web/app/[lang]/(app)/explore/explore-content.tsx
@@ -88,6 +88,7 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
       hasLoggedInHint() ||
       hasAnonJobLanguagesHint() ||
       hasSearchFilterParams(searchParams) ||
+      searchParams.has("lang") ||
       initialData === undefined;
     if (!needsPersonalizedFetch) return;
 
@@ -135,7 +136,22 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
 
   if (!data) return <ExploreSkeleton />;
 
-  const { result, repositoryFallbackCompanies, parsed, displayCurrency, jobLanguages, languages, userLat, userLng, salaryCurrencyParam, salaryMinDisplay, salaryMaxDisplay, experienceMin, experienceMax } = data;
+  const {
+    result,
+    repositoryFallbackCompanies,
+    parsed,
+    displayCurrency,
+    jobLanguages,
+    languages,
+    languageOverride,
+    userLat,
+    userLng,
+    salaryCurrencyParam,
+    salaryMinDisplay,
+    salaryMaxDisplay,
+    experienceMin,
+    experienceMax,
+  } = data;
 
   return (
     <div ref={rootRef} data-explore-content-root>
@@ -161,6 +177,7 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
         displayCurrency={displayCurrency}
         jobLanguages={jobLanguages}
         languages={languages}
+        initialLanguageOverride={languageOverride}
         userLat={userLat}
         userLng={userLng}
       />

--- a/apps/web/app/[lang]/(app)/explore/search-page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/search-page.tsx
@@ -22,6 +22,8 @@ import { useClearTypesenseOnAuthChange } from "@/lib/search/use-clear-typesense-
 import { useSession } from "@/components/providers/SessionProvider";
 import { parseSearchFilters } from "@/lib/actions/search-input";
 import { buildFilteredPath } from "@/lib/search/query-params";
+import { parseExploreSearchLanguages } from "@/lib/search/language-param";
+import { resolveJobLanguages } from "@/lib/job-languages";
 import { useLatest, useLatestState } from "@/lib/use-latest";
 import { useBrowserSearchParams } from "@/lib/use-browser-search-params";
 import type { SearchResultCompany, HistogramFilters, WorkMode } from "@/lib/search";
@@ -78,6 +80,8 @@ interface SearchPageProps {
   jobLanguages: string[];
   /** Resolved language filter for search queries */
   languages: string[];
+  /** URL-level override supplied by the public API's `moreAt` link. */
+  initialLanguageOverride?: string[] | null;
   userLat?: number;
   userLng?: number;
 }
@@ -103,7 +107,8 @@ export function SearchPage({
   locale,
   displayCurrency,
   jobLanguages,
-  languages,
+  languages: initialLanguages,
+  initialLanguageOverride,
   userLat,
   userLng,
 }: SearchPageProps) {
@@ -117,6 +122,10 @@ export function SearchPage({
   const { isLoggedIn } = useSession();
   const isLoggedInRef = useLatest(isLoggedIn);
   const { get: getSearchState, set: setSearchState, setPageActions } = useSearchStateStore();
+  const [languageOverride, setLanguageOverride, languageOverrideRef] =
+    useLatestState<string[] | null>(initialLanguageOverride ?? null);
+  const [languages, setLanguages, languagesRef] =
+    useLatestState<string[]>(initialLanguages);
 
   const cachedSnapshot = getSearchState();
   const currentCacheKey = buildCacheKey(
@@ -135,6 +144,7 @@ export function SearchPage({
         : undefined,
       experienceMin: initialExperienceMin,
       experienceMax: initialExperienceMax,
+      languages,
     },
   );
   // Restore the cached snapshot only when it matches the current URL
@@ -300,6 +310,16 @@ export function SearchPage({
     const sal = searchParams.get("sal") ?? undefined;
     const salcur = searchParams.get("salcur") ?? undefined;
     const exp = searchParams.get("exp") ?? undefined;
+    const parsedLanguageOverride = parseExploreSearchLanguages(
+      searchParams.get("lang"),
+    );
+    const nextLanguageOverride = parsedLanguageOverride.ok
+      ? parsedLanguageOverride.languages
+      : null;
+    setLanguageOverride(nextLanguageOverride);
+    setLanguages(
+      nextLanguageOverride ?? resolveJobLanguages(jobLanguages, locale),
+    );
 
     const parseSalParts = sal ? sal.split("-") : [];
     const newSalMin = parseSalParts[0] ? parseInt(parseSalParts[0], 10) : undefined;
@@ -383,8 +403,22 @@ export function SearchPage({
                 : undefined,
             experienceMin: experienceMinRef.current,
             experienceMax: experienceMaxRef.current,
+            languages: languagesRef.current,
           },
         ),
+        hasResultFilters:
+          keywordsRef.current.length > 0 ||
+          locationsRef.current.length > 0 ||
+          occupationsRef.current.length > 0 ||
+          senioritiesRef.current.length > 0 ||
+          technologiesRef.current.length > 0 ||
+          employmentTypesRef.current.length > 0 ||
+          workModeRef.current.length > 0 ||
+          salaryMinRef.current != null ||
+          salaryMaxRef.current != null ||
+          experienceMinRef.current != null ||
+          experienceMaxRef.current != null ||
+          (languageOverrideRef.current?.length ?? 0) > 0,
       });
       setPageActions(null);
     };
@@ -486,6 +520,9 @@ export function SearchPage({
       if (cached.experienceMin != null || cached.experienceMax != null) {
         extra.exp = `${cached.experienceMin ?? ""}-${cached.experienceMax ?? ""}`;
       }
+      if (languageOverrideRef.current !== null) {
+        extra.lang = languageOverrideRef.current.join(",") || "*";
+      }
       const url = buildFilteredPath(
         pathname,
         cached.keywords,
@@ -507,7 +544,7 @@ export function SearchPage({
   }, []);
 
   const hasMore = companies.length < totalCompanies && !isTruncated;
-  const hasFilters = keywords.length > 0 || locations.length > 0 || occupations.length > 0 || seniorities.length > 0 || technologies.length > 0 || employmentTypes.length > 0 || workMode.length > 0 || salaryMin != null || salaryMax != null || experienceMin != null || experienceMax != null;
+  const hasFilters = keywords.length > 0 || locations.length > 0 || occupations.length > 0 || seniorities.length > 0 || technologies.length > 0 || employmentTypes.length > 0 || workMode.length > 0 || salaryMin != null || salaryMax != null || experienceMin != null || experienceMax != null || (languageOverride?.length ?? 0) > 0;
 
   /** Update only the `show` query param without touching filter state. */
   function updateShowParam(postingId: string | null) {
@@ -537,6 +574,9 @@ export function SearchPage({
     }
     if (employmentTypesRef.current.length > 0) {
       extra.etype = employmentTypesRef.current.join(",");
+    }
+    if (languageOverrideRef.current !== null) {
+      extra.lang = languageOverrideRef.current.join(",") || "*";
     }
     const url = buildFilteredPath(
       pathname,
@@ -602,7 +642,7 @@ export function SearchPage({
                   salaryMaxEur: salMaxEur,
                   experienceMin: expMin,
                   experienceMax: expMax,
-                  languages,
+                  languages: languagesRef.current,
                   locale,
                   offset: 0,
                   limit: PAGE_SIZE,
@@ -621,7 +661,7 @@ export function SearchPage({
                   salaryMaxEur: salMaxEur,
                   experienceMin: expMin,
                   experienceMax: expMax,
-                  languages,
+                  languages: languagesRef.current,
                   locale,
                   offset: 0,
                   limit: PAGE_SIZE,
@@ -851,6 +891,8 @@ export function SearchPage({
     setSalaryMax(undefined);
     setExperienceMin(undefined);
     setExperienceMax(undefined);
+    setLanguageOverride(null);
+    setLanguages(resolveJobLanguages(jobLanguages, locale));
     setShowPostingId(null);
     updateUrl();
     runSearch();
@@ -870,8 +912,8 @@ export function SearchPage({
     const expMin = experienceMinRef.current;
     const expMax = experienceMaxRef.current;
     const result = kws.length > 0
-      ? await runSearchJobs({ keywords: kws, locationIds, occupationIds, seniorityIds, technologyIds, employmentTypes: etypes, workMode: wm, salaryMinEur: salMinEur, salaryMaxEur: salMaxEur, experienceMin: expMin, experienceMax: expMax, languages, locale, offset, limit: PAGE_SIZE }, isLoggedInRef.current)
-      : await runListTopCompanies({ locationIds, occupationIds, seniorityIds, technologyIds, employmentTypes: etypes, workMode: wm, salaryMinEur: salMinEur, salaryMaxEur: salMaxEur, experienceMin: expMin, experienceMax: expMax, languages, locale, offset, limit: PAGE_SIZE }, isLoggedInRef.current);
+      ? await runSearchJobs({ keywords: kws, locationIds, occupationIds, seniorityIds, technologyIds, employmentTypes: etypes, workMode: wm, salaryMinEur: salMinEur, salaryMaxEur: salMaxEur, experienceMin: expMin, experienceMax: expMax, languages: languagesRef.current, locale, offset, limit: PAGE_SIZE }, isLoggedInRef.current)
+      : await runListTopCompanies({ locationIds, occupationIds, seniorityIds, technologyIds, employmentTypes: etypes, workMode: wm, salaryMinEur: salMinEur, salaryMaxEur: salMaxEur, experienceMin: expMin, experienceMax: expMax, languages: languagesRef.current, locale, offset, limit: PAGE_SIZE }, isLoggedInRef.current);
 
     if (result.truncated) setIsTruncated(true);
     if (result.degraded) setIsDegraded(true);
@@ -934,7 +976,13 @@ export function SearchPage({
         salaryMax={salaryMax}
         experienceMin={experienceMin}
         experienceMax={experienceMax}
-        jobLanguages={jobLanguages}
+        jobLanguages={
+          languageOverride === null
+            ? jobLanguages
+            : languageOverride.length > 0
+              ? languageOverride
+              : ["*"]
+        }
         onRemoveKeyword={handleRemoveKeyword}
         onAddLocation={handleAddLocation}
         onRemoveLocation={handleRemoveLocation}

--- a/apps/web/app/api/v1/_shared.test.ts
+++ b/apps/web/app/api/v1/_shared.test.ts
@@ -126,3 +126,80 @@ describe("apiResponse status contract (#3213)", () => {
     expect(apiResponse({ error: "Bad request" }, { status: 400 }).status).toBe(400);
   });
 });
+
+describe("parseApiLocale public v1 contract (#6132)", () => {
+  it("uses the shared default and accepts every supported locale", async () => {
+    const { parseApiLocale } = await import("./_shared");
+
+    expect(parseApiLocale(new URLSearchParams())).toBe("en");
+    for (const locale of ["en", "de", "fr", "it"]) {
+      expect(parseApiLocale(new URLSearchParams({ locale }))).toBe(locale);
+    }
+  });
+
+  it("returns a non-cacheable 400 with rate-limit metadata for unsupported locales", async () => {
+    const { parseApiLocale } = await import("./_shared");
+    const response = parseApiLocale(
+      new URLSearchParams({ locale: "xx" }),
+      { limit: 30, remaining: 29, reset: 12345 },
+    );
+
+    expect(response).toBeInstanceOf(Response);
+    if (!(response instanceof Response)) return;
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "Invalid 'locale' param. Supported: en, de, fr, it",
+    });
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("X-RateLimit-Limit")).toBe("30");
+    expect(response.headers.get("X-RateLimit-Remaining")).toBe("29");
+  });
+});
+
+describe("public search-filter contract (#6132)", () => {
+  it("rejects unknown finite-list values without caching the response", async () => {
+    const { validatePublicEnumListParam, PUBLIC_WORK_MODE_VALUES } = await import(
+      "./_shared"
+    );
+    const response = validatePublicEnumListParam(
+      "wm",
+      "remote,bogus",
+      PUBLIC_WORK_MODE_VALUES,
+    );
+
+    expect(response?.status).toBe(400);
+    expect(await response?.json()).toEqual({
+      error: "Invalid 'wm' value(s): bogus. Supported: onsite, hybrid, remote",
+    });
+    expect(response?.headers.get("Cache-Control")).toBe("no-store");
+  });
+
+  it("rejects unresolved exact slugs instead of widening the search", async () => {
+    const { validateResolvedPublicFilters } = await import("./_shared");
+    const response = validateResolvedPublicFilters({
+      unresolvedExplicitSlugs: { tech: ["not-a-technology"] },
+    });
+
+    expect(response?.status).toBe(400);
+    expect(await response?.json()).toEqual({
+      error:
+        "Invalid 'tech' slug(s): not-a-technology. Use /api/v1/resolve for exact slugs.",
+    });
+  });
+
+  it("pins Explore links to EUR when the public API applies a salary range", async () => {
+    const { exploreUrl } = await import("./_shared");
+    const url = new URL(
+      exploreUrl(
+        new URLSearchParams("q=engineer&sal=100000-&salcur=USD"),
+        "de",
+      ),
+    );
+
+    expect(url.pathname).toBe("/de/explore");
+    expect(url.searchParams.get("q")).toBe("engineer");
+    expect(url.searchParams.get("sal")).toBe("100000-");
+    expect(url.searchParams.get("salcur")).toBe("EUR");
+  });
+});

--- a/apps/web/app/api/v1/_shared.ts
+++ b/apps/web/app/api/v1/_shared.ts
@@ -3,6 +3,18 @@ import { apiLimiter, getClientIp } from "@/lib/rate-limit";
 import { CACHE_TTL_MEDIUM } from "@/lib/cache-ttl";
 import { siteConfig } from "@/content/config";
 import { logExternalError } from "@/lib/safe-external-error";
+import {
+  defaultLocale,
+  isLocale,
+  locales,
+  type Locale,
+} from "@/lib/i18n";
+import type { ParsedSearchFilters } from "@/lib/services/search-input";
+import {
+  PUBLIC_SEARCH_QUERY_PARAMETERS,
+  SEARCH_EMPLOYMENT_TYPE_VALUES,
+  SEARCH_WORK_MODE_VALUES,
+} from "@jseek/mcp-server/public-api-contract";
 
 /** Rate-limit result to thread through to apiResponse(). */
 export type RateLimitInfo = { limit: number; remaining: number; reset: number };
@@ -73,6 +85,70 @@ export function apiResponse(
   return NextResponse.json(data, { headers, status: options?.status });
 }
 
+/** Parse and validate the response locale shared by every public v1 route. */
+export function parseApiLocale(
+  params: URLSearchParams,
+  rateLimit?: RateLimitInfo | null,
+): Locale | NextResponse {
+  const locale = params.get("locale") ?? defaultLocale;
+  if (isLocale(locale)) return locale;
+
+  const response = apiResponse(
+    { error: `Invalid 'locale' param. Supported: ${locales.join(", ")}` },
+    { maxAge: 0, rateLimit, status: 400 },
+  );
+  response.headers.set("Cache-Control", "no-store");
+  return response;
+}
+
+/** Reject unsupported finite-list filters at the public API boundary. */
+export function validatePublicEnumListParam(
+  name: "wm" | "etype",
+  raw: string | undefined,
+  supported: readonly string[],
+  rateLimit?: RateLimitInfo | null,
+): NextResponse | null {
+  if (raw === undefined) return null;
+  const values = raw.split(",").map((value) => value.trim());
+  const invalid = values.filter(
+    (value) => value.length === 0 || !supported.includes(value),
+  );
+  if (invalid.length === 0) return null;
+
+  const detail = invalid.filter(Boolean).join(", ") || "empty value";
+  const response = apiResponse(
+    {
+      error: `Invalid '${name}' value(s): ${detail}. Supported: ${supported.join(", ")}`,
+    },
+    { maxAge: 0, rateLimit, status: 400 },
+  );
+  response.headers.set("Cache-Control", "no-store");
+  return response;
+}
+
+/** Reject unresolved exact-slug filters instead of silently widening a public search. */
+export function validateResolvedPublicFilters(
+  parsed: Pick<ParsedSearchFilters, "unresolvedExplicitSlugs">,
+  rateLimit?: RateLimitInfo | null,
+): NextResponse | null {
+  const unresolved = parsed.unresolvedExplicitSlugs;
+  if (!unresolved) return null;
+
+  for (const name of ["loc", "occ", "sen", "tech"] as const) {
+    const values = unresolved[name];
+    if (!values?.length) continue;
+    const response = apiResponse(
+      {
+        error: `Invalid '${name}' slug(s): ${values.join(", ")}. Use /api/v1/resolve for exact slugs.`,
+      },
+      { maxAge: 0, rateLimit, status: 400 },
+    );
+    response.headers.set("Cache-Control", "no-store");
+    return response;
+  }
+  return null;
+}
+
 /** Build the full URL to the site for a given path. */
 export function siteUrl(path: string): string {
   return `${siteConfig.url}${path}`;
@@ -84,22 +160,21 @@ export function exploreUrl(
   locale: string = "en",
 ): string {
   const kept = new URLSearchParams();
-  for (const key of [
-    "q",
-    "loc",
-    "occ",
-    "sen",
-    "tech",
-    "wm",
-    "etype",
-    "sal",
-    "salcur",
-    "exp",
-    "lang",
-  ]) {
+  for (const key of PUBLIC_SEARCH_QUERY_PARAMETERS) {
+    if (key === "locale") continue;
     const val = params.get(key);
     if (val) kept.set(key, val);
   }
+  // REST defaults to all document languages, whereas Explore normally uses
+  // the viewer's preference. Carry the UI's existing `*` sentinel so the
+  // linked result set stays equivalent when the API caller omitted `lang`.
+  if (!kept.has("lang")) kept.set("lang", "*");
+  // Public search salary bounds are always EUR. Pin the UI link so a user's
+  // display-currency preference cannot reinterpret the same numeric range.
+  if (kept.has("sal")) kept.set("salcur", "EUR");
   const qs = kept.toString();
   return siteUrl(`/${locale}/explore${qs ? `?${qs}` : ""}`);
 }
+
+export const PUBLIC_WORK_MODE_VALUES = SEARCH_WORK_MODE_VALUES;
+export const PUBLIC_EMPLOYMENT_TYPE_VALUES = SEARCH_EMPLOYMENT_TYPE_VALUES;

--- a/apps/web/app/api/v1/companies/route.test.ts
+++ b/apps/web/app/api/v1/companies/route.test.ts
@@ -45,6 +45,16 @@ describe("GET /api/v1/companies service boundary (#3331)", () => {
     expect(mocks.suggestCompanies).not.toHaveBeenCalled();
   });
 
+  it("rejects unsupported locales before constructing company URLs", async () => {
+    const res = await GET(makeReq("?q=goo&locale=xx"));
+    const body = (await res.json()) as { error?: string };
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(body.error).toBe("Invalid 'locale' param. Supported: en, de, fr, it");
+    expect(mocks.suggestCompanies).not.toHaveBeenCalled();
+  });
+
   it("resolves company suggestions through the service tier", async () => {
     mocks.suggestCompanies.mockResolvedValue([
       {

--- a/apps/web/app/api/v1/companies/route.ts
+++ b/apps/web/app/api/v1/companies/route.ts
@@ -4,7 +4,12 @@ import { type NextRequest, NextResponse } from "next/server";
 // issues #3231 / #3331.
 import { suggestCompanies } from "@/lib/services/company";
 import { CACHE_TTL_LONG } from "@/lib/cache-ttl";
-import { checkRateLimit, apiResponse, siteUrl } from "../_shared";
+import {
+  checkRateLimit,
+  apiResponse,
+  parseApiLocale,
+  siteUrl,
+} from "../_shared";
 
 const MAX_RESULTS = 10;
 
@@ -14,7 +19,8 @@ export async function GET(request: NextRequest) {
 
   const sp = request.nextUrl.searchParams;
   const q = sp.get("q");
-  const locale = sp.get("locale") ?? "en";
+  const locale = parseApiLocale(sp, rl);
+  if (locale instanceof NextResponse) return locale;
 
   if (!q) {
     return apiResponse(

--- a/apps/web/app/api/v1/job/route.test.ts
+++ b/apps/web/app/api/v1/job/route.test.ts
@@ -45,6 +45,15 @@ describe("GET /api/v1/job status contract (#3213)", () => {
     expect(mocks.getPostingDetail).not.toHaveBeenCalled();
   });
 
+  it("rejects unsupported locales before loading or linking a posting", async () => {
+    const { res, body } = await callRoute("?id=job-1&locale=xx");
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(body.error).toBe("Invalid 'locale' param. Supported: en, de, fr, it");
+    expect(mocks.getPostingDetail).not.toHaveBeenCalled();
+  });
+
   it("returns 404 when the requested posting is not found", async () => {
     mocks.getPostingDetail.mockResolvedValue(null);
 

--- a/apps/web/app/api/v1/job/route.ts
+++ b/apps/web/app/api/v1/job/route.ts
@@ -1,7 +1,12 @@
 import { type NextRequest, NextResponse } from "next/server";
 // Public REST routes use the plain service tier — see issue #3231.
 import { getPostingDetail } from "@/lib/services/search";
-import { checkRateLimit, apiResponse, siteUrl } from "../_shared";
+import {
+  checkRateLimit,
+  apiResponse,
+  parseApiLocale,
+  siteUrl,
+} from "../_shared";
 
 export async function GET(request: NextRequest) {
   const rl = await checkRateLimit(request);
@@ -9,7 +14,8 @@ export async function GET(request: NextRequest) {
 
   const sp = request.nextUrl.searchParams;
   const id = sp.get("id");
-  const locale = sp.get("locale") ?? "en";
+  const locale = parseApiLocale(sp, rl);
+  if (locale instanceof NextResponse) return locale;
 
   if (!id) {
     return apiResponse(

--- a/apps/web/app/api/v1/resolve/route.test.ts
+++ b/apps/web/app/api/v1/resolve/route.test.ts
@@ -98,6 +98,15 @@ describe("GET /api/v1/resolve?type=industries (issue #3228)", () => {
     expect(mocks.suggestIndustries).not.toHaveBeenCalled();
   });
 
+  it("rejects unsupported locales before resolving taxonomy values", async () => {
+    const { res, body } = await call("?type=industries&q=tech&locale=xx");
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(body.error).toBe("Invalid 'locale' param. Supported: en, de, fr, it");
+    expect(mocks.suggestIndustries).not.toHaveBeenCalled();
+  });
+
   it("emits a slug-shaped string for each industry, NOT the stringified id", async () => {
     mocks.suggestIndustries.mockResolvedValue([
       { id: 3, name: "Technology" },

--- a/apps/web/app/api/v1/resolve/route.ts
+++ b/apps/web/app/api/v1/resolve/route.ts
@@ -13,7 +13,7 @@ import {
 import { suggestIndustries } from "@/lib/services/company";
 import { CACHE_TTL_LONG } from "@/lib/cache-ttl";
 import { slugifyTitle } from "@/lib/watchlist-slug";
-import { checkRateLimit, apiResponse } from "../_shared";
+import { checkRateLimit, apiResponse, parseApiLocale } from "../_shared";
 
 const VALID_TYPES = [
   "locations",
@@ -30,7 +30,8 @@ export async function GET(request: NextRequest) {
   const sp = request.nextUrl.searchParams;
   const type = sp.get("type") as (typeof VALID_TYPES)[number] | null;
   const q = sp.get("q");
-  const locale = sp.get("locale") ?? "en";
+  const locale = parseApiLocale(sp, rl);
+  if (locale instanceof NextResponse) return locale;
 
   if (!type || !VALID_TYPES.includes(type)) {
     return apiResponse(

--- a/apps/web/app/api/v1/search/route.test.ts
+++ b/apps/web/app/api/v1/search/route.test.ts
@@ -121,9 +121,25 @@ describe("GET /api/v1/search", () => {
       error: "Invalid 'locale' param. Supported: en, de, fr, it",
     },
     {
+      caseName: "unknown work mode",
+      query: "?locale=en&wm=remote,bogus",
+      error: "Invalid 'wm' value(s): bogus. Supported: onsite, hybrid, remote",
+    },
+    {
+      caseName: "unknown employment type",
+      query: "?locale=en&etype=full_time,bogus",
+      error:
+        "Invalid 'etype' value(s): bogus. Supported: full_time, part_time, contract, internship, temporary, volunteer",
+    },
+    {
       caseName: "unknown document language",
       query: "?locale=en&lang=xx",
       error: "Invalid 'lang' value(s): xx. Supported: en, de, fr, it",
+    },
+    {
+      caseName: "UI-only all-language sentinel",
+      query: "?locale=en&lang=*",
+      error: "Invalid 'lang' value(s): *. Supported: en, de, fr, it",
     },
     {
       caseName: "empty document-language array",
@@ -253,10 +269,10 @@ describe("GET /api/v1/search", () => {
     expect(url.searchParams.get("q")).toBe("engineer");
   });
 
-  it("omits `lang=` from `moreAt` when not provided by the caller", async () => {
+  it("pins `moreAt` to all languages when the REST caller omits `lang`", async () => {
     const { body } = await callRoute("?locale=en&q=engineer");
     const url = new URL(body.moreAt as string);
-    expect(url.searchParams.has("lang")).toBe(false);
+    expect(url.searchParams.get("lang")).toBe("*");
     expect(url.searchParams.get("q")).toBe("engineer");
   });
 
@@ -338,6 +354,33 @@ describe("GET /api/v1/search", () => {
     const url = new URL(body.moreAt as string);
     expect(url.searchParams.get("etype")).toBe("full_time,internship");
     expect(url.searchParams.get("q")).toBe("designer");
+  });
+
+  it("returns 400 when an exact slug cannot be resolved", async () => {
+    mocks.parseSearchFilters.mockResolvedValue({
+      ...emptyParsed,
+      unresolvedExplicitSlugs: { loc: ["not-a-location"] },
+    });
+
+    const { res, body } = await callRoute("?locale=en&loc=not-a-location");
+
+    expect(res.status).toBe(400);
+    expect(body).toEqual({
+      error:
+        "Invalid 'loc' slug(s): not-a-location. Use /api/v1/resolve for exact slugs.",
+    });
+    expect(mocks.listTopCompanies).not.toHaveBeenCalled();
+    expect(mocks.searchJobs).not.toHaveBeenCalled();
+  });
+
+  it("pins salary-bearing `moreAt` links to EUR and drops caller salcur", async () => {
+    const { body } = await callRoute(
+      "?locale=en&q=engineer&sal=100000-&salcur=USD",
+    );
+    const url = new URL(body.moreAt as string);
+
+    expect(url.searchParams.get("sal")).toBe("100000-");
+    expect(url.searchParams.get("salcur")).toBe("EUR");
   });
 
   it("keeps rate-limit failures distinct from validation failures", async () => {

--- a/apps/web/app/api/v1/search/route.ts
+++ b/apps/web/app/api/v1/search/route.ts
@@ -7,14 +7,20 @@ import { type NextRequest, NextResponse } from "next/server";
 // two distinct surfaces.
 import { searchJobs, listTopCompanies } from "@/lib/services/search";
 import { parseSearchFilters } from "@/lib/services/search-input";
-import { isLocale, locales } from "@/lib/i18n";
+import { parsePublicSearchLanguages } from "@/lib/search/language-param";
 import { logExternalError } from "@/lib/safe-external-error";
+import { PUBLIC_SEARCH_QUERY_PARAMETERS } from "@jseek/mcp-server/public-api-contract";
 import {
   checkRateLimit,
   apiResponse,
+  PUBLIC_EMPLOYMENT_TYPE_VALUES,
+  PUBLIC_WORK_MODE_VALUES,
+  parseApiLocale,
   siteUrl,
   exploreUrl,
   type RateLimitInfo,
+  validatePublicEnumListParam,
+  validateResolvedPublicFilters,
 } from "../_shared";
 
 const MAX_COMPANIES = 5;
@@ -31,51 +37,6 @@ function searchErrorResponse(
   // outage (or a malformed request) from becoming a cached API response.
   response.headers.set("Cache-Control", "no-store");
   return response;
-}
-
-/**
- * Parse the optional `lang=` query param into a validated list of job
- * document language codes. Distinct from the UI ``locale`` (i18n labels
- * + currency formatting) — ``lang`` filters by the language the posting
- * itself is written in (`job_posting.locales` in Typesense).
- *
- * - absent → returns ``null`` (caller should pass ``[]`` to ``searchJobs`` /
- *   ``listTopCompanies`` so no language filter is applied — this is a public
- *   REST API, callers are stateless and should not be biased by the UI locale)
- * - present but empty → returns a ``400`` validation error
- * - comma-separated codes (e.g. ``de`` or ``de,fr``) → returns the
- *   validated subset. Unknown codes cause a ``400``.
- *
- * Validated against the same set of locales the UI supports
- * (`apps/web/src/lib/i18n.ts` :data:`locales`).
- */
-function parseLangParam(raw: string | null): {
-  ok: true;
-  langs: string[] | null;
-} | {
-  ok: false;
-  error: string;
-} {
-  if (raw === null) return { ok: true, langs: null };
-  const parts = raw
-    .split(",")
-    .map((s) => s.trim())
-    .filter(Boolean);
-  if (parts.length === 0) {
-    return {
-      ok: false,
-      error: `Invalid 'lang' param: must be a comma-separated list of language codes (${locales.join(", ")})`,
-    };
-  }
-  const invalid = parts.filter((c) => !isLocale(c));
-  if (invalid.length > 0) {
-    return {
-      ok: false,
-      error: `Invalid 'lang' value(s): ${invalid.join(", ")}. Supported: ${locales.join(", ")}`,
-    };
-  }
-  // Dedupe preserving the validated form
-  return { ok: true, langs: Array.from(new Set(parts)) };
 }
 
 function parseIntegerRangeParam(
@@ -135,33 +96,33 @@ export async function GET(request: NextRequest) {
   if (rl instanceof NextResponse) return rl;
 
   const sp = request.nextUrl.searchParams;
-  const q = sp.get("q") ?? undefined;
-  const loc = sp.get("loc") ?? undefined;
-  const occ = sp.get("occ") ?? undefined;
-  const sen = sp.get("sen") ?? undefined;
-  const tech = sp.get("tech") ?? undefined;
-  const wm = sp.get("wm") ?? undefined;
-  const etype = sp.get("etype") ?? undefined;
-  const sal = sp.get("sal") ?? undefined;
-  const exp = sp.get("exp") ?? undefined;
-  const locale = sp.get("locale") ?? "en";
+  const rawParams = Object.fromEntries(
+    PUBLIC_SEARCH_QUERY_PARAMETERS.map((name) => [
+      name,
+      sp.get(name) ?? undefined,
+    ]),
+  ) as Record<(typeof PUBLIC_SEARCH_QUERY_PARAMETERS)[number], string | undefined>;
+  const { q, loc, occ, sen, tech, wm, etype, sal, exp, lang } = rawParams;
 
-  if (!isLocale(locale)) {
-    return searchErrorResponse(
-      `Invalid 'locale' param. Supported: ${locales.join(", ")}`,
-      400,
-      rl,
-    );
+  const locale = parseApiLocale(sp, rl);
+  if (locale instanceof NextResponse) return locale;
+
+  for (const [name, raw, supported] of [
+    ["wm", wm, PUBLIC_WORK_MODE_VALUES],
+    ["etype", etype, PUBLIC_EMPLOYMENT_TYPE_VALUES],
+  ] as const) {
+    const invalid = validatePublicEnumListParam(name, raw, supported, rl);
+    if (invalid) return invalid;
   }
 
-  const langParsed = parseLangParam(sp.get("lang"));
+  const langParsed = parsePublicSearchLanguages(lang);
   if (!langParsed.ok) {
     return searchErrorResponse(langParsed.error, 400, rl);
   }
   // `searchJobs` / `listTopCompanies` treat `languages: []` as "no
   // filter" (see `apps/web/src/lib/search/typesense-filters.ts` —
   // `filters.languages?.length` guards the locales clause).
-  const languages = langParsed.langs ?? [];
+  const languages = langParsed.languages ?? [];
 
   const salaryRange = parseIntegerRangeParam("sal", sal);
   if (!salaryRange.ok) {
@@ -184,6 +145,8 @@ export async function GET(request: NextRequest) {
     );
     return searchErrorResponse("Search service unavailable", 500, rl);
   }
+  const unresolved = validateResolvedPublicFilters(parsed, rl);
+  if (unresolved) return unresolved;
 
   const locationIds =
     parsed.locations.length > 0 ? parsed.locations.map((l) => l.id) : undefined;

--- a/apps/web/app/api/v1/taxonomies/route.test.ts
+++ b/apps/web/app/api/v1/taxonomies/route.test.ts
@@ -56,6 +56,19 @@ describe("GET /api/v1/taxonomies industries service boundary (#3331)", () => {
     expect(mocks.getAllTechnologiesGrouped).not.toHaveBeenCalled();
   });
 
+  it("rejects unsupported locales before loading taxonomy values", async () => {
+    const res = await GET(makeReq("?type=industries&locale=xx"));
+    const body = (await res.json()) as { error?: string };
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(body.error).toBe("Invalid 'locale' param. Supported: en, de, fr, it");
+    expect(mocks.suggestIndustries).not.toHaveBeenCalled();
+    expect(mocks.getAllSeniorities).not.toHaveBeenCalled();
+    expect(mocks.getAllOccupationsGrouped).not.toHaveBeenCalled();
+    expect(mocks.getAllTechnologiesGrouped).not.toHaveBeenCalled();
+  });
+
   it("resolves industries through the company service tier", async () => {
     mocks.suggestIndustries.mockResolvedValue([
       { id: 3, name: "Technology" },

--- a/apps/web/app/api/v1/taxonomies/route.ts
+++ b/apps/web/app/api/v1/taxonomies/route.ts
@@ -11,7 +11,7 @@ import {
 } from "@/lib/services/taxonomy";
 import { suggestIndustries } from "@/lib/services/company";
 import { CACHE_TTL_LONG } from "@/lib/cache-ttl";
-import { checkRateLimit, apiResponse } from "../_shared";
+import { checkRateLimit, apiResponse, parseApiLocale } from "../_shared";
 
 const VALID_TYPES = ["seniority", "occupations", "technologies", "industries"] as const;
 
@@ -21,7 +21,8 @@ export async function GET(request: NextRequest) {
 
   const sp = request.nextUrl.searchParams;
   const type = sp.get("type") as (typeof VALID_TYPES)[number] | null;
-  const locale = sp.get("locale") ?? "en";
+  const locale = parseApiLocale(sp, rl);
+  if (locale instanceof NextResponse) return locale;
 
   if (!type || !VALID_TYPES.includes(type)) {
     return apiResponse(

--- a/apps/web/app/api/v1/watchlist/create/route.test.ts
+++ b/apps/web/app/api/v1/watchlist/create/route.test.ts
@@ -70,6 +70,47 @@ describe("GET /api/v1/watchlist/create — filter params", () => {
     expect(mocks.listTopCompanies).not.toHaveBeenCalled();
   });
 
+  it("rejects unsupported locales before parsing or linking filters", async () => {
+    const { res, body } = await callRoute("?title=Design%20roles&locale=xx");
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(body.error).toBe("Invalid 'locale' param. Supported: en, de, fr, it");
+    expect(mocks.parseSearchFilters).not.toHaveBeenCalled();
+    expect(mocks.searchJobs).not.toHaveBeenCalled();
+    expect(mocks.listTopCompanies).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported finite-list values before parsing filters", async () => {
+    const { res, body } = await callRoute(
+      "?locale=en&title=Roles&etype=contract,unknown",
+    );
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe(
+      "Invalid 'etype' value(s): unknown. Supported: full_time, part_time, contract, internship, temporary, volunteer",
+    );
+    expect(mocks.parseSearchFilters).not.toHaveBeenCalled();
+  });
+
+  it("rejects unresolved exact slugs before running the preview search", async () => {
+    mocks.parseSearchFilters.mockResolvedValue({
+      ...emptyParsed,
+      unresolvedExplicitSlugs: { tech: ["not-a-tech"] },
+    });
+
+    const { res, body } = await callRoute(
+      "?locale=en&title=Roles&tech=not-a-tech",
+    );
+
+    expect(res.status).toBe(400);
+    expect(body.error).toBe(
+      "Invalid 'tech' slug(s): not-a-tech. Use /api/v1/resolve for exact slugs.",
+    );
+    expect(mocks.listTopCompanies).not.toHaveBeenCalled();
+    expect(mocks.searchJobs).not.toHaveBeenCalled();
+  });
+
   it("forwards `etype=` to the parser, preview search, and create URL", async () => {
     mocks.parseSearchFilters.mockResolvedValue({
       ...emptyParsed,

--- a/apps/web/app/api/v1/watchlist/create/route.ts
+++ b/apps/web/app/api/v1/watchlist/create/route.ts
@@ -2,13 +2,25 @@ import { type NextRequest, NextResponse } from "next/server";
 // Public REST routes use the plain service tier — see issue #3231.
 import { listTopCompanies, searchJobs } from "@/lib/services/search";
 import { parseSearchFilters } from "@/lib/services/search-input";
-import { checkRateLimit, apiResponse, siteUrl } from "../../_shared";
+import {
+  checkRateLimit,
+  apiResponse,
+  PUBLIC_EMPLOYMENT_TYPE_VALUES,
+  PUBLIC_WORK_MODE_VALUES,
+  parseApiLocale,
+  siteUrl,
+  validatePublicEnumListParam,
+  validateResolvedPublicFilters,
+} from "../../_shared";
 
 export async function GET(request: NextRequest) {
   const rl = await checkRateLimit(request);
   if (rl instanceof NextResponse) return rl;
 
   const sp = request.nextUrl.searchParams;
+  const locale = parseApiLocale(sp, rl);
+  if (locale instanceof NextResponse) return locale;
+
   const title = sp.get("title");
   if (!title) {
     return apiResponse(
@@ -17,7 +29,6 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const locale = sp.get("locale") ?? "en";
   const q = sp.get("q") ?? undefined;
   const loc = sp.get("loc") ?? undefined;
   const occ = sp.get("occ") ?? undefined;
@@ -31,8 +42,18 @@ export async function GET(request: NextRequest) {
   const description = sp.get("description") ?? undefined;
   const companies = sp.get("companies") ?? undefined;
 
+  for (const [name, raw, supported] of [
+    ["wm", wm, PUBLIC_WORK_MODE_VALUES],
+    ["etype", etype, PUBLIC_EMPLOYMENT_TYPE_VALUES],
+  ] as const) {
+    const invalid = validatePublicEnumListParam(name, raw, supported, rl);
+    if (invalid) return invalid;
+  }
+
   // Resolve slugs to get matching counts for the preview
   const parsed = await parseSearchFilters({ q, loc, occ, sen, tech, wm, etype, locale });
+  const unresolved = validateResolvedPublicFilters(parsed, rl);
+  if (unresolved) return unresolved;
 
   const locationIds =
     parsed.locations.length > 0 ? parsed.locations.map((l) => l.id) : undefined;

--- a/apps/web/app/api/v1/watchlists/route.test.ts
+++ b/apps/web/app/api/v1/watchlists/route.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("server-only", () => ({}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  apiLimiter: {
+    limit: vi.fn(async () => {
+      throw new Error("no redis in unit tests");
+    }),
+  },
+  getClientIp: () => "test-ip",
+}));
+
+const mocks = vi.hoisted(() => ({
+  searchPublicWatchlists: vi.fn(),
+  getPopularWatchlists: vi.fn(),
+}));
+
+vi.mock("@/lib/services/watchlists", () => ({
+  searchPublicWatchlists: mocks.searchPublicWatchlists,
+  getPopularWatchlists: mocks.getPopularWatchlists,
+}));
+
+import { GET } from "./route";
+
+function makeReq(qs: string): NextRequest {
+  return new NextRequest(`http://localhost/api/v1/watchlists${qs}`);
+}
+
+describe("GET /api/v1/watchlists locale contract (#6132)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects unsupported locales before querying or constructing links", async () => {
+    const res = await GET(makeReq("?q=engineering&locale=xx"));
+    const body = (await res.json()) as { error?: string };
+
+    expect(res.status).toBe(400);
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(body.error).toBe("Invalid 'locale' param. Supported: en, de, fr, it");
+    expect(mocks.searchPublicWatchlists).not.toHaveBeenCalled();
+    expect(mocks.getPopularWatchlists).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/app/api/v1/watchlists/route.ts
+++ b/apps/web/app/api/v1/watchlists/route.ts
@@ -3,7 +3,12 @@ import {
   searchPublicWatchlists,
   getPopularWatchlists,
 } from "@/lib/services/watchlists";
-import { checkRateLimit, apiResponse, siteUrl } from "../_shared";
+import {
+  checkRateLimit,
+  apiResponse,
+  parseApiLocale,
+  siteUrl,
+} from "../_shared";
 
 const MAX_RESULTS = 10;
 
@@ -13,7 +18,8 @@ export async function GET(request: NextRequest) {
 
   const sp = request.nextUrl.searchParams;
   const q = sp.get("q") ?? "";
-  const locale = sp.get("locale") ?? "en";
+  const locale = parseApiLocale(sp, rl);
+  if (locale instanceof NextResponse) return locale;
 
   const result = q
     ? await searchPublicWatchlists({

--- a/apps/web/public/api/openapi.json
+++ b/apps/web/public/api/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Job Seek API",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Public API for AI agents to search jobs, companies, watchlists, and taxonomies on jseek.co. Rate limited to 30 requests per minute per IP.\n\nIMPORTANT: Filter parameters (loc, occ, sen, tech) require exact slugs, NOT freetext. Use /api/v1/resolve to convert freetext to slugs first, or /api/v1/taxonomies to list all valid slugs. Passing freetext like loc=Zurich will NOT work — use loc=zurich (the slug)."
   },
   "servers": [{ "url": "https://jseek.co" }],
@@ -11,18 +11,18 @@
       "get": {
         "operationId": "searchJobs",
         "summary": "Search jobs across companies",
-        "description": "Returns up to 5 companies with their top 3 job postings matching the filters. Only 'q' accepts freetext. All other filter params (loc, occ, sen, tech) require exact slugs — use /api/v1/resolve to convert freetext to slugs first.\n\nUI ``locale`` (response labels) is distinct from ``lang`` (job document language). Omitting ``lang`` returns postings in any language — pass ``lang=en`` (or a comma-separated list) to filter to specific posting languages. Malformed or unsupported parameters return HTTP 400 with an ``{\"error\": string}`` body; provider failures use HTTP 500 and never include provider details.",
+        "description": "Returns up to 5 companies with their top 3 job postings matching the filters. Only 'q' accepts freetext. Slug filters (loc, occ, sen, tech) require exact slugs — use /api/v1/resolve to convert freetext to slugs first.\n\nUI ``locale`` (response labels) is distinct from ``lang`` (job document language). Omitting ``lang`` returns postings in any language — pass ``lang=en`` (or a comma-separated list) to filter to specific posting languages. Unsupported locale, language, enum, slug, and range values return HTTP 400 with an ``{\"error\": string}`` body. Provider failures use HTTP 500 and never include provider details.",
         "parameters": [
           { "name": "q", "in": "query", "schema": { "type": "string" }, "description": "Keywords (free text search)" },
           { "name": "loc", "in": "query", "schema": { "type": "string" }, "description": "Location slugs, comma-separated (exact slugs only, use /resolve to look up)" },
           { "name": "occ", "in": "query", "schema": { "type": "string" }, "description": "Occupation slugs, comma-separated (exact slugs only, use /resolve to look up)" },
           { "name": "sen", "in": "query", "schema": { "type": "string" }, "description": "Seniority slugs, comma-separated (exact slugs only, use /resolve to look up)" },
           { "name": "tech", "in": "query", "schema": { "type": "string" }, "description": "Technology slugs, comma-separated (exact slugs only, use /resolve to look up)" },
-          { "name": "wm", "in": "query", "schema": { "type": "string", "enum": ["onsite", "hybrid", "remote"] }, "description": "Work-mode filter (single value)" },
+          { "name": "wm", "in": "query", "style": "form", "explode": false, "schema": { "type": "array", "items": { "type": "string", "enum": ["onsite", "hybrid", "remote"] } }, "description": "Work modes, comma-separated. Unsupported values return HTTP 400." },
+          { "name": "etype", "in": "query", "style": "form", "explode": false, "schema": { "type": "array", "items": { "type": "string", "enum": ["full_time", "part_time", "contract", "internship", "temporary", "volunteer"] } }, "description": "Employment types, comma-separated. Unsupported values return HTTP 400." },
           { "name": "sal", "in": "query", "schema": { "type": "string", "pattern": "^\\s*(?:\\d+\\s*-\\s*\\d+|\\d+\\s*-\\s*|-\\s*\\d+)\\s*$", "examples": ["80000-150000", "80000-", "-150000"] }, "description": "Salary range in EUR with non-negative integer bounds. Closed (min-max) and one-sided open ranges (min- or -max) are accepted; at least one bound is required. Omit the parameter for no salary bound." },
-          { "name": "salcur", "in": "query", "schema": { "type": "string" }, "description": "Salary currency code (e.g. USD, EUR)" },
           { "name": "exp", "in": "query", "schema": { "type": "string", "pattern": "^\\s*(?:\\d+\\s*-\\s*\\d+|\\d+\\s*-\\s*|-\\s*\\d+)\\s*$", "examples": ["3-10", "3-", "-10"] }, "description": "Experience range in years with non-negative integer bounds. Closed (min-max) and one-sided open ranges (min- or -max) are accepted; at least one bound is required. Omit the parameter for no experience bound." },
-          { "name": "lang", "in": "query", "schema": { "type": "string" }, "description": "Job document language filter (comma-separated codes — en, de, fr, it). Distinct from ``locale`` (which controls response labels/currency formatting). Omit to return postings in any language; the API does not fall back to a cookie or to ``locale`` (public APIs are stateless)." },
+          { "name": "lang", "in": "query", "style": "form", "explode": false, "schema": { "type": "array", "items": { "type": "string", "enum": ["en", "de", "fr", "it"] } }, "description": "Job document language filter (comma-separated codes). Distinct from ``locale`` (which controls response labels/currency formatting). Omit to return postings in any language; the API does not fall back to a cookie or to ``locale`` (public APIs are stateless)." },
           { "name": "locale", "in": "query", "schema": { "type": "string", "default": "en", "enum": ["en", "de", "fr", "it"] }, "description": "UI locale for response labels and currency formatting (en, de, fr, it). Does NOT filter postings by document language — use ``lang`` for that." }
         ],
         "responses": {
@@ -59,7 +59,7 @@
                       }
                     },
                     "totalCompanies": { "type": "integer" },
-                    "moreAt": { "type": "string", "description": "Link to full results on jseek.co" }
+                    "moreAt": { "type": "string", "description": "Link to the equivalent full result set on jseek.co. When ``lang`` is omitted, the link carries the UI's ``*`` sentinel to preserve the API's all-language default." }
                   }
                 }
               }
@@ -171,7 +171,7 @@
         "description": "Returns structured metadata for a single job posting: salary, technologies, seniority, experience, locations. Does not include the job description text — visit the returned URL on jseek.co to read the full posting.",
         "parameters": [
           { "name": "id", "in": "query", "required": true, "schema": { "type": "string" }, "description": "Job posting UUID (from search results topPostings[].id)" },
-          { "name": "locale", "in": "query", "schema": { "type": "string", "default": "en" }, "description": "Response language (en, de, fr, it)" }
+          { "name": "locale", "in": "query", "schema": { "type": "string", "default": "en", "enum": ["en", "de", "fr", "it"] }, "description": "Response language (en, de, fr, it)" }
         ],
         "responses": {
           "200": {
@@ -247,7 +247,7 @@
               }
             }
           },
-          "400": { "description": "Missing required parameter: id" },
+          "400": { "$ref": "#/components/responses/BadRequest" },
           "404": { "description": "Job posting not found" },
           "429": { "description": "Rate limit exceeded" }
         }
@@ -260,7 +260,7 @@
         "description": "Returns all valid slugs for a taxonomy type. Use these exact slugs in filter params. For locations, use /api/v1/resolve instead (too many to enumerate).",
         "parameters": [
           { "name": "type", "in": "query", "required": true, "schema": { "type": "string", "enum": ["seniority", "occupations", "technologies", "industries"] } },
-          { "name": "locale", "in": "query", "schema": { "type": "string", "default": "en" } }
+          { "name": "locale", "in": "query", "schema": { "type": "string", "default": "en", "enum": ["en", "de", "fr", "it"] } }
         ],
         "responses": {
           "200": {
@@ -276,7 +276,8 @@
                 }
               }
             }
-          }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" }
         }
       }
     },
@@ -287,7 +288,7 @@
         "description": "Returns up to 10 companies matching the query. Use company slugs in watchlist creation.",
         "parameters": [
           { "name": "q", "in": "query", "required": true, "schema": { "type": "string" }, "description": "Company name query (min 2 chars)" },
-          { "name": "locale", "in": "query", "schema": { "type": "string", "default": "en" } }
+          { "name": "locale", "in": "query", "schema": { "type": "string", "default": "en", "enum": ["en", "de", "fr", "it"] } }
         ],
         "responses": {
           "200": {
@@ -313,7 +314,8 @@
                 }
               }
             }
-          }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" }
         }
       }
     },
@@ -324,7 +326,7 @@
         "description": "Returns up to 10 public watchlists. Without query, returns most popular.",
         "parameters": [
           { "name": "q", "in": "query", "schema": { "type": "string" }, "description": "Search query for watchlist title/description" },
-          { "name": "locale", "in": "query", "schema": { "type": "string", "default": "en" } }
+          { "name": "locale", "in": "query", "schema": { "type": "string", "default": "en", "enum": ["en", "de", "fr", "it"] } }
         ],
         "responses": {
           "200": {
@@ -351,7 +353,8 @@
                 }
               }
             }
-          }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" }
         }
       }
     },
@@ -359,7 +362,7 @@
       "get": {
         "operationId": "createWatchlistLink",
         "summary": "Generate a prefilled watchlist creation link",
-        "description": "Returns a URL that opens the watchlist creation page with filters, title, and description prefilled. The user must log in to save. Also returns a preview with matching job/company counts so the agent can verify the filters are useful before handing off.",
+        "description": "Returns a URL that opens the watchlist creation page with filters, title, and description prefilled. The user must log in to save. Also returns a preview with matching job/company counts so the agent can verify the filters are useful before handing off. Unsupported locale, enum, and exact-slug values return HTTP 400.",
         "parameters": [
           { "name": "title", "in": "query", "required": true, "schema": { "type": "string" }, "description": "Watchlist title" },
           { "name": "description", "in": "query", "schema": { "type": "string" }, "description": "Watchlist description" },
@@ -368,11 +371,13 @@
           { "name": "occ", "in": "query", "schema": { "type": "string" } },
           { "name": "sen", "in": "query", "schema": { "type": "string" } },
           { "name": "tech", "in": "query", "schema": { "type": "string" } },
+          { "name": "wm", "in": "query", "style": "form", "explode": false, "schema": { "type": "array", "items": { "type": "string", "enum": ["onsite", "hybrid", "remote"] } }, "description": "Work modes, comma-separated" },
+          { "name": "etype", "in": "query", "style": "form", "explode": false, "schema": { "type": "array", "items": { "type": "string", "enum": ["full_time", "part_time", "contract", "internship", "temporary", "volunteer"] } }, "description": "Employment types, comma-separated" },
           { "name": "sal", "in": "query", "schema": { "type": "string" } },
           { "name": "salcur", "in": "query", "schema": { "type": "string" } },
           { "name": "exp", "in": "query", "schema": { "type": "string" } },
           { "name": "companies", "in": "query", "schema": { "type": "string" }, "description": "Company slugs, comma-separated" },
-          { "name": "locale", "in": "query", "schema": { "type": "string", "default": "en" } }
+          { "name": "locale", "in": "query", "schema": { "type": "string", "default": "en", "enum": ["en", "de", "fr", "it"] } }
         ],
         "responses": {
           "200": {
@@ -396,7 +401,8 @@
                 }
               }
             }
-          }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" }
         }
       }
     },
@@ -408,7 +414,7 @@
         "parameters": [
           { "name": "type", "in": "query", "required": true, "schema": { "type": "string", "enum": ["locations", "occupations", "seniority", "technologies", "industries"] }, "description": "Which taxonomy to search" },
           { "name": "q", "in": "query", "required": true, "schema": { "type": "string" }, "description": "Freetext query (min 2 chars)" },
-          { "name": "locale", "in": "query", "schema": { "type": "string", "default": "en" }, "description": "Response language" }
+          { "name": "locale", "in": "query", "schema": { "type": "string", "default": "en", "enum": ["en", "de", "fr", "it"] }, "description": "Response language" }
         ],
         "responses": {
           "200": {
@@ -437,12 +443,23 @@
                 }
               }
             }
-          }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" }
         }
       }
     }
   },
   "components": {
+    "responses": {
+      "BadRequest": {
+        "description": "A required parameter is missing or a parameter value is unsupported. The response is not cacheable.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+          }
+        }
+      }
+    },
     "schemas": {
       "ErrorResponse": {
         "type": "object",

--- a/apps/web/script/check-blog-mention-snapshot.ts
+++ b/apps/web/script/check-blog-mention-snapshot.ts
@@ -220,6 +220,7 @@ const FORBIDDEN_LOCAL_BOUNDARIES = [
   "/src/lib/services/",
 ] as const;
 const ALLOWED_EXTERNAL_PACKAGES = new Set([
+  "@jseek/mcp-server/public-api-contract",
   "@lingui/core",
   "@lingui/react/server",
   "lucide-react",

--- a/apps/web/src/components/__tests__/SearchStateProvider.test.tsx
+++ b/apps/web/src/components/__tests__/SearchStateProvider.test.tsx
@@ -63,6 +63,14 @@ describe("buildCacheKey", () => {
     );
   });
 
+  it("differentiates language-filtered snapshots", () => {
+    expect(
+      buildCacheKey([], [], [], [], [], { languages: ["de"] }),
+    ).not.toBe(
+      buildCacheKey([], [], [], [], [], { languages: ["en"] }),
+    );
+  });
+
   // #3276 — keyword strings sort with `canonicalStringCompare` so accented
   // entries don't fragment the snapshot key across input permutations.
   it("collapses accented keyword permutations onto one key", () => {
@@ -151,6 +159,34 @@ describe("shouldRestoreSnapshot — #2989 regression", () => {
     });
     const currentKey = buildCacheKey([], [], [], [], []);
     expect(shouldRestoreSnapshot(cached, currentKey)).toBe(false);
+  });
+
+  it("does NOT restore a default-language empty snapshot with no result filters (#3354)", () => {
+    const currentKey = buildCacheKey([], [], [], [], [], {
+      languages: ["en"],
+    });
+    const cached = makeSnapshot({
+      cacheKey: currentKey,
+      companies: [],
+      totalCompanies: 0,
+      hasResultFilters: false,
+    });
+
+    expect(shouldRestoreSnapshot(cached, currentKey)).toBe(false);
+  });
+
+  it("keeps legitimate empty snapshots for an explicit language filter", () => {
+    const currentKey = buildCacheKey([], [], [], [], [], {
+      languages: ["de"],
+    });
+    const cached = makeSnapshot({
+      cacheKey: currentKey,
+      companies: [],
+      totalCompanies: 0,
+      hasResultFilters: true,
+    });
+
+    expect(shouldRestoreSnapshot(cached, currentKey)).toBe(true);
   });
 
   /**

--- a/apps/web/src/components/providers/SearchStateProvider.tsx
+++ b/apps/web/src/components/providers/SearchStateProvider.tsx
@@ -31,6 +31,8 @@ export interface SearchStateSnapshot {
   showPostingId: string | null;
   scrollY: number;
   cacheKey: string;
+  /** Explicit result filters, excluding locale-derived language defaults. */
+  hasResultFilters?: boolean;
 }
 
 export function buildCacheKey(
@@ -47,6 +49,7 @@ export function buildCacheKey(
     salaryCurrency?: string;
     experienceMin?: number;
     experienceMax?: number;
+    languages?: string[];
   },
 ): string {
   // String dimensions (keywords) sort with `canonicalStringCompare`
@@ -72,6 +75,7 @@ export function buildCacheKey(
       filters.salaryCurrency ?? "",
       filters.experienceMin == null ? "" : String(filters.experienceMin),
       filters.experienceMax == null ? "" : String(filters.experienceMax),
+      [...(filters.languages ?? [])].sort(canonicalStringCompare).join(","),
     );
   }
   return parts.join("|");
@@ -90,8 +94,9 @@ export function buildCacheKey(
  * prerendered ``initialData`` had ~10 top companies. See #2989.
  *
  * Additional guard (#3354): never restore a snapshot whose
- * ``companies`` is empty AND whose ``cacheKey`` represents the no-
- * filter view (``||||``). The snapshot only serves the
+ * ``companies`` is empty and whose explicit ``hasResultFilters`` flag is
+ * false. Legacy snapshots fall back to the historical no-filter cache-key
+ * sentinels. The snapshot only serves the
  * "return to the same view after a posting-detail dive" use case — but
  * an empty unfiltered result is never a legitimate destination (the
  * homepage always has top companies). The empty state arises only from
@@ -103,7 +108,7 @@ export function buildCacheKey(
  * Restoration semantics now:
  *   - Same URL filters (or both empty), snapshot has results → restore.
  *   - Same URL filters (or both empty), snapshot has empty companies
- *     AND the no-filter cacheKey → ignore (#3354 poison guard).
+ *     AND no explicit result filters → ignore (#3354 poison guard).
  *   - Different URL filters → ignore the snapshot, render the fresh
  *     ``initialData`` from the server prerender / re-fetch.
  *
@@ -127,6 +132,12 @@ export function shouldRestoreSnapshot(
   // can render. Filtered empty snapshots stay restorable because a
   // 0-result keyword search IS a legitimate destination the user may
   // want to return to.
+  if (
+    cached.hasResultFilters === false &&
+    cached.companies.length === 0
+  ) {
+    return false;
+  }
   if (
     (cached.cacheKey === NO_FILTER_CACHE_KEY ||
       cached.cacheKey === LEGACY_NO_FILTER_CACHE_KEY) &&

--- a/apps/web/src/lib/actions/__tests__/explore-page-data-salary-currency.test.ts
+++ b/apps/web/src/lib/actions/__tests__/explore-page-data-salary-currency.test.ts
@@ -44,7 +44,7 @@ vi.mock("@/lib/actions/search-input", () => ({
 import { fetchExplorePageData, fetchExplorePageDefaults } from "../explore-page-data";
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  vi.resetAllMocks();
   stubTypesenseConfiguration(true);
   mocks.searchJobs.mockResolvedValue({
     companies: [],
@@ -289,5 +289,57 @@ describe("Explore repository fallback — configuration boundary (#2640)", () =>
     expect(data.parsed.keywords).toEqual(["python"]);
     expect(mocks.parseSearchFilters).not.toHaveBeenCalled();
     expect(mocks.searchJobs).not.toHaveBeenCalled();
+  });
+
+  it("preserves an all-language override through a secretless fallback", async () => {
+    stubTypesenseConfiguration(false);
+
+    const data = await fetchExplorePageData({
+      searchParams: { lang: "*" },
+      locale: "en",
+    });
+
+    expect(data.repositoryFallbackCompanies).toHaveLength(10);
+    expect(data.languages).toEqual([]);
+    expect(data.languageOverride).toEqual([]);
+    expect(mocks.parseSearchFilters).not.toHaveBeenCalled();
+    expect(mocks.searchJobs).not.toHaveBeenCalled();
+    expect(mocks.listTopCompanies).not.toHaveBeenCalled();
+  });
+});
+
+describe("fetchExplorePageData — public language override (#6132)", () => {
+  it("uses `lang` instead of locale/preferences for the linked result set", async () => {
+    const data = await fetchExplorePageData({
+      searchParams: { lang: "de,fr" },
+      locale: "en",
+    });
+
+    const callArgs = mocks.listTopCompanies.mock.calls[0][0];
+    expect(callArgs.languages).toEqual(["de", "fr"]);
+    expect(data.languages).toEqual(["de", "fr"]);
+    expect(data.languageOverride).toEqual(["de", "fr"]);
+    expect(data.jobLanguages).toEqual([]);
+  });
+
+  it("maps the Explore `*` sentinel to REST's all-language semantics", async () => {
+    const data = await fetchExplorePageData({
+      searchParams: { lang: "*" },
+      locale: "en",
+    });
+
+    expect(mocks.listTopCompanies.mock.calls[0][0].languages).toEqual([]);
+    expect(data.languages).toEqual([]);
+    expect(data.languageOverride).toEqual([]);
+  });
+
+  it("falls back to the normal preference semantics without `lang`", async () => {
+    const data = await fetchExplorePageData({
+      searchParams: {},
+      locale: "it",
+    });
+
+    expect(mocks.listTopCompanies.mock.calls[0][0].languages).toEqual(["it"]);
+    expect(data.languageOverride).toBeNull();
   });
 });

--- a/apps/web/src/lib/actions/__tests__/search-input.test.ts
+++ b/apps/web/src/lib/actions/__tests__/search-input.test.ts
@@ -161,3 +161,34 @@ describe("parseSearchFilters — employment type URL param (#3218)", () => {
     expect(r.employmentTypes).toEqual(["full_time", "temporary"]);
   });
 });
+
+describe("parseSearchFilters — explicit slug resolution contract (#6132)", () => {
+  it("reports unresolved exact slugs without changing lenient UI results", async () => {
+    mocks.resolveLocationSlugs.mockResolvedValue(
+      new Map([
+        [
+          "zurich",
+          {
+            id: 1,
+            slug: "zurich",
+            name: "Zurich",
+            type: "city",
+            parentName: "Switzerland",
+          },
+        ],
+      ]),
+    );
+
+    const result = await parseSearchFilters({
+      loc: "zurich,not-a-location",
+      tech: "not-a-tech",
+      locale: "en",
+    });
+
+    expect(result.locations.map(({ slug }) => slug)).toEqual(["zurich"]);
+    expect(result.unresolvedExplicitSlugs).toEqual({
+      loc: ["not-a-location"],
+      tech: ["not-a-tech"],
+    });
+  });
+});

--- a/apps/web/src/lib/actions/explore-page-data.ts
+++ b/apps/web/src/lib/actions/explore-page-data.ts
@@ -14,6 +14,7 @@ import { getSession } from "@/lib/sessionCache";
 import { firstOf, idsOrUndefined, parseRangeParam, getGeoFromHeaders } from "@/lib/search/params";
 import { parseEmploymentTypeParam, parseWorkModeParam } from "@/lib/search/query-params";
 import { convertToEur } from "@/lib/salary";
+import { parseExploreSearchLanguages } from "@/lib/search/language-param";
 import type { SearchResponse } from "@/lib/search";
 import {
   getExploreRepositoryFallbackCompanies,
@@ -47,6 +48,8 @@ export interface ExploreData {
   displayCurrency: string;
   jobLanguages: string[];
   languages: string[];
+  /** Explicit public-API language override carried by a `moreAt` URL. */
+  languageOverride?: string[] | null;
   userLat: number | undefined;
   userLng: number | undefined;
   salaryCurrencyParam: string;
@@ -101,6 +104,8 @@ export async function fetchExplorePageData(params: {
   const salcur = firstOf(searchParams.salcur);
   const exp = firstOf(searchParams.exp);
   const typesenseConfigured = hasTypesenseSearchConfiguration();
+  const languageParam = parseExploreSearchLanguages(firstOf(searchParams.lang));
+  const languageOverride = languageParam.ok ? languageParam.languages : null;
 
   const { userLat, userLng } = await getGeoFromHeaders();
 
@@ -120,7 +125,7 @@ export async function fetchExplorePageData(params: {
 
   const jobLanguages = prefs?.jobLanguages ?? anonJobLangs ?? [];
   const displayCurrency = prefs?.displayCurrency ?? "EUR";
-  const languages = resolveJobLanguages(jobLanguages, locale);
+  const languages = languageOverride ?? resolveJobLanguages(jobLanguages, locale);
 
   const locationIds = idsOrUndefined(parsed.locations);
   const occupationIds = idsOrUndefined(parsed.occupations);
@@ -191,6 +196,7 @@ export async function fetchExplorePageData(params: {
     displayCurrency,
     jobLanguages,
     languages,
+    languageOverride,
     userLat,
     userLng,
     salaryCurrencyParam,
@@ -259,6 +265,7 @@ export async function fetchExplorePageDefaults(params: {
     displayCurrency,
     jobLanguages,
     languages,
+    languageOverride: null,
     userLat: undefined,
     userLng: undefined,
     salaryCurrencyParam: displayCurrency,

--- a/apps/web/src/lib/i18n.ts
+++ b/apps/web/src/lib/i18n.ts
@@ -1,9 +1,13 @@
 import { type I18n, type Messages, setupI18n } from "@lingui/core";
 import { setI18n } from "@lingui/react/server";
+import {
+  API_LOCALES,
+  DEFAULT_API_LOCALE,
+} from "@jseek/mcp-server/public-api-contract";
 
-export const locales = ["en", "de", "fr", "it"] as const;
+export const locales = API_LOCALES;
 export type Locale = (typeof locales)[number];
-export const defaultLocale: Locale = "en";
+export const defaultLocale: Locale = DEFAULT_API_LOCALE;
 
 export function isLocale(value: string): value is Locale {
   return locales.includes(value as Locale);

--- a/apps/web/src/lib/search/language-param.ts
+++ b/apps/web/src/lib/search/language-param.ts
@@ -1,0 +1,40 @@
+import { API_LOCALES } from "@jseek/mcp-server/public-api-contract";
+
+export type PublicSearchLanguageResult =
+  | { ok: true; languages: string[] | null }
+  | { ok: false; error: string };
+
+/** Parse the public `lang` query without consulting UI preference state. */
+export function parsePublicSearchLanguages(
+  raw: string | null | undefined,
+): PublicSearchLanguageResult {
+  if (raw == null) return { ok: true, languages: null };
+  const parts = raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (parts.length === 0) {
+    return {
+      ok: false,
+      error: `Invalid 'lang' param: must be a comma-separated list of language codes (${API_LOCALES.join(", ")})`,
+    };
+  }
+  const invalid = parts.filter(
+    (value) => !(API_LOCALES as readonly string[]).includes(value),
+  );
+  if (invalid.length > 0) {
+    return {
+      ok: false,
+      error: `Invalid 'lang' value(s): ${invalid.join(", ")}. Supported: ${API_LOCALES.join(", ")}`,
+    };
+  }
+  return { ok: true, languages: [...new Set(parts)] };
+}
+
+/** Parse Explore links, where `*` explicitly preserves REST's all-language default. */
+export function parseExploreSearchLanguages(
+  raw: string | null | undefined,
+): PublicSearchLanguageResult {
+  if (raw?.trim() === "*") return { ok: true, languages: [] };
+  return parsePublicSearchLanguages(raw);
+}

--- a/apps/web/src/lib/search/types.ts
+++ b/apps/web/src/lib/search/types.ts
@@ -1,3 +1,8 @@
+import {
+  SEARCH_EMPLOYMENT_TYPE_VALUES,
+  SEARCH_WORK_MODE_VALUES,
+} from "@jseek/mcp-server/public-api-contract";
+
 export interface PostingLocation {
   name: string;
   type: string;
@@ -25,9 +30,8 @@ export interface SelectedLocation {
  * Issue #2983 — filter-wide multi-select reusing the existing
  * ``location_types`` field on ``job_posting``. No schema change.
  */
-export type WorkMode = "onsite" | "hybrid" | "remote";
-
-export const WORK_MODE_VALUES: readonly WorkMode[] = ["onsite", "hybrid", "remote"] as const;
+export const WORK_MODE_VALUES = SEARCH_WORK_MODE_VALUES;
+export type WorkMode = (typeof WORK_MODE_VALUES)[number];
 
 export function isWorkMode(value: string): value is WorkMode {
   return (WORK_MODE_VALUES as readonly string[]).includes(value);
@@ -39,22 +43,8 @@ export function isWorkMode(value: string): value is WorkMode {
  * `full_or_part`; those are intentionally not accepted as URL filter
  * values because the user-facing filter controls do not expose them.
  */
-export type EmploymentType =
-  | "full_time"
-  | "part_time"
-  | "contract"
-  | "internship"
-  | "temporary"
-  | "volunteer";
-
-export const EMPLOYMENT_TYPE_VALUES: readonly EmploymentType[] = [
-  "full_time",
-  "part_time",
-  "contract",
-  "internship",
-  "temporary",
-  "volunteer",
-] as const;
+export const EMPLOYMENT_TYPE_VALUES = SEARCH_EMPLOYMENT_TYPE_VALUES;
+export type EmploymentType = (typeof EMPLOYMENT_TYPE_VALUES)[number];
 
 export function isEmploymentType(value: string): value is EmploymentType {
   return (EMPLOYMENT_TYPE_VALUES as readonly string[]).includes(value);

--- a/apps/web/src/lib/services/search-input.ts
+++ b/apps/web/src/lib/services/search-input.ts
@@ -27,6 +27,10 @@ export interface ParsedSearchFilters {
   technologies: { id: number; slug: string; name: string }[];
   workMode: WorkMode[];
   employmentTypes: EmploymentType[];
+  /** Exact public-API slugs that could not be resolved. UI callers stay lenient. */
+  unresolvedExplicitSlugs?: Partial<
+    Record<"loc" | "occ" | "sen" | "tech", string[]>
+  >;
 }
 
 /**
@@ -228,6 +232,23 @@ export async function parseSearchFilters(params: {
       : Promise.resolve(new Map()),
   ]);
 
+  const unresolvedExplicitSlugs: NonNullable<
+    ParsedSearchFilters["unresolvedExplicitSlugs"]
+  > = {};
+  for (const [name, requested, resolved] of [
+    ["loc", explicitLocSlugs, resolvedExplicitLocs],
+    ["occ", explicitOccSlugs, resolvedOccs],
+    ["sen", explicitSenSlugs, resolvedSens],
+    ["tech", explicitTechSlugs, resolvedTechs],
+  ] as const) {
+    const unresolved = requested.filter((slug) => !resolved.has(slug));
+    if (unresolved.length > 0) unresolvedExplicitSlugs[name] = unresolved;
+  }
+  const unresolvedResult =
+    Object.keys(unresolvedExplicitSlugs).length > 0
+      ? { unresolvedExplicitSlugs }
+      : {};
+
   const locations: SelectedLocation[] = explicitLocSlugs
     .map((slug) => resolvedExplicitLocs.get(slug))
     .filter((location): location is NonNullable<typeof location> => location !== undefined)
@@ -295,6 +316,7 @@ export async function parseSearchFilters(params: {
       technologies,
       workMode,
       employmentTypes,
+      ...unresolvedResult,
     };
   }
 
@@ -481,5 +503,6 @@ export async function parseSearchFilters(params: {
     technologies,
     workMode,
     employmentTypes,
+    ...unresolvedResult,
   };
 }

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -54,7 +54,7 @@ Add to `.cursor/mcp.json`:
 
 | Tool | Description |
 |------|-------------|
-| `search_jobs` | Search job postings with filters (keywords, location, seniority, tech stack, salary, experience) |
+| `search_jobs` | Search job postings with filters (keywords, location, seniority, tech stack, work mode, employment type, salary, experience, document language) |
 | `get_job_detail` | Get full metadata for a posting (salary, technologies, seniority, experience, locations) |
 | `search_companies` | Search companies by name |
 | `list_taxonomies` | List valid filter values (seniority levels, occupations, technologies, industries) |
@@ -83,6 +83,8 @@ The server calls `search_companies(q: "Google")` to find the company, then `sear
 **User:** "Create a watchlist for React jobs in Switzerland paying over 100k EUR"
 
 The server resolves "Switzerland" and "React" to slugs, then calls `create_watchlist_link(title: "React Jobs Switzerland 100k+", loc: "switzerland", tech: "react", sal: "100000-")`. Returns a prefilled link the user can open to save the watchlist and receive email alerts for new matching jobs.
+
+`search_jobs` accepts comma-separated `wm` values (`onsite`, `hybrid`, `remote`) and `etype` values (`full_time`, `part_time`, `contract`, `internship`, `temporary`, `volunteer`). Its `sal` range is always EUR; use `lang` to filter by the posting document language independently of the UI `locale`. `create_watchlist_link` also accepts `wm` and `etype`, and retains its separate `salcur` option as UI prefill state.
 
 ### Example 4: Discover filter options
 

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jseek/mcp-server",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "mcpName": "io.github.colophon-group/jobseek",
   "description": "MCP server for Job Seek — search jobs, companies, and watchlists on jseek.co",
   "license": "MIT",
@@ -17,7 +17,8 @@
   "exports": {
     ".": "./dist/index.js",
     "./server": "./dist/server.js",
-    "./handler": "./dist/handler.js"
+    "./handler": "./dist/handler.js",
+    "./public-api-contract": "./dist/public-api-contract.js"
   },
   "files": [
     "dist",

--- a/packages/mcp-server/scripts/verify-package.mjs
+++ b/packages/mcp-server/scripts/verify-package.mjs
@@ -2,9 +2,27 @@ import { access, readFile } from "node:fs/promises";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createServer } from "../dist/server.js";
+import {
+  API_LOCALES,
+  DEFAULT_API_LOCALE,
+  PUBLIC_API_VERSION,
+  PUBLIC_SEARCH_QUERY_PARAMETERS,
+  SEARCH_EMPLOYMENT_TYPE_LIST_PATTERN,
+  SEARCH_EMPLOYMENT_TYPE_VALUES,
+  SEARCH_INTEGER_RANGE_PATTERN,
+  SEARCH_LANGUAGE_LIST_PATTERN,
+  SEARCH_WORK_MODE_LIST_PATTERN,
+  SEARCH_WORK_MODE_VALUES,
+} from "../dist/public-api-contract.js";
 
 const packageJson = JSON.parse(await readFile("package.json", "utf8"));
 const serverJson = JSON.parse(await readFile("server.json", "utf8"));
+const openApi = JSON.parse(
+  await readFile(
+    new URL("../../../apps/web/public/api/openapi.json", import.meta.url),
+    "utf8",
+  ),
+);
 
 function assert(condition, message) {
   if (!condition) {
@@ -62,6 +80,7 @@ const expectedToolSchemas = {
     properties: [
       "companies",
       "description",
+      "etype",
       "exp",
       "loc",
       "locale",
@@ -72,6 +91,7 @@ const expectedToolSchemas = {
       "sen",
       "tech",
       "title",
+      "wm",
     ],
     required: ["title"],
   },
@@ -93,7 +113,7 @@ const expectedToolSchemas = {
     required: ["q"],
   },
   search_jobs: {
-    properties: ["exp", "loc", "locale", "occ", "q", "sal", "sen", "tech"],
+    properties: [...PUBLIC_SEARCH_QUERY_PARAMETERS].sort(),
     required: [],
   },
   search_watchlists: { properties: ["locale", "q"], required: [] },
@@ -107,6 +127,79 @@ const expectedToolSchemas = {
   },
 };
 const expectedTools = Object.keys(expectedToolSchemas).sort();
+assert(
+  openApi.info?.version === PUBLIC_API_VERSION,
+  "OpenAPI info.version must match the public API contract",
+);
+const openApiSearchParameters = openApi.paths?.["/api/v1/search"]?.get?.parameters;
+assert(
+  Array.isArray(openApiSearchParameters),
+  "OpenAPI must define /api/v1/search GET parameters",
+);
+const openApiSearchNames = openApiSearchParameters
+  .filter((parameter) => parameter.in === "query")
+  .map((parameter) => parameter.name)
+  .sort();
+assert(
+  JSON.stringify(openApiSearchNames) ===
+    JSON.stringify([...PUBLIC_SEARCH_QUERY_PARAMETERS].sort()),
+  "OpenAPI search query parameters must match the public API contract",
+);
+
+function openApiQueryParameter(path, name) {
+  return openApi.paths?.[path]?.get?.parameters?.find(
+    (parameter) => parameter.in === "query" && parameter.name === name,
+  );
+}
+
+for (const path of ["/api/v1/search", "/api/v1/watchlist/create"]) {
+  const workModeParameter = openApiQueryParameter(path, "wm");
+  assert(
+    JSON.stringify(workModeParameter?.schema?.items?.enum) ===
+      JSON.stringify(SEARCH_WORK_MODE_VALUES),
+    `OpenAPI ${path} work-mode values must match the public API contract`,
+  );
+  const employmentTypeParameter = openApiQueryParameter(path, "etype");
+  assert(
+    JSON.stringify(employmentTypeParameter?.schema?.items?.enum) ===
+      JSON.stringify(SEARCH_EMPLOYMENT_TYPE_VALUES),
+    `OpenAPI ${path} employment-type values must match the public API contract`,
+  );
+}
+const languageParameter = openApiQueryParameter("/api/v1/search", "lang");
+assert(
+  JSON.stringify(languageParameter?.schema?.items?.enum) ===
+    JSON.stringify(API_LOCALES),
+  "OpenAPI search language values must match the public API contract",
+);
+for (const name of ["sal", "exp"]) {
+  assert(
+    openApiQueryParameter("/api/v1/search", name)?.schema?.pattern ===
+      SEARCH_INTEGER_RANGE_PATTERN,
+    `OpenAPI search ${name} pattern must match the public API contract`,
+  );
+}
+
+for (const [path, pathItem] of Object.entries(openApi.paths ?? {})) {
+  const parameters = pathItem?.get?.parameters;
+  assert(Array.isArray(parameters), `OpenAPI ${path} must define GET parameters`);
+  const localeParameter = parameters.find(
+    (parameter) => parameter.in === "query" && parameter.name === "locale",
+  );
+  assert(localeParameter, `OpenAPI ${path} must define the shared locale query`);
+  assert(
+    JSON.stringify(localeParameter.schema?.enum) === JSON.stringify(API_LOCALES),
+    `OpenAPI ${path} locale enum must match the public API contract`,
+  );
+  assert(
+    localeParameter.schema?.default === DEFAULT_API_LOCALE,
+    `OpenAPI ${path} locale default must match the public API contract`,
+  );
+  assert(
+    pathItem.get?.responses?.["400"],
+    `OpenAPI ${path} must document invalid-request responses`,
+  );
+}
 
 const server = createServer("https://example.invalid");
 const client = new Client({ name: "jobseek-package-verifier", version: "1.0.0" });
@@ -144,6 +237,94 @@ try {
         JSON.stringify(expectedToolSchemas[tool.name]),
       `MCP tool ${tool.name} must preserve its public input interface`,
     );
+    const localeSchema = tool.inputSchema.properties?.locale;
+    if (localeSchema) {
+      assert(
+        JSON.stringify(localeSchema.enum) === JSON.stringify(API_LOCALES),
+        `MCP tool ${tool.name} locale enum must match the public API contract`,
+      );
+      assert(
+        localeSchema.default === DEFAULT_API_LOCALE,
+        `MCP tool ${tool.name} locale default must match the public API contract`,
+      );
+    }
+  }
+
+  const searchTool = tools.find(({ name }) => name === "search_jobs");
+  const searchPatterns = {
+    wm: SEARCH_WORK_MODE_LIST_PATTERN,
+    etype: SEARCH_EMPLOYMENT_TYPE_LIST_PATTERN,
+    sal: SEARCH_INTEGER_RANGE_PATTERN,
+    exp: SEARCH_INTEGER_RANGE_PATTERN,
+    lang: SEARCH_LANGUAGE_LIST_PATTERN,
+  };
+  for (const [name, pattern] of Object.entries(searchPatterns)) {
+    assert(
+      searchTool?.inputSchema?.properties?.[name]?.pattern === pattern,
+      `MCP search_jobs ${name} pattern must match the public API contract`,
+    );
+  }
+  const createWatchlistTool = tools.find(
+    ({ name }) => name === "create_watchlist_link",
+  );
+  for (const [name, pattern] of Object.entries({
+    wm: SEARCH_WORK_MODE_LIST_PATTERN,
+    etype: SEARCH_EMPLOYMENT_TYPE_LIST_PATTERN,
+  })) {
+    assert(
+      createWatchlistTool?.inputSchema?.properties?.[name]?.pattern === pattern,
+      `MCP create_watchlist_link ${name} pattern must match the public API contract`,
+    );
+  }
+
+  const originalFetch = globalThis.fetch;
+  const requestedUrls = [];
+  globalThis.fetch = async (input) => {
+    requestedUrls.push(String(input));
+    return new Response(JSON.stringify({ companies: [], totalCompanies: 0 }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  try {
+    const validSearch = await client.callTool({
+      name: "search_jobs",
+      arguments: {
+        q: "engineer",
+        loc: "switzerland",
+        occ: "software-engineer",
+        sen: "senior",
+        tech: "typescript",
+        wm: "remote,hybrid",
+        etype: "full_time,contract",
+        sal: "80000-150000",
+        exp: "3-10",
+        lang: "en,de",
+        locale: "fr",
+      },
+    });
+    assert(!validSearch.isError, "MCP search_jobs must accept the shared contract");
+    assert(requestedUrls.length === 1, "MCP search_jobs must issue exactly one API request");
+    const forwarded = new URL(requestedUrls[0]);
+    for (const name of PUBLIC_SEARCH_QUERY_PARAMETERS) {
+      assert(
+        forwarded.searchParams.has(name),
+        `MCP search_jobs must forward ${name} to the REST API`,
+      );
+    }
+
+    requestedUrls.length = 0;
+    const invalidSearch = await client.callTool({
+      name: "search_jobs",
+      arguments: { wm: "remote,bogus" },
+    });
+    assert(invalidSearch.isError, "MCP search_jobs must reject unsupported filter values");
+    assert(
+      requestedUrls.length === 0,
+      "MCP search_jobs must reject invalid input before calling the REST API",
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
   }
 
   const { resourceTemplates } = await client.listResourceTemplates();

--- a/packages/mcp-server/server.json
+++ b/packages/mcp-server/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/colophon-group/jobseek",
     "source": "github"
   },
-  "version": "0.1.3",
+  "version": "0.1.4",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@jseek/mcp-server",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "transport": {
         "type": "stdio"
       }

--- a/packages/mcp-server/src/locale-schema.ts
+++ b/packages/mcp-server/src/locale-schema.ts
@@ -1,0 +1,8 @@
+import { z } from "zod";
+import { API_LOCALES, DEFAULT_API_LOCALE } from "./public-api-contract.js";
+
+/** The common locale input accepted by every public MCP tool. */
+export const apiLocaleSchema = z
+  .enum(API_LOCALES)
+  .default(DEFAULT_API_LOCALE)
+  .describe("Response language");

--- a/packages/mcp-server/src/public-api-contract.ts
+++ b/packages/mcp-server/src/public-api-contract.ts
@@ -1,0 +1,58 @@
+/**
+ * Public query vocabulary shared by the MCP server and external API clients.
+ *
+ * Keep this module dependency-free: consumers that only need to build URLs or
+ * validate generated OpenAPI can import it without loading the MCP SDK.
+ */
+export const API_LOCALES = ["en", "de", "fr", "it"] as const;
+
+export const DEFAULT_API_LOCALE = API_LOCALES[0];
+
+export const PUBLIC_API_VERSION = "1.1.0";
+
+export const PUBLIC_SEARCH_QUERY_PARAMETERS = [
+  "q",
+  "loc",
+  "occ",
+  "sen",
+  "tech",
+  "wm",
+  "etype",
+  "sal",
+  "exp",
+  "lang",
+  "locale",
+] as const;
+
+export const SEARCH_WORK_MODE_VALUES = [
+  "onsite",
+  "hybrid",
+  "remote",
+] as const;
+
+export const SEARCH_EMPLOYMENT_TYPE_VALUES = [
+  "full_time",
+  "part_time",
+  "contract",
+  "internship",
+  "temporary",
+  "volunteer",
+] as const;
+
+function commaSeparatedPattern(values: readonly string[]): string {
+  const alternatives = values.join("|");
+  return `^\\s*(?:${alternatives})(?:\\s*,\\s*(?:${alternatives}))*\\s*$`;
+}
+
+export const SEARCH_WORK_MODE_LIST_PATTERN = commaSeparatedPattern(
+  SEARCH_WORK_MODE_VALUES,
+);
+
+export const SEARCH_EMPLOYMENT_TYPE_LIST_PATTERN = commaSeparatedPattern(
+  SEARCH_EMPLOYMENT_TYPE_VALUES,
+);
+
+export const SEARCH_LANGUAGE_LIST_PATTERN = commaSeparatedPattern(API_LOCALES);
+
+export const SEARCH_INTEGER_RANGE_PATTERN =
+  "^\\s*(?:\\d+\\s*-\\s*\\d+|\\d+\\s*-\\s*|-\\s*\\d+)\\s*$";

--- a/packages/mcp-server/src/server.ts
+++ b/packages/mcp-server/src/server.ts
@@ -10,7 +10,7 @@ import { register as registerCreateWatchlist } from "./tools/create-watchlist.js
 
 export function createServer(baseUrl: string) {
   const server = new McpServer(
-    { name: "jobseek", version: "0.1.0" },
+    { name: "jobseek", version: "0.1.4" },
     {
       instructions: `You are connected to Job Seek (jseek.co), a job search engine that monitors 290+ company career pages across Switzerland and Europe.
 

--- a/packages/mcp-server/src/tools/companies.ts
+++ b/packages/mcp-server/src/tools/companies.ts
@@ -1,11 +1,12 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { JobseekClient } from "../client.js";
+import { apiLocaleSchema } from "../locale-schema.js";
 type HC = { found: boolean; activeListings: number; avgViews: number; avgApplications: number; lowEngagement: boolean; signal: string | null };
 type GR = { company: string; overallGhostRisk: number; ghostRate: number; ghostCandidates: number; totalUniqueJobs: number; avgDurationDays: number; recommendation: string; orgGhostSignal: string | null; hiringCafeSignal: HC | null; geminiSummary: string; matchingJobs: Array<{ title: string; durationDays: number; ghostScore: number; ghostReason: string; reposted: boolean }> };
 
 export function register(server: McpServer, client: JobseekClient) {
-  server.tool("search_companies", "Search companies by name on jseek.co. Returns up to 10 matching companies with links to their company pages.", { q: z.string().describe("Company name query (min 2 chars)"), locale: z.enum(["en", "de", "fr", "it"]).default("en").describe("Response language") }, { title: "Search Companies", readOnlyHint: true, destructiveHint: false, openWorldHint: true }, async (p) => ({ content: [{ type: "text", text: JSON.stringify(await client.get("/api/v1/companies", { q: p.q, locale: p.locale }), null, 2) }] }));
+  server.tool("search_companies", "Search companies by name on jseek.co. Returns up to 10 matching companies with links to their company pages.", { q: z.string().describe("Company name query (min 2 chars)"), locale: apiLocaleSchema }, { title: "Search Companies", readOnlyHint: true, destructiveHint: false, openWorldHint: true }, async (p) => ({ content: [{ type: "text", text: JSON.stringify(await client.get("/api/v1/companies", { q: p.q, locale: p.locale }), null, 2) }] }));
 
   server.tool("trigger_ghost_analysis", "Start ghost-job analysis for a career page via Wayback Machine. Detects jobs open months without being filled. Returns runId — poll get_ghost_analysis until SUCCEEDED (3–8 min).", { portalUrl: z.string().url().describe("Career page URL e.g. https://boards.greenhouse.io/stripe"), companyName: z.string().optional(), inventoryMode: z.boolean().optional().describe("CDX mode for Workday/SPA portals"), maxSnapshots: z.number().int().min(10).max(500).optional() }, { title: "Trigger Ghost Analysis", readOnlyHint: false, destructiveHint: false, openWorldHint: true }, async (p) => {
     const d = await client.post("/agentic/api/ghosting", p as Record<string, unknown>) as { runId: string; status: string };

--- a/packages/mcp-server/src/tools/create-watchlist.ts
+++ b/packages/mcp-server/src/tools/create-watchlist.ts
@@ -1,6 +1,13 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { JobseekClient } from "../client.js";
+import {
+  SEARCH_EMPLOYMENT_TYPE_LIST_PATTERN,
+  SEARCH_EMPLOYMENT_TYPE_VALUES,
+  SEARCH_WORK_MODE_LIST_PATTERN,
+  SEARCH_WORK_MODE_VALUES,
+} from "../public-api-contract.js";
+import { apiLocaleSchema } from "../locale-schema.js";
 
 export function register(server: McpServer, client: JobseekClient) {
   server.tool(
@@ -23,6 +30,18 @@ export function register(server: McpServer, client: JobseekClient) {
         .string()
         .optional()
         .describe("Technology slugs, comma-separated"),
+      wm: z
+        .string()
+        .regex(new RegExp(SEARCH_WORK_MODE_LIST_PATTERN))
+        .optional()
+        .describe(`Work mode, comma-separated: ${SEARCH_WORK_MODE_VALUES.join(", ")}`),
+      etype: z
+        .string()
+        .regex(new RegExp(SEARCH_EMPLOYMENT_TYPE_LIST_PATTERN))
+        .optional()
+        .describe(
+          `Employment type, comma-separated: ${SEARCH_EMPLOYMENT_TYPE_VALUES.join(", ")}`,
+        ),
       sal: z.string().optional().describe("Salary range, format: min-max"),
       salcur: z.string().optional().describe("Salary currency code (e.g. EUR, USD, CHF)"),
       exp: z
@@ -33,10 +52,7 @@ export function register(server: McpServer, client: JobseekClient) {
         .string()
         .optional()
         .describe("Company slugs, comma-separated"),
-      locale: z
-        .enum(["en", "de", "fr", "it"])
-        .default("en")
-        .describe("Response language"),
+      locale: apiLocaleSchema,
     },
     { title: "Create Watchlist Link", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async (params) => {
@@ -48,6 +64,8 @@ export function register(server: McpServer, client: JobseekClient) {
         occ: params.occ,
         sen: params.sen,
         tech: params.tech,
+        wm: params.wm,
+        etype: params.etype,
         sal: params.sal,
         salcur: params.salcur,
         exp: params.exp,

--- a/packages/mcp-server/src/tools/job-detail.ts
+++ b/packages/mcp-server/src/tools/job-detail.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { JobseekClient } from "../client.js";
+import { apiLocaleSchema } from "../locale-schema.js";
 
 export function register(server: McpServer, client: JobseekClient) {
   server.tool(
@@ -8,10 +9,7 @@ export function register(server: McpServer, client: JobseekClient) {
     "Get full structured metadata for a job posting by ID. Returns salary, technologies, seniority, experience, and locations. Does not include the job description — visit the returned URL on jseek.co to read the full posting. Use posting IDs from search_jobs results.",
     {
       id: z.string().describe("Job posting UUID (from search_jobs topPostings[].id)"),
-      locale: z
-        .enum(["en", "de", "fr", "it"])
-        .default("en")
-        .describe("Response language"),
+      locale: apiLocaleSchema,
     },
     { title: "Get Job Detail", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async (params) => {

--- a/packages/mcp-server/src/tools/resolve.ts
+++ b/packages/mcp-server/src/tools/resolve.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { JobseekClient } from "../client.js";
+import { apiLocaleSchema } from "../locale-schema.js";
 
 export function register(server: McpServer, client: JobseekClient) {
   server.tool(
@@ -11,10 +12,7 @@ export function register(server: McpServer, client: JobseekClient) {
         .enum(["locations", "occupations", "seniority", "technologies", "industries"])
         .describe("Which taxonomy to search"),
       q: z.string().describe("Freetext query (min 2 chars)"),
-      locale: z
-        .enum(["en", "de", "fr", "it"])
-        .default("en")
-        .describe("Response language"),
+      locale: apiLocaleSchema,
     },
     { title: "Resolve Slugs", readOnlyHint: true, destructiveHint: false, openWorldHint: true, idempotentHint: true },
     async (params) => {

--- a/packages/mcp-server/src/tools/search.ts
+++ b/packages/mcp-server/src/tools/search.ts
@@ -1,11 +1,15 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { JobseekClient } from "../client.js";
-
-const LOCALE = z
-  .enum(["en", "de", "fr", "it"])
-  .default("en")
-  .describe("Response language");
+import {
+  SEARCH_EMPLOYMENT_TYPE_VALUES,
+  SEARCH_EMPLOYMENT_TYPE_LIST_PATTERN,
+  SEARCH_INTEGER_RANGE_PATTERN,
+  SEARCH_LANGUAGE_LIST_PATTERN,
+  SEARCH_WORK_MODE_LIST_PATTERN,
+  SEARCH_WORK_MODE_VALUES,
+} from "../public-api-contract.js";
+import { apiLocaleSchema } from "../locale-schema.js";
 
 export function register(server: McpServer, client: JobseekClient) {
   server.tool(
@@ -29,15 +33,34 @@ export function register(server: McpServer, client: JobseekClient) {
         .string()
         .optional()
         .describe("Technology slugs, comma-separated (from resolve_slugs)"),
+      wm: z
+        .string()
+        .regex(new RegExp(SEARCH_WORK_MODE_LIST_PATTERN))
+        .optional()
+        .describe(`Work mode, comma-separated: ${SEARCH_WORK_MODE_VALUES.join(", ")}`),
+      etype: z
+        .string()
+        .regex(new RegExp(SEARCH_EMPLOYMENT_TYPE_LIST_PATTERN))
+        .optional()
+        .describe(
+          `Employment type, comma-separated: ${SEARCH_EMPLOYMENT_TYPE_VALUES.join(", ")}`,
+        ),
       sal: z
         .string()
+        .regex(new RegExp(SEARCH_INTEGER_RANGE_PATTERN))
         .optional()
         .describe("Salary range in EUR, format: min-max (e.g. 80000-150000)"),
       exp: z
         .string()
+        .regex(new RegExp(SEARCH_INTEGER_RANGE_PATTERN))
         .optional()
         .describe("Experience range in years, format: min-max (e.g. 3-10)"),
-      locale: LOCALE,
+      lang: z
+        .string()
+        .regex(new RegExp(SEARCH_LANGUAGE_LIST_PATTERN))
+        .optional()
+        .describe("Job document language codes, comma-separated (en, de, fr, it)"),
+      locale: apiLocaleSchema,
     },
     { title: "Search Jobs", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async (params) => {
@@ -47,8 +70,11 @@ export function register(server: McpServer, client: JobseekClient) {
         occ: params.occ,
         sen: params.sen,
         tech: params.tech,
+        wm: params.wm,
+        etype: params.etype,
         sal: params.sal,
         exp: params.exp,
+        lang: params.lang,
         locale: params.locale,
       });
       return {

--- a/packages/mcp-server/src/tools/taxonomies.ts
+++ b/packages/mcp-server/src/tools/taxonomies.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { JobseekClient } from "../client.js";
+import { apiLocaleSchema } from "../locale-schema.js";
 
 export function register(server: McpServer, client: JobseekClient) {
   server.tool(
@@ -10,10 +11,7 @@ export function register(server: McpServer, client: JobseekClient) {
       type: z
         .enum(["seniority", "occupations", "technologies", "industries"])
         .describe("Which taxonomy to list"),
-      locale: z
-        .enum(["en", "de", "fr", "it"])
-        .default("en")
-        .describe("Response language"),
+      locale: apiLocaleSchema,
     },
     { title: "List Taxonomies", readOnlyHint: true, destructiveHint: false, openWorldHint: true, idempotentHint: true },
     async (params) => {

--- a/packages/mcp-server/src/tools/watchlists.ts
+++ b/packages/mcp-server/src/tools/watchlists.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { JobseekClient } from "../client.js";
+import { apiLocaleSchema } from "../locale-schema.js";
 
 export function register(server: McpServer, client: JobseekClient) {
   server.tool(
@@ -11,10 +12,7 @@ export function register(server: McpServer, client: JobseekClient) {
         .string()
         .optional()
         .describe("Search query for watchlist title/description"),
-      locale: z
-        .enum(["en", "de", "fr", "it"])
-        .default("en")
-        .describe("Response language"),
+      locale: apiLocaleSchema,
     },
     { title: "Search Watchlists", readOnlyHint: true, destructiveHint: false, openWorldHint: true },
     async (params) => {


### PR DESCRIPTION
## Summary

- centralize locale and search-filter contracts across REST, OpenAPI, and MCP
- validate public locale/filter values and preserve exact Explore-link semantics, including EUR salary and the all-language default
- expand and verify MCP filters, align OpenAPI with runtime behavior, and bump MCP to 0.1.4 / API to 1.1.0

## Why

The public surfaces had drifted: arbitrary locales were accepted, `etype` was omitted in places, search advertised a phantom `salcur`, MCP missed supported filters, and some `moreAt` links changed the requested result set.

## Validation

- `pnpm --dir apps/web test` — 245 files, 1,825 tests
- `pnpm typecheck` — 6/6 tasks
- `pnpm lint` — 3/3 tasks
- `pnpm --dir apps/web build`
- `pnpm --filter @jseek/mcp-server build`
- `pnpm --filter @jseek/mcp-server typecheck`
- `pnpm --filter @jseek/mcp-server test`
- independent final review: SHIP

Closes #6132