### PR TITLE
Move company personalization to browser search

### DIFF
--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-content.test.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-content.test.tsx
@@ -1,56 +1,64 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, waitFor } from "@testing-library/react";
 import type { CompanyPageData } from "@/lib/actions/company-page-data";
+import type { CompanyBrowserDataResult } from "@/lib/search/company-browser-data";
 
-// `@/lib/actions/company-page-data` is a server action that transitively
-// imports `server-only`, which throws when loaded in a non-Next runtime.
-// Neutralise the gate, then swap the action itself for a spy.
-vi.mock("server-only", () => ({}));
-const mockFetchCompanyPageData = vi.fn();
-vi.mock("@/lib/actions/company-page-data", async () => {
-  const actual =
-    await vi.importActual<typeof import("@/lib/actions/company-page-data")>(
-      "@/lib/actions/company-page-data",
-    );
-  return {
-    ...actual,
-    fetchCompanyPageData: (...args: unknown[]) => mockFetchCompanyPageData(...args),
-  };
-});
+const mockLoadCompanyBrowserData = vi.fn();
+vi.mock("@/lib/search/company-browser-data", () => ({
+  loadCompanyBrowserData: (...args: unknown[]) =>
+    mockLoadCompanyBrowserData(...args),
+}));
 
-// CompanyPage has a heavy dependency tree (Lingui i18n, Typesense
-// provider, currency rates, infinite scroll, etc.). Stub it out — this
-// suite is testing the conditional-fetch logic in CompanyContent, not
-// CompanyPage's behaviour. Render a marker with initial props so the
-// stale-ISR-data regression test can assert which dataset mounted it.
+let sessionState: {
+  isLoggedIn: boolean;
+  isPending: boolean;
+  preferences: {
+    displayCurrency?: string;
+    jobLanguages?: string[];
+  } | null;
+};
+const stableRates = [{ currency: "CHF", toEur: 1.04 }];
+vi.mock("@/components/providers/SessionProvider", () => ({
+  useSession: () => sessionState,
+}));
+vi.mock("@/components/providers/SalaryDisplayProvider", () => ({
+  useSalaryRates: () => stableRates,
+}));
+
 vi.mock("../company-page", () => ({
   CompanyPage: ({
     company,
     initialActiveCount,
     initialEmploymentTypes,
+    jobLanguages,
+    displayCurrency,
+    initialSearchUnavailable,
+    initialDirectRefreshAttempted,
   }: {
     company: CompanyPageData["company"];
     initialActiveCount: number;
     initialEmploymentTypes: string[];
+    jobLanguages: string[];
+    displayCurrency: string;
+    initialSearchUnavailable?: boolean;
+    initialDirectRefreshAttempted?: boolean;
   }) => (
     <div
       data-testid="company-page"
       data-company={company.slug}
       data-active={initialActiveCount}
       data-etypes={initialEmploymentTypes.join(",")}
+      data-languages={jobLanguages.join(",")}
+      data-currency={displayCurrency}
+      data-unavailable={String(Boolean(initialSearchUnavailable))}
+      data-direct-attempted={String(Boolean(initialDirectRefreshAttempted))}
     />
   ),
 }));
-
-// Skeleton stub — a distinct marker so tests can assert when CompanyPage
-// is intentionally unmounted while personalised data is loading.
 vi.mock("@/components/search/company-skeleton", () => ({
   CompanySkeleton: () => <div data-testid="company-skeleton" />,
 }));
 
