### PR TITLE
Update Vercel CLI pin to 59.3.0

### DIFF
--- a/.github/scripts/verify-vercel-promotion.mjs
+++ b/.github/scripts/verify-vercel-promotion.mjs
@@ -154,7 +154,7 @@ async function main() {
           "pnpm",
           [
             "dlx",
-            "vercel@55.0.0",
+            "vercel@59.3.0",
             "api",
             `/v13/deployments/${alias}?teamId=${orgId}`,
             "--raw",

--- a/.github/workflows/deploy-web-production.yml
+++ b/.github/workflows/deploy-web-production.yml
@@ -61,7 +61,7 @@ jobs:
             fi
             current_sha="$REQUESTED_SHA"
           fi
-          production="$(pnpm dlx vercel@55.0.0 api \
+          production="$(pnpm dlx vercel@59.3.0 api \
             "/v13/deployments/$PRODUCTION_ALIAS?teamId=$VERCEL_ORG_ID" \
             --raw --token="$VERCEL_TOKEN")"
           production_sha="$(jq -r '.gitSource.sha // .meta.githubCommitSha // ""' <<<"$production")"
@@ -89,7 +89,7 @@ jobs:
       - name: Pull production project settings
         if: steps.paths.outputs.deploy == 'true'
         run: >-
-          pnpm dlx vercel@55.0.0 pull
+          pnpm dlx vercel@59.3.0 pull
           --yes
           --environment=production
           --token="$VERCEL_TOKEN"
@@ -105,7 +105,7 @@ jobs:
         env:
           NEXT_SERVER_ACTIONS_ENCRYPTION_KEY: ${{ secrets.NEXT_SERVER_ACTIONS_ENCRYPTION_KEY }}
         run: >-
-          pnpm dlx vercel@55.0.0 build
+          pnpm dlx vercel@59.3.0 build
           --prod
           --token="$VERCEL_TOKEN"
 
@@ -116,7 +116,7 @@ jobs:
           COMMIT_SHA: ${{ steps.paths.outputs.current_sha }}
           COMMIT_REF: main
         run: |
-          deployment="$(pnpm dlx vercel@55.0.0 deploy \
+          deployment="$(pnpm dlx vercel@59.3.0 deploy \
             --prebuilt --prod --skip-domain --archive=tgz --format=json \
             --token="$VERCEL_TOKEN" \
             --meta githubCommitSha="$COMMIT_SHA" \
@@ -136,13 +136,13 @@ jobs:
         env:
           DEPLOYMENT_URL: ${{ steps.stage.outputs.url }}
         run: |
-          pnpm dlx vercel@55.0.0 inspect "$DEPLOYMENT_URL" \
+          pnpm dlx vercel@59.3.0 inspect "$DEPLOYMENT_URL" \
             --wait --timeout=5m --token="$VERCEL_TOKEN"
           for path in \
             /en/explore?wm=remote\&q=python \
             /en/company/securitas-ag \
             /en/sign-in; do
-            status="$(pnpm dlx vercel@55.0.0 curl "$path" \
+            status="$(pnpm dlx vercel@59.3.0 curl "$path" \
               --deployment="$DEPLOYMENT_URL" \
               -- --silent --show-error --output /dev/null --write-out '%{http_code}')"
             echo "Smoke $path -> HTTP $status"
@@ -155,7 +155,7 @@ jobs:
           scanner_headers="$(mktemp "$RUNNER_TEMP/vercel-scanner-headers.XXXXXX")"
           chmod 600 "$scanner_headers"
           trap 'rm -f -- "$scanner_headers"' EXIT
-          scanner_status="$(pnpm dlx vercel@55.0.0 curl /wp-admin/setup-config.php \
+          scanner_status="$(pnpm dlx vercel@59.3.0 curl /wp-admin/setup-config.php \
             --deployment="$DEPLOYMENT_URL" \
             -- --location --silent --show-error \
             --dump-header "$scanner_headers" \
@@ -187,7 +187,7 @@ jobs:
             fi
             exit 0
           fi
-          pnpm dlx vercel@55.0.0 promote "$DEPLOYMENT_URL" \
+          pnpm dlx vercel@59.3.0 promote "$DEPLOYMENT_URL" \
             --yes --timeout=3m --token="$VERCEL_TOKEN"
           echo "promoted=true" >> "$GITHUB_OUTPUT"
 

--- a/scripts/vercel-web-deploy-paths.test.mjs
+++ b/scripts/vercel-web-deploy-paths.test.mjs
@@ -98,7 +98,7 @@ test("production workflow stages, verifies, then promotes exact main", () => {
   assert.match(workflow, /current_main=.*commits\/main/);
   assert.match(workflow, /REQUESTED_SHA: \$\{\{ inputs\.revision \}\}/);
   assert.match(workflow, /Requested revision \$REQUESTED_SHA is stale/);
-  assert.match(workflow, /vercel@55\.0\.0 promote/);
+  assert.match(workflow, /vercel@59\.3\.0 promote/);
   assert.match(workflow, /id: promote/);
   assert.match(workflow, /promoted=true/);
   assert.match(workflow, /REQUIRE_EXACT_PROMOTION/);
@@ -118,7 +118,7 @@ test("production workflow stages, verifies, then promotes exact main", () => {
   );
   const curlLines = workflow
     .split("\n")
-    .filter((line) => line.includes("vercel@55.0.0") && line.includes("curl"));
+    .filter((line) => line.includes("vercel@59.3.0") && line.includes("curl"));
   assert.equal(curlLines.length, 2);
   for (const line of curlLines) {
     assert.doesNotMatch(line, /--token/);
@@ -145,7 +145,7 @@ test("production workflow stages, verifies, then promotes exact main", () => {
   assert.match(workflow, /environment: Production/);
   assert.match(
     workflow,
-    /vercel@55\.0\.0 pull[\s\S]{0,400}verify-vercel-server-action-key\.mjs[\s\S]{0,400}vercel@55\.0\.0 build/,
+    /vercel@59\.3\.0 pull[\s\S]{0,400}verify-vercel-server-action-key\.mjs[\s\S]{0,400}vercel@59\.3\.0 build/,
   );
   assert.doesNotMatch(workflow, /environment:\n\s+name: Production\n\s+url:/);
   assert.doesNotMatch(workflow, /pull_request:/);


### PR DESCRIPTION
## Summary

- update every repository-owned Vercel CLI workflow pin from 55.0.0 to 59.3.0
- keep the production-promotion verifier and deployment path assertions synchronized with the workflow
- recommend updating local/global Vercel CLI installations to 59.3.0 for operator parity

## Verification

- independent subagent review found no actionable code or security issues at exact head 2cd9fc4e3
- confirmed all nine executable pins use 59.3.0 and no 55.0.0 or 59.1.4 pin remains
- 14 focused workflow and deployment script tests passed after rebasing onto current main
- full CI is rerunning on the updated exact head

## Operational note

Keep this draft unmerged until the active Fluid CPU observation window ends at 2026-08-20T22:26:58.554Z. Merging the production workflow change during the window could invalidate the measurement.