### PR TITLE
Fix fleet benchmark terminal validation

### DIFF
--- a/.github/workflows/crawler-sitemap-fleet-benchmark.yml
+++ b/.github/workflows/crawler-sitemap-fleet-benchmark.yml
@@ -284,7 +284,7 @@ jobs:
                 label_key=org.colophon.jobseek.fleet-benchmark.owner
                 [[ "$owner" =~ ^[A-Za-z0-9]+$ ]] || exit 70
                 [[ "$auth_path" == "/tmp/jobseek-sitemap-fleet-auth.$owner" ]] || exit 70
-                mapfile -t ids < <(timeout 20s docker ps -aq --filter "label=${label_key}=${owner}" 2>/dev/null || true)
+                mapfile -t ids < <(timeout 20s docker ps -aq --no-trunc --filter "label=${label_key}=${owner}" 2>/dev/null || true)
                 for id in "${ids[@]}"; do
                   [[ "$id" =~ ^[0-9a-f]{64}$ ]] && timeout 20s docker rm -f "$id" >/dev/null 2>&1 || true
                 done
@@ -359,7 +359,7 @@ jobs:
                 "$preflight_stage" "$status" "${protected_sha256:-none}" || true
             fi
             if (( cleanup_armed )); then
-              mapfile -t owned_ids < <(timeout 20s docker ps -aq --filter "label=${label_key}=${label_value}" 2>/dev/null || true)
+              mapfile -t owned_ids < <(timeout 20s docker ps -aq --no-trunc --filter "label=${label_key}=${label_value}" 2>/dev/null || true)
               for candidate_id in "${owned_ids[@]}"; do
                 [[ "$candidate_id" =~ ^[0-9a-f]{64}$ ]] && timeout 20s docker rm -f "$candidate_id" >/dev/null 2>&1 || true
               done
