### PR TITLE
[Fluid CPU] Refresh public watchlists in the browser

### DIFF
--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx
@@ -11,7 +11,10 @@ import {
   type Locale,
 } from "@/lib/i18n";
 import { watchlistCacheTag } from "@/lib/cache-tags";
-import { CACHE_TTL_LONG, CACHE_TTL_SHORT } from "@/lib/cache-ttl";
+import {
+  CACHE_TTL_LONG,
+  CACHE_TTL_WATCHLIST_SHELL,
+} from "@/lib/cache-ttl";
 import {
   getPublicWatchlistByUserAndSlug,
   getWatchlistMatchingCompanyCount,
@@ -27,8 +30,10 @@ import { fetchPublicWatchlistPageData } from "@/lib/services/watchlist-page-data
 import { WatchlistContent } from "./watchlist-content";
 import { WatchlistRuntimeFallback } from "./watchlist-runtime-fallback";
 
-// Metadata is cached for an hour; the page body uses the short tier so
-// its posting list stays reasonably fresh. Each is its own `'use cache'`
+// Metadata and the public page shell are cached for an hour. The posting
+// list refreshes directly from Typesense after anonymous hydration, while
+// exact watchlist mutations invalidate both cache boundaries immediately.
+// Each is its own `'use cache'`
 // boundary — under cacheComponents they run in
 // separate clean AsyncLocalStorage snapshots, so React's `cache()`
 // wouldn't dedupe the watchlist lookup across them. Cross-boundary
@@ -182,7 +187,7 @@ async function getWatchlistRouteSnapshot(
   watchlistSlug: string,
 ) {
   "use cache";
-  cacheLife({ revalidate: CACHE_TTL_SHORT });
+  cacheLife({ revalidate: CACHE_TTL_WATCHLIST_SHELL });
   cacheTag(watchlistCacheTag(userSlug, watchlistSlug));
 
   // Re-fetch the watchlist detail. The Redis `cached()` layer inside
@@ -190,8 +195,9 @@ async function getWatchlistRouteSnapshot(
   // `generateMetadata` call above (single SQL per cold cache fill).
   // The body and its structured data must reach non-JS consumers (AI
   // retrievers and search-engine crawlers that don't execute JS), so
-  // render the anonymous snapshot here. Viewers with personalization
-  // hints replace it through WatchlistContent's server action.
+  // render the anonymous snapshot here. Anonymous language preferences
+  // refresh it directly from Typesense; authenticated viewers retain the
+  // authoritative WatchlistContent Server Action path.
   const detail = await getPublicWatchlistByUserAndSlug(userSlug, watchlistSlug);
   if (!detail) return null;
 

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-content.test.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-content.test.tsx
@@ -4,7 +4,8 @@ import type { WatchlistPageData } from "@/lib/actions/watchlist-page-data";
 
 const mockFetchWatchlistPageData = vi.fn();
 const mockHasLoggedInHint = vi.fn();
-const mockHasAnonJobLanguagesHint = vi.fn();
+const mockReadAnonJobLanguagesPreference = vi.fn();
+const mockTryGetWatchlistSnapshotDirect = vi.fn();
 
 vi.mock("@/lib/actions/watchlist-page-data", () => ({
   fetchWatchlistPageData: (...args: unknown[]) =>
@@ -13,7 +14,13 @@ vi.mock("@/lib/actions/watchlist-page-data", () => ({
 
 vi.mock("@/lib/client-cookies", () => ({
   hasLoggedInHint: () => mockHasLoggedInHint(),
-  hasAnonJobLanguagesHint: () => mockHasAnonJobLanguagesHint(),
+  readAnonJobLanguagesPreference: () =>
+    mockReadAnonJobLanguagesPreference(),
+}));
+
+vi.mock("@/lib/search/search-runner", () => ({
+  tryGetWatchlistSnapshotDirect: (...args: unknown[]) =>
+    mockTryGetWatchlistSnapshotDirect(...args),
 }));
 
 vi.mock("@/components/search/watchlist-skeleton", () => ({
@@ -21,8 +28,21 @@ vi.mock("@/components/search/watchlist-skeleton", () => ({
 }));
 
 vi.mock("./watchlist-view-page", () => ({
-  WatchlistViewPage: ({ isOwner }: { isOwner: boolean }) => (
-    <div data-testid="watchlist-view" data-owner={String(isOwner)} />
+  WatchlistViewPage: ({
+    isOwner,
+    initialTotal,
+    yearTotal,
+  }: {
+    isOwner: boolean;
+    initialTotal: number;
+    yearTotal: number;
+  }) => (
+    <div
+      data-testid="watchlist-view"
+      data-owner={String(isOwner)}
+      data-total={String(initialTotal)}
+      data-year-total={String(yearTotal)}
+    />
   ),
 }));
 
@@ -64,13 +84,19 @@ function makeData(isOwner = false): WatchlistPageData {
     resolvedTechnologies: [],
     jobLanguages: [],
     languages: ["en"],
+    browserPostingFilters: {
+      companyIds: [],
+      anyCompany: true,
+      languages: ["en"],
+    },
   };
 }
 
 beforeEach(() => {
   mockFetchWatchlistPageData.mockReset();
   mockHasLoggedInHint.mockReset().mockReturnValue(false);
-  mockHasAnonJobLanguagesHint.mockReset().mockReturnValue(false);
+  mockReadAnonJobLanguagesPreference.mockReset().mockReturnValue(null);
+  mockTryGetWatchlistSnapshotDirect.mockReset().mockResolvedValue(null);
   vi.spyOn(window, "scrollTo").mockImplementation(() => {});
 });
 
@@ -79,7 +105,7 @@ afterEach(() => {
 });
 
 describe("WatchlistContent initial data", () => {
-  it("renders anonymous public data immediately without a mount fetch", async () => {
+  it("renders anonymous SSR data and refreshes directly without a server action", async () => {
     const { getByTestId, queryByTestId } = render(
       <WatchlistContent
         lang="en"
@@ -92,6 +118,65 @@ describe("WatchlistContent initial data", () => {
     expect(getByTestId("watchlist-view")).toBeTruthy();
     expect(queryByTestId("watchlist-skeleton")).toBeNull();
     await waitFor(() => expect(mockFetchWatchlistPageData).not.toHaveBeenCalled());
+    expect(mockTryGetWatchlistSnapshotDirect).toHaveBeenCalledWith({
+      companyIds: [],
+      anyCompany: true,
+      languages: ["en"],
+    });
+  });
+
+  it("replaces SSR postings and counts after a successful direct refresh", async () => {
+    mockTryGetWatchlistSnapshotDirect.mockResolvedValue({
+      postings: [],
+      total: 12,
+      yearTotal: 34,
+    });
+
+    const { getByTestId } = render(
+      <WatchlistContent
+        lang="en"
+        userSlug="owner"
+        watchlistSlug="public-list"
+        initialData={makeData()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("watchlist-view").getAttribute("data-total")).toBe(
+        "12",
+      );
+      expect(
+        getByTestId("watchlist-view").getAttribute("data-year-total"),
+      ).toBe("34");
+    });
+    expect(mockFetchWatchlistPageData).not.toHaveBeenCalled();
+  });
+
+  it("applies anonymous language preferences without a server action", async () => {
+    mockReadAnonJobLanguagesPreference.mockReturnValue(["de"]);
+    mockTryGetWatchlistSnapshotDirect.mockResolvedValue({
+      postings: [],
+      total: 3,
+      yearTotal: 8,
+    });
+
+    render(
+      <WatchlistContent
+        lang="en"
+        userSlug="owner"
+        watchlistSlug="public-list"
+        initialData={makeData()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(mockTryGetWatchlistSnapshotDirect).toHaveBeenCalledWith({
+        companyIds: [],
+        anyCompany: true,
+        languages: ["de"],
+      });
+    });
+    expect(mockFetchWatchlistPageData).not.toHaveBeenCalled();
   });
 
   it("refetches when the logged-in hint requires viewer-specific data", async () => {
@@ -117,6 +202,7 @@ describe("WatchlistContent initial data", () => {
         "true",
       );
     });
+    expect(mockTryGetWatchlistSnapshotDirect).not.toHaveBeenCalled();
   });
 
   it("uses viewer-resolved server data without another authenticated fetch", async () => {
@@ -136,6 +222,7 @@ describe("WatchlistContent initial data", () => {
       "true",
     );
     await waitFor(() => expect(mockFetchWatchlistPageData).not.toHaveBeenCalled());
+    expect(mockTryGetWatchlistSnapshotDirect).not.toHaveBeenCalled();
   });
 
   it("renders a definitive server not-found result without a client lookup", async () => {
@@ -152,6 +239,7 @@ describe("WatchlistContent initial data", () => {
     expect(getByTestId("watchlist-not-found")).toBeTruthy();
     expect(queryByTestId("watchlist-skeleton")).toBeNull();
     await waitFor(() => expect(mockFetchWatchlistPageData).not.toHaveBeenCalled());
+    expect(mockTryGetWatchlistSnapshotDirect).not.toHaveBeenCalled();
   });
 
   it("keeps the legacy fetch path when no public initial data exists", async () => {
@@ -166,5 +254,6 @@ describe("WatchlistContent initial data", () => {
     );
 
     await waitFor(() => expect(mockFetchWatchlistPageData).toHaveBeenCalledTimes(1));
+    expect(mockTryGetWatchlistSnapshotDirect).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-content.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-content.tsx
@@ -3,7 +3,12 @@
 import { useEffect, useState } from "react";
 import { Trans } from "@lingui/react/macro";
 import { fetchWatchlistPageData, type WatchlistPageData } from "@/lib/actions/watchlist-page-data";
-import { hasAnonJobLanguagesHint, hasLoggedInHint } from "@/lib/client-cookies";
+import {
+  hasLoggedInHint,
+  readAnonJobLanguagesPreference,
+} from "@/lib/client-cookies";
+import { resolveJobLanguages } from "@/lib/job-languages";
+import { tryGetWatchlistSnapshotDirect } from "@/lib/search/search-runner";
 import { WatchlistSkeleton } from "@/components/search/watchlist-skeleton";
 import { WatchlistViewPage } from "./watchlist-view-page";
 import { WatchlistNotFoundState } from "./watchlist-not-found";
@@ -68,13 +73,35 @@ export function WatchlistContent({
       return;
     }
 
-    const needsPersonalizedFetch =
-      hasLoggedInHint() ||
-      hasAnonJobLanguagesHint() ||
-      initialData === undefined;
+    const needsPersonalizedFetch = hasLoggedInHint() || initialData === undefined;
     if (!needsPersonalizedFetch) {
       setData(initialData);
-      return;
+      if (!initialData?.browserPostingFilters) return;
+      const jobLanguages = readAnonJobLanguagesPreference() ?? [];
+      const languages = resolveJobLanguages(jobLanguages, lang);
+      let cancelled = false;
+      void tryGetWatchlistSnapshotDirect({
+        ...initialData.browserPostingFilters,
+        languages,
+      }).then(
+        (fresh) => {
+          if (!fresh || cancelled) return;
+          setData((current) => {
+            if (!current || current === "not-found") return current;
+            return {
+              ...current,
+              postings: fresh.postings,
+              total: fresh.total,
+              yearTotal: fresh.yearTotal,
+              jobLanguages,
+              languages,
+            };
+          });
+        },
+      );
+      return () => {
+        cancelled = true;
+      };
     }
 
     setData(null);

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-shell-cache.test.ts
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-shell-cache.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+describe("public watchlist shell cache (#8258)", () => {
+  it("uses the one-hour shell tier while retaining exact tag invalidation", () => {
+    const routeSource = readFileSync(
+      "app/[lang]/(app)/[userSlug]/[watchlistSlug]/page.tsx",
+      "utf8",
+    );
+    const ttlSource = readFileSync("src/lib/cache-ttl.ts", "utf8");
+
+    expect(routeSource).toContain(
+      "cacheLife({ revalidate: CACHE_TTL_WATCHLIST_SHELL });",
+    );
+    expect(routeSource).toContain(
+      "cacheTag(watchlistCacheTag(userSlug, watchlistSlug));",
+    );
+    expect(ttlSource).toContain(
+      "export const CACHE_TTL_WATCHLIST_SHELL = CACHE_TTL_LONG;",
+    );
+    expect(ttlSource).toContain("export const CACHE_TTL_LONG = 3600;");
+  });
+});

--- a/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
+++ b/apps/web/app/[lang]/(app)/[userSlug]/[watchlistSlug]/watchlist-view-page.tsx
@@ -361,6 +361,13 @@ export function WatchlistViewPage({
     salaryMax != null ||
     experienceMin != null ||
     experienceMax != null;
+  const postingSnapshotKey = JSON.stringify([
+    initialTotal,
+    yearTotal,
+    initialPostings,
+    jobLanguages,
+    languages,
+  ]);
 
   return (
     <div className="space-y-6">
@@ -605,6 +612,7 @@ export function WatchlistViewPage({
           inside the left flex column alongside the postings list,
           not stacked above the detail panel. */}
       <WatchlistJobList
+        key={postingSnapshotKey}
         filters={{
           companyIds: anyCompany ? [] : companies.map((c) => c.id),
           anyCompany,

--- a/apps/web/src/lib/cache-ttl.ts
+++ b/apps/web/src/lib/cache-ttl.ts
@@ -11,8 +11,8 @@
  * | Constant            | Seconds | Use cases                                    |
  * |---------------------|---------|----------------------------------------------|
  * | `CACHE_TTL_SHORT`   |   60    | Fast-moving lists (explore homepage,         |
- * |                     |         | search degraded responses, public watchlist  |
- * |                     |         | detail, new public watchlists search)        |
+ * |                     |         | search degraded responses, new public        |
+ * |                     |         | watchlists search)                           |
  * | `CACHE_TTL_POPULAR` |  120    | Popular watchlists list (curated, slower-    |
  * |                     |         | churn than freshly-created public lists)     |
  * | `CACHE_TTL_MEDIUM`  |  300    | Moderate churn (posting detail, company      |
@@ -25,6 +25,8 @@
  * |                           |         | companies, sitemap, watchlist matching count |
  * | `CACHE_TTL_COMPANY_SHELL` | 86400   | Anonymous company prerender; browser         |
  * |                           |         | Typesense refreshes postings + peers         |
+ * | `CACHE_TTL_WATCHLIST_SHELL` | 3600  | Public watchlist prerender; browser refreshes |
+ * |                             |       | postings + counts after hydration            |
  * | `CACHE_TTL_DAY`           | 86400   | Very static / rare-change (blog pages)       |
  *
  * Notes:
@@ -58,3 +60,6 @@ export const CACHE_TTL_DAY = 86400;
 
 /** 1 day — anonymous company shell; hydrated posting data refreshes from Typesense. */
 export const CACHE_TTL_COMPANY_SHELL = CACHE_TTL_DAY;
+
+/** 1 hour — public watchlist shell; exact mutations still invalidate its cache tag. */
+export const CACHE_TTL_WATCHLIST_SHELL = CACHE_TTL_LONG;

--- a/apps/web/src/lib/search/__tests__/search-runner-direct-refresh.test.ts
+++ b/apps/web/src/lib/search/__tests__/search-runner-direct-refresh.test.ts
@@ -136,8 +136,10 @@ describe("browser-direct shell refreshes", () => {
     expect(mocks.serverGetWatchlistYearCount).not.toHaveBeenCalled();
   });
 
-  it("keeps the watchlist shell on browser failure without a server fallback", async () => {
-    mocks.browserWatchlistPostings.mockRejectedValue(new Error("unavailable"));
+  it("keeps the watchlist shell when browser validation rejects a malformed success", async () => {
+    mocks.browserWatchlistPostings.mockRejectedValue(
+      new Error("Typesense response was malformed"),
+    );
     mocks.browserWatchlistYearCount.mockResolvedValue(19);
     const { tryGetWatchlistSnapshotDirect } = await import("../search-runner");
 

--- a/apps/web/src/lib/search/__tests__/search-runner-direct-refresh.test.ts
+++ b/apps/web/src/lib/search/__tests__/search-runner-direct-refresh.test.ts
@@ -5,9 +5,13 @@ const mocks = vi.hoisted(() => ({
   browserListTopCompanies: vi.fn(),
   browserLoadCompanyPostings: vi.fn(),
   browserLoadSimilarCompanies: vi.fn(),
+  browserWatchlistPostings: vi.fn(),
+  browserWatchlistYearCount: vi.fn(),
   serverListTopCompanies: vi.fn(),
   serverSearchJobs: vi.fn(),
   serverGetCompanyPostings: vi.fn(),
+  serverGetWatchlistPostings: vi.fn(),
+  serverGetWatchlistYearCount: vi.fn(),
 }));
 
 vi.mock("@/lib/actions/search", () => ({
@@ -20,8 +24,13 @@ vi.mock("@/lib/actions/company", () => ({
 }));
 
 vi.mock("@/lib/actions/watchlists", () => ({
-  getWatchlistPostings: vi.fn(),
-  getWatchlistPostingYearCount: vi.fn(),
+  getWatchlistPostings: mocks.serverGetWatchlistPostings,
+  getWatchlistPostingYearCount: mocks.serverGetWatchlistYearCount,
+}));
+
+vi.mock("../typesense-browser-watchlist", () => ({
+  getWatchlistPostingsBrowser: mocks.browserWatchlistPostings,
+  getWatchlistPostingYearCountBrowser: mocks.browserWatchlistYearCount,
 }));
 
 vi.mock("../typesense-browser", () => ({
@@ -101,12 +110,51 @@ describe("browser-direct shell refreshes", () => {
     expect(mocks.serverGetCompanyPostings).not.toHaveBeenCalled();
   });
 
+  it("refreshes a public watchlist snapshot without invoking server fallbacks", async () => {
+    mocks.browserWatchlistPostings.mockResolvedValue({
+      postings: [],
+      total: 7,
+    });
+    mocks.browserWatchlistYearCount.mockResolvedValue(19);
+    const { tryGetWatchlistSnapshotDirect } = await import("../search-runner");
+
+    await expect(
+      tryGetWatchlistSnapshotDirect({
+        companyIds: ["company-1"],
+        locationIds: [4],
+        languages: ["en"],
+      }),
+    ).resolves.toEqual({ postings: [], total: 7, yearTotal: 19 });
+    expect(mocks.browserWatchlistPostings).toHaveBeenCalledWith({
+      companyIds: ["company-1"],
+      locationIds: [4],
+      languages: ["en"],
+      offset: 0,
+      limit: 20,
+    });
+    expect(mocks.serverGetWatchlistPostings).not.toHaveBeenCalled();
+    expect(mocks.serverGetWatchlistYearCount).not.toHaveBeenCalled();
+  });
+
+  it("keeps the watchlist shell on browser failure without a server fallback", async () => {
+    mocks.browserWatchlistPostings.mockRejectedValue(new Error("unavailable"));
+    mocks.browserWatchlistYearCount.mockResolvedValue(19);
+    const { tryGetWatchlistSnapshotDirect } = await import("../search-runner");
+
+    await expect(
+      tryGetWatchlistSnapshotDirect({ companyIds: ["company-1"] }),
+    ).resolves.toBeNull();
+    expect(mocks.serverGetWatchlistPostings).not.toHaveBeenCalled();
+    expect(mocks.serverGetWatchlistYearCount).not.toHaveBeenCalled();
+  });
+
   it("does nothing when browser-direct search is disabled", async () => {
     setTestEnv({ NEXT_PUBLIC_TYPESENSE_DIRECT: "0" });
     vi.resetModules();
     const {
       tryGetCompanyPostingsDirect,
       tryGetSimilarCompaniesDirect,
+      tryGetWatchlistSnapshotDirect,
       tryListTopCompaniesDirect,
     } = await import("../search-runner");
 
@@ -136,9 +184,14 @@ describe("browser-direct shell refreshes", () => {
         limit: 10,
       }),
     ).resolves.toBeNull();
+    await expect(
+      tryGetWatchlistSnapshotDirect({ companyIds: ["company-1"] }),
+    ).resolves.toBeNull();
     expect(mocks.browserListTopCompanies).not.toHaveBeenCalled();
     expect(mocks.browserLoadCompanyPostings).not.toHaveBeenCalled();
     expect(mocks.browserLoadSimilarCompanies).not.toHaveBeenCalled();
+    expect(mocks.browserWatchlistPostings).not.toHaveBeenCalled();
+    expect(mocks.browserWatchlistYearCount).not.toHaveBeenCalled();
   });
 
   it("refreshes similar companies without invoking a Server Action", async () => {

--- a/apps/web/src/lib/search/__tests__/typesense-browser-watchlist.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense-browser-watchlist.test.ts
@@ -14,7 +14,10 @@ vi.mock("../typesense-browser-key", () => ({
   getTypesenseBrowserConfig: mocks.getTypesenseBrowserConfig,
 }));
 
-import { getWatchlistPostingsBrowser } from "../typesense-browser-watchlist";
+import {
+  getWatchlistPostingsBrowser,
+  getWatchlistPostingYearCountBrowser,
+} from "../typesense-browser-watchlist";
 
 function makeUuid(index: number): string {
   return `00000000-0000-0000-0000-${String(index).padStart(12, "0")}`;
@@ -42,5 +45,59 @@ describe("getWatchlistPostingsBrowser (#3477)", () => {
 
     expect(mocks.getTypesenseBrowserConfig).not.toHaveBeenCalled();
     expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("uses the flow filter for a browser-direct year count", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({ found: 31 }),
+    } as Response);
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      getWatchlistPostingYearCountBrowser({
+        companyIds: [makeUuid(1)],
+        languages: ["en"],
+      }),
+    ).resolves.toBe(31);
+
+    const requestUrl = new URL(String(fetchMock.mock.calls[0]?.[0]));
+    const filter = requestUrl.searchParams.get("filter_by") ?? "";
+    expect(filter).toContain("has_content:!=false");
+    expect(filter).toContain("first_seen_at:>");
+    expect(filter).toContain(`company_id:[${makeUuid(1)}]`);
+    expect(filter).not.toContain("is_active:true");
+    expect(requestUrl.searchParams.get("per_page")).toBe("0");
+  });
+
+  it("preserves posting locations in a browser refresh", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        found: 1,
+        hits: [{
+          document: {
+            id: "posting-1",
+            first_seen_at: 1_700_000_000,
+            company_id: "company-1",
+            company_name: "Acme",
+            company_slug: "acme",
+            location_names: ["Zurich", "Switzerland"],
+          },
+        }],
+      }),
+    } as Response);
+    globalThis.fetch = fetchMock;
+
+    const result = await getWatchlistPostingsBrowser({
+      companyIds: [makeUuid(1)],
+      offset: 0,
+      limit: 20,
+    });
+
+    expect(result.postings[0]?.locationNames).toEqual([
+      "Zurich",
+      "Switzerland",
+    ]);
   });
 });

--- a/apps/web/src/lib/search/__tests__/typesense-browser-watchlist.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense-browser-watchlist.test.ts
@@ -23,6 +23,16 @@ function makeUuid(index: number): string {
   return `00000000-0000-0000-0000-${String(index).padStart(12, "0")}`;
 }
 
+function validDocument(index = 1) {
+  return {
+    id: `posting-${index}`,
+    first_seen_at: 1_700_000_000 + index,
+    company_id: `company-${index}`,
+    company_name: "Acme",
+    company_slug: "acme",
+  };
+}
+
 describe("getWatchlistPostingsBrowser (#3477)", () => {
   const originalFetch = globalThis.fetch;
 
@@ -122,6 +132,33 @@ describe("getWatchlistPostingsBrowser (#3477)", () => {
   });
 
   it.each([
+    ["found>0 with an empty page", { found: 1, hits: [] }],
+    ["found=0 with a hit", {
+      found: 0,
+      hits: [{ document: validDocument() }],
+    }],
+    ["more hits than the requested anonymous page", {
+      found: 21,
+      hits: Array.from({ length: 21 }, (_, index) => ({
+        document: validDocument(index + 1),
+      })),
+    }],
+  ])("rejects HTTP-200 search payloads with %s", async (_label, payload) => {
+    globalThis.fetch = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    } as Response);
+
+    await expect(
+      getWatchlistPostingsBrowser({
+        companyIds: [makeUuid(1)],
+        offset: 0,
+        limit: 20,
+      }),
+    ).rejects.toThrow("Typesense response was malformed");
+  });
+
+  it.each([
     ["id", { first_seen_at: 1_700_000_000 }],
     ["first_seen_at", { id: "posting-1" }],
     ["company field type", {
@@ -155,5 +192,50 @@ describe("getWatchlistPostingsBrowser (#3477)", () => {
         companyIds: [makeUuid(1)],
       }),
     ).rejects.toThrow("Typesense response was malformed");
+  });
+
+  it("normalizes mixed or non-array location fields like the server mapper", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          found: 1,
+          hits: [{
+            document: {
+              ...validDocument(),
+              location_names: [42, "", "Zurich", null],
+            },
+          }],
+        }),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          found: 1,
+          hits: [{
+            document: {
+              ...validDocument(2),
+              location_names: "Zurich",
+            },
+          }],
+        }),
+      } as Response);
+    globalThis.fetch = fetchMock;
+
+    await expect(
+      getWatchlistPostingsBrowser({
+        companyIds: [makeUuid(1)],
+        offset: 0,
+        limit: 20,
+      }),
+    ).resolves.toMatchObject({ postings: [{ locationNames: ["Zurich"] }] });
+    await expect(
+      getWatchlistPostingsBrowser({
+        companyIds: [makeUuid(1)],
+        offset: 0,
+        limit: 20,
+      }),
+    ).resolves.toMatchObject({ postings: [{ locationNames: [] }] });
   });
 });

--- a/apps/web/src/lib/search/__tests__/typesense-browser-watchlist.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense-browser-watchlist.test.ts
@@ -100,4 +100,60 @@ describe("getWatchlistPostingsBrowser (#3477)", () => {
       "Switzerland",
     ]);
   });
+
+  it.each([
+    ["a missing found count", { hits: [] }],
+    ["a fractional found count", { found: 1.5, hits: [] }],
+    ["missing hits for a non-empty page", { found: 1 }],
+    ["a non-object hit", { found: 1, hits: [null] }],
+  ])("rejects HTTP-200 search payloads with %s", async (_label, payload) => {
+    globalThis.fetch = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => payload,
+    } as Response);
+
+    await expect(
+      getWatchlistPostingsBrowser({
+        companyIds: [makeUuid(1)],
+        offset: 0,
+        limit: 20,
+      }),
+    ).rejects.toThrow("Typesense response was malformed");
+  });
+
+  it.each([
+    ["id", { first_seen_at: 1_700_000_000 }],
+    ["first_seen_at", { id: "posting-1" }],
+    ["company field type", {
+      id: "posting-1",
+      first_seen_at: 1_700_000_000,
+      company_name: 42,
+    }],
+  ])("rejects HTTP-200 hits with an invalid %s", async (_label, document) => {
+    globalThis.fetch = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({ found: 1, hits: [{ document }] }),
+    } as Response);
+
+    await expect(
+      getWatchlistPostingsBrowser({
+        companyIds: [makeUuid(1)],
+        offset: 0,
+        limit: 20,
+      }),
+    ).rejects.toThrow("Typesense response was malformed");
+  });
+
+  it("rejects an HTTP-200 year count without a valid found field", async () => {
+    globalThis.fetch = vi.fn<typeof fetch>().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
+
+    await expect(
+      getWatchlistPostingYearCountBrowser({
+        companyIds: [makeUuid(1)],
+      }),
+    ).rejects.toThrow("Typesense response was malformed");
+  });
 });

--- a/apps/web/src/lib/search/search-runner.ts
+++ b/apps/web/src/lib/search/search-runner.ts
@@ -145,6 +145,38 @@ type WatchlistPostingsInput = {
   languages?: string[];
 };
 
+type WatchlistRefreshResult = {
+  postings: WatchlistPostingEntry[];
+  total: number;
+  yearTotal: number;
+};
+
+/**
+ * Refresh an anonymous public watchlist shell directly from Typesense.
+ * A failure returns null so callers preserve SSR data without consuming a
+ * mount-time Server Action invocation.
+ */
+export async function tryGetWatchlistSnapshotDirect(
+  params: Omit<WatchlistPostingsInput, "offset" | "limit">,
+): Promise<WatchlistRefreshResult | null> {
+  if (!directEnabled) return null;
+  try {
+    const browser = await import("./typesense-browser-watchlist");
+    const [{ postings, total }, yearTotal] = await Promise.all([
+      browser.getWatchlistPostingsBrowser({ ...params, offset: 0, limit: 20 }),
+      browser.getWatchlistPostingYearCountBrowser(params),
+    ]);
+    return { postings, total, yearTotal };
+  } catch (err) {
+    logExternalError(
+      "error",
+      { service: "typesense", operation: "browser_watchlist_snapshot" },
+      err,
+    );
+    return null;
+  }
+}
+
 export async function runGetWatchlistPostings(
   params: WatchlistPostingsInput,
   isLoggedIn: boolean,

--- a/apps/web/src/lib/search/typesense-browser-watchlist.ts
+++ b/apps/web/src/lib/search/typesense-browser-watchlist.ts
@@ -85,6 +85,20 @@ function assertSearchResponse(
   }
 }
 
+function assertSearchPageCardinality(
+  result: RawSearchResponse,
+  params: { offset: number; limit: number },
+): void {
+  const hits = result.hits ?? [];
+  const expectedHits =
+    params.limit === 0
+      ? 0
+      : Math.min(params.limit, Math.max(0, result.found - params.offset));
+  if (hits.length !== expectedHits) {
+    throw new Error("Typesense response was malformed");
+  }
+}
+
 function assertJobPostingDoc(
   value: Record<string, unknown>,
 ): asserts value is Record<string, unknown> & JobPostingDoc {
@@ -116,7 +130,12 @@ function mapHit(doc: Record<string, unknown>): WatchlistPostingEntry {
   return {
     id: doc.id,
     title: normalizePostingTitle(doc.title),
-    locationNames: (doc.location_names ?? []).filter(Boolean),
+    locationNames: Array.isArray(doc.location_names)
+      ? doc.location_names.filter(
+          (name): name is string =>
+            typeof name === "string" && name.length > 0,
+        )
+      : [],
     sourceUrl: doc.source_url ?? "",
     firstSeenAt: new Date((doc.first_seen_at ?? 0) * 1000).toISOString(),
     isActive: doc.is_active ?? true,
@@ -205,6 +224,7 @@ export async function getWatchlistPostingsBrowser(
   const cfg = await getTypesenseBrowserConfig();
   const result = await searchOne(cfg, "job_posting", searchParams);
   assertSearchResponse(result, { expectHits: params.limit !== 0 });
+  assertSearchPageCardinality(result, params);
 
   const total = result.found;
   if (total === 0 || params.limit === 0) return { postings: [], total };

--- a/apps/web/src/lib/search/typesense-browser-watchlist.ts
+++ b/apps/web/src/lib/search/typesense-browser-watchlist.ts
@@ -3,7 +3,11 @@ import {
   invalidateTypesenseBrowserConfigIfUnauthorized,
   type TypesenseBrowserConfig,
 } from "./typesense-browser-key";
-import { buildFilterString, POSTING_BASE_FILTER } from "./typesense-filters";
+import {
+  buildFilterString,
+  POSTING_BASE_FILTER,
+  POSTING_FLOW_FILTER,
+} from "./typesense-filters";
 import { COMPANY_BATCH_SIZE } from "./constants";
 import { isTypesenseQueryStringSafe } from "./typesense-query-size";
 import type { WatchlistPostingEntry } from "@/lib/actions/watchlists";
@@ -19,6 +23,7 @@ interface JobPostingDoc {
   company_name?: string;
   company_slug?: string;
   company_icon?: string;
+  location_names?: string[];
 }
 
 interface SearchHit<T> {
@@ -56,6 +61,7 @@ function mapHit(doc: JobPostingDoc): WatchlistPostingEntry {
   return {
     id: doc.id,
     title: normalizePostingTitle(doc.title),
+    locationNames: (doc.location_names ?? []).filter(Boolean),
     sourceUrl: doc.source_url ?? "",
     firstSeenAt: new Date((doc.first_seen_at ?? 0) * 1000).toISOString(),
     isActive: doc.is_active ?? true,
@@ -93,9 +99,9 @@ export interface WatchlistPostingsParams {
  * Browser-side watchlist postings fetch. Mirrors the server-side single-query
  * path when the request fits Typesense's GET query-string limit.
  *
- * For larger requests, throws so the runner falls back to the server action
- * (which has a batched/merge implementation we don't need to duplicate
- * browser-side).
+ * For larger requests, throws. Interactive pagination may use its existing
+ * server fallback; anonymous shell refreshes instead keep their rendered SSR
+ * snapshot so a degraded mount never consumes Fluid CPU.
  */
 export async function getWatchlistPostingsBrowser(
   params: WatchlistPostingsParams,
@@ -150,4 +156,56 @@ export async function getWatchlistPostingsBrowser(
     postings: (result.hits ?? []).map((h) => mapHit(h.document)),
     total,
   };
+}
+
+/** Browser-side counterpart to the server's flow count (active state excluded). */
+export async function getWatchlistPostingYearCountBrowser(
+  params: Omit<WatchlistPostingsParams, "offset" | "limit">,
+): Promise<number> {
+  if (!params.anyCompany && params.companyIds.length === 0) return 0;
+  if (params.companyIds.length > COMPANY_BATCH_SIZE) {
+    throw new Error("watchlist exceeds COMPANY_BATCH_SIZE");
+  }
+
+  const filterStr = buildFilterString({
+    locationIds: params.locationIds,
+    occupationIds: params.occupationIds,
+    seniorityIds: params.seniorityIds,
+    technologyIds: params.technologyIds,
+    workMode: params.workMode?.length ? params.workMode : undefined,
+    employmentTypes: params.employmentType?.length
+      ? params.employmentType
+      : undefined,
+    salaryMinEur: params.salaryMin,
+    salaryMaxEur: params.salaryMax,
+    experienceMin: params.experienceMin,
+    experienceMax: params.experienceMax,
+    languages: params.languages,
+  });
+  const q = params.keywords?.length ? params.keywords.join(" ") : "*";
+  const oneYearAgo = Math.floor(
+    (Date.now() - 365 * 24 * 60 * 60 * 1000) / 1000,
+  );
+  const filterParts = [POSTING_FLOW_FILTER, `first_seen_at:>${oneYearAgo}`];
+  if (params.companyIds.length > 0) {
+    filterParts.push(`company_id:[${params.companyIds.join(",")}]`);
+  }
+  if (filterStr) filterParts.push(filterStr);
+  const searchParams = {
+    q,
+    query_by: "title",
+    filter_by: filterParts.join(" && "),
+    per_page: 0,
+  };
+  if (!isTypesenseQueryStringSafe(searchParams)) {
+    throw new Error("watchlist Typesense year-count query exceeds GET limit");
+  }
+
+  const cfg = await getTypesenseBrowserConfig();
+  const result = await searchOne<JobPostingDoc>(
+    cfg,
+    "job_posting",
+    searchParams,
+  );
+  return result.found ?? 0;
 }

--- a/apps/web/src/lib/search/typesense-browser-watchlist.ts
+++ b/apps/web/src/lib/search/typesense-browser-watchlist.ts
@@ -15,14 +15,14 @@ import { normalizePostingTitle } from "@/lib/posting-title";
 
 interface JobPostingDoc {
   id: string;
-  title?: string;
-  source_url?: string;
-  first_seen_at?: number;
-  is_active?: boolean;
-  company_id?: string;
-  company_name?: string;
-  company_slug?: string;
-  company_icon?: string;
+  title?: string | null;
+  source_url?: string | null;
+  first_seen_at: number;
+  is_active?: boolean | null;
+  company_id?: string | null;
+  company_name?: string | null;
+  company_slug?: string | null;
+  company_icon?: string | null;
   location_names?: string[];
 }
 
@@ -30,16 +30,16 @@ interface SearchHit<T> {
   document: T;
 }
 
-interface RawSearchResponse<T> {
-  found?: number;
-  hits?: SearchHit<T>[];
+interface RawSearchResponse {
+  found: number;
+  hits?: SearchHit<Record<string, unknown>>[];
 }
 
-async function searchOne<T>(
+async function searchOne(
   cfg: TypesenseBrowserConfig,
   collection: string,
   params: Record<string, unknown>,
-): Promise<RawSearchResponse<T>> {
+): Promise<unknown> {
   const url = `${cfg.protocol}://${cfg.host}:${cfg.port}/collections/${collection}/documents/search`;
   const qs = new URLSearchParams();
   for (const [k, v] of Object.entries(params)) {
@@ -57,7 +57,62 @@ async function searchOne<T>(
   return res.json();
 }
 
-function mapHit(doc: JobPostingDoc): WatchlistPostingEntry {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function assertSearchResponse(
+  value: unknown,
+  options: { expectHits?: boolean } = {},
+): asserts value is RawSearchResponse {
+  if (!isRecord(value)) throw new Error("Typesense response was malformed");
+  const found = value.found;
+  if (typeof found !== "number" || !Number.isInteger(found) || found < 0) {
+    throw new Error("Typesense response was malformed");
+  }
+  const hits = value.hits;
+  if (hits !== undefined && !Array.isArray(hits)) {
+    throw new Error("Typesense response was malformed");
+  }
+  if (options.expectHits && found > 0 && !Array.isArray(hits)) {
+    throw new Error("Typesense response was malformed");
+  }
+  if (
+    Array.isArray(hits) &&
+    hits.some((hit) => !isRecord(hit) || !isRecord(hit.document))
+  ) {
+    throw new Error("Typesense response was malformed");
+  }
+}
+
+function assertJobPostingDoc(
+  value: Record<string, unknown>,
+): asserts value is Record<string, unknown> & JobPostingDoc {
+  const optionalString = (candidate: unknown) =>
+    candidate == null || typeof candidate === "string";
+  if (
+    typeof value.id !== "string" ||
+    !optionalString(value.title) ||
+    !optionalString(value.source_url) ||
+    typeof value.first_seen_at !== "number" ||
+    !Number.isFinite(value.first_seen_at) ||
+    (value.is_active != null && typeof value.is_active !== "boolean") ||
+    !optionalString(value.company_id) ||
+    !optionalString(value.company_name) ||
+    !optionalString(value.company_slug) ||
+    !optionalString(value.company_icon)
+  ) {
+    throw new Error("Typesense response was malformed");
+  }
+
+  const firstSeenAt = new Date(value.first_seen_at * 1000);
+  if (!Number.isFinite(firstSeenAt.getTime())) {
+    throw new Error("Typesense response was malformed");
+  }
+}
+
+function mapHit(doc: Record<string, unknown>): WatchlistPostingEntry {
+  assertJobPostingDoc(doc);
   return {
     id: doc.id,
     title: normalizePostingTitle(doc.title),
@@ -148,12 +203,13 @@ export async function getWatchlistPostingsBrowser(
   }
 
   const cfg = await getTypesenseBrowserConfig();
-  const result = await searchOne<JobPostingDoc>(cfg, "job_posting", searchParams);
+  const result = await searchOne(cfg, "job_posting", searchParams);
+  assertSearchResponse(result, { expectHits: params.limit !== 0 });
 
-  const total = result.found ?? 0;
+  const total = result.found;
   if (total === 0 || params.limit === 0) return { postings: [], total };
   return {
-    postings: (result.hits ?? []).map((h) => mapHit(h.document)),
+    postings: (result.hits ?? []).map((hit) => mapHit(hit.document)),
     total,
   };
 }
@@ -202,10 +258,7 @@ export async function getWatchlistPostingYearCountBrowser(
   }
 
   const cfg = await getTypesenseBrowserConfig();
-  const result = await searchOne<JobPostingDoc>(
-    cfg,
-    "job_posting",
-    searchParams,
-  );
-  return result.found ?? 0;
+  const result = await searchOne(cfg, "job_posting", searchParams);
+  assertSearchResponse(result);
+  return result.found;
 }

--- a/apps/web/src/lib/services/__tests__/watchlist-page-data.test.ts
+++ b/apps/web/src/lib/services/__tests__/watchlist-page-data.test.ts
@@ -103,7 +103,12 @@ describe("watchlist page Typesense degradation (#7487)", () => {
     const result = await buildWatchlistPageData(params);
 
     expect(result.detail).toBe(detail);
-    expect(result).toMatchObject({ postings: [], total: 0, yearTotal: 0 });
+    expect(result).toMatchObject({
+      postings: [],
+      total: 0,
+      yearTotal: 0,
+      browserPostingFilters: null,
+    });
     expect(mocks.logExternalError).toHaveBeenCalledWith(
       "error",
       { service: "typesense", operation: "watchlist_page_data" },
@@ -129,5 +134,39 @@ describe("watchlist page Typesense degradation (#7487)", () => {
     });
     expect(mocks.resolveLocationSlugs).toHaveBeenCalledWith(["zurich"], "en");
     expect(mocks.getPublicWatchlistPostings).not.toHaveBeenCalled();
+  });
+});
+
+describe("watchlist browser refresh input (#8258)", () => {
+  it("serializes the exact resolved server query without its abort signal", async () => {
+    mocks.resolveLocationSlugs.mockResolvedValueOnce(new Map([
+      ["zurich", {
+        id: 4,
+        slug: "zurich",
+        name: "Zurich",
+        type: "city",
+        parentName: "Switzerland",
+      }],
+    ]));
+
+    const result = await buildWatchlistPageData(params);
+
+    expect(result.browserPostingFilters).toEqual({
+      companyIds: ["company-1"],
+      anyCompany: undefined,
+      keywords: undefined,
+      locationIds: [4],
+      occupationIds: [],
+      seniorityIds: [],
+      technologyIds: [],
+      workMode: undefined,
+      employmentType: undefined,
+      salaryMin: undefined,
+      salaryMax: undefined,
+      experienceMin: undefined,
+      experienceMax: undefined,
+      languages: ["en"],
+    });
+    expect(result.browserPostingFilters).not.toHaveProperty("abortSignal");
   });
 });

--- a/apps/web/src/lib/services/watchlist-page-data.ts
+++ b/apps/web/src/lib/services/watchlist-page-data.ts
@@ -18,6 +18,7 @@ import { resolveJobLanguages } from "@/lib/job-languages";
 import { convertToEur } from "@/lib/salary";
 import { isTypesenseUnavailableError } from "@/lib/search/typesense-retry";
 import { logExternalError } from "@/lib/safe-external-error";
+import type { WatchlistPostingsParams } from "@/lib/search/typesense-browser-watchlist";
 
 /**
  * Existing watchlist routes must return a usable degraded response before a
@@ -47,6 +48,8 @@ export interface WatchlistPageData {
   resolvedTechnologies: { id: number; slug: string; name: string }[];
   jobLanguages: string[];
   languages: string[];
+  /** Resolved query base used for a no-fallback anonymous browser refresh. */
+  browserPostingFilters?: Omit<WatchlistPostingsParams, "offset" | "limit"> | null;
 }
 
 export type BuildWatchlistPageDataParams = {
@@ -76,6 +79,7 @@ function degradedWatchlistPageData(
     resolvedTechnologies: [],
     jobLanguages: params.jobLanguages,
     languages: resolveJobLanguages(params.jobLanguages, params.locale),
+    browserPostingFilters: null,
   };
 }
 
@@ -142,7 +146,7 @@ async function buildWatchlistPageDataUnbounded(
   const salaryMinEur = convertToEur(filters.salaryMin, salaryCurrency, rates);
   const salaryMaxEur = convertToEur(filters.salaryMax, salaryCurrency, rates);
 
-  const sharedCountsParams = {
+  const browserPostingFilters = {
     companyIds: filters.anyCompany ? [] : detail.companies.map((company) => company.id),
     anyCompany: filters.anyCompany,
     keywords: filters.keywords,
@@ -157,6 +161,9 @@ async function buildWatchlistPageDataUnbounded(
     experienceMin: filters.experienceMin,
     experienceMax: filters.experienceMax,
     languages,
+  } satisfies Omit<WatchlistPostingsParams, "offset" | "limit">;
+  const sharedCountsParams = {
+    ...browserPostingFilters,
     abortSignal,
   };
   const [{ postings, total }, yearTotal] = await Promise.all([
@@ -182,6 +189,7 @@ async function buildWatchlistPageDataUnbounded(
     resolvedTechnologies,
     jobLanguages,
     languages,
+    browserPostingFilters,
   };
 }
 


### PR DESCRIPTION
Closes #8258

## Summary

- serialize the exact resolved watchlist posting filter base into the public SSR snapshot
- refresh anonymous postings, active count, and one-year flow count directly from Typesense with no Server Action fallback
- apply bounded anonymous language preferences in the same browser-direct path; keep authenticated/owner resolution authoritative on the server
- preserve SSR postings and JSON-LD, and keep the rendered snapshot on direct-search failure
- raise the public watchlist shell cache from 60 seconds to one hour while retaining exact `watchlistCacheTag` invalidation
- preserve refreshed posting location labels and remount only the job-list state when the snapshot identity changes

## Verification

- `pnpm exec tsc --noEmit`
- 24 focused tests across watchlist content, direct runner, browser Typesense, server snapshot, and cache policy
- full web Vitest: 267 files / 2,028 tests passing (Typesense E2E remains on CI)
- targeted ESLint
- `pnpm build`
- `pnpm --filter @jobseek/web check:bundle`

## Measurement

Baseline: public watchlist detail routes were approximately 72 invocations / 13.5s Fluid Active CPU over the rolling 12-hour production view. After merge, verify anonymous browser traffic has no mount-time `Next-Action`, then compare a clean post-deploy window.