### PR TITLE
Wait for quiet fleet benchmark host

### DIFF
--- a/.github/workflows/crawler-sitemap-fleet-benchmark.yml
+++ b/.github/workflows/crawler-sitemap-fleet-benchmark.yml
@@ -430,22 +430,42 @@ jobs:
             [[ "$available" =~ ^[0-9]+$ && "$free" =~ ^[0-9]+$ && "$load" =~ ^[0-9]+([.][0-9]+)?$ ]] || return 1
             printf '%s|%s|%s\n' "$available" "$free" "$load"
           }
+          wait_for_quiet_host() {
+            local attempt resources available free load
+            for attempt in {1..13}; do
+              resources="$(host_resources)" || return 2
+              IFS='|' read -r available free load <<<"$resources"
+              (( available >= 1572864 && free >= 5242880 )) || return 2
+              if awk -v value="$load" 'BEGIN { exit !(value <= 1.50) }'; then
+                printf '%s\n' "$resources"
+                return 0
+              fi
+              (( attempt == 13 )) || sleep 5
+            done
+            return 1
+          }
           preflight_stage=host_resources_before_pull
           docker_root_dir="$(timeout 20s docker info --format '{{.DockerRootDir}}' 2>/dev/null)" || exit 70
           [[ "$docker_root_dir" == /* && "$docker_root_dir" != / ]] || exit 70
-          resources_before_pull="$(host_resources)" || exit 70
+          set +e
+          resources_before_pull="$(wait_for_quiet_host)"
+          capacity_status=$?
+          set -e
+          (( capacity_status == 0 )) || { (( capacity_status == 2 )) && exit 70 || exit 71; }
           IFS='|' read -r mem_before_pull disk_before_pull load_before_pull <<<"$resources_before_pull"
-          (( mem_before_pull >= 1572864 && disk_before_pull >= 5242880 )) || exit 70
-          awk -v load="$load_before_pull" 'BEGIN { exit !(load <= 1.50) }' || exit 71
+          [[ "$(snapshot_protected_services)" == "$protected_base" ]] || exit 70
           preflight_stage=pull_go_image
           DOCKER_CONFIG="$docker_config" timeout 300s docker pull "$go_ref" >/dev/null 2>&1 || exit 71
           preflight_stage=pull_python_image
           DOCKER_CONFIG="$docker_config" timeout 300s docker pull "$python_ref" >/dev/null 2>&1 || exit 71
           preflight_stage=host_resources_after_pull
-          resources_after_pull="$(host_resources)" || exit 70
+          set +e
+          resources_after_pull="$(wait_for_quiet_host)"
+          capacity_status=$?
+          set -e
+          (( capacity_status == 0 )) || { (( capacity_status == 2 )) && exit 70 || exit 71; }
           IFS='|' read -r mem_after_pull disk_after_pull load_after_pull <<<"$resources_after_pull"
-          (( mem_after_pull >= 1572864 && disk_after_pull >= 5242880 )) || exit 70
-          awk -v load="$load_after_pull" 'BEGIN { exit !(load <= 1.50) }' || exit 71
+          [[ "$(snapshot_protected_services)" == "$protected_base" ]] || exit 70
           preflight_stage=image_attestation
           [[ "$(uname -m)" == aarch64 ]] || exit 71
           [[ "$(timeout 20s docker image inspect --format '{{.Os}}|{{.Architecture}}' "$go_ref" 2>/dev/null)" == 'linux|arm64' ]] || exit 71

--- a/pilots/go-http-sitemap/FLEET-BENCHMARK.md
+++ b/pilots/go-http-sitemap/FLEET-BENCHMARK.md
@@ -29,6 +29,11 @@ not change the authoritative worker, queue, database, exporter, or publisher.
 - Each arm is limited to 1 CPU, 1 GiB total memory with no additional swap,
   128 PIDs, and 256 file descriptors. Containers are non-root, read-only,
   capability-free, and run one at a time on the allocated Murmur machine.
+- Before and after image pulls, Murmur must provide at least 1.5 GiB available
+  memory, 5 GiB Docker storage, and a one-minute load average no greater than
+  1.50. At each gate, the workflow waits up to 60 seconds for transient load to
+  fall below that unchanged ceiling and rechecks protected services before
+  continuing.
 - Every job permits exactly one GET, no retry, redirect, proxy, or sitemap-index
   expansion. Requests use `Accept-Encoding: identity`; decoded response and
   aggregate byte caps remain enforced.

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -1140,6 +1140,15 @@ test("fleet benchmark workflow is bounded, isolated, and uses the reviewed wire 
   ]) {
     assert.match(goSitemapFleetWorkflow, new RegExp(`preflight_stage=${stage}`));
   }
+  assert.match(goSitemapFleetWorkflow, /wait_for_quiet_host\(\)/);
+  assert.match(goSitemapFleetWorkflow, /for attempt in \{1\.\.13\}/);
+  assert.match(goSitemapFleetWorkflow, /value <= 1\.50/);
+  assert.match(goSitemapFleetWorkflow, /attempt == 13 \)\) \|\| sleep 5/);
+  assert.equal(
+    (goSitemapFleetWorkflow.match(/resources_(?:before|after)_pull="\$\(wait_for_quiet_host\)"/g) ?? [])
+      .length,
+    2,
+  );
   assert.match(
     goSitemapFleetWorkflow,
     /\.status == "succeeded" and \.report_valid == true and \.timing_comparable == true/,


### PR DESCRIPTION
## Outcome

Keep the Murmur safety ceilings unchanged while allowing the manual fleet benchmark to wait through transient host load.

The diagnostic run 34366886211 proved that the previous attempt stopped at host_resources_before_pull because one-minute load briefly exceeded 1.50. It stopped before image pulls and before source requests.

## Change

- sample host capacity up to 13 times, five seconds apart, at each preflight capacity gate
- proceed only when available RAM is at least 1.5 GiB, Docker storage is at least 5 GiB, and load1 is at most 1.50
- fail immediately as a safety failure on probe, RAM, or disk faults
- retain persistent high load as an infrastructure failure
- re-verify protected Murmur services after every wait

## Verification

- independent production-safety review: approved, no blockers
- actionlint
- workflow tests: 83 passed
- report-wire tests: 19 passed
- mocked shell cases for success, persistent load, low RAM/disk, and probe failure
- git diff --check

Refs #8648