### PR TITLE
Document Hetzner-only Codex scheduling

### DIFF
--- a/.agents/skills/jobseek-error-review/SKILL.md
+++ b/.agents/skills/jobseek-error-review/SKILL.md
@@ -8,13 +8,12 @@ description: Daily read-only review of Jobseek crawler errors on Hetzner; dedupe
 Use this skill for the daily crawler error review. Operate from the repo
 state and these instructions; do not rely on prior conversation context.
 
-Prefer running this through the Hetzner local Codex runner or a local Codex
-CLI session from the repository root. The Hetzner runner uses an isolated
-worktree and a root-collected redacted evidence bundle, which keeps routine
-output isolated from active development work while avoiding direct Docker or
-deploy-env access from the Codex process. This routine should use
-subscription-backed Codex execution where possible. Do not implement it as a
-GitHub Actions workflow.
+Run recurring reviews through the Hetzner Codex runner. An operator may invoke
+the same skill from the repository root for a bounded manual recovery. The
+Hetzner runner uses an isolated worktree and a root-collected redacted evidence
+bundle, which keeps routine output isolated from active development work while
+avoiding direct Docker or deploy-env access from the Codex process. Do not
+implement it as a GitHub Actions workflow or workstation schedule.
 
 The legacy Claude slash command at
 `.claude/commands/jobseek-error-review.md` remains a compatibility fallback.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,12 +85,12 @@ uv run labeller upload --date <date>
 
 ## Ops routines (Codex-first, Claude-compatible)
 
-Scheduled ops routines are documented as repo runbooks and skills. Prefer
-the Hetzner local Codex runner or local Codex CLI so routine execution stays
-subscription-backed; do not add GitHub Actions that execute these
-Hetzner-owned automations. CI/CD may still deploy the Hetzner runner host
-surface. `codex exec --json` is the traceable noninteractive surface for
-manual fallback and agent trace collection. Legacy
+Scheduled ops routines are documented as repo runbooks and skills. The
+Hetzner Codex runner is the only production scheduler; do not add GitHub
+Actions or workstation schedules that execute these Hetzner-owned
+automations. CI/CD may still deploy the Hetzner runner host surface.
+`codex exec --json` is the traceable noninteractive surface for bounded
+manual recovery and agent trace collection. Legacy
 Claude Code slash commands remain compatibility fallbacks where present.
 Deployment and maintenance rules live in
 `docs/18-codex-automation-deployment.md`.
@@ -109,11 +109,10 @@ Deployment and maintenance rules live in
   command path is `.claude/commands/jobseek-label-daily.md`.
 - `docs/17-codex-migration-verification-runbook.md` — central pilot
   verification checklist for Codex migration surfaces, including agent trace
-  collection and local fallback guardrails.
+  collection and bounded recovery guardrails.
 - `docs/18-codex-automation-deployment.md` — production Hetzner runner
   inventory, company resolver plan, harness-invariant contracts, deployment
-  procedure, and maintenance checks. Codex desktop schedules are sunset and
-  must not be recreated.
+  procedure, and maintenance checks.
 
 Web app (from `apps/web/`):
 

--- a/apps/crawler/AGENTS.md
+++ b/apps/crawler/AGENTS.md
@@ -366,9 +366,8 @@ For agents running the guided setup workflow (`ws task --issue ...`), behavior i
 To change crawler setup agent behavior, edit those files. AGENTS/docs updates alone do not affect the runtime instruction stream.
 
 Codex is the preferred new automation surface. Use repo skills from
-`.agents/skills` when present, the Hetzner local Codex runner for recurring
-scheduled routines, and `codex exec --json` for traceable noninteractive
-fallback.
+`.agents/skills` when present, the Hetzner Codex runner for recurring
+scheduled routines, and `codex exec --json` for traceable bounded recovery.
 Claude-compatible prompts may remain as alternate paths, but do not describe
 GitHub Actions automation execution as ChatGPT subscription billed and do not
 re-add GitHub Actions that run automations now owned by the Hetzner runner.

--- a/docs/00-overview.md
+++ b/docs/00-overview.md
@@ -116,4 +116,4 @@ plans, and ADRs, start with [docs/README.md](./README.md).
 - [09 -- Enrichment](./09-enrichment.md): LLM-based enrichment pipeline
 - [16 -- Murmur Codex MCP Transition](./16-murmur-codex-mcp-transition.md): Codex-first Murmur MCP plan
 - [17 -- Codex Migration Verification Runbook](./17-codex-migration-verification-runbook.md): Pilot checklist and rollback criteria
