### PR TITLE
Remove Python-only fleet benchmark prework

### DIFF
--- a/.github/workflows/crawler-sitemap-fleet-benchmark.yml
+++ b/.github/workflows/crawler-sitemap-fleet-benchmark.yml
@@ -593,7 +593,7 @@ jobs:
           import json, os
           data = json.load(open(os.environ["RAW_FILE"], encoding="utf-8"))
           source_denied = {"tdm_reserved", "http_tdm_reservation"}
-          egress_denied = {"ssrf_refused", "target_rejected", "host_pin_invalid", "http_network_policy"}
+          egress_denied = {"ssrf_refused", "target_rejected", "http_network_policy"}
           kinds = {data.get("error_kind")}
           for round_report in data.get("rounds", []):
               kinds.add(round_report.get("error_kind"))

--- a/pilots/go-http-sitemap/FLEET-BENCHMARK.md
+++ b/pilots/go-http-sitemap/FLEET-BENCHMARK.md
@@ -41,9 +41,12 @@ not change the authoritative worker, queue, database, exporter, or publisher.
 The full schedule makes at most 3,840 source GETs: 30 pairs x 2 runtimes x 2
 rounds x 32 origins, or 120 GETs per origin. DNS is resolved once before the
 schedule, restricted to public addresses that are not Murmur, and the exact
-same singleton host pins are injected into both runtimes. No crawler secrets,
-volumes, Docker socket, Redis, Postgres, R2, Typesense, or Lightpanda endpoint
-are available to either container.
+same singleton host pins are injected into both runtimes. There is no
+benchmark-only in-container DNS fanout before the measured rounds: Python
+validates each request and Go validates each dial against those pinned public
+answers on their normal transport paths. No crawler secrets, volumes, Docker
+socket, Redis, Postgres, R2, Typesense, or Lightpanda endpoint are available to
+either container.
 
 ## Admission and interpretation
 
@@ -58,11 +61,29 @@ scaling. Per-pair, per-round decoded-byte deltas are always disclosed. Timing
 is comparable only when every aggregate Go/Python byte delta is at most 5%; a
 larger difference leaves the artifact valid but makes the performance result
 `inconclusive_workload_imbalance`. It does not invalidate count/hash parity or
-trigger more source requests. `ru_maxrss` and cgroup `memory.peak` are lifetime high-water values,
-not phase-specific incremental memory. If neither runtime approaches 1 GiB,
-the result demonstrates headroom for this slice, not the production RAM
-ceiling. Per-arm p99 across 32 jobs is effectively a maximum and is descriptive
-only.
+trigger more source requests. `ru_maxrss` and cgroup `memory.peak` are lifetime
+high-water values, not phase-specific incremental memory. If neither runtime
+approaches 1 GiB, the result demonstrates headroom for this slice, not the
+production RAM ceiling. Per-arm p99 across 32 jobs is effectively a maximum
+and is descriptive only.
+
+The Go density case is admitted only when all 60 arms succeed, every paired
+round has identical non-empty count and digest, no policy, OOM, container, or
+resource invariant fails, and all aggregate byte deltas remain within 5%.
+Collapse each arm's cold and warm rounds deterministically: throughput is
+`64,000 / sum(round run_duration_ms)` jobs/second, CPU/job is
+`sum(round cpu_user_ms + cpu_system_ms) / 64`, and density is arm throughput
+divided by arm `cgroup_memory_peak_bytes`. For each schedule pair, divide the
+Go arm metric by its Python arm metric; each thresholded profile result is the
+median of its six paired ratios. At both `c12` and `c16`, median paired density
+must be at least 1.25, at least five of six density ratios must be greater than
+1.0, and the median of the six paired Go/Python cgroup-peak ratios must be no
+more than 0.85. Median paired throughput must be at least 0.90 at `c5`, `c12`,
+and `c16`; median paired CPU/job must be no more than 1.25 at `c12` and `c16`.
+Finally, the median of the six Go arm throughputs at `c16` must be at least 1.5
+times the median of the six Go arm throughputs at `c5`. A valid parity result
+that misses any threshold remains useful correctness evidence but does not
+establish a RAM-density advantage or authorize a resident shadow.
 
 A repeatable Go density advantage authorizes continued work on a long-lived,
 continuously fed Go worker with bounded global and per-origin permits. It does

--- a/pilots/go-http-sitemap/python_shadow/runner.py
+++ b/pilots/go-http-sitemap/python_shadow/runner.py
@@ -17,7 +17,6 @@ import ipaddress
 import json
 import re
 import resource
-import socket
 import ssl
 import stat
 import struct
