### PR TITLE
Block web promotions with unapplied migrations

### DIFF
--- a/.github/workflows/deploy-web-production.yml
+++ b/.github/workflows/deploy-web-production.yml
@@ -90,6 +90,13 @@ jobs:
         if: steps.paths.outputs.deploy == 'true'
         run: pnpm install --frozen-lockfile
 
+      - name: Require production database at checked-out migration head
+        if: steps.paths.outputs.deploy == 'true'
+        working-directory: apps/web
+        env:
+          DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}
+        run: pnpm db:migrate:verify-head
+
       - name: Pull production project settings
         if: steps.paths.outputs.deploy == 'true'
         run: >-
@@ -173,41 +180,23 @@ jobs:
           rm -f -- "$scanner_headers"
           trap - EXIT
 
-      - name: Require the migration revision is still main
+      - name: Require the staged revision is still main
         if: steps.paths.outputs.deploy == 'true'
         env:
           EXPECTED_SHA: ${{ steps.paths.outputs.current_sha }}
         run: |
           current_main="$(gh api "repos/$GITHUB_REPOSITORY/commits/main" --jq '.sha')"
           if [[ "$current_main" != "$EXPECTED_SHA" ]]; then
-            echo "Refusing database migration for stale revision $EXPECTED_SHA; main is $current_main" >&2
+            echo "Refusing promotion for stale revision $EXPECTED_SHA; main is $current_main" >&2
             exit 1
           fi
 
-      - name: Verify Better Auth account issuer preflight
+      - name: Reverify production migration head immediately before promotion
         if: steps.paths.outputs.deploy == 'true'
+        working-directory: apps/web
         env:
           DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}
-        run: >-
-          pnpm --filter @jobseek/web db:migrate:verify-account-issuer --
-          preflight "$RUNNER_TEMP/better-auth-account-issuer-preflight.json"
-
-      - name: Apply the reviewed Better Auth account issuer migration
-        if: steps.paths.outputs.deploy == 'true'
-        env:
-          DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}
-          MIGRATION_REQUIRE_UNPOOLED: "true"
-        run: >-
-          timeout --signal=TERM --kill-after=15s 12m
-          pnpm --filter @jobseek/web db:migrate:apply-account-issuer
-
-      - name: Verify Better Auth account issuer postflight
-        if: steps.paths.outputs.deploy == 'true'
-        env:
-          DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}
-        run: >-
-          pnpm --filter @jobseek/web db:migrate:verify-account-issuer --
-          postflight "$RUNNER_TEMP/better-auth-account-issuer-postflight.json"
+        run: pnpm db:migrate:verify-head
 
       - name: Promote only if this SHA is still main
         if: steps.paths.outputs.deploy == 'true'

--- a/.github/workflows/web-database-migrations.yml
+++ b/.github/workflows/web-database-migrations.yml
@@ -316,6 +316,9 @@ jobs:
       - name: Install locked dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Check exact Drizzle migration head
+        run: pnpm --filter @jobseek/web db:migrate:verify-head
+
       - name: Check for production baseline drift
         run: >-
           pnpm --filter @jobseek/web db:migrate:verify-retirement --

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "compile": "lingui compile",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx src/db/migrate.ts",
+    "db:migrate:verify-head": "tsx scripts/verify-production-migration-head.ts",
     "db:migrate:apply-account-issuer": "tsx scripts/apply-better-auth-account-issuer.ts",
     "db:migrate:verify-account-issuer": "tsx scripts/verify-better-auth-account-issuer.ts",
     "db:migrate:verify-retirement": "tsx scripts/verify-job-posting-retirement.ts",

