### PR TITLE
Fix watchlist count request context

### DIFF
--- a/apps/web/app/api/web/watchlists/counts/__tests__/route.test.ts
+++ b/apps/web/app/api/web/watchlists/counts/__tests__/route.test.ts
@@ -1,16 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  getSessionUserId: vi.fn(),
-  getUserWatchlistCounts: vi.fn(),
+  getSessionUserIdFromHeaders: vi.fn(),
+  getUserWatchlistCountsForUser: vi.fn(),
 }));
 
 vi.mock("@/lib/sessionCache", () => ({
-  getSessionUserId: mocks.getSessionUserId,
+  getSessionUserIdFromHeaders: mocks.getSessionUserIdFromHeaders,
 }));
 
 vi.mock("@/lib/services/watchlists", () => ({
-  getUserWatchlistCounts: mocks.getUserWatchlistCounts,
+  getUserWatchlistCountsForUser: mocks.getUserWatchlistCountsForUser,
 }));
 
 import { GET } from "../route";
@@ -18,35 +18,46 @@ import { GET } from "../route";
 describe("GET /api/web/watchlists/counts", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.getSessionUserId.mockResolvedValue("user-1");
-    mocks.getUserWatchlistCounts.mockResolvedValue({ "watchlist-1": 42 });
+    mocks.getSessionUserIdFromHeaders.mockResolvedValue("user-1");
+    mocks.getUserWatchlistCountsForUser.mockResolvedValue({ "watchlist-1": 42 });
   });
 
   it("requires an authenticated session", async () => {
-    mocks.getSessionUserId.mockResolvedValueOnce(null);
+    mocks.getSessionUserIdFromHeaders.mockResolvedValueOnce(null);
 
     const response = await GET(
       new Request("https://jseek.co/api/web/watchlists/counts?locale=en"),
     );
 
     expect(response.status).toBe(401);
-    expect(mocks.getUserWatchlistCounts).not.toHaveBeenCalled();
+    expect(mocks.getUserWatchlistCountsForUser).not.toHaveBeenCalled();
   });
 
   it("returns private no-store counts in a supported locale", async () => {
-    const response = await GET(
-      new Request("https://jseek.co/api/web/watchlists/counts?locale=de"),
+    const request = new Request(
+      "https://jseek.co/api/web/watchlists/counts?locale=de",
+      { headers: { cookie: "better-auth.session_token=route-token" } },
     );
+    const response = await GET(request);
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Cache-Control")).toBe("private, no-store");
     expect(await response.json()).toEqual({ counts: { "watchlist-1": 42 } });
-    expect(mocks.getUserWatchlistCounts).toHaveBeenCalledWith("de");
+    expect(mocks.getSessionUserIdFromHeaders).toHaveBeenCalledWith(
+      request.headers,
+    );
+    expect(mocks.getUserWatchlistCountsForUser).toHaveBeenCalledWith(
+      "user-1",
+      "de",
+    );
   });
 
   it("falls back to English for an unsupported locale", async () => {
     await GET(new Request("https://jseek.co/api/web/watchlists/counts?locale=xx"));
 
-    expect(mocks.getUserWatchlistCounts).toHaveBeenCalledWith("en");
+    expect(mocks.getUserWatchlistCountsForUser).toHaveBeenCalledWith(
+      "user-1",
+      "en",
+    );
   });
 });

--- a/apps/web/app/api/web/watchlists/counts/route.ts
+++ b/apps/web/app/api/web/watchlists/counts/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from "next/server";
 
 import { locales } from "@/lib/i18n";
