### PR TITLE
Add weekly notification persistence and policy foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -988,6 +988,14 @@ jobs:
           scripts/test-better-auth-account-issuer-pg17.ts
           --database-url "$AUTH_FIXTURE_DATABASE_URL"
 
+      - name: Execute notification policy migration against PostgreSQL 17
+        env:
+          NOTIFICATION_FIXTURE_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/jobseek_auth_fixture
+        run: >-
+          pnpm --filter @jobseek/web exec tsx
+          scripts/test-notification-policy-pg17.ts
+          --database-url "$NOTIFICATION_FIXTURE_DATABASE_URL"
+
   web-smoke:
     name: Web Build Smoke
     needs: changes

--- a/apps/web/drizzle/0088_notification_policy_foundation.sql
+++ b/apps/web/drizzle/0088_notification_policy_foundation.sql
@@ -121,7 +121,8 @@ CREATE TABLE public.notification_delivery (
   CONSTRAINT notification_delivery_skipped_check CHECK (
     status <> 'skipped'
     OR (
-      match_count = 0
+      match_count IS NOT NULL
+      AND match_count = 0
       AND provider_attempt_count = 0
       AND last_provider_attempt_at IS NULL
       AND provider_message_id IS NULL
@@ -129,7 +130,7 @@ CREATE TABLE public.notification_delivery (
   ),
   CONSTRAINT notification_delivery_sendable_match_check CHECK (
     status NOT IN ('sent', 'unknown', 'quota_deferred')
-    OR match_count > 0
+    OR (match_count IS NOT NULL AND match_count > 0)
   ),
   CONSTRAINT notification_delivery_provider_attempt_check CHECK (
     status NOT IN ('sent', 'unknown')

--- a/apps/web/drizzle/0088_notification_policy_foundation.sql
+++ b/apps/web/drizzle/0088_notification_policy_foundation.sql
@@ -1,0 +1,154 @@
+-- Backend-only notification persistence for #8317 / #8366.
+-- Existing and new alerts remain opt-in. Any legacy enabled row is floored at
+-- migration time so this additive migration cannot expose a historical digest.
+
+CREATE TYPE public.notification_cadence AS ENUM ('weekly');--> statement-breakpoint
+CREATE TYPE public.notification_delivery_status AS ENUM (
+  'pending',
+  'sent',
+  'skipped',
+  'failed',
+  'unknown',
+  'quota_deferred'
+);--> statement-breakpoint
+
+ALTER TABLE public.user_preferences
+  ADD COLUMN notification_cadence public.notification_cadence
+    DEFAULT 'weekly' NOT NULL,
+  ADD COLUMN notifications_paused boolean DEFAULT false NOT NULL,
+  ADD COLUMN notifications_state_changed_at timestamp with time zone
+    DEFAULT now() NOT NULL;--> statement-breakpoint
+
+-- Keep the floor coupled to the boolean even if a future writer updates the
+-- row outside the canonical service. Repeated writes preserve the old floor;
+-- a real transition without an explicit timestamp receives database time.
+CREATE FUNCTION public.jobseek_notifications_pause_state_changed_at()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $pause_state$
+BEGIN
+  IF NEW.notifications_paused IS NOT DISTINCT FROM OLD.notifications_paused THEN
+    NEW.notifications_state_changed_at := OLD.notifications_state_changed_at;
+  ELSIF NEW.notifications_state_changed_at
+    IS NOT DISTINCT FROM OLD.notifications_state_changed_at
+  THEN
+    NEW.notifications_state_changed_at := statement_timestamp();
+  END IF;
+  RETURN NEW;
+END
+$pause_state$;--> statement-breakpoint
+
+CREATE TRIGGER notifications_pause_state_changed_at_before_write
+BEFORE UPDATE OF notifications_paused, notifications_state_changed_at
+ON public.user_preferences
+FOR EACH ROW
+EXECUTE FUNCTION public.jobseek_notifications_pause_state_changed_at();--> statement-breakpoint
+
+ALTER TABLE public.watchlist
+  ADD COLUMN alerts_enabled_at timestamp with time zone;--> statement-breakpoint
+
+UPDATE public.watchlist
+SET alerts_enabled_at = statement_timestamp()
+WHERE alerts_enabled = true
+  AND alerts_enabled_at IS NULL;--> statement-breakpoint
+
+-- Keep the migration compatible with the pre-migration web runtime during a
+-- rolling deploy. Old code updates only alerts_enabled; the trigger supplies
+-- or clears the timestamp while new code can provide an exact enable time.
+CREATE FUNCTION public.jobseek_watchlist_alerts_enabled_at_compat()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $compat$
+BEGIN
+  IF NEW.alerts_enabled THEN
+    IF NEW.alerts_enabled_at IS NULL
+      OR (TG_OP = 'UPDATE' AND OLD.alerts_enabled = false)
+    THEN
+      NEW.alerts_enabled_at := statement_timestamp();
+    END IF;
+  ELSE
+    NEW.alerts_enabled_at := NULL;
+  END IF;
+  RETURN NEW;
+END
+$compat$;--> statement-breakpoint
+
+CREATE TRIGGER watchlist_alerts_enabled_at_compat_before_write
+BEFORE INSERT OR UPDATE OF alerts_enabled, alerts_enabled_at
+ON public.watchlist
+FOR EACH ROW
+EXECUTE FUNCTION public.jobseek_watchlist_alerts_enabled_at_compat();--> statement-breakpoint
+
+ALTER TABLE public.watchlist
+  ADD CONSTRAINT watchlist_alerts_enabled_at_check CHECK (
+    (alerts_enabled AND alerts_enabled_at IS NOT NULL)
+    OR (NOT alerts_enabled AND alerts_enabled_at IS NULL)
+  );--> statement-breakpoint
+
+CREATE TABLE public.notification_delivery (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  user_id text NOT NULL,
+  cadence public.notification_cadence NOT NULL,
+  scheduled_for timestamp with time zone NOT NULL,
+  window_start timestamp with time zone NOT NULL,
+  window_end timestamp with time zone NOT NULL,
+  status public.notification_delivery_status DEFAULT 'pending' NOT NULL,
+  match_count integer,
+  idempotency_key text NOT NULL,
+  provider_message_id text,
+  provider_attempt_count integer DEFAULT 0 NOT NULL,
+  last_provider_attempt_at timestamp with time zone,
+  last_error_code text,
+  deferred_until timestamp with time zone,
+  completed_at timestamp with time zone,
+  created_at timestamp with time zone DEFAULT now() NOT NULL,
+  updated_at timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT notification_delivery_user_id_user_id_fk
+    FOREIGN KEY (user_id) REFERENCES public."user"(id) ON DELETE CASCADE,
+  CONSTRAINT notification_delivery_window_check CHECK (
+    window_start < window_end AND window_end <= scheduled_for
+  ),
+  CONSTRAINT notification_delivery_match_count_check CHECK (
+    match_count IS NULL OR match_count >= 0
+  ),
+  CONSTRAINT notification_delivery_attempt_count_check CHECK (
+    provider_attempt_count >= 0
+  ),
+  CONSTRAINT notification_delivery_completion_check CHECK (
+    (status IN ('sent', 'skipped') AND completed_at IS NOT NULL)
+    OR (status NOT IN ('sent', 'skipped') AND completed_at IS NULL)
+  ),
+  CONSTRAINT notification_delivery_skipped_check CHECK (
+    status <> 'skipped'
+    OR (
+      match_count = 0
+      AND provider_attempt_count = 0
+      AND last_provider_attempt_at IS NULL
+      AND provider_message_id IS NULL
+    )
+  ),
+  CONSTRAINT notification_delivery_sendable_match_check CHECK (
+    status NOT IN ('sent', 'unknown', 'quota_deferred')
+    OR match_count > 0
+  ),
+  CONSTRAINT notification_delivery_provider_attempt_check CHECK (
+    status NOT IN ('sent', 'unknown')
+    OR (provider_attempt_count > 0 AND last_provider_attempt_at IS NOT NULL)
+  ),
+  CONSTRAINT notification_delivery_sent_provider_check CHECK (
+    status <> 'sent' OR NULLIF(BTRIM(provider_message_id), '') IS NOT NULL
+  ),
+  CONSTRAINT notification_delivery_deferred_check CHECK (
+    (status = 'quota_deferred' AND deferred_until IS NOT NULL)
+    OR (status <> 'quota_deferred' AND deferred_until IS NULL)
+  )
+);--> statement-breakpoint
+
+CREATE UNIQUE INDEX notification_delivery_period_uidx
+  ON public.notification_delivery (user_id, cadence, scheduled_for);--> statement-breakpoint
+CREATE UNIQUE INDEX notification_delivery_idempotency_key_uidx
+  ON public.notification_delivery (idempotency_key);--> statement-breakpoint
+CREATE INDEX notification_delivery_due_idx
+  ON public.notification_delivery (status, scheduled_for);--> statement-breakpoint
+CREATE INDEX notification_delivery_user_window_idx
+  ON public.notification_delivery (user_id, window_end);--> statement-breakpoint

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -533,6 +533,13 @@
       "when": 1787560116000,
       "tag": "0087_better_auth_account_issuer",
       "breakpoints": true
+    },
+    {
+      "idx": 76,
+      "version": "7",
+      "when": 1788199156000,
+      "tag": "0088_notification_policy_foundation",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/scripts/test-better-auth-account-issuer-pg17.ts
+++ b/apps/web/scripts/test-better-auth-account-issuer-pg17.ts
@@ -155,7 +155,7 @@ async function loadLedgerFixture(): Promise<{
   const migrations = readMigrationFiles({ migrationsFolder: migrationFolder });
 
   invariant(journal.entries.length === migrations.length, "Journal and SQL migration counts differ");
-  invariant(migrations.length === 76, `Expected 76 real journal migrations, found ${migrations.length}`);
+  invariant(migrations.length === 77, `Expected 77 real journal migrations, found ${migrations.length}`);
 
   const prerequisiteIndex = journal.entries.findIndex(
     (entry) => entry.tag === prerequisiteTag,

--- a/apps/web/scripts/test-job-posting-retirement-pg17.ts
+++ b/apps/web/scripts/test-job-posting-retirement-pg17.ts
@@ -106,7 +106,7 @@ async function loadLedgerFixture(): Promise<{
   const migrations = readMigrationFiles({ migrationsFolder: migrationFolder });
 
   invariant(journal.entries.length === migrations.length, "Journal and SQL migration counts differ");
-  invariant(migrations.length === 76, `Expected 76 real journal migrations, found ${migrations.length}`);
+  invariant(migrations.length === 77, `Expected 77 real journal migrations, found ${migrations.length}`);
 
   const retirementIndex = journal.entries.findIndex((entry) => entry.tag === retirementTag);
   invariant(retirementIndex !== -1, `Journal does not contain ${retirementTag}`);
@@ -115,7 +115,7 @@ async function loadLedgerFixture(): Promise<{
   const through0085 = migrations.slice(0, retirementIndex);
   const subsequent = migrations.slice(retirementIndex + 1);
   invariant(through0085.length === 74, "Expected 74 journal entries through 0085");
-  invariant(subsequent.length === 1, "Expected exactly one journal entry after 0086");
+  invariant(subsequent.length === 2, "Expected exactly two journal entries after 0086");
 
   // The production guard intentionally expects 75 ledger rows at the 0085
   // tip, one more than the current 74 journal entries through 0085. Model that
@@ -147,6 +147,23 @@ const baseFixtureSql = String.raw`
     account_id text NOT NULL,
     provider_id text NOT NULL,
     user_id text NOT NULL
+  );
+
+  CREATE TABLE public.user_preferences (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id text NOT NULL UNIQUE,
+    CONSTRAINT user_preferences_user_id_user_id_fk
+      FOREIGN KEY (user_id) REFERENCES public."user"(id)
+      ON DELETE CASCADE ON UPDATE NO ACTION
+  );
+
+  CREATE TABLE public.watchlist (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id text NOT NULL,
+    alerts_enabled boolean DEFAULT false NOT NULL,
+    CONSTRAINT watchlist_user_id_user_id_fk
+      FOREIGN KEY (user_id) REFERENCES public."user"(id)
+      ON DELETE CASCADE ON UPDATE NO ACTION
   );
 
   CREATE TABLE public.company (
@@ -609,8 +626,11 @@ async function runHarness(databaseUrl: string): Promise<void> {
     invariant(!afterSuccess.jobPostingPresent, "0086 did not remove public.job_posting");
     assertEqual(
       afterSuccess.publicTables,
-      beforeSuccess.publicTables.filter((table) => table !== "job_posting"),
-      "0086 changed a public table other than public.job_posting",
+      [
+        ...beforeSuccess.publicTables.filter((table) => table !== "job_posting"),
+        "notification_delivery",
+      ].sort(),
+      "0086 plus subsequent additive migrations changed unexpected public tables",
     );
     invariant(
       afterSuccess.savedJobDigest === beforeSuccess.savedJobDigest,
@@ -701,7 +721,11 @@ async function runHarness(databaseUrl: string): Promise<void> {
     );
     const restored = await captureProof(sql);
     invariant(!restored.jobPostingPresent, "Restore convergence recreated job_posting");
-    assertEqual(restored.publicTables, restoreShape.publicTables, "Restore convergence changed public tables");
+    assertEqual(
+      restored.publicTables,
+      [...restoreShape.publicTables, "notification_delivery"].sort(),
+      "Restore convergence changed unexpected public tables",
+    );
     invariant(
       restored.savedJobDigest === restoreShape.savedJobDigest &&
         restored.relationshipDigest === restoreShape.relationshipDigest &&

--- a/apps/web/scripts/test-notification-policy-pg17.ts
+++ b/apps/web/scripts/test-notification-policy-pg17.ts
@@ -1,0 +1,252 @@
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import postgres, { type Sql } from "postgres";
+
+const webRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const migrationPath = resolve(
+  webRoot,
+  "drizzle/0088_notification_policy_foundation.sql",
+);
+
+const constrainedStatuses = [
+  "skipped",
+  "sent",
+  "unknown",
+  "quota_deferred",
+] as const;
+
+type ConstrainedStatus = (typeof constrainedStatuses)[number];
+
+function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function parseDatabaseUrl(argv: string[]): string {
+  const flagIndex = argv.indexOf("--database-url");
+  if (flagIndex === -1 || !argv[flagIndex + 1]) {
+    throw new Error(
+      "Usage: tsx scripts/test-notification-policy-pg17.ts --database-url <disposable-postgresql-url>",
+    );
+  }
+  if (argv.indexOf("--database-url", flagIndex + 1) !== -1) {
+    throw new Error("--database-url must be supplied exactly once");
+  }
+
+  const rawUrl = argv[flagIndex + 1];
+  const parsed = new URL(rawUrl);
+  if (!/^postgres(?:ql)?:$/.test(parsed.protocol)) {
+    throw new Error("--database-url must use the postgres or postgresql protocol");
+  }
+
+  const databaseName = decodeURIComponent(parsed.pathname.replace(/^\//, ""));
+  if (["postgres", "template0", "template1"].includes(databaseName)) {
+    throw new Error("Refusing to use a PostgreSQL administrative database");
+  }
+  if (!/fixture/i.test(databaseName)) {
+    throw new Error(
+      "Refusing destructive fixture setup: disposable database name must contain 'fixture'",
+    );
+  }
+
+  return rawUrl;
+}
+
+async function resetFixture(sql: Sql): Promise<void> {
+  await sql.unsafe("DROP SCHEMA IF EXISTS public CASCADE");
+  await sql.unsafe("CREATE SCHEMA public");
+  await sql.unsafe(`
+    CREATE TABLE public."user" (
+      id text PRIMARY KEY,
+      name text NOT NULL
+    );
+    CREATE TABLE public.user_preferences (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id text NOT NULL UNIQUE REFERENCES public."user"(id) ON DELETE CASCADE
+    );
+    CREATE TABLE public.watchlist (
+      id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+      user_id text NOT NULL REFERENCES public."user"(id) ON DELETE CASCADE,
+      alerts_enabled boolean DEFAULT false NOT NULL
+    );
+    INSERT INTO public."user" (id, name)
+    VALUES ('notification-fixture-user', 'Notification Fixture User');
+  `);
+}
+
+async function applyRealMigration(sql: Sql): Promise<void> {
+  const migration = await readFile(migrationPath, "utf8");
+  const statements = migration
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter(Boolean);
+
+  invariant(statements.length > 0, "0088 migration contains no statements");
+  await sql.begin(async (transaction) => {
+    for (const statement of statements) {
+      await transaction.unsafe(statement);
+    }
+  });
+}
+
+function expectedConstraint(status: ConstrainedStatus): string {
+  return status === "skipped"
+    ? "notification_delivery_skipped_check"
+    : "notification_delivery_sendable_match_check";
+}
+
+async function insertDelivery(
+  sql: Sql,
+  status: ConstrainedStatus,
+  ordinal: number,
+  matchCount: number | null,
+): Promise<void> {
+  const scheduledFor = new Date(Date.UTC(2026, 8, 7 + ordinal, 8));
+  const windowEnd = new Date(scheduledFor.getTime() - 24 * 60 * 60 * 1_000);
+  const windowStart = new Date(scheduledFor.getTime() - 8 * 24 * 60 * 60 * 1_000);
+  const hasProviderAttempt = status === "sent" || status === "unknown";
+  const completedAt = status === "sent" || status === "skipped"
+    ? scheduledFor
+    : null;
+  const deferredUntil = status === "quota_deferred"
+    ? new Date(scheduledFor.getTime() + 24 * 60 * 60 * 1_000)
+    : null;
+  const idempotencyKey = [
+    "notification-fixture",
+    status,
+    matchCount === null ? "null" : "valid",
+  ].join(":");
+
+  await sql`
+    INSERT INTO public.notification_delivery (
+      user_id,
+      cadence,
+      scheduled_for,
+      window_start,
+      window_end,
+      status,
+      match_count,
+      idempotency_key,
+      provider_message_id,
+      provider_attempt_count,
+      last_provider_attempt_at,
+      deferred_until,
+      completed_at
+    ) VALUES (
+      'notification-fixture-user',
+      'weekly',
+      ${scheduledFor},
+      ${windowStart},
+      ${windowEnd},
+      ${status},
+      ${matchCount},
+      ${idempotencyKey},
+      ${status === "sent" ? `provider-${ordinal}` : null},
+      ${hasProviderAttempt ? 1 : 0},
+      ${hasProviderAttempt ? windowEnd : null},
+      ${deferredUntil},
+      ${completedAt}
+    )
+  `;
+}
+
+async function assertNullMatchRejected(
+  sql: Sql,
+  status: ConstrainedStatus,
+  ordinal: number,
+): Promise<void> {
+  try {
+    await insertDelivery(sql, status, ordinal, null);
+  } catch (error) {
+    const pgError = error as {
+      code?: string;
+      constraint_name?: string;
+    };
+    invariant(
+      pgError.code === "23514",
+      `${status}: expected PostgreSQL check violation, got ${String(pgError.code)}`,
+    );
+    invariant(
+      pgError.constraint_name === expectedConstraint(status),
+      `${status}: expected ${expectedConstraint(status)}, got ${String(pgError.constraint_name)}`,
+    );
+    return;
+  }
+
+  throw new Error(`${status}: NULL match_count unexpectedly passed its check`);
+}
+
+async function runHarness(databaseUrl: string): Promise<void> {
+  const sql = postgres(databaseUrl, {
+    max: 1,
+    prepare: false,
+    connect_timeout: 15,
+    connection: { application_name: "jobseek-notification-policy-pg17-fixture" },
+  });
+
+  try {
+    const [server] = await sql<{ version: number; databaseName: string }[]>`
+      SELECT
+        current_setting('server_version_num')::integer AS version,
+        current_database() AS "databaseName"
+    `;
+    invariant(server, "Could not read PostgreSQL server identity");
+    invariant(
+      server.version >= 170_000 && server.version < 180_000,
+      `Execution harness requires PostgreSQL 17, got server_version_num=${server.version}`,
+    );
+
+    const requestedDatabase = decodeURIComponent(
+      new URL(databaseUrl).pathname.replace(/^\//, ""),
+    );
+    invariant(
+      server.databaseName === requestedDatabase,
+      "Connected database does not match the explicitly supplied URL",
+    );
+
+    await resetFixture(sql);
+    await applyRealMigration(sql);
+
+    for (const [ordinal, status] of constrainedStatuses.entries()) {
+      await assertNullMatchRejected(sql, status, ordinal);
+      await insertDelivery(sql, status, ordinal, status === "skipped" ? 0 : 1);
+    }
+
+    const rows = await sql<{ status: ConstrainedStatus; matchCount: number }[]>`
+      SELECT status, match_count AS "matchCount"
+      FROM public.notification_delivery
+      ORDER BY status
+    `;
+    invariant(
+      rows.length === constrainedStatuses.length,
+      `Expected ${constrainedStatuses.length} valid delivery rows, found ${rows.length}`,
+    );
+    for (const row of rows) {
+      invariant(
+        row.matchCount === (row.status === "skipped" ? 0 : 1),
+        `${row.status}: valid match_count did not persist`,
+      );
+    }
+
+    console.log(
+      "PASS notification delivery NULL match_count guards and valid status shapes",
+    );
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+async function main(): Promise<void> {
+  const databaseUrl = parseDatabaseUrl(process.argv.slice(2));
+  await runHarness(databaseUrl);
+  console.log("PostgreSQL 17 notification policy execution harness passed.");
+}
+
+void main().catch((error: unknown) => {
+  const message = error instanceof Error
+    ? error.message
+    : "Unknown notification policy harness failure";
+  process.stderr.write(`${message}\n`);
+  process.exitCode = 1;
+});

--- a/apps/web/src/db/__tests__/better-auth-1-7-migration.test.ts
+++ b/apps/web/src/db/__tests__/better-auth-1-7-migration.test.ts
@@ -180,12 +180,16 @@ describe("0087 Better Auth account issuer migration", () => {
     );
   });
 
-  it("appends one monotonic journal entry", () => {
+  it("retains the exact 0087 journal identity", () => {
     const journal = JSON.parse(
       readFileSync(resolve(webRoot, "drizzle/meta/_journal.json"), "utf8"),
     ) as { entries: { idx: number; when: number; tag: string }[] };
 
-    expect(journal.entries.at(-1)).toEqual({
+    expect(
+      journal.entries.find(
+        (entry) => entry.tag === "0087_better_auth_account_issuer",
+      ),
+    ).toEqual({
       idx: 75,
       version: "7",
       when: 1_787_560_116_000,

--- a/apps/web/src/db/__tests__/job-posting-retirement-pg17-harness.test.ts
+++ b/apps/web/src/db/__tests__/job-posting-retirement-pg17-harness.test.ts
@@ -20,7 +20,7 @@ describe("PostgreSQL 17 job_posting retirement execution harness", () => {
 
   it("uses the real journal SQL hashes and the real migration runner", () => {
     expect(harness).toContain("readMigrationFiles({ migrationsFolder: migrationFolder })");
-    expect(harness).toContain("Expected 76 real journal migrations");
+    expect(harness).toContain("Expected 77 real journal migrations");
     expect(harness).toContain("const seed = [through0085[0], ...through0085]");
     expect(harness).toContain('resolve(webRoot, "src/db/migrate.ts")');
     expect(harness).toContain("spawn(process.execPath, [tsxRunner, migrationRunner]");

--- a/apps/web/src/db/__tests__/notification-policy-migration.test.ts
+++ b/apps/web/src/db/__tests__/notification-policy-migration.test.ts
@@ -8,6 +8,15 @@ const migration = readFileSync(
   resolve(webRoot, "drizzle/0088_notification_policy_foundation.sql"),
   "utf8",
 );
+const schema = readFileSync(resolve(webRoot, "src/db/schema.ts"), "utf8");
+const executionHarness = readFileSync(
+  resolve(webRoot, "scripts/test-notification-policy-pg17.ts"),
+  "utf8",
+);
+const ciWorkflow = readFileSync(
+  resolve(webRoot, "../../.github/workflows/ci.yml"),
+  "utf8",
+);
 
 describe("0088 notification policy foundation migration", () => {
   it("adds one extensible weekly cadence with conservative preference defaults", () => {
@@ -83,6 +92,43 @@ describe("0088 notification policy foundation migration", () => {
     );
     expect(migration).toContain("notification_delivery_sent_provider_check");
     expect(migration).toContain("notification_delivery_deferred_check");
+  });
+
+  it("requires concrete match counts in both migration and Drizzle constraints", () => {
+    const normalizedMigration = migration.replace(/\s+/g, " ");
+    const normalizedSchema = schema.replace(/\s+/g, " ");
+
+    expect(normalizedMigration).toContain(
+      "match_count IS NOT NULL AND match_count = 0",
+    );
+    expect(normalizedMigration).toContain(
+      "match_count IS NOT NULL AND match_count > 0",
+    );
+    expect(normalizedSchema).toContain(
+      '${table.matchCount} IS NOT NULL AND ${table.matchCount} = 0',
+    );
+    expect(normalizedSchema).toContain(
+      '${table.matchCount} IS NOT NULL AND ${table.matchCount} > 0',
+    );
+  });
+
+  it("runs the real migration and status matrix against PostgreSQL 17 in CI", () => {
+    expect(executionHarness).toContain(
+      '"drizzle/0088_notification_policy_foundation.sql"',
+    );
+    expect(executionHarness).toContain('pgError.code === "23514"');
+    expect(executionHarness).toContain(
+      '"notification_delivery_skipped_check"',
+    );
+    expect(executionHarness).toContain(
+      '"notification_delivery_sendable_match_check"',
+    );
+    for (const status of ["skipped", "sent", "unknown", "quota_deferred"]) {
+      expect(executionHarness).toContain(`"${status}"`);
+    }
+    expect(ciWorkflow).toContain(
+      "scripts/test-notification-policy-pg17.ts",
+    );
   });
 
   it("appends exactly one monotonic journal entry", () => {

--- a/apps/web/src/db/__tests__/notification-policy-migration.test.ts
+++ b/apps/web/src/db/__tests__/notification-policy-migration.test.ts
@@ -1,0 +1,104 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const webRoot = process.cwd();
+const migration = readFileSync(
+  resolve(webRoot, "drizzle/0088_notification_policy_foundation.sql"),
+  "utf8",
+);
+
+describe("0088 notification policy foundation migration", () => {
+  it("adds one extensible weekly cadence with conservative preference defaults", () => {
+    expect(migration).toContain(
+      "CREATE TYPE public.notification_cadence AS ENUM ('weekly')",
+    );
+    expect(migration).toMatch(
+      /notification_cadence public\.notification_cadence\s+DEFAULT 'weekly' NOT NULL/,
+    );
+    expect(migration).toContain(
+      "notifications_paused boolean DEFAULT false NOT NULL",
+    );
+    expect(migration).toMatch(
+      /notifications_state_changed_at timestamp with time zone\s+DEFAULT now\(\) NOT NULL/,
+    );
+    expect(migration).toContain(
+      "notifications_pause_state_changed_at_before_write",
+    );
+    expect(migration).toContain(
+      "NEW.notifications_paused IS NOT DISTINCT FROM OLD.notifications_paused",
+    );
+    expect(migration).toContain(
+      "NEW.notifications_state_changed_at := OLD.notifications_state_changed_at",
+    );
+  });
+
+  it("keeps alerts opt-in and floors every existing enabled interval", () => {
+    expect(migration).not.toMatch(/SET\s+alerts_enabled\s*=\s*true/i);
+    expect(migration).toContain(
+      "SET alerts_enabled_at = statement_timestamp()",
+    );
+    expect(migration).toContain("WHERE alerts_enabled = true");
+    expect(migration).toContain("watchlist_alerts_enabled_at_check");
+    expect(migration).toContain(
+      "BEFORE INSERT OR UPDATE OF alerts_enabled, alerts_enabled_at",
+    );
+    expect(migration).toContain(
+      "jobseek_watchlist_alerts_enabled_at_compat",
+    );
+  });
+
+  it("creates the durable ledger identity and privacy-safe user lifecycle", () => {
+    expect(migration).toContain("CREATE TABLE public.notification_delivery");
+    expect(migration).toContain(
+      "FOREIGN KEY (user_id) REFERENCES public.\"user\"(id) ON DELETE CASCADE",
+    );
+    expect(migration).toContain(
+      "ON public.notification_delivery (user_id, cadence, scheduled_for)",
+    );
+    expect(migration).toContain(
+      "ON public.notification_delivery (idempotency_key)",
+    );
+    for (const status of [
+      "pending",
+      "sent",
+      "skipped",
+      "failed",
+      "unknown",
+      "quota_deferred",
+    ]) {
+      expect(migration).toContain(`'${status}'`);
+    }
+  });
+
+  it("enforces window, completion, provider-attempt, and deferral shapes", () => {
+    expect(migration).toContain(
+      "window_start < window_end AND window_end <= scheduled_for",
+    );
+    expect(migration).toContain("notification_delivery_completion_check");
+    expect(migration).toContain("notification_delivery_skipped_check");
+    expect(migration).toContain(
+      "notification_delivery_provider_attempt_check",
+    );
+    expect(migration).toContain("notification_delivery_sent_provider_check");
+    expect(migration).toContain("notification_delivery_deferred_check");
+  });
+
+  it("appends exactly one monotonic journal entry", () => {
+    const journal = JSON.parse(
+      readFileSync(resolve(webRoot, "drizzle/meta/_journal.json"), "utf8"),
+    ) as { entries: { idx: number; when: number; tag: string }[] };
+
+    expect(journal.entries.at(-1)).toEqual({
+      idx: 76,
+      version: "7",
+      when: 1_788_199_156_000,
+      tag: "0088_notification_policy_foundation",
+      breakpoints: true,
+    });
+    expect(journal.entries.at(-2)?.when).toBeLessThan(
+      journal.entries.at(-1)?.when ?? 0,
+    );
+  });
+});

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -18,6 +18,10 @@ import {
   jsonb,
   type AnyPgColumn,
 } from "drizzle-orm/pg-core";
+import {
+  NOTIFICATION_CADENCE_VALUES,
+  NOTIFICATION_DELIVERY_STATUS_VALUES,
+} from "../lib/notifications/contracts";
 
 // ── Better Auth core tables ──────────────────────────────────────────
 
@@ -116,6 +120,16 @@ export const verification = pgTable(
 
 // ── User preferences (1:1 with user) ────────────────────────────────
 
+export const notificationCadenceEnum = pgEnum(
+  "notification_cadence",
+  NOTIFICATION_CADENCE_VALUES,
+);
+
+export const notificationDeliveryStatusEnum = pgEnum(
+  "notification_delivery_status",
+  NOTIFICATION_DELIVERY_STATUS_VALUES,
+);
+
 export const userPreferences = pgTable("user_preferences", {
   id: uuid("id").defaultRandom().primaryKey(),
   userId: text("user_id")
@@ -131,6 +145,18 @@ export const userPreferences = pgTable("user_preferences", {
   salaryPeriod: text("salary_period"),
   cookieConsent: boolean("cookie_consent").default(false).notNull(),
   dismissedBanners: text("dismissed_banners").array().notNull().default([]),
+  notificationCadence: notificationCadenceEnum("notification_cadence")
+    .default("weekly")
+    .notNull(),
+  notificationsPaused: boolean("notifications_paused")
+    .default(false)
+    .notNull(),
+  notificationsStateChangedAt: timestamp(
+    "notifications_state_changed_at",
+    { withTimezone: true },
+  )
+    .defaultNow()
+    .notNull(),
   themeUpdatedAt: timestamp("theme_updated_at", { withTimezone: true }),
   localeUpdatedAt: timestamp("locale_updated_at", { withTimezone: true }),
   lastPasswordResetAt: timestamp("last_password_reset_at", {
@@ -722,6 +748,7 @@ export const watchlist = pgTable(
     description: text("description"),
     isPublic: boolean("is_public").default(false).notNull(),
     alertsEnabled: boolean("alerts_enabled").default(false).notNull(),
+    alertsEnabledAt: timestamp("alerts_enabled_at", { withTimezone: true }),
     filters: jsonb("filters").default({}).notNull(),
     sourceWatchlistId: uuid("source_watchlist_id").references((): AnyPgColumn => watchlist.id, {
       onDelete: "set null",
@@ -743,6 +770,124 @@ export const watchlist = pgTable(
     index("idx_wl_public")
       .on(table.isPublic)
       .where(sql`is_public = true`),
+    check(
+      "watchlist_alerts_enabled_at_check",
+      sql`(${table.alertsEnabled} AND ${table.alertsEnabledAt} IS NOT NULL)
+        OR (NOT ${table.alertsEnabled} AND ${table.alertsEnabledAt} IS NULL)`,
+    ),
+  ],
+);
+
+export const notificationDelivery = pgTable(
+  "notification_delivery",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: text("user_id")
+      .notNull()
+      .references(() => user.id, { onDelete: "cascade" }),
+    cadence: notificationCadenceEnum("cadence").notNull(),
+    scheduledFor: timestamp("scheduled_for", { withTimezone: true }).notNull(),
+    windowStart: timestamp("window_start", { withTimezone: true }).notNull(),
+    windowEnd: timestamp("window_end", { withTimezone: true }).notNull(),
+    status: notificationDeliveryStatusEnum("status")
+      .default("pending")
+      .notNull(),
+    matchCount: integer("match_count"),
+    idempotencyKey: text("idempotency_key").notNull(),
+    providerMessageId: text("provider_message_id"),
+    providerAttemptCount: integer("provider_attempt_count")
+      .default(0)
+      .notNull(),
+    lastProviderAttemptAt: timestamp("last_provider_attempt_at", {
+      withTimezone: true,
+    }),
+    lastErrorCode: text("last_error_code"),
+    deferredUntil: timestamp("deferred_until", { withTimezone: true }),
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex("notification_delivery_period_uidx").on(
+      table.userId,
+      table.cadence,
+      table.scheduledFor,
+    ),
+    uniqueIndex("notification_delivery_idempotency_key_uidx").on(
+      table.idempotencyKey,
+    ),
+    index("notification_delivery_due_idx").on(
+      table.status,
+      table.scheduledFor,
+    ),
+    index("notification_delivery_user_window_idx").on(
+      table.userId,
+      table.windowEnd,
+    ),
+    check(
+      "notification_delivery_window_check",
+      sql`${table.windowStart} < ${table.windowEnd}
+        AND ${table.windowEnd} <= ${table.scheduledFor}`,
+    ),
+    check(
+      "notification_delivery_match_count_check",
+      sql`${table.matchCount} IS NULL OR ${table.matchCount} >= 0`,
+    ),
+    check(
+      "notification_delivery_attempt_count_check",
+      sql`${table.providerAttemptCount} >= 0`,
+    ),
+    check(
+      "notification_delivery_completion_check",
+      sql`(
+          ${table.status} IN ('sent', 'skipped')
+          AND ${table.completedAt} IS NOT NULL
+        ) OR (
+          ${table.status} NOT IN ('sent', 'skipped')
+          AND ${table.completedAt} IS NULL
+        )`,
+    ),
+    check(
+      "notification_delivery_skipped_check",
+      sql`${table.status} <> 'skipped' OR (
+        ${table.matchCount} = 0
+        AND ${table.providerAttemptCount} = 0
+        AND ${table.lastProviderAttemptAt} IS NULL
+        AND ${table.providerMessageId} IS NULL
+      )`,
+    ),
+    check(
+      "notification_delivery_sendable_match_check",
+      sql`${table.status} NOT IN ('sent', 'unknown', 'quota_deferred')
+        OR ${table.matchCount} > 0`,
+    ),
+    check(
+      "notification_delivery_provider_attempt_check",
+      sql`${table.status} NOT IN ('sent', 'unknown') OR (
+        ${table.providerAttemptCount} > 0
+        AND ${table.lastProviderAttemptAt} IS NOT NULL
+      )`,
+    ),
+    check(
+      "notification_delivery_sent_provider_check",
+      sql`${table.status} <> 'sent'
+        OR NULLIF(BTRIM(${table.providerMessageId}), '') IS NOT NULL`,
+    ),
+    check(
+      "notification_delivery_deferred_check",
+      sql`(
+          ${table.status} = 'quota_deferred'
+          AND ${table.deferredUntil} IS NOT NULL
+        ) OR (
+          ${table.status} <> 'quota_deferred'
+          AND ${table.deferredUntil} IS NULL
+        )`,
+    ),
   ],
 );
 

--- a/apps/web/src/db/schema.ts
+++ b/apps/web/src/db/schema.ts
@@ -855,7 +855,8 @@ export const notificationDelivery = pgTable(
     check(
       "notification_delivery_skipped_check",
       sql`${table.status} <> 'skipped' OR (
-        ${table.matchCount} = 0
+        ${table.matchCount} IS NOT NULL
+        AND ${table.matchCount} = 0
         AND ${table.providerAttemptCount} = 0
         AND ${table.lastProviderAttemptAt} IS NULL
         AND ${table.providerMessageId} IS NULL
@@ -864,7 +865,7 @@ export const notificationDelivery = pgTable(
     check(
       "notification_delivery_sendable_match_check",
       sql`${table.status} NOT IN ('sent', 'unknown', 'quota_deferred')
-        OR ${table.matchCount} > 0`,
+        OR (${table.matchCount} IS NOT NULL AND ${table.matchCount} > 0)`,
     ),
     check(
       "notification_delivery_provider_attempt_check",

--- a/apps/web/src/lib/actions/__tests__/watchlists-invalidation.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-invalidation.test.ts
@@ -179,7 +179,13 @@ vi.mock("@/db/schema", () => ({
     description: { _col: "description" },
     isPublic: { _col: "isPublic" },
     alertsEnabled: { _col: "alertsEnabled" },
+    alertsEnabledAt: { _col: "alertsEnabledAt" },
     filters: { _col: "filters" },
+  },
+  userPreferences: {
+    userId: { _col: "userId" },
+    notificationsPaused: { _col: "notificationsPaused" },
+    notificationsStateChangedAt: { _col: "notificationsStateChangedAt" },
   },
   watchlistCompany: {
     watchlistId: { _col: "watchlistId" },
@@ -674,18 +680,36 @@ describe("createWatchlist trivial public watchlist", () => {
 });
 
 describe("toggleWatchlistAlerts (private-only mutation)", () => {
-  it("does NOT call updateTag or invalidate", async () => {
-    mocks.selectLimitResult.mockResolvedValue([
-      { userId: USER_ID, alertsEnabled: false },
-    ]);
-    mocks.getUserPlan.mockResolvedValue("paid");
+  it("allows free users and does NOT call updateTag or invalidate", async () => {
+    mocks.selectLimitResult
+      .mockResolvedValueOnce([
+        { alertsEnabled: false, alertsEnabledAt: null },
+      ])
+      .mockResolvedValueOnce([{ notificationsPaused: false }]);
+    mocks.getUserPlan.mockResolvedValue("free");
 
-    await toggleWatchlistAlerts(WATCHLIST_ID);
+    await expect(toggleWatchlistAlerts(WATCHLIST_ID)).resolves.toEqual({
+      enabled: true,
+    });
     await flushAfterQueue();
 
+    expect(mocks.getUserPlan).not.toHaveBeenCalled();
     expect(mocks.updateTag).not.toHaveBeenCalled();
     expect(mocks.invalidate).not.toHaveBeenCalled();
     // Defensively also assert no after() callbacks were even registered.
+    expect(mocks.afterFn).not.toHaveBeenCalled();
+  });
+
+  it("rejects a toggle while globally paused without changing its value", async () => {
+    mocks.selectLimitResult
+      .mockResolvedValueOnce([
+        { alertsEnabled: true, alertsEnabledAt: new Date("2026-08-01") },
+      ])
+      .mockResolvedValueOnce([{ notificationsPaused: true }]);
+
+    await expect(toggleWatchlistAlerts(WATCHLIST_ID)).resolves.toEqual({
+      error: "notifications_paused",
+    });
     expect(mocks.afterFn).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/actions/notifications.ts
+++ b/apps/web/src/lib/actions/notifications.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { getSessionUserId } from "@/lib/sessionCache";
+import {
+  getNotificationPreferencesForUser,
+  setNotificationsPausedForUser,
+} from "@/lib/services/notification-preferences";
+
+export async function getNotificationPreferences() {
+  const userId = await getSessionUserId();
+  if (!userId) return null;
+  return getNotificationPreferencesForUser(userId);
+}
+
+export async function setNotificationsPaused(
+  notificationsPaused: boolean,
+): Promise<
+  | Awaited<ReturnType<typeof setNotificationsPausedForUser>>
+  | { error: "not_authenticated" | "invalid_request" }
+> {
+  if (typeof notificationsPaused !== "boolean") {
+    return { error: "invalid_request" };
+  }
+  const userId = await getSessionUserId();
+  if (!userId) return { error: "not_authenticated" };
+  return setNotificationsPausedForUser(userId, notificationsPaused);
+}

--- a/apps/web/src/lib/notifications/__tests__/policy.test.ts
+++ b/apps/web/src/lib/notifications/__tests__/policy.test.ts
@@ -1,0 +1,328 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+import {
+  NOTIFICATION_CADENCE_VALUES,
+  NOTIFICATION_DELIVERY_STATUS_VALUES,
+  type NotificationDeliveryStatus,
+} from "../contracts";
+import {
+  DEFAULT_NOTIFICATION_CADENCE,
+  MAX_NOTIFICATION_PROVIDER_ATTEMPTS,
+  NOTIFICATION_CADENCES,
+  NOTIFICATION_DELIVERY_RETENTION_DAYS,
+  advancesNotificationWindow,
+  beginNotificationProviderAttempt,
+  canTransitionNotificationDelivery,
+  createNotificationDeliveryIdempotencyKey,
+  getNotificationMinimumIntervalMs,
+  getNotificationWindowFloor,
+  isNotificationDeliveryRetentionEligible,
+  isWatchlistNotificationEligible,
+  resolveNotificationCadence,
+  shouldAutomaticallyRetryNotificationDelivery,
+  toggleWatchlistAlertState,
+  transitionNotificationPause,
+} from "../policy";
+
+const dayMs = 24 * 60 * 60 * 1_000;
+
+describe("notification cadence policy", () => {
+  it("keeps the persisted cadence tuple and typed policy map in sync", () => {
+    expect(Object.keys(NOTIFICATION_CADENCES)).toEqual([
+      ...NOTIFICATION_CADENCE_VALUES,
+    ]);
+    expect(DEFAULT_NOTIFICATION_CADENCE).toBe("weekly");
+    expect(getNotificationMinimumIntervalMs("weekly")).toBe(7 * dayMs);
+    expect(NOTIFICATION_CADENCES.weekly.deliveryBuckets).toBe(7);
+  });
+
+  it("fails closed to the weekly fallback for absent or unknown values", () => {
+    expect(resolveNotificationCadence(null)).toBe("weekly");
+    expect(resolveNotificationCadence("daily")).toBe("weekly");
+    expect(resolveNotificationCadence("weekly")).toBe("weekly");
+  });
+});
+
+describe("pause, enable, and window-floor transitions", () => {
+  const initial = new Date("2026-08-01T08:00:00.000Z");
+  const pausedAt = new Date("2026-08-10T08:00:00.000Z");
+  const resumedAt = new Date("2026-08-20T08:00:00.000Z");
+
+  it("uses the exact enabled-and-not-paused server eligibility precedence", () => {
+    expect(
+      isWatchlistNotificationEligible({
+        alertsEnabled: true,
+        alertsEnabledAt: initial,
+        notificationsPaused: false,
+      }),
+    ).toBe(true);
+    expect(
+      isWatchlistNotificationEligible({
+        alertsEnabled: true,
+        alertsEnabledAt: initial,
+        notificationsPaused: true,
+      }),
+    ).toBe(false);
+    expect(
+      isWatchlistNotificationEligible({
+        alertsEnabled: false,
+        alertsEnabledAt: null,
+        notificationsPaused: false,
+      }),
+    ).toBe(false);
+  });
+
+  it("preserves watchlist state while paused and refreshes each enable floor", () => {
+    const disabled = { alertsEnabled: false, alertsEnabledAt: null };
+    const blocked = toggleWatchlistAlertState(disabled, true, pausedAt);
+    expect(blocked).toEqual({
+      ok: false,
+      error: "notifications_paused",
+      state: disabled,
+    });
+
+    const enabled = toggleWatchlistAlertState(disabled, false, initial);
+    expect(enabled).toEqual({
+      ok: true,
+      state: { alertsEnabled: true, alertsEnabledAt: initial },
+    });
+    if (!enabled.ok) throw new Error("expected enabled transition");
+
+    const disabledAgain = toggleWatchlistAlertState(
+      enabled.state,
+      false,
+      pausedAt,
+    );
+    expect(disabledAgain).toEqual({
+      ok: true,
+      state: { alertsEnabled: false, alertsEnabledAt: null },
+    });
+    if (!disabledAgain.ok) throw new Error("expected disabled transition");
+
+    expect(
+      toggleWatchlistAlertState(disabledAgain.state, false, resumedAt),
+    ).toEqual({
+      ok: true,
+      state: { alertsEnabled: true, alertsEnabledAt: resumedAt },
+    });
+  });
+
+  it("moves the global floor only on a real pause or resume", () => {
+    const unpaused = {
+      notificationsPaused: false,
+      notificationsStateChangedAt: initial,
+    };
+    expect(transitionNotificationPause(unpaused, false, pausedAt)).toBe(
+      unpaused,
+    );
+
+    const paused = transitionNotificationPause(unpaused, true, pausedAt);
+    expect(paused).toEqual({
+      notificationsPaused: true,
+      notificationsStateChangedAt: pausedAt,
+    });
+    expect(transitionNotificationPause(paused, true, resumedAt)).toBe(paused);
+    expect(transitionNotificationPause(paused, false, resumedAt)).toEqual({
+      notificationsPaused: false,
+      notificationsStateChangedAt: resumedAt,
+    });
+  });
+
+  it("floors the next window after enable, resume, and prior advancement", () => {
+    expect(
+      getNotificationWindowFloor({
+        alertsEnabledAt: initial,
+        notificationsStateChangedAt: resumedAt,
+        lastProcessedWindowEnd: pausedAt,
+      }),
+    ).toEqual(resumedAt);
+
+    const lastProcessed = new Date("2026-08-25T08:00:00.000Z");
+    expect(
+      getNotificationWindowFloor({
+        alertsEnabledAt: initial,
+        notificationsStateChangedAt: resumedAt,
+        lastProcessedWindowEnd: lastProcessed,
+      }),
+    ).toEqual(lastProcessed);
+  });
+});
+
+describe("durable delivery state policy", () => {
+  const allowed: Record<
+    NotificationDeliveryStatus,
+    NotificationDeliveryStatus[]
+  > = {
+    pending: ["skipped", "failed", "unknown", "quota_deferred"],
+    unknown: ["sent", "failed"],
+    failed: ["pending"],
+    quota_deferred: ["pending"],
+    sent: [],
+    skipped: [],
+  };
+
+  it("allows only the documented state transitions", () => {
+    for (const from of NOTIFICATION_DELIVERY_STATUS_VALUES) {
+      for (const to of NOTIFICATION_DELIVERY_STATUS_VALUES) {
+        expect(
+          canTransitionNotificationDelivery(from, to, 0),
+          `${from} -> ${to}`,
+        ).toBe(allowed[from].includes(to));
+      }
+    }
+    expect(
+      canTransitionNotificationDelivery(
+        "failed",
+        "pending",
+        MAX_NOTIFICATION_PROVIDER_ATTEMPTS,
+      ),
+    ).toBe(false);
+  });
+
+  it("records an attempt as unknown before the provider side effect", () => {
+    const attemptedAt = new Date("2026-08-31T08:00:00.000Z");
+    expect(
+      beginNotificationProviderAttempt(
+        {
+          status: "pending",
+          providerAttemptCount: 1,
+          lastProviderAttemptAt: null,
+        },
+        attemptedAt,
+      ),
+    ).toEqual({
+      status: "unknown",
+      providerAttemptCount: 2,
+      lastProviderAttemptAt: attemptedAt,
+    });
+    expect(() =>
+      beginNotificationProviderAttempt(
+        {
+          status: "unknown",
+          providerAttemptCount: 1,
+          lastProviderAttemptAt: attemptedAt,
+        },
+        attemptedAt,
+      ),
+    ).toThrow("only from pending");
+    expect(() =>
+      beginNotificationProviderAttempt(
+        {
+          status: "pending",
+          providerAttemptCount: MAX_NOTIFICATION_PROVIDER_ATTEMPTS,
+          lastProviderAttemptAt: attemptedAt,
+        },
+        attemptedAt,
+      ),
+    ).toThrow("budget exhausted");
+  });
+
+  it("retries definitive failures and due quota deferrals, never unknowns", () => {
+    const now = new Date("2026-08-31T08:00:00.000Z");
+    expect(
+      shouldAutomaticallyRetryNotificationDelivery({
+        status: "failed",
+        providerAttemptCount: 2,
+        now,
+      }),
+    ).toBe(true);
+    expect(
+      shouldAutomaticallyRetryNotificationDelivery({
+        status: "failed",
+        providerAttemptCount: 3,
+        now,
+      }),
+    ).toBe(false);
+    expect(
+      shouldAutomaticallyRetryNotificationDelivery({
+        status: "quota_deferred",
+        providerAttemptCount: 0,
+        deferredUntil: new Date(now.getTime() - 1),
+        now,
+      }),
+    ).toBe(true);
+    expect(
+      shouldAutomaticallyRetryNotificationDelivery({
+        status: "quota_deferred",
+        providerAttemptCount: 0,
+        deferredUntil: new Date(now.getTime() + 1),
+        now,
+      }),
+    ).toBe(false);
+    expect(
+      shouldAutomaticallyRetryNotificationDelivery({
+        status: "unknown",
+        providerAttemptCount: 1,
+        now,
+      }),
+    ).toBe(false);
+  });
+
+  it("advances windows only for sent and zero-match skipped outcomes", () => {
+    expect(advancesNotificationWindow("sent")).toBe(true);
+    expect(advancesNotificationWindow("skipped")).toBe(true);
+    for (const status of [
+      "pending",
+      "failed",
+      "unknown",
+      "quota_deferred",
+    ] as const) {
+      expect(advancesNotificationWindow(status)).toBe(false);
+    }
+  });
+
+  it("retains unresolved identities and expires only old completed rows", () => {
+    const completedAt = new Date("2025-01-01T00:00:00.000Z");
+    const beforeCutoff = new Date(
+      completedAt.getTime() + NOTIFICATION_DELIVERY_RETENTION_DAYS * dayMs - 1,
+    );
+    const atCutoff = new Date(beforeCutoff.getTime() + 1);
+    expect(
+      isNotificationDeliveryRetentionEligible({
+        status: "sent",
+        completedAt,
+        now: beforeCutoff,
+      }),
+    ).toBe(false);
+    expect(
+      isNotificationDeliveryRetentionEligible({
+        status: "skipped",
+        completedAt,
+        now: atCutoff,
+      }),
+    ).toBe(true);
+    expect(
+      isNotificationDeliveryRetentionEligible({
+        status: "unknown",
+        completedAt,
+        now: atCutoff,
+      }),
+    ).toBe(false);
+  });
+
+  it("derives a stable, opaque key from the unique delivery identity", () => {
+    const scheduledFor = new Date("2026-09-01T08:00:00.000Z");
+    const first = createNotificationDeliveryIdempotencyKey({
+      userId: "user-1",
+      cadence: "weekly",
+      scheduledFor,
+    });
+    expect(first).toBe(
+      createNotificationDeliveryIdempotencyKey({
+        userId: "user-1",
+        cadence: "weekly",
+        scheduledFor,
+      }),
+    );
+    expect(first).not.toContain("user-1");
+    expect(first).not.toBe(
+      createNotificationDeliveryIdempotencyKey({
+        userId: "user-2",
+        cadence: "weekly",
+        scheduledFor,
+      }),
+    );
+  });
+});

--- a/apps/web/src/lib/notifications/contracts.ts
+++ b/apps/web/src/lib/notifications/contracts.ts
@@ -1,0 +1,24 @@
+/**
+ * Persisted notification values shared by Drizzle and the server policy.
+ *
+ * Adding a cadence is intentionally a coordinated change: extend this tuple,
+ * the policy map, and the PostgreSQL enum migration. Matching and ledger code
+ * consume the generic `NotificationCadence` type and do not special-case a
+ * seven-day window.
+ */
+export const NOTIFICATION_CADENCE_VALUES = ["weekly"] as const;
+
+export type NotificationCadence =
+  (typeof NOTIFICATION_CADENCE_VALUES)[number];
+
+export const NOTIFICATION_DELIVERY_STATUS_VALUES = [
+  "pending",
+  "sent",
+  "skipped",
+  "failed",
+  "unknown",
+  "quota_deferred",
+] as const;
+
+export type NotificationDeliveryStatus =
+  (typeof NOTIFICATION_DELIVERY_STATUS_VALUES)[number];

--- a/apps/web/src/lib/notifications/policy.ts
+++ b/apps/web/src/lib/notifications/policy.ts
@@ -1,0 +1,266 @@
+import "server-only";
+
+import { createHash } from "node:crypto";
+
+import {
+  NOTIFICATION_CADENCE_VALUES,
+  type NotificationCadence,
+  type NotificationDeliveryStatus,
+} from "./contracts";
+
+const DAY_MS = 24 * 60 * 60 * 1_000;
+
+export type NotificationCadencePolicy = Readonly<{
+  minimumIntervalDays: number;
+  deliveryBuckets: number;
+}>;
+
+/**
+ * Cadence is policy, not matcher behavior. Callers derive explicit window
+ * bounds from this map and pass those bounds to the canonical matcher.
+ */
+export const NOTIFICATION_CADENCES = {
+  weekly: {
+    minimumIntervalDays: 7,
+    deliveryBuckets: 7,
+  },
+} as const satisfies Record<NotificationCadence, NotificationCadencePolicy>;
+
+export const DEFAULT_NOTIFICATION_CADENCE: NotificationCadence = "weekly";
+
+/**
+ * A bounded automatic retry budget for definitive failures. An `unknown`
+ * outcome is deliberately not retryable because the provider may have
+ * accepted the message even when its response was lost.
+ */
+export const MAX_NOTIFICATION_PROVIDER_ATTEMPTS = 3;
+
+/**
+ * Completed identities stay long enough to cover more than a full year of
+ * weekly periods. Non-terminal rows are never automatically retention-eligible
+ * so unresolved failures cannot silently lose their idempotency barrier.
+ */
+export const NOTIFICATION_DELIVERY_RETENTION_DAYS = 400;
+
+const DELIVERY_TRANSITIONS = {
+  pending: ["skipped", "failed", "unknown", "quota_deferred"],
+  unknown: ["sent", "failed"],
+  failed: ["pending"],
+  quota_deferred: ["pending"],
+  sent: [],
+  skipped: [],
+} as const satisfies Record<
+  NotificationDeliveryStatus,
+  readonly NotificationDeliveryStatus[]
+>;
+
+export type NotificationPauseState = Readonly<{
+  notificationsPaused: boolean;
+  notificationsStateChangedAt: Date;
+}>;
+
+export type WatchlistAlertState = Readonly<{
+  alertsEnabled: boolean;
+  alertsEnabledAt: Date | null;
+}>;
+
+export type WatchlistAlertTransition =
+  | Readonly<{
+      ok: true;
+      state: WatchlistAlertState;
+    }>
+  | Readonly<{
+      ok: false;
+      error: "notifications_paused";
+      state: WatchlistAlertState;
+    }>;
+
+export type NotificationWindowFloorInput = Readonly<{
+  alertsEnabledAt: Date;
+  notificationsStateChangedAt: Date;
+  lastProcessedWindowEnd?: Date | null;
+}>;
+
+export type NotificationProviderAttemptState = Readonly<{
+  status: NotificationDeliveryStatus;
+  providerAttemptCount: number;
+  lastProviderAttemptAt: Date | null;
+}>;
+
+export function resolveNotificationCadence(
+  value: unknown,
+): NotificationCadence {
+  return typeof value === "string" &&
+    (NOTIFICATION_CADENCE_VALUES as readonly string[]).includes(value)
+    ? (value as NotificationCadence)
+    : DEFAULT_NOTIFICATION_CADENCE;
+}
+
+export function getNotificationMinimumIntervalMs(
+  cadence: NotificationCadence,
+): number {
+  return NOTIFICATION_CADENCES[cadence].minimumIntervalDays * DAY_MS;
+}
+
+/** Exact server-side eligibility precedence from #8317. */
+export function isWatchlistNotificationEligible(input: {
+  alertsEnabled: boolean;
+  alertsEnabledAt: Date | null;
+  notificationsPaused: boolean;
+}): boolean {
+  return (
+    input.alertsEnabled &&
+    input.alertsEnabledAt !== null &&
+    !input.notificationsPaused
+  );
+}
+
+/**
+ * A repeated pause/resume request is idempotent and does not move the floor.
+ * A real state change records its own timestamp without touching watchlists.
+ */
+export function transitionNotificationPause(
+  current: NotificationPauseState,
+  notificationsPaused: boolean,
+  changedAt: Date,
+): NotificationPauseState {
+  if (current.notificationsPaused === notificationsPaused) return current;
+  return { notificationsPaused, notificationsStateChangedAt: changedAt };
+}
+
+/**
+ * Per-watchlist toggles are inert while globally paused. Enabling or
+ * re-enabling records a new floor; disabling clears the active interval.
+ */
+export function toggleWatchlistAlertState(
+  current: WatchlistAlertState,
+  notificationsPaused: boolean,
+  changedAt: Date,
+): WatchlistAlertTransition {
+  if (notificationsPaused) {
+    return { ok: false, error: "notifications_paused", state: current };
+  }
+
+  const alertsEnabled = !current.alertsEnabled;
+  return {
+    ok: true,
+    state: {
+      alertsEnabled,
+      alertsEnabledAt: alertsEnabled ? changedAt : null,
+    },
+  };
+}
+
+/**
+ * The state-change timestamp is deliberately included even while unpaused:
+ * migration establishes a no-backlog floor, and every resume replaces it so
+ * jobs accumulated during a pause can never enter a later window.
+ */
+export function getNotificationWindowFloor(
+  input: NotificationWindowFloorInput,
+): Date {
+  const candidates = [
+    input.alertsEnabledAt,
+    input.notificationsStateChangedAt,
+    input.lastProcessedWindowEnd,
+  ].filter((value): value is Date => value instanceof Date);
+
+  return new Date(Math.max(...candidates.map((value) => value.getTime())));
+}
+
+export function canTransitionNotificationDelivery(
+  from: NotificationDeliveryStatus,
+  to: NotificationDeliveryStatus,
+  providerAttemptCount = 0,
+): boolean {
+  if (from === "failed" && to === "pending") {
+    return providerAttemptCount < MAX_NOTIFICATION_PROVIDER_ATTEMPTS;
+  }
+  return (DELIVERY_TRANSITIONS[from] as readonly NotificationDeliveryStatus[])
+    .includes(to);
+}
+
+/**
+ * Move to `unknown` before the external side effect. If the process dies
+ * during the provider call, the durable row therefore fails closed instead
+ * of being retried as though no send had happened.
+ */
+export function beginNotificationProviderAttempt(
+  current: NotificationProviderAttemptState,
+  attemptedAt: Date,
+): NotificationProviderAttemptState {
+  if (current.status !== "pending") {
+    throw new Error("A provider attempt can start only from pending");
+  }
+  if (
+    current.providerAttemptCount >= MAX_NOTIFICATION_PROVIDER_ATTEMPTS
+  ) {
+    throw new Error("Notification provider attempt budget exhausted");
+  }
+  return {
+    status: "unknown",
+    providerAttemptCount: current.providerAttemptCount + 1,
+    lastProviderAttemptAt: attemptedAt,
+  };
+}
+
+export function shouldAutomaticallyRetryNotificationDelivery(input: {
+  status: NotificationDeliveryStatus;
+  providerAttemptCount: number;
+  deferredUntil?: Date | null;
+  now: Date;
+}): boolean {
+  if (input.status === "failed") {
+    return input.providerAttemptCount < MAX_NOTIFICATION_PROVIDER_ATTEMPTS;
+  }
+  if (input.status === "quota_deferred") {
+    return (
+      input.deferredUntil !== null &&
+      input.deferredUntil !== undefined &&
+      input.deferredUntil.getTime() <= input.now.getTime()
+    );
+  }
+  return false;
+}
+
+export function advancesNotificationWindow(
+  status: NotificationDeliveryStatus,
+): boolean {
+  return status === "sent" || status === "skipped";
+}
+
+export function isNotificationDeliveryRetentionEligible(input: {
+  status: NotificationDeliveryStatus;
+  completedAt: Date | null;
+  now: Date;
+}): boolean {
+  if (!advancesNotificationWindow(input.status) || !input.completedAt) {
+    return false;
+  }
+  const ageMs = input.now.getTime() - input.completedAt.getTime();
+  return ageMs >= NOTIFICATION_DELIVERY_RETENTION_DAYS * DAY_MS;
+}
+
+/**
+ * Provider-safe, privacy-minimizing identity for one user/cadence/period.
+ * The database stores this key and separately enforces the same source tuple.
+ */
+export function createNotificationDeliveryIdempotencyKey(input: {
+  userId: string;
+  cadence: NotificationCadence;
+  scheduledFor: Date;
+}): string {
+  if (!input.userId) throw new Error("Notification user id is required");
+  if (Number.isNaN(input.scheduledFor.getTime())) {
+    throw new Error("Notification scheduled time is invalid");
+  }
+  const canonical = [
+    "jobseek-notification-v1",
+    input.userId,
+    input.cadence,
+    input.scheduledFor.toISOString(),
+  ].join("\n");
+  return `jobseek-notification-v1:${createHash("sha256")
+    .update(canonical)
+    .digest("hex")}`;
+}

--- a/apps/web/src/lib/services/notification-preferences.ts
+++ b/apps/web/src/lib/services/notification-preferences.ts
@@ -1,0 +1,128 @@
+import "server-only";
+
+import { eq, sql, type SQL } from "drizzle-orm";
+
+import { db } from "@/db";
+import { userPreferences } from "@/db/schema";
+import type { NotificationCadence } from "@/lib/notifications/contracts";
+import {
+  DEFAULT_NOTIFICATION_CADENCE,
+  resolveNotificationCadence,
+  transitionNotificationPause,
+} from "@/lib/notifications/policy";
+
+type NotificationPolicyLockExecutor = {
+  execute(query: SQL): PromiseLike<unknown>;
+};
+
+export type NotificationPreferences = Readonly<{
+  cadence: NotificationCadence;
+  notificationsPaused: boolean;
+  notificationsStateChangedAt: Date | null;
+}>;
+
+export type NotificationPauseMutationResult = Readonly<{
+  changed: boolean;
+  notificationsPaused: boolean;
+  notificationsStateChangedAt: Date;
+}>;
+
+/**
+ * Pause/resume and per-watchlist alert toggles take the same transaction lock.
+ * This prevents a concurrent toggle from slipping through while pause wins.
+ */
+export async function lockNotificationPolicyForUser(
+  executor: NotificationPolicyLockExecutor,
+  userId: string,
+): Promise<void> {
+  await executor.execute(sql`
+    SELECT pg_advisory_xact_lock(
+      hashtextextended(${`jobseek:notification-policy:${userId}`}, 0)
+    )
+  `);
+}
+
+export async function getNotificationPreferencesForUser(
+  userId: string,
+): Promise<NotificationPreferences> {
+  const [row] = await db
+    .select({
+      cadence: userPreferences.notificationCadence,
+      notificationsPaused: userPreferences.notificationsPaused,
+      notificationsStateChangedAt:
+        userPreferences.notificationsStateChangedAt,
+    })
+    .from(userPreferences)
+    .where(eq(userPreferences.userId, userId))
+    .limit(1);
+
+  return {
+    cadence: resolveNotificationCadence(
+      row?.cadence ?? DEFAULT_NOTIFICATION_CADENCE,
+    ),
+    notificationsPaused: row?.notificationsPaused ?? false,
+    notificationsStateChangedAt: row?.notificationsStateChangedAt ?? null,
+  };
+}
+
+/**
+ * Persist one idempotent global pause transition without touching the
+ * underlying watchlist alert preferences. A real resume records the floor
+ * that later window calculation must honor.
+ */
+export async function setNotificationsPausedForUser(
+  userId: string,
+  notificationsPaused: boolean,
+  changedAt = new Date(),
+): Promise<NotificationPauseMutationResult> {
+  return db.transaction(async (tx) => {
+    await lockNotificationPolicyForUser(tx, userId);
+
+    // Preferences are normally materialized during bootstrap. The insert
+    // keeps this mutation safe for older or partially initialized accounts.
+    await tx
+      .insert(userPreferences)
+      .values({
+        userId,
+        notificationCadence: DEFAULT_NOTIFICATION_CADENCE,
+        notificationsPaused: false,
+        notificationsStateChangedAt: changedAt,
+      })
+      .onConflictDoNothing({ target: userPreferences.userId });
+
+    const [current] = await tx
+      .select({
+        notificationsPaused: userPreferences.notificationsPaused,
+        notificationsStateChangedAt:
+          userPreferences.notificationsStateChangedAt,
+      })
+      .from(userPreferences)
+      .where(eq(userPreferences.userId, userId))
+      .for("update")
+      .limit(1);
+
+    if (!current) {
+      throw new Error("Notification preferences could not be initialized");
+    }
+
+    const next = transitionNotificationPause(
+      current,
+      notificationsPaused,
+      changedAt,
+    );
+    if (next === current) {
+      return { changed: false, ...current };
+    }
+
+    await tx
+      .update(userPreferences)
+      .set({
+        notificationsPaused: next.notificationsPaused,
+        notificationsStateChangedAt: next.notificationsStateChangedAt,
+        updatedAt: changedAt,
+      })
+      .where(eq(userPreferences.userId, userId));
+
+    return { changed: true, ...next };
+  });
+}

--- a/apps/web/src/lib/services/watchlists.ts
+++ b/apps/web/src/lib/services/watchlists.ts
@@ -8,6 +8,7 @@ import { db } from "@/db";
 import {
   watchlist,
   watchlistCompany,
+  userPreferences,
 } from "@/db/schema";
 import { getSessionUserId } from "@/lib/sessionCache";
 import { getViewerLanguages } from "@/lib/viewer";
@@ -19,7 +20,7 @@ import {
 } from "@/lib/cache-ttl";
 import { withDbRetry } from "@/lib/db-retry";
 import { watchlistCacheTag } from "@/lib/cache-tags";
-import { canCreateWatchlist, getUserPlan, PLAN_LIMITS } from "@/lib/plans";
+import { canCreateWatchlist } from "@/lib/plans";
 import {
   createWithinWatchlistLimit,
   WatchlistLimitReachedError,
@@ -55,6 +56,8 @@ import { isTrivialWatchlist, buildFilterCacheKey } from "@/lib/watchlist-utils";
 import { notifyIndexNow, logIndexNowResult } from "@/lib/indexnow";
 import { createWatchlistFromHandoffWithDeps } from "@/lib/services/watchlist-handoff";
 import { publicWatchlistRouteStatusCacheKey } from "@/lib/services/public-resource-status";
+import { toggleWatchlistAlertState } from "@/lib/notifications/policy";
+import { lockNotificationPolicyForUser } from "@/lib/services/notification-preferences";
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -729,27 +732,57 @@ export async function toggleWatchlistAlerts(
   const userId = await getSessionUserId();
   if (!userId) throw new Error("Not authenticated");
 
-  const [wl] = await db
-    .select({
-      userId: watchlist.userId,
-      alertsEnabled: watchlist.alertsEnabled,
-    })
-    .from(watchlist)
-    .where(eq(watchlist.id, watchlistId))
-    .limit(1);
+  return db.transaction(async (tx) => {
+    await lockNotificationPolicyForUser(tx, userId);
+    const changedAt = new Date();
 
-  if (!wl || wl.userId !== userId) return { error: "not_found" };
+    const [wl] = await tx
+      .select({
+        alertsEnabled: watchlist.alertsEnabled,
+        alertsEnabledAt: watchlist.alertsEnabledAt,
+      })
+      .from(watchlist)
+      .where(
+        and(eq(watchlist.id, watchlistId), eq(watchlist.userId, userId)),
+      )
+      .for("update")
+      .limit(1);
 
-  const plan = await getUserPlan(userId);
-  if (!PLAN_LIMITS[plan].canReceiveAlerts) return { error: "paid_only" };
+    if (!wl) return { error: "not_found" };
 
-  const newVal = !wl.alertsEnabled;
-  await db
-    .update(watchlist)
-    .set({ alertsEnabled: newVal })
-    .where(eq(watchlist.id, watchlistId));
+    // Older accounts may not have materialized a preference row yet. Create
+    // the conservative weekly/unpaused baseline so every enabled alert has a
+    // persisted global state timestamp available to later window policy.
+    await tx
+      .insert(userPreferences)
+      .values({
+        userId,
+        notificationsStateChangedAt: changedAt,
+      })
+      .onConflictDoNothing({ target: userPreferences.userId });
 
-  return { enabled: newVal };
+    const [preferences] = await tx
+      .select({ notificationsPaused: userPreferences.notificationsPaused })
+      .from(userPreferences)
+      .where(eq(userPreferences.userId, userId))
+      .limit(1);
+
+    const transition = toggleWatchlistAlertState(
+      wl,
+      preferences?.notificationsPaused ?? false,
+      changedAt,
+    );
+    if (!transition.ok) return { error: transition.error };
+
+    await tx
+      .update(watchlist)
+      .set(transition.state)
+      .where(
+        and(eq(watchlist.id, watchlistId), eq(watchlist.userId, userId)),
+      );
+
+    return { enabled: transition.state.alertsEnabled };
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements the backend-only persistence and notification-policy layer split out from #8317 by the clarification comment and tracked in #8366.

- adds an extensible typed cadence contract with `weekly` as the only exposed/default/fallback policy
- adds `watchlist.alerts_enabled_at` plus global pause state and its state-change floor on `user_preferences`
- adds a durable delivery ledger with unique `(user_id, cadence, scheduled_for)` and deterministic provider idempotency state
- defines pending/sent/skipped/failed/unknown/quota-deferred transitions, window advancement, provider-attempt accounting, conservative retry behavior, and retention eligibility
- removes the paid-plan check from the server alert mutation
- serializes pause/resume and watchlist toggles by user, rejects toggles while globally paused, and preserves the underlying watchlist values through pause/resume

## Migration notes

- Existing and new alerts remain opt-in/default-off. The migration never enables an alert.
- If an enabled legacy row exists, its `alerts_enabled_at` is set to migration time to prevent historical catch-up.
- Existing preferences default to weekly/unpaused, with migration time as the initial notification-state floor.
- Rolling-deploy compatibility triggers maintain enable timestamps for the old alert writer and keep pause timestamps coupled to real state changes.
- User deletion cascades ledger rows. Database constraints enforce delivery window/status shapes, unique delivery-period identity, and unique idempotency keys.

## Conservative policy decisions / ambiguity

The issue does not prescribe numeric retry or retention values. This PR chooses at most 3 automatic attempts for definitive failures and 400 days of retention for completed sent/skipped identities. Unresolved pending/failed/unknown/quota-deferred identities are never automatically retention-eligible. Ambiguous provider outcomes enter `unknown` before the external side effect and are not automatically retried; they must first be reconciled to sent or a definitive failed state. These are typed constants rather than provider or scheduler configuration.

Only `sent` and zero-match `skipped` advance a processed window. The next window floor is the maximum of alert enable time, notification pause/resume state-change time, and the prior processed window end, so paused-period catch-up is impossible.

## Verification

- `pnpm --dir apps/web test` — 273 files / 2,139 tests passed
- focused post-rebase Vitest set — 5 files / 55 tests passed
- `pnpm --dir apps/web typecheck`
- `pnpm --dir apps/web db:check`
- focused ESLint — passed
- `pnpm --dir apps/web build` — passed locally (expected missing local Redis/auth env warnings only)
- commit/push hooks — passed

## Explicitly out of scope

No Settings or action-bar UI, localized product copy, rendered email, provider call, cron/scheduler, matcher extraction, live rollout/configuration, paid-service change, provider-cap change, or cost commitment is included. Consequently, the human UI-taste and human cost-approval gates are not applicable to this PR. Those gates remain active for their separately scoped delivery layers.

References #8317 and #8366. Does not close either issue.
