### PR TITLE
Enforce universal 10-watchlist backend cap

### DIFF
--- a/apps/web/src/lib/__tests__/watchlist-copy-policy.test.ts
+++ b/apps/web/src/lib/__tests__/watchlist-copy-policy.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { canCopyWatchlistSource } from "@/lib/watchlist-copy-policy";
+
+describe("watchlist copy source policy", () => {
+  it("allows an owner to duplicate a private watchlist", () => {
+    expect(canCopyWatchlistSource({
+      userId: "owner-1",
+      isPublic: false,
+    }, "owner-1")).toBe(true);
+  });
+
+  it("preserves cross-user copying for currently shareable public sources", () => {
+    expect(canCopyWatchlistSource({
+      userId: "owner-1",
+      isPublic: true,
+    }, "owner-2")).toBe(true);
+  });
+
+  it("does not infer cross-user access to a private source", () => {
+    expect(canCopyWatchlistSource({
+      userId: "owner-1",
+      isPublic: false,
+    }, "owner-2")).toBe(false);
+  });
+});

--- a/apps/web/src/lib/__tests__/watchlist-limit.test.ts
+++ b/apps/web/src/lib/__tests__/watchlist-limit.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import { PLAN_LIMITS } from "@/lib/plans";
+import {
+  createWithinWatchlistLimit,
+  MAX_WATCHLISTS_PER_ACCOUNT,
+  WatchlistLimitReachedError,
+} from "@/lib/watchlist-limit";
+
+class Mutex {
+  private tail = Promise.resolve();
+
+  async acquire(): Promise<() => void> {
+    const previous = this.tail;
+    let release!: () => void;
+    this.tail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    return release;
+  }
+}
+
+function accountHarness(initialOwned: number) {
+  const mutex = new Mutex();
+  let owned = initialOwned;
+
+  const transaction = async <T>(
+    callback: (tx: unknown) => Promise<T>,
+  ): Promise<T> => {
+    let release: (() => void) | undefined;
+    const tx = {
+      execute: async () => {
+        release = await mutex.acquire();
+        return [];
+      },
+      select: () => ({
+        from: () => ({
+          where: async () => [{ value: owned }],
+        }),
+      }),
+    };
+
+    try {
+      return await callback(tx);
+    } finally {
+      release?.();
+    }
+  };
+
+  const create = () => transaction((tx) =>
+    createWithinWatchlistLimit(tx as never, "user-1", async () => {
+      await Promise.resolve();
+      owned += 1;
+      return owned;
+    })
+  );
+
+  return {
+    create,
+    deleteOne: () => {
+      owned -= 1;
+    },
+    owned: () => owned,
+  };
+}
+
+describe("universal watchlist ownership policy (#8316)", () => {
+  it("uses the same 10-watchlist ceiling for Free and paid plans", () => {
+    expect(MAX_WATCHLISTS_PER_ACCOUNT).toBe(10);
+    expect(PLAN_LIMITS.free.maxWatchlists).toBe(10);
+    expect(PLAN_LIMITS.unlimited.maxWatchlists).toBe(10);
+  });
+
+  it("allows the tenth watchlist", async () => {
+    const account = accountHarness(9);
+
+    await expect(account.create()).resolves.toBe(10);
+    expect(account.owned()).toBe(10);
+  });
+
+  it("rejects a create when the account already owns exactly 10", async () => {
+    const account = accountHarness(10);
+
+    await expect(account.create()).rejects.toBeInstanceOf(
+      WatchlistLimitReachedError,
+    );
+    expect(account.owned()).toBe(10);
+  });
+
+  it("allows creation again after deletion takes the account below 10", async () => {
+    const account = accountHarness(10);
+    account.deleteOne();
+
+    await expect(account.create()).resolves.toBe(10);
+    expect(account.owned()).toBe(10);
+  });
+
+  it("serializes concurrent attempts so only one can claim the tenth slot", async () => {
+    const account = accountHarness(9);
+
+    const results = await Promise.allSettled([
+      account.create(),
+      account.create(),
+    ]);
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+    const rejection = results.find((result) => result.status === "rejected");
+    expect(rejection).toMatchObject({
+      status: "rejected",
+      reason: expect.any(WatchlistLimitReachedError),
+    });
+    expect(account.owned()).toBe(10);
+  });
+
+  it("does not mutate a grandfathered 16-watchlist account", async () => {
+    const account = accountHarness(16);
+
+    await expect(account.create()).rejects.toBeInstanceOf(
+      WatchlistLimitReachedError,
+    );
+    expect(account.owned()).toBe(16);
+  });
+
+  it("restores creation after a grandfathered account deletes below the cap", async () => {
+    const account = accountHarness(16);
+    for (let index = 0; index < 7; index += 1) account.deleteOne();
+
+    expect(account.owned()).toBe(9);
+    await expect(account.create()).resolves.toBe(10);
+  });
+});

