### PR TITLE
Land versionless adjacent contract policy candidate

### DIFF
--- a/apps/crawler/contracts/v1/compatibility.md
+++ b/apps/crawler/contracts/v1/compatibility.md
@@ -85,7 +85,38 @@ current-source check, committed self-regeneration regression, post-introduction
 reservation and map-history regressions, shared Python corpora, and shared Go
 corpora.
 
-Adjacent-version reservation and executable converter policy is intentionally
-out of scope here and is owned by #8057. Generated bindings, packaging,
-semantic validators, replay/redaction/projection implementations, runtime
-consumption, and activation are also excluded.
+Generated bindings, packaging, semantic validators,
+replay/redaction/projection implementations, runtime consumption, and
+activation remain excluded.
+
+## Future adjacent-version policy
+
+Every future adjacent contract version must retain field and enum tombstones
+for both the removed name and number. Existing tombstones remain immutable;
+active fields and enum values may not reuse them. Map key/value shapes, oneof
+identity and membership, and enum aliases are compatibility identities too.
+Aliases require an explicit `allow_alias` declaration and retained aliases may
+not silently move to another number.
+
+An adjacent-version change must provide executable Python and Go converters in
+both directions over one shared, nonempty corpus. The corpus must include both
+reversible and genuinely lossy cases, exact integers above `2^53`, absent
+versus explicitly defaulted fields, forwarded unknown data, and a path plus
+reason for every declared loss. A loss is valid only when the source value is
+present, every other field is preserved, and the reverse conversion cannot
+reconstruct the removed value. Empty, one-way, echo, constant-output,
+nondeterministic, or unexecuted language evidence fails closed. Canonical
+serialized results must be byte-identical across repeated runs and languages.
+
+`fixtures/compatibility/adjacent_version_policy` is only the enforcement
+specimen for that rule. Its packages contain `.policytest.`, its manifest uses
+the exact JSON boolean `production: false`, and its converters are test-only
+executables. It is not `crawler.runtime/v2`, does not introduce a production
+schema or converter, and is never generated, packaged, imported, deployed, or
+consumed by crawler runtime code. A real v2 requires a separate versioned IDL
+decision and activation plan.
+
+The ordinary Required-CI discovery bridge executes the named Python module and
+Go package. The Go runner uses only the standard library and is launched with
+`GOTOOLCHAIN=local`, `GOPROXY=off`, and an isolated module/build cache, so the
+policy cannot fetch tools or dependencies from the network.

--- a/apps/crawler/contracts/v1/conformance/go/adjacent_version_policy_test.go
+++ b/apps/crawler/contracts/v1/conformance/go/adjacent_version_policy_test.go
@@ -1,0 +1,181 @@
+package adjacentpolicy
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+type endpoint struct {
+	Package string `json:"package"`
+	Version int    `json:"version"`
+}
+
+type manifestShape struct {
+	From endpoint `json:"from"`
+	To   endpoint `json:"to"`
+}
+
+type lossShape struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason"`
+}
+
+type expectedShape struct {
+	Losses  []lossShape    `json:"losses"`
+	Payload map[string]any `json:"payload"`
+}
+
+type vectorCase struct {
+	Direction  string         `json:"direction"`
+	Expected   expectedShape  `json:"expected"`
+	ID         string         `json:"id"`
+	Input      map[string]any `json:"input"`
+	Reversible bool           `json:"reversible"`
+}
+
+type vectorDocument struct {
+	Cases []vectorCase `json:"cases"`
+}
+
+func contractRoot(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate adjacent-version Go test")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", ".."))
+}
+
+func policyRoot(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(
+		contractRoot(t),
+		"fixtures",
+		"compatibility",
+		"adjacent_version_policy",
+	)
+}
+
+func readJSONUseNumber(t *testing.T, path string, target any) []byte {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	decoder.UseNumber()
+	if err := decoder.Decode(target); err != nil {
+		t.Fatal(err)
+	}
+	return content
+}
+
+func TestAdjacentVersionManifestIsStrictlyTestOnly(t *testing.T) {
+	path := filepath.Join(policyRoot(t), "manifest.json")
+	var raw map[string]json.RawMessage
+	content := readJSONUseNumber(t, path, &raw)
+	if string(raw["production"]) != "false" {
+		t.Fatalf("production must be the exact JSON boolean false: %s", raw["production"])
+	}
+	if string(raw["fixture_only"]) != "true" {
+		t.Fatalf("fixture_only must be the exact JSON boolean true: %s", raw["fixture_only"])
+	}
+	var manifest manifestShape
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	if err := decoder.Decode(&manifest); err != nil {
+		t.Fatal(err)
+	}
+	for _, item := range []endpoint{manifest.From, manifest.To} {
+		if !strings.Contains(item.Package, ".runtime.policytest.v") {
+			t.Fatalf("package is not unmistakably test-only: %s", item.Package)
+		}
+	}
+	if manifest.To.Version != manifest.From.Version+1 {
+		t.Fatalf("specimen versions are not adjacent: %d -> %d", manifest.From.Version, manifest.To.Version)
+	}
+}
+
+func TestSharedVectorsKeepLargeIntegersPresenceAndRealLoss(t *testing.T) {
+	var vectors vectorDocument
+	readJSONUseNumber(t, filepath.Join(policyRoot(t), "vectors.json"), &vectors)
+	if len(vectors.Cases) == 0 {
+		t.Fatal("shared vector corpus is empty")
+	}
+	directions := map[string]bool{}
+	lossy := map[string]bool{}
+	reversible := map[string]bool{}
+	sawLarge := false
+	sawAbsent := false
+	sawExplicitDefaults := false
+	for _, item := range vectors.Cases {
+		directions[item.Direction] = true
+		if item.Reversible {
+			reversible[item.Direction] = true
+		} else {
+			lossy[item.Direction] = true
+			if len(item.Expected.Losses) == 0 || item.Expected.Payload == nil {
+				t.Fatalf("lossy case lacks evidence: %s", item.ID)
+			}
+		}
+		if number, ok := item.Input["sequence"].(json.Number); ok {
+			if number.String() == "9007199254740993" || number.String() == "9007199254740997" {
+				sawLarge = true
+			}
+		}
+		_, countPresent := item.Input["explicit_count"]
+		_, labelPresent := item.Input["explicit_label"]
+		if !countPresent && !labelPresent {
+			sawAbsent = true
+		}
+		if count, ok := item.Input["explicit_count"].(json.Number); ok && count.String() == "0" {
+			if label, ok := item.Input["explicit_label"].(string); ok && label == "" {
+				sawExplicitDefaults = true
+			}
+		}
+	}
+	for _, direction := range []string{"old_to_new", "new_to_old"} {
+		if !directions[direction] || !lossy[direction] || !reversible[direction] {
+			t.Fatalf("direction lacks reversible and lossy evidence: %s", direction)
+		}
+	}
+	if !sawLarge || !sawAbsent || !sawExplicitDefaults {
+		t.Fatal("vectors do not prove exact >2^53 and absence/default handling")
+	}
+}
+
+func TestAdjacentVersionPythonAndGoConvertersExecuteOffline(t *testing.T) {
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Fatal("python3 is required for the cross-language policy gate")
+	}
+	root := contractRoot(t)
+	checker := filepath.Join(root, "tools", "check_compatibility.py")
+	command := exec.Command( // #nosec G204 -- executable and arguments are repository-owned.
+		python,
+		checker,
+		"--root",
+		root,
+		"--adjacent-policy-only",
+	)
+	command.Env = append(
+		os.Environ(),
+		"GO111MODULE=off",
+		"GOENV=off",
+		"GOPROXY=off",
+		"GOSUMDB=off",
+		"GOTOOLCHAIN=local",
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("offline adjacent-version policy failed: %v\n%s", err, output)
+	}
+	if string(output) != "runtime v1 adjacent-version policy: ok\n" {
+		t.Fatalf("unexpected adjacent-version policy output: %q", output)
+	}
+}

