### PR TITLE
Add fixed-RAM Lightpanda density evidence

### DIFF
--- a/.github/workflows/go-lightpanda-pilot.yml
+++ b/.github/workflows/go-lightpanda-pilot.yml
@@ -60,8 +60,7 @@ jobs:
           go test -v -timeout=60s -tags densitybench ./...
           go test -v -timeout=90s -race -tags densitybench ./...
           go vet -tags densitybench ./...
-          cd density
-          python3 -m unittest test_controller.py test_fixture_server.py test_python_runner.py
+          python3 -m unittest discover -s density -p 'test_*.py'
 
       - name: Exercise checksum-pinned stable Lightpanda
         run: docker build --build-context contracts=../../apps/crawler/contracts --platform ${{ matrix.platform }} --target integration-test --tag jobseek-lightpanda-integration:${{ matrix.arch }}-${{ github.run_id }} .
@@ -74,19 +73,23 @@ jobs:
           DENSITY_ARCH: ${{ matrix.arch }}
           DENSITY_PLATFORM: ${{ matrix.platform }}
           DENSITY_RUN_ID: ${{ github.run_id }}
+          DENSITY_SOURCE_COMMIT: ${{ github.sha }}
         run: |
           docker build \
             --build-context contracts=../../apps/crawler/contracts \
+            --build-arg "SOURCE_COMMIT=${DENSITY_SOURCE_COMMIT}" \
             --platform "${DENSITY_PLATFORM}" \
             --target density \
             --tag "jobseek-lightpanda-density:${DENSITY_ARCH}-${DENSITY_RUN_ID}" \
             .
           docker build \
+            --build-arg "SOURCE_COMMIT=${DENSITY_SOURCE_COMMIT}" \
             --platform "${DENSITY_PLATFORM}" \
             --file density/Dockerfile.python \
             --tag "jobseek-python-chromium-density:${DENSITY_ARCH}-${DENSITY_RUN_ID}" \
             density
           docker build \
+            --build-arg "SOURCE_COMMIT=${DENSITY_SOURCE_COMMIT}" \
             --platform "${DENSITY_PLATFORM}" \
             --file density/Dockerfile.fixture \
             --tag "jobseek-density-fixture:${DENSITY_ARCH}-${DENSITY_RUN_ID}" \

--- a/pilots/go-lightpanda/Dockerfile
+++ b/pilots/go-lightpanda/Dockerfile
@@ -70,6 +70,11 @@ ENTRYPOINT ["/usr/local/bin/go-lightpanda"]
 
 FROM pilot-base AS density
 
+ARG SOURCE_COMMIT
+RUN test "${#SOURCE_COMMIT}" -eq 40 \
+    && case "${SOURCE_COMMIT}" in ''|*[!0-9a-f]*) exit 1 ;; esac
+LABEL org.jobseek.density.source-commit="${SOURCE_COMMIT}"
+
 USER 0:0
 RUN install -d --owner=10001 --group=10001 --mode=0555 /density
 COPY --from=density-build /out/go-lightpanda-density /usr/local/bin/go-lightpanda-density

--- a/pilots/go-lightpanda/README.md
+++ b/pilots/go-lightpanda/README.md
@@ -68,6 +68,7 @@ GLIBC 2.38 requirement. The Go builder tag and packages resolved during
 docker build \
   --build-context contracts=../../apps/crawler/contracts \
   --platform linux/amd64 \
+  --target runtime \
   -t jobseek-lightpanda-pilot .
 
 docker run --rm \
@@ -199,7 +200,84 @@ Those belong to the still-open fixed-RAM evidence issue and require a separate
 frozen protocol plus independent review. The smoke grants no crawler, queue,
 database, Murmur, or production authority.
 
-The controller releases each measured runner with one short `docker exec`
-after attaching the cgroup sampler. That helper runs inside the measured
-cgroup, so this smoke's counters prove limit enforcement only. The repeated
-evidence protocol must replace that synchronization before comparing density.
+Each measured runner publishes an empty, private initial marker only after its
+release-signal handler is installed. The controller attests the runner's host
+PID identity and sole cgroup membership, starts the sampler, and sends
+`SIGUSR1`. After the workload and all browser resources are torn down, the
+runner publishes a distinct final marker and waits for `SIGUSR2`; only then
+does it emit its single JSON report and exit. The controller never enters the
+measured cgroup, and stale markers cannot satisfy the other phase.
+
+## Frozen Stage B2 density evidence
+
+`density/schedule.v1.json` freezes the comparative protocol independently of
+the pull-request smoke. It runs one diagnostic c1 pair, five counterbalanced
+c4 pairs, and five counterbalanced c8 pairs, for exactly 22 sequential arm
+records. Every arm gets a fresh fixture, internal network, measured container,
+and cgroup with the same one-CPU, 1 GiB no-swap, 768-PID, and 256-file limit.
+There are no retries, substitutions, adaptive profiles, public origins, or
+production queue/database access.
+
+Admission requires both implementations to pass all five c4 arms and Go to
+pass all five c8 arms. If both implementations pass c8, the paired median
+Python/Go elapsed ratio must be at least 1.25 with four strict Go wins, and the
+paired median Go/Python memory ratio must be at most 0.80 with four strict Go
+wins. If both c8 median peaks remain below 70% of the cap, the result is
+inconclusive because the RAM ceiling was not exercised. If Python instead has
+at least three kernel-confirmed c8 memory-pressure failures and no other c8
+failure class, every Go c8 peak must remain strictly below 80% of the cap.
+
+The executor checkpoints all 22 ordered slots in a private atomic report.
+Cleaned runtime, correctness, timeout, and memory-pressure failures are
+retained and later arms continue. Cleanup, containment, protected-host-health,
+or measured-process-residue failures abort the run, leave unstarted slots
+explicitly `not_run`, and can never produce admission. Failed memory samples
+may exceed the cgroup limit by at most one recorded host page; values are never
+clamped. Evidence output contains only closed identifiers, exact image IDs,
+integer timings, and aggregate cgroup counters—never raw logs, URLs, PIDs,
+cgroup paths, or service names.
+
+Run the frozen protocol only on an isolated Linux Docker host after building
+the three density images from the same reviewed source commit. Repeat
+`--protected-container` for any colocated service whose identity, start time,
+restart count, and boundary health must remain unchanged. These checks run
+before and after every arm; resource isolation remains the protection against
+transient interference within an arm:
+
+```sh
+test "$(git rev-parse HEAD)" = "$REVIEWED_SOURCE_COMMIT"
+git diff --quiet
+git diff --cached --quiet
+test -z "$(git ls-files --others --exclude-standard)"
+
+docker build \
+  --build-context contracts=../../apps/crawler/contracts \
+  --build-arg "SOURCE_COMMIT=$REVIEWED_SOURCE_COMMIT" \
+  --target density \
+  --tag jobseek-lightpanda-density:evidence \
+  .
+docker build \
+  --build-arg "SOURCE_COMMIT=$REVIEWED_SOURCE_COMMIT" \
+  --file density/Dockerfile.python \
+  --tag jobseek-python-chromium-density:evidence \
+  density
+docker build \
+  --build-arg "SOURCE_COMMIT=$REVIEWED_SOURCE_COMMIT" \
+  --file density/Dockerfile.fixture \
+  --tag jobseek-density-fixture:evidence \
+  density
+
+sudo --non-interactive python3 density/evidence_runner.py \
+  --go-image jobseek-lightpanda-density:evidence \
+  --python-image jobseek-python-chromium-density:evidence \
+  --fixture-image jobseek-density-fixture:evidence \
+  --source-commit "$REVIEWED_SOURCE_COMMIT" \
+  --protected-container protected-service \
+  --timeout-seconds 180 \
+  --output /tmp/go-lightpanda-density-evidence.json
+```
+
+The final process status reports whether the frozen execution completed; the
+report's closed `summary.status` is the separate admission decision. An
+`inconclusive`, `not_admitted`, or `invalid` summary must not be promoted into
+a production-routing decision.

--- a/pilots/go-lightpanda/density/Dockerfile.fixture
+++ b/pilots/go-lightpanda/density/Dockerfile.fixture
@@ -1,5 +1,10 @@
 FROM python:3.13.15-slim-trixie@sha256:7ce4b6dfe35e55397b7cda544f8a13f191b7ae28dc5aad71fe664dbc9bc2623f
 
+ARG SOURCE_COMMIT
+RUN test "${#SOURCE_COMMIT}" -eq 40 \
+    && case "${SOURCE_COMMIT}" in ''|*[!0-9a-f]*) exit 1 ;; esac
+LABEL org.jobseek.density.source-commit="${SOURCE_COMMIT}"
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 

--- a/pilots/go-lightpanda/density/Dockerfile.python
+++ b/pilots/go-lightpanda/density/Dockerfile.python
@@ -1,5 +1,10 @@
 FROM python:3.13.15-slim-trixie@sha256:7ce4b6dfe35e55397b7cda544f8a13f191b7ae28dc5aad71fe664dbc9bc2623f
 
+ARG SOURCE_COMMIT
+RUN test "${#SOURCE_COMMIT}" -eq 40 \
+    && case "${SOURCE_COMMIT}" in ''|*[!0-9a-f]*) exit 1 ;; esac
+LABEL org.jobseek.density.source-commit="${SOURCE_COMMIT}"
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PLAYWRIGHT_BROWSERS_PATH=/ms-playwright

--- a/pilots/go-lightpanda/density/controller.py
+++ b/pilots/go-lightpanda/density/controller.py
@@ -17,20 +17,23 @@ from pathlib import Path
 import re
 import secrets
 import selectors
+import stat
 import subprocess
 import tempfile
 import threading
 import time
-from typing import Any
+from typing import Any, NamedTuple
 
 
 GIB = 1024**3
 FIXTURE_MEMORY = 256 * 1024**2
 FIXTURE_PIDS = 64
 MEASURED_PIDS = 512
+EVIDENCE_MEASURED_PIDS = 768
 FIXTURE_TMPFS = "rw,noexec,nosuid,nodev,size=16777216,uid=10001,gid=10001,mode=0700"
 MEASURED_TMPFS = "rw,noexec,nosuid,nodev,size=268435456,uid=10001,gid=10001,mode=0700"
-START_GATE = "/tmp/controller-start"
+INITIAL_MARKER_PATH = "/tmp/controller-initial"
+FINAL_MARKER_PATH = "/tmp/controller-final"
 ALIASES = tuple(f"origin-{i}.bench.test" for i in range(8))
 LABEL_RUN = "org.jobseek.density.run"
 LABEL_ROLE = "org.jobseek.density.role"
@@ -38,7 +41,7 @@ MAX_REPORT_BYTES = 1024 * 1024
 CGROUP_FILES = (
     "memory.current", "memory.peak", "memory.max", "memory.swap.max",
     "memory.events", "cpu.max", "cpu.stat", "pids.max", "pids.events",
-    "pids.peak", "cgroup.procs",
+    "pids.current", "pids.peak", "cgroup.procs",
 )
 CGROUP_FILE_FAILURES = {
     name: "missing_cgroup_" + name.replace(".", "_") for name in CGROUP_FILES
@@ -50,10 +53,12 @@ GO_RUNNER_FAILURES = {
     )
 }
 FAILURE_IDS = {
-    "cleanup", "command", "concurrency", "conservation", "image", "inspect",
+    "cleanup", "command", "concurrency", "conservation", "image", "infrastructure", "inspect",
     "malformed_output", "missing_cgroup", "nonzero", "oom", "oracle",
+    "memory_pressure", "pid_limit",
     "missing_cgroup_membership", "missing_cgroup_path", "missing_cgroup_pid",
-    "start_timeout", "timeout", "transcript", *CGROUP_FILE_FAILURES.values(),
+    "process_identity", "process_residue", "process_state", "start_timeout",
+    "timeout", "transcript", *CGROUP_FILE_FAILURES.values(),
     *GO_RUNNER_FAILURES.values(),
 }
 
@@ -62,7 +67,7 @@ COMMON_KEYS = {
     "image_identity", "concurrency",
 }
 GO_KEYS = COMMON_KEYS | {
-    "implementation_id", "runtime_id", "succeeded", "elapsed_ms", "submitted",
+    "implementation_id", "runtime_id", "succeeded", "elapsed_ns", "submitted",
     "accepted", "terminal", "succeeded_jobs", "failed_jobs",
     "oracle_matches", "conservation_ok", "oracle_ok", "max_in_flight_ok",
     "zero_panic_residue", "waves", "pool", "failure_id",
@@ -97,10 +102,18 @@ FIXTURE_UNEXPECTED_KEYS = {"method", "path", "origin", "duplicate", "total"}
 
 
 class SmokeFailure(RuntimeError):
-    def __init__(self, failure_id: str):
+    def __init__(
+        self,
+        failure_id: str,
+        *,
+        resources: dict[str, Any] | None = None,
+        resources_final: bool = False,
+    ) -> None:
         if failure_id not in FAILURE_IDS:
             failure_id = "command"
         self.failure_id = failure_id
+        self.resources = resources
+        self.resources_final = resources_final
         super().__init__(failure_id)
 
 
@@ -198,7 +211,7 @@ def validate_measured(report: dict[str, Any], implementation: str, concurrency: 
                 re.fullmatch(r"go1\.[0-9]+(?:\.[0-9]+)?(?:[a-z0-9.-]+)?", report["runtime_id"]) is None or
                 report.get("failure_id") not in (None, "")):
             raise SmokeFailure("oracle")
-        _integer(report.get("elapsed_ms"))
+        _integer(report.get("elapsed_ns"), minimum=1)
         stats = _object(report.get("pool"), GO_STATS_KEYS)
         if any(report.get(k) != v for k, v in {
             "submitted": 16, "accepted": 16, "terminal": 16, "succeeded_jobs": 16,
@@ -344,22 +357,31 @@ def workload_waves(tasks: dict[str, dict[str, Any]]) -> list[dict[str, Any]]:
     return [{"id": wave, "tasks": grouped[wave]} for wave in ("w0", "w1")]
 
 
-def validate_resources(resources: dict[str, Any]) -> None:
+def validate_resources(
+    resources: dict[str, Any], *, expected_pids: int = MEASURED_PIDS
+) -> None:
     current = _integer(resources.get("memory_current"))
     peak = _integer(resources.get("memory_peak"), minimum=1)
+    pids_current = _integer(resources.get("pids_current"), minimum=1)
     pids_peak = _integer(resources.get("pids_peak"), minimum=1)
+    process_count = _integer(resources.get("cgroup_process_count"), minimum=1)
+    page_size = _integer(resources.get("host_page_size"), minimum=4096)
     events = _object(resources.get("memory_events"), {"low", "high", "max", "oom", "oom_kill", "oom_group_kill"})
     cpu = resources.get("cpu_stat")
     if (resources.get("memory_limit") != GIB or resources.get("memory_swap_limit") != 0 or
-            resources.get("pids_limit") != MEASURED_PIDS):
+            resources.get("pids_limit") != expected_pids):
         raise SmokeFailure("inspect")
     cpu_max = resources.get("cpu_max")
     if (not isinstance(cpu_max, list) or len(cpu_max) != 2 or
             any(isinstance(value, bool) or not isinstance(value, int) or value <= 0 for value in cpu_max) or
             cpu_max[0] != cpu_max[1]):
         raise SmokeFailure("inspect")
-    if current > GIB or peak > GIB or pids_peak > MEASURED_PIDS:
+    if (current > GIB or peak > GIB + page_size or pids_current > expected_pids or
+            pids_peak > expected_pids or
+            page_size > 65536 or page_size & (page_size - 1)):
         raise SmokeFailure("inspect")
+    if process_count != 1:
+        raise SmokeFailure("process_residue")
     if not isinstance(cpu, dict):
         raise SmokeFailure("missing_cgroup")
     for key in ("usage_usec", "user_usec", "system_usec"):
@@ -367,9 +389,18 @@ def validate_resources(resources: dict[str, Any]) -> None:
     for value in events.values():
         _integer(value)
     pids_events = _object(resources.get("pids_events"), {"max"})
-    if (events["oom"] or events["oom_kill"] or events["oom_group_kill"] or
-            _integer(pids_events.get("max")) != 0):
+    pid_pressure = _integer(pids_events.get("max")) != 0
+    memory_pressure = any(
+        events[key] for key in ("max", "oom", "oom_kill", "oom_group_kill")
+    )
+    if peak > GIB and not memory_pressure:
+        raise SmokeFailure("inspect")
+    if pid_pressure:
+        raise SmokeFailure("pid_limit")
+    if events["oom"] or events["oom_kill"] or events["oom_group_kill"]:
         raise SmokeFailure("oom")
+    if peak > GIB:
+        raise SmokeFailure("memory_pressure")
 
 
 class Docker:
@@ -442,8 +473,16 @@ class Docker:
             return stdout_path.read_bytes()
 
 
-def attest_container(inspect: dict[str, Any], network: str, role: str, run_id: str,
-                     image_identity: str, *, measured: bool) -> None:
+def attest_container(
+    inspect: dict[str, Any],
+    network: str,
+    role: str,
+    run_id: str,
+    image_identity: str,
+    *,
+    measured: bool,
+    measured_pids: int = MEASURED_PIDS,
+) -> None:
     try:
         config, host = inspect["Config"], inspect["HostConfig"]
         labels = config["Labels"]
@@ -477,7 +516,7 @@ def attest_container(inspect: dict[str, Any], network: str, role: str, run_id: s
             raise KeyError
         if role != "fixture" and aliases:
             raise KeyError
-        expected_memory, expected_pids = (GIB, MEASURED_PIDS) if measured else (FIXTURE_MEMORY, FIXTURE_PIDS)
+        expected_memory, expected_pids = (GIB, measured_pids) if measured else (FIXTURE_MEMORY, FIXTURE_PIDS)
         if (host.get("NanoCpus") != 1_000_000_000 or host.get("Memory") != expected_memory or
                 host.get("MemorySwap") != expected_memory or host.get("PidsLimit") != expected_pids):
             raise KeyError
@@ -552,6 +591,140 @@ def _parse_flat(raw: str, required: set[str]) -> dict[str, int]:
     return result
 
 
+def _read_cgroup_members(
+    path: Path, *, allow_empty: bool = False
+) -> tuple[int, ...]:
+    try:
+        lines = (path / "cgroup.procs").read_text(encoding="ascii").splitlines()
+    except (OSError, UnicodeError):
+        raise SmokeFailure("missing_cgroup_cgroup_procs") from None
+    if ((not lines and not allow_empty) or
+            any(not line.isdigit() or int(line) <= 0 for line in lines)):
+        raise SmokeFailure("process_residue")
+    members = tuple(int(line) for line in lines)
+    if len(set(members)) != len(members):
+        raise SmokeFailure("process_residue")
+    return members
+
+
+class ProcessIdentity(NamedTuple):
+    """Host-only identity for the measured container's main process."""
+
+    pid: int
+    start_time: int
+    cgroup_path: Path
+
+    @classmethod
+    def capture(cls, pid: int, *, proc_root: Path = Path("/proc")) -> "ProcessIdentity":
+        try:
+            state, start_time = _read_process_stat(pid, proc_root=proc_root)
+        except FileNotFoundError:
+            raise SmokeFailure("process_identity") from None
+        if not state:
+            raise SmokeFailure("process_identity")
+        cgroup_path = _read_process_cgroup(pid, proc_root=proc_root)
+        return cls(pid=pid, start_time=start_time, cgroup_path=cgroup_path)
+
+    def state(self, *, proc_root: Path = Path("/proc")) -> str | None:
+        try:
+            state, start_time = _read_process_stat(self.pid, proc_root=proc_root)
+            cgroup_path = _read_process_cgroup(self.pid, proc_root=proc_root)
+        except FileNotFoundError:
+            return None
+        if start_time != self.start_time or cgroup_path != self.cgroup_path:
+            raise SmokeFailure("process_identity")
+        return state
+
+    def only_main_process(self) -> bool:
+        return _read_cgroup_members(self.cgroup_path) == (self.pid,)
+
+    def marker_ready(
+        self, marker_path: str, *, proc_root: Path = Path("/proc")
+    ) -> bool:
+        if marker_path not in {INITIAL_MARKER_PATH, FINAL_MARKER_PATH}:
+            raise SmokeFailure("process_state")
+        marker = proc_root / str(self.pid) / "root" / marker_path.lstrip("/")
+        try:
+            metadata = marker.lstat()
+        except FileNotFoundError:
+            return False
+        except OSError:
+            raise SmokeFailure("process_state") from None
+        valid = (
+            stat.S_ISREG(metadata.st_mode)
+            and stat.S_IMODE(metadata.st_mode) == 0o600
+            and metadata.st_uid == 10001
+            and metadata.st_gid == 10001
+            and metadata.st_nlink == 1
+            and metadata.st_size == 0
+        )
+        if not valid:
+            raise SmokeFailure("process_state")
+        return True
+
+
+def _read_process_stat(pid: int, *, proc_root: Path) -> tuple[str, int]:
+    if isinstance(pid, bool) or not isinstance(pid, int) or pid <= 0:
+        raise SmokeFailure("missing_cgroup_pid")
+    try:
+        raw = (proc_root / str(pid) / "stat").read_text(encoding="ascii")
+    except FileNotFoundError:
+        raise
+    except (OSError, UnicodeError):
+        raise SmokeFailure("process_identity") from None
+    prefix, separator, tail = raw.rpartition(") ")
+    fields = tail.split()
+    if separator != ") " or not prefix.startswith(f"{pid} (") or len(fields) < 20:
+        raise SmokeFailure("process_identity")
+    state = fields[0]
+    start_time = fields[19]
+    if re.fullmatch(r"[A-Z]", state) is None or not start_time.isdigit():
+        raise SmokeFailure("process_identity")
+    return state, int(start_time)
+
+
+def _read_process_cgroup(pid: int, *, proc_root: Path) -> Path:
+    try:
+        lines = (proc_root / str(pid) / "cgroup").read_text(encoding="ascii").splitlines()
+    except FileNotFoundError:
+        raise
+    except (OSError, UnicodeError):
+        raise SmokeFailure("missing_cgroup_membership") from None
+    memberships = [line.split("::", 1)[1] for line in lines if line.startswith("0::")]
+    if len(memberships) != 1:
+        raise SmokeFailure("missing_cgroup_membership")
+    try:
+        root = Path("/sys/fs/cgroup").resolve()
+        path = (root / memberships[0].lstrip("/")).resolve()
+        path.relative_to(root)
+    except (OSError, ValueError, IndexError):
+        raise SmokeFailure("missing_cgroup_path") from None
+    return path
+
+
+def wait_process_phase(
+    identity: ProcessIdentity, *, phase: str, deadline: float
+) -> str:
+    """Require exact runner-authored markers without entering its cgroup."""
+
+    if phase not in {"initial", "final"}:
+        raise SmokeFailure("process_state")
+    while time.monotonic() < deadline:
+        state = identity.state()
+        if state is None:
+            return "exited"
+        initial_ready = identity.marker_ready(INITIAL_MARKER_PATH)
+        final_ready = identity.marker_ready(FINAL_MARKER_PATH)
+        if phase == "initial" and initial_ready and not final_ready:
+            return "matched"
+        if phase == "final" and not initial_ready and final_ready:
+            return "matched"
+        if final_ready and phase == "initial":
+            raise SmokeFailure("process_state")
+        time.sleep(0.01)
+    return "timeout"
+
+
 class CgroupSampler:
     """Samples only aggregate cgroup counters; PIDs and argv never leave it."""
     def __init__(self, path: Path, interval: float = 0.1) -> None:
@@ -562,19 +735,11 @@ class CgroupSampler:
 
     @classmethod
     def from_pid(cls, pid: int) -> "CgroupSampler":
-        if isinstance(pid, bool) or not isinstance(pid, int) or pid <= 0:
-            raise SmokeFailure("missing_cgroup_pid")
-        try:
-            lines = Path(f"/proc/{pid}/cgroup").read_text().splitlines()
-        except (OSError, UnicodeError):
-            raise SmokeFailure("missing_cgroup_membership") from None
-        try:
-            relative = next(line.split("::", 1)[1] for line in lines if line.startswith("0::"))
-            root = Path("/sys/fs/cgroup").resolve()
-            path = (root / relative.lstrip("/")).resolve()
-            path.relative_to(root)
-        except (OSError, StopIteration, ValueError, IndexError):
-            raise SmokeFailure("missing_cgroup_path") from None
+        return cls.from_identity(ProcessIdentity.capture(pid))
+
+    @classmethod
+    def from_identity(cls, identity: ProcessIdentity) -> "CgroupSampler":
+        path = identity.cgroup_path
         for name in CGROUP_FILES:
             if not (path / name).is_file():
                 raise SmokeFailure(CGROUP_FILE_FAILURES[name])
@@ -584,18 +749,22 @@ class CgroupSampler:
         self._sample()
         self._thread.start()
 
-    def stop(self) -> dict[str, Any]:
+    def stop(
+        self, *, reject_oom: bool = True, allow_fallback: bool = True
+    ) -> dict[str, Any]:
         self._stop.set()
         self._thread.join(timeout=2)
         if self._thread.is_alive():
             raise SmokeFailure("missing_cgroup")
         try:
             result = self._read_resources()
-        except (OSError, ValueError):
+        except (OSError, ValueError, SmokeFailure):
+            if not allow_fallback:
+                raise SmokeFailure("missing_cgroup") from None
             result = self.latest
         if result is None:
             raise SmokeFailure("missing_cgroup")
-        if result["memory_events"]["oom"] or result["memory_events"]["oom_kill"] or result["memory_events"]["oom_group_kill"]:
+        if reject_oom and (result["memory_events"]["oom"] or result["memory_events"]["oom_kill"] or result["memory_events"]["oom_group_kill"]):
             raise SmokeFailure("oom")
         return result
 
@@ -607,7 +776,7 @@ class CgroupSampler:
     def _sample(self) -> None:
         try:
             self.latest = self._read_resources()
-        except (OSError, ValueError):
+        except (OSError, ValueError, SmokeFailure):
             pass
 
     def _read_resources(self) -> dict[str, Any]:
@@ -623,6 +792,7 @@ class CgroupSampler:
                 len(cpu_parts) != 2 or "max" in cpu_parts):
             raise ValueError
         return {
+            "host_page_size": os.sysconf("SC_PAGE_SIZE"),
             "memory_current": int((self.path / "memory.current").read_text()),
             "memory_peak": int((self.path / "memory.peak").read_text()),
             "memory_limit": int(memory_limit),
@@ -635,8 +805,52 @@ class CgroupSampler:
             ) if key in cpu},
             "pids_limit": int(pids_limit),
             "pids_events": {"max": pids_events["max"]},
+            "pids_current": int((self.path / "pids.current").read_text()),
             "pids_peak": int((self.path / "pids.peak").read_text()),
+            "cgroup_process_count": len(
+                _read_cgroup_members(self.path, allow_empty=True)
+            ),
         }
