### PR TITLE
Fix fleet benchmark log rotation

### DIFF
--- a/.github/workflows/crawler-sitemap-fleet-benchmark.yml
+++ b/.github/workflows/crawler-sitemap-fleet-benchmark.yml
@@ -564,7 +564,7 @@ jobs:
               host.get("CapDrop") == ["ALL"], not host.get("CapAdd"),
               sorted(host.get("SecurityOpt") or []) == ["no-new-privileges:true"],
               host.get("Ulimits") == [{"Name": "nofile", "Hard": 256, "Soft": 256}],
-              host.get("LogConfig") == {"Type": "local", "Config": {"max-size": "256k", "max-file": "1"}},
+              host.get("LogConfig") == {"Type": "local", "Config": {"compress": "false", "max-file": "1", "max-size": "256k"}},
               host.get("ExtraHosts") == expected_hosts, config.get("Env") == image["Config"].get("Env"),
           ]
           raise SystemExit(0 if all(checks) else 1)
@@ -658,7 +658,7 @@ jobs:
               set +e
               timeout --signal=TERM --kill-after=5s 30s docker create \
                 --name "$name" --cidfile "$cid_file" --label "$label_key=$label_value" \
-                --log-driver local --log-opt max-size=256k --log-opt max-file=1 \
+                --log-driver local --log-opt max-size=256k --log-opt max-file=1 --log-opt compress=false \
                 --read-only --network bridge "${add_host_args[@]}" --security-opt no-new-privileges:true \
                 --cap-drop ALL --pids-limit 128 --ulimit nofile=256:256 --cpus 1 --memory 1g \
                 --memory-swap 1g --user 65532:65532 "$image_ref" --profile "$profile" \

--- a/pilots/go-http-sitemap/FLEET-BENCHMARK.md
+++ b/pilots/go-http-sitemap/FLEET-BENCHMARK.md
@@ -28,7 +28,8 @@ not change the authoritative worker, queue, database, exporter, or publisher.
   inside a container are correlated observations, not independent samples.
 - Each arm is limited to 1 CPU, 1 GiB total memory with no additional swap,
   128 PIDs, and 256 file descriptors. Containers are non-root, read-only,
-  capability-free, and run one at a time on the allocated Murmur machine.
+  capability-free, and run one at a time on the allocated Murmur machine. The
+  local log driver keeps one uncompressed 256 KiB file per ephemeral arm.
 - Before and after image pulls, Murmur must provide at least 1.5 GiB available
   memory, 5 GiB Docker storage, and a one-minute load average no greater than
   1.50. At each gate, the workflow waits up to 60 seconds for transient load to

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -1082,6 +1082,14 @@ test("fleet benchmark workflow is bounded, isolated, and uses the reviewed wire 
   assert.match(goSitemapFleetWorkflow, /--memory-swap 1g --user 65532:65532/);
   assert.match(
     goSitemapFleetWorkflow,
+    /--log-driver local --log-opt max-size=256k --log-opt max-file=1 --log-opt compress=false/,
+  );
+  assert.match(
+    goSitemapFleetWorkflow,
+    /"Config": \{"compress": "false", "max-file": "1", "max-size": "256k"\}/,
+  );
+  assert.match(
+    goSitemapFleetWorkflow,
     /remote_docker_config="\/tmp\/jobseek-sitemap-fleet-auth\.\$owner"/,
   );
   assert.match(


### PR DESCRIPTION
## Outcome

Allow the already-attested fleet containers to start on Murmur without changing any workload or safety limit.

Exact-main run 34371719580 reached the first Go c2 arm, created and attested the container, then Docker left it in created state with exit 128. Cleanup and protected-service checks passed.

A no-request reproduction using the retained successful ARM64 scratch canary image and every fleet Docker option produced the exact daemon error: the local log driver cannot enable compression when max-file is 1. Adding compress=false made the same control start successfully and exit at its intentionally rejected argument before network use.

## Change

- keep one local 256 KiB log file and explicitly disable compression
- attest the exact Docker LogConfig, including compress=false
- document and test the bound

No retries, safety gates, resource caps, isolation, workload, runtime, production services, or cleanup behavior change.

## Verification

- independent production-safety review: approved
- exact no-request Murmur control with corrected config: started successfully
- protected Murmur services unchanged and all diagnostic containers cleaned
- workflow tests: 83 passed
- actionlint and diff-check: passed

Refs #8648