--- a/apps/crawler/contracts/v1/conformance/python/test_adjacent_version_policy.py
+++ b/apps/crawler/contracts/v1/conformance/python/test_adjacent_version_policy.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+V1 = Path(__file__).resolve().parents[2]
+POLICY = V1 / "fixtures" / "compatibility" / "adjacent_version_policy"
+
+_SPEC = importlib.util.spec_from_file_location(
+    "runtime_v1_adjacent_policy_checker", V1 / "tools" / "check_compatibility.py"
+)
+assert _SPEC is not None and _SPEC.loader is not None
+compatibility = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = compatibility
+_SPEC.loader.exec_module(compatibility)
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _copy_policy(tmp_path: Path) -> Path:
+    destination = tmp_path / "adjacent_version_policy"
+    shutil.copytree(POLICY, destination)
+    return destination
+
+
+def _mutate_json(
+    directory: Path,
+    filename: str,
+    mutation: Callable[[dict[str, Any]], None],
+) -> None:
+    path = directory / filename
+    value = json.loads(path.read_text(encoding="utf-8"))
+    mutation(value)
+    _write_json(path, value)
+
+
+def _manifest_production_true(value: dict[str, Any]) -> None:
+    value["production"] = True
+
+
+def _manifest_production_missing(value: dict[str, Any]) -> None:
+    value.pop("production")
+
+
+def _manifest_wrong_package(value: dict[str, Any]) -> None:
+    value["to"]["package"] = "jobseek.crawler.runtime.v18"
+
+
+def _manifest_nonadjacent(value: dict[str, Any]) -> None:
+    value["to"]["version"] = 19
+    value["to"]["package"] = "jobseek.crawler.runtime.policytest.v19"
+
+
+def _manifest_missing_go(value: dict[str, Any]) -> None:
+    value["converters"].pop("go")
+
+
+def _manifest_one_way(value: dict[str, Any]) -> None:
+    value["converters"]["python"]["directions"] = ["old_to_new"]
+
+
+def _manifest_missing_runner(value: dict[str, Any]) -> None:
+    value["converters"]["go"]["path"] = "not_executed.go"
+
+
+def _mutate_proto(directory: Path, old: str, new: str) -> None:
+    path = directory / "v18.proto"
+    source = path.read_text(encoding="utf-8")
+    assert source.count(old) == 1, old
+    path.write_text(source.replace(old, new, 1), encoding="utf-8")
+
+
+def _empty_corpus(value: dict[str, Any]) -> None:
+    value["cases"] = []
+
+
+def _identity_only_corpus(value: dict[str, Any]) -> None:
+    value["cases"] = [case for case in value["cases"] if case["reversible"]]
+
+
+def _false_loss(value: dict[str, Any]) -> None:
+    case = value["cases"][0]
+    case["expected"]["losses"] = [{"path": "$.legacy_note", "reason": "fabricated loss"}]
+    case["reversible"] = False
+
+
+_VALIDATION_FAILURES = [
+    ("manifest.json", _manifest_production_true, "production must be exactly false"),
+    ("manifest.json", _manifest_production_missing, "unexpected or missing keys"),
+    ("manifest.json", _manifest_wrong_package, "package is not test-only"),
+    ("manifest.json", _manifest_missing_go, "requires Python and Go"),
+    ("manifest.json", _manifest_one_way, "declare both directions"),
+    ("manifest.json", _manifest_missing_runner, "regular fixture file"),
+    ("vectors.json", _empty_corpus, "corpus must be nonempty"),
+    ("vectors.json", _identity_only_corpus, "genuinely lossy both ways"),
+    ("vectors.json", _false_loss, "loss is false"),
+]
+
+_PROTO_FAILURES = [
+    ("  reserved 6;\n", "", "removed field must reserve both name and number"),
+    ('  reserved "legacy_note";\n', "", "removed field must reserve both name and number"),
+    ("  optional string future_hint = 9;", "  optional string future_hint = 6;", "reserved"),
+    (
+        '  reserved "legacy_note";',
+        '  reserved "legacy_note";\n  optional string legacy_note = 11;',
+        "reserved",
+    ),
+    ("map<string, string> labels", "map<uint64, string> labels", "field or map shape changed"),
+    ("map<string, string> labels", "map<string, uint64> labels", "field or map shape changed"),
+    ("oneof source {", "oneof origin {", "oneof identity or membership changed"),
+    (
+        """  oneof source {
+    string source_url = 4;
+    string inline_source = 5;
+  }""",
+        """  oneof source {
+    string source_url = 4;
+  }
+  string inline_source = 5;""",
+        "oneof identity or membership changed",
+    ),
+    ("  reserved 2;\n", "", "removed enum value must reserve both name and number"),
+    (
+        '  reserved "POLICY_MODE_RETIRED";\n',
+        "",
+        "removed enum value must reserve both name and number",
+    ),
+    (
+        "  POLICY_MODE_ACTIVE = 1;",
+        "  POLICY_MODE_ACTIVE = 1;\n  POLICY_MODE_REPLACEMENT = 2;",
+        "reserved",
+    ),
+    ("  option allow_alias = true;\n\n", "", "uses the same enum value"),
+    (
+        "  POLICY_MODE_ACTIVE = 1;",
+        "  POLICY_MODE_ACTIVE = 3;\n  POLICY_MODE_ENABLED = 1;",
+        "enum alias or value changed",
+    ),
+]
+
+
+def test_adjacent_version_policy_executes_python_go_and_mixed_round_trips() -> None:
+    compatibility.check_adjacent_version_policy(V1)
+
+
+def test_specimen_is_explicitly_nonproduction_and_does_not_claim_v2() -> None:
+    manifest = json.loads((POLICY / "manifest.json").read_text(encoding="utf-8"))
+    assert manifest["production"] is False
+    assert manifest["fixture_only"] is True
+    assert set(manifest["converters"]) == {"python", "go"}
+    assert all(".policytest.v" in manifest[endpoint]["package"] for endpoint in ("from", "to"))
+    assert not (V1.parent / "v2").exists()
+
+
+@pytest.mark.parametrize(
+    ("filename", "mutation", "expected"),
+    _VALIDATION_FAILURES,
+    ids=[mutation.__name__.removeprefix("_") for _, mutation, _ in _VALIDATION_FAILURES],
+)
+def test_policy_validation_fails_closed(
+    tmp_path: Path,
+    filename: str,
+    mutation: Callable[[dict[str, Any]], None],
+    expected: str,
+) -> None:
+    directory = _copy_policy(tmp_path)
+    _mutate_json(directory, filename, mutation)
+    with pytest.raises(compatibility.CompatibilityError, match=expected):
+        compatibility.validate_adjacent_version_policy(directory)
+
+
+@pytest.mark.parametrize(
+    ("old", "new", "expected"),
+    _PROTO_FAILURES,
+    ids=[f"proto-policy-{index}" for index in range(len(_PROTO_FAILURES))],
+)
+def test_protobuf_reservation_and_identity_policy_fails_closed(
+    tmp_path: Path, old: str, new: str, expected: str
+) -> None:
+    directory = _copy_policy(tmp_path)
+    _mutate_proto(directory, old, new)
+    with pytest.raises(compatibility.CompatibilityError, match=expected):
+        compatibility.validate_adjacent_version_policy(directory)
+
+
+def test_nonadjacent_version_evidence_fails(tmp_path: Path) -> None:
+    directory = _copy_policy(tmp_path)
+    _mutate_json(directory, "manifest.json", _manifest_nonadjacent)
+    with pytest.raises(compatibility.CompatibilityError, match="not numerically adjacent"):
+        compatibility.validate_adjacent_version_policy(directory)
+
+
+def _replace_python_runner(directory: Path, body: str) -> None:
+    (directory / "python_converter.py").write_text(body, encoding="utf-8")
+
+
+def test_nondeterministic_converter_output_fails(tmp_path: Path) -> None:
+    directory = _copy_policy(tmp_path)
+    _replace_python_runner(
+        directory,
+        """import json, os, sys
+document = json.load(sys.stdin)
+results = [
+    {"id": case["id"], "losses": [], "payload": {"nonce": os.urandom(8).hex()}}
+    for case in document["cases"]
+]
+sys.stdout.write(json.dumps({"results": results}, separators=(",", ":"), sort_keys=True) + "\\n")
+""",
+    )
+    with pytest.raises(compatibility.CompatibilityError, match="nondeterministic"):
+        compatibility.check_adjacent_version_policy(V1, policy_directory=directory)
+
+
+@pytest.mark.parametrize("behavior", ["echo", "constant"])
+def test_identity_or_constant_converter_output_fails(tmp_path: Path, behavior: str) -> None:
+    directory = _copy_policy(tmp_path)
+    payload_expression = "case['payload']" if behavior == "echo" else "{'constant': True}"
+    _replace_python_runner(
+        directory,
+        f"""import json, sys
+document = json.load(sys.stdin)
+results = [
+    {{"id": case["id"], "losses": [], "payload": {payload_expression}}}
+    for case in document["cases"]
+]
+sys.stdout.write(json.dumps({{"results": results}}, separators=(",", ":"), sort_keys=True) + "\\n")
+""",
+    )
+    with pytest.raises(compatibility.CompatibilityError, match="disagrees with shared vectors"):
+        compatibility.check_adjacent_version_policy(V1, policy_directory=directory)