--- a/apps/web/src/lib/actions/__tests__/watchlists-invalidation.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-invalidation.test.ts
@@ -95,6 +95,14 @@ vi.mock("@/lib/plans", () => ({
   getUserPlan: mocks.getUserPlan,
   PLAN_LIMITS: { free: { canReceiveAlerts: false }, paid: { canReceiveAlerts: true } },
 }));
+vi.mock("@/lib/watchlist-limit", () => ({
+  createWithinWatchlistLimit: async (
+    _tx: unknown,
+    _userId: string,
+    create: () => Promise<unknown>,
+  ) => create(),
+  WatchlistLimitReachedError: class WatchlistLimitReachedError extends Error {},
+}));
 
 vi.mock("@/lib/watchlist-slug", () => ({
   generateUniqueSlug: mocks.generateUniqueSlug,

--- a/apps/web/src/lib/actions/__tests__/watchlists-transactions.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-transactions.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => {
     description: string | null;
     isPublic: boolean;
     filters: Record<string, unknown>;
+    sourceWatchlistId?: string | null;
   };
   type CompanyRow = { watchlistId: string; companyId: string };
   type State = { watchlists: WatchlistRow[]; companies: CompanyRow[] };
@@ -51,9 +52,20 @@ const mocks = vi.hoisted(() => {
     companies: state.companies.map((row) => ({ ...row })),
   });
 
-  const makeSelect = (state: State, useRootQueue: boolean) => {
+  const makeSelect = (
+    state: State,
+    useRootQueue: boolean,
+    projection?: Record<string, unknown>,
+  ) => {
     let table: unknown;
     const rows = () => {
+      if (
+        projection
+        && "value" in projection
+        && (projection.value as { kind?: string }).kind === "count"
+      ) {
+        return [{ value: state.watchlists.filter((row) => row.userId === "user-1").length }];
+      }
       if (useRootQueue) return rootSelectRows.shift() ?? [];
       if (table === watchlistCompany) {
         return state.companies.map(({ companyId }) => ({ companyId }));
@@ -106,6 +118,7 @@ const mocks = vi.hoisted(() => {
           description: (value.description as string | null) ?? null,
           isPublic: Boolean(value.isPublic),
           filters: (value.filters as Record<string, unknown>) ?? {},
+          sourceWatchlistId: (value.sourceWatchlistId as string | null) ?? null,
         };
         state.watchlists.push(row);
         return [{ id: row.id }];
@@ -147,14 +160,15 @@ const mocks = vi.hoisted(() => {
   };
 
   const makeTx = (state: State) => ({
-    select: () => makeSelect(state, false),
+    execute: async () => [],
+    select: (projection?: Record<string, unknown>) => makeSelect(state, false, projection),
     insert: (table: unknown) => makeInsert(state, table),
     update: (table: unknown) => makeUpdate(state, table),
     delete: (table: unknown) => makeDelete(state, table),
   });
 
   const db = {
-    select: () => makeSelect(committed, true),
+    select: (projection?: Record<string, unknown>) => makeSelect(committed, true, projection),
     insert: () => {
       throw new Error("mutation escaped transaction");
     },
@@ -242,6 +256,7 @@ vi.mock("drizzle-orm", () => {
   const sql = (strings: TemplateStringsArray, ...values: unknown[]) => ({ strings, values });
   sql.join = (..._args: unknown[]) => ({ strings: [], values: [] });
   return {
+    count: () => ({ kind: "count" }),
     eq: (...args: unknown[]) => ({ kind: "eq", args }),
     and: (...args: unknown[]) => ({ kind: "and", args }),
     sql,
@@ -322,6 +337,76 @@ describe("#3114 — watchlist multi-table writes are atomic", () => {
     expect(mocks.afterFn).not.toHaveBeenCalled();
   });
 
+  it("rejects the 11th direct create inside the insert transaction", async () => {
+    mocks.setState({
+      watchlists: Array.from({ length: 10 }, (_, index) => ({
+        id: `wl-${index}`,
+        userId: USER_ID,
+        slug: `existing-${index}`,
+        title: `Existing ${index}`,
+        description: null,
+        isPublic: false,
+        filters: {},
+      })),
+      companies: [],
+    });
+
+    await expect(createWatchlist({
+      title: "Eleventh",
+      companyIds: [],
+    })).resolves.toEqual({ error: "limit_reached" });
+
+    expect(mocks.snapshot().watchlists).toHaveLength(10);
+    expect(mocks.calls).toEqual({ transactions: 1, rollbacks: 1 });
+    expect(mocks.afterFn).not.toHaveBeenCalled();
+  });
+
+  it("preserves a grandfathered 16-watchlist account while blocking create", async () => {
+    mocks.setState({
+      watchlists: Array.from({ length: 16 }, (_, index) => ({
+        id: `wl-${index}`,
+        userId: USER_ID,
+        slug: `existing-${index}`,
+        title: `Existing ${index}`,
+        description: null,
+        isPublic: false,
+        filters: {},
+      })),
+      companies: [],
+    });
+
+    await expect(createWatchlist({
+      title: "Seventeenth",
+      companyIds: [],
+    })).resolves.toEqual({ error: "limit_reached" });
+
+    expect(mocks.snapshot().watchlists).toHaveLength(16);
+    expect(mocks.calls).toEqual({ transactions: 1, rollbacks: 1 });
+    expect(mocks.afterFn).not.toHaveBeenCalled();
+  });
+
+  it("still permits edits for a grandfathered 16-watchlist account", async () => {
+    const existing = Array.from({ length: 16 }, (_, index) => ({
+      id: index === 0 ? WATCHLIST_ID : `wl-${index}`,
+      userId: USER_ID,
+      slug: `existing-${index}`,
+      title: `Existing ${index}`,
+      description: null,
+      isPublic: false,
+      filters: {},
+    }));
+    mocks.setState({ watchlists: existing, companies: [] });
+    mocks.queueRootSelect([{ ...existing[0] }]);
+
+    await expect(updateWatchlist({
+      watchlistId: WATCHLIST_ID,
+      description: "Still editable",
+    })).resolves.toEqual({ slug: "existing-0" });
+
+    expect(mocks.snapshot().watchlists).toHaveLength(16);
+    expect(mocks.snapshot().watchlists[0].description).toBe("Still editable");
+  });
+
   it("preserves metadata and company membership when replacement fails", async () => {
     const originalState = {
       watchlists: [{
@@ -375,6 +460,79 @@ describe("#3114 — watchlist multi-table writes are atomic", () => {
     expect(mocks.snapshot()).toEqual(originalState);
     expect(mocks.calls).toEqual({ transactions: 1, rollbacks: 1 });
     expect(mocks.afterFn).not.toHaveBeenCalled();
+  });
+
+  it("copies a cross-user public source when the destination has capacity", async () => {
+    const audit = vi.spyOn(console, "info").mockImplementation(() => {});
+    const source = {
+      id: WATCHLIST_ID,
+      userId: "source-owner",
+      slug: "source",
+      title: "Shared source",
+      description: null,
+      isPublic: true,
+      filters: {},
+    };
+    const destinationRows = Array.from({ length: 9 }, (_, index) => ({
+      id: `destination-${index}`,
+      userId: USER_ID,
+      slug: `destination-${index}`,
+      title: `Destination ${index}`,
+      description: null,
+      isPublic: false,
+      filters: {},
+    }));
+    mocks.setState({ watchlists: [source, ...destinationRows], companies: [] });
+    mocks.queueRootSelect([{ ...source }]);
+    mocks.setNextWatchlistId("wl-copy");
+
+    try {
+      await expect(copyWatchlist(WATCHLIST_ID)).resolves.toEqual({
+        id: "wl-copy",
+        slug: "shared-source",
+      });
+
+      const rows = mocks.snapshot().watchlists;
+      expect(rows.filter((row) => row.userId === USER_ID)).toHaveLength(10);
+      expect(rows).toContainEqual(expect.objectContaining({
+        id: "wl-copy",
+        userId: USER_ID,
+        title: "Shared source",
+        sourceWatchlistId: WATCHLIST_ID,
+      }));
+    } finally {
+      audit.mockRestore();
+    }
+  });
+
+  it("applies copy capacity to the destination owner, not the cross-user source", async () => {
+    const source = {
+      id: WATCHLIST_ID,
+      userId: "source-owner",
+      slug: "source",
+      title: "Shared source",
+      description: null,
+      isPublic: true,
+      filters: {},
+    };
+    const destinationRows = Array.from({ length: 10 }, (_, index) => ({
+      id: `destination-${index}`,
+      userId: USER_ID,
+      slug: `destination-${index}`,
+      title: `Destination ${index}`,
+      description: null,
+      isPublic: false,
+      filters: {},
+    }));
+    mocks.setState({ watchlists: [source, ...destinationRows], companies: [] });
+    mocks.queueRootSelect([{ ...source }]);
+
+    await expect(copyWatchlist(WATCHLIST_ID)).resolves.toEqual({
+      error: "limit_reached",
+    });
+
+    expect(mocks.snapshot().watchlists).toEqual([source, ...destinationRows]);
+    expect(mocks.calls).toEqual({ transactions: 1, rollbacks: 1 });
   });
 
   it("rechecks copy authorization inside the transaction", async () => {

--- a/apps/web/src/lib/plans.ts
+++ b/apps/web/src/lib/plans.ts
@@ -1,8 +1,12 @@
 import "server-only";
 
-import { eq, and, count } from "drizzle-orm";
+import { eq, and } from "drizzle-orm";
 import { db } from "@/db";
-import { subscription, watchlist } from "@/db/schema";
+import { subscription } from "@/db/schema";
+import {
+  canCreateWatchlist,
+  MAX_WATCHLISTS_PER_ACCOUNT,
+} from "@/lib/watchlist-limit";
 
 export type PlanId = "free" | "unlimited";
 
@@ -16,12 +20,12 @@ export const PLAN_LIMITS: Record<PlanId, PlanLimits> = {
   free: {
     maxAlerts: 0,
     canReceiveAlerts: false,
-    maxWatchlists: 1,
+    maxWatchlists: MAX_WATCHLISTS_PER_ACCOUNT,
   },
   unlimited: {
     maxAlerts: Number.MAX_SAFE_INTEGER,
     canReceiveAlerts: true,
-    maxWatchlists: Number.MAX_SAFE_INTEGER,
+    maxWatchlists: MAX_WATCHLISTS_PER_ACCOUNT,
   },
 };
 
@@ -35,20 +39,6 @@ export async function getUserPlan(userId: string): Promise<PlanId> {
   return (row?.plan as PlanId) ?? "free";
 }
 
-export async function canCreateWatchlist(
-  userId: string,
-): Promise<{ allowed: boolean; current: number; max: number }> {
-  const plan = await getUserPlan(userId);
-  const limits = PLAN_LIMITS[plan];
-
-  const [{ value: current }] = await db
-    .select({ value: count() })
-    .from(watchlist)
-    .where(eq(watchlist.userId, userId));
-
-  return {
-    allowed: current < limits.maxWatchlists,
-    current,
-    max: limits.maxWatchlists,
-  };
-}
+// Compatibility re-export for existing page-data consumers. The ownership
+// ceiling is account-wide domain policy, not a subscription entitlement.
+export { canCreateWatchlist };

--- a/apps/web/src/lib/services/__tests__/watchlist-handoff.test.ts
+++ b/apps/web/src/lib/services/__tests__/watchlist-handoff.test.ts
@@ -60,4 +60,14 @@ describe("createWatchlistFromHandoff", () => {
     }, mocks)).resolves.toEqual({ error: "invalid_companies" });
     expect(mocks.createWatchlist).not.toHaveBeenCalled();
   });
+
+  it("propagates the account-wide limit from the atomic create path", async () => {
+    mocks.getCompanyIdsBySlugs.mockResolvedValue(new Map());
+    mocks.createWatchlist.mockResolvedValue({ error: "limit_reached" });
+
+    await expect(createWatchlistFromHandoffWithDeps({
+      title: "Eleventh",
+      companySlugs: [],
+    }, mocks)).resolves.toEqual({ error: "limit_reached" });
+  });
 });

--- a/apps/web/src/lib/services/watchlists.ts
+++ b/apps/web/src/lib/services/watchlists.ts
@@ -21,6 +21,11 @@ import { withDbRetry } from "@/lib/db-retry";
 import { watchlistCacheTag } from "@/lib/cache-tags";
 import { canCreateWatchlist, getUserPlan, PLAN_LIMITS } from "@/lib/plans";
 import {
+  createWithinWatchlistLimit,
+  WatchlistLimitReachedError,
+} from "@/lib/watchlist-limit";
+import { canCopyWatchlistSource } from "@/lib/watchlist-copy-policy";
+import {
   generateUniqueSlug,
   insertWatchlistWithUniqueSlug,
 } from "@/lib/watchlist-slug";
@@ -237,9 +242,6 @@ export async function createWatchlist(params: {
   const userId = await getSessionUserId();
   if (!userId) throw new Error("Not authenticated");
 
-  const { allowed } = await canCreateWatchlist(userId);
-  if (!allowed) return { error: "limit_reached" };
-
   // Slug allocation is concurrency-safe: `insertWatchlistWithUniqueSlug`
   // wraps the INSERT in a retry loop that recovers from the SELECT-then-
   // INSERT race on `idx_wl_user_slug` (#3201). Two browser tabs (or a
@@ -251,35 +253,43 @@ export async function createWatchlist(params: {
   // its transaction in Postgres; allowing that transaction to reject
   // before the helper retries gives every slug candidate a fresh
   // transaction while keeping the parent + company rows atomic.
-  const { row, slug } = await insertWatchlistWithUniqueSlug(
+  const inserted = await insertWatchlistWithUniqueSlug(
     userId,
     params.title,
     async (candidate) =>
-      db.transaction(async (tx) => {
-        const [r] = await tx
-          .insert(watchlist)
-          .values({
-            userId,
-            slug: candidate,
-            title: params.title,
-            description: params.description ?? null,
-            isPublic: params.isPublic ?? false,
-            filters: { anyCompany: true, ...params.filters },
-          })
-          .returning({ id: watchlist.id });
+      db.transaction((tx) =>
+        createWithinWatchlistLimit(tx, userId, async () => {
+          const [r] = await tx
+            .insert(watchlist)
+            .values({
+              userId,
+              slug: candidate,
+              title: params.title,
+              description: params.description ?? null,
+              isPublic: params.isPublic ?? false,
+              filters: { anyCompany: true, ...params.filters },
+            })
+            .returning({ id: watchlist.id });
 
-        if (params.companyIds.length > 0) {
-          await tx.insert(watchlistCompany).values(
-            params.companyIds.map((companyId) => ({
-              watchlistId: r.id,
-              companyId,
-            })),
-          );
-        }
+          if (params.companyIds.length > 0) {
+            await tx.insert(watchlistCompany).values(
+              params.companyIds.map((companyId) => ({
+                watchlistId: r.id,
+                companyId,
+              })),
+            );
+          }
 
-        return r;
-      }),
-  );
+          return r;
+        }),
+      ),
+  ).catch((error: unknown) => {
+    if (error instanceof WatchlistLimitReachedError) return null;
+    throw error;
+  });
+
+  if (!inserted) return { error: "limit_reached" };
+  const { row, slug } = inserted;
 
   // Typesense + IndexNow hook: upsert if public and non-trivial.
   // Wrapped in after() so the registration is synchronous in the
@@ -404,6 +414,18 @@ export async function updateWatchlist(params: {
 
   if (Object.keys(updates).length > 0 || params.companyIds !== undefined) {
     await db.transaction(async (tx) => {
+      if (params.companyIds !== undefined) {
+        // Copy takes a shared lock on this row before reading company
+        // membership. Coordinate company-only edits with that lock so a copy
+        // observes one coherent source version under READ COMMITTED.
+        await tx
+          .select({ id: watchlist.id })
+          .from(watchlist)
+          .where(eq(watchlist.id, params.watchlistId))
+          .for("update")
+          .limit(1);
+      }
+
       if (Object.keys(updates).length > 0) {
         await tx
           .update(watchlist)
@@ -558,9 +580,6 @@ export async function copyWatchlist(
   const userId = await getSessionUserId();
   if (!userId) throw new Error("Not authenticated");
 
-  const { allowed } = await canCreateWatchlist(userId);
-  if (!allowed) return { error: "limit_reached" };
-
   const [source] = await db
     .select({
       title: watchlist.title,
@@ -573,8 +592,7 @@ export async function copyWatchlist(
     .where(eq(watchlist.id, watchlistId))
     .limit(1);
 
-  // Allow mirroring if public or owned by the user
-  if (!source || (!source.isPublic && source.userId !== userId)) {
+  if (!source || !canCopyWatchlistSource(source, userId)) {
     return { error: "not_found" };
   }
 
@@ -584,16 +602,16 @@ export async function copyWatchlist(
   // `idx_wl_user_slug` 23505. As in create, each retry attempt owns a
   // fresh transaction so a rejected candidate never poisons the next. Re-read
   // and authorize the source inside that transaction too: the first read is
-  // only a slug-allocation hint, while the repeatable-read snapshot supplies
-  // every field and company row that is actually copied.
+  // only a slug-allocation hint. The shared source-row lock coordinates with
+  // edits so the fields and company rows belong to one coherent version.
   let inserted;
   try {
     inserted = await insertWatchlistWithUniqueSlug(
       userId,
       source.title,
       async (candidate) =>
-        db.transaction(
-          async (tx) => {
+        db.transaction(async (tx) =>
+          createWithinWatchlistLimit(tx, userId, async () => {
             const [currentSource] = await tx
               .select({
                 title: watchlist.title,
@@ -609,7 +627,7 @@ export async function copyWatchlist(
 
             if (
               !currentSource
-              || (!currentSource.isPublic && currentSource.userId !== userId)
+              || !canCopyWatchlistSource(currentSource, userId)
             ) {
               throw new WatchlistCopySourceUnavailableError();
             }
@@ -645,13 +663,15 @@ export async function copyWatchlist(
             }
 
             return { row: r, companies };
-          },
-          { isolationLevel: "repeatable read" },
+          }),
         ),
     );
   } catch (error) {
     if (error instanceof WatchlistCopySourceUnavailableError) {
       return { error: "not_found" };
+    }
+    if (error instanceof WatchlistLimitReachedError) {
+      return { error: "limit_reached" };
     }
     throw error;
   }

--- a/apps/web/src/lib/watchlist-copy-policy.ts
+++ b/apps/web/src/lib/watchlist-copy-policy.ts
@@ -1,0 +1,13 @@
+/**
+ * Source-side authorization for watchlist copies.
+ *
+ * Keep this separate from destination capacity: future share grants and
+ * curated templates can extend this policy without bypassing the universal
+ * destination-owner limit enforced by the creation transaction.
+ */
+export function canCopyWatchlistSource(source: {
+  userId: string;
+  isPublic: boolean;
+}, destinationUserId: string): boolean {
+  return source.userId === destinationUserId || source.isPublic;
+}

--- a/apps/web/src/lib/watchlist-limit.ts
+++ b/apps/web/src/lib/watchlist-limit.ts
@@ -1,0 +1,66 @@
+import "server-only";
+
+import { count, eq, sql } from "drizzle-orm";
+import { db } from "@/db";
+import { watchlist } from "@/db/schema";
+
+export const MAX_WATCHLISTS_PER_ACCOUNT = 10;
+
+type WatchlistTransaction = Parameters<
+  Parameters<typeof db.transaction>[0]
+>[0];
+
+export class WatchlistLimitReachedError extends Error {
+  constructor() {
+    super("Watchlist ownership limit reached");
+    this.name = "WatchlistLimitReachedError";
+  }
+}
+
+/**
+ * Run a watchlist-creating mutation while holding the account's creation
+ * slot. The transaction-scoped advisory lock serializes all inserts for one
+ * owner, so the count and insert cannot race with another create/copy/handoff
+ * request. Callers must keep the callback and this helper in the same
+ * READ COMMITTED transaction.
+ */
+export async function createWithinWatchlistLimit<T>(
+  tx: WatchlistTransaction,
+  userId: string,
+  create: () => Promise<T>,
+): Promise<T> {
+  // hashtextextended gives the UUID/string account id a stable 64-bit lock
+  // key. The issue number is a namespace seed, preventing accidental reuse
+  // by unrelated account-scoped advisory locks.
+  await tx.execute(sql`
+    SELECT pg_advisory_xact_lock(
+      hashtextextended(${userId}, 8316::bigint)
+    )
+  `);
+
+  const [{ value: current }] = await tx
+    .select({ value: count() })
+    .from(watchlist)
+    .where(eq(watchlist.userId, userId));
+
+  if (current >= MAX_WATCHLISTS_PER_ACCOUNT) {
+    throw new WatchlistLimitReachedError();
+  }
+
+  return create();
+}
+
+export async function canCreateWatchlist(
+  userId: string,
+): Promise<{ allowed: boolean; current: number; max: number }> {
+  const [{ value: current }] = await db
+    .select({ value: count() })
+    .from(watchlist)
+    .where(eq(watchlist.userId, userId));
+
+  return {
+    allowed: current < MAX_WATCHLISTS_PER_ACCOUNT,
+    current,
+    max: MAX_WATCHLISTS_PER_ACCOUNT,
+  };
+}


### PR DESCRIPTION
## Summary

- define one account-wide limit of 10 watchlists for Free and paid accounts
- serialize destination-owner count + insert with a transaction-scoped advisory lock across direct create, saved-search create, handoff, and copy paths
- preserve grandfathered data and read/edit/delete behavior while blocking ownership-increasing writes at or above 10
- keep source authorization separate from destination capacity, preserving cross-user public copy/provenance today and an explicit seam for future grant/share/template authorization

## Scope

This is the backend capacity kernel for #8316 (also tracked by #8366). It intentionally does not change rendered UI, product copy, localization catalogs, pricing/FAQ/structured data, public-watchlist removal (#8348), notification behavior (#8317), AI behavior, or route/session-cookie state (#8368).

The human UI taste gate is not applicable to this PR because it contains no rendered UI or product-copy changes. No preview, screenshots, video, or taste approval are required for this backend-only slice; the gate remains active for the separate UI/product-truth PR.

## Verification

- `pnpm exec vitest run src/lib/__tests__/watchlist-limit.test.ts src/lib/__tests__/watchlist-copy-policy.test.ts src/lib/actions/__tests__/watchlists-transactions.test.ts src/lib/actions/__tests__/watchlists-invalidation.test.ts src/lib/services/__tests__/watchlist-handoff.test.ts` — 49 passed
- `pnpm typecheck` — passed
- targeted ESLint for all changed TypeScript files — passed
- full `pnpm exec vitest run` — 2,134 passed / 1 unrelated failure: the existing stale generated company Proxy matcher does not yet include `abercrombie`; the normal `pnpm test` wrapper regenerates that derived block first

## Backend cases covered

- Free and paid plans both resolve to 10
- tenth create succeeds; eleventh direct create is rejected in-transaction
- two concurrent attempts at 9 cannot produce an eleventh watchlist
- handoff propagates the same limit result
- owner/cross-user copy applies capacity to the destination and retains `sourceWatchlistId`
- the observed 16-watchlist grandfathered shape is preserved and editable; creation resumes only after deletion below the cap

Refs #8316