### PR TITLE
Cache public API responses behind edge rate limiting

### DIFF
--- a/apps/web/app/api/v1/_shared.test.ts
+++ b/apps/web/app/api/v1/_shared.test.ts
@@ -119,11 +119,43 @@ describe("checkRateLimit — Redis bypass observability (#3175)", () => {
 });
 
 describe("apiResponse status contract (#3213)", () => {
-  it("uses 200 by default but honors explicit non-2xx status codes", async () => {
+  it("uses 200 by default, honors status codes, and is never cacheable", async () => {
     const { apiResponse } = await import("./_shared");
 
+    const response = apiResponse(
+      { error: "Bad request" },
+      {
+        rateLimit: { limit: 30, remaining: 29, reset: 12345 },
+        status: 400,
+      },
+    );
+
     expect(apiResponse({ ok: true }).status).toBe(200);
-    expect(apiResponse({ error: "Bad request" }, { status: 400 }).status).toBe(400);
+    expect(response.status).toBe(400);
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
+    expect(response.headers.get("Vercel-CDN-Cache-Control")).toBeNull();
+    expect(response.headers.get("X-RateLimit-Remaining")).toBe("29");
+  });
+
+  it("caches deterministic successes only at Vercel and omits caller metadata", async () => {
+    const { sharedApiResponse } = await import("./_shared");
+
+    const response = sharedApiResponse(
+      { ok: true },
+      { maxAge: 3600 },
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe(
+      "public, max-age=0, must-revalidate",
+    );
+    expect(response.headers.get("Vercel-CDN-Cache-Control")).toBe(
+      "public, max-age=3600",
+    );
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(response.headers.get("X-RateLimit-Limit")).toBeNull();
+    expect(response.headers.get("X-RateLimit-Remaining")).toBeNull();
+    expect(response.headers.get("X-RateLimit-Reset")).toBeNull();
   });
 });
 

--- a/apps/web/app/api/v1/_shared.ts
+++ b/apps/web/app/api/v1/_shared.ts
@@ -84,6 +84,19 @@ export function apiResponse(
   return NextResponse.json(data, { headers, status: options?.status });
 }
 
+/** Convert an upstream search failure into the shared public API contract. */
+export function apiProviderUnavailableResponse(
+  operation: string,
+  rateLimit: RateLimitInfo | null,
+  error: unknown,
+): NextResponse {
+  logExternalError("error", { service: "typesense", operation }, error);
+  return apiResponse(
+    { error: "Search service unavailable" },
+    { rateLimit, status: 500 },
+  );
+}
+
 /** Build a deterministic public JSON response cached only by Vercel's CDN.
  *
  * Browsers and downstream intermediaries must revalidate. Vercel consumes and

--- a/apps/web/app/api/v1/_shared.ts
+++ b/apps/web/app/api/v1/_shared.ts
@@ -16,7 +16,7 @@ import {
   SEARCH_WORK_MODE_VALUES,
 } from "@jseek/mcp-server/public-api-contract";
 
-/** Rate-limit result to thread through to apiResponse(). */
+/** Rate-limit result to thread through to non-cacheable API responses. */
 export type RateLimitInfo = { limit: number; remaining: number; reset: number };
 
 /** Check rate limit and return 429 response if exceeded. */
@@ -57,23 +57,22 @@ export async function checkRateLimit(
   return null;
 }
 
-/** Build a JSON response with standard API headers.
+/** Build a private JSON response with standard API headers.
  *
- * Public `/api/v1/*` contract errors should pass an explicit non-2xx status
- * so standard `response.ok` callers do not treat malformed requests as
- * successful empty payloads.
+ * Use this for contract errors, provider failures, rate limits, and any other
+ * caller-specific response. Successful deterministic GET responses must use
+ * `sharedApiResponse()` so per-client rate-limit metadata can never enter a
+ * shared cache.
  */
 export function apiResponse(
   data: unknown,
   options?: {
-    maxAge?: number;
     rateLimit?: RateLimitInfo | null;
     status?: number;
   },
 ): NextResponse {
-  const maxAge = options?.maxAge ?? CACHE_TTL_MEDIUM;
   const headers: Record<string, string> = {
-    "Cache-Control": `public, max-age=${maxAge}, s-maxage=${maxAge}`,
+    "Cache-Control": "no-store",
     "Access-Control-Allow-Origin": "*",
     "Access-Control-Allow-Methods": "GET",
   };
@@ -83,6 +82,29 @@ export function apiResponse(
     headers["X-RateLimit-Reset"] = String(options.rateLimit.reset);
   }
   return NextResponse.json(data, { headers, status: options?.status });
+}
+
+/** Build a deterministic public JSON response cached only by Vercel's CDN.
+ *
+ * Browsers and downstream intermediaries must revalidate. Vercel consumes and
+ * strips `Vercel-CDN-Cache-Control`, so the public response never advertises a
+ * reusable shared TTL or contains caller-specific rate-limit metadata. A
+ * pre-cache Vercel Firewall rule enforces the public API request budget even
+ * when this response is served without invoking the origin function.
+ */
+export function sharedApiResponse(
+  data: unknown,
+  options?: { maxAge?: number },
+): NextResponse {
+  const maxAge = options?.maxAge ?? CACHE_TTL_MEDIUM;
+  return NextResponse.json(data, {
+    headers: {
+      "Cache-Control": "public, max-age=0, must-revalidate",
+      "Vercel-CDN-Cache-Control": `public, max-age=${maxAge}`,
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET",
+    },
+  });
 }
 
 /** Parse and validate the response locale shared by every public v1 route. */
@@ -95,9 +117,8 @@ export function parseApiLocale(
 
   const response = apiResponse(
     { error: `Invalid 'locale' param. Supported: ${locales.join(", ")}` },
-    { maxAge: 0, rateLimit, status: 400 },
+    { rateLimit, status: 400 },
   );
-  response.headers.set("Cache-Control", "no-store");
   return response;
 }
 
@@ -120,9 +141,8 @@ export function validatePublicEnumListParam(
     {
       error: `Invalid '${name}' value(s): ${detail}. Supported: ${supported.join(", ")}`,
     },
-    { maxAge: 0, rateLimit, status: 400 },
+    { rateLimit, status: 400 },
   );
-  response.headers.set("Cache-Control", "no-store");
   return response;
 }
 
@@ -141,9 +161,8 @@ export function validateResolvedPublicFilters(
       {
         error: `Invalid '${name}' slug(s): ${values.join(", ")}. Use /api/v1/resolve for exact slugs.`,
       },
-      { maxAge: 0, rateLimit, status: 400 },
+      { rateLimit, status: 400 },
     );
-    response.headers.set("Cache-Control", "no-store");
     return response;
   }
   return null;

--- a/apps/web/app/api/v1/companies/route.test.ts
+++ b/apps/web/app/api/v1/companies/route.test.ts
@@ -13,7 +13,12 @@ vi.mock("@/lib/rate-limit", () => ({
 }));
 
 const mocks = vi.hoisted(() => ({
+  logExternalError: vi.fn(),
   suggestCompanies: vi.fn(),
+}));
+
+vi.mock("@/lib/safe-external-error", () => ({
+  logExternalError: mocks.logExternalError,
 }));
 
 vi.mock("@/lib/actions/company", () => ({
@@ -33,6 +38,7 @@ function makeReq(qs: string): NextRequest {
 
 describe("GET /api/v1/companies service boundary (#3331)", () => {
   beforeEach(() => {
+    mocks.logExternalError.mockReset();
     mocks.suggestCompanies.mockReset();
   });
 
@@ -76,7 +82,10 @@ describe("GET /api/v1/companies service boundary (#3331)", () => {
     };
 
     expect(res.status).toBe(200);
-    expect(mocks.suggestCompanies).toHaveBeenCalledWith({ query: "goo" });
+    expect(mocks.suggestCompanies).toHaveBeenCalledWith({
+      query: "goo",
+      failOnUnavailable: true,
+    });
     expect(body.companies).toEqual([
       {
         name: "Google",
@@ -85,5 +94,25 @@ describe("GET /api/v1/companies service boundary (#3331)", () => {
         url: "https://jseek.co/de/company/google",
       },
     ]);
+  });
+
+  it("returns a non-cacheable safe error when Typesense is unavailable", async () => {
+    const providerError = new Error("provider-internal-canary-do-not-expose");
+    mocks.suggestCompanies.mockRejectedValue(providerError);
+
+    const res = await GET(makeReq("?q=goo&locale=en"));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body).toEqual({ error: "Search service unavailable" });
+    expect(JSON.stringify(body)).not.toContain("provider-internal-canary");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Vercel-CDN-Cache-Control")).toBeNull();
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(mocks.logExternalError).toHaveBeenCalledWith(
+      "error",
+      { service: "typesense", operation: "public_api_companies" },
+      providerError,
+    );
   });
 });

--- a/apps/web/app/api/v1/companies/route.ts
+++ b/apps/web/app/api/v1/companies/route.ts
@@ -8,6 +8,7 @@ import { withPublicApiObservability } from "@/lib/public-api-observability";
 import {
   checkRateLimit,
   apiResponse,
+  apiProviderUnavailableResponse,
   sharedApiResponse,
   parseApiLocale,
   siteUrl,
@@ -31,7 +32,19 @@ async function handleGet(request: NextRequest) {
     );
   }
 
-  const results = await suggestCompanies({ query: q });
+  let results: Awaited<ReturnType<typeof suggestCompanies>>;
+  try {
+    results = await suggestCompanies({
+      query: q,
+      failOnUnavailable: true,
+    });
+  } catch (error) {
+    return apiProviderUnavailableResponse(
+      "public_api_companies",
+      rl,
+      error,
+    );
+  }
 
   const companies = results.slice(0, MAX_RESULTS).map((c) => ({
     name: c.name,

--- a/apps/web/app/api/v1/companies/route.ts
+++ b/apps/web/app/api/v1/companies/route.ts
@@ -8,6 +8,7 @@ import { withPublicApiObservability } from "@/lib/public-api-observability";
 import {
   checkRateLimit,
   apiResponse,
+  sharedApiResponse,
   parseApiLocale,
   siteUrl,
 } from "../_shared";
@@ -26,7 +27,7 @@ async function handleGet(request: NextRequest) {
   if (!q) {
     return apiResponse(
       { error: "Missing required 'q' param (company name query)" },
-      { maxAge: 0, status: 400 },
+      { status: 400 },
     );
   }
 
@@ -42,7 +43,7 @@ async function handleGet(request: NextRequest) {
   // Autocomplete suggestions are very stable (a single new company per few
   // days, slug shape never changes). Bumped from the 300s default to 1h
   // for higher CDN reuse on common queries — see issue #2644.
-  return apiResponse({ companies }, { maxAge: CACHE_TTL_LONG, rateLimit: rl });
+  return sharedApiResponse({ companies }, { maxAge: CACHE_TTL_LONG });
 }
 
 export const GET = withPublicApiObservability("companies", handleGet);

--- a/apps/web/app/api/v1/job/route.ts
+++ b/apps/web/app/api/v1/job/route.ts
@@ -5,6 +5,7 @@ import { withPublicApiObservability } from "@/lib/public-api-observability";
 import {
   checkRateLimit,
   apiResponse,
+  sharedApiResponse,
   parseApiLocale,
   siteUrl,
 } from "../_shared";
@@ -21,7 +22,7 @@ async function handleGet(request: NextRequest) {
   if (!id) {
     return apiResponse(
       { error: "Missing required parameter: id" },
-      { maxAge: 0, status: 400 },
+      { status: 400 },
     );
   }
 
@@ -30,11 +31,11 @@ async function handleGet(request: NextRequest) {
   if (!detail) {
     return apiResponse(
       { error: "Job posting not found" },
-      { maxAge: 0, status: 404 },
+      { status: 404 },
     );
   }
 
-  return apiResponse(
+  return sharedApiResponse(
     {
       id: detail.id,
       title: detail.title,
@@ -71,7 +72,6 @@ async function handleGet(request: NextRequest) {
       url: siteUrl(`/${locale}/company/${detail.company.slug}?show=${detail.id}`),
       firstSeenAt: detail.firstSeenAt,
     },
-    { rateLimit: rl },
   );
 }
 

--- a/apps/web/app/api/v1/resolve/route.test.ts
+++ b/apps/web/app/api/v1/resolve/route.test.ts
@@ -28,11 +28,16 @@ vi.mock("@/lib/rate-limit", () => ({
 }));
 
 const mocks = vi.hoisted(() => ({
+  logExternalError: vi.fn(),
   suggestIndustries: vi.fn(),
   suggestLocations: vi.fn(),
   suggestOccupations: vi.fn(),
   suggestSeniorities: vi.fn(),
   suggestTechnologies: vi.fn(),
+}));
+
+vi.mock("@/lib/safe-external-error", () => ({
+  logExternalError: mocks.logExternalError,
 }));
 
 vi.mock("@/lib/actions/company", () => ({
@@ -140,6 +145,7 @@ describe("GET /api/v1/resolve?type=industries (issue #3228)", () => {
     expect(mocks.suggestIndustries).toHaveBeenCalledWith({
       query: "tech",
       locale: "de",
+      failOnUnavailable: true,
     });
     expect(body.matches).toEqual([{ slug: "technologie", name: "Technologie" }]);
   });
@@ -188,6 +194,24 @@ describe("GET /api/v1/resolve?type=industries (issue #3228)", () => {
       expect(m.slug).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*$/);
     }
   });
+
+  it("returns a non-cacheable safe error when the resolver provider fails", async () => {
+    const providerError = new Error("provider-internal-canary-do-not-expose");
+    mocks.suggestIndustries.mockRejectedValue(providerError);
+
+    const { res, body } = await call("?type=industries&q=tech");
+
+    expect(res.status).toBe(500);
+    expect(body).toEqual({ error: "Search service unavailable" });
+    expect(JSON.stringify(body)).not.toContain("provider-internal-canary");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Vercel-CDN-Cache-Control")).toBeNull();
+    expect(mocks.logExternalError).toHaveBeenCalledWith(
+      "error",
+      { service: "typesense", operation: "public_api_resolve" },
+      providerError,
+    );
+  });
 });
 
 describe("GET /api/v1/resolve location service boundary (#3330)", () => {
@@ -212,6 +236,7 @@ describe("GET /api/v1/resolve location service boundary (#3330)", () => {
     expect(mocks.suggestLocations).toHaveBeenCalledWith({
       query: "zur",
       locale: "de",
+      failOnUnavailable: true,
     });
     expect(body.matches).toEqual([
       {
@@ -221,5 +246,30 @@ describe("GET /api/v1/resolve location service boundary (#3330)", () => {
         parentName: "Switzerland",
       },
     ]);
+  });
+});
+
+describe("GET /api/v1/resolve strict taxonomy reads (#8261)", () => {
+  beforeEach(() => {
+    mocks.suggestOccupations.mockReset();
+    mocks.suggestSeniorities.mockReset();
+    mocks.suggestTechnologies.mockReset();
+  });
+
+  it.each([
+    ["occupations", "suggestOccupations"],
+    ["seniority", "suggestSeniorities"],
+    ["technologies", "suggestTechnologies"],
+  ] as const)("opts %s into strict provider handling", async (type, mockName) => {
+    mocks[mockName].mockResolvedValue([{ slug: "example", name: "Example" }]);
+
+    const { res } = await call(`?type=${type}&q=example&locale=en`);
+
+    expect(res.status).toBe(200);
+    expect(mocks[mockName]).toHaveBeenCalledWith({
+      query: "example",
+      locale: "en",
+      failOnUnavailable: true,
+    });
   });
 });

--- a/apps/web/app/api/v1/resolve/route.ts
+++ b/apps/web/app/api/v1/resolve/route.ts
@@ -14,7 +14,12 @@ import { suggestIndustries } from "@/lib/services/company";
 import { CACHE_TTL_LONG } from "@/lib/cache-ttl";
 import { slugifyTitle } from "@/lib/watchlist-slug";
 import { withPublicApiObservability } from "@/lib/public-api-observability";
-import { checkRateLimit, apiResponse, parseApiLocale } from "../_shared";
+import {
+  checkRateLimit,
+  apiResponse,
+  sharedApiResponse,
+  parseApiLocale,
+} from "../_shared";
 
 const VALID_TYPES = [
   "locations",
@@ -39,14 +44,14 @@ async function handleGet(request: NextRequest) {
       {
         error: `Missing or invalid 'type' param. Valid: ${VALID_TYPES.join(", ")}`,
       },
-      { maxAge: 0, status: 400 },
+      { status: 400 },
     );
   }
 
   if (!q || q.trim().length < 2) {
     return apiResponse(
       { error: "Missing or too short 'q' param (min 2 chars)" },
-      { maxAge: 0, status: 400 },
+      { status: 400 },
     );
   }
 
@@ -100,13 +105,13 @@ async function handleGet(request: NextRequest) {
   // taxonomy collections change on a daily-deploy cadence at most. Bumped
   // from the 300s default to 1h for higher CDN reuse on common queries.
   // See issue #2644 + alignment with /api/v1/taxonomies which is already 1h.
-  return apiResponse(
+  return sharedApiResponse(
     {
       type,
       query: q,
       matches: matches.slice(0, 10),
     },
-    { maxAge: CACHE_TTL_LONG, rateLimit: rl },
+    { maxAge: CACHE_TTL_LONG },
   );
 }
 

--- a/apps/web/app/api/v1/resolve/route.ts
+++ b/apps/web/app/api/v1/resolve/route.ts
@@ -17,6 +17,7 @@ import { withPublicApiObservability } from "@/lib/public-api-observability";
 import {
   checkRateLimit,
   apiResponse,
+  apiProviderUnavailableResponse,
   sharedApiResponse,
   parseApiLocale,
 } from "../_shared";
@@ -57,48 +58,72 @@ async function handleGet(request: NextRequest) {
 
   let matches: { slug: string; name: string; type?: string; parentName?: string | null }[];
 
-  switch (type) {
-    case "locations": {
-      const data = await suggestLocations({ query: q, locale });
-      matches = data.map((l) => ({
-        slug: l.slug,
-        name: l.name,
-        type: l.type,
-        parentName: l.parentName,
-      }));
-      break;
+  try {
+    switch (type) {
+      case "locations": {
+        const data = await suggestLocations({
+          query: q,
+          locale,
+          failOnUnavailable: true,
+        });
+        matches = data.map((l) => ({
+          slug: l.slug,
+          name: l.name,
+          type: l.type,
+          parentName: l.parentName,
+        }));
+        break;
+      }
+      case "occupations": {
+        const data = await suggestOccupations({
+          query: q,
+          locale,
+          failOnUnavailable: true,
+        });
+        matches = data.map((o) => ({ slug: o.slug, name: o.name }));
+        break;
+      }
+      case "seniority": {
+        const data = await suggestSeniorities({
+          query: q,
+          locale,
+          failOnUnavailable: true,
+        });
+        matches = data.map((s) => ({ slug: s.slug, name: s.name }));
+        break;
+      }
+      case "technologies": {
+        const data = await suggestTechnologies({
+          query: q,
+          locale,
+          failOnUnavailable: true,
+        });
+        matches = data.map((t) => ({ slug: t.slug, name: t.name }));
+        break;
+      }
+      case "industries": {
+        // The `industry` table has no `slug` column today, but the response
+        // contract is uniform across taxonomies: callers expect `slug` to
+        // be a URL-stable slug-shaped string. Derive one from the localized
+        // display name with the same canonical slugifier the rest of the
+        // app uses, falling back to the numeric id if the name slugifies
+        // to empty (e.g., all-symbol pathological input). See issue #3228.
+        // Note: `/api/v1/search` does not currently accept an industry
+        // filter, so this is a response-shape fix; no roundtrip breakage.
+        const data = await suggestIndustries({
+          query: q,
+          locale,
+          failOnUnavailable: true,
+        });
+        matches = data.map((i) => ({
+          slug: slugifyTitle(i.name) || String(i.id),
+          name: i.name,
+        }));
+        break;
+      }
     }
-    case "occupations": {
-      const data = await suggestOccupations({ query: q, locale });
-      matches = data.map((o) => ({ slug: o.slug, name: o.name }));
-      break;
-    }
-    case "seniority": {
-      const data = await suggestSeniorities({ query: q, locale });
-      matches = data.map((s) => ({ slug: s.slug, name: s.name }));
-      break;
-    }
-    case "technologies": {
-      const data = await suggestTechnologies({ query: q, locale });
-      matches = data.map((t) => ({ slug: t.slug, name: t.name }));
-      break;
-    }
-    case "industries": {
-      // The `industry` table has no `slug` column today, but the response
-      // contract is uniform across taxonomies: callers expect `slug` to
-      // be a URL-stable slug-shaped string. Derive one from the localized
-      // display name with the same canonical slugifier the rest of the
-      // app uses, falling back to the numeric id if the name slugifies
-      // to empty (e.g., all-symbol pathological input). See issue #3228.
-      // Note: `/api/v1/search` does not currently accept an industry
-      // filter, so this is a response-shape fix; no roundtrip breakage.
-      const data = await suggestIndustries({ query: q, locale });
-      matches = data.map((i) => ({
-        slug: slugifyTitle(i.name) || String(i.id),
-        name: i.name,
-      }));
-      break;
-    }
+  } catch (error) {
+    return apiProviderUnavailableResponse("public_api_resolve", rl, error);
   }
 
   // Resolve responses (taxonomy/location autocomplete) are stable — the

--- a/apps/web/app/api/v1/search/route.test.ts
+++ b/apps/web/app/api/v1/search/route.test.ts
@@ -75,8 +75,24 @@ describe("GET /api/v1/search", () => {
   });
 
   it("defaults `languages` to `[]` (no filter) when `lang=` is absent", async () => {
+    mocks.apiLimit.mockResolvedValueOnce({
+      success: true,
+      limit: 30,
+      remaining: 29,
+      reset: Date.now() + 30_000,
+    });
     const { res } = await callRoute("?locale=en");
     expect(res.status).toBe(200);
+    expect(res.headers.get("Cache-Control")).toBe(
+      "public, max-age=0, must-revalidate",
+    );
+    expect(res.headers.get("Vercel-CDN-Cache-Control")).toBe(
+      "public, max-age=300",
+    );
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(res.headers.get("X-RateLimit-Limit")).toBeNull();
+    expect(res.headers.get("X-RateLimit-Remaining")).toBeNull();
+    expect(res.headers.get("X-RateLimit-Reset")).toBeNull();
     // No keywords → listTopCompanies path
     expect(mocks.listTopCompanies).toHaveBeenCalledTimes(1);
     const call = mocks.listTopCompanies.mock.calls[0][0];

--- a/apps/web/app/api/v1/search/route.test.ts
+++ b/apps/web/app/api/v1/search/route.test.ts
@@ -452,4 +452,24 @@ describe("GET /api/v1/search", () => {
       providerError,
     );
   });
+
+  it("does not cache a degraded search as a real empty result", async () => {
+    mocks.listTopCompanies.mockResolvedValueOnce({
+      companies: [],
+      totalCompanies: 0,
+      degraded: true,
+    });
+
+    const { res, body } = await callRoute("?locale=en");
+
+    expect(res.status).toBe(500);
+    expect(body).toEqual({ error: "Search service unavailable" });
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Vercel-CDN-Cache-Control")).toBeNull();
+    expect(mocks.logExternalError).toHaveBeenCalledWith(
+      "error",
+      { service: "typesense", operation: "public_api_search_degraded" },
+      expect.any(Error),
+    );
+  });
 });

--- a/apps/web/app/api/v1/search/route.ts
+++ b/apps/web/app/api/v1/search/route.ts
@@ -14,6 +14,7 @@ import { PUBLIC_SEARCH_QUERY_PARAMETERS } from "@jseek/mcp-server/public-api-con
 import {
   checkRateLimit,
   apiResponse,
+  sharedApiResponse,
   PUBLIC_EMPLOYMENT_TYPE_VALUES,
   PUBLIC_WORK_MODE_VALUES,
   parseApiLocale,
@@ -32,12 +33,7 @@ function searchErrorResponse(
   status: 400 | 500,
   rateLimit: RateLimitInfo | null,
 ) {
-  const response = apiResponse({ error }, { maxAge: 0, rateLimit, status });
-  // Search errors must never be stored by a browser or shared cache. This is
-  // stricter than merely setting max-age=0 and keeps a transient provider
-  // outage (or a malformed request) from becoming a cached API response.
-  response.headers.set("Cache-Control", "no-store");
-  return response;
+  return apiResponse({ error }, { rateLimit, status });
 }
 
 function parseIntegerRangeParam(
@@ -213,13 +209,12 @@ async function handleGet(request: NextRequest) {
     })),
   }));
 
-  return apiResponse(
+  return sharedApiResponse(
     {
       companies,
       totalCompanies: result.totalCompanies,
       moreAt: exploreUrl(sp, locale),
     },
-    { rateLimit: rl },
   );
 }
 

--- a/apps/web/app/api/v1/search/route.ts
+++ b/apps/web/app/api/v1/search/route.ts
@@ -8,12 +8,12 @@ import { type NextRequest, NextResponse } from "next/server";
 import { searchJobs, listTopCompanies } from "@/lib/services/search";
 import { parseSearchFilters } from "@/lib/services/search-input";
 import { parsePublicSearchLanguages } from "@/lib/search/language-param";
-import { logExternalError } from "@/lib/safe-external-error";
 import { withPublicApiObservability } from "@/lib/public-api-observability";
 import { PUBLIC_SEARCH_QUERY_PARAMETERS } from "@jseek/mcp-server/public-api-contract";
 import {
   checkRateLimit,
   apiResponse,
+  apiProviderUnavailableResponse,
   sharedApiResponse,
   PUBLIC_EMPLOYMENT_TYPE_VALUES,
   PUBLIC_WORK_MODE_VALUES,
@@ -135,12 +135,11 @@ async function handleGet(request: NextRequest) {
   try {
     parsed = await parseSearchFilters({ q, loc, occ, sen, tech, wm, etype, locale });
   } catch (error) {
-    logExternalError(
-      "error",
-      { service: "typesense", operation: "public_api_search" },
+    return apiProviderUnavailableResponse(
+      "public_api_search_filters",
+      rl,
       error,
     );
-    return searchErrorResponse("Search service unavailable", 500, rl);
   }
   const unresolved = validateResolvedPublicFilters(parsed, rl);
   if (unresolved) return unresolved;
@@ -185,12 +184,18 @@ async function handleGet(request: NextRequest) {
         ? await searchJobs({ keywords: parsed.keywords, ...searchParams })
         : await listTopCompanies(searchParams);
   } catch (error) {
-    logExternalError(
-      "error",
-      { service: "typesense", operation: "public_api_search" },
+    return apiProviderUnavailableResponse(
+      "public_api_search",
+      rl,
       error,
     );
-    return searchErrorResponse("Search service unavailable", 500, rl);
+  }
+  if (result.degraded) {
+    return apiProviderUnavailableResponse(
+      "public_api_search_degraded",
+      rl,
+      new Error("Search provider returned a degraded result"),
+    );
   }
 
   const companies = result.companies.slice(0, MAX_COMPANIES).map((c) => ({

--- a/apps/web/app/api/v1/taxonomies/route.test.ts
+++ b/apps/web/app/api/v1/taxonomies/route.test.ts
@@ -13,10 +13,15 @@ vi.mock("@/lib/rate-limit", () => ({
 }));
 
 const mocks = vi.hoisted(() => ({
+  logExternalError: vi.fn(),
   suggestIndustries: vi.fn(),
   getAllSeniorities: vi.fn(),
   getAllOccupationsGrouped: vi.fn(),
   getAllTechnologiesGrouped: vi.fn(),
+}));
+
+vi.mock("@/lib/safe-external-error", () => ({
+  logExternalError: mocks.logExternalError,
 }));
 
 vi.mock("@/lib/actions/company", () => ({
@@ -41,7 +46,11 @@ function makeReq(qs: string): NextRequest {
 
 describe("GET /api/v1/taxonomies industries service boundary (#3331)", () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    for (const mock of Object.values(mocks)) mock.mockReset();
+    mocks.suggestIndustries.mockResolvedValue([]);
+    mocks.getAllSeniorities.mockResolvedValue([]);
+    mocks.getAllOccupationsGrouped.mockResolvedValue([]);
+    mocks.getAllTechnologiesGrouped.mockResolvedValue([]);
   });
 
   it("returns 400 when the required `type` param is missing (#3213)", async () => {
@@ -85,6 +94,7 @@ describe("GET /api/v1/taxonomies industries service boundary (#3331)", () => {
     expect(mocks.suggestIndustries).toHaveBeenCalledWith({
       query: "",
       locale: "de",
+      failOnUnavailable: true,
     });
     expect(body).toEqual({
       type: "industries",
@@ -93,5 +103,35 @@ describe("GET /api/v1/taxonomies industries service boundary (#3331)", () => {
         { id: 42, name: "Financial Services" },
       ],
     });
+  });
+
+  it("returns a non-cacheable safe error when a taxonomy provider fails", async () => {
+    const providerError = new Error("provider-internal-canary-do-not-expose");
+    mocks.suggestIndustries.mockRejectedValue(providerError);
+
+    const res = await GET(makeReq("?type=industries&locale=en"));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body).toEqual({ error: "Search service unavailable" });
+    expect(JSON.stringify(body)).not.toContain("provider-internal-canary");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Vercel-CDN-Cache-Control")).toBeNull();
+    expect(mocks.logExternalError).toHaveBeenCalledWith(
+      "error",
+      { service: "typesense", operation: "public_api_taxonomies" },
+      providerError,
+    );
+  });
+
+  it.each([
+    ["seniority", "getAllSeniorities", ["en", undefined, { failOnUnavailable: true }]],
+    ["occupations", "getAllOccupationsGrouped", ["en", undefined, { failOnUnavailable: true }]],
+    ["technologies", "getAllTechnologiesGrouped", [undefined, { failOnUnavailable: true }]],
+  ] as const)("opts %s into strict provider handling", async (type, mockName, args) => {
+    const res = await GET(makeReq(`?type=${type}&locale=en`));
+
+    expect(res.status).toBe(200);
+    expect(mocks[mockName]).toHaveBeenCalledWith(...args);
   });
 });

--- a/apps/web/app/api/v1/taxonomies/route.ts
+++ b/apps/web/app/api/v1/taxonomies/route.ts
@@ -15,6 +15,7 @@ import { withPublicApiObservability } from "@/lib/public-api-observability";
 import {
   checkRateLimit,
   apiResponse,
+  apiProviderUnavailableResponse,
   sharedApiResponse,
   parseApiLocale,
 } from "../_shared";
@@ -39,27 +40,45 @@ async function handleGet(request: NextRequest) {
 
   let items: unknown;
 
-  switch (type) {
-    case "seniority": {
-      const data = await getAllSeniorities(locale);
-      items = data.map((s) => ({ slug: s.slug, name: s.name }));
-      break;
+  try {
+    switch (type) {
+      case "seniority": {
+        const data = await getAllSeniorities(locale, undefined, {
+          failOnUnavailable: true,
+        });
+        items = data.map((s) => ({ slug: s.slug, name: s.name }));
+        break;
+      }
+      case "occupations": {
+        const data = await getAllOccupationsGrouped(locale, undefined, {
+          failOnUnavailable: true,
+        });
+        items = data;
+        break;
+      }
+      case "technologies": {
+        const data = await getAllTechnologiesGrouped(undefined, {
+          failOnUnavailable: true,
+        });
+        items = data;
+        break;
+      }
+      case "industries": {
+        const data = await suggestIndustries({
+          query: "",
+          locale,
+          failOnUnavailable: true,
+        });
+        items = data.map((i) => ({ id: i.id, name: i.name }));
+        break;
+      }
     }
-    case "occupations": {
-      const data = await getAllOccupationsGrouped(locale);
-      items = data;
-      break;
-    }
-    case "technologies": {
-      const data = await getAllTechnologiesGrouped();
-      items = data;
-      break;
-    }
-    case "industries": {
-      const data = await suggestIndustries({ query: "", locale });
-      items = data.map((i) => ({ id: i.id, name: i.name }));
-      break;
-    }
+  } catch (error) {
+    return apiProviderUnavailableResponse(
+      "public_api_taxonomies",
+      rl,
+      error,
+    );
   }
 
   return sharedApiResponse({ type, items }, { maxAge: CACHE_TTL_LONG });

--- a/apps/web/app/api/v1/taxonomies/route.ts
+++ b/apps/web/app/api/v1/taxonomies/route.ts
@@ -12,7 +12,12 @@ import {
 import { suggestIndustries } from "@/lib/services/company";
 import { CACHE_TTL_LONG } from "@/lib/cache-ttl";
 import { withPublicApiObservability } from "@/lib/public-api-observability";
-import { checkRateLimit, apiResponse, parseApiLocale } from "../_shared";
+import {
+  checkRateLimit,
+  apiResponse,
+  sharedApiResponse,
+  parseApiLocale,
+} from "../_shared";
 
 const VALID_TYPES = ["seniority", "occupations", "technologies", "industries"] as const;
 
@@ -28,7 +33,7 @@ async function handleGet(request: NextRequest) {
   if (!type || !VALID_TYPES.includes(type)) {
     return apiResponse(
       { error: `Missing or invalid 'type' param. Valid: ${VALID_TYPES.join(", ")}` },
-      { maxAge: 0, status: 400 },
+      { status: 400 },
     );
   }
 
@@ -57,7 +62,7 @@ async function handleGet(request: NextRequest) {
     }
   }
 
-  return apiResponse({ type, items }, { maxAge: CACHE_TTL_LONG, rateLimit: rl });
+  return sharedApiResponse({ type, items }, { maxAge: CACHE_TTL_LONG });
 }
 
 export const GET = withPublicApiObservability("taxonomies", handleGet);

--- a/apps/web/app/api/v1/watchlist/create/route.test.ts
+++ b/apps/web/app/api/v1/watchlist/create/route.test.ts
@@ -13,9 +13,14 @@ vi.mock("@/lib/rate-limit", () => ({
 }));
 
 const mocks = vi.hoisted(() => ({
+  logExternalError: vi.fn(),
   parseSearchFilters: vi.fn(),
   searchJobs: vi.fn(),
   listTopCompanies: vi.fn(),
+}));
+
+vi.mock("@/lib/safe-external-error", () => ({
+  logExternalError: mocks.logExternalError,
 }));
 
 vi.mock("@/lib/services/search-input", () => ({
@@ -52,6 +57,7 @@ async function callRoute(qs: string) {
 
 describe("GET /api/v1/watchlist/create — filter params", () => {
   beforeEach(() => {
+    mocks.logExternalError.mockReset();
     mocks.parseSearchFilters.mockReset();
     mocks.parseSearchFilters.mockResolvedValue(emptyParsed);
     mocks.searchJobs.mockReset();
@@ -144,5 +150,49 @@ describe("GET /api/v1/watchlist/create — filter params", () => {
       matchingCompanies: 2,
       matchingJobs: 7,
     });
+  });
+
+  it("does not cache a degraded preview as a real empty result", async () => {
+    mocks.listTopCompanies.mockResolvedValue({
+      companies: [],
+      totalCompanies: 0,
+      degraded: true,
+    });
+
+    const { res, body } = await callRoute("?locale=en&title=Roles");
+
+    expect(res.status).toBe(500);
+    expect(body).toEqual({ error: "Search service unavailable" });
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Vercel-CDN-Cache-Control")).toBeNull();
+    expect(mocks.logExternalError).toHaveBeenCalledWith(
+      "error",
+      {
+        service: "typesense",
+        operation: "public_api_watchlist_create_degraded",
+      },
+      expect.any(Error),
+    );
+  });
+
+  it("returns a non-cacheable safe error when filter resolution fails", async () => {
+    const providerError = new Error("provider-internal-canary-do-not-expose");
+    mocks.parseSearchFilters.mockRejectedValue(providerError);
+
+    const { res, body } = await callRoute("?locale=en&title=Roles");
+
+    expect(res.status).toBe(500);
+    expect(body).toEqual({ error: "Search service unavailable" });
+    expect(JSON.stringify(body)).not.toContain("provider-internal-canary");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Vercel-CDN-Cache-Control")).toBeNull();
+    expect(mocks.logExternalError).toHaveBeenCalledWith(
+      "error",
+      {
+        service: "typesense",
+        operation: "public_api_watchlist_create_filters",
+      },
+      providerError,
+    );
   });
 });

--- a/apps/web/app/api/v1/watchlist/create/route.ts
+++ b/apps/web/app/api/v1/watchlist/create/route.ts
@@ -6,6 +6,7 @@ import { withPublicApiObservability } from "@/lib/public-api-observability";
 import {
   checkRateLimit,
   apiResponse,
+  apiProviderUnavailableResponse,
   sharedApiResponse,
   PUBLIC_EMPLOYMENT_TYPE_VALUES,
   PUBLIC_WORK_MODE_VALUES,
@@ -52,8 +53,18 @@ async function handleGet(request: NextRequest) {
     if (invalid) return invalid;
   }
 
-  // Resolve slugs to get matching counts for the preview
-  const parsed = await parseSearchFilters({ q, loc, occ, sen, tech, wm, etype, locale });
+  // Resolve slugs to get matching counts for the preview. Public API
+  // responses must not turn a provider outage into a cacheable empty preview.
+  let parsed: Awaited<ReturnType<typeof parseSearchFilters>>;
+  try {
+    parsed = await parseSearchFilters({ q, loc, occ, sen, tech, wm, etype, locale });
+  } catch (error) {
+    return apiProviderUnavailableResponse(
+      "public_api_watchlist_create_filters",
+      rl,
+      error,
+    );
+  }
   const unresolved = validateResolvedPublicFilters(parsed, rl);
   if (unresolved) return unresolved;
 
@@ -107,10 +118,26 @@ async function handleGet(request: NextRequest) {
   };
 
   // Get matching counts
-  const result =
-    parsed.keywords.length > 0
-      ? await searchJobs({ keywords: parsed.keywords, ...searchParams })
-      : await listTopCompanies(searchParams);
+  let result: Awaited<ReturnType<typeof listTopCompanies>>;
+  try {
+    result =
+      parsed.keywords.length > 0
+        ? await searchJobs({ keywords: parsed.keywords, ...searchParams })
+        : await listTopCompanies(searchParams);
+  } catch (error) {
+    return apiProviderUnavailableResponse(
+      "public_api_watchlist_create",
+      rl,
+      error,
+    );
+  }
+  if (result.degraded) {
+    return apiProviderUnavailableResponse(
+      "public_api_watchlist_create_degraded",
+      rl,
+      new Error("Search provider returned a degraded result"),
+    );
+  }
 
   const totalJobs = result.companies.reduce(
     (sum, c) => sum + c.activeMatches,

--- a/apps/web/app/api/v1/watchlist/create/route.ts
+++ b/apps/web/app/api/v1/watchlist/create/route.ts
@@ -6,6 +6,7 @@ import { withPublicApiObservability } from "@/lib/public-api-observability";
 import {
   checkRateLimit,
   apiResponse,
+  sharedApiResponse,
   PUBLIC_EMPLOYMENT_TYPE_VALUES,
   PUBLIC_WORK_MODE_VALUES,
   parseApiLocale,
@@ -26,7 +27,7 @@ async function handleGet(request: NextRequest) {
   if (!title) {
     return apiResponse(
       { error: "Missing required 'title' param" },
-      { maxAge: 0, status: 400 },
+      { status: 400 },
     );
   }
 
@@ -132,7 +133,7 @@ async function handleGet(request: NextRequest) {
   if (exp) createParams.set("exp", exp);
   if (companies) createParams.set("companies", companies);
 
-  return apiResponse(
+  return sharedApiResponse(
     {
       url: siteUrl(
         `/${locale}/watchlists?${createParams.toString()}`,
@@ -144,7 +145,6 @@ async function handleGet(request: NextRequest) {
         matchingJobs: totalJobs,
       },
     },
-    { rateLimit: rl },
   );
 }
 

--- a/apps/web/app/api/v1/watchlists/route.test.ts
+++ b/apps/web/app/api/v1/watchlists/route.test.ts
@@ -13,8 +13,13 @@ vi.mock("@/lib/rate-limit", () => ({
 }));
 
 const mocks = vi.hoisted(() => ({
+  logExternalError: vi.fn(),
   searchPublicWatchlists: vi.fn(),
   getPopularWatchlists: vi.fn(),
+}));
+
+vi.mock("@/lib/safe-external-error", () => ({
+  logExternalError: mocks.logExternalError,
 }));
 
 vi.mock("@/lib/services/watchlists", () => ({
@@ -31,6 +36,8 @@ function makeReq(qs: string): NextRequest {
 describe("GET /api/v1/watchlists locale contract (#6132)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.searchPublicWatchlists.mockResolvedValue({ watchlists: [], total: 0 });
+    mocks.getPopularWatchlists.mockResolvedValue({ watchlists: [], total: 0 });
   });
 
   it("rejects unsupported locales before querying or constructing links", async () => {
@@ -42,5 +49,37 @@ describe("GET /api/v1/watchlists locale contract (#6132)", () => {
     expect(body.error).toBe("Invalid 'locale' param. Supported: en, de, fr, it");
     expect(mocks.searchPublicWatchlists).not.toHaveBeenCalled();
     expect(mocks.getPopularWatchlists).not.toHaveBeenCalled();
+  });
+
+  it("requests strict provider handling for cacheable successes", async () => {
+    const res = await GET(makeReq("?q=engineering&locale=en"));
+
+    expect(res.status).toBe(200);
+    expect(mocks.searchPublicWatchlists).toHaveBeenCalledWith({
+      query: "engineering",
+      offset: 0,
+      limit: 10,
+      locale: "en",
+      failOnUnavailable: true,
+    });
+  });
+
+  it("returns a non-cacheable safe error when Typesense is unavailable", async () => {
+    const providerError = new Error("provider-internal-canary-do-not-expose");
+    mocks.getPopularWatchlists.mockRejectedValue(providerError);
+
+    const res = await GET(makeReq("?locale=en"));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body).toEqual({ error: "Search service unavailable" });
+    expect(JSON.stringify(body)).not.toContain("provider-internal-canary");
+    expect(res.headers.get("Cache-Control")).toBe("no-store");
+    expect(res.headers.get("Vercel-CDN-Cache-Control")).toBeNull();
+    expect(mocks.logExternalError).toHaveBeenCalledWith(
+      "error",
+      { service: "typesense", operation: "public_api_watchlists" },
+      providerError,
+    );
   });
 });

--- a/apps/web/app/api/v1/watchlists/route.ts
+++ b/apps/web/app/api/v1/watchlists/route.ts
@@ -5,7 +5,7 @@ import {
 } from "@/lib/services/watchlists";
 import {
   checkRateLimit,
-  apiResponse,
+  sharedApiResponse,
   parseApiLocale,
   siteUrl,
 } from "../_shared";
@@ -41,7 +41,7 @@ async function handleGet(request: NextRequest) {
     ),
   }));
 
-  return apiResponse({ watchlists }, { rateLimit: rl });
+  return sharedApiResponse({ watchlists });
 }
 
 export const GET = withPublicApiObservability("watchlists", handleGet);

--- a/apps/web/app/api/v1/watchlists/route.ts
+++ b/apps/web/app/api/v1/watchlists/route.ts
@@ -5,6 +5,7 @@ import {
 } from "@/lib/services/watchlists";
 import {
   checkRateLimit,
+  apiProviderUnavailableResponse,
   sharedApiResponse,
   parseApiLocale,
   siteUrl,
@@ -22,14 +23,29 @@ async function handleGet(request: NextRequest) {
   const locale = parseApiLocale(sp, rl);
   if (locale instanceof NextResponse) return locale;
 
-  const result = q
-    ? await searchPublicWatchlists({
-        query: q,
-        offset: 0,
-        limit: MAX_RESULTS,
-        locale,
-      })
-    : await getPopularWatchlists({ offset: 0, limit: MAX_RESULTS, locale });
+  let result: Awaited<ReturnType<typeof searchPublicWatchlists>>;
+  try {
+    result = q
+      ? await searchPublicWatchlists({
+          query: q,
+          offset: 0,
+          limit: MAX_RESULTS,
+          locale,
+          failOnUnavailable: true,
+        })
+      : await getPopularWatchlists({
+          offset: 0,
+          limit: MAX_RESULTS,
+          locale,
+          failOnUnavailable: true,
+        });
+  } catch (error) {
+    return apiProviderUnavailableResponse(
+      "public_api_watchlists",
+      rl,
+      error,
+    );
+  }
 
   const watchlists = result.watchlists.map((w) => ({
     title: w.title,

--- a/apps/web/docs/edge-requests.md
+++ b/apps/web/docs/edge-requests.md
@@ -545,20 +545,27 @@ These are the most common:
 
 ### API route compute
 
-External API routes run the same query logic as server actions but add
-rate-limit checks (1 Redis call) and response serialization:
+External API routes run the same query logic as server actions. A successful
+cache miss adds one origin Upstash rate-limit check and response serialization;
+successful cache hits skip the Function and origin Redis entirely but remain
+inside the pre-cache Vercel WAF budget:
 
-| Route | DB queries | Redis cache | Cache-Control | Est. duration |
-|-------|-----------|-------------|---------------|---------------|
-| `GET /api/v1/search` | 3-5 | 5min | `s-maxage=300` | 40-180ms |
-| `GET /api/v1/job` | 3 | 5min | `s-maxage=300` | 30-120ms |
-| `GET /api/v1/companies` | 1 | 10min | `max-age=600` | 15-60ms |
-| `GET /api/v1/taxonomies` | 1 | 1h | `max-age=3600` | 15-50ms |
-| `GET /api/v1/watchlists` | 2 + 2N | None | `max-age=300` | 40-200ms+ |
+| Route | Origin work on CDN miss | Vercel CDN TTL | Caller Cache-Control | Est. duration |
+|-------|-------------------------|----------------|----------------------|---------------|
+| `GET /api/v1/search` | Upstash + Typesense | 5min | revalidate | 40-180ms |
+| `GET /api/v1/job` | Upstash + Supabase/Typesense | 5min | revalidate | 30-120ms |
+| `GET /api/v1/companies` | Upstash + Typesense | 1h | revalidate | 15-60ms |
+| `GET /api/v1/resolve` | Upstash + Typesense | 1h | revalidate | 15-60ms |
+| `GET /api/v1/taxonomies` | Upstash + Typesense | 1h | revalidate | 15-50ms |
+| `GET /api/v1/watchlists` | Upstash + Typesense | 5min | revalidate | 40-200ms+ |
+| `GET /api/v1/watchlist/create` | Upstash + Typesense | 5min | revalidate | 40-180ms |
 | `POST /api/auth/*` | 1-5 | Session: 5min | None | 20-150ms |
 | `POST /api/stripe/webhook` | 1-2 | None | None | 15-60ms |
 
-The listed routes typically complete in under 500ms.
+The listed routes typically complete in under 500ms. Successful public GETs
+do not expose `X-RateLimit-*`, because those values are caller-specific and
+would be unsafe in a shared cache. Non-cacheable origin errors and 429s retain
+them.
 
 ### OG image compute
 

--- a/apps/web/docs/edge-requests/special-routes.md
+++ b/apps/web/docs/edge-requests/special-routes.md
@@ -84,12 +84,15 @@ Browsers may fetch this on first visit. If they do, they may also fetch:
 
 ## API Routes
 
-All API routes count as 1 edge request + 1 serverless function invocation per call.
+All API routes count as one edge request. Successful anonymous `/api/v1/*`
+GETs use the Vercel CDN; a cache hit skips the route Function and origin
+Upstash limiter but still passes through the pre-cache WAF rate-limit rule.
 
 | Route | Method | Typical caller |
 |-------|--------|----------------|
 | `/api/auth/[...all]` | * | Auth flows (sign-in, sign-up, OAuth, verify, etc.) |
 | `/api/v1/search` | GET | External API consumers, AI agents |
+| `/api/v1/job` | GET | External API consumers, AI agents |
 | `/api/v1/resolve` | GET | External API consumers |
 | `/api/v1/companies` | GET | External API consumers |
 | `/api/v1/taxonomies` | GET | External API consumers |
@@ -136,7 +139,8 @@ Auth sign-in/sign-up includes bcrypt password hashing (~50-100ms CPU), making
 it the most CPU-intensive per-request auth operation. Other listed functions
 typically complete under 500ms.
 
-API routes with `Cache-Control: s-maxage` headers (`/api/v1/search`, `/job`,
-`/companies`, `/taxonomies`) benefit from Vercel's edge cache — repeat
-identical requests within the TTL window hit CDN and skip the function
-entirely.
+Successful anonymous `/api/v1/*` GETs use
+`Cache-Control: public, max-age=0, must-revalidate` plus a Vercel-only CDN TTL.
+Repeat identical requests within that TTL hit the CDN and skip the Function.
+The Vercel header is stripped before the response reaches callers. Validation,
+provider, not-found, and rate-limit responses remain `no-store`.

--- a/apps/web/docs/public-read-abuse.md
+++ b/apps/web/docs/public-read-abuse.md
@@ -84,12 +84,14 @@ observation rule itself must not deny, challenge, bypass, or rate-limit public
 API traffic. The preceding rate-limit rule is the enforcement boundary.
 
 Open the live [API/MCP Firewall Traffic filter](https://vercel.com/viktor-shcherbakovs-projects/jobseek-web/firewall/traffic?filter=rule_log_public_api_and_mcp_traffic_w3Ii5m).
-Firewall Traffic observes requests at the Vercel edge, so its count includes
-CDN hits that never invoke an origin Function and requests denied by the WAF.
-Application events and Redis counters measure origin executions instead. Use
-the edge view for total ingress and enforcement; use origin metrics for
-handler status, latency, consumer attribution, and cost. Do not add the two
-counts together. A hosted MCP REST cache hit intentionally has no origin
+This trailing log rule counts matching requests that reach it, including CDN
+hits that never invoke an origin Function. Requests denied by the preceding
+rate-limit rule stop there and do not appear under this log-rule filter; inspect
+the combined rate-limit rule or the unfiltered Firewall Traffic view for those
+denials. Application events and Redis counters measure origin executions
+instead. Use the edge views for ingress and enforcement; use origin metrics for
+handler status, latency, consumer attribution, and cost. Do not add the counts
+together. A hosted MCP REST cache hit intentionally has no origin
 consumer-attribution event because the response is identical for every
 anonymous caller.
 
@@ -163,10 +165,12 @@ done
 ```
 
 Then select **Live** or **Past Hour** in the filtered Firewall Traffic view and
-confirm both controlled REST and MCP requests appear under
-`rule_log_public_api_and_mcp_traffic_w3Ii5m`. The log rule does not add a
-mitigation response header. After publication and verification,
-`vercel firewall diff --json` must report an empty `changes` array.
+confirm the allowed controlled REST and MCP requests appear under
+`rule_log_public_api_and_mcp_traffic_w3Ii5m`. Inspect any bounded-probe 403s
+under `rule_deny_public_read_server_action_bursts_SZRRK0` or in the unfiltered
+view. The log rule does not add a mitigation response header. After publication
+and verification, `vercel firewall diff --json` must report an empty `changes`
+array.
 
 ### Rollback constraints
 

--- a/apps/web/docs/public-read-abuse.md
+++ b/apps/web/docs/public-read-abuse.md
@@ -10,21 +10,32 @@ tokens and must never be treated as a security boundary.
 The controls are layered so a deployment or provider failure does not remove
 the whole boundary:
 
-1. **Vercel WAF** — production `POST` requests with a `Next-Action` header on
-   the four public read route shapes are rate-counted by authoritative IP.
-   Roll a new threshold out with the exceeded action set to `log`, review its
-   Firewall Traffic matches, then change the exceeded action to `rate_limit`
-   (HTTP 429). Match the header's existence, not a deployment-specific action
-   hash.
+1. **Vercel WAF** — one Hobby-plan rate-limit rule protects both production
+   `POST` requests with a `Next-Action` header on the four public read route
+   shapes and production `GET /api/v1/*` requests on `jseek.co`. The rule uses
+   one fixed 60 requests/minute budget keyed by authoritative IP and denies
+   excess requests before CDN lookup. The API group requires the exact host,
+   environment, method, and namespace; the Server Action groups match the
+   header's existence, not a deployment-specific action hash. The shared
+   budget is intentional because Hobby permits one rate-limit rule per
+   project. The pre-existing API/MCP log rule supplied the observation stage
+   before the API group was added.
 2. **Next.js Proxy** — the same route/header shapes use shared Upstash sliding
    windows of 30 requests/minute and 300 requests/hour per authoritative IP.
    A rejected request receives a non-cacheable 429 before the page action
    runs. Redis transport failures fail open and emit a sanitized
    `public_read.rate_limit_unavailable` event.
-3. **Action validation** — replayed pagination is limited to `limit <= 100`
+3. **Public REST origin** — every `/api/v1/*` cache miss still uses the
+   existing Upstash sliding window of 30 requests/minute per authoritative IP.
+   Cache hits do not invoke the route or Upstash, but they remain inside the
+   WAF's coarser 60/minute boundary. Contract errors, provider failures, and
+   origin 429s are `no-store` and may include caller-specific rate-limit
+   metadata. Successful deterministic GETs omit those headers and cache only
+   at Vercel via `Vercel-CDN-Cache-Control`.
+4. **Action validation** — replayed pagination is limited to `limit <= 100`
    and `offset <= 5000`; the application UI uses pages of 10-20. Server Action
    bodies are limited to 128 KB instead of Next's 1 MB default.
-4. **Anonymous result caps** — existing surface-specific result caps remain a
+5. **Anonymous result caps** — existing surface-specific result caps remain a
    product boundary, but they are not a substitute for request rate limits.
 
 The Proxy key comes from `x-real-ip`, falling back to the final
@@ -53,9 +64,13 @@ The final three-rule topology is:
    first OR group is the existing exploit-scanner path regex; the following
    groups preserve the selected company-bot match and the exact obsolete
    Explore `Next-Action` match from #7189.
-2. `rule_deny_public_read_server_action_bursts_SZRRK0` remains byte-for-byte
-   unchanged at position 2: 60 requests per 60 seconds, fixed window, keyed by
-   IP, with `deny` when exceeded.
+2. `rule_deny_public_read_server_action_bursts_SZRRK0`, displayed as
+   **Deny public read and API bursts**, remains at position 2. Its first two
+   OR groups preserve the public Server Action path/route conditions. Its
+   third group requires `environment = production`, `host = jseek.co`,
+   `method = GET`, and path regex `^/api/v1(?:/.*)?$`. All groups share the
+   existing 60 requests per 60 seconds fixed window keyed by IP, with `deny`
+   when exceeded.
 3. `rule_log_public_api_and_mcp_traffic_w3Ii5m` is last and remains an enabled
    `log` rule. Each OR group requires `environment = production` and
    `host = jseek.co`; the paths are either
@@ -64,15 +79,19 @@ The final three-rule topology is:
 The observation rule deliberately does not match preview deployments,
 deployment hostnames, other domains, `/mcp.json`, or the broader `/api/*`
 namespace. In particular, `/api/auth`, `/api/admin`, `/api/web`, and
-`/api/typesense-key` remain outside the rule. Keep the action `log`; this rule
-must not deny, challenge, bypass, or rate-limit public API traffic.
+`/api/typesense-key` remain outside the rule. Keep the action `log`; this
+observation rule itself must not deny, challenge, bypass, or rate-limit public
+API traffic. The preceding rate-limit rule is the enforcement boundary.
 
 Open the live [API/MCP Firewall Traffic filter](https://vercel.com/viktor-shcherbakovs-projects/jobseek-web/firewall/traffic?filter=rule_log_public_api_and_mcp_traffic_w3Ii5m).
 Firewall Traffic observes requests at the Vercel edge, so its count includes
-CDN hits that never invoke an origin Function. Application events and Redis
-counters measure origin executions instead. Use the edge view for total
-ingress and the origin metrics for handler status, latency, source, and cost
-attribution; do not add the two counts together.
+CDN hits that never invoke an origin Function and requests denied by the WAF.
+Application events and Redis counters measure origin executions instead. Use
+the edge view for total ingress and enforcement; use origin metrics for
+handler status, latency, consumer attribution, and cost. Do not add the two
+counts together. A hosted MCP REST cache hit intentionally has no origin
+consumer-attribution event because the response is identical for every
+anonymous caller.
 
 On Hobby, **Past Day is a rolling view, not durable history**. Record any
 needed result before it ages out, and do not infer a 7-day or 30-day trend from
@@ -82,7 +101,8 @@ produce matches.
 Immediately before any future publication, confirm that the machine-readable
 diff contains only the reviewed changes and that the two hostname-scoped IP
 blocks are unchanged. Publication is user/operator-only and must run from the
-linked repository root:
+linked repository root. Hobby permits three custom rules and one rate-limit
+rule, so extend the combined rule instead of attempting to add a fourth rule:
 
 ```bash
 vercel firewall diff --json
@@ -100,9 +120,9 @@ returned edge-denied 403s for the scanner, bot, and obsolete-action probes.
 Ordinary company, Explore, sign-in, REST, and MCP requests returned 200 after
 publication; excluded `/api/typesense-key` remained 200, while `/mcp.json` and
 `/api/v1foo` returned their normal unmitigated 404s. Reuse the bounded checks
-below after future WAF changes. Do not use the 61-request rate-limit probe for
-this topology; structural identity of the unchanged live rule is the approved
-verification.
+below after future WAF changes. Structural inspection remains sufficient when
+the combined rate-limit rule is unchanged. When its API group changes, wait
+for a clean fixed window and run the bounded repeated-cache probe once.
 
 ```bash
 # Existing deny branches: expect 403 and `x-vercel-mitigated: deny`.
@@ -127,10 +147,19 @@ curl -sS -X POST \
   --data-binary '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"waf-verification","version":"1.0"}}}' \
   -D - -o /dev/null https://jseek.co/mcp
 
-# The existing rate-limit rule must still be live and unchanged; inspect it.
+# The combined rate-limit rule must still be live and structurally exact.
 vercel firewall rules inspect \
   rule_deny_public_read_server_action_bursts_SZRRK0 --json
 vercel firewall diff --json
+
+# Only after changing the API group: warm one deterministic URL, wait for a
+# clean fixed window, then issue 61 identical GETs. At least one must be a WAF
+# denial and ordinary requests must recover after the next window. Do not run
+# this as routine monitoring.
+for _ in $(seq 1 61); do
+  curl -sS -o /dev/null -w '%{http_code}\n' \
+    'https://jseek.co/api/v1/search?q=python&wm=remote&locale=en&lang=en'
+done
 ```
 
 Then select **Live** or **Past Hour** in the filtered Firewall Traffic view and
@@ -140,6 +169,13 @@ mitigation response header. After publication and verification,
 `vercel firewall diff --json` must report an empty `changes` array.
 
 ### Rollback constraints
+
+To restore the pre-#8261 API enforcement while retaining the #8120 observation
+topology, remove only the third `/api/v1` OR group from
+`rule_deny_public_read_server_action_bursts_SZRRK0`, restore its prior name and
+description, and publish after reviewing the full diff. The two Server Action
+groups, rate-limit action, threshold, algorithm, key, and order must remain
+unchanged.
 
 To restore the pre-#8120 topology, first stage the reverse change: remove the
 API/MCP log rule, remove only the scanner OR group from the retained deny rule,

--- a/apps/web/public/api/openapi.json
+++ b/apps/web/public/api/openapi.json
@@ -96,37 +96,7 @@
             }
           },
           "403": { "$ref": "#/components/responses/EdgeRateLimited" },
-          "500": {
-            "description": "Search provider failure. The message is user-safe and contains no provider detail.",
-            "headers": {
-              "Cache-Control": {
-                "description": "Always ``no-store`` for error responses.",
-                "schema": { "type": "string", "const": "no-store" }
-              },
-              "Access-Control-Allow-Origin": {
-                "description": "Cross-origin access is permitted for public API clients.",
-                "schema": { "type": "string", "const": "*" }
-              },
-              "X-RateLimit-Limit": {
-                "description": "Request limit when the rate-limit backend is available.",
-                "schema": { "type": "integer" }
-              },
-              "X-RateLimit-Remaining": {
-                "description": "Remaining requests when the rate-limit backend is available.",
-                "schema": { "type": "integer" }
-              },
-              "X-RateLimit-Reset": {
-                "description": "Rate-limit reset time in Unix milliseconds when the backend is available.",
-                "schema": { "type": "integer" }
-              }
-            },
-            "content": {
-              "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" },
-                "example": { "error": "Search service unavailable" }
-              }
-            }
-          },
+          "500": { "$ref": "#/components/responses/ProviderUnavailable" },
           "429": {
             "description": "Rate limit exceeded. The response is not cacheable.",
             "headers": {
@@ -280,7 +250,8 @@
             }
           },
           "400": { "$ref": "#/components/responses/BadRequest" },
-          "403": { "$ref": "#/components/responses/EdgeRateLimited" }
+          "403": { "$ref": "#/components/responses/EdgeRateLimited" },
+          "500": { "$ref": "#/components/responses/ProviderUnavailable" }
         }
       }
     },
@@ -319,7 +290,8 @@
             }
           },
           "400": { "$ref": "#/components/responses/BadRequest" },
-          "403": { "$ref": "#/components/responses/EdgeRateLimited" }
+          "403": { "$ref": "#/components/responses/EdgeRateLimited" },
+          "500": { "$ref": "#/components/responses/ProviderUnavailable" }
         }
       }
     },
@@ -359,7 +331,8 @@
             }
           },
           "400": { "$ref": "#/components/responses/BadRequest" },
-          "403": { "$ref": "#/components/responses/EdgeRateLimited" }
+          "403": { "$ref": "#/components/responses/EdgeRateLimited" },
+          "500": { "$ref": "#/components/responses/ProviderUnavailable" }
         }
       }
     },
@@ -408,7 +381,8 @@
             }
           },
           "400": { "$ref": "#/components/responses/BadRequest" },
-          "403": { "$ref": "#/components/responses/EdgeRateLimited" }
+          "403": { "$ref": "#/components/responses/EdgeRateLimited" },
+          "500": { "$ref": "#/components/responses/ProviderUnavailable" }
         }
       }
     },
@@ -451,7 +425,8 @@
             }
           },
           "400": { "$ref": "#/components/responses/BadRequest" },
-          "403": { "$ref": "#/components/responses/EdgeRateLimited" }
+          "403": { "$ref": "#/components/responses/EdgeRateLimited" },
+          "500": { "$ref": "#/components/responses/ProviderUnavailable" }
         }
       }
     }
@@ -468,6 +443,37 @@
       },
       "EdgeRateLimited": {
         "description": "The pre-cache Vercel WAF denied this request because the authoritative IP exceeded the shared 60 requests per 60 seconds public-read budget. This response is generated before the application route; its body, CORS headers, and origin rate-limit headers are not part of the JSON API contract. Retry after the fixed window."
+      },
+      "ProviderUnavailable": {
+        "description": "Search provider failure. The message is user-safe, contains no provider detail, and is never cacheable.",
+        "headers": {
+          "Cache-Control": {
+            "description": "Always ``no-store`` for provider failure responses.",
+            "schema": { "type": "string", "const": "no-store" }
+          },
+          "Access-Control-Allow-Origin": {
+            "description": "Cross-origin access is permitted for public API clients.",
+            "schema": { "type": "string", "const": "*" }
+          },
+          "X-RateLimit-Limit": {
+            "description": "Request limit when the rate-limit backend is available.",
+            "schema": { "type": "integer" }
+          },
+          "X-RateLimit-Remaining": {
+            "description": "Remaining requests when the rate-limit backend is available.",
+            "schema": { "type": "integer" }
+          },
+          "X-RateLimit-Reset": {
+            "description": "Rate-limit reset time in Unix milliseconds when the backend is available.",
+            "schema": { "type": "integer" }
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/ErrorResponse" },
+            "example": { "error": "Search service unavailable" }
+          }
+        }
       }
     },
     "schemas": {

--- a/apps/web/public/api/openapi.json
+++ b/apps/web/public/api/openapi.json
@@ -2,8 +2,8 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Job Seek API",
-    "version": "1.1.0",
-    "description": "Public API for AI agents to search jobs, companies, watchlists, and taxonomies on jseek.co. Rate limited to 30 requests per minute per IP.\n\nIMPORTANT: Filter parameters (loc, occ, sen, tech) require exact slugs, NOT freetext. Use /api/v1/resolve to convert freetext to slugs first, or /api/v1/taxonomies to list all valid slugs. Passing freetext like loc=Zurich will NOT work — use loc=zurich (the slug)."
+    "version": "1.2.0",
+    "description": "Public API for AI agents to search jobs, companies, watchlists, and taxonomies on jseek.co. Anonymous GETs share a pre-cache edge budget of 60 requests per minute per IP with public-read Server Actions. Requests that execute an API origin additionally use a 30 requests per minute sliding limit. Successful deterministic responses may be served from Vercel's CDN; they omit caller-specific rate-limit headers. The edge may return HTTP 403 when its shared budget is exceeded, while the origin returns a non-cacheable HTTP 429 with reset metadata.\n\nIMPORTANT: Filter parameters (loc, occ, sen, tech) require exact slugs, NOT freetext. Use /api/v1/resolve to convert freetext to slugs first, or /api/v1/taxonomies to list all valid slugs. Passing freetext like loc=Zurich will NOT work — use loc=zurich (the slug)."
   },
   "servers": [{ "url": "https://jseek.co" }],
   "paths": {
@@ -95,6 +95,7 @@
               }
             }
           },
+          "403": { "$ref": "#/components/responses/EdgeRateLimited" },
           "500": {
             "description": "Search provider failure. The message is user-safe and contains no provider detail.",
             "headers": {
@@ -248,6 +249,7 @@
             }
           },
           "400": { "$ref": "#/components/responses/BadRequest" },
+          "403": { "$ref": "#/components/responses/EdgeRateLimited" },
           "404": { "description": "Job posting not found" },
           "429": { "description": "Rate limit exceeded" }
         }
@@ -277,7 +279,8 @@
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" }
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "403": { "$ref": "#/components/responses/EdgeRateLimited" }
         }
       }
     },
@@ -315,7 +318,8 @@
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" }
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "403": { "$ref": "#/components/responses/EdgeRateLimited" }
         }
       }
     },
@@ -354,7 +358,8 @@
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" }
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "403": { "$ref": "#/components/responses/EdgeRateLimited" }
         }
       }
     },
@@ -402,7 +407,8 @@
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" }
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "403": { "$ref": "#/components/responses/EdgeRateLimited" }
         }
       }
     },
@@ -444,7 +450,8 @@
               }
             }
           },
-          "400": { "$ref": "#/components/responses/BadRequest" }
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "403": { "$ref": "#/components/responses/EdgeRateLimited" }
         }
       }
     }
@@ -458,6 +465,9 @@
             "schema": { "$ref": "#/components/schemas/ErrorResponse" }
           }
         }
+      },
+      "EdgeRateLimited": {
+        "description": "The pre-cache Vercel WAF denied this request because the authoritative IP exceeded the shared 60 requests per 60 seconds public-read budget. This response is generated before the application route; its body, CORS headers, and origin rate-limit headers are not part of the JSON API contract. Retry after the fixed window."
       }
     },
     "schemas": {

--- a/apps/web/src/lib/__tests__/openapi-public-api-rate-limit-contract.test.ts
+++ b/apps/web/src/lib/__tests__/openapi-public-api-rate-limit-contract.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+type OpenApiOperation = {
+  responses?: Record<string, { $ref?: string }>;
+};
+
+type OpenApiDocument = {
+  info: { description: string; version: string };
+  paths: Record<string, { get?: OpenApiOperation }>;
+  components: { responses: Record<string, { description: string }> };
+};
+
+const spec = JSON.parse(
+  readFileSync(
+    resolve(__dirname, "../../../public/api/openapi.json"),
+    "utf8",
+  ),
+) as OpenApiDocument;
+
+const PUBLIC_GET_PATHS = [
+  "/api/v1/search",
+  "/api/v1/job",
+  "/api/v1/taxonomies",
+  "/api/v1/companies",
+  "/api/v1/watchlists",
+  "/api/v1/watchlist/create",
+  "/api/v1/resolve",
+] as const;
+
+describe("public API OpenAPI edge-rate-limit contract (#8261)", () => {
+  it("documents the two rate-limit layers and cache-safe success headers", () => {
+    expect(spec.info.version).toBe("1.2.0");
+    expect(spec.info.description).toContain("60 requests per minute");
+    expect(spec.info.description).toContain("30 requests per minute");
+    expect(spec.info.description).toContain(
+      "omit caller-specific rate-limit headers",
+    );
+  });
+
+  it("documents the pre-cache 403 on every public GET operation", () => {
+    for (const path of PUBLIC_GET_PATHS) {
+      expect(spec.paths[path]?.get?.responses?.["403"]).toEqual({
+        $ref: "#/components/responses/EdgeRateLimited",
+      });
+    }
+    expect(spec.components.responses.EdgeRateLimited?.description).toContain(
+      "generated before the application route",
+    );
+  });
+});

--- a/apps/web/src/lib/__tests__/openapi-public-api-rate-limit-contract.test.ts
+++ b/apps/web/src/lib/__tests__/openapi-public-api-rate-limit-contract.test.ts
@@ -29,6 +29,15 @@ const PUBLIC_GET_PATHS = [
   "/api/v1/resolve",
 ] as const;
 
+const PROVIDER_BACKED_GET_PATHS = [
+  "/api/v1/search",
+  "/api/v1/taxonomies",
+  "/api/v1/companies",
+  "/api/v1/watchlists",
+  "/api/v1/watchlist/create",
+  "/api/v1/resolve",
+] as const;
+
 describe("public API OpenAPI edge-rate-limit contract (#8261)", () => {
   it("documents the two rate-limit layers and cache-safe success headers", () => {
     expect(spec.info.version).toBe("1.2.0");
@@ -47,6 +56,17 @@ describe("public API OpenAPI edge-rate-limit contract (#8261)", () => {
     }
     expect(spec.components.responses.EdgeRateLimited?.description).toContain(
       "generated before the application route",
+    );
+  });
+
+  it("documents non-cacheable provider failures on provider-backed GETs", () => {
+    for (const path of PROVIDER_BACKED_GET_PATHS) {
+      expect(spec.paths[path]?.get?.responses?.["500"]).toEqual({
+        $ref: "#/components/responses/ProviderUnavailable",
+      });
+    }
+    expect(spec.components.responses.ProviderUnavailable?.description).toContain(
+      "never cacheable",
     );
   });
 });

--- a/apps/web/src/lib/cache-ttl.ts
+++ b/apps/web/src/lib/cache-ttl.ts
@@ -3,7 +3,7 @@
  *
  * Centralises the magic numbers previously scattered across `'use cache'`
  * + `cacheLife({ revalidate: N })`, Redis `cached(..., { ttl: N })`, and
- * API-route `apiResponse({ maxAge: N })` call sites. Changing a tier here
+ * API-route `sharedApiResponse({ maxAge: N })` call sites. Changing a tier here
  * propagates to every consumer instead of hunting individual literals.
  *
  * Buckets reflect the values already in use across `apps/web/`:
@@ -17,7 +17,7 @@
  * |                     |         | churn than freshly-created public lists)     |
  * | `CACHE_TTL_MEDIUM`  |  300    | Moderate churn (posting detail, company      |
  * |                     |         | postings, filtered watchlist counts,         |
- * |                     |         | default API `maxAge`)                        |
+ * |                     |         | default Vercel API CDN `maxAge`)             |
  * | `CACHE_TTL_DETAIL`        |   600   | Company detail page                          |
  * | `CACHE_TTL_EXPLORE_SHELL` | 86400   | Anonymous explore prerender; browser         |
  * |                           |         | Typesense refreshes it after hydration       |

--- a/apps/web/src/lib/public-api-observability.ts
+++ b/apps/web/src/lib/public-api-observability.ts
@@ -52,7 +52,8 @@ function consumerFor(request: NextRequest): PublicApiMetricInput["consumer"] {
 
 /**
  * Decorate a public REST GET handler with one post-response telemetry callback.
- * CDN cache hits do not execute this code and therefore are not represented.
+ * CDN cache hits and WAF-rejected requests do not execute this code and
+ * therefore are not represented.
  */
 export function withPublicApiObservability(
   route: PublicApiRestRoute,

--- a/apps/web/src/lib/services/__tests__/company-watchlist-search.test.ts
+++ b/apps/web/src/lib/services/__tests__/company-watchlist-search.test.ts
@@ -155,6 +155,16 @@ describe("suggestCompanies", () => {
     expect(mocks.dbExecute).not.toHaveBeenCalled();
   });
 
+  it("rethrows availability failures when a caller requires strict results", async () => {
+    const error = Object.assign(new Error("reset"), { code: "ECONNRESET" });
+    searchMock.mockRejectedValue(error);
+
+    await expect(
+      suggestCompanies({ query: "acme", failOnUnavailable: true }),
+    ).rejects.toBe(error);
+    expect(mocks.dbExecute).not.toHaveBeenCalled();
+  });
+
   it("does not hide non-availability Typesense errors", async () => {
     const error = Object.assign(new Error("Bad Request"), { httpStatus: 400 });
     searchMock.mockRejectedValue(error);

--- a/apps/web/src/lib/services/company.ts
+++ b/apps/web/src/lib/services/company.ts
@@ -41,6 +41,7 @@ export interface CompanySuggestion {
 
 export async function suggestCompanies(params: {
   query: string;
+  failOnUnavailable?: boolean;
 }): Promise<CompanySuggestion[]> {
   const q = params.query.trim().toLowerCase();
   if (q.length < 2) return [];
@@ -52,6 +53,7 @@ export async function suggestCompanies(params: {
     return await _queryCompanySuggestionsCached(q);
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
+    if (params.failOnUnavailable) throw err;
     return [];
   }
 }
@@ -405,11 +407,13 @@ export interface IndustrySuggestion {
 export async function suggestIndustries(params: {
   query?: string;
   locale: string;
+  failOnUnavailable?: boolean;
 }): Promise<IndustrySuggestion[]> {
   try {
     return await _suggestIndustries(params);
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
+    if (params.failOnUnavailable) throw err;
     logExternalError("error", { service: "typesense", operation: "suggest_industries" }, err);
     return [];
   }

--- a/apps/web/src/lib/services/locations.ts
+++ b/apps/web/src/lib/services/locations.ts
@@ -39,6 +39,7 @@ export async function suggestLocations(params: {
   userLat?: number;
   userLng?: number;
   filters?: TypeaheadBoostFilters;
+  failOnUnavailable?: boolean;
 }): Promise<LocationSuggestion[]> {
   const q = params.query.trim();
   if (q.length < 2) return [];
@@ -69,7 +70,8 @@ export async function suggestLocations(params: {
       bucketedLat,
       bucketedLng,
     );
-  } catch {
+  } catch (err) {
+    if (params.failOnUnavailable) throw err;
     suggestions = [];
   }
 

--- a/apps/web/src/lib/services/taxonomy.ts
+++ b/apps/web/src/lib/services/taxonomy.ts
@@ -38,6 +38,7 @@ export async function suggestOccupations(params: {
   query: string;
   locale: string;
   filters?: TypeaheadBoostFilters;
+  failOnUnavailable?: boolean;
 }): Promise<TaxonomySuggestion[]> {
   const q = params.query.trim();
   if (q.length < 2) return [];
@@ -51,7 +52,8 @@ export async function suggestOccupations(params: {
       q.toLowerCase(),
       params.locale,
     );
-  } catch {
+  } catch (err) {
+    if (params.failOnUnavailable) throw err;
     suggestions = [];
   }
   if (!params.filters) return suggestions;
@@ -138,6 +140,7 @@ export async function suggestSeniorities(params: {
   query: string;
   locale: string;
   filters?: TypeaheadBoostFilters;
+  failOnUnavailable?: boolean;
 }): Promise<TaxonomySuggestion[]> {
   const q = params.query.trim();
   if (q.length < 2) return [];
@@ -151,7 +154,8 @@ export async function suggestSeniorities(params: {
       q.toLowerCase(),
       params.locale,
     );
-  } catch {
+  } catch (err) {
+    if (params.failOnUnavailable) throw err;
     suggestions = [];
   }
   if (!params.filters) return suggestions;
@@ -237,6 +241,7 @@ export async function suggestTechnologies(params: {
   query: string;
   locale: string;
   filters?: TypeaheadBoostFilters;
+  failOnUnavailable?: boolean;
 }): Promise<TaxonomySuggestion[]> {
   const q = params.query.trim();
   if (q.length < 2) return [];
@@ -251,7 +256,8 @@ export async function suggestTechnologies(params: {
   let suggestions: TaxonomySuggestion[];
   try {
     suggestions = await _fetchTechnologySuggestionsCached(q.toLowerCase());
-  } catch {
+  } catch (err) {
+    if (params.failOnUnavailable) throw err;
     suggestions = [];
   }
   if (!params.filters) return suggestions;
@@ -587,6 +593,7 @@ export interface OccupationGroup {
 export async function getAllOccupationsGrouped(
   locale: string,
   filters?: { companyId?: string; keywords?: string[]; locationIds?: number[]; seniorityIds?: number[]; technologyIds?: number[]; languages?: string[] },
+  options: { failOnUnavailable?: boolean } = {},
 ): Promise<OccupationGroup[]> {
   // Stable cache key across array permutations — see #3187 and the helper
   // doc for the full rationale.
@@ -602,7 +609,9 @@ export async function getAllOccupationsGrouped(
       ttl: CACHE_TTL_LONG,
     });
   } catch (err) {
-    if (!isTypesenseUnavailableError(err)) throw sanitizeTypesenseBoundaryError(err);
+    if (options.failOnUnavailable || !isTypesenseUnavailableError(err)) {
+      throw sanitizeTypesenseBoundaryError(err);
+    }
     logExternalError(
       "error",
       { service: "typesense", operation: "all_occupations_grouped" },
@@ -943,6 +952,7 @@ export interface SeniorityOption {
 export async function getAllSeniorities(
   locale: string,
   filters?: { companyId?: string; keywords?: string[]; locationIds?: number[]; occupationIds?: number[]; technologyIds?: number[]; languages?: string[] },
+  options: { failOnUnavailable?: boolean } = {},
 ): Promise<SeniorityOption[]> {
   // Stable cache key across array permutations — see #3187.
   const fKey = filters ? JSON.stringify(canonicalizeFilters(filters)) : "";
@@ -952,7 +962,9 @@ export async function getAllSeniorities(
       ttl: CACHE_TTL_LONG,
     });
   } catch (err) {
-    if (!isTypesenseUnavailableError(err)) throw sanitizeTypesenseBoundaryError(err);
+    if (options.failOnUnavailable || !isTypesenseUnavailableError(err)) {
+      throw sanitizeTypesenseBoundaryError(err);
+    }
     logExternalError("error", { service: "typesense", operation: "all_seniorities" }, err);
     return [];
   }
@@ -1054,6 +1066,7 @@ export interface TechnologyGroup {
 
 export async function getAllTechnologiesGrouped(
   filters?: { companyId?: string; keywords?: string[]; locationIds?: number[]; occupationIds?: number[]; seniorityIds?: number[]; languages?: string[] },
+  options: { failOnUnavailable?: boolean } = {},
 ): Promise<TechnologyGroup[]> {
   // Stable cache key across array permutations — see #3187.
   const fKey = filters ? JSON.stringify(canonicalizeFilters(filters)) : "";
@@ -1063,7 +1076,9 @@ export async function getAllTechnologiesGrouped(
       ttl: CACHE_TTL_LONG,
     });
   } catch (err) {
-    if (!isTypesenseUnavailableError(err)) throw sanitizeTypesenseBoundaryError(err);
+    if (options.failOnUnavailable || !isTypesenseUnavailableError(err)) {
+      throw sanitizeTypesenseBoundaryError(err);
+    }
     logExternalError(
       "error",
       { service: "typesense", operation: "all_technologies_grouped" },

--- a/apps/web/src/lib/services/watchlists.ts
+++ b/apps/web/src/lib/services/watchlists.ts
@@ -1599,6 +1599,7 @@ export async function searchPublicWatchlists(params: {
   offset: number;
   limit: number;
   locale: string;
+  failOnUnavailable?: boolean;
 }): Promise<{ watchlists: PublicWatchlistEntry[]; total: number }> {
   const q = params.query.trim();
   if (!q) return { watchlists: [], total: 0 };
@@ -1627,6 +1628,7 @@ export async function searchPublicWatchlists(params: {
     );
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
+    if (params.failOnUnavailable) throw err;
     logExternalError("error", { service: "typesense", operation: "search_public_watchlists" }, err);
     return { watchlists: [], total: 0 };
   }
@@ -1636,6 +1638,7 @@ export async function getPopularWatchlists(params: {
   offset: number;
   limit: number;
   locale: string;
+  failOnUnavailable?: boolean;
 }): Promise<{ watchlists: PublicWatchlistEntry[]; total: number }> {
   const languages = await getViewerLanguages(params.locale);
   const langKey = languagesCacheKey(languages);
@@ -1658,6 +1661,7 @@ export async function getPopularWatchlists(params: {
     );
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
+    if (params.failOnUnavailable) throw err;
     logExternalError("error", { service: "typesense", operation: "popular_watchlists" }, err);
     return { watchlists: [], total: 0 };
   }

--- a/docs/07-system-design.md
+++ b/docs/07-system-design.md
@@ -536,6 +536,15 @@ Uses `@upstash/ratelimit` with sliding window algorithm backed by Upstash Redis.
 | `authLimiter`        | 60 seconds   | 10    | POST `/api/auth/[...all]`      |
 | `passwordResetLimiter` | 300 seconds | 3     | Password reset requests        |
 | `companyRequestLimiter` | 3600 seconds | 5    | Company request submissions    |
+| `apiLimiter`         | 60 seconds   | 30    | Origin executions of public `/api/v1/*` GETs |
+
+The public REST limiter is the defense-in-depth origin layer. Successful
+deterministic responses cache only on Vercel for 5 minutes or 1 hour, so CDN
+hits do not execute it. A production `jseek.co` WAF group matches
+`GET /api/v1/*` before CDN lookup and shares the project's existing fixed
+60/minute IP budget with public-read Server Actions. Hobby permits only one
+rate-limit rule per project. Errors and origin 429s are `no-store`; successful
+shared responses omit caller-specific `X-RateLimit-*` headers.
 
 ---
 
@@ -550,8 +559,10 @@ script/report-api-traffic.ts            # Operator 7/30/90-day report
 The public REST and MCP surfaces write privacy-bounded daily aggregates to
 the existing Upstash Redis database after the response has been produced.
 These counters measure **origin executions only**: Vercel CDN hits that never
-reach a Function and requests stopped by the WAF are absent. They complement,
-but do not replace, Vercel Firewall edge totals.
+reach a Function and requests stopped by the WAF are absent. Hosted MCP
+consumer attribution is likewise origin-only; a cached REST response is
+anonymous and records no consumer event. These counters complement, but do
+not replace, Vercel Firewall edge totals.
 
 Each request increments one canonical low-cardinality hash field containing
 only the enumerated interface, route, consumer class, status class, latency

--- a/packages/mcp-server/src/public-api-contract.ts
+++ b/packages/mcp-server/src/public-api-contract.ts
@@ -8,7 +8,7 @@ export const API_LOCALES = ["en", "de", "fr", "it"] as const;
 
 export const DEFAULT_API_LOCALE = API_LOCALES[0];
 
-export const PUBLIC_API_VERSION = "1.1.0";
+export const PUBLIC_API_VERSION = "1.2.0";
 
 export const PUBLIC_SEARCH_QUERY_PARAMETERS = [
   "q",


### PR DESCRIPTION
Closes #8261.

## Problem

Production already caches successful `/api/v1/*` GETs, but the shared response also contains caller-specific `X-RateLimit-*` values. A repeated `/api/v1/search` probe returned MISS then HIT with the first caller's stale remaining/reset values. The HIT also bypassed the origin Upstash limiter with no pre-cache public-API control.

## Change

- split private/non-shareable JSON responses from deterministic shared successes
- keep validation, provider, degraded, not-found, and origin 429 responses `no-store`, with CORS and caller rate-limit metadata where available
- opt public REST routes into strict Typesense handling so outage-shaped empty/degraded results cannot enter shared cache
- cache successful anonymous GETs only at Vercel using `Vercel-CDN-Cache-Control`
- make browsers and downstream intermediaries revalidate and omit `X-RateLimit-*` from shared responses
- apply the helper to search, job, companies, resolve, taxonomies, watchlists, and watchlist/create
- retain origin Upstash 30/min sliding enforcement and origin-only REST/MCP attribution
- publish OpenAPI v1.2 with the two rate-limit layers, cache-safe success contract, provider failures, and pre-cache 403 on all seven GET operations
- synchronize the MCP/public API contract version and document the edge/origin/cache contract and rollback procedure

## Unpublished Firewall draft

Vercel Hobby permits three custom rules and one rate-limit rule, so a fourth rule was rejected without staging. The reviewed draft instead modifies only `rule_deny_public_read_server_action_bursts_SZRRK0`:

- preserve position 2, enabled state, fixed-window algorithm, IP key, 60/60 threshold, and exceeded action `deny`
- preserve the existing two Server Action OR groups
- add one OR group requiring production + host `jseek.co` + GET + path regex `^/api/v1(?:/.*)?$`
- rename it to `Deny public read and API bursts` and update its description
- leave the first deny rule, trailing API/MCP log rule, and both hostname-scoped IP blocks unchanged

The Firewall change is staged but deliberately not published. It must be published by the operator before this PR merges.

## Validation

- 85 focused route/service/OpenAPI regression tests
- full web suite: 271 files / 2,121 tests
- web and MCP TypeScript
- focused ESLint and commit-hook ESLint
- MCP package build and contract verification
- production Next.js build
- bundle budget: 670.0 KB gzip
- `git diff --check`
- all required GitHub CI checks green

## Independent review

The critic found two issues in the first pass: degraded provider results could still be cached, and the Firewall log-rule documentation misattributed earlier denials. Both were fixed. Exact-head re-review at `e3721d69b5081d3d90aa585fa694126d48d3c3d2` is clean with no P0/P1/P2 findings.
