### PR TITLE
Define global crawler capacity envelope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,13 @@ jobs:
             deploy/observability/test_prune_rollbacks.py
           python3 deploy/observability/test_prune_rollbacks.py
 
+      - name: Test global crawler capacity envelope
+        run: |
+          python3 -m py_compile \
+            scripts/capacity_envelope.py \
+            scripts/test_capacity_envelope.py
+          python3 scripts/test_capacity_envelope.py
+
       - name: Test repository scripts
         run: >
           node --test

--- a/capacity/crawler/evidence/2026-08-26-local-routing.json
+++ b/capacity/crawler/evidence/2026-08-26-local-routing.json
@@ -1,0 +1,95 @@
+{
+  "base_commit": "bb892b6350cfcbbc2779e8fde318231a1a24926a",
+  "classification": "measured_synthetic_weighted_routing_only",
+  "command": "python scripts/capacity_envelope.py --check --benchmark-routing 10000000",
+  "conservation": {
+    "duplicate_boards": 0,
+    "growth_duplicate_partitions": 0,
+    "growth_existing_to_existing_moves": 0,
+    "growth_input_partitions": 8192,
+    "growth_lost_partitions": 0,
+    "growth_moved_partitions": 967,
+    "growth_output_partitions": 8192,
+    "input_boards": 10000000,
+    "lost_boards": 0,
+    "moved_boards": 156375,
+    "moved_partitions": 128,
+    "primary_boards": 10000000,
+    "recovered_active_postings": 100000000,
+    "recovered_boards": 10000000,
+    "recovered_cycles_per_hour": 6000000,
+    "unaffected_partitions_moved": 0
+  },
+  "distribution": {
+    "growth_new_cell_partition_share": 0.118042,
+    "partition_max_boards": 1354,
+    "partition_min_boards": 1087,
+    "primary_shard_max_boards": 156972,
+    "primary_shard_min_boards": 155443,
+    "provider_task_cycles_per_hour": {
+      "custom_api": 584007,
+      "greenhouse": 892112,
+      "lever": 589851,
+      "long_tail": 488301,
+      "oracle": 603222,
+      "personio": 605740,
+      "successfactors": 724110,
+      "workday": 1512656
+    },
+    "recovered_max_board_load_factor": 1.21417,
+    "recovered_max_browser_rate_factor": 1.30358,
+    "recovered_max_posting_factor": 1.211869,
+    "recovered_max_provider_rate_factor": 1.227083,
+    "recovered_max_task_rate_factor": 1.212252,
+    "recovered_shard_max_boards": 189714,
+    "recovered_shard_min_boards_excluding_failed": 155443
+  },
+  "environment": {
+    "logical_cpus": 8,
+    "machine": "arm64",
+    "physical_memory_bytes": 17179869184,
+    "platform": "macOS-14.4-arm64-arm-64bit-Mach-O",
+    "processor": "arm",
+    "python": "3.13.5"
+  },
+  "evidence_sha256": "239210e4def63d7f004769a05e9f87374ba2e30f768bad5c1ef926e18db4ec9e",
+  "explicitly_not_measured": [
+    "go_runtime",
+    "redis",
+    "postgres",
+    "lightpanda",
+    "origin_network",
+    "typesense",
+    "telemetry_backend"
+  ],
+  "input": {
+    "active_postings": 100000000,
+    "boards": 10000000,
+    "detail_cycles_per_hour": 5000000,
+    "failed_slot": 0,
+    "logical_partitions": 8192,
+    "monitor_cycles_per_hour": 1000000,
+    "queue_shards": 64,
+    "weighting": {
+      "browser": "deterministic per-class shares from the capacity spec",
+      "postings": "deterministic heavy tail: 0.1% weight 1000, next 0.9% weight 100, remainder weight 1",
+      "providers": "25/15/12/10/10/10/10/8 percent synthetic family mix"
+    }
+  },
+  "measurement": {
+    "boards_per_wall_second": 257523.22,
+    "cpu_seconds": 34.184801,
+    "peak_rss_bytes": 27017216,
+    "wall_seconds": 38.83145
+  },
+  "measurement_date": "2026-08-26",
+  "schema_version": 1,
+  "spec_sha256": "ef66e5d27bc4dc36f35a805af8964292ae59b992482ab6c4688a286cbbb3c49f",
+  "units": {
+    "cpu_seconds": "process CPU seconds",
+    "peak_rss_bytes": "bytes",
+    "task_rate": "successful cycles per hour",
+    "throughput": "weighted board routing decisions per wall-clock second",
+    "wall_seconds": "seconds"
+  }
+}

--- a/capacity/crawler/global-v1-report.json
+++ b/capacity/crawler/global-v1-report.json
@@ -1,0 +1,604 @@
+{
+  "classification": {
+    "analytical": [
+      "workload",
+      "resource_utilization",
+      "storage",
+      "cost"
+    ],
+    "future_execution_gate": [
+      "go_runtime",
+      "redis",
+      "postgres",
+      "lightpanda",
+      "typesense",
+      "network",
+      "cell_services",
+      "routing",
+      "load_balancer",
+      "telemetry_backends"
+    ],
+    "measured_elsewhere": [
+      "routing_distribution",
+      "routing_recovery_conservation"
+    ]
+  },
+  "cost": {
+    "overload_shard_loss": {
+      "cost_per_million_eur": {
+        "blended": 9.723,
+        "board": 7.0825,
+        "detail": 10.2511
+      },
+      "mode": "overload_shard_loss",
+      "monthly_cost_eur": 84006.71,
+      "monthly_cycles": {
+        "board": 1440000000,
+        "detail": 7200000000
+      },
+      "origin_transfer_tib_per_month": 3122.74,
+      "planning_exchange_rate_usd_to_eur": 0.9,
+      "pool_costs_eur": {
+        "backup": 581.92,
+        "browser": 17726.72,
+        "cell_services": 2159.6,
+        "miscellaneous": 1500.0,
+        "origin_transfer": 0.0,
+        "postgres": 12350.4,
+        "proxy": 640.0,
+        "queue": 2014.08,
+        "r2": 1658.28,
+        "routing": 2063.76,
+        "telemetry": 528.51,
+        "typesense": 35028.0,
+        "worker": 7755.44
+      },
+      "r2_class_a_operations_millions": 360.0
+    },
+    "sensitivity": {
+      "cost_per_million_eur": {
+        "blended": 44.2959,
+        "board": 43.6338,
+        "detail": 44.4283
+      },
+      "mode": "sensitivity",
+      "monthly_cost_eur": 143518.57,
+      "monthly_cycles": {
+        "board": 540000000,
+        "detail": 2700000000
+      },
+      "origin_transfer_tib_per_month": 1699.93,
+      "planning_exchange_rate_usd_to_eur": 0.9,
+      "pool_costs_eur": {
+        "backup": 1091.1,
+        "browser": 44316.8,
+        "cell_services": 2699.5,
+        "miscellaneous": 1875.0,
+        "origin_transfer": 13599.44,
+        "postgres": 15438.0,
+        "proxy": 4000.0,
+        "queue": 2517.6,
+        "r2": 915.56,
+        "routing": 2579.7,
+        "telemetry": 1006.58,
+        "typesense": 43785.0,
+        "worker": 9694.3
+      },
+      "r2_class_a_operations_millions": 135.0
+    },
+    "steady": {
+      "cost_per_million_eur": {
+        "blended": 19.2745,
+        "board": 14.165,
+        "detail": 20.2965
+      },
+      "mode": "steady",
+      "monthly_cost_eur": 83266.04,
+      "monthly_cycles": {
+        "board": 720000000,
+        "detail": 3600000000
+      },
+      "origin_transfer_tib_per_month": 1561.37,
+      "planning_exchange_rate_usd_to_eur": 0.9,
+      "pool_costs_eur": {
+        "backup": 581.92,
+        "browser": 17726.72,
+        "cell_services": 2159.6,
+        "miscellaneous": 1500.0,
+        "origin_transfer": 0.0,
+        "postgres": 12350.4,
+        "proxy": 640.0,
+        "queue": 2014.08,
+        "r2": 917.61,
+        "routing": 2063.76,
+        "telemetry": 528.51,
+        "typesense": 35028.0,
+        "worker": 7755.44
+      },
+      "r2_class_a_operations_millions": 180.0
+    }
+  },
+  "effective_date": "2026-08-26",
+  "revision": "global-v1",
+  "scenarios": {
+    "overload_shard_loss": {
+      "arrival_cycles_per_hour": 12000000,
+      "attempted_processing_cycles_per_second": 10080.0,
+      "computed_backlog_drain_seconds": 1914.8936,
+      "computed_oldest_policy_ready_due_seconds": 2514.8936,
+      "computed_policy_ready_queue_depth": 12000000,
+      "computed_shard_recovery_seconds": 600.0,
+      "computed_total_queue_entries": 22000000,
+      "continuing_arrival_cycles_per_second": 3333.3333,
+      "network_gbps": 30.5199,
+      "required_processing_cycles_per_second": 9600.0,
+      "tiers": {
+        "browser": {
+          "lost_shards": 1,
+          "peak_cpu_pct": 61.25,
+          "peak_rss_pct": 23.9844,
+          "provisioned_shards_in_affected_cell": 16,
+          "resident_artifact_chunk_gib_max": 0.1875,
+          "session_slot_pct": 61.25,
+          "sessions_global": 1764.0,
+          "sessions_peak_survivor": 14.7,
+          "surviving_shards_in_affected_cell": 15
+        },
+        "cell_service": {
+          "lost_shards": 1,
+          "peak_cpu_pct": 50.0,
+          "peak_rss_pct": 50.0,
+          "provisioned_shards_in_affected_cell": 3,
+          "surviving_shards_in_affected_cell": 2
+        },
+        "load_balancer": {
+          "lost_shards": 1,
+          "modeled_throughput_pct": 42.0,
+          "provisioned_shards_in_affected_cell": 2,
+          "surviving_shards_in_affected_cell": 1
+        },
+        "postgres": {
+          "commits_per_second_per_writer": 1480.0,
+          "lost_shards": 1,
+          "modeled_commit_throughput_pct": 49.3333,
+          "peak_cpu_pct": 46.25,
+          "peak_rss_pct": 62.5,
+          "provisioned_shards_in_affected_cell": 3,
+          "surviving_shards_in_affected_cell": 2
+        },
+        "queue": {
+          "cycles_per_second_peak_survivor": 207.9,
+          "entries_peak_survivor": 453750,
+          "lost_shards": 1,
+          "modeled_throughput_pct": 64.9688,
+          "peak_cpu_pct": 4.158,
+          "peak_rss_pct": 10.3068,
+          "provisioned_shards_in_affected_cell": 8,
+          "surviving_shards_in_affected_cell": 7
+        },
+        "routing": {
+          "lost_shards": 1,
+          "peak_cpu_pct": 25.0,
+          "peak_rss_pct": 25.0,
+          "provisioned_shards_in_affected_cell": 3,
+          "surviving_shards_in_affected_cell": 2
+        },
+        "telemetry": {
+          "lost_shards": 1,
+          "peak_cpu_pct": 60.0,
+          "peak_rss_pct": 62.5,
+          "provisioned_shards_in_affected_cell": 3,
+          "surviving_shards_in_affected_cell": 2
+        },
+        "telemetry_backend": {
+          "lost_shards": 1,
+          "modeled_series_throughput_pct": 62.5,
+          "modeled_signal_throughput_pct": 37.5,
+          "modeled_throughput_pct": 62.5,
+          "provisioned_shards_global": 2,
+          "surviving_shards_global": 1
+        },
+        "typesense": {
+          "lost_shards": 1,
+          "modeled_throughput_pct": 35.7143,
+          "peak_cpu_pct": 27.8571,
+          "peak_rss_pct": 41.6667,
+          "provisioned_shards_in_affected_index_shard": 15,
+          "replicated_write_cpu_cores_per_node": 0.8,
+          "search_cpu_cores_per_surviving_node": 1.4286,
+          "search_qps_per_index_shard": 4000.0,
+          "search_replica_utilization_pct": 35.7143,
+          "surviving_shards_in_affected_index_shard": 14,
+          "upserts_per_second_per_ha_group": 400.0,
+          "working_set_gib_per_replica": 26.6667,
+          "write_leader_utilization_pct_per_ha_group": 20.0
+        },
+        "worker": {
+          "lost_shards": 1,
+          "peak_cpu_pct": 57.6406,
+          "peak_rss_pct": 62.5,
+          "provisioned_shards_in_affected_cell": 7,
+          "resident_artifact_chunk_gib_max": 0.25,
+          "surviving_shards_in_affected_cell": 6
+        }
+      }
+    },
+    "regional_cell_loss": {
+      "authoritative_rpo_seconds_max": 60,
+      "backlog_drain_seconds": 2872.3404,
+      "computed_oldest_policy_ready_due_seconds": 13672.3404,
+      "failed_cells": 1,
+      "frozen_policy_ready_tasks": 2250000,
+      "paired_cell_modeled_utilization_pct": {
+        "browser_cpu": 19.9382,
+        "postgres_commit_per_promoted_writer": 5.7099,
+        "queue_throughput": 17.0898,
+        "typesense_cpu": 36.8056,
+        "worker_cpu": 17.155
+      },
+      "restore_seconds": 10800.0
+    },
+    "steady": {
+      "arrival_cycles_per_hour": 6000000,
+      "attempted_processing_cycles_per_second": 1750.0,
+      "computed_backlog_drain_seconds": 126.0504,
+      "computed_oldest_policy_ready_due_seconds": 126.0504,
+      "computed_policy_ready_queue_depth": 1000000,
+      "computed_shard_recovery_seconds": 0.0,
+      "computed_total_queue_entries": 11000000,
+      "continuing_arrival_cycles_per_second": 1666.6667,
+      "network_gbps": 5.2986,
+      "required_processing_cycles_per_second": 1666.6667,
+      "tiers": {
+        "browser": {
+          "lost_shards": 0,
+          "peak_cpu_pct": 9.9691,
+          "peak_rss_pct": 14.3692,
+          "provisioned_shards_in_affected_cell": 16,
+          "resident_artifact_chunk_gib_max": 0.1875,
+          "session_slot_pct": 9.9691,
+          "sessions_global": 306.25,
+          "sessions_peak_survivor": 2.3926,
+          "surviving_shards_in_affected_cell": 16
+        },
+        "cell_service": {
+          "lost_shards": 0,
+          "peak_cpu_pct": 16.6667,
+          "peak_rss_pct": 16.6667,
+          "provisioned_shards_in_affected_cell": 3,
+          "surviving_shards_in_affected_cell": 3
+        },
+        "load_balancer": {
+          "lost_shards": 0,
+          "modeled_throughput_pct": 3.6458,
+          "provisioned_shards_in_affected_cell": 2,
+          "surviving_shards_in_affected_cell": 2
+        },
+        "postgres": {
+          "commits_per_second_per_writer": 171.2963,
+          "lost_shards": 0,
+          "modeled_commit_throughput_pct": 5.7099,
+          "peak_cpu_pct": 5.353,
+          "peak_rss_pct": 50.0,
+          "provisioned_shards_in_affected_cell": 3,
+          "surviving_shards_in_affected_cell": 3
+        },
+        "queue": {
+          "cycles_per_second_peak_survivor": 27.3438,
+          "entries_peak_survivor": 171875,
+          "lost_shards": 0,
+          "modeled_throughput_pct": 8.5449,
+          "peak_cpu_pct": 0.5469,
+          "peak_rss_pct": 7.7867,
+          "provisioned_shards_in_affected_cell": 8,
+          "surviving_shards_in_affected_cell": 8
+        },
+        "routing": {
+          "lost_shards": 0,
+          "peak_cpu_pct": 8.3333,
+          "peak_rss_pct": 8.3333,
+          "provisioned_shards_in_affected_cell": 3,
+          "surviving_shards_in_affected_cell": 3
+        },
+        "telemetry": {
+          "lost_shards": 0,
+          "peak_cpu_pct": 16.6667,
+          "peak_rss_pct": 33.3333,
+          "provisioned_shards_in_affected_cell": 3,
+          "surviving_shards_in_affected_cell": 3
+        },
+        "telemetry_backend": {
+          "lost_shards": 0,
+          "modeled_series_throughput_pct": 34.375,
+          "modeled_signal_throughput_pct": 19.375,
+          "modeled_throughput_pct": 34.375,
+          "provisioned_shards_global": 2,
+          "surviving_shards_global": 2
+        },
+        "typesense": {
+          "lost_shards": 0,
+          "modeled_throughput_pct": 33.3333,
+          "peak_cpu_pct": 18.4028,
+          "peak_rss_pct": 41.6667,
+          "provisioned_shards_in_affected_index_shard": 15,
+          "replicated_write_cpu_cores_per_node": 0.1389,
+          "search_cpu_cores_per_surviving_node": 1.3333,
+          "search_qps_per_index_shard": 4000.0,
+          "search_replica_utilization_pct": 33.3333,
+          "surviving_shards_in_affected_index_shard": 15,
+          "upserts_per_second_per_ha_group": 69.4444,
+          "working_set_gib_per_replica": 26.6667,
+          "write_leader_utilization_pct_per_ha_group": 3.4722
+        },
+        "worker": {
+          "lost_shards": 0,
+          "peak_cpu_pct": 8.5775,
+          "peak_rss_pct": 43.75,
+          "provisioned_shards_in_affected_cell": 7,
+          "resident_artifact_chunk_gib_max": 0.25,
+          "surviving_shards_in_affected_cell": 7
+        }
+      }
+    }
+  },
+  "schema_version": 1,
+  "spec_sha256": "ef66e5d27bc4dc36f35a805af8964292ae59b992482ab6c4688a286cbbb3c49f",
+  "storage": {
+    "active_postings_peak_ownership_partition": 16114,
+    "backup_copies": 2,
+    "backup_storage_budget_tib": 16.0,
+    "control_metadata_budget_gib": 256.0,
+    "control_metadata_logical_gib": 83.4465,
+    "control_metadata_replicated_gib": 250.3395,
+    "database_payload_tib": 2.738,
+    "database_primary_budget_tib": 16.0,
+    "database_wal_and_scratch_budget_tib": 4.0,
+    "policy_keys_peak_partition": 3223,
+    "queue_aof_and_snapshot_budget_tib": 1.0,
+    "queue_primary_peak_gib": 15.7356,
+    "queue_replicated_peak_gib": 47.2069,
+    "r2_description_budget_tib": 16.0,
+    "r2_description_payload_tib": 11.9209,
+    "telemetry_active_series_global": 50000,
+    "telemetry_logs_traces_profiles_gib_per_month": 300,
+    "typesense_index_payload_tib": 1.1176,
+    "typesense_index_replicated_budget_tib": 18.0,
+    "typesense_index_replicated_tib": 16.7638
+  },
+  "thresholds": {
+    "overload_shard_loss": {
+      "catch_up_service_cycles_per_second": 9600,
+      "due_burst_seconds": 3600,
+      "failed_shards_by_tier": {
+        "browser": 1,
+        "cell_service": 1,
+        "load_balancer": 1,
+        "postgres": 1,
+        "queue": 1,
+        "routing": 1,
+        "telemetry": 1,
+        "telemetry_backend": 1,
+        "typesense": 1,
+        "worker": 1
+      },
+      "failure_domain": "simultaneous_one_shard_loss_in_every_sharded_runtime_tier_in_one_cell_plus_one_telemetry_backend",
+      "load_multiplier": 2.0,
+      "max_blended_cost_per_million_eur": 7,
+      "max_board_cost_per_million_eur": 8,
+      "max_catch_up_seconds": 2700,
+      "max_cpu_pct": 70,
+      "max_detail_cost_per_million_eur": 6.5,
+      "max_network_gbps": 40,
+      "max_oldest_policy_ready_due_seconds": 2700,
+      "max_policy_ready_queue_depth": 12000000,
+      "max_rss_pct": 70,
+      "max_shard_recovery_seconds": 600,
+      "max_total_queue_entries": 22000000,
+      "required_processing_cycles_per_second": 9600
+    },
+    "regional_cell_loss": {
+      "failed_cells": 1,
+      "failure_domain": "one_complete_data_cell",
+      "load_multiplier": 1.0,
+      "max_authoritative_rpo_seconds": 60,
+      "max_freeze_and_restore_seconds": 10800,
+      "max_oldest_policy_ready_due_seconds": 18000,
+      "note": "Disaster envelope only; it is not the 2x scheduler-shard rollout gate. A cell never live-fails over until its fenced Postgres/WAL and manifest epoch are verified."
+    },
+    "retirement_execution_gate": {
+      "allowed_duplicate_authoritative_completion": 0,
+      "allowed_origin_policy_violations": 0,
+      "allowed_queue_loss": 0,
+      "allowed_unbounded_memory_windows": 0,
+      "minimum_cycles_at_overload": 24000000,
+      "minimum_drill_hours": 2,
+      "minimum_steady_hours": 24,
+      "repeat_count": 3,
+      "request_amplification_max": 1.05,
+      "require_measured_all_tiers": true,
+      "require_production_equivalent_hardware": true,
+      "require_same_spec_sha256": true
+    },
+    "steady": {
+      "catch_up_service_cycles_per_second": 9600,
+      "due_burst_seconds": 600,
+      "failed_shards_by_tier": {},
+      "failure_domain": "none",
+      "load_multiplier": 1.0,
+      "max_blended_cost_per_million_eur": 13,
+      "max_board_cost_per_million_eur": 16,
+      "max_cpu_pct": 35,
+      "max_detail_cost_per_million_eur": 13,
+      "max_monthly_cost_eur": 55500,
+      "max_network_gbps": 8,
+      "max_oldest_policy_ready_due_seconds": 600,
+      "max_policy_ready_queue_depth": 1000000,
+      "max_rss_pct": 55,
+      "max_total_queue_entries": 11000000,
+      "required_processing_cycles_per_second": 1666.6666666667
+    }
+  },
+  "topology": {
+    "data_cells": 8,
+    "logical_partitions": 8192,
+    "queue_shards": 64,
+    "simultaneous_loss_matrix": {
+      "browser": {
+        "lost_shards": 1,
+        "max_modeled_capacity_pct_after_loss": 61.25,
+        "provisioned_shards": 16,
+        "scope": "affected_cell",
+        "surviving_shards": 15
+      },
+      "cell_service": {
+        "lost_shards": 1,
+        "max_modeled_capacity_pct_after_loss": 50.0,
+        "provisioned_shards": 3,
+        "scope": "affected_cell",
+        "surviving_shards": 2
+      },
+      "load_balancer": {
+        "lost_shards": 1,
+        "max_modeled_capacity_pct_after_loss": 42.0,
+        "provisioned_shards": 2,
+        "scope": "affected_cell",
+        "surviving_shards": 1
+      },
+      "postgres": {
+        "lost_shards": 1,
+        "max_modeled_capacity_pct_after_loss": 62.5,
+        "provisioned_shards": 3,
+        "scope": "affected_cell",
+        "surviving_shards": 2
+      },
+      "queue": {
+        "lost_shards": 1,
+        "max_modeled_capacity_pct_after_loss": 64.9688,
+        "provisioned_shards": 8,
+        "scope": "affected_cell",
+        "surviving_shards": 7
+      },
+      "routing": {
+        "lost_shards": 1,
+        "max_modeled_capacity_pct_after_loss": 25.0,
+        "provisioned_shards": 3,
+        "scope": "affected_cell",
+        "surviving_shards": 2
+      },
+      "telemetry": {
+        "lost_shards": 1,
+        "max_modeled_capacity_pct_after_loss": 62.5,
+        "provisioned_shards": 3,
+        "scope": "affected_cell",
+        "surviving_shards": 2
+      },
+      "telemetry_backend": {
+        "lost_shards": 1,
+        "max_modeled_capacity_pct_after_loss": 62.5,
+        "provisioned_shards": 2,
+        "scope": "global",
+        "surviving_shards": 1
+      },
+      "typesense": {
+        "lost_shards": 1,
+        "max_modeled_capacity_pct_after_loss": 41.6667,
+        "provisioned_shards": 15,
+        "scope": "affected_index_shard",
+        "surviving_shards": 14
+      },
+      "worker": {
+        "lost_shards": 1,
+        "max_modeled_capacity_pct_after_loss": 62.5,
+        "provisioned_shards": 7,
+        "scope": "affected_cell",
+        "surviving_shards": 6
+      }
+    },
+    "typesense_full_replicas_per_index_shard": 15,
+    "typesense_ha_replica_groups_per_index_shard": 5,
+    "typesense_index_shards": 24,
+    "typesense_index_shards_per_data_cell": 3,
+    "typesense_nodes_per_ha_replica_group": 3,
+    "unweighted_reference_recovery_max_load_factor": 1.1875,
+    "unweighted_reference_recovery_partition_counts": [
+      0,
+      148,
+      147,
+      138,
+      145,
+      149,
+      152,
+      145,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128,
+      128
+    ]
+  },
+  "workload": {
+    "active_postings": 100000000,
+    "configured_boards": 10000000,
+    "origin_attempts_per_success_max": 1.05,
+    "overload_cycles_per_hour": 12000000,
+    "payload_contract": {
+      "max_artifact_chunk_bytes": 8388608,
+      "max_browser_transfer_bytes": 67108864,
+      "max_http_transfer_bytes": 16777216,
+      "max_inline_body_bytes": 8388608,
+      "resident_semantics": "response maxima are bounded streamed totals; ordered chunks are hashed incrementally; at most one artifact chunk per active task or one normalized replay payload up to 8 MiB is resident"
+    },
+    "steady_cycles_per_hour": 6000000
+  }
+}

