### PR TITLE
Stop company syncs from resetting the web cache

### DIFF
--- a/.github/scripts/classify-vercel-web-change.mjs
+++ b/.github/scripts/classify-vercel-web-change.mjs
@@ -9,12 +9,17 @@ const EXACT_WEB_INPUTS = new Set([
   ".github/scripts/verify-vercel-server-action-key.mjs",
   ".github/scripts/verify-vercel-promotion.mjs",
   ".github/workflows/deploy-web-production.yml",
-  "apps/crawler/data/companies.csv",
   "package.json",
   "pnpm-lock.yaml",
   "pnpm-workspace.yaml",
   "turbo.json",
 ]);
+
+// `apps/crawler/data/companies.csv` is intentionally absent. A deployed
+// matcher snapshot bypasses Proxy for the companies it already knows, while a
+// newly synced slug takes the bounded Typesense status path until the next
+// genuine web build. Treating every registry change as a web input replaces
+// the Next.js build ID and cold-starts the entire Cache Components namespace.
 
 const WEB_INPUT_PREFIXES = [
   "apps/web/",

--- a/.github/scripts/dispatch-company-production-sync.sh
+++ b/.github/scripts/dispatch-company-production-sync.sh
@@ -45,46 +45,13 @@ fi
 echo "Waiting for company OG prewarm run $prewarm_run_id"
 gh run watch "$prewarm_run_id" --repo "$REPO" --exit-status
 
-# Company routes are compiled out of Proxy from the registry. Bot-authored
-# merges do not emit push workflows, so explicitly deploy and wait for the
-# exact prewarmed revision before publishing its Typesense data. A failure
-# leaves the company unpublished instead of serving it through a stale Proxy
-# matcher or exposing a broken social image.
-web_deploy_started=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-gh workflow run deploy-web-production.yml \
-  --repo "$REPO" \
-  --ref "$default_branch" \
-  -f revision="$prewarm_sha"
-
-web_deploy_run_id=""
-for attempt in $(seq 1 30); do
-  web_deploy_run_id=$(gh run list \
-    --repo "$REPO" \
-    --workflow deploy-web-production.yml \
-    --branch "$default_branch" \
-    --event workflow_dispatch \
-    --limit 20 \
-    --json databaseId,createdAt,headSha \
-    --jq ".[] | select(.createdAt >= \"$web_deploy_started\" and .headSha == \"$prewarm_sha\") | .databaseId" \
-    | head -n1)
-  if [[ "$web_deploy_run_id" =~ ^[0-9]+$ ]]; then
-    break
-  fi
-  web_deploy_run_id=""
-  echo "Waiting for web deployment run to appear (attempt $attempt/30)"
-  sleep 2
-done
-
-if [[ -z "$web_deploy_run_id" ]]; then
-  echo "Unable to identify the dispatched web deployment run for $prewarm_sha" >&2
-  exit 1
-fi
-
-echo "Waiting for web deployment run $web_deploy_run_id"
-gh run watch "$web_deploy_run_id" --repo "$REPO" --exit-status
-
-# Publish through the normal CSV sync only after the matching web deployment
-# is live. The sync invalidates the company CSV tag after Typesense is ready.
+# Publish through the normal CSV sync after the matching OG namespace is
+# complete. The deployed Proxy snapshot deliberately does not need to contain
+# a brand-new slug: candidates absent from that snapshot take the bounded
+# Typesense status path until the next genuine web release regenerates the
+# fast bypass matcher. This preserves immediate visibility and hard 404s
+# without replacing the Next.js build ID and cold-starting every page cache.
+# The sync invalidates the company CSV tag after Typesense is ready.
 gh workflow run sync-data.yml \
   --repo "$REPO" \
   --ref "$default_branch" \

--- a/apps/web/docs/company-og-cache.md
+++ b/apps/web/docs/company-og-cache.md
@@ -69,8 +69,10 @@ Company PRs merged by the repository's trusted auto-merge workflow use
 `GITHUB_TOKEN`, so GitHub intentionally suppresses their recursive `push`
 workflows. The same post-merge helper that dispatches production CSV sync also
 dispatches this prewarm explicitly and waits for it to succeed before starting
-the CSV sync at that exact prewarmed main SHA; neither data consumer may rely
-solely on a push path filter.
+the CSV sync at that exact prewarmed main SHA. It deliberately does not replace
+the web deployment: a new slug uses the deployed Proxy snapshot's bounded
+Typesense path until the next genuine web release includes it in the fast
+bypass matcher. Neither data consumer may rely solely on a push path filter.
 
 The production GitHub environment supplies R2 write credentials. The job has
 no dependency on the public Typesense tunnel and sends no request through the

--- a/apps/web/docs/edge-requests.md
+++ b/apps/web/docs/edge-requests.md
@@ -63,17 +63,20 @@ company candidates, and public-watchlist document status checks.
 The company matcher is generated from `apps/crawler/data/companies.csv`.
 Registered canonical slugs do not match Proxy at all, so a warm company page
 can reach Vercel's page cache without first consuming a middleware invocation.
-Only slug candidates absent from that deployment's registry enter the
-Typesense status check. `pnpm dev` and `pnpm build` refresh the generated block;
-`pnpm proxy-matchers:check` is available as a read-only freshness gate. The
-production deploy classifier treats the company registry as a web input. For
-bot-authored company merges, the trusted production dispatcher requests and
-waits for that exact revision; the deployment fails closed if main moves before
-promotion. Only then does the crawler sync publish Typesense data and
-invalidate the company CSV cache tag, evicting any route snapshot created in
-the short deploy-before-sync window. The registry is also an explicit input to
-the `@jobseek/web#build` Turbo task; a data-only company change therefore cannot
-restore an older `.next` artifact and skip matcher generation.
+Only slug candidates absent from that deployment's registry enter the bounded
+Typesense status check. That includes newly added companies until the next
+genuine web release, so company data can become visible immediately without
+replacing the current deployment. `pnpm dev` and `pnpm build` refresh the
+generated block; `pnpm proxy-matchers:check` is available as a read-only
+freshness gate. The production deploy classifier deliberately does not treat
+the company registry as a web input: replacing the Next.js build for every
+company addition changes the build-keyed Cache Components namespace and
+cold-starts the entire page cache. The trusted production dispatcher instead
+waits for the exact revision's OG prewarm, then publishes its Typesense data and
+invalidates the company CSV cache tag. The registry remains an explicit input
+to the `@jobseek/web#build` Turbo task so every unrelated, genuine web build
+regenerates the fast bypass matcher from the current registry rather than
+restoring an older `.next` artifact.
 
 The same generator excludes every reserved username prefix from the generic
 two-segment watchlist matcher. This lets explicit multi-segment application

--- a/apps/web/src/lib/__tests__/proxy.test.ts
+++ b/apps/web/src/lib/__tests__/proxy.test.ts
@@ -333,10 +333,12 @@ describe("missing-resource HTTP boundary", () => {
     expect(forbiddenFetch).not.toHaveBeenCalled();
   });
 
-  it("passes a known company through without changing its status", async () => {
+  it("passes a company recognized after deployment without a matcher update", async () => {
     resourceStatusMocks.hasPublicCompanyRoute.mockResolvedValue(true);
 
-    const response = await proxy(documentRequest("/en/company/acme"));
+    const response = await proxy(
+      documentRequest("/en/company/newly-synced-company"),
+    );
 
     expect(response.status).toBe(200);
     expect(response.headers.get("x-middleware-next")).toBe("1");
@@ -590,6 +592,16 @@ describe("proxy config", () => {
         config,
         nextConfig: {},
         url: "/en/company/definitely-not-real",
+      }),
+    ).toBe(true);
+  });
+
+  it("routes post-deployment company additions through the status boundary", () => {
+    expect(
+      unstable_doesMiddlewareMatch({
+        config,
+        nextConfig: {},
+        url: "/en/company/newly-synced-company",
       }),
     ).toBe(true);
   });

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -147,7 +147,6 @@ function runDispatchCompanyProductionSync({
   includeDefaultBranch = true,
   prewarmSha = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
   prewarmWatchStatus = 0,
-  deployWatchStatus = 0,
 } = {}) {
   const dir = mkdtempSync(join(tmpdir(), "dispatch-company-sync-"));
   const log = join(dir, "gh.log");
@@ -164,10 +163,7 @@ if [[ "$1 $2" == "run list" ]]; then
     printf '4343\\n'
   fi
 elif [[ "$1 $2" == "run watch" ]]; then
-  if [[ "$3" == "4242" ]]; then
-    exit "$MOCK_PREWARM_WATCH_STATUS"
-  fi
-  exit "$MOCK_DEPLOY_WATCH_STATUS"
+  exit "$MOCK_PREWARM_WATCH_STATUS"
 fi
 `,
   );
@@ -181,7 +177,6 @@ fi
     MOCK_GH_LOG: log,
     MOCK_PREWARM_SHA: prewarmSha,
     MOCK_PREWARM_WATCH_STATUS: String(prewarmWatchStatus),
-    MOCK_DEPLOY_WATCH_STATUS: String(deployWatchStatus),
   };
   if (includeDefaultBranch) env.DEFAULT_BRANCH = defaultBranch;
   const result = spawnSync(
@@ -786,7 +781,7 @@ test("maybe-auto-merge script skips image PRs and retries pending merges", () =>
   assert.match(maybeAutoMergeScript, /scheduled\/workflow_run retries will revisit it/);
 });
 
-test("company auto-merges prewarm and deploy before exact-revision production sync", () => {
+test("company auto-merges prewarm before exact-revision production sync without deploying web", () => {
   for (const source of [maybeAutoMergeWorkflow, uploadCompanyImagesWorkflow]) {
     assert.match(
       source,
@@ -800,7 +795,11 @@ test("company auto-merges prewarm and deploy before exact-revision production sy
   );
   assert.match(
     dispatchCompanyProductionSyncScript,
-    /gh workflow run prewarm-company-og-cache\.yml[\s\S]*gh run watch "\$prewarm_run_id"[\s\S]*gh workflow run deploy-web-production\.yml[\s\S]*gh run watch "\$web_deploy_run_id"[\s\S]*gh workflow run sync-data\.yml[\s\S]*-f revision="\$prewarm_sha"/,
+    /gh workflow run prewarm-company-og-cache\.yml[\s\S]*gh run watch "\$prewarm_run_id"[\s\S]*gh workflow run sync-data\.yml[\s\S]*-f revision="\$prewarm_sha"/,
+  );
+  assert.doesNotMatch(
+    dispatchCompanyProductionSyncScript,
+    /deploy-web-production\.yml/,
   );
 
   for (const fixture of [
@@ -814,12 +813,10 @@ test("company auto-merges prewarm and deploy before exact-revision production sy
       : "main";
     const calls = result.calls.trim().split("\n");
     assert.deepEqual(
-      [calls[0], calls[2], calls[3], calls[5], calls[6]],
+      [calls[0], calls[2], calls[3]],
       [
         `workflow run prewarm-company-og-cache.yml --repo colophon-group/jobseek --ref ${expectedBranch} -f concurrency=4`,
         "run watch 4242 --repo colophon-group/jobseek --exit-status",
-        `workflow run deploy-web-production.yml --repo colophon-group/jobseek --ref ${expectedBranch} -f revision=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`,
-        "run watch 4343 --repo colophon-group/jobseek --exit-status",
         `workflow run sync-data.yml --repo colophon-group/jobseek --ref ${expectedBranch} -f revision=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`,
       ],
     );
@@ -829,12 +826,7 @@ test("company auto-merges prewarm and deploy before exact-revision production sy
         `^run list --repo colophon-group/jobseek --workflow prewarm-company-og-cache\\.yml --branch ${expectedBranch} --event workflow_dispatch`,
       ),
     );
-    assert.match(
-      calls[4],
-      new RegExp(
-        `^run list --repo colophon-group/jobseek --workflow deploy-web-production\\.yml --branch ${expectedBranch} --event workflow_dispatch`,
-      ),
-    );
+    assert.doesNotMatch(result.calls, /deploy-web-production\.yml/);
   }
 
   const failedPrewarm = runDispatchCompanyProductionSync({ prewarmWatchStatus: 1 });
@@ -842,10 +834,6 @@ test("company auto-merges prewarm and deploy before exact-revision production sy
   assert.doesNotMatch(failedPrewarm.calls, /workflow run deploy-web-production\.yml/);
   assert.doesNotMatch(failedPrewarm.calls, /workflow run sync-data\.yml/);
 
-  const failedDeploy = runDispatchCompanyProductionSync({ deployWatchStatus: 1 });
-  assert.equal(failedDeploy.status, 1);
-  assert.match(failedDeploy.calls, /workflow run deploy-web-production\.yml/);
-  assert.doesNotMatch(failedDeploy.calls, /workflow run sync-data\.yml/);
 });
 
 test("bot-authored company branch updates dispatch path-aware CI", () => {

--- a/scripts/vercel-web-deploy-paths.test.mjs
+++ b/scripts/vercel-web-deploy-paths.test.mjs
@@ -25,11 +25,10 @@ const scannerVerifier = fileURLToPath(
 );
 const turboConfig = JSON.parse(readFileSync("turbo.json", "utf8"));
 
-test("deploys web runtime and every current workspace input", () => {
+test("deploys web runtime and production-workflow inputs", () => {
   for (const path of [
     "apps/web/app/page.tsx",
     "apps/web/vercel.json",
-    "apps/crawler/data/companies.csv",
     "packages/mcp-server/src/handler.ts",
     "patches/next@16.2.11.patch",
     "package.json",
@@ -56,17 +55,22 @@ test("does not redeploy for unrelated crawler data, docs, or ops changes", () =>
   assert.deepEqual(result, { deploy: false, relevant: [] });
 });
 
-test("redeploys when the company registry changes", () => {
+test("does not replace the web deployment for company registry changes", () => {
   assert.deepEqual(
     classifyVercelWebChanges(["apps/crawler/data/companies.csv"]),
-    {
-      deploy: true,
-      relevant: ["apps/crawler/data/companies.csv"],
-    },
+    { deploy: false, relevant: [] },
+  );
+  assert.equal(isVercelWebInput("apps/crawler/data/companies.csv"), false);
+  assert.deepEqual(
+    classifyVercelWebChanges([
+      "apps/crawler/data/companies.csv",
+      "apps/web/app/page.tsx",
+    ]),
+    { deploy: true, relevant: ["apps/web/app/page.tsx"] },
   );
 });
 
-test("company registry changes invalidate the cached web build", () => {
+test("genuine web builds still regenerate from the current company registry", () => {
   const genericBuild = turboConfig.tasks.build;
   const webBuild = turboConfig.tasks["@jobseek/web#build"];
   assert.deepEqual(webBuild.inputs, [


### PR DESCRIPTION
## Summary

- stop classifying `apps/crawler/data/companies.csv` as a production web-deployment input
- remove the explicit exact-revision web deployment from the company publication dispatcher
- retain the generated company matcher as a snapshot that genuine web builds refresh
- document and test the new-company fallback through the Typesense-backed Proxy boundary

## Root cause

A retained 12-hour production sample contained 18 production promotions, mostly company/image additions. Next Cache Components keys `use cache` entries by deployment Build ID, so those promotions repeatedly cold-started the page cache. Company routes accounted for about 203 of 249.6 visible Active CPU seconds in the sample.

The deployment was unnecessary for correctness. A newly synced slug absent from the deployed matcher already reaches the bounded Typesense status check; once sync recognizes it, Proxy passes it to the company page. Truly absent slugs still receive the pre-stream hard 404. The next genuine web release naturally folds accumulated companies into the fast bypass snapshot.

## Behavior

- company publication still waits for the exact revision's complete off-platform OG prewarm
- the exact-revision Typesense/data sync then runs without replacing the web deployment
- existing deployed company slugs continue to bypass Proxy
- new company slugs use the status boundary until the next genuine web build
- `companies.csv` remains a Turbo web-build input so genuine builds cannot reuse a matcher generated from an older registry

## Verification

- pre-commit ESLint and Lingui coverage hooks
- `node --test scripts/vercel-web-deploy-paths.test.mjs scripts/ci-workflow.test.mjs`: 62 passed
- focused Proxy publication-contract tests: 2 passed
- `bash -n .github/scripts/dispatch-company-production-sync.sh`
- ShellCheck
- `git diff --check`

Relates #6616 and #7436.
