### PR TITLE
[pilot] Bridge runtime v1 to the Lightpanda one-shot runner

### DIFF
--- a/.github/workflows/go-lightpanda-pilot.yml
+++ b/.github/workflows/go-lightpanda-pilot.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     paths:
       - "pilots/go-lightpanda/**"
+      - "apps/crawler/contracts/go.mod"
+      - "apps/crawler/contracts/go.sum"
+      - "apps/crawler/contracts/v1/gen/go/**"
+      - "apps/crawler/contracts/v1/lightpandaadapter/**"
       - ".github/workflows/go-lightpanda-pilot.yml"
   workflow_dispatch:
 
@@ -51,7 +55,7 @@ jobs:
           test -z "$(gofmt -l .)"
 
       - name: Exercise checksum-pinned stable Lightpanda
-        run: docker build --platform ${{ matrix.platform }} --target integration-test --tag jobseek-lightpanda-integration:${{ matrix.arch }}-${{ github.run_id }} .
+        run: docker build --build-context contracts=../../apps/crawler/contracts --platform ${{ matrix.platform }} --target integration-test --tag jobseek-lightpanda-integration:${{ matrix.arch }}-${{ github.run_id }} .
 
       - name: Build bounded runtime image
-        run: docker build --platform ${{ matrix.platform }} --target runtime --tag jobseek-lightpanda-pilot:${{ matrix.arch }}-${{ github.run_id }} .
+        run: docker build --build-context contracts=../../apps/crawler/contracts --platform ${{ matrix.platform }} --target runtime --tag jobseek-lightpanda-pilot:${{ matrix.arch }}-${{ github.run_id }} .

--- a/pilots/go-lightpanda/Dockerfile
+++ b/pilots/go-lightpanda/Dockerfile
@@ -1,6 +1,12 @@
 FROM golang:1.24-bookworm AS go-source
 
-WORKDIR /src
+# The primary build context remains this pilot directory. The caller supplies
+# apps/crawler/contracts as the narrowly scoped BuildKit context "contracts";
+# the repository root and crawler credentials never enter the build context.
+WORKDIR /workspace/pilots/go-lightpanda
+COPY --from=contracts go.mod go.sum /workspace/apps/crawler/contracts/
+COPY --from=contracts v1/gen/go/ /workspace/apps/crawler/contracts/v1/gen/go/
+COPY --from=contracts v1/lightpandaadapter/ /workspace/apps/crawler/contracts/v1/lightpandaadapter/
 COPY go.mod go.sum ./
 RUN go mod download
 COPY *.go ./
@@ -45,7 +51,8 @@ FROM pilot-base AS integration-test
 COPY --from=integration-build /out/go-lightpanda.test /usr/local/bin/go-lightpanda.test
 ENV LIGHTPANDA_INTEGRATION_BIN=/usr/local/bin/lightpanda
 RUN --network=none /usr/local/bin/go-lightpanda.test \
-    -test.run '^TestLightpandaIntegration$' -test.count=1 -test.v
+    -test.run '^(TestLightpandaIntegration|TestLightpandaRuntimeV1BridgeIntegration)$' \
+    -test.count=1 -test.v
 
 FROM pilot-base AS runtime
 

--- a/pilots/go-lightpanda/README.md
+++ b/pilots/go-lightpanda/README.md
@@ -6,6 +6,22 @@ HTTP(S) URL and one synchronous JavaScript expression. It returns bounded JSON
 containing the top-level document's final response status, final URL,
 `<html>` outerHTML, and the expression value.
 
+The same package also contains a dormant in-process implementation of the
+runtime-v1 `lightpandaadapter.Runner`. It maps only B0 render or B1 render plus
+one synchronous evaluation declared to have no network effect onto exactly
+one existing one-shot lifecycle. It is not exposed by the CLI and adds no
+service, endpoint, queue, persistence, fallback, deployment, or production
+routing.
+The adapter still requires an injected evaluation-privacy implementation;
+only a loopback-fixture sealer exists in tests.
+
+The bridge preserves the pilot's stricter 512 KiB HTML ceiling and reports an
+oversized document as the adapter's closed `RESOURCE_LIMIT` result. B1 uses
+the smaller of the plan's `max_result_bytes` and the pilot's 64 KiB ceiling.
+A typed cleanup-verification failure remains authoritative over a concurrent
+timeout or cancellation; other provider details are reduced to message-free,
+fail-closed adapter errors.
+
 The runner starts a new Lightpanda process for its single task on a chosen free
 loopback port:
 
@@ -38,7 +54,10 @@ GLIBC 2.38 requirement. The Go builder tag and packages resolved during
 `apt-get` are not snapshot-pinned, so the complete build is not reproducible.
 
 ```sh
-docker build --platform linux/amd64 -t jobseek-lightpanda-pilot .
+docker build \
+  --build-context contracts=../../apps/crawler/contracts \
+  --platform linux/amd64 \
+  -t jobseek-lightpanda-pilot .
 
 docker run --rm \
   --cpus=1 \
@@ -81,15 +100,19 @@ disposable Linux environment:
 
 ```sh
 LIGHTPANDA_INTEGRATION_BIN=/absolute/path/to/lightpanda-x86_64-linux \
-  go test -run '^TestLightpandaIntegration$' -count=1 -v .
+  go test -run '^(TestLightpandaIntegration|TestLightpandaRuntimeV1BridgeIntegration)$' \
+  -count=1 -v .
 
-docker build --platform linux/amd64 --target integration-test \
+docker build --build-context contracts=../../apps/crawler/contracts \
+  --platform linux/amd64 --target integration-test \
   -t jobseek-lightpanda-integration:amd64 .
 
 LIGHTPANDA_INTEGRATION_BIN=/absolute/path/to/lightpanda-aarch64-linux \
-  go test -run '^TestLightpandaIntegration$' -count=1 -v .
+  go test -run '^(TestLightpandaIntegration|TestLightpandaRuntimeV1BridgeIntegration)$' \
+  -count=1 -v .
 
