### PR TITLE
Stop stateless MCP GET streams from timing out

### DIFF
--- a/packages/mcp-server/scripts/verify-package.mjs
+++ b/packages/mcp-server/scripts/verify-package.mjs
@@ -1,6 +1,7 @@
 import { access, readFile } from "node:fs/promises";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { handleMcpRequest } from "../dist/handler.js";
 import { createServer } from "../dist/server.js";
 import { JobseekClient } from "../dist/client.js";
 import {
@@ -72,6 +73,25 @@ assert(
 assert(
   packageJson.repository?.directory === "packages/mcp-server",
   "package.json repository.directory must identify this workspace package",
+);
+
+// A request-scoped, stateless transport cannot deliver server-initiated
+// messages on a standalone GET stream. Reject it instead of leaving a
+// serverless invocation open until the hosting platform kills it.
+const standaloneStreamResponse = await handleMcpRequest(
+  new Request("https://example.invalid/mcp", {
+    method: "GET",
+    headers: { Accept: "text/event-stream" },
+  }),
+  "https://example.invalid",
+);
+assert(
+  standaloneStreamResponse.status === 405,
+  "Stateless MCP handler must reject standalone GET streams with HTTP 405",
+);
+assert(
+  standaloneStreamResponse.headers.get("Allow") === "POST, DELETE",
+  "Stateless MCP GET rejection must advertise the supported methods",
 );
 
 // Exercise the published protocol boundary. This catches SDK/Zod integration

--- a/packages/mcp-server/src/handler.ts
+++ b/packages/mcp-server/src/handler.ts
@@ -11,6 +11,16 @@ export async function handleMcpRequest(
   baseUrl = "https://jseek.co",
   options: JobseekClientOptions = {},
 ): Promise<Response> {
+  if (req.method === "GET") {
+    // This handler creates an isolated transport for every request, so a
+    // standalone SSE stream cannot receive messages from later POSTs. Leaving
+    // it open only pins the serverless invocation until the platform timeout.
+    return new Response(null, {
+      status: 405,
+      headers: { Allow: "POST, DELETE" },
+    });
+  }
+
   if (req.method === "DELETE") {
     return new Response(null, { status: 200 });
   }


### PR DESCRIPTION
## Summary

- return HTTP 405 for standalone GET requests handled by the stateless MCP server
- advertise the supported POST and DELETE methods
- add a package-level protocol assertion covering the hosted transport behavior

## Context

Vercel production logs showed repeated `GET /mcp` invocations staying open until the 300-second function timeout. The handler creates a fresh stateless transport for every request, so a standalone GET SSE stream cannot receive server-initiated messages from later POST requests. MCP permits a 405 response when the endpoint does not offer this stream.

## Verification

- `pnpm --filter @jseek/mcp-server test`
- `pnpm --filter @jseek/mcp-server typecheck`
- `pnpm --filter @jobseek/web exec vitest run app/mcp/route.test.ts` (18 tests)
- `pnpm typecheck` (6 tasks)