### PR TITLE
Fix Oerlikon company identity

### DIFF
--- a/apps/crawler/data/companies.csv
+++ b/apps/crawler/data/companies.csv
@@ -3384,7 +3384,7 @@ odle-sales,Odle Sales,https://www.odlesales.com,https://jobseek-assets.colophon-
 odoo,Odoo,https://www.odoo.com,https://jobseek-assets.colophon-group.org/companies/odoo/logo.png,https://jobseek-assets.colophon-group.org/companies/odoo/icon.webp,wordmark,1,7,2005,"{""wikidataId"": ""Q832300""}"
 odyssey,Odyssey,https://www.odyssey.io,https://jobseek-assets.colophon-group.org/companies/odyssey/logo.jpg,https://jobseek-assets.colophon-group.org/companies/odyssey/icon.webp,icon,1,,,
 odysseyhotelgroup,Odysseyhotelgroup,https://www.odysseyhotelgroup.com,https://jobseek-assets.colophon-group.org/companies/odysseyhotelgroup/logo.png,https://jobseek-assets.colophon-group.org/companies/odysseyhotelgroup/icon.webp,wordmark,17,,,
-oerlikon,Oerlikon,https://www.oerlikon.com/,,,wordmark,4,7,1876,"{""parentOrganization"": {""name"": ""Rheinmetall AG""}, ""wikidataId"": ""Q11069710""}"
+oerlikon,Oerlikon,https://www.oerlikon.com/,,,wordmark,4,7,1876,"{""wikidataId"": ""Q11121670""}"
 offerup,OfferUp,https://offerup.com,https://jobseek-assets.colophon-group.org/companies/offerup/logo.png,https://jobseek-assets.colophon-group.org/companies/offerup/icon.webp,icon,5,,,
 offerzen,OfferZen,https://www.offerzen.com,https://jobseek-assets.colophon-group.org/companies/offerzen/logo.svg,https://jobseek-assets.colophon-group.org/companies/offerzen/icon.webp,wordmark,1,,,
 office-hours,Office Hours,https://officehours.com,https://jobseek-assets.colophon-group.org/companies/office-hours/logo.png,https://jobseek-assets.colophon-group.org/companies/office-hours/icon.webp,icon,1,,,


### PR DESCRIPTION
## Summary

- replace the unrelated Oerlikon Rheinmetall Air Defence Wikidata entity with the canonical OC Oerlikon company entity
- remove the false Rheinmetall AG parent relationship from the newly added Oerlikon record

## Evidence

PR #7701 accidentally used Wikidata `Q11069710`, whose entity is **Oerlikon Rheinmetall Air Defence**, a former Swiss military arms company owned by Rheinmetall. The configured employer is the separate publicly listed industrial technology group **OC Oerlikon** (`Q11121670`). Oerlikon's 2025 annual report identifies OC Oerlikon Corporation AG as the ultimate parent of its own group.

The underlying Oerlikon careers feed remains sound: the live SuccessFactors RSS feed currently exposes 131/131 unique links, all with non-empty titles, descriptions (5,084–29,414 characters), and locations.

## Validation

- `uv run ws validate`
- `git diff --check`

Corrective follow-up to #7701.