+
+
+def classify_resource_failure(
+    failure_id: str, resources: dict[str, Any] | None
+) -> str:
+    """Prefer kernel pressure only over a secondary process-exit symptom."""
+
+    if failure_id not in {
+        "process_state",
+        "timeout",
+        "nonzero",
+        "oom",
+        "memory_pressure",
+        "pid_limit",
+    } or not isinstance(resources, dict):
+        return failure_id
+    memory_events = resources.get("memory_events")
+    pids_events = resources.get("pids_events")
+    if (
+        isinstance(pids_events, dict)
+        and isinstance(pids_events.get("max"), int)
+        and not isinstance(pids_events.get("max"), bool)
+        and pids_events["max"] > 0
+    ):
+        return "pid_limit"
+    if isinstance(memory_events, dict) and any(
+        isinstance(memory_events.get(key), int)
+        and not isinstance(memory_events.get(key), bool)
+        and memory_events[key] > 0
+        for key in ("oom", "oom_kill", "oom_group_kill")
+    ):
+        return "oom"
+    if (
+        isinstance(memory_events, dict)
+        and isinstance(memory_events.get("max"), int)
+        and not isinstance(memory_events.get("max"), bool)
+        and memory_events["max"] > 0
+    ):
+        return "memory_pressure"
+    return failure_id
 
 
 class SmokeController:
@@ -688,9 +902,13 @@ class SmokeController:
             self.docker.run(["kill", container], timeout=10, check=False)
             raise SmokeFailure("start_timeout") from None
 
-    def _release_start_gate(self, container: str) -> None:
-        result = self.docker.run(["exec", container, "touch", START_GATE], timeout=5)
-        if result.stdout or result.stderr:
+    def _signal(self, container: str, signal_name: str) -> None:
+        if signal_name not in {"USR1", "USR2"}:
+            raise SmokeFailure("command")
+        result = self.docker.run(
+            ["kill", "--signal", signal_name, container], timeout=5
+        )
+        if result.stderr or result.stdout.strip() != container.encode("ascii"):
             raise SmokeFailure("command")
 
     def _inspect_one(self, container: str) -> dict[str, Any]:
@@ -703,6 +921,12 @@ class SmokeController:
         return data[0]
 
     def _cleanup(self, network: str) -> None:
+        try:
+            self._cleanup_checked(network)
+        except (SmokeFailure, UnicodeDecodeError, TypeError, ValueError):
+            raise SmokeFailure("cleanup") from None
+
+    def _cleanup_checked(self, network: str) -> None:
         failed = False
         result = self.docker.run(["ps", "-aq", "--no-trunc", "--filter", f"label={LABEL_RUN}={self.run_id}"], check=False)
         try:
@@ -756,13 +980,35 @@ class SmokeController:
         if failed:
             raise SmokeFailure("cleanup")
 
-    def run_arm(self, implementation: str, image: str, fixture_image: str) -> dict[str, Any]:
+    def run_arm(
+        self,
+        implementation: str,
+        image: str,
+        fixture_image: str,
+        *,
+        measured_pids: int = MEASURED_PIDS,
+        expected_image_identity: str | None = None,
+        expected_fixture_identity: str | None = None,
+        retain_failure_resources: bool = False,
+    ) -> dict[str, Any]:
         network = f"density-{self.run_id}-{implementation}"
         identity = self.image_identity(image)
         fixture_identity = self.image_identity(fixture_image)
+        if (
+            (expected_image_identity is not None
+             and identity != expected_image_identity)
+            or (expected_fixture_identity is not None
+                and fixture_identity != expected_fixture_identity)
+        ):
+            raise SmokeFailure("image")
         fixture_id = measured_id = ""
         primary: SmokeFailure | None = None
         result: dict[str, Any] | None = None
+        resources: dict[str, Any] | None = None
+        resources_final = False
+        sampler: CgroupSampler | None = None
+        failure_subject = "controller"
+        primary_pressure_attributable = False
         try:
             self.docker.run(["network", "create", "--internal", "--label", f"{LABEL_RUN}={self.run_id}", "--label", f"{LABEL_ROLE}=network", network])
             network_data = self.docker.json(["network", "inspect", network])
@@ -781,41 +1027,115 @@ class SmokeController:
                 if time.monotonic() >= ready_deadline:
                     raise SmokeFailure("start_timeout")
                 time.sleep(0.05)
-            measured_args = [*common, "--label", f"{LABEL_ROLE}={implementation}", "--cpus", "1", "--memory", "1g", "--memory-swap", "1g", "--pids-limit", str(MEASURED_PIDS), "--ulimit", "nofile=256:256", "--tmpfs", f"/tmp:{MEASURED_TMPFS}",
-                             identity, "--workload", "/density/workload.v1.json", "--concurrency", str(self.concurrency), "--source-commit", self.source, "--image-identity", identity, "--start-gate", START_GATE]
+            measured_args = [*common, "--label", f"{LABEL_ROLE}={implementation}", "--cpus", "1", "--memory", "1g", "--memory-swap", "1g", "--pids-limit", str(measured_pids), "--ulimit", "nofile=256:256", "--tmpfs", f"/tmp:{MEASURED_TMPFS}",
+                             identity, "--workload", "/density/workload.v1.json", "--concurrency", str(self.concurrency), "--source-commit", self.source, "--image-identity", identity]
             measured_id = self._create(measured_args)
-            attest_container(self._inspect_one(measured_id), network, implementation, self.run_id, identity, measured=True)
+            attest_container(
+                self._inspect_one(measured_id), network, implementation,
+                self.run_id, identity, measured=True,
+                measured_pids=measured_pids,
+            )
+            failure_subject = "measured"
             self._start(measured_id)
             running = self._inspect_one(measured_id)
-            sampler = CgroupSampler.from_pid(running.get("State", {}).get("Pid", 0))
+            process = ProcessIdentity.capture(running.get("State", {}).get("Pid", 0))
+            sampler = CgroupSampler.from_identity(process)
             sampler.start()
+            initial = wait_process_phase(
+                process, phase="initial", deadline=time.monotonic() + 10
+            )
+            if initial != "matched":
+                raise SmokeFailure("start_timeout" if initial == "timeout" else "process_state")
+            if not process.only_main_process():
+                raise SmokeFailure("process_residue")
             try:
-                self._release_start_gate(measured_id)
-                self._wait(measured_id, self.timeout)
-                resources = sampler.stop()
+                self._signal(measured_id, "USR1")
+                finished = wait_process_phase(
+                    process, phase="final", deadline=time.monotonic() + self.timeout
+                )
+                if finished != "matched":
+                    if finished == "timeout":
+                        self.docker.run(["kill", measured_id], timeout=10, check=False)
+                        raise SmokeFailure("timeout")
+                    try:
+                        inspect_measured_exit(
+                            self.docker, measured_id, implementation,
+                            self._inspect_one(measured_id),
+                        )
+                    except SmokeFailure:
+                        raise
+                    raise SmokeFailure("process_state")
+                if not process.only_main_process():
+                    raise SmokeFailure("process_residue")
+                resources_final = True
+                active_sampler, sampler = sampler, None
+                resources = active_sampler.stop(
+                    reject_oom=False, allow_fallback=False
+                )
+                self._signal(measured_id, "USR2")
+                self._wait(measured_id, 10)
             except BaseException:
-                try:
-                    sampler.stop()
-                except SmokeFailure:
-                    pass
+                if sampler is not None:
+                    active_sampler, sampler = sampler, None
+                    try:
+                        resources = active_sampler.stop(reject_oom=False)
+                    except SmokeFailure:
+                        pass
                 raise
             inspect_measured_exit(self.docker, measured_id, implementation,
                                   self._inspect_one(measured_id))
+            failure_subject = "fixture"
             self._wait(fixture_id, 20)
             inspect_exit(self._inspect_one(fixture_id))
+            failure_subject = "measured"
             measured = validate_measured(parse_json_object(self.docker.logs(measured_id)), implementation, self.concurrency, self.source, identity, self.workload_sha, self.tasks)
+            failure_subject = "fixture"
             fixture = validate_fixture(parse_fixture_output(self.docker.logs(fixture_id)), self.concurrency, self.workload_sha, self.tasks)
-            validate_resources(resources)
+            failure_subject = "measured"
+            validate_resources(resources, expected_pids=measured_pids)
+            failure_subject = "controller"
             result = {"implementation": implementation, "image_identity": identity, "fixture_image_identity": fixture_identity, "measured": measured, "fixture": fixture, "resources": resources}
         except SmokeFailure as error:
             primary = error
+            primary_pressure_attributable = failure_subject == "measured"
+        except Exception:
+            # Keep all executor-visible failures closed and allow cleanup to
+            # replace an unexpected implementation error authoritatively.
+            primary = SmokeFailure("infrastructure")
+            failure_subject = "controller"
+            primary_pressure_attributable = False
         finally:
+            if sampler is not None:
+                active_sampler, sampler = sampler, None
+                try:
+                    resources = active_sampler.stop(reject_oom=False)
+                except SmokeFailure:
+                    pass
             try:
                 self._cleanup(network)
             except SmokeFailure as cleanup_error:
                 primary = cleanup_error
+                failure_subject = "controller"
+                primary_pressure_attributable = False
         if primary is not None:
-            raise primary
+            failure_id = primary.failure_id
+            retained_resources: dict[str, Any] | None = None
+            retained_resources_final = False
+            if primary_pressure_attributable:
+                failure_id = classify_resource_failure(failure_id, resources)
+                if retain_failure_resources:
+                    retained_resources = resources
+                    retained_resources_final = resources_final
+            elif failure_subject == "fixture":
+                # The sampled cgroup belongs to the measured container, so a
+                # fixture lifecycle failure must never inherit a measured OOM
+                # identity or measured resource evidence.
+                failure_id = "infrastructure"
+            raise SmokeFailure(
+                failure_id,
+                resources=retained_resources,
+                resources_final=retained_resources_final,
+            )
         assert result is not None
         return result
 

