### PR TITLE
Add bounded Lightpanda worker pool

### DIFF
--- a/pilots/go-lightpanda/Dockerfile
+++ b/pilots/go-lightpanda/Dockerfile
@@ -51,7 +51,7 @@ FROM pilot-base AS integration-test
 COPY --from=integration-build /out/go-lightpanda.test /usr/local/bin/go-lightpanda.test
 ENV LIGHTPANDA_INTEGRATION_BIN=/usr/local/bin/lightpanda
 RUN --network=none /usr/local/bin/go-lightpanda.test \
-    -test.run '^(TestLightpandaIntegration|TestLightpandaRuntimeV1BridgeIntegration)$' \
+    -test.run '^(TestLightpandaIntegration|TestLightpandaRuntimeV1BridgeIntegration|TestLightpandaPoolRuntimeV1IntegrationC4)$' \
     -test.count=1 -test.v
 
 FROM pilot-base AS runtime

--- a/pilots/go-lightpanda/README.md
+++ b/pilots/go-lightpanda/README.md
@@ -15,6 +15,14 @@ routing.
 The adapter still requires an injected evaluation-privacy implementation;
 only a loopback-fixture sealer exists in tests.
 
+The package also contains a non-authoritative bounded execution pool for the
+fixed-RAM pilot. The pool admits immutable runtime-v1 inputs into a fixed set
+of workers, dispatches different origins fairly, and permits at most one task
+per origin at a time. Every active slot still owns a separate one-shot
+Lightpanda process and the same cleanup proof below. Processes are not reused
+or shared between tasks. The pool has no CLI, queue, crawler, or production
+entry point.
+
 The bridge preserves the pilot's stricter 512 KiB HTML ceiling and reports an
 oversized document as the adapter's closed `RESOURCE_LIMIT` result. B1 uses
 the smaller of the plan's `max_result_bytes` and the pilot's 64 KiB ceiling.
@@ -23,7 +31,9 @@ timeout or cancellation; other provider details are reduced to message-free,
 fail-closed adapter errors.
 
 The runner starts a new Lightpanda process for its single task on a chosen free
-loopback port:
+loopback port. Concurrent in-process runners retain each allocated port until
+that process has been cleaned up, preventing sibling tasks from selecting the
+same close-then-bind port:
 
 ```text
 lightpanda serve --host 127.0.0.1 --port <port> --log-level error
@@ -76,9 +86,11 @@ docker run --rm \
 
 Those CPU, memory, PID, network-namespace, capability, privilege,
 read-only-root, and tmpfs controls are caller responsibilities and are required
-for every pilot run. Run exactly one pilot task per container. Keep Docker's
+for every pilot run. The public CLI still runs exactly one task per container;
+the test-only fixed-RAM pool may run its declared number of independent
+one-shot processes inside one harder whole-container bound. Keep Docker's
 private PID namespace and a dedicated network namespace: never use
-`--pid=host`, `--network=host`, or expose the internal CDP port. The unavoidable
+`--pid=host`, `--network=host`, or expose an internal CDP port. The unavoidable
 close-then-bind free-port handoff and numeric process-group cleanup are accepted
 only under those isolation conditions.
 
@@ -100,7 +112,7 @@ disposable Linux environment:
 
 ```sh
 LIGHTPANDA_INTEGRATION_BIN=/absolute/path/to/lightpanda-x86_64-linux \
-  go test -run '^(TestLightpandaIntegration|TestLightpandaRuntimeV1BridgeIntegration)$' \
+  go test -run '^(TestLightpandaIntegration|TestLightpandaRuntimeV1BridgeIntegration|TestLightpandaPoolRuntimeV1IntegrationC4)$' \
   -count=1 -v .
 
 docker build --build-context contracts=../../apps/crawler/contracts \
@@ -108,7 +120,7 @@ docker build --build-context contracts=../../apps/crawler/contracts \
   -t jobseek-lightpanda-integration:amd64 .
 
 LIGHTPANDA_INTEGRATION_BIN=/absolute/path/to/lightpanda-aarch64-linux \
-  go test -run '^(TestLightpandaIntegration|TestLightpandaRuntimeV1BridgeIntegration)$' \
+  go test -run '^(TestLightpandaIntegration|TestLightpandaRuntimeV1BridgeIntegration|TestLightpandaPoolRuntimeV1IntegrationC4)$' \
   -count=1 -v .
 
 docker build --build-context contracts=../../apps/crawler/contracts \
@@ -151,7 +163,8 @@ content, or expressions.
 ## Scope exclusions
 
 This pilot intentionally has no queues, crawler wiring, browser fallback,
-process pooling, proxy or authentication support, request interception,
+resident or shared browser-process pooling, proxy or authentication support,
+request interception,
 `networkidle` waiting, `stopLoading`, iframe capture, nightly binary, deployment,
 or observability integration. The runtime-v1 bridge is exercised only against
 loopback fixtures and has no reusable production evaluation-privacy sealer or

--- a/pilots/go-lightpanda/go.mod
+++ b/pilots/go-lightpanda/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/chromedp/cdproto v0.0.0-20250724212937-08a3db8b4327
 	github.com/chromedp/chromedp v0.14.2
 	github.com/colophon-group/jobseek/apps/crawler/contracts v0.0.0
+	google.golang.org/protobuf v1.36.10
 )
 
 require (
@@ -15,7 +16,6 @@ require (
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.4.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
-	google.golang.org/protobuf v1.36.10 // indirect
 )
 
 replace github.com/colophon-group/jobseek/apps/crawler/contracts => ../../apps/crawler/contracts

--- a/pilots/go-lightpanda/harness.go
+++ b/pilots/go-lightpanda/harness.go
@@ -39,6 +39,10 @@ const (
 var (
 	errCleanupUnproved = errors.New("lightpanda cleanup could not be proved")
 	errResourceLimit   = errors.New("lightpanda result exceeded a resource limit")
+	loopbackPorts      = struct {
+		sync.Mutex
+		reserved map[int]struct{}
+	}{reserved: make(map[int]struct{})}
 )
 
 // Task is intentionally small: the pilot navigates once and optionally
@@ -88,6 +92,7 @@ type dependencies struct {
 	ready        readyWaiter
 	executor     taskExecutor
 	allocatePort func() (int, error)
+	releasePort  func(int)
 	portOpen     func(int) bool
 }
 
@@ -121,6 +126,7 @@ func runTask(ctx context.Context, config Config, task Task) (Result, error) {
 		ready:        httpReadyWaiter{interval: defaultReadyInterval},
 		executor:     chromedpExecutor{},
 		allocatePort: allocateLoopbackPort,
+		releasePort:  releaseLoopbackPort,
 		portOpen:     loopbackPortOpen,
 	}, task)
 }
@@ -139,6 +145,9 @@ func runTaskWithDependencies(ctx context.Context, config Config, deps dependenci
 	}
 	process, err := deps.process.Start(port)
 	if err != nil {
+		if deps.releasePort != nil {
+			deps.releasePort(port)
+		}
 		return Result{}, fmt.Errorf("start lightpanda: %w", err)
 	}
 	state := watchProcess(process)
@@ -154,6 +163,8 @@ func runTaskWithDependencies(ctx context.Context, config Config, deps dependenci
 			errCleanupUnproved,
 			fmt.Errorf("cleanup lightpanda: %w", cleanupErr),
 		)