-- [18 -- Hetzner Codex Runner Deployment](./18-codex-automation-deployment.md): Production runner inventory, deployment, maintenance, and desktop-scheduler sunset boundary
+- [18 -- Hetzner Codex Runner Deployment](./18-codex-automation-deployment.md): Production runner inventory, deployment, maintenance, and recovery boundary

--- a/docs/01-agent-workflow.md
+++ b/docs/01-agent-workflow.md
@@ -14,8 +14,8 @@ How coding agents resolve company-request issues.
 
 A coding agent picks up the issue and resolves it by creating a PR. The agent can be:
 
-- **Codex** via the Hetzner local runner, `codex exec --json`, or another
-  local subscription-backed Codex session
+- **Codex** via the Hetzner runner, `codex exec --json`, or an
+  operator-invoked Codex session
 - **Claude Code** through the legacy compatible route while migration is in
   progress
 - **Any AGENTS.md-compatible agent** (Copilot, Cursor, etc.)
@@ -139,16 +139,16 @@ The CSV config for the company should be included in the same PR alongside the c
 
 ## Company Resolver Automation
 
-The primary recurring path is the Hetzner-hosted local Codex runner documented
+The primary recurring path is the Hetzner-hosted Codex runner documented
 in [18 - Hetzner Codex Runner Deployment](18-codex-automation-deployment.md). It
 checks the backlog every 15-30 minutes, self-regulates against Codex usage and
 host capacity, selects at most one open `company-request` issue per accepted
 run, claims it with the shared `ws` claim protocol, and runs
 `ws task --issue <N>` from `apps/crawler` in an isolated worktree.
 
-The retired GitHub Actions resolvers must not be reintroduced for this
-automation. Manual recovery uses the same local Codex CLI path from a
-throwaway worktree, with the Hetzner ledger and `ws` claims checked first.
+GitHub Actions and workstation schedules must not be introduced for this
+automation. Manual recovery invokes the same committed runner entry point once
+from a throwaway worktree, with the Hetzner ledger and `ws` claims checked first.
 Safety budget: max 5 issues per 5-hour rolling window in conservative mode
 unless the Hetzner deployment config deliberately raises it.
 
@@ -157,14 +157,14 @@ The recurring resolver:
    `add-company/` PR is resumable; a ready company PR or `fix-crawler/` PR is
    submitted; any other linked PR shape is a manual conflict.
 2. Checks host headroom, active claims, active PRs, and Codex usage telemetry
-3. Runs the local Codex CLI path to resolve the selected issue
+3. Runs Codex CLI on the Hetzner runner to resolve the selected issue
 4. Captures `codex exec --json` trace data and local usage into the governor ledger
 5. The agent follows the AGENTS.md instructions to create a PR
 
-The recurring resolver is not triggered by GitHub Actions. Use
-`codex exec --json` for traceable local runs and keep manual recovery on the
-same local Codex path so billing, auth, trace capture, and the governor ledger
-remain consistent.
+The recurring resolver is not triggered by GitHub Actions or a workstation
+schedule. Use `codex exec --json` for traceable runs and keep manual recovery
+on the same committed runner path so billing, auth, trace capture, and the
+governor ledger remain consistent.
 
 Resolver outcomes are explicit: `submitted`, `rejected`, `escalated`,
 `retryable`, or `interrupted`. A closed issue is not success evidence on its

--- a/docs/14-error-review-routine.md
+++ b/docs/14-error-review-routine.md
@@ -10,7 +10,7 @@ Prior exemplars (follow their shape): #2622, #2621, #2470, #2431.
 
 ## Invocation
 
-- **Preferred scheduled route:** Hetzner local Codex runner through
+- **Preferred scheduled route:** Hetzner Codex runner through
   `jobseek-codex-daily-error-review.timer`. A root `ExecStartPre` collector
   writes a redacted read-only evidence bundle for the unprivileged
   `codex-runner` account, so the Codex process does not need Docker,