--- a/pilots/go-lightpanda/density/evidence_protocol.py
+++ b/pilots/go-lightpanda/density/evidence_protocol.py
@@ -1,0 +1,679 @@
+"""Pure validation and admission math for the frozen Stage B2 protocol.
+
+The process/controller layer emits one normalized record for every scheduled
+arm.  This module has no process, Docker, clock, or network access: given the
+frozen schedule and 22 arm records, it either rejects malformed evidence or
+derives the admission result with exact integer/Fraction comparisons.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable
+from fractions import Fraction
+from pathlib import Path
+from typing import Any
+
+GIB = 1024**3
+EXPECTED_SCHEDULE_SHA256 = (
+    "65698192e1264490f2e0ecbc8fbf8ca3a0180e702736f8a5a6a6bb08cdb5b820"
+)
+
+STATUSES = frozenset({"admitted", "not_admitted", "inconclusive", "invalid"})
+REASON_IDS = frozenset(
+    {
+        "admission_thresholds_met",
+        "memory_pressure_fallback_met",
+        "schedule_invalid",
+        "schedule_hash_invalid",
+        "evidence_count_invalid",
+        "evidence_shape_invalid",
+        "evidence_order_invalid",
+        "evidence_duplicate_invalid",
+        "evidence_not_run",
+        "protocol_integrity_failure",
+        "c4_correctness_gate_failed",
+        "c4_measurement_inconclusive",
+        "go_c8_correctness_gate_failed",
+        "go_c8_measurement_inconclusive",
+        "python_c8_mixed_failures",
+        "python_c8_memory_pressure_insufficient",
+        "python_c8_memory_pressure_unconfirmed",
+        "c8_ram_ceiling_unreached",
+        "go_rate_median_below_threshold",
+        "go_rate_wins_below_threshold",
+        "go_memory_median_above_threshold",
+        "go_memory_wins_below_threshold",
+        "go_memory_pressure_peak_too_high",
+    }
+)
+
+# These are normalized evidence IDs, not raw stderr or exception strings.
+# The disjoint sets determine whether a complete arm can reject correctness,
+# enter the memory-pressure branch, make measurement inconclusive, or
+# invalidate the protocol. ``not_run`` preserves an unmeasured scheduled slot
+# after an executor abort and also invalidates the protocol.
+CORRECTNESS_FAILURE_IDS = frozenset(
+    {
+        "concurrency",
+        "conservation",
+        "oracle",
+        "go_runner_invariant_failure",
+    }
+)
+MEMORY_FAILURE_IDS = frozenset({"oom", "memory_pressure"})
+PROTOCOL_FAILURE_IDS = frozenset({"cleanup", "containment", "process_residue"})
+NOT_RUN_FAILURE_ID = "not_run"
+INCONCLUSIVE_FAILURE_IDS = frozenset(
+    {
+        "command",
+        "image",
+        "inspect",
+        "malformed_output",
+        "nonzero",
+        "missing_cgroup",
+        "missing_cgroup_membership",
+        "missing_cgroup_path",
+        "missing_cgroup_pid",
+        "missing_cgroup_memory_current",
+        "missing_cgroup_memory_peak",
+        "missing_cgroup_memory_max",
+        "missing_cgroup_memory_swap_max",
+        "missing_cgroup_memory_events",
+        "missing_cgroup_cpu_max",
+        "missing_cgroup_cpu_stat",
+        "missing_cgroup_pids_max",
+        "missing_cgroup_pids_events",
+        "missing_cgroup_pids_current",
+        "missing_cgroup_pids_peak",
+        "missing_cgroup_cgroup_procs",
+        "process_identity",
+        "process_state",
+        "start_timeout",
+        "timeout",
+        "transcript",
+        "pid_limit",
+        "fd_limit",
+        "missing_artifact",
+        "infrastructure",
+        "start_failure",
+        "cgroup_failure",
+        "transcript_failure",
+        "go_runner_arguments_invalid",
+        "go_runner_start_gate",
+        "go_runner_manifest_invalid",
+        "go_runner_adapter_initialization",
+        "go_runner_configuration_invalid",
+        "go_runner_pool_initialization",
+    }
+)
+FAILURE_IDS = (
+    CORRECTNESS_FAILURE_IDS
+    | MEMORY_FAILURE_IDS
+    | INCONCLUSIVE_FAILURE_IDS
+    | PROTOCOL_FAILURE_IDS
+    | {NOT_RUN_FAILURE_ID}
+)
+GO_ONLY_FAILURE_IDS = frozenset(
+    failure_id for failure_id in FAILURE_IDS if failure_id.startswith("go_runner_")
+)
+
+_RECORD_KEYS = {
+    "schema_version",
+    "pair_id",
+    "arm_index",
+    "implementation",
+    "concurrency",
+    "outcome",
+    "failure_id",
+    "elapsed_ns",
+    "resources",
+}
+_RESOURCE_KEYS = {
+    "final_sample",
+    "observation",
+    "memory_current",
+    "memory_peak",
+    "memory_limit",
+    "memory_swap_limit",
+    "host_page_size",
+    "memory_events",
+    "cpu_max",
+    "cpu_stat",
+    "pids_limit",
+    "pids_current",
+    "pids_peak",
+    "pids_events",
+    "cgroup_process_count",
+}
+_MEMORY_EVENT_KEYS = {"low", "high", "max", "oom", "oom_kill", "oom_group_kill"}
+_PIDS_EVENT_KEYS = {"max"}
+_CPU_STAT_REQUIRED_KEYS = {"usage_usec", "user_usec", "system_usec"}
+_CPU_STAT_KEYS = _CPU_STAT_REQUIRED_KEYS | {
+    "nr_periods",
+    "nr_throttled",
+    "throttled_usec",
+    "nr_bursts",
+    "burst_usec",
+}
+
+
+class ProtocolError(ValueError):
+    """A bounded, public failure that is safe to copy to an evidence report."""
+
+    def __init__(self, reason_id: str):
+        if reason_id not in REASON_IDS:
+            reason_id = "evidence_shape_invalid"
+        self.reason_id = reason_id
+        super().__init__(reason_id)
+
+
+def _expected_schedule() -> dict[str, Any]:
+    pairs: list[dict[str, Any]] = [
+        {
+            "id": "c1-p01",
+            "concurrency": 1,
+            "diagnostic": True,
+            "order": ["python", "go"],
+        }
+    ]
+    c4_orders = (
+        ("go", "python"),
+        ("python", "go"),
+        ("go", "python"),
+        ("python", "go"),
+        ("go", "python"),
+    )
+    c8_orders = (
+        ("python", "go"),
+        ("go", "python"),
+        ("python", "go"),
+        ("go", "python"),
+        ("python", "go"),
+    )
+    for concurrency, orders in ((4, c4_orders), (8, c8_orders)):
+        for index, order in enumerate(orders, start=1):
+            pairs.append(
+                {
+                    "id": f"c{concurrency}-p{index:02d}",
+                    "concurrency": concurrency,
+                    "diagnostic": False,
+                    "order": list(order),
+                }
+            )
+    return {
+        "schema_version": 1,
+        "protocol_id": "go-lightpanda-fixed-ram-density-b2-v1",
+        "workload_sha256": "3db365d2a484b932049313d53469d07ffb2c5d9fdfe05821fd87cf67b1557740",
+        "expected_arm_records": 22,
+        "tasks_per_arm": 16,
+        "resource_envelope": {
+            "cpu_nanos": 1_000_000_000,
+            "cpu_max": [100_000, 100_000],
+            "memory_bytes": GIB,
+            "memory_swap_bytes": 0,
+            "host_page_size_min_bytes": 4096,
+            "host_page_size_max_bytes": 65536,
+            "pids_limit": 768,
+            "nofile_soft": 256,
+            "nofile_hard": 256,
+        },
+        "admission": {
+            "c4_required_passes_per_implementation": 5,
+            "go_c8_required_passes": 5,
+            "go_rate_median_min": {"numerator": 5, "denominator": 4},
+            "go_rate_wins_min": 4,
+            "go_memory_median_max": {"numerator": 4, "denominator": 5},
+            "go_memory_wins_min": 4,
+            "ram_relevance_floor": {"numerator": 7, "denominator": 10},
+            "python_memory_pressure_min": 3,
+            "go_pressure_peak_max_exclusive": {"numerator": 4, "denominator": 5},
+        },
+        "pairs": pairs,
+    }
+
+
+def _strict_equal(value: Any, expected: Any) -> bool:
+    if type(value) is not type(expected):
+        return False
+    if isinstance(expected, dict):
+        return set(value) == set(expected) and all(
+            _strict_equal(value[key], expected[key]) for key in expected
+        )
+    if isinstance(expected, list):
+        return len(value) == len(expected) and all(
+            _strict_equal(item, expected_item)
+            for item, expected_item in zip(value, expected, strict=True)
+        )
+    return bool(value == expected)
+
+
+def validate_schedule(schedule: Any) -> dict[str, Any]:
+    """Require the exact frozen schedule, thresholds, and resource envelope."""
+
+    if not isinstance(schedule, dict) or not _strict_equal(
+        schedule, _expected_schedule()
+    ):
+        raise ProtocolError("schedule_invalid")
+    return schedule
+
+
+def load_schedule(path: Path) -> tuple[dict[str, Any], str]:
+    """Load the frozen source file and attest its exact raw-byte digest."""
+
+    try:
+        raw = path.read_bytes()
+        digest = hashlib.sha256(raw).hexdigest()
+        if digest != EXPECTED_SCHEDULE_SHA256:
+            raise ProtocolError("schedule_hash_invalid")
+        decoder = json.JSONDecoder(
+            parse_constant=lambda _value: (_ for _ in ()).throw(ValueError())
+        )
+        text = raw.decode("utf-8", "strict")
+        schedule, end = decoder.raw_decode(text.lstrip())
+        if text.lstrip()[end:].strip():
+            raise ValueError
+    except ProtocolError:
+        raise
+    except (OSError, UnicodeDecodeError, ValueError, json.JSONDecodeError):
+        raise ProtocolError("schedule_invalid") from None
+    return validate_schedule(schedule), digest
+
+
+def _integer(value: Any, *, minimum: int = 0) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise ProtocolError("evidence_shape_invalid")
+    return value
+
+
+def _closed_object(value: Any, keys: set[str]) -> dict[str, Any]:
+    if not isinstance(value, dict) or set(value) != keys:
+        raise ProtocolError("evidence_shape_invalid")
+    return value
+
+
+def _validate_resources(value: Any, envelope: dict[str, Any]) -> dict[str, Any]:
+    resources = _closed_object(value, _RESOURCE_KEYS)
+    if (
+        not isinstance(resources["observation"], str)
+        or resources["observation"] not in {"final", "sampled_not_final"}
+        or resources["final_sample"] is not (resources["observation"] == "final")
+    ):
+        raise ProtocolError("evidence_shape_invalid")
+    memory_current = _integer(resources["memory_current"])
+    memory_peak = _integer(resources["memory_peak"], minimum=1)
+    memory_limit = _integer(resources["memory_limit"], minimum=1)
+    memory_swap_limit = _integer(resources["memory_swap_limit"])
+    host_page_size = _integer(resources["host_page_size"], minimum=1)
+    pids_limit = _integer(resources["pids_limit"], minimum=1)
+    pids_current = _integer(resources["pids_current"])
+    pids_peak = _integer(resources["pids_peak"], minimum=1)
+    process_count = _integer(resources["cgroup_process_count"])
+    if (
+        memory_limit != envelope["memory_bytes"]
+        or memory_swap_limit != envelope["memory_swap_bytes"]
+        or host_page_size < envelope["host_page_size_min_bytes"]
+        or host_page_size > envelope["host_page_size_max_bytes"]
+        or host_page_size & (host_page_size - 1)
+        or pids_limit != envelope["pids_limit"]
+        or memory_current > envelope["memory_bytes"]
+        or memory_current > memory_peak
+        or memory_peak > envelope["memory_bytes"] + host_page_size
+        or pids_current > envelope["pids_limit"]
+        or pids_current > pids_peak
+        or pids_peak > envelope["pids_limit"]
+        or process_count > pids_current
+        or process_count > envelope["pids_limit"]
+    ):
+        raise ProtocolError("evidence_shape_invalid")
+    events = _closed_object(resources["memory_events"], _MEMORY_EVENT_KEYS)
+    pids_events = _closed_object(resources["pids_events"], _PIDS_EVENT_KEYS)
+    for count in (*events.values(), *pids_events.values()):
+        _integer(count)
+    cpu_max = resources["cpu_max"]
+    if (
+        not isinstance(cpu_max, list)
+        or len(cpu_max) != 2
+        or any(_integer(value, minimum=1) != value for value in cpu_max)
+        or cpu_max != envelope["cpu_max"]
+    ):
+        raise ProtocolError("evidence_shape_invalid")
+    cpu_stat = resources["cpu_stat"]
+    if (
+        not isinstance(cpu_stat, dict)
+        or not _CPU_STAT_REQUIRED_KEYS <= set(cpu_stat) <= _CPU_STAT_KEYS
+    ):
+        raise ProtocolError("evidence_shape_invalid")
+    for count in cpu_stat.values():
+        _integer(count)
+    return resources
+
+
+def _validate_record(
+    record: Any, pair: dict[str, Any], arm_index: int, envelope: dict[str, Any]
+) -> dict[str, Any]:
+    record = _closed_object(record, _RECORD_KEYS)
+    implementation = pair["order"][arm_index]
+    if (
+        _integer(record["schema_version"], minimum=1) != 1
+        or not isinstance(record["pair_id"], str)
+        or record["pair_id"] != pair["id"]
+        or _integer(record["arm_index"]) != arm_index
+        or not isinstance(record["implementation"], str)
+        or record["implementation"] != implementation
+        or _integer(record["concurrency"], minimum=1) != pair["concurrency"]
+        or not isinstance(record["outcome"], str)
+        or record["outcome"] not in {"pass", "failure"}
+    ):
+        raise ProtocolError("evidence_order_invalid")
+    if record["outcome"] == "pass":
+        if record["failure_id"] is not None:
+            raise ProtocolError("evidence_shape_invalid")
+        _integer(record["elapsed_ns"], minimum=1)
+        resources = _validate_resources(record["resources"], envelope)
+        events = resources["memory_events"]
+        if (
+            resources["observation"] != "final"
+            or resources["cgroup_process_count"] != 1
+            or resources["memory_peak"] > envelope["memory_bytes"]
+            or events["oom"]
+            or events["oom_kill"]
+            or events["oom_group_kill"]
+            or resources["pids_events"]["max"]
+        ):
+            raise ProtocolError("evidence_shape_invalid")
+    else:
+        if (
+            not isinstance(record["failure_id"], str)
+            or record["failure_id"] not in FAILURE_IDS
+            or (implementation != "go" and record["failure_id"] in GO_ONLY_FAILURE_IDS)
+            or record["elapsed_ns"] is not None
+            or (
+                record["failure_id"] == NOT_RUN_FAILURE_ID
+                and record["resources"] is not None
+            )
+            or (
+                record["failure_id"] == "pid_limit"
+                and record["resources"] is None
+            )
+        ):
+            raise ProtocolError("evidence_shape_invalid")
+        if record["resources"] is not None:
+            resources = _validate_resources(record["resources"], envelope)
+            pid_pressure = resources["pids_events"]["max"] > 0
+            if pid_pressure is not (record["failure_id"] == "pid_limit"):
+                raise ProtocolError("evidence_shape_invalid")
+            if (
+                resources["memory_peak"] > envelope["memory_bytes"]
+                and record["failure_id"] not in MEMORY_FAILURE_IDS
+                and not (
+                    record["failure_id"] == "pid_limit"
+                    and any(
+                        resources["memory_events"][key] > 0
+                        for key in ("max", "oom", "oom_kill", "oom_group_kill")
+                    )
+                )
+            ):
+                raise ProtocolError("evidence_shape_invalid")
+    return record
+
+
+def _index_records(
+    schedule: dict[str, Any], records: Any
+) -> dict[tuple[str, str], dict[str, Any]]:
+    if (
+        not isinstance(records, list)
+        or len(records) != schedule["expected_arm_records"]
+    ):
+        raise ProtocolError("evidence_count_invalid")
+    expected_positions = [
+        (pair, arm_index) for pair in schedule["pairs"] for arm_index in range(2)
+    ]
+    result: dict[tuple[str, str], dict[str, Any]] = {}
+    for record, (pair, arm_index) in zip(records, expected_positions, strict=True):
+        validated = _validate_record(
+            record, pair, arm_index, schedule["resource_envelope"]
+        )
+        key = (validated["pair_id"], validated["implementation"])
+        if key in result:
+            raise ProtocolError("evidence_duplicate_invalid")
+        result[key] = validated
+    page_sizes = {
+        record["resources"]["host_page_size"]
+        for record in result.values()
+        if record["resources"] is not None
+    }
+    if any(record["failure_id"] in PROTOCOL_FAILURE_IDS for record in result.values()):
+        raise ProtocolError("protocol_integrity_failure")
+    if any(record["failure_id"] == NOT_RUN_FAILURE_ID for record in result.values()):
+        raise ProtocolError("evidence_not_run")
+    if len(page_sizes) != 1:
+        raise ProtocolError("evidence_shape_invalid")
+    return result
+
+
+def _fraction_json(value: Fraction) -> dict[str, int]:
+    return {"numerator": value.numerator, "denominator": value.denominator}
+
+
+def _median(values: Iterable[Fraction]) -> Fraction:
+    ordered = sorted(values)
+    if len(ordered) != 5:
+        raise ProtocolError("evidence_shape_invalid")
+    return ordered[2]
+
+
+def _kernel_memory_pressure(record: dict[str, Any]) -> bool:
+    resources = record["resources"]
+    if resources is None:
+        return False
+    events = resources["memory_events"]
+    return any(events[key] > 0 for key in ("max", "oom", "oom_kill", "oom_group_kill"))
+
+
+def _result(
+    schedule: dict[str, Any] | None,
+    status: str,
+    reason_ids: list[str],
+    *,
+    metrics: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    if (
+        status not in STATUSES
+        or not reason_ids
+        or any(reason not in REASON_IDS for reason in reason_ids)
+    ):
+        raise AssertionError("internal evidence result is not closed")
+    result: dict[str, Any] = {
+        "schema_version": 1,
+        "protocol_id": schedule["protocol_id"] if schedule is not None else None,
+        "status": status,
+        "reason_ids": reason_ids,
+        "metrics": metrics or {},
+    }
+    # This catches accidental Fraction/float leakage before callers serialize it.
+    json.dumps(result, allow_nan=False, sort_keys=True)
+    return result
+
+
+def _failed(records: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [record for record in records if record["outcome"] != "pass"]
+
+
+def _gate_failure_result(
+    schedule: dict[str, Any],
+    failures: list[dict[str, Any]],
+    correctness_reason: str,
+    inconclusive_reason: str,
+) -> dict[str, Any]:
+    # A correctness failure is conclusive only when every gate failure is a
+    # correctness failure. Mixed failure modes do not support attribution.
+    if failures and all(
+        record["failure_id"] in CORRECTNESS_FAILURE_IDS for record in failures
+    ):
+        return _result(schedule, "not_admitted", [correctness_reason])
+    return _result(schedule, "inconclusive", [inconclusive_reason])
+
+
+def summarize_evidence(schedule: Any, records: Any) -> dict[str, Any]:
+    """Validate complete evidence and apply the frozen Stage B2 admission rule."""
+
+    try:
+        schedule = validate_schedule(schedule)
+        indexed = _index_records(schedule, records)
+    except ProtocolError as error:
+        return _result(
+            schedule
+            if isinstance(schedule, dict)
+            and schedule.get("protocol_id") == _expected_schedule()["protocol_id"]
+            else None,
+            "invalid",
+            [error.reason_id],
+        )
+
+    c4 = [
+        indexed[(pair["id"], implementation)]
+        for pair in schedule["pairs"]
+        if pair["concurrency"] == 4
+        for implementation in ("go", "python")
+    ]
+    c4_failures = _failed(c4)
+    if c4_failures:
+        return _gate_failure_result(
+            schedule,
+            c4_failures,
+            "c4_correctness_gate_failed",
+            "c4_measurement_inconclusive",
+        )
+
+    go_c8 = [
+        indexed[(pair["id"], "go")]
+        for pair in schedule["pairs"]
+        if pair["concurrency"] == 8
+    ]
+    go_c8_failures = _failed(go_c8)
+    if go_c8_failures:
+        return _gate_failure_result(
+            schedule,
+            go_c8_failures,
+            "go_c8_correctness_gate_failed",
+            "go_c8_measurement_inconclusive",
+        )
+
+    python_c8 = [
+        indexed[(pair["id"], "python")]
+        for pair in schedule["pairs"]
+        if pair["concurrency"] == 8
+    ]
+    python_c8_failures = _failed(python_c8)
+    admission = schedule["admission"]
+
+    if not python_c8_failures:
+        rate_ratios: list[Fraction] = []
+        memory_ratios: list[Fraction] = []
+        go_peaks: list[int] = []
+        python_peaks: list[int] = []
+        for pair in (pair for pair in schedule["pairs"] if pair["concurrency"] == 8):
+            go_record = indexed[(pair["id"], "go")]
+            python_record = indexed[(pair["id"], "python")]
+            rate_ratios.append(
+                Fraction(python_record["elapsed_ns"], go_record["elapsed_ns"])
+            )
+            go_peak = go_record["resources"]["memory_peak"]
+            python_peak = python_record["resources"]["memory_peak"]
+            go_peaks.append(go_peak)
+            python_peaks.append(python_peak)
+            memory_ratios.append(Fraction(go_peak, python_peak))
+
+        median_rate = _median(rate_ratios)
+        median_memory = _median(memory_ratios)
+        median_go_peak = sorted(go_peaks)[2]
+        median_python_peak = sorted(python_peaks)[2]
+        rate_wins = sum(ratio > 1 for ratio in rate_ratios)
+        memory_wins = sum(ratio < 1 for ratio in memory_ratios)
+        metrics = {
+            "branch": "paired_c8",
+            "rate_ratios": [_fraction_json(value) for value in rate_ratios],
+            "median_rate_ratio": _fraction_json(median_rate),
+            "rate_wins": rate_wins,
+            "memory_ratios": [_fraction_json(value) for value in memory_ratios],
+            "median_memory_ratio": _fraction_json(median_memory),
+            "memory_wins": memory_wins,
+            "median_go_memory_peak": median_go_peak,
+            "median_python_memory_peak": median_python_peak,
+        }
+        floor = Fraction(
+            admission["ram_relevance_floor"]["numerator"],
+            admission["ram_relevance_floor"]["denominator"],
+        )
+        if (
+            Fraction(median_go_peak, GIB) < floor
+            and Fraction(median_python_peak, GIB) < floor
+        ):
+            return _result(
+                schedule, "inconclusive", ["c8_ram_ceiling_unreached"], metrics=metrics
+            )
+
+        reasons: list[str] = []
+        rate_min = Fraction(
+            admission["go_rate_median_min"]["numerator"],
+            admission["go_rate_median_min"]["denominator"],
+        )
+        memory_max = Fraction(
+            admission["go_memory_median_max"]["numerator"],
+            admission["go_memory_median_max"]["denominator"],
+        )
+        if median_rate < rate_min:
+            reasons.append("go_rate_median_below_threshold")
+        if rate_wins < admission["go_rate_wins_min"]:
+            reasons.append("go_rate_wins_below_threshold")
+        if median_memory > memory_max:
+            reasons.append("go_memory_median_above_threshold")
+        if memory_wins < admission["go_memory_wins_min"]:
+            reasons.append("go_memory_wins_below_threshold")
+        if reasons:
+            return _result(schedule, "not_admitted", reasons, metrics=metrics)
+        return _result(
+            schedule, "admitted", ["admission_thresholds_met"], metrics=metrics
+        )
+
+    if any(
+        record["failure_id"] not in MEMORY_FAILURE_IDS for record in python_c8_failures
+    ):
+        return _result(schedule, "inconclusive", ["python_c8_mixed_failures"])
+    if len(python_c8_failures) < admission["python_memory_pressure_min"]:
+        return _result(
+            schedule, "inconclusive", ["python_c8_memory_pressure_insufficient"]
+        )
+    confirmed_pressure = sum(
+        _kernel_memory_pressure(record) for record in python_c8_failures
+    )
+    if confirmed_pressure < admission["python_memory_pressure_min"]:
+        return _result(
+            schedule, "inconclusive", ["python_c8_memory_pressure_unconfirmed"]
+        )
+
+    go_peaks = [record["resources"]["memory_peak"] for record in go_c8]
+    peak_limit = Fraction(
+        schedule["resource_envelope"]["memory_bytes"]
+        * admission["go_pressure_peak_max_exclusive"]["numerator"],
+        admission["go_pressure_peak_max_exclusive"]["denominator"],
+    )
+    metrics = {
+        "branch": "python_memory_pressure",
+        "python_memory_pressure_failures": len(python_c8_failures),
+        "python_kernel_confirmed_pressure_failures": confirmed_pressure,
+        "go_memory_peaks": go_peaks,
+        "go_peak_limit_exclusive": _fraction_json(peak_limit),
+    }
+    if any(Fraction(peak, 1) >= peak_limit for peak in go_peaks):
+        return _result(
+            schedule,
+            "not_admitted",
+            ["go_memory_pressure_peak_too_high"],
+            metrics=metrics,
+        )
+    return _result(
+        schedule, "admitted", ["memory_pressure_fallback_met"], metrics=metrics
+    )

--- a/pilots/go-lightpanda/density/evidence_runner.py
+++ b/pilots/go-lightpanda/density/evidence_runner.py
@@ -1,0 +1,531 @@
+#!/usr/bin/env python3
+"""Failure-retaining executor for the frozen Stage B2 density protocol.
+
+Only frozen identifiers, immutable image digests, and aggregate cgroup
+counters cross the evidence boundary. Docker transcripts, container names,
+host PIDs, cgroup paths, URLs, and exception text are never serialized.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import re
+import secrets
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+try:
+    from . import controller, evidence_protocol
+except ImportError:  # Direct script execution.
+    import controller  # type: ignore[no-redef]
+    import evidence_protocol  # type: ignore[no-redef]
+
+
+IMAGE_KEYS = ("go", "python", "fixture")
+PROVENANCE_LABEL = "org.jobseek.density.source-commit"
+EXECUTOR_STATES = frozenset({"initialized", "running", "complete", "aborted"})
+ABORT_FAILURE_IDS = evidence_protocol.PROTOCOL_FAILURE_IDS | {"containment"}
+
+
+class GuardFailure(RuntimeError):
+    """A bounded executor guard failure; no external text is retained."""
+
+    def __init__(self, failure_id: str) -> None:
+        self.failure_id = (
+            failure_id
+            if failure_id in evidence_protocol.FAILURE_IDS
+            else "infrastructure"
+        )
+        super().__init__(self.failure_id)
+
+
+class IdentityGuard(Protocol):
+    def resolve(self) -> dict[str, str]: ...
+
+    def verify(self, identities: dict[str, str]) -> None: ...
+
+
+class HealthGuard(Protocol):
+    def capture(self) -> None: ...
+
+    def verify(self) -> None: ...
+
+
+class DockerImageGuard:
+    """Resolve image tags once and reject any later tag mutation."""
+
+    def __init__(
+        self,
+        docker: controller.Docker,
+        references: dict[str, str],
+        source_commit: str,
+    ) -> None:
+        if (
+            set(references) != set(IMAGE_KEYS)
+            or re.fullmatch(r"[0-9a-f]{40}", source_commit) is None
+        ):
+            raise GuardFailure("image")
+        self.docker = docker
+        self.references = dict(references)
+        self.source_commit = source_commit
+
+    def _identity(self, reference: str) -> str:
+        try:
+            data = self.docker.json(["image", "inspect", reference])
+            if not isinstance(data, list) or len(data) != 1:
+                raise KeyError
+            item = data[0]
+            identity = item["Id"]
+            controller._digest(identity, prefixed=True)
+            labels = item["Config"]["Labels"]
+            if (
+                not isinstance(labels, dict)
+                or labels.get(PROVENANCE_LABEL) != self.source_commit
+            ):
+                raise KeyError
+            return identity
+        except (controller.SmokeFailure, KeyError, TypeError, IndexError):
+            raise GuardFailure("image") from None
+
+    def resolve(self) -> dict[str, str]:
+        return {key: self._identity(self.references[key]) for key in IMAGE_KEYS}
+
+    def verify(self, identities: dict[str, str]) -> None:
+        if set(identities) != set(IMAGE_KEYS):
+            raise GuardFailure("containment")
+        for key in IMAGE_KEYS:
+            if self._identity(self.references[key]) != identities[key]:
+                raise GuardFailure("containment")
+
+
+class ProtectedContainerGuard:
+    """Require optional protected containers to stay healthy and unchanged."""
+
+    def __init__(self, docker: controller.Docker, names: tuple[str, ...]) -> None:
+        if len(set(names)) != len(names) or any(
+            re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,127}", name) is None
+            for name in names
+        ):
+            raise GuardFailure("containment")
+        self.docker = docker
+        self.names = names
+        self._baseline: tuple[tuple[str, str, str, int], ...] | None = None
+
+    def _snapshot(self) -> tuple[tuple[str, str, str, int], ...]:
+        values: list[tuple[str, str, str, int]] = []
+        for name in self.names:
+            try:
+                data = self.docker.json(["inspect", name])
+                if not isinstance(data, list) or len(data) != 1:
+                    raise KeyError
+                item = data[0]
+                state = item["State"]
+                health = state.get("Health")
+                if (
+                    state.get("Status") != "running"
+                    or state.get("Running") is not True
+                    or state.get("Restarting") is not False
+                    or state.get("Dead") is not False
+                    or (health is not None and health.get("Status") != "healthy")
+                ):
+                    raise KeyError
+                identity = item["Id"]
+                image = item["Image"]
+                started = state["StartedAt"]
+                restarts = item["RestartCount"]
+                if (
+                    re.fullmatch(r"[0-9a-f]{64}", identity) is None
+                    or re.fullmatch(r"sha256:[0-9a-f]{64}", image) is None
+                    or not isinstance(started, str)
+                    or not started
+                    or isinstance(restarts, bool)
+                    or not isinstance(restarts, int)
+                    or restarts < 0
+                ):
+                    raise KeyError
+                values.append((identity, image, started, restarts))
+            except (
+                controller.SmokeFailure,
+                KeyError,
+                TypeError,
+                AttributeError,
+            ):
+                raise GuardFailure("containment") from None
+        return tuple(values)
+
+    def capture(self) -> None:
+        self._baseline = self._snapshot()
+
+    def verify(self) -> None:
+        if self._baseline is None or self._snapshot() != self._baseline:
+            raise GuardFailure("containment")
+
+
+def _not_run_record(
+    pair: dict[str, Any], arm_index: int, implementation: str
+) -> dict[str, Any]:
+    return {
+        "schema_version": 1,
+        "pair_id": pair["id"],
+        "arm_index": arm_index,
+        "implementation": implementation,
+        "concurrency": pair["concurrency"],
+        "outcome": "failure",
+        "failure_id": evidence_protocol.NOT_RUN_FAILURE_ID,
+        "elapsed_ns": None,
+        "resources": None,
+    }
+
+
+def _blank_records(schedule: dict[str, Any]) -> list[dict[str, Any]]:
+    return [
+        _not_run_record(pair, arm_index, implementation)
+        for pair in schedule["pairs"]
+        for arm_index, implementation in enumerate(pair["order"])
+    ]
+
+
+def _safe_resources(
+    raw: dict[str, Any] | None,
+    envelope: dict[str, Any],
+    *,
+    final_sample: bool,
+) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    keys = evidence_protocol._RESOURCE_KEYS - {"final_sample", "observation"}
+    if not keys <= set(raw):
+        return None
+    candidate = {
+        "final_sample": final_sample,
+        "observation": "final" if final_sample else "sampled_not_final",
+        **{key: copy.deepcopy(raw[key]) for key in keys},
+    }
+    try:
+        evidence_protocol._validate_resources(candidate, envelope)
+    except evidence_protocol.ProtocolError:
+        return None
+    return candidate
+
+
+def _failure_record(
+    slot: dict[str, Any],
+    failure_id: str,
+    resources: dict[str, Any] | None,
+) -> dict[str, Any]:
+    record = dict(slot)
+    record["failure_id"] = (
+        failure_id
+        if failure_id in evidence_protocol.FAILURE_IDS
+        else "infrastructure"
+    )
+    record["resources"] = resources
+    return record
+
+
+class EvidenceRunner:
+    """Execute and checkpoint every frozen schedule slot in exact order."""
+
+    def __init__(
+        self,
+        *,
+        source_commit: str,
+        schedule: dict[str, Any],
+        schedule_sha256: str,
+        workload: dict[str, Any],
+        workload_sha256: str,
+        timeout: float,
+        output: Path,
+        identity_guard: IdentityGuard,
+        health_guard: HealthGuard,
+        docker: controller.Docker | None = None,
+        arm_runner: Callable[
+            [dict[str, Any], int, str, dict[str, str]], dict[str, Any]
+        ]
+        | None = None,
+        checkpoint_writer: Callable[[dict[str, Any]], None] | None = None,
+        token_factory: Callable[[], str] | None = None,
+    ) -> None:
+        evidence_protocol.validate_schedule(schedule)
+        if (
+            re.fullmatch(r"[0-9a-f]{40}", source_commit) is None
+            or schedule_sha256
+            != evidence_protocol.EXPECTED_SCHEDULE_SHA256
+            or workload_sha256 != schedule["workload_sha256"]
+            or timeout <= 0
+        ):
+            raise GuardFailure("infrastructure")
+        self.source_commit = source_commit
+        self.schedule = schedule
+        self.schedule_sha256 = schedule_sha256
+        self.workload = workload
+        self.workload_sha256 = workload_sha256
+        self.timeout = timeout
+        self.output = output
+        self.identity_guard = identity_guard
+        self.health_guard = health_guard
+        self.docker = docker or controller.Docker()
+        self.arm_runner = arm_runner or self._run_arm
+        self.checkpoint_writer = checkpoint_writer or (
+            lambda report: controller.write_report(self.output, report)
+        )
+        self.token_factory = token_factory or (lambda: secrets.token_hex(8))
+
+    def _run_arm(
+        self,
+        pair: dict[str, Any],
+        _arm_index: int,
+        implementation: str,
+        identities: dict[str, str],
+    ) -> dict[str, Any]:
+        smoke = controller.SmokeController(
+            self.docker,
+            self.source_commit,
+            pair["concurrency"],
+            self.timeout,
+            self.workload,
+            self.workload_sha256,
+            run_id=self.token_factory(),
+        )
+        return smoke.run_arm(
+            implementation,
+            identities[implementation],
+            identities["fixture"],
+            measured_pids=self.schedule["resource_envelope"]["pids_limit"],
+            expected_image_identity=identities[implementation],
+            expected_fixture_identity=identities["fixture"],
+            retain_failure_resources=True,
+        )
+
+    def _report(
+        self,
+        state: str,
+        identities: dict[str, str | None],
+        records: list[dict[str, Any]],
+        executor_failure_id: str | None,
+    ) -> dict[str, Any]:
+        if (
+            state not in EXECUTOR_STATES
+            or set(identities) != set(IMAGE_KEYS)
+            or any(
+                value is not None
+                and re.fullmatch(r"sha256:[0-9a-f]{64}", value) is None
+                for value in identities.values()
+            )
+            or (
+                executor_failure_id is not None
+                and executor_failure_id not in evidence_protocol.FAILURE_IDS
+            )
+        ):
+            raise AssertionError("executor report is not closed")
+        report = {
+            "schema_version": 1,
+            "protocol_id": self.schedule["protocol_id"],
+            "schedule_sha256": self.schedule_sha256,
+            "source_commit": self.source_commit,
+            "state": state,
+            "executor_failure_id": executor_failure_id,
+            "image_identities": identities,
+            "completed_arms": sum(
+                record["failure_id"] != evidence_protocol.NOT_RUN_FAILURE_ID
+                for record in records
+            ),
+            "records": records,
+            "summary": evidence_protocol.summarize_evidence(
+                self.schedule, records
+            ),
+        }
+        return report
+
+    def _checkpoint(
+        self,
+        state: str,
+        identities: dict[str, str | None],
+        records: list[dict[str, Any]],
+        executor_failure_id: str | None,
+    ) -> dict[str, Any]:
+        report = self._report(
+            state, identities, records, executor_failure_id
+        )
+        self.checkpoint_writer(report)
+        return report
+
+    def run(self) -> dict[str, Any]:
+        records = _blank_records(self.schedule)
+        identities: dict[str, str | None] = {key: None for key in IMAGE_KEYS}
+        try:
+            resolved = self.identity_guard.resolve()
+            if (
+                set(resolved) != set(IMAGE_KEYS)
+                or any(
+                    re.fullmatch(r"sha256:[0-9a-f]{64}", value) is None
+                    for value in resolved.values()
+                )
+            ):
+                raise GuardFailure("image")
+            identities = dict(resolved)
+            self.identity_guard.verify(resolved)
+            self.health_guard.capture()
+            self.health_guard.verify()
+        except GuardFailure as error:
+            return self._checkpoint(
+                "aborted", identities, records, error.failure_id
+            )
+        except Exception:
+            return self._checkpoint(
+                "aborted", identities, records, "infrastructure"
+            )
+
+        self._checkpoint("initialized", identities, records, None)
+        position = 0
+        aborted: str | None = None
+        envelope = self.schedule["resource_envelope"]
+        for pair in self.schedule["pairs"]:
+            for arm_index, implementation in enumerate(pair["order"]):
+                slot = records[position]
+                try:
+                    self.identity_guard.verify(resolved)
+                    self.health_guard.verify()
+                    result = self.arm_runner(
+                        pair, arm_index, implementation, resolved
+                    )
+                    resources = _safe_resources(
+                        result.get("resources"), envelope, final_sample=True
+                    )
+                    measured = result.get("measured")
+                    elapsed = (
+                        measured.get("elapsed_ns")
+                        if isinstance(measured, dict)
+                        else None
+                    )
+                    if (
+                        resources is None
+                        or isinstance(elapsed, bool)
+                        or not isinstance(elapsed, int)
+                        or elapsed <= 0
+                    ):
+                        raise controller.SmokeFailure("transcript")
+                    record = dict(slot)
+                    record.update(
+                        outcome="pass",
+                        failure_id=None,
+                        elapsed_ns=elapsed,
+                        resources=resources,
+                    )
+                except controller.SmokeFailure as error:
+                    resources = _safe_resources(
+                        error.resources,
+                        envelope,
+                        final_sample=error.resources_final,
+                    )
+                    # SmokeController owns failure attribution because it knows
+                    # whether the failing lifecycle belongs to the measured
+                    # container, fixture, or controller. Reclassifying from the
+                    # measured cgroup counters here could turn a fixture failure
+                    # into apparent measured memory pressure.
+                    record = _failure_record(
+                        slot, error.failure_id, resources
+                    )
+                except GuardFailure as error:
+                    record = _failure_record(slot, error.failure_id, None)
+                except Exception:
+                    record = _failure_record(slot, "infrastructure", None)
+
+                records[position] = record
+                try:
+                    self.identity_guard.verify(resolved)
+                    self.health_guard.verify()
+                except (GuardFailure, Exception):
+                    resources = record.get("resources")
+                    records[position] = _failure_record(
+                        slot, "containment", resources
+                    )
+                    aborted = "containment"
+
+                if record["failure_id"] in ABORT_FAILURE_IDS:
+                    aborted = record["failure_id"]
+                position += 1
+                if aborted is not None:
+                    return self._checkpoint(
+                        "aborted", identities, records, aborted
+                    )
+                state = (
+                    "complete"
+                    if position == self.schedule["expected_arm_records"]
+                    else "running"
+                )
+                report = self._checkpoint(state, identities, records, None)
+        return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--go-image", required=True)
+    parser.add_argument("--python-image", required=True)
+    parser.add_argument("--fixture-image", required=True)
+    parser.add_argument("--source-commit", required=True)
+    parser.add_argument("--schedule", type=Path, default=Path(__file__).with_name("schedule.v1.json"))
+    parser.add_argument("--timeout-seconds", type=float, default=180)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--docker-binary", default="docker")
+    parser.add_argument("--protected-container", action="append", default=[])
+    args = parser.parse_args(argv)
+
+    try:
+        schedule, schedule_sha = evidence_protocol.load_schedule(args.schedule)
+        workload, workload_sha = controller.load_manifest(
+            Path(__file__).resolve().parent
+        )
+        docker = controller.Docker(args.docker_binary)
+        images = DockerImageGuard(
+            docker,
+            {
+                "go": args.go_image,
+                "python": args.python_image,
+                "fixture": args.fixture_image,
+            },
+            args.source_commit,
+        )
+        health = ProtectedContainerGuard(
+            docker, tuple(args.protected_container)
+        )
+        runner = EvidenceRunner(
+            source_commit=args.source_commit,
+            schedule=schedule,
+            schedule_sha256=schedule_sha,
+            workload=workload,
+            workload_sha256=workload_sha,
+            timeout=args.timeout_seconds,
+            output=args.output,
+            identity_guard=images,
+            health_guard=health,
+            docker=docker,
+        )
+        report = runner.run()
+    except evidence_protocol.ProtocolError as error:
+        controller.write_report(
+            args.output,
+            {
+                "schema_version": 1,
+                "state": "aborted",
+                "failure_id": error.reason_id,
+            },
+        )
+        return 1
+    except (OSError, GuardFailure, controller.SmokeFailure) as error:
+        failure_id = getattr(error, "failure_id", "infrastructure")
+        controller.write_report(
+            args.output,
+            {
+                "schema_version": 1,
+                "state": "aborted",
+                "failure_id": failure_id,
+            },
+        )
+        return 1
+    return 0 if report["state"] == "complete" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pilots/go-lightpanda/density/python_runner.py
+++ b/pilots/go-lightpanda/density/python_runner.py
@@ -14,8 +14,10 @@ import hashlib
 import json
 import os
 import re
