### PR TITLE
Compose bounded Go admission before claim

### DIFF
--- a/pilots/go-http-sitemap/README.md
+++ b/pilots/go-http-sitemap/README.md
@@ -62,6 +62,40 @@ bounded admission/results, origin-fair dispatch, task deadlines, panic
 containment, and bounded shutdown cancellation. Its fixed-resource comparison
 method is frozen in [WORKER-BENCHMARK.md](WORKER-BENCHMARK.md).
 
+The additive `admission` package is an inactive, dependency-injected
+claim-boundary proof with a hermetic real HTTP/sitemap composition test. Its
+private processor adapter enters the injected claim operation only
+after `worker.Pool` assigns both a worker and an origin slot; callers cannot
+bypass the pool through a public `Process` method. `Candidate` requires the
+exact `crawler.runtime/v1` discriminator and snapshots the complete normalized
+sitemap config plus the identity/revision/fingerprint subset of runtime-v1
+`BoardManifest`. `sitemap.NormalizeConfig` is the single pure validation and
+defaulting seam used by both admission and execution, so their attempted
+request count/backoff and every other config value cannot drift.
+
+The injected claim grant keeps its local candidate digest separate from the
+opaque 32-byte runtime-v1 fence digest. Its immutable `Fence` adds local task
+and board bindings to the seven losslessly mapped runtime-v1 `FencingContext`
+fields: shard, routing epoch, Go engine owner, config revision, claim token,
+lease ID, and fence digest. Server time, lease-until time, and the monotonic
+claim-request start stay outside fence identity so a future lease supervisor
+can derive a conservative deadline without comparing server and worker wall
+clocks. Supervisor handles, execution, and terminal publication must echo and
+exactly compare the fence. A future authoritative terminal adapter must compare
+that entire fence and the candidate's manifest revision/fingerprint in the
+same transaction as its mutation; an echo alone never authorizes a write.
+
+Admission and execution contexts remain separate. Cancellation, timeout,
+lease loss, invalid echoes, dependency panic, or supervisor cleanup failure
+suppress terminal mutation. A supervisor is stopped and deadline-joined before
+any terminal attempt. Closing starts the existing bounded worker drain,
+cancels and joins any claim already in progress, and prevents queued or later
+tasks from starting a claim. Duplicate and stale task rejection deliberately
+belongs to the injected atomic claim operation rather than a second in-memory
+scheduler. There is still no Redis/Lua client, Postgres mutation, retry loop,
+browser/Lightpanda adapter, global cross-process politeness, queue authority,
+workflow, image, or deployment path in this package.
+
 The RAM-density comparison against the production Python sitemap monitor is
 frozen separately in [FLEET-BENCHMARK.md](FLEET-BENCHMARK.md). It uses 32
 distinct production origins and paired `c2` through `c16` profiles without

--- a/pilots/go-http-sitemap/admission/candidate.go
+++ b/pilots/go-http-sitemap/admission/candidate.go
@@ -1,0 +1,163 @@
+package admission
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/colophon-group/jobseek/pilots/go-http-sitemap/sitemap"
+)
+
+var ErrInvalidCandidate = errors.New("invalid admission candidate")
+
+const runtimeV1ContractVersion = "crawler.runtime/v1"
+
+// ManifestIdentity is the narrow local boundary for the identity-bearing
+// fields of runtime-v1 BoardManifest. It is intentionally not a second wire
+// contract. A later runtime-v1 adapter owns full-message validation before it
+// constructs this value.
+type ManifestIdentity struct {
+	ContractVersion   string
+	ManifestID        string
+	BoardID           string
+	CompanyID         string
+	ConfigRevision    string
+	ConfigFingerprint string
+}
+
+// Candidate is an immutable snapshot. Its fields are private and every
+// accessor returns a value copy, so injected phases cannot change what was
+// admitted or the local digest carried separately by ClaimGrant.
+type Candidate struct {
+	taskID   string
+	manifest ManifestIdentity
+	sitemap  sitemap.Config
+	digest   [sha256.Size]byte
+}
+
+// candidateDigestShape has no maps, interfaces, floats, or optional pointer
+// fields. encoding/json therefore gives one stable byte shape for this local
+// inactive proof. It is not a runtime-v1 canonicalization rule.
+type candidateDigestShape struct {
+	TaskID   string                     `json:"task_id"`
+	Manifest candidateManifestDigest    `json:"manifest"`
+	Sitemap  candidateSitemapConfigHash `json:"sitemap"`
+}
+
+type candidateManifestDigest struct {
+	ContractVersion   string `json:"contract_version"`
+	ManifestID        string `json:"manifest_id"`
+	BoardID           string `json:"board_id"`
+	CompanyID         string `json:"company_id"`
+	ConfigRevision    string `json:"config_revision"`
+	ConfigFingerprint string `json:"config_fingerprint"`
+}
+
+type candidateSitemapConfigHash struct {
+	SitemapURL          string `json:"sitemap_url"`
+	IncludeLiteral      string `json:"include_literal"`
+	ExcludeLiteral      string `json:"exclude_literal"`
+	ReplacePrefix       string `json:"replace_prefix"`
+	Replacement         string `json:"replacement"`
+	MaxURLs             int    `json:"max_urls"`
+	MaxIndexChildren    int    `json:"max_index_children"`
+	RootMaxAttempts     int    `json:"root_max_attempts"`
+	RootBackoffNanos    int64  `json:"root_backoff_nanos"`
+	RequireURLSet       bool   `json:"require_url_set"`
+	AllowHTTPForTesting bool   `json:"allow_http_for_testing"`
+}
+
+func NewCandidate(taskID string, manifest ManifestIdentity, config sitemap.Config) (Candidate, error) {
+	stringsToValidate := []string{
+		taskID,
+		manifest.ContractVersion,
+		manifest.ManifestID,
+		manifest.BoardID,
+		manifest.CompanyID,
+		manifest.ConfigRevision,
+		manifest.ConfigFingerprint,
+		config.SitemapURL,
+		config.IncludeLiteral,
+		config.ExcludeLiteral,
+		config.ReplacePrefix,
+		config.Replacement,
+	}
+	for _, value := range stringsToValidate {
+		if !utf8.ValidString(value) {
+			return Candidate{}, ErrInvalidCandidate
+		}
+	}
+	if strings.TrimSpace(taskID) == "" ||
+		manifest.ContractVersion != runtimeV1ContractVersion ||
+		strings.TrimSpace(manifest.ManifestID) == "" ||
+		strings.TrimSpace(manifest.BoardID) == "" ||
+		strings.TrimSpace(manifest.CompanyID) == "" ||
+		strings.TrimSpace(manifest.ConfigRevision) == "" ||
+		strings.TrimSpace(manifest.ConfigFingerprint) == "" ||
+		strings.TrimSpace(config.SitemapURL) == "" {
+		return Candidate{}, ErrInvalidCandidate
+	}
+	normalized, err := sitemap.NormalizeConfig(config)
+	if err != nil {
+		return Candidate{}, ErrInvalidCandidate
+	}
+	config = normalized
+
+	shape := candidateDigestShape{
+		TaskID: taskID,
+		Manifest: candidateManifestDigest{
+			ContractVersion:   manifest.ContractVersion,
+			ManifestID:        manifest.ManifestID,
+			BoardID:           manifest.BoardID,
+			CompanyID:         manifest.CompanyID,
+			ConfigRevision:    manifest.ConfigRevision,
+			ConfigFingerprint: manifest.ConfigFingerprint,
+		},
+		Sitemap: candidateSitemapConfigHash{
+			SitemapURL:          config.SitemapURL,
+			IncludeLiteral:      config.IncludeLiteral,
+			ExcludeLiteral:      config.ExcludeLiteral,
+			ReplacePrefix:       config.ReplacePrefix,
+			Replacement:         config.Replacement,
+			MaxURLs:             config.MaxURLs,
+			MaxIndexChildren:    config.MaxIndexChildren,
+			RootMaxAttempts:     config.RootMaxAttempts,
+			RootBackoffNanos:    int64(config.RootBackoff),
+			RequireURLSet:       config.RequireURLSet,
+			AllowHTTPForTesting: config.AllowHTTPForTesting,
+		},
+	}
+	encoded, err := json.Marshal(shape)
+	if err != nil {
+		return Candidate{}, ErrInvalidCandidate
+	}
+	return Candidate{
+		taskID:   taskID,
+		manifest: manifest,
+		sitemap:  config,
+		digest:   sha256.Sum256(encoded),
+	}, nil
+}
+
+func (candidate Candidate) TaskID() string { return candidate.taskID }
+
+func (candidate Candidate) Manifest() ManifestIdentity { return candidate.manifest }
+
+func (candidate Candidate) Sitemap() sitemap.Config { return candidate.sitemap }
+
+func (candidate Candidate) Digest() [sha256.Size]byte { return candidate.digest }
+
+func (candidate Candidate) valid() bool {
+	return candidate.taskID != "" &&
+		candidate.manifest.ContractVersion == runtimeV1ContractVersion &&
+		candidate.manifest.ManifestID != "" &&
+		candidate.manifest.BoardID != "" &&
+		candidate.manifest.CompanyID != "" &&
+		candidate.manifest.ConfigRevision != "" &&
+		candidate.manifest.ConfigFingerprint != "" &&
+		candidate.sitemap.SitemapURL != "" &&
+		candidate.sitemap.RootBackoff >= 0 &&
+		candidate.digest != ([sha256.Size]byte{})
+}

