### PR TITLE
Retain fleet benchmark preflight failures

### DIFF
--- a/.github/workflows/crawler-sitemap-fleet-benchmark.yml
+++ b/.github/workflows/crawler-sitemap-fleet-benchmark.yml
@@ -347,10 +347,17 @@ jobs:
           pins_file="$docker_config/pins.tsv"
           docker_root_dir=""
           cleanup_armed=0
+          meta_emitted=0
+          preflight_stage=inventory
+          protected_sha256=""
 
           cleanup_remote() {
             status=$?
             trap - EXIT HUP INT TERM
+            if (( status != 0 && meta_emitted == 0 )); then
+              printf 'PREFLIGHT_FAILURE\t%s\t%s\t%s\n' \
+                "$preflight_stage" "$status" "${protected_sha256:-none}" || true
+            fi
             if (( cleanup_armed )); then
               mapfile -t owned_ids < <(timeout 20s docker ps -aq --filter "label=${label_key}=${label_value}" 2>/dev/null || true)
               for candidate_id in "${owned_ids[@]}"; do
@@ -378,6 +385,7 @@ jobs:
           existing_benchmark_ids="$(timeout 20s docker ps -aq --filter "label=${label_key}")" || exit 70
           [[ -z "$existing_benchmark_ids" ]] || exit 70
           cleanup_armed=1
+          preflight_stage=protected_services
 
           inspect_protected_service() {
             local service="$1" container_id="$2" state_payload
@@ -422,22 +430,28 @@ jobs:
             [[ "$available" =~ ^[0-9]+$ && "$free" =~ ^[0-9]+$ && "$load" =~ ^[0-9]+([.][0-9]+)?$ ]] || return 1
             printf '%s|%s|%s\n' "$available" "$free" "$load"
           }
+          preflight_stage=host_resources_before_pull
           docker_root_dir="$(timeout 20s docker info --format '{{.DockerRootDir}}' 2>/dev/null)" || exit 70
           [[ "$docker_root_dir" == /* && "$docker_root_dir" != / ]] || exit 70
           resources_before_pull="$(host_resources)" || exit 70
           IFS='|' read -r mem_before_pull disk_before_pull load_before_pull <<<"$resources_before_pull"
           (( mem_before_pull >= 1572864 && disk_before_pull >= 5242880 )) || exit 70
           awk -v load="$load_before_pull" 'BEGIN { exit !(load <= 1.50) }' || exit 71
+          preflight_stage=pull_go_image
           DOCKER_CONFIG="$docker_config" timeout 300s docker pull "$go_ref" >/dev/null 2>&1 || exit 71
+          preflight_stage=pull_python_image
           DOCKER_CONFIG="$docker_config" timeout 300s docker pull "$python_ref" >/dev/null 2>&1 || exit 71
+          preflight_stage=host_resources_after_pull
           resources_after_pull="$(host_resources)" || exit 70
           IFS='|' read -r mem_after_pull disk_after_pull load_after_pull <<<"$resources_after_pull"
           (( mem_after_pull >= 1572864 && disk_after_pull >= 5242880 )) || exit 70
           awk -v load="$load_after_pull" 'BEGIN { exit !(load <= 1.50) }' || exit 71
+          preflight_stage=image_attestation
           [[ "$(uname -m)" == aarch64 ]] || exit 71
           [[ "$(timeout 20s docker image inspect --format '{{.Os}}|{{.Architecture}}' "$go_ref" 2>/dev/null)" == 'linux|arm64' ]] || exit 71
           [[ "$(timeout 20s docker image inspect --format '{{.Os}}|{{.Architecture}}' "$python_ref" 2>/dev/null)" == 'linux|arm64' ]] || exit 71
 
+          preflight_stage=schedule_validation
           printf '%s' "$schedule_b64" | base64 -d >"$schedule_file"
           [[ "$(sha256sum "$schedule_file" | awk '{print $1}')" == "$schedule_payload_sha256" ]] || exit 71
           SCHEDULE_FILE="$schedule_file" python3 - <<'PY' || exit 71
@@ -453,6 +467,7 @@ jobs:
           raise SystemExit(0 if valid else 1)
           PY
 
+          preflight_stage=dns_pinning
           read -r _ _ ssh_server_ip _ <<<"${SSH_CONNECTION:-}"
           [[ -n "$ssh_server_ip" ]] || exit 70
           PIN_HOSTS="$hosts_csv" PIN_TARGET="$target_host" PIN_SSH_SERVER="$ssh_server_ip" \
@@ -502,6 +517,7 @@ jobs:
           printf 'RUN_META\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
             "$pinset_sha256" "$protected_sha256" "$cooldown_seconds" "$mem_before_pull" \
             "$disk_before_pull" "$load_before_pull" "$mem_after_pull" "$disk_after_pull" "$load_after_pull"
+          meta_emitted=1
 
           validate_host_config() {
             local name="$1" image_ref="$2" profile="$3"

--- a/pilots/go-http-sitemap/FLEET-BENCHMARK.md
+++ b/pilots/go-http-sitemap/FLEET-BENCHMARK.md
@@ -72,6 +72,13 @@ from merged `main`. It builds immutable ARM64 images for both runtimes, pins
 them by digest, verifies protected Murmur services before and after every arm,
 and uploads one sanitized JSON artifact even when a benchmark arm fails.
 Production-safety invariant failures stop the schedule immediately.
+If preflight fails before `RUN_META`, the remote cleanup trap emits exactly one
+record containing an allowlisted stage name, the exit status, and the protected-
+service baseline digest (or `none` if no baseline was established). Such a
+failure is classified as ordinary benchmark infrastructure only when the
+independent postflight digest exactly matches that baseline; missing or changed
+protected-state evidence remains a production-safety abort. Raw remote stderr,
+host addresses, credentials, and temporary paths are never retained.
 
 Run local conformance from `pilots/go-http-sitemap`:
 

--- a/pilots/go-http-sitemap/benchmark/report_wire.py
+++ b/pilots/go-http-sitemap/benchmark/report_wire.py
@@ -20,6 +20,19 @@ from typing import Any
 
 PROFILES = {"c2": 2, "c4": 4, "c5": 5, "c8": 8, "c12": 12, "c16": 16}
 EXPECTED_PAIR_COUNTS = {"c2": 4, "c4": 4, "c5": 6, "c8": 4, "c12": 6, "c16": 6}
+PREFLIGHT_FAILURE_STAGES = frozenset(
+    {
+        "inventory",
+        "protected_services",
+        "host_resources_before_pull",
+        "pull_go_image",
+        "pull_python_image",
+        "host_resources_after_pull",
+        "image_attestation",
+        "schedule_validation",
+        "dns_pinning",
+    }
+)
 MAX_WIRE_BYTES = 8_388_608
 BYTE_IMBALANCE_LIMIT = 0.05
 TOKEN_RE = re.compile(r"^[a-z0-9_]{1,64}$")
@@ -541,19 +554,42 @@ def parse_report(args: argparse.Namespace) -> dict[str, Any]:
         )
     except (OSError, UnicodeError):
         lines, protocol_valid = [], False
+    protected_baseline_sha256: str | None = None
+    preflight_failure_stage: str | None = None
     meta: dict[str, Any] | None = None
     postflight_valid = False
     arms: list[dict[str, Any]] = []
     index = 0
     if lines:
         fields = lines[0].split("\t")
-        if (
+        if fields[0] == "PREFLIGHT_FAILURE":
+            marker_valid = False
+            if len(fields) == 4:
+                try:
+                    marker_status = int(fields[2])
+                except ValueError:
+                    marker_status = -1
+                marker_valid = bool(
+                    len(lines) == 1
+                    and fields[1] in PREFLIGHT_FAILURE_STAGES
+                    and marker_status == args.remote_status
+                    and marker_status in {70, 71}
+                    and (fields[3] == "none" or SHA_RE.fullmatch(fields[3]))
+                )
+            protocol_valid &= marker_valid
+            if marker_valid:
+                preflight_failure_stage = fields[1]
+                if fields[3] != "none":
+                    protected_baseline_sha256 = fields[3]
+            index = 1
+        elif (
             len(fields) == 10
             and fields[0] == "RUN_META"
             and SHA_RE.fullmatch(fields[1])
             and SHA_RE.fullmatch(fields[2])
         ):
             try:
+                protected_baseline_sha256 = fields[2]
                 meta = {
                     "pinset_sha256": fields[1],
                     "protected_baseline_sha256": fields[2],
@@ -575,9 +611,9 @@ def parse_report(args: argparse.Namespace) -> dict[str, Any]:
                     meta = None
             except ValueError:
                 protocol_valid = False
+            index += 1
         else:
             protocol_valid = False
-        index = 1
     else:
         protocol_valid = False
 
@@ -594,6 +630,9 @@ def parse_report(args: argparse.Namespace) -> dict[str, Any]:
             )
             index += 1
             protocol_valid &= index == len(lines)
+            break
+        if meta is None:
+            protocol_valid = False
             break
         if len(fields) != 15 or fields[0] != "ARM_LIFECYCLE" or index + 1 >= len(lines):
             protocol_valid = False
@@ -690,7 +729,7 @@ def parse_report(args: argparse.Namespace) -> dict[str, Any]:
         index += 2
 
     expected_count = 2 if args.remote_status == 72 else 60 if args.remote_status == 0 else len(arms)
-    structural = bool(
+    full_run_structural = bool(
         protocol_valid
         and meta is not None
         and args.cleanup_verified
@@ -698,6 +737,22 @@ def parse_report(args: argparse.Namespace) -> dict[str, Any]:
         and all(arm["raw_report_valid"] for arm in arms)
         and (postflight_valid or args.remote_status not in {0, 72, 73})
     )
+    protected_digest_match = bool(
+        protected_baseline_sha256
+        and args.protected_postflight_sha256
+        and protected_baseline_sha256 == args.protected_postflight_sha256
+    )
+    preflight_failure_structural = bool(
+        protocol_valid
+        and meta is None
+        and args.remote_status in {70, 71}
+        and args.cleanup_verified
+        and protected_digest_match
+        and preflight_failure_stage is not None
+        and not arms
+        and index == len(lines)
+    )
+    structural = full_run_structural or preflight_failure_structural
     all_successful = len(arms) == 60 and all(_successful_arm(arm, expected_ids) for arm in arms)
     correctness = all_successful
     parity: dict[tuple[str, int, str], list[tuple[int, str]]] = {}
@@ -743,11 +798,6 @@ def parse_report(args: argparse.Namespace) -> dict[str, Any]:
         and all(item["relative_delta"] <= BYTE_IMBALANCE_LIMIT for item in byte_deltas)
     )
 
-    protected_digest_match = bool(
-        meta is not None
-        and args.protected_postflight_sha256
-        and meta["protected_baseline_sha256"] == args.protected_postflight_sha256
-    )
     safety_event = (
         args.remote_status == 70
         or not args.cleanup_verified
@@ -787,7 +837,8 @@ def parse_report(args: argparse.Namespace) -> dict[str, Any]:
         "go_image_digest": args.go_digest,
         "python_image_digest": args.python_digest,
         "pinset_sha256": meta["pinset_sha256"] if meta else None,
-        "protected_baseline_sha256": meta["protected_baseline_sha256"] if meta else None,
+        "protected_baseline_sha256": protected_baseline_sha256,
+        "preflight_failure_stage": preflight_failure_stage,
         "cooldown_seconds": args.cooldown,
         "protocol_valid": protocol_valid,
         "postflight_valid": postflight_valid,

--- a/pilots/go-http-sitemap/benchmark/test_report_wire.py
+++ b/pilots/go-http-sitemap/benchmark/test_report_wire.py
@@ -208,7 +208,7 @@ class ReportWireTest(unittest.TestCase):
                     "6000000",
                     "0.4",
                 )
-            )
+            ),
         ]
         for (pair, profile, implementation), raw, source, remote_valid in arms:
             lines.append(
@@ -219,6 +219,16 @@ class ReportWireTest(unittest.TestCase):
             lines.append(f"RUN_POSTFLIGHT\ttrue\t{PIN_SHA}\t{PROTECTED_SHA}")
         path = self.temp / "wire"
         path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return path
+
+    def make_preflight_failure_wire(
+        self, stage: str, *, status: int = 71, baseline: str = PROTECTED_SHA
+    ) -> Path:
+        path = self.temp / "preflight-wire"
+        path.write_text(
+            f"PREFLIGHT_FAILURE\t{stage}\t{status}\t{baseline}\n",
+            encoding="utf-8",
+        )
         return path
 
     def successful_arms(self, *, python_factor: float = 1.0):
@@ -241,6 +251,46 @@ class ReportWireTest(unittest.TestCase):
         self.assertTrue(report["timing_comparable"])
         self.assertEqual(len(report["arms"]), 60)
         self.assertEqual(len(report["byte_deltas"]), 60)
+
+    def test_preflight_failure_retains_exact_stage_without_safety_alarm(self) -> None:
+        wire = self.make_preflight_failure_wire("pull_go_image")
+        report = report_wire.parse_report(self.args(wire, 71))
+        self.assertEqual(report["status"], "failed")
+        self.assertEqual(report["error_kind"], "benchmark_infrastructure_failure")
+        self.assertEqual(report["preflight_failure_stage"], "pull_go_image")
+        self.assertEqual(report["protected_baseline_sha256"], PROTECTED_SHA)
+        self.assertTrue(report["report_valid"])
+
+    def test_preflight_failure_stage_must_be_allowlisted(self) -> None:
+        wire = self.temp / "bad-stage-wire"
+        wire.write_text(
+            f"PREFLIGHT_FAILURE\tnot_a_stage\t71\t{PROTECTED_SHA}\n",
+            encoding="utf-8",
+        )
+        report = report_wire.parse_report(self.args(wire, 71))
+        self.assertEqual(report["error_kind"], "production_safety_violation")
+        self.assertFalse(report["report_valid"])
+
+    def test_preflight_safety_status_retains_sanitized_stage(self) -> None:
+        wire = self.make_preflight_failure_wire("dns_pinning", status=70)
+        report = report_wire.parse_report(self.args(wire, 70))
+        self.assertEqual(report["status"], "aborted")
+        self.assertEqual(report["error_kind"], "production_safety_violation")
+        self.assertEqual(report["preflight_failure_stage"], "dns_pinning")
+        self.assertTrue(report["report_valid"])
+
+    def test_preflight_failure_status_must_match_remote_exit(self) -> None:
+        wire = self.make_preflight_failure_wire("pull_go_image", status=70)
+        report = report_wire.parse_report(self.args(wire, 71))
+        self.assertEqual(report["error_kind"], "production_safety_violation")
+        self.assertFalse(report["report_valid"])
+
+    def test_preflight_failure_without_baseline_fails_closed_as_safety(self) -> None:
+        wire = self.make_preflight_failure_wire("inventory", baseline="none")
+        report = report_wire.parse_report(self.args(wire, 71))
+        self.assertEqual(report["status"], "aborted")
+        self.assertEqual(report["error_kind"], "production_safety_violation")
+        self.assertFalse(report["report_valid"])
 
     def test_byte_imbalance_is_inconclusive_not_correctness_failure(self) -> None:
         report = report_wire.parse_report(

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -1123,6 +1123,25 @@ test("fleet benchmark workflow is bounded, isolated, and uses the reviewed wire 
   );
   assert.match(
     goSitemapFleetWorkflow,
+    /printf 'PREFLIGHT_FAILURE\\t%s\\t%s\\t%s\\n'/,
+  );
+  assert.match(goSitemapFleetWorkflow, /status != 0 && meta_emitted == 0/);
+  assert.match(goSitemapFleetWorkflow, /meta_emitted=1/);
+  for (const stage of [
+    "inventory",
+    "protected_services",
+    "host_resources_before_pull",
+    "pull_go_image",
+    "pull_python_image",
+    "host_resources_after_pull",
+    "image_attestation",
+    "schedule_validation",
+    "dns_pinning",
+  ]) {
+    assert.match(goSitemapFleetWorkflow, new RegExp(`preflight_stage=${stage}`));
+  }
+  assert.match(
+    goSitemapFleetWorkflow,
     /\.status == "succeeded" and \.report_valid == true and \.timing_comparable == true/,
   );
 });


### PR DESCRIPTION
## Outcome

Retain the exact preflight stage when the bounded Go/Python fleet benchmark exits before RUN_META, without retaining raw remote stderr.

Run 34362982879 cleaned up successfully but produced no metadata or arms. The old parser necessarily treated any such failure as a production-safety violation because no protected baseline digest survived, so it could not distinguish exit 70 from an ordinary exit 71 infrastructure failure.

## Change

- successful RUN_META wire protocol remains unchanged
- remote EXIT cleanup emits exactly one PREFLIGHT_FAILURE record only for nonzero pre-metadata exits
- record fields are limited to an allowlisted stage, matching exit status, and protected-service SHA-256 or none
- parser accepts only an exact one-line failure shape
- exit 71 is infrastructure only when cleanup succeeds and independent postflight matches the retained baseline
- exit 70, malformed evidence, missing baseline, cleanup failure, or digest mismatch remains fail-closed production safety

## Verification

- report-wire tests: 19/19
- workflow contract tests: 83/83
- actionlint
- Ruff lint and format
- Pyright
- git diff --check
- independent protocol critic: approved, no blockers

Refs #8648