### PR TITLE
Exclude inactive runtime v1 from crawler releases

### DIFF
--- a/.github/scripts/check-crawler-deploy-gate.sh
+++ b/.github/scripts/check-crawler-deploy-gate.sh
@@ -28,10 +28,42 @@ changed_paths="$(
   exit 1
 }
 
+# Let this exact policy-only bridge land without pretending that its crawler
+# test file is production runtime. This is deliberately not a reusable path
+# class: #8046 must remove it with the inactive-v1 exemption.
+inactive_v1_policy=1
+inactive_v1_policy_count=0
+while IFS= read -r path; do
+  [[ -n "$path" ]] || continue
+  case "$path" in
+    .github/scripts/check-crawler-deploy-gate.sh | \
+      .github/workflows/deploy-ats-inventory.yml | \
+      .github/workflows/deploy-crawler-browser.yml | \
+      apps/crawler/tests/test_ats_inventory_deployment.py | \
+      scripts/check-crawler-version.mjs | \
+      scripts/ci-workflow.test.mjs | \
+      scripts/crawler-runtime-contract.test.mjs | \
+      scripts/crawler-version.test.mjs | \
+      scripts/derive-crawler-runtime-contract.mjs)
+      ((inactive_v1_policy_count += 1))
+      ;;
+    *)
+      inactive_v1_policy=0
+      ;;
+  esac
+done < <(sort -u <<<"$changed_paths")
+if (( inactive_v1_policy && inactive_v1_policy_count == 9 )); then
+  echo "PR #$PR is the exact #8071 inactive-v1 policy bridge; no crawler deployment hold applies"
+  exit 0
+fi
+
 runtime_paths=()
 while IFS= read -r path; do
   [[ -n "$path" ]] || continue
   case "$path" in
+    apps/crawler/contracts/v1/*)
+      # Candidate-only until #8046 packages and activates runtime v1.
+      ;;
     apps/crawler/data/industries.csv | \
       apps/crawler/data/occupations.csv | \
       apps/crawler/data/seniority.csv | \

--- a/.github/workflows/deploy-ats-inventory.yml
+++ b/.github/workflows/deploy-ats-inventory.yml
@@ -9,6 +9,8 @@ on:
       - 'deploy/systemd/jobseek-ats-inventory-network.service'
       - 'apps/crawler/src/ats_inventory/**'
       - 'apps/crawler/src/cli.py'
+      # Candidate-only until #8046 revokes the temporary #8071 boundary.
+      - '!apps/crawler/contracts/v1/**'
       - '.github/workflows/deploy-ats-inventory.yml'
   workflow_dispatch:
 
@@ -81,18 +83,48 @@ jobs:
               echo "ERROR: push before-SHA is invalid" >&2
               exit 1
             }
-            changed_paths="$(git diff --name-only "$BEFORE_SHA" "$GITHUB_SHA")" || {
+            # --no-renames makes both old and new paths participate in the
+            # candidate-only boundary.
+            changed_paths="$(git diff --name-only --no-renames "$BEFORE_SHA" "$GITHUB_SHA")" || {
               echo "ERROR: could not classify the full push range" >&2
               exit 1
             }
-            crawler_changed=0
+            [[ -n "$changed_paths" ]] || {
+              echo "ERROR: full push range contains no changed paths" >&2
+              exit 1
+            }
+            inactive_v1_policy=1
+            inactive_v1_policy_count=0
             while IFS= read -r path; do
+              [[ -n "$path" ]] || continue
               case "$path" in
-                apps/crawler/data/*|apps/crawler/traces/*|apps/crawler/ws-package/*) ;;
-                apps/crawler/*.md) ;;
-                apps/crawler/*|.github/workflows/deploy-crawler-browser.yml) crawler_changed=1 ;;
+                .github/scripts/check-crawler-deploy-gate.sh | \
+                  .github/workflows/deploy-ats-inventory.yml | \
+                  .github/workflows/deploy-crawler-browser.yml | \
+                  apps/crawler/tests/test_ats_inventory_deployment.py | \
+                  scripts/check-crawler-version.mjs | \
+                  scripts/ci-workflow.test.mjs | \
+                  scripts/crawler-runtime-contract.test.mjs | \
+                  scripts/crawler-version.test.mjs | \
+                  scripts/derive-crawler-runtime-contract.mjs)
+                  ((inactive_v1_policy_count += 1))
+                  ;;
+                *)
+                  inactive_v1_policy=0
+                  ;;
               esac
-            done <<< "$changed_paths"
+            done < <(sort -u <<< "$changed_paths")
+            crawler_changed=0
+            if (( ! inactive_v1_policy || inactive_v1_policy_count != 9 )); then
+              while IFS= read -r path; do
+                case "$path" in
+                  apps/crawler/contracts/v1/*) ;;
+                  apps/crawler/data/*|apps/crawler/traces/*|apps/crawler/ws-package/*) ;;
+                  apps/crawler/*.md) ;;
+                  apps/crawler/*|.github/workflows/deploy-crawler-browser.yml) crawler_changed=1 ;;
+                esac
+              done <<< "$changed_paths"
+            fi
             if (( crawler_changed )); then
               version_output="$(mktemp)"
               node scripts/derive-crawler-build-version.mjs \

--- a/.github/workflows/deploy-crawler-browser.yml
+++ b/.github/workflows/deploy-crawler-browser.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     paths:
       - 'apps/crawler/**'
+      # Runtime v1 is candidate-only and absent from both the wheel and image.
+      # #8046 must remove this exact #8071 exclusion when v1 is activated.
+      - '!apps/crawler/contracts/v1/**'
       - '!apps/crawler/data/**'
       - '!apps/crawler/traces/**'
       - '!apps/crawler/ws-package/**'

--- a/apps/crawler/tests/test_ats_inventory_deployment.py
+++ b/apps/crawler/tests/test_ats_inventory_deployment.py
@@ -352,9 +352,33 @@ def test_workflow_uses_protected_app_credentials_native_ssh_and_provisions_label
     assert "derive-crawler-build-version.mjs" in workflow
     assert '--base "$BEFORE_SHA"' in workflow
     assert "fetch-depth: 0" in workflow
-    assert 'changed_paths="$(git diff --name-only "$BEFORE_SHA" "$GITHUB_SHA")"' in workflow
+    assert (
+        'changed_paths="$(git diff --name-only --no-renames "$BEFORE_SHA" "$GITHUB_SHA")"'
+        in workflow
+    )
     assert 'done <<< "$changed_paths"' in workflow
     assert "could not classify the full push range" in workflow
+    assert "full push range contains no changed paths" in workflow
+    assert "apps/crawler/contracts/v1/*) ;;" in workflow
+    assert "'!apps/crawler/contracts/v1/**'" in workflow
+    assert "inactive_v1_policy_count != 9" in workflow
+    assert "#8046" in workflow
+    for path in (
+        ".github/scripts/check-crawler-deploy-gate.sh",
+        ".github/workflows/deploy-ats-inventory.yml",
+        ".github/workflows/deploy-crawler-browser.yml",
+        "apps/crawler/tests/test_ats_inventory_deployment.py",
+        "scripts/check-crawler-version.mjs",
+        "scripts/ci-workflow.test.mjs",
+        "scripts/crawler-runtime-contract.test.mjs",
+        "scripts/crawler-version.test.mjs",
+        "scripts/derive-crawler-runtime-contract.mjs",
+    ):
+        assert path in workflow
+    # VERSION, another contract version, and crawler source still fall through
+    # to the ordinary apps/crawler/* active-runtime arm.
+    assert "apps/crawler/VERSION) ;;" not in workflow
+    assert "apps/crawler/contracts/v2/*) ;;" not in workflow
     # In shell case patterns, * spans slash; a ** arm is redundant and actionlint rejects it.
     assert "apps/crawler/**/*.md" not in workflow
     assert "done < <(git diff" not in workflow