@@ -556,7 +556,8 @@ jobs:
           checks = [
               config["Image"] == os.environ["IMAGE_REF"], config["User"] == "65532:65532",
               config["Labels"].get(os.environ["LABEL_KEY"]) == os.environ["LABEL_VALUE"],
-              container["Args"] == ["--profile", os.environ["PROFILE"]], host["ReadonlyRootfs"] is True,
+              config.get("Entrypoint") == image["Config"].get("Entrypoint"),
+              config.get("Cmd") == ["--profile", os.environ["PROFILE"]], host["ReadonlyRootfs"] is True,
               host["NetworkMode"] == "bridge", host["NanoCpus"] == 1_000_000_000,
               host["Memory"] == 1_073_741_824, host["MemorySwap"] == 1_073_741_824,
               host["PidsLimit"] == 128, not host.get("Binds"), not container.get("Mounts"),

--- a/pilots/go-http-sitemap/FLEET-BENCHMARK.md
+++ b/pilots/go-http-sitemap/FLEET-BENCHMARK.md
@@ -98,6 +98,10 @@ The manual `crawler-sitemap-fleet-benchmark.yml` workflow is dispatchable only
 from merged `main`. It builds immutable ARM64 images for both runtimes, pins
 them by digest, verifies protected Murmur services before and after every arm,
 and uploads one sanitized JSON artifact even when a benchmark arm fails.
+Each container's inherited image entrypoint and explicit profile command are
+attested separately so the Go and Python image layouts receive the same check.
+Cleanup discovers exact-owned containers by their full 64-character IDs before
+removal; it does not act on unrelated containers.
 Production-safety invariant failures stop the schedule immediately.
 If preflight fails before `RUN_META`, the remote cleanup trap emits exactly one
 record containing an allowlisted stage name, the exit status, and the protected-

--- a/pilots/go-http-sitemap/benchmark/benchmark.go
+++ b/pilots/go-http-sitemap/benchmark/benchmark.go
@@ -415,16 +415,22 @@ func Run(ctx context.Context, started time.Time, manifest Manifest, manifestSHA2
 		ProcessCurrentRSSBytes: readCurrentRSS(),
 		OpenFDs:                readOpenFDs(),
 	}
-	report.CgroupMemoryPeakBytes = readCgroupMemoryPeak()
-	report.CgroupMemoryCurrentBytes = readCgroupValue("memory.current")
-	report.CgroupOOMEvents = readCgroupEvent("oom")
 	expected := uint64(len(manifest.Jobs) * roundsPerProcess)
-	if failed != 0 || len(report.Rounds) != roundsPerProcess || stats.Accepted != expected || stats.Completed != expected || stats.Panics != 0 || stats.Queued != 0 || stats.InFlight != 0 || stats.MaxInFlight != int64(concurrency) || connections.Open != 0 || connections.InUsePermits != 0 || connections.Waiters != 0 || connections.PermitLimit != maxConnections || connections.MaximumOpen > maxConnections || !report.resourceMetricsValid() {
+	return finishCompletedRun(finish, func(report Report) bool {
+		return failed == 0 && len(report.Rounds) == roundsPerProcess && stats.Accepted == expected && stats.Completed == expected && stats.Panics == 0 && stats.Queued == 0 && stats.InFlight == 0 && stats.MaxInFlight == int64(concurrency) && connections.Open == 0 && connections.InUsePermits == 0 && connections.Waiters == 0 && connections.PermitLimit == maxConnections && connections.MaximumOpen <= maxConnections && report.resourceMetricsValid()
+	})
+}
+
+// finishCompletedRun captures terminal metrics before applying the final gate,
+// and returns the exact captured report that the gate evaluated.
+func finishCompletedRun(capture func() Report, valid func(Report) bool) Report {
+	report := capture()
+	if !valid(report) {
 		report.ErrorKind = "final_invariant"
-		return finish()
+		return report
 	}
 	report.Status = "succeeded"
-	return finish()
+	return report
 }
 
 func runRound(parent context.Context, pool *worker.Pool, manifest Manifest, round int, state string, expectedConcurrency int) RoundReport {

--- a/pilots/go-http-sitemap/benchmark/benchmark_test.go
+++ b/pilots/go-http-sitemap/benchmark/benchmark_test.go
@@ -244,3 +244,20 @@ func TestResourceMetricsMustBePresentBoundedAndLeakFree(t *testing.T) {
 		t.Fatal("cgroup OOM unexpectedly accepted")
 	}
 }
+
+func TestCompletedRunCapturesBeforeTerminalValidation(t *testing.T) {
+	order := make([]string, 0, 2)
+	report := finishCompletedRun(func() Report {
+		order = append(order, "capture")
+		return Report{ProcessMaxRSSBytes: 64 << 20, Status: "failed"}
+	}, func(report Report) bool {
+		order = append(order, "validate")
+		return report.ProcessMaxRSSBytes > 0
+	})
+	if report.Status != "succeeded" || report.ProcessMaxRSSBytes != 64<<20 {
+		t.Fatalf("completed report=%+v", report)
+	}
+	if got := strings.Join(order, ","); got != "capture,validate" {
+		t.Fatalf("terminal order=%q, want capture,validate", got)
+	}
+}

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -1090,6 +1090,34 @@ test("fleet benchmark workflow is bounded, isolated, and uses the reviewed wire 
   );
   assert.match(
     goSitemapFleetWorkflow,
+    /config\.get\("Entrypoint"\) == image\["Config"\]\.get\("Entrypoint"\)/,
+  );
+  assert.match(
+    goSitemapFleetWorkflow,
+    /config\.get\("Cmd"\) == \["--profile", os\.environ\["PROFILE"\]\]/,
+  );
+  assert.doesNotMatch(
+    goSitemapFleetWorkflow,
+    /container\["Args"\] == \["--profile", os\.environ\["PROFILE"\]\]/,
+  );
+  assert.equal(
+    (
+      goSitemapFleetWorkflow.match(
+        /docker ps -aq --no-trunc --filter "label=\$\{label_key\}=\$\{(?:owner|label_value)\}"/g,
+      ) ?? []
+    ).length,
+    2,
+  );
+  assert.equal(
+    (
+      goSitemapFleetWorkflow.match(
+        /\[\[ "\$(?:id|candidate_id)" =~ \^\[0-9a-f\]\{64\}\$ \]\]/g,
+      ) ?? []
+    ).length,
+    2,
+  );
+  assert.match(
+    goSitemapFleetWorkflow,
     /remote_docker_config="\/tmp\/jobseek-sitemap-fleet-auth\.\$owner"/,
   );
   assert.match(


### PR DESCRIPTION
Refs #8648.

Run 34374343660 reached the real Go workload and completed all 64 jobs with every worker, request, connection, FD, and OOM invariant satisfied. It then failed for three deterministic harness reasons fixed here:

- Capture terminal process/cgroup metrics before validating them, and return the exact snapshot used by the gate.
- Attest the inherited image entrypoint and explicit profile command separately, which is correct for both the Go and Python image layouts.
- Request full Docker IDs for exact-owner cleanup so the existing 64-hex guard can remove created-but-not-started arms.

The patch does not change workloads, source cohort, network policy, resource limits, concurrency profiles, admission thresholds, or protected-service checks.

Regression coverage includes an ordering-sensitive Go finalization seam and workflow contract assertions for both corrected attestation and both cleanup paths.

Verified locally:
- go test ./...
- go test -race ./...
- go vet ./...
- go mod tidy -diff
- actionlint .github/workflows/crawler-sitemap-fleet-benchmark.yml
- node --test scripts/ci-workflow.test.mjs (83/83)
- Python comparator/report unit tests
- ruff check and format --check
- repository CI Pyright command
- git diff --check

Independent critics approved the Go/control-flow lane and workflow/safety lane after one inadequate-test blocker was corrected.