### PR TITLE
Fix public watchlist cold loads

### DIFF
--- a/apps/web/app/[lang]/(app)/watchlists/__tests__/watchlists-loader.test.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/__tests__/watchlists-loader.test.tsx
@@ -124,6 +124,34 @@ describe("WatchlistsLoader server read (#5896)", () => {
     expect(page.getAttribute("data-popular-count")).toBe("0");
     expect(page.getAttribute("data-popular-total")).toBe("0");
   });
+
+  it("does not discard a cold popular-watchlist response after three seconds", async () => {
+    vi.useFakeTimers();
+    try {
+      mocks.load.mockResolvedValue({
+        watchlists: [{ id: "wl-1" }],
+        limitReached: false,
+      });
+      mocks.popular.mockImplementation(
+        () => new Promise((resolve) => {
+          setTimeout(() => resolve({
+            watchlists: [{ id: "public-wl-1" }],
+            total: 12,
+          }), 3_100);
+        }),
+      );
+
+      const loader = WatchlistsLoader({ locale: "en" });
+      await vi.advanceTimersByTimeAsync(3_100);
+      render(await loader);
+
+      const page = screen.getByTestId("watchlists-page");
+      expect(page.getAttribute("data-popular-count")).toBe("1");
+      expect(page.getAttribute("data-popular-total")).toBe("12");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe("Watchlists route partial prerendering", () => {

--- a/apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/watchlists-loader.tsx
@@ -9,7 +9,6 @@ import { logExternalError } from "@/lib/safe-external-error";
 import { WatchlistsPage } from "./watchlists-page";
 
 const WATCHLIST_LOAD_TIMEOUT_MS = 8_000;
-const PUBLIC_WATCHLIST_LOAD_TIMEOUT_MS = 3_000;
 const PUBLIC_WATCHLIST_PAGE_SIZE = 10;
 
 async function loadWatchlists(locale: string) {
@@ -21,27 +20,6 @@ async function loadWatchlists(locale: string) {
         timeoutId = setTimeout(
           () => reject(new Error("Watchlists request timed out")),
           WATCHLIST_LOAD_TIMEOUT_MS,
-        );
-      }),
-    ]);
-  } finally {
-    if (timeoutId) clearTimeout(timeoutId);
-  }
-}
-
-async function loadPopularWatchlists(locale: string) {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      getPopularWatchlists({
-        offset: 0,
-        limit: PUBLIC_WATCHLIST_PAGE_SIZE,
-        locale,
-      }),
-      new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(
-          () => reject(new Error("Popular watchlists request timed out")),
-          PUBLIC_WATCHLIST_LOAD_TIMEOUT_MS,
         );
       }),
     ]);
@@ -62,7 +40,14 @@ export async function WatchlistsLoader({ locale }: { locale: string }) {
   try {
     const [{ watchlists, limitReached }, popular] = await Promise.all([
       loadWatchlists(locale),
-      loadPopularWatchlists(locale).catch((err) => {
+      // A cold precise-count pass can take longer than three seconds. Do not
+      // abandon it here: this is the only mount read, so a timed-out result
+      // would leave the public panel empty until the user hard-reloads.
+      getPopularWatchlists({
+        offset: 0,
+        limit: PUBLIC_WATCHLIST_PAGE_SIZE,
+        locale,
+      }).catch((err) => {
         logExternalError(
           "error",
           { service: "typesense", operation: "load_popular_watchlists" },


### PR DESCRIPTION
## What changed

- remove the premature three-second application timeout from the server-rendered popular-watchlist read
- keep genuine Typesense failures isolated so personal watchlists still render
- add a regression test for a cold public-watchlist response that completes after 3.1 seconds

## Root cause

The watchlists page recently moved its initial public-list read into the server render. A three-second `Promise.race` converted slow cold reads into an empty initial list while the underlying request continued and warmed the cache. Because the client intentionally skips its initial read when mount data is present, that empty result remained on screen until a hard reload.

## User impact

Public watchlists now render on the first successful cold load instead of intermittently appearing blank and only recovering after refresh.

## Validation

- 79 relevant watchlist tests
- targeted ESLint
- Next.js route type generation and TypeScript typecheck
- `git diff --check`
- reproduced in production before the fix: page blank while `/api/v1/watchlists?locale=en` returned 10 entries