--- a/apps/crawler/contracts/v1/fixtures/compatibility/adjacent_version_policy/go_converter.go
+++ b/apps/crawler/contracts/v1/fixtures/compatibility/adjacent_version_policy/go_converter.go
@@ -1,0 +1,102 @@
+//go:build ignore
+
+// Fixture-only adjacent-version converter. It is never built into crawler runtime.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+)
+
+type conversionCase struct {
+	ID      string         `json:"id"`
+	Payload map[string]any `json:"payload"`
+}
+
+type batch struct {
+	Cases []conversionCase `json:"cases"`
+}
+
+type loss struct {
+	Path   string `json:"path"`
+	Reason string `json:"reason"`
+}
+
+type result struct {
+	ID      string         `json:"id"`
+	Losses  []loss         `json:"losses"`
+	Payload map[string]any `json:"payload"`
+}
+
+type results struct {
+	Results []result `json:"results"`
+}
+
+func convert(direction string, payload map[string]any) result {
+	converted := make(map[string]any, len(payload))
+	for key, value := range payload {
+		converted[key] = value
+	}
+	losses := make([]loss, 0)
+	if direction == "old_to_new" {
+		if _, present := converted["legacy_note"]; present {
+			delete(converted, "legacy_note")
+			losses = append(losses, loss{
+				Path:   "$.legacy_note",
+				Reason: "field removed in adjacent test version",
+			})
+		}
+	}
+	if direction == "new_to_old" {
+		if _, present := converted["future_hint"]; present {
+			delete(converted, "future_hint")
+			losses = append(losses, loss{
+				Path:   "$.future_hint",
+				Reason: "field unavailable in adjacent test version",
+			})
+		}
+	}
+	return result{Losses: losses, Payload: converted}
+}
+
+func main() {
+	direction := flag.String("direction", "", "old_to_new or new_to_old")
+	flag.Parse()
+	if *direction != "old_to_new" && *direction != "new_to_old" {
+		fmt.Fprintln(os.Stderr, "invalid --direction")
+		os.Exit(2)
+	}
+	decoder := json.NewDecoder(os.Stdin)
+	decoder.UseNumber()
+	var input batch
+	if err := decoder.Decode(&input); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	if len(input.Cases) == 0 {
+		fmt.Fprintln(os.Stderr, "converter input must contain nonempty cases")
+		os.Exit(1)
+	}
+	output := results{Results: make([]result, 0, len(input.Cases))}
+	for _, item := range input.Cases {
+		if item.ID == "" || item.Payload == nil {
+			fmt.Fprintln(os.Stderr, "converter case must have id and payload")
+			os.Exit(1)
+		}
+		converted := convert(*direction, item.Payload)
+		converted.ID = item.ID
+		output.Results = append(output.Results, converted)
+	}
+	encoded, err := json.Marshal(output)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	encoded = append(encoded, '\n')
+	if _, err := os.Stdout.Write(encoded); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/apps/crawler/contracts/v1/fixtures/compatibility/adjacent_version_policy/manifest.json
+++ b/apps/crawler/contracts/v1/fixtures/compatibility/adjacent_version_policy/manifest.json
@@ -1,0 +1,32 @@
+{
+  "converters": {
+    "go": {
+      "directions": [
+        "old_to_new",
+        "new_to_old"
+      ],
+      "path": "go_converter.go"
+    },
+    "python": {
+      "directions": [
+        "old_to_new",
+        "new_to_old"
+      ],
+      "path": "python_converter.py"
+    }
+  },
+  "fixture_only": true,
+  "format": 1,
+  "from": {
+    "package": "jobseek.crawler.runtime.policytest.v17",
+    "proto": "v17.proto",
+    "version": 17
+  },
+  "production": false,
+  "to": {
+    "package": "jobseek.crawler.runtime.policytest.v18",
+    "proto": "v18.proto",
+    "version": 18
+  },
+  "vectors": "vectors.json"
+}

--- a/apps/crawler/contracts/v1/fixtures/compatibility/adjacent_version_policy/python_converter.py
+++ b/apps/crawler/contracts/v1/fixtures/compatibility/adjacent_version_policy/python_converter.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Fixture-only adjacent-version converter; never imported by crawler runtime."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+
+def _convert(direction: str, payload: dict[str, Any]) -> dict[str, Any]:
+    converted = dict(payload)
+    losses: list[dict[str, str]] = []
+    if direction == "old_to_new" and "legacy_note" in converted:
+        converted.pop("legacy_note")
+        losses.append(
+            {
+                "path": "$.legacy_note",
+                "reason": "field removed in adjacent test version",
+            }
+        )
+    if direction == "new_to_old" and "future_hint" in converted:
+        converted.pop("future_hint")
+        losses.append(
+            {
+                "path": "$.future_hint",
+                "reason": "field unavailable in adjacent test version",
+            }
+        )
+    return {"losses": losses, "payload": converted}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--direction", choices=("old_to_new", "new_to_old"), required=True)
+    arguments = parser.parse_args()
+    document = json.load(sys.stdin)
+    cases = document.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise ValueError("converter input must contain nonempty cases")
+    results = []
+    for case in cases:
+        if not isinstance(case, dict) or not isinstance(case.get("id"), str):
+            raise ValueError("converter case must have a string id")
+        payload = case.get("payload")
+        if not isinstance(payload, dict):
+            raise ValueError("converter case payload must be an object")
+        results.append({"id": case["id"], **_convert(arguments.direction, payload)})
+    rendered = json.dumps(
+        {"results": results},
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    sys.stdout.write(rendered + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/crawler/contracts/v1/fixtures/compatibility/adjacent_version_policy/v17.proto
+++ b/apps/crawler/contracts/v1/fixtures/compatibility/adjacent_version_policy/v17.proto
@@ -1,0 +1,26 @@
+syntax = "proto3";
+
+package jobseek.crawler.runtime.policytest.v17;
+
+enum PolicyMode {
+  option allow_alias = true;
+
+  POLICY_MODE_UNSPECIFIED = 0;
+  POLICY_MODE_READY = 1;
+  POLICY_MODE_ACTIVE = 1;
+  POLICY_MODE_RETIRED = 2;
+}
+
+message PolicyEnvelope {
+  string request_id = 1;
+  optional uint64 sequence = 2;
+  map<string, string> labels = 3;
+  oneof source {
+    string source_url = 4;
+    string inline_source = 5;
+  }
+  optional string legacy_note = 6;
+  optional uint64 explicit_count = 7;
+  optional string explicit_label = 8;
+  optional PolicyMode mode = 10;
+}

--- a/apps/crawler/contracts/v1/fixtures/compatibility/adjacent_version_policy/v18.proto
+++ b/apps/crawler/contracts/v1/fixtures/compatibility/adjacent_version_policy/v18.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+
+package jobseek.crawler.runtime.policytest.v18;
+
+enum PolicyMode {
+  option allow_alias = true;
+
+  reserved 2;
+  reserved "POLICY_MODE_RETIRED";
+
+  POLICY_MODE_UNSPECIFIED = 0;
+  POLICY_MODE_READY = 1;
+  POLICY_MODE_ACTIVE = 1;
+}
+
+message PolicyEnvelope {
+  reserved 6;
+  reserved "legacy_note";
+
+  string request_id = 1;
+  optional uint64 sequence = 2;
+  map<string, string> labels = 3;
+  oneof source {
+    string source_url = 4;
+    string inline_source = 5;
+  }
+  optional uint64 explicit_count = 7;
+  optional string explicit_label = 8;
+  optional string future_hint = 9;
+  optional PolicyMode mode = 10;
+}

--- a/apps/crawler/contracts/v1/fixtures/compatibility/adjacent_version_policy/vectors.json
+++ b/apps/crawler/contracts/v1/fixtures/compatibility/adjacent_version_policy/vectors.json
@@ -1,0 +1,135 @@
+{
+  "cases": [
+    {
+      "direction": "old_to_new",
+      "expected": {
+        "losses": [],
+        "payload": {
+          "labels": {
+            "a": "first",
+            "z": "last"
+          },
+          "mode": "POLICY_MODE_ACTIVE",
+          "request_id": "old-large-absent",
+          "sequence": 9007199254740993,
+          "source_url": "https://policytest.invalid/jobs/1",
+          "unknown_777": {
+            "wire": 9007199254740995
+          }
+        }
+      },
+      "id": "old-large-absent",
+      "input": {
+        "labels": {
+          "a": "first",
+          "z": "last"
+        },
+        "mode": "POLICY_MODE_ACTIVE",
+        "request_id": "old-large-absent",
+        "sequence": 9007199254740993,
+        "source_url": "https://policytest.invalid/jobs/1",
+        "unknown_777": {
+          "wire": 9007199254740995
+        }
+      },
+      "reversible": true
+    },
+    {
+      "direction": "old_to_new",
+      "expected": {
+        "losses": [],
+        "payload": {
+          "explicit_count": 0,
+          "explicit_label": "",
+          "inline_source": "",
+          "labels": {},
+          "mode": "POLICY_MODE_READY",
+          "request_id": "old-explicit-defaults",
+          "sequence": 0
+        }
+      },
+      "id": "old-explicit-defaults",
+      "input": {
+        "explicit_count": 0,
+        "explicit_label": "",
+        "inline_source": "",
+        "labels": {},
+        "mode": "POLICY_MODE_READY",
+        "request_id": "old-explicit-defaults",
+        "sequence": 0
+      },
+      "reversible": true
+    },
+    {
+      "direction": "old_to_new",
+      "expected": {
+        "losses": [
+          {
+            "path": "$.legacy_note",
+            "reason": "field removed in adjacent test version"
+          }
+        ],
+        "payload": {
+          "request_id": "old-genuine-loss",
+          "sequence": 7
+        }
+      },
+      "id": "old-genuine-loss",
+      "input": {
+        "legacy_note": "cannot be reconstructed",
+        "request_id": "old-genuine-loss",
+        "sequence": 7
+      },
+      "reversible": false
+    },
+    {
+      "direction": "new_to_old",
+      "expected": {
+        "losses": [],
+        "payload": {
+          "explicit_count": 0,
+          "explicit_label": "",
+          "request_id": "new-large-defaults",
+          "sequence": 9007199254740997,
+          "unknown_888": {
+            "present": true
+          }
+        }
+      },
+      "id": "new-large-defaults",
+      "input": {
+        "explicit_count": 0,
+        "explicit_label": "",
+        "request_id": "new-large-defaults",
+        "sequence": 9007199254740997,
+        "unknown_888": {
+          "present": true
+        }
+      },
+      "reversible": true
+    },
+    {
+      "direction": "new_to_old",
+      "expected": {
+        "losses": [
+          {
+            "path": "$.future_hint",
+            "reason": "field unavailable in adjacent test version"
+          }
+        ],
+        "payload": {
+          "request_id": "new-genuine-loss",
+          "sequence": 9
+        }
+      },
+      "id": "new-genuine-loss",
+      "input": {
+        "future_hint": "cannot be represented",
+        "request_id": "new-genuine-loss",
+        "sequence": 9
+      },
+      "reversible": false
+    }
+  ],
+  "format": 1
+}

--- a/apps/crawler/contracts/v1/tools/check_compatibility.py
+++ b/apps/crawler/contracts/v1/tools/check_compatibility.py
@@ -10,7 +10,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
@@ -84,7 +84,10 @@ class GitBaselineState:
 _BASELINE_RELATIVE = Path("baseline/runtime-v1.descriptor.b64")
 _MANIFEST_RELATIVE = Path("baseline/manifest.json")
 _PROTO_RELATIVE = Path("runtime.proto")
+_ADJACENT_POLICY_RELATIVE = Path("fixtures/compatibility/adjacent_version_policy")
 _HEX_SHA256 = re.compile(r"[0-9a-f]{64}\Z")
+_TEST_PACKAGE = re.compile(r"jobseek\.crawler\.runtime\.policytest\.v([1-9][0-9]*)\Z")
+_CONVERTER_DIRECTIONS = ("old_to_new", "new_to_old")
 
 
 def _varint(data: bytes, offset: int) -> tuple[int, int]:
@@ -482,6 +485,7 @@ def _run(
     *,
     cwd: Path,
     input_bytes: bytes | None = None,
+    env: dict[str, str] | None = None,
     timeout: int = 30,
 ) -> subprocess.CompletedProcess[bytes]:
     try:
@@ -491,6 +495,7 @@ def _run(
             input=input_bytes,
             capture_output=True,
             check=False,
+            env=env,
             timeout=timeout,
         )
     except (OSError, subprocess.TimeoutExpired) as error:
@@ -787,6 +792,472 @@ def check(
         compare_descriptors(prior_main, current)
 
 
+def _policy_json(path: Path) -> dict[str, Any]:
+    def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise CompatibilityError(f"duplicate JSON key in {path.name}: {key}")
+            result[key] = value
+        return result
+
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=reject_duplicates)
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise CompatibilityError(
+            f"invalid adjacent-version fixture {path.name}: {error}"
+        ) from error
+    if not isinstance(value, dict):
+        raise CompatibilityError(f"adjacent-version fixture must be an object: {path.name}")
+    return value
+
+
+def _exact_keys(value: dict[str, Any], expected: set[str], label: str) -> None:
+    if set(value) != expected:
+        raise CompatibilityError(f"{label} has unexpected or missing keys")
+
+
+def _fixture_file(directory: Path, value: object, label: str) -> Path:
+    if not isinstance(value, str) or not value or Path(value).is_absolute():
+        raise CompatibilityError(f"{label} must be a relative fixture path")
+    path = (directory / value).resolve()
+    if not path.is_relative_to(directory.resolve()) or path.is_symlink() or not path.is_file():
+        raise CompatibilityError(f"{label} does not resolve to a regular fixture file")
+    return path
+
+
+def _relative_shapes(file: FileShape) -> tuple[dict[str, MessageShape], dict[str, EnumShape]]:
+    prefix = f"{file.package}."
+    return (
+        {name.removeprefix(prefix): shape for name, shape in _flatten_messages(file).items()},
+        {name.removeprefix(prefix): shape for name, shape in _flatten_enums(file).items()},
+    )
+
+
+def _field_oneof(message: MessageShape, field: FieldShape) -> str | None:
+    return message.oneofs[field.oneof_index] if field.oneof_index is not None else None
+
+
+def _normalized_policy_field(field: FieldShape, package: str) -> FieldShape:
+    return replace(
+        field,
+        type_name=field.type_name.removeprefix(f".{package}"),
+        oneof_index=None,
+    )
+
+
+def _compare_policy_descriptors(old: FileShape, new: FileShape) -> tuple[set[str], set[str]]:
+    if old.syntax != "proto3" or new.syntax != "proto3":
+        raise CompatibilityError("adjacent-version specimens must use proto3")
+    if old.dependencies or new.dependencies:
+        raise CompatibilityError("adjacent-version specimens cannot import dependencies")
+    old_messages, old_enums = _relative_shapes(old)
+    new_messages, new_enums = _relative_shapes(new)
+    removed_fields: set[str] = set()
+    added_fields: set[str] = set()
+    for name, old_message in old_messages.items():
+        new_message = new_messages.get(name)
+        if new_message is None:
+            raise CompatibilityError(f"test message removed without a field-level policy: {name}")
+        if old_message.options != new_message.options:
+            raise CompatibilityError(f"message or map-entry options changed: {name}")
+        if not old_message.reserved_names <= new_message.reserved_names or any(
+            not _reserved_range_preserved(
+                old_range, new_message.reserved_ranges, inclusive_end=False
+            )
+            for old_range in old_message.reserved_ranges
+        ):
+            raise CompatibilityError(f"prior field tombstone was removed: {name}")
+        new_by_name = {field.name: field for field in new_message.fields}
+        new_by_number = {field.number: field for field in new_message.fields}
+        for old_field in old_message.fields:
+            field_name = old_field.name
+            new_field = new_by_name.get(field_name)
+            if new_field is not None:
+                if _normalized_policy_field(old_field, old.package) != _normalized_policy_field(
+                    new_field, new.package
+                ):
+                    raise CompatibilityError(f"field or map shape changed: {name}.{field_name}")
+                if _field_oneof(old_message, old_field) != _field_oneof(new_message, new_field):
+                    raise CompatibilityError(
+                        f"oneof identity or membership changed: {name}.{field_name}"
+                    )
+                continue
+            number = old_field.number
+            if field_name not in new_message.reserved_names or not _number_reserved(
+                new_message.reserved_ranges, number
+            ):
+                raise CompatibilityError(
+                    f"removed field must reserve both name and number: {name}.{field_name}"
+                )
+            if number in new_by_number:
+                raise CompatibilityError(f"removed field number was reused: {name} #{number}")
+            removed_fields.add(field_name)
+        added_fields.update(set(new_by_name) - {field.name for field in old_message.fields})
+
+    for name, old_enum in old_enums.items():
+        new_enum = new_enums.get(name)
+        if new_enum is None:
+            raise CompatibilityError(f"test enum was removed: {name}")
+        if old_enum.options != new_enum.options:
+            raise CompatibilityError(f"enum alias policy changed: {name}")
+        if not old_enum.reserved_names <= new_enum.reserved_names or any(
+            not _reserved_range_preserved(old_range, new_enum.reserved_ranges, inclusive_end=True)
+            for old_range in old_enum.reserved_ranges
+        ):
+            raise CompatibilityError(f"prior enum tombstone was removed: {name}")
+        new_by_name = {value.name: value for value in new_enum.values}
+        new_numbers = {value.number for value in new_enum.values}
+        for old_value in old_enum.values:
+            value_name = old_value.name
+            new_value = new_by_name.get(value_name)
+            if new_value is not None:
+                if new_value != old_value:
+                    raise CompatibilityError(f"enum alias or value changed: {name}.{value_name}")
+                continue
+            number = old_value.number
+            if value_name not in new_enum.reserved_names or not _enum_number_reserved(
+                new_enum.reserved_ranges, number
+            ):
+                raise CompatibilityError(
+                    f"removed enum value must reserve both name and number: {name}.{value_name}"
+                )
+            if number in new_numbers:
+                raise CompatibilityError(f"removed enum number was reused: {name} #{number}")
+    return removed_fields, added_fields
+
+
+def _contains_large_integer(value: Any) -> bool:
+    if type(value) is int:
+        return abs(value) > 2**53
+    if isinstance(value, dict):
+        return any(_contains_large_integer(item) for item in value.values())
+    if isinstance(value, list):
+        return any(_contains_large_integer(item) for item in value)
+    return False
+
+
+def _canonical_json(value: Any) -> bytes:
+    return (
+        json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True).encode()
+        + b"\n"
+    )
+
+
+def _validate_vectors(
+    vectors: dict[str, Any], removed_fields: set[str], added_fields: set[str]
+) -> list[dict[str, Any]]:
+    _exact_keys(vectors, {"format", "cases"}, "adjacent-version vectors")
+    if type(vectors["format"]) is not int or vectors["format"] != 1:
+        raise CompatibilityError("adjacent-version vector format must be 1")
+    cases = vectors["cases"]
+    if not isinstance(cases, list) or not cases:
+        raise CompatibilityError("adjacent-version evidence corpus must be nonempty")
+    ids: set[str] = set()
+    directions: set[str] = set()
+    lossy_directions: set[str] = set()
+    reversible_directions: set[str] = set()
+    saw_large = False
+    saw_absent_defaults = False
+    saw_explicit_defaults = False
+    saw_unknown = False
+    serialized_outputs: set[bytes] = set()
+    for case in cases:
+        if not isinstance(case, dict):
+            raise CompatibilityError("adjacent-version case must be an object")
+        _exact_keys(
+            case,
+            {"id", "direction", "input", "expected", "reversible"},
+            "adjacent-version case",
+        )
+        case_id = case["id"]
+        direction = case["direction"]
+        payload = case["input"]
+        expected = case["expected"]
+        if not isinstance(case_id, str) or not case_id or case_id in ids:
+            raise CompatibilityError("adjacent-version case id is invalid or duplicated")
+        if direction not in _CONVERTER_DIRECTIONS:
+            raise CompatibilityError(f"unsupported converter direction: {direction}")
+        if not isinstance(payload, dict) or not isinstance(expected, dict):
+            raise CompatibilityError(f"case {case_id} input and expected must be objects")
+        _exact_keys(expected, {"payload", "losses"}, f"case {case_id} expected")
+        if not isinstance(expected["payload"], dict) or not isinstance(expected["losses"], list):
+            raise CompatibilityError(f"case {case_id} expected payload/losses are invalid")
+        if type(case["reversible"]) is not bool:
+            raise CompatibilityError(f"case {case_id} reversible must be a boolean")
+        allowed_loss_fields = removed_fields if direction == "old_to_new" else added_fields
+        loss_fields: set[str] = set()
+        for loss in expected["losses"]:
+            if not isinstance(loss, dict):
+                raise CompatibilityError(f"case {case_id} loss must be an object")
+            _exact_keys(loss, {"path", "reason"}, f"case {case_id} loss")
+            path = loss["path"]
+            reason = loss["reason"]
+            if (
+                not isinstance(path, str)
+                or not path.startswith("$.")
+                or not isinstance(reason, str)
+                or not reason.strip()
+            ):
+                raise CompatibilityError(f"case {case_id} loss path/reason is invalid")
+            field = path[2:]
+            if "." in field or field not in allowed_loss_fields:
+                raise CompatibilityError(f"case {case_id} declares an unsupported loss: {path}")
+            if field not in payload or field in expected["payload"] or field in loss_fields:
+                raise CompatibilityError(f"case {case_id} loss is false or duplicated: {path}")
+            loss_fields.add(field)
+        preserved = {key: value for key, value in payload.items() if key not in loss_fields}
+        if expected["payload"] != preserved:
+            raise CompatibilityError(f"case {case_id} fabricates or changes preserved fields")
+        if case["reversible"] != (not loss_fields):
+            raise CompatibilityError(f"case {case_id} reversible/loss declaration disagrees")
+        if loss_fields:
+            lossy_directions.add(direction)
+        else:
+            reversible_directions.add(direction)
+        saw_large = saw_large or _contains_large_integer(payload)
+        saw_absent_defaults = saw_absent_defaults or (
+            "explicit_count" not in payload and "explicit_label" not in payload
+        )
+        saw_explicit_defaults = saw_explicit_defaults or (
+            payload.get("explicit_count") == 0
+            and "explicit_count" in payload
+            and payload.get("explicit_label") == ""
+            and "explicit_label" in payload
+        )
+        saw_unknown = saw_unknown or any(key.startswith("unknown_") for key in payload)
+        serialized_outputs.add(_canonical_json(expected))
+        ids.add(case_id)
+        directions.add(direction)
+    if directions != set(_CONVERTER_DIRECTIONS):
+        raise CompatibilityError("adjacent-version evidence must cover both directions")
+    if lossy_directions != set(_CONVERTER_DIRECTIONS):
+        raise CompatibilityError("adjacent-version evidence must be genuinely lossy both ways")
+    if reversible_directions != set(_CONVERTER_DIRECTIONS):
+        raise CompatibilityError(
+            "adjacent-version evidence must include reversible cases both ways"
+        )
+    if not saw_large or not saw_absent_defaults or not saw_explicit_defaults or not saw_unknown:
+        raise CompatibilityError(
+            "adjacent-version evidence lacks >2^53, presence/default, or unknown-field coverage"
+        )
+    if len(serialized_outputs) < 2:
+        raise CompatibilityError("constant-output converter evidence is forbidden")
+    return cases
+
+
+def _load_adjacent_policy(directory: Path) -> dict[str, Any]:
+    directory = directory.resolve()
+    manifest = _policy_json(directory / "manifest.json")
+    _exact_keys(
+        manifest,
+        {"format", "production", "fixture_only", "from", "to", "converters", "vectors"},
+        "adjacent-version manifest",
+    )
+    if type(manifest["format"]) is not int or manifest["format"] != 1:
+        raise CompatibilityError("adjacent-version manifest format must be 1")
+    if type(manifest["production"]) is not bool or manifest["production"] is not False:
+        raise CompatibilityError("adjacent-version specimen production must be exactly false")
+    if type(manifest["fixture_only"]) is not bool or manifest["fixture_only"] is not True:
+        raise CompatibilityError("adjacent-version specimen must be explicitly fixture_only")
+    proto_paths: list[Path] = []
+    for key in ("from", "to"):
+        endpoint = manifest[key]
+        if not isinstance(endpoint, dict):
+            raise CompatibilityError(f"adjacent-version {key} endpoint must be an object")
+        _exact_keys(endpoint, {"version", "package", "proto"}, f"{key} endpoint")
+        version = endpoint["version"]
+        package = endpoint["package"]
+        if type(version) is not int or version <= 0 or not isinstance(package, str):
+            raise CompatibilityError(f"adjacent-version {key} identity is invalid")
+        match = _TEST_PACKAGE.fullmatch(package)
+        if match is None or int(match.group(1)) != version:
+            raise CompatibilityError(f"adjacent-version {key} package is not test-only")
+        proto = _fixture_file(directory, endpoint["proto"], f"{key} protobuf")
+        if proto.suffix != ".proto":
+            raise CompatibilityError(f"adjacent-version {key} protobuf has the wrong file type")
+        proto_paths.append(proto)
+    if manifest["to"]["version"] != manifest["from"]["version"] + 1:
+        raise CompatibilityError("adjacent-version specimen is not numerically adjacent")
+    endpoints = [parse_descriptor_set(compile_descriptor(path)) for path in proto_paths]
+    for key, descriptor in zip(("from", "to"), endpoints, strict=True):
+        if descriptor.package != manifest[key]["package"]:
+            raise CompatibilityError(f"adjacent-version {key} protobuf package disagrees")
+    removed_fields, added_fields = _compare_policy_descriptors(*endpoints)
+    if not removed_fields or not added_fields:
+        raise CompatibilityError(
+            "adjacent-version specimen must exercise real additions and removals"
+        )
+
+    converters = manifest["converters"]
+    if not isinstance(converters, dict) or set(converters) != {"python", "go"}:
+        raise CompatibilityError("adjacent-version policy requires Python and Go converters")
+    runners: dict[str, Path] = {}
+    for language, suffix in (("python", ".py"), ("go", ".go")):
+        config = converters[language]
+        if not isinstance(config, dict):
+            raise CompatibilityError(f"{language} converter declaration must be an object")
+        _exact_keys(config, {"path", "directions"}, f"{language} converter")
+        if config["directions"] != list(_CONVERTER_DIRECTIONS):
+            raise CompatibilityError(f"{language} converter must declare both directions")
+        path = _fixture_file(directory, config["path"], f"{language} converter")
+        if path.suffix != suffix:
+            raise CompatibilityError(f"{language} converter has the wrong file type")
+        runners[language] = path
+    vectors_path = _fixture_file(directory, manifest["vectors"], "adjacent-version vectors")
+    cases = _validate_vectors(_policy_json(vectors_path), removed_fields, added_fields)
+    return {"manifest": manifest, "runners": runners, "cases": cases}
+
+
+def validate_adjacent_version_policy(directory: Path) -> None:
+    """Validate the deliberately test-only adjacent-version policy specimen."""
+
+    _load_adjacent_policy(directory)
+
+
+def _converter_batch(
+    *,
+    language: str,
+    runner: Path,
+    direction: str,
+    cases: list[dict[str, Any]],
+    go_cache: Path,
+) -> tuple[bytes, dict[str, Any]]:
+    batch = {"cases": [{"id": case["id"], "payload": case["input"]} for case in cases]}
+    if language == "python":
+        command = [sys.executable, str(runner), "--direction", direction]
+        environment = os.environ.copy()
+    else:
+        go = shutil.which("go")
+        if go is None:
+            raise CompatibilityError("required Go toolchain is unavailable")
+        command = [go, "run", str(runner), "--direction", direction]
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "GO111MODULE": "off",
+                "GOCACHE": str(go_cache / "build"),
+                "GOENV": "off",
+                "GOMODCACHE": str(go_cache / "modules"),
+                "GOPATH": str(go_cache / "path"),
+                "GOPROXY": "off",
+                "GOSUMDB": "off",
+                "GOTOOLCHAIN": "local",
+            }
+        )
+    completed = _run(
+        command,
+        cwd=runner.parent,
+        input_bytes=_canonical_json(batch),
+        env=environment,
+        timeout=60,
+    )
+    try:
+        parsed = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise CompatibilityError(f"{language} converter emitted invalid JSON") from error
+    if (
+        not isinstance(parsed, dict)
+        or set(parsed) != {"results"}
+        or not isinstance(parsed["results"], list)
+    ):
+        raise CompatibilityError(f"{language} converter emitted an invalid result envelope")
+    if completed.stdout != _canonical_json(parsed):
+        raise CompatibilityError(f"{language} converter bytes are not canonical")
+    return completed.stdout, parsed
+
+
+def check_adjacent_version_policy(root: Path, *, policy_directory: Path | None = None) -> None:
+    """Execute both test-only language paths, directions, and mixed compositions."""
+
+    directory = (
+        policy_directory.resolve()
+        if policy_directory is not None
+        else root.resolve() / _ADJACENT_POLICY_RELATIVE
+    )
+    policy = _load_adjacent_policy(directory)
+    cases: list[dict[str, Any]] = policy["cases"]
+    runners: dict[str, Path] = policy["runners"]
+    by_direction = {
+        direction: [case for case in cases if case["direction"] == direction]
+        for direction in _CONVERTER_DIRECTIONS
+    }
+    observed: dict[tuple[str, str], dict[str, Any]] = {}
+    raw: dict[tuple[str, str], bytes] = {}
+    with tempfile.TemporaryDirectory(prefix="runtime-adjacent-policy-go-") as temporary:
+        go_cache = Path(temporary)
+        for language, runner in runners.items():
+            for direction, direction_cases in by_direction.items():
+                first_raw, first = _converter_batch(
+                    language=language,
+                    runner=runner,
+                    direction=direction,
+                    cases=direction_cases,
+                    go_cache=go_cache,
+                )
+                second_raw, _ = _converter_batch(
+                    language=language,
+                    runner=runner,
+                    direction=direction,
+                    cases=direction_cases,
+                    go_cache=go_cache,
+                )
+                if first_raw != second_raw:
+                    raise CompatibilityError(
+                        f"{language} {direction} converter is nondeterministic"
+                    )
+                expected = {
+                    "results": [{"id": case["id"], **case["expected"]} for case in direction_cases]
+                }
+                if first != expected:
+                    raise CompatibilityError(
+                        f"{language} {direction} converter disagrees with shared vectors"
+                    )
+                observed[(language, direction)] = first
+                raw[(language, direction)] = first_raw
+        for direction in _CONVERTER_DIRECTIONS:
+            if raw[("python", direction)] != raw[("go", direction)]:
+                raise CompatibilityError(f"cross-language {direction} canonical bytes differ")
+
+        opposite = {"old_to_new": "new_to_old", "new_to_old": "old_to_new"}
+        for first_language, second_language in (("python", "go"), ("go", "python")):
+            for direction in _CONVERTER_DIRECTIONS:
+                direction_cases = by_direction[direction]
+                first_results = {
+                    item["id"]: item for item in observed[(first_language, direction)]["results"]
+                }
+                composed_cases = [
+                    {
+                        "id": case["id"],
+                        "input": first_results[case["id"]]["payload"],
+                    }
+                    for case in direction_cases
+                ]
+                _, composed = _converter_batch(
+                    language=second_language,
+                    runner=runners[second_language],
+                    direction=opposite[direction],
+                    cases=composed_cases,
+                    go_cache=go_cache,
+                )
+                final = {item["id"]: item for item in composed["results"]}
+                for case in direction_cases:
+                    item = final.get(case["id"])
+                    if item is None or item["losses"]:
+                        raise CompatibilityError(
+                            f"mixed {first_language}/{second_language} round trip failed: "
+                            f"{case['id']}"
+                        )
+                    expected_payload = (
+                        case["input"] if case["reversible"] else case["expected"]["payload"]
+                    )
+                    if item["payload"] != expected_payload:
+                        raise CompatibilityError(
+                            f"mixed {first_language}/{second_language} round trip failed: "
+                            f"{case['id']}"
+                        )
+
+
 def _default_root() -> Path:
     return Path(__file__).resolve().parents[1]
 
