### PR TITLE
Harden Vercel scanner-path smoke validation

### DIFF
--- a/.github/scripts/classify-vercel-web-change.mjs
+++ b/.github/scripts/classify-vercel-web-change.mjs
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 
 const EXACT_WEB_INPUTS = new Set([
   ".github/scripts/classify-vercel-web-change.mjs",
+  ".github/scripts/verify-vercel-scanner-response.mjs",
   ".github/scripts/verify-vercel-server-action-key.mjs",
   ".github/scripts/verify-vercel-promotion.mjs",
   ".github/workflows/deploy-web-production.yml",

--- a/.github/scripts/verify-vercel-scanner-response.mjs
+++ b/.github/scripts/verify-vercel-scanner-response.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+
+import { readFileSync, statSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+const HTTP_STATUS_RE = /^HTTP\/(?:\d+(?:\.\d+)?)\s+([1-5]\d{2})(?:\s|$)/;
+const HEADER_NAME_RE = /^[!#$%&'*+.^_`|~0-9A-Za-z-]+$/;
+const MAX_HEADER_BYTES = 1_000_000;
+
+export class ScannerResponseError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "ScannerResponseError";
+  }
+}
+
+function parseHeaderBlocks(rawHeaders) {
+  if (typeof rawHeaders !== "string" || rawHeaders.length === 0) {
+    throw new ScannerResponseError("Scanner response headers are missing");
+  }
+
+  const blocks = [];
+  let current = null;
+
+  for (const line of rawHeaders.split(/\r?\n/)) {
+    const statusMatch = HTTP_STATUS_RE.exec(line);
+    if (statusMatch) {
+      if (current) blocks.push(current);
+      current = { status: statusMatch[1], mitigationValues: [], malformed: false };
+      continue;
+    }
+
+    if (!current || line === "") continue;
+    if (/^[ \t]/.test(line)) {
+      current.malformed = true;
+      continue;
+    }
+
+    const colon = line.indexOf(":");
+    if (colon <= 0) {
+      current.malformed = true;
+      continue;
+    }
+
+    const name = line.slice(0, colon);
+    if (!HEADER_NAME_RE.test(name)) {
+      current.malformed = true;
+      continue;
+    }
+    if (name.toLowerCase() === "x-vercel-mitigated") {
+      current.mitigationValues.push(line.slice(colon + 1).trim());
+    }
+  }
+
+  if (current) blocks.push(current);
+  if (blocks.length === 0) {
+    throw new ScannerResponseError("Scanner response has no HTTP header block");
+  }
+  return blocks;
+}
+
+export function verifyScannerResponse(status, rawHeaders) {
+  if (typeof status !== "string" || !/^[1-5]\d{2}$/.test(status)) {
+    throw new ScannerResponseError("Scanner response has an invalid HTTP status");
+  }
+
+  const blocks = parseHeaderBlocks(rawHeaders);
+  const finalBlock = blocks.at(-1);
+  if (finalBlock.status !== status) {
+    throw new ScannerResponseError(
+      `Scanner final header status ${finalBlock.status} does not match curl status ${status}`,
+    );
+  }
+
+  if (status === "404") {
+    return { status, outcome: "not_found" };
+  }
+
+  if (status === "403") {
+    if (finalBlock.malformed) {
+      throw new ScannerResponseError("Scanner 403 has malformed final headers");
+    }
+    if (
+      finalBlock.mitigationValues.length === 1 &&
+      finalBlock.mitigationValues[0] === "deny"
+    ) {
+      return { status, outcome: "vercel_mitigated" };
+    }
+    throw new ScannerResponseError(
+      "Scanner 403 lacks one exact x-vercel-mitigated: deny header",
+    );
+  }
+
+  throw new ScannerResponseError(`Scanner path returned disallowed HTTP ${status}`);
+}
+
+function main() {
+  const [status, headerPath, ...extra] = process.argv.slice(2);
+  if (!status || !headerPath || extra.length > 0) {
+    throw new ScannerResponseError(
+      "usage: verify-vercel-scanner-response.mjs <status> <header-file>",
+    );
+  }
+  if (statSync(headerPath).size > MAX_HEADER_BYTES) {
+    throw new ScannerResponseError("Scanner response headers exceed the size limit");
+  }
+
+  const result = verifyScannerResponse(status, readFileSync(headerPath, "utf8"));
+  const description = result.outcome === "not_found"
+    ? "not found"
+    : "Vercel mitigation confirmed";
+  process.stdout.write(`Scanner path accepted: HTTP ${result.status} (${description})\n`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/.github/workflows/deploy-web-production.yml
+++ b/.github/workflows/deploy-web-production.yml
@@ -132,14 +132,23 @@ jobs:
               exit 1
             fi
           done
+          umask 077
+          scanner_headers="$(mktemp "$RUNNER_TEMP/vercel-scanner-headers.XXXXXX")"
+          chmod 600 "$scanner_headers"
+          trap 'rm -f -- "$scanner_headers"' EXIT
           scanner_status="$(pnpm dlx vercel@55.0.0 curl /wp-admin/setup-config.php \
             --deployment="$DEPLOYMENT_URL" \
-            -- --location --silent --show-error --output /dev/null --write-out '%{http_code}')"
+            -- --location --silent --show-error \
+            --dump-header "$scanner_headers" \
+            --output /dev/null --write-out '%{http_code}')"
           echo "Smoke /wp-admin/setup-config.php -> HTTP $scanner_status after redirects"
-          if [[ "$scanner_status" != "404" ]]; then
-            echo "::error title=Scanner path exposed::Expected HTTP 404 after redirects, got $scanner_status"
+          if ! node .github/scripts/verify-vercel-scanner-response.mjs \
+            "$scanner_status" "$scanner_headers"; then
+            echo "::error title=Scanner path exposed::Rejected final HTTP $scanner_status"
             exit 1
           fi
+          rm -f -- "$scanner_headers"
+          trap - EXIT
 
       - name: Promote only if this SHA is still main
         if: steps.paths.outputs.deploy == 'true'

--- a/scripts/vercel-web-deploy-paths.test.mjs
+++ b/scripts/vercel-web-deploy-paths.test.mjs
@@ -1,10 +1,28 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import {
   classifyVercelWebChanges,
   isVercelWebInput,
 } from "../.github/scripts/classify-vercel-web-change.mjs";
+import {
+  ScannerResponseError,
+  verifyScannerResponse,
+} from "../.github/scripts/verify-vercel-scanner-response.mjs";
+
+const scannerVerifier = fileURLToPath(
+  new URL("../.github/scripts/verify-vercel-scanner-response.mjs", import.meta.url),
+);
 
 test("deploys web runtime and every current workspace input", () => {
   for (const path of [
@@ -18,6 +36,7 @@ test("deploys web runtime and every current workspace input", () => {
     "turbo.json",
     ".github/workflows/deploy-web-production.yml",
     ".github/scripts/classify-vercel-web-change.mjs",
+    ".github/scripts/verify-vercel-scanner-response.mjs",
     ".github/scripts/verify-vercel-server-action-key.mjs",
     ".github/scripts/verify-vercel-promotion.mjs",
   ]) {
@@ -82,8 +101,13 @@ test("production workflow stages, verifies, then promotes exact main", () => {
   assert.doesNotMatch(workflow, /--(?:output|write-out)=/);
   assert.match(
     workflow,
-    /scanner_status=[\s\S]{0,240}-- --location --silent/,
+    /scanner_headers=.*RUNNER_TEMP[\s\S]{0,500}--dump-header "\$scanner_headers"/,
   );
+  assert.match(workflow, /umask 077/);
+  assert.match(workflow, /chmod 600 "\$scanner_headers"/);
+  assert.match(workflow, /trap 'rm -f -- "\$scanner_headers"' EXIT/);
+  assert.match(workflow, /verify-vercel-scanner-response\.mjs/);
+  assert.doesNotMatch(workflow, /\bcat\s+.*scanner_headers/);
   assert.match(workflow, /Smoke \$path -> HTTP \$status/);
   assert.match(workflow, /Scanner path exposed/);
   assert.doesNotMatch(workflow, /--cwd=apps\/web/);
@@ -95,4 +119,131 @@ test("production workflow stages, verifies, then promotes exact main", () => {
   );
   assert.doesNotMatch(workflow, /environment:\n\s+name: Production\n\s+url:/);
   assert.doesNotMatch(workflow, /pull_request:/);
+});
+
+test("accepts a normal final 404 scanner response", () => {
+  assert.deepEqual(
+    verifyScannerResponse(
+      "404",
+      "HTTP/2 404\r\ncontent-type: text/html\r\nset-cookie: private=value\r\n\r\n",
+    ),
+    { status: "404", outcome: "not_found" },
+  );
+});
+
+test("accepts only an exact Vercel-mitigated final 403", () => {
+  assert.deepEqual(
+    verifyScannerResponse(
+      "403",
+      "HTTP/2 403\r\nx-vercel-mitigated: deny\r\ncache-control: private, no-store\r\n\r\n",
+    ),
+    { status: "403", outcome: "vercel_mitigated" },
+  );
+});
+
+test("CLI reports only a safe scanner decision", () => {
+  const directory = mkdtempSync(join(tmpdir(), "vercel-scanner-response-"));
+  const headerPath = join(directory, "headers");
+  const sensitiveValue = "sensitive-test-value";
+  writeFileSync(
+    headerPath,
+    [
+      "HTTP/2 403",
+      "x-vercel-mitigated: deny",
+      `set-cookie: session=${sensitiveValue}`,
+      `authorization: Bearer ${sensitiveValue}`,
+      "",
+      "",
+    ].join("\r\n"),
+    { mode: 0o600 },
+  );
+  chmodSync(headerPath, 0o600);
+
+  const result = spawnSync(process.execPath, [scannerVerifier, "403", headerPath], {
+    encoding: "utf8",
+  });
+  rmSync(directory, { recursive: true, force: true });
+
+  assert.equal(result.status, 0);
+  assert.match(result.stdout, /HTTP 403 \(Vercel mitigation confirmed\)/);
+  assert.equal(result.stderr, "");
+  assert.doesNotMatch(`${result.stdout}${result.stderr}`, new RegExp(sensitiveValue));
+});
+
+test("rejects a generic application 403", () => {
+  assert.throws(
+    () =>
+      verifyScannerResponse(
+        "403",
+        "HTTP/2 403\r\ncontent-type: text/html\r\n\r\n",
+      ),
+    ScannerResponseError,
+  );
+});
+
+test("rejects missing, malformed, or ambiguous mitigation evidence", () => {
+  for (const headers of [
+    "HTTP/2 403\r\nx-vercel-mitigated: block\r\n\r\n",
+    "HTTP/2 403\r\nx-vercel-mitigated: Deny\r\n\r\n",
+    "HTTP/2 403\r\nx-vercel-mitigated: deny, challenge\r\n\r\n",
+    "HTTP/2 403\r\nx-vercel-mitigated: deny\r\nx-vercel-mitigated: deny\r\n\r\n",
+    "HTTP/2 403\r\nx-vercel-mitigated deny\r\n\r\n",
+    "HTTP/2 403\r\nx-vercel-mitigated: deny\r\n folded\r\n\r\n",
+  ]) {
+    assert.throws(
+      () => verifyScannerResponse("403", headers),
+      ScannerResponseError,
+      headers,
+    );
+  }
+});
+
+test("rejects exposed 200 and redirect-to-200 responses", () => {
+  assert.throws(
+    () =>
+      verifyScannerResponse(
+        "200",
+        "HTTP/2 200\r\ncontent-type: text/html\r\n\r\n",
+      ),
+    ScannerResponseError,
+  );
+  assert.throws(
+    () =>
+      verifyScannerResponse(
+        "200",
+        "HTTP/2 302\r\nlocation: /login\r\n\r\nHTTP/2 200\r\ncontent-type: text/html\r\n\r\n",
+      ),
+    ScannerResponseError,
+  );
+});
+
+test("uses only the final block in a multi-response header file", () => {
+  const earlierMitigation =
+    "HTTP/2 403\r\nx-vercel-mitigated: deny\r\n\r\n";
+  const finalGeneric403 = "HTTP/2 403\r\ncontent-type: text/html\r\n\r\n";
+
+  assert.throws(
+    () => verifyScannerResponse("403", earlierMitigation + finalGeneric403),
+    ScannerResponseError,
+  );
+  assert.deepEqual(
+    verifyScannerResponse(
+      "403",
+      "HTTP/2 302\r\nlocation: /blocked\r\n\r\n" + earlierMitigation,
+    ),
+    { status: "403", outcome: "vercel_mitigated" },
+  );
+});
+
+test("rejects status/header disagreement and every other status", () => {
+  assert.throws(
+    () => verifyScannerResponse("403", "HTTP/2 404\r\n\r\n"),
+    ScannerResponseError,
+  );
+  for (const status of ["301", "401", "429", "500"]) {
+    assert.throws(
+      () => verifyScannerResponse(status, `HTTP/2 ${status}\r\n\r\n`),
+      ScannerResponseError,
+    );
+  }
 });


### PR DESCRIPTION
## Summary

- keep final HTTP 404 as the normal accepted scanner-path response
- accept HTTP 403 only when the final response has one exact x-vercel-mitigated: deny header
- capture headers in a private runner-temp file, discard the body, and clean up on success or failure
- reject generic or malformed 403s, exposed 200s, redirect-to-200 responses, status mismatches, and all other statuses
- classify the verifier as a Vercel web deployment input

## Verification

- focused deployment workflow tests: 12 passed
- Node syntax check: passed
- git diff check: passed
- zizmor 1.26.1 regular profile: no findings
- full repository script suite: 101 passed; 4 unrelated local-only failures because jq is unavailable in this workstation shell
- independent review: PASS, no P0-P2 findings

Relates to #7209.

Production promotion and acceptance remain intentionally out of scope for this draft PR.