### PR TITLE
Migrate legacy watchlists to private with rollback inventory

### DIFF
--- a/apps/web/drizzle/0089_make_existing_watchlists_private.sql
+++ b/apps/web/drizzle/0089_make_existing_watchlists_private.sql
@@ -46,6 +46,8 @@ BEGIN
     AND private_mutations_deploy_sha ~ '^[0-9a-f]{40}$'
     AND route_cutover_deploy_sha ~ '^[0-9a-f]{40}$'
     AND NULLIF(btrim(route_cutover_approved_by), '') IS NOT NULL
+    AND public_api_cutover_deploy_sha ~ '^[0-9a-f]{40}$'
+    AND public_api_cutover_verification_run_id > 0
     AND expected_public_count >= 0
     AND expected_public_digest ~ '^[0-9a-f]{32}$'
     AND attested_at >= clock_timestamp() - interval '30 minutes'
@@ -186,7 +188,9 @@ SELECT
           'ownerSlugKind', owner_slug.kind,
           'ownerSlug', owner_slug.value,
           'pagePath', format('/%s/%s/%s', locale.value, owner_slug.value, w.slug),
-          'ogPath', format('/og/watchlist/%s/%s/%s', locale.value, owner_slug.value, w.slug)
+          'ogPath', format('/og/watchlist/%s/%s/%s', locale.value, owner_slug.value, w.slug),
+          'legacyOgPathPattern', format('/%s/%s/%s/opengraph-image-:hash', locale.value, owner_slug.value, w.slug),
+          'legacyOgPurgePattern', format('/%s/%s/%s/opengraph-image-*', locale.value, owner_slug.value, w.slug)
         )
         ORDER BY owner_slug.kind, locale.value
       )

--- a/apps/web/drizzle/0089_make_existing_watchlists_private.sql
+++ b/apps/web/drizzle/0089_make_existing_watchlists_private.sql
@@ -1,0 +1,458 @@
+-- Make every legacy public watchlist private while preserving a complete,
+-- durable rollback inventory for the compatibility window.
+--
+-- This is a data migration only. Drizzle's outer transaction owns commit and
+-- rollback. The migration intentionally retains watchlist.is_public and the
+-- idx_wl_public partial index; removing either belongs to #8371.
+
+DO $preflight$
+DECLARE
+  ledger_count integer;
+  latest_hash text;
+  latest_created_at bigint;
+  column_count integer;
+  index_definition text;
+  index_valid boolean;
+  index_ready boolean;
+  marker_count integer;
+  marker_valid boolean;
+BEGIN
+  SELECT count(*),
+         (array_agg(hash ORDER BY created_at DESC, id DESC))[1],
+         (array_agg(created_at ORDER BY created_at DESC, id DESC))[1]
+  INTO ledger_count, latest_hash, latest_created_at
+  FROM drizzle.__drizzle_migrations;
+
+  IF ledger_count <> 78
+     OR latest_created_at IS DISTINCT FROM 1788199156000
+     OR latest_hash IS DISTINCT FROM
+        'c637d066ac3d44905e9ae6cbc39f8683275a025e3f8201ae8181b3f598f94e7a'
+  THEN
+    RAISE EXCEPTION
+      'Refusing watchlist privacy migration: expected exact 0088 ledger tip, got rows=% created_at=% hash=%',
+      ledger_count,
+      latest_created_at,
+      latest_hash;
+  END IF;
+
+  IF to_regclass('pg_temp.jobseek_watchlist_privacy_attestation') IS NULL THEN
+    RAISE EXCEPTION
+      'Refusing watchlist privacy migration: session-local rollout attestation is absent';
+  END IF;
+
+  SELECT count(*), bool_and(
+    confirmation = 'PRIVATE-WATCHLISTS-0089'
+    AND backup_restore_run_id > 0
+    AND private_mutations_deploy_sha ~ '^[0-9a-f]{40}$'
+    AND route_cutover_deploy_sha ~ '^[0-9a-f]{40}$'
+    AND NULLIF(btrim(route_cutover_approved_by), '') IS NOT NULL
+    AND expected_public_count >= 0
+    AND expected_public_digest ~ '^[0-9a-f]{32}$'
+    AND attested_at >= clock_timestamp() - interval '30 minutes'
+    AND attested_at <= clock_timestamp() + interval '1 minute'
+  )
+  INTO marker_count, marker_valid
+  FROM pg_temp.jobseek_watchlist_privacy_attestation;
+
+  IF marker_count <> 1 OR marker_valid IS DISTINCT FROM true THEN
+    RAISE EXCEPTION
+      'Refusing watchlist privacy migration: session-local rollout attestation is invalid';
+  END IF;
+
+  SELECT count(*)
+  INTO column_count
+  FROM pg_attribute
+  WHERE attrelid = 'public.watchlist'::regclass
+    AND attname = 'is_public'
+    AND atttypid = 'boolean'::regtype
+    AND attnotnull
+    AND NOT attisdropped;
+
+  IF column_count <> 1 THEN
+    RAISE EXCEPTION
+      'Refusing watchlist privacy migration: watchlist.is_public is not the expected NOT NULL boolean';
+  END IF;
+
+  SELECT pg_get_indexdef(indexrelid), indisvalid, indisready
+  INTO index_definition, index_valid, index_ready
+  FROM pg_index
+  WHERE indexrelid = to_regclass('public.idx_wl_public');
+
+  IF index_definition IS NULL
+     OR index_valid IS DISTINCT FROM true
+     OR index_ready IS DISTINCT FROM true
+     OR index_definition NOT LIKE '% ON public.watchlist %'
+     OR index_definition NOT LIKE '%(is_public)%'
+     OR index_definition NOT LIKE '%WHERE (is_public = true)%'
+  THEN
+    RAISE EXCEPTION
+      'Refusing watchlist privacy migration: idx_wl_public is absent or differs: %',
+      index_definition;
+  END IF;
+
+  IF to_regclass('public.watchlist_visibility_0089_state') IS NOT NULL
+     OR to_regclass('public.watchlist_visibility_0089_rollback') IS NOT NULL
+  THEN
+    RAISE EXCEPTION
+      'Refusing watchlist privacy migration: rollback artifact relations already exist without the 0089 ledger row';
+  END IF;
+END
+$preflight$;--> statement-breakpoint
+
+-- Prevent watchlist, membership, and owner-path changes between the snapshot,
+-- visibility update, and postconditions. The lock window contains one bounded
+-- UPDATE and aggregate verification only.
+LOCK TABLE public.watchlist IN SHARE ROW EXCLUSIVE MODE;--> statement-breakpoint
+LOCK TABLE public.watchlist_company IN SHARE ROW EXCLUSIVE MODE;--> statement-breakpoint
+LOCK TABLE public."user" IN SHARE MODE;--> statement-breakpoint
+
+CREATE TEMPORARY TABLE jobseek_0089_watchlist_before
+ON COMMIT DROP
+AS
+SELECT
+  w.id,
+  w.is_public,
+  to_jsonb(w) - 'is_public' AS payload
+FROM public.watchlist AS w;--> statement-breakpoint
+
+CREATE TEMPORARY TABLE jobseek_0089_membership_before
+ON COMMIT DROP
+AS
+SELECT wc.id, to_jsonb(wc) AS payload
+FROM public.watchlist_company AS wc;--> statement-breakpoint
+
+CREATE TABLE public.watchlist_visibility_0089_state (
+  migration_key text PRIMARY KEY,
+  status text NOT NULL CHECK (status IN ('private', 'rolled_back')),
+  captured_at timestamp with time zone NOT NULL,
+  watchlist_count bigint NOT NULL CHECK (watchlist_count >= 0),
+  membership_count bigint NOT NULL CHECK (membership_count >= 0),
+  public_count bigint NOT NULL CHECK (public_count >= 0),
+  watchlist_content_digest text NOT NULL CHECK (watchlist_content_digest ~ '^[0-9a-f]{32}$'),
+  filters_digest text NOT NULL CHECK (filters_digest ~ '^[0-9a-f]{32}$'),
+  alerts_digest text NOT NULL CHECK (alerts_digest ~ '^[0-9a-f]{32}$'),
+  provenance_digest text NOT NULL CHECK (provenance_digest ~ '^[0-9a-f]{32}$'),
+  owners_digest text NOT NULL CHECK (owners_digest ~ '^[0-9a-f]{32}$'),
+  membership_digest text NOT NULL CHECK (membership_digest ~ '^[0-9a-f]{32}$'),
+  public_inventory_digest text NOT NULL CHECK (public_inventory_digest ~ '^[0-9a-f]{32}$')
+);--> statement-breakpoint
+
+CREATE TABLE public.watchlist_visibility_0089_rollback (
+  watchlist_id uuid PRIMARY KEY,
+  owner_user_id text NOT NULL,
+  owner_name text NOT NULL,
+  owner_username text,
+  owner_display_username text,
+  watchlist_slug text NOT NULL,
+  watchlist_payload jsonb NOT NULL,
+  company_memberships jsonb NOT NULL,
+  path_variants jsonb NOT NULL,
+  captured_at timestamp with time zone NOT NULL
+);--> statement-breakpoint
+
+INSERT INTO public.watchlist_visibility_0089_rollback (
+  watchlist_id,
+  owner_user_id,
+  owner_name,
+  owner_username,
+  owner_display_username,
+  watchlist_slug,
+  watchlist_payload,
+  company_memberships,
+  path_variants,
+  captured_at
+)
+SELECT
+  w.id,
+  u.id,
+  u.name,
+  u.username,
+  u.display_username,
+  w.slug,
+  to_jsonb(w),
+  COALESCE(
+    (
+      SELECT jsonb_agg(to_jsonb(wc) ORDER BY wc.id)
+      FROM public.watchlist_company AS wc
+      WHERE wc.watchlist_id = w.id
+    ),
+    '[]'::jsonb
+  ),
+  COALESCE(
+    (
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'locale', locale.value,
+          'ownerSlugKind', owner_slug.kind,
+          'ownerSlug', owner_slug.value,
+          'pagePath', format('/%s/%s/%s', locale.value, owner_slug.value, w.slug),
+          'ogPath', format('/og/watchlist/%s/%s/%s', locale.value, owner_slug.value, w.slug)
+        )
+        ORDER BY owner_slug.kind, locale.value
+      )
+      FROM (
+        VALUES
+          ('username'::text, u.username),
+          ('display_username'::text, u.display_username)
+      ) AS owner_slug(kind, value)
+      CROSS JOIN (
+        VALUES ('en'::text), ('de'::text), ('fr'::text), ('it'::text)
+      ) AS locale(value)
+      WHERE owner_slug.value IS NOT NULL
+    ),
+    '[]'::jsonb
+  ),
+  transaction_timestamp()
+FROM public.watchlist AS w
+JOIN public."user" AS u ON u.id = w.user_id
+WHERE w.is_public
+ORDER BY w.id;--> statement-breakpoint
+
+INSERT INTO public.watchlist_visibility_0089_state (
+  migration_key,
+  status,
+  captured_at,
+  watchlist_count,
+  membership_count,
+  public_count,
+  watchlist_content_digest,
+  filters_digest,
+  alerts_digest,
+  provenance_digest,
+  owners_digest,
+  membership_digest,
+  public_inventory_digest
+)
+SELECT
+  '0089_make_existing_watchlists_private',
+  'private',
+  transaction_timestamp(),
+  (SELECT count(*) FROM public.watchlist),
+  (SELECT count(*) FROM public.watchlist_company),
+  (SELECT count(*) FROM public.watchlist WHERE is_public),
+  (
+    SELECT md5(COALESCE(jsonb_agg(to_jsonb(w) - 'is_public' ORDER BY w.id)::text, '[]'))
+    FROM public.watchlist AS w
+  ),
+  (
+    SELECT md5(COALESCE(jsonb_agg(jsonb_build_object('id', w.id, 'filters', w.filters) ORDER BY w.id)::text, '[]'))
+    FROM public.watchlist AS w
+  ),
+  (
+    SELECT md5(COALESCE(jsonb_agg(jsonb_build_object('id', w.id, 'alertsEnabled', w.alerts_enabled) ORDER BY w.id)::text, '[]'))
+    FROM public.watchlist AS w
+  ),
+  (
+    SELECT md5(COALESCE(jsonb_agg(jsonb_build_object('id', w.id, 'sourceWatchlistId', w.source_watchlist_id) ORDER BY w.id)::text, '[]'))
+    FROM public.watchlist AS w
+  ),
+  (
+    SELECT md5(COALESCE(jsonb_agg(jsonb_build_object('watchlistId', w.id, 'ownerUserId', w.user_id) ORDER BY w.id)::text, '[]'))
+    FROM public.watchlist AS w
+  ),
+  (
+    SELECT md5(COALESCE(jsonb_agg(to_jsonb(wc) ORDER BY wc.id)::text, '[]'))
+    FROM public.watchlist_company AS wc
+  ),
+  (
+    SELECT md5(COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'watchlist', rollback.watchlist_payload,
+        'ownerUserId', rollback.owner_user_id,
+        'ownerName', rollback.owner_name,
+        'ownerUsername', rollback.owner_username,
+        'ownerDisplayUsername', rollback.owner_display_username,
+        'companies', rollback.company_memberships
+      ) ORDER BY rollback.watchlist_id
+    )::text, '[]'))
+    FROM public.watchlist_visibility_0089_rollback AS rollback
+  );--> statement-breakpoint
+
+DO $inventory$
+DECLARE
+  expected_count bigint;
+  expected_digest text;
+  actual_count bigint;
+  actual_digest text;
+  orphaned_owner_count bigint;
+BEGIN
+  SELECT expected_public_count, expected_public_digest
+  INTO expected_count, expected_digest
+  FROM pg_temp.jobseek_watchlist_privacy_attestation;
+
+  SELECT public_count, public_inventory_digest
+  INTO actual_count, actual_digest
+  FROM public.watchlist_visibility_0089_state
+  WHERE migration_key = '0089_make_existing_watchlists_private';
+
+  IF actual_count IS DISTINCT FROM expected_count
+     OR actual_digest IS DISTINCT FROM expected_digest
+  THEN
+    RAISE EXCEPTION
+      'Refusing watchlist privacy migration: live public inventory count/digest (%/%) differs from reviewed artifact (%/%)',
+      actual_count,
+      actual_digest,
+      expected_count,
+      expected_digest;
+  END IF;
+
+  SELECT count(*)
+  INTO orphaned_owner_count
+  FROM public.watchlist AS w
+  LEFT JOIN public."user" AS u ON u.id = w.user_id
+  WHERE u.id IS NULL;
+
+  IF orphaned_owner_count <> 0 THEN
+    RAISE EXCEPTION
+      'Refusing watchlist privacy migration: % watchlists are not owner-readable',
+      orphaned_owner_count;
+  END IF;
+END
+$inventory$;--> statement-breakpoint
+
+DO $migration$
+DECLARE
+  expected_count bigint;
+  migrated_count bigint;
+BEGIN
+  SELECT public_count
+  INTO expected_count
+  FROM public.watchlist_visibility_0089_state
+  WHERE migration_key = '0089_make_existing_watchlists_private';
+
+  UPDATE public.watchlist
+  SET is_public = false
+  WHERE is_public = true;
+
+  GET DIAGNOSTICS migrated_count = ROW_COUNT;
+
+  IF migrated_count IS DISTINCT FROM expected_count THEN
+    RAISE EXCEPTION
+      'Watchlist privacy migration updated % rows; expected %',
+      migrated_count,
+      expected_count;
+  END IF;
+END
+$migration$;--> statement-breakpoint
+
+DO $postconditions$
+DECLARE
+  state_row public.watchlist_visibility_0089_state%ROWTYPE;
+  current_watchlist_count bigint;
+  current_membership_count bigint;
+  current_public_count bigint;
+  current_watchlist_content_digest text;
+  current_filters_digest text;
+  current_alerts_digest text;
+  current_provenance_digest text;
+  current_owners_digest text;
+  current_membership_digest text;
+  orphaned_owner_count bigint;
+  index_definition text;
+  index_valid boolean;
+  index_ready boolean;
+BEGIN
+  SELECT *
+  INTO STRICT state_row
+  FROM public.watchlist_visibility_0089_state
+  WHERE migration_key = '0089_make_existing_watchlists_private';
+
+  SELECT
+    count(*),
+    count(*) FILTER (WHERE is_public),
+    md5(COALESCE(jsonb_agg(to_jsonb(w) - 'is_public' ORDER BY w.id)::text, '[]')),
+    md5(COALESCE(jsonb_agg(jsonb_build_object('id', w.id, 'filters', w.filters) ORDER BY w.id)::text, '[]')),
+    md5(COALESCE(jsonb_agg(jsonb_build_object('id', w.id, 'alertsEnabled', w.alerts_enabled) ORDER BY w.id)::text, '[]')),
+    md5(COALESCE(jsonb_agg(jsonb_build_object('id', w.id, 'sourceWatchlistId', w.source_watchlist_id) ORDER BY w.id)::text, '[]')),
+    md5(COALESCE(jsonb_agg(jsonb_build_object('watchlistId', w.id, 'ownerUserId', w.user_id) ORDER BY w.id)::text, '[]'))
+  INTO
+    current_watchlist_count,
+    current_public_count,
+    current_watchlist_content_digest,
+    current_filters_digest,
+    current_alerts_digest,
+    current_provenance_digest,
+    current_owners_digest
+  FROM public.watchlist AS w;
+
+  SELECT
+    count(*),
+    md5(COALESCE(jsonb_agg(to_jsonb(wc) ORDER BY wc.id)::text, '[]'))
+  INTO current_membership_count, current_membership_digest
+  FROM public.watchlist_company AS wc;
+
+  SELECT count(*)
+  INTO orphaned_owner_count
+  FROM public.watchlist AS w
+  LEFT JOIN public."user" AS u ON u.id = w.user_id
+  WHERE u.id IS NULL;
+
+  IF current_watchlist_count IS DISTINCT FROM state_row.watchlist_count
+     OR current_membership_count IS DISTINCT FROM state_row.membership_count
+     OR current_public_count <> 0
+     OR current_watchlist_content_digest IS DISTINCT FROM state_row.watchlist_content_digest
+     OR current_filters_digest IS DISTINCT FROM state_row.filters_digest
+     OR current_alerts_digest IS DISTINCT FROM state_row.alerts_digest
+     OR current_provenance_digest IS DISTINCT FROM state_row.provenance_digest
+     OR current_owners_digest IS DISTINCT FROM state_row.owners_digest
+     OR current_membership_digest IS DISTINCT FROM state_row.membership_digest
+     OR orphaned_owner_count <> 0
+  THEN
+    RAISE EXCEPTION
+      'Watchlist privacy migration changed protected watchlist, filter, alert, provenance, owner, or membership state';
+  END IF;
+
+  IF EXISTS (
+    (SELECT id, payload FROM jobseek_0089_watchlist_before
+     EXCEPT
+     SELECT w.id, to_jsonb(w) - 'is_public' FROM public.watchlist AS w)
+    UNION ALL
+    (SELECT w.id, to_jsonb(w) - 'is_public' FROM public.watchlist AS w
+     EXCEPT
+     SELECT id, payload FROM jobseek_0089_watchlist_before)
+  ) THEN
+    RAISE EXCEPTION
+      'Watchlist privacy migration changed watchlist row content other than is_public';
+  END IF;
+
+  IF EXISTS (
+    (SELECT id, payload FROM jobseek_0089_membership_before
+     EXCEPT
+     SELECT wc.id, to_jsonb(wc) FROM public.watchlist_company AS wc)
+    UNION ALL
+    (SELECT wc.id, to_jsonb(wc) FROM public.watchlist_company AS wc
+     EXCEPT
+     SELECT id, payload FROM jobseek_0089_membership_before)
+  ) THEN
+    RAISE EXCEPTION
+      'Watchlist privacy migration changed watchlist_company content';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.watchlist_visibility_0089_rollback AS rollback
+    LEFT JOIN public.watchlist AS w ON w.id = rollback.watchlist_id
+    WHERE w.id IS NULL
+       OR w.user_id IS DISTINCT FROM rollback.owner_user_id
+       OR w.source_watchlist_id IS DISTINCT FROM
+          (rollback.watchlist_payload ->> 'source_watchlist_id')::uuid
+  ) THEN
+    RAISE EXCEPTION
+      'Watchlist privacy migration lost an owner, copy, or source provenance row';
+  END IF;
+
+  SELECT pg_get_indexdef(indexrelid), indisvalid, indisready
+  INTO index_definition, index_valid, index_ready
+  FROM pg_index
+  WHERE indexrelid = to_regclass('public.idx_wl_public');
+
+  IF index_definition IS NULL
+     OR index_valid IS DISTINCT FROM true
+     OR index_ready IS DISTINCT FROM true
+     OR index_definition NOT LIKE '%WHERE (is_public = true)%'
+  THEN
+    RAISE EXCEPTION
+      'Watchlist privacy migration did not retain valid idx_wl_public';
+  END IF;
+END
+$postconditions$;

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -540,6 +540,13 @@
       "when": 1788199156000,
       "tag": "0088_notification_policy_foundation",
       "breakpoints": true
