### PR TITLE
Trigger Murmur deploy for shared schema inputs

### DIFF
--- a/.github/workflows/deploy-murmur-shim.yml
+++ b/.github/workflows/deploy-murmur-shim.yml
@@ -7,9 +7,9 @@
 #
 # Trigger model:
 #   - `push` to `murmur-demo` touching the shim source, the crawler
-#     compose (where the murmur-shim service is declared by H3), or
-#     this workflow file. The path filter prevents accidental redeploys
-#     when unrelated files change.
+#     compose (where the murmur-shim service is declared by H3), the web
+#     schema inputs compiled into the shim, or this workflow file. The path
+#     filter prevents accidental redeploys when unrelated files change.
 #   - `workflow_dispatch`: manual trigger so the operator can force a
 #     redeploy without a code commit (e.g. after rotating MURMUR_TOKEN).
 #
@@ -60,6 +60,8 @@ on:
     branches: [main, murmur-demo]
     paths:
       - apps/murmur-shim/**
+      - apps/web/src/db/schema.ts
+      - apps/web/src/lib/notifications/contracts.ts
       - apps/crawler/docker-compose.yml
       - apps/crawler/deploy.sh
       - scripts/verify-crawler-release-bridge.py

--- a/scripts/ci-workflow.test.mjs
+++ b/scripts/ci-workflow.test.mjs
@@ -79,6 +79,10 @@ const deployCrawlerWorkflow = readFileSync(
   ".github/workflows/deploy-crawler-browser.yml",
   "utf8",
 );
+const deployMurmurShimWorkflow = readFileSync(
+  ".github/workflows/deploy-murmur-shim.yml",
+  "utf8",
+);
 const crawlerRuntimeContractsWorkflow = readFileSync(
   ".github/workflows/crawler-runtime-contracts.yml",
   "utf8",
@@ -1601,6 +1605,24 @@ test("workflow-security runs repository script tests", () => {
   assert.match(workflow, /scripts\/crawler-host-hygiene\.test\.mjs/);
   assert.match(workflow, /scripts\/docs-index\.test\.mjs/);
   assert.match(workflow, /scripts\/dealroom-company-requests\.test\.mjs/);
+});
+
+test("murmur-shim deploy watches its web build inputs", () => {
+  const pushTrigger = deployMurmurShimWorkflow.match(
+    /^on:\n  push:\n[\s\S]*?^  workflow_dispatch:/m,
+  );
+  assert.ok(pushTrigger, "deploy-murmur-shim push trigger is missing");
+
+  for (const buildInput of [
+    "apps/web/src/db/schema.ts",
+    "apps/web/src/lib/notifications/contracts.ts",
+  ]) {
+    assert.match(
+      pushTrigger[0],
+      new RegExp(`^      - ${buildInput.replaceAll(".", "\\.")}$`, "m"),
+      `${buildInput} must trigger a murmur-shim deployment`,
+    );
+  }
 });
 
 test("crawler deploys derive immutable versions for unchanged releases", () => {


### PR DESCRIPTION
## Summary
- trigger the Murmur image workflow when either selectively copied web schema input changes
- add an exact, push-block-scoped regression test for both paths

## Why
The Murmur Dockerfile compiles `apps/web/src/db/schema.ts` and `apps/web/src/lib/notifications/contracts.ts`, but a change limited to those files previously did not trigger the image deployment. That allowed build-context drift to remain latent until an unrelated coupled crawler release.

## Verification
- `node --test scripts/ci-workflow.test.mjs`: 85 passed
- actionlint: passed
- zizmor: no findings
- `git diff --check`: passed
- independent critic approved exact commit `a775218d3234aec8fa78492764f3fbb32fa0d725`

No rendered UI and no crawler runtime change.

Follow-up to #8807.
