### PR TITLE
Correct attribution for @fotorpics' contribution

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+# Map historical commit identities to their GitHub-linked identities.
+Nusk1 <184746972+fotorpics@users.noreply.github.com> Rex <your_username@users.noreply.github.com>


### PR DESCRIPTION
## Summary

- map the placeholder author identity from #7846 to @fotorpics' GitHub-linked no-reply address
- record the corrective commit with @fotorpics as author and the maintainer as committer
- preserve published `main` history without a force-push

## Verification

- `git check-mailmap "Rex <your_username@users.noreply.github.com>"` resolves to the linked identity
- GitHub's commit API links `eba009035e91a6e7ffe56fd02f71697b09b71092` to `fotorpics`

Follow-up to #7846.