### PR TITLE
Gate crawler merges during deployment holds

### DIFF
--- a/.github/rulesets/main-strict-gate.json
+++ b/.github/rulesets/main-strict-gate.json
@@ -18,6 +18,9 @@
         "required_status_checks": [
           {
             "context": "Required CI"
+          },
+          {
+            "context": "Crawler Deploy Gate"
           }
         ]
       }

--- a/.github/scripts/check-crawler-deploy-gate.sh
+++ b/.github/scripts/check-crawler-deploy-gate.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${REPO:?REPO is required}"
+: "${PR:?PR is required}"
+: "${DRAFT:?DRAFT is required}"
+
+if [[ "$DRAFT" == "true" ]]; then
+  echo "PR #$PR is draft; no merge authority is granted"
+  exit 0
+fi
+[[ "$DRAFT" == "false" ]] || {
+  echo "ERROR: PR #$PR has invalid draft state $DRAFT" >&2
+  exit 1
+}
+
+runtime_paths=()
+while IFS= read -r path; do
+  [[ -n "$path" ]] || continue
+  case "$path" in
+    apps/crawler/data/industries.csv | \
+      apps/crawler/data/occupations.csv | \
+      apps/crawler/data/seniority.csv | \
+      apps/crawler/data/technologies.csv | \
+      .github/workflows/deploy-crawler-browser.yml | \
+      scripts/derive-crawler-runtime-contract.mjs | \
+      scripts/verify-crawler-release-bridge.py)
+      runtime_paths+=("$path")
+      ;;
+    apps/crawler/data/* | \
+      apps/crawler/traces/* | \
+      apps/crawler/ws-package/* | \
+      apps/crawler/*.md)
+      # These exclusions mirror Deploy Crawler (Hetzner). Keep both surfaces
+      # synchronized so a required gate is neither missing nor over-broad.
+      ;;
+    apps/crawler/*)
+      runtime_paths+=("$path")
+      ;;
+  esac
+done < <(
+  gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
+    --jq '.[] | .filename, (.previous_filename // empty)'
+)
+
+if (( ${#runtime_paths[@]} == 0 )); then
+  echo "PR #$PR does not trigger the crawler runtime deployment"
+  exit 0
+fi
+
+holds_json="$({
+  gh issue list --repo "$REPO" --state open \
+    --label 'deployment-hold:crawler' --limit 100 \
+    --json number,title,url
+})"
+jq -e 'type == "array"' <<<"$holds_json" >/dev/null || {
+  echo "ERROR: crawler deployment hold query returned malformed JSON" >&2
+  exit 1
+}
+
+if jq -e 'length == 0' <<<"$holds_json" >/dev/null; then
+  echo "PR #$PR may enter the crawler deployment path; no deployment hold is active"
+  exit 0
+fi
+
+echo "ERROR: PR #$PR changes crawler runtime paths while deployment is held:" >&2
+jq -r '.[] | "- #\(.number) \(.title) (\(.url))"' <<<"$holds_json" >&2
+echo "Changed runtime paths:" >&2
+printf -- '- %s\n' "${runtime_paths[@]:0:20}" >&2
+exit 1

--- a/.github/scripts/check-crawler-deploy-gate.sh
+++ b/.github/scripts/check-crawler-deploy-gate.sh
@@ -16,6 +16,18 @@ fi
   exit 1
 }
 
+changed_paths="$(
+  gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
+    --jq '.[] | .filename, (.previous_filename // empty)'
+)" || {
+  echo "ERROR: could not classify files for PR #$PR" >&2
+  exit 1
+}
+[[ -n "$changed_paths" ]] || {
+  echo "ERROR: file query for PR #$PR returned no paths" >&2
+  exit 1
+}
+
 runtime_paths=()
 while IFS= read -r path; do
   [[ -n "$path" ]] || continue
@@ -40,10 +52,7 @@ while IFS= read -r path; do
       runtime_paths+=("$path")
       ;;
   esac
-done < <(
-  gh api --paginate "repos/$REPO/pulls/$PR/files?per_page=100" \
-    --jq '.[] | .filename, (.previous_filename // empty)'
-)
+done <<<"$changed_paths"
 
 if (( ${#runtime_paths[@]} == 0 )); then
   echo "PR #$PR does not trigger the crawler runtime deployment"

--- a/.github/scripts/reconcile-crawler-deploy-gate.sh
+++ b/.github/scripts/reconcile-crawler-deploy-gate.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+: "${GH_TOKEN:?GH_TOKEN is required}"
+: "${REPO:?REPO is required}"
+: "${TARGET_URL:?TARGET_URL is required}"
+
+prs_json="$(
+  gh pr list --repo "$REPO" --state open --limit 1000 \
+    --json number
+)" || {
+  echo "ERROR: could not list open pull requests" >&2
+  exit 1
+}
+jq -e '
+  type == "array" and
+  all(.[];
+    (.number | type == "number"))
+' <<<"$prs_json" >/dev/null || {
+  echo "ERROR: open pull-request query returned malformed JSON" >&2
+  exit 1
+}
+
+prs="$(jq -r '.[].number' <<<"$prs_json")"
+[[ -n "$prs" ]] || {
+  echo "No open pull requests require crawler deployment reconciliation"
+  exit 0
+}
+
+# Every event reconciles every open PR from current repository state. Combined
+# with the workflow's single non-cancelling job concurrency group, this keeps an
+# older evaluator from overwriting a newer hold decision and makes a replacement
+# pending run converge the entire queue rather than only its triggering PR.
+while IFS= read -r pr; do
+  [[ "$pr" =~ ^[1-9][0-9]*$ ]] || {
+    echo "ERROR: invalid pull-request number in reconciliation input" >&2
+    exit 1
+  }
+
+  # Re-read state and identity immediately before evaluation. The queue listing
+  # can be stale by the time a serialized run reaches a later PR.
+  pr_json="$(
+    gh pr view "$pr" --repo "$REPO" --json state,isDraft,headRefOid
+  )" || {
+    echo "ERROR: could not refresh PR #$pr before reconciliation" >&2
+    exit 1
+  }
+  jq -e '
+    type == "object" and
+    (.state | type == "string") and
+    (.isDraft | type == "boolean") and
+    (.headRefOid | type == "string")
+  ' <<<"$pr_json" >/dev/null || {
+    echo "ERROR: PR #$pr refresh returned malformed JSON" >&2
+    exit 1
+  }
+  IFS=$'\t' read -r state_now draft head_sha <<<"$(
+    jq -r '[.state, (.isDraft | tostring), .headRefOid] | @tsv' \
+      <<<"$pr_json"
+  )"
+  [[ "$state_now" == "OPEN" ]] || continue
+  [[ "$draft" == "true" || "$draft" == "false" ]] || {
+    echo "ERROR: PR #$pr has invalid draft state" >&2
+    exit 1
+  }
+  [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]] || {
+    echo "ERROR: PR #$pr has invalid head SHA" >&2
+    exit 1
+  }
+
+  state=failure
+  description="Draft PR; no merge authority is granted"
+  if [[ "$draft" == "false" ]]; then
+    description="Crawler deployment is held"
+    if PR="$pr" DRAFT=false \
+      .github/scripts/check-crawler-deploy-gate.sh; then
+      state=success
+      description="No crawler deployment hold applies"
+    fi
+  fi
+
+  gh api --method POST "repos/$REPO/statuses/$head_sha" \
+    -f state="$state" \
+    -f context="Crawler Deploy Gate" \
+    -f description="$description" \
+    -f target_url="$TARGET_URL" >/dev/null
+done <<<"$prs"

--- a/.github/workflows/crawler-deploy-gate.yml
+++ b/.github/workflows/crawler-deploy-gate.yml
@@ -1,0 +1,117 @@
+name: Crawler Deploy Gate
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, labeled, unlabeled]
+  issues:
+    types: [opened, reopened, closed, labeled, unlabeled]
+
+permissions: {}
+
+concurrency:
+  group: >-
+    crawler-deploy-gate-${{ github.event_name }}-${{
+      github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  pull-request:
+    if: github.event_name == 'pull_request_target'
+    name: Evaluate Crawler Deploy Gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+      statuses: write
+    steps:
+      - name: Check out the trusted workflow revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+
+      - name: Enforce crawler deployment holds
+        id: evaluate
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          DRAFT: ${{ github.event.pull_request.draft }}
+        run: .github/scripts/check-crawler-deploy-gate.sh
+
+      - name: Publish required crawler deployment status
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          DRAFT: ${{ github.event.pull_request.draft }}
+          OUTCOME: ${{ steps.evaluate.outcome }}
+          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          state=success
+          description="No crawler deployment hold applies"
+          if [[ "$DRAFT" == "true" ]]; then
+            description="Draft PR; no merge authority is granted"
+          elif [[ "$OUTCOME" != "success" ]]; then
+            state=failure
+            description="Crawler deployment is held"
+          fi
+          gh api --method POST "repos/$REPO/statuses/$HEAD_SHA" \
+            -f state="$state" \
+            -f context="Crawler Deploy Gate" \
+            -f description="$description" \
+            -f target_url="$TARGET_URL" >/dev/null
+
+      - name: Fail the evaluator when deployment is held
+        if: steps.evaluate.outcome != 'success'
+        run: exit 1
+
+  deployment-hold:
+    if: >-
+      github.event_name == 'issues' &&
+      (github.event.label.name == 'deployment-hold:crawler' ||
+       contains(toJson(github.event.issue.labels.*.name), 'deployment-hold:crawler'))
+    name: Reconcile Crawler Deploy Gate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+      statuses: write
+    steps:
+      - name: Check out the trusted default branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Re-evaluate every ready PR at its exact head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          gh pr list --repo "$REPO" --state open --limit 1000 \
+            --json number,isDraft,headRefOid \
+            --jq '.[] | select(.isDraft == false) | [.number, .headRefOid] | @tsv' |
+          while IFS=$'\t' read -r pr head_sha; do
+            [[ "$pr" =~ ^[1-9][0-9]*$ ]]
+            [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
+            state=success
+            description="No crawler deployment hold applies"
+            if ! PR="$pr" DRAFT=false \
+              .github/scripts/check-crawler-deploy-gate.sh; then
+              state=failure
+              description="Crawler deployment is held"
+            fi
+            gh api --method POST "repos/$REPO/statuses/$head_sha" \
+              -f state="$state" \
+              -f context="Crawler Deploy Gate" \
+              -f description="$description" \
+              -f target_url="$TARGET_URL" >/dev/null
+          done

--- a/.github/workflows/crawler-deploy-gate.yml
+++ b/.github/workflows/crawler-deploy-gate.yml
@@ -2,23 +2,24 @@ name: Crawler Deploy Gate
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft, labeled, unlabeled]
+    types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
   issues:
     types: [opened, reopened, closed, labeled, unlabeled]
 
 permissions: {}
 
-concurrency:
-  group: >-
-    crawler-deploy-gate-${{ github.event_name }}-${{
-      github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
-
 jobs:
-  pull-request:
-    if: github.event_name == 'pull_request_target'
-    name: Evaluate Crawler Deploy Gate
+  reconcile:
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issues' &&
+       (github.event.label.name == 'deployment-hold:crawler' ||
+        contains(toJson(github.event.issue.labels.*.name), 'deployment-hold:crawler')))
+    name: Reconcile Crawler Deploy Gate
     runs-on: ubuntu-latest
+    concurrency:
+      group: crawler-deploy-gate-status-writer
+      cancel-in-progress: false
     permissions:
       contents: read
       issues: read
@@ -31,87 +32,9 @@ jobs:
           ref: ${{ github.workflow_sha }}
           persist-credentials: false
 
-      - name: Enforce crawler deployment holds
-        id: evaluate
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          PR: ${{ github.event.pull_request.number }}
-          DRAFT: ${{ github.event.pull_request.draft }}
-        run: .github/scripts/check-crawler-deploy-gate.sh
-
-      - name: Publish required crawler deployment status
-        if: always()
-        env:
-          GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          DRAFT: ${{ github.event.pull_request.draft }}
-          OUTCOME: ${{ steps.evaluate.outcome }}
-          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          state=success
-          description="No crawler deployment hold applies"
-          if [[ "$DRAFT" == "true" ]]; then
-            description="Draft PR; no merge authority is granted"
-          elif [[ "$OUTCOME" != "success" ]]; then
-            state=failure
-            description="Crawler deployment is held"
-          fi
-          gh api --method POST "repos/$REPO/statuses/$HEAD_SHA" \
-            -f state="$state" \
-            -f context="Crawler Deploy Gate" \
-            -f description="$description" \
-            -f target_url="$TARGET_URL" >/dev/null
-
-      - name: Fail the evaluator when deployment is held
-        if: steps.evaluate.outcome != 'success'
-        run: exit 1
-
-  deployment-hold:
-    if: >-
-      github.event_name == 'issues' &&
-      (github.event.label.name == 'deployment-hold:crawler' ||
-       contains(toJson(github.event.issue.labels.*.name), 'deployment-hold:crawler'))
-    name: Reconcile Crawler Deploy Gate
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: read
-      pull-requests: read
-      statuses: write
-    steps:
-      - name: Check out the trusted default branch
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-          persist-credentials: false
-
-      - name: Re-evaluate every ready PR at its exact head
+      - name: Re-evaluate every open PR at its exact head
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          gh pr list --repo "$REPO" --state open --limit 1000 \
-            --json number,isDraft,headRefOid \
-            --jq '.[] | select(.isDraft == false) | [.number, .headRefOid] | @tsv' |
-          while IFS=$'\t' read -r pr head_sha; do
-            [[ "$pr" =~ ^[1-9][0-9]*$ ]]
-            [[ "$head_sha" =~ ^[0-9a-f]{40}$ ]]
-            state=success
-            description="No crawler deployment hold applies"
-            if ! PR="$pr" DRAFT=false \
-              .github/scripts/check-crawler-deploy-gate.sh; then
-              state=failure
-              description="Crawler deployment is held"
-            fi
-            gh api --method POST "repos/$REPO/statuses/$head_sha" \
-              -f state="$state" \
-              -f context="Crawler Deploy Gate" \
-              -f description="$description" \
-              -f target_url="$TARGET_URL" >/dev/null
-          done
+        run: .github/scripts/reconcile-crawler-deploy-gate.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,3 +228,12 @@ See [docs/13-seo-and-indexnow.md](docs/13-seo-and-indexnow.md).
 - Branch naming: `add-company/<slug>` for company additions, `fix-crawler/<description>` for code changes
 - Commit messages: imperative mood, concise (`Add Stripe`, `Fix sitemap parser timeout`)
 - Never push directly to main — always create a PR
+- Final merge authority is a lease, not a durable approval. Immediately before
+  merging, re-read the PR's state, draft flag, exact head/base OIDs, required
+  checks, and merge state. A head change, a transition back to draft, or a
+  conflicting task/operator decision invalidates prior merge authority; stop
+  instead of restoring ready state or merging from stale review evidence.
+- Ready crawler-runtime PRs must have a green `Crawler Deploy Gate`. An open
+  issue labelled `deployment-hold:crawler` intentionally blocks that check.
+  Do not remove the label or bypass/weaken the check unless the operator has
+  explicitly cleared the underlying production condition.

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -53,6 +53,10 @@ const crawlerDeployGateScript = readFileSync(
   ".github/scripts/check-crawler-deploy-gate.sh",
   "utf8",
 );
+const reconcileCrawlerDeployGateScript = readFileSync(
+  ".github/scripts/reconcile-crawler-deploy-gate.sh",
+  "utf8",
+);
 const labelPrScript = readFileSync(".github/scripts/label-pr.sh", "utf8");
 const labelPrCsvDiffHelper = ".github/scripts/label_pr_csv_diff.py";
 const publishMcpServerWorkflow = readFileSync(
@@ -160,7 +164,12 @@ printf '%s\\n' "$*" >> "$MOCK_GH_LOG"
   return { ...result, calls };
 }
 
-function runCrawlerDeployGate({ draft = false, files = [], holds = [] } = {}) {
+function runCrawlerDeployGate({
+  draft = false,
+  files = [],
+  holds = [],
+  fileApiStatus = 0,
+} = {}) {
   const dir = mkdtempSync(join(tmpdir(), "crawler-deploy-gate-"));
   const log = join(dir, "gh.log");
   const gh = join(dir, "gh");
@@ -170,6 +179,9 @@ function runCrawlerDeployGate({ draft = false, files = [], holds = [] } = {}) {
 set -euo pipefail
 printf '%s\\n' "$*" >> "$MOCK_GH_LOG"
 if [[ "$1" == "api" ]]; then
+  if (( MOCK_FILE_API_STATUS != 0 )); then
+    exit "$MOCK_FILE_API_STATUS"
+  fi
   printf '%s\\n' "$MOCK_FILES"
   exit 0
 fi
@@ -193,6 +205,7 @@ exit 1
       MOCK_GH_LOG: log,
       MOCK_FILES: files.join("\n"),
       MOCK_HOLDS: JSON.stringify(holds),
+      MOCK_FILE_API_STATUS: String(fileApiStatus),
     },
     encoding: "utf8",
   });
@@ -201,6 +214,82 @@ exit 1
     calls = readFileSync(log, "utf8");
   } catch {
     // Draft checks deliberately make no API calls.
+  }
+  rmSync(dir, { recursive: true, force: true });
+  return { ...result, calls };
+}
+
+function runCrawlerDeployReconciler({
+  isDraft = false,
+  files = ["apps/crawler/src/core/monitor.py"],
+  holds = [],
+  prs = null,
+} = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "crawler-deploy-reconcile-"));
+  const log = join(dir, "gh.log");
+  const gh = join(dir, "gh");
+  writeFileSync(
+    gh,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$MOCK_GH_LOG"
+if [[ "$1 $2" == "pr list" ]]; then
+  jq -c '[.[] | {number}]' <<<"$MOCK_PRS"
+  exit 0
+fi
+if [[ "$1 $2" == "pr view" ]]; then
+  jq -c --argjson number "$3" '
+    .[] | select(.number == $number) |
+    {state: (.state // "OPEN"), isDraft, headRefOid}
+  ' <<<"$MOCK_PRS"
+  exit 0
+fi
+if [[ "$1" == "api" && "$*" == *"/statuses/"* ]]; then
+  exit 0
+fi
+if [[ "$1" == "api" ]]; then
+  printf '%s\\n' "$MOCK_FILES"
+  exit 0
+fi
+if [[ "$1 $2" == "issue list" ]]; then
+  printf '%s' "$MOCK_HOLDS"
+  exit 0
+fi
+exit 1
+`,
+  );
+  chmodSync(gh, 0o755);
+  const mockPrs = prs ?? [
+    {
+      number: 123,
+      isDraft,
+      headRefOid: "a".repeat(40),
+    },
+  ];
+  const result = spawnSync(
+    "bash",
+    [".github/scripts/reconcile-crawler-deploy-gate.sh"],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        PATH: `${dir}:${process.env.PATH}`,
+        GH_TOKEN: "test-token",
+        REPO: "colophon-group/jobseek",
+        TARGET_URL: "https://example.test/run/1",
+        MOCK_GH_LOG: log,
+        MOCK_PRS: JSON.stringify(mockPrs),
+        MOCK_FILES: files.join("\n"),
+        MOCK_HOLDS: JSON.stringify(holds),
+      },
+      encoding: "utf8",
+    },
+  );
+  let calls = "";
+  try {
+    calls = readFileSync(log, "utf8");
+  } catch {
+    // A malformed PR response can fail before a status API call.
   }
   rmSync(dir, { recursive: true, force: true });
   return { ...result, calls };
@@ -1492,10 +1581,18 @@ test("crawler deploy gate runs trusted and path-aware on PR state changes", () =
   );
   assert.match(crawlerDeployGateWorkflow, /persist-credentials: false/);
   assert.match(crawlerDeployGateWorkflow, /statuses: write/);
-  assert.match(crawlerDeployGateWorkflow, /statuses\/\$HEAD_SHA/);
-  assert.match(crawlerDeployGateWorkflow, /context="Crawler Deploy Gate"/);
-  assert.match(crawlerDeployGateWorkflow, /Re-evaluate every ready PR at its exact head/);
-  assert.match(crawlerDeployGateWorkflow, /DRAFT: \$\{\{ github\.event\.pull_request\.draft \}\}/);
+  assert.match(crawlerDeployGateWorkflow, /group: crawler-deploy-gate-status-writer/);
+  assert.match(crawlerDeployGateWorkflow, /cancel-in-progress: false/);
+  assert.match(crawlerDeployGateWorkflow, /Re-evaluate every open PR at its exact head/);
+  assert.match(crawlerDeployGateWorkflow, /reconcile-crawler-deploy-gate\.sh/);
+  assert.match(reconcileCrawlerDeployGateScript, /statuses\/\$head_sha/);
+  assert.match(reconcileCrawlerDeployGateScript, /context="Crawler Deploy Gate"/);
+  assert.match(reconcileCrawlerDeployGateScript, /state=failure/);
+  assert.match(reconcileCrawlerDeployGateScript, /gh pr view "\$pr"/);
+  assert.match(
+    reconcileCrawlerDeployGateScript,
+    /Draft PR; no merge authority is granted/,
+  );
   assert.match(crawlerDeployGateScript, /\.previous_filename \/\/ empty/);
   assert.match(crawlerDeployGateScript, /deployment-hold:crawler/);
 });
@@ -1523,6 +1620,15 @@ test("crawler deploy gate blocks ready runtime changes during a hold", () => {
   assert.match(result.stderr, /#6632 Typesense capacity/);
   assert.match(result.calls, /pulls\/123\/files\?per_page=100/);
   assert.match(result.calls, /issue list.*deployment-hold:crawler/);
+});
+
+test("crawler deploy gate fails closed when PR file classification fails", () => {
+  const result = runCrawlerDeployGate({ fileApiStatus: 1 });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /could not classify files for PR #123/);
+  assert.doesNotMatch(result.stdout, /does not trigger/);
+  assert.doesNotMatch(result.calls, /issue list/);
 });
 
 test("crawler deploy gate mirrors runtime deploy path exclusions", () => {
@@ -1571,19 +1677,35 @@ test("crawler deploy gate permits a ready runtime change when holds are clear", 
   assert.match(result.stdout, /no deployment hold is active/);
 });
 
-test("a newly active hold revokes a prior ready runtime success", () => {
-  const beforeHold = runCrawlerDeployGate({
-    files: ["apps/crawler/src/core/monitor.py"],
-    holds: [],
-  });
-  const afterHold = runCrawlerDeployGate({
-    files: ["apps/crawler/src/core/monitor.py"],
+test("draft and hold transitions replace a prior ready success with failure", () => {
+  const ready = runCrawlerDeployReconciler();
+  const draft = runCrawlerDeployReconciler({ isDraft: true });
+  const readyDuringHold = runCrawlerDeployReconciler({
     holds: [{ number: 6632, title: "capacity", url: "https://example.test/6632" }],
   });
 
-  assert.equal(beforeHold.status, 0, beforeHold.stderr);
-  assert.equal(afterHold.status, 1);
-  assert.match(afterHold.stderr, /deployment is held/);
+  assert.equal(ready.status, 0, ready.stderr);
+  assert.match(ready.calls, /statuses\/a{40}.*-f state=success/);
+  assert.equal(draft.status, 0, draft.stderr);
+  assert.match(draft.calls, /statuses\/a{40}.*-f state=failure/);
+  assert.doesNotMatch(draft.calls, /pulls\/123\/files/);
+  assert.equal(readyDuringHold.status, 0, readyDuringHold.stderr);
+  assert.match(readyDuringHold.calls, /statuses\/a{40}.*-f state=failure/);
+});
+
+test("a stale queued evaluator converges every PR to the current hold state", () => {
+  const result = runCrawlerDeployReconciler({
+    holds: [{ number: 6632, title: "capacity", url: "https://example.test/6632" }],
+    prs: [
+      { number: 123, isDraft: false, headRefOid: "a".repeat(40) },
+      { number: 456, isDraft: false, headRefOid: "b".repeat(40) },
+    ],
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.calls, /statuses\/a{40}.*-f state=failure/);
+  assert.match(result.calls, /statuses\/b{40}.*-f state=failure/);
+  assert.equal((result.calls.match(/issue list/g) ?? []).length, 2);
 });
 
 test("workflow-dispatched CI publishes the Required CI status context", () => {

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -45,6 +45,14 @@ const dispatchPrChecksScript = readFileSync(
   ".github/scripts/dispatch-pr-checks.sh",
   "utf8",
 );
+const crawlerDeployGateWorkflow = readFileSync(
+  ".github/workflows/crawler-deploy-gate.yml",
+  "utf8",
+);
+const crawlerDeployGateScript = readFileSync(
+  ".github/scripts/check-crawler-deploy-gate.sh",
+  "utf8",
+);
 const labelPrScript = readFileSync(".github/scripts/label-pr.sh", "utf8");
 const labelPrCsvDiffHelper = ".github/scripts/label_pr_csv_diff.py";
 const publishMcpServerWorkflow = readFileSync(
@@ -147,6 +155,52 @@ printf '%s\\n' "$*" >> "$MOCK_GH_LOG"
     calls = readFileSync(log, "utf8");
   } catch {
     // A correctly skipped PR does not call `gh workflow run`.
+  }
+  rmSync(dir, { recursive: true, force: true });
+  return { ...result, calls };
+}
+
+function runCrawlerDeployGate({ draft = false, files = [], holds = [] } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "crawler-deploy-gate-"));
+  const log = join(dir, "gh.log");
+  const gh = join(dir, "gh");
+  writeFileSync(
+    gh,
+    `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$MOCK_GH_LOG"
+if [[ "$1" == "api" ]]; then
+  printf '%s\\n' "$MOCK_FILES"
+  exit 0
+fi
+if [[ "$1 $2" == "issue list" ]]; then
+  printf '%s' "$MOCK_HOLDS"
+  exit 0
+fi
+exit 1
+`,
+  );
+  chmodSync(gh, 0o755);
+  const result = spawnSync("bash", [".github/scripts/check-crawler-deploy-gate.sh"], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      PATH: `${dir}:${process.env.PATH}`,
+      GH_TOKEN: "test-token",
+      REPO: "colophon-group/jobseek",
+      PR: "123",
+      DRAFT: String(draft),
+      MOCK_GH_LOG: log,
+      MOCK_FILES: files.join("\n"),
+      MOCK_HOLDS: JSON.stringify(holds),
+    },
+    encoding: "utf8",
+  });
+  let calls = "";
+  try {
+    calls = readFileSync(log, "utf8");
+  } catch {
+    // Draft checks deliberately make no API calls.
   }
   rmSync(dir, { recursive: true, force: true });
   return { ...result, calls };
@@ -1403,7 +1457,7 @@ test("dependency review scopes the sharp libvips license exception", () => {
   assert.doesNotMatch(dependencyReviewJob, /allow-licenses:/);
 });
 
-test("main branch ruleset does not require non-path-aware code scanning", () => {
+test("main branch ruleset requires CI and the crawler deployment gate", () => {
   assert.equal(mainStrictGateRuleset.name, "main-strict-gate");
   assert.equal(
     mainStrictGateRuleset.rules.some((rule) => rule.type === "code_scanning"),
@@ -1419,11 +1473,117 @@ test("main branch ruleset does not require non-path-aware code scanning", () => 
     (check) => check.context,
   );
 
-  assert.deepEqual(contexts, ["Required CI"]);
-  assert.equal(
-    Object.hasOwn(statusRule.parameters.required_status_checks[0], "integration_id"),
-    false,
+  assert.deepEqual(contexts, ["Required CI", "Crawler Deploy Gate"]);
+  for (const check of statusRule.parameters.required_status_checks) {
+    assert.equal(Object.hasOwn(check, "integration_id"), false);
+  }
+});
+
+test("crawler deploy gate runs trusted and path-aware on PR state changes", () => {
+  assert.match(crawlerDeployGateWorkflow, /pull_request_target:/);
+  assert.match(crawlerDeployGateWorkflow, /issues:/);
+  assert.match(crawlerDeployGateWorkflow, /ready_for_review/);
+  assert.match(crawlerDeployGateWorkflow, /converted_to_draft/);
+  assert.match(crawlerDeployGateWorkflow, /deployment-hold:crawler/);
+  assert.match(crawlerDeployGateWorkflow, /permissions: \{\}/);
+  assert.match(
+    crawlerDeployGateWorkflow,
+    /ref: \$\{\{ github\.workflow_sha \}\}/,
   );
+  assert.match(crawlerDeployGateWorkflow, /persist-credentials: false/);
+  assert.match(crawlerDeployGateWorkflow, /statuses: write/);
+  assert.match(crawlerDeployGateWorkflow, /statuses\/\$HEAD_SHA/);
+  assert.match(crawlerDeployGateWorkflow, /context="Crawler Deploy Gate"/);
+  assert.match(crawlerDeployGateWorkflow, /Re-evaluate every ready PR at its exact head/);
+  assert.match(crawlerDeployGateWorkflow, /DRAFT: \$\{\{ github\.event\.pull_request\.draft \}\}/);
+  assert.match(crawlerDeployGateScript, /\.previous_filename \/\/ empty/);
+  assert.match(crawlerDeployGateScript, /deployment-hold:crawler/);
+});
+
+test("crawler deploy gate grants no authority or API access while draft", () => {
+  const result = runCrawlerDeployGate({
+    draft: true,
+    files: ["apps/crawler/src/core/monitor.py"],
+    holds: [{ number: 6632, title: "capacity", url: "https://example.test/6632" }],
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /draft; no merge authority is granted/);
+  assert.equal(result.calls, "");
+});
+
+test("crawler deploy gate blocks ready runtime changes during a hold", () => {
+  const result = runCrawlerDeployGate({
+    files: ["apps/crawler/src/core/monitor.py"],
+    holds: [{ number: 6632, title: "Typesense capacity", url: "https://example.test/6632" }],
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /changes crawler runtime paths while deployment is held/);
+  assert.match(result.stderr, /#6632 Typesense capacity/);
+  assert.match(result.calls, /pulls\/123\/files\?per_page=100/);
+  assert.match(result.calls, /issue list.*deployment-hold:crawler/);
+});
+
+test("crawler deploy gate mirrors runtime deploy path exclusions", () => {
+  const excluded = runCrawlerDeployGate({
+    files: [
+      "apps/crawler/data/companies.csv",
+      "apps/crawler/data/images/example/logo.png",
+      "apps/crawler/traces/example.json",
+      "apps/crawler/ws-package/README.txt",
+      "apps/crawler/docs/nested.md",
+    ],
+    holds: [{ number: 6632, title: "capacity", url: "https://example.test/6632" }],
+  });
+  const taxonomy = runCrawlerDeployGate({
+    files: ["apps/crawler/data/technologies.csv"],
+    holds: [{ number: 6632, title: "capacity", url: "https://example.test/6632" }],
+  });
+
+  assert.equal(excluded.status, 0, excluded.stderr);
+  assert.match(excluded.stdout, /does not trigger the crawler runtime deployment/);
+  assert.doesNotMatch(excluded.calls, /issue list/);
+  assert.equal(taxonomy.status, 1);
+});
+
+test("crawler deploy gate blocks a runtime file renamed into an excluded path", () => {
+  const result = runCrawlerDeployGate({
+    // The GitHub files query emits both filename and previous_filename.
+    files: [
+      "apps/crawler/data/archive/monitor.py",
+      "apps/crawler/src/core/monitor.py",
+    ],
+    holds: [{ number: 6632, title: "capacity", url: "https://example.test/6632" }],
+  });
+
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /apps\/crawler\/src\/core\/monitor\.py/);
+});
+
+test("crawler deploy gate permits a ready runtime change when holds are clear", () => {
+  const result = runCrawlerDeployGate({
+    files: ["scripts/derive-crawler-runtime-contract.mjs"],
+    holds: [],
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /no deployment hold is active/);
+});
+
+test("a newly active hold revokes a prior ready runtime success", () => {
+  const beforeHold = runCrawlerDeployGate({
+    files: ["apps/crawler/src/core/monitor.py"],
+    holds: [],
+  });
+  const afterHold = runCrawlerDeployGate({
+    files: ["apps/crawler/src/core/monitor.py"],
+    holds: [{ number: 6632, title: "capacity", url: "https://example.test/6632" }],
+  });
+
+  assert.equal(beforeHold.status, 0, beforeHold.stderr);
+  assert.equal(afterHold.status, 1);
+  assert.match(afterHold.stderr, /deployment is held/);
 });
 
 test("workflow-dispatched CI publishes the Required CI status context", () => {


### PR DESCRIPTION
## Summary
- require a trusted, path-aware `Crawler Deploy Gate` status on main
- revoke ready runtime PR status whenever `deployment-hold:crawler` changes
- document that final merge authority is a short-lived lease
- cover draft, active-hold, renamed-runtime, and hold-revocation cases

## Validation
- `node --test` (full Workflow Security script suite; 129 passed)
- `bash -n .github/scripts/check-crawler-deploy-gate.sh`
- `actionlint .github/workflows/crawler-deploy-gate.yml`
- `zizmor --persona regular --min-severity medium --min-confidence high .github/workflows/crawler-deploy-gate.yml`
- `git diff --check`

Closes #8052