-// `useSearchParams` from `next/navigation` returns a `URLSearchParams`-
-// like object in the test environment. Mock it per-test to control the
-// filter state being observed by the component.
 let currentSearchParams = new URLSearchParams();
 vi.mock("next/navigation", () => ({
   useSearchParams: () => currentSearchParams,
@@ -81,12 +89,12 @@ function makeCompany(): CompanyPageData["company"] {
   };
 }
 
-function makeInitialData(overrides: Partial<CompanyPageData> = {}): CompanyPageData {
+function makeData(overrides: Partial<CompanyPageData> = {}): CompanyPageData {
   return {
     company: makeCompany(),
     postings: [],
-    activeCount: 0,
-    yearCount: 0,
+    activeCount: 5,
+    yearCount: 8,
     parsed: {
       keywords: [],
       locations: [],
@@ -111,11 +119,21 @@ function makeInitialData(overrides: Partial<CompanyPageData> = {}): CompanyPageD
   };
 }
 
+function successfulResult(
+  data: CompanyPageData,
+  directAttempted = true,
+): CompanyBrowserDataResult {
+  return { data, unavailable: false, directAttempted };
+}
+
 beforeEach(() => {
-  mockFetchCompanyPageData.mockReset();
-  mockFetchCompanyPageData.mockResolvedValue(makeInitialData());
   currentSearchParams = new URLSearchParams();
+  sessionState = { isLoggedIn: false, isPending: false, preferences: null };
   setDocumentCookie("");
+  mockLoadCompanyBrowserData.mockReset();
+  mockLoadCompanyBrowserData.mockImplementation(({ initialData }) =>
+    Promise.resolve(successfulResult(initialData)),
+  );
 });
 
 afterEach(() => {
@@ -123,242 +141,38 @@ afterEach(() => {
   cookieSpy = undefined;
 });
 
-describe("CompanyContent — server-render initial-data path (#3203)", () => {
-  it("does not force-scroll to the top on mount or remount", async () => {
-    const scrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
-    const initialData = makeInitialData();
-
-    try {
-      const { unmount } = render(
-        <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
-      );
-
-      await new Promise((r) => setTimeout(r, 0));
-      expect(scrollTo).not.toHaveBeenCalled();
-
-      unmount();
-      render(
-        <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
-      );
-
-      await new Promise((r) => setTimeout(r, 0));
-      expect(scrollTo).not.toHaveBeenCalled();
-    } finally {
-      scrollTo.mockRestore();
-    }
-  });
-
-  it("does NOT call fetchCompanyPageData for an anonymous, no-filter visit with prerendered initialData", async () => {
-    const initialData = makeInitialData();
-    render(
-      <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
-    );
-
-    // Wait for any queued effects to run — give them a real chance to
-    // misbehave before asserting that they didn't.
-    await new Promise((r) => setTimeout(r, 0));
-    expect(mockFetchCompanyPageData).not.toHaveBeenCalled();
-  });
-
-  it("calls fetchCompanyPageData when the `logged_in` hint cookie is present even without filters", async () => {
-    setDocumentCookie("logged_in=1");
-
-    const initialData = makeInitialData();
-    render(
-      <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
-    );
-
-    await waitFor(() => {
-      expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it("calls fetchCompanyPageData when the anon job-languages hint cookie is present", async () => {
-    // Issue #2850: anonymous viewers persist `jobLanguages` via the
-    // JSEEK_JOB_LANGUAGES cookie. When present, the server-rendered
-    // anonymous-default data may not match what the personalized
-    // server action would return, so we must refetch.
-    setDocumentCookie("JSEEK_JOB_LANGUAGES=en,de");
-
-    const initialData = makeInitialData();
-    render(
-      <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
-    );
-
-    await waitFor(() => {
-      expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it("calls fetchCompanyPageData when a filter searchParam is present", async () => {
-    currentSearchParams = new URLSearchParams("q=python");
-
-    const initialData = makeInitialData();
-    render(
-      <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
-    );
-
-    await waitFor(() => {
-      expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(1);
-    });
-
-    const callArgs = mockFetchCompanyPageData.mock.calls[0]?.[0] as {
-      slug: string;
-      searchParams: Record<string, string | undefined>;
-      locale: string;
-    };
-    expect(callArgs.slug).toBe("test-company");
-    expect(callArgs.locale).toBe("en");
-    expect(callArgs.searchParams.q).toBe("python");
-  });
-
-  it("calls fetchCompanyPageData when initialData is omitted (legacy path)", async () => {
-    render(<CompanyContent locale="en" slug="test-company" />);
-
-    await waitFor(() => {
-      expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it("does NOT call fetchCompanyPageData when a non-filter searchParam is present (e.g. utm tracking)", async () => {
-    currentSearchParams = new URLSearchParams("utm_source=google");
-
-    const initialData = makeInitialData();
-    render(
-      <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
-    );
-
-    await new Promise((r) => setTimeout(r, 0));
-    expect(mockFetchCompanyPageData).not.toHaveBeenCalled();
-  });
-
-  it("recognises every documented filter searchParam as a refetch trigger", async () => {
-    const filterParams = [
-      "q",
-      "loc",
-      "occ",
-      "sen",
-      "tech",
-      "wm",
-      "etype",
-      "sal",
-      "salcur",
-      "exp",
-    ];
-    for (const param of filterParams) {
-      mockFetchCompanyPageData.mockClear();
-      currentSearchParams = new URLSearchParams(`${param}=x`);
-
-      const initialData = makeInitialData();
-      const { unmount } = render(
-        <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
-      );
-
-      await waitFor(() => {
-        expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(1);
-      });
-      unmount();
-    }
-  });
-
-  it("does not refetch company results when only the selected posting changes", async () => {
-    setDocumentCookie("logged_in=1");
-    const initialData = makeInitialData({ activeCount: 5 });
-    const personalizedData = makeInitialData({ activeCount: 4 });
-    mockFetchCompanyPageData.mockResolvedValue(personalizedData);
-
-    const { queryByTestId, rerender } = render(
-      <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
-    );
-
-    await waitFor(() => {
-      expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(1);
-      expect(queryByTestId("company-page")?.getAttribute("data-active")).toBe(
-        "4",
-      );
-    });
-
-    currentSearchParams = new URLSearchParams("show=posting-1");
-    rerender(
-      <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
-    );
-    currentSearchParams = new URLSearchParams("show=posting-2");
-    rerender(
-      <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
+describe("CompanyContent browser initialization", () => {
+  it("uses the prerendered shell with zero mount request for default anonymous views", async () => {
+    const { getByTestId } = render(
+      <CompanyContent locale="en" slug="test-company" initialData={makeData()} />,
     );
 
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(1);
-    expect(queryByTestId("company-skeleton")).toBeNull();
-    expect(queryByTestId("company-page")?.getAttribute("data-active")).toBe(
-      "4",
-    );
+    expect(mockLoadCompanyBrowserData).not.toHaveBeenCalled();
+    expect(getByTestId("company-page").getAttribute("data-active")).toBe("5");
   });
 
-  it("keeps `show` out of filtered fetches and does not refetch when it changes", async () => {
-    currentSearchParams = new URLSearchParams("q=python&show=posting-1");
-    const initialData = makeInitialData();
+  it("ignores non-result params, including selected posting changes", async () => {
+    currentSearchParams = new URLSearchParams("utm_source=test&show=posting-1");
+    const initialData = makeData();
     const { rerender } = render(
       <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
     );
 
-    await waitFor(() => {
-      expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(1);
-    });
-    expect(mockFetchCompanyPageData.mock.calls[0]?.[0]).toMatchObject({
-      searchParams: { q: "python" },
-    });
-    expect(
-      (mockFetchCompanyPageData.mock.calls[0]?.[0] as {
-        searchParams: Record<string, string | undefined>;
-      }).searchParams.show,
-    ).toBeUndefined();
-
-    currentSearchParams = new URLSearchParams("q=python&show=posting-2");
+    currentSearchParams = new URLSearchParams("show=posting-2");
     rerender(
       <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
     );
-
     await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(1);
+    expect(mockLoadCompanyBrowserData).not.toHaveBeenCalled();
   });
 
-  it("passes etype through when it triggers a personalized fetch", async () => {
-    currentSearchParams = new URLSearchParams("etype=internship");
-
-    const initialData = makeInitialData();
-    render(
-      <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
-    );
-
-    await waitFor(() => {
-      expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(1);
-    });
-
-    const callArgs = mockFetchCompanyPageData.mock.calls[0]?.[0] as {
-      searchParams: Record<string, string | undefined>;
-    };
-    expect(callArgs.searchParams.etype).toBe("internship");
-  });
-
-  it("unmounts stale prerendered data until the filtered etype fetch resolves", async () => {
-    currentSearchParams = new URLSearchParams("etype=internship");
-    const unfilteredInitial = makeInitialData({
-      activeCount: 3835,
+  it("loads filter-bearing anonymous views through the browser path", async () => {
+    currentSearchParams = new URLSearchParams("q=python&etype=internship");
+    const filtered = makeData({
+      activeCount: 2,
       parsed: {
-        keywords: [],
-        locations: [],
-        occupations: [],
-        seniorities: [],
-        technologies: [],
-        workMode: [],
-        employmentTypes: [],
-      },
-    });
-    const filteredData = makeInitialData({
-      activeCount: 870,
-      parsed: {
-        keywords: [],
+        keywords: ["python"],
         locations: [],
         occupations: [],
         seniorities: [],
@@ -367,129 +181,156 @@ describe("CompanyContent — server-render initial-data path (#3203)", () => {
         employmentTypes: ["internship"],
       },
     });
+    mockLoadCompanyBrowserData.mockResolvedValue(successfulResult(filtered));
 
-    let resolve: (v: CompanyPageData) => void = () => {};
-    mockFetchCompanyPageData.mockReturnValueOnce(
-      new Promise<CompanyPageData>((r) => {
-        resolve = r;
-      }),
+    const { getByTestId } = render(
+      <CompanyContent locale="en" slug="test-company" initialData={makeData()} />,
     );
 
-    const { queryByTestId } = render(
-      <CompanyContent locale="en" slug="test-company" initialData={unfilteredInitial} />,
-    );
-
-    await waitFor(() => {
-      expect(queryByTestId("company-skeleton")).not.toBeNull();
+    await waitFor(() => expect(mockLoadCompanyBrowserData).toHaveBeenCalledOnce());
+    expect(mockLoadCompanyBrowserData.mock.calls[0]?.[0]).toMatchObject({
+      locale: "en",
+      isLoggedIn: false,
+      jobLanguages: [],
     });
-    expect(queryByTestId("company-page")).toBeNull();
-
-    resolve(filteredData);
-
-    await waitFor(() => {
-      expect(queryByTestId("company-page")).not.toBeNull();
-    });
-    expect(queryByTestId("company-skeleton")).toBeNull();
-    expect(queryByTestId("company-page")?.getAttribute("data-active")).toBe(
-      "870",
+    await waitFor(() =>
+      expect(getByTestId("company-page").getAttribute("data-active")).toBe("2"),
     );
-    expect(queryByTestId("company-page")?.getAttribute("data-etypes")).toBe(
+    expect(getByTestId("company-page").getAttribute("data-etypes")).toBe(
       "internship",
     );
   });
 
-  it("refetches on page identity changes and ignores stale responses", async () => {
-    let resolveAlpha: (v: CompanyPageData) => void = () => {};
-    let resolveBeta: (v: CompanyPageData) => void = () => {};
-    mockFetchCompanyPageData
+  it.each(["q", "loc", "occ", "sen", "tech", "wm", "etype", "sal", "salcur", "exp"])(
+    "treats %s as a result-bearing param",
+    async (param) => {
+      currentSearchParams = new URLSearchParams(`${param}=x`);
+      const { unmount } = render(
+        <CompanyContent locale="en" slug="test-company" initialData={makeData()} />,
+      );
+      await waitFor(() => expect(mockLoadCompanyBrowserData).toHaveBeenCalledOnce());
+      unmount();
+      mockLoadCompanyBrowserData.mockClear();
+    },
+  );
+
+  it("waits for authenticated bootstrap and reuses its preferences", async () => {
+    setDocumentCookie("logged_in=1");
+    sessionState = { isLoggedIn: false, isPending: true, preferences: null };
+    const initialData = makeData();
+    const personalized = makeData({
+      displayCurrency: "CHF",
+      jobLanguages: ["de", "en"],
+      languages: ["de", "en"],
+    });
+    mockLoadCompanyBrowserData.mockResolvedValue(successfulResult(personalized));
+    const { getByTestId, rerender } = render(
+      <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mockLoadCompanyBrowserData).not.toHaveBeenCalled();
+
+    sessionState = {
+      isLoggedIn: true,
+      isPending: false,
+      preferences: { displayCurrency: "CHF", jobLanguages: ["de", "en"] },
+    };
+    rerender(
+      <CompanyContent locale="en" slug="test-company" initialData={initialData} />,
+    );
+
+    await waitFor(() => expect(mockLoadCompanyBrowserData).toHaveBeenCalledOnce());
+    expect(mockLoadCompanyBrowserData.mock.calls[0]?.[0]).toMatchObject({
+      displayCurrency: "CHF",
+      jobLanguages: ["de", "en"],
+      isLoggedIn: true,
+    });
+    await waitFor(() =>
+      expect(getByTestId("company-page").getAttribute("data-currency")).toBe(
+        "CHF",
+      ),
+    );
+  });
+
+  it("parses anonymous language preferences locally", async () => {
+    setDocumentCookie(
+      "JSEEK_JOB_LANGUAGES=%5B%22de%22%2C%22en%22%5D",
+    );
+    render(
+      <CompanyContent locale="en" slug="test-company" initialData={makeData()} />,
+    );
+
+    await waitFor(() => expect(mockLoadCompanyBrowserData).toHaveBeenCalledOnce());
+    expect(mockLoadCompanyBrowserData.mock.calls[0]?.[0]).toMatchObject({
+      jobLanguages: ["de", "en"],
+      isLoggedIn: false,
+    });
+  });
+
+  it("renders an explicit unavailable state without restoring broad shell results", async () => {
+    currentSearchParams = new URLSearchParams("loc=missing-place");
+    const failed = makeData({ activeCount: 0, yearCount: 0, postings: [] });
+    mockLoadCompanyBrowserData.mockResolvedValue({
+      data: failed,
+      unavailable: true,
+      directAttempted: true,
+    });
+    const { getByTestId, queryByTestId } = render(
+      <CompanyContent
+        locale="en"
+        slug="test-company"
+        initialData={makeData({ activeCount: 99 })}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(getByTestId("company-page").getAttribute("data-unavailable")).toBe(
+        "true",
+      ),
+    );
+    expect(getByTestId("company-page").getAttribute("data-active")).toBe("0");
+    expect(getByTestId("company-page").getAttribute("data-direct-attempted")).toBe(
+      "true",
+    );
+    expect(queryByTestId("company-skeleton")).toBeNull();
+  });
+
+  it("ignores stale browser responses across page identity changes", async () => {
+    currentSearchParams = new URLSearchParams("q=engineer");
+    let resolveAlpha: (result: CompanyBrowserDataResult) => void = () => {};
+    let resolveBeta: (result: CompanyBrowserDataResult) => void = () => {};
+    mockLoadCompanyBrowserData
       .mockReturnValueOnce(
-        new Promise<CompanyPageData>((resolve) => {
+        new Promise<CompanyBrowserDataResult>((resolve) => {
           resolveAlpha = resolve;
         }),
       )
       .mockReturnValueOnce(
-        new Promise<CompanyPageData>((resolve) => {
+        new Promise<CompanyBrowserDataResult>((resolve) => {
           resolveBeta = resolve;
         }),
       );
-
+    const alpha = makeData({ company: { ...makeCompany(), slug: "alpha" } });
+    const beta = makeData({ company: { ...makeCompany(), slug: "beta" } });
     const { queryByTestId, rerender } = render(
-      <CompanyContent locale="en" slug="alpha" />,
+      <CompanyContent locale="en" slug="alpha" initialData={alpha} />,
     );
+    await waitFor(() => expect(mockLoadCompanyBrowserData).toHaveBeenCalledOnce());
 
-    await waitFor(() => {
-      expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(1);
-    });
-    expect(mockFetchCompanyPageData.mock.calls[0]?.[0]).toMatchObject({
-      slug: "alpha",
-      locale: "en",
-    });
-
-    rerender(<CompanyContent locale="en" slug="beta" />);
-
-    await waitFor(() => {
-      expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(2);
-    });
-    expect(mockFetchCompanyPageData.mock.calls[1]?.[0]).toMatchObject({
-      slug: "beta",
-      locale: "en",
-    });
-
-    resolveAlpha(makeInitialData({
-      company: { ...makeCompany(), slug: "alpha" },
-      activeCount: 1,
-    }));
-
-    await new Promise((r) => setTimeout(r, 0));
+    rerender(<CompanyContent locale="en" slug="beta" initialData={beta} />);
+    await waitFor(() =>
+      expect(mockLoadCompanyBrowserData).toHaveBeenCalledTimes(2),
+    );
+    resolveAlpha(successfulResult(alpha));
+    await new Promise((resolve) => setTimeout(resolve, 0));
     expect(queryByTestId("company-page")).toBeNull();
 
-    resolveBeta(makeInitialData({
-      company: { ...makeCompany(), slug: "beta" },
-      activeCount: 2,
-    }));
-
-    await waitFor(() => {
+    resolveBeta(successfulResult(beta));
+    await waitFor(() =>
       expect(queryByTestId("company-page")?.getAttribute("data-company")).toBe(
         "beta",
-      );
-    });
-    expect(queryByTestId("company-page")?.getAttribute("data-active")).toBe(
-      "2",
+      ),
     );
-  });
-
-  it("renders the CompanySkeleton fallback when no initialData and the fetch is in-flight", async () => {
-    // Never-resolving promise to keep the component in the loading
-    // state for the duration of the assertion.
-    mockFetchCompanyPageData.mockReturnValue(new Promise(() => {}));
-
-    const { queryByTestId } = render(
-      <CompanyContent locale="en" slug="test-company" />,
-    );
-
-    await waitFor(() => {
-      expect(queryByTestId("company-skeleton")).not.toBeNull();
-    });
-    expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(1);
-    expect(queryByTestId("company-page")).toBeNull();
-  });
-
-  it("triggers the not-found path when fetchCompanyPageData resolves to null", async () => {
-    mockFetchCompanyPageData.mockResolvedValueOnce(null);
-
-    // The Lingui <Trans> macros inside CompanyNotFound need an i18n
-    // provider to render their text — outside that scope they emit
-    // empty strings. So we assert the call resolved with null and the
-    // component re-rendered (no crash, no infinite loading) rather
-    // than text content.
-    const { container } = render(<CompanyContent locale="en" slug="ghost-slug" />);
-
-    await waitFor(() => {
-      expect(mockFetchCompanyPageData).toHaveBeenCalledTimes(1);
-    });
-    // Sanity check: the component rendered something (the not-found
-    // shell wrapper), not crashed.
-    await new Promise((r) => setTimeout(r, 0));
-    expect(container).toBeTruthy();
   });
 });

--- a/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-posting-state.test.ts
+++ b/apps/web/app/[lang]/(app)/company/[slug]/__tests__/company-posting-state.test.ts
@@ -37,4 +37,17 @@ describe("getCompanyPostingListState", () => {
       }),
     ).toBe("no-matches");
   });
+
+  it("does not claim that a failed filtered search has no matches", () => {
+    expect(
+      getCompanyPostingListState({
+        isSearching: false,
+        hasFilters: true,
+        postingCount: 0,
+        isTruncated: false,
+        activeCount: 0,
+        isUnavailable: true,
+      }),
+    ).toBe("unavailable");
+  });
 });

--- a/apps/web/app/[lang]/(app)/company/[slug]/company-content.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-content.tsx
@@ -2,17 +2,21 @@
 
 import { useEffect, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { Trans } from "@lingui/react/macro";
-import { fetchCompanyPageData, type CompanyPageData } from "@/lib/actions/company-page-data";
-import { hasLoggedInHint, hasAnonJobLanguagesHint } from "@/lib/client-cookies";
+import type { CompanyPageData } from "@/lib/actions/company-page-data";
+import {
+  hasLoggedInHint,
+  readAnonJobLanguagesPreference,
+} from "@/lib/client-cookies";
 import { logExternalError } from "@/lib/safe-external-error";
 import { CompanySkeleton } from "@/components/search/company-skeleton";
+import { useSession } from "@/components/providers/SessionProvider";
+import { useSalaryRates } from "@/components/providers/SalaryDisplayProvider";
+import { loadCompanyBrowserData } from "@/lib/search/company-browser-data";
 import {
   hasSearchFilterParams,
   serializeSearchFilterParams,
 } from "@/lib/search/query-params";
 import { CompanyPage } from "./company-page";
-import { CompanyNotFoundState } from "./company-not-found";
 
 type CompanyContentProps = {
   locale: string;
@@ -21,18 +25,16 @@ type CompanyContentProps = {
    * Server-prerendered ``CompanyPageData`` for the unauthenticated,
    * no-filter visit case (#3203, mirrors `/explore` from #2640).
    * Anonymous visitors with no filter searchParams use this directly —
-   * no second server-action round-trip on mount. When ``initialData``
-   * is omitted (legacy call sites or null-from-server signalling a
-   * ghost slug), the component falls back to the client-mount fetch
-   * behaviour from before this PR.
+   * no second server-action round-trip on mount. The server route resolves
+   * unknown slugs before this client boundary is rendered.
    */
-  initialData?: CompanyPageData;
+  initialData: CompanyPageData;
 };
 
 /**
- * URL searchParams that ``fetchCompanyPageData`` consumes. If any of
- * these are present, the prerendered ``initialData`` doesn't reflect
- * the filters and we must re-fetch the personalized variant.
+ * Result-bearing URL searchParams. If any are present, the prerendered
+ * ``initialData`` does not reflect the browser state and we resolve the
+ * bounded filter vocabulary plus posting results directly through Typesense.
  *
  * The shared result-bearing parameter list deliberately excludes the
  * ``show`` deep-link param: it only selects a posting in ``CompanyPage``
@@ -40,63 +42,26 @@ type CompanyContentProps = {
  * as a data input would unmount and refetch the entire company results
  * view on every posting click (#5766).
  */
-function CompanyNotFound({ locale, slug }: { locale: string; slug: string }) {
-  return (
-    <CompanyNotFoundState
-      locale={locale}
-      slug={slug}
-      title={
-        <Trans
-          id="company.notFound.title"
-          comment="Heading shown when the company URL slug doesn't resolve to a known company"
-        >
-          Company not found
-        </Trans>
-      }
-      message={
-        <Trans
-          id="company.notFound.body"
-          comment="Body text for the company-not-found page; explains the company is either gone or never existed"
-        >
-          The company you are looking for does not exist or has been removed.
-        </Trans>
-      }
-      exploreLabel={
-        <Trans
-          id="company.notFound.explore"
-          comment="Primary recovery action on the company-not-found page"
-        >
-          Explore companies
-        </Trans>
-      }
-      requestLabel={
-        <Trans
-          id="company.notFound.request"
-          comment="Secondary action on the company-not-found page to request that company"
-        >
-          Request this company
-        </Trans>
-      }
-    />
-  );
-}
-
 export function CompanyContent({ locale, slug, initialData }: CompanyContentProps) {
   const searchParams = useSearchParams();
   const dataParamsKey = serializeSearchFilterParams(searchParams);
+  const { isLoggedIn, isPending, preferences } = useSession();
+  const rates = useSalaryRates();
+  const preferenceLanguagesKey = preferences?.jobLanguages?.join(",") ?? "";
+  const preferenceCurrency = preferences?.displayCurrency ?? null;
   const fetchIdRef = useRef(0);
-  const [data, setData] = useState<CompanyPageData | null | "not-found">(initialData ?? null);
+  const [view, setView] = useState<{
+    data: CompanyPageData;
+    unavailable: boolean;
+    directAttempted: boolean;
+  } | null>({ data: initialData, unavailable: false, directAttempted: false });
 
-  // Re-fetch on mount only when the prerendered ``initialData``
-  // doesn't reflect the user's actual view — i.e. they have filter
-  // searchParams, the ``logged_in`` hint cookie is present (their
-  // DB-backed preferences / job-language filter / display currency
-  // would change the result set), OR they have an anonymous
-  // job-language cookie set (#2850 — anon viewers persist
-  // `jobLanguages` via a cookie that the server side reads in
-  // `fetchCompanyPageData`). Anonymous, no-filter, no-job-lang-cookie
-  // visitors still get the prerendered data with zero server-action
-  // invocations — the bulk of organic traffic per #3203 + #2640.
+  // Re-initialize only when the prerendered anonymous snapshot does not
+  // reflect the browser URL or viewer preferences. Authenticated preferences
+  // come from the app bootstrap action the layout already paid for; anonymous
+  // job languages come from their client-readable, bounded cookie. Filter
+  // resolution and posting results go browser-direct to Typesense, so this
+  // boundary no longer emits a company-page Server Action on mount.
   //
   // After this effect, CompanyPage owns interactive filter changes and
   // searches — URL sync via replaceState is for bookmarkability only.
@@ -106,38 +71,70 @@ export function CompanyContent({ locale, slug, initialData }: CompanyContentProp
   useEffect(() => {
     const fetchId = ++fetchIdRef.current;
     const params = new URLSearchParams(dataParamsKey);
-    const needsPersonalizedFetch =
-      hasLoggedInHint() ||
-      hasAnonJobLanguagesHint() ||
-      hasSearchFilterParams(params) ||
-      initialData === undefined;
-    if (!needsPersonalizedFetch) {
-      setData(initialData ?? null);
+    if (hasLoggedInHint() && isPending) return;
+
+    const anonymousJobLanguages = isLoggedIn
+      ? null
+      : readAnonJobLanguagesPreference();
+    const needsBrowserLoad =
+      isLoggedIn ||
+      anonymousJobLanguages !== null ||
+      hasSearchFilterParams(params);
+    if (!needsBrowserLoad) {
+      setView({
+        data: initialData,
+        unavailable: false,
+        directAttempted: false,
+      });
       return;
     }
 
-    // Clear stale prerendered data before the personalised fetch so
+    // Clear stale prerendered data before the browser-direct load so
     // CompanyPage unmounts. Its filters/postings are useState-initialised
     // from props, so keeping the unfiltered ISR instance mounted would
-    // ignore the filtered props when this fetch resolves.
-    setData(null);
+    // ignore resolved filtered props. This also prevents a filtered URL from
+    // flashing the broader unfiltered list while its scoped read is pending.
+    setView(null);
 
-    const sp: Record<string, string | undefined> = {};
-    params.forEach((value, key) => {
-      sp[key] = value;
-    });
-    fetchCompanyPageData({ slug, searchParams: sp, locale }).then((result) => {
-      if (fetchIdRef.current !== fetchId) return;
-      setData(result ?? "not-found");
-    }).catch((err) => {
-      if (fetchIdRef.current !== fetchId) return;
-      logExternalError("error", { service: "typesense", operation: "fetch_company_page" }, err);
-      if (initialData) setData(initialData);
-    });
-  }, [dataParamsKey, initialData, locale, slug]);
+    void loadCompanyBrowserData({
+      initialData,
+      searchParams: params,
+      locale,
+      displayCurrency: preferenceCurrency,
+      jobLanguages:
+        preferences?.jobLanguages ?? anonymousJobLanguages ?? [],
+      rates,
+      isLoggedIn,
+    })
+      .then((result) => {
+        if (fetchIdRef.current !== fetchId) return;
+        setView(result);
+      })
+      .catch((error) => {
+        if (fetchIdRef.current !== fetchId) return;
+        logExternalError(
+          "error",
+          { service: "typesense", operation: "load_company_browser_data" },
+          error,
+        );
+        // Stay on the skeleton rather than restoring unfiltered results under
+        // a filtered/personalized URL. Expected transport failures are already
+        // converted to an explicit unavailable result by the loader.
+      });
+  }, [
+    dataParamsKey,
+    initialData,
+    isLoggedIn,
+    isPending,
+    locale,
+    preferenceCurrency,
+    preferenceLanguagesKey,
+    rates,
+    slug,
+  ]);
 
-  if (data === null) return <CompanySkeleton />;
-  if (data === "not-found") return <CompanyNotFound locale={locale} slug={slug} />;
+  if (view === null) return <CompanySkeleton />;
+  const { data } = view;
 
   return (
     <CompanyPage
@@ -165,6 +162,8 @@ export function CompanyContent({ locale, slug, initialData }: CompanyContentProp
       languages={data.languages}
       userLat={data.userLat}
       userLng={data.userLng}
+      initialSearchUnavailable={view.unavailable}
+      initialDirectRefreshAttempted={view.directAttempted}
     />
   );
 }

--- a/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-page.tsx
@@ -58,6 +58,8 @@ interface CompanyPageProps {
   languages: string[];
   userLat?: number;
   userLng?: number;
+  initialSearchUnavailable?: boolean;
+  initialDirectRefreshAttempted?: boolean;
 }
 
 export function CompanyPage({
@@ -85,6 +87,8 @@ export function CompanyPage({
   languages,
   userLat,
   userLng,
+  initialSearchUnavailable = false,
+  initialDirectRefreshAttempted = false,
 }: CompanyPageProps) {
   const { t } = useLingui();
   const params = useParams();
@@ -116,8 +120,16 @@ export function CompanyPage({
   const [isSearching, startSearch] = useTransition();
   const [exhausted, setExhausted] = useState(initialPostings.length < PAGE_SIZE);
   const [isTruncated, setIsTruncated] = useState(initialTruncated ?? false);
+  const [searchUnavailable, setSearchUnavailable] = useState(
+    initialSearchUnavailable,
+  );
   const searchGenerationRef = useRef(0);
-  const initialDirectRefreshKeyRef = useRef<string | null>(null);
+  const directRefreshLanguagesKey = languages.join(",");
+  const initialDirectRefreshKeyRef = useRef<string | null>(
+    initialDirectRefreshAttempted
+      ? [company.id, uiLocale, directRefreshLanguagesKey].join("|")
+      : null,
+  );
 
   // Currency rates for EUR conversion — shared via `SalaryDisplayProvider`
   // which fetches once at the (app) layout root. Previously this page
@@ -136,6 +148,7 @@ export function CompanyPage({
     postingCount: postings.length,
     isTruncated,
     activeCount,
+    isUnavailable: searchUnavailable,
   });
 
   /** Convert a salary amount from the user's display currency to EUR. */
@@ -239,6 +252,7 @@ export function CompanyPage({
       setYearCount(result.yearCount);
       setExhausted(result.postings.length < PAGE_SIZE);
       setIsTruncated(result.truncated ?? false);
+      setSearchUnavailable(false);
     });
   }
 
@@ -246,7 +260,6 @@ export function CompanyPage({
   // visible default postings directly from Typesense after hydration. This
   // path never falls back to a Server Action, so it preserves freshness
   // without converting page views back into Fluid CPU.
-  const directRefreshLanguagesKey = languages.join(",");
   useEffect(() => {
     if (hasFilters) return;
 
@@ -282,6 +295,7 @@ export function CompanyPage({
       setYearCount(result.yearCount);
       setExhausted(result.postings.length < PAGE_SIZE);
       setIsTruncated(result.truncated ?? false);
+      setSearchUnavailable(false);
     });
 
     return () => {

--- a/apps/web/app/[lang]/(app)/company/[slug]/company-posting-state.ts
+++ b/apps/web/app/[lang]/(app)/company/[slug]/company-posting-state.ts
@@ -11,6 +11,7 @@ interface CompanyPostingListStateInput {
   postingCount: number;
   isTruncated: boolean;
   activeCount: number;
+  isUnavailable?: boolean;
 }
 
 export function getCompanyPostingListState({
@@ -19,8 +20,10 @@ export function getCompanyPostingListState({
   postingCount,
   isTruncated,
   activeCount,
+  isUnavailable = false,
 }: CompanyPostingListStateInput): CompanyPostingListState {
   if (isSearching) return "loading";
+  if (isUnavailable) return "unavailable";
   if (postingCount > 0) return "results";
   if (!hasFilters && (isTruncated || activeCount > 0)) return "unavailable";
   if (hasFilters) return "no-matches";

--- a/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/company/[slug]/page.tsx
@@ -139,9 +139,9 @@ export default async function CompanyPageRoute({ params }: Props) {
   // shell with zero client-side server-action round-trips (#3203,
   // mirrors `/explore` from #2640). ``fetchCompanyPageDefaults``
   // deliberately avoids ``headers()``/``cookies()`` to stay
-  // ISR-eligible — the client component re-fetches the personalised
-  // variant via ``fetchCompanyPageData`` when filters or auth-related
-  // hint cookies are present.
+  // ISR-eligible — the client component reuses app-bootstrap preferences and
+  // resolves personalized/filter-bearing results browser-direct through the
+  // scoped Typesense key when required.
   const initialData = await getCompanyRouteSnapshot(slug, locale);
   if (!initialData) notFound();
   const { company } = initialData;

--- a/apps/web/src/components/__tests__/AppBootstrapProvider.test.tsx
+++ b/apps/web/src/components/__tests__/AppBootstrapProvider.test.tsx
@@ -14,6 +14,9 @@ const mockBootstrap = vi.fn();
 vi.mock("@/lib/actions/bootstrap", () => ({
   fetchAppBootstrap: (...args: unknown[]) => mockBootstrap(...args),
 }));
+vi.mock("../providers/PreferencesInitializer", () => ({
+  PreferencesInitializer: () => null,
+}));
 
 // BannerProvider reads window.localStorage during render. happy-dom's
 // localStorage implementation doesn't always expose getItem as a plain
@@ -51,12 +54,15 @@ const initialCurrencyRates = [
 ];
 
 function SessionProbe() {
-  const { user, isLoggedIn, isPending } = useSession();
+  const { user, preferences, isLoggedIn, isPending } = useSession();
   return (
     <>
       <span data-testid="pending">{String(isPending)}</span>
       <span data-testid="logged-in">{String(isLoggedIn)}</span>
       <span data-testid="user-name">{user?.name ?? "none"}</span>
+      <span data-testid="job-languages">
+        {preferences?.jobLanguages?.join(",") ?? "none"}
+      </span>
     </>
   );
 }
@@ -90,7 +96,7 @@ describe("AppBootstrapProvider", () => {
     setDocumentCookie("utm_source=google; NEXT_LOCALE=en");
     mockBootstrap.mockResolvedValue({
       user: { id: "ghost", email: "x@x", name: "Ghost", emailVerified: true },
-      prefs: null,
+      prefs: { jobLanguages: ["de", "en"] },
       savedStatuses: [],
       starredIds: [],
     });
@@ -122,7 +128,7 @@ describe("AppBootstrapProvider", () => {
         name: "Alice",
         emailVerified: true,
       },
-      prefs: null,
+      prefs: { jobLanguages: ["de", "en"] },
       savedStatuses: [],
       starredIds: [],
     });
@@ -138,6 +144,7 @@ describe("AppBootstrapProvider", () => {
     });
     expect(mockBootstrap).toHaveBeenCalledTimes(1);
     expect(screen.getByTestId("user-name").textContent).toBe("Alice");
+    expect(screen.getByTestId("job-languages").textContent).toBe("de,en");
   });
 
   it("is pending at first render when bootstrap is required", async () => {

--- a/apps/web/src/components/__tests__/SessionProvider.test.tsx
+++ b/apps/web/src/components/__tests__/SessionProvider.test.tsx
@@ -3,11 +3,14 @@ import { render, screen } from "@testing-library/react";
 import { SessionProvider, useSession } from "../providers/SessionProvider";
 
 function SessionDisplay() {
-  const { user, isLoggedIn } = useSession();
+  const { user, preferences, isLoggedIn } = useSession();
   return (
     <div>
       <span data-testid="logged-in">{String(isLoggedIn)}</span>
       <span data-testid="user-name">{user?.name ?? "none"}</span>
+      <span data-testid="display-currency">
+        {preferences?.displayCurrency ?? "none"}
+      </span>
     </div>
   );
 }
@@ -31,12 +34,16 @@ describe("SessionProvider", () => {
       emailVerified: true,
     };
     render(
-      <SessionProvider user={user}>
+      <SessionProvider
+        user={user}
+        preferences={{ displayCurrency: "CHF" }}
+      >
         <SessionDisplay />
       </SessionProvider>,
     );
     expect(screen.getByTestId("logged-in").textContent).toBe("true");
     expect(screen.getByTestId("user-name").textContent).toBe("Test User");
+    expect(screen.getByTestId("display-currency").textContent).toBe("CHF");
   });
 });
 

--- a/apps/web/src/components/providers/AppBootstrapProvider.tsx
+++ b/apps/web/src/components/providers/AppBootstrapProvider.tsx
@@ -60,7 +60,12 @@ export function AppBootstrapProvider({
   const prefs = data?.prefs;
 
   return (
-    <SessionProvider user={user} isPending={isPending} refresh={refresh}>
+    <SessionProvider
+      user={user}
+      preferences={prefs ?? null}
+      isPending={isPending}
+      refresh={refresh}
+    >
       <SavedJobsProvider initialStatuses={data?.savedStatuses}>
         <StarredCompaniesProvider initialIds={data?.starredIds}>
           <SalaryDisplayProvider

--- a/apps/web/src/components/providers/SessionProvider.tsx
+++ b/apps/web/src/components/providers/SessionProvider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { createContext, useContext, type ReactNode } from "react";
+import type { AppPreferences } from "@/lib/actions/bootstrap";
 
 export type SessionUser = {
   id: string;
@@ -14,6 +15,7 @@ export type SessionUser = {
 
 type SessionContextValue = {
   user: SessionUser | null;
+  preferences: AppPreferences | null;
   isLoggedIn: boolean;
   isPending: boolean;
   /**
@@ -33,6 +35,7 @@ type SessionContextValue = {
 
 const SessionContext = createContext<SessionContextValue>({
   user: null,
+  preferences: null,
   isLoggedIn: false,
   isPending: true,
   refresh: async () => {},
@@ -40,11 +43,13 @@ const SessionContext = createContext<SessionContextValue>({
 
 export function SessionProvider({
   user,
+  preferences = null,
   isPending = false,
   refresh,
   children,
 }: {
   user: SessionUser | null;
+  preferences?: AppPreferences | null;
   isPending?: boolean;
   refresh?: () => Promise<void>;
   children: ReactNode;
@@ -53,6 +58,7 @@ export function SessionProvider({
     <SessionContext.Provider
       value={{
         user,
+        preferences,
         isLoggedIn: Boolean(user),
         isPending,
         refresh: refresh ?? (async () => {}),

--- a/apps/web/src/lib/__tests__/client-cookies.test.ts
+++ b/apps/web/src/lib/__tests__/client-cookies.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { hasCookieNamed, LOGGED_IN_COOKIE } from "../client-cookies";
+import {
+  hasCookieNamed,
+  LOGGED_IN_COOKIE,
+  readAnonJobLanguagesPreference,
+  readCookieValue,
+} from "../client-cookies";
 
 describe("hasCookieNamed", () => {
   const SESSION = "better-auth.session_token";
@@ -77,5 +82,41 @@ describe("hasCookieNamed", () => {
       true,
     );
     expect(hasCookieNamed("other=1", LOGGED_IN_COOKIE)).toBe(false);
+  });
+});
+
+describe("readCookieValue", () => {
+  it("decodes an exact cookie value without substring matching", () => {
+    expect(readCookieValue("x_pref=bad; pref=%5B%22en%22%5D", "pref")).toBe(
+      '["en"]',
+    );
+    expect(readCookieValue("x_pref=bad", "pref")).toBeNull();
+  });
+});
+
+describe("readAnonJobLanguagesPreference", () => {
+  it("accepts bounded known language codes and removes duplicates", () => {
+    expect(
+      readAnonJobLanguagesPreference(
+        "JSEEK_JOB_LANGUAGES=%5B%22de%22%2C%22en%22%2C%22de%22%5D",
+      ),
+    ).toEqual(["de", "en"]);
+    expect(
+      readAnonJobLanguagesPreference('JSEEK_JOB_LANGUAGES=["*"]'),
+    ).toEqual(["*"]);
+  });
+
+  it("rejects malformed, unknown, and oversized values", () => {
+    expect(
+      readAnonJobLanguagesPreference("JSEEK_JOB_LANGUAGES=not-json"),
+    ).toBeNull();
+    expect(
+      readAnonJobLanguagesPreference('JSEEK_JOB_LANGUAGES=["en","bogus"]'),
+    ).toBeNull();
+    expect(
+      readAnonJobLanguagesPreference(
+        `JSEEK_JOB_LANGUAGES=${encodeURIComponent(JSON.stringify(Array(33).fill("en")))}`,
+      ),
+    ).toBeNull();
   });
 });

--- a/apps/web/src/lib/actions/__tests__/company-filter-state.test.ts
+++ b/apps/web/src/lib/actions/__tests__/company-filter-state.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getGeo: vi.fn(),
+  parse: vi.fn(),
+}));
+
+vi.mock("@/lib/search/params", () => ({
+  getGeoFromHeaders: mocks.getGeo,
+}));
+vi.mock("@/lib/services/search-input", () => ({
+  parseSearchFilters: mocks.parse,
+}));
+
+import { resolveCompanySemanticFilters } from "../company-filter-state";
+
+const parsed = {
+  keywords: [],
+  locations: [],
+  occupations: [],
+  seniorities: [],
+  technologies: [],
+  workMode: ["remote"],
+  employmentTypes: [],
+};
+
+beforeEach(() => {
+  mocks.getGeo.mockReset();
+  mocks.getGeo.mockResolvedValue({ userLat: 47.37, userLng: 8.54 });
+  mocks.parse.mockReset();
+  mocks.parse.mockResolvedValue(parsed);
+});
+
+describe("resolveCompanySemanticFilters", () => {
+  it("delegates free text to the canonical parser with request geolocation", async () => {
+    const result = await resolveCompanySemanticFilters({
+      q: "remote backend developer",
+      loc: "zurich",
+      occ: "software-engineer",
+      locale: "de",
+    });
+
+    expect(mocks.parse).toHaveBeenCalledWith({
+      q: "remote backend developer",
+      loc: "zurich",
+      occ: "software-engineer",
+      sen: undefined,
+      tech: undefined,
+      wm: undefined,
+      etype: undefined,
+      locale: "de",
+      userLat: 47.37,
+      userLng: 8.54,
+    });
+    expect(result).toEqual({
+      parsed,
+      userLat: 47.37,
+      userLng: 8.54,
+    });
+  });
+
+  it("normalizes unsupported route locales", async () => {
+    await resolveCompanySemanticFilters({ q: "Zurich", locale: "xx" });
+    expect(mocks.parse.mock.calls[0]?.[0]).toMatchObject({ locale: "en" });
+  });
+
+  it("rejects query fan-out and unsafe explicit slugs before server work", async () => {
+    const tooManyTerms = Array.from({ length: 21 }, (_, index) => `q${index}`).join(" ");
+
+    await expect(
+      resolveCompanySemanticFilters({ q: tooManyTerms, locale: "en" }),
+    ).resolves.toBeNull();
+    await expect(
+      resolveCompanySemanticFilters({
+        q: "remote",
+        loc: "zurich`,company_id:!=[]",
+        locale: "en",
+      }),
+    ).resolves.toBeNull();
+    expect(mocks.getGeo).not.toHaveBeenCalled();
+    expect(mocks.parse).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/actions/__tests__/company-filter-state.test.ts
+++ b/apps/web/src/lib/actions/__tests__/company-filter-state.test.ts
@@ -11,6 +11,8 @@ vi.mock("@/lib/search/params", () => ({
 }));
 vi.mock("@/lib/services/search-input", () => ({
   parseSearchFilters: mocks.parse,
+}));
+vi.mock("@/lib/search/semantic-query", () => ({
   getSemanticSearchQueryComplexity: mocks.complexity,
 }));
 

--- a/apps/web/src/lib/actions/__tests__/company-filter-state.test.ts
+++ b/apps/web/src/lib/actions/__tests__/company-filter-state.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   getGeo: vi.fn(),
   parse: vi.fn(),
+  complexity: vi.fn(),
 }));
 
 vi.mock("@/lib/search/params", () => ({
@@ -10,6 +11,7 @@ vi.mock("@/lib/search/params", () => ({
 }));
 vi.mock("@/lib/services/search-input", () => ({
   parseSearchFilters: mocks.parse,
+  getSemanticSearchQueryComplexity: mocks.complexity,
 }));
 
 import { resolveCompanySemanticFilters } from "../company-filter-state";
@@ -29,6 +31,12 @@ beforeEach(() => {
   mocks.getGeo.mockResolvedValue({ userLat: 47.37, userLng: 8.54 });
   mocks.parse.mockReset();
   mocks.parse.mockResolvedValue(parsed);
+  mocks.complexity.mockReset();
+  mocks.complexity.mockReturnValue({
+    uniqueTerms: 3,
+    occupationCandidates: 6,
+    maxTermLength: 9,
+  });
 });
 
 describe("resolveCompanySemanticFilters", () => {
@@ -65,7 +73,13 @@ describe("resolveCompanySemanticFilters", () => {
   });
 
   it("rejects query fan-out and unsafe explicit slugs before server work", async () => {
-    const tooManyTerms = Array.from({ length: 21 }, (_, index) => `q${index}`).join(" ");
+    const tooManyTerms = Array.from({ length: 13 }, (_, index) => `q${index}`).join("/");
+
+    mocks.complexity.mockReturnValueOnce({
+      uniqueTerms: 13,
+      occupationCandidates: 13,
+      maxTermLength: 3,
+    });
 
     await expect(
       resolveCompanySemanticFilters({ q: tooManyTerms, locale: "en" }),
@@ -77,6 +91,26 @@ describe("resolveCompanySemanticFilters", () => {
         locale: "en",
       }),
     ).resolves.toBeNull();
+    expect(mocks.getGeo).not.toHaveBeenCalled();
+    expect(mocks.parse).not.toHaveBeenCalled();
+  });
+
+  it("caps canonical slash/pipe/hyphen candidate fan-out", async () => {
+    mocks.complexity.mockReturnValue({
+      uniqueTerms: 12,
+      occupationCandidates: 37,
+      maxTermLength: 3,
+    });
+
+    await expect(
+      resolveCompanySemanticFilters({
+        q: "a/b|c-d/e|f-g/h|i-j/k|l-m",
+        locale: "en",
+      }),
+    ).resolves.toBeNull();
+    expect(mocks.complexity).toHaveBeenCalledWith(
+      "a/b|c-d/e|f-g/h|i-j/k|l-m",
+    );
     expect(mocks.getGeo).not.toHaveBeenCalled();
     expect(mocks.parse).not.toHaveBeenCalled();
   });

--- a/apps/web/src/lib/actions/__tests__/search-input.test.ts
+++ b/apps/web/src/lib/actions/__tests__/search-input.test.ts
@@ -39,6 +39,7 @@ vi.mock("@/lib/services/taxonomy", () => ({
 }));
 
 import { parseSearchFilters } from "../search-input";
+import { getSemanticSearchQueryComplexity } from "@/lib/services/search-input";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -52,6 +53,32 @@ beforeEach(() => {
   mocks.resolveOccupationSlugs.mockResolvedValue(new Map());
   mocks.resolveSenioritySlugs.mockResolvedValue(new Map());
   mocks.resolveTechnologySlugs.mockResolvedValue(new Map());
+});
+
+describe("getSemanticSearchQueryComplexity", () => {
+  it("uses the canonical slash, pipe, comma, newline, tab, and hyphen delimiters", () => {
+    expect(
+      getSemanticSearchQueryComplexity("a/b|c-d,e\nf\tg"),
+    ).toEqual({
+      uniqueTerms: 7,
+      occupationCandidates: 7,
+      maxTermLength: 1,
+    });
+  });
+
+  it("counts the exact pair and triplet occupation candidate fan-out", () => {
+    expect(getSemanticSearchQueryComplexity("one two three")).toEqual({
+      uniqueTerms: 3,
+      occupationCandidates: 6,
+      maxTermLength: 5,
+    });
+    expect(
+      getSemanticSearchQueryComplexity("a b c a c b a b c"),
+    ).toMatchObject({
+      uniqueTerms: 3,
+      occupationCandidates: 15,
+    });
+  });
 });
 
 // =====================================================================

--- a/apps/web/src/lib/actions/__tests__/search-input.test.ts
+++ b/apps/web/src/lib/actions/__tests__/search-input.test.ts
@@ -39,7 +39,7 @@ vi.mock("@/lib/services/taxonomy", () => ({
 }));
 
 import { parseSearchFilters } from "../search-input";
-import { getSemanticSearchQueryComplexity } from "@/lib/services/search-input";
+import { getSemanticSearchQueryComplexity } from "@/lib/search/semantic-query";
 
 beforeEach(() => {
   vi.clearAllMocks();

--- a/apps/web/src/lib/actions/company-filter-state.ts
+++ b/apps/web/src/lib/actions/company-filter-state.ts
@@ -2,12 +2,14 @@
 
 import { getGeoFromHeaders } from "@/lib/search/params";
 import {
+  getSemanticSearchQueryComplexity,
   parseSearchFilters,
   type ParsedSearchFilters,
 } from "@/lib/services/search-input";
 
 const MAX_QUERY_LENGTH = 512;
-const MAX_QUERY_TERMS = 20;
+const MAX_QUERY_TERMS = 12;
+const MAX_OCCUPATION_CANDIDATES = 36;
 const MAX_QUERY_TERM_LENGTH = 120;
 const MAX_SLUGS_PER_DIMENSION = 20;
 const MAX_SLUG_LENGTH = 100;
@@ -37,10 +39,12 @@ function validQuery(raw: string): boolean {
   ) {
     return false;
   }
-  const terms = raw.split(/[\s,]+/u).filter(Boolean);
+  const complexity = getSemanticSearchQueryComplexity(raw);
   return (
-    terms.length <= MAX_QUERY_TERMS &&
-    terms.every((term) => term.length <= MAX_QUERY_TERM_LENGTH)
+    complexity.uniqueTerms > 0 &&
+    complexity.uniqueTerms <= MAX_QUERY_TERMS &&
+    complexity.occupationCandidates <= MAX_OCCUPATION_CANDIDATES &&
+    complexity.maxTermLength <= MAX_QUERY_TERM_LENGTH
   );
 }
 

--- a/apps/web/src/lib/actions/company-filter-state.ts
+++ b/apps/web/src/lib/actions/company-filter-state.ts
@@ -1,0 +1,105 @@
+"use server";
+
+import { getGeoFromHeaders } from "@/lib/search/params";
+import {
+  parseSearchFilters,
+  type ParsedSearchFilters,
+} from "@/lib/services/search-input";
+
+const MAX_QUERY_LENGTH = 512;
+const MAX_QUERY_TERMS = 20;
+const MAX_QUERY_TERM_LENGTH = 120;
+const MAX_SLUGS_PER_DIMENSION = 20;
+const MAX_SLUG_LENGTH = 100;
+
+type CompanySemanticFilterInput = {
+  q: string;
+  loc?: string;
+  occ?: string;
+  sen?: string;
+  tech?: string;
+  wm?: string;
+  etype?: string;
+  locale: string;
+};
+
+export type CompanySemanticFilterResult = {
+  parsed: ParsedSearchFilters;
+  userLat: number | undefined;
+  userLng: number | undefined;
+};
+
+function validQuery(raw: string): boolean {
+  if (
+    raw.length === 0 ||
+    raw.length > MAX_QUERY_LENGTH ||
+    /[\u0000-\u001f\u007f]/.test(raw)
+  ) {
+    return false;
+  }
+  const terms = raw.split(/[\s,]+/u).filter(Boolean);
+  return (
+    terms.length <= MAX_QUERY_TERMS &&
+    terms.every((term) => term.length <= MAX_QUERY_TERM_LENGTH)
+  );
+}
+
+function validSlugList(raw: string | undefined): boolean {
+  if (!raw) return true;
+  if (raw.length > MAX_QUERY_LENGTH) return false;
+  const values = raw.split(",").map((value) => value.trim()).filter(Boolean);
+  return (
+    values.length <= MAX_SLUGS_PER_DIMENSION &&
+    values.every(
+      (value) =>
+        value.length <= MAX_SLUG_LENGTH &&
+        /^[\p{L}\p{N}][\p{L}\p{N}._-]*$/u.test(value),
+    )
+  );
+}
+
+function validEnumList(raw: string | undefined): boolean {
+  return raw === undefined || raw.length <= MAX_QUERY_LENGTH;
+}
+
+/**
+ * Preserve the canonical semantic meaning of free-text `q` URLs without
+ * re-running the full company-page initializer. This narrow, read-only action
+ * is used only for `q` because the canonical parser needs server-side taxonomy
+ * suggestions and request geolocation. Explicit-only URL filters stay on the
+ * browser-direct Typesense path.
+ */
+export async function resolveCompanySemanticFilters(
+  input: CompanySemanticFilterInput,
+): Promise<CompanySemanticFilterResult | null> {
+  if (
+    !validQuery(input.q) ||
+    !validSlugList(input.loc) ||
+    !validSlugList(input.occ) ||
+    !validSlugList(input.sen) ||
+    !validSlugList(input.tech) ||
+    !validEnumList(input.wm) ||
+    !validEnumList(input.etype)
+  ) {
+    return null;
+  }
+
+  const locale =
+    input.locale === "de" || input.locale === "fr" || input.locale === "it"
+      ? input.locale
+      : "en";
+  const { userLat, userLng } = await getGeoFromHeaders();
+  const parsed = await parseSearchFilters({
+    q: input.q,
+    loc: input.loc,
+    occ: input.occ,
+    sen: input.sen,
+    tech: input.tech,
+    wm: input.wm,
+    etype: input.etype,
+    locale,
+    userLat,
+    userLng,
+  });
+  return { parsed, userLat, userLng };
+}

--- a/apps/web/src/lib/actions/company-filter-state.ts
+++ b/apps/web/src/lib/actions/company-filter-state.ts
@@ -1,11 +1,8 @@
 "use server";
 
 import { getGeoFromHeaders } from "@/lib/search/params";
-import {
-  getSemanticSearchQueryComplexity,
-  parseSearchFilters,
-  type ParsedSearchFilters,
-} from "@/lib/services/search-input";
+import { getSemanticSearchQueryComplexity } from "@/lib/search/semantic-query";
+import { parseSearchFilters, type ParsedSearchFilters } from "@/lib/services/search-input";
 
 const MAX_QUERY_LENGTH = 512;
 const MAX_QUERY_TERMS = 12;

--- a/apps/web/src/lib/actions/company-page-data.ts
+++ b/apps/web/src/lib/actions/company-page-data.ts
@@ -168,10 +168,9 @@ export async function fetchCompanyPageData(params: {
  * ISR eligibility (`revalidate = CACHE_TTL_DETAIL`). Returns the same
  * ``CompanyPageData`` shape with anonymous defaults: EUR currency, no
  * job-language filter, no geo proximity bias, no active filters,
- * ``showPostingId: null``. The client component conditionally re-fetches
- * the personalised variant via :func:`fetchCompanyPageData` when the
- * ``logged_in`` hint cookie, the anonymous-job-languages hint cookie,
- * or any filter searchParams are present.
+ * ``showPostingId: null``. The client component reuses app-bootstrap
+ * preferences and resolves personalized/filter-bearing results directly
+ * through the scoped browser Typesense key.
  *
  * Returns ``null`` when the slug is unknown — caller renders the
  * not-found shell. The cache layer in `getCompanyBySlug` ensures repeat

--- a/apps/web/src/lib/client-cookies.ts
+++ b/apps/web/src/lib/client-cookies.ts
@@ -1,3 +1,5 @@
+import { getLanguage } from "@/lib/job-languages";
+
 /**
  * Name of the non-httpOnly "hint" cookie that mirrors the presence of a
  * Better Auth session cookie. It carries no security meaning — the real
@@ -61,6 +63,59 @@ export function hasLoggedInHint(): boolean {
 export function hasAnonJobLanguagesHint(): boolean {
   if (typeof document === "undefined") return false;
   return hasCookieNamed(document.cookie, JOB_LANGUAGES_COOKIE);
+}
+
+const MAX_JOB_LANGUAGES_COOKIE_LENGTH = 1024;
+const MAX_JOB_LANGUAGE_PREFERENCES = 32;
+
+/** Read one cookie value from a Cookie-header-style string. */
+export function readCookieValue(cookieHeader: string, name: string): string | null {
+  if (!cookieHeader) return null;
+  for (const raw of cookieHeader.split(";")) {
+    const part = raw.trim();
+    const separator = part.indexOf("=");
+    if (separator < 0 || part.slice(0, separator) !== name) continue;
+    const value = part.slice(separator + 1);
+    try {
+      return decodeURIComponent(value);
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse the client-readable anonymous job-language preference without a
+ * Server Action. The cookie remains untrusted: bound its size/count and accept
+ * only the same known language codes as the server-side reader.
+ */
+export function readAnonJobLanguagesPreference(
+  cookieHeader = typeof document === "undefined" ? "" : document.cookie,
+): string[] | null {
+  const raw = readCookieValue(cookieHeader, JOB_LANGUAGES_COOKIE);
+  if (!raw || raw.length > MAX_JOB_LANGUAGES_COOKIE_LENGTH) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(parsed) || parsed.length > MAX_JOB_LANGUAGE_PREFERENCES) {
+    return null;
+  }
+
+  const values: string[] = [];
+  const seen = new Set<string>();
+  for (const item of parsed) {
+    if (typeof item !== "string") return null;
+    if (item !== "*" && getLanguage(item) == null) return null;
+    if (seen.has(item)) continue;
+    seen.add(item);
+    values.push(item);
+  }
+  return values;
 }
 
 /**

--- a/apps/web/src/lib/search/__tests__/company-browser-data.test.ts
+++ b/apps/web/src/lib/search/__tests__/company-browser-data.test.ts
@@ -1,0 +1,266 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CompanyPageData } from "@/lib/actions/company-page-data";
+import type { ParsedSearchFilters } from "@/lib/services/search-input";
+
+const mocks = vi.hoisted(() => ({
+  resolveFilters: vi.fn(),
+  directPostings: vi.fn(),
+  parseOffline: vi.fn(),
+}));
+
+vi.mock("@/lib/search/typesense-browser-filter-state", () => ({
+  resolveCompanyFilterStateDirect: mocks.resolveFilters,
+  parseCompanyFilterStateOffline: mocks.parseOffline,
+}));
+vi.mock("@/lib/search/search-runner", () => ({
+  tryGetCompanyPostingsDirect: mocks.directPostings,
+}));
+
+import { loadCompanyBrowserData } from "../company-browser-data";
+
+const emptyParsed: ParsedSearchFilters = {
+  keywords: [],
+  locations: [],
+  occupations: [],
+  seniorities: [],
+  technologies: [],
+  workMode: [],
+  employmentTypes: [],
+};
+
+function makeData(overrides: Partial<CompanyPageData> = {}): CompanyPageData {
+  return {
+    company: {
+      id: "company-1",
+      name: "Example",
+      slug: "example",
+      icon: null,
+      logo: null,
+      website: null,
+      description: null,
+      industryId: null,
+      industryName: null,
+      employeeCountRange: null,
+      foundedYear: null,
+      activeJobCount: 50,
+    },
+    postings: [{ id: "broad-posting" } as CompanyPageData["postings"][number]],
+    activeCount: 50,
+    yearCount: 80,
+    parsed: emptyParsed,
+    displayCurrency: "EUR",
+    jobLanguages: [],
+    languages: ["en"],
+    userLat: undefined,
+    userLng: undefined,
+    salaryCurrencyParam: "EUR",
+    salaryMinDisplay: undefined,
+    salaryMaxDisplay: undefined,
+    experienceMin: undefined,
+    experienceMax: undefined,
+    showPostingId: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mocks.parseOffline.mockReset();
+  mocks.parseOffline.mockImplementation((params: URLSearchParams) => {
+    const q = params.get("q");
+    const loc = params.get("loc");
+    return {
+      complete: !loc,
+      parsed: {
+        ...emptyParsed,
+        keywords: q ? q.split(",") : [],
+        ...(loc ? { unresolvedExplicitSlugs: { loc: loc.split(",") } } : {}),
+      },
+    };
+  });
+  mocks.resolveFilters.mockReset();
+  mocks.resolveFilters.mockResolvedValue({ parsed: emptyParsed, complete: true });
+  mocks.directPostings.mockReset();
+  mocks.directPostings.mockResolvedValue({
+    postings: [],
+    activeCount: 0,
+    yearCount: 0,
+    truncated: false,
+  });
+});
+
+describe("loadCompanyBrowserData", () => {
+  it("uses resolved URL filters, preferences, bounds, and the authenticated cap", async () => {
+    const parsed: ParsedSearchFilters = {
+      ...emptyParsed,
+      keywords: ["python"],
+      locations: [
+        {
+          id: 10,
+          slug: "zurich",
+          name: "Zürich",
+          type: "city",
+          parentName: "Switzerland",
+        },
+      ],
+      occupations: [{ id: 20, slug: "engineer", name: "Engineer" }],
+      seniorities: [{ id: 30, slug: "senior", name: "Senior" }],
+      technologies: [{ id: 40, slug: "react", name: "React" }],
+      workMode: ["remote"],
+      employmentTypes: ["full_time"],
+    };
+    mocks.resolveFilters.mockResolvedValue({ parsed, complete: true });
+    mocks.directPostings.mockResolvedValue({
+      postings: [{ id: "filtered" }],
+      activeCount: 1,
+      yearCount: 2,
+      truncated: false,
+    });
+
+    const result = await loadCompanyBrowserData({
+      initialData: makeData(),
+      searchParams: new URLSearchParams(
+        "q=python&loc=zurich&sal=100-200&salcur=CHF&exp=2-5",
+      ),
+      locale: "de",
+      displayCurrency: "CHF",
+      jobLanguages: ["de", "en"],
+      rates: [{ currency: "CHF", toEur: 1.04 }],
+      isLoggedIn: true,
+    });
+
+    expect(mocks.directPostings).toHaveBeenCalledWith(
+      {
+        companyId: "company-1",
+        keywords: ["python"],
+        locationIds: [10],
+        occupationIds: [20],
+        seniorityIds: [30],
+        technologyIds: [40],
+        employmentTypes: ["full_time"],
+        workMode: ["remote"],
+        salaryMinEur: 104,
+        salaryMaxEur: 208,
+        experienceMin: 2,
+        experienceMax: 5,
+        languages: ["de", "en"],
+        locale: "de",
+        offset: 0,
+        limit: 20,
+      },
+      true,
+    );
+    expect(result).toMatchObject({
+      unavailable: false,
+      directAttempted: true,
+      data: {
+        activeCount: 1,
+        displayCurrency: "CHF",
+        jobLanguages: ["de", "en"],
+        salaryCurrencyParam: "CHF",
+      },
+    });
+  });
+
+  it("passes anonymous status to preserve posting caps", async () => {
+    mocks.resolveFilters.mockResolvedValue({
+      parsed: { ...emptyParsed, keywords: ["python"] },
+      complete: true,
+    });
+
+    await loadCompanyBrowserData({
+      initialData: makeData(),
+      searchParams: new URLSearchParams("q=python"),
+      locale: "en",
+      displayCurrency: null,
+      jobLanguages: [],
+      rates: [],
+      isLoggedIn: false,
+    });
+
+    expect(mocks.directPostings.mock.calls[0]?.[1]).toBe(false);
+  });
+
+  it("fails closed when direct posting search is degraded", async () => {
+    mocks.resolveFilters.mockResolvedValue({
+      parsed: { ...emptyParsed, keywords: ["python"] },
+      complete: true,
+    });
+    mocks.directPostings.mockResolvedValue(null);
+
+    const result = await loadCompanyBrowserData({
+      initialData: makeData(),
+      searchParams: new URLSearchParams("q=python"),
+      locale: "en",
+      displayCurrency: "EUR",
+      jobLanguages: [],
+      rates: [],
+      isLoggedIn: false,
+    });
+
+    expect(result.unavailable).toBe(true);
+    expect(result.data.postings).toEqual([]);
+    expect(result.data.activeCount).toBe(0);
+    expect(result.data.parsed.keywords).toEqual(["python"]);
+  });
+
+  it("does not query postings when an explicit slug is unresolved", async () => {
+    const parsed: ParsedSearchFilters = {
+      ...emptyParsed,
+      unresolvedExplicitSlugs: { loc: ["missing-place"] },
+    };
+    mocks.resolveFilters.mockResolvedValue({ parsed, complete: false });
+
+    const result = await loadCompanyBrowserData({
+      initialData: makeData(),
+      searchParams: new URLSearchParams("loc=missing-place"),
+      locale: "en",
+      displayCurrency: "EUR",
+      jobLanguages: [],
+      rates: [],
+      isLoggedIn: false,
+    });
+
+    expect(mocks.directPostings).not.toHaveBeenCalled();
+    expect(result.unavailable).toBe(true);
+    expect(result.data.parsed.unresolvedExplicitSlugs).toEqual({
+      loc: ["missing-place"],
+    });
+  });
+
+  it("reuses the shell when browser state does not change results", async () => {
+    const initialData = makeData();
+    const result = await loadCompanyBrowserData({
+      initialData,
+      searchParams: new URLSearchParams("salcur=EUR"),
+      locale: "en",
+      displayCurrency: "EUR",
+      jobLanguages: [],
+      rates: [],
+      isLoggedIn: false,
+    });
+
+    expect(mocks.directPostings).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      unavailable: false,
+      directAttempted: false,
+      data: { postings: initialData.postings },
+    });
+  });
+
+  it("rejects malformed numeric ranges without searching", async () => {
+    const result = await loadCompanyBrowserData({
+      initialData: makeData(),
+      searchParams: new URLSearchParams("sal=100-not-a-number"),
+      locale: "en",
+      displayCurrency: "EUR",
+      jobLanguages: [],
+      rates: [],
+      isLoggedIn: false,
+    });
+
+    expect(mocks.resolveFilters).not.toHaveBeenCalled();
+    expect(mocks.directPostings).not.toHaveBeenCalled();
+    expect(result.unavailable).toBe(true);
+    expect(result.data.postings).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/search/__tests__/company-browser-data.test.ts
+++ b/apps/web/src/lib/search/__tests__/company-browser-data.test.ts
@@ -6,6 +6,7 @@ const mocks = vi.hoisted(() => ({
   resolveFilters: vi.fn(),
   directPostings: vi.fn(),
   parseOffline: vi.fn(),
+  semanticFilters: vi.fn(),
 }));
 
 vi.mock("@/lib/search/typesense-browser-filter-state", () => ({
@@ -14,6 +15,9 @@ vi.mock("@/lib/search/typesense-browser-filter-state", () => ({
 }));
 vi.mock("@/lib/search/search-runner", () => ({
   tryGetCompanyPostingsDirect: mocks.directPostings,
+}));
+vi.mock("@/lib/actions/company-filter-state", () => ({
+  resolveCompanySemanticFilters: mocks.semanticFilters,
 }));
 
 import { loadCompanyBrowserData } from "../company-browser-data";
@@ -79,6 +83,12 @@ beforeEach(() => {
   });
   mocks.resolveFilters.mockReset();
   mocks.resolveFilters.mockResolvedValue({ parsed: emptyParsed, complete: true });
+  mocks.semanticFilters.mockReset();
+  mocks.semanticFilters.mockImplementation(({ q }: { q: string }) => ({
+    parsed: { ...emptyParsed, keywords: q.split(",") },
+    userLat: 47.37,
+    userLng: 8.54,
+  }));
   mocks.directPostings.mockReset();
   mocks.directPostings.mockResolvedValue({
     postings: [],
@@ -108,7 +118,11 @@ describe("loadCompanyBrowserData", () => {
       workMode: ["remote"],
       employmentTypes: ["full_time"],
     };
-    mocks.resolveFilters.mockResolvedValue({ parsed, complete: true });
+    mocks.semanticFilters.mockResolvedValue({
+      parsed,
+      userLat: 47.37,
+      userLng: 8.54,
+    });
     mocks.directPostings.mockResolvedValue({
       postings: [{ id: "filtered" }],
       activeCount: 1,
@@ -157,14 +171,17 @@ describe("loadCompanyBrowserData", () => {
         displayCurrency: "CHF",
         jobLanguages: ["de", "en"],
         salaryCurrencyParam: "CHF",
+        userLat: 47.37,
+        userLng: 8.54,
       },
     });
   });
 
   it("passes anonymous status to preserve posting caps", async () => {
-    mocks.resolveFilters.mockResolvedValue({
+    mocks.semanticFilters.mockResolvedValue({
       parsed: { ...emptyParsed, keywords: ["python"] },
-      complete: true,
+      userLat: undefined,
+      userLng: undefined,
     });
 
     await loadCompanyBrowserData({
@@ -180,10 +197,66 @@ describe("loadCompanyBrowserData", () => {
     expect(mocks.directPostings.mock.calls[0]?.[1]).toBe(false);
   });
 
+  it("uses canonical semantic and geo-aware q results instead of title keywords", async () => {
+    mocks.semanticFilters.mockResolvedValue({
+      parsed: {
+        ...emptyParsed,
+        keywords: ["python"],
+        locations: [
+          {
+            id: 10,
+            slug: "zurich",
+            name: "Zurich",
+            type: "city",
+            parentName: "Switzerland",
+          },
+        ],
+        occupations: [
+          { id: 20, slug: "backend-developer", name: "Backend Developer" },
+        ],
+        workMode: ["remote"],
+      },
+      userLat: 47.37,
+      userLng: 8.54,
+    });
+
+    const result = await loadCompanyBrowserData({
+      initialData: makeData(),
+      searchParams: new URLSearchParams(
+        "q=remote%20Zurich%20backend%20developer%20python",
+      ),
+      locale: "en",
+      displayCurrency: "EUR",
+      jobLanguages: [],
+      rates: [],
+      isLoggedIn: false,
+    });
+
+    expect(mocks.semanticFilters).toHaveBeenCalledWith({
+      q: "remote Zurich backend developer python",
+      loc: undefined,
+      occ: undefined,
+      sen: undefined,
+      tech: undefined,
+      wm: undefined,
+      etype: undefined,
+      locale: "en",
+    });
+    expect(mocks.resolveFilters).not.toHaveBeenCalled();
+    expect(mocks.directPostings.mock.calls[0]?.[0]).toMatchObject({
+      keywords: ["python"],
+      locationIds: [10],
+      occupationIds: [20],
+      workMode: ["remote"],
+    });
+    expect(result.data).toMatchObject({ userLat: 47.37, userLng: 8.54 });
+  });
+
   it("fails closed when direct posting search is degraded", async () => {
-    mocks.resolveFilters.mockResolvedValue({
+    mocks.semanticFilters.mockResolvedValue({
       parsed: { ...emptyParsed, keywords: ["python"] },
-      complete: true,
+      userLat: undefined,
+      userLng: undefined,
     });
     mocks.directPostings.mockResolvedValue(null);
 

--- a/apps/web/src/lib/search/__tests__/typesense-browser-filter-state.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense-browser-filter-state.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getConfig: vi.fn(),
+  invalidate: vi.fn(),
+}));
+
+vi.mock("@/lib/search/typesense-browser-key", () => ({
+  getTypesenseBrowserConfig: mocks.getConfig,
+  invalidateTypesenseBrowserConfigIfUnauthorized: mocks.invalidate,
+}));
+
+import {
+  parseCompanyFilterStateOffline,
+  resolveCompanyFilterStateDirect,
+} from "../typesense-browser-filter-state";
+
+const config = {
+  protocol: "https",
+  host: "typesense.example.test",
+  port: 443,
+  apiKey: "scoped-key",
+  expiresAt: Date.now() + 60_000,
+};
+
+beforeEach(() => {
+  mocks.getConfig.mockReset();
+  mocks.getConfig.mockResolvedValue(config);
+  mocks.invalidate.mockReset();
+  vi.unstubAllGlobals();
+});
+
+describe("resolveCompanyFilterStateDirect", () => {
+  it("resolves bounded canonical slugs in one scoped multi_search", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          results: [
+            {
+              hits: [
+                {
+                  document: {
+                    location_id: 10,
+                    slug: "zurich",
+                    type: "city",
+                    parent_name: "Switzerland",
+                    name_en: "Zurich",
+                    name_de: "Zürich",
+                  },
+                },
+              ],
+            },
+            {
+              hits: [
+                {
+                  document: {
+                    occupation_id: 20,
+                    slug: "software-engineer",
+                    name: "Software Engineer",
+                    locale: "en",
+                  },
+                },
+                {
+                  document: {
+                    occupation_id: 20,
+                    slug: "software-engineer",
+                    name: "Softwareentwickler/in",
+                    locale: "de",
+                  },
+                },
+              ],
+            },
+            {
+              hits: [
+                {
+                  document: {
+                    seniority_id: 30,
+                    slug: "senior",
+                    name: "Senior",
+                    locale: "de",
+                  },
+                },
+              ],
+            },
+            {
+              hits: [
+                {
+                  document: {
+                    technology_id: 40,
+                    slug: "react",
+                    name: "React",
+                  },
+                },
+              ],
+            },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await resolveCompanyFilterStateDirect(
+      new URLSearchParams(
+        "q=python,sql&loc=zurich&occ=software-engineer&sen=senior&tech=react&wm=remote&etype=full_time",
+      ),
+      "de",
+    );
+
+    expect(result).toEqual({
+      complete: true,
+      parsed: {
+        keywords: ["python", "sql"],
+        locations: [
+          {
+            id: 10,
+            slug: "zurich",
+            name: "Zürich",
+            type: "city",
+            parentName: "Switzerland",
+          },
+        ],
+        occupations: [
+          {
+            id: 20,
+            slug: "software-engineer",
+            name: "Softwareentwickler/in",
+          },
+        ],
+        seniorities: [{ id: 30, slug: "senior", name: "Senior" }],
+        technologies: [{ id: 40, slug: "react", name: "React" }],
+        workMode: ["remote"],
+        employmentTypes: ["full_time"],
+      },
+    });
+    expect(mocks.getConfig).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://typesense.example.test:443/multi_search");
+    expect(init.headers).toMatchObject({ "x-typesense-api-key": "scoped-key" });
+    const body = JSON.parse(String(init.body));
+    expect(body.searches.map((search: { collection: string }) => search.collection)).toEqual([
+      "location",
+      "occupation",
+      "seniority",
+      "technology",
+    ]);
+    expect(body.searches[0].filter_by).toBe("slug:[`zurich`]");
+  });
+
+  it("fails closed when an explicit slug cannot be resolved", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ results: [{ hits: [] }] }), {
+          status: 200,
+        }),
+      ),
+    );
+
+    const result = await resolveCompanyFilterStateDirect(
+      new URLSearchParams("loc=missing-place"),
+      "en",
+    );
+
+    expect(result.complete).toBe(false);
+    expect(result.parsed.unresolvedExplicitSlugs).toEqual({
+      loc: ["missing-place"],
+    });
+  });
+
+  it("rejects oversized or unsafe input before requesting a child key", async () => {
+    vi.stubGlobal("fetch", vi.fn());
+
+    const result = await resolveCompanyFilterStateDirect(
+      new URLSearchParams(`loc=${"x".repeat(101)}`),
+      "en",
+    );
+
+    expect(result.complete).toBe(false);
+    expect(mocks.getConfig).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("keeps network-free degraded state bounded and explicitly unresolved", () => {
+    const result = parseCompanyFilterStateOffline(
+      new URLSearchParams(`q=${"x".repeat(600)}&loc=zurich`),
+    );
+
+    expect(result.complete).toBe(false);
+    expect(result.parsed.keywords).toEqual([]);
+    expect(result.parsed.unresolvedExplicitSlugs).toEqual({ loc: ["zurich"] });
+  });
+
+  it("invalidates a rejected scoped key", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(new Response("unauthorized", { status: 401 })),
+    );
+
+    await expect(
+      resolveCompanyFilterStateDirect(
+        new URLSearchParams("tech=react"),
+        "en",
+      ),
+    ).rejects.toThrow("401");
+    expect(mocks.invalidate).toHaveBeenCalledWith(401);
+  });
+});

--- a/apps/web/src/lib/search/__tests__/typesense-browser-filter-state.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense-browser-filter-state.test.ts
@@ -102,7 +102,7 @@ describe("resolveCompanyFilterStateDirect", () => {
 
     const result = await resolveCompanyFilterStateDirect(
       new URLSearchParams(
-        "q=python,sql&loc=zurich&occ=software-engineer&sen=senior&tech=react&wm=remote&etype=full_time",
+        "loc=zurich&occ=software-engineer&sen=senior&tech=react&wm=remote&etype=full_time",
       ),
       "de",
     );
@@ -110,7 +110,7 @@ describe("resolveCompanyFilterStateDirect", () => {
     expect(result).toEqual({
       complete: true,
       parsed: {
-        keywords: ["python", "sql"],
+        keywords: [],
         locations: [
           {
             id: 10,
@@ -190,6 +190,19 @@ describe("resolveCompanyFilterStateDirect", () => {
     expect(result.complete).toBe(false);
     expect(result.parsed.keywords).toEqual([]);
     expect(result.parsed.unresolvedExplicitSlugs).toEqual({ loc: ["zurich"] });
+  });
+
+  it("refuses to reinterpret semantic free text as title keywords", async () => {
+    vi.stubGlobal("fetch", vi.fn());
+
+    const result = await resolveCompanyFilterStateDirect(
+      new URLSearchParams("q=remote"),
+      "en",
+    );
+
+    expect(result.complete).toBe(false);
+    expect(mocks.getConfig).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
   });
 
   it("invalidates a rejected scoped key", async () => {

--- a/apps/web/src/lib/search/company-browser-data.ts
+++ b/apps/web/src/lib/search/company-browser-data.ts
@@ -1,4 +1,5 @@
 import type { CompanyPageData } from "@/lib/actions/company-page-data";
+import { resolveCompanySemanticFilters } from "@/lib/actions/company-filter-state";
 import type { CurrencyRate } from "@/lib/actions/search";
 import { resolveJobLanguages } from "@/lib/job-languages";
 import { convertToEur } from "@/lib/salary";
@@ -63,6 +64,8 @@ function buildUnavailableData(params: {
   salaryCurrencyParam: string;
   salary: RangeResult;
   experience: RangeResult;
+  userLat?: number;
+  userLng?: number;
 }): CompanyPageData {
   return {
     ...params.initialData,
@@ -79,6 +82,8 @@ function buildUnavailableData(params: {
     salaryMaxDisplay: params.salary.max,
     experienceMin: params.experience.min,
     experienceMax: params.experience.max,
+    userLat: params.userLat ?? params.initialData.userLat,
+    userLng: params.userLng ?? params.initialData.userLng,
   };
 }
 
@@ -104,7 +109,10 @@ export async function loadCompanyBrowserData(params: {
   const experience = parseRange(params.searchParams.get("exp"));
   const languages = resolveJobLanguages(params.jobLanguages, params.locale);
   const offline = parseCompanyFilterStateOffline(params.searchParams);
-  const unavailable = (parsed = offline.parsed) => ({
+  const unavailable = (
+    parsed = offline.parsed,
+    geo?: { userLat?: number; userLng?: number },
+  ) => ({
     data: buildUnavailableData({
       initialData: params.initialData,
       parsed,
@@ -114,6 +122,8 @@ export async function loadCompanyBrowserData(params: {
       salaryCurrencyParam,
       salary,
       experience,
+      userLat: geo?.userLat,
+      userLng: geo?.userLng,
     }),
     unavailable: true,
     directAttempted: true,
@@ -121,25 +131,57 @@ export async function loadCompanyBrowserData(params: {
 
   if (!salary.valid || !experience.valid) return unavailable();
 
-  let filterState;
-  try {
-    filterState = await resolveCompanyFilterStateDirect(
-      params.searchParams,
-      params.locale,
-    );
-  } catch (error) {
-    logExternalError(
-      "error",
-      { service: "typesense", operation: "browser_company_filter_state" },
-      error,
-    );
-    return unavailable();
+  let parsed: ParsedSearchFilters;
+  let userLat = params.initialData.userLat;
+  let userLng = params.initialData.userLng;
+  const rawQuery = params.searchParams.get("q")?.trim();
+  if (rawQuery) {
+    try {
+      const semantic = await resolveCompanySemanticFilters({
+        q: rawQuery,
+        loc: params.searchParams.get("loc") ?? undefined,
+        occ: params.searchParams.get("occ") ?? undefined,
+        sen: params.searchParams.get("sen") ?? undefined,
+        tech: params.searchParams.get("tech") ?? undefined,
+        wm: params.searchParams.get("wm") ?? undefined,
+        etype: params.searchParams.get("etype") ?? undefined,
+        locale: params.locale,
+      });
+      if (!semantic) return unavailable();
+      parsed = semantic.parsed;
+      userLat = semantic.userLat;
+      userLng = semantic.userLng;
+    } catch (error) {
+      logExternalError(
+        "error",
+        { service: "typesense", operation: "company_semantic_filters" },
+        error,
+      );
+      return unavailable();
+    }
+  } else {
+    let filterState;
+    try {
+      filterState = await resolveCompanyFilterStateDirect(
+        params.searchParams,
+        params.locale,
+      );
+    } catch (error) {
+      logExternalError(
+        "error",
+        { service: "typesense", operation: "browser_company_filter_state" },
+        error,
+      );
+      return unavailable();
+    }
+    if (!filterState.complete) {
+      return unavailable(filterState.parsed);
+    }
+    parsed = filterState.parsed;
   }
-  if (!filterState.complete) {
-    return unavailable(filterState.parsed);
+  if (parsed.unresolvedExplicitSlugs) {
+    return unavailable(parsed, { userLat, userLng });
   }
-
-  const parsed = filterState.parsed;
   const hasResultFilter =
     parsed.keywords.length > 0 ||
     parsed.locations.length > 0 ||
@@ -165,6 +207,8 @@ export async function loadCompanyBrowserData(params: {
     salaryMaxDisplay: salary.max,
     experienceMin: experience.min,
     experienceMax: experience.max,
+    userLat,
+    userLng,
   };
   if (!hasResultFilter) {
     return { data: baseData, unavailable: false, directAttempted: false };
@@ -214,7 +258,7 @@ export async function loadCompanyBrowserData(params: {
     },
     params.isLoggedIn,
   );
-  if (!result) return unavailable(parsed);
+  if (!result) return unavailable(parsed, { userLat, userLng });
 
   return {
     data: {

--- a/apps/web/src/lib/search/company-browser-data.ts
+++ b/apps/web/src/lib/search/company-browser-data.ts
@@ -1,0 +1,230 @@
+import type { CompanyPageData } from "@/lib/actions/company-page-data";
+import type { CurrencyRate } from "@/lib/actions/search";
+import { resolveJobLanguages } from "@/lib/job-languages";
+import { convertToEur } from "@/lib/salary";
+import { logExternalError } from "@/lib/safe-external-error";
+import { tryGetCompanyPostingsDirect } from "@/lib/search/search-runner";
+import {
+  parseCompanyFilterStateOffline,
+  resolveCompanyFilterStateDirect,
+} from "@/lib/search/typesense-browser-filter-state";
+import type { ParsedSearchFilters } from "@/lib/services/search-input";
+
+const PAGE_SIZE = 20;
+const MAX_RANGE_PARAM_LENGTH = 64;
+
+type RangeResult = {
+  min: number | undefined;
+  max: number | undefined;
+  valid: boolean;
+};
+
+export type CompanyBrowserDataResult = {
+  data: CompanyPageData;
+  unavailable: boolean;
+  /** Prevents CompanyPage from immediately repeating this mount-time read. */
+  directAttempted: boolean;
+};
+
+function parseRange(raw: string | null): RangeResult {
+  if (!raw) return { min: undefined, max: undefined, valid: true };
+  if (raw.length > MAX_RANGE_PARAM_LENGTH) {
+    return { min: undefined, max: undefined, valid: false };
+  }
+  const parts = raw.split("-");
+  if (parts.length !== 2) {
+    return { min: undefined, max: undefined, valid: false };
+  }
+  const parse = (value: string): number | undefined => {
+    if (!value) return undefined;
+    if (!/^\d+$/.test(value)) return Number.NaN;
+    const parsed = Number.parseInt(value, 10);
+    return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : Number.NaN;
+  };
+  const min = parse(parts[0]);
+  const max = parse(parts[1]);
+  return {
+    min: Number.isNaN(min) ? undefined : min,
+    max: Number.isNaN(max) ? undefined : max,
+    valid: !Number.isNaN(min) && !Number.isNaN(max),
+  };
+}
+
+function validCurrency(value: string | null | undefined): string | null {
+  return value && /^[A-Z]{3}$/.test(value) ? value : null;
+}
+
+function buildUnavailableData(params: {
+  initialData: CompanyPageData;
+  parsed: ParsedSearchFilters;
+  displayCurrency: string;
+  jobLanguages: string[];
+  languages: string[];
+  salaryCurrencyParam: string;
+  salary: RangeResult;
+  experience: RangeResult;
+}): CompanyPageData {
+  return {
+    ...params.initialData,
+    postings: [],
+    activeCount: 0,
+    yearCount: 0,
+    truncated: false,
+    parsed: params.parsed,
+    displayCurrency: params.displayCurrency,
+    jobLanguages: params.jobLanguages,
+    languages: params.languages,
+    salaryCurrencyParam: params.salaryCurrencyParam,
+    salaryMinDisplay: params.salary.min,
+    salaryMaxDisplay: params.salary.max,
+    experienceMin: params.experience.min,
+    experienceMax: params.experience.max,
+  };
+}
+
+/**
+ * Initialize a personalized/filter-bearing company view without invoking a
+ * Server Action. URL vocabulary is resolved through the scoped browser key;
+ * any unsafe, unresolved, or degraded input fails closed to an unavailable
+ * result rather than restoring the broader prerendered posting list.
+ */
+export async function loadCompanyBrowserData(params: {
+  initialData: CompanyPageData;
+  searchParams: URLSearchParams;
+  locale: string;
+  displayCurrency?: string | null;
+  jobLanguages: string[];
+  rates: CurrencyRate[];
+  isLoggedIn: boolean;
+}): Promise<CompanyBrowserDataResult> {
+  const displayCurrency = validCurrency(params.displayCurrency) ?? "EUR";
+  const salaryCurrencyParam =
+    validCurrency(params.searchParams.get("salcur")) ?? displayCurrency;
+  const salary = parseRange(params.searchParams.get("sal"));
+  const experience = parseRange(params.searchParams.get("exp"));
+  const languages = resolveJobLanguages(params.jobLanguages, params.locale);
+  const offline = parseCompanyFilterStateOffline(params.searchParams);
+  const unavailable = (parsed = offline.parsed) => ({
+    data: buildUnavailableData({
+      initialData: params.initialData,
+      parsed,
+      displayCurrency,
+      jobLanguages: params.jobLanguages,
+      languages,
+      salaryCurrencyParam,
+      salary,
+      experience,
+    }),
+    unavailable: true,
+    directAttempted: true,
+  });
+
+  if (!salary.valid || !experience.valid) return unavailable();
+
+  let filterState;
+  try {
+    filterState = await resolveCompanyFilterStateDirect(
+      params.searchParams,
+      params.locale,
+    );
+  } catch (error) {
+    logExternalError(
+      "error",
+      { service: "typesense", operation: "browser_company_filter_state" },
+      error,
+    );
+    return unavailable();
+  }
+  if (!filterState.complete) {
+    return unavailable(filterState.parsed);
+  }
+
+  const parsed = filterState.parsed;
+  const hasResultFilter =
+    parsed.keywords.length > 0 ||
+    parsed.locations.length > 0 ||
+    parsed.occupations.length > 0 ||
+    parsed.seniorities.length > 0 ||
+    parsed.technologies.length > 0 ||
+    parsed.employmentTypes.length > 0 ||
+    parsed.workMode.length > 0 ||
+    salary.min != null ||
+    salary.max != null ||
+    experience.min != null ||
+    experience.max != null ||
+    languages.join(",") !== params.initialData.languages.join(",");
+
+  const baseData: CompanyPageData = {
+    ...params.initialData,
+    parsed,
+    displayCurrency,
+    jobLanguages: params.jobLanguages,
+    languages,
+    salaryCurrencyParam,
+    salaryMinDisplay: salary.min,
+    salaryMaxDisplay: salary.max,
+    experienceMin: experience.min,
+    experienceMax: experience.max,
+  };
+  if (!hasResultFilter) {
+    return { data: baseData, unavailable: false, directAttempted: false };
+  }
+
+  const result = await tryGetCompanyPostingsDirect(
+    {
+      companyId: params.initialData.company.id,
+      keywords: parsed.keywords,
+      locationIds:
+        parsed.locations.length > 0
+          ? parsed.locations.map((location) => location.id)
+          : undefined,
+      occupationIds:
+        parsed.occupations.length > 0
+          ? parsed.occupations.map((occupation) => occupation.id)
+          : undefined,
+      seniorityIds:
+        parsed.seniorities.length > 0
+          ? parsed.seniorities.map((seniority) => seniority.id)
+          : undefined,
+      technologyIds:
+        parsed.technologies.length > 0
+          ? parsed.technologies.map((technology) => technology.id)
+          : undefined,
+      employmentTypes:
+        parsed.employmentTypes.length > 0
+          ? parsed.employmentTypes
+          : undefined,
+      workMode: parsed.workMode.length > 0 ? parsed.workMode : undefined,
+      salaryMinEur: convertToEur(
+        salary.min,
+        salaryCurrencyParam,
+        params.rates,
+      ),
+      salaryMaxEur: convertToEur(
+        salary.max,
+        salaryCurrencyParam,
+        params.rates,
+      ),
+      experienceMin: experience.min,
+      experienceMax: experience.max,
+      languages,
+      locale: params.locale,
+      offset: 0,
+      limit: PAGE_SIZE,
+    },
+    params.isLoggedIn,
+  );
+  if (!result) return unavailable(parsed);
+
+  return {
+    data: {
+      ...baseData,
+      postings: result.postings,
+      activeCount: result.activeCount,
+      yearCount: result.yearCount,
+      truncated: result.truncated,
+    },
+    unavailable: false,
+    directAttempted: true,
+  };
+}

--- a/apps/web/src/lib/search/semantic-query.ts
+++ b/apps/web/src/lib/search/semantic-query.ts
@@ -1,0 +1,62 @@
+export type TokenizedSemanticSearchQuery = {
+  segmentWords: string[][];
+  singles: string[];
+  allCandidates: string[];
+};
+
+/**
+ * Canonical tokenizer shared by semantic parsing and its server-action bound.
+ * Keep delimiter and candidate construction changes centralized here so input
+ * validation always measures the exact work the parser will perform.
+ */
+export function tokenizeSemanticSearchQuery(
+  input: string,
+): TokenizedSemanticSearchQuery {
+  const segments = input
+    .split(/[,\n\r\t/|]+|-+/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const segmentWords = segments.map((segment) =>
+    segment.split(/\s+/).filter(Boolean),
+  );
+  const singleSet = new Set<string>();
+  const allCandidateSet = new Set<string>();
+  for (const words of segmentWords) {
+    for (const word of words) {
+      singleSet.add(word);
+      allCandidateSet.add(word);
+    }
+    for (let index = 0; index < words.length - 1; index += 1) {
+      allCandidateSet.add(`${words[index]} ${words[index + 1]}`);
+    }
+    if (words.length <= 10) {
+      for (let index = 0; index < words.length - 2; index += 1) {
+        allCandidateSet.add(
+          `${words[index]} ${words[index + 1]} ${words[index + 2]}`,
+        );
+      }
+    }
+  }
+  return {
+    segmentWords,
+    singles: [...singleSet],
+    allCandidates: [...allCandidateSet],
+  };
+}
+
+/** Exact fan-out dimensions used by the canonical semantic parser. */
+export function getSemanticSearchQueryComplexity(input: string): {
+  uniqueTerms: number;
+  occupationCandidates: number;
+  maxTermLength: number;
+} {
+  const tokenized = tokenizeSemanticSearchQuery(input);
+  return {
+    uniqueTerms: tokenized.singles.length,
+    occupationCandidates: tokenized.allCandidates.length,
+    maxTermLength: tokenized.singles.reduce(
+      (maximum, term) => Math.max(maximum, term.length),
+      0,
+    ),
+  };
+}

--- a/apps/web/src/lib/search/typesense-browser-filter-state.ts
+++ b/apps/web/src/lib/search/typesense-browser-filter-state.ts
@@ -221,7 +221,9 @@ export function parseCompanyFilterStateOffline(
   return {
     parsed: input.parsed,
     complete:
-      input.valid && input.parsed.unresolvedExplicitSlugs === undefined,
+      input.valid &&
+      input.keywords.values.length === 0 &&
+      input.parsed.unresolvedExplicitSlugs === undefined,
   };
 }
 
@@ -238,7 +240,10 @@ export async function resolveCompanyFilterStateDirect(
   const locale = safeLocale(localeInput);
   const input = parseFilterInput(searchParams);
   const { byDimension, parsed: base } = input;
-  if (!input.valid) {
+  // Free text needs the canonical semantic parser (work mode, taxonomy and
+  // geo-aware location inference). This direct helper resolves only explicit
+  // URL dimensions and refuses to reinterpret `q` as title keywords.
+  if (!input.valid || input.keywords.values.length > 0) {
     return { parsed: base, complete: false };
   }
 

--- a/apps/web/src/lib/search/typesense-browser-filter-state.ts
+++ b/apps/web/src/lib/search/typesense-browser-filter-state.ts
@@ -1,0 +1,358 @@
+import type { ParsedSearchFilters } from "@/lib/services/search-input";
+import type { SelectedLocation } from "@/lib/search/types";
+import {
+  parseEmploymentTypeParam,
+  parseWorkModeParam,
+} from "@/lib/search/query-params";
+import {
+  getTypesenseBrowserConfig,
+  invalidateTypesenseBrowserConfigIfUnauthorized,
+  type TypesenseBrowserConfig,
+} from "@/lib/search/typesense-browser-key";
+
+const MAX_QUERY_LENGTH = 512;
+const MAX_KEYWORDS = 20;
+const MAX_KEYWORD_LENGTH = 120;
+const MAX_SLUGS_PER_DIMENSION = 20;
+const MAX_SLUG_LENGTH = 100;
+
+type FilterDimension = "loc" | "occ" | "sen" | "tech";
+
+type SearchRequest = {
+  collection: string;
+  [key: string]: unknown;
+};
+
+type SearchHit<T> = { document: T };
+type SearchResult<T> = {
+  hits?: SearchHit<T>[];
+  error?: string;
+};
+
+type LocationDocument = {
+  location_id: number;
+  slug: string;
+  type: string;
+  parent_name?: string;
+  name_en?: string;
+  name_de?: string;
+  name_fr?: string;
+  name_it?: string;
+};
+
+type TaxonomyDocument = {
+  occupation_id?: number;
+  seniority_id?: number;
+  technology_id?: number;
+  slug: string;
+  name?: string;
+  locale?: string;
+};
+
+export type BrowserFilterStateResult = {
+  parsed: ParsedSearchFilters;
+  /** False means at least one URL filter was unsafe or could not be resolved. */
+  complete: boolean;
+};
+
+type ParsedFilterInput = {
+  keywords: { values: string[]; valid: boolean };
+  byDimension: Record<
+    FilterDimension,
+    { values: string[]; valid: boolean }
+  >;
+  parsed: ParsedSearchFilters;
+  valid: boolean;
+};
+
+function safeLocale(locale: string): "en" | "de" | "fr" | "it" {
+  return locale === "de" || locale === "fr" || locale === "it"
+    ? locale
+    : "en";
+}
+
+function filterLiteral(value: string): string {
+  return `\`${value.replace(/\\/g, "\\\\").replace(/`/g, "\\`")}\``;
+}
+
+function splitSlugs(raw: string | null): { values: string[]; valid: boolean } {
+  if (!raw) return { values: [], valid: true };
+  if (raw.length > MAX_QUERY_LENGTH) return { values: [], valid: false };
+
+  const values: string[] = [];
+  const seen = new Set<string>();
+  for (const part of raw.split(",")) {
+    const value = part.trim();
+    const key = value.toLowerCase();
+    if (!value || seen.has(key)) continue;
+    if (
+      value.length > MAX_SLUG_LENGTH ||
+      !/^[\p{L}\p{N}][\p{L}\p{N}._-]*$/u.test(value)
+    ) {
+      return { values: [], valid: false };
+    }
+    seen.add(key);
+    values.push(value);
+    if (values.length > MAX_SLUGS_PER_DIMENSION) {
+      return { values: [], valid: false };
+    }
+  }
+  return { values, valid: true };
+}
+
+function splitKeywords(raw: string | null): { values: string[]; valid: boolean } {
+  if (!raw) return { values: [], valid: true };
+  if (raw.length > MAX_QUERY_LENGTH || /[\u0000-\u001f\u007f]/.test(raw)) {
+    return { values: [], valid: false };
+  }
+  const values = raw
+    .split(",")
+    .map((value) => value.trim())
+    .filter(Boolean);
+  if (
+    values.length > MAX_KEYWORDS ||
+    values.some((value) => value.length > MAX_KEYWORD_LENGTH)
+  ) {
+    return { values: [], valid: false };
+  }
+  return { values: [...new Set(values)], valid: true };
+}
+
+async function searchMany(
+  config: TypesenseBrowserConfig,
+  searches: SearchRequest[],
+): Promise<SearchResult<Record<string, unknown>>[]> {
+  const url = `${config.protocol}://${config.host}:${config.port}/multi_search`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-typesense-api-key": config.apiKey,
+    },
+    body: JSON.stringify({ searches }),
+  });
+  if (!response.ok) {
+    invalidateTypesenseBrowserConfigIfUnauthorized(response.status);
+    throw new Error(`typesense filter resolver ${response.status}`);
+  }
+  const body = (await response.json()) as {
+    results?: SearchResult<Record<string, unknown>>[];
+  };
+  if (!body.results || body.results.length !== searches.length) {
+    throw new Error("typesense filter resolver returned an incomplete result set");
+  }
+  for (const result of body.results) {
+    if (result.error) throw new Error("typesense filter resolver search failed");
+  }
+  return body.results;
+}
+
+function localizedLocationName(
+  document: LocationDocument,
+  locale: "en" | "de" | "fr" | "it",
+): string {
+  return document[`name_${locale}`] ?? document.name_en ?? document.slug;
+}
+
+function preferLocale(
+  documents: TaxonomyDocument[],
+  locale: "en" | "de" | "fr" | "it",
+): Map<string, TaxonomyDocument> {
+  const bySlug = new Map<string, TaxonomyDocument>();
+  for (const document of documents) {
+    const current = bySlug.get(document.slug);
+    if (
+      !current ||
+      (document.locale === locale && current.locale !== locale)
+    ) {
+      bySlug.set(document.slug, document);
+    }
+  }
+  return bySlug;
+}
+
+function parseFilterInput(searchParams: URLSearchParams): ParsedFilterInput {
+  const keywords = splitKeywords(searchParams.get("q"));
+  const byDimension = {
+    loc: splitSlugs(searchParams.get("loc")),
+    occ: splitSlugs(searchParams.get("occ")),
+    sen: splitSlugs(searchParams.get("sen")),
+    tech: splitSlugs(searchParams.get("tech")),
+  } satisfies ParsedFilterInput["byDimension"];
+
+  const unresolvedExplicitSlugs = Object.fromEntries(
+    (Object.entries(byDimension) as Array<
+      [FilterDimension, { values: string[]; valid: boolean }]
+    >)
+      .filter(([, value]) => value.values.length > 0)
+      .map(([dimension, value]) => [dimension, value.values]),
+  ) as NonNullable<ParsedSearchFilters["unresolvedExplicitSlugs"]>;
+  const parsed: ParsedSearchFilters = {
+    keywords: keywords.values,
+    locations: [],
+    occupations: [],
+    seniorities: [],
+    technologies: [],
+    workMode: parseWorkModeParam(searchParams.get("wm")),
+    employmentTypes: parseEmploymentTypeParam(searchParams.get("etype")),
+    ...(Object.keys(unresolvedExplicitSlugs).length > 0
+      ? { unresolvedExplicitSlugs }
+      : {}),
+  };
+  return {
+    keywords,
+    byDimension,
+    parsed,
+    valid:
+      keywords.valid &&
+      Object.values(byDimension).every((value) => value.valid),
+  };
+}
+
+/**
+ * Preserve bounded URL state when the network cannot resolve taxonomy slugs.
+ * Explicit slugs remain marked unresolved, so callers cannot accidentally
+ * broaden a failed filtered search.
+ */
+export function parseCompanyFilterStateOffline(
+  searchParams: URLSearchParams,
+): BrowserFilterStateResult {
+  const input = parseFilterInput(searchParams);
+  return {
+    parsed: input.parsed,
+    complete:
+      input.valid && input.parsed.unresolvedExplicitSlugs === undefined,
+  };
+}
+
+/**
+ * Resolve the canonical company-page URL vocabulary directly through the
+ * scoped browser Typesense key. The helper is deliberately bounded because
+ * every value originates in an untrusted URL. Missing/invalid slugs fail
+ * closed: callers render an unavailable state instead of dropping the filter.
+ */
+export async function resolveCompanyFilterStateDirect(
+  searchParams: URLSearchParams,
+  localeInput: string,
+): Promise<BrowserFilterStateResult> {
+  const locale = safeLocale(localeInput);
+  const input = parseFilterInput(searchParams);
+  const { byDimension, parsed: base } = input;
+  if (!input.valid) {
+    return { parsed: base, complete: false };
+  }
+
+  const searches: SearchRequest[] = [];
+  const kinds: FilterDimension[] = [];
+  const addSearch = (kind: FilterDimension, search: SearchRequest) => {
+    kinds.push(kind);
+    searches.push(search);
+  };
+  const list = (values: string[]) =>
+    values.map(filterLiteral).join(",");
+
+  if (byDimension.loc.values.length > 0) {
+    addSearch("loc", {
+      collection: "location",
+      q: "*",
+      query_by: "name_en",
+      filter_by: `slug:[${list(byDimension.loc.values)}]`,
+      per_page: byDimension.loc.values.length,
+      include_fields:
+        "location_id,slug,type,parent_name,name_en,name_de,name_fr,name_it",
+    });
+  }
+  const localizedFilter = (values: string[]) =>
+    `slug:[${list(values)}] && locale:[${locale},en]`;
+  if (byDimension.occ.values.length > 0) {
+    addSearch("occ", {
+      collection: "occupation",
+      q: "*",
+      query_by: "name",
+      filter_by: localizedFilter(byDimension.occ.values),
+      per_page: byDimension.occ.values.length * 2,
+      include_fields: "occupation_id,slug,name,locale",
+    });
+  }
+  if (byDimension.sen.values.length > 0) {
+    addSearch("sen", {
+      collection: "seniority",
+      q: "*",
+      query_by: "name",
+      filter_by: localizedFilter(byDimension.sen.values),
+      per_page: byDimension.sen.values.length * 2,
+      include_fields: "seniority_id,slug,name,locale",
+    });
+  }
+  if (byDimension.tech.values.length > 0) {
+    addSearch("tech", {
+      collection: "technology",
+      q: "*",
+      query_by: "name",
+      filter_by: `slug:[${list(byDimension.tech.values)}]`,
+      per_page: byDimension.tech.values.length,
+      include_fields: "technology_id,slug,name",
+    });
+  }
+  if (searches.length === 0) return { parsed: base, complete: true };
+
+  const results = await searchMany(
+    await getTypesenseBrowserConfig(),
+    searches,
+  );
+  const resolved = new Set<string>();
+  for (let index = 0; index < kinds.length; index += 1) {
+    const kind = kinds[index];
+    const documents = (results[index].hits ?? []).map(
+      (hit) => hit.document,
+    );
+    if (kind === "loc") {
+      base.locations = documents.map((raw) => {
+        const document = raw as unknown as LocationDocument;
+        resolved.add(`loc:${document.slug}`);
+        return {
+          id: document.location_id,
+          slug: document.slug,
+          name: localizedLocationName(document, locale),
+          type: document.type as SelectedLocation["type"],
+          parentName: document.parent_name ?? null,
+        };
+      });
+      continue;
+    }
+
+    const preferred = preferLocale(
+      documents as unknown as TaxonomyDocument[],
+      locale,
+    );
+    const target =
+      kind === "occ"
+        ? base.occupations
+        : kind === "sen"
+          ? base.seniorities
+          : base.technologies;
+    for (const document of preferred.values()) {
+      const id =
+        kind === "occ"
+          ? document.occupation_id
+          : kind === "sen"
+            ? document.seniority_id
+            : document.technology_id;
+      if (!Number.isInteger(id)) continue;
+      resolved.add(`${kind}:${document.slug}`);
+      target.push({
+        id: id as number,
+        slug: document.slug,
+        name: document.name ?? document.slug,
+      });
+    }
+  }
+
+  const missing = (Object.entries(byDimension) as Array<
+    [FilterDimension, { values: string[]; valid: boolean }]
+  >).some(([kind, value]) =>
+    value.values.some((slug) => !resolved.has(`${kind}:${slug}`)),
+  );
+  if (!missing) delete base.unresolvedExplicitSlugs;
+  return { parsed: base, complete: !missing };
+}

--- a/apps/web/src/lib/services/search-input.ts
+++ b/apps/web/src/lib/services/search-input.ts
@@ -92,6 +92,57 @@ function splitIntoWords(segment: string): string[] {
   return segment.split(/\s+/).filter(Boolean);
 }
 
+type TokenizedSearchQuery = {
+  segmentWords: string[][];
+  singles: string[];
+  allCandidates: string[];
+};
+
+function tokenizeSearchQuery(input: string): TokenizedSearchQuery {
+  const segments = input ? splitIntoSegments(input) : [];
+  const segmentWords = segments.map(splitIntoWords);
+  const singleSet = new Set<string>();
+  const allCandidateSet = new Set<string>();
+  for (const words of segmentWords) {
+    for (const word of words) {
+      singleSet.add(word);
+      allCandidateSet.add(word);
+    }
+    for (let index = 0; index < words.length - 1; index += 1) {
+      allCandidateSet.add(`${words[index]} ${words[index + 1]}`);
+    }
+    if (words.length <= 10) {
+      for (let index = 0; index < words.length - 2; index += 1) {
+        allCandidateSet.add(
+          `${words[index]} ${words[index + 1]} ${words[index + 2]}`,
+        );
+      }
+    }
+  }
+  return {
+    segmentWords,
+    singles: [...singleSet],
+    allCandidates: [...allCandidateSet],
+  };
+}
+
+/** Exact fan-out dimensions used by the canonical semantic parser. */
+export function getSemanticSearchQueryComplexity(input: string): {
+  uniqueTerms: number;
+  occupationCandidates: number;
+  maxTermLength: number;
+} {
+  const tokenized = tokenizeSearchQuery(input);
+  return {
+    uniqueTerms: tokenized.singles.length,
+    occupationCandidates: tokenized.allCandidates.length,
+    maxTermLength: tokenized.singles.reduce(
+      (maximum, term) => Math.max(maximum, term.length),
+      0,
+    ),
+  };
+}
+
 function exactLocationMatch(
   text: string,
   suggestions: LocationSuggestion[],
@@ -285,28 +336,9 @@ export async function parseSearchFilters(params: {
   const technologyIds = new Set(technologies.map((t) => t.id));
 
   // --- Word-level tokenization ---
-  const segments = params.q ? splitIntoSegments(params.q) : [];
-  const segmentWords = segments.map(splitIntoWords);
-
-  // Collect unique single words and all candidates (singles + pairs + triplets)
-  const singleSet = new Set<string>();
-  const allCandidateSet = new Set<string>();
-  for (const words of segmentWords) {
-    for (const w of words) {
-      singleSet.add(w);
-      allCandidateSet.add(w);
-    }
-    for (let i = 0; i < words.length - 1; i++) {
-      allCandidateSet.add(`${words[i]} ${words[i + 1]}`);
-    }
-    if (words.length <= 10) {
-      for (let i = 0; i < words.length - 2; i++) {
-        allCandidateSet.add(`${words[i]} ${words[i + 1]} ${words[i + 2]}`);
-      }
-    }
-  }
-  const singles = [...singleSet];
-  const allCandidates = [...allCandidateSet];
+  const { segmentWords, singles, allCandidates } = tokenizeSearchQuery(
+    params.q ?? "",
+  );
   if (singles.length === 0) {
     return {
       keywords: [],

--- a/apps/web/src/lib/services/search-input.ts
+++ b/apps/web/src/lib/services/search-input.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/services/taxonomy";
 import type { TaxonomySuggestion } from "@/lib/services/taxonomy";
 import { parseEmploymentTypeParam, parseWorkModeParam } from "@/lib/search/query-params";
+import { tokenizeSemanticSearchQuery } from "@/lib/search/semantic-query";
 import type { EmploymentType, SelectedLocation, WorkMode } from "@/lib/search/types";
 
 export interface ParsedSearchFilters {
@@ -79,68 +80,6 @@ function normalizeLocationText(value: string): string {
     .toLowerCase()
     .normalize("NFKD")
     .replace(/[^\p{L}\p{N}]+/gu, "");
-}
-
-function splitIntoSegments(input: string): string[] {
-  return input
-    .split(/[,\n\r\t/|]+|-+/)
-    .map((part) => part.trim())
-    .filter(Boolean);
-}
-
-function splitIntoWords(segment: string): string[] {
-  return segment.split(/\s+/).filter(Boolean);
-}
-
-type TokenizedSearchQuery = {
-  segmentWords: string[][];
-  singles: string[];
-  allCandidates: string[];
-};
-
-function tokenizeSearchQuery(input: string): TokenizedSearchQuery {
-  const segments = input ? splitIntoSegments(input) : [];
-  const segmentWords = segments.map(splitIntoWords);
-  const singleSet = new Set<string>();
-  const allCandidateSet = new Set<string>();
-  for (const words of segmentWords) {
-    for (const word of words) {
-      singleSet.add(word);
-      allCandidateSet.add(word);
-    }
-    for (let index = 0; index < words.length - 1; index += 1) {
-      allCandidateSet.add(`${words[index]} ${words[index + 1]}`);
-    }
-    if (words.length <= 10) {
-      for (let index = 0; index < words.length - 2; index += 1) {
-        allCandidateSet.add(
-          `${words[index]} ${words[index + 1]} ${words[index + 2]}`,
-        );
-      }
-    }
-  }
-  return {
-    segmentWords,
-    singles: [...singleSet],
-    allCandidates: [...allCandidateSet],
-  };
-}
-
-/** Exact fan-out dimensions used by the canonical semantic parser. */
-export function getSemanticSearchQueryComplexity(input: string): {
-  uniqueTerms: number;
-  occupationCandidates: number;
-  maxTermLength: number;
-} {
-  const tokenized = tokenizeSearchQuery(input);
-  return {
-    uniqueTerms: tokenized.singles.length,
-    occupationCandidates: tokenized.allCandidates.length,
-    maxTermLength: tokenized.singles.reduce(
-      (maximum, term) => Math.max(maximum, term.length),
-      0,
-    ),
-  };
 }
 
 function exactLocationMatch(
@@ -336,7 +275,7 @@ export async function parseSearchFilters(params: {
   const technologyIds = new Set(technologies.map((t) => t.id));
 
   // --- Word-level tokenization ---
-  const { segmentWords, singles, allCandidates } = tokenizeSearchQuery(
+  const { segmentWords, singles, allCandidates } = tokenizeSemanticSearchQuery(
     params.q ?? "",
   );
   if (singles.length === 0) {


### PR DESCRIPTION
## Summary
- reuse the existing app bootstrap preferences and bounded anonymous language cookie instead of mounting the full company-page Server Action
- resolve explicit canonical URL filters through one scoped Typesense `multi_search`, then load company postings/counts browser-direct with existing anonymous caps
- preserve raw `q` semantics and geo-aware taxonomy/location inference through a narrow bounded canonical-parser action; no company lookup, preferences, or posting search run in that action
- share the canonical tokenizer/candidate construction with that action so delimiter-heavy free text cannot amplify taxonomy fan-out
- fail closed with an explicit unavailable state on unsafe, unresolved, or degraded filtered searches
- prevent duplicate hydration refreshes after the browser initializer already fetched data

## Verification
- focused Vitest suite (9 files, 82 tests), including canonical search-input parity and delimiter/candidate fan-out tests
- `pnpm exec tsc --noEmit`
- targeted ESLint
- `pnpm build`
- production scoped-key `multi_search` probe for explicit location/localized occupation syntax

Closes #8257