@@ -44,7 +43,6 @@ REQUEST_TIMEOUT_SECONDS = 20
 JOB_TIMEOUT_SECONDS = 25
 ROUND_TIMEOUT_SECONDS = 90
 PROCESS_TIMEOUT_SECONDS = 210
-HOST_PIN_TIMEOUT_SECONDS = 5
 MAX_FILE_DESCRIPTORS = 256
 ROUNDS = 2
 ALLOWED_CONCURRENCY = (2, 4, 5, 8, 12, 16)
@@ -100,10 +98,6 @@ class SitemapIndexRejectedError(RuntimeError):
 
 
 class EmptyResultError(RuntimeError):
-    pass
-
-
-class HostPinError(RuntimeError):
     pass
 
 
@@ -384,7 +378,6 @@ def _safe_error_kind(exc: BaseException) -> str:
         ("ContentEncodingRejectedError", "content_encoding_rejected"),
         ("SitemapIndexRejectedError", "sitemap_index_rejected"),
         ("EmptyResultError", "empty_result"),
-        ("HostPinError", "host_pin_invalid"),
         ("TimeoutError", "deadline"),
         ("HTTPError", "http_transport"),
         ("ParseError", "xml"),
@@ -424,38 +417,6 @@ def _load_runtime():
     from src.shared import tdm as production_tdm
 
     return httpx, certifi, production_monitor, production_sitemap, production_ssrf, production_tdm
-
-
-def _public_host_pin(job: Job, production_ssrf) -> str:
-    host = urlparse(job.sitemap_url).hostname
-    assert host is not None
-    try:
-        infos = socket.getaddrinfo(host, 443, type=socket.SOCK_STREAM)
-        addresses = {
-            str(sockaddr[0]).split("%", 1)[0]
-            for family, _socktype, _proto, _canonname, sockaddr in infos
-            if family in (socket.AF_INET, socket.AF_INET6)
-        }
-        chosen = production_ssrf._public_address_from_infos(job.sitemap_url, host, infos)
-    except Exception as exc:
-        raise HostPinError from exc
-    # The workflow installs exactly one validated address per hostname in the
-    # container's /etc/hosts. Requiring a single result proves that httpx's
-    # subsequent resolver call is constrained to that same pinned address.
-    if len(addresses) != 1 or chosen not in addresses:
-        raise HostPinError
-    return chosen
-
-
-async def _validate_host_pins(jobs: tuple[Job, ...], production_ssrf) -> None:
-    semaphore = asyncio.Semaphore(8)
-
-    async def validate(job: Job) -> None:
-        async with semaphore:
-            async with asyncio.timeout(HOST_PIN_TIMEOUT_SECONDS):
-                await asyncio.to_thread(_public_host_pin, job, production_ssrf)
-
-    await asyncio.gather(*(validate(job) for job in jobs))
 
 
 class ExactTargetTransport:
@@ -759,7 +720,6 @@ async def run(
                 production_ssrf,
                 production_tdm,
             ) = _load_runtime()
-            await _validate_host_pins(manifest.jobs, production_ssrf)
 
             context = ssl.create_default_context(cafile=certifi.where())
             context.options |= ssl.OP_NO_TICKET

--- a/pilots/go-http-sitemap/python_shadow/test_runner.py
+++ b/pilots/go-http-sitemap/python_shadow/test_runner.py
@@ -7,7 +7,6 @@ import hashlib
 import http.cookiejar
 import io
 import json
-import socket
 import struct
 import sys
 import unittest
