### PR TITLE
Batch company posting Typesense queries

### DIFF
--- a/apps/web/src/lib/search/__tests__/typesense.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense.test.ts
@@ -665,6 +665,16 @@ describe("loadPostingsWithCounts multi_search batching", () => {
     };
   }
 
+  const malformedPostingSlots: Array<[string, unknown]> = [
+    ["a truncated page", { found: 2, hits: [] }],
+    ["a hit when found is zero", { found: 0, hits: [freshPosting] }],
+    [
+      "more hits than the requested page",
+      { found: 3, hits: [freshPosting, freshRole, olderRole] },
+    ],
+    ["a structurally invalid posting", { found: 1, hits: [{ document: {} }] }],
+  ];
+
   it("uses one ordered SDK batch for postings and both counts", async () => {
     mocks.multiSearch.mockResolvedValue(batchResponse());
 
@@ -727,6 +737,25 @@ describe("loadPostingsWithCounts multi_search batching", () => {
     error.mockRestore();
   });
 
+  it.each(malformedPostingSlots)(
+    "fails the entire SDK batch for %s",
+    async (_label, postingSlot) => {
+      const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      try {
+        mocks.multiSearch.mockResolvedValue({
+          results: [postingSlot, { found: 7 }, { found: 11 }],
+        });
+
+        await expect(
+          new TypesenseSearchProvider().loadPostingsWithCounts(params),
+        ).resolves.toEqual({ postings: [], activeCount: 0, yearCount: 0 });
+        expect(mocks.multiSearch).toHaveBeenCalledOnce();
+      } finally {
+        error.mockRestore();
+      }
+    },
+  );
+
   it("uses one browser multi_search and preserves ordered result mapping", async () => {
     const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = String(input);
@@ -786,6 +815,33 @@ describe("loadPostingsWithCounts multi_search batching", () => {
       new TypesenseBrowserProvider().loadPostingsWithCounts(params),
     ).rejects.toThrow("Typesense multi_search response was malformed");
   });
+
+  it.each(malformedPostingSlots)(
+    "rejects a browser batch with %s",
+    async (_label, postingSlot) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(async (input: string | URL | Request) => {
+          if (String(input) === "/api/typesense-key") {
+            return Response.json({
+              apiKey: "browser-key",
+              host: "typesense.example",
+              port: 443,
+              protocol: "https",
+              expiresAt: Date.now() + 60_000,
+            });
+          }
+          return Response.json({
+            results: [postingSlot, { found: 7 }, { found: 11 }],
+          });
+        }),
+      );
+
+      await expect(
+        new TypesenseBrowserProvider().loadPostingsWithCounts(params),
+      ).rejects.toThrow("Typesense multi_search response was malformed");
+    },
+  );
 });
 
 describe("resolveTypesenseCompany", () => {

--- a/apps/web/src/lib/search/__tests__/typesense.test.ts
+++ b/apps/web/src/lib/search/__tests__/typesense.test.ts
@@ -9,10 +9,12 @@ const mocks = vi.hoisted(() => ({
   calls: [] as SearchCall[],
   browserCalls: [] as SearchCall[],
   search: vi.fn(),
+  multiSearch: vi.fn(),
 }));
 
 vi.mock("../typesense-client", () => ({
   getSearchClient: () => ({
+    multiSearch: { perform: mocks.multiSearch },
     collections: (collection: string) => ({
       documents: () => ({
         search: (params: Record<string, unknown>) => {
@@ -201,6 +203,7 @@ beforeEach(() => {
   mocks.calls.length = 0;
   mocks.browserCalls.length = 0;
   mocks.search.mockReset();
+  mocks.multiSearch.mockReset();
   clearTypesenseBrowserConfig();
 });
 
@@ -639,6 +642,149 @@ describe("TypesenseBrowserProvider.listTopCompanies", () => {
     expect(result.companies.every((entry) => entry.company.slug.length > 0)).toBe(
       true,
     );
+  });
+});
+
+describe("loadPostingsWithCounts multi_search batching", () => {
+  const params = {
+    languages: ["en"],
+    locale: "en",
+    companyId: "fresh-co",
+    keywords: ["engineer"],
+    offset: 0,
+    limit: 2,
+  };
+
+  function batchResponse() {
+    return {
+      results: [
+        { found: 2, hits: [freshPosting, freshRole] },
+        { found: 7 },
+        { found: 11 },
+      ],
+    };
+  }
+
+  it("uses one ordered SDK batch for postings and both counts", async () => {
+    mocks.multiSearch.mockResolvedValue(batchResponse());
+
+    const result = await new TypesenseSearchProvider().loadPostingsWithCounts(params);
+
+    expect(result).toMatchObject({ activeCount: 7, yearCount: 11 });
+    expect(result.postings.map((posting) => posting.id)).toEqual([
+      freshPosting.document.id,
+      freshRole.document.id,
+    ]);
+    expect(mocks.multiSearch).toHaveBeenCalledOnce();
+    const batch = mocks.multiSearch.mock.calls[0][0] as {
+      searches: Array<Record<string, unknown>>;
+    };
+    expect(batch.searches).toHaveLength(3);
+    expect(batch.searches.map((search) => search.collection)).toEqual([
+      "job_posting",
+      "job_posting",
+      "job_posting",
+    ]);
+    expect(batch.searches[0]).toMatchObject({
+      q: "engineer",
+      sort_by: "_text_match:desc,first_seen_at:desc",
+      per_page: 2,
+      page: 1,
+    });
+    expect(batch.searches[1]).toMatchObject({ q: "engineer", per_page: 0 });
+    expect(batch.searches[2]).toMatchObject({ q: "engineer", per_page: 0 });
+    expect(String(batch.searches[2].filter_by)).toContain("first_seen_at:>");
+  });
+
+  it("retries the whole SDK batch after a transient transport failure", async () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      mocks.multiSearch
+        .mockRejectedValueOnce(Object.assign(new Error("reset"), { code: "ECONNRESET" }))
+        .mockResolvedValueOnce(batchResponse());
+
+      const pending = new TypesenseSearchProvider().loadPostingsWithCounts(params);
+      await vi.runAllTimersAsync();
+
+      await expect(pending).resolves.toMatchObject({ activeCount: 7, yearCount: 11 });
+      expect(mocks.multiSearch).toHaveBeenCalledTimes(2);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it("fails the entire SDK batch when a result slot is missing", async () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.multiSearch.mockResolvedValue({ results: batchResponse().results.slice(0, 2) });
+
+    await expect(
+      new TypesenseSearchProvider().loadPostingsWithCounts(params),
+    ).resolves.toEqual({ postings: [], activeCount: 0, yearCount: 0 });
+    expect(mocks.multiSearch).toHaveBeenCalledOnce();
+    error.mockRestore();
+  });
+
+  it("uses one browser multi_search and preserves ordered result mapping", async () => {
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input);
+      if (url === "/api/typesense-key") {
+        return Response.json({
+          apiKey: "browser-key",
+          host: "typesense.example",
+          port: 443,
+          protocol: "https",
+          expiresAt: Date.now() + 60_000,
+        });
+      }
+      expect(url).toBe("https://typesense.example:443/multi_search");
+      expect(init?.method).toBe("POST");
+      return Response.json(batchResponse());
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await new TypesenseBrowserProvider().loadPostingsWithCounts(params);
+
+    expect(result).toMatchObject({ activeCount: 7, yearCount: 11 });
+    expect(result.postings.map((posting) => posting.id)).toEqual([
+      freshPosting.document.id,
+      freshRole.document.id,
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const batchCall = fetchMock.mock.calls[1];
+    const body = JSON.parse(String(batchCall[1]?.body)) as {
+      searches: Array<Record<string, unknown>>;
+    };
+    expect(body.searches).toHaveLength(3);
+    expect(body.searches[0]).toMatchObject({ per_page: 2, page: 1 });
+    expect(body.searches[1]).toMatchObject({ per_page: 0 });
+    expect(body.searches[2]).toMatchObject({ per_page: 0 });
+  });
+
+  it("rejects a browser batch that contains a per-search error", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: string | URL | Request) => {
+        if (String(input) === "/api/typesense-key") {
+          return Response.json({
+            apiKey: "browser-key",
+            host: "typesense.example",
+            port: 443,
+            protocol: "https",
+            expiresAt: Date.now() + 60_000,
+          });
+        }
+        const response = batchResponse();
+        response.results[1] = { found: 0, error: "bad filter" } as never;
+        return Response.json(response);
+      }),
+    );
+
+    await expect(
+      new TypesenseBrowserProvider().loadPostingsWithCounts(params),
+    ).rejects.toThrow("Typesense multi_search response was malformed");
   });
 });
 

--- a/apps/web/src/lib/search/typesense-browser.ts
+++ b/apps/web/src/lib/search/typesense-browser.ts
@@ -21,6 +21,7 @@ import {
   resolveTypesenseCompany,
   type TypesenseCompanyDocument,
 } from "./typesense-company";
+import { parseTypesenseMultiSearchResults } from "./typesense-multi-search";
 
 interface JobPostingDoc {
   id: string;
@@ -119,6 +120,29 @@ async function searchOne<T>(
     throw new Error(`typesense ${collection} search ${res.status}`);
   }
   return res.json();
+}
+
+async function searchMany<T>(
+  cfg: TypesenseBrowserConfig,
+  searches: Array<Record<string, unknown>>,
+): Promise<RawSearchResponse<T>[]> {
+  const url = `${cfg.protocol}://${cfg.host}:${cfg.port}/multi_search`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-typesense-api-key": cfg.apiKey,
+    },
+    body: JSON.stringify({ searches }),
+  });
+  if (!res.ok) {
+    invalidateTypesenseBrowserConfigIfUnauthorized(res.status);
+    throw new Error(`typesense multi_search ${res.status}`);
+  }
+  const body: unknown = await res.json();
+  return parseTypesenseMultiSearchResults<T>(body, searches.length, {
+    expectHitsAt: [0],
+  }) as RawSearchResponse<T>[];
 }
 
 function buildLocations(
@@ -519,30 +543,36 @@ export class TypesenseBrowserProvider implements SearchProvider {
     const baseFilter = `company_id:=${companyId}${filterStr ? ` && ${filterStr}` : ""}`;
     const q = keywords.length ? keywords.join(" ") : "*";
 
-    const [postingsResult, activeResult, yearResult] = await Promise.all([
-      searchOne<JobPostingDoc>(cfg, "job_posting", {
-        q,
-        query_by: "title",
-        filter_by: `${POSTING_BASE_FILTER} && ${baseFilter}`,
-        sort_by: keywords.length
-          ? "_text_match:desc,first_seen_at:desc"
-          : "first_seen_at:desc",
-        per_page: limit,
-        page: Math.floor(offset / limit) + 1,
-      }),
-      searchOne<JobPostingDoc>(cfg, "job_posting", {
-        q,
-        query_by: "title",
-        filter_by: `${POSTING_BASE_FILTER} && ${baseFilter}`,
-        per_page: 0,
-      }),
-      searchOne<JobPostingDoc>(cfg, "job_posting", {
-        q,
-        query_by: "title",
-        filter_by: `${POSTING_FLOW_FILTER} && first_seen_at:>${oneYearAgoUnix()} && ${baseFilter}`,
-        per_page: 0,
-      }),
-    ]);
+    const [postingsResult, activeResult, yearResult] = await searchMany<JobPostingDoc>(
+      cfg,
+      [
+        {
+          collection: "job_posting",
+          q,
+          query_by: "title",
+          filter_by: `${POSTING_BASE_FILTER} && ${baseFilter}`,
+          sort_by: keywords.length
+            ? "_text_match:desc,first_seen_at:desc"
+            : "first_seen_at:desc",
+          per_page: limit,
+          page: Math.floor(offset / limit) + 1,
+        },
+        {
+          collection: "job_posting",
+          q,
+          query_by: "title",
+          filter_by: `${POSTING_BASE_FILTER} && ${baseFilter}`,
+          per_page: 0,
+        },
+        {
+          collection: "job_posting",
+          q,
+          query_by: "title",
+          filter_by: `${POSTING_FLOW_FILTER} && first_seen_at:>${oneYearAgoUnix()} && ${baseFilter}`,
+          per_page: 0,
+        },
+      ],
+    );
 
     const postings = (postingsResult.hits ?? []).map((h) =>
       mapHitToPosting(h, locationIds),

--- a/apps/web/src/lib/search/typesense-browser.ts
+++ b/apps/web/src/lib/search/typesense-browser.ts
@@ -21,7 +21,10 @@ import {
   resolveTypesenseCompany,
   type TypesenseCompanyDocument,
 } from "./typesense-company";
-import { parseTypesenseMultiSearchResults } from "./typesense-multi-search";
+import {
+  assertCompanyPostingPage,
+  parseTypesenseMultiSearchResults,
+} from "./typesense-multi-search";
 
 interface JobPostingDoc {
   id: string;
@@ -573,6 +576,7 @@ export class TypesenseBrowserProvider implements SearchProvider {
         },
       ],
     );
+    assertCompanyPostingPage(postingsResult, { offset, limit });
 
     const postings = (postingsResult.hits ?? []).map((h) =>
       mapHitToPosting(h, locationIds),

--- a/apps/web/src/lib/search/typesense-multi-search.ts
+++ b/apps/web/src/lib/search/typesense-multi-search.ts
@@ -16,6 +16,70 @@ function malformedBatch(): Error {
   return new Error("Typesense multi_search response was malformed");
 }
 
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
+}
+
+function isFiniteNumberArray(value: unknown): value is number[] {
+  return (
+    Array.isArray(value) &&
+    value.every((item) => typeof item === "number" && Number.isFinite(item))
+  );
+}
+
+/**
+ * Validate the page-level invariants and every document field consumed by the
+ * company posting mapper. This prevents a syntactically valid HTTP-200 body
+ * from replacing a good prerendered snapshot with a truncated, oversized, or
+ * structurally corrupt direct-browser result.
+ */
+export function assertCompanyPostingPage<T>(
+  result: TypesenseMultiSearchResult<T>,
+  params: { offset: number; limit: number },
+): void {
+  if (
+    !Number.isInteger(params.offset) ||
+    params.offset < 0 ||
+    !Number.isInteger(params.limit) ||
+    params.limit < 0
+  ) {
+    throw malformedBatch();
+  }
+
+  const hits = result.hits ?? [];
+  const pageStart =
+    params.limit === 0
+      ? params.offset
+      : Math.floor(params.offset / params.limit) * params.limit;
+  const expectedHits =
+    params.limit === 0
+      ? 0
+      : Math.min(params.limit, Math.max(0, result.found - pageStart));
+  if (hits.length !== expectedHits) {
+    throw malformedBatch();
+  }
+
+  for (const hit of hits) {
+    const doc = hit.document as unknown;
+    if (
+      !isRecord(doc) ||
+      typeof doc.id !== "string" ||
+      doc.id.length === 0 ||
+      typeof doc.title !== "string" ||
+      typeof doc.first_seen_at !== "number" ||
+      !Number.isFinite(doc.first_seen_at) ||
+      !Number.isFinite(new Date(doc.first_seen_at * 1000).getTime()) ||
+      typeof doc.is_active !== "boolean" ||
+      !isFiniteNumberArray(doc.location_ids) ||
+      !isStringArray(doc.location_names) ||
+      !isStringArray(doc.location_types) ||
+      !isStringArray(doc.location_geo_types)
+    ) {
+      throw malformedBatch();
+    }
+  }
+}
+
 /**
  * Validate the ordered result envelope returned by Typesense multi_search.
  * A missing slot or a successful HTTP response containing a per-search error
@@ -67,4 +131,3 @@ export function parseTypesenseMultiSearchResults<T>(
     return rawResult as unknown as TypesenseMultiSearchResult<T>;
   });
 }
-

--- a/apps/web/src/lib/search/typesense-multi-search.ts
+++ b/apps/web/src/lib/search/typesense-multi-search.ts
@@ -1,0 +1,70 @@
+export type TypesenseMultiSearchResult<T> = {
+  found: number;
+  hits?: Array<{
+    document: T;
+    text_match?: number;
+  }>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function malformedBatch(): Error {
+  // Keep upstream response content out of errors that can cross a Server
+  // Action boundary or reach client-side telemetry.
+  return new Error("Typesense multi_search response was malformed");
+}
+
+/**
+ * Validate the ordered result envelope returned by Typesense multi_search.
+ * A missing slot or a successful HTTP response containing a per-search error
+ * fails the whole batch, so callers can never pair postings with the wrong
+ * active/year count.
+ */
+export function parseTypesenseMultiSearchResults<T>(
+  value: unknown,
+  expectedResults: number,
+  options: { expectHitsAt?: readonly number[] } = {},
+): TypesenseMultiSearchResult<T>[] {
+  if (!isRecord(value) || !Array.isArray(value.results)) {
+    throw malformedBatch();
+  }
+  if (value.results.length !== expectedResults) {
+    throw malformedBatch();
+  }
+
+  const expectHits = new Set(options.expectHitsAt ?? []);
+  return value.results.map((rawResult, index) => {
+    if (!isRecord(rawResult) || rawResult.error !== undefined) {
+      throw malformedBatch();
+    }
+    if (
+      typeof rawResult.found !== "number" ||
+      !Number.isInteger(rawResult.found) ||
+      rawResult.found < 0
+    ) {
+      throw malformedBatch();
+    }
+    if (rawResult.hits !== undefined && !Array.isArray(rawResult.hits)) {
+      throw malformedBatch();
+    }
+    if (expectHits.has(index) && rawResult.found > 0 && !Array.isArray(rawResult.hits)) {
+      throw malformedBatch();
+    }
+    if (
+      Array.isArray(rawResult.hits) &&
+      rawResult.hits.some((hit) => {
+        if (!isRecord(hit) || !isRecord(hit.document)) return true;
+        return (
+          hit.text_match !== undefined &&
+          (typeof hit.text_match !== "number" || !Number.isFinite(hit.text_match))
+        );
+      })
+    ) {
+      throw malformedBatch();
+    }
+    return rawResult as unknown as TypesenseMultiSearchResult<T>;
+  });
+}
+

--- a/apps/web/src/lib/search/typesense.ts
+++ b/apps/web/src/lib/search/typesense.ts
@@ -23,6 +23,7 @@ import {
   resolveTypesenseCompany,
   type TypesenseCompanyDocument,
 } from "./typesense-company";
+import { parseTypesenseMultiSearchResults } from "./typesense-multi-search";
 
 // ── Typesense document shapes ──────────────────────────────────────
 
@@ -622,14 +623,15 @@ export class TypesenseSearchProvider implements SearchProvider {
       const q = keywords.length ? keywords.join(" ") : "*";
       const client = getSearchClient();
 
-      // Three queries in parallel: postings + active count + year count
-      const [postingsResult, activeResult, yearResult] = await Promise.all([
-        withTypesenseRetry(
-          () =>
-            client
-              .collections<JobPostingDoc>("job_posting")
-              .documents()
-              .search({
+      // Result order is contractual: postings, active count, one-year flow
+      // count. One retry replays the whole HTTP batch so counts cannot come
+      // from a different attempt than the visible postings.
+      const batch = await withTypesenseRetry(
+        () =>
+          client.multiSearch.perform({
+            searches: [
+              {
+                collection: "job_posting",
                 q,
                 query_by: "title",
                 filter_by: `${POSTING_BASE_FILTER} && ${baseFilter}`,
@@ -638,39 +640,32 @@ export class TypesenseSearchProvider implements SearchProvider {
                   : "first_seen_at:desc",
                 per_page: limit,
                 page: Math.floor(offset / limit) + 1,
-              }),
-          { label: "loadPostingsWithCounts.postings" },
-        ),
-        withTypesenseRetry(
-          () =>
-            client
-              .collections<JobPostingDoc>("job_posting")
-              .documents()
-              .search({
+              },
+              {
+                collection: "job_posting",
                 q,
                 query_by: "title",
                 filter_by: `${POSTING_BASE_FILTER} && ${baseFilter}`,
                 per_page: 0,
-              }),
-          { label: "loadPostingsWithCounts.activeCount" },
-        ),
-        withTypesenseRetry(
-          () =>
-            client
-              .collections<JobPostingDoc>("job_posting")
-              .documents()
-              .search({
+              },
+              {
+                collection: "job_posting",
                 q,
                 query_by: "title",
                 filter_by: `${POSTING_FLOW_FILTER} && first_seen_at:>${oneYearAgoUnix()} && ${baseFilter}`,
                 per_page: 0,
-              }),
-          { label: "loadPostingsWithCounts.yearCount" },
-        ),
-      ]);
+              },
+            ],
+          }),
+        { label: "loadPostingsWithCounts.batch" },
+      );
+      const [postingsResult, activeResult, yearResult] =
+        parseTypesenseMultiSearchResults<JobPostingDoc>(batch, 3, {
+          expectHitsAt: [0],
+        });
 
       const postings = (postingsResult.hits ?? []).map(
-        (hit: JobPostingHit) => mapHitToPosting(hit, locationIds),
+        (hit) => mapHitToPosting(hit as JobPostingHit, locationIds),
       );
       const activeCount = activeResult.found;
       const yearCount = yearResult.found;

--- a/apps/web/src/lib/search/typesense.ts
+++ b/apps/web/src/lib/search/typesense.ts
@@ -23,7 +23,10 @@ import {
   resolveTypesenseCompany,
   type TypesenseCompanyDocument,
 } from "./typesense-company";
-import { parseTypesenseMultiSearchResults } from "./typesense-multi-search";
+import {
+  assertCompanyPostingPage,
+  parseTypesenseMultiSearchResults,
+} from "./typesense-multi-search";
 
 // ── Typesense document shapes ──────────────────────────────────────
 
@@ -663,6 +666,7 @@ export class TypesenseSearchProvider implements SearchProvider {
         parseTypesenseMultiSearchResults<JobPostingDoc>(batch, 3, {
           expectHitsAt: [0],
         });
+      assertCompanyPostingPage(postingsResult, { offset, limit });
 
       const postings = (postingsResult.hits ?? []).map(
         (hit) => mapHitToPosting(hit as JobPostingHit, locationIds),

--- a/docs/11-typesense.md
+++ b/docs/11-typesense.md
@@ -453,6 +453,11 @@ The web app can bypass the Vercel server-action proxy and call Typesense directl
 - **Scoped key endpoint** (`GET /api/typesense-key`): mints a Typesense scoped search key (HMAC-SHA256 + base64) from `TYPESENSE_BROWSER_PARENT_KEY`. The embed is `{ use_cache: true, expires_at: <Unix seconds> }`. `limit_hits` is intentionally **not** embedded because Typesense counts raw hits (not grouped rows) and would block normal anon traffic on `group_by company_id` with `group_limit 10`.
 - **TTL**: 10 min for every visitor because the search-only scope has no user-specific permissions. Browser memory plus `localStorage` reuse the key across reloads/tabs and refresh 30 s before expiry. The endpoint sets a Vercel-only 510 s `max-age` CDN TTL, leaving a 90 s validity margin on the oldest fresh cache hit. Do not use `s-maxage` here: Vercel may serve that response stale once while asynchronously revalidating, but the scoped key has a hard expiry.
 - **Browser provider**: `apps/web/src/lib/search/typesense-browser.ts` (postings/companies), `typesense-browser-typeahead.ts` (taxonomy suggest), `typesense-browser-watchlist.ts`. All thin -- no `typesense-js` runtime dependency in the browser bundle.
+- **Company posting batch**: one `multi_search` carries the ordered posting
+  page, active count, and one-year flow count. Both the browser provider and
+  server fallback reject missing or errored result slots as one failed batch;
+  a server transport retry replays the whole batch so visible postings and
+  counts always come from the same attempt.
 - **Anon truncation**: enforced as a soft client-side cap (`ANON_MAX_COMPANIES`, `ANON_MAX_POSTINGS`, `ANON_MAX_WATCHLIST_POSTINGS`) matching the current server-action behaviour. Real abuse protection is the Cloudflare per-IP rate-limit on the tunnel hostname.
 - **Fallback**: every runner falls back to the corresponding server action when the browser path errors, returns degraded, or hits a code-explicit fallback case (e.g. watchlist >100 companies).
 - **Search-bar application-data request budget**: direct mode batches candidate


### PR DESCRIPTION
Closes #8260

## Summary
- replace three independent posting/count searches with one ordered Typesense `multi_search` on both server and browser providers
- reject missing, malformed, or per-search-error result slots as one failed batch
- retry the whole server batch so postings and counts come from the same attempt
- document and test the one-request application-data budget

## Validation
- `pnpm --filter @jobseek/web exec vitest run src/lib/search/__tests__/typesense.test.ts` (17 tests)
- `pnpm --filter @jobseek/web exec tsc --noEmit`
- focused ESLint
- `pnpm --filter @jobseek/web test` (270 files / 2094 tests)
- `pnpm --filter @jobseek/web build`
- `pnpm --filter @jobseek/web check:bundle` (669.5 KB gzip)