--- a/scripts/check-crawler-version.mjs
+++ b/scripts/check-crawler-version.mjs
@@ -6,6 +6,21 @@ import { pathToFileURL } from "node:url";
 const DEPENDABOT_LOGIN = "dependabot[bot]";
 const CRAWLER_DEPLOY_WORKFLOW =
   ".github/workflows/deploy-crawler-browser.yml";
+const CRAWLER_VERSION_PATH = "apps/crawler/VERSION";
+const INACTIVE_V1_CANDIDATE_PREFIX = "apps/crawler/contracts/v1/";
+// Temporary, exact release-policy bridge for #8071. #8046 must remove this
+// exception when runtime v1 is packaged and activated.
+const INACTIVE_V1_POLICY_FILES = new Set([
+  ".github/scripts/check-crawler-deploy-gate.sh",
+  ".github/workflows/deploy-ats-inventory.yml",
+  ".github/workflows/deploy-crawler-browser.yml",
+  "apps/crawler/tests/test_ats_inventory_deployment.py",
+  "scripts/check-crawler-version.mjs",
+  "scripts/ci-workflow.test.mjs",
+  "scripts/crawler-runtime-contract.test.mjs",
+  "scripts/crawler-version.test.mjs",
+  "scripts/derive-crawler-runtime-contract.mjs",
+]);
 const DEPENDENCY_FILES = new Set([
   "apps/crawler/Dockerfile",
   "apps/crawler/docker-compose.yml",
@@ -38,6 +53,35 @@ export function isCrawlerDependencyOnly(files) {
   );
 }
 
+export function isInactiveV1CandidateOnly(files) {
+  const uniqueFiles = [...new Set(files)].sort();
+  return (
+    uniqueFiles.length > 0 &&
+    uniqueFiles.every((file) => file.startsWith(INACTIVE_V1_CANDIDATE_PREFIX))
+  );
+}
+
+export function isInactiveV1PolicyInfrastructureCommit(files) {
+  const uniqueFiles = [...new Set(files)].sort();
+  return (
+    uniqueFiles.length === INACTIVE_V1_POLICY_FILES.size &&
+    uniqueFiles.every((file) => INACTIVE_V1_POLICY_FILES.has(file))
+  );
+}
+
+function isInactiveV1CandidatePlusVersionOnly(files) {
+  const uniqueFiles = [...new Set(files)].sort();
+  return (
+    uniqueFiles.includes(CRAWLER_VERSION_PATH) &&
+    uniqueFiles.some((file) => file.startsWith(INACTIVE_V1_CANDIDATE_PREFIX)) &&
+    uniqueFiles.every(
+      (file) =>
+        file === CRAWLER_VERSION_PATH ||
+        file.startsWith(INACTIVE_V1_CANDIDATE_PREFIX),
+    )
+  );
+}
+
 export function isCrawlerDeployInfrastructureCommit(files) {
   const uniqueFiles = [...new Set(files)].sort();
   return (
@@ -52,7 +96,8 @@ export function isCrawlerDeployInfrastructureCommit(files) {
 export function isCrawlerDerivedBuildEligible(files) {
   return (
     isCrawlerDependencyOnly(files) ||
-    isCrawlerDeployInfrastructureCommit(files)
+    isCrawlerDeployInfrastructureCommit(files) ||
+    isInactiveV1PolicyInfrastructureCommit(files)
   );
 }
 
@@ -62,9 +107,48 @@ export function evaluateCrawlerVersion({
   author,
   files,
 }) {
+  const uniqueFiles = [...new Set(files)].sort();
+
+  // Check the attempted candidate exemption before accepting any VERSION
+  // increase. A candidate plus VERSION diff is mixed by definition and must
+  // not turn an inactive artifact edit into a release.
+  if (isInactiveV1CandidatePlusVersionOnly(uniqueFiles)) {
+    throw new Error(
+      "inactive runtime v1 candidate changes must not include apps/crawler/VERSION",
+    );
+  }
+
   const base = parseVersion(baseVersion, "Base VERSION");
   const pr = parseVersion(prVersion, "PR VERSION");
   const comparison = compareVersions(pr, base);
+
+  if (isInactiveV1CandidateOnly(uniqueFiles)) {
+    if (comparison !== 0) {
+      throw new Error(
+        "inactive runtime v1 candidate-only changes must keep apps/crawler/VERSION unchanged",
+      );
+    }
+    return {
+      kind: "inactive-v1-candidate",
+      message:
+        `Inactive runtime v1 candidate keeps ${prVersion.trim()}; ` +
+        "#8046 must revoke this temporary #8071 exemption on activation",
+    };
+  }
+
+  if (isInactiveV1PolicyInfrastructureCommit(uniqueFiles)) {
+    if (comparison !== 0) {
+      throw new Error(
+        "the exact #8071 release-policy bridge must keep apps/crawler/VERSION unchanged",
+      );
+    }
+    return {
+      kind: "inactive-v1-policy",
+      message:
+        `Exact #8071 inactive-v1 policy bridge keeps ${prVersion.trim()}; ` +
+        "#8046 owns mandatory revocation",
+    };
+  }
 
   if (comparison > 0) {
     return {
@@ -78,7 +162,6 @@ export function evaluateCrawlerVersion({
     );
   }
 
-  const uniqueFiles = [...new Set(files)].sort();
   const dependencyOnly = isCrawlerDependencyOnly(uniqueFiles);
 
   if (author === DEPENDABOT_LOGIN && dependencyOnly) {
@@ -116,10 +199,17 @@ function main() {
   const baseSha = argument("--base");
   const headSha = argument("--head");
   const author = argument("--author");
-  const versionPath = "apps/crawler/VERSION";
+  const versionPath = CRAWLER_VERSION_PATH;
   const baseVersion = git("show", `${baseSha}:${versionPath}`);
   const prVersion = git("show", `${headSha}:${versionPath}`);
-  const files = git("diff", "--name-only", `${baseSha}...${headSha}`)
+  // Disable rename detection so both old and new paths participate in the
+  // candidate-only predicate.
+  const files = git(
+    "diff",
+    "--name-only",
+    "--no-renames",
+    `${baseSha}...${headSha}`,
+  )
     .split("\n")
     .filter(Boolean);
 

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -71,6 +71,8 @@ const deployCrawlerWorkflow = readFileSync(
   ".github/workflows/deploy-crawler-browser.yml",
   "utf8",
 );
+const crawlerDockerfile = readFileSync("apps/crawler/Dockerfile", "utf8");
+const crawlerPyproject = readFileSync("apps/crawler/pyproject.toml", "utf8");
 const crawlerDeployScript = readFileSync("apps/crawler/deploy.sh", "utf8");
 const crawlerMaintenanceScript = readFileSync(
   "scripts/jobseek-maintenance.py",
@@ -539,6 +541,25 @@ test("manual PR classification exports the validated PR base context", () => {
   assert.match(result.outputs, /^base_ref=main$/m);
 });
 
+test("inactive runtime v1 candidates retain full code and crawler CI", () => {
+  const result = runClassifyPrPaths({
+    files: ["apps/crawler/contracts/v1/runtime.proto"],
+    baseRef: "main",
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.outputs, /^code=true$/m);
+  assert.match(result.outputs, /^crawler_code=true$/m);
+  assert.match(result.outputs, /^codeql=true$/m);
+  assert.match(
+    workflow,
+    /crawler_code:\n\s+- 'apps\/crawler\/\*\*'/,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /crawler_code:[\s\S]*?!apps\/crawler\/contracts\/v1\/\*\*/,
+  );
+});
+
 test("runtime taxonomies and contract derivation require crawler version gates", () => {
   for (const file of [
     "apps/crawler/data/industries.csv",
@@ -628,6 +649,29 @@ test("crawler deploys derive immutable versions for unchanged releases", () => {
     deployCrawlerWorkflow,
     /steps\.version\.outputs\.version/,
   );
+});
+
+test("crawler deployment excludes only inactive runtime v1 candidates", () => {
+  assert.match(
+    deployCrawlerWorkflow,
+    /- 'apps\/crawler\/\*\*'[\s\S]*?- '!apps\/crawler\/contracts\/v1\/\*\*'/,
+  );
+  assert.doesNotMatch(
+    deployCrawlerWorkflow,
+    /!apps\/crawler\/contracts\/v2\/\*\*/,
+  );
+  assert.match(deployCrawlerWorkflow, /#8046/);
+});
+
+test("inactive runtime v1 is absent from both crawler packaging boundaries", () => {
+  assert.match(crawlerDockerfile, /^COPY src\/ src\/$/m);
+  assert.match(crawlerDockerfile, /^COPY data\/ data\/$/m);
+  assert.doesNotMatch(crawlerDockerfile, /^COPY .*contracts/m);
+  assert.match(
+    crawlerPyproject,
+    /\[tool\.hatch\.build\.targets\.wheel\]\npackages = \["src"\]/,
+  );
+  assert.doesNotMatch(crawlerPyproject, /packages\s*=\s*\[[^\]]*contracts/);
 });
 
 test("web build jobs use one deterministic secretless environment", () => {
@@ -1651,6 +1695,100 @@ test("crawler deploy gate mirrors runtime deploy path exclusions", () => {
   assert.match(excluded.stdout, /does not trigger the crawler runtime deployment/);
   assert.doesNotMatch(excluded.calls, /issue list/);
   assert.equal(taxonomy.status, 1);
+});
+
+test("crawler deploy gate skips pure inactive-v1 diffs without querying holds", () => {
+  for (const files of [
+    ["apps/crawler/contracts/v1/runtime.proto"],
+    [
+      "apps/crawler/contracts/v1/old-name.proto",
+      "apps/crawler/contracts/v1/new-name.proto",
+    ],
+  ]) {
+    const result = runCrawlerDeployGate({
+      files,
+      holds: [
+        { number: 6632, title: "capacity", url: "https://example.test/6632" },
+      ],
+    });
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /does not trigger the crawler runtime deployment/);
+    assert.doesNotMatch(result.calls, /issue list/);
+  }
+});
+
+test("crawler deploy gate rejects an empty changed-path set", () => {
+  const result = runCrawlerDeployGate({ files: [] });
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /returned no paths/);
+  assert.doesNotMatch(result.calls, /issue list/);
+});
+
+test("crawler deploy gate keeps candidate mixtures and renames strict", () => {
+  for (const files of [
+    [
+      "apps/crawler/contracts/v1/runtime.proto",
+      "apps/crawler/src/cli.py",
+    ],
+    [
+      "apps/crawler/contracts/v1/runtime.proto",
+      "apps/crawler/Dockerfile",
+    ],
+    [
+      "apps/crawler/src/old.py",
+      "apps/crawler/contracts/v1/old.py",
+    ],
+    [
+      "apps/crawler/contracts/v1/new.py",
+      "apps/crawler/src/new.py",
+    ],
+    [
+      "apps/crawler/contracts/v1/runtime.proto",
+      "apps/crawler/VERSION",
+    ],
+    ["apps/crawler/contracts/v2/runtime.proto"],
+  ]) {
+    const result = runCrawlerDeployGate({
+      files,
+      holds: [
+        { number: 6632, title: "capacity", url: "https://example.test/6632" },
+      ],
+    });
+    assert.equal(result.status, 1, `${files.join(", ")}: ${result.stderr}`);
+    assert.match(result.calls, /issue list.*deployment-hold:crawler/);
+  }
+});
+
+test("crawler deploy gate narrowly exempts the exact #8071 policy bridge", () => {
+  const policyFiles = [
+    ".github/scripts/check-crawler-deploy-gate.sh",
+    ".github/workflows/deploy-ats-inventory.yml",
+    ".github/workflows/deploy-crawler-browser.yml",
+    "apps/crawler/tests/test_ats_inventory_deployment.py",
+    "scripts/check-crawler-version.mjs",
+    "scripts/ci-workflow.test.mjs",
+    "scripts/crawler-runtime-contract.test.mjs",
+    "scripts/crawler-version.test.mjs",
+    "scripts/derive-crawler-runtime-contract.mjs",
+  ];
+  const exact = runCrawlerDeployGate({
+    files: policyFiles,
+    holds: [
+      { number: 6632, title: "capacity", url: "https://example.test/6632" },
+    ],
+  });
+  const mixed = runCrawlerDeployGate({
+    files: [...policyFiles, "apps/crawler/src/cli.py"],
+    holds: [
+      { number: 6632, title: "capacity", url: "https://example.test/6632" },
+    ],
+  });
+
+  assert.equal(exact.status, 0, exact.stderr);
+  assert.match(exact.stdout, /exact #8071 inactive-v1 policy bridge/);
+  assert.doesNotMatch(exact.calls, /issue list/);
+  assert.equal(mixed.status, 1, mixed.stderr);
+  assert.match(mixed.calls, /issue list.*deployment-hold:crawler/);
 });
 
 test("crawler deploy gate blocks a runtime file renamed into an excluded path", () => {

--- a/scripts/crawler-runtime-contract.test.mjs
+++ b/scripts/crawler-runtime-contract.test.mjs
@@ -41,6 +41,8 @@ test("runtime contract matches the crawler deploy boundary", () => {
   }
 
   for (const path of [
+    "apps/crawler/contracts/v1/runtime.proto",
+    "apps/crawler/contracts/v1/fixtures/replay.json",
     "apps/crawler/data/images/example/logo.png",
     "apps/crawler/traces/example.json",
     "apps/crawler/ws-package/pyproject.toml",
@@ -49,6 +51,14 @@ test("runtime contract matches the crawler deploy boundary", () => {
     ".github/workflows/sync-data.yml",
   ]) {
     assert.equal(isCrawlerRuntimePath(path), false, path);
+  }
+
+  for (const path of [
+    "apps/crawler/contracts/v2/runtime.proto",
+    "apps/crawler/contracts/v10/runtime.proto",
+    "apps/crawler/contracts/v1",
+  ]) {
+    assert.equal(isCrawlerRuntimePath(path), true, path);
   }
 });
 
@@ -91,6 +101,77 @@ test("data-only changes preserve the runtime contract", () => {
   assert.equal(
     deriveCrawlerRuntimeContract(before),
     deriveCrawlerRuntimeContract(after),
+  );
+});
+
+test("inactive runtime v1 candidates do not alter the active runtime digest", () => {
+  const source = entry("apps/crawler/src/cli.py", "a".repeat(40));
+  const workflow = entry(
+    ".github/workflows/deploy-crawler-browser.yml",
+    "b".repeat(40),
+  );
+  const baseline = deriveCrawlerRuntimeContract([source, workflow]);
+
+  assert.equal(
+    baseline,
+    deriveCrawlerRuntimeContract([
+      source,
+      workflow,
+      entry("apps/crawler/contracts/v1/runtime.proto", "c".repeat(40)),
+    ]),
+  );
+  assert.equal(
+    deriveCrawlerRuntimeContract([
+      source,
+      workflow,
+      entry("apps/crawler/contracts/v1/runtime.proto", "c".repeat(40)),
+    ]),
+    deriveCrawlerRuntimeContract([
+      source,
+      workflow,
+      entry("apps/crawler/contracts/v1/runtime.proto", "d".repeat(40)),
+      entry("apps/crawler/contracts/v1/new.proto", "e".repeat(40)),
+    ]),
+  );
+});
+
+test("mixed, other-version, and cross-boundary changes alter the runtime digest", () => {
+  const source = entry("apps/crawler/src/contract.py", "a".repeat(40));
+  const workflow = entry(
+    ".github/workflows/deploy-crawler-browser.yml",
+    "b".repeat(40),
+  );
+  const candidate = entry(
+    "apps/crawler/contracts/v1/runtime.proto",
+    "c".repeat(40),
+  );
+  const baseline = deriveCrawlerRuntimeContract([source, workflow, candidate]);
+
+  assert.notEqual(
+    baseline,
+    deriveCrawlerRuntimeContract([
+      workflow,
+      entry("apps/crawler/contracts/v1/contract.py", "a".repeat(40)),
+      candidate,
+    ]),
+  );
+  assert.notEqual(
+    baseline,
+    deriveCrawlerRuntimeContract([
+      source,
+      workflow,
+      candidate,
+      entry("apps/crawler/src/new.py", "d".repeat(40)),
+    ]),
+  );
+  assert.notEqual(
+    baseline,
+    deriveCrawlerRuntimeContract([
+      source,
+      workflow,
+      candidate,
+      entry("apps/crawler/contracts/v2/runtime.proto", "e".repeat(40)),
+    ]),
   );
 });
 
@@ -252,6 +333,50 @@ test("runtime attestation lists only the immutable first-parent runtime epoch", 
     writeFileSync(join(repo, "apps/crawler/src/cli.py"), "print('new')\n");
     execFileSync("git", ["-C", repo, "add", "."]);
     execFileSync("git", ["-C", repo, "commit", "--quiet", "-m", "new runtime"]);
+    const changed = execFileSync("git", ["-C", repo, "rev-parse", "HEAD"], {
+      encoding: "utf8",
+    }).trim();
+    assert.deepEqual(
+      deriveCrawlerRuntimeAttestation(repo, changed).compatibleRevisions,
+      [changed],
+    );
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("inactive runtime v1 commits remain in the rollback-compatible epoch", () => {
+  const repo = mkdtempSync(join(tmpdir(), "crawler-candidate-attestation-"));
+  try {
+    execFileSync("git", ["-C", repo, "init", "--quiet"]);
+    execFileSync("git", ["-C", repo, "config", "user.email", "test@example.com"]);
+    execFileSync("git", ["-C", repo, "config", "user.name", "Test"]);
+    mkdirSync(join(repo, "apps/crawler/src"), { recursive: true });
+    mkdirSync(join(repo, "apps/crawler/contracts/v1"), { recursive: true });
+    writeFileSync(join(repo, "apps/crawler/src/cli.py"), "print('runtime')\n");
+    execFileSync("git", ["-C", repo, "add", "."]);
+    execFileSync("git", ["-C", repo, "commit", "--quiet", "-m", "runtime"]);
+    const initial = execFileSync("git", ["-C", repo, "rev-parse", "HEAD"], {
+      encoding: "utf8",
+    }).trim();
+
+    writeFileSync(
+      join(repo, "apps/crawler/contracts/v1/runtime.proto"),
+      "syntax = \"proto3\";\n",
+    );
+    execFileSync("git", ["-C", repo, "add", "."]);
+    execFileSync("git", ["-C", repo, "commit", "--quiet", "-m", "candidate"]);
+    const candidate = execFileSync("git", ["-C", repo, "rev-parse", "HEAD"], {
+      encoding: "utf8",
+    }).trim();
+    assert.deepEqual(
+      deriveCrawlerRuntimeAttestation(repo, candidate).compatibleRevisions,
+      [candidate, initial],
+    );
+
+    writeFileSync(join(repo, "apps/crawler/src/cli.py"), "print('changed')\n");
+    execFileSync("git", ["-C", repo, "add", "."]);
+    execFileSync("git", ["-C", repo, "commit", "--quiet", "-m", "mixed"]);
     const changed = execFileSync("git", ["-C", repo, "rev-parse", "HEAD"], {
       encoding: "utf8",
     }).trim();

--- a/scripts/crawler-version.test.mjs
+++ b/scripts/crawler-version.test.mjs
@@ -1,8 +1,50 @@
 import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import test from "node:test";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { evaluateCrawlerVersion } from "./check-crawler-version.mjs";
+import {
+  evaluateCrawlerVersion,
+  isInactiveV1CandidateOnly,
+  isInactiveV1PolicyInfrastructureCommit,
+} from "./check-crawler-version.mjs";
 import { deriveCrawlerBuildVersion } from "./derive-crawler-build-version.mjs";
+
+const inactiveV1PolicyFiles = [
+  ".github/scripts/check-crawler-deploy-gate.sh",
+  ".github/workflows/deploy-ats-inventory.yml",
+  ".github/workflows/deploy-crawler-browser.yml",
+  "apps/crawler/tests/test_ats_inventory_deployment.py",
+  "scripts/check-crawler-version.mjs",
+  "scripts/ci-workflow.test.mjs",
+  "scripts/crawler-runtime-contract.test.mjs",
+  "scripts/crawler-version.test.mjs",
+  "scripts/derive-crawler-runtime-contract.mjs",
+];
+
+function git(repo, ...args) {
+  return execFileSync("git", ["-C", repo, ...args], {
+    encoding: "utf8",
+  }).trim();
+}
+
+function runVersionCheck(repo, base, head) {
+  return spawnSync(
+    "node",
+    [
+      join(process.cwd(), "scripts/check-crawler-version.mjs"),
+      "--base",
+      base,
+      "--head",
+      head,
+      "--author",
+      "developer",
+    ],
+    { cwd: repo, encoding: "utf8" },
+  );
+}
 
 test("explicit crawler releases remain the default", () => {
   const result = evaluateCrawlerVersion({
@@ -12,6 +54,202 @@ test("explicit crawler releases remain the default", () => {
     files: ["apps/crawler/src/cli.py", "apps/crawler/VERSION"],
   });
   assert.equal(result.kind, "release");
+});
+
+test("pure nonempty inactive runtime v1 candidate changes keep VERSION", () => {
+  for (const files of [
+    ["apps/crawler/contracts/v1/runtime.proto"],
+    [
+      "apps/crawler/contracts/v1/runtime.proto",
+      "apps/crawler/contracts/v1/fixtures/deleted.json",
+    ],
+    // A same-prefix rename is represented rename-safely by both paths.
+    [
+      "apps/crawler/contracts/v1/old-name.proto",
+      "apps/crawler/contracts/v1/new-name.proto",
+    ],
+  ]) {
+    const result = evaluateCrawlerVersion({
+      baseVersion: "0.13.525",
+      prVersion: "0.13.525",
+      author: "developer",
+      files,
+    });
+    assert.equal(result.kind, "inactive-v1-candidate");
+    assert.match(result.message, /#8046/);
+  }
+});
+
+test("inactive runtime v1 candidate predicate is exact and nonempty", () => {
+  assert.equal(isInactiveV1CandidateOnly([]), false);
+  assert.equal(
+    isInactiveV1CandidateOnly(["apps/crawler/contracts/v1/runtime.proto"]),
+    true,
+  );
+  for (const path of [
+    "apps/crawler/contracts/v1",
+    "apps/crawler/contracts/v10/runtime.proto",
+    "apps/crawler/contracts/v2/runtime.proto",
+    "apps/crawler/src/contracts/v1/runtime.proto",
+  ]) {
+    assert.equal(isInactiveV1CandidateOnly([path]), false, path);
+  }
+});
+
+test("the executable version gate classifies old and new rename paths", () => {
+  const repo = mkdtempSync(join(tmpdir(), "crawler-version-candidate-"));
+  try {
+    git(repo, "init", "--quiet");
+    git(repo, "config", "user.email", "test@example.com");
+    git(repo, "config", "user.name", "Test");
+    mkdirSync(join(repo, "apps/crawler/contracts/v1"), { recursive: true });
+    mkdirSync(join(repo, "apps/crawler/src"), { recursive: true });
+    writeFileSync(join(repo, "apps/crawler/VERSION"), "0.13.525\n");
+    writeFileSync(
+      join(repo, "apps/crawler/contracts/v1/old.proto"),
+      "syntax = \"proto3\";\n",
+    );
+    git(repo, "add", ".");
+    git(repo, "commit", "--quiet", "-m", "base");
+    const initial = git(repo, "rev-parse", "HEAD");
+
+    git(
+      repo,
+      "mv",
+      "apps/crawler/contracts/v1/old.proto",
+      "apps/crawler/contracts/v1/new.proto",
+    );
+    git(repo, "commit", "--quiet", "-m", "candidate rename");
+    const renamed = git(repo, "rev-parse", "HEAD");
+    const samePrefix = runVersionCheck(repo, initial, renamed);
+    assert.equal(samePrefix.status, 0, samePrefix.stderr);
+    assert.match(samePrefix.stdout, /Inactive runtime v1 candidate/);
+
+    rmSync(join(repo, "apps/crawler/contracts/v1/new.proto"));
+    git(repo, "add", ".");
+    git(repo, "commit", "--quiet", "-m", "candidate deletion");
+    const deleted = git(repo, "rev-parse", "HEAD");
+    const deletion = runVersionCheck(repo, renamed, deleted);
+    assert.equal(deletion.status, 0, deletion.stderr);
+
+    writeFileSync(
+      join(repo, "apps/crawler/contracts/v1/cross.py"),
+      "VALUE = 1\n",
+    );
+    git(repo, "add", ".");
+    git(repo, "commit", "--quiet", "-m", "candidate addition");
+    const beforeCrossBoundary = git(repo, "rev-parse", "HEAD");
+    git(
+      repo,
+      "mv",
+      "apps/crawler/contracts/v1/cross.py",
+      "apps/crawler/src/cross.py",
+    );
+    git(repo, "commit", "--quiet", "-m", "cross boundary rename");
+    const crossBoundary = git(repo, "rev-parse", "HEAD");
+    const crossing = runVersionCheck(repo, beforeCrossBoundary, crossBoundary);
+    assert.equal(crossing.status, 1);
+    assert.match(crossing.stderr, /must be bumped/);
+
+    const empty = runVersionCheck(repo, crossBoundary, crossBoundary);
+    assert.equal(empty.status, 1);
+    assert.match(empty.stderr, /must be bumped/);
+  } finally {
+    rmSync(repo, { recursive: true, force: true });
+  }
+});
+
+test("candidate plus VERSION is rejected before a release can be accepted", () => {
+  for (const prVersion of ["0.13.525", "0.13.526"] ) {
+    assert.throws(
+      () =>
+        evaluateCrawlerVersion({
+          baseVersion: "0.13.525",
+          prVersion,
+          author: "developer",
+          files: [
+            "apps/crawler/contracts/v1/runtime.proto",
+            "apps/crawler/VERSION",
+          ],
+        }),
+      /must not include apps\/crawler\/VERSION/,
+    );
+  }
+});
+
+test("mixed and cross-boundary candidate diffs retain normal version policy", () => {
+  for (const files of [
+    [
+      "apps/crawler/contracts/v1/runtime.proto",
+      "apps/crawler/src/cli.py",
+    ],
+    [
+      "apps/crawler/contracts/v1/runtime.proto",
+      "apps/crawler/pyproject.toml",
+    ],
+    // Rename from active runtime into v1.
+    [
+      "apps/crawler/src/old_contract.py",
+      "apps/crawler/contracts/v1/old_contract.py",
+    ],
+    // Rename from v1 into active runtime.
+    [
+      "apps/crawler/contracts/v1/new_contract.py",
+      "apps/crawler/src/new_contract.py",
+    ],
+    ["apps/crawler/contracts/v2/runtime.proto"],
+  ]) {
+    assert.throws(
+      () =>
+        evaluateCrawlerVersion({
+          baseVersion: "0.13.525",
+          prVersion: "0.13.525",
+          author: "developer",
+          files,
+        }),
+      /must be bumped/,
+    );
+    assert.equal(
+      evaluateCrawlerVersion({
+        baseVersion: "0.13.525",
+        prVersion: "0.13.526",
+        author: "developer",
+        files: [...files, "apps/crawler/VERSION"],
+      }).kind,
+      "release",
+    );
+  }
+});
+
+test("the exact #8071 policy bridge self-hosts without VERSION", () => {
+  assert.equal(
+    isInactiveV1PolicyInfrastructureCommit(inactiveV1PolicyFiles),
+    true,
+  );
+  assert.equal(
+    evaluateCrawlerVersion({
+      baseVersion: "0.13.525",
+      prVersion: "0.13.525",
+      author: "developer",
+      files: inactiveV1PolicyFiles,
+    }).kind,
+    "inactive-v1-policy",
+  );
+
+  assert.equal(
+    isInactiveV1PolicyInfrastructureCommit(inactiveV1PolicyFiles.slice(1)),
+    false,
+  );
+  assert.throws(
+    () =>
+      evaluateCrawlerVersion({
+        baseVersion: "0.13.525",
+        prVersion: "0.13.525",
+        author: "developer",
+        files: [...inactiveV1PolicyFiles, "apps/crawler/src/cli.py"],
+      }),
+    /must be bumped/,
+  );
 });
 
 test("dependency-only Dependabot updates may keep the base version", () => {
@@ -185,6 +423,40 @@ test("deploy-infrastructure self-triggers get deterministic build versions", () 
       derived: true,
     },
   );
+});
+
+test("the exact #8071 policy bridge gets a deterministic derived build", () => {
+  const result = deriveCrawlerBuildVersion({
+    sourceVersion: "0.13.525",
+    parentVersion: "0.13.525",
+    commitCount: "7001",
+    sha: "abc123def4567890",
+    files: inactiveV1PolicyFiles,
+  });
+  assert.equal(result.packageVersion, "0.13.525+build.7001.gabc123def456");
+  assert.equal(result.imageTag, "v0.13.525-build.7001.gabc123def456");
+  assert.equal(result.derived, true);
+});
+
+test("derived builds reject candidate and #8071 policy mixtures", () => {
+  for (const files of [
+    ["apps/crawler/contracts/v1/runtime.proto"],
+    [...inactiveV1PolicyFiles, "apps/crawler/contracts/v1/runtime.proto"],
+    [...inactiveV1PolicyFiles, "apps/crawler/src/cli.py"],
+    [...inactiveV1PolicyFiles, "apps/crawler/VERSION"],
+  ]) {
+    assert.throws(
+      () =>
+        deriveCrawlerBuildVersion({
+          sourceVersion: "0.13.525",
+          parentVersion: "0.13.525",
+          commitCount: "7001",
+          sha: "abc123def4567890",
+          files,
+        }),
+      /dependency-only or deploy-infrastructure main commit/,
+    );
+  }
 });
 
 test("deploy-infrastructure self-triggers cannot hide crawler source changes", () => {

--- a/scripts/derive-crawler-runtime-contract.mjs
+++ b/scripts/derive-crawler-runtime-contract.mjs
@@ -16,11 +16,15 @@ const RUNTIME_DATA_PATHS = new Set([
   "apps/crawler/data/seniority.csv",
   "apps/crawler/data/technologies.csv",
 ]);
+const INACTIVE_V1_CANDIDATE_PREFIX = "apps/crawler/contracts/v1/";
 const MAX_CRAWLER_DATA_BLOB_BYTES = 64 * 1024 * 1024;
 
 export function isCrawlerRuntimePath(path) {
   if (EXTRA_RUNTIME_PATHS.has(path)) return true;
   if (RUNTIME_DATA_PATHS.has(path)) return true;
+  // Temporary #8071 exemption: these files are not copied into the image or
+  // built into the wheel. #8046 must remove this before activating v1.
+  if (path.startsWith(INACTIVE_V1_CANDIDATE_PREFIX)) return false;
   if (!path.startsWith("apps/crawler/")) return false;
 
   const relative = path.slice("apps/crawler/".length);


### PR DESCRIPTION
Closes #8071
Parent: #7937
Epic: #7935
Blocks #8069 until merged and verified.

## Why

`apps/crawler/contracts/v1/**` is still candidate-only: Hatch builds only `src`, and the crawler Dockerfile copies only `src/` and `data/`. Treating every v1 artifact edit as active runtime causes VERSION livelock and false deploy, hold, runtime-digest, and ATS signals before #8046 packages and activates the contract.

## What

- Exempt only a nonempty diff whose complete old/new path set stays under exact `apps/crawler/contracts/v1/**` from crawler VERSION bumps.
- Keep full normal code and crawler CI classification unchanged.
- Exclude candidate-only v1 from the crawler push trigger, deploy-hold query, active runtime digest/rollback epoch, and ATS internal crawler classification.
- Fail strict for candidate plus VERSION, mixed runtime/packaging paths, other contract versions, and cross-boundary renames.
- Allow this exact nine-file policy bridge to self-host without changing `apps/crawler/VERSION`; mixtures do not inherit that allowance.
- Mark every temporary boundary for mandatory revocation by activation owner #8046.

No contract artifact, crawler runtime/source, packaging, Dockerfile, lockfile, or VERSION file changes.

## Verification

- `node --test scripts/crawler-version.test.mjs scripts/crawler-runtime-contract.test.mjs scripts/ci-workflow.test.mjs` — 103 passed
- `cd apps/crawler && uv run --frozen pytest tests/test_ats_inventory_deployment.py -q` — 12 passed
- `cd apps/crawler && uv run --frozen ruff check tests/test_ats_inventory_deployment.py`
- `cd apps/crawler && uv run --frozen ruff format --check tests/test_ats_inventory_deployment.py`
- `bash -n .github/scripts/check-crawler-deploy-gate.sh`
- `actionlint` on both changed workflows
- exact executable version evaluator at reviewed candidate: unchanged `0.13.536`, classified `inactive-v1-policy`
- mechanical refresh patch ID: `3e0a3e89695db234edf0c3e7b441928444e01c16`, byte-identical across abandoned unpushed base and this fresh-main branch

## Review boundary

Draft for one independent exact-head review. Writer will not self-review, mark ready, merge, activate rulesets, or force-push. At most one bounded repair is permitted.