+import signal
 import stat
 import sys
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -29,8 +31,8 @@ ALLOWED_CONCURRENCY = (1, 4, 8)
 EXPECTED_ORIGINS = tuple(f"origin-{number}" for number in range(8))
 MAX_INPUT_BYTES = 128 << 10
 EXPECTED_WORKLOAD_SHA256 = "3db365d2a484b932049313d53469d07ffb2c5d9fdfe05821fd87cf67b1557740"
-START_GATE = Path("/tmp/controller-start")
-
+INITIAL_MARKER = Path("/tmp/controller-initial")
+FINAL_MARKER = Path("/tmp/controller-final")
 _ID_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
 _SHA_RE = re.compile(r"^[0-9a-f]{64}$")
 _COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
@@ -56,25 +58,91 @@ class ContractError(ValueError):
     """A trusted, local pilot input did not match the closed contract."""
 
 
-def wait_for_start_gate(
-    path: Path,
-    *,
-    expected: Path = START_GATE,
-    pause: Callable[[float], None] = time.sleep,
-) -> None:
-    if path != expected:
-        raise ContractError("start gate path")
-    while True:
+class _ProtocolCancelled(BaseException):
+    """The controller interrupted the evidence process."""
+
+
+class _ClosedArgumentParser(argparse.ArgumentParser):
+    def error(self, _message: str) -> None:
+        raise ContractError("arguments")
+
+
+def _create_marker(path: Path) -> None:
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        metadata = os.fstat(descriptor)
+    finally:
+        os.close(descriptor)
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or stat.S_IMODE(metadata.st_mode) != 0o600
+        or metadata.st_size != 0
+        or metadata.st_nlink != 1
+        or metadata.st_uid != os.geteuid()
+        or metadata.st_gid != os.getegid()
+    ):
+        raise ContractError("protocol marker")
+
+
+def _validate_marker(path: Path) -> None:
+    metadata = path.lstat()
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or stat.S_IMODE(metadata.st_mode) != 0o600
+        or metadata.st_size != 0
+        or metadata.st_nlink != 1
+        or metadata.st_uid != os.geteuid()
+        or metadata.st_gid != os.getegid()
+    ):
+        raise ContractError("protocol marker")
+
+
+class _SignalMarkerProtocol:
+    """Race-free controller rendezvous using distinct main-thread signals."""
+
+    def __init__(self) -> None:
+        self._previous_cancel_handlers = {
+            number: signal.getsignal(number)
+            for number in (signal.SIGINT, signal.SIGTERM)
+        }
+        for number in self._previous_cancel_handlers:
+            signal.signal(number, self._cancel)
+
+    @staticmethod
+    def _cancel(_number: int, _frame: Any) -> None:
+        raise _ProtocolCancelled
+
+    def _wait(self, path: Path, release_signal: signal.Signals) -> None:
+        released = threading.Event()
+        previous = signal.getsignal(release_signal)
+
+        def release(_number: int, _frame: Any) -> None:
+            released.set()
+
+        # Arm the handler before publishing the marker so the controller can
+        # never race marker observation against signal readiness.
+        signal.signal(release_signal, release)
         try:
-            metadata = path.lstat()
-        except FileNotFoundError:
-            pause(0.01)
-            continue
-        except OSError as exc:
-            raise ContractError("start gate read") from exc
-        if not stat.S_ISREG(metadata.st_mode) or metadata.st_uid != os.geteuid():
-            raise ContractError("start gate type")
-        return
+            _create_marker(path)
+            # Python dispatches signal handlers on the main interpreter thread.
+            # signal.pause() yields to that dispatcher; Event.wait() may remain
+            # inside a restarted lock wait and never run the Python handler.
+            while not released.is_set():
+                signal.pause()
+            _validate_marker(path)
+            path.unlink()
+        finally:
+            signal.signal(release_signal, previous)
+
+    def wait_initial(self) -> None:
+        self._wait(INITIAL_MARKER, signal.SIGUSR1)
+
+    def wait_final(self) -> None:
+        self._wait(FINAL_MARKER, signal.SIGUSR2)
+
+    def close(self) -> None:
+        for number, previous in self._previous_cancel_handlers.items():
+            signal.signal(number, previous)
 
 
 @dataclass(frozen=True, slots=True)
@@ -499,34 +567,72 @@ def _raw_sha(path: Path) -> str | None:
         return None
 
 
-def main(argv: list[str] | None = None) -> int:
-    parser = argparse.ArgumentParser()
+def main(
+    argv: list[str] | None = None,
+    *,
+    protocol_factory: Callable[[], Any] = _SignalMarkerProtocol,
+    output: Any = None,
+) -> int:
+    parser = _ClosedArgumentParser(add_help=False)
     parser.add_argument("--workload", type=Path, required=True)
     parser.add_argument("--concurrency", type=int, required=True)
     parser.add_argument("--source-commit", required=True)
     parser.add_argument("--image-identity", required=True)
-    parser.add_argument("--start-gate", type=Path, required=True)
-    args = parser.parse_args(argv)
+    args = argparse.Namespace(
+        workload=Path(""), concurrency=0, source_commit="", image_identity=""
+    )
+    arguments_ok = False
     try:
-        wait_for_start_gate(args.start_gate)
-        workload = load_workload(args.workload)
-        report = asyncio.run(
-            run_benchmark(
-                workload,
-                args.concurrency,
+        args = parser.parse_args(argv)
+        arguments_ok = True
+    except Exception:
+        pass
+
+    protocol = protocol_factory()
+    try:
+        # The initial release precedes all manifest, Playwright driver, pool,
+        # and browser initialization, giving the controller an idle baseline.
+        protocol.wait_initial()
+
+        if arguments_ok:
+            try:
+                workload = load_workload(args.workload)
+                report = asyncio.run(
+                    run_benchmark(
+                        workload,
+                        args.concurrency,
+                        args.source_commit,
+                        args.image_identity,
+                    )
+                )
+            except Exception:
+                report = _failed_report(
+                    _raw_sha(args.workload),
+                    args.source_commit,
+                    args.image_identity,
+                    args.concurrency,
+                )
+        else:
+            report = _failed_report(
+                _raw_sha(args.workload),
                 args.source_commit,
                 args.image_identity,
+                args.concurrency,
             )
-        )
+
+        # run_benchmark does not return until every page, context, browser,
+        # driver, and worker has been torn down.  Keep the closed report in
+        # memory while the controller takes its final live-cgroup sample.
+        protocol.wait_final()
+        destination = sys.stdout if output is None else output
+        destination.write(json.dumps(report, ensure_ascii=True, separators=(",", ":")) + "\n")
+        return 0 if report["ok"] else 1
+    except _ProtocolCancelled:
+        return 1
     except Exception:
-        report = _failed_report(
-            _raw_sha(args.workload),
-            args.source_commit,
-            args.image_identity,
-            args.concurrency,
-        )
-    sys.stdout.write(json.dumps(report, ensure_ascii=True, separators=(",", ":")) + "\n")
-    return 0 if report["ok"] else 1
+        return 1
+    finally:
+        protocol.close()
 
 
 if __name__ == "__main__":

--- a/pilots/go-lightpanda/density/schedule.v1.json
+++ b/pilots/go-lightpanda/density/schedule.v1.json
@@ -1,0 +1,145 @@
+{
+  "schema_version": 1,
+  "protocol_id": "go-lightpanda-fixed-ram-density-b2-v1",
+  "workload_sha256": "3db365d2a484b932049313d53469d07ffb2c5d9fdfe05821fd87cf67b1557740",
+  "expected_arm_records": 22,
+  "tasks_per_arm": 16,
+  "resource_envelope": {
+    "cpu_nanos": 1000000000,
+    "cpu_max": [
+      100000,
+      100000
+    ],
+    "memory_bytes": 1073741824,
+    "memory_swap_bytes": 0,
+    "host_page_size_min_bytes": 4096,
+    "host_page_size_max_bytes": 65536,
+    "pids_limit": 768,
+    "nofile_soft": 256,
+    "nofile_hard": 256
+  },
+  "admission": {
+    "c4_required_passes_per_implementation": 5,
+    "go_c8_required_passes": 5,
+    "go_rate_median_min": {
+      "numerator": 5,
+      "denominator": 4
+    },
+    "go_rate_wins_min": 4,
+    "go_memory_median_max": {
+      "numerator": 4,
+      "denominator": 5
+    },
+    "go_memory_wins_min": 4,
+    "ram_relevance_floor": {
+      "numerator": 7,
+      "denominator": 10
+    },
+    "python_memory_pressure_min": 3,
+    "go_pressure_peak_max_exclusive": {
+      "numerator": 4,
+      "denominator": 5
+    }
+  },
+  "pairs": [
+    {
+      "id": "c1-p01",
+      "concurrency": 1,
+      "diagnostic": true,
+      "order": [
+        "python",
+        "go"
+      ]
+    },
+    {
+      "id": "c4-p01",
+      "concurrency": 4,
+      "diagnostic": false,
+      "order": [
+        "go",
+        "python"
+      ]
+    },
+    {
+      "id": "c4-p02",
+      "concurrency": 4,
+      "diagnostic": false,
+      "order": [
+        "python",
+        "go"
+      ]
+    },
+    {
+      "id": "c4-p03",
+      "concurrency": 4,
+      "diagnostic": false,
+      "order": [
+        "go",
+        "python"
+      ]
+    },
+    {
+      "id": "c4-p04",
+      "concurrency": 4,
+      "diagnostic": false,
+      "order": [
+        "python",
+        "go"
+      ]
+    },
+    {
+      "id": "c4-p05",
+      "concurrency": 4,
+      "diagnostic": false,
+      "order": [
+        "go",
+        "python"
+      ]
+    },
+    {
+      "id": "c8-p01",
+      "concurrency": 8,
+      "diagnostic": false,
+      "order": [
+        "python",
+        "go"
+      ]
+    },
+    {
+      "id": "c8-p02",
+      "concurrency": 8,
+      "diagnostic": false,
+      "order": [
+        "go",
+        "python"
+      ]
+    },
+    {
+      "id": "c8-p03",
+      "concurrency": 8,
+      "diagnostic": false,
+      "order": [
+        "python",
+        "go"
+      ]
+    },
+    {
+      "id": "c8-p04",
+      "concurrency": 8,
+      "diagnostic": false,
+      "order": [
+        "go",
+        "python"
+      ]
+    },
+    {
+      "id": "c8-p05",
+      "concurrency": 8,
+      "diagnostic": false,
+      "order": [
+        "python",
+        "go"
+      ]
+    }
+  ]
+}

--- a/pilots/go-lightpanda/density/test_controller.py
+++ b/pilots/go-lightpanda/density/test_controller.py
@@ -5,6 +5,7 @@ import hashlib
 import importlib.util
 import json
 from pathlib import Path
+import stat
 import subprocess
 import tempfile
 import time
@@ -109,7 +110,7 @@ class ValidationTests(unittest.TestCase):
             "schema_version": 1, "implementation_id": "go-lightpanda",
             "runtime_id": "go1.24.0", "workload_sha256": self.workload_sha,
             "source_commit": "a" * 40, "image_identity": "sha256:" + "b" * 64,
-            "concurrency": 4, "succeeded": True, "elapsed_ms": 1,
+            "concurrency": 4, "succeeded": True, "elapsed_ns": 1,
             "submitted": 16, "accepted": 16, "terminal": 16,
             "succeeded_jobs": 16, "failed_jobs": 0, "oracle_matches": 16,
             "conservation_ok": True, "oracle_ok": True, "max_in_flight_ok": True,
@@ -321,8 +322,12 @@ class FakeDocker:
         self.calls.append(list(args))
         if self.mode == "timeout" and args[0] == "wait":
             raise controller.SmokeFailure("command")
-        if self.mode == "gate_output" and args[0] == "exec":
+        if self.mode == "cleanup_command" and args[:2] == ["ps", "-aq"]:
+            raise controller.SmokeFailure("command")
+        if self.mode == "signal_output" and args[:3] == ["kill", "--signal", "USR1"]:
             return subprocess.CompletedProcess(args, 0, b"unexpected", b"")
+        if args[:3] in (["kill", "--signal", "USR1"], ["kill", "--signal", "USR2"]):
+            return subprocess.CompletedProcess(args, 0, args[3].encode() + b"\n", b"")
         if args[:2] == ["ps", "-aq"]:
             return subprocess.CompletedProcess(args, 0, b"c" * 64 + b"\n", b"")
         if args[:3] == ["network", "ls", "--format"]:
@@ -334,6 +339,9 @@ class FakeDocker:
         if self.mode == "malformed_labels":
             return [{"Config": {"Labels": None}}]
         return [{"Config": {"Labels": {controller.LABEL_RUN: "run", controller.LABEL_ROLE: "attacker"}}}]
+
+    def logs(self, _container):
+        return b"{}"
 
 
 class LifecycleTests(unittest.TestCase):
@@ -347,17 +355,24 @@ class LifecycleTests(unittest.TestCase):
         self.assertEqual(failure_id(lambda: smoke._wait("c" * 64, 0.01)), "timeout")
         self.assertIn(["kill", "c" * 64], docker.calls)
 
-    def test_start_gate_release_is_exact_and_silent(self):
+    def test_phase_signals_are_exact_and_validate_docker_output(self):
         docker = FakeDocker("ok")
         smoke = self.smoke(docker)
-        smoke._release_start_gate("c" * 64)
+        smoke._signal("c" * 64, "USR1")
+        smoke._signal("c" * 64, "USR2")
         self.assertEqual(
             docker.calls,
-            [["exec", "c" * 64, "touch", controller.START_GATE]],
+            [
+                ["kill", "--signal", "USR1", "c" * 64],
+                ["kill", "--signal", "USR2", "c" * 64],
+            ],
         )
         self.assertEqual(
-            failure_id(lambda: self.smoke(FakeDocker("gate_output"))._release_start_gate("c" * 64)),
+            failure_id(lambda: self.smoke(FakeDocker("signal_output"))._signal("c" * 64, "USR1")),
             "command",
+        )
+        self.assertEqual(
+            failure_id(lambda: smoke._signal("c" * 64, "TERM")), "command"
         )
 
     def test_cleanup_refuses_label_mutation(self):
@@ -371,6 +386,13 @@ class LifecycleTests(unittest.TestCase):
     def test_cleanup_normalizes_null_labels(self):
         docker = FakeDocker("malformed_labels")
         self.assertEqual(failure_id(lambda: self.smoke(docker)._cleanup("network")), "cleanup")
+
+    def test_cleanup_normalizes_docker_command_failure(self):
+        docker = FakeDocker("cleanup_command")
+        self.assertEqual(
+            failure_id(lambda: self.smoke(docker)._cleanup("network")),
+            "cleanup",
+        )
 
     def test_image_identity_rejects_malformed_docker_shapes(self):
         class ImageDocker:
@@ -387,6 +409,333 @@ class LifecycleTests(unittest.TestCase):
             self.smoke(ImageDocker([{"Id": "sha256:" + "b" * 64}])).image_identity("tag"),
             "sha256:" + "b" * 64,
         )
