### PR TITLE
Prevent stale-head runtime migration approvals

### DIFF
--- a/.github/rulesets/main-strict-gate.json
+++ b/.github/rulesets/main-strict-gate.json
@@ -21,6 +21,9 @@
           },
           {
             "context": "Crawler Deploy Gate"
+          },
+          {
+            "context": "Runtime Review Attestation"
           }
         ]
       }

--- a/.github/scripts/runtime-review-attestation.mjs
+++ b/.github/scripts/runtime-review-attestation.mjs
@@ -1,0 +1,493 @@
+#!/usr/bin/env node
+
+const MARKER = "<!-- jobseek-runtime-review-event:v1 -->";
+const SCHEMA = "jobseek.runtime-review-event/v1";
+const STATUS_CONTEXT = "Runtime Review Attestation";
+const BOT_LOGIN = "github-actions[bot]";
+const SHA = /^[0-9a-f]{40}$/;
+
+const GOVERNANCE_PATHS = new Set([
+  ".github/rulesets/main-strict-gate.json",
+  ".github/scripts/runtime-review-attestation.mjs",
+  ".github/workflows/runtime-review-attestation.yml",
+]);
+
+export function isRuntimeMigrationPath(path) {
+  if (GOVERNANCE_PATHS.has(path)) return true;
+  if (!path.startsWith("apps/crawler/")) return false;
+  return (
+    path.startsWith("apps/crawler/contracts/") ||
+    path.startsWith("apps/crawler/go/") ||
+    path.startsWith("apps/crawler/cmd/") ||
+    path.startsWith("apps/crawler/internal/") ||
+    path.endsWith(".go") ||
+    path.endsWith("/go.mod") ||
+    path.endsWith("/go.sum")
+  );
+}
+
+function exactKeys(value, expected) {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  return (
+    Object.keys(value).sort().join("\0") === [...expected].sort().join("\0")
+  );
+}
+
+export function validateRecord(record) {
+  const keys = [
+    "approved_head_sha",
+    "head_tree_sha",
+    "kind",
+    "outcome",
+    "pull_request",
+    "repair_count",
+    "repaired_from_head",
+    "repository",
+    "review_sequence",
+    "schema",
+  ];
+  if (!exactKeys(record, keys)) return "record fields are not exact";
+  if (record.schema !== SCHEMA) return "record schema is unsupported";
+  if (
+    typeof record.repository !== "string" ||
+    !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(record.repository)
+  ) {
+    return "record repository is invalid";
+  }
+  if (!Number.isSafeInteger(record.pull_request) || record.pull_request < 1) {
+    return "record pull request is invalid";
+  }
+  if (!SHA.test(record.approved_head_sha) || !SHA.test(record.head_tree_sha)) {
+    return "record commit or tree SHA is invalid";
+  }
+  if (record.kind === "head_observed") {
+    if (
+      record.outcome !== "invalidated" ||
+      record.review_sequence !== null ||
+      record.repair_count !== null ||
+      record.repaired_from_head !== null
+    ) {
+      return "head observation has approval metadata";
+    }
+    return null;
+  }
+  if (record.kind !== "approval" || record.outcome !== "approved") {
+    return "record outcome is not an approval or invalidation";
+  }
+  if (record.review_sequence === 1) {
+    if (record.repair_count !== 0 || record.repaired_from_head !== null) {
+      return "initial review has inconsistent repair metadata";
+    }
+    return null;
+  }
+  if (
+    record.review_sequence === 2 &&
+    record.repair_count === 1 &&
+    SHA.test(record.repaired_from_head) &&
+    record.repaired_from_head !== record.approved_head_sha
+  ) {
+    return null;
+  }
+  return "record exceeds the one-review/one-repair policy";
+}
+
+export function parseEventComments(comments) {
+  const events = [];
+  for (const comment of comments) {
+    if (!comment.body?.startsWith(`${MARKER}\n`)) continue;
+    if (comment.user?.login !== BOT_LOGIN) {
+      return {
+        error: "record marker was not published by the trusted workflow",
+      };
+    }
+    if (comment.created_at !== comment.updated_at) {
+      return { error: "a machine record was edited" };
+    }
+    let record;
+    try {
+      record = JSON.parse(comment.body.slice(MARKER.length + 1));
+    } catch {
+      return { error: "machine record contains malformed JSON" };
+    }
+    const error = validateRecord(record);
+    if (error) return { error };
+    events.push({ id: Number(comment.id), record });
+  }
+  events.sort((left, right) => left.id - right.id);
+  return { events };
+}
+
+export function validateTransition(previous, next) {
+  const error = validateRecord(next);
+  if (error) return error;
+  if (next.kind !== "approval") return "transition target is not an approval";
+  if (!previous) return null;
+  if (
+    previous.repository !== next.repository ||
+    previous.pull_request !== next.pull_request
+  ) {
+    return "approval transition crosses repository or pull request";
+  }
+  if (previous.approved_head_sha === next.approved_head_sha) {
+    return "an approval already exists for this exact head";
+  }
+  if (next.repair_count < previous.repair_count) {
+    return "approval transition rolls the repair count back";
+  }
+  if (previous.repair_count === 0 && next.repair_count === 0) {
+    return previous.head_tree_sha === next.head_tree_sha
+      ? null
+      : "changed content requires the one bounded repair";
+  }
+  if (previous.repair_count === 0 && next.repair_count === 1) {
+    return next.repaired_from_head === previous.approved_head_sha
+      ? null
+      : "repair predecessor does not match the previously approved head";
+  }
+  if (previous.repair_count === 1 && next.repair_count === 1) {
+    if (previous.repaired_from_head !== next.repaired_from_head) {
+      return "approval transition represents a second repair";
+    }
+    return previous.head_tree_sha === next.head_tree_sha
+      ? null
+      : "content changed after the repair budget was spent";
+  }
+  return "approval transition exceeds the one-repair budget";
+}
+
+function validateHistory(events) {
+  let priorApproval = null;
+  for (const event of events) {
+    if (event.record.kind !== "approval") continue;
+    const error = validateTransition(priorApproval, event.record);
+    if (error) return error;
+    priorApproval = event.record;
+  }
+  return null;
+}
+
+export function evaluateApproval({
+  repository,
+  pullRequest,
+  headAtStart,
+  treeAtStart,
+  headAtConclusion,
+  comments,
+  changedPaths,
+}) {
+  if (!changedPaths.some(isRuntimeMigrationPath)) {
+    return {
+      eligible: true,
+      scoped: false,
+      reason: "not a runtime migration PR",
+    };
+  }
+  if (headAtConclusion !== headAtStart) {
+    return {
+      eligible: false,
+      scoped: true,
+      reason: "PR head changed while the approval gate was evaluating",
+    };
+  }
+  const parsed = parseEventComments(comments);
+  if (parsed.error)
+    return { eligible: false, scoped: true, reason: parsed.error };
+  if (parsed.events.length === 0) {
+    return {
+      eligible: false,
+      scoped: true,
+      reason: "approval record is missing",
+    };
+  }
+  const historyError = validateHistory(parsed.events);
+  if (historyError) {
+    return { eligible: false, scoped: true, reason: historyError };
+  }
+  const latest = parsed.events.at(-1).record;
+  if (latest.kind !== "approval") {
+    return {
+      eligible: false,
+      scoped: true,
+      reason: "the latest head observation has no current approval",
+    };
+  }
+  const sameHeadApprovals = parsed.events.filter(
+    (event) =>
+      event.record.kind === "approval" &&
+      event.record.approved_head_sha === latest.approved_head_sha,
+  );
+  if (sameHeadApprovals.length !== 1) {
+    return {
+      eligible: false,
+      scoped: true,
+      reason: "multiple or conflicting approval records target the same head",
+    };
+  }
+  if (latest.repository !== repository || latest.pull_request !== pullRequest) {
+    return {
+      eligible: false,
+      scoped: true,
+      reason: "approval record targets another repository or pull request",
+    };
+  }
+  if (latest.approved_head_sha !== headAtStart) {
+    return {
+      eligible: false,
+      scoped: true,
+      reason:
+        latest.head_tree_sha === treeAtStart
+          ? "approval is stale: current commit changed even though its tree is identical"
+          : "approval is stale: current commit changed",
+    };
+  }
+  if (latest.head_tree_sha !== treeAtStart) {
+    return {
+      eligible: false,
+      scoped: true,
+      reason: "approval tree diagnostic does not match the approved commit",
+    };
+  }
+  return {
+    eligible: true,
+    scoped: true,
+    reason: `exact head approved at review sequence ${latest.review_sequence}`,
+  };
+}
+
+function body(record) {
+  return `${MARKER}\n${JSON.stringify(record)}`;
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+async function api(path, options = {}) {
+  const response = await fetch(`${requiredEnv("GITHUB_API_URL")}${path}`, {
+    ...options,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${requiredEnv("GH_TOKEN")}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...(options.headers ?? {}),
+    },
+  });
+  if (!response.ok) {
+    throw new Error(
+      `GitHub API ${options.method ?? "GET"} ${path} returned ${response.status}`,
+    );
+  }
+  if (response.status === 204) return null;
+  return response.json();
+}
+
+async function paginate(path) {
+  const values = [];
+  for (let page = 1; ; page += 1) {
+    const separator = path.includes("?") ? "&" : "?";
+    const batch = await api(`${path}${separator}per_page=100&page=${page}`);
+    if (!Array.isArray(batch))
+      throw new Error(`${path} did not return an array`);
+    values.push(...batch);
+    if (batch.length < 100) return values;
+  }
+}
+
+async function pullState(repository, pullRequest) {
+  const pull = await api(`/repos/${repository}/pulls/${pullRequest}`);
+  if (pull.state !== "open" || !SHA.test(pull.head?.sha)) {
+    throw new Error(`PR #${pullRequest} is not open or has an invalid head`);
+  }
+  return pull;
+}
+
+async function treeFor(repository, head) {
+  const commit = await api(`/repos/${repository}/git/commits/${head}`);
+  if (!SHA.test(commit.tree?.sha))
+    throw new Error(`commit ${head} has no valid tree`);
+  return commit.tree.sha;
+}
+
+async function commentsFor(repository, pullRequest) {
+  return paginate(`/repos/${repository}/issues/${pullRequest}/comments`);
+}
+
+async function pathsFor(repository, pullRequest) {
+  const files = await paginate(
+    `/repos/${repository}/pulls/${pullRequest}/files`,
+  );
+  return files.flatMap((file) =>
+    [file.filename, file.previous_filename].filter(
+      (path) => typeof path === "string" && path.length > 0,
+    ),
+  );
+}
+
+async function appendRecord(repository, pullRequest, record) {
+  await api(`/repos/${repository}/issues/${pullRequest}/comments`, {
+    method: "POST",
+    body: JSON.stringify({ body: body(record) }),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function observeCommand() {
+  const repository = requiredEnv("REPO");
+  const pullRequest = Number(requiredEnv("PR"));
+  const first = await pullState(repository, pullRequest);
+  const tree = await treeFor(repository, first.head.sha);
+  const final = await pullState(repository, pullRequest);
+  if (final.head.sha !== first.head.sha) {
+    throw new Error("PR head changed while recording synchronization");
+  }
+  await appendRecord(repository, pullRequest, {
+    schema: SCHEMA,
+    kind: "head_observed",
+    repository,
+    pull_request: pullRequest,
+    approved_head_sha: first.head.sha,
+    head_tree_sha: tree,
+    outcome: "invalidated",
+    review_sequence: null,
+    repair_count: null,
+    repaired_from_head: null,
+  });
+}
+
+async function publishStatus(repository, head, result) {
+  await api(`/repos/${repository}/statuses/${head}`, {
+    method: "POST",
+    body: JSON.stringify({
+      state: result.eligible ? "success" : "failure",
+      context: STATUS_CONTEXT,
+      description: result.reason.slice(0, 140),
+      target_url: requiredEnv("TARGET_URL"),
+    }),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function checkPull(repository, pullRequest) {
+  const initial = await pullState(repository, pullRequest);
+  const headAtStart = initial.head.sha;
+  const [treeAtStart, comments, changedPaths] = await Promise.all([
+    treeFor(repository, headAtStart),
+    commentsFor(repository, pullRequest),
+    pathsFor(repository, pullRequest),
+  ]);
+  const final = await pullState(repository, pullRequest);
+  const result = evaluateApproval({
+    repository,
+    pullRequest,
+    headAtStart,
+    treeAtStart,
+    headAtConclusion: final.head.sha,
+    comments,
+    changedPaths,
+  });
+  if (final.head.sha !== headAtStart) {
+    await publishStatus(repository, headAtStart, {
+      eligible: false,
+      reason: result.reason,
+    });
+  }
+  await publishStatus(repository, final.head.sha, result);
+  console.log(
+    `PR #${pullRequest}: ${result.eligible ? "PASS" : "BLOCK"}: ${result.reason}`,
+  );
+}
+
+async function checkCommand() {
+  const repository = requiredEnv("REPO");
+  if (process.env.PR) {
+    await checkPull(repository, Number(process.env.PR));
+    return;
+  }
+  const pulls = await paginate(`/repos/${repository}/pulls?state=open`);
+  for (const pull of pulls) await checkPull(repository, pull.number);
+}
+
+async function publishCommand() {
+  const repository = requiredEnv("REPO");
+  const pullRequest = Number(requiredEnv("PR"));
+  const expectedHead = requiredEnv("EXPECTED_HEAD_SHA");
+  if (requiredEnv("REF_NAME") !== requiredEnv("DEFAULT_BRANCH")) {
+    throw new Error("approval publication must run from the default branch");
+  }
+  if (
+    !Number.isSafeInteger(pullRequest) ||
+    pullRequest < 1 ||
+    !SHA.test(expectedHead)
+  ) {
+    throw new Error("PR number or expected head is invalid");
+  }
+  const pull = await pullState(repository, pullRequest);
+  if (pull.head.sha !== expectedHead) {
+    throw new Error(
+      `expected head ${expectedHead} is stale; live head is ${pull.head.sha}`,
+    );
+  }
+  const tree = await treeFor(repository, expectedHead);
+  const repairedFrom = process.env.REPAIRED_FROM_HEAD?.trim() || null;
+  const record = {
+    schema: SCHEMA,
+    kind: "approval",
+    repository,
+    pull_request: pullRequest,
+    approved_head_sha: expectedHead,
+    head_tree_sha: tree,
+    outcome: "approved",
+    review_sequence: Number(requiredEnv("REVIEW_SEQUENCE")),
+    repair_count: Number(requiredEnv("REPAIR_COUNT")),
+    repaired_from_head: repairedFrom,
+  };
+  const error = validateRecord(record);
+  if (error) throw new Error(error);
+  const parsed = parseEventComments(await commentsFor(repository, pullRequest));
+  if (parsed.error) throw new Error(parsed.error);
+  const approvals = parsed.events.filter(
+    (event) => event.record.kind === "approval",
+  );
+  if (
+    approvals.some((event) => event.record.approved_head_sha === expectedHead)
+  ) {
+    throw new Error(
+      "a prior approval for this exact head cannot be reactivated",
+    );
+  }
+  const transitionError = validateTransition(
+    approvals.at(-1)?.record ?? null,
+    record,
+  );
+  if (transitionError) throw new Error(transitionError);
+  const final = await pullState(repository, pullRequest);
+  if (final.head.sha !== expectedHead) {
+    throw new Error("PR head changed before approval publication");
+  }
+  await appendRecord(repository, pullRequest, record);
+  console.log(
+    `Published exact-head approval for PR #${pullRequest} at ${expectedHead}`,
+  );
+}
+
+async function main() {
+  if (process.argv[2] === "observe") return observeCommand();
+  if (process.argv[2] === "check") return checkCommand();
+  if (process.argv[2] === "publish") return publishCommand();
+  throw new Error(
+    "usage: runtime-review-attestation.mjs <observe|check|publish>",
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(`ERROR: ${error.message}`);
+    process.exitCode = 1;
+  });
+}
+
+export { BOT_LOGIN, MARKER, SCHEMA };

--- a/.github/workflows/runtime-review-attestation.yml
+++ b/.github/workflows/runtime-review-attestation.yml
@@ -1,0 +1,144 @@
+name: Runtime Review Attestation
+
+on:
+  pull_request_target:
+    types:
+      [
+        opened,
+        synchronize,
+        reopened,
+        ready_for_review,
+        converted_to_draft,
+        edited,
+      ]
+  issue_comment:
+    types: [created, edited, deleted]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: Pull request number
+        required: true
+        type: number
+      expected_head_sha:
+        description: Exact reviewed PR head SHA
+        required: true
+        type: string
+      review_sequence:
+        description: 1 for initial review, 2 for the single repaired verification
+        required: true
+        type: choice
+        options: ["1", "2"]
+      repair_count:
+        description: 0 initially, 1 after the single bounded repair
+        required: true
+        type: choice
+        options: ["0", "1"]
+      repaired_from_head:
+        description: Exact predecessor SHA required when repair_count is 1
+        required: false
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: >-
+    runtime-review-attestation-${{
+      inputs.pr || github.event.pull_request.number ||
+      github.event.issue.number || github.run_id
+    }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      github.ref_name == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Check out trusted default-branch code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Publish exact-head approval record
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          REPO: ${{ github.repository }}
+          PR: ${{ inputs.pr }}
+          EXPECTED_HEAD_SHA: ${{ inputs.expected_head_sha }}
+          REVIEW_SEQUENCE: ${{ inputs.review_sequence }}
+          REPAIR_COUNT: ${{ inputs.repair_count }}
+          REPAIRED_FROM_HEAD: ${{ inputs.repaired_from_head }}
+          REF_NAME: ${{ github.ref_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: node .github/scripts/runtime-review-attestation.mjs publish
+
+  evaluate-pr:
+    if: >-
+      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+      statuses: write
+    steps:
+      - name: Check out trusted default-branch code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Record a head transition before evaluation
+        if: >-
+          (github.event_name == 'pull_request_target' &&
+           (github.event.action == 'opened' || github.event.action == 'synchronize')) ||
+          (github.event_name == 'issue_comment' &&
+           (github.event.action == 'edited' || github.event.action == 'deleted'))
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number || github.event.issue.number }}
+        run: node .github/scripts/runtime-review-attestation.mjs observe
+
+      - name: Re-evaluate the live pull request head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number || github.event.issue.number }}
+          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node .github/scripts/runtime-review-attestation.mjs check
+
+  reconcile-open-prs:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
+      statuses: write
+    steps:
+      - name: Check out trusted default-branch code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Reconcile every open pull request at its live head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          REPO: ${{ github.repository }}
+          TARGET_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node .github/scripts/runtime-review-attestation.mjs check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,3 +237,8 @@ See [docs/13-seo-and-indexnow.md](docs/13-seo-and-indexnow.md).
   issue labelled `deployment-hold:crawler` intentionally blocks that check.
   Do not remove the label or bypass/weaken the check unless the operator has
   explicitly cleared the underlying production condition.
+- Runtime-migration PRs must have a green `Runtime Review Attestation` on the
+  exact live head. Ready state and an approval/status on an older head grant no
+  merge authority. Publish or renew the machine record through the trusted
+  default-branch workflow documented in
+  `docs/22-runtime-review-attestation.md`; do not hand-edit machine comments.

--- a/docs/22-runtime-review-attestation.md
+++ b/docs/22-runtime-review-attestation.md
@@ -1,0 +1,70 @@
+# Runtime migration exact-head approval guard
+
+The `Runtime Review Attestation` required status prevents a crawler runtime
+migration PR from retaining approval after its head commit changes. It was
+introduced after PR #8060 gained a late commit after the recorded review head.
+
+## Security claim
+
+This is an accidental-drift guard, not an identity or cryptographic
+attestation system. All current agents use the same `viktor-shcherb` GitHub
+credential. The workflow cannot prove which agent supplied an approval, prove
+writer/reviewer independence, or resist deliberate forgery by someone holding
+that credential. Those properties require a separately credentialed app,
+broker, or human principal and are explicitly out of scope.
+
+The repository control provides two narrower guarantees:
+
+- evaluation and record publication execute code checked out from the default
+  branch, never code from the PR;
+- the required status succeeds only when the latest unedited workflow-published
+  JSON record is an approval naming the exact live PR head. The tree SHA is
+  checked diagnostic metadata and never substitutes for commit identity.
+
+## Append-only records
+
+Machine comments begin with
+`<!-- jobseek-runtime-review-event:v1 -->` and contain one JSON object. A head
+observation invalidates prior approval whenever GitHub reports a synchronization
+or when a machine comment is edited or deleted. This append-only transition is
+why moving from head H0 to H1 and then back to H0 cannot reactivate H0's old
+approval.
+
+An approval record contains the schema, repository, PR number, approved head
+and tree SHAs, outcome, review sequence, repair count, and optional
+repaired-from head. Sequence 1 is the initial review with repair count 0.
+Sequence 2 is the only bounded repair, with repair count 1 and an exact
+predecessor SHA. The gate rejects counter rollback, mismatched lineage, changed
+content after the repair, malformed or edited records, and duplicate approval
+for a previously approved head.
+
+Publish a freshly observed initial approval from the default branch:
+
+```bash
+gh workflow run runtime-review-attestation.yml \
+  --ref main \
+  -f pr=<PR> \
+  -f expected_head_sha=<40-character-live-head> \
+  -f review_sequence=1 \
+  -f repair_count=0
+```
+
+After the single bounded repair, use sequence 2, repair count 1, and
+`-f repaired_from_head=<previous-approved-head>`. The publisher re-reads the
+head immediately before appending the record. The record's comment-created
+event then causes a fresh evaluation.
+
+Every synchronize, rebase, force-push, or new commit makes the prior record
+stale. A different commit with the same tree also remains stale. Ready state,
+labels, PR prose, and a successful status on an older commit grant no
+authority. The evaluator re-reads the live PR head immediately before posting
+its status and fails the newly observed head if it moved during evaluation.
+
+## Activation
+
+`.github/rulesets/main-strict-gate.json` declares `Runtime Review Attestation`
+as a required context. Updating that checked-in file does not mutate GitHub's
+live ruleset. After this change reaches `main`, an authorized operator must
+reconcile the live `main-strict-gate` ruleset separately, then verify an
+in-scope test PR cannot merge with a missing or stale record. The next
+migration lane remains blocked until that post-merge activation succeeds.

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,6 +43,9 @@ Status tags:
 - [23 - Go and Lightpanda Crawler Migration](23-go-lightpanda-migration.md)
   `[reference]` - global-scale runtime replacement boundaries, capacity floor,
   cutover safety, replay, metrics, Murmur coordination, and retirement plan.
+- [22 - Runtime Migration Exact-Head Approval](22-runtime-review-attestation.md)
+  `[reference]` - required accidental-drift guard, append-only record lifecycle,
+  threat-model limits, and activation procedure for migration PRs.
 
 ## Search, SEO, And Web Read Paths
 

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -13,6 +13,7 @@ import test from "node:test";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { spawnSync } from "node:child_process";
+import "./runtime-review-attestation.test.mjs";
 
 const workflow = readFileSync(".github/workflows/ci.yml", "utf8");
 const webBuildEnvAction = readFileSync(
@@ -47,6 +48,14 @@ const dispatchPrChecksScript = readFileSync(
 );
 const crawlerDeployGateWorkflow = readFileSync(
   ".github/workflows/crawler-deploy-gate.yml",
+  "utf8",
+);
+const runtimeReviewAttestationWorkflow = readFileSync(
+  ".github/workflows/runtime-review-attestation.yml",
+  "utf8",
+);
+const runtimeReviewAttestationScript = readFileSync(
+  ".github/scripts/runtime-review-attestation.mjs",
   "utf8",
 );
 const crawlerDeployGateScript = readFileSync(
@@ -1546,7 +1555,7 @@ test("dependency review scopes the sharp libvips license exception", () => {
   assert.doesNotMatch(dependencyReviewJob, /allow-licenses:/);
 });
 
-test("main branch ruleset requires CI and the crawler deployment gate", () => {
+test("main branch ruleset requires CI and both crawler governance gates", () => {
   assert.equal(mainStrictGateRuleset.name, "main-strict-gate");
   assert.equal(
     mainStrictGateRuleset.rules.some((rule) => rule.type === "code_scanning"),
@@ -1562,10 +1571,42 @@ test("main branch ruleset requires CI and the crawler deployment gate", () => {
     (check) => check.context,
   );
 
-  assert.deepEqual(contexts, ["Required CI", "Crawler Deploy Gate"]);
+  assert.deepEqual(contexts, [
+    "Required CI",
+    "Crawler Deploy Gate",
+    "Runtime Review Attestation",
+  ]);
   for (const check of statusRule.parameters.required_status_checks) {
     assert.equal(Object.hasOwn(check, "integration_id"), false);
   }
+});
+
+test("runtime review gate uses trusted code and exact live-head status", () => {
+  assert.match(runtimeReviewAttestationWorkflow, /pull_request_target:/);
+  assert.match(runtimeReviewAttestationWorkflow, /issue_comment:/);
+  assert.match(
+    runtimeReviewAttestationWorkflow,
+    /pull_request_target:[\s\S]*opened,[\s\S]*synchronize,[\s\S]*reopened,[\s\S]*ready_for_review/,
+  );
+  assert.match(
+    runtimeReviewAttestationWorkflow,
+    /types: \[created, edited, deleted\]/,
+  );
+  assert.match(
+    runtimeReviewAttestationWorkflow,
+    /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/,
+  );
+  assert.match(runtimeReviewAttestationWorkflow, /persist-credentials: false/);
+  assert.match(runtimeReviewAttestationWorkflow, /statuses: write/);
+  assert.match(runtimeReviewAttestationWorkflow, /cancel-in-progress: false/);
+  assert.match(runtimeReviewAttestationWorkflow, /runtime-review-attestation-\$\{\{/);
+  assert.match(
+    runtimeReviewAttestationScript,
+    /const STATUS_CONTEXT = "Runtime Review Attestation"/,
+  );
+  assert.match(runtimeReviewAttestationScript, /const final = await pullState/);
+  assert.match(runtimeReviewAttestationScript, /final\.head\.sha !== headAtStart/);
+  assert.doesNotMatch(runtimeReviewAttestationWorkflow, /pull_request:\n/);
 });
 
 test("crawler deploy gate runs trusted and path-aware on PR state changes", () => {

--- a/scripts/runtime-review-attestation.test.mjs
+++ b/scripts/runtime-review-attestation.test.mjs
@@ -1,0 +1,265 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  BOT_LOGIN,
+  MARKER,
+  SCHEMA,
+  evaluateApproval,
+  isRuntimeMigrationPath,
+  validateTransition,
+} from "../.github/scripts/runtime-review-attestation.mjs";
+
+const repository = "colophon-group/jobseek";
+const pullRequest = 8060;
+const reviewed = "1b0e7f2ec00212088396a5d9a98b4d702d5111b8";
+const late = "b0816915b01748296506ae587b52347cc4e262c9";
+const rebased = "9c5b0e77a266e2b57decb22c5cc303bd181a9089";
+const forcePushed = "a".repeat(40);
+const tree = "15f2be386de875b7684f45222268962857700c32";
+const changedTree = "b".repeat(40);
+
+function approval({
+  head = reviewed,
+  headTree = tree,
+  sequence = 1,
+  repairCount = 0,
+  repairedFrom = null,
+} = {}) {
+  return {
+    schema: SCHEMA,
+    kind: "approval",
+    repository,
+    pull_request: pullRequest,
+    approved_head_sha: head,
+    head_tree_sha: headTree,
+    outcome: "approved",
+    review_sequence: sequence,
+    repair_count: repairCount,
+    repaired_from_head: repairedFrom,
+  };
+}
+
+function observation(head, headTree) {
+  return {
+    schema: SCHEMA,
+    kind: "head_observed",
+    repository,
+    pull_request: pullRequest,
+    approved_head_sha: head,
+    head_tree_sha: headTree,
+    outcome: "invalidated",
+    review_sequence: null,
+    repair_count: null,
+    repaired_from_head: null,
+  };
+}
+
+function comment(record, { id = 1, edited = false, login = BOT_LOGIN } = {}) {
+  return {
+    id,
+    user: { login },
+    created_at: "2026-08-26T18:00:00Z",
+    updated_at: edited ? "2026-08-26T18:01:00Z" : "2026-08-26T18:00:00Z",
+    body: `${MARKER}\n${JSON.stringify(record)}`,
+  };
+}
+
+function evaluate({
+  headAtStart = reviewed,
+  treeAtStart = tree,
+  headAtConclusion = headAtStart,
+  comments = [comment(approval())],
+  changedPaths = ["apps/crawler/contracts/v1/runtime.proto"],
+} = {}) {
+  return evaluateApproval({
+    repository,
+    pullRequest,
+    headAtStart,
+    treeAtStart,
+    headAtConclusion,
+    comments,
+    changedPaths,
+  });
+}
+
+test("allows one valid approval only on the exact current head", () => {
+  assert.deepEqual(evaluate(), {
+    eligible: true,
+    scoped: true,
+    reason: "exact head approved at review sequence 1",
+  });
+});
+
+test("reproduces #8060 late-commit stale approval", () => {
+  const result = evaluate({ headAtStart: late, treeAtStart: changedTree });
+  assert.equal(result.eligible, false);
+  assert.match(result.reason, /stale: current commit changed$/);
+});
+
+test("same-tree new commits and ordinary or force-pushed rebases are stale", () => {
+  for (const head of [late, rebased, forcePushed]) {
+    const result = evaluate({ headAtStart: head, treeAtStart: tree });
+    assert.equal(result.eligible, false);
+    assert.match(result.reason, /tree is identical/);
+  }
+});
+
+test("H0 to H1 to H0 cannot reactivate the old H0 approval", () => {
+  const result = evaluate({
+    comments: [
+      comment(approval(), { id: 1 }),
+      comment(observation(late, changedTree), { id: 2 }),
+      comment(observation(reviewed, tree), { id: 3 }),
+    ],
+  });
+  assert.equal(result.eligible, false);
+  assert.match(
+    result.reason,
+    /latest head observation has no current approval/,
+  );
+});
+
+test("head movement during evaluation fails before any approval can pass", () => {
+  const result = evaluate({ headAtConclusion: late });
+  assert.equal(result.eligible, false);
+  assert.match(result.reason, /changed while.*evaluating/);
+});
+
+test("missing or deleted current approval fails closed", () => {
+  assert.match(evaluate({ comments: [] }).reason, /missing/);
+  assert.match(
+    evaluate({ comments: [comment(observation(reviewed, tree))] }).reason,
+    /no current approval/,
+  );
+});
+
+test("malformed, edited, and non-workflow records fail closed", () => {
+  const malformed = { ...comment(approval()), body: `${MARKER}\n{` };
+  assert.match(evaluate({ comments: [malformed] }).reason, /malformed/);
+  assert.match(
+    evaluate({ comments: [comment(approval(), { edited: true })] }).reason,
+    /edited/,
+  );
+  assert.match(
+    evaluate({ comments: [comment(approval(), { login: "viktor-shcherb" })] })
+      .reason,
+    /trusted workflow/,
+  );
+});
+
+test("duplicate or conflicting records for one head fail closed", () => {
+  const result = evaluate({
+    comments: [comment(approval(), { id: 1 }), comment(approval(), { id: 2 })],
+  });
+  assert.equal(result.eligible, false);
+  assert.match(result.reason, /already exists|multiple or conflicting/);
+});
+
+test("one bounded repair succeeds with exact predecessor lineage", () => {
+  const repaired = approval({
+    head: late,
+    headTree: changedTree,
+    sequence: 2,
+    repairCount: 1,
+    repairedFrom: reviewed,
+  });
+  const result = evaluate({
+    headAtStart: late,
+    treeAtStart: changedTree,
+    comments: [
+      comment(approval(), { id: 1 }),
+      comment(observation(late, changedTree), { id: 2 }),
+      comment(repaired, { id: 3 }),
+    ],
+  });
+  assert.equal(result.eligible, true);
+  assert.match(result.reason, /sequence 2/);
+});
+
+test("repair rollback, mismatched lineage, and a second repair are rejected", () => {
+  const repaired = approval({
+    head: late,
+    headTree: changedTree,
+    sequence: 2,
+    repairCount: 1,
+    repairedFrom: reviewed,
+  });
+  const rollback = evaluate({
+    comments: [
+      comment(repaired, { id: 1 }),
+      comment(observation(forcePushed, tree), { id: 2 }),
+      comment(approval({ head: forcePushed }), { id: 3 }),
+    ],
+    headAtStart: forcePushed,
+  });
+  assert.match(rollback.reason, /rolls the repair count back/);
+
+  const badLineage = validateTransition(
+    approval(),
+    approval({
+      head: late,
+      headTree: changedTree,
+      sequence: 2,
+      repairCount: 1,
+      repairedFrom: forcePushed,
+    }),
+  );
+  assert.match(badLineage, /predecessor/);
+
+  const second = validateTransition(
+    repaired,
+    approval({
+      head: forcePushed,
+      headTree: "c".repeat(40),
+      sequence: 2,
+      repairCount: 1,
+      repairedFrom: reviewed,
+    }),
+  );
+  assert.match(second, /budget was spent/);
+});
+
+test("same-tree fresh approval preserves the existing repair budget", () => {
+  assert.equal(
+    validateTransition(approval(), approval({ head: rebased })),
+    null,
+  );
+  const repaired = approval({
+    head: late,
+    headTree: changedTree,
+    sequence: 2,
+    repairCount: 1,
+    repairedFrom: reviewed,
+  });
+  assert.equal(
+    validateTransition(
+      repaired,
+      approval({
+        head: forcePushed,
+        headTree: changedTree,
+        sequence: 2,
+        repairCount: 1,
+        repairedFrom: reviewed,
+      }),
+    ),
+    null,
+  );
+});
+
+test("scope includes contracts, Go, and the guard itself only", () => {
+  for (const path of [
+    "apps/crawler/contracts/v1/runtime.proto",
+    "apps/crawler/internal/worker/worker.go",
+    "apps/crawler/go.mod",
+    ".github/workflows/runtime-review-attestation.yml",
+  ]) {
+    assert.equal(isRuntimeMigrationPath(path), true, path);
+  }
+  assert.equal(isRuntimeMigrationPath("apps/crawler/data/boards.csv"), false);
+  assert.equal(isRuntimeMigrationPath("apps/web/app/page.tsx"), false);
+  assert.equal(
+    evaluate({ changedPaths: ["apps/web/app/page.tsx"] }).eligible,
+    true,
+  );
+});


### PR DESCRIPTION
Closes #8061
Parent: #7937
Epic: #7935
Blocks: #8057

## Outcome

Adds the narrow accidental-drift guard chosen in #8061. Trusted default-branch automation appends head-observation and approval records, then writes `Runtime Review Attestation` only when the latest unedited machine record approves the exact live PR head. A final API reread prevents an evaluation from succeeding after the head moves. Tree equality is diagnostic only, so same-tree rebases and H0→H1→H0 remain invalidated until freshly approved.

The append-only transition state enforces one initial review and at most one bounded repair. Missing, stale, malformed, edited, deleted, duplicate/conflicting, rollback, mismatched-lineage, and second-repair state fails closed. Ready state, labels, PR prose, and an older successful status grant no authority.

The threat model is deliberately narrow: this prevents accidental stale-head reuse but does not authenticate agent independence or resist deliberate forgery by the shared `viktor-shcherb` credential. No app, broker, external service, cryptography, merge queue, crawler runtime, contract, or deployment behavior is added.

## Verification

Exact base: `0afefaa9f4a989b49f7d55b03257136d07d87263`
Exact head: `59de389ddc6de98e4e6c8cbc40328f5f5ea406c3`

- focused guard scenarios: 12/12 passed
- combined guard + CI workflow suite: 87/87 passed
- complete Workflow Security Node suite: 145/145 passed
- `actionlint`: passed
- Node syntax, JSON, authored-artifact Prettier, and `git diff --check`: passed
- commit/push hooks: passed

## Activation boundary

This PR only updates the checked-in `main-strict-gate` ruleset declaration. It does not mutate the live GitHub ruleset. After merge, an authorized operator must reconcile and verify the live required context before #8057 is unblocked.

Keep draft for the sole independent exact-head review. Do not mark ready or merge from implementation authority.
