### PR TITLE
Enforce private watchlist mutations and copy authorization

### DIFF
--- a/apps/web/src/lib/__tests__/watchlist-copy-policy.test.ts
+++ b/apps/web/src/lib/__tests__/watchlist-copy-policy.test.ts
@@ -1,26 +1,42 @@
 import { describe, expect, it } from "vitest";
 
-import { canCopyWatchlistSource } from "@/lib/watchlist-copy-policy";
+import {
+  authorizeWatchlistCopySource,
+  WATCHLIST_COPY_SOURCE_KINDS,
+} from "@/lib/watchlist-copy-policy";
 
 describe("watchlist copy source policy", () => {
-  it("allows an owner to duplicate a private watchlist", () => {
-    expect(canCopyWatchlistSource({
+  it("authorizes owner duplication without consulting visibility", () => {
+    expect(authorizeWatchlistCopySource({
       userId: "owner-1",
-      isPublic: false,
-    }, "owner-1")).toBe(true);
+    }, "owner-1")).toEqual({ sourceKind: "owned" });
   });
 
-  it("preserves cross-user copying for currently shareable public sources", () => {
-    expect(canCopyWatchlistSource({
+  it("fails closed for a cross-user source even if a legacy public signal is present", () => {
+    const legacyPublicSource = {
       userId: "owner-1",
       isPublic: true,
-    }, "owner-2")).toBe(true);
+    };
+    expect(authorizeWatchlistCopySource(legacyPublicSource, "owner-2")).toBeNull();
   });
 
-  it("does not infer cross-user access to a private source", () => {
-    expect(canCopyWatchlistSource({
-      userId: "owner-1",
-      isPublic: false,
-    }, "owner-2")).toBe(false);
+  it.each(["grant", "share", "template"] as const)(
+    "keeps the future %s policy dormant until real authorization exists",
+    (sourceKind) => {
+      expect(authorizeWatchlistCopySource(
+        { userId: "owner-1" },
+        "owner-2",
+        sourceKind,
+      )).toBeNull();
+    },
+  );
+
+  it("enumerates the reviewed source-kind seam", () => {
+    expect(WATCHLIST_COPY_SOURCE_KINDS).toEqual([
+      "owned",
+      "grant",
+      "share",
+      "template",
+    ]);
   });
 });

--- a/apps/web/src/lib/actions/__tests__/watchlists-invalidation.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-invalidation.test.ts
@@ -338,61 +338,62 @@ afterEach(() => {
 // ---- Per-mutator happy-path tests -----------------------------------
 
 describe("watchlist mutator cache invalidation", () => {
-  it("createWatchlist invalidates both username + displayUsername slug variants", async () => {
-    queueOwnerInfo();
+  it("createWatchlist persists privately without public cache/index work", async () => {
     mocks.insertReturningResult.mockResolvedValue([{ id: WATCHLIST_ID }]);
 
-    await createWatchlist({
+    await expect(createWatchlist({
       title: "My Watchlist",
       companyIds: ["co-1", "co-2"],
-      isPublic: true,
-    });
+      isPublic: false,
+    })).resolves.toEqual({ id: WATCHLIST_ID, slug: SLUG });
     await flushAfterQueue();
 
-    const tagCalls = mocks.updateTag.mock.calls.map((c) => c[0]);
-    expect(tagCalls.sort()).toEqual(expectedTagPair(SLUG).sort());
-    const invalidateCalls = mocks.invalidate.mock.calls.map((c) => c[0]);
-    expect(invalidateCalls.sort()).toEqual(expectedInvalidateKeyPair(SLUG).sort());
+    expect(mocks.updateTag).not.toHaveBeenCalled();
+    expect(mocks.invalidate).not.toHaveBeenCalled();
+    expect(mocks.tsUpsertWatchlist).not.toHaveBeenCalled();
+    expect(mocks.notifyIndexNow).not.toHaveBeenCalled();
+    expect(mocks.afterFn).not.toHaveBeenCalled();
   });
 
-  it("createWatchlist upserts indexed filters_json for public anyCompany watchlists", async () => {
-    queueOwnerInfo();
-    mocks.insertReturningResult.mockResolvedValue([{ id: WATCHLIST_ID }]);
-    const { resolveLocationSlugs } = await import("@/lib/actions/locations");
-    const { resolveOccupationSlugs } = await import("@/lib/services/taxonomy");
-    vi.mocked(resolveLocationSlugs).mockResolvedValueOnce(
-      new Map([
-        ["switzerland", { id: 30, slug: "switzerland", name: "Switzerland", type: "country", parentName: null }],
-      ]),
-    );
-    vi.mocked(resolveOccupationSlugs).mockResolvedValueOnce(
-      new Map([
-        ["account-executive", { id: 101, slug: "account-executive", name: "Account Executive" }],
-      ]),
-    );
-
-    await createWatchlist({
-      title: "Enterprise Sales in Switzerland",
-      companyIds: [],
-      filters: {
-        anyCompany: true,
-        locationSlugs: ["switzerland"],
-        occupationSlugs: ["account-executive"],
-      },
+  it("rejects public create intent before hooks or writes", async () => {
+    await expect(createWatchlist({
+      title: "Must stay private",
+      companyIds: ["co-1"],
       isPublic: true,
-    });
+    })).resolves.toEqual({ error: "visibility_locked" });
     await flushAfterQueue();
 
-    expect(mocks.tsUpsertWatchlist).toHaveBeenCalledTimes(1);
-    const doc = mocks.tsUpsertWatchlist.mock.calls[0][0];
-    const payload = JSON.parse(doc.filters_json);
-    expect(payload).toMatchObject({
-      anyCompany: true,
-      locationSlugs: ["switzerland"],
-      locationIds: [30],
-      occupationSlugs: ["account-executive"],
-      occupationIds: [101],
-    });
+    expect(mocks.insertReturningResult).not.toHaveBeenCalled();
+    expect(mocks.updateTag).not.toHaveBeenCalled();
+    expect(mocks.invalidate).not.toHaveBeenCalled();
+    expect(mocks.tsUpsertWatchlist).not.toHaveBeenCalled();
+    expect(mocks.notifyIndexNow).not.toHaveBeenCalled();
+    expect(mocks.afterFn).not.toHaveBeenCalled();
+  });
+
+  it("rejects visibility updates without invalidation or index hooks", async () => {
+    mocks.selectLimitResult.mockResolvedValue([{
+      id: WATCHLIST_ID,
+      userId: USER_ID,
+      slug: SLUG,
+      title: "Existing",
+      description: null,
+      isPublic: false,
+      filters: {},
+    }]);
+
+    await expect(updateWatchlist({
+      watchlistId: WATCHLIST_ID,
+      isPublic: true,
+    })).resolves.toEqual({ error: "visibility_locked" });
+    await flushAfterQueue();
+
+    expect(mocks.updateTag).not.toHaveBeenCalled();
+    expect(mocks.invalidate).not.toHaveBeenCalled();
+    expect(mocks.tsUpsertWatchlist).not.toHaveBeenCalled();
+    expect(mocks.tsDeleteWatchlist).not.toHaveBeenCalled();
+    expect(mocks.notifyIndexNow).not.toHaveBeenCalled();
+    expect(mocks.afterFn).not.toHaveBeenCalled();
   });
 
   it("updateWatchlist invalidates current slug pair when title is unchanged", async () => {
@@ -445,6 +446,7 @@ describe("watchlist mutator cache invalidation", () => {
   });
 
   it("copyWatchlist invalidates new copy's slug for both variants", async () => {
+    const audit = spyAuditLog();
     queueOwnerInfo();
     // First select: source watchlist slug hint; second: the authoritative
     // source snapshot inside the transaction; third: copied companies.
@@ -453,7 +455,7 @@ describe("watchlist mutator cache invalidation", () => {
       description: null,
       filters: {},
       isPublic: true,
-      userId: "other",
+      userId: USER_ID,
     };
     mocks.selectLimitResult
       .mockResolvedValueOnce([source])
@@ -464,10 +466,9 @@ describe("watchlist mutator cache invalidation", () => {
     // makeChain.then resolves with selectLimitResult() — when no more
     // queued, returns `undefined`. The companies query needs `[]`:
     mocks.selectLimitResult.mockResolvedValueOnce([]);
-    // Mirror count
-    mocks.dbExecute
-      .mockResolvedValueOnce([{ name: "Alice", username: USER_NAME, display_username: DISPLAY_USER_NAME }])
-      .mockResolvedValueOnce([{ cnt: 0 }]);
+    mocks.dbExecute.mockResolvedValueOnce([
+      { name: "Alice", username: USER_NAME, display_username: DISPLAY_USER_NAME },
+    ]);
     mocks.insertReturningResult.mockResolvedValue([{ id: "wl-copy" }]);
 
     await copyWatchlist(WATCHLIST_ID);
@@ -479,6 +480,16 @@ describe("watchlist mutator cache invalidation", () => {
     expect(mocks.invalidate.mock.calls.map((c) => c[0]).sort()).toEqual(
       expectedInvalidateKeyPair(SLUG).sort(),
     );
+    expect(mocks.tsUpdateWatchlistField).not.toHaveBeenCalled();
+
+    const payload = expectSingleAuditPayload(audit);
+    expect(payload).toMatchObject({
+      action: "watchlist.copy",
+      copy_source_kind: "owned",
+      is_public_after: false,
+    });
+    expect(JSON.stringify(payload)).not.toContain(USER_ID);
+    expect(JSON.stringify(payload)).not.toContain(WATCHLIST_ID);
   });
 
   it("addCompanyToWatchlist invalidates both slug variants for public watchlists", async () => {
@@ -642,37 +653,6 @@ describe("updateWatchlist title rename", () => {
   });
 });
 
-describe("createWatchlist trivial public watchlist", () => {
-  /**
-   * Round-5 fix (PR #2888): cache invalidation runs unconditionally for
-   * public watchlists, even trivial ones, to bust any pre-existing
-   * null-detail render cached at the page level. Typesense + IndexNow
-   * are gated on !trivial; only invalidation must fire here.
-   */
-  it("still invalidates caches when no companies + no filters", async () => {
-    queueOwnerInfo();
-    mocks.insertReturningResult.mockResolvedValue([{ id: WATCHLIST_ID }]);
-
-    await createWatchlist({
-      title: "Empty",
-      companyIds: [],
-      isPublic: true,
-      // no filters → trivial
-    });
-    await flushAfterQueue();
-
-    expect(mocks.updateTag.mock.calls.map((c) => c[0]).sort()).toEqual(
-      expectedTagPair(SLUG).sort(),
-    );
-    expect(mocks.invalidate.mock.calls.map((c) => c[0]).sort()).toEqual(
-      expectedInvalidateKeyPair(SLUG).sort(),
-    );
-    // Trivial → must NOT touch Typesense / IndexNow.
-    expect(mocks.tsUpsertWatchlist).not.toHaveBeenCalled();
-    expect(mocks.notifyIndexNow).not.toHaveBeenCalled();
-  });
-});
-
 describe("toggleWatchlistAlerts (private-only mutation)", () => {
   it("does NOT call updateTag or invalidate", async () => {
     mocks.selectLimitResult.mockResolvedValue([
@@ -716,7 +696,6 @@ const SOURCE_PATH = join(__dirname, "..", "..", "services", "watchlists.ts");
 
 /** Mutators that MUST call `_invalidateWatchlistCaches`. */
 const EXPECTED_INVALIDATING_MUTATORS = new Set<string>([
-  "createWatchlist",
   "updateWatchlist",
   "deleteWatchlist",
   "copyWatchlist",
@@ -731,6 +710,9 @@ const EXPECTED_INVALIDATING_MUTATORS = new Set<string>([
  * a one-line comment justifying why no invalidation is required.
  */
 const EXPECTED_NON_INVALIDATING = new Set<string>([
+  // New watchlists are private by construction and have no public cache or
+  // search document to invalidate.
+  "createWatchlist",
   // alertsEnabled is a private field — never rendered on the public page,
   // so no public cache key is affected by toggling it.
   "toggleWatchlistAlerts",

--- a/apps/web/src/lib/actions/__tests__/watchlists-transactions.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-transactions.test.ts
@@ -279,28 +279,31 @@ beforeEach(() => {
 });
 
 describe("#3114 — watchlist multi-table writes are atomic", () => {
-  it("commits parent and company rows before registering post-commit work", async () => {
+  it("commits a private parent and company rows atomically", async () => {
     const audit = vi.spyOn(console, "info").mockImplementation(() => {});
     try {
       await expect(createWatchlist({
         title: "New watchlist",
         companyIds: ["company-1"],
-        isPublic: true,
       })).resolves.toEqual({ id: "wl-new", slug: "new-watchlist" });
 
       expect(mocks.snapshot()).toEqual({
-        watchlists: [expect.objectContaining({ id: "wl-new", title: "New watchlist" })],
+        watchlists: [expect.objectContaining({
+          id: "wl-new",
+          title: "New watchlist",
+          isPublic: false,
+        })],
         companies: [{ watchlistId: "wl-new", companyId: "company-1" }],
       });
       expect(mocks.calls).toEqual({ transactions: 1, rollbacks: 0 });
       expect(audit).toHaveBeenCalledTimes(1);
-      expect(mocks.afterFn).toHaveBeenCalledTimes(2);
+      expect(mocks.afterFn).not.toHaveBeenCalled();
     } finally {
       audit.mockRestore();
     }
   });
 
-  it("retries a slug conflict in a fresh transaction and emits hooks once", async () => {
+  it("retries a slug conflict in a fresh transaction and audits once", async () => {
     const audit = vi.spyOn(console, "info").mockImplementation(() => {});
     mocks.queueRootSelect([], [{ slug: "new-watchlist" }]);
     mocks.failSlugInserts(1);
@@ -309,7 +312,6 @@ describe("#3114 — watchlist multi-table writes are atomic", () => {
       await expect(createWatchlist({
         title: "New watchlist",
         companyIds: ["company-1"],
-        isPublic: true,
       })).resolves.toEqual({ id: "wl-new", slug: "new-watchlist-2" });
 
       expect(mocks.snapshot()).toEqual({
@@ -318,7 +320,25 @@ describe("#3114 — watchlist multi-table writes are atomic", () => {
       });
       expect(mocks.calls).toEqual({ transactions: 2, rollbacks: 1 });
       expect(audit).toHaveBeenCalledTimes(1);
-      expect(mocks.afterFn).toHaveBeenCalledTimes(2);
+      expect(mocks.afterFn).not.toHaveBeenCalled();
+    } finally {
+      audit.mockRestore();
+    }
+  });
+
+  it("rejects a legacy public create before capacity or transaction work", async () => {
+    const audit = vi.spyOn(console, "info").mockImplementation(() => {});
+    try {
+      await expect(createWatchlist({
+        title: "Must stay private",
+        companyIds: ["company-1"],
+        isPublic: true,
+      })).resolves.toEqual({ error: "visibility_locked" });
+
+      expect(mocks.snapshot()).toEqual({ watchlists: [], companies: [] });
+      expect(mocks.calls).toEqual({ transactions: 0, rollbacks: 0 });
+      expect(mocks.afterFn).not.toHaveBeenCalled();
+      expect(audit).not.toHaveBeenCalled();
     } finally {
       audit.mockRestore();
     }
@@ -435,15 +455,48 @@ describe("#3114 — watchlist multi-table writes are atomic", () => {
     expect(mocks.afterFn).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { current: false, requested: true },
+    { current: true, requested: false },
+  ])(
+    "rejects the visibility update from $current to $requested before mutation work",
+    async ({ current, requested }) => {
+      const originalState = {
+        watchlists: [{
+          id: WATCHLIST_ID,
+          userId: USER_ID,
+          slug: "existing",
+          title: "Existing",
+          description: null,
+          isPublic: current,
+          filters: {},
+        }],
+        companies: [],
+      };
+      mocks.setState(originalState);
+      mocks.queueRootSelect([{ ...originalState.watchlists[0] }]);
+
+      await expect(updateWatchlist({
+        watchlistId: WATCHLIST_ID,
+        description: "Must not partially apply",
+        isPublic: requested,
+      })).resolves.toEqual({ error: "visibility_locked" });
+
+      expect(mocks.snapshot()).toEqual(originalState);
+      expect(mocks.calls).toEqual({ transactions: 0, rollbacks: 0 });
+      expect(mocks.afterFn).not.toHaveBeenCalled();
+    },
+  );
+
   it("rolls back the destination watchlist when copied company rows fail", async () => {
     const originalState = {
       watchlists: [{
         id: WATCHLIST_ID,
-        userId: "source-owner",
+        userId: USER_ID,
         slug: "source",
         title: "Source",
         description: null,
-        isPublic: true,
+        isPublic: false,
         filters: {},
       }],
       companies: [{ watchlistId: WATCHLIST_ID, companyId: "company-1" }],
@@ -462,8 +515,7 @@ describe("#3114 — watchlist multi-table writes are atomic", () => {
     expect(mocks.afterFn).not.toHaveBeenCalled();
   });
 
-  it("copies a cross-user public source when the destination has capacity", async () => {
-    const audit = vi.spyOn(console, "info").mockImplementation(() => {});
+  it("fails closed for a cross-user source despite a legacy public flag", async () => {
     const source = {
       id: WATCHLIST_ID,
       userId: "source-owner",
@@ -484,38 +536,92 @@ describe("#3114 — watchlist multi-table writes are atomic", () => {
     }));
     mocks.setState({ watchlists: [source, ...destinationRows], companies: [] });
     mocks.queueRootSelect([{ ...source }]);
+    await expect(copyWatchlist(WATCHLIST_ID)).resolves.toEqual({
+      error: "not_found",
+    });
+
+    expect(mocks.snapshot().watchlists).toEqual([source, ...destinationRows]);
+    expect(mocks.calls).toEqual({ transactions: 0, rollbacks: 0 });
+    expect(mocks.afterFn).not.toHaveBeenCalled();
+  });
+
+  it("atomically duplicates an owned source with provenance and source-kind audit", async () => {
+    const audit = vi.spyOn(console, "info").mockImplementation(() => {});
+    const source = {
+      id: WATCHLIST_ID,
+      userId: USER_ID,
+      slug: "source",
+      title: "Owned source",
+      description: "Private filters",
+      isPublic: false,
+      filters: { keywords: ["engineer"] },
+    };
+    const destinationRows = Array.from({ length: 8 }, (_, index) => ({
+      id: `destination-${index}`,
+      userId: USER_ID,
+      slug: `destination-${index}`,
+      title: `Destination ${index}`,
+      description: null,
+      isPublic: false,
+      filters: {},
+    }));
+    mocks.setState({
+      watchlists: [source, ...destinationRows],
+      companies: [{ watchlistId: WATCHLIST_ID, companyId: "company-1" }],
+    });
+    mocks.queueRootSelect([{ ...source }]);
     mocks.setNextWatchlistId("wl-copy");
 
     try {
       await expect(copyWatchlist(WATCHLIST_ID)).resolves.toEqual({
         id: "wl-copy",
-        slug: "shared-source",
+        slug: "owned-source",
       });
 
-      const rows = mocks.snapshot().watchlists;
-      expect(rows.filter((row) => row.userId === USER_ID)).toHaveLength(10);
-      expect(rows).toContainEqual(expect.objectContaining({
+      const state = mocks.snapshot();
+      expect(state.watchlists.filter((row) => row.userId === USER_ID)).toHaveLength(10);
+      expect(state.watchlists).toContainEqual(expect.objectContaining({
         id: "wl-copy",
         userId: USER_ID,
-        title: "Shared source",
+        title: "Owned source",
+        description: "Private filters",
+        isPublic: false,
+        filters: { keywords: ["engineer"] },
         sourceWatchlistId: WATCHLIST_ID,
       }));
+      expect(state.companies).toContainEqual({
+        watchlistId: "wl-copy",
+        companyId: "company-1",
+      });
+      expect(mocks.calls).toEqual({ transactions: 1, rollbacks: 0 });
+      expect(mocks.afterFn).toHaveBeenCalledTimes(1);
+
+      const payload = JSON.parse(audit.mock.calls[0][0] as string) as Record<string, unknown>;
+      expect(payload).toMatchObject({
+        action: "watchlist.copy",
+        watchlist_id: "wl-copy",
+        copy_source_kind: "owned",
+        is_public_after: false,
+      });
+      expect(JSON.stringify(payload)).not.toContain(USER_ID);
+      expect(JSON.stringify(payload)).not.toContain("engineer");
+      expect(JSON.stringify(payload)).not.toContain(WATCHLIST_ID);
     } finally {
       audit.mockRestore();
     }
   });
 
-  it("applies copy capacity to the destination owner, not the cross-user source", async () => {
+  it("applies copy capacity to the destination owner independently of source authorization", async () => {
     const source = {
       id: WATCHLIST_ID,
-      userId: "source-owner",
+      userId: USER_ID,
       slug: "source",
       title: "Shared source",
       description: null,
-      isPublic: true,
+      isPublic: false,
       filters: {},
     };
-    const destinationRows = Array.from({ length: 10 }, (_, index) => ({
+    const destinationRows = Array.from({ length: 9 }, (_, index) => ({
       id: `destination-${index}`,
       userId: USER_ID,
       slug: `destination-${index}`,
@@ -538,11 +644,11 @@ describe("#3114 — watchlist multi-table writes are atomic", () => {
   it("rechecks copy authorization inside the transaction", async () => {
     mocks.queueRootSelect([{
       id: WATCHLIST_ID,
-      userId: "source-owner",
+      userId: USER_ID,
       slug: "source",
       title: "Source",
       description: null,
-      isPublic: true,
+      isPublic: false,
       filters: {},
     }]);
 
@@ -553,24 +659,24 @@ describe("#3114 — watchlist multi-table writes are atomic", () => {
     expect(mocks.afterFn).not.toHaveBeenCalled();
   });
 
-  it("rejects a source that becomes private before the copy transaction", async () => {
+  it("rejects a source whose ownership changes before the copy transaction", async () => {
     mocks.setState({
       watchlists: [{
         id: WATCHLIST_ID,
-        userId: "source-owner",
+        userId: "different-owner",
         slug: "source",
         title: "Source",
         description: null,
-        isPublic: false,
+        isPublic: true,
         filters: {},
       }],
       companies: [],
     });
     mocks.queueRootSelect([{
-      userId: "source-owner",
+      userId: USER_ID,
       title: "Source",
       description: null,
-      isPublic: true,
+      isPublic: false,
       filters: {},
     }]);
 

--- a/apps/web/src/lib/services/__tests__/watchlist-handoff.test.ts
+++ b/apps/web/src/lib/services/__tests__/watchlist-handoff.test.ts
@@ -45,7 +45,6 @@ describe("createWatchlistFromHandoff", () => {
       description: "Selected companies",
       companyIds: ["uuid-stripe", "uuid-gitlab"],
       filters: { workMode: ["remote"], anyCompany: false },
-      isPublic: false,
     });
   });
 

--- a/apps/web/src/lib/services/__tests__/watchlists-tier.test.ts
+++ b/apps/web/src/lib/services/__tests__/watchlists-tier.test.ts
@@ -73,4 +73,33 @@ describe("watchlists service tier boundary (#3332)", () => {
       /export async function getWatchlistByUserAndSlug\b/,
     );
   });
+
+  it("keeps every mutation entrypoint private and copy authorization visibility-free", () => {
+    const actionSrc = readSource("src/lib/actions/watchlists.ts");
+    const serviceSrc = readSource("src/lib/services/watchlists.ts");
+    const handoffSrc = readSource("src/lib/services/watchlist-handoff.ts");
+    const copyPolicySrc = readSource("src/lib/watchlist-copy-policy.ts");
+
+    expect(actionSrc).toContain("return service.createWatchlist(...args);");
+    expect(actionSrc).toContain("return service.updateWatchlist(...args);");
+    expect(actionSrc).toContain("return service.copyWatchlist(...args);");
+
+    expect(serviceSrc).toContain(
+      'if (params.isPublic === true) return { error: "visibility_locked" };',
+    );
+    expect(serviceSrc).toContain(
+      'if (params.isPublic !== undefined) return { error: "visibility_locked" };',
+    );
+    expect(serviceSrc).not.toContain("isPublic: params.isPublic");
+    expect(serviceSrc).not.toContain("updates.isPublic");
+    expect(serviceSrc).not.toContain("copy_watchlist_mirror_count");
+    expect(serviceSrc).not.toContain("_getWatchlistMirrorCount");
+
+    expect(handoffSrc).not.toContain("isPublic");
+    expect(copyPolicySrc).not.toContain("source.isPublic");
+    expect(copyPolicySrc).toContain('case "owned"');
+    expect(copyPolicySrc).toContain('case "grant"');
+    expect(copyPolicySrc).toContain('case "share"');
+    expect(copyPolicySrc).toContain('case "template"');
+  });
 });

--- a/apps/web/src/lib/services/watchlist-handoff.ts
+++ b/apps/web/src/lib/services/watchlist-handoff.ts
@@ -22,7 +22,6 @@ export async function createWatchlistFromHandoffWithDeps(params: {
     description?: string;
     companyIds: string[];
     filters?: WatchlistFilters;
-    isPublic: boolean;
   }) => Promise<{ id: string; slug: string } | { error: string }>;
 }): Promise<{ id: string; slug: string } | { error: string }> {
   if (params.companySlugs.length > MAX_HANDOFF_COMPANIES) {
@@ -56,6 +55,5 @@ export async function createWatchlistFromHandoffWithDeps(params: {
     description: params.description,
     companyIds,
     filters,
-    isPublic: false,
   });
 }

--- a/apps/web/src/lib/services/watchlists.ts
+++ b/apps/web/src/lib/services/watchlists.ts
@@ -24,7 +24,10 @@ import {
   createWithinWatchlistLimit,
   WatchlistLimitReachedError,
 } from "@/lib/watchlist-limit";
-import { canCopyWatchlistSource } from "@/lib/watchlist-copy-policy";
+import {
+  authorizeWatchlistCopySource,
+  type WatchlistCopySourceKind,
+} from "@/lib/watchlist-copy-policy";
 import {
   generateUniqueSlug,
   insertWatchlistWithUniqueSlug,
@@ -204,6 +207,7 @@ type WatchlistAuditPayload = {
   slug_after?: string | null;
   is_public_before?: boolean | null;
   is_public_after?: boolean | null;
+  copy_source_kind?: WatchlistCopySourceKind;
   company_count_delta?: number | null;
 };
 
@@ -242,6 +246,12 @@ export async function createWatchlist(params: {
   const userId = await getSessionUserId();
   if (!userId) throw new Error("Not authenticated");
 
+  // Bounded compatibility for callers that still send the retired field:
+  // false is harmless, but an attempt to create a public row fails before the
+  // slug lookup, capacity lock, or transaction. All persisted creates below
+  // are private by construction.
+  if (params.isPublic === true) return { error: "visibility_locked" };
+
   // Slug allocation is concurrency-safe: `insertWatchlistWithUniqueSlug`
   // wraps the INSERT in a retry loop that recovers from the SELECT-then-
   // INSERT race on `idx_wl_user_slug` (#3201). Two browser tabs (or a
@@ -266,7 +276,7 @@ export async function createWatchlist(params: {
               slug: candidate,
               title: params.title,
               description: params.description ?? null,
-              isPublic: params.isPublic ?? false,
+              isPublic: false,
               filters: { anyCompany: true, ...params.filters },
             })
             .returning({ id: watchlist.id });
@@ -291,15 +301,6 @@ export async function createWatchlist(params: {
   if (!inserted) return { error: "limit_reached" };
   const { row, slug } = inserted;
 
-  // Typesense + IndexNow hook: upsert if public and non-trivial.
-  // Wrapped in after() so the registration is synchronous in the
-  // request scope — calling notifyIndexNow from a detached .then()
-  // chain (the previous shape) silently broke because next/server's
-  // after() requires a live request context to attach work.
-  const isPublic = params.isPublic ?? false;
-  const mergedFilters = { anyCompany: true, ...params.filters };
-  const trivial = isTrivialWatchlist(mergedFilters, params.companyIds.length);
-
   _logWatchlistAudit({
     action: "watchlist.create",
     userId,
@@ -307,42 +308,9 @@ export async function createWatchlist(params: {
     slug_before: null,
     slug_after: slug,
     is_public_before: null,
-    is_public_after: isPublic,
+    is_public_after: false,
     company_count_delta: params.companyIds.length,
   });
-
-  // Cache invalidation runs unconditionally for public watchlists
-  // (even trivial ones): if the URL was visited before the watchlist
-  // existed, the page-level `'use cache'` may hold a null-detail
-  // noindex render that needs busting. Trivial watchlists don't go
-  // into Typesense / IndexNow (those flows are gated on !trivial).
-  if (isPublic) {
-    after(async () => {
-      try {
-        await _invalidateWatchlistCaches(userId, [slug]);
-      } catch (err) {
-        logExternalError("error", { service: "redis", operation: "create_watchlist_invalidate" }, err);
-      }
-    });
-  }
-
-  if (isPublic && !trivial) {
-    after(async () => {
-      try {
-        await _reindexPublicWatchlist(userId, {
-          id: row.id,
-          slug,
-          title: params.title,
-          description: params.description,
-          company_count: params.companyIds.length,
-          filters: mergedFilters,
-          logLabel: "createWatchlist",
-        });
-      } catch (err) {
-        logExternalError("error", { service: "external_http", operation: "create_watchlist_hook" }, err);
-      }
-    });
-  }
 
   return { id: row.id, slug };
 }
@@ -391,6 +359,11 @@ export async function updateWatchlist(params: {
 
   if (!wl || wl.userId !== userId) return { error: "not_found" };
 
+  // Visibility is no longer mutable through the domain service. Keep the
+  // field in the input temporarily so the backend can fail closed while the
+  // separate UI cutover removes legacy toggles.
+  if (params.isPublic !== undefined) return { error: "visibility_locked" };
+
   let newSlug = wl.slug;
   const updates: Record<string, unknown> = {};
 
@@ -410,8 +383,6 @@ export async function updateWatchlist(params: {
   }
   if (params.description !== undefined) updates.description = params.description;
   if (params.filters !== undefined) updates.filters = params.filters;
-  if (params.isPublic !== undefined) updates.isPublic = params.isPublic;
-
   if (Object.keys(updates).length > 0 || params.companyIds !== undefined) {
     await db.transaction(async (tx) => {
       if (params.companyIds !== undefined) {
@@ -456,7 +427,7 @@ export async function updateWatchlist(params: {
   // after the response is flushed but before Vercel terminates the
   // function.
   const wasPublic = wl.isPublic;
-  const nowPublic = params.isPublic !== undefined ? params.isPublic : wasPublic;
+  const nowPublic = wasPublic;
   const newFilters = params.filters !== undefined
     ? params.filters
     : (wl.filters ?? {}) as WatchlistFilters;
@@ -481,8 +452,9 @@ export async function updateWatchlist(params: {
       // Bust both cache layers so the next read of the page (and its
       // OG meta + JSON-LD) reflects the edit. Pass both old + new slug:
       // a rename leaves the old URL pointing at a stale cached entry
-      // until its TTL expires. Privacy toggles + filter/companies edits
-      // also flow through here. See cache-components.md "Layered TTL".
+      // until its TTL expires. Filter/company edits to grandfathered public
+      // rows also flow through here until migration. See cache-components.md
+      // "Layered TTL".
       const slugsToInvalidate = newSlug !== wl.slug ? [wl.slug, newSlug] : [wl.slug];
       await _invalidateWatchlistCaches(userId, slugsToInvalidate);
 
@@ -580,24 +552,29 @@ export async function copyWatchlist(
   const userId = await getSessionUserId();
   if (!userId) throw new Error("Not authenticated");
 
+  // The server action exposes only owner duplication today. Future verified
+  // grant/share/template entrypoints can select another source kind, but must
+  // still pass through the policy recheck and destination transaction below.
+  const requestedSourceKind: WatchlistCopySourceKind = "owned";
+
   const [source] = await db
     .select({
       title: watchlist.title,
-      description: watchlist.description,
-      filters: watchlist.filters,
-      isPublic: watchlist.isPublic,
       userId: watchlist.userId,
     })
     .from(watchlist)
     .where(eq(watchlist.id, watchlistId))
     .limit(1);
 
-  if (!source || !canCopyWatchlistSource(source, userId)) {
+  const sourceAuthorization = source
+    ? authorizeWatchlistCopySource(source, userId, requestedSourceKind)
+    : null;
+  if (!sourceAuthorization) {
     return { error: "not_found" };
   }
 
   // Same race shape as createWatchlist (#3201): two fast clicks of the
-  // "Copy" button on a public watchlist used to race the SELECT-then-
+  // "Copy" button on a watchlist used to race the SELECT-then-
   // INSERT slug pick and crash the loser. The helper retries on a
   // `idx_wl_user_slug` 23505. As in create, each retry attempt owns a
   // fresh transaction so a rejected candidate never poisons the next. Re-read
@@ -617,7 +594,6 @@ export async function copyWatchlist(
                 title: watchlist.title,
                 description: watchlist.description,
                 filters: watchlist.filters,
-                isPublic: watchlist.isPublic,
                 userId: watchlist.userId,
               })
               .from(watchlist)
@@ -625,10 +601,14 @@ export async function copyWatchlist(
               .for("share")
               .limit(1);
 
-            if (
-              !currentSource
-              || !canCopyWatchlistSource(currentSource, userId)
-            ) {
+            const currentAuthorization = currentSource
+              ? authorizeWatchlistCopySource(
+                currentSource,
+                userId,
+                sourceAuthorization.sourceKind,
+              )
+              : null;
+            if (!currentAuthorization) {
               throw new WatchlistCopySourceUnavailableError();
             }
 
@@ -662,7 +642,11 @@ export async function copyWatchlist(
               );
             }
 
-            return { row: r, companies };
+            return {
+              row: r,
+              companies,
+              sourceKind: currentAuthorization.sourceKind,
+            };
           }),
         ),
     );
@@ -677,7 +661,7 @@ export async function copyWatchlist(
   }
 
   const { row: copyResult, slug } = inserted;
-  const { row, companies } = copyResult;
+  const { row, companies, sourceKind } = copyResult;
 
   _logWatchlistAudit({
     action: "watchlist.copy",
@@ -687,6 +671,7 @@ export async function copyWatchlist(
     slug_after: slug,
     is_public_before: null,
     is_public_after: false,
+    copy_source_kind: sourceKind,
     company_count_delta: companies.length,
   });
 
@@ -706,19 +691,8 @@ export async function copyWatchlist(
     }
   });
 
-  // Copies now default to private, so they must not enter Typesense,
-  // sitemaps, or IndexNow until the owner explicitly makes them public.
-
-  // 2. Update source watchlist's mirror_count (increment). No IndexNow
-  // here — the source URL hasn't changed visible content.
-  after(async () => {
-    try {
-      const count = await _getWatchlistMirrorCount(watchlistId);
-      tsUpdateWatchlistField(watchlistId, { mirror_count: count });
-    } catch (err) {
-      logExternalError("error", { service: "typesense", operation: "copy_watchlist_mirror_count" }, err);
-    }
-  });
+  // Copies are private by construction, so they never enter Typesense,
+  // sitemaps, or IndexNow.
 
   return { id: row.id, slug };
 }
@@ -2576,16 +2550,4 @@ async function _countWatchlistCompanies(watchlistId: string): Promise<number> {
 async function _syncWatchlistCompanyCountToTypesense(watchlistId: string): Promise<void> {
   const count = await _countWatchlistCompanies(watchlistId);
   tsUpdateWatchlistField(watchlistId, { company_count: count });
-}
-
-/** Get the mirror count for a watchlist (number of copies). */
-async function _getWatchlistMirrorCount(watchlistId: string): Promise<number> {
-  const [row] = await withDbRetry(
-    () =>
-      db.execute<{ [key: string]: unknown; cnt: number }>(
-        sql`SELECT count(*)::int AS cnt FROM watchlist WHERE source_watchlist_id = ${watchlistId}`,
-      ),
-    { label: `watchlistMirrorCount[${watchlistId}]` },
-  );
-  return (row as unknown as { cnt: number })?.cnt ?? 0;
 }

--- a/apps/web/src/lib/watchlist-copy-policy.ts
+++ b/apps/web/src/lib/watchlist-copy-policy.ts
@@ -1,13 +1,43 @@
 /**
  * Source-side authorization for watchlist copies.
  *
- * Keep this separate from destination capacity: future share grants and
- * curated templates can extend this policy without bypassing the universal
- * destination-owner limit enforced by the creation transaction.
+ * Keep this separate from destination capacity: a source decision says only
+ * whether the caller may clone this row. The destination-owner limit remains
+ * an independent, transaction-scoped policy in `watchlist-limit.ts`.
+ *
+ * Only `owned` is live today. The other kinds are deliberately represented so
+ * a future grant/share/template implementation has to add real evidence here
+ * instead of falling back to visibility or bypassing destination capacity.
  */
-export function canCopyWatchlistSource(source: {
-  userId: string;
-  isPublic: boolean;
-}, destinationUserId: string): boolean {
-  return source.userId === destinationUserId || source.isPublic;
+export const WATCHLIST_COPY_SOURCE_KINDS = [
+  "owned",
+  "grant",
+  "share",
+  "template",
+] as const;
+
+export type WatchlistCopySourceKind =
+  (typeof WATCHLIST_COPY_SOURCE_KINDS)[number];
+
+export type WatchlistCopyAuthorization = {
+  sourceKind: WatchlistCopySourceKind;
+};
+
+export function authorizeWatchlistCopySource(
+  source: { userId: string },
+  destinationUserId: string,
+  requestedSourceKind: WatchlistCopySourceKind = "owned",
+): WatchlistCopyAuthorization | null {
+  switch (requestedSourceKind) {
+    case "owned":
+      return source.userId === destinationUserId
+        ? { sourceKind: "owned" }
+        : null;
+    case "grant":
+    case "share":
+    case "template":
+      // Dormant until the corresponding server-verified authorization source
+      // exists. In particular, `is_public` is intentionally not evidence.
+      return null;
+  }
 }


### PR DESCRIPTION
## Summary

- make watchlist creation private by construction, reject legacy public-create intent, and reject every service-level visibility update before mutation work
- replace `is_public` copy permission with an explicit source authorization policy: `owned` is active while `grant`, `share`, and `template` remain fail-closed seams for future verified authorization
- preserve the existing advisory-lock capacity kernel, atomic destination/filter/company cloning, and `sourceWatchlistId`; record the non-sensitive copy source kind in audit output
- remove copy-time mirror-count writes and keep handoff creation free of visibility input

## Rollout notes

This backend/privacy gate must land before the row migration in #8369. Existing public rows are intentionally not migrated or purged here; ordinary owner edits retain their stored legacy visibility until that coordinated migration. The temporary mutation input compatibility accepts `isPublic: false`, rejects `true` creation, and rejects any visibility update. Cross-user copy returns privacy-safe `not_found`, even for a legacy public row.

No sharing UI, grant persistence, template catalog, route/rendering work, row migration, SEO/cache/OG/Typesense purge, notifications, API authentication, or cost changes are included. The human UI taste gate and cost gate are not applicable because this PR changes no rendered UI/product copy and no provider tier, quota, or paid commitment.

## Verification

- `pnpm exec vitest run src/lib/__tests__/watchlist-copy-policy.test.ts src/lib/actions/__tests__/watchlists-transactions.test.ts src/lib/actions/__tests__/watchlists-invalidation.test.ts src/lib/services/__tests__/watchlists-tier.test.ts src/lib/services/__tests__/watchlist-handoff.test.ts` — 53 passed
- `pnpm typecheck` — passed
- focused ESLint on all changed TypeScript files — passed
- `git diff --check` — passed
- commit and push hooks — passed

A broad raw Vitest run was stopped after reproducing the pre-existing generated company Proxy matcher failure; CI owns the generated-suite breadth for this focused handoff.

Closes #8364
Refs #8348
Refs #8366