--- a/pilots/go-http-sitemap/admission/candidate_test.go
+++ b/pilots/go-http-sitemap/admission/candidate_test.go
@@ -1,0 +1,234 @@
+package admission
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/colophon-group/jobseek/pilots/go-http-sitemap/sitemap"
+)
+
+func fixtureManifest(board string) ManifestIdentity {
+	return ManifestIdentity{
+		ContractVersion:   runtimeV1ContractVersion,
+		ManifestID:        "manifest-" + board,
+		BoardID:           board,
+		CompanyID:         "company-1",
+		ConfigRevision:    "revision-7",
+		ConfigFingerprint: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+	}
+}
+
+func fixtureSitemap(rawURL string) sitemap.Config {
+	return sitemap.Config{
+		SitemapURL:          rawURL,
+		IncludeLiteral:      "/jobs/",
+		ExcludeLiteral:      "/archive/",
+		ReplacePrefix:       "https://old.example/",
+		Replacement:         "https://new.example/",
+		MaxURLs:             101,
+		MaxIndexChildren:    7,
+		RootMaxAttempts:     3,
+		RootBackoff:         23 * time.Millisecond,
+		RequireURLSet:       true,
+		AllowHTTPForTesting: true,
+	}
+}
+
+func fixtureCandidate(t *testing.T, taskID, boardID, rawURL string) Candidate {
+	t.Helper()
+	candidate, err := NewCandidate(taskID, fixtureManifest(boardID), fixtureSitemap(rawURL))
+	if err != nil {
+		t.Fatalf("NewCandidate: %v", err)
+	}
+	return candidate
+}
+
+func TestCandidateSnapshotsManifestAndExactSitemapConfig(t *testing.T) {
+	manifest := fixtureManifest("board-1")
+	config := fixtureSitemap("https://one.example/sitemap.xml")
+	candidate, err := NewCandidate("task-1", manifest, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantDigest := candidate.Digest()
+
+	manifest.ManifestID = "mutated"
+	manifest.ConfigRevision = "mutated"
+	config.SitemapURL = "https://mutated.example/sitemap.xml"
+	config.MaxURLs = 1
+	returnedManifest := candidate.Manifest()
+	returnedManifest.ConfigFingerprint = "mutated"
+	returnedConfig := candidate.Sitemap()
+	returnedConfig.IncludeLiteral = "mutated"
+
+	if got := candidate.Manifest(); got != fixtureManifest("board-1") {
+		t.Fatalf("manifest mutated through caller: %#v", got)
+	}
+	if got := candidate.Sitemap(); got != fixtureSitemap("https://one.example/sitemap.xml") {
+		t.Fatalf("sitemap config mutated through caller: %#v", got)
+	}
+	if got := candidate.Digest(); got != wantDigest {
+		t.Fatal("candidate digest changed after external mutation")
+	}
+}
+
+func TestCandidateDigestCoversEverySnapshotField(t *testing.T) {
+	baseManifest := fixtureManifest("board-1")
+	baseConfig := fixtureSitemap("https://one.example/sitemap.xml")
+	base, err := NewCandidate("task-1", baseManifest, baseConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := map[string]func(*string, *ManifestIdentity, *sitemap.Config){
+		"task":           func(task *string, _ *ManifestIdentity, _ *sitemap.Config) { *task = "task-2" },
+		"manifest id":    func(_ *string, manifest *ManifestIdentity, _ *sitemap.Config) { manifest.ManifestID += "x" },
+		"board id":       func(_ *string, manifest *ManifestIdentity, _ *sitemap.Config) { manifest.BoardID += "x" },
+		"company id":     func(_ *string, manifest *ManifestIdentity, _ *sitemap.Config) { manifest.CompanyID += "x" },
+		"revision":       func(_ *string, manifest *ManifestIdentity, _ *sitemap.Config) { manifest.ConfigRevision += "x" },
+		"fingerprint":    func(_ *string, manifest *ManifestIdentity, _ *sitemap.Config) { manifest.ConfigFingerprint += "x" },
+		"url":            func(_ *string, _ *ManifestIdentity, config *sitemap.Config) { config.SitemapURL += "x" },
+		"include":        func(_ *string, _ *ManifestIdentity, config *sitemap.Config) { config.IncludeLiteral += "x" },
+		"exclude":        func(_ *string, _ *ManifestIdentity, config *sitemap.Config) { config.ExcludeLiteral += "x" },
+		"replace prefix": func(_ *string, _ *ManifestIdentity, config *sitemap.Config) { config.ReplacePrefix += "x" },
+		"replacement":    func(_ *string, _ *ManifestIdentity, config *sitemap.Config) { config.Replacement += "x" },
+		"max urls":       func(_ *string, _ *ManifestIdentity, config *sitemap.Config) { config.MaxURLs++ },
+		"max children":   func(_ *string, _ *ManifestIdentity, config *sitemap.Config) { config.MaxIndexChildren++ },
+		"attempts":       func(_ *string, _ *ManifestIdentity, config *sitemap.Config) { config.RootMaxAttempts-- },
+		"backoff":        func(_ *string, _ *ManifestIdentity, config *sitemap.Config) { config.RootBackoff++ },
+		"require urlset": func(_ *string, _ *ManifestIdentity, config *sitemap.Config) {
+			config.RequireURLSet = !config.RequireURLSet
+		},
+		"allow http": func(_ *string, _ *ManifestIdentity, config *sitemap.Config) {
+			config.AllowHTTPForTesting = !config.AllowHTTPForTesting
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			task := "task-1"
+			manifest := baseManifest
+			config := baseConfig
+			mutate(&task, &manifest, &config)
+			changed, candidateErr := NewCandidate(task, manifest, config)
+			if candidateErr != nil {
+				t.Fatalf("NewCandidate: %v", candidateErr)
+			}
+			if changed.Digest() == base.Digest() {
+				t.Fatal("field change did not change digest")
+			}
+		})
+	}
+}
+
+func TestFenceEqualityCoversEveryField(t *testing.T) {
+	candidate := fixtureCandidate(t, "task-1", "board-1", "https://one.example/sitemap.xml")
+	base := fixtureFence(candidate, "token-1")
+	if !base.Equal(base) || !base.validFor(candidate) {
+		t.Fatal("valid fence rejected")
+	}
+	if base.FenceDigest == candidate.Digest() {
+		t.Fatal("opaque runtime fence digest was conflated with candidate digest")
+	}
+
+	tests := map[string]func(*Fence){
+		"task":     func(fence *Fence) { fence.TaskID += "x" },
+		"board":    func(fence *Fence) { fence.BoardID += "x" },
+		"shard":    func(fence *Fence) { fence.ShardID += "x" },
+		"epoch":    func(fence *Fence) { fence.RoutingEpoch++ },
+		"owner":    func(fence *Fence) { fence.EngineOwner = "python" },
+		"revision": func(fence *Fence) { fence.ConfigRevision += "x" },
+		"token":    func(fence *Fence) { fence.ClaimToken += "x" },
+		"lease":    func(fence *Fence) { fence.LeaseID += "x" },
+		"digest":   func(fence *Fence) { fence.FenceDigest[0]++ },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			changed := base
+			mutate(&changed)
+			if base.Equal(changed) {
+				t.Fatal("changed fence compared equal")
+			}
+			if changed.validFor(candidate) && (name == "task" || name == "board" || name == "owner" || name == "revision") {
+				t.Fatal("candidate identity mismatch was accepted")
+			}
+		})
+	}
+}
+
+func TestNewCandidateRejectsIncompleteBoundary(t *testing.T) {
+	manifest := fixtureManifest("board-1")
+	config := fixtureSitemap("https://one.example/sitemap.xml")
+	manifest.ConfigRevision = ""
+	if _, err := NewCandidate("task-1", manifest, config); !errors.Is(err, ErrInvalidCandidate) {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestNewCandidateRequiresExactRuntimeV1Discriminator(t *testing.T) {
+	manifest := fixtureManifest("board-1")
+	manifest.ContractVersion = "1.0"
+	if _, err := NewCandidate("task-1", manifest, fixtureSitemap("https://one.example/sitemap.xml")); !errors.Is(err, ErrInvalidCandidate) {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestNewCandidateRejectsInvalidUTF8BeforeDigesting(t *testing.T) {
+	for name, mutate := range map[string]func(*ManifestIdentity, *sitemap.Config){
+		"manifest": func(manifest *ManifestIdentity, _ *sitemap.Config) { manifest.ManifestID = "manifest-\xff" },
+		"sitemap":  func(_ *ManifestIdentity, config *sitemap.Config) { config.IncludeLiteral = "include-\xfe" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			manifest := fixtureManifest("board-1")
+			config := fixtureSitemap("https://one.example/sitemap.xml")
+			mutate(&manifest, &config)
+			if _, err := NewCandidate("task-1", manifest, config); !errors.Is(err, ErrInvalidCandidate) {
+				t.Fatalf("got %v", err)
+			}
+		})
+	}
+}
+
+func TestCandidateStoresNormalizedExecutionConfig(t *testing.T) {
+	config := fixtureSitemap("https://one.example/sitemap.xml")
+	config.RootMaxAttempts = 0
+	config.RootBackoff = 0
+	candidate, err := NewCandidate("task-1", fixtureManifest("board-1"), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := candidate.Sitemap()
+	if got.RootMaxAttempts != 3 || got.RootBackoff != 500*time.Millisecond {
+		t.Fatalf("defaults were not normalized: %#v", got)
+	}
+	if got == config {
+		t.Fatal("candidate retained unnormalized input")
+	}
+}
+
+func TestCandidateRejectsEveryInvalidSitemapBoundaryBeforeClaim(t *testing.T) {
+	base := fixtureSitemap("https://one.example/sitemap.xml")
+	tests := map[string]func(*sitemap.Config){
+		"relative": func(config *sitemap.Config) { config.SitemapURL = "/sitemap.xml" },
+		"http production": func(config *sitemap.Config) {
+			config.SitemapURL = "http://one.example/sitemap.xml"
+			config.AllowHTTPForTesting = false
+		},
+		"userinfo":      func(config *sitemap.Config) { config.SitemapURL = "https://user:secret@one.example/sitemap.xml" },
+		"max urls low":  func(config *sitemap.Config) { config.MaxURLs = 0 },
+		"max urls high": func(config *sitemap.Config) { config.MaxURLs = 50_001 },
+		"children":      func(config *sitemap.Config) { config.MaxIndexChildren = 0 },
+		"attempts":      func(config *sitemap.Config) { config.RootMaxAttempts = 4 },
+		"backoff":       func(config *sitemap.Config) { config.RootBackoff = time.Duration(1<<62 + 1) },
+		"replace pair":  func(config *sitemap.Config) { config.Replacement = "" },
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			config := base
+			mutate(&config)
+			if _, err := NewCandidate("task-1", fixtureManifest("board-1"), config); !errors.Is(err, ErrInvalidCandidate) {
+				t.Fatalf("got %v", err)
+			}
+		})
+	}
+}

--- a/pilots/go-http-sitemap/admission/coordinator.go
+++ b/pilots/go-http-sitemap/admission/coordinator.go
@@ -1,0 +1,511 @@
+package admission
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/colophon-group/jobseek/pilots/go-http-sitemap/sitemap"
+	"github.com/colophon-group/jobseek/pilots/go-http-sitemap/worker"
+)
+
+var (
+	ErrClosed          = errors.New("admission coordinator is closed")
+	ErrInvalidContext  = errors.New("invalid admission context")
+	ErrInvalidConfig   = errors.New("invalid admission coordinator config")
+	ErrFenceMismatch   = errors.New("admission fence mismatch")
+	ErrLeaseLost       = errors.New("admission lease lost")
+	ErrSupervisorJoin  = errors.New("admission lease supervisor did not join cleanly")
+	ErrDependencyPanic = errors.New("admission dependency panicked")
+)
+
+// Fence is the complete value-owned identity used at every phase boundary.
+// No pointer, slice, or map can be mutated behind the coordinator's back.
+type Fence struct {
+	// TaskID and BoardID bind the runtime fence to this local dispatch. The
+	// remaining fields map one-for-one to runtime-v1 FencingContext. The local
+	// string "go" maps only to ENGINE_OWNER_GO; no other enum is admitted.
+	TaskID         string
+	BoardID        string
+	ShardID        string
+	RoutingEpoch   uint64
+	EngineOwner    string
+	ConfigRevision string
+	ClaimToken     string
+	LeaseID        string
+	FenceDigest    [sha256.Size]byte
+}
+
+func (fence Fence) Equal(other Fence) bool { return fence == other }
+
+func (fence Fence) validFor(candidate Candidate) bool {
+	manifest := candidate.Manifest()
+	return fence.TaskID == candidate.TaskID() &&
+		fence.BoardID == manifest.BoardID &&
+		fence.ShardID != "" &&
+		fence.RoutingEpoch > 0 &&
+		fence.EngineOwner == "go" &&
+		fence.ConfigRevision == manifest.ConfigRevision &&
+		fence.ClaimToken != "" &&
+		fence.LeaseID != "" &&
+		fence.FenceDigest != ([sha256.Size]byte{})
+}
+
+// ClaimGrant separates lease timing and the local candidate binding from
+// immutable runtime fence identity. RequestStartedAt must be captured
+// immediately before the claim request. Together with server time it lets the
+// supervisor derive a conservative monotonic deadline without comparing the
+// server and worker wall clocks. Heartbeats may replace lease timing without
+// changing the Fence echoed by execution and terminal phases.
+type ClaimGrant struct {
+	Fence            Fence
+	CandidateDigest  [sha256.Size]byte
+	ServerTimeMS     int64
+	LeaseUntilMS     int64
+	RequestStartedAt time.Time
+}
+
+func (grant ClaimGrant) validFor(candidate Candidate) bool {
+	return grant.Fence.validFor(candidate) &&
+		grant.CandidateDigest == candidate.Digest() &&
+		grant.ServerTimeMS > 0 &&
+		grant.LeaseUntilMS > grant.ServerTimeMS &&
+		!grant.RequestStartedAt.IsZero()
+}
+
+// Claimer is invoked exactly once from worker.Pool's Processor callback. It
+// therefore cannot run while the task is merely buffered for a worker or an
+// origin slot. Implementations must observe ctx and must not call back into
+// Coordinator.Close; Close cancels the context and waits for Claim to return
+// so it cannot return ahead of an externally started claim.
+type Claimer interface {
+	Claim(context.Context, Candidate) (ClaimGrant, error)
+}
+
+type ClaimerFunc func(context.Context, Candidate) (ClaimGrant, error)
+
+func (function ClaimerFunc) Claim(ctx context.Context, candidate Candidate) (ClaimGrant, error) {
+	return function(ctx, candidate)
+}
+
+// LeaseSupervisor starts at most once after a valid claim. It must validate
+// the ClaimGrant and derive its initial deadline conservatively from
+// RequestStartedAt, ServerTimeMS, and LeaseUntilMS. The handle's Lost context
+// closes only for genuine lease loss or supervisor failure, never for a
+// normal Stop. Join must return ErrLeaseLost for a lost lease and nil only
+// after Stop has fully terminated the supervisor.
+type LeaseSupervisor interface {
+	Start(context.Context, ClaimGrant) (LeaseHandle, error)
+}
+
+type LeaseSupervisorFunc func(context.Context, ClaimGrant) (LeaseHandle, error)
+
+func (function LeaseSupervisorFunc) Start(ctx context.Context, grant ClaimGrant) (LeaseHandle, error) {
+	return function(ctx, grant)
+}
+
+type LeaseHandle interface {
+	Fence() Fence
+	Lost() context.Context
+	// Stop must be an idempotent, non-blocking signal. All waiting and cleanup
+	// belongs in Join, where the coordinator supplies a fixed deadline.
+	Stop()
+	Join(context.Context) error
+}
+
+// Execution echoes the exact input fence. Result is cloned before it crosses
+// into Terminaler so returned URL storage cannot be mutated concurrently.
+type Execution struct {
+	Fence  Fence
+	Result sitemap.Result
+}
+
+type Executor interface {
+	// Execute must observe ctx. Cancellation, timeout, or lease loss must stop
+	// origin work before it returns.
+	Execute(context.Context, Candidate, Fence) (Execution, error)
+}
+
+type ExecutorFunc func(context.Context, Candidate, Fence) (Execution, error)
+
+func (function ExecutorFunc) Execute(ctx context.Context, candidate Candidate, fence Fence) (Execution, error) {
+	return function(ctx, candidate, fence)
+}
+
+// Terminaler receives one terminal attempt only after the lease supervisor
+// has stopped and joined. It must observe ctx, atomically compare every Fence
+// field plus Candidate's exact config revision/fingerprint binding in the
+// same authoritative mutation, and echo the exact fence it applied. The echo
+// is validation evidence, never separate authorization.
+type Terminaler interface {
+	Terminal(context.Context, Candidate, Execution, error) (Fence, error)
+}
+
+type TerminalerFunc func(context.Context, Candidate, Execution, error) (Fence, error)
+
+func (function TerminalerFunc) Terminal(ctx context.Context, candidate Candidate, execution Execution, executionErr error) (Fence, error) {
+	return function(ctx, candidate, execution, executionErr)
+}
+
+type Config struct {
+	Worker      worker.Config
+	JoinTimeout time.Duration
+}
+
+// Coordinator owns the worker pool. Its processor adapter is private so
+// external callers cannot bypass bounded Submit and worker/origin dispatch.
+// It provides no concrete queue, persistence, or retry implementation.
+type Coordinator struct {
+	claimer     Claimer
+	supervisor  LeaseSupervisor
+	executor    Executor
+	terminaler  Terminaler
+	joinTimeout time.Duration
+
+	pool *worker.Pool
+
+	claimGate   sync.RWMutex
+	closeCtx    context.Context
+	cancelClose context.CancelCauseFunc
+	closeOnce   sync.Once
+}
+
+type candidateContextKey struct{}
+
+func New(config Config, claimer Claimer, supervisor LeaseSupervisor, executor Executor, terminaler Terminaler) (*Coordinator, error) {
+	if config.JoinTimeout <= 0 || config.Worker.Capacity < 0 || claimer == nil || supervisor == nil || executor == nil || terminaler == nil {
+		return nil, ErrInvalidConfig
+	}
+	closeCtx, cancelClose := context.WithCancelCause(context.Background())
+	coordinator := &Coordinator{
+		claimer:     claimer,
+		supervisor:  supervisor,
+		executor:    executor,
+		terminaler:  terminaler,
+		joinTimeout: config.JoinTimeout,
+		closeCtx:    closeCtx,
+		cancelClose: cancelClose,
+	}
+	pool, err := worker.NewWithProcessor(config.Worker, coordinatorProcessor{coordinator: coordinator})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrInvalidConfig, err)
+	}
+	coordinator.pool = pool
+	return coordinator, nil
+}
+
+// Submit admits an immutable candidate to the bounded worker pool.
+// admissionCtx controls only waiting for bounded admission; executionCtx is
+// retained for the accepted job's lifetime. Duplicate/stale task rejection is
+// owned by the injected claim CAS, not by a second local scheduler.
+func (coordinator *Coordinator) Submit(admissionCtx, executionCtx context.Context, candidate Candidate) error {
+	if admissionCtx == nil || executionCtx == nil {
+		return ErrInvalidContext
+	}
+	if !candidate.valid() {
+		return ErrInvalidCandidate
+	}
+
+	select {
+	case <-coordinator.closeCtx.Done():
+		return ErrClosed
+	default:
+	}
+	jobContext := context.WithValue(executionCtx, candidateContextKey{}, candidate)
+	err := coordinator.pool.Submit(admissionCtx, worker.Job{
+		ID:      candidate.TaskID(),
+		Context: jobContext,
+		Sitemap: candidate.Sitemap(),
+	})
+	if err != nil {
+		if errors.Is(err, worker.ErrClosed) {
+			return ErrClosed
+		}
+	}
+	return err
+}
+
+type coordinatorProcessor struct{ coordinator *Coordinator }
+
+func (processor coordinatorProcessor) Process(ctx context.Context, job worker.Job) (sitemap.Result, error) {
+	return processor.coordinator.process(ctx, job)
+}
+
+// process is reachable only through coordinatorProcessor after worker.Pool's
+// scheduler has assigned both global worker capacity and an origin slot.
+func (coordinator *Coordinator) process(ctx context.Context, job worker.Job) (sitemap.Result, error) {
+	candidate, ok := ctx.Value(candidateContextKey{}).(Candidate)
+	if !ok {
+		return sitemap.Result{}, ErrInvalidCandidate
+	}
+	if candidate.TaskID() != job.ID || candidate.Sitemap() != job.Sitemap {
+		return sitemap.Result{}, ErrInvalidCandidate
+	}
+	if err := ctx.Err(); err != nil {
+		return sitemap.Result{}, err
+	}
+
+	claimContext, cancelClaim := context.WithCancelCause(ctx)
+	stopCloseWatch := context.AfterFunc(coordinator.closeCtx, func() {
+		cancelClaim(ErrClosed)
+	})
+	defer func() {
+		stopCloseWatch()
+		cancelClaim(nil)
+	}()
+
+	// The read reservation spans the external call. Close first cancels
+	// claimContext, then takes the exclusive reservation before returning. A
+	// conforming Claimer therefore cannot begin after Close has returned and a
+	// queued task never crosses this boundary.
+	grant, err, claimPanicked := coordinator.claim(claimContext, candidate)
+	if claimPanicked {
+		return sitemap.Result{}, ErrDependencyPanic
+	}
+	if err != nil {
+		if errors.Is(context.Cause(claimContext), ErrClosed) {
+			return sitemap.Result{}, ErrClosed
+		}
+		return sitemap.Result{}, err
+	}
+	if errors.Is(context.Cause(claimContext), ErrClosed) {
+		return sitemap.Result{}, ErrClosed
+	}
+	if !grant.validFor(candidate) {
+		return sitemap.Result{}, ErrFenceMismatch
+	}
+	fence := grant.Fence
+	if err := ctx.Err(); err != nil {
+		return sitemap.Result{}, err
+	}
+
+	handle, err, startPanicked := callStart(coordinator.supervisor, ctx, grant)
+	if startPanicked {
+		return sitemap.Result{}, ErrDependencyPanic
+	}
+	if err != nil {
+		if handle != nil {
+			if cleanupErr := coordinator.stopAndJoin(handle); cleanupErr != nil {
+				return sitemap.Result{}, fmt.Errorf("%w: %v", ErrSupervisorJoin, cleanupErr)
+			}
+		}
+		return sitemap.Result{}, err
+	}
+	handleFence, leaseContext, inspectErr := inspectHandle(handle)
+	if inspectErr != nil || !handleFence.Equal(fence) || leaseContext == nil {
+		if handle != nil {
+			if cleanupErr := coordinator.stopAndJoin(handle); cleanupErr != nil {
+				return sitemap.Result{}, fmt.Errorf("%w: %v", ErrSupervisorJoin, cleanupErr)
+			}
+		}
+		if errors.Is(inspectErr, ErrDependencyPanic) {
+			return sitemap.Result{}, ErrDependencyPanic
+		}
+		return sitemap.Result{}, ErrFenceMismatch
+	}
+
+	executionContext, cancelExecution := context.WithCancelCause(ctx)
+	stopLossWatch := context.AfterFunc(leaseContext, func() {
+		cancelExecution(ErrLeaseLost)
+	})
+	if leaseContext.Err() != nil {
+		cancelExecution(ErrLeaseLost)
+	}
+	if cause := context.Cause(executionContext); cause != nil {
+		stopLossWatch()
+		cancelExecution(nil)
+		joinErr := coordinator.stopAndJoin(handle)
+		if errors.Is(cause, ErrLeaseLost) || errors.Is(joinErr, ErrLeaseLost) {
+			return sitemap.Result{}, ErrLeaseLost
+		}
+		if joinErr != nil {
+			return sitemap.Result{}, fmt.Errorf("%w: %v", ErrSupervisorJoin, joinErr)
+		}
+		return sitemap.Result{}, cause
+	}
+
+	execution, executionErr, executionPanicked := callExecute(coordinator.executor, executionContext, candidate, fence)
+	leaseLostBeforeStop := errors.Is(context.Cause(executionContext), ErrLeaseLost) || leaseContext.Err() != nil
+	stopLossWatch()
+	cancelExecution(nil)
+
+	joinErr := coordinator.stopAndJoin(handle)
+	if leaseLostBeforeStop || leaseContext.Err() != nil || errors.Is(joinErr, ErrLeaseLost) {
+		return sitemap.Result{}, ErrLeaseLost
+	}
+	if joinErr != nil {
+		return sitemap.Result{}, fmt.Errorf("%w: %v", ErrSupervisorJoin, joinErr)
+	}
+	if executionPanicked {
+		return sitemap.Result{}, ErrDependencyPanic
+	}
+	if err := ctx.Err(); err != nil {
+		return sitemap.Result{}, err
+	}
+	if !execution.Fence.Equal(fence) {
+		return sitemap.Result{}, ErrFenceMismatch
+	}
+
+	protectedResult := cloneResult(execution.Result)
+	terminalExecution := execution
+	terminalExecution.Result = cloneResult(protectedResult)
+	echo, terminalErr, terminalPanicked := callTerminal(coordinator.terminaler, ctx, candidate, terminalExecution, executionErr)
+	if terminalPanicked {
+		return sitemap.Result{}, ErrDependencyPanic
+	}
+	if !echo.Equal(fence) {
+		return sitemap.Result{}, ErrFenceMismatch
+	}
+	if terminalErr != nil {
+		return sitemap.Result{}, terminalErr
+	}
+	return cloneResult(protectedResult), executionErr
+}
+
+func inspectHandle(handle LeaseHandle) (fence Fence, lost context.Context, err error) {
+	if handle == nil {
+		return Fence{}, nil, ErrFenceMismatch
+	}
+	defer func() {
+		if recover() != nil {
+			fence = Fence{}
+			lost = nil
+			err = ErrDependencyPanic
+		}
+	}()
+	return handle.Fence(), handle.Lost(), nil
+}
+
+func (coordinator *Coordinator) claim(ctx context.Context, candidate Candidate) (grant ClaimGrant, err error, panicked bool) {
+	coordinator.claimGate.RLock()
+	defer coordinator.claimGate.RUnlock()
+	if coordinator.closeCtx.Err() != nil {
+		return ClaimGrant{}, ErrClosed, false
+	}
+	return callClaim(coordinator.claimer, ctx, candidate)
+}
+
+func callClaim(claimer Claimer, ctx context.Context, candidate Candidate) (grant ClaimGrant, err error, panicked bool) {
+	defer func() {
+		if recover() != nil {
+			grant = ClaimGrant{}
+			err = ErrDependencyPanic
+			panicked = true
+		}
+	}()
+	grant, err = claimer.Claim(ctx, candidate)
+	return grant, err, false
+}
+
+func callStart(supervisor LeaseSupervisor, ctx context.Context, grant ClaimGrant) (handle LeaseHandle, err error, panicked bool) {
+	defer func() {
+		if recover() != nil {
+			handle = nil
+			err = ErrDependencyPanic
+			panicked = true
+		}
+	}()
+	handle, err = supervisor.Start(ctx, grant)
+	return handle, err, false
+}
+
+func callExecute(executor Executor, ctx context.Context, candidate Candidate, fence Fence) (execution Execution, err error, panicked bool) {
+	defer func() {
+		if recover() != nil {
+			execution = Execution{}
+			err = ErrDependencyPanic
+			panicked = true
+		}
+	}()
+	execution, err = executor.Execute(ctx, candidate, fence)
+	return execution, err, false
+}
+
+func callTerminal(terminaler Terminaler, ctx context.Context, candidate Candidate, execution Execution, executionErr error) (fence Fence, err error, panicked bool) {
+	defer func() {
+		if recover() != nil {
+			fence = Fence{}
+			err = ErrDependencyPanic
+			panicked = true
+		}
+	}()
+	fence, err = terminaler.Terminal(ctx, candidate, execution, executionErr)
+	return fence, err, false
+}
+
+func (coordinator *Coordinator) stopAndJoin(handle LeaseHandle) error {
+	stopErr := callStop(handle)
+	joinContext, cancel := context.WithTimeout(context.Background(), coordinator.joinTimeout)
+	defer cancel()
+	joinErr := callJoin(joinContext, handle)
+	if stopErr != nil {
+		return stopErr
+	}
+	return joinErr
+}
+
+func callStop(handle LeaseHandle) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = ErrDependencyPanic
+		}
+	}()
+	handle.Stop()
+	return nil
+}
+
+func callJoin(ctx context.Context, handle LeaseHandle) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = ErrDependencyPanic
+		}
+	}()
+	return handle.Join(ctx)
+}
+
+func cloneResult(result sitemap.Result) sitemap.Result {
+	result.URLs = append([]string(nil), result.URLs...)
+	return result
+}
+
+func (coordinator *Coordinator) Results() <-chan worker.Result { return coordinator.pool.Results() }
+
+func (coordinator *Coordinator) Done() <-chan struct{} { return coordinator.pool.Done() }
+
+func (coordinator *Coordinator) Stats() worker.Stats { return coordinator.pool.Stats() }
+
+// Close starts the worker drain and cancels any claim phase, then waits for
+// every already-started Claim to return before it returns. Claimer is required
+// to observe its context. A violating Claimer can keep Close blocked, just as
+// a violating worker Processor can keep Pool.Close from draining; Shutdown
+// still respects its caller deadline.
+func (coordinator *Coordinator) Close() {
+	coordinator.initiateClose()
+	coordinator.claimGate.Lock()
+	coordinator.claimGate.Unlock()
+}
+
+func (coordinator *Coordinator) Shutdown(ctx context.Context) error {
+	if ctx == nil {
+		return ErrInvalidContext
+	}
+	coordinator.initiateClose()
+	select {
+	case <-coordinator.Done():
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (coordinator *Coordinator) initiateClose() {
+	coordinator.closeOnce.Do(func() {
+		coordinator.cancelClose(ErrClosed)
+		coordinator.pool.Close()
+	})
+}
+
+var _ worker.Processor = coordinatorProcessor{}

--- a/pilots/go-http-sitemap/admission/coordinator_api_test.go
+++ b/pilots/go-http-sitemap/admission/coordinator_api_test.go
@@ -1,0 +1,14 @@
+package admission_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/colophon-group/jobseek/pilots/go-http-sitemap/admission"
+)
+
+func TestCoordinatorDoesNotExposeProcessorBypass(t *testing.T) {
+	if _, exposed := reflect.TypeOf((*admission.Coordinator)(nil)).MethodByName("Process"); exposed {
+		t.Fatal("Coordinator exposes Process and bypasses bounded dispatch")
+	}
+}

--- a/pilots/go-http-sitemap/admission/coordinator_test.go
+++ b/pilots/go-http-sitemap/admission/coordinator_test.go
@@ -1,0 +1,1336 @@
+package admission
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/colophon-group/jobseek/pilots/go-http-sitemap/boundedhttp"
+	"github.com/colophon-group/jobseek/pilots/go-http-sitemap/sitemap"
+	"github.com/colophon-group/jobseek/pilots/go-http-sitemap/worker"
+)
+
+type fakeHandle struct {
+	fence Fence
+	lost  context.Context
+	lose  context.CancelFunc
+	stop  chan struct{}
+	once  sync.Once
+
+	joinErr error
+	order   func(string)
+	stops   atomic.Int64
+	joins   atomic.Int64
+}
+
+func newFakeHandle(fence Fence) *fakeHandle {
+	lost, lose := context.WithCancel(context.Background())
+	return &fakeHandle{
+		fence: fence,
+		lost:  lost,
+		lose:  lose,
+		stop:  make(chan struct{}),
+	}
+}
+
+func (handle *fakeHandle) Fence() Fence          { return handle.fence }
+func (handle *fakeHandle) Lost() context.Context { return handle.lost }
+func (handle *fakeHandle) loseLease()            { handle.lose() }
+
+func (handle *fakeHandle) Stop() {
+	handle.stops.Add(1)
+	if handle.order != nil {
+		handle.order("stop")
+	}
+	handle.once.Do(func() { close(handle.stop) })
+}
+
+func (handle *fakeHandle) Join(ctx context.Context) error {
+	handle.joins.Add(1)
+	if handle.order != nil {
+		handle.order("join")
+	}
+	select {
+	case <-handle.lost.Done():
+		return ErrLeaseLost
+	case <-handle.stop:
+		return handle.joinErr
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type blockingJoinHandle struct{ *fakeHandle }
+
+func (handle *blockingJoinHandle) Join(ctx context.Context) error {
+	handle.joins.Add(1)
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+type panicInspectHandle struct{ *fakeHandle }
+
+func (handle *panicInspectHandle) Fence() Fence {
+	panic("secret inspect panic")
+}
+
+type lossAtJoinHandle struct{ *fakeHandle }
+
+func (handle *lossAtJoinHandle) Join(ctx context.Context) error {
+	select {
+	case <-handle.stop:
+		handle.loseLease()
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+type fakeDependencies struct {
+	mu sync.Mutex
+
+	claims     int
+	starts     int
+	executions int
+	terminals  int
+	handles    map[string]*fakeHandle
+	order      []string
+
+	claimHook    func(context.Context, Candidate) (ClaimGrant, error)
+	startHook    func(context.Context, ClaimGrant) (LeaseHandle, error)
+	executeHook  func(context.Context, Candidate, Fence) (Execution, error)
+	terminalHook func(context.Context, Candidate, Execution, error) (Fence, error)
+}
+
+type realSitemapExecutor struct{ client *boundedhttp.Client }
+
+func (executor realSitemapExecutor) Execute(ctx context.Context, candidate Candidate, fence Fence) (Execution, error) {
+	runner, err := sitemap.New(executor.client, candidate.Sitemap())
+	if err != nil {
+		return Execution{Fence: fence}, err
+	}
+	result, err := runner.Run(ctx)
+	return Execution{Fence: fence, Result: result}, err
+}
+
+func newFakeDependencies() *fakeDependencies {
+	return &fakeDependencies{handles: make(map[string]*fakeHandle)}
+}
+
+func (fake *fakeDependencies) appendOrder(event string) {
+	fake.mu.Lock()
+	fake.order = append(fake.order, event)
+	fake.mu.Unlock()
+}
+
+func (fake *fakeDependencies) Claim(ctx context.Context, candidate Candidate) (ClaimGrant, error) {
+	fake.mu.Lock()
+	fake.claims++
+	fake.order = append(fake.order, "claim")
+	hook := fake.claimHook
+	fake.mu.Unlock()
+	if hook != nil {
+		return hook(ctx, candidate)
+	}
+	return fixtureGrant(candidate, "token-"+candidate.TaskID()), nil
+}
+
+func (fake *fakeDependencies) Start(ctx context.Context, grant ClaimGrant) (LeaseHandle, error) {
+	fake.mu.Lock()
+	fake.starts++
+	fake.order = append(fake.order, "start")
+	hook := fake.startHook
+	fake.mu.Unlock()
+	if hook != nil {
+		return hook(ctx, grant)
+	}
+	handle := newFakeHandle(grant.Fence)
+	fake.mu.Lock()
+	fake.handles[grant.Fence.TaskID] = handle
+	fake.mu.Unlock()
+	return handle, nil
+}
+
+func (fake *fakeDependencies) Execute(ctx context.Context, candidate Candidate, fence Fence) (Execution, error) {
+	fake.mu.Lock()
+	fake.executions++
+	fake.order = append(fake.order, "execute")
+	hook := fake.executeHook
+	fake.mu.Unlock()
+	if hook != nil {
+		return hook(ctx, candidate, fence)
+	}
+	return Execution{Fence: fence, Result: sitemap.Result{URLs: []string{"https://result.example/job"}}}, nil
+}
+
+func (fake *fakeDependencies) Terminal(ctx context.Context, candidate Candidate, execution Execution, executionErr error) (Fence, error) {
+	fake.mu.Lock()
+	fake.terminals++
+	fake.order = append(fake.order, "terminal")
+	hook := fake.terminalHook
+	fake.mu.Unlock()
+	if hook != nil {
+		return hook(ctx, candidate, execution, executionErr)
+	}
+	return execution.Fence, nil
+}
+
+func (fake *fakeDependencies) counts() (int, int, int, int) {
+	fake.mu.Lock()
+	defer fake.mu.Unlock()
+	return fake.claims, fake.starts, fake.executions, fake.terminals
+}
+
+func fixtureFence(candidate Candidate, token string) Fence {
+	opaqueDigest := sha256.Sum256([]byte("opaque-runtime-fence:" + candidate.TaskID()))
+	return Fence{
+		TaskID:         candidate.TaskID(),
+		BoardID:        candidate.Manifest().BoardID,
+		ShardID:        "shard-1",
+		RoutingEpoch:   3,
+		EngineOwner:    "go",
+		ConfigRevision: candidate.Manifest().ConfigRevision,
+		ClaimToken:     token,
+		LeaseID:        "lease-" + candidate.TaskID(),
+		FenceDigest:    opaqueDigest,
+	}
+}
+
+func fixtureGrant(candidate Candidate, token string) ClaimGrant {
+	return ClaimGrant{
+		Fence:            fixtureFence(candidate, token),
+		CandidateDigest:  candidate.Digest(),
+		ServerTimeMS:     1_000,
+		LeaseUntilMS:     11_000,
+		RequestStartedAt: time.Now(),
+	}
+}
+
+func testConfig(workers, capacity, results, perOrigin int, timeout time.Duration) Config {
+	return Config{
+		Worker: worker.Config{
+			Workers:              workers,
+			Capacity:             capacity,
+			ResultCapacity:       results,
+			PerOriginConcurrency: perOrigin,
+			JobTimeout:           timeout,
+			ShutdownGrace:        200 * time.Millisecond,
+		},
+		JoinTimeout: 100 * time.Millisecond,
+	}
+}
+
+func newTestCoordinator(t *testing.T, config Config, fake *fakeDependencies) *Coordinator {
+	t.Helper()
+	coordinator, err := New(config, fake, fake, fake, fake)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return coordinator
+}
+
+func awaitResult(t *testing.T, coordinator *Coordinator) worker.Result {
+	t.Helper()
+	select {
+	case result, ok := <-coordinator.Results():
+		if !ok {
+			t.Fatal("results closed early")
+		}
+		return result
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for result")
+		return worker.Result{}
+	}
+}
+
+func shutdownCoordinator(t *testing.T, coordinator *Coordinator) {
+	t.Helper()
+	coordinator.Close()
+	for range coordinator.Results() {
+	}
+	select {
+	case <-coordinator.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("coordinator did not stop")
+	}
+}
+
+func TestClaimStartsOnlyAfterWorkerAndOriginDispatch(t *testing.T) {
+	fake := newFakeDependencies()
+	started := make(chan string, 3)
+	releases := map[string]chan struct{}{
+		"a-1": make(chan struct{}),
+		"a-2": make(chan struct{}),
+		"b-1": make(chan struct{}),
+	}
+	fake.claimHook = func(_ context.Context, candidate Candidate) (ClaimGrant, error) {
+		started <- candidate.TaskID()
+		return fixtureGrant(candidate, "token-"+candidate.TaskID()), nil
+	}
+	fake.executeHook = func(ctx context.Context, candidate Candidate, fence Fence) (Execution, error) {
+		select {
+		case <-releases[candidate.TaskID()]:
+			return Execution{Fence: fence}, nil
+		case <-ctx.Done():
+			return Execution{Fence: fence}, ctx.Err()
+		}
+	}
+	coordinator := newTestCoordinator(t, testConfig(2, 4, 4, 1, time.Second), fake)
+
+	for _, candidate := range []Candidate{
+		fixtureCandidate(t, "a-1", "board-a1", "https://a.example/one.xml"),
+		fixtureCandidate(t, "a-2", "board-a2", "https://a.example/two.xml"),
+		fixtureCandidate(t, "b-1", "board-b1", "https://b.example/one.xml"),
+	} {
+		if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+			t.Fatalf("Submit %s: %v", candidate.TaskID(), err)
+		}
+	}
+
+	first := awaitString(t, started, "first claim")
+	second := awaitString(t, started, "second claim")
+	seen := map[string]bool{first: true, second: true}
+	if !seen["b-1"] || seen["a-1"] == seen["a-2"] {
+		t.Fatalf("origin slot did not gate claim: first claims %q, %q", first, second)
+	}
+	assertNoString(t, started, "queued same-origin claim")
+
+	close(releases["b-1"])
+	if result := awaitResult(t, coordinator); result.JobID != "b-1" || result.Err != nil {
+		t.Fatalf("unexpected b result: %#v", result)
+	}
+	assertNoString(t, started, "same-origin claim after only b released")
+	activeA, queuedA := "a-1", "a-2"
+	if seen["a-2"] {
+		activeA, queuedA = queuedA, activeA
+	}
+	close(releases[activeA])
+	if result := awaitResult(t, coordinator); result.JobID != activeA || result.Err != nil {
+		t.Fatalf("unexpected active a result: %#v", result)
+	}
+	select {
+	case task := <-started:
+		if task != queuedA {
+			t.Fatalf("claimed %q, want %q", task, queuedA)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("queued origin task was not claimed")
+	}
+	close(releases[queuedA])
+	if result := awaitResult(t, coordinator); result.JobID != queuedA || result.Err != nil {
+		t.Fatalf("unexpected queued a result: %#v", result)
+	}
+	shutdownCoordinator(t, coordinator)
+	assertCounts(t, fake, 3, 3, 3, 3)
+}
+
+func TestClaimFenceMismatchSuppressesEveryLaterPhase(t *testing.T) {
+	mutations := map[string]func(*ClaimGrant){
+		"task":             func(grant *ClaimGrant) { grant.Fence.TaskID += "x" },
+		"board":            func(grant *ClaimGrant) { grant.Fence.BoardID += "x" },
+		"shard":            func(grant *ClaimGrant) { grant.Fence.ShardID = "" },
+		"epoch":            func(grant *ClaimGrant) { grant.Fence.RoutingEpoch = 0 },
+		"owner":            func(grant *ClaimGrant) { grant.Fence.EngineOwner = "python" },
+		"revision":         func(grant *ClaimGrant) { grant.Fence.ConfigRevision += "x" },
+		"token":            func(grant *ClaimGrant) { grant.Fence.ClaimToken = "" },
+		"lease id":         func(grant *ClaimGrant) { grant.Fence.LeaseID = "" },
+		"candidate digest": func(grant *ClaimGrant) { grant.CandidateDigest[0]++ },
+		"server time":      func(grant *ClaimGrant) { grant.ServerTimeMS = 0 },
+		"lease expiry":     func(grant *ClaimGrant) { grant.LeaseUntilMS = grant.ServerTimeMS },
+		"request start":    func(grant *ClaimGrant) { grant.RequestStartedAt = time.Time{} },
+		"digest":           func(grant *ClaimGrant) { grant.Fence.FenceDigest = [sha256.Size]byte{} },
+	}
+	for name, mutate := range mutations {
+		t.Run(name, func(t *testing.T) {
+			fake := newFakeDependencies()
+			fake.claimHook = func(_ context.Context, candidate Candidate) (ClaimGrant, error) {
+				grant := fixtureGrant(candidate, "token")
+				mutate(&grant)
+				return grant, nil
+			}
+			coordinator := newTestCoordinator(t, testConfig(1, 1, 1, 1, time.Second), fake)
+			candidate := fixtureCandidate(t, "task-1", "board-1", "https://one.example/sitemap.xml")
+			if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+				t.Fatal(err)
+			}
+			if result := awaitResult(t, coordinator); !errors.Is(result.Err, ErrFenceMismatch) {
+				t.Fatalf("got %v", result.Err)
+			}
+			shutdownCoordinator(t, coordinator)
+			assertCounts(t, fake, 1, 0, 0, 0)
+		})
+	}
+}
+
+func TestEchoMismatchFailsClosedAtEachBoundary(t *testing.T) {
+	tests := map[string]func(*fakeDependencies){
+		"supervisor": func(fake *fakeDependencies) {
+			fake.startHook = func(_ context.Context, grant ClaimGrant) (LeaseHandle, error) {
+				changed := grant.Fence
+				changed.ClaimToken += "x"
+				return newFakeHandle(changed), nil
+			}
+		},
+		"executor": func(fake *fakeDependencies) {
+			fake.executeHook = func(_ context.Context, _ Candidate, fence Fence) (Execution, error) {
+				changed := fence
+				changed.LeaseID += "x"
+				return Execution{Fence: changed}, nil
+			}
+		},
+		"terminal": func(fake *fakeDependencies) {
+			fake.terminalHook = func(_ context.Context, _ Candidate, execution Execution, _ error) (Fence, error) {
+				changed := execution.Fence
+				changed.RoutingEpoch++
+				return changed, nil
+			}
+		},
+	}
+	for name, configure := range tests {
+		t.Run(name, func(t *testing.T) {
+			fake := newFakeDependencies()
+			configure(fake)
+			coordinator := newTestCoordinator(t, testConfig(1, 1, 1, 1, time.Second), fake)
+			candidate := fixtureCandidate(t, "task-1", "board-1", "https://one.example/sitemap.xml")
+			if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+				t.Fatal(err)
+			}
+			if result := awaitResult(t, coordinator); !errors.Is(result.Err, ErrFenceMismatch) {
+				t.Fatalf("got %v", result.Err)
+			}
+			shutdownCoordinator(t, coordinator)
+			_, _, executions, terminals := fake.counts()
+			wantExecutions, wantTerminals := 1, 0
+			if name == "supervisor" {
+				wantExecutions = 0
+			}
+			if name == "terminal" {
+				wantTerminals = 1
+			}
+			if executions != wantExecutions || terminals != wantTerminals {
+				t.Fatalf("executions=%d terminals=%d", executions, terminals)
+			}
+		})
+	}
+}
+
+func TestLeaseLossCancelsOnlyItsExecutionAndSuppressesTerminal(t *testing.T) {
+	fake := newFakeDependencies()
+	started := make(chan string, 2)
+	releaseHealthy := make(chan struct{})
+	fake.executeHook = func(ctx context.Context, candidate Candidate, fence Fence) (Execution, error) {
+		started <- candidate.TaskID()
+		if candidate.TaskID() == "lost" {
+			<-ctx.Done()
+			return Execution{Fence: fence}, ctx.Err()
+		}
+		select {
+		case <-releaseHealthy:
+			return Execution{Fence: fence, Result: sitemap.Result{URLs: []string{"https://healthy.example/job"}}}, nil
+		case <-ctx.Done():
+			return Execution{Fence: fence}, ctx.Err()
+		}
+	}
+	coordinator := newTestCoordinator(t, testConfig(2, 2, 2, 1, time.Second), fake)
+	for _, candidate := range []Candidate{
+		fixtureCandidate(t, "lost", "board-lost", "https://lost.example/sitemap.xml"),
+		fixtureCandidate(t, "healthy", "board-healthy", "https://healthy.example/sitemap.xml"),
+	} {
+		if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = awaitString(t, started, "first execution")
+	_ = awaitString(t, started, "second execution")
+	fake.mu.Lock()
+	lostHandle := fake.handles["lost"]
+	fake.mu.Unlock()
+	if lostHandle == nil {
+		t.Fatal("lost handle was not registered")
+	}
+	lostHandle.loseLease()
+	close(releaseHealthy)
+	results := map[string]worker.Result{}
+	for range 2 {
+		result := awaitResult(t, coordinator)
+		results[result.JobID] = result
+	}
+	if !errors.Is(results["lost"].Err, ErrLeaseLost) {
+		t.Fatalf("lost result: %v", results["lost"].Err)
+	}
+	if results["healthy"].Err != nil {
+		t.Fatalf("healthy result: %v", results["healthy"].Err)
+	}
+	shutdownCoordinator(t, coordinator)
+	_, _, executions, terminals := fake.counts()
+	if executions != 2 || terminals != 1 {
+		t.Fatalf("loss was not isolated: executions=%d terminals=%d", executions, terminals)
+	}
+}
+
+func TestSupervisorStopsAndJoinsBeforeTerminal(t *testing.T) {
+	fake := newFakeDependencies()
+	handleReady := make(chan *fakeHandle, 1)
+	fake.startHook = func(_ context.Context, grant ClaimGrant) (LeaseHandle, error) {
+		handle := newFakeHandle(grant.Fence)
+		handle.order = fake.appendOrder
+		handleReady <- handle
+		return handle, nil
+	}
+	fake.executeHook = func(_ context.Context, _ Candidate, fence Fence) (Execution, error) {
+		fake.appendOrder("execute-return")
+		return Execution{Fence: fence}, nil
+	}
+	coordinator := newTestCoordinator(t, testConfig(1, 1, 1, 1, time.Second), fake)
+	candidate := fixtureCandidate(t, "task-1", "board-1", "https://one.example/sitemap.xml")
+	if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+		t.Fatal(err)
+	}
+	if result := awaitResult(t, coordinator); result.Err != nil {
+		t.Fatal(result.Err)
+	}
+	handle := awaitValue(t, handleReady, "ordered handle")
+	if handle.stops.Load() != 1 || handle.joins.Load() != 1 {
+		t.Fatalf("cleanup counts: stop=%d join=%d", handle.stops.Load(), handle.joins.Load())
+	}
+	fake.mu.Lock()
+	order := append([]string(nil), fake.order...)
+	fake.mu.Unlock()
+	want := []string{"claim", "start", "execute", "execute-return", "stop", "join", "terminal"}
+	if fmt.Sprint(order) != fmt.Sprint(want) {
+		t.Fatalf("order %v, want %v", order, want)
+	}
+	shutdownCoordinator(t, coordinator)
+}
+
+func TestDuplicateTaskIsRejectedOnlyByInjectedClaimCAS(t *testing.T) {
+	fake := newFakeDependencies()
+	release := make(chan struct{})
+	started := make(chan struct{})
+	duplicateClaim := errors.New("duplicate claim rejected")
+	var claimed atomic.Bool
+	fake.claimHook = func(_ context.Context, candidate Candidate) (ClaimGrant, error) {
+		if !claimed.CompareAndSwap(false, true) {
+			return ClaimGrant{}, duplicateClaim
+		}
+		return fixtureGrant(candidate, "only-token"), nil
+	}
+	fake.executeHook = func(ctx context.Context, _ Candidate, fence Fence) (Execution, error) {
+		close(started)
+		select {
+		case <-release:
+			return Execution{Fence: fence}, nil
+		case <-ctx.Done():
+			return Execution{Fence: fence}, ctx.Err()
+		}
+	}
+	coordinator := newTestCoordinator(t, testConfig(1, 2, 1, 1, time.Second), fake)
+	candidate := fixtureCandidate(t, "task-1", "board-1", "https://one.example/sitemap.xml")
+	if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+		t.Fatal(err)
+	}
+	awaitSignal(t, started, "first execution")
+	if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+		t.Fatalf("local duplicate should reach claim CAS: %v", err)
+	}
+	close(release)
+	var successes, rejected int
+	for range 2 {
+		result := awaitResult(t, coordinator)
+		switch {
+		case result.Err == nil:
+			successes++
+		case errors.Is(result.Err, duplicateClaim):
+			rejected++
+		default:
+			t.Fatalf("unexpected result: %v", result.Err)
+		}
+	}
+	shutdownCoordinator(t, coordinator)
+	if successes != 1 || rejected != 1 {
+		t.Fatalf("successes=%d rejected=%d", successes, rejected)
+	}
+	assertCounts(t, fake, 2, 1, 1, 1)
+}
+
+func TestCloseGateWaitsForStartedClaimAndSuppressesLaterClaims(t *testing.T) {
+	fake := newFakeDependencies()
+	claimEntered := make(chan struct{})
+	claimExited := make(chan struct{})
+	fake.claimHook = func(ctx context.Context, candidate Candidate) (ClaimGrant, error) {
+		close(claimEntered)
+		<-ctx.Done()
+		close(claimExited)
+		return ClaimGrant{}, ctx.Err()
+	}
+	coordinator := newTestCoordinator(t, testConfig(1, 2, 2, 1, time.Second), fake)
+	first := fixtureCandidate(t, "first", "board-first", "https://one.example/first.xml")
+	queued := fixtureCandidate(t, "queued", "board-queued", "https://two.example/queued.xml")
+	if err := coordinator.Submit(context.Background(), context.Background(), first); err != nil {
+		t.Fatal(err)
+	}
+	awaitSignal(t, claimEntered, "claim entry")
+	if err := coordinator.Submit(context.Background(), context.Background(), queued); err != nil {
+		t.Fatal(err)
+	}
+	closed := make(chan struct{})
+	go func() {
+		coordinator.Close()
+		close(closed)
+	}()
+	select {
+	case <-claimExited:
+	case <-time.After(time.Second):
+		t.Fatal("started claim did not observe Close cancellation")
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("Close did not finish after claim exit")
+	}
+	postClose := fixtureCandidate(t, "post", "board-post", "https://three.example/post.xml")
+	if err := coordinator.Submit(context.Background(), context.Background(), postClose); !errors.Is(err, ErrClosed) {
+		t.Fatalf("post-close submit got %v", err)
+	}
+	results := map[string]worker.Result{}
+	for range 2 {
+		result := awaitResult(t, coordinator)
+		results[result.JobID] = result
+	}
+	if !errors.Is(results["first"].Err, ErrClosed) || !errors.Is(results["queued"].Err, ErrClosed) {
+		t.Fatalf("close results: first=%v queued=%v", results["first"].Err, results["queued"].Err)
+	}
+	awaitSignal(t, coordinator.Done(), "closed coordinator")
+	assertCounts(t, fake, 1, 0, 0, 0)
+}
+
+func TestShutdownDeadlineBoundsNoncooperativeClaim(t *testing.T) {
+	fake := newFakeDependencies()
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	fake.claimHook = func(_ context.Context, _ Candidate) (ClaimGrant, error) {
+		close(entered)
+		<-release
+		return ClaimGrant{}, ErrClosed
+	}
+	coordinator := newTestCoordinator(t, testConfig(1, 1, 1, 1, time.Second), fake)
+	candidate := fixtureCandidate(t, "task-1", "board-1", "https://one.example/sitemap.xml")
+	if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+		t.Fatal(err)
+	}
+	awaitSignal(t, entered, "noncooperative claim entry")
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	started := time.Now()
+	if err := coordinator.Shutdown(shutdownCtx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Shutdown got %v", err)
+	}
+	if time.Since(started) > 200*time.Millisecond {
+		t.Fatal("Shutdown deadline was hidden behind blocking Close")
+	}
+	close(release)
+	for range coordinator.Results() {
+	}
+	select {
+	case <-coordinator.Done():
+	case <-time.After(time.Second):
+		t.Fatal("coordinator did not drain after dependency released")
+	}
+}
+
+func TestAdmissionContextDoesNotOwnAcceptedExecution(t *testing.T) {
+	fake := newFakeDependencies()
+	executed := make(chan error, 1)
+	fake.executeHook = func(ctx context.Context, _ Candidate, fence Fence) (Execution, error) {
+		select {
+		case <-ctx.Done():
+			executed <- ctx.Err()
+			return Execution{Fence: fence}, ctx.Err()
+		case <-time.After(30 * time.Millisecond):
+			executed <- nil
+			return Execution{Fence: fence}, nil
+		}
+	}
+	coordinator := newTestCoordinator(t, testConfig(1, 1, 1, 1, time.Second), fake)
+	admissionCtx, cancelAdmission := context.WithCancel(context.Background())
+	candidate := fixtureCandidate(t, "task-1", "board-1", "https://one.example/sitemap.xml")
+	if err := coordinator.Submit(admissionCtx, context.Background(), candidate); err != nil {
+		t.Fatal(err)
+	}
+	cancelAdmission()
+	if result := awaitResult(t, coordinator); result.Err != nil {
+		t.Fatalf("admission cancellation escaped into execution: %v", result.Err)
+	}
+	if err := awaitValue(t, executed, "execution outcome"); err != nil {
+		t.Fatalf("execution context was canceled: %v", err)
+	}
+	shutdownCoordinator(t, coordinator)
+}
+
+func TestQueuedExecutionCancellationNeverClaims(t *testing.T) {
+	fake := newFakeDependencies()
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	fake.executeHook = func(ctx context.Context, candidate Candidate, fence Fence) (Execution, error) {
+		if candidate.TaskID() == "first" {
+			close(firstStarted)
+			select {
+			case <-releaseFirst:
+				return Execution{Fence: fence}, nil
+			case <-ctx.Done():
+				return Execution{Fence: fence}, ctx.Err()
+			}
+		}
+		return Execution{Fence: fence}, nil
+	}
+	coordinator := newTestCoordinator(t, testConfig(1, 2, 2, 1, time.Second), fake)
+	first := fixtureCandidate(t, "first", "board-first", "https://one.example/first.xml")
+	queued := fixtureCandidate(t, "queued", "board-queued", "https://two.example/queued.xml")
+	if err := coordinator.Submit(context.Background(), context.Background(), first); err != nil {
+		t.Fatal(err)
+	}
+	awaitSignal(t, firstStarted, "first execution")
+	queuedCtx, cancelQueued := context.WithCancel(context.Background())
+	if err := coordinator.Submit(context.Background(), queuedCtx, queued); err != nil {
+		t.Fatal(err)
+	}
+	cancelQueued()
+	close(releaseFirst)
+	results := map[string]worker.Result{}
+	for range 2 {
+		result := awaitResult(t, coordinator)
+		results[result.JobID] = result
+	}
+	if results["first"].Err != nil || !errors.Is(results["queued"].Err, context.Canceled) {
+		t.Fatalf("results: first=%v queued=%v", results["first"].Err, results["queued"].Err)
+	}
+	shutdownCoordinator(t, coordinator)
+	assertCounts(t, fake, 1, 1, 1, 1)
+}
+
+func TestCancellationAtTerminalStartSuppressesMutation(t *testing.T) {
+	fake := newFakeDependencies()
+	terminalStarted := make(chan struct{})
+	var applied atomic.Bool
+	fake.terminalHook = func(ctx context.Context, _ Candidate, execution Execution, _ error) (Fence, error) {
+		close(terminalStarted)
+		<-ctx.Done()
+		if ctx.Err() == nil {
+			applied.Store(true)
+		}
+		return execution.Fence, ctx.Err()
+	}
+	coordinator := newTestCoordinator(t, testConfig(1, 1, 1, 1, time.Second), fake)
+	executionCtx, cancelExecution := context.WithCancel(context.Background())
+	candidate := fixtureCandidate(t, "task-1", "board-1", "https://one.example/sitemap.xml")
+	if err := coordinator.Submit(context.Background(), executionCtx, candidate); err != nil {
+		t.Fatal(err)
+	}
+	awaitSignal(t, terminalStarted, "terminal entry")
+	cancelExecution()
+	if result := awaitResult(t, coordinator); !errors.Is(result.Err, context.Canceled) {
+		t.Fatalf("got %v", result.Err)
+	}
+	if applied.Load() {
+		t.Fatal("terminal mutation applied after cancellation")
+	}
+	shutdownCoordinator(t, coordinator)
+}
+
+func TestPostJoinLeaseLossSuppressesTerminalEvenIfJoinReturnsNil(t *testing.T) {
+	fake := newFakeDependencies()
+	fake.startHook = func(_ context.Context, grant ClaimGrant) (LeaseHandle, error) {
+		return &lossAtJoinHandle{fakeHandle: newFakeHandle(grant.Fence)}, nil
+	}
+	coordinator := newTestCoordinator(t, testConfig(1, 1, 1, 1, time.Second), fake)
+	candidate := fixtureCandidate(t, "task-1", "board-1", "https://one.example/sitemap.xml")
+	if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+		t.Fatal(err)
+	}
+	if result := awaitResult(t, coordinator); !errors.Is(result.Err, ErrLeaseLost) {
+		t.Fatalf("got %v", result.Err)
+	}
+	_, _, _, terminals := fake.counts()
+	if terminals != 0 {
+		t.Fatal("terminal ran after post-join loss")
+	}
+	shutdownCoordinator(t, coordinator)
+}
+
+func TestExecutorPanicStillStopsAndJoinsWithoutTerminal(t *testing.T) {
+	fake := newFakeDependencies()
+	handleReady := make(chan *fakeHandle, 1)
+	fake.startHook = func(_ context.Context, grant ClaimGrant) (LeaseHandle, error) {
+		handle := newFakeHandle(grant.Fence)
+		handleReady <- handle
+		return handle, nil
+	}
+	fake.executeHook = func(context.Context, Candidate, Fence) (Execution, error) {
+		panic("secret panic value")
+	}
+	coordinator := newTestCoordinator(t, testConfig(1, 1, 1, 1, time.Second), fake)
+	candidate := fixtureCandidate(t, "task-1", "board-1", "https://one.example/sitemap.xml")
+	if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+		t.Fatal(err)
+	}
+	result := awaitResult(t, coordinator)
+	if !errors.Is(result.Err, ErrDependencyPanic) || strings.Contains(result.Err.Error(), "secret") {
+		t.Fatalf("panic was not safely contained: %v", result.Err)
+	}
+	handle := awaitValue(t, handleReady, "panic handle")
+	if handle.stops.Load() != 1 || handle.joins.Load() != 1 {
+		t.Fatalf("cleanup counts: stop=%d join=%d", handle.stops.Load(), handle.joins.Load())
+	}
+	_, _, _, terminals := fake.counts()
+	if terminals != 0 {
+		t.Fatal("terminal ran after executor panic")
+	}
+	shutdownCoordinator(t, coordinator)
+}
+
+func TestClaimPanicReleasesCloseGateAndCapacity(t *testing.T) {
+	fake := newFakeDependencies()
+	fake.claimHook = func(context.Context, Candidate) (ClaimGrant, error) {
+		panic("secret claim panic")
+	}
+	coordinator := newTestCoordinator(t, testConfig(1, 1, 1, 1, time.Second), fake)
+	candidate := fixtureCandidate(t, "task-1", "board-1", "https://one.example/sitemap.xml")
+	if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+		t.Fatal(err)
+	}
+	if result := awaitResult(t, coordinator); !errors.Is(result.Err, ErrDependencyPanic) || strings.Contains(result.Err.Error(), "secret") {
+		t.Fatalf("claim panic was not contained: %v", result.Err)
+	}
+	closed := make(chan struct{})
+	go func() {
+		coordinator.Close()
+		close(closed)
+	}()
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("claim panic leaked the close gate")
+	}
+	for range coordinator.Results() {
+	}
+	awaitSignal(t, coordinator.Done(), "backpressured coordinator")
+}
+
+func TestSupervisorStartFailureAndPanicAreContained(t *testing.T) {
+	startFailure := errors.New("start failed")
+	tests := map[string]struct {
+		hook        func(context.Context, ClaimGrant) (LeaseHandle, error)
+		want        error
+		wantCleanup bool
+	}{
+		"handle plus error": {
+			hook: func(_ context.Context, grant ClaimGrant) (LeaseHandle, error) {
+				return newFakeHandle(grant.Fence), startFailure
+			},
+			want:        startFailure,
+			wantCleanup: true,
+		},
+		"panic": {
+			hook: func(context.Context, ClaimGrant) (LeaseHandle, error) {
+				panic("secret start panic")
+			},
+			want: ErrDependencyPanic,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			fake := newFakeDependencies()
+			var returned *fakeHandle
+			fake.startHook = func(ctx context.Context, grant ClaimGrant) (LeaseHandle, error) {
+				handle, err := test.hook(ctx, grant)
+				if value, ok := handle.(*fakeHandle); ok {
+					returned = value
+				}
+				return handle, err
+			}
+			coordinator := newTestCoordinator(t, testConfig(1, 1, 1, 1, time.Second), fake)
+			candidate := fixtureCandidate(t, "task-1", "board-1", "https://one.example/sitemap.xml")
+			if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+				t.Fatal(err)
+			}
+			result := awaitResult(t, coordinator)
+			if !errors.Is(result.Err, test.want) || strings.Contains(result.Err.Error(), "secret") {
+				t.Fatalf("got %v want %v", result.Err, test.want)
+			}
+			if test.wantCleanup && (returned == nil || returned.stops.Load() != 1 || returned.joins.Load() != 1) {
+				t.Fatalf("start error handle not cleaned: %#v", returned)
+			}
+			_, _, executions, terminals := fake.counts()
+			if executions != 0 || terminals != 0 {
+				t.Fatalf("later phase ran: executions=%d terminals=%d", executions, terminals)
+			}
+			shutdownCoordinator(t, coordinator)
+		})
+	}
+}
+
+func TestHandleInspectionPanicCleansUpAndKeepsPanicClass(t *testing.T) {
+	fake := newFakeDependencies()
+	var underlying *fakeHandle
+	fake.startHook = func(_ context.Context, grant ClaimGrant) (LeaseHandle, error) {
+		underlying = newFakeHandle(grant.Fence)
+		return &panicInspectHandle{fakeHandle: underlying}, nil
+	}
+	coordinator := newTestCoordinator(t, testConfig(1, 1, 1, 1, time.Second), fake)
+	candidate := fixtureCandidate(t, "task-1", "board-1", "https://one.example/sitemap.xml")
+	if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+		t.Fatal(err)
+	}
+	if result := awaitResult(t, coordinator); !errors.Is(result.Err, ErrDependencyPanic) {
+		t.Fatalf("got %v", result.Err)
+	}
+	if underlying == nil || underlying.stops.Load() != 1 || underlying.joins.Load() != 1 {
+		t.Fatalf("inspection panic leaked handle: %#v", underlying)
+	}
+	shutdownCoordinator(t, coordinator)
+}
+
+func TestExecutorErrorRequiresExactFenceBeforeTerminal(t *testing.T) {
+	executionFailure := errors.New("execution failed")
+	for _, exact := range []bool{false, true} {
+		t.Run(fmt.Sprintf("exact=%t", exact), func(t *testing.T) {
+			fake := newFakeDependencies()
+			fake.executeHook = func(_ context.Context, _ Candidate, fence Fence) (Execution, error) {
+				if !exact {
+					fence.ClaimToken += "changed"
+				}
+				return Execution{Fence: fence}, executionFailure
+			}
+			coordinator := newTestCoordinator(t, testConfig(1, 1, 1, 1, time.Second), fake)
+			candidate := fixtureCandidate(t, "task-1", "board-1", "https://one.example/sitemap.xml")
+			if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+				t.Fatal(err)
+			}
+			result := awaitResult(t, coordinator)
+			_, _, _, terminals := fake.counts()
+			if exact {
+				if !errors.Is(result.Err, executionFailure) || terminals != 1 {
+					t.Fatalf("exact failure got err=%v terminals=%d", result.Err, terminals)
+				}
+			} else if !errors.Is(result.Err, ErrFenceMismatch) || terminals != 0 {
+				t.Fatalf("mismatch got err=%v terminals=%d", result.Err, terminals)
+			}
+			shutdownCoordinator(t, coordinator)
+		})
+	}
+}
+
+func TestTerminalCannotMutatePublishedResult(t *testing.T) {
+	fake := newFakeDependencies()
+	retained := make(chan Execution, 1)
+	fake.executeHook = func(_ context.Context, _ Candidate, fence Fence) (Execution, error) {
+		return Execution{Fence: fence, Result: sitemap.Result{URLs: []string{"https://original.example/job"}}}, nil
+	}
+	fake.terminalHook = func(_ context.Context, _ Candidate, execution Execution, _ error) (Fence, error) {
+		execution.Result.URLs[0] = "https://mutated.example/job"
+		retained <- execution
+		return execution.Fence, nil
+	}
+	coordinator := newTestCoordinator(t, testConfig(1, 1, 1, 1, time.Second), fake)
+	candidate := fixtureCandidate(t, "task-1", "board-1", "https://one.example/sitemap.xml")
+	if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+		t.Fatal(err)
+	}
+	result := awaitResult(t, coordinator)
+	if result.Err != nil || len(result.Sitemap.URLs) != 1 || result.Sitemap.URLs[0] != "https://original.example/job" {
+		t.Fatalf("terminal mutated published result: %#v", result)
+	}
+	kept := awaitValue(t, retained, "retained terminal execution")
+	kept.Result.URLs[0] = "https://retained.example/job"
+	if result.Sitemap.URLs[0] != "https://original.example/job" {
+		t.Fatal("terminal retained published result backing storage")
+	}
+	shutdownCoordinator(t, coordinator)
+}
+
+func TestTimeoutStopsAndJoinsWithoutTerminal(t *testing.T) {
+	fake := newFakeDependencies()
+	fake.executeHook = func(ctx context.Context, _ Candidate, fence Fence) (Execution, error) {
+		<-ctx.Done()
+		return Execution{Fence: fence}, ctx.Err()
+	}
+	coordinator := newTestCoordinator(t, testConfig(1, 1, 1, 1, 20*time.Millisecond), fake)
+	candidate := fixtureCandidate(t, "task-1", "board-1", "https://one.example/sitemap.xml")
+	if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+		t.Fatal(err)
+	}
+	if result := awaitResult(t, coordinator); !errors.Is(result.Err, context.DeadlineExceeded) {
+		t.Fatalf("got %v", result.Err)
+	}
+	_, _, _, terminals := fake.counts()
+	if terminals != 0 {
+		t.Fatal("terminal ran after timeout")
+	}
+	shutdownCoordinator(t, coordinator)
+}
+
+func TestBoundedCandidateCarriageUnderResultBackpressure(t *testing.T) {
+	const capacity = 2
+	fake := newFakeDependencies()
+	coordinator := newTestCoordinator(t, testConfig(1, capacity, 1, 1, time.Second), fake)
+
+	// The first result fills the sole result slot. The second worker then blocks
+	// publishing, retaining its worker slot while many callers contend.
+	for index := range 2 {
+		candidate := fixtureCandidate(t, fmt.Sprintf("seed-%d", index), fmt.Sprintf("seed-board-%d", index), fmt.Sprintf("https://seed%d.example/sitemap.xml", index))
+		if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+			t.Fatal(err)
+		}
+	}
+	deadline := time.Now().Add(time.Second)
+	for coordinator.Stats().Completed < 1 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if coordinator.Stats().Completed < 1 {
+		t.Fatal("first result never filled the backpressure slot")
+	}
+
+	const contenders = 24
+	errorsOut := make(chan error, contenders)
+	start := make(chan struct{})
+	contenderCandidates := make([]Candidate, 0, contenders)
+	for index := range contenders {
+		contenderCandidates = append(contenderCandidates, fixtureCandidate(t, fmt.Sprintf("blocked-%d", index), fmt.Sprintf("blocked-board-%d", index), fmt.Sprintf("https://blocked%d.example/sitemap.xml", index)))
+	}
+	for index := range contenders {
+		go func(index int) {
+			<-start
+			ctx, cancel := context.WithTimeout(context.Background(), 40*time.Millisecond)
+			defer cancel()
+			errorsOut <- coordinator.Submit(ctx, context.Background(), contenderCandidates[index])
+		}(index)
+	}
+	close(start)
+	until := time.Now().Add(60 * time.Millisecond)
+	for time.Now().Before(until) {
+		stats := coordinator.Stats()
+		outstanding := stats.Accepted - stats.Completed
+		if outstanding > uint64(capacity) || stats.Queued+stats.InFlight > int64(capacity) {
+			t.Fatalf("worker bound exceeded: outstanding=%d queued=%d inflight=%d", outstanding, stats.Queued, stats.InFlight)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	for range contenders {
+		err := awaitValue(t, errorsOut, "contender result")
+		if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("contender error: %v", err)
+		}
+	}
+	coordinator.Close()
+	for range coordinator.Results() {
+	}
+	awaitSignal(t, coordinator.Done(), "bounded coordinator")
+}
+
+func TestJoinTimeoutSuppressesTerminal(t *testing.T) {
+	fake := newFakeDependencies()
+	fake.startHook = func(_ context.Context, grant ClaimGrant) (LeaseHandle, error) {
+		return &blockingJoinHandle{fakeHandle: newFakeHandle(grant.Fence)}, nil
+	}
+	config := testConfig(1, 1, 1, 1, time.Second)
+	config.JoinTimeout = 10 * time.Millisecond
+	coordinator := newTestCoordinator(t, config, fake)
+	candidate := fixtureCandidate(t, "task-1", "board-1", "https://one.example/sitemap.xml")
+	if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+		t.Fatal(err)
+	}
+	if result := awaitResult(t, coordinator); !errors.Is(result.Err, ErrSupervisorJoin) {
+		t.Fatalf("got %v", result.Err)
+	}
+	_, _, _, terminals := fake.counts()
+	if terminals != 0 {
+		t.Fatal("terminal ran after join timeout")
+	}
+	shutdownCoordinator(t, coordinator)
+}
+
+func TestCoordinatorRejectsNegativeWorkerCapacityWithoutPanic(t *testing.T) {
+	fake := newFakeDependencies()
+	config := testConfig(1, 1, 1, 1, time.Second)
+	config.Worker.Capacity = -1
+	if coordinator, err := New(config, fake, fake, fake, fake); coordinator != nil || !errors.Is(err, ErrInvalidConfig) {
+		t.Fatalf("coordinator=%v err=%v", coordinator, err)
+	}
+}
+
+func TestNilContextsAreRejectedByTheContextBoundary(t *testing.T) {
+	fake := newFakeDependencies()
+	coordinator := newTestCoordinator(t, testConfig(1, 1, 1, 1, time.Second), fake)
+	candidate := fixtureCandidate(t, "task-1", "board-1", "https://one.example/sitemap.xml")
+	if err := coordinator.Submit(nil, context.Background(), candidate); !errors.Is(err, ErrInvalidContext) {
+		t.Fatalf("nil admission context got %v", err)
+	}
+	if err := coordinator.Submit(context.Background(), nil, candidate); !errors.Is(err, ErrInvalidContext) {
+		t.Fatalf("nil execution context got %v", err)
+	}
+	if err := coordinator.Shutdown(nil); !errors.Is(err, ErrInvalidContext) {
+		t.Fatalf("nil shutdown context got %v", err)
+	}
+	shutdownCoordinator(t, coordinator)
+}
+
+func TestCoordinatorsDoNotShareWorkerOrOriginPermits(t *testing.T) {
+	firstFake := newFakeDependencies()
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	firstFake.executeHook = func(ctx context.Context, _ Candidate, fence Fence) (Execution, error) {
+		close(firstStarted)
+		select {
+		case <-releaseFirst:
+			return Execution{Fence: fence}, nil
+		case <-ctx.Done():
+			return Execution{Fence: fence}, ctx.Err()
+		}
+	}
+	first := newTestCoordinator(t, testConfig(1, 1, 1, 1, time.Second), firstFake)
+	secondFake := newFakeDependencies()
+	second := newTestCoordinator(t, testConfig(1, 1, 1, 1, time.Second), secondFake)
+	rawURL := "https://shared-origin.example/sitemap.xml"
+	if err := first.Submit(context.Background(), context.Background(), fixtureCandidate(t, "first", "board-first", rawURL)); err != nil {
+		t.Fatal(err)
+	}
+	awaitSignal(t, firstStarted, "first coordinator execution")
+	if err := second.Submit(context.Background(), context.Background(), fixtureCandidate(t, "second", "board-second", rawURL)); err != nil {
+		t.Fatal(err)
+	}
+	if result := awaitResult(t, second); result.Err != nil {
+		t.Fatalf("second coordinator inherited first permit: %v", result.Err)
+	}
+	close(releaseFirst)
+	if result := awaitResult(t, first); result.Err != nil {
+		t.Fatal(result.Err)
+	}
+	shutdownCoordinator(t, first)
+	shutdownCoordinator(t, second)
+}
+
+func TestHermeticHTTPCompositionPreservesDispatchAndConservation(t *testing.T) {
+	const (
+		workerCount = 3
+		jobCount    = 4
+	)
+	release := make(chan struct{})
+	started := make(chan int, jobCount)
+	var globalActive atomic.Int64
+	var globalMax atomic.Int64
+	var requests atomic.Int64
+	originActive := make([]atomic.Int64, 3)
+	originMax := make([]atomic.Int64, 3)
+	servers := make([]*httptest.Server, 0, 3)
+	for index := range 3 {
+		originIndex := index
+		server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+			requests.Add(1)
+			active := globalActive.Add(1)
+			storeAtomicMax(&globalMax, active)
+			originNow := originActive[originIndex].Add(1)
+			storeAtomicMax(&originMax[originIndex], originNow)
+			started <- originIndex
+			<-release
+			originActive[originIndex].Add(-1)
+			globalActive.Add(-1)
+			_, _ = response.Write([]byte(fmt.Sprintf(`<urlset><url><loc>https://jobs.example/jobs/%d</loc></url></urlset>`, originIndex)))
+		}))
+		servers = append(servers, server)
+		defer server.Close()
+	}
+	// Register this cleanup after the server cleanups so LIFO defer order
+	// releases any blocked handlers before httptest.Server.Close waits for
+	// their connections. This keeps an assertion failure bounded.
+	defer func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	}()
+	client, err := boundedhttp.New(boundedhttp.Config{
+		RequestTimeout:           time.Second,
+		MaxDecodedBodyBytes:      1 << 20,
+		MaxRequests:              3,
+		MaxAggregateDecodedBytes: 2 << 20,
+		AllowPrivateNetwork:      true,
+		SharedTransport: &boundedhttp.SharedTransportConfig{
+			MaxIdleConns:          workerCount,
+			MaxIdleConnsPerHost:   1,
+			MaxConnsPerHost:       workerCount,
+			MaxConnections:        workerCount,
+			MaxConcurrentRequests: workerCount,
+			IdleConnTimeout:       time.Second,
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.Close()
+
+	fake := newFakeDependencies()
+	realExecutor := realSitemapExecutor{client: client}
+	fake.executeHook = realExecutor.Execute
+	coordinator := newTestCoordinator(t, testConfig(workerCount, jobCount, jobCount, 1, time.Second), fake)
+	URLs := []string{servers[0].URL, servers[0].URL, servers[1].URL, servers[2].URL}
+	for index, rawURL := range URLs {
+		candidate := fixtureCandidate(t, fmt.Sprintf("task-%d", index), fmt.Sprintf("board-%d", index), rawURL+"/sitemap.xml")
+		if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+			t.Fatal(err)
+		}
+	}
+	firstOrigins := map[int]bool{}
+	for range workerCount {
+		firstOrigins[awaitValue(t, started, "hermetic origin start")] = true
+	}
+	if len(firstOrigins) != workerCount {
+		t.Fatalf("first wave did not span origins: %v", firstOrigins)
+	}
+	assertNoInt(t, started, "duplicate origin HTTP request before release")
+	if globalMax.Load() != workerCount {
+		t.Fatalf("global HTTP overlap %d, want %d", globalMax.Load(), workerCount)
+	}
+	for index := range originMax {
+		if originMax[index].Load() != 1 {
+			t.Fatalf("origin %d overlap %d", index, originMax[index].Load())
+		}
+	}
+	close(release)
+	seen := map[string]bool{}
+	for range jobCount {
+		result := awaitResult(t, coordinator)
+		if result.Err != nil || len(result.Sitemap.URLs) != 1 {
+			t.Fatalf("result %s: err=%v urls=%v", result.JobID, result.Err, result.Sitemap.URLs)
+		}
+		seen[result.JobID] = true
+	}
+	shutdownCoordinator(t, coordinator)
+	if len(seen) != jobCount || requests.Load() != jobCount {
+		t.Fatalf("conservation: results=%d requests=%d", len(seen), requests.Load())
+	}
+	assertCounts(t, fake, jobCount, jobCount, jobCount, jobCount)
+}
+
+func TestAdversarialConcurrencyRemainsBoundedAndConserved(t *testing.T) {
+	const (
+		workerCount = 5
+		jobCount    = 60
+	)
+	fake := newFakeDependencies()
+	var active atomic.Int64
+	var maxActive atomic.Int64
+	activeByOrigin := map[string]int{}
+	maxByOrigin := map[string]int{}
+	var originMu sync.Mutex
+	fake.executeHook = func(ctx context.Context, candidate Candidate, fence Fence) (Execution, error) {
+		current := active.Add(1)
+		storeAtomicMax(&maxActive, current)
+		origin := strings.Split(candidate.Sitemap().SitemapURL, "/sitemap.xml")[0]
+		originMu.Lock()
+		activeByOrigin[origin]++
+		if activeByOrigin[origin] > maxByOrigin[origin] {
+			maxByOrigin[origin] = activeByOrigin[origin]
+		}
+		originMu.Unlock()
+		select {
+		case <-time.After(time.Duration(candidate.TaskID()[len(candidate.TaskID())-1]%3+1) * time.Millisecond):
+		case <-ctx.Done():
+		}
+		originMu.Lock()
+		activeByOrigin[origin]--
+		originMu.Unlock()
+		active.Add(-1)
+		return Execution{Fence: fence}, ctx.Err()
+	}
+	coordinator := newTestCoordinator(t, testConfig(workerCount, jobCount, jobCount, 1, time.Second), fake)
+	for index := range jobCount {
+		origin := index % 6
+		candidate := fixtureCandidate(t, fmt.Sprintf("task-%02d", index), fmt.Sprintf("board-%02d", index), fmt.Sprintf("https://o%d.example/sitemap.xml", origin))
+		if err := coordinator.Submit(context.Background(), context.Background(), candidate); err != nil {
+			t.Fatalf("Submit %d: %v", index, err)
+		}
+	}
+	for range jobCount {
+		if result := awaitResult(t, coordinator); result.Err != nil {
+			t.Fatalf("result %s: %v", result.JobID, result.Err)
+		}
+	}
+	shutdownCoordinator(t, coordinator)
+	if got := maxActive.Load(); got != workerCount {
+		t.Fatalf("max active %d, want %d", got, workerCount)
+	}
+	for origin, maximum := range maxByOrigin {
+		if maximum != 1 {
+			t.Fatalf("origin %s max %d", origin, maximum)
+		}
+	}
+	assertCounts(t, fake, jobCount, jobCount, jobCount, jobCount)
+}
+
+func assertNoString(t *testing.T, values <-chan string, description string) {
+	t.Helper()
+	select {
+	case value := <-values:
+		t.Fatalf("%s: %s", description, value)
+	case <-time.After(30 * time.Millisecond):
+	}
+}
+
+func assertNoInt(t *testing.T, values <-chan int, description string) {
+	t.Helper()
+	select {
+	case value := <-values:
+		t.Fatalf("%s: %d", description, value)
+	case <-time.After(30 * time.Millisecond):
+	}
+}
+
+func awaitSignal(t *testing.T, signal <-chan struct{}, description string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+	}
+}
+
+func awaitString(t *testing.T, values <-chan string, description string) string {
+	return awaitValue(t, values, description)
+}
+
+func awaitValue[T any](t *testing.T, values <-chan T, description string) T {
+	t.Helper()
+	select {
+	case value := <-values:
+		return value
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for %s", description)
+		var zero T
+		return zero
+	}
+}
+
+func assertCounts(t *testing.T, fake *fakeDependencies, claims, starts, executions, terminals int) {
+	t.Helper()
+	gotClaims, gotStarts, gotExecutions, gotTerminals := fake.counts()
+	if gotClaims != claims || gotStarts != starts || gotExecutions != executions || gotTerminals != terminals {
+		t.Fatalf("phase counts got %d/%d/%d/%d want %d/%d/%d/%d", gotClaims, gotStarts, gotExecutions, gotTerminals, claims, starts, executions, terminals)
+	}
+}
+
+func storeAtomicMax(target *atomic.Int64, candidate int64) {
+	for current := target.Load(); candidate > current; current = target.Load() {
+		if target.CompareAndSwap(current, candidate) {
+			return
+		}
+	}
+}