@@ -798,17 +1269,23 @@ def main() -> int:
     parser.add_argument("--root", type=Path, default=_default_root())
     parser.add_argument("--base-ref")
     parser.add_argument("--protoc", default="protoc")
+    parser.add_argument("--adjacent-policy-only", action="store_true")
     arguments = parser.parse_args()
     try:
-        check(
-            arguments.root,
-            base_ref=arguments.base_ref,
-            protoc=arguments.protoc,
-        )
+        if not arguments.adjacent_policy_only:
+            check(
+                arguments.root,
+                base_ref=arguments.base_ref,
+                protoc=arguments.protoc,
+            )
+        check_adjacent_version_policy(arguments.root)
     except CompatibilityError as error:
         print(f"runtime v1 compatibility failed: {error}", file=sys.stderr)
         return 1
-    print("runtime v1 compatibility: ok")
+    if arguments.adjacent_policy_only:
+        print("runtime v1 adjacent-version policy: ok")
+    else:
+        print("runtime v1 compatibility and adjacent-version policy: ok")
     return 0
 
 


### PR DESCRIPTION
Closes #8076
Parent: #8057
Umbrella: #8042
Epic: #7935
Supersedes closed, unmerged PR #8070

## Outcome

Replays only the immutable, reviewed adjacent-version policy candidate from donor `3f68bf29560a912be69486aad5834f012ce89e56` onto fresh main. The exact ten policy files have canonical content hash `2f54c3d266bf00097645d86ec6ac72bf01c2e7b7070654d417e463f3eb42a1f7`.

