### PR TITLE
Refresh filtered Explore views in browser

### DIFF
--- a/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
+++ b/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
@@ -1,29 +1,33 @@
-import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, render, waitFor } from "@testing-library/react";
 import type { ExploreData } from "@/lib/actions/explore-page-data";
 
-// `@/lib/actions/explore-page-data` is a server action that transitively imports
-// `server-only`, which throws when loaded in a non-Next runtime. Neutralise
-// the gate, then swap the action itself for a spy.
 vi.mock("server-only", () => ({}));
-const mockFetchExploreData = vi.fn();
-const mockSearchPageProps = vi.fn();
-vi.mock("@/lib/actions/explore-page-data", async () => {
-  const actual =
-    await vi.importActual<typeof import("@/lib/actions/explore-page-data")>(
-      "@/lib/actions/explore-page-data",
-    );
-  return {
-    ...actual,
-    fetchExplorePageData: (...args: unknown[]) => mockFetchExploreData(...args),
-  };
-});
 
-// SearchPage has a heavy dependency tree (Lingui i18n, Typesense provider,
-// etc.). Stub it out — this suite is testing the conditional-fetch logic
-// in ExploreContent, not SearchPage's behaviour. Renders a marker with the
-// initialTotalCompanies prop so the data-routing regression test in #3350
-// can assert which dataset the page mounted ``SearchPage`` with.
+const mocks = vi.hoisted(() => ({
+  loadBrowserData: vi.fn(),
+  searchPageProps: vi.fn(),
+  rates: [{ currency: "CHF", toEur: 1.04 }],
+  session: {
+    isLoggedIn: false,
+    isPending: false,
+    preferences: null as null | {
+      displayCurrency?: string;
+      jobLanguages?: string[];
+    },
+  },
+}));
+
+vi.mock("@/lib/search/explore-browser-data", () => ({
+  loadExploreBrowserData: (...args: unknown[]) =>
+    mocks.loadBrowserData(...args),
+}));
+vi.mock("@/components/providers/SessionProvider", () => ({
+  useSession: () => mocks.session,
+}));
+vi.mock("@/components/providers/SalaryDisplayProvider", () => ({
+  useSalaryRates: () => mocks.rates,
+}));
 vi.mock("../search-page", () => ({
   SearchPage: (props: {
     initialCompanies: ExploreData["result"]["companies"];
@@ -32,17 +36,22 @@ vi.mock("../search-page", () => ({
     initialKeywords: string[];
     initialEmploymentTypes: string[];
     initialWorkMode: string[];
-    initialRepositoryFallbackCompanies?: ExploreData["repositoryFallbackCompanies"];
+    initialRepositoryFallbackCompanies?:
+      ExploreData["repositoryFallbackCompanies"];
     initialLanguageOverride?: string[] | null;
-    initialUnresolvedExplicitSlugs?: ExploreData["parsed"]["unresolvedExplicitSlugs"];
+    initialUnresolvedExplicitSlugs?:
+      ExploreData["parsed"]["unresolvedExplicitSlugs"];
+    initialDirectRefreshAttempted?: boolean;
   }) => {
-    mockSearchPageProps(props);
-    return <div data-testid="search-page" data-total={props.initialTotalCompanies} />;
+    mocks.searchPageProps(props);
+    return (
+      <div
+        data-testid="search-page"
+        data-total={props.initialTotalCompanies}
+      />
+    );
   },
 }));
-
-// Skeleton stub — a distinct marker so the #3350 regression test can
-// assert which branch (skeleton vs SearchPage) is currently rendered.
 vi.mock("@/components/search/explore-skeleton", () => ({
   ExploreSkeleton: () => <div data-testid="explore-skeleton" />,
 }));
@@ -50,13 +59,18 @@ vi.mock("@/components/search/explore-skeleton", () => ({
 import { ExploreContent } from "../explore-content";
 
 let cookieSpy: ReturnType<typeof vi.spyOn> | undefined;
+
 function setDocumentCookie(value: string) {
   cookieSpy?.mockRestore();
   cookieSpy = vi.spyOn(document, "cookie", "get").mockReturnValue(value);
 }
 
 function setBrowserSearch(search = "") {
-  window.history.replaceState(null, "", `/en/explore${search ? `?${search}` : ""}`);
+  window.history.replaceState(
+    null,
+    "",
+    `/en/explore${search ? `?${search}` : ""}`,
+  );
 }
 
 function makeInitialData(overrides: Partial<ExploreData> = {}): ExploreData {
@@ -65,7 +79,7 @@ function makeInitialData(overrides: Partial<ExploreData> = {}): ExploreData {
       companies: [],
       totalCompanies: 0,
       truncated: false,
-    } as unknown as ExploreData["result"],
+    },
     parsed: {
       keywords: [],
       locations: [],
@@ -77,7 +91,8 @@ function makeInitialData(overrides: Partial<ExploreData> = {}): ExploreData {
     },
     displayCurrency: "EUR",
     jobLanguages: [],
-    languages: [],
+    languages: ["en"],
+    languageOverride: null,
     userLat: undefined,
     userLng: undefined,
     salaryCurrencyParam: "EUR",
@@ -89,16 +104,25 @@ function makeInitialData(overrides: Partial<ExploreData> = {}): ExploreData {
   };
 }
 
-async function flushQueuedEffects(): Promise<void> {
+async function flushEffects(): Promise<void> {
   await act(async () => {
     await Promise.resolve();
   });
 }
 
 beforeEach(() => {
-  mockFetchExploreData.mockReset();
-  mockSearchPageProps.mockReset();
-  mockFetchExploreData.mockResolvedValue(makeInitialData());
+  mocks.loadBrowserData.mockReset();
+  mocks.searchPageProps.mockReset();
+  mocks.session.isLoggedIn = false;
+  mocks.session.isPending = false;
+  mocks.session.preferences = null;
+  mocks.loadBrowserData.mockImplementation(
+    async ({ initialData }: { initialData: ExploreData }) => ({
+      data: initialData,
+      unavailable: false,
+      directAttempted: true,
+    }),
+  );
   setBrowserSearch();
   setDocumentCookie("");
 });
@@ -106,31 +130,223 @@ beforeEach(() => {
 afterEach(() => {
   cookieSpy?.mockRestore();
   cookieSpy = undefined;
+  vi.restoreAllMocks();
 });
 
-describe("ExploreContent — server-render initial-data path (#2640)", () => {
-  it("does NOT call fetchExplorePageData for an anonymous, no-filter visit with prerendered initialData", async () => {
+describe("ExploreContent browser initialization", () => {
+  it("uses the prerendered shell without a mount read for an anonymous default visit", async () => {
+    const initialData = makeInitialData({
+      result: { companies: [], totalCompanies: 3928, truncated: false },
+    });
+    const { queryByTestId } = render(
+      <ExploreContent locale="en" initialData={initialData} />,
+    );
+
+    await flushEffects();
+    expect(mocks.loadBrowserData).not.toHaveBeenCalled();
+    expect(queryByTestId("search-page")?.getAttribute("data-total")).toBe(
+      "3928",
+    );
+    expect(queryByTestId("explore-skeleton")).toBeNull();
+  });
+
+  it("does not load for attribution-only query parameters", async () => {
+    setBrowserSearch("utm_source=google");
+    render(
+      <ExploreContent locale="en" initialData={makeInitialData()} />,
+    );
+
+    await flushEffects();
+    expect(mocks.loadBrowserData).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "q",
+    "loc",
+    "occ",
+    "sen",
+    "tech",
+    "wm",
+    "etype",
+    "sal",
+    "salcur",
+    "exp",
+    "lang",
+  ])("initializes the %s URL through the browser loader", async (param) => {
+    setBrowserSearch(`${param}=x`);
     const initialData = makeInitialData();
-    render(<ExploreContent locale="en" initialData={initialData} />);
+    const { unmount } = render(
+      <ExploreContent locale="en" initialData={initialData} />,
+    );
 
-    await flushQueuedEffects();
-    expect(mockFetchExploreData).not.toHaveBeenCalled();
+    await waitFor(() => expect(mocks.loadBrowserData).toHaveBeenCalledOnce());
+    const input = mocks.loadBrowserData.mock.calls[0]?.[0] as {
+      searchParams: URLSearchParams;
+      locale: string;
+    };
+    expect(input.locale).toBe("en");
+    expect(input.searchParams.get(param)).toBe("x");
+    unmount();
   });
 
-  it("does NOT reset scroll on the prerendered initial-data mount", async () => {
-    const scrollTo = vi.spyOn(window, "scrollTo").mockImplementation(() => {});
+  it("unmounts broad SearchPage state until filtered direct data lands", async () => {
+    setBrowserSearch("loc=zurich");
+    const broad = makeInitialData({
+      result: { companies: [], totalCompanies: 3928, truncated: false },
+    });
+    const filtered = makeInitialData({
+      result: { companies: [], totalCompanies: 1133, truncated: false },
+    });
+    let resolve!: (value: unknown) => void;
+    mocks.loadBrowserData.mockReturnValueOnce(
+      new Promise((done) => {
+        resolve = done;
+      }),
+    );
 
-    try {
-      render(<ExploreContent locale="en" initialData={makeInitialData()} />);
+    const { queryByTestId } = render(
+      <ExploreContent locale="en" initialData={broad} />,
+    );
+    await waitFor(() =>
+      expect(queryByTestId("explore-skeleton")).not.toBeNull(),
+    );
+    expect(queryByTestId("search-page")).toBeNull();
 
-      await flushQueuedEffects();
-      expect(scrollTo).not.toHaveBeenCalled();
-    } finally {
-      scrollTo.mockRestore();
-    }
+    resolve({
+      data: filtered,
+      unavailable: false,
+      directAttempted: true,
+    });
+    await waitFor(() =>
+      expect(queryByTestId("search-page")?.getAttribute("data-total")).toBe(
+        "1133",
+      ),
+    );
+    expect(mocks.searchPageProps).toHaveBeenLastCalledWith(
+      expect.objectContaining({ initialDirectRefreshAttempted: true }),
+    );
   });
 
-  it("forwards repository fallback identities and an explicit language override together", async () => {
+  it("passes authenticated bootstrap preferences to the browser loader", async () => {
+    setDocumentCookie("logged_in=1");
+    mocks.session.isLoggedIn = true;
+    mocks.session.preferences = {
+      displayCurrency: "CHF",
+      jobLanguages: ["de", "en"],
+    };
+
+    render(
+      <ExploreContent locale="de" initialData={makeInitialData()} />,
+    );
+
+    await waitFor(() => expect(mocks.loadBrowserData).toHaveBeenCalledOnce());
+    expect(mocks.loadBrowserData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        displayCurrency: "CHF",
+        jobLanguages: ["de", "en"],
+        rates: mocks.rates,
+        isLoggedIn: true,
+      }),
+    );
+  });
+
+  it("waits for a hinted authenticated bootstrap before loading", async () => {
+    setDocumentCookie("logged_in=1");
+    mocks.session.isPending = true;
+    const initialData = makeInitialData();
+    const view = render(
+      <ExploreContent locale="en" initialData={initialData} />,
+    );
+
+    await waitFor(() =>
+      expect(view.queryByTestId("explore-skeleton")).not.toBeNull(),
+    );
+    expect(mocks.loadBrowserData).not.toHaveBeenCalled();
+
+    mocks.session.isPending = false;
+    mocks.session.isLoggedIn = true;
+    mocks.session.preferences = { displayCurrency: "CHF" };
+    view.rerender(<ExploreContent locale="en" initialData={initialData} />);
+    await waitFor(() => expect(mocks.loadBrowserData).toHaveBeenCalledOnce());
+  });
+
+  it("parses anonymous language preferences without a Server Action", async () => {
+    setDocumentCookie(
+      `JSEEK_JOB_LANGUAGES=${encodeURIComponent(JSON.stringify(["de", "en"]))}`,
+    );
+    render(
+      <ExploreContent locale="de" initialData={makeInitialData()} />,
+    );
+
+    await waitFor(() => expect(mocks.loadBrowserData).toHaveBeenCalledOnce());
+    expect(mocks.loadBrowserData).toHaveBeenCalledWith(
+      expect.objectContaining({ jobLanguages: ["de", "en"] }),
+    );
+  });
+
+  it("does not duplicate a filtered load when anonymous bootstrap settles", async () => {
+    setBrowserSearch("wm=remote");
+    mocks.session.isPending = true;
+    const initialData = makeInitialData();
+    const view = render(
+      <ExploreContent locale="en" initialData={initialData} />,
+    );
+    await waitFor(() => expect(mocks.loadBrowserData).toHaveBeenCalledOnce());
+
+    mocks.session.isPending = false;
+    view.rerender(<ExploreContent locale="en" initialData={initialData} />);
+    await flushEffects();
+    expect(mocks.loadBrowserData).toHaveBeenCalledOnce();
+  });
+
+  it("keeps a rejected unexpected browser load on the skeleton", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    setBrowserSearch("q=python");
+    mocks.loadBrowserData.mockRejectedValueOnce(new Error("unexpected"));
+    const { queryByTestId } = render(
+      <ExploreContent locale="en" initialData={makeInitialData()} />,
+    );
+
+    await waitFor(() => expect(console.error).toHaveBeenCalled());
+    expect(queryByTestId("explore-skeleton")).not.toBeNull();
+    expect(queryByTestId("search-page")).toBeNull();
+  });
+
+  it("forwards fail-closed data and direct-attempt state", async () => {
+    setBrowserSearch("q=python&loc=missing&wm=remote");
+    const unavailable = makeInitialData({
+      result: { companies: [], totalCompanies: 0, degraded: true },
+      parsed: {
+        ...makeInitialData().parsed,
+        keywords: ["python"],
+        workMode: ["remote"],
+        unresolvedExplicitSlugs: { loc: ["missing"] },
+      },
+    });
+    mocks.loadBrowserData.mockResolvedValueOnce({
+      data: unavailable,
+      unavailable: true,
+      directAttempted: true,
+    });
+
+    render(
+      <ExploreContent locale="en" initialData={makeInitialData()} />,
+    );
+    await waitFor(() =>
+      expect(mocks.searchPageProps).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          initialCompanies: [],
+          initialDegraded: true,
+          initialKeywords: ["python"],
+          initialWorkMode: ["remote"],
+          initialUnresolvedExplicitSlugs: { loc: ["missing"] },
+          initialDirectRefreshAttempted: true,
+        }),
+      ),
+    );
+  });
+
+  it("preserves fallback identities and language override on the default shell", async () => {
     const repositoryFallbackCompanies = [{ name: "Acme", slug: "acme" }];
     render(
       <ExploreContent
@@ -141,369 +357,12 @@ describe("ExploreContent — server-render initial-data path (#2640)", () => {
         })}
       />,
     );
-
-    await flushQueuedEffects();
-    expect(mockSearchPageProps).toHaveBeenCalledWith(
+    await flushEffects();
+    expect(mocks.searchPageProps).toHaveBeenLastCalledWith(
       expect.objectContaining({
         initialRepositoryFallbackCompanies: repositoryFallbackCompanies,
         initialLanguageOverride: [],
       }),
     );
-  });
-
-  it("forwards unresolved explicit slugs into the interactive search state", async () => {
-    const unresolvedExplicitSlugs = { loc: ["india"] };
-    render(
-      <ExploreContent
-        locale="en"
-        initialData={makeInitialData({
-          parsed: {
-            ...makeInitialData().parsed,
-            unresolvedExplicitSlugs,
-          },
-        })}
-      />,
-    );
-
-    await flushQueuedEffects();
-    expect(mockSearchPageProps).toHaveBeenCalledWith(
-      expect.objectContaining({ initialUnresolvedExplicitSlugs: unresolvedExplicitSlugs }),
-    );
-  });
-
-  it("calls fetchExplorePageData when the `logged_in` hint cookie is present even without filters", async () => {
-    setDocumentCookie("logged_in=1");
-
-    const initialData = makeInitialData();
-    render(<ExploreContent locale="en" initialData={initialData} />);
-
-    await waitFor(() => {
-      expect(mockFetchExploreData).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it("calls fetchExplorePageData when a filter searchParam is present", async () => {
-    setBrowserSearch("q=python");
-
-    const initialData = makeInitialData();
-    render(<ExploreContent locale="en" initialData={initialData} />);
-
-    await waitFor(() => {
-      expect(mockFetchExploreData).toHaveBeenCalledTimes(1);
-    });
-
-    const callArgs = mockFetchExploreData.mock.calls[0]?.[0] as {
-      searchParams: Record<string, string | undefined>;
-      locale: string;
-    };
-    expect(callArgs.locale).toBe("en");
-    expect(callArgs.searchParams.q).toBe("python");
-  });
-
-  it("calls fetchExplorePageData when initialData is omitted (legacy path)", async () => {
-    render(<ExploreContent locale="en" />);
-
-    await waitFor(() => {
-      expect(mockFetchExploreData).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  it("does NOT call fetchExplorePageData when a non-filter searchParam is present (e.g. utm tracking)", async () => {
-    setBrowserSearch("utm_source=google");
-
-    const initialData = makeInitialData();
-    render(<ExploreContent locale="en" initialData={initialData} />);
-
-    await flushQueuedEffects();
-    expect(mockFetchExploreData).not.toHaveBeenCalled();
-  });
-
-  it("recognises every documented filter searchParam as a refetch trigger", async () => {
-    // Mirrors `FILTER_PARAMS` in `../explore-content.tsx`. Adding a new
-    // filter param to that array MUST also add it here so the regression
-    // surface stays explicit (e.g. #3275 — `wm` was added to the live
-    // code in #2987 but the test list lagged behind, leaving the
-    // refetch-trigger contract unguarded).
-    const filterParams = ["q", "loc", "occ", "sen", "tech", "wm", "etype", "sal", "salcur", "exp", "lang"];
-    for (const param of filterParams) {
-      mockFetchExploreData.mockClear();
-      setBrowserSearch(`${param}=x`);
-
-      const initialData = makeInitialData();
-      const { unmount } = render(
-        <ExploreContent locale="en" initialData={initialData} />,
-      );
-
-      await waitFor(() => {
-        expect(mockFetchExploreData).toHaveBeenCalledTimes(1);
-      });
-      unmount();
-    }
-  });
-
-  // Regression coverage for #3275. The `wm` (workMode) searchParam was
-  // added to `FILTER_PARAMS` in #2987 alongside the work-mode filter
-  // feature, but no test pinned the behaviour. A future revert/refactor
-  // that drops `wm` would silently re-introduce the stale-data bug
-  // (anonymous deep-link to `/explore?wm=remote` paints the unfiltered
-  // homepage `initialData` and never refetches). These tests lock that
-  // contract in place.
-  describe("wm (workMode) filter-param refetch trigger (#3275)", () => {
-    it("triggers refetch when ?wm=remote is in the URL", async () => {
-      setBrowserSearch("wm=remote");
-
-      render(
-        <ExploreContent locale="en" initialData={makeInitialData()} />,
-      );
-
-      await waitFor(() => {
-        expect(mockFetchExploreData).toHaveBeenCalledTimes(1);
-      });
-      const callArgs = mockFetchExploreData.mock.calls[0]?.[0] as {
-        searchParams: Record<string, string | undefined>;
-      };
-      expect(callArgs.searchParams.wm).toBe("remote");
-    });
-
-    it("triggers refetch when ?wm=hybrid is in the URL", async () => {
-      setBrowserSearch("wm=hybrid");
-
-      render(
-        <ExploreContent locale="en" initialData={makeInitialData()} />,
-      );
-
-      await waitFor(() => {
-        expect(mockFetchExploreData).toHaveBeenCalledTimes(1);
-      });
-      const callArgs = mockFetchExploreData.mock.calls[0]?.[0] as {
-        searchParams: Record<string, string | undefined>;
-      };
-      expect(callArgs.searchParams.wm).toBe("hybrid");
-    });
-
-    it("does NOT trigger refetch when the wm param is absent", async () => {
-      // Sanity: a no-wm anonymous visit must still hit the prerendered
-      // initialData path so #2640's zero-invocation guarantee holds.
-      setBrowserSearch();
-
-      render(
-        <ExploreContent locale="en" initialData={makeInitialData()} />,
-      );
-
-      await flushQueuedEffects();
-      expect(mockFetchExploreData).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("etype (employment type) filter-param refetch trigger (#3218)", () => {
-    it("triggers refetch when ?etype=internship is in the URL", async () => {
-      setBrowserSearch("etype=internship");
-
-      render(
-        <ExploreContent locale="en" initialData={makeInitialData()} />,
-      );
-
-      await waitFor(() => {
-        expect(mockFetchExploreData).toHaveBeenCalledTimes(1);
-      });
-      const callArgs = mockFetchExploreData.mock.calls[0]?.[0] as {
-        searchParams: Record<string, string | undefined>;
-      };
-      expect(callArgs.searchParams.etype).toBe("internship");
-    });
-  });
-
-  describe("filter-param visits unmount SearchPage until refetch lands (#3350)", () => {
-    // Regression coverage for #3350. The #2746 prerender path embeds the
-    // ANONYMOUS, NO-FILTER ``ExploreData`` as ``initialData``. If
-    // ``ExploreContent`` mounted ``SearchPage`` with that stale dataset
-    // and only later swapped ``data`` once the personalised fetch
-    // returned, ``SearchPage``'s ``useState`` initialisers (companies,
-    // locations, totals…) would already be locked in on the unfiltered
-    // defaults — so the filtered result list would never appear. The fix
-    // is to render the skeleton between mount and fetch completion when
-    // a refetch is needed, so ``SearchPage`` mounts ONCE with the
-    // filtered data.
-    it("renders ExploreSkeleton — NOT SearchPage with stale initialData — between mount and the filtered fetch resolution", async () => {
-      setBrowserSearch("loc=eu");
-      const filteredData = makeInitialData({
-        result: { companies: [], totalCompanies: 1133, truncated: false } as unknown as ExploreData["result"],
-      });
-      const unfilteredInitial = makeInitialData({
-        result: { companies: [], totalCompanies: 3928, truncated: false } as unknown as ExploreData["result"],
-      });
-
-      // Use a never-resolving promise initially so we can observe the
-      // skeleton-while-pending state, then resolve to the filtered data.
-      let resolve: (v: ExploreData) => void = () => {};
-      mockFetchExploreData.mockReturnValueOnce(
-        new Promise<ExploreData>((r) => {
-          resolve = r;
-        }),
-      );
-
-      const { queryByTestId } = render(
-        <ExploreContent locale="en" initialData={unfilteredInitial} />,
-      );
-
-      // While the fetch is pending the skeleton must be on screen — the
-      // unfiltered ``initialTotalCompanies=3928`` MUST NOT have been
-      // handed to ``SearchPage``, otherwise the filter regression
-      // recurs.
-      await waitFor(() => {
-        expect(queryByTestId("explore-skeleton")).not.toBeNull();
-      });
-      expect(queryByTestId("search-page")).toBeNull();
-
-      resolve(filteredData);
-
-      await waitFor(() => {
-        expect(queryByTestId("search-page")).not.toBeNull();
-      });
-      expect(queryByTestId("explore-skeleton")).toBeNull();
-      expect(queryByTestId("search-page")?.getAttribute("data-total")).toBe(
-        "1133",
-      );
-    });
-
-    it("for an anonymous no-filter visit, SearchPage mounts directly with the prerendered initialData (#2640 ISR path preserved)", async () => {
-      const initialData = makeInitialData({
-        result: { companies: [], totalCompanies: 3928, truncated: false } as unknown as ExploreData["result"],
-      });
-      const { queryByTestId } = render(
-        <ExploreContent locale="en" initialData={initialData} />,
-      );
-
-      await waitFor(() => {
-        expect(queryByTestId("search-page")).not.toBeNull();
-      });
-      expect(queryByTestId("explore-skeleton")).toBeNull();
-      expect(queryByTestId("search-page")?.getAttribute("data-total")).toBe(
-        "3928",
-      );
-      expect(mockFetchExploreData).not.toHaveBeenCalled();
-    });
-  });
-});
-
-describe("ExploreContent — cold-start retry (#3008)", () => {
-  beforeEach(() => {
-    vi.spyOn(console, "warn").mockImplementation(() => {});
-    vi.spyOn(console, "error").mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it("retries fetchExplorePageData once when the first call rejects (cold-start abort)", async () => {
-    setDocumentCookie("logged_in=1");
-    const successData = makeInitialData();
-    mockFetchExploreData
-      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
-      .mockResolvedValueOnce(successData);
-
-    render(<ExploreContent locale="en" initialData={makeInitialData()} />);
-
-    await waitFor(() => {
-      expect(mockFetchExploreData).toHaveBeenCalledTimes(2);
-    });
-    // First failure logged at warn level (the retry attempt)
-    expect(console.warn).toHaveBeenCalled();
-  });
-
-  it("keeps filtered URLs unavailable instead of restoring unfiltered initialData", async () => {
-    setBrowserSearch("q=python&loc=india&wm=remote&etype=full_time");
-    mockFetchExploreData
-      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
-      .mockRejectedValueOnce(new TypeError("Failed to fetch"));
-
-    const unfilteredCompany = {
-      company: { id: "company-1", name: "Unfiltered", slug: "unfiltered", icon: null },
-      activeMatches: 1,
-      yearMatches: 1,
-      postings: [],
-    } as unknown as ExploreData["result"]["companies"][number];
-    render(
-      <ExploreContent
-        locale="en"
-        initialData={makeInitialData({
-          result: {
-            companies: [unfilteredCompany],
-            totalCompanies: 1,
-          },
-        })}
-      />,
-    );
-
-    await waitFor(() => {
-      expect(mockFetchExploreData).toHaveBeenCalledTimes(2);
-    });
-    await waitFor(() => {
-      expect(console.error).toHaveBeenCalled();
-    });
-    // The structured event and operation remain filterable without
-    // serializing the raw server-action error.
-    const [event, payload] = (console.error as unknown as ReturnType<typeof vi.fn>).mock
-      .calls[0] as [string, Record<string, unknown>];
-    expect(event).toBe("external_client_error");
-    expect(payload).toMatchObject({
-      service: "typesense",
-      operation: "fetch_explore_page",
-      retry_count: 2,
-    });
-    await waitFor(() => {
-      expect(mockSearchPageProps).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          initialCompanies: [],
-          initialTotalCompanies: 0,
-          initialDegraded: true,
-          initialKeywords: ["python"],
-          initialUnresolvedExplicitSlugs: { loc: ["india"] },
-          initialWorkMode: ["remote"],
-          initialEmploymentTypes: ["full_time"],
-        }),
-      );
-    });
-    expect(window.location.search).toBe(
-      "?q=python&loc=india&wm=remote&etype=full_time",
-    );
-    // The queryless snapshot may render during hydration, but the terminal
-    // mounted SearchPage must be the URL-derived unavailable state.
-    expect(mockSearchPageProps.mock.calls.at(-1)?.[0]).toEqual(
-      expect.objectContaining({ initialCompanies: [], initialDegraded: true }),
-    );
-  });
-
-  it("leaves the legacy no-initialData path in an explicit unavailable state", async () => {
-    setBrowserSearch("q=python");
-    mockFetchExploreData.mockRejectedValue(new TypeError("Failed to fetch"));
-
-    render(<ExploreContent locale="en" />);
-
-    await waitFor(() => {
-      expect(mockSearchPageProps).toHaveBeenLastCalledWith(
-        expect.objectContaining({
-          initialCompanies: [],
-          initialTotalCompanies: 0,
-          initialDegraded: true,
-          initialKeywords: ["python"],
-        }),
-      );
-    });
-  });
-
-  it("does NOT retry on the happy path (single resolved call)", async () => {
-    setDocumentCookie("logged_in=1");
-    mockFetchExploreData.mockResolvedValueOnce(makeInitialData());
-
-    render(<ExploreContent locale="en" initialData={makeInitialData()} />);
-
-    await waitFor(() => {
-      expect(mockFetchExploreData).toHaveBeenCalledTimes(1);
-    });
-    await flushQueuedEffects();
-    expect(mockFetchExploreData).toHaveBeenCalledTimes(1);
-    expect(console.warn).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
+++ b/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
@@ -287,6 +287,16 @@ describe("ExploreContent browser initialization", () => {
   it("does not duplicate a filtered load when anonymous bootstrap settles", async () => {
     setBrowserSearch("wm=remote");
     mocks.session.isPending = true;
+    let resolveLoad!: (value: {
+      data: ExploreData;
+      unavailable: boolean;
+      directAttempted: boolean;
+    }) => void;
+    mocks.loadBrowserData.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveLoad = resolve;
+      }),
+    );
     const initialData = makeInitialData();
     const view = render(
       <ExploreContent locale="en" initialData={initialData} />,
@@ -297,6 +307,18 @@ describe("ExploreContent browser initialization", () => {
     view.rerender(<ExploreContent locale="en" initialData={initialData} />);
     await flushEffects();
     expect(mocks.loadBrowserData).toHaveBeenCalledOnce();
+    expect(view.queryByTestId("explore-skeleton")).not.toBeNull();
+
+    resolveLoad({
+      data: makeInitialData({
+        result: { companies: [], totalCompanies: 7 },
+      }),
+      unavailable: false,
+      directAttempted: true,
+    });
+    await waitFor(() =>
+      expect(view.getByTestId("search-page").dataset.total).toBe("7"),
+    );
   });
 
   it("keeps a rejected unexpected browser load on the skeleton", async () => {

--- a/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
+++ b/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
@@ -378,6 +378,25 @@ describe("ExploreContent browser initialization", () => {
     );
   });
 
+  it("leaves URL changes to SearchPage after browser initialization commits", async () => {
+    setBrowserSearch("wm=remote");
+    render(
+      <ExploreContent locale="en" initialData={makeInitialData()} />,
+    );
+    await waitFor(() => expect(mocks.loadBrowserData).toHaveBeenCalledOnce());
+    await waitFor(() =>
+      expect(document.querySelector('[data-testid="search-page"]')).not.toBeNull(),
+    );
+
+    act(() => {
+      window.history.replaceState(null, "", "/en/explore?loc=zurich");
+    });
+    await flushEffects();
+
+    expect(mocks.loadBrowserData).toHaveBeenCalledOnce();
+    expect(document.querySelector('[data-testid="search-page"]')).not.toBeNull();
+  });
+
   it("keeps a rejected unexpected browser load on the skeleton", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     setBrowserSearch("q=python");

--- a/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
+++ b/apps/web/app/[lang]/(app)/explore/__tests__/explore-content.test.tsx
@@ -321,6 +321,63 @@ describe("ExploreContent browser initialization", () => {
     );
   });
 
+  it("invalidates a pending filtered load when browser navigation changes the URL", async () => {
+    setBrowserSearch("wm=remote");
+    type LoadResult = {
+      data: ExploreData;
+      unavailable: boolean;
+      directAttempted: boolean;
+    };
+    let resolveFirst!: (value: LoadResult) => void;
+    let resolveSecond!: (value: LoadResult) => void;
+    mocks.loadBrowserData
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+      )
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveSecond = resolve;
+        }),
+      );
+
+    const view = render(
+      <ExploreContent locale="en" initialData={makeInitialData()} />,
+    );
+    await waitFor(() => expect(mocks.loadBrowserData).toHaveBeenCalledOnce());
+    expect(
+      (mocks.loadBrowserData.mock.calls[0][0] as { searchParams: URLSearchParams })
+        .searchParams.toString(),
+    ).toBe("wm=remote");
+
+    act(() => {
+      window.history.pushState(null, "", "/en/explore?loc=zurich");
+    });
+    await waitFor(() => expect(mocks.loadBrowserData).toHaveBeenCalledTimes(2));
+    expect(
+      (mocks.loadBrowserData.mock.calls[1][0] as { searchParams: URLSearchParams })
+        .searchParams.toString(),
+    ).toBe("loc=zurich");
+
+    resolveFirst({
+      data: makeInitialData({ result: { companies: [], totalCompanies: 1 } }),
+      unavailable: false,
+      directAttempted: true,
+    });
+    await flushEffects();
+    expect(view.queryByTestId("explore-skeleton")).not.toBeNull();
+
+    resolveSecond({
+      data: makeInitialData({ result: { companies: [], totalCompanies: 2 } }),
+      unavailable: false,
+      directAttempted: true,
+    });
+    await waitFor(() =>
+      expect(view.getByTestId("search-page").dataset.total).toBe("2"),
+    );
+  });
+
   it("keeps a rejected unexpected browser load on the skeleton", async () => {
     vi.spyOn(console, "error").mockImplementation(() => {});
     setBrowserSearch("q=python");

--- a/apps/web/app/[lang]/(app)/explore/__tests__/search-page-heading.test.tsx
+++ b/apps/web/app/[lang]/(app)/explore/__tests__/search-page-heading.test.tsx
@@ -115,11 +115,16 @@ vi.mock("@/lib/search/query-params", async (importOriginal) => ({
 
 import { SearchPage, resolveInitialRepositoryFallbackCompanies } from "../search-page";
 import { fetchExploreFilterPageData } from "@/lib/actions/explore-page-data";
-import { runListTopCompanies, runSearchJobs } from "@/lib/search/search-runner";
+import {
+  runListTopCompanies,
+  runSearchJobs,
+  tryListTopCompaniesDirect,
+} from "@/lib/search/search-runner";
 
 const fetchExploreFilterPageDataMock = vi.mocked(fetchExploreFilterPageData);
 const runListTopCompaniesMock = vi.mocked(runListTopCompanies);
 const runSearchJobsMock = vi.mocked(runSearchJobs);
+const tryListTopCompaniesDirectMock = vi.mocked(tryListTopCompaniesDirect);
 
 beforeEach(() => {
   // jsdom/happy-dom may not set up window.history.replaceState identically
@@ -176,6 +181,34 @@ describe("SearchPage — heading landmark (#3196)", () => {
     // sr-only is the load-bearing class — without it, a visible h1
     // would shift the visual design unexpectedly.
     expect(h1.className).toMatch(/\bsr-only\b/);
+  });
+});
+
+describe("SearchPage — mount direct refresh ownership (#8259)", () => {
+  it("does not repeat a result read completed by ExploreContent", async () => {
+    render(
+      <SearchPage
+        initialCompanies={[]}
+        initialTotalCompanies={0}
+        initialKeywords={[]}
+        initialLocations={[]}
+        initialOccupations={[]}
+        initialSeniorities={[]}
+        initialTechnologies={[]}
+        initialEmploymentTypes={[]}
+        initialWorkMode={[]}
+        locale="en"
+        displayCurrency="EUR"
+        jobLanguages={[]}
+        languages={["en"]}
+        initialDirectRefreshAttempted
+      />,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(tryListTopCompaniesDirectMock).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/web/app/[lang]/(app)/explore/explore-content.tsx
+++ b/apps/web/app/[lang]/(app)/explore/explore-content.tsx
@@ -12,6 +12,7 @@ import { ExploreSkeleton } from "@/components/search/explore-skeleton";
 import { useSession } from "@/components/providers/SessionProvider";
 import { useSalaryRates } from "@/components/providers/SalaryDisplayProvider";
 import { loadExploreBrowserData } from "@/lib/search/explore-browser-data";
+import { useBrowserSearchParams } from "@/lib/use-browser-search-params";
 import { SearchPage } from "./search-page";
 
 type ExploreContentProps = {
@@ -32,6 +33,8 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
   const loadKeyRef = useRef<string | null>(null);
   const { isLoggedIn, isPending, preferences } = useSession();
   const rates = useSalaryRates();
+  const browserSearchParams = useBrowserSearchParams();
+  const browserSearchKey = browserSearchParams.toString();
   const preferenceLanguagesKey = preferences?.jobLanguages?.join(",") ?? "";
   const preferenceCurrency = preferences?.displayCurrency ?? null;
   const [view, setView] = useState<{
@@ -136,6 +139,7 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
       });
   }, [
     initialData,
+    browserSearchKey,
     isLoggedIn,
     isPending,
     locale,

--- a/apps/web/app/[lang]/(app)/explore/explore-content.tsx
+++ b/apps/web/app/[lang]/(app)/explore/explore-content.tsx
@@ -31,6 +31,8 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const fetchIdRef = useRef(0);
   const loadKeyRef = useRef<string | null>(null);
+  const viewerKeyRef = useRef<string | null>(null);
+  const initializationCompleteRef = useRef(false);
   const { isLoggedIn, isPending, preferences } = useSession();
   const rates = useSalaryRates();
   const browserSearchParams = useBrowserSearchParams();
@@ -71,6 +73,7 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
       // unresolved. The eventual authenticated/anonymous key will start a new
       // request once bootstrap settles.
       fetchIdRef.current += 1;
+      initializationCompleteRef.current = false;
       setView(null);
       return;
     }
@@ -78,16 +81,28 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
     const anonymousJobLanguages = isLoggedIn
       ? null
       : readAnonJobLanguagesPreference();
-    const loadKey = [
+    const viewerKey = [
       locale,
-      searchParams.toString(),
       isLoggedIn ? "authenticated" : "anonymous",
       preferenceCurrency ?? "",
       preferences?.jobLanguages?.join(",") ??
         anonymousJobLanguages?.join(",") ??
         "",
     ].join("|");
+    const loadKey = `${viewerKey}|${searchParams.toString()}`;
     if (loadKeyRef.current === loadKey) return;
+    const viewerChanged =
+      viewerKeyRef.current !== null && viewerKeyRef.current !== viewerKey;
+
+    // Once SearchPage is mounted it exclusively owns URL changes and their
+    // result reads. The outer subscription exists only so navigation can
+    // replace an in-flight initialization safely; re-running it afterward
+    // would duplicate SearchPage's request and discard its local state.
+    if (initializationCompleteRef.current && !viewerChanged) {
+      loadKeyRef.current = loadKey;
+      return;
+    }
+    viewerKeyRef.current = viewerKey;
     loadKeyRef.current = loadKey;
     // Allocate the stale-result guard only after same-key dedupe. Anonymous
     // bootstrap changes isPending without changing this key; incrementing
@@ -100,6 +115,7 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
       hasSearchFilterParams(searchParams) ||
       searchParams.has("lang");
     if (!needsBrowserLoad) {
+      initializationCompleteRef.current = true;
       setView({
         data: initialData,
         unavailable: false,
@@ -111,6 +127,7 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
     // Unmount SearchPage before the browser load: its state is initialized
     // from props, and a filtered URL must never flash or retain the broader
     // queryless shell while its scoped request is pending.
+    initializationCompleteRef.current = false;
     setView(null);
     void loadExploreBrowserData({
       initialData,
@@ -124,6 +141,7 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
     })
       .then((result) => {
         if (fetchIdRef.current !== fetchId) return;
+        initializationCompleteRef.current = true;
         setView(result);
       })
       .catch((err) => {

--- a/apps/web/app/[lang]/(app)/explore/explore-content.tsx
+++ b/apps/web/app/[lang]/(app)/explore/explore-content.tsx
@@ -1,45 +1,18 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { fetchExplorePageData, type ExploreData } from "@/lib/actions/explore-page-data";
-import { hasLoggedInHint, hasAnonJobLanguagesHint } from "@/lib/client-cookies";
+import type { ExploreData } from "@/lib/actions/explore-page-data";
+import {
+  hasLoggedInHint,
+  readAnonJobLanguagesPreference,
+} from "@/lib/client-cookies";
 import { logExternalError } from "@/lib/safe-external-error";
 import { hasSearchFilterParams } from "@/lib/search/query-params";
-import { buildUnavailableExploreData } from "@/lib/search/explore-degraded";
 import { ExploreSkeleton } from "@/components/search/explore-skeleton";
+import { useSession } from "@/components/providers/SessionProvider";
+import { useSalaryRates } from "@/components/providers/SalaryDisplayProvider";
+import { loadExploreBrowserData } from "@/lib/search/explore-browser-data";
 import { SearchPage } from "./search-page";
-
-/**
- * Retry policy for the personalized `fetchExplorePageData` server action
- * on cold-start. When the Vercel function instance is cold and
- * Typesense's first-request TLS handshake takes a few hundred ms, the
- * client-side fetch can be aborted (`net::ERR_ABORTED`) by the browser
- * before the server response arrives — DevTools surfaces this as
- * "Fetch failed loading: POST". Without a client retry, the rejected
- * promise leaks out and `setData` is never called, leaving the user on
- * whatever the prerendered static cache had (potentially the empty/
- * degraded variant from issue #3008).
- *
- * Retry once with a short delay (the second call usually hits a warm
- * function instance + warm Typesense connection). If both fail, the caller
- * installs a URL-derived unavailable snapshot so explicit filters remain
- * visible and no stale or broadened initial result set is shown.
- */
-async function fetchExplorePageDataWithRetry(
-  args: Parameters<typeof fetchExplorePageData>[0],
-): Promise<ExploreData> {
-  try {
-    return await fetchExplorePageData(args);
-  } catch (err) {
-    logExternalError(
-      "warn",
-      { service: "typesense", operation: "fetch_explore_page_retry", retryCount: 1 },
-      err,
-    );
-    await new Promise((resolve) => setTimeout(resolve, 250));
-    return fetchExplorePageData(args);
-  }
-}
 
 type ExploreContentProps = {
   locale: string;
@@ -47,26 +20,36 @@ type ExploreContentProps = {
    * Server-prerendered ``ExploreData`` for the unauthenticated, no-filter
    * homepage case (#2640). Anonymous visitors with no filter searchParams
    * use this directly — no Vercel function invocation. When ``initialData``
-   * is omitted (legacy call sites), the component falls back to the
-   * client-mount fetch behaviour from before this PR.
+   * The cached route always supplies this query-agnostic shell. Preference-
+   * and filter-bearing views replace it from browser-direct Typesense reads.
    */
-  initialData?: ExploreData;
+  initialData: ExploreData;
 };
 
 export function ExploreContent({ locale, initialData }: ExploreContentProps) {
   const rootRef = useRef<HTMLDivElement>(null);
-  const [data, setData] = useState<ExploreData | null>(initialData ?? null);
+  const fetchIdRef = useRef(0);
+  const loadKeyRef = useRef<string | null>(null);
+  const { isLoggedIn, isPending, preferences } = useSession();
+  const rates = useSalaryRates();
+  const preferenceLanguagesKey = preferences?.jobLanguages?.join(",") ?? "";
+  const preferenceCurrency = preferences?.displayCurrency ?? null;
+  const [view, setView] = useState<{
+    data: ExploreData;
+    unavailable: boolean;
+    directAttempted: boolean;
+  } | null>({
+    data: initialData,
+    unavailable: false,
+    directAttempted: false,
+  });
 
-  // Re-fetch on mount only when the prerendered ``initialData`` doesn't
-  // reflect the user's actual view — i.e. they have filter searchParams,
-  // the ``logged_in`` hint cookie is present (their DB-backed
-  // preferences / job-language filter / display currency would change
-  // the result set), OR they have an anonymous job-language cookie
-  // set (#2850 — anon viewers persist `jobLanguages` via a cookie
-  // that the server side reads in `fetchExplorePageData`). Anonymous, no-
-  // filter, no-job-lang-cookie visitors still get the prerendered data
-  // with zero function invocations — the bulk of organic traffic per
-  // #2640.
+  // Re-initialize only when the query-agnostic shell does not reflect the
+  // browser URL or viewer preferences. Authenticated preferences come from
+  // the shared app bootstrap action; anonymous language state is bounded and
+  // parsed from its client-readable cookie. Result data and explicit taxonomy
+  // resolution stay browser-direct, with only semantic free text retaining a
+  // narrow geo-aware parser action.
   useEffect(() => {
     // Keep the cached server snapshot visible until this interactive island
     // has hydrated successfully. At that point swap the two atomically: the
@@ -79,61 +62,82 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
     }
     interactive?.removeAttribute("hidden");
 
-    // Read the URL from the browser inside the mount effect instead of using
-    // Next's `useSearchParams` render-time API. The cached route intentionally
-    // serves one query-agnostic HTML shell; `useSearchParams` made this entire
-    // result subtree bail out to `loading.tsx`, so crawlers received only
-    // "Loading results" even though `initialData` was serialized in the RSC
-    // payload (#2640).
+    const fetchId = ++fetchIdRef.current;
     const searchParams = new URLSearchParams(window.location.search);
-    const needsPersonalizedFetch =
-      hasLoggedInHint() ||
-      hasAnonJobLanguagesHint() ||
+    if (hasLoggedInHint() && isPending) {
+      setView(null);
+      return;
+    }
+
+    const anonymousJobLanguages = isLoggedIn
+      ? null
+      : readAnonJobLanguagesPreference();
+    const loadKey = [
+      locale,
+      searchParams.toString(),
+      isLoggedIn ? "authenticated" : "anonymous",
+      preferenceCurrency ?? "",
+      preferences?.jobLanguages?.join(",") ??
+        anonymousJobLanguages?.join(",") ??
+        "",
+    ].join("|");
+    if (loadKeyRef.current === loadKey) return;
+    loadKeyRef.current = loadKey;
+    const needsBrowserLoad =
+      isLoggedIn ||
+      anonymousJobLanguages !== null ||
       hasSearchFilterParams(searchParams) ||
-      searchParams.has("lang") ||
-      initialData === undefined;
-    if (!needsPersonalizedFetch) return;
+      searchParams.has("lang");
+    if (!needsBrowserLoad) {
+      setView({
+        data: initialData,
+        unavailable: false,
+        directAttempted: false,
+      });
+      return;
+    }
 
-    // Clear ``data`` BEFORE firing the personalised fetch so
-    // ``SearchPage`` doesn't mount with the stale prerendered
-    // ``initialData`` and lock its ``useState``-initialised filter /
-    // result state to the unfiltered defaults — the subsequent
-    // ``setData(filtered)`` would otherwise re-render ``ExploreContent``
-    // with new ``initialX`` props, but ``SearchPage``'s state
-    // initialisers only run on first mount, so the filtered companies
-    // would never appear in the UI. By unmounting ``SearchPage`` (via
-    // ``ExploreSkeleton``) while the filtered fetch is in flight, the
-    // remount on data arrival re-initialises every ``useState``
-    // initialiser with the filtered data. Issue #3350 (regression of
-    // the #2746 ISR-prerender path for filter-bearing URLs).
-    setData(null);
-
-    const sp: Record<string, string | undefined> = {};
-    searchParams.forEach((value, key) => {
-      sp[key] = value;
-    });
-    fetchExplorePageDataWithRetry({ searchParams: sp, locale })
-      .then(setData)
+    // Unmount SearchPage before the browser load: its state is initialized
+    // from props, and a filtered URL must never flash or retain the broader
+    // queryless shell while its scoped request is pending.
+    setView(null);
+    void loadExploreBrowserData({
+      initialData,
+      searchParams,
+      locale,
+      displayCurrency: preferenceCurrency,
+      jobLanguages:
+        preferences?.jobLanguages ?? anonymousJobLanguages ?? [],
+      rates,
+      isLoggedIn,
+    })
+      .then((result) => {
+        if (fetchIdRef.current !== fetchId) return;
+        setView(result);
+      })
       .catch((err) => {
-        // Both attempts failed. Build an explicit unavailable snapshot from
-        // the browser URL. Restoring queryless ``initialData`` here would put
-        // unfiltered companies beneath a filtered URL and erase its toolbar
-        // state—the exact fail-open broadening this boundary prevents.
+        if (fetchIdRef.current !== fetchId) return;
         logExternalError(
           "error",
-          { service: "typesense", operation: "fetch_explore_page", retryCount: 2 },
+          { service: "typesense", operation: "load_explore_browser_data" },
           err,
         );
-        setData(buildUnavailableExploreData({ initialData, locale, searchParams: sp }));
+        // Expected transport/degradation paths are converted into explicit
+        // unavailable data by the loader. An unexpected failure stays on the
+        // skeleton rather than restoring unfiltered shell results.
       });
-    // Empty deps: the conditional-fetch decision is made once on
-    // mount. ``initialData`` is stable across re-renders (page
-    // identity), and ``SearchPage`` owns subsequent filter changes
-    // via its own state — re-running this effect on ``searchParams``
-    // change would clobber the user's interactive filter selection.
-  }, []);
+  }, [
+    initialData,
+    isLoggedIn,
+    isPending,
+    locale,
+    preferenceCurrency,
+    preferenceLanguagesKey,
+    rates,
+  ]);
 
-  if (!data) return <ExploreSkeleton />;
+  if (!view) return <ExploreSkeleton />;
+  const { data } = view;
 
   const {
     result,
@@ -180,6 +184,7 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
         initialLanguageOverride={languageOverride}
         userLat={userLat}
         userLng={userLng}
+        initialDirectRefreshAttempted={view.directAttempted}
       />
     </div>
   );

--- a/apps/web/app/[lang]/(app)/explore/explore-content.tsx
+++ b/apps/web/app/[lang]/(app)/explore/explore-content.tsx
@@ -62,9 +62,12 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
     }
     interactive?.removeAttribute("hidden");
 
-    const fetchId = ++fetchIdRef.current;
     const searchParams = new URLSearchParams(window.location.search);
     if (hasLoggedInHint() && isPending) {
+      // Invalidate any prior viewer-state request while the hinted session is
+      // unresolved. The eventual authenticated/anonymous key will start a new
+      // request once bootstrap settles.
+      fetchIdRef.current += 1;
       setView(null);
       return;
     }
@@ -83,6 +86,11 @@ export function ExploreContent({ locale, initialData }: ExploreContentProps) {
     ].join("|");
     if (loadKeyRef.current === loadKey) return;
     loadKeyRef.current = loadKey;
+    // Allocate the stale-result guard only after same-key dedupe. Anonymous
+    // bootstrap changes isPending without changing this key; incrementing
+    // before the return would discard the still-valid in-flight result and
+    // leave the filtered shell on its skeleton forever.
+    const fetchId = ++fetchIdRef.current;
     const needsBrowserLoad =
       isLoggedIn ||
       anonymousJobLanguages !== null ||

--- a/apps/web/app/[lang]/(app)/explore/explore-shell-cache.test.ts
+++ b/apps/web/app/[lang]/(app)/explore/explore-shell-cache.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const appDir = resolve(__dirname, "../../../..");
+
+describe("Explore shell cache policy (#8259)", () => {
+  it("uses the one-day shell lifetime backed by visible browser refresh", () => {
+    const routeSource = readFileSync(resolve(__dirname, "page.tsx"), "utf8");
+    const ttlSource = readFileSync(
+      resolve(appDir, "src/lib/cache-ttl.ts"),
+      "utf8",
+    );
+
+    expect(routeSource).toContain(
+      "cacheLife({ revalidate: CACHE_TTL_EXPLORE_SHELL });",
+    );
+    expect(routeSource).toContain("cacheLife(EXPLORE_DEFAULTS_CACHE_LIFE);");
+    expect(ttlSource).toContain(
+      "export const CACHE_TTL_EXPLORE_SHELL = CACHE_TTL_DAY;",
+    );
+    expect(ttlSource).toContain("export const CACHE_TTL_DAY = 86400;");
+  });
+});

--- a/apps/web/app/[lang]/(app)/explore/page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/page.tsx
@@ -16,7 +16,7 @@ const EXPLORE_DEFAULTS_CACHE_LIFE = {
 } as const;
 const EXPLORE_DEFAULTS_PAYLOAD_VERSION = "v4";
 
-// Cached for 10 minutes. The anonymous, no-filter explore payload is rendered
+// Cached for one day. The anonymous, no-filter explore payload is rendered
 // server-side via `fetchExplorePageDefaults` and embedded as `initialData`.
 // `SearchPage` refreshes the default result directly from Typesense after
 // hydration, so the longer CDN lifetime removes background regenerations

--- a/apps/web/app/[lang]/(app)/explore/search-page.tsx
+++ b/apps/web/app/[lang]/(app)/explore/search-page.tsx
@@ -110,6 +110,8 @@ interface SearchPageProps {
   initialLanguageOverride?: string[] | null;
   userLat?: number;
   userLng?: number;
+  /** Mount-time browser loader already attempted the visible result read. */
+  initialDirectRefreshAttempted?: boolean;
 }
 
 export function SearchPage({
@@ -138,6 +140,7 @@ export function SearchPage({
   initialLanguageOverride,
   userLat,
   userLng,
+  initialDirectRefreshAttempted = false,
 }: SearchPageProps) {
   // The cached route is always `/<locale>/explore`; query state is observed
   // separately after hydration. Reading `usePathname()` here would suspend
@@ -859,7 +862,7 @@ export function SearchPage({
   // current results and the refresh cannot add Fluid CPU.
   const directRefreshLanguagesKey = languages.join(",");
   useEffect(() => {
-    if (shouldRestore || hasFilters) return;
+    if (initialDirectRefreshAttempted || shouldRestore || hasFilters) return;
 
     const refreshKey = [
       locale,
@@ -905,6 +908,7 @@ export function SearchPage({
   }, [
     directRefreshLanguagesKey,
     hasFilters,
+    initialDirectRefreshAttempted,
     locale,
     shouldRestore,
     userLat,

--- a/apps/web/docs/edge-requests.md
+++ b/apps/web/docs/edge-requests.md
@@ -509,7 +509,7 @@ invoked.
 
 | Route | Shell behavior | Dynamic work | Pattern | Redis/cache | Est. duration |
 |-------|----------------|--------------|---------|-------------|---------------|
-| **Explore** | Cached anonymous defaults | Personalized `fetchExplorePageData()` / search actions when signed in or filtered | Mixed | Defaults 60s; search 5min | 30-250ms when invoked |
+| **Explore** | One-day cached anonymous defaults | Browser-direct filtered/preference refresh; shared bootstrap for signed-in prefs; narrow parser action only for semantic `q` | Browser-first | Shell 1d; search 5min | 0ms result compute on direct mounts |
 | **Company** | Cached anonymous defaults + metadata | Personalized `fetchCompanyPageData()` when signed in, filtered, or language cookie present | Mixed | Company/detail caches | 30-200ms when invoked |
 | **Shared watchlist** | Cached anonymous public snapshot + metadata | Personalized `fetchWatchlistPageData()` only when viewer/filters require it | Mixed | Watchlist lookup cached | 60-300ms when invoked |
 | **My Jobs** | Static shell | `getMyJobs()` after mount | Sequential | None | 20-100ms |

--- a/apps/web/docs/edge-requests/explore.md
+++ b/apps/web/docs/edge-requests/explore.md
@@ -4,7 +4,7 @@
 
 ## Initial document contract
 
-`page.tsx` calls `fetchExplorePageDefaults({ locale })` inside a 10-minute Cache
+`page.tsx` calls `fetchExplorePageDefaults({ locale })` inside a one-day Cache
 Component and passes the serializable result to `ExploreContent`. Raw HTML for
 every supported locale must contain:
 
@@ -28,7 +28,10 @@ zero-result search.
 Filter-bearing document requests are normalized by `proxy.ts` to the same
 queryless cached shell. The address bar keeps the original query. After
 hydration, `ExploreContent` reads `window.location.search`, requests the
-personalized/filtered page data, and replaces the anonymous defaults.
+personalized/filtered result directly through the scoped browser Typesense key,
+and replaces the anonymous defaults. Explicit taxonomy slugs resolve in the
+same browser `multi_search`; semantic free text alone uses the narrow canonical
+parser action because it needs request geolocation.
 
 Do not add request-bound `searchParams`, `headers()`, or `cookies()` reads to
 the cached page. Do not put `useSearchParams()` back in the result-owning
@@ -52,17 +55,20 @@ The whole page therefore emits **zero Next Server Action POSTs** on an
 anonymous unfiltered mount. `script/smoke-built-app.ts` verifies this against
 the production build.
 
-Filtered URLs and signed-in/job-language-hinted viewers deliberately call
-`fetchExplorePageData()` once after hydration because their result set depends
-on request or viewer state. The anonymous result shell remains visible in raw
-HTML while JavaScript loads; the client shows the busy skeleton only while it
-is replacing stale defaults with filtered data.
+Filtered URLs and job-language-hinted viewers initialize through browser-direct
+Typesense after hydration. Signed-in preferences reuse `fetchAppBootstrap()`
+from the shared app layout; Explore does not issue a second page-data action.
+The anonymous result shell remains visible in raw HTML while JavaScript loads;
+the client shows the busy skeleton only while replacing stale defaults with
+filtered data. A failed scoped read keeps the URL-derived filters and an
+explicit unavailable state—it never restores the broader queryless snapshot.
 
 ## Interactive requests
 
 | Operation | Preferred path | Server Action fallback / mutation |
 |-----------|----------------|-----------------------------------|
 | Default inventory refresh | Browser-direct Typesense | None |
+| Filter-bearing initial mount | Browser-direct Typesense; narrow semantic parser for free text | None for result data |
 | Search/filter change | Browser-direct Typesense runner | Search Server Action when direct access is unavailable or request exceeds the public bound |
 | Load more companies/postings | Browser-direct where supported | Bounded read action |
 | Posting detail | Cached posting-detail read | `getPostingDetail()` |

--- a/apps/web/src/lib/actions/__tests__/preferences-revalidation.test.ts
+++ b/apps/web/src/lib/actions/__tests__/preferences-revalidation.test.ts
@@ -78,10 +78,10 @@ vi.mock("@/db", () => ({
 vi.mock("@/lib/auth", () => ({ auth: { api: { setPassword: vi.fn() } } }));
 
 const PATHS = [
-  "/[lang]/(app)/explore",
   "/[lang]/(app)/[userSlug]/[watchlistSlug]",
   "/[lang]/(app)/company/[slug]",
 ];
+const EXPLORE_PATH = "/[lang]/(app)/explore";
 
 describe("updatePreferences invalidates job-language-dependent pages (#2916)", () => {
   beforeEach(() => {
@@ -108,6 +108,7 @@ describe("updatePreferences invalidates job-language-dependent pages (#2916)", (
     for (const p of PATHS) {
       expect(mocks.revalidatePath).toHaveBeenCalledWith(p, "page");
     }
+    expect(mocks.revalidatePath).not.toHaveBeenCalledWith(EXPLORE_PATH, "page");
   });
 
   it("anon path: skips revalidation when jobLanguages is not in payload", async () => {
@@ -134,6 +135,7 @@ describe("updatePreferences invalidates job-language-dependent pages (#2916)", (
     for (const p of PATHS) {
       expect(mocks.revalidatePath).toHaveBeenCalledWith(p, "page");
     }
+    expect(mocks.revalidatePath).not.toHaveBeenCalledWith(EXPLORE_PATH, "page");
   });
 
   it("auth update path: does NOT revalidate when only theme changes", async () => {
@@ -162,6 +164,7 @@ describe("updatePreferences invalidates job-language-dependent pages (#2916)", (
     for (const p of PATHS) {
       expect(mocks.revalidatePath).toHaveBeenCalledWith(p, "page");
     }
+    expect(mocks.revalidatePath).not.toHaveBeenCalledWith(EXPLORE_PATH, "page");
   });
 
   it("revalidatePath failure is swallowed (preference write must not 500)", async () => {

--- a/apps/web/src/lib/actions/explore-page-data.ts
+++ b/apps/web/src/lib/actions/explore-page-data.ts
@@ -284,19 +284,18 @@ export async function fetchExplorePageData(params: {
  *
  * Critically does NOT call :func:`getPreferences` (reads
  * ``cookies()``) or :func:`getGeoFromHeaders` (reads ``headers()``) —
- * both forces dynamic rendering and would silently break the page's
+ * both force dynamic rendering and would silently break the page's
  * ISR eligibility. Returns the same ``ExploreData`` shape with
  * anonymous defaults: EUR currency, no job-language filter, no geo
- * proximity bias. The client component conditionally re-fetches the
- * personalized variant via :func:`fetchExplorePageData` when the
- * ``logged_in`` hint cookie or any filter searchParams are present.
+ * proximity bias. The client component resolves preference- or filter-bearing
+ * views through the browser loader and scoped Typesense key. Semantic free
+ * text retains only the narrow geo-aware parser action.
  *
  * Net effect: anonymous visitors hitting ``/explore`` with no
  * filters get a CDN-cached prerendered page with embedded
- * ``initialData``, no Vercel function invocation. Logged-in users
- * still pay the function call (one fetch on mount, same as today).
- * Filter changes always go through ``fetchExplorePageData`` because the
- * defaults can't reflect them.
+ * ``initialData``, no Vercel function invocation. Logged-in users reuse the
+ * layout bootstrap they already need; Explore no longer invokes this full
+ * page-data action on mount.
  */
 export async function fetchExplorePageDefaults(params: {
   locale: string;

--- a/apps/web/src/lib/actions/preferences.ts
+++ b/apps/web/src/lib/actions/preferences.ts
@@ -47,15 +47,15 @@ function sanitizeJobLanguages(input: string[]): string[] {
 }
 
 /**
- * Routes whose `'use cache'` output depends on the viewer's job-language
- * filter (DB row for auth users, `JSEEK_JOB_LANGUAGES` cookie for anon).
+ * Routes whose server-rendered output still depends on the viewer's job-
+ * language filter (DB row for auth users, `JSEEK_JOB_LANGUAGES` cookie for
+ * anon).
  * After `updatePreferences` mutates `jobLanguages`, every cached layer
  * across these routes needs to be invalidated — otherwise the user
  * navigates back to a stale prerender that predates the cookie write
  * (#2916). Stays in sync with the read sites enumerated in PR #2914.
  */
 const JOB_LANGUAGE_DEPENDENT_PATHS = [
-  "/[lang]/(app)/explore",
   "/[lang]/(app)/[userSlug]/[watchlistSlug]",
   "/[lang]/(app)/company/[slug]",
 ] as const;
@@ -68,11 +68,11 @@ const JOB_LANGUAGE_DEPENDENT_PATHS = [
  * dependency comes via cookie/DB rather than a `cacheTag`: it evicts
  * the per-region cache entry for the route and forces a fresh server
  * render on the next request. The caller (a client component in
- * /settings) ALSO calls `router.refresh()` to flush the client-side
- * router cache that holds a snapshot of /explore in memory across
- * back-nav (#2916). Both layers must be cleared — the per-region
- * cache is the source for the RSC payload server-side, the router
- * cache is the source the browser uses on back-nav.
+ * /settings) ALSO calls `router.refresh()` to flush its client-side router
+ * cache across back-nav (#2916). Explore is intentionally absent here: its
+ * one-day shell is query-agnostic and the browser loader consumes bootstrap
+ * preferences / the anonymous cookie after hydration, so evicting that global
+ * shell would only add regeneration and ISR writes.
  *
  * Failures are swallowed because a successful preference write is the
  * load-bearing operation; a revalidation hiccup must not 500 the form
@@ -147,11 +147,9 @@ export async function updatePreferences(
     // server-resolved field. See issue #2850 + `anon-preferences.ts`.
     if (data.jobLanguages !== undefined) {
       await writeAnonJobLanguagesCookie(data.jobLanguages);
-      // Cookie write happened — flush every page whose `'use cache'`
-      // output depends on the cookie. Without this the back-nav from
-      // /settings to /explore renders the prerender that predates the
-      // toggle; the user only sees the new filter after a hard reload
-      // (#2916).
+      // Cookie write happened — flush the remaining server-rendered pages
+      // whose output depends on the cookie. Explore applies it browser-side
+      // and must retain its shared query-agnostic shell.
       invalidateJobLanguageDependentPages();
     }
     return null;
@@ -223,7 +221,7 @@ export async function updatePreferences(
     // mutation for other fields (theme/locale/currency) is observed
     // by the caller via `router.refresh()` and doesn't need a
     // server-side `revalidatePath` because none of those flow into
-    // the explore/watchlist `'use cache'` outputs.
+    // the remaining watchlist/company server-rendered outputs.
     if (data.jobLanguages !== undefined) {
       invalidateJobLanguageDependentPages();
     }

--- a/apps/web/src/lib/cache-ttl.ts
+++ b/apps/web/src/lib/cache-ttl.ts
@@ -19,7 +19,7 @@
  * |                     |         | postings, filtered watchlist counts,         |
  * |                     |         | default API `maxAge`)                        |
  * | `CACHE_TTL_DETAIL`        |   600   | Company detail page                          |
- * | `CACHE_TTL_EXPLORE_SHELL` |   600   | Anonymous explore prerender; browser         |
+ * | `CACHE_TTL_EXPLORE_SHELL` | 86400   | Anonymous explore prerender; browser         |
  * |                           |         | Typesense refreshes it after hydration       |
  * | `CACHE_TTL_LONG`          |  3600   | Semi-static taxonomies, locations, similar   |
  * |                           |         | companies, sitemap, watchlist matching count |
@@ -49,14 +49,14 @@ export const CACHE_TTL_MEDIUM = 300;
 /** 600 seconds (10 min) — company detail page (cross-`'use cache'`-boundary dedup). */
 export const CACHE_TTL_DETAIL = 600;
 
-/** 10 minutes — anonymous explore shell; hydrated results refresh from Typesense. */
-export const CACHE_TTL_EXPLORE_SHELL = 600;
-
 /** 3600 seconds (1 hour) — semi-static taxonomies, locations, sitemap, similar companies. */
 export const CACHE_TTL_LONG = 3600;
 
 /** 86400 seconds (1 day) — very static / rare-change (blog pages). */
 export const CACHE_TTL_DAY = 86400;
+
+/** 1 day — anonymous explore shell; hydrated results refresh from Typesense. */
+export const CACHE_TTL_EXPLORE_SHELL = CACHE_TTL_DAY;
 
 /** 1 day — anonymous company shell; hydrated posting data refreshes from Typesense. */
 export const CACHE_TTL_COMPANY_SHELL = CACHE_TTL_DAY;

--- a/apps/web/src/lib/client-cookies.ts
+++ b/apps/web/src/lib/client-cookies.ts
@@ -13,10 +13,10 @@ export const LOGGED_IN_COOKIE = "logged_in";
  * Name of the non-httpOnly cookie that persists anonymous-viewer
  * `jobLanguages` preferences. The same cookie is the canonical source
  * of truth on the server (read by `viewer.ts::getViewerLanguages` and
- * `explore-page-data.ts::fetchExplorePageData`); the client only needs to know
- * whether it's set so it can decide to re-fetch the personalised
- * `ExploreData` instead of using the anon-default static prerender
- * (#2850). MUST stay in sync with `lib/anon-preferences.ts`.
+ * `viewer.ts::getViewerLanguages`); Explore and company browser loaders parse
+ * the same bounded value directly so their personalized result refresh does
+ * not require a page-data Server Action (#2850, #8257, #8259). MUST stay in
+ * sync with `lib/anon-preferences.ts`.
  */
 export const JOB_LANGUAGES_COOKIE = "JSEEK_JOB_LANGUAGES";
 
@@ -50,19 +50,6 @@ export function hasCookieNamed(cookieHeader: string, name: string): boolean {
 export function hasLoggedInHint(): boolean {
   if (typeof document === "undefined") return false;
   return hasCookieNamed(document.cookie, LOGGED_IN_COOKIE);
-}
-
-/**
- * Client-only: does the current browser have a stored anon
- * `jobLanguages` cookie? Used by ``ExploreContent`` (and its peers) to
- * decide whether to refetch the personalised ``ExploreData`` even when
- * the viewer is anonymous and the URL has no filter searchParams.
- * Without this, the static anon-default prerender would render with
- * `[locale]` filters regardless of the cookie state. See #2850.
- */
-export function hasAnonJobLanguagesHint(): boolean {
-  if (typeof document === "undefined") return false;
-  return hasCookieNamed(document.cookie, JOB_LANGUAGES_COOKIE);
 }
 
 const MAX_JOB_LANGUAGES_COOKIE_LENGTH = 1024;

--- a/apps/web/src/lib/search/__tests__/explore-browser-data.test.ts
+++ b/apps/web/src/lib/search/__tests__/explore-browser-data.test.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExploreData } from "@/lib/actions/explore-page-data";
+import type { ParsedSearchFilters } from "@/lib/services/search-input";
+
+const mocks = vi.hoisted(() => ({
+  parseOffline: vi.fn(),
+  resolveFilters: vi.fn(),
+  semanticFilters: vi.fn(),
+  directList: vi.fn(),
+  directSearch: vi.fn(),
+}));
+
+vi.mock("@/lib/search/typesense-browser-filter-state", () => ({
+  parseCompanyFilterStateOffline: mocks.parseOffline,
+  resolveCompanyFilterStateDirect: mocks.resolveFilters,
+}));
+vi.mock("@/lib/actions/company-filter-state", () => ({
+  resolveCompanySemanticFilters: mocks.semanticFilters,
+}));
+vi.mock("@/lib/search/search-runner", () => ({
+  tryListTopCompaniesDirect: mocks.directList,
+  trySearchJobsDirect: mocks.directSearch,
+}));
+
+import { loadExploreBrowserData } from "../explore-browser-data";
+
+const emptyParsed: ParsedSearchFilters = {
+  keywords: [],
+  locations: [],
+  occupations: [],
+  seniorities: [],
+  technologies: [],
+  workMode: [],
+  employmentTypes: [],
+};
+
+function makeData(overrides: Partial<ExploreData> = {}): ExploreData {
+  return {
+    result: {
+      companies: [{ company: { id: "broad" } } as never],
+      totalCompanies: 1,
+    },
+    parsed: emptyParsed,
+    displayCurrency: "EUR",
+    jobLanguages: [],
+    languages: ["en"],
+    languageOverride: null,
+    userLat: undefined,
+    userLng: undefined,
+    salaryCurrencyParam: "EUR",
+    salaryMinDisplay: undefined,
+    salaryMaxDisplay: undefined,
+    experienceMin: undefined,
+    experienceMax: undefined,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mocks.parseOffline.mockReset();
+  mocks.parseOffline.mockReturnValue({ parsed: emptyParsed, complete: true });
+  mocks.resolveFilters.mockReset();
+  mocks.resolveFilters.mockResolvedValue({ parsed: emptyParsed, complete: true });
+  mocks.semanticFilters.mockReset();
+  mocks.semanticFilters.mockImplementation(({ q }: { q: string }) => ({
+    parsed: { ...emptyParsed, keywords: [q] },
+    userLat: 47.37,
+    userLng: 8.54,
+  }));
+  mocks.directList.mockReset();
+  mocks.directList.mockResolvedValue({ companies: [], totalCompanies: 0 });
+  mocks.directSearch.mockReset();
+  mocks.directSearch.mockResolvedValue({ companies: [], totalCompanies: 0 });
+});
+
+describe("loadExploreBrowserData", () => {
+  it("resolves explicit filters and searches directly with preferences and EUR bounds", async () => {
+    const parsed: ParsedSearchFilters = {
+      ...emptyParsed,
+      locations: [{
+        id: 10,
+        slug: "zurich",
+        name: "Zürich",
+        type: "city",
+        parentName: "Switzerland",
+      }],
+      occupations: [{ id: 20, slug: "engineer", name: "Engineer" }],
+      seniorities: [{ id: 30, slug: "senior", name: "Senior" }],
+      technologies: [{ id: 40, slug: "react", name: "React" }],
+      workMode: ["remote"],
+      employmentTypes: ["full_time"],
+    };
+    mocks.resolveFilters.mockResolvedValue({ parsed, complete: true });
+
+    const result = await loadExploreBrowserData({
+      initialData: makeData(),
+      searchParams: new URLSearchParams(
+        "loc=zurich&occ=engineer&sen=senior&tech=react&wm=remote&etype=full_time&sal=100-200&salcur=CHF&exp=2-5",
+      ),
+      locale: "de",
+      displayCurrency: "CHF",
+      jobLanguages: ["de", "en"],
+      rates: [{ currency: "CHF", toEur: 1.04 }],
+      isLoggedIn: true,
+    });
+
+    expect(mocks.directList).toHaveBeenCalledWith(
+      {
+        locationIds: [10],
+        occupationIds: [20],
+        seniorityIds: [30],
+        technologyIds: [40],
+        employmentTypes: ["full_time"],
+        workMode: ["remote"],
+        salaryMinEur: 104,
+        salaryMaxEur: 208,
+        experienceMin: 2,
+        experienceMax: 5,
+        languages: ["de", "en"],
+        locale: "de",
+        offset: 0,
+        limit: 10,
+      },
+      true,
+    );
+    expect(mocks.directSearch).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      unavailable: false,
+      directAttempted: true,
+      data: {
+        displayCurrency: "CHF",
+        jobLanguages: ["de", "en"],
+        salaryCurrencyParam: "CHF",
+      },
+    });
+  });
+
+  it("keeps canonical semantic q parsing and geolocation but reads results directly", async () => {
+    const parsed: ParsedSearchFilters = {
+      ...emptyParsed,
+      keywords: ["python"],
+      locations: [{
+        id: 10,
+        slug: "zurich",
+        name: "Zurich",
+        type: "city",
+        parentName: "Switzerland",
+      }],
+      workMode: ["remote"],
+    };
+    mocks.semanticFilters.mockResolvedValue({
+      parsed,
+      userLat: 47.37,
+      userLng: 8.54,
+    });
+
+    const result = await loadExploreBrowserData({
+      initialData: makeData(),
+      searchParams: new URLSearchParams("q=remote%20Zurich%20python"),
+      locale: "en",
+      displayCurrency: "EUR",
+      jobLanguages: [],
+      rates: [],
+      isLoggedIn: false,
+    });
+
+    expect(mocks.semanticFilters).toHaveBeenCalledWith({
+      q: "remote Zurich python",
+      loc: undefined,
+      occ: undefined,
+      sen: undefined,
+      tech: undefined,
+      wm: undefined,
+      etype: undefined,
+      locale: "en",
+    });
+    expect(mocks.resolveFilters).not.toHaveBeenCalled();
+    expect(mocks.directSearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        keywords: ["python"],
+        locationIds: [10],
+        workMode: ["remote"],
+        languages: ["en"],
+      }),
+      false,
+    );
+    expect(result.data).toMatchObject({ userLat: 47.37, userLng: 8.54 });
+  });
+
+  it("honors a public language override independently of preferences", async () => {
+    await loadExploreBrowserData({
+      initialData: makeData(),
+      searchParams: new URLSearchParams("lang=fr,it"),
+      locale: "de",
+      displayCurrency: "EUR",
+      jobLanguages: ["de", "en"],
+      rates: [],
+      isLoggedIn: false,
+    });
+
+    expect(mocks.directList).toHaveBeenCalledWith(
+      expect.objectContaining({ languages: ["fr", "it"] }),
+      false,
+    );
+  });
+
+  it("fails closed when direct search is unavailable", async () => {
+    mocks.semanticFilters.mockResolvedValue({
+      parsed: { ...emptyParsed, keywords: ["python"] },
+      userLat: undefined,
+      userLng: undefined,
+    });
+    mocks.directSearch.mockResolvedValue(null);
+
+    const result = await loadExploreBrowserData({
+      initialData: makeData(),
+      searchParams: new URLSearchParams("q=python"),
+      locale: "en",
+      displayCurrency: "EUR",
+      jobLanguages: [],
+      rates: [],
+      isLoggedIn: false,
+    });
+
+    expect(result.unavailable).toBe(true);
+    expect(result.directAttempted).toBe(true);
+    expect(result.data.result).toEqual({
+      companies: [],
+      totalCompanies: 0,
+      degraded: true,
+    });
+    expect(result.data.parsed.keywords).toEqual(["python"]);
+  });
+
+  it("does not broaden unresolved explicit slugs", async () => {
+    const parsed: ParsedSearchFilters = {
+      ...emptyParsed,
+      unresolvedExplicitSlugs: { loc: ["missing-place"] },
+    };
+    mocks.resolveFilters.mockResolvedValue({ parsed, complete: false });
+
+    const result = await loadExploreBrowserData({
+      initialData: makeData(),
+      searchParams: new URLSearchParams("loc=missing-place"),
+      locale: "en",
+      displayCurrency: "EUR",
+      jobLanguages: [],
+      rates: [],
+      isLoggedIn: false,
+    });
+
+    expect(mocks.directList).not.toHaveBeenCalled();
+    expect(mocks.directSearch).not.toHaveBeenCalled();
+    expect(result.unavailable).toBe(true);
+    expect(result.data.parsed.unresolvedExplicitSlugs).toEqual({
+      loc: ["missing-place"],
+    });
+  });
+
+  it("rejects malformed numeric ranges before a direct query", async () => {
+    const result = await loadExploreBrowserData({
+      initialData: makeData(),
+      searchParams: new URLSearchParams("sal=not-a-range"),
+      locale: "en",
+      displayCurrency: "EUR",
+      jobLanguages: [],
+      rates: [],
+      isLoggedIn: false,
+    });
+
+    expect(mocks.resolveFilters).not.toHaveBeenCalled();
+    expect(mocks.directList).not.toHaveBeenCalled();
+    expect(result.unavailable).toBe(true);
+  });
+});

--- a/apps/web/src/lib/search/__tests__/search-runner-direct-refresh.test.ts
+++ b/apps/web/src/lib/search/__tests__/search-runner-direct-refresh.test.ts
@@ -3,6 +3,7 @@ import { setTestEnv, withTestEnv } from "@/test-utils/env";
 
 const mocks = vi.hoisted(() => ({
   browserListTopCompanies: vi.fn(),
+  browserSearchJobs: vi.fn(),
   browserLoadCompanyPostings: vi.fn(),
   browserLoadSimilarCompanies: vi.fn(),
   browserWatchlistPostings: vi.fn(),
@@ -36,6 +37,7 @@ vi.mock("../typesense-browser-watchlist", () => ({
 vi.mock("../typesense-browser", () => ({
   getBrowserSearchProvider: () => ({
     listTopCompanies: mocks.browserListTopCompanies,
+    search: mocks.browserSearchJobs,
     loadPostingsWithCounts: mocks.browserLoadCompanyPostings,
     loadSimilarCompanies: mocks.browserLoadSimilarCompanies,
   }),
@@ -66,6 +68,53 @@ describe("browser-direct shell refreshes", () => {
       ),
     ).resolves.toEqual(browserResult);
     expect(mocks.serverListTopCompanies).not.toHaveBeenCalled();
+  });
+
+  it("searches a filtered Explore shell without invoking the server fallback", async () => {
+    const browserResult = {
+      companies: [],
+      totalCompanies: 7,
+      truncated: false,
+    };
+    mocks.browserSearchJobs.mockResolvedValue(browserResult);
+    const { trySearchJobsDirect } = await import("../search-runner");
+
+    await expect(
+      trySearchJobsDirect(
+        {
+          keywords: ["python"],
+          languages: ["en"],
+          locale: "en",
+          offset: 0,
+          limit: 10,
+        },
+        false,
+      ),
+    ).resolves.toEqual(browserResult);
+    expect(mocks.serverSearchJobs).not.toHaveBeenCalled();
+  });
+
+  it("returns null for a degraded direct Explore search", async () => {
+    mocks.browserSearchJobs.mockResolvedValue({
+      companies: [],
+      totalCompanies: 0,
+      degraded: true,
+    });
+    const { trySearchJobsDirect } = await import("../search-runner");
+
+    await expect(
+      trySearchJobsDirect(
+        {
+          keywords: ["python"],
+          languages: ["en"],
+          locale: "en",
+          offset: 0,
+          limit: 10,
+        },
+        false,
+      ),
+    ).resolves.toBeNull();
+    expect(mocks.serverSearchJobs).not.toHaveBeenCalled();
   });
 
   it("returns null on a degraded browser result instead of consuming Fluid CPU", async () => {
@@ -190,6 +239,7 @@ describe("browser-direct shell refreshes", () => {
       tryGetWatchlistSnapshotDirect({ companyIds: ["company-1"] }),
     ).resolves.toBeNull();
     expect(mocks.browserListTopCompanies).not.toHaveBeenCalled();
+    expect(mocks.browserSearchJobs).not.toHaveBeenCalled();
     expect(mocks.browserLoadCompanyPostings).not.toHaveBeenCalled();
     expect(mocks.browserLoadSimilarCompanies).not.toHaveBeenCalled();
     expect(mocks.browserWatchlistPostings).not.toHaveBeenCalled();

--- a/apps/web/src/lib/search/__tests__/typesense-browser-filter-state.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense-browser-filter-state.test.ts
@@ -169,6 +169,43 @@ describe("resolveCompanyFilterStateDirect", () => {
     });
   });
 
+  it("rejects malformed HTTP-200 documents instead of constructing invalid filters", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            results: [{ hits: [{ document: { slug: "zurich", type: "city" } }] }],
+          }),
+          { status: 200 },
+        ),
+      ),
+    );
+
+    await expect(
+      resolveCompanyFilterStateDirect(
+        new URLSearchParams("loc=zurich"),
+        "en",
+      ),
+    ).rejects.toThrow("malformed location");
+  });
+
+  it("rejects malformed HTTP-200 result envelopes", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ results: [{}] }), { status: 200 }),
+      ),
+    );
+
+    await expect(
+      resolveCompanyFilterStateDirect(
+        new URLSearchParams("tech=react"),
+        "en",
+      ),
+    ).rejects.toThrow("malformed hits");
+  });
+
   it("rejects oversized or unsafe input before requesting a child key", async () => {
     vi.stubGlobal("fetch", vi.fn());
 

--- a/apps/web/src/lib/search/explore-browser-data.ts
+++ b/apps/web/src/lib/search/explore-browser-data.ts
@@ -1,0 +1,263 @@
+import type { ExploreData } from "@/lib/actions/explore-page-data";
+import { resolveCompanySemanticFilters } from "@/lib/actions/company-filter-state";
+import type { CurrencyRate } from "@/lib/actions/search";
+import { resolveJobLanguages } from "@/lib/job-languages";
+import { convertToEur } from "@/lib/salary";
+import { logExternalError } from "@/lib/safe-external-error";
+import { parseExploreSearchLanguages } from "@/lib/search/language-param";
+import {
+  tryListTopCompaniesDirect,
+  trySearchJobsDirect,
+} from "@/lib/search/search-runner";
+import {
+  parseCompanyFilterStateOffline,
+  resolveCompanyFilterStateDirect,
+} from "@/lib/search/typesense-browser-filter-state";
+import type { ParsedSearchFilters } from "@/lib/services/search-input";
+
+const PAGE_SIZE = 10;
+const MAX_RANGE_PARAM_LENGTH = 64;
+const MAX_LANGUAGE_PARAM_LENGTH = 128;
+
+type RangeResult = {
+  min: number | undefined;
+  max: number | undefined;
+  valid: boolean;
+};
+
+export type ExploreBrowserDataResult = {
+  data: ExploreData;
+  unavailable: boolean;
+  /** Prevents SearchPage from repeating this mount-time direct read. */
+  directAttempted: boolean;
+};
+
+function parseRange(raw: string | null): RangeResult {
+  if (!raw) return { min: undefined, max: undefined, valid: true };
+  if (raw.length > MAX_RANGE_PARAM_LENGTH) {
+    return { min: undefined, max: undefined, valid: false };
+  }
+  const parts = raw.split("-");
+  if (parts.length !== 2) {
+    return { min: undefined, max: undefined, valid: false };
+  }
+  const parse = (value: string): number | undefined => {
+    if (!value) return undefined;
+    if (!/^\d+$/.test(value)) return Number.NaN;
+    const parsed = Number.parseInt(value, 10);
+    return Number.isSafeInteger(parsed) && parsed >= 0
+      ? parsed
+      : Number.NaN;
+  };
+  const min = parse(parts[0]);
+  const max = parse(parts[1]);
+  return {
+    min: Number.isNaN(min) ? undefined : min,
+    max: Number.isNaN(max) ? undefined : max,
+    valid: !Number.isNaN(min) && !Number.isNaN(max),
+  };
+}
+
+function validCurrency(value: string | null | undefined): string | null {
+  return value && /^[A-Z]{3}$/.test(value) ? value : null;
+}
+
+function unavailableData(params: {
+  initialData: ExploreData;
+  parsed: ParsedSearchFilters;
+  displayCurrency: string;
+  jobLanguages: string[];
+  languages: string[];
+  languageOverride: string[] | null;
+  salaryCurrencyParam: string;
+  salary: RangeResult;
+  experience: RangeResult;
+  userLat?: number;
+  userLng?: number;
+}): ExploreData {
+  return {
+    ...params.initialData,
+    result: { companies: [], totalCompanies: 0, degraded: true },
+    repositoryFallbackCompanies: undefined,
+    parsed: params.parsed,
+    displayCurrency: params.displayCurrency,
+    jobLanguages: params.jobLanguages,
+    languages: params.languages,
+    languageOverride: params.languageOverride,
+    userLat: params.userLat,
+    userLng: params.userLng,
+    salaryCurrencyParam: params.salaryCurrencyParam,
+    salaryMinDisplay: params.salary.min,
+    salaryMaxDisplay: params.salary.max,
+    experienceMin: params.experience.min,
+    experienceMax: params.experience.max,
+  };
+}
+
+/**
+ * Initialize a preference- or filter-bearing Explore shell from the browser.
+ * Explicit taxonomy slugs and results use the scoped Typesense key. Semantic
+ * free text retains the narrow canonical parser action because it needs
+ * request geolocation; it never fetches the result set server-side.
+ */
+export async function loadExploreBrowserData(params: {
+  initialData: ExploreData;
+  searchParams: URLSearchParams;
+  locale: string;
+  displayCurrency?: string | null;
+  jobLanguages: string[];
+  rates: CurrencyRate[];
+  isLoggedIn: boolean;
+}): Promise<ExploreBrowserDataResult> {
+  const displayCurrency = validCurrency(params.displayCurrency) ?? "EUR";
+  const salaryCurrencyParam =
+    validCurrency(params.searchParams.get("salcur")) ?? displayCurrency;
+  const salary = parseRange(params.searchParams.get("sal"));
+  const experience = parseRange(params.searchParams.get("exp"));
+  const rawLanguage = params.searchParams.get("lang");
+  const languageParam =
+    (rawLanguage?.length ?? 0) <= MAX_LANGUAGE_PARAM_LENGTH
+      ? parseExploreSearchLanguages(rawLanguage)
+      : { ok: false as const, error: "language param is too long" };
+  const languageOverride = languageParam.ok
+    ? languageParam.languages
+    : null;
+  const languages =
+    languageOverride ?? resolveJobLanguages(params.jobLanguages, params.locale);
+  const offline = parseCompanyFilterStateOffline(params.searchParams);
+  const unavailable = (
+    parsed = offline.parsed,
+    geo?: { userLat?: number; userLng?: number },
+  ): ExploreBrowserDataResult => ({
+    data: unavailableData({
+      initialData: params.initialData,
+      parsed,
+      displayCurrency,
+      jobLanguages: params.jobLanguages,
+      languages,
+      languageOverride,
+      salaryCurrencyParam,
+      salary,
+      experience,
+      userLat: geo?.userLat,
+      userLng: geo?.userLng,
+    }),
+    unavailable: true,
+    directAttempted: true,
+  });
+
+  if (!salary.valid || !experience.valid) return unavailable();
+
+  let parsed: ParsedSearchFilters;
+  let userLat: number | undefined;
+  let userLng: number | undefined;
+  const rawQuery = params.searchParams.get("q")?.trim();
+  if (rawQuery) {
+    try {
+      const semantic = await resolveCompanySemanticFilters({
+        q: rawQuery,
+        loc: params.searchParams.get("loc") ?? undefined,
+        occ: params.searchParams.get("occ") ?? undefined,
+        sen: params.searchParams.get("sen") ?? undefined,
+        tech: params.searchParams.get("tech") ?? undefined,
+        wm: params.searchParams.get("wm") ?? undefined,
+        etype: params.searchParams.get("etype") ?? undefined,
+        locale: params.locale,
+      });
+      if (!semantic) return unavailable();
+      parsed = semantic.parsed;
+      userLat = semantic.userLat;
+      userLng = semantic.userLng;
+    } catch (error) {
+      logExternalError(
+        "error",
+        { service: "typesense", operation: "explore_semantic_filters" },
+        error,
+      );
+      return unavailable();
+    }
+  } else {
+    let filterState;
+    try {
+      filterState = await resolveCompanyFilterStateDirect(
+        params.searchParams,
+        params.locale,
+      );
+    } catch (error) {
+      logExternalError(
+        "error",
+        { service: "typesense", operation: "browser_explore_filter_state" },
+        error,
+      );
+      return unavailable();
+    }
+    if (!filterState.complete) return unavailable(filterState.parsed);
+    parsed = filterState.parsed;
+  }
+
+  if (parsed.unresolvedExplicitSlugs) {
+    return unavailable(parsed, { userLat, userLng });
+  }
+
+  const searchInput = {
+    locationIds:
+      parsed.locations.length > 0
+        ? parsed.locations.map((location) => location.id)
+        : undefined,
+    occupationIds:
+      parsed.occupations.length > 0
+        ? parsed.occupations.map((occupation) => occupation.id)
+        : undefined,
+    seniorityIds:
+      parsed.seniorities.length > 0
+        ? parsed.seniorities.map((seniority) => seniority.id)
+        : undefined,
+    technologyIds:
+      parsed.technologies.length > 0
+        ? parsed.technologies.map((technology) => technology.id)
+        : undefined,
+    employmentTypes:
+      parsed.employmentTypes.length > 0
+        ? parsed.employmentTypes
+        : undefined,
+    workMode: parsed.workMode.length > 0 ? parsed.workMode : undefined,
+    salaryMinEur: convertToEur(salary.min, salaryCurrencyParam, params.rates),
+    salaryMaxEur: convertToEur(salary.max, salaryCurrencyParam, params.rates),
+    experienceMin: experience.min,
+    experienceMax: experience.max,
+    languages,
+    locale: params.locale,
+    offset: 0,
+    limit: PAGE_SIZE,
+  };
+  const result =
+    parsed.keywords.length > 0
+      ? await trySearchJobsDirect(
+          { ...searchInput, keywords: parsed.keywords },
+          params.isLoggedIn,
+        )
+      : await tryListTopCompaniesDirect(searchInput, params.isLoggedIn);
+  if (!result) return unavailable(parsed, { userLat, userLng });
+
+  return {
+    data: {
+      ...params.initialData,
+      result,
+      repositoryFallbackCompanies: undefined,
+      parsed,
+      displayCurrency,
+      jobLanguages: params.jobLanguages,
+      languages,
+      languageOverride,
+      userLat,
+      userLng,
+      salaryCurrencyParam,
+      salaryMinDisplay: salary.min,
+      salaryMaxDisplay: salary.max,
+      experienceMin: experience.min,
+      experienceMax: experience.max,
+    },
+    unavailable: false,
+    directAttempted: true,
+  };
+}

--- a/apps/web/src/lib/search/search-runner.ts
+++ b/apps/web/src/lib/search/search-runner.ts
@@ -73,19 +73,38 @@ export async function runSearchJobs(
   params: SearchInput,
   isLoggedIn: boolean,
 ): Promise<SearchResponse> {
-  if (directEnabled) {
-    if (!isLoggedIn && params.offset >= ANON_MAX_COMPANIES) {
-      return { companies: [], totalCompanies: 0, truncated: true };
-    }
-    try {
-      const provider = await tryBrowserProvider();
-      const result = await provider.search(params);
-      if (!result.degraded) return applyAnonCap(result, params.offset, isLoggedIn);
-    } catch (err) {
-      logExternalError("error", { service: "typesense", operation: "browser_search_jobs" }, err);
-    }
-  }
+  const direct = await trySearchJobsDirect(params, isLoggedIn);
+  if (direct) return direct;
   return serverSearchJobs(params);
+}
+
+/**
+ * Search directly from a hydrated shell without falling through to a Server
+ * Action. A null result lets mount-time callers keep or replace their SSR
+ * snapshot explicitly, without accidentally consuming Fluid CPU.
+ */
+export async function trySearchJobsDirect(
+  params: SearchInput,
+  isLoggedIn: boolean,
+): Promise<SearchResponse | null> {
+  if (!directEnabled) return null;
+  if (!isLoggedIn && params.offset >= ANON_MAX_COMPANIES) {
+    return { companies: [], totalCompanies: 0, truncated: true };
+  }
+  try {
+    const provider = await tryBrowserProvider();
+    const result = await provider.search(params);
+    if (!result.degraded) {
+      return applyAnonCap(result, params.offset, isLoggedIn);
+    }
+  } catch (err) {
+    logExternalError(
+      "error",
+      { service: "typesense", operation: "browser_search_jobs" },
+      err,
+    );
+  }
+  return null;
 }
 
 export async function runListTopCompanies(

--- a/apps/web/src/lib/search/typesense-browser-filter-state.ts
+++ b/apps/web/src/lib/search/typesense-browser-filter-state.ts
@@ -23,9 +23,8 @@ type SearchRequest = {
   [key: string]: unknown;
 };
 
-type SearchHit<T> = { document: T };
 type SearchResult<T> = {
-  hits?: SearchHit<T>[];
+  hits: Array<{ document: T }>;
   error?: string;
 };
 
@@ -33,7 +32,7 @@ type LocationDocument = {
   location_id: number;
   slug: string;
   type: string;
-  parent_name?: string;
+  parent_name?: string | null;
   name_en?: string;
   name_de?: string;
   name_fr?: string;
@@ -135,16 +134,78 @@ async function searchMany(
     invalidateTypesenseBrowserConfigIfUnauthorized(response.status);
     throw new Error(`typesense filter resolver ${response.status}`);
   }
-  const body = (await response.json()) as {
-    results?: SearchResult<Record<string, unknown>>[];
-  };
-  if (!body.results || body.results.length !== searches.length) {
+  const body: unknown = await response.json();
+  if (
+    !isRecord(body) ||
+    !Array.isArray(body.results) ||
+    body.results.length !== searches.length
+  ) {
     throw new Error("typesense filter resolver returned an incomplete result set");
   }
-  for (const result of body.results) {
-    if (result.error) throw new Error("typesense filter resolver search failed");
+  const results: SearchResult<Record<string, unknown>>[] = [];
+  for (const rawResult of body.results) {
+    if (!isRecord(rawResult) || typeof rawResult.error === "string") {
+      throw new Error("typesense filter resolver search failed");
+    }
+    if (!Array.isArray(rawResult.hits)) {
+      throw new Error("typesense filter resolver returned malformed hits");
+    }
+    const hits = rawResult.hits.map((rawHit) => {
+      if (!isRecord(rawHit) || !isRecord(rawHit.document)) {
+        throw new Error("typesense filter resolver returned malformed documents");
+      }
+      return { document: rawHit.document };
+    });
+    results.push({ hits });
   }
-  return body.results;
+  return results;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isOptionalString(value: unknown): value is string | null | undefined {
+  return value === undefined || value === null || typeof value === "string";
+}
+
+function isLocationDocument(value: Record<string, unknown>): value is LocationDocument {
+  return (
+    Number.isInteger(value.location_id) &&
+    typeof value.slug === "string" &&
+    ["macro", "country", "region", "city"].includes(String(value.type)) &&
+    isOptionalString(value.parent_name) &&
+    isOptionalString(value.name_en) &&
+    isOptionalString(value.name_de) &&
+    isOptionalString(value.name_fr) &&
+    isOptionalString(value.name_it)
+  );
+}
+
+function taxonomyId(
+  document: Record<string, unknown>,
+  kind: Exclude<FilterDimension, "loc">,
+): number | null {
+  const key =
+    kind === "occ"
+      ? "occupation_id"
+      : kind === "sen"
+        ? "seniority_id"
+        : "technology_id";
+  const id = document[key];
+  return Number.isInteger(id) ? (id as number) : null;
+}
+
+function isTaxonomyDocument(
+  value: Record<string, unknown>,
+  kind: Exclude<FilterDimension, "loc">,
+): value is TaxonomyDocument {
+  return (
+    taxonomyId(value, kind) !== null &&
+    typeof value.slug === "string" &&
+    isOptionalString(value.name) &&
+    isOptionalString(value.locale)
+  );
 }
 
 function localizedLocationName(
@@ -308,12 +369,13 @@ export async function resolveCompanyFilterStateDirect(
   const resolved = new Set<string>();
   for (let index = 0; index < kinds.length; index += 1) {
     const kind = kinds[index];
-    const documents = (results[index].hits ?? []).map(
-      (hit) => hit.document,
-    );
+    const documents = results[index].hits.map((hit) => hit.document);
     if (kind === "loc") {
       base.locations = documents.map((raw) => {
-        const document = raw as unknown as LocationDocument;
+        if (!isLocationDocument(raw)) {
+          throw new Error("typesense filter resolver returned a malformed location");
+        }
+        const document = raw;
         resolved.add(`loc:${document.slug}`);
         return {
           id: document.location_id,
@@ -326,10 +388,14 @@ export async function resolveCompanyFilterStateDirect(
       continue;
     }
 
-    const preferred = preferLocale(
-      documents as unknown as TaxonomyDocument[],
-      locale,
-    );
+    const taxonomyKind = kind as Exclude<FilterDimension, "loc">;
+    const taxonomyDocuments = documents.map((document) => {
+      if (!isTaxonomyDocument(document, taxonomyKind)) {
+        throw new Error("typesense filter resolver returned malformed taxonomy");
+      }
+      return document;
+    });
+    const preferred = preferLocale(taxonomyDocuments, locale);
     const target =
       kind === "occ"
         ? base.occupations


### PR DESCRIPTION
Closes #8259

## Summary
- extend the anonymous Explore Cache Component shell from 10 minutes to one day
- initialize filter- and preference-bearing Explore views through bounded browser-direct Typesense reads instead of the full page-data Server Action
- retain the narrow canonical semantic parser action for free text/geolocation while result reads stay browser-direct
- preserve authenticated and anonymous language preferences, salary conversion, anonymous caps, SSR fallback, and fail-closed filtered degradation
- validate browser taxonomy response envelopes/documents before constructing filters

## Expected impact
The observed Explore surface used at least 125 invocations / 11s Active CPU in the 12-hour baseline. Anonymous queryless mounts already use the cached shell; this change lengthens that shell lifetime 144x and removes the full mount-time result action from filtered and personalized views.

## Verification
- `pnpm --filter @jobseek/web exec tsc --noEmit`
- targeted ESLint on all changed TypeScript/TSX
- 55 focused tests
- full web suite: 269 files / 2,054 tests (Typesense E2E excluded)
- `pnpm build` (Explore reported `1d` revalidate / `5d` expire)
- `pnpm --filter @jobseek/web check:bundle` (668.8 KB gzip, passed)

## Rollout checks
After merge: verify queryless, explicit-filter, and semantic-query request traces; confirm no full Explore page-data Server Action POST; then monitor production warnings/errors for at least 10 minutes.