--- a/pilots/go-http-sitemap/admission/doc.go
+++ b/pilots/go-http-sitemap/admission/doc.go
@@ -1,0 +1,10 @@
+// Package admission is an inactive, dependency-injected claim-boundary
+// experiment for the Go sitemap pilot.
+//
+// It deliberately has no Redis, database, HTTP, runtime-v1 binding, or
+// deployment adapter. The package only proves that an injected claim begins
+// inside worker service capacity, after both a worker and an origin slot have
+// been assigned, and that terminal publication is fenced and fail-closed.
+// A later adapter may translate runtime-v1 BoardManifest into ManifestIdentity
+// only after validating the complete contract message.
+package admission

--- a/pilots/go-http-sitemap/sitemap/sitemap.go
+++ b/pilots/go-http-sitemap/sitemap/sitemap.go
@@ -131,26 +131,42 @@ type location struct {
 }
 
 func New(client *boundedhttp.Client, config Config) (*Runner, error) {
+	if client == nil {
+		return nil, newError(ErrorConfig, config.SitemapURL, 0, nil)
+	}
+	normalized, err := NormalizeConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	config = normalized
+	parsed, _ := url.Parse(config.SitemapURL)
+	return &Runner{client: client, config: config, allowedOrigin: canonicalOrigin(parsed), sleep: sleepContext}, nil
+}
+
+// NormalizeConfig applies the exact defaults and validation used by New
+// without allocating an HTTP client or runner. It lets bounded admission
+// snapshot the precise configuration that execution will receive.
+func NormalizeConfig(config Config) (Config, error) {
 	if config.RootMaxAttempts == 0 {
 		config.RootMaxAttempts = defaultRootMaxAttempts
 	}
 	if config.RootBackoff == 0 {
 		config.RootBackoff = defaultRootBackoff
 	}
-	if client == nil || config.SitemapURL == "" || config.MaxURLs <= 0 || config.MaxURLs > maxProtocolURLs || config.MaxIndexChildren <= 0 {
-		return nil, newError(ErrorConfig, config.SitemapURL, 0, nil)
+	if config.SitemapURL == "" || config.MaxURLs <= 0 || config.MaxURLs > maxProtocolURLs || config.MaxIndexChildren <= 0 {
+		return Config{}, newError(ErrorConfig, config.SitemapURL, 0, nil)
 	}
 	if config.RootMaxAttempts < 1 || config.RootMaxAttempts > maxRootMaxAttempts || config.RootBackoff < 0 || config.RootBackoff > time.Duration(math.MaxInt64/2) {
-		return nil, newError(ErrorConfig, config.SitemapURL, 0, nil)
+		return Config{}, newError(ErrorConfig, config.SitemapURL, 0, nil)
 	}
 	parsed, err := url.Parse(config.SitemapURL)
 	if err != nil || parsed.Scheme == "" || parsed.Host == "" || parsed.User != nil || parsed.Scheme != "https" && !(config.AllowHTTPForTesting && parsed.Scheme == "http") {
-		return nil, newError(ErrorConfig, config.SitemapURL, 0, nil)
+		return Config{}, newError(ErrorConfig, config.SitemapURL, 0, nil)
 	}
 	if (config.ReplacePrefix == "") != (config.Replacement == "") {
-		return nil, newError(ErrorConfig, config.SitemapURL, 0, nil)
+		return Config{}, newError(ErrorConfig, config.SitemapURL, 0, nil)
 	}
-	return &Runner{client: client, config: config, allowedOrigin: canonicalOrigin(parsed), sleep: sleepContext}, nil
+	return config, nil
 }
 
 func (r *Runner) Run(ctx context.Context) (Result, error) {

--- a/pilots/go-http-sitemap/sitemap/sitemap_test.go
+++ b/pilots/go-http-sitemap/sitemap/sitemap_test.go
@@ -564,6 +564,28 @@ func TestInvalidConfigMakesNoRequest(t *testing.T) {
 	}
 }
 
+func TestNormalizeConfigMatchesNewDefaults(t *testing.T) {
+	config := Config{
+		SitemapURL:       "https://example.test/sitemap.xml",
+		MaxURLs:          10,
+		MaxIndexChildren: 2,
+	}
+	normalized, err := NormalizeConfig(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if normalized.RootMaxAttempts != defaultRootMaxAttempts || normalized.RootBackoff != defaultRootBackoff {
+		t.Fatalf("wrong defaults: %#v", normalized)
+	}
+	runner, err := New(newHTTPClient(t, 1), config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if runner.config != normalized {
+		t.Fatalf("New normalized %#v, want %#v", runner.config, normalized)
+	}
+}
+
 func TestRootRetryRecoversRetryableStatuses(t *testing.T) {
 	for _, status := range []int{http.StatusAccepted, http.StatusUnauthorized, http.StatusForbidden, http.StatusRequestTimeout, http.StatusTooEarly, http.StatusTooManyRequests, http.StatusInternalServerError, 599} {
 		t.Run(fmt.Sprintf("status=%d", status), func(t *testing.T) {


### PR DESCRIPTION
Closes #8583.

## Outcome

Adds an inactive admission-before-claim composition for the accepted Go HTTP/sitemap worker. An immutable unclaimed candidate enters the existing bounded, origin-fair pool; only a dispatched worker/origin slot may call the injected atomic claim. A validated fence then flows through lease supervision, execution, stop/join, and an exact-fence terminal operation.

This is necessary RAM-ceiling worker topology work: it prevents inactive work from holding leases while waiting behind local capacity. It is not another language microbenchmark.

## Safety and scope

- one existing worker pool is the only local capacity/backlog bound
- exact runtime-v1 identity and opaque fence values are immutable and fail closed
- lease loss, cancellation, panic, mismatch, or join failure suppress terminal mutation
- close prevents queued or later work from starting a claim
- a real loopback boundedhttp+sitemap composition proves c3 across three origins and exact four-task conservation
- no Redis client, due enumerator, database writer, queue-v2 activation, Lightpanda service, workflow, infrastructure, or production authority

Deferred as premature here: claim_next or another scheduler, outbox/catalog, sharding/autoscaling, mixed queue ownership, and production cohort handoff.

## Verification

- go test -count=20 ./admission
- go test -race -count=5 ./admission
- go test ./...
- go test -race ./...
- go vet ./...
- go mod tidy -diff
- formatting and diff checks
- hermetic three-origin composition repeated 100 times by the lifecycle critic
- two independent local merge-quality approvals before publication

The PR remains draft pending exact commit-SHA review and required CI.