### PR TITLE
Fix fleet benchmark health snapshots

### DIFF
--- a/.github/workflows/crawler-sitemap-fleet-benchmark.yml
+++ b/.github/workflows/crawler-sitemap-fleet-benchmark.yml
@@ -379,13 +379,31 @@ jobs:
           [[ -z "$existing_benchmark_ids" ]] || exit 70
           cleanup_armed=1
 
+          inspect_protected_service() {
+            local service="$1" container_id="$2" state_payload
+            state_payload="$(timeout 20s docker inspect --format '{{.Id}}|{{.RestartCount}}|{{json .State}}' "$container_id")" || return 1
+            PROTECTED_SERVICE="$service" PROTECTED_STATE="$state_payload" python3 - <<'PY'
+          import json, os, re
+          container_id, restart_text, state_text = os.environ["PROTECTED_STATE"].split("|", 2)
+          state = json.loads(state_text)
+          health_state = state.get("Health")
+          health = "none" if health_state is None else health_state.get("Status")
+          restart_count = int(restart_text)
+          if (re.fullmatch(r"[0-9a-f]{64}", container_id) is None or restart_count < 0
+                  or state.get("Status") not in {"created", "running", "paused", "restarting", "removing", "exited", "dead"}
+                  or not isinstance(health, str)):
+              raise SystemExit(1)
+          print(f'{os.environ["PROTECTED_SERVICE"]}|{container_id}|{state["Status"]}|{restart_count}|{health}')
+          PY
+          }
+
           snapshot_protected_services() {
             for service in murmur cloudflared; do
               ids_text="$(timeout 20s docker ps -aq --filter label=com.docker.compose.project=deploy \
                 --filter "label=com.docker.compose.service=$service")" || return 1
               mapfile -t ids <<<"$ids_text"
               [[ ${#ids[@]} -eq 1 ]] || return 1
-              timeout 20s docker inspect --format "${service}|{{.Id}}|{{.State.Status}}|{{.RestartCount}}|{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}" "${ids[0]}"
+              inspect_protected_service "$service" "${ids[0]}"
             done
           }
           protected_base="$(snapshot_protected_services)" || exit 70
@@ -759,12 +777,29 @@ jobs:
           python_images="$(timeout 20s docker image ls --quiet --no-trunc "$python_ref")"
           [[ -z "$benchmark_ids" && -z "$go_images" && -z "$python_images" ]]
           [[ ! -e "$auth_path" ]]
+          inspect_protected_service() {
+            local service="$1" container_id="$2" state_payload
+            state_payload="$(timeout 20s docker inspect --format '{{.Id}}|{{.RestartCount}}|{{json .State}}' "$container_id")" || return 1
+            PROTECTED_SERVICE="$service" PROTECTED_STATE="$state_payload" python3 - <<'PY'
+          import json, os, re
+          container_id, restart_text, state_text = os.environ["PROTECTED_STATE"].split("|", 2)
+          state = json.loads(state_text)
+          health_state = state.get("Health")
+          health = "none" if health_state is None else health_state.get("Status")
+          restart_count = int(restart_text)
+          if (re.fullmatch(r"[0-9a-f]{64}", container_id) is None or restart_count < 0
+                  or state.get("Status") not in {"created", "running", "paused", "restarting", "removing", "exited", "dead"}
+                  or not isinstance(health, str)):
+              raise SystemExit(1)
+          print(f'{os.environ["PROTECTED_SERVICE"]}|{container_id}|{state["Status"]}|{restart_count}|{health}')
+          PY
+          }
           snapshot=""
           for service in murmur cloudflared; do
             ids_text="$(timeout 20s docker ps -q --filter label=com.docker.compose.project=deploy --filter "label=com.docker.compose.service=$service")"
             mapfile -t ids <<<"$ids_text"
             [[ ${#ids[@]} -eq 1 ]]
-            line="$(timeout 20s docker inspect --format "${service}|{{.Id}}|{{.State.Status}}|{{.RestartCount}}|{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}" "${ids[0]}")"
+            line="$(inspect_protected_service "$service" "${ids[0]}")"
             IFS='|' read -r _ _ status _ health <<<"$line"
             [[ "$status" == running && ("$health" == none || "$health" == healthy) ]]
             snapshot+="${snapshot:+$'\n'}$line"

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -1108,6 +1108,19 @@ test("fleet benchmark workflow is bounded, isolated, and uses the reviewed wire 
     goSitemapFleetWorkflow,
     /--protected-postflight-sha256 "\$protected_postflight_sha256"/,
   );
+  assert.equal(goSitemapFleetWorkflow.includes("{{if .State.Health}}"), false);
+  assert.equal(
+    (
+      goSitemapFleetWorkflow.match(
+        /\{\{\.Id\}\}\|\{\{\.RestartCount\}\}\|\{\{json \.State\}\}/g,
+      ) ?? []
+    ).length,
+    2,
+  );
+  assert.equal(
+    (goSitemapFleetWorkflow.match(/health_state = state\.get\("Health"\)/g) ?? []).length,
+    2,
+  );
   assert.match(
     goSitemapFleetWorkflow,
     /\.status == "succeeded" and \.report_valid == true and \.timing_comparable == true/,


### PR DESCRIPTION
## Outcome

Fix the merged-main sitemap fleet benchmark so Docker services without a configured health check are snapshotted safely.

The first merged-main run (34360384384) aborted before any source request because `deploy-cloudflared-1` legitimately omits `.State.Health`; Docker's strict Go-template lookup treated the missing map key as an inspection failure.

## Change

- serialize bounded `.State` JSON and parse it explicitly
- map only missing/null `Health` to `none`
- retain exact container ID, running-state, restart-count, and health validation
- use the same helper in baseline and independent postflight
- add workflow contracts that ban the unsafe direct lookup in both paths

## Safety

- reproduced read-only on Murmur: crawler -> `running|1|healthy`, cloudflared -> `running|0|none`
- no benchmark containers, credentials, volumes, or images remained after the failed run
- production services were unchanged
- independent safety review: approved, no blockers

## Verification

- `actionlint .github/workflows/crawler-sitemap-fleet-benchmark.yml`
- `node --test scripts/ci-workflow.test.mjs` (83/83)
- `git diff --check`

Refs #8648