+	} else if deps.releasePort != nil {
+		deps.releasePort(port)
 	}
 	if runErr != nil {
 		return Result{}, runErr
@@ -525,15 +536,46 @@ func (b *boundedBuffer) String() string {
 }
 
 func allocateLoopbackPort() (int, error) {
-	listener, err := net.Listen("tcp4", "127.0.0.1:0")
-	if err != nil {
-		return 0, err
+	return allocateLoopbackPortWithListener(func() (net.Listener, error) {
+		return net.Listen("tcp4", "127.0.0.1:0")
+	})
+}
+
+func allocateLoopbackPortWithListener(listen func() (net.Listener, error)) (int, error) {
+	for {
+		listener, err := listen()
+		if err != nil {
+			return 0, err
+		}
+		port := listener.Addr().(*net.TCPAddr).Port
+
+		loopbackPorts.Lock()
+		_, alreadyReserved := loopbackPorts.reserved[port]
+		if !alreadyReserved {
+			loopbackPorts.reserved[port] = struct{}{}
+		}
+		loopbackPorts.Unlock()
+
+		if err := listener.Close(); err != nil {
+			if !alreadyReserved {
+				releaseLoopbackPort(port)
+			}
+			return 0, err
+		}
+		if !alreadyReserved {
+			return port, nil
+		}
 	}
-	port := listener.Addr().(*net.TCPAddr).Port
-	if err := listener.Close(); err != nil {
-		return 0, err
-	}
-	return port, nil
+}
+
+// releaseLoopbackPort ends the ownership established by allocateLoopbackPort.
+// The kernel listener must be closed before Lightpanda can bind, so this
+// process-local reservation prevents a concurrent sibling task from receiving
+// the same close-then-bind port without serializing unrelated executions.
+func releaseLoopbackPort(port int) {
+	loopbackPorts.Lock()
+	delete(loopbackPorts.reserved, port)
+	loopbackPorts.Unlock()
 }
 
 func loopbackPortOpen(port int) bool {

--- a/pilots/go-lightpanda/harness_test.go
+++ b/pilots/go-lightpanda/harness_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -104,6 +105,7 @@ func TestRunTaskFailsAfterUnverifiedCleanup(t *testing.T) {
 	}), func(int) bool { return true })
 	config.CleanupTimeout = 20 * time.Millisecond
 	config.TerminateGrace = 5 * time.Millisecond
+	deps.releasePort = func(int) { events.add("release-port") }
 
 	if _, err := runTaskWithDependencies(context.Background(), config, deps, validTask()); err == nil || !errors.Is(err, errCleanupUnproved) {
 		t.Fatal("Run succeeded despite listener cleanup failure")
@@ -111,6 +113,26 @@ func TestRunTaskFailsAfterUnverifiedCleanup(t *testing.T) {
 	if contains(events.snapshot(), "signal-9") {
 		t.Fatal("cleanup sent SIGKILL after the process group was already gone")
 	}
+	if contains(events.snapshot(), "release-port") {
+		t.Fatal("unproved cleanup released the quarantined process-local port reservation")
+	}
+}
+
+func TestRunTaskReleasesPortAfterSuccessfulCleanup(t *testing.T) {
+	events := &eventLog{}
+	process := newFakeProcess(events, true)
+	config, deps := testRunner(process, taskExecutorFunc(func(context.Context, string, Task) (Result, error) {
+		return validResult(), nil
+	}), func(int) bool {
+		events.add("verify-listener")
+		return false
+	})
+	deps.releasePort = func(int) { events.add("release-port") }
+
+	if _, err := runTaskWithDependencies(context.Background(), config, deps, validTask()); err != nil {
+		t.Fatal(err)
+	}
+	assertOrdered(t, events.snapshot(), "verify-listener", "release-port")
 }
 
 func TestRunTaskContainsExecutorPanicAndCleansUp(t *testing.T) {
@@ -129,6 +151,74 @@ func TestRunTaskContainsExecutorPanicAndCleansUp(t *testing.T) {
 		t.Fatalf("Run error = %v", err)
 	}
 	assertOrdered(t, events.snapshot(), "execute-panic", "signal-15", "wait-reaped", "verify-listener")
+}
+
+func TestRunTaskReleasesPortOnStartFailure(t *testing.T) {
+	released := 0
+	deps := dependencies{
+		process: processStarterFunc(func(int) (managedProcess, error) {
+			return nil, errors.New("start failed")
+		}),
+		allocatePort: func() (int, error) { return 9222, nil },
+		releasePort:  func(port int) { released = port },
+	}
+
+	if _, err := runTaskWithDependencies(context.Background(), Config{}, deps, validTask()); err == nil {
+		t.Fatal("Run succeeded after process start failure")
+	}
+	if released != 9222 {
+		t.Fatalf("released port = %d, want 9222", released)
+	}
+}
+
+func TestLoopbackPortReservationsAreUniqueUntilReleased(t *testing.T) {
+	const count = 128
+	ports := make([]int, 0, count)
+	seen := make(map[int]bool, count)
+	defer func() {
+		for _, port := range ports {
+			releaseLoopbackPort(port)
+		}
+	}()
+
+	for range count {
+		port, err := allocateLoopbackPort()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if seen[port] {
+			t.Fatalf("port %d was allocated twice while reserved", port)
+		}
+		seen[port] = true
+		ports = append(ports, port)
+	}
+}
+
+func TestLoopbackPortReservationSkipsSiblingCloseThenBindCollision(t *testing.T) {
+	const firstPort = 61001
+	ports := []int{firstPort, firstPort, firstPort + 1}
+	listen := func() (net.Listener, error) {
+		if len(ports) == 0 {
+			return nil, errors.New("test listener sequence exhausted")
+		}
+		port := ports[0]
+		ports = ports[1:]
+		return &fixedPortListener{port: port}, nil
+	}
+
+	first, err := allocateLoopbackPortWithListener(listen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseLoopbackPort(first)
+	second, err := allocateLoopbackPortWithListener(listen)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseLoopbackPort(second)
+	if first != firstPort || second != firstPort+1 {
+		t.Fatalf("reserved ports = %d, %d", first, second)
+	}
 }
 
 func TestReadyWaiterChecksChildBeforeRequest(t *testing.T) {
@@ -386,6 +476,26 @@ type fixedStarter struct {
 
 func (starter *fixedStarter) Start(int) (managedProcess, error) {
 	return starter.process, nil
+}
+
+type processStarterFunc func(int) (managedProcess, error)
+
+func (function processStarterFunc) Start(port int) (managedProcess, error) {
+	return function(port)
+}
+
+type fixedPortListener struct {
+	port int
+}
+
+func (*fixedPortListener) Accept() (net.Conn, error) {
+	return nil, errors.New("fixed listener does not accept")
+}
+
+func (*fixedPortListener) Close() error { return nil }
+
+func (listener *fixedPortListener) Addr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: listener.port}
 }
 
 type fakeProcess struct {

--- a/pilots/go-lightpanda/pool.go
+++ b/pilots/go-lightpanda/pool.go
@@ -1,0 +1,572 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	runtimev1 "github.com/colophon-group/jobseek/apps/crawler/contracts/v1/gen/go"
+	"github.com/colophon-group/jobseek/apps/crawler/contracts/v1/lightpandaadapter"
+	"google.golang.org/protobuf/proto"
+)
+
+var (
+	errPoolClosed        = errors.New("lightpanda pool is closed")
+	errInvalidPoolConfig = errors.New("invalid lightpanda pool config")
+	errInvalidPoolJob    = errors.New("invalid lightpanda pool job")
+	errPoolProcessor     = errors.New("lightpanda pool processor returned no terminal result")
+)
+
+// PoolConfig fixes all concurrency and buffering bounds. Capacity includes
+// accepted jobs until terminal publication. ResultCapacity must cover one full
+// accepted window, but callers must still continuously drain Results: across a
+// longer pool lifetime, completed windows can fill the bounded result buffer.
+type PoolConfig struct {
+	Workers        int
+	Capacity       int
+	ResultCapacity int
+	JobTimeout     time.Duration
+	ShutdownGrace  time.Duration
+}
+
+// PoolJob is cloned behind bounded capacity during Submit. The caller must not
+// mutate Input until Submit returns. AdmissionContext controls only admission;
+// Context and Timeout own execution after acceptance.
+type PoolJob struct {
+	ID      string
+	Context context.Context
+	Timeout time.Duration
+	Input   *runtimev1.BrowserExecutionInput
+}
+
+// PoolResult is the sole terminal record for one accepted job.
+type PoolResult struct {
+	JobID           string
+	Origin          string
+	Runtime         *runtimev1.BrowserResult
+	Err             error
+	AcceptedAt      time.Time
+	StartedAt       time.Time
+	FinishedAt      time.Time
+	QueueDuration   time.Duration
+	ServiceDuration time.Duration
+}
+
+// PoolStats is race-free. Once Done is closed, it is an internally consistent
+// final snapshot with Accepted == Completed and Queued == InFlight == 0.
+type PoolStats struct {
+	Accepted         uint64
+	Completed        uint64
+	Panics           uint64
+	Queued           int64
+	InFlight         int64
+	MaxQueued        int64
+	MaxInFlight      int64
+	TotalQueueTime   time.Duration
+	MaxQueueTime     time.Duration
+	TotalServiceTime time.Duration
+	MaxServiceTime   time.Duration
+}
+
+// PoolProcessor is injectable for scheduler tests. Implementations must obey
+// ctx; the pool deliberately creates no goroutine per job and cannot forcibly
+// stop an implementation that ignores cancellation.
+type PoolProcessor interface {
+	Process(context.Context, *runtimev1.BrowserExecutionInput) (*runtimev1.BrowserResult, error)
+}
+
+type PoolProcessorFunc func(context.Context, *runtimev1.BrowserExecutionInput) (*runtimev1.BrowserResult, error)
+
+func (function PoolProcessorFunc) Process(
+	ctx context.Context,
+	input *runtimev1.BrowserExecutionInput,
+) (*runtimev1.BrowserResult, error) {
+	return function(ctx, input)
+}
+
+// PoolPanicError contains no recovered panic text because it may include
+// caller input or provider details.
+type PoolPanicError struct{}
+
+func (*PoolPanicError) Error() string { return "lightpanda pool processor panicked" }
+
+type adapterProcessor struct {
+	adapter *lightpandaadapter.Adapter
+}
+
+func (processor adapterProcessor) Process(
+	ctx context.Context,
+	input *runtimev1.BrowserExecutionInput,
+) (*runtimev1.BrowserResult, error) {
+	return processor.adapter.Execute(ctx, input), nil
+}
+
+type poolMetrics struct {
+	accepted          atomic.Uint64
+	completed         atomic.Uint64
+	panics            atomic.Uint64
+	queued            atomic.Int64
+	inFlight          atomic.Int64
+	maxQueued         atomic.Int64
+	maxInFlight       atomic.Int64
+	totalQueueNanos   atomic.Int64
+	maxQueueNanos     atomic.Int64
+	totalServiceNanos atomic.Int64
+	maxServiceNanos   atomic.Int64
+}
+
+type poolSubmit struct {
+	job        PoolJob
+	origin     string
+	acceptedAt time.Time
+	accounted  chan struct{}
+}
+
+type poolQueued struct {
+	job        PoolJob
+	origin     string
+	acceptedAt time.Time
+}
+
+type poolOriginState struct {
+	queued   []poolQueued
+	inFlight bool
+}
+
+// LightpandaPool owns one scheduler and exactly PoolConfig.Workers worker
+// goroutines. Each worker invokes one Adapter.Execute only after global and
+// per-origin capacity have been assigned.
+type LightpandaPool struct {
+	config    PoolConfig
+	processor PoolProcessor
+	now       func() time.Time
+	launch    func(func())
+
+	submits     chan poolSubmit
+	dispatch    chan poolQueued
+	completions chan string
+	results     chan PoolResult
+	done        chan struct{}
+	closed      chan struct{}
+	slots       chan struct{}
+
+	closeMu  sync.RWMutex
+	isClosed bool
+	workers  sync.WaitGroup
+	metrics  poolMetrics
+	activeMu sync.Mutex
+	active   map[int]context.CancelFunc
+	forced   bool
+}
+
+// NewLightpandaPool wires the real runtime-v1 adapter into the bounded pool.
+func NewLightpandaPool(adapter *lightpandaadapter.Adapter, config PoolConfig) (*LightpandaPool, error) {
+	if adapter == nil {
+		return nil, fmt.Errorf("%w: nil adapter", errInvalidPoolConfig)
+	}
+	return NewLightpandaPoolWithProcessor(config, adapterProcessor{adapter: adapter})
+}
+
+// NewLightpandaPoolWithProcessor constructs a pool for deterministic tests.
+func NewLightpandaPoolWithProcessor(config PoolConfig, processor PoolProcessor) (*LightpandaPool, error) {
+	return newLightpandaPool(config, processor, time.Now)
+}
+
+func newLightpandaPool(config PoolConfig, processor PoolProcessor, now func() time.Time) (*LightpandaPool, error) {
+	if config.Workers <= 0 || config.Capacity < config.Workers ||
+		config.ResultCapacity < config.Capacity || config.JobTimeout <= 0 ||
+		config.ShutdownGrace <= 0 || processor == nil || now == nil {
+		return nil, errInvalidPoolConfig
+	}
+	pool := &LightpandaPool{
+		config:      config,
+		processor:   processor,
+		now:         now,
+		launch:      func(function func()) { go function() },
+		submits:     make(chan poolSubmit),
+		dispatch:    make(chan poolQueued),
+		completions: make(chan string),
+		results:     make(chan PoolResult, config.ResultCapacity),
+		done:        make(chan struct{}),
+		closed:      make(chan struct{}),
+		slots:       make(chan struct{}, config.Capacity),
+		active:      make(map[int]context.CancelFunc, config.Workers),
+	}
+	pool.workers.Add(config.Workers)
+	for workerID := range config.Workers {
+		go pool.work(workerID)
+	}
+	go pool.schedule()
+	return pool, nil
+}
+
+// Submit blocks until bounded capacity is available. A nil error means the
+// input was cloned and exactly one terminal PoolResult will be published.
+func (pool *LightpandaPool) Submit(admissionContext context.Context, job PoolJob) error {
+	if admissionContext == nil || strings.TrimSpace(job.ID) == "" || job.Timeout < 0 || job.Input == nil {
+		return errInvalidPoolJob
+	}
+	if err := admissionContext.Err(); err != nil {
+		return err
+	}
+	if job.Context == nil {
+		job.Context = context.Background()
+	}
+
+	select {
+	case pool.slots <- struct{}{}:
+	case <-admissionContext.Done():
+		return admissionContext.Err()
+	case <-pool.closed:
+		return errPoolClosed
+	}
+	pool.closeMu.RLock()
+	defer pool.closeMu.RUnlock()
+	if pool.isClosed {
+		<-pool.slots
+		return errPoolClosed
+	}
+	cloned, origin, err := clonePoolInput(job.Input)
+	if err != nil {
+		<-pool.slots
+		return fmt.Errorf("%w: %v", errInvalidPoolJob, err)
+	}
+	job.Input = cloned
+
+	acceptedAt := pool.now()
+	accounted := make(chan struct{})
+	select {
+	case pool.submits <- poolSubmit{job: job, origin: origin, acceptedAt: acceptedAt, accounted: accounted}:
+		<-accounted
+		return nil
+	case <-admissionContext.Done():
+		<-pool.slots
+		return admissionContext.Err()
+	}
+}
+
+func clonePoolInput(input *runtimev1.BrowserExecutionInput) (
+	cloned *runtimev1.BrowserExecutionInput,
+	origin string,
+	err error,
+) {
+	defer func() {
+		if recover() != nil {
+			cloned = nil
+			origin = ""
+			err = errors.New("runtime-v1 input could not be cloned")
+		}
+	}()
+	if input == nil || proto.Size(input) > lightpandaadapter.InputPayloadLimit {
+		return nil, "", errors.New("runtime-v1 input is missing or too large")
+	}
+	cloned = proto.Clone(input).(*runtimev1.BrowserExecutionInput)
+	origin, err = canonicalTargetOrigin(cloned.GetPlan().GetTargetUrl())
+	if err != nil {
+		return nil, "", err
+	}
+	return cloned, origin, nil
+}
+
+// Results returns the bounded terminal stream. Callers must continuously drain
+// it until closed; intentional result backpressure can otherwise stop workers
+// and prevent the accepted-work drain from completing.
+func (pool *LightpandaPool) Results() <-chan PoolResult { return pool.results }
+
+func (pool *LightpandaPool) Done() <-chan struct{} { return pool.done }
+
+// Close rejects new work and begins draining. It is idempotent and returns
+// immediately. At one nonextendable ShutdownGrace deadline, executing and
+// subsequently dispatched queued jobs are cancelled. The caller must continue
+// draining Results until it closes.
+func (pool *LightpandaPool) Close() {
+	pool.closeMu.Lock()
+	defer pool.closeMu.Unlock()
+	if pool.isClosed {
+		return
+	}
+	pool.isClosed = true
+	close(pool.closed)
+	close(pool.submits)
+	deadline := time.Now().Add(pool.config.ShutdownGrace)
+	pool.launch(func() { pool.cancelAfterGrace(deadline) })
+}
+
+func (pool *LightpandaPool) cancelAfterGrace(deadline time.Time) {
+	if waitUntilPoolDeadline(deadline, pool.done) {
+		pool.cancelActive()
+	}
+}
+
+func waitUntilPoolDeadline(deadline time.Time, done <-chan struct{}) bool {
+	timer := time.NewTimer(max(time.Until(deadline), 0))
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-done:
+		return false
+	}
+}
+
+func (pool *LightpandaPool) cancelActive() {
+	pool.activeMu.Lock()
+	pool.forced = true
+	cancels := make([]context.CancelFunc, 0, len(pool.active))
+	for _, cancel := range pool.active {
+		cancels = append(cancels, cancel)
+	}
+	pool.activeMu.Unlock()
+	for _, cancel := range cancels {
+		cancel()
+	}
+}
+
+func (pool *LightpandaPool) setActive(workerID int, cancel context.CancelFunc) {
+	pool.activeMu.Lock()
+	pool.active[workerID] = cancel
+	forced := pool.forced
+	pool.activeMu.Unlock()
+	if forced {
+		cancel()
+	}
+}
+
+func (pool *LightpandaPool) clearActive(workerID int) {
+	pool.activeMu.Lock()
+	delete(pool.active, workerID)
+	pool.activeMu.Unlock()
+}
+
+// Shutdown starts draining and waits no longer than ctx. The owned drain
+// continues if ctx expires so accepted jobs retain terminal conservation.
+func (pool *LightpandaPool) Shutdown(ctx context.Context) error {
+	if ctx == nil {
+		return errInvalidPoolJob
+	}
+	pool.Close()
+	select {
+	case <-pool.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (pool *LightpandaPool) Stats() PoolStats {
+	return PoolStats{
+		Accepted:         pool.metrics.accepted.Load(),
+		Completed:        pool.metrics.completed.Load(),
+		Panics:           pool.metrics.panics.Load(),
+		Queued:           pool.metrics.queued.Load(),
+		InFlight:         pool.metrics.inFlight.Load(),
+		MaxQueued:        pool.metrics.maxQueued.Load(),
+		MaxInFlight:      pool.metrics.maxInFlight.Load(),
+		TotalQueueTime:   time.Duration(pool.metrics.totalQueueNanos.Load()),
+		MaxQueueTime:     time.Duration(pool.metrics.maxQueueNanos.Load()),
+		TotalServiceTime: time.Duration(pool.metrics.totalServiceNanos.Load()),
+		MaxServiceTime:   time.Duration(pool.metrics.maxServiceNanos.Load()),
+	}
+}
+
+func (pool *LightpandaPool) schedule() {
+	defer close(pool.done)
+	states := make(map[string]*poolOriginState)
+	ready := make([]string, 0)
+	queuedCount := 0
+	inFlight := 0
+	submits := pool.submits
+
+	for {
+		if submits == nil && queuedCount == 0 && inFlight == 0 {
+			close(pool.dispatch)
+			pool.workers.Wait()
+			close(pool.results)
+			return
+		}
+
+		readyIndex := -1
+		var dispatch chan poolQueued
+		var next poolQueued
+		if inFlight < pool.config.Workers {
+			readyIndex = nextPoolReadyIndex(ready, states)
+			if readyIndex >= 0 {
+				dispatch = pool.dispatch
+				next = states[ready[readyIndex]].queued[0]
+			}
+		}
+
+		select {
+		case request, ok := <-submits:
+			if !ok {
+				submits = nil
+				continue
+			}
+			state := states[request.origin]
+			if state == nil {
+				state = &poolOriginState{}
+				states[request.origin] = state
+			}
+			if len(state.queued) == 0 {
+				ready = append(ready, request.origin)
+			}
+			state.queued = append(state.queued, poolQueued{
+				job: request.job, origin: request.origin, acceptedAt: request.acceptedAt,
+			})
+			queuedCount++
+			pool.metrics.accepted.Add(1)
+			current := pool.metrics.queued.Add(1)
+			storePoolMax(&pool.metrics.maxQueued, current)
+			close(request.accounted)
+
+		case dispatch <- next:
+			origin := ready[readyIndex]
+			state := states[origin]
+			state.queued[0] = poolQueued{}
+			state.queued = state.queued[1:]
+			ready = append(ready[:readyIndex], ready[readyIndex+1:]...)
+			if len(state.queued) > 0 {
+				ready = append(ready, origin)
+			} else {
+				state.queued = nil
+			}
+			state.inFlight = true
+			queuedCount--
+			inFlight++
+			pool.metrics.queued.Add(-1)
+			current := pool.metrics.inFlight.Add(1)
+			storePoolMax(&pool.metrics.maxInFlight, current)
+
+		case origin := <-pool.completions:
+			state := states[origin]
+			state.inFlight = false
+			inFlight--
+			pool.metrics.inFlight.Add(-1)
+			<-pool.slots
+			if len(state.queued) == 0 {
+				delete(states, origin)
+			}
+		}
+	}
+}
+
+func nextPoolReadyIndex(ready []string, states map[string]*poolOriginState) int {
+	for index, origin := range ready {
+		if !states[origin].inFlight {
+			return index
+		}
+	}
+	return -1
+}
+
+func (pool *LightpandaPool) work(workerID int) {
+	defer pool.workers.Done()
+	for queued := range pool.dispatch {
+		startedAt := pool.now()
+		queueDuration := nonnegativePoolDuration(startedAt.Sub(queued.acceptedAt))
+		pool.metrics.totalQueueNanos.Add(int64(queueDuration))
+		storePoolMax(&pool.metrics.maxQueueNanos, int64(queueDuration))
+
+		timeout := pool.config.JobTimeout
+		if queued.job.Timeout > 0 {
+			timeout = queued.job.Timeout
+		}
+		ctx, cancel := context.WithTimeout(queued.job.Context, timeout)
+		pool.setActive(workerID, cancel)
+		value, err, panicked := callPoolProcessor(ctx, pool.processor, queued.job.Input)
+		if value == nil && err == nil && ctx.Err() != nil {
+			err = ctx.Err()
+		}
+		if value == nil && err == nil {
+			err = errPoolProcessor
+		}
+		if err != nil {
+			value = nil
+		}
+		pool.clearActive(workerID)
+		cancel()
+
+		finishedAt := pool.now()
+		serviceDuration := nonnegativePoolDuration(finishedAt.Sub(startedAt))
+		pool.metrics.totalServiceNanos.Add(int64(serviceDuration))
+		storePoolMax(&pool.metrics.maxServiceNanos, int64(serviceDuration))
+		if panicked {
+			pool.metrics.panics.Add(1)
+		}
+		if value != nil {
+			value = proto.Clone(value).(*runtimev1.BrowserResult)
+		}
+
+		pool.results <- PoolResult{
+			JobID: queued.job.ID, Origin: queued.origin, Runtime: value, Err: err,
+			AcceptedAt: queued.acceptedAt, StartedAt: startedAt, FinishedAt: finishedAt,
+			QueueDuration: queueDuration, ServiceDuration: serviceDuration,
+		}
+		pool.metrics.completed.Add(1)
+		pool.completions <- queued.origin
+	}
+}
+
+func callPoolProcessor(
+	ctx context.Context,
+	processor PoolProcessor,
+	input *runtimev1.BrowserExecutionInput,
+) (value *runtimev1.BrowserResult, err error, panicked bool) {
+	defer func() {
+		if recover() != nil {
+			value = nil
+			err = &PoolPanicError{}
+			panicked = true
+		}
+	}()
+	value, err = processor.Process(ctx, input)
+	return value, err, false
+}
+
+func canonicalTargetOrigin(rawURL string) (string, error) {
+	if len(rawURL) == 0 || len(rawURL) > maxURLBytes {
+		return "", errors.New("target URL is missing or too large")
+	}
+	parsed, err := url.ParseRequestURI(rawURL)
+	if err != nil || parsed.User != nil || parsed.Host == "" ||
+		(parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Fragment != "" ||
+		strings.Contains(rawURL, "#") {
+		return "", errors.New("target URL must be an absolute HTTP(S) URL without userinfo or fragment")
+	}
+	hostname := strings.ToLower(parsed.Hostname())
+	if hostname == "" {
+		return "", errors.New("target URL has no hostname")
+	}
+	port := parsed.Port()
+	if (parsed.Scheme == "http" && port == "80") || (parsed.Scheme == "https" && port == "443") {
+		port = ""
+	}
+	host := hostname
+	if port != "" {
+		host = net.JoinHostPort(hostname, port)
+	} else if strings.Contains(hostname, ":") {
+		host = "[" + hostname + "]"
+	}
+	return parsed.Scheme + "://" + host, nil
+}
+
+func nonnegativePoolDuration(duration time.Duration) time.Duration {
+	if duration < 0 {
+		return 0
+	}
+	return duration
+}
+
+func storePoolMax(target *atomic.Int64, candidate int64) {
+	for current := target.Load(); candidate > current; current = target.Load() {
+		if target.CompareAndSwap(current, candidate) {
+			return
+		}
+	}
+}

--- a/pilots/go-lightpanda/pool_integration_test.go
+++ b/pilots/go-lightpanda/pool_integration_test.go
@@ -1,0 +1,273 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	runtimev1 "github.com/colophon-group/jobseek/apps/crawler/contracts/v1/gen/go"
+	"github.com/colophon-group/jobseek/apps/crawler/contracts/v1/lightpandaadapter"
+)
+
+func TestLightpandaPoolRuntimeV1IntegrationC4(t *testing.T) {
+	expectedSHA256, supported := lightpandaStable040SHA256[runtime.GOARCH]
+	if runtime.GOOS != "linux" || !supported {
+		t.Skip("stable Lightpanda 0.4.0 integration binary requires Linux amd64 or arm64")
+	}
+	binary := os.Getenv("LIGHTPANDA_INTEGRATION_BIN")
+	if binary == "" {
+		t.Skip("set LIGHTPANDA_INTEGRATION_BIN to opt in")
+	}
+	if err := verifyFileSHA256(binary, expectedSHA256); err != nil {
+		t.Fatal(err)
+	}
+
+	const (
+		workerCount = 4
+		originCount = 8
+	)
+	observer := newPoolFixtureObserver(workerCount)
+	servers := make([]*httptest.Server, 0, originCount)
+	for originID := range originCount {
+		originID := originID
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+			observer.serve(originID, writer, request)
+		}))
+		servers = append(servers, server)
+	}
+	defer func() {
+		for _, server := range servers {
+			server.Close()
+		}
+	}()
+
+	privacy := &lockedBridgePrivacy{}
+	adapter, err := lightpandaadapter.New(
+		runtimeV1Runner{config: Config{Binary: binary}},
+		privacy,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool, err := NewLightpandaPool(adapter, PoolConfig{
+		Workers:        workerCount,
+		Capacity:       originCount * 2,
+		ResultCapacity: originCount * 2,
+		JobTimeout:     30 * time.Second,
+		ShutdownGrace:  30 * time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for originID, server := range servers {
+		for _, mode := range []string{"b0", "b1"} {
+			expression := ""
+			if mode == "b1" {
+				expression = "document.title"
+			}
+			input := bridgeInput(fmt.Sprintf("%s/fixture/%d", server.URL, originID), expression, 1024)
+			input.Plan.Navigation.TimeoutMs = uint64(defaultTaskTimeout / time.Millisecond)
+			submitPoolJob(t, pool, PoolJob{
+				ID:      fmt.Sprintf("origin-%d-%s", originID, mode),
+				Timeout: 25 * time.Second,
+				Input:   input,
+			})
+		}
+	}
+	pool.Close()
+	results := collectPoolResultsWithTimeout(t, pool, 90*time.Second)
+	if len(results) != originCount*2 {
+		t.Fatalf("terminal results = %d, want %d", len(results), originCount*2)
+	}
+
+	seen := make(map[string]bool, len(results))
+	for _, result := range results {
+		if seen[result.JobID] {
+			t.Fatalf("duplicate terminal result for %s", result.JobID)
+		}
+		seen[result.JobID] = true
+		if result.Err != nil || result.Runtime.GetSuccess() == nil {
+			t.Fatalf("job %s failed: err=%v runtime=%v", result.JobID, result.Err, result.Runtime)
+		}
+		var originID int
+		var mode string
+		if _, err := fmt.Sscanf(result.JobID, "origin-%d-%s", &originID, &mode); err != nil {
+			t.Fatalf("parse job ID %q: %v", result.JobID, err)
+		}
+		success := result.Runtime.GetSuccess()
+		wantURL := fmt.Sprintf("%s/fixture/%d", servers[originID].URL, originID)
+		wantHTML := fmt.Sprintf(
+			`<html><head><title>Origin %d</title></head><body><main id="origin-%d">local only</main></body></html>`,
+			originID, originID,
+		)
+		if success.GetStatus() != http.StatusCreated || success.FinalUrl != wantURL ||
+			!bytes.Equal(bridgeManifestBody(success.Html), []byte(wantHTML)) {
+			t.Fatalf("job %s unexpected success: %v", result.JobID, success)
+		}
+		if mode == "b0" {
+			if len(success.Evaluations) != 0 {
+				t.Fatalf("B0 job %s returned evaluations: %v", result.JobID, success.Evaluations)
+			}
+		} else {
+			want := fmt.Sprintf(`"Origin %d"`, originID)
+			if len(success.Evaluations) != 1 || string(success.Evaluations[0].Value.Payload) != want {
+				t.Fatalf("B1 job %s evaluations = %v, want %s", result.JobID, success.Evaluations, want)
+			}
+		}
+	}
+
+	maximumGlobal, maximumByOrigin, requestsByOrigin, unexpected, barrierTimedOut := observer.snapshot()
+	if barrierTimedOut || unexpected != 0 || maximumGlobal != workerCount {
+		t.Fatalf("fixture global evidence: max=%d unexpected=%d barrier_timeout=%v", maximumGlobal, unexpected, barrierTimedOut)
+	}
+	for originID := range originCount {
+		if maximumByOrigin[originID] != 1 || requestsByOrigin[originID] != 2 {
+			t.Fatalf("origin %d evidence: max=%d requests=%d", originID, maximumByOrigin[originID], requestsByOrigin[originID])
+		}
+	}
+	if privacy.callCount() != originCount {
+		t.Fatalf("privacy calls = %d, want %d", privacy.callCount(), originCount)
+	}
+	stats := pool.Stats()
+	if stats.Accepted != originCount*2 || stats.Completed != stats.Accepted || stats.Panics != 0 ||
+		stats.Queued != 0 || stats.InFlight != 0 || stats.MaxInFlight != workerCount {
+		t.Fatalf("pool stats = %+v", stats)
+	}
+}
+
+type poolFixtureObserver struct {
+	mu               sync.Mutex
+	barrier          chan struct{}
+	barrierOnce      sync.Once
+	barrierTarget    int
+	activeGlobal     int
+	maximumGlobal    int
+	activeByOrigin   map[int]int
+	maximumByOrigin  map[int]int
+	requestsByOrigin map[int]int
+	unexpected       int
+	barrierTimedOut  bool
+}
+
+func newPoolFixtureObserver(barrierTarget int) *poolFixtureObserver {
+	return &poolFixtureObserver{
+		barrier:          make(chan struct{}),
+		barrierTarget:    barrierTarget,
+		activeByOrigin:   make(map[int]int),
+		maximumByOrigin:  make(map[int]int),
+		requestsByOrigin: make(map[int]int),
+	}
+}
+
+func (observer *poolFixtureObserver) serve(originID int, writer http.ResponseWriter, request *http.Request) {
+	wantPath := fmt.Sprintf("/fixture/%d", originID)
+	if request.Method != http.MethodGet || request.URL.Path != wantPath || request.URL.RawQuery != "" {
+		observer.mu.Lock()
+		observer.unexpected++
+		observer.mu.Unlock()
+		http.NotFound(writer, request)
+		return
+	}
+
+	observer.mu.Lock()
+	observer.activeGlobal++
+	observer.activeByOrigin[originID]++
+	observer.requestsByOrigin[originID]++
+	observer.maximumGlobal = max(observer.maximumGlobal, observer.activeGlobal)
+	observer.maximumByOrigin[originID] = max(observer.maximumByOrigin[originID], observer.activeByOrigin[originID])
+	if observer.activeGlobal == observer.barrierTarget {
+		observer.barrierOnce.Do(func() { close(observer.barrier) })
+	}
+	observer.mu.Unlock()
+
+	select {
+	case <-observer.barrier:
+	case <-time.After(15 * time.Second):
+		observer.mu.Lock()
+		observer.barrierTimedOut = true
+		observer.mu.Unlock()
+	}
+	// Keep the first wave overlapping after all four requests reached the
+	// fixture so both the global and per-origin observations are unambiguous.
+	time.Sleep(25 * time.Millisecond)
+
+	observer.mu.Lock()
+	observer.activeGlobal--
+	observer.activeByOrigin[originID]--
+	observer.mu.Unlock()
+
+	writer.Header().Set("Content-Type", "text/html; charset=utf-8")
+	writer.WriteHeader(http.StatusCreated)
+	_, _ = io.WriteString(writer, fmt.Sprintf(
+		`<!doctype html><html><head><title>Origin %d</title></head><body><main id="origin-%d">local only</main></body></html>`,
+		originID, originID,
+	))
+}
+
+func (observer *poolFixtureObserver) snapshot() (int, map[int]int, map[int]int, int, bool) {
+	observer.mu.Lock()
+	defer observer.mu.Unlock()
+	maximumByOrigin := make(map[int]int, len(observer.maximumByOrigin))
+	for origin, maximum := range observer.maximumByOrigin {
+		maximumByOrigin[origin] = maximum
+	}
+	requestsByOrigin := make(map[int]int, len(observer.requestsByOrigin))
+	for origin, requests := range observer.requestsByOrigin {
+		requestsByOrigin[origin] = requests
+	}
+	return observer.maximumGlobal, maximumByOrigin, requestsByOrigin, observer.unexpected, observer.barrierTimedOut
+}
+
+type lockedBridgePrivacy struct {
+	mu    sync.Mutex
+	calls int
+}
+
+func (privacy *lockedBridgePrivacy) SealEvaluation(
+	ctx context.Context,
+	evaluationID string,
+	raw []byte,
+	limit uint64,
+) (*runtimev1.ExtensionEnvelope, error) {
+	privacy.mu.Lock()
+	defer privacy.mu.Unlock()
+	fixture := &bridgeFixturePrivacy{}
+	envelope, err := fixture.SealEvaluation(ctx, evaluationID, raw, limit)
+	if err == nil {
+		privacy.calls++
+	}
+	return envelope, err
+}
+
+func (privacy *lockedBridgePrivacy) callCount() int {
+	privacy.mu.Lock()
+	defer privacy.mu.Unlock()
+	return privacy.calls
+}
+
+func collectPoolResultsWithTimeout(t *testing.T, pool *LightpandaPool, timeout time.Duration) []PoolResult {
+	t.Helper()
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	var results []PoolResult
+	for {
+		select {
+		case result, ok := <-pool.Results():
+			if !ok {
+				return results
+			}
+			results = append(results, result)
+		case <-deadline.C:
+			t.Fatal("timed out draining integration results")
+		}
+	}
+}

--- a/pilots/go-lightpanda/pool_test.go
+++ b/pilots/go-lightpanda/pool_test.go
@@ -1,0 +1,574 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	runtimev1 "github.com/colophon-group/jobseek/apps/crawler/contracts/v1/gen/go"
+	"github.com/colophon-group/jobseek/apps/crawler/contracts/v1/lightpandaadapter"
+	"google.golang.org/protobuf/proto"
+)
+
+func testPoolConfig(workers, capacity int) PoolConfig {
+	return PoolConfig{
+		Workers:        workers,
+		Capacity:       capacity,
+		ResultCapacity: capacity,
+		JobTimeout:     time.Second,
+		ShutdownGrace:  time.Second,
+	}
+}
+
+func testPoolJob(id, target string) PoolJob {
+	return PoolJob{ID: id, Input: bridgeInput(target, "", 0)}
+}
+
+func submitPoolJob(t *testing.T, pool *LightpandaPool, job PoolJob) {
+	t.Helper()
+	if err := pool.Submit(context.Background(), job); err != nil {
+		t.Fatalf("submit %s: %v", job.ID, err)
+	}
+}
+
+func collectPoolResults(t *testing.T, pool *LightpandaPool) []PoolResult {
+	t.Helper()
+	deadline := time.NewTimer(3 * time.Second)
+	defer deadline.Stop()
+	var results []PoolResult
+	for {
+		select {
+		case result, ok := <-pool.Results():
+			if !ok {
+				return results
+			}
+			results = append(results, result)
+		case <-deadline.C:
+			t.Fatal("timed out draining pool results")
+		}
+	}
+}
+
+func waitForPool(t *testing.T, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for !condition() {
+		if time.Now().After(deadline) {
+			t.Fatal("condition was not met")
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestLightpandaPoolRejectsInvalidBounds(t *testing.T) {
+	processor := PoolProcessorFunc(func(context.Context, *runtimev1.BrowserExecutionInput) (*runtimev1.BrowserResult, error) {
+		return &runtimev1.BrowserResult{}, nil
+	})
+	valid := testPoolConfig(2, 3)
+
+	for name, mutate := range map[string]func(*PoolConfig){
+		"workers":           func(config *PoolConfig) { config.Workers = 0 },
+		"capacity":          func(config *PoolConfig) { config.Capacity = 1 },
+		"result capacity":   func(config *PoolConfig) { config.ResultCapacity = 0 },
+		"result under work": func(config *PoolConfig) { config.ResultCapacity = 2 },
+		"job timeout":       func(config *PoolConfig) { config.JobTimeout = 0 },
+		"shutdown grace":    func(config *PoolConfig) { config.ShutdownGrace = 0 },
+	} {
+		t.Run(name, func(t *testing.T) {
+			config := valid
+			mutate(&config)
+			if _, err := NewLightpandaPoolWithProcessor(config, processor); !errors.Is(err, errInvalidPoolConfig) {
+				t.Fatalf("error = %v", err)
+			}
+		})
+	}
+	if _, err := NewLightpandaPoolWithProcessor(valid, nil); !errors.Is(err, errInvalidPoolConfig) {
+		t.Fatalf("nil processor error = %v", err)
+	}
+	if _, err := NewLightpandaPool(nil, valid); !errors.Is(err, errInvalidPoolConfig) {
+		t.Fatalf("nil adapter error = %v", err)
+	}
+}
+
+func TestLightpandaPoolRejectsInvalidJobsWithoutConsumingCapacity(t *testing.T) {
+	processor := PoolProcessorFunc(func(context.Context, *runtimev1.BrowserExecutionInput) (*runtimev1.BrowserResult, error) {
+		return &runtimev1.BrowserResult{}, nil
+	})
+	pool, err := NewLightpandaPoolWithProcessor(testPoolConfig(1, 1), processor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	valid := testPoolJob("valid", "https://valid.example/jobs")
+	oversized := testPoolJob("oversized", "https://oversized.example/jobs")
+	oversized.Input.Assignment.RoutingRevision = strings.Repeat("x", lightpandaadapter.InputPayloadLimit)
+	invalidURL := testPoolJob("invalid-url", "https://valid.example/jobs")
+	invalidURL.Input.Plan.TargetUrl = "file:///tmp/jobs"
+	negativeTimeout := valid
+	negativeTimeout.Timeout = -time.Millisecond
+
+	tests := map[string]struct {
+		context context.Context
+		job     PoolJob
+	}{
+		"nil context":      {job: valid},
+		"blank ID":         {context: context.Background(), job: PoolJob{ID: " ", Input: valid.Input}},
+		"negative timeout": {context: context.Background(), job: negativeTimeout},
+		"invalid URL":      {context: context.Background(), job: invalidURL},
+		"oversized input":  {context: context.Background(), job: oversized},
+	}
+	for name, test := range tests {
+		if err := pool.Submit(test.context, test.job); !errors.Is(err, errInvalidPoolJob) {
+			t.Fatalf("%s error = %v", name, err)
+		}
+	}
+	if stats := pool.Stats(); stats.Accepted != 0 || stats.Completed != 0 || stats.Queued != 0 || stats.InFlight != 0 {
+		t.Fatalf("invalid jobs changed stats = %+v", stats)
+	}
+
+	submitPoolJob(t, pool, valid)
+	pool.Close()
+	if results := collectPoolResults(t, pool); len(results) != 1 || results[0].JobID != valid.ID {
+		t.Fatalf("valid result after rejection = %+v", results)
+	}
+}
+
+func TestLightpandaPoolBoundsAcceptedWork(t *testing.T) {
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	processor := PoolProcessorFunc(func(context.Context, *runtimev1.BrowserExecutionInput) (*runtimev1.BrowserResult, error) {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-release
+		return &runtimev1.BrowserResult{}, nil
+	})
+	pool, err := NewLightpandaPoolWithProcessor(testPoolConfig(1, 2), processor)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	submitPoolJob(t, pool, testPoolJob("one", "https://one.example/jobs"))
+	<-started
+	submitPoolJob(t, pool, testPoolJob("two", "https://two.example/jobs"))
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := pool.Submit(ctx, testPoolJob("rejected", "https://three.example/jobs")); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("third submit error = %v", err)
+	}
+
+	pool.Close()
+	close(release)
+	results := collectPoolResults(t, pool)
+	if len(results) != 2 {
+		t.Fatalf("results = %d", len(results))
+	}
+	stats := pool.Stats()
+	if stats.Accepted != 2 || stats.Completed != 2 || stats.MaxInFlight != 1 || stats.MaxQueued < 1 {
+		t.Fatalf("stats = %+v", stats)
+	}
+}
+
+func TestLightpandaPoolRejectsPreCanceledAdmissionDeterministically(t *testing.T) {
+	processor := PoolProcessorFunc(func(context.Context, *runtimev1.BrowserExecutionInput) (*runtimev1.BrowserResult, error) {
+		return &runtimev1.BrowserResult{}, nil
+	})
+	pool, err := NewLightpandaPoolWithProcessor(testPoolConfig(1, 1), processor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	admissionContext, cancel := context.WithCancel(context.Background())
+	cancel()
+	for attempt := range 100 {
+		err := pool.Submit(admissionContext, testPoolJob(
+			fmt.Sprintf("canceled-%d", attempt),
+			"https://canceled-admission.example/jobs",
+		))
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("attempt %d error = %v", attempt, err)
+		}
+	}
+	if stats := pool.Stats(); stats.Accepted != 0 || stats.Completed != 0 || stats.Queued != 0 || stats.InFlight != 0 {
+		t.Fatalf("stats before close = %+v", stats)
+	}
+	pool.Close()
+	if results := collectPoolResults(t, pool); len(results) != 0 {
+		t.Fatalf("terminal results = %d", len(results))
+	}
+}
+
+func TestLightpandaPoolIsOriginFairAndSingleFlight(t *testing.T) {
+	started := make(chan string, 8)
+	release := make(chan struct{})
+	var mu sync.Mutex
+	activeByOrigin := make(map[string]int)
+	maxByOrigin := make(map[string]int)
+	activeTotal := 0
+	maxTotal := 0
+
+	processor := PoolProcessorFunc(func(_ context.Context, input *runtimev1.BrowserExecutionInput) (*runtimev1.BrowserResult, error) {
+		origin, err := canonicalTargetOrigin(input.Plan.TargetUrl)
+		if err != nil {
+			return nil, err
+		}
+		mu.Lock()
+		activeByOrigin[origin]++
+		if activeByOrigin[origin] > maxByOrigin[origin] {
+			maxByOrigin[origin] = activeByOrigin[origin]
+		}
+		activeTotal++
+		if activeTotal > maxTotal {
+			maxTotal = activeTotal
+		}
+		mu.Unlock()
+		started <- origin
+		<-release
+		mu.Lock()
+		activeByOrigin[origin]--
+		activeTotal--
+		mu.Unlock()
+		return &runtimev1.BrowserResult{}, nil
+	})
+
+	pool, err := NewLightpandaPoolWithProcessor(testPoolConfig(4, 8), processor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, origin := range []string{"a", "b", "c", "d"} {
+		for wave := range 2 {
+			submitPoolJob(t, pool, testPoolJob(
+				fmt.Sprintf("%s-%d", origin, wave),
+				fmt.Sprintf("https://%s.example/jobs", origin),
+			))
+		}
+	}
+
+	firstWave := make(map[string]bool)
+	for range 4 {
+		select {
+		case origin := <-started:
+			firstWave[origin] = true
+		case <-time.After(time.Second):
+			t.Fatal("four distinct origins did not reach service")
+		}
+	}
+	if len(firstWave) != 4 {
+		t.Fatalf("first active origins = %v", firstWave)
+	}
+	for range 100 {
+		stats := pool.Stats()
+		if stats.Queued < 0 || stats.InFlight < 0 || stats.MaxQueued < 0 || stats.MaxInFlight < 0 {
+			t.Fatalf("invalid concurrent stats snapshot = %+v", stats)
+		}
+	}
+	pool.Close()
+	close(release)
+	if results := collectPoolResults(t, pool); len(results) != 8 {
+		t.Fatalf("results = %d", len(results))
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if maxTotal != 4 {
+		t.Fatalf("maximum global concurrency = %d, want 4", maxTotal)
+	}
+	for origin, maximum := range maxByOrigin {
+		if maximum != 1 {
+			t.Fatalf("origin %s maximum concurrency = %d", origin, maximum)
+		}
+	}
+	if stats := pool.Stats(); stats.MaxInFlight != 4 || stats.Accepted != 8 || stats.Completed != 8 ||
+		stats.TotalQueueTime <= 0 || stats.MaxQueueTime <= 0 || stats.TotalServiceTime <= 0 || stats.MaxServiceTime <= 0 {
+		t.Fatalf("stats = %+v", stats)
+	}
+}
+
+func TestLightpandaPoolConcurrentSubmitAndCloseConservesAcceptedJobs(t *testing.T) {
+	processor := PoolProcessorFunc(func(context.Context, *runtimev1.BrowserExecutionInput) (*runtimev1.BrowserResult, error) {
+		return &runtimev1.BrowserResult{}, nil
+	})
+	pool, err := NewLightpandaPoolWithProcessor(testPoolConfig(4, 16), processor)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resultsDone := make(chan []PoolResult, 1)
+	go func() {
+		var results []PoolResult
+		for result := range pool.Results() {
+			results = append(results, result)
+		}
+		resultsDone <- results
+	}()
+	gate := make(chan struct{})
+	var accepted atomic.Uint64
+	var submits sync.WaitGroup
+	for index := range 64 {
+		submits.Add(1)
+		go func(index int) {
+			defer submits.Done()
+			<-gate
+			err := pool.Submit(context.Background(), testPoolJob(
+				fmt.Sprintf("job-%d", index),
+				fmt.Sprintf("https://origin-%d.example/jobs", index),
+			))
+			switch {
+			case err == nil:
+				accepted.Add(1)
+			case errors.Is(err, errPoolClosed):
+			default:
+				t.Errorf("submit %d error = %v", index, err)
+			}
+		}(index)
+	}
+	close(gate)
+	pool.Close()
+	submits.Wait()
+	pool.Close()
+	results := <-resultsDone
+	if uint64(len(results)) != accepted.Load() {
+		t.Fatalf("terminal/accepted = %d/%d", len(results), accepted.Load())
+	}
+	stats := pool.Stats()
+	if stats.Accepted != accepted.Load() || stats.Completed != stats.Accepted || stats.Queued != 0 || stats.InFlight != 0 {
+		t.Fatalf("stats = %+v, submit accepted = %d", stats, accepted.Load())
+	}
+}
+
+func TestLightpandaPoolRejectsAmbiguousProcessorTerminal(t *testing.T) {
+	pool, err := NewLightpandaPoolWithProcessor(testPoolConfig(1, 1), PoolProcessorFunc(
+		func(context.Context, *runtimev1.BrowserExecutionInput) (*runtimev1.BrowserResult, error) {
+			return nil, nil
+		},
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	submitPoolJob(t, pool, testPoolJob("ambiguous", "https://ambiguous.example/jobs"))
+	pool.Close()
+	results := collectPoolResults(t, pool)
+	if len(results) != 1 || !errors.Is(results[0].Err, errPoolProcessor) || results[0].Runtime != nil {
+		t.Fatalf("terminal result = %+v", results)
+	}
+}
+
+func TestLightpandaPoolClonesAcceptedInput(t *testing.T) {
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	observed := make(chan *runtimev1.BrowserExecutionInput, 1)
+	processor := PoolProcessorFunc(func(_ context.Context, input *runtimev1.BrowserExecutionInput) (*runtimev1.BrowserResult, error) {
+		if input.Plan.TargetUrl == "https://block.example/jobs" {
+			close(firstStarted)
+			<-releaseFirst
+		} else {
+			observed <- proto.Clone(input).(*runtimev1.BrowserExecutionInput)
+		}
+		return &runtimev1.BrowserResult{}, nil
+	})
+	pool, err := NewLightpandaPoolWithProcessor(testPoolConfig(1, 2), processor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	submitPoolJob(t, pool, testPoolJob("block", "https://block.example/jobs"))
+	<-firstStarted
+	input := bridgeInput("https://immutable.example/jobs", "document.title", 64)
+	original := proto.Clone(input).(*runtimev1.BrowserExecutionInput)
+	submitPoolJob(t, pool, PoolJob{ID: "immutable", Input: input})
+	input.Plan.TargetUrl = "https://caller-mutated.invalid/jobs"
+	input.Plan.Evaluations[0].Expression = "secret mutation"
+	close(releaseFirst)
+	pool.Close()
+	_ = collectPoolResults(t, pool)
+	if got := <-observed; !proto.Equal(got, original) {
+		t.Fatalf("processor input changed after Submit: got %v want %v", got, original)
+	}
+}
+
+func TestLightpandaPoolClonesPublishedOutput(t *testing.T) {
+	owned := &runtimev1.BrowserResult{ContractVersion: "processor-owned"}
+	processor := PoolProcessorFunc(func(context.Context, *runtimev1.BrowserExecutionInput) (*runtimev1.BrowserResult, error) {
+		return owned, nil
+	})
+	pool, err := NewLightpandaPoolWithProcessor(testPoolConfig(1, 1), processor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	submitPoolJob(t, pool, testPoolJob("output-clone", "https://output.example/jobs"))
+	pool.Close()
+	results := collectPoolResults(t, pool)
+	if len(results) != 1 || results[0].Runtime == nil {
+		t.Fatalf("terminal results = %+v", results)
+	}
+
+	owned.ContractVersion = "processor-mutated"
+	if results[0].Runtime.ContractVersion != "processor-owned" {
+		t.Fatalf("published output aliased processor output: %q", results[0].Runtime.ContractVersion)
+	}
+	results[0].Runtime.ContractVersion = "consumer-mutated"
+	if owned.ContractVersion != "processor-mutated" {
+		t.Fatalf("processor output aliased published output: %q", owned.ContractVersion)
+	}
+}
+
+func TestLightpandaPoolPublishesOneTerminalPerAcceptedJob(t *testing.T) {
+	processor := PoolProcessorFunc(func(ctx context.Context, input *runtimev1.BrowserExecutionInput) (*runtimev1.BrowserResult, error) {
+		switch input.Plan.TargetUrl {
+		case "https://panic.example/jobs":
+			panic("secret panic text")
+		case "https://success.example/jobs":
+			return &runtimev1.BrowserResult{ContractVersion: "success"}, nil
+		default:
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+	})
+	config := testPoolConfig(4, 4)
+	config.JobTimeout = 25 * time.Millisecond
+	pool, err := NewLightpandaPoolWithProcessor(config, processor)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	canceledContext, cancel := context.WithCancel(context.Background())
+	cancel()
+	jobs := []PoolJob{
+		testPoolJob("panic", "https://panic.example/jobs"),
+		testPoolJob("success", "https://success.example/jobs"),
+		testPoolJob("timeout", "https://timeout.example/jobs"),
+		testPoolJob("canceled", "https://canceled.example/jobs"),
+	}
+	jobs[3].Context = canceledContext
+	for _, job := range jobs {
+		submitPoolJob(t, pool, job)
+	}
+	pool.Close()
+	results := collectPoolResults(t, pool)
+
+	byID := make(map[string]PoolResult)
+	for _, result := range results {
+		if _, exists := byID[result.JobID]; exists {
+			t.Fatalf("duplicate terminal result for %s", result.JobID)
+		}
+		byID[result.JobID] = result
+		if result.AcceptedAt.IsZero() || result.StartedAt.Before(result.AcceptedAt) ||
+			result.FinishedAt.Before(result.StartedAt) || result.QueueDuration < 0 || result.ServiceDuration < 0 {
+			t.Fatalf("invalid timing: %+v", result)
+		}
+	}
+	if len(byID) != len(jobs) {
+		t.Fatalf("terminal results = %d", len(byID))
+	}
+	var panicErr *PoolPanicError
+	if !errors.As(byID["panic"].Err, &panicErr) || strings.Contains(byID["panic"].Err.Error(), "secret") {
+		t.Fatalf("panic result = %v", byID["panic"].Err)
+	}
+	if byID["success"].Err != nil || byID["success"].Runtime.GetContractVersion() != "success" {
+		t.Fatalf("success result = %+v", byID["success"])
+	}
+	if !errors.Is(byID["timeout"].Err, context.DeadlineExceeded) {
+		t.Fatalf("timeout result = %v", byID["timeout"].Err)
+	}
+	if !errors.Is(byID["canceled"].Err, context.Canceled) {
+		t.Fatalf("canceled result = %v", byID["canceled"].Err)
+	}
+	if stats := pool.Stats(); stats.Accepted != 4 || stats.Completed != 4 || stats.Panics != 1 ||
+		stats.Queued != 0 || stats.InFlight != 0 {
+		t.Fatalf("stats = %+v", stats)
+	}
+}
+
+func TestLightpandaPoolShutdownWaitIsBoundedWhenProcessorViolatesContext(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	processor := PoolProcessorFunc(func(context.Context, *runtimev1.BrowserExecutionInput) (*runtimev1.BrowserResult, error) {
+		close(started)
+		<-release
+		return nil, nil
+	})
+	config := testPoolConfig(1, 1)
+	config.ShutdownGrace = 5 * time.Millisecond
+	pool, err := NewLightpandaPoolWithProcessor(config, processor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	submitPoolJob(t, pool, testPoolJob("ignores-context", "https://ignores.example/jobs"))
+	<-started
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := pool.Shutdown(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Shutdown error = %v", err)
+	}
+	close(release)
+	if results := collectPoolResults(t, pool); len(results) != 1 || !errors.Is(results[0].Err, context.Canceled) {
+		t.Fatalf("results = %+v", results)
+	}
+}
+
+func TestLightpandaPoolOneAcceptedWindowFitsBeforeResultDrain(t *testing.T) {
+	processor := PoolProcessorFunc(func(ctx context.Context, _ *runtimev1.BrowserExecutionInput) (*runtimev1.BrowserResult, error) {
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+	config := testPoolConfig(1, 3)
+	config.JobTimeout = 5 * time.Second
+	config.ShutdownGrace = 25 * time.Millisecond
+	pool, err := NewLightpandaPoolWithProcessor(config, processor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for index := range 3 {
+		submitPoolJob(t, pool, testPoolJob(fmt.Sprintf("job-%d", index), "https://same.example/jobs"))
+	}
+
+	started := time.Now()
+	pool.Close()
+	select {
+	case <-pool.Done():
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("one accepted window did not fit in the bounded result buffer")
+	}
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		t.Fatalf("bounded shutdown took %s", elapsed)
+	}
+	results := collectPoolResults(t, pool)
+	if len(results) != 3 {
+		t.Fatalf("results = %d", len(results))
+	}
+	for _, result := range results {
+		if !errors.Is(result.Err, context.Canceled) {
+			t.Fatalf("job %s error = %v", result.JobID, result.Err)
+		}
+	}
+	if err := pool.Submit(context.Background(), testPoolJob("late", "https://late.example/jobs")); !errors.Is(err, errPoolClosed) {
+		t.Fatalf("late submit error = %v", err)
+	}
+}
+
+func TestCanonicalTargetOrigin(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{raw: "https://EXAMPLE.test:443/jobs?x=1", want: "https://example.test"},
+		{raw: "http://[::1]:80/jobs", want: "http://[::1]"},
+		{raw: "http://127.0.0.1:8123/jobs", want: "http://127.0.0.1:8123"},
+		{raw: "https://user@example.test/jobs", wantErr: true},
+		{raw: "file:///tmp/jobs", wantErr: true},
+		{raw: "https://example.test/jobs#fragment", wantErr: true},
+	} {
+		t.Run(test.raw, func(t *testing.T) {
+			t.Parallel()
+			got, err := canonicalTargetOrigin(test.raw)
+			if (err != nil) != test.wantErr || got != test.want {
+				t.Fatalf("canonicalTargetOrigin(%q) = %q, %v", test.raw, got, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Related to #8706

## Summary

- add a non-authoritative fixed-worker, bounded-capacity pool around the merged runtime-v1 Lightpanda adapter
- schedule origins round-robin with strict per-origin single-flight and no goroutine per submitted job
- retain process-local CDP port ownership through proved cleanup and quarantine ports after cleanup uncertainty
- add a real c4 integration over eight loopback origins and sixteen exact B0/B1 terminals

## Classification

Necessary Stage A for the fixed-RAM density question: it creates the production-shaped concurrency primitive without queue, database, or crawler authority. Resident/shared browser processes, a generic scheduler abstraction, and the rejected unintegrated Python comparator remain explicitly out of scope.

## Safety

- no CLI or production entry point
- no queue or data authority
- one fresh checksum-pinned Lightpanda process per active slot
- loopback-only real integration fixtures
- caller must retain isolated PID/network namespaces and continuously drain bounded results

## Review and verification

- independent exact-byte critic approval: manifest 71fefdab89d572a84d178da1bf14393349017a81406506c0bc84f792ebf501a9
- normal tests, race tests, vet, tidy, formatting, diff checks, and race/shuffle x200 passed
- local pinned arm64 Lightpanda 0.4.0 c4 run passed 16/16 terminals, global max 4, per-origin max 1

## Merge gate

Keep draft until the PR workflow executes the corrected integration selector and both native linux/amd64 and linux/arm64 Docker jobs pass. This PR does not authorize a Murmur or production run.