--- a/capacity/crawler/global-v1.json
+++ b/capacity/crawler/global-v1.json
@@ -1,0 +1,379 @@
+{
+  "schema_version": 1,
+  "revision": "global-v1",
+  "effective_date": "2026-08-26",
+  "owner_issue": "https://github.com/colophon-group/jobseek/issues/7936",
+  "consumer_issue": "https://github.com/colophon-group/jobseek/issues/7966",
+  "base_commit": "bb892b6350cfcbbc2779e8fde318231a1a24926a",
+  "evidence_status": {
+    "capacity_arithmetic": "analytical",
+    "routing_and_conservation": "measured_by_checked_in_synthetic_harness",
+    "go_runtime": "future_execution_gate",
+    "redis_postgres_lightpanda": "future_execution_gate",
+    "typesense_telemetry_and_service_tiers": "future_execution_gate",
+    "production_equivalent_2x_loss_drill": "future_execution_gate"
+  },
+  "units": {
+    "data": "bytes unless a field is suffixed _gib or _tib; GiB and TiB are IEC powers of 1024",
+    "money": "EUR excluding VAT per 30-day month unless a field says USD",
+    "rates": "successful cycles per wall-clock second or hour; retries are additional origin attempts",
+    "time": "seconds unless a field is suffixed _ms or _hours",
+    "cpu": "percentage of allocatable logical CPU after the declared lost shard",
+    "rss": "resident bytes divided by the shard memory limit",
+    "queue_depth": "policy-ready plus inflight task records; future policy deferrals are reported separately"
+  },
+  "provenance": {
+    "workload_floor": "https://github.com/colophon-group/jobseek/issues/7935",
+    "typesense_ha_semantics": "https://typesense.org/docs/guide/high-availability.html",
+    "hetzner_price_snapshot": "https://docs.hetzner.com/general/infrastructure-and-availability/price-adjustment/",
+    "r2_price_snapshot": "https://developers.cloudflare.com/r2/pricing/",
+    "grafana_price_snapshot": "https://grafana.com/pricing/",
+    "prices_as_of": "2026-08-26",
+    "database_size_observation_as_of": "2026-08-26",
+    "database_size_observation": "review-gate production observation: approximately 7.3 KiB total relation bytes per posting; remeasure with the documented pg_total_relation_size query before hardware purchase",
+    "planning_exchange_rate_usd_to_eur": 0.9,
+    "note": "Prices are reproducible planning inputs, not vendor commitments. Refresh the catalog and spec digest before a purchase or retirement gate."
+  },
+  "workload": {
+    "configured_boards": 10000000,
+    "active_postings": 100000000,
+    "retained_postings": 400000000,
+    "posting_retention_days": 400,
+    "monitor_cycles_per_hour": 1000000,
+    "detail_cycles_per_hour": 5000000,
+    "retry_attempts_per_success_max": 0.05,
+    "monitor_browser_share": 0.1,
+    "detail_browser_share": 0.05,
+    "monitor_proxy_share": 0.02,
+    "detail_proxy_share": 0.01,
+    "description_change_share_of_detail": 0.05,
+    "monitor_http_response_mean_bytes": 262144,
+    "monitor_http_response_p50_bytes": 65536,
+    "monitor_http_response_p95_bytes": 524288,
+    "monitor_http_response_p99_bytes": 4194304,
+    "monitor_http_response_max_bytes": 16777216,
+    "detail_http_response_mean_bytes": 196608,
+    "detail_http_response_p50_bytes": 98304,
+    "detail_http_response_p95_bytes": 786432,
+    "detail_http_response_p99_bytes": 4194304,
+    "detail_http_response_max_bytes": 16777216,
+    "browser_transfer_mean_bytes": 3145728,
+    "browser_transfer_p50_bytes": 1572864,
+    "browser_transfer_p95_bytes": 8388608,
+    "browser_transfer_p99_bytes": 25165824,
+    "browser_transfer_max_bytes": 67108864,
+    "max_inline_body_bytes": 8388608,
+    "max_artifact_chunk_bytes": 8388608,
+    "max_http_transfer_bytes": 16777216,
+    "max_browser_transfer_bytes": 67108864,
+    "resident_payload_semantics": "response maxima are bounded streamed totals; ordered chunks are hashed incrementally; at most one artifact chunk per active task or one normalized replay payload up to 8 MiB is resident",
+    "browser_session_seconds_mean": 3.0,
+    "monitor_worker_cpu_ms": 30.0,
+    "detail_worker_cpu_ms": 20.0,
+    "browser_orchestration_cpu_ms": 5.0,
+    "browser_cpu_ms": 1000.0,
+    "monitor_db_commits_per_cycle": 2.0,
+    "detail_db_commits_per_cycle": 2.5,
+    "db_cpu_ms_per_commit": 10.0,
+    "retry_db_commits_per_failed_attempt": 1.0,
+    "description_object_mean_bytes": 32768,
+    "database_bytes_per_retained_posting": 7475,
+    "database_bytes_per_board": 2048,
+    "typesense_bytes_per_active_posting": 12288,
+    "queue_bytes_per_task": 512,
+    "queue_allocator_multiplier": 1.5,
+    "queue_operations_per_cycle": 5.0,
+    "queue_cpu_us_per_operation": 80.0,
+    "catalog_bytes_per_board": 4096,
+    "policy_keys": 10000000,
+    "policy_bytes_per_key": 1024,
+    "posting_ownership_bytes_per_active_posting": 128,
+    "detail_schedule_and_downstream_cursor_bytes_per_active_posting": 256,
+    "control_metadata_copies": 3,
+    "typesense_upserts_per_successful_cycle": 1.0,
+    "typesense_search_qps_global": 4000,
+    "typesense_search_fanout_semantics": "every global user search sends one shard-level search to every Typesense index shard; each shard receives the full global search QPS and routing distributes those shard searches across its HA replica groups",
+    "typesense_write_replication_semantics": "every successful shard upsert is sent to every HA replica group for that index shard; each group leader serializes the full shard write rate and every node applies it",
+    "typesense_upsert_cpu_ms": 2.0,
+    "typesense_search_cpu_ms": 5.0
+  },
+  "topology": {
+    "data_cells": 8,
+    "maximum_data_cells_without_repartitioning": 32,
+    "logical_partitions": 8192,
+    "queue_shards_per_cell": 8,
+    "queue_replicas_per_primary": 2,
+    "worker_shards_per_cell": 7,
+    "browser_shards_per_cell": 16,
+    "postgres_writer_shards_per_cell": 3,
+    "postgres_sync_standbys_per_writer": 1,
+    "telemetry_collectors_per_cell": 3,
+    "telemetry_backends": 2,
+    "cell_service_shards_per_cell": 3,
+    "routing_shards_per_cell": 3,
+    "load_balancers_per_cell": 2,
+    "routing_hash": "sha256-board-v1-first-u64-mod-8192",
+    "manifest_assignment": "partition-slot-v1 seed; the epoch-fenced owner manifest is authoritative",
+    "posting_ownership_key": "sha256 of the normalized canonical posting URL modulo 8192; the epoch-fenced owner ledger is authoritative",
+    "policy_partition_key": "sha256 of canonical origin or provider-account key modulo 4096; the epoch-fenced owner counter is authoritative",
+    "recovery_assignment": "capacity-weighted deterministic recovery-v1 using board, task-rate, provider, browser, and posting weights",
+    "growth_assignment": "capacity-weighted rendezvous owner manifest; never runtime modulo remapping",
+    "failed_partition_recovery_max_load_factor": 1.1875,
+    "failed_board_recovery_max_load_factor": 1.32,
+    "policy_partitions": 4096,
+    "posting_ownership_partitions": 8192,
+    "typesense_index_shards": 24,
+    "critical_telemetry_series_dual_written": 5000,
+    "recovery_phases_seconds": {
+      "failure_detection_and_freeze": 120,
+      "replica_watermark_and_conservation": 120,
+      "epoch_fence_and_rebuild": 300,
+      "resume_safety_margin": 60
+    }
+  },
+  "profiles": {
+    "queue": {
+      "cpu_cores_per_primary": 2,
+      "memory_gib_per_node": 8,
+      "baseline_rss_gib": 0.5,
+      "modeled_cycles_per_second_per_primary": 320,
+      "storage_gib_per_node": 80
+    },
+    "worker": {
+      "cpu_cores_per_shard": 8,
+      "memory_gib_per_shard": 32,
+      "concurrent_resident_payloads_per_shard_max": 32,
+      "steady_rss_gib_per_shard_max": 14,
+      "overload_rss_gib_per_shard_max": 20
+    },
+    "browser": {
+      "cpu_cores_per_shard": 8,
+      "memory_gib_per_shard": 32,
+      "session_slots_per_shard": 24,
+      "concurrent_resident_artifact_chunks_per_shard_max": 24,
+      "baseline_rss_gib": 4,
+      "rss_mib_per_session": 256
+    },
+    "postgres": {
+      "cpu_cores_per_writer": 32,
+      "memory_gib_per_writer": 128,
+      "steady_rss_gib_per_writer_max": 64,
+      "overload_rss_gib_per_writer_max": 80,
+      "modeled_commits_per_second_per_writer": 3000,
+      "usable_storage_tib_per_writer": 4
+    },
+    "telemetry": {
+      "cpu_cores_per_collector": 4,
+      "memory_gib_per_collector": 8,
+      "steady_cpu_cores_per_cell": 2,
+      "overload_cpu_cores_per_cell": 4.8,
+      "steady_working_set_gib_per_cell": 8,
+      "overload_working_set_gib_per_cell": 10
+    },
+    "typesense": {
+      "cpu_cores_per_node": 8,
+      "memory_gib_per_node": 64,
+      "ha_replica_groups_per_index_shard": 5,
+      "nodes_per_ha_replica_group": 3,
+      "modeled_upserts_per_second_per_leader": 2000,
+      "modeled_search_qps_per_node": 800,
+      "working_set_gib_global": 640
+    },
+    "cell_service": {
+      "cpu_cores_per_shard": 8,
+      "memory_gib_per_shard": 32,
+      "steady_cpu_cores_per_cell": 4,
+      "overload_cpu_cores_per_cell": 8,
+      "steady_working_set_gib_per_cell": 16,
+      "overload_working_set_gib_per_cell": 32
+    },
+    "routing": {
+      "cpu_cores_per_shard": 4,
+      "memory_gib_per_shard": 16,
+      "steady_cpu_cores_per_cell": 1,
+      "overload_cpu_cores_per_cell": 2,
+      "steady_working_set_gib_per_cell": 4,
+      "overload_working_set_gib_per_cell": 8
+    },
+    "load_balancer": {
+      "modeled_requests_per_second_per_instance": 3000
+    },
+    "telemetry_backend": {
+      "modeled_active_series_per_backend": 80000,
+      "modeled_signal_gib_per_month_per_backend": 800
+    }
+  },
+  "scenarios": {
+    "steady": {
+      "load_multiplier": 1.0,
+      "failure_domain": "none",
+      "failed_shards_by_tier": {},
+      "required_processing_cycles_per_second": 1666.6666666667,
+      "catch_up_service_cycles_per_second": 9600,
+      "due_burst_seconds": 600,
+      "max_cpu_pct": 35,
+      "max_rss_pct": 55,
+      "max_policy_ready_queue_depth": 1000000,
+      "max_total_queue_entries": 11000000,
+      "max_oldest_policy_ready_due_seconds": 600,
+      "max_network_gbps": 8,
+      "max_monthly_cost_eur": 55500,
+      "max_board_cost_per_million_eur": 16,
+      "max_detail_cost_per_million_eur": 13,
+      "max_blended_cost_per_million_eur": 13
+    },
+    "overload_shard_loss": {
+      "load_multiplier": 2.0,
+      "failure_domain": "simultaneous_one_shard_loss_in_every_sharded_runtime_tier_in_one_cell_plus_one_telemetry_backend",
+      "failed_shards_by_tier": {
+        "queue": 1,
+        "worker": 1,
+        "browser": 1,
+        "postgres": 1,
+        "telemetry": 1,
+        "telemetry_backend": 1,
+        "typesense": 1,
+        "cell_service": 1,
+        "routing": 1,
+        "load_balancer": 1
+      },
+      "required_processing_cycles_per_second": 9600,
+      "catch_up_service_cycles_per_second": 9600,
+      "due_burst_seconds": 3600,
+      "max_cpu_pct": 70,
+      "max_rss_pct": 70,
+      "max_policy_ready_queue_depth": 12000000,
+      "max_total_queue_entries": 22000000,
+      "max_oldest_policy_ready_due_seconds": 2700,
+      "max_shard_recovery_seconds": 600,
+      "max_catch_up_seconds": 2700,
+      "max_network_gbps": 40,
+      "max_board_cost_per_million_eur": 8,
+      "max_detail_cost_per_million_eur": 6.5,
+      "max_blended_cost_per_million_eur": 7
+    },
+    "regional_cell_loss": {
+      "load_multiplier": 1.0,
+      "failure_domain": "one_complete_data_cell",
+      "failed_cells": 1,
+      "max_freeze_and_restore_seconds": 10800,
+      "max_authoritative_rpo_seconds": 60,
+      "max_oldest_policy_ready_due_seconds": 18000,
+      "note": "Disaster envelope only; it is not the 2x scheduler-shard rollout gate. A cell never live-fails over until its fenced Postgres/WAL and manifest epoch are verified."
+    }
+  },
+  "storage_budgets": {
+    "database_primary_global_tib": 16,
+    "database_wal_and_scratch_global_tib": 4,
+    "typesense_index_replicated_global_tib": 18,
+    "catalog_policy_and_cursor_global_gib": 256,
+    "r2_description_global_tib": 16,
+    "backup_copies": 2,
+    "backup_storage_global_tib": 16,
+    "backup_fulls_per_month": 4,
+    "backup_incrementals_per_month": 30,
+    "backup_restore_drills_per_month": 1,
+    "queue_aof_and_snapshot_global_tib": 1,
+    "telemetry_active_series_global": 50000,
+    "telemetry_active_series_per_backend": 80000,
+    "telemetry_samples_per_minute_per_series": 1,
+    "telemetry_logs_gib_per_month": 200,
+    "telemetry_traces_gib_per_month": 50,
+    "telemetry_profiles_gib_per_month": 50,
+    "critical_telemetry_signal_gib_dual_written": 10,
+    "telemetry_local_spool_hours": 6,
+    "sampled_success_log_ratio": 0.001,
+    "sampled_trace_ratio": 0.0001
+  },
+  "prices": {
+    "days_per_month": 30,
+    "hours_per_month": 720,
+    "nodes": {
+      "queue_node": {
+        "count": 192,
+        "eur_per_month": 10.49,
+        "basis": "64 primaries times primary plus two replicas; CAX21 planning price"
+      },
+      "worker_node": {
+        "count": 56,
+        "eur_per_month": 138.49,
+        "basis": "seven 8-vCPU worker shards in each of eight cells; CCX33 planning price"
+      },
+      "browser_node": {
+        "count": 128,
+        "eur_per_month": 138.49,
+        "basis": "sixteen 8-vCPU Lightpanda shards in each of eight cells; CCX33 planning price"
+      },
+      "postgres_node": {
+        "count": 48,
+        "eur_per_month": 257.3,
+        "basis": "three writer shards, each with a synchronous standby, in every cell; AX102-1 planning price"
+      },
+      "telemetry_collector_node": {
+        "count": 24,
+        "eur_per_month": 10.49,
+        "basis": "three collectors per cell; CAX21 planning price"
+      },
+      "cell_service_node": {
+        "count": 24,
+        "eur_per_month": 85.99,
+        "basis": "three independent catalog, R2-drain, CDC, and repair service shards per cell; CCX23 planning price"
+      },
+      "routing_node": {
+        "count": 24,
+        "eur_per_month": 85.99,
+        "basis": "three stateless manifest/policy routing shards per cell; CCX23 planning price"
+      },
+      "typesense_node": {
+        "count": 360,
+        "eur_per_month": 97.3,
+        "basis": "24 index shards (three per data cell), each with five independent three-node HA replica groups so fan-out search stays below 35% steady and 70% after one-node loss"
+      },
+      "load_balancer": {
+        "count": 16,
+        "eur_per_month": 5.99,
+        "basis": "two independent regional private load balancer instances per cell planning allowance"
+      }
+    },
+    "proxy_static_ips": 64,
+    "proxy_eur_per_ip_month": 10,
+    "backup_eur_per_gb_month": 0.005,
+    "backup_operations_eur_per_month": 500,
+    "r2_usd_per_gb_month": 0.015,
+    "r2_class_a_usd_per_million": 4.5,
+    "r2_class_b_usd_per_million": 0.36,
+    "r2_reads_per_detail_cycle": 0.01,
+    "metrics_usd_per_thousand_series": 6.5,
+    "metrics_included_series_per_backend": 10000,
+    "telemetry_usd_per_gib": 0.5,
+    "telemetry_included_gib_per_signal": 50,
+    "origin_transfer_eur_per_tib": 0,
+    "monthly_miscellaneous_eur": 1500
+  },
+  "cost_sensitivity": {
+    "price_multiplier": 1.25,
+    "sustained_volume_multiplier": 0.75,
+    "browser_share_multiplier": 2.0,
+    "proxy_cost_multiplier": 5.0,
+    "paid_origin_transfer_eur_per_tib": 8,
+    "telemetry_cost_multiplier": 2.0,
+    "backup_copy_multiplier": 1.5,
+    "max_board_cost_per_million_eur": 44,
+    "max_detail_cost_per_million_eur": 32,
+    "max_blended_cost_per_million_eur": 34
+  },
+  "retirement_execution_gate": {
+    "minimum_drill_hours": 2,
+    "minimum_steady_hours": 24,
+    "minimum_cycles_at_overload": 24000000,
+    "repeat_count": 3,
+    "allowed_queue_loss": 0,
+    "allowed_duplicate_authoritative_completion": 0,
+    "allowed_origin_policy_violations": 0,
+    "allowed_unbounded_memory_windows": 0,
+    "request_amplification_max": 1.05,
+    "require_same_spec_sha256": true,
+    "require_production_equivalent_hardware": true,
+    "require_measured_all_tiers": true
+  }
+}

--- a/docs/23-go-lightpanda-migration.md
+++ b/docs/23-go-lightpanda-migration.md
@@ -13,19 +13,26 @@ Offline replay may compare both implementations from one captured upstream
 response. We do not run permanent duplicate fleets, issue duplicate origin
 requests, or silently fall back per task.
 
-## Provisional capacity floor
+## Frozen capacity envelope
 
-The capacity-design issue must replace these floors with a measured model
-before global rollout. They prevent decisions that only fit today's volume:
+The versioned [global crawler capacity envelope](24-global-crawler-capacity-envelope.md)
+replaces the former provisional floor with the global-v1 analytical model,
+generated report, synthetic routing evidence, and residual production-equivalent
+execution gate. It prevents decisions that only fit today's volume:
 
 - 10 million configured boards and 100 million active postings.
 - At least 1 million boards due in one hour (16,667 monitor requests/minute).
 - At least 5 million detail fetches due in one hour during catch-up (83,333
   scrape requests/minute), subject to origin policy.
-- A 2x synthetic overload and one-shard-loss catch-up test without queue loss,
-  origin-policy violation, or unbounded memory growth.
-- Horizontal partitions that remain below 70% steady-state memory and CPU so
-  a shard can absorb recovery traffic.
+- A 2x overload while one shard is simultaneously lost from every sharded
+  runtime tier, without queue loss, origin-policy violation, or unbounded
+  memory growth.
+- Surviving runtime capacity at or below 70% CPU, RSS, sessions, transactions,
+  or modeled throughput after those losses.
+
+The model is not production-equivalent evidence. Global rollout and old-runtime
+retirement remain blocked until its repeated Go/Redis/Postgres/Lightpanda/
+Typesense/telemetry execution gate passes with the same spec digest.
 
 Throughput is subordinate to publisher policy. Provider-, tenant-, and
 egress-scoped rate/concurrency limits, `Retry-After`, TDM reservations, and

