### PR TITLE
Bound observability rollback retention

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,17 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+
+      - name: Test observability rollback retention
+        run: |
+          python3 -m py_compile \
+            deploy/observability/prune_rollbacks.py \
+            deploy/observability/test_prune_rollbacks.py
+          python3 deploy/observability/test_prune_rollbacks.py
+
       - name: Test repository scripts
         run: >
           node --test

--- a/.github/workflows/deploy-hetzner-observability.yml
+++ b/.github/workflows/deploy-hetzner-observability.yml
@@ -36,6 +36,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          # The crawler host is Ubuntu 22.04 and runs the system Python 3.10.
+          python-version: "3.10"
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - name: Validate observability artifacts
         run: |

--- a/.github/workflows/deploy-hetzner-observability.yml
+++ b/.github/workflows/deploy-hetzner-observability.yml
@@ -41,6 +41,8 @@ jobs:
         run: |
           set -euo pipefail
           bash -n deploy/observability/install-host.sh
+          python3 -m py_compile deploy/observability/prune_rollbacks.py
+          python3 deploy/observability/test_prune_rollbacks.py
           python3 -m py_compile scripts/codex-routine-status.py scripts/jobseek-host-observability.py scripts/sync-grafana-alertmanager.py scripts/sync-grafana-rules.py scripts/verify-grafana-host-metrics.py
           cd apps/crawler
           uv run --frozen python ../../scripts/sync-grafana-alertmanager.py \