The candidate is deliberately versionless and inactive. It introduces executable, test-only Python and Go bidirectional compatibility evidence, reservation/tombstone enforcement, deterministic shared reversible/lossy vectors, and a normal Required-CI discovery surface. It does not introduce a real v2, production converters, bindings, packaging, runtime consumption, deployment, or activation.

## Publication boundary

- Fresh base: `60bb601063c998857e1898c199b080501aebe466`
- Exact head: `847f24105ea66d073e3ac5ea458530b5e671dc00`
- Branch: `codex/8076-versionless-policy-root-20260826`
- #8071 / PR #8073 merge `9b7ea8afda2e45167e6477eff1087faef6ecc372` verified in base ancestry
- Exact changed-path count: 10, all below `apps/crawler/contracts/v1/**`
- Canonical ten-file content hash: `2f54c3d266bf00097645d86ec6ac72bf01c2e7b7070654d417e463f3eb42a1f7`
- VERSION: unchanged at `0.13.538`
- Frozen `runtime.proto` and `baseline/**`: unchanged
- First push: ordinary/non-forced after live main and remote branch absence were rechecked

No bytes or history were reused from PR #8070, its retired heads, or the unauthorized directional-loss changes.

## Verification

- focused Python adjacent-policy suite: 28 passed
- fully offline Go `test -race -count=1` and `go vet`: passed
- adjacent-only compatibility CLI: passed
- full runtime v1 compatibility + adjacent-policy CLI: passed
- normal Required-CI discovery wrapper: 101 passed
- #8071 release/runtime/workflow policy tests: 103 passed
- ATS inventory deployment checks: 12 passed
- Ruff check/format and Pyright: clean, 0 errors
- exact path/hash/VERSION/frozen-proto/baseline checks: passed
- `git diff --check`: clean

The exact commit evaluates as `inactive-v1-candidate`; the active runtime digest is unchanged. Crawler/browser deployment, ATS deployment, ws publishing, and Murmur deployment are not selected. Hosted CI supplies exact-head integration evidence.

## Review boundary

Draft for one independent exact-head review. At most one bounded repair limited to that review is permitted. The writer will not force/rebase, self-review, mark ready, or merge.