-docker build --platform linux/arm64 --target integration-test \
+docker build --build-context contracts=../../apps/crawler/contracts \
+  --platform linux/arm64 --target integration-test \
   -t jobseek-lightpanda-integration:arm64 .
 ```
 
@@ -113,9 +136,11 @@ they are written. HTML and expression values are necessarily materialized by
 the CDP client before their output-size checks run; the required 512 MiB
 container memory limit is the hard allocation bound. Normally an oversized
 result returns an error, but an extreme page can instead hit the container
-limit. Error strings are truncated only after the originating library creates
-them. Successfully encoded JSON is buffered and size-checked before its single
-output write.
+limit. The runtime-v1 bridge preserves this inherited pre-materialization
+behavior; streamed CDP decoding is deferred and is not implied by the caller's
+smaller evaluation-result ceiling. Error strings are truncated only after the
+originating library creates them. Successfully encoded JSON is buffered and
+size-checked before its single output write.
 
 This CLI is not a secret-handling interface. Its URL and expression are visible
 in process arguments, and final URLs, browser-derived values, child logs, and
@@ -128,5 +153,7 @@ content, or expressions.
 This pilot intentionally has no queues, crawler wiring, browser fallback,
 process pooling, proxy or authentication support, request interception,
 `networkidle` waiting, `stopLoading`, iframe capture, nightly binary, deployment,
-or observability integration. It is not a production service or production
+or observability integration. The runtime-v1 bridge is exercised only against
+loopback fixtures and has no reusable production evaluation-privacy sealer or
+destination/subresource policy. It is not a production service or production
 browser-security boundary.

--- a/pilots/go-lightpanda/go.mod
+++ b/pilots/go-lightpanda/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/chromedp/cdproto v0.0.0-20250724212937-08a3db8b4327
 	github.com/chromedp/chromedp v0.14.2
+	github.com/colophon-group/jobseek/apps/crawler/contracts v0.0.0
 )
 
 require (
@@ -14,4 +15,7 @@ require (
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.4.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
+	google.golang.org/protobuf v1.36.10 // indirect
 )
+
+replace github.com/colophon-group/jobseek/apps/crawler/contracts => ../../apps/crawler/contracts

--- a/pilots/go-lightpanda/go.sum
+++ b/pilots/go-lightpanda/go.sum
@@ -12,6 +12,8 @@ github.com/gobwas/pool v0.2.1 h1:xfeeEhW7pwmX8nuLVlqbzVc7udMDrwetjEv+TZIz1og=
 github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6WezmKEw=
 github.com/gobwas/ws v1.4.0 h1:CTaoG1tojrh4ucGPcoJFiAQUAsEWekEWvLy7GsVNqGs=
 github.com/gobwas/ws v1.4.0/go.mod h1:G3gNqMNtPppf5XUz7O4shetPpcZ1VJ7zt18dlUeakrc=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80 h1:6Yzfa6GP0rIo/kULo2bwGEkFvCePZ3qHDDTC3/J9Swo=
 github.com/ledongthuc/pdf v0.0.0-20220302134840-0c2507a12d80/go.mod h1:imJHygn/1yfhB7XSJJKlFZKl/J+dCPAknuiaGOshXAs=
 github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde h1:x0TT0RDC7UhAVbbWWBzr41ElhJx5tXPWkIHA2HWPRuw=
@@ -19,3 +21,5 @@ github.com/orisano/pixelmatch v0.0.0-20220722002657-fb0b55479cde/go.mod h1:nZgzb
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
 golang.org/x/sys v0.34.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+google.golang.org/protobuf v1.36.10 h1:AYd7cD/uASjIL6Q9LiTjz8JLcrh/88q5UObnmY3aOOE=
+google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=

--- a/pilots/go-lightpanda/harness.go
+++ b/pilots/go-lightpanda/harness.go
@@ -36,19 +36,32 @@ const (
 	maxProcessLogBytes    = 32 << 10
 )
 
-// Task is intentionally small: the pilot navigates once and evaluates one
-// synchronous JavaScript expression.
+var (
+	errCleanupUnproved = errors.New("lightpanda cleanup could not be proved")
+	errResourceLimit   = errors.New("lightpanda result exceeded a resource limit")
+)
+
+// Task is intentionally small: the pilot navigates once and optionally
+// evaluates one synchronous JavaScript expression.
 type Task struct {
 	URL        string
-	Expression string
+	Evaluation *TaskEvaluation
+}
+
+// TaskEvaluation is present exactly for B1 work. Presence is explicit so an
+// empty or malformed B1 expression can never be mistaken for render-only B0.
+type TaskEvaluation struct {
+	Expression     string
+	MaxResultBytes int
 }
 
 // Result contains only data from the top-level document.
 type Result struct {
-	Status     int             `json:"status"`
-	FinalURL   string          `json:"final_url"`
-	HTML       string          `json:"html"`
-	Expression json.RawMessage `json:"expression"`
+	Status      int             `json:"status"`
+	FinalURL    string          `json:"final_url"`
+	HTML        string          `json:"html"`
+	HTMLPresent bool            `json:"-"`
+	Expression  json.RawMessage `json:"expression"`
 }
 
 type managedProcess interface {
@@ -131,17 +144,38 @@ func runTaskWithDependencies(ctx context.Context, config Config, deps dependenci
 	state := watchProcess(process)
 
 	taskCtx, cancel := context.WithTimeout(ctx, config.TaskTimeout)
-	result, runErr := executeTask(taskCtx, deps, process, state, port, task)
+	result, runErr := executeTaskSafely(taskCtx, deps, process, state, port, task)
 	cancel()
 
 	cleanupErr := cleanupProcess(config, deps, process, state, port)
 	if cleanupErr != nil {
-		runErr = errors.Join(runErr, fmt.Errorf("cleanup lightpanda: %w", cleanupErr))
+		runErr = errors.Join(
+			runErr,
+			errCleanupUnproved,
+			fmt.Errorf("cleanup lightpanda: %w", cleanupErr),
+		)
 	}
 	if runErr != nil {
 		return Result{}, runErr
 	}
 	return result, nil
+}
+
+func executeTaskSafely(
+	ctx context.Context,
+	deps dependencies,
+	process managedProcess,
+	state *processState,
+	port int,
+	task Task,
+) (result Result, err error) {
+	defer func() {
+		if recover() != nil {
+			result = Result{}
+			err = errors.New("lightpanda execution panicked")
+		}
+	}()
+	return executeTask(ctx, deps, process, state, port, task)
 }
 
 func executeTask(ctx context.Context, deps dependencies, process managedProcess, state *processState, port int, task Task) (Result, error) {
@@ -160,7 +194,7 @@ func executeTask(ctx context.Context, deps dependencies, process managedProcess,
 	if err != nil {
 		return Result{}, fmt.Errorf("execute CDP task: %w", err)
 	}
-	if err := validateResult(result); err != nil {
+	if err := validateResult(task, result); err != nil {
 		return Result{}, err
 	}
 	return result, nil
@@ -174,8 +208,14 @@ func validateTask(task Task) error {
 	if err != nil || parsed.Host == "" || parsed.User != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") {
 		return errors.New("URL must be an absolute http or https URL")
 	}
-	if len(task.Expression) == 0 || len(task.Expression) > maxExpressionBytes {
+	if task.Evaluation == nil {
+		return nil
+	}
+	if len(task.Evaluation.Expression) == 0 || len(task.Evaluation.Expression) > maxExpressionBytes {
 		return fmt.Errorf("expression must contain 1..%d bytes", maxExpressionBytes)
+	}
+	if task.Evaluation.MaxResultBytes <= 0 || task.Evaluation.MaxResultBytes > maxExpressionResult {
+		return fmt.Errorf("expression result limit must contain 1..%d bytes", maxExpressionResult)
 	}
 	return nil
 }
@@ -208,21 +248,30 @@ func validateCDPEndpoint(raw string, expectedPort int) error {
 	return nil
 }
 
-func validateResult(result Result) error {
+func validateResult(task Task, result Result) error {
 	if result.Status < 100 || result.Status > 599 {
 		return fmt.Errorf("missing or invalid main-document response status %d", result.Status)
 	}
 	if len(result.FinalURL) == 0 || len(result.FinalURL) > maxURLBytes {
 		return errors.New("final URL is missing or too large")
 	}
+	if !result.HTMLPresent {
+		return errors.New("main-document outerHTML is missing")
+	}
 	if len(result.HTML) > maxHTMLBytes {
-		return fmt.Errorf("main-document outerHTML exceeds %d bytes", maxHTMLBytes)
+		return fmt.Errorf("%w: main-document outerHTML exceeds %d bytes", errResourceLimit, maxHTMLBytes)
+	}
+	if task.Evaluation == nil {
+		if result.Expression != nil {
+			return errors.New("render-only task returned an expression result")
+		}
+		return nil
 	}
 	if len(result.Expression) == 0 {
 		return errors.New("expression result is empty")
 	}
-	if len(result.Expression) > maxExpressionResult {
-		return fmt.Errorf("expression result exceeds %d bytes", maxExpressionResult)
+	if len(result.Expression) > task.Evaluation.MaxResultBytes {
+		return fmt.Errorf("%w: expression result exceeds %d bytes", errResourceLimit, task.Evaluation.MaxResultBytes)
 	}
 	if !json.Valid(result.Expression) {
 		return errors.New("expression result is not valid JSON")
@@ -239,7 +288,15 @@ type processState struct {
 func watchProcess(process managedProcess) *processState {
 	state := &processState{done: make(chan struct{})}
 	go func() {
-		err := process.Wait()
+		var err error
+		func() {
+			defer func() {
+				if recover() != nil {
+					err = errors.New("lightpanda process wait panicked")
+				}
+			}()
+			err = process.Wait()
+		}()
 		state.mu.Lock()
 		state.err = err
 		state.mu.Unlock()
@@ -269,7 +326,7 @@ func (s *processState) readinessError() error {
 func cleanupProcess(config Config, deps dependencies, process managedProcess, state *processState, port int) error {
 	deadline := time.Now().Add(config.CleanupTimeout)
 	var errs []error
-	if err := process.SignalGroup(syscall.SIGTERM); err != nil {
+	if err := signalProcessGroup(process, syscall.SIGTERM); err != nil {
 		errs = append(errs, fmt.Errorf("terminate process group: %w", err))
 	}
 
@@ -278,11 +335,11 @@ func cleanupProcess(config Config, deps dependencies, process managedProcess, st
 		grace = remaining
 	}
 	if !waitUntil(state.done, grace) {
-		alive, err := process.GroupAlive()
+		alive, err := processGroupAlive(process)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("verify process group before kill: %w", err))
 		} else if alive {
-			if err := process.SignalGroup(syscall.SIGKILL); err != nil {
+			if err := signalProcessGroup(process, syscall.SIGKILL); err != nil {
 				errs = append(errs, fmt.Errorf("kill process group: %w", err))
 			}
 		}
@@ -295,29 +352,41 @@ func cleanupProcess(config Config, deps dependencies, process managedProcess, st
 	// The leader may have exited while descendants retained its process group.
 	// Check before signaling so an already-gone group is never killed solely
 	// because its former numeric PGID was retained in commandProcess.
-	alive, err := process.GroupAlive()
+	alive, err := processGroupAlive(process)
 	if err != nil {
 		errs = append(errs, fmt.Errorf("verify residual process group: %w", err))
 	} else if alive {
-		if err := process.SignalGroup(syscall.SIGKILL); err != nil {
+		if err := signalProcessGroup(process, syscall.SIGKILL); err != nil {
 			errs = append(errs, fmt.Errorf("kill residual process group: %w", err))
 		}
 	}
 
 	for {
-		alive, err := process.GroupAlive()
+		alive, err := processGroupAlive(process)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("verify process group: %w", err))
 			break
 		}
-		if !alive && !deps.portOpen(port) {
-			return errors.Join(errs...)
+		if !alive {
+			portOpen, portErr := portOpenSafely(deps.portOpen, port)
+			if portErr != nil {
+				errs = append(errs, fmt.Errorf("verify CDP listener: %w", portErr))
+				break
+			}
+			if !portOpen {
+				return errors.Join(errs...)
+			}
 		}
 		if time.Now().After(deadline) {
 			if alive {
 				errs = append(errs, errors.New("process group still exists after cleanup"))
 			}
-			if deps.portOpen(port) {
+			portOpen, portErr := portOpenSafely(deps.portOpen, port)
+			if portErr != nil {
+				errs = append(errs, fmt.Errorf("verify CDP listener after cleanup deadline: %w", portErr))
+				return errors.Join(errs...)
+			}
+			if portOpen {
 				errs = append(errs, errors.New("CDP listener still accepts connections after cleanup"))
 			}
 			return errors.Join(errs...)
@@ -325,6 +394,35 @@ func cleanupProcess(config Config, deps dependencies, process managedProcess, st
 		time.Sleep(10 * time.Millisecond)
 	}
 	return errors.Join(errs...)
+}
+
+func signalProcessGroup(process managedProcess, signal syscall.Signal) (err error) {
+	defer func() {
+		if recover() != nil {
+			err = errors.New("lightpanda process signal panicked")
+		}
+	}()
+	return process.SignalGroup(signal)
+}
+
+func processGroupAlive(process managedProcess) (alive bool, err error) {
+	defer func() {
+		if recover() != nil {
+			alive = false
+			err = errors.New("lightpanda process-group check panicked")
+		}
+	}()
+	return process.GroupAlive()
+}
+
+func portOpenSafely(check func(int) bool, port int) (open bool, err error) {
+	defer func() {
+		if recover() != nil {
+			open = false
+			err = errors.New("lightpanda listener check panicked")
+		}
+	}()
+	return check(port), nil
 }
 
 func waitUntil(done <-chan struct{}, timeout time.Duration) bool {
@@ -636,30 +734,33 @@ func (chromedpExecutor) Execute(ctx context.Context, cdpURL string, task Task) (
 	}
 
 	var expression json.RawMessage
-	if err := chromedp.Run(targetCtx,
-		chromedp.ActionFunc(func(actionCtx context.Context) error {
-			remoteObject, exception, err := runtime.Evaluate(task.Expression).
-				WithReturnByValue(true).
-				WithAwaitPromise(false).
-				Do(actionCtx)
-			if err != nil {
+	if task.Evaluation != nil {
+		if err := chromedp.Run(targetCtx,
+			chromedp.ActionFunc(func(actionCtx context.Context) error {
+				remoteObject, exception, err := runtime.Evaluate(task.Evaluation.Expression).
+					WithReturnByValue(true).
+					WithAwaitPromise(false).
+					Do(actionCtx)
+				if err != nil {
+					return err
+				}
+				if exception != nil {
+					return fmt.Errorf("expression evaluation: %w", exception)
+				}
+				expression, err = serializeExpressionResult(remoteObject)
 				return err
-			}
-			if exception != nil {
-				return fmt.Errorf("expression evaluation: %w", exception)
-			}
-			expression, err = serializeExpressionResult(remoteObject)
-			return err
-		}),
-	); err != nil {
-		return Result{}, err
+			}),
+		); err != nil {
+			return Result{}, err
+		}
 	}
 
 	return Result{
-		Status:     int(mainStatus),
-		FinalURL:   finalURL,
-		HTML:       html,
-		Expression: expression,
+		Status:      int(mainStatus),
+		FinalURL:    finalURL,
+		HTML:        html,
+		HTMLPresent: true,
+		Expression:  expression,
 	}, nil
 }
 

--- a/pilots/go-lightpanda/harness_test.go
+++ b/pilots/go-lightpanda/harness_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -104,12 +105,30 @@ func TestRunTaskFailsAfterUnverifiedCleanup(t *testing.T) {
 	config.CleanupTimeout = 20 * time.Millisecond
 	config.TerminateGrace = 5 * time.Millisecond
 
-	if _, err := runTaskWithDependencies(context.Background(), config, deps, validTask()); err == nil {
+	if _, err := runTaskWithDependencies(context.Background(), config, deps, validTask()); err == nil || !errors.Is(err, errCleanupUnproved) {
 		t.Fatal("Run succeeded despite listener cleanup failure")
 	}
 	if contains(events.snapshot(), "signal-9") {
 		t.Fatal("cleanup sent SIGKILL after the process group was already gone")
 	}
+}
+
+func TestRunTaskContainsExecutorPanicAndCleansUp(t *testing.T) {
+	events := &eventLog{}
+	process := newFakeProcess(events, true)
+	config, deps := testRunner(process, taskExecutorFunc(func(context.Context, string, Task) (Result, error) {
+		events.add("execute-panic")
+		panic("provider detail must not escape")
+	}), func(int) bool {
+		events.add("verify-listener")
+		return false
+	})
+
+	_, err := runTaskWithDependencies(context.Background(), config, deps, validTask())
+	if err == nil || err.Error() != "lightpanda execution panicked" {
+		t.Fatalf("Run error = %v", err)
+	}
+	assertOrdered(t, events.snapshot(), "execute-panic", "signal-15", "wait-reaped", "verify-listener")
 }
 
 func TestReadyWaiterChecksChildBeforeRequest(t *testing.T) {
@@ -179,18 +198,60 @@ func TestReadyWaiterRejectsMismatchedResponsePort(t *testing.T) {
 func TestResultBounds(t *testing.T) {
 	t.Parallel()
 	result := validResult()
-	result.HTML = string(make([]byte, maxHTMLBytes+1))
-	if err := validateResult(result); err == nil {
-		t.Fatal("validateResult accepted oversized HTML")
+	result.HTML = strings.Repeat("h", maxHTMLBytes)
+	if err := validateResult(validTask(), result); err != nil {
+		t.Fatalf("validateResult rejected exact HTML limit: %v", err)
 	}
 	result = validResult()
+	result.HTML = string(make([]byte, maxHTMLBytes+1))
+	if err := validateResult(validTask(), result); err == nil || !errors.Is(err, errResourceLimit) {
+		t.Fatalf("validateResult oversized HTML error = %v", err)
+	}
+
+	limitedTask := validTask()
+	limitedTask.Evaluation.MaxResultBytes = 4
+	result = validResult()
+	result.Expression = json.RawMessage(`"xx"`)
+	if err := validateResult(limitedTask, result); err != nil {
+		t.Fatalf("validateResult rejected exact expression limit: %v", err)
+	}
+	result.Expression = json.RawMessage(`"xxx"`)
+	if err := validateResult(limitedTask, result); err == nil || !errors.Is(err, errResourceLimit) {
+		t.Fatalf("validateResult oversized expression error = %v", err)
+	}
+
+	globalTask := validTask()
+	globalTask.Evaluation.MaxResultBytes = maxExpressionResult
+	if err := validateTask(globalTask); err != nil {
+		t.Fatalf("validateTask rejected global expression limit: %v", err)
+	}
+	globalTask.Evaluation.MaxResultBytes++
+	if err := validateTask(globalTask); err == nil {
+		t.Fatal("validateTask accepted expression limit above global ceiling")
+	}
+
+	renderOnly := Task{URL: "https://example.test/jobs"}
+	result = validResult()
 	result.Expression = nil
-	if err := validateResult(result); err == nil {
+	if err := validateTask(renderOnly); err != nil {
+		t.Fatalf("validateTask rejected B0: %v", err)
+	}
+	if err := validateResult(renderOnly, result); err != nil {
+		t.Fatalf("validateResult rejected B0: %v", err)
+	}
+	renderOnly.Evaluation = &TaskEvaluation{MaxResultBytes: 1}
+	if err := validateTask(renderOnly); err == nil {
+		t.Fatal("validateTask treated malformed B1 as B0")
+	}
+
+	result = validResult()
+	result.Expression = nil
+	if err := validateResult(validTask(), result); err == nil {
 		t.Fatal("validateResult accepted an empty expression result")
 	}
 	result = validResult()
 	result.Expression = json.RawMessage(`{"not":"closed"`)
-	if err := validateResult(result); err == nil {
+	if err := validateResult(validTask(), result); err == nil {
 		t.Fatal("validateResult accepted invalid expression JSON")
 	}
 }
@@ -291,11 +352,20 @@ func testRunner(process *fakeProcess, executor taskExecutor, portOpen func(int) 
 }
 
 func validTask() Task {
-	return Task{URL: "https://example.test/jobs", Expression: "document.title"}
+	return Task{
+		URL: "https://example.test/jobs",
+		Evaluation: &TaskEvaluation{
+			Expression:     "document.title",
+			MaxResultBytes: maxExpressionResult,
+		},
+	}
 }
 
 func validResult() Result {
-	return Result{Status: 200, FinalURL: "https://example.test/jobs", HTML: "<html></html>", Expression: json.RawMessage(`"Jobs"`)}
+	return Result{
+		Status: 200, FinalURL: "https://example.test/jobs", HTML: "<html></html>", HTMLPresent: true,
+		Expression: json.RawMessage(`"Jobs"`),
+	}
 }
 
 type readyWaiterFunc func(context.Context, int, *processState) (string, error)

--- a/pilots/go-lightpanda/integration_test.go
+++ b/pilots/go-lightpanda/integration_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
@@ -12,6 +13,9 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/colophon-group/jobseek/apps/crawler/contracts/v1/lightpandaadapter"
 )
 
 var lightpandaStable040SHA256 = map[string]string{
@@ -103,6 +107,69 @@ func TestLightpandaIntegration(t *testing.T) {
 		if response.OK || !strings.Contains(response.Error, test.wantError) {
 			t.Errorf("expression %q did not fail with %q: %+v", test.expression, test.wantError, response)
 		}
+	}
+}
+
+func TestLightpandaRuntimeV1BridgeIntegration(t *testing.T) {
+	expectedSHA256, supported := lightpandaStable040SHA256[runtime.GOARCH]
+	if runtime.GOOS != "linux" || !supported {
+		t.Skip("stable Lightpanda 0.4.0 integration binary requires Linux amd64 or arm64")
+	}
+	binary := os.Getenv("LIGHTPANDA_INTEGRATION_BIN")
+	if binary == "" {
+		t.Skip("set LIGHTPANDA_INTEGRATION_BIN to opt in")
+	}
+	if err := verifyFileSHA256(binary, expectedSHA256); err != nil {
+		t.Fatal(err)
+	}
+
+	origin := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/runtime-v1-fixture" {
+			http.NotFound(writer, request)
+			return
+		}
+		writer.Header().Set("Content-Type", "text/html; charset=utf-8")
+		writer.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(writer, `<!doctype html><html><head><title>Runtime v1 fixture</title></head><body><main id="runtime-v1-fixture">local only</main></body></html>`)
+	}))
+	defer origin.Close()
+
+	for _, test := range []struct {
+		name       string
+		expression string
+	}{
+		{name: "B0"},
+		{name: "B1", expression: "document.title"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			privacy := &bridgeFixturePrivacy{}
+			adapter, err := lightpandaadapter.New(
+				runtimeV1Runner{config: Config{Binary: binary}},
+				privacy,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			input := bridgeInput(origin.URL+"/runtime-v1-fixture", test.expression, 1024)
+			input.Plan.Navigation.TimeoutMs = uint64(defaultTaskTimeout / time.Millisecond)
+			result := adapter.Execute(context.Background(), input)
+			if result.GetSuccess() == nil {
+				t.Fatalf("runtime-v1 bridge failed: %v", result)
+			}
+			success := result.GetSuccess()
+			if success.GetStatus() != http.StatusCreated || success.FinalUrl != input.Plan.TargetUrl ||
+				!bytes.Contains(bridgeManifestBody(success.Html), []byte(`id="runtime-v1-fixture"`)) {
+				t.Fatalf("unexpected bridge result: %v", success)
+			}
+			if test.expression == "" {
+				if len(success.Evaluations) != 0 || len(privacy.calls) != 0 {
+					t.Fatalf("B0 evaluated unexpectedly: %v/%#v", success.Evaluations, privacy.calls)
+				}
+			} else if len(success.Evaluations) != 1 || len(privacy.calls) != 1 ||
+				string(success.Evaluations[0].Value.Payload) != `"Runtime v1 fixture"` {
+				t.Fatalf("B1 evaluation was not preserved: %v/%#v", success.Evaluations, privacy.calls)
+			}
+		})
 	}
 }
 

--- a/pilots/go-lightpanda/main.go
+++ b/pilots/go-lightpanda/main.go
@@ -40,7 +40,13 @@ func runCLIWithRunner(args []string, output io.Writer, runner taskRunner) int {
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	result, err := runner(ctx, Config{Binary: binary}, Task{URL: args[0], Expression: args[1]})
+	result, err := runner(ctx, Config{Binary: binary}, Task{
+		URL: args[0],
+		Evaluation: &TaskEvaluation{
+			Expression:     args[1],
+			MaxResultBytes: maxExpressionResult,
+		},
+	})
 	if err != nil {
 		_ = writeCLIResponse(output, cliResponse{OK: false, Error: boundedError(err)})
 		return 1

--- a/pilots/go-lightpanda/main_test.go
+++ b/pilots/go-lightpanda/main_test.go
@@ -13,7 +13,7 @@ import (
 func TestRunCLIReturnsFailureWhenSuccessOutputIsDowngraded(t *testing.T) {
 	result := validResult()
 	result.HTML = strings.Repeat("\x01", maxHTMLBytes)
-	if err := validateResult(result); err != nil {
+	if err := validateResult(validTask(), result); err != nil {
 		t.Fatalf("expansion-heavy result should pass field bounds: %v", err)
 	}
 

--- a/pilots/go-lightpanda/runtime_v1_runner.go
+++ b/pilots/go-lightpanda/runtime_v1_runner.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	runtimev1 "github.com/colophon-group/jobseek/apps/crawler/contracts/v1/gen/go"
+	"github.com/colophon-group/jobseek/apps/crawler/contracts/v1/lightpandaadapter"
+)
+
+// runtimeV1Runner is a dormant in-process bridge from the typed runtime-v1
+// adapter to the existing one-shot Lightpanda lifecycle. It owns no service,
+// queue, retry, fallback, persistence, or production-routing behavior.
+type runtimeV1Runner struct {
+	config Config
+	run    taskRunner
+}
+
+var _ lightpandaadapter.Runner = runtimeV1Runner{}
+
+// Run translates the already-bound B0/B1 input into exactly one one-shot
+// invocation. The called lifecycle returns only after process cleanup, which
+// lets cleanup failure remain authoritative over concurrent cancellation.
+func (runner runtimeV1Runner) Run(
+	ctx context.Context,
+	bound lightpandaadapter.BoundInput,
+) lightpandaadapter.RunnerOutcome {
+	input := bound.Input()
+	if input == nil || input.Plan == nil || input.Plan.Navigation == nil ||
+		len(input.Plan.Evaluations) > 1 {
+		return internalRunnerFailure(bound)
+	}
+
+	task := Task{URL: input.Plan.TargetUrl}
+	if len(input.Plan.Evaluations) == 1 {
+		evaluation := input.Plan.Evaluations[0]
+		if evaluation == nil {
+			return internalRunnerFailure(bound)
+		}
+		limit := evaluation.MaxResultBytes
+		if limit > uint64(maxExpressionResult) {
+			limit = uint64(maxExpressionResult)
+		}
+		if limit == 0 {
+			return internalRunnerFailure(bound)
+		}
+		task.Evaluation = &TaskEvaluation{
+			Expression:     evaluation.Expression,
+			MaxResultBytes: int(limit),
+		}
+	}
+
+	config := runner.config
+	config.TaskTimeout = time.Duration(input.Plan.Navigation.TimeoutMs) * time.Millisecond
+	run := runner.run
+	if run == nil {
+		run = runTask
+	}
+	result, err := run(ctx, config, task)
+	if err != nil {
+		contextErr := ctx.Err()
+		switch {
+		case errors.Is(err, errCleanupUnproved):
+			return lightpandaadapter.NewRunnerCleanupFailure(bound)
+		case errors.Is(err, errResourceLimit):
+			return lightpandaadapter.NewRunnerFailure(bound, lightpandaadapter.ProviderFailure{
+				Code:        runtimev1.ErrorCode_ERROR_CODE_RESOURCE_LIMIT,
+				Disposition: runtimev1.ErrorDisposition_ERROR_DISPOSITION_DEFER_POLICY,
+			})
+		case errors.Is(err, context.DeadlineExceeded) &&
+			errors.Is(contextErr, context.DeadlineExceeded):
+			return lightpandaadapter.NewRunnerFailure(bound, lightpandaadapter.ProviderFailure{
+				Code:        runtimev1.ErrorCode_ERROR_CODE_TIMEOUT,
+				Disposition: runtimev1.ErrorDisposition_ERROR_DISPOSITION_RETRY_POLICY,
+			})
+		case errors.Is(err, context.Canceled) && errors.Is(contextErr, context.Canceled):
+			return lightpandaadapter.NewRunnerFailure(bound, lightpandaadapter.ProviderFailure{
+				Code:        runtimev1.ErrorCode_ERROR_CODE_CANCELLED,
+				Disposition: runtimev1.ErrorDisposition_ERROR_DISPOSITION_CANCELLED_POLICY,
+			})
+		default:
+			return internalRunnerFailure(bound)
+		}
+	}
+	if err := validateResult(task, result); err != nil {
+		if errors.Is(err, errResourceLimit) {
+			return lightpandaadapter.NewRunnerFailure(bound, lightpandaadapter.ProviderFailure{
+				Code:        runtimev1.ErrorCode_ERROR_CODE_RESOURCE_LIMIT,
+				Disposition: runtimev1.ErrorDisposition_ERROR_DISPOSITION_DEFER_POLICY,
+			})
+		}
+		return internalRunnerFailure(bound)
+	}
+
+	status := uint32(result.Status)
+	html := []byte(result.HTML)
+	if html == nil {
+		html = []byte{}
+	}
+	raw := &lightpandaadapter.RawSuccess{
+		FinalURL: result.FinalURL,
+		Status:   &status,
+		HTML:     html,
+	}
+	if len(input.Plan.Evaluations) == 1 {
+		raw.Evaluations = []lightpandaadapter.RawEvaluation{{
+			EvaluationID: input.Plan.Evaluations[0].EvaluationId,
+			JSON:         append([]byte(nil), result.Expression...),
+		}}
+	}
+	return lightpandaadapter.NewRunnerSuccess(bound, raw)
+}
+
+func internalRunnerFailure(bound lightpandaadapter.BoundInput) lightpandaadapter.RunnerOutcome {
+	return lightpandaadapter.NewRunnerFailure(bound, lightpandaadapter.ProviderFailure{
+		Code:        runtimev1.ErrorCode_ERROR_CODE_INTERNAL,
+		Disposition: runtimev1.ErrorDisposition_ERROR_DISPOSITION_FAIL_CLOSED_POLICY,
+	})
+}

--- a/pilots/go-lightpanda/runtime_v1_runner_test.go
+++ b/pilots/go-lightpanda/runtime_v1_runner_test.go
@@ -1,0 +1,701 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	runtimev1 "github.com/colophon-group/jobseek/apps/crawler/contracts/v1/gen/go"
+	"github.com/colophon-group/jobseek/apps/crawler/contracts/v1/lightpandaadapter"
+)
+
+type bridgePrivacyCall struct {
+	evaluationID string
+	raw          []byte
+	limit        uint64
+}
+
+// bridgeFixturePrivacy is test-only. It deliberately proves adapter wiring,
+// not the production privacy boundary that remains required before activation.
+type bridgeFixturePrivacy struct {
+	calls []bridgePrivacyCall
+}
+
+func (privacy *bridgeFixturePrivacy) SealEvaluation(
+	ctx context.Context,
+	evaluationID string,
+	raw []byte,
+	limit uint64,
+) (*runtimev1.ExtensionEnvelope, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	privacy.calls = append(privacy.calls, bridgePrivacyCall{
+		evaluationID: evaluationID,
+		raw:          append([]byte(nil), raw...),
+		limit:        limit,
+	})
+	digest := sha256.Sum256(raw)
+	return &runtimev1.ExtensionEnvelope{
+		SchemaId:      "jobseek.browser.evaluation-json",
+		SchemaVersion: 1,
+		Encoding:      runtimev1.ExtensionEncoding_EXTENSION_ENCODING_CANONICAL_JSON,
+		Payload:       append([]byte(nil), raw...),
+		PayloadSha256: hex.EncodeToString(digest[:]),
+	}, nil
+}
+
+func TestRuntimeV1RunnerTranslatesB0AndB1ExactlyOnce(t *testing.T) {
+	for _, test := range []struct {
+		name           string
+		expression     string
+		wantEvaluation bool
+	}{
+		{name: "B0 render only"},
+		{name: "B1 evaluation", expression: "document.title", wantEvaluation: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			input := bridgeInput("https://example.test/jobs", test.expression, 17)
+			calls := 0
+			runner := runtimeV1Runner{
+				config: Config{Binary: "/fixed/lightpanda"},
+				run: func(_ context.Context, config Config, task Task) (Result, error) {
+					calls++
+					if config.Binary != "/fixed/lightpanda" || config.TaskTimeout != 1250*time.Millisecond {
+						t.Fatalf("config = %#v", config)
+					}
+					if task.URL != input.Plan.TargetUrl {
+						t.Fatalf("task = %#v", task)
+					}
+					if test.wantEvaluation {
+						if task.Evaluation == nil || task.Evaluation.Expression != test.expression ||
+							task.Evaluation.MaxResultBytes != 17 {
+							t.Fatalf("evaluation = %#v", task.Evaluation)
+						}
+						return Result{
+							Status: 201, FinalURL: input.Plan.TargetUrl, HTML: "<html>bridge</html>", HTMLPresent: true,
+							Expression: []byte(`"fixture"`),
+						}, nil
+					}
+					if task.Evaluation != nil {
+						t.Fatalf("B0 evaluation = %#v", task.Evaluation)
+					}
+					return Result{
+						Status: 201, FinalURL: input.Plan.TargetUrl, HTML: "<html>bridge</html>", HTMLPresent: true,
+					}, nil
+				},
+			}
+			privacy := &bridgeFixturePrivacy{}
+			adapter, err := lightpandaadapter.New(runner, privacy)
+			if err != nil {
+				t.Fatal(err)
+			}
+			result := adapter.Execute(context.Background(), input)
+			if calls != 1 || result.GetSuccess() == nil {
+				t.Fatalf("calls/result = %d/%v", calls, result)
+			}
+			success := result.GetSuccess()
+			if success.GetStatus() != 201 || success.FinalUrl != input.Plan.TargetUrl ||
+				!bytes.Equal(bridgeManifestBody(success.Html), []byte("<html>bridge</html>")) {
+				t.Fatalf("success = %v", success)
+			}
+			if test.wantEvaluation {
+				if len(success.Evaluations) != 1 || len(privacy.calls) != 1 ||
+					privacy.calls[0].evaluationID != "evaluation-1" ||
+					privacy.calls[0].limit != 17 || string(privacy.calls[0].raw) != `"fixture"` {
+					t.Fatalf("evaluations/privacy = %v/%#v", success.Evaluations, privacy.calls)
+				}
+			} else if len(success.Evaluations) != 0 || len(privacy.calls) != 0 {
+				t.Fatalf("B0 evaluations/privacy = %v/%#v", success.Evaluations, privacy.calls)
+			}
+		})
+	}
+}
+
+func TestRuntimeV1RunnerPreservesHTMLPresence(t *testing.T) {
+	t.Run("missing HTML fails closed", func(t *testing.T) {
+		input := bridgeInput("https://example.test/jobs", "document.title", 64)
+		runner := runtimeV1Runner{run: func(context.Context, Config, Task) (Result, error) {
+			return Result{
+				Status: 200, FinalURL: input.Plan.TargetUrl, HTML: "",
+				Expression: []byte(`"value"`),
+			}, nil
+		}}
+		privacy := &bridgeFixturePrivacy{}
+		adapter, err := lightpandaadapter.New(runner, privacy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertBridgeFailure(
+			t,
+			adapter.Execute(context.Background(), input),
+			runtimev1.ErrorCode_ERROR_CODE_INTERNAL,
+			runtimev1.ErrorDisposition_ERROR_DISPOSITION_FAIL_CLOSED_POLICY,
+		)
+		if len(privacy.calls) != 0 {
+			t.Fatal("missing HTML reached privacy")
+		}
+	})
+
+	t.Run("present empty HTML is accepted", func(t *testing.T) {
+		input := bridgeInput("https://example.test/jobs", "", 0)
+		runner := runtimeV1Runner{run: func(context.Context, Config, Task) (Result, error) {
+			return Result{
+				Status: 200, FinalURL: input.Plan.TargetUrl, HTML: "", HTMLPresent: true,
+			}, nil
+		}}
+		privacy := &bridgeFixturePrivacy{}
+		adapter, err := lightpandaadapter.New(runner, privacy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result := adapter.Execute(context.Background(), input)
+		if result.GetSuccess() == nil || result.GetSuccess().Html == nil ||
+			result.GetSuccess().Html.TotalSizeBytes != 0 || !result.GetSuccess().Html.Complete ||
+			len(bridgeManifestBody(result.GetSuccess().Html)) != 0 {
+			t.Fatalf("present-empty HTML result = %v", result)
+		}
+		if len(privacy.calls) != 0 {
+			t.Fatal("B0 present-empty HTML reached privacy")
+		}
+	})
+}
+
+func TestRuntimeV1RunnerRejectsForgedStatusBeforeConversion(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		status int
+	}{
+		{name: "negative", status: -1},
+		{name: "wide value that truncates to HTTP status", status: int(uint64(1)<<32) + 200},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			input := bridgeInput("https://example.test/jobs", "document.title", 64)
+			runner := runtimeV1Runner{run: func(context.Context, Config, Task) (Result, error) {
+				return Result{
+					Status: test.status, FinalURL: input.Plan.TargetUrl,
+					HTML: "<html></html>", HTMLPresent: true, Expression: []byte(`"value"`),
+				}, nil
+			}}
+			privacy := &bridgeFixturePrivacy{}
+			adapter, err := lightpandaadapter.New(runner, privacy)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertBridgeFailure(
+				t,
+				adapter.Execute(context.Background(), input),
+				runtimev1.ErrorCode_ERROR_CODE_INTERNAL,
+				runtimev1.ErrorDisposition_ERROR_DISPOSITION_FAIL_CLOSED_POLICY,
+			)
+			if len(privacy.calls) != 0 {
+				t.Fatal("invalid status reached privacy")
+			}
+		})
+	}
+}
+
+func TestRuntimeV1RunnerHonorsCallerEvaluationLimit(t *testing.T) {
+	input := bridgeInput("https://example.test/jobs", "document.title", 4)
+	runner := runtimeV1Runner{run: func(_ context.Context, _ Config, task Task) (Result, error) {
+		if task.Evaluation == nil || task.Evaluation.MaxResultBytes != 4 {
+			t.Fatalf("evaluation = %#v", task.Evaluation)
+		}
+		result := Result{
+			Status: 200, FinalURL: input.Plan.TargetUrl, HTML: "<html></html>", HTMLPresent: true,
+			Expression: []byte(`"five"`),
+		}
+		return Result{}, validateResult(task, result)
+	}}
+	privacy := &bridgeFixturePrivacy{}
+	adapter, err := lightpandaadapter.New(runner, privacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBridgeFailure(
+		t,
+		adapter.Execute(context.Background(), input),
+		runtimev1.ErrorCode_ERROR_CODE_RESOURCE_LIMIT,
+		runtimev1.ErrorDisposition_ERROR_DISPOSITION_DEFER_POLICY,
+	)
+	if len(privacy.calls) != 0 {
+		t.Fatal("oversized raw evaluation reached privacy")
+	}
+}
+
+func TestRuntimeV1RunnerPreservesPilotOutputBoundaries(t *testing.T) {
+	t.Run("HTML exact limit", func(t *testing.T) {
+		input := bridgeInput("https://example.test/jobs", "", 0)
+		html := strings.Repeat("h", maxHTMLBytes)
+		runner := runtimeV1Runner{run: func(_ context.Context, _ Config, task Task) (Result, error) {
+			result := Result{Status: 200, FinalURL: input.Plan.TargetUrl, HTML: html, HTMLPresent: true}
+			if err := validateResult(task, result); err != nil {
+				return Result{}, err
+			}
+			return result, nil
+		}}
+		privacy := &bridgeFixturePrivacy{}
+		adapter, err := lightpandaadapter.New(runner, privacy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result := adapter.Execute(context.Background(), input)
+		if result.GetSuccess() == nil || len(bridgeManifestBody(result.GetSuccess().Html)) != maxHTMLBytes ||
+			len(privacy.calls) != 0 {
+			t.Fatalf("exact HTML result/privacy = %v/%d", result, len(privacy.calls))
+		}
+	})
+
+	t.Run("HTML above limit", func(t *testing.T) {
+		input := bridgeInput("https://example.test/jobs", "", 0)
+		runner := runtimeV1Runner{run: func(_ context.Context, _ Config, task Task) (Result, error) {
+			result := Result{
+				Status: 200, FinalURL: input.Plan.TargetUrl,
+				HTML: strings.Repeat("h", maxHTMLBytes+1), HTMLPresent: true,
+			}
+			return Result{}, validateResult(task, result)
+		}}
+		privacy := &bridgeFixturePrivacy{}
+		adapter, err := lightpandaadapter.New(runner, privacy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertBridgeFailure(
+			t,
+			adapter.Execute(context.Background(), input),
+			runtimev1.ErrorCode_ERROR_CODE_RESOURCE_LIMIT,
+			runtimev1.ErrorDisposition_ERROR_DISPOSITION_DEFER_POLICY,
+		)
+		if len(privacy.calls) != 0 {
+			t.Fatal("oversized HTML reached privacy")
+		}
+	})
+
+	t.Run("evaluation exact global limit", func(t *testing.T) {
+		input := bridgeInput("https://example.test/jobs", "document.title", uint64(maxExpressionResult))
+		evaluation := bridgeJSONString(maxExpressionResult)
+		runner := runtimeV1Runner{run: func(_ context.Context, _ Config, task Task) (Result, error) {
+			if task.Evaluation == nil || task.Evaluation.MaxResultBytes != maxExpressionResult {
+				t.Fatalf("evaluation = %#v", task.Evaluation)
+			}
+			result := Result{
+				Status: 200, FinalURL: input.Plan.TargetUrl, HTML: "<html></html>", HTMLPresent: true,
+				Expression: evaluation,
+			}
+			if err := validateResult(task, result); err != nil {
+				return Result{}, err
+			}
+			return result, nil
+		}}
+		privacy := &bridgeFixturePrivacy{}
+		adapter, err := lightpandaadapter.New(runner, privacy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result := adapter.Execute(context.Background(), input)
+		if result.GetSuccess() == nil || len(privacy.calls) != 1 ||
+			len(privacy.calls[0].raw) != maxExpressionResult || privacy.calls[0].limit != uint64(maxExpressionResult) {
+			t.Fatalf("exact evaluation result/privacy = %v/%#v", result, privacy.calls)
+		}
+	})
+
+	t.Run("plan above global and result above global", func(t *testing.T) {
+		input := bridgeInput("https://example.test/jobs", "document.title", uint64(maxExpressionResult+1))
+		runner := runtimeV1Runner{run: func(_ context.Context, _ Config, task Task) (Result, error) {
+			if task.Evaluation == nil || task.Evaluation.MaxResultBytes != maxExpressionResult {
+				t.Fatalf("evaluation was not capped: %#v", task.Evaluation)
+			}
+			result := Result{
+				Status: 200, FinalURL: input.Plan.TargetUrl, HTML: "<html></html>", HTMLPresent: true,
+				Expression: bridgeJSONString(maxExpressionResult + 1),
+			}
+			return Result{}, validateResult(task, result)
+		}}
+		privacy := &bridgeFixturePrivacy{}
+		adapter, err := lightpandaadapter.New(runner, privacy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertBridgeFailure(
+			t,
+			adapter.Execute(context.Background(), input),
+			runtimev1.ErrorCode_ERROR_CODE_RESOURCE_LIMIT,
+			runtimev1.ErrorDisposition_ERROR_DISPOSITION_DEFER_POLICY,
+		)
+		if len(privacy.calls) != 0 {
+			t.Fatal("above-global evaluation reached privacy")
+		}
+	})
+}
+
+func TestRuntimeV1RunnerCleanupFailureDominatesDeadline(t *testing.T) {
+	input := bridgeInput("https://example.test/jobs", "document.title", 64)
+	input.Plan.Navigation.TimeoutMs = 5
+	runner := runtimeV1Runner{run: func(ctx context.Context, _ Config, _ Task) (Result, error) {
+		<-ctx.Done()
+		return Result{}, errors.Join(ctx.Err(), errCleanupUnproved)
+	}}
+	privacy := &bridgeFixturePrivacy{}
+	adapter, err := lightpandaadapter.New(runner, privacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBridgeFailure(
+		t,
+		adapter.Execute(context.Background(), input),
+		runtimev1.ErrorCode_ERROR_CODE_INTERNAL,
+		runtimev1.ErrorDisposition_ERROR_DISPOSITION_FAIL_CLOSED_POLICY,
+	)
+	if len(privacy.calls) != 0 {
+		t.Fatal("cleanup failure reached privacy")
+	}
+}
+
+func TestRuntimeV1RunnerAuthenticatesContextFailures(t *testing.T) {
+	t.Run("genuine deadline", func(t *testing.T) {
+		input := bridgeInput("https://example.test/jobs", "document.title", 64)
+		input.Plan.Navigation.TimeoutMs = 5
+		runner := runtimeV1Runner{run: func(ctx context.Context, _ Config, _ Task) (Result, error) {
+			<-ctx.Done()
+			return Result{}, ctx.Err()
+		}}
+		privacy := &bridgeFixturePrivacy{}
+		adapter, err := lightpandaadapter.New(runner, privacy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertBridgeFailure(
+			t,
+			adapter.Execute(context.Background(), input),
+			runtimev1.ErrorCode_ERROR_CODE_TIMEOUT,
+			runtimev1.ErrorDisposition_ERROR_DISPOSITION_RETRY_POLICY,
+		)
+		if len(privacy.calls) != 0 {
+			t.Fatal("deadline failure reached privacy")
+		}
+	})
+
+	t.Run("genuine cancellation", func(t *testing.T) {
+		input := bridgeInput("https://example.test/jobs", "document.title", 64)
+		callerCtx, cancelCaller := context.WithCancel(context.Background())
+		runner := runtimeV1Runner{run: func(ctx context.Context, _ Config, _ Task) (Result, error) {
+			cancelCaller()
+			<-ctx.Done()
+			return Result{}, ctx.Err()
+		}}
+		privacy := &bridgeFixturePrivacy{}
+		adapter, err := lightpandaadapter.New(runner, privacy)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertBridgeFailure(
+			t,
+			adapter.Execute(callerCtx, input),
+			runtimev1.ErrorCode_ERROR_CODE_CANCELLED,
+			runtimev1.ErrorDisposition_ERROR_DISPOSITION_CANCELLED_POLICY,
+		)
+		if len(privacy.calls) != 0 {
+			t.Fatal("cancellation failure reached privacy")
+		}
+	})
+
+	for _, test := range []struct {
+		name string
+		err  error
+	}{
+		{name: "deadline masquerade", err: errors.Join(errors.New("provider"), context.DeadlineExceeded)},
+		{name: "cancellation masquerade", err: errors.Join(errors.New("provider"), context.Canceled)},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			input := bridgeInput("https://example.test/jobs", "document.title", 64)
+			runner := runtimeV1Runner{run: func(ctx context.Context, _ Config, _ Task) (Result, error) {
+				if ctx.Err() != nil {
+					t.Fatalf("runner context unexpectedly ended: %v", ctx.Err())
+				}
+				return Result{}, test.err
+			}}
+			privacy := &bridgeFixturePrivacy{}
+			adapter, err := lightpandaadapter.New(runner, privacy)
+			if err != nil {
+				t.Fatal(err)
+			}
+			assertBridgeFailure(
+				t,
+				adapter.Execute(context.Background(), input),
+				runtimev1.ErrorCode_ERROR_CODE_INTERNAL,
+				runtimev1.ErrorDisposition_ERROR_DISPOSITION_FAIL_CLOSED_POLICY,
+			)
+			if len(privacy.calls) != 0 {
+				t.Fatal("masquerade failure reached privacy")
+			}
+		})
+	}
+}
+
+func TestRuntimeV1RunnerContainsExecutorPanicBeforeAdapterBoundary(t *testing.T) {
+	input := bridgeInput("https://example.test/jobs", "document.title", 64)
+	events := &eventLog{}
+	process := newFakeProcess(events, true)
+	_, deps := testRunner(process, taskExecutorFunc(func(context.Context, string, Task) (Result, error) {
+		events.add("execute-panic")
+		panic("provider detail must not escape")
+	}), func(int) bool {
+		events.add("verify-listener")
+		return false
+	})
+	runner := runtimeV1Runner{
+		config: Config{CleanupTimeout: 500 * time.Millisecond, TerminateGrace: 100 * time.Millisecond},
+		run: func(ctx context.Context, config Config, task Task) (Result, error) {
+			return runTaskWithDependencies(ctx, config, deps, task)
+		},
+	}
+	privacy := &bridgeFixturePrivacy{}
+	adapter, err := lightpandaadapter.New(runner, privacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := adapter.Execute(context.Background(), input)
+	assertBridgeFailure(
+		t,
+		result,
+		runtimev1.ErrorCode_ERROR_CODE_INTERNAL,
+		runtimev1.ErrorDisposition_ERROR_DISPOSITION_FAIL_CLOSED_POLICY,
+	)
+	assertOrdered(t, events.snapshot(), "execute-panic", "signal-15", "wait-reaped", "verify-listener")
+	if strings.Contains(result.GetError().Error.Message, "provider detail") || len(privacy.calls) != 0 {
+		t.Fatalf("panic detail/privacy escaped: %v/%#v", result, privacy.calls)
+	}
+}
+
+func TestRuntimeV1RunnerCleanupFailureDominatesTimedOutExecutorPanic(t *testing.T) {
+	input := bridgeInput("https://example.test/jobs", "document.title", 64)
+	input.Plan.Navigation.TimeoutMs = 5
+	events := &eventLog{}
+	process := newFakeProcess(events, true)
+	_, deps := testRunner(process, taskExecutorFunc(func(ctx context.Context, _ string, _ Task) (Result, error) {
+		<-ctx.Done()
+		events.add("execute-panic")
+		panic("late provider panic")
+	}), func(int) bool {
+		events.add("verify-listener")
+		return true
+	})
+	runner := runtimeV1Runner{
+		config: Config{CleanupTimeout: 20 * time.Millisecond, TerminateGrace: 5 * time.Millisecond},
+		run: func(ctx context.Context, config Config, task Task) (Result, error) {
+			return runTaskWithDependencies(ctx, config, deps, task)
+		},
+	}
+	privacy := &bridgeFixturePrivacy{}
+	adapter, err := lightpandaadapter.New(runner, privacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertBridgeFailure(
+		t,
+		adapter.Execute(context.Background(), input),
+		runtimev1.ErrorCode_ERROR_CODE_INTERNAL,
+		runtimev1.ErrorDisposition_ERROR_DISPOSITION_FAIL_CLOSED_POLICY,
+	)
+	assertOrdered(t, events.snapshot(), "execute-panic", "signal-15", "wait-reaped", "verify-listener")
+	if len(privacy.calls) != 0 {
+		t.Fatal("failed cleanup reached privacy")
+	}
+}
+
+func TestRuntimeV1AdapterPreflightNeverStartsOneShot(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		mutate func(*runtimev1.BrowserExecutionInput, *context.Context)
+		code   runtimev1.ErrorCode
+	}{
+		{
+			name: "wrong assignment",
+			mutate: func(input *runtimev1.BrowserExecutionInput, _ *context.Context) {
+				input.Assignment.Backend = runtimev1.BrowserBackend_BROWSER_BACKEND_CHROMIUM
+			},
+			code: runtimev1.ErrorCode_ERROR_CODE_INVALID_CONFIG,
+		},
+		{
+			name: "unsupported capability",
+			mutate: func(input *runtimev1.BrowserExecutionInput, _ *context.Context) {
+				input.Plan.RequiredCapabilities = append(
+					input.Plan.RequiredCapabilities,
+					runtimev1.BrowserCapability_BROWSER_CAPABILITY_ACTIONS,
+				)
+			},
+			code: runtimev1.ErrorCode_ERROR_CODE_UNSPECIFIED,
+		},
+		{
+			name: "pre-cancelled",
+			mutate: func(_ *runtimev1.BrowserExecutionInput, ctx *context.Context) {
+				cancelled, cancel := context.WithCancel(*ctx)
+				cancel()
+				*ctx = cancelled
+			},
+			code: runtimev1.ErrorCode_ERROR_CODE_CANCELLED,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			input := bridgeInput("https://example.test/jobs", "document.title", 64)
+			ctx := context.Background()
+			test.mutate(input, &ctx)
+			starts := 0
+			runner := runtimeV1Runner{run: func(context.Context, Config, Task) (Result, error) {
+				starts++
+				return validResult(), nil
+			}}
+			privacy := &bridgeFixturePrivacy{}
+			adapter, err := lightpandaadapter.New(runner, privacy)
+			if err != nil {
+				t.Fatal(err)
+			}
+			result := adapter.Execute(ctx, input)
+			if starts != 0 || len(privacy.calls) != 0 {
+				t.Fatalf("preflight started dependencies: %d/%d", starts, len(privacy.calls))
+			}
+			if test.name == "unsupported capability" {
+				if result.GetUnsupported() == nil || len(result.GetUnsupported().Capabilities) != 1 ||
+					result.GetUnsupported().Capabilities[0] != runtimev1.BrowserCapability_BROWSER_CAPABILITY_ACTIONS {
+					t.Fatalf("unsupported result = %v", result)
+				}
+				return
+			}
+			if result.GetError() == nil || result.GetError().Error == nil || result.GetError().Error.Code != test.code {
+				t.Fatalf("preflight result = %v, want %s", result, test.code)
+			}
+		})
+	}
+}
+
+func TestRuntimeV1RunnerClonesCallerInputAndResult(t *testing.T) {
+	input := bridgeInput("https://example.test/jobs", "document.title", 64)
+	originalURL := input.Plan.TargetUrl
+	rawEvaluation := []byte(`"stable"`)
+	runner := runtimeV1Runner{run: func(_ context.Context, _ Config, task Task) (Result, error) {
+		if task.URL != originalURL || task.Evaluation == nil || task.Evaluation.Expression != "document.title" {
+			t.Fatalf("task changed before execution: %#v", task)
+		}
+		return Result{
+			Status: 200, FinalURL: originalURL, HTML: "<html>stable</html>", HTMLPresent: true,
+			Expression: rawEvaluation,
+		}, nil
+	}}
+	privacy := &bridgeFixturePrivacy{}
+	adapter, err := lightpandaadapter.New(runner, privacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := adapter.Execute(context.Background(), input)
+	if result.GetSuccess() == nil {
+		t.Fatalf("result = %v", result)
+	}
+	input.Plan.TargetUrl = "https://caller-mutated.invalid/"
+	input.Plan.Evaluations[0].Expression = "caller-mutated"
+	rawEvaluation[1] = 'X'
+	if result.GetSuccess().FinalUrl != originalURL ||
+		string(result.GetSuccess().Evaluations[0].Value.Payload) != `"stable"` ||
+		string(privacy.calls[0].raw) != `"stable"` {
+		t.Fatalf("caller mutation reached output/privacy: %v/%#v", result, privacy.calls)
+	}
+}
+
+func TestRuntimeV1RunnerMapsOpaqueProviderFailure(t *testing.T) {
+	input := bridgeInput("https://example.test/jobs", "document.title", 64)
+	runner := runtimeV1Runner{run: func(context.Context, Config, Task) (Result, error) {
+		return Result{}, errors.New("provider included secret detail")
+	}}
+	privacy := &bridgeFixturePrivacy{}
+	adapter, err := lightpandaadapter.New(runner, privacy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := adapter.Execute(context.Background(), input)
+	assertBridgeFailure(
+		t,
+		result,
+		runtimev1.ErrorCode_ERROR_CODE_INTERNAL,
+		runtimev1.ErrorDisposition_ERROR_DISPOSITION_FAIL_CLOSED_POLICY,
+	)
+	if strings.Contains(result.GetError().Error.Message, "secret detail") || len(privacy.calls) != 0 {
+		t.Fatalf("provider detail/privacy escaped: %v/%#v", result, privacy.calls)
+	}
+}
+
+func bridgeInput(targetURL string, expression string, resultLimit uint64) *runtimev1.BrowserExecutionInput {
+	capabilities := []runtimev1.BrowserCapability{
+		runtimev1.BrowserCapability_BROWSER_CAPABILITY_RENDER,
+	}
+	var evaluations []*runtimev1.EvaluationPlan
+	if expression != "" {
+		capabilities = append(capabilities, runtimev1.BrowserCapability_BROWSER_CAPABILITY_EVALUATE)
+		evaluations = []*runtimev1.EvaluationPlan{{
+			EvaluationId:   "evaluation-1",
+			Expression:     expression,
+			MaxResultBytes: resultLimit,
+			NetworkEffect:  runtimev1.BrowserNetworkEffect_BROWSER_NETWORK_EFFECT_NONE,
+		}}
+	}
+	return &runtimev1.BrowserExecutionInput{
+		Assignment: &runtimev1.BrowserAssignment{
+			Backend:         runtimev1.BrowserBackend_BROWSER_BACKEND_LIGHTPANDA,
+			CapabilityClass: runtimev1.BrowserCapabilityClass_BROWSER_CAPABILITY_CLASS_NAVIGATION_EVALUATION,
+			ServiceLane:     runtimev1.BrowserServiceLane_BROWSER_SERVICE_LANE_LIGHTPANDA,
+			RoutingRevision: "lightpanda-bridge-r1",
+		},
+		Plan: &runtimev1.BrowserPlan{
+			ContractVersion:      "crawler.runtime/v1",
+			TargetUrl:            targetURL,
+			RequiredCapabilities: capabilities,
+			Navigation: &runtimev1.NavigationPlan{
+				WaitUntil:       runtimev1.WaitCondition_WAIT_CONDITION_LOAD,
+				TimeoutMs:       1250,
+				OriginRequestId: "origin-1",
+			},
+			Evaluations: evaluations,
+			OriginOperations: []*runtimev1.OriginOperationRef{{
+				OriginRequestId:    "origin-1",
+				OperationSequence:  1,
+				Role:               "navigation",
+				RequestFingerprint: strings.Repeat("1", 64),
+			}},
+		},
+	}
+}
+
+func bridgeManifestBody(manifest *runtimev1.ChunkManifest) []byte {
+	if manifest == nil {
+		return nil
+	}
+	var body []byte
+	for _, chunk := range manifest.Chunks {
+		body = append(body, chunk.GetInlineBody()...)
+	}
+	return body
+}
+
+func bridgeJSONString(size int) []byte {
+	if size < 2 {
+		panic("JSON string size must include two quotes")
+	}
+	return []byte(`"` + strings.Repeat("x", size-2) + `"`)
+}
+
+func assertBridgeFailure(
+	t *testing.T,
+	result *runtimev1.BrowserResult,
+	code runtimev1.ErrorCode,
+	disposition runtimev1.ErrorDisposition,
+) {
+	t.Helper()
+	if result == nil || result.GetError() == nil || result.GetError().Error == nil ||
+		result.GetError().Error.Code != code || result.GetError().Error.Disposition != disposition ||
+		result.GetSuccess() != nil {
+		t.Fatalf("result = %v, want %s/%s", result, code, disposition)
+	}
+}


### PR DESCRIPTION
Closes #7961\n\n## Outcome\n\nConnect the dormant runtime-v1 Lightpanda adapter to exactly one real one-shot Lightpanda lifecycle inside the standalone pilot.\n\n## Necessary scope\n\n- execute true B0 render-only and B1 render plus one declared network-effect-free evaluation\n- preserve exact navigation timeout and caller evaluation-result ceiling\n- preserve the pilot 512 KiB HTML ceiling as RESOURCE_LIMIT\n- make post-start panics cleanup-safe and make cleanup failure dominate timeout/cancellation\n- distinguish missing HTML from present-empty HTML\n- authenticate context failures against the actual runner context\n- validate raw status before narrowing and keep provider details opaque\n- exercise Adapter.Execute against checksum-pinned stable Lightpanda on loopback for native amd64 and arm64\n- keep the Docker primary context at the pilot and copy only the contracts module subset through a named BuildKit context\n\n## Explicit exclusions\n\nNo service or process pool, RPC, public origin, destination policy, production privacy implementation, queue, Redis, database, lease, persistence, fallback, deployment, worker coupling, or production routing.\n\nPre-materialization DOM/evaluation memory remains the documented inherited one-shot limitation under the mandatory container memory ceiling. Streaming CDP work is deferred until production-density evidence justifies it.\n\n## Local verification\n\n- go test ./...\n- go test -race ./...\n- go test and race stress repetitions\n- go vet ./...\n- go mod tidy -diff\n- gofmt and git diff checks\n- runtime-contract race suite\n- actionlint\n- relevant workflow/contract tests: 94 passed\n- Linux amd64 and arm64 cross-compiles\n\nTwo independent critics approved exact final snapshot b69e495fb8ebde1bbd2ede669ce086c44c88f6877c08dde3f5bbca9a7ef28dba after blocking and repairing HTML-presence and context-authenticity defects.\n\nThe local Docker daemon was unavailable. Keep this PR draft until the hosted dual-native named-context builds and real-binary integration pass on the exact head.