--- a/deploy/observability/install-host.sh
+++ b/deploy/observability/install-host.sh
@@ -53,8 +53,10 @@ fail() {
 
 require_root() {
   [[ "$(id -u)" -eq 0 ]] || fail "must run as root"
-  command -v docker >/dev/null || fail "docker is required to obtain the pinned Alloy binary"
-  command -v systemctl >/dev/null || fail "systemd is required"
+  local command
+  for command in docker flock install python3 readlink stat systemctl; do
+    command -v "$command" >/dev/null || fail "required command is unavailable: ${command}"
+  done
   local name value
   for name in "${REQUIRED_ENV[@]}"; do
     value="${!name:-}"
@@ -64,6 +66,19 @@ require_root() {
   if [[ -n "$DEPLOY_SHA" ]]; then
     [[ "$DEPLOY_SHA" =~ ^[0-9a-f]{40}$ ]] || fail "invalid deployment SHA"
   fi
+}
+
+prepare_rollback_root() {
+  if [[ -L "$ROLLBACK_ROOT" || ( -e "$ROLLBACK_ROOT" && ! -d "$ROLLBACK_ROOT" ) ]]; then
+    fail "rollback root must be an exact directory, not a link or other entry"
+  fi
+  if [[ ! -e "$ROLLBACK_ROOT" ]]; then
+    install -d -o root -g root -m 0700 "$ROLLBACK_ROOT"
+  fi
+  [[ "$(readlink -f -- "$ROLLBACK_ROOT")" == "$ROLLBACK_ROOT" ]] ||
+    fail "rollback root does not resolve to its exact path"
+  [[ "$(stat -c '%u:%g:%a:%F' -- "$ROLLBACK_ROOT")" == "0:0:700:directory" ]] ||
+    fail "rollback root must be root-owned mode 0700"
 }
 
 write_env_line() {
@@ -123,7 +138,8 @@ snapshot_previous() {
   local stamp path unit
   stamp="$(date -u +%Y%m%dT%H%M%SZ)"
   path="${ROLLBACK_ROOT}/${stamp}"
-  install -d -m 0700 "$path"
+  [[ ! -e "$path" && ! -L "$path" ]] || fail "rollback snapshot timestamp already exists"
+  install -d -o root -g root -m 0700 "$path"
   for source in \
     "$BINARY" \
     "$SAMPLER" \
@@ -131,16 +147,35 @@ snapshot_previous() {
     "${CONFIG_ROOT}/alloy.env" \
     "${CONFIG_ROOT}/host.env" \
     "${STATE_ROOT}/deployed-sha"; do
-    if [[ -e "$source" ]]; then
-      cp --archive "$source" "$path/"
+    if [[ -e "$source" || -L "$source" ]]; then
+      [[ -f "$source" && ! -L "$source" ]] ||
+        fail "rollback source is not an exact regular file: ${source}"
+      cp --archive --no-dereference "$source" "$path/"
     fi
   done
   for unit in "${UNITS[@]}"; do
-    if [[ -e "/etc/systemd/system/${unit}" ]]; then
-      cp --archive "/etc/systemd/system/${unit}" "$path/"
+    local source="/etc/systemd/system/${unit}"
+    if [[ -e "$source" || -L "$source" ]]; then
+      [[ -f "$source" && ! -L "$source" ]] ||
+        fail "rollback unit source is not an exact regular file: ${source}"
+      cp --archive --no-dereference "$source" "$path/"
     fi
   done
   printf '%s\n' "$path"
+}
+
+prune_rollback_snapshots() {
+  local rollback="$1" name="${1##*/}"
+  [[ "$rollback" == "${ROLLBACK_ROOT}/${name}" ]] ||
+    fail "accepted rollback is outside the exact rollback root"
+  python3 "${REPO_ROOT}/deploy/observability/prune_rollbacks.py" \
+    --protect-name "$name"
+}
+
+disarm_rollback_and_prune() {
+  ROLLBACK_ARMED=0
+  trap - EXIT
+  prune_rollback_snapshots "$ROLLBACK_PATH"
 }
 
 restore_previous() {
@@ -273,7 +308,7 @@ main() {
   # Alloy stays unprivileged: it can traverse only the config/textfile roots
   # it needs, while secret env and rollback material remain root-only.
   install -d -o root -g jobseek-alloy -m 0750 "$CONFIG_ROOT" "$STATE_ROOT"
-  install -d -o root -g root -m 0700 "$ROLLBACK_ROOT"
+  prepare_rollback_root
   install -d -o root -g jobseek-alloy -m 0750 "${STATE_ROOT}/textfile"
   install -d -o root -g root -m 0700 "${STATE_ROOT}/state"
 
@@ -283,9 +318,10 @@ main() {
   ROLLBACK_ARMED=1
   trap rollback_on_exit EXIT
   install_surface
-  ROLLBACK_ARMED=0
-  trap - EXIT
+  disarm_rollback_and_prune
   log "installed host observability role=${ROLE} sha=${DEPLOY_SHA:-manual}"
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/deploy/observability/prune_rollbacks.py
+++ b/deploy/observability/prune_rollbacks.py
@@ -24,6 +24,7 @@ EXPECTED_GID = 0
 # The crawler host remains on Ubuntu 22.04 with system Python 3.10.
 UTC = timezone.utc  # noqa: UP017
 SNAPSHOT_RE = re.compile(r"^[0-9]{8}T[0-9]{6}Z$")
+MOUNT_ID_RE = re.compile(r"^mnt_id:\s+([1-9][0-9]*)$")
 ALLOWED_FILES = frozenset(
     {
         "jobseek-alloy",
@@ -89,7 +90,18 @@ def _require_deploy_lock(lock_fd: int) -> None:
         raise RetentionError("retention lock descriptor is not the deployment lock")
 
 
-def _open_root() -> int:
+def _mount_id_for_fd(fd: int) -> int:
+    try:
+        lines = Path(f"/proc/self/fdinfo/{fd}").read_text(encoding="ascii").splitlines()
+    except (OSError, UnicodeError) as exc:
+        raise RetentionError("Linux mount identity is unavailable for retention") from exc
+    matches = [match for line in lines if (match := MOUNT_ID_RE.fullmatch(line))]
+    if len(matches) != 1:
+        raise RetentionError("Linux mount identity is missing or ambiguous")
+    return int(matches[0].group(1))
+
+
+def _open_root() -> tuple[int, int]:
     metadata = _require_exact_path(ROLLBACK_ROOT, directory=True)
     if stat.S_IMODE(metadata.st_mode) != 0o700:
         raise RetentionError("rollback root must be root-owned mode 0700")
@@ -104,7 +116,12 @@ def _open_root() -> int:
     if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
         os.close(root_fd)
         raise RetentionError("rollback root changed while retention was starting")
-    return root_fd
+    try:
+        mount_id = _mount_id_for_fd(root_fd)
+    except RetentionError:
+        os.close(root_fd)
+        raise
+    return root_fd, mount_id
 
 
 def _parse_timestamp(name: str) -> datetime:
@@ -119,7 +136,7 @@ def _parse_timestamp(name: str) -> datetime:
     return parsed
 
 
-def _open_snapshot(root_fd: int, snapshot: Snapshot) -> int:
+def _open_snapshot(root_fd: int, root_mount_id: int, snapshot: Snapshot) -> int:
     flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
     try:
         snapshot_fd = os.open(snapshot.name, flags, dir_fd=root_fd)
@@ -129,10 +146,22 @@ def _open_snapshot(root_fd: int, snapshot: Snapshot) -> int:
     if (opened.st_dev, opened.st_ino) != (snapshot.device, snapshot.inode):
         os.close(snapshot_fd)
         raise RetentionError(f"rollback snapshot changed while opening: {snapshot.name}")
+    try:
+        snapshot_mount_id = _mount_id_for_fd(snapshot_fd)
+    except RetentionError:
+        os.close(snapshot_fd)
+        raise
+    if snapshot_mount_id != root_mount_id:
+        os.close(snapshot_fd)
+        raise RetentionError(f"rollback snapshot is on a different mount: {snapshot.name}")
     return snapshot_fd
 
 
-def _validated_entry_names(snapshot_fd: int, snapshot_name: str) -> tuple[str, ...]:
+def _validated_entry_names(
+    snapshot_fd: int,
+    root_mount_id: int,
+    snapshot_name: str,
+) -> tuple[str, ...]:
     try:
         with os.scandir(snapshot_fd) as entries:
             names = tuple(entry.name for entry in entries)
@@ -155,10 +184,34 @@ def _validated_entry_names(snapshot_fd: int, snapshot_name: str) -> tuple[str, .
             raise RetentionError(
                 f"rollback snapshot entry is not an owned regular file: {snapshot_name}/{name}"
             )
+        try:
+            child_fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW, dir_fd=snapshot_fd)
+        except OSError as exc:
+            raise RetentionError(
+                f"rollback snapshot entry cannot be opened safely: {snapshot_name}/{name}"
+            ) from exc
+        try:
+            opened = os.fstat(child_fd)
+            if (opened.st_dev, opened.st_ino) != (child.st_dev, child.st_ino):
+                raise RetentionError(
+                    f"rollback snapshot entry changed while opening: {snapshot_name}/{name}"
+                )
+            if _mount_id_for_fd(child_fd) != root_mount_id:
+                raise RetentionError(
+                    f"rollback snapshot entry is on a different mount: {snapshot_name}/{name}"
+                )
+        finally:
+            os.close(child_fd)
     return tuple(sorted(names))
 
 
-def _validate_snapshot(root_fd: int, name: str, *, expected: Snapshot | None = None) -> Snapshot:
+def _validate_snapshot(
+    root_fd: int,
+    root_mount_id: int,
+    name: str,
+    *,
+    expected: Snapshot | None = None,
+) -> Snapshot:
     created_at = _parse_timestamp(name)
     try:
         metadata = os.stat(name, dir_fd=root_fd, follow_symlinks=False)
@@ -177,22 +230,27 @@ def _validate_snapshot(root_fd: int, name: str, *, expected: Snapshot | None = N
         raise RetentionError(f"rollback snapshot changed before deletion: {name}")
 
     snapshot = Snapshot(name, created_at, metadata.st_dev, metadata.st_ino)
-    snapshot_fd = _open_snapshot(root_fd, snapshot)
+    snapshot_fd = _open_snapshot(root_fd, root_mount_id, snapshot)
     try:
-        _validated_entry_names(snapshot_fd, name)
+        _validated_entry_names(snapshot_fd, root_mount_id, name)
     finally:
         os.close(snapshot_fd)
     return snapshot
 
 
-def _delete_snapshot(root_fd: int, expected: Snapshot) -> None:
-    snapshot = _validate_snapshot(root_fd, expected.name, expected=expected)
-    snapshot_fd = _open_snapshot(root_fd, snapshot)
+def _delete_snapshot(root_fd: int, root_mount_id: int, expected: Snapshot) -> None:
+    snapshot = _validate_snapshot(
+        root_fd,
+        root_mount_id,
+        expected.name,
+        expected=expected,
+    )
+    snapshot_fd = _open_snapshot(root_fd, root_mount_id, snapshot)
     try:
         # Snapshots are deliberately flat. Revalidate and unlink only the
         # allowlisted regular files through the already-verified directory fd;
         # never recurse into an entry that appears after validation.
-        for name in _validated_entry_names(snapshot_fd, snapshot.name):
+        for name in _validated_entry_names(snapshot_fd, root_mount_id, snapshot.name):
             try:
                 os.unlink(name, dir_fd=snapshot_fd)
             except OSError as exc:
@@ -210,7 +268,7 @@ def _delete_snapshot(root_fd: int, expected: Snapshot) -> None:
         ) from exc
 
 
-def _list_snapshots(root_fd: int, *, now: datetime) -> list[Snapshot]:
+def _list_snapshots(root_fd: int, root_mount_id: int, *, now: datetime) -> list[Snapshot]:
     snapshots: list[Snapshot] = []
     try:
         with os.scandir(root_fd) as entries:
@@ -218,7 +276,7 @@ def _list_snapshots(root_fd: int, *, now: datetime) -> list[Snapshot]:
     except OSError as exc:
         raise RetentionError("rollback root cannot be enumerated safely") from exc
     for name in names:
-        snapshot = _validate_snapshot(root_fd, name)
+        snapshot = _validate_snapshot(root_fd, root_mount_id, name)
         if snapshot.created_at > now + FUTURE_SKEW:
             raise RetentionError(f"rollback timestamp is unexpectedly in the future: {name}")
         snapshots.append(snapshot)
@@ -237,9 +295,9 @@ def prune_snapshots(
         raise RetentionError("retention clock must be timezone-aware")
     current_time = current_time.astimezone(UTC)
     _require_deploy_lock(lock_fd)
-    root_fd = _open_root()
+    root_fd, root_mount_id = _open_root()
     try:
-        snapshots = _list_snapshots(root_fd, now=current_time)
+        snapshots = _list_snapshots(root_fd, root_mount_id, now=current_time)
         if protect_name is not None:
             _parse_timestamp(protect_name)
             if not snapshots or snapshots[-1].name != protect_name:
@@ -259,7 +317,7 @@ def prune_snapshots(
         # each target by inode and contents immediately before flat,
         # fd-relative removal.
         for snapshot in to_delete:
-            _delete_snapshot(root_fd, snapshot)
+            _delete_snapshot(root_fd, root_mount_id, snapshot)
         if to_delete:
             os.fsync(root_fd)
         deleted = tuple(snapshot.name for snapshot in to_delete)

--- a/deploy/observability/prune_rollbacks.py
+++ b/deploy/observability/prune_rollbacks.py
@@ -7,11 +7,10 @@ import argparse
 import fcntl
 import os
 import re
-import shutil
 import stat
 import sys
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 ROLLBACK_ROOT = Path("/var/lib/jobseek-observability/rollback")
@@ -22,6 +21,8 @@ MAX_AGE = timedelta(days=14)
 FUTURE_SKEW = timedelta(minutes=5)
 EXPECTED_UID = 0
 EXPECTED_GID = 0
+# The crawler host remains on Ubuntu 22.04 with system Python 3.10.
+UTC = timezone.utc  # noqa: UP017
 SNAPSHOT_RE = re.compile(r"^[0-9]{8}T[0-9]{6}Z$")
 ALLOWED_FILES = frozenset(
     {
@@ -118,6 +119,45 @@ def _parse_timestamp(name: str) -> datetime:
     return parsed
 
 
+def _open_snapshot(root_fd: int, snapshot: Snapshot) -> int:
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    try:
+        snapshot_fd = os.open(snapshot.name, flags, dir_fd=root_fd)
+    except OSError as exc:
+        raise RetentionError(f"rollback snapshot cannot be opened safely: {snapshot.name}") from exc
+    opened = os.fstat(snapshot_fd)
+    if (opened.st_dev, opened.st_ino) != (snapshot.device, snapshot.inode):
+        os.close(snapshot_fd)
+        raise RetentionError(f"rollback snapshot changed while opening: {snapshot.name}")
+    return snapshot_fd
+
+
+def _validated_entry_names(snapshot_fd: int, snapshot_name: str) -> tuple[str, ...]:
+    try:
+        with os.scandir(snapshot_fd) as entries:
+            names = tuple(entry.name for entry in entries)
+    except OSError as exc:
+        raise RetentionError(
+            f"rollback snapshot cannot be enumerated safely: {snapshot_name}"
+        ) from exc
+    for name in names:
+        if name not in ALLOWED_FILES:
+            raise RetentionError(
+                f"rollback snapshot contains an unexpected entry: {snapshot_name}/{name}"
+            )
+        try:
+            child = os.stat(name, dir_fd=snapshot_fd, follow_symlinks=False)
+        except OSError as exc:
+            raise RetentionError(
+                f"rollback snapshot entry is unavailable: {snapshot_name}/{name}"
+            ) from exc
+        if not stat.S_ISREG(child.st_mode) or child.st_uid != EXPECTED_UID or child.st_nlink != 1:
+            raise RetentionError(
+                f"rollback snapshot entry is not an owned regular file: {snapshot_name}/{name}"
+            )
+    return tuple(sorted(names))
+
+
 def _validate_snapshot(root_fd: int, name: str, *, expected: Snapshot | None = None) -> Snapshot:
     created_at = _parse_timestamp(name)
     try:
@@ -136,34 +176,38 @@ def _validate_snapshot(root_fd: int, name: str, *, expected: Snapshot | None = N
     ):
         raise RetentionError(f"rollback snapshot changed before deletion: {name}")
 
-    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    snapshot = Snapshot(name, created_at, metadata.st_dev, metadata.st_ino)
+    snapshot_fd = _open_snapshot(root_fd, snapshot)
     try:
-        snapshot_fd = os.open(name, flags, dir_fd=root_fd)
-    except OSError as exc:
-        raise RetentionError(f"rollback snapshot cannot be opened safely: {name}") from exc
-    try:
-        opened = os.fstat(snapshot_fd)
-        if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
-            raise RetentionError(f"rollback snapshot changed while opening: {name}")
-        with os.scandir(snapshot_fd) as entries:
-            for entry in entries:
-                if entry.name not in ALLOWED_FILES:
-                    raise RetentionError(
-                        f"rollback snapshot contains an unexpected entry: {name}/{entry.name}"
-                    )
-                child = entry.stat(follow_symlinks=False)
-                if (
-                    entry.is_symlink()
-                    or not stat.S_ISREG(child.st_mode)
-                    or child.st_uid != EXPECTED_UID
-                    or child.st_nlink != 1
-                ):
-                    raise RetentionError(
-                        f"rollback snapshot entry is not an owned regular file: {name}/{entry.name}"
-                    )
+        _validated_entry_names(snapshot_fd, name)
     finally:
         os.close(snapshot_fd)
-    return Snapshot(name, created_at, metadata.st_dev, metadata.st_ino)
+    return snapshot
+
+
+def _delete_snapshot(root_fd: int, expected: Snapshot) -> None:
+    snapshot = _validate_snapshot(root_fd, expected.name, expected=expected)
+    snapshot_fd = _open_snapshot(root_fd, snapshot)
+    try:
+        # Snapshots are deliberately flat. Revalidate and unlink only the
+        # allowlisted regular files through the already-verified directory fd;
+        # never recurse into an entry that appears after validation.
+        for name in _validated_entry_names(snapshot_fd, snapshot.name):
+            try:
+                os.unlink(name, dir_fd=snapshot_fd)
+            except OSError as exc:
+                raise RetentionError(
+                    f"rollback snapshot entry could not be removed safely: {snapshot.name}/{name}"
+                ) from exc
+        os.fsync(snapshot_fd)
+    finally:
+        os.close(snapshot_fd)
+    try:
+        os.rmdir(snapshot.name, dir_fd=root_fd)
+    except OSError as exc:
+        raise RetentionError(
+            f"rollback snapshot could not be removed safely: {snapshot.name}"
+        ) from exc
 
 
 def _list_snapshots(root_fd: int, *, now: datetime) -> list[Snapshot]:
@@ -188,8 +232,6 @@ def prune_snapshots(
     lock_fd: int = DEPLOY_LOCK_FD,
 ) -> RetentionReport:
     """Validate the full root, then retain a bounded recent rollback set."""
-    if not shutil.rmtree.avoids_symlink_attacks:
-        raise RetentionError("platform lacks symlink-safe recursive removal")
     current_time = now or datetime.now(UTC)
     if current_time.tzinfo is None:
         raise RetentionError("retention clock must be timezone-aware")
@@ -214,16 +256,10 @@ def prune_snapshots(
         ]
 
         # The complete root is validated before the first deletion. Revalidate
-        # each target by inode and contents immediately before fd-relative,
-        # symlink-resistant removal.
+        # each target by inode and contents immediately before flat,
+        # fd-relative removal.
         for snapshot in to_delete:
-            _validate_snapshot(root_fd, snapshot.name, expected=snapshot)
-            try:
-                shutil.rmtree(snapshot.name, dir_fd=root_fd)
-            except OSError as exc:
-                raise RetentionError(
-                    f"rollback snapshot could not be removed safely: {snapshot.name}"
-                ) from exc
+            _delete_snapshot(root_fd, snapshot)
         if to_delete:
             os.fsync(root_fd)
         deleted = tuple(snapshot.name for snapshot in to_delete)

--- a/deploy/observability/prune_rollbacks.py
+++ b/deploy/observability/prune_rollbacks.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Fail-closed retention for installer-owned observability rollback snapshots."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import os
+import re
+import shutil
+import stat
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+ROLLBACK_ROOT = Path("/var/lib/jobseek-observability/rollback")
+DEPLOY_LOCK = Path("/run/jobseek-observability-deploy.lock")
+DEPLOY_LOCK_FD = 9
+RETAIN_COUNT = 3
+MAX_AGE = timedelta(days=14)
+FUTURE_SKEW = timedelta(minutes=5)
+EXPECTED_UID = 0
+EXPECTED_GID = 0
+SNAPSHOT_RE = re.compile(r"^[0-9]{8}T[0-9]{6}Z$")
+ALLOWED_FILES = frozenset(
+    {
+        "jobseek-alloy",
+        "jobseek-host-observability",
+        "alloy-host.alloy",
+        "alloy.env",
+        "host.env",
+        "deployed-sha",
+        "jobseek-alloy.service",
+        "jobseek-host-observability.service",
+        "jobseek-host-observability.timer",
+    }
+)
+
+
+class RetentionError(RuntimeError):
+    """Rollback retention cannot prove that deletion is safe."""
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    name: str
+    created_at: datetime
+    device: int
+    inode: int
+
+
+@dataclass(frozen=True)
+class RetentionReport:
+    retained: tuple[str, ...]
+    deleted: tuple[str, ...]
+
+
+def _require_exact_path(path: Path, *, directory: bool) -> os.stat_result:
+    try:
+        metadata = path.lstat()
+        resolved = path.resolve(strict=True)
+    except OSError as exc:
+        raise RetentionError(f"required retention path is unavailable: {path}") from exc
+    if stat.S_ISLNK(metadata.st_mode):
+        raise RetentionError(f"retention path must not be a symlink: {path}")
+    expected_type = stat.S_ISDIR if directory else stat.S_ISREG
+    if not expected_type(metadata.st_mode):
+        raise RetentionError(f"retention path has an unexpected type: {path}")
+    if resolved != path:
+        raise RetentionError(f"retention path does not resolve to its exact location: {path}")
+    if metadata.st_uid != EXPECTED_UID or metadata.st_gid != EXPECTED_GID:
+        raise RetentionError(f"retention path has unexpected ownership: {path}")
+    return metadata
+
+
+def _require_deploy_lock(lock_fd: int) -> None:
+    lock_metadata = _require_exact_path(DEPLOY_LOCK, directory=False)
+    try:
+        fd_metadata = os.fstat(lock_fd)
+        fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (OSError, BlockingIOError) as exc:
+        raise RetentionError("observability deployment lock is not held") from exc
+    if (fd_metadata.st_dev, fd_metadata.st_ino) != (
+        lock_metadata.st_dev,
+        lock_metadata.st_ino,
+    ):
+        raise RetentionError("retention lock descriptor is not the deployment lock")
+
+
+def _open_root() -> int:
+    metadata = _require_exact_path(ROLLBACK_ROOT, directory=True)
+    if stat.S_IMODE(metadata.st_mode) != 0o700:
+        raise RetentionError("rollback root must be root-owned mode 0700")
+    try:
+        root_fd = os.open(
+            ROLLBACK_ROOT,
+            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW,
+        )
+    except OSError as exc:
+        raise RetentionError("rollback root cannot be opened without following links") from exc
+    opened = os.fstat(root_fd)
+    if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
+        os.close(root_fd)
+        raise RetentionError("rollback root changed while retention was starting")
+    return root_fd
+
+
+def _parse_timestamp(name: str) -> datetime:
+    if SNAPSHOT_RE.fullmatch(name) is None:
+        raise RetentionError(f"unexpected rollback entry name: {name}")
+    try:
+        parsed = datetime.strptime(name, "%Y%m%dT%H%M%SZ").replace(tzinfo=UTC)
+    except ValueError as exc:
+        raise RetentionError(f"invalid rollback timestamp: {name}") from exc
+    if parsed.strftime("%Y%m%dT%H%M%SZ") != name:
+        raise RetentionError(f"non-canonical rollback timestamp: {name}")
+    return parsed
+
+
+def _validate_snapshot(root_fd: int, name: str, *, expected: Snapshot | None = None) -> Snapshot:
+    created_at = _parse_timestamp(name)
+    try:
+        metadata = os.stat(name, dir_fd=root_fd, follow_symlinks=False)
+    except OSError as exc:
+        raise RetentionError(f"rollback snapshot is unavailable: {name}") from exc
+    if not stat.S_ISDIR(metadata.st_mode):
+        raise RetentionError(f"rollback entry is not a directory: {name}")
+    if metadata.st_uid != EXPECTED_UID or metadata.st_gid != EXPECTED_GID:
+        raise RetentionError(f"rollback snapshot has unexpected ownership: {name}")
+    if stat.S_IMODE(metadata.st_mode) != 0o700:
+        raise RetentionError(f"rollback snapshot must be mode 0700: {name}")
+    if expected is not None and (metadata.st_dev, metadata.st_ino) != (
+        expected.device,
+        expected.inode,
+    ):
+        raise RetentionError(f"rollback snapshot changed before deletion: {name}")
+
+    flags = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
+    try:
+        snapshot_fd = os.open(name, flags, dir_fd=root_fd)
+    except OSError as exc:
+        raise RetentionError(f"rollback snapshot cannot be opened safely: {name}") from exc
+    try:
+        opened = os.fstat(snapshot_fd)
+        if (opened.st_dev, opened.st_ino) != (metadata.st_dev, metadata.st_ino):
+            raise RetentionError(f"rollback snapshot changed while opening: {name}")
+        with os.scandir(snapshot_fd) as entries:
+            for entry in entries:
+                if entry.name not in ALLOWED_FILES:
+                    raise RetentionError(
+                        f"rollback snapshot contains an unexpected entry: {name}/{entry.name}"
+                    )
+                child = entry.stat(follow_symlinks=False)
+                if (
+                    entry.is_symlink()
+                    or not stat.S_ISREG(child.st_mode)
+                    or child.st_uid != EXPECTED_UID
+                    or child.st_nlink != 1
+                ):
+                    raise RetentionError(
+                        f"rollback snapshot entry is not an owned regular file: {name}/{entry.name}"
+                    )
+    finally:
+        os.close(snapshot_fd)
+    return Snapshot(name, created_at, metadata.st_dev, metadata.st_ino)
+
+
+def _list_snapshots(root_fd: int, *, now: datetime) -> list[Snapshot]:
+    snapshots: list[Snapshot] = []
+    try:
+        with os.scandir(root_fd) as entries:
+            names = [entry.name for entry in entries]
+    except OSError as exc:
+        raise RetentionError("rollback root cannot be enumerated safely") from exc
+    for name in names:
+        snapshot = _validate_snapshot(root_fd, name)
+        if snapshot.created_at > now + FUTURE_SKEW:
+            raise RetentionError(f"rollback timestamp is unexpectedly in the future: {name}")
+        snapshots.append(snapshot)
+    return sorted(snapshots, key=lambda snapshot: (snapshot.created_at, snapshot.name))
+
+
+def prune_snapshots(
+    *,
+    protect_name: str | None,
+    now: datetime | None = None,
+    lock_fd: int = DEPLOY_LOCK_FD,
+) -> RetentionReport:
+    """Validate the full root, then retain a bounded recent rollback set."""
+    if not shutil.rmtree.avoids_symlink_attacks:
+        raise RetentionError("platform lacks symlink-safe recursive removal")
+    current_time = now or datetime.now(UTC)
+    if current_time.tzinfo is None:
+        raise RetentionError("retention clock must be timezone-aware")
+    current_time = current_time.astimezone(UTC)
+    _require_deploy_lock(lock_fd)
+    root_fd = _open_root()
+    try:
+        snapshots = _list_snapshots(root_fd, now=current_time)
+        if protect_name is not None:
+            _parse_timestamp(protect_name)
+            if not snapshots or snapshots[-1].name != protect_name:
+                raise RetentionError("accepted rollback is not the newest validated snapshot")
+
+        newest_names = {snapshot.name for snapshot in snapshots[-RETAIN_COUNT:]}
+        newest_name = snapshots[-1].name if snapshots else None
+        cutoff = current_time - MAX_AGE
+        to_delete = [
+            snapshot
+            for snapshot in snapshots
+            if snapshot.name != newest_name
+            and (snapshot.name not in newest_names or snapshot.created_at < cutoff)
+        ]
+
+        # The complete root is validated before the first deletion. Revalidate
+        # each target by inode and contents immediately before fd-relative,
+        # symlink-resistant removal.
+        for snapshot in to_delete:
+            _validate_snapshot(root_fd, snapshot.name, expected=snapshot)
+            try:
+                shutil.rmtree(snapshot.name, dir_fd=root_fd)
+            except OSError as exc:
+                raise RetentionError(
+                    f"rollback snapshot could not be removed safely: {snapshot.name}"
+                ) from exc
+        if to_delete:
+            os.fsync(root_fd)
+        deleted = tuple(snapshot.name for snapshot in to_delete)
+        retained = tuple(snapshot.name for snapshot in snapshots if snapshot.name not in deleted)
+        return RetentionReport(retained=retained, deleted=deleted)
+    finally:
+        os.close(root_fd)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--protect-name", required=True)
+    args = parser.parse_args()
+    try:
+        report = prune_snapshots(protect_name=args.protect_name)
+    except RetentionError as exc:
+        parser.exit(1, f"ERROR: {exc}\n")
+    print(
+        "Observability rollback retention complete; "
+        f"retained={len(report.retained)} deleted={len(report.deleted)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/deploy/observability/test_prune_rollbacks.py
+++ b/deploy/observability/test_prune_rollbacks.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Behavioral tests for observability rollback retention."""
+
+from __future__ import annotations
+
+import fcntl
+import os
+import subprocess
+import tempfile
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+
+import prune_rollbacks as retention  # pyright: ignore[reportMissingImports]
+
+HERE = Path(__file__).resolve().parent
+INSTALLER = HERE / "install-host.sh"
+
+
+class RollbackRetentionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.base = Path(self.temporary.name).resolve()
+        self.root = self.base / "rollback"
+        self.root.mkdir(mode=0o700)
+        self.lock_path = self.base / "deploy.lock"
+        self.lock_path.touch(mode=0o600)
+        self.lock_fd = os.open(self.lock_path, os.O_RDWR)
+        fcntl.flock(self.lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        self.originals = (
+            retention.ROLLBACK_ROOT,
+            retention.DEPLOY_LOCK,
+            retention.EXPECTED_UID,
+            retention.EXPECTED_GID,
+        )
+        retention.ROLLBACK_ROOT = self.root
+        retention.DEPLOY_LOCK = self.lock_path
+        retention.EXPECTED_UID = os.getuid()
+        retention.EXPECTED_GID = os.getgid()
+        self.now = datetime(2026, 8, 12, 2, 0, tzinfo=UTC)
+
+    def tearDown(self) -> None:
+        (
+            retention.ROLLBACK_ROOT,
+            retention.DEPLOY_LOCK,
+            retention.EXPECTED_UID,
+            retention.EXPECTED_GID,
+        ) = self.originals
+        os.close(self.lock_fd)
+        self.temporary.cleanup()
+
+    def snapshot(self, name: str, payload: bytes | None = b"alloy") -> Path:
+        path = self.root / name
+        path.mkdir(mode=0o700)
+        if payload is not None:
+            (path / "jobseek-alloy").write_bytes(payload)
+        return path
+
+    def test_empty_root_and_first_install_are_safe(self) -> None:
+        empty = retention.prune_snapshots(
+            protect_name=None,
+            now=self.now,
+            lock_fd=self.lock_fd,
+        )
+        self.assertEqual(empty.retained, ())
+        self.assertEqual(empty.deleted, ())
+
+        first = self.snapshot("20260812T020000Z", payload=None)
+        report = retention.prune_snapshots(
+            protect_name=first.name,
+            now=self.now,
+            lock_fd=self.lock_fd,
+        )
+        self.assertEqual(report.retained, (first.name,))
+        self.assertEqual(report.deleted, ())
+        self.assertTrue(first.is_dir())
+
+    def test_successful_repeated_deploys_keep_three_newest_byte_valid_snapshots(self) -> None:
+        names = [
+            "20260808T020000Z",
+            "20260809T020000Z",
+            "20260810T020000Z",
+            "20260811T020000Z",
+            "20260812T020000Z",
+        ]
+        for name in names:
+            self.snapshot(name, payload=name.encode())
+
+        first = retention.prune_snapshots(
+            protect_name=names[-1],
+            now=self.now,
+            lock_fd=self.lock_fd,
+        )
+        self.assertEqual(first.retained, tuple(names[-3:]))
+        self.assertEqual((self.root / names[-1] / "jobseek-alloy").read_bytes(), names[-1].encode())
+
+        next_name = "20260813T020000Z"
+        self.snapshot(next_name, payload=b"next-known-good")
+        second = retention.prune_snapshots(
+            protect_name=next_name,
+            now=datetime(2026, 8, 13, 2, 0, tzinfo=UTC),
+            lock_fd=self.lock_fd,
+        )
+        self.assertEqual(second.retained, (names[-2], names[-1], next_name))
+        self.assertEqual(
+            (self.root / next_name / "jobseek-alloy").read_bytes(),
+            b"next-known-good",
+        )
+
+    def test_age_limit_keeps_only_the_newest_when_other_snapshots_are_stale(self) -> None:
+        for name in (
+            "20260701T020000Z",
+            "20260720T020000Z",
+            "20260721T020000Z",
+            "20260812T020000Z",
+        ):
+            self.snapshot(name)
+
+        report = retention.prune_snapshots(
+            protect_name="20260812T020000Z",
+            now=self.now,
+            lock_fd=self.lock_fd,
+        )
+
+        self.assertEqual(report.retained, ("20260812T020000Z",))
+        self.assertEqual(len(report.deleted), 3)
+
+    def test_concurrent_retention_is_rejected_without_deletion(self) -> None:
+        names = [
+            "20260809T020000Z",
+            "20260810T020000Z",
+            "20260811T020000Z",
+            "20260812T020000Z",
+        ]
+        for name in names:
+            self.snapshot(name)
+        competing_fd = os.open(self.lock_path, os.O_RDWR)
+        try:
+            with self.assertRaisesRegex(retention.RetentionError, "lock"):
+                retention.prune_snapshots(
+                    protect_name=names[-1],
+                    now=self.now,
+                    lock_fd=competing_fd,
+                )
+        finally:
+            os.close(competing_fd)
+        self.assertEqual(sorted(path.name for path in self.root.iterdir()), names)
+
+    def test_unexpected_entry_rejects_the_whole_root_before_deletion(self) -> None:
+        names = [
+            "20260808T020000Z",
+            "20260809T020000Z",
+            "20260810T020000Z",
+            "20260811T020000Z",
+            "20260812T020000Z",
+        ]
+        for name in names:
+            self.snapshot(name)
+        (self.root / "operator-notes").write_text("keep", encoding="utf-8")
+
+        with self.assertRaisesRegex(retention.RetentionError, "unexpected rollback entry name"):
+            retention.prune_snapshots(
+                protect_name=names[-1],
+                now=self.now,
+                lock_fd=self.lock_fd,
+            )
+
+        self.assertEqual(
+            sorted(path.name for path in self.root.iterdir()),
+            sorted([*names, "operator-notes"]),
+        )
+
+    def test_malformed_snapshot_types_and_contents_are_never_deleted(self) -> None:
+        cases = ("top-level-symlink", "timestamp-file", "unexpected-child", "child-symlink")
+        for index, case in enumerate(cases):
+            with self.subTest(case=case):
+                case_root = self.base / f"case-{index}"
+                case_root.mkdir(mode=0o700)
+                retention.ROLLBACK_ROOT = case_root
+                good = case_root / "20260812T020000Z"
+                good.mkdir(mode=0o700)
+                if case == "top-level-symlink":
+                    (case_root / "20260811T020000Z").symlink_to(good, target_is_directory=True)
+                elif case == "timestamp-file":
+                    (case_root / "20260811T020000Z").write_text("not a directory", encoding="utf-8")
+                else:
+                    malformed = case_root / "20260811T020000Z"
+                    malformed.mkdir(mode=0o700)
+                    if case == "unexpected-child":
+                        (malformed / "unowned-file").write_text("keep", encoding="utf-8")
+                    else:
+                        (malformed / "jobseek-alloy").symlink_to(good)
+
+                with self.assertRaises(retention.RetentionError):
+                    retention.prune_snapshots(
+                        protect_name=good.name,
+                        now=self.now,
+                        lock_fd=self.lock_fd,
+                    )
+                self.assertTrue(good.is_dir())
+                self.assertTrue((case_root / "20260811T020000Z").exists())
+
+    def test_symlinked_root_is_rejected(self) -> None:
+        real_root = self.base / "real-root"
+        real_root.mkdir(mode=0o700)
+        snapshot = real_root / "20260812T020000Z"
+        snapshot.mkdir(mode=0o700)
+        linked_root = self.base / "linked-root"
+        linked_root.symlink_to(real_root, target_is_directory=True)
+        retention.ROLLBACK_ROOT = linked_root
+
+        with self.assertRaisesRegex(retention.RetentionError, "symlink"):
+            retention.prune_snapshots(
+                protect_name=snapshot.name,
+                now=self.now,
+                lock_fd=self.lock_fd,
+            )
+        self.assertTrue(snapshot.is_dir())
+
+
+class InstallerLifecycleTests(unittest.TestCase):
+    def run_installer_functions(self, body: str, events: Path) -> subprocess.CompletedProcess[str]:
+        script = f"""
+source {shlex_quote(INSTALLER)} crawler
+restore_previous() {{ printf 'rollback\\n' >> {shlex_quote(events)}; }}
+prune_rollback_snapshots() {{
+  printf 'prune\\n' >> {shlex_quote(events)}
+  return "${{PRUNE_STATUS:-0}}"
+}}
+ROLLBACK_PATH=/var/lib/jobseek-observability/rollback/20260812T020000Z
+ROLLBACK_ARMED=1
+trap rollback_on_exit EXIT
+{body}
+"""
+        return subprocess.run(
+            ["bash", "-c", script],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_failed_install_rolls_back_and_never_prunes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            events = Path(temporary) / "events"
+            result = self.run_installer_functions("false", events)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(events.read_text(encoding="utf-8"), "rollback\n")
+
+    def test_success_disarms_rollback_before_pruning(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            events = Path(temporary) / "events"
+            result = self.run_installer_functions("disarm_rollback_and_prune", events)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(events.read_text(encoding="utf-8"), "prune\n")
+
+    def test_retention_failure_after_success_does_not_roll_back_accepted_surface(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            events = Path(temporary) / "events"
+            result = self.run_installer_functions(
+                "PRUNE_STATUS=9 disarm_rollback_and_prune",
+                events,
+            )
+            self.assertEqual(result.returncode, 9)
+            self.assertEqual(events.read_text(encoding="utf-8"), "prune\n")
+
+
+def shlex_quote(path: Path) -> str:
+    import shlex
+
+    return shlex.quote(str(path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/observability/test_prune_rollbacks.py
+++ b/deploy/observability/test_prune_rollbacks.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import fcntl
 import os
 import subprocess
+import sys
 import tempfile
 import unittest
 from datetime import datetime, timezone
@@ -34,11 +35,13 @@ class RollbackRetentionTests(unittest.TestCase):
             retention.DEPLOY_LOCK,
             retention.EXPECTED_UID,
             retention.EXPECTED_GID,
+            retention._mount_id_for_fd,
         )
         retention.ROLLBACK_ROOT = self.root
         retention.DEPLOY_LOCK = self.lock_path
         retention.EXPECTED_UID = os.getuid()
         retention.EXPECTED_GID = os.getgid()
+        retention._mount_id_for_fd = lambda _fd: 1
         self.now = datetime(2026, 8, 12, 2, 0, tzinfo=UTC)
 
     def tearDown(self) -> None:
@@ -47,6 +50,7 @@ class RollbackRetentionTests(unittest.TestCase):
             retention.DEPLOY_LOCK,
             retention.EXPECTED_UID,
             retention.EXPECTED_GID,
+            retention._mount_id_for_fd,
         ) = self.originals
         os.close(self.lock_fd)
         self.temporary.cleanup()
@@ -218,6 +222,49 @@ class RollbackRetentionTests(unittest.TestCase):
                 lock_fd=self.lock_fd,
             )
         self.assertTrue(snapshot.is_dir())
+
+    def test_same_filesystem_bind_mount_identity_is_rejected(self) -> None:
+        old = self.snapshot("20260811T020000Z")
+        newest = self.snapshot("20260812T020000Z")
+        old_metadata = old.stat()
+        self.assertEqual(old_metadata.st_dev, self.root.stat().st_dev)
+
+        def fake_mount_id(fd: int) -> int:
+            opened = os.fstat(fd)
+            if (opened.st_dev, opened.st_ino) == (old_metadata.st_dev, old_metadata.st_ino):
+                return 2
+            return 1
+
+        retention._mount_id_for_fd = fake_mount_id
+        with self.assertRaisesRegex(retention.RetentionError, "different mount"):
+            retention.prune_snapshots(
+                protect_name=newest.name,
+                now=self.now,
+                lock_fd=self.lock_fd,
+            )
+        self.assertTrue(old.is_dir())
+        self.assertTrue(newest.is_dir())
+
+    @unittest.skipUnless(sys.platform.startswith("linux"), "Linux fdinfo contract")
+    def test_linux_fdinfo_reports_the_same_mount_for_root_snapshot_and_file(self) -> None:
+        snapshot = self.snapshot("20260812T020000Z")
+        actual_mount_id_for_fd = self.originals[4]
+        root_fd = os.open(self.root, os.O_RDONLY | os.O_DIRECTORY)
+        snapshot_fd = os.open(snapshot, os.O_RDONLY | os.O_DIRECTORY)
+        file_fd = os.open(snapshot / "jobseek-alloy", os.O_RDONLY)
+        try:
+            self.assertEqual(
+                {
+                    actual_mount_id_for_fd(root_fd),
+                    actual_mount_id_for_fd(snapshot_fd),
+                    actual_mount_id_for_fd(file_fd),
+                },
+                {actual_mount_id_for_fd(root_fd)},
+            )
+        finally:
+            os.close(file_fd)
+            os.close(snapshot_fd)
+            os.close(root_fd)
 
 
 class InstallerLifecycleTests(unittest.TestCase):

--- a/deploy/observability/test_prune_rollbacks.py
+++ b/deploy/observability/test_prune_rollbacks.py
@@ -8,13 +8,15 @@ import os
 import subprocess
 import tempfile
 import unittest
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import prune_rollbacks as retention  # pyright: ignore[reportMissingImports]
 
 HERE = Path(__file__).resolve().parent
 INSTALLER = HERE / "install-host.sh"
+# Match the Ubuntu 22.04 production interpreter supported by the helper.
+UTC = timezone.utc  # noqa: UP017
 
 
 class RollbackRetentionTests(unittest.TestCase):

--- a/docs/16-hetzner-maintenance.md
+++ b/docs/16-hetzner-maintenance.md
@@ -774,7 +774,18 @@ and units under the root-only
 `/var/lib/jobseek-observability/rollback/` directory and automatically
 restores them if validation, service startup, or loopback readiness fails;
 artifacts that did not exist before the attempt are removed rather than left
-as a partial installation.
+as a partial installation. Failed attempts never run retention. After a new
+surface is fully accepted and its automatic rollback trap is disarmed, the
+installer prunes under the same deployment lock. It keeps at most the three
+newest timestamped snapshots, removes snapshots older than 14 days, and always
+keeps the just-accepted rollback even when it is the only remaining snapshot.
+The complete root is validated before deletion: its path, ownership, mode,
+timestamp names, directory types, and allowlisted regular-file contents must
+all match the installer contract, with no symlinks. Any unexpected entry stops
+retention without deleting known snapshots; operators must classify and move
+that entry explicitly before rerunning the reviewed deployment. A retention
+failure happens after service acceptance, so it reports deployment failure but
+does not roll the healthy surface back.
 It restarts only Alloy; it does not restart Docker, PostgreSQL, Typesense, the
 tunnel, or any crawler workload.
 

--- a/docs/16-hetzner-maintenance.md
+++ b/docs/16-hetzner-maintenance.md
@@ -781,11 +781,13 @@ newest timestamped snapshots, removes snapshots older than 14 days, and always
 keeps the just-accepted rollback even when it is the only remaining snapshot.
 The complete root is validated before deletion: its path, ownership, mode,
 timestamp names, directory types, and allowlisted regular-file contents must
-all match the installer contract, with no symlinks. Any unexpected entry stops
-retention without deleting known snapshots; operators must classify and move
-that entry explicitly before rerunning the reviewed deployment. A retention
-failure happens after service acceptance, so it reports deployment failure but
-does not roll the healthy surface back.
+all match the installer contract, with no symlinks. The kernel mount identity
+of every snapshot directory and file must also equal the rollback root, so a
+bind mount is rejected even when it shares the root filesystem's device ID.
+Any unexpected entry stops retention without deleting known snapshots;
+operators must classify and move that entry explicitly before rerunning the
+reviewed deployment. A retention failure happens after service acceptance, so
+it reports deployment failure but does not roll the healthy surface back.
 It restarts only Alloy; it does not restart Docker, PostgreSQL, Typesense, the
 tunnel, or any crawler workload.
 

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -414,6 +414,11 @@ test("PR-only CI gates cover pull requests and dispatched PRs", () => {
 });
 
 test("workflow-security runs repository script tests", () => {
+  assert.match(workflow, /name: Test observability rollback retention/);
+  assert.match(
+    workflow,
+    /python3 deploy\/observability\/test_prune_rollbacks\.py/,
+  );
   assert.match(workflow, /node --test/);
   assert.match(workflow, /scripts\/ci-workflow\.test\.mjs/);
   assert.match(workflow, /scripts\/crawler-version\.test\.mjs/);


### PR DESCRIPTION
Closes #7217.

## Summary
- retain at most three timestamped observability rollback snapshots and expire snapshots older than 14 days while always protecting the newest accepted rollback
- prune only after service acceptance and rollback disarm, under the existing deployment lock
- validate the exact root, lock, timestamped directories, ownership, modes, and allowlisted regular-file contents before any flat, fd-relative deletion
- require the Linux kernel mount ID of every snapshot directory and file to equal the rollback root, rejecting ordinary and same-filesystem bind mounts
- exercise empty, first-install, failed-install, successful, repeated, stale, concurrent, malformed-entry, and mount-identity behavior
- validate the helper against the Ubuntu 22.04 production floor (Python 3.10)
- document the retention and fail-closed operator contract

## Verification
- Python 3.10 compile plus deploy/observability/test_prune_rollbacks.py (12 cases; 11 passed locally and the Linux-only real fdinfo integration case is exercised in CI)
- focused observability pytest suite (109 passed before rebase; 63 direct tests after review corrections)
- repository workflow/docs/security Node suite (106 passed before rebase; 52 direct tests after review correction)
- Ruff check/format and Pyright for the new Python files
- bash -n and ShellCheck for install-host.sh
- Python compile checks and Grafana alert/rules dry-runs

## Deployment boundary
Draft only. No production deployment, merge, issue closure, or ad-hoc deletion was performed.