--- a/apps/web/scripts/verify-production-migration-head.ts
+++ b/apps/web/scripts/verify-production-migration-head.ts
@@ -1,0 +1,134 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import dotenv from "dotenv";
+import { readMigrationFiles } from "drizzle-orm/migrator";
+import postgres from "postgres";
+
+import {
+  assertMigrationHead,
+  MigrationHeadMismatchError,
+  type MigrationIdentity,
+  type MigrationLedgerSnapshot,
+} from "../src/db/migration-head";
+import { logExternalError } from "../src/lib/safe-external-error";
+
+dotenv.config({ path: ".env.local", quiet: true });
+
+type LocalMigrationHead = MigrationIdentity & { tag: string };
+type Journal = {
+  entries: Array<{ tag: string; when: number }>;
+};
+
+function requireDatabaseUrl(): string {
+  const value = process.env.DATABASE_URL_UNPOOLED;
+  if (!value) {
+    throw new Error(
+      "DATABASE_URL_UNPOOLED must be set for migration-head verification",
+    );
+  }
+  return value;
+}
+
+function loadLocalMigrationHead(): LocalMigrationHead {
+  const migrationFolder = resolve(process.cwd(), "drizzle");
+  const migrations = readMigrationFiles({ migrationsFolder: migrationFolder });
+  const localHead = migrations.at(-1);
+  if (!localHead) throw new Error("No local Drizzle migrations were found");
+
+  const journal = JSON.parse(
+    readFileSync(resolve(migrationFolder, "meta/_journal.json"), "utf8"),
+  ) as Journal;
+  const journalHead = journal.entries.at(-1);
+  if (!journalHead || journalHead.when !== localHead.folderMillis) {
+    throw new Error(
+      "Local Drizzle journal head does not match the migration files",
+    );
+  }
+
+  return {
+    tag: journalHead.tag,
+    createdAt: localHead.folderMillis,
+    hash: localHead.hash,
+  };
+}
+
+async function main(): Promise<void> {
+  const databaseUrl = requireDatabaseUrl();
+  if (new URL(databaseUrl).port === "6543") {
+    throw new Error(
+      "Refusing migration-head verification through the transaction pooler",
+    );
+  }
+  const expected = loadLocalMigrationHead();
+  const sql = postgres(databaseUrl, {
+    max: 1,
+    prepare: false,
+    connect_timeout: 15,
+    connection: { application_name: "jobseek-web-migration-head-check" },
+  });
+
+  try {
+    const observed = await sql.begin(async (tx) => {
+      await tx`SET TRANSACTION READ ONLY`;
+      await tx`SET LOCAL statement_timeout = '15s'`;
+
+      const latestRows = await tx<
+        Array<{ createdAt: string; hash: string }>
+      >`
+        SELECT created_at::text AS "createdAt", hash
+        FROM drizzle.__drizzle_migrations
+        ORDER BY created_at DESC, id DESC
+        LIMIT 1
+      `;
+      const [counts] = await tx<
+        Array<{ matchingHeadRows: number; headTimestampRows: number }>
+      >`
+        SELECT
+          count(*) FILTER (
+            WHERE created_at = ${expected.createdAt}
+              AND hash = ${expected.hash}
+          )::integer AS "matchingHeadRows",
+          count(*) FILTER (
+            WHERE created_at = ${expected.createdAt}
+          )::integer AS "headTimestampRows"
+        FROM drizzle.__drizzle_migrations
+      `;
+
+      const latest = latestRows[0];
+      const snapshot: MigrationLedgerSnapshot = {
+        latest: latest
+          ? { createdAt: Number(latest.createdAt), hash: latest.hash }
+          : null,
+        matchingHeadRows: counts?.matchingHeadRows ?? 0,
+        headTimestampRows: counts?.headTimestampRows ?? 0,
+      };
+      return snapshot;
+    });
+
+    assertMigrationHead(expected, observed);
+    process.stdout.write(`${JSON.stringify({
+      event: "production_migration_head_verified",
+      migration: expected.tag,
+      createdAt: expected.createdAt,
+      hash: expected.hash.slice(0, 12),
+    })}\n`);
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+void main().catch((error: unknown) => {
+  if (error instanceof MigrationHeadMismatchError) {
+    console.error(
+      "Production migration head does not match the checked-out code. Refusing promotion; apply reviewed migrations and rerun the deployment.",
+    );
+  } else {
+    logExternalError(
+      "error",
+      { service: "database", operation: "verify_migration_head" },
+      error,
+    );
+  }
+  process.exitCode = 1;
+});

--- a/apps/web/src/db/__tests__/better-auth-1-7-migration.test.ts
+++ b/apps/web/src/db/__tests__/better-auth-1-7-migration.test.ts
@@ -102,42 +102,15 @@ describe("0087 Better Auth account issuer migration", () => {
     expect(verifier).toContain('status: "failed"');
   });
 
-  it("applies 0087 after staged smoke and before promotion", () => {
-    const stagedSmoke = deployWorkflow.indexOf(
-      "Verify staged production functionality",
-    );
-    const preflight = deployWorkflow.indexOf(
+  it("does not keep a one-off 0087 write in the production deploy", () => {
+    expect(deployWorkflow).not.toContain("db:migrate:apply-account-issuer");
+    expect(deployWorkflow).not.toContain(
       "Verify Better Auth account issuer preflight",
     );
-    const currentMainGuard = deployWorkflow.indexOf(
-      "Require the migration revision is still main",
-    );
-    const apply = deployWorkflow.indexOf(
-      "Apply the reviewed Better Auth account issuer migration",
-    );
-    const postflight = deployWorkflow.indexOf(
+    expect(deployWorkflow).not.toContain(
       "Verify Better Auth account issuer postflight",
     );
-    const promote = deployWorkflow.indexOf(
-      "Promote only if this SHA is still main",
-    );
-
-    expect(stagedSmoke).toBeGreaterThan(0);
-    expect(currentMainGuard).toBeGreaterThan(stagedSmoke);
-    expect(preflight).toBeGreaterThan(currentMainGuard);
-    expect(apply).toBeGreaterThan(preflight);
-    expect(postflight).toBeGreaterThan(apply);
-    expect(promote).toBeGreaterThan(postflight);
-    expect(deployWorkflow).toContain("pnpm install --frozen-lockfile");
-    expect(deployWorkflow).toContain("db:migrate:apply-account-issuer");
-    expect(deployWorkflow).toContain("db:migrate:verify-account-issuer");
-    expect(deployWorkflow).toContain(
-      "DATABASE_URL_UNPOOLED: ${{ secrets.DATABASE_URL_UNPOOLED }}",
-    );
-    expect(deployWorkflow).toContain('MIGRATION_REQUIRE_UNPOOLED: "true"');
-    expect(
-      deployWorkflow.slice(preflight, promote),
-    ).not.toMatch(/\bdb:migrate(?:\s|$)/);
+    expect(deployWorkflow).not.toMatch(/run: pnpm db:migrate\s*$/m);
   });
 
   it("checks the applied issuer contract in scheduled drift verification", () => {

--- a/apps/web/src/db/__tests__/migration-head.test.ts
+++ b/apps/web/src/db/__tests__/migration-head.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertMigrationHead,
+  MigrationHeadMismatchError,
+  type MigrationLedgerSnapshot,
+} from "../migration-head";
+
+const expected = {
+  createdAt: 1_788_199_156_000,
+  hash: "a".repeat(64),
+};
+
+function snapshot(
+  overrides: Partial<MigrationLedgerSnapshot> = {},
+): MigrationLedgerSnapshot {
+  return {
+    latest: expected,
+    matchingHeadRows: 1,
+    headTimestampRows: 1,
+    ...overrides,
+  };
+}
+
+describe("production migration head guard", () => {
+  it("accepts one exact production head", () => {
+    expect(() => assertMigrationHead(expected, snapshot())).not.toThrow();
+  });
+
+  it("rejects an empty or behind production ledger", () => {
+    expect(() =>
+      assertMigrationHead(expected, snapshot({ latest: null })),
+    ).toThrow(MigrationHeadMismatchError);
+    expect(() =>
+      assertMigrationHead(expected, snapshot({
+        latest: { createdAt: expected.createdAt - 1, hash: "b".repeat(64) },
+      })),
+    ).toThrow(/behind the checked-out code/);
+  });
+
+  it("rejects a database ahead of the checked-out deployment", () => {
+    expect(() =>
+      assertMigrationHead(expected, snapshot({
+        latest: { createdAt: expected.createdAt + 1, hash: "b".repeat(64) },
+      })),
+    ).toThrow(/ahead of the checked-out code/);
+  });
+
+  it("rejects a different SQL hash at the expected timestamp", () => {
+    expect(() =>
+      assertMigrationHead(expected, snapshot({
+        latest: { createdAt: expected.createdAt, hash: "b".repeat(64) },
+        matchingHeadRows: 0,
+      })),
+    ).toThrow(/head hash differs/);
+  });
+
+  it("rejects missing, duplicate, or colliding head ledger rows", () => {
+    for (const observed of [
+      snapshot({ matchingHeadRows: 0, headTimestampRows: 0 }),
+      snapshot({ matchingHeadRows: 2, headTimestampRows: 2 }),
+      snapshot({ matchingHeadRows: 1, headTimestampRows: 2 }),
+    ]) {
+      expect(() => assertMigrationHead(expected, observed)).toThrow(
+        /recorded exactly once/,
+      );
+    }
+  });
+});

--- a/apps/web/src/db/__tests__/production-migration-safety.test.ts
+++ b/apps/web/src/db/__tests__/production-migration-safety.test.ts
@@ -123,6 +123,8 @@ describe("production migration safety", () => {
     expect(workflow).toContain(
       "timeout --signal=TERM --kill-after=15s 12m pnpm db:migrate",
     );
+    expect(workflow).toContain("Check exact Drizzle migration head");
+    expect(workflow).toContain("db:migrate:verify-head");
 
     const maintenance = readRepo(
       ".github/workflows/crawler-scheduled-maintenance.yml",
@@ -134,5 +136,23 @@ describe("production migration safety", () => {
     expect(maintenance).toContain(
       'run-name: "Crawler maintenance: ${{ inputs.task || \'refresh-typesense\' }} @ ${{ inputs.expected_crawler_revision || \'scheduled\' }}"',
     );
+  });
+
+  it("blocks production promotion unless the exact local migration head exists", () => {
+    const deployWorkflow = readRepo(
+      ".github/workflows/deploy-web-production.yml",
+    );
+    const verifier = readWeb("scripts/verify-production-migration-head.ts");
+
+    expect(
+      deployWorkflow.match(/run: pnpm db:migrate:verify-head/g),
+    ).toHaveLength(2);
+    expect(deployWorkflow).not.toContain("db:migrate:apply-account-issuer");
+    expect(deployWorkflow).not.toMatch(/run: pnpm db:migrate\s*$/m);
+    expect(verifier).toContain("readMigrationFiles");
+    expect(verifier).toContain("SET TRANSACTION READ ONLY");
+    expect(verifier).toContain("DATABASE_URL_UNPOOLED");
+    expect(verifier).toContain('new URL(databaseUrl).port === "6543"');
+    expect(verifier).toContain("assertMigrationHead(expected, observed)");
   });
 });

--- a/apps/web/src/db/migration-head.ts
+++ b/apps/web/src/db/migration-head.ts
@@ -1,0 +1,64 @@
+export type MigrationIdentity = {
+  createdAt: number;
+  hash: string;
+};
+
+export type MigrationLedgerSnapshot = {
+  latest: MigrationIdentity | null;
+  matchingHeadRows: number;
+  headTimestampRows: number;
+};
+
+export class MigrationHeadMismatchError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MigrationHeadMismatchError";
+  }
+}
+
+function renderIdentity(identity: MigrationIdentity | null): string {
+  if (!identity) return "empty ledger";
+  return `${identity.createdAt}/${identity.hash.slice(0, 12)}`;
+}
+
+/**
+ * Require production to match the exact migration head bundled with the
+ * deployment artifact. Deploys must never apply migrations implicitly: some
+ * migrations require protected evidence and human approval. Instead, this
+ * check makes promotion fail closed until the reviewed migration path has
+ * brought production to the same head.
+ */
+export function assertMigrationHead(
+  expected: MigrationIdentity,
+  observed: MigrationLedgerSnapshot,
+): void {
+  if (!observed.latest) {
+    throw new MigrationHeadMismatchError(
+      `Production migration ledger is empty; expected ${renderIdentity(expected)}. Apply reviewed migrations before promotion.`,
+    );
+  }
+
+  if (observed.latest.createdAt !== expected.createdAt) {
+    const direction = observed.latest.createdAt < expected.createdAt
+      ? "behind"
+      : "ahead of";
+    throw new MigrationHeadMismatchError(
+      `Production migration ledger is ${direction} the checked-out code: expected ${renderIdentity(expected)}, found ${renderIdentity(observed.latest)}. Refusing promotion.`,
+    );
+  }
+
+  if (observed.latest.hash !== expected.hash) {
+    throw new MigrationHeadMismatchError(
+      `Production migration head hash differs from the checked-out migration at ${expected.createdAt}: expected ${expected.hash.slice(0, 12)}, found ${observed.latest.hash.slice(0, 12)}. Refusing promotion.`,
+    );
+  }
+
+  if (
+    observed.matchingHeadRows !== 1 ||
+    observed.headTimestampRows !== 1
+  ) {
+    throw new MigrationHeadMismatchError(
+      `Production migration head must be recorded exactly once; found ${observed.matchingHeadRows} exact rows and ${observed.headTimestampRows} rows at timestamp ${expected.createdAt}. Refusing promotion.`,
+    );
+  }
+}

--- a/docs/18-vercel-fluid-cpu.md
+++ b/docs/18-vercel-fluid-cpu.md
@@ -108,6 +108,13 @@ pnpm and Turbo configuration, and dependency patches. Crawler code, crawler
 board configuration, documentation, and company CSV changes do not deploy the
 web.
 
+The same workflow verifies the production Drizzle ledger before building and
+again immediately before promotion. Its timestamp and SQL hash must match the
+exact migration head in the checked-out artifact, recorded exactly once. This
+check is read-only and fails closed: apply pending migrations through the
+reviewed production-migration path, then rerun the deployment. The scheduled
+database-drift job performs the same check with its read-only credential.
+
 Company CSV changes are safe to exclude because the external OG prewarm job
 publishes `og/company/<renderer>/_complete/current.json` only after the full
 company/locale matrix and its immutable source-version marker exist. Company

--- a/scripts/vercel-web-deploy-paths.test.mjs
+++ b/scripts/vercel-web-deploy-paths.test.mjs
@@ -141,37 +141,34 @@ test("production workflow stages, verifies, then promotes exact main", () => {
   assert.match(workflow, /Smoke \$path -> HTTP \$status/);
   assert.match(workflow, /Scanner path exposed/);
   assert.match(workflow, /pnpm install --frozen-lockfile/);
-  assert.match(workflow, /db:migrate:verify-account-issuer --[\s\S]*preflight/);
-  assert.match(workflow, /db:migrate:apply-account-issuer/);
-  assert.match(workflow, /db:migrate:verify-account-issuer --[\s\S]*postflight/);
+  assert.equal(
+    [...workflow.matchAll(/run: pnpm db:migrate:verify-head/g)].length,
+    2,
+  );
+  assert.doesNotMatch(workflow, /db:migrate:apply-account-issuer/);
+  assert.doesNotMatch(workflow, /run: pnpm db:migrate\s*$/m);
   assert.match(
     workflow,
     /DATABASE_URL_UNPOOLED: \$\{\{ secrets\.DATABASE_URL_UNPOOLED \}\}/,
   );
-  assert.match(workflow, /MIGRATION_REQUIRE_UNPOOLED: "true"/);
+  const install = workflow.indexOf("Install locked dependencies");
+  const initialHeadCheck = workflow.indexOf(
+    "Require production database at checked-out migration head",
+  );
+  const pull = workflow.indexOf("Pull production project settings");
   const stagedSmoke = workflow.indexOf("Verify staged production functionality");
-  const migrationPreflight = workflow.indexOf(
-    "Verify Better Auth account issuer preflight",
-  );
   const currentMainGuard = workflow.indexOf(
-    "Require the migration revision is still main",
+    "Require the staged revision is still main",
   );
-  const targetedMigration = workflow.indexOf(
-    "Apply the reviewed Better Auth account issuer migration",
-  );
-  const migrationPostflight = workflow.indexOf(
-    "Verify Better Auth account issuer postflight",
+  const finalHeadCheck = workflow.indexOf(
+    "Reverify production migration head immediately before promotion",
   );
   const promotion = workflow.indexOf("Promote only if this SHA is still main");
+  assert.ok(install < initialHeadCheck);
+  assert.ok(initialHeadCheck < pull);
   assert.ok(stagedSmoke < currentMainGuard);
-  assert.ok(currentMainGuard < migrationPreflight);
-  assert.ok(migrationPreflight < targetedMigration);
-  assert.ok(targetedMigration < migrationPostflight);
-  assert.ok(migrationPostflight < promotion);
-  assert.doesNotMatch(
-    workflow.slice(migrationPreflight, promotion),
-    /\bdb:migrate(?:\s|$)/,
-  );
+  assert.ok(currentMainGuard < finalHeadCheck);
+  assert.ok(finalHeadCheck < promotion);
   assert.doesNotMatch(workflow, /--cwd=apps\/web/);
   assert.doesNotMatch(workflow, /--git-branch/);
   assert.match(workflow, /environment: Production/);


### PR DESCRIPTION
## Summary

- fail production builds and promotions unless the live Drizzle ledger exactly matches the checked-out migration timestamp and SQL hash
- run the same read-only head check in scheduled migration drift monitoring
- remove the obsolete one-off 0087 mutation from the web deployment path while preserving protected migration writes
- document the fail-closed recovery path

## Incident

Production was deployed with 0088 code while its database was still at 0087, causing authenticated watchlist requests to fail on the missing `user_preferences.notification_cadence` column. Migration 0088 has been applied directly and the authenticated watchlist page is healthy. This PR prevents the same deployment/database skew from being promoted again.

Fixes #8406

## Verification

- `pnpm --filter @jobseek/web typecheck`
- targeted ESLint on changed TypeScript
- `node --test scripts/vercel-web-deploy-paths.test.mjs`
- 19 focused Vitest migration/deployment tests
- live read-only verifier passed against production at `0088_notification_policy_foundation`
- full Vitest run: 2,199 passed; one unrelated baseline failure because `proxy.ts` is already stale for canonical company `abercrombie` (`proxy-matchers:check` confirms the stale generated file)