### PR TITLE
Fix company ranking pagination

### DIFF
--- a/apps/web/src/lib/search/__tests__/typesense.e2e.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense.e2e.test.ts
@@ -762,7 +762,7 @@ describe("search()", () => {
 // =====================================================================
 
 describe("listTopCompanies()", () => {
-  it("unfiltered returns companies sorted by freshest posting", async () => {
+  it("unfiltered returns companies sorted by active posting count", async () => {
     if (skipIfUnavailable()) return;
 
     const result = await provider.listTopCompanies({
@@ -774,16 +774,10 @@ describe("listTopCompanies()", () => {
     expect(result.companies.length).toBeGreaterThan(0);
     expect(result.totalCompanies).toBeGreaterThan(0);
 
-    // Companies should be sorted by each company's newest visible posting.
+    // Companies should be sorted by their pre-computed active inventory size.
     for (let i = 1; i < result.companies.length; i++) {
-      const previousNewest = new Date(
-        result.companies[i - 1].postings[0].firstSeenAt,
-      ).getTime();
-      const currentNewest = new Date(
-        result.companies[i].postings[0].firstSeenAt,
-      ).getTime();
-      expect(previousNewest).toBeGreaterThanOrEqual(
-        currentNewest,
+      expect(result.companies[i - 1].activeMatches).toBeGreaterThanOrEqual(
+        result.companies[i].activeMatches,
       );
     }
   });

--- a/apps/web/src/lib/search/__tests__/typesense.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense.test.ts
@@ -95,8 +95,7 @@ function freshnessGroupedResponse() {
 
 function companyResponse() {
   return {
-    // Deliberately return company docs in active-count order. Providers must
-    // preserve the freshness order from grouped postings.
+    found: 2,
     hits: [
       companyHit("stale-bigco", "Stale BigCo", 50_000, 50_000),
       companyHit("fresh-co", "Fresh Co", 1, 1),
@@ -123,8 +122,32 @@ function outOfOrderPostingsResponse() {
 
 function mixedCompanyResponse() {
   return {
+    found: 1,
     hits: [companyHit("mixed-co", "Mixed Co", 2, 2)],
   };
+}
+
+function rankedCompanyHits(ids: string[]) {
+  return ids.map((id, index) =>
+    companyHit(id, `Company ${id}`, ids.length - index, ids.length - index),
+  );
+}
+
+function groupedPostingsFor(ids: string[], missing = new Set<string>()) {
+  return {
+    grouped_hits: ids
+      .filter((id) => !missing.has(id))
+      .map((id, index) => ({
+        group_key: [id],
+        found: 1,
+        hits: [postingHit(id, `Company ${id}`, NOW - index)],
+      })),
+  };
+}
+
+function companyIdsFromFilter(filter: unknown): string[] {
+  const match = String(filter).match(/company_id:\[([^\]]+)\]/);
+  return match?.[1]?.split(",") ?? [];
 }
 
 function blankCompanyPostingHit(companyId: string, title: string) {
@@ -186,7 +209,7 @@ afterEach(() => {
 });
 
 describe("TypesenseSearchProvider.listTopCompanies", () => {
-  it("ranks the anonymous default surface by freshest active posting, not company size", async () => {
+  it("ranks the anonymous default surface by active company size", async () => {
     const provider = new TypesenseSearchProvider();
 
     mocks.search.mockImplementation(async (collection: string) => {
@@ -203,31 +226,101 @@ describe("TypesenseSearchProvider.listTopCompanies", () => {
     });
 
     expect(result.companies.map((c) => c.company.id)).toEqual([
-      "fresh-co",
       "stale-bigco",
+      "fresh-co",
     ]);
-    expect(result.companies.map((c) => c.activeMatches)).toEqual([1, 50_000]);
+    expect(result.companies.map((c) => c.activeMatches)).toEqual([50_000, 1]);
     expect(result.totalCompanies).toBe(2);
     expect(mocks.calls[0]).toMatchObject({
+      collection: "company",
+      params: {
+        q: "*",
+        filter_by: "active_posting_count:>0",
+        sort_by: "active_posting_count:desc,year_posting_count:desc",
+        offset: 0,
+        limit: 2,
+      },
+    });
+    expect(mocks.calls[1]).toMatchObject({
       collection: "job_posting",
       params: {
         q: "*",
-        filter_by: POSTING_BASE_FILTER,
+        filter_by: `company_id:[stale-bigco,fresh-co] && ${POSTING_BASE_FILTER}`,
         group_by: "company_id",
         group_limit: 10,
         sort_by: "first_seen_at:desc",
         per_page: 2,
-        page: 1,
       },
     });
-    expect(mocks.calls[1]).toMatchObject({
+  });
+
+  it("honors a non-page-aligned offset in the deterministic company ranking", async () => {
+    const ids = Array.from({ length: 15 }, (_, index) => `company-${index + 1}`);
+    const hits = rankedCompanyHits(ids);
+    mocks.search.mockImplementation(
+      async (collection: string, params: Record<string, unknown>) => {
+        if (collection === "company") {
+          const offset = Number(params.offset);
+          const limit = Number(params.limit);
+          return { found: ids.length, hits: hits.slice(offset, offset + limit) };
+        }
+        return groupedPostingsFor(companyIdsFromFilter(params.filter_by));
+      },
+    );
+
+    const result = await new TypesenseSearchProvider().listTopCompanies({
+      languages: [],
+      locale: "en",
+      offset: 5,
+      limit: 4,
+    });
+
+    expect(result.companies.map((entry) => entry.company.id)).toEqual(
+      ids.slice(5, 9),
+    );
+    expect(mocks.calls[0]).toMatchObject({
       collection: "company",
-      params: {
-        q: "*",
-        filter_by: "id:[fresh-co,stale-bigco]",
-        per_page: 2,
-      },
+      params: { offset: 0, limit: 9 },
     });
+  });
+
+  it("continues ranked hydration when stale company counts underfill a batch", async () => {
+    const ids = ["stale", "company-b", "company-c", "company-d"];
+    const hits = rankedCompanyHits(ids);
+    const missing = new Set(["stale"]);
+    mocks.search.mockImplementation(
+      async (collection: string, params: Record<string, unknown>) => {
+        if (collection === "company") {
+          const offset = Number(params.offset);
+          const limit = Number(params.limit);
+          return { found: ids.length, hits: hits.slice(offset, offset + limit) };
+        }
+        return groupedPostingsFor(
+          companyIdsFromFilter(params.filter_by),
+          missing,
+        );
+      },
+    );
+
+    const result = await new TypesenseSearchProvider().listTopCompanies({
+      languages: [],
+      locale: "en",
+      offset: 1,
+      limit: 2,
+    });
+
+    expect(result.companies.map((entry) => entry.company.id)).toEqual([
+      "company-c",
+      "company-d",
+    ]);
+    expect(
+      mocks.calls
+        .filter((call) => call.collection === "company")
+        .map((call) => call.params),
+    ).toEqual([
+      expect.objectContaining({ offset: 0, limit: 3 }),
+      expect.objectContaining({ offset: 3, limit: 2 }),
+    ]);
   });
 
   it("orders postings inside anonymous default company cards by freshness", async () => {
@@ -291,7 +384,7 @@ describe("TypesenseSearchProvider.listTopCompanies", () => {
 });
 
 describe("TypesenseBrowserProvider.listTopCompanies", () => {
-  it("uses the same freshness ranking as the server provider", async () => {
+  it("uses the same active-company ranking as the server provider", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: string | URL | Request) => {
@@ -328,30 +421,142 @@ describe("TypesenseBrowserProvider.listTopCompanies", () => {
     });
 
     expect(result.companies.map((c) => c.company.id)).toEqual([
-      "fresh-co",
       "stale-bigco",
+      "fresh-co",
     ]);
     expect(result.totalCompanies).toBe(2);
     expect(mocks.browserCalls[0]).toMatchObject({
+      collection: "company",
+      params: {
+        q: "*",
+        filter_by: "active_posting_count:>0",
+        sort_by: "active_posting_count:desc,year_posting_count:desc",
+        offset: "0",
+        limit: "2",
+      },
+    });
+    expect(mocks.browserCalls[1]).toMatchObject({
       collection: "job_posting",
       params: {
         q: "*",
-        filter_by: POSTING_BASE_FILTER,
+        filter_by: `company_id:[stale-bigco,fresh-co] && ${POSTING_BASE_FILTER}`,
         group_by: "company_id",
         group_limit: "10",
         sort_by: "first_seen_at:desc",
         per_page: "2",
-        page: "1",
       },
     });
-    expect(mocks.browserCalls[1]).toMatchObject({
+  });
+
+  it("honors a non-page-aligned browser offset", async () => {
+    const ids = Array.from({ length: 15 }, (_, index) => `company-${index + 1}`);
+    const hits = rankedCompanyHits(ids);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url === "/api/typesense-key") {
+          return Response.json({
+            apiKey: "browser-key",
+            host: "typesense.example",
+            port: 443,
+            protocol: "https",
+            expiresAt: Date.now() + 60_000,
+          });
+        }
+        const parsed = new URL(url);
+        const collection = parsed.pathname.match(/\/collections\/([^/]+)/)?.[1];
+        const params = Object.fromEntries(parsed.searchParams.entries());
+        if (!collection) throw new Error(`unexpected URL: ${url}`);
+        mocks.browserCalls.push({ collection, params });
+        if (collection === "company") {
+          const offset = Number(params.offset);
+          const limit = Number(params.limit);
+          return Response.json({
+            found: ids.length,
+            hits: hits.slice(offset, offset + limit),
+          });
+        }
+        return Response.json(
+          groupedPostingsFor(companyIdsFromFilter(params.filter_by)),
+        );
+      }),
+    );
+
+    const result = await new TypesenseBrowserProvider().listTopCompanies({
+      languages: [],
+      locale: "en",
+      offset: 5,
+      limit: 4,
+    });
+
+    expect(result.companies.map((entry) => entry.company.id)).toEqual(
+      ids.slice(5, 9),
+    );
+    expect(mocks.browserCalls[0]).toMatchObject({
       collection: "company",
-      params: {
-        q: "*",
-        filter_by: "id:[fresh-co,stale-bigco]",
-        per_page: "2",
-      },
+      params: { offset: "0", limit: "9" },
     });
+  });
+
+  it("continues browser hydration past an underfilled ranked batch", async () => {
+    const ids = ["stale", "company-b", "company-c", "company-d"];
+    const hits = rankedCompanyHits(ids);
+    const missing = new Set(["stale"]);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        const url = String(input);
+        if (url === "/api/typesense-key") {
+          return Response.json({
+            apiKey: "browser-key",
+            host: "typesense.example",
+            port: 443,
+            protocol: "https",
+            expiresAt: Date.now() + 60_000,
+          });
+        }
+        const parsed = new URL(url);
+        const collection = parsed.pathname.match(/\/collections\/([^/]+)/)?.[1];
+        const params = Object.fromEntries(parsed.searchParams.entries());
+        if (!collection) throw new Error(`unexpected URL: ${url}`);
+        mocks.browserCalls.push({ collection, params });
+        if (collection === "company") {
+          const offset = Number(params.offset);
+          const limit = Number(params.limit);
+          return Response.json({
+            found: ids.length,
+            hits: hits.slice(offset, offset + limit),
+          });
+        }
+        return Response.json(
+          groupedPostingsFor(
+            companyIdsFromFilter(params.filter_by),
+            missing,
+          ),
+        );
+      }),
+    );
+
+    const result = await new TypesenseBrowserProvider().listTopCompanies({
+      languages: [],
+      locale: "en",
+      offset: 1,
+      limit: 2,
+    });
+
+    expect(result.companies.map((entry) => entry.company.id)).toEqual([
+      "company-c",
+      "company-d",
+    ]);
+    expect(
+      mocks.browserCalls
+        .filter((call) => call.collection === "company")
+        .map((call) => call.params),
+    ).toEqual([
+      expect.objectContaining({ offset: "0", limit: "3" }),
+      expect.objectContaining({ offset: "3", limit: "2" }),
+    ]);
   });
 
   it("orders browser-fetched anonymous card postings by freshness", async () => {

--- a/apps/web/src/lib/search/typesense-browser.ts
+++ b/apps/web/src/lib/search/typesense-browser.ts
@@ -360,51 +360,88 @@ export class TypesenseBrowserProvider implements SearchProvider {
     offset: number,
     limit: number,
   ): Promise<SearchResponse> {
-    const postingResults = await searchOne<JobPostingDoc>(cfg, "job_posting", {
-      q: "*",
-      filter_by: POSTING_BASE_FILTER,
-      group_by: "company_id",
-      group_limit: 10,
-      sort_by: "first_seen_at:desc",
-      per_page: limit,
-      page: Math.floor(offset / limit) + 1,
-      facet_by: "company_id",
-      facet_strategy: "exhaustive",
-      max_facet_values: 1,
-    });
-    const groupedHits = (postingResults.grouped_hits ?? []) as GroupedHit<JobPostingDoc>[];
-    const totalCompanies =
-      postingResults.facet_counts?.[0]?.stats?.total_values ?? groupedHits.length;
-    if (groupedHits.length === 0) return { companies: [], totalCompanies };
+    const targetCount = offset + limit;
+    const rankedCompanies: SearchResultCompany[] = [];
+    const seenCompanyIds = new Set<string>();
+    let rawOffset = 0;
+    let totalCompanies = 0;
 
-    const companyIds = groupedHits.map((g) => g.hits[0].document.company_id);
-    const compMap = await fetchCompaniesById(cfg, companyIds);
-
-    const companies: SearchResultCompany[] = groupedHits
-      .map((g) => {
-        const first = g.hits[0]?.document;
-        if (!first) return null;
-        const cid = first.company_id;
-        const compDoc = compMap.get(cid);
-        const company = resolveTypesenseCompany(
-          cid,
-          g.hits.map((hit) => hit.document),
-          compDoc,
-        );
-        if (!company) return null;
-        return {
-          company,
-          activeMatches: compDoc?.active_posting_count ?? g.found ?? g.hits.length,
-          yearMatches: compDoc?.year_posting_count ?? 0,
-          postings: mapHitsToPostingsByFreshness(g.hits),
-        } satisfies SearchResultCompany;
-      })
-      .filter(
-        (company): company is SearchResultCompany =>
-          company !== null && company.postings.length > 0,
+    while (rankedCompanies.length < targetCount) {
+      const requestLimit = Math.min(
+        250,
+        Math.max(limit, targetCount - rankedCompanies.length),
       );
+      const companyResults = await searchOne<TypesenseCompanyDocument>(
+        cfg,
+        "company",
+        {
+          q: "*",
+          filter_by: "active_posting_count:>0",
+          sort_by: "active_posting_count:desc,year_posting_count:desc",
+          offset: rawOffset,
+          limit: requestLimit,
+        },
+      );
+      if (rawOffset === 0) totalCompanies = companyResults.found ?? 0;
+      const companyHits = companyResults.hits ?? [];
+      if (companyHits.length === 0) break;
+      rawOffset += companyHits.length;
 
-    return { companies, totalCompanies };
+      const uniqueHits = companyHits.filter((hit) => {
+        const companyId = hit.document.id;
+        if (seenCompanyIds.has(companyId)) return false;
+        seenCompanyIds.add(companyId);
+        return true;
+      });
+      const companyIds = uniqueHits.map((hit) => hit.document.id);
+      if (companyIds.length > 0) {
+        const postingResults = await searchOne<JobPostingDoc>(cfg, "job_posting", {
+          q: "*",
+          filter_by: `company_id:[${companyIds.join(",")}] && ${POSTING_BASE_FILTER}`,
+          group_by: "company_id",
+          group_limit: 10,
+          sort_by: "first_seen_at:desc",
+          per_page: companyIds.length,
+        });
+        const groupedHits = (postingResults.grouped_hits ?? []) as GroupedHit<JobPostingDoc>[];
+        const groupMap = new Map(
+          groupedHits.map((group) => [group.hits[0].document.company_id, group]),
+        );
+        const compMap = new Map(
+          uniqueHits.map((hit) => [hit.document.id, hit.document]),
+        );
+
+        for (const cid of companyIds) {
+          const group = groupMap.get(cid);
+          if (!group) continue;
+          const first = group.hits[0]?.document;
+          if (!first) continue;
+          const compDoc = compMap.get(cid);
+          const company = resolveTypesenseCompany(
+            cid,
+            group.hits.map((hit) => hit.document),
+            compDoc,
+          );
+          if (!company) continue;
+          const postings = mapHitsToPostingsByFreshness(group.hits);
+          if (postings.length === 0) continue;
+          rankedCompanies.push({
+            company,
+            activeMatches:
+              compDoc?.active_posting_count ?? group.found ?? group.hits.length,
+            yearMatches: compDoc?.year_posting_count ?? 0,
+            postings,
+          });
+        }
+      }
+
+      if (companyHits.length < requestLimit || rawOffset >= companyResults.found) break;
+    }
+
+    return {
+      companies: rankedCompanies.slice(offset, targetCount),
+      totalCompanies,
+    };
   }
 
   async loadPostings(

--- a/apps/web/src/lib/search/typesense.ts
+++ b/apps/web/src/lib/search/typesense.ts
@@ -458,64 +458,107 @@ export class TypesenseSearchProvider implements SearchProvider {
     limit: number,
   ): Promise<SearchResponse> {
     const client = getSearchClient();
+    const targetCount = offset + limit;
+    const rankedCompanies: SearchResultCompany[] = [];
+    const seenCompanyIds = new Set<string>();
+    let rawOffset = 0;
+    let totalCompanies = 0;
 
-    const postingResults: TsSearchResponse<JobPostingDoc> = await withTypesenseRetry(
-      () =>
-        client
-          .collections<JobPostingDoc>("job_posting")
-          .documents()
-          .search({
-            q: "*",
-            filter_by: POSTING_BASE_FILTER,
-            group_by: "company_id",
-            group_limit: 10,
-            sort_by: "first_seen_at:desc",
-            per_page: limit,
-            page: Math.floor(offset / limit) + 1,
-            facet_by: "company_id",
-            facet_strategy: "exhaustive",
-            max_facet_values: 1,
-          }),
-      { label: "topCompaniesUnfiltered" },
-    );
+    // Company counts are refreshed independently from posting documents. A
+    // ranked company can therefore have no currently visible posting group.
+    // Scan from the start of the deterministic Typesense ranking on every
+    // request and count only hydrated companies before applying the public
+    // offset. This keeps arbitrary offsets exact across underfilled batches.
+    while (rankedCompanies.length < targetCount) {
+      const requestLimit = Math.min(
+        250,
+        Math.max(limit, targetCount - rankedCompanies.length),
+      );
+      const companyResults: TsSearchResponse<TypesenseCompanyDocument> =
+        await withTypesenseRetry(
+          () =>
+            client
+              .collections<TypesenseCompanyDocument>("company")
+              .documents()
+              .search({
+                q: "*",
+                filter_by: "active_posting_count:>0",
+                sort_by: "active_posting_count:desc,year_posting_count:desc",
+                offset: rawOffset,
+                limit: requestLimit,
+              }),
+          { label: "topCompaniesUnfilteredRank" },
+        );
 
-    const groupedHits = (postingResults.grouped_hits ?? []) as GroupedHit[];
-    const totalCompanies =
-      postingResults.facet_counts?.[0]?.stats?.total_values ?? groupedHits.length;
-    if (groupedHits.length === 0) {
-      return { companies: [], totalCompanies };
+      if (rawOffset === 0) totalCompanies = companyResults.found;
+      const companyHits = companyResults.hits ?? [];
+      if (companyHits.length === 0) break;
+      rawOffset += companyHits.length;
+
+      const uniqueHits = companyHits.filter((hit) => {
+        const companyId = hit.document.id;
+        if (seenCompanyIds.has(companyId)) return false;
+        seenCompanyIds.add(companyId);
+        return true;
+      });
+      const companyIds = uniqueHits.map((hit) => hit.document.id);
+      if (companyIds.length > 0) {
+        const postingResults: TsSearchResponse<JobPostingDoc> =
+          await withTypesenseRetry(
+            () =>
+              client
+                .collections<JobPostingDoc>("job_posting")
+                .documents()
+                .search({
+                  q: "*",
+                  filter_by: `company_id:[${companyIds.join(",")}] && ${POSTING_BASE_FILTER}`,
+                  group_by: "company_id",
+                  group_limit: 10,
+                  sort_by: "first_seen_at:desc",
+                  per_page: companyIds.length,
+                }),
+            { label: "topCompaniesUnfilteredPostings" },
+          );
+
+        const groupedHits = (postingResults.grouped_hits ?? []) as GroupedHit[];
+        const groupMap = new Map<string, GroupedHit>(
+          groupedHits.map((group) => [group.hits[0].document.company_id, group]),
+        );
+        const companyMap = new Map(
+          uniqueHits.map((hit) => [hit.document.id, hit.document]),
+        );
+
+        for (const companyId of companyIds) {
+          const group = groupMap.get(companyId);
+          if (!group) continue;
+          const firstHit = group.hits[0]?.document;
+          if (!firstHit) continue;
+          const compDoc = companyMap.get(companyId);
+          const company = resolveTypesenseCompany(
+            companyId,
+            group.hits.map((hit) => hit.document),
+            compDoc,
+          );
+          if (!company) continue;
+          const postings = mapHitsToPostingsByFreshness(group.hits);
+          if (postings.length === 0) continue;
+          rankedCompanies.push({
+            company,
+            activeMatches:
+              compDoc?.active_posting_count ?? group.found ?? group.hits.length,
+            yearMatches: compDoc?.year_posting_count ?? 0,
+            postings,
+          });
+        }
+      }
+
+      if (companyHits.length < requestLimit || rawOffset >= companyResults.found) break;
     }
 
-    const companyIds = groupedHits.map(
-      (g: GroupedHit) => g.hits[0].document.company_id,
-    );
-    const companyMap = await fetchCompaniesById(companyIds);
-
-    const companies: SearchResultCompany[] = groupedHits
-      .map((group: GroupedHit) => {
-        const firstHit = group.hits[0]?.document;
-        if (!firstHit) return null;
-        const companyId = firstHit.company_id;
-        const compDoc = companyMap.get(companyId);
-        const company = resolveTypesenseCompany(
-          companyId,
-          group.hits.map((hit) => hit.document),
-          compDoc,
-        );
-        if (!company) return null;
-        return {
-          company,
-          activeMatches: compDoc?.active_posting_count ?? group.found ?? group.hits.length,
-          yearMatches: compDoc?.year_posting_count ?? 0,
-          postings: mapHitsToPostingsByFreshness(group.hits),
-        };
-      })
-      .filter(
-        (company): company is SearchResultCompany =>
-          company !== null && company.postings.length > 0,
-      );
-
-    return { companies, totalCompanies };
+    return {
+      companies: rankedCompanies.slice(offset, targetCount),
+      totalCompanies,
+    };
   }
 
   async loadPostings(


### PR DESCRIPTION
## Summary

- rank the unfiltered all-languages company browse from the `company` collection by active posting count, then hydrate every ranked company with its newest visible postings
- honor arbitrary public offsets by scanning the deterministic ranking until `offset + limit` companies have actually hydrated, so stale count documents cannot repeat or skip companies
- keep server and browser-direct Typesense paths aligned while preserving their existing degraded-result/server-action fallback behavior
- add server, browser, and Typesense E2E regressions for ranking, non-page-aligned offsets, stale-count underfill, and posting freshness within company cards

This is the fresh-main, web-only extraction from #8019 and supersedes only that PR's company-ranking slice. It contains no crawler, runtime, data, migration, or deployment changes.

## Validation

- focused server/browser Typesense tests — 12 passed
- Typesense E2E search tests — 33 passed
- browser-direct fallback regressions — 4 passed
- changed-file ESLint — passed
- full web typecheck — passed
- production web build — passed
- committed diff check — passed
- `apps/crawler/VERSION` unchanged

Exact base SHA: `a5009e358edbca09d8e2fce4e7192ae14262d014`.
Exact candidate SHA: `24e4ca3d7e440f1a8249e46714d7ca58c0ea3208`.

Closes #8017.
