### PR TITLE
Isolate Lightpanda child environment

### DIFF
--- a/pilots/go-lightpanda/README.md
+++ b/pilots/go-lightpanda/README.md
@@ -32,9 +32,11 @@ timeout or cancellation; other provider details are reduced to message-free,
 fail-closed adapter errors.
 
 The runner starts a new Lightpanda process for its single task on a chosen free
-loopback port. Concurrent in-process runners retain each allocated port until
-that process has been cleaned up, preventing sibling tasks from selecting the
-same close-then-bind port:
+loopback port. The child receives a fixed non-secret environment that disables
+Lightpanda telemetry and core dumps; it inherits no parent credentials or
+configuration through environment variables. Concurrent in-process runners retain
+each allocated port until that process has been cleaned up, preventing sibling tasks
+from selecting the same close-then-bind port:
 
 ```text
 lightpanda serve --host 127.0.0.1 --port <port> --log-level error

--- a/pilots/go-lightpanda/harness.go
+++ b/pilots/go-lightpanda/harness.go
@@ -36,6 +36,11 @@ const (
 	maxProcessLogBytes    = 32 << 10
 )
 
+var lightpandaChildEnvironment = []string{
+	"LIGHTPANDA_DISABLE_CORE_DUMP=1",
+	"LIGHTPANDA_DISABLE_TELEMETRY=true",
+}
+
 var (
 	errCleanupUnproved = errors.New("lightpanda cleanup could not be proved")
 	errResourceLimit   = errors.New("lightpanda result exceeded a resource limit")
@@ -461,19 +466,25 @@ type commandStarter struct {
 
 func (s commandStarter) Start(port int) (managedProcess, error) {
 	logs := &boundedBuffer{limit: maxProcessLogBytes}
+	command := s.buildCommand(port, logs)
+	if err := command.Start(); err != nil {
+		return nil, err
+	}
+	return &commandProcess{command: command, pgid: command.Process.Pid, logs: logs}, nil
+}
+
+func (s commandStarter) buildCommand(port int, logs io.Writer) *exec.Cmd {
 	command := exec.Command(s.binary,
 		"serve",
 		"--host", "127.0.0.1",
 		"--port", strconv.Itoa(port),
 		"--log-level", "error",
 	)
+	command.Env = append([]string(nil), lightpandaChildEnvironment...)
 	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	command.Stdout = logs
 	command.Stderr = logs
-	if err := command.Start(); err != nil {
-		return nil, err
-	}
-	return &commandProcess{command: command, pgid: command.Process.Pid, logs: logs}, nil
+	return command
 }
 
 type commandProcess struct {

--- a/pilots/go-lightpanda/harness_test.go
+++ b/pilots/go-lightpanda/harness_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -168,6 +169,29 @@ func TestRunTaskReleasesPortOnStartFailure(t *testing.T) {
 	}
 	if released != 9222 {
 		t.Fatalf("released port = %d, want 9222", released)
+	}
+}
+
+func TestCommandStarterBuildCommandDoesNotInheritEnvironment(t *testing.T) {
+	const sentinel = "JOBSEEK_LIGHTPANDA_CHILD_ENV_SENTINEL"
+	t.Setenv(sentinel, "must-not-reach-lightpanda")
+
+	command := (commandStarter{binary: "lightpanda"}).buildCommand(9222, &boundedBuffer{limit: maxProcessLogBytes})
+	if command.Env == nil {
+		t.Fatal("Lightpanda command has a nil environment and would inherit the parent environment")
+	}
+	environment := command.Environ()
+	for _, entry := range environment {
+		if strings.HasPrefix(entry, sentinel+"=") {
+			t.Fatalf("Lightpanda command inherited sentinel environment variable %q", entry)
+		}
+	}
+	want := []string{
+		"LIGHTPANDA_DISABLE_CORE_DUMP=1",
+		"LIGHTPANDA_DISABLE_TELEMETRY=true",
+	}
+	if !slices.Equal(environment, want) {
+		t.Fatalf("Lightpanda command environment = %q, want fixed non-secret environment %q", environment, want)
 	}
 }
 


### PR DESCRIPTION
Progresses #7935.

This necessary, dormant safety slice prevents each one-shot Lightpanda process from inheriting the Go parent process environment. The child receives only `LIGHTPANDA_DISABLE_CORE_DUMP=1` and `LIGHTPANDA_DISABLE_TELEMETRY=true`; crawler database, Redis, proxy, R2, and other environment credentials are not forwarded. The existing process-group lifecycle and zero production authority are unchanged.

Review caught and repaired an unsafe initial empty-environment design: Lightpanda enables telemetry by default and an empty environment also omitted its core-dump opt-out. Documentation now limits the guarantee precisely to environment-variable inheritance.

Verification on exact local content: default and density-benchmark Go tests, race detector, vet, gofmt, tidy, diff checks, and two independent adversarial rereviews. No crawler VERSION bump is included because this pilot is not part of the Python crawler image.

No queue, database, deployment, service, routing, or production traffic changes.