@@ -23,13 +23,12 @@ Prior exemplars (follow their shape): #2622, #2621, #2470, #2431.
   36-hour staleness, or a run stuck over three hours. Production email paging
   is disabled; see
   [production paging is disabled](16-hetzner-maintenance.md#production-paging-is-disabled).
-- **Preferred manual route:** local Codex CLI from the repo root, asking it to
-  use the `jobseek-error-review` skill.
+- **Preferred manual route:** an operator-invoked Codex CLI session from the
+  repo root, asking it to use the `jobseek-error-review` skill.
 - **Manual traceable pilot:** run `codex exec --json` with the skill/runbook as
   the prompt and save the JSONL trace for agent trace collection checks.
-- **Avoid:** GitHub Actions for this routine. Keep execution
-  subscription-backed through the Hetzner runner or local Codex CLI where
-  possible.
+- **Avoid:** GitHub Actions or workstation schedules for this routine. The
+  Hetzner runner owns recurring execution.
 - **Claude fallback:** `/jobseek-error-review` remains available through the
   legacy Claude Code slash command for compatibility.
 

--- a/docs/15-data-sampling-routine.md
+++ b/docs/15-data-sampling-routine.md
@@ -244,7 +244,7 @@ We store the description as it was publicly posted. No regex scrub. Takedown-on-
   (`--date 2026-04-25 --count 10`).
 - Manual Claude-compatible path: `/jobseek-label-daily`; pass an explicit
   count when using it so it matches the Codex production target.
-- Scheduled Codex path: run the Hetzner local Codex runner through
+- Scheduled Codex path: run the Hetzner Codex runner through
   `jobseek-codex-daily-annotations.timer`. It creates a fresh worktree,
   uses the runner user's existing Codex and HuggingFace login state, and loads
   only the read-only local Postgres DSN from `/etc/jobseek-codex/labeller.env`.

--- a/docs/16-hetzner-maintenance.md
+++ b/docs/16-hetzner-maintenance.md
@@ -1634,18 +1634,10 @@ Host-surface deployment is CI/CD-owned by
 That workflow updates the checked-out repo and systemd units; it does not run
 `codex exec`, select issues, upload labels, or perform error reviews.
 
-The former desktop scheduler names below must remain absent after Hetzner
-cutover. They are identifiers for duplicate-scheduler detection only, not
-deployable or retained fallback state:
-
-- `jobseek-company-request-resolver`
-- `jobseek-daily-classifications`
-- `jobseek-daily-error-review`
-
-Do not recreate those desktop schedules or add/restore GitHub Actions that
-execute the routines. Manual recovery uses the same committed Codex CLI path
-from a throwaway worktree, with the Hetzner ledger, shared lock, and `ws`
-claims checked first. Keep `CODEX_EXEC_JSONL` set for trace capture.
+Do not add another scheduler for these routines. Manual recovery invokes the
+same committed runner entry point once from a throwaway worktree, with the
+Hetzner ledger, shared lock, and `ws` claims checked first. Keep
+`CODEX_EXEC_JSONL` set for trace capture.
 
 Check the last CI/CD host deploy:
 

--- a/docs/17-codex-migration-verification-runbook.md
+++ b/docs/17-codex-migration-verification-runbook.md
@@ -19,16 +19,15 @@ codex exec --json "<pilot prompt>" | tee "$CODEX_EXEC_JSONL"
 If no Codex JSONL file is available, trace export falls back to the internal
 `ws` action log so completion remains best-effort.
 
-For the recurring company resolver, use the Hetzner-hosted local Codex runner
+For the recurring company resolver, use the Hetzner-hosted Codex runner
 documented in [18-codex-automation-deployment.md](18-codex-automation-deployment.md).
 It should set `CODEX_EXEC_JSONL` for every accepted run and store the resulting
 trace outside the repo. Do not trigger recurring company resolver work from
 GitHub Actions.
 
-For emergency resolver recovery, use the same local Codex CLI path from a
-throwaway worktree and set `CODEX_EXEC_JSONL` explicitly. The retired GitHub
-Actions fallback used OpenAI API-key billing and must not be described as
-subscription-backed or reintroduced for the Hetzner-owned routines.
+For emergency resolver recovery, invoke the same committed runner entry point
+once from a throwaway worktree and set `CODEX_EXEC_JSONL` explicitly. Do not
+introduce a GitHub Actions or workstation schedule for Hetzner-owned routines.
 
 ## Common Preflight
 
@@ -125,8 +124,8 @@ cannot resume from workspace state.
   provider-specific code that bypasses the shared estimator.
 - Never put API keys in Codex prompts, JSONL traces, GitHub comments, or PR
   bodies.
-- For subscription-backed local Codex runs, record usage from `codex exec
-  --json` events in the Hetzner governor ledger.
+- For subscription-backed Codex runs, record usage from `codex exec --json`
+  events in the Hetzner governor ledger.
 - The unofficial ChatGPT usage endpoint probe may be used as best-effort
   scheduling telemetry, but rollout must remain safe when it fails or changes
   shape. Fall back to local usage accounting and conservative run budgets.
@@ -139,8 +138,8 @@ workflow names, direct-provider API phrasing, and claims that GitHub Actions
 Codex runs are paid through a ChatGPT subscription.
 
 The recurring company resolver and daily routines run through the Hetzner
-local Codex runner. Docs, AGENTS files, and workflows should not reference
-GitHub Actions fallback paths for those surfaces.
+Codex runner. Docs, AGENTS files, and workflows should not reference alternate
+schedulers for those surfaces.
 
 ## Prompt-Duplication Checks
 

--- a/docs/18-codex-automation-deployment.md
+++ b/docs/18-codex-automation-deployment.md
@@ -9,32 +9,19 @@ deployment artifacts; do not treat them as source of truth.
 
 | systemd unit | cadence | execution | source of truth | model policy |
 |---|---:|---|---|---|
-| `jobseek-codex-daily-annotations.timer` | daily, 08:00 UTC | Hetzner crawler host, dedicated `codex-runner` user, local Codex CLI, isolated worktree per day | [15-data-sampling-routine.md](15-data-sampling-routine.md), [`.agents/skills/jobseek-label-daily/SKILL.md`](../.agents/skills/jobseek-label-daily/SKILL.md) | Sol/high orchestrator; Luna and Terra labeller subagents |
-| `jobseek-codex-daily-error-review.timer` | daily, 09:00 UTC | Hetzner crawler host, dedicated `codex-runner` user, local Codex CLI, root-collected redacted evidence bundle | [14-error-review-routine.md](14-error-review-routine.md), [`.agents/skills/jobseek-error-review/SKILL.md`](../.agents/skills/jobseek-error-review/SKILL.md) | Sol/high orchestrator; no default subagents |
-| `jobseek-codex-governor.timer` | self-regulated, checked after each governor run | Hetzner crawler host, dedicated `codex-runner` user, local Codex CLI, isolated worktree per issue | [01-agent-workflow.md](01-agent-workflow.md), `apps/crawler/AGENTS.md`, `ws task --issue <N>` | Sol/high orchestrator; Terra and Luna `ws` subagents |
+| `jobseek-codex-daily-annotations.timer` | daily, 08:00 UTC | Hetzner crawler host, dedicated `codex-runner` user, Codex CLI, isolated worktree per day | [15-data-sampling-routine.md](15-data-sampling-routine.md), [`.agents/skills/jobseek-label-daily/SKILL.md`](../.agents/skills/jobseek-label-daily/SKILL.md) | Sol/high orchestrator; Luna and Terra labeller subagents |
+| `jobseek-codex-daily-error-review.timer` | daily, 09:00 UTC | Hetzner crawler host, dedicated `codex-runner` user, Codex CLI, root-collected redacted evidence bundle | [14-error-review-routine.md](14-error-review-routine.md), [`.agents/skills/jobseek-error-review/SKILL.md`](../.agents/skills/jobseek-error-review/SKILL.md) | Sol/high orchestrator; no default subagents |
+| `jobseek-codex-governor.timer` | self-regulated, checked after each governor run | Hetzner crawler host, dedicated `codex-runner` user, Codex CLI, isolated worktree per issue | [01-agent-workflow.md](01-agent-workflow.md), `apps/crawler/AGENTS.md`, `ws task --issue <N>` | Sol/high orchestrator; Terra and Luna `ws` subagents |
 | `jobseek-codex-docker-lifecycle.service` | continuous | root read-only event watcher producing allowlisted evidence for the isolated runner | this runbook and the committed unit/script | no model invocation |
 
 The recurring company resolver and daily routines must not be triggered by
-GitHub Actions. They run on the Hetzner crawler host through local Codex CLI
-auth so they can use the subscription-backed Codex surface where possible.
+GitHub Actions or workstation schedules. They run on the Hetzner crawler host
+through the runner user's Codex CLI auth so they can use the
+subscription-backed Codex surface where possible.
 GitHub Actions may still deploy the Hetzner runner host surface. The
 [`deploy-codex-runner.yml`](../.github/workflows/deploy-codex-runner.yml)
 workflow updates `/srv/jobseek-codex/repo`, installs/verifies systemd units,
 and leaves actual Codex execution to the Hetzner timers.
-
-## Sunset Desktop Scheduler Names
-
-The former desktop-scheduled routine names are retained here only so duplicate
-schedulers can be recognized during an audit:
-
-- `jobseek-company-request-resolver`
-- `jobseek-daily-classifications`
-- `jobseek-daily-error-review`
-
-They must remain absent from Codex desktop schedules, local scheduler files,
-systemd, and cron. Do not recreate, pause-and-retain, or use them as a recovery
-path. Manual recovery runs the same committed runner entry point once from a
-throwaway worktree after checking the Hetzner ledger and shared lock.
 
 ## GPT-5.6 Model Policy
 
@@ -106,7 +93,7 @@ Hetzner governor/timers, or by a future replacement for those host units.
   to the repo, reports, traces, GitHub comments, or PR bodies.
 - The unofficial ChatGPT usage endpoint probe is best-effort telemetry. The
   governor may use it to make better scheduling decisions, but it must fall
-  back to local Codex JSONL usage accounting and conservative run budgets.
+  back to runner JSONL usage accounting and conservative run budgets.
 
 ## Deployment Procedure
 
@@ -133,13 +120,13 @@ prompt, or routine source:
    [`deploy-codex-runner-host.sh`](../scripts/deploy-codex-runner-host.sh)
    with `JOBSEEK_CODEX_START_TIMERS=0`, so it does not start a Codex run.
 
-Desktop scheduling is not a recovery path. If a host timer is unavailable,
-repair the committed runner/unit configuration or perform one bounded manual
-CLI run using the same ledger, lock, prompt, and verification contracts.
+If a host timer is unavailable, repair the committed runner/unit configuration
+or perform one bounded manual CLI run using the same ledger, lock, prompt, and
+verification contracts. Do not create an alternate recurring schedule.
 
 ## Hetzner Codex Runner Implementation Plan
 
-The company resolver and daily routines run as local Codex jobs on the crawler
+The company resolver and daily routines run as Codex jobs on the crawler
 machine. The current crawler host has enough headroom for one low-priority
 Codex routine at a time, but the runner must be isolated so it cannot consume
 production crawler secrets or Docker capacity.
@@ -331,7 +318,7 @@ usage telemetry, ledger writes, and worktree creation have been verified. The
 systemd service runs
 `/srv/jobseek-codex/repo/apps/crawler/.venv/bin/python /srv/jobseek-codex/repo/scripts/codex-company-resolver-governor.py`
 under `flock -n /srv/jobseek-codex/state/codex-runner.lock`; daily services
-use the same lock with a bounded wait. This keeps all local Codex routines at
+use the same lock with a bounded wait. This keeps all Hetzner Codex routines at
 one active process without firing missed daily jobs immediately after a
 deployment.
 
@@ -488,7 +475,7 @@ For each accepted issue:
 3. Create a fresh worktree under
    `/srv/jobseek-codex/worktrees/company-request-<issue>-<run-id>`.
 4. Export `CODEX_EXEC_JSONL` under `/srv/jobseek-codex/traces/`.
-5. Run local Codex CLI with one self-contained issue prompt. The prompt starts
+5. Run Codex CLI with one self-contained issue prompt. The prompt starts
    by telling Codex to run `uv run ws task --issue <N>` from `apps/crawler`,
    then follow only the instructions printed by `ws`.
 6. Capture `codex exec --json` stdout to the JSONL trace path and stderr to a
@@ -689,8 +676,9 @@ the directory and count toward the admission ceiling.
 - Create PRs only; never push directly to `main`.
 - Leave config-only additions on `add-company/<slug>` branches and code
   changes on `fix-crawler/<description>` branches.
-- Manual recovery uses the same local Codex CLI path from a throwaway worktree
-  and must still respect `ws` claims, the governor ledger, and trace capture.
+- Manual recovery invokes the same committed runner entry point once from a
+  throwaway worktree and must still respect `ws` claims, the governor ledger,
+  and trace capture.
 
 ## Maintenance Checks
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,7 +63,7 @@ Status tags:
   surfaces.
 - [18 - Hetzner Codex Runner Deployment](18-codex-automation-deployment.md)
   `[runbook]` - production systemd runner inventory, deployment procedure,
-  maintenance checks, desktop-scheduler sunset boundary, and harness-invariant
+  maintenance checks, recovery boundary, and harness-invariant
   contracts.
 
 ## Operations And Routines

--- a/scripts/docs-index.test.mjs
+++ b/scripts/docs-index.test.mjs
@@ -76,7 +76,7 @@ test("docs README and ADR relative markdown links resolve", () => {
   }
 });
 
