### PR TITLE
Cache company shells for one day

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-route-suspense.test.ts
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-route-suspense.test.ts
@@ -50,6 +50,7 @@ describe("company route partial prerendering", () => {
       "export const CACHE_TTL_COMPANY_SHELL = CACHE_TTL_DAY;",
     );
     expect(ttlSource).toContain("export const CACHE_TTL_DAY = 86400;");
+    expect(routeSource).not.toContain("company.activeJobCount");
   });
 
   it("routes a missing company to the localized recovery boundary", () => {

--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-route-suspense.test.ts
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-route-suspense.test.ts
@@ -37,6 +37,21 @@ describe("company route partial prerendering", () => {
     expect(source.match(/cacheTag\(companyCsvDataCacheTag\(\)\)/g)).toHaveLength(3);
   });
 
+  it("keeps the noindex company shell on the shared one-day cache tier", () => {
+    const routeSource = readFileSync(
+      "app/[lang]/(app)/company/[slug]/page.tsx",
+      "utf8",
+    );
+    const ttlSource = readFileSync("src/lib/cache-ttl.ts", "utf8");
+
+    expect(routeSource.match(/cacheLife\(\{ revalidate: CACHE_TTL_COMPANY_SHELL \}\)/g))
+      .toHaveLength(3);
+    expect(ttlSource).toContain(
+      "export const CACHE_TTL_COMPANY_SHELL = CACHE_TTL_DAY;",
+    );
+    expect(ttlSource).toContain("export const CACHE_TTL_DAY = 86400;");
+  });
+
   it("routes a missing company to the localized recovery boundary", () => {
     const source = readFileSync(
       "app/[lang]/(app)/company/[slug]/page.tsx",

--- a/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
@@ -242,7 +242,7 @@ export function CompanyPage({
     });
   }
 
-  // Keep the anonymous shell cacheable for an hour, then revalidate the
+  // Keep the anonymous shell cacheable for a day, then revalidate the
   // visible default postings directly from Typesense after hydration. This
   // path never falls back to a Server Action, so it preserves freshness
   // without converting page views back into Fluid CPU.

--- a/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
@@ -151,7 +151,7 @@ export default async function CompanyPageRoute({ params }: Props) {
   if (!initialData) notFound();
   const { company } = initialData;
 
-  // The page body is `'use cache'`-wrapped (1-hour revalidate) so the
+  // The page body is `'use cache'`-wrapped (1-day revalidate) so the
   // anonymous static shell ships from the per-region cache without
   // invoking a function on every request. Anything that reads
   // `CompanyPage` refreshes anonymous postings directly from Typesense after

--- a/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
@@ -59,19 +59,14 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     message: "Jobs at {name}",
     values: { name: company.name },
   });
-  const count = company.activeJobCount;
-  const countText = count > 0
-    ? i18n._({
-        id: "company.meta.positionCount",
-        comment: "SEO metadata count text for a company page; {count} is the active job count.",
-        message: "{count, plural, one {# open position} other {# open positions}}",
-        values: { count },
-      })
-    : i18n._({
-        id: "company.meta.openPositions",
-        comment: "Fallback SEO metadata count text for a company with no active jobs.",
-        message: "Open positions",
-      });
+  // Company shells are cached for a day, while posting counts move every few
+  // hours. Keep noindex/share metadata durable instead of publishing a count
+  // that can age beyond the browser-refreshed visible list.
+  const countText = i18n._({
+    id: "company.meta.openPositions",
+    comment: "Generic SEO metadata text for positions on a company page.",
+    message: "Open positions",
+  });
   const description = company.description
     ? i18n._({
         id: "company.meta.descriptionWithInfo",

--- a/apps/web/app/[lang]/(app)/company/[slug]/similar-section.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/similar-section.tsx
@@ -13,10 +13,10 @@ type Props = {
 
 /**
  * Client wrapper for the filter-aware strip. Page zero arrives in the cached
- * company route snapshot, so a no-filter visit does not need a mount-time
- * Server Action. The client still owns URL filter changes and pagination,
- * keeping `searchParams` / `headers()` / `getSession()` out of the cached
- * route render path.
+ * company route snapshot, then refreshes browser-direct from Typesense so a
+ * no-filter visit does not need a mount-time Server Action. The client still
+ * owns URL filter changes and pagination, keeping `searchParams` / `headers()`
+ * / `getSession()` out of the cached route render path.
  */
 export function SimilarSection({
   companyId,
@@ -32,7 +32,6 @@ export function SimilarSection({
       initialCompanies={initialPage?.companies ?? []}
       initialHasMore={initialPage?.hasMore ?? false}
       initialTruncated={initialPage?.truncated ?? false}
-      initialPageLoaded={initialPage != null}
       locale={locale}
     />
   );

--- a/apps/web/src/components/company/__tests__/similar-companies-strip.test.tsx
+++ b/apps/web/src/components/company/__tests__/similar-companies-strip.test.tsx
@@ -4,6 +4,7 @@ import type { SimilarCompany } from "@/lib/actions/company";
 
 const mocks = vi.hoisted(() => ({
   getSimilarCompanies: vi.fn(),
+  tryGetSimilarCompaniesDirect: vi.fn(),
 }));
 
 let currentSearchParams = new URLSearchParams();
@@ -21,6 +22,10 @@ vi.mock("@lingui/react/macro", () => ({
 vi.mock("@/lib/actions/company", () => ({
   getSimilarCompanies: (...args: unknown[]) =>
     mocks.getSimilarCompanies(...args),
+}));
+vi.mock("@/lib/search/search-runner", () => ({
+  tryGetSimilarCompaniesDirect: (...args: unknown[]) =>
+    mocks.tryGetSimilarCompaniesDirect(...args),
 }));
 vi.mock("@/components/providers/SessionProvider", () => ({
   useSession: () => ({ isPending: false }),
@@ -61,7 +66,6 @@ function renderStrip(overrides: Partial<React.ComponentProps<typeof SimilarCompa
       industryId={7}
       initialCompanies={initialCompanies}
       initialHasMore={false}
-      initialPageLoaded
       locale="en"
       {...overrides}
     />,
@@ -71,6 +75,7 @@ function renderStrip(overrides: Partial<React.ComponentProps<typeof SimilarCompa
 beforeEach(() => {
   currentSearchParams = new URLSearchParams();
   mocks.getSimilarCompanies.mockReset();
+  mocks.tryGetSimilarCompaniesDirect.mockReset();
   mocks.getSimilarCompanies.mockResolvedValue({
     companies: [
       {
@@ -83,21 +88,42 @@ beforeEach(() => {
     ],
     hasMore: false,
   });
+  mocks.tryGetSimilarCompaniesDirect.mockResolvedValue({
+    companies: [
+      {
+        id: "fresh-peer",
+        slug: "fresh-peer",
+        name: "Fresh Peer",
+        icon: null,
+        activeJobCount: 6,
+      },
+    ],
+    hasMore: false,
+  });
 });
 
 describe("SimilarCompaniesStrip cached initial page", () => {
-  it("does not issue a mount-time Server Action for an unfiltered visit", async () => {
+  it("refreshes an unfiltered visit browser-direct without a Server Action", async () => {
     renderStrip();
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(screen.getByText("Peer One")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText("Fresh Peer")).toBeTruthy();
+    });
+    expect(mocks.tryGetSimilarCompaniesDirect).toHaveBeenCalledWith({
+      companyId: "company-1",
+      industryId: 7,
+      limit: 10,
+    });
     expect(mocks.getSimilarCompanies).not.toHaveBeenCalled();
   });
 
-  it("does not retry a cached empty result on mount", async () => {
+  it("keeps a cached empty result when the direct refresh is unavailable", async () => {
+    mocks.tryGetSimilarCompaniesDirect.mockResolvedValue(null);
     const { container } = renderStrip({ initialCompanies: [] });
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await waitFor(() => {
+      expect(mocks.tryGetSimilarCompaniesDirect).toHaveBeenCalledOnce();
+    });
     expect(container.innerHTML).toBe("");
     expect(mocks.getSimilarCompanies).not.toHaveBeenCalled();
   });
@@ -118,7 +144,7 @@ describe("SimilarCompaniesStrip cached initial page", () => {
     expect(screen.getByText("Filtered Peer")).toBeTruthy();
   });
 
-  it("restores the cached unfiltered page when filters are cleared", async () => {
+  it("refreshes browser-direct when filters are cleared", async () => {
     currentSearchParams = new URLSearchParams("q=python");
     const view = renderStrip();
 
@@ -133,14 +159,14 @@ describe("SimilarCompaniesStrip cached initial page", () => {
         industryId={7}
         initialCompanies={initialCompanies}
         initialHasMore={false}
-        initialPageLoaded
         locale="en"
       />,
     );
 
     await waitFor(() => {
-      expect(screen.getByText("Peer One")).toBeTruthy();
+      expect(screen.getByText("Fresh Peer")).toBeTruthy();
     });
     expect(mocks.getSimilarCompanies).toHaveBeenCalledTimes(1);
+    expect(mocks.tryGetSimilarCompaniesDirect).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/web/src/components/company/similar-companies-strip.tsx
+++ b/apps/web/src/components/company/similar-companies-strip.tsx
@@ -10,6 +10,7 @@ import { InfiniteScrollSentinel } from "@/components/InfiniteScrollSentinel";
 import { useSession } from "@/components/providers/SessionProvider";
 import { useInfiniteScroll } from "@/lib/use-infinite-scroll";
 import { getSimilarCompanies, type SimilarCompany } from "@/lib/actions/company";
+import { tryGetSimilarCompaniesDirect } from "@/lib/search/search-runner";
 import type { Locale } from "@/lib/i18n";
 import {
   searchFilterParamsToObject,
@@ -24,8 +25,6 @@ type Props = {
   initialHasMore: boolean;
   /** True when anonymous-user pagination cap is already reached on page 0. */
   initialTruncated?: boolean;
-  /** True when the cached route snapshot already resolved unfiltered page 0. */
-  initialPageLoaded?: boolean;
   locale: Locale;
 };
 
@@ -37,7 +36,6 @@ export function SimilarCompaniesStrip({
   initialCompanies,
   initialHasMore,
   initialTruncated = false,
-  initialPageLoaded = false,
   locale,
 }: Props) {
   const { t } = useLingui();
@@ -50,11 +48,6 @@ export function SimilarCompaniesStrip({
     () => searchFilterParamsToObject(new URLSearchParams(paramsKey)),
     [paramsKey],
   );
-  // The server snapshot is unfiltered. Suppress the inaugural read when it
-  // matches the current URL, including a legitimate empty result. A filtered
-  // entry URL still fetches its filtered ranking after hydration.
-  const skipNextFetch = useRef(initialPageLoaded && paramsKey === "");
-
   const [companies, setCompanies] = useState<SimilarCompany[]>(initialCompanies);
   const [hasMore, setHasMore] = useState(initialHasMore);
   const [truncated, setTruncated] = useState(initialTruncated);
@@ -64,31 +57,30 @@ export function SimilarCompaniesStrip({
   // a filter on the search toolbar). Counts on each card stay in sync
   // with the same filter state that drives the postings list.
   useEffect(() => {
-    if (skipNextFetch.current) {
-      skipNextFetch.current = false;
-      return;
-    }
-    // When a user clears filters, restore the already-resolved unfiltered
-    // snapshot instead of creating another Server Action read.
-    if (initialPageLoaded && paramsKey === "") {
-      setCompanies(initialCompanies);
-      setHasMore(initialHasMore);
-      setTruncated(initialTruncated);
-      scrollRef.current?.scrollTo({ left: 0 });
-      return;
-    }
+    const currentIndustryId = industryId;
+    if (currentIndustryId == null) return;
     let cancelled = false;
     (async () => {
-      const next = await getSimilarCompanies(companyId, industryId, {
-        offset: 0,
-        limit: PAGE_SIZE,
-        searchParams: spObject,
-        locale,
-      });
-      if (cancelled) return;
+      // A one-day shell must not pin posting-derived rankings for a day. The
+      // unfiltered refresh talks to Typesense from the browser and deliberately
+      // returns null on failure, preserving the snapshot without consuming
+      // Fluid CPU. Filtered, user-driven changes retain the Server Action path.
+      const next = paramsKey === ""
+        ? await tryGetSimilarCompaniesDirect({
+            companyId,
+            industryId: currentIndustryId,
+            limit: PAGE_SIZE,
+          })
+        : await getSimilarCompanies(companyId, currentIndustryId, {
+            offset: 0,
+            limit: PAGE_SIZE,
+            searchParams: spObject,
+            locale,
+          });
+      if (!next || cancelled) return;
       setCompanies(next.companies);
       setHasMore(next.hasMore);
-      setTruncated(next.truncated ?? false);
+      setTruncated("truncated" in next && next.truncated === true);
       scrollRef.current?.scrollTo({ left: 0 });
     })();
     return () => {
@@ -98,10 +90,6 @@ export function SimilarCompaniesStrip({
     paramsKey,
     companyId,
     industryId,
-    initialCompanies,
-    initialHasMore,
-    initialPageLoaded,
-    initialTruncated,
     locale,
     spObject,
   ]);

--- a/apps/web/src/lib/cache-ttl.ts
+++ b/apps/web/src/lib/cache-ttl.ts
@@ -23,7 +23,7 @@
  * |                           |         | Typesense refreshes it after hydration       |
  * | `CACHE_TTL_LONG`          |  3600   | Semi-static taxonomies, locations, similar   |
  * |                           |         | companies, sitemap, watchlist matching count |
- * | `CACHE_TTL_COMPANY_SHELL` |  3600   | Anonymous company prerender; browser         |
+ * | `CACHE_TTL_COMPANY_SHELL` | 86400   | Anonymous company prerender; browser         |
  * |                           |         | Typesense refreshes postings after hydration |
  * | `CACHE_TTL_DAY`           | 86400   | Very static / rare-change (blog pages)       |
  *
@@ -53,8 +53,8 @@ export const CACHE_TTL_EXPLORE_SHELL = 600;
 /** 3600 seconds (1 hour) — semi-static taxonomies, locations, sitemap, similar companies. */
 export const CACHE_TTL_LONG = 3600;
 
-/** 1 hour — anonymous company shell; hydrated postings refresh from Typesense. */
-export const CACHE_TTL_COMPANY_SHELL = 3600;
-
 /** 86400 seconds (1 day) — very static / rare-change (blog pages). */
 export const CACHE_TTL_DAY = 86400;
+
+/** 1 day — anonymous company shell; hydrated postings refresh from Typesense. */
+export const CACHE_TTL_COMPANY_SHELL = CACHE_TTL_DAY;

--- a/apps/web/src/lib/cache-ttl.ts
+++ b/apps/web/src/lib/cache-ttl.ts
@@ -24,7 +24,7 @@
  * | `CACHE_TTL_LONG`          |  3600   | Semi-static taxonomies, locations, similar   |
  * |                           |         | companies, sitemap, watchlist matching count |
  * | `CACHE_TTL_COMPANY_SHELL` | 86400   | Anonymous company prerender; browser         |
- * |                           |         | Typesense refreshes postings after hydration |
+ * |                           |         | Typesense refreshes postings + peers         |
  * | `CACHE_TTL_DAY`           | 86400   | Very static / rare-change (blog pages)       |
  *
  * Notes:
@@ -56,5 +56,5 @@ export const CACHE_TTL_LONG = 3600;
 /** 86400 seconds (1 day) — very static / rare-change (blog pages). */
 export const CACHE_TTL_DAY = 86400;
 
-/** 1 day — anonymous company shell; hydrated postings refresh from Typesense. */
+/** 1 day — anonymous company shell; hydrated posting data refreshes from Typesense. */
 export const CACHE_TTL_COMPANY_SHELL = CACHE_TTL_DAY;

--- a/apps/web/src/lib/search/__tests__/search-runner-direct-refresh.test.ts
+++ b/apps/web/src/lib/search/__tests__/search-runner-direct-refresh.test.ts
@@ -4,6 +4,7 @@ import { setTestEnv, withTestEnv } from "@/test-utils/env";
 const mocks = vi.hoisted(() => ({
   browserListTopCompanies: vi.fn(),
   browserLoadCompanyPostings: vi.fn(),
+  browserLoadSimilarCompanies: vi.fn(),
   serverListTopCompanies: vi.fn(),
   serverSearchJobs: vi.fn(),
   serverGetCompanyPostings: vi.fn(),
@@ -27,6 +28,7 @@ vi.mock("../typesense-browser", () => ({
   getBrowserSearchProvider: () => ({
     listTopCompanies: mocks.browserListTopCompanies,
     loadPostingsWithCounts: mocks.browserLoadCompanyPostings,
+    loadSimilarCompanies: mocks.browserLoadSimilarCompanies,
   }),
 }));
 
@@ -104,6 +106,7 @@ describe("browser-direct shell refreshes", () => {
     vi.resetModules();
     const {
       tryGetCompanyPostingsDirect,
+      tryGetSimilarCompaniesDirect,
       tryListTopCompaniesDirect,
     } = await import("../search-runner");
 
@@ -126,7 +129,38 @@ describe("browser-direct shell refreshes", () => {
         false,
       ),
     ).resolves.toBeNull();
+    await expect(
+      tryGetSimilarCompaniesDirect({
+        companyId: "company-1",
+        industryId: 7,
+        limit: 10,
+      }),
+    ).resolves.toBeNull();
     expect(mocks.browserListTopCompanies).not.toHaveBeenCalled();
     expect(mocks.browserLoadCompanyPostings).not.toHaveBeenCalled();
+    expect(mocks.browserLoadSimilarCompanies).not.toHaveBeenCalled();
+  });
+
+  it("refreshes similar companies without invoking a Server Action", async () => {
+    const browserResult = {
+      companies: [],
+      hasMore: false,
+    };
+    mocks.browserLoadSimilarCompanies.mockResolvedValue(browserResult);
+    const { tryGetSimilarCompaniesDirect } = await import("../search-runner");
+
+    await expect(
+      tryGetSimilarCompaniesDirect({
+        companyId: "company-1",
+        industryId: 7,
+        limit: 10,
+      }),
+    ).resolves.toEqual(browserResult);
+    expect(mocks.browserLoadSimilarCompanies).toHaveBeenCalledWith(
+      "company-1",
+      7,
+      10,
+    );
+    expect(mocks.serverGetCompanyPostings).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/search/__tests__/typesense-browser-similar.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense-browser-similar.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../typesense-browser-key", () => ({
+  getTypesenseBrowserConfig: vi.fn().mockResolvedValue({
+    apiKey: "browser-key",
+    host: "typesense.example",
+    port: 443,
+    protocol: "https",
+    expiresAt: Date.now() + 60_000,
+  }),
+  invalidateTypesenseBrowserConfigIfUnauthorized: vi.fn(),
+}));
+
+import { TypesenseBrowserProvider } from "../typesense-browser";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("TypesenseBrowserProvider.loadSimilarCompanies", () => {
+  it("maps and ranks the unfiltered peer page from the company collection", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(Response.json({
+      found: 2,
+      hits: [
+        {
+          document: {
+            id: "peer-1",
+            slug: "peer-one",
+            name: "Peer One",
+            icon: "peer.svg",
+            active_posting_count: 12,
+          },
+        },
+      ],
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const provider = new TypesenseBrowserProvider();
+    await expect(
+      provider.loadSimilarCompanies("company-1", 7, 1),
+    ).resolves.toEqual({
+      companies: [
+        {
+          id: "peer-1",
+          slug: "peer-one",
+          name: "Peer One",
+          icon: "peer.svg",
+          activeJobCount: 12,
+        },
+      ],
+      hasMore: true,
+    });
+
+    const requestUrl = new URL(String(fetchMock.mock.calls[0]?.[0]));
+    expect(requestUrl.pathname).toBe("/collections/company/documents/search");
+    expect(requestUrl.searchParams.get("filter_by")).toBe(
+      "industry_id:=7 && active_posting_count:>0 && id:!=company-1",
+    );
+    expect(requestUrl.searchParams.get("sort_by")).toBe(
+      "active_posting_count:desc",
+    );
+    expect(requestUrl.searchParams.get("per_page")).toBe("1");
+    expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+      headers: { "x-typesense-api-key": "browser-key" },
+    });
+  });
+});

--- a/apps/web/src/lib/search/search-runner.ts
+++ b/apps/web/src/lib/search/search-runner.ts
@@ -36,6 +36,16 @@ type CompanyPostingsResult = {
   yearCount: number;
   truncated?: boolean;
 };
+type SimilarCompaniesResult = {
+  companies: Array<{
+    id: string;
+    slug: string;
+    name: string;
+    icon: string | null;
+    activeJobCount: number;
+  }>;
+  hasMore: boolean;
+};
 
 const directEnabled = process.env.NEXT_PUBLIC_TYPESENSE_DIRECT === "1";
 
@@ -211,6 +221,34 @@ export async function tryGetCompanyPostingsDirect(
     logExternalError(
       "error",
       { service: "typesense", operation: "browser_company_postings" },
+      err,
+    );
+    return null;
+  }
+}
+
+/**
+ * Revalidate the unfiltered peer strip embedded in a company shell directly
+ * against Typesense. A failed refresh keeps the rendered snapshot and never
+ * falls through to a mount-time Server Action.
+ */
+export async function tryGetSimilarCompaniesDirect(params: {
+  companyId: string;
+  industryId: number;
+  limit: number;
+}): Promise<SimilarCompaniesResult | null> {
+  if (!directEnabled) return null;
+  try {
+    const provider = await tryBrowserProvider();
+    return await provider.loadSimilarCompanies(
+      params.companyId,
+      params.industryId,
+      params.limit,
+    );
+  } catch (err) {
+    logExternalError(
+      "error",
+      { service: "typesense", operation: "browser_similar_companies" },
       err,
     );
     return null;

--- a/apps/web/src/lib/search/typesense-browser.ts
+++ b/apps/web/src/lib/search/typesense-browser.ts
@@ -61,6 +61,27 @@ interface RawSearchResponse<T> {
   search_time_ms?: number;
 }
 
+export interface BrowserSimilarCompany {
+  id: string;
+  slug: string;
+  name: string;
+  icon: string | null;
+  activeJobCount: number;
+}
+
+export interface BrowserSimilarCompaniesPage {
+  companies: BrowserSimilarCompany[];
+  hasMore: boolean;
+}
+
+interface SimilarCompanyDocument {
+  id: string;
+  slug: string;
+  name: string;
+  icon?: string;
+  active_posting_count?: number;
+}
+
 function oneYearAgoUnix(): number {
   const d = new Date();
   d.setFullYear(d.getFullYear() - 1);
@@ -530,6 +551,41 @@ export class TypesenseBrowserProvider implements SearchProvider {
       postings,
       activeCount: activeResult.found ?? 0,
       yearCount: yearResult.found ?? 0,
+    };
+  }
+
+  /** Refresh the unfiltered company-page peer strip without a Server Action. */
+  async loadSimilarCompanies(
+    companyId: string,
+    industryId: number,
+    limit: number,
+  ): Promise<BrowserSimilarCompaniesPage> {
+    // Let transport errors escape so the direct-refresh runner can preserve
+    // the prerendered snapshot without falling back to Fluid CPU.
+    const cfg = await this.cfg();
+    const result = await searchOne<SimilarCompanyDocument>(cfg, "company", {
+      q: "*",
+      query_by: "name",
+      filter_by:
+        `industry_id:=${industryId} && active_posting_count:>0 && id:!=${companyId}`,
+      sort_by: "active_posting_count:desc",
+      per_page: limit,
+      page: 1,
+      include_fields: "id,slug,name,icon,active_posting_count",
+    });
+    const companies = (result.hits ?? []).map(({ document }) => ({
+      id: String(document.id),
+      slug: String(document.slug ?? ""),
+      name: String(document.name ?? ""),
+      icon: typeof document.icon === "string" ? document.icon : null,
+      activeJobCount:
+        typeof document.active_posting_count === "number"
+          ? document.active_posting_count
+          : 0,
+    }));
+    return {
+      companies,
+      hasMore: companies.length < (result.found ?? companies.length),
     };
   }
 


### PR DESCRIPTION
Closes #8256

## Summary
- move anonymous company shells from the hourly cache tier to the one-day tier
- retain existing company and CSV cache tags so company edits continue to invalidate immediately
- refresh both postings and unfiltered peer rankings browser-direct from Typesense after hydration, with no mount-time Server Action fallback
- keep day-cached share metadata independent of volatile active-job counts
- lock the cache policy and direct-refresh behavior with regression tests

## Verification
- focused company/direct-search Vitest suite (30 tests)
- focused ESLint
- pnpm typecheck
- pnpm build
- git diff --check

## Independent review
- critic found that the explicit outer lifetime pinned nested posting-derived fragments; fixed with browser-direct peer refresh and durable metadata, pending critic re-review