+
+    def test_exit_before_final_stops_sampler_once_and_retains_oom(self):
+        smoke = self.smoke(FakeDocker("ok"))
+        identity = mock.Mock()
+        identity.only_main_process.return_value = True
+        resources = {
+            "memory_events": {
+                "low": 0, "high": 0, "max": 3, "oom": 1,
+                "oom_kill": 1, "oom_group_kill": 0,
+            },
+            "pids_events": {"max": 0},
+        }
+        sampler = mock.Mock()
+        sampler.stop.return_value = resources
+        exited = {
+            "State": {
+                "Status": "exited", "Running": False,
+                "Restarting": False, "Dead": False, "Pid": 0,
+                "ExitCode": 137, "OOMKilled": True,
+            }
+        }
+        with (
+            mock.patch.object(smoke, "image_identity", side_effect=[
+                "sha256:" + "a" * 64, "sha256:" + "b" * 64,
+            ]),
+            mock.patch.object(smoke, "_create", side_effect=["f" * 64, "m" * 64]),
+            mock.patch.object(smoke, "_start"),
+            mock.patch.object(smoke, "_cleanup"),
+            mock.patch.object(smoke, "_inspect_one", side_effect=[
+                {}, {}, {"State": {"Pid": 123}}, exited,
+            ]),
+            mock.patch.object(controller, "attest_network"),
+            mock.patch.object(controller, "attest_container"),
+            mock.patch.object(controller.ProcessIdentity, "capture", return_value=identity),
+            mock.patch.object(controller, "wait_process_phase", side_effect=["matched", "exited"]),
+            mock.patch.object(controller.CgroupSampler, "from_identity", return_value=sampler),
+        ):
+            with self.assertRaises(controller.SmokeFailure) as caught:
+                smoke.run_arm(
+                    "go", "go", "fixture", retain_failure_resources=True
+                )
+        self.assertEqual(caught.exception.failure_id, "oom")
+        self.assertIs(caught.exception.resources, resources)
+        self.assertFalse(caught.exception.resources_final)
+        sampler.stop.assert_called_once_with(reject_oom=False)
+
+    def test_exit_before_initial_retains_kernel_pressure(self):
+        smoke = self.smoke(FakeDocker("ok"))
+        identity = mock.Mock()
+        resources = {
+            "memory_events": {
+                "low": 0, "high": 0, "max": 2, "oom": 1,
+                "oom_kill": 1, "oom_group_kill": 0,
+            },
+            "pids_events": {"max": 0},
+        }
+        sampler = mock.Mock()
+        sampler.stop.return_value = resources
+        with (
+            mock.patch.object(smoke, "image_identity", side_effect=[
+                "sha256:" + "a" * 64, "sha256:" + "b" * 64,
+            ]),
+            mock.patch.object(smoke, "_create", side_effect=["f" * 64, "m" * 64]),
+            mock.patch.object(smoke, "_start"),
+            mock.patch.object(smoke, "_cleanup"),
+            mock.patch.object(smoke, "_inspect_one", side_effect=[
+                {}, {}, {"State": {"Pid": 123}},
+            ]),
+            mock.patch.object(controller, "attest_network"),
+            mock.patch.object(controller, "attest_container"),
+            mock.patch.object(controller.ProcessIdentity, "capture", return_value=identity),
+            mock.patch.object(controller, "wait_process_phase", return_value="exited"),
+            mock.patch.object(controller.CgroupSampler, "from_identity", return_value=sampler),
+        ):
+            with self.assertRaises(controller.SmokeFailure) as caught:
+                smoke.run_arm(
+                    "go", "go", "fixture", retain_failure_resources=True
+                )
+        self.assertEqual(caught.exception.failure_id, "oom")
+        self.assertIs(caught.exception.resources, resources)
+        self.assertFalse(caught.exception.resources_final)
+        sampler.stop.assert_called_once_with(reject_oom=False)
+
+    def test_fixture_failures_are_not_reclassified_from_measured_pressure(self):
+        measured_exit = {
+            "State": {
+                "Status": "exited", "Running": False,
+                "Restarting": False, "Dead": False, "Pid": 0,
+                "ExitCode": 0, "OOMKilled": False,
+            }
+        }
+        fixture_states = {
+            "timeout": measured_exit,
+            "nonzero": {
+                "State": {**measured_exit["State"], "ExitCode": 2},
+            },
+            "oom": {
+                "State": {
+                    **measured_exit["State"], "ExitCode": 137,
+                    "OOMKilled": True,
+                },
+            },
+        }
+        for fixture_failure in ("timeout", "nonzero", "oom"):
+            with self.subTest(fixture_failure=fixture_failure):
+                smoke = self.smoke(FakeDocker("ok"))
+                identity = mock.Mock()
+                identity.only_main_process.return_value = True
+                resources = {
+                    "memory_events": {
+                        "low": 0, "high": 0, "max": 3,
+                        "oom": int(fixture_failure != "oom"),
+                        "oom_kill": int(fixture_failure != "oom"),
+                        "oom_group_kill": 0,
+                    },
+                    "pids_events": {"max": 0},
+                }
+                sampler = mock.Mock()
+                sampler.stop.return_value = resources
+                waits = [None]
+                if fixture_failure == "timeout":
+                    waits.append(controller.SmokeFailure("timeout"))
+                else:
+                    waits.append(None)
+                with (
+                    mock.patch.object(smoke, "image_identity", side_effect=[
+                        "sha256:" + "a" * 64, "sha256:" + "b" * 64,
+                    ]),
+                    mock.patch.object(smoke, "_create", side_effect=["f" * 64, "m" * 64]),
+                    mock.patch.object(smoke, "_start"),
+                    mock.patch.object(smoke, "_signal"),
+                    mock.patch.object(smoke, "_wait", side_effect=waits),
+                    mock.patch.object(smoke, "_cleanup"),
+                    mock.patch.object(smoke, "_inspect_one", side_effect=[
+                        {}, {}, {"State": {"Pid": 123}}, measured_exit,
+                        fixture_states[fixture_failure],
+                    ]),
+                    mock.patch.object(controller, "attest_network"),
+                    mock.patch.object(controller, "attest_container"),
+                    mock.patch.object(controller.ProcessIdentity, "capture", return_value=identity),
+                    mock.patch.object(controller, "wait_process_phase", side_effect=["matched", "matched"]),
+                    mock.patch.object(controller.CgroupSampler, "from_identity", return_value=sampler),
+                ):
+                    with self.assertRaises(controller.SmokeFailure) as caught:
+                        smoke.run_arm(
+                            "go", "go", "fixture",
+                            retain_failure_resources=True,
+                        )
+                self.assertEqual(caught.exception.failure_id, "infrastructure")
+                self.assertIsNone(caught.exception.resources)
+                self.assertFalse(caught.exception.resources_final)
+                sampler.stop.assert_called_once_with(
+                    reject_oom=False, allow_fallback=False,
+                )
+
+    def test_cleanup_failure_overrides_fixture_failure_and_aborts(self):
+        smoke = self.smoke(FakeDocker("ok"))
+        identity = mock.Mock()
+        identity.only_main_process.return_value = True
+        resources = {
+            "memory_events": {
+                "low": 0, "high": 0, "max": 3, "oom": 1,
+                "oom_kill": 1, "oom_group_kill": 0,
+            },
+            "pids_events": {"max": 0},
+        }
+        sampler = mock.Mock()
+        sampler.stop.return_value = resources
+        measured_exit = {
+            "State": {
+                "Status": "exited", "Running": False,
+                "Restarting": False, "Dead": False, "Pid": 0,
+                "ExitCode": 0, "OOMKilled": False,
+            }
+        }
+        with (
+            mock.patch.object(smoke, "image_identity", side_effect=[
+                "sha256:" + "a" * 64, "sha256:" + "b" * 64,
+            ]),
+            mock.patch.object(smoke, "_create", side_effect=["f" * 64, "m" * 64]),
+            mock.patch.object(smoke, "_start"),
+            mock.patch.object(smoke, "_signal"),
+            mock.patch.object(
+                smoke, "_wait",
+                side_effect=[None, controller.SmokeFailure("timeout")],
+            ),
+            mock.patch.object(
+                smoke, "_cleanup", side_effect=controller.SmokeFailure("cleanup")
+            ),
+            mock.patch.object(smoke, "_inspect_one", side_effect=[
+                {}, {}, {"State": {"Pid": 123}}, measured_exit,
+            ]),
+            mock.patch.object(controller, "attest_network"),
+            mock.patch.object(controller, "attest_container"),
+            mock.patch.object(
+                controller.ProcessIdentity, "capture", return_value=identity
+            ),
+            mock.patch.object(
+                controller, "wait_process_phase", side_effect=["matched", "matched"]
+            ),
+            mock.patch.object(
+                controller.CgroupSampler, "from_identity", return_value=sampler
+            ),
+        ):
+            with self.assertRaises(controller.SmokeFailure) as caught:
+                smoke.run_arm(
+                    "go", "go", "fixture", retain_failure_resources=True
+                )
+        self.assertEqual(caught.exception.failure_id, "cleanup")
+        self.assertIsNone(caught.exception.resources)
+        self.assertFalse(caught.exception.resources_final)
+
+    def test_fixture_validation_failures_are_infrastructure(self):
+        exited = {
+            "State": {
+                "Status": "exited", "Running": False,
+                "Restarting": False, "Dead": False, "Pid": 0,
+                "ExitCode": 0, "OOMKilled": False,
+            }
+        }
+        for fixture_failure in ("transcript", "oracle"):
+            with self.subTest(fixture_failure=fixture_failure):
+                smoke = self.smoke(FakeDocker("ok"))
+                identity = mock.Mock()
+                identity.only_main_process.return_value = True
+                sampler = mock.Mock()
+                sampler.stop.return_value = {
+                    "memory_events": {
+                        "low": 0, "high": 0, "max": 3, "oom": 1,
+                        "oom_kill": 1, "oom_group_kill": 0,
+                    },
+                    "pids_events": {"max": 0},
+                }
+                with (
+                    mock.patch.object(smoke, "image_identity", side_effect=[
+                        "sha256:" + "a" * 64, "sha256:" + "b" * 64,
+                    ]),
+                    mock.patch.object(
+                        smoke, "_create", side_effect=["f" * 64, "m" * 64]
+                    ),
+                    mock.patch.object(smoke, "_start"),
+                    mock.patch.object(smoke, "_signal"),
+                    mock.patch.object(smoke, "_wait"),
+                    mock.patch.object(smoke, "_cleanup"),
+                    mock.patch.object(smoke, "_inspect_one", side_effect=[
+                        {}, {}, {"State": {"Pid": 123}}, exited, exited,
+                    ]),
+                    mock.patch.object(controller, "attest_network"),
+                    mock.patch.object(controller, "attest_container"),
+                    mock.patch.object(
+                        controller.ProcessIdentity, "capture", return_value=identity
+                    ),
+                    mock.patch.object(
+                        controller, "wait_process_phase",
+                        side_effect=["matched", "matched"],
+                    ),
+                    mock.patch.object(
+                        controller.CgroupSampler,
+                        "from_identity",
+                        return_value=sampler,
+                    ),
+                    mock.patch.object(controller, "parse_json_object", return_value={}),
+                    mock.patch.object(controller, "validate_measured", return_value={}),
+                    mock.patch.object(
+                        controller, "parse_fixture_output", return_value={}
+                    ),
+                    mock.patch.object(
+                        controller,
+                        "validate_fixture",
+                        side_effect=controller.SmokeFailure(fixture_failure),
+                    ),
+                ):
+                    with self.assertRaises(controller.SmokeFailure) as caught:
+                        smoke.run_arm(
+                            "go", "go", "fixture",
+                            retain_failure_resources=True,
+                        )
+                self.assertEqual(caught.exception.failure_id, "infrastructure")
+                self.assertIsNone(caught.exception.resources)
+                self.assertFalse(caught.exception.resources_final)
+
+    def test_cleanup_overrides_unexpected_runtime_failure(self):
+        smoke = self.smoke(FakeDocker("ok"))
+        identity = mock.Mock()
+        identity.only_main_process.return_value = True
+        sampler = mock.Mock()
+        sampler.stop.return_value = {
+            "memory_events": {
+                "low": 0, "high": 0, "max": 0, "oom": 0,
+                "oom_kill": 0, "oom_group_kill": 0,
+            },
+            "pids_events": {"max": 0},
+        }
+        with (
+            mock.patch.object(smoke, "image_identity", side_effect=[
+                "sha256:" + "a" * 64, "sha256:" + "b" * 64,
+            ]),
+            mock.patch.object(smoke, "_create", side_effect=["f" * 64, "m" * 64]),
+            mock.patch.object(smoke, "_start"),
+            mock.patch.object(smoke, "_signal"),
+            mock.patch.object(
+                smoke, "_cleanup", side_effect=controller.SmokeFailure("cleanup")
+            ),
+            mock.patch.object(smoke, "_inspect_one", side_effect=[
+                {}, {}, {"State": {"Pid": 123}},
+            ]),
+            mock.patch.object(controller, "attest_network"),
+            mock.patch.object(controller, "attest_container"),
+            mock.patch.object(
+                controller.ProcessIdentity, "capture", return_value=identity
+            ),
+            mock.patch.object(
+                controller,
+                "wait_process_phase",
+                side_effect=["matched", RuntimeError("unexpected")],
+            ),
+            mock.patch.object(
+                controller.CgroupSampler, "from_identity", return_value=sampler
+            ),
+        ):
+            with self.assertRaises(controller.SmokeFailure) as caught:
+                smoke.run_arm(
+                    "go", "go", "fixture", retain_failure_resources=True
+                )
+        self.assertEqual(caught.exception.failure_id, "cleanup")
+        self.assertIsNone(caught.exception.resources)
+        self.assertFalse(caught.exception.resources_final)
 
 
 class DockerBoundaryTests(unittest.TestCase):
@@ -431,7 +780,7 @@ class SamplerTests(unittest.TestCase):
                 "core_sched.force_idle_usec 0\n"
             ),
             "pids.max": f"{controller.MEASURED_PIDS}\n", "pids.events": "max 0\n",
-            "pids.peak": "2\n", "cgroup.procs": "",
+            "pids.current": "1\n", "pids.peak": "2\n", "cgroup.procs": "123\n",
         }
         for name, value in values.items():
             (path / name).write_text(value, encoding="ascii")
@@ -456,14 +805,18 @@ class SamplerTests(unittest.TestCase):
             self.assertEqual(result["memory_limit"], controller.GIB)
             self.assertEqual(result["memory_swap_limit"], 0)
             self.assertEqual(result["pids_limit"], controller.MEASURED_PIDS)
+            self.assertEqual(result["pids_current"], 1)
             self.assertEqual(result["pids_events"], {"max": 0})
+            self.assertEqual(result["cgroup_process_count"], 1)
             self.assertEqual(result["cpu_max"], [100000, 100000])
             controller.validate_resources(result)
             for key, value, want in (
                 ("memory_swap_limit", 1, "inspect"),
                 ("cpu_max", [200000, 100000], "inspect"),
+                ("cgroup_process_count", 2, "process_residue"),
+                ("pids_current", controller.MEASURED_PIDS + 1, "inspect"),
                 ("pids_peak", controller.MEASURED_PIDS + 1, "inspect"),
-                ("pids_events", {"max": 1}, "oom"),
+                ("pids_events", {"max": 1}, "pid_limit"),
             ):
                 mutated = copy.deepcopy(result)
                 mutated[key] = value
@@ -471,6 +824,79 @@ class SamplerTests(unittest.TestCase):
                     failure_id(lambda mutated=mutated: controller.validate_resources(mutated)),
                     want,
                 )
