### PR TITLE
Center watchlist overview list

### DIFF
--- a/apps/web/app/[lang]/(app)/watchlists/__tests__/watchlists-page.test.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/__tests__/watchlists-page.test.tsx
@@ -179,6 +179,8 @@ describe("WatchlistsPage private overview", () => {
     expect(fadeWrapper?.className).toContain("max-h-[max(12rem,calc(100dvh_-_8rem))]");
     expect(fadeWrapper?.className).toContain("overflow-hidden");
     expect(create.className).toContain("w-full");
+    expect(fadeWrapper?.parentElement?.className).toContain("mx-auto");
+    expect(fadeWrapper?.parentElement?.className).toContain("w-full");
     expect(fadeWrapper?.parentElement?.className).toContain("max-w-3xl");
   });
 

--- a/apps/web/app/[lang]/(app)/watchlists/watchlists-page.tsx
+++ b/apps/web/app/[lang]/(app)/watchlists/watchlists-page.tsx
@@ -288,7 +288,7 @@ export function WatchlistsPage({
           </Button>
         </div>
       ) : (
-        <div className="max-w-3xl" aria-busy={activityPending}>
+        <div className="mx-auto w-full max-w-3xl" aria-busy={activityPending}>
           {initialWatchlists.length > 0 && !activityPending ? (
             <span className="sr-only" role="status" aria-live="polite">
               {t({


### PR DESCRIPTION
## Summary
- center the width-constrained private watchlist overview within the app shell
- preserve full-width behavior on narrow/mobile layouts
- pin the centering utilities with a regression test

## Verification
- watchlists page tests: 14/14 passed
- focused ESLint passed
- git diff --check passed
- independent reviewer: APPROVE

## UI gate
Approved by the user after local visual review.