+    },
+    {
+      "idx": 77,
+      "version": "7",
+      "when": 1788206680000,
+      "tag": "0089_make_existing_watchlists_private",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
     "db:migrate": "tsx src/db/migrate.ts",
     "db:migrate:apply-account-issuer": "tsx scripts/apply-better-auth-account-issuer.ts",
     "db:migrate:verify-account-issuer": "tsx scripts/verify-better-auth-account-issuer.ts",
+    "db:migrate:watchlist-visibility": "tsx scripts/watchlist-visibility-migration.ts",
     "db:migrate:verify-retirement": "tsx scripts/verify-job-posting-retirement.ts",
     "db:seed": "tsx src/db/seed.ts",
     "db:push": "drizzle-kit push",

--- a/apps/web/scripts/watchlist-visibility-contract.ts
+++ b/apps/web/scripts/watchlist-visibility-contract.ts
@@ -1,0 +1,188 @@
+export const watchlistPathLocales = ["en", "de", "fr", "it"] as const;
+
+export type WatchlistPathLocale = (typeof watchlistPathLocales)[number];
+export type OwnerSlugKind = "username" | "display_username";
+
+export type WatchlistPathVariant = {
+  locale: WatchlistPathLocale;
+  ownerSlugKind: OwnerSlugKind;
+  ownerSlug: string;
+  pagePath: string;
+  ogPath: string;
+  legacyOgPathPattern: string;
+  legacyOgPurgePattern: string;
+};
+
+type ApplyEnvironment = Readonly<Record<string, string | undefined>>;
+
+type InventoryIdentity = {
+  publicCount: number;
+  publicInventoryDigest: string;
+};
+
+function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function pathVariant(
+  ownerSlugKind: OwnerSlugKind,
+  ownerSlug: string,
+  locale: WatchlistPathLocale,
+  watchlistSlug: string,
+): WatchlistPathVariant {
+  const legacyPrefix = `/${locale}/${ownerSlug}/${watchlistSlug}/opengraph-image-`;
+  return {
+    locale,
+    ownerSlugKind,
+    ownerSlug,
+    pagePath: `/${locale}/${ownerSlug}/${watchlistSlug}`,
+    ogPath: `/og/watchlist/${locale}/${ownerSlug}/${watchlistSlug}`,
+    legacyOgPathPattern: `${legacyPrefix}:hash`,
+    legacyOgPurgePattern: `${legacyPrefix}*`,
+  };
+}
+
+export function expectedWatchlistPathVariants(params: {
+  ownerUsername: string | null;
+  ownerDisplayUsername: string | null;
+  watchlistSlug: string;
+}): WatchlistPathVariant[] {
+  const ownerSlugs: Array<[OwnerSlugKind, string | null]> = [
+    ["username", params.ownerUsername],
+    ["display_username", params.ownerDisplayUsername],
+  ];
+  return ownerSlugs.flatMap(([kind, value]) =>
+    value === null
+      ? []
+      : watchlistPathLocales.map((locale) =>
+          pathVariant(kind, value, locale, params.watchlistSlug),
+        ),
+  );
+}
+
+/**
+ * Validate both views of the removal manifest:
+ *
+ * - every non-null source column keeps its labelled `(kind, locale)` entries;
+ * - the distinct concrete URL and legacy-pattern sets contain every URL form.
+ *
+ * Mirrored `username`/`display_username` values therefore retain eight labelled
+ * provenance entries while correctly representing four distinct URLs per form.
+ */
+export function assertWatchlistPathVariantMatrix(
+  params: {
+    watchlistId: string;
+    ownerUsername: string | null;
+    ownerDisplayUsername: string | null;
+    watchlistSlug: string;
+  },
+  actual: WatchlistPathVariant[],
+): void {
+  const expected = expectedWatchlistPathVariants(params);
+  const key = (variant: WatchlistPathVariant) =>
+    `${variant.ownerSlugKind}\u0000${variant.locale}`;
+  const expectedByLabel = new Map(expected.map((variant) => [key(variant), variant]));
+  const actualByLabel = new Map(actual.map((variant) => [key(variant), variant]));
+
+  invariant(
+    actual.length === expected.length && actualByLabel.size === actual.length,
+    `Localized labelled path inventory is incomplete or duplicated for watchlist ${params.watchlistId}`,
+  );
+  invariant(
+    expectedByLabel.size === actualByLabel.size,
+    `Localized labelled path inventory has the wrong matrix for watchlist ${params.watchlistId}`,
+  );
+  for (const [label, expectedVariant] of expectedByLabel) {
+    const actualVariant = actualByLabel.get(label);
+    invariant(
+      actualVariant !== undefined &&
+        actualVariant.locale === expectedVariant.locale &&
+        actualVariant.ownerSlugKind === expectedVariant.ownerSlugKind &&
+        actualVariant.ownerSlug === expectedVariant.ownerSlug &&
+        actualVariant.pagePath === expectedVariant.pagePath &&
+        actualVariant.ogPath === expectedVariant.ogPath &&
+        actualVariant.legacyOgPathPattern ===
+          expectedVariant.legacyOgPathPattern &&
+        actualVariant.legacyOgPurgePattern ===
+          expectedVariant.legacyOgPurgePattern,
+      `Localized path inventory differs for ${label} on watchlist ${params.watchlistId}`,
+    );
+  }
+
+  for (const field of [
+    "pagePath",
+    "ogPath",
+    "legacyOgPathPattern",
+    "legacyOgPurgePattern",
+  ] as const) {
+    const expectedDistinct = new Set(expected.map((variant) => variant[field]));
+    const actualDistinct = new Set(actual.map((variant) => variant[field]));
+    invariant(
+      expectedDistinct.size === actualDistinct.size &&
+        [...expectedDistinct].every((value) => actualDistinct.has(value)),
+      `Distinct ${field} inventory is incomplete for watchlist ${params.watchlistId}`,
+    );
+  }
+}
+
+function positiveRunId(environment: ApplyEnvironment, name: string): number {
+  const raw = environment[name];
+  const parsed = Number(raw);
+  invariant(
+    raw && /^\d+$/.test(raw) && Number.isSafeInteger(parsed) && parsed > 0,
+    `${name} must be a positive immutable run ID`,
+  );
+  return parsed;
+}
+
+function deployedSha(environment: ApplyEnvironment, name: string): string {
+  const value = environment[name];
+  invariant(
+    value && /^[0-9a-f]{40}$/.test(value),
+    `${name} must be a deployed 40-hex SHA`,
+  );
+  return value;
+}
+
+export function requiredWatchlistApplyEvidence(
+  environment: ApplyEnvironment,
+  inventory: InventoryIdentity,
+) {
+  invariant(
+    environment.WATCHLIST_PRIVACY_CONFIRMATION === "PRIVATE-WATCHLISTS-0089",
+    "Apply confirmation is invalid",
+  );
+  const routeCutoverApprovedBy =
+    environment.WATCHLIST_ROUTE_CUTOVER_APPROVED_BY;
+  invariant(
+    routeCutoverApprovedBy?.trim(),
+    "WATCHLIST_ROUTE_CUTOVER_APPROVED_BY must record the human approver",
+  );
+
+  return {
+    confirmation: environment.WATCHLIST_PRIVACY_CONFIRMATION,
+    backupRestoreRunId: positiveRunId(
+      environment,
+      "WATCHLIST_PRIVACY_BACKUP_RESTORE_RUN_ID",
+    ),
+    privateMutationsDeploySha: deployedSha(
+      environment,
+      "WATCHLIST_PRIVATE_MUTATIONS_DEPLOY_SHA",
+    ),
+    routeCutoverDeploySha: deployedSha(
+      environment,
+      "WATCHLIST_ROUTE_CUTOVER_DEPLOY_SHA",
+    ),
+    routeCutoverApprovedBy,
+    publicApiCutoverDeploySha: deployedSha(
+      environment,
+      "WATCHLIST_PUBLIC_API_CUTOVER_DEPLOY_SHA",
+    ),
+    publicApiCutoverVerificationRunId: positiveRunId(
+      environment,
+      "WATCHLIST_PUBLIC_API_CUTOVER_VERIFICATION_RUN_ID",
+    ),
+    expectedPublicCount: inventory.publicCount,
+    expectedPublicDigest: inventory.publicInventoryDigest,
+  };
+}

--- a/apps/web/scripts/watchlist-visibility-contract.ts
+++ b/apps/web/scripts/watchlist-visibility-contract.ts
@@ -144,6 +144,18 @@ function deployedSha(environment: ApplyEnvironment, name: string): string {
   return value;
 }
 
+function requiredNonBlankString(
+  environment: ApplyEnvironment,
+  name: string,
+): string {
+  const value = environment[name];
+  invariant(
+    typeof value === "string" && value.trim().length > 0,
+    `${name} must be a non-empty string`,
+  );
+  return value.trim();
+}
+
 export function requiredWatchlistApplyEvidence(
   environment: ApplyEnvironment,
   inventory: InventoryIdentity,
@@ -152,11 +164,9 @@ export function requiredWatchlistApplyEvidence(
     environment.WATCHLIST_PRIVACY_CONFIRMATION === "PRIVATE-WATCHLISTS-0089",
     "Apply confirmation is invalid",
   );
-  const routeCutoverApprovedBy =
-    environment.WATCHLIST_ROUTE_CUTOVER_APPROVED_BY;
-  invariant(
-    routeCutoverApprovedBy?.trim(),
-    "WATCHLIST_ROUTE_CUTOVER_APPROVED_BY must record the human approver",
+  const routeCutoverApprovedBy = requiredNonBlankString(
+    environment,
+    "WATCHLIST_ROUTE_CUTOVER_APPROVED_BY",
   );
 
   return {

--- a/apps/web/scripts/watchlist-visibility-migration.ts
+++ b/apps/web/scripts/watchlist-visibility-migration.ts
@@ -1,0 +1,907 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import dotenv from "dotenv";
+import { readMigrationFiles, type MigrationMeta } from "drizzle-orm/migrator";
+import postgres, { type Sql } from "postgres";
+
+import { logExternalError } from "../src/lib/safe-external-error";
+
+dotenv.config({ path: ".env.local", quiet: true });
+
+type Command = "inventory" | "apply" | "verify" | "rollback";
+
+type PathVariant = {
+  locale: "en" | "de" | "fr" | "it";
+  ownerSlugKind: "username" | "display_username";
+  ownerSlug: string;
+  pagePath: string;
+  ogPath: string;
+};
+
+type InventoryRow = {
+  watchlistId: string;
+  ownerUserId: string;
+  ownerName: string;
+  ownerUsername: string | null;
+  ownerDisplayUsername: string | null;
+  watchlistSlug: string;
+  watchlistPayload: Record<string, unknown>;
+  companyMemberships: Array<Record<string, unknown>>;
+  pathVariants: PathVariant[];
+};
+
+type AggregateEvidence = {
+  watchlistCount: number;
+  membershipCount: number;
+  publicCount: number;
+  privateCount: number;
+  alertsEnabledCount: number;
+  copiedWatchlistCount: number;
+  watchlistContentDigest: string;
+  filtersDigest: string;
+  alertsDigest: string;
+  provenanceDigest: string;
+  ownersDigest: string;
+  membershipDigest: string;
+  publicInventoryDigest: string;
+};
+
+type InventoryArtifact = {
+  formatVersion: 1;
+  migrationTag: typeof targetTag;
+  capturedAt: string;
+  databaseName: string;
+  serverVersion: string;
+  prerequisite: {
+    tag: typeof prerequisiteTag;
+    createdAt: number;
+    hash: string;
+  };
+  target: {
+    tag: typeof targetTag;
+    createdAt: number;
+    hash: string;
+  };
+  aggregates: AggregateEvidence;
+  publicWatchlists: InventoryRow[];
+};
+
+type Journal = {
+  entries: Array<{ idx: number; when: number; tag: string }>;
+};
+
+const migrationFolder = resolve(process.cwd(), "drizzle");
+const prerequisiteTag = "0088_notification_policy_foundation";
+const targetTag = "0089_make_existing_watchlists_private";
+const prerequisiteCreatedAt = 1_788_199_156_000;
+const targetCreatedAt = 1_788_206_680_000;
+const migrationKey = targetTag;
+
+function invariant(condition: unknown, message: string): asserts condition {
+  if (!condition) throw new Error(message);
+}
+
+function isCommand(value: string | undefined): value is Command {
+  return (
+    value === "inventory" ||
+    value === "apply" ||
+    value === "verify" ||
+    value === "rollback"
+  );
+}
+
+function requireDirectDatabaseUrl(command: Command): string {
+  const databaseUrl = process.env.DATABASE_URL_UNPOOLED;
+  invariant(
+    databaseUrl,
+    `DATABASE_URL_UNPOOLED must be set for watchlist visibility ${command}`,
+  );
+  invariant(
+    new URL(databaseUrl).port !== "6543",
+    "Refusing watchlist visibility work through the transaction pooler",
+  );
+  if (command === "apply" || command === "rollback") {
+    invariant(
+      process.env.MIGRATION_REQUIRE_UNPOOLED === "true",
+      "MIGRATION_REQUIRE_UNPOOLED=true is required for writes",
+    );
+  }
+  return databaseUrl;
+}
+
+function migrationByTag(
+  journal: Journal,
+  migrations: MigrationMeta[],
+  tag: string,
+): MigrationMeta {
+  const index = journal.entries.findIndex((entry) => entry.tag === tag);
+  invariant(index !== -1, `Migration journal does not contain ${tag}`);
+  const migration = migrations[index];
+  invariant(migration, `Migration metadata does not contain ${tag}`);
+  invariant(
+    migration.folderMillis === journal.entries[index]?.when,
+    `Migration timestamp does not match journal entry ${tag}`,
+  );
+  return migration;
+}
+
+function loadMigrations(): {
+  prerequisite: MigrationMeta;
+  target: MigrationMeta;
+} {
+  const journal = JSON.parse(
+    readFileSync(resolve(migrationFolder, "meta/_journal.json"), "utf8"),
+  ) as Journal;
+  const migrations = readMigrationFiles({ migrationsFolder: migrationFolder });
+  invariant(
+    journal.entries.length === migrations.length,
+    "Journal and SQL migration counts differ",
+  );
+
+  const prerequisite = migrationByTag(
+    journal,
+    migrations,
+    prerequisiteTag,
+  );
+  const target = migrationByTag(journal, migrations, targetTag);
+  invariant(
+    prerequisite.folderMillis === prerequisiteCreatedAt,
+    "0088 prerequisite timestamp differs",
+  );
+  invariant(
+    target.folderMillis === targetCreatedAt,
+    "0089 target timestamp differs",
+  );
+  return { prerequisite, target };
+}
+
+function readArtifact(path: string): InventoryArtifact {
+  const artifact = JSON.parse(readFileSync(resolve(path), "utf8")) as Partial<InventoryArtifact>;
+  invariant(artifact.formatVersion === 1, "Unsupported inventory formatVersion");
+  invariant(artifact.migrationTag === targetTag, "Inventory is for a different migration");
+  invariant(artifact.prerequisite?.tag === prerequisiteTag, "Inventory prerequisite differs");
+  invariant(artifact.target?.tag === targetTag, "Inventory target differs");
+  invariant(artifact.aggregates, "Inventory aggregate evidence is absent");
+  invariant(Array.isArray(artifact.publicWatchlists), "Inventory rows are absent");
+  invariant(
+    artifact.aggregates.publicCount === artifact.publicWatchlists.length,
+    "Inventory row count differs from its public count",
+  );
+  invariant(
+    /^[0-9a-f]{32}$/.test(artifact.aggregates.publicInventoryDigest),
+    "Inventory digest is invalid",
+  );
+  return artifact as InventoryArtifact;
+}
+
+function writePrivateJson(path: string, value: unknown, exclusive: boolean): void {
+  writeFileSync(resolve(path), `${JSON.stringify(value, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+    flag: exclusive ? "wx" : "w",
+  });
+}
+
+async function readAggregateEvidence(sql: Sql): Promise<AggregateEvidence> {
+  const [watchlists] = await sql<
+    Omit<AggregateEvidence, "membershipCount" | "membershipDigest" | "publicInventoryDigest">[]
+  >`
+    SELECT
+      count(*)::integer AS "watchlistCount",
+      count(*) FILTER (WHERE is_public)::integer AS "publicCount",
+      count(*) FILTER (WHERE NOT is_public)::integer AS "privateCount",
+      count(*) FILTER (WHERE alerts_enabled)::integer AS "alertsEnabledCount",
+      count(*) FILTER (WHERE source_watchlist_id IS NOT NULL)::integer AS "copiedWatchlistCount",
+      md5(COALESCE(jsonb_agg(to_jsonb(w) - 'is_public' ORDER BY w.id)::text, '[]'))
+        AS "watchlistContentDigest",
+      md5(COALESCE(jsonb_agg(jsonb_build_object('id', w.id, 'filters', w.filters) ORDER BY w.id)::text, '[]'))
+        AS "filtersDigest",
+      md5(COALESCE(jsonb_agg(jsonb_build_object('id', w.id, 'alertsEnabled', w.alerts_enabled) ORDER BY w.id)::text, '[]'))
+        AS "alertsDigest",
+      md5(COALESCE(jsonb_agg(jsonb_build_object('id', w.id, 'sourceWatchlistId', w.source_watchlist_id) ORDER BY w.id)::text, '[]'))
+        AS "provenanceDigest",
+      md5(COALESCE(jsonb_agg(jsonb_build_object('watchlistId', w.id, 'ownerUserId', w.user_id) ORDER BY w.id)::text, '[]'))
+        AS "ownersDigest"
+    FROM public.watchlist AS w
+  `;
+  const [memberships] = await sql<
+    Pick<AggregateEvidence, "membershipCount" | "membershipDigest">[]
+  >`
+    SELECT
+      count(*)::integer AS "membershipCount",
+      md5(COALESCE(jsonb_agg(to_jsonb(wc) ORDER BY wc.id)::text, '[]'))
+        AS "membershipDigest"
+    FROM public.watchlist_company AS wc
+  `;
+  const [publicInventory] = await sql<
+    Pick<AggregateEvidence, "publicInventoryDigest">[]
+  >`
+    SELECT md5(COALESCE(jsonb_agg(
+      jsonb_build_object(
+        'watchlist', inventory.watchlist_payload,
+        'ownerUserId', inventory.owner_user_id,
+        'ownerName', inventory.owner_name,
+        'ownerUsername', inventory.owner_username,
+        'ownerDisplayUsername', inventory.owner_display_username,
+        'companies', inventory.company_memberships
+      ) ORDER BY inventory.watchlist_id
+    )::text, '[]')) AS "publicInventoryDigest"
+    FROM (
+      SELECT
+        w.id AS watchlist_id,
+        to_jsonb(w) AS watchlist_payload,
+        u.id AS owner_user_id,
+        u.name AS owner_name,
+        u.username AS owner_username,
+        u.display_username AS owner_display_username,
+        COALESCE(
+          (
+            SELECT jsonb_agg(to_jsonb(wc) ORDER BY wc.id)
+            FROM public.watchlist_company AS wc
+            WHERE wc.watchlist_id = w.id
+          ),
+          '[]'::jsonb
+        ) AS company_memberships
+      FROM public.watchlist AS w
+      JOIN public."user" AS u ON u.id = w.user_id
+      WHERE w.is_public
+      ORDER BY w.id
+    ) AS inventory
+  `;
+  invariant(watchlists && memberships && publicInventory, "Could not aggregate watchlists");
+  return { ...watchlists, ...memberships, ...publicInventory };
+}
+
+async function readPublicRows(sql: Sql): Promise<InventoryRow[]> {
+  return sql<InventoryRow[]>`
+    SELECT
+      w.id AS "watchlistId",
+      u.id AS "ownerUserId",
+      u.name AS "ownerName",
+      u.username AS "ownerUsername",
+      u.display_username AS "ownerDisplayUsername",
+      w.slug AS "watchlistSlug",
+      to_jsonb(w) AS "watchlistPayload",
+      COALESCE(
+        (
+          SELECT jsonb_agg(to_jsonb(wc) ORDER BY wc.id)
+          FROM public.watchlist_company AS wc
+          WHERE wc.watchlist_id = w.id
+        ),
+        '[]'::jsonb
+      ) AS "companyMemberships",
+      COALESCE(
+        (
+          SELECT jsonb_agg(
+            jsonb_build_object(
+              'locale', locale.value,
+              'ownerSlugKind', owner_slug.kind,
+              'ownerSlug', owner_slug.value,
+              'pagePath', format('/%s/%s/%s', locale.value, owner_slug.value, w.slug),
+              'ogPath', format('/og/watchlist/%s/%s/%s', locale.value, owner_slug.value, w.slug)
+            )
+            ORDER BY owner_slug.kind, locale.value
+          )
+          FROM (
+            VALUES
+              ('username'::text, u.username),
+              ('display_username'::text, u.display_username)
+          ) AS owner_slug(kind, value)
+          CROSS JOIN (
+            VALUES ('en'::text), ('de'::text), ('fr'::text), ('it'::text)
+          ) AS locale(value)
+          WHERE owner_slug.value IS NOT NULL
+        ),
+        '[]'::jsonb
+      ) AS "pathVariants"
+    FROM public.watchlist AS w
+    JOIN public."user" AS u ON u.id = w.user_id
+    WHERE w.is_public
+    ORDER BY w.id
+  `;
+}
+
+async function assertCompatibilitySchema(sql: Sql): Promise<void> {
+  const [column] = await sql<
+    { count: number; defaultValue: string | null }[]
+  >`
+    SELECT
+      count(*)::integer AS count,
+      min(pg_get_expr(default_value.adbin, default_value.adrelid)) AS "defaultValue"
+    FROM pg_attribute AS attribute
+    LEFT JOIN pg_attrdef AS default_value
+      ON default_value.adrelid = attribute.attrelid
+     AND default_value.adnum = attribute.attnum
+    WHERE attribute.attrelid = 'public.watchlist'::regclass
+      AND attribute.attname = 'is_public'
+      AND attribute.atttypid = 'boolean'::regtype
+      AND attribute.attnotnull
+      AND NOT attribute.attisdropped
+  `;
+  const [index] = await sql<
+    { definition: string | null; valid: boolean | null; ready: boolean | null }[]
+  >`
+    SELECT
+      pg_get_indexdef(indexrelid) AS definition,
+      indisvalid AS valid,
+      indisready AS ready
+    FROM pg_index
+    WHERE indexrelid = to_regclass('public.idx_wl_public')
+  `;
+  invariant(
+    column?.count === 1 && column.defaultValue === "false",
+    `watchlist.is_public is not the expected retained private-default boolean: ${JSON.stringify(column)}`,
+  );
+  invariant(
+    index?.valid === true &&
+      index.ready === true &&
+      index.definition?.includes(" ON public.watchlist ") &&
+      index.definition.includes("(is_public)") &&
+      index.definition.includes("WHERE (is_public = true)"),
+    `idx_wl_public is not the expected retained partial index: ${JSON.stringify(index)}`,
+  );
+}
+
+async function assertLedgerPreflight(
+  sql: Sql,
+  prerequisite: MigrationMeta,
+  target: MigrationMeta,
+): Promise<void> {
+  const [ledger] = await sql<
+    { rowCount: number; latestCreatedAt: string | null; latestHash: string | null }[]
+  >`
+    SELECT
+      count(*)::integer AS "rowCount",
+      (array_agg(created_at::text ORDER BY created_at DESC, id DESC))[1]
+        AS "latestCreatedAt",
+      (array_agg(hash ORDER BY created_at DESC, id DESC))[1]
+        AS "latestHash"
+    FROM drizzle.__drizzle_migrations
+  `;
+  const [rows] = await sql<
+    { prerequisiteExact: number; targetExact: number }[]
+  >`
+    SELECT
+      count(*) FILTER (
+        WHERE created_at = ${prerequisite.folderMillis}
+          AND hash = ${prerequisite.hash}
+      )::integer AS "prerequisiteExact",
+      count(*) FILTER (
+        WHERE created_at = ${target.folderMillis}
+          AND hash = ${target.hash}
+      )::integer AS "targetExact"
+    FROM drizzle.__drizzle_migrations
+  `;
+  invariant(ledger && rows, "Could not read the migration ledger");
+  invariant(rows.targetExact === 0, "0089 is already recorded; use verify");
+  invariant(
+    rows.prerequisiteExact === 1 &&
+      ledger.rowCount === 78 &&
+      Number(ledger.latestCreatedAt) === prerequisite.folderMillis &&
+      ledger.latestHash === prerequisite.hash,
+    `Expected exact post-0088 ledger before 0089: ${JSON.stringify({ ledger, rows })}`,
+  );
+}
+
+async function inventory(sql: Sql, outputPath: string): Promise<void> {
+  const { prerequisite, target } = loadMigrations();
+  const artifact = await sql.begin(async (tx) => {
+    await tx`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`;
+    await tx`SET LOCAL statement_timeout = '60s'`;
+    await tx`SET LOCAL idle_in_transaction_session_timeout = '90s'`;
+    await assertLedgerPreflight(tx, prerequisite, target);
+    await assertCompatibilitySchema(tx);
+
+    const [relations] = await tx<{ artifactRelations: number }[]>`
+      SELECT count(*)::integer AS "artifactRelations"
+      FROM pg_class
+      WHERE oid IN (
+        to_regclass('public.watchlist_visibility_0089_state'),
+        to_regclass('public.watchlist_visibility_0089_rollback')
+      )
+    `;
+    const [orphans] = await tx<{ count: number }[]>`
+      SELECT count(*)::integer AS count
+      FROM public.watchlist AS w
+      LEFT JOIN public."user" AS u ON u.id = w.user_id
+      WHERE u.id IS NULL
+    `;
+    invariant(relations?.artifactRelations === 0, "0089 artifact relations already exist");
+    invariant(orphans?.count === 0, "A watchlist is not owner-readable");
+
+    const [database] = await tx<{ databaseName: string; serverVersion: string }[]>`
+      SELECT
+        current_database() AS "databaseName",
+        current_setting('server_version') AS "serverVersion"
+    `;
+    const aggregates = await readAggregateEvidence(tx);
+    const publicWatchlists = await readPublicRows(tx);
+    invariant(database, "Could not read database identity");
+    invariant(
+      aggregates.publicCount === publicWatchlists.length,
+      "Public inventory lost an owner or row",
+    );
+    for (const row of publicWatchlists) {
+      const ownerSlugs = new Set(
+        [row.ownerUsername, row.ownerDisplayUsername].filter(
+          (value): value is string => value !== null,
+        ),
+      );
+      invariant(
+        row.pathVariants.length === ownerSlugs.size * 4,
+        `Localized path inventory is incomplete for watchlist ${row.watchlistId}`,
+      );
+    }
+
+    return {
+      formatVersion: 1,
+      migrationTag: targetTag,
+      capturedAt: new Date().toISOString(),
+      ...database,
+      prerequisite: {
+        tag: prerequisiteTag,
+        createdAt: prerequisite.folderMillis,
+        hash: prerequisite.hash,
+      },
+      target: {
+        tag: targetTag,
+        createdAt: target.folderMillis,
+        hash: target.hash,
+      },
+      aggregates,
+      publicWatchlists,
+    } satisfies InventoryArtifact;
+  });
+
+  writePrivateJson(outputPath, artifact, true);
+  process.stdout.write(
+    `${JSON.stringify({
+      command: "inventory",
+      output: resolve(outputPath),
+      publicCount: artifact.aggregates.publicCount,
+      publicInventoryDigest: artifact.aggregates.publicInventoryDigest,
+      localizedPathCount: artifact.publicWatchlists.reduce(
+        (count, row) => count + row.pathVariants.length,
+        0,
+      ),
+    })}\n`,
+  );
+}
+
+function requiredApplyEvidence(artifact: InventoryArtifact) {
+  const confirmation = process.env.WATCHLIST_PRIVACY_CONFIRMATION;
+  const rawBackupRunId = process.env.WATCHLIST_PRIVACY_BACKUP_RESTORE_RUN_ID;
+  const privateMutationsDeploySha =
+    process.env.WATCHLIST_PRIVATE_MUTATIONS_DEPLOY_SHA;
+  const routeCutoverDeploySha = process.env.WATCHLIST_ROUTE_CUTOVER_DEPLOY_SHA;
+  const routeCutoverApprovedBy =
+    process.env.WATCHLIST_ROUTE_CUTOVER_APPROVED_BY;
+  const backupRestoreRunId = Number(rawBackupRunId);
+
+  invariant(confirmation === "PRIVATE-WATCHLISTS-0089", "Apply confirmation is invalid");
+  invariant(
+    rawBackupRunId && /^\d+$/.test(rawBackupRunId) && Number.isSafeInteger(backupRestoreRunId) && backupRestoreRunId > 0,
+    "WATCHLIST_PRIVACY_BACKUP_RESTORE_RUN_ID must be a positive run ID",
+  );
+  invariant(
+    privateMutationsDeploySha && /^[0-9a-f]{40}$/.test(privateMutationsDeploySha),
+    "WATCHLIST_PRIVATE_MUTATIONS_DEPLOY_SHA must be a deployed 40-hex SHA",
+  );
+  invariant(
+    routeCutoverDeploySha && /^[0-9a-f]{40}$/.test(routeCutoverDeploySha),
+    "WATCHLIST_ROUTE_CUTOVER_DEPLOY_SHA must be a deployed 40-hex SHA",
+  );
+  invariant(
+    routeCutoverApprovedBy?.trim(),
+    "WATCHLIST_ROUTE_CUTOVER_APPROVED_BY must record the human approver",
+  );
+
+  return {
+    confirmation,
+    backupRestoreRunId,
+    privateMutationsDeploySha,
+    routeCutoverDeploySha,
+    routeCutoverApprovedBy,
+    expectedPublicCount: artifact.aggregates.publicCount,
+    expectedPublicDigest: artifact.aggregates.publicInventoryDigest,
+  };
+}
+
+async function applyMigration(sql: Sql, artifact: InventoryArtifact): Promise<void> {
+  const { prerequisite, target } = loadMigrations();
+  invariant(
+    artifact.prerequisite.hash === prerequisite.hash &&
+      artifact.target.hash === target.hash,
+    "Inventory was not captured for the checked-out migration hashes",
+  );
+  const evidence = requiredApplyEvidence(artifact);
+
+  const outcome = await sql.begin(async (tx) => {
+    await tx`SET LOCAL lock_timeout = '10s'`;
+    await tx`SET LOCAL statement_timeout = '10min'`;
+    await tx`SET LOCAL idle_in_transaction_session_timeout = '2min'`;
+    await tx`
+      SELECT pg_advisory_xact_lock(
+        hashtextextended('jobseek:web-schema-migrations', 0)
+      )
+    `;
+
+    const [targetLedger] = await tx<{ count: number }[]>`
+      SELECT count(*)::integer AS count
+      FROM drizzle.__drizzle_migrations
+      WHERE created_at = ${target.folderMillis}
+        AND hash = ${target.hash}
+    `;
+    invariant(targetLedger, "Could not read the 0089 ledger row");
+    if (targetLedger.count === 1) {
+      const [state] = await tx<{ status: string; publicCount: number }[]>`
+        SELECT
+          state.status,
+          count(*) FILTER (WHERE w.is_public)::integer AS "publicCount"
+        FROM public.watchlist_visibility_0089_state AS state
+        CROSS JOIN public.watchlist AS w
+        WHERE state.migration_key = ${migrationKey}
+        GROUP BY state.status
+      `;
+      invariant(
+        state?.status === "private" && state.publicCount === 0,
+        "0089 is recorded but the private postcondition does not hold",
+      );
+      return "already-applied" as const;
+    }
+    invariant(targetLedger.count === 0, "0089 is recorded more than once");
+    await assertLedgerPreflight(tx, prerequisite, target);
+
+    await tx`
+      CREATE TEMPORARY TABLE jobseek_watchlist_privacy_attestation (
+        confirmation text NOT NULL,
+        backup_restore_run_id bigint NOT NULL,
+        private_mutations_deploy_sha text NOT NULL,
+        route_cutover_deploy_sha text NOT NULL,
+        route_cutover_approved_by text NOT NULL,
+        expected_public_count bigint NOT NULL,
+        expected_public_digest text NOT NULL,
+        attested_at timestamp with time zone NOT NULL
+      ) ON COMMIT DROP
+    `;
+    await tx`
+      INSERT INTO pg_temp.jobseek_watchlist_privacy_attestation (
+        confirmation,
+        backup_restore_run_id,
+        private_mutations_deploy_sha,
+        route_cutover_deploy_sha,
+        route_cutover_approved_by,
+        expected_public_count,
+        expected_public_digest,
+        attested_at
+      ) VALUES (
+        ${evidence.confirmation},
+        ${evidence.backupRestoreRunId},
+        ${evidence.privateMutationsDeploySha},
+        ${evidence.routeCutoverDeploySha},
+        ${evidence.routeCutoverApprovedBy},
+        ${evidence.expectedPublicCount},
+        ${evidence.expectedPublicDigest},
+        clock_timestamp()
+      )
+    `;
+
+    for (const statement of target.sql) {
+      if (statement.trim()) await tx.unsafe(statement);
+    }
+    await tx`
+      INSERT INTO drizzle.__drizzle_migrations (hash, created_at)
+      VALUES (${target.hash}, ${target.folderMillis})
+    `;
+    return "applied" as const;
+  });
+
+  process.stdout.write(`${JSON.stringify({ command: "apply", migration: targetTag, outcome })}\n`);
+}
+
+async function readState(sql: Sql) {
+  const [state] = await sql<
+    ({ status: "private" | "rolled_back" } & Omit<
+      AggregateEvidence,
+      "privateCount" | "alertsEnabledCount" | "copiedWatchlistCount"
+    >)[]
+  >`
+    SELECT
+      status,
+      watchlist_count::integer AS "watchlistCount",
+      membership_count::integer AS "membershipCount",
+      public_count::integer AS "publicCount",
+      watchlist_content_digest AS "watchlistContentDigest",
+      filters_digest AS "filtersDigest",
+      alerts_digest AS "alertsDigest",
+      provenance_digest AS "provenanceDigest",
+      owners_digest AS "ownersDigest",
+      membership_digest AS "membershipDigest",
+      public_inventory_digest AS "publicInventoryDigest"
+    FROM public.watchlist_visibility_0089_state
+    WHERE migration_key = ${migrationKey}
+  `;
+  invariant(state, "0089 migration state is absent");
+  return state;
+}
+
+async function assertRollbackArtifact(
+  sql: Sql,
+  artifact: InventoryArtifact,
+): Promise<{ changedRows: number; changedMemberships: number; ownerFailures: number }> {
+  const [evidence] = await sql<
+    { rowCount: number; digest: string; changedRows: number; changedMemberships: number; ownerFailures: number }[]
+  >`
+    SELECT
+      count(*)::integer AS "rowCount",
+      md5(COALESCE(jsonb_agg(
+        jsonb_build_object(
+          'watchlist', rollback.watchlist_payload,
+          'ownerUserId', rollback.owner_user_id,
+          'ownerName', rollback.owner_name,
+          'ownerUsername', rollback.owner_username,
+          'ownerDisplayUsername', rollback.owner_display_username,
+          'companies', rollback.company_memberships
+        ) ORDER BY rollback.watchlist_id
+      )::text, '[]')) AS digest,
+      count(*) FILTER (
+        WHERE w.id IS NULL
+           OR (to_jsonb(w) - 'is_public') IS DISTINCT FROM
+              (rollback.watchlist_payload - 'is_public')
+      )::integer AS "changedRows",
+      count(*) FILTER (
+        WHERE rollback.company_memberships IS DISTINCT FROM COALESCE(
+          (
+            SELECT jsonb_agg(to_jsonb(wc) ORDER BY wc.id)
+            FROM public.watchlist_company AS wc
+            WHERE wc.watchlist_id = rollback.watchlist_id
+          ),
+          '[]'::jsonb
+        )
+      )::integer AS "changedMemberships",
+      count(*) FILTER (
+        WHERE u.id IS NULL OR w.user_id IS DISTINCT FROM rollback.owner_user_id
+      )::integer AS "ownerFailures"
+    FROM public.watchlist_visibility_0089_rollback AS rollback
+    LEFT JOIN public.watchlist AS w ON w.id = rollback.watchlist_id
+    LEFT JOIN public."user" AS u ON u.id = rollback.owner_user_id
+  `;
+  invariant(evidence, "Could not verify the rollback artifact");
+  invariant(
+    evidence.rowCount === artifact.aggregates.publicCount &&
+      evidence.digest === artifact.aggregates.publicInventoryDigest,
+    "Database rollback inventory differs from the reviewed artifact",
+  );
+  return evidence;
+}
+
+async function verify(
+  sql: Sql,
+  artifact: InventoryArtifact,
+  outputPath: string | undefined,
+): Promise<void> {
+  const { target } = loadMigrations();
+  const evidence = await sql.begin(async (tx) => {
+    await tx`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`;
+    await tx`SET LOCAL statement_timeout = '60s'`;
+    await assertCompatibilitySchema(tx);
+    const [ledger] = await tx<{ exact: number }[]>`
+      SELECT count(*)::integer AS exact
+      FROM drizzle.__drizzle_migrations
+      WHERE created_at = ${target.folderMillis}
+        AND hash = ${target.hash}
+    `;
+    invariant(ledger?.exact === 1, "The exact 0089 ledger row is not recorded once");
+    const state = await readState(tx);
+    const rollback = await assertRollbackArtifact(tx, artifact);
+    const current = await readAggregateEvidence(tx);
+    const currentWithoutVisibility = {
+      watchlistCount: current.watchlistCount,
+      membershipCount: current.membershipCount,
+      watchlistContentDigest: current.watchlistContentDigest,
+      filtersDigest: current.filtersDigest,
+      alertsDigest: current.alertsDigest,
+      provenanceDigest: current.provenanceDigest,
+      ownersDigest: current.ownersDigest,
+      membershipDigest: current.membershipDigest,
+    };
+    const stateWithoutVisibility = {
+      watchlistCount: state.watchlistCount,
+      membershipCount: state.membershipCount,
+      watchlistContentDigest: state.watchlistContentDigest,
+      filtersDigest: state.filtersDigest,
+      alertsDigest: state.alertsDigest,
+      provenanceDigest: state.provenanceDigest,
+      ownersDigest: state.ownersDigest,
+      membershipDigest: state.membershipDigest,
+    };
+    invariant(
+      JSON.stringify(currentWithoutVisibility) === JSON.stringify(stateWithoutVisibility),
+      "Postflight watchlist content differs from the transactional snapshot",
+    );
+    invariant(
+      state.status === "private" && current.publicCount === 0,
+      "Postflight visibility is not uniformly private",
+    );
+    invariant(
+      state.publicCount === artifact.aggregates.publicCount &&
+        state.publicInventoryDigest === artifact.aggregates.publicInventoryDigest,
+      "Postflight state differs from the reviewed preflight inventory",
+    );
+    invariant(
+      rollback.changedRows === 0 &&
+        rollback.changedMemberships === 0 &&
+        rollback.ownerFailures === 0,
+      `Postflight rollback rows, memberships, or owner access changed: ${JSON.stringify(rollback)}`,
+    );
+    return {
+      checkedAt: new Date().toISOString(),
+      migration: targetTag,
+      status: state.status,
+      migratedPublicCount: state.publicCount,
+      remainingPublicCount: current.publicCount,
+      retainedWatchlistCount: current.watchlistCount,
+      retainedMembershipCount: current.membershipCount,
+      retainedAlertsEnabledCount: current.alertsEnabledCount,
+      retainedCopiedWatchlistCount: current.copiedWatchlistCount,
+      publicInventoryDigest: state.publicInventoryDigest,
+      rollbackArtifactRows: artifact.publicWatchlists.length,
+      rollback,
+      retainedCompatibility: {
+        isPublicColumn: true,
+        publicPartialIndex: true,
+      },
+    };
+  });
+  if (outputPath) writePrivateJson(outputPath, evidence, false);
+  process.stdout.write(`${JSON.stringify(evidence)}\n`);
+}
+
+async function rollback(sql: Sql, artifact: InventoryArtifact): Promise<void> {
+  invariant(
+    process.env.WATCHLIST_PRIVACY_ROLLBACK_CONFIRMATION ===
+      "ROLLBACK-PRIVATE-WATCHLISTS-0089",
+    "Rollback confirmation is invalid",
+  );
+  invariant(
+    process.env.WATCHLIST_PRIVACY_ROLLBACK_OWNER?.trim(),
+    "WATCHLIST_PRIVACY_ROLLBACK_OWNER must identify the responsible operator",
+  );
+  const { target } = loadMigrations();
+
+  const outcome = await sql.begin(async (tx) => {
+    await tx`SET LOCAL lock_timeout = '10s'`;
+    await tx`SET LOCAL statement_timeout = '10min'`;
+    await tx`SET LOCAL idle_in_transaction_session_timeout = '2min'`;
+    await tx`
+      SELECT pg_advisory_xact_lock(
+        hashtextextended('jobseek:web-schema-migrations', 0)
+      )
+    `;
+    await tx`LOCK TABLE public.watchlist IN SHARE ROW EXCLUSIVE MODE`;
+    await tx`LOCK TABLE public.watchlist_company IN SHARE ROW EXCLUSIVE MODE`;
+    await tx`LOCK TABLE public."user" IN SHARE MODE`;
+    await assertCompatibilitySchema(tx);
+
+    const [ledger] = await tx<{ exact: number }[]>`
+      SELECT count(*)::integer AS exact
+      FROM drizzle.__drizzle_migrations
+      WHERE created_at = ${target.folderMillis}
+        AND hash = ${target.hash}
+    `;
+    invariant(ledger?.exact === 1, "Cannot rollback without the exact 0089 ledger row");
+    const state = await readState(tx);
+    invariant(state.status === "private", `Cannot rollback from status ${state.status}`);
+    const before = await assertRollbackArtifact(tx, artifact);
+    invariant(
+      before.changedRows === 0 &&
+        before.changedMemberships === 0 &&
+        before.ownerFailures === 0,
+      `Rollback abort: protected rows changed after migration: ${JSON.stringify(before)}`,
+    );
+    const [visibility] = await tx<{ publicCount: number; inventoryPublicCount: number }[]>`
+      SELECT
+        count(*) FILTER (WHERE w.is_public)::integer AS "publicCount",
+        count(*) FILTER (
+          WHERE w.is_public AND rollback.watchlist_id IS NOT NULL
+        )::integer AS "inventoryPublicCount"
+      FROM public.watchlist AS w
+      LEFT JOIN public.watchlist_visibility_0089_rollback AS rollback
+        ON rollback.watchlist_id = w.id
+    `;
+    invariant(
+      visibility?.publicCount === 0 && visibility.inventoryPublicCount === 0,
+      "Rollback abort: database is no longer in the uniformly private state",
+    );
+
+    const restored = await tx<{ watchlistId: string }[]>`
+      UPDATE public.watchlist AS w
+      SET is_public = true
+      FROM public.watchlist_visibility_0089_rollback AS rollback
+      WHERE w.id = rollback.watchlist_id
+        AND NOT w.is_public
+      RETURNING w.id AS "watchlistId"
+    `;
+    invariant(
+      restored.length === artifact.aggregates.publicCount,
+      `Rollback restored ${restored.length} rows; expected ${artifact.aggregates.publicCount}`,
+    );
+    const [post] = await tx<{ expectedPublic: number; unexpectedPublic: number }[]>`
+      SELECT
+        count(*) FILTER (WHERE w.is_public AND rollback.watchlist_id IS NOT NULL)::integer
+          AS "expectedPublic",
+        count(*) FILTER (WHERE w.is_public AND rollback.watchlist_id IS NULL)::integer
+          AS "unexpectedPublic"
+      FROM public.watchlist AS w
+      LEFT JOIN public.watchlist_visibility_0089_rollback AS rollback
+        ON rollback.watchlist_id = w.id
+    `;
+    invariant(
+      post?.expectedPublic === artifact.aggregates.publicCount &&
+        post.unexpectedPublic === 0,
+      `Rollback visibility postcondition failed: ${JSON.stringify(post)}`,
+    );
+    await tx`
+      UPDATE public.watchlist_visibility_0089_state
+      SET status = 'rolled_back'
+      WHERE migration_key = ${migrationKey}
+        AND status = 'private'
+    `;
+    return "rolled-back" as const;
+  });
+
+  process.stdout.write(
+    `${JSON.stringify({
+      command: "rollback",
+      migration: targetTag,
+      outcome,
+      restoredPublicCount: artifact.aggregates.publicCount,
+      artifactRetained: true,
+    })}\n`,
+  );
+}
+
+async function main(): Promise<void> {
+  const args = process.argv.slice(2).filter((argument) => argument !== "--");
+  const command = args[0];
+  invariant(
+    isCommand(command),
+    "Usage: tsx scripts/watchlist-visibility-migration.ts <inventory|apply|verify|rollback> <inventory.json> [evidence.json]",
+  );
+  const inventoryPath = args[1];
+  invariant(inventoryPath, `${command} requires an inventory path`);
+  const databaseUrl = requireDirectDatabaseUrl(command);
+  const sql = postgres(databaseUrl, {
+    max: 1,
+    prepare: false,
+    connect_timeout: 15,
+    connection: { application_name: `jobseek-watchlist-visibility-${command}` },
+  });
+
+  try {
+    if (command === "inventory") {
+      await inventory(sql, inventoryPath);
+      return;
+    }
+    const artifact = readArtifact(inventoryPath);
+    if (command === "apply") {
+      await applyMigration(sql, artifact);
+    } else if (command === "verify") {
+      await verify(sql, artifact, args[2]);
+    } else {
+      await rollback(sql, artifact);
+    }
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+void main().catch((error: unknown) => {
+  logExternalError(
+    "error",
+    { service: "database", operation: "watchlist_visibility_migration" },
+    error,
+  );
+  process.exitCode = 1;
+});

--- a/apps/web/scripts/watchlist-visibility-migration.ts
+++ b/apps/web/scripts/watchlist-visibility-migration.ts
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 
 import dotenv from "dotenv";
 import { readMigrationFiles, type MigrationMeta } from "drizzle-orm/migrator";
-import postgres, { type Sql } from "postgres";
+import postgres, { type Sql, type TransactionSql } from "postgres";
 
 import { logExternalError } from "../src/lib/safe-external-error";
 import {
@@ -191,7 +191,9 @@ function writePrivateJson(path: string, value: unknown, exclusive: boolean): voi
   });
 }
 
-async function readAggregateEvidence(sql: Sql): Promise<AggregateEvidence> {
+async function readAggregateEvidence(
+  sql: TransactionSql,
+): Promise<AggregateEvidence> {
   const [watchlists] = await sql<
     Omit<AggregateEvidence, "membershipCount" | "membershipDigest" | "publicInventoryDigest">[]
   >`
@@ -261,7 +263,7 @@ async function readAggregateEvidence(sql: Sql): Promise<AggregateEvidence> {
   return { ...watchlists, ...memberships, ...publicInventory };
 }
 
-async function readPublicRows(sql: Sql): Promise<InventoryRow[]> {
+async function readPublicRows(sql: TransactionSql): Promise<InventoryRow[]> {
   return sql<InventoryRow[]>`
     SELECT
       w.id AS "watchlistId",
@@ -312,7 +314,7 @@ async function readPublicRows(sql: Sql): Promise<InventoryRow[]> {
   `;
 }
 
-async function assertCompatibilitySchema(sql: Sql): Promise<void> {
+async function assertCompatibilitySchema(sql: TransactionSql): Promise<void> {
   const [column] = await sql<
     { count: number; defaultValue: string | null }[]
   >`
@@ -354,7 +356,7 @@ async function assertCompatibilitySchema(sql: Sql): Promise<void> {
 }
 
 async function assertLedgerPreflight(
-  sql: Sql,
+  sql: TransactionSql,
   prerequisite: MigrationMeta,
   target: MigrationMeta,
 ): Promise<void> {
@@ -580,7 +582,7 @@ async function applyMigration(sql: Sql, artifact: InventoryArtifact): Promise<vo
   process.stdout.write(`${JSON.stringify({ command: "apply", migration: targetTag, outcome })}\n`);
 }
 
-async function readState(sql: Sql) {
+async function readState(sql: TransactionSql) {
   const [state] = await sql<
     ({ status: "private" | "rolled_back" } & Omit<
       AggregateEvidence,
@@ -607,7 +609,7 @@ async function readState(sql: Sql) {
 }
 
 async function assertRollbackArtifact(
-  sql: Sql,
+  sql: TransactionSql,
   artifact: InventoryArtifact,
 ): Promise<{ changedRows: number; changedMemberships: number; ownerFailures: number }> {
   const [evidence] = await sql<

--- a/apps/web/scripts/watchlist-visibility-migration.ts
+++ b/apps/web/scripts/watchlist-visibility-migration.ts
@@ -6,18 +6,15 @@ import { readMigrationFiles, type MigrationMeta } from "drizzle-orm/migrator";
 import postgres, { type Sql } from "postgres";
 
 import { logExternalError } from "../src/lib/safe-external-error";
+import {
+  assertWatchlistPathVariantMatrix,
+  requiredWatchlistApplyEvidence,
+  type WatchlistPathVariant,
+} from "./watchlist-visibility-contract";
 
 dotenv.config({ path: ".env.local", quiet: true });
 
 type Command = "inventory" | "apply" | "verify" | "rollback";
-
-type PathVariant = {
-  locale: "en" | "de" | "fr" | "it";
-  ownerSlugKind: "username" | "display_username";
-  ownerSlug: string;
-  pagePath: string;
-  ogPath: string;
-};
 
 type InventoryRow = {
   watchlistId: string;
@@ -28,7 +25,7 @@ type InventoryRow = {
   watchlistSlug: string;
   watchlistPayload: Record<string, unknown>;
   companyMemberships: Array<Record<string, unknown>>;
-  pathVariants: PathVariant[];
+  pathVariants: WatchlistPathVariant[];
 };
 
 type AggregateEvidence = {
@@ -172,6 +169,17 @@ function readArtifact(path: string): InventoryArtifact {
     /^[0-9a-f]{32}$/.test(artifact.aggregates.publicInventoryDigest),
     "Inventory digest is invalid",
   );
+  for (const row of artifact.publicWatchlists) {
+    assertWatchlistPathVariantMatrix(
+      {
+        watchlistId: row.watchlistId,
+        ownerUsername: row.ownerUsername,
+        ownerDisplayUsername: row.ownerDisplayUsername,
+        watchlistSlug: row.watchlistSlug,
+      },
+      row.pathVariants,
+    );
+  }
   return artifact as InventoryArtifact;
 }
 
@@ -279,7 +287,9 @@ async function readPublicRows(sql: Sql): Promise<InventoryRow[]> {
               'ownerSlugKind', owner_slug.kind,
               'ownerSlug', owner_slug.value,
               'pagePath', format('/%s/%s/%s', locale.value, owner_slug.value, w.slug),
-              'ogPath', format('/og/watchlist/%s/%s/%s', locale.value, owner_slug.value, w.slug)
+              'ogPath', format('/og/watchlist/%s/%s/%s', locale.value, owner_slug.value, w.slug),
+              'legacyOgPathPattern', format('/%s/%s/%s/opengraph-image-:hash', locale.value, owner_slug.value, w.slug),
+              'legacyOgPurgePattern', format('/%s/%s/%s/opengraph-image-*', locale.value, owner_slug.value, w.slug)
             )
             ORDER BY owner_slug.kind, locale.value
           )
@@ -423,14 +433,14 @@ async function inventory(sql: Sql, outputPath: string): Promise<void> {
       "Public inventory lost an owner or row",
     );
     for (const row of publicWatchlists) {
-      const ownerSlugs = new Set(
-        [row.ownerUsername, row.ownerDisplayUsername].filter(
-          (value): value is string => value !== null,
-        ),
-      );
-      invariant(
-        row.pathVariants.length === ownerSlugs.size * 4,
-        `Localized path inventory is incomplete for watchlist ${row.watchlistId}`,
+      assertWatchlistPathVariantMatrix(
+        {
+          watchlistId: row.watchlistId,
+          ownerUsername: row.ownerUsername,
+          ownerDisplayUsername: row.ownerDisplayUsername,
+          watchlistSlug: row.watchlistSlug,
+        },
+        row.pathVariants,
       );
     }
 
@@ -469,45 +479,6 @@ async function inventory(sql: Sql, outputPath: string): Promise<void> {
   );
 }
 
-function requiredApplyEvidence(artifact: InventoryArtifact) {
-  const confirmation = process.env.WATCHLIST_PRIVACY_CONFIRMATION;
-  const rawBackupRunId = process.env.WATCHLIST_PRIVACY_BACKUP_RESTORE_RUN_ID;
-  const privateMutationsDeploySha =
-    process.env.WATCHLIST_PRIVATE_MUTATIONS_DEPLOY_SHA;
-  const routeCutoverDeploySha = process.env.WATCHLIST_ROUTE_CUTOVER_DEPLOY_SHA;
-  const routeCutoverApprovedBy =
-    process.env.WATCHLIST_ROUTE_CUTOVER_APPROVED_BY;
-  const backupRestoreRunId = Number(rawBackupRunId);
-
-  invariant(confirmation === "PRIVATE-WATCHLISTS-0089", "Apply confirmation is invalid");
-  invariant(
-    rawBackupRunId && /^\d+$/.test(rawBackupRunId) && Number.isSafeInteger(backupRestoreRunId) && backupRestoreRunId > 0,
-    "WATCHLIST_PRIVACY_BACKUP_RESTORE_RUN_ID must be a positive run ID",
-  );
-  invariant(
-    privateMutationsDeploySha && /^[0-9a-f]{40}$/.test(privateMutationsDeploySha),
-    "WATCHLIST_PRIVATE_MUTATIONS_DEPLOY_SHA must be a deployed 40-hex SHA",
-  );
-  invariant(
-    routeCutoverDeploySha && /^[0-9a-f]{40}$/.test(routeCutoverDeploySha),
-    "WATCHLIST_ROUTE_CUTOVER_DEPLOY_SHA must be a deployed 40-hex SHA",
-  );
-  invariant(
-    routeCutoverApprovedBy?.trim(),
-    "WATCHLIST_ROUTE_CUTOVER_APPROVED_BY must record the human approver",
-  );
-
-  return {
-    confirmation,
-    backupRestoreRunId,
-    privateMutationsDeploySha,
-    routeCutoverDeploySha,
-    routeCutoverApprovedBy,
-    expectedPublicCount: artifact.aggregates.publicCount,
-    expectedPublicDigest: artifact.aggregates.publicInventoryDigest,
-  };
-}
-
 async function applyMigration(sql: Sql, artifact: InventoryArtifact): Promise<void> {
   const { prerequisite, target } = loadMigrations();
   invariant(
@@ -515,7 +486,10 @@ async function applyMigration(sql: Sql, artifact: InventoryArtifact): Promise<vo
       artifact.target.hash === target.hash,
     "Inventory was not captured for the checked-out migration hashes",
   );
-  const evidence = requiredApplyEvidence(artifact);
+  const evidence = requiredWatchlistApplyEvidence(process.env, {
+    publicCount: artifact.aggregates.publicCount,
+    publicInventoryDigest: artifact.aggregates.publicInventoryDigest,
+  });
 
   const outcome = await sql.begin(async (tx) => {
     await tx`SET LOCAL lock_timeout = '10s'`;
@@ -560,6 +534,8 @@ async function applyMigration(sql: Sql, artifact: InventoryArtifact): Promise<vo
         private_mutations_deploy_sha text NOT NULL,
         route_cutover_deploy_sha text NOT NULL,
         route_cutover_approved_by text NOT NULL,
+        public_api_cutover_deploy_sha text NOT NULL,
+        public_api_cutover_verification_run_id bigint NOT NULL,
         expected_public_count bigint NOT NULL,
         expected_public_digest text NOT NULL,
         attested_at timestamp with time zone NOT NULL
@@ -572,6 +548,8 @@ async function applyMigration(sql: Sql, artifact: InventoryArtifact): Promise<vo
         private_mutations_deploy_sha,
         route_cutover_deploy_sha,
         route_cutover_approved_by,
+        public_api_cutover_deploy_sha,
+        public_api_cutover_verification_run_id,
         expected_public_count,
         expected_public_digest,
         attested_at
@@ -581,6 +559,8 @@ async function applyMigration(sql: Sql, artifact: InventoryArtifact): Promise<vo
         ${evidence.privateMutationsDeploySha},
         ${evidence.routeCutoverDeploySha},
         ${evidence.routeCutoverApprovedBy},
+        ${evidence.publicApiCutoverDeploySha},
+        ${evidence.publicApiCutoverVerificationRunId},
         ${evidence.expectedPublicCount},
         ${evidence.expectedPublicDigest},
         clock_timestamp()

--- a/apps/web/src/db/__tests__/notification-policy-migration.test.ts
+++ b/apps/web/src/db/__tests__/notification-policy-migration.test.ts
@@ -136,15 +136,19 @@ describe("0088 notification policy foundation migration", () => {
       readFileSync(resolve(webRoot, "drizzle/meta/_journal.json"), "utf8"),
     ) as { entries: { idx: number; when: number; tag: string }[] };
 
-    expect(journal.entries.at(-1)).toEqual({
+    const notificationIndex = journal.entries.findIndex(
+      (entry) => entry.tag === "0088_notification_policy_foundation",
+    );
+
+    expect(journal.entries[notificationIndex]).toEqual({
       idx: 76,
       version: "7",
       when: 1_788_199_156_000,
       tag: "0088_notification_policy_foundation",
       breakpoints: true,
     });
-    expect(journal.entries.at(-2)?.when).toBeLessThan(
-      journal.entries.at(-1)?.when ?? 0,
+    expect(journal.entries[notificationIndex - 1]?.when).toBeLessThan(
+      journal.entries[notificationIndex]?.when ?? 0,
     );
   });
 });

--- a/apps/web/src/db/__tests__/watchlist-privacy-interview-migration.test.ts
+++ b/apps/web/src/db/__tests__/watchlist-privacy-interview-migration.test.ts
@@ -36,6 +36,10 @@ const privacyRunner = readFileSync(
   ),
   "utf8",
 );
+const nextConfig = readFileSync(
+  join(__dirname, "..", "..", "..", "next.config.ts"),
+  "utf8",
+);
 
 describe("0083 Supabase baseline reconciliation", () => {
   it("aligns the database interview CHECK with the general UI option", () => {
@@ -82,6 +86,10 @@ describe("0089 legacy watchlist visibility migration", () => {
     expect(privacyMigrationSql).toContain("private_mutations_deploy_sha");
     expect(privacyMigrationSql).toContain("route_cutover_deploy_sha");
     expect(privacyMigrationSql).toContain("route_cutover_approved_by");
+    expect(privacyMigrationSql).toContain("public_api_cutover_deploy_sha");
+    expect(privacyMigrationSql).toContain(
+      "public_api_cutover_verification_run_id",
+    );
     expect(privacyMigrationSql).toMatch(
       /UPDATE public\.watchlist\s+SET is_public = false\s+WHERE is_public = true/,
     );
@@ -103,6 +111,12 @@ describe("0089 legacy watchlist visibility migration", () => {
     }
     expect(privacyMigrationSql).toContain("'pagePath'");
     expect(privacyMigrationSql).toContain("'ogPath'");
+    expect(privacyMigrationSql).toContain("'legacyOgPathPattern'");
+    expect(privacyMigrationSql).toContain("'legacyOgPurgePattern'");
+    expect(privacyMigrationSql).toContain("opengraph-image-:hash");
+    expect(nextConfig).toContain(
+      'source: "/:lang(en|de|fr|it)/:userSlug/:watchlistSlug/opengraph-image-:hash"',
+    );
   });
 
   it("asserts rows, filters, alerts, provenance, owners, and memberships", () => {
@@ -135,10 +149,7 @@ describe("0089 legacy watchlist visibility migration", () => {
     );
     expect(privacyRunner).toContain("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY");
     expect(privacyRunner).toContain("MIGRATION_REQUIRE_UNPOOLED");
-    expect(privacyRunner).toContain("WATCHLIST_PRIVATE_MUTATIONS_DEPLOY_SHA");
-    expect(privacyRunner).toContain("WATCHLIST_ROUTE_CUTOVER_DEPLOY_SHA");
-    expect(privacyRunner).toContain("WATCHLIST_ROUTE_CUTOVER_APPROVED_BY");
-    expect(privacyRunner).toContain("WATCHLIST_PRIVACY_BACKUP_RESTORE_RUN_ID");
+    expect(privacyRunner).toContain("requiredWatchlistApplyEvidence(process.env");
     expect(privacyRunner).toContain("ROLLBACK-PRIVATE-WATCHLISTS-0089");
     expect(privacyRunner).toContain('mode: 0o600');
     expect(privacyRunner).not.toContain("notifyIndexNow");

--- a/apps/web/src/db/__tests__/watchlist-privacy-interview-migration.test.ts
+++ b/apps/web/src/db/__tests__/watchlist-privacy-interview-migration.test.ts
@@ -16,6 +16,27 @@ const migrationPath = join(
 );
 const migrationSql = readFileSync(migrationPath, "utf8");
 
+const privacyMigrationPath = join(
+  __dirname,
+  "..",
+  "..",
+  "..",
+  "drizzle",
+  "0089_make_existing_watchlists_private.sql",
+);
+const privacyMigrationSql = readFileSync(privacyMigrationPath, "utf8");
+const privacyRunner = readFileSync(
+  join(
+    __dirname,
+    "..",
+    "..",
+    "..",
+    "scripts",
+    "watchlist-visibility-migration.ts",
+  ),
+  "utf8",
+);
+
 describe("0083 Supabase baseline reconciliation", () => {
   it("aligns the database interview CHECK with the general UI option", () => {
     expect(migrationSql).toMatch(
@@ -49,5 +70,105 @@ describe("0083 Supabase baseline reconciliation", () => {
     expect(journal.entries.map((entry) => entry.tag)).not.toContain(
       "0080_experience_decimal_years",
     );
+  });
+});
+
+describe("0089 legacy watchlist visibility migration", () => {
+  it("requires reviewed rollout evidence and changes only public visibility", () => {
+    expect(privacyMigrationSql).toContain(
+      "pg_temp.jobseek_watchlist_privacy_attestation",
+    );
+    expect(privacyMigrationSql).toContain("PRIVATE-WATCHLISTS-0089");
+    expect(privacyMigrationSql).toContain("private_mutations_deploy_sha");
+    expect(privacyMigrationSql).toContain("route_cutover_deploy_sha");
+    expect(privacyMigrationSql).toContain("route_cutover_approved_by");
+    expect(privacyMigrationSql).toMatch(
+      /UPDATE public\.watchlist\s+SET is_public = false\s+WHERE is_public = true/,
+    );
+    expect(privacyMigrationSql.match(/UPDATE public\.watchlist/g)).toHaveLength(1);
+    expect(privacyMigrationSql).not.toMatch(/DELETE\s+FROM\s+public\.watchlist/i);
+  });
+
+  it("retains exact rollback content and old localized path variants", () => {
+    expect(privacyMigrationSql).toContain(
+      "CREATE TABLE public.watchlist_visibility_0089_rollback",
+    );
+    expect(privacyMigrationSql).toContain("watchlist_payload jsonb NOT NULL");
+    expect(privacyMigrationSql).toContain("company_memberships jsonb NOT NULL");
+    expect(privacyMigrationSql).toContain("owner_username text");
+    expect(privacyMigrationSql).toContain("owner_display_username text");
+    expect(privacyMigrationSql).toContain("path_variants jsonb NOT NULL");
+    for (const locale of ["en", "de", "fr", "it"]) {
+      expect(privacyMigrationSql).toContain(`('${locale}'::text)`);
+    }
+    expect(privacyMigrationSql).toContain("'pagePath'");
+    expect(privacyMigrationSql).toContain("'ogPath'");
+  });
+
+  it("asserts rows, filters, alerts, provenance, owners, and memberships", () => {
+    for (const invariant of [
+      "watchlist_content_digest",
+      "filters_digest",
+      "alerts_digest",
+      "provenance_digest",
+      "owners_digest",
+      "membership_digest",
+      "jobseek_0089_watchlist_before",
+      "jobseek_0089_membership_before",
+      "orphaned_owner_count",
+    ]) {
+      expect(privacyMigrationSql).toContain(invariant);
+    }
+    expect(privacyMigrationSql).toContain("source_watchlist_id");
+    expect(privacyMigrationSql).toContain("watchlist_company content");
+  });
+
+  it("retains the compatibility column and partial index", () => {
+    expect(privacyMigrationSql).toContain("idx_wl_public");
+    expect(privacyMigrationSql).not.toMatch(/DROP\s+(?:INDEX|COLUMN)/i);
+    expect(getTableColumns(watchlist).isPublic).toBeDefined();
+  });
+
+  it("provides guarded inventory, verification, and rollback operations", () => {
+    expect(privacyRunner).toContain(
+      'type Command = "inventory" | "apply" | "verify" | "rollback"',
+    );
+    expect(privacyRunner).toContain("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY");
+    expect(privacyRunner).toContain("MIGRATION_REQUIRE_UNPOOLED");
+    expect(privacyRunner).toContain("WATCHLIST_PRIVATE_MUTATIONS_DEPLOY_SHA");
+    expect(privacyRunner).toContain("WATCHLIST_ROUTE_CUTOVER_DEPLOY_SHA");
+    expect(privacyRunner).toContain("WATCHLIST_ROUTE_CUTOVER_APPROVED_BY");
+    expect(privacyRunner).toContain("WATCHLIST_PRIVACY_BACKUP_RESTORE_RUN_ID");
+    expect(privacyRunner).toContain("ROLLBACK-PRIVATE-WATCHLISTS-0089");
+    expect(privacyRunner).toContain('mode: 0o600');
+    expect(privacyRunner).not.toContain("notifyIndexNow");
+  });
+
+  it("appends one monotonic journal entry", () => {
+    const journalPath = join(
+      __dirname,
+      "..",
+      "..",
+      "..",
+      "drizzle",
+      "meta",
+      "_journal.json",
+    );
+    const journal = JSON.parse(readFileSync(journalPath, "utf8")) as {
+      entries: Array<{
+        idx: number;
+        version: string;
+        when: number;
+        tag: string;
+        breakpoints: boolean;
+      }>;
+    };
+    expect(journal.entries.at(-1)).toEqual({
+      idx: 77,
+      version: "7",
+      when: 1_788_206_680_000,
+      tag: "0089_make_existing_watchlists_private",
+      breakpoints: true,
+    });
   });
 });

--- a/apps/web/src/db/__tests__/watchlist-visibility-contract.test.ts
+++ b/apps/web/src/db/__tests__/watchlist-visibility-contract.test.ts
@@ -83,7 +83,9 @@ describe("watchlist visibility apply evidence", () => {
       publicCount: 7,
       publicInventoryDigest: "a".repeat(32),
     });
+    const approvedBy: string = evidence.routeCutoverApprovedBy;
 
+    expect(approvedBy).toBe("privacy-reviewer");
     expect(evidence.publicApiCutoverDeploySha).toBe("3".repeat(40));
     expect(evidence.publicApiCutoverVerificationRunId).toBe(202);
     expect(evidence.expectedPublicCount).toBe(7);
@@ -108,5 +110,27 @@ describe("watchlist visibility apply evidence", () => {
         publicInventoryDigest: "a".repeat(32),
       }),
     ).toThrow(message);
+  });
+
+  it("returns a definite trimmed approval string and rejects blank input", () => {
+    const evidence = requiredWatchlistApplyEvidence(
+      {
+        ...validApplyEnvironment,
+        WATCHLIST_ROUTE_CUTOVER_APPROVED_BY: "  privacy-reviewer  ",
+      },
+      { publicCount: 7, publicInventoryDigest: "a".repeat(32) },
+    );
+    const approvedBy: string = evidence.routeCutoverApprovedBy;
+    expect(approvedBy).toBe("privacy-reviewer");
+
+    expect(() =>
+      requiredWatchlistApplyEvidence(
+        {
+          ...validApplyEnvironment,
+          WATCHLIST_ROUTE_CUTOVER_APPROVED_BY: "   ",
+        },
+        { publicCount: 7, publicInventoryDigest: "a".repeat(32) },
+      ),
+    ).toThrow(/must be a non-empty string/);
   });
 });

--- a/apps/web/src/db/__tests__/watchlist-visibility-contract.test.ts
+++ b/apps/web/src/db/__tests__/watchlist-visibility-contract.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertWatchlistPathVariantMatrix,
+  expectedWatchlistPathVariants,
+  requiredWatchlistApplyEvidence,
+} from "../../../scripts/watchlist-visibility-contract";
+
+const validApplyEnvironment = {
+  WATCHLIST_PRIVACY_CONFIRMATION: "PRIVATE-WATCHLISTS-0089",
+  WATCHLIST_PRIVACY_BACKUP_RESTORE_RUN_ID: "101",
+  WATCHLIST_PRIVATE_MUTATIONS_DEPLOY_SHA: "1".repeat(40),
+  WATCHLIST_ROUTE_CUTOVER_DEPLOY_SHA: "2".repeat(40),
+  WATCHLIST_ROUTE_CUTOVER_APPROVED_BY: "privacy-reviewer",
+  WATCHLIST_PUBLIC_API_CUTOVER_DEPLOY_SHA: "3".repeat(40),
+  WATCHLIST_PUBLIC_API_CUTOVER_VERIFICATION_RUN_ID: "202",
+} as const;
+
+describe("watchlist visibility path inventory", () => {
+  it("retains both labels and four distinct URL forms when usernames match", () => {
+    const params = {
+      watchlistId: "watchlist-equal",
+      ownerUsername: "alice",
+      ownerDisplayUsername: "alice",
+      watchlistSlug: "engineering",
+    };
+    const variants = expectedWatchlistPathVariants(params);
+
+    expect(variants).toHaveLength(8);
+    expect(new Set(variants.map((variant) => variant.pagePath)).size).toBe(4);
+    expect(new Set(variants.map((variant) => variant.ogPath)).size).toBe(4);
+    expect(
+      new Set(variants.map((variant) => variant.legacyOgPathPattern)),
+    ).toHaveProperty("size", 4);
+    expect(
+      new Set(variants.map((variant) => variant.legacyOgPurgePattern)),
+    ).toHaveProperty("size", 4);
+    expect(new Set(variants.map((variant) => variant.ownerSlugKind))).toEqual(
+      new Set(["username", "display_username"]),
+    );
+    expect(() => assertWatchlistPathVariantMatrix(params, variants)).not.toThrow();
+  });
+
+  it("retains eight distinct URL forms when username values differ", () => {
+    const params = {
+      watchlistId: "watchlist-different",
+      ownerUsername: "alice-canonical",
+      ownerDisplayUsername: "alice-display",
+      watchlistSlug: "engineering",
+    };
+    const variants = expectedWatchlistPathVariants(params);
+
+    expect(variants).toHaveLength(8);
+    for (const field of [
+      "pagePath",
+      "ogPath",
+      "legacyOgPathPattern",
+      "legacyOgPurgePattern",
+    ] as const) {
+      expect(new Set(variants.map((variant) => variant[field])).size).toBe(8);
+    }
+    expect(() => assertWatchlistPathVariantMatrix(params, variants)).not.toThrow();
+  });
+
+  it("rejects a missing labelled URL variant", () => {
+    const params = {
+      watchlistId: "watchlist-incomplete",
+      ownerUsername: "alice",
+      ownerDisplayUsername: "alice",
+      watchlistSlug: "engineering",
+    };
+    const variants = expectedWatchlistPathVariants(params);
+
+    expect(() =>
+      assertWatchlistPathVariantMatrix(params, variants.slice(1)),
+    ).toThrow(/incomplete or duplicated/);
+  });
+});
+
+describe("watchlist visibility apply evidence", () => {
+  it("binds immutable #8367 deployment and verification evidence", () => {
+    const evidence = requiredWatchlistApplyEvidence(validApplyEnvironment, {
+      publicCount: 7,
+      publicInventoryDigest: "a".repeat(32),
+    });
+
+    expect(evidence.publicApiCutoverDeploySha).toBe("3".repeat(40));
+    expect(evidence.publicApiCutoverVerificationRunId).toBe(202);
+    expect(evidence.expectedPublicCount).toBe(7);
+    expect(evidence.expectedPublicDigest).toBe("a".repeat(32));
+  });
+
+  it.each([
+    ["WATCHLIST_PUBLIC_API_CUTOVER_DEPLOY_SHA", /deployed 40-hex SHA/],
+    [
+      "WATCHLIST_PUBLIC_API_CUTOVER_VERIFICATION_RUN_ID",
+      /positive immutable run ID/,
+    ],
+  ] as const)("fails closed without %s", (name, message) => {
+    const environment: Record<string, string | undefined> = {
+      ...validApplyEnvironment,
+      [name]: undefined,
+    };
+
+    expect(() =>
+      requiredWatchlistApplyEvidence(environment, {
+        publicCount: 7,
+        publicInventoryDigest: "a".repeat(32),
+      }),
+    ).toThrow(message);
+  });
+});

--- a/docs/24-watchlist-visibility-migration.md
+++ b/docs/24-watchlist-visibility-migration.md
@@ -1,0 +1,123 @@
+# Watchlist visibility migration
+
+This runbook covers the reversible data migration in #8369. It inventories
+legacy public watchlists, makes those rows private in one transaction, and
+retains exact rollback and URL-path evidence for #8370. It does not purge
+caches, SEO/IndexNow state, Typesense documents, routes, rows, or columns.
+
+## Hard deployment gate
+
+Do not merge or deploy this migration before both conditions are evidenced:
+
+1. #8376 is merged, deployed, and verified so creates/copies are private and
+   copy authorization no longer depends on `is_public`.
+2. #8368 has passed the human UI review, its owner-only route cutover is
+   deployed, and anonymous/cross-owner probes return the same not-found result.
+
+#8367's anonymous REST/MCP cutover must also be deployed as required by #8369.
+The PR is intentionally draft and no workflow invokes the migration. The
+rendered-UI and cost gates are not applicable to this data-only PR; the human
+approval attached to #8368 remains a prerequisite.
+
+The migration reviewer and rollback owner must be two named people. The
+rollback owner stays available for the observation window and owns the final
+go/no-go call.
+
+## Preflight and inventory
+
+Use a direct, unpooled production connection. Record the successful protected
+PostgreSQL backup/restore-drill run ID and verify its restored copy contains
+both `watchlist` and `watchlist_company` with matching counts/checksums.
+
+Create the sensitive inventory on encrypted operator storage; never attach it
+to a public PR, Actions summary, or ordinary logs:
+
+```bash
+cd apps/web
+umask 077
+DATABASE_URL_UNPOOLED="$DATABASE_URL_UNPOOLED" \
+  pnpm db:migrate:watchlist-visibility -- \
+  inventory /secure/watchlist-0089-inventory.json
+```
+
+The artifact includes every public row ID, owner ID/name, canonical username,
+display username, slug, full watchlist payload (filters, alerts and source
+provenance included), exact company memberships, and page/OG paths for `en`,
+`de`, `fr`, and `it`. Record its public count, digest, filesystem checksum,
+owner, and retention deadline in the private change record.
+
+Go only when the inventory command passes, the backup restore evidence is
+fresh, #8376/#8368/#8367 deployment evidence is immutable, no privacy/API
+probe fails, no database alert is firing, and both reviewers are present.
+Abort on any missing/different ledger row, schema/index drift, owner orphan,
+inventory count/digest mismatch, lock timeout, backup uncertainty, route/API
+exposure, or unavailable rollback owner.
+
+## Apply and verify
+
+Export the reviewed evidence without printing secrets or inventory contents:
+
+```bash
+export MIGRATION_REQUIRE_UNPOOLED=true
+export WATCHLIST_PRIVACY_CONFIRMATION=PRIVATE-WATCHLISTS-0089
+export WATCHLIST_PRIVACY_BACKUP_RESTORE_RUN_ID=<successful-run-id>
+export WATCHLIST_PRIVATE_MUTATIONS_DEPLOY_SHA=<deployed-8376-sha>
+export WATCHLIST_ROUTE_CUTOVER_DEPLOY_SHA=<deployed-8368-sha>
+export WATCHLIST_ROUTE_CUTOVER_APPROVED_BY=<github-login>
+
+pnpm db:migrate:watchlist-visibility -- \
+  apply /secure/watchlist-0089-inventory.json
+pnpm db:migrate:watchlist-visibility -- \
+  verify /secure/watchlist-0089-inventory.json \
+  /secure/watchlist-0089-postflight.json
+```
+
+The targeted runner, not generic `db:migrate`, owns this operation. It takes
+the web migration advisory lock and supplies a session-local attestation. SQL
+then locks `watchlist`, `watchlist_company`, and owner rows; stores the durable
+rollback/path inventory; updates only `is_public=true`; and compares exact
+row, filter, alert, provenance, owner, and membership digests/content before
+commit. Any mismatch rolls back the transaction and its ledger row.
+
+During the observation window, verify:
+
+- migrated owners can list and open every watchlist while signed in;
+- anonymous and different-owner page, REST, and MCP probes are uniformly
+  not-found and never reveal titles, filters, companies, or owner metadata;
+- public-watchlist counts stay zero in Postgres while total watchlists,
+  memberships, alerts-enabled rows, and copied/source-linked rows match the
+  postflight artifact;
+- database errors/latency, Vercel route errors, auth failures, and alert
+  delivery volume show no regression.
+
+Do not run cache, Typesense, sitemap, OG, or IndexNow cleanup here. Hand the
+retained `pathVariants` inventory to #8370 only after the observation window
+is accepted. Keep `is_public`, `idx_wl_public`, and both 0089 artifact tables
+until the rollback window closes; #8371 owns their later removal.
+
+## Rollback
+
+Rollback if any owner loses access, any protected count/digest changes, an
+anonymous/cross-owner read succeeds, alerts regress, or the rollout produces
+sustained database/route errors. Stop the rollout and preserve diagnostics;
+do not purge caches or indexes first.
+
+```bash
+export MIGRATION_REQUIRE_UNPOOLED=true
+export WATCHLIST_PRIVACY_ROLLBACK_CONFIRMATION=ROLLBACK-PRIVATE-WATCHLISTS-0089
+export WATCHLIST_PRIVACY_ROLLBACK_OWNER=<responsible-operator>
+
+pnpm db:migrate:watchlist-visibility -- \
+  rollback /secure/watchlist-0089-inventory.json
+```
+
+Rollback locks the same tables, requires the exact retained inventory and
+unchanged row/membership content, and republishes only IDs that were public in
+the reviewed artifact. It leaves the migration ledger and rollback tables in
+place for audit. If any protected row changed after migration, rollback aborts
+rather than exposing altered content; restore the protected backup to an
+isolated database and open a separately reviewed recovery change.
+
+After rollback, verify the exact restored public count, owner access, legacy
+public paths, and alert behavior. Do not re-run apply from the rolled-back
+state; prepare a new reviewed recovery migration after the incident is closed.

--- a/docs/24-watchlist-visibility-migration.md
+++ b/docs/24-watchlist-visibility-migration.md
@@ -43,8 +43,13 @@ DATABASE_URL_UNPOOLED="$DATABASE_URL_UNPOOLED" \
 The artifact includes every public row ID, owner ID/name, canonical username,
 display username, slug, full watchlist payload (filters, alerts and source
 provenance included), exact company memberships, and page/OG paths for `en`,
-`de`, `fr`, and `it`. Record its public count, digest, filesystem checksum,
-owner, and retention deadline in the private change record.
+`de`, `fr`, and `it`. Both owner-slug labels are retained when `username` and
+`display_username` have the same value. The inventory also carries the legacy
+`/:lang/:userSlug/:watchlistSlug/opengraph-image-:hash` route and its
+`opengraph-image-*` purge pattern because historical hashes cannot be
+reconstructed from Postgres. Record the artifact's public count, digest,
+filesystem checksum, owner, and retention deadline in the private change
+record.
 
 Go only when the inventory command passes, the backup restore evidence is
 fresh, #8376/#8368/#8367 deployment evidence is immutable, no privacy/API
@@ -64,6 +69,8 @@ export WATCHLIST_PRIVACY_BACKUP_RESTORE_RUN_ID=<successful-run-id>
 export WATCHLIST_PRIVATE_MUTATIONS_DEPLOY_SHA=<deployed-8376-sha>
 export WATCHLIST_ROUTE_CUTOVER_DEPLOY_SHA=<deployed-8368-sha>
 export WATCHLIST_ROUTE_CUTOVER_APPROVED_BY=<github-login>
+export WATCHLIST_PUBLIC_API_CUTOVER_DEPLOY_SHA=<deployed-8367-sha>
+export WATCHLIST_PUBLIC_API_CUTOVER_VERIFICATION_RUN_ID=<successful-run-id>
 
 pnpm db:migrate:watchlist-visibility -- \
   apply /secure/watchlist-0089-inventory.json
@@ -72,8 +79,11 @@ pnpm db:migrate:watchlist-visibility -- \
   /secure/watchlist-0089-postflight.json
 ```
 
-The targeted runner, not generic `db:migrate`, owns this operation. It takes
-the web migration advisory lock and supplies a session-local attestation. SQL
+Before applying, verify the immutable `#8367` run ID succeeded for the supplied
+deploy SHA and recorded passing anonymous REST and MCP not-found probes. The
+targeted runner, not generic `db:migrate`, owns this operation. It takes the
+web migration advisory lock and supplies a session-local attestation binding
+both #8367 evidence values. SQL
 then locks `watchlist`, `watchlist_company`, and owner rows; stores the durable
 rollback/path inventory; updates only `is_public=true`; and compares exact
 row, filter, alert, provenance, owner, and membership digests/content before
@@ -92,8 +102,10 @@ During the observation window, verify:
 
 Do not run cache, Typesense, sitemap, OG, or IndexNow cleanup here. Hand the
 retained `pathVariants` inventory to #8370 only after the observation window
-is accepted. Keep `is_public`, `idx_wl_public`, and both 0089 artifact tables
-until the rollback window closes; #8371 owns their later removal.
+is accepted. That handoff must purge both `/og/watchlist/...` and every
+matching localized `opengraph-image-*` legacy URL before removing the redirect.
+Keep `is_public`, `idx_wl_public`, and both 0089 artifact tables until the
+rollback window closes; #8371 owns their later removal.
 
 ## Rollback
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -95,6 +95,9 @@ Status tags:
 - [22 - PostgreSQL Connection Budget](22-postgresql-connections.md) `[runbook]` -
   exact service and deploy-overlap pool ceilings, ownership metrics, reserves,
   idle-transaction controls, and seven-day production acceptance.
+- [24 - Watchlist Visibility Migration](24-watchlist-visibility-migration.md)
+  `[runbook]` - staged inventory, transactional private-row migration,
+  observation, and exact rollback contract for #8369.
 - [Didi Reactivation Runbook](runbook-didi-reactivate-2026-05-10.md)
   `[runbook]` - historical Didi reactivation notes.
 


### PR DESCRIPTION
## Summary

- add a guarded, transactional 0089 data migration that snapshots every watchlist and membership, stores the exact legacy-public rollback inventory, and changes only `is_public=true` rows to private
- preserve row/filter/alert/company/source-provenance/owner content with before/after digests and exact set comparisons; retain `is_public` and `idx_wl_public` for rollback compatibility
- capture canonical username and display-username provenance (including mirrored values), slug, all `en`/`de`/`fr`/`it` page/current-OG paths, and the historical localized `opengraph-image-:hash` route plus purge pattern for #8370
- add a direct-unpooled inventory/apply/verify/rollback tool and a staged operator runbook with backup evidence, abort thresholds, rollback owner, observation checks, and purge handoff

## Stack and rollout blockers

This PR was rebased onto `main` after #8376 merged. It is Ready for Review for checkpoint visibility only; do not merge, deploy, or execute it until:

1. #8376 is deployed and verified;
2. #8368 has passed its human UI approval and its owner-only route cutover is deployed and verified; and
3. #8367's anonymous REST/MCP cutover is deployed and its verification run is recorded.

No workflow invokes 0089 in this PR, and no production command was run. The apply path requires session-local evidence for the #8376 and #8368 deployment SHAs, #8368 human approval, a fresh backup/restore run, and the exact reviewed inventory digest. It also fails closed without an immutable #8367 deployment SHA and positive verification-run ID; SQL validates both attested values before locking or mutation.

There is no rendered UI or cost/provider change in this incremental PR, so it has no independent human-UI or cost gate; the #8368 human gate remains a hard dependency.

## Scope exclusions

No route/UI change, copy-authorization expansion, cache/SEO/OG/IndexNow/Typesense purge (#8370), notification behavior, production execution, schema/column/index removal (#8371), or cost change is included.

## Verification

- `pnpm --filter @jobseek/web typecheck` — passed (`next typegen && tsc`)
- `pnpm --filter @jobseek/web exec vitest run src/db/__tests__/watchlist-privacy-interview-migration.test.ts src/db/__tests__/watchlist-visibility-contract.test.ts src/db/__tests__/notification-policy-migration.test.ts` — 3 files / 23 tests passed
- `pnpm --filter @jobseek/web db:check` — passed
- focused ESLint on the migration tool, contract, and tests — passed
- `git diff --check` — passed
- commit and push hooks — passed

No production database or migration command was run.

Closes #8369
Refs #8348
Refs #8376
Refs #8368
Refs #8367


<!-- remote-checkpoint:2026-09-01 -->
## Remote checkpoint — 2026-09-01

**Ready for Review is a review-visibility state only; it is not merge, deployment, or migration-execution authorization.** This PR remains dependency-blocked.

### Remote and review evidence

- Remote head: `codex/watchlist-visibility-migration` at [`35d4ab0e3cb6d0a41e0cb34981d78f054b6dd2ab`](https://github.com/colophon-group/jobseek/commit/35d4ab0e3cb6d0a41e0cb34981d78f054b6dd2ab).
- The clean local worktree and local branch matched that remote SHA at checkpoint time; no local-only commit or uncommitted PR change was found.
- Exact-head technical approval: [final migration review](https://github.com/colophon-group/jobseek/pull/8381#pullrequestreview-5070770553).
- Current base audit: `main` was `3c20e13c3b97481b9bf5a1d3b894c773c38ad210`; GitHub reported the branch **mergeable with no conflict**, 4 commits ahead and 6 behind ([compare](https://github.com/colophon-group/jobseek/compare/main...codex/watchlist-visibility-migration)). It is behind but mergeable, so this checkpoint did not rewrite/rebase the reviewed head.
- The technical review records passing `git diff --check`, focused Vitest (3 files / 23 tests), targeted ESLint, `pnpm db:check`, and full web typecheck. No production migration command was run.

### Exact dependency and execution blockers

1. #8376 is merged at `bf297095a4610a975984201e3ac0f6d7bd9df90a` and has a [successful production deployment](https://github.com/colophon-group/jobseek/actions/runs/33433820772/job/99625330499), but the migration still requires its exact deployed SHA and verification evidence in the session-local attestation.
2. #8367/#8374 is merged at `2dc8ae8539fde551cdf487b8e73bb55c9d2fc6fc` and has successful production deployment records ([web](https://github.com/colophon-group/jobseek/actions/runs/33425365048/job/99597507467), [crawler](https://github.com/colophon-group/jobseek/actions/runs/33425365289/job/99597507678)); the apply path still fails closed until an immutable deployment SHA and a positive anonymous REST/MCP verification-run ID are supplied.
3. #8385/#8368 is still open. It must receive explicit human taste approval, then be merged, deployed, and verified as the owner-only route cutover before this PR may merge, deploy, or execute. Ready for Review on either PR does not satisfy that dependency.
4. Before execution, record a fresh backup/restore run, the exact reviewed inventory digest, all required session-local attestations, go/no-go approval, and rollback ownership. No production database or migration command has been run.
5. Do not merge this dependency-blocked migration merely because it is technically approved and conflict-free.