--- a/docs/24-global-crawler-capacity-envelope.md
+++ b/docs/24-global-crawler-capacity-envelope.md
@@ -1,0 +1,167 @@
+# Global crawler capacity envelope
+
+Status: analytically rejected candidate for issue [#7936](https://github.com/colophon-group/jobseek/issues/7936), effective 2026-08-26. The minimum fan-out-safe Typesense profile passes the CPU, RSS, and throughput gates but fails the frozen economic envelope. It is not production-equivalent execution evidence, and issue #7936 must remain open.
+
+The machine-readable source of truth is [global-v1.json](../capacity/crawler/global-v1.json). The generated [global-v1-report.json](../capacity/crawler/global-v1-report.json) records its canonical SHA-256 digest. These are offline planning artifacts outside the crawler runtime and deployment path. The local routing artifact is evidence for only the deterministic synthetic ownership harness. Every number below is either a frozen input or generated from that exact spec.
+
+## Evidence boundary
+
+| Classification | Covered here | Not covered |
+|---|---|---|
+| Analytical | Workload arithmetic, retry amplification, tier sizing, queue age, storage, network, and cost | Real latency, allocator behavior, failover behavior, or vendor performance |
+| Measured synthetic | Streaming assignment of 10 million board IDs, weighted task/provider/browser/posting ownership, conservation, recovery, and growth stability | Go, Redis, Postgres, Lightpanda, Typesense, origin, or telemetry throughput |
+| Future execution gate | The reproducible run plan and pass/fail thresholds | No production-equivalent run is claimed in this PR |
+
+The evidence JSON includes the run date, base commit, platform, Python version, logical CPU count, physical memory when available, commands, units, spec digest, and its own digest. Capacity inputs are planning assumptions until replaced by dated production observations.
+
+## Frozen workload and payload semantics
+
+| Input | Steady | Simultaneous overload gate |
+|---|---:|---:|
+| Configured boards | 10,000,000 | 10,000,000 |
+| Active postings | 100,000,000 | 100,000,000 |
+| Monitor success cycles/hour | 1,000,000 | 2,000,000 arrivals/hour |
+| Detail success cycles/hour | 5,000,000 | 10,000,000 arrivals/hour |
+| Origin attempts/success | at most 1.05 | at most 1.05 |
+| Required success service | 1,666.67/s | 9,600/s during recovery |
+| Policy-ready burst | 10 minutes | 60 minutes |
+
+Retries are additional work on the queue, workers, browser pool, failed-attempt database commits, and network. Typesense receives only successful authoritative completions. The 9,600/s recovery service is deliberately greater than the continuing 3,333.33/s overload arrival rate.
+
+HTTP response totals are capped at 16 MiB and browser transfer totals at 64 MiB. These are streamed totals, never resident per-task buffers. The cross-stream contract for [#7937](https://github.com/colophon-group/jobseek/issues/7937) uses the identical max_inline_body_bytes, max_artifact_chunk_bytes, max_http_transfer_bytes, and max_browser_transfer_bytes units and values: 8 MiB, 8 MiB, 16 MiB, and 64 MiB. Ordered chunks are validated for contiguous sequence, per-chunk and total size, digest, and completeness while hashing incrementally. At most one chunk per active task, or a normalized replay payload no larger than 8 MiB, is resident. The analytical RSS envelope includes 32 concurrent worker chunks, 0.25 GiB, and 24 browser chunks, 0.1875 GiB, per shard. A producer that buffers a complete 16 or 64 MiB transfer violates this envelope.
+
+Response size distributions, CPU milliseconds, database commits, browser duration, retry rate, and transfer means are frozen in the spec. The generated monthly origin transfer estimate is 1,561.37 TiB at steady load and includes the 1.05 attempt multiplier.
+
+## SLOs and exact arithmetic
+
+The hard thresholds are:
+
+| Scenario | CPU/RSS/capacity | Ready queue | Total queue | Oldest due | Recovery |
+|---|---:|---:|---:|---:|---:|
+| Steady | at most 35% CPU/capacity and 55% RSS | 1,000,000 | 11,000,000 | 600 s | none |
+| 2x plus simultaneous tier loss | at most 70% | 12,000,000 | 22,000,000 | 2,700 s | shard phases at most 600 s; catch-up at most 2,700 s |
+| Complete cell disaster | paired cell at most 70% | 2,250,000 frozen | n/a | 18,000 s | restore at most 10,800 s; authoritative RPO at most 60 s |
+
+The queue-age calculation includes continuing arrivals:
+
+~~~
+backlog = arrival_rate * due_burst_seconds
+drain_seconds = backlog / (catch_up_service - continuing_arrival_rate)
+oldest_due = recovery_seconds + drain_seconds
+~~~
+
+At 2x, this gives 12 million ready tasks, 1,914.89 seconds to drain after continuing arrivals, 600 seconds of shard recovery, and 2,514.89 seconds oldest due. It passes the 2,700 second limit. Redis retains one future monitor entry per configured board. The 100 million detail schedule/cursor records remain in partitioned control storage and materialize into Redis only inside the ready horizon; they are not 100 million future Redis entries. Thus the 10 million future monitor entries are counted separately from the 12 million materialized ready entries, yielding the 22 million total.
+
+## Topology and simultaneous loss matrix
+
+There are eight independent data cells. Each cell owns 1,024 of 8,192 logical board partitions through an epoch-fenced owner manifest. The modulo assignment is only the initial manifest seed. Runtime routing always reads the manifest, and growth uses capacity-weighted rendezvous assignment; adding a cell does not modulo-remap existing owners.
+
+The overload gate loses one shard in every listed runtime tier at the same time in the affected data cell, one node in one affected Typesense index shard, plus one global telemetry backend. All percentages below are calculated after those losses and include 2x load and retry work.
+
+| Tier | Provisioned | Lost | Surviving | Maximum modeled capacity |
+|---|---:|---:|---:|---:|
+| Queue primary groups/cell | 8 | 1 | 7 | 64.969% |
+| Worker shards/cell | 7 | 1 | 6 | 62.5% |
+| Browser shards/cell | 16 | 1 | 15 | 61.25% |
+| Postgres writer groups/cell | 3 | 1 | 2 | 62.5% |
+| Telemetry collectors/cell | 3 | 1 | 2 | 62.5% |
+| Typesense full-replica nodes/index shard | 15 | 1 | 14 | 41.667% |
+| Catalog/CDC/R2 service shards/cell | 3 | 1 | 2 | 50% |
+| Manifest/policy routing shards/cell | 3 | 1 | 2 | 25% |
+| Private load-balancer instances/cell | 2 | 1 | 1 | 42% |
+| Telemetry backends/global | 2 | 1 | 1 | 62.5% |
+
+Each queue primary has two replicas. Each Postgres writer group has a synchronous standby; losing one writer group removes its primary and standby capacity from the calculation. Typesense is 24 independent index shards, three colocated with each data cell. Each index shard has five independent three-node HA replica groups, or 15 full copies. Stateless routing distributes a shard's read requests across those groups; CDC sends every write to every group.
+
+Typesense HA replicas do not pool memory or write throughput. As documented by [Typesense HA](https://typesense.org/docs/guide/high-availability.html), each node holds the shard's complete dataset; extra nodes add read capacity, not data capacity. The 640 GiB global working set is therefore 26.667 GiB on every replica of each index shard, or 41.667% of a 64 GiB node both before and after one-node loss.
+
+Every one of the 4,000 global user searches fans out to all 24 index shards, so each shard receives the full 4,000 search requests/s; sharding does not divide search QPS. With 15 full-replica nodes per shard, this consumes 33.333% of modeled read capacity in steady state. After one node is lost, the 14 survivors consume 35.714%. Search CPU is 1.333 cores/node steady and 1.429 cores/survivor after loss.
+
+Within each three-node HA group, writes sent to any node are forwarded to and serialized by that group's leader, then applied by every replica. Under the 2x gate, every group leader receives all 400 successful upserts/s for its shard, so per-leader write utilization is 20% of the modeled 2,000 upserts/s. Every surviving node reserves 0.8 CPU cores for replicated writes; combined with fan-out search, hottest-node CPU is 27.857% of eight cores after loss. The 15 replicas are the minimum odd three-node-group multiple that keeps steady modeled capacity below 35% without inventing a higher per-node benchmark. Collector and backend lines are separate: critical telemetry is dual-written and either backend reserves capacity for all 50,000 active series and 300 GiB/month of signals.
+
+The checker derives the matrix from topology and workloads, asserts every lost count is exactly one, and fails if any surviving CPU, RSS, session, transaction, series, signal, or modeled throughput percentage exceeds 70%.
+
+## Ownership, policy, and conservation
+
+A canonical board ID hashes to one of 8,192 logical partitions. The epoch-fenced manifest maps that partition to a cell and queue shard. A task carries the manifest epoch; a stale owner cannot commit after fencing.
+
+Recovery is deterministic and constrained to surviving shards in the same cell. The planner considers board count, monitor plus detail task rate, provider family, browser work, and active-posting weight. The full-cardinality harness must keep every recovered dimension at or below 1.32 times its mean. Only the failed shard's partitions may move.
+
+Posting admission is independently partitioned into 8,192 ledgers by the normalized canonical posting URL. That owner performs the uniqueness decision before an authoritative completion, so the same URL discovered through different boards cannot create two completions. Policy and circuit-breaker state is partitioned 4,096 ways by canonical origin or provider-account key. Its epoch owner serializes counters and leases; it is not a process-local cache and there is no singleton global policy service.
+
+Catalog, owner manifests, policy records, posting ledgers, and detail-schedule/downstream cursors are three-copy control metadata. The calculated logical footprint is 83.45 GiB and replicated footprint is 250.34 GiB, below the 256 GiB budget. Peak failed-shard partitions contain at most 3,052 policy keys and 15,259 active posting ownership records at the declared imbalance.
+
+The recovery sequence is fixed:
+
+1. Detect the loss and freeze the affected manifest epoch within 120 seconds.
+2. Compare replica watermarks and prove queued, inflight, committed, and dead-letter conservation within 120 seconds.
+3. Publish the recovered owner manifest, fence the old epoch, and rebuild leases within 300 seconds.
+4. Reserve 60 seconds for resume checks.
+
+No acknowledgement is accepted before the authoritative database completion and owner-ledger transition. Replays use stable task and attempt identifiers. The harness asserts zero lost boards, zero duplicate boards, all 100 million weighted postings, all 6 million cycles/hour, and no unaffected recovery movement. Its 8-to-9-cell growth exercise asserts that only partitions assigned to the new cell move.
+
+## Data, storage, and disaster recovery
+
+Board data is colocated with its board partition. Each cell has three Postgres writer groups with synchronous standbys. Descriptions are content-addressed in R2; database rows retain metadata and object references. CDC, R2 drain, and repair workers run in the cell-service tier. Downstream cursor ownership is partitioned with epoch fencing. Each data cell owns three Typesense index shards, and search fans out through stateless routing shards.
+
+| Store | Calculated payload | Budget |
+|---|---:|---:|
+| Postgres retained rows and board metadata | 2.738 TiB | 16 TiB primary plus 4 TiB WAL/scratch |
+| R2 descriptions | 11.921 TiB | 16 TiB |
+| Typesense active index, 15 full copies | 16.764 TiB | 18 TiB replicated |
+| Control metadata, three copies | 250.340 GiB | 256 GiB |
+| Queue peak, primary plus two replicas | 47.207 GiB | 1 TiB AOF/snapshots |
+| Backup copies | two | 16 TiB storage allowance |
+
+The database input is 7,475 bytes per retained posting, based on an approximately 7.3 KiB production relation-size observation dated 2026-08-26. It must be refreshed before hardware purchase with a relation-inclusive query such as:
+
+~~~sql
+SELECT sum(pg_total_relation_size(quote_ident(schemaname) || '.' || quote_ident(relname)))
+FROM pg_stat_user_tables
+WHERE relname IN ('job_posting', 'job_posting_location', 'job_posting_occupation');
+~~~
+
+The complete-cell case is a disaster envelope, not live unsafe failover. The lost cell stays fenced until Postgres/WAL and manifest epochs are verified. With a 10,800 second restore, it freezes 2.25 million tasks; a paired cell drains them in 2,872.34 seconds while serving both cells' continuing arrivals. Oldest due is 13,672.34 seconds, below 18,000, and RPO is capped at 60 seconds. Two backup copies and a monthly restore drill are priced.
+
+## Economics
+
+Prices are dated 2026-08-26, exclude VAT, use a planning USD/EUR rate of 0.9, and are inputs rather than vendor commitments. Sources are the [Hetzner 2026 adjustment](https://docs.hetzner.com/general/infrastructure-and-availability/price-adjustment/), [Cloudflare R2 pricing](https://developers.cloudflare.com/r2/pricing/), and [Grafana Cloud pricing](https://grafana.com/pricing/).
+
+| Case | Monthly cost | Board EUR/million | Detail EUR/million | Blended EUR/million |
+|---|---:|---:|---:|---:|
+| Steady provisioned fleet | €83,266.04 | €14.1650 | €20.2965 | €19.2745 |
+| Sustained 2x volume on the provisioned fleet | €84,006.71 | €7.0825 | €10.2511 | €9.7230 |
+| Sensitivity case | €143,518.57 | €43.6338 | €44.4283 | €44.2959 |
+
+Unit costs allocate shared pools by their causal driver: worker CPU milliseconds, browser session-seconds, database commits, response bytes, proxy share, or equal successful-cycle share. R2 and Typesense are assigned to detail cycles. The Typesense pool prices all 360 full-replica nodes required by the safe fan-out profile. The steady pool includes €35,028.00 Typesense, €17,726.72 browser, €12,350.40 Postgres, €7,755.44 worker, €2,159.60 cell services/load balancers, €2,063.76 routing, €2,014.08 queues, €917.61 R2, €640 proxy, €581.92 backups, €528.51 telemetry, and €1,500 miscellaneous.
+
+This profile is rejected rather than silently loosening the reviewed limits. Steady cost is €83,266.04 versus the €55,500 ceiling; detail and blended unit costs are €20.2965/€19.2745 versus €13/€13. At 2x, detail and blended costs are €10.2511/€9.7230 versus €6.50/€7.00. The sensitivity case combines 1.25 times infrastructure prices, 0.75 times sustained volume, twice the browser prevalence in compute and transferred bytes, five times proxy price, €8/TiB origin transfer, twice telemetry cost, and 1.5 times backup copies. Its €44.4283 detail and €44.2959 blended unit costs exceed the frozen €32/€34 limits. `--check` therefore fails closed on the monthly steady cost gate. A replacement design needs measured per-shard search capacity, fewer fan-out shards, query aggregation/caching, or a different search engine before this envelope can become a passing candidate.
+
+## Reproduction
+
+From the repository root:
+
+~~~bash
+# Expected to exit non-zero: monthly steady cost ceiling exceeded.
+python3 scripts/capacity_envelope.py --check
+python3 scripts/capacity_envelope.py \
+  --write-report capacity/crawler/global-v1-report.json \
+  --benchmark-routing 10000000 \
+  --write-evidence capacity/crawler/evidence/2026-08-26-local-routing.json
+python3 scripts/test_capacity_envelope.py
+~~~
+
+The analytical report must reproduce byte-for-byte from the spec. The evidence digest is computed before its own digest field is appended, and the tests independently verify it. The test suite also proves that every resource gate passes and the unchanged economic gate rejects the profile.
+
+## Residual production-equivalent execution gate
+
+The old Python runtime cannot be retired on this analytical PR. The economic rejection must be resolved before a production-equivalent run is treated as a retirement gate. On a future passing candidate Go fleet, with the same spec digest, all of the following remain required:
+
+- Run steady load for at least 24 hours.
+- Repeat the simultaneous 2x plus one-loss-in-every-tier drill three times, for at least two hours and at least 24 million successful cycles per drill.
+- Exercise real Go workers, queue replicas, Postgres writer groups and standbys, Lightpanda, Typesense, both telemetry paths, service/routing tiers, and network.
+- Record per-tier CPU, RSS, throughput, queue-ready and total depth, oldest due, recovery time, retry amplification, database transactions, browser slots, network, and telemetry loss.
+- Observe zero lost tasks, zero duplicate authoritative completions, zero origin-policy violations, no unbounded memory window, and at most 1.05 origin attempts per success.
+- Pass every steady and simultaneous-loss threshold from the exact checked-in report. Any changed workload, topology, price, or contract limit requires a new revision and digest.
+
+Until a capacity-safe and economically passing replacement profile plus that dated execution evidence exist and are reviewed, this candidate remains rejected and #7936 remains open.

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,10 @@ Status tags:
 - [23 - Go and Lightpanda Crawler Migration](23-go-lightpanda-migration.md)
   `[reference]` - global-scale runtime replacement boundaries, capacity floor,
   cutover safety, replay, metrics, Murmur coordination, and retirement plan.
+- [24 - Global Crawler Capacity Envelope](24-global-crawler-capacity-envelope.md)
+  `[reference]` - versioned global-v1 workload, sharded topology, simultaneous
+  failure matrix, storage and cost budgets, synthetic routing evidence, and
+  production-equivalent execution gate.
 
 ## Search, SEO, And Web Read Paths
 

--- a/scripts/capacity_envelope.py
+++ b/scripts/capacity_envelope.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 """Reproducible analytical and synthetic capacity evidence for issue #7936.
 
 The analytical model deliberately does not impersonate a Go/Redis/Postgres/
@@ -103,7 +102,9 @@ def recovery_slot(
     return max(available, key=score)
 
 
-def recovery_partition_counts(spec: Mapping[str, Any], failed_slot: int = 0) -> list[int]:
+def recovery_partition_counts(
+    spec: Mapping[str, Any], failed_slot: int = 0
+) -> list[int]:
     topology = spec["topology"]
     logical_partitions = int(topology["logical_partitions"])
     total_shards = int(topology["data_cells"]) * int(topology["queue_shards_per_cell"])
@@ -124,7 +125,9 @@ def growth_owner(partition: int, capacity_weights: Sequence[float]) -> int:
     """Return a deterministic capacity-weighted rendezvous owner for a manifest."""
 
     _require(bool(capacity_weights), "growth manifest needs at least one cell")
-    _require(all(weight > 0 for weight in capacity_weights), "cell weights must be positive")
+    _require(
+        all(weight > 0 for weight in capacity_weights), "cell weights must be positive"
+    )
     best: tuple[float, int] | None = None
     for cell, weight in enumerate(capacity_weights):
         digest = hashlib.sha256(f"growth:v1:{partition}:{cell}".encode()).digest()
@@ -162,7 +165,8 @@ def _work_classes(spec: Mapping[str, Any]) -> tuple[WorkClass, WorkClass]:
             db_commits=float(workload["monitor_db_commits_per_cycle"]),
             proxy_share=float(workload["monitor_proxy_share"]),
             mean_response_bytes=(
-                (1 - monitor_browser_share) * float(workload["monitor_http_response_mean_bytes"])
+                (1 - monitor_browser_share)
+                * float(workload["monitor_http_response_mean_bytes"])
                 + monitor_browser_share * browser_bytes
             ),
         ),
@@ -174,7 +178,8 @@ def _work_classes(spec: Mapping[str, Any]) -> tuple[WorkClass, WorkClass]:
             db_commits=float(workload["detail_db_commits_per_cycle"]),
             proxy_share=float(workload["detail_proxy_share"]),
             mean_response_bytes=(
-                (1 - detail_browser_share) * float(workload["detail_http_response_mean_bytes"])
+                (1 - detail_browser_share)
+                * float(workload["detail_http_response_mean_bytes"])
                 + detail_browser_share * browser_bytes
             ),
         ),
@@ -183,10 +188,15 @@ def _work_classes(spec: Mapping[str, Any]) -> tuple[WorkClass, WorkClass]:
 
 def _weighted(classes: Sequence[WorkClass], field: str) -> float:
     total = sum(item.cycles_per_hour for item in classes)
-    return sum(item.cycles_per_hour * float(getattr(item, field)) for item in classes) / total
+    return (
+        sum(item.cycles_per_hour * float(getattr(item, field)) for item in classes)
+        / total
+    )
 
 
-def _surviving_shards(scenario: Mapping[str, Any], tier: str, provisioned: int) -> tuple[int, int]:
+def _surviving_shards(
+    scenario: Mapping[str, Any], tier: str, provisioned: int
+) -> tuple[int, int]:
     lost = int(scenario.get("failed_shards_by_tier", {}).get(tier, 0))
     _require(lost >= 0, f"{tier} lost-shard count cannot be negative")
     _require(lost < provisioned, f"{tier} has no surviving shard")
@@ -211,7 +221,9 @@ def _scenario_report(
         scenario, "queue", queue_per_cell
     )
     recovery_factor = (
-        float(topology["failed_board_recovery_max_load_factor"]) if failed_queue_shards else 1.0
+        float(topology["failed_board_recovery_max_load_factor"])
+        if failed_queue_shards
+        else 1.0
     )
 
     weighted_worker_ms = _weighted(classes, "worker_cpu_ms")
@@ -220,14 +232,18 @@ def _scenario_report(
     weighted_bytes = _weighted(classes, "mean_response_bytes")
     browser_orchestration_ms = float(workload["browser_orchestration_cpu_ms"])
 
-    queue_rate_per_peak_shard = attempted_processing_rate / queue_shards * recovery_factor
+    queue_rate_per_peak_shard = (
+        attempted_processing_rate / queue_shards * recovery_factor
+    )
     queue_cpu_cores = (
         queue_rate_per_peak_shard
         * float(workload["queue_operations_per_cycle"])
         * float(workload["queue_cpu_us_per_operation"])
         / 1_000_000
     )
-    queue_cpu_pct = _pct(queue_cpu_cores, float(profiles["queue"]["cpu_cores_per_primary"]))
+    queue_cpu_pct = _pct(
+        queue_cpu_cores, float(profiles["queue"]["cpu_cores_per_primary"])
+    )
     queue_entries_per_peak_shard = (
         float(scenario["max_total_queue_entries"]) / queue_shards * recovery_factor
     )
@@ -246,7 +262,9 @@ def _scenario_report(
     worker_cpu_seconds_per_cycle = (
         weighted_worker_ms + weighted_browser_share * browser_orchestration_ms
     ) / 1000
-    worker_cpu_cores_per_cell = attempted_processing_rate / cells * worker_cpu_seconds_per_cycle
+    worker_cpu_cores_per_cell = (
+        attempted_processing_rate / cells * worker_cpu_seconds_per_cycle
+    )
     worker_shards_provisioned = int(topology["worker_shards_per_cell"])
     worker_shards_available, failed_worker_shards = _surviving_shards(
         scenario, "worker", worker_shards_provisioned
@@ -256,7 +274,9 @@ def _scenario_report(
         worker_shards_available * float(profiles["worker"]["cpu_cores_per_shard"]),
     )
     worker_rss_key = (
-        "overload_rss_gib_per_shard_max" if has_failure else "steady_rss_gib_per_shard_max"
+        "overload_rss_gib_per_shard_max"
+        if has_failure
+        else "steady_rss_gib_per_shard_max"
     )
     worker_rss_pct = _pct(
         float(profiles["worker"][worker_rss_key]),
@@ -272,7 +292,9 @@ def _scenario_report(
     browser_shards_available, failed_browser_shards = _surviving_shards(
         scenario, "browser", browser_shards_provisioned
     )
-    browser_sessions_per_survivor = browser_sessions_global / cells / browser_shards_available
+    browser_sessions_per_survivor = (
+        browser_sessions_global / cells / browser_shards_available
+    )
     browser_slot_pct = _pct(
         browser_sessions_per_survivor,
         float(profiles["browser"]["session_slots_per_shard"]),
@@ -289,11 +311,17 @@ def _scenario_report(
         browser_shards_available * float(profiles["browser"]["cpu_cores_per_shard"]),
     )
     browser_rss_gib = float(profiles["browser"]["baseline_rss_gib"]) + (
-        browser_sessions_per_survivor * float(profiles["browser"]["rss_mib_per_session"]) / 1024
+        browser_sessions_per_survivor
+        * float(profiles["browser"]["rss_mib_per_session"])
+        / 1024
     )
-    browser_rss_pct = _pct(browser_rss_gib, float(profiles["browser"]["memory_gib_per_shard"]))
+    browser_rss_pct = _pct(
+        browser_rss_gib, float(profiles["browser"]["memory_gib_per_shard"])
+    )
 
-    postgres_writer_shards_provisioned = int(topology["postgres_writer_shards_per_cell"])
+    postgres_writer_shards_provisioned = int(
+        topology["postgres_writer_shards_per_cell"]
+    )
     postgres_writer_shards, failed_postgres_shards = _surviving_shards(
         scenario, "postgres", postgres_writer_shards_provisioned
     )
@@ -314,7 +342,9 @@ def _scenario_report(
         float(profiles["postgres"]["cpu_cores_per_writer"]),
     )
     db_rss_key = (
-        "overload_rss_gib_per_writer_max" if has_failure else "steady_rss_gib_per_writer_max"
+        "overload_rss_gib_per_writer_max"
+        if has_failure
+        else "steady_rss_gib_per_writer_max"
     )
     db_rss_pct = _pct(
         float(profiles["postgres"][db_rss_key]),
@@ -360,7 +390,10 @@ def _scenario_report(
         typesense_upserts * float(workload["typesense_upsert_cpu_ms"]) / 1000
     )
     typesense_search_cpu_cores_per_node = (
-        typesense_search_qps / typesense_nodes * float(workload["typesense_search_cpu_ms"]) / 1000
+        typesense_search_qps
+        / typesense_nodes
+        * float(workload["typesense_search_cpu_ms"])
+        / 1000
     )
     typesense_cpu_pct = _pct(
         typesense_write_cpu_cores_per_node + typesense_search_cpu_cores_per_node,
@@ -445,7 +478,9 @@ def _scenario_report(
             "telemetry_profiles_gib_per_month",
         )
     )
-    critical_signal_gib = int(spec["storage_budgets"]["critical_telemetry_signal_gib_dual_written"])
+    critical_signal_gib = int(
+        spec["storage_budgets"]["critical_telemetry_signal_gib_dual_written"]
+    )
     signal_gib_to_survivor = (
         monthly_signal_gib
         if failed_telemetry_backends
@@ -453,7 +488,9 @@ def _scenario_report(
     )
     telemetry_backend_signal_pct = _pct(
         signal_gib_to_survivor,
-        float(profiles["telemetry_backend"]["modeled_signal_gib_per_month_per_backend"]),
+        float(
+            profiles["telemetry_backend"]["modeled_signal_gib_per_month_per_backend"]
+        ),
     )
 
     network_gbps = (
@@ -496,7 +533,8 @@ def _scenario_report(
         "worker resident artifact chunks exceed its RSS envelope",
     )
     _require(
-        browser_resident_payload_gib <= float(profiles["browser"]["memory_gib_per_shard"]),
+        browser_resident_payload_gib
+        <= float(profiles["browser"]["memory_gib_per_shard"]),
         "browser resident artifact chunks exceed its RSS envelope",
     )
 
@@ -552,9 +590,15 @@ def _scenario_report(
             "modeled_throughput_pct": _round(typesense_throughput_pct),
             "write_leader_utilization_pct_per_ha_group": _round(typesense_write_pct),
             "search_replica_utilization_pct": _round(typesense_search_pct),
-            "replicated_write_cpu_cores_per_node": _round(typesense_write_cpu_cores_per_node),
-            "search_cpu_cores_per_surviving_node": _round(typesense_search_cpu_cores_per_node),
-            "working_set_gib_per_replica": _round(typesense_working_set_gib_per_replica),
+            "replicated_write_cpu_cores_per_node": _round(
+                typesense_write_cpu_cores_per_node
+            ),
+            "search_cpu_cores_per_surviving_node": _round(
+                typesense_search_cpu_cores_per_node
+            ),
+            "working_set_gib_per_replica": _round(
+                typesense_working_set_gib_per_replica
+            ),
             "upserts_per_second_per_ha_group": _round(typesense_upserts),
             "search_qps_per_index_shard": _round(typesense_search_qps),
             "provisioned_shards_in_affected_index_shard": typesense_nodes_provisioned,
@@ -614,7 +658,9 @@ def _storage_report(spec: Mapping[str, Any]) -> dict[str, Any]:
     database_payload = int(workload["retained_postings"]) * int(
         workload["database_bytes_per_retained_posting"]
     ) + int(workload["configured_boards"]) * int(workload["database_bytes_per_board"])
-    r2_payload = int(workload["retained_postings"]) * int(workload["description_object_mean_bytes"])
+    r2_payload = int(workload["retained_postings"]) * int(
+        workload["description_object_mean_bytes"]
+    )
     typesense_payload = int(workload["active_postings"]) * int(
         workload["typesense_bytes_per_active_posting"]
     )
@@ -629,11 +675,17 @@ def _storage_report(spec: Mapping[str, Any]) -> dict[str, Any]:
         + int(workload["active_postings"])
         * (
             int(workload["posting_ownership_bytes_per_active_posting"])
-            + int(workload["detail_schedule_and_downstream_cursor_bytes_per_active_posting"])
+            + int(
+                workload[
+                    "detail_schedule_and_downstream_cursor_bytes_per_active_posting"
+                ]
+            )
         )
     )
     control_replicated = control_payload * int(workload["control_metadata_copies"])
-    overload_entries = int(spec["scenarios"]["overload_shard_loss"]["max_total_queue_entries"])
+    overload_entries = int(
+        spec["scenarios"]["overload_shard_loss"]["max_total_queue_entries"]
+    )
     queue_primary = (
         overload_entries
         * int(workload["queue_bytes_per_task"])
@@ -655,7 +707,9 @@ def _storage_report(spec: Mapping[str, Any]) -> dict[str, Any]:
         ),
         "control_metadata_logical_gib": _round(control_payload / GIB),
         "control_metadata_replicated_gib": _round(control_replicated / GIB),
-        "control_metadata_budget_gib": float(budgets["catalog_policy_and_cursor_global_gib"]),
+        "control_metadata_budget_gib": float(
+            budgets["catalog_policy_and_cursor_global_gib"]
+        ),
         "policy_keys_peak_partition": math.ceil(
             int(workload["policy_keys"])
             / int(topology["policy_partitions"])
@@ -668,10 +722,14 @@ def _storage_report(spec: Mapping[str, Any]) -> dict[str, Any]:
         ),
         "queue_primary_peak_gib": _round(queue_primary / GIB),
         "queue_replicated_peak_gib": _round(queue_replicated / GIB),
-        "queue_aof_and_snapshot_budget_tib": float(budgets["queue_aof_and_snapshot_global_tib"]),
+        "queue_aof_and_snapshot_budget_tib": float(
+            budgets["queue_aof_and_snapshot_global_tib"]
+        ),
         "backup_copies": int(budgets["backup_copies"]),
         "backup_storage_budget_tib": float(budgets["backup_storage_global_tib"]),
-        "telemetry_active_series_global": int(budgets["telemetry_active_series_global"]),
+        "telemetry_active_series_global": int(
+            budgets["telemetry_active_series_global"]
+        ),
         "telemetry_logs_traces_profiles_gib_per_month": int(
             budgets["telemetry_logs_gib_per_month"]
             + budgets["telemetry_traces_gib_per_month"]
@@ -696,7 +754,9 @@ def _regional_cell_loss_report(
         recovery_cell_service > paired_continuing_arrivals,
         "paired cell cannot absorb a lost cell's continuing arrivals",
     )
-    drain_seconds = frozen_backlog / (recovery_cell_service - paired_continuing_arrivals)
+    drain_seconds = frozen_backlog / (
+        recovery_cell_service - paired_continuing_arrivals
+    )
     oldest_due = restore_seconds + drain_seconds
     steady_tiers = _scenario_report(spec, "steady", classes)["tiers"]
     return {
@@ -709,7 +769,9 @@ def _regional_cell_loss_report(
         "paired_cell_modeled_utilization_pct": {
             "worker_cpu": _round(steady_tiers["worker"]["peak_cpu_pct"] * 2),
             "browser_cpu": _round(steady_tiers["browser"]["peak_cpu_pct"] * 2),
-            "queue_throughput": _round(steady_tiers["queue"]["modeled_throughput_pct"] * 2),
+            "queue_throughput": _round(
+                steady_tiers["queue"]["modeled_throughput_pct"] * 2
+            ),
             "postgres_commit_per_promoted_writer": steady_tiers["postgres"][
                 "modeled_commit_throughput_pct"
             ],
@@ -725,7 +787,9 @@ def _allocate_pool(
 ) -> dict[str, float]:
     denominator = sum(volumes[name] * weights[name] for name in volumes)
     _require(denominator > 0, "cost allocation denominator must be positive")
-    return {name: pool_eur * volumes[name] * weights[name] / denominator for name in volumes}
+    return {
+        name: pool_eur * volumes[name] * weights[name] / denominator for name in volumes
+    }
 
 
 def _cost_report(
@@ -758,7 +822,9 @@ def _cost_report(
             "backup": float(stress["backup_copy_multiplier"]),
             "origin_transfer": float(stress["paid_origin_transfer_eur_per_tib"]),
         }
-        volumes = {name: value * multipliers["volume"] for name, value in volumes.items()}
+        volumes = {
+            name: value * multipliers["volume"] for name, value in volumes.items()
+        }
 
     node_costs = {
         name: float(node["count"]) * float(node["eur_per_month"]) * multipliers["price"]
@@ -786,13 +852,20 @@ def _cost_report(
         / 1_000_000_000
     )
     r2_storage_cost = (
-        r2_storage_gb * float(prices["r2_usd_per_gb_month"]) * exchange * multipliers["price"]
+        r2_storage_gb
+        * float(prices["r2_usd_per_gb_month"])
+        * exchange
+        * multipliers["price"]
     )
     detail_cycles = volumes["detail"]
     r2_writes_millions = (
-        detail_cycles * float(workload["description_change_share_of_detail"]) / 1_000_000
+        detail_cycles
+        * float(workload["description_change_share_of_detail"])
+        / 1_000_000
     )
-    r2_reads_millions = detail_cycles * float(prices["r2_reads_per_detail_cycle"]) / 1_000_000
+    r2_reads_millions = (
+        detail_cycles * float(prices["r2_reads_per_detail_cycle"]) / 1_000_000
+    )
     r2_operation_cost = (
         (
             r2_writes_millions * float(prices["r2_class_a_usd_per_million"])
@@ -854,7 +927,9 @@ def _cost_report(
         for item in classes
     )
     transfer_cost = transfer_bytes / TIB * multipliers["origin_transfer"]
-    miscellaneous_cost = float(prices["monthly_miscellaneous_eur"]) * multipliers["price"]
+    miscellaneous_cost = (
+        float(prices["monthly_miscellaneous_eur"]) * multipliers["price"]
+    )
 
     pools = {
         "queue": node_costs["queue_node"],
@@ -888,7 +963,8 @@ def _cost_report(
     allocate(
         "browser",
         {
-            item.name: item.browser_share * float(workload["browser_session_seconds_mean"])
+            item.name: item.browser_share
+            * float(workload["browser_session_seconds_mean"])
             for item in classes
         },
     )
@@ -917,7 +993,9 @@ def _cost_report(
     }
 
 
-def _overload_cost_report(spec: Mapping[str, Any], classes: Sequence[WorkClass]) -> dict[str, Any]:
+def _overload_cost_report(
+    spec: Mapping[str, Any], classes: Sequence[WorkClass]
+) -> dict[str, Any]:
     multiplier = float(spec["scenarios"]["overload_shard_loss"]["load_multiplier"])
     overloaded = tuple(
         WorkClass(
@@ -948,9 +1026,15 @@ def build_report(spec: Mapping[str, Any]) -> dict[str, Any]:
     overload_report = _scenario_report(spec, "overload_shard_loss", classes)
     loss_matrix: dict[str, Any] = {}
     for tier, values in overload_report["tiers"].items():
-        pct_values = [float(value) for key, value in values.items() if key.endswith("_pct")]
-        provisioned_key = next(key for key in values if key.startswith("provisioned_shards_"))
-        surviving_key = next(key for key in values if key.startswith("surviving_shards_"))
+        pct_values = [
+            float(value) for key, value in values.items() if key.endswith("_pct")
+        ]
+        provisioned_key = next(
+            key for key in values if key.startswith("provisioned_shards_")
+        )
+        surviving_key = next(
+            key for key in values if key.startswith("surviving_shards_")
+        )
         if provisioned_key.endswith("_global"):
             scope = "global"
         elif provisioned_key.endswith("_index_shard"):
@@ -991,7 +1075,9 @@ def build_report(spec: Mapping[str, Any]) -> dict[str, Any]:
         "workload": {
             "configured_boards": int(spec["workload"]["configured_boards"]),
             "active_postings": int(spec["workload"]["active_postings"]),
-            "steady_cycles_per_hour": int(sum(item.cycles_per_hour for item in classes)),
+            "steady_cycles_per_hour": int(
+                sum(item.cycles_per_hour for item in classes)
+            ),
             "overload_cycles_per_hour": int(
                 sum(item.cycles_per_hour for item in classes)
                 * float(spec["scenarios"]["overload_shard_loss"]["load_multiplier"])
@@ -1001,9 +1087,15 @@ def build_report(spec: Mapping[str, Any]) -> dict[str, Any]:
             ),
             "payload_contract": {
                 "max_inline_body_bytes": int(spec["workload"]["max_inline_body_bytes"]),
-                "max_artifact_chunk_bytes": int(spec["workload"]["max_artifact_chunk_bytes"]),
-                "max_http_transfer_bytes": int(spec["workload"]["max_http_transfer_bytes"]),
-                "max_browser_transfer_bytes": int(spec["workload"]["max_browser_transfer_bytes"]),
+                "max_artifact_chunk_bytes": int(
+                    spec["workload"]["max_artifact_chunk_bytes"]
+                ),
+                "max_http_transfer_bytes": int(
+                    spec["workload"]["max_http_transfer_bytes"]
+                ),
+                "max_browser_transfer_bytes": int(
+                    spec["workload"]["max_browser_transfer_bytes"]
+                ),
                 "resident_semantics": spec["workload"]["resident_payload_semantics"],
             },
         },
@@ -1011,7 +1103,8 @@ def build_report(spec: Mapping[str, Any]) -> dict[str, Any]:
             "data_cells": int(spec["topology"]["data_cells"]),
             "typesense_index_shards": int(spec["topology"]["typesense_index_shards"]),
             "typesense_index_shards_per_data_cell": int(
-                spec["topology"]["typesense_index_shards"] // spec["topology"]["data_cells"]
+                spec["topology"]["typesense_index_shards"]
+                // spec["topology"]["data_cells"]
             ),
             "typesense_ha_replica_groups_per_index_shard": int(
                 spec["profiles"]["typesense"]["ha_replica_groups_per_index_shard"]
@@ -1061,24 +1154,36 @@ def check_report(spec: Mapping[str, Any], report: Mapping[str, Any]) -> None:
     _require(len(spec["provenance"]) >= 5, "source provenance is incomplete")
     _require(int(workload["configured_boards"]) >= 10_000_000, "board floor regressed")
     _require(int(workload["active_postings"]) >= 100_000_000, "posting floor regressed")
-    _require(int(workload["monitor_cycles_per_hour"]) >= 1_000_000, "monitor floor regressed")
-    _require(int(workload["detail_cycles_per_hour"]) >= 5_000_000, "detail floor regressed")
+    _require(
+        int(workload["monitor_cycles_per_hour"]) >= 1_000_000, "monitor floor regressed"
+    )
+    _require(
+        int(workload["detail_cycles_per_hour"]) >= 5_000_000, "detail floor regressed"
+    )
     _require(
         float(workload["retry_attempts_per_success_max"]) <= 0.05,
         "request amplification exceeds 1.05x",
     )
-    _require(int(topology["data_cells"]) >= 8, "fewer than eight data cells is global coupling")
+    _require(
+        int(topology["data_cells"]) >= 8,
+        "fewer than eight data cells is global coupling",
+    )
     logical_partitions = int(topology["logical_partitions"])
     _require(
-        logical_partitions >= 8192 and (logical_partitions & (logical_partitions - 1)) == 0,
+        logical_partitions >= 8192
+        and (logical_partitions & (logical_partitions - 1)) == 0,
         "logical partitions must be a power of two at least 8192",
     )
-    total_queue_shards = int(topology["data_cells"]) * int(topology["queue_shards_per_cell"])
+    total_queue_shards = int(topology["data_cells"]) * int(
+        topology["queue_shards_per_cell"]
+    )
     _require(
         logical_partitions % total_queue_shards == 0,
         "logical partitions must divide evenly across queue shards",
     )
-    _require(int(topology["queue_replicas_per_primary"]) >= 2, "queue needs two replicas")
+    _require(
+        int(topology["queue_replicas_per_primary"]) >= 2, "queue needs two replicas"
+    )
     _require(
         int(topology["postgres_sync_standbys_per_writer"]) >= 1,
         "each Postgres writer needs a synchronous standby",
@@ -1102,7 +1207,9 @@ def check_report(spec: Mapping[str, Any], report: Mapping[str, Any]) -> None:
         and int(typesense_profile["nodes_per_ha_replica_group"]) % 2 == 1,
         "Typesense HA replica groups need an odd node count of at least three",
     )
-    _require(int(topology["policy_partitions"]) >= 4096, "policy state is under-partitioned")
+    _require(
+        int(topology["policy_partitions"]) >= 4096, "policy state is under-partitioned"
+    )
     _require(
         int(topology["posting_ownership_partitions"]) >= 8192,
         "canonical posting ownership is under-partitioned",
@@ -1141,7 +1248,8 @@ def check_report(spec: Mapping[str, Any], report: Mapping[str, Any]) -> None:
         "postgres_node": cells
         * int(topology["postgres_writer_shards_per_cell"])
         * (1 + int(topology["postgres_sync_standbys_per_writer"])),
-        "telemetry_collector_node": cells * int(topology["telemetry_collectors_per_cell"]),
+        "telemetry_collector_node": cells
+        * int(topology["telemetry_collectors_per_cell"]),
         "cell_service_node": cells * int(topology["cell_service_shards_per_cell"]),
         "routing_node": cells * int(topology["routing_shards_per_cell"]),
         "typesense_node": int(topology["typesense_index_shards"])
@@ -1151,7 +1259,8 @@ def check_report(spec: Mapping[str, Any], report: Mapping[str, Any]) -> None:
     }
     _require(
         all(
-            int(node_prices[name]["count"]) == count for name, count in expected_node_counts.items()
+            int(node_prices[name]["count"]) == count
+            for name, count in expected_node_counts.items()
         ),
         "priced node counts do not match the declared topology",
     )
@@ -1201,11 +1310,13 @@ def check_report(spec: Mapping[str, Any], report: Mapping[str, Any]) -> None:
                     f"{scenario_name} {tier} RSS exceeds {threshold['max_rss_pct']}%",
                 )
         _require(
-            result["tiers"]["queue"]["modeled_throughput_pct"] <= float(threshold["max_cpu_pct"]),
+            result["tiers"]["queue"]["modeled_throughput_pct"]
+            <= float(threshold["max_cpu_pct"]),
             f"{scenario_name} queue modeled throughput headroom is too small",
         )
         _require(
-            result["tiers"]["browser"]["session_slot_pct"] <= float(threshold["max_cpu_pct"]),
+            result["tiers"]["browser"]["session_slot_pct"]
+            <= float(threshold["max_cpu_pct"]),
             f"{scenario_name} browser session headroom is too small",
         )
         _require(
@@ -1220,7 +1331,8 @@ def check_report(spec: Mapping[str, Any], report: Mapping[str, Any]) -> None:
         )
         for tier in ("load_balancer", "telemetry_backend"):
             _require(
-                result["tiers"][tier]["modeled_throughput_pct"] <= float(threshold["max_cpu_pct"]),
+                result["tiers"][tier]["modeled_throughput_pct"]
+                <= float(threshold["max_cpu_pct"]),
                 f"{scenario_name} {tier} throughput headroom is too small",
             )
     for tier, values in report["topology"]["simultaneous_loss_matrix"].items():
@@ -1232,7 +1344,10 @@ def check_report(spec: Mapping[str, Any], report: Mapping[str, Any]) -> None:
         )
     overload = report["scenarios"]["overload_shard_loss"]
     steady = report["scenarios"]["steady"]
-    for scenario_name, result in (("steady", steady), ("overload_shard_loss", overload)):
+    for scenario_name, result in (
+        ("steady", steady),
+        ("overload_shard_loss", overload),
+    ):
         threshold = scenarios[scenario_name]
         _require(
             result["computed_policy_ready_queue_depth"]
@@ -1240,7 +1355,8 @@ def check_report(spec: Mapping[str, Any], report: Mapping[str, Any]) -> None:
             f"{scenario_name} computed ready queue exceeds its threshold",
         )
         _require(
-            result["computed_total_queue_entries"] <= int(threshold["max_total_queue_entries"]),
+            result["computed_total_queue_entries"]
+            <= int(threshold["max_total_queue_entries"]),
             f"{scenario_name} computed total queue exceeds its threshold",
         )
         _require(
@@ -1250,7 +1366,9 @@ def check_report(spec: Mapping[str, Any], report: Mapping[str, Any]) -> None:
         )
     _require(
         overload["computed_oldest_policy_ready_due_seconds"]
-        <= float(scenarios["overload_shard_loss"]["max_oldest_policy_ready_due_seconds"]),
+        <= float(
+            scenarios["overload_shard_loss"]["max_oldest_policy_ready_due_seconds"]
+        ),
         "2x catch-up cannot meet the frozen RTO",
     )
     _require(
@@ -1266,7 +1384,9 @@ def check_report(spec: Mapping[str, Any], report: Mapping[str, Any]) -> None:
     cell_loss = report["scenarios"]["regional_cell_loss"]
     _require(
         cell_loss["computed_oldest_policy_ready_due_seconds"]
-        <= float(scenarios["regional_cell_loss"]["max_oldest_policy_ready_due_seconds"]),
+        <= float(
+            scenarios["regional_cell_loss"]["max_oldest_policy_ready_due_seconds"]
+        ),
         "regional cell loss exceeds its disaster oldest-due threshold",
     )
     _require(
@@ -1287,17 +1407,20 @@ def check_report(spec: Mapping[str, Any], report: Mapping[str, Any]) -> None:
         "Typesense index exceeds its budget",
     )
     _require(
-        storage["control_metadata_replicated_gib"] <= storage["control_metadata_budget_gib"],
+        storage["control_metadata_replicated_gib"]
+        <= storage["control_metadata_budget_gib"],
         "replicated catalog/policy/cursor metadata exceeds 256 GiB",
     )
     _require(
-        storage["queue_replicated_peak_gib"] <= storage["queue_aof_and_snapshot_budget_tib"] * 1024,
+        storage["queue_replicated_peak_gib"]
+        <= storage["queue_aof_and_snapshot_budget_tib"] * 1024,
         "replicated queue state exceeds its persistence budget",
     )
     steady_cost = report["cost"]["steady"]
     steady_threshold = scenarios["steady"]
     _require(
-        steady_cost["monthly_cost_eur"] <= float(steady_threshold["max_monthly_cost_eur"]),
+        steady_cost["monthly_cost_eur"]
+        <= float(steady_threshold["max_monthly_cost_eur"]),
         "monthly steady cost ceiling exceeded",
     )
     for name in ("board", "detail", "blended"):
@@ -1351,13 +1474,16 @@ def benchmark_routing(spec: Mapping[str, Any], boards: int) -> dict[str, Any]:
     old_cell_weights = [1.0] * int(topology["data_cells"])
     new_cell_weights = [*old_cell_weights, 1.0]
     old_growth_owners = [
-        growth_owner(partition, old_cell_weights) for partition in range(logical_partitions)
+        growth_owner(partition, old_cell_weights)
+        for partition in range(logical_partitions)
     ]
     new_growth_owners = [
-        growth_owner(partition, new_cell_weights) for partition in range(logical_partitions)
+        growth_owner(partition, new_cell_weights)
+        for partition in range(logical_partitions)
     ]
     growth_moved_partitions = sum(
-        old != new for old, new in zip(old_growth_owners, new_growth_owners, strict=True)
+        old != new
+        for old, new in zip(old_growth_owners, new_growth_owners, strict=True)
     )
     _require(
         all(
@@ -1383,8 +1509,12 @@ def benchmark_routing(spec: Mapping[str, Any], boards: int) -> dict[str, Any]:
     provider_thresholds = (64, 102, 133, 159, 184, 210, 235, 256)
     provider_board_weights = [0] * len(provider_names)
     provider_posting_weights = [0] * len(provider_names)
-    provider_board_partitions = [[0] * logical_partitions for _ in range(len(provider_names))]
-    provider_posting_partitions = [[0] * logical_partitions for _ in range(len(provider_names))]
+    provider_board_partitions = [
+        [0] * logical_partitions for _ in range(len(provider_names))
+    ]
+    provider_posting_partitions = [
+        [0] * logical_partitions for _ in range(len(provider_names))
+    ]
     started_wall = time.perf_counter()
     started_cpu = time.process_time()
     for index in range(boards):
@@ -1413,7 +1543,9 @@ def benchmark_routing(spec: Mapping[str, Any], boards: int) -> dict[str, Any]:
     task_rates = [
         board_count / boards * monitor_cycles
         + posting_weight / total_posting_weight * detail_cycles
-        for board_count, posting_weight in zip(board_counts, posting_weights, strict=True)
+        for board_count, posting_weight in zip(
+            board_counts, posting_weights, strict=True
+        )
     ]
     scaled_postings = [
         posting_weight / total_posting_weight * postings_target
@@ -1471,7 +1603,10 @@ def benchmark_routing(spec: Mapping[str, Any], boards: int) -> dict[str, Any]:
     ) + tuple(provider_task_rates[name] / total_shards for name in provider_names)
     dimension_loads = [
         [
-            sum(values[partition] for partition in range(owner, logical_partitions, total_shards))
+            sum(
+                values[partition]
+                for partition in range(owner, logical_partitions, total_shards)
+            )
             for owner in range(total_shards)
         ]
         for values in dimensions
@@ -1490,14 +1625,18 @@ def benchmark_routing(spec: Mapping[str, Any], boards: int) -> dict[str, Any]:
     candidate_slots = range(1, shards_per_cell)
     for partition in failed_partitions:
 
-        def candidate_score(slot: int, owned_partition: int = partition) -> tuple[float, int]:
+        def candidate_score(
+            slot: int, owned_partition: int = partition
+        ) -> tuple[float, int]:
             projected = max(
                 (dimension_loads[index][slot] + dimensions[index][owned_partition])
                 / dimension_targets[index]
                 for index in range(len(dimensions))
             )
             tie_break = -int.from_bytes(
-                hashlib.sha256(f"recovery:v1:{owned_partition}:{slot}".encode()).digest()[:8],
+                hashlib.sha256(
+                    f"recovery:v1:{owned_partition}:{slot}".encode()
+                ).digest()[:8],
                 "big",
             )
             return projected, tie_break
@@ -1527,10 +1666,14 @@ def benchmark_routing(spec: Mapping[str, Any], boards: int) -> dict[str, Any]:
     cpu_seconds = time.process_time() - started_cpu
     _require(sum(board_counts) == boards, "logical partition conservation failed")
     _require(round(sum(primary_boards)) == boards, "primary shard conservation failed")
-    _require(round(sum(recovered_boards)) == boards, "recovery shard conservation failed")
+    _require(
+        round(sum(recovered_boards)) == boards, "recovery shard conservation failed"
+    )
     _require(recovered_boards[failed_slot] == 0, "failed shard retained ownership")
     _require(
-        math.isclose(sum(recovered_tasks), monitor_cycles + detail_cycles, rel_tol=1e-12),
+        math.isclose(
+            sum(recovered_tasks), monitor_cycles + detail_cycles, rel_tol=1e-12
+        ),
         "weighted task-rate conservation failed",
     )
     _require(
@@ -1546,7 +1689,9 @@ def benchmark_routing(spec: Mapping[str, Any], boards: int) -> dict[str, Any]:
     )
     mean_shard_boards = boards / total_shards
     max_recovery_factor = max(recovered_boards) / mean_shard_boards
-    task_factor = max(recovered_tasks) / ((monitor_cycles + detail_cycles) / total_shards)
+    task_factor = max(recovered_tasks) / (
+        (monitor_cycles + detail_cycles) / total_shards
+    )
     posting_factor = max(recovered_postings) / (postings_target / total_shards)
     browser_factor = max(recovered_browser) / (expected_browser_rate / total_shards)
     provider_factors = {
@@ -1582,7 +1727,9 @@ def benchmark_routing(spec: Mapping[str, Any], boards: int) -> dict[str, Any]:
             "telemetry_backend",
         ],
         "spec_sha256": sha256_json(spec),
-        "command": (f"python scripts/capacity_envelope.py --check --benchmark-routing {boards}"),
+        "command": (
+            f"python scripts/capacity_envelope.py --check --benchmark-routing {boards}"
+        ),
         "units": {
             "wall_seconds": "seconds",
             "cpu_seconds": "process CPU seconds",
@@ -1630,13 +1777,17 @@ def benchmark_routing(spec: Mapping[str, Any], boards: int) -> dict[str, Any]:
             "partition_max_boards": max(board_counts),
             "primary_shard_min_boards": round(min(primary_boards)),
             "primary_shard_max_boards": round(max(primary_boards)),
-            "recovered_shard_min_boards_excluding_failed": round(min(recovered_boards[1:])),
+            "recovered_shard_min_boards_excluding_failed": round(
+                min(recovered_boards[1:])
+            ),
             "recovered_shard_max_boards": round(max(recovered_boards)),
             "recovered_max_board_load_factor": _round(max_recovery_factor, 6),
             "recovered_max_task_rate_factor": _round(task_factor, 6),
             "recovered_max_posting_factor": _round(posting_factor, 6),
             "recovered_max_browser_rate_factor": _round(browser_factor, 6),
-            "recovered_max_provider_rate_factor": _round(max(provider_factors.values()), 6),
+            "recovered_max_provider_rate_factor": _round(
+                max(provider_factors.values()), 6
+            ),
             "provider_task_cycles_per_hour": {
                 name: round(value) for name, value in provider_task_rates.items()
             },
@@ -1665,14 +1816,20 @@ def benchmark_routing(spec: Mapping[str, Any], boards: int) -> dict[str, Any]:
 
 def _write_json(path: Path, value: Any) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--spec", type=Path, default=DEFAULT_SPEC)
-    parser.add_argument("--check", action="store_true", help="assert every frozen threshold")
-    parser.add_argument("--json", action="store_true", help="print the analytical report as JSON")
+    parser.add_argument(
+        "--check", action="store_true", help="assert every frozen threshold"
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="print the analytical report as JSON"
+    )
     parser.add_argument("--write-report", type=Path, help="write the analytical report")
     parser.add_argument(
         "--benchmark-routing",
@@ -1680,7 +1837,9 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         metavar="BOARDS",
         help="measure streaming ownership/recovery at the requested board count",
     )
-    parser.add_argument("--write-evidence", type=Path, help="write routing benchmark evidence")
+    parser.add_argument(
+        "--write-evidence", type=Path, help="write routing benchmark evidence"
+    )
     return parser.parse_args(argv)
 
 

--- a/scripts/capacity_envelope.py
+++ b/scripts/capacity_envelope.py
@@ -1,0 +1,1723 @@
+#!/usr/bin/env python3
+"""Reproducible analytical and synthetic capacity evidence for issue #7936.
+
+The analytical model deliberately does not impersonate a Go/Redis/Postgres/
+Lightpanda benchmark. It turns the reviewed envelope into executable
+arithmetic and hard assertions. The routing benchmark separately measures
+the deterministic, streaming ownership/recovery algorithm at the full board
+cardinality without allocating one Python object per board.
+"""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import hashlib
+import json
+import math
+import os
+import platform
+import resource
+import sys
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_SPEC = ROOT / "capacity" / "crawler" / "global-v1.json"
+GIB = 1024**3
+TIB = 1024**4
+
+
+class CapacityError(AssertionError):
+    """The checked-in capacity contract is internally inconsistent."""
+
+
+def canonical_json_bytes(value: Any) -> bytes:
+    """Return the stable byte representation used for evidence digests."""
+
+    return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+
+
+def sha256_json(value: Any) -> str:
+    return hashlib.sha256(canonical_json_bytes(value)).hexdigest()
+
+
+def load_spec(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(value, dict):
+        raise CapacityError("capacity spec must contain a JSON object")
+    return value
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise CapacityError(message)
+
+
+def _pct(numerator: float, denominator: float) -> float:
+    return 100.0 * numerator / denominator
+
+
+def _round(value: float, digits: int = 4) -> float:
+    return round(value, digits)
+
+
+def partition_for_board(board_id: str, logical_partitions: int) -> int:
+    """Map a canonical board ID to one stable logical partition.
+
+    The power-of-two modulo and exact byte order are part of global-v1.
+    Production routing remains manifest driven: this function identifies the
+    partition, while an epoch-fenced owner manifest identifies its cell/shard.
+    """
+
+    digest = hashlib.sha256(f"board:{board_id}".encode()).digest()
+    return int.from_bytes(digest[:8], "big") % logical_partitions
+
+
+def primary_slot(partition: int, total_queue_shards: int) -> int:
+    """Return the balanced v1 manifest slot for a logical partition."""
+
+    return partition % total_queue_shards
+
+
+def recovery_slot(
+    partition: int,
+    *,
+    failed_slot: int,
+    queue_shards_per_cell: int,
+) -> int:
+    """Pick a same-cell recovery shard with deterministic rendezvous hashing."""
+
+    failed_cell = failed_slot // queue_shards_per_cell
+    first_slot = failed_cell * queue_shards_per_cell
+    candidates = range(first_slot, first_slot + queue_shards_per_cell)
+    available = (slot for slot in candidates if slot != failed_slot)
+
+    def score(slot: int) -> int:
+        value = f"recovery:v1:{partition}:{slot}".encode()
+        return int.from_bytes(hashlib.sha256(value).digest()[:8], "big")
+
+    return max(available, key=score)
+
+
+def recovery_partition_counts(spec: Mapping[str, Any], failed_slot: int = 0) -> list[int]:
+    topology = spec["topology"]
+    logical_partitions = int(topology["logical_partitions"])
+    total_shards = int(topology["data_cells"]) * int(topology["queue_shards_per_cell"])
+    counts = [0] * total_shards
+    for partition in range(logical_partitions):
+        owner = primary_slot(partition, total_shards)
+        if owner == failed_slot:
+            owner = recovery_slot(
+                partition,
+                failed_slot=failed_slot,
+                queue_shards_per_cell=int(topology["queue_shards_per_cell"]),
+            )
+        counts[owner] += 1
+    return counts
+
+
+def growth_owner(partition: int, capacity_weights: Sequence[float]) -> int:
+    """Return a deterministic capacity-weighted rendezvous owner for a manifest."""
+
+    _require(bool(capacity_weights), "growth manifest needs at least one cell")
+    _require(all(weight > 0 for weight in capacity_weights), "cell weights must be positive")
+    best: tuple[float, int] | None = None
+    for cell, weight in enumerate(capacity_weights):
+        digest = hashlib.sha256(f"growth:v1:{partition}:{cell}".encode()).digest()
+        uniform = (int.from_bytes(digest[:8], "big") + 1) / (2**64 + 1)
+        score = float(weight) / -math.log(uniform)
+        candidate = (score, -cell)
+        if best is None or candidate > best:
+            best = candidate
+    assert best is not None
+    return -best[1]
+
+
+@dataclass(frozen=True)
+class WorkClass:
+    name: str
+    cycles_per_hour: float
+    browser_share: float
+    worker_cpu_ms: float
+    db_commits: float
+    mean_response_bytes: float
+    proxy_share: float
+
+
+def _work_classes(spec: Mapping[str, Any]) -> tuple[WorkClass, WorkClass]:
+    workload = spec["workload"]
+    browser_bytes = float(workload["browser_transfer_mean_bytes"])
+    monitor_browser_share = float(workload["monitor_browser_share"])
+    detail_browser_share = float(workload["detail_browser_share"])
+    return (
+        WorkClass(
+            name="board",
+            cycles_per_hour=float(workload["monitor_cycles_per_hour"]),
+            browser_share=monitor_browser_share,
+            worker_cpu_ms=float(workload["monitor_worker_cpu_ms"]),
+            db_commits=float(workload["monitor_db_commits_per_cycle"]),
+            proxy_share=float(workload["monitor_proxy_share"]),
+            mean_response_bytes=(
+                (1 - monitor_browser_share) * float(workload["monitor_http_response_mean_bytes"])
+                + monitor_browser_share * browser_bytes
+            ),
+        ),
+        WorkClass(
+            name="detail",
+            cycles_per_hour=float(workload["detail_cycles_per_hour"]),
+            browser_share=detail_browser_share,
+            worker_cpu_ms=float(workload["detail_worker_cpu_ms"]),
+            db_commits=float(workload["detail_db_commits_per_cycle"]),
+            proxy_share=float(workload["detail_proxy_share"]),
+            mean_response_bytes=(
+                (1 - detail_browser_share) * float(workload["detail_http_response_mean_bytes"])
+                + detail_browser_share * browser_bytes
+            ),
+        ),
+    )
+
+
+def _weighted(classes: Sequence[WorkClass], field: str) -> float:
+    total = sum(item.cycles_per_hour for item in classes)
+    return sum(item.cycles_per_hour * float(getattr(item, field)) for item in classes) / total
+
+
+def _surviving_shards(scenario: Mapping[str, Any], tier: str, provisioned: int) -> tuple[int, int]:
+    lost = int(scenario.get("failed_shards_by_tier", {}).get(tier, 0))
+    _require(lost >= 0, f"{tier} lost-shard count cannot be negative")
+    _require(lost < provisioned, f"{tier} has no surviving shard")
+    return provisioned - lost, lost
+
+
+def _scenario_report(
+    spec: Mapping[str, Any], name: str, classes: Sequence[WorkClass]
+) -> dict[str, Any]:
+    scenario = spec["scenarios"][name]
+    topology = spec["topology"]
+    profiles = spec["profiles"]
+    workload = spec["workload"]
+    cells = int(topology["data_cells"])
+    queue_per_cell = int(topology["queue_shards_per_cell"])
+    queue_shards = cells * queue_per_cell
+    has_failure = bool(scenario.get("failed_shards_by_tier", {}))
+    processing_rate = float(scenario["required_processing_cycles_per_second"])
+    attempt_multiplier = 1 + float(workload["retry_attempts_per_success_max"])
+    attempted_processing_rate = processing_rate * attempt_multiplier
+    queue_shards_available, failed_queue_shards = _surviving_shards(
+        scenario, "queue", queue_per_cell
+    )
+    recovery_factor = (
+        float(topology["failed_board_recovery_max_load_factor"]) if failed_queue_shards else 1.0
+    )
+
+    weighted_worker_ms = _weighted(classes, "worker_cpu_ms")
+    weighted_browser_share = _weighted(classes, "browser_share")
+    weighted_commits = _weighted(classes, "db_commits")
+    weighted_bytes = _weighted(classes, "mean_response_bytes")
+    browser_orchestration_ms = float(workload["browser_orchestration_cpu_ms"])
+
+    queue_rate_per_peak_shard = attempted_processing_rate / queue_shards * recovery_factor
+    queue_cpu_cores = (
+        queue_rate_per_peak_shard
+        * float(workload["queue_operations_per_cycle"])
+        * float(workload["queue_cpu_us_per_operation"])
+        / 1_000_000
+    )
+    queue_cpu_pct = _pct(queue_cpu_cores, float(profiles["queue"]["cpu_cores_per_primary"]))
+    queue_entries_per_peak_shard = (
+        float(scenario["max_total_queue_entries"]) / queue_shards * recovery_factor
+    )
+    queue_rss_gib = float(profiles["queue"]["baseline_rss_gib"]) + (
+        queue_entries_per_peak_shard
+        * float(workload["queue_bytes_per_task"])
+        * float(workload["queue_allocator_multiplier"])
+        / GIB
+    )
+    queue_rss_pct = _pct(queue_rss_gib, float(profiles["queue"]["memory_gib_per_node"]))
+    queue_capacity_pct = _pct(
+        queue_rate_per_peak_shard,
+        float(profiles["queue"]["modeled_cycles_per_second_per_primary"]),
+    )
+
+    worker_cpu_seconds_per_cycle = (
+        weighted_worker_ms + weighted_browser_share * browser_orchestration_ms
+    ) / 1000
+    worker_cpu_cores_per_cell = attempted_processing_rate / cells * worker_cpu_seconds_per_cycle
+    worker_shards_provisioned = int(topology["worker_shards_per_cell"])
+    worker_shards_available, failed_worker_shards = _surviving_shards(
+        scenario, "worker", worker_shards_provisioned
+    )
+    worker_cpu_pct = _pct(
+        worker_cpu_cores_per_cell,
+        worker_shards_available * float(profiles["worker"]["cpu_cores_per_shard"]),
+    )
+    worker_rss_key = (
+        "overload_rss_gib_per_shard_max" if has_failure else "steady_rss_gib_per_shard_max"
+    )
+    worker_rss_pct = _pct(
+        float(profiles["worker"][worker_rss_key]),
+        float(profiles["worker"]["memory_gib_per_shard"]),
+    )
+
+    browser_sessions_global = (
+        attempted_processing_rate
+        * weighted_browser_share
+        * float(workload["browser_session_seconds_mean"])
+    )
+    browser_shards_provisioned = int(topology["browser_shards_per_cell"])
+    browser_shards_available, failed_browser_shards = _surviving_shards(
+        scenario, "browser", browser_shards_provisioned
+    )
+    browser_sessions_per_survivor = browser_sessions_global / cells / browser_shards_available
+    browser_slot_pct = _pct(
+        browser_sessions_per_survivor,
+        float(profiles["browser"]["session_slots_per_shard"]),
+    )
+    browser_cpu_cores_per_cell = (
+        attempted_processing_rate
+        / cells
+        * weighted_browser_share
+        * float(workload["browser_cpu_ms"])
+        / 1000
+    )
+    browser_cpu_pct = _pct(
+        browser_cpu_cores_per_cell,
+        browser_shards_available * float(profiles["browser"]["cpu_cores_per_shard"]),
+    )
+    browser_rss_gib = float(profiles["browser"]["baseline_rss_gib"]) + (
+        browser_sessions_per_survivor * float(profiles["browser"]["rss_mib_per_session"]) / 1024
+    )
+    browser_rss_pct = _pct(browser_rss_gib, float(profiles["browser"]["memory_gib_per_shard"]))
+
+    postgres_writer_shards_provisioned = int(topology["postgres_writer_shards_per_cell"])
+    postgres_writer_shards, failed_postgres_shards = _surviving_shards(
+        scenario, "postgres", postgres_writer_shards_provisioned
+    )
+    retry_commits_per_second = (attempted_processing_rate - processing_rate) * float(
+        workload["retry_db_commits_per_failed_attempt"]
+    )
+    db_commits_per_second = (
+        (processing_rate * weighted_commits + retry_commits_per_second)
+        / cells
+        / postgres_writer_shards
+    )
+    db_transaction_pct = _pct(
+        db_commits_per_second,
+        float(profiles["postgres"]["modeled_commits_per_second_per_writer"]),
+    )
+    db_cpu_pct = _pct(
+        db_commits_per_second * float(workload["db_cpu_ms_per_commit"]) / 1000,
+        float(profiles["postgres"]["cpu_cores_per_writer"]),
+    )
+    db_rss_key = (
+        "overload_rss_gib_per_writer_max" if has_failure else "steady_rss_gib_per_writer_max"
+    )
+    db_rss_pct = _pct(
+        float(profiles["postgres"][db_rss_key]),
+        float(profiles["postgres"]["memory_gib_per_writer"]),
+    )
+
+    telemetry = profiles["telemetry"]
+    telemetry_provisioned = int(topology["telemetry_collectors_per_cell"])
+    telemetry_available, failed_telemetry_shards = _surviving_shards(
+        scenario, "telemetry", telemetry_provisioned
+    )
+    telemetry_mode = "overload" if has_failure else "steady"
+    telemetry_cpu_pct = _pct(
+        float(telemetry[f"{telemetry_mode}_cpu_cores_per_cell"]),
+        telemetry_available * float(telemetry["cpu_cores_per_collector"]),
+    )
+    telemetry_rss_pct = _pct(
+        float(telemetry[f"{telemetry_mode}_working_set_gib_per_cell"]),
+        telemetry_available * float(telemetry["memory_gib_per_collector"]),
+    )
+
+    typesense = profiles["typesense"]
+    typesense_index_shards = int(topology["typesense_index_shards"])
+    typesense_ha_groups = int(typesense["ha_replica_groups_per_index_shard"])
+    typesense_nodes_per_ha_group = int(typesense["nodes_per_ha_replica_group"])
+    typesense_nodes_provisioned = typesense_ha_groups * typesense_nodes_per_ha_group
+    typesense_nodes, failed_typesense_nodes = _surviving_shards(
+        scenario, "typesense", typesense_nodes_provisioned
+    )
+    typesense_upserts = (
+        processing_rate
+        / typesense_index_shards
+        * float(workload["typesense_upserts_per_successful_cycle"])
+    )
+    # Every user search fans out to every independent index shard, so every
+    # shard receives the full global query rate. Sharding distributes writes
+    # and data, but it does not divide search work.
+    typesense_search_qps = float(workload["typesense_search_qps_global"])
+    # Each node contains the full index-shard replica. Writes are serialized by
+    # the leader and applied by every replica; only reads spread across nodes.
+    # Therefore the hottest surviving node carries all writes plus its read share.
+    typesense_write_cpu_cores_per_node = (
+        typesense_upserts * float(workload["typesense_upsert_cpu_ms"]) / 1000
+    )
+    typesense_search_cpu_cores_per_node = (
+        typesense_search_qps / typesense_nodes * float(workload["typesense_search_cpu_ms"]) / 1000
+    )
+    typesense_cpu_pct = _pct(
+        typesense_write_cpu_cores_per_node + typesense_search_cpu_cores_per_node,
+        float(typesense["cpu_cores_per_node"]),
+    )
+    typesense_write_pct = _pct(
+        typesense_upserts,
+        float(typesense["modeled_upserts_per_second_per_leader"]),
+    )
+    typesense_search_pct = _pct(
+        typesense_search_qps,
+        typesense_nodes * float(typesense["modeled_search_qps_per_node"]),
+    )
+    typesense_throughput_pct = max(typesense_write_pct, typesense_search_pct)
+    typesense_working_set_gib_per_replica = (
+        float(typesense["working_set_gib_global"]) / typesense_index_shards
+    )
+    typesense_rss_pct = _pct(
+        typesense_working_set_gib_per_replica,
+        float(typesense["memory_gib_per_node"]),
+    )
+
+    service_mode = "overload" if has_failure else "steady"
+    cell_service = profiles["cell_service"]
+    cell_service_provisioned = int(topology["cell_service_shards_per_cell"])
+    cell_service_available, failed_cell_services = _surviving_shards(
+        scenario, "cell_service", cell_service_provisioned
+    )
+    cell_service_cpu_pct = _pct(
+        float(cell_service[f"{service_mode}_cpu_cores_per_cell"]),
+        cell_service_available * float(cell_service["cpu_cores_per_shard"]),
+    )
+    cell_service_rss_pct = _pct(
+        float(cell_service[f"{service_mode}_working_set_gib_per_cell"]),
+        cell_service_available * float(cell_service["memory_gib_per_shard"]),
+    )
+
+    routing = profiles["routing"]
+    routing_provisioned = int(topology["routing_shards_per_cell"])
+    routing_available, failed_routing_shards = _surviving_shards(
+        scenario, "routing", routing_provisioned
+    )
+    routing_cpu_pct = _pct(
+        float(routing[f"{service_mode}_cpu_cores_per_cell"]),
+        routing_available * float(routing["cpu_cores_per_shard"]),
+    )
+    routing_rss_pct = _pct(
+        float(routing[f"{service_mode}_working_set_gib_per_cell"]),
+        routing_available * float(routing["memory_gib_per_shard"]),
+    )
+
+    load_balancers_provisioned = int(topology["load_balancers_per_cell"])
+    load_balancers_available, failed_load_balancers = _surviving_shards(
+        scenario, "load_balancer", load_balancers_provisioned
+    )
+    load_balancer_throughput_pct = _pct(
+        attempted_processing_rate / cells,
+        load_balancers_available
+        * float(profiles["load_balancer"]["modeled_requests_per_second_per_instance"]),
+    )
+
+    telemetry_backends_provisioned = int(topology["telemetry_backends"])
+    telemetry_backends_available, failed_telemetry_backends = _surviving_shards(
+        scenario, "telemetry_backend", telemetry_backends_provisioned
+    )
+    active_series = int(spec["storage_budgets"]["telemetry_active_series_global"])
+    critical_series = int(topology["critical_telemetry_series_dual_written"])
+    series_to_survivor = (
+        active_series
+        if failed_telemetry_backends
+        else (active_series + critical_series) / telemetry_backends_available
+    )
+    telemetry_backend_series_pct = _pct(
+        series_to_survivor,
+        float(profiles["telemetry_backend"]["modeled_active_series_per_backend"]),
+    )
+    monthly_signal_gib = sum(
+        int(spec["storage_budgets"][field])
+        for field in (
+            "telemetry_logs_gib_per_month",
+            "telemetry_traces_gib_per_month",
+            "telemetry_profiles_gib_per_month",
+        )
+    )
+    critical_signal_gib = int(spec["storage_budgets"]["critical_telemetry_signal_gib_dual_written"])
+    signal_gib_to_survivor = (
+        monthly_signal_gib
+        if failed_telemetry_backends
+        else (monthly_signal_gib + critical_signal_gib) / telemetry_backends_available
+    )
+    telemetry_backend_signal_pct = _pct(
+        signal_gib_to_survivor,
+        float(profiles["telemetry_backend"]["modeled_signal_gib_per_month_per_backend"]),
+    )
+
+    network_gbps = (
+        processing_rate
+        * weighted_bytes
+        * (1 + float(workload["retry_attempts_per_success_max"]))
+        * 8
+        / 1_000_000_000
+    )
+    arrival_cycles_per_hour = sum(item.cycles_per_hour for item in classes) * float(
+        scenario["load_multiplier"]
+    )
+    arrival_cycles_per_second = arrival_cycles_per_hour / 3600
+    due_backlog = arrival_cycles_per_second * float(scenario["due_burst_seconds"])
+    catch_up_service = float(scenario["catch_up_service_cycles_per_second"])
+    _require(
+        catch_up_service > arrival_cycles_per_second,
+        f"{name} catch-up service must exceed continuing arrivals",
+    )
+    backlog_drain_seconds = due_backlog / (catch_up_service - arrival_cycles_per_second)
+    recovery_seconds = (
+        sum(float(value) for value in topology["recovery_phases_seconds"].values())
+        if failed_queue_shards
+        else 0.0
+    )
+    oldest_due_seconds = recovery_seconds + backlog_drain_seconds
+    computed_total_queue_entries = int(workload["configured_boards"] + due_backlog)
+    worker_resident_payload_gib = (
+        int(profiles["worker"]["concurrent_resident_payloads_per_shard_max"])
+        * int(workload["max_artifact_chunk_bytes"])
+        / GIB
+    )
+    browser_resident_payload_gib = (
+        int(profiles["browser"]["concurrent_resident_artifact_chunks_per_shard_max"])
+        * int(workload["max_artifact_chunk_bytes"])
+        / GIB
+    )
+    _require(
+        worker_resident_payload_gib <= float(profiles["worker"][worker_rss_key]),
+        "worker resident artifact chunks exceed its RSS envelope",
+    )
+    _require(
+        browser_resident_payload_gib <= float(profiles["browser"]["memory_gib_per_shard"]),
+        "browser resident artifact chunks exceed its RSS envelope",
+    )
+
+    tiers = {
+        "queue": {
+            "peak_cpu_pct": _round(queue_cpu_pct),
+            "peak_rss_pct": _round(queue_rss_pct),
+            "modeled_throughput_pct": _round(queue_capacity_pct),
+            "cycles_per_second_peak_survivor": _round(queue_rate_per_peak_shard),
+            "entries_peak_survivor": math.ceil(queue_entries_per_peak_shard),
+            "provisioned_shards_in_affected_cell": queue_per_cell,
+            "lost_shards": failed_queue_shards,
+            "surviving_shards_in_affected_cell": queue_shards_available,
+        },
+        "worker": {
+            "peak_cpu_pct": _round(worker_cpu_pct),
+            "peak_rss_pct": _round(worker_rss_pct),
+            "resident_artifact_chunk_gib_max": _round(worker_resident_payload_gib),
+            "provisioned_shards_in_affected_cell": worker_shards_provisioned,
+            "lost_shards": failed_worker_shards,
+            "surviving_shards_in_affected_cell": worker_shards_available,
+        },
+        "browser": {
+            "peak_cpu_pct": _round(browser_cpu_pct),
+            "peak_rss_pct": _round(browser_rss_pct),
+            "session_slot_pct": _round(browser_slot_pct),
+            "sessions_global": _round(browser_sessions_global),
+            "sessions_peak_survivor": _round(browser_sessions_per_survivor),
+            "resident_artifact_chunk_gib_max": _round(browser_resident_payload_gib),
+            "provisioned_shards_in_affected_cell": browser_shards_provisioned,
+            "lost_shards": failed_browser_shards,
+            "surviving_shards_in_affected_cell": browser_shards_available,
+        },
+        "postgres": {
+            "peak_cpu_pct": _round(db_cpu_pct),
+            "peak_rss_pct": _round(db_rss_pct),
+            "modeled_commit_throughput_pct": _round(db_transaction_pct),
+            "commits_per_second_per_writer": _round(db_commits_per_second),
+            "provisioned_shards_in_affected_cell": postgres_writer_shards_provisioned,
+            "lost_shards": failed_postgres_shards,
+            "surviving_shards_in_affected_cell": postgres_writer_shards,
+        },
+        "telemetry": {
+            "peak_cpu_pct": _round(telemetry_cpu_pct),
+            "peak_rss_pct": _round(telemetry_rss_pct),
+            "provisioned_shards_in_affected_cell": telemetry_provisioned,
+            "lost_shards": failed_telemetry_shards,
+            "surviving_shards_in_affected_cell": telemetry_available,
+        },
+        "typesense": {
+            "peak_cpu_pct": _round(typesense_cpu_pct),
+            "peak_rss_pct": _round(typesense_rss_pct),
+            "modeled_throughput_pct": _round(typesense_throughput_pct),
+            "write_leader_utilization_pct_per_ha_group": _round(typesense_write_pct),
+            "search_replica_utilization_pct": _round(typesense_search_pct),
+            "replicated_write_cpu_cores_per_node": _round(typesense_write_cpu_cores_per_node),
+            "search_cpu_cores_per_surviving_node": _round(typesense_search_cpu_cores_per_node),
+            "working_set_gib_per_replica": _round(typesense_working_set_gib_per_replica),
+            "upserts_per_second_per_ha_group": _round(typesense_upserts),
+            "search_qps_per_index_shard": _round(typesense_search_qps),
+            "provisioned_shards_in_affected_index_shard": typesense_nodes_provisioned,
+            "lost_shards": failed_typesense_nodes,
+            "surviving_shards_in_affected_index_shard": typesense_nodes,
+        },
+        "cell_service": {
+            "peak_cpu_pct": _round(cell_service_cpu_pct),
+            "peak_rss_pct": _round(cell_service_rss_pct),
+            "provisioned_shards_in_affected_cell": cell_service_provisioned,
+            "lost_shards": failed_cell_services,
+            "surviving_shards_in_affected_cell": cell_service_available,
+        },
+        "routing": {
+            "peak_cpu_pct": _round(routing_cpu_pct),
+            "peak_rss_pct": _round(routing_rss_pct),
+            "provisioned_shards_in_affected_cell": routing_provisioned,
+            "lost_shards": failed_routing_shards,
+            "surviving_shards_in_affected_cell": routing_available,
+        },
+        "load_balancer": {
+            "modeled_throughput_pct": _round(load_balancer_throughput_pct),
+            "provisioned_shards_in_affected_cell": load_balancers_provisioned,
+            "lost_shards": failed_load_balancers,
+            "surviving_shards_in_affected_cell": load_balancers_available,
+        },
+        "telemetry_backend": {
+            "modeled_throughput_pct": _round(
+                max(telemetry_backend_series_pct, telemetry_backend_signal_pct)
+            ),
+            "modeled_series_throughput_pct": _round(telemetry_backend_series_pct),
+            "modeled_signal_throughput_pct": _round(telemetry_backend_signal_pct),
+            "provisioned_shards_global": telemetry_backends_provisioned,
+            "lost_shards": failed_telemetry_backends,
+            "surviving_shards_global": telemetry_backends_available,
+        },
+    }
+    return {
+        "arrival_cycles_per_hour": int(arrival_cycles_per_hour),
+        "required_processing_cycles_per_second": _round(processing_rate),
+        "attempted_processing_cycles_per_second": _round(attempted_processing_rate),
+        "continuing_arrival_cycles_per_second": _round(arrival_cycles_per_second),
+        "computed_policy_ready_queue_depth": math.ceil(due_backlog),
+        "computed_total_queue_entries": computed_total_queue_entries,
+        "computed_shard_recovery_seconds": _round(recovery_seconds),
+        "computed_backlog_drain_seconds": _round(backlog_drain_seconds),
+        "computed_oldest_policy_ready_due_seconds": _round(oldest_due_seconds),
+        "network_gbps": _round(network_gbps),
+        "tiers": tiers,
+    }
+
+
+def _storage_report(spec: Mapping[str, Any]) -> dict[str, Any]:
+    workload = spec["workload"]
+    topology = spec["topology"]
+    budgets = spec["storage_budgets"]
+    database_payload = int(workload["retained_postings"]) * int(
+        workload["database_bytes_per_retained_posting"]
+    ) + int(workload["configured_boards"]) * int(workload["database_bytes_per_board"])
+    r2_payload = int(workload["retained_postings"]) * int(workload["description_object_mean_bytes"])
+    typesense_payload = int(workload["active_postings"]) * int(
+        workload["typesense_bytes_per_active_posting"]
+    )
+    typesense_replicated = (
+        typesense_payload
+        * int(spec["profiles"]["typesense"]["ha_replica_groups_per_index_shard"])
+        * int(spec["profiles"]["typesense"]["nodes_per_ha_replica_group"])
+    )
+    control_payload = (
+        int(workload["configured_boards"]) * int(workload["catalog_bytes_per_board"])
+        + int(workload["policy_keys"]) * int(workload["policy_bytes_per_key"])
+        + int(workload["active_postings"])
+        * (
+            int(workload["posting_ownership_bytes_per_active_posting"])
+            + int(workload["detail_schedule_and_downstream_cursor_bytes_per_active_posting"])
+        )
+    )
+    control_replicated = control_payload * int(workload["control_metadata_copies"])
+    overload_entries = int(spec["scenarios"]["overload_shard_loss"]["max_total_queue_entries"])
+    queue_primary = (
+        overload_entries
+        * int(workload["queue_bytes_per_task"])
+        * float(workload["queue_allocator_multiplier"])
+    )
+    queue_replicated = queue_primary * (1 + int(topology["queue_replicas_per_primary"]))
+    return {
+        "database_payload_tib": _round(database_payload / TIB),
+        "database_primary_budget_tib": float(budgets["database_primary_global_tib"]),
+        "database_wal_and_scratch_budget_tib": float(
+            budgets["database_wal_and_scratch_global_tib"]
+        ),
+        "r2_description_payload_tib": _round(r2_payload / TIB),
+        "r2_description_budget_tib": float(budgets["r2_description_global_tib"]),
+        "typesense_index_payload_tib": _round(typesense_payload / TIB),
+        "typesense_index_replicated_tib": _round(typesense_replicated / TIB),
+        "typesense_index_replicated_budget_tib": float(
+            budgets["typesense_index_replicated_global_tib"]
+        ),
+        "control_metadata_logical_gib": _round(control_payload / GIB),
+        "control_metadata_replicated_gib": _round(control_replicated / GIB),
+        "control_metadata_budget_gib": float(budgets["catalog_policy_and_cursor_global_gib"]),
+        "policy_keys_peak_partition": math.ceil(
+            int(workload["policy_keys"])
+            / int(topology["policy_partitions"])
+            * float(topology["failed_board_recovery_max_load_factor"])
+        ),
+        "active_postings_peak_ownership_partition": math.ceil(
+            int(workload["active_postings"])
+            / int(topology["posting_ownership_partitions"])
+            * float(topology["failed_board_recovery_max_load_factor"])
+        ),
+        "queue_primary_peak_gib": _round(queue_primary / GIB),
+        "queue_replicated_peak_gib": _round(queue_replicated / GIB),
+        "queue_aof_and_snapshot_budget_tib": float(budgets["queue_aof_and_snapshot_global_tib"]),
+        "backup_copies": int(budgets["backup_copies"]),
+        "backup_storage_budget_tib": float(budgets["backup_storage_global_tib"]),
+        "telemetry_active_series_global": int(budgets["telemetry_active_series_global"]),
+        "telemetry_logs_traces_profiles_gib_per_month": int(
+            budgets["telemetry_logs_gib_per_month"]
+            + budgets["telemetry_traces_gib_per_month"]
+            + budgets["telemetry_profiles_gib_per_month"]
+        ),
+    }
+
+
+def _regional_cell_loss_report(
+    spec: Mapping[str, Any], classes: Sequence[WorkClass]
+) -> dict[str, Any]:
+    scenario = spec["scenarios"]["regional_cell_loss"]
+    steady = spec["scenarios"]["steady"]
+    cells = int(spec["topology"]["data_cells"])
+    global_arrival = sum(item.cycles_per_hour for item in classes) / 3600
+    cell_arrival = global_arrival / cells
+    restore_seconds = float(scenario["max_freeze_and_restore_seconds"])
+    frozen_backlog = cell_arrival * restore_seconds
+    recovery_cell_service = float(steady["catch_up_service_cycles_per_second"]) / cells
+    paired_continuing_arrivals = cell_arrival * 2
+    _require(
+        recovery_cell_service > paired_continuing_arrivals,
+        "paired cell cannot absorb a lost cell's continuing arrivals",
+    )
+    drain_seconds = frozen_backlog / (recovery_cell_service - paired_continuing_arrivals)
+    oldest_due = restore_seconds + drain_seconds
+    steady_tiers = _scenario_report(spec, "steady", classes)["tiers"]
+    return {
+        "failed_cells": int(scenario["failed_cells"]),
+        "frozen_policy_ready_tasks": math.ceil(frozen_backlog),
+        "restore_seconds": _round(restore_seconds),
+        "backlog_drain_seconds": _round(drain_seconds),
+        "computed_oldest_policy_ready_due_seconds": _round(oldest_due),
+        "authoritative_rpo_seconds_max": int(scenario["max_authoritative_rpo_seconds"]),
+        "paired_cell_modeled_utilization_pct": {
+            "worker_cpu": _round(steady_tiers["worker"]["peak_cpu_pct"] * 2),
+            "browser_cpu": _round(steady_tiers["browser"]["peak_cpu_pct"] * 2),
+            "queue_throughput": _round(steady_tiers["queue"]["modeled_throughput_pct"] * 2),
+            "postgres_commit_per_promoted_writer": steady_tiers["postgres"][
+                "modeled_commit_throughput_pct"
+            ],
+            "typesense_cpu": _round(steady_tiers["typesense"]["peak_cpu_pct"] * 2),
+        },
+    }
+
+
+def _allocate_pool(
+    pool_eur: float,
+    volumes: Mapping[str, float],
+    weights: Mapping[str, float],
+) -> dict[str, float]:
+    denominator = sum(volumes[name] * weights[name] for name in volumes)
+    _require(denominator > 0, "cost allocation denominator must be positive")
+    return {name: pool_eur * volumes[name] * weights[name] / denominator for name in volumes}
+
+
+def _cost_report(
+    spec: Mapping[str, Any], classes: Sequence[WorkClass], *, sensitivity: bool = False
+) -> dict[str, Any]:
+    prices = spec["prices"]
+    workload = spec["workload"]
+    topology = spec["topology"]
+    budgets = spec["storage_budgets"]
+    exchange = float(spec["provenance"]["planning_exchange_rate_usd_to_eur"])
+    hours = float(prices["hours_per_month"])
+    volumes = {item.name: item.cycles_per_hour * hours for item in classes}
+    multipliers = {
+        "price": 1.0,
+        "volume": 1.0,
+        "browser": 1.0,
+        "proxy": 1.0,
+        "telemetry": 1.0,
+        "backup": 1.0,
+        "origin_transfer": float(prices["origin_transfer_eur_per_tib"]),
+    }
+    if sensitivity:
+        stress = spec["cost_sensitivity"]
+        multipliers = {
+            "price": float(stress["price_multiplier"]),
+            "volume": float(stress["sustained_volume_multiplier"]),
+            "browser": float(stress["browser_share_multiplier"]),
+            "proxy": float(stress["proxy_cost_multiplier"]),
+            "telemetry": float(stress["telemetry_cost_multiplier"]),
+            "backup": float(stress["backup_copy_multiplier"]),
+            "origin_transfer": float(stress["paid_origin_transfer_eur_per_tib"]),
+        }
+        volumes = {name: value * multipliers["volume"] for name, value in volumes.items()}
+
+    node_costs = {
+        name: float(node["count"]) * float(node["eur_per_month"]) * multipliers["price"]
+        for name, node in prices["nodes"].items()
+    }
+    proxy_cost = (
+        float(prices["proxy_static_ips"])
+        * float(prices["proxy_eur_per_ip_month"])
+        * multipliers["price"]
+        * multipliers["proxy"]
+    )
+    backup_cost = (
+        (
+            float(budgets["backup_storage_global_tib"])
+            * 1024
+            * float(prices["backup_eur_per_gb_month"])
+            + float(prices["backup_operations_eur_per_month"])
+        )
+        * multipliers["price"]
+        * multipliers["backup"]
+    )
+    r2_storage_gb = (
+        int(workload["retained_postings"])
+        * int(workload["description_object_mean_bytes"])
+        / 1_000_000_000
+    )
+    r2_storage_cost = (
+        r2_storage_gb * float(prices["r2_usd_per_gb_month"]) * exchange * multipliers["price"]
+    )
+    detail_cycles = volumes["detail"]
+    r2_writes_millions = (
+        detail_cycles * float(workload["description_change_share_of_detail"]) / 1_000_000
+    )
+    r2_reads_millions = detail_cycles * float(prices["r2_reads_per_detail_cycle"]) / 1_000_000
+    r2_operation_cost = (
+        (
+            r2_writes_millions * float(prices["r2_class_a_usd_per_million"])
+            + r2_reads_millions * float(prices["r2_class_b_usd_per_million"])
+        )
+        * exchange
+        * multipliers["price"]
+    )
+    included_series = int(topology["telemetry_backends"]) * int(
+        prices["metrics_included_series_per_backend"]
+    )
+    ingested_series = int(budgets["telemetry_active_series_global"]) + int(
+        topology["critical_telemetry_series_dual_written"]
+    )
+    billable_series = max(0, ingested_series - included_series)
+    metrics_cost = (
+        billable_series
+        / 1000
+        * float(prices["metrics_usd_per_thousand_series"])
+        * exchange
+        * multipliers["price"]
+    )
+    telemetry_billable_gib = sum(
+        max(
+            0,
+            int(budgets[field]) - int(prices["telemetry_included_gib_per_signal"]),
+        )
+        for field in (
+            "telemetry_logs_gib_per_month",
+            "telemetry_traces_gib_per_month",
+            "telemetry_profiles_gib_per_month",
+        )
+    )
+    telemetry_billable_gib += int(budgets["critical_telemetry_signal_gib_dual_written"])
+    signal_cost = (
+        telemetry_billable_gib
+        * float(prices["telemetry_usd_per_gib"])
+        * exchange
+        * multipliers["price"]
+    )
+    telemetry_cost = (metrics_cost + signal_cost) * multipliers["telemetry"]
+    transfer_mean_bytes = {item.name: item.mean_response_bytes for item in classes}
+    if sensitivity:
+        browser_bytes = float(workload["browser_transfer_mean_bytes"])
+        http_bytes = {
+            "board": float(workload["monitor_http_response_mean_bytes"]),
+            "detail": float(workload["detail_http_response_mean_bytes"]),
+        }
+        transfer_mean_bytes = {
+            item.name: (1 - min(1.0, item.browser_share * multipliers["browser"]))
+            * http_bytes[item.name]
+            + min(1.0, item.browser_share * multipliers["browser"]) * browser_bytes
+            for item in classes
+        }
+    transfer_bytes = sum(
+        volumes[item.name]
+        * transfer_mean_bytes[item.name]
+        * (1 + float(workload["retry_attempts_per_success_max"]))
+        for item in classes
+    )
+    transfer_cost = transfer_bytes / TIB * multipliers["origin_transfer"]
+    miscellaneous_cost = float(prices["monthly_miscellaneous_eur"]) * multipliers["price"]
+
+    pools = {
+        "queue": node_costs["queue_node"],
+        "worker": node_costs["worker_node"],
+        "browser": node_costs["browser_node"] * multipliers["browser"],
+        "postgres": node_costs["postgres_node"],
+        "telemetry": node_costs["telemetry_collector_node"] + telemetry_cost,
+        "cell_services": node_costs["cell_service_node"] + node_costs["load_balancer"],
+        "routing": node_costs["routing_node"],
+        "typesense": node_costs["typesense_node"],
+        "proxy": proxy_cost,
+        "backup": backup_cost,
+        "r2": r2_storage_cost + r2_operation_cost,
+        "origin_transfer": transfer_cost,
+        "miscellaneous": miscellaneous_cost,
+    }
+    allocations = {name: 0.0 for name in volumes}
+
+    def allocate(pool: str, weights: Mapping[str, float]) -> None:
+        for name, value in _allocate_pool(pools[pool], volumes, weights).items():
+            allocations[name] += value
+
+    equal_weights = {item.name: 1.0 for item in classes}
+    allocate("queue", equal_weights)
+    allocate("cell_services", equal_weights)
+    allocate("routing", equal_weights)
+    allocate("telemetry", equal_weights)
+    allocate("proxy", {item.name: item.proxy_share for item in classes})
+    allocate("miscellaneous", equal_weights)
+    allocate("worker", {item.name: item.worker_cpu_ms for item in classes})
+    allocate(
+        "browser",
+        {
+            item.name: item.browser_share * float(workload["browser_session_seconds_mean"])
+            for item in classes
+        },
+    )
+    allocate("postgres", {item.name: item.db_commits for item in classes})
+    allocate("backup", {item.name: item.db_commits for item in classes})
+    allocate("origin_transfer", transfer_mean_bytes)
+    allocations["detail"] += pools["r2"]
+    allocations["detail"] += pools["typesense"]
+
+    total_cost = sum(pools.values())
+    unit = {name: allocations[name] / volumes[name] * 1_000_000 for name in volumes}
+    blended = total_cost / sum(volumes.values()) * 1_000_000
+    return {
+        "mode": "sensitivity" if sensitivity else "steady",
+        "monthly_cycles": {name: int(value) for name, value in volumes.items()},
+        "monthly_cost_eur": _round(total_cost, 2),
+        "pool_costs_eur": {name: _round(value, 2) for name, value in pools.items()},
+        "cost_per_million_eur": {
+            "board": _round(unit["board"], 4),
+            "detail": _round(unit["detail"], 4),
+            "blended": _round(blended, 4),
+        },
+        "origin_transfer_tib_per_month": _round(transfer_bytes / TIB, 2),
+        "r2_class_a_operations_millions": _round(r2_writes_millions, 2),
+        "planning_exchange_rate_usd_to_eur": exchange,
+    }
+
+
+def _overload_cost_report(spec: Mapping[str, Any], classes: Sequence[WorkClass]) -> dict[str, Any]:
+    multiplier = float(spec["scenarios"]["overload_shard_loss"]["load_multiplier"])
+    overloaded = tuple(
+        WorkClass(
+            name=item.name,
+            cycles_per_hour=item.cycles_per_hour * multiplier,
+            browser_share=item.browser_share,
+            worker_cpu_ms=item.worker_cpu_ms,
+            db_commits=item.db_commits,
+            mean_response_bytes=item.mean_response_bytes,
+            proxy_share=item.proxy_share,
+        )
+        for item in classes
+    )
+    report = _cost_report(spec, overloaded)
+    report["mode"] = "overload_shard_loss"
+    return report
+
+
+def build_report(spec: Mapping[str, Any]) -> dict[str, Any]:
+    classes = _work_classes(spec)
+    recovery_counts = recovery_partition_counts(spec)
+    logical_partitions = int(spec["topology"]["logical_partitions"])
+    total_shards = int(spec["topology"]["data_cells"]) * int(
+        spec["topology"]["queue_shards_per_cell"]
+    )
+    partition_factor = max(recovery_counts) / (logical_partitions / total_shards)
+    steady_report = _scenario_report(spec, "steady", classes)
+    overload_report = _scenario_report(spec, "overload_shard_loss", classes)
+    loss_matrix: dict[str, Any] = {}
+    for tier, values in overload_report["tiers"].items():
+        pct_values = [float(value) for key, value in values.items() if key.endswith("_pct")]
+        provisioned_key = next(key for key in values if key.startswith("provisioned_shards_"))
+        surviving_key = next(key for key in values if key.startswith("surviving_shards_"))
+        if provisioned_key.endswith("_global"):
+            scope = "global"
+        elif provisioned_key.endswith("_index_shard"):
+            scope = "affected_index_shard"
+        else:
+            scope = "affected_cell"
+        loss_matrix[tier] = {
+            "scope": scope,
+            "provisioned_shards": int(values[provisioned_key]),
+            "lost_shards": int(values["lost_shards"]),
+            "surviving_shards": int(values[surviving_key]),
+            "max_modeled_capacity_pct_after_loss": _round(max(pct_values)),
+        }
+    return {
+        "schema_version": 1,
+        "revision": spec["revision"],
+        "effective_date": spec["effective_date"],
+        "spec_sha256": sha256_json(spec),
+        "classification": {
+            "analytical": ["workload", "resource_utilization", "storage", "cost"],
+            "measured_elsewhere": [
+                "routing_distribution",
+                "routing_recovery_conservation",
+            ],
+            "future_execution_gate": [
+                "go_runtime",
+                "redis",
+                "postgres",
+                "lightpanda",
+                "typesense",
+                "network",
+                "cell_services",
+                "routing",
+                "load_balancer",
+                "telemetry_backends",
+            ],
+        },
+        "workload": {
+            "configured_boards": int(spec["workload"]["configured_boards"]),
+            "active_postings": int(spec["workload"]["active_postings"]),
+            "steady_cycles_per_hour": int(sum(item.cycles_per_hour for item in classes)),
+            "overload_cycles_per_hour": int(
+                sum(item.cycles_per_hour for item in classes)
+                * float(spec["scenarios"]["overload_shard_loss"]["load_multiplier"])
+            ),
+            "origin_attempts_per_success_max": _round(
+                1 + float(spec["workload"]["retry_attempts_per_success_max"])
+            ),
+            "payload_contract": {
+                "max_inline_body_bytes": int(spec["workload"]["max_inline_body_bytes"]),
+                "max_artifact_chunk_bytes": int(spec["workload"]["max_artifact_chunk_bytes"]),
+                "max_http_transfer_bytes": int(spec["workload"]["max_http_transfer_bytes"]),
+                "max_browser_transfer_bytes": int(spec["workload"]["max_browser_transfer_bytes"]),
+                "resident_semantics": spec["workload"]["resident_payload_semantics"],
+            },
+        },
+        "topology": {
+            "data_cells": int(spec["topology"]["data_cells"]),
+            "typesense_index_shards": int(spec["topology"]["typesense_index_shards"]),
+            "typesense_index_shards_per_data_cell": int(
+                spec["topology"]["typesense_index_shards"] // spec["topology"]["data_cells"]
+            ),
+            "typesense_ha_replica_groups_per_index_shard": int(
+                spec["profiles"]["typesense"]["ha_replica_groups_per_index_shard"]
+            ),
+            "typesense_nodes_per_ha_replica_group": int(
+                spec["profiles"]["typesense"]["nodes_per_ha_replica_group"]
+            ),
+            "typesense_full_replicas_per_index_shard": int(
+                spec["profiles"]["typesense"]["ha_replica_groups_per_index_shard"]
+            )
+            * int(spec["profiles"]["typesense"]["nodes_per_ha_replica_group"]),
+            "logical_partitions": logical_partitions,
+            "queue_shards": total_shards,
+            "unweighted_reference_recovery_partition_counts": recovery_counts,
+            "unweighted_reference_recovery_max_load_factor": _round(partition_factor),
+            "simultaneous_loss_matrix": loss_matrix,
+        },
+        "scenarios": {
+            "steady": steady_report,
+            "overload_shard_loss": overload_report,
+            "regional_cell_loss": _regional_cell_loss_report(spec, classes),
+        },
+        "storage": _storage_report(spec),
+        "cost": {
+            "steady": _cost_report(spec, classes),
+            "overload_shard_loss": _overload_cost_report(spec, classes),
+            "sensitivity": _cost_report(spec, classes, sensitivity=True),
+        },
+        "thresholds": {
+            "steady": spec["scenarios"]["steady"],
+            "overload_shard_loss": spec["scenarios"]["overload_shard_loss"],
+            "regional_cell_loss": spec["scenarios"]["regional_cell_loss"],
+            "retirement_execution_gate": spec["retirement_execution_gate"],
+        },
+    }
+
+
+def check_report(spec: Mapping[str, Any], report: Mapping[str, Any]) -> None:
+    workload = spec["workload"]
+    topology = spec["topology"]
+    scenarios = spec["scenarios"]
+    storage = report["storage"]
+    _require(spec["schema_version"] == 1, "unknown capacity schema version")
+    _require(spec["revision"] == "global-v1", "revision must remain global-v1")
+    _require(bool(spec["effective_date"]), "effective_date is required")
+    _require(bool(spec["provenance"]["prices_as_of"]), "price date is required")
+    _require(len(spec["provenance"]) >= 5, "source provenance is incomplete")
+    _require(int(workload["configured_boards"]) >= 10_000_000, "board floor regressed")
+    _require(int(workload["active_postings"]) >= 100_000_000, "posting floor regressed")
+    _require(int(workload["monitor_cycles_per_hour"]) >= 1_000_000, "monitor floor regressed")
+    _require(int(workload["detail_cycles_per_hour"]) >= 5_000_000, "detail floor regressed")
+    _require(
+        float(workload["retry_attempts_per_success_max"]) <= 0.05,
+        "request amplification exceeds 1.05x",
+    )
+    _require(int(topology["data_cells"]) >= 8, "fewer than eight data cells is global coupling")
+    logical_partitions = int(topology["logical_partitions"])
+    _require(
+        logical_partitions >= 8192 and (logical_partitions & (logical_partitions - 1)) == 0,
+        "logical partitions must be a power of two at least 8192",
+    )
+    total_queue_shards = int(topology["data_cells"]) * int(topology["queue_shards_per_cell"])
+    _require(
+        logical_partitions % total_queue_shards == 0,
+        "logical partitions must divide evenly across queue shards",
+    )
+    _require(int(topology["queue_replicas_per_primary"]) >= 2, "queue needs two replicas")
+    _require(
+        int(topology["postgres_sync_standbys_per_writer"]) >= 1,
+        "each Postgres writer needs a synchronous standby",
+    )
+    _require(int(topology["telemetry_backends"]) >= 2, "telemetry needs two backends")
+    _require(
+        int(topology["typesense_index_shards"]) >= 8,
+        "Typesense must not be a global cluster",
+    )
+    _require(
+        int(topology["typesense_index_shards"]) % int(topology["data_cells"]) == 0,
+        "Typesense index shards must divide evenly across data cells",
+    )
+    typesense_profile = spec["profiles"]["typesense"]
+    _require(
+        int(typesense_profile["ha_replica_groups_per_index_shard"]) >= 1,
+        "Typesense needs at least one HA replica group per index shard",
+    )
+    _require(
+        int(typesense_profile["nodes_per_ha_replica_group"]) >= 3
+        and int(typesense_profile["nodes_per_ha_replica_group"]) % 2 == 1,
+        "Typesense HA replica groups need an odd node count of at least three",
+    )
+    _require(int(topology["policy_partitions"]) >= 4096, "policy state is under-partitioned")
+    _require(
+        int(topology["posting_ownership_partitions"]) >= 8192,
+        "canonical posting ownership is under-partitioned",
+    )
+    _require(
+        int(topology["postgres_writer_shards_per_cell"]) >= 2,
+        "one Postgres writer per cell is still a cell bottleneck",
+    )
+    _require(
+        int(workload["max_inline_body_bytes"]) == 8 * 1024 * 1024,
+        "inline body limit must match the 8 MiB contract ceiling",
+    )
+    _require(
+        int(workload["max_artifact_chunk_bytes"]) == 8 * 1024 * 1024,
+        "artifact chunk limit must match the 8 MiB contract ceiling",
+    )
+    _require(
+        int(workload["max_http_transfer_bytes"]) == 16 * 1024 * 1024
+        and int(workload["max_browser_transfer_bytes"]) == 64 * 1024 * 1024
+        and int(workload["monitor_http_response_max_bytes"])
+        == int(workload["max_http_transfer_bytes"])
+        and int(workload["detail_http_response_max_bytes"])
+        == int(workload["max_http_transfer_bytes"])
+        and int(workload["browser_transfer_max_bytes"])
+        == int(workload["max_browser_transfer_bytes"]),
+        "total transfer maxima must match the cross-stream contract",
+    )
+    node_prices = spec["prices"]["nodes"]
+    cells = int(topology["data_cells"])
+    expected_node_counts = {
+        "queue_node": cells
+        * int(topology["queue_shards_per_cell"])
+        * (1 + int(topology["queue_replicas_per_primary"])),
+        "worker_node": cells * int(topology["worker_shards_per_cell"]),
+        "browser_node": cells * int(topology["browser_shards_per_cell"]),
+        "postgres_node": cells
+        * int(topology["postgres_writer_shards_per_cell"])
+        * (1 + int(topology["postgres_sync_standbys_per_writer"])),
+        "telemetry_collector_node": cells * int(topology["telemetry_collectors_per_cell"]),
+        "cell_service_node": cells * int(topology["cell_service_shards_per_cell"]),
+        "routing_node": cells * int(topology["routing_shards_per_cell"]),
+        "typesense_node": int(topology["typesense_index_shards"])
+        * int(spec["profiles"]["typesense"]["ha_replica_groups_per_index_shard"])
+        * int(spec["profiles"]["typesense"]["nodes_per_ha_replica_group"]),
+        "load_balancer": cells * int(topology["load_balancers_per_cell"]),
+    }
+    _require(
+        all(
+            int(node_prices[name]["count"]) == count for name, count in expected_node_counts.items()
+        ),
+        "priced node counts do not match the declared topology",
+    )
+    _require(
+        float(scenarios["overload_shard_loss"]["load_multiplier"]) == 2.0,
+        "overload must be exactly 2x",
+    )
+    expected_lost_tiers = {
+        "queue",
+        "worker",
+        "browser",
+        "postgres",
+        "telemetry",
+        "telemetry_backend",
+        "typesense",
+        "cell_service",
+        "routing",
+        "load_balancer",
+    }
+    loss_by_tier = scenarios["overload_shard_loss"]["failed_shards_by_tier"]
+    _require(
+        set(loss_by_tier) == expected_lost_tiers
+        and all(int(value) == 1 for value in loss_by_tier.values()),
+        "overload must coincide with one lost shard in every runtime tier",
+    )
+    _require(
+        report["topology"]["unweighted_reference_recovery_max_load_factor"]
+        <= float(topology["failed_partition_recovery_max_load_factor"]),
+        "recovery assignment exceeds its frozen imbalance factor",
+    )
+    for scenario_name in ("steady", "overload_shard_loss"):
+        threshold = scenarios[scenario_name]
+        result = report["scenarios"][scenario_name]
+        _require(
+            result["network_gbps"] <= float(threshold["max_network_gbps"]),
+            f"{scenario_name} network budget exceeded",
+        )
+        for tier, values in result["tiers"].items():
+            if "peak_cpu_pct" in values:
+                _require(
+                    values["peak_cpu_pct"] <= float(threshold["max_cpu_pct"]),
+                    f"{scenario_name} {tier} CPU exceeds {threshold['max_cpu_pct']}%",
+                )
+            if "peak_rss_pct" in values:
+                _require(
+                    values["peak_rss_pct"] <= float(threshold["max_rss_pct"]),
+                    f"{scenario_name} {tier} RSS exceeds {threshold['max_rss_pct']}%",
+                )
+        _require(
+            result["tiers"]["queue"]["modeled_throughput_pct"] <= float(threshold["max_cpu_pct"]),
+            f"{scenario_name} queue modeled throughput headroom is too small",
+        )
+        _require(
+            result["tiers"]["browser"]["session_slot_pct"] <= float(threshold["max_cpu_pct"]),
+            f"{scenario_name} browser session headroom is too small",
+        )
+        _require(
+            result["tiers"]["postgres"]["modeled_commit_throughput_pct"]
+            <= float(threshold["max_cpu_pct"]),
+            f"{scenario_name} Postgres commit headroom is too small",
+        )
+        _require(
+            result["tiers"]["typesense"]["modeled_throughput_pct"]
+            <= float(threshold["max_cpu_pct"]),
+            f"{scenario_name} Typesense throughput headroom is too small",
+        )
+        for tier in ("load_balancer", "telemetry_backend"):
+            _require(
+                result["tiers"][tier]["modeled_throughput_pct"] <= float(threshold["max_cpu_pct"]),
+                f"{scenario_name} {tier} throughput headroom is too small",
+            )
+    for tier, values in report["topology"]["simultaneous_loss_matrix"].items():
+        _require(values["lost_shards"] == 1, f"{tier} loss gate is not one shard")
+        _require(
+            values["max_modeled_capacity_pct_after_loss"]
+            <= float(scenarios["overload_shard_loss"]["max_cpu_pct"]),
+            f"{tier} surviving capacity exceeds 70%",
+        )
+    overload = report["scenarios"]["overload_shard_loss"]
+    steady = report["scenarios"]["steady"]
+    for scenario_name, result in (("steady", steady), ("overload_shard_loss", overload)):
+        threshold = scenarios[scenario_name]
+        _require(
+            result["computed_policy_ready_queue_depth"]
+            <= int(threshold["max_policy_ready_queue_depth"]),
+            f"{scenario_name} computed ready queue exceeds its threshold",
+        )
+        _require(
+            result["computed_total_queue_entries"] <= int(threshold["max_total_queue_entries"]),
+            f"{scenario_name} computed total queue exceeds its threshold",
+        )
+        _require(
+            result["computed_oldest_policy_ready_due_seconds"]
+            <= float(threshold["max_oldest_policy_ready_due_seconds"]),
+            f"{scenario_name} computed oldest-due exceeds its threshold",
+        )
+    _require(
+        overload["computed_oldest_policy_ready_due_seconds"]
+        <= float(scenarios["overload_shard_loss"]["max_oldest_policy_ready_due_seconds"]),
+        "2x catch-up cannot meet the frozen RTO",
+    )
+    _require(
+        overload["computed_shard_recovery_seconds"]
+        <= float(scenarios["overload_shard_loss"]["max_shard_recovery_seconds"]),
+        "computed shard recovery exceeds 600 seconds",
+    )
+    _require(
+        overload["computed_backlog_drain_seconds"]
+        <= float(scenarios["overload_shard_loss"]["max_catch_up_seconds"]),
+        "computed overload backlog drain exceeds catch-up threshold",
+    )
+    cell_loss = report["scenarios"]["regional_cell_loss"]
+    _require(
+        cell_loss["computed_oldest_policy_ready_due_seconds"]
+        <= float(scenarios["regional_cell_loss"]["max_oldest_policy_ready_due_seconds"]),
+        "regional cell loss exceeds its disaster oldest-due threshold",
+    )
+    _require(
+        max(cell_loss["paired_cell_modeled_utilization_pct"].values()) <= 70,
+        "paired recovery cell cannot absorb the lost cell below 70%",
+    )
+    _require(
+        storage["database_payload_tib"] <= storage["database_primary_budget_tib"],
+        "database payload exceeds its primary budget",
+    )
+    _require(
+        storage["r2_description_payload_tib"] <= storage["r2_description_budget_tib"],
+        "R2 descriptions exceed their budget",
+    )
+    _require(
+        storage["typesense_index_replicated_tib"]
+        <= storage["typesense_index_replicated_budget_tib"],
+        "Typesense index exceeds its budget",
+    )
+    _require(
+        storage["control_metadata_replicated_gib"] <= storage["control_metadata_budget_gib"],
+        "replicated catalog/policy/cursor metadata exceeds 256 GiB",
+    )
+    _require(
+        storage["queue_replicated_peak_gib"] <= storage["queue_aof_and_snapshot_budget_tib"] * 1024,
+        "replicated queue state exceeds its persistence budget",
+    )
+    steady_cost = report["cost"]["steady"]
+    steady_threshold = scenarios["steady"]
+    _require(
+        steady_cost["monthly_cost_eur"] <= float(steady_threshold["max_monthly_cost_eur"]),
+        "monthly steady cost ceiling exceeded",
+    )
+    for name in ("board", "detail", "blended"):
+        _require(
+            steady_cost["cost_per_million_eur"][name]
+            <= float(steady_threshold[f"max_{name}_cost_per_million_eur"]),
+            f"steady {name} unit cost ceiling exceeded",
+        )
+    overload_cost = report["cost"]["overload_shard_loss"]
+    overload_threshold = scenarios["overload_shard_loss"]
+    for name in ("board", "detail", "blended"):
+        _require(
+            overload_cost["cost_per_million_eur"][name]
+            <= float(overload_threshold[f"max_{name}_cost_per_million_eur"]),
+            f"overload {name} unit cost ceiling exceeded",
+        )
+    sensitivity = report["cost"]["sensitivity"]
+    sensitivity_threshold = spec["cost_sensitivity"]
+    for name in ("board", "detail", "blended"):
+        _require(
+            sensitivity["cost_per_million_eur"][name]
+            <= float(sensitivity_threshold[f"max_{name}_cost_per_million_eur"]),
+            f"sensitivity {name} unit cost ceiling exceeded",
+        )
+
+
+def _peak_rss_bytes() -> int:
+    value = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    return value if sys.platform == "darwin" else value * 1024
+
+
+def _physical_memory_bytes() -> int | None:
+    try:
+        page_size = int(os.sysconf("SC_PAGE_SIZE"))
+        pages = int(os.sysconf("SC_PHYS_PAGES"))
+    except (OSError, ValueError):
+        return None
+    return page_size * pages
+
+
+def benchmark_routing(spec: Mapping[str, Any], boards: int) -> dict[str, Any]:
+    """Measure weighted full-cardinality routing and prove conservation."""
+
+    _require(boards > 0, "benchmark board count must be positive")
+    topology = spec["topology"]
+    workload = spec["workload"]
+    logical_partitions = int(topology["logical_partitions"])
+    shards_per_cell = int(topology["queue_shards_per_cell"])
+    total_shards = int(topology["data_cells"]) * shards_per_cell
+    failed_slot = 0
+    old_cell_weights = [1.0] * int(topology["data_cells"])
+    new_cell_weights = [*old_cell_weights, 1.0]
+    old_growth_owners = [
+        growth_owner(partition, old_cell_weights) for partition in range(logical_partitions)
+    ]
+    new_growth_owners = [
+        growth_owner(partition, new_cell_weights) for partition in range(logical_partitions)
+    ]
+    growth_moved_partitions = sum(
+        old != new for old, new in zip(old_growth_owners, new_growth_owners, strict=True)
+    )
+    _require(
+        all(
+            old == new or new == len(old_cell_weights)
+            for old, new in zip(old_growth_owners, new_growth_owners, strict=True)
+        ),
+        "growth rendezvous moved a partition between existing cells",
+    )
+    board_counts = [0] * logical_partitions
+    posting_weights = [0] * logical_partitions
+    monitor_browser_counts = [0] * logical_partitions
+    detail_browser_weights = [0] * logical_partitions
+    provider_names = (
+        "workday",
+        "greenhouse",
+        "successfactors",
+        "oracle",
+        "lever",
+        "personio",
+        "custom_api",
+        "long_tail",
+    )
+    provider_thresholds = (64, 102, 133, 159, 184, 210, 235, 256)
+    provider_board_weights = [0] * len(provider_names)
+    provider_posting_weights = [0] * len(provider_names)
+    provider_board_partitions = [[0] * logical_partitions for _ in range(len(provider_names))]
+    provider_posting_partitions = [[0] * logical_partitions for _ in range(len(provider_names))]
+    started_wall = time.perf_counter()
+    started_cpu = time.process_time()
+    for index in range(boards):
+        digest = hashlib.sha256(f"board:synthetic-{index:08d}".encode()).digest()
+        partition = int.from_bytes(digest[:8], "big") % logical_partitions
+        board_counts[partition] += 1
+        posting_roll = int.from_bytes(digest[8:12], "big") % 1000
+        posting_weight = 1000 if posting_roll == 0 else 100 if posting_roll < 10 else 1
+        posting_weights[partition] += posting_weight
+        if digest[12] < round(256 * float(workload["monitor_browser_share"])):
+            monitor_browser_counts[partition] += 1
+        if digest[13] < round(256 * float(workload["detail_browser_share"])):
+            detail_browser_weights[partition] += posting_weight
+        provider_index = bisect.bisect_right(provider_thresholds, digest[14])
+        provider_board_weights[provider_index] += 1
+        provider_posting_weights[provider_index] += posting_weight
+        provider_board_partitions[provider_index][partition] += 1
+        provider_posting_partitions[provider_index][partition] += posting_weight
+
+    monitor_cycles = float(workload["monitor_cycles_per_hour"])
+    detail_cycles = float(workload["detail_cycles_per_hour"])
+    postings_target = float(workload["active_postings"])
+    total_posting_weight = sum(posting_weights)
+    total_monitor_browser = sum(monitor_browser_counts)
+    total_detail_browser = sum(detail_browser_weights)
+    task_rates = [
+        board_count / boards * monitor_cycles
+        + posting_weight / total_posting_weight * detail_cycles
+        for board_count, posting_weight in zip(board_counts, posting_weights, strict=True)
+    ]
+    scaled_postings = [
+        posting_weight / total_posting_weight * postings_target
+        for posting_weight in posting_weights
+    ]
+    browser_rates = [
+        monitor_browser
+        / total_monitor_browser
+        * monitor_cycles
+        * float(workload["monitor_browser_share"])
+        + detail_browser
+        / total_detail_browser
+        * detail_cycles
+        * float(workload["detail_browser_share"])
+        for monitor_browser, detail_browser in zip(
+            monitor_browser_counts, detail_browser_weights, strict=True
+        )
+    ]
+    provider_task_rates = {
+        name: (
+            provider_board_weights[index] / boards * monitor_cycles
+            + provider_posting_weights[index] / total_posting_weight * detail_cycles
+        )
+        for index, name in enumerate(provider_names)
+    }
+    provider_partition_task_rates = [
+        [
+            board_weight / boards * monitor_cycles
+            + posting_weight / total_posting_weight * detail_cycles
+            for board_weight, posting_weight in zip(
+                provider_board_partitions[index],
+                provider_posting_partitions[index],
+                strict=True,
+            )
+        ]
+        for index in range(len(provider_names))
+    ]
+
+    core_dimensions: tuple[Sequence[float], ...] = (
+        board_counts,
+        task_rates,
+        scaled_postings,
+        browser_rates,
+    )
+    dimensions = core_dimensions + tuple(provider_partition_task_rates)
+    dimension_targets = (
+        boards / total_shards,
+        (monitor_cycles + detail_cycles) / total_shards,
+        postings_target / total_shards,
+        (
+            monitor_cycles * float(workload["monitor_browser_share"])
+            + detail_cycles * float(workload["detail_browser_share"])
+        )
+        / total_shards,
+    ) + tuple(provider_task_rates[name] / total_shards for name in provider_names)
+    dimension_loads = [
+        [
+            sum(values[partition] for partition in range(owner, logical_partitions, total_shards))
+            for owner in range(total_shards)
+        ]
+        for values in dimensions
+    ]
+    failed_partitions = list(range(failed_slot, logical_partitions, total_shards))
+    failed_partitions.sort(
+        key=lambda partition: (
+            -max(
+                dimensions[index][partition] / dimension_targets[index]
+                for index in range(len(dimensions))
+            ),
+            partition,
+        )
+    )
+    recovery_owners: dict[int, int] = {}
+    candidate_slots = range(1, shards_per_cell)
+    for partition in failed_partitions:
+
+        def candidate_score(slot: int, owned_partition: int = partition) -> tuple[float, int]:
+            projected = max(
+                (dimension_loads[index][slot] + dimensions[index][owned_partition])
+                / dimension_targets[index]
+                for index in range(len(dimensions))
+            )
+            tie_break = -int.from_bytes(
+                hashlib.sha256(f"recovery:v1:{owned_partition}:{slot}".encode()).digest()[:8],
+                "big",
+            )
+            return projected, tie_break
+
+        owner = min(candidate_slots, key=candidate_score)
+        recovery_owners[partition] = owner
+        for index, values in enumerate(dimensions):
+            dimension_loads[index][owner] += values[partition]
+
+    def aggregate(values: Sequence[float], *, recover: bool) -> list[float]:
+        result = [0.0] * total_shards
+        for partition, value in enumerate(values):
+            owner = primary_slot(partition, total_shards)
+            if recover and owner == failed_slot:
+                owner = recovery_owners[partition]
+            result[owner] += value
+        return result
+
+    primary_boards = aggregate(board_counts, recover=False)
+    recovered_boards = aggregate(board_counts, recover=True)
+    recovered_tasks = aggregate(task_rates, recover=True)
+    recovered_postings = aggregate(scaled_postings, recover=True)
+    recovered_browser = aggregate(browser_rates, recover=True)
+    moved_boards = int(primary_boards[failed_slot])
+    moved_partitions = logical_partitions // total_shards
+    wall_seconds = time.perf_counter() - started_wall
+    cpu_seconds = time.process_time() - started_cpu
+    _require(sum(board_counts) == boards, "logical partition conservation failed")
+    _require(round(sum(primary_boards)) == boards, "primary shard conservation failed")
+    _require(round(sum(recovered_boards)) == boards, "recovery shard conservation failed")
+    _require(recovered_boards[failed_slot] == 0, "failed shard retained ownership")
+    _require(
+        math.isclose(sum(recovered_tasks), monitor_cycles + detail_cycles, rel_tol=1e-12),
+        "weighted task-rate conservation failed",
+    )
+    _require(
+        math.isclose(sum(recovered_postings), postings_target, rel_tol=1e-12),
+        "posting-cardinality conservation failed",
+    )
+    expected_browser_rate = monitor_cycles * float(
+        workload["monitor_browser_share"]
+    ) + detail_cycles * float(workload["detail_browser_share"])
+    _require(
+        math.isclose(sum(recovered_browser), expected_browser_rate, rel_tol=1e-12),
+        "browser-rate conservation failed",
+    )
+    mean_shard_boards = boards / total_shards
+    max_recovery_factor = max(recovered_boards) / mean_shard_boards
+    task_factor = max(recovered_tasks) / ((monitor_cycles + detail_cycles) / total_shards)
+    posting_factor = max(recovered_postings) / (postings_target / total_shards)
+    browser_factor = max(recovered_browser) / (expected_browser_rate / total_shards)
+    provider_factors = {
+        provider_names[index]: max(aggregate(values, recover=True))
+        / (provider_task_rates[provider_names[index]] / total_shards)
+        for index, values in enumerate(provider_partition_task_rates)
+    }
+    recovery_limit = float(topology["failed_board_recovery_max_load_factor"])
+    if boards >= int(workload["configured_boards"]):
+        for label, factor in (
+            ("board", max_recovery_factor),
+            ("task-rate", task_factor),
+            ("posting", posting_factor),
+            ("browser-rate", browser_factor),
+            ("provider-rate", max(provider_factors.values())),
+        ):
+            _require(
+                factor <= recovery_limit,
+                f"measured {label} recovery imbalance {factor:.4f} exceeds {recovery_limit:.4f}",
+            )
+    result: dict[str, Any] = {
+        "schema_version": 1,
+        "classification": "measured_synthetic_weighted_routing_only",
+        "measurement_date": str(spec["effective_date"]),
+        "base_commit": str(spec["base_commit"]),
+        "explicitly_not_measured": [
+            "go_runtime",
+            "redis",
+            "postgres",
+            "lightpanda",
+            "origin_network",
+            "typesense",
+            "telemetry_backend",
+        ],
+        "spec_sha256": sha256_json(spec),
+        "command": (f"python scripts/capacity_envelope.py --check --benchmark-routing {boards}"),
+        "units": {
+            "wall_seconds": "seconds",
+            "cpu_seconds": "process CPU seconds",
+            "peak_rss_bytes": "bytes",
+            "throughput": "weighted board routing decisions per wall-clock second",
+            "task_rate": "successful cycles per hour",
+        },
+        "input": {
+            "boards": boards,
+            "active_postings": int(postings_target),
+            "monitor_cycles_per_hour": int(monitor_cycles),
+            "detail_cycles_per_hour": int(detail_cycles),
+            "logical_partitions": logical_partitions,
+            "queue_shards": total_shards,
+            "failed_slot": failed_slot,
+            "weighting": {
+                "postings": (
+                    "deterministic heavy tail: 0.1% weight 1000, "
+                    "next 0.9% weight 100, remainder weight 1"
+                ),
+                "browser": "deterministic per-class shares from the capacity spec",
+                "providers": "25/15/12/10/10/10/10/8 percent synthetic family mix",
+            },
+        },
+        "conservation": {
+            "input_boards": boards,
+            "primary_boards": round(sum(primary_boards)),
+            "recovered_boards": round(sum(recovered_boards)),
+            "lost_boards": boards - round(sum(recovered_boards)),
+            "duplicate_boards": 0,
+            "recovered_active_postings": round(sum(recovered_postings)),
+            "recovered_cycles_per_hour": round(sum(recovered_tasks)),
+            "moved_boards": moved_boards,
+            "moved_partitions": moved_partitions,
+            "unaffected_partitions_moved": 0,
+            "growth_input_partitions": logical_partitions,
+            "growth_output_partitions": len(new_growth_owners),
+            "growth_lost_partitions": 0,
+            "growth_duplicate_partitions": 0,
+            "growth_moved_partitions": growth_moved_partitions,
+            "growth_existing_to_existing_moves": 0,
+        },
+        "distribution": {
+            "partition_min_boards": min(board_counts),
+            "partition_max_boards": max(board_counts),
+            "primary_shard_min_boards": round(min(primary_boards)),
+            "primary_shard_max_boards": round(max(primary_boards)),
+            "recovered_shard_min_boards_excluding_failed": round(min(recovered_boards[1:])),
+            "recovered_shard_max_boards": round(max(recovered_boards)),
+            "recovered_max_board_load_factor": _round(max_recovery_factor, 6),
+            "recovered_max_task_rate_factor": _round(task_factor, 6),
+            "recovered_max_posting_factor": _round(posting_factor, 6),
+            "recovered_max_browser_rate_factor": _round(browser_factor, 6),
+            "recovered_max_provider_rate_factor": _round(max(provider_factors.values()), 6),
+            "provider_task_cycles_per_hour": {
+                name: round(value) for name, value in provider_task_rates.items()
+            },
+            "growth_new_cell_partition_share": _round(
+                growth_moved_partitions / logical_partitions, 6
+            ),
+        },
+        "measurement": {
+            "wall_seconds": _round(wall_seconds, 6),
+            "cpu_seconds": _round(cpu_seconds, 6),
+            "peak_rss_bytes": _peak_rss_bytes(),
+            "boards_per_wall_second": _round(boards / wall_seconds, 2),
+        },
+        "environment": {
+            "python": platform.python_version(),
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "processor": platform.processor(),
+            "logical_cpus": os.cpu_count(),
+            "physical_memory_bytes": _physical_memory_bytes(),
+        },
+    }
+    result["evidence_sha256"] = sha256_json(result)
+    return result
+
+
+def _write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--spec", type=Path, default=DEFAULT_SPEC)
+    parser.add_argument("--check", action="store_true", help="assert every frozen threshold")
+    parser.add_argument("--json", action="store_true", help="print the analytical report as JSON")
+    parser.add_argument("--write-report", type=Path, help="write the analytical report")
+    parser.add_argument(
+        "--benchmark-routing",
+        type=int,
+        metavar="BOARDS",
+        help="measure streaming ownership/recovery at the requested board count",
+    )
+    parser.add_argument("--write-evidence", type=Path, help="write routing benchmark evidence")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    spec = load_spec(args.spec)
+    report = build_report(spec)
+    if args.check:
+        check_report(spec, report)
+    if args.write_report:
+        _write_json(args.write_report, report)
+    evidence = None
+    if args.benchmark_routing is not None:
+        evidence = benchmark_routing(spec, args.benchmark_routing)
+        if args.write_evidence:
+            _write_json(args.write_evidence, evidence)
+    elif args.write_evidence:
+        raise CapacityError("--write-evidence requires --benchmark-routing")
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        status = "checked" if args.check else "modelled"
+        cost = report["cost"]["steady"]["cost_per_million_eur"]
+        print(
+            f"capacity {status}: spec_sha256={report['spec_sha256']} "
+            f"cost_eur_per_million={cost['blended']:.4f}"
+        )
+        if evidence:
+            measured = evidence["measurement"]
+            print(
+                f"routing measured: boards={evidence['input']['boards']} "
+                f"wall_seconds={measured['wall_seconds']:.6f} "
+                f"peak_rss_bytes={measured['peak_rss_bytes']} "
+                f"evidence_sha256={evidence['evidence_sha256']}"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/test_capacity_envelope.py
+++ b/scripts/test_capacity_envelope.py
@@ -30,7 +30,9 @@ class CapacityEnvelopeTest(unittest.TestCase):
     def test_checked_in_report_is_reproducible(self) -> None:
         self.assertEqual(json.loads(REPORT.read_text(encoding="utf-8")), self.report)
         self.assertEqual(self.report["spec_sha256"], capacity.sha256_json(self.spec))
-        with self.assertRaisesRegex(capacity.CapacityError, "monthly steady cost ceiling exceeded"):
+        with self.assertRaisesRegex(
+            capacity.CapacityError, "monthly steady cost ceiling exceeded"
+        ):
             capacity.check_report(self.spec, self.report)
 
     def test_epic_floor_and_simultaneous_failure_are_frozen(self) -> None:
@@ -66,21 +68,34 @@ class CapacityEnvelopeTest(unittest.TestCase):
             scenario = self.report["scenarios"][name]
             for values in scenario["tiers"].values():
                 if "peak_cpu_pct" in values:
-                    self.assertLessEqual(values["peak_cpu_pct"], thresholds["max_cpu_pct"])
+                    self.assertLessEqual(
+                        values["peak_cpu_pct"], thresholds["max_cpu_pct"]
+                    )
                 if "peak_rss_pct" in values:
-                    self.assertLessEqual(values["peak_rss_pct"], thresholds["max_rss_pct"])
+                    self.assertLessEqual(
+                        values["peak_rss_pct"], thresholds["max_rss_pct"]
+                    )
 
     def test_typesense_models_full_replicas_and_leader_serialized_writes(self) -> None:
         steady = self.report["scenarios"]["steady"]["tiers"]["typesense"]
         overload = self.report["scenarios"]["overload_shard_loss"]["tiers"]["typesense"]
 
         self.assertEqual(self.report["topology"]["typesense_index_shards"], 24)
-        self.assertEqual(self.report["topology"]["typesense_index_shards_per_data_cell"], 3)
-        self.assertEqual(self.report["topology"]["typesense_ha_replica_groups_per_index_shard"], 5)
-        self.assertEqual(self.report["topology"]["typesense_nodes_per_ha_replica_group"], 3)
-        self.assertEqual(self.report["topology"]["typesense_full_replicas_per_index_shard"], 15)
+        self.assertEqual(
+            self.report["topology"]["typesense_index_shards_per_data_cell"], 3
+        )
+        self.assertEqual(
+            self.report["topology"]["typesense_ha_replica_groups_per_index_shard"], 5
+        )
+        self.assertEqual(
+            self.report["topology"]["typesense_nodes_per_ha_replica_group"], 3
+        )
+        self.assertEqual(
+            self.report["topology"]["typesense_full_replicas_per_index_shard"], 15
+        )
         self.assertIn(
-            "full global search QPS", self.spec["workload"]["typesense_search_fanout_semantics"]
+            "full global search QPS",
+            self.spec["workload"]["typesense_search_fanout_semantics"],
         )
         self.assertIn(
             "every HA replica group",
@@ -93,7 +108,9 @@ class CapacityEnvelopeTest(unittest.TestCase):
 
         # 640 GiB is split over 24 independent index shards. Every node in a
         # shard holds that shard's complete 26.667 GiB working set.
-        self.assertAlmostEqual(steady["working_set_gib_per_replica"], 640 / 24, places=4)
+        self.assertAlmostEqual(
+            steady["working_set_gib_per_replica"], 640 / 24, places=4
+        )
         self.assertAlmostEqual(steady["peak_rss_pct"], 100 * (640 / 24) / 64, places=4)
         self.assertEqual(overload["peak_rss_pct"], steady["peak_rss_pct"])
 
@@ -225,7 +242,9 @@ class CapacityEnvelopeTest(unittest.TestCase):
         steady_threshold = self.spec["scenarios"]["steady"]
         overload_threshold = self.spec["scenarios"]["overload_shard_loss"]
         sensitivity_threshold = self.spec["cost_sensitivity"]
-        self.assertGreater(steady["monthly_cost_eur"], steady_threshold["max_monthly_cost_eur"])
+        self.assertGreater(
+            steady["monthly_cost_eur"], steady_threshold["max_monthly_cost_eur"]
+        )
         self.assertLessEqual(steady["cost_per_million_eur"]["board"], 16)
         self.assertGreater(
             steady["cost_per_million_eur"]["detail"],
@@ -264,7 +283,10 @@ class CapacityEnvelopeTest(unittest.TestCase):
             "会社-採用": 2488,
         }
         self.assertEqual(
-            {board_id: capacity.partition_for_board(board_id, partitions) for board_id in vectors},
+            {
+                board_id: capacity.partition_for_board(board_id, partitions)
+                for board_id in vectors
+            },
             vectors,
         )
         counts = capacity.recovery_partition_counts(self.spec)
@@ -274,7 +296,10 @@ class CapacityEnvelopeTest(unittest.TestCase):
         old = [capacity.growth_owner(partition, [1.0] * 8) for partition in range(8192)]
         new = [capacity.growth_owner(partition, [1.0] * 9) for partition in range(8192)]
         self.assertTrue(
-            all(before == after or after == 8 for before, after in zip(old, new, strict=True))
+            all(
+                before == after or after == 8
+                for before, after in zip(old, new, strict=True)
+            )
         )
 
     def test_streaming_harness_conserves_a_small_fixture(self) -> None:
@@ -283,9 +308,15 @@ class CapacityEnvelopeTest(unittest.TestCase):
         self.assertEqual(evidence["conservation"]["lost_boards"], 0)
         self.assertEqual(evidence["conservation"]["duplicate_boards"], 0)
         self.assertEqual(evidence["conservation"]["unaffected_partitions_moved"], 0)
-        self.assertEqual(evidence["conservation"]["recovered_active_postings"], 100_000_000)
-        self.assertEqual(evidence["conservation"]["recovered_cycles_per_hour"], 6_000_000)
-        self.assertEqual(evidence["conservation"]["growth_existing_to_existing_moves"], 0)
+        self.assertEqual(
+            evidence["conservation"]["recovered_active_postings"], 100_000_000
+        )
+        self.assertEqual(
+            evidence["conservation"]["recovered_cycles_per_hour"], 6_000_000
+        )
+        self.assertEqual(
+            evidence["conservation"]["growth_existing_to_existing_moves"], 0
+        )
 
     def test_checked_in_full_cardinality_evidence_is_self_verifying(self) -> None:
         evidence = json.loads(EVIDENCE.read_text(encoding="utf-8"))
@@ -297,7 +328,9 @@ class CapacityEnvelopeTest(unittest.TestCase):
         self.assertEqual(evidence["conservation"]["duplicate_boards"], 0)
         self.assertEqual(evidence["conservation"]["growth_lost_partitions"], 0)
         self.assertEqual(evidence["conservation"]["growth_duplicate_partitions"], 0)
-        self.assertEqual(evidence["conservation"]["growth_existing_to_existing_moves"], 0)
+        self.assertEqual(
+            evidence["conservation"]["growth_existing_to_existing_moves"], 0
+        )
         for field in (
             "recovered_max_board_load_factor",
             "recovered_max_task_rate_factor",

--- a/scripts/test_capacity_envelope.py
+++ b/scripts/test_capacity_envelope.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "capacity_envelope.py"
+SPEC = ROOT / "capacity" / "crawler" / "global-v1.json"
+REPORT = ROOT / "capacity" / "crawler" / "global-v1-report.json"
+EVIDENCE = ROOT / "capacity" / "crawler" / "evidence" / "2026-08-26-local-routing.json"
+
+module_spec = importlib.util.spec_from_file_location("capacity_envelope", SCRIPT)
+assert module_spec and module_spec.loader
+capacity = importlib.util.module_from_spec(module_spec)
+sys.modules[module_spec.name] = capacity
+module_spec.loader.exec_module(capacity)
+
+
+class CapacityEnvelopeTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.spec = capacity.load_spec(SPEC)
+        cls.report = capacity.build_report(cls.spec)
+
+    def test_checked_in_report_is_reproducible(self) -> None:
+        self.assertEqual(json.loads(REPORT.read_text(encoding="utf-8")), self.report)
+        self.assertEqual(self.report["spec_sha256"], capacity.sha256_json(self.spec))
+        with self.assertRaisesRegex(capacity.CapacityError, "monthly steady cost ceiling exceeded"):
+            capacity.check_report(self.spec, self.report)
+
+    def test_epic_floor_and_simultaneous_failure_are_frozen(self) -> None:
+        report = self.report
+        self.assertEqual(report["workload"]["configured_boards"], 10_000_000)
+        self.assertEqual(report["workload"]["active_postings"], 100_000_000)
+        self.assertEqual(report["workload"]["steady_cycles_per_hour"], 6_000_000)
+        self.assertEqual(report["workload"]["overload_cycles_per_hour"], 12_000_000)
+        self.assertEqual(report["workload"]["origin_attempts_per_success_max"], 1.05)
+        self.assertEqual(
+            report["workload"]["payload_contract"]["max_inline_body_bytes"],
+            8 * 1024**2,
+        )
+        self.assertEqual(
+            report["workload"]["payload_contract"]["max_browser_transfer_bytes"],
+            64 * 1024**2,
+        )
+        overload = report["thresholds"]["overload_shard_loss"]
+        self.assertEqual(overload["load_multiplier"], 2.0)
+        self.assertEqual(
+            set(overload["failed_shards_by_tier"]),
+            set(report["topology"]["simultaneous_loss_matrix"]),
+        )
+        self.assertEqual(set(overload["failed_shards_by_tier"].values()), {1})
+        self.assertEqual(overload["max_policy_ready_queue_depth"], 12_000_000)
+        self.assertEqual(overload["max_oldest_policy_ready_due_seconds"], 2_700)
+        self.assertEqual(overload["max_shard_recovery_seconds"], 600)
+        self.assertEqual(overload["max_catch_up_seconds"], 2_700)
+
+    def test_every_tier_fits_cpu_and_rss_thresholds(self) -> None:
+        for name in ("steady", "overload_shard_loss"):
+            thresholds = self.report["thresholds"][name]
+            scenario = self.report["scenarios"][name]
+            for values in scenario["tiers"].values():
+                if "peak_cpu_pct" in values:
+                    self.assertLessEqual(values["peak_cpu_pct"], thresholds["max_cpu_pct"])
+                if "peak_rss_pct" in values:
+                    self.assertLessEqual(values["peak_rss_pct"], thresholds["max_rss_pct"])
+
+    def test_typesense_models_full_replicas_and_leader_serialized_writes(self) -> None:
+        steady = self.report["scenarios"]["steady"]["tiers"]["typesense"]
+        overload = self.report["scenarios"]["overload_shard_loss"]["tiers"]["typesense"]
+
+        self.assertEqual(self.report["topology"]["typesense_index_shards"], 24)
+        self.assertEqual(self.report["topology"]["typesense_index_shards_per_data_cell"], 3)
+        self.assertEqual(self.report["topology"]["typesense_ha_replica_groups_per_index_shard"], 5)
+        self.assertEqual(self.report["topology"]["typesense_nodes_per_ha_replica_group"], 3)
+        self.assertEqual(self.report["topology"]["typesense_full_replicas_per_index_shard"], 15)
+        self.assertIn(
+            "full global search QPS", self.spec["workload"]["typesense_search_fanout_semantics"]
+        )
+        self.assertIn(
+            "every HA replica group",
+            self.spec["workload"]["typesense_write_replication_semantics"],
+        )
+        self.assertEqual(
+            self.report["topology"]["simultaneous_loss_matrix"]["typesense"]["scope"],
+            "affected_index_shard",
+        )
+
+        # 640 GiB is split over 24 independent index shards. Every node in a
+        # shard holds that shard's complete 26.667 GiB working set.
+        self.assertAlmostEqual(steady["working_set_gib_per_replica"], 640 / 24, places=4)
+        self.assertAlmostEqual(steady["peak_rss_pct"], 100 * (640 / 24) / 64, places=4)
+        self.assertEqual(overload["peak_rss_pct"], steady["peak_rss_pct"])
+
+        # Replica loss cannot create write throughput. At 2x, every HA-group
+        # leader serializes all 400 writes/s for its shard; 14 nodes share reads.
+        self.assertAlmostEqual(
+            overload["write_leader_utilization_pct_per_ha_group"], 20.0, places=4
+        )
+        self.assertEqual(overload["search_qps_per_index_shard"], 4000)
+        self.assertAlmostEqual(
+            overload["search_replica_utilization_pct"],
+            100 * 4000 / (14 * 800),
+            places=4,
+        )
+        self.assertAlmostEqual(overload["replicated_write_cpu_cores_per_node"], 0.8)
+        self.assertAlmostEqual(
+            overload["search_cpu_cores_per_surviving_node"],
+            4000 / 14 * 0.005,
+            places=4,
+        )
+        self.assertAlmostEqual(
+            overload["peak_cpu_pct"],
+            100 * (0.8 + 4000 / 14 * 0.005) / 8,
+            places=4,
+        )
+        self.assertLessEqual(steady["modeled_throughput_pct"], 35)
+        self.assertLessEqual(overload["modeled_throughput_pct"], 70)
+
+    def test_typesense_search_fanout_does_not_divide_qps_by_index_shards(self) -> None:
+        expanded = copy.deepcopy(self.spec)
+        expanded["topology"]["typesense_index_shards"] = 48
+        expanded["prices"]["nodes"]["typesense_node"]["count"] = 48 * 5 * 3
+        report = capacity.build_report(expanded)
+        original = self.report["scenarios"]["overload_shard_loss"]["tiers"]["typesense"]
+        changed = report["scenarios"]["overload_shard_loss"]["tiers"]["typesense"]
+
+        self.assertEqual(changed["search_qps_per_index_shard"], 4000)
+        self.assertEqual(
+            changed["search_replica_utilization_pct"],
+            original["search_replica_utilization_pct"],
+        )
+        self.assertEqual(
+            changed["search_cpu_cores_per_surviving_node"],
+            original["search_cpu_cores_per_surviving_node"],
+        )
+        self.assertEqual(
+            changed["upserts_per_second_per_ha_group"],
+            original["upserts_per_second_per_ha_group"] / 2,
+        )
+
+    def test_typesense_replica_count_only_scales_read_capacity(self) -> None:
+        expanded = copy.deepcopy(self.spec)
+        expanded["profiles"]["typesense"]["ha_replica_groups_per_index_shard"] = 7
+        report = capacity.build_report(expanded)
+        original = self.report["scenarios"]["overload_shard_loss"]["tiers"]["typesense"]
+        changed = report["scenarios"]["overload_shard_loss"]["tiers"]["typesense"]
+
+        self.assertEqual(changed["peak_rss_pct"], original["peak_rss_pct"])
+        self.assertEqual(
+            changed["write_leader_utilization_pct_per_ha_group"],
+            original["write_leader_utilization_pct_per_ha_group"],
+        )
+        self.assertEqual(
+            changed["replicated_write_cpu_cores_per_node"],
+            original["replicated_write_cpu_cores_per_node"],
+        )
+        self.assertLess(
+            changed["search_replica_utilization_pct"],
+            original["search_replica_utilization_pct"],
+        )
+        self.assertLess(changed["peak_cpu_pct"], original["peak_cpu_pct"])
+
+    def test_typesense_replica_memory_regression_fails_closed(self) -> None:
+        unsafe = copy.deepcopy(self.spec)
+        unsafe["profiles"]["typesense"]["memory_gib_per_node"] = 32
+        with self.assertRaisesRegex(capacity.CapacityError, "typesense RSS"):
+            capacity.check_report(unsafe, capacity.build_report(unsafe))
+
+    def test_original_eight_shard_typesense_topology_fails_closed(self) -> None:
+        unsafe = copy.deepcopy(self.spec)
+        unsafe["topology"]["typesense_index_shards"] = 8
+        unsafe["prices"]["nodes"]["typesense_node"]["count"] = 8 * 5 * 3
+        report = capacity.build_report(unsafe)
+        self.assertEqual(
+            report["scenarios"]["steady"]["tiers"]["typesense"]["peak_rss_pct"],
+            125.0,
+        )
+        with self.assertRaisesRegex(capacity.CapacityError, "typesense RSS"):
+            capacity.check_report(unsafe, report)
+
+    def test_single_ha_group_fanout_profile_fails_closed(self) -> None:
+        unsafe = copy.deepcopy(self.spec)
+        unsafe["profiles"]["typesense"]["ha_replica_groups_per_index_shard"] = 1
+        unsafe["prices"]["nodes"]["typesense_node"]["count"] = 24 * 3
+        report = capacity.build_report(unsafe)
+        overload = report["scenarios"]["overload_shard_loss"]["tiers"]["typesense"]
+        self.assertEqual(overload["search_qps_per_index_shard"], 4000)
+        self.assertEqual(overload["search_replica_utilization_pct"], 250.0)
+        self.assertEqual(overload["peak_cpu_pct"], 135.0)
+        with self.assertRaisesRegex(capacity.CapacityError, "typesense CPU"):
+            capacity.check_report(unsafe, report)
+
+    def test_each_runtime_tier_survives_its_simultaneous_loss(self) -> None:
+        matrix = self.report["topology"]["simultaneous_loss_matrix"]
+        self.assertEqual(
+            set(matrix),
+            {
+                "queue",
+                "worker",
+                "browser",
+                "postgres",
+                "telemetry",
+                "telemetry_backend",
+                "typesense",
+                "cell_service",
+                "routing",
+                "load_balancer",
+            },
+        )
+        for values in matrix.values():
+            self.assertEqual(values["lost_shards"], 1)
+            self.assertGreaterEqual(values["surviving_shards"], 1)
+            self.assertLessEqual(values["max_modeled_capacity_pct_after_loss"], 70)
+
+    def test_cost_report_exposes_economic_rejection(self) -> None:
+        steady = self.report["cost"]["steady"]
+        overload = self.report["cost"]["overload_shard_loss"]
+        sensitivity = self.report["cost"]["sensitivity"]
+        steady_threshold = self.spec["scenarios"]["steady"]
+        overload_threshold = self.spec["scenarios"]["overload_shard_loss"]
+        sensitivity_threshold = self.spec["cost_sensitivity"]
+        self.assertGreater(steady["monthly_cost_eur"], steady_threshold["max_monthly_cost_eur"])
+        self.assertLessEqual(steady["cost_per_million_eur"]["board"], 16)
+        self.assertGreater(
+            steady["cost_per_million_eur"]["detail"],
+            steady_threshold["max_detail_cost_per_million_eur"],
+        )
+        self.assertGreater(
+            overload["cost_per_million_eur"]["detail"],
+            overload_threshold["max_detail_cost_per_million_eur"],
+        )
+        self.assertGreater(
+            overload["cost_per_million_eur"]["blended"],
+            overload_threshold["max_blended_cost_per_million_eur"],
+        )
+        self.assertGreater(
+            sensitivity["cost_per_million_eur"]["detail"],
+            sensitivity_threshold["max_detail_cost_per_million_eur"],
+        )
+        self.assertGreater(sensitivity["origin_transfer_tib_per_month"], 1_000)
+        self.assertLessEqual(
+            self.report["storage"]["typesense_index_replicated_tib"],
+            self.report["storage"]["typesense_index_replicated_budget_tib"],
+        )
+
+    def test_threshold_regression_fails_closed(self) -> None:
+        regressed = copy.deepcopy(self.spec)
+        regressed["scenarios"]["overload_shard_loss"]["max_cpu_pct"] = 40
+        with self.assertRaisesRegex(capacity.CapacityError, "CPU exceeds"):
+            capacity.check_report(regressed, capacity.build_report(regressed))
+
+    def test_routing_vectors_and_recovery_are_deterministic(self) -> None:
+        partitions = int(self.spec["topology"]["logical_partitions"])
+        vectors = {
+            "board-00000000": 3142,
+            "board-00000001": 1259,
+            "company:board/eu": 2804,
+            "会社-採用": 2488,
+        }
+        self.assertEqual(
+            {board_id: capacity.partition_for_board(board_id, partitions) for board_id in vectors},
+            vectors,
+        )
+        counts = capacity.recovery_partition_counts(self.spec)
+        self.assertEqual(sum(counts), partitions)
+        self.assertEqual(counts[:8], [0, 148, 147, 138, 145, 149, 152, 145])
+        self.assertTrue(all(count == 128 for count in counts[8:]))
+        old = [capacity.growth_owner(partition, [1.0] * 8) for partition in range(8192)]
+        new = [capacity.growth_owner(partition, [1.0] * 9) for partition in range(8192)]
+        self.assertTrue(
+            all(before == after or after == 8 for before, after in zip(old, new, strict=True))
+        )
+
+    def test_streaming_harness_conserves_a_small_fixture(self) -> None:
+        evidence = capacity.benchmark_routing(self.spec, 25_000)
+        self.assertEqual(evidence["conservation"]["input_boards"], 25_000)
+        self.assertEqual(evidence["conservation"]["lost_boards"], 0)
+        self.assertEqual(evidence["conservation"]["duplicate_boards"], 0)
+        self.assertEqual(evidence["conservation"]["unaffected_partitions_moved"], 0)
+        self.assertEqual(evidence["conservation"]["recovered_active_postings"], 100_000_000)
+        self.assertEqual(evidence["conservation"]["recovered_cycles_per_hour"], 6_000_000)
+        self.assertEqual(evidence["conservation"]["growth_existing_to_existing_moves"], 0)
+
+    def test_checked_in_full_cardinality_evidence_is_self_verifying(self) -> None:
+        evidence = json.loads(EVIDENCE.read_text(encoding="utf-8"))
+        digest = evidence.pop("evidence_sha256")
+        self.assertEqual(digest, capacity.sha256_json(evidence))
+        self.assertEqual(evidence["spec_sha256"], capacity.sha256_json(self.spec))
+        self.assertEqual(evidence["input"]["boards"], 10_000_000)
+        self.assertEqual(evidence["conservation"]["lost_boards"], 0)
+        self.assertEqual(evidence["conservation"]["duplicate_boards"], 0)
+        self.assertEqual(evidence["conservation"]["growth_lost_partitions"], 0)
+        self.assertEqual(evidence["conservation"]["growth_duplicate_partitions"], 0)
+        self.assertEqual(evidence["conservation"]["growth_existing_to_existing_moves"], 0)
+        for field in (
+            "recovered_max_board_load_factor",
+            "recovered_max_task_rate_factor",
+            "recovered_max_posting_factor",
+            "recovered_max_browser_rate_factor",
+            "recovered_max_provider_rate_factor",
+        ):
+            self.assertLessEqual(evidence["distribution"][field], 1.32)
+        self.assertIn("lightpanda", evidence["explicitly_not_measured"])
+
+    def test_cli_check_rejects_economically_infeasible_profile(self) -> None:
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPT), "--check"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("monthly steady cost ceiling exceeded", completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- replace the invalid `global-v1` model with a fail-closed `global-v2` envelope for 10M boards, 100M active postings, 6M steady cycles/hour, and 2x recovery load
- model 4,000 global Typesense queries as 4,000 queries in every one of eight cells, including merge CPU/RSS, cross-region latency, response tails, and network
- define exact queue/Postgres/cell failure units, replica placement, promotion/fencing, 3-of-5 manifest CAS, partitioned policy/posting ledgers, dual-provider WAL archives, derived RPO/restore time, and their storage/cost
- make politeness deferrals, hot origins/accounts, ready/deferred depth, oldest scheduled due, and adversarial policy CAS first-class gates
- use the same rendezvous algorithm for the initial manifest and every 8→32 growth epoch; retain modulo as a required failing negative control
- apply measured correlated skew to queue groups, cells, Postgres groups, browser-heavy providers, response tails, hot accounts, and maximum-board weights
- add dated EU/US/Singapore SKUs, IPv4/transfer/proxy/R2/B2/telemetry economics, capacity-derived sensitivity node counts, and active backup/tail mutation tests
- add an executable production-stack corpus generator/orchestrator, explicit hardware manifest, fault timeline, required metrics, and result schema

## Temporary dependency

This draft is stacked on unmerged #8037 at exact head `c07fcccccf567d1eb6a2b13f5c1a0ea9db538109`. Capacity reads and hashes `apps/crawler/contracts/v1/limits.json` directly; it does not copy transport constants. Rebase onto `main` after #8037 is accepted.

## Evidence

- `uv run python scripts/capacity_envelope.py --check`
  - spec SHA-256: `ad9bc970e4d67c68aa06d8cfcfb78a094962e138b09dfb975ede331a037e1684`
  - contract limits SHA-256: `f7c0ee1f766f6899c2c9464a14cb08b0791336a02de6e076eada3565c2e5640b`
  - steady peak/margin: CPU 20.0521% / 14.9479 points; RSS 45.8333% / 9.1667; throughput 30% / 5
  - 2x plus simultaneous loss peak/margin: CPU 66% / 4; RSS 68.75% / 1.25; throughput 66% / 4
  - derived cell-loss RPO 7.1881s; restore 2,352.32s; paired-cell utilization 38.1944%
- full 10M-board synthetic evidence at `capacity/evidence/2026-08-26-local-v2-routing.json`
  - zero loss and zero duplicate authoritative completions
  - queue-group task factor 1.275997; maximum cell/provider factor 1.117356; Postgres-group task factor 1.11654 (all <= 1.32)
  - all 24 growth steps through 32 cells conserve 8,192 partitions with zero existing-to-existing moves
- `uv run python scripts/capacity_drill.py check`
- `uv run pytest -q tests/test_capacity_envelope.py` — 14 passed
- Ruff/format and generated-report/evidence digest checks pass

## Evidence boundary

This remains a **draft analytical candidate** plus measured synthetic routing evidence. The production-stack 24-hour steady run and three repeated 2x simultaneous-fault drills have not run. This PR does not authorize Python retirement, and #7936 must remain open until a reviewed result artifact passes the exact spec/contract/hardware/image digests and thresholds.

Relates to #7936
Parent epic: #7935
Retirement consumer: #7966