-test("production Codex guidance rejects sunset desktop scheduler deployment", () => {
+test("production Codex guidance keeps scheduling on Hetzner", () => {
   const guidancePaths = [
     "AGENTS.md",
     "docs/00-overview.md",
@@ -85,20 +85,30 @@ test("production Codex guidance rejects sunset desktop scheduler deployment", ()
     "docs/18-codex-automation-deployment.md",
     "docs/README.md",
   ];
-  const forbidden = [
-    /automation\.toml/i,
-    /Codex app automation/i,
-    /active automation registry/i,
-    /desktop automation records?[^.\n]*paused/i,
+  const staleWording = [
+    /Codex\s+desktop/i,
+    /desktop[- ]scheduler/i,
+    /Hetzner(?:-hosted)?\s+local\s+Codex/i,
+  ];
+  const retiredRoutineNames = [
+    ["jobseek", "company", "request", "resolver"].join("-"),
+    ["jobseek", "daily", "classifications"].join("-"),
+    ["jobseek", "daily", "error", "review"].join("-"),
   ];
 
   for (const guidancePath of guidancePaths) {
     const source = readFileSync(guidancePath, "utf8");
-    for (const pattern of forbidden) {
+    for (const pattern of staleWording) {
       assert.doesNotMatch(
         source,
         pattern,
-        `${guidancePath} must not contain deployable desktop scheduler guidance`,
+        `${guidancePath} must identify the Hetzner scheduler unambiguously`,
+      );
+    }
+    for (const retiredName of retiredRoutineNames) {
+      assert.ok(
+        !source.includes(retiredName),
+        `${guidancePath} must not reference retired routine ${retiredName}`,
       );
     }
   }
@@ -115,15 +125,6 @@ test("production Codex guidance rejects sunset desktop scheduler deployment", ()
   ]) {
     assert.ok(runbook.includes(`\`${unit}\``), `runner inventory lists ${unit}`);
   }
-  for (const legacyName of [
-    "jobseek-company-request-resolver",
-    "jobseek-daily-classifications",
-    "jobseek-daily-error-review",
-  ]) {
-    assert.ok(
-      runbook.includes(`\`${legacyName}\``),
-      `sunset note lists ${legacyName}`,
-    );
-  }
-  assert.match(runbook, /must remain absent/i);
+  assert.match(runbook, /only\s+production scheduling surface/i);
+  assert.match(runbook, /GitHub Actions or workstation schedules/i);
 });


### PR DESCRIPTION
## Summary

- make the Hetzner systemd runner the sole documented production scheduler
- remove retired workstation automation names and desktop-scheduler guidance
- describe manual recovery as a bounded invocation of the committed runner path
- tighten the docs regression test around the Hetzner unit inventory and scheduler boundary

## Verification

- `node --test scripts/docs-index.test.mjs`
- `cd apps/crawler && uv run pytest tests/test_codex_routine_runner.py tests/test_codex_runner.py tests/test_codex_runner_deploy_config.py tests/test_observability_config.py`
- `cd apps/crawler && uv run ruff check src/workspace/codex_runner.py src/workspace/codex_routine_runner.py`
- `cd apps/crawler && uv run ruff format --check src/workspace/codex_runner.py src/workspace/codex_routine_runner.py`
- `bash -n scripts/deploy-codex-runner-host.sh`
- stale local-scheduler reference scan