@@ -28,7 +27,6 @@ from runner import (
     AttemptLimitError,
     ConnectionProbe,
     ExactTargetTransport,
-    HostPinError,
     ManifestError,
     ResponseBodyTooLargeError,
     RoundMeter,
@@ -40,7 +38,6 @@ from runner import (
     _fetch_and_extract,
     _final_invariants_valid,
     _monitor_config,
-    _public_host_pin,
     _RejectAllCookiePolicy,
     _run_round,
     canonical_url_sha256,
@@ -442,37 +439,6 @@ class FetchSafetyTests(unittest.IsolatedAsyncioTestCase):
             await self.fetch(index)
 
 
-class HostPinTests(unittest.TestCase):
-    def setUp(self) -> None:
-        self.job = decode_manifest(manifest_bytes()).jobs[0]
-        from src.shared import ssrf
-
-        self.ssrf = ssrf
-
-    @staticmethod
-    def infos(*addresses: str) -> list[tuple]:
-        return [
-            (socket.AF_INET, socket.SOCK_STREAM, 6, "", (address, 443)) for address in addresses
-        ]
-
-    def test_exactly_one_public_hosts_entry_is_admitted(self) -> None:
-        with mock.patch("socket.getaddrinfo", return_value=self.infos("93.184.216.34")):
-            self.assertEqual(_public_host_pin(self.job, self.ssrf), "93.184.216.34")
-
-    def test_mixed_multi_answer_and_private_results_are_rejected(self) -> None:
-        for addresses in (
-            ("93.184.216.34", "93.184.216.35"),
-            ("93.184.216.34", "10.0.0.5"),
-            ("127.0.0.1",),
-        ):
-            with (
-                self.subTest(addresses=addresses),
-                mock.patch("socket.getaddrinfo", return_value=self.infos(*addresses)),
-                self.assertRaises(HostPinError),
-            ):
-                _public_host_pin(self.job, self.ssrf)
-
-
 class ConnectionProbeTests(unittest.IsolatedAsyncioTestCase):
     async def test_pinned_httpcore_pool_open_waiter_and_close_shape(self) -> None:
         import httpcore
@@ -704,10 +670,13 @@ class RoundTests(unittest.IsolatedAsyncioTestCase):
                 await task
         self.assertEqual(meter.in_flight, 0)
 
-    async def test_process_deadline_with_zero_rounds_returns_structural_failure(
+    async def test_process_deadline_has_no_eager_dns_fanout_and_is_structural(
         self,
     ) -> None:
         manifest = decode_manifest(manifest_bytes())
+        import certifi
+
+        from src.shared import ssrf
 
         async def never_finishes(*args, **kwargs):
             del args, kwargs
@@ -716,9 +685,13 @@ class RoundTests(unittest.IsolatedAsyncioTestCase):
         with (
             mock.patch(
                 "runner._load_runtime",
-                return_value=(None, None, None, None, object(), None),
+                return_value=(httpx, certifi, object(), object(), ssrf, object()),
             ),
-            mock.patch("runner._validate_host_pins", side_effect=never_finishes),
+            mock.patch("runner._run_round", side_effect=never_finishes),
+            mock.patch(
+                "src.shared.ssrf.socket.getaddrinfo",
+                side_effect=AssertionError("unexpected eager DNS validation"),
+            ),
             mock.patch("runner.PROCESS_TIMEOUT_SECONDS", 0.01),
         ):
             report = await run(manifest, "0" * 64, "c5", 5)

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -1149,6 +1149,16 @@ test("fleet benchmark workflow is bounded, isolated, and uses the reviewed wire 
       .length,
     2,
   );
+  assert.ok(
+    (goSitemapFleetWorkflow.match(/len\(hosts\) != 32 or len\(set\(hosts\)\) != 32/g) ?? [])
+      .length >= 2,
+  );
+  assert.match(
+    goSitemapFleetWorkflow,
+    /any\(unsafe\(address\) or address in excluded for address in answers\)/,
+  );
+  assert.match(goSitemapFleetWorkflow, /add_host_args\+=\(--add-host "\$host:\$address"\)/);
+  assert.match(goSitemapFleetWorkflow, /host\.get\("ExtraHosts"\) == expected_hosts/);
   assert.match(
     goSitemapFleetWorkflow,
     /\.status == "succeeded" and \.report_valid == true and \.timing_comparable == true/,


### PR DESCRIPTION
## Outcome

Make the Go/Python fleet RAM comparison fair before the next Murmur run.

The Python comparator eagerly resolved all 32 pinned hosts through up to eight asyncio worker threads before either measured round. Those executor threads persisted while lifetime RSS and cgroup peak were sampled. Go had no equivalent benchmark-only phase, so earlier RAM evidence is directional only.

## Change

- remove only the Python eager pre-round DNS fanout and its dead taxonomy/tests
- retain workflow resolution of all 32 distinct hosts, public/mixed/protected-address rejection, identical singleton host injection, and exact ExtraHosts attestation
- retain production Python per-request SSRF validation and Go per-dial public-address pinning
- add a regression proving startup reaches the measured round without eager DNS resolution
- predeclare exact paired density, memory, throughput, CPU, and scaling formulas and thresholds before running

## Decision

This is necessary methodology correction, not worker redesign. Equivalent Go prewarming, a new machine, new phase metrics, queue integration, or a larger benchmark matrix remain out of scope.

## Verification

- independent methodology audit and independent safety/quality review: approved
- Python comparator: 29 tests plus 47 subtests passed
- report-wire: 19 tests passed
- Ruff check and format, Pyright: passed
- workflow tests: 83 passed
- actionlint and diff-check: passed
- Go test, race detector, vet, and module-tidiness check: passed

Refs #8648
Refs #7935