### PR TITLE
Add canonical watchlist candidate matcher

### DIFF
--- a/apps/web/src/lib/search/__tests__/watchlist-candidate-query.test.ts
+++ b/apps/web/src/lib/search/__tests__/watchlist-candidate-query.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, expectTypeOf, it } from "vitest";
+import type { WatchlistCandidateFilters } from "@/lib/watchlist-matcher-contract";
 
 import {
   buildWatchlistCandidateSearchParams,
@@ -9,6 +10,12 @@ import {
 const companyId = "11111111-1111-1111-1111-111111111111";
 
 describe("canonical watchlist candidate query", () => {
+  it("keeps candidate company membership readonly at the compiler boundary", () => {
+    expectTypeOf<WatchlistCandidateFilters["companyIds"]>().toEqualTypeOf<
+      readonly string[]
+    >();
+  });
+
   it("preserves every interactive structured-filter dimension", () => {
     const search = buildWatchlistCandidateSearchParams({
       filters: {

--- a/apps/web/src/lib/search/__tests__/watchlist-candidate-query.test.ts
+++ b/apps/web/src/lib/search/__tests__/watchlist-candidate-query.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildWatchlistCandidateSearchParams,
+  buildWatchlistCandidateWindowFilter,
+  WATCHLIST_CANDIDATE_WINDOW_BOUNDARY,
+} from "../watchlist-candidate-query";
+
+const companyId = "11111111-1111-1111-1111-111111111111";
+
+describe("canonical watchlist candidate query", () => {
+  it("preserves every interactive structured-filter dimension", () => {
+    const search = buildWatchlistCandidateSearchParams({
+      filters: {
+        companyIds: [companyId],
+        keywords: ["staff", "engineer"],
+        locationIds: [1],
+        occupationIds: [2],
+        seniorityIds: [3],
+        technologyIds: [4],
+        workMode: ["remote"],
+        employmentType: ["full_time"],
+        salaryMin: 100_000,
+        salaryMax: 180_000,
+        experienceMin: 3,
+        experienceMax: 7,
+        languages: ["de", "en"],
+      },
+      offset: 20,
+      limit: 20,
+    });
+
+    expect(search).toMatchObject({
+      q: "staff engineer",
+      query_by: "title",
+      sort_by: "_text_match:desc,first_seen_at:desc",
+      per_page: 20,
+      page: 2,
+    });
+    expect(search.filter_by).toContain("is_active:true");
+    expect(search.filter_by).toContain("has_content:!=false");
+    expect(search.filter_by).toContain(`company_id:[${companyId}]`);
+    expect(search.filter_by).toContain("location_ids:[1]");
+    expect(search.filter_by).toContain("occupation_ids:[2]");
+    expect(search.filter_by).toContain("seniority_id:[3]");
+    expect(search.filter_by).toContain("technology_ids:[4]");
+    expect(search.filter_by).toContain("location_types:[remote]");
+    expect(search.filter_by).toContain("employment_type:[full_time]");
+    expect(search.filter_by).toContain("salary_eur:[100000..180000]");
+    expect(search.filter_by).toContain("locales:[de,en,_none]");
+  });
+
+  it("uses an explicit half-open whole-second UTC window", () => {
+    const windowStart = new Date("2026-08-24T00:00:00.000Z");
+    const windowEnd = new Date("2026-08-31T00:00:00.000Z");
+    const filter = buildWatchlistCandidateWindowFilter({
+      windowStart,
+      windowEnd,
+    });
+
+    expect(WATCHLIST_CANDIDATE_WINDOW_BOUNDARY).toBe(
+      "[windowStart, windowEnd)",
+    );
+    expect(filter).toBe(
+      `first_seen_at:>=${windowStart.getTime() / 1_000} && ` +
+        `first_seen_at:<${windowEnd.getTime() / 1_000}`,
+    );
+
+    const search = buildWatchlistCandidateSearchParams({
+      filters: { companyIds: [], anyCompany: true },
+      offset: 0,
+      limit: 20,
+      window: { windowStart, windowEnd },
+      order: "newest",
+    });
+    expect(search.filter_by).toContain("is_active:true");
+    expect(search.filter_by).toContain(filter);
+    expect(search.sort_by).toBe("first_seen_at:desc");
+  });
+
+  it("rejects overlapping/ambiguous window bounds", () => {
+    const instant = new Date("2026-08-31T00:00:00.000Z");
+    expect(() =>
+      buildWatchlistCandidateWindowFilter({
+        windowStart: instant,
+        windowEnd: instant,
+      }),
+    ).toThrow("windowStart must be earlier than windowEnd");
+    expect(() =>
+      buildWatchlistCandidateWindowFilter({
+        windowStart: new Date("2026-08-24T00:00:00.001Z"),
+        windowEnd: instant,
+      }),
+    ).toThrow("whole-second Typesense precision");
+  });
+
+  it("fails closed on unsafe company identifiers", () => {
+    expect(() =>
+      buildWatchlistCandidateSearchParams({
+        filters: { companyIds: ["safe] || is_active:false"] },
+        offset: 0,
+        limit: 20,
+      }),
+    ).toThrow("invalid Typesense identifier");
+  });
+});

--- a/apps/web/src/lib/search/search-runner.ts
+++ b/apps/web/src/lib/search/search-runner.ts
@@ -21,6 +21,7 @@ import {
   ANON_MAX_WATCHLIST_POSTINGS,
 } from "./constants";
 import { logExternalError } from "@/lib/safe-external-error";
+import type { WatchlistCandidateFilters } from "@/lib/watchlist-matcher-contract";
 
 type SearchInput = SearchFilters & { keywords: string[]; offset: number; limit: number };
 type ListInput = SearchFilters & { offset: number; limit: number };
@@ -143,25 +144,9 @@ export async function tryListTopCompaniesDirect(
   return null;
 }
 
-type WatchlistPostingsInput = {
-  companyIds: string[];
-  anyCompany?: boolean;
+type WatchlistPostingsInput = WatchlistCandidateFilters & {
   offset: number;
   limit: number;
-  keywords?: string[];
-  locationIds?: number[];
-  occupationIds?: number[];
-  seniorityIds?: number[];
-  technologyIds?: number[];
-  /** Work-mode filter — `onsite | hybrid | remote` (issue #3037). */
-  workMode?: ("onsite" | "hybrid" | "remote")[];
-  /** Employment-type filter (issue #3037). */
-  employmentType?: string[];
-  salaryMin?: number;
-  salaryMax?: number;
-  experienceMin?: number;
-  experienceMax?: number;
-  languages?: string[];
 };
 
 type WatchlistRefreshResult = {

--- a/apps/web/src/lib/search/typesense-browser-watchlist.ts
+++ b/apps/web/src/lib/search/typesense-browser-watchlist.ts
@@ -3,15 +3,18 @@ import {
   invalidateTypesenseBrowserConfigIfUnauthorized,
   type TypesenseBrowserConfig,
 } from "./typesense-browser-key";
-import {
-  buildFilterString,
-  POSTING_BASE_FILTER,
-  POSTING_FLOW_FILTER,
-} from "./typesense-filters";
+import { buildFilterString, POSTING_FLOW_FILTER } from "./typesense-filters";
 import { COMPANY_BATCH_SIZE } from "./constants";
 import { isTypesenseQueryStringSafe } from "./typesense-query-size";
-import type { WatchlistPostingEntry } from "@/lib/actions/watchlists";
+import type {
+  WatchlistCandidateFilters,
+  WatchlistPostingEntry,
+} from "@/lib/watchlist-matcher-contract";
 import { normalizePostingTitle } from "@/lib/posting-title";
+import {
+  buildWatchlistCandidateSearchParams,
+  hasWatchlistCandidateScope,
+} from "./watchlist-candidate-query";
 
 interface JobPostingDoc {
   id: string;
@@ -148,25 +151,9 @@ function mapHit(doc: Record<string, unknown>): WatchlistPostingEntry {
   };
 }
 
-export interface WatchlistPostingsParams {
-  companyIds: string[];
-  anyCompany?: boolean;
+export interface WatchlistPostingsParams extends WatchlistCandidateFilters {
   offset: number;
   limit: number;
-  keywords?: string[];
-  locationIds?: number[];
-  occupationIds?: number[];
-  seniorityIds?: number[];
-  technologyIds?: number[];
-  /** Work-mode filter — `onsite | hybrid | remote` (issue #3037). */
-  workMode?: ("onsite" | "hybrid" | "remote")[];
-  /** Employment-type filter (issue #3037). */
-  employmentType?: string[];
-  salaryMin?: number;
-  salaryMax?: number;
-  experienceMin?: number;
-  experienceMax?: number;
-  languages?: string[];
 }
 
 /**
@@ -180,43 +167,18 @@ export interface WatchlistPostingsParams {
 export async function getWatchlistPostingsBrowser(
   params: WatchlistPostingsParams,
 ): Promise<{ postings: WatchlistPostingEntry[]; total: number }> {
-  if (!params.anyCompany && params.companyIds.length === 0) {
+  if (!hasWatchlistCandidateScope(params)) {
     return { postings: [], total: 0 };
   }
   if (params.companyIds.length > COMPANY_BATCH_SIZE) {
     throw new Error("watchlist exceeds COMPANY_BATCH_SIZE — falling back");
   }
 
-  const filterStr = buildFilterString({
-    locationIds: params.locationIds,
-    occupationIds: params.occupationIds,
-    seniorityIds: params.seniorityIds,
-    technologyIds: params.technologyIds,
-    workMode: params.workMode?.length ? params.workMode : undefined,
-    employmentTypes: params.employmentType?.length ? params.employmentType : undefined,
-    salaryMinEur: params.salaryMin,
-    salaryMaxEur: params.salaryMax,
-    experienceMin: params.experienceMin,
-    experienceMax: params.experienceMax,
-    languages: params.languages,
+  const searchParams = buildWatchlistCandidateSearchParams({
+    filters: params,
+    offset: params.offset,
+    limit: params.limit,
   });
-  const hasKeywords = params.keywords && params.keywords.length > 0;
-  const q = hasKeywords ? params.keywords!.join(" ") : "*";
-
-  const filterParts = [POSTING_BASE_FILTER];
-  if (params.companyIds.length > 0) {
-    filterParts.push(`company_id:[${params.companyIds.join(",")}]`);
-  }
-  if (filterStr) filterParts.push(filterStr);
-
-  const searchParams = {
-    q,
-    query_by: "title",
-    filter_by: filterParts.join(" && "),
-    sort_by: hasKeywords ? "_text_match:desc,first_seen_at:desc" : "first_seen_at:desc",
-    per_page: params.limit === 0 ? 0 : params.limit,
-    page: params.limit === 0 ? 1 : Math.floor(params.offset / params.limit) + 1,
-  };
   if (!isTypesenseQueryStringSafe(searchParams)) {
     throw new Error("watchlist Typesense query exceeds GET limit — falling back");
   }

--- a/apps/web/src/lib/search/watchlist-candidate-query.ts
+++ b/apps/web/src/lib/search/watchlist-candidate-query.ts
@@ -1,0 +1,135 @@
+import type { WatchlistCandidateFilters } from "@/lib/watchlist-matcher-contract";
+import { buildFilterString, POSTING_BASE_FILTER } from "@/lib/search/typesense-filters";
+
+/** Adjacent delivery windows compose without gaps or duplicate boundary jobs. */
+export const WATCHLIST_CANDIDATE_WINDOW_BOUNDARY =
+  "[windowStart, windowEnd)" as const;
+
+export type WatchlistCandidateWindow = {
+  /** Inclusive UTC instant. Must align to the index's whole-second precision. */
+  windowStart: Date;
+  /** Exclusive UTC instant. Must align to the index's whole-second precision. */
+  windowEnd: Date;
+};
+
+export type WatchlistCandidateOrder = "interactive" | "newest";
+
+export type WatchlistCandidateSearchParams = {
+  q: string;
+  query_by: "title";
+  filter_by: string;
+  sort_by: string;
+  per_page: number;
+  page: number;
+};
+
+function unixSecond(value: Date, name: "windowStart" | "windowEnd"): number {
+  if (!(value instanceof Date) || !Number.isFinite(value.getTime())) {
+    throw new TypeError(`${name} must be a valid UTC Date`);
+  }
+  if (value.getUTCMilliseconds() !== 0) {
+    throw new RangeError(
+      `${name} must align to whole-second Typesense precision`,
+    );
+  }
+  return value.getTime() / 1_000;
+}
+
+/**
+ * Compile the explicit UTC window to Typesense's numeric timestamp grammar.
+ * The interval is start-inclusive and end-exclusive: `[start, end)`.
+ */
+export function buildWatchlistCandidateWindowFilter(
+  window: WatchlistCandidateWindow,
+): string {
+  const start = unixSecond(window.windowStart, "windowStart");
+  const end = unixSecond(window.windowEnd, "windowEnd");
+  if (start >= end) {
+    throw new RangeError("windowStart must be earlier than windowEnd");
+  }
+  return `first_seen_at:>=${start} && first_seen_at:<${end}`;
+}
+
+export function hasWatchlistCandidateScope(
+  filters: WatchlistCandidateFilters,
+): boolean {
+  return filters.anyCompany === true || filters.companyIds.length > 0;
+}
+
+function safeCompanyIds(values: readonly string[]): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    // Company IDs are UUIDs today, but keep the contract compatible with a
+    // future safe Typesense identifier while rejecting filter grammar.
+    if (!/^[0-9a-z_-]{8,64}$/i.test(value)) {
+      throw new TypeError("companyIds contains an invalid Typesense identifier");
+    }
+    if (!seen.has(value)) {
+      seen.add(value);
+      result.push(value);
+    }
+  }
+  return result;
+}
+
+/**
+ * One canonical compiler for every current-watchlist candidate search.
+ * Interactive reads omit `window`; background notification/AI reads pass an
+ * explicit window and choose deterministic newest-first ordering.
+ */
+export function buildWatchlistCandidateSearchParams(params: {
+  filters: WatchlistCandidateFilters;
+  offset: number;
+  limit: number;
+  window?: WatchlistCandidateWindow;
+  order?: WatchlistCandidateOrder;
+}): WatchlistCandidateSearchParams {
+  if (!Number.isInteger(params.offset) || params.offset < 0) {
+    throw new RangeError("offset must be a non-negative integer");
+  }
+  if (!Number.isInteger(params.limit) || params.limit < 0) {
+    throw new RangeError("limit must be a non-negative integer");
+  }
+
+  const filters = params.filters;
+  const structuredFilter = buildFilterString({
+    locationIds: filters.locationIds,
+    occupationIds: filters.occupationIds,
+    seniorityIds: filters.seniorityIds,
+    technologyIds: filters.technologyIds,
+    workMode: filters.workMode?.length ? filters.workMode : undefined,
+    employmentTypes: filters.employmentType?.length
+      ? filters.employmentType
+      : undefined,
+    salaryMinEur: filters.salaryMin,
+    salaryMaxEur: filters.salaryMax,
+    experienceMin: filters.experienceMin,
+    experienceMax: filters.experienceMax,
+    languages: filters.languages,
+  });
+  const companyIds = filters.anyCompany ? [] : safeCompanyIds(filters.companyIds);
+  const filterParts = [POSTING_BASE_FILTER];
+  if (params.window) {
+    filterParts.push(buildWatchlistCandidateWindowFilter(params.window));
+  }
+  if (companyIds.length > 0) {
+    filterParts.push(`company_id:[${companyIds.join(",")}]`);
+  }
+  if (structuredFilter) filterParts.push(structuredFilter);
+
+  const hasKeywords = Boolean(filters.keywords?.length);
+  const order = params.order ?? "interactive";
+  return {
+    q: hasKeywords ? filters.keywords!.join(" ") : "*",
+    query_by: "title",
+    filter_by: filterParts.join(" && "),
+    sort_by:
+      order === "interactive" && hasKeywords
+        ? "_text_match:desc,first_seen_at:desc"
+        : "first_seen_at:desc",
+    per_page: params.limit,
+    page:
+      params.limit === 0 ? 1 : Math.floor(params.offset / params.limit) + 1,
+  };
+}

--- a/apps/web/src/lib/services/__tests__/watchlist-matcher.test.ts
+++ b/apps/web/src/lib/services/__tests__/watchlist-matcher.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
+const mocks = vi.hoisted(() => ({
+  getCurrencyRates: vi.fn(),
+  resolveLocationSlugs: vi.fn(),
+  resolveOccupationSlugs: vi.fn(),
+  resolveSenioritySlugs: vi.fn(),
+  resolveTechnologySlugs: vi.fn(),
+  multiSearch: vi.fn(),
+  singleSearch: vi.fn(),
+}));
+
+vi.mock("@/lib/services/search", () => ({
+  getCurrencyRates: mocks.getCurrencyRates,
+}));
+vi.mock("@/lib/services/locations", () => ({
+  resolveLocationSlugs: mocks.resolveLocationSlugs,
+}));
+vi.mock("@/lib/services/taxonomy", () => ({
+  resolveOccupationSlugs: mocks.resolveOccupationSlugs,
+  resolveSenioritySlugs: mocks.resolveSenioritySlugs,
+  resolveTechnologySlugs: mocks.resolveTechnologySlugs,
+}));
+vi.mock("@/lib/search/typesense-client", () => ({
+  getSearchClient: () => ({
+    collections: () => ({ documents: () => ({ search: mocks.singleSearch }) }),
+    multiSearch: { perform: mocks.multiSearch },
+  }),
+}));
+vi.mock("@/lib/search/typesense-retry", async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import("@/lib/search/typesense-retry")
+  >();
+  return {
+    ...actual,
+    withTypesenseRetry: (operation: () => Promise<unknown>) => operation(),
+  };
+});
+import {
+  compileWatchlistMatcherSources,
+  matchCompiledWatchlistsInWindow,
+} from "../watchlist-matcher";
+
+function posting(id: string, firstSeenAt: number) {
+  return {
+    document: {
+      id,
+      title: `Role ${id}`,
+      source_url: `https://example.test/${id}`,
+      first_seen_at: firstSeenAt,
+      is_active: true,
+      company_id: "company-1",
+      company_name: "Acme",
+      company_slug: "acme",
+      location_names: ["Zurich"],
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.getCurrencyRates.mockResolvedValue([
+    { currency: "USD", toEur: 0.9 },
+  ]);
+  mocks.resolveLocationSlugs.mockResolvedValue(
+    new Map([
+      [
+        "zurich",
+        {
+          id: 10,
+          slug: "zurich",
+          name: "Zürich",
+          type: "city",
+          parentName: "Schweiz",
+        },
+      ],
+    ]),
+  );
+  mocks.resolveOccupationSlugs.mockResolvedValue(
+    new Map([["engineering", { id: 20, slug: "engineering", name: "Engineering" }]]),
+  );
+  mocks.resolveSenioritySlugs.mockResolvedValue(
+    new Map([["senior", { id: 30, slug: "senior", name: "Senior" }]]),
+  );
+  mocks.resolveTechnologySlugs.mockResolvedValue(
+    new Map([["typescript", { id: 40, slug: "typescript", name: "TypeScript" }]]),
+  );
+});
+
+describe("compileWatchlistMatcherSources", () => {
+  it("batch-resolves current taxonomy, currency, and owner locale semantics", async () => {
+    const compiled = await compileWatchlistMatcherSources([
+      {
+        watchlistId: "watchlist-1",
+        watchlistLabel: "Backend",
+        filters: {
+          keywords: ["staff"],
+          locationSlugs: ["zurich"],
+          occupationSlugs: ["engineering"],
+          senioritySlugs: ["senior"],
+          technologySlugs: ["typescript"],
+          workMode: ["remote"],
+          employmentType: ["full_time"],
+          salaryMin: 100_000,
+          salaryCurrency: "USD",
+          experienceMin: 3,
+        },
+        companyIds: ["company-1"],
+        locale: "de",
+        jobLanguages: [],
+      },
+      {
+        watchlistId: "watchlist-2",
+        watchlistLabel: "All roles",
+        filters: { anyCompany: true, locationSlugs: ["zurich"] },
+        companyIds: ["company-2"],
+        locale: "de",
+        jobLanguages: ["*"],
+      },
+    ]);
+
+    expect(mocks.resolveLocationSlugs).toHaveBeenCalledTimes(1);
+    expect(mocks.resolveLocationSlugs).toHaveBeenCalledWith(["zurich"], "de");
+    expect(mocks.getCurrencyRates).toHaveBeenCalledTimes(1);
+    expect(compiled[0]?.candidateFilters).toMatchObject({
+      companyIds: ["company-1"],
+      keywords: ["staff"],
+      locationIds: [10],
+      occupationIds: [20],
+      seniorityIds: [30],
+      technologyIds: [40],
+      workMode: ["remote"],
+      employmentType: ["full_time"],
+      salaryMin: 90_000,
+      experienceMin: 3,
+      languages: ["de"],
+    });
+    expect(compiled[1]?.candidateFilters).toMatchObject({
+      companyIds: [],
+      anyCompany: true,
+      locationIds: [10],
+      languages: [],
+    });
+  });
+});
+
+describe("matchCompiledWatchlistsInWindow", () => {
+  it("uses one multi-search and deduplicates posting IDs with all labels", async () => {
+    const start = new Date("2026-08-24T00:00:00.000Z");
+    const end = new Date("2026-08-31T00:00:00.000Z");
+    const shared = posting("shared", end.getTime() / 1_000 - 20);
+    mocks.multiSearch.mockResolvedValue({
+      results: [
+        {
+          found: 2,
+          hits: [posting("newest", end.getTime() / 1_000 - 10), shared],
+        },
+        {
+          found: 2,
+          hits: [shared, posting("older", start.getTime() / 1_000 + 10)],
+        },
+      ],
+    });
+
+    const result = await matchCompiledWatchlistsInWindow({
+      watchlists: [
+        {
+          watchlistId: "watchlist-1",
+          watchlistLabel: "Backend",
+          candidateFilters: {
+            companyIds: ["company-1"],
+            locationIds: [10],
+            languages: ["de"],
+          },
+        },
+        {
+          watchlistId: "watchlist-2",
+          watchlistLabel: "Remote",
+          candidateFilters: {
+            companyIds: [],
+            anyCompany: true,
+            workMode: ["remote"],
+            languages: ["en"],
+          },
+        },
+      ],
+      windowStart: start,
+      windowEnd: end,
+      limitPerWatchlist: 20,
+    });
+
+    expect(mocks.multiSearch).toHaveBeenCalledTimes(1);
+    const request = mocks.multiSearch.mock.calls[0]?.[0] as {
+      searches: Array<{ filter_by: string; sort_by: string }>;
+    };
+    expect(request.searches).toHaveLength(2);
+    for (const search of request.searches) {
+      expect(search.filter_by).toContain("is_active:true");
+      expect(search.filter_by).toContain(
+        `first_seen_at:>=${start.getTime() / 1_000}`,
+      );
+      expect(search.filter_by).toContain(
+        `first_seen_at:<${end.getTime() / 1_000}`,
+      );
+      expect(search.sort_by).toBe("first_seen_at:desc");
+    }
+    expect(request.searches[0]?.filter_by).toContain("location_ids:[10]");
+    expect(request.searches[0]?.filter_by).toContain("locales:[de,_none]");
+    expect(request.searches[1]?.filter_by).toContain("location_types:[remote]");
+
+    expect(result.window).toEqual({
+      windowStart: start.toISOString(),
+      windowEnd: end.toISOString(),
+      boundary: "[windowStart, windowEnd)",
+    });
+    expect(result.postings.map((value) => value.id)).toEqual([
+      "newest",
+      "shared",
+      "older",
+    ]);
+    expect(
+      result.postings.find((value) => value.id === "shared")?.matchedWatchlists,
+    ).toEqual([
+      { id: "watchlist-1", label: "Backend" },
+      { id: "watchlist-2", label: "Remote" },
+    ]);
+    expect(result.watchlists).toEqual([
+      { id: "watchlist-1", label: "Backend", total: 2, returned: 2, truncated: false },
+      { id: "watchlist-2", label: "Remote", total: 2, returned: 2, truncated: false },
+    ]);
+  });
+});

--- a/apps/web/src/lib/services/watchlist-matcher.ts
+++ b/apps/web/src/lib/services/watchlist-matcher.ts
@@ -1,0 +1,600 @@
+import "server-only";
+
+import { getCurrencyRates } from "@/lib/services/search";
+import { resolveLocationSlugs, type ResolvedLocation } from "@/lib/services/locations";
+import {
+  resolveOccupationSlugs,
+  resolveSenioritySlugs,
+  resolveTechnologySlugs,
+  type TaxonomySuggestion,
+} from "@/lib/services/taxonomy";
+import { resolveJobLanguages } from "@/lib/job-languages";
+import { convertToEur } from "@/lib/salary";
+import { getSearchClient } from "@/lib/search/typesense-client";
+import {
+  assertTypesenseSearchResult,
+  malformedTypesenseResponseError,
+  withTypesenseRetry,
+} from "@/lib/search/typesense-retry";
+import {
+  parseTypesenseMultiSearchResults,
+  type TypesenseMultiSearchResult,
+} from "@/lib/search/typesense-multi-search";
+import {
+  isTypesenseQueryStringSafe,
+  splitValuesForTypesenseQuery,
+} from "@/lib/search/typesense-query-size";
+import { COMPANY_BATCH_SIZE } from "@/lib/search/constants";
+import { normalizePostingTitle } from "@/lib/posting-title";
+import { canonicalStringCompare } from "@/lib/sort";
+import {
+  buildWatchlistCandidateSearchParams,
+  hasWatchlistCandidateScope,
+  WATCHLIST_CANDIDATE_WINDOW_BOUNDARY,
+  type WatchlistCandidateOrder,
+  type WatchlistCandidateSearchParams,
+  type WatchlistCandidateWindow,
+} from "@/lib/search/watchlist-candidate-query";
+import type {
+  CompiledWatchlistMatcher,
+  MatchedWatchlistPosting,
+  WatchlistCandidateFilters,
+  WatchlistMatcherSource,
+  WatchlistPostingEntry,
+} from "@/lib/watchlist-matcher-contract";
+
+type WorkMode = NonNullable<WatchlistCandidateFilters["workMode"]>[number];
+
+const WORK_MODES = new Set<WorkMode>(["onsite", "hybrid", "remote"]);
+const MULTI_SEARCH_CHUNK_SIZE = 40;
+
+export type CompiledWatchlistFilter = CompiledWatchlistMatcher & {
+  resolvedLocations: ResolvedLocation[];
+  resolvedOccupations: TaxonomySuggestion[];
+  resolvedSeniorities: TaxonomySuggestion[];
+  resolvedTechnologies: TaxonomySuggestion[];
+};
+
+function strings(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const result = value.filter(
+    (item): item is string => typeof item === "string" && item.length > 0,
+  );
+  return result.length > 0 ? result : undefined;
+}
+
+function finite(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function uniqueStrings(values: readonly string[]): string[] {
+  return [...new Set(values)];
+}
+
+function valuesForSlugs<T>(
+  slugs: string[] | undefined,
+  resolved: Map<string, T>,
+): T[] {
+  return (slugs ?? [])
+    .map((slug) => resolved.get(slug))
+    .filter((value): value is T => value !== undefined);
+}
+
+/**
+ * Resolve persisted JSONB filters against current taxonomy, currency, and
+ * locale state. This function never reads a request session and compiles all
+ * supplied watchlists in batches, making it suitable for both a page read and
+ * a background user's consolidated digest.
+ */
+export async function compileWatchlistMatcherSources(
+  sources: readonly WatchlistMatcherSource[],
+): Promise<CompiledWatchlistFilter[]> {
+  if (sources.length === 0) return [];
+
+  const ids = new Set<string>();
+  for (const source of sources) {
+    if (ids.has(source.watchlistId)) {
+      throw new Error(`Duplicate watchlist matcher source: ${source.watchlistId}`);
+    }
+    ids.add(source.watchlistId);
+  }
+
+  const byLocale = new Map<string, WatchlistMatcherSource[]>();
+  for (const source of sources) {
+    const group = byLocale.get(source.locale) ?? [];
+    group.push(source);
+    byLocale.set(source.locale, group);
+  }
+
+  const localeMaps = new Map<
+    string,
+    {
+      locations: Map<string, ResolvedLocation>;
+      occupations: Map<string, TaxonomySuggestion>;
+      seniorities: Map<string, TaxonomySuggestion>;
+    }
+  >();
+  await Promise.all(
+    [...byLocale.entries()].map(async ([locale, group]) => {
+      const locationSlugs = uniqueStrings(
+        group.flatMap((source) => strings(source.filters?.locationSlugs) ?? []),
+      );
+      const occupationSlugs = uniqueStrings(
+        group.flatMap((source) => strings(source.filters?.occupationSlugs) ?? []),
+      );
+      const senioritySlugs = uniqueStrings(
+        group.flatMap((source) => strings(source.filters?.senioritySlugs) ?? []),
+      );
+      const [locations, occupations, seniorities] = await Promise.all([
+        locationSlugs.length
+          ? resolveLocationSlugs(locationSlugs, locale)
+          : Promise.resolve(new Map<string, ResolvedLocation>()),
+        occupationSlugs.length
+          ? resolveOccupationSlugs(occupationSlugs, locale)
+          : Promise.resolve(new Map<string, TaxonomySuggestion>()),
+        senioritySlugs.length
+          ? resolveSenioritySlugs(senioritySlugs, locale)
+          : Promise.resolve(new Map<string, TaxonomySuggestion>()),
+      ]);
+      localeMaps.set(locale, { locations, occupations, seniorities });
+    }),
+  );
+
+  const technologySlugs = uniqueStrings(
+    sources.flatMap(
+      (source) => strings(source.filters?.technologySlugs) ?? [],
+    ),
+  );
+  const needsCurrencyRates = sources.some(
+    (source) =>
+      finite(source.filters?.salaryMin) !== undefined ||
+      finite(source.filters?.salaryMax) !== undefined,
+  );
+  const [technologies, rates] = await Promise.all([
+    technologySlugs.length
+      ? resolveTechnologySlugs(technologySlugs)
+      : Promise.resolve(new Map<string, TaxonomySuggestion>()),
+    needsCurrencyRates ? getCurrencyRates() : Promise.resolve([]),
+  ]);
+
+  return sources.map((source) => {
+    const raw = source.filters ?? {};
+    const maps = localeMaps.get(source.locale)!;
+    const locationSlugs = strings(raw.locationSlugs);
+    const occupationSlugs = strings(raw.occupationSlugs);
+    const senioritySlugs = strings(raw.senioritySlugs);
+    const sourceTechnologySlugs = strings(raw.technologySlugs);
+    const resolvedLocations = valuesForSlugs(locationSlugs, maps.locations);
+    const resolvedOccupations = valuesForSlugs(
+      occupationSlugs,
+      maps.occupations,
+    );
+    const resolvedSeniorities = valuesForSlugs(
+      senioritySlugs,
+      maps.seniorities,
+    );
+    const resolvedTechnologies = valuesForSlugs(
+      sourceTechnologySlugs,
+      technologies,
+    );
+    const rawWorkMode = strings(raw.workMode);
+    const workMode = rawWorkMode?.filter((mode): mode is WorkMode =>
+      WORK_MODES.has(mode as WorkMode),
+    );
+    const salaryCurrency =
+      typeof raw.salaryCurrency === "string" && raw.salaryCurrency.length > 0
+        ? raw.salaryCurrency
+        : "EUR";
+    const salaryMin = finite(raw.salaryMin);
+    const salaryMax = finite(raw.salaryMax);
+
+    return {
+      watchlistId: source.watchlistId,
+      watchlistLabel: source.watchlistLabel,
+      candidateFilters: {
+        companyIds:
+          raw.anyCompany === true ? [] : uniqueStrings(source.companyIds),
+        anyCompany: raw.anyCompany === true ? true : undefined,
+        keywords: strings(raw.keywords),
+        locationIds: resolvedLocations.map((value) => value.id),
+        occupationIds: resolvedOccupations.map((value) => value.id),
+        seniorityIds: resolvedSeniorities.map((value) => value.id),
+        technologyIds: resolvedTechnologies.map((value) => value.id),
+        workMode: workMode?.length ? workMode : undefined,
+        employmentType: strings(raw.employmentType),
+        salaryMin: convertToEur(salaryMin, salaryCurrency, rates),
+        salaryMax: convertToEur(salaryMax, salaryCurrency, rates),
+        experienceMin: finite(raw.experienceMin),
+        experienceMax: finite(raw.experienceMax),
+        languages: resolveJobLanguages(source.jobLanguages, source.locale),
+      },
+      resolvedLocations,
+      resolvedOccupations,
+      resolvedSeniorities,
+      resolvedTechnologies,
+    };
+  });
+}
+
+type CandidateHit = {
+  document: object;
+  text_match?: number;
+};
+
+function mapCandidateHit(hit: CandidateHit): WatchlistPostingEntry {
+  const doc = hit.document as Record<string, unknown>;
+  const optionalString = (value: unknown) =>
+    value == null || typeof value === "string";
+  if (
+    typeof doc.id !== "string" ||
+    !optionalString(doc.title) ||
+    !optionalString(doc.source_url) ||
+    typeof doc.first_seen_at !== "number" ||
+    !Number.isFinite(doc.first_seen_at) ||
+    (doc.is_active != null && typeof doc.is_active !== "boolean") ||
+    !optionalString(doc.company_id) ||
+    !optionalString(doc.company_name) ||
+    !optionalString(doc.company_slug) ||
+    !optionalString(doc.company_icon)
+  ) {
+    throw malformedTypesenseResponseError();
+  }
+
+  const firstSeenAt = new Date(doc.first_seen_at * 1_000);
+  if (!Number.isFinite(firstSeenAt.getTime())) {
+    throw malformedTypesenseResponseError();
+  }
+  return {
+    id: doc.id,
+    title: normalizePostingTitle(doc.title),
+    locationNames: Array.isArray(doc.location_names)
+      ? doc.location_names.filter(
+          (name): name is string =>
+            typeof name === "string" && name.length > 0,
+        )
+      : [],
+    sourceUrl: doc.source_url ?? "",
+    firstSeenAt: firstSeenAt.toISOString(),
+    isActive: doc.is_active ?? true,
+    company: {
+      id: doc.company_id ?? "",
+      name: doc.company_name ?? "",
+      slug: doc.company_slug ?? "",
+      icon: doc.company_icon ?? null,
+    },
+  };
+}
+
+function compareHits(
+  a: CandidateHit,
+  b: CandidateHit,
+  order: WatchlistCandidateOrder,
+): number {
+  if (order === "interactive") {
+    const relevance = (b.text_match ?? 0) - (a.text_match ?? 0);
+    if (relevance !== 0) return relevance;
+  }
+  const aDoc = a.document as Record<string, unknown>;
+  const bDoc = b.document as Record<string, unknown>;
+  const freshness =
+    ((bDoc.first_seen_at as number) ?? 0) -
+    ((aDoc.first_seen_at as number) ?? 0);
+  if (freshness !== 0) return freshness;
+  return canonicalStringCompare(String(aDoc.id ?? ""), String(bDoc.id ?? ""));
+}
+
+function batchesForFilters(
+  filters: WatchlistCandidateFilters,
+  buildParams: (filters: WatchlistCandidateFilters) => WatchlistCandidateSearchParams,
+): WatchlistCandidateFilters[] {
+  if (filters.anyCompany || filters.companyIds.length === 0) return [filters];
+  const batches = splitValuesForTypesenseQuery(
+    uniqueStrings(filters.companyIds),
+    (companyIds) => buildParams({ ...filters, companyIds }),
+    COMPANY_BATCH_SIZE,
+  );
+  return batches.map((companyIds) => ({ ...filters, companyIds }));
+}
+
+/** Session-free canonical reader used beneath the existing interactive action. */
+export async function readWatchlistCandidates(params: {
+  filters: WatchlistCandidateFilters;
+  offset: number;
+  limit: number;
+  window?: WatchlistCandidateWindow;
+  order?: WatchlistCandidateOrder;
+  abortSignal?: AbortSignal;
+}): Promise<{ postings: WatchlistPostingEntry[]; total: number }> {
+  if (!hasWatchlistCandidateScope(params.filters)) {
+    return { postings: [], total: 0 };
+  }
+  const order = params.order ?? "interactive";
+  const buildParams = (filters: WatchlistCandidateFilters) =>
+    buildWatchlistCandidateSearchParams({
+      filters,
+      offset: params.offset,
+      limit: params.limit,
+      window: params.window,
+      order,
+    });
+  const searchParams = buildParams(params.filters);
+  const needsBatches =
+    !params.filters.anyCompany &&
+    params.filters.companyIds.length > 0 &&
+    (params.filters.companyIds.length > COMPANY_BATCH_SIZE ||
+      !isTypesenseQueryStringSafe(searchParams));
+  const client = getSearchClient();
+  if (!needsBatches) {
+    const result = await withTypesenseRetry(
+      () =>
+        client.collections("job_posting").documents().search(searchParams, {
+          abortSignal: params.abortSignal,
+        }),
+      { label: "readWatchlistCandidates", abortSignal: params.abortSignal },
+    );
+    assertTypesenseSearchResult(result, { expectHits: params.limit !== 0 });
+    const total = result.found ?? 0;
+    return {
+      postings:
+        total === 0 || params.limit === 0
+          ? []
+          : (result.hits ?? []).map(mapCandidateHit),
+      total,
+    };
+  }
+
+  const needed = params.offset + params.limit;
+  const filterBatches = batchesForFilters(params.filters, (filters) =>
+    buildWatchlistCandidateSearchParams({
+      filters,
+      offset: 0,
+      limit: needed,
+      window: params.window,
+      order,
+    }),
+  );
+  const countResults = await Promise.all(
+    filterBatches.map((filters) =>
+      withTypesenseRetry(
+        () =>
+          client.collections("job_posting").documents().search(
+            buildWatchlistCandidateSearchParams({
+              filters,
+              offset: 0,
+              limit: 0,
+              window: params.window,
+              order,
+            }),
+            { abortSignal: params.abortSignal },
+          ),
+        {
+          label: "readWatchlistCandidates.batched.count",
+          abortSignal: params.abortSignal,
+        },
+      ),
+    ),
+  );
+  for (const result of countResults) assertTypesenseSearchResult(result);
+  const total = countResults.reduce((sum, result) => sum + (result.found ?? 0), 0);
+  if (total === 0 || params.limit === 0) return { postings: [], total };
+
+  const rowResults = await Promise.all(
+    filterBatches.map((filters) =>
+      withTypesenseRetry(
+        () =>
+          client.collections("job_posting").documents().search(
+            buildWatchlistCandidateSearchParams({
+              filters,
+              offset: 0,
+              limit: needed,
+              window: params.window,
+              order,
+            }),
+            { abortSignal: params.abortSignal },
+          ),
+        {
+          label: "readWatchlistCandidates.batched.rows",
+          abortSignal: params.abortSignal,
+        },
+      ),
+    ),
+  );
+  for (const result of rowResults) {
+    assertTypesenseSearchResult(result, { expectHits: true });
+  }
+  const allHits = rowResults.flatMap((result) => result.hits ?? []);
+  allHits.sort((a, b) => compareHits(a, b, order));
+  return {
+    postings: allHits
+      .slice(params.offset, params.offset + params.limit)
+      .map(mapCandidateHit),
+    total,
+  };
+}
+
+type SearchPlanEntry = {
+  watchlistIndex: number;
+  search: WatchlistCandidateSearchParams & { collection: "job_posting" };
+};
+
+export type WatchlistWindowMatchResult = {
+  /** Explicit UTC bounds and their shared, documented boundary semantics. */
+  window: {
+    windowStart: string;
+    windowEnd: string;
+    boundary: typeof WATCHLIST_CANDIDATE_WINDOW_BOUNDARY;
+  };
+  postings: MatchedWatchlistPosting[];
+  watchlists: Array<{
+    id: string;
+    label: string;
+    total: number;
+    returned: number;
+    truncated: boolean;
+  }>;
+};
+
+/**
+ * Evaluate many compiled watchlists through bounded Typesense multi_search
+ * calls, then deduplicate posting IDs while retaining every matching label.
+ */
+export async function matchCompiledWatchlistsInWindow(params: {
+  watchlists: readonly CompiledWatchlistMatcher[];
+  windowStart: Date;
+  windowEnd: Date;
+  limitPerWatchlist: number;
+  abortSignal?: AbortSignal;
+}): Promise<WatchlistWindowMatchResult> {
+  if (
+    !Number.isInteger(params.limitPerWatchlist) ||
+    params.limitPerWatchlist < 1 ||
+    params.limitPerWatchlist > 250
+  ) {
+    throw new RangeError("limitPerWatchlist must be an integer between 1 and 250");
+  }
+  const window = {
+    windowStart: params.windowStart,
+    windowEnd: params.windowEnd,
+  } satisfies WatchlistCandidateWindow;
+  // Validate even an empty watchlist batch so callers cannot advance an
+  // invalid ledger window merely because no filters were due.
+  buildWatchlistCandidateSearchParams({
+    filters: { companyIds: [], anyCompany: true },
+    offset: 0,
+    limit: 0,
+    window,
+    order: "newest",
+  });
+
+  const ids = new Set<string>();
+  for (const watchlist of params.watchlists) {
+    if (ids.has(watchlist.watchlistId)) {
+      throw new Error(`Duplicate compiled watchlist: ${watchlist.watchlistId}`);
+    }
+    ids.add(watchlist.watchlistId);
+  }
+
+  const plan: SearchPlanEntry[] = [];
+  params.watchlists.forEach((watchlist, watchlistIndex) => {
+    if (!hasWatchlistCandidateScope(watchlist.candidateFilters)) return;
+    const batches = batchesForFilters(watchlist.candidateFilters, (filters) =>
+      buildWatchlistCandidateSearchParams({
+        filters,
+        offset: 0,
+        limit: params.limitPerWatchlist,
+        window,
+        order: "newest",
+      }),
+    );
+    for (const filters of batches) {
+      plan.push({
+        watchlistIndex,
+        search: {
+          collection: "job_posting",
+          ...buildWatchlistCandidateSearchParams({
+            filters,
+            offset: 0,
+            limit: params.limitPerWatchlist,
+            window,
+            order: "newest",
+          }),
+        },
+      });
+    }
+  });
+
+  const results: TypesenseMultiSearchResult<object>[] = [];
+  if (plan.length > 0) {
+    const client = getSearchClient();
+    for (let offset = 0; offset < plan.length; offset += MULTI_SEARCH_CHUNK_SIZE) {
+      const chunk = plan.slice(offset, offset + MULTI_SEARCH_CHUNK_SIZE);
+      const raw = await withTypesenseRetry(
+        () =>
+          client.multiSearch.perform({
+            searches: chunk.map((entry) => entry.search),
+          }),
+        {
+          label: "matchCompiledWatchlistsInWindow",
+          abortSignal: params.abortSignal,
+        },
+      );
+      results.push(
+        ...parseTypesenseMultiSearchResults<object>(raw, chunk.length, {
+          expectHitsAt: chunk.map((_entry, index) => index),
+        }),
+      );
+    }
+  }
+
+  const hitsByWatchlist = params.watchlists.map(() => [] as CandidateHit[]);
+  const totals = params.watchlists.map(() => 0);
+  results.forEach((result, resultIndex) => {
+    const watchlistIndex = plan[resultIndex]!.watchlistIndex;
+    totals[watchlistIndex] += result.found;
+    hitsByWatchlist[watchlistIndex].push(...(result.hits ?? []));
+  });
+
+  const postings = new Map<string, MatchedWatchlistPosting>();
+  const watchlistStats = params.watchlists.map((watchlist, index) => {
+    const uniqueHits = new Map<string, CandidateHit>();
+    for (const hit of hitsByWatchlist[index]) {
+      const doc = hit.document as Record<string, unknown>;
+      if (typeof doc.id !== "string") throw malformedTypesenseResponseError();
+      if (!uniqueHits.has(doc.id)) uniqueHits.set(doc.id, hit);
+    }
+    const selected = [...uniqueHits.values()]
+      .sort((a, b) => compareHits(a, b, "newest"))
+      .slice(0, params.limitPerWatchlist);
+    for (const hit of selected) {
+      const posting = mapCandidateHit(hit);
+      const label = {
+        id: watchlist.watchlistId,
+        label: watchlist.watchlistLabel,
+      };
+      const existing = postings.get(posting.id);
+      if (existing) existing.matchedWatchlists.push(label);
+      else postings.set(posting.id, { ...posting, matchedWatchlists: [label] });
+    }
+    return {
+      id: watchlist.watchlistId,
+      label: watchlist.watchlistLabel,
+      total: totals[index],
+      returned: selected.length,
+      truncated: totals[index] > selected.length,
+    };
+  });
+
+  return {
+    window: {
+      windowStart: params.windowStart.toISOString(),
+      windowEnd: params.windowEnd.toISOString(),
+      boundary: WATCHLIST_CANDIDATE_WINDOW_BOUNDARY,
+    },
+    postings: [...postings.values()].sort((a, b) => {
+      const freshness =
+        Date.parse(b.firstSeenAt) - Date.parse(a.firstSeenAt);
+      return freshness || canonicalStringCompare(a.id, b.id);
+    }),
+    watchlists: watchlistStats,
+  };
+}
+
+/** Compile persisted filters and evaluate them through the same reader. */
+export async function matchWatchlistsInWindow(params: {
+  watchlists: readonly WatchlistMatcherSource[];
+  windowStart: Date;
+  windowEnd: Date;
+  limitPerWatchlist: number;
+  abortSignal?: AbortSignal;
+}): Promise<WatchlistWindowMatchResult> {
+  const compiled = await compileWatchlistMatcherSources(params.watchlists);
+  return matchCompiledWatchlistsInWindow({
+    watchlists: compiled,
+    windowStart: params.windowStart,
+    windowEnd: params.windowEnd,
+    limitPerWatchlist: params.limitPerWatchlist,
+    abortSignal: params.abortSignal,
+  });
+}

--- a/apps/web/src/lib/services/watchlist-page-data.ts
+++ b/apps/web/src/lib/services/watchlist-page-data.ts
@@ -7,18 +7,11 @@ import {
   type WatchlistDetail,
   type WatchlistPostingEntry,
 } from "@/lib/services/watchlists";
-import { getCurrencyRates } from "@/lib/services/search";
-import { resolveLocationSlugs } from "@/lib/services/locations";
-import {
-  resolveOccupationSlugs,
-  resolveSenioritySlugs,
-  resolveTechnologySlugs,
-} from "@/lib/services/taxonomy";
 import { resolveJobLanguages } from "@/lib/job-languages";
-import { convertToEur } from "@/lib/salary";
 import { isTypesenseUnavailableError } from "@/lib/search/typesense-retry";
 import { logExternalError } from "@/lib/safe-external-error";
 import type { WatchlistPostingsParams } from "@/lib/search/typesense-browser-watchlist";
+import { compileWatchlistMatcherSources } from "@/lib/services/watchlist-matcher";
 
 /**
  * Existing watchlist routes must return a usable degraded response before a
@@ -96,72 +89,27 @@ async function buildWatchlistPageDataUnbounded(
     jobLanguages,
     publicSnapshot,
   } = params;
-  const languages = resolveJobLanguages(jobLanguages, locale);
-  const filters = detail.filters;
-
-  const [locMap, occMap, senMap, techMap] = await Promise.all([
-    filters.locationSlugs?.length
-      ? resolveLocationSlugs(filters.locationSlugs, locale)
-      : Promise.resolve(new Map()),
-    filters.occupationSlugs?.length
-      ? resolveOccupationSlugs(filters.occupationSlugs, locale)
-      : Promise.resolve(new Map()),
-    filters.senioritySlugs?.length
-      ? resolveSenioritySlugs(filters.senioritySlugs, locale)
-      : Promise.resolve(new Map()),
-    filters.technologySlugs?.length
-      ? resolveTechnologySlugs(filters.technologySlugs)
-      : Promise.resolve(new Map()),
-  ]);
-
-  const resolvedLocations = (filters.locationSlugs ?? [])
-    .map((slug) => locMap.get(slug))
-    .filter((location): location is NonNullable<typeof location> => location != null)
-    .map((location) => ({
+  const [compiled] = await compileWatchlistMatcherSources([{
+    watchlistId: detail.id,
+    watchlistLabel: detail.title,
+    filters: detail.filters,
+    companyIds: detail.companies.map((company) => company.id),
+    locale,
+    jobLanguages,
+  }]);
+  const browserPostingFilters = compiled.candidateFilters;
+  const languages = browserPostingFilters.languages ?? resolveJobLanguages(jobLanguages, locale);
+  const resolvedLocations = compiled.resolvedLocations.map((location) => ({
       id: location.id,
       slug: location.slug,
       name: location.name,
       type: location.type as "macro" | "country" | "region" | "city",
       parentName: location.parentName ?? null,
     }));
-  const resolvedOccupations = (filters.occupationSlugs ?? [])
-    .map((slug) => occMap.get(slug))
-    .filter((occupation): occupation is NonNullable<typeof occupation> => occupation != null);
-  const resolvedSeniorities = (filters.senioritySlugs ?? [])
-    .map((slug) => senMap.get(slug))
-    .filter((seniority): seniority is NonNullable<typeof seniority> => seniority != null);
-  const resolvedTechnologies = (filters.technologySlugs ?? [])
-    .map((slug) => techMap.get(slug))
-    .filter((technology): technology is NonNullable<typeof technology> => technology != null);
-
-  const workModes = new Set(["onsite", "hybrid", "remote"] as const);
-  const validatedWorkMode = (filters.workMode ?? []).filter(
-    (mode): mode is "onsite" | "hybrid" | "remote" => workModes.has(mode),
-  );
-  const salaryCurrency = filters.salaryCurrency ?? "EUR";
-  const rates =
-    filters.salaryMin != null || filters.salaryMax != null
-      ? await getCurrencyRates()
-      : [];
-  const salaryMinEur = convertToEur(filters.salaryMin, salaryCurrency, rates);
-  const salaryMaxEur = convertToEur(filters.salaryMax, salaryCurrency, rates);
-
-  const browserPostingFilters = {
-    companyIds: filters.anyCompany ? [] : detail.companies.map((company) => company.id),
-    anyCompany: filters.anyCompany,
-    keywords: filters.keywords,
-    locationIds: resolvedLocations.map((location) => location.id),
-    occupationIds: resolvedOccupations.map((occupation) => occupation.id),
-    seniorityIds: resolvedSeniorities.map((seniority) => seniority.id),
-    technologyIds: resolvedTechnologies.map((technology) => technology.id),
-    workMode: validatedWorkMode.length > 0 ? validatedWorkMode : undefined,
-    employmentType: filters.employmentType?.length ? filters.employmentType : undefined,
-    salaryMin: salaryMinEur,
-    salaryMax: salaryMaxEur,
-    experienceMin: filters.experienceMin,
-    experienceMax: filters.experienceMax,
-    languages,
-  } satisfies Omit<WatchlistPostingsParams, "offset" | "limit">;
+  const resolvedOccupations = compiled.resolvedOccupations;
+  const resolvedSeniorities = compiled.resolvedSeniorities;
+  const resolvedTechnologies = compiled.resolvedTechnologies;
+  browserPostingFilters satisfies Omit<WatchlistPostingsParams, "offset" | "limit">;
   const sharedCountsParams = {
     ...browserPostingFilters,
     abortSignal,

--- a/apps/web/src/lib/services/watchlists.ts
+++ b/apps/web/src/lib/services/watchlists.ts
@@ -37,19 +37,14 @@ import { ANON_MAX_WATCHLIST_POSTINGS, COMPANY_BATCH_SIZE } from "@/lib/search/co
 import { resolveLocationSlugs } from "@/lib/actions/locations";
 import { resolveOccupationSlugs, resolveSenioritySlugs, resolveTechnologySlugs } from "@/lib/services/taxonomy";
 import { getSearchClient } from "@/lib/search/typesense-client";
-import { normalizePostingTitle } from "@/lib/posting-title";
 import { logExternalError } from "@/lib/safe-external-error";
 import { buildFilterString, POSTING_BASE_FILTER, POSTING_FLOW_FILTER } from "@/lib/search/typesense-filters";
 import {
   assertTypesenseSearchResult,
   isTypesenseUnavailableError,
-  malformedTypesenseResponseError,
   withTypesenseRetry,
 } from "@/lib/search/typesense-retry";
-import {
-  isTypesenseQueryStringSafe,
-  splitValuesForTypesenseQuery,
-} from "@/lib/search/typesense-query-size";
+import { splitValuesForTypesenseQuery } from "@/lib/search/typesense-query-size";
 import {
   upsertWatchlist as tsUpsertWatchlist,
   deleteWatchlist as tsDeleteWatchlist,
@@ -61,43 +56,19 @@ import { createWatchlistFromHandoffWithDeps } from "@/lib/services/watchlist-han
 import { publicWatchlistRouteStatusCacheKey } from "@/lib/services/public-resource-status";
 import { toggleWatchlistAlertState } from "@/lib/notifications/policy";
 import { lockNotificationPolicyForUser } from "@/lib/services/notification-preferences";
+import { readWatchlistCandidates } from "@/lib/services/watchlist-matcher";
+import type {
+  WatchlistCandidateFilters,
+  WatchlistFilters,
+  WatchlistPostingEntry,
+} from "@/lib/watchlist-matcher-contract";
+
+export type {
+  WatchlistFilters,
+  WatchlistPostingEntry,
+} from "@/lib/watchlist-matcher-contract";
 
 // ── Types ───────────────────────────────────────────────────────────
-
-export type WatchlistFilters = {
-  keywords?: string[];
-  locationSlugs?: string[];
-  occupationSlugs?: string[];
-  senioritySlugs?: string[];
-  technologySlugs?: string[];
-  /**
-   * Work-mode (location_types) filter — `onsite | hybrid | remote`.
-   * Issue #2983. Backwards-compatible: missing field on existing
-   * watchlists ⇒ undefined ⇒ no filter applied. Reading code must
-   * defensively re-validate strings against {@link WORK_MODE_VALUES}
-   * before passing to Typesense (this column is JSONB and could carry
-   * legacy garbage from older client versions).
-   */
-  workMode?: ("onsite" | "hybrid" | "remote")[];
-  /**
-   * Employment-type filter — `full_time | part_time | contract |
-   * internship | temporary | volunteer`. Issue #3037 — closes the
-   * parity gap between this watchlist editor and the explore page's
-   * `AdvancedSearchPanel`. Same backwards-compat shape as `workMode`:
-   * missing on legacy rows ⇒ undefined ⇒ no filter applied. The
-   * column is JSONB and untrusted at read time; downstream consumers
-   * forward values straight into Typesense `filter_by` so any future
-   * sanitisation must live in `buildFilterString` (already accepts
-   * `employmentTypes`).
-   */
-  employmentType?: string[];
-  salaryMin?: number;
-  salaryMax?: number;
-  salaryCurrency?: string;
-  experienceMin?: number;
-  experienceMax?: number;
-  anyCompany?: boolean;
-};
 
 type WorkMode = NonNullable<WatchlistFilters["workMode"]>[number];
 
@@ -152,37 +123,7 @@ export type WatchlistDetail = {
   }[];
 };
 
-export type WatchlistPostingEntry = {
-  id: string;
-  title: string | null;
-  /** Leaf location names, in source order, used to disambiguate repeated titles. */
-  locationNames?: string[];
-  sourceUrl: string;
-  firstSeenAt: string;
-  isActive: boolean;
-  company: {
-    id: string;
-    name: string;
-    slug: string;
-    icon: string | null;
-  };
-};
-
-type WatchlistPostingFilterParams = {
-  companyIds: string[];
-  anyCompany?: boolean;
-  keywords?: string[];
-  locationIds?: number[];
-  occupationIds?: number[];
-  seniorityIds?: number[];
-  technologyIds?: number[];
-  workMode?: ("onsite" | "hybrid" | "remote")[];
-  employmentType?: string[];
-  salaryMin?: number;
-  salaryMax?: number;
-  experienceMin?: number;
-  experienceMax?: number;
-  languages?: string[];
+type WatchlistPostingFilterParams = WatchlistCandidateFilters & {
   abortSignal?: AbortSignal;
 };
 
@@ -1709,7 +1650,18 @@ export async function getWatchlistPostings(
   }
 
   try {
-    return await _getWatchlistPostingsTypesense(params, userId);
+    const result = await readWatchlistCandidates({
+      filters: params,
+      offset: params.offset,
+      limit: params.limit,
+      abortSignal: params.abortSignal,
+    });
+    return {
+      ...result,
+      ...(!userId && params.offset + params.limit >= ANON_MAX_WATCHLIST_POSTINGS
+        ? { truncated: true }
+        : {}),
+    };
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
     logExternalError("error", { service: "typesense", operation: "watchlist_postings" }, err);
@@ -1743,7 +1695,18 @@ export async function getPublicWatchlistPostings(
   }
 
   try {
-    return await _getWatchlistPostingsTypesense(params, null);
+    const result = await readWatchlistCandidates({
+      filters: params,
+      offset: params.offset,
+      limit: params.limit,
+      abortSignal: params.abortSignal,
+    });
+    return {
+      ...result,
+      ...(params.offset + params.limit >= ANON_MAX_WATCHLIST_POSTINGS
+        ? { truncated: true }
+        : {}),
+    };
   } catch (err) {
     if (!isTypesenseUnavailableError(err)) throw err;
     logExternalError("error", { service: "typesense", operation: "public_watchlist_postings" }, err);
@@ -2166,239 +2129,6 @@ function buildWatchlistPostingFilter(
     companyIds.length > 0 ? `company_id:[${companyIds.join(",")}]` : "",
     filterStr,
   ].filter(Boolean).join(" && ");
-}
-
-function mapWatchlistPostingHit(hit: {
-  document: object;
-}): WatchlistPostingEntry {
-  const doc = hit.document as Record<string, unknown>;
-  const optionalString = (value: unknown) =>
-    value == null || typeof value === "string";
-  if (
-    typeof doc.id !== "string" ||
-    !optionalString(doc.title) ||
-    !optionalString(doc.source_url) ||
-    typeof doc.first_seen_at !== "number" ||
-    !Number.isFinite(doc.first_seen_at) ||
-    (doc.is_active != null && typeof doc.is_active !== "boolean") ||
-    !optionalString(doc.company_id) ||
-    !optionalString(doc.company_name) ||
-    !optionalString(doc.company_slug) ||
-    !optionalString(doc.company_icon)
-  ) {
-    throw malformedTypesenseResponseError();
-  }
-
-  const firstSeenAt = new Date(doc.first_seen_at * 1000);
-  if (!Number.isFinite(firstSeenAt.getTime())) {
-    throw malformedTypesenseResponseError();
-  }
-
-  return {
-    id: doc.id,
-    title: normalizePostingTitle(doc.title),
-    locationNames: Array.isArray(doc.location_names)
-      ? doc.location_names.filter(
-          (name): name is string => typeof name === "string" && name.length > 0,
-        )
-      : [],
-    sourceUrl: doc.source_url ?? "",
-    firstSeenAt: firstSeenAt.toISOString(),
-    isActive: doc.is_active ?? true,
-    company: {
-      id: doc.company_id ?? "",
-      name: doc.company_name ?? "",
-      slug: doc.company_slug ?? "",
-      icon: doc.company_icon ?? null,
-    },
-  };
-}
-
-async function _getWatchlistPostingsTypesense(
-  params: WatchlistPostingQueryParams,
-  userId: string | null,
-): Promise<{ postings: WatchlistPostingEntry[]; total: number; truncated?: boolean }> {
-  const client = getSearchClient();
-
-  // No expansion needed — ancestor IDs are stored on each Typesense document
-  // Build filter string from watchlist context filters
-  // Map salaryMin/salaryMax to salaryMinEur/salaryMaxEur
-  const filterStr = buildFilterString({
-    locationIds: params.locationIds,
-    occupationIds: params.occupationIds,
-    seniorityIds: params.seniorityIds,
-    technologyIds: params.technologyIds,
-    workMode: params.workMode?.length ? params.workMode : undefined,
-    employmentTypes: params.employmentType?.length ? params.employmentType : undefined,
-    salaryMinEur: params.salaryMin,
-    salaryMaxEur: params.salaryMax,
-    experienceMin: params.experienceMin,
-    experienceMax: params.experienceMax,
-    languages: params.languages,
-  });
-
-  const hasKeywords = params.keywords && params.keywords.length > 0;
-  const keywordsQ = hasKeywords ? params.keywords!.join(" ") : "*";
-
-  // Build company_id filter — omit for "any company" mode
-  const fullFilter = buildWatchlistPostingFilter(
-    [POSTING_BASE_FILTER],
-    params.companyIds,
-    filterStr,
-  );
-  const searchParams = {
-    q: keywordsQ,
-    query_by: "title",
-    filter_by: fullFilter,
-    sort_by: hasKeywords ? "_text_match:desc,first_seen_at:desc" : "first_seen_at:desc",
-    per_page: params.limit === 0 ? 0 : params.limit,
-    page: params.limit === 0 ? 1 : Math.floor(params.offset / params.limit) + 1,
-  };
-
-  if (
-    params.companyIds.length > 0 &&
-    (params.companyIds.length > COMPANY_BATCH_SIZE ||
-      !isTypesenseQueryStringSafe(searchParams))
-  ) {
-    return _getWatchlistPostingsBatched(params, userId);
-  }
-
-  const result = await withTypesenseRetry(
-    () =>
-      client.collections("job_posting").documents().search(
-        searchParams,
-        { abortSignal: params.abortSignal },
-      ),
-    { label: "getWatchlistPostings", abortSignal: params.abortSignal },
-  );
-  assertTypesenseSearchResult(result, { expectHits: params.limit !== 0 });
-
-  const total = result.found ?? 0;
-  if (total === 0 || params.limit === 0) return { postings: [], total };
-
-  const postings = (result.hits ?? []).map(mapWatchlistPostingHit);
-
-  return {
-    postings,
-    total,
-    ...(!userId && params.offset + params.limit >= ANON_MAX_WATCHLIST_POSTINGS ? { truncated: true } : {}),
-  };
-}
-
-/** Batched version for large watchlists or large serialized filters. */
-async function _getWatchlistPostingsBatched(
-  params: WatchlistPostingQueryParams,
-  userId: string | null,
-): Promise<{ postings: WatchlistPostingEntry[]; total: number; truncated?: boolean }> {
-  const client = getSearchClient();
-
-  // No expansion needed — ancestor IDs are stored on each Typesense document
-  const filterStr = buildFilterString({
-    locationIds: params.locationIds,
-    occupationIds: params.occupationIds,
-    seniorityIds: params.seniorityIds,
-    technologyIds: params.technologyIds,
-    workMode: params.workMode?.length ? params.workMode : undefined,
-    employmentTypes: params.employmentType?.length ? params.employmentType : undefined,
-    salaryMinEur: params.salaryMin,
-    salaryMaxEur: params.salaryMax,
-    experienceMin: params.experienceMin,
-    experienceMax: params.experienceMax,
-    languages: params.languages,
-  });
-
-  const hasKeywords = params.keywords && params.keywords.length > 0;
-  const keywordsQ = hasKeywords ? params.keywords!.join(" ") : "*";
-  const sortBy = hasKeywords ? "_text_match:desc,first_seen_at:desc" : "first_seen_at:desc";
-  const needed = params.offset + params.limit;
-  const buildFilter = (batch: readonly string[]) =>
-    buildWatchlistPostingFilter([POSTING_BASE_FILTER], batch, filterStr);
-  const buildCountSearchParams = (batch: readonly string[]) => ({
-    q: keywordsQ,
-    query_by: "title",
-    filter_by: buildFilter(batch),
-    per_page: 0,
-  });
-  const buildRowsSearchParams = (batch: readonly string[]) => ({
-    q: keywordsQ,
-    query_by: "title",
-    filter_by: buildFilter(batch),
-    sort_by: sortBy,
-    per_page: needed,
-    page: 1,
-  });
-
-  const batches = splitValuesForTypesenseQuery(
-    params.companyIds,
-    buildRowsSearchParams,
-    COMPANY_BATCH_SIZE,
-  );
-
-  // Query each batch for total count (per_page: 0)
-  const countResults = await Promise.all(
-    batches.map((batch) => {
-      return withTypesenseRetry(
-        () =>
-          client.collections("job_posting").documents().search(
-            buildCountSearchParams(batch),
-            { abortSignal: params.abortSignal },
-          ),
-        {
-          label: "getWatchlistPostings.batched.count",
-          abortSignal: params.abortSignal,
-        },
-      );
-    }),
-  );
-  for (const result of countResults) assertTypesenseSearchResult(result);
-
-  const total = countResults.reduce((sum, r) => sum + (r.found ?? 0), 0);
-  if (total === 0 || params.limit === 0) return { postings: [], total };
-
-  // For actual postings, query all batches with enough per_page to cover
-  // offset+limit, then merge using the same global order requested from each
-  // batch. Pulling the top K from every disjoint batch is sufficient to
-  // compute the global top K.
-  const postingsResults = await Promise.all(
-    batches.map((batch) => {
-      return withTypesenseRetry(
-        () =>
-          client.collections("job_posting").documents().search(
-            buildRowsSearchParams(batch),
-            { abortSignal: params.abortSignal },
-          ),
-        {
-          label: "getWatchlistPostings.batched.rows",
-          abortSignal: params.abortSignal,
-        },
-      );
-    }),
-  );
-  for (const result of postingsResults) {
-    assertTypesenseSearchResult(result, { expectHits: true });
-  }
-
-  // Merge all hits, sort, and paginate
-  const allHits = postingsResults.flatMap((r) => r.hits ?? []);
-  allHits.sort((a, b) => {
-    const aDoc = a.document as Record<string, unknown>;
-    const bDoc = b.document as Record<string, unknown>;
-    if (hasKeywords) {
-      const relevanceDelta = (b.text_match ?? 0) - (a.text_match ?? 0);
-      if (relevanceDelta !== 0) return relevanceDelta;
-    }
-    return ((bDoc.first_seen_at as number) ?? 0) - ((aDoc.first_seen_at as number) ?? 0);
-  });
-
-  const pageHits = allHits.slice(params.offset, params.offset + params.limit);
-
-  const postings = pageHits.map(mapWatchlistPostingHit);
-
-  return {
-    postings,
-    total,
-    ...(!userId && params.offset + params.limit >= ANON_MAX_WATCHLIST_POSTINGS ? { truncated: true } : {}),
-  };
 }
 
 // ── Helper functions for Typesense write hooks ────────────────────────

--- a/apps/web/src/lib/watchlist-matcher-contract.ts
+++ b/apps/web/src/lib/watchlist-matcher-contract.ts
@@ -22,7 +22,8 @@ export type WatchlistFilters = {
 
 /** Fully resolved filter state consumed by the canonical candidate reader. */
 export type WatchlistCandidateFilters = {
-  companyIds: string[];
+  /** Candidate readers treat company membership as immutable input. */
+  companyIds: readonly string[];
   anyCompany?: boolean;
   keywords?: string[];
   locationIds?: number[];

--- a/apps/web/src/lib/watchlist-matcher-contract.ts
+++ b/apps/web/src/lib/watchlist-matcher-contract.ts
@@ -1,0 +1,86 @@
+/**
+ * Persisted structured filters shared by interactive watchlists and headless
+ * candidate consumers. The JSONB value is untrusted at read time; the
+ * canonical compiler in `services/watchlist-matcher.ts` validates values
+ * before they reach Typesense.
+ */
+export type WatchlistFilters = {
+  keywords?: string[];
+  locationSlugs?: string[];
+  occupationSlugs?: string[];
+  senioritySlugs?: string[];
+  technologySlugs?: string[];
+  workMode?: ("onsite" | "hybrid" | "remote")[];
+  employmentType?: string[];
+  salaryMin?: number;
+  salaryMax?: number;
+  salaryCurrency?: string;
+  experienceMin?: number;
+  experienceMax?: number;
+  anyCompany?: boolean;
+};
+
+/** Fully resolved filter state consumed by the canonical candidate reader. */
+export type WatchlistCandidateFilters = {
+  companyIds: string[];
+  anyCompany?: boolean;
+  keywords?: string[];
+  locationIds?: number[];
+  occupationIds?: number[];
+  seniorityIds?: number[];
+  technologyIds?: number[];
+  workMode?: ("onsite" | "hybrid" | "remote")[];
+  employmentType?: string[];
+  /** EUR-equivalent thresholds, despite the legacy property names. */
+  salaryMin?: number;
+  salaryMax?: number;
+  experienceMin?: number;
+  experienceMax?: number;
+  /** Effective job-language preference. Empty means all languages. */
+  languages?: string[];
+};
+
+export type WatchlistPostingEntry = {
+  id: string;
+  title: string | null;
+  /** Leaf location names, in source order, used to disambiguate repeated titles. */
+  locationNames?: string[];
+  sourceUrl: string;
+  firstSeenAt: string;
+  isActive: boolean;
+  company: {
+    id: string;
+    name: string;
+    slug: string;
+    icon: string | null;
+  };
+};
+
+/**
+ * Session-free input to the persisted-filter compiler. Background callers
+ * batch-load these fields; interactive callers build the same shape from the
+ * already-authorized watchlist page row.
+ */
+export type WatchlistMatcherSource = {
+  watchlistId: string;
+  watchlistLabel: string;
+  filters: WatchlistFilters | null;
+  companyIds: string[];
+  locale: string;
+  jobLanguages: string[];
+};
+
+export type CompiledWatchlistMatcher = {
+  watchlistId: string;
+  watchlistLabel: string;
+  candidateFilters: WatchlistCandidateFilters;
+};
+
+export type MatchedWatchlistLabel = {
+  id: string;
+  label: string;
+};
+
+export type MatchedWatchlistPosting = WatchlistPostingEntry & {
+  matchedWatchlists: MatchedWatchlistLabel[];
+};


### PR DESCRIPTION
## Summary

- extract the persisted watchlist filter contract and a session-free compiler that resolves current taxonomy IDs, salary conversion, company scope, and owner job-language semantics in batches
- route interactive server and browser posting reads through one canonical Typesense query compiler while preserving keyword relevance, freshness, active-posting, content-quality, structured-filter, and locale behavior
- add explicit UTC half-open candidate windows: [windowStart, windowEnd), start-inclusive and end-exclusive at whole-second Typesense precision
- add bounded multi-watchlist multi-search evaluation with newest-first results, per-watchlist counts/truncation, posting-ID deduplication, and retained watchlist ID/label matches
- expose compileWatchlistMatcherSources, readWatchlistCandidates, matchCompiledWatchlistsInWindow, and matchWatchlistsInWindow as the reusable backend seam for weekly notifications (#8317) and the future AI candidate reader (#8333)

This is the focused canonical-matcher prerequisite described by #8317 and Track C of #8366. It does not add or depend on notification persistence from #8375.

## Boundaries

Included: backend matcher/compiler/reader, interactive parity wiring, window semantics, batch evaluation, and tests.

Excluded: notification ledger or pause persistence, cadence policy, cron/scheduler, provider calls, rendered email/UI/copy, public-watchlist sunset, AI/model calls, and cost/config changes.

The human UI taste gate is not applicable because this PR changes no rendered UI, interaction, or product copy. The human cost gate is not applicable because this PR changes no provider tier, quota, cost envelope, or cost-bearing configuration.

## Evidence

- pnpm --dir apps/web exec vitest run src/lib/search/__tests__/watchlist-candidate-query.test.ts src/lib/services/__tests__/watchlist-matcher.test.ts src/lib/search/__tests__/typesense-browser-watchlist.test.ts src/lib/services/__tests__/watchlist-page-data.test.ts src/lib/actions/__tests__/watchlist-year-count-fallback.test.ts (39 passed)
- pnpm --dir apps/web exec tsc --noEmit --pretty false
- pre-commit web ESLint and Lingui translation coverage passed

References #8317
References #8366
Coordinates with #8333

Do not merge as part of this task.