-import { getSessionUserId } from "@/lib/sessionCache";
-import { getUserWatchlistCounts } from "@/lib/services/watchlists";
+import { getSessionUserIdFromHeaders } from "@/lib/sessionCache";
+import { getUserWatchlistCountsForUser } from "@/lib/services/watchlists";
 
 export async function GET(request: Request) {
-  if (!(await getSessionUserId())) {
+  const userId = await getSessionUserIdFromHeaders(request.headers);
+  if (!userId) {
     return NextResponse.json({ error: "unauthorized" }, { status: 401 });
   }
 
@@ -13,7 +14,7 @@ export async function GET(request: Request) {
   const locale = requestedLocale && locales.includes(requestedLocale as (typeof locales)[number])
     ? requestedLocale
     : "en";
-  const counts = await getUserWatchlistCounts(locale);
+  const counts = await getUserWatchlistCountsForUser(userId, locale);
 
   return NextResponse.json(
     { counts },

--- a/apps/web/src/lib/__tests__/sessionCache.test.ts
+++ b/apps/web/src/lib/__tests__/sessionCache.test.ts
@@ -41,6 +41,7 @@ import { kvDelete, kvGet, kvMget, kvScan, kvSet } from "@/lib/cache";
 import {
   getSession,
   getSessionUserId,
+  getSessionUserIdFromHeaders,
   invalidateSessionCache,
   invalidateAllUserSessionCacheEntries,
 } from "../sessionCache";
@@ -169,6 +170,46 @@ describe("getSessionUserId", () => {
 
     const result = await getSessionUserId();
     expect(result).toBeNull();
+  });
+
+  it("uses explicit route-handler headers without reading Next request context", async () => {
+    const routeHeaders = new Headers({
+      cookie: "better-auth.session_token=route-token",
+    });
+    mockKvGet.mockResolvedValue({
+      user: { id: "route-user" },
+      session: { id: "route-session" },
+    });
+
+    const result = await getSessionUserIdFromHeaders(routeHeaders);
+
+    expect(result).toBe("route-user");
+    expect(mockHeadersGet).not.toHaveBeenCalled();
+    expect(mockKvGet).toHaveBeenCalledWith("session:route-token");
+  });
+
+  it("passes explicit route-handler headers through Better Auth on a cache miss", async () => {
+    const routeHeaders = new Headers({
+      cookie: "better-auth.session_token=cold-route-token",
+    });
+    const sessionData = {
+      user: { id: "cold-route-user" },
+      session: { id: "cold-route-session" },
+    };
+    mockKvGet.mockResolvedValue(null);
+    mockKvSet.mockResolvedValue(undefined);
+    mockGetSession.mockResolvedValue(sessionData);
+
+    const result = await getSessionUserIdFromHeaders(routeHeaders);
+
+    expect(result).toBe("cold-route-user");
+    expect(mockHeadersGet).not.toHaveBeenCalled();
+    expect(mockGetSession).toHaveBeenCalledWith({ headers: routeHeaders });
+    expect(mockKvSet).toHaveBeenCalledWith(
+      "session:cold-route-token",
+      sessionData,
+      { ttl: 300 },
+    );
   });
 });
 

--- a/apps/web/src/lib/actions/__tests__/watchlists-listing-perf.test.ts
+++ b/apps/web/src/lib/actions/__tests__/watchlists-listing-perf.test.ts
@@ -273,6 +273,7 @@ vi.mock("@/db", () => ({
 // Module under test must be imported AFTER all vi.mock factories.
 import {
   getUserWatchlists,
+  getUserWatchlistCountsForUser,
   getUserWatchlistsWithLimit,
   getPopularWatchlists,
   searchPublicWatchlists,
@@ -357,6 +358,41 @@ function fakePublicWatchlistHit(
 // ---- getUserWatchlists (user's own listing page) -----------------------
 
 describe("getUserWatchlists — listing fan-out fix (#3176)", () => {
+  it("loads route-handler counts from an explicit user without ambient request APIs", async () => {
+    const rows = [fakeUserWatchlistRow(0, 5)];
+    mocks.dbExecute
+      .mockResolvedValueOnce(rows)
+      .mockResolvedValueOnce([{ job_languages: ["de"] }]);
+    mocks.tsMultiSearch.mockResolvedValueOnce({
+      results: [{ found: 5, hits: [] }],
+    });
+
+    const result = await getUserWatchlistCountsForUser(USER_ID, "en");
+
+    expect(result).toEqual({ "wl-0": 5 });
+    expect(mocks.getSessionUserId).not.toHaveBeenCalled();
+    expect(mocks.getViewerLanguages).not.toHaveBeenCalled();
+    expect(mocks.dbExecute).toHaveBeenCalledTimes(2);
+    const queries = mocks.dbExecute.mock.calls.map(([query]) =>
+      query as { text: string; values: unknown[] },
+    );
+    expect(queries).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          text: expect.stringContaining("FROM watchlist w"),
+          values: expect.arrayContaining([USER_ID]),
+        }),
+        expect.objectContaining({
+          text: expect.stringContaining("FROM user_preferences"),
+          values: expect.arrayContaining([USER_ID]),
+        }),
+      ]),
+    );
+    expect(mocks.tsMultiSearch.mock.calls[0]?.[0].searches[0]).toMatchObject({
+      filter_by: expect.stringContaining("locales:[de,_none]"),
+    });
+  });
+
   it("keeps the initial overview independent from active-count aggregation (#5896)", async () => {
     const rows = [fakeUserWatchlistRow(0, 42), fakeUserWatchlistRow(1, 7)];
     mocks.dbExecute.mockResolvedValueOnce(rows);

--- a/apps/web/src/lib/services/watchlists.ts
+++ b/apps/web/src/lib/services/watchlists.ts
@@ -12,6 +12,7 @@ import {
 } from "@/db/schema";
 import { getSessionUserId } from "@/lib/sessionCache";
 import { getViewerLanguages } from "@/lib/viewer";
+import { resolveJobLanguages } from "@/lib/job-languages";
 import { cached, invalidate } from "@/lib/cache";
 import {
   CACHE_TTL_SHORT,
@@ -786,15 +787,16 @@ function _toUserWatchlistSummary(
   };
 }
 
-export async function getUserWatchlists(locale: string): Promise<WatchlistSummary[]> {
-  const userId = await getSessionUserId();
-  if (!userId) return [];
-
+async function _getUserWatchlistsForUser(
+  userId: string,
+  locale: string,
+  loadLanguages: () => Promise<string[]> = () => getViewerLanguages(locale),
+): Promise<WatchlistSummary[]> {
   // Viewer language preference is used by the batched Typesense count so
   // listing counts match the watchlist-detail page.
   const [rows, languages] = await Promise.all([
     _getUserWatchlistRows(userId),
-    getViewerLanguages(locale),
+    loadLanguages(),
   ]);
 
   const preciseCounts = await _resolveUserListingCounts(rows, locale, languages);
@@ -802,6 +804,45 @@ export async function getUserWatchlists(locale: string): Promise<WatchlistSummar
     ..._toUserWatchlistSummary(row, preciseCounts.get(row.id) ?? 0),
     activeJobCount: preciseCounts.get(row.id) ?? 0,
   }));
+}
+
+export async function getUserWatchlists(locale: string): Promise<WatchlistSummary[]> {
+  const userId = await getSessionUserId();
+  if (!userId) return [];
+
+  return _getUserWatchlistsForUser(userId, locale);
+}
+
+async function _getViewerLanguagesForUser(
+  userId: string,
+  locale: string,
+): Promise<string[]> {
+  const rows = await withDbRetry(
+    () =>
+      db.execute<{ job_languages: string[] | null }>(sql`
+        SELECT job_languages
+        FROM user_preferences
+        WHERE user_id = ${userId}
+        LIMIT 1
+      `),
+    { label: "userWatchlistLanguages" },
+  );
+
+  return resolveJobLanguages(rows[0]?.job_languages ?? [], locale);
+}
+
+export async function getUserWatchlistCountsForUser(
+  userId: string,
+  locale: string,
+): Promise<Record<string, number>> {
+  const watchlists = await _getUserWatchlistsForUser(
+    userId,
+    locale,
+    () => _getViewerLanguagesForUser(userId, locale),
+  );
+  return Object.fromEntries(
+    watchlists.map((watchlist) => [watchlist.id, watchlist.activeJobCount]),
+  );
 }
 
 export async function getUserWatchlistCounts(locale: string): Promise<Record<string, number>> {

--- a/apps/web/src/lib/sessionCache.ts
+++ b/apps/web/src/lib/sessionCache.ts
@@ -26,8 +26,9 @@ function extractToken(cookieHeader: string): string | null {
   return null;
 }
 
-async function fetchSession(): Promise<SessionResult> {
-  const headersList = await headers();
+async function fetchSessionFromHeaders(
+  headersList: Headers,
+): Promise<SessionResult> {
   const cookieHeader = headersList.get("cookie") ?? "";
   const token = extractToken(cookieHeader);
   if (!token) return null;
@@ -55,6 +56,10 @@ async function fetchSession(): Promise<SessionResult> {
   return result;
 }
 
+async function fetchSession(): Promise<SessionResult> {
+  return fetchSessionFromHeaders(await headers());
+}
+
 /**
  * Per-request cached session getter (full user object).
  *
@@ -71,6 +76,21 @@ export const getSession = cache(fetchSession);
  */
 export async function getSessionUserId(): Promise<string | null> {
   const session = await getSession();
+  return session?.user?.id ?? null;
+}
+
+/**
+ * Route-handler session check using the request's explicit headers.
+ *
+ * Route handlers are not React render scopes, so wrapping a dynamic
+ * `headers()` read in React `cache()` can lose Next's request context.
+ * Passing the handler's headers keeps the auth lookup request-bound while
+ * preserving the shared Redis/DB session path.
+ */
+export async function getSessionUserIdFromHeaders(
+  headersList: Headers,
+): Promise<string | null> {
+  const session = await fetchSessionFromHeaders(headersList);
   return session?.user?.id ?? null;
 }
 


### PR DESCRIPTION
## Summary

- read the authenticated session from explicit `request.headers` in the watchlist-count Route Handler
- pass the authenticated user id into a server-only count path so nested service calls do not depend on ambient Next request context
- preserve the existing Redis/Better Auth cache path, parallel preference/watchlist reads, and batched Typesense counting

Fixes #8739

## Why

The existing Route Handler entered a React-cached helper whose body reads `next/headers`. Route Handlers are not React Server Component render scopes, so Cache Components could execute it without a request store and throw `headers was called outside a request scope`. The optional client refresh suppressed the rejection, leaving stale counts while server logs accumulated errors.

## Verification

- focused Vitest: 3 files / 53 tests passed
- targeted ESLint passed
- clean `pnpm exec tsc --noEmit --incremental false` passed
- `git diff --check` passed
- live anonymous HTTP smoke returned `401` with the private route contract intact
- independent exact-branch technical reviewer and adversarial critic reported no P1–P3 findings

## Scope

This is a non-UI fix and is intentionally separate from Draft watchlist interface work in #8377/#8385. No production data or subscription behavior changes.