+
+            one_page_oom = copy.deepcopy(result)
+            one_page_oom["memory_peak"] = (
+                controller.GIB + one_page_oom["host_page_size"]
+            )
+            one_page_oom["memory_events"]["max"] = 1
+            one_page_oom["memory_events"]["oom"] = 1
+            one_page_oom["memory_events"]["oom_kill"] = 1
+            self.assertEqual(
+                failure_id(lambda: controller.validate_resources(one_page_oom)),
+                "oom",
+            )
+            one_page_pressure = copy.deepcopy(result)
+            one_page_pressure["memory_peak"] = (
+                controller.GIB + one_page_pressure["host_page_size"]
+            )
+            one_page_pressure["memory_events"]["max"] = 1
+            self.assertEqual(
+                failure_id(
+                    lambda: controller.validate_resources(one_page_pressure)
+                ),
+                "memory_pressure",
+            )
+            one_page_without_pressure = copy.deepcopy(result)
+            one_page_without_pressure["memory_peak"] = (
+                controller.GIB
+                + one_page_without_pressure["host_page_size"]
+            )
+            self.assertEqual(
+                failure_id(
+                    lambda: controller.validate_resources(
+                        one_page_without_pressure
+                    )
+                ),
+                "inspect",
+            )
+            for key, value in (
+                (
+                    "memory_peak",
+                    controller.GIB + one_page_oom["host_page_size"] + 1,
+                ),
+                ("cgroup_process_count", 2),
+            ):
+                invalid = copy.deepcopy(one_page_oom)
+                invalid[key] = value
+                with self.subTest(key=key):
+                    self.assertEqual(
+                        failure_id(
+                            lambda invalid=invalid: controller.validate_resources(
+                                invalid
+                            )
+                        ),
+                        (
+                            "process_residue"
+                            if key == "cgroup_process_count"
+                            else "inspect"
+                        ),
+                    )
+
+    def test_final_sample_never_falls_back_to_earlier_read(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "cgroup"
+            path.mkdir()
+            self.write_cgroup(path, peak=7)
+            sampler = controller.CgroupSampler(path, interval=0.002)
+            sampler.start()
+            deadline = time.monotonic() + 1
+            while sampler.latest is None and time.monotonic() < deadline:
+                time.sleep(0.002)
+            path.rename(path.with_name("vanished"))
+            with self.assertRaises(controller.SmokeFailure) as caught:
+                sampler.stop(reject_oom=False, allow_fallback=False)
+            self.assertEqual(caught.exception.failure_id, "missing_cgroup")
 
     def test_missing_event_counters_fail_closed(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -480,9 +906,85 @@ class SamplerTests(unittest.TestCase):
             with self.assertRaises(ValueError):
                 controller.CgroupSampler(path)._read_resources()
             self.write_cgroup(path, peak=2)
-            (path / "memory.events").write_text("low 0\nhigh 0\nmax 0\noom 0\noom_kill 0\n", encoding="ascii")
+            (path / "memory.events").write_text(
+                "low 0\nhigh 0\nmax 0\noom 0\noom_kill 0\n", encoding="ascii"
+            )
             with self.assertRaises(ValueError):
                 controller.CgroupSampler(path)._read_resources()
+
+    def test_process_stat_is_strict(self):
+        with tempfile.TemporaryDirectory() as directory:
+            proc_root = Path(directory)
+            process_dir = proc_root / "123"
+            process_dir.mkdir()
+            fields = ["T", *("0" for _ in range(18)), "42"]
+            (process_dir / "stat").write_text(
+                "123 (density runner) " + " ".join(fields) + "\n", encoding="ascii"
+            )
+            self.assertEqual(
+                controller._read_process_stat(123, proc_root=proc_root), ("T", 42)
+            )
+            (process_dir / "stat").write_text("malformed\n", encoding="ascii")
+            self.assertEqual(
+                failure_id(
+                    lambda: controller._read_process_stat(123, proc_root=proc_root)
+                ),
+                "process_identity",
+            )
+
+    def test_only_main_process_rejects_residue_and_malformed_members(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory)
+            identity = controller.ProcessIdentity(123, 42, path)
+            (path / "cgroup.procs").write_text("123\n", encoding="ascii")
+            self.assertTrue(identity.only_main_process())
+            (path / "cgroup.procs").write_text("123\n124\n", encoding="ascii")
+            self.assertFalse(identity.only_main_process())
+            (path / "cgroup.procs").write_text("secret\n", encoding="ascii")
+            self.assertEqual(
+                failure_id(identity.only_main_process), "process_residue"
+            )
+
+    def test_phase_markers_are_exact_and_prove_progress(self):
+        identity = controller.ProcessIdentity(123, 42, Path("/cgroup"))
+        valid = mock.Mock(
+            st_mode=stat.S_IFREG | 0o600,
+            st_uid=10001,
+            st_gid=10001,
+            st_nlink=1,
+            st_size=0,
+        )
+        with mock.patch.object(Path, "lstat", return_value=valid):
+            self.assertTrue(identity.marker_ready(controller.INITIAL_MARKER_PATH))
+            self.assertTrue(identity.marker_ready(controller.FINAL_MARKER_PATH))
+        invalid = mock.Mock(
+            st_mode=stat.S_IFREG | 0o600,
+            st_uid=0,
+            st_gid=10001,
+            st_nlink=1,
+            st_size=0,
+        )
+        with mock.patch.object(Path, "lstat", return_value=invalid):
+            self.assertEqual(
+                failure_id(
+                    lambda: identity.marker_ready(controller.FINAL_MARKER_PATH)
+                ),
+                "process_state",
+            )
+
+        class FinalIdentity:
+            def state(self):
+                return "S"
+
+            def marker_ready(self, marker_path):
+                return marker_path == controller.FINAL_MARKER_PATH
+
+        self.assertEqual(
+            controller.wait_process_phase(
+                FinalIdentity(), phase="final", deadline=time.monotonic() + 1
+            ),
+            "matched",
+        )
 
     def test_flat_cgroup_parser_rejects_malformed_or_duplicate_keys(self):
         for raw in (

--- a/pilots/go-lightpanda/density/test_evidence_protocol.py
+++ b/pilots/go-lightpanda/density/test_evidence_protocol.py
@@ -1,0 +1,593 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import math
+import tempfile
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+SPEC = importlib.util.spec_from_file_location(
+    "density_evidence_protocol", HERE / "evidence_protocol.py"
+)
+assert SPEC is not None and SPEC.loader is not None
+protocol = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(protocol)
+
+
+def resources(
+    peak: int,
+    *,
+    memory_max_events: int = 0,
+    oom_events: int = 0,
+    observation: str = "final",
+    host_page_size: int = 4096,
+):
+    return {
+        "final_sample": observation == "final",
+        "observation": observation,
+        "memory_current": min(peak, 64 * 1024**2),
+        "memory_peak": peak,
+        "memory_limit": protocol.GIB,
+        "memory_swap_limit": 0,
+        "host_page_size": host_page_size,
+        "memory_events": {
+            "low": 0,
+            "high": 0,
+            "max": memory_max_events,
+            "oom": oom_events,
+            "oom_kill": oom_events,
+            "oom_group_kill": 0,
+        },
+        "cpu_max": [100000, 100000],
+        "cpu_stat": {"usage_usec": 1, "user_usec": 1, "system_usec": 0},
+        "pids_limit": 768,
+        "pids_current": 1,
+        "pids_peak": 64,
+        "pids_events": {"max": 0},
+        "cgroup_process_count": 1,
+    }
+
+
+def pressure_resources(*, memory_max_events: int = 0, oom_events: int = 0):
+    return resources(
+        protocol.GIB + 4096,
+        memory_max_events=memory_max_events,
+        oom_events=oom_events,
+        observation="sampled_not_final",
+    )
+
+
+class EvidenceProtocolTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.schedule, cls.schedule_sha = protocol.load_schedule(
+            HERE / "schedule.v1.json"
+        )
+
+    def records(
+        self,
+        *,
+        go_elapsed: int = 100,
+        python_elapsed: int = 125,
+        go_peak: int = 640 * 1024**2,
+        python_peak: int = 800 * 1024**2,
+    ):
+        result = []
+        for pair in self.schedule["pairs"]:
+            for arm_index, implementation in enumerate(pair["order"]):
+                result.append(
+                    {
+                        "schema_version": 1,
+                        "pair_id": pair["id"],
+                        "arm_index": arm_index,
+                        "implementation": implementation,
+                        "concurrency": pair["concurrency"],
+                        "outcome": "pass",
+                        "failure_id": None,
+                        "elapsed_ns": go_elapsed
+                        if implementation == "go"
+                        else python_elapsed,
+                        "resources": resources(
+                            go_peak if implementation == "go" else python_peak
+                        ),
+                    }
+                )
+        return result
+
+    def record(self, records, pair_id, implementation):
+        return next(
+            record
+            for record in records
+            if record["pair_id"] == pair_id
+            and record["implementation"] == implementation
+        )
+
+    def set_failure(self, record, failure_id, *, final_resources=None):
+        record["outcome"] = "failure"
+        record["failure_id"] = failure_id
+        record["elapsed_ns"] = None
+        record["resources"] = final_resources
+
+    def test_schedule_is_exact_frozen_shape_order_and_hash(self):
+        self.assertEqual(self.schedule_sha, protocol.EXPECTED_SCHEDULE_SHA256)
+        self.assertEqual(self.schedule["expected_arm_records"], 22)
+        self.assertEqual(self.schedule["resource_envelope"]["pids_limit"], 768)
+        self.assertEqual(
+            [
+                (pair["concurrency"], pair["order"], pair["diagnostic"])
+                for pair in self.schedule["pairs"]
+            ],
+            [
+                (1, ["python", "go"], True),
+                (4, ["go", "python"], False),
+                (4, ["python", "go"], False),
+                (4, ["go", "python"], False),
+                (4, ["python", "go"], False),
+                (4, ["go", "python"], False),
+                (8, ["python", "go"], False),
+                (8, ["go", "python"], False),
+                (8, ["python", "go"], False),
+                (8, ["go", "python"], False),
+                (8, ["python", "go"], False),
+            ],
+        )
+
+        for mutation in (
+            lambda value: value.update(expected_arm_records=21),
+            lambda value: value.update(schema_version=True),
+            lambda value: value.update(expected_arm_records=22.0),
+            lambda value: value["resource_envelope"].update(memory_swap_bytes=False),
+            lambda value: value["resource_envelope"].update(pids_limit=768.0),
+            lambda value: value["pairs"][2].update(order=["go", "python"]),
+            lambda value: value["resource_envelope"].update(pids_limit=769),
+            lambda value: value["admission"].update(go_rate_wins_min=3),
+            lambda value: value.update(extra=True),
+        ):
+            changed = copy.deepcopy(self.schedule)
+            mutation(changed)
+            with self.subTest(changed=changed):
+                with self.assertRaises(protocol.ProtocolError) as caught:
+                    protocol.validate_schedule(changed)
+                self.assertEqual(caught.exception.reason_id, "schedule_invalid")
+
+        with tempfile.TemporaryDirectory() as directory:
+            changed_path = Path(directory) / "schedule.json"
+            changed_path.write_bytes((HERE / "schedule.v1.json").read_bytes() + b"\n")
+            with self.assertRaises(protocol.ProtocolError) as caught:
+                protocol.load_schedule(changed_path)
+            self.assertEqual(caught.exception.reason_id, "schedule_hash_invalid")
+
+    def test_exact_thresholds_are_admitted_and_json_serializable(self):
+        report = protocol.summarize_evidence(self.schedule, self.records())
+        self.assertEqual(report["status"], "admitted")
+        self.assertEqual(report["reason_ids"], ["admission_thresholds_met"])
+        self.assertEqual(
+            report["metrics"]["median_rate_ratio"],
+            {"numerator": 5, "denominator": 4},
+        )
+        self.assertEqual(
+            report["metrics"]["median_memory_ratio"],
+            {"numerator": 4, "denominator": 5},
+        )
+        encoded = json.dumps(report, allow_nan=False)
+        self.assertNotIn("Infinity", encoded)
+        self.assertNotIn("NaN", encoded)
+
+    def test_exact_four_of_five_strict_wins_are_admitted(self):
+        records = self.records()
+        for pair_id in ("c8-p01", "c8-p02", "c8-p03", "c8-p04"):
+            self.record(records, pair_id, "python")["elapsed_ns"] = 125
+            self.record(records, pair_id, "go")["elapsed_ns"] = 100
+        self.record(records, "c8-p05", "python")["elapsed_ns"] = 100
+        self.record(records, "c8-p05", "go")["elapsed_ns"] = 100
+        self.record(records, "c8-p05", "go")["resources"]["memory_peak"] = 800 * 1024**2
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "admitted")
+        self.assertEqual(report["metrics"]["rate_wins"], 4)
+        self.assertEqual(report["metrics"]["memory_wins"], 4)
+
+    def test_only_three_strict_wins_fails_both_count_gates(self):
+        records = self.records()
+        for pair_id in ("c8-p04", "c8-p05"):
+            self.record(records, pair_id, "python")["elapsed_ns"] = 100
+            self.record(records, pair_id, "go")["elapsed_ns"] = 100
+            self.record(records, pair_id, "go")["resources"]["memory_peak"] = (
+                800 * 1024**2
+            )
+            self.record(records, pair_id, "python")["resources"]["memory_peak"] = (
+                800 * 1024**2
+            )
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "not_admitted")
+        self.assertEqual(
+            report["reason_ids"],
+            ["go_rate_wins_below_threshold", "go_memory_wins_below_threshold"],
+        )
+
+    def test_median_threshold_failures_are_exact(self):
+        records = self.records()
+        for pair_id in ("c8-p01", "c8-p02", "c8-p03"):
+            self.record(records, pair_id, "python")["elapsed_ns"] = 124
+            self.record(records, pair_id, "go")["elapsed_ns"] = 100
+            self.record(records, pair_id, "go")["resources"]["memory_peak"] = (
+                801 * 1024**2
+            )
+            self.record(records, pair_id, "python")["resources"]["memory_peak"] = (
+                1000 * 1024**2
+            )
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "not_admitted")
+        self.assertIn("go_rate_median_below_threshold", report["reason_ids"])
+        self.assertIn("go_memory_median_above_threshold", report["reason_ids"])
+
+    def test_both_c8_median_peaks_below_seventy_percent_is_inconclusive(self):
+        below = (7 * protocol.GIB) // 10
+        records = self.records(go_peak=below, python_peak=below)
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "inconclusive")
+        self.assertEqual(report["reason_ids"], ["c8_ram_ceiling_unreached"])
+
+        above = below + 1
+        records = self.records(go_peak=below, python_peak=above)
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertNotEqual(report["reason_ids"], ["c8_ram_ceiling_unreached"])
+
+    def test_c1_is_diagnostic_only(self):
+        records = self.records()
+        self.set_failure(self.record(records, "c1-p01", "python"), "timeout")
+        self.set_failure(self.record(records, "c1-p01", "go"), "missing_artifact")
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "admitted")
+
+    def test_c4_and_go_c8_prerequisites_distinguish_correctness_from_measurement(self):
+        cases = (
+            (
+                "c4-p01",
+                "python",
+                "oracle",
+                "not_admitted",
+                "c4_correctness_gate_failed",
+            ),
+            (
+                "c4-p01",
+                "python",
+                "timeout",
+                "inconclusive",
+                "c4_measurement_inconclusive",
+            ),
+            (
+                "c8-p01",
+                "go",
+                "conservation",
+                "not_admitted",
+                "go_c8_correctness_gate_failed",
+            ),
+            (
+                "c8-p01",
+                "go",
+                "fd_limit",
+                "inconclusive",
+                "go_c8_measurement_inconclusive",
+            ),
+            (
+                "c4-p01",
+                "python",
+                "concurrency",
+                "not_admitted",
+                "c4_correctness_gate_failed",
+            ),
+            (
+                "c8-p01",
+                "go",
+                "go_runner_invariant_failure",
+                "not_admitted",
+                "go_c8_correctness_gate_failed",
+            ),
+        )
+        for pair_id, implementation, failure_id, status, reason in cases:
+            records = self.records()
+            self.set_failure(self.record(records, pair_id, implementation), failure_id)
+            report = protocol.summarize_evidence(self.schedule, records)
+            with self.subTest(failure_id=failure_id):
+                self.assertEqual(report["status"], status)
+                self.assertEqual(report["reason_ids"], [reason])
+
+        records = self.records()
+        self.set_failure(
+            self.record(records, "c4-p01", "python"),
+            "go_runner_invariant_failure",
+        )
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "invalid")
+        self.assertEqual(report["reason_ids"], ["evidence_shape_invalid"])
+
+        for failure_id in ("cleanup", "containment", "process_residue"):
+            records = self.records()
+            self.set_failure(
+                self.record(records, "c1-p01", "go"),
+                failure_id,
+            )
+            report = protocol.summarize_evidence(self.schedule, records)
+            with self.subTest(failure_id=failure_id):
+                self.assertEqual(report["status"], "invalid")
+                self.assertEqual(report["reason_ids"], ["protocol_integrity_failure"])
+
+    def test_executor_abort_keeps_slots_without_fabricated_measurements(self):
+        records = self.records()
+        first_not_run = next(
+            index
+            for index, record in enumerate(records)
+            if record["pair_id"] == "c4-p03"
+        )
+        self.set_failure(records[first_not_run - 1], "timeout")
+        for record in records[first_not_run:]:
+            self.set_failure(record, "not_run")
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "invalid")
+        self.assertEqual(report["reason_ids"], ["evidence_not_run"])
+
+        records = self.records()
+        self.set_failure(records[0], "not_run", final_resources=resources(1024))
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "invalid")
+        self.assertEqual(report["reason_ids"], ["evidence_shape_invalid"])
+
+    def test_memory_pressure_fallback_requires_three_kernel_confirmed_failures(self):
+        records = self.records(go_peak=700 * 1024**2)
+        for pair_id in ("c8-p01", "c8-p02", "c8-p03"):
+            self.set_failure(
+                self.record(records, pair_id, "python"),
+                "oom",
+                final_resources=pressure_resources(oom_events=1),
+            )
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "admitted")
+        self.assertEqual(report["reason_ids"], ["memory_pressure_fallback_met"])
+        self.assertEqual(report["metrics"]["branch"], "python_memory_pressure")
+        self.assertNotIn("rate_ratios", report["metrics"])
+        self.assertNotIn("memory_ratios", report["metrics"])
+        self.assertFalse(any("ratio" in key for key in report["metrics"]))
+
+        records = self.records(go_peak=700 * 1024**2)
+        for pair_id in ("c8-p01", "c8-p02"):
+            self.set_failure(
+                self.record(records, pair_id, "python"),
+                "memory_pressure",
+                final_resources=pressure_resources(memory_max_events=1),
+            )
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "inconclusive")
+        self.assertEqual(
+            report["reason_ids"], ["python_c8_memory_pressure_insufficient"]
+        )
+
+    def test_memory_fallback_rejects_mixed_and_unconfirmed_failures(self):
+        records = self.records()
+        for pair_id in ("c8-p01", "c8-p02", "c8-p03"):
+            self.set_failure(
+                self.record(records, pair_id, "python"),
+                "oom",
+                final_resources=pressure_resources(oom_events=1),
+            )
+        self.set_failure(self.record(records, "c8-p04", "python"), "timeout")
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "inconclusive")
+        self.assertEqual(report["reason_ids"], ["python_c8_mixed_failures"])
+
+        records = self.records()
+        for pair_id in ("c8-p01", "c8-p02", "c8-p03"):
+            self.set_failure(
+                self.record(records, pair_id, "python"),
+                "oom",
+                final_resources=pressure_resources(),
+            )
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "inconclusive")
+        self.assertEqual(
+            report["reason_ids"], ["python_c8_memory_pressure_unconfirmed"]
+        )
+
+        records = self.records(go_peak=700 * 1024**2)
+        for pair_id in ("c8-p01", "c8-p02", "c8-p03"):
+            self.set_failure(
+                self.record(records, pair_id, "python"),
+                "oom",
+                final_resources=pressure_resources(oom_events=1),
+            )
+        self.set_failure(
+            self.record(records, "c8-p04", "python"),
+            "memory_pressure",
+            final_resources=pressure_resources(),
+        )
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "admitted")
+        self.assertEqual(
+            report["metrics"]["python_kernel_confirmed_pressure_failures"], 3
+        )
+
+    def test_pid_pressure_cannot_be_mislabeled_for_memory_admission(self):
+        records = self.records(go_peak=700 * 1024**2)
+        for pair_id in ("c8-p01", "c8-p02", "c8-p03"):
+            sampled = pressure_resources(oom_events=1)
+            sampled["pids_events"]["max"] = 1
+            self.set_failure(
+                self.record(records, pair_id, "python"),
+                "oom",
+                final_resources=sampled,
+            )
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "invalid")
+        self.assertEqual(report["reason_ids"], ["evidence_shape_invalid"])
+
+        records = self.records(go_peak=700 * 1024**2)
+        for pair_id in ("c8-p01", "c8-p02", "c8-p03"):
+            sampled = pressure_resources(oom_events=1)
+            sampled["pids_events"]["max"] = 1
+            self.set_failure(
+                self.record(records, pair_id, "python"),
+                "pid_limit",
+                final_resources=sampled,
+            )
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "inconclusive")
+        self.assertEqual(report["reason_ids"], ["python_c8_mixed_failures"])
+
+        records = self.records()
+        self.set_failure(
+            self.record(records, "c8-p01", "python"), "pid_limit"
+        )
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "invalid")
+        self.assertEqual(report["reason_ids"], ["evidence_shape_invalid"])
+
+    def test_cpu_period_is_frozen_and_symmetric(self):
+        records = self.records()
+        self.record(records, "c8-p01", "go")["resources"]["cpu_max"] = [
+            1000,
+            1000,
+        ]
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "invalid")
+        self.assertEqual(report["reason_ids"], ["evidence_shape_invalid"])
+
+    def test_failed_oom_retains_only_bounded_page_slack(self):
+        records = self.records(go_peak=700 * 1024**2)
+        for pair_id in ("c8-p01", "c8-p02", "c8-p03"):
+            self.set_failure(
+                self.record(records, pair_id, "python"),
+                "oom",
+                final_resources=pressure_resources(oom_events=1),
+            )
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "admitted")
+
+        invalid = self.record(records, "c8-p01", "python")["resources"]
+        invalid["memory_peak"] = protocol.GIB + invalid["host_page_size"] + 1
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "invalid")
+        self.assertEqual(report["reason_ids"], ["evidence_shape_invalid"])
+
+        records = self.records()
+        failed = self.record(records, "c8-p01", "python")
+        sampled = pressure_resources(oom_events=1)
+        sampled["host_page_size"] = 6000
+        self.set_failure(failed, "oom", final_resources=sampled)
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "invalid")
+
+    def test_pass_requires_final_observation_and_single_process(self):
+        for mutation in (
+            lambda value: value.update(
+                final_sample=False, observation="sampled_not_final"
+            ),
+            lambda value: value.update(cgroup_process_count=2),
+        ):
+            records = self.records()
+            mutation(self.record(records, "c8-p01", "go")["resources"])
+            report = protocol.summarize_evidence(self.schedule, records)
+            with self.subTest(report=report):
+                self.assertEqual(report["status"], "invalid")
+                self.assertEqual(report["reason_ids"], ["evidence_shape_invalid"])
+
+    def test_resource_current_values_cannot_exceed_peaks_or_processes(self):
+        mutations = (
+            lambda value: value.update(memory_current=value["memory_peak"] + 1),
+            lambda value: value.update(pids_current=value["pids_peak"] + 1),
+            lambda value: value.update(pids_current=0, cgroup_process_count=1),
+        )
+        for mutation in mutations:
+            records = self.records()
+            mutation(self.record(records, "c8-p01", "go")["resources"])
+            report = protocol.summarize_evidence(self.schedule, records)
+            with self.subTest(report=report):
+                self.assertEqual(report["status"], "invalid")
+                self.assertEqual(report["reason_ids"], ["evidence_shape_invalid"])
+
+    def test_host_page_size_is_one_recorded_run_invariant(self):
+        records = self.records()
+        self.record(records, "c8-p01", "go")["resources"]["host_page_size"] = 8192
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "invalid")
+        self.assertEqual(report["reason_ids"], ["evidence_shape_invalid"])
+
+    def test_memory_fallback_go_peak_limit_is_strict(self):
+        strict_max = (4 * protocol.GIB) // 5
+        records = self.records(go_peak=strict_max)
+        for pair_id in ("c8-p01", "c8-p02", "c8-p03"):
+            self.set_failure(
+                self.record(records, pair_id, "python"),
+                "memory_pressure",
+                final_resources=pressure_resources(memory_max_events=1),
+            )
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "admitted")
+
+        records = self.records(go_peak=strict_max + 1)
+        for pair_id in ("c8-p01", "c8-p02", "c8-p03"):
+            self.set_failure(
+                self.record(records, pair_id, "python"),
+                "memory_pressure",
+                final_resources=pressure_resources(memory_max_events=1),
+            )
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "not_admitted")
+        self.assertEqual(report["reason_ids"], ["go_memory_pressure_peak_too_high"])
+
+    def test_zero_noninteger_nan_and_infinite_values_are_invalid(self):
+        for invalid in (0, 1.0, math.nan, math.inf):
+            records = self.records()
+            self.record(records, "c8-p01", "go")["elapsed_ns"] = invalid
+            report = protocol.summarize_evidence(self.schedule, records)
+            with self.subTest(invalid=invalid):
+                self.assertEqual(report["status"], "invalid")
+                self.assertEqual(report["reason_ids"], ["evidence_shape_invalid"])
+
+        records = self.records()
+        self.record(records, "c8-p01", "go")["resources"]["memory_peak"] = math.inf
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "invalid")
+
+    def test_unhashable_enums_and_loose_record_numbers_fail_closed(self):
+        mutations = (
+            lambda record: record.update(outcome=[]),
+            lambda record: record["resources"].update(observation=[]),
+            lambda record: record.update(schema_version=True),
+            lambda record: record.update(concurrency=True),
+        )
+        for mutation in mutations:
+            records = self.records()
+            mutation(records[0])
+            report = protocol.summarize_evidence(self.schedule, records)
+            with self.subTest(report=report):
+                self.assertEqual(report["status"], "invalid")
+
+        records = self.records()
+        failed = records[0]
+        failed.update(outcome="failure", failure_id=[], elapsed_ns=None, resources=None)
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "invalid")
+
+    def test_exact_22_record_order_and_closed_shape_are_required(self):
+        records = self.records()
+        report = protocol.summarize_evidence(self.schedule, records[:-1])
+        self.assertEqual(report["status"], "invalid")
+        self.assertEqual(report["reason_ids"], ["evidence_count_invalid"])
+
+        records = self.records()
+        records[0], records[1] = records[1], records[0]
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "invalid")
+        self.assertEqual(report["reason_ids"], ["evidence_order_invalid"])
+
+        records = self.records()
+        records[0]["raw_stderr"] = "forbidden"
+        report = protocol.summarize_evidence(self.schedule, records)
+        self.assertEqual(report["status"], "invalid")
+        self.assertEqual(report["reason_ids"], ["evidence_shape_invalid"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pilots/go-lightpanda/density/test_evidence_runner.py
+++ b/pilots/go-lightpanda/density/test_evidence_runner.py
@@ -1,0 +1,612 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+try:
+    from . import controller, evidence_protocol, evidence_runner
+except ImportError:
+    import controller  # type: ignore[no-redef]
+    import evidence_protocol  # type: ignore[no-redef]
+    import evidence_runner  # type: ignore[no-redef]
+
+
+HERE = Path(__file__).resolve().parent
+GIB = 1024**3
+
+
+def raw_resources(
+    peak: int,
+    *,
+    memory_max: int = 0,
+    oom: int = 0,
+    pids_max: int = 0,
+    processes: int = 1,
+) -> dict:
+    return {
+        "host_page_size": 4096,
+        "memory_current": min(peak, 64 * 1024**2),
+        "memory_peak": peak,
+        "memory_limit": GIB,
+        "memory_swap_limit": 0,
+        "memory_events": {
+            "low": 0,
+            "high": 0,
+            "max": memory_max,
+            "oom": oom,
+            "oom_kill": oom,
+            "oom_group_kill": 0,
+        },
+        "cpu_max": [100000, 100000],
+        "cpu_stat": {"usage_usec": 3, "user_usec": 2, "system_usec": 1},
+        "pids_limit": 768,
+        "pids_events": {"max": pids_max},
+        "pids_current": max(1, processes),
+        "pids_peak": 64,
+        "cgroup_process_count": processes,
+    }
+
+
+class FakeIdentityGuard:
+    identities = {
+        "go": "sha256:" + "a" * 64,
+        "python": "sha256:" + "b" * 64,
+        "fixture": "sha256:" + "c" * 64,
+    }
+
+    def __init__(self):
+        self.changed = False
+        self.verifications = 0
+
+    def resolve(self):
+        return dict(self.identities)
+
+    def verify(self, identities):
+        self.verifications += 1
+        if self.changed or identities != self.identities:
+            raise evidence_runner.GuardFailure("containment")
+
+
+class FakeHealthGuard:
+    def __init__(self):
+        self.captured = False
+        self.unhealthy = False
+
+    def capture(self):
+        self.captured = True
+
+    def verify(self):
+        if not self.captured or self.unhealthy:
+            raise evidence_runner.GuardFailure("containment")
+
+
+class EvidenceRunnerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.schedule, cls.schedule_sha = evidence_protocol.load_schedule(
+            HERE / "schedule.v1.json"
+        )
+        cls.workload, cls.workload_sha = controller.load_manifest(HERE)
+
+    def runner(self, directory, arm_runner, *, identity=None, health=None):
+        checkpoints = []
+        instance = evidence_runner.EvidenceRunner(
+            source_commit="d" * 40,
+            schedule=self.schedule,
+            schedule_sha256=self.schedule_sha,
+            workload=self.workload,
+            workload_sha256=self.workload_sha,
+            timeout=1,
+            output=Path(directory) / "evidence.json",
+            identity_guard=identity or FakeIdentityGuard(),
+            health_guard=health or FakeHealthGuard(),
+            arm_runner=arm_runner,
+            checkpoint_writer=lambda report: checkpoints.append(
+                json.loads(json.dumps(report))
+            ),
+        )
+        return instance, checkpoints
+
+    def successful_arm(self, pair, _arm_index, implementation, _identities):
+        return {
+            "measured": {
+                "elapsed_ns": 100 if implementation == "go" else 125
+            },
+            "resources": raw_resources(
+                640 * 1024**2
+                if implementation == "go"
+                else 800 * 1024**2
+            ),
+        }
+
+    def test_runs_all_frozen_slots_in_order_and_checkpoints_every_arm(self):
+        calls = []
+
+        def arm(pair, index, implementation, identities):
+            calls.append((pair["id"], index, implementation, dict(identities)))
+            return self.successful_arm(pair, index, implementation, identities)
+
+        with tempfile.TemporaryDirectory() as directory:
+            runner, checkpoints = self.runner(directory, arm)
+            report = runner.run()
+        expected = [
+            (pair["id"], index, implementation)
+            for pair in self.schedule["pairs"]
+            for index, implementation in enumerate(pair["order"])
+        ]
+        self.assertEqual([call[:3] for call in calls], expected)
+        self.assertEqual(len(checkpoints), 23)
+        self.assertEqual(checkpoints[0]["state"], "initialized")
+        self.assertEqual(checkpoints[0]["completed_arms"], 0)
+        self.assertEqual(report["state"], "complete")
+        self.assertEqual(report["completed_arms"], 22)
+        self.assertEqual(report["summary"]["status"], "admitted")
+        self.assertTrue(all(item["outcome"] == "pass" for item in report["records"]))
+        encoded = json.dumps(report)
+        for forbidden in (
+            "container",
+            "/sys/fs/cgroup",
+            "origin-",
+            "https://",
+            "/proc/",
+        ):
+            self.assertNotIn(forbidden, encoded)
+
+    def test_bounded_arm_failure_is_retained_and_later_arms_continue(self):
+        calls = 0
+
+        def arm(pair, index, implementation, identities):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise controller.SmokeFailure("timeout")
+            return self.successful_arm(pair, index, implementation, identities)
+
+        with tempfile.TemporaryDirectory() as directory:
+            runner, checkpoints = self.runner(directory, arm)
+            report = runner.run()
+        self.assertEqual(calls, 22)
+        self.assertEqual(len(checkpoints), 23)
+        self.assertEqual(report["state"], "complete")
+        self.assertEqual(report["records"][0]["failure_id"], "timeout")
+        self.assertEqual(report["records"][1]["outcome"], "pass")
+
+    def test_cleanup_failure_aborts_and_preserves_remaining_slots(self):
+        calls = 0
+
+        def arm(*_args):
+            nonlocal calls
+            calls += 1
+            raise controller.SmokeFailure(
+                "cleanup", resources=raw_resources(32 * 1024**2)
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            runner, checkpoints = self.runner(directory, arm)
+            report = runner.run()
+        self.assertEqual(calls, 1)
+        self.assertEqual(len(checkpoints), 2)
+        self.assertEqual(report["state"], "aborted")
+        self.assertEqual(report["executor_failure_id"], "cleanup")
+        self.assertEqual(report["records"][0]["failure_id"], "cleanup")
+        self.assertTrue(
+            all(
+                record["failure_id"] == "not_run"
+                for record in report["records"][1:]
+            )
+        )
+        self.assertEqual(
+            report["summary"]["reason_ids"], ["protocol_integrity_failure"]
+        )
+
+    def test_c1_final_process_residue_aborts_all_later_arms(self):
+        calls = 0
+
+        def arm(*_args):
+            nonlocal calls
+            calls += 1
+            raise controller.SmokeFailure(
+                "process_residue",
+                resources=raw_resources(32 * 1024**2, processes=2),
+                resources_final=True,
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            runner, checkpoints = self.runner(directory, arm)
+            report = runner.run()
+        self.assertEqual(calls, 1)
+        self.assertEqual(len(checkpoints), 2)
+        self.assertEqual(report["state"], "aborted")
+        self.assertEqual(report["executor_failure_id"], "process_residue")
+        self.assertEqual(report["records"][0]["failure_id"], "process_residue")
+        self.assertTrue(
+            all(
+                record["failure_id"] == "not_run"
+                for record in report["records"][1:]
+            )
+        )
+        self.assertEqual(
+            report["summary"]["reason_ids"], ["protocol_integrity_failure"]
+        )
+
+    def test_preserves_controller_resource_pressure_attribution(self):
+        failures = [
+            controller.SmokeFailure(
+                "pid_limit",
+                resources=raw_resources(
+                    GIB + 4096, memory_max=9, oom=2, pids_max=1, processes=0
+                ),
+            ),
+            controller.SmokeFailure(
+                "oom",
+                resources=raw_resources(
+                    GIB + 4096, memory_max=9, oom=2, processes=0
+                ),
+            ),
+            controller.SmokeFailure(
+                "memory_pressure",
+                resources=raw_resources(
+                    GIB, memory_max=1, processes=0
+                ),
+            ),
+        ]
+        calls = 0
+
+        def arm(pair, index, implementation, identities):
+            nonlocal calls
+            if calls < len(failures):
+                error = failures[calls]
+                calls += 1
+                raise error
+            calls += 1
+            return self.successful_arm(pair, index, implementation, identities)
+
+        with tempfile.TemporaryDirectory() as directory:
+            runner, _checkpoints = self.runner(directory, arm)
+            report = runner.run()
+        self.assertEqual(
+            [record["failure_id"] for record in report["records"][:3]],
+            ["pid_limit", "oom", "memory_pressure"],
+        )
+        self.assertEqual(
+            report["records"][0]["resources"]["observation"],
+            "sampled_not_final",
+        )
+        self.assertEqual(report["summary"]["status"], "inconclusive")
+
+    def test_does_not_infer_failure_subject_from_measured_counters(self):
+        calls = 0
+
+        def arm(pair, index, implementation, identities):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise controller.SmokeFailure(
+                    "nonzero",
+                    resources=raw_resources(
+                        GIB + 4096,
+                        memory_max=9,
+                        oom=2,
+                        pids_max=1,
+                        processes=0,
+                    ),
+                )
+            return self.successful_arm(pair, index, implementation, identities)
+
+        with tempfile.TemporaryDirectory() as directory:
+            runner, _checkpoints = self.runner(directory, arm)
+            report = runner.run()
+        self.assertEqual(report["records"][0]["failure_id"], "nonzero")
+        self.assertEqual(report["summary"]["status"], "invalid")
+        self.assertEqual(
+            report["summary"]["reason_ids"], ["evidence_shape_invalid"]
+        )
+
+    def test_correctness_failure_is_not_reclassified_as_memory_pressure(self):
+        failures = 0
+
+        def arm(pair, index, implementation, identities):
+            nonlocal failures
+            if pair["concurrency"] == 8 and implementation == "python":
+                failures += 1
+                raise controller.SmokeFailure(
+                    "oracle",
+                    resources=raw_resources(
+                        GIB, memory_max=1, processes=0
+                    ),
+                )
+            return self.successful_arm(pair, index, implementation, identities)
+
+        with tempfile.TemporaryDirectory() as directory:
+            runner, _checkpoints = self.runner(directory, arm)
+            report = runner.run()
+        self.assertEqual(failures, 5)
+        python_c8 = [
+            record
+            for record in report["records"]
+            if record["concurrency"] == 8
+            and record["implementation"] == "python"
+        ]
+        self.assertTrue(
+            all(record["failure_id"] == "oracle" for record in python_c8)
+        )
+        self.assertEqual(report["summary"]["status"], "inconclusive")
+        self.assertEqual(
+            report["summary"]["reason_ids"], ["python_c8_mixed_failures"]
+        )
+
+    def test_repeated_normalized_fixture_ooms_cannot_admit(self):
+        fixture_failures = 0
+
+        def arm(pair, index, implementation, identities):
+            nonlocal fixture_failures
+            if pair["concurrency"] == 8 and implementation == "python":
+                fixture_failures += 1
+                # SmokeController normalizes any fixture lifecycle failure,
+                # including OOMKilled, and omits the measured cgroup sample.
+                raise controller.SmokeFailure("infrastructure")
+            return self.successful_arm(pair, index, implementation, identities)
+
+        with tempfile.TemporaryDirectory() as directory:
+            runner, _checkpoints = self.runner(directory, arm)
+            report = runner.run()
+        self.assertEqual(fixture_failures, 5)
+        self.assertEqual(report["summary"]["status"], "inconclusive")
+        self.assertEqual(
+            report["summary"]["reason_ids"], ["python_c8_mixed_failures"]
+        )
+        python_c8 = [
+            record
+            for record in report["records"]
+            if record["concurrency"] == 8
+            and record["implementation"] == "python"
+        ]
+        self.assertTrue(
+            all(
+                record["failure_id"] == "infrastructure"
+                and record["resources"] is None
+                for record in python_c8
+            )
+        )
+
+    def test_invalid_resource_overshoot_is_dropped_without_clamping(self):
+        calls = 0
+
+        def arm(pair, index, implementation, identities):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise controller.SmokeFailure(
+                    "oom",
+                    resources=raw_resources(
+                        GIB + 8192, memory_max=1, oom=1, processes=0
+                    ),
+                )
+            return self.successful_arm(pair, index, implementation, identities)
+
+        with tempfile.TemporaryDirectory() as directory:
+            runner, _checkpoints = self.runner(directory, arm)
+            report = runner.run()
+        self.assertIsNone(report["records"][0]["resources"])
+        self.assertEqual(report["records"][0]["failure_id"], "oom")
+
+    def test_failure_after_final_marker_keeps_final_observation(self):
+        calls = 0
+
+        def arm(pair, index, implementation, identities):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise controller.SmokeFailure(
+                    "oracle",
+                    resources=raw_resources(32 * 1024**2),
+                    resources_final=True,
+                )
+            return self.successful_arm(pair, index, implementation, identities)
+
+        with tempfile.TemporaryDirectory() as directory:
+            runner, _checkpoints = self.runner(directory, arm)
+            report = runner.run()
+        self.assertEqual(report["records"][0]["failure_id"], "oracle")
+        self.assertEqual(
+            report["records"][0]["resources"]["observation"], "final"
+        )
+        self.assertTrue(report["records"][0]["resources"]["final_sample"])
+
+    def test_constructor_requires_exact_frozen_schedule_digest(self):
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaises(evidence_runner.GuardFailure) as caught:
+                evidence_runner.EvidenceRunner(
+                    source_commit="d" * 40,
+                    schedule=self.schedule,
+                    schedule_sha256="0" * 64,
+                    workload=self.workload,
+                    workload_sha256=self.workload_sha,
+                    timeout=1,
+                    output=Path(directory) / "evidence.json",
+                    identity_guard=FakeIdentityGuard(),
+                    health_guard=FakeHealthGuard(),
+                    arm_runner=self.successful_arm,
+                )
+        self.assertEqual(caught.exception.failure_id, "infrastructure")
+
+    def test_post_arm_image_mutation_converts_current_slot_and_aborts(self):
+        identity = FakeIdentityGuard()
+
+        def arm(pair, index, implementation, identities):
+            identity.changed = True
+            return self.successful_arm(pair, index, implementation, identities)
+
+        with tempfile.TemporaryDirectory() as directory:
+            runner, _checkpoints = self.runner(
+                directory, arm, identity=identity
+            )
+            report = runner.run()
+        self.assertEqual(report["state"], "aborted")
+        self.assertEqual(report["executor_failure_id"], "containment")
+        self.assertEqual(report["records"][0]["failure_id"], "containment")
+        self.assertIsNotNone(report["records"][0]["resources"])
+
+    def test_unexpected_exception_is_normalized_without_leaking_text(self):
+        def arm(*_args):
+            raise RuntimeError("https://secret.invalid/private")
+
+        with tempfile.TemporaryDirectory() as directory:
+            runner, _checkpoints = self.runner(directory, arm)
+            report = runner.run()
+        self.assertEqual(report["state"], "complete")
+        self.assertTrue(
+            all(
+                record["failure_id"] == "infrastructure"
+                for record in report["records"]
+            )
+        )
+        self.assertNotIn("secret", json.dumps(report))
+
+    def test_actual_adapter_uses_fresh_tokens_and_frozen_pids_limit(self):
+        captured = []
+
+        class FakeSmoke:
+            def __init__(self, *_args, run_id, **_kwargs):
+                self.run_id = run_id
+
+            def run_arm(self, implementation, image, fixture, **kwargs):
+                captured.append(
+                    (self.run_id, implementation, image, fixture, kwargs)
+                )
+                return self_outer.successful_arm({}, 0, implementation, {})
+
+        self_outer = self
+        tokens = iter(("one", "two"))
+        with tempfile.TemporaryDirectory() as directory, mock.patch.object(
+            evidence_runner.controller, "SmokeController", FakeSmoke
+        ):
+            runner, _checkpoints = self.runner(directory, self.successful_arm)
+            runner.token_factory = lambda: next(tokens)
+            runner._run_arm(
+                self.schedule["pairs"][0], 0, "python", FakeIdentityGuard.identities
+            )
+            runner._run_arm(
+                self.schedule["pairs"][0], 1, "go", FakeIdentityGuard.identities
+            )
+        self.assertEqual([item[0] for item in captured], ["one", "two"])
+        for _token, implementation, image, fixture, kwargs in captured:
+            self.assertEqual(image, FakeIdentityGuard.identities[implementation])
+            self.assertEqual(fixture, FakeIdentityGuard.identities["fixture"])
+            self.assertEqual(kwargs["measured_pids"], 768)
+            self.assertTrue(kwargs["retain_failure_resources"])
+
+    def test_default_checkpoint_is_atomic_private_and_final(self):
+        with tempfile.TemporaryDirectory() as directory:
+            identity = FakeIdentityGuard()
+            health = FakeHealthGuard()
+            output = Path(directory) / "evidence.json"
+            runner = evidence_runner.EvidenceRunner(
+                source_commit="d" * 40,
+                schedule=self.schedule,
+                schedule_sha256=self.schedule_sha,
+                workload=self.workload,
+                workload_sha256=self.workload_sha,
+                timeout=1,
+                output=output,
+                identity_guard=identity,
+                health_guard=health,
+                arm_runner=self.successful_arm,
+            )
+            report = runner.run()
+            self.assertEqual(output.stat().st_mode & 0o777, 0o600)
+            self.assertEqual(json.loads(output.read_text()), report)
+
+
+class GuardTests(unittest.TestCase):
+    def test_image_guard_resolves_once_and_detects_tag_mutation(self):
+        identities = [
+            "sha256:" + "a" * 64,
+            "sha256:" + "b" * 64,
+            "sha256:" + "c" * 64,
+        ]
+        docker = mock.Mock()
+        inspected = [
+            {
+                "Id": value,
+                "Config": {
+                    "Labels": {
+                        evidence_runner.PROVENANCE_LABEL: "d" * 40,
+                    }
+                },
+            }
+            for value in identities * 2
+        ]
+        docker.json.side_effect = [[item] for item in inspected]
+        guard = evidence_runner.DockerImageGuard(
+            docker,
+            {"go": "g", "python": "p", "fixture": "f"},
+            "d" * 40,
+        )
+        resolved = guard.resolve()
+        guard.verify(resolved)
+        docker.json.side_effect = [
+            [{**inspected[0], "Id": "sha256:" + "d" * 64}],
+            [inspected[1]],
+            [inspected[2]],
+        ]
+        with self.assertRaises(evidence_runner.GuardFailure) as caught:
+            guard.verify(resolved)
+        self.assertEqual(caught.exception.failure_id, "containment")
+
+    def test_image_guard_rejects_missing_or_stale_source_provenance(self):
+        docker = mock.Mock()
+        docker.json.return_value = [{
+            "Id": "sha256:" + "a" * 64,
+            "Config": {"Labels": {
+                evidence_runner.PROVENANCE_LABEL: "c" * 40,
+            }},
+        }]
+        guard = evidence_runner.DockerImageGuard(
+            docker,
+            {"go": "g", "python": "p", "fixture": "f"},
+            "d" * 40,
+        )
+        with self.assertRaises(evidence_runner.GuardFailure) as caught:
+            guard.resolve()
+        self.assertEqual(caught.exception.failure_id, "image")
+
+    def test_protected_guard_requires_stable_healthy_container(self):
+        name = "deploy-murmur-1"
+        base = {
+            "Id": "a" * 64,
+            "Image": "sha256:" + "b" * 64,
+            "RestartCount": 0,
+            "State": {
+                "Status": "running",
+                "Running": True,
+                "Restarting": False,
+                "Dead": False,
+                "StartedAt": "2026-01-01T00:00:00Z",
+                "Health": {"Status": "healthy"},
+            },
+        }
+        docker = mock.Mock()
+        docker.json.return_value = [base]
+        guard = evidence_runner.ProtectedContainerGuard(docker, (name,))
+        guard.capture()
+        guard.verify()
+        changed = json.loads(json.dumps(base))
+        changed["RestartCount"] = 1
+        docker.json.return_value = [changed]
+        with self.assertRaises(evidence_runner.GuardFailure):
+            guard.verify()
+        self.assertNotIn(name, str(guard._baseline))
+
+    def test_invalid_protected_name_is_closed(self):
+        with self.assertRaises(evidence_runner.GuardFailure) as caught:
+            evidence_runner.ProtectedContainerGuard(mock.Mock(), ("--all",))
+        self.assertEqual(caught.exception.failure_id, "containment")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pilots/go-lightpanda/density/test_python_runner.py
+++ b/pilots/go-lightpanda/density/test_python_runner.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import io
 import json
+import os
+import signal
+import stat
 import tempfile
 import unittest
+from unittest import mock
 from pathlib import Path
 from typing import Any
 
@@ -180,30 +185,136 @@ class ContractTests(unittest.TestCase):
         self.assertEqual(runner.evaluation_json_bytes("café"), b'"caf\\u00e9"')
         self.assertEqual(runner.evaluation_json_bytes('a"b'), b'"a\\"b"')
 
-    def test_start_gate_waits_for_an_owned_regular_file(self) -> None:
+    def test_cli_protocol_surrounds_manifest_read_and_output(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            gate = Path(directory) / "start"
-            pauses: list[float] = []
+            workload = Path(directory) / "workload.json"
+            output = io.StringIO()
+            events: list[str] = []
 
-            def release(delay: float) -> None:
-                pauses.append(delay)
-                gate.touch(mode=0o600)
+            class Protocol:
+                def wait_initial(inner_self) -> None:
+                    events.append("initial")
+                    self.assertEqual(output.getvalue(), "")
+                    workload.write_text("not the manifest", encoding="ascii")
 
-            runner.wait_for_start_gate(gate, expected=gate, pause=release)
-            self.assertEqual(pauses, [0.01])
-            with self.assertRaises(runner.ContractError):
-                runner.wait_for_start_gate(Path(directory), expected=Path(directory))
+                def wait_final(inner_self) -> None:
+                    events.append("final")
+                    self.assertEqual(output.getvalue(), "")
 
-    def test_start_gate_rejects_the_wrong_path_and_symlinks(self) -> None:
+                def close(inner_self) -> None:
+                    events.append("close")
+
+            exit_code = runner.main(
+                [
+                    "--workload",
+                    str(workload),
+                    "--concurrency",
+                    "4",
+                    "--source-commit",
+                    SOURCE_COMMIT,
+                    "--image-identity",
+                    IMAGE_IDENTITY,
+                ],
+                protocol_factory=Protocol,
+                output=output,
+            )
+            self.assertEqual(exit_code, 1)
+            self.assertEqual(events, ["initial", "final", "close"])
+            self.assertFalse(json.loads(output.getvalue())["ok"])
+
+    def test_cli_removed_start_gate_uses_both_protocol_phases(self) -> None:
+        output = io.StringIO()
+        events: list[str] = []
+
+        class Protocol:
+            def wait_initial(inner_self) -> None:
+                events.append("initial")
+                self.assertEqual(output.getvalue(), "")
+
+            def wait_final(inner_self) -> None:
+                events.append("final")
+
+            def close(inner_self) -> None:
+                events.append("close")
+
+        exit_code = runner.main(
+            ["--start-gate", "/tmp/controller-start"],
+            protocol_factory=Protocol,
+            output=output,
+        )
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(events, ["initial", "final", "close"])
+        self.assertFalse(json.loads(output.getvalue())["ok"])
+
+    def test_cli_protocol_cancellation_emits_no_evidence(self) -> None:
+        output = io.StringIO()
+        events: list[str] = []
+
+        class Protocol:
+            def wait_initial(inner_self) -> None:
+                events.append("initial")
+
+            def wait_final(inner_self) -> None:
+                events.append("final")
+                raise runner._ProtocolCancelled
+
+            def close(inner_self) -> None:
+                events.append("close")
+
+        exit_code = runner.main(
+            ["--start-gate", "/tmp/controller-start"],
+            protocol_factory=Protocol,
+            output=output,
+        )
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(events, ["initial", "final", "close"])
+        self.assertEqual(output.getvalue(), "")
+
+    def test_protocol_marker_is_exact_exclusive_and_removed(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
-            target = Path(directory) / "target"
-            target.touch(mode=0o600)
-            gate = Path(directory) / "gate"
-            gate.symlink_to(target)
-            with self.assertRaises(runner.ContractError):
-                runner.wait_for_start_gate(gate, expected=gate)
-            with self.assertRaises(runner.ContractError):
-                runner.wait_for_start_gate(target, expected=gate)
+            marker = Path(directory) / "controller-final"
+            runner._create_marker(marker)
+            metadata = marker.lstat()
+            self.assertTrue(stat.S_ISREG(metadata.st_mode))
+            self.assertEqual(stat.S_IMODE(metadata.st_mode), 0o600)
+            self.assertEqual(metadata.st_size, 0)
+            self.assertEqual(metadata.st_nlink, 1)
+            self.assertEqual(metadata.st_uid, os.geteuid())
+            self.assertEqual(metadata.st_gid, os.getegid())
+            with self.assertRaises(FileExistsError):
+                runner._create_marker(marker)
+            runner._validate_marker(marker)
+            marker.unlink()
+            self.assertFalse(marker.exists())
+
+    def test_release_between_handler_arm_and_wait_is_not_lost(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            marker = Path(directory) / "controller-initial"
+            events: list[str] = []
+            handlers: dict[signal.Signals, Any] = {}
+            create_marker = runner._create_marker
+
+            def install_handler(number: signal.Signals, handler: Any) -> None:
+                events.append("arm" if callable(handler) else "restore")
+                handlers[number] = handler
+
+            def create_and_release(path: Path) -> None:
+                events.append("create")
+                create_marker(path)
+                handlers[signal.SIGUSR1](signal.SIGUSR1, None)
+                events.append("release")
+
+            protocol = object.__new__(runner._SignalMarkerProtocol)
+            with (
+                mock.patch.object(runner.signal, "getsignal", return_value=signal.SIG_DFL),
+                mock.patch.object(runner.signal, "signal", side_effect=install_handler),
+                mock.patch.object(runner.signal, "pause", side_effect=AssertionError("release was lost")),
+                mock.patch.object(runner, "_create_marker", side_effect=create_and_release),
+            ):
+                protocol._wait(marker, signal.SIGUSR1)
+
+            self.assertEqual(events, ["arm", "create", "release", "restore"])
+            self.assertFalse(marker.exists())
 
 
 class RunnerTests(unittest.IsolatedAsyncioTestCase):

--- a/pilots/go-lightpanda/density_benchmark.go
+++ b/pilots/go-lightpanda/density_benchmark.go
@@ -73,7 +73,7 @@ type densityReport struct {
 	Concurrency      int                 `json:"concurrency"`
 	Succeeded        bool                `json:"succeeded"`
 	FailureID        string              `json:"failure_id,omitempty"`
-	ElapsedMS        int64               `json:"elapsed_ms"`
+	ElapsedNS        int64               `json:"elapsed_ns"`
 	Submitted        int                 `json:"submitted"`
 	Accepted         uint64              `json:"accepted"`
 	Terminal         int                 `json:"terminal"`
@@ -325,7 +325,7 @@ func runDensityBenchmark(ctx context.Context, workload densityWorkload, workload
 		report.OracleMatches += waveReport.OracleMatches
 		report.Waves = append(report.Waves, waveReport)
 	}
-	report.ElapsedMS = measuredFinished.Sub(measuredStarted).Milliseconds()
+	report.ElapsedNS = measuredFinished.Sub(measuredStarted).Nanoseconds()
 	pool.Close()
 	for range drained {
 		report.Terminal++

--- a/pilots/go-lightpanda/density_benchmark_test.go
+++ b/pilots/go-lightpanda/density_benchmark_test.go
@@ -8,8 +8,10 @@ import (
 	"encoding/json"
 	"errors"
 	"os"
+	"slices"
 	"strings"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
 
@@ -71,33 +73,124 @@ func TestDensityConcurrencyIsFixed(t *testing.T) {
 	}
 }
 
-func TestDensityStartGateWaitsForARegularFile(t *testing.T) {
-	path := t.TempDir() + "/start"
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	go func() {
-		time.Sleep(20 * time.Millisecond)
-		_ = os.WriteFile(path, nil, 0o600)
-	}()
-	if err := waitDensityStartGate(ctx, path); err != nil {
-		t.Fatal(err)
-	}
-	if err := waitDensityStartGate(ctx, t.TempDir()); err == nil {
-		t.Fatal("directory accepted as start gate")
-	}
-}
-
-func TestDensityStartGateHonorsCancellation(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-	if err := waitDensityStartGate(ctx, t.TempDir()+"/absent"); !errors.Is(err, context.Canceled) {
-		t.Fatalf("err=%v", err)
-	}
-}
-
 // Kept as a variable-sized helper so test writes remain local and obvious.
 func osWriteFileForDensityTest(path string, value []byte) error {
 	return os.WriteFile(path, value, 0o600)
+}
+
+func TestDensityCLIWaitsForInitialAndFinalReleasesAroundWork(t *testing.T) {
+	workloadPath := t.TempDir() + "/workload.json"
+	var output bytes.Buffer
+	events := []string{}
+	waitInitial := func(ctx context.Context) error {
+		events = append(events, "initial")
+		if output.Len() != 0 {
+			t.Fatalf("output emitted before initial release: %q", output.String())
+		}
+		if ctx.Err() != nil {
+			t.Fatal(ctx.Err())
+		}
+		if err := os.WriteFile(workloadPath, []byte("not the manifest"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return nil
+	}
+	waitFinal := func(ctx context.Context) error {
+		events = append(events, "final")
+		if output.Len() != 0 {
+			t.Fatalf("output emitted before final release")
+		}
+		if ctx.Err() != nil {
+			t.Fatal(ctx.Err())
+		}
+		return nil
+	}
+	exitCode := runDensityCLIWithProtocol([]string{
+		"--workload", workloadPath,
+		"--concurrency", "4",
+		"--source-commit", densityTestCommit,
+		"--image-identity", "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+	}, &output, waitInitial, waitFinal)
+	if exitCode != 2 || !slices.Equal(events, []string{"initial", "final"}) {
+		t.Fatalf("exit=%d events=%v output=%q", exitCode, events, output.String())
+	}
+	var report densityReport
+	if json.Unmarshal(output.Bytes(), &report) != nil || report.FailureID != "manifest_invalid" || report.ElapsedNS <= 0 {
+		t.Fatalf("report=%+v output=%q", report, output.String())
+	}
+	if bytes.Count(output.Bytes(), []byte(`"elapsed_ns"`)) != 1 || bytes.Contains(output.Bytes(), []byte(`"elapsed_ms"`)) {
+		t.Fatalf("failure report must expose only elapsed_ns: %s", output.Bytes())
+	}
+}
+
+func TestDensityCLIRemovedStartGateUsesBothProtocolPhases(t *testing.T) {
+	var output bytes.Buffer
+	initialReleases := 0
+	finalReleases := 0
+	waitInitial := func(context.Context) error {
+		initialReleases++
+		if output.Len() != 0 {
+			t.Fatalf("output emitted before initial release")
+		}
+		return nil
+	}
+	waitFinal := func(context.Context) error {
+		finalReleases++
+		return nil
+	}
+	exitCode := runDensityCLIWithProtocol([]string{"--start-gate", "/tmp/controller-start"}, &output, waitInitial, waitFinal)
+	if exitCode != 2 || initialReleases != 1 || finalReleases != 1 {
+		t.Fatalf("exit=%d initial=%d final=%d output=%q", exitCode, initialReleases, finalReleases, output.String())
+	}
+	var report densityReport
+	if json.Unmarshal(output.Bytes(), &report) != nil || report.FailureID != "arguments_invalid" {
+		t.Fatalf("report=%+v output=%q", report, output.String())
+	}
+}
+
+func TestDensityCLIProtocolCancellationEmitsNoEvidence(t *testing.T) {
+	workloadPath := t.TempDir() + "/workload.json"
+	var output bytes.Buffer
+	waitInitial := func(context.Context) error {
+		return os.WriteFile(workloadPath, []byte("not the manifest"), 0o600)
+	}
+	waitFinal := func(context.Context) error {
+		return context.Canceled
+	}
+	exitCode := runDensityCLIWithProtocol([]string{
+		"--workload", workloadPath,
+		"--concurrency", "4",
+		"--source-commit", densityTestCommit,
+		"--image-identity", "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+	}, &output, waitInitial, waitFinal)
+	if exitCode != 1 || output.Len() != 0 {
+		t.Fatalf("exit=%d output=%q", exitCode, output.String())
+	}
+}
+
+func TestDensityProtocolMarkerIsExactExclusiveAndRemoved(t *testing.T) {
+	path := t.TempDir() + "/controller-final"
+	if err := densityCreateMarkerAt(path); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	metadata, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 || info.Size() != 0 ||
+		metadata.Nlink != 1 || int(metadata.Uid) != os.Geteuid() || int(metadata.Gid) != os.Getegid() {
+		t.Fatalf("marker=%+v metadata=%+v", info, metadata)
+	}
+	if err := densityCreateMarkerAt(path); err == nil {
+		t.Fatal("exclusive marker creation accepted an existing path")
+	}
+	if err := densityRemoveMarkerAt(path); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Lstat(path); !os.IsNotExist(err) {
+		t.Fatalf("marker remained after release: %v", err)
+	}
 }
 
 func TestDensityRawPrivacyPreservesExactAdapterBytes(t *testing.T) {
@@ -138,8 +231,27 @@ func TestDensityBenchmarkRunsSequentialWavesOnOneC4Pool(t *testing.T) {
 			t.Fatalf("asymmetric diagnostic %q in report: %s", forbidden, encoded)
 		}
 	}
-	if bytes.Count(encoded, []byte(`"elapsed_ms"`)) != 1 {
-		t.Fatalf("elapsed_ms must be whole-arm only: %s", encoded)
+	if report.ElapsedNS <= 0 {
+		t.Fatalf("elapsed_ns=%d", report.ElapsedNS)
+	}
+	if bytes.Count(encoded, []byte(`"elapsed_ns"`)) != 1 || bytes.Contains(encoded, []byte(`"elapsed_ms"`)) {
+		t.Fatalf("elapsed_ns must be whole-arm only: %s", encoded)
+	}
+}
+
+func TestDensityFailureReportUsesNanosecondsFromItsMeasuredInterval(t *testing.T) {
+	started := time.Now()
+	time.Sleep(time.Millisecond)
+	report := densityFailureReport(started, 4, densityTestCommit, "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "manifest_invalid")
+	if report.ElapsedNS < int64(time.Millisecond) {
+		t.Fatalf("elapsed_ns=%d", report.ElapsedNS)
+	}
+	encoded, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Count(encoded, []byte(`"elapsed_ns"`)) != 1 || bytes.Contains(encoded, []byte(`"elapsed_ms"`)) {
+		t.Fatalf("failure report must expose only elapsed_ns: %s", encoded)
 	}
 }
 

--- a/pilots/go-lightpanda/densitybench_main.go
+++ b/pilots/go-lightpanda/densitybench_main.go
@@ -15,83 +15,138 @@ import (
 	"github.com/colophon-group/jobseek/apps/crawler/contracts/v1/lightpandaadapter"
 )
 
-const densityStartGatePath = "/tmp/controller-start"
+type densityProtocolPhase func(context.Context) error
+
+const (
+	densityInitialMarkerPath = "/tmp/controller-initial"
+	densityFinalMarkerPath   = "/tmp/controller-final"
+)
 
 func main() { os.Exit(runDensityCLI(os.Args[1:], os.Stdout)) }
 
 func runDensityCLI(args []string, output io.Writer) int {
+	return runDensityCLIWithProtocol(args, output, densityWaitInitialRelease, densityWaitFinalRelease)
+}
+
+func runDensityCLIWithProtocol(args []string, output io.Writer, waitInitial, waitFinal densityProtocolPhase) int {
 	flags := flag.NewFlagSet("go-lightpanda-density", flag.ContinueOnError)
 	flags.SetOutput(io.Discard)
 	workloadPath := flags.String("workload", "", "")
 	concurrency := flags.Int("concurrency", 0, "")
 	sourceCommit := flags.String("source-commit", "", "")
 	imageIdentity := flags.String("image-identity", "", "")
-	startGate := flags.String("start-gate", "", "")
-	started := time.Now()
-	if flags.Parse(args) != nil || flags.NArg() != 0 || *workloadPath == "" || *startGate != densityStartGatePath {
-		return writeDensityFailure(output, started, *concurrency, *sourceCommit, *imageIdentity, "arguments_invalid")
-	}
+	parseErr := flags.Parse(args)
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
-	if waitDensityStartGate(ctx, *startGate) != nil {
-		return writeDensityFailure(output, started, *concurrency, *sourceCommit, *imageIdentity, "start_gate")
+	if waitInitial == nil || waitInitial(ctx) != nil || ctx.Err() != nil {
+		return 1
 	}
+	started := time.Now()
+	if parseErr != nil || flags.NArg() != 0 || *workloadPath == "" {
+		report := densityFailureReport(started, *concurrency, *sourceCommit, *imageIdentity, "arguments_invalid")
+		return finishDensityCLI(ctx, output, report, 2, waitFinal)
+	}
+
 	workload, workloadSHA, err := loadDensityWorkload(*workloadPath)
 	if err != nil {
-		return writeDensityFailure(output, started, *concurrency, *sourceCommit, *imageIdentity, "manifest_invalid")
+		report := densityFailureReport(started, *concurrency, *sourceCommit, *imageIdentity, "manifest_invalid")
+		return finishDensityCLI(ctx, output, report, 2, waitFinal)
 	}
 	adapter, err := lightpandaadapter.New(runtimeV1Runner{config: Config{Binary: os.Getenv("LIGHTPANDA_BIN")}}, densityRawPrivacy{})
 	if err != nil {
-		return writeDensityFailure(output, started, *concurrency, *sourceCommit, *imageIdentity, "adapter_initialization")
+		report := densityFailureReport(started, *concurrency, *sourceCommit, *imageIdentity, "adapter_initialization")
+		return finishDensityCLI(ctx, output, report, 2, waitFinal)
 	}
 	report := runDensityBenchmark(ctx, workload, workloadSHA, *concurrency, *sourceCommit, *imageIdentity, adapter)
-	if encodeDensityReport(output, report) != nil {
-		return 1
-	}
 	if !report.Succeeded {
-		return 1
+		return finishDensityCLI(ctx, output, report, 1, waitFinal)
 	}
-	return 0
+	return finishDensityCLI(ctx, output, report, 0, waitFinal)
 }
 
-func waitDensityStartGate(ctx context.Context, path string) error {
-	if ctx == nil || path == "" {
+func densityWaitInitialRelease(ctx context.Context) error {
+	return densityWaitForMarkerSignal(ctx, densityInitialMarkerPath, syscall.SIGUSR1)
+}
+
+func densityWaitFinalRelease(ctx context.Context) error {
+	return densityWaitForMarkerSignal(ctx, densityFinalMarkerPath, syscall.SIGUSR2)
+}
+
+func densityWaitForMarkerSignal(ctx context.Context, path string, releaseSignal os.Signal) error {
+	if ctx == nil || path == "" || releaseSignal == nil {
 		return errDensityConfig
 	}
-	ticker := time.NewTicker(10 * time.Millisecond)
-	defer ticker.Stop()
-	for {
-		info, err := os.Lstat(path)
-		if err == nil {
-			metadata, ok := info.Sys().(*syscall.Stat_t)
-			if !info.Mode().IsRegular() || !ok || int(metadata.Uid) != os.Geteuid() {
-				return errDensityConfig
-			}
-			return nil
-		}
-		if !os.IsNotExist(err) {
-			return err
-		}
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
-		}
+	released := make(chan os.Signal, 1)
+	signal.Notify(released, releaseSignal)
+	defer signal.Stop(released)
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := densityCreateMarkerAt(path); err != nil {
+		return err
+	}
+	select {
+	case <-released:
+		return densityRemoveMarkerAt(path)
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
-func writeDensityFailure(output io.Writer, started time.Time, concurrency int, sourceCommit, imageIdentity, failureID string) int {
+func densityCreateMarkerAt(path string) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err != nil {
+		return err
+	}
+	info, statErr := file.Stat()
+	closeErr := file.Close()
+	if statErr != nil {
+		return statErr
+	}
+	if closeErr != nil || densityValidateMarkerInfo(info) != nil {
+		return errDensityConfig
+	}
+	return nil
+}
+
+func densityRemoveMarkerAt(path string) error {
+	info, err := os.Lstat(path)
+	if err != nil || densityValidateMarkerInfo(info) != nil {
+		return errDensityConfig
+	}
+	return os.Remove(path)
+}
+
+func densityValidateMarkerInfo(info os.FileInfo) error {
+	if info == nil {
+		return errDensityConfig
+	}
+	metadata, ok := info.Sys().(*syscall.Stat_t)
+	if !ok || !info.Mode().IsRegular() || info.Mode().Perm() != 0o600 || info.Size() != 0 ||
+		metadata.Nlink != 1 || int(metadata.Uid) != os.Geteuid() || int(metadata.Gid) != os.Getegid() {
+		return errDensityConfig
+	}
+	return nil
+}
+
+func densityFailureReport(started time.Time, concurrency int, sourceCommit, imageIdentity, failureID string) densityReport {
 	if !densityLowerHex(sourceCommit, 40) {
 		sourceCommit = ""
 	}
 	if !densityImageIdentity(imageIdentity) {
 		imageIdentity = ""
 	}
-	report := densityReport{SchemaVersion: 1, ImplementationID: "go-lightpanda", RuntimeID: "go", SourceCommit: sourceCommit, ImageIdentity: imageIdentity, Concurrency: concurrency, FailureID: failureID, ElapsedMS: time.Since(started).Milliseconds(), Waves: []densityWaveReport{}}
+	return densityReport{SchemaVersion: 1, ImplementationID: "go-lightpanda", RuntimeID: "go", SourceCommit: sourceCommit, ImageIdentity: imageIdentity, Concurrency: concurrency, FailureID: failureID, ElapsedNS: time.Since(started).Nanoseconds(), Waves: []densityWaveReport{}}
+}
+
+func finishDensityCLI(ctx context.Context, output io.Writer, report densityReport, exitCode int, waitFinal densityProtocolPhase) int {
+	if waitFinal == nil || waitFinal(ctx) != nil || ctx.Err() != nil {
+		return 1
+	}
 	if encodeDensityReport(output, report) != nil {
 		return 1
 	}
-	return 2
+	return exitCode
 }
 
 func encodeDensityReport(output io.Writer, report densityReport) error {


### PR DESCRIPTION
## Summary

- freeze the Stage B2 c1/c4/c8 counterbalanced density schedule under one CPU and a 1 GiB no-swap ceiling
- add a failure-retaining, atomic evidence executor with exact image/source provenance, cgroup-v2/resource validation, and protected-container boundary checks
- replace the native runner start/finish timing handshake with runner-owned marker and signal gates
- retain only sanitized closed-schema evidence and reject cleanup, containment, PID, process-residue, fixture-attribution, or provenance ambiguity

## Safety

- internal fixture network only; no public origins, crawler queue, database, or production routing
- no retries, substitutions, or adaptive parameters
- fixture/controller failures cannot be counted as measured memory pressure
- cleanup and process-residue failures abort and leave remaining arms `not_run`

## Verification

- 89 Python tests
- Go default and density-tagged tests, density race tests, and `go vet`
- `gofmt`, `go mod tidy -diff`, Python compilation, and `git diff --check`
- 83 workflow-security tests
- native amd64 and arm64 pilot CI plus all repository required checks
- two independent adversarial code reviews: no P0-P2 findings

## Exact-commit Murmur evidence

Reviewed commit: `7fcb9943d8bcb5a2873587c8d1ca724aa2b26834`

Report SHA-256: `661e5a4516f18c80a84130acbd8f83f322fa772796113158f59049c818dfd2b8`

Result: `admitted / memory_pressure_fallback_met`

- c1: both passed
- c4 correctness gate: Go 5/5 and Python 5/5
- c8: Go 5/5 passed at 52.0–52.5 MiB peak; Python 5/5 hit the 1 GiB ceiling with kernel OOM evidence
- zero PID-pressure events; no cleanup, containment, process-residue, or `not_run` records
- the three immutable image IDs carried the exact reviewed source label
- protected Murmur services kept their identity, start time, restart count, and boundary health; zero density containers/networks remained
- only the internal fixture network was used; no public or production traffic

Two independent post-run auditors recomputed the closed schema, hashes, order, resource envelope, admission math, and serialized summary